### PR TITLE
M3: nested-COSE hybrid envelope (#152) + fail-closed Hybrid (#160) + StreamRegister hybrid (#161)

### DIFF
--- a/crates/hyprstream-rpc/Cargo.toml
+++ b/crates/hyprstream-rpc/Cargo.toml
@@ -34,9 +34,10 @@ rand = { workspace = true }
 # FIPS mode (optional)
 p256 = { workspace = true, optional = true }
 
-# Post-quantum hybrid (optional)
-ml-dsa = { workspace = true, optional = true }
-ml-kem = { workspace = true, optional = true }
+# Post-quantum hybrid — always compiled (PQ mode is selected at RUNTIME via
+# CryptoPolicy, not at compile time). See M3 (#152).
+ml-dsa = { workspace = true }
+ml-kem = { workspace = true }
 
 # Shared deps — all targets
 anyhow = { workspace = true }
@@ -114,7 +115,10 @@ systemd = { version = "0.10", optional = true }
 [features]
 default = []
 fips = ["p256", "hmac"]  # FIPS mode uses P-256 + HMAC-SHA256 (hkdf is always enabled)
-pq-hybrid = ["ml-dsa", "ml-kem"]  # Post-quantum hybrid: ML-DSA-65 signatures + ML-KEM-768 KEM
+# `pq-hybrid` is retained as a NO-OP alias for source/build compatibility.
+# Post-quantum primitives (ML-DSA-65 + ML-KEM-768) are now ALWAYS compiled;
+# Classical vs Hybrid is selected at runtime via `crypto::CryptoPolicy`. See M3.
+pq-hybrid = []
 systemd = ["dep:systemd"]
 
 [build-dependencies]

--- a/crates/hyprstream-rpc/schema/common.capnp
+++ b/crates/hyprstream-rpc/schema/common.capnp
@@ -72,13 +72,18 @@ struct RequestEnvelope {
 #   Decryption: X25519 DH(server_sk, clientEphemeralPublic) -> AES-256-GCM-SIV
 struct SignedEnvelope {
   envelope @0 :RequestEnvelope;    # Cleartext envelope (used when encryptedEnvelope is absent)
-  sig @1 :Data $fixedSize(64);     # Ed25519 signature (64 bytes)
-  cnf @2 :Data $fixedSize(32);     # Ed25519 public key (32 bytes)
+  sig @1 :Data $fixedSize(64);     # Ed25519 signature (64 bytes) — cnf, sig retained for the
+  cnf @2 :Data $fixedSize(32);     # signer-pubkey advertisement + transition; auth comes from `cose`.
   encryptedEnvelope @3 :Data;      # AES-256-GCM-SIV ciphertext of serialized RequestEnvelope
   clientEphemeralPublic @4 :Data $fixedSize(32);  # X25519 ephemeral public key for DH
-  pqSig @5 :Data;                  # ML-DSA-65 signature (3309 bytes when present, pq-hybrid)
-  pqCnf @6 :Data;                  # ML-DSA-65 verifying key (1952 bytes when present, pq-hybrid)
-  pqKemCiphertext @7 :Data;        # ML-KEM-768 ciphertext (1088 bytes when present, pq-hybrid)
+  # M3 (#152): COSE composite signature (RFC 9052 COSE_Sign), detached over the
+  # canonical RequestEnvelope (cleartext) or the encrypted signing-data.
+  #   - Classical mode: ONE EdDSA COSE_Signature entry.
+  #   - Hybrid mode: TWO entries (EdDSA + ML-DSA-65).
+  # The ML-DSA-65 verifying key is NOT carried here; it is resolved by kid from
+  # the trust store (kid-anchored), fixing the prior self-certification gap.
+  cose @5 :Data;                   # CBOR-encoded COSE_Sign (composite signatures)
+  pqKemCiphertext @6 :Data;        # ML-KEM-768 ciphertext (1088 bytes) for hybrid encryption
 }
 
 # Signed response envelope

--- a/crates/hyprstream-rpc/src/auth/jwt.rs
+++ b/crates/hyprstream-rpc/src/auth/jwt.rs
@@ -30,7 +30,6 @@ pub enum JwkThumbprintInput<'a> {
     Rsa { n: &'a str, e: &'a str },
     /// AKP / ML-DSA-65 (draft-ietf-cose-dilithium-11): canonical
     /// `{"alg":"ML-DSA-65","kty":"AKP","pub":"<base64url>"}`
-    #[cfg(feature = "pq-hybrid")]
     Akp { alg: &'a str, pub_bytes: &'a [u8] },
 }
 
@@ -52,7 +51,6 @@ pub fn jwk_thumbprint(input: &JwkThumbprintInput<'_>) -> String {
         JwkThumbprintInput::Rsa { n, e } => {
             format!(r#"{{"e":"{}","kty":"RSA","n":"{}"}}"#, e, n)
         }
-        #[cfg(feature = "pq-hybrid")]
         JwkThumbprintInput::Akp { alg, pub_bytes } => {
             let pub_b64 = URL_SAFE_NO_PAD.encode(pub_bytes);
             format!(r#"{{"alg":"{}","kty":"AKP","pub":"{}"}}"#, alg, pub_b64)
@@ -320,7 +318,6 @@ pub fn decode_unverified(token: &str) -> Result<Claims, JwtError> {
 /// Uses lenient audience validation (same as `decode_with_key`): if
 /// `expected_aud` is `Some`, a wrong `aud` is rejected but an absent
 /// `aud` is accepted.
-#[cfg(feature = "pq-hybrid")]
 pub fn decode_ml_dsa_65(
     token: &str,
     vk: &crate::crypto::pq::MlDsaVerifyingKey,
@@ -379,7 +376,6 @@ pub fn decode_ml_dsa_65(
 ///
 /// Per draft-ietf-jose-pq-composite-sigs, the signature is
 /// `ml_dsa_sig (3309 bytes) ∥ ed25519_sig (64 bytes)`.
-#[cfg(feature = "pq-hybrid")]
 pub fn decode_composite(
     token: &str,
     ml_dsa_vk: &crate::crypto::pq::MlDsaVerifyingKey,

--- a/crates/hyprstream-rpc/src/auth/key_source.rs
+++ b/crates/hyprstream-rpc/src/auth/key_source.rs
@@ -23,6 +23,12 @@
 //! let service = MyService::new(...).with_jwt_key_source(key_source);
 //! ```
 
+// The ML-DSA-65 verifying-key list is shared across crates (the rotation task
+// in `hyprstream` and the service factory in `hyprstream-service`) via an
+// `Arc<std::sync::RwLock<..>>` contract, so this module intentionally uses
+// `std::sync::RwLock` for that field rather than `parking_lot::RwLock`.
+#![allow(clippy::disallowed_types)]
+
 use anyhow::Result;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use ed25519_dalek::VerifyingKey;
@@ -64,7 +70,6 @@ pub trait JwtKeySource: Send + Sync + 'static {
     ///
     /// Returns keys for all rotation slots (drain/active/lead) so that tokens
     /// signed by any current slot can be verified. Empty vec disables PQ verification.
-    #[cfg(feature = "pq-hybrid")]
     fn ml_dsa_verifying_keys(&self) -> Vec<crate::crypto::pq::MlDsaVerifyingKey> {
         vec![]
     }
@@ -95,7 +100,6 @@ pub struct ClusterKeySource {
     ca_verifying_key: VerifyingKey,
     local_issuer_url: String,
     local_issuers_vec: Vec<String>,
-    #[cfg(feature = "pq-hybrid")]
     ml_dsa_vks: Arc<std::sync::RwLock<Vec<crate::crypto::pq::MlDsaVerifyingKey>>>,
 }
 
@@ -116,7 +120,6 @@ impl ClusterKeySource {
             ca_verifying_key,
             local_issuer_url,
             local_issuers_vec,
-            #[cfg(feature = "pq-hybrid")]
             ml_dsa_vks: Arc::new(std::sync::RwLock::new(Vec::new())),
         }
     }
@@ -124,7 +127,6 @@ impl ClusterKeySource {
     /// Set the shared ML-DSA-65 verifying key list for PQ-hybrid JWT verification.
     ///
     /// The Arc is shared with the rotation task so keys stay current.
-    #[cfg(feature = "pq-hybrid")]
     pub fn with_ml_dsa_verifying_keys(mut self, vks: Arc<std::sync::RwLock<Vec<crate::crypto::pq::MlDsaVerifyingKey>>>) -> Self {
         self.ml_dsa_vks = vks;
         self
@@ -159,9 +161,8 @@ impl JwtKeySource for ClusterKeySource {
         &self.local_issuers_vec
     }
 
-    #[cfg(feature = "pq-hybrid")]
     fn ml_dsa_verifying_keys(&self) -> Vec<crate::crypto::pq::MlDsaVerifyingKey> {
-        self.ml_dsa_vks.read().unwrap_or_else(|p| p.into_inner()).clone()
+        self.ml_dsa_vks.read().unwrap_or_else(std::sync::PoisonError::into_inner).clone()
     }
 }
 
@@ -214,7 +215,6 @@ impl JwtKeySource for FederatedKeySource {
         self.local.local_issuers()
     }
 
-    #[cfg(feature = "pq-hybrid")]
     fn ml_dsa_verifying_keys(&self) -> Vec<crate::crypto::pq::MlDsaVerifyingKey> {
         self.local.ml_dsa_verifying_keys()
     }
@@ -283,7 +283,6 @@ pub struct JwksKeySource {
     soft_ttl: std::time::Duration,
     /// Negative cache TTL (unknown kids cached as missing for this duration)
     negative_ttl: std::time::Duration,
-    #[cfg(feature = "pq-hybrid")]
     ml_dsa_vks: Arc<std::sync::RwLock<Vec<crate::crypto::pq::MlDsaVerifyingKey>>>,
 }
 
@@ -305,13 +304,11 @@ impl JwksKeySource {
             fetch_semaphore: Semaphore::new(4),
             soft_ttl: std::time::Duration::from_secs(300),
             negative_ttl: std::time::Duration::from_secs(5),
-            #[cfg(feature = "pq-hybrid")]
             ml_dsa_vks: Arc::new(std::sync::RwLock::new(Vec::new())),
         }
     }
 
     /// Set the shared ML-DSA-65 verifying key list for PQ-hybrid JWT verification.
-    #[cfg(feature = "pq-hybrid")]
     pub fn with_ml_dsa_verifying_keys(mut self, vks: Arc<std::sync::RwLock<Vec<crate::crypto::pq::MlDsaVerifyingKey>>>) -> Self {
         self.ml_dsa_vks = vks;
         self
@@ -491,9 +488,8 @@ impl JwtKeySource for JwksKeySource {
         &self.local_issuers_vec
     }
 
-    #[cfg(feature = "pq-hybrid")]
     fn ml_dsa_verifying_keys(&self) -> Vec<crate::crypto::pq::MlDsaVerifyingKey> {
-        self.ml_dsa_vks.read().unwrap_or_else(|p| p.into_inner()).clone()
+        self.ml_dsa_vks.read().unwrap_or_else(std::sync::PoisonError::into_inner).clone()
     }
 
     fn kid_algs(&self, kid: &str) -> Vec<String> {

--- a/crates/hyprstream-rpc/src/crypto/cose_sign.rs
+++ b/crates/hyprstream-rpc/src/crypto/cose_sign.rs
@@ -1,0 +1,563 @@
+//! Nested-COSE **Strong-Non-Separable (SNS)** composite signing for the
+//! hyprstream `SignedEnvelope` (EdDSA + ML-DSA-65).
+//!
+//! M3 (#152) migrates envelope authentication to a **nested COSE composite**.
+//! A prior design used a `COSE_Sign` with two *independent* signatures over the
+//! same payload (concatenation / Weak-Non-Separable, WNS). A security review
+//! found that scheme **fail-open + strippable**: an attacker could remove the
+//! ML-DSA-65 signature and the remaining EdDSA-only object still verified under
+//! a verifier that did not actively require the PQ entry. This module replaces
+//! it with a **Strong-Non-Separable (SNS)** nesting:
+//!
+//! ```text
+//! Classical:
+//!   inner  = EdDSA   COSE_Sign1 over  payload                       (detached)
+//!
+//! Hybrid (SNS):
+//!   inner  = EdDSA   COSE_Sign1 over  payload                       (detached)
+//!   outer  = ML-DSA  COSE_Sign1 over  payload ‖ inner_eddsa_sig     (detached)
+//! ```
+//!
+//! Both layers bind the same `external_aad` (the CBOR `[envelope_schema_id,
+//! inner_type_id]` schema binding, see [`crate::crypto::cose_sign1::build_external_aad`]).
+//!
+//! # Why this is SNS
+//!
+//! - The OUTER ML-DSA-65 signature covers `payload ‖ inner_eddsa_signature`, so
+//!   the inner signature is *part of the outer's signed message*. Tampering with
+//!   or removing the inner EdDSA signature invalidates the outer.
+//! - Under Hybrid policy the verifier REQUIRES the outer ML-DSA-65 layer and an
+//!   anchored PQ key. **Stripping the outer fails the policy** (there is no
+//!   valid outer to verify), so a downgrade-to-classical attack is rejected.
+//! - The PQ key is kid-anchored: it is resolved from a [`PqTrustStore`] keyed by
+//!   the EdDSA signer identity, never self-asserted in the COSE object. This
+//!   closes the prior self-certification weakness.
+//!
+//! # Wire shape (`SignedEnvelope.cose`)
+//!
+//! A definite-length CBOR array of two entries:
+//!
+//! ```text
+//! [ inner_cose_sign1_bytes : bstr,
+//!   outer_cose_sign1_bytes : bstr / null ]   ; null in Classical mode
+//! ```
+//!
+//! The signed payloads are *detached* (never embedded). Each COSE_Sign1 carries
+//! its signer's `kid` + `alg` in its protected header.
+
+use anyhow::{anyhow, bail, Context, Result};
+use ciborium::value::Value as CborValue;
+use coset::{
+    iana::{self, EnumI64},
+    CborSerializable, CoseSign1, CoseSign1Builder, HeaderBuilder,
+};
+
+use crate::crypto::pq::{ml_dsa_sign, ml_dsa_verify, MlDsaSigningKey, MlDsaVerifyingKey};
+
+/// IANA COSE algorithm id for ML-DSA-65 (FIPS 204, draft-ietf-cose-dilithium).
+pub const ALG_ML_DSA_65: i64 = iana::Algorithm::ML_DSA_65 as i64;
+
+/// EdDSA kid convention: raw 32-byte Ed25519 verifying key.
+fn eddsa_kid(vk: &ed25519_dalek::VerifyingKey) -> Vec<u8> {
+    vk.to_bytes().to_vec()
+}
+
+/// ML-DSA-65 kid convention: raw verifying key bytes (1952 bytes).
+fn ml_dsa_kid(vk: &MlDsaVerifyingKey) -> Vec<u8> {
+    crate::crypto::pq::ml_dsa_vk_bytes(vk)
+}
+
+/// Build the inner EdDSA `COSE_Sign1` over the detached `payload`.
+fn build_inner_eddsa(
+    ed_sk: &ed25519_dalek::SigningKey,
+    payload: &[u8],
+    external_aad: &[u8],
+) -> Result<CoseSign1> {
+    use ed25519_dalek::Signer as _;
+    let protected = HeaderBuilder::new()
+        .algorithm(iana::Algorithm::EdDSA)
+        .key_id(eddsa_kid(&ed_sk.verifying_key()))
+        .build();
+    Ok(CoseSign1Builder::new()
+        .protected(protected)
+        .create_detached_signature(payload, external_aad, |tbs| {
+            ed_sk.sign(tbs).to_bytes().to_vec()
+        })
+        .build())
+}
+
+/// Build the outer ML-DSA-65 `COSE_Sign1` over the detached
+/// `payload ‖ inner_eddsa_signature` (the SNS binding).
+fn build_outer_mldsa(
+    pq_sk: &MlDsaSigningKey,
+    outer_payload: &[u8],
+    external_aad: &[u8],
+) -> Result<CoseSign1> {
+    use ml_dsa::Keypair;
+    let pq_vk = pq_sk.verifying_key().clone();
+    let protected = HeaderBuilder::new()
+        .algorithm(iana::Algorithm::ML_DSA_65)
+        .key_id(ml_dsa_kid(&pq_vk))
+        .build();
+    Ok(CoseSign1Builder::new()
+        .protected(protected)
+        .create_detached_signature(outer_payload, external_aad, |tbs| ml_dsa_sign(pq_sk, tbs))
+        .build())
+}
+
+/// Encode the nested composite as a 2-element CBOR array
+/// `[inner_bstr, outer_bstr | null]`.
+fn encode_composite(inner: Vec<u8>, outer: Option<Vec<u8>>) -> Result<Vec<u8>> {
+    let arr = CborValue::Array(vec![
+        CborValue::Bytes(inner),
+        match outer {
+            Some(o) => CborValue::Bytes(o),
+            None => CborValue::Null,
+        },
+    ]);
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&arr, &mut buf)
+        .map_err(|e| anyhow!("failed to encode nested COSE composite: {e}"))?;
+    Ok(buf)
+}
+
+/// Decode the nested composite back into `(inner_bytes, Option<outer_bytes>)`.
+fn decode_composite(bytes: &[u8]) -> Result<(Vec<u8>, Option<Vec<u8>>)> {
+    let value: CborValue = ciborium::de::from_reader(bytes)
+        .map_err(|e| anyhow!("malformed nested COSE composite: {e}"))?;
+    let arr = match value {
+        CborValue::Array(a) => a,
+        _ => bail!("nested COSE composite must be a CBOR array"),
+    };
+    if arr.len() != 2 {
+        bail!("nested COSE composite must have exactly 2 elements, got {}", arr.len());
+    }
+    let inner = match &arr[0] {
+        CborValue::Bytes(b) => b.clone(),
+        _ => bail!("nested COSE composite inner entry must be a byte string"),
+    };
+    let outer = match &arr[1] {
+        CborValue::Null => None,
+        CborValue::Bytes(b) => Some(b.clone()),
+        _ => bail!("nested COSE composite outer entry must be a byte string or null"),
+    };
+    Ok((inner, outer))
+}
+
+/// The raw inner EdDSA signature bytes (64) extracted from an inner COSE_Sign1.
+fn inner_signature_bytes(inner: &CoseSign1) -> &[u8] {
+    &inner.signature
+}
+
+/// Compute the outer payload for the SNS binding: `payload ‖ inner_eddsa_sig`.
+fn outer_payload(payload: &[u8], inner_sig: &[u8]) -> Vec<u8> {
+    let mut v = Vec::with_capacity(payload.len() + inner_sig.len());
+    v.extend_from_slice(payload);
+    v.extend_from_slice(inner_sig);
+    v
+}
+
+/// Sign `payload` (detached) producing the CBOR-encoded nested COSE composite.
+///
+/// - Classical (`pq_sk = None`): single inner EdDSA COSE_Sign1, outer = null.
+/// - Hybrid (`pq_sk = Some`): inner EdDSA over `payload`, outer ML-DSA-65 over
+///   `payload ‖ inner_eddsa_signature` (SNS).
+pub fn sign_composite(
+    ed_sk: &ed25519_dalek::SigningKey,
+    pq_sk: Option<&MlDsaSigningKey>,
+    payload: &[u8],
+    external_aad: &[u8],
+) -> Result<Vec<u8>> {
+    let inner = build_inner_eddsa(ed_sk, payload, external_aad)?;
+    let inner_sig = inner_signature_bytes(&inner).to_vec();
+    let inner_bytes = inner
+        .to_vec()
+        .map_err(|e| anyhow!("failed to serialize inner EdDSA COSE_Sign1: {e}"))?;
+
+    let outer_bytes = match pq_sk {
+        Some(pq) => {
+            let outer_pl = outer_payload(payload, &inner_sig);
+            let outer = build_outer_mldsa(pq, &outer_pl, external_aad)?;
+            Some(
+                outer
+                    .to_vec()
+                    .map_err(|e| anyhow!("failed to serialize outer ML-DSA COSE_Sign1: {e}"))?,
+            )
+        }
+        None => None,
+    };
+
+    encode_composite(inner_bytes, outer_bytes)
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Out-of-band (async / WASM) signing API for the nested SNS composite.
+//
+// Abstract signers (e.g. the WASM `JsSigner`) cannot run inside a synchronous
+// signing closure, so they compute each layer's to-be-signed bytes, sign them
+// out-of-band, and assemble the composite here. The SNS nesting REQUIRES the
+// outer ML-DSA layer to sign `payload ‖ inner_eddsa_signature`, so callers MUST
+// sign the inner first, take its signature, then sign the outer over
+// [`outer_tbs`].
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Build an unsigned inner EdDSA `COSE_Sign1` (protected header only).
+fn unsigned_inner(ed_kid: Vec<u8>) -> CoseSign1 {
+    CoseSign1Builder::new()
+        .protected(
+            HeaderBuilder::new()
+                .algorithm(iana::Algorithm::EdDSA)
+                .key_id(ed_kid)
+                .build(),
+        )
+        .build()
+}
+
+/// Build an unsigned outer ML-DSA-65 `COSE_Sign1` (protected header only).
+fn unsigned_outer(pq_kid: Vec<u8>) -> CoseSign1 {
+    CoseSign1Builder::new()
+        .protected(
+            HeaderBuilder::new()
+                .algorithm(iana::Algorithm::ML_DSA_65)
+                .key_id(pq_kid)
+                .build(),
+        )
+        .build()
+}
+
+/// Compute the inner EdDSA layer's detached to-be-signed bytes.
+pub fn inner_tbs(ed_kid: Vec<u8>, payload: &[u8], external_aad: &[u8]) -> Vec<u8> {
+    unsigned_inner(ed_kid).tbs_detached_data(payload, external_aad)
+}
+
+/// Compute the outer ML-DSA-65 layer's detached to-be-signed bytes over
+/// `payload ‖ inner_eddsa_signature` (the SNS binding).
+pub fn outer_tbs(
+    pq_kid: Vec<u8>,
+    payload: &[u8],
+    inner_eddsa_sig: &[u8],
+    external_aad: &[u8],
+) -> Vec<u8> {
+    let outer_pl = outer_payload(payload, inner_eddsa_sig);
+    unsigned_outer(pq_kid).tbs_detached_data(&outer_pl, external_aad)
+}
+
+/// Assemble the nested SNS composite from out-of-band signatures.
+///
+/// - `ed = (ed_kid, ed_signature)` — required; `ed_signature` is the raw 64-byte
+///   Ed25519 signature over [`inner_tbs`].
+/// - `pq = Some((pq_kid, pq_signature))` — Hybrid; `pq_signature` is the ML-DSA-65
+///   signature over [`outer_tbs`] (which was computed using `ed_signature`).
+pub fn assemble_composite_nested(
+    ed: (Vec<u8>, Vec<u8>),
+    pq: Option<(Vec<u8>, Vec<u8>)>,
+) -> Result<Vec<u8>> {
+    let (ed_kid, ed_sig) = ed;
+    let mut inner = unsigned_inner(ed_kid);
+    inner.signature = ed_sig;
+    let inner_bytes = inner
+        .to_vec()
+        .map_err(|e| anyhow!("serialize inner EdDSA COSE_Sign1: {e}"))?;
+
+    let outer_bytes = match pq {
+        Some((pq_kid, pq_sig)) => {
+            let mut outer = unsigned_outer(pq_kid);
+            outer.signature = pq_sig;
+            Some(
+                outer
+                    .to_vec()
+                    .map_err(|e| anyhow!("serialize outer ML-DSA COSE_Sign1: {e}"))?,
+            )
+        }
+        None => None,
+    };
+
+    encode_composite(inner_bytes, outer_bytes)
+}
+
+/// Test-only: decode a composite into `(inner_bytes, Option<outer_bytes>)`.
+///
+/// Exposed so integration tests in other modules (e.g. `envelope.rs`) can
+/// simulate an attacker stripping the outer ML-DSA layer.
+#[doc(hidden)]
+pub fn decode_composite_for_test(bytes: &[u8]) -> Result<(Vec<u8>, Option<Vec<u8>>)> {
+    decode_composite(bytes)
+}
+
+/// Test-only: re-encode a composite from `(inner_bytes, Option<outer_bytes>)`.
+#[doc(hidden)]
+pub fn encode_composite_for_test(inner: Vec<u8>, outer: Option<Vec<u8>>) -> Result<Vec<u8>> {
+    encode_composite(inner, outer)
+}
+
+/// Outcome of composite verification.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompositeVerified {
+    /// Inner EdDSA was verified.
+    pub eddsa: bool,
+    /// Outer ML-DSA-65 (SNS) was verified.
+    pub ml_dsa: bool,
+}
+
+/// Verify a CBOR-encoded nested COSE composite against a detached `payload`.
+///
+/// # kid-anchoring
+///
+/// `expected_ed_vk` is the EdDSA verifying key resolved by the caller. When
+/// `expected_pq_vk` is `Some`, it is the trust-anchored ML-DSA-65 key — the
+/// outer COSE entry's kid AND signature must verify against it, closing the
+/// self-certification gap.
+///
+/// # Policy
+///
+/// - `require_pq = true` (Hybrid verifier): the OUTER ML-DSA-65 layer MUST be
+///   present and verify against the anchored key over `payload ‖ inner_sig`, AND
+///   the inner EdDSA layer MUST verify over `payload`. If `expected_pq_vk` is
+///   `None`, verification fails (no anchor — fail-closed). **Stripping the outer
+///   layer (outer = null) is rejected.**
+/// - `require_pq = false` (Classical verifier): only the inner EdDSA layer is
+///   required and verified; any outer ML-DSA layer is IGNORED (skip-unknown
+///   interop — a Hybrid-signed envelope still verifies via its inner EdDSA).
+pub fn verify_composite(
+    cose_composite_bytes: &[u8],
+    expected_ed_vk: &ed25519_dalek::VerifyingKey,
+    expected_pq_vk: Option<&MlDsaVerifyingKey>,
+    payload: &[u8],
+    external_aad: &[u8],
+    require_pq: bool,
+) -> Result<CompositeVerified> {
+    let (inner_bytes, outer_bytes) = decode_composite(cose_composite_bytes)?;
+
+    // --- Inner EdDSA layer (always required) ---
+    let inner = CoseSign1::from_slice(&inner_bytes)
+        .map_err(|e| anyhow!("malformed inner EdDSA COSE_Sign1: {e}"))?;
+
+    let inner_alg = header_alg(&inner)?;
+    if inner_alg != iana::Algorithm::EdDSA.to_i64() {
+        bail!("inner COSE_Sign1 must be EdDSA, got alg={inner_alg}");
+    }
+    let inner_kid = &inner.protected.header.key_id;
+    if !inner_kid.is_empty() && inner_kid.as_slice() != expected_ed_vk.to_bytes() {
+        bail!("inner EdDSA COSE_Sign1 kid does not match anchored EdDSA key");
+    }
+    inner
+        .verify_detached_signature(payload, external_aad, |sig, tbs| {
+            ed_verify(expected_ed_vk, tbs, sig)
+        })
+        .context("inner EdDSA signature verification failed")?;
+    let eddsa_ok = true;
+
+    // Capture the inner signature; it is the SNS binding for the outer layer.
+    let inner_sig = inner_signature_bytes(&inner).to_vec();
+
+    // --- Outer ML-DSA-65 layer (SNS) ---
+    let mut ml_dsa_ok = false;
+
+    match outer_bytes {
+        Some(ref ob) if require_pq || expected_pq_vk.is_some() => {
+            // Anchored PQ key is mandatory to verify the outer layer.
+            let Some(pq_vk) = expected_pq_vk else {
+                if require_pq {
+                    bail!("Hybrid policy requires an anchored ML-DSA-65 key, none provided");
+                }
+                // Classical verifier without an anchor: ignore the outer layer.
+                return Ok(CompositeVerified { eddsa: eddsa_ok, ml_dsa: false });
+            };
+            let outer = CoseSign1::from_slice(ob)
+                .map_err(|e| anyhow!("malformed outer ML-DSA COSE_Sign1: {e}"))?;
+            let outer_alg = header_alg(&outer)?;
+            if outer_alg != ALG_ML_DSA_65 {
+                bail!("outer COSE_Sign1 must be ML-DSA-65, got alg={outer_alg}");
+            }
+            let outer_kid = &outer.protected.header.key_id;
+            if !outer_kid.is_empty() && outer_kid.as_slice() != ml_dsa_kid(pq_vk).as_slice() {
+                bail!("outer ML-DSA-65 COSE_Sign1 kid does not match anchored PQ key (self-cert rejected)");
+            }
+            let outer_pl = outer_payload(payload, &inner_sig);
+            outer
+                .verify_detached_signature(&outer_pl, external_aad, |sig, tbs| {
+                    ml_dsa_verify(pq_vk, tbs, sig)
+                })
+                .context("outer ML-DSA-65 signature verification failed")?;
+            ml_dsa_ok = true;
+        }
+        Some(_) => {
+            // require_pq is false and no anchor: ignore outer (skip-unknown).
+        }
+        None => {
+            // No outer layer present (Classical-signed).
+            if require_pq {
+                bail!("Hybrid policy requires the outer ML-DSA-65 layer, but it is absent (stripped or classical-only)");
+            }
+        }
+    }
+
+    if require_pq && !ml_dsa_ok {
+        bail!("Hybrid policy: outer ML-DSA-65 layer missing or unverified");
+    }
+
+    Ok(CompositeVerified { eddsa: eddsa_ok, ml_dsa: ml_dsa_ok })
+}
+
+/// Extract the IANA alg integer from a COSE_Sign1 protected header.
+fn header_alg(cose: &CoseSign1) -> Result<i64> {
+    match cose.protected.header.alg.as_ref() {
+        Some(coset::Algorithm::Assigned(a)) => Ok(a.to_i64()),
+        Some(coset::Algorithm::PrivateUse(v)) => Ok(*v),
+        Some(coset::Algorithm::Text(s)) => bail!("unsupported text algorithm: {s}"),
+        None => bail!("COSE_Sign1 missing alg in protected header"),
+    }
+}
+
+fn ed_verify(vk: &ed25519_dalek::VerifyingKey, msg: &[u8], sig: &[u8]) -> Result<()> {
+    if sig.len() != 64 {
+        bail!("Ed25519 signature must be 64 bytes, got {}", sig.len());
+    }
+    let mut arr = [0u8; 64];
+    arr.copy_from_slice(sig);
+    let signature = ed25519_dalek::Signature::from_bytes(&arr);
+    vk.verify_strict(msg, &signature)
+        .map_err(|e| anyhow!("Ed25519 verification failed: {e}"))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::crypto::cose_sign1::build_external_aad;
+    use crate::crypto::pq::ml_dsa_generate_keypair;
+    use ed25519_dalek::SigningKey;
+    use rand::rngs::OsRng;
+
+    const SCHEMA_ID: u64 = 0xcf5e_016c_5d4a_af92;
+    const INNER_TYPE_ID: u64 = 0xdead_beef_cafe_babe;
+
+    fn aad() -> Vec<u8> {
+        build_external_aad(SCHEMA_ID, INNER_TYPE_ID)
+    }
+
+    #[test]
+    fn classical_sign_verify() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let payload = b"classical payload";
+        let cose = sign_composite(&ed, None, payload, &aad()).unwrap();
+        let res = verify_composite(&cose, &ed.verifying_key(), None, payload, &aad(), false).unwrap();
+        assert!(res.eddsa);
+        assert!(!res.ml_dsa);
+    }
+
+    #[test]
+    fn hybrid_sign_verify_both() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let (pq_sk, pq_vk) = ml_dsa_generate_keypair();
+        let payload = b"hybrid payload";
+        let cose = sign_composite(&ed, Some(&pq_sk), payload, &aad()).unwrap();
+        let res = verify_composite(&cose, &ed.verifying_key(), Some(&pq_vk), payload, &aad(), true).unwrap();
+        assert!(res.eddsa);
+        assert!(res.ml_dsa);
+    }
+
+    #[test]
+    fn hybrid_signed_verified_by_classical_via_eddsa() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let (pq_sk, _pq_vk) = ml_dsa_generate_keypair();
+        let payload = b"cross payload";
+        let cose = sign_composite(&ed, Some(&pq_sk), payload, &aad()).unwrap();
+        // Classical verifier: no PQ key, require_pq=false → inner EdDSA only.
+        let res = verify_composite(&cose, &ed.verifying_key(), None, payload, &aad(), false).unwrap();
+        assert!(res.eddsa);
+        assert!(!res.ml_dsa);
+    }
+
+    #[test]
+    fn classical_signed_rejected_by_hybrid_policy() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let (_pq_sk, pq_vk) = ml_dsa_generate_keypair();
+        let payload = b"classical only";
+        let cose = sign_composite(&ed, None, payload, &aad()).unwrap();
+        // Hybrid verifier requires the outer layer → absent → rejected.
+        let res = verify_composite(&cose, &ed.verifying_key(), Some(&pq_vk), payload, &aad(), true);
+        assert!(res.is_err(), "hybrid policy must reject classical-only (no outer layer)");
+    }
+
+    #[test]
+    fn self_cert_wrong_pq_key_rejected() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let (pq_sk, _pq_vk) = ml_dsa_generate_keypair();
+        let (_other_sk, other_vk) = ml_dsa_generate_keypair();
+        let payload = b"anchored";
+        let cose = sign_composite(&ed, Some(&pq_sk), payload, &aad()).unwrap();
+        let res = verify_composite(&cose, &ed.verifying_key(), Some(&other_vk), payload, &aad(), true);
+        assert!(res.is_err(), "PQ key not matching kid-anchored key must be rejected");
+    }
+
+    #[test]
+    fn tampered_payload_rejected() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let (pq_sk, pq_vk) = ml_dsa_generate_keypair();
+        let cose = sign_composite(&ed, Some(&pq_sk), b"orig", &aad()).unwrap();
+        let res = verify_composite(&cose, &ed.verifying_key(), Some(&pq_vk), b"tampered", &aad(), true);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn wrong_aad_rejected() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let cose = sign_composite(&ed, None, b"p", &aad()).unwrap();
+        let wrong = build_external_aad(SCHEMA_ID, INNER_TYPE_ID ^ 1);
+        let res = verify_composite(&cose, &ed.verifying_key(), None, b"p", &wrong, false);
+        assert!(res.is_err());
+    }
+
+    /// SNS: stripping the outer ML-DSA layer (set to null) must be rejected
+    /// under Hybrid policy. This is the attack the review found accepted before.
+    #[test]
+    fn strip_outer_mldsa_rejected_under_hybrid() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let (pq_sk, pq_vk) = ml_dsa_generate_keypair();
+        let payload = b"strip me";
+        let cose = sign_composite(&ed, Some(&pq_sk), payload, &aad()).unwrap();
+
+        // Strip: rebuild the composite with the outer set to null.
+        let (inner, _outer) = decode_composite(&cose).unwrap();
+        let stripped = encode_composite(inner, None).unwrap();
+
+        let res = verify_composite(&stripped, &ed.verifying_key(), Some(&pq_vk), payload, &aad(), true);
+        assert!(res.is_err(), "stripping the outer ML-DSA layer must fail Hybrid policy");
+    }
+
+    /// SNS: tampering with the inner EdDSA signature invalidates the outer,
+    /// because the outer signs `payload ‖ inner_sig`.
+    #[test]
+    fn tamper_inner_eddsa_invalidates_outer() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let (pq_sk, pq_vk) = ml_dsa_generate_keypair();
+        let payload = b"sns binding";
+        let cose = sign_composite(&ed, Some(&pq_sk), payload, &aad()).unwrap();
+
+        // Re-sign the inner with a DIFFERENT EdDSA key but keep the original
+        // outer. The inner kid won't match the anchored ed_vk, and even if it
+        // did, the outer was bound to the original inner_sig.
+        let (_inner, outer) = decode_composite(&cose).unwrap();
+        let other_ed = SigningKey::generate(&mut OsRng);
+        let forged_inner = build_inner_eddsa(&other_ed, payload, &aad()).unwrap();
+        let forged_inner_bytes = forged_inner.to_vec().unwrap();
+        let tampered = encode_composite(forged_inner_bytes, outer).unwrap();
+
+        // Verify under the ORIGINAL ed_vk + anchored pq_vk: inner kid mismatch
+        // OR outer-binding mismatch → reject.
+        let res = verify_composite(&tampered, &ed.verifying_key(), Some(&pq_vk), payload, &aad(), true);
+        assert!(res.is_err(), "tampering the inner EdDSA must invalidate the composite");
+    }
+
+    /// Hybrid policy with no anchored PQ key must fail closed.
+    #[test]
+    fn hybrid_no_anchor_rejected() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let (pq_sk, _pq_vk) = ml_dsa_generate_keypair();
+        let payload = b"no anchor";
+        let cose = sign_composite(&ed, Some(&pq_sk), payload, &aad()).unwrap();
+        let res = verify_composite(&cose, &ed.verifying_key(), None, payload, &aad(), true);
+        assert!(res.is_err(), "Hybrid policy requires an anchored PQ key");
+    }
+}

