### PR TITLE
#151(a): cert-pin Quic variant + LazyQuinnTransport + dial() Quic arm

### DIFF
--- a/crates/hyprstream-rpc/src/dial.rs
+++ b/crates/hyprstream-rpc/src/dial.rs
@@ -132,12 +132,23 @@ where
             Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
                 as Arc<dyn RpcClient>)
         }
-        endpoint @ (EndpointType::Ipc { .. }
-        | EndpointType::SystemdFd { .. }
-        | EndpointType::Quic { .. }) => bail!(
-            "dial(): endpoint {endpoint:?} is not yet served by the dial factory \
-             — lazy quinn/iroh/moq transports land in a later #151(a) increment; \
-             ZMQ ipc/systemd endpoints stay on the codegen path during the transition"
+        EndpointType::Quic { addr, cert_pin: Some(pin), .. } => {
+            // Pinned QUIC peer: the transport authenticates the server (pinned
+            // TLS), so a `None` server_verifying_key is sound here — response
+            // signatures are still verified against the envelope-embedded key.
+            let transport = crate::transport::lazy_quinn::LazyQuinnTransport::new(*addr, *pin);
+            Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
+                as Arc<dyn RpcClient>)
+        }
+        EndpointType::Quic { cert_pin: None, .. } => bail!(
+            "dial(): QUIC endpoint has no cert pin — cannot authenticate the server. \
+             The resolver must supply EndpointType::Quic.cert_pin (the server cert's \
+             SHA-256), e.g. via TransportConfig::quic_pinned"
+        ),
+        endpoint @ (EndpointType::Ipc { .. } | EndpointType::SystemdFd { .. }) => bail!(
+            "dial(): endpoint {endpoint:?} is not served by the dial factory — \
+             ZMQ ipc/systemd endpoints stay on the codegen path during the transition; \
+             iroh/moq lazy transports land in a later #151(a) increment"
         ),
     }
 }
@@ -208,5 +219,21 @@ mod tests {
         let cfg = TransportConfig::ipc("/tmp/hyprstream-test.sock");
         let err = dial(&cfg, test_signer(), None);
         assert!(err.is_err(), "ipc dial is not yet served by the factory");
+    }
+
+    #[test]
+    fn dial_quic_without_cert_pin_errors() {
+        // Plain `quic()` has no pin → cannot authenticate the server → must bail.
+        let cfg = TransportConfig::quic("127.0.0.1:9999".parse().unwrap(), "localhost");
+        let err = dial(&cfg, test_signer(), None);
+        assert!(err.is_err(), "QUIC dial without a cert pin must error");
+    }
+
+    #[test]
+    fn dial_quic_with_cert_pin_builds_client() {
+        // With a pin, dial() builds a (lazy, not-yet-connected) client — sync, no I/O.
+        let cfg = TransportConfig::quic_pinned("127.0.0.1:9999".parse().unwrap(), "localhost", [7u8; 32]);
+        let client = dial(&cfg, test_signer(), None);
+        assert!(client.is_ok(), "pinned QUIC dial must build a client without connecting");
     }
 }

--- a/crates/hyprstream-rpc/src/dial.rs
+++ b/crates/hyprstream-rpc/src/dial.rs
@@ -133,9 +133,19 @@ where
                 as Arc<dyn RpcClient>)
         }
         EndpointType::Quic { addr, cert_pin: Some(pin), .. } => {
-            // Pinned QUIC peer: the transport authenticates the server (pinned
-            // TLS), so a `None` server_verifying_key is sound here — response
-            // signatures are still verified against the envelope-embedded key.
+            // SECURITY (#185): the pin authenticates the TLS *channel* ("a server
+            // presenting this cert"), not the peer's DID identity. Identity comes
+            // from the response signature. With `None` here that signature is
+            // still verified, but only against the envelope-embedded key (no
+            // identity pinning) — so for a *networked* peer, prefer passing the
+            // resolver-known verifying key. Warn when we can't.
+            if server_verifying_key.is_none() {
+                tracing::debug!(
+                    %addr,
+                    "dial: networked QUIC peer with no expected verifying key — \
+                     response identity is unpinned (cert pin authenticates the channel only, #185)"
+                );
+            }
             let transport = crate::transport::lazy_quinn::LazyQuinnTransport::new(*addr, *pin);
             Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
                 as Arc<dyn RpcClient>)

