### PR TITLE
#148 part 1: extract process_request → service/dispatch.rs (transport-neutral dispatch core)

### DIFF
--- a/crates/hyprstream-rpc/src/service/dispatch.rs
+++ b/crates/hyprstream-rpc/src/service/dispatch.rs
@@ -1,0 +1,132 @@
+//! Transport-neutral request dispatch core (#148).
+//!
+//! `process_request` is the single envelope-verify → JWT/DPoP → Casbin →
+//! `handle_request` → signed-response pipeline shared by every front-end:
+//! the ZMQ `RequestLoop`, the WebTransport server, and the generic RPC plane's
+//! `LocalServiceBridge`. It contains no transport-specific code (no ZMQ, no
+//! quinn) — extracted out of `transport/zmtp_quic.rs` so the ZMQ-specific
+//! remainder of that file can be deleted in #138 without touching this.
+
+use anyhow::Result;
+use tracing::{debug, error, warn};
+
+/// Envelope signer verification mode (re-exported from `crate::envelope`).
+///
+/// - **FixedSigner**: internal service-to-service — envelope signer must match
+///   a known `server_pubkey` for mutual authentication. Peers pre-share keys.
+/// - **AnySigner**: external clients (e.g. browser over WebTransport) — any
+///   valid signer accepted; transport TLS provides peer authentication.
+pub use crate::envelope::EnvelopeVerification;
+
+/// Process a request through the full envelope verification pipeline.
+///
+/// Unified handler for all transport front-ends. The only difference between
+/// them is envelope signer verification, controlled by `verification`.
+///
+/// # Pipeline
+///
+/// 1. Unwrap `SignedEnvelope` and verify the signature (mode-dependent), under
+///    the process-global verify policy + kid-anchored PQ trust store.
+/// 2. Verify JWT claims (`sub`, `exp`, `aud`, `scope`, downgrade protection).
+/// 3. Dispatch to `service.handle_request()` with a verified `EnvelopeContext`.
+/// 4. Sign the response with the server's `signing_key`.
+///
+/// # Returns
+///
+/// * `Ok((response_bytes, continuation))` - Signed response and optional continuation
+/// * `Err(e)` - Processing error (already logged)
+pub async fn process_request<S>(
+    raw_bytes: &[u8],
+    service: &S,
+    verification: EnvelopeVerification<'_>,
+    signing_key: &ed25519_dalek::SigningKey,
+    nonce_cache: &crate::envelope::InMemoryNonceCache,
+) -> Result<(Vec<u8>, Option<crate::service::Continuation>)>
+where
+    S: crate::service::RequestService,
+{
+    use crate::ToCapnp;
+    use crate::envelope::ResponseEnvelope;
+    use capnp::message::Builder;
+    use capnp::serialize;
+
+    // 1. Unwrap, verify, and optionally decrypt the SignedEnvelope.
+    //    The verify policy + kid-anchored PQ trust store come from the
+    //    process-global verify configuration installed at startup (Hybrid
+    //    ENFORCED in the daemon). This closes the prior fail-open where the
+    //    site hardcoded Classical / no PQ store.
+    let pq_store_holder = crate::envelope::global_pq_store();
+    let base = match verification {
+        EnvelopeVerification::FixedSigner(pubkey) =>
+            crate::envelope::UnwrapOptions::fixed_signer(pubkey, nonce_cache),
+        EnvelopeVerification::AnySigner =>
+            crate::envelope::UnwrapOptions::any_signer(nonce_cache),
+    }.with_decryption_key(signing_key);
+    let opts =
+        crate::envelope::apply_global_verify_config(base, &pq_store_holder);
+
+    let (mut ctx, payload) = match crate::envelope::unwrap_envelope(raw_bytes, &opts) {
+        Ok(result) => result,
+        Err(e) => {
+            warn!("{} envelope verification failed: {}", service.name(), e);
+            // Build error response with request_id=0 (envelope is invalid)
+            let error_payload = service.build_error_payload(0, &format!("envelope verification failed: {}", e));
+            let signed_response = ResponseEnvelope::new_signed(0, error_payload, signing_key);
+
+            let mut message = Builder::new_default();
+            let mut builder = message.init_root::<crate::common_capnp::response_envelope::Builder>();
+            signed_response.write_to(&mut builder);
+
+            let mut bytes = Vec::new();
+            serialize::write_message(&mut bytes, &message)?;
+            return Ok((bytes, None));
+        }
+    };
+
+    let request_id = ctx.request_id;
+    debug!(
+        "{} verified request from {} (id={})",
+        service.name(),
+        ctx.subject(),
+        request_id
+    );
+
+    // 2. Verify claims (E2E JWT, downgrade protection)
+    if let Err(e) = service.verify_claims(&mut ctx).await {
+        warn!(
+            "{} claims verification failed for {} (id={}): {}",
+            service.name(), ctx.subject(), request_id, e
+        );
+        let error_payload = service.build_error_payload(request_id, &e.to_string());
+        let signed_response = ResponseEnvelope::new_signed(request_id, error_payload, signing_key);
+
+        let mut message = Builder::new_default();
+        let mut builder = message.init_root::<crate::common_capnp::response_envelope::Builder>();
+        signed_response.write_to(&mut builder);
+
+        let mut bytes = Vec::new();
+        serialize::write_message(&mut bytes, &message)?;
+        return Ok((bytes, None));
+    }
+
+    // 3. Handle request
+    let (response_payload, continuation) = match service.handle_request(&ctx, &payload).await {
+        Ok((resp, cont)) => (resp, cont),
+        Err(e) => {
+            error!("{} request handling error: {}", service.name(), e);
+            (service.build_error_payload(request_id, &e.to_string()), None)
+        }
+    };
+
+    // 4. Sign and serialize response
+    let signed_response = ResponseEnvelope::new_signed(request_id, response_payload, signing_key);
+
+    let mut message = Builder::new_default();
+    let mut builder = message.init_root::<crate::common_capnp::response_envelope::Builder>();
+    signed_response.write_to(&mut builder);
+
+    let mut bytes = Vec::new();
+    serialize::write_message(&mut bytes, &message)?;
+
+    Ok((bytes, continuation))
+}