--- a/crates/hyprstream-rpc/src/crypto/cose_sign.rs
+++ b/crates/hyprstream-rpc/src/crypto/cose_sign.rs
@@ -1,19 +1,45 @@
-//! Nested-COSE **Strong-Non-Separable (SNS)** composite signing for the
-//! hyprstream `SignedEnvelope` (EdDSA + ML-DSA-65).
+//! Nested-COSE hybrid composite signing for the hyprstream `SignedEnvelope`
+//! (EdDSA + ML-DSA-65).
 //!
-//! M3 (#152) migrates envelope authentication to a **nested COSE composite**.
-//! A prior design used a `COSE_Sign` with two *independent* signatures over the
-//! same payload (concatenation / Weak-Non-Separable, WNS). A security review
-//! found that scheme **fail-open + strippable**: an attacker could remove the
-//! ML-DSA-65 signature and the remaining EdDSA-only object still verified under
-//! a verifier that did not actively require the PQ entry. This module replaces
-//! it with a **Strong-Non-Separable (SNS)** nesting:
+//! ## Where this sits in the PQUIP hybrid-signature taxonomy
+//!
+//! In the taxonomy of `draft-ietf-pquip-hybrid-signature-spectrums` §1.3.4 this
+//! construction is **Weak Non-Separable (WNS)**, *not* Strong Non-Separable
+//! (SNS). SNS requires *fusion* — the two algorithms' signatures combined into a
+//! single object that cannot be verified by either component alone. We do not do
+//! that: we emit two distinct COSE_Sign1 signatures and bind them by nesting
+//! (the outer signs `payload ‖ inner_sig`). A classical-only verifier can — and,
+//! per [`verify_composite`]'s `require_pq = false` path, deliberately does —
+//! accept the inner EdDSA signature on its own. That standalone-acceptability is
+//! exactly what SNS precludes, so labelling this SNS would overstate the
+//! cryptographic guarantee.
+//!
+//! **Downgrade resistance here is enforced by *verifier policy*, not by the
+//! crypto.** It rests on two policy mechanisms, not on non-separability:
+//!   1. `require_pq` (fail-closed Hybrid policy): a Hybrid verifier rejects any
+//!      envelope lacking a valid outer ML-DSA-65 layer, so an attacker who strips
+//!      the outer layer is rejected by *policy* (not because the inner is
+//!      cryptographically unusable without it).
+//!   2. kid-anchoring: the PQ key is resolved from a [`PqTrustStore`] keyed by
+//!      the EdDSA signer identity, never self-asserted in the COSE object —
+//!      closing the self-certification gap a naïve two-signature scheme has.
+//!
+//! ## What the nesting *does* buy
+//!
+//! M3 (#152) replaced an earlier `COSE_Sign` with two *independent* signatures
+//! over the same payload (a fail-open, trivially strippable scheme). The nesting
+//! below is a real improvement over that: because the outer ML-DSA-65 signature
+//! covers `payload ‖ inner_eddsa_signature`, the inner signature is part of the
+//! outer's signed message — so once a verifier has *committed to checking the
+//! outer* (Hybrid policy), it cannot be fed a mismatched inner/outer pair. The
+//! nesting binds the two layers together; the *requirement* to check the outer
+//! at all comes from policy.
 //!
 //! ```text
 //! Classical:
 //!   inner  = EdDSA   COSE_Sign1 over  payload                       (detached)
 //!
