### PR TITLE
#151(a): in-process transport + inproc registry + dial() factory

### DIFF
--- a/crates/hyprstream-rpc/src/dial.rs
+++ b/crates/hyprstream-rpc/src/dial.rs
@@ -1,0 +1,156 @@
+//! The `dial()` factory: the single place transport choice is made.
+//!
+//! Today transport selection leaks into generated client code, which hardcodes
+//! `ZmqConnection::new(...)`. Per the A1 addressing spike, that decision belongs
+//! in exactly one place: [`dial`] takes a resolved [`TransportConfig`] and
+//! returns a ready [`Arc<dyn RpcClient>`], erasing the concrete transport behind
+//! the object-safe client trait (`Transport` itself is not object-safe — it has
+//! `Sub`/`Pub` associated types — so erasure happens at the `RpcClient` layer).
+//!
+//! # Inproc dial table
+//!
+//! `inproc://` names resolve through a process-local registry mapping a name to
+//! a co-located service's [`IrohRequestProcessor`]. The registry — not the
+//! [`TransportConfig`] — holds the live handle: a `TransportConfig` is
+//! `Clone + Eq` and wire-publishable (DiscoveryService), so an `Arc<dyn
+//! IrohRequestProcessor>` cannot live inside it. Naming (resolver →
+//! `TransportConfig`) and handles (registry → processor) stay separate; `dial()`
+//! is where they meet.
+//!
+//! # Construction is synchronous; transports connect lazily
+//!
+//! `dial()` is sync and does no I/O — the inproc arm only looks up an existing
+//! processor. Networked transports (quinn/iroh/moq) connect lazily on first
+//! `send()` (cached like `ZmqConnection`), so dialing never blocks and the
+//! `inventory`-registered sync factory pattern is preserved. Those arms land in
+//! a follow-up increment of #151(a); ZMQ ipc/systemd endpoints stay on the
+//! existing codegen path during the transition.
+
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
+
+use anyhow::{anyhow, bail, Result};
+use parking_lot::RwLock;
+
+use crate::crypto::VerifyingKey;
+use crate::rpc_client::{RpcClient, RpcClientImpl};
+use crate::transport::in_memory::InMemoryTransport;
+use crate::transport::rpc_session::IrohRequestProcessor;
+use crate::transport::{EndpointType, TransportConfig};
+use crate::transport_traits::Signer;
+
+/// Process-local map of inproc endpoint name → co-located request processor.
+type InprocRegistry = RwLock<HashMap<String, Arc<dyn IrohRequestProcessor>>>;
+
+static INPROC_REGISTRY: OnceLock<InprocRegistry> = OnceLock::new();
+
+fn registry() -> &'static InprocRegistry {
+    INPROC_REGISTRY.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+/// Register a co-located service's request processor under an `inproc://` name.
+///
+/// Called at service spawn. The `name` is the endpoint without the scheme
+/// (e.g. `hyprstream/registry` for `inproc://hyprstream/registry`). Returns the
+/// previous processor if one was registered under the same name.
+pub fn register_inproc(
+    name: impl Into<String>,
+    processor: Arc<dyn IrohRequestProcessor>,
+) -> Option<Arc<dyn IrohRequestProcessor>> {
+    registry().write().insert(name.into(), processor)
+}
+
+/// Remove a co-located service's processor (called at service shutdown).
+pub fn unregister_inproc(name: &str) -> Option<Arc<dyn IrohRequestProcessor>> {
+    registry().write().remove(name)
+}
+
+/// Look up a co-located service's processor by inproc name.
+pub fn lookup_inproc(name: &str) -> Option<Arc<dyn IrohRequestProcessor>> {
+    registry().read().get(name).cloned()
+}
+
+/// Dial a resolved [`TransportConfig`], returning a ready RPC client.
+///
+/// `server_verifying_key` is the destination's response-verification key
+/// (`None` skips response signature verification — only sound when the
+/// transport itself authenticates the peer, e.g. pinned TLS). The inproc path
+/// is verified end-to-end via the in-process processor's signed responses, so
+/// callers may pass the service's verifying key here.
+pub fn dial<S>(
+    target: &TransportConfig,
+    signer: S,
+    server_verifying_key: Option<VerifyingKey>,
+) -> Result<Arc<dyn RpcClient>>
+where
+    S: Signer + 'static,
+{
+    match &target.endpoint {
+        EndpointType::Inproc { endpoint } => {
+            let processor = lookup_inproc(endpoint).ok_or_else(|| {
+                anyhow!("no in-process service registered for inproc endpoint '{endpoint}'")
+            })?;
+            let transport = InMemoryTransport::new(processor);
+            Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
+                as Arc<dyn RpcClient>)
+        }
+        other => bail!(
+            "dial(): endpoint {other:?} is not yet served by the dial factory \
+             — lazy quinn/iroh/moq transports land in a later #151(a) increment; \
+             ZMQ ipc/systemd endpoints stay on the codegen path during the transition"
+        ),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::crypto::SigningKey;
+    use crate::signer::LocalSigner;
+    use crate::transport::rpc_session::from_fn;
+    use bytes::Bytes;
+    use rand::rngs::OsRng;
+
+    fn test_signer() -> LocalSigner {
+        LocalSigner::new(SigningKey::generate(&mut OsRng))
+    }
+
+    #[test]
+    fn register_lookup_unregister() {
+        let name = "test/dial/register_lookup_unregister";
+        assert!(lookup_inproc(name).is_none());
+        let proc = Arc::new(from_fn(|r: Bytes| async move { Ok(r) }));
+        assert!(register_inproc(name, proc).is_none());
+        assert!(lookup_inproc(name).is_some());
+        assert!(unregister_inproc(name).is_some());
+        assert!(lookup_inproc(name).is_none());
+    }
+
+    #[test]
+    fn dial_inproc_resolves_registered_processor() {
+        let name = "test/dial/dial_inproc_resolves";
+        let proc = Arc::new(from_fn(|r: Bytes| async move { Ok(r) }));
+        register_inproc(name, proc);
+
+        let cfg = TransportConfig::inproc(name);
+        let client = dial(&cfg, test_signer(), None);
+        assert!(client.is_ok(), "dialing a registered inproc endpoint must succeed");
+
+        unregister_inproc(name);
+    }
+
+    #[test]
+    fn dial_inproc_unregistered_errors() {
+        let cfg = TransportConfig::inproc("test/dial/never_registered");
+        let err = dial(&cfg, test_signer(), None);
+        assert!(err.is_err(), "dialing an unregistered inproc endpoint must error");
+    }
+
+    #[test]
+    fn dial_unsupported_endpoint_errors() {
+        let cfg = TransportConfig::ipc("/tmp/hyprstream-test.sock");
+        let err = dial(&cfg, test_signer(), None);
+        assert!(err.is_err(), "ipc dial is not yet served by the factory");
+    }
+}

