### PR TITLE
#151(a): QUIC channel auth as a validated requirements struct + pin sets

### DIFF
--- a/crates/hyprstream-rpc/src/dial.rs
+++ b/crates/hyprstream-rpc/src/dial.rs
@@ -36,7 +36,7 @@ use crate::crypto::VerifyingKey;
 use crate::rpc_client::{RpcClient, RpcClientImpl};
 use crate::transport::in_memory::InMemoryTransport;
 use crate::transport::rpc_session::IrohRequestProcessor;
-use crate::transport::{EndpointType, QuicServerAuth, TransportConfig};
+use crate::transport::{EndpointType, TransportConfig};
 use crate::transport_traits::Signer;
 
 /// Process-local map of inproc endpoint name → co-located request processor.
@@ -132,19 +132,15 @@ where
             Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
                 as Arc<dyn RpcClient>)
         }
-        EndpointType::Quic { auth: QuicServerAuth::RawPublicKey(_), .. } => bail!(
-            "dial(): QUIC RFC 7250 raw-public-key auth is not yet implemented (#200) — \
-             use iroh for identity-bound transport, or QuicServerAuth::Pinned / WebPki"
-        ),
         EndpointType::Quic { addr, server_name, auth } => {
-            // SECURITY (#185): WebPki/Pinned authenticate the TLS *channel* (a CA
-            // chain, or a specific cert), not the peer's DID identity. Identity
-            // comes from the response signature, which is still verified against
-            // the envelope-embedded key when `server_verifying_key` is `None` —
+            // SECURITY (#185): QUIC channel auth (WebPKI / cert-hash pin) binds the
+            // *channel*, not the peer's DID identity. Identity is established at the
+            // application layer — the response signature is verified against the
+            // envelope-embedded key even when `server_verifying_key` is `None`,
             // just not *pinned* to an expected identity. For a networked peer,
             // prefer passing the resolver-known key; note (debug) when we can't.
             // (iroh's arm needs no such note — it is identity-bound at the
-            // transport.)
+            // transport, RFC 7250.)
             if server_verifying_key.is_none() {
                 tracing::debug!(
                     %addr,
@@ -197,6 +193,7 @@ where
 mod tests {
     use super::*;
     use crate::crypto::SigningKey;
+    use crate::transport::QuicServerAuth;
     use crate::signer::LocalSigner;
     use crate::transport::rpc_session::from_fn;
     use bytes::Bytes;
@@ -278,18 +275,25 @@ mod tests {
     }
 
     #[test]
-    fn dial_quic_raw_public_key_errors() {
-        // RFC 7250 raw-public-key auth is not yet implemented → fail fast.
+    fn dial_quic_web_pki_pinned_builds_client() {
+        // WebPKI + pin (defence in depth): builds a lazy client.
         let cfg = TransportConfig {
             endpoint: EndpointType::Quic {
                 addr: "127.0.0.1:9999".parse().unwrap(),
                 server_name: "localhost".to_owned(),
-                auth: QuicServerAuth::RawPublicKey([9u8; 32]),
+                auth: QuicServerAuth::web_pki_pinned(vec![[9u8; 32]]).unwrap(),
             },
             curve: None,
             bind_mode: crate::transport::BindMode::Connect,
         };
-        let err = dial(&cfg, test_signer(), None);
-        assert!(err.is_err(), "RFC 7250 QUIC auth must error until implemented");
+        let client = dial(&cfg, test_signer(), None);
+        assert!(client.is_ok(), "WebPKI+pin QUIC dial must build a client");
+    }
+
+    #[test]
+    fn quic_server_auth_rejects_no_requirement() {
+        assert!(QuicServerAuth::pinned(vec![]).is_err(), "empty pin set is no auth");
+        assert!(QuicServerAuth::web_pki_pinned(vec![]).is_err(), "empty pin set is no auth");
+        assert!(QuicServerAuth::web_pki().require_web_pki());
     }
 }

--- a/crates/hyprstream-rpc/src/transport/lazy_quinn.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_quinn.rs
@@ -32,7 +32,8 @@ use async_trait::async_trait;
 use tokio::sync::Mutex;
 
 use crate::transport::quinn_transport::{
-    connect_pinned_sha256, connect_webpki, QuinnPendingStream, QuinnPublishStub, QuinnTransport,
+    connect_pinned_hashes, connect_webpki, verify_peer_cert_pinned, QuinnPendingStream,
+    QuinnPublishStub, QuinnTransport,
 };
 use crate::transport::QuicServerAuth;
 use crate::transport_traits::Transport;
@@ -78,13 +79,22 @@ impl LazyQuinnTransport {
             return Ok(transport.clone());
         }
         let connect = async {
-            match &self.auth {
-                QuicServerAuth::WebPki => connect_webpki(&self.server_name, self.addr.port()).await,
-                QuicServerAuth::Pinned(hash) => connect_pinned_sha256(self.addr, *hash).await,
-                QuicServerAuth::RawPublicKey(_) => bail!(
-                    "RFC 7250 raw-public-key QUIC auth is not yet implemented (#200) — use iroh \
-                     for identity-bound transport, or QuicServerAuth::Pinned / WebPki"
-                ),
+            let hashes = self.auth.accept_cert_hashes();
+            match (self.auth.require_web_pki(), hashes.is_empty()) {
+                // WebPKI only.
+                (true, true) => connect_webpki(&self.server_name, self.addr.port()).await,
+                // Pin only (self-signed) — verified in-handshake by cert-hash.
+                (false, false) => connect_pinned_hashes(self.addr, hashes).await,
+                // WebPKI + pin: CA-validate in the handshake, then enforce the
+                // pin on the established session before any RPC flows.
+                (true, false) => {
+                    let session = connect_webpki(&self.server_name, self.addr.port()).await?;
+                    verify_peer_cert_pinned(&session, hashes)?;
+                    Ok(session)
+                }
+                // No auth at all — unreachable: QuicServerAuth's constructors
+                // reject the empty case.
+                (false, true) => bail!("QUIC endpoint has no server-auth requirement"),
             }
         };
         let session = tokio::time::timeout(CONNECT_TIMEOUT, connect)
@@ -202,7 +212,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn lazy_connects_on_first_send_and_caches() {
         let (addr, pin, shutdown) = spawn_echo_server();
-        let t = LazyQuinnTransport::new(addr, "localhost", QuicServerAuth::Pinned(pin));
+        let t = LazyQuinnTransport::new(addr, "localhost", QuicServerAuth::pinned(vec![pin]).unwrap());
 
         assert!(t.cached.lock().await.is_none(), "no connection before first send");
 
@@ -219,7 +229,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn wrong_cert_pin_does_not_connect() {
         let (addr, _pin, shutdown) = spawn_echo_server();
-        let t = LazyQuinnTransport::new(addr, "localhost", QuicServerAuth::Pinned([0u8; 32])); // wrong fingerprint
+        let t = LazyQuinnTransport::new(addr, "localhost", QuicServerAuth::pinned(vec![[0u8; 32]]).unwrap()); // wrong fingerprint
         // The TLS handshake must *promptly reject* a wrong pin: the send must
         // COMPLETE with an error well within the hang-guard. If the guard fires
         // (i.e. send hung), the test fails — so a hang can't masquerade as a pass.
@@ -239,7 +249,7 @@ mod tests {
         let t = LazyQuinnTransport::new(
             "127.0.0.1:1".parse().unwrap(),
             "localhost",
-            QuicServerAuth::Pinned([0u8; 32]),
+            QuicServerAuth::pinned(vec![[0u8; 32]]).unwrap(),
         );
         let res = tokio::time::timeout(Duration::from_secs(13), t.send(b"x".to_vec(), Some(2_000)))
             .await
@@ -253,7 +263,7 @@ mod tests {
         let t = LazyQuinnTransport::new(
             "127.0.0.1:1".parse().unwrap(),
             "localhost",
-            QuicServerAuth::Pinned([0u8; 32]),
+            QuicServerAuth::pinned(vec![[0u8; 32]]).unwrap(),
         );
         assert!(t.subscribe(b"topic").await.is_err());
         assert!(t.publish(b"topic").await.is_err());

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -129,36 +129,70 @@ pub struct TransportConfig {
     pub bind_mode: BindMode,
 }
 
-/// How a QUIC client authenticates the server it dials.
+/// How a QUIC client authenticates the **channel** to the server it dials.
 ///
-/// Server authentication is a *policy*, not a single mechanism — this replaces
-/// the earlier hardcoded SHA-256 cert pin. All variants carry only
-/// serializable, public material so `TransportConfig` stays `Clone + Eq` and
-/// wire-publishable.
+/// # This is channel auth, not identity auth
+///
+/// Peer *identity* ("which node is this") is established at the **application
+/// layer** — every response is a signed COSE `SignedEnvelope` verified against
+/// the peer's published keys (the DID-doc `#mesh` verification method / JWKS).
+/// That works identically on native and in WASM, because it is our code, not the
+/// browser's TLS stack. This type only decides how the *TLS channel* is
+/// authenticated (confidentiality + anti-active-MITM); it is defence in depth,
+/// not the trust root (#185).
+///
+/// Channel auth is a small lattice of independent requirements, not a fixed set
+/// of modes, so it is a validated struct rather than an enum of combinations:
+///   - `require_web_pki` — the leaf must chain to a system-trusted CA and match
+///     `server_name` (public peers, dialed by hostname).
+///   - `accept_cert_hashes` — a **set** of acceptable leaf-cert SHA-256s. A set
+///     (not one hash) so cert rotation can overlap (`{current, next}`) and
+///     load-balanced endpoints with distinct certs work. The resolver / DID doc
+///     supplies these — they are directory-distributed pins, not trust-on-first-
+///     use. (For browsers this is the *only* knob the WebTransport API exposes.)
+///
+/// The verifier ANDs the active requirements. At least one must be active —
+/// `{web_pki: false, hashes: []}` is no auth and is rejected at construction.
+///
+/// RFC 7250 raw-public-key binding (bind the channel to the published key
+/// directly, so native QUIC reuses the identity key instead of a cert hash) is
+/// tracked in #200; it is channel hygiene, not an identity requirement (identity
+/// is app-layer regardless). iroh already does it natively.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum QuicServerAuth {
-    /// Standard WebPKI / CA-chain validation against the system root store,
-    /// matching the server's DNS `server_name`. For public peers fronted by a
-    /// CA-issued certificate (dialed by hostname).
-    WebPki,
-    /// Pin the server's (self-signed) certificate by its SHA-256 fingerprint
-    /// (`with_server_certificate_hashes`) — the internal-mesh model, dialed by
-    /// IP. The resolver / DID doc vouches for the hash.
-    ///
-    /// SECURITY: authenticates the *channel* ("a server holding this cert"), not
-    /// the peer's DID *identity* (#185). For identity-bound transport use iroh
-    /// (which is RFC 7250 — the connection is bound to the peer's public key).
-    Pinned([u8; 32]),
-    /// RFC 7250 raw-public-key identity binding: the server proves possession of
-    /// this Ed25519 key during the TLS handshake.
-    ///
-    /// **Not yet implemented** — `web_transport_quinn`'s builder exposes no
-    /// raw-key/custom-verifier hook, so this needs a custom rustls verifier + a
-    /// raw `quinn` connect + `Session::raw`, plus a server-side raw-key config.
-    /// It is also browser-incompatible (WebTransport mandates cert hashes) and
-    /// overlaps iroh (which already provides RFC 7250). Tracked in #200; use
-    /// iroh for identity-bound native transport today.
-    RawPublicKey([u8; 32]),
+pub struct QuicServerAuth {
+    require_web_pki: bool,
+    accept_cert_hashes: Vec<[u8; 32]>,
+}
+
+impl QuicServerAuth {
+    /// WebPKI / CA-chain validation only (public, CA-fronted peer).
+    pub fn web_pki() -> Self {
+        Self { require_web_pki: true, accept_cert_hashes: Vec::new() }
+    }
+
+    /// Pin the leaf cert to one of `hashes` (SHA-256), no CA requirement — the
+    /// self-signed internal-mesh model. Errors if `hashes` is empty.
+    pub fn pinned(hashes: Vec<[u8; 32]>) -> anyhow::Result<Self> {
+        anyhow::ensure!(!hashes.is_empty(), "QuicServerAuth::pinned requires >= 1 cert hash");
+        Ok(Self { require_web_pki: false, accept_cert_hashes: hashes })
+    }
+
+    /// WebPKI validation **and** the leaf must be one of `hashes` — defence in
+    /// depth against CA mis-issuance (HPKP-style). Errors if `hashes` is empty.
+    pub fn web_pki_pinned(hashes: Vec<[u8; 32]>) -> anyhow::Result<Self> {
+        anyhow::ensure!(!hashes.is_empty(), "QuicServerAuth::web_pki_pinned requires >= 1 cert hash");
+        Ok(Self { require_web_pki: true, accept_cert_hashes: hashes })
+    }
+
+    /// Whether CA-chain validation is required.
+    pub fn require_web_pki(&self) -> bool {
+        self.require_web_pki
+    }
+
+    /// The set of accepted leaf-cert SHA-256 pins (empty => no pin requirement).
+    pub fn accept_cert_hashes(&self) -> &[[u8; 32]] {
+        &self.accept_cert_hashes
+    }
 }
 
 /// Endpoint type (without encryption config)
@@ -278,7 +312,7 @@ impl TransportConfig {
             endpoint: EndpointType::Quic {
                 addr,
                 server_name: server_name.into(),
-                auth: QuicServerAuth::WebPki,
+                auth: QuicServerAuth::web_pki(),
             },
             curve: None, // QUIC has TLS 1.3 built-in, no CurveZMQ needed
             bind_mode: BindMode::Bind,
@@ -293,7 +327,8 @@ impl TransportConfig {
             endpoint: EndpointType::Quic {
                 addr,
                 server_name: server_name.into(),
-                auth: QuicServerAuth::Pinned(cert_hash),
+                // In-module: construct directly (a one-element set is always valid).
+                auth: QuicServerAuth { require_web_pki: false, accept_cert_hashes: vec![cert_hash] },
             },
             curve: None,
             bind_mode: BindMode::Connect,

--- a/crates/hyprstream-rpc/src/transport/quinn_transport.rs
+++ b/crates/hyprstream-rpc/src/transport/quinn_transport.rs
@@ -19,7 +19,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{Result, anyhow};
+use anyhow::{Result, anyhow, bail};
 use async_trait::async_trait;
 use ed25519_dalek::SigningKey;
 use tokio::sync::Semaphore;
@@ -288,7 +288,7 @@ impl Transport for QuinnTransport {
 
 /// Build a quinn WebTransport client session against a server with a CA-issued
 /// certificate, validated via the system root store and the DNS `server_name`
-/// (`QuicServerAuth::WebPki`). Dials `https://{server_name}:{port}/`.
+/// (`QuicServerAuth::web_pki`). Dials `https://{server_name}:{port}/`.
 pub async fn connect_webpki(
     server_name: &str,
     port: u16,
@@ -305,18 +305,17 @@ pub async fn connect_webpki(
 }
 
 /// Build a quinn WebTransport client session against a self-signed server,
-/// pinning the server cert by its **SHA-256 fingerprint** (the 32-byte hash
-/// carried in `QuicServerAuth::Pinned`). Hermetic: dials an IP-literal URL so no
-/// DNS lookup or network egress occurs.
-///
-/// This is the connect path the lazy dial transport uses for internal-mesh
-/// peers — the resolver/DID doc publishes the compact hash, not the full cert.
-pub async fn connect_pinned_sha256(
+/// accepting the leaf cert if its **SHA-256 fingerprint** is any of
+/// `cert_hashes` (`QuicServerAuth::accept_cert_hashes` — a set so rotation can
+/// overlap). Hermetic: dials an IP-literal URL so no DNS lookup or network
+/// egress occurs.
+pub async fn connect_pinned_hashes(
     addr: std::net::SocketAddr,
-    cert_sha256: [u8; 32],
+    cert_hashes: &[[u8; 32]],
 ) -> Result<web_transport_quinn::Session> {
+    let hashes: Vec<Vec<u8>> = cert_hashes.iter().map(|h| h.to_vec()).collect();
     let client = web_transport_quinn::ClientBuilder::new()
-        .with_server_certificate_hashes(vec![cert_sha256.to_vec()])
+        .with_server_certificate_hashes(hashes)
         .map_err(|e| anyhow!("quinn client build: {e}"))?;
     let url = url::Url::parse(&format!("https://{addr}/"))
         .map_err(|e| anyhow!("quinn url: {e}"))?;
@@ -324,6 +323,33 @@ pub async fn connect_pinned_sha256(
         .connect(url)
         .await
         .map_err(|e| anyhow!("quinn connect: {e}"))
+}
+
+/// Verify the peer's leaf-cert SHA-256 is one of `accept` — the post-connect pin
+/// check for the WebPKI+pin mode (CA validation runs in the handshake; this adds
+/// the pin on top). Call immediately after connect, before any RPC. The cert
+/// fingerprint is public, so a plain comparison is fine (no secret to leak).
+pub fn verify_peer_cert_pinned(
+    session: &web_transport_quinn::Session,
+    accept: &[[u8; 32]],
+) -> Result<()> {
+    // `Session` derefs to `quinn::Connection`, exposing `peer_identity()`.
+    let identity = session
+        .peer_identity()
+        .ok_or_else(|| anyhow!("peer presented no certificate"))?;
+    let certs = identity
+        .downcast_ref::<Vec<rustls::pki_types::CertificateDer<'static>>>()
+        .ok_or_else(|| anyhow!("unexpected peer-identity type (not an X.509 chain)"))?;
+    let leaf = certs
+        .first()
+        .ok_or_else(|| anyhow!("peer cert chain is empty"))?;
+    let mut leaf_hash = [0u8; 32];
+    leaf_hash.copy_from_slice(&sha256(leaf.as_ref()));
+    if accept.contains(&leaf_hash) {
+        Ok(())
+    } else {
+        bail!("peer leaf-cert SHA-256 is not in the configured pin set")
+    }
 }
 
 /// Convenience: pin by the full server cert DER (hashes it for you). Used by
@@ -334,7 +360,7 @@ pub async fn connect_pinned(
 ) -> Result<web_transport_quinn::Session> {
     let mut hash = [0u8; 32];
     hash.copy_from_slice(&sha256(cert_der));
-    connect_pinned_sha256(addr, hash).await
+    connect_pinned_hashes(addr, &[hash]).await
 }
 
 fn sha256(bytes: &[u8]) -> Vec<u8> {
@@ -399,6 +425,32 @@ mod tests {
 
         let resp = client.send(b"ping".to_vec(), Some(5_000)).await?;
         assert_eq!(&resp[..], b"\xCDping");
+
+        shutdown.cancel();
+        let _ = server_task.await;
+        Ok(())
+    }
+
+    /// Isolated test of the WebPKI+pin post-connect check: against the hermetic
+    /// self-signed server, the leaf hash must match the pin set (right => Ok,
+    /// wrong => Err, empty set => Err = fail-closed).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn verify_peer_cert_pinned_accepts_right_rejects_wrong() -> Result<()> {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let processor =
+            crate::transport::rpc_session::from_fn(|req: Bytes| async move { Ok(req) });
+        let (server, addr, cert_der) = build_server()?;
+        let rpc_server = QuinnRpcServer::new(server, processor, fresh_signing_key());
+        let shutdown = rpc_server.shutdown_token();
+        let server_task = tokio::spawn(rpc_server.run());
+
+        let session = connect_pinned(addr, &cert_der).await?;
+        let mut right = [0u8; 32];
+        right.copy_from_slice(&sha256(&cert_der));
+
+        assert!(verify_peer_cert_pinned(&session, &[right]).is_ok(), "matching leaf hash must pass");
+        assert!(verify_peer_cert_pinned(&session, &[[0u8; 32]]).is_err(), "wrong hash must reject");
+        assert!(verify_peer_cert_pinned(&session, &[]).is_err(), "empty pin set must reject (fail-closed)");
 
         shutdown.cancel();
         let _ = server_task.await;

--- a/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
+++ b/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
@@ -1863,7 +1863,7 @@ pub fn cert_hash(cert_der: &[u8]) -> String {
 }
 
 /// SHA-256 fingerprint of a certificate as raw bytes — the pin carried in
-/// `QuicServerAuth::Pinned` and matched by `connect_pinned_sha256`. A
+/// `QuicServerAuth::accept_cert_hashes` and matched by `connect_pinned_hashes`. A
 /// self-signed QUIC server registers `TransportConfig::quic_pinned(addr, name,
 /// cert_sha256(leaf_cert))` so clients can pin it.
 pub fn cert_sha256(cert_der: &[u8]) -> [u8; 32] {


### PR DESCRIPTION
Per design discussion, replaces the `QuicServerAuth` enum with a validated requirements struct and makes pinning a **set**.

- `QuicServerAuth { require_web_pki: bool, accept_cert_hashes: Vec<[u8;32]> }` + smart ctors `web_pki()`/`pinned(set)`/`web_pki_pinned(set)` that reject the no-auth case. Verifier ANDs requirements — composable (WebPKI+pin = defence in depth vs CA mis-issuance) without a combinatorial enum.
- Pin is a **set** (rotation overlap / multi-cert). WebPKI+pin implemented (CA-validate in handshake, then `verify_peer_cert_pinned` checks the leaf hash via `Session`→`quinn::Connection::peer_identity()`, before any RPC).
- Documents the layer split: **identity is app-layer** (signed envelopes vs `#mesh`/JWKS, works in WASM); this struct is channel auth only (defence in depth, #185), so #200 is channel hygiene not identity.

Code+security reviewed (APPROVE; verified fail-closed vs quinn-proto source). 📚 Stacked — base `ewindisch/moq-151d`. Part of epic #131.
