### PR TITLE
#136: RPC production cutover (M1 exit)

### DIFF
--- a/crates/hyprstream-rpc-derive/src/codegen/client.rs
+++ b/crates/hyprstream-rpc-derive/src/codegen/client.rs
@@ -496,39 +496,41 @@ pub fn generate_constructors(service_name: &str) -> TokenStream {
                 signing_key: hyprstream_rpc::crypto::SigningKey,
                 destination: hyprstream_rpc::crypto::VerifyingKey,
                 token: Option<String>,
-            ) -> Self {
-                let endpoint = hyprstream_rpc::registry::try_global()
+            ) -> anyhow::Result<Self> {
+                let transport = hyprstream_rpc::registry::try_global()
                     .map(|r| r.endpoint(#service_name_lit, hyprstream_rpc::registry::SocketKind::Rep))
                     .unwrap_or_else(|| hyprstream_rpc::transport::TransportConfig::inproc(
                         concat!("hyprstream/", #service_name_lit)
-                    ))
-                    .to_zmq_string();
-                Self::for_endpoint(&endpoint, signing_key, destination, token)
+                    ));
+                Self::dial_transport(&transport, signing_key, destination, token)
             }
 
-            /// Create a new client connected to a specific endpoint.
-            ///
-            /// `destination` is the target service's Ed25519 verifying key,
-            /// used to verify response signatures.
+            /// Create a new client connected to a specific endpoint string
+            /// (`inproc://…` / `ipc://…`). Parsed to a `TransportConfig` and routed
+            /// through [`hyprstream_rpc::dial::dial`] — the one place transport
+            /// selection happens. For networked (quic/iroh) targets, prefer
+            /// [`Self::from_resolver`], which carries the full auth config.
             pub fn for_endpoint(
                 endpoint: &str,
                 signing_key: hyprstream_rpc::crypto::SigningKey,
                 destination: hyprstream_rpc::crypto::VerifyingKey,
                 token: Option<String>,
-            ) -> Self {
+            ) -> anyhow::Result<Self> {
+                let transport = hyprstream_rpc::transport::TransportConfig::from_endpoint(endpoint);
+                Self::dial_transport(&transport, signing_key, destination, token)
+            }
+
+            /// Build a client for an already-resolved `TransportConfig` (the one
+            /// place the generated client meets `dial()`).
+            fn dial_transport(
+                transport: &hyprstream_rpc::transport::TransportConfig,
+                signing_key: hyprstream_rpc::crypto::SigningKey,
+                destination: hyprstream_rpc::crypto::VerifyingKey,
+                token: Option<String>,
+            ) -> anyhow::Result<Self> {
                 let signer = hyprstream_rpc::signer::LocalSigner::new(signing_key);
-                let transport = hyprstream_rpc::zmq_connection::ZmqConnection::new(
-                    endpoint,
-                    hyprstream_rpc::zmq_context::global_context(),
-                );
-                let rpc = hyprstream_rpc::rpc_client::RpcClientImpl::new(
-                    signer, transport, Some(destination),
-                );
-                let rpc = match token {
-                    Some(t) => rpc.with_default_jwt(t),
-                    None => rpc,
-                };
-                Self::new(std::sync::Arc::new(rpc) as std::sync::Arc<dyn hyprstream_rpc::RpcClient>)
+                let rpc = hyprstream_rpc::dial::dial(transport, signer, Some(destination), token)?;
+                Ok(Self::new(rpc))
             }
 
             /// Create a new client by resolving the service endpoint via a `Resolver`.
@@ -538,29 +540,35 @@ pub fn generate_constructors(service_name: &str) -> TokenStream {
                 destination: hyprstream_rpc::crypto::VerifyingKey,
                 token: Option<String>,
             ) -> anyhow::Result<Self> {
-                let endpoint = resolver
+                let transport = resolver
                     .resolve(Self::SERVICE_NAME, hyprstream_rpc::registry::SocketKind::Rep)
-                    .await?
-                    .to_zmq_string();
-                Ok(Self::for_endpoint(&endpoint, signing_key, destination, token))
+                    .await?;
+                Self::dial_transport(&transport, signing_key, destination, token)
             }
 
             /// Create a client from an `IdentityProvider` with automatic endpoint resolution.
             pub async fn from_provider(
                 provider: &dyn hyprstream_rpc::identity::IdentityProvider,
             ) -> anyhow::Result<Self> {
-                let endpoint = hyprstream_rpc::registry::try_global()
+                let transport = hyprstream_rpc::registry::try_global()
                     .map(|r| r.endpoint(#service_name_lit, hyprstream_rpc::registry::SocketKind::Rep))
                     .unwrap_or_else(|| hyprstream_rpc::transport::TransportConfig::inproc(
                         concat!("hyprstream/", #service_name_lit)
-                    ))
-                    .to_zmq_string();
-                Self::from_provider_at(&endpoint, provider).await
+                    ));
+                Self::from_provider_at_transport(&transport, provider).await
             }
 
-            /// Create a client from an `IdentityProvider` at a specific endpoint.
+            /// Create a client from an `IdentityProvider` at a specific endpoint string.
             pub async fn from_provider_at(
                 endpoint: &str,
+                provider: &dyn hyprstream_rpc::identity::IdentityProvider,
+            ) -> anyhow::Result<Self> {
+                let transport = hyprstream_rpc::transport::TransportConfig::from_endpoint(endpoint);
+                Self::from_provider_at_transport(&transport, provider).await
+            }
+
+            async fn from_provider_at_transport(
+                transport: &hyprstream_rpc::transport::TransportConfig,
                 provider: &dyn hyprstream_rpc::identity::IdentityProvider,
             ) -> anyhow::Result<Self> {
                 let handle = provider.identity_open(concat!("hyprstream-", #service_name_lit, "-v1")).await?;
@@ -568,14 +576,8 @@ pub fn generate_constructors(service_name: &str) -> TokenStream {
                 let server_vk = hyprstream_rpc::crypto::VerifyingKey::from_bytes(&pubkey)
                     .map_err(|e| anyhow::anyhow!("invalid derived pubkey: {}", e))?;
                 let signer = hyprstream_rpc::signer::IdentitySigner::new(handle);
-                let transport = hyprstream_rpc::zmq_connection::ZmqConnection::new(
-                    endpoint,
-                    hyprstream_rpc::zmq_context::global_context(),
-                );
-                let rpc = hyprstream_rpc::rpc_client::RpcClientImpl::new(
-                    signer, transport, Some(server_vk),
-                );
-                Ok(Self::new(std::sync::Arc::new(rpc) as std::sync::Arc<dyn hyprstream_rpc::RpcClient>))
+                let rpc = hyprstream_rpc::dial::dial(transport, signer, Some(server_vk), None)?;
+                Ok(Self::new(rpc))
             }
         }
     }

--- a/crates/hyprstream-rpc/src/dial.rs
+++ b/crates/hyprstream-rpc/src/dial.rs
@@ -180,11 +180,23 @@ where
             Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
                 as Arc<dyn RpcClient>)
         }
-        endpoint @ (EndpointType::Ipc { .. } | EndpointType::SystemdFd { .. }) => bail!(
-            "dial(): endpoint {endpoint:?} is not served by the dial factory — \
-             ZMQ ipc/systemd endpoints stay on the codegen path during the transition; \
-             iroh/moq lazy transports land in a later #151(a) increment"
-        ),
+        // Same-host `ipc` plane: connect a UdsSession (RPC plane) at the socket
+        // path. systemd socket-activation is the same client-side dial — the fd
+        // is the *server's* pre-bound listener; clients connect by `client_path`.
+        // UDS has no transport-level peer identity; the app-layer SignedEnvelope
+        // is the authentication (a `None` server_verifying_key leaves the
+        // response identity unpinned but still signature-verified). Socket perms
+        // + SO_PEERCRED are daemon-owned defense-in-depth (#207).
+        EndpointType::Ipc { path } => {
+            let transport = crate::transport::lazy_uds::LazyUdsTransport::new(path.clone());
+            Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
+                as Arc<dyn RpcClient>)
+        }
+        EndpointType::SystemdFd { client_path, .. } => {
+            let transport = crate::transport::lazy_uds::LazyUdsTransport::new(client_path.clone());
+            Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
+                as Arc<dyn RpcClient>)
+        }
     }
 }
 
@@ -251,10 +263,20 @@ mod tests {
     }
 
     #[test]
-    fn dial_unsupported_endpoint_errors() {
-        let cfg = TransportConfig::ipc("/tmp/hyprstream-test.sock");
-        let err = dial(&cfg, test_signer(), None);
-        assert!(err.is_err(), "ipc dial is not yet served by the factory");
+    fn dial_ipc_builds_lazy_client() {
+        // ipc dial builds a lazy UdsSession client — sync, no I/O, connects on
+        // first send (the socket need not exist yet at dial() time).
+        let cfg = TransportConfig::ipc("/tmp/hyprstream-test-dial.sock");
+        let client = dial(&cfg, test_signer(), None);
+        assert!(client.is_ok(), "ipc dial must build a lazy client without connecting");
+    }
+
+    #[test]
+    fn dial_systemd_fd_builds_lazy_client() {
+        // systemd socket-activation: client dials the client_path via UDS.
+        let cfg = TransportConfig::systemd_fd(7, "/tmp/hyprstream-test-systemd.sock");
+        let client = dial(&cfg, test_signer(), None);
+        assert!(client.is_ok(), "systemd-fd dial must build a lazy client via client_path");
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/dial.rs
+++ b/crates/hyprstream-rpc/src/dial.rs
@@ -116,10 +116,31 @@ pub fn dial<S>(
     target: &TransportConfig,
     signer: S,
     server_verifying_key: Option<VerifyingKey>,
+    token: Option<String>,
 ) -> Result<Arc<dyn RpcClient>>
 where
     S: Signer + 'static,
 {
+    /// Wrap a built transport as an `RpcClient`, applying the optional default
+    /// JWT (CA-signed trust cert included in request envelopes) if present.
+    fn build_client<S2, T2>(
+        signer: S2,
+        transport: T2,
+        vk: Option<VerifyingKey>,
+        token: Option<String>,
+    ) -> Arc<dyn RpcClient>
+    where
+        S2: Signer + 'static,
+        T2: crate::transport_traits::Transport + 'static,
+    {
+        let rpc = RpcClientImpl::new(signer, transport, vk);
+        let rpc = match token {
+            Some(t) => rpc.with_default_jwt(t),
+            None => rpc,
+        };
+        Arc::new(rpc) as Arc<dyn RpcClient>
+    }
+
     // Matched exhaustively on purpose: this is the one place transport choice is
     // made, so a newly-added EndpointType variant MUST be a compile error here
     // rather than silently falling through to a runtime bail.
@@ -129,8 +150,7 @@ where
                 anyhow!("no in-process service registered for inproc endpoint '{endpoint}'")
             })?;
             let transport = InMemoryTransport::new(processor);
-            Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
-                as Arc<dyn RpcClient>)
+            Ok(build_client(signer, transport, server_verifying_key, token))
         }
         EndpointType::Quic { addr, server_name, auth } => {
             // SECURITY (#185): QUIC channel auth (WebPKI / cert-hash pin) binds the
@@ -153,8 +173,7 @@ where
                 server_name.clone(),
                 auth.clone(),
             );
-            Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
-                as Arc<dyn RpcClient>)
+            Ok(build_client(signer, transport, server_verifying_key, token))
         }
         EndpointType::Iroh { direct_addrs, relay_url, .. }
             if direct_addrs.is_empty() && relay_url.is_none() =>
@@ -177,8 +196,7 @@ where
                 direct_addrs.clone(),
                 relay_url.clone(),
             );
-            Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
-                as Arc<dyn RpcClient>)
+            Ok(build_client(signer, transport, server_verifying_key, token))
         }
         // Same-host `ipc` plane: connect a UdsSession (RPC plane) at the socket
         // path. systemd socket-activation is the same client-side dial — the fd
@@ -189,13 +207,11 @@ where
         // + SO_PEERCRED are daemon-owned defense-in-depth (#207).
         EndpointType::Ipc { path } => {
             let transport = crate::transport::lazy_uds::LazyUdsTransport::new(path.clone());
-            Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
-                as Arc<dyn RpcClient>)
+            Ok(build_client(signer, transport, server_verifying_key, token))
         }
         EndpointType::SystemdFd { client_path, .. } => {
             let transport = crate::transport::lazy_uds::LazyUdsTransport::new(client_path.clone());
-            Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
-                as Arc<dyn RpcClient>)
+            Ok(build_client(signer, transport, server_verifying_key, token))
         }
     }
 }
