### PR TITLE
test(policy): real PolicyService over iroh (Epic #131 #133 part 3/3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6401,6 +6401,7 @@ dependencies = [
  "indicatif",
  "inquire",
  "inventory",
+ "iroh",
  "json-threat-protection",
  "jsonwebtoken 10.3.0",
  "keyring",

--- a/crates/hyprstream-rpc/src/transport/iroh_moq.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_moq.rs
@@ -1,0 +1,265 @@
+//! Iroh streaming plane — moq-lite (`moql` ALPN) protocol handler.
+//!
+//! Part of Epic #131 Phase 3 (#134). This module ships the wire layer for
+//! the streaming plane:
+//!
+//! - [`IrohMoqProtocolHandler`] plugs into [`crate::transport::iroh_substrate`]
+//!   under the `moql` ALPN, wrapping each accepted iroh `Connection` as a
+//!   `web_transport_iroh::Session` and handing it to `moq_net::Server`,
+//!   which spawns the moq-lite session machinery internally.
+//! - One shared [`OriginShared`] (an `OriginProducer` + matching
+//!   `OriginConsumer`) is held by the handler; the *same* origin is used
+//!   for **in-process publishing** (callers obtain it via
+//!   [`IrohMoqProtocolHandler::origin_producer`] and create broadcasts
+//!   directly) **and for external subscribers** — per spike #94's finding,
+//!   `moq_net::Server` does exactly this.
+//!
+//! **Trust model**: §7.5 unchanged. The transport is unauthenticated;
+//! subscribers learn the DH-derived (unguessable) Track path out-of-band
+//! via authenticated RPC (a signed `StreamInfo`), and the per-Frame
+//! payload carries the chained-HMAC envelope. CDN-portability per §10.x
+//! of the Federated Agentic Namespaces doc.
+//!
+//! **What this module does NOT do**: refactor `StreamService` or
+//! `EventService` to use this. That lands in Phase 3 part 2+ along with
+//! the §7.5 chained-HMAC tokenstream port.
+
+use std::sync::Arc;
+
+use iroh::endpoint::Connection;
+use iroh::protocol::{AcceptError, ProtocolHandler};
+use moq_net::{Origin, OriginConsumer, OriginProducer, Server, StatsHandle};
+use tokio_util::sync::CancellationToken;
+use web_transport_iroh::Session;
+
+/// Shared `Origin` clone-pair held by the handler.
+///
+/// - `producer` is what *we* publish into (call `create_broadcast`, `create_track`, etc.).
+/// - `consumer` is what *remote subscribers* read from (handed to `Server::with_publish`).
+///
+/// Both reference the same underlying tree — broadcasts created via
+/// `producer` are visible to remote subscribers consuming via `consumer`.
+#[derive(Clone)]
+pub struct OriginShared {
+    producer: OriginProducer,
+    consumer: OriginConsumer,
+}
+
+impl OriginShared {
+    /// Build a fresh origin pair with a random id.
+    pub fn new() -> Self {
+        let producer = Origin::random().produce();
+        let consumer = producer.consume();
+        Self { producer, consumer }
+    }
+
+    pub fn producer(&self) -> &OriginProducer {
+        &self.producer
+    }
+
+    pub fn consumer(&self) -> &OriginConsumer {
+        &self.consumer
+    }
+}
+
+impl Default for OriginShared {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// iroh `ProtocolHandler` for the `moql` ALPN. Each accepted connection is
+/// wrapped as a `web_transport_iroh::Session` and handed to
+/// `moq_net::Server::accept`, which performs the moq handshake and spawns
+/// the session machinery.
+#[derive(Clone)]
+pub struct IrohMoqProtocolHandler {
+    inner: Arc<HandlerInner>,
+}
+
+struct HandlerInner {
+    origin: OriginShared,
+    stats: StatsHandle,
+    /// Triggered by `ProtocolHandler::shutdown` so accept handlers stop
+    /// waiting for `Session::closed()` and exit promptly.
+    shutdown: CancellationToken,
+}
+
+impl std::fmt::Debug for IrohMoqProtocolHandler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IrohMoqProtocolHandler").finish_non_exhaustive()
+    }
+}
+
+impl IrohMoqProtocolHandler {
+    /// Build with a fresh origin pair (use [`Self::origin_producer`] to
+    /// publish broadcasts).
+    pub fn new() -> Self {
+        Self::with_origin(OriginShared::new())
+    }
+
+    /// Build with a caller-supplied origin pair. Useful when one origin is
+    /// shared across multiple substrates or with an existing service.
+    pub fn with_origin(origin: OriginShared) -> Self {
+        Self {
+            inner: Arc::new(HandlerInner {
+                origin,
+                stats: StatsHandle::default(),
+                shutdown: CancellationToken::new(),
+            }),
+        }
+    }
+
+    /// Borrow the shared origin pair.
+    pub fn origin(&self) -> &OriginShared {
+        &self.inner.origin
+    }
+
+    /// Borrow the producer (for in-process publishing).
+    pub fn origin_producer(&self) -> &OriginProducer {
+        self.inner.origin.producer()
+    }
+
+    /// Borrow the consumer (for in-process subscribing — same data as a
+    /// remote subscriber sees on the wire).
+    pub fn origin_consumer(&self) -> &OriginConsumer {
+        self.inner.origin.consumer()
+    }
+}
+
+impl Default for IrohMoqProtocolHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ProtocolHandler for IrohMoqProtocolHandler {
+    async fn accept(&self, conn: Connection) -> Result<(), AcceptError> {
+        let session = Session::raw(conn);
+        let server = Server::new()
+            .with_publish(self.inner.origin.consumer.clone())
+            // Subscribe slot is None for v1 — we only serve broadcasts;
+            // accepting remote announces (cross-instance fan-out) lands
+            // in Phase 3 part N (#142).
+            .with_stats(self.inner.stats.clone());
+        let moq_session = server
+            .accept(session)
+            .await
+            .map_err(AcceptError::from_err)?;
+
+        // Hold the session alive until either the connection closes or
+        // shutdown is requested. Server::accept has already spawned the
+        // session's pump tasks; dropping `moq_session` tears them down.
+        tokio::select! {
+            biased;
+            _ = self.inner.shutdown.cancelled() => {
+                tracing::debug!("iroh-moq: shutdown signalled, dropping session");
+            }
+            res = moq_session.closed() => {
+                tracing::debug!(result = ?res, "iroh-moq: session closed");
+            }
+        }
+        Ok(())
+    }
+
+    async fn shutdown(&self) {
+        self.inner.shutdown.cancel();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transport::iroh_substrate::{
+        ALPN_MOQ_LITE, IrohSubstrate, NoopHandler,
+    };
+    use bytes::Bytes;
+    use iroh::{EndpointAddr, TransportAddr};
+    use moq_net::{Client, Group, Track};
+    use rand::RngCore;
+
+    fn fresh_key() -> [u8; 32] {
+        let mut k = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut k);
+        k
+    }
+
+    fn direct_addr(substrate: &IrohSubstrate) -> EndpointAddr {
+        EndpointAddr::from_parts(
+            substrate.endpoint_id(),
+            substrate
+                .endpoint()
+                .bound_sockets()
+                .into_iter()
+                .map(TransportAddr::Ip),
+        )
+    }
+
+    /// In-process publisher writes one Frame to a Track on a Broadcast;
+    /// an external subscriber connects over iroh, navigates the same
+    /// broadcast/track path, and reads back the same Frame bytes.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn moq_publish_subscribe_round_trip() -> anyhow::Result<()> {
+        // ─── Server side ──────────────────────────────────────────────
+        let handler = IrohMoqProtocolHandler::new();
+        let producer = handler.origin_producer().clone();
+        let server = IrohSubstrate::new(
+            fresh_key(),
+            handler,
+            NoopHandler::new("rpc-not-wired"),
+        )
+        .await?;
+        let server_addr = direct_addr(&server);
+
+        // Publish a broadcast with one track before the subscriber connects.
+        let mut broadcast = producer
+            .create_broadcast("alice/run-1")
+            .ok_or_else(|| anyhow::anyhow!("create_broadcast denied"))?;
+        let mut track = broadcast.create_track(Track::new("tokens"))?;
+        let mut group = track.create_group(Group::from(0u64))?;
+        group.write_frame(Bytes::from_static(b"hello-moq"))?;
+        drop(group);
+
+        // ─── Client side: connect via iroh, run moq Client to negotiate,
+        // then subscribe to the known broadcast path. ─────────────────
+        let client = IrohSubstrate::new(
+            fresh_key(),
+            NoopHandler::new("c-moq"),
+            NoopHandler::new("c-rpc"),
+        )
+        .await?;
+        let conn = client.connect(server_addr, ALPN_MOQ_LITE).await?;
+        let session = Session::raw(conn);
+        let client_origin: OriginProducer = Origin::random().produce();
+        let client_consumer: OriginConsumer = client_origin.consume();
+        let moq_client = Client::new().with_consume(client_origin);
+        let _moq_session = moq_client.connect(session).await?;
+
+        // Subscribe to alice/run-1 and read the first group's frame.
+        let broadcast_consumer = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            client_consumer.announced_broadcast("alice/run-1"),
+        )
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("broadcast not announced"))?;
+        let mut track_consumer =
+            broadcast_consumer.subscribe_track(&Track::new("tokens"))?;
+        let mut group_consumer = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            track_consumer.next_group(),
+        )
+        .await??
+        .ok_or_else(|| anyhow::anyhow!("next_group returned None"))?;
+        let frame: Bytes = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            group_consumer.read_frame(),
+        )
+        .await??
+        .ok_or_else(|| anyhow::anyhow!("read_frame returned None"))?;
+        assert_eq!(&frame[..], b"hello-moq");
+
+        client.shutdown().await?;
+        server.shutdown().await?;
+        Ok(())
+    }
+}

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -17,6 +17,8 @@ pub mod iroh_substrate;
 pub mod iroh_rpc;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod iroh_transport;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod iroh_moq;
 
 use std::net::SocketAddr;
 use std::os::unix::io::RawFd;

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -214,6 +214,9 @@ hyprstream-rpc-build.workspace = true  # Shared annotation extraction
 criterion.workspace = true
 tempfile.workspace = true
 tokio-stream.workspace = true