--- a/crates/hyprstream-rpc/src/service/dispatch.rs
+++ b/crates/hyprstream-rpc/src/service/dispatch.rs
@@ -8,7 +8,12 @@
 //! remainder of that file can be deleted in #138 without touching this.
 
 use anyhow::Result;
+use capnp::message::Builder;
+use capnp::serialize;
 use tracing::{debug, error, warn};
+
+use crate::envelope::ResponseEnvelope;
+use crate::ToCapnp;
 
 /// Envelope signer verification mode (re-exported from `crate::envelope`).
 ///
@@ -45,11 +50,6 @@ pub async fn process_request<S>(
 where
     S: crate::service::RequestService,
 {
-    use crate::ToCapnp;
-    use crate::envelope::ResponseEnvelope;
-    use capnp::message::Builder;
-    use capnp::serialize;
-
     // 1. Unwrap, verify, and optionally decrypt the SignedEnvelope.
     //    The verify policy + kid-anchored PQ trust store come from the
     //    process-global verify configuration installed at startup (Hybrid

--- a/crates/hyprstream-rpc/src/service/mod.rs
+++ b/crates/hyprstream-rpc/src/service/mod.rs
@@ -11,12 +11,15 @@
 
 mod traits;
 mod zmq;
+pub mod dispatch;
 pub mod streaming;
 pub mod spawnable;
 pub mod metadata;
 pub mod doc;
 
 pub use traits::{RpcHandler, RpcRequest, RpcService};
+/// Transport-neutral request dispatch core (#148) — shared by all front-ends.
+pub use dispatch::process_request;
 #[allow(deprecated)]
 pub use zmq::{AuthorizeFn, Continuation, EnvelopeContext, QuicLoopConfig, ServiceHandle, RequestLoop, UnifiedRequestLoop, RequestService};
 /// Transitional compatibility alias for the former `ZmqService` name (#166).

--- a/crates/hyprstream-rpc/src/service/zmq.rs
+++ b/crates/hyprstream-rpc/src/service/zmq.rs
@@ -996,10 +996,10 @@ impl RequestLoop {
                     // not a shared root key. The envelope signature is still verified —
                     // JWT claims + Casbin handle authorization.
                     // subsecond::call wraps the dispatch so handler code can be hot-patched during dev.
-                    let (response_bytes, continuation) = match subsecond::call(|| crate::transport::zmtp_quic::process_request(
+                    let (response_bytes, continuation) = match subsecond::call(|| crate::service::dispatch::process_request(
                         &request,
                         &*service,
-                        crate::transport::zmtp_quic::EnvelopeVerification::AnySigner,
+                        crate::envelope::EnvelopeVerification::AnySigner,
                         &signing_key,
                         &nonce_cache,
                     )).await {

--- a/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
@@ -15,7 +15,7 @@
 //! it forwards opaque bytes to the [`IrohRequestProcessor`]. Envelope
 //! verification, JWT/DPoP, and `authorize_signer` enforcement happen inside
 //! the processor (which is `LocalServiceBridge` in production, delegating
-//! to [`crate::transport::zmtp_quic::process_request`]). The handler does
+//! to [`crate::service::dispatch::process_request`]). The handler does
 //! hold a signing key, but uses it only to produce signed error envelopes
 //! when the processor itself returns `Err` (a wire-level failure), so the
 //! client always sees a parseable `ResponseEnvelope` rather than an opaque
@@ -243,7 +243,7 @@ pub struct LocalServiceBridge {
 
 impl LocalServiceBridge {
     /// Spawn a dedicated bridge thread that owns `service` and forwards
-    /// requests through [`crate::transport::zmtp_quic::process_request`].
+    /// requests through [`crate::service::dispatch::process_request`].
     ///
     /// The response signing key is taken from `service.signing_key()` — there
     /// is no separate parameter to avoid drift between the service's identity
@@ -288,7 +288,7 @@ impl LocalServiceBridge {
                             // Re-derive the signing key per call: cheap clone,
                             // tracks any future rotation in the service.
                             let signing_key = service.signing_key();
-                            let result = crate::transport::zmtp_quic::process_request(
+                            let result = crate::service::dispatch::process_request(
                                 msg.request.as_ref(),
                                 &*service,
                                 crate::envelope::EnvelopeVerification::AnySigner,

--- a/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
+++ b/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
@@ -529,7 +529,7 @@ impl QuicRep {
         // just don't pin it to the server's own key. JWT claims + Casbin handle
         // authorization.
         // subsecond::call wraps dispatch for hot-patching during dev
-        let (response_bytes, continuation) = subsecond::call(|| process_request(
+        let (response_bytes, continuation) = subsecond::call(|| crate::service::dispatch::process_request(
             raw_bytes,
             &*service,
             EnvelopeVerification::AnySigner,
@@ -1673,7 +1673,7 @@ impl WebTransportServer {
                 ensure!(!request.parts.is_empty(), "Empty RPC request");
                 let raw_bytes = &request.parts[0];
 
-                match subsecond::call(|| process_request(
+                match subsecond::call(|| crate::service::dispatch::process_request(
                     raw_bytes,
                     &*service,
                     EnvelopeVerification::AnySigner,
@@ -1969,126 +1969,8 @@ pub fn client_tls_system_roots() -> Result<rustls::ClientConfig> {
 /// verification. The only difference is step 1 of 4 in the verification pipeline.
 pub use crate::envelope::EnvelopeVerification;
 
-/// Process a request through the full envelope verification pipeline.
-///
-/// Unified handler for both ZMQ (ROUTER) and WebTransport paths. The only
-/// difference is envelope signer verification, controlled by `verification`.
-///
-/// # Pipeline
-///
-/// 1. Unwrap `SignedEnvelope` and verify Ed25519 signature (mode-dependent)
-/// 2. Verify JWT claims (`sub`, `exp`, `aud`, `scope`, downgrade protection)
-/// 3. Dispatch to `service.handle_request()` with verified `EnvelopeContext`
-/// 4. Sign response with server's `signing_key`
-///
-/// # Arguments
-///
-/// * `raw_bytes` - Raw Cap'n Proto bytes containing a `SignedEnvelope`
-/// * `service` - The RequestService to dispatch to
-/// * `verification` - Envelope signer verification mode
-/// * `signing_key` - Server's signing key for response
-/// * `nonce_cache` - Nonce cache for replay protection
-///
-/// # Returns
-///
-/// * `Ok((response_bytes, continuation))` - Signed response and optional continuation
-/// * `Err(e)` - Processing error (already logged)
-pub async fn process_request<S>(
-    raw_bytes: &[u8],
-    service: &S,
-    verification: EnvelopeVerification<'_>,
-    signing_key: &ed25519_dalek::SigningKey,
-    nonce_cache: &crate::envelope::InMemoryNonceCache,
-) -> Result<(Vec<u8>, Option<crate::service::Continuation>)>
-where
-    S: crate::service::RequestService,
-{
-    use crate::ToCapnp;
-    use crate::envelope::ResponseEnvelope;
-    use capnp::message::Builder;
-    use capnp::serialize;
-    use tracing::warn;
-
-    // 1. Unwrap, verify, and optionally decrypt the SignedEnvelope.
-    //    The verify policy + kid-anchored PQ trust store come from the
-    //    process-global verify configuration installed at startup (Hybrid
-    //    ENFORCED in the daemon). This closes the prior fail-open where the
-    //    site hardcoded Classical / no PQ store.
-    let pq_store_holder = crate::envelope::global_pq_store();
-    let base = match verification {
-        EnvelopeVerification::FixedSigner(pubkey) =>
-            crate::envelope::UnwrapOptions::fixed_signer(pubkey, nonce_cache),
-        EnvelopeVerification::AnySigner =>
-            crate::envelope::UnwrapOptions::any_signer(nonce_cache),
-    }.with_decryption_key(signing_key);
-    let opts =
-        crate::envelope::apply_global_verify_config(base, &pq_store_holder);
-
-    let (mut ctx, payload) = match crate::envelope::unwrap_envelope(raw_bytes, &opts) {
-        Ok(result) => result,
-        Err(e) => {
-            warn!("{} envelope verification failed: {}", service.name(), e);
-            // Build error response with request_id=0 (envelope is invalid)
-            let error_payload = service.build_error_payload(0, &format!("envelope verification failed: {}", e));
-            let signed_response = ResponseEnvelope::new_signed(0, error_payload, signing_key);
-
-            let mut message = Builder::new_default();
-            let mut builder = message.init_root::<crate::common_capnp::response_envelope::Builder>();
-            signed_response.write_to(&mut builder);
-
-            let mut bytes = Vec::new();
-            serialize::write_message(&mut bytes, &message)?;
-            return Ok((bytes, None));
-        }
-    };
-
-    let request_id = ctx.request_id;
-    debug!(
-        "{} verified request from {} (id={})",
-        service.name(),
-        ctx.subject(),
-        request_id
-    );
-
-    // 2. Verify claims (E2E JWT, downgrade protection)
-    if let Err(e) = service.verify_claims(&mut ctx).await {
-        warn!(
-            "{} claims verification failed for {} (id={}): {}",
-            service.name(), ctx.subject(), request_id, e
-        );
-        let error_payload = service.build_error_payload(request_id, &e.to_string());
-        let signed_response = ResponseEnvelope::new_signed(request_id, error_payload, signing_key);
-
-        let mut message = Builder::new_default();
-        let mut builder = message.init_root::<crate::common_capnp::response_envelope::Builder>();
-        signed_response.write_to(&mut builder);
-
-        let mut bytes = Vec::new();
-        serialize::write_message(&mut bytes, &message)?;
-        return Ok((bytes, None));
-    }
-
-    // 3. Handle request
-    let (response_payload, continuation) = match service.handle_request(&ctx, &payload).await {
-        Ok((resp, cont)) => (resp, cont),
-        Err(e) => {
-            error!("{} request handling error: {}", service.name(), e);
-            (service.build_error_payload(request_id, &e.to_string()), None)
-        }
-    };
-
-    // 4. Sign and serialize response
-    let signed_response = ResponseEnvelope::new_signed(request_id, response_payload, signing_key);
-
-    let mut message = Builder::new_default();
-    let mut builder = message.init_root::<crate::common_capnp::response_envelope::Builder>();
-    signed_response.write_to(&mut builder);
-
-    let mut bytes = Vec::new();
-    serialize::write_message(&mut bytes, &message)?;
-
-    Ok((bytes, continuation))
-}
+// process_request moved to crate::service::dispatch (#148) — transport-neutral
+// dispatch core, shared by RequestLoop / WebTransport / LocalServiceBridge.
 
 // ============================================================================
 // Tests


### PR DESCRIPTION
Extract `process_request` into `service/dispatch.rs` — the transport-neutral envelope-verify → JWT/DPoP → Casbin → handle_request → signed-response core shared by every front-end. All callers repointed; `service/zmq.rs` drops its last `zmtp_quic` dep.

Note: the rest of #148 (WebTransportServer + TLS helpers) is FE-2-gated (handle_wt_stream still uses ZMTP framing) and deferred. 261 rpc tests green.

📚 Stacked PR — **base: `ewindisch/moq-178`**. Part of epic #131.
