### PR TITLE
Add repository to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ exclude = [
     "**/*.pyc",
     "**/__pycache__/",
 ]
+repository = "https://github.com/hyprstream/hyprstream.git"
 
 [lib]
 name = "hyprstream_core"


### PR DESCRIPTION
I was scrolling through the docs.rs page for this crate and noticed that there was no repository link. I was able to find the repo through the CI button in the README. By adding a link to the repo in the Cargo.toml, folks can access the repo directly from docs.rs.

There are a few other parts of the "Documentation - Cargo.toml" section of the [Rust API Guidelines ](https://rust-lang.github.io/api-guidelines/checklist.html) that could be applied too, but those are a bit less straightforward.