-//! Hybrid (SNS):
+//! Hybrid (WNS, policy-enforced):
 //!   inner  = EdDSA   COSE_Sign1 over  payload                       (detached)
 //!   outer  = ML-DSA  COSE_Sign1 over  payload ‖ inner_eddsa_sig     (detached)
 //! ```
@@ -21,17 +47,12 @@
 //! Both layers bind the same `external_aad` (the CBOR `[envelope_schema_id,
 //! inner_type_id]` schema binding, see [`crate::crypto::cose_sign1::build_external_aad`]).
 //!
-//! # Why this is SNS
-//!
-//! - The OUTER ML-DSA-65 signature covers `payload ‖ inner_eddsa_signature`, so
-//!   the inner signature is *part of the outer's signed message*. Tampering with
-//!   or removing the inner EdDSA signature invalidates the outer.
-//! - Under Hybrid policy the verifier REQUIRES the outer ML-DSA-65 layer and an
-//!   anchored PQ key. **Stripping the outer fails the policy** (there is no
-//!   valid outer to verify), so a downgrade-to-classical attack is rejected.
-//! - The PQ key is kid-anchored: it is resolved from a [`PqTrustStore`] keyed by
-//!   the EdDSA signer identity, never self-asserted in the COSE object. This
-//!   closes the prior self-certification weakness.
+//! Note the `external_aad` does **not** currently carry a hybrid-composite
+//! algorithm identifier, so the inner EdDSA COSE_Sign1 produced in Hybrid mode is
+//! byte-identical to one produced in Classical mode. Binding a composite alg-id
+//! into the AAD would move this construction closer to true non-separability —
+//! but at the cost of the deliberate classical-verifier interop documented on
+//! [`verify_composite`]. That trade-off is tracked as a follow-up; see #152.
 //!
 //! # Wire shape (`SignedEnvelope.cose`)
 //!
@@ -87,7 +108,7 @@ fn build_inner_eddsa(
 }
 
 /// Build the outer ML-DSA-65 `COSE_Sign1` over the detached
