### PR TITLE
feat(transport): iroh substrate + ALPN router (Epic #131 Phase 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api_client"
@@ -257,9 +257,12 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.7.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "argminmax"
@@ -945,6 +948,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_io_stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
+dependencies = [
+ "futures",
+ "pharos",
+ "rustc_version",
+]
+
+[[package]]
 name = "asynchronous-codec"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1188,12 +1202,23 @@ dependencies = [
  "hyper 1.7.0",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.23.31",
+ "rustls 0.23.40",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
  "tower-service",
+]
+
+[[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand 2.3.0",
+ "gloo-timers",
+ "tokio",
 ]
 
 [[package]]
@@ -1207,6 +1232,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base256emoji"
@@ -1374,15 +1405,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.2"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if 1.0.3",
- "constant_time_eq 0.3.1",
+ "constant_time_eq 0.4.2",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -1419,6 +1451,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
@@ -1577,9 +1618,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytes-utils"
@@ -1635,7 +1676,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fe67a3f89b693d2163cf3d94129125463ac5913e1c4322f2db905aa631d3c67"
 dependencies = [
- "embedded-io",
+ "embedded-io 0.7.1",
 ]
 
 [[package]]
@@ -1897,13 +1938,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if 1.0.3",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chacha20poly1305"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -1929,7 +1981,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2077,6 +2129,15 @@ name = "cmov"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.17",
+]
 
 [[package]]
 name = "colorchoice"
@@ -2319,9 +2380,9 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
@@ -2346,6 +2407,16 @@ name = "cookie-factory"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396de984970346b0d9e93d1415082923c679e5ae5c3ee3dcbd104f5610af126b"
+
+[[package]]
+name = "cordyceps"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688d7fbb8092b8de775ef2536f36c8c31f2bc4006ece2e8d8ad2d17d00ce0a2a"
+dependencies = [
+ "loom",
+ "tracing",
+]
 
 [[package]]
 name = "core-foundation"
@@ -2745,9 +2816,27 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto",
+ "fiat-crypto 0.2.9",
  "rand_core 0.6.4",
  "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0-pre.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
+dependencies = [
+ "cfg-if 1.0.3",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto 0.3.0",
+ "rand_core 0.10.1",
+ "rustc_version",
+ "serde",
  "subtle",
  "zeroize",
 ]
@@ -2940,15 +3029,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.9.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ce6c96ea0102f01122a185683611bd5ac8d99e62bc59dd12e6bda344ee673d"
+checksum = "3259c913752a86488b501ed8680446a5ed2d5aeac6e596cb23ba3800768ea32c"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -2956,9 +3045,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.16"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
+checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
  "syn 2.0.111",
@@ -3869,7 +3958,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
  "zeroize",
 ]
 
@@ -3880,6 +3969,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
  "const-oid 0.10.2",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -4005,6 +4095,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 2.0.111",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -4015,6 +4106,12 @@ checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
 dependencies = [
  "cipher",
 ]
+
+[[package]]
+name = "diatomic-waker"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab03c107fafeb3ee9f5925686dbb7a73bc76e3932abb0d2b365cb64b169cf04c"
 
 [[package]]
 name = "digest"
@@ -4044,6 +4141,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
+ "const-oid 0.10.2",
  "crypto-common 0.2.1",
 ]
 
@@ -4128,6 +4226,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.0",
+ "block2",
+ "libc",
  "objc2",
 ]
 
@@ -4140,6 +4240,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "dlopen2"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4"
+dependencies = [
+ "libc",
+ "once_cell",
+ "winapi",
 ]
 
 [[package]]
@@ -4313,16 +4424,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
+dependencies = [
+ "pkcs8 0.11.0",
+ "serdect",
+ "signature 3.0.0",
+]
+
+[[package]]
 name = "ed25519-dalek"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
  "rand_core 0.6.4",
  "serde",
  "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0-pre.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20449acd54b660981ae5caa2bcb56d1fe7f25f2e37a38ec507400fab034d4bb6"
+dependencies = [
+ "curve25519-dalek 5.0.0-pre.6",
+ "ed25519 3.0.0",
+ "rand_core 0.10.1",
+ "serde",
+ "sha2 0.11.0",
+ "signature 3.0.0",
  "subtle",
  "zeroize",
 ]
@@ -4362,20 +4500,32 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "crypto-bigint",
  "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
  "hkdf",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "embedded-io"
@@ -4417,6 +4567,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
  "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "enum-assoc"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed8956bd5c1f0415200516e78ff07ec9e16415ade83c056c230d7b7ea0d55b7"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -4706,6 +4867,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
+
+[[package]]
 name = "file_utils"
 version = "0.14.2"
 source = "git+https://github.com/huggingface/xet-core?tag=git-xet-v0.2.0#eeee211e5900cbe6a65649fbec0ee0750cc831b2"
@@ -4795,7 +4962,7 @@ dependencies = [
  "ahash 0.8.12",
  "num_cpus",
  "parking_lot 0.12.4",
- "seize",
+ "seize 0.3.3",
 ]
 
 [[package]]
@@ -5022,6 +5189,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-buffered"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4421cb78ee172b6b06080093479d3c50f058e7c81b7d577bbb8d118d551d4cd5"
+dependencies = [
+ "cordyceps",
+ "diatomic-waker",
+ "futures-core",
+ "pin-project-lite",
+ "spin 0.10.0",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5101,7 +5281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
- "rustls 0.23.31",
+ "rustls 0.23.40",
  "rustls-pki-types",
 ]
 
