### PR TITLE
#166: rename ZmqService → RequestService (transport-neutral)

### DIFF
--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -4,7 +4,7 @@
 //! socket kinds, and schemas via the standard ZMQ REQ/REP transport.
 
 use async_trait::async_trait;
-use hyprstream_rpc::service::{EnvelopeContext, ZmqService};
+use hyprstream_rpc::service::{EnvelopeContext, RequestService};
 use hyprstream_rpc::transport::TransportConfig;
 use hyprstream_rpc::registry::{self, EndpointRegistry, SocketKind};
 use hyprstream_rpc::resolver::Resolver;
@@ -94,7 +94,7 @@ pub struct DiscoveryService {
     signing_key: Arc<SigningKey>,
     /// JWT verifying key for service JWT verification (derived from root via HKDF)
     jwt_verifying_key: hyprstream_rpc::prelude::VerifyingKey,
-    /// JWT key source for client JWT verification (ZmqService trait)
+    /// JWT key source for client JWT verification (RequestService trait)
     jwt_key_source: Option<std::sync::Arc<dyn hyprstream_rpc::auth::JwtKeySource>>,
     /// OAuth issuer URL for RFC 9728 metadata (None = not configured)
     oauth_issuer_url: Option<String>,
@@ -110,7 +110,7 @@ pub struct DiscoveryService {
     /// Consumed by FederationKeyResolver before falling back to HTTPS.
     entity_statements: RwLock<HashMap<String, CachedEntityStatement>>,
     /// Phase 0.5 Stage D — cached envelope COSE_KeySets per service did:web.
-    /// Pushed by each service at startup + rotation. Consumed by ZmqService
+    /// Pushed by each service at startup + rotation. Consumed by RequestService
     /// receivers verifying COSE_Sign1 envelope signatures.
     envelope_keysets: RwLock<HashMap<String, CachedEnvelopeKeyset>>,
     /// Pre-computed TLS endorsement: Sign(tls_key, ed25519_pubkey || domain).
@@ -723,11 +723,11 @@ impl DiscoveryHandler for DiscoveryService {
 }
 
 // ============================================================================
-// ZmqService implementation
+// RequestService implementation
 // ============================================================================
 
 #[async_trait(?Send)]
-impl ZmqService for DiscoveryService {
+impl RequestService for DiscoveryService {
     async fn handle_request(
         &self,
         ctx: &EnvelopeContext,

--- a/crates/hyprstream-rpc/src/auth/federation.rs
+++ b/crates/hyprstream-rpc/src/auth/federation.rs
@@ -11,7 +11,7 @@ use ed25519_dalek::VerifyingKey;
 ///
 /// Implemented by `hyprstream::auth::FederationKeyResolver`. Services that
 /// serve external traffic return `Some(Arc<dyn FederationKeySource>)` from
-/// `ZmqService::federation_key_source()` so the default `verify_claims()`
+/// `RequestService::federation_key_source()` so the default `verify_claims()`
 /// can perform real key resolution instead of rejecting federated JWTs.
 ///
 /// # Note on `Send` bounds
@@ -19,10 +19,10 @@ use ed25519_dalek::VerifyingKey;
 /// `get_key` uses the default (`Send`) flavour of `#[async_trait]` because
 /// `FederationKeyResolver` performs real async I/O (HTTPS JWKS fetch) whose
 /// future must be `Send`. Call sites inside `#[async_trait(?Send)]` contexts
-/// (e.g. `ZmqService::verify_claims`) may `.await` this future directly:
+/// (e.g. `RequestService::verify_claims`) may `.await` this future directly:
 /// it is valid in Rust to await a `Send` future from within a `!Send`
 /// async function — the `?Send` bound constrains the outer function's
-/// future, not the futures it polls. `ZmqService::verify_claims` does
+/// future, not the futures it polls. `RequestService::verify_claims` does
 /// exactly this and compiles correctly.
 #[async_trait::async_trait]
 pub trait FederationKeySource: Send + Sync + 'static {

--- a/crates/hyprstream-rpc/src/lib.rs
+++ b/crates/hyprstream-rpc/src/lib.rs
@@ -200,7 +200,11 @@ pub use resolver::Resolver;
 pub use registry::SocketKind;
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use service::{Continuation, EnvelopeContext, RequestLoop, Spawnable, ServiceHandle, ZmqService};
+pub use service::{Continuation, EnvelopeContext, RequestLoop, Spawnable, ServiceHandle, RequestService};
+/// Transitional compat alias for the former `ZmqService` (#166); removed in #138.
+#[cfg(not(target_arch = "wasm32"))]
+#[doc(hidden)]
+pub use service::RequestService as ZmqService;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use streaming::{
@@ -232,7 +236,7 @@ pub mod prelude {
         // Error
         EnvelopeError, EnvelopeResult, Result, RpcError,
         // Service (transport)
-        EnvelopeContext, RequestLoop, ServiceHandle, ZmqService,
+        EnvelopeContext, RequestLoop, ServiceHandle, RequestService,
         // Streaming
         StreamContext, StreamPublisher,
     };

--- a/crates/hyprstream-rpc/src/service/mod.rs
+++ b/crates/hyprstream-rpc/src/service/mod.rs
@@ -1,7 +1,7 @@
 //! Service-side RPC infrastructure.
 //!
 //! This module provides:
-//! - `ZmqService`, `RequestLoop`, `ZmqClient` - ZMQ REQ/REP service infrastructure
+//! - `RequestService`, `RequestLoop`, `ZmqClient` - ZMQ REQ/REP service infrastructure
 //! - `EnvelopeContext` - Verified request context passed to handlers
 //! - `ServiceHandle` - Handle for managing running services
 //! - `RpcService`, `RpcHandler` - Lower-level RPC traits
@@ -18,7 +18,12 @@ pub mod doc;
 
 pub use traits::{RpcHandler, RpcRequest, RpcService};
 #[allow(deprecated)]
-pub use zmq::{AuthorizeFn, Continuation, EnvelopeContext, QuicLoopConfig, ServiceHandle, RequestLoop, UnifiedRequestLoop, ZmqService};
+pub use zmq::{AuthorizeFn, Continuation, EnvelopeContext, QuicLoopConfig, ServiceHandle, RequestLoop, UnifiedRequestLoop, RequestService};
+/// Transitional compatibility alias for the former `ZmqService` name (#166).
+/// Lets stacked epic branches rebase onto this rename without simultaneous
+/// edits; removed in #138 when ZMQ is torn down.
+#[doc(hidden)]
+pub use zmq::RequestService as ZmqService;
 pub use streaming::StreamService;
 pub use spawnable::Spawnable;
 pub use metadata::{MethodMeta, ParamMeta, SchemaMetadataFn, ScopedSchemaMetadataFn, ScopedClientTreeNode};

--- a/crates/hyprstream-rpc/src/service/spawnable.rs
+++ b/crates/hyprstream-rpc/src/service/spawnable.rs
@@ -9,7 +9,7 @@ use tokio::sync::Notify;
 
 use crate::error::{Result, RpcError};
 use crate::registry::SocketKind;
-use crate::service::{RequestLoop, ZmqService};
+use crate::service::{RequestLoop, RequestService};
 use crate::transport::TransportConfig;
 
 /// Trait for services that can be spawned by ServiceSpawner.
@@ -46,28 +46,28 @@ pub trait Spawnable: Send + 'static {
 }
 
 // ============================================================================
-// Blanket Spawnable impl for ZmqService
+// Blanket Spawnable impl for RequestService
 // ============================================================================
 
-/// Every `ZmqService + Send + Sync` is automatically `Spawnable`.
+/// Every `RequestService + Send + Sync` is automatically `Spawnable`.
 ///
 /// This blanket implementation eliminates the need for wrapper types.
-/// Services that implement `ZmqService` include their infrastructure
+/// Services that implement `RequestService` include their infrastructure
 /// (context, transport, verifying_key) and can be spawned directly.
 ///
 /// Services not satisfying `Send + Sync` (e.g., those using `Rc` or `!Send` fields)
 /// must implement `Spawnable` directly (as `InferenceServiceConfig` does).
-impl<S: ZmqService + Send + Sync> Spawnable for S {
+impl<S: RequestService + Send + Sync> Spawnable for S {
     fn name(&self) -> &str {
-        ZmqService::name(self)
+        RequestService::name(self)
     }
 
     fn context(&self) -> &Arc<zmq::Context> {
-        ZmqService::context(self)
+        RequestService::context(self)
     }
 
     fn registrations(&self) -> Vec<(SocketKind, TransportConfig)> {
-        vec![(SocketKind::Rep, ZmqService::transport(self).clone())]
+        vec![(SocketKind::Rep, RequestService::transport(self).clone())]
     }
 
     fn run(
@@ -75,9 +75,9 @@ impl<S: ZmqService + Send + Sync> Spawnable for S {
         shutdown: Arc<Notify>,
         on_ready: Option<tokio::sync::oneshot::Sender<()>>,
     ) -> Result<()> {
-        let transport = ZmqService::transport(&*self).clone();
-        let context = Arc::clone(ZmqService::context(&*self));
-        let signing_key = ZmqService::signing_key(&*self);
+        let transport = RequestService::transport(&*self).clone();
+        let context = Arc::clone(RequestService::context(&*self));
+        let signing_key = RequestService::signing_key(&*self);
 
         let rt = tokio::runtime::Builder::new_multi_thread()
             .enable_all()

--- a/crates/hyprstream-rpc/src/service/zmq.rs
+++ b/crates/hyprstream-rpc/src/service/zmq.rs
@@ -244,7 +244,7 @@ impl EnvelopeContext {
 ///
 /// This is the unified trait for services that:
 /// 1. Handle requests via `handle_request()`
-/// 2. Are automatically spawnable (blanket `impl Spawnable for S: ZmqService`)
+/// 2. Are automatically spawnable (blanket `impl Spawnable for S: RequestService`)
 ///
 /// Services include their infrastructure (context, transport, verifying key) so they
 /// can be spawned directly without wrapping.
@@ -266,7 +266,7 @@ impl EnvelopeContext {
 ///     verifying_key: VerifyingKey,
 /// }
 ///
-/// impl ZmqService for MyService {
+/// impl RequestService for MyService {
 ///     fn handle_request(&self, ctx: &EnvelopeContext, payload: &[u8]) -> Result<(Vec<u8>, Option<Continuation>)> {
 ///         // ctx.identity is already verified
 ///         info!("Request from {} (id={})", ctx.subject(), ctx.request_id);
@@ -283,7 +283,7 @@ impl EnvelopeContext {
 /// manager.spawn(Box::new(my_service)).await?;
 /// ```
 #[async_trait(?Send)]
-pub trait ZmqService: 'static {
+pub trait RequestService: 'static {
     /// Process a request and return a response with optional continuation.
     ///
     /// # Arguments
@@ -645,7 +645,7 @@ pub trait ZmqService: 'static {
     }
 }
 
-/// REQ/REP message loop for ZmqService.
+/// REQ/REP message loop for RequestService.
 ///
 /// Runs the REQ/REP message loop as an async task with TMQ for I/O.
 /// Uses proper async/await with epoll integration instead of blocking threads.
@@ -662,7 +662,7 @@ pub trait ZmqService: 'static {
 ///
 /// # Usage
 ///
-/// Typically used internally by the blanket `Spawnable` impl for `ZmqService`.
+/// Typically used internally by the blanket `Spawnable` impl for `RequestService`.
 /// Direct usage is for advanced cases only.
 /// REQ/REP message loop with ZMQ ROUTER + optional QUIC accept.
 ///
@@ -748,7 +748,7 @@ impl RequestLoop {
     /// Run the unified service loop as an async task.
     ///
     /// Spawns on `LocalSet` via `spawn_local` — supports `!Send` services.
-    pub async fn run<S: ZmqService>(self, service: S) -> Result<ServiceHandle> {
+    pub async fn run<S: RequestService>(self, service: S) -> Result<ServiceHandle> {
         let transport = self.transport.clone();
         let context = Arc::clone(&self.context);
         let server_pubkey = self.server_pubkey;
@@ -795,7 +795,7 @@ impl RequestLoop {
     /// Accepts requests from both ZMQ ROUTER and WebTransport server,
     /// dispatching both through `process_request`.
     #[allow(clippy::too_many_arguments)]
-    async fn unified_loop<S: ZmqService>(
+    async fn unified_loop<S: RequestService>(
         transport: TransportConfig,
         context: Arc<zmq::Context>,
         service: Rc<S>,

--- a/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
@@ -8,7 +8,7 @@
 //!   drains in-flight requests on `ProtocolHandler::shutdown`.
 //! - [`IrohRequestProcessor`] — trait callers implement to wire actual
 //!   request processing (envelope verification + service dispatch).
-//! - [`LocalServiceBridge`] — adapts a [`crate::service::ZmqService`]
+//! - [`LocalServiceBridge`] — adapts a [`crate::service::RequestService`]
 //!   (potentially `!Send`) to the Send-bounded [`IrohRequestProcessor`].
 //!
 //! **Trust model**: The protocol handler does not parse `SignedEnvelope` —
@@ -212,7 +212,7 @@ pub async fn client_request(conn: &Connection, request: &[u8]) -> Result<Bytes> 
 }
 
 // ============================================================================
-// LocalServiceBridge — adapt a (possibly `!Send`) ZmqService to the Send-bound
+// LocalServiceBridge — adapt a (possibly `!Send`) RequestService to the Send-bound
 // IrohRequestProcessor trait by running the service on a dedicated LocalSet
 // thread and forwarding requests over an mpsc channel.
 // ============================================================================
@@ -223,7 +223,7 @@ struct BridgeMessage {
     respond: tokio::sync::oneshot::Sender<Result<Bytes>>,
 }
 
-/// Adapt a [`crate::service::ZmqService`] to [`IrohRequestProcessor`].
+/// Adapt a [`crate::service::RequestService`] to [`IrohRequestProcessor`].
 ///
 /// Spins up a dedicated thread running a single-threaded tokio runtime with
 /// a `LocalSet`. The service runs on that thread (compatible with both `Send`
@@ -257,7 +257,7 @@ impl LocalServiceBridge {
         queue_depth: usize,
     ) -> Result<Self>
     where
-        S: crate::service::ZmqService + Send + 'static,
+        S: crate::service::RequestService + Send + 'static,
     {
         let cap = if queue_depth == 0 { 128 } else { queue_depth };
         let (tx, mut rx) = tokio::sync::mpsc::channel::<BridgeMessage>(cap);

--- a/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
+++ b/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
@@ -384,7 +384,7 @@ impl QuicRep {
         Ok(())
     }
 
-    /// Accept loop for ZmqService handlers.
+    /// Accept loop for RequestService handlers.
     ///
     /// This variant handles the full envelope processing pipeline:
     /// 1. ZMTP handshake
@@ -392,11 +392,11 @@ impl QuicRep {
     /// 3. Service handle_request dispatch
     /// 4. Signed response serialization
     ///
-    /// Uses `spawn_local` because `ZmqService` is `?Send`.
+    /// Uses `spawn_local` because `RequestService` is `?Send`.
     ///
     /// # Arguments
     ///
-    /// * `service` - ZmqService implementation (wrapped in Rc)
+    /// * `service` - RequestService implementation (wrapped in Rc)
     /// * `server_pubkey` - Server's Ed25519 verifying key
     /// * `signing_key` - Server's Ed25519 signing key
     /// * `nonce_cache` - Nonce cache for replay protection (wrapped in Arc)
@@ -410,7 +410,7 @@ impl QuicRep {
         shutdown: Arc<Notify>,
     ) -> Result<()>
     where
-        S: crate::service::ZmqService + 'static,
+        S: crate::service::RequestService + 'static,
     {
         loop {
             tokio::select! {
@@ -419,7 +419,7 @@ impl QuicRep {
                     let nonce_cache = Arc::clone(&nonce_cache);
                     let signing_key = signing_key.clone();  // Clone before spawn
 
-                    // Use spawn_local because ZmqService is ?Send
+                    // Use spawn_local because RequestService is ?Send
                     tokio::task::spawn_local(async move {
                         match incoming.await {
                             Ok(conn) => {
@@ -459,7 +459,7 @@ impl QuicRep {
         nonce_cache: Arc<crate::envelope::InMemoryNonceCache>,
     ) -> Result<()>
     where
-        S: crate::service::ZmqService + 'static,
+        S: crate::service::RequestService + 'static,
     {
         let remote = conn.remote_address();
         debug!(?remote, "QUIC connection established");
@@ -508,7 +508,7 @@ impl QuicRep {
         nonce_cache: Arc<crate::envelope::InMemoryNonceCache>,
     ) -> Result<()>
     where
-        S: crate::service::ZmqService + 'static,
+        S: crate::service::RequestService + 'static,
     {
         let mut stream = ZmtpStream::new(QuicStream { send, recv });
 
@@ -1229,14 +1229,14 @@ impl<S: AsyncWrite + Unpin, R: Unpin> AsyncWrite for WtStream<S, R> {
 // QuicServiceLoop - QUIC Transport Service Loop
 // ============================================================================
 
-/// Service loop for hosting ZmqService over QUIC transport.
+/// Service loop for hosting RequestService over QUIC transport.
 ///
-/// This struct wraps a `QuicRep` socket and a `ZmqService` implementation,
+/// This struct wraps a `QuicRep` socket and a `RequestService` implementation,
 /// running the QUIC accept loop in a dedicated thread with its own tokio runtime.
 ///
 /// # Threading Model
 ///
-/// `ZmqService` is `#[async_trait(?Send)]` - handlers are not `Send`. This requires:
+/// `RequestService` is `#[async_trait(?Send)]` - handlers are not `Send`. This requires:
 /// - Single-threaded runtime (`new_current_thread`)
 /// - `LocalSet` for non-Send futures
 /// - `spawn_local` instead of `tokio::spawn`
@@ -1260,7 +1260,7 @@ impl<S: AsyncWrite + Unpin, R: Unpin> AsyncWrite for WtStream<S, R> {
 /// ```
 pub struct QuicServiceLoop<S>
 where
-    S: crate::service::ZmqService + Send + Sync + 'static,
+    S: crate::service::RequestService + Send + Sync + 'static,
 {
     rep: QuicRep,
     service: S,
@@ -1276,7 +1276,7 @@ where
 
 impl<S> QuicServiceLoop<S>
 where
-    S: crate::service::ZmqService + Send + Sync + 'static,
+    S: crate::service::RequestService + Send + Sync + 'static,
 {
     /// Create a new QUIC service loop.
     pub fn new(rep: QuicRep, service: S, cert_der: Vec<u8>) -> Result<Self> {
@@ -1300,7 +1300,7 @@ where
 
 impl<S> crate::service::Spawnable for QuicServiceLoop<S>
 where
-    S: crate::service::ZmqService + Send + Sync + 'static,
+    S: crate::service::RequestService + Send + Sync + 'static,
 {
     fn name(&self) -> &str {
         &self.name
@@ -1358,7 +1358,7 @@ where
 /// WebTransport server for browser clients.
 ///
 /// Accepts WebTransport sessions (HTTP/3) from browsers and handles
-/// ZMTP requests using the same ZmqService handlers as native QUIC.
+/// ZMTP requests using the same RequestService handlers as native QUIC.
 ///
 /// # Browser Compatibility
 ///
@@ -1441,7 +1441,7 @@ impl WebTransportServer {
 
     /// Accept connections and dispatch HTTP/3 + WebTransport.
     ///
-    /// Uses `spawn_local` because `ZmqService` is `?Send`.
+    /// Uses `spawn_local` because `RequestService` is `?Send`.
     pub async fn accept_loop_service<S>(
         self,
         service: Rc<S>,
@@ -1451,7 +1451,7 @@ impl WebTransportServer {
         shutdown: Arc<Notify>,
     ) -> Result<()>
     where
-        S: crate::service::ZmqService + 'static,
+        S: crate::service::RequestService + 'static,
     {
         let metadata_json = self.protected_resource_json.map(Arc::new);
         let cert_hash_hex = Arc::new(cert_hash_hex(&self.cert_der));
@@ -1498,7 +1498,7 @@ impl WebTransportServer {
         cert_hash_hex: Arc<String>,
     ) -> Result<()>
     where
-        S: crate::service::ZmqService + 'static,
+        S: crate::service::RequestService + 'static,
     {
         let quinn_conn = incoming.await?;
         let h3_conn = h3_quinn::Connection::new(quinn_conn);
@@ -1599,7 +1599,7 @@ impl WebTransportServer {
         metadata_json: Option<Arc<Vec<u8>>>,
     ) -> Result<()>
     where
-        S: crate::service::ZmqService + 'static,
+        S: crate::service::RequestService + 'static,
     {
         debug!("WebTransport session established");
         loop {
@@ -1653,7 +1653,7 @@ impl WebTransportServer {
         nonce_cache: Arc<crate::envelope::InMemoryNonceCache>,
     ) -> Result<()>
     where
-        S: crate::service::ZmqService + 'static,
+        S: crate::service::RequestService + 'static,
     {
         use h3::quic::BidiStream as H3BidiStream;
         let (send, recv) = H3BidiStream::split(stream);
@@ -1984,7 +1984,7 @@ pub use crate::envelope::EnvelopeVerification;
 /// # Arguments
 ///
 /// * `raw_bytes` - Raw Cap'n Proto bytes containing a `SignedEnvelope`
-/// * `service` - The ZmqService to dispatch to
+/// * `service` - The RequestService to dispatch to
 /// * `verification` - Envelope signer verification mode
 /// * `signing_key` - Server's signing key for response
 /// * `nonce_cache` - Nonce cache for replay protection
@@ -2001,7 +2001,7 @@ pub async fn process_request<S>(
     nonce_cache: &crate::envelope::InMemoryNonceCache,
 ) -> Result<(Vec<u8>, Option<crate::service::Continuation>)>
 where
-    S: crate::service::ZmqService,
+    S: crate::service::RequestService,
 {
     use crate::ToCapnp;
     use crate::envelope::ResponseEnvelope;

--- a/crates/hyprstream-rpc/tests/iroh_rpc_e2e.rs
+++ b/crates/hyprstream-rpc/tests/iroh_rpc_e2e.rs
@@ -1,6 +1,6 @@
 //! End-to-end Phase 2 canary: real SignedEnvelope round-trip over iroh.
 //!
-//! Wires a minimal [`ZmqService`] through:
+//! Wires a minimal [`RequestService`] through:
 //! 1. [`LocalServiceBridge`] (dedicated LocalSet thread)
 //! 2. [`IrohRpcProtocolHandler`] on ALPN `hyprstream-rpc/1`
 //! 3. iroh `Connection` (direct dial, no DNS/pkarr)
@@ -24,7 +24,7 @@ use ed25519_dalek::{SigningKey, VerifyingKey};
 
 use hyprstream_rpc::envelope::InMemoryNonceCache;
 use hyprstream_rpc::rpc_client::RpcClientImpl;
-use hyprstream_rpc::service::{Continuation, EnvelopeContext, ZmqService};
+use hyprstream_rpc::service::{Continuation, EnvelopeContext, RequestService};
 use hyprstream_rpc::signer::LocalSigner;
 use hyprstream_rpc::transport::iroh_rpc::{IrohRpcProtocolHandler, LocalServiceBridge};
 use hyprstream_rpc::transport::iroh_substrate::{
@@ -35,7 +35,7 @@ use hyprstream_rpc::transport::TransportConfig;
 use iroh::{EndpointAddr, TransportAddr};
 use rand::RngCore;
 
-/// Minimal `ZmqService` for the canary: echoes the request payload with a
+/// Minimal `RequestService` for the canary: echoes the request payload with a
 /// 1-byte prefix so the test can verify identity round-trip.
 struct EchoService {
     name: String,
@@ -56,7 +56,7 @@ impl EchoService {
 }
 
 #[async_trait(?Send)]
-impl ZmqService for EchoService {
+impl RequestService for EchoService {
     async fn handle_request(
         &self,
         _ctx: &EnvelopeContext,

--- a/crates/hyprstream-service/src/lib.rs
+++ b/crates/hyprstream-service/src/lib.rs
@@ -9,7 +9,7 @@
 //! # Architecture
 //!
 //! ```text
-//! hyprstream-rpc       (transport: ZmqService, RequestLoop, Resolver)
+//! hyprstream-rpc       (transport: RequestService, RequestLoop, Resolver)
 //!     ↑
 //! hyprstream-service   (orchestration: spawner, factory, manager)
 //!     ↑

--- a/crates/hyprstream-service/src/service/factory.rs
+++ b/crates/hyprstream-service/src/service/factory.rs
@@ -635,7 +635,7 @@ impl ServiceContext {
         std::sync::Arc::new(rpc)
     }
 
-    /// Wrap a ZmqService for spawning with a per-service QUIC port.
+    /// Wrap a RequestService for spawning with a per-service QUIC port.
     ///
     /// - `quic_port: None` → use ephemeral port (0) when QUIC is globally enabled
     /// - `quic_port: Some(0)` → ephemeral (OS-assigned) port
@@ -644,7 +644,7 @@ impl ServiceContext {
     /// When `[quic] enabled = true` in config, all services get QUIC on
     /// auto-assigned ephemeral ports by default. Set an explicit port to
     /// control which port a service uses.
-    pub fn into_spawnable_quic<S: hyprstream_rpc::service::ZmqService + Send + Sync + 'static>(
+    pub fn into_spawnable_quic<S: hyprstream_rpc::service::RequestService + Send + Sync + 'static>(
         &self,
         service: S,
         quic_port: Option<u16>,
@@ -687,10 +687,10 @@ impl ServiceContext {
         }
     }
 
-    /// Wrap a ZmqService for spawning, enabling QUIC when globally configured.
+    /// Wrap a RequestService for spawning, enabling QUIC when globally configured.
     ///
     /// Uses ephemeral port (0) for QUIC when `[quic] enabled = true`.
-    pub fn into_spawnable<S: hyprstream_rpc::service::ZmqService + Send + Sync + 'static>(
+    pub fn into_spawnable<S: hyprstream_rpc::service::RequestService + Send + Sync + 'static>(
         &self,
         service: S,
     ) -> Box<dyn Spawnable> {

--- a/crates/hyprstream-service/src/service/spawner/mod.rs
+++ b/crates/hyprstream-service/src/service/spawner/mod.rs
@@ -14,7 +14,7 @@
 //!     └── SystemdBackend (systemd-run)
 //!         └── Transient units in hyprstream-workers.slice
 //!
-//! ServiceSpawner (ZmqService hosting)
+//! ServiceSpawner (RequestService hosting)
 //!     ├── Tokio mode (tokio::spawn)
 //!     ├── Thread mode (std::thread + runtime)
 //!     └── Subprocess mode (ProcessSpawner)

--- a/crates/hyprstream-service/src/service/spawner/service.rs
+++ b/crates/hyprstream-service/src/service/spawner/service.rs
@@ -1,6 +1,6 @@
-//! Unified service spawner for ZmqService hosting.
+//! Unified service spawner for RequestService hosting.
 //!
-//! Provides a single API for spawning ZmqService implementations with different
+//! Provides a single API for spawning RequestService implementations with different
 //! execution modes (Tokio task, dedicated thread, or subprocess).
 
 use std::path::PathBuf;
@@ -12,7 +12,7 @@ use tokio::sync::Notify;
 use super::{ProcessConfig, ProcessSpawner, SpawnedProcess};
 use hyprstream_rpc::error::Result;
 use hyprstream_rpc::registry::{ServiceRegistration, SocketKind};
-use hyprstream_rpc::service::ZmqService;
+use hyprstream_rpc::service::RequestService;
 use hyprstream_rpc::transport::TransportConfig;
 
 // Import anyhow! macro for error creation in ServiceManager impl
@@ -322,36 +322,36 @@ impl Spawnable for LoadBalancerService {
 // QuicServiceLoop — Spawnable wrapper for QUIC-only service loop
 // ============================================================================
 
-/// Spawnable wrapper that runs a ZmqService with explicit QUIC configuration.
+/// Spawnable wrapper that runs a RequestService with explicit QUIC configuration.
 ///
 /// This is used when a service factory wants to pass a `QuicLoopConfig` to
 /// `RequestLoop::with_quic()` without relying on the blanket `Spawnable` impl.
 ///
-/// The blanket `impl Spawnable for S: ZmqService` creates a plain `RequestLoop`;
+/// The blanket `impl Spawnable for S: RequestService` creates a plain `RequestLoop`;
 /// this wrapper additionally enables QUIC when `quic_config` is `Some`.
-pub struct UnifiedServiceConfig<S: ZmqService + Send + 'static> {
+pub struct UnifiedServiceConfig<S: RequestService + Send + 'static> {
     service: S,
     quic_config: Option<hyprstream_rpc::service::QuicLoopConfig>,
 }
 
-impl<S: ZmqService + Send + 'static> UnifiedServiceConfig<S> {
+impl<S: RequestService + Send + 'static> UnifiedServiceConfig<S> {
     /// Create a unified service config with optional QUIC.
     pub fn new(service: S, quic_config: Option<hyprstream_rpc::service::QuicLoopConfig>) -> Self {
         Self { service, quic_config }
     }
 }
 
-impl<S: ZmqService + Send + Sync + 'static> Spawnable for UnifiedServiceConfig<S> {
+impl<S: RequestService + Send + Sync + 'static> Spawnable for UnifiedServiceConfig<S> {
     fn name(&self) -> &str {
-        ZmqService::name(&self.service)
+        RequestService::name(&self.service)
     }
 
     fn context(&self) -> &Arc<zmq::Context> {
-        ZmqService::context(&self.service)
+        RequestService::context(&self.service)
     }
 
     fn registrations(&self) -> Vec<(SocketKind, TransportConfig)> {
-        vec![(SocketKind::Rep, ZmqService::transport(&self.service).clone())]
+        vec![(SocketKind::Rep, RequestService::transport(&self.service).clone())]
     }
 
     fn run(
@@ -360,9 +360,9 @@ impl<S: ZmqService + Send + Sync + 'static> Spawnable for UnifiedServiceConfig<S
         on_ready: Option<tokio::sync::oneshot::Sender<()>>,
     ) -> Result<()> {
         let UnifiedServiceConfig { service, quic_config } = *self;
-        let transport = ZmqService::transport(&service).clone();
-        let context = Arc::clone(ZmqService::context(&service));
-        let signing_key = ZmqService::signing_key(&service);
+        let transport = RequestService::transport(&service).clone();
+        let context = Arc::clone(RequestService::context(&service));
+        let signing_key = RequestService::signing_key(&service);
 
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -423,8 +423,8 @@ pub enum ServiceMode {
 /// use hyprstream_rpc::service::spawner::{ServiceSpawner, ProxyService};
 /// use hyprstream_rpc::transport::TransportConfig;
 ///
-/// // Spawn a REQ/REP service (ZmqService implementations are directly Spawnable)
-/// let service = MyZmqService::new(ctx, transport, verifying_key);
+/// // Spawn a REQ/REP service (RequestService implementations are directly Spawnable)
+/// let service = MyRequestService::new(ctx, transport, verifying_key);
 /// let spawner = ServiceSpawner::tokio();
 /// let spawned = spawner.spawn(service).await?;
 ///
@@ -487,7 +487,7 @@ impl ServiceSpawner {
     /// Spawn any Spawnable service with registry integration.
     ///
     /// This is the unified spawning API that works with both:
-    /// - Any `S: ZmqService` - REQ/REP services (directly Spawnable via blanket impl)
+    /// - Any `S: RequestService` - REQ/REP services (directly Spawnable via blanket impl)
     /// - `ProxyService` - XSUB/XPUB proxies
     ///
     /// The service is automatically registered with the EndpointRegistry and
@@ -496,8 +496,8 @@ impl ServiceSpawner {
     /// # Example
     ///
     /// ```ignore
-    /// // Spawn a REQ/REP service (ZmqService implementations are directly Spawnable)
-    /// let service = MyZmqService::new(ctx, transport, verifying_key);
+    /// // Spawn a REQ/REP service (RequestService implementations are directly Spawnable)
+    /// let service = MyRequestService::new(ctx, transport, verifying_key);
     /// let spawned = spawner.spawn(service).await?;
     ///
     /// // Spawn a proxy
@@ -1007,7 +1007,7 @@ mod tests {
     use super::*;
     use hyprstream_rpc::crypto::generate_signing_keypair;
     use hyprstream_rpc::prelude::SigningKey;
-    use hyprstream_rpc::service::ZmqService;
+    use hyprstream_rpc::service::RequestService;
     use anyhow::Result as AnyhowResult;
 
     /// Test service that includes infrastructure (new pattern)
@@ -1024,7 +1024,7 @@ mod tests {
     }
 
     #[async_trait::async_trait(?Send)]
-    impl ZmqService for EchoService {
+    impl RequestService for EchoService {
         async fn handle_request(
             &self,
             _ctx: &hyprstream_rpc::service::EnvelopeContext,

--- a/crates/hyprstream-workers/src/runtime/mod.rs
+++ b/crates/hyprstream-workers/src/runtime/mod.rs
@@ -7,7 +7,7 @@
 //! # Architecture
 //!
 //! ```text
-//! WorkerService (ZmqService)
+//! WorkerService (RequestService)
 //!     │
 //!     ├── RuntimeClient trait (client-side interface)
 //!     │     ├── run_pod_sandbox()    → Creates Kata VM
@@ -78,7 +78,7 @@ pub use pool::{PoolStats, SandboxPool};
 pub use sandbox::PodSandbox;
 pub use service::WorkerService;
 // Re-export service infrastructure from hyprstream-rpc for convenience
-pub use hyprstream_rpc::service::{EnvelopeContext, ServiceHandle, ZmqService};
+pub use hyprstream_rpc::service::{EnvelopeContext, ServiceHandle, RequestService};
 pub use virtiofs::{SandboxVirtiofs, SandboxVirtiofsBuilder};
 
 /// CRI runtime version

--- a/crates/hyprstream-workers/src/runtime/service.rs
+++ b/crates/hyprstream-workers/src/runtime/service.rs
@@ -1,6 +1,6 @@
 //! WorkerService - CRI RuntimeClient + ImageClient via ZMQ
 //!
-//! Implements ZmqService trait for handling CRI-aligned requests.
+//! Implements RequestService trait for handling CRI-aligned requests.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -13,7 +13,7 @@ use tracing::{debug, info, warn};
 
 // Import ZMQ service infrastructure from hyprstream-rpc
 use hyprstream_rpc::prelude::SigningKey;
-use hyprstream_rpc::service::{AuthorizeFn, EnvelopeContext, ZmqService};
+use hyprstream_rpc::service::{AuthorizeFn, EnvelopeContext, RequestService};
 use hyprstream_rpc::streaming::{StreamChannel, StreamPublisher};
 use hyprstream_rpc::transport::TransportConfig;
 
@@ -58,7 +58,7 @@ const SERVICE_NAME: &str = "worker";
 
 /// WorkerService handles CRI RuntimeClient and ImageClient requests
 ///
-/// Implements the ZmqService trait for integration with hyprstream's ZMQ infrastructure.
+/// Implements the RequestService trait for integration with hyprstream's ZMQ infrastructure.
 pub struct WorkerService {
     // Business logic
     /// Sandbox pool for VM management
@@ -1281,11 +1281,11 @@ impl WorkerHandler for WorkerService {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// ZmqService Implementation — delegates to generated dispatch_worker
+// RequestService Implementation — delegates to generated dispatch_worker
 // ═══════════════════════════════════════════════════════════════════════════════
 
 #[async_trait(?Send)]
-impl ZmqService for WorkerService {
+impl RequestService for WorkerService {
     async fn handle_request(&self, ctx: &EnvelopeContext, payload: &[u8]) -> AnyhowResult<(Vec<u8>, Option<hyprstream_rpc::service::Continuation>)> {
         debug!(
             "Worker request from {} (request_id={})",

--- a/crates/hyprstream-workers/src/workflow/mod.rs
+++ b/crates/hyprstream-workers/src/workflow/mod.rs
@@ -6,7 +6,7 @@
 //! # Architecture
 //!
 //! ```text
-//! WorkflowService (ZmqService)
+//! WorkflowService (RequestService)
 //!     │
 //!     ├── scan_repo()       → Discover .github/workflows/*.yml
 //!     ├── subscribe()       → Register event triggers

--- a/crates/hyprstream-workers/src/workflow/service.rs
+++ b/crates/hyprstream-workers/src/workflow/service.rs
@@ -1,4 +1,4 @@
-//! WorkflowService - ZmqService implementation for workflow orchestration
+//! WorkflowService - RequestService implementation for workflow orchestration
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -9,7 +9,7 @@ use tokio_util::sync::CancellationToken;
 use anyhow::Result as AnyhowResult;
 use async_trait::async_trait;
 use hyprstream_rpc::prelude::SigningKey;
-use hyprstream_rpc::service::{AuthorizeFn, EnvelopeContext, ZmqService};
+use hyprstream_rpc::service::{AuthorizeFn, EnvelopeContext, RequestService};
 use hyprstream_rpc::transport::TransportConfig;
 
 use hyprstream_vfs::Namespace;
@@ -99,7 +99,7 @@ pub struct WorkflowService {
     /// Background event loop handle
     event_loop_handle: tokio::sync::Mutex<Option<JoinHandle<()>>>,
 
-    // Infrastructure (for ZmqService / Spawnable)
+    // Infrastructure (for RequestService / Spawnable)
     /// Transport configuration
     transport: TransportConfig,
     /// Signing key for message authentication
@@ -613,11 +613,11 @@ impl WorkflowHandler for WorkflowService {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// ZmqService Implementation — delegates to generated dispatch_workflow
+// RequestService Implementation — delegates to generated dispatch_workflow
 // ═══════════════════════════════════════════════════════════════════════════════
 
 #[async_trait(?Send)]
-impl ZmqService for WorkflowService {
+impl RequestService for WorkflowService {
     async fn handle_request(&self, ctx: &EnvelopeContext, payload: &[u8]) -> AnyhowResult<(Vec<u8>, Option<hyprstream_rpc::service::Continuation>)> {
         tracing::debug!(
             "Workflow request from {} (request_id={})",

--- a/crates/hyprstream/src/services/core.rs
+++ b/crates/hyprstream/src/services/core.rs
@@ -1,6 +1,6 @@
 //! Core service infrastructure — re-exports from `hyprstream-rpc`.
 
-pub use hyprstream_rpc::service::{Continuation, EnvelopeContext, ZmqService};
+pub use hyprstream_rpc::service::{Continuation, EnvelopeContext, RequestService};
 
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::print_stdout)]
@@ -32,7 +32,7 @@ mod tests {
     }
 
     #[async_trait::async_trait(?Send)]
-    impl ZmqService for EchoService {
+    impl RequestService for EchoService {
         async fn handle_request(&self, ctx: &EnvelopeContext, payload: &[u8]) -> Result<(Vec<u8>, Option<crate::services::Continuation>)> {
             let user = ctx.user();
             let mut response = format!("from {}:", user).into_bytes();

--- a/crates/hyprstream/src/services/inference.rs
+++ b/crates/hyprstream/src/services/inference.rs
@@ -2543,15 +2543,15 @@ impl InferenceHandler for InferenceService {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// ZmqService adapter and Spawnable implementation
+// RequestService adapter and Spawnable implementation
 // ═══════════════════════════════════════════════════════════════════════════════
 
-// verify_claims is now handled by the default ZmqService::verify_claims() implementation
+// verify_claims is now handled by the default RequestService::verify_claims() implementation
 // in hyprstream-rpc (E2E JWT verification for all non-local identities).
 
-/// ZmqService adapter for InferenceService.
+/// RequestService adapter for InferenceService.
 ///
-/// Wraps `InferenceService` to implement `ZmqService` for use with `RequestLoop`.
+/// Wraps `InferenceService` to implement `RequestService` for use with `RequestLoop`.
 /// This adapter is created inside `Spawnable::run()` on the service thread —
 /// it never crosses thread boundaries.
 struct InferenceZmqAdapter {
@@ -2564,7 +2564,7 @@ struct InferenceZmqAdapter {
 }
 
 #[async_trait::async_trait(?Send)]
-impl hyprstream_rpc::service::ZmqService for InferenceZmqAdapter {
+impl hyprstream_rpc::service::RequestService for InferenceZmqAdapter {
     async fn handle_request(
         &self,
         ctx: &EnvelopeContext,
@@ -2744,7 +2744,7 @@ impl hyprstream_service::Spawnable for InferenceServiceConfig {
             .await
             .map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(format!("init: {e}")))?;
 
-            // Create ZmqService adapter for RequestLoop
+            // Create RequestService adapter for RequestLoop
             let adapter = InferenceZmqAdapter {
                 service,
                 zmq_context: context.clone(),

--- a/crates/hyprstream/src/services/mcp_service.rs
+++ b/crates/hyprstream/src/services/mcp_service.rs
@@ -34,7 +34,7 @@ use ed25519_dalek::{SigningKey, VerifyingKey};
 use futures::future::BoxFuture;
 use hyprstream_rpc::auth::jwt;
 use hyprstream_service::ServiceContext;
-use hyprstream_rpc::service::ZmqService;
+use hyprstream_rpc::service::RequestService;
 use hyprstream_rpc::streaming::{StreamHandle, StreamPayload};
 use hyprstream_rpc::transport::TransportConfig;
 use rmcp::{
@@ -712,7 +712,7 @@ pub struct McpService {
     stdio_token: Option<String>,
     /// Verifying key for JWT validation
     verifying_key: VerifyingKey,
-    // === ZmqService infrastructure ===
+    // === RequestService infrastructure ===
     context: Arc<zmq::Context>,
     transport: TransportConfig,
     signing_key: SigningKey,
@@ -1136,11 +1136,11 @@ impl McpHandler for McpService {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// ZmqService Implementation (internal control plane)
+// RequestService Implementation (internal control plane)
 // ═══════════════════════════════════════════════════════════════════════════════
 
 #[async_trait(?Send)]
-impl ZmqService for McpService {
+impl RequestService for McpService {
     async fn handle_request(&self, ctx: &crate::services::EnvelopeContext, payload: &[u8]) -> anyhow::Result<(Vec<u8>, Option<crate::services::Continuation>)> {
         trace!(
             "McpService request from {} (id={})",

--- a/crates/hyprstream/src/services/metrics.rs
+++ b/crates/hyprstream/src/services/metrics.rs
@@ -21,7 +21,7 @@ use hyprstream_rpc::streaming::StreamChannel;
 use hyprstream_rpc::transport::TransportConfig;
 use tracing::{error, trace};
 
-use crate::services::{Continuation, EnvelopeContext, PolicyClient, ZmqService};
+use crate::services::{Continuation, EnvelopeContext, PolicyClient, RequestService};
 use crate::services::generated::policy_client::PolicyCheck;
 use crate::services::generated::metrics_client::{
     MetricsHandler, MetricsResponseVariant,
@@ -585,11 +585,11 @@ impl MetricsHandler for MetricsService {
 }
 
 // ============================================================================
-// ZmqService
+// RequestService
 // ============================================================================
 
 #[async_trait(?Send)]
-impl ZmqService for MetricsService {
+impl RequestService for MetricsService {
     async fn handle_request(
         &self,
         ctx: &EnvelopeContext,

--- a/crates/hyprstream/src/services/mod.rs
+++ b/crates/hyprstream/src/services/mod.rs
@@ -15,7 +15,7 @@
 //! ```text
 //! ┌─────────────────────────────────────────────────────────────┐
 //! │  hyprstream/src/services/                                   │
-//! │  ├── core.rs      ← ZmqService trait, runners, clients     │
+//! │  ├── core.rs      ← RequestService trait, runners, clients     │
 //! │  ├── types.rs     ← Shared types (FsDirEntry, ModelInfo, etc.)│
 //! │  ├── registry.rs  ← Registry service (REP) + client (REQ)  │
 //! │  └── inference.rs ← Inference service (REP) + client (REQ) │
@@ -24,11 +24,11 @@
 //!
 //! # Usage
 //!
-//! Services implement `ZmqService` with infrastructure methods and are automatically
+//! Services implement `RequestService` with infrastructure methods and are automatically
 //! `Spawnable` via blanket impl:
 //!
 //! ```rust,ignore
-//! use crate::services::{EnvelopeContext, ZmqService};
+//! use crate::services::{EnvelopeContext, RequestService};
 //! use hyprstream_rpc::prelude::*;
 //! use hyprstream_rpc::service::{InprocManager, ServiceManager, Spawnable};
 //! use hyprstream_rpc::transport::TransportConfig;
@@ -41,7 +41,7 @@
 //!     verifying_key: VerifyingKey,
 //! }
 //!
-//! impl ZmqService for MyService {
+//! impl RequestService for MyService {
 //!     fn handle_request(&self, ctx: &EnvelopeContext, payload: &[u8]) -> Result<(Vec<u8>, Option<Continuation>)> {
 //!         // ctx.identity is already verified
 //!         println!("Request from: {}", ctx.subject());
@@ -95,7 +95,7 @@ pub mod typed;
 pub mod worker;
 
 pub use core::{
-    Continuation, EnvelopeContext, ZmqService,
+    Continuation, EnvelopeContext, RequestService,
 };
 
 // Generated client types — the public API

--- a/crates/hyprstream/src/services/model.rs
+++ b/crates/hyprstream/src/services/model.rs
@@ -390,7 +390,7 @@ impl ModelService {
         let fs: Option<crate::services::WorktreeClient> = Some(repo_client.worktree(&branch_name));
 
         // Start InferenceService for this model via standard Spawnable infrastructure
-        let zmq_ctx = Arc::clone(hyprstream_rpc::ZmqService::context(self));
+        let zmq_ctx = Arc::clone(hyprstream_rpc::RequestService::context(self));
         let spawner = hyprstream_service::ServiceSpawner::threaded();
 
         let transport = hyprstream_rpc::transport::TransportConfig::from_endpoint(&endpoint);
@@ -1297,11 +1297,11 @@ impl ModelService {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// ZmqService Implementation — delegates to generated dispatch_model
+// RequestService Implementation — delegates to generated dispatch_model
 // ═══════════════════════════════════════════════════════════════════════════════
 
 #[async_trait(?Send)]
-impl crate::services::ZmqService for ModelService {
+impl crate::services::RequestService for ModelService {
     async fn handle_request(&self, ctx: &EnvelopeContext, payload: &[u8]) -> Result<(Vec<u8>, Option<crate::services::Continuation>)> {
         debug!(
             "Model request from {} (id={})",

--- a/crates/hyprstream/src/services/notification.rs
+++ b/crates/hyprstream/src/services/notification.rs
@@ -31,7 +31,7 @@ use parking_lot::RwLock;
 use tracing::{debug, error, trace, warn};
 use uuid::Uuid;
 
-use crate::services::{Continuation, EnvelopeContext, PolicyClient, ZmqService};
+use crate::services::{Continuation, EnvelopeContext, PolicyClient, RequestService};
 use crate::services::generated::policy_client::PolicyCheck;
 use crate::services::generated::notification_client::{
     NotificationClient, NotificationHandler, NotificationResponseVariant,
@@ -766,11 +766,11 @@ impl NotificationHandler for NotificationService {
 }
 
 // ============================================================================
-// ZmqService implementation
+// RequestService implementation
 // ============================================================================
 
 #[async_trait(?Send)]
-impl ZmqService for NotificationService {
+impl RequestService for NotificationService {
     async fn handle_request(
         &self,
         ctx: &EnvelopeContext,

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -70,7 +70,7 @@ use axum::{
     Router,
 };
 use hyprstream_rpc::registry::SocketKind;
-use hyprstream_rpc::service::{RequestLoop, ZmqService};
+use hyprstream_rpc::service::{RequestLoop, RequestService};
 use hyprstream_rpc::transport::TransportConfig;
 use hyprstream_service::Spawnable;
 use tokio::sync::Notify;
@@ -655,9 +655,9 @@ impl Spawnable for OAuthService {
                     zmq_transport,
                     zmq_signing_key,
                 );
-                let zmq_transport = ZmqService::transport(&handler).clone();
-                let zmq_context = Arc::clone(ZmqService::context(&handler));
-                let zmq_signing_key = ZmqService::signing_key(&handler);
+                let zmq_transport = RequestService::transport(&handler).clone();
+                let zmq_context = Arc::clone(RequestService::context(&handler));
+                let zmq_signing_key = RequestService::signing_key(&handler);
                 let loop_ = RequestLoop::new(zmq_transport, zmq_context, zmq_signing_key);
                 if let Err(e) = loop_.run(handler).await {
                     tracing::error!("OAuth ZMQ loop error: {}", e);

--- a/crates/hyprstream/src/services/oauth/zmq_handler.rs
+++ b/crates/hyprstream/src/services/oauth/zmq_handler.rs
@@ -1,7 +1,7 @@
 //! ZMQ RPC handler for user CRUD operations.
 //!
 //! Implements the `OauthHandler` trait (generated from `oauth.capnp`)
-//! and `ZmqService` for ZMQ transport. Delegates to `UserService` for
+//! and `RequestService` for ZMQ transport. Delegates to `UserService` for
 //! shared CRUD logic.
 
 use std::sync::Arc;
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use hyprstream_rpc::prelude::*;
-use hyprstream_rpc::service::{Continuation, EnvelopeContext, ZmqService};
+use hyprstream_rpc::service::{Continuation, EnvelopeContext, RequestService};
 use hyprstream_rpc::transport::TransportConfig;
 
 use crate::auth::{UserFilter, decode_pubkey_base64};
@@ -25,7 +25,7 @@ use super::state::OAuthState;
 /// ZMQ RPC handler for OAuth user management.
 ///
 /// Wraps `UserService` and implements the generated `OauthHandler` trait
-/// for Cap'n Proto serialization, and `ZmqService` for ZMQ transport.
+/// for Cap'n Proto serialization, and `RequestService` for ZMQ transport.
 pub struct OAuthZmqHandler {
     state: Arc<OAuthState>,
     context: Arc<zmq::Context>,
@@ -266,7 +266,7 @@ impl OauthHandler for OAuthZmqHandler {
 
 
 #[async_trait(?Send)]
-impl ZmqService for OAuthZmqHandler {
+impl RequestService for OAuthZmqHandler {
     async fn handle_request(
         &self,
         ctx: &EnvelopeContext,

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -1,12 +1,12 @@
 //! Policy service for authorization checks over ZMQ
 //!
-//! Wraps PolicyManager and exposes it as a ZmqService.
+//! Wraps PolicyManager and exposes it as a RequestService.
 //! Handlers are async and use `.await` directly (compatible with single-threaded runtime).
 
 use async_trait::async_trait;
 use crate::auth::PolicyManager;
 use crate::auth::policy_templates;
-use crate::services::{EnvelopeContext, ZmqService};
+use crate::services::{EnvelopeContext, RequestService};
 use crate::services::generated::policy_client::{
     ErrorInfo, PolicyHandler, PolicyResponseVariant, TokenInfo, ScopeList,
     PolicyCheck, IssueToken,
@@ -1470,7 +1470,7 @@ impl PolicyHandler for PolicyService {
 }
 
 #[async_trait(?Send)]
-impl ZmqService for PolicyService {
+impl RequestService for PolicyService {
     async fn handle_request(&self, ctx: &EnvelopeContext, payload: &[u8]) -> Result<(Vec<u8>, Option<crate::services::Continuation>)> {
         trace!(
             "Policy request from {} (id={})",

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -6,7 +6,7 @@
 use crate::services::PolicyClient;
 use crate::services::types::{MAX_FDS_GLOBAL, MAX_FDS_PER_CLIENT};
 use hyprstream_containedfs::{ContainedFs, FsError, FsHandle};
-use crate::services::{EnvelopeContext, ZmqService};
+use crate::services::{EnvelopeContext, RequestService};
 use hyprstream_rpc::transport::TransportConfig;
 use hyprstream_rpc::prelude::*;
 use hyprstream_rpc::registry::{global as endpoint_registry, SocketKind};
@@ -297,7 +297,7 @@ impl FidTable {
 /// 4. Continuation publishes clone progress via PUB/SUB
 ///
 /// The registry is wrapped in RwLock for interior mutability since some operations
-/// (like clone) require mutable access but ZmqService::handle_request takes &self.
+/// (like clone) require mutable access but RequestService::handle_request takes &self.
 pub struct RegistryService {
     // Business logic
     registry: Arc<RwLock<Git2DB>>,
@@ -2660,7 +2660,7 @@ impl WorktreeHandler for RegistryService {
 }
 
 #[async_trait(?Send)]
-impl ZmqService for RegistryService {
+impl RequestService for RegistryService {
     async fn handle_request(&self, ctx: &EnvelopeContext, payload: &[u8]) -> Result<(Vec<u8>, Option<crate::services::Continuation>)> {
         dispatch_registry(self, ctx, payload).await
     }

--- a/crates/hyprstream/src/services/worker.rs
+++ b/crates/hyprstream/src/services/worker.rs
@@ -45,7 +45,7 @@ use crate::services::PolicyClient;
 /// Build an `AuthorizeFn` backed by a `PolicyClient`.
 ///
 /// The returned closure is async-compatible (returns a boxed future) so it
-/// works on single-threaded runtimes used by ZmqService.
+/// works on single-threaded runtimes used by RequestService.
 pub fn build_authorize_fn(policy_client: PolicyClient) -> AuthorizeFn {
     Arc::new(move |subject: String, resource: String, operation: String| {
         let client = policy_client.clone();

--- a/crates/hyprstream/src/tui/service.rs
+++ b/crates/hyprstream/src/tui/service.rs
@@ -1,6 +1,6 @@
 //! TuiService — ZMQ RPC service for the TUI multiplexer.
 //!
-//! Implements `ZmqService` for the TUI display server. Manages sessions,
+//! Implements `RequestService` for the TUI display server. Manages sessions,
 //! windows, and panes via RPC. Frame publishing is handled separately
 //! by the frame loop task (not in the service struct).
 
@@ -21,7 +21,7 @@ use hyprstream_rpc::prelude::*;
 use hyprstream_rpc::streaming::{
     BatchingConfig, StreamChannel, StreamContext, StreamPublisher, StreamPublisherConfig,
 };
-use hyprstream_rpc::{EnvelopeContext, ZmqService, Continuation};
+use hyprstream_rpc::{EnvelopeContext, RequestService, Continuation};
 
 use crate::tui_capnp;
 use crate::services::PolicyClient;
@@ -134,11 +134,11 @@ pub struct TuiService {
     state: Arc<RwLock<TuiState>>,
     /// Next viewer ID counter (atomic for Send+Sync).
     next_viewer_id: AtomicU32,
-    /// ZMQ context (required by ZmqService).
+    /// ZMQ context (required by RequestService).
     context: Arc<zmq::Context>,
-    /// Transport config (required by ZmqService).
+    /// Transport config (required by RequestService).
     transport: TransportConfig,
-    /// Signing key (required by ZmqService).
+    /// Signing key (required by RequestService).
     signing_key: SigningKey,
     /// Per-session viewer registration channels + frame loop tokens.
     sessions: SessionRegistry,
@@ -1614,7 +1614,7 @@ impl TuiService {
 }
 
 #[async_trait(?Send)]
-impl ZmqService for TuiService {
+impl RequestService for TuiService {
     async fn handle_request(
         &self,
         _ctx: &EnvelopeContext,

--- a/crates/hyprstream/tests/policy_over_iroh.rs
+++ b/crates/hyprstream/tests/policy_over_iroh.rs
@@ -83,7 +83,7 @@ async fn make_policy_service() -> Result<(PolicyService, SigningKey, TempDir)> {
         TokenConfig::default(),
         git2db,
         // Unused on the iroh path — the bridge never touches the ZMQ
-        // transport bits of ZmqService, just `handle_request` + envelope
+        // transport bits of RequestService, just `handle_request` + envelope
         // metadata.
         Arc::new(zmq::Context::new()),
         TransportConfig::inproc("policy-over-iroh-unused"),


### PR DESCRIPTION
Workspace-wide rename `ZmqService → RequestService` (147 sites, 6 crates) + a transitional `pub use RequestService as ZmqService` alias (removed in #138 at ZMQ teardown). Pure refactor; no behaviour change.

📚 Stacked PR — **base: `ewindisch/moq-m1`**. Part of epic #131.
