### PR TITLE
#151(a): QUIC server-auth policy (de-hardcode the cert pin)

### DIFF
--- a/crates/hyprstream-rpc/src/dial.rs
+++ b/crates/hyprstream-rpc/src/dial.rs
@@ -36,7 +36,7 @@ use crate::crypto::VerifyingKey;
 use crate::rpc_client::{RpcClient, RpcClientImpl};
 use crate::transport::in_memory::InMemoryTransport;
 use crate::transport::rpc_session::IrohRequestProcessor;
-use crate::transport::{EndpointType, TransportConfig};
+use crate::transport::{EndpointType, QuicServerAuth, TransportConfig};
 use crate::transport_traits::Signer;
 
 /// Process-local map of inproc endpoint name → co-located request processor.
@@ -132,29 +132,33 @@ where
             Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
                 as Arc<dyn RpcClient>)
         }
-        EndpointType::Quic { addr, cert_pin: Some(pin), .. } => {
-            // SECURITY (#185): the pin authenticates the TLS *channel* ("a server
-            // presenting this cert"), not the peer's DID identity. Identity comes
-            // from the response signature. With `None` here that signature is
-            // still verified, but only against the envelope-embedded key (no
-            // identity pinning) — so for a *networked* peer, prefer passing the
-            // resolver-known verifying key. Warn when we can't.
+        EndpointType::Quic { auth: QuicServerAuth::RawPublicKey(_), .. } => bail!(
+            "dial(): QUIC RFC 7250 raw-public-key auth is not yet implemented (#200) — \
+             use iroh for identity-bound transport, or QuicServerAuth::Pinned / WebPki"
+        ),
+        EndpointType::Quic { addr, server_name, auth } => {
+            // SECURITY (#185): WebPki/Pinned authenticate the TLS *channel* (a CA
+            // chain, or a specific cert), not the peer's DID identity. Identity
+            // comes from the response signature, which is still verified against
+            // the envelope-embedded key when `server_verifying_key` is `None` —
+            // just not *pinned* to an expected identity. For a networked peer,
+            // prefer passing the resolver-known key; warn when we can't. (iroh's
+            // arm needs no such warning — it is identity-bound at the transport.)
             if server_verifying_key.is_none() {
                 tracing::debug!(
                     %addr,
                     "dial: networked QUIC peer with no expected verifying key — \
-                     response identity is unpinned (cert pin authenticates the channel only, #185)"
+                     response identity unpinned (channel-level auth only, #185)"
                 );
             }
-            let transport = crate::transport::lazy_quinn::LazyQuinnTransport::new(*addr, *pin);
+            let transport = crate::transport::lazy_quinn::LazyQuinnTransport::new(
+                *addr,
+                server_name.clone(),
+                auth.clone(),
+            );
             Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
                 as Arc<dyn RpcClient>)
         }
-        EndpointType::Quic { cert_pin: None, .. } => bail!(
-            "dial(): QUIC endpoint has no cert pin — cannot authenticate the server. \
-             The resolver must supply EndpointType::Quic.cert_pin (the server cert's \
-             SHA-256), e.g. via TransportConfig::quic_pinned"
-        ),
         EndpointType::Iroh { direct_addrs, relay_url, .. }
             if direct_addrs.is_empty() && relay_url.is_none() =>
         {
@@ -256,18 +260,35 @@ mod tests {
     }
 
     #[test]
-    fn dial_quic_without_cert_pin_errors() {
-        // Plain `quic()` has no pin → cannot authenticate the server → must bail.
+    fn dial_quic_webpki_builds_client() {
+        // Plain `quic()` = WebPKI/CA validation — a valid auth policy, so dial()
+        // builds a (lazy, not-yet-connected) client.
         let cfg = TransportConfig::quic("127.0.0.1:9999".parse().unwrap(), "localhost");
-        let err = dial(&cfg, test_signer(), None);
-        assert!(err.is_err(), "QUIC dial without a cert pin must error");
+        let client = dial(&cfg, test_signer(), None);
+        assert!(client.is_ok(), "WebPKI QUIC dial must build a client without connecting");
     }
 
     #[test]
-    fn dial_quic_with_cert_pin_builds_client() {
-        // With a pin, dial() builds a (lazy, not-yet-connected) client — sync, no I/O.
+    fn dial_quic_pinned_builds_client() {
+        // Cert-hash-pinned QUIC: builds a lazy client — sync, no I/O.
         let cfg = TransportConfig::quic_pinned("127.0.0.1:9999".parse().unwrap(), "localhost", [7u8; 32]);
         let client = dial(&cfg, test_signer(), None);
         assert!(client.is_ok(), "pinned QUIC dial must build a client without connecting");
+    }
+
+    #[test]
+    fn dial_quic_raw_public_key_errors() {
+        // RFC 7250 raw-public-key auth is not yet implemented → fail fast.
+        let cfg = TransportConfig {
+            endpoint: EndpointType::Quic {
+                addr: "127.0.0.1:9999".parse().unwrap(),
+                server_name: "localhost".to_owned(),
+                auth: QuicServerAuth::RawPublicKey([9u8; 32]),
+            },
+            curve: None,
+            bind_mode: crate::transport::BindMode::Connect,
+        };
+        let err = dial(&cfg, test_signer(), None);
+        assert!(err.is_err(), "RFC 7250 QUIC auth must error until implemented");
     }
 }

--- a/crates/hyprstream-rpc/src/dial.rs
+++ b/crates/hyprstream-rpc/src/dial.rs
@@ -142,8 +142,9 @@ where
             // comes from the response signature, which is still verified against
             // the envelope-embedded key when `server_verifying_key` is `None` —
             // just not *pinned* to an expected identity. For a networked peer,
-            // prefer passing the resolver-known key; warn when we can't. (iroh's
-            // arm needs no such warning — it is identity-bound at the transport.)
+            // prefer passing the resolver-known key; note (debug) when we can't.
+            // (iroh's arm needs no such note — it is identity-bound at the
+            // transport.)
             if server_verifying_key.is_none() {
                 tracing::debug!(
                     %addr,

--- a/crates/hyprstream-rpc/src/registry/mod.rs
+++ b/crates/hyprstream-rpc/src/registry/mod.rs
@@ -254,7 +254,12 @@ impl EndpointRegistry {
 
     /// Generate a default endpoint for a service and socket type.
     fn default_endpoint(&self, name: &str, socket_kind: SocketKind) -> TransportConfig {
-        // QUIC endpoints are always TCP-based, independent of ZMQ endpoint mode
+        // QUIC endpoints are always TCP-based, independent of ZMQ endpoint mode.
+        // This is a non-dialable PLACEHOLDER (port 0), returned only when a
+        // service has no real registration; a genuine QUIC endpoint is
+        // registered by the serving loop *pinned* with its cert hash (see
+        // QuicServiceLoop::registrations and the unified loop's QUIC
+        // registration). The WebPki policy here is moot — :0 can't be connected.
         if socket_kind == SocketKind::Quic {
             return TransportConfig::quic(
                 std::net::SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), 0),

--- a/crates/hyprstream-rpc/src/service/zmq.rs
+++ b/crates/hyprstream-rpc/src/service/zmq.rs
@@ -869,12 +869,21 @@ impl RequestLoop {
                         actual_addr,
                         cert_hash,
                     );
-                    // Register QUIC endpoint in the global registry for discovery
+                    // Register QUIC endpoint in the global registry for discovery.
+                    // The server is self-signed, so register it *pinned* by the
+                    // leaf cert's SHA-256 — otherwise a client dialing this config
+                    // would attempt CA validation (WebPki) against a self-signed
+                    // cert and fail.
                     if let Some(reg) = crate::registry::try_global() {
+                        let pin = crate::transport::zmtp_quic::cert_sha256(&qc.cert_chain[0]);
                         reg.register(
                             service.name(),
                             crate::registry::SocketKind::Quic,
-                            crate::transport::TransportConfig::quic(actual_addr, &qc.server_name),
+                            crate::transport::TransportConfig::quic_pinned(
+                                actual_addr,
+                                &qc.server_name,
+                                pin,
+                            ),
                             None,
                         );
                     }

--- a/crates/hyprstream-rpc/src/transport/lazy_iroh.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_iroh.rs
@@ -42,6 +42,11 @@ use crate::transport_traits::Transport;
 /// Default per-request deadline when the caller passes `None`.
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Ceiling on the lazy connect (iroh dial + handshake). The per-request deadline
+/// wraps only the request; without this an unreachable peer would hang the first
+/// `send()` indefinitely.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Process-wide client iroh endpoint, installed once at startup.
 static IROH_CLIENT_ENDPOINT: OnceLock<iroh::Endpoint> = OnceLock::new();
 
@@ -111,9 +116,9 @@ impl LazyIrohTransport {
             )
         })?;
         let addr = self.endpoint_addr()?;
-        let conn = endpoint
-            .connect(addr, ALPN_HYPRSTREAM_RPC)
+        let conn = tokio::time::timeout(CONNECT_TIMEOUT, endpoint.connect(addr, ALPN_HYPRSTREAM_RPC))
             .await
+            .map_err(|_| anyhow!("iroh connect timed out after {CONNECT_TIMEOUT:?}"))?
             .map_err(|e| anyhow!("iroh connect: {e}"))?;
         let transport = IrohTransport::new(conn);
         *guard = Some(transport.clone());

--- a/crates/hyprstream-rpc/src/transport/lazy_quinn.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_quinn.rs
@@ -30,8 +30,9 @@ use async_trait::async_trait;
 use tokio::sync::Mutex;
 
 use crate::transport::quinn_transport::{
-    connect_pinned_sha256, QuinnPendingStream, QuinnPublishStub, QuinnTransport,
+    connect_pinned_sha256, connect_webpki, QuinnPendingStream, QuinnPublishStub, QuinnTransport,
 };
+use crate::transport::QuicServerAuth;
 use crate::transport_traits::Transport;
 
 /// Default per-request deadline when the caller passes `None`, mirroring
@@ -41,31 +42,42 @@ const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 /// A quinn RPC transport that connects on first use and caches the session.
 pub struct LazyQuinnTransport {
     addr: SocketAddr,
-    cert_pin: [u8; 32],
+    server_name: String,
+    auth: QuicServerAuth,
     /// `None` until the first successful dial, and reset to `None` after a
     /// `send()` failure so the next call re-dials.
     cached: Mutex<Option<QuinnTransport>>,
 }
 
 impl LazyQuinnTransport {
-    /// Create a lazy transport for a QUIC peer pinned by `cert_pin` (the SHA-256
-    /// of its self-signed cert). No connection is made until the first `send()`.
-    pub fn new(addr: SocketAddr, cert_pin: [u8; 32]) -> Self {
+    /// Create a lazy transport for a QUIC peer, authenticated per `auth`
+    /// (WebPKI, cert-hash pin, or — later — RFC 7250 raw key). No connection is
+    /// made until the first `send()`.
+    pub fn new(addr: SocketAddr, server_name: impl Into<String>, auth: QuicServerAuth) -> Self {
         Self {
             addr,
-            cert_pin,
+            server_name: server_name.into(),
+            auth,
             cached: Mutex::new(None),
         }
     }
 
     /// Return the cached connected transport, dialing once (under the lock —
-    /// single-flight) if not yet connected.
+    /// single-flight) if not yet connected. The connect path is chosen by the
+    /// server-auth policy.
     async fn connected(&self) -> Result<QuinnTransport> {
         let mut guard = self.cached.lock().await;
         if let Some(transport) = guard.as_ref() {
             return Ok(transport.clone());
         }
-        let session = connect_pinned_sha256(self.addr, self.cert_pin).await?;
+        let session = match &self.auth {
+            QuicServerAuth::WebPki => connect_webpki(&self.server_name, self.addr.port()).await?,
+            QuicServerAuth::Pinned(hash) => connect_pinned_sha256(self.addr, *hash).await?,
+            QuicServerAuth::RawPublicKey(_) => bail!(
+                "RFC 7250 raw-public-key QUIC auth is not yet implemented (#200) — use iroh \
+                 for identity-bound transport, or QuicServerAuth::Pinned / WebPki"
+            ),
+        };
         let transport = QuinnTransport::new(session);
         *guard = Some(transport.clone());
         Ok(transport)
@@ -178,7 +190,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn lazy_connects_on_first_send_and_caches() {
         let (addr, pin, shutdown) = spawn_echo_server();
-        let t = LazyQuinnTransport::new(addr, pin);
+        let t = LazyQuinnTransport::new(addr, "localhost", QuicServerAuth::Pinned(pin));
 
         assert!(t.cached.lock().await.is_none(), "no connection before first send");
 
@@ -195,7 +207,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn wrong_cert_pin_does_not_connect() {
         let (addr, _pin, shutdown) = spawn_echo_server();
-        let t = LazyQuinnTransport::new(addr, [0u8; 32]); // wrong fingerprint
+        let t = LazyQuinnTransport::new(addr, "localhost", QuicServerAuth::Pinned([0u8; 32])); // wrong fingerprint
         // The TLS handshake must *promptly reject* a wrong pin: the send must
         // COMPLETE with an error well within the hang-guard. If the guard fires
         // (i.e. send hung), the test fails — so a hang can't masquerade as a pass.
@@ -209,7 +221,11 @@ mod tests {
 
     #[tokio::test]
     async fn subscribe_publish_bail() {
-        let t = LazyQuinnTransport::new("127.0.0.1:1".parse().unwrap(), [0u8; 32]);
+        let t = LazyQuinnTransport::new(
+            "127.0.0.1:1".parse().unwrap(),
+            "localhost",
+            QuicServerAuth::Pinned([0u8; 32]),
+        );
         assert!(t.subscribe(b"topic").await.is_err());
         assert!(t.publish(b"topic").await.is_err());
     }

--- a/crates/hyprstream-rpc/src/transport/lazy_quinn.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_quinn.rs
@@ -2,10 +2,12 @@
 //!
 //! The [`dial`](crate::dial::dial) factory is synchronous and does no I/O, but a
 //! networked QUIC peer must be connected before the first request. This wrapper
-//! bridges that: it holds the dial target (`addr` + the server cert's SHA-256
-//! pin) and connects on the **first `send()`**, caching the established session
-//! for subsequent calls — exactly the lazy-connect model `ZmqConnection` uses,
-//! so sync construction + zero I/O at dial time is preserved (A1 spike).
+//! bridges that: it holds the dial target (`addr` + `server_name` + the
+//! [`QuicServerAuth`](crate::transport::QuicServerAuth) policy) and connects on
+//! the **first `send()`**, caching the established session for subsequent calls
+//! — exactly the lazy-connect model `ZmqConnection` uses, so sync construction +
+//! zero I/O at dial time is preserved (A1 spike). The connect path (WebPKI vs
+//! cert-hash pin) is selected by the auth policy.
 //!
 //! # Re-dial / self-heal
 //!
@@ -39,6 +41,11 @@ use crate::transport_traits::Transport;
 /// `SessionRpcTransport`.
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Ceiling on the lazy connect itself (TLS handshake + dial). The per-request
+/// deadline wraps only the *request*; without this a dead/misrouted address (or
+/// a stalled handshake) would hang the first `send()` indefinitely.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// A quinn RPC transport that connects on first use and caches the session.
 pub struct LazyQuinnTransport {
     addr: SocketAddr,
@@ -70,14 +77,19 @@ impl LazyQuinnTransport {
         if let Some(transport) = guard.as_ref() {
             return Ok(transport.clone());
         }
-        let session = match &self.auth {
-            QuicServerAuth::WebPki => connect_webpki(&self.server_name, self.addr.port()).await?,
-            QuicServerAuth::Pinned(hash) => connect_pinned_sha256(self.addr, *hash).await?,
-            QuicServerAuth::RawPublicKey(_) => bail!(
-                "RFC 7250 raw-public-key QUIC auth is not yet implemented (#200) — use iroh \
-                 for identity-bound transport, or QuicServerAuth::Pinned / WebPki"
-            ),
+        let connect = async {
+            match &self.auth {
+                QuicServerAuth::WebPki => connect_webpki(&self.server_name, self.addr.port()).await,
+                QuicServerAuth::Pinned(hash) => connect_pinned_sha256(self.addr, *hash).await,
+                QuicServerAuth::RawPublicKey(_) => bail!(
+                    "RFC 7250 raw-public-key QUIC auth is not yet implemented (#200) — use iroh \
+                     for identity-bound transport, or QuicServerAuth::Pinned / WebPki"
+                ),
+            }
         };
+        let session = tokio::time::timeout(CONNECT_TIMEOUT, connect)
+            .await
+            .map_err(|_| anyhow!("quinn connect timed out after {CONNECT_TIMEOUT:?}"))??;
         let transport = QuinnTransport::new(session);
         *guard = Some(transport.clone());
         Ok(transport)
@@ -217,6 +229,23 @@ mod tests {
         assert!(res.is_err(), "a wrong cert pin must make send fail");
         assert!(t.cached.lock().await.is_none(), "failed dial leaves nothing cached");
         shutdown.cancel();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dead_address_send_fails_fast_not_hang() {
+        // No server at 127.0.0.1:1 → the lazy connect must fail (or hit
+        // CONNECT_TIMEOUT) so `send()` returns an error rather than hanging
+        // forever. The guard (> CONNECT_TIMEOUT) fails the test if it hangs.
+        let t = LazyQuinnTransport::new(
+            "127.0.0.1:1".parse().unwrap(),
+            "localhost",
+            QuicServerAuth::Pinned([0u8; 32]),
+        );
+        let res = tokio::time::timeout(Duration::from_secs(13), t.send(b"x".to_vec(), Some(2_000)))
+            .await
+            .expect("send must complete (with an error) within the connect timeout, not hang");
+        assert!(res.is_err(), "a dead address must yield an error, not a connection");
+        assert!(t.cached.lock().await.is_none(), "a failed connect caches nothing");
     }
 
     #[tokio::test]

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -129,6 +129,38 @@ pub struct TransportConfig {
     pub bind_mode: BindMode,
 }
 
+/// How a QUIC client authenticates the server it dials.
+///
+/// Server authentication is a *policy*, not a single mechanism — this replaces
+/// the earlier hardcoded SHA-256 cert pin. All variants carry only
+/// serializable, public material so `TransportConfig` stays `Clone + Eq` and
+/// wire-publishable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QuicServerAuth {
+    /// Standard WebPKI / CA-chain validation against the system root store,
+    /// matching the server's DNS `server_name`. For public peers fronted by a
+    /// CA-issued certificate (dialed by hostname).
+    WebPki,
+    /// Pin the server's (self-signed) certificate by its SHA-256 fingerprint
+    /// (`with_server_certificate_hashes`) — the internal-mesh model, dialed by
+    /// IP. The resolver / DID doc vouches for the hash.
+    ///
+    /// SECURITY: authenticates the *channel* ("a server holding this cert"), not
+    /// the peer's DID *identity* (#185). For identity-bound transport use iroh
+    /// (which is RFC 7250 — the connection is bound to the peer's public key).
+    Pinned([u8; 32]),
+    /// RFC 7250 raw-public-key identity binding: the server proves possession of
+    /// this Ed25519 key during the TLS handshake.
+    ///
+    /// **Not yet implemented** — `web_transport_quinn`'s builder exposes no
+    /// raw-key/custom-verifier hook, so this needs a custom rustls verifier + a
+    /// raw `quinn` connect + `Session::raw`, plus a server-side raw-key config.
+    /// It is also browser-incompatible (WebTransport mandates cert hashes) and
+    /// overlaps iroh (which already provides RFC 7250). Tracked in #200; use
+    /// iroh for identity-bound native transport today.
+    RawPublicKey([u8; 32]),
+}
+
 /// Endpoint type (without encryption config)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EndpointType {
@@ -164,15 +196,13 @@ pub enum EndpointType {
     Quic {
         /// Socket address to bind (server) or connect (client)
         addr: SocketAddr,
-        /// Server hostname for TLS certificate validation
+        /// Server hostname — used as the WebPKI validation name (`WebPki`) and
+        /// the TLS SNI. Ignored by `Pinned` (which dials by IP and matches the
+        /// cert hash).
         server_name: String,
-        /// SHA-256 fingerprint of the server's self-signed certificate, for
-        /// client-side cert pinning (`with_server_certificate_hashes`). `None`
-        /// for the server/bind side or when peer authentication is provided
-        /// some other way (e.g. an expected response-signing key). Carrying the
-        /// 32-byte hash (not the full cert) keeps `TransportConfig` compact and
-        /// wire-publishable. Public fingerprint — not secret.
-        cert_pin: Option<[u8; 32]>,
+        /// How the client authenticates this server (WebPKI, cert-hash pin, or
+        /// — later — RFC 7250 raw key). Public material only.
+        auth: QuicServerAuth,
     },
 
     /// iroh transport endpoint (RPC over `ALPN_HYPRSTREAM_RPC`).
@@ -248,7 +278,7 @@ impl TransportConfig {
             endpoint: EndpointType::Quic {
                 addr,
                 server_name: server_name.into(),
-                cert_pin: None,
+                auth: QuicServerAuth::WebPki,
             },
             curve: None, // QUIC has TLS 1.3 built-in, no CurveZMQ needed
             bind_mode: BindMode::Bind,
@@ -256,14 +286,14 @@ impl TransportConfig {
     }
 
     /// Create a client QUIC endpoint that pins the server's self-signed cert by
-    /// its SHA-256 fingerprint (`cert_pin`). This is the dial target the
-    /// resolver/`dial()` produce for a networked RPC peer.
-    pub fn quic_pinned(addr: SocketAddr, server_name: impl Into<String>, cert_pin: [u8; 32]) -> Self {
+    /// its SHA-256 fingerprint. This is the dial target the resolver/`dial()`
+    /// produce for an internal-mesh RPC peer (dialed by IP).
+    pub fn quic_pinned(addr: SocketAddr, server_name: impl Into<String>, cert_hash: [u8; 32]) -> Self {
         Self {
             endpoint: EndpointType::Quic {
                 addr,
                 server_name: server_name.into(),
-                cert_pin: Some(cert_pin),
+                auth: QuicServerAuth::Pinned(cert_hash),
             },
             curve: None,
             bind_mode: BindMode::Connect,

--- a/crates/hyprstream-rpc/src/transport/quinn_transport.rs
+++ b/crates/hyprstream-rpc/src/transport/quinn_transport.rs
@@ -286,13 +286,31 @@ impl Transport for QuinnTransport {
     }
 }
 
+/// Build a quinn WebTransport client session against a server with a CA-issued
+/// certificate, validated via the system root store and the DNS `server_name`
+/// (`QuicServerAuth::WebPki`). Dials `https://{server_name}:{port}/`.
+pub async fn connect_webpki(
+    server_name: &str,
+    port: u16,
+) -> Result<web_transport_quinn::Session> {
+    let client = web_transport_quinn::ClientBuilder::new()
+        .with_system_roots()
+        .map_err(|e| anyhow!("quinn client (system roots): {e}"))?;
+    let url = url::Url::parse(&format!("https://{server_name}:{port}/"))
+        .map_err(|e| anyhow!("quinn url: {e}"))?;
+    client
+        .connect(url)
+        .await
+        .map_err(|e| anyhow!("quinn connect (webpki): {e}"))
+}
+
 /// Build a quinn WebTransport client session against a self-signed server,
 /// pinning the server cert by its **SHA-256 fingerprint** (the 32-byte hash
-/// carried in `EndpointType::Quic { cert_pin }`). Hermetic: dials an IP-literal
-/// URL so no DNS lookup or network egress occurs.
+/// carried in `QuicServerAuth::Pinned`). Hermetic: dials an IP-literal URL so no
+/// DNS lookup or network egress occurs.
 ///
-/// This is the connect path the lazy dial transport uses — the resolver/DID doc
-/// publishes the compact hash, not the full cert.
+/// This is the connect path the lazy dial transport uses for internal-mesh
+/// peers — the resolver/DID doc publishes the compact hash, not the full cert.
 pub async fn connect_pinned_sha256(
     addr: std::net::SocketAddr,
     cert_sha256: [u8; 32],

--- a/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
+++ b/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
@@ -1264,8 +1264,9 @@ where
 {
     rep: QuicRep,
     service: S,
-    /// Server certificate DER bytes (for registration)
-    _cert_der: Vec<u8>,
+    /// Server leaf certificate DER bytes — used to pin the registered QUIC
+    /// endpoint (self-signed, so clients pin the SHA-256 rather than CA-validate).
+    cert_der: Vec<u8>,
     /// ZMQ context (for Spawnable trait)
     context: Arc<zmq::Context>,
     /// Service name
@@ -1285,7 +1286,7 @@ where
         Ok(Self {
             rep,
             service,
-            _cert_der: cert_der,
+            cert_der,
             context: Arc::new(zmq::Context::new()),
             name,
             addr,
@@ -1311,10 +1312,13 @@ where
     }
 
     fn registrations(&self) -> Vec<(crate::registry::SocketKind, crate::transport::TransportConfig)> {
-        // Register QUIC endpoint
+        // Register the QUIC endpoint *pinned* by the self-signed leaf cert's
+        // SHA-256 — a plain (WebPki) registration would make clients CA-validate
+        // a self-signed cert and fail.
+        let pin = cert_sha256(&self.cert_der);
         vec![(
             crate::registry::SocketKind::Rep,
-            crate::transport::TransportConfig::quic(self.addr, "hyprstream.local"),
+            crate::transport::TransportConfig::quic_pinned(self.addr, "hyprstream.local", pin),
         )]
     }
 
@@ -1856,6 +1860,17 @@ pub fn cert_hash(cert_der: &[u8]) -> String {
     use sha2::{Sha256, Digest};
     let hash = Sha256::digest(cert_der);
     base64::engine::general_purpose::STANDARD.encode(hash)
+}
+
+/// SHA-256 fingerprint of a certificate as raw bytes — the pin carried in
+/// `QuicServerAuth::Pinned` and matched by `connect_pinned_sha256`. A
+/// self-signed QUIC server registers `TransportConfig::quic_pinned(addr, name,
+/// cert_sha256(leaf_cert))` so clients can pin it.
+pub fn cert_sha256(cert_der: &[u8]) -> [u8; 32] {
+    use sha2::{Digest, Sha256};
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&Sha256::digest(cert_der));
+    out
 }
 
 /// Compute SHA-256 hash of certificate as hex string.


### PR DESCRIPTION
Refactors `LazyQuinnTransport`'s hardcoded SHA-256 cert pin into a server-auth *policy*, after design review found pin-only conflated "how the client authenticates the server" with the transport and mismatched the spike's CA-validated QuicTransport shape.

- `EndpointType::Quic.cert_pin: Option<[u8;32]>` → `auth: QuicServerAuth` (WebPki / Pinned / [later] RawPublicKey).
- WebPKI (CA + system roots, by hostname) and Pinned (self-signed hash, by IP) implemented; RFC 7250 raw-key deferred to #200.
- **Regression fix** (review): two prod sites registered self-signed QUIC servers as WebPki (would CA-fail) → now `quic_pinned` with the real hash. **Connect-timeout fix**: the lazy connect was unbounded → 10s `CONNECT_TIMEOUT` in both lazy transports.

Code+security reviewed. 📚 Stacked — base `ewindisch/moq-151c` (#199). Part of epic #131.