--- a/crates/hyprstream-rpc/src/dial.rs
+++ b/crates/hyprstream-rpc/src/dial.rs
@@ -27,7 +27,7 @@
 //! existing codegen path during the transition.
 
 use std::collections::HashMap;
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, OnceLock, Weak};
 
 use anyhow::{anyhow, bail, Result};
 use parking_lot::RwLock;
@@ -40,7 +40,14 @@ use crate::transport::{EndpointType, TransportConfig};
 use crate::transport_traits::Signer;
 
 /// Process-local map of inproc endpoint name → co-located request processor.
-type InprocRegistry = RwLock<HashMap<String, Arc<dyn IrohRequestProcessor>>>;
+///
+/// Entries are `Weak`: the registry is a *lookup index*, not the owner. The
+/// service spawn site retains the strong `Arc` for the service's lifetime, so
+/// dropping the service (e.g. on shutdown) automatically tears down its bridge
+/// thread AND leaves a dead `Weak` here that self-evicts on the next lookup —
+/// no leak-by-forgotten-unregister, and no strong ref pinning a bridge thread
+/// past shutdown.
+type InprocRegistry = RwLock<HashMap<String, Weak<dyn IrohRequestProcessor>>>;
 
 static INPROC_REGISTRY: OnceLock<InprocRegistry> = OnceLock::new();
 
@@ -51,32 +58,60 @@ fn registry() -> &'static InprocRegistry {
 /// Register a co-located service's request processor under an `inproc://` name.
 ///
 /// Called at service spawn. The `name` is the endpoint without the scheme
