### PR TITLE
#186: spawn streaming pump in dispatch core, not transport front-ends

### DIFF
--- a/crates/hyprstream-rpc/src/service/dispatch.rs
+++ b/crates/hyprstream-rpc/src/service/dispatch.rs
@@ -38,15 +38,15 @@ pub use crate::envelope::EnvelopeVerification;
 ///
 /// # Streaming
 ///
-/// A streaming handler returns a `Continuation` (the server-side pump that runs
-/// after the reply). As of #186 that pump is spawned **here**, via
-/// [`crate::streaming::spawn_stream_pump`], rather than handed back to the
-/// transport front-end — so every front-end (ZMQ `RequestLoop`, WebTransport
-/// server, generic-plane `LocalServiceBridge`) is uniform "bytes in → bytes
-/// out" and the generic plane no longer has to reject continuations it cannot
-/// return. **Invariant:** `process_request` must therefore run on a
-/// `tokio::task::LocalSet` (it already did — `RequestService` is `?Send`); the
-/// spawned pump is `?Send`.
+/// A streaming handler returns a `Continuation` (the server-side streaming
+/// response that runs after the reply). As of #186 that task is spawned
+/// **here**, via [`crate::streaming::spawn_streaming_response`], rather than
+/// handed back to the transport front-end — so every front-end (ZMQ
+/// `RequestLoop`, WebTransport server, generic-plane `LocalServiceBridge`) is
+/// uniform "bytes in → bytes out" and the generic plane no longer has to reject
+/// continuations it cannot return. **Invariant:** `process_request` must
+/// therefore run on a `tokio::task::LocalSet` (it already did — `RequestService`
+/// is `?Send`); the spawned task is `?Send`.
 ///
 /// # Returns
 ///
@@ -141,11 +141,12 @@ where
     let mut bytes = Vec::new();
     serialize::write_message(&mut bytes, &message)?;
 
-    // 5. Spawn the streaming pump (if any) onto the current LocalSet, so the
-    //    reply is all the transport front-end has to deal with (#186). The pump
-    //    is bounded by a process-wide permit; see spawn_stream_pump.
+    // 5. Spawn the server-side streaming response (if any) onto the current
+    //    LocalSet, so the reply is all the transport front-end has to deal with
+    //    (#186). Bounded by a per-service admission permit; see
+    //    spawn_streaming_response.
     if let Some(cont) = continuation {
-        crate::streaming::spawn_stream_pump(service.name(), cont);
+        crate::streaming::spawn_streaming_response(service.name(), cont);
     }
 
     Ok(bytes)

--- a/crates/hyprstream-rpc/src/service/dispatch.rs
+++ b/crates/hyprstream-rpc/src/service/dispatch.rs
@@ -36,9 +36,22 @@ pub use crate::envelope::EnvelopeVerification;
 /// 3. Dispatch to `service.handle_request()` with a verified `EnvelopeContext`.
 /// 4. Sign the response with the server's `signing_key`.
 ///
+/// # Streaming
+///
+/// A streaming handler returns a `Continuation` (the server-side pump that runs
+/// after the reply). As of #186 that pump is spawned **here**, via
+/// [`crate::streaming::spawn_stream_pump`], rather than handed back to the
+/// transport front-end — so every front-end (ZMQ `RequestLoop`, WebTransport
+/// server, generic-plane `LocalServiceBridge`) is uniform "bytes in → bytes
+/// out" and the generic plane no longer has to reject continuations it cannot
+/// return. **Invariant:** `process_request` must therefore run on a
+/// `tokio::task::LocalSet` (it already did — `RequestService` is `?Send`); the
+/// spawned pump is `?Send`.
+///
 /// # Returns
 ///