+# Test-only: iroh substrate types used by `tests/policy_over_iroh.rs`.
+iroh.workspace = true
+rand.workspace = true
 
 [lints]
 workspace = true

--- a/crates/hyprstream/tests/policy_over_iroh.rs
+++ b/crates/hyprstream/tests/policy_over_iroh.rs
@@ -1,0 +1,233 @@
+//! Phase 2 part 3: real `PolicyService` exercised end-to-end over iroh.
+//!
+//! Constructs a real `PolicyService` (PolicyManager + Git2DB + signing key,
+//! all in a `TempDir`), serves it through a `LocalServiceBridge` behind an
+//! `IrohRpcProtocolHandler` on ALPN `hyprstream-rpc/1`, and drives the
+//! generated `PolicyClient` against it via `IrohTransport` + `RpcClientImpl`.
+//!
+//! This validates the canary path for #133: every byte that the production
+//! `create_policy_service` factory would terminate on the ZMTP wire also
+//! works unchanged over iroh, because we reuse the same `process_request`
+//! envelope-verify/JWT/Casbin path via the bridge.
+//!
+//! Factory wiring (so deployments actually serve over iroh) is a separate
+//! follow-up under Phase 5 (#136), since every service will need the same
+//! change at the same place.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use ed25519_dalek::SigningKey;
+use rand::RngCore;
+use tempfile::TempDir;
+use tokio::sync::RwLock;
+
+use git2db::Git2DB;
+use hyprstream_core::auth::PolicyManager;
+use hyprstream_core::config::TokenConfig;
+use hyprstream_core::services::PolicyService;
+use hyprstream_core::services::generated::policy_client::{PolicyCheck, PolicyClient};
+
+use hyprstream_rpc::envelope::InMemoryNonceCache;
+use hyprstream_rpc::rpc_client::RpcClientImpl;
+use hyprstream_rpc::signer::LocalSigner;
+use hyprstream_rpc::transport::TransportConfig;
+use hyprstream_rpc::transport::iroh_rpc::{IrohRpcProtocolHandler, LocalServiceBridge};
+use hyprstream_rpc::transport::iroh_substrate::{
+    ALPN_HYPRSTREAM_RPC, IrohSubstrate, NoopHandler,
+};
+use hyprstream_rpc::transport::iroh_transport::IrohTransport;
+
+use iroh::{EndpointAddr, TransportAddr};
+
+fn fresh_node_key() -> [u8; 32] {
+    let mut k = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut k);
+    k
+}
+
+fn fresh_signing_key() -> SigningKey {
+    SigningKey::from_bytes(&fresh_node_key())
+}
+
+fn direct_addr(substrate: &IrohSubstrate) -> EndpointAddr {
+    EndpointAddr::from_parts(
+        substrate.endpoint_id(),
+        substrate
+            .endpoint()
+            .bound_sockets()
+            .into_iter()
+            .map(TransportAddr::Ip),
+    )
+}
+
+/// Stand up a real `PolicyService` in a fresh tempdir and return it
+/// alongside its signing key and the tempdir guard (which must outlive
+/// the service).
+async fn make_policy_service() -> Result<(PolicyService, SigningKey, TempDir)> {
+    let temp = TempDir::new()?;
+    let models_dir = temp.path().to_path_buf();
+    let policies_dir = models_dir.join(".registry").join("policies");
+
+    // PolicyManager bootstraps with SERVICE_BASE_POLICIES so service:*
+    // authorization works without any extra rule writes.
+    let policy_manager = Arc::new(PolicyManager::new(&policies_dir).await?);
+
+    // Git2DB::open initializes .registry as a git repo at this path.
+    let git2db = Arc::new(RwLock::new(Git2DB::open(&models_dir).await?));
+
+    let signing_key = fresh_signing_key();
+    let service = PolicyService::new(
+        policy_manager,
+        Arc::new(signing_key.clone()),
+        TokenConfig::default(),
+        git2db,
+        // Unused on the iroh path — the bridge never touches the ZMQ
+        // transport bits of ZmqService, just `handle_request` + envelope
+        // metadata.
+        Arc::new(zmq::Context::new()),
+        TransportConfig::inproc("policy-over-iroh-unused"),
+    );
+
+    Ok((service, signing_key, temp))
+}
+
+/// Build the iroh server side: PolicyService → LocalServiceBridge →
+/// IrohRpcProtocolHandler → IrohSubstrate.
+async fn serve_over_iroh(
+    service: PolicyService,
+    server_signing: SigningKey,
+) -> Result<(IrohSubstrate, EndpointAddr)> {
+    let nonce_cache = Arc::new(InMemoryNonceCache::new());
+    let bridge = LocalServiceBridge::spawn(service, nonce_cache, 0)?;
+
+    let substrate = IrohSubstrate::new(
+        fresh_node_key(),
+        NoopHandler::new("moq-not-wired"),
+        IrohRpcProtocolHandler::new(bridge, server_signing),
+    )
+    .await?;
+    let addr = direct_addr(&substrate);
+    Ok((substrate, addr))
+}
+
+/// Build the client side: iroh dial → IrohTransport → RpcClientImpl →
+/// PolicyClient.
+async fn client_for(
+    server_addr: EndpointAddr,
+    server_vk: ed25519_dalek::VerifyingKey,
+) -> Result<(IrohSubstrate, PolicyClient)> {
+    let client_substrate = IrohSubstrate::new(
+        fresh_node_key(),
+        NoopHandler::new("c-moq"),
+        NoopHandler::new("c-rpc"),
+    )
+    .await?;
+
+    let conn = client_substrate
+        .connect(server_addr, ALPN_HYPRSTREAM_RPC)
+        .await?;
+    let transport = IrohTransport::new(conn);
+    let rpc = RpcClientImpl::new(LocalSigner::new(fresh_signing_key()), transport, Some(server_vk));
+    let policy_client = PolicyClient::new(Arc::new(rpc));
+    Ok((client_substrate, policy_client))
+}
+
+/// Real PolicyService over iroh — verifies the canary path end-to-end with
+/// a representative `check` RPC, including both ALLOW and DENY outcomes
+/// produced by the bootstrap `SERVICE_BASE_POLICIES`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn policy_check_allow_and_deny_over_iroh() -> Result<()> {
+    let (service, server_signing, _temp) = make_policy_service().await?;
+    let server_vk = server_signing.verifying_key();
+
+    let (server, server_addr) = serve_over_iroh(service, server_signing).await?;
+    let (client_substrate, policy) = client_for(server_addr, server_vk).await?;
+
+    // ALLOW: service:oauth → policy:ResolveServiceKey:query (from
+    // SERVICE_BASE_POLICIES, asserted in policy_manager.rs base-rules test).
+    let allow_resp = policy
+        .check(&PolicyCheck {
+            subject: "service:oauth".to_owned(),
+            domain: "*".to_owned(),
+            resource: "policy:ResolveServiceKey".to_owned(),
+            operation: "query".to_owned(),
+        })
+        .await?;
+    assert!(allow_resp, "service:oauth must be allowed: {allow_resp:?}");
+
+    // DENY: service:unknown is not in the base policies.
+    let deny_resp = policy
+        .check(&PolicyCheck {
+            subject: "service:unknown".to_owned(),
+            domain: "*".to_owned(),
+            resource: "policy:ResolveServiceKey".to_owned(),
+            operation: "query".to_owned(),
+        })
+        .await?;
+    assert!(!deny_resp, "service:unknown must be denied: {deny_resp:?}");
+
+    client_substrate.shutdown().await?;
+    server.shutdown().await?;
+    Ok(())
+}
+
+/// Concurrent `check` calls on the same `PolicyClient` (one iroh connection,
+/// many bidi streams) — verifies the wire layer's per-stream correlation
+/// holds under a real service's response shape.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn policy_concurrent_checks_over_iroh() -> Result<()> {
+    let (service, server_signing, _temp) = make_policy_service().await?;
+    let server_vk = server_signing.verifying_key();
+
+    let (server, server_addr) = serve_over_iroh(service, server_signing).await?;
+    let (client_substrate, policy) = client_for(server_addr, server_vk).await?;
+    let policy = Arc::new(policy);
+
+    // Cases chosen so wildcard base rules don't interfere:
+    //   - policy:ResolveServiceKey:query is granted ONLY to specific services
+    //     (service:oauth, service:policy, service:model, service:registry,
+    //     service:worker, service:mcp), so unknown service:* subjects deny.
+    //   - policy:Check:check is similarly per-service.
+    //   - Non-`service:` subjects (e.g. "alice") deny on everything below
+    //     unless explicitly granted.
+    let cases: Vec<(&str, &str, &str, bool)> = vec![
+        ("service:oauth", "policy:ResolveServiceKey", "query", true),
+        ("service:policy", "policy:ResolveServiceKey", "query", true),
+        ("service:model", "policy:Check", "check", true),
+        ("service:oauth", "policy:IssueToken", "manage", true),
+        ("service:bogus0", "policy:ResolveServiceKey", "query", false),
+        ("service:bogus1", "policy:Check", "check", false),
+        ("alice", "policy:ResolveServiceKey", "query", false),
+        ("alice", "policy:IssueToken", "manage", false),
+    ];
+    let mut handles = Vec::new();
+    for (subject, resource, operation, expect_allow) in cases {
+        let policy = Arc::clone(&policy);
+        let subject = subject.to_owned();
+        let resource = resource.to_owned();
+        let operation = operation.to_owned();
+        handles.push(tokio::spawn(async move {
+            let resp = policy
+                .check(&PolicyCheck {
+                    subject: subject.clone(),
+                    domain: "*".to_owned(),
+                    resource: resource.clone(),
+                    operation,
+                })
+                .await?;
+            assert_eq!(
+                resp, expect_allow,
+                "{subject} -> {resource}: expected allow={expect_allow}, got {resp:?}"
+            );
+            anyhow::Ok(())
+        }));
+    }
+    for h in handles {
+        h.await??;
+    }
+
+    client_substrate.shutdown().await?;
+    server.shutdown().await?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Final part of #133 (Epic #131 Phase 2). Closes the canary: a real \`PolicyService\` — backed by an actual \`PolicyManager\` + \`Git2DB\` in a \`TempDir\` — served through \`LocalServiceBridge\` behind \`IrohRpcProtocolHandler\` on ALPN \`hyprstream-rpc/1\`, exercised by the generated \`PolicyClient\` via \`IrohTransport\` + \`RpcClientImpl\`.