-/// (e.g. `hyprstream/registry` for `inproc://hyprstream/registry`). Returns the
-/// previous processor if one was registered under the same name.
-pub fn register_inproc(
-    name: impl Into<String>,
-    processor: Arc<dyn IrohRequestProcessor>,
-) -> Option<Arc<dyn IrohRequestProcessor>> {
-    registry().write().insert(name.into(), processor)
+/// (e.g. `hyprstream/registry` for `inproc://hyprstream/registry`). The caller
+/// MUST retain `processor` (the strong `Arc`) for as long as the service should
+/// be dialable — the registry only holds a `Weak`.
+///
+/// Overwriting a name whose service is still live is almost always a bug
+/// (name-squatting / double-spawn); it is logged loudly. Existing dialed
+/// clients keep the processor they captured; only future dials see the new one.
+pub fn register_inproc(name: impl Into<String>, processor: &Arc<dyn IrohRequestProcessor>) {
+    let name = name.into();
+    let mut map = registry().write();
+    if map.get(&name).is_some_and(|w| w.strong_count() > 0) {
+        tracing::warn!(
+            endpoint = %name,
+            "register_inproc: overwriting a still-live in-process service registration"
+        );
+    }
+    map.insert(name, Arc::downgrade(processor));
 }
 
-/// Remove a co-located service's processor (called at service shutdown).
-pub fn unregister_inproc(name: &str) -> Option<Arc<dyn IrohRequestProcessor>> {
-    registry().write().remove(name)
+/// Explicitly drop a name's registration (best-effort; dead entries also
+/// self-evict on lookup once the service's strong `Arc` is gone).
+pub fn unregister_inproc(name: &str) {
+    registry().write().remove(name);
 }
 
-/// Look up a co-located service's processor by inproc name.
+/// Look up a co-located service's processor by inproc name, upgrading the
+/// `Weak`. A stale (dead-service) entry is pruned in passing.
 pub fn lookup_inproc(name: &str) -> Option<Arc<dyn IrohRequestProcessor>> {
-    registry().read().get(name).cloned()
+    let mut map = registry().write();
+    match map.get(name).and_then(Weak::upgrade) {
+        Some(arc) => Some(arc),
+        None => {
+            // Present-but-dead → evict; absent → no-op.
+            map.remove(name);
+            None
+        }
+    }
 }
 
 /// Dial a resolved [`TransportConfig`], returning a ready RPC client.
 ///
-/// `server_verifying_key` is the destination's response-verification key
-/// (`None` skips response signature verification — only sound when the
-/// transport itself authenticates the peer, e.g. pinned TLS). The inproc path
-/// is verified end-to-end via the in-process processor's signed responses, so
-/// callers may pass the service's verifying key here.
+/// `server_verifying_key` is the destination's response-verification key.
+/// `None` does NOT disable signature verification — the response is still
+/// cryptographically verified against the key embedded in its envelope; `None`
+/// only declines to pin *which* identity that key must be. Passing `None` is
+/// only sound when the transport itself authenticates the peer (e.g. pinned
+/// TLS / QUIC cert).
+///
+/// **For `inproc://` there is no transport-level peer authentication** (it is a
+/// function call into a registry-resolved processor), so `None` is *discouraged*
+/// on the inproc path: without it, a name-squatting registration could be dialed
+/// without detection. Callers SHOULD pass the resolved service verifying key for
+/// inproc. (The codegen wire-up will thread the resolver-supplied key through;
+/// see #151(a) follow-up.)
 pub fn dial<S>(
     target: &TransportConfig,
     signer: S,
@@ -85,6 +120,9 @@ pub fn dial<S>(
 where
     S: Signer + 'static,
 {
+    // Matched exhaustively on purpose: this is the one place transport choice is
+    // made, so a newly-added EndpointType variant MUST be a compile error here
+    // rather than silently falling through to a runtime bail.
     match &target.endpoint {
         EndpointType::Inproc { endpoint } => {
             let processor = lookup_inproc(endpoint).ok_or_else(|| {
@@ -94,8 +132,10 @@ where
             Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
                 as Arc<dyn RpcClient>)
         }
-        other => bail!(
-            "dial(): endpoint {other:?} is not yet served by the dial factory \
+        endpoint @ (EndpointType::Ipc { .. }
+        | EndpointType::SystemdFd { .. }
+        | EndpointType::Quic { .. }) => bail!(
+            "dial(): endpoint {endpoint:?} is not yet served by the dial factory \
              — lazy quinn/iroh/moq transports land in a later #151(a) increment; \
              ZMQ ipc/systemd endpoints stay on the codegen path during the transition"
         ),
@@ -116,22 +156,38 @@ mod tests {
         LocalSigner::new(SigningKey::generate(&mut OsRng))
     }
 
+    fn echo() -> Arc<dyn IrohRequestProcessor> {
+        Arc::new(from_fn(|r: Bytes| async move { Ok(r) }))
+    }
+
     #[test]
     fn register_lookup_unregister() {
         let name = "test/dial/register_lookup_unregister";
         assert!(lookup_inproc(name).is_none());
-        let proc = Arc::new(from_fn(|r: Bytes| async move { Ok(r) }));
-        assert!(register_inproc(name, proc).is_none());
+        let proc = echo();
+        register_inproc(name, &proc);
         assert!(lookup_inproc(name).is_some());
-        assert!(unregister_inproc(name).is_some());
+        unregister_inproc(name);
         assert!(lookup_inproc(name).is_none());
+    }
+
+    #[test]
+    fn lookup_self_evicts_when_service_dropped() {
+        let name = "test/dial/self_evict";
+        let proc = echo();
+        register_inproc(name, &proc);
+        assert!(lookup_inproc(name).is_some());
+        // Service shuts down: drop the only strong ref. The Weak in the
+        // registry is now dead and must not resolve (and is pruned).
+        drop(proc);
+        assert!(lookup_inproc(name).is_none(), "dead-service entry must not resolve");
     }
 
     #[test]
     fn dial_inproc_resolves_registered_processor() {
         let name = "test/dial/dial_inproc_resolves";
-        let proc = Arc::new(from_fn(|r: Bytes| async move { Ok(r) }));
-        register_inproc(name, proc);
+        let proc = echo();
+        register_inproc(name, &proc);
 
         let cfg = TransportConfig::inproc(name);
         let client = dial(&cfg, test_signer(), None);

--- a/crates/hyprstream-rpc/src/lib.rs
+++ b/crates/hyprstream-rpc/src/lib.rs
@@ -140,6 +140,8 @@ pub mod moq_stream;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod transport;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod dial;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod notify;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod paths;

--- a/crates/hyprstream-rpc/src/transport/in_memory.rs
+++ b/crates/hyprstream-rpc/src/transport/in_memory.rs
@@ -43,6 +43,12 @@ use crate::transport_traits::Transport;
 /// Default ceiling on a single in-process request, mirroring the networked
 /// RPC transport. A wedged co-located handler should surface as a timeout
 /// rather than hanging the caller indefinitely.
+///
+/// Note this deadline also covers *enqueue* latency: `LocalServiceBridge`
+/// forwards over a bounded mpsc, so a saturated bridge can make `send()` block
+/// on the channel and eventually trip this timeout. The error therefore
+/// conflates "handler wedged" with "bridge backpressure" — acceptable for the
+/// transport surface, but not a substitute for a real backpressure signal.
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// In-process RPC transport over an [`IrohRequestProcessor`].

--- a/crates/hyprstream-rpc/src/transport/in_memory.rs
+++ b/crates/hyprstream-rpc/src/transport/in_memory.rs
@@ -1,0 +1,133 @@
+//! In-process RPC transport for co-located services.
+//!
+//! Dials a service running in the *same process* without a network socket.
+//! This is the in-memory dial target the [`crate::dial`] factory selects for
+//! `inproc://` endpoints — the replacement for ZMQ's `inproc://` transport.
+//!
+//! # No second security model
+//!
+//! [`InMemoryTransport::send`] forwards the canonical request bytes to an
+//! [`IrohRequestProcessor`] (in production a
+//! [`LocalServiceBridge`](crate::transport::iroh_rpc::LocalServiceBridge),
+//! which isolates `!Send` `tch`-holding services on a dedicated `LocalSet`
+//! thread and exposes only a `Send` `Bytes`-in/`Bytes`-out surface) and returns
+//! the signed response bytes. The envelope is signed and verified by the exact
+//! same `process_request` path a networked transport uses — co-located calls
+//! skip *serialization to a socket*, never authentication or Casbin authz. This
+//! is behaviourally identical to ZMQ's `inproc://` (serialize once, no socket),
+//! so there is no distinct trust path to review.
+//!
+//! Per the A1 addressing spike, every in-process call goes through the bridge
+//! (one channel hop — the same cost as inproc-ZMQ today). A zero-hop tier that
+//! calls `process_request` directly is inexpressible while `RequestService` is
+//! unconditionally `?Send`; it is a deliberate later follow-up, not part of this
+//! change.
+//!
+//! # RPC plane only
+//!
+//! Like [`SessionRpcTransport`](crate::transport::rpc_session::SessionRpcTransport),
+//! this transport is request-response only; `subscribe`/`publish` bail. The
+//! streaming plane (moq-net) carries SUB/PUB, and in-process streaming is
+//! deferred with the streaming substrate (#134).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Result};
+use async_trait::async_trait;
+use bytes::Bytes;
+
+use crate::transport::rpc_session::{IrohRequestProcessor, RpcPendingStream, RpcPublishStub};
+use crate::transport_traits::Transport;
+
+/// Default ceiling on a single in-process request, mirroring the networked
+/// RPC transport. A wedged co-located handler should surface as a timeout
+/// rather than hanging the caller indefinitely.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// In-process RPC transport over an [`IrohRequestProcessor`].
+///
+/// Cheaply cloneable: holds an `Arc` to the shared processor.
+#[derive(Clone)]
+pub struct InMemoryTransport {
+    processor: Arc<dyn IrohRequestProcessor>,
+}
+
+impl InMemoryTransport {
+    /// Dial a co-located service by its already-resolved request processor.
+    pub fn new(processor: Arc<dyn IrohRequestProcessor>) -> Self {
+        Self { processor }
+    }
+}
+
+#[async_trait]
+impl Transport for InMemoryTransport {
+    type Sub = RpcPendingStream;
+    type Pub = RpcPublishStub;
+
+    async fn send(&self, payload: Vec<u8>, timeout_ms: Option<i32>) -> Result<Vec<u8>> {
+        let timeout = timeout_ms
+            .map(|ms| Duration::from_millis(ms.max(0) as u64))
+            .unwrap_or(DEFAULT_TIMEOUT);
+        let processor = Arc::clone(&self.processor);
+        let fut = async move { processor.process(Bytes::from(payload)).await };
+        let resp = tokio::time::timeout(timeout, fut)
+            .await
+            .map_err(|_| anyhow!("in-process RPC timeout after {timeout:?}"))??;
+        Ok(resp.to_vec())
+    }
+
+    async fn subscribe(&self, _topic: &[u8]) -> Result<Self::Sub> {
+        bail!("in-process RPC transport does not support SUB — streaming moves to moq-net (#134)")
+    }
+
+    async fn publish(&self, _topic: &[u8]) -> Result<Self::Pub> {
+        bail!("in-process RPC transport does not support PUB — streaming moves to moq-net (#134)")
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::transport::rpc_session::from_fn;
+
+    fn echo_processor() -> Arc<dyn IrohRequestProcessor> {
+        Arc::new(from_fn(|req: Bytes| async move { Ok(req) }))
+    }
+
+    #[tokio::test]
+    async fn send_roundtrips_through_processor() {
+        let t = InMemoryTransport::new(echo_processor());
+        let resp = t.send(b"ping".to_vec(), None).await.unwrap();
+        assert_eq!(resp, b"ping");
+    }
+
+    #[tokio::test]
+    async fn subscribe_and_publish_bail() {
+        let t = InMemoryTransport::new(echo_processor());
+        assert!(t.subscribe(b"topic").await.is_err());
+        assert!(t.publish(b"topic").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn slow_processor_times_out() {
+        let slow = Arc::new(from_fn(|req: Bytes| async move {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            Ok(req)
+        }));
+        let t = InMemoryTransport::new(slow);
+        let err = t.send(b"x".to_vec(), Some(20)).await;
+        assert!(err.is_err(), "a handler exceeding the deadline must time out");
+    }
+
+    #[tokio::test]
+    async fn processor_error_propagates() {
+        let failing = Arc::new(from_fn(|_req: Bytes| async move {
+            Err(anyhow!("handler boom"))
+        }));
+        let t = InMemoryTransport::new(failing);
+        let err = t.send(b"x".to_vec(), None).await;
+        assert!(err.is_err());
+    }
+}

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -23,6 +23,8 @@ pub mod quinn_transport;
 pub mod iroh_transport;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod iroh_moq;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod in_memory;
 
 use std::net::SocketAddr;
 use std::os::unix::io::RawFd;


### PR DESCRIPTION
The dialing layer (#151 follow-on): `dial(&TransportConfig, signer, vk) -> Arc<dyn RpcClient>` — the single place transport choice is made, erasing the non-object-safe `Transport` behind `RpcClient`. Adds `InMemoryTransport` (RPC over `IrohRequestProcessor`, reusing the exact sign/verify path — no second security model) and a process-local `Weak` inproc registry.

Inproc arm implemented; lazy quinn/iroh/moq transports + codegen de-leak are follow-on increments. Code+security reviewed (ship-with-fixes, applied: Weak registry, warn-on-overwrite, exhaustive match, corrected None-key doc). 9 new tests, 269 rpc green.

📚 Stacked PR — **base: `ewindisch/moq-148`** (sibling to #186). Part of epic #131.