-/// * `Ok((response_bytes, continuation))` - Signed response and optional continuation
+/// * `Ok(response_bytes)` - Signed response. Any streaming pump has already been
+///   spawned onto the current `LocalSet`.
 /// * `Err(e)` - Processing error (already logged)
 pub async fn process_request<S>(
     raw_bytes: &[u8],
@@ -46,7 +59,7 @@ pub async fn process_request<S>(
     verification: EnvelopeVerification<'_>,
     signing_key: &ed25519_dalek::SigningKey,
     nonce_cache: &crate::envelope::InMemoryNonceCache,
-) -> Result<(Vec<u8>, Option<crate::service::Continuation>)>
+) -> Result<Vec<u8>>
 where
     S: crate::service::RequestService,
 {
@@ -79,7 +92,7 @@ where
 
             let mut bytes = Vec::new();
             serialize::write_message(&mut bytes, &message)?;
-            return Ok((bytes, None));
+            return Ok(bytes);
         }
     };
 
@@ -106,7 +119,7 @@ where
 
         let mut bytes = Vec::new();
         serialize::write_message(&mut bytes, &message)?;
-        return Ok((bytes, None));
+        return Ok(bytes);
     }
 
     // 3. Handle request
@@ -128,5 +141,12 @@ where
     let mut bytes = Vec::new();
     serialize::write_message(&mut bytes, &message)?;
 
-    Ok((bytes, continuation))
+    // 5. Spawn the streaming pump (if any) onto the current LocalSet, so the
+    //    reply is all the transport front-end has to deal with (#186). The pump
+    //    is bounded by a process-wide permit; see spawn_stream_pump.
+    if let Some(cont) = continuation {
+        crate::streaming::spawn_stream_pump(cont);
+    }
+
+    Ok(bytes)
 }

--- a/crates/hyprstream-rpc/src/service/dispatch.rs
+++ b/crates/hyprstream-rpc/src/service/dispatch.rs
@@ -145,7 +145,7 @@ where
     //    reply is all the transport front-end has to deal with (#186). The pump
     //    is bounded by a process-wide permit; see spawn_stream_pump.
     if let Some(cont) = continuation {
-        crate::streaming::spawn_stream_pump(cont);
+        crate::streaming::spawn_stream_pump(service.name(), cont);
     }
 
     Ok(bytes)

--- a/crates/hyprstream-rpc/src/service/zmq.rs
+++ b/crates/hyprstream-rpc/src/service/zmq.rs
@@ -929,10 +929,6 @@ impl RequestLoop {
             });
         }
 
-        // Bounded semaphore for continuations
-        const MAX_INFLIGHT_CONTINUATIONS: usize = 16;
-        let continuation_semaphore = Arc::new(tokio::sync::Semaphore::new(MAX_INFLIGHT_CONTINUATIONS));
-
         // Use futures traits for Router async I/O
         use futures::{SinkExt, StreamExt};
         let mut router_stream = router;