@@ -249,7 +265,7 @@ mod tests {
         register_inproc(name, &proc);
 
         let cfg = TransportConfig::inproc(name);
-        let client = dial(&cfg, test_signer(), None);
+        let client = dial(&cfg, test_signer(), None, None);
         assert!(client.is_ok(), "dialing a registered inproc endpoint must succeed");
 
         unregister_inproc(name);
@@ -258,7 +274,7 @@ mod tests {
     #[test]
     fn dial_inproc_unregistered_errors() {
         let cfg = TransportConfig::inproc("test/dial/never_registered");
-        let err = dial(&cfg, test_signer(), None);
+        let err = dial(&cfg, test_signer(), None, None);
         assert!(err.is_err(), "dialing an unregistered inproc endpoint must error");
     }
 
@@ -267,7 +283,7 @@ mod tests {
         // ipc dial builds a lazy UdsSession client — sync, no I/O, connects on
         // first send (the socket need not exist yet at dial() time).
         let cfg = TransportConfig::ipc("/tmp/hyprstream-test-dial.sock");
-        let client = dial(&cfg, test_signer(), None);
+        let client = dial(&cfg, test_signer(), None, None);
         assert!(client.is_ok(), "ipc dial must build a lazy client without connecting");
     }
 
@@ -275,7 +291,7 @@ mod tests {
     fn dial_systemd_fd_builds_lazy_client() {
         // systemd socket-activation: client dials the client_path via UDS.
         let cfg = TransportConfig::systemd_fd(7, "/tmp/hyprstream-test-systemd.sock");
-        let client = dial(&cfg, test_signer(), None);
+        let client = dial(&cfg, test_signer(), None, None);
         assert!(client.is_ok(), "systemd-fd dial must build a lazy client via client_path");
     }
 
@@ -284,7 +300,7 @@ mod tests {
         // Plain `quic()` = WebPKI/CA validation — a valid auth policy, so dial()
         // builds a (lazy, not-yet-connected) client.
         let cfg = TransportConfig::quic("127.0.0.1:9999".parse().unwrap(), "localhost");
-        let client = dial(&cfg, test_signer(), None);
+        let client = dial(&cfg, test_signer(), None, None);
         assert!(client.is_ok(), "WebPKI QUIC dial must build a client without connecting");
     }
 
@@ -292,7 +308,7 @@ mod tests {
     fn dial_quic_pinned_builds_client() {
         // Cert-hash-pinned QUIC: builds a lazy client — sync, no I/O.
         let cfg = TransportConfig::quic_pinned("127.0.0.1:9999".parse().unwrap(), "localhost", [7u8; 32]);
-        let client = dial(&cfg, test_signer(), None);
+        let client = dial(&cfg, test_signer(), None, None);
         assert!(client.is_ok(), "pinned QUIC dial must build a client without connecting");
     }
 
@@ -308,7 +324,7 @@ mod tests {
             curve: None,
             bind_mode: crate::transport::BindMode::Connect,
         };
-        let client = dial(&cfg, test_signer(), None);
+        let client = dial(&cfg, test_signer(), None, None);
         assert!(client.is_ok(), "WebPKI+pin QUIC dial must build a client");
     }
 

--- a/crates/hyprstream-rpc/src/service/mod.rs
+++ b/crates/hyprstream-rpc/src/service/mod.rs
@@ -13,6 +13,7 @@ mod traits;
 mod zmq;
 pub mod dispatch;
 pub mod streaming;
+pub mod serve;
 pub mod spawnable;
 pub mod metadata;
 pub mod doc;

--- a/crates/hyprstream-rpc/src/service/serve.rs
+++ b/crates/hyprstream-rpc/src/service/serve.rs
@@ -1,0 +1,110 @@
+//! Bridged serve helper for the post-ZMQ spawn path (#136).
+//!
+//! The RPC cutover replaces every `RequestLoop::new(..).run(service)` (ZMQ
+//! ROUTER) with this: bridge the service to a `Send` processor
+//! ([`LocalServiceBridge`](crate::transport::iroh_rpc::LocalServiceBridge)), then
+//! serve it over its *registered* transport via the same `process_request`
+//! dispatch core the quinn/iroh planes use.
+//!
+//! Spawn-path transports (from `EndpointRegistry::endpoint(name, Rep)`):
+//! - `Inproc{endpoint}` (default daemon mode) → register the processor in the
+//!   in-memory dial registry ([`register_inproc`](crate::dial::register_inproc));
+//!   **no socket**. The registry holds only a `Weak`, so the strong `processor`
+//!   `Arc` is retained here for the service's lifetime.
+//! - `Ipc{path}` (`--ipc`) → bind a `UnixListener` at `path`, run
+//!   [`UdsRpcServer`].
+//! - `SystemdFd{fd,..}` → adopt the systemd-passed listener fd, run [`UdsRpcServer`].
+//! - `Quic`/`Iroh` are *dialed*, never bound on the spawn path → error.
+
+use std::sync::Arc;
+
+use anyhow::{anyhow, bail, Result};
+use ed25519_dalek::SigningKey;
+use tokio::sync::Notify;
+
+use crate::transport::rpc_session::{IrohRequestProcessor, DEFAULT_STREAM_LIMIT};
+use crate::transport::uds_server::UdsRpcServer;
+use crate::transport::{EndpointType, TransportConfig};
+
+/// Signal startup readiness: fire the `on_ready` oneshot (spawner waits on it)
+/// and notify systemd (`Type=notify`).
+fn signal_ready(on_ready: Option<tokio::sync::oneshot::Sender<()>>) {
+    if let Some(tx) = on_ready {
+        let _ = tx.send(());
+    }
+    let _ = crate::notify::ready();
+}
+
+/// Serve a bridged request `processor` over its registered `transport` until
+/// `shutdown` fires. See the module docs for the per-transport behaviour.
+///
+/// `processor` MUST be the bridge wrapping the spawn-path service (built via
+/// [`LocalServiceBridge::spawn`](crate::transport::iroh_rpc::LocalServiceBridge::spawn)
+/// or `spawn_with`). This fn holds it for the serve lifetime.
+pub async fn serve_bridged(
+    transport: &TransportConfig,
+    processor: Arc<dyn IrohRequestProcessor>,
+    signing_key: SigningKey,
+    shutdown: Arc<Notify>,
+    on_ready: Option<tokio::sync::oneshot::Sender<()>>,
+) -> Result<()> {
+    match &transport.endpoint {
+        EndpointType::Inproc { endpoint } => {
+            crate::dial::register_inproc(endpoint.clone(), &processor);
+            signal_ready(on_ready);
+            shutdown.notified().await;
+            crate::dial::unregister_inproc(endpoint);
+            // Drop the strong Arc → bridge thread exits its receive loop.
+            drop(processor);
+            Ok(())
+        }
+        EndpointType::Ipc { path } => {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)
+                    .map_err(|e| anyhow!("create uds dir {}: {e}", parent.display()))?;
+            }
+            // Clear a stale socket left by a prior unclean shutdown.
+            let _ = std::fs::remove_file(path);
+            let listener = tokio::net::UnixListener::bind(path)
+                .map_err(|e| anyhow!("bind uds {}: {e}", path.display()))?;
+            signal_ready(on_ready);
+            run_uds(listener, processor, signing_key, shutdown).await
+        }
+        EndpointType::SystemdFd { fd, .. } => {
+            use std::os::unix::io::FromRawFd;
+            // The fd is the systemd-passed, already-bound server listener.
+            let std_listener = unsafe { std::os::unix::net::UnixListener::from_raw_fd(*fd) };
+            std_listener
+                .set_nonblocking(true)
+                .map_err(|e| anyhow!("systemd fd set_nonblocking: {e}"))?;
+            let listener = tokio::net::UnixListener::from_std(std_listener)
+                .map_err(|e| anyhow!("adopt systemd uds fd: {e}"))?;
+            signal_ready(on_ready);
+            run_uds(listener, processor, signing_key, shutdown).await
+        }
+        other => bail!(
+            "serve_bridged: {other:?} is not a spawn-path RPC endpoint \
+             (Quic/Iroh are dialed via dial(), not bound here)"
+        ),
+    }
+}
+
+/// Run a [`UdsRpcServer`] until it ends or `shutdown` fires (graceful drain).
+async fn run_uds(
+    listener: tokio::net::UnixListener,
+    processor: Arc<dyn IrohRequestProcessor>,
+    signing_key: SigningKey,
+    shutdown: Arc<Notify>,
+) -> Result<()> {
+    let server = UdsRpcServer::with_capacity(listener, processor, signing_key, DEFAULT_STREAM_LIMIT);
+    let token = server.shutdown_token();
+    let limit = server.stream_limit();
+    let cap = server.capacity();
+    tokio::select! {
+        r = server.run() => r,
+        _ = shutdown.notified() => {
+            UdsRpcServer::shutdown(&limit, cap, &token).await;
+            Ok(())
+        }
+    }
+}

--- a/crates/hyprstream-rpc/src/service/spawnable.rs
+++ b/crates/hyprstream-rpc/src/service/spawnable.rs
@@ -9,7 +9,7 @@ use tokio::sync::Notify;
 
 use crate::error::{Result, RpcError};
 use crate::registry::SocketKind;
-use crate::service::{RequestLoop, RequestService};
+use crate::service::RequestService;
 use crate::transport::TransportConfig;
 
 /// Trait for services that can be spawned by ServiceSpawner.
@@ -76,7 +76,6 @@ impl<S: RequestService + Send + Sync> Spawnable for S {
         on_ready: Option<tokio::sync::oneshot::Sender<()>>,
     ) -> Result<()> {
         let transport = RequestService::transport(&*self).clone();
-        let context = Arc::clone(RequestService::context(&*self));
         let signing_key = RequestService::signing_key(&*self);
 
         let rt = tokio::runtime::Builder::new_multi_thread()
@@ -84,22 +83,18 @@ impl<S: RequestService + Send + Sync> Spawnable for S {
             .build()
             .map_err(|e| RpcError::SpawnFailed(format!("runtime: {e}")))?;
 
-        let local = tokio::task::LocalSet::new();
-        local.block_on(&rt, async move {
-            let runner = RequestLoop::new(transport, context, signing_key);
-
-            match runner.run(*self).await {
-                Ok(mut handle) => {
-                    if let Some(tx) = on_ready {
-                        let _ = tx.send(());
-                    }
-                    let _ = crate::notify::ready();
-                    shutdown.notified().await;
-                    handle.stop().await;
-                    Ok(())
-                }
-                Err(e) => Err(RpcError::SpawnFailed(e.to_string())),
-            }
+        // Post-ZMQ serve (#136): bridge the service to a Send processor on its own
+        // LocalSet thread, then serve it over its registered transport (inproc →
+        // in-memory dial registry; ipc/systemd → UdsRpcServer). No ZMQ ROUTER.
+        rt.block_on(async move {
+            let nonce_cache = Arc::new(crate::envelope::InMemoryNonceCache::new());
+            let bridge = crate::transport::iroh_rpc::LocalServiceBridge::spawn(*self, nonce_cache, 0)
+                .map_err(|e| RpcError::SpawnFailed(format!("bridge: {e}")))?;
+            let processor: Arc<dyn crate::transport::rpc_session::IrohRequestProcessor> =
+                Arc::new(bridge);
+            crate::service::serve::serve_bridged(&transport, processor, signing_key, shutdown, on_ready)
+                .await
+                .map_err(|e| RpcError::SpawnFailed(e.to_string()))
         })
     }
 }

--- a/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
@@ -328,6 +328,91 @@ impl LocalServiceBridge {
 
         Ok(Self { tx })
     }
+
+    /// Like [`LocalServiceBridge::spawn`], but constructs the service ON the
+    /// bridge thread via the async `build` closure. For services whose
+    /// construction is itself `!Send` or async (e.g. GPU init that must happen on
+    /// the serve thread, like `InferenceService`): the built service value never
+    /// has to be `Send`-moved across threads — only the builder's captured inputs
+    /// do (`F: Send`), and the `!Send` result lives only on the bridge thread.
+    ///
+    /// Returns the bridge plus a readiness receiver that resolves once `build`
+    /// completes: `Ok(())` when the service is built and serving, or the build
+    /// error. Callers MUST await it before advertising the service (a build
+    /// failure otherwise surfaces only as "channel closed" on the first request).
+    pub fn spawn_with<F, Fut, S>(
+        thread_name: impl Into<String>,
+        build: F,
+        nonce_cache: Arc<crate::envelope::InMemoryNonceCache>,
+        queue_depth: usize,
+    ) -> Result<(Self, tokio::sync::oneshot::Receiver<Result<()>>)>
+    where
+        F: FnOnce() -> Fut + Send + 'static,
+        Fut: Future<Output = Result<S>>,
+        S: crate::service::RequestService + 'static,
+    {
+        let cap = if queue_depth == 0 { 128 } else { queue_depth };
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<BridgeMessage>(cap);
+        let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<Result<()>>();
+        let thread_name = thread_name.into();
+
+        std::thread::Builder::new()
+            .name(format!("rpc-bridge:{thread_name}"))
+            .spawn(move || {
+                let rt = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
+                    Ok(rt) => rt,
+                    Err(e) => {
+                        let _ = ready_tx.send(Err(anyhow::anyhow!("bridge runtime: {e}")));
+                        return;
+                    }
+                };
+                let local = tokio::task::LocalSet::new();
+                local.spawn_local(async move {
+                    // Build on-thread; a failure (e.g. GPU init) is reported via
+                    // the readiness channel and the bridge thread exits.
+                    let service = match build().await {
+                        Ok(s) => std::rc::Rc::new(s),
+                        Err(e) => {
+                            let _ = ready_tx.send(Err(e));
+                            return;
+                        }
+                    };
+                    if ready_tx.send(Ok(())).is_err() {
+                        // Caller gave up waiting; no point serving.
+                        return;
+                    }
+                    while let Some(msg) = rx.recv().await {
+                        let service = std::rc::Rc::clone(&service);
+                        let nonce_cache = Arc::clone(&nonce_cache);
+                        tokio::task::spawn_local(async move {
+                            let signing_key = service.signing_key();
+                            let result = crate::service::dispatch::process_request(
+                                msg.request.as_ref(),
+                                &*service,
+                                crate::envelope::EnvelopeVerification::AnySigner,
+                                &signing_key,
+                                &nonce_cache,
+                            )
+                            .await
+                            .and_then(|(bytes, cont)| {
+                                if cont.is_some() {
+                                    return Err(anyhow::anyhow!(
+                                        "rpc bridge: streaming continuation unsupported \
+                                         (streaming is on the moq plane, #134)"
+                                    ));
+                                }
+                                Ok(Bytes::from(bytes))
+                            });
+                            let _ = msg.respond.send(result);
+                        });
+                    }
+                });
+                rt.block_on(local);
+            })
+            .map_err(|e| anyhow::anyhow!("spawn rpc bridge thread: {e}"))?;
+
+        Ok((Self { tx }, ready_rx))
+    }
 }
 
 impl IrohRequestProcessor for LocalServiceBridge {
@@ -380,6 +465,78 @@ mod tests {
                 .into_iter()
                 .map(TransportAddr::Ip),
         )
+    }
+
+    /// Minimal `RequestService` for `spawn_with` tests.
+    struct BridgeEcho {
+        name: String,
+        ctx: Arc<zmq::Context>,
+        transport: crate::transport::TransportConfig,
+        signing_key: SigningKey,
+    }
+    impl BridgeEcho {
+        fn new(signing_key: SigningKey) -> Self {
+            Self {
+                name: "bridge-echo".to_owned(),
+                ctx: Arc::new(zmq::Context::new()),
+                transport: crate::transport::TransportConfig::inproc("bridge-echo-unused"),
+                signing_key,
+            }
+        }
+    }
+    #[async_trait::async_trait(?Send)]
+    impl crate::service::RequestService for BridgeEcho {
+        async fn handle_request(
+            &self,
+            _ctx: &crate::service::EnvelopeContext,
+            payload: &[u8],
+        ) -> Result<(Vec<u8>, Option<crate::service::Continuation>)> {
+            let mut out = vec![0xBE];
+            out.extend_from_slice(payload);
+            Ok((out, None))
+        }
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn context(&self) -> &Arc<zmq::Context> {
+            &self.ctx
+        }
+        fn transport(&self) -> &crate::transport::TransportConfig {
+            &self.transport
+        }
+        fn signing_key(&self) -> SigningKey {
+            self.signing_key.clone()
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn spawn_with_readiness_ok_on_success_err_on_failure() -> Result<()> {
+        let nonce = Arc::new(crate::envelope::InMemoryNonceCache::new());
+
+        // Builder succeeds → readiness resolves Ok and the bridge serves.
+        let sk = fresh_signing_key();
+        let (_bridge, ready) = LocalServiceBridge::spawn_with(
+            "ok",
+            move || async move { Ok(BridgeEcho::new(sk)) },
+            Arc::clone(&nonce),
+            0,
+        )?;
+        ready.await.map_err(|_| anyhow::anyhow!("readiness dropped"))??;
+
+        // Builder fails (e.g. GPU init error) → the error surfaces on readiness,
+        // not silently as a later channel-closed.
+        let (_bridge2, ready2) = LocalServiceBridge::spawn_with::<_, _, BridgeEcho>(
+            "fail",
+            move || async move { Err(anyhow::anyhow!("boom")) },
+            nonce,
+            0,
+        )?;
+        let build_result = ready2.await.map_err(|_| anyhow::anyhow!("readiness dropped"))?;
+        assert!(
+            build_result.is_err(),
+            "a build failure must surface on the readiness channel"
+        );
+        Ok(())
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
@@ -296,27 +296,19 @@ impl LocalServiceBridge {
                                 &nonce_cache,
                             )
                             .await
-                            .and_then(|(bytes, cont)| {
-                                // Streaming continuations are not wired on
-                                // the iroh RPC plane — streaming moves to
-                                // moq-net (`moql` ALPN, Phase 3, #134). In
-                                // debug, panic loudly; in release, return an
-                                // error so the wire emits a signed error
-                                // envelope (handler's build_error_envelope)
-                                // rather than silently dropping the stream.
-                                if cont.is_some() {
-                                    debug_assert!(
-                                        false,
-                                        "iroh-rpc bridge: streaming continuation not supported \
-                                         — wait for Phase 3 (#134)"
-                                    );
-                                    return Err(anyhow::anyhow!(
-                                        "iroh-rpc bridge: service returned a streaming \
-                                         continuation, which is not supported on the iroh \
-                                         RPC plane (Phase 3 / #134 moves streaming to moq-net)"
-                                    ));
+                            .map(|(bytes, cont)| {
+                                // The continuation is the streaming pump — it
+                                // publishes to the moq/notification plane,
+                                // independent of the RPC transport — so spawn it
+                                // on this bridge LocalSet after the response,
+                                // exactly as RequestLoop / WebTransportServer do.
+                                // (Without this, streaming services like model /
+                                // tui would have their continuation dropped and
+                                // the stream would never be served.)
+                                if let Some(cont) = cont {
+                                    tokio::task::spawn_local(cont);
                                 }
-                                Ok(Bytes::from(bytes))
+                                Bytes::from(bytes)
                             });
                             let _ = msg.respond.send(result);
                         });
@@ -394,14 +386,13 @@ impl LocalServiceBridge {
                                 &nonce_cache,
                             )
                             .await
-                            .and_then(|(bytes, cont)| {
-                                if cont.is_some() {
-                                    return Err(anyhow::anyhow!(
-                                        "rpc bridge: streaming continuation unsupported \
-                                         (streaming is on the moq plane, #134)"
-                                    ));
+                            .map(|(bytes, cont)| {
+                                // Spawn the streaming pump on this bridge LocalSet
+                                // (see spawn() for the rationale).
+                                if let Some(cont) = cont {
+                                    tokio::task::spawn_local(cont);
                                 }
-                                Ok(Bytes::from(bytes))
+                                Bytes::from(bytes)
                             });
                             let _ = msg.respond.send(result);
                         });

--- a/crates/hyprstream-rpc/src/transport/lazy_uds.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_uds.rs
@@ -1,0 +1,209 @@
+//! Lazy-connecting UDS RPC transport (same-host `ipc` plane).
+//!
+//! Mirrors [`LazyQuinnTransport`](super::lazy_quinn::LazyQuinnTransport) and
+//! [`LazyIrohTransport`](super::lazy_iroh::LazyIrohTransport): the
+//! [`dial`](crate::dial::dial) factory is synchronous, so this holds the socket
+//! path and connects on the **first `send()`**, caching the session — preserving
+//! sync, zero-I/O construction.
+//!
+//! The connection is a [`UdsSession`](super::uds_session::UdsSession) on the RPC
+//! plane (`PLANE_RPC`), wrapped as a [`SessionRpcTransport`] — the *same* generic
+//! client used by the quinn and iroh backends, so the ipc plane carries the
+//! identical Cap'n Proto bidi wire protocol with no transport-specific RPC code.
+//! This is the post-ZMQ `ipc` transport: same-host processes keep `ipc`,
+//! re-platformed off ZMQ framing onto SignedEnvelope-over-UDS.
+//!
+//! # Identity
+//!
+//! UDS has no transport-level peer identity; same-host trust + the app-layer
+//! `SignedEnvelope` (verified against the response key) are the authentication.
+//! Socket-file permissions + `SO_PEERCRED` are defense-in-depth owned by the
+//! daemon that binds the listener (see #207). A `None` `server_verifying_key`
+//! leaves the response identity unpinned (the envelope sig is still verified),
+//! matching the quinn arm.
+//!
+//! Re-dial/self-heal semantics match the other lazy transports: a per-request
+//! timeout keeps the session; a transport-fatal error drops it so the next call
+//! re-dials.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Result};
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+
+use super::rpc_session::{RpcPendingStream, RpcPublishStub, SessionRpcTransport};
+use super::uds_session::{connect_uds, UdsSession, PLANE_RPC};
+use crate::transport_traits::Transport;
+
+/// Default per-request deadline when the caller passes `None`.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Ceiling on the lazy connect (UDS connect + yamux/SETUP). The per-request
+/// deadline wraps only the request; without this a missing socket would hang the
+/// first `send()`.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// A UDS RPC transport that connects on first use and caches the session.
+pub struct LazyUdsTransport {
+    path: PathBuf,
+    cached: Mutex<Option<SessionRpcTransport<UdsSession>>>,
+}
+
+impl LazyUdsTransport {
+    /// Create a lazy transport for the UDS endpoint at `path`. No connection is
+    /// made until the first `send()`.
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            cached: Mutex::new(None),
+        }
+    }
+
+    /// Return the cached connected transport, connecting once (single-flight
+    /// under the lock) if not yet connected.
+    async fn connected(&self) -> Result<SessionRpcTransport<UdsSession>> {
+        let mut guard = self.cached.lock().await;
+        if let Some(transport) = guard.as_ref() {
+            return Ok(transport.clone());
+        }
+        let session = tokio::time::timeout(CONNECT_TIMEOUT, connect_uds(&self.path, PLANE_RPC))
+            .await
+            .map_err(|_| {
+                anyhow!(
+                    "uds connect to {} timed out after {CONNECT_TIMEOUT:?}",
+                    self.path.display()
+                )
+            })?
+            .map_err(|e| anyhow!("uds connect to {}: {e}", self.path.display()))?;
+        let transport = SessionRpcTransport::new(session);
+        *guard = Some(transport.clone());
+        Ok(transport)
+    }
+
+    /// Drop the cached session so the next `send()` re-connects.
+    async fn invalidate(&self) {
+        *self.cached.lock().await = None;
+    }
+}
+
+#[async_trait]
+impl Transport for LazyUdsTransport {
+    type Sub = RpcPendingStream;
+    type Pub = RpcPublishStub;
+
+    async fn send(&self, payload: Vec<u8>, timeout_ms: Option<i32>) -> Result<Vec<u8>> {
+        let transport = self.connected().await?;
+
+        // Our deadline is authoritative so a per-request timeout (busy peer —
+        // keep the session) is distinguishable from a transport-fatal error
+        // (re-connect), matching the other lazy transports.
+        let deadline = timeout_ms
+            .map(|ms| Duration::from_millis(ms.max(0) as u64))
+            .unwrap_or(DEFAULT_TIMEOUT);
+        let inner_ceiling_ms = deadline.as_millis().saturating_mul(2).min(i32::MAX as u128) as i32;
+
+        match tokio::time::timeout(deadline, transport.send(payload, Some(inner_ceiling_ms))).await {
+            Err(_elapsed) => Err(anyhow!("uds RPC timeout after {deadline:?}")),
+            Ok(Ok(resp)) => Ok(resp),
+            Ok(Err(e)) => {
+                self.invalidate().await;
+                Err(e)
+            }
+        }
+    }
+
+    async fn subscribe(&self, _topic: &[u8]) -> Result<Self::Sub> {
+        bail!("lazy UDS RPC transport does not support SUB — streaming is on the moq plane")
+    }
+
+    async fn publish(&self, _topic: &[u8]) -> Result<Self::Pub> {
+        bail!("lazy UDS RPC transport does not support PUB — streaming is on the moq plane")
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::transport::rpc_session::{
+        from_fn, serve_rpc_connection, DEFAULT_STREAM_LIMIT, REQUEST_READ_TIMEOUT,
+    };
+    use crate::transport::uds_session::accept_uds;
+    use bytes::Bytes;
+    use std::sync::Arc;
+    use tokio::sync::Semaphore;
+    use tokio_util::sync::CancellationToken;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn lazy_uds_connects_on_first_send_and_caches() {
+        let dir = std::env::temp_dir().join(format!("lazy-uds-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("rpc.sock");
+        let _ = std::fs::remove_file(&path);
+        let listener = tokio::net::UnixListener::bind(&path).unwrap();
+
+        // Echo RPC server over UDS.
+        let shutdown = CancellationToken::new();
+        let shutdown_srv = shutdown.clone();
+        let srv = tokio::spawn(async move {
+            let (sk, _vk) = crate::generate_signing_keypair();
+            let processor = Arc::new(from_fn(|req: Bytes| async move { Ok(req) }));
+            let limit = Arc::new(Semaphore::new(DEFAULT_STREAM_LIMIT));
+            loop {
+                tokio::select! {
+                    _ = shutdown_srv.cancelled() => break,
+                    accepted = listener.accept() => {
+                        let (stream, _) = accepted.unwrap();
+                        let (plane, session) = accept_uds(stream).await.unwrap();
+                        assert_eq!(plane, PLANE_RPC);
+                        let p = Arc::clone(&processor);
+                        let l = Arc::clone(&limit);
+                        let sk = sk.clone();
+                        let sd = shutdown_srv.clone();
+                        tokio::spawn(async move {
+                            let _ = serve_rpc_connection(
+                                session, p, sk, l, REQUEST_READ_TIMEOUT, sd,
+                            )
+                            .await;
+                        });
+                    }
+                }
+            }
+        });
+
+        let t = LazyUdsTransport::new(path.clone());
+        assert!(t.cached.lock().await.is_none(), "no connection before first send");
+        let resp = t.send(b"ping".to_vec(), Some(4_000)).await.unwrap();
+        assert_eq!(resp, b"ping");
+        assert!(t.cached.lock().await.is_some(), "session cached after first send");
+        // Second call reuses the cached session (multiplexed stream).
+        let resp2 = t.send(b"pong".to_vec(), Some(4_000)).await.unwrap();
+        assert_eq!(resp2, b"pong");
+
+        shutdown.cancel();
+        let _ = srv.await;
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_dir(&dir);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn lazy_uds_missing_socket_errors_without_hang() {
+        let path = std::env::temp_dir().join(format!("lazy-uds-absent-{}.sock", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        let t = LazyUdsTransport::new(path);
+        let res = tokio::time::timeout(Duration::from_secs(5), t.send(b"x".to_vec(), Some(2_000)))
+            .await
+            .expect("send must complete (with an error), not hang");
+        assert!(res.is_err(), "dialing an absent socket must fail");
+        assert!(t.cached.lock().await.is_none(), "a failed connect caches nothing");
+    }
+
+    #[tokio::test]
+    async fn subscribe_publish_bail() {
+        let t = LazyUdsTransport::new(PathBuf::from("/nonexistent.sock"));
+        assert!(t.subscribe(b"topic").await.is_err());
+        assert!(t.publish(b"topic").await.is_err());
+    }
+}

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -33,6 +33,8 @@ pub mod lazy_iroh;
 pub mod uds_session;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod lazy_uds;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod uds_server;
 
 use std::net::SocketAddr;
 use std::os::unix::io::RawFd;

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -31,6 +31,8 @@ pub mod lazy_quinn;
 pub mod lazy_iroh;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod uds_session;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod lazy_uds;
 
 use std::net::SocketAddr;
 use std::os::unix::io::RawFd;

--- a/crates/hyprstream-rpc/src/transport/uds_server.rs
+++ b/crates/hyprstream-rpc/src/transport/uds_server.rs
@@ -1,0 +1,280 @@
+//! UDS RPC server — the same-host `ipc` serve path, post-ZMQ.
+//!
+//! Mirrors [`QuinnRpcServer`](super::quinn_transport::QuinnRpcServer): a
+//! `UnixListener` accept loop that hands each accepted connection to the
+//! transport-generic [`serve_rpc_connection`] over a
+//! [`UdsSession`](super::uds_session::UdsSession). Same DoS discipline — a
+//! server-wide concurrent-stream semaphore (drained on shutdown), a
+//! per-connection cap, a bounded handshake, and the per-stream read timeout —
+//! and the same `process_request` dispatch core, so the ipc plane is identical
+//! to the quinn/iroh planes save for the socket underneath.
+//!
+//! The daemon binds the `UnixListener` (choosing the path + file mode; peer
+//! creds are #207) and runs one of these per spawn-path service. A
+//! `!Send` service is bridged to the `Send`-bound processor via
+//! [`LocalServiceBridge`](super::iroh_rpc::LocalServiceBridge), exactly as the
+//! quinn/iroh serve paths do.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use ed25519_dalek::SigningKey;
+use tokio::net::UnixListener;
+use tokio::sync::Semaphore;
+use tokio_util::sync::CancellationToken;
+
+use super::rpc_session::{
+    serve_rpc_connection, IrohRequestProcessor, DEFAULT_CONNECTION_LIMIT, DEFAULT_STREAM_LIMIT,
+    DRAIN_TIMEOUT, REQUEST_READ_TIMEOUT,
+};
+use super::uds_session::{accept_uds, PLANE_MOQ, PLANE_RPC};
+
+/// A `UnixListener`-backed RPC server for the same-host `ipc` plane.
+pub struct UdsRpcServer {
+    listener: UnixListener,
+    processor: Arc<dyn IrohRequestProcessor>,
+    signing_key: SigningKey,
+    /// Server-wide concurrent-stream cap, shared across all connections; one
+    /// permit per in-flight bidi stream. `shutdown` drains it via `acquire_many`.
+    stream_limit: Arc<Semaphore>,
+    stream_limit_capacity: u32,
+    /// Cap on concurrent accepted connections (#162). Connections beyond the cap
+    /// are rejected (dropped), not queued.
+    connection_limit: Arc<Semaphore>,
+    /// Per-stream request-read timeout (#159 slowloris bound).
+    read_timeout: Duration,
+    shutdown: CancellationToken,
+}
+
+impl UdsRpcServer {
+    /// Build a server over an already-bound [`UnixListener`].
+    pub fn new<P: IrohRequestProcessor>(
+        listener: UnixListener,
+        processor: P,
+        signing_key: SigningKey,
+    ) -> Self {
+        Self::with_capacity(listener, Arc::new(processor), signing_key, DEFAULT_STREAM_LIMIT)
+    }
+
+    /// Build a server with an explicit server-wide concurrent-stream cap.
+    pub fn with_capacity(
+        listener: UnixListener,
+        processor: Arc<dyn IrohRequestProcessor>,
+        signing_key: SigningKey,
+        stream_limit: usize,
+    ) -> Self {
+        Self {
+            listener,
+            processor,
+            signing_key,
+            stream_limit: Arc::new(Semaphore::new(stream_limit)),
+            stream_limit_capacity: u32::try_from(stream_limit).unwrap_or(u32::MAX),
+            connection_limit: Arc::new(Semaphore::new(DEFAULT_CONNECTION_LIMIT)),
+            read_timeout: REQUEST_READ_TIMEOUT,
+            shutdown: CancellationToken::new(),
+        }
+    }
+
+    /// Override the concurrent-connection cap (builder style).
+    pub fn with_connection_limit(mut self, limit: usize) -> Self {
+        self.connection_limit = Arc::new(Semaphore::new(limit));
+        self
+    }
+
+    /// Override the server-wide concurrent-stream cap (builder style).
+    pub fn with_stream_limit(mut self, limit: usize) -> Self {
+        self.stream_limit = Arc::new(Semaphore::new(limit));
+        self.stream_limit_capacity = u32::try_from(limit).unwrap_or(u32::MAX);
+        self
+    }
+
+    /// Override the per-stream request-read timeout (#159). Primarily for tests.
+    pub fn with_read_timeout(mut self, read_timeout: Duration) -> Self {
+        self.read_timeout = read_timeout;
+        self
+    }
+
+    /// A handle that, when cancelled, stops the accept loop and per-connection
+    /// serve loops. Does not by itself drain in-flight streams — use
+    /// [`UdsRpcServer::shutdown`] for a graceful drain.
+    pub fn shutdown_token(&self) -> CancellationToken {
+        self.shutdown.clone()
+    }
+
+    /// The shared concurrent-stream semaphore (pair with [`UdsRpcServer::capacity`]
+    /// + [`UdsRpcServer::shutdown_token`] to drain while `run` owns `self`).
+    pub fn stream_limit(&self) -> Arc<Semaphore> {
+        Arc::clone(&self.stream_limit)
+    }
+
+    /// The configured server-wide concurrent-stream capacity.
+    pub fn capacity(&self) -> u32 {
+        self.stream_limit_capacity
+    }
+
+    /// Graceful shutdown: cancel the accept loop, then wait (bounded by
+    /// [`DRAIN_TIMEOUT`]) for every in-flight stream to release its permit, then
+    /// close the semaphore. Mirrors [`QuinnRpcServer::shutdown`](super::quinn_transport::QuinnRpcServer::shutdown).
+    pub async fn shutdown(stream_limit: &Arc<Semaphore>, capacity: u32, token: &CancellationToken) {
+        token.cancel();
+        match tokio::time::timeout(DRAIN_TIMEOUT, stream_limit.acquire_many(capacity)).await {
+            Ok(Ok(permits)) => {
+                permits.forget();
+                stream_limit.close();
+            }
+            Ok(Err(_)) => { /* already closed */ }
+            Err(_) => {
+                tracing::warn!(timeout = ?DRAIN_TIMEOUT, "uds-rpc: drain timed out, forcing teardown");
+                stream_limit.close();
+            }
+        }
+    }
+
+    /// Run the accept loop until `shutdown` is cancelled. Each accepted
+    /// connection is served on its own task by [`serve_rpc_connection`], sharing
+    /// the server-wide [`Semaphore`] so [`UdsRpcServer::shutdown`] can drain
+    /// every in-flight stream regardless of which connection it belongs to.
+    pub async fn run(self) -> Result<()> {
+        loop {
+            tokio::select! {
+                biased;
+                _ = self.shutdown.cancelled() => {
+                    tracing::debug!("uds-rpc: accept loop cancelled");
+                    return Ok(());
+                }
+                accepted = self.listener.accept() => {
+                    let stream = match accepted {
+                        Ok((stream, _addr)) => stream,
+                        Err(e) => {
+                            tracing::debug!(error = %e, "uds-rpc: listener accept error");
+                            continue;
+                        }
+                    };
+
+                    // Connection cap (#162): reject (drop) at cap rather than queue.
+                    let conn_permit = match Arc::clone(&self.connection_limit).try_acquire_owned() {
+                        Ok(p) => p,
+                        Err(_) => {
+                            tracing::warn!("uds-rpc: connection cap reached, rejecting connection");
+                            drop(stream);
+                            continue;
+                        }
+                    };
+
+                    let processor = Arc::clone(&self.processor);
+                    let signing_key = self.signing_key.clone();
+                    let stream_limit = Arc::clone(&self.stream_limit);
+                    let read_timeout = self.read_timeout;
+                    let shutdown = self.shutdown.clone();
+                    tokio::spawn(async move {
+                        let _conn_permit = conn_permit; // released when this connection ends
+
+                        // Read the plane byte + spin up the yamux session, bounded
+                        // so a stalled handshake never pins a connection permit.
+                        let (plane, session) = match tokio::time::timeout(
+                            super::rpc_session::HANDSHAKE_TIMEOUT,
+                            accept_uds(stream),
+                        )
+                        .await
+                        {
+                            Ok(Ok(pair)) => pair,
+                            Ok(Err(e)) => {
+                                tracing::debug!(error = %e, "uds-rpc: accept_uds failed");
+                                return;
+                            }
+                            Err(_) => {
+                                tracing::warn!("uds-rpc: plane handshake timed out");
+                                return;
+                            }
+                        };
+
+                        match plane {
+                            PLANE_RPC => {
+                                if let Err(e) = serve_rpc_connection(
+                                    session, processor, signing_key, stream_limit, read_timeout, shutdown,
+                                )
+                                .await
+                                {
+                                    tracing::debug!(error = ?e, "uds-rpc: serve connection ended with error");
+                                }
+                            }
+                            PLANE_MOQ => {
+                                // moq streaming over UDS is a later increment; the
+                                // same UdsSession is moq-capable, but the daemon
+                                // does not yet wire a moq Server on this listener.
+                                tracing::warn!("uds-rpc: PLANE_MOQ on the RPC listener — not yet served, closing");
+                            }
+                            other => {
+                                tracing::warn!(plane = other, "uds-rpc: unknown plane, closing");
+                            }
+                        }
+                    });
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::transport::lazy_uds::LazyUdsTransport;
+    use crate::transport::rpc_session::from_fn;
+    use crate::transport_traits::Transport;
+    use bytes::Bytes;
+
+    fn temp_sock(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("uds-server-{}-{}", tag, std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        dir.join("rpc.sock")
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn uds_server_round_trips_via_lazy_client() {
+        let path = temp_sock("rt");
+        let _ = std::fs::remove_file(&path);
+        let listener = UnixListener::bind(&path).unwrap();
+
+        let (sk, _vk) = crate::generate_signing_keypair();
+        let processor = from_fn(|req: Bytes| async move { Ok(req) }); // echo
+        let server = UdsRpcServer::new(listener, processor, sk);
+        let token = server.shutdown_token();
+        let srv = tokio::spawn(server.run());
+
+        let client = LazyUdsTransport::new(path.clone());
+        let r1 = client.send(b"ping".to_vec(), Some(4_000)).await.unwrap();
+        assert_eq!(r1, b"ping");
+        // Reuse the cached session over a second multiplexed stream.
+        let r2 = client.send(b"pong".to_vec(), Some(4_000)).await.unwrap();
+        assert_eq!(r2, b"pong");
+
+        token.cancel();
+        let _ = srv.await;
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn uds_server_shutdown_drains() {
+        let path = temp_sock("drain");
+        let _ = std::fs::remove_file(&path);
+        let listener = UnixListener::bind(&path).unwrap();
+
+        let (sk, _vk) = crate::generate_signing_keypair();
+        let processor = from_fn(|req: Bytes| async move { Ok(req) });
+        let server = UdsRpcServer::new(listener, processor, sk);
+        let token = server.shutdown_token();
+        let stream_limit = server.stream_limit();
+        let capacity = server.capacity();
+        let srv = tokio::spawn(server.run());
+
+        let client = LazyUdsTransport::new(path.clone());
+        assert_eq!(client.send(b"x".to_vec(), Some(4_000)).await.unwrap(), b"x");
+
+        // Graceful drain completes promptly with no in-flight streams.
+        UdsRpcServer::shutdown(&stream_limit, capacity, &token).await;
+        let _ = srv.await;
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/crates/hyprstream-rpc/tests/inproc_bridged_e2e.rs
+++ b/crates/hyprstream-rpc/tests/inproc_bridged_e2e.rs
@@ -1,0 +1,128 @@
+//! End-to-end test for the default (inproc) flipped serve path — the #136 cut's
+//! most-used path, previously untested (the UDS canary covers ipc only).
+//!
+//! Wires a `RequestService` through the exact bridged inproc path the daemon uses:
+//! `LocalServiceBridge` → `register_inproc` (in-memory dial registry) → `dial()`
+//! (InMemoryTransport) → `RpcClientImpl`. A real SignedEnvelope round-trips, and —
+//! crucially — the service returns a streaming **continuation** that must be
+//! spawned by the bridge (the #186 StreamInfo pump). This guards against the
+//! regression where the bridge dropped/rejected continuations, silently breaking
+//! streaming services (model / tui).
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use rand::RngCore;
+use tokio::sync::Mutex;
+
+use hyprstream_rpc::dial::{dial, register_inproc};
+use hyprstream_rpc::envelope::InMemoryNonceCache;
+use hyprstream_rpc::service::{Continuation, EnvelopeContext, RequestService};
+use hyprstream_rpc::signer::LocalSigner;
+use hyprstream_rpc::transport::iroh_rpc::LocalServiceBridge;
+use hyprstream_rpc::transport::rpc_session::IrohRequestProcessor;
+use hyprstream_rpc::transport::TransportConfig;
+
+/// Echoes the payload AND returns a continuation that fires a oneshot — so the
+/// test can assert the bridge actually spawned the streaming pump.
+struct StreamingEcho {
+    name: String,
+    ctx: Arc<zmq::Context>,
+    transport: TransportConfig,
+    signing_key: SigningKey,
+    fired: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+}
+
+#[async_trait(?Send)]
+impl RequestService for StreamingEcho {
+    async fn handle_request(
+        &self,
+        _ctx: &EnvelopeContext,
+        payload: &[u8],
+    ) -> Result<(Vec<u8>, Option<Continuation>)> {
+        let tx = self.fired.lock().await.take();
+        let cont: Continuation = Box::pin(async move {
+            if let Some(tx) = tx {
+                let _ = tx.send(());
+            }
+        });
+        Ok((payload.to_vec(), Some(cont)))
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn context(&self) -> &Arc<zmq::Context> {
+        &self.ctx
+    }
+    fn transport(&self) -> &TransportConfig {
+        &self.transport
+    }
+    fn signing_key(&self) -> SigningKey {
+        self.signing_key.clone()
+    }
+}
+
+fn fresh_key() -> SigningKey {
+    let mut b = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut b);
+    SigningKey::from_bytes(&b)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn inproc_bridged_round_trip_and_continuation_spawned() -> Result<()> {
+    // Integration test → hyprstream-rpc in non-test mode → verify policy
+    // fail-closes to Hybrid (#160); opt into the Classical policy this exercises.
+    let _ = hyprstream_rpc::envelope::install_verify_config(
+        hyprstream_rpc::envelope::EnvelopeVerifyConfig {
+            policy: hyprstream_rpc::crypto::CryptoPolicy::Classical,
+            pq_store: None,
+        },
+    );
+
+    const NAME: &str = "test/inproc-stream-echo";
+
+    let server_key = fresh_key();
+    let server_vk: VerifyingKey = server_key.verifying_key();
+    let (fired_tx, fired_rx) = tokio::sync::oneshot::channel();
+
+    let svc = StreamingEcho {
+        name: NAME.to_owned(),
+        ctx: Arc::new(zmq::Context::new()),
+        transport: TransportConfig::inproc(NAME),
+        signing_key: server_key,
+        fired: Mutex::new(Some(fired_tx)),
+    };
+
+    // Server side: bridge + register in the in-memory dial registry. Keep the
+    // strong processor Arc alive for the duration (registry holds only a Weak).
+    let nonce = Arc::new(InMemoryNonceCache::new());
+    let bridge = LocalServiceBridge::spawn(svc, nonce, 0)?;
+    let processor: Arc<dyn IrohRequestProcessor> = Arc::new(bridge);
+    register_inproc(NAME, &processor);
+
+    // Client side: dial inproc → InMemoryTransport → real SignedEnvelope.
+    let client = dial(
+        &TransportConfig::inproc(NAME),
+        LocalSigner::new(fresh_key()),
+        Some(server_vk),
+        None,
+    )?;
+    let resp = client.call(b"hello-inproc".to_vec()).await?;
+    assert_eq!(&resp[..], b"hello-inproc");
+
+    // The streaming continuation must have been spawned by the bridge and run.
+    tokio::time::timeout(std::time::Duration::from_secs(3), fired_rx)
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "continuation did not run — regression: the bridge dropped/rejected \
+                 the streaming continuation, which silently breaks streaming services"
+            )
+        })??;
+
+    drop(processor);
+    Ok(())
+}

--- a/crates/hyprstream-rpc/tests/uds_rpc_e2e.rs
+++ b/crates/hyprstream-rpc/tests/uds_rpc_e2e.rs
@@ -1,0 +1,144 @@
+//! End-to-end canary: real SignedEnvelope round-trip over the same-host UDS plane.
+//!
+//! Mirrors `iroh_rpc_e2e.rs` but over a Unix-domain socket, exercising the exact
+//! bridged serve path the daemon will use for the post-ZMQ `ipc` transport:
+//! 1. [`LocalServiceBridge`] — a (possibly `!Send`) [`RequestService`] on its own
+//!    LocalSet thread, exposed as a `Send` processor.
+//! 2. [`UdsRpcServer`] — UnixListener accept loop → `serve_rpc_connection` over a
+//!    `UdsSession` (PLANE_RPC), feeding the same `process_request` dispatch core.
+//! 3. [`LazyUdsTransport`] — client wire (connect-on-first-send, yamux-muxed).
+//! 4. [`RpcClientImpl`] — envelope sign + response verify.
+//!
+//! Verifies that a real `SignedEnvelope` issued by `RpcClientImpl::call` traverses
+//! the UDS plane, arrives at the service's `handle_request` with verified
+//! identity, and the signed response verifies back at the client — the same
+//! exit criterion the iroh canary proves, on the ipc transport.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use rand::RngCore;
+
+use hyprstream_rpc::envelope::InMemoryNonceCache;
+use hyprstream_rpc::rpc_client::RpcClientImpl;
+use hyprstream_rpc::service::{Continuation, EnvelopeContext, RequestService};
+use hyprstream_rpc::signer::LocalSigner;
+use hyprstream_rpc::transport::iroh_rpc::LocalServiceBridge;
+use hyprstream_rpc::transport::lazy_uds::LazyUdsTransport;
+use hyprstream_rpc::transport::uds_server::UdsRpcServer;
+use hyprstream_rpc::transport::TransportConfig;
+use tokio::net::UnixListener;
+
+/// Minimal `RequestService` for the canary: echoes the request payload with a
+/// 1-byte prefix so the test can verify the identity round-trip.
+struct EchoService {
+    name: String,
+    ctx: Arc<zmq::Context>,
+    transport: TransportConfig,
+    signing_key: SigningKey,
+}
+
+impl EchoService {
+    fn new(signing_key: SigningKey) -> Self {
+        Self {
+            name: "uds-echo".to_owned(),
+            ctx: Arc::new(zmq::Context::new()),
+            transport: TransportConfig::inproc("uds-echo-unused"),
+            signing_key,
+        }
+    }
+}
+
+#[async_trait(?Send)]
+impl RequestService for EchoService {
+    async fn handle_request(
+        &self,
+        _ctx: &EnvelopeContext,
+        payload: &[u8],
+    ) -> Result<(Vec<u8>, Option<Continuation>)> {
+        let mut out = Vec::with_capacity(1 + payload.len());
+        out.push(0xEC);
+        out.extend_from_slice(payload);
+        Ok((out, None))
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn context(&self) -> &Arc<zmq::Context> {
+        &self.ctx
+    }
+
+    fn transport(&self) -> &TransportConfig {
+        &self.transport
+    }
+
+    fn signing_key(&self) -> SigningKey {
+        self.signing_key.clone()
+    }
+}
+
+fn fresh_signing_key() -> SigningKey {
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    SigningKey::from_bytes(&bytes)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn signed_envelope_round_trip_over_uds() -> Result<()> {
+    // As an integration test this compiles hyprstream-rpc in non-test mode, where
+    // the uninstalled global verify policy fail-closes to Hybrid (#160). Opt in to
+    // the Classical policy this canary validates. `set`-by-first-write: ignore the
+    // error if another test in this binary already installed a matching config.
+    let _ = hyprstream_rpc::envelope::install_verify_config(
+        hyprstream_rpc::envelope::EnvelopeVerifyConfig {
+            policy: hyprstream_rpc::crypto::CryptoPolicy::Classical,
+            pq_store: None,
+        },
+    );
+
+    // ─── Server side: bridge the service, serve it over a UnixListener ────────
+    let server_signing = fresh_signing_key();
+    let server_verifying: VerifyingKey = server_signing.verifying_key();
+    let server_nonce_cache = Arc::new(InMemoryNonceCache::new());
+
+    let bridge = LocalServiceBridge::spawn(
+        EchoService::new(server_signing.clone()),
+        server_nonce_cache,
+        0,
+    )?;
+
+    let dir = std::env::temp_dir().join(format!("uds-e2e-{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&dir);
+    let path = dir.join("rpc.sock");
+    let _ = std::fs::remove_file(&path);
+    let listener = UnixListener::bind(&path)?;
+
+    let server = UdsRpcServer::new(listener, bridge, server_signing.clone());
+    let token = server.shutdown_token();
+    let srv = tokio::spawn(server.run());
+
+    // ─── Client side: real signed envelope over LazyUdsTransport ─────────────
+    let client_signing = fresh_signing_key();
+    let rpc = RpcClientImpl::new(
+        LocalSigner::new(client_signing.clone()),
+        LazyUdsTransport::new(path.clone()),
+        Some(server_verifying),
+    );
+
+    let response = rpc.call(b"ping-payload".to_vec()).await?;
+    assert_eq!(&response[..], b"\xECping-payload");
+
+    // Second call reuses the cached session over a fresh multiplexed bidi stream.
+    let response2 = rpc.call(b"second".to_vec()).await?;
+    assert_eq!(&response2[..], b"\xECsecond");
+
+    token.cancel();
+    let _ = srv.await;
+    let _ = std::fs::remove_file(&path);
+    let _ = std::fs::remove_dir(&dir);
+    Ok(())
+}

--- a/crates/hyprstream-service/src/service/factory.rs
+++ b/crates/hyprstream-service/src/service/factory.rs
@@ -159,11 +159,17 @@ impl QuicSharedConfig {
                         let _ = policy_vk; // suppress unused warning
                     }
 
-                    let client = hyprstream_discovery::DiscoveryClient::for_service(
+                    let client = match hyprstream_discovery::DiscoveryClient::for_service(
                         sk,
                         discovery_vk,
                         None,
-                    );
+                    ) {
+                        Ok(c) => c,
+                        Err(e) => {
+                            tracing::warn!("Failed to build DiscoveryClient: {}", e);
+                            return;
+                        }
+                    };
                     match client.announce(&hyprstream_discovery::ServiceAnnouncement {
                         service_name: svc_name,
                         socket_kind: "quic".to_owned(),

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -490,7 +490,7 @@ fn handle_quick_command(
                     signing_key,
                     model_server_vk,
                     None,
-                );
+                )?;
                 let filters = parse_filters(&filter)?;
                 let status_filter = parse_status_filter(&status)?;
                 handle_list(ctx.registry(), model_client, &filters, &status_filter).await
@@ -1090,7 +1090,7 @@ fn handle_quick_command(
                             resolve_service_vk("policy")
                                 .ok_or_else(|| anyhow::anyhow!("Cannot resolve policy pubkey. Run wizard."))?,
                             None,
-                        );
+                        )?;
                         worker_service.set_authorize_fn(
                             hyprstream_core::services::build_authorize_fn(worker_policy_client),
                         );
@@ -1115,7 +1115,7 @@ fn handle_quick_command(
                     let worker_server_vk = resolve_service_vk("worker")
                         .ok_or_else(|| anyhow::anyhow!("Cannot resolve worker pubkey. Run wizard."))?;
                     let worker_client =
-                        WorkerClient::for_service(signing_key, worker_server_vk, None);
+                        WorkerClient::for_service(signing_key, worker_server_vk, None)?;
 
                     match action {
                         WorkerAction::List {
@@ -1643,7 +1643,7 @@ fn main() -> Result<()> {
                 signing_key.clone(),
                 registry_vk,
                 None,
-            );
+            )?;
 
             Ok::<_, anyhow::Error>((client, signing_key, verifying_key))
         })
@@ -1768,7 +1768,7 @@ fn main() -> Result<()> {
                                         resolve_service_vk("policy")
                                             .ok_or_else(|| anyhow::anyhow!("Cannot resolve policy pubkey. Run wizard."))?,
                                         None,
-                                    );
+                                    )?;
 
                                     let runtime_config =
                                         hyprstream_core::runtime::RuntimeConfig::default();

--- a/crates/hyprstream/src/cli/git_handlers.rs
+++ b/crates/hyprstream/src/cli/git_handlers.rs
@@ -1268,7 +1268,7 @@ pub async fn handle_infer(
         let policy_vk = signing_key.verifying_key();
         let policy_client = crate::services::PolicyClient::for_service(
             signing_key.clone(), policy_vk, None,
-        );
+        )?;
         let resp = policy_client.resolve_service_key(
             &crate::services::generated::policy_client::ResolveServiceKey {
                 service_name: "model".to_owned(),
@@ -1283,7 +1283,7 @@ pub async fn handle_infer(
         signing_key.clone(),
         model_server_vk,
         None,
-    );
+    )?;
 
     // Apply chat template to the prompt via ModelService
     let messages = vec![ChatMessage {
@@ -1445,7 +1445,7 @@ pub async fn handle_load(
     let policy_vk = signing_key.verifying_key();
     let policy_client = crate::services::PolicyClient::for_service(
         signing_key.clone(), policy_vk, None,
-    );
+    )?;
 
     // If --wait, subscribe to notifications BEFORE issuing load request
     // (ensures no events are missed between load and subscribe)
@@ -1469,7 +1469,7 @@ pub async fn handle_load(
             signing_key.clone(),
             notif_vk,
             None,
-        );
+        )?;
 
         let sub_resp = notif_client.subscribe(&SubscribeRequest {
             scope_pattern: scope_pattern.clone(),
@@ -1517,7 +1517,7 @@ pub async fn handle_load(
         signing_key.clone(),
         model_vk,
         None,
-    );
+    )?;
     let model_ref_owned = model_ref_str.to_owned();
     match model_client.load(&LoadModelRequest {
         model_ref: model_ref_owned.clone(),
@@ -1775,7 +1775,7 @@ async fn handle_notify_subscribe(
     let policy_vk = signing_key.verifying_key();
     let policy_client = crate::services::PolicyClient::for_service(
         signing_key.clone(), policy_vk, None,
-    );
+    )?;
     let notif_key_resp = policy_client.resolve_service_key(
         &crate::services::generated::policy_client::ResolveServiceKey {
             service_name: "notification".to_owned(),
@@ -1789,7 +1789,7 @@ async fn handle_notify_subscribe(
         signing_key,
         notif_server_vk,
         None,
-    );
+    )?;
 
     // Subscribe with maximum TTL for long-running listeners
     let ttl = if timeout_secs == 0 { 3600u32 } else { (timeout_secs as u32).min(3600) };
@@ -1929,7 +1929,7 @@ pub async fn handle_unload(
         let policy_vk = signing_key.verifying_key();
         let policy_client = crate::services::PolicyClient::for_service(
             signing_key.clone(), policy_vk, None,
-        );
+        )?;
         let resp = policy_client.resolve_service_key(
             &crate::services::generated::policy_client::ResolveServiceKey {
                 service_name: "model".to_owned(),
@@ -1940,7 +1940,7 @@ pub async fn handle_unload(
                 .map_err(|_| anyhow::anyhow!("Invalid key length"))?,
         ).map_err(|e| anyhow::anyhow!("Invalid key: {e}"))?
     };
-    let model_client = ModelClient::for_service(signing_key, model_server_vk, None);
+    let model_client = ModelClient::for_service(signing_key, model_server_vk, None)?;
 
     model_client.unload(&UnloadModelRequest { model_ref: model_ref_str.to_owned() }).await?;
 

--- a/crates/hyprstream/src/cli/policy_handlers.rs
+++ b/crates/hyprstream/src/cli/policy_handlers.rs
@@ -27,7 +27,7 @@ use std::process::Command;
 /// Create a PolicyClient for RPC calls.
 ///
 /// Bootstrap: PolicyService key needed to create the PolicyClient for peer key resolution.
-fn create_policy_client(signing_key: &SigningKey) -> PolicyClient {
+fn create_policy_client(signing_key: &SigningKey) -> Result<PolicyClient> {
     PolicyClient::for_service(
         signing_key.clone(),
         // Bootstrap: PolicyService uses the root key
@@ -41,7 +41,7 @@ pub async fn handle_policy_show(
     signing_key: &SigningKey,
     raw: bool,
 ) -> Result<()> {
-    let client = create_policy_client(signing_key);
+    let client = create_policy_client(signing_key)?;
     let policy_info = client.get_policy().await
         .context("Failed to get policy from PolicyService. Are services running?")?;
 
@@ -113,7 +113,7 @@ pub async fn handle_policy_history(
     count: usize,
     _oneline: bool,
 ) -> Result<()> {
-    let client = create_policy_client(signing_key);
+    let client = create_policy_client(signing_key)?;
     let history = client.get_history(&GetHistory { count: count as u32 }).await
         .context("Failed to get policy history from PolicyService. Are services running?")?;
 
@@ -160,7 +160,7 @@ pub async fn handle_policy_edit(
     }
 
     // Check for draft changes via PolicyService RPC
-    let client = create_policy_client(signing_key);
+    let client = create_policy_client(signing_key)?;
     match client.get_draft_status().await {
         Ok(draft) if draft.has_changes => {
             println!();
@@ -182,7 +182,7 @@ pub async fn handle_policy_diff(
     signing_key: &SigningKey,
     against: Option<String>,
 ) -> Result<()> {
-    let client = create_policy_client(signing_key);
+    let client = create_policy_client(signing_key)?;
     let git_ref = against.as_deref().unwrap_or("");
 
     let diff_text = client.get_diff(&GetDiff { git_ref: Some(git_ref.to_owned()) }).await
@@ -217,7 +217,7 @@ pub async fn handle_policy_apply(
     dry_run: bool,
     message: Option<String>,
 ) -> Result<()> {
-    let client = create_policy_client(signing_key);
+    let client = create_policy_client(signing_key)?;
 
     // Check for uncommitted changes via RPC
     let draft = client.get_draft_status().await
@@ -268,7 +268,7 @@ pub async fn handle_policy_rollback(
     git_ref: &str,
     dry_run: bool,
 ) -> Result<()> {
-    let client = create_policy_client(signing_key);
+    let client = create_policy_client(signing_key)?;
 
     if dry_run {
         // Use history RPC to show what we'd be rolling back to
@@ -316,7 +316,7 @@ pub async fn handle_policy_check(
     resource: &str,
     action: &str,
 ) -> Result<()> {
-    let client = create_policy_client(signing_key);
+    let client = create_policy_client(signing_key)?;
 
     let allowed = client.check(&PolicyCheck { subject: user.to_owned(), domain: "*".to_owned(), resource: resource.to_owned(), operation: action.to_owned() }).await
         .context("Failed to check policy via PolicyService. Are services running?")?;
@@ -534,7 +534,7 @@ pub async fn handle_policy_role_add(
         return Ok(());
     }
 
-    let client = create_policy_client(signing_key);
+    let client = create_policy_client(signing_key)?;
     let sha = client.add_grouping(&AddGrouping { user: user.to_owned(), role: role.to_owned() }).await
         .context("Failed to add role assignment via PolicyService. Are services running?")?;
 
@@ -562,7 +562,7 @@ pub async fn handle_policy_role_remove(
         }
     }
 
-    let client = create_policy_client(signing_key);
+    let client = create_policy_client(signing_key)?;
     let sha = client.remove_grouping(&RemoveGrouping { user: user.to_owned(), role: role.to_owned() }).await
         .context("Failed to remove role assignment via PolicyService. Are services running?")?;
 
@@ -576,7 +576,7 @@ pub async fn handle_policy_role_list(
     user: Option<&str>,
     role: Option<&str>,
 ) -> Result<()> {
-    let client = create_policy_client(signing_key);
+    let client = create_policy_client(signing_key)?;
     let policy_info = client.get_policy().await
         .context("Failed to get policy from PolicyService. Are services running?")?;
 
@@ -646,7 +646,7 @@ pub async fn handle_policy_apply_template(
     }
 
     // Use PolicyService RPC to apply the template (writes file, validates, stages, commits)
-    let client = create_policy_client(signing_key);
+    let client = create_policy_client(signing_key)?;
     let result_msg = client.apply_template(&ApplyTemplate { name: template_name.to_owned() }).await
         .context("Failed to apply template via PolicyService. Are services running?")?;
 

--- a/crates/hyprstream/src/cli/schema_cli.rs
+++ b/crates/hyprstream/src/cli/schema_cli.rs
@@ -366,7 +366,7 @@ async fn resolve_key_via_policy(
     let policy_vk = signing_key.verifying_key();
     let policy_client = PolicyClient::for_service(
         signing_key.clone(), policy_vk, None,
-    );
+    )?;
     let resp = policy_client.resolve_service_key(
         &crate::services::generated::policy_client::ResolveServiceKey {
             service_name: service_name.to_owned(),
@@ -390,23 +390,23 @@ async fn dispatch_top_level(
             let server_vk = resolve_key_via_policy(&signing_key, "registry").await?;
             let client: RegistryClient = RegistryClient::for_service(
                 signing_key, server_vk, None,
-            );
+            )?;
             client.call_method(method, args).await
         }
         "model" => {
             let server_vk = resolve_key_via_policy(&signing_key, "model").await?;
-            let client = ModelClient::for_service(signing_key, server_vk, None);
+            let client = ModelClient::for_service(signing_key, server_vk, None)?;
             client.call_method(method, args).await
         }
         "inference" => {
             let server_vk = resolve_key_via_policy(&signing_key, "inference").await?;
-            let client = InferenceClient::for_service(signing_key, server_vk, None);
+            let client = InferenceClient::for_service(signing_key, server_vk, None)?;
             client.call_method(method, args).await
         }
         "policy" => {
             // Bootstrap: PolicyService uses the root key
             let server_vk = signing_key.verifying_key();
-            let client = PolicyClient::for_service(signing_key, server_vk, None);
+            let client = PolicyClient::for_service(signing_key, server_vk, None)?;
             client.call_method(method, args).await
         }
         "worker" => {
@@ -432,17 +432,17 @@ async fn dispatch_scoped_dynamic(
             let server_vk = resolve_key_via_policy(&signing_key, "registry").await?;
             let client: RegistryClient = RegistryClient::for_service(
                 signing_key, server_vk, None,
-            );
+            )?;
             client.call_scoped_method(scope_chain, method, args).await
         }
         "model" => {
             let server_vk = resolve_key_via_policy(&signing_key, "model").await?;
-            let client = ModelClient::for_service(signing_key, server_vk, None);
+            let client = ModelClient::for_service(signing_key, server_vk, None)?;
             client.call_scoped_method(scope_chain, method, args).await
         }
         "worker" => {
             let server_vk = resolve_key_via_policy(&signing_key, "worker").await?;
-            let client = WorkerClient::for_service(signing_key, server_vk, None);
+            let client = WorkerClient::for_service(signing_key, server_vk, None)?;
             client.call_scoped_method(scope_chain, method, args).await
         }
         _ => bail!("Service '{}' has no scoped methods", service),

--- a/crates/hyprstream/src/cli/shell_handlers.rs
+++ b/crates/hyprstream/src/cli/shell_handlers.rs
@@ -166,7 +166,7 @@ pub async fn handle_shell_tui(
         signing_key.clone(),
         policy_vk,
         None,
-    );
+    )?;
     let model_vk_resp = policy_client.resolve_service_key(
         &crate::services::generated::policy_client::ResolveServiceKey {
             service_name: "model".to_owned(),
@@ -190,7 +190,7 @@ pub async fn handle_shell_tui(
             signing_key.clone(),
             model_server_vk,
             None,
-        )
+        )?
     };
     // Worker client for sandbox/container/image management.
     let worker_client = {
@@ -198,7 +198,7 @@ pub async fn handle_shell_tui(
             signing_key.clone(),
             worker_server_vk,
             None,
-        )
+        )?
     };
     let registry_server_vk = match policy_client.resolve_service_key(
         &crate::services::generated::policy_client::ResolveServiceKey {
@@ -214,7 +214,7 @@ pub async fn handle_shell_tui(
         signing_key.clone(),
         registry_server_vk,
         None,
-    );
+    )?;
 
     let (model_status_tx, mut model_status_rx) =
         tokio::sync::mpsc::channel::<ModelStatusUpdate>(32);
@@ -1688,9 +1688,15 @@ async fn fetch_models(
 
     // Resolve registry + model keys via PolicyClient
     let policy_vk = signing_key.verifying_key();
-    let policy_client = crate::services::PolicyClient::for_service(
+    let policy_client = match crate::services::PolicyClient::for_service(
         signing_key.clone(), policy_vk, None,
-    );
+    ) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("Failed to create PolicyClient: {e}");
+            return Vec::new();
+        }
+    };
     let registry_server_vk = match policy_client.resolve_service_key(
         &crate::services::generated::policy_client::ResolveServiceKey {
             service_name: "registry".to_owned(),
@@ -1725,17 +1731,29 @@ async fn fetch_models(
     let registry_endpoint = hyprstream_rpc::registry::global()
         .endpoint("registry", hyprstream_rpc::registry::SocketKind::Rep)
         .to_zmq_string();
-    let registry: crate::services::RegistryClient = crate::services::RegistryClient::for_endpoint(
+    let registry: crate::services::RegistryClient = match crate::services::RegistryClient::for_endpoint(
         &registry_endpoint,
         signing_key.clone(),
         registry_server_vk,
         None,
-    );
-    let model_client_for_status = crate::services::generated::model_client::ModelClient::for_service(
+    ) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("Failed to create RegistryClient: {e}");
+            return Vec::new();
+        }
+    };
+    let model_client_for_status = match crate::services::generated::model_client::ModelClient::for_service(
         signing_key.clone(),
         model_server_vk,
         None,
-    );
+    ) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("Failed to create ModelClient: {e}");
+            return Vec::new();
+        }
+    };
     let registry_models_dir = models_dir.to_path_buf();
     let status_timeout = std::time::Duration::from_millis(500);
 

--- a/crates/hyprstream/src/cli/training_handlers.rs
+++ b/crates/hyprstream/src/cli/training_handlers.rs
@@ -397,7 +397,7 @@ pub async fn handle_training_infer(
     let policy_vk = signing_key.verifying_key();
     let policy_client = crate::services::PolicyClient::for_service(
         signing_key.clone(), policy_vk, None,
-    );
+    )?;
     let key_resp = policy_client.resolve_service_key(
         &crate::services::generated::policy_client::ResolveServiceKey {
             service_name: "inference".to_owned(),
@@ -411,7 +411,7 @@ pub async fn handle_training_infer(
         signing_key.clone(),
         inference_vk,
         None,
-    );
+    )?;
 
     // Apply chat template
     let messages = vec![ChatMessage { role: "user".into(), content: prompt.into(), tool_calls: vec![], tool_call_id: String::new() }];
@@ -706,7 +706,7 @@ pub async fn handle_training_batch(
     let policy_vk = signing_key.verifying_key();
     let policy_client = crate::services::PolicyClient::for_service(
         signing_key.clone(), policy_vk, None,
-    );
+    )?;
     let key_resp = policy_client.resolve_service_key(
         &crate::services::generated::policy_client::ResolveServiceKey {
             service_name: "inference".to_owned(),
@@ -720,7 +720,7 @@ pub async fn handle_training_batch(
         signing_key.clone(),
         inference_vk,
         None,
-    );
+    )?;
 
     // Get adapter info for checkpoint saves
     let adapter_manager = AdapterManager::new(&model_path);

--- a/crates/hyprstream/src/cli/tui_handlers.rs
+++ b/crates/hyprstream/src/cli/tui_handlers.rs
@@ -32,9 +32,12 @@ pub fn create_tui_client(signing_key: &SigningKey) -> TuiClient {
 
     // Bootstrap: PolicyService uses the root key in inproc mode
     let policy_vk = signing_key.verifying_key();
-    let policy_client = crate::services::PolicyClient::for_service(
+    let policy_client = match crate::services::PolicyClient::for_service(
         sk.clone(), policy_vk, None,
-    );
+    ) {
+        Ok(c) => c,
+        Err(e) => panic!("Failed to create PolicyClient: {e}"),
+    };
     let server_vk = {
         let resp = tokio::task::block_in_place(|| {
             let rt = tokio::runtime::Handle::current();
@@ -56,7 +59,10 @@ pub fn create_tui_client(signing_key: &SigningKey) -> TuiClient {
         }
     };
 
-    TuiClient::for_endpoint(&endpoint, sk, server_vk, None)
+    match TuiClient::for_endpoint(&endpoint, sk, server_vk, None) {
+        Ok(c) => c,
+        Err(e) => panic!("Failed to create TuiClient: {e}"),
+    }
 }
 
 /// Attach to an existing TUI session.

--- a/crates/hyprstream/src/server/routes/openai.rs
+++ b/crates/hyprstream/src/server/routes/openai.rs
@@ -482,7 +482,13 @@ async fn chat_completions(
             return (StatusCode::INTERNAL_SERVER_ERROR, "Key resolution failed").into_response();
         }
     };
-    let model_client = ModelClient::for_service((*state.signing_key).clone(), model_server_vk, None);
+    let model_client = match ModelClient::for_service((*state.signing_key).clone(), model_server_vk, None) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!("Failed to create ModelClient: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "Client creation failed").into_response();
+        }
+    };
     let _claims = claims_from_auth(&user, jwt_token.as_deref(), jwt_exp);
     // Note: OAI adapter currently creates a fresh client per request.
     // For bearer delegation, use: model_client.request().delegated_bearer(jwt).call(payload)
@@ -711,7 +717,14 @@ async fn stream_chat(state: ServerState, _headers: HeaderMap, request: ChatCompl
                 return;
             }
         };
-        let model_client = ModelClient::for_service((*state.signing_key).clone(), model_server_vk, None);
+        let model_client = match ModelClient::for_service((*state.signing_key).clone(), model_server_vk, None) {
+            Ok(c) => c,
+            Err(e) => {
+                error!("Failed to create ModelClient: {}", e);
+                let _ = tx.send(Err(anyhow::anyhow!("Client creation failed: {}", e))).await;
+                return;
+            }
+        };
         let _claims = claims_from_auth(&user, jwt_token.as_deref(), jwt_exp);
         // Note: For bearer delegation, use: model_client.request().delegated_bearer(jwt).call(payload)
         use crate::services::generated::model_client::InferRpc;
@@ -1059,7 +1072,13 @@ async fn completions(
             return (StatusCode::INTERNAL_SERVER_ERROR, "Key resolution failed").into_response();
         }
     };
-    let model_client = ModelClient::for_service((*state.signing_key).clone(), model_server_vk, None);
+    let model_client = match ModelClient::for_service((*state.signing_key).clone(), model_server_vk, None) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!("Failed to create ModelClient: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "Client creation failed").into_response();
+        }
+    };
     let _claims = claims_from_auth(&user, jwt_token.as_deref(), jwt_exp);
     let result = collect_stream_to_result(&model_client, &request.model, &gen_request).await;
 

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -109,7 +109,7 @@ fn register_service_key(
         signing_key.clone(),
         policy_vk,
         Some(jwt.clone()),
-    );
+    )?;
 
     let request = RegisterServiceKey {
         service_name: service_name.to_owned(),
@@ -206,7 +206,13 @@ fn spawn_jwt_renewal_task(
                 (vk, svc_jwt)
             };
 
-            let policy_client = PolicyClient::for_service(signing_key.clone(), policy_vk, Some(current_jwt));
+            let policy_client = match PolicyClient::for_service(signing_key.clone(), policy_vk, Some(current_jwt)) {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::warn!(service = service_name, error = %e, "failed to create PolicyClient; skipping JWT renewal");
+                    continue;
+                }
+            };
             let req = RefreshServiceTokenRequest { ttl_seconds: 2_592_000 };
 
             match policy_client.refresh_service_token(&req).await {
@@ -365,7 +371,7 @@ fn create_registry_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawn
     let policy_vk = hyprstream_service::global_trust_store()
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
-    let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("registry"));
+    let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("registry"))?;
 
     // Create registry service with infrastructure (blocking since we're in sync context)
     let mut registry_service = tokio::task::block_in_place(|| {
@@ -456,7 +462,7 @@ fn create_model_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnabl
     let policy_vk = hyprstream_service::global_trust_store()
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
-    let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("model"));
+    let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("model"))?;
 
     // Create registry client
     let registry_vk = hyprstream_service::global_trust_store()
@@ -466,7 +472,7 @@ fn create_model_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnabl
         sk.clone(),
         registry_vk,
         service_token("model"),
-    );
+    )?;
 
     #[allow(clippy::expect_used)]
     let mut model_service = tokio::task::block_in_place(|| {
@@ -577,7 +583,7 @@ fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
         sk.clone(),
         policy_vk,
         service_token("worker"),
-    );
+    )?;
     worker_service.set_authorize_fn(super::worker::build_authorize_fn(policy_client));
     if let Some(issuer) = ctx.oauth_issuer_url() {
         worker_service.set_expected_audience(issuer.to_owned());
@@ -614,11 +620,11 @@ fn create_oai_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
     let model_vk = hyprstream_service::global_trust_store()
         .resolve_one("model")
         .ok_or_else(|| anyhow::anyhow!("trust store has no model key"))?;
-    let model_client = ModelClient::for_service(sk.clone(), model_vk, service_token("oai"));
+    let model_client = ModelClient::for_service(sk.clone(), model_vk, service_token("oai"))?;
     let policy_vk = hyprstream_service::global_trust_store()
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
-    let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("oai"));
+    let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("oai"))?;
 
     // Create registry client
     let registry_vk = hyprstream_service::global_trust_store()
@@ -628,7 +634,7 @@ fn create_oai_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
         sk.clone(),
         registry_vk,
         service_token("oai"),
-    );
+    )?;
 
     // Create server state (blocking since we're in sync context)
     let resource_url = config.oai.resource_url();
@@ -693,7 +699,7 @@ fn create_flight_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
                 sk.clone(),
                 registry_vk,
                 service_token("flight"),
-            );
+            )?;
             Some(Arc::new(zmq_client))
         } else {
             None
@@ -814,7 +820,7 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
                 ctx.service_signing_key("mcp"),
                 policy_vk,
                 service_token("mcp"),
-            ));
+            )?);
             std::sync::Arc::new(
                 crate::auth::FederationKeyResolver::new(&config.oauth.trusted_issuers)
                     .with_policy_client(fallback_policy_client)
@@ -1062,7 +1068,7 @@ fn create_tui_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
     let policy_vk = hyprstream_service::global_trust_store()
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
-    let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("tui"));
+    let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("tui"))?;
 
     // Build VFS namespace for ChatApps spawned via TUI RPC.
     let (vfs_ns, vfs_subject) = crate::tui::vfs::build_chat_vfs_namespace(&sk)?;
@@ -1105,7 +1111,7 @@ fn create_discovery_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spaw
     let policy_vk = hyprstream_service::global_trust_store()
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
-    let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("discovery"));
+    let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("discovery"))?;
     let auth_provider = crate::services::discovery::PolicyAuthProvider::new(policy_client);
 
     let mut discovery_service = DiscoveryService::new(
@@ -1163,7 +1169,7 @@ fn create_notification_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn S
     let policy_vk = hyprstream_service::global_trust_store()
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
-    let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("notification"));
+    let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("notification"))?;
 
     let mut notification_service = crate::services::NotificationService::new(
         Arc::new(sk),
@@ -1225,7 +1231,7 @@ fn create_metrics_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawna
     let policy_vk = hyprstream_service::global_trust_store()
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
-    let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("metrics"));
+    let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("metrics"))?;
 
     let mut metrics_service = MetricsService::new(
         orchestrator,

--- a/crates/hyprstream/src/services/inference.rs
+++ b/crates/hyprstream/src/services/inference.rs
@@ -2702,74 +2702,94 @@ impl hyprstream_service::Spawnable for InferenceServiceConfig {
         on_ready: Option<tokio::sync::oneshot::Sender<()>>,
     ) -> hyprstream_rpc::error::Result<()> {
         let transport = self.transport.clone();
-        let context = Arc::clone(&self.zmq_context);
-        let signing_key = self.signing_key.clone();
+        let server_signing_key = self.signing_key.clone();
 
-        let rt = tokio::runtime::Builder::new_current_thread()
+        // Post-ZMQ serve (#136): the GPU `InferenceService` is `!Send`, so build it
+        // on a dedicated LocalServiceBridge thread via `spawn_with`, then serve the
+        // resulting processor over the registered transport with `serve_bridged`.
+        // No ZMQ ROUTER. (QUIC is not enabled on this service.)
+        let rt = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()
             .map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(format!("runtime: {e}")))?;
 
-        let local = tokio::task::LocalSet::new();
-        local.block_on(&rt, async move {
-            // Create nonce cache (shared between service and RequestLoop)
+        rt.block_on(async move {
+            // Shared between the bridge dispatch and the InferenceService.
             let nonce_cache = Arc::new(InMemoryNonceCache::new());
+            let bridge_nonce = Arc::clone(&nonce_cache);
 
-            // Bootstrap: Create PolicyClient HERE, inside the service thread's runtime,
-            // so ZMQ sockets are registered with the correct reactor.
-            let policy_vk = match hyprstream_service::global_trust_store().resolve_one("policy") {
-                Some(vk) => vk,
-                None => {
-                    return Err(hyprstream_rpc::error::RpcError::SpawnFailed(
-                        "trust store has no policy key — startup must populate it".to_owned(),
-                    ));
-                }
-            };
-            let policy_client = PolicyClient::for_service(
-                self.policy_signing_key.clone(),
-                policy_vk,
-                None,
-            );
+            // Destructure so the (Send) config moves into the on-thread builder.
+            let InferenceServiceConfig {
+                model_path,
+                config,
+                server_pubkey,
+                signing_key: svc_signing_key,
+                policy_signing_key,
+                zmq_context,
+                transport: _transport,
+                fs,
+                expected_audience,
+                jwt_key_source,
+            } = *self;
+            let adapter_transport = transport.clone();
 
-            // GPU initialization happens HERE, on the service thread
-            let service = InferenceService::initialize(
-                self.model_path,
-                self.config,
-                self.server_pubkey,
-                self.signing_key.clone(),
-                Arc::clone(&nonce_cache),
-                policy_client,
-                self.fs,
+            // Build PolicyClient + GPU service + adapter ON the bridge thread.
+            let (bridge, ready) = hyprstream_rpc::transport::iroh_rpc::LocalServiceBridge::spawn_with(
+                "inference",
+                move || async move {
+                    let policy_vk = hyprstream_service::global_trust_store()
+                        .resolve_one("policy")
+                        .ok_or_else(|| {
+                            anyhow::anyhow!("trust store has no policy key — startup must populate it")
+                        })?;
+                    let policy_client =
+                        PolicyClient::for_service(policy_signing_key, policy_vk, None)?;
+                    let service = InferenceService::initialize(
+                        model_path,
+                        config,
+                        server_pubkey,
+                        svc_signing_key.clone(),
+                        Arc::clone(&bridge_nonce),
+                        policy_client,
+                        fs,
+                    )
+                    .await
+                    .map_err(|e| anyhow::anyhow!("inference init: {e}"))?;
+                    Ok(InferenceZmqAdapter {
+                        service,
+                        zmq_context,
+                        transport: adapter_transport,
+                        signing_key: svc_signing_key,
+                        expected_audience,
+                        jwt_key_source,
+                    })
+                },
+                nonce_cache,
+                0,
+            )
+            .map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(format!("bridge: {e}")))?;
+
+            // Surface GPU-init failure before advertising readiness.
+            ready
+                .await
+                .map_err(|_| {
+                    hyprstream_rpc::error::RpcError::SpawnFailed(
+                        "inference bridge readiness dropped".to_owned(),
+                    )
+                })?
+                .map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(format!("init: {e}")))?;
+
+            let processor: Arc<dyn hyprstream_rpc::transport::rpc_session::IrohRequestProcessor> =
+                Arc::new(bridge);
+            hyprstream_rpc::service::serve::serve_bridged(
+                &transport,
+                processor,
+                server_signing_key,
+                shutdown,
+                on_ready,
             )
             .await
-            .map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(format!("init: {e}")))?;
-
-            // Create RequestService adapter for RequestLoop
-            let adapter = InferenceZmqAdapter {
-                service,
-                zmq_context: context.clone(),
-                transport: transport.clone(),
-                signing_key: signing_key.clone(),
-                expected_audience: self.expected_audience,
-                jwt_key_source: self.jwt_key_source,
-            };
-
-            // Use shared nonce cache between service and RequestLoop
-            let runner = RequestLoop::new(transport, context, signing_key)
-                .with_nonce_cache(nonce_cache);
-            let mut handle = runner.run(adapter).await
-                .map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(format!("loop: {e}")))?;
-
-            if let Some(tx) = on_ready {
-                let _ = tx.send(());
-            }
-
-            // Notify systemd that service is ready (for Type=notify services)
-            let _ = hyprstream_rpc::notify::ready();
-
-            shutdown.notified().await;
-            handle.stop().await;
-            Ok::<_, hyprstream_rpc::error::RpcError>(())
+            .map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(e.to_string()))
         })
     }
 }

--- a/crates/hyprstream/src/services/mcp_service.rs
+++ b/crates/hyprstream/src/services/mcp_service.rs
@@ -428,12 +428,12 @@ fn register_scoped_tools_recursive(
                                     let server_vk = ctx.resolve_peer_key("registry").await?;
                                     let client: RegistryClient = RegistryClient::for_service(
                                         ctx.signing_key, server_vk, None,
-                                    );
+                                    )?;
                                     client.call_scoped_streaming_method(&scope_refs, &method, &ctx.args, client_pubkey_bytes).await?
                                 }
                                 "model" => {
                                     let server_vk = ctx.resolve_peer_key("model").await?;
-                                    let client = ModelClient::for_service(ctx.signing_key, server_vk, None);
+                                    let client = ModelClient::for_service(ctx.signing_key, server_vk, None)?;
                                     client.call_scoped_streaming_method(&scope_refs, &method, &ctx.args, client_pubkey_bytes).await?
                                 }
                                 _ => anyhow::bail!("No scoped streaming dispatch for service: {service}"),
@@ -515,12 +515,12 @@ async fn dispatch_scoped_call(
             let server_vk = ctx.resolve_peer_key("registry").await?;
             let client: RegistryClient = RegistryClient::for_service(
                 ctx.signing_key.clone(), server_vk, None,
-            );
+            )?;
             client.call_scoped_method(scopes, method, &ctx.args).await?
         }
         "model" => {
             let server_vk = ctx.resolve_peer_key("model").await?;
-            let client = ModelClient::for_service(ctx.signing_key.clone(), server_vk, None);
+            let client = ModelClient::for_service(ctx.signing_key.clone(), server_vk, None)?;
             client.call_scoped_method(scopes, method, &ctx.args).await?
         }
         _ => anyhow::bail!("No scoped dispatch for service: {service}"),
@@ -583,17 +583,17 @@ fn register_streaming_tool(
                         let server_vk = ctx.resolve_peer_key("registry").await?;
                         let client: RegistryClient = RegistryClient::for_service(
                             ctx.signing_key, server_vk, None,
-                        );
+                        )?;
                         client.call_streaming_method(&method, &ctx.args, client_pubkey_bytes).await?
                     }
                     "model" => {
                         let server_vk = ctx.resolve_peer_key("model").await?;
-                        let client = ModelClient::for_service(ctx.signing_key, server_vk, None);
+                        let client = ModelClient::for_service(ctx.signing_key, server_vk, None)?;
                         client.call_streaming_method(&method, &ctx.args, client_pubkey_bytes).await?
                     }
                     "tui" => {
                         let server_vk = ctx.resolve_peer_key("tui").await?;
-                        let client = TuiClient::for_service(ctx.signing_key, server_vk, None);
+                        let client = TuiClient::for_service(ctx.signing_key, server_vk, None)?;
                         client.call_streaming_method(&method, &ctx.args, client_pubkey_bytes).await?
                     }
                     _ => anyhow::bail!("No streaming support for service: {}", service),
@@ -676,24 +676,24 @@ async fn dispatch_schema_call(service: &str, method: &str, ctx: &ToolCallContext
     match service {
         "model" => {
             let server_vk = ctx.resolve_peer_key("model").await?;
-            let client = ModelClient::for_service(signing_key, server_vk, None);
+            let client = ModelClient::for_service(signing_key, server_vk, None)?;
             client.call_method(method, &ctx.args).await
         }
         "registry" => {
             let server_vk = ctx.resolve_peer_key("registry").await?;
             let client: RegistryClient = RegistryClient::for_service(
                 signing_key, server_vk, None,
-            );
+            )?;
             client.call_method(method, &ctx.args).await
         }
         "policy" => {
             let server_vk = ctx.resolve_peer_key("policy").await?;
-            let client = PolicyClient::for_service(signing_key, server_vk, None);
+            let client = PolicyClient::for_service(signing_key, server_vk, None)?;
             client.call_method(method, &ctx.args).await
         }
         "tui" => {
             let server_vk = ctx.resolve_peer_key("tui").await?;
-            let client = TuiClient::for_service(signing_key, server_vk, None);
+            let client = TuiClient::for_service(signing_key, server_vk, None)?;
             client.call_method(method, &ctx.args).await
         }
         _ => anyhow::bail!("Unknown service: {service}"),
@@ -743,7 +743,7 @@ impl McpService {
             config.signing_key.clone(),
             config.policy_verifying_key,
             None,
-        );
+        )?;
 
         Ok(Self {
             registry: Arc::new(RwLock::new(tool_reg)),
@@ -1039,7 +1039,7 @@ impl McpHandler for McpService {
                 self.signing_key.clone(),
                 server_vk,
                 None,
-            );
+            )?;
             client.status(&crate::services::generated::model_client::StatusRequest { model_ref: String::new() }).await
                 .map(|models| models.len() as u32)
                 .unwrap_or(0)

--- a/crates/hyprstream/src/services/metrics.rs
+++ b/crates/hyprstream/src/services/metrics.rs
@@ -695,7 +695,7 @@ mod tests {
             signing_key.clone(),
             signing_key.verifying_key(),
             None,
-        );
+        ).expect("create policy client");
 
         // In-memory DuckDB backend + metrics table creation.
         let backend = Arc::new(
@@ -735,7 +735,7 @@ mod tests {
             signing_key.clone(),
             signing_key.verifying_key(),
             None,
-        );
+        ).expect("create metrics client");
 
         (client, manager)
     }

--- a/crates/hyprstream/src/services/model.rs
+++ b/crates/hyprstream/src/services/model.rs
@@ -204,7 +204,7 @@ impl ModelService {
             signing_key.clone(),
             notif_vk,
             None,
-        );
+        )?;
         let notification_publisher = NotificationPublisher::new(notif_client, signing_key.clone());
 
         Ok(Self { inner: Arc::new(ModelServiceInner {
@@ -282,7 +282,7 @@ impl ModelService {
             signing_key.clone(),
             notif_vk,
             None,
-        );
+        )?;
         let notification_publisher = NotificationPublisher::new(notif_client, signing_key.clone());
 
         Ok(Self { inner: Arc::new(ModelServiceInner {
@@ -420,7 +420,7 @@ impl ModelService {
             self.signing_key.clone(),
             self.signing_key.verifying_key(),
             None,
-        );
+        )?;
 
         // Load TTT config from model's config.json (if TTT is enabled)
         let ttt_config = crate::runtime::model_config::ModelConfig::load_training_config(&model_path)

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -688,8 +688,11 @@ impl Spawnable for OAuthService {
             // Run HTTP(S) server with graceful shutdown
             let _ = crate::server::tls::serve_app(addr, app, rustls_config, shutdown, "OAuthService").await;
 
-            // HTTP server stopped — stop the RPC serve and join it.
-            serve_shutdown.notify_waiters();
+            // HTTP server stopped — stop the RPC serve and join it. notify_one
+            // (not notify_waiters) stores a permit if the serve task hasn't yet
+            // armed its `notified()` await, so the signal can't be missed even if
+            // the HTTP server exited before the RPC task reached serve_bridged.
+            serve_shutdown.notify_one();
             let _ = rpc_loop.await;
 
             Ok(())

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -70,7 +70,6 @@ use axum::{
     Router,
 };
 use hyprstream_rpc::registry::SocketKind;
-use hyprstream_rpc::service::{RequestLoop, RequestService};
 use hyprstream_rpc::transport::TransportConfig;
 use hyprstream_service::Spawnable;
 use tokio::sync::Notify;
@@ -360,7 +359,9 @@ impl Spawnable for OAuthService {
                 self.signing_key.clone(),
                 policy_vk,
                 None,
-            );
+            ).map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(
+                format!("failed to create PolicyClient: {e}"),
+            ))?;
 
             // Get discovery key from trust store (populated by depends_on = ["discovery"]).
             // Using trust store avoids RPC calls which require LocalSet context.
@@ -376,7 +377,9 @@ impl Spawnable for OAuthService {
                 self.signing_key.clone(),
                 discovery_vk,
                 None,
-            );
+            ).map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(
+                format!("failed to create DiscoveryClient: {e}"),
+            ))?;
 
             let credentials_dir = crate::config::HyprConfig::load()
                 .map(|c| c.config_dir().join("credentials"))
@@ -638,32 +641,56 @@ impl Spawnable for OAuthService {
 
             let _ = hyprstream_rpc::notify::ready();
 
-            // ZMQ RPC loop for user CRUD (alongside HTTP server)
-            // Must use spawn_local because RequestLoop uses spawn_local internally
-            let zmq_transport = self.control_transport.clone();
-            let zmq_context = Arc::clone(&self.context);
-            let zmq_signing_key = self.signing_key.clone();
-            let zmq_state = state.clone();
-            let zmq_loop = tokio::task::spawn_local(async move {
+            // User-CRUD RPC serve, alongside the HTTP server. #136: bridged
+            // dispatch over the registered transport (inproc/ipc) instead of the
+            // ZMQ ROUTER. A dedicated `serve_shutdown` stops it once the HTTP
+            // server exits, so the task joins cleanly.
+            let control_transport = self.control_transport.clone();
+            let rpc_context = Arc::clone(&self.context);
+            let rpc_signing_key = self.signing_key.clone();
+            let rpc_state = state.clone();
+            let serve_shutdown = Arc::new(Notify::new());
+            let serve_shutdown_task = Arc::clone(&serve_shutdown);
+            let rpc_loop = tokio::task::spawn_local(async move {
                 let handler = zmq_handler::OAuthZmqHandler::new(
-                    zmq_state,
-                    zmq_context,
-                    zmq_transport,
-                    zmq_signing_key,
+                    rpc_state,
+                    rpc_context,
+                    control_transport.clone(),
+                    rpc_signing_key.clone(),
                 );
-                let zmq_transport = RequestService::transport(&handler).clone();
-                let zmq_context = Arc::clone(RequestService::context(&handler));
-                let zmq_signing_key = RequestService::signing_key(&handler);
-                let loop_ = RequestLoop::new(zmq_transport, zmq_context, zmq_signing_key);
-                if let Err(e) = loop_.run(handler).await {
-                    tracing::error!("OAuth ZMQ loop error: {}", e);
+                let nonce_cache = Arc::new(hyprstream_rpc::envelope::InMemoryNonceCache::new());
+                let bridge = match hyprstream_rpc::transport::iroh_rpc::LocalServiceBridge::spawn(
+                    handler,
+                    nonce_cache,
+                    0,
+                ) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        tracing::error!("OAuth RPC bridge spawn error: {}", e);
+                        return;
+                    }
+                };
+                let processor: Arc<dyn hyprstream_rpc::transport::rpc_session::IrohRequestProcessor> =
+                    Arc::new(bridge);
+                if let Err(e) = hyprstream_rpc::service::serve::serve_bridged(
+                    &control_transport,
+                    processor,
+                    rpc_signing_key,
+                    serve_shutdown_task,
+                    None,
+                )
+                .await
+                {
+                    tracing::error!("OAuth RPC serve error: {}", e);
                 }
             });
 
             // Run HTTP(S) server with graceful shutdown
             let _ = crate::server::tls::serve_app(addr, app, rustls_config, shutdown, "OAuthService").await;
 
-            let _ = zmq_loop.await;
+            // HTTP server stopped — stop the RPC serve and join it.
+            serve_shutdown.notify_waiters();
+            let _ = rpc_loop.await;
 
             Ok(())
         })

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -2791,7 +2791,7 @@ mod tests {
             signing_key.clone(),
             signing_key.verifying_key(),
             None,
-        );
+        ).expect("test: create policy client");
 
         // Start the registry service with policy client
         let registry_transport = TransportConfig::inproc("test-registry-health");
@@ -2810,7 +2810,7 @@ mod tests {
             signing_key.clone(),
             signing_key.verifying_key(),
             None,
-        );
+        ).expect("test: create registry client");
         // health_check returns () on success
         let result = client.health_check().await;
         assert!(result.is_ok(), "health_check should succeed: {:?}", result.err());

--- a/crates/hyprstream/src/tui/service.rs
+++ b/crates/hyprstream/src/tui/service.rs
@@ -825,7 +825,7 @@ impl TuiService {
             self.signing_key.clone(),
             policy_vk,
             None,
-        );
+        )?;
 
         let registry_key_resp = policy_client.resolve_service_key(
             &crate::services::generated::policy_client::ResolveServiceKey {
@@ -857,12 +857,12 @@ impl TuiService {
                     self.signing_key.clone(),
                     registry_vk,
                     None,
-                );
+                )?;
             let model_client_for_status = crate::services::generated::model_client::ModelClient::for_service(
                 self.signing_key.clone(),
                 model_vk,
                 None,
-            );
+            )?;
             let status_timeout = std::time::Duration::from_millis(500);
             let all_status_req = crate::services::generated::model_client::StatusRequest { model_ref: String::new() };
             let (repos_result, status_result) = tokio::join!(
@@ -912,11 +912,17 @@ impl TuiService {
                 let vk  = model_vk_load;
                 // Submit load — returns "accepted" immediately (Continuation pattern).
                 h.block_on(async {
-                    let client = crate::services::generated::model_client::ModelClient::for_service(
+                    let client = match crate::services::generated::model_client::ModelClient::for_service(
                         sk.clone(),
                         vk,
                         None,
-                    );
+                    ) {
+                        Ok(c) => c,
+                        Err(e) => {
+                            tracing::warn!("Failed to create ModelClient: {e}");
+                            return;
+                        }
+                    };
                     let _ = client.load(&crate::services::generated::model_client::LoadModelRequest {
                         model_ref: mr.clone(),
                         max_context: None,
@@ -932,11 +938,17 @@ impl TuiService {
                     for _ in 0..60u32 {   // max ~2 minutes (60 × 2 s)
                         std::thread::sleep(std::time::Duration::from_secs(2));
                         let loaded = h_poll.block_on(async {
-                            let client = crate::services::generated::model_client::ModelClient::for_service(
+                            let client = match crate::services::generated::model_client::ModelClient::for_service(
                                 sk_poll.clone(),
                                 vk_poll,
                                 None,
-                            );
+                            ) {
+                                Ok(c) => c,
+                                Err(e) => {
+                                    tracing::warn!("Failed to create ModelClient: {e}");
+                                    return false;
+                                }
+                            };
                             client.status(&crate::services::generated::model_client::StatusRequest { model_ref: mr_poll.clone() }).await
                                 .is_ok_and(|es| es.iter().any(|e| e.status == "loaded"))
                         });
@@ -956,11 +968,17 @@ impl TuiService {
             let sk = sk_unload.clone();
             let mr = model_ref.to_owned();
             handle_unload.block_on(async move {
-                let client = crate::services::generated::model_client::ModelClient::for_service(
+                let client = match crate::services::generated::model_client::ModelClient::for_service(
                     sk.clone(),
                     model_vk_unload,
                     None,
-                );
+                ) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        tracing::warn!("Failed to create ModelClient: {e}");
+                        return false;
+                    }
+                };
                 client.unload(&crate::services::generated::model_client::UnloadModelRequest { model_ref: mr.clone() }).await.is_ok()
             })
         });
@@ -981,7 +999,13 @@ impl TuiService {
                 let rmd = rmd_clone.clone();
                 std::thread::spawn(move || {
                     h.block_on(async {
-                        let registry = crate::services::RegistryClient::for_service(sk, rvk, None);
+                        let registry = match crate::services::RegistryClient::for_service(sk, rvk, None) {
+                            Ok(c) => c,
+                            Err(e) => {
+                                let _ = tx.send(GitOpProgress::Failed(format!("Failed to create RegistryClient: {e}")));
+                                return;
+                            }
+                        };
                         let model_name = name.unwrap_or_else(|| {
                             url.rsplit('/').next().unwrap_or("model")
                                 .trim_end_matches(".git").to_owned()
@@ -1076,7 +1100,13 @@ impl TuiService {
                 let rvk = rvk_pull;
                 std::thread::spawn(move || {
                     h.block_on(async {
-                        let registry = crate::services::RegistryClient::for_service(sk, rvk, None);
+                        let registry = match crate::services::RegistryClient::for_service(sk, rvk, None) {
+                            Ok(c) => c,
+                            Err(e) => {
+                                let _ = tx.send(GitOpProgress::Failed(format!("Failed to create RegistryClient: {e}")));
+                                return;
+                            }
+                        };
                         let model_name = model_ref.split(':').next().unwrap_or(&model_ref);
                         let tracked = match registry.get_by_name(model_name).await {
                             Ok(t) => t,
@@ -1111,7 +1141,13 @@ impl TuiService {
                 let rvk = rvk_push;
                 std::thread::spawn(move || {
                     h.block_on(async {
-                        let registry = crate::services::RegistryClient::for_service(sk, rvk, None);
+                        let registry = match crate::services::RegistryClient::for_service(sk, rvk, None) {
+                            Ok(c) => c,
+                            Err(e) => {
+                                let _ = tx.send(GitOpProgress::Failed(format!("Failed to create RegistryClient: {e}")));
+                                return;
+                            }
+                        };
                         let model_name = model_ref.split(':').next().unwrap_or(&model_ref);
                         let branch = model_ref.split(':').nth(1).unwrap_or("main");
                         let tracked = match registry.get_by_name(model_name).await {
@@ -1152,7 +1188,13 @@ impl TuiService {
                 let rvk = rvk_status;
                 std::thread::spawn(move || {
                     h.block_on(async {
-                        let registry = crate::services::RegistryClient::for_service(sk, rvk, None);
+                        let registry = match crate::services::RegistryClient::for_service(sk, rvk, None) {
+                            Ok(c) => c,
+                            Err(e) => {
+                                tracing::warn!("Failed to create RegistryClient: {e}");
+                                return;
+                            }
+                        };
                         for mr in model_refs {
                             let model_name = mr.split(':').next().unwrap_or(&mr);
                             if let Ok(tracked) = registry.get_by_name(model_name).await {

--- a/crates/hyprstream/src/tui/vfs.rs
+++ b/crates/hyprstream/src/tui/vfs.rs
@@ -117,7 +117,7 @@ pub fn build_chat_vfs_namespace(
         signing_key.clone(),
         policy_vk,
         None,
-    );
+    )?;
     let model_vk_resp = tokio::task::block_in_place(|| {
         let rt = tokio::runtime::Handle::current();
         rt.block_on(policy_client.resolve_service_key(
@@ -137,7 +137,7 @@ pub fn build_chat_vfs_namespace(
         signing_key.clone(),
         model_vk,
         None,
-    );
+    )?;
     let remote_model_mount = crate::services::remote_mount::RemoteModelMount::new(model_client);
     let _ = ns.mount("/srv/model", Arc::new(remote_model_mount));
 

--- a/crates/hyprstream/src/tui/zmq_transport.rs
+++ b/crates/hyprstream/src/tui/zmq_transport.rs
@@ -61,11 +61,17 @@ pub fn make_chat_spawner(
             rt.block_on(async move {
                 // Resolve model service key via PolicyClient.
                 let policy_vk = sk_inner.verifying_key();
-                let policy_client = crate::services::PolicyClient::for_service(
+                let policy_client = match crate::services::PolicyClient::for_service(
                     sk_inner.clone(),
                     policy_vk,
                     None,
-                );
+                ) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        let _ = tx.send(ChatEvent::StreamError(format!("Failed to create PolicyClient: {e}")));
+                        return;
+                    }
+                };
                 let model_key_resp = match policy_client.resolve_service_key(
                     &crate::services::generated::policy_client::ResolveServiceKey {
                         service_name: "model".to_owned(),
@@ -91,7 +97,13 @@ pub fn make_chat_spawner(
                     }
                 };
                 let model_client =
-                    ModelClient::for_service(sk_inner.clone(), model_vk, None);
+                    match ModelClient::for_service(sk_inner.clone(), model_vk, None) {
+                        Ok(c) => c,
+                        Err(e) => {
+                            let _ = tx.send(ChatEvent::StreamError(format!("Failed to create ModelClient: {e}")));
+                            return;
+                        }
+                    };
 
                 // Map ChatHistoryEntry → ChatMessage, handling all roles.
                 // Skip the trailing empty assistant placeholder — it's only a
@@ -275,7 +287,7 @@ pub fn make_tool_caller(
                     sk_fetch.clone(),
                     policy_vk,
                     None,
-                );
+                ).ok()?;
                 let mcp_key_resp = policy_client.resolve_service_key(
                     &crate::services::generated::policy_client::ResolveServiceKey {
                         service_name: "mcp".to_owned(),
@@ -285,7 +297,7 @@ pub fn make_tool_caller(
                     mcp_key_resp.verifying_key.as_slice().try_into().ok()?
                 ).ok()?;
                 let gen: GenMcpClient =
-                    GenMcpClient::for_endpoint(&endpoint, sk_fetch, mcp_vk, None);
+                    GenMcpClient::for_endpoint(&endpoint, sk_fetch, mcp_vk, None).ok()?;
                 let tool_list = gen.list_tools().await.ok()?;
                 let mut descs = HashMap::new();
                 let mut tools = Vec::new();
@@ -329,11 +341,14 @@ pub fn make_tool_caller(
                     rt.block_on(async move {
                         // Resolve MCP service key via PolicyClient.
                         let policy_vk = sk_c.verifying_key();
-                        let policy_client = crate::services::PolicyClient::for_service(
+                        let policy_client = match crate::services::PolicyClient::for_service(
                             sk_c.clone(),
                             policy_vk,
                             None,
-                        );
+                        ) {
+                            Ok(c) => c,
+                            Err(e) => return format!("error: failed to create PolicyClient: {e}"),
+                        };
                         let mcp_vk = match policy_client.resolve_service_key(
                             &crate::services::generated::policy_client::ResolveServiceKey {
                                 service_name: "mcp".to_owned(),
@@ -351,7 +366,11 @@ pub fn make_tool_caller(
                             },
                             Err(e) => return format!("error: failed to resolve MCP key: {e}"),
                         };
-                        match GenMcpClient::for_endpoint(&endpoint, sk_c, mcp_vk, None)
+                        let mcp_client = match GenMcpClient::for_endpoint(&endpoint, sk_c, mcp_vk, None) {
+                            Ok(c) => c,
+                            Err(e) => return format!("error: failed to create McpClient: {e}"),
+                        };
+                        match mcp_client
                             .call_tool(&crate::services::generated::mcp_client::CallTool {
                                 tool_name: uuid_c,
                                 arguments,

--- a/docs/plans/2026-06-11-136-rpc-cutover.md
+++ b/docs/plans/2026-06-11-136-rpc-cutover.md
@@ -1,0 +1,140 @@
+# #136 — RPC production cutover (M1 exit)
+
+2026-06-11. Replace the ZMQ `RequestLoop`/ROUTER on the spawn path with the
+generic dispatch plane over the dial layer, for **all spawn-path services at
+once** (one switch, not a parallel plane). This is the M1 flip everything in the
+`#151(a)` sub-stack was built to enable.
+
+## Prereqs — all landed (the dial-layer sub-stack)
+
+| Piece | Branch | Status |
+|---|---|---|
+| `process_request` dispatch core | `moq-148` (#194) | merged-track |
+| `dial()` factory + in-process transport + inproc registry | `moq-151a` (#195) | reviewed |
+| `LazyQuinnTransport` + cert-pin Quic | `moq-151b` (#198) | reviewed |
+| `LazyIrohTransport` + iroh dial | `moq-151c` (#199) | reviewed |
+| `QuicServerAuth` policy (WebPKI / pin-set / WebPKI+pin) | `moq-151d`/`151e` | reviewed |
+| DID-doc transport service-entry codec | `moq-151f` | reviewed |
+| `UdsSession` — `Session` over UnixStream (ipc plane, RPC + moq) | `moq-151g` | reviewed (#207 follow-up) |
+| `Continuation` killed at the dispatch boundary | `moq-186` (#196) | reviewed |
+
+So the client dial path, channel auth, addressing wire format, and streaming
+bootstrap are all in place. `#136` is the **server-side flip** + wiring.
+
+## The pieces of the cutover
+
+1. **Daemon provisions prod transport listeners.** Today `QuinnRpcServer` /
+   iroh substrate are test-only. The daemon must, at bootstrap, bind the QUIC
+   baseline listener (+ optional iroh) and register each service's endpoint
+   **pinned** (`quic_pinned`, already wired in `moq-151e`'s registration sites)
+   so clients can dial it. Server cert chain/key live *outside* `TransportConfig`
+   (it is wire-published) — keep them in a server-config path.
+
+2. **Resolver registration.** `resolver::set_global(...)` so `dial()`/codegen can
+   turn a service name → `TransportConfig`. Bootstrap can register the existing
+   `EndpointRegistry` resolver immediately (local, already implemented); the
+   `DidWebResolver` (HTTPS fetch + `#mesh` binding, consuming `moq-151f`'s codec)
+   slots in later for cross-node did:web dialing.
+
+3. **Codegen de-leak (R3).** Rewire generated `for_endpoint` to call `dial()`
+   instead of hardcoding `ZmqConnection::new`. This **changes generated client
+   constructor signatures** (takes `TransportConfig`, not an endpoint string)
+   across ~95 call sites — the highest-blast-radius change. ZMQ `ipc://`/systemd
+   endpoints stay on the codegen path during the transition (`dial()` bails on
+   them today, by design).
+
+4. **`Spawnable::run` cutover.** Replace the ZMQ `RequestLoop` with the generic
+   serve path (`QuinnRpcServer` / the iroh accept loop driving `process_request`)
+   for all spawn-path services. Note the runtime-shape gap (spike): `Spawnable::run`
+   is sync with its own `LocalSet`; `QuinnRpcServer::run` is async on the main
+   runtime — needs a Spawnable adapter.
+
+5. **Streaming bootstrap** — already de-coupled (`#186`): `process_request` spawns
+   the streaming pump itself; nothing to thread.
+
+## Approach: hard cut (settled 2026-06-11)
+
+Nothing here is merged or deployed; there are no production users and no prior
+release in production. So there is **no rollback path to preserve** and **no
+feature flag** — a parallel ZMQ-RPC plane behind a config knob would be pure dead
+weight (two code paths, doubled test matrix) guarding a safety net no one can
+use. The spawn-path RPC services flip from the ZMQ `RequestLoop` to the
+dial/dispatch plane in one go.
+
+"Irreversible" is the wrong frame: anything pre-merge reverts trivially. The two
+real constraints are ordinary:
+
+- **Commit sequencing (keep the stack green), not rollback.** Each stacked commit
+  must still build + test. Land the listener provisioning + `resolver::set_global`
+  *before/with* the codegen de-leak, so the moment generated clients call
+  `dial()` there is something to dial. This is "no broken intermediate commit,"
+  not "keep an escape hatch."
+- **The codegen de-leak is atomic, not irreversible.** ~95 generated
+  `for_endpoint` sites change constructor signature in one sweep — do it all at
+  once and verify with the build; it can't land half-done. Annoying to review,
+  trivial to revert.
+
+Scope note: the cut is narrower than "rip out ZMQ." `#136` is **RPC spawn-path
+services only**; ZMQ-the-dependency stays in-tree for the planes this ticket
+doesn't touch (EventService, CLI/SUB → #138/N-cli). Confirm no spawn-path service
+must stay on ZMQ past the switch (`zmq_connection.rs` consumers are M5/#138).
+
+### Still open — one technical spike (not a policy call)
+
+- **`Spawnable::run` runtime-shape gap.** `Spawnable::run` is sync with its own
+  `LocalSet`; `QuinnRpcServer::run` is async on the main runtime. The serve path
+  needs a small adapter. See the spike notes below.
+- **#187 (per-listener vs process-global verify policy)** — closed as superseded
+  by #158, but re-check if the cutover runs a Classical-tolerant browser listener
+  in-process before #158.
+
+## Spike: `Spawnable::run` runtime-shape gap — resolved (the adapter exists)
+
+Investigated 2026-06-11. The gap is real but **already solved by an existing
+component** — it's a wiring choice, not new architecture.
+
+The shapes:
+- `Spawnable::run` (`service/spawnable.rs`) is **sync/blocking**, runs on a
+  **dedicated OS thread**, builds its own runtime + **`LocalSet`**, and drives
+  `RequestLoop`, which wraps the service in `Rc<>` — so spawn-path services may
+  be **`!Send`** (e.g. `InferenceService` holding tch-rs tensors).
+- `QuinnRpcServer::run` / `serve_rpc_connection` are **async on the shared
+  multi-thread runtime** and require the processor (`IrohRequestProcessor`) to be
+  **`Send + Sync + 'static`**.
+
+The adapter: **`LocalServiceBridge`** (`transport/iroh_rpc.rs`) already bridges
+exactly this. It spins a dedicated thread with a current-thread runtime +
+`LocalSet`, keeps the `!Send` service there (wrapped in `Rc`), and exposes a
+`Send + Sync` `IrohRequestProcessor` via an mpsc request + oneshot response
+channel. The iroh accept loop already uses it; quinn and UDS serve paths take the
+same `Arc<dyn IrohRequestProcessor>`, so they reuse it unchanged.
+
+**Chosen shape (a):** keep each spawn-path service on its own OS thread +
+`LocalSet`; wrap it in `LocalServiceBridge`; hand the bridge to
+`QuinnRpcServer` / the iroh handler / the UDS `UnixListener` accept loop. No
+service rewrite, GPU/tensor thread-confinement preserved. Rejected: (b) moving
+services onto the shared runtime is infeasible — tch-rs is genuinely `!Send`.
+
+Bonus cleanup this enables: `InferenceService`'s current `unsafe impl Send + Sync`
+(a soundness smell that only holds because the service never actually crosses
+threads) can be **removed** — the bridge keeps it authentically `!Send` and
+thread-confined. The serve path needs the bridge, not a fake `Send` claim.
+
+Cutover wiring touch-points: `ServiceSpawner` (wrap service in
+`LocalServiceBridge` before the serve path), the quinn/iroh/UDS handler
+construction (accept `Arc<dyn IrohRequestProcessor>`), and removing the
+`unsafe impl` in `inference.rs`. `Spawnable::run`'s signature does **not** change.
+
+## Out of scope (later milestones)
+
+EventService/StreamService → moq (M2: #167/#134/N6/N7), CLI/client migration
+(N-cli), ZMQ teardown + `cargo deny` no-zmq gate (M5/#138), browser FE reframe
+(M4). `#136` is **RPC spawn-path services only**.
+
+## Exit criteria
+
+Daemon serves all spawn-path RPC over the QUIC baseline (+ ipc via `UdsSession`)
+through `dial()` + the generic dispatch plane; the ZMQ `RequestLoop`/ROUTER path
+is deleted for those services and the full test suite is green. `grep` still
+shows ZMQ for the not-yet-migrated planes (EventService, CLI) — those are
+separate tickets.

--- a/docs/plans/2026-06-11-uds-session-spike.md
+++ b/docs/plans/2026-06-11-uds-session-spike.md
@@ -1,0 +1,135 @@
+# Spike — `UdsSession`: one `web_transport_trait::Session` over UnixStream
+
+> **STATUS (2026-06-11): BUILT** as `moq-151g`
+> (`crates/hyprstream-rpc/src/transport/uds_session.rs`, yamux-backed). 9 tests
+> green (incl. real RPC plane via `SessionRpcTransport`/`serve_rpc_connection`
+> and full moq publish/subscribe over UDS); release clippy clean. Code +
+> security review done — fixes applied (concurrent-stream cap, tag-read timeout,
+> fail-closed plane validation, observability). One follow-up filed: **#207**
+> (socket perms + `SO_PEERCRED`, daemon/#136 scope). Feeds #136's `dial()` ipc
+> arm + daemon `UnixListener` provisioning.
+>
+> Review caught a real defect: `SendStream::closed()` must *detect* closure, not
+> *cause* it — an early impl called `close()` inside `closed()`, so moq's
+> `select! { biased; _ = stream.closed() => cancel }` in `serve_group` aborted
+> every group right after its header, truncating all frames. Fixed.
+
+2026-06-11. Decision input for the ipc-transport re-platform (ZMQ-over-`ipc://` →
+SignedEnvelope-over-UDS) and #136's `dial()` ipc arm. Question answered:
+**can the same UDS transport carry both the RPC plane and the moq streaming
+plane?** Answer: **yes**, via one `web_transport_trait::Session` impl.
+
+## Why one impl covers both planes
+
+`moq-net 0.1.8` is fully generic over `web_transport_trait::Session`:
+
+- `Server::accept<S: web_transport_trait::Session>(&self, session: S)` — `server.rs:54`
+- `Client::connect<S: web_transport_trait::Session>(&self, session: S)` — `client.rs:54`
+- `moq_net::Session` type-erases via blanket `impl<S: web_transport_trait::Session>
+  SessionInner for S` → `Arc<dyn SessionInner>` — `session.rs:144`
+- moq-net's own tests ship a hand-rolled `FakeSession` (non-quinn/non-iroh) and run
+  full SETUP negotiation over it — the genericity is real, not incidental.
+
+So one `UdsSession: web_transport_trait::Session` serves:
+- **RPC plane** → `SessionRpcTransport` (`open_bi` → SignedEnvelope req/resp)
+- **Streaming plane** → `moq_net::Client::connect(uds_session)` / `Server::accept`
+
+exactly as quinn/iroh do today. Everything layered above the trait is transport-agnostic.
+
+## What moq-lite actually requires of the Session (the contract)
+
+| Capability | Required by moq-lite? | Evidence | UDS impl |
+|---|---|---|---|
+| `open_bi` / `accept_bi` | **Yes** — one SETUP control stream | `coding/stream.rs:25` `Stream::open`→`open_bi`; client negotiates Lite version over it (`client.rs:180+`) | mux bidi stream |
+| `open_uni` / `accept_uni` | **Yes** — one per Group | `lite/publisher.rs:484`, `lite/subscriber.rs:93` | mux uni stream |
+| `send_datagram` / `recv_datagram` / `max_datagram_size` | **No** — zero datagram refs in `lite/`; datagrams are IETF-draft-only (`ietf/adapter.rs`) | trait still requires the methods | stub: `max_datagram_size()→0`, `send/recv → Err(Closed)` |
+| ALPN `protocol()` | optional | `None` → manual version negotiation arm `Some(ALPN_LITE) | None` (`client.rs:174`) | return `None`; moq negotiates Lite over the control stream |
+
+Net: genuine concurrent stream multiplexing (1 bidi + N uni), **no datagrams, no ALPN**.
+
+## Multiplexer: yamux (already in-tree)
+
+A `UnixStream` is one ordered byte-stream; QUIC/iroh provide stream multiplexing
+natively, UDS does not. `UdsSession` carries a multiplexer.
+
+- **yamux 0.13.7 / 0.12.1 already in `Cargo.lock`** (via libp2p/iroh) — adding
+  `yamux` to `hyprstream-rpc` pulls in nothing new.
+- `yamux::Stream: futures::io::AsyncRead + AsyncWrite` → wrap as the trait's
+  `SendStream`/`RecvStream`.
+- yamux gives **flow control + HOL-correct concurrent streams** for free — the
+  exact thing a raw socket lacks and we'd otherwise hand-roll incorrectly.
+- Rejected alternatives: hand-rolled framing mux (~350 LOC, reinvents flow
+  control); `SOCK_SEQPACKET`/fd-passing (no independent flow-controlled streams).
+
+### The one real integration cost — actor wrapper
+
+`yamux::Connection<T>` is a single-owner, poll-driven driver: **not `Clone`**, must
+be polled by exactly one task (`poll_next_inbound` also drives outbound). But
+`web_transport_trait::Session: Clone` and is called concurrently from many tasks.
+
+Standard fix (what `libp2p-yamux` does): one **driver task** owns the `Connection`;
+`open_bi`/`open_uni`/`accept_bi`/`accept_uni` are channel RPCs to it.
+
+```
+UdsSession (Clone)            driver task (owns yamux::Connection<Compat<UnixStream>>)
+  open_bi  ─ mpsc ─────────▶  poll_new_outbound → tag BIDI → oneshot back (send,recv)
+  open_uni ─ mpsc ─────────▶  poll_new_outbound → tag UNI  → oneshot back (send)
+  accept_* ◀── mpsc queues ── poll_next_inbound → read 1-byte tag → route uni|bidi queue
+```
+
+Sizing: ~150 LOC actor + ~120 LOC stream-type wrappers (`SendStream::{write,
+write_buf, finish, reset, set_priority}`, `RecvStream::{read, read_buf, stop}`).
+
+### Two wire conventions to lock in (trivial)
+
+1. **uni-vs-bidi tag** — yamux substreams are all bidi; prefix each new substream
+   with a 1-byte `UNI`/`BIDI` marker. Acceptor reads it first and routes to the
+   matching `accept_*` queue. Uni opener simply never reads its half.
+2. **plane select** — 1-byte handshake at socket-open (`RPC` vs `MOQ`) in place of
+   ALPN, since UDS has none. Server's `UnixListener` accept loop dispatches the
+   connection to the RPC dispatcher or `moq_net::Server::accept` on that byte.
+
+### Adapter glue
+
+- `tokio::net::UnixStream` is `tokio::io::AsyncRead/Write`; yamux wants
+  `futures::io::AsyncRead/Write` → bridge with
+  `tokio_util::compat::TokioAsyncReadCompatExt` (`tokio-util` already a dep).
+- Error-code mapping is lossy and that's fine (local socket): `finish`→close write
+  half; `reset`/`stop`→drop/close; session `close(code,reason)`→`poll_close`.
+
+## Build outline (its own increment, feeds #136 ipc arm)
+
+1. `transport/uds_session.rs` — `UdsSession` + driver actor + `UdsSendStream`/
+   `UdsRecvStream`; `impl web_transport_trait::Session`.
+2. Client `connect(path) -> UdsSession` (yamux `Mode::Client`); server
+   `UnixListener` accept loop → 1-byte plane select → `Mode::Server` `UdsSession`.
+3. RPC plane: reuse `SessionRpcTransport` over `UdsSession` (no new RPC code).
+4. Streaming plane: `moq_net::{Client,Server}` over the same `UdsSession`.
+5. `dial()` ipc arm constructs `UdsSession`; daemon binds the `UnixListener`.
+6. Tests: loopback `UdsSession` pair — bidi echo, N concurrent uni streams,
+   SETUP negotiation, then a full moq publish/subscribe over UDS.
+
+## Open question deferred → filed as #207
+
+- **Peer auth on UDS** — same-host identity via `SO_PEERCRED` (uid/pid) plus
+  socket-file permissions is defense-in-depth; the SignedEnvelope app-layer
+  identity already authenticates the caller regardless of transport. Owned by
+  the daemon listener bootstrap (where the bind path + mode are chosen), not the
+  Session primitive. Tracked in **#207** (coordinate with #136).
+
+## Review outcomes applied in moq-151g
+
+- **Tag-read timeout** (`TAG_READ_TIMEOUT`) on `classify_inbound` — a substream
+  that never sends its UNI/BIDI tag can't pin a task + yamux slot forever
+  (pre-dispatch slowloris that bypassed rpc_session's `REQUEST_READ_TIMEOUT`).
+- **Concurrent-substream cap** (`MAX_CONCURRENT_STREAMS` via yamux
+  `set_max_num_streams`) — bounds the inbound classification fan-out.
+- **Fail-closed plane validation** in `accept_uds` — unknown selector → error.
+- **Observability** — warn/debug logs on unknown tag, untagged-timeout, FIN-flush
+  failure.
+- Rejected (by-design, evidenced): `closed()` pends rather than reporting
+  spurious closure (moq relies on `read()==None` for EOF); the
+  `tokio::sync::Mutex` around the accept receiver is held across `await` by
+  design (single-consumer mpsc). The detached `finish()` close task is correct —
+  writes are queued into yamux's send buffer before `finish`, proven by the moq
+  round-trip delivering the full frame.


### PR DESCRIPTION
The server-side flip: replace the ZMQ `RequestLoop`/ROUTER on the spawn path with the generic dispatch plane over the dial layer, for all spawn-path services at once. Now buildable — the `#151(a)` dial-layer sub-stack (factory + quinn/iroh transports + QuicServerAuth + DID-doc codec) and #186/#148 are complete.

This PR currently carries the **cutover scope/plan** (`docs/plans/2026-06-11-136-rpc-cutover.md`); implementation follows after the decision points are settled (see the #136 issue comment).

**Pieces:** (1) daemon provisions prod QUIC/iroh listeners + pinned registration · (2) `resolver::set_global` · (3) codegen de-leak (`for_endpoint`→`dial()`, ~95 sites) · (4) `Spawnable::run` replaces `RequestLoop`. Streaming bootstrap already decoupled (#186).

**Decisions open** (discussing): codegen-de-leak sequencing, single-switch vs phased, rollback flag, #187 re-check.

📚 Stacked — base `ewindisch/moq-151f`. Closes the RPC half of epic #131 / M1.