Same \`process_request\` envelope-verify/JWT/DPoP/Casbin path as ZMTP — only the wire differs.

## Note on the #133 exit criterion

The original issue language said "PolicyClient over iroh passes the full \`services/policy/tests/\` suite with zero application-layer changes." That suite **does not exist** — there were no pre-existing integration tests for \`PolicyService\` before this PR. So this PR both *creates* the canary suite and runs it over iroh, which is the actual validation the criterion was reaching for.

## Tests

\`crates/hyprstream/tests/policy_over_iroh.rs\`:
- **\`policy_check_allow_and_deny_over_iroh\`** — single ALLOW + single DENY, driven by \`PolicyManager\`'s \`SERVICE_BASE_POLICIES\` bootstrap.
- **\`policy_concurrent_checks_over_iroh\`** — 8 concurrent checks on one \`PolicyClient\` (so one iroh connection, many bidi streams), mixing ALLOW and DENY for \`service:*\` and non-\`service:\` subjects. Validates per-stream correlation under a real service's response shape.

Both pass in ~2.5s.

## Out of scope (Phase 5, #136)

Wiring \`services/factories.rs::create_policy_service\` to optionally serve over an iroh substrate. Every service will need the same factory change during Phase 5's broader RPC migration; doing it once for policy in isolation would just split the work twice.

Towards #133. Stacked on #145.