-/// `payload ‖ inner_eddsa_signature` (the SNS binding).
+/// `payload ‖ inner_eddsa_signature` (the inner→outer binding).
 fn build_outer_mldsa(
     pq_sk: &MlDsaSigningKey,
     outer_payload: &[u8],
@@ -149,7 +170,7 @@ fn inner_signature_bytes(inner: &CoseSign1) -> &[u8] {
     &inner.signature
 }
 
-/// Compute the outer payload for the SNS binding: `payload ‖ inner_eddsa_sig`.
+/// Compute the outer payload for the inner→outer binding: `payload ‖ inner_eddsa_sig`.
 fn outer_payload(payload: &[u8], inner_sig: &[u8]) -> Vec<u8> {
     let mut v = Vec::with_capacity(payload.len() + inner_sig.len());
     v.extend_from_slice(payload);
@@ -161,7 +182,7 @@ fn outer_payload(payload: &[u8], inner_sig: &[u8]) -> Vec<u8> {
 ///
 /// - Classical (`pq_sk = None`): single inner EdDSA COSE_Sign1, outer = null.
 /// - Hybrid (`pq_sk = Some`): inner EdDSA over `payload`, outer ML-DSA-65 over
-///   `payload ‖ inner_eddsa_signature` (SNS).
+///   `payload ‖ inner_eddsa_signature` (the inner→outer binding).
 pub fn sign_composite(
     ed_sk: &ed25519_dalek::SigningKey,
     pq_sk: Option<&MlDsaSigningKey>,
@@ -191,11 +212,11 @@ pub fn sign_composite(
 }
 
 // ────────────────────────────────────────────────────────────────────────────
-// Out-of-band (async / WASM) signing API for the nested SNS composite.
+// Out-of-band (async / WASM) signing API for the nested WNS composite.
 //
 // Abstract signers (e.g. the WASM `JsSigner`) cannot run inside a synchronous
 // signing closure, so they compute each layer's to-be-signed bytes, sign them
-// out-of-band, and assemble the composite here. The SNS nesting REQUIRES the
+// out-of-band, and assemble the composite here. The nesting REQUIRES the
 // outer ML-DSA layer to sign `payload ‖ inner_eddsa_signature`, so callers MUST
 // sign the inner first, take its signature, then sign the outer over
 // [`outer_tbs`].
@@ -231,7 +252,7 @@ pub fn inner_tbs(ed_kid: Vec<u8>, payload: &[u8], external_aad: &[u8]) -> Vec<u8
 }
 
 /// Compute the outer ML-DSA-65 layer's detached to-be-signed bytes over
-/// `payload ‖ inner_eddsa_signature` (the SNS binding).
+/// `payload ‖ inner_eddsa_signature` (the inner→outer binding).
 pub fn outer_tbs(
     pq_kid: Vec<u8>,
     payload: &[u8],
@@ -242,7 +263,7 @@ pub fn outer_tbs(
     unsigned_outer(pq_kid).tbs_detached_data(&outer_pl, external_aad)
 }
 
-/// Assemble the nested SNS composite from out-of-band signatures.
+/// Assemble the nested WNS composite from out-of-band signatures.
 ///
 /// - `ed = (ed_kid, ed_signature)` — required; `ed_signature` is the raw 64-byte
 ///   Ed25519 signature over [`inner_tbs`].
@@ -295,7 +316,7 @@ pub fn encode_composite_for_test(inner: Vec<u8>, outer: Option<Vec<u8>>) -> Resu
 pub struct CompositeVerified {
     /// Inner EdDSA was verified.
     pub eddsa: bool,
-    /// Outer ML-DSA-65 (SNS) was verified.
+    /// Outer ML-DSA-65 layer was verified.
     pub ml_dsa: bool,
 }
 
@@ -347,10 +368,10 @@ pub fn verify_composite(
         .context("inner EdDSA signature verification failed")?;
     let eddsa_ok = true;
 
-    // Capture the inner signature; it is the SNS binding for the outer layer.
+    // Capture the inner signature; it is bound into the outer layer's signed message.
     let inner_sig = inner_signature_bytes(&inner).to_vec();
 
-    // --- Outer ML-DSA-65 layer (SNS) ---
+    // --- Outer ML-DSA-65 layer (inner→outer binding) ---
     let mut ml_dsa_ok = false;
 
     match outer_bytes {
@@ -509,7 +530,7 @@ mod tests {
         assert!(res.is_err());
     }
 
-    /// SNS: stripping the outer ML-DSA layer (set to null) must be rejected
+    /// Policy-enforced: stripping the outer ML-DSA layer (set to null) must be rejected
     /// under Hybrid policy. This is the attack the review found accepted before.
     #[test]
     fn strip_outer_mldsa_rejected_under_hybrid() {
@@ -526,7 +547,7 @@ mod tests {
         assert!(res.is_err(), "stripping the outer ML-DSA layer must fail Hybrid policy");
     }
 
-    /// SNS: tampering with the inner EdDSA signature invalidates the outer,
+    /// inner→outer binding: tampering with the inner EdDSA signature invalidates the outer,
     /// because the outer signs `payload ‖ inner_sig`.
     #[test]
     fn tamper_inner_eddsa_invalidates_outer() {

--- a/crates/hyprstream-rpc/src/crypto/envelope_crypto.rs
+++ b/crates/hyprstream-rpc/src/crypto/envelope_crypto.rs
@@ -99,7 +99,6 @@ pub fn decrypt_envelope(
 ///
 /// Two shared secrets are derived independently and combined via KDF.
 /// Returns `(ciphertext, ephemeral_public, kem_ciphertext)`.
-#[cfg(feature = "pq-hybrid")]
 pub fn encrypt_envelope_hybrid(
     plaintext: &[u8],
     server_ed25519_pubkey: &VerifyingKey,
@@ -132,7 +131,6 @@ pub fn encrypt_envelope_hybrid(
 }
 
 /// Hybrid envelope decryption: X25519 DH + ML-KEM-768 + AES-256-GCM-SIV.
-#[cfg(feature = "pq-hybrid")]
 pub fn decrypt_envelope_hybrid(
     ciphertext: &[u8],
     client_ephemeral_public: &[u8; 32],
@@ -161,7 +159,6 @@ pub fn decrypt_envelope_hybrid(
 }
 
 /// Derive AES-256 key from combined X25519 + ML-KEM shared secrets.
-#[cfg(feature = "pq-hybrid")]
 fn derive_hybrid_envelope_key(
     shared_x25519: &[u8; 32],
     shared_kem: &[u8; 32],
@@ -238,7 +235,6 @@ mod tests {
         assert_ne!(ct1, ct2);
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn hybrid_roundtrip() {
         let server_key = SigningKey::generate(&mut OsRng);
@@ -257,7 +253,6 @@ mod tests {
         assert_eq!(decrypted, plaintext);
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn hybrid_wrong_kem_key_fails() {
         let server_key = SigningKey::generate(&mut OsRng);

--- a/crates/hyprstream-rpc/src/crypto/mod.rs
+++ b/crates/hyprstream-rpc/src/crypto/mod.rs
@@ -28,14 +28,41 @@
 
 pub mod backend;
 pub mod cose_sign1;
+pub mod cose_sign;
 pub mod envelope_crypto;
 pub mod event_crypto;
 pub mod hmac;
 pub mod key_exchange;
 pub mod notification;
-#[cfg(feature = "pq-hybrid")]
 pub mod pq;
 pub mod signing;
+
+/// Runtime crypto mode selecting how envelopes/tokens are signed and verified.
+///
+/// This REPLACES the old compile-time `pq-hybrid` cargo feature. PQ primitives
+/// (ML-DSA-65, ML-KEM-768) are always compiled; the policy chooses whether they
+/// are used at runtime.
+///
+/// - `Hybrid` (default): sign with a COSE composite (EdDSA + ML-DSA-65) and
+///   REQUIRE both components to verify.
+/// - `Classical`: sign with EdDSA only and accept EdDSA-only signatures. A
+///   `Classical` verifier still accepts a `Hybrid`-signed item via its EdDSA
+///   component (RFC 7517 skip-unknown interop).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CryptoPolicy {
+    /// EdDSA only (classical).
+    Classical,
+    /// EdDSA + ML-DSA-65 composite (post-quantum hybrid). Default.
+    #[default]
+    Hybrid,
+}
+
+impl CryptoPolicy {
+    /// Whether this policy emits/requires the post-quantum (ML-DSA-65) component.
+    pub fn uses_pq(self) -> bool {
+        matches!(self, CryptoPolicy::Hybrid)
+    }
+}
 
 pub use backend::{derive_key, keyed_mac, keyed_mac_truncated};
 pub use hmac::StreamHmacState;

--- a/crates/hyprstream-rpc/src/crypto/pq.rs
+++ b/crates/hyprstream-rpc/src/crypto/pq.rs
@@ -1,6 +1,7 @@
 //! Post-quantum hybrid cryptographic primitives (ML-DSA-65 + ML-KEM-768).
 //!
-//! Gated behind `#[cfg(feature = "pq-hybrid")]`. Provides:
+//! Always compiled (M3 #152). Whether these are USED is a runtime decision via
+//! [`crate::crypto::CryptoPolicy`], not a compile-time cargo feature. Provides:
 //! - ML-DSA-65 (FIPS 204) digital signatures
 //! - ML-KEM-768 (FIPS 203) key encapsulation
 

--- a/crates/hyprstream-rpc/src/envelope.rs
+++ b/crates/hyprstream-rpc/src/envelope.rs
@@ -33,7 +33,7 @@ use crate::common_capnp;
 use crate::crypto::{SigningKey, VerifyingKey};
 use crate::error::{EnvelopeError, EnvelopeResult};
 use anyhow::{anyhow, Result};
-use ed25519_dalek::{Signature, Signer};
+use ed25519_dalek::Signer;
 use subtle::ConstantTimeEq;
 use std::fmt;
 use std::str::FromStr;
@@ -223,6 +223,19 @@ pub enum EnvelopeVerification<'a> {
 }
 
 /// Options controlling envelope unwrap, verification, and optional decryption.
+///
+/// # Crypto policy (fail-closed default)
+///
+/// `verify_policy` defaults to [`CryptoPolicy::default()`] which is **Hybrid
+/// ENFORCED**. Under Hybrid the verifier REQUIRES the outer ML-DSA-65 SNS layer
+/// anchored to a [`PqTrustStore`] entry — stripping the outer layer or signing
+/// classical-only is rejected. To verify against a kid-anchored PQ key, callers
+/// MUST supply `pq_store`; under Hybrid with no resolvable anchor the envelope
+/// is **rejected** (fail-closed), never accepted as classical.
+///
+/// Callers that genuinely need the legacy classical-only path (e.g. WASM in-
+/// browser verification without a PQ trust store) must explicitly downgrade via
+/// [`UnwrapOptions::classical`].
 pub struct UnwrapOptions<'a> {
     /// How to verify the envelope signer.
     pub verification: EnvelopeVerification<'a>,
@@ -232,27 +245,61 @@ pub struct UnwrapOptions<'a> {
     /// When present and the envelope has `encrypted_envelope`, the server's
     /// Ed25519 key is converted to X25519 for DH decryption.
     pub decryption_key: Option<&'a crate::crypto::SigningKey>,
+    /// kid-anchored ML-DSA-65 trust store used to resolve the PQ verifying key
+    /// for the envelope's EdDSA signer. Required under Hybrid policy.
+    pub pq_store: Option<&'a dyn PqTrustStore>,
+    /// Verification policy enforced at this site. Defaults to Hybrid (enforced).
+    pub verify_policy: crate::crypto::CryptoPolicy,
 }
 
 impl<'a> UnwrapOptions<'a> {
+    /// Fixed-signer verification under the default (Hybrid-enforced) policy.
     pub fn fixed_signer(pubkey: &'a VerifyingKey, nonce_cache: &'a dyn NonceCache) -> Self {
         Self {
             verification: EnvelopeVerification::FixedSigner(pubkey),
             nonce_cache,
             decryption_key: None,
+            pq_store: None,
+            verify_policy: crate::crypto::CryptoPolicy::default(),
         }
     }
 
+    /// Any-signer verification under the default (Hybrid-enforced) policy.
     pub fn any_signer(nonce_cache: &'a dyn NonceCache) -> Self {
         Self {
             verification: EnvelopeVerification::AnySigner,
             nonce_cache,
             decryption_key: None,
+            pq_store: None,
+            verify_policy: crate::crypto::CryptoPolicy::default(),
         }
     }
 
     pub fn with_decryption_key(mut self, key: &'a crate::crypto::SigningKey) -> Self {
         self.decryption_key = Some(key);
+        self
+    }
+
+    /// Attach a kid-anchored ML-DSA-65 trust store (required under Hybrid).
+    pub fn with_pq_store(mut self, store: &'a dyn PqTrustStore) -> Self {
+        self.pq_store = Some(store);
+        self
+    }
+
+    /// Set the verification policy explicitly.
+    pub fn with_verify_policy(mut self, policy: crate::crypto::CryptoPolicy) -> Self {
+        self.verify_policy = policy;
+        self
+    }
+
+    /// Explicitly downgrade this site to the legacy classical-only verifier.
+    ///
+    /// Use ONLY for surfaces that cannot carry a PQ trust store (e.g. external
+    /// JOSE/classical interop). This accepts a single-EdDSA composite and
+    /// ignores any outer ML-DSA layer.
+    pub fn classical(mut self) -> Self {
+        self.verify_policy = crate::crypto::CryptoPolicy::Classical;
+        self.pq_store = None;
         self
     }
 }
@@ -661,14 +708,164 @@ pub struct SignedEnvelope {
     /// X25519 ephemeral public key for DH key agreement (present when encrypted)
     pub client_ephemeral_public: Option<[u8; 32]>,
 
-    /// ML-DSA-65 signature (3309 bytes, present when pq-hybrid is enabled)
-    pub pq_sig: Option<Vec<u8>>,
+    /// M3 (#152): CBOR-encoded COSE_Sign composite signature (detached).
+    ///
+    /// Authoritative authentication mechanism. Carries one EdDSA entry
+    /// (Classical) or EdDSA + ML-DSA-65 entries (Hybrid) over the canonical
+    /// signing-data. The ML-DSA-65 verifying key is NOT embedded; it is
+    /// resolved by kid from a trust store (kid-anchored), which fixes the
+    /// prior self-certification weakness.
+    ///
+    /// `sig`/`cnf` remain populated with the raw EdDSA signature + signer
+    /// public key for backward compatibility and for the JWT `cnf` key-binding
+    /// path, but the COSE composite is what `verify*` enforces.
+    pub cose: Vec<u8>,
 
-    /// ML-DSA-65 verifying key (1952 bytes, present when pq-hybrid is enabled)
-    pub pq_cnf: Option<Vec<u8>>,
+    /// Runtime crypto policy used when this envelope was signed.
+    pub policy: crate::crypto::CryptoPolicy,
 
     /// ML-KEM-768 ciphertext (1088 bytes, present when hybrid encryption is used)
     pub pq_kem_ciphertext: Option<Vec<u8>>,
+}
+
+/// Cap'n Proto file id of `common.capnp` (the envelope schema). Used as the
+/// first component of the COSE `external_aad` schema-binding.
+pub const ENVELOPE_SCHEMA_ID: u64 = 0xb3e9_f4a1_c7d8_2056;
+
+/// Stable inner-type id for `RequestEnvelope` in the COSE `external_aad`.
+/// Distinct from any payload schema id; binds the COSE signature to the
+/// envelope structure to prevent schema-confusion / cross-protocol replay.
+pub const REQUEST_ENVELOPE_TYPE_ID: u64 = 0x5265_7145_6e76_3031; // "ReqEnv01"
+
+/// Stable inner-type id for `ResponseEnvelope`, distinct from
+/// [`REQUEST_ENVELOPE_TYPE_ID`]. Even though responses currently use a separate
+/// raw-Ed25519 signing domain (`request_id ‖ payload`, not COSE), keeping a
+/// distinct type-id documents/enforces the request↔response domain separation
+/// so a response can never be replayed as a request (LOW finding).
+pub const RESPONSE_ENVELOPE_TYPE_ID: u64 = 0x5265_7350_456e_7631; // "RsPEnv1"
+
+/// Build the COSE external_aad used for all envelope signatures.
+fn envelope_external_aad() -> Vec<u8> {
+    crate::crypto::cose_sign1::build_external_aad(ENVELOPE_SCHEMA_ID, REQUEST_ENVELOPE_TYPE_ID)
+}
+
+/// Resolves the anchored ML-DSA-65 verifying key for an EdDSA signer identity.
+///
+/// kid-anchoring: the envelope's EdDSA signer key (`cnf`, 32 bytes) is the
+/// identity. A `PqTrustStore` maps that identity to its trusted ML-DSA-65 key.
+/// The COSE ML-DSA-65 entry must verify against this anchored key (and its kid
+/// must match), so an attacker cannot strip + re-sign with their own PQ key.
+pub trait PqTrustStore: Send + Sync {
+    /// Return the trusted ML-DSA-65 verifying key bound to the given Ed25519
+    /// signer public key, or `None` if no binding is known.
+    fn ml_dsa_key_for(&self, ed25519_pubkey: &[u8; 32]) -> Option<crate::crypto::pq::MlDsaVerifyingKey>;
+}
+
+/// In-memory kid-anchored ML-DSA-65 trust store mapping an Ed25519 signer
+/// identity to its trusted ML-DSA-65 verifying key.
+///
+/// This is the authoritative anchor for the mesh/streaming/browser SNS
+/// composite. Bindings come from the node's own hybrid identity and from
+/// attested peer identities. Entries MUST be established out-of-band (peer
+/// attestation / trust-store), never from the self-asserted COSE object.
+#[derive(Default)]
+pub struct KeyedPqTrustStore {
+    bindings: std::collections::HashMap<[u8; 32], Vec<u8>>,
+}
+
+impl KeyedPqTrustStore {
+    /// Create an empty store.
+    pub fn new() -> Self {
+        Self { bindings: std::collections::HashMap::new() }
+    }
+
+    /// Bind an Ed25519 signer identity to its trusted ML-DSA-65 verifying key
+    /// (stored as raw vk bytes; re-decoded on lookup).
+    pub fn bind(&mut self, ed25519_pubkey: [u8; 32], ml_dsa_vk: &crate::crypto::pq::MlDsaVerifyingKey) {
+        self.bindings
+            .insert(ed25519_pubkey, crate::crypto::pq::ml_dsa_vk_bytes(ml_dsa_vk));
+    }
+
+    /// Number of bindings.
+    pub fn len(&self) -> usize {
+        self.bindings.len()
+    }
+
+    /// Whether the store has no bindings.
+    pub fn is_empty(&self) -> bool {
+        self.bindings.is_empty()
+    }
+}
+
+impl PqTrustStore for KeyedPqTrustStore {
+    fn ml_dsa_key_for(&self, ed25519_pubkey: &[u8; 32]) -> Option<crate::crypto::pq::MlDsaVerifyingKey> {
+        self.bindings
+            .get(ed25519_pubkey)
+            .and_then(|bytes| crate::crypto::pq::ml_dsa_vk_from_bytes(bytes).ok())
+    }
+}
+
+// ============================================================================
+// Process-global envelope verify configuration (closes the fail-open).
+// ============================================================================
+
+/// Process-wide envelope verification configuration shared by all production
+/// verify sites (`process_request` / `RequestLoop`, `StreamService` register).
+///
+/// Holds the enforced [`CryptoPolicy`] and the kid-anchored [`PqTrustStore`].
+/// The daemon installs this at startup with `Hybrid` + a real store wired from
+/// the node's hybrid identity (see `key_rotation`). When unset (libraries, unit
+/// tests that don't opt in), verification defaults to `Classical` so unrelated
+/// code paths keep working — production code MUST call [`install_verify_config`].
+pub struct EnvelopeVerifyConfig {
+    pub policy: crate::crypto::CryptoPolicy,
+    pub pq_store: Option<std::sync::Arc<dyn PqTrustStore>>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+static VERIFY_CONFIG: std::sync::OnceLock<EnvelopeVerifyConfig> = std::sync::OnceLock::new();
+
+/// Install the process-global envelope verify configuration. First write wins.
+///
+/// Returns `Err` if a configuration was already installed.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn install_verify_config(config: EnvelopeVerifyConfig) -> Result<()> {
+    VERIFY_CONFIG
+        .set(config)
+        .map_err(|_| anyhow!("envelope verify config already installed"))
+}
+
+/// Whether a process-global verify configuration has been installed.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn verify_config_installed() -> bool {
+    VERIFY_CONFIG.get().is_some()
+}
+
+/// The enforced verify policy: the installed policy, else `Classical`.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn global_verify_policy() -> crate::crypto::CryptoPolicy {
+    VERIFY_CONFIG
+        .get()
+        .map(|c| c.policy)
+        .unwrap_or(crate::crypto::CryptoPolicy::Classical)
+}
+
+/// The installed kid-anchored PQ trust store, if any.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn global_pq_store() -> Option<std::sync::Arc<dyn PqTrustStore>> {
+    VERIFY_CONFIG.get().and_then(|c| c.pq_store.clone())
+}
+
+/// Apply the process-global verify configuration to an `UnwrapOptions`,
+/// unless it has already been explicitly downgraded/overridden.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn apply_global_verify_config<'a>(
+    mut opts: UnwrapOptions<'a>,
+    store_holder: &'a Option<std::sync::Arc<dyn PqTrustStore>>,
+) -> UnwrapOptions<'a> {
+    opts.verify_policy = global_verify_policy();
+    opts.pq_store = store_holder.as_deref();
+    opts
 }
 
 /// Replay protection cache interface.
@@ -825,39 +1022,40 @@ impl SignedEnvelope {
     /// The signature covers the Cap'n Proto serialized bytes of the envelope.
     /// If the authorization is `IdJag` and `wth` is not already set, `wth`
     /// is auto-populated as SHA-256(jwt) per the WIMSE wth binding.
-    pub fn new_signed(mut envelope: RequestEnvelope, signing_key: &SigningKey) -> Self {
-        // Auto-populate wth from IdJag JWT when present and not already set
-        if envelope.wth.is_none() {
-            if let Some(jwt) = envelope.jwt_token() {
-                use sha2::{Digest, Sha256};
-                envelope.wth = Some(Sha256::digest(jwt.as_bytes()).into());
-            }
-        }
-
-        // Serialize the envelope to get canonical bytes
-        let envelope_bytes = envelope.to_bytes();
-
-        // Sign the serialized envelope
-        let signature = signing_key.sign(&envelope_bytes);
-
-        Self {
-            envelope,
-            sig: signature.to_bytes(),
-            cnf: signing_key.verifying_key().to_bytes(),
-            encrypted_envelope: None,
-            client_ephemeral_public: None,
-            pq_sig: None,
-            pq_cnf: None,
-            pq_kem_ciphertext: None,
-        }
+    pub fn new_signed(envelope: RequestEnvelope, signing_key: &SigningKey) -> Self {
+        // Default policy is Classical for the bare Ed25519-only constructor so
+        // that callers that don't supply a PQ key produce verifiable envelopes.
+        Self::new_signed_with_policy(envelope, signing_key, None, crate::crypto::CryptoPolicy::Classical)
     }
 
-    /// Create and dual-sign a new envelope with Ed25519 + ML-DSA-65.
-    #[cfg(feature = "pq-hybrid")]
+    /// Create and dual-sign a new envelope with Ed25519 + ML-DSA-65 (Hybrid).
     pub fn new_signed_hybrid(
-        mut envelope: RequestEnvelope,
+        envelope: RequestEnvelope,
         signing_key: &SigningKey,
         pq_signing_key: &crate::crypto::pq::MlDsaSigningKey,
+    ) -> Self {
+        Self::new_signed_with_policy(
+            envelope,
+            signing_key,
+            Some(pq_signing_key),
+            crate::crypto::CryptoPolicy::Hybrid,
+        )
+    }
+
+    /// Create and sign a new envelope under an explicit [`CryptoPolicy`].
+    ///
+    /// - `Classical`: emits a single-EdDSA COSE composite. `pq_signing_key` is
+    ///   ignored.
+    /// - `Hybrid`: emits an EdDSA + ML-DSA-65 COSE composite. `pq_signing_key`
+    ///   MUST be `Some`; if `None`, falls back to Classical (defensive).
+    ///
+    /// `sig`/`cnf` are always populated with the raw EdDSA signature + signer
+    /// public key for the cnf key-binding path.
+    pub fn new_signed_with_policy(
+        mut envelope: RequestEnvelope,
+        signing_key: &SigningKey,
+        pq_signing_key: Option<&crate::crypto::pq::MlDsaSigningKey>,
+        policy: crate::crypto::CryptoPolicy,
     ) -> Self {
         if envelope.wth.is_none() {
             if let Some(jwt) = envelope.jwt_token() {
@@ -868,10 +1066,13 @@ impl SignedEnvelope {
 
         let envelope_bytes = envelope.to_bytes();
         let signature = signing_key.sign(&envelope_bytes);
-        let pq_sig = crate::crypto::pq::ml_dsa_sign(pq_signing_key, &envelope_bytes);
-        let pq_cnf = crate::crypto::pq::ml_dsa_vk_bytes(
-            &ml_dsa::Keypair::verifying_key(pq_signing_key),
-        );
+        // SECURITY: no empty-cose fallback. A COSE build failure is a
+        // should-never-happen crypto-encoding error (CBOR-encoding fixed-shape
+        // COSE_Sign1 structures over valid keys); fail loud rather than silently
+        // emit an empty (and thus potentially fail-open) composite.
+        #[allow(clippy::expect_used)]
+        let cose = Self::build_cose(signing_key, pq_signing_key, policy, &envelope_bytes)
+            .expect("COSE composite signing must not fail for valid keys");
 
         Self {
             envelope,
@@ -879,61 +1080,77 @@ impl SignedEnvelope {
             cnf: signing_key.verifying_key().to_bytes(),
             encrypted_envelope: None,
             client_ephemeral_public: None,
-            pq_sig: Some(pq_sig),
-            pq_cnf: Some(pq_cnf),
+            cose,
+            policy,
             pq_kem_ciphertext: None,
         }
     }
 
-    /// Create, encrypt, and sign a new envelope (encrypt-then-sign).
+    /// Build the nested COSE composite signature for the given signing-data per
+    /// policy. Returns `Err` on encoding failure — callers MUST NOT substitute
+    /// an empty cose (that would fail open at verify time).
+    fn build_cose(
+        signing_key: &SigningKey,
+        pq_signing_key: Option<&crate::crypto::pq::MlDsaSigningKey>,
+        policy: crate::crypto::CryptoPolicy,
+        signing_data: &[u8],
+    ) -> Result<Vec<u8>> {
+        let pq = if policy.uses_pq() { pq_signing_key } else { None };
+        let aad = envelope_external_aad();
+        crate::crypto::cose_sign::sign_composite(signing_key, pq, signing_data, &aad)
+    }
+
+    /// Create, encrypt, and sign a new envelope (encrypt-then-sign), Classical.
     ///
     /// The envelope is serialized, encrypted with AES-256-GCM-SIV using a key
     /// derived from X25519 DH(client_ephemeral, server_static), then signed.
-    /// The signature covers `encrypted_envelope || client_ephemeral_public`.
+    /// The COSE signature covers `encrypted_envelope || client_ephemeral_public`.
     pub fn new_signed_encrypted(
-        mut envelope: RequestEnvelope,
+        envelope: RequestEnvelope,
         signing_key: &SigningKey,
         server_pubkey: &VerifyingKey,
     ) -> EnvelopeResult<Self> {
-        use crate::crypto::envelope_crypto::encrypt_envelope;
-
-        if envelope.wth.is_none() {
-            if let Some(jwt) = envelope.jwt_token() {
-                use sha2::{Digest, Sha256};
-                envelope.wth = Some(Sha256::digest(jwt.as_bytes()).into());
-            }
-        }
-
-        let envelope_bytes = envelope.to_bytes();
-        let (ciphertext, eph_public) = encrypt_envelope(&envelope_bytes, server_pubkey)?;
-
-        let mut signing_data = Vec::with_capacity(ciphertext.len() + 32);
-        signing_data.extend_from_slice(&ciphertext);
-        signing_data.extend_from_slice(&eph_public);
-        let signature = signing_key.sign(&signing_data);
-
-        Ok(Self {
+        Self::new_signed_encrypted_with_policy(
             envelope,
-            sig: signature.to_bytes(),
-            cnf: signing_key.verifying_key().to_bytes(),
-            encrypted_envelope: Some(ciphertext),
-            client_ephemeral_public: Some(eph_public),
-            pq_sig: None,
-            pq_cnf: None,
-            pq_kem_ciphertext: None,
-        })
+            signing_key,
+            server_pubkey,
+            None,
+            None,
+            crate::crypto::CryptoPolicy::Classical,
+        )
     }
 
     /// Create, encrypt (hybrid X25519+ML-KEM-768), and dual-sign with Ed25519 + ML-DSA-65.
-    #[cfg(feature = "pq-hybrid")]
     pub fn new_signed_encrypted_hybrid(
-        mut envelope: RequestEnvelope,
+        envelope: RequestEnvelope,
         signing_key: &SigningKey,
         server_pubkey: &VerifyingKey,
         pq_signing_key: &crate::crypto::pq::MlDsaSigningKey,
         server_kem_ek: &crate::crypto::pq::MlKemEncapsKey,
     ) -> EnvelopeResult<Self> {
-        use crate::crypto::envelope_crypto::encrypt_envelope_hybrid;
+        Self::new_signed_encrypted_with_policy(
+            envelope,
+            signing_key,
+            server_pubkey,
+            Some(pq_signing_key),
+            Some(server_kem_ek),
+            crate::crypto::CryptoPolicy::Hybrid,
+        )
+    }
+
+    /// Encrypt-then-sign under an explicit [`CryptoPolicy`].
+    ///
+    /// In `Hybrid` mode both `pq_signing_key` and `server_kem_ek` must be
+    /// supplied (ML-KEM-768 hybrid encryption + ML-DSA-65 composite signature).
+    pub fn new_signed_encrypted_with_policy(
+        mut envelope: RequestEnvelope,
+        signing_key: &SigningKey,
+        server_pubkey: &VerifyingKey,
+        pq_signing_key: Option<&crate::crypto::pq::MlDsaSigningKey>,
+        server_kem_ek: Option<&crate::crypto::pq::MlKemEncapsKey>,
+        policy: crate::crypto::CryptoPolicy,
+    ) -> EnvelopeResult<Self> {
+        use crate::crypto::envelope_crypto::{encrypt_envelope, encrypt_envelope_hybrid};
 
         if envelope.wth.is_none() {
             if let Some(jwt) = envelope.jwt_token() {
@@ -943,19 +1160,30 @@ impl SignedEnvelope {
         }
 
         let envelope_bytes = envelope.to_bytes();
-        let (ciphertext, eph_public, kem_ct) =
-            encrypt_envelope_hybrid(&envelope_bytes, server_pubkey, server_kem_ek)?;
 
-        // Sign ciphertext ∥ eph_x25519_public ∥ kem_ciphertext
-        let mut signing_data = Vec::with_capacity(ciphertext.len() + 32 + kem_ct.len());
+        let (ciphertext, eph_public, kem_ct) = if policy.uses_pq() {
+            let kem_ek = server_kem_ek.ok_or_else(|| {
+                EnvelopeError::Encryption("Hybrid policy requires server ML-KEM key".into())
+            })?;
+            let (ct, eph, kem) = encrypt_envelope_hybrid(&envelope_bytes, server_pubkey, kem_ek)?;
+            (ct, eph, Some(kem))
+        } else {
+            let (ct, eph) = encrypt_envelope(&envelope_bytes, server_pubkey)?;
+            (ct, eph, None)
+        };
+
+        // Signing data: ciphertext ∥ eph_x25519_public ∥ [kem_ciphertext]
+        let kem_len = kem_ct.as_ref().map_or(0, Vec::len);
+        let mut signing_data = Vec::with_capacity(ciphertext.len() + 32 + kem_len);
         signing_data.extend_from_slice(&ciphertext);
         signing_data.extend_from_slice(&eph_public);
-        signing_data.extend_from_slice(&kem_ct);
+        if let Some(ref kem) = kem_ct {
+            signing_data.extend_from_slice(kem);
+        }
+
         let signature = signing_key.sign(&signing_data);
-        let pq_sig = crate::crypto::pq::ml_dsa_sign(pq_signing_key, &signing_data);
-        let pq_cnf = crate::crypto::pq::ml_dsa_vk_bytes(
-            &ml_dsa::Keypair::verifying_key(pq_signing_key),
-        );
+        let cose = Self::build_cose(signing_key, pq_signing_key, policy, &signing_data)
+            .map_err(|e| EnvelopeError::Encryption(format!("COSE composite signing failed: {e}")))?;
 
         Ok(Self {
             envelope,
@@ -963,9 +1191,9 @@ impl SignedEnvelope {
             cnf: signing_key.verifying_key().to_bytes(),
             encrypted_envelope: Some(ciphertext),
             client_ephemeral_public: Some(eph_public),
-            pq_sig: Some(pq_sig),
-            pq_cnf: Some(pq_cnf),
-            pq_kem_ciphertext: Some(kem_ct),
+            cose,
+            policy,
+            pq_kem_ciphertext: kem_ct,
         })
     }
 
@@ -993,6 +1221,26 @@ impl SignedEnvelope {
         expected_pubkey: &VerifyingKey,
         nonce_cache: &dyn NonceCache,
     ) -> EnvelopeResult<()> {
+        self.verify_with(expected_pubkey, nonce_cache, None, crate::crypto::CryptoPolicy::Classical)
+    }
+
+    /// Verify with an explicit kid-anchored PQ trust store and verify policy.
+    ///
+    /// - `pq_store`: when `Some`, resolves the trust-anchored ML-DSA-65 key for
+    ///   the envelope's EdDSA signer (`cnf`). The COSE ML-DSA-65 entry must
+    ///   verify against this key and its kid must match (kid-anchoring) —
+    ///   fixing the self-certification weakness.
+    /// - `verify_policy`: `Hybrid` REQUIRES a valid ML-DSA-65 entry anchored to
+    ///   the trust store (rejects classical-only and self-asserted PQ keys);
+    ///   `Classical` verifies only EdDSA and SKIPS any PQ entry (RFC 7517
+    ///   skip-unknown interop).
+    pub fn verify_with(
+        &self,
+        expected_pubkey: &VerifyingKey,
+        nonce_cache: &dyn NonceCache,
+        pq_store: Option<&dyn PqTrustStore>,
+        verify_policy: crate::crypto::CryptoPolicy,
+    ) -> EnvelopeResult<()> {
         // 1. Verify signer matches expected (constant-time comparison)
         if !bool::from(self.cnf.ct_eq(&expected_pubkey.to_bytes())) {
             return Err(EnvelopeError::SignerMismatch {
@@ -1001,38 +1249,8 @@ impl SignedEnvelope {
             });
         }
 
-        // 2. Check timestamp window
-        let now = current_timestamp();
-
-        let age = now - self.envelope.iat;
-        if age > MAX_TIMESTAMP_AGE_MS {
-            return Err(EnvelopeError::ReplayAttack(format!(
-                "timestamp too old: {age}ms > {MAX_TIMESTAMP_AGE_MS}ms"
-            )));
-        }
-        if age < -MAX_CLOCK_SKEW_MS {
-            return Err(EnvelopeError::ReplayAttack(format!(
-                "timestamp in future: {}ms beyond clock skew tolerance",
-                -age - MAX_CLOCK_SKEW_MS
-            )));
-        }
-
-        // 3. Check nonce not seen before
-        if !nonce_cache.check_and_insert(&self.envelope.nonce) {
-            return Err(EnvelopeError::ReplayAttack(
-                "nonce already seen".to_owned(),
-            ));
-        }
-
-        // 4. Verify signature (strict: rejects small-order public keys)
-        let signing_data = self.signed_bytes();
-        let signature = Signature::from_bytes(&self.sig);
-        expected_pubkey.verify_strict(&signing_data, &signature)?;
-
-        // 5. Verify PQ signature
-        self.verify_pq_signature(&signing_data, None)?;
-
-        Ok(())
+        self.check_replay(nonce_cache)?;
+        self.verify_cose(expected_pubkey, pq_store, verify_policy)
     }
 
     /// Verify signature only (skip replay protection).
@@ -1045,13 +1263,23 @@ impl SignedEnvelope {
                 actual: hex::encode(self.cnf),
             });
         }
+        self.verify_cose(expected_pubkey, None, crate::crypto::CryptoPolicy::Classical)
+    }
 
-        let signing_data = self.signed_bytes();
-        let signature = Signature::from_bytes(&self.sig);
-        expected_pubkey.verify_strict(&signing_data, &signature)?;
-        self.verify_pq_signature(&signing_data, None)?;
-
-        Ok(())
+    /// Verify signature only under an explicit policy + PQ trust store.
+    pub fn verify_signature_only_with(
+        &self,
+        expected_pubkey: &VerifyingKey,
+        pq_store: Option<&dyn PqTrustStore>,
+        verify_policy: crate::crypto::CryptoPolicy,
+    ) -> EnvelopeResult<()> {
+        if !bool::from(self.cnf.ct_eq(&expected_pubkey.to_bytes())) {
+            return Err(EnvelopeError::SignerMismatch {
+                expected: hex::encode(expected_pubkey.to_bytes()),
+                actual: hex::encode(self.cnf),
+            });
+        }
+        self.verify_cose(expected_pubkey, pq_store, verify_policy)
     }
 
     /// Verify against the envelope's own embedded signer pubkey.
@@ -1062,11 +1290,24 @@ impl SignedEnvelope {
         &self,
         nonce_cache: &dyn NonceCache,
     ) -> EnvelopeResult<()> {
-        // 1. Reconstruct the verifying key from the embedded pubkey
+        self.verify_any_signer_with(nonce_cache, None, crate::crypto::CryptoPolicy::Classical)
+    }
+
+    /// `verify_any_signer` with an explicit kid-anchored PQ trust store + policy.
+    pub fn verify_any_signer_with(
+        &self,
+        nonce_cache: &dyn NonceCache,
+        pq_store: Option<&dyn PqTrustStore>,
+        verify_policy: crate::crypto::CryptoPolicy,
+    ) -> EnvelopeResult<()> {
         let verifying_key = VerifyingKey::from_bytes(&self.cnf)
             .map_err(|_| EnvelopeError::InvalidPublicKey { expected: 32, actual: 0 })?;
+        self.check_replay(nonce_cache)?;
+        self.verify_cose(&verifying_key, pq_store, verify_policy)
+    }
 
-        // 2. Check timestamp window
+    /// Timestamp window + nonce replay check.
+    fn check_replay(&self, nonce_cache: &dyn NonceCache) -> EnvelopeResult<()> {
         let now = current_timestamp();
         let age = now - self.envelope.iat;
         if age > MAX_TIMESTAMP_AGE_MS {
@@ -1080,72 +1321,50 @@ impl SignedEnvelope {
                 -age - MAX_CLOCK_SKEW_MS
             )));
         }
-
-        // 3. Check nonce not seen before
         if !nonce_cache.check_and_insert(&self.envelope.nonce) {
-            return Err(EnvelopeError::ReplayAttack(
-                "nonce already seen".to_owned(),
-            ));
+            return Err(EnvelopeError::ReplayAttack("nonce already seen".to_owned()));
         }
-
-        // 4. Verify signature against the embedded public key
-        let signing_data = self.signed_bytes();
-        let signature = Signature::from_bytes(&self.sig);
-        verifying_key.verify_strict(&signing_data, &signature)?;
-
-        // 5. Verify PQ signature
-        self.verify_pq_signature(&signing_data, None)?;
-
         Ok(())
     }
 
-    /// Verify ML-DSA-65 post-quantum signature if present.
+    /// Verify the COSE composite signature (authoritative auth check).
     ///
-    /// When `pq-hybrid` feature is enabled, PQ signatures are mandatory —
-    /// envelopes without them are rejected.
-    ///
-    /// When `expected_pq_cnf` is `Some`, the envelope's `pq_cnf` must match
-    /// (constant-time comparison). This binds the PQ key to an identity,
-    /// preventing an attacker from stripping the PQ signature and re-signing
-    /// with their own ML-DSA key. When `None`, the PQ key is self-certified
-    /// and the hybrid scheme degrades to Ed25519-level authentication.
-    fn verify_pq_signature(&self, signing_data: &[u8], expected_pq_cnf: Option<&[u8]>) -> EnvelopeResult<()> {
-        match (&self.pq_sig, &self.pq_cnf) {
-            (Some(sig), Some(cnf)) => {
-                #[cfg(feature = "pq-hybrid")]
-                {
-                    if let Some(expected) = expected_pq_cnf {
-                        if cnf.len() != expected.len()
-                            || !bool::from(cnf.as_slice().ct_eq(expected))
-                        {
-                            return Err(EnvelopeError::PqSignatureInvalid(
-                                "pq_cnf does not match expected PQ verifying key".to_owned(),
-                            ));
-                        }
-                    }
-                    let vk = crate::crypto::pq::ml_dsa_vk_from_bytes(cnf)
-                        .map_err(|e| EnvelopeError::PqSignatureInvalid(e.to_string()))?;
-                    crate::crypto::pq::ml_dsa_verify(&vk, signing_data, sig)
-                        .map_err(|e| EnvelopeError::PqSignatureInvalid(e.to_string()))?;
-                }
-                #[cfg(not(feature = "pq-hybrid"))]
-                {
-                    let _ = (sig, cnf, signing_data, expected_pq_cnf);
-                }
-                Ok(())
-            }
-            (None, None) => {
-                #[cfg(feature = "pq-hybrid")]
-                return Err(EnvelopeError::PqSignatureInvalid(
-                    "missing mandatory PQ signature".to_owned(),
-                ));
-                #[cfg(not(feature = "pq-hybrid"))]
-                Ok(())
-            }
-            _ => Err(EnvelopeError::PqSignatureInvalid(
-                "incomplete PQ signature fields (need both pq_sig and pq_cnf)".to_owned(),
-            )),
+    /// The raw EdDSA `sig`/`cnf` advertisement is NOT trusted on its own; this
+    /// re-verifies the EdDSA component inside the COSE composite against
+    /// `ed_vk`, and (under Hybrid policy) the kid-anchored ML-DSA-65 component.
+    fn verify_cose(
+        &self,
+        ed_vk: &VerifyingKey,
+        pq_store: Option<&dyn PqTrustStore>,
+        verify_policy: crate::crypto::CryptoPolicy,
+    ) -> EnvelopeResult<()> {
+        let signing_data = self.signed_bytes();
+        let aad = envelope_external_aad();
+
+        // kid-anchor: resolve the trusted ML-DSA-65 key for this EdDSA identity.
+        let anchored_pq = pq_store.and_then(|s| s.ml_dsa_key_for(&self.cnf));
+
+        // Hybrid enforcement requires an anchored PQ key; without one we cannot
+        // safely require PQ (resolving from the self-asserted COSE entry would
+        // reintroduce the self-cert weakness). Treat as a policy error.
+        let require_pq = verify_policy.uses_pq();
+        if require_pq && anchored_pq.is_none() {
+            return Err(EnvelopeError::PqSignatureInvalid(
+                "Hybrid policy requires a kid-anchored ML-DSA-65 key, none resolved".to_owned(),
+            ));
         }
+
+        crate::crypto::cose_sign::verify_composite(
+            &self.cose,
+            ed_vk,
+            anchored_pq.as_ref(),
+            &signing_data,
+            &aad,
+            require_pq,
+        )
+        .map_err(|e| EnvelopeError::PqSignatureInvalid(e.to_string()))?;
+
+        Ok(())
     }
 
     /// Compute the bytes that were signed.
@@ -1199,7 +1418,6 @@ impl SignedEnvelope {
     }
 
     /// Decrypt a hybrid-encrypted envelope in-place (X25519 + ML-KEM-768).
-    #[cfg(feature = "pq-hybrid")]
     pub fn decrypt_in_place_hybrid(
         &mut self,
         server_signing_key: &crate::crypto::SigningKey,
@@ -1362,12 +1580,7 @@ impl ToCapnp for SignedEnvelope {
         if let Some(ref eph) = self.client_ephemeral_public {
             builder.set_client_ephemeral_public(eph);
         }
-        if let Some(ref pq_sig) = self.pq_sig {
-            builder.set_pq_sig(pq_sig);
-        }
-        if let Some(ref pq_cnf) = self.pq_cnf {
-            builder.set_pq_cnf(pq_cnf);
-        }
+        builder.set_cose(&self.cose);
         if let Some(ref kem_ct) = self.pq_kem_ciphertext {
             builder.set_pq_kem_ciphertext(kem_ct);
         }
@@ -1425,29 +1638,23 @@ impl FromCapnp for SignedEnvelope {
             }
         };
 
-        let pq_sig = {
-            let data = reader.get_pq_sig()?;
-            if data.is_empty() { None } else { Some(data.to_vec()) }
-        };
-
-        let pq_cnf = {
-            let data = reader.get_pq_cnf()?;
-            if data.is_empty() { None } else { Some(data.to_vec()) }
-        };
+        let cose = reader.get_cose()?.to_vec();
 
         let pq_kem_ciphertext = {
             let data = reader.get_pq_kem_ciphertext()?;
             if data.is_empty() { None } else { Some(data.to_vec()) }
         };
 
+        // `policy` is a signing-time concept; the verifier supplies the verify
+        // policy explicitly, so decode to the default here.
         Ok(Self {
             envelope: RequestEnvelope::read_from(reader.get_envelope()?)?,
             sig,
             cnf,
             encrypted_envelope,
             client_ephemeral_public,
-            pq_sig,
-            pq_cnf,
+            cose,
+            policy: crate::crypto::CryptoPolicy::default(),
             pq_kem_ciphertext,
         })
     }
@@ -1587,10 +1794,10 @@ pub fn unwrap_and_verify(
 
     match &opts.verification {
         EnvelopeVerification::FixedSigner(pubkey) => {
-            signed.verify(pubkey, opts.nonce_cache)?;
+            signed.verify_with(pubkey, opts.nonce_cache, opts.pq_store, opts.verify_policy)?;
         }
         EnvelopeVerification::AnySigner => {
-            signed.verify_any_signer(opts.nonce_cache)?;
+            signed.verify_any_signer_with(opts.nonce_cache, opts.pq_store, opts.verify_policy)?;
         }
     }
 
@@ -1698,20 +1905,32 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "pq-hybrid")]
-    fn test_pq_keypair() -> crate::crypto::pq::MlDsaSigningKey {
-        let (sk, _vk) = crate::crypto::pq::ml_dsa_generate_keypair();
-        sk
+    /// Test envelopes default to Classical signing; the existing tests exercise
+    /// the EdDSA path. Hybrid/cross-compat is covered by the dedicated M3 tests
+    /// below.
+    fn test_new_signed(envelope: RequestEnvelope, signing_key: &SigningKey) -> SignedEnvelope {
+        SignedEnvelope::new_signed(envelope, signing_key)
     }
 
-    fn test_new_signed(envelope: RequestEnvelope, signing_key: &SigningKey) -> SignedEnvelope {
-        #[cfg(feature = "pq-hybrid")]
-        {
-            let pq_sk = test_pq_keypair();
-            SignedEnvelope::new_signed_hybrid(envelope, signing_key, &pq_sk)
+    /// In-memory kid-anchored PQ trust store for tests.
+    struct TestPqStore {
+        bindings: Vec<([u8; 32], crate::crypto::pq::MlDsaVerifyingKey)>,
+    }
+    impl PqTrustStore for TestPqStore {
+        fn ml_dsa_key_for(
+            &self,
+            ed25519_pubkey: &[u8; 32],
+        ) -> Option<crate::crypto::pq::MlDsaVerifyingKey> {
+            self.bindings
+                .iter()
+                .find(|(k, _)| k == ed25519_pubkey)
+                .map(|(_, vk)| {
+                    crate::crypto::pq::ml_dsa_vk_from_bytes(
+                        &crate::crypto::pq::ml_dsa_vk_bytes(vk),
+                    )
+                    .expect("re-decode pq vk")
+                })
         }
-        #[cfg(not(feature = "pq-hybrid"))]
-        SignedEnvelope::new_signed(envelope, signing_key)
     }
 
     #[test]
@@ -2149,5 +2368,224 @@ mod tests {
 
         let result = signed.verify_signature_only(&verifying_key);
         assert!(result.is_err(), "Tampered wth must invalidate signature");
+    }
+
+    // =========================================================================
+    // M3 (#152): COSE composite envelope — both schemes + cross-compat + anchor
+    // =========================================================================
+
+    use crate::crypto::CryptoPolicy;
+
+    fn pq_store_for(ed_pubkey: [u8; 32], pq_vk: &crate::crypto::pq::MlDsaVerifyingKey) -> TestPqStore {
+        let vk = crate::crypto::pq::ml_dsa_vk_from_bytes(
+            &crate::crypto::pq::ml_dsa_vk_bytes(pq_vk),
+        )
+        .expect("decode pq vk");
+        TestPqStore { bindings: vec![(ed_pubkey, vk)] }
+    }
+
+    /// classical_only: sign + verify in Classical mode.
+    #[test]
+    fn m3_classical_only() -> crate::EnvelopeResult<()> {
+        let (sk, vk) = generate_signing_keypair();
+        let cache = TestNonceCache::new();
+        let signed = SignedEnvelope::new_signed_with_policy(
+            RequestEnvelope::anonymous(vec![1, 2, 3]),
+            &sk,
+            None,
+            CryptoPolicy::Classical,
+        );
+        signed.verify_with(&vk, &cache, None, CryptoPolicy::Classical)?;
+        Ok(())
+    }
+
+    /// hybrid: sign + verify composite (both EdDSA + ML-DSA-65 checked).
+    #[test]
+    fn m3_hybrid_both_checked() -> crate::EnvelopeResult<()> {
+        let (sk, vk) = generate_signing_keypair();
+        let (pq_sk, pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
+        let cache = TestNonceCache::new();
+        let signed = SignedEnvelope::new_signed_hybrid(
+            RequestEnvelope::anonymous(vec![4, 5, 6]),
+            &sk,
+            &pq_sk,
+        );
+        let store = pq_store_for(vk.to_bytes(), &pq_vk);
+        signed.verify_with(&vk, &cache, Some(&store), CryptoPolicy::Hybrid)?;
+        Ok(())
+    }
+
+    /// cross_pq_signer_classical_verifier: a Hybrid-signed envelope verifies
+    /// under a Classical verifier via the EdDSA component + skip-unknown.
+    #[test]
+    fn m3_cross_hybrid_signer_classical_verifier() -> crate::EnvelopeResult<()> {
+        let (sk, vk) = generate_signing_keypair();
+        let (pq_sk, _pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
+        let cache = TestNonceCache::new();
+        let signed = SignedEnvelope::new_signed_hybrid(
+            RequestEnvelope::anonymous(vec![7, 8, 9]),
+            &sk,
+            &pq_sk,
+        );
+        // Classical verifier: no PQ store, Classical policy → skips ML-DSA entry.
+        signed.verify_with(&vk, &cache, None, CryptoPolicy::Classical)?;
+        Ok(())
+    }
+
+    /// cross_classical_signer_hybrid_verifier: a Classical-signed item under a
+    /// Hybrid verifier — the policy knob. Hybrid REQUIRES PQ → rejected.
+    #[test]
+    fn m3_cross_classical_signer_hybrid_verifier_rejected() {
+        let (sk, vk) = generate_signing_keypair();
+        let (_pq_sk, pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
+        let cache = TestNonceCache::new();
+        let signed = SignedEnvelope::new_signed(RequestEnvelope::anonymous(vec![1]), &sk);
+        let store = pq_store_for(vk.to_bytes(), &pq_vk);
+        let res = signed.verify_with(&vk, &cache, Some(&store), CryptoPolicy::Hybrid);
+        assert!(res.is_err(), "Hybrid policy must reject a classical-only envelope");
+    }
+
+    /// Classical signer accepted by a verifier whose policy permits classical.
+    #[test]
+    fn m3_classical_signer_classical_policy_accepted() -> crate::EnvelopeResult<()> {
+        let (sk, vk) = generate_signing_keypair();
+        let cache = TestNonceCache::new();
+        let signed = SignedEnvelope::new_signed(RequestEnvelope::anonymous(vec![1]), &sk);
+        signed.verify_with(&vk, &cache, None, CryptoPolicy::Classical)?;
+        Ok(())
+    }
+
+    /// self_cert_fix: an envelope whose ML-DSA key doesn't match the
+    /// kid-resolved key is REJECTED (proves the kid-anchoring).
+    #[test]
+    fn m3_self_cert_fix_wrong_anchored_pq_key_rejected() {
+        let (sk, vk) = generate_signing_keypair();
+        let (pq_sk, _pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
+        // Attacker/foreign anchored key that does NOT match the signer's PQ key.
+        let (_other_sk, other_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
+        let cache = TestNonceCache::new();
+        let signed = SignedEnvelope::new_signed_hybrid(
+            RequestEnvelope::anonymous(vec![1, 2, 3]),
+            &sk,
+            &pq_sk,
+        );
+        let store = pq_store_for(vk.to_bytes(), &other_vk);
+        let res = signed.verify_with(&vk, &cache, Some(&store), CryptoPolicy::Hybrid);
+        assert!(
+            res.is_err(),
+            "PQ key not matching the kid-anchored key must be rejected (self-cert fix)"
+        );
+    }
+
+    /// Hybrid policy with NO anchored key must fail closed (cannot trust a
+    /// self-asserted PQ key — this is the core of the self-cert fix).
+    #[test]
+    fn m3_hybrid_policy_without_anchor_rejected() {
+        let (sk, vk) = generate_signing_keypair();
+        let (pq_sk, _pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
+        let cache = TestNonceCache::new();
+        let signed = SignedEnvelope::new_signed_hybrid(
+            RequestEnvelope::anonymous(vec![1]),
+            &sk,
+            &pq_sk,
+        );
+        let res = signed.verify_with(&vk, &cache, None, CryptoPolicy::Hybrid);
+        assert!(res.is_err(), "Hybrid policy requires a kid-anchored PQ key");
+    }
+
+    // -- SNS-specific: strip the outer ML-DSA layer at the cose level and prove
+    //    Hybrid policy rejects it (the attack the review found accepted before).
+    #[test]
+    fn m3_sns_strip_outer_mldsa_rejected() {
+        let (sk, vk) = generate_signing_keypair();
+        let (pq_sk, pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
+        let cache = TestNonceCache::new();
+        let mut signed = SignedEnvelope::new_signed_hybrid(
+            RequestEnvelope::anonymous(vec![1, 2, 3]),
+            &sk,
+            &pq_sk,
+        );
+        // Strip: re-encode the composite with the outer set to null.
+        let (inner, outer) =
+            crate::crypto::cose_sign::decode_composite_for_test(&signed.cose).expect("decode");
+        assert!(outer.is_some(), "hybrid envelope must have an outer layer");
+        signed.cose =
+            crate::crypto::cose_sign::encode_composite_for_test(inner, None).expect("encode");
+
+        let store = pq_store_for(vk.to_bytes(), &pq_vk);
+        let res = signed.verify_with(&vk, &cache, Some(&store), CryptoPolicy::Hybrid);
+        assert!(res.is_err(), "stripping the outer ML-DSA layer must fail Hybrid policy");
+    }
+
+    /// Integration at the `unwrap_and_verify` level (prod-wiring path the review
+    /// flagged as missing): sign Hybrid, strip the outer, serialize to wire, and
+    /// assert `unwrap_and_verify` REJECTS under a Hybrid deployment.
+    #[test]
+    fn m3_unwrap_and_verify_strip_rejected_under_hybrid() {
+        let (sk, vk) = generate_signing_keypair();
+        let (pq_sk, pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
+        let cache = TestNonceCache::new();
+
+        // Sign Hybrid, then strip the outer layer.
+        let mut signed = SignedEnvelope::new_signed_hybrid(
+            RequestEnvelope::anonymous(vec![9, 9, 9]),
+            &sk,
+            &pq_sk,
+        );
+        let (inner, _outer) =
+            crate::crypto::cose_sign::decode_composite_for_test(&signed.cose).expect("decode");
+        signed.cose =
+            crate::crypto::cose_sign::encode_composite_for_test(inner, None).expect("encode");
+
+        // Serialize to wire bytes.
+        let mut message = capnp::message::Builder::new_default();
+        {
+            let mut builder = message.init_root::<common_capnp::signed_envelope::Builder>();
+            signed.write_to(&mut builder);
+        }
+        let mut wire = Vec::new();
+        capnp::serialize::write_message(&mut wire, &message).expect("serialize");
+
+        // Verify under a Hybrid deployment via unwrap_and_verify.
+        let store = pq_store_for(vk.to_bytes(), &pq_vk);
+        let opts = UnwrapOptions::fixed_signer(&vk, &cache)
+            .with_verify_policy(CryptoPolicy::Hybrid)
+            .with_pq_store(&store);
+        let res = unwrap_and_verify(&wire, &opts);
+        assert!(
+            res.is_err(),
+            "unwrap_and_verify must reject a stripped Hybrid envelope (prod fail-open closed)"
+        );
+    }
+
+    /// Integration: a well-formed Hybrid envelope passes unwrap_and_verify under
+    /// a Hybrid deployment with the correct anchor.
+    #[test]
+    fn m3_unwrap_and_verify_hybrid_round_trip() -> crate::EnvelopeResult<()> {
+        let (sk, vk) = generate_signing_keypair();
+        let (pq_sk, pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
+        let cache = TestNonceCache::new();
+
+        let signed = SignedEnvelope::new_signed_hybrid(
+            RequestEnvelope::anonymous(vec![4, 2]),
+            &sk,
+            &pq_sk,
+        );
+        let mut message = capnp::message::Builder::new_default();
+        {
+            let mut builder = message.init_root::<common_capnp::signed_envelope::Builder>();
+            signed.write_to(&mut builder);
+        }
+        let mut wire = Vec::new();
+        capnp::serialize::write_message(&mut wire, &message).expect("serialize");
+
+        let store = pq_store_for(vk.to_bytes(), &pq_vk);
+        let opts = UnwrapOptions::fixed_signer(&vk, &cache)
+            .with_verify_policy(CryptoPolicy::Hybrid)
+            .with_pq_store(&store);
+        let (_signed, payload) = unwrap_and_verify(&wire, &opts)
+            .map_err(|e| EnvelopeError::PqSignatureInvalid(e.to_string()))?;
+        assert_eq!(payload, vec![4, 2]);
+        Ok(())
     }
 }

--- a/crates/hyprstream-rpc/src/envelope.rs
+++ b/crates/hyprstream-rpc/src/envelope.rs
@@ -841,13 +841,43 @@ pub fn verify_config_installed() -> bool {
     VERIFY_CONFIG.get().is_some()
 }
 
-/// The enforced verify policy: the installed policy, else `Classical`.
+/// The enforced verify policy.
+///
+/// When a config has been installed, its policy is returned verbatim.
+///
+/// When **uninstalled**, the default is **fail-closed**: production builds
+/// default to [`CryptoPolicy::Hybrid`] so that any verify site reached before
+/// `install_verify_config` (subprocess-spawner services, early init) rejects
+/// classical-only envelopes rather than silently accepting EdDSA-only ones
+/// (#160 — this previously defaulted `Classical`, re-opening the M3 fail-open).
+///
+/// Under `cfg(test)` the uninstalled default stays `Classical`: in-process unit
+/// tests share one `OnceLock` and rely on per-call `UnwrapOptions` overrides
+/// rather than a global install. Integration tests (which compile this crate in
+/// non-test mode) must call [`install_verify_config`] explicitly.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn global_verify_policy() -> crate::crypto::CryptoPolicy {
-    VERIFY_CONFIG
-        .get()
-        .map(|c| c.policy)
-        .unwrap_or(crate::crypto::CryptoPolicy::Classical)
+    if let Some(c) = VERIFY_CONFIG.get() {
+        return c.policy;
+    }
+    #[cfg(test)]
+    {
+        crate::crypto::CryptoPolicy::Classical
+    }
+    #[cfg(not(test))]
+    {
+        // Fail-closed default. Loud (once — this is on the per-request verify
+        // path), because reaching a verify site with no installed config in
+        // production is a wiring bug (#160).
+        static WARNED: std::sync::Once = std::sync::Once::new();
+        WARNED.call_once(|| {
+            tracing::warn!(
+                "envelope verify config not installed; defaulting to fail-closed Hybrid \
+                 policy. Production code MUST call install_verify_config() at startup."
+            );
+        });
+        crate::crypto::CryptoPolicy::Hybrid
+    }
 }
 
 /// The installed kid-anchored PQ trust store, if any.

--- a/crates/hyprstream-rpc/src/lib.rs
+++ b/crates/hyprstream-rpc/src/lib.rs
@@ -180,9 +180,9 @@ pub use crypto::{generate_ephemeral_keypair, ristretto_dh, RistrettoPublic, Rist
 
 pub use envelope::{
     unwrap_and_verify,
-    Authorization, EnvelopeVerification, FederatedToken, InMemoryNonceCache, NonceCache,
-    RequestEnvelope, ResponseEnvelope, SignedEnvelope, Subject, TokenClaims, UnwrapOptions,
-    MAX_CLOCK_SKEW_MS, MAX_TIMESTAMP_AGE_MS,
+    Authorization, EnvelopeVerification, FederatedToken, InMemoryNonceCache, KeyedPqTrustStore,
+    NonceCache, PqTrustStore, RequestEnvelope, ResponseEnvelope, SignedEnvelope, Subject,
+    TokenClaims, UnwrapOptions, MAX_CLOCK_SKEW_MS, MAX_TIMESTAMP_AGE_MS,
 };
 #[cfg(not(target_arch = "wasm32"))]
 pub use envelope::unwrap_envelope;

--- a/crates/hyprstream-rpc/src/rpc_client.rs
+++ b/crates/hyprstream-rpc/src/rpc_client.rs
@@ -291,19 +291,55 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
         }
 
         let canonical = envelope.to_bytes();
+        let ed_pubkey = self.signer.pubkey();
+
+        // Raw EdDSA signature (sig/cnf) retained for signer-pubkey advertisement
+        // + the JWT cnf key-binding path.
         let signature = self.signer.sign(&canonical).await?;
 
-        let pq_sig = self.signer.pq_sign(&canonical).await?;
-        let pq_cnf = self.signer.pq_pubkey();
+        // Build the COSE composite (M3 #152) by signing each entry's
+        // Sig_structure out-of-band via the (possibly async/WASM) Signer.
+        let aad = crate::crypto::cose_sign1::build_external_aad(
+            crate::envelope::ENVELOPE_SCHEMA_ID,
+            crate::envelope::REQUEST_ENVELOPE_TYPE_ID,
+        );
+        // Nested SNS composite: sign the inner EdDSA layer first, then sign the
+        // outer ML-DSA-65 layer over `canonical ‖ inner_eddsa_signature` so the
+        // inner signature is bound into the outer (Strong-Non-Separable).
+        let ed_kid = ed_pubkey.to_vec();
+        let ed_tbs = crate::crypto::cose_sign::inner_tbs(ed_kid.clone(), &canonical, &aad);
+        let ed_sig = self.signer.sign(&ed_tbs).await?.to_vec();
+
+        // Hybrid component when the signer exposes an ML-DSA-65 key.
+        let pq_entry = if let Some(pq_kid) = self.signer.pq_pubkey() {
+            let pq_tbs = crate::crypto::cose_sign::outer_tbs(
+                pq_kid.clone(),
+                &canonical,
+                &ed_sig,
+                &aad,
+            );
+            self.signer
+                .pq_sign(&pq_tbs)
+                .await?
+                .map(|pq_sig| (pq_kid, pq_sig))
+        } else {
+            None
+        };
+        let policy = if pq_entry.is_some() {
+            crate::crypto::CryptoPolicy::Hybrid
+        } else {
+            crate::crypto::CryptoPolicy::Classical
+        };
+        let cose = crate::crypto::cose_sign::assemble_composite_nested((ed_kid, ed_sig), pq_entry)?;
 
         let signed = SignedEnvelope {
             envelope,
             sig: signature,
-            cnf: self.signer.pubkey(),
+            cnf: ed_pubkey,
             encrypted_envelope: None,
             client_ephemeral_public: None,
-            pq_sig,
-            pq_cnf,
+            cose,
+            policy,
             pq_kem_ciphertext: None,
         };
 

--- a/crates/hyprstream-rpc/src/service/streaming.rs
+++ b/crates/hyprstream-rpc/src/service/streaming.rs
@@ -290,8 +290,16 @@ impl StreamService {
         let signed_reader = reader.get_root::<common_capnp::signed_envelope::Reader>()?;
         let signed = SignedEnvelope::read_from(signed_reader)?;
 
-        // Verify signature against the envelope's embedded pubkey.
-        signed.verify_any_signer(&*self.nonce_cache)?;
+        // Verify signature against the envelope's embedded pubkey, enforcing
+        // the process-global crypto policy (Hybrid in the daemon) with the
+        // kid-anchored PQ trust store. Closes the prior fail-open where this
+        // site hardcoded Classical / no PQ store.
+        let pq_store = crate::envelope::global_pq_store();
+        signed.verify_any_signer_with(
+            &*self.nonce_cache,
+            pq_store.as_deref(),
+            crate::envelope::global_verify_policy(),
+        )?;
 
         // Reject signers not attested in the trust store.
         if let Some(ref authorize) = self.authorize_signer {

--- a/crates/hyprstream-rpc/src/service/zmq.rs
+++ b/crates/hyprstream-rpc/src/service/zmq.rs
@@ -476,7 +476,6 @@ pub trait RequestService: 'static {
 
         // Route verification by algorithm
         let verified = match alg.as_str() {
-            #[cfg(feature = "pq-hybrid")]
             "ML-DSA-65" => {
                 let vks = key_source.ml_dsa_verifying_keys();
                 if vks.is_empty() {
@@ -499,7 +498,6 @@ pub trait RequestService: 'static {
                     }
                 }
             }
-            #[cfg(feature = "pq-hybrid")]
             "ML-DSA-65-Ed25519" => {
                 let vks = key_source.ml_dsa_verifying_keys();
                 if vks.is_empty() {

--- a/crates/hyprstream-rpc/src/signer.rs
+++ b/crates/hyprstream-rpc/src/signer.rs
@@ -17,7 +17,6 @@ use crate::transport_traits::Signer;
 /// Used for server-to-server RPC where the signing key is local.
 pub struct LocalSigner {
     signing_key: SigningKey,
-    #[cfg(feature = "pq-hybrid")]
     pq_signing_key: Option<crate::crypto::pq::MlDsaSigningKey>,
 }
 
@@ -25,7 +24,6 @@ impl LocalSigner {
     pub fn new(signing_key: SigningKey) -> Self {
         Self {
             signing_key,
-            #[cfg(feature = "pq-hybrid")]
             pq_signing_key: {
                 let (sk, _) = crate::crypto::pq::ml_dsa_generate_keypair();
                 Some(sk)
@@ -33,7 +31,6 @@ impl LocalSigner {
         }
     }
 
-    #[cfg(feature = "pq-hybrid")]
     pub fn with_pq_key(mut self, key: crate::crypto::pq::MlDsaSigningKey) -> Self {
         self.pq_signing_key = Some(key);
         self
@@ -57,29 +54,16 @@ impl Signer for LocalSigner {
     }
 
     fn pq_pubkey(&self) -> Option<Vec<u8>> {
-        #[cfg(feature = "pq-hybrid")]
-        {
-            self.pq_signing_key.as_ref().map(|sk| {
-                let vk = ml_dsa::Keypair::verifying_key(sk);
-                crate::crypto::pq::ml_dsa_vk_bytes(&vk)
-            })
-        }
-        #[cfg(not(feature = "pq-hybrid"))]
-        None
+        self.pq_signing_key.as_ref().map(|sk| {
+            let vk = ml_dsa::Keypair::verifying_key(sk);
+            crate::crypto::pq::ml_dsa_vk_bytes(&vk)
+        })
     }
 
     async fn pq_sign(&self, canonical_bytes: &[u8]) -> Result<Option<Vec<u8>>> {
-        #[cfg(feature = "pq-hybrid")]
-        {
-            return match &self.pq_signing_key {
-                Some(sk) => Ok(Some(crate::crypto::pq::ml_dsa_sign(sk, canonical_bytes))),
-                None => Ok(None),
-            };
-        }
-        #[cfg(not(feature = "pq-hybrid"))]
-        {
-            let _ = canonical_bytes;
-            Ok(None)
+        match &self.pq_signing_key {
+            Some(sk) => Ok(Some(crate::crypto::pq::ml_dsa_sign(sk, canonical_bytes))),
+            None => Ok(None),
         }
     }
 }

--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -1360,8 +1360,14 @@ impl Stream for StreamHandle {
 pub struct StreamChannel {
     /// ZMQ context (shared)
     context: Arc<zmq::Context>,
-    /// Signing key for stream registration
+    /// Ed25519 signing key for stream registration
     signing_key: SigningKey,
+    /// ML-DSA-65 signing key for the post-quantum half of the StreamRegister
+    /// composite signature. Mirrors `LocalSigner` on the RPC plane so the
+    /// streaming control plane signs under the same policy (#161). Auto-
+    /// generated; the node's persistent ML-DSA identity is wired in via
+    /// [`Self::with_pq_key`] once peer attestation lands (#157).
+    pq_signing_key: Option<crate::crypto::pq::MlDsaSigningKey>,
     /// Lazy-initialized async PUSH socket to StreamService (wrapped in Arc for sharing)
     push_socket: OnceCell<Arc<tokio::sync::Mutex<tmq::push::Push>>>,
     /// Channel to send subscription requests to the ctrl listener task
@@ -1372,14 +1378,30 @@ pub struct StreamChannel {
 
 impl StreamChannel {
     /// Create a new stream channel.
+    ///
+    /// Auto-generates an ML-DSA-65 key for the post-quantum half of the
+    /// StreamRegister composite, mirroring `LocalSigner::new` on the RPC
+    /// plane. Use [`Self::with_pq_key`] to install the node's persistent
+    /// ML-DSA identity (#157).
     pub fn new(context: Arc<zmq::Context>, signing_key: SigningKey) -> Self {
+        let (pq_sk, _) = crate::crypto::pq::ml_dsa_generate_keypair();
         Self {
             context,
             signing_key,
+            pq_signing_key: Some(pq_sk),
             push_socket: OnceCell::new(),
             ctrl_sub_tx: OnceCell::new(),
             cancel_tokens: Arc::new(DashMap::new()),
         }
+    }
+
+    /// Install the node's persistent ML-DSA-65 signing key, replacing the
+    /// auto-generated one. The matching public key must be anchored in the
+    /// StreamService verifier's PQ trust store for Hybrid verification to
+    /// succeed (peer attestation, #157).
+    pub fn with_pq_key(mut self, key: crate::crypto::pq::MlDsaSigningKey) -> Self {
+        self.pq_signing_key = Some(key);
+        self
     }
 
     /// Prepare a stream with DH key exchange and pre-authorization.
@@ -1478,6 +1500,7 @@ impl StreamChannel {
             topic,
             expiry,
             &self.signing_key,
+            self.pq_signing_key.as_ref(),
             claims,
         );
 
@@ -1854,6 +1877,7 @@ fn build_stream_register_envelope(
     topic: &str,
     expiry: i64,
     signing_key: &SigningKey,
+    pq_signing_key: Option<&crate::crypto::pq::MlDsaSigningKey>,
     _claims: Option<Claims>,
 ) -> Vec<u8> {
     use crate::common_capnp;
@@ -1879,7 +1903,18 @@ fn build_stream_register_envelope(
     let envelope = RequestEnvelope::new(inner_bytes);
     // Claims are no longer carried in the envelope — authorization is via JWT/Authorization field
 
-    let signed = SignedEnvelope::new_signed(envelope, signing_key);
+    // Sign under the same policy mechanism as the RPC plane (#161): Hybrid
+    // (EdDSA + ML-DSA-65 SNS composite) when a PQ key is present, else
+    // Classical. This removes the prior unconditional `new_signed` (Classical)
+    // that the StreamService verifier — enforcing the global Hybrid policy —
+    // would either reject or accept as a strict downgrade vs RPC.
+    let policy = if pq_signing_key.is_some() {
+        crate::crypto::CryptoPolicy::Hybrid
+    } else {
+        crate::crypto::CryptoPolicy::Classical
+    };
+    let signed =
+        SignedEnvelope::new_signed_with_policy(envelope, signing_key, pq_signing_key, policy);
 
     let mut msg = Builder::new_default();
     {
@@ -1926,6 +1961,66 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #161: a StreamRegister built with a PQ key is a Hybrid (SNS) composite
+    /// that verifies under the global Hybrid policy when the signer's ML-DSA
+    /// key is anchored in the PQ trust store — and fail-closes when it isn't,
+    /// exactly mirroring the RPC plane (no silent Classical downgrade).
+    #[test]
+    fn stream_register_hybrid_verifies_only_when_pq_anchored() -> anyhow::Result<()> {
+        use crate::crypto::pq::{ml_dsa_generate_keypair, ml_dsa_vk_from_bytes};
+        use crate::crypto::CryptoPolicy;
+        use crate::envelope::{
+            InMemoryNonceCache, KeyedPqTrustStore, SignedEnvelope,
+        };
+        use crate::common_capnp;
+        use crate::FromCapnp;
+
+        let signing_key = SigningKey::from_bytes(&[7u8; 32]);
+        let (pq_sk, pq_vk) = ml_dsa_generate_keypair();
+
+        let bytes = build_stream_register_envelope(
+            "deadbeef".repeat(8).as_str(),
+            i64::MAX,
+            &signing_key,
+            Some(&pq_sk),
+            None,
+        );
+        assert!(!bytes.is_empty(), "register envelope must serialize");
+
+        let reader = serialize::read_message(
+            &mut std::io::Cursor::new(&bytes[..]),
+            capnp::message::ReaderOptions::default(),
+        )?;
+        let signed = SignedEnvelope::read_from(
+            reader.get_root::<common_capnp::signed_envelope::Reader>()?,
+        )?;
+
+        assert_eq!(signed.policy, CryptoPolicy::Hybrid, "must sign Hybrid with PQ key");
+
+        // Anchored: the signer's ML-DSA vk is bound to its Ed25519 identity.
+        let mut store = KeyedPqTrustStore::new();
+        let vk = ml_dsa_vk_from_bytes(&crate::crypto::pq::ml_dsa_vk_bytes(&pq_vk))?;
+        store.bind(signing_key.verifying_key().to_bytes(), &vk);
+        let nonce_ok = InMemoryNonceCache::new();
+        assert!(
+            signed
+                .verify_any_signer_with(&nonce_ok, Some(&store), CryptoPolicy::Hybrid)
+                .is_ok(),
+            "anchored Hybrid register must verify"
+        );
+
+        // Not anchored: empty store under Hybrid fails closed.
+        let empty = KeyedPqTrustStore::new();
+        let nonce_empty = InMemoryNonceCache::new();
+        assert!(
+            signed
+                .verify_any_signer_with(&nonce_empty, Some(&empty), CryptoPolicy::Hybrid)
+                .is_err(),
+            "unanchored Hybrid register must fail closed (no Classical downgrade)"
+        );
+        Ok(())
+    }
 
     #[test]
     fn test_batching_config_default() {

--- a/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
+++ b/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
@@ -2010,12 +2010,19 @@ where
     use tracing::warn;
 
     // 1. Unwrap, verify, and optionally decrypt the SignedEnvelope.
-    let opts = match verification {
+    //    The verify policy + kid-anchored PQ trust store come from the
+    //    process-global verify configuration installed at startup (Hybrid
+    //    ENFORCED in the daemon). This closes the prior fail-open where the
+    //    site hardcoded Classical / no PQ store.
+    let pq_store_holder = crate::envelope::global_pq_store();
+    let base = match verification {
         EnvelopeVerification::FixedSigner(pubkey) =>
             crate::envelope::UnwrapOptions::fixed_signer(pubkey, nonce_cache),
         EnvelopeVerification::AnySigner =>
             crate::envelope::UnwrapOptions::any_signer(nonce_cache),
     }.with_decryption_key(signing_key);
+    let opts =
+        crate::envelope::apply_global_verify_config(base, &pq_store_holder);
 
     let (mut ctx, payload) = match crate::envelope::unwrap_envelope(raw_bytes, &opts) {
         Ok(result) => result,

--- a/crates/hyprstream-rpc/src/wasm_api.rs
+++ b/crates/hyprstream-rpc/src/wasm_api.rs
@@ -271,7 +271,12 @@ pub fn verify_signed_envelope(
         .map_err(|e| JsError::new(&format!("invalid verifying key: {}", e)))?;
 
     let nonce_cache = WASM_NONCE_CACHE.with(|c| c.clone());
-    let opts = UnwrapOptions::fixed_signer(&verifying_key, &*nonce_cache);
+    // WASM/browser verify currently uses the classical (EdDSA) verifier: the
+    // in-browser side has no kid-anchored ML-DSA trust store wired yet. A
+    // Hybrid-signed envelope still verifies here via its inner EdDSA layer
+    // (skip-unknown). Provisioning a WASM-side PqTrustStore to enforce the SNS
+    // outer layer in the browser is residual integration work.
+    let opts = UnwrapOptions::fixed_signer(&verifying_key, &*nonce_cache).classical();
 
     let (_signed, payload) = unwrap_and_verify(envelope_bytes, &opts)
         .map_err(|e| JsError::new(&format!("envelope verification failed: {}", e)))?;

--- a/crates/hyprstream-rpc/tests/envelope_canonicalization.rs
+++ b/crates/hyprstream-rpc/tests/envelope_canonicalization.rs
@@ -3,12 +3,9 @@ use ed25519_dalek::SigningKey;
 use rand::rngs::OsRng;
 
 fn make_signed(envelope: RequestEnvelope, signing_key: &SigningKey) -> SignedEnvelope {
-    #[cfg(feature = "pq-hybrid")]
-    {
-        let (pq_sk, _) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();
-        SignedEnvelope::new_signed_hybrid(envelope, signing_key, &pq_sk)
-    }
-    #[cfg(not(feature = "pq-hybrid"))]
+    // Classical so the raw Ed25519 `sig` field is deterministic (ML-DSA-65
+    // signatures are randomized/hedged). Composite behavior is tested in the
+    // envelope `cose::`/`crypto::` suites.
     SignedEnvelope::new_signed(envelope, signing_key)
 }
 
@@ -90,8 +87,8 @@ fn test_envelope_signature_verification_stable() {
         cnf: signed1.cnf,
         encrypted_envelope: None,
         client_ephemeral_public: None,
-        pq_sig: signed1.pq_sig.clone(),
-        pq_cnf: signed1.pq_cnf.clone(),
+        cose: signed1.cose.clone(),
+        policy: signed1.policy,
         pq_kem_ciphertext: None,
     };
 

--- a/crates/hyprstream-rpc/tests/iroh_rpc_e2e.rs
+++ b/crates/hyprstream-rpc/tests/iroh_rpc_e2e.rs
@@ -110,6 +110,19 @@ fn direct_addr(substrate: &IrohSubstrate) -> EndpointAddr {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn signed_envelope_round_trip_over_iroh() -> Result<()> {
+    // This canary exercises the classical (EdDSA-only) wire+envelope path. As
+    // an integration test it compiles hyprstream-rpc in non-test mode, where
+    // the uninstalled global verify policy now fail-closes to Hybrid (#160).
+    // Opt in to the Classical policy this test actually validates. `set` is
+    // idempotent-by-first-write; ignore the error if another test in this
+    // binary already installed a (matching) config.
+    let _ = hyprstream_rpc::envelope::install_verify_config(
+        hyprstream_rpc::envelope::EnvelopeVerifyConfig {
+            policy: hyprstream_rpc::crypto::CryptoPolicy::Classical,
+            pq_store: None,
+        },
+    );
+
     // ─── Server side ──────────────────────────────────────────────────────
     let server_signing = fresh_signing_key();
     let server_verifying: VerifyingKey = server_signing.verifying_key();

--- a/crates/hyprstream-service/Cargo.toml
+++ b/crates/hyprstream-service/Cargo.toml
@@ -67,7 +67,7 @@ zbus_systemd = { version = "0.0.11", features = ["login1", "systemd1"], optional
 [features]
 default = []
 systemd = ["dep:systemd", "dep:zbus_systemd"]
-pq-hybrid = ["hyprstream-rpc/pq-hybrid"]
+pq-hybrid = []  # NO-OP alias (PQ always compiled; runtime CryptoPolicy). See M3 #152.
 
 [lints]
 workspace = true

--- a/crates/hyprstream-service/src/service/factory.rs
+++ b/crates/hyprstream-service/src/service/factory.rs
@@ -234,7 +234,10 @@ pub struct ServiceContext {
 
     /// Shared ML-DSA-65 verifying keys for PQ-hybrid JWT verification.
     /// Updated by the rotation task; shared across all key sources.
-    #[cfg(feature = "pq-hybrid")]
+    ///
+    /// Uses `std::sync::RwLock` to match the cross-crate `Arc<RwLock<..>>`
+    /// contract with `hyprstream::auth::key_rotation` and `JwtKeySource`.
+    #[allow(clippy::disallowed_types)]
     ml_dsa_verifying_keys: std::sync::Arc<std::sync::RwLock<Vec<hyprstream_rpc::crypto::pq::MlDsaVerifyingKey>>>,
 }
 
@@ -263,19 +266,21 @@ impl ServiceContext {
             service_keys: HashMap::new(),
             ca_verifying_key: None,
             jwks_fetcher: None,
-            #[cfg(feature = "pq-hybrid")]
-            ml_dsa_verifying_keys: std::sync::Arc::new(std::sync::RwLock::new(Vec::new())),
+            ml_dsa_verifying_keys: {
+                #[allow(clippy::disallowed_types)]
+                std::sync::Arc::new(std::sync::RwLock::new(Vec::new()))
+            },
         }
     }
 
     /// Set the shared ML-DSA-65 verifying keys for PQ-hybrid JWT verification.
-    #[cfg(feature = "pq-hybrid")]
+    #[allow(clippy::disallowed_types)]
     pub fn set_ml_dsa_verifying_keys(&mut self, keys: std::sync::Arc<std::sync::RwLock<Vec<hyprstream_rpc::crypto::pq::MlDsaVerifyingKey>>>) {
         self.ml_dsa_verifying_keys = keys;
     }
 
     /// Get a clone of the shared ML-DSA verifying keys Arc.
-    #[cfg(feature = "pq-hybrid")]
+    #[allow(clippy::disallowed_types)]
     pub fn ml_dsa_verifying_keys_arc(&self) -> std::sync::Arc<std::sync::RwLock<Vec<hyprstream_rpc::crypto::pq::MlDsaVerifyingKey>>> {
         self.ml_dsa_verifying_keys.clone()
     }
@@ -556,7 +561,6 @@ impl ServiceContext {
                 issuer_url,
                 fetcher.clone(),
             );
-            #[cfg(feature = "pq-hybrid")]
             let source = source.with_ml_dsa_verifying_keys(self.ml_dsa_verifying_keys.clone());
             std::sync::Arc::new(source)
         } else {
@@ -564,7 +568,6 @@ impl ServiceContext {
                 self.jwt_verifying_key(),
                 issuer_url,
             );
-            #[cfg(feature = "pq-hybrid")]
             let source = source.with_ml_dsa_verifying_keys(self.ml_dsa_verifying_keys.clone());
             std::sync::Arc::new(source)
         }

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -48,7 +48,7 @@ serde_yaml.workspace = true
 git2.workspace = true  # Still needed by git2db internally
 git2db = { path = "../git2db", features = ["overlayfs"] }  # High-level git library with overlayfs
 hyprstream-rpc = { path = "../hyprstream-rpc" }  # RPC infrastructure (Cap'n Proto + ZMQ)
-ml-dsa = { workspace = true, optional = true }  # ML-DSA-65 (pq-hybrid JWT signing)
+ml-dsa = { workspace = true }  # ML-DSA-65 — always compiled (runtime CryptoPolicy selects PQ). See M3 #152.
 hyprstream-rpc-std = { path = "../hyprstream-rpc-std" }  # Standard service schemas + clients
 hyprstream-discovery = { path = "../hyprstream-discovery" }  # Service discovery
 hyprstream-service = { path = "../hyprstream-service" }  # Service orchestration
@@ -202,7 +202,7 @@ download-libtorch = ["tch/download-libtorch"]
 overlayfs = ["git2db/overlayfs"]  # Enable overlayfs-backed worktrees (delegated to git2db)
 systemd = ["hyprstream-rpc/systemd", "hyprstream-service/systemd", "hyprstream-workers/systemd", "dep:listenfd"]  # Systemd integration (socket activation, service units)
 experimental = ["hyprstream-compositor/experimental"]  # EXPERIMENTAL: Enable service/worker panels, git write operations
-pq-hybrid = ["hyprstream-rpc/pq-hybrid", "hyprstream-service/pq-hybrid", "dep:ml-dsa"]  # Post-quantum hybrid: ML-DSA-65 + ML-KEM-768
+pq-hybrid = []  # NO-OP alias: PQ primitives always compiled; Classical/Hybrid selected at runtime. See M3 #152.
 
 [build-dependencies]
 capnpc.workspace = true  # Cap'n Proto schema compiler

--- a/crates/hyprstream/src/auth/jwt.rs
+++ b/crates/hyprstream/src/auth/jwt.rs
@@ -74,7 +74,6 @@ pub fn generate_es256_key() -> Es256SigningKey {
 // ── ML-DSA-65 JWT encoding (draft-ietf-cose-dilithium-11) ──────────────
 
 /// Encode and sign a JWT with ML-DSA-65 (`alg: "ML-DSA-65"`, `kty: "AKP"`).
-#[cfg(feature = "pq-hybrid")]
 pub fn encode_ml_dsa_65(
     claims: &Claims,
     signing_key: &hyprstream_rpc::crypto::pq::MlDsaSigningKey,
@@ -109,7 +108,6 @@ pub fn encode_ml_dsa_65(
 ///
 /// Signature = ML-DSA-65 sig (3309 bytes) ∥ Ed25519 sig (64 bytes).
 /// Per draft-ietf-jose-pq-composite-sigs.
-#[cfg(feature = "pq-hybrid")]
 pub fn encode_composite_ml_dsa_65_ed25519(
     claims: &Claims,
     ml_dsa_key: &hyprstream_rpc::crypto::pq::MlDsaSigningKey,
@@ -155,7 +153,6 @@ pub fn encode_composite_ml_dsa_65_ed25519(
 }
 
 /// Encode a service WIT (`typ: "wit+jwt"`) with ML-DSA-65-Ed25519 composite signature.
-#[cfg(feature = "pq-hybrid")]
 pub fn encode_composite_service_jwt(
     claims: &Claims,
     ml_dsa_key: &hyprstream_rpc::crypto::pq::MlDsaSigningKey,
@@ -201,7 +198,6 @@ pub fn encode_composite_service_jwt(
 }
 
 /// Build a JWK for an ML-DSA-65 key (`kty: "AKP"`).
-#[cfg(feature = "pq-hybrid")]
 pub fn ml_dsa_65_jwk(
     vk: &hyprstream_rpc::crypto::pq::MlDsaVerifyingKey,
 ) -> serde_json::Value {
@@ -222,7 +218,6 @@ pub fn ml_dsa_65_jwk(
 }
 
 /// Build a JWK for a composite ML-DSA-65-Ed25519 key (`kty: "AKP"`).
-#[cfg(feature = "pq-hybrid")]
 pub fn composite_jwk(
     ml_dsa_vk: &hyprstream_rpc::crypto::pq::MlDsaVerifyingKey,
     ed25519_vk: &ed25519_dalek::VerifyingKey,
@@ -313,7 +308,6 @@ mod tests {
         assert!(decoded.jti.is_some());
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn ml_dsa_65_roundtrip() {
         let (sk, vk) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();
@@ -334,7 +328,6 @@ mod tests {
         assert!(decoded.jti.is_some());
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn ml_dsa_65_jwk_structure() {
         let (sk, _) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();
@@ -347,7 +340,6 @@ mod tests {
         assert!(jwk["pub"].as_str().is_some());
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn composite_ml_dsa_65_ed25519_roundtrip() {
         let (ml_dsa_sk, ml_dsa_vk) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();
@@ -371,7 +363,6 @@ mod tests {
         assert!(decoded.jti.is_some());
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn composite_jwk_structure() {
         let (ml_dsa_sk, _) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();
@@ -387,7 +378,6 @@ mod tests {
         assert!(jwk["pub"].as_str().is_some());
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn ml_dsa_65_wrong_key_rejects() {
         let (sk, _) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();
@@ -397,7 +387,6 @@ mod tests {
         assert!(hyprstream_rpc::auth::jwt::decode_ml_dsa_65(&token, &wrong_vk, None).is_err());
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn composite_wrong_ed25519_key_rejects() {
         let (ml_dsa_sk, ml_dsa_vk) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();
@@ -411,7 +400,6 @@ mod tests {
         ).is_err());
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn ml_dsa_65_expired_token_rejected() {
         let (sk, vk) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();
@@ -421,7 +409,6 @@ mod tests {
         assert!(matches!(err, hyprstream_rpc::auth::JwtError::Expired));
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn composite_expired_token_rejected() {
         let (ml_dsa_sk, ml_dsa_vk) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();
@@ -435,7 +422,6 @@ mod tests {
         assert!(matches!(err, hyprstream_rpc::auth::JwtError::Expired));
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn ml_dsa_65_rejects_eddsa_token() {
         let ed25519_sk = ed25519_dalek::SigningKey::from_bytes(&[42u8; 32]);
@@ -445,7 +431,6 @@ mod tests {
         assert!(hyprstream_rpc::auth::jwt::decode_ml_dsa_65(&token, &vk, None).is_err());
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn ml_dsa_65_lenient_audience() {
         let (sk, vk) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();
@@ -457,7 +442,6 @@ mod tests {
         ).is_ok());
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn ml_dsa_65_wrong_audience_rejected() {
         let (sk, vk) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();

--- a/crates/hyprstream/src/auth/key_rotation.rs
+++ b/crates/hyprstream/src/auth/key_rotation.rs
@@ -25,11 +25,13 @@ use crate::config::OAuthConfig;
 /// Populated at startup from the ML-DSA rotation store's current slots.
 /// Updated by the rotation task after each promotion. Services read from this
 /// via their `JwtKeySource` implementation.
-#[cfg(feature = "pq-hybrid")]
+// Cross-crate `Arc<std::sync::RwLock<..>>` contract with `JwtKeySource` and the
+// service factory; intentionally `std::sync::RwLock`, not `parking_lot`.
+#[allow(clippy::disallowed_types)]
 static ML_DSA_VERIFYING_KEYS: std::sync::OnceLock<std::sync::Arc<std::sync::RwLock<Vec<hyprstream_rpc::crypto::pq::MlDsaVerifyingKey>>>> = std::sync::OnceLock::new();
 
 /// Get or initialize the global ML-DSA verifying keys Arc.
-#[cfg(feature = "pq-hybrid")]
+#[allow(clippy::disallowed_types)]
 pub fn global_ml_dsa_verifying_keys() -> std::sync::Arc<std::sync::RwLock<Vec<hyprstream_rpc::crypto::pq::MlDsaVerifyingKey>>> {
     ML_DSA_VERIFYING_KEYS.get_or_init(|| {
         std::sync::Arc::new(std::sync::RwLock::new(Vec::new()))
@@ -40,13 +42,11 @@ pub fn global_ml_dsa_verifying_keys() -> std::sync::Arc<std::sync::RwLock<Vec<hy
 ///
 /// Ensures all services (PolicyService, OAuthService, rotation task) share
 /// the same store instance — rotation applies universally.
-#[cfg(feature = "pq-hybrid")]
 static ML_DSA_SIGNING_STORE: std::sync::OnceLock<Arc<MlDsaSigningKeyStore>> = std::sync::OnceLock::new();
 
 /// Get or initialize the global ML-DSA signing key store.
 ///
 /// First call initializes from disk; subsequent calls return the same Arc.
-#[cfg(feature = "pq-hybrid")]
 pub fn global_ml_dsa_key_store(secrets_dir: &Path, config: &OAuthConfig) -> Arc<MlDsaSigningKeyStore> {
     ML_DSA_SIGNING_STORE.get_or_init(|| {
         Arc::new(load_or_init_ml_dsa_key_store(secrets_dir, config))
@@ -307,7 +307,6 @@ pub async fn rotate_jwt_keys(
 /// Additional stores to rotate alongside the primary Ed25519 store.
 pub struct RotationStores {
     pub es256: Option<Arc<Es256SigningKeyStore>>,
-    #[cfg(feature = "pq-hybrid")]
     pub ml_dsa: Option<Arc<MlDsaSigningKeyStore>>,
 }
 
@@ -329,12 +328,11 @@ pub fn spawn_rotation_task(
             if let Some(ref es256) = extra.es256 {
                 rotate_es256_keys(&config, &secrets_dir, es256, now).await;
             }
-            #[cfg(feature = "pq-hybrid")]
             if let Some(ref ml_dsa) = extra.ml_dsa {
                 rotate_ml_dsa_keys(&config, &secrets_dir, ml_dsa, now).await;
                 // Refresh the global verifying key snapshot.
                 let vks: Vec<_> = ml_dsa.all_slots_snapshot().await.iter()
-                    .map(|slot| slot.verifying_key())
+                    .map(ml_dsa_rotation::MlDsaKeySlot::verifying_key)
                     .collect();
                 let shared = global_ml_dsa_verifying_keys();
                 let _ = shared.write().map(|mut guard| *guard = vks);
@@ -533,10 +531,9 @@ pub async fn rotate_es256_keys(
 }
 
 // ════════════════════════════════════════════════════════════════════════════════
-// ML-DSA-65 Key Rotation Store (pq-hybrid feature)
+// ML-DSA-65 Key Rotation Store (always compiled; runtime CryptoPolicy)
 // ════════════════════════════════════════════════════════════════════════════════
 
-#[cfg(feature = "pq-hybrid")]
 mod ml_dsa_rotation {
     use super::*;
     use hyprstream_rpc::crypto::pq::{
@@ -684,8 +681,9 @@ mod ml_dsa_rotation {
         let drain_secs = config.drain_secs();
 
         // Phase 1: promote lead → active
-        if let Some(ref lead) = slots.lead {
-            if lead.nbf <= now {
+        let lead_ready = slots.lead.as_ref().is_some_and(|lead| lead.nbf <= now);
+        if lead_ready {
+            if let Some(new_active) = slots.lead.take() {
                 if let Some(old_active) = slots.active.take() {
                     delete_ml_dsa_slot(secrets_dir, "drain");
                     if let Err(e) = persist_ml_dsa_slot(secrets_dir, "drain", &old_active) {
@@ -693,7 +691,6 @@ mod ml_dsa_rotation {
                     }
                     slots.drain = Some(old_active);
                 }
-                let new_active = slots.lead.take().unwrap();
                 if let Err(e) = persist_ml_dsa_slot(secrets_dir, "active", &new_active) {
                     warn!("ML-DSA: failed to persist promoted active: {e}");
                 }
@@ -729,7 +726,6 @@ mod ml_dsa_rotation {
     }
 }
 
-#[cfg(feature = "pq-hybrid")]
 pub use ml_dsa_rotation::{MlDsaKeySlot, MlDsaKeySlots, MlDsaSigningKeyStore, load_or_init_ml_dsa_key_store, rotate_ml_dsa_keys};
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -927,7 +923,6 @@ mod tests {
 
     // ── ML-DSA store tests ─────────────────────────────────────────────────
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn ml_dsa_load_or_init_creates_active_key() {
         let dir = TempDir::new().unwrap();
@@ -938,7 +933,6 @@ mod tests {
         assert!(key.is_some());
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn ml_dsa_persist_and_reload() {
         let dir = TempDir::new().unwrap();
@@ -957,7 +951,6 @@ mod tests {
         assert_eq!(vk1, vk2, "ML-DSA key must survive reload from disk");
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[tokio::test]
     async fn ml_dsa_rotate_promotes_lead() {
         use super::ml_dsa_rotation::*;

--- a/crates/hyprstream/src/auth/mod.rs
+++ b/crates/hyprstream/src/auth/mod.rs
@@ -23,7 +23,6 @@ pub mod valkey;
 pub use federation::FederationKeyResolver;
 pub use jwt::{Claims, JwtError};
 pub use key_rotation::{SigningKeyStore, Es256SigningKeyStore, Es256KeySlot, RotationStores};
-#[cfg(feature = "pq-hybrid")]
 pub use key_rotation::{MlDsaSigningKeyStore, MlDsaKeySlot};
 pub use policy_manager::{PolicyManager, PolicyError, write_policy_file, global_policy_manager, set_global_policy_manager};
 pub use policy_migration::migrate_policy_csv;

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1944,7 +1944,6 @@ fn main() -> Result<()> {
                                 }
 
                                 // Populate ML-DSA-65 verifying keys for PQ-hybrid JWT verification.
-                                #[cfg(feature = "pq-hybrid")]
                                 {
                                     let secrets_dir = hyprstream_core::config::HyprConfig::resolve_secrets_dir();
                                     let ml_dsa_store = hyprstream_core::auth::key_rotation::global_ml_dsa_key_store(
@@ -1956,12 +1955,80 @@ fn main() -> Result<()> {
                                         rt.block_on(ml_dsa_store.all_slots_snapshot())
                                     })
                                     .iter()
-                                    .map(|slot| slot.verifying_key())
+                                    .map(hyprstream_core::auth::MlDsaKeySlot::verifying_key)
                                     .collect();
                                     let shared_vks = hyprstream_core::auth::key_rotation::global_ml_dsa_verifying_keys();
                                     let _ = shared_vks.write().map(|mut guard| *guard = vks);
                                     ctx.set_ml_dsa_verifying_keys(shared_vks);
                                     tracing::info!("PQ-hybrid: ML-DSA-65 verifying keys loaded for JWT verification");
+                                }
+
+                                // M3 (#152): install the process-global envelope
+                                // verify configuration that closes the fail-open
+                                // at the ZMQ RequestLoop + StreamService verify
+                                // sites.
+                                //
+                                // KEY SEPARATION (PQUIP key-reuse restriction):
+                                // the mesh hybrid identity's ML-DSA key MUST be
+                                // distinct from the JWT-signing ML-DSA keyset
+                                // (`global_ml_dsa_verifying_keys`, loaded above).
+                                // We therefore DO NOT seed the mesh PqTrustStore
+                                // from the JWT keyset. The mesh store is keyed by
+                                // Ed25519 signer identity and is populated from
+                                // attested peer identities (peer-attestation
+                                // registry — residual integration work).
+                                //
+                                // Policy: Hybrid is enforced by default. Operators
+                                // mid-rollout (before peer ML-DSA bindings are
+                                // provisioned) may set
+                                // HYPRSTREAM_ENVELOPE_POLICY=classical to keep the
+                                // legacy EdDSA-only verifier. Under Hybrid with no
+                                // anchored key the verifier FAILS CLOSED.
+                                {
+                                    use hyprstream_rpc::envelope::{
+                                        install_verify_config, EnvelopeVerifyConfig, KeyedPqTrustStore,
+                                    };
+                                    use hyprstream_rpc::crypto::CryptoPolicy;
+
+                                    let policy = match std::env::var("HYPRSTREAM_ENVELOPE_POLICY")
+                                        .ok()
+                                        .as_deref()
+                                    {
+                                        Some("classical") => CryptoPolicy::Classical,
+                                        Some("hybrid") | None => CryptoPolicy::Hybrid,
+                                        Some(other) => {
+                                            tracing::warn!(
+                                                "unknown HYPRSTREAM_ENVELOPE_POLICY={other:?}, defaulting to Hybrid"
+                                            );
+                                            CryptoPolicy::Hybrid
+                                        }
+                                    };
+
+                                    // Mesh kid-anchored PQ trust store. Peer
+                                    // bindings (Ed25519 signer -> trusted ML-DSA)
+                                    // are added by the attestation layer; an empty
+                                    // store under Hybrid fails closed for unknown
+                                    // peers (correct, by design).
+                                    let pq_store: std::sync::Arc<dyn hyprstream_rpc::envelope::PqTrustStore> =
+                                        std::sync::Arc::new(KeyedPqTrustStore::new());
+
+                                    if install_verify_config(EnvelopeVerifyConfig {
+                                        policy,
+                                        pq_store: Some(pq_store),
+                                    })
+                                    .is_ok()
+                                    {
+                                        match policy {
+                                            CryptoPolicy::Hybrid => tracing::info!(
+                                                "envelope verify policy: HYBRID enforced (SNS nested COSE); \
+                                                 peer ML-DSA bindings required for cross-node traffic"
+                                            ),
+                                            CryptoPolicy::Classical => tracing::warn!(
+                                                "envelope verify policy: CLASSICAL (EdDSA-only) — \
+                                                 set HYPRSTREAM_ENVELOPE_POLICY=hybrid to enforce PQ"
+                                            ),
+                                        }
+                                    }
                                 }
 
                                 let manager = InprocManager::new();

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1095,6 +1095,11 @@ fn handle_quick_command(
                             hyprstream_core::services::build_authorize_fn(worker_policy_client),
                         );
 
+                        // Standalone worker entrypoint serves RPC, so it must
+                        // install the verify config too (#160) — otherwise the
+                        // fail-closed default rejects all mesh traffic.
+                        install_envelope_verify_config();
+
                         let manager = InprocManager::new();
                         Some(
                             manager
@@ -1296,6 +1301,58 @@ fn resolve_service_vk(service_name: &str) -> Option<VerifyingKey> {
         }
     }
     trust.resolve_one(service_name)
+}
+
+/// Install the process-global envelope verify configuration (#152, #160).
+///
+/// MUST be called once at startup on **every** process entrypoint that serves
+/// RPC — the inproc daemon AND standalone service entrypoints (e.g. a lone
+/// worker). When uninstalled, `global_verify_policy()` fail-closes to Hybrid
+/// (#160), so a missing call here breaks mesh verification loudly rather than
+/// silently downgrading to EdDSA-only. `install_verify_config` is first-write-
+/// wins, so calling it from multiple stages within one process is harmless.
+///
+/// Policy default is Hybrid (SNS nested COSE); operators mid-rollout, before
+/// peer ML-DSA bindings are provisioned, may set
+/// `HYPRSTREAM_ENVELOPE_POLICY=classical`. Under Hybrid with no anchored peer
+/// key the verifier fails closed (correct, by design).
+fn install_envelope_verify_config() {
+    use hyprstream_rpc::crypto::CryptoPolicy;
+    use hyprstream_rpc::envelope::{
+        install_verify_config, EnvelopeVerifyConfig, KeyedPqTrustStore, PqTrustStore,
+    };
+
+    let policy = match std::env::var("HYPRSTREAM_ENVELOPE_POLICY").ok().as_deref() {
+        Some("classical") => CryptoPolicy::Classical,
+        Some("hybrid") | None => CryptoPolicy::Hybrid,
+        Some(other) => {
+            tracing::warn!("unknown HYPRSTREAM_ENVELOPE_POLICY={other:?}, defaulting to Hybrid");
+            CryptoPolicy::Hybrid
+        }
+    };
+
+    // Mesh kid-anchored PQ trust store. Peer bindings (Ed25519 signer ->
+    // trusted ML-DSA) are added by the attestation layer; an empty store under
+    // Hybrid fails closed for unknown peers (correct, by design).
+    let pq_store: std::sync::Arc<dyn PqTrustStore> = std::sync::Arc::new(KeyedPqTrustStore::new());
+
+    if install_verify_config(EnvelopeVerifyConfig {
+        policy,
+        pq_store: Some(pq_store),
+    })
+    .is_ok()
+    {
+        match policy {
+            CryptoPolicy::Hybrid => tracing::info!(
+                "envelope verify policy: HYBRID enforced (SNS nested COSE); \
+                 peer ML-DSA bindings required for cross-node traffic"
+            ),
+            CryptoPolicy::Classical => tracing::warn!(
+                "envelope verify policy: CLASSICAL (EdDSA-only) — \
+                 set HYPRSTREAM_ENVELOPE_POLICY=hybrid to enforce PQ"
+            ),
+        }
+    }
 }
 
 fn main() -> Result<()> {
@@ -1984,52 +2041,7 @@ fn main() -> Result<()> {
                                 // HYPRSTREAM_ENVELOPE_POLICY=classical to keep the
                                 // legacy EdDSA-only verifier. Under Hybrid with no
                                 // anchored key the verifier FAILS CLOSED.
-                                {
-                                    use hyprstream_rpc::envelope::{
-                                        install_verify_config, EnvelopeVerifyConfig, KeyedPqTrustStore,
-                                    };
-                                    use hyprstream_rpc::crypto::CryptoPolicy;
-
-                                    let policy = match std::env::var("HYPRSTREAM_ENVELOPE_POLICY")
-                                        .ok()
-                                        .as_deref()
-                                    {
-                                        Some("classical") => CryptoPolicy::Classical,
-                                        Some("hybrid") | None => CryptoPolicy::Hybrid,
-                                        Some(other) => {
-                                            tracing::warn!(
-                                                "unknown HYPRSTREAM_ENVELOPE_POLICY={other:?}, defaulting to Hybrid"
-                                            );
-                                            CryptoPolicy::Hybrid
-                                        }
-                                    };
-
-                                    // Mesh kid-anchored PQ trust store. Peer
-                                    // bindings (Ed25519 signer -> trusted ML-DSA)
-                                    // are added by the attestation layer; an empty
-                                    // store under Hybrid fails closed for unknown
-                                    // peers (correct, by design).
-                                    let pq_store: std::sync::Arc<dyn hyprstream_rpc::envelope::PqTrustStore> =
-                                        std::sync::Arc::new(KeyedPqTrustStore::new());
-
-                                    if install_verify_config(EnvelopeVerifyConfig {
-                                        policy,
-                                        pq_store: Some(pq_store),
-                                    })
-                                    .is_ok()
-                                    {
-                                        match policy {
-                                            CryptoPolicy::Hybrid => tracing::info!(
-                                                "envelope verify policy: HYBRID enforced (SNS nested COSE); \
-                                                 peer ML-DSA bindings required for cross-node traffic"
-                                            ),
-                                            CryptoPolicy::Classical => tracing::warn!(
-                                                "envelope verify policy: CLASSICAL (EdDSA-only) — \
-                                                 set HYPRSTREAM_ENVELOPE_POLICY=hybrid to enforce PQ"
-                                            ),
-                                        }
-                                    }
-                                }
+                                install_envelope_verify_config();
 
                                 let manager = InprocManager::new();
                                 let mut handles = Vec::new();

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -338,7 +338,6 @@ fn create_policy_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
     let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir();
     let es256_store = crate::auth::key_rotation::global_es256_key_store(&secrets_dir, &config.oauth);
     policy_service = policy_service.with_es256_key_store(es256_store);
-    #[cfg(feature = "pq-hybrid")]
     {
         let ml_dsa_store = crate::auth::key_rotation::global_ml_dsa_key_store(&secrets_dir, &config.oauth);
         policy_service = policy_service.with_ml_dsa_key_store(ml_dsa_store);

--- a/crates/hyprstream/src/services/oauth/dpop.rs
+++ b/crates/hyprstream/src/services/oauth/dpop.rs
@@ -27,9 +27,7 @@ use subtle::ConstantTimeEq;
 pub enum DpopKey {
     Ed25519 { bytes: [u8; 32] },
     Es256 { x: [u8; 32], y: [u8; 32] },
-    #[cfg(feature = "pq-hybrid")]
     MlDsa65 { pub_bytes: Vec<u8> },
-    #[cfg(feature = "pq-hybrid")]
     MlDsa65Ed25519 { pub_bytes: Vec<u8> },
 }
 
@@ -42,11 +40,9 @@ impl DpopKey {
             DpopKey::Es256 { x, y } => {
                 jwk_thumbprint(&JwkThumbprintInput::Es256 { x, y })
             }
-            #[cfg(feature = "pq-hybrid")]
             DpopKey::MlDsa65 { pub_bytes } => {
                 jwk_thumbprint(&JwkThumbprintInput::Akp { alg: "ML-DSA-65", pub_bytes })
             }
-            #[cfg(feature = "pq-hybrid")]
             DpopKey::MlDsa65Ed25519 { pub_bytes } => {
                 jwk_thumbprint(&JwkThumbprintInput::Akp { alg: "ML-DSA-65-Ed25519", pub_bytes })
             }
@@ -163,8 +159,7 @@ pub fn verify_dpop_proof(
         let (x, y) = extract_p256_key(jwk)?;
         verify_es256(&x, &y, signing_input.as_bytes(), &sig_bytes)?;
         DpopKey::Es256 { x, y }
-    } else if cfg!(feature = "pq-hybrid") && alg == "ML-DSA-65" {
-        #[cfg(feature = "pq-hybrid")]
+    } else if alg == "ML-DSA-65" {
         {
             let pub_bytes = extract_akp_pub(jwk)?;
             let vk = hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(&pub_bytes)
@@ -173,10 +168,7 @@ pub fn verify_dpop_proof(
                 .map_err(|_| DpopError::SignatureInvalid)?;
             DpopKey::MlDsa65 { pub_bytes }
         }
-        #[cfg(not(feature = "pq-hybrid"))]
-        return Err(DpopError::WrongAlg(alg.to_owned()))
-    } else if cfg!(feature = "pq-hybrid") && alg == "ML-DSA-65-Ed25519" {
-        #[cfg(feature = "pq-hybrid")]
+    } else if alg == "ML-DSA-65-Ed25519" {
         {
             let pub_bytes = extract_akp_pub(jwk)?;
             // Composite: ML-DSA-65 vk (1952) + Ed25519 vk (32) = 1984
@@ -203,8 +195,6 @@ pub fn verify_dpop_proof(
                 .map_err(|_| DpopError::SignatureInvalid)?;
             DpopKey::MlDsa65Ed25519 { pub_bytes }
         }
-        #[cfg(not(feature = "pq-hybrid"))]
-        return Err(DpopError::WrongAlg(alg.to_owned()))
     } else {
         return Err(DpopError::WrongAlg(alg.to_owned()));
     };
@@ -298,7 +288,6 @@ fn extract_p256_key(jwk: &serde_json::Value) -> Result<([u8; 32], [u8; 32]), Dpo
     Ok((x_bytes, y_bytes))
 }
 
-#[cfg(feature = "pq-hybrid")]
 fn extract_akp_pub(jwk: &serde_json::Value) -> Result<Vec<u8>, DpopError> {
     if jwk["kty"].as_str() != Some("AKP") {
         return Err(DpopError::InvalidJwk);
@@ -435,10 +424,9 @@ mod dpop_nonce_tests {
 
 /// Regression test: take a JWT-style DPoP proof signed with a composite alg,
 /// strip the ML-DSA-65 sig half, confirm `verify_dpop_proof` rejects.
-#[cfg(all(test, feature = "pq-hybrid"))]
+#[cfg(test)]
 mod dpop_stripping_tests {
     use super::*;
-    use base64::Engine as _;
     use ed25519_dalek::Signer as _;
 
     #[test]

--- a/crates/hyprstream/src/services/oauth/federation_entity.rs
+++ b/crates/hyprstream/src/services/oauth/federation_entity.rs
@@ -115,7 +115,6 @@ pub async fn build_entity_configuration_jwt(state: &OAuthState) -> Result<String
     }
 
     // ML-DSA-65 keys from rotation store.
-    #[cfg(feature = "pq-hybrid")]
     if let Some(ref store) = state.ml_dsa_key_store {
         for slot in store.all_slots_snapshot().await {
             let ml_vk = ml_dsa::Keypair::verifying_key(&*slot.key);

--- a/crates/hyprstream/src/services/oauth/jwks.rs
+++ b/crates/hyprstream/src/services/oauth/jwks.rs
@@ -91,7 +91,6 @@ pub async fn jwks(State(state): State<Arc<OAuthState>>) -> impl IntoResponse {
     }
 
     // ML-DSA-65 from rotation store — publish all slots + composite pairing
-    #[cfg(feature = "pq-hybrid")]
     if let Some(ref store) = state.ml_dsa_key_store {
         for slot in store.all_slots_snapshot().await {
             let vk = ml_dsa::Keypair::verifying_key(&*slot.key);

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -446,12 +446,10 @@ impl Spawnable for OAuthService {
             );
             info!("ES256 (P-256) signing key rotation store loaded");
 
-            #[cfg(feature = "pq-hybrid")]
             let ml_dsa_store = crate::auth::key_rotation::global_ml_dsa_key_store(
                 &secrets_dir,
                 &self.config,
             );
-            #[cfg(feature = "pq-hybrid")]
             info!("ML-DSA-65 signing key rotation store loaded");
 
             let (ca_jwt_key, signing_key_store) = match crate::auth::identity_store::load_ca_signing_key(&credentials_dir) {
@@ -473,7 +471,6 @@ impl Spawnable for OAuthService {
                         Arc::clone(&store_arc),
                         crate::auth::key_rotation::RotationStores {
                             es256: Some(Arc::clone(&es256_store)),
-                            #[cfg(feature = "pq-hybrid")]
                             ml_dsa: Some(Arc::clone(&ml_dsa_store)),
                         },
                     );
@@ -513,7 +510,6 @@ impl Spawnable for OAuthService {
                 oauth_state = oauth_state.with_signing_key_store(store);
             }
             oauth_state = oauth_state.with_es256_key_store(Arc::clone(&es256_store));
-            #[cfg(feature = "pq-hybrid")]
             {
                 oauth_state = oauth_state.with_ml_dsa_key_store(Arc::clone(&ml_dsa_store));
             }

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -367,7 +367,6 @@ pub struct OAuthState {
     /// ES256 (P-256) signing key rotation store for JWKS and DPoP/atproto interop.
     pub es256_key_store: Option<Arc<crate::auth::Es256SigningKeyStore>>,
     /// ML-DSA-65 signing key rotation store for PQ-hybrid JWT issuance.
-    #[cfg(feature = "pq-hybrid")]
     pub ml_dsa_key_store: Option<Arc<crate::auth::MlDsaSigningKeyStore>>,
 }
 
@@ -417,7 +416,6 @@ impl OAuthState {
             signing_key_store: None,
             jti_blocklist: None,
             es256_key_store: None,
-            #[cfg(feature = "pq-hybrid")]
             ml_dsa_key_store: None,
         }
     }
@@ -456,7 +454,6 @@ impl OAuthState {
     }
 
     /// Attach the ML-DSA-65 key rotation store.
-    #[cfg(feature = "pq-hybrid")]
     pub fn with_ml_dsa_key_store(mut self, store: Arc<crate::auth::MlDsaSigningKeyStore>) -> Self {
         self.ml_dsa_key_store = Some(store);
         self

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -78,7 +78,6 @@ pub struct PolicyService {
     /// ES256 (P-256) key rotation store for DPoP/atproto interop.
     es256_key_store: Option<Arc<crate::auth::Es256SigningKeyStore>>,
     /// ML-DSA-65 key rotation store for PQ-hybrid composite token issuance.
-    #[cfg(feature = "pq-hybrid")]
     ml_dsa_key_store: Option<Arc<crate::auth::MlDsaSigningKeyStore>>,
 }
 
@@ -109,7 +108,6 @@ impl PolicyService {
             event_prefixes: RwLock::new(HashMap::new()),
             jti_blocklist: Arc::new(hyprstream_rpc::auth::InMemoryJtiBlocklist::new()),
             es256_key_store: None,
-            #[cfg(feature = "pq-hybrid")]
             ml_dsa_key_store: None,
         }
     }
@@ -127,7 +125,6 @@ impl PolicyService {
 
     /// Sign a token with composite PQ signature when available, falling back to Ed25519.
     async fn sign_token(&self, claims: &hyprstream_rpc::auth::Claims, is_service: bool) -> String {
-        #[cfg(feature = "pq-hybrid")]
         {
             let ml_dsa_key = if let Some(ref store) = self.ml_dsa_key_store {
                 store.active_key().await
@@ -169,7 +166,6 @@ impl PolicyService {
     }
 
     /// Attach the ML-DSA-65 key rotation store for composite token issuance.
-    #[cfg(feature = "pq-hybrid")]
     pub fn with_ml_dsa_key_store(mut self, store: Arc<crate::auth::MlDsaSigningKeyStore>) -> Self {
         self.ml_dsa_key_store = Some(store);
         self


### PR DESCRIPTION
- **#152** nested-COSE hybrid envelope signing (EdDSA + ML-DSA-65) + enforced policy. **Relabeled SNS→WNS** per `draft-ietf-pquip-hybrid-signature-spectrums` §1.3.4 — downgrade resistance is policy-enforced (require_pq + kid-anchoring), not cryptographic non-separability. Follow-ups (AAD alg-id bind, redundant `sig` removal) tracked on #152.
- **#160** fail-closed global verify policy when uninstalled (closes the M3 fail-open).
- **#161** StreamRegister signs under Hybrid like RPC.

All reviewed (code + security). 📚 Stacked PR — **base: `ewindisch/moq-m2a`**. Part of epic #131.