@@ -996,7 +992,7 @@ impl RequestLoop {
                     // not a shared root key. The envelope signature is still verified —
                     // JWT claims + Casbin handle authorization.
                     // subsecond::call wraps the dispatch so handler code can be hot-patched during dev.
-                    let (response_bytes, continuation) = match subsecond::call(|| crate::service::dispatch::process_request(
+                    let response_bytes = match subsecond::call(|| crate::service::dispatch::process_request(
                         &request,
                         &*service,
                         crate::envelope::EnvelopeVerification::AnySigner,
@@ -1007,7 +1003,7 @@ impl RequestLoop {
                         Err(e) => {
                             error!("{} request processing error: {}", service.name(), e);
                             let error_payload = service.build_error_payload(0, &e.to_string());
-                            (Self::wrap_response(0, error_payload, &signing_key)?, None)
+                            Self::wrap_response(0, error_payload, &signing_key)?
                         }
                     };
 
@@ -1021,18 +1017,8 @@ impl RequestLoop {
                     if let Err(e) = router_stream.send(response_msg).await {
                         error!("{} ROUTER send error: {}", service.name(), e);
                     }
-
-                    // Spawn continuation after response is sent
-                    if let Some(future) = continuation {
-                        let sem = continuation_semaphore.clone();
-                        tokio::task::spawn_local(async move {
-                            let Ok(_permit) = sem.acquire_owned().await else {
-                                warn!("continuation semaphore closed");
-                                return;
-                            };
-                            future.await;
-                        });
-                    }
+                    // Any streaming pump was already spawned inside
+                    // process_request (#186); nothing to do here.
                 }
             }
         }

--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -1818,26 +1818,51 @@ impl StreamGuard {
 }
 
 // ============================================================================
-// Streaming pump spawning (#186)
+// Streaming-response concurrency (#186)
 // ============================================================================
 
-/// Ceiling on concurrently-running streaming pumps **per service**.
+/// Default ceiling on **concurrent server-side streaming responses per
+/// service** — i.e. how many streaming RPCs one service may be actively pushing
+/// data for at once. Overridable via [`install_max_concurrent_streams_per_service`]
+/// (wired from `ServerConfig::max_concurrent_streams_per_service`).
 ///
 /// This is the former per-`RequestLoop` `MAX_INFLIGHT_CONTINUATIONS` (16). When
-/// the pump-spawn moved out of the transport front-ends into the dispatch core
+/// the spawn moved out of the transport front-ends into the dispatch core
 /// (#186) the bound is keyed by service name rather than living on each loop —
-/// which is the *same* granularity, since each service has exactly one
-/// `RequestLoop`. Keeping it per-service (not process-wide) preserves the
-/// original isolation: one service's stuck or long-lived pumps cannot starve
-/// streaming on every other service.
-const MAX_INFLIGHT_STREAM_PUMPS_PER_SERVICE: usize = 16;
+/// the *same* granularity, since each service has exactly one `RequestLoop`.
+/// Keeping it per-service (not process-wide) preserves the original isolation:
+/// one service's stuck or long-lived streams cannot starve another's.
+pub const DEFAULT_MAX_CONCURRENT_STREAMS_PER_SERVICE: usize = 16;
 
-/// Per-service pump semaphores, created on first use. A permit is held for the
-/// full lifetime of a pump (which is itself bounded by the stream's JWT/TTL
-/// cancel token in `StreamChannel`, so permits are always eventually released —
-/// there is no unbounded hold). The map only ever grows by the number of
-/// distinct services (small, bounded), so it is never pruned.
-fn stream_pump_semaphore(service_name: &str) -> std::sync::Arc<tokio::sync::Semaphore> {
+/// Process-global override for the per-service concurrent-streams cap.
+/// First-write-wins, mirroring `install_verify_config`; installed once at
+/// startup from the loaded `ServerConfig`. Read when a service's semaphore is
+/// first created, so it must be installed before serving (it always is — the
+/// daemon installs it right after loading config).
+static MAX_CONCURRENT_STREAMS_PER_SERVICE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+
+/// Install the per-service concurrent-streams cap. Call once at startup with
+/// `ServerConfig::max_concurrent_streams_per_service`. Values are clamped to a
+/// minimum of 1. Returns `Err(existing)` if already installed (first-write-wins).
+pub fn install_max_concurrent_streams_per_service(n: usize) -> Result<(), usize> {
+    MAX_CONCURRENT_STREAMS_PER_SERVICE.set(n.max(1))
+}
+
+/// The effective cap: the installed value, or [`DEFAULT_MAX_CONCURRENT_STREAMS_PER_SERVICE`].
+fn max_concurrent_streams_per_service() -> usize {
+    MAX_CONCURRENT_STREAMS_PER_SERVICE
+        .get()
+        .copied()
+        .unwrap_or(DEFAULT_MAX_CONCURRENT_STREAMS_PER_SERVICE)
+}
+
+/// Per-service admission semaphores, created on first use at the effective cap.
+/// A permit is held for the full lifetime of a streaming response (which is
+/// itself bounded by the stream's JWT/TTL cancel token in `StreamChannel`, so
+/// permits are always eventually released — there is no unbounded hold). The map
+/// only ever grows by the number of distinct services (small, bounded), so it is
+/// never pruned.
+fn stream_admission_semaphore(service_name: &str) -> std::sync::Arc<tokio::sync::Semaphore> {
     use parking_lot::RwLock;
     use std::collections::HashMap;
     static MAP: std::sync::OnceLock<RwLock<HashMap<String, std::sync::Arc<tokio::sync::Semaphore>>>> =
@@ -1850,64 +1875,63 @@ fn stream_pump_semaphore(service_name: &str) -> std::sync::Arc<tokio::sync::Sema
         map.write()
             .entry(service_name.to_owned())
             .or_insert_with(|| {
-                std::sync::Arc::new(tokio::sync::Semaphore::new(
-                    MAX_INFLIGHT_STREAM_PUMPS_PER_SERVICE,
-                ))
+                std::sync::Arc::new(tokio::sync::Semaphore::new(max_concurrent_streams_per_service()))
             }),
     )
 }
 
-/// Spawn a streaming pump — the server-side half of a streaming RPC that runs
-/// *after* the StreamInfo reply has been sent — onto the current `LocalSet`,
-/// bounded by a per-service permit.
+/// Spawn the server-side half of a streaming RPC — the task that keeps pushing
+/// data *after* the `StreamInfo` reply has been sent — onto the current
+/// `LocalSet`, bounded by a per-service admission permit.
 ///
 /// Replaces the former "transport front-end spawns the continuation it got back
-/// from `process_request`" model (#186): the dispatch core now spawns the pump
+/// from `process_request`" model (#186): the dispatch core now spawns this task
 /// itself and returns only the reply bytes, so the streaming lifecycle is no
 /// longer threaded through every transport's request/response path. This is the
-/// M1 shape; in M2 the pump's transport (`StreamChannel`) moves to a
+/// M1 shape; in M2 the streaming transport (`StreamChannel`) moves to a
 /// service-owned moq broadcast and this coarse per-service cap is replaced by
 /// the StreamPolicy backpressure axes (#134).
 ///
 /// `service_name` keys the per-service permit pool (see
-/// [`MAX_INFLIGHT_STREAM_PUMPS_PER_SERVICE`]). When the pool is saturated the
-/// pump waits for a permit rather than being dropped — but the wait is logged
-/// so saturation is observable rather than a silent stall.
+/// [`DEFAULT_MAX_CONCURRENT_STREAMS_PER_SERVICE`] and
+/// [`install_max_concurrent_streams_per_service`]). When the pool is saturated
+/// the task waits for a permit rather than being dropped — and the wait is
+/// logged so saturation is observable rather than a silent stall.
 ///
 /// # Invariant
 ///
-/// MUST be called from within a `tokio::task::LocalSet`: the pump is `?Send`
+/// MUST be called from within a `tokio::task::LocalSet`: the task is `?Send`
 /// (like every [`RequestService`](crate::service::RequestService)), and
 /// `spawn_local` panics outside a `LocalSet`. Every
 /// [`process_request`](crate::service::dispatch::process_request) caller already
 /// runs on a `LocalSet` (ZMQ `RequestLoop`, the WebTransport server, and the
 /// generic plane's `LocalServiceBridge`), which is the only place this is
 /// invoked.
-pub fn spawn_stream_pump(service_name: &str, continuation: crate::service::Continuation) {
-    let sem = stream_pump_semaphore(service_name);
+pub fn spawn_streaming_response(service_name: &str, continuation: crate::service::Continuation) {
+    let sem = stream_admission_semaphore(service_name);
     let service_name = service_name.to_owned();
     tokio::task::spawn_local(async move {
         // Observe saturation: a permit that isn't immediately available means
-        // this service is at its concurrent-stream cap and new streams are
+        // this service is at its concurrent-streams cap and new streams are
         // queueing behind running ones.
         let permit = match sem.clone().try_acquire_owned() {
             Ok(p) => p,
             Err(_) => {
                 tracing::warn!(
                     service = %service_name,
-                    cap = MAX_INFLIGHT_STREAM_PUMPS_PER_SERVICE,
-                    "streaming pump cap reached; new stream waiting for a slot"
+                    cap = max_concurrent_streams_per_service(),
+                    "concurrent-streams cap reached; new stream waiting for a slot"
                 );
                 // The semaphore is a static that is never closed, so
-                // acquire_owned cannot fail; if it somehow did, drop the pump.
+                // acquire_owned cannot fail; if it somehow did, drop the stream.
                 let Ok(p) = sem.acquire_owned().await else {
-                    tracing::error!(service = %service_name, "stream pump semaphore closed; dropping pump");
+                    tracing::error!(service = %service_name, "stream admission semaphore closed; dropping stream");
                     return;
                 };
                 p
             }
         };
-        let _permit = permit; // held for the pump's lifetime
+        let _permit = permit; // held for the streaming response's lifetime
         continuation.await;
     });
 }

--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -1821,31 +1821,58 @@ impl StreamGuard {
 // Streaming pump spawning (#186)
 // ============================================================================
 
-/// Process-wide ceiling on concurrently-running streaming pumps.
+/// Ceiling on concurrently-running streaming pumps **per service**.
 ///
-/// This is the former per-`RequestLoop` `MAX_INFLIGHT_CONTINUATIONS`, relocated
-/// here when the pump-spawn moved out of the transport front-ends and into the
-/// dispatch core (#186). The bound is now process-wide rather than per-loop —
-/// a deliberate consequence of centralizing the spawn; sized generously so a
-/// single busy front-end does not starve others.
-const MAX_INFLIGHT_STREAM_PUMPS: usize = 64;
+/// This is the former per-`RequestLoop` `MAX_INFLIGHT_CONTINUATIONS` (16). When
+/// the pump-spawn moved out of the transport front-ends into the dispatch core
+/// (#186) the bound is keyed by service name rather than living on each loop —
+/// which is the *same* granularity, since each service has exactly one
+/// `RequestLoop`. Keeping it per-service (not process-wide) preserves the
+/// original isolation: one service's stuck or long-lived pumps cannot starve
+/// streaming on every other service.
+const MAX_INFLIGHT_STREAM_PUMPS_PER_SERVICE: usize = 16;
 
-fn stream_pump_semaphore() -> &'static std::sync::Arc<tokio::sync::Semaphore> {
-    static SEM: std::sync::OnceLock<std::sync::Arc<tokio::sync::Semaphore>> =
+/// Per-service pump semaphores, created on first use. A permit is held for the
+/// full lifetime of a pump (which is itself bounded by the stream's JWT/TTL
+/// cancel token in `StreamChannel`, so permits are always eventually released —
+/// there is no unbounded hold). The map only ever grows by the number of
+/// distinct services (small, bounded), so it is never pruned.
+fn stream_pump_semaphore(service_name: &str) -> std::sync::Arc<tokio::sync::Semaphore> {
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+    static MAP: std::sync::OnceLock<RwLock<HashMap<String, std::sync::Arc<tokio::sync::Semaphore>>>> =
         std::sync::OnceLock::new();
-    SEM.get_or_init(|| std::sync::Arc::new(tokio::sync::Semaphore::new(MAX_INFLIGHT_STREAM_PUMPS)))
+    let map = MAP.get_or_init(|| RwLock::new(HashMap::new()));
+    if let Some(sem) = map.read().get(service_name) {
+        return std::sync::Arc::clone(sem);
+    }
+    std::sync::Arc::clone(
+        map.write()
+            .entry(service_name.to_owned())
+            .or_insert_with(|| {
+                std::sync::Arc::new(tokio::sync::Semaphore::new(
+                    MAX_INFLIGHT_STREAM_PUMPS_PER_SERVICE,
+                ))
+            }),
+    )
 }
 
 /// Spawn a streaming pump — the server-side half of a streaming RPC that runs
 /// *after* the StreamInfo reply has been sent — onto the current `LocalSet`,
-/// bounded by a process-wide permit.
+/// bounded by a per-service permit.
 ///
 /// Replaces the former "transport front-end spawns the continuation it got back
 /// from `process_request`" model (#186): the dispatch core now spawns the pump
 /// itself and returns only the reply bytes, so the streaming lifecycle is no
 /// longer threaded through every transport's request/response path. This is the
 /// M1 shape; in M2 the pump's transport (`StreamChannel`) moves to a
-/// service-owned moq broadcast and this per-RPC spawn goes away entirely.
+/// service-owned moq broadcast and this coarse per-service cap is replaced by
+/// the StreamPolicy backpressure axes (#134).
+///
+/// `service_name` keys the per-service permit pool (see
+/// [`MAX_INFLIGHT_STREAM_PUMPS_PER_SERVICE`]). When the pool is saturated the
+/// pump waits for a permit rather than being dropped — but the wait is logged
+/// so saturation is observable rather than a silent stall.
 ///
 /// # Invariant
 ///
@@ -1856,13 +1883,31 @@ fn stream_pump_semaphore() -> &'static std::sync::Arc<tokio::sync::Semaphore> {
 /// runs on a `LocalSet` (ZMQ `RequestLoop`, the WebTransport server, and the
 /// generic plane's `LocalServiceBridge`), which is the only place this is
 /// invoked.
-pub fn spawn_stream_pump(continuation: crate::service::Continuation) {
-    let sem = std::sync::Arc::clone(stream_pump_semaphore());
+pub fn spawn_stream_pump(service_name: &str, continuation: crate::service::Continuation) {
+    let sem = stream_pump_semaphore(service_name);
+    let service_name = service_name.to_owned();
     tokio::task::spawn_local(async move {
-        let Ok(_permit) = sem.acquire_owned().await else {
-            tracing::warn!("stream pump semaphore closed; dropping streaming pump");
-            return;
+        // Observe saturation: a permit that isn't immediately available means
+        // this service is at its concurrent-stream cap and new streams are
+        // queueing behind running ones.
+        let permit = match sem.clone().try_acquire_owned() {
+            Ok(p) => p,
+            Err(_) => {
+                tracing::warn!(
+                    service = %service_name,
+                    cap = MAX_INFLIGHT_STREAM_PUMPS_PER_SERVICE,
+                    "streaming pump cap reached; new stream waiting for a slot"
+                );
+                // The semaphore is a static that is never closed, so
+                // acquire_owned cannot fail; if it somehow did, drop the pump.
+                let Ok(p) = sem.acquire_owned().await else {
+                    tracing::error!(service = %service_name, "stream pump semaphore closed; dropping pump");
+                    return;
+                };
+                p
+            }
         };
+        let _permit = permit; // held for the pump's lifetime
         continuation.await;
     });
 }

--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -1818,6 +1818,56 @@ impl StreamGuard {
 }
 
 // ============================================================================
+// Streaming pump spawning (#186)
+// ============================================================================
+
+/// Process-wide ceiling on concurrently-running streaming pumps.
+///
+/// This is the former per-`RequestLoop` `MAX_INFLIGHT_CONTINUATIONS`, relocated
+/// here when the pump-spawn moved out of the transport front-ends and into the
+/// dispatch core (#186). The bound is now process-wide rather than per-loop —
+/// a deliberate consequence of centralizing the spawn; sized generously so a
+/// single busy front-end does not starve others.
+const MAX_INFLIGHT_STREAM_PUMPS: usize = 64;
+
+fn stream_pump_semaphore() -> &'static std::sync::Arc<tokio::sync::Semaphore> {
+    static SEM: std::sync::OnceLock<std::sync::Arc<tokio::sync::Semaphore>> =
+        std::sync::OnceLock::new();
+    SEM.get_or_init(|| std::sync::Arc::new(tokio::sync::Semaphore::new(MAX_INFLIGHT_STREAM_PUMPS)))
+}
+
+/// Spawn a streaming pump — the server-side half of a streaming RPC that runs
+/// *after* the StreamInfo reply has been sent — onto the current `LocalSet`,
+/// bounded by a process-wide permit.
+///
+/// Replaces the former "transport front-end spawns the continuation it got back
+/// from `process_request`" model (#186): the dispatch core now spawns the pump
+/// itself and returns only the reply bytes, so the streaming lifecycle is no
+/// longer threaded through every transport's request/response path. This is the
+/// M1 shape; in M2 the pump's transport (`StreamChannel`) moves to a
+/// service-owned moq broadcast and this per-RPC spawn goes away entirely.
+///
+/// # Invariant
+///
+/// MUST be called from within a `tokio::task::LocalSet`: the pump is `?Send`
+/// (like every [`RequestService`](crate::service::RequestService)), and
+/// `spawn_local` panics outside a `LocalSet`. Every
+/// [`process_request`](crate::service::dispatch::process_request) caller already
+/// runs on a `LocalSet` (ZMQ `RequestLoop`, the WebTransport server, and the
+/// generic plane's `LocalServiceBridge`), which is the only place this is
+/// invoked.
+pub fn spawn_stream_pump(continuation: crate::service::Continuation) {
+    let sem = std::sync::Arc::clone(stream_pump_semaphore());
+    tokio::task::spawn_local(async move {
+        let Ok(_permit) = sem.acquire_owned().await else {
+            tracing::warn!("stream pump semaphore closed; dropping streaming pump");
+            return;
+        };
+        continuation.await;
+    });
+}
+
+// ============================================================================
 // Helpers
 // ============================================================================
 

--- a/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
@@ -288,6 +288,13 @@ impl LocalServiceBridge {
                             // Re-derive the signing key per call: cheap clone,
                             // tracks any future rotation in the service.
                             let signing_key = service.signing_key();
+                            // As of #186 process_request spawns any streaming
+                            // pump itself (onto this bridge's LocalSet, where
+                            // this task already runs) and returns only the reply
+                            // bytes, so the generic plane no longer has to reject
+                            // continuations it cannot return. The pump's
+                            // transport moves to moq-net in M2 (#134); until then
+                            // it uses StreamChannel exactly as on the ZMQ path.
                             let result = crate::service::dispatch::process_request(
                                 msg.request.as_ref(),
                                 &*service,
@@ -296,28 +303,7 @@ impl LocalServiceBridge {
                                 &nonce_cache,
                             )
                             .await
-                            .and_then(|(bytes, cont)| {
-                                // Streaming continuations are not wired on
-                                // the iroh RPC plane — streaming moves to
-                                // moq-net (`moql` ALPN, Phase 3, #134). In
-                                // debug, panic loudly; in release, return an
-                                // error so the wire emits a signed error
-                                // envelope (handler's build_error_envelope)
-                                // rather than silently dropping the stream.
-                                if cont.is_some() {
-                                    debug_assert!(
-                                        false,
-                                        "iroh-rpc bridge: streaming continuation not supported \
-                                         — wait for Phase 3 (#134)"
-                                    );
-                                    return Err(anyhow::anyhow!(
-                                        "iroh-rpc bridge: service returned a streaming \
-                                         continuation, which is not supported on the iroh \
-                                         RPC plane (Phase 3 / #134 moves streaming to moq-net)"
-                                    ));
-                                }
-                                Ok(Bytes::from(bytes))
-                            });
+                            .map(Bytes::from);
                             let _ = msg.respond.send(result);
                         });
                     }

--- a/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
+++ b/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
@@ -529,7 +529,7 @@ impl QuicRep {
         // just don't pin it to the server's own key. JWT claims + Casbin handle
         // authorization.
         // subsecond::call wraps dispatch for hot-patching during dev
-        let (response_bytes, continuation) = subsecond::call(|| crate::service::dispatch::process_request(
+        let response_bytes = subsecond::call(|| crate::service::dispatch::process_request(
             raw_bytes,
             &*service,
             EnvelopeVerification::AnySigner,
@@ -543,14 +543,9 @@ impl QuicRep {
         };
         stream.send_multipart(&response.parts).await?;
 
-        // Signal end of response
+        // Signal end of response. Any streaming pump was already spawned inside
+        // process_request (#186).
         stream.stream.send.finish()?;
-
-        // Handle continuation if present (for streaming)
-        if let Some(cont) = continuation {
-            // Spawn continuation on LocalSet (streaming handler is ?Send)
-            tokio::task::spawn_local(cont);
-        }
 
         Ok(())
     }
@@ -1680,14 +1675,12 @@ impl WebTransportServer {
                     &signing_key,
                     &nonce_cache,
                 )).await {
-                    Ok((response_bytes, continuation)) => {
+                    Ok(response_bytes) => {
                         zmtp.send_multipart(&[Bytes::from(response_bytes)]).await?;
                         zmtp.stream.send.shutdown().await
                             .map_err(std::io::Error::other)?;
-
-                        if let Some(cont) = continuation {
-                            tokio::task::spawn_local(cont);
-                        }
+                        // Any streaming pump was already spawned inside
+                        // process_request (#186).
                     }
                     Err(e) => {
                         warn!("WebTransport RPC error: {}", e);

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1442,6 +1442,13 @@ fn main() -> Result<()> {
         .validate()
         .context("Configuration validation failed")?;
 
+    // Install the per-service streaming-response concurrency cap from config
+    // (#186) before any RPC service starts. First-write-wins; ignore if already
+    // installed on this process.
+    let _ = hyprstream_rpc::streaming::install_max_concurrent_streams_per_service(
+        config.server.max_concurrent_streams_per_service,
+    );
+
     // ========== TRACING INITIALIZATION (before service startup) ==========
     let is_service_command = matches.subcommand_name() == Some("service");
     let _log_guard: Option<tracing_appender::non_blocking::WorkerGuard>;

--- a/crates/hyprstream/src/config/server.rs
+++ b/crates/hyprstream/src/config/server.rs
@@ -165,6 +165,12 @@ pub struct ServerConfig {
     #[serde(default = "default_cancellation_check_interval")]
     pub cancellation_check_interval: u64,
 
+    /// Max concurrent server-side streaming responses **per service** — how many
+    /// streaming RPCs one service may actively push data for at once. Bounds the
+    /// streaming-response tasks spawned by the RPC dispatch core (#186).
+    #[serde(default = "default_max_concurrent_streams_per_service")]
+    pub max_concurrent_streams_per_service: usize,
+
     /// Maximum context length for KV cache allocation.
     /// Overrides model's max_position_embeddings to reduce GPU memory.
     /// None = use model's default, Some(n) = cap at n tokens
@@ -236,6 +242,9 @@ fn default_max_concurrent_requests() -> usize {
 fn default_cancellation_check_interval() -> u64 {
     100
 }
+fn default_max_concurrent_streams_per_service() -> usize {
+    hyprstream_rpc::streaming::DEFAULT_MAX_CONCURRENT_STREAMS_PER_SERVICE
+}
 fn default_tls_min_version() -> String {
     "1.2".to_owned()
 }
@@ -253,6 +262,7 @@ impl Default for ServerConfig {
             request_timeout_secs: default_request_timeout_secs(),
             max_concurrent_requests: default_max_concurrent_requests(),
             cancellation_check_interval: default_cancellation_check_interval(),
+            max_concurrent_streams_per_service: default_max_concurrent_streams_per_service(),
             max_context: None, // Use model's default max_position_embeddings
             kv_quant: KVQuantArg::None,
             cors: CorsConfig::default(),


### PR DESCRIPTION
`process_request` now returns `Result<Vec<u8>>` and spawns the streaming pump itself (`streaming::spawn_stream_pump`, per-service bounded), so all four transport front-ends are uniform bytes-in/bytes-out and **the generic RPC plane no longer rejects streaming** — the #136-cutover blocker this clears.

M1 scope: removes `Continuation` from the dispatch boundary + every front-end. `handle_request` keeps `Option<Continuation>` as the internal service→core contract, so the 16 service impls + proc-macro codegen are untouched; the type dies in M2 when the pump's transport moves to a service-owned moq broadcast (#134). Code+security reviewed (ship-with-fixes; per-service cap fix applied; LocalSet invariant verified). 261 rpc green; full workspace compiles.

📚 Stacked PR — **base: `ewindisch/moq-148`** (sibling to #151a). Part of epic #131.