--- a/crates/hyprstream-rpc/src/transport/lazy_quinn.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_quinn.rs
@@ -23,8 +23,9 @@
 //! lock — only the dial does.
 
 use std::net::SocketAddr;
+use std::time::Duration;
 
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 use async_trait::async_trait;
 use tokio::sync::Mutex;
 
@@ -32,6 +33,10 @@ use crate::transport::quinn_transport::{
     connect_pinned_sha256, QuinnPendingStream, QuinnPublishStub, QuinnTransport,
 };
 use crate::transport_traits::Transport;
+
+/// Default per-request deadline when the caller passes `None`, mirroring
+/// `SessionRpcTransport`.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// A quinn RPC transport that connects on first use and caches the session.
 pub struct LazyQuinnTransport {
@@ -79,9 +84,28 @@ impl Transport for LazyQuinnTransport {
 
     async fn send(&self, payload: Vec<u8>, timeout_ms: Option<i32>) -> Result<Vec<u8>> {
         let transport = self.connected().await?;
-        match transport.send(payload, timeout_ms).await {
-            Ok(resp) => Ok(resp),
-            Err(e) => {
+
+        // Make *our* deadline authoritative so we can tell a per-request timeout
+        // (the connection is probably fine — keep it) apart from a transport-fatal
+        // error (re-dial). The inner transport gets a generous ceiling that fires
+        // only if ours somehow doesn't.
+        let deadline = timeout_ms
+            .map(|ms| Duration::from_millis(ms.max(0) as u64))
+            .unwrap_or(DEFAULT_TIMEOUT);
+        let inner_ceiling_ms = deadline
+            .as_millis()
+            .saturating_mul(2)
+            .min(i32::MAX as u128) as i32;
+
+        match tokio::time::timeout(deadline, transport.send(payload, Some(inner_ceiling_ms))).await {
+            // Our deadline fired: a slow/stalled request, not necessarily a dead
+            // connection. Keep the cached session — re-dialing on every timeout
+            // would thrash a merely-busy peer. (#156 owns liveness-based re-dial.)
+            Err(_elapsed) => Err(anyhow!("quinn RPC timeout after {deadline:?}")),
+            Ok(Ok(resp)) => Ok(resp),
+            // Transport-fatal (open_bi/write/read failed): the session is likely
+            // dead — drop it so the next call re-dials, like ZmqConnection.
+            Ok(Err(e)) => {
                 self.invalidate().await;
                 Err(e)
             }
@@ -172,11 +196,13 @@ mod tests {
     async fn wrong_cert_pin_does_not_connect() {
         let (addr, _pin, shutdown) = spawn_echo_server();
         let t = LazyQuinnTransport::new(addr, [0u8; 32]); // wrong fingerprint
-        let res = tokio::time::timeout(Duration::from_secs(5), t.send(b"x".to_vec(), Some(2_000)))
-            .await;
-        // Either the dial errors, or it times out — never a successful echo.
-        let connected = matches!(&res, Ok(Ok(_)));
-        assert!(!connected, "a wrong cert pin must not yield a working connection");
+        // The TLS handshake must *promptly reject* a wrong pin: the send must
+        // COMPLETE with an error well within the hang-guard. If the guard fires
+        // (i.e. send hung), the test fails — so a hang can't masquerade as a pass.
+        let res = tokio::time::timeout(Duration::from_secs(8), t.send(b"x".to_vec(), Some(3_000)))
+            .await
+            .expect("send must complete (with an error) — a wrong pin should reject, not hang");
+        assert!(res.is_err(), "a wrong cert pin must make send fail");
         assert!(t.cached.lock().await.is_none(), "failed dial leaves nothing cached");
         shutdown.cancel();
     }

--- a/crates/hyprstream-rpc/src/transport/lazy_quinn.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_quinn.rs
@@ -1,0 +1,190 @@
+//! Lazy-connecting quinn RPC transport.
+//!
+//! The [`dial`](crate::dial::dial) factory is synchronous and does no I/O, but a
+//! networked QUIC peer must be connected before the first request. This wrapper
+//! bridges that: it holds the dial target (`addr` + the server cert's SHA-256
+//! pin) and connects on the **first `send()`**, caching the established session
+//! for subsequent calls — exactly the lazy-connect model `ZmqConnection` uses,
+//! so sync construction + zero I/O at dial time is preserved (A1 spike).
+//!
+//! # Re-dial / self-heal
+//!
+//! On a `send()` error the cached session is dropped, so the next call re-dials
+//! — like `ZmqConnection`, which a dead cached session would otherwise not
+//! recover from. This is deliberately **coarse**: it re-dials on *any* failure,
+//! including a per-request timeout on an otherwise-live connection. Refined,
+//! liveness-based re-dial with backoff is the connection-manager's job (#156);
+//! this wrapper only needs to not strand a dead session.
+//!
+//! Concurrent first-sends are **single-flighted**: the dial happens under the
+//! cache lock, so N racing callers dial once and the rest reuse the session.
+//! The connected handle is cloned out from under the lock (both `QuinnTransport`
+//! and its `Session` are cheap `Clone`), so `send()` itself never holds the
+//! lock — only the dial does.
+
+use std::net::SocketAddr;
+
+use anyhow::{bail, Result};
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+
+use crate::transport::quinn_transport::{
+    connect_pinned_sha256, QuinnPendingStream, QuinnPublishStub, QuinnTransport,
+};
+use crate::transport_traits::Transport;
+
+/// A quinn RPC transport that connects on first use and caches the session.
+pub struct LazyQuinnTransport {
+    addr: SocketAddr,
+    cert_pin: [u8; 32],
+    /// `None` until the first successful dial, and reset to `None` after a
+    /// `send()` failure so the next call re-dials.
+    cached: Mutex<Option<QuinnTransport>>,
+}
+
+impl LazyQuinnTransport {
+    /// Create a lazy transport for a QUIC peer pinned by `cert_pin` (the SHA-256
+    /// of its self-signed cert). No connection is made until the first `send()`.
+    pub fn new(addr: SocketAddr, cert_pin: [u8; 32]) -> Self {
+        Self {
+            addr,
+            cert_pin,
+            cached: Mutex::new(None),
+        }
+    }
+
+    /// Return the cached connected transport, dialing once (under the lock —
+    /// single-flight) if not yet connected.
+    async fn connected(&self) -> Result<QuinnTransport> {
+        let mut guard = self.cached.lock().await;
+        if let Some(transport) = guard.as_ref() {
+            return Ok(transport.clone());
+        }
+        let session = connect_pinned_sha256(self.addr, self.cert_pin).await?;
+        let transport = QuinnTransport::new(session);
+        *guard = Some(transport.clone());
+        Ok(transport)
+    }
+
+    /// Drop the cached session so the next `send()` re-dials.
+    async fn invalidate(&self) {
+        *self.cached.lock().await = None;
+    }
+}
+
+#[async_trait]
+impl Transport for LazyQuinnTransport {
+    type Sub = QuinnPendingStream;
+    type Pub = QuinnPublishStub;
+
+    async fn send(&self, payload: Vec<u8>, timeout_ms: Option<i32>) -> Result<Vec<u8>> {
+        let transport = self.connected().await?;
+        match transport.send(payload, timeout_ms).await {
+            Ok(resp) => Ok(resp),
+            Err(e) => {
+                self.invalidate().await;
+                Err(e)
+            }
+        }
+    }
+
+    async fn subscribe(&self, _topic: &[u8]) -> Result<Self::Sub> {
+        bail!("lazy quinn RPC transport does not support SUB — streaming is on the moq plane")
+    }
+
+    async fn publish(&self, _topic: &[u8]) -> Result<Self::Pub> {
+        bail!("lazy quinn RPC transport does not support PUB — streaming is on the moq plane")
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::transport::quinn_transport::QuinnRpcServer;
+    use bytes::Bytes;
+    use ed25519_dalek::SigningKey;
+    use rand::RngCore;
+    use std::time::Duration;
+    use tokio_util::sync::CancellationToken;
+
+    fn fresh_signing_key() -> SigningKey {
+        let mut k = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut k);
+        SigningKey::from_bytes(&k)
+    }
+
+    fn sha256_32(bytes: &[u8]) -> [u8; 32] {
+        use sha2::{Digest, Sha256};
+        let mut h = [0u8; 32];
+        h.copy_from_slice(&Sha256::digest(bytes));
+        h
+    }
+
+    /// Hermetic loopback WebTransport echo server. Returns the bound addr, the
+    /// server cert's SHA-256 pin, and a shutdown token. (Mirrors the harness in
+    /// `quinn_transport::tests`; `build_server` there is test-private.)
+    fn spawn_echo_server() -> (SocketAddr, [u8; 32], CancellationToken) {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let cert_key =
+            rcgen::generate_simple_self_signed(vec!["localhost".to_owned()]).unwrap();
+        let cert_der = cert_key.cert.der().to_vec();
+        let key_der = cert_key.key_pair.serialize_der();
+        let chain = vec![rustls::pki_types::CertificateDer::from(cert_der.clone())];
+        let key = rustls::pki_types::PrivateKeyDer::Pkcs8(
+            rustls::pki_types::PrivatePkcs8KeyDer::from(key_der),
+        );
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let server = web_transport_quinn::ServerBuilder::new()
+            .with_addr(addr)
+            .with_certificate(chain, key)
+            .unwrap();
+        let bound = server.local_addr().unwrap();
+
+        let processor =
+            crate::transport::rpc_session::from_fn(|req: Bytes| async move { Ok(req) });
+        let rpc_server = QuinnRpcServer::new(server, processor, fresh_signing_key());
+        let shutdown = rpc_server.shutdown_token();
+        tokio::spawn(rpc_server.run());
+
+        (bound, sha256_32(&cert_der), shutdown)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn lazy_connects_on_first_send_and_caches() {
+        let (addr, pin, shutdown) = spawn_echo_server();
+        let t = LazyQuinnTransport::new(addr, pin);
+
+        assert!(t.cached.lock().await.is_none(), "no connection before first send");
+
+        let resp = t.send(b"hello".to_vec(), Some(5_000)).await.unwrap();
+        assert_eq!(resp, b"hello");
+        assert!(t.cached.lock().await.is_some(), "session cached after first send");
+
+        let resp2 = t.send(b"again".to_vec(), Some(5_000)).await.unwrap();
+        assert_eq!(resp2, b"again");
+
+        shutdown.cancel();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn wrong_cert_pin_does_not_connect() {
+        let (addr, _pin, shutdown) = spawn_echo_server();
+        let t = LazyQuinnTransport::new(addr, [0u8; 32]); // wrong fingerprint
+        let res = tokio::time::timeout(Duration::from_secs(5), t.send(b"x".to_vec(), Some(2_000)))
+            .await;
+        // Either the dial errors, or it times out — never a successful echo.
+        let connected = matches!(&res, Ok(Ok(_)));
+        assert!(!connected, "a wrong cert pin must not yield a working connection");
+        assert!(t.cached.lock().await.is_none(), "failed dial leaves nothing cached");
+        shutdown.cancel();
+    }
+
+    #[tokio::test]
+    async fn subscribe_publish_bail() {
+        let t = LazyQuinnTransport::new("127.0.0.1:1".parse().unwrap(), [0u8; 32]);
+        assert!(t.subscribe(b"topic").await.is_err());
+        assert!(t.publish(b"topic").await.is_err());
+    }
+}

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -25,6 +25,8 @@ pub mod iroh_transport;
 pub mod iroh_moq;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod in_memory;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod lazy_quinn;
 
 use std::net::SocketAddr;
 use std::os::unix::io::RawFd;
@@ -162,6 +164,13 @@ pub enum EndpointType {
         addr: SocketAddr,
         /// Server hostname for TLS certificate validation
         server_name: String,
+        /// SHA-256 fingerprint of the server's self-signed certificate, for
+        /// client-side cert pinning (`with_server_certificate_hashes`). `None`
+        /// for the server/bind side or when peer authentication is provided
+        /// some other way (e.g. an expected response-signing key). Carrying the
+        /// 32-byte hash (not the full cert) keeps `TransportConfig` compact and
+        /// wire-publishable. Public fingerprint — not secret.
+        cert_pin: Option<[u8; 32]>,
     },
 }
 
@@ -219,9 +228,25 @@ impl TransportConfig {
             endpoint: EndpointType::Quic {
                 addr,
                 server_name: server_name.into(),
+                cert_pin: None,
             },
             curve: None, // QUIC has TLS 1.3 built-in, no CurveZMQ needed
             bind_mode: BindMode::Bind,
+        }
+    }
+
+    /// Create a client QUIC endpoint that pins the server's self-signed cert by
+    /// its SHA-256 fingerprint (`cert_pin`). This is the dial target the
+    /// resolver/`dial()` produce for a networked RPC peer.
+    pub fn quic_pinned(addr: SocketAddr, server_name: impl Into<String>, cert_pin: [u8; 32]) -> Self {
+        Self {
+            endpoint: EndpointType::Quic {
+                addr,
+                server_name: server_name.into(),
+                cert_pin: Some(cert_pin),
+            },
+            curve: None,
+            bind_mode: BindMode::Connect,
         }
     }
 
@@ -300,7 +325,7 @@ impl TransportConfig {
             EndpointType::SystemdFd { client_path, .. } => {
                 format!("ipc://{}", client_path.display())
             }
-            EndpointType::Quic { addr, server_name } => {
+            EndpointType::Quic { addr, server_name, .. } => {
                 format!("quic://{server_name}:{addr}")
             }
         }
@@ -317,7 +342,7 @@ impl TransportConfig {
     /// Returns `https://{server_name}:{port}` for QUIC endpoints, `None` otherwise.
     pub fn quic_webtransport_url(&self) -> Option<String> {
         match &self.endpoint {
-            EndpointType::Quic { addr, server_name } => {
+            EndpointType::Quic { addr, server_name, .. } => {
                 Some(format!("https://{}:{}", server_name, addr.port()))
             }
             _ => None,

--- a/crates/hyprstream-rpc/src/transport/quinn_transport.rs
+++ b/crates/hyprstream-rpc/src/transport/quinn_transport.rs
@@ -286,15 +286,19 @@ impl Transport for QuinnTransport {
     }
 }
 
-/// Helper to build a quinn WebTransport client session against a self-signed
-/// server, pinning the server cert by its sha256 fingerprint. Hermetic: dials
-/// an IP-literal URL so no DNS lookup or network egress occurs.
-pub async fn connect_pinned(
+/// Build a quinn WebTransport client session against a self-signed server,
+/// pinning the server cert by its **SHA-256 fingerprint** (the 32-byte hash
+/// carried in `EndpointType::Quic { cert_pin }`). Hermetic: dials an IP-literal
+/// URL so no DNS lookup or network egress occurs.
+///
+/// This is the connect path the lazy dial transport uses — the resolver/DID doc
+/// publishes the compact hash, not the full cert.
+pub async fn connect_pinned_sha256(
     addr: std::net::SocketAddr,
-    cert_der: &[u8],
+    cert_sha256: [u8; 32],
 ) -> Result<web_transport_quinn::Session> {
     let client = web_transport_quinn::ClientBuilder::new()
-        .with_server_certificate_hashes(vec![sha256(cert_der)])
+        .with_server_certificate_hashes(vec![cert_sha256.to_vec()])
         .map_err(|e| anyhow!("quinn client build: {e}"))?;
     let url = url::Url::parse(&format!("https://{addr}/"))
         .map_err(|e| anyhow!("quinn url: {e}"))?;
@@ -302,6 +306,17 @@ pub async fn connect_pinned(
         .connect(url)
         .await
         .map_err(|e| anyhow!("quinn connect: {e}"))
+}
+
+/// Convenience: pin by the full server cert DER (hashes it for you). Used by
+/// tests and callers that hold the cert rather than its fingerprint.
+pub async fn connect_pinned(
+    addr: std::net::SocketAddr,
+    cert_der: &[u8],
+) -> Result<web_transport_quinn::Session> {
+    let mut hash = [0u8; 32];
+    hash.copy_from_slice(&sha256(cert_der));
+    connect_pinned_sha256(addr, hash).await
 }
 
 fn sha256(bytes: &[u8]) -> Vec<u8> {


### PR DESCRIPTION
Second #151(a) increment — makes networked **QUIC** peers dialable through `dial()`.

- `EndpointType::Quic` gains `cert_pin: Option<[u8;32]>` (the server cert's SHA-256 — compact, wire-publishable) + `TransportConfig::quic_pinned`.
- `connect_pinned_sha256(addr, [u8;32])` core (pins via `with_server_certificate_hashes`); `connect_pinned(cert_der)` delegates.
- **`LazyQuinnTransport`**: connects on first `send()`, caches the session (sync dial, zero-I/O per the A1 spike), single-flights the dial under the cache lock, lock-free send via the `Clone` handle. The deadline is authoritative so a per-request timeout *keeps* the session; only transport-fatal errors re-dial. (Liveness-based re-dial + backoff is #156.)
- `dial()` Quic arm: pinned → lazy transport; no-pin → bail (can't authenticate). Exhaustive match preserved.

Code+security reviewed (ship-with-fixes, applied). The cert pin authenticates the **channel, not the DID identity** — see #185. 10 new tests (incl. a real hermetic-server lazy round-trip + wrong-pin rejection); 275 rpc lib tests green.

📚 Stacked PR — **base: `ewindisch/moq-151a`** (#195). Part of epic #131.