@@ -5169,6 +5349,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.3",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5223,11 +5418,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if 1.0.3",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5353,7 +5550,7 @@ dependencies = [
  "colored",
  "config 0.13.4",
  "dirs 5.0.1",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "futures",
  "git2",
  "glob",
@@ -5379,6 +5576,18 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "go-flag"
@@ -5552,6 +5761,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
 name = "hashlink"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5654,6 +5874,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cfg-if 1.0.3",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "h2 0.4.12",
+ "hickory-proto 0.26.1",
+ "http 1.3.1",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "rand 0.10.1",
+ "rustls 0.23.40",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hickory-proto"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5680,6 +5929,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hickory-resolver"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5687,7 +5956,7 @@ checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
 dependencies = [
  "cfg-if 1.0.3",
  "futures-util",
- "hickory-proto",
+ "hickory-proto 0.25.2",
  "ipconfig",
  "moka",
  "once_cell",
@@ -5697,6 +5966,34 @@ dependencies = [
  "smallvec",
  "thiserror 2.0.17",
  "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+dependencies = [
+ "cfg-if 1.0.3",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto 0.26.1",
+ "ipconfig",
+ "ipnet",
+ "jni 0.22.4",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot 0.12.4",
+ "rand 0.10.1",
+ "resolv-conf",
+ "rustls 0.23.40",
+ "smallvec",
+ "system-configuration 0.7.0",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-rustls 0.26.2",
  "tracing",
 ]
 
@@ -5907,13 +6204,13 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.7.0",
  "hyper-util",
- "rustls 0.23.31",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
  "tower-service",
- "webpki-roots 1.0.2",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -6070,11 +6367,11 @@ dependencies = [
  "clap",
  "config 0.13.4",
  "criterion",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "daemonize",
  "dashmap",
  "dirs 5.0.1",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "fastrand 2.3.0",
  "fred",
  "futures",
@@ -6137,7 +6434,7 @@ dependencies = [
  "rlimit 0.10.2",
  "rmcp",
  "rocksdb",
- "rustls 0.23.31",
+ "rustls 0.23.40",
  "rustls-acme",
  "rustls-pemfile 2.2.0",
  "safetensors 0.4.5",
@@ -6223,7 +6520,7 @@ dependencies = [
  "async-trait",
  "capnp",
  "capnpc",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "hyprstream-rpc",
  "hyprstream-rpc-build",
  "hyprstream-rpc-derive",
@@ -6258,7 +6555,7 @@ dependencies = [
  "parking_lot 0.12.4",
  "prost 0.13.5",
  "rlimit 0.10.2",
- "rustls 0.23.31",
+ "rustls 0.23.40",
  "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
@@ -6327,10 +6624,10 @@ dependencies = [
  "chrono",
  "ciborium",
  "coset",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "dashmap",
  "dirs 5.0.1",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "futures",
  "getrandom 0.2.16",
  "h3",
@@ -6343,9 +6640,11 @@ dependencies = [
  "hyprstream-rpc-build",
  "hyprstream-rpc-derive",
  "inventory",
+ "iroh",
  "js-sys",
  "ml-dsa",
  "ml-kem",
+ "moq-net",
  "nix 0.27.1",
  "once_cell",
  "p256",
@@ -6353,7 +6652,7 @@ dependencies = [
  "quinn",
  "rand 0.8.5",
  "rcgen",
- "rustls 0.23.31",
+ "rustls 0.23.40",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
@@ -6372,6 +6671,8 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "web-time",
+ "web-transport-iroh",
+ "web-transport-trait",
  "webpki-roots 0.26.11",
  "whoami",
  "zeroize",
@@ -6438,7 +6739,7 @@ dependencies = [
  "chrono",
  "dashmap",
  "dirs 5.0.1",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "futures",
  "hyprstream-discovery",
  "hyprstream-rpc",
@@ -6523,9 +6824,9 @@ dependencies = [
  "capnpc",
  "ch-config",
  "chrono",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "dashmap",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "fuse-backend-rs 0.12.1",
  "futures",
  "glob",
@@ -6578,7 +6879,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.0",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -6689,6 +6990,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "identity-hash"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfdd7caa900436d8f13b2346fe10257e0c05c1f1f9e351f4f5d57c03bd5f45da"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6732,9 +7039,9 @@ dependencies = [
  "if-addrs",
  "ipnet",
  "log",
- "netlink-packet-core",
- "netlink-packet-route",
- "netlink-proto",
+ "netlink-packet-core 0.7.0",
+ "netlink-packet-route 0.17.1",
+ "netlink-proto 0.11.5",
  "netlink-sys",
  "rtnetlink",
  "system-configuration 0.6.1",
@@ -6959,9 +7266,12 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -6971,6 +7281,177 @@ checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "iroh"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98e206e3d3f2642f5c08c413755fc0ac19b54ae1a656af88be03454ce3ed2e6"
+dependencies = [
+ "backon",
+ "blake3",
+ "bytes",
+ "cfg_aliases",
+ "ctutils",
+ "data-encoding",
+ "derive_more",
+ "ed25519-dalek 3.0.0-pre.7",
+ "futures-util",
+ "getrandom 0.4.2",
+ "hickory-resolver 0.26.1",
+ "http 1.3.1",
+ "ipnet",
+ "iroh-base",
+ "iroh-dns",
+ "iroh-metrics",
+ "iroh-relay",
+ "n0-error",
+ "n0-future",
+ "n0-watcher",
+ "netwatch",
+ "noq",
+ "noq-proto",
+ "noq-udp",
+ "papaya",
+ "pin-project",
+ "portable-atomic",
+ "rand 0.10.1",
+ "reqwest 0.13.4",
+ "rustc-hash",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.13",
+ "serde",
+ "smallvec",
+ "strum 0.28.0",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+ "wasm-bindgen-futures",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "iroh-base"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af93d67701c00c504982154569192ad384738c0450ba1196930314b955100552"
+dependencies = [
+ "curve25519-dalek 5.0.0-pre.6",
+ "data-encoding",
+ "data-encoding-macro",
+ "derive_more",
+ "digest 0.11.3",
+ "ed25519-dalek 3.0.0-pre.7",
+ "getrandom 0.4.2",
+ "n0-error",
+ "rand 0.10.1",
+ "serde",
+ "sha2 0.11.0",
+ "url",
+ "zeroize",
+ "zeroize_derive",
+]
+
+[[package]]
+name = "iroh-dns"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de4112c91eb64094d77df9d3112606dcf7ff216421afccd2dc762fda5a7b2879"
+dependencies = [
+ "arc-swap",
+ "cfg_aliases",
+ "derive_more",
+ "hickory-resolver 0.26.1",
+ "iroh-base",
+ "n0-error",
+ "n0-future",
+ "ndk-context",
+ "rand 0.10.1",
+ "reqwest 0.13.4",
+ "rustls 0.23.40",
+ "simple-dns",
+ "strum 0.28.0",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "iroh-metrics"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d102597d0ee523f17fdb672c532395e634dbe945429284c811430d63bacc0d8a"
+dependencies = [
+ "iroh-metrics-derive",
+ "itoa",
+ "n0-error",
+ "portable-atomic",
+ "ryu",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "iroh-metrics-derive"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c8e0c97f1dc787107f388433c349397c565572fe6406d600ff7bb7b7fe3b30"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "iroh-relay"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54f490405e42dd2ecf16be18a3587d2665401e94a498094f12322eaa6d5ebb2b"
+dependencies = [
+ "blake3",
+ "bytes",
+ "cfg_aliases",
+ "data-encoding",
+ "derive_more",
+ "getrandom 0.4.2",
+ "hickory-resolver 0.26.1",
+ "http 1.3.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-util",
+ "iroh-base",
+ "iroh-dns",
+ "iroh-metrics",
+ "lru 0.18.0",
+ "n0-error",
+ "n0-future",
+ "noq",
+ "noq-proto",
+ "num_enum",
+ "pin-project",
+ "postcard",
+ "rand 0.10.1",
+ "reqwest 0.13.4",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "serde",
+ "serde_bytes",
+ "strum 0.28.0",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tokio-util",
+ "tokio-websockets",
+ "tracing",
+ "url",
+ "vergen-gitcl",
+ "webpki-roots 1.0.7",
+ "ws_stream_wasm",
 ]
 
 [[package]]
@@ -7038,7 +7519,7 @@ dependencies = [
  "cesu8",
  "cfg-if 1.0.3",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.0",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -7046,10 +7527,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if 1.0.3",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.17",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.111",
+]
 
 [[package]]
 name = "jobserver"
@@ -7115,7 +7645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
  "base64 0.22.1",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "getrandom 0.2.16",
  "hmac 0.12.1",
  "js-sys",
@@ -7243,6 +7773,15 @@ dependencies = [
  "security-framework 3.5.0",
  "windows-sys 0.60.2",
  "zeroize",
+]
+
+[[package]]
+name = "kio"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32311a076e65af53bebb6ba1d6808aae929453800cbebc12e1fa561624baa808"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -7578,7 +8117,7 @@ checksum = "0b770c1c8476736ca98c578cba4b505104ff8e842c2876b528925f9766379f9a"
 dependencies = [
  "async-trait",
  "futures",
- "hickory-resolver",
+ "hickory-resolver 0.25.2",
  "libp2p-core",
  "libp2p-identity",
  "parking_lot 0.12.4",
@@ -7614,7 +8153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3104e13b51e4711ff5738caa1fb54467c8604c2e94d607e27745bcf709068774"
 dependencies = [
  "bs58",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "hkdf",
  "multihash",
  "quick-protobuf",
@@ -7659,7 +8198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c66872d0f1ffcded2788683f76931be1c52e27f343edb93bc6d0bcd8887be443"
 dependencies = [
  "futures",
- "hickory-proto",
+ "hickory-proto 0.25.2",
  "if-watch",
  "libp2p-core",
  "libp2p-identity",
@@ -7726,7 +8265,7 @@ dependencies = [
  "quinn",
  "rand 0.8.5",
  "ring",
- "rustls 0.23.31",
+ "rustls 0.23.40",
  "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
@@ -7811,8 +8350,8 @@ dependencies = [
  "libp2p-identity",
  "rcgen",
  "ring",
- "rustls 0.23.31",
- "rustls-webpki 0.103.6",
+ "rustls 0.23.40",
+ "rustls-webpki 0.103.13",
  "thiserror 2.0.17",
  "x509-parser 0.17.0",
  "yasna",
@@ -8058,6 +8597,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if 1.0.3",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8073,6 +8625,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfe949189f46fabb938b3a9a0be30fdd93fd8a09260da863399a8cf3db756ec8"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+dependencies = [
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -8119,6 +8680,12 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[package]]
+name = "mac-addr"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d25b0e0b648a86960ac23b7ad4abb9717601dec6f66c165f5b037f3f03065f"
 
 [[package]]
 name = "macro_rules_attribute"
@@ -8471,6 +9038,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "moq-net"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e6df8317fbac0fc334536c85ad8b2ff7e880d11802f1f93af56f1e30486ed0e"
+dependencies = [
+ "bytes",
+ "futures",
+ "kio",
+ "num_enum",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "web-async",
+ "web-transport-trait",
+]
+
+[[package]]
 name = "more-asserts"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8570,6 +9157,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "n0-error"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "223e946a84aa91644507a6b7865cfebbb9a231ace499041c747ab0fd30408212"
+dependencies = [
+ "n0-error-macros",
+ "spez",
+]
+
+[[package]]
+name = "n0-error-macros"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "565305a21e6b3bf26640ad98f05a0fda12d3ab4315394566b52a7bddb8b34828"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "n0-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2ab99dfb861450e68853d34ae665243a88b8c493d01ba957321a1e9b2312bbe"
+dependencies = [
+ "cfg_aliases",
+ "derive_more",
+ "futures-buffered",
+ "futures-lite 2.6.1",
+ "futures-util",
+ "js-sys",
+ "pin-project",
+ "send_wrapper",
+ "tokio",
+ "tokio-util",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
+name = "n0-watcher"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928d8039a66cce5efcfd35e88b32d3defc8eba630b3ac451522997f563956a52"
+dependencies = [
+ "derive_more",
+ "n0-error",
+ "n0-future",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8602,6 +9242,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "netdev"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57bacaf873ee4eab5646f99b381b271ec75e716902a67cf962c0f328c5eb5bfb"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "dlopen2",
+ "ipnet",
+ "libc",
+ "mac-addr",
+ "netlink-packet-core 0.8.1",
+ "netlink-packet-route 0.29.0",
+ "netlink-sys",
+ "objc2-core-foundation",
+ "objc2-core-wlan",
+ "objc2-foundation",
+ "objc2-system-configuration",
+ "once_cell",
+ "plist",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
 name = "netlink-packet-core"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8610,6 +9280,15 @@ dependencies = [
  "anyhow",
  "byteorder",
  "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-core"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
+dependencies = [
+ "paste",
 ]
 
 [[package]]
@@ -8622,8 +9301,32 @@ dependencies = [
  "bitflags 1.3.2",
  "byteorder",
  "libc",
- "netlink-packet-core",
+ "netlink-packet-core 0.7.0",
  "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9854ea6ad14e3f4698a7f03b65bce0833dd2d81d594a0e4a984170537146b6"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "log",
+ "netlink-packet-core 0.8.1",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "log",
+ "netlink-packet-core 0.8.1",
 ]
 
 [[package]]
@@ -8647,22 +9350,72 @@ dependencies = [
  "bytes",
  "futures",
  "log",
- "netlink-packet-core",
+ "netlink-packet-core 0.7.0",
+ "netlink-sys",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "netlink-proto"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "netlink-packet-core 0.8.1",
  "netlink-sys",
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "netlink-sys"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16c903aa70590cb93691bf97a767c8d1d6122d2cc9070433deb3bbf36ce8bd23"
+checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
 dependencies = [
  "bytes",
- "futures",
+ "futures-util",
  "libc",
  "log",
  "tokio",
+]
+
+[[package]]
+name = "netwatch"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5bfbba77b994ce69f1d40fc66fd8abbd23df62ce4aea61fbb34d638106a2549"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "cfg_aliases",
+ "derive_more",
+ "js-sys",
+ "libc",
+ "n0-error",
+ "n0-future",
+ "n0-watcher",
+ "netdev",
+ "netlink-packet-core 0.8.1",
+ "netlink-packet-route 0.30.0",
+ "netlink-proto 0.12.0",
+ "netlink-sys",
+ "noq-udp",
+ "objc2-core-foundation",
+ "objc2-system-configuration",
+ "pin-project-lite",
+ "serde",
+ "socket2 0.6.0",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "web-sys",
+ "windows 0.62.2",
+ "windows-result 0.4.1",
+ "wmi",
 ]
 
 [[package]]
@@ -8771,6 +9524,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "noq"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22739e0831e40f5ab7d6ac5317ed80bfe5fb3f44be57d23fa2eea8bff83fb303"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "derive_more",
+ "noq-proto",
+ "noq-udp",
+ "pin-project-lite",
+ "rustc-hash",
+ "rustls 0.23.40",
+ "socket2 0.6.0",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "noq-proto"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cee32450cf726b223ac4154003c93cb52fbde159ab1240990e88945bf3ae35e"
+dependencies = [
+ "aes-gcm",
+ "bytes",
+ "derive_more",
+ "enum-assoc",
+ "getrandom 0.4.2",
+ "identity-hash",
+ "lru-slab",
+ "rand 0.10.1",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "slab",
+ "sorted-index-buffer",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "noq-udp"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78633d1fe1bde91d12bcabb230ac9edb890857414c6d44f3212e0d309525b5ff"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "socket2 0.6.0",
+ "tracing",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
 name = "notify"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8876,9 +9691,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -8929,6 +9744,28 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -9187,7 +10024,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.0",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
 ]
 
@@ -9205,6 +10044,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-wlan"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e34919aba0d701380d911702455038a8a3587467fe0141d6a71501e7ffe48"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-security",
+ "objc2-security-foundation",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9217,6 +10070,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
+ "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -9230,6 +10085,41 @@ dependencies = [
  "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-security-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef76382e9cedd18123099f17638715cc3d81dba3637d4c0d39ab69df2ef345a5"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "bitflags 2.11.0",
+ "dispatch2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-security",
 ]
 
 [[package]]
@@ -9569,7 +10459,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "ecdsa",
  "elliptic-curve",
  "primeorder",
@@ -9600,6 +10490,16 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "windows 0.58.0",
+]
+
+[[package]]
+name = "papaya"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "997ee03cd38c01469a7046643714f0ad28880bcb9e6679ff0666e24817ca19b7"
+dependencies = [
+ "equivalent",
+ "seize 0.5.1",
 ]
 
 [[package]]
@@ -9801,6 +10701,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9896,6 +10805,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.12.1",
  "serde",
+]
+
+[[package]]
+name = "pharos"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
+dependencies = [
+ "futures",
+ "rustc_version",
 ]
 
 [[package]]
@@ -10656,6 +11575,9 @@ name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "portable-atomic-util"
@@ -10664,6 +11586,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "postcard-derive",
+ "serde",
+]
+
+[[package]]
+name = "postcard-derive"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0232bd009a197ceec9cc881ba46f727fcd8060a2d8d6a9dde7a69030a6fe2bb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -10714,6 +11660,17 @@ checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
 ]
 
 [[package]]
@@ -11217,7 +12174,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.31",
+ "rustls 0.23.40",
  "socket2 0.6.0",
  "thiserror 2.0.17",
  "tokio",
@@ -11238,7 +12195,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls 0.23.31",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "slab",
@@ -11321,6 +12278,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20 0.10.0",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11372,6 +12340,15 @@ checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -11616,7 +12593,7 @@ dependencies = [
  "cfg-if 1.0.3",
  "libc",
  "rustix 1.1.2",
- "windows 0.62.0",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -11697,7 +12674,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots 0.25.4",
  "winreg",
@@ -11730,7 +12707,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.31",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "rustls-pki-types",
  "serde",
@@ -11747,9 +12724,46 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots 1.0.2",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tokio-util",
+ "tower 0.5.2",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
+ "web-sys",
 ]
 
 [[package]]
@@ -12021,10 +13035,10 @@ checksum = "7a552eb82d19f38c3beed3f786bd23aa434ceb9ac43ab44419ca6d67a7e186c0"
 dependencies = [
  "futures",
  "log",
- "netlink-packet-core",
- "netlink-packet-route",
+ "netlink-packet-core 0.7.0",
+ "netlink-packet-route 0.17.1",
  "netlink-packet-utils",
- "netlink-proto",
+ "netlink-proto 0.11.5",
  "netlink-sys",
  "nix 0.26.4",
  "thiserror 1.0.69",
@@ -12055,9 +13069,9 @@ dependencies = [
  "byteorder",
  "bytes",
  "cbc",
- "chacha20",
+ "chacha20 0.9.1",
  "ctr",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "delegate",
  "des",
  "digest 0.10.7",
@@ -12120,7 +13134,7 @@ dependencies = [
  "der 0.7.10",
  "digest 0.10.7",
  "ecdsa",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "elliptic-curve",
  "futures",
  "getrandom 0.2.16",
@@ -12320,16 +13334,16 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.31"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.6",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -12410,13 +13424,13 @@ checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
- "rustls 0.23.31",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.6",
+ "rustls-webpki 0.103.13",
  "security-framework 3.5.0",
  "security-framework-sys",
  "webpki-root-certs",
@@ -12441,9 +13455,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.6"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -12627,7 +13641,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "der 0.7.10",
  "generic-array",
  "pkcs8 0.10.2",
@@ -12706,10 +13720,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "689224d06523904ebcc9b482c6a3f4f7fb396096645c4cd10c0d2ff7371a34d3"
 
 [[package]]
+name = "seize"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "sendfd"
@@ -12787,6 +13817,16 @@ dependencies = [
  "js-sys",
  "serde",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -12899,6 +13939,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
+ "serde",
+]
+
+[[package]]
+name = "sfv"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d471eaefb14f4b30032525bdb124b36e55ba9cb1292080e06f1a236cd10fe87"
+dependencies = [
+ "base64 0.22.1",
+ "indexmap 2.12.1",
+ "ref-cast",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12938,6 +13999,17 @@ dependencies = [
  "cpufeatures 0.2.17",
  "digest 0.10.7",
  "sha2-asm",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if 1.0.3",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -13055,10 +14127,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple-dns"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a75cbde1bf934313596a004973e462f9a82caa814dcf1a5f507bdf51597eeb4"
+dependencies = [
+ "bitflags 2.11.0",
+]
 
 [[package]]
 name = "simple_asn1"
@@ -13219,7 +14310,7 @@ dependencies = [
  "aes-gcm",
  "blake2",
  "chacha20poly1305",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "ring",
  "rustc_version",
@@ -13258,6 +14349,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "sorted-index-buffer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea06cc588e43c632923a55450401b8f25e628131571d4e1baea1bdfdb2b5ed06"
+
+[[package]]
+name = "spez"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87e960f4dca2788eeb86bbdde8dd246be8948790b7618d656e68f9b720a86e8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13268,6 +14376,12 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spki"
@@ -13363,7 +14477,7 @@ dependencies = [
  "aes",
  "aes-gcm",
  "cbc",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "ctr",
  "poly1305",
@@ -13379,7 +14493,7 @@ checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
 dependencies = [
  "base64ct",
  "bytes",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
  "sha2 0.10.9",
 ]
 
@@ -13390,7 +14504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3"
 dependencies = [
  "bcrypt-pbkdf",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "num-bigint-dig",
  "p256",
  "p384",
@@ -13474,6 +14588,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13491,6 +14614,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -13662,6 +14797,17 @@ name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys 0.6.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.9.4",
@@ -13905,31 +15051,33 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.43"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
+ "js-sys",
  "libc",
  "num-conv",
  "num_threads",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -14100,7 +15248,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.31",
+ "rustls 0.23.40",
  "tokio",
 ]
 
@@ -14169,6 +15317,29 @@ dependencies = [
  "libc",
  "tokio",
  "vsock",
+]
+
+[[package]]
+name = "tokio-websockets"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad543404f98bfc969aeb71994105c592acfc6c43323fddcd016bb208d1c65cb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "getrandom 0.4.2",
+ "http 1.3.1",
+ "httparse",
+ "rand 0.10.1",
+ "ring",
+ "rustls-pki-types",
+ "sha1_smol",
+ "simdutf8",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tokio-util",
 ]
 
 [[package]]
@@ -14424,9 +15595,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -14448,9 +15619,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14459,9 +15630,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -14785,7 +15956,7 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
- "rustls 0.23.31",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -14901,6 +16072,43 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vergen"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-gitcl"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ff3b5300a085d6bcd8fc96a507f706a28ae3814693236c9b409db71a1d15b9"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+ "time",
+ "vergen",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+]
 
 [[package]]
 name = "version-compare"
@@ -15309,6 +16517,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-timer"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15346,6 +16567,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-async"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5414b65d9a5094649bb99987bb74db71febfdfa3677b7954a0a05c99d0424e8"
+dependencies = [
+ "tokio",
+ "tracing",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15363,6 +16595,47 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-transport-iroh"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4ebffba98c30a0ac3560c4d7c595e61a5ad040049d65ff5c91304e5ee5f5ee"
+dependencies = [
+ "bytes",
+ "http 1.3.1",
+ "iroh",
+ "n0-error",
+ "n0-future",
+ "tokio",
+ "tracing",
+ "url",
+ "web-transport-proto",
+ "web-transport-trait",
+]
+
+[[package]]
+name = "web-transport-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0225d295c8ac00a2e9a498aefeaf3f3c6186da12a251c938189b15b82ea22808"
+dependencies = [
+ "bytes",
+ "http 1.3.1",
+ "sfv",
+ "thiserror 2.0.17",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "web-transport-trait"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc5f83d19cf6c8ba147f4e1e5935a8a115c91f6abbf714d740a83b967d558e6e"
+dependencies = [
+ "bytes",
 ]
 
 [[package]]
@@ -15386,14 +16659,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.2",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.2"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -15508,24 +16781,23 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.62.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9579d0e6970fd5250aa29aba5994052385ff55cf7b28a059e484bb79ea842e42"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.62.0",
+ "windows-core 0.62.2",
  "windows-future",
- "windows-link 0.2.0",
  "windows-numerics",
 ]
 
 [[package]]
 name = "windows-collections"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90dd7a7b86859ec4cdf864658b311545ef19dbcf17a672b52ab7cefe80c336f"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -15565,25 +16837,25 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.62.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.0",
- "windows-interface 0.59.1",
- "windows-link 0.2.0",
- "windows-result 0.4.0",
- "windows-strings 0.5.0",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
 name = "windows-future"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2194dee901458cb79e1148a4e9aac2b164cc95fa431891e7b296ff0b2f1d8a6"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.0",
- "windows-link 0.2.0",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
  "windows-threading",
 ]
 
@@ -15611,9 +16883,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -15644,9 +16916,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -15661,18 +16933,18 @@ checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce3498fe0aba81e62e477408383196b4b0363db5e0c27646f932676283b43d8"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.0",
- "windows-link 0.2.0",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -15715,11 +16987,11 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -15743,11 +17015,11 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -15801,7 +17073,7 @@ version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -15869,11 +17141,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab47f085ad6932defa48855254c758cdd0e2f2d48e62a34118a268d8f345e118"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -16185,10 +17457,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "wmi"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c81b85c57a57500e56669586496bf2abd5cf082b9d32995251185d105208b64"
+dependencies = [
+ "chrono",
+ "futures",
+ "log",
+ "serde",
+ "thiserror 2.0.17",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "ws_stream_wasm"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c173014acad22e83f16403ee360115b38846fe754e735c5d9d3803fe70c6abc"
+dependencies = [
+ "async_io_stream",
+ "futures",
+ "js-sys",
+ "log",
+ "pharos",
+ "rustc_version",
+ "send_wrapper",
+ "thiserror 2.0.17",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "wyz"
@@ -16222,7 +17528,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "serde",
  "zeroize",
@@ -16618,9 +17924,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,14 @@ h3-quinn = { version = "0.0.10", features = ["datagram"] }
 h3-webtransport = "0.1.2"
 http = "1"
 
+# Iroh + Media-over-QUIC (Epic #131 — Phase 1 substrate)
+# iroh re-exported via web-transport-iroh — match its major to avoid duplicate copies.
+# Note: web-transport-iroh 0.5.x pins iroh =1.0.0-rc.0 exactly; co-bump these together.
+iroh = { version = "=1.0.0-rc.0", default-features = false, features = ["tls-ring"] }
+moq-net = "0.1"
+web-transport-iroh = { version = "0.5.1", default-features = false, features = ["ring"] }
+web-transport-trait = "0.3"
+
 # Data processing
 polars = "0.45.1"
 sqlparser = "0.39.0"

--- a/crates/hyprstream-compositor/src/lib.rs
+++ b/crates/hyprstream-compositor/src/lib.rs
@@ -411,12 +411,12 @@ impl Compositor {
                                 return vec![CompositorOutput::Redraw];
                             }
                         }
-                        ShellMode::WorkerManager { ref mut sandbox_sel, show_containers: false, .. } => {
-                            if idx < self.chrome.worker_list.len() {
-                                *sandbox_sel = idx;
-                                let out = self.chrome.handle_key(waxterm::input::KeyPress::Enter);
-                                return self.dispatch_chrome(out);
-                            }
+                        ShellMode::WorkerManager { ref mut sandbox_sel, show_containers: false, .. }
+                            if idx < self.chrome.worker_list.len() =>
+                        {
+                            *sandbox_sel = idx;
+                            let out = self.chrome.handle_key(waxterm::input::KeyPress::Enter);
+                            return self.dispatch_chrome(out);
                         }
                         _ => {}
                     }

--- a/crates/hyprstream-rpc/Cargo.toml
+++ b/crates/hyprstream-rpc/Cargo.toml
@@ -84,6 +84,12 @@ h3-quinn = { workspace = true }
 h3-webtransport = { workspace = true }
 http = { workspace = true }
 
+# Iroh + MoQ (Epic #131 — Phase 1 substrate). See transport::iroh_substrate.
+iroh = { workspace = true }
+moq-net = { workspace = true }
+web-transport-iroh = { workspace = true }
+web-transport-trait = { workspace = true }
+
 # Async runtime
 tokio = { workspace = true, features = ["io-util", "net"] }
 tokio-util = { workspace = true }

--- a/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
@@ -1,64 +1,89 @@
 //! Iroh RPC plane — server-side protocol handler for ALPN `hyprstream-rpc/1`.
 //!
-//! Part of Epic #131 Phase 2 (#133). This module ships the wire layer:
+//! Part of Epic #131 Phase 2 (#133). This module ships:
 //!
-//! - A length-prefixed framing over an iroh bidi stream (`accept_bi`/`open_bi`).
-//! - An [`IrohRpcProtocolHandler`] that plugs into [`crate::transport::iroh_substrate`]
-//!   under the `hyprstream-rpc/1` ALPN.
-//! - An [`IrohRequestProcessor`] trait that callers implement to wire actual
+//! - [`IrohRpcProtocolHandler`] — iroh [`ProtocolHandler`] that plugs into
+//!   [`crate::transport::iroh_substrate`] under the `hyprstream-rpc/1` ALPN.
+//!   Enforces a per-connection cap on concurrent streams (DoS bound) and
+//!   drains in-flight requests on `ProtocolHandler::shutdown`.
+//! - [`IrohRequestProcessor`] — trait callers implement to wire actual
 //!   request processing (envelope verification + service dispatch).
+//! - [`LocalServiceBridge`] — adapts a [`crate::service::ZmqService`]
+//!   (potentially `!Send`) to the Send-bounded [`IrohRequestProcessor`].
 //!
-//! **Trust model**: The protocol handler does not verify `SignedEnvelope`
-//! itself — it forwards the raw bytes to the [`IrohRequestProcessor`], which
-//! is where envelope verification, JWT/DPoP checks, and `authorize_signer`
-//! enforcement happen. This matches the ZMTP path's separation of concerns
-//! (`transport::zmtp_quic::process_request`) and keeps the wire dumb.
+//! **Trust model**: The protocol handler does not parse `SignedEnvelope` —
+//! it forwards opaque bytes to the [`IrohRequestProcessor`]. Envelope
+//! verification, JWT/DPoP, and `authorize_signer` enforcement happen inside
+//! the processor (which is `LocalServiceBridge` in production, delegating
+//! to [`crate::transport::zmtp_quic::process_request`]). The handler does
+//! hold a signing key, but uses it only to produce signed error envelopes
+//! when the processor itself returns `Err` (a wire-level failure), so the
+//! client always sees a parseable `ResponseEnvelope` rather than an opaque
+//! EOF + Cap'n Proto parse error.
 //!
-//! **Wire framing**: each message is a 4-byte big-endian length followed by
-//! that many opaque bytes (Cap'n Proto-encoded `SignedEnvelope`). The bidi
-//! stream is request-response: one request frame, one response frame, then
-//! both sides close. No multipart, no ZMTP framing — both endpoints are our
-//! code; iroh's QUIC TLS handles peer authentication at the transport layer.
-//!
-//! **Service integration** lands in a follow-up: the canary `PolicyClient`
-//! port (the rest of #133) wraps the existing `ZmqService` trait — including
-//! the `Rc<S>`/`!Send` constraint for services like inference — behind an
-//! `IrohRequestProcessor` adapter that bridges to a per-service LocalSet.
+//! **Wire framing**: each request is the opaque bytes of a Cap'n Proto-encoded
+//! [`crate::envelope::SignedEnvelope`] written to a freshly-opened iroh bidi
+//! stream. The response is symmetric. Both endpoints are our code; iroh's
+//! QUIC TLS already authenticates the connection peer's Ed25519 NodeId at
+//! the transport layer.
 
 use std::future::Future;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use bytes::Bytes;
+use ed25519_dalek::SigningKey;
 use iroh::endpoint::Connection;
 use iroh::protocol::{AcceptError, ProtocolHandler};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio_util::sync::CancellationToken;
 
-/// Hard cap on inbound message size, to avoid unbounded memory growth from
-/// a misbehaving peer. Matches the ZMTP-over-QUIC server-side cap used in
-/// [`crate::transport::zmtp_quic`].
-const MAX_REQUEST_BYTES: usize = 64 * 1024 * 1024; // 64 MiB
+/// Hard cap on per-frame size (request or response). Mirrors the WebTransport
+/// server-side cap used in [`crate::transport::zmtp_quic`].
+pub const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024; // 64 MiB
+
+/// Default per-connection concurrent-stream cap. Caps memory usage from a
+/// hostile peer to `MAX_FRAME_BYTES × DEFAULT_STREAM_LIMIT` per connection
+/// (4 GiB at defaults). Configurable via [`IrohRpcProtocolHandlerBuilder`].
+pub const DEFAULT_STREAM_LIMIT: usize = 64;
+
+/// Grace period for `SendStream::stopped()` after writing the response — if
+/// the peer crashes without acking the FIN, we don't leak a task forever.
+const STOPPED_GRACE: Duration = Duration::from_secs(5);
+
+// ============================================================================
+// IrohRequestProcessor — pluggable request handling trait
+// ============================================================================
 
 /// Trait implemented by callers to wire actual request processing.
 ///
 /// The processor receives the raw request bytes (a Cap'n Proto-encoded
-/// `SignedEnvelope`) and returns the raw response bytes. Verification,
-/// authorization, and service dispatch all happen inside the implementation.
+/// `SignedEnvelope`) and returns the raw response bytes.
+///
+/// **Contract for `process`**:
+/// - **`Ok(bytes)`** — `bytes` MUST be a valid Cap'n Proto-encoded
+///   `ResponseEnvelope` and is written verbatim to the bidi stream.
+///   Application-layer errors (verification failure, handler error, etc.)
+///   MUST be returned this way as signed error envelopes — the handler
+///   forwards them unchanged.
+/// - **`Err(_)`** — wire-level fatal: the processor cannot produce *any*
+///   response (channel closed during shutdown, etc.). The handler responds
+///   with its own signed error envelope (`request_id = 0`) so the client
+///   sees a parseable error rather than a Cap'n Proto parse failure.
 ///
 /// Implementations MUST be `Send + Sync + 'static` because iroh's accept
 /// loop runs on a multi-threaded tokio runtime. For services that are
-/// `!Send` (e.g. those holding `tch-rs` tensors), implement this trait by
-/// forwarding to a dedicated `LocalSet` via an `mpsc` channel — same
-/// pattern used today for the inference service.
+/// `!Send` (e.g. those holding `tch-rs` tensors), use [`LocalServiceBridge`].
 pub trait IrohRequestProcessor: Send + Sync + 'static {
-    /// Process one request and return the response bytes.
     fn process(
         &self,
         request: Bytes,
     ) -> std::pin::Pin<Box<dyn Future<Output = Result<Bytes>> + Send + '_>>;
 }
 
-/// Convenience: implement [`IrohRequestProcessor`] from a `Send + Sync`
-/// async closure. Useful for tests and simple processors.
+/// Convenience: build an [`IrohRequestProcessor`] from a `Send + Sync`
+/// async closure. Useful for tests.
 pub fn from_fn<F, Fut>(f: F) -> impl IrohRequestProcessor
 where
     F: Fn(Bytes) -> Fut + Send + Sync + 'static,
@@ -80,98 +105,343 @@ where
     FnProcessor(f)
 }
 
+// ============================================================================
+// IrohRpcProtocolHandler — iroh ProtocolHandler with concurrency cap + drain
+// ============================================================================
+
 /// Iroh protocol handler that terminates `hyprstream-rpc/1` bidi streams,
-/// applies length-prefixed framing, and dispatches each request through
-/// the wrapped [`IrohRequestProcessor`].
+/// dispatches each request through the wrapped [`IrohRequestProcessor`],
+/// caps concurrent streams per connection, and drains in-flight requests
+/// on `ProtocolHandler::shutdown` (called by `Router::shutdown`).
 #[derive(Clone)]
 pub struct IrohRpcProtocolHandler {
+    inner: Arc<HandlerInner>,
+}
+
+struct HandlerInner {
     processor: Arc<dyn IrohRequestProcessor>,
+    /// Used to produce signed error envelopes when the processor itself
+    /// returns `Err` (wire-level fatal). Application errors come back from
+    /// the processor pre-wrapped as signed `ResponseEnvelope` bytes.
+    signing_key: SigningKey,
+    /// Caps concurrent bidi streams in flight. Hold one permit per stream.
+    stream_limit: Arc<Semaphore>,
+    stream_limit_capacity: u32,
+    /// Level-triggered shutdown signal: once `cancel()` is called, every
+    /// future and current `cancelled().await` resolves immediately. Used
+    /// instead of `tokio::sync::Notify` because `Notify::notify_waiters`
+    /// is edge-triggered and a shutdown signal landing between accept-loop
+    /// iterations would be lost.
+    shutdown: CancellationToken,
 }
 
 impl std::fmt::Debug for IrohRpcProtocolHandler {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("IrohRpcProtocolHandler").finish_non_exhaustive()
+        f.debug_struct("IrohRpcProtocolHandler")
+            .field("stream_limit", &self.inner.stream_limit_capacity)
+            .finish_non_exhaustive()
     }
 }
 
 impl IrohRpcProtocolHandler {
-    pub fn new<P: IrohRequestProcessor>(processor: P) -> Self {
-        Self {
-            processor: Arc::new(processor),
-        }
+    /// Build a handler with default per-connection stream limit
+    /// ([`DEFAULT_STREAM_LIMIT`]).
+    pub fn new<P: IrohRequestProcessor>(processor: P, signing_key: SigningKey) -> Self {
+        Self::with_stream_limit(Arc::new(processor), signing_key, DEFAULT_STREAM_LIMIT)
     }
 
-    pub fn from_arc(processor: Arc<dyn IrohRequestProcessor>) -> Self {
-        Self { processor }
+    /// Build a handler with an explicit per-connection stream limit.
+    pub fn with_stream_limit(
+        processor: Arc<dyn IrohRequestProcessor>,
+        signing_key: SigningKey,
+        stream_limit: usize,
+    ) -> Self {
+        let stream_limit_capacity = u32::try_from(stream_limit).unwrap_or(u32::MAX);
+        Self {
+            inner: Arc::new(HandlerInner {
+                processor,
+                signing_key,
+                stream_limit: Arc::new(Semaphore::new(stream_limit)),
+                stream_limit_capacity,
+                shutdown: CancellationToken::new(),
+            }),
+        }
     }
 }
 
 impl ProtocolHandler for IrohRpcProtocolHandler {
     async fn accept(&self, conn: Connection) -> Result<(), AcceptError> {
-        // Accept bidi streams on this connection until the peer goes away.
-        // Each stream is one request-response pair, processed concurrently.
         loop {
-            let (mut send, mut recv) = match conn.accept_bi().await {
-                Ok(streams) => streams,
-                Err(e) => {
-                    tracing::debug!(error = ?e, "iroh-rpc: connection closed");
+            tokio::select! {
+                biased;
+                _ = self.inner.shutdown.cancelled() => {
+                    tracing::debug!("iroh-rpc: accept loop cancelled");
                     return Ok(());
                 }
-            };
+                streams = conn.accept_bi() => {
+                    let (send, recv) = match streams {
+                        Ok(pair) => pair,
+                        Err(e) => {
+                            tracing::debug!(error = ?e, "iroh-rpc: connection closed");
+                            return Ok(());
+                        }
+                    };
 
-            let processor = Arc::clone(&self.processor);
-            tokio::spawn(async move {
-                // Read full request (length-prefixed).
-                let request = match recv.read_to_end(MAX_REQUEST_BYTES).await {
-                    Ok(buf) => Bytes::from(buf),
-                    Err(e) => {
-                        tracing::warn!(error = ?e, "iroh-rpc: failed reading request");
-                        return;
-                    }
-                };
+                    // Acquire a permit to cap concurrent streams. If the
+                    // semaphore is closed (shutdown), exit cleanly.
+                    let permit = match Arc::clone(&self.inner.stream_limit).acquire_owned().await {
+                        Ok(p) => p,
+                        Err(_) => return Ok(()),
+                    };
 
-                // Process.
-                let response = match processor.process(request).await {
-                    Ok(bytes) => bytes,
-                    Err(e) => {
-                        tracing::warn!(error = ?e, "iroh-rpc: processor returned error");
-                        // Close the send side without a body; client will see EOF.
-                        let _ = send.finish();
-                        return;
-                    }
-                };
-
-                // Write response.
-                if let Err(e) = send.write_all(&response).await {
-                    tracing::warn!(error = ?e, "iroh-rpc: failed writing response");
-                    return;
+                    let inner = Arc::clone(&self.inner);
+                    tokio::spawn(handle_stream(send, recv, inner, permit));
                 }
-                if let Err(e) = send.finish() {
-                    tracing::warn!(error = ?e, "iroh-rpc: failed finishing send");
-                }
-                // Optional: wait for peer to read.
-                let _ = send.stopped().await;
-            });
+            }
         }
     }
+
+    async fn shutdown(&self) {
+        // Stop the accept loop from taking new streams. Level-triggered:
+        // even if cancel() lands between iterations, the next time the
+        // loop hits `cancelled().await` it returns immediately.
+        self.inner.shutdown.cancel();
+        // Wait for all in-flight streams to release their permits.
+        // `acquire_many` succeeds only once every permit is returned.
+        let cap = self.inner.stream_limit_capacity;
+        match self.inner.stream_limit.acquire_many(cap).await {
+            Ok(permits) => {
+                // Keep permits drained so any post-shutdown accept also
+                // sees a closed semaphore.
+                permits.forget();
+                self.inner.stream_limit.close();
+            }
+            Err(_) => {
+                // Already closed; nothing to drain.
+            }
+        }
+    }
+}
+
+/// Handle one bidi stream end-to-end: read request, dispatch to processor,
+/// write response (or signed error envelope on processor failure).
+async fn handle_stream(
+    mut send: iroh::endpoint::SendStream,
+    mut recv: iroh::endpoint::RecvStream,
+    inner: Arc<HandlerInner>,
+    permit: OwnedSemaphorePermit,
+) {
+    // Permit is released when this function returns.
+    let _permit = permit;
+
+    let request = match recv.read_to_end(MAX_FRAME_BYTES).await {
+        Ok(buf) => Bytes::from(buf),
+        Err(e) => {
+            tracing::warn!(error = ?e, "iroh-rpc: failed reading request");
+            return;
+        }
+    };
+
+    let response = match inner.processor.process(request).await {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            tracing::warn!(error = ?e, "iroh-rpc: processor error, sending stub error envelope");
+            build_error_envelope(&inner.signing_key, &format!("processor error: {e}"))
+        }
+    };
+
+    if let Err(e) = send.write_all(&response).await {
+        tracing::warn!(error = ?e, "iroh-rpc: failed writing response");
+        return;
+    }
+    if let Err(e) = send.finish() {
+        tracing::warn!(error = ?e, "iroh-rpc: failed finishing send");
+        return;
+    }
+    // Wait for the peer to ack the FIN, but cap it so a dead peer can't
+    // leak this task forever.
+    let _ = tokio::time::timeout(STOPPED_GRACE, send.stopped()).await;
+}
+
+/// Build a signed `ResponseEnvelope` (request_id = 0) carrying `message` as
+/// the payload. Used when the processor itself fails — guarantees the client
+/// sees a parseable envelope rather than EOF.
+fn build_error_envelope(signing_key: &SigningKey, message: &str) -> Bytes {
+    use crate::ToCapnp;
+    use capnp::{message::Builder, serialize};
+    let envelope =
+        crate::envelope::ResponseEnvelope::new_signed(0, message.as_bytes().to_vec(), signing_key);
+    let mut msg = Builder::new_default();
+    {
+        let mut builder = msg.init_root::<crate::common_capnp::response_envelope::Builder>();
+        envelope.write_to(&mut builder);
+    }
+    let mut bytes = Vec::new();
+    if let Err(e) = serialize::write_message(&mut bytes, &msg) {
+        // Last-ditch: if even this fails, return empty bytes — client will
+        // see Cap'n Proto parse error, which is no worse than the original
+        // behaviour. This should be unreachable in practice.
+        tracing::error!(error = ?e, "iroh-rpc: failed serializing error envelope");
+        return Bytes::new();
+    }
+    Bytes::from(bytes)
 }
 
 /// Client-side helper: open a bidi stream on `hyprstream-rpc/1` against an
 /// already-connected iroh [`Connection`], write the request, read the response.
 ///
-/// This is a primitive — the real per-service RPC clients (generated by
-/// `hyprstream_rpc_derive::generate_rpc_service!`) will wrap it with their
-/// own envelope construction and response decoding. Used directly only in
-/// tests during Phase 2.
+/// Primitive used by tests and internally by
+/// [`super::iroh_transport::IrohTransport`] — production callers should
+/// construct an `IrohTransport` + [`crate::rpc_client::RpcClientImpl`] instead.
 pub async fn client_request(conn: &Connection, request: &[u8]) -> Result<Bytes> {
     let (mut send, mut recv) = conn.open_bi().await.context("open_bi")?;
     send.write_all(request).await.context("write request")?;
     send.finish().context("finish send")?;
     let buf = recv
-        .read_to_end(MAX_REQUEST_BYTES)
+        .read_to_end(MAX_FRAME_BYTES)
         .await
         .context("read response")?;
     Ok(Bytes::from(buf))
+}
+
+// ============================================================================
+// LocalServiceBridge — adapt a (possibly `!Send`) ZmqService to the Send-bound
+// IrohRequestProcessor trait by running the service on a dedicated LocalSet
+// thread and forwarding requests over an mpsc channel.
+// ============================================================================
+
+/// Per-request payload + response slot exchanged with the bridge thread.
+struct BridgeMessage {
+    request: Bytes,
+    respond: tokio::sync::oneshot::Sender<Result<Bytes>>,
+}
+
+/// Adapt a [`crate::service::ZmqService`] to [`IrohRequestProcessor`].
+///
+/// Spins up a dedicated thread running a single-threaded tokio runtime with
+/// a `LocalSet`. The service runs on that thread (compatible with both `Send`
+/// and `!Send` services like inference); requests arriving on the iroh accept
+/// loop are forwarded via an `mpsc` channel and awaited via `oneshot`.
+///
+/// **Lifecycle**: in-flight requests are drained when the
+/// [`IrohRpcProtocolHandler`] holding this bridge is shut down via
+/// `Router::shutdown` (each in-flight handler task holds a semaphore permit;
+/// the handler's drain waits for all permits to return, which only happens
+/// once the bridge has produced each response). After that, dropping the
+/// last `Arc<LocalServiceBridge>` closes the mpsc Sender, the bridge thread
+/// exits its receive loop, and `LocalSet::block_on` returns.
+pub struct LocalServiceBridge {
+    tx: tokio::sync::mpsc::Sender<BridgeMessage>,
+}
+
+impl LocalServiceBridge {
+    /// Spawn a dedicated bridge thread that owns `service` and forwards
+    /// requests through [`crate::transport::zmtp_quic::process_request`].
+    ///
+    /// The response signing key is taken from `service.signing_key()` — there
+    /// is no separate parameter to avoid drift between the service's identity
+    /// and the key used to sign responses.
+    ///
+    /// `queue_depth` is the mpsc channel capacity — backpressure point when
+    /// the bridge falls behind. Pass `0` for default (128).
+    pub fn spawn<S>(
+        service: S,
+        nonce_cache: Arc<crate::envelope::InMemoryNonceCache>,
+        queue_depth: usize,
+    ) -> Result<Self>
+    where
+        S: crate::service::ZmqService + Send + 'static,
+    {
+        let cap = if queue_depth == 0 { 128 } else { queue_depth };
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<BridgeMessage>(cap);
+        let service_name = service.name().to_owned();
+
+        std::thread::Builder::new()
+            .name(format!("iroh-rpc-bridge:{service_name}"))
+            .spawn(move || {
+                let rt = match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(rt) => rt,
+                    Err(e) => {
+                        tracing::error!(error = ?e, "bridge: failed to build runtime");
+                        return;
+                    }
+                };
+                let local = tokio::task::LocalSet::new();
+                local.spawn_local(async move {
+                    let service = std::rc::Rc::new(service);
+                    while let Some(msg) = rx.recv().await {
+                        let service = std::rc::Rc::clone(&service);
+                        let nonce_cache = Arc::clone(&nonce_cache);
+                        // Each request gets its own local task so a slow
+                        // handler doesn't head-of-line the queue.
+                        tokio::task::spawn_local(async move {
+                            // Re-derive the signing key per call: cheap clone,
+                            // tracks any future rotation in the service.
+                            let signing_key = service.signing_key();
+                            let result = crate::transport::zmtp_quic::process_request(
+                                msg.request.as_ref(),
+                                &*service,
+                                crate::envelope::EnvelopeVerification::AnySigner,
+                                &signing_key,
+                                &nonce_cache,
+                            )
+                            .await
+                            .and_then(|(bytes, cont)| {
+                                // Streaming continuations are not wired on
+                                // the iroh RPC plane — streaming moves to
+                                // moq-net (`moql` ALPN, Phase 3, #134). In
+                                // debug, panic loudly; in release, return an
+                                // error so the wire emits a signed error
+                                // envelope (handler's build_error_envelope)
+                                // rather than silently dropping the stream.
+                                if cont.is_some() {
+                                    debug_assert!(
+                                        false,
+                                        "iroh-rpc bridge: streaming continuation not supported \
+                                         — wait for Phase 3 (#134)"
+                                    );
+                                    return Err(anyhow::anyhow!(
+                                        "iroh-rpc bridge: service returned a streaming \
+                                         continuation, which is not supported on the iroh \
+                                         RPC plane (Phase 3 / #134 moves streaming to moq-net)"
+                                    ));
+                                }
+                                Ok(Bytes::from(bytes))
+                            });
+                            let _ = msg.respond.send(result);
+                        });
+                    }
+                });
+                rt.block_on(local);
+            })
+            .map_err(|e| anyhow::anyhow!("spawn iroh-rpc bridge thread: {e}"))?;
+
+        Ok(Self { tx })
+    }
+}
+
+impl IrohRequestProcessor for LocalServiceBridge {
+    fn process(
+        &self,
+        request: Bytes,
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<Bytes>> + Send + '_>> {
+        let tx = self.tx.clone();
+        Box::pin(async move {
+            let (respond_tx, respond_rx) = tokio::sync::oneshot::channel();
+            tx.send(BridgeMessage {
+                request,
+                respond: respond_tx,
+            })
+            .await
+            .map_err(|_| anyhow::anyhow!("iroh-rpc bridge: channel closed"))?;
+            respond_rx
+                .await
+                .map_err(|_| anyhow::anyhow!("iroh-rpc bridge: response dropped"))?
+        })
+    }
 }
 
 #[cfg(test)]
@@ -189,6 +459,10 @@ mod tests {
         k
     }
 
+    fn fresh_signing_key() -> SigningKey {
+        SigningKey::from_bytes(&fresh_key())
+    }
+
     fn direct_addr(substrate: &IrohSubstrate) -> EndpointAddr {
         EndpointAddr::from_parts(
             substrate.endpoint_id(),
@@ -200,9 +474,6 @@ mod tests {
         )
     }
 
-    /// End-to-end: server runs an `IrohRpcProtocolHandler` wired to a
-    /// closure-based processor that prepends a magic byte to the request,
-    /// client sends one request and reads the response.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn rpc_request_response_round_trip() -> Result<()> {
         let processor = from_fn(|req: Bytes| async move {
@@ -211,14 +482,10 @@ mod tests {
             out.extend_from_slice(&req);
             Ok(Bytes::from(out))
         });
-        let rpc_handler = IrohRpcProtocolHandler::new(processor);
+        let rpc_handler = IrohRpcProtocolHandler::new(processor, fresh_signing_key());
 
-        let server = IrohSubstrate::new(
-            fresh_key(),
-            NoopHandler::new("moq-not-wired"),
-            rpc_handler,
-        )
-        .await?;
+        let server =
+            IrohSubstrate::new(fresh_key(), NoopHandler::new("moq-not-wired"), rpc_handler).await?;
         let server_addr = direct_addr(&server);
 
         let client = IrohSubstrate::new(
@@ -228,13 +495,10 @@ mod tests {
         )
         .await?;
 
-        let conn = client
-            .connect(server_addr, ALPN_HYPRSTREAM_RPC)
-            .await?;
+        let conn = client.connect(server_addr, ALPN_HYPRSTREAM_RPC).await?;
         let resp = client_request(&conn, b"ping").await?;
         assert_eq!(&resp[..], b"\xABping");
 
-        // Sanity: moq ALPN still routes to the noop handler (does not crash).
         let conn2 = client.connect(direct_addr(&server), ALPN_MOQ_LITE).await?;
         drop(conn2);
 
@@ -243,12 +507,9 @@ mod tests {
         Ok(())
     }
 
-    /// Multiple concurrent requests on the same connection round-trip
-    /// independently and arrive at the correct caller.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn rpc_concurrent_requests() -> Result<()> {
         let processor = from_fn(|req: Bytes| async move {
-            // Echo with a trailing marker so we can verify correlation.
             let mut out = req.to_vec();
             out.push(b'!');
             Ok(Bytes::from(out))
@@ -256,7 +517,7 @@ mod tests {
         let server = IrohSubstrate::new(
             fresh_key(),
             NoopHandler::new("moq"),
-            IrohRpcProtocolHandler::new(processor),
+            IrohRpcProtocolHandler::new(processor, fresh_signing_key()),
         )
         .await?;
         let server_addr = direct_addr(&server);
@@ -267,11 +528,7 @@ mod tests {
             NoopHandler::new("c-rpc"),
         )
         .await?;
-        let conn = Arc::new(
-            client
-                .connect(server_addr, ALPN_HYPRSTREAM_RPC)
-                .await?,
-        );
+        let conn = Arc::new(client.connect(server_addr, ALPN_HYPRSTREAM_RPC).await?);
 
         let mut handles = Vec::new();
         for i in 0..8u8 {
@@ -288,6 +545,160 @@ mod tests {
 
         client.shutdown().await?;
         server.shutdown().await?;
+        Ok(())
+    }
+
+    /// Processor returns `Err` → client gets a parseable signed
+    /// `ResponseEnvelope` carrying the error message (request_id = 0), not
+    /// an opaque EOF / Cap'n Proto parse failure. (Fix for review finding #4.)
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rpc_processor_error_yields_parseable_envelope() -> Result<()> {
+        let server_signing = fresh_signing_key();
+        let server_vk = server_signing.verifying_key();
+
+        let processor =
+            from_fn(|_req: Bytes| async move { Err(anyhow::anyhow!("boom from processor")) });
+        let handler = IrohRpcProtocolHandler::new(processor, server_signing);
+
+        let server = IrohSubstrate::new(fresh_key(), NoopHandler::new("moq"), handler).await?;
+        let server_addr = direct_addr(&server);
+
+        let client = IrohSubstrate::new(
+            fresh_key(),
+            NoopHandler::new("c-moq"),
+            NoopHandler::new("c-rpc"),
+        )
+        .await?;
+        let conn = client.connect(server_addr, ALPN_HYPRSTREAM_RPC).await?;
+
+        // Send any bytes; the processor will Err regardless. The interesting
+        // assertion is what comes back: a verifiable ResponseEnvelope.
+        let resp_bytes = client_request(&conn, b"anything").await?;
+        let (request_id, payload) = crate::envelope::unwrap_response(&resp_bytes, Some(&server_vk))?;
+        assert_eq!(request_id, 0, "error envelope uses request_id=0");
+        let body = std::str::from_utf8(&payload)?;
+        assert!(body.contains("boom from processor"), "got: {body}");
+
+        client.shutdown().await?;
+        server.shutdown().await?;
+        Ok(())
+    }
+
+    /// Concurrency cap is enforced: with a stream_limit of 2, a third
+    /// concurrent slow request must wait for one of the first two to finish.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rpc_stream_limit_enforced() -> Result<()> {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let in_flight_c = Arc::clone(&in_flight);
+        let peak_c = Arc::clone(&peak);
+
+        let processor = from_fn(move |_req: Bytes| {
+            let in_flight = Arc::clone(&in_flight_c);
+            let peak = Arc::clone(&peak_c);
+            async move {
+                let cur = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                // Update peak.
+                let mut p = peak.load(Ordering::SeqCst);
+                while cur > p {
+                    match peak.compare_exchange_weak(p, cur, Ordering::SeqCst, Ordering::SeqCst) {
+                        Ok(_) => break,
+                        Err(prev) => p = prev,
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(200)).await;
+                in_flight.fetch_sub(1, Ordering::SeqCst);
+                Ok(Bytes::from_static(b"ok"))
+            }
+        });
+        let handler = IrohRpcProtocolHandler::with_stream_limit(
+            Arc::new(processor),
+            fresh_signing_key(),
+            2,
+        );
+
+        let server = IrohSubstrate::new(fresh_key(), NoopHandler::new("moq"), handler).await?;
+        let server_addr = direct_addr(&server);
+
+        let client = IrohSubstrate::new(
+            fresh_key(),
+            NoopHandler::new("c-moq"),
+            NoopHandler::new("c-rpc"),
+        )
+        .await?;
+        let conn = Arc::new(client.connect(server_addr, ALPN_HYPRSTREAM_RPC).await?);
+
+        let mut handles = Vec::new();
+        for _ in 0..6 {
+            let conn = Arc::clone(&conn);
+            handles.push(tokio::spawn(async move {
+                let _ = client_request(&conn, b"x").await?;
+                anyhow::Ok(())
+            }));
+        }
+        for h in handles {
+            h.await??;
+        }
+
+        assert!(
+            peak.load(Ordering::SeqCst) <= 2,
+            "stream_limit=2 violated, observed peak={}",
+            peak.load(Ordering::SeqCst)
+        );
+
+        client.shutdown().await?;
+        server.shutdown().await?;
+        Ok(())
+    }
+
+    /// `Router::shutdown` (via `IrohSubstrate::shutdown`) drains in-flight
+    /// requests before returning — a request in-progress when shutdown
+    /// starts still gets a clean response. (Fix for review round-1 #1.)
+    ///
+    /// Uses an explicit `Notify` to synchronise "processor has entered the
+    /// long sleep" with "now safe to shut down" — replaces the previous
+    /// 50ms `tokio::sleep` that was flaky on loaded CI runners.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rpc_shutdown_drains_in_flight() -> Result<()> {
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let entered_c = Arc::clone(&entered);
+        let processor = from_fn(move |_req: Bytes| {
+            let entered = Arc::clone(&entered_c);
+            async move {
+                entered.notify_one();
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                Ok(Bytes::from_static(b"drained-ok"))
+            }
+        });
+        let handler = IrohRpcProtocolHandler::new(processor, fresh_signing_key());
+
+        let server = IrohSubstrate::new(fresh_key(), NoopHandler::new("moq"), handler).await?;
+        let server_addr = direct_addr(&server);
+
+        let client = IrohSubstrate::new(
+            fresh_key(),
+            NoopHandler::new("c-moq"),
+            NoopHandler::new("c-rpc"),
+        )
+        .await?;
+        let conn = client.connect(server_addr, ALPN_HYPRSTREAM_RPC).await?;
+
+        let req_task = {
+            let conn = conn.clone();
+            tokio::spawn(async move { client_request(&conn, b"slow").await })
+        };
+
+        // Synchronise: wait until the processor signals it has entered the
+        // sleep, *then* shut down. No wall-clock guesses.
+        entered.notified().await;
+        server.shutdown().await?;
+
+        let resp = req_task.await??;
+        assert_eq!(&resp[..], b"drained-ok");
+
+        client.shutdown().await?;
         Ok(())
     }
 }

--- a/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
@@ -1,0 +1,293 @@
+//! Iroh RPC plane — server-side protocol handler for ALPN `hyprstream-rpc/1`.
+//!
+//! Part of Epic #131 Phase 2 (#133). This module ships the wire layer:
+//!
+//! - A length-prefixed framing over an iroh bidi stream (`accept_bi`/`open_bi`).
+//! - An [`IrohRpcProtocolHandler`] that plugs into [`crate::transport::iroh_substrate`]
+//!   under the `hyprstream-rpc/1` ALPN.
+//! - An [`IrohRequestProcessor`] trait that callers implement to wire actual
+//!   request processing (envelope verification + service dispatch).
+//!
+//! **Trust model**: The protocol handler does not verify `SignedEnvelope`
+//! itself — it forwards the raw bytes to the [`IrohRequestProcessor`], which
+//! is where envelope verification, JWT/DPoP checks, and `authorize_signer`
+//! enforcement happen. This matches the ZMTP path's separation of concerns
+//! (`transport::zmtp_quic::process_request`) and keeps the wire dumb.
+//!
+//! **Wire framing**: each message is a 4-byte big-endian length followed by
+//! that many opaque bytes (Cap'n Proto-encoded `SignedEnvelope`). The bidi
+//! stream is request-response: one request frame, one response frame, then
+//! both sides close. No multipart, no ZMTP framing — both endpoints are our
+//! code; iroh's QUIC TLS handles peer authentication at the transport layer.
+//!
+//! **Service integration** lands in a follow-up: the canary `PolicyClient`
+//! port (the rest of #133) wraps the existing `ZmqService` trait — including
+//! the `Rc<S>`/`!Send` constraint for services like inference — behind an
+//! `IrohRequestProcessor` adapter that bridges to a per-service LocalSet.
+
+use std::future::Future;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use bytes::Bytes;
+use iroh::endpoint::Connection;
+use iroh::protocol::{AcceptError, ProtocolHandler};
+
+/// Hard cap on inbound message size, to avoid unbounded memory growth from
+/// a misbehaving peer. Matches the ZMTP-over-QUIC server-side cap used in
+/// [`crate::transport::zmtp_quic`].
+const MAX_REQUEST_BYTES: usize = 64 * 1024 * 1024; // 64 MiB
+
+/// Trait implemented by callers to wire actual request processing.
+///
+/// The processor receives the raw request bytes (a Cap'n Proto-encoded
+/// `SignedEnvelope`) and returns the raw response bytes. Verification,
+/// authorization, and service dispatch all happen inside the implementation.
+///
+/// Implementations MUST be `Send + Sync + 'static` because iroh's accept
+/// loop runs on a multi-threaded tokio runtime. For services that are
+/// `!Send` (e.g. those holding `tch-rs` tensors), implement this trait by
+/// forwarding to a dedicated `LocalSet` via an `mpsc` channel — same
+/// pattern used today for the inference service.
+pub trait IrohRequestProcessor: Send + Sync + 'static {
+    /// Process one request and return the response bytes.
+    fn process(
+        &self,
+        request: Bytes,
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<Bytes>> + Send + '_>>;
+}
+
+/// Convenience: implement [`IrohRequestProcessor`] from a `Send + Sync`
+/// async closure. Useful for tests and simple processors.
+pub fn from_fn<F, Fut>(f: F) -> impl IrohRequestProcessor
+where
+    F: Fn(Bytes) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<Bytes>> + Send + 'static,
+{
+    struct FnProcessor<F>(F);
+    impl<F, Fut> IrohRequestProcessor for FnProcessor<F>
+    where
+        F: Fn(Bytes) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<Bytes>> + Send + 'static,
+    {
+        fn process(
+            &self,
+            request: Bytes,
+        ) -> std::pin::Pin<Box<dyn Future<Output = Result<Bytes>> + Send + '_>> {
+            Box::pin((self.0)(request))
+        }
+    }
+    FnProcessor(f)
+}
+
+/// Iroh protocol handler that terminates `hyprstream-rpc/1` bidi streams,
+/// applies length-prefixed framing, and dispatches each request through
+/// the wrapped [`IrohRequestProcessor`].
+#[derive(Clone)]
+pub struct IrohRpcProtocolHandler {
+    processor: Arc<dyn IrohRequestProcessor>,
+}
+
+impl std::fmt::Debug for IrohRpcProtocolHandler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IrohRpcProtocolHandler").finish_non_exhaustive()
+    }
+}
+
+impl IrohRpcProtocolHandler {
+    pub fn new<P: IrohRequestProcessor>(processor: P) -> Self {
+        Self {
+            processor: Arc::new(processor),
+        }
+    }
+
+    pub fn from_arc(processor: Arc<dyn IrohRequestProcessor>) -> Self {
+        Self { processor }
+    }
+}
+
+impl ProtocolHandler for IrohRpcProtocolHandler {
+    async fn accept(&self, conn: Connection) -> Result<(), AcceptError> {
+        // Accept bidi streams on this connection until the peer goes away.
+        // Each stream is one request-response pair, processed concurrently.
+        loop {
+            let (mut send, mut recv) = match conn.accept_bi().await {
+                Ok(streams) => streams,
+                Err(e) => {
+                    tracing::debug!(error = ?e, "iroh-rpc: connection closed");
+                    return Ok(());
+                }
+            };
+
+            let processor = Arc::clone(&self.processor);
+            tokio::spawn(async move {
+                // Read full request (length-prefixed).
+                let request = match recv.read_to_end(MAX_REQUEST_BYTES).await {
+                    Ok(buf) => Bytes::from(buf),
+                    Err(e) => {
+                        tracing::warn!(error = ?e, "iroh-rpc: failed reading request");
+                        return;
+                    }
+                };
+
+                // Process.
+                let response = match processor.process(request).await {
+                    Ok(bytes) => bytes,
+                    Err(e) => {
+                        tracing::warn!(error = ?e, "iroh-rpc: processor returned error");
+                        // Close the send side without a body; client will see EOF.
+                        let _ = send.finish();
+                        return;
+                    }
+                };
+
+                // Write response.
+                if let Err(e) = send.write_all(&response).await {
+                    tracing::warn!(error = ?e, "iroh-rpc: failed writing response");
+                    return;
+                }
+                if let Err(e) = send.finish() {
+                    tracing::warn!(error = ?e, "iroh-rpc: failed finishing send");
+                }
+                // Optional: wait for peer to read.
+                let _ = send.stopped().await;
+            });
+        }
+    }
+}
+
+/// Client-side helper: open a bidi stream on `hyprstream-rpc/1` against an
+/// already-connected iroh [`Connection`], write the request, read the response.
+///
+/// This is a primitive — the real per-service RPC clients (generated by
+/// `hyprstream_rpc_derive::generate_rpc_service!`) will wrap it with their
+/// own envelope construction and response decoding. Used directly only in
+/// tests during Phase 2.
+pub async fn client_request(conn: &Connection, request: &[u8]) -> Result<Bytes> {
+    let (mut send, mut recv) = conn.open_bi().await.context("open_bi")?;
+    send.write_all(request).await.context("write request")?;
+    send.finish().context("finish send")?;
+    let buf = recv
+        .read_to_end(MAX_REQUEST_BYTES)
+        .await
+        .context("read response")?;
+    Ok(Bytes::from(buf))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transport::iroh_substrate::{
+        ALPN_HYPRSTREAM_RPC, ALPN_MOQ_LITE, IrohSubstrate, NoopHandler,
+    };
+    use iroh::{EndpointAddr, TransportAddr};
+    use rand::RngCore;
+
+    fn fresh_key() -> [u8; 32] {
+        let mut k = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut k);
+        k
+    }
+
+    fn direct_addr(substrate: &IrohSubstrate) -> EndpointAddr {
+        EndpointAddr::from_parts(
+            substrate.endpoint_id(),
+            substrate
+                .endpoint()
+                .bound_sockets()
+                .into_iter()
+                .map(TransportAddr::Ip),
+        )
+    }
+
+    /// End-to-end: server runs an `IrohRpcProtocolHandler` wired to a
+    /// closure-based processor that prepends a magic byte to the request,
+    /// client sends one request and reads the response.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rpc_request_response_round_trip() -> Result<()> {
+        let processor = from_fn(|req: Bytes| async move {
+            let mut out = Vec::with_capacity(1 + req.len());
+            out.push(0xAB);
+            out.extend_from_slice(&req);
+            Ok(Bytes::from(out))
+        });
+        let rpc_handler = IrohRpcProtocolHandler::new(processor);
+
+        let server = IrohSubstrate::new(
+            fresh_key(),
+            NoopHandler::new("moq-not-wired"),
+            rpc_handler,
+        )
+        .await?;
+        let server_addr = direct_addr(&server);
+
+        let client = IrohSubstrate::new(
+            fresh_key(),
+            NoopHandler::new("client moq"),
+            NoopHandler::new("client rpc"),
+        )
+        .await?;
+
+        let conn = client
+            .connect(server_addr, ALPN_HYPRSTREAM_RPC)
+            .await?;
+        let resp = client_request(&conn, b"ping").await?;
+        assert_eq!(&resp[..], b"\xABping");
+
+        // Sanity: moq ALPN still routes to the noop handler (does not crash).
+        let conn2 = client.connect(direct_addr(&server), ALPN_MOQ_LITE).await?;
+        drop(conn2);
+
+        client.shutdown().await?;
+        server.shutdown().await?;
+        Ok(())
+    }
+
+    /// Multiple concurrent requests on the same connection round-trip
+    /// independently and arrive at the correct caller.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rpc_concurrent_requests() -> Result<()> {
+        let processor = from_fn(|req: Bytes| async move {
+            // Echo with a trailing marker so we can verify correlation.
+            let mut out = req.to_vec();
+            out.push(b'!');
+            Ok(Bytes::from(out))
+        });
+        let server = IrohSubstrate::new(
+            fresh_key(),
+            NoopHandler::new("moq"),
+            IrohRpcProtocolHandler::new(processor),
+        )
+        .await?;
+        let server_addr = direct_addr(&server);
+
+        let client = IrohSubstrate::new(
+            fresh_key(),
+            NoopHandler::new("c-moq"),
+            NoopHandler::new("c-rpc"),
+        )
+        .await?;
+        let conn = Arc::new(
+            client
+                .connect(server_addr, ALPN_HYPRSTREAM_RPC)
+                .await?,
+        );
+
+        let mut handles = Vec::new();
+        for i in 0..8u8 {
+            let conn = Arc::clone(&conn);
+            handles.push(tokio::spawn(async move {
+                let resp = client_request(&conn, &[i]).await?;
+                assert_eq!(&resp[..], &[i, b'!']);
+                anyhow::Ok(())
+            }));
+        }
+        for h in handles {
+            h.await??;
+        }
+
+        client.shutdown().await?;
+        server.shutdown().await?;
+        Ok(())
+    }
+}

--- a/crates/hyprstream-rpc/src/transport/iroh_substrate.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_substrate.rs
@@ -1,0 +1,237 @@
+//! Iroh transport substrate — Phase 1 of Epic #131 (ZMQ → moq-net + iroh).
+//!
+//! Builds a shared `iroh::Endpoint` from an Ed25519 node key and wires an
+//! [`iroh::protocol::Router`] with two ALPN slots:
+//!
+//! - [`ALPN_MOQ_LITE`] (`moql`) — moq-net session handler. Wired in Phase 3
+//!   (issue hyprstream/hyprstream#134) to dispatch into an in-process
+//!   `moq_net::Origin` for the streaming plane.
+//! - [`ALPN_HYPRSTREAM_RPC`] (`hyprstream-rpc/1`) — raw Cap'n Proto bidi
+//!   handler. Wired in Phase 2 (issue hyprstream/hyprstream#133) to terminate
+//!   `IrohRpcTransport` for the RPC plane.
+//!
+//! Phase 1 ships the substrate, a [`NoopHandler`] placeholder, and a smoke
+//! test verifying that two endpoints can dial each other directly and open a
+//! bidi stream on each ALPN. No production code consumes this module yet.
+
+use anyhow::Result;
+use iroh::endpoint::{Connection, presets};
+use iroh::protocol::{AcceptError, DynProtocolHandler, ProtocolHandler, Router};
+use iroh::{Endpoint, EndpointAddr, EndpointId, SecretKey};
+
+/// ALPN for moq-net (moq-lite). Must equal `moq_net::version::ALPN_LITE`.
+pub const ALPN_MOQ_LITE: &[u8] = b"moql";
+
+/// ALPN for the raw Cap'n Proto bidi RPC plane.
+pub const ALPN_HYPRSTREAM_RPC: &[u8] = b"hyprstream-rpc/1";
+
+/// Two-plane iroh substrate: one shared QUIC endpoint, two ALPN-dispatched
+/// protocol handlers.
+///
+/// Drop to abort the accept loop; call [`IrohSubstrate::shutdown`] for a
+/// clean shutdown that drains protocol handlers and closes the endpoint.
+pub struct IrohSubstrate {
+    endpoint: Endpoint,
+    router: Router,
+}
+
+impl IrohSubstrate {
+    /// Build the substrate from raw 32-byte Ed25519 secret key material.
+    ///
+    /// Uses iroh's `presets::N0` for discovery (n0 DNS + pkarr) and relay
+    /// fallback. Operators wanting self-hosted discovery should bypass this
+    /// constructor and use [`IrohSubstrate::from_endpoint`] with a
+    /// pre-configured `iroh::Endpoint`.
+    pub async fn new<M, R>(
+        secret_key_bytes: [u8; 32],
+        moq_handler: M,
+        rpc_handler: R,
+    ) -> Result<Self>
+    where
+        M: Into<Box<dyn DynProtocolHandler>>,
+        R: Into<Box<dyn DynProtocolHandler>>,
+    {
+        let endpoint = Endpoint::builder(presets::N0)
+            .secret_key(SecretKey::from_bytes(&secret_key_bytes))
+            .bind()
+            .await
+            .map_err(|e| anyhow::anyhow!("iroh endpoint bind: {e}"))?;
+
+        Ok(Self::from_endpoint(endpoint, moq_handler, rpc_handler))
+    }
+
+    /// Wrap a caller-built endpoint. Useful when the caller wants
+    /// non-default discovery (e.g. self-hosted `iroh-dns-server`), a
+    /// non-default crypto provider, or to share an existing endpoint
+    /// across substrates.
+    pub fn from_endpoint<M, R>(
+        endpoint: Endpoint,
+        moq_handler: M,
+        rpc_handler: R,
+    ) -> Self
+    where
+        M: Into<Box<dyn DynProtocolHandler>>,
+        R: Into<Box<dyn DynProtocolHandler>>,
+    {
+        let router = Router::builder(endpoint.clone())
+            .accept(ALPN_MOQ_LITE, moq_handler.into())
+            .accept(ALPN_HYPRSTREAM_RPC, rpc_handler.into())
+            .spawn();
+        Self { endpoint, router }
+    }
+
+    /// Endpoint id = our Ed25519 public key. Published in JWKS for
+    /// federation peer binding (Phase 6, issue #137).
+    pub fn endpoint_id(&self) -> EndpointId {
+        self.endpoint.id()
+    }
+
+    /// Borrow the underlying endpoint, e.g. to issue outbound connects on
+    /// an ALPN not served by this substrate's router.
+    pub fn endpoint(&self) -> &Endpoint {
+        &self.endpoint
+    }
+
+    /// Borrow the router (e.g. to inspect or to share lifetime).
+    pub fn router(&self) -> &Router {
+        &self.router
+    }
+
+    /// Dial a peer for the given ALPN.
+    pub async fn connect(&self, addr: EndpointAddr, alpn: &[u8]) -> Result<Connection> {
+        self.endpoint
+            .connect(addr, alpn)
+            .await
+            .map_err(|e| anyhow::anyhow!("iroh connect: {e}"))
+    }
+
+    /// Drain handlers and close the endpoint.
+    pub async fn shutdown(self) -> Result<()> {
+        self.router
+            .shutdown()
+            .await
+            .map_err(|e| anyhow::anyhow!("router shutdown: {e}"))?;
+        Ok(())
+    }
+}
+
+/// Placeholder protocol handler that accepts an incoming connection and
+/// immediately returns. Used until Phase 2 / Phase 3 wire the real handlers.
+#[derive(Debug, Clone, Default)]
+pub struct NoopHandler {
+    reason: &'static str,
+}
+
+impl NoopHandler {
+    pub fn new(reason: &'static str) -> Self {
+        Self { reason }
+    }
+}
+
+impl ProtocolHandler for NoopHandler {
+    async fn accept(&self, _conn: Connection) -> Result<(), AcceptError> {
+        tracing::trace!(reason = %self.reason, "NoopHandler accepted (no-op)");
+        Ok(())
+    }
+}
+
+/// Test-only handler that accepts one bidi stream, reads one length-prefixed
+/// message, echoes it back, then closes. Used by the Phase 1 smoke test to
+/// verify that both ALPN slots route correctly.
+#[derive(Debug, Clone, Default)]
+pub struct EchoHandler;
+
+impl ProtocolHandler for EchoHandler {
+    async fn accept(&self, conn: Connection) -> Result<(), AcceptError> {
+        let (mut send, mut recv) = conn
+            .accept_bi()
+            .await
+            .map_err(|e| AcceptError::from_err(e))?;
+        let buf = recv
+            .read_to_end(1024)
+            .await
+            .map_err(|e| AcceptError::from_err(e))?;
+        send.write_all(&buf)
+            .await
+            .map_err(|e| AcceptError::from_err(e))?;
+        send.finish().map_err(|e| AcceptError::from_err(e))?;
+        // Cleanly wait for the peer to acknowledge by reading the final FIN.
+        let _ = send.stopped().await;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iroh::TransportAddr;
+    use rand::RngCore;
+
+    fn fresh_key() -> [u8; 32] {
+        let mut k = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut k);
+        k
+    }
+
+    /// Build an `EndpointAddr` for a server directly from its bound sockets +
+    /// endpoint id. Skips the n0 relay/pkarr resolution path, which keeps the
+    /// smoke test hermetic — no DNS lookup, no network egress.
+    fn direct_addr(substrate: &IrohSubstrate) -> EndpointAddr {
+        EndpointAddr::from_parts(
+            substrate.endpoint_id(),
+            substrate
+                .endpoint()
+                .bound_sockets()
+                .into_iter()
+                .map(TransportAddr::Ip),
+        )
+    }
+
+    /// Smoke test: build two substrates, dial direct (no DNS/pkarr), echo a
+    /// message on each ALPN. Verifies the router dispatches by ALPN and that
+    /// both planes terminate distinct handlers.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn smoke_two_endpoints_two_alpns() -> Result<()> {
+        // Server with EchoHandler on both ALPNs.
+        let server = IrohSubstrate::new(fresh_key(), EchoHandler, EchoHandler).await?;
+        let server_id = server.endpoint_id();
+        let server_addr = direct_addr(&server);
+
+        // Client with no-op handlers (it only originates).
+        let client = IrohSubstrate::new(
+            fresh_key(),
+            NoopHandler::new("client moq"),
+            NoopHandler::new("client rpc"),
+        )
+        .await?;
+
+        // RPC plane round-trip.
+        {
+            let conn = client
+                .connect(server_addr.clone(), ALPN_HYPRSTREAM_RPC)
+                .await?;
+            let (mut send, mut recv) = conn.open_bi().await?;
+            send.write_all(b"hello rpc").await?;
+            send.finish()?;
+            let got = recv.read_to_end(64).await?;
+            assert_eq!(&got, b"hello rpc");
+        }
+
+        // Streaming plane round-trip (echo here; real moq-net wiring lands in Phase 3).
+        {
+            let conn = client.connect(server_addr.clone(), ALPN_MOQ_LITE).await?;
+            let (mut send, mut recv) = conn.open_bi().await?;
+            send.write_all(b"hello moq").await?;
+            send.finish()?;
+            let got = recv.read_to_end(64).await?;
+            assert_eq!(&got, b"hello moq");
+        }
+
+        // Sanity: server id is stable.
+        assert_eq!(server.endpoint_id(), server_id);
+
+        client.shutdown().await?;
+        server.shutdown().await?;
+        Ok(())
+    }
+}

--- a/crates/hyprstream-rpc/src/transport/iroh_transport.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_transport.rs
@@ -1,0 +1,110 @@
+//! Iroh client-side transport — Phase 2 part 2 of Epic #131 (#133).
+//!
+//! Implements [`Transport`] over an iroh [`Connection`] so existing
+//! [`RpcClientImpl<S, T>`] consumers can ride the `hyprstream-rpc/1` ALPN
+//! with zero changes to envelope signing, JWT handling, or response parsing.
+//!
+//! Each `send()` opens a fresh bidi stream on the connection, writes the
+//! length-prefixed `SignedEnvelope` bytes, and reads the response — matching
+//! the [`IrohRpcProtocolHandler`] (`transport::iroh_rpc`) accept loop on the
+//! server side.
+//!
+//! **Out of scope** (Phase 3): the [`Transport::subscribe`] and
+//! [`Transport::publish`] methods are streaming-plane concerns. They return
+//! errors here; subscribers go through `moq-net` on the `moql` ALPN instead.
+//!
+//! [`IrohRpcProtocolHandler`]: super::iroh_rpc::IrohRpcProtocolHandler
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Result, anyhow, bail};
+use async_trait::async_trait;
+use iroh::endpoint::Connection;
+
+use crate::transport::iroh_rpc::MAX_FRAME_BYTES;
+use crate::transport_traits::{PublishSink, Transport};
+
+/// Default per-call timeout when the caller passes `None`.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Wraps an iroh [`Connection`] as a [`Transport`] for RPC plane traffic.
+///
+/// Clone-cheap — the connection itself is reference-counted internally by
+/// iroh, and we share it via `Arc` so the same `IrohTransport` can be
+/// installed in multiple `RpcClientImpl`s if a service holds parallel
+/// per-tenant clients.
+#[derive(Clone)]
+pub struct IrohTransport {
+    conn: Arc<Connection>,
+}
+
+impl IrohTransport {
+    /// Build from an already-established iroh connection on
+    /// [`super::iroh_substrate::ALPN_HYPRSTREAM_RPC`].
+    pub fn new(conn: Connection) -> Self {
+        Self {
+            conn: Arc::new(conn),
+        }
+    }
+
+    /// Borrow the underlying iroh connection (e.g. for inspection).
+    pub fn connection(&self) -> &Connection {
+        &self.conn
+    }
+}
+
+/// Stub stream type for [`Transport::Sub`]. Always pending — the iroh RPC
+/// plane does not carry SUB-style topic streams; those live on the `moql`
+/// ALPN under Phase 3.
+pub type IrohPendingStream = futures::stream::Pending<Result<Vec<Vec<u8>>>>;
+
+/// Stub publish sink for [`Transport::Pub`]. Errors on any `send_frames`
+/// call; iroh-rpc is request-response only.
+pub struct IrohPublishStub;
+
+#[async_trait]
+impl PublishSink for IrohPublishStub {
+    async fn send_frames(&self, _frames: &[&[u8]]) -> Result<()> {
+        bail!("iroh RPC plane does not support PUB/PUSH — use moq-net on the `moql` ALPN")
+    }
+}
+
+#[async_trait]
+impl Transport for IrohTransport {
+    type Sub = IrohPendingStream;
+    type Pub = IrohPublishStub;
+
+    async fn send(&self, payload: Vec<u8>, timeout_ms: Option<i32>) -> Result<Vec<u8>> {
+        let timeout = timeout_ms
+            .map(|ms| Duration::from_millis(ms.max(0) as u64))
+            .unwrap_or(DEFAULT_TIMEOUT);
+        let fut = async {
+            let (mut send, mut recv) = self
+                .conn
+                .open_bi()
+                .await
+                .map_err(|e| anyhow!("iroh open_bi: {e}"))?;
+            send.write_all(&payload)
+                .await
+                .map_err(|e| anyhow!("iroh write_all: {e}"))?;
+            send.finish().map_err(|e| anyhow!("iroh finish: {e}"))?;
+            let buf = recv
+                .read_to_end(MAX_FRAME_BYTES)
+                .await
+                .map_err(|e| anyhow!("iroh read_to_end: {e}"))?;
+            Ok(buf)
+        };
+        tokio::time::timeout(timeout, fut)
+            .await
+            .map_err(|_| anyhow!("iroh RPC timeout after {timeout:?}"))?
+    }
+
+    async fn subscribe(&self, _topic: &[u8]) -> Result<Self::Sub> {
+        bail!("iroh RPC plane does not support SUB — use moq-net on the `moql` ALPN")
+    }
+
+    async fn publish(&self, _topic: &[u8]) -> Result<Self::Pub> {
+        bail!("iroh RPC plane does not support PUB — use moq-net on the `moql` ALPN")
+    }
+}

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -11,6 +11,8 @@ mod traits;
 pub mod sockopt;
 pub mod zmtp_quic;
 pub mod quic_stream_bridge;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod iroh_substrate;
 
 use std::net::SocketAddr;
 use std::os::unix::io::RawFd;

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -15,6 +15,8 @@ pub mod quic_stream_bridge;
 pub mod iroh_substrate;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod iroh_rpc;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod iroh_transport;
 
 use std::net::SocketAddr;
 use std::os::unix::io::RawFd;

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -13,6 +13,8 @@ pub mod zmtp_quic;
 pub mod quic_stream_bridge;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod iroh_substrate;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod iroh_rpc;
 
 use std::net::SocketAddr;
 use std::os::unix::io::RawFd;

--- a/crates/hyprstream-rpc/tests/iroh_rpc_e2e.rs
+++ b/crates/hyprstream-rpc/tests/iroh_rpc_e2e.rs
@@ -1,0 +1,160 @@
+//! End-to-end Phase 2 canary: real SignedEnvelope round-trip over iroh.
+//!
+//! Wires a minimal [`ZmqService`] through:
+//! 1. [`LocalServiceBridge`] (dedicated LocalSet thread)
+//! 2. [`IrohRpcProtocolHandler`] on ALPN `hyprstream-rpc/1`
+//! 3. iroh `Connection` (direct dial, no DNS/pkarr)
+//! 4. [`IrohTransport`] (client wire)
+//! 5. [`RpcClientImpl`] (envelope sign + JWT + response unwrap)
+//!
+//! Verifies the canary exit criterion's wire-and-envelope half: a real
+//! `SignedEnvelope` issued by `RpcClientImpl::call` traverses iroh and
+//! arrives at the service's `handle_request` with verified identity, and
+//! the signed response verifies back at the client.
+//!
+//! Full PolicyClient integration (running the whole `services/policy/tests/`
+//! suite over iroh) requires `services/factories.rs` wiring — tracked as
+//! Phase 2 part 3 of #133.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use ed25519_dalek::{SigningKey, VerifyingKey};
+
+use hyprstream_rpc::envelope::InMemoryNonceCache;
+use hyprstream_rpc::rpc_client::RpcClientImpl;
+use hyprstream_rpc::service::{Continuation, EnvelopeContext, ZmqService};
+use hyprstream_rpc::signer::LocalSigner;
+use hyprstream_rpc::transport::iroh_rpc::{IrohRpcProtocolHandler, LocalServiceBridge};
+use hyprstream_rpc::transport::iroh_substrate::{
+    ALPN_HYPRSTREAM_RPC, IrohSubstrate, NoopHandler,
+};
+use hyprstream_rpc::transport::iroh_transport::IrohTransport;
+use hyprstream_rpc::transport::TransportConfig;
+use iroh::{EndpointAddr, TransportAddr};
+use rand::RngCore;
+
+/// Minimal `ZmqService` for the canary: echoes the request payload with a
+/// 1-byte prefix so the test can verify identity round-trip.
+struct EchoService {
+    name: String,
+    ctx: Arc<zmq::Context>,
+    transport: TransportConfig,
+    signing_key: SigningKey,
+}
+
+impl EchoService {
+    fn new(signing_key: SigningKey) -> Self {
+        Self {
+            name: "iroh-echo".to_owned(),
+            ctx: Arc::new(zmq::Context::new()),
+            transport: TransportConfig::inproc("iroh-echo-unused"),
+            signing_key,
+        }
+    }
+}
+
+#[async_trait(?Send)]
+impl ZmqService for EchoService {
+    async fn handle_request(
+        &self,
+        _ctx: &EnvelopeContext,
+        payload: &[u8],
+    ) -> Result<(Vec<u8>, Option<Continuation>)> {
+        let mut out = Vec::with_capacity(1 + payload.len());
+        out.push(0xEC);
+        out.extend_from_slice(payload);
+        Ok((out, None))
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn context(&self) -> &Arc<zmq::Context> {
+        &self.ctx
+    }
+
+    fn transport(&self) -> &TransportConfig {
+        &self.transport
+    }
+
+    fn signing_key(&self) -> SigningKey {
+        self.signing_key.clone()
+    }
+}
+
+fn fresh_signing_key() -> SigningKey {
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    SigningKey::from_bytes(&bytes)
+}
+
+fn fresh_node_key() -> [u8; 32] {
+    let mut k = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut k);
+    k
+}
+
+fn direct_addr(substrate: &IrohSubstrate) -> EndpointAddr {
+    EndpointAddr::from_parts(
+        substrate.endpoint_id(),
+        substrate
+            .endpoint()
+            .bound_sockets()
+            .into_iter()
+            .map(TransportAddr::Ip),
+    )
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn signed_envelope_round_trip_over_iroh() -> Result<()> {
+    // ─── Server side ──────────────────────────────────────────────────────
+    let server_signing = fresh_signing_key();
+    let server_verifying: VerifyingKey = server_signing.verifying_key();
+    let server_nonce_cache = Arc::new(InMemoryNonceCache::new());
+
+    let bridge = LocalServiceBridge::spawn(
+        EchoService::new(server_signing.clone()),
+        server_nonce_cache,
+        0,
+    )?;
+
+    let server = IrohSubstrate::new(
+        fresh_node_key(),
+        NoopHandler::new("moq-not-wired"),
+        IrohRpcProtocolHandler::new(bridge, server_signing.clone()),
+    )
+    .await?;
+    let server_addr = direct_addr(&server);
+
+    // ─── Client side ──────────────────────────────────────────────────────
+    let client_signing = fresh_signing_key();
+    let client = IrohSubstrate::new(
+        fresh_node_key(),
+        NoopHandler::new("client-moq"),
+        NoopHandler::new("client-rpc"),
+    )
+    .await?;
+
+    let conn = client.connect(server_addr, ALPN_HYPRSTREAM_RPC).await?;
+    let transport = IrohTransport::new(conn);
+    let rpc = RpcClientImpl::new(
+        LocalSigner::new(client_signing.clone()),
+        transport,
+        Some(server_verifying),
+    );
+
+    // Real signed envelope round-trip.
+    let response = rpc.call(b"ping-payload".to_vec()).await?;
+    assert_eq!(&response[..], b"\xECping-payload");
+
+    // Second call on the same connection to exercise multiple bidi streams.
+    let response2 = rpc.call(b"second".to_vec()).await?;
+    assert_eq!(&response2[..], b"\xECsecond");
+
+    client.shutdown().await?;
+    server.shutdown().await?;
+    Ok(())
+}

--- a/crates/hyprstream-workers/src/events/secure_publisher.rs
+++ b/crates/hyprstream-workers/src/events/secure_publisher.rs
@@ -47,13 +47,13 @@ pub enum RekeyPolicy {
 impl RekeyPolicy {
     pub fn validate(&self) -> Result<(), String> {
         match self {
-            Self::Scheduled { interval } | Self::Jittered { interval, .. } => {
-                if *interval > MAX_KEY_LIFETIME {
-                    return Err(format!(
-                        "interval {:?} exceeds MAX_KEY_LIFETIME ({:?})",
-                        interval, MAX_KEY_LIFETIME
-                    ));
-                }
+            Self::Scheduled { interval } | Self::Jittered { interval, .. }
+                if *interval > MAX_KEY_LIFETIME =>
+            {
+                return Err(format!(
+                    "interval {:?} exceeds MAX_KEY_LIFETIME ({:?})",
+                    interval, MAX_KEY_LIFETIME
+                ));
             }
             _ => {}
         }

--- a/crates/hyprstream/src/runtime/model_config.rs
+++ b/crates/hyprstream/src/runtime/model_config.rs
@@ -543,13 +543,11 @@ impl ModelConfig {
                     self.rope_theta = 10_000_000.0; // Qwen3.5 uses 10M
                 }
             }
-            ModelArchitecture::Gemma => {
-                if self.vocab_size == 262144 {
-                    self.rope_theta = 1_000_000.0;
-                    self.use_qk_norm = true;
-                    self.scale_embeddings = true;
-                    self.query_pre_attn_scalar = Some(256.0);
-                }
+            ModelArchitecture::Gemma if self.vocab_size == 262144 => {
+                self.rope_theta = 1_000_000.0;
+                self.use_qk_norm = true;
+                self.scale_embeddings = true;
+                self.query_pre_attn_scalar = Some(256.0);
             }
             _ => {}
         }

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -1560,11 +1560,10 @@ pub(crate) async fn watch_policy_file(
     let mut watcher = match notify::recommended_watcher(move |res: Result<Event, notify::Error>| {
         if let Ok(event) = res {
             match event.kind {
-                EventKind::Modify(_) | EventKind::Create(_) => {
-                    // Only trigger for events involving our policy.csv
-                    if event.paths.iter().any(|p| p.ends_with("policy.csv")) {
-                        let _ = tx.blocking_send(());
-                    }
+                EventKind::Modify(_) | EventKind::Create(_)
+                    if event.paths.iter().any(|p| p.ends_with("policy.csv")) =>
+                {
+                    let _ = tx.blocking_send(());
                 }
                 _ => {}
             }

--- a/crates/hyprstream/src/tui/service.rs
+++ b/crates/hyprstream/src/tui/service.rs
@@ -1011,7 +1011,7 @@ impl TuiService {
                                             let stage = parts[0];
                                             let current: u64 = parts[1].parse().unwrap_or(0);
                                             let total: u64 = parts[2].parse().unwrap_or(0);
-                                            let pct = if total > 0 { ((current * 70) / total).min(70) as u8 } else { 0 };
+                                            let pct = (current * 70).checked_div(total).map(|v| v.min(70) as u8).unwrap_or(0);
                                             let label = match stage {
                                                 "fetch" => "Fetching objects",
                                                 "indexing" => "Indexing",

--- a/crates/hyprstream/src/tui/vte_parser.rs
+++ b/crates/hyprstream/src/tui/vte_parser.rs
@@ -671,11 +671,9 @@ impl<'a> vte::Perform for PanePerformer<'a> {
         }
         // OSC 0 or 2: set title
         match params[0] {
-            b"0" | b"2" => {
-                if params.len() > 1 {
-                    if let Ok(title) = std::str::from_utf8(params[1]) {
-                        self.pane.title = title.to_owned();
-                    }
+            b"0" | b"2" if params.len() > 1 => {
+                if let Ok(title) = std::str::from_utf8(params[1]) {
+                    self.pane.title = title.to_owned();
                 }
             }
             _ => {}
@@ -1018,7 +1016,7 @@ mod tests {
         }
         // Bottom row (row 9, 0-indexed) should have been cleared with the
         // current background color, not Color::Reset.
-        let last_row = (pane.primary.buffer.area().height - 1) as u16;
+        let last_row = pane.primary.buffer.area().height - 1;
         let cell = &pane.primary.buffer[(0, last_row)];
         assert_eq!(
             cell.bg,


### PR DESCRIPTION
## Summary

Phase 1 of Epic #131 — adds the iroh QUIC endpoint substrate that the rest of the migration builds on.

- New module \`crates/hyprstream-rpc/src/transport/iroh_substrate.rs\` (~200 LoC): \`IrohSubstrate\` struct holding a shared \`iroh::Endpoint\` + \`iroh::protocol::Router\`, with two ALPN slots:
  - \`moql\` — moq-net session handler (wired in Phase 3, #134)
  - \`hyprstream-rpc/1\` — raw Cap'n Proto bidi handler (wired in Phase 2, #133)
- Placeholder \`NoopHandler\` + test-only \`EchoHandler\`.
- Smoke test \`transport::iroh_substrate::tests::smoke_two_endpoints_two_alpns\` — hermetic direct-dial (no DNS/pkarr), bidi round-trip on both ALPNs, runs in ~1s.
- Deps added: \`iroh =1.0.0-rc.0\` (exact pin — \`web-transport-iroh 0.5.x\` requires it), \`moq-net 0.1\`, \`web-transport-iroh 0.5.1\`, \`web-transport-trait 0.3\`. All TLS via \`ring\` to match workspace rustls config.

## Trust-model boundary (out of scope here, lands in later phases)

- iroh's QUIC TLS authenticates the connection peer's Ed25519 NodeId at the transport layer. **Phase 1 ships this only.**
- \`SignedEnvelope\` / JWT / DPoP / Casbin verification stays in application handlers, moves over unchanged in Phase 2.
- PQ-hybrid signing (ML-DSA-65, ML-KEM-768) is application-layer (\`SignedEnvelope\`, JWKS publication) and unaffected by this transport swap. Iroh's transport-layer PQ is upstream-blocked; not a regression.

## Test plan

- [x] \`cargo check --release -p hyprstream-rpc --tests\` clean
- [x] \`cargo check --release -p hyprstream\` (no regressions in main crate)
- [x] \`cargo test --release -p hyprstream-rpc transport::iroh_substrate\` — 1 passed

Closes #132.