### PR TITLE
TTT + TTN profiling for Qwen3.5

### DIFF
--- a/crates/hyprstream/schema/inference.capnp
+++ b/crates/hyprstream/schema/inference.capnp
@@ -74,6 +74,9 @@ struct InferenceRequest {
 
     # Vision embeddings (synchronous — returns all embeddings in one response)
     embed @32 :EmbedImagesRequest $mcpScope(infer);
+
+    # TTN layer profile (returns JSON-encoded LayerProfile for diagnostics/tooling)
+    getLayerProfile @33 :Void $mcpScope(query);
   }
 }
 
@@ -131,6 +134,9 @@ struct InferenceResponse {
 
     # Embed result
     embedResult @33 :EmbedImagesResponse;
+
+    # TTN layer profile result
+    getLayerProfileResult @34 :LayerProfileResult;
   }
 }
 
@@ -358,6 +364,11 @@ struct EmbedImagesRequest {
 struct EmbedImagesResponse {
   embeddings @0 :List(List(Float32));  # one vector per image
   dimensions @1 :UInt32;               # embedding dimensionality
+}
+
+# TTN layer profile result (JSON-encoded to avoid complex capnp map types)
+struct LayerProfileResult {
+  json @0 :Text;   # JSON-encoded LayerProfile (serde_json::to_string_pretty)
 }
 
 # Error Information

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1253,7 +1253,7 @@ fn main() -> Result<()> {
             tracing_subscriber::fmt()
                 .with_env_filter(EnvFilter::builder().parse_lossy(
                     std::env::var("RUST_LOG")
-                        .unwrap_or_else(|_| default_log_level.to_string()),
+                        .unwrap_or_else(|_| default_log_level.to_owned()),
                 ))
                 .with_target(true)
                 .with_file(true)
@@ -1267,7 +1267,7 @@ fn main() -> Result<()> {
             tracing_subscriber::fmt()
                 .with_env_filter(EnvFilter::builder().parse_lossy(
                     std::env::var("RUST_LOG")
-                        .unwrap_or_else(|_| default_log_level.to_string()),
+                        .unwrap_or_else(|_| default_log_level.to_owned()),
                 ))
                 .with_target(true)
                 .with_file(true)

--- a/crates/hyprstream/src/runtime/architectures/qwen3_5.rs
+++ b/crates/hyprstream/src/runtime/architectures/qwen3_5.rs
@@ -548,6 +548,7 @@ impl GatedDeltaNetLayer {
         hidden: &Tensor,
         conv_state: &mut Option<Tensor>,
         rec_state: &mut Option<Tensor>,
+        delta: Option<(&crate::training::TenantDelta, usize)>,
     ) -> Result<Tensor> {
         let (batch, seq, _) = dims3(hidden)?;
         let device = hidden.device();
@@ -716,12 +717,27 @@ impl GatedDeltaNetLayer {
         // Ensure output matches model dtype for out_proj matmul (weight is BF16)
         let normed = if normed.kind() != dtype { normed.to_kind(dtype) } else { normed };
         let flat = normed.reshape([batch * seq, val_dim]);
+
         let projected = self.out_proj.apply(&flat);
+        // Standard LoRA: add correction in the OUTPUT space of out_proj (y = Wx + BAx).
+        // Inject after out_proj so correction shape [B*seq, hidden_size] matches projected,
+        // regardless of whether val_dim == hidden_size. (Issue 6 + standard LoRA semantics)
+        let projected = if let Some((delta, layer_idx)) = delta {
+            if delta.has_module("o_proj", layer_idx) {
+                // forward_2d(flat): [B*seq, val_dim] → [B*seq, hidden_size]
+                &projected + delta.forward_2d(&flat, "o_proj", layer_idx)?
+            } else {
+                projected
+            }
+        } else {
+            projected
+        };
         Ok(projected.reshape([batch, seq, self.hidden_size_from_out_proj()]))
     }
 
     fn hidden_size_from_out_proj(&self) -> i64 {
-        self.out_proj.weight.size()[1]
+        // weight is stored [out_features, in_features]; size()[0] = out_features = hidden_size
+        self.out_proj.weight.size()[0]
     }
 }
 
@@ -793,6 +809,7 @@ impl Qwen3_5FullAttention {
         position_ids: Option<&Tensor>,
         kv_cache: Option<&mut crate::runtime::kv_cache::LayerKVCache>,
         start_pos: usize,
+        delta: Option<(&crate::training::TenantDelta, usize)>,
     ) -> Result<Tensor> {
         let (batch, seq, _) = dims3(hidden)?;
         let device = hidden.device();
@@ -802,9 +819,44 @@ impl Qwen3_5FullAttention {
         // Fused QKV projection: single matmul, then split
         let qkv = self.qkv_proj.apply(&h2);
         let [q_dim, k_dim, v_dim] = self.qkv_split;
-        let q_out = qkv.narrow(1, 0, q_dim);
+
+        // Delta injection on q_proj and v_proj (out-of-place to avoid aliasing, C2 fix)
+        // q_out layout: [B*seq, q_dim] where q_dim = num_heads * head_dim * 2
+        //   first half = Q, second half = gate
+        // Must apply correction to Q-half only, then reassemble with gate half
+        let (q_out, v_out) = if let Some((d, layer_idx)) = delta {
+            let q_raw = qkv.narrow(1, 0, q_dim);
+            let v_raw = qkv.narrow(1, q_dim + k_dim, v_dim);
+
+            let q_out = if d.has_module("q_proj", layer_idx) {
+                // q_dim = num_heads * head_dim * 2; split into Q and gate halves
+                let q_half = q_dim / 2;
+                let q_part = q_raw.narrow(1, 0, q_half);
+                let gate_part = q_raw.narrow(1, q_half, q_dim - q_half);
+                let q_correction = d.forward_2d(&h2, "q_proj", layer_idx)?;
+                // q_correction shape: [B*seq, q_half] (delta target is the pre-gate Q only)
+                // If correction has full q_dim, only apply to q-half
+                let q_correction = if q_correction.size()[1] == q_half {
+                    q_correction
+                } else {
+                    q_correction.narrow(1, 0, q_half)
+                };
+                let corrected_q = &q_part + &q_correction;
+                Tensor::cat(&[corrected_q, gate_part], 1)
+            } else {
+                q_raw
+            };
+
+            let v_out = if d.has_module("v_proj", layer_idx) {
+                &v_raw + d.forward_2d(&h2, "v_proj", layer_idx)?
+            } else {
+                v_raw
+            };
+            (q_out, v_out)
+        } else {
+            (qkv.narrow(1, 0, q_dim), qkv.narrow(1, q_dim + k_dim, v_dim))
+        };
         let k_out = qkv.narrow(1, q_dim, k_dim);
-        let v_out = qkv.narrow(1, q_dim + k_dim, v_dim);
 
         let nh = self.num_heads as i64;
         let nkv = self.num_kv_heads as i64;
@@ -874,6 +926,18 @@ impl Qwen3_5FullAttention {
         let ctx_flat = ctx.reshape([batch * seq, nh * hd]);
         let gate_flat = gate.reshape([batch * seq, nh * hd]).sigmoid();
         let ctx_gated = ctx_flat * gate_flat;
+
+        // Delta injection on o_proj (after gate, before linear projection)
+        let ctx_gated = if let Some((d, layer_idx)) = delta {
+            if d.has_module("o_proj", layer_idx) {
+                &ctx_gated + d.forward_2d(&ctx_gated, "o_proj", layer_idx)?
+            } else {
+                ctx_gated
+            }
+        } else {
+            ctx_gated
+        };
+
         let out = self.o_proj.apply(&ctx_gated);
         Ok(out.reshape([batch, seq, -1]))
     }
@@ -1380,11 +1444,16 @@ impl Qwen3_5Model {
         }
     }
 
+    /// Unified forward inner: replaces the old `forward_inner` to avoid
+    /// a deadlock that would occur if a no-delta wrapper acquired conv/rec
+    /// locks and then delegated to a delta version that also tried to acquire them.
+    /// (C5 deadlock fix: single implementation, delta=None for inference path)
     fn forward_inner(
         &self,
         input_ids: Option<&Tensor>,
         embeddings: Option<&Tensor>,
         start_pos: usize,
+        delta: Option<&crate::training::TenantDelta>,
     ) -> Result<Tensor> {
         let mut hidden = if let Some(embeds) = embeddings {
             embeds.shallow_clone()
@@ -1400,7 +1469,7 @@ impl Qwen3_5Model {
             emb.reshape([batch, seq, hidden_sz])
         };
 
-        let (batch, seq) = (hidden.size()[0], hidden.size()[1]);
+        let (_, seq) = (hidden.size()[0], hidden.size()[1]);
         let device = self.device;
 
         // Position IDs for full-attention RoPE
@@ -1412,26 +1481,27 @@ impl Qwen3_5Model {
 
         let mut conv_guard = self.conv_states.lock();
         let mut rec_guard = self.rec_states.lock();
-        // kv_arc dropped per-layer to avoid holding lock across SSM layers
 
         for (idx, layer) in self.layers.iter().enumerate() {
             let residual = hidden.shallow_clone();
 
             hidden = layer.input_layernorm.forward(&hidden)?;
 
+            let delta_arg = delta.map(|d| (d, idx));
+
             let mixer_out = match &layer.mixer {
                 LayerMixer::LinearAttn(gdn) => {
-                    gdn.forward(&hidden, &mut conv_guard[idx], &mut rec_guard[idx])?
+                    gdn.forward(&hidden, &mut conv_guard[idx], &mut rec_guard[idx], delta_arg)?
                 }
                 LayerMixer::FullAttn(attn) => {
                     if let Some(ref cache_arc) = self.kv_cache {
                         let kv = cache_arc.lock();
                         kv.with_layer_cache(idx, |lc| {
-                            attn.forward(&hidden, Some(&position_ids), Some(lc), start_pos)
+                            attn.forward(&hidden, Some(&position_ids), Some(lc), start_pos, delta_arg)
                         })
                         .ok_or_else(|| anyhow!("No KV cache for layer {idx}"))??
                     } else {
-                        attn.forward(&hidden, Some(&position_ids), None, start_pos)?
+                        attn.forward(&hidden, Some(&position_ids), None, start_pos, delta_arg)?
                     }
                 }
             };
@@ -1507,6 +1577,79 @@ impl Qwen3_5Model {
         Ok(combined)
     }
 
+    /// Expose the Qwen3.5 text config for external callers (e.g., get_per_layer_lora_dims).
+    pub fn text_config(&self) -> &Qwen3_5TextConfig {
+        &self.config
+    }
+
+    /// Deep-copy current SSM states for TTT snapshot/restore (C4 fix: must use .copy(), not .shallow_clone()).
+    ///
+    /// Returns (conv_snapshot, rec_snapshot). Each tensor is deep-copied so that
+    /// subsequent SSM mutations during TTT adaptation do not corrupt the snapshot.
+    pub fn snapshot_ssm_states(&self) -> (Vec<Option<Tensor>>, Vec<Option<Tensor>>) {
+        let conv_snapshot = {
+            let guard = self.conv_states.lock();
+            guard.iter().map(|opt| opt.as_ref().map(|t| t.copy())).collect()
+        };
+        let rec_snapshot = {
+            let guard = self.rec_states.lock();
+            guard.iter().map(|opt| opt.as_ref().map(|t| t.copy())).collect()
+        };
+        (conv_snapshot, rec_snapshot)
+    }
+
+    /// Restore SSM states from a snapshot produced by `snapshot_ssm_states`.
+    pub fn restore_ssm_states(
+        &self,
+        conv_snapshot: Vec<Option<Tensor>>,
+        rec_snapshot: Vec<Option<Tensor>>,
+    ) {
+        *self.conv_states.lock() = conv_snapshot;
+        *self.rec_states.lock() = rec_snapshot;
+    }
+
+    /// Shared implementation for `decode_layer` and `decode_layer_with_delta`.
+    ///
+    /// **Training path only.** Full-attention layers run with `start_pos=0` and no KV
+    /// cache, which is correct for the TTT gradient loop (full causal mask over the entire
+    /// context). Do not use this method for incremental autoregressive inference — use
+    /// `forward_with_cache_and_delta` / `forward_with_cache` instead.
+    ///
+    /// GDN layers acquire `conv_states` / `rec_states` locks per call (not held across
+    /// layers), which is safe because `forward_with_delta` in TorchEngine never holds
+    /// those locks itself.
+    fn decode_layer_impl(
+        &self,
+        layer_idx: usize,
+        hidden_states: &Tensor,
+        position_ids: Option<&Tensor>,
+        delta: Option<&crate::training::TenantDelta>,
+    ) -> Result<(Tensor, Option<(Tensor, Tensor)>)> {
+        let layer = self.layers.get(layer_idx)
+            .ok_or_else(|| anyhow!("Layer {layer_idx} out of range"))?;
+        let residual = hidden_states.shallow_clone();
+        let normed = layer.input_layernorm.forward(hidden_states)?;
+
+        let delta_arg = delta.map(|d| (d, layer_idx));
+
+        let mixer_out = match &layer.mixer {
+            LayerMixer::LinearAttn(gdn) => {
+                let mut conv = self.conv_states.lock();
+                let mut rec = self.rec_states.lock();
+                gdn.forward(&normed, &mut conv[layer_idx], &mut rec[layer_idx], delta_arg)?
+            }
+            LayerMixer::FullAttn(attn) => {
+                attn.forward(&normed, position_ids, None, 0, delta_arg)?
+            }
+        };
+
+        let hidden = &residual + &mixer_out;
+        let residual2 = hidden.shallow_clone();
+        let normed2 = layer.post_attention_layernorm.forward(&hidden)?;
+        let ffn_out = layer.mlp.forward(&normed2)?;
+        Ok((&residual2 + &ffn_out, None))
+    }
+
     fn lm_head_apply(&self, hidden: &Tensor) -> Result<Tensor> {
         let (batch, seq, hs) = dims3(hidden)?;
         let flat = hidden.reshape([batch * seq, hs]);
@@ -1537,19 +1680,30 @@ impl ModelOperations for Qwen3_5Model {
     }
 
     fn forward(&self, input: &Tensor, _past_kv: Option<&Tensor>) -> Result<Tensor> {
-        let hidden = self.forward_inner(Some(input), None, 0)?;
+        let hidden = self.forward_inner(Some(input), None, 0, None)?;
         let normed = self.norm.forward(&hidden)?;
         self.lm_head_apply(&normed)
     }
 
     fn forward_with_cache(&self, input: &Tensor, start_pos: usize) -> Result<Tensor> {
-        let hidden = self.forward_inner(Some(input), None, start_pos)?;
+        let hidden = self.forward_inner(Some(input), None, start_pos, None)?;
         let normed = self.norm.forward(&hidden)?;
         self.lm_head_apply(&normed)
     }
 
     fn forward_from_embeddings(&self, embeddings: &Tensor, start_pos: usize) -> Result<Tensor> {
-        let hidden = self.forward_inner(None, Some(embeddings), start_pos)?;
+        let hidden = self.forward_inner(None, Some(embeddings), start_pos, None)?;
+        let normed = self.norm.forward(&hidden)?;
+        self.lm_head_apply(&normed)
+    }
+
+    fn forward_with_cache_and_delta(
+        &self,
+        input: &Tensor,
+        start_pos: usize,
+        delta: Option<&crate::training::TenantDelta>,
+    ) -> Result<Tensor> {
+        let hidden = self.forward_inner(Some(input), None, start_pos, delta)?;
         let normed = self.norm.forward(&hidden)?;
         self.lm_head_apply(&normed)
     }
@@ -1573,6 +1727,29 @@ impl ModelOperations for Qwen3_5Model {
 
     fn num_layers(&self) -> usize {
         self.config.num_hidden_layers
+    }
+
+    fn decode_layer(
+        &self,
+        layer_idx: usize,
+        hidden_states: &Tensor,
+        _attention_mask: Option<&Tensor>,
+        position_ids: Option<&Tensor>,
+        _past_kv: Option<&crate::runtime::kv_cache::LayerKVCache>,
+    ) -> Result<(Tensor, Option<(Tensor, Tensor)>)> {
+        self.decode_layer_impl(layer_idx, hidden_states, position_ids, None)
+    }
+
+    fn decode_layer_with_delta(
+        &self,
+        layer_idx: usize,
+        hidden_states: &Tensor,
+        _attention_mask: Option<&Tensor>,
+        position_ids: Option<&Tensor>,
+        _past_kv: Option<&crate::runtime::kv_cache::LayerKVCache>,
+        delta: &crate::training::TenantDelta,
+    ) -> Result<(Tensor, Option<(Tensor, Tensor)>)> {
+        self.decode_layer_impl(layer_idx, hidden_states, position_ids, Some(delta))
     }
 
     fn clear_kv_cache(&self) {

--- a/crates/hyprstream/src/runtime/batched_lora.rs
+++ b/crates/hyprstream/src/runtime/batched_lora.rs
@@ -213,6 +213,7 @@ mod tests {
             learning_rate: 3e-4,
             max_accumulated_steps: 300,
             decay_lambda: 0.02,
+            layer_overrides: None,
         };
 
         let pool = DeltaPool::new(config, module_dims, device, None, std::env::temp_dir().join("batched_lora_test_snapshots"), None, 2);

--- a/crates/hyprstream/src/runtime/mod.rs
+++ b/crates/hyprstream/src/runtime/mod.rs
@@ -16,6 +16,7 @@ pub use crate::config::{
 };
 
 pub mod architectures; // Architecture-specific model implementations (includes Janus placeholder utils)
+pub mod ttn_profile;  // TTN analysis pipeline: adaptive layer profiling + embedded profiles
 pub mod batched_lora; // Batched multi-tenant LoRA forward pass
 // REMOVED: pub mod conversation_router; // Dead code - VDB TemporalStreamingLayer removed
 pub mod generation_metrics; // Quality metrics for self-supervised training

--- a/crates/hyprstream/src/runtime/model_factory.rs
+++ b/crates/hyprstream/src/runtime/model_factory.rs
@@ -102,7 +102,7 @@ impl ModelFactory {
             // Standard loading for single files or small models
             let weights = Self::load_weights(model_path, device, dtype).await?;
             let config = ModelConfig::load(model_path, &weights)?;
-            let model = Self::create_model_from_config(config, weights, device, dtype, max_context, kv_quant_type)?;
+            let model = Self::create_model_from_config(config, weights, device, dtype, max_context, kv_quant_type, model_path)?;
             info!("✅ ModelFactory: Model created successfully");
             Ok(model)
         }
@@ -205,7 +205,7 @@ impl ModelFactory {
 
         // Load config and create model
         let config = ModelConfig::load(model_path, &all_weights)?;
-        let model = Self::create_model_from_config(config, all_weights, device, dtype, max_context, kv_quant_type)?;
+        let model = Self::create_model_from_config(config, all_weights, device, dtype, max_context, kv_quant_type, model_path)?;
 
         info!("Model loaded");
         Ok(model)
@@ -588,7 +588,16 @@ impl ModelFactory {
         dtype: DType,
         max_context: Option<usize>,
         kv_quant_type: KVQuantType,
+        model_path: &Path,
     ) -> Result<Box<dyn ModelOperations>> {
+        // Run TTN analysis: Tier 1 (embedded) → Tier 2 (cached) → Tier 3 (weight entropy SVD).
+        // Weights are available here, enabling Tier 3 for unknown models.
+        // Result cached to .analysis/layer_profile.json; non-fatal if it fails.
+        // Runs in sync/blocking context (called from spawn_blocking), safe for SVD.
+        if let Err(e) = crate::runtime::ttn_profile::get_layer_profile(model_path, &config, Some(&weights)) {
+            tracing::warn!("TTN profile analysis failed (non-fatal): {e}");
+        }
+
         match config.architecture {
             ModelArchitecture::Llama => {
                 info!("Creating Llama model");
@@ -864,7 +873,7 @@ impl ModelFactory {
 
         let weights = Self::load_weights_fs(fs, &shard_names, device, dtype).await?;
         let config = ModelConfig::load(model_path, &weights)?;
-        let model = Self::create_model_from_config(config, weights, device, dtype, max_context, kv_quant_type)?;
+        let model = Self::create_model_from_config(config, weights, device, dtype, max_context, kv_quant_type, model_path)?;
         info!("Model created successfully via FsOps");
         Ok(model)
     }

--- a/crates/hyprstream/src/runtime/torch_engine.rs
+++ b/crates/hyprstream/src/runtime/torch_engine.rs
@@ -939,6 +939,41 @@ impl TorchEngine {
         }
     }
 
+    /// Snapshot Qwen3.5 SSM (conv/rec) states for TTT adaptation.
+    ///
+    /// Returns `Some((conv, rec))` if the loaded model is Qwen3.5; `None` otherwise.
+    /// Each `Tensor` is deep-copied via `.copy()` (C4 fix) so the snapshot is
+    /// independent of subsequent forward-pass mutations during the TTT loop.
+    pub fn snapshot_ssm_states(
+        &self,
+    ) -> Option<(Vec<Option<Tensor>>, Vec<Option<Tensor>>)> {
+        let model_arc = self.persistent_model.as_ref()?;
+        let model = model_arc.lock();
+        let q35 = model
+            .as_any()
+            .downcast_ref::<crate::runtime::architectures::qwen3_5::Qwen3_5Model>()?;
+        Some(q35.snapshot_ssm_states())
+    }
+
+    /// Restore Qwen3.5 SSM states from a snapshot produced by `snapshot_ssm_states`.
+    ///
+    /// No-op if the loaded model is not Qwen3.5 or snapshot is `None`.
+    pub fn restore_ssm_states(
+        &self,
+        snapshot: Option<(Vec<Option<Tensor>>, Vec<Option<Tensor>>)>,
+    ) {
+        let Some((conv_snap, rec_snap)) = snapshot else { return };
+        let Some(model_arc) = &self.persistent_model else { return };
+        let model = model_arc.lock();
+        if let Some(q35) = model
+            .as_any()
+            .downcast_ref::<crate::runtime::architectures::qwen3_5::Qwen3_5Model>()
+        {
+            q35.restore_ssm_states(conv_snap, rec_snap);
+            tracing::debug!("Restored Qwen3.5 SSM states after TTT adaptation");
+        }
+    }
+
     /// Sample next token using bundled parameters with tiered repeat penalty.
     fn sample_token_with_params(
         &self,
@@ -1488,6 +1523,74 @@ impl TorchEngine {
         dims.insert("down_proj".to_owned(), (intermediate_size, hidden_size));
 
         Ok(dims)
+    }
+
+    /// Get per-layer LoRA module dimensions for hybrid architectures (e.g., Qwen3.5).
+    ///
+    /// Returns `None` for uniform architectures (Llama, Gemma, etc.) where all layers
+    /// have identical module dims. Returns per-layer overrides for Qwen3.5 where GDN
+    /// layers have different `o_proj` input dims than full-attention layers.
+    pub fn get_per_layer_lora_dims(
+        &self,
+    ) -> Option<std::collections::HashMap<usize, std::collections::HashMap<String, (usize, usize)>>> {
+        let model_arc = self.persistent_model.as_ref()?;
+        let model = model_arc.lock();
+        let model_any = model.as_any();
+
+        if let Some(q35) = model_any.downcast_ref::<crate::runtime::architectures::qwen3_5::Qwen3_5Model>() {
+            let qcfg = q35.text_config();
+            let hidden = qcfg.hidden_size;
+            let nh = qcfg.num_attention_heads;
+            let hd = qcfg.head_dim;
+            // q_proj outputs num_heads * head_dim * 2 (first half = Q, second half = gate).
+            // The LoRA delta targets only the Q half, so lora_b out_features = nh*hd (the half-dim).
+            // o_proj in_features is also nh*hd (attention output after gate application).
+            let q_half_dim = nh * hd;
+
+            let gdn_out_proj_in = qcfg.linear_num_value_heads * qcfg.linear_value_head_dim;
+            let num_layers = qcfg.num_hidden_layers;
+
+            let mut per_layer: std::collections::HashMap<usize, std::collections::HashMap<String, (usize, usize)>> =
+                std::collections::HashMap::new();
+
+            let nkv_out = qcfg.num_key_value_heads * hd;
+            for (layer_idx, lt) in qcfg.layer_types.iter().enumerate() {
+                let mut layer_dims: std::collections::HashMap<String, (usize, usize)> =
+                    std::collections::HashMap::new();
+                if lt == "full_attention" {
+                    // Full-attention: q correction targets the Q half (not the doubled projection)
+                    layer_dims.insert("q_proj".to_owned(), (hidden, q_half_dim));
+                    layer_dims.insert("v_proj".to_owned(), (hidden, nkv_out));
+                    layer_dims.insert("o_proj".to_owned(), (q_half_dim, hidden));
+                } else {
+                    // GDN (linear_attention): only o_proj; maps to struct field out_proj.
+                    // in_features = val_dim (input to out_proj), out_features = hidden_size.
+                    layer_dims.insert("o_proj".to_owned(), (gdn_out_proj_in, hidden));
+                }
+                per_layer.insert(layer_idx, layer_dims);
+            }
+
+            // Fill any layers not covered by layer_types (every 4th is full_attn)
+            for layer_idx in 0..num_layers {
+                per_layer.entry(layer_idx).or_insert_with(|| {
+                    let is_full_attn = (layer_idx + 1) % 4 == 0;
+                    let mut layer_dims: std::collections::HashMap<String, (usize, usize)> =
+                        std::collections::HashMap::new();
+                    if is_full_attn {
+                        layer_dims.insert("q_proj".to_owned(), (hidden, q_half_dim));
+                        layer_dims.insert("v_proj".to_owned(), (hidden, nkv_out));
+                        layer_dims.insert("o_proj".to_owned(), (q_half_dim, hidden));
+                    } else {
+                        layer_dims.insert("o_proj".to_owned(), (gdn_out_proj_in, hidden));
+                    }
+                    layer_dims
+                });
+            }
+
+            Some(per_layer)
+        } else {
+            None
+        }
     }
 
     /// Validate LoRA configuration against model dimensions.

--- a/crates/hyprstream/src/runtime/ttn_profile.rs
+++ b/crates/hyprstream/src/runtime/ttn_profile.rs
@@ -1,0 +1,593 @@
+//! TTN (Test-Time Naturalization) analysis pipeline for model layer profiling.
+//!
+//! Provides adaptive analysis for determining optimal LoRA rank allocation
+//! per layer. Uses a tiered approach:
+//!
+//! - **Tier 1**: Embedded profiles for known models (zero-cost const lookup)
+//! - **Tier 2**: Cached profiles from disk (~1ms file read)
+//! - **Tier 3**: Computed profiles via bond entropy analysis (~2-5s, cached)
+//!
+//! Ported from `tnn-transformer-1/src/entropy.py` and `attention_analysis.py`.
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::Path;
+use tch::{Kind, Tensor};
+use tracing::{info, warn};
+
+use crate::runtime::model_config::ModelConfig;
+
+// ============================================================================
+// Core types
+// ============================================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum LayerType {
+    FullAttention,
+    GatedDeltaNet,
+    StandardAttention,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LayerAnalysis {
+    pub layer_idx: usize,
+    pub layer_type: LayerType,
+    /// Weight name → bond entropy in nats
+    pub bond_entropy: HashMap<String, f64>,
+    /// Perplexity delta if ablation data available, else None
+    pub perplexity_delta: Option<f64>,
+    pub recommended_rank: usize,
+    pub target_modules: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LayerProfile {
+    pub model_id: String,
+    pub num_layers: usize,
+    pub hidden_size: usize,
+    pub baseline_perplexity: Option<f64>,
+    pub layers: Vec<LayerAnalysis>,
+    /// ISO timestamp; None for embedded profiles
+    pub computed_at: Option<String>,
+}
+
+// ============================================================================
+// Tier 1: Embedded profiles (known models — zero cost)
+// ============================================================================
+
+/// Pre-computed layer analysis for Qwen3.5-0.8B (Tier 1).
+///
+/// Data from `tnn-transformer-1/results/linearization_ablation.json`.
+/// Rank assignments based on perplexity delta (ablation gold standard).
+pub fn qwen3_5_0_8b_profile() -> LayerProfile {
+    // Full-attention layers: 3, 7, 11, 15, 19, 23
+    // GDN layers: 0-2, 4-6, 8-10, 12-14, 16-18, 20-22
+    let attn_layers = [
+        // (layer_idx, perplexity_delta, rank, bond_entropies: [(name, k_entropy, v_entropy)])
+        (23usize, Some(8.40f64), 32usize, vec![
+            ("q_proj", 5.33f64), ("k_proj", 5.28f64), ("v_proj", 5.28f64),
+        ]),
+        (3usize,  Some(5.62f64), 24usize, vec![
+            ("q_proj", 5.75f64), ("k_proj", 5.85f64), ("v_proj", 5.85f64),
+        ]),
+        (19usize, Some(4.39f64), 16usize, vec![
+            ("q_proj", 5.15f64), ("k_proj", 5.56f64), ("v_proj", 5.56f64),
+        ]),
+        (15usize, Some(3.22f64), 16usize, vec![
+            ("q_proj", 5.49f64), ("k_proj", 5.83f64), ("v_proj", 5.83f64),
+        ]),
+        (7usize,  Some(2.16f64), 8usize, vec![
+            ("q_proj", 5.65f64), ("k_proj", 5.82f64), ("v_proj", 5.82f64),
+        ]),
+        (11usize, Some(1.13f64), 8usize, vec![
+            ("q_proj", 5.42f64), ("k_proj", 5.77f64), ("v_proj", 5.77f64),
+        ]),
+    ];
+    let attn_set: std::collections::HashSet<usize> =
+        attn_layers.iter().map(|(i, ..)| *i).collect();
+
+    let mut layers: Vec<LayerAnalysis> = Vec::with_capacity(24);
+
+    // Build full-attention entries
+    for (idx, ppl_delta, rank, entropies) in &attn_layers {
+        let mut entropy_map = HashMap::new();
+        for (name, e) in entropies {
+            entropy_map.insert((*name).to_owned(), *e);
+        }
+        layers.push(LayerAnalysis {
+            layer_idx: *idx,
+            layer_type: LayerType::FullAttention,
+            bond_entropy: entropy_map,
+            perplexity_delta: *ppl_delta,
+            recommended_rank: *rank,
+            target_modules: vec![
+                "q_proj".to_owned(),
+                "v_proj".to_owned(),
+                "o_proj".to_owned(),
+            ],
+        });
+    }
+
+    // Build GDN entries (layers 0-23 not in attn_set)
+    for idx in 0..24usize {
+        if !attn_set.contains(&idx) {
+            layers.push(LayerAnalysis {
+                layer_idx: idx,
+                layer_type: LayerType::GatedDeltaNet,
+                bond_entropy: {
+                    let mut m = HashMap::new();
+                    m.insert("o_proj".to_owned(), 6.2f64); // representative value
+                    m
+                },
+                perplexity_delta: None,
+                recommended_rank: 4,
+                target_modules: vec!["o_proj".to_owned()],
+            });
+        }
+    }
+
+    layers.sort_by_key(|l| l.layer_idx);
+
+    LayerProfile {
+        model_id: "Qwen/Qwen3.5-0.8B".to_owned(),
+        num_layers: 24,
+        hidden_size: 1024,
+        baseline_perplexity: Some(29.54),
+        layers,
+        computed_at: None,
+    }
+}
+
+/// Registry lookup for embedded profiles. Returns `None` for unknown models.
+pub fn find_embedded_profile(
+    model_type: &str,
+    num_layers: usize,
+    hidden_size: usize,
+) -> Option<LayerProfile> {
+    let normalized = model_type.to_lowercase();
+    let normalized = normalized.as_str();
+    match (normalized, num_layers, hidden_size) {
+        ("qwen3_5" | "qwen3.5" | "qwen3_5_text", 24, 1024) => Some(qwen3_5_0_8b_profile()),
+        _ => None,
+    }
+}
+
+// ============================================================================
+// Tier 2: Cached profiles (disk cache)
+// ============================================================================
+
+const ANALYSIS_DIR: &str = ".analysis";
+const PROFILE_FILE: &str = "layer_profile.json";
+
+/// Load cached profile from model directory.
+pub fn load_cached_profile(model_path: &Path) -> Option<LayerProfile> {
+    let path = model_path.join(ANALYSIS_DIR).join(PROFILE_FILE);
+    let content = std::fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+/// Save computed profile to model directory (atomic: tmpfile + rename).
+pub fn save_cached_profile(model_path: &Path, profile: &LayerProfile) -> Result<()> {
+    let dir = model_path.join(ANALYSIS_DIR);
+    std::fs::create_dir_all(&dir)?;
+    let content = serde_json::to_string_pretty(profile)?;
+    let tmp = dir.join(format!("{PROFILE_FILE}.tmp.{}", std::process::id()));
+    std::fs::write(&tmp, &content)?;
+    std::fs::rename(&tmp, dir.join(PROFILE_FILE))?; // atomic on Linux same-FS
+    Ok(())
+}
+
+// ============================================================================
+// Tier 3: Computed profiles (bond entropy analysis)
+// ============================================================================
+
+/// Shannon entropy of a non-negative tensor treated as unnormalized probabilities.
+///
+/// Shared by `bond_entropy` (applied to squared singular values) and
+/// `delta_rank_utilization` (applied to gram eigenvalues, which are already σᵢ²).
+/// Keeping this separate preserves the distinct SVD strategies in each caller.
+fn entropy_of_nonneg(s: &Tensor) -> f64 {
+    let total: f64 = s.sum(Kind::Double).double_value(&[]);
+    if total < 1e-30 {
+        return 0.0;
+    }
+    let p = s / total;
+    let mask = p.gt(1e-30);
+    let p_valid = p.masked_select(&mask);
+    -(&p_valid * p_valid.log()).sum(Kind::Double).double_value(&[])
+}
+
+/// Compute bond entropy of a weight matrix.
+///
+/// Returns `(entropy_nats, num_singular_values)`.
+/// The caller normalizes by `ln(num_sv)` for per-matrix normalization (I-1 fix).
+///
+/// Ported from `tnn-transformer-1/src/entropy.py:bond_entropy_from_singular_values`.
+pub fn bond_entropy(matrix: &Tensor) -> (f64, usize) {
+    let _guard = tch::no_grad_guard();
+    // Reshape to 2D if needed (FP8 may have been dequantized already)
+    let m = if matrix.dim() == 2 {
+        matrix.to_kind(Kind::Float)
+    } else {
+        let shape = matrix.size();
+        let rows = shape[0];
+        let cols: i64 = shape[1..].iter().product();
+        matrix.reshape([rows, cols]).to_kind(Kind::Float)
+    };
+
+    // Use Tensor::svd (economy, compute_uv=false) — compatible with both CPU and CUDA.
+    // linalg_svdvals requires the driver argument which fails on CPU without cuSOLVER.
+    let (_, s, _) = m.svd(true, false);
+    let num_sv = s.size()[0] as usize;
+    let s_sq = &s * &s;
+    (entropy_of_nonneg(&s_sq), num_sv)
+}
+
+/// Map normalized entropy [0,1] to LoRA rank.
+/// Lower normalized entropy → more structured → higher rank.
+///
+/// Calibrated approximately against Qwen3.5-0.8B ablation data.
+/// Note: Tier 3 ranks are approximate — embedded profiles (Tier 1) use
+/// ablation-derived perplexity delta as the gold standard.
+fn entropy_to_rank(normalized: f64) -> usize {
+    match normalized {
+        x if x < 0.80 => 32, // Very structured (critical layers)
+        x if x < 0.85 => 16, // Moderate structure
+        x if x < 0.92 => 8,  // Low structure
+        _ => 4,               // Near-uniform
+    }
+}
+
+/// Detect the layer type for a given layer index.
+///
+/// Priority:
+/// 1. `config.layer_types` if non-empty
+/// 2. Weight key presence
+/// 3. Default: `StandardAttention`
+fn detect_layer_type(
+    config: &ModelConfig,
+    layer_idx: usize,
+    weights: &HashMap<String, Tensor>,
+    prefix: &str,
+) -> LayerType {
+    // Tier 1: use config.layer_types
+    if let Some(lt) = config.layer_types.get(layer_idx) {
+        return match lt.as_str() {
+            "linear_attention" => LayerType::GatedDeltaNet,
+            "full_attention" | "global" | "sliding_window" => LayerType::FullAttention,
+            _ => LayerType::StandardAttention,
+        };
+    }
+
+    // Tier 2: weight key presence
+    let gdn_key = format!("{prefix}.linear_attn.out_proj.weight");
+    if weights.contains_key(&gdn_key) {
+        return LayerType::GatedDeltaNet;
+    }
+    let attn_key = format!("{prefix}.self_attn.q_proj.weight");
+    if weights.contains_key(&attn_key) {
+        return LayerType::FullAttention;
+    }
+
+    LayerType::StandardAttention
+}
+
+/// Compute layer profile by analyzing weight matrices (Tier 3).
+///
+/// Runs SVD on Q/K/V/O projection weights per layer to determine bond entropy.
+/// Results are cached to `{model_path}/.analysis/layer_profile.json`.
+///
+/// # Complexity
+/// O(layers × projs × min(rows,cols)²) SVD. Typically 2–5s for 0.8B models.
+pub fn compute_weight_entropy_profile(
+    weights: &HashMap<String, Tensor>,
+    config: &ModelConfig,
+    model_path: &Path,
+) -> Result<LayerProfile> {
+    let _guard = tch::no_grad_guard();
+    info!(
+        "Computing TTN layer profile for {} ({} layers)...",
+        config.model_type, config.num_hidden_layers
+    );
+
+    // Detect key prefix: base models use "model.layers.*",
+    // Instruct models may use "model.language_model.layers.*"
+    let prefix_base = if weights.keys().any(|k| k.starts_with("model.language_model.")) {
+        "model.language_model.layers"
+    } else {
+        "model.layers"
+    };
+
+    let mut layers = Vec::new();
+
+    for layer_idx in 0..config.num_hidden_layers {
+        let prefix = format!("{prefix_base}.{layer_idx}");
+
+        let layer_type = detect_layer_type(config, layer_idx, weights, &prefix);
+
+        // Architecture-aware key resolution (R2-C1 fix)
+        let (subpath, projs): (&str, &[&str]) = match layer_type {
+            LayerType::FullAttention | LayerType::StandardAttention => {
+                ("self_attn", &["q_proj", "k_proj", "v_proj", "o_proj"])
+            }
+            LayerType::GatedDeltaNet => ("linear_attn", &["out_proj"]),
+        };
+
+        let mut entropies = HashMap::new();
+        let mut entropy_normalized_sum = 0.0f64;
+        let mut entropy_count = 0usize;
+
+        for proj in projs {
+            let key = format!("{prefix}.{subpath}.{proj}.weight");
+            if let Some(w) = weights.get(&key) {
+                let (entropy_nats, num_sv) = bond_entropy(w);
+                entropies.insert((*proj).to_owned(), entropy_nats);
+
+                // Per-matrix normalization (R2-I1 fix): divide by ln(num_sv)
+                let max_entropy = (num_sv as f64).ln();
+                if max_entropy > 1e-10 {
+                    entropy_normalized_sum += entropy_nats / max_entropy;
+                    entropy_count += 1;
+                }
+            }
+        }
+
+        let avg_normalized = if entropy_count > 0 {
+            entropy_normalized_sum / entropy_count as f64
+        } else {
+            0.95 // Default: near-uniform → low rank
+        };
+
+        let recommended_rank = entropy_to_rank(avg_normalized);
+
+        // Target modules: default ["q_proj", "v_proj"] for standard (R2-I4 fix)
+        let target_modules = match layer_type {
+            LayerType::FullAttention => {
+                vec!["q_proj".to_owned(), "v_proj".to_owned(), "o_proj".to_owned()]
+            }
+            LayerType::GatedDeltaNet => vec!["o_proj".to_owned()],
+            LayerType::StandardAttention => {
+                vec!["q_proj".to_owned(), "v_proj".to_owned()]
+            }
+        };
+
+        layers.push(LayerAnalysis {
+            layer_idx,
+            layer_type,
+            bond_entropy: entropies,
+            perplexity_delta: None,
+            recommended_rank,
+            target_modules,
+        });
+    }
+
+    let profile = LayerProfile {
+        model_id: config.model_type.clone(),
+        num_layers: config.num_hidden_layers,
+        hidden_size: config.hidden_size,
+        baseline_perplexity: None,
+        layers,
+        computed_at: Some(chrono::Utc::now().to_rfc3339()),
+    };
+
+    // Atomic cache write (R2-I2 fix)
+    if let Err(e) = save_cached_profile(model_path, &profile) {
+        warn!("Failed to cache layer profile: {e}");
+    }
+
+    info!(
+        "TTN profile computed: {} layers analyzed",
+        profile.layers.len()
+    );
+    Ok(profile)
+}
+
+/// Fallback uniform profile when no weights are available for analysis.
+///
+/// Uses `["o_proj"]` as the sole target module because it is present in all known
+/// architectures (full-attention and GDN/SSM layers alike). Using `["q_proj", "v_proj"]`
+/// would crash delta pool creation for hybrid models whose GDN layers have no q/v projections.
+fn uniform_fallback_profile(config: &ModelConfig) -> LayerProfile {
+    let layers = (0..config.num_hidden_layers)
+        .map(|layer_idx| LayerAnalysis {
+            layer_idx,
+            layer_type: LayerType::StandardAttention,
+            bond_entropy: HashMap::new(),
+            perplexity_delta: None,
+            recommended_rank: 8, // uniform default
+            target_modules: vec!["o_proj".to_owned()],
+        })
+        .collect();
+
+    LayerProfile {
+        model_id: config.model_type.clone(),
+        num_layers: config.num_hidden_layers,
+        hidden_size: config.hidden_size,
+        baseline_perplexity: None,
+        layers,
+        computed_at: None,
+    }
+}
+
+// ============================================================================
+// Unified public API
+// ============================================================================
+
+/// Get or compute the layer profile for a model.
+///
+/// Tiered: embedded → cached → computed.
+///
+/// # Arguments
+/// * `model_path` - Path to model directory (for cache read/write)
+/// * `config` - Model configuration
+/// * `weights` - Optional loaded weights (required for Tier 3 computation)
+pub fn get_layer_profile(
+    model_path: &Path,
+    config: &ModelConfig,
+    weights: Option<&HashMap<String, Tensor>>,
+) -> Result<LayerProfile> {
+    // Tier 1: Embedded profile for known models (zero-cost)
+    if let Some(profile) =
+        find_embedded_profile(&config.model_type, config.num_hidden_layers, config.hidden_size)
+    {
+        info!(
+            "Using embedded TTN profile for {} ({} layers)",
+            config.model_type, config.num_hidden_layers
+        );
+        return Ok(profile);
+    }
+
+    // Tier 2: Cached profile from disk (~1ms)
+    if let Some(profile) = load_cached_profile(model_path) {
+        info!(
+            "Loaded cached TTN profile from {}",
+            model_path.display()
+        );
+        return Ok(profile);
+    }
+
+    // Tier 3: Compute from weights (~2-5s)
+    if let Some(weights) = weights {
+        info!("Computing TTN profile for new model (one-time analysis)...");
+        return compute_weight_entropy_profile(weights, config, model_path);
+    }
+
+    // Fallback: uniform profile
+    warn!("No weights available for TTN analysis, using uniform profile");
+    Ok(uniform_fallback_profile(config))
+}
+
+// ============================================================================
+// Runtime observability
+// ============================================================================
+
+/// Compute delta rank utilization: how much of allocated rank is actually used.
+///
+/// Returns value in [0, 1]: 0 = rank-1 (collapsed), 1 = fully utilized.
+///
+/// Uses SVD of `B^T @ B` which is `[rank, rank]` (I2 fix) — much cheaper than `B @ A`
+/// which is `[out, in]`. B accumulates the learned update (initialized to zeros), so its
+/// singular value distribution captures how much of the allocated rank is actually being
+/// used. When B is zero (fresh delta), returns 0.0.
+///
+/// lora_a: [rank, in_features], lora_b: [out_features, rank]
+///
+/// Called periodically during TTT (every N steps), not on every forward pass.
+pub fn delta_rank_utilization(lora_a: &Tensor, lora_b: &Tensor) -> f64 {
+    let _guard = tch::no_grad_guard();
+    let _ = lora_a; // A is kaiming-initialized and not informative for rank utilization
+    // Gram trick: B^T @ B = [rank, rank]; eigenvalues = σᵢ² of B.
+    // O(rank³) — much cheaper than SVD of [out, rank] directly (O(out·rank²)).
+    let gram = lora_b.tr().matmul(lora_b);
+    let (_, s, _) = gram.svd(true, false); // s = σᵢ² of B (eigenvalues of PSD gram)
+    let max_entropy = (s.size()[0] as f64).ln();
+    if max_entropy < 1e-10 {
+        return 0.0;
+    }
+    // s is already σᵢ² — pass directly to shared helper (no double-squaring)
+    entropy_of_nonneg(&s) / max_entropy
+}
+
+// ============================================================================
+// Attention analysis functions (offline / developer tooling)
+// ============================================================================
+
+/// Compute Shannon entropy of attention distributions.
+///
+/// Input: `[B, H, N, N]` attention weights → Output: `[B, H, N]` per-token entropy.
+///
+/// Ported from `tnn-transformer-1/src/attention_analysis.py:compute_attention_entropy`.
+pub fn attention_entropy(attn_weights: &Tensor) -> Tensor {
+    let _guard = tch::no_grad_guard();
+    let eps = 1e-10f64;
+    let p = attn_weights.clamp_min(eps);
+    -(&p * p.log()).sum_dim_intlist(&[-1i64][..], false, None)
+}
+
+/// Compute top-k attention mass fraction (sparsity measure).
+///
+/// Input: `[B, H, N, N]` attention weights → Output: `[B, H, N]` per-token sparsity.
+///
+/// Ported from `tnn-transformer-1/src/attention_analysis.py:compute_attention_sparsity`.
+pub fn attention_sparsity(attn_weights: &Tensor, top_k: i64) -> Tensor {
+    let _guard = tch::no_grad_guard();
+    let (top_vals, _) = attn_weights.topk(top_k, -1, true, false);
+    top_vals.sum_dim_intlist(&[-1i64][..], false, None)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_qwen3_5_profile_structure() {
+        let profile = qwen3_5_0_8b_profile();
+        assert_eq!(profile.num_layers, 24);
+        assert_eq!(profile.layers.len(), 24);
+
+        // Check full-attention layers have correct ranks
+        let attn_23 = profile.layers.iter().find(|l| l.layer_idx == 23).expect("layer 23 should exist");
+        assert_eq!(attn_23.recommended_rank, 32);
+        assert_eq!(attn_23.layer_type, LayerType::FullAttention);
+
+        let gdn_0 = profile.layers.iter().find(|l| l.layer_idx == 0).expect("layer 0 should exist");
+        assert_eq!(gdn_0.recommended_rank, 4);
+        assert_eq!(gdn_0.layer_type, LayerType::GatedDeltaNet);
+    }
+
+    #[test]
+    fn test_find_embedded_profile() {
+        assert!(find_embedded_profile("qwen3_5", 24, 1024).is_some());
+        assert!(find_embedded_profile("qwen3.5", 24, 1024).is_some());
+        assert!(find_embedded_profile("llama", 32, 4096).is_none());
+        assert!(find_embedded_profile("qwen3_5", 32, 4096).is_none()); // different dims
+    }
+
+    #[test]
+    fn test_entropy_to_rank() {
+        assert_eq!(entropy_to_rank(0.70), 32);
+        assert_eq!(entropy_to_rank(0.82), 16);
+        assert_eq!(entropy_to_rank(0.90), 8);
+        assert_eq!(entropy_to_rank(0.95), 4);
+    }
+
+    #[test]
+    fn test_bond_entropy_random() {
+        let _guard = tch::no_grad_guard();
+        let m = Tensor::randn([64, 64], (Kind::Float, tch::Device::Cpu));
+        let (entropy, num_sv) = bond_entropy(&m);
+        assert_eq!(num_sv, 64);
+        assert!(entropy > 0.0);
+        // Random matrix should have near-uniform distribution, so high entropy
+        let max_entropy = (64f64).ln();
+        assert!(entropy < max_entropy + 1e-6);
+    }
+
+    #[test]
+    fn test_bond_entropy_rank1() {
+        let _guard = tch::no_grad_guard();
+        // Rank-1 matrix: outer product of two vectors
+        let u = Tensor::randn([64, 1], (Kind::Float, tch::Device::Cpu));
+        let v = Tensor::randn([1, 32], (Kind::Float, tch::Device::Cpu));
+        let m = u.matmul(&v);
+        let (entropy, _) = bond_entropy(&m);
+        // Rank-1 → single nonzero singular value → entropy = 0
+        assert!(entropy < 0.1, "Rank-1 matrix entropy should be near 0, got {entropy}");
+    }
+
+    #[test]
+    fn test_delta_rank_utilization() {
+        let _guard = tch::no_grad_guard();
+        let rank = 8i64;
+        let in_f = 64i64;
+        let out_f = 64i64;
+
+        let a = Tensor::randn([rank, in_f], (Kind::Float, tch::Device::Cpu));
+        let b = Tensor::zeros([out_f, rank], (Kind::Float, tch::Device::Cpu));
+        // B = 0 → product is 0 → utilization should be 0
+        let util = delta_rank_utilization(&a, &b);
+        assert_eq!(util, 0.0);
+    }
+}

--- a/crates/hyprstream/src/services/inference.rs
+++ b/crates/hyprstream/src/services/inference.rs
@@ -577,9 +577,10 @@ impl InferenceService {
         // Initialize delta pool if TTT is enabled
         let delta_pool = if ttt_trainer.is_some() {
             let module_dims = engine.get_lora_module_dims().unwrap_or_default();
+            let per_layer_dims = engine.get_per_layer_lora_dims();
             let device = engine.device();
 
-            let delta_config = if let Some(ref tc) = training_config {
+            let base_delta_config = if let Some(ref tc) = training_config {
                 let alpha = tc.lora_alpha.unwrap_or(tc.lora_rank as f32);
                 TenantDeltaConfig {
                     rank: tc.lora_rank,
@@ -591,6 +592,28 @@ impl InferenceService {
             } else {
                 TenantDeltaConfig::default()
             };
+
+            // Try to load TTN layer profile for non-uniform rank allocation
+            let model_config_result = crate::runtime::model_config::ModelConfig::load(&model_path, &std::collections::HashMap::new());
+            let delta_config = if let Ok(ref mc) = model_config_result {
+                match crate::runtime::ttn_profile::get_layer_profile(&model_path, mc, None) {
+                    Ok(profile) => {
+                        let cfg = TenantDeltaConfig::from_profile(&base_delta_config, &profile);
+                        info!(
+                            "Delta pool: using TTN profile ({} layer overrides)",
+                            cfg.layer_overrides.as_ref().map_or(0, std::collections::HashMap::len)
+                        );
+                        cfg
+                    }
+                    Err(e) => {
+                        info!("TTN profile unavailable ({}), using uniform config", e);
+                        base_delta_config
+                    }
+                }
+            } else {
+                base_delta_config
+            };
+
             let kv_reg = engine.kv_registry();
             let snapshots_dir = model_path.join("adapters").join(".snapshots");
             let num_layers = engine.get_num_layers().unwrap_or(32);
@@ -599,7 +622,10 @@ impl InferenceService {
                 "Delta pool initialized: rank={}, alpha={:.1}, modules={:?}, lr={:.1e}",
                 delta_config.rank, delta_config.alpha, delta_config.target_modules, delta_config.learning_rate
             );
-            let pool = DeltaPool::new(delta_config, module_dims, device, kv_reg, snapshots_dir, fs.clone(), num_layers);
+            let mut pool = DeltaPool::new(delta_config, module_dims, device, kv_reg, snapshots_dir, fs.clone(), num_layers);
+            if let Some(pld) = per_layer_dims {
+                pool = pool.with_per_layer_dims(pld);
+            }
 
             Some(Arc::new(pool))
         } else {
@@ -2012,6 +2038,20 @@ impl InferenceHandler for InferenceService {
     async fn handle_is_ready(&self, _ctx: &EnvelopeContext, _request_id: u64) -> Result<InferenceResponseVariant> {
         let ready = InferenceService::handle_is_ready(self).await;
         Ok(InferenceResponseVariant::IsReadyResult(ready))
+    }
+
+    async fn handle_get_layer_profile(&self, _ctx: &EnvelopeContext, _request_id: u64) -> Result<InferenceResponseVariant> {
+        use crate::runtime::ttn_profile;
+        use crate::services::generated::inference_client::LayerProfileResult;
+
+        let model_config = crate::runtime::model_config::ModelConfig::load(
+            &self.model_path,
+            &std::collections::HashMap::new(),
+        )?;
+        let profile = ttn_profile::get_layer_profile(&self.model_path, &model_config, None)?;
+        let json = serde_json::to_string_pretty(&profile)?;
+
+        Ok(InferenceResponseVariant::GetLayerProfileResult(LayerProfileResult { json }))
     }
 
     async fn handle_apply_chat_template(

--- a/crates/hyprstream/src/training/delta_pool.rs
+++ b/crates/hyprstream/src/training/delta_pool.rs
@@ -33,6 +33,10 @@ pub struct DeltaPool {
     default_config: Mutex<TenantDeltaConfig>,
     /// Module dimensions from the loaded model: module_name -> (in_features, out_features)
     module_dims: HashMap<String, (usize, usize)>,
+    /// Per-layer dimension overrides: layer_idx -> module_name -> (in, out)
+    /// Used for hybrid architectures (e.g., Qwen3.5) where GDN and full-attn layers
+    /// have different dimensions for the same LoRA module name (e.g., "o_proj").
+    per_layer_dims: Option<HashMap<usize, HashMap<String, (usize, usize)>>>,
     /// Device for tensor allocation
     device: Device,
     /// Memory budget in bytes (None = unlimited)
@@ -75,6 +79,7 @@ impl DeltaPool {
             deltas: DashMap::new(),
             default_config: Mutex::new(config),
             module_dims,
+            per_layer_dims: None,
             device,
             memory_budget_bytes: None,
             base_weight_norms: HashMap::new(),
@@ -84,6 +89,15 @@ impl DeltaPool {
             num_layers,
             max_tenants: MAX_TENANTS_DEFAULT,
         }
+    }
+
+    /// Set per-layer dimension overrides for hybrid architectures (e.g., Qwen3.5).
+    pub fn with_per_layer_dims(
+        mut self,
+        per_layer_dims: HashMap<usize, HashMap<String, (usize, usize)>>,
+    ) -> Self {
+        self.per_layer_dims = Some(per_layer_dims);
+        self
     }
 
     /// Set memory budget for the pool
@@ -129,7 +143,13 @@ impl DeltaPool {
 
         // Slow path: create new delta (lock config briefly to clone it)
         let config = self.default_config.lock().clone();
-        let delta = TenantDelta::new(&config, &self.module_dims, self.device, self.num_layers)?;
+        let delta = TenantDelta::new_with_per_layer_dims(
+            &config,
+            &self.module_dims,
+            self.device,
+            self.num_layers,
+            self.per_layer_dims.as_ref(),
+        )?;
         let delta = Arc::new(Mutex::new(delta));
 
         // Insert (handles race condition)

--- a/crates/hyprstream/src/training/tenant_delta.rs
+++ b/crates/hyprstream/src/training/tenant_delta.rs
@@ -47,6 +47,16 @@ pub fn extract_lora_components(tensor_name: &str) -> Option<(usize, String, Stri
     None
 }
 
+/// Per-layer LoRA rank and target module override.
+///
+/// When present in `TenantDeltaConfig::layer_overrides`, these values replace
+/// the top-level `rank` and `target_modules` for the specified layer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LayerDeltaConfig {
+    pub rank: usize,
+    pub target_modules: Vec<String>,
+}
+
 /// Configuration for creating a new tenant delta (also used by the create_lora MCP tool)
 ///
 /// This is the single LoRA configuration type. TTT and PEFT differ only in lifecycle
@@ -80,6 +90,36 @@ pub struct TenantDeltaConfig {
     /// Weight decay factor for AdamW (default: 0.02)
     #[serde(default = "default_decay_lambda")]
     pub decay_lambda: f64,
+
+    /// Per-layer rank/module override. Key = layer index.
+    /// Layers not in map use the top-level `rank` and `target_modules`.
+    #[serde(default)]
+    pub layer_overrides: Option<HashMap<usize, LayerDeltaConfig>>,
+}
+
+impl TenantDeltaConfig {
+    /// Create config with non-uniform per-layer ranks from a TTN analysis profile.
+    ///
+    /// Works for any model — the profile is produced by `ttn_profile::get_layer_profile()`.
+    pub fn from_profile(
+        base: &TenantDeltaConfig,
+        profile: &crate::runtime::ttn_profile::LayerProfile,
+    ) -> Self {
+        let mut overrides = HashMap::new();
+        for la in &profile.layers {
+            overrides.insert(
+                la.layer_idx,
+                LayerDeltaConfig {
+                    rank: la.recommended_rank,
+                    target_modules: la.target_modules.clone(),
+                },
+            );
+        }
+        Self {
+            layer_overrides: Some(overrides),
+            ..base.clone()
+        }
+    }
 }
 
 fn default_rank() -> usize {
@@ -111,6 +151,7 @@ impl Default for TenantDeltaConfig {
             learning_rate: default_learning_rate(),
             max_accumulated_steps: default_max_accumulated_steps(),
             decay_lambda: default_decay_lambda(),
+            layer_overrides: None,
         }
     }
 }
@@ -130,7 +171,10 @@ pub struct TenantDelta {
     pub vs: VarStore,
     /// AdamW optimizer over all trainable parameters
     pub optimizer: tch::nn::Optimizer,
-    /// Scaling factor: alpha / rank
+    /// Per-key scaling: "layer_idx.module_name" -> alpha / layer_rank
+    /// Replaces the single `scaling` field for non-uniform rank support (C7 fix).
+    pub scaling_map: HashMap<String, f64>,
+    /// Default scaling factor: alpha / rank (for uniform-rank deltas or backward compat)
     pub scaling: f64,
     /// LoRA rank
     pub rank: usize,
@@ -163,32 +207,70 @@ pub struct TenantDelta {
 }
 
 impl TenantDelta {
-    /// Create a new per-layer tenant delta with Kaiming init for A and zeros for B
+    /// Create a new per-layer tenant delta with Kaiming init for A and zeros for B.
     ///
     /// Creates `num_layers × num_modules` A/B pairs keyed as `"layer_idx.module_name"`.
     ///
     /// # Arguments
-    /// * `config` - Delta configuration (rank, alpha, target modules, etc.)
-    /// * `module_dims` - Map of module_name -> (in_features, out_features)
+    /// * `config` - Delta configuration (rank, alpha, target modules, layer_overrides, etc.)
+    /// * `module_dims` - Map of module_name -> (in_features, out_features) (flat, for uniform layers)
     /// * `device` - Device for tensor allocation
     /// * `num_layers` - Number of model layers
+    /// * `per_layer_dims` - Optional per-layer dim overrides: layer_idx -> module_name -> (in, out)
+    ///   Required when different layer types have different `o_proj` dimensions (e.g. Qwen3.5).
     pub fn new(
         config: &TenantDeltaConfig,
         module_dims: &HashMap<String, (usize, usize)>,
         device: Device,
         num_layers: usize,
     ) -> Result<Self> {
+        Self::new_with_per_layer_dims(config, module_dims, device, num_layers, None)
+    }
+
+    /// Create a new per-layer tenant delta with optional per-layer dimension overrides.
+    ///
+    /// Same as `new()` but accepts `per_layer_dims` for architectures where
+    /// `o_proj` (or other modules) have different dimensions across layer types.
+    pub fn new_with_per_layer_dims(
+        config: &TenantDeltaConfig,
+        module_dims: &HashMap<String, (usize, usize)>,
+        device: Device,
+        num_layers: usize,
+        per_layer_dims: Option<&HashMap<usize, HashMap<String, (usize, usize)>>>,
+    ) -> Result<Self> {
         let vs = VarStore::new(device);
         let root = vs.root();
 
         let mut lora_a = HashMap::new();
         let mut lora_b = HashMap::new();
+        let mut scaling_map = HashMap::new();
 
         for layer_idx in 0..num_layers {
-            for module_name in &config.target_modules {
-                let (in_features, out_features) = module_dims
-                    .get(module_name)
-                    .ok_or_else(|| anyhow!("Module '{}' not found in model dimensions", module_name))?;
+            // Determine layer-specific rank and modules
+            let (layer_rank, layer_modules): (usize, &Vec<String>) =
+                if let Some(overrides) = &config.layer_overrides {
+                    if let Some(lc) = overrides.get(&layer_idx) {
+                        (lc.rank, &lc.target_modules)
+                    } else {
+                        (config.rank, &config.target_modules)
+                    }
+                } else {
+                    (config.rank, &config.target_modules)
+                };
+
+            for module_name in layer_modules {
+                // Per-layer dims take priority over flat module_dims (C1 fix)
+                let (in_features, out_features) = per_layer_dims
+                    .and_then(|pld| pld.get(&layer_idx))
+                    .and_then(|m| m.get(module_name.as_str()))
+                    .or_else(|| module_dims.get(module_name.as_str()))
+                    .ok_or_else(|| {
+                        anyhow!(
+                            "Module '{}' not found in model dimensions (layer {})",
+                            module_name,
+                            layer_idx
+                        )
+                    })?;
 
                 let key = format!("{}.{}", layer_idx, module_name);
 
@@ -198,17 +280,20 @@ impl TenantDelta {
                 // A: Kaiming uniform initialization [rank, in_features]
                 let a = layer_path.kaiming_uniform(
                     "lora_a",
-                    &[config.rank as i64, *in_features as i64],
+                    &[layer_rank as i64, *in_features as i64],
                 );
 
                 // B: Zero initialization [out_features, rank]
                 let b = layer_path.zeros(
                     "lora_b",
-                    &[*out_features as i64, config.rank as i64],
+                    &[*out_features as i64, layer_rank as i64],
                 );
 
                 lora_a.insert(key.clone(), a);
-                lora_b.insert(key, b);
+                lora_b.insert(key.clone(), b);
+
+                // Per-key scaling: alpha / layer_rank (C7 fix)
+                scaling_map.insert(key, config.alpha as f64 / layer_rank as f64);
             }
         }
 
@@ -226,15 +311,28 @@ impl TenantDelta {
         let scaling = config.alpha as f64 / config.rank as f64;
         let now = Instant::now();
 
+        // Collect unique target modules across all layers for iteration metadata
+        let mut all_modules: Vec<String> = config.target_modules.clone();
+        if let Some(overrides) = &config.layer_overrides {
+            for lc in overrides.values() {
+                for m in &lc.target_modules {
+                    if !all_modules.contains(m) {
+                        all_modules.push(m.clone());
+                    }
+                }
+            }
+        }
+
         Ok(Self {
             lora_a,
             lora_b,
             vs,
             optimizer,
+            scaling_map,
             scaling,
             rank: config.rank,
             device,
-            target_modules: config.target_modules.clone(),
+            target_modules: all_modules,
             num_layers,
             learning_rate: config.learning_rate,
             accumulated_steps: 0,
@@ -269,13 +367,16 @@ impl TenantDelta {
         let b = self.lora_b.get(&key)
             .ok_or_else(|| anyhow!("Module '{}' B not found in delta", key))?;
 
+        // Per-key scaling (C7 fix): use per-key alpha/rank, fall back to global scaling
+        let scaling = self.scaling_map.get(&key).copied().unwrap_or(self.scaling);
+
         let x = x.to_kind(a.kind());
         let intermediate = x.f_matmul(&a.tr())
             .map_err(|e| anyhow!("Delta forward matmul A failed for '{}': {}", key, e))?;
         let output = intermediate.f_matmul(&b.tr())
             .map_err(|e| anyhow!("Delta forward matmul B failed for '{}': {}", key, e))?;
 
-        Ok(output * self.scaling)
+        Ok(output * scaling)
     }
 
     /// Compute LoRA correction for 2D tensors at a specific layer: output += scaling * (x @ A^T) @ B^T
@@ -296,13 +397,16 @@ impl TenantDelta {
         let b = self.lora_b.get(&key)
             .ok_or_else(|| anyhow!("Module '{}' B not found in delta", key))?;
 
+        // Per-key scaling (C7 fix): use per-key alpha/rank, fall back to global scaling
+        let scaling = self.scaling_map.get(&key).copied().unwrap_or(self.scaling);
+
         let x = x.to_kind(a.kind());
         let intermediate = x.f_matmul(&a.tr())
             .map_err(|e| anyhow!("Delta forward_2d matmul A failed for '{}': {}", key, e))?;
         let output = intermediate.f_matmul(&b.tr())
             .map_err(|e| anyhow!("Delta forward_2d matmul B failed for '{}': {}", key, e))?;
 
-        Ok(output * self.scaling)
+        Ok(output * scaling)
     }
 
     /// Compute the ratio of delta norm to a reference norm for drift monitoring
@@ -313,15 +417,16 @@ impl TenantDelta {
         let _guard = tch::no_grad_guard();
         let mut ratios = HashMap::new();
 
-        for layer_idx in 0..self.num_layers {
-            for module_name in &self.target_modules {
-                let key = format!("{}.{}", layer_idx, module_name);
-                if let (Some(a), Some(b)) = (self.lora_a.get(&key), self.lora_b.get(&key)) {
-                    let delta = b.matmul(a) * self.scaling;
-                    let delta_norm: f64 = delta.norm().double_value(&[]);
-                    let base_norm = base_norms.get(module_name).copied().unwrap_or(1.0);
-                    ratios.insert(key, delta_norm / base_norm.max(1e-8));
-                }
+        // Iterate lora_a.keys() to handle non-uniform per-layer module sets (I1 fix)
+        for key in self.lora_a.keys() {
+            if let (Some(a), Some(b)) = (self.lora_a.get(key), self.lora_b.get(key)) {
+                let scaling = self.scaling_map.get(key).copied().unwrap_or(self.scaling);
+                let delta = b.matmul(a) * scaling;
+                let delta_norm: f64 = delta.norm().double_value(&[]);
+                // Extract module name from key "layer_idx.module_name"
+                let module_name = key.split_once('.').map_or(key.as_str(), |(_, m)| m);
+                let base_norm = base_norms.get(module_name).copied().unwrap_or(1.0);
+                ratios.insert(key.clone(), delta_norm / base_norm.max(1e-8));
             }
         }
 
@@ -335,15 +440,13 @@ impl TenantDelta {
         let _guard = tch::no_grad_guard();
         let mut state = HashMap::new();
 
-        for layer_idx in 0..self.num_layers {
-            for module_name in &self.target_modules {
-                let key = format!("{}.{}", layer_idx, module_name);
-                if let Some(a) = self.lora_a.get(&key) {
-                    state.insert(format!("{}.lora_a", key), a.copy());
-                }
-                if let Some(b) = self.lora_b.get(&key) {
-                    state.insert(format!("{}.lora_b", key), b.copy());
-                }
+        // Iterate lora_a.keys() to handle non-uniform per-layer module sets (I1 fix)
+        for key in self.lora_a.keys() {
+            if let Some(a) = self.lora_a.get(key) {
+                state.insert(format!("{}.lora_a", key), a.copy());
+            }
+            if let Some(b) = self.lora_b.get(key) {
+                state.insert(format!("{}.lora_b", key), b.copy());
             }
         }
 
@@ -356,22 +459,19 @@ impl TenantDelta {
     pub fn load_state_dict(&mut self, state: &HashMap<String, Tensor>) -> Result<()> {
         let _guard = tch::no_grad_guard();
 
-        for layer_idx in 0..self.num_layers {
-            for module_name in &self.target_modules {
-                let key = format!("{}.{}", layer_idx, module_name);
-                let a_key = format!("{}.lora_a", key);
-                let b_key = format!("{}.lora_b", key);
+        for key in self.lora_a.keys().cloned().collect::<Vec<_>>() {
+            let a_key = format!("{}.lora_a", key);
+            let b_key = format!("{}.lora_b", key);
 
-                if let Some(a_src) = state.get(&a_key) {
-                    if let Some(a_dst) = self.lora_a.get_mut(&key) {
-                        a_dst.copy_(a_src);
-                    }
+            if let Some(a_src) = state.get(&a_key) {
+                if let Some(a_dst) = self.lora_a.get_mut(&key) {
+                    a_dst.copy_(a_src);
                 }
+            }
 
-                if let Some(b_src) = state.get(&b_key) {
-                    if let Some(b_dst) = self.lora_b.get_mut(&key) {
-                        b_dst.copy_(b_src);
-                    }
+            if let Some(b_src) = state.get(&b_key) {
+                if let Some(b_dst) = self.lora_b.get_mut(&key) {
+                    b_dst.copy_(b_src);
                 }
             }
         }
@@ -443,19 +543,26 @@ impl TenantDelta {
         let mut composed_a = HashMap::new();
         let mut composed_b = HashMap::new();
 
-        let ranks_match = base_guard.rank == tenant_guard.rank;
-
         for key in &all_keys {
             let base_a = base_guard.lora_a.get(key);
             let base_b = base_guard.lora_b.get(key);
             let tenant_a = tenant_guard.lora_a.get(key);
             let tenant_b = tenant_guard.lora_b.get(key);
 
+            // Use per-key scaling if available (C7 fix), else fall back to global
+            let base_scaling = base_guard.scaling_map.get(key).copied().unwrap_or(base_guard.scaling);
+            let tenant_scaling = tenant_guard.scaling_map.get(key).copied().unwrap_or(tenant_guard.scaling);
+
+            // Check if ranks match for this specific key
+            let base_rank = base_a.map(|a| a.size()[0]);
+            let tenant_rank = tenant_a.map(|a| a.size()[0]);
+            let ranks_match = base_rank == tenant_rank;
+
             match (base_a, tenant_a) {
                 (Some(ba), Some(ta)) if ranks_match => {
                     // Same rank: add A matrices directly (pre-scaled)
-                    let base_effective_a = ba * base_guard.scaling;
-                    let tenant_effective_a = ta * tenant_guard.scaling;
+                    let base_effective_a = ba * base_scaling;
+                    let tenant_effective_a = ta * tenant_scaling;
                     composed_a.insert(key.clone(), base_effective_a + tenant_effective_a);
                 }
                 (Some(ba), Some(ta)) => {
@@ -483,8 +590,8 @@ impl TenantDelta {
                     // A is [rank, in_dim], B is [out_dim, rank]
                     // B @ A = [out_dim, in_dim]
                     // B @ A = [out_dim, rank] @ [rank, in_dim] = [out_dim, in_dim]
-                    let base_w = bb.matmul(ba) * base_guard.scaling;
-                    let tenant_w = tb.matmul(ta) * tenant_guard.scaling;
+                    let base_w = bb.matmul(ba) * base_scaling;
+                    let tenant_w = tb.matmul(ta) * tenant_scaling;
                     let w_eff = base_w + tenant_w;
                     // forward_2d computes: scaling * (x @ A^T) @ B^T
                     // We want: x @ W_eff^T  (result shape [tokens, out_dim])
@@ -497,10 +604,10 @@ impl TenantDelta {
                     continue; // Skip the B match below, we already handled it
                 }
                 (Some(ba), None) => {
-                    composed_a.insert(key.clone(), ba * base_guard.scaling);
+                    composed_a.insert(key.clone(), ba * base_scaling);
                 }
                 (None, Some(ta)) => {
-                    composed_a.insert(key.clone(), ta * tenant_guard.scaling);
+                    composed_a.insert(key.clone(), ta * tenant_scaling);
                 }
                 (None, None) => {}
             }
@@ -544,6 +651,7 @@ impl TenantDelta {
             lora_b: composed_b,
             vs,
             optimizer,
+            scaling_map: HashMap::new(), // scaling=1.0 already baked in during composition
             scaling: 1.0, // Already pre-scaled during composition
             rank,
             device,
@@ -610,25 +718,29 @@ impl TenantDelta {
     pub fn serialize_to_safetensors_bytes(&self) -> Result<Vec<u8>> {
         let mut pairs: Vec<(String, Tensor)> = Vec::new();
 
-        for layer_idx in 0..self.num_layers {
-            for module in &self.target_modules {
-                let key = format!("{}.{}", layer_idx, module);
-                let subpath = module_to_peft_subpath(module);
+        // Iterate lora_a.keys() to handle non-uniform per-layer module sets (I1 fix)
+        let mut keys: Vec<&String> = self.lora_a.keys().collect();
+        keys.sort(); // deterministic output
+        for key in keys {
+            // key format: "layer_idx.module_name"
+            let mut parts = key.splitn(2, '.');
+            let layer_idx: usize = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+            let module = parts.next().unwrap_or(key.as_str());
+            let subpath = module_to_peft_subpath(module);
 
-                if let Some(a) = self.lora_a.get(&key) {
-                    let peft_key = format!(
-                        "base_model.model.layers.{}.{}.{}.lora_A.weight",
-                        layer_idx, subpath, module
-                    );
-                    pairs.push((peft_key, a.shallow_clone()));
-                }
-                if let Some(b) = self.lora_b.get(&key) {
-                    let peft_key = format!(
-                        "base_model.model.layers.{}.{}.{}.lora_B.weight",
-                        layer_idx, subpath, module
-                    );
-                    pairs.push((peft_key, b.shallow_clone()));
-                }
+            if let Some(a) = self.lora_a.get(key) {
+                let peft_key = format!(
+                    "base_model.model.layers.{}.{}.{}.lora_A.weight",
+                    layer_idx, subpath, module
+                );
+                pairs.push((peft_key, a.shallow_clone()));
+            }
+            if let Some(b) = self.lora_b.get(key) {
+                let peft_key = format!(
+                    "base_model.model.layers.{}.{}.{}.lora_B.weight",
+                    layer_idx, subpath, module
+                );
+                pairs.push((peft_key, b.shallow_clone()));
             }
         }
 
@@ -712,11 +824,21 @@ impl TenantDelta {
             alpha
         );
 
+        // Build per-key scaling map from loaded A matrix ranks
+        let scaling_map: HashMap<String, f64> = lora_a
+            .iter()
+            .map(|(key, a)| {
+                let layer_rank = a.size()[0] as usize;
+                (key.clone(), alpha as f64 / layer_rank as f64)
+            })
+            .collect();
+
         Ok(Self {
             lora_a,
             lora_b,
             vs,
             optimizer,
+            scaling_map,
             scaling,
             rank,
             device,

--- a/crates/hyprstream/src/training/ttt.rs
+++ b/crates/hyprstream/src/training/ttt.rs
@@ -453,6 +453,11 @@ impl TestTimeTrainer {
         // Snapshot delta state before adaptation (for rollback)
         let pre_snapshot = delta.extract_state_dict();
 
+        // Snapshot SSM states before TTT loop (C4 fix: prevents training data from
+        // accumulating into the inference recurrent state for Qwen3.5 GDN layers).
+        // No-op for non-Qwen3.5 models.
+        let ssm_snapshot = engine.snapshot_ssm_states();
+
         // Track whether input was truncated
         let tokens_provided = input_tokens.len();
         let was_truncated = tokens_provided > self.config.max_ttt_context;
@@ -478,6 +483,8 @@ impl TestTimeTrainer {
             .unwrap_or(self.config.max_adaptation_ms);
 
         if gated_steps == 0 {
+            // Restore SSM states — initial NTP loss forward pass may have mutated them.
+            engine.restore_ssm_states(ssm_snapshot);
             return Ok((
                 TTTResult {
                     avg_loss: initial_loss,
@@ -551,6 +558,9 @@ impl TestTimeTrainer {
 
                 let time_used_ms = start.elapsed().as_millis() as u64;
 
+                // Restore SSM states so TTT training data does not pollute inference recurrent state.
+                engine.restore_ssm_states(ssm_snapshot);
+
                 Ok((
                     TTTResult {
                         avg_loss,
@@ -577,20 +587,22 @@ impl TestTimeTrainer {
                 ))
             }
             Ok(Err(e)) => {
-                // Gradient loop returned an error — restore delta from snapshot
+                // Gradient loop returned an error — restore delta and SSM states from snapshot
                 tracing::warn!("TTT adapt_tenant gradient loop error, restoring delta: {}", e);
                 let _ = delta.load_state_dict(&pre_snapshot);
                 // Flush stale gradients from optimizer (may have accumulated before error)
                 delta.optimizer.zero_grad();
+                engine.restore_ssm_states(ssm_snapshot);
                 Err(e)
             }
             Err(panic_info) => {
-                // Panic during gradient loop — restore delta from snapshot.
+                // Panic during gradient loop — restore delta and SSM states from snapshot.
                 // Also zero gradients: a panic mid-backward/step leaves stale
                 // gradient accumulation and corrupted AdamW moment buffers.
                 tracing::error!("TTT adapt_tenant panicked during gradient loop, restoring delta");
                 let _ = delta.load_state_dict(&pre_snapshot);
                 delta.optimizer.zero_grad();
+                engine.restore_ssm_states(ssm_snapshot);
                 let msg = if let Some(s) = panic_info.downcast_ref::<String>() {
                     s.clone()
                 } else if let Some(s) = panic_info.downcast_ref::<&str>() {
@@ -671,6 +683,18 @@ impl TestTimeTrainer {
                 any_clipped = true;
             }
             actual_steps += 1;
+
+            // Delta rank utilization monitoring every 10 cumulative steps (Phase 3e).
+            // Uses delta.accumulated_steps (cross-call total) so monitoring fires even
+            // for short TTT runs (gated_steps < 10). SVD on [rank×rank] is ~μs.
+            if (delta.accumulated_steps + actual_steps as u64).is_multiple_of(10) {
+                for (key, a) in &delta.lora_a {
+                    if let Some(b) = delta.lora_b.get(key) {
+                        let util = crate::runtime::ttn_profile::delta_rank_utilization(a, b);
+                        tracing::debug!(key = %key, utilization = %util, "Delta rank utilization");
+                    }
+                }
+            }
         }
 
         // Compute final loss for perplexity
@@ -767,6 +791,9 @@ impl TestTimeTrainer {
         // Snapshot for panic recovery
         let pre_snapshot = delta.extract_state_dict();
 
+        // Snapshot SSM states before training loop (prevents training data from polluting inference state).
+        let ssm_snapshot = engine.snapshot_ssm_states();
+
         let loop_result = std::panic::catch_unwind(AssertUnwindSafe(|| {
             self.train_step_inner(engine, delta, &tokens, clamped_steps, lr, &start, budget)
         }));
@@ -800,6 +827,9 @@ impl TestTimeTrainer {
 
                 let time_used_ms = start.elapsed().as_millis() as u64;
 
+                // Restore SSM states so training data does not pollute inference recurrent state.
+                engine.restore_ssm_states(ssm_snapshot);
+
                 Ok(TTTResult {
                     avg_loss,
                     loss_improvement,
@@ -826,12 +856,14 @@ impl TestTimeTrainer {
                 tracing::warn!("TTT train_step gradient loop error, restoring delta: {}", e);
                 let _ = delta.load_state_dict(&pre_snapshot);
                 delta.optimizer.zero_grad();
+                engine.restore_ssm_states(ssm_snapshot);
                 Err(e)
             }
             Err(panic_info) => {
                 tracing::error!("TTT train_step panicked during gradient loop, restoring delta");
                 let _ = delta.load_state_dict(&pre_snapshot);
                 delta.optimizer.zero_grad();
+                engine.restore_ssm_states(ssm_snapshot);
                 let msg = if let Some(s) = panic_info.downcast_ref::<String>() {
                     s.clone()
                 } else if let Some(s) = panic_info.downcast_ref::<&str>() {


### PR DESCRIPTION
Add Test-Time Training (TTT) support for the Qwen3.5 hybrid SSM/attention architecture with an adaptive TTN analysis pipeline for optimal LoRA rank allocation per layer.

Key changes:
- ttn_profile.rs: Adaptive layer profiling (embedded → cached → weight entropy SVD); shared entropy_of_nonneg helper used by both bond_entropy (full SVD) and delta_rank_utilization (gram trick fast path, O(rank³))
- model_factory.rs: Automatic Tier 3 profiling at model load when weights are available; caches result to .analysis/layer_profile.json
- tenant_delta.rs: Non-uniform per-layer rank allocation via LayerDeltaConfig and from_profile(); per-key scaling HashMap replaces single scaling field
- qwen3_5.rs: delta injection on FullAttention and GatedDeltaNet forward paths; decode_layer, decode_layer_with_delta, forward_with_cache_and_delta
- torch_engine.rs: per-layer LoRA dims for Qwen3.5 o_proj dim differences
- ttt.rs: SSM state snapshot/restore around adaptation; rank utilization monitoring
- inference.capnp + inference.rs: getLayerProfile RPC method exposing the TTN profile as JSON; ModelService gets client access via macro regeneration