### PR TITLE
Epic #131: ZMQ → moq-net + iroh transport replacement (integration, DO NOT MERGE)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6401,6 +6401,7 @@ dependencies = [
  "indicatif",
  "inquire",
  "inventory",
+ "iroh",
  "json-threat-protection",
  "jsonwebtoken 10.3.0",
  "keyring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api_client"
@@ -257,9 +257,12 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.7.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "argminmax"
@@ -945,6 +948,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_io_stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
+dependencies = [
+ "futures",
+ "pharos",
+ "rustc_version",
+]
+
+[[package]]
 name = "asynchronous-codec"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1188,12 +1202,23 @@ dependencies = [
  "hyper 1.7.0",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.23.31",
+ "rustls 0.23.40",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
  "tower-service",
+]
+
+[[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand 2.3.0",
+ "gloo-timers",
+ "tokio",
 ]
 
 [[package]]
@@ -1207,6 +1232,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base256emoji"
@@ -1374,15 +1405,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.2"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if 1.0.3",
- "constant_time_eq 0.3.1",
+ "constant_time_eq 0.4.2",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -1419,6 +1451,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
@@ -1577,9 +1618,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytes-utils"
@@ -1635,7 +1676,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fe67a3f89b693d2163cf3d94129125463ac5913e1c4322f2db905aa631d3c67"
 dependencies = [
- "embedded-io",
+ "embedded-io 0.7.1",
 ]
 
 [[package]]
@@ -1897,13 +1938,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if 1.0.3",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chacha20poly1305"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -1929,7 +1981,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2077,6 +2129,15 @@ name = "cmov"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.17",
+]
 
 [[package]]
 name = "colorchoice"
@@ -2319,9 +2380,9 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
@@ -2346,6 +2407,16 @@ name = "cookie-factory"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396de984970346b0d9e93d1415082923c679e5ae5c3ee3dcbd104f5610af126b"
+
+[[package]]
+name = "cordyceps"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688d7fbb8092b8de775ef2536f36c8c31f2bc4006ece2e8d8ad2d17d00ce0a2a"
+dependencies = [
+ "loom",
+ "tracing",
+]
 
 [[package]]
 name = "core-foundation"
@@ -2745,9 +2816,27 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto",
+ "fiat-crypto 0.2.9",
  "rand_core 0.6.4",
  "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0-pre.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
+dependencies = [
+ "cfg-if 1.0.3",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto 0.3.0",
+ "rand_core 0.10.1",
+ "rustc_version",
+ "serde",
  "subtle",
  "zeroize",
 ]
@@ -2940,15 +3029,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.9.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ce6c96ea0102f01122a185683611bd5ac8d99e62bc59dd12e6bda344ee673d"
+checksum = "3259c913752a86488b501ed8680446a5ed2d5aeac6e596cb23ba3800768ea32c"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -2956,9 +3045,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.16"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
+checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
  "syn 2.0.111",
@@ -3869,7 +3958,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
  "zeroize",
 ]
 
@@ -3880,6 +3969,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
  "const-oid 0.10.2",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -4005,6 +4095,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 2.0.111",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -4015,6 +4106,12 @@ checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
 dependencies = [
  "cipher",
 ]
+
+[[package]]
+name = "diatomic-waker"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab03c107fafeb3ee9f5925686dbb7a73bc76e3932abb0d2b365cb64b169cf04c"
 
 [[package]]
 name = "digest"
@@ -4044,6 +4141,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
+ "const-oid 0.10.2",
  "crypto-common 0.2.1",
 ]
 
@@ -4128,6 +4226,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.0",
+ "block2",
+ "libc",
  "objc2",
 ]
 
@@ -4140,6 +4240,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "dlopen2"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4"
+dependencies = [
+ "libc",
+ "once_cell",
+ "winapi",
 ]
 
 [[package]]
@@ -4313,16 +4424,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
+dependencies = [
+ "pkcs8 0.11.0",
+ "serdect",
+ "signature 3.0.0",
+]
+
+[[package]]
 name = "ed25519-dalek"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
  "rand_core 0.6.4",
  "serde",
  "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0-pre.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20449acd54b660981ae5caa2bcb56d1fe7f25f2e37a38ec507400fab034d4bb6"
+dependencies = [
+ "curve25519-dalek 5.0.0-pre.6",
+ "ed25519 3.0.0",
+ "rand_core 0.10.1",
+ "serde",
+ "sha2 0.11.0",
+ "signature 3.0.0",
  "subtle",
  "zeroize",
 ]
@@ -4362,20 +4500,32 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "crypto-bigint",
  "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
  "hkdf",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "embedded-io"
@@ -4417,6 +4567,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
  "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "enum-assoc"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed8956bd5c1f0415200516e78ff07ec9e16415ade83c056c230d7b7ea0d55b7"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -4706,6 +4867,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
+
+[[package]]
 name = "file_utils"
 version = "0.14.2"
 source = "git+https://github.com/huggingface/xet-core?tag=git-xet-v0.2.0#eeee211e5900cbe6a65649fbec0ee0750cc831b2"
@@ -4795,7 +4962,7 @@ dependencies = [
  "ahash 0.8.12",
  "num_cpus",
  "parking_lot 0.12.4",
- "seize",
+ "seize 0.3.3",
 ]
 
 [[package]]
@@ -5022,6 +5189,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-buffered"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4421cb78ee172b6b06080093479d3c50f058e7c81b7d577bbb8d118d551d4cd5"
+dependencies = [
+ "cordyceps",
+ "diatomic-waker",
+ "futures-core",
+ "pin-project-lite",
+ "spin 0.10.0",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5101,7 +5281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
- "rustls 0.23.31",
+ "rustls 0.23.40",
  "rustls-pki-types",
 ]
 
@@ -5169,6 +5349,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.3",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5223,11 +5418,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if 1.0.3",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5353,7 +5550,7 @@ dependencies = [
  "colored",
  "config 0.13.4",
  "dirs 5.0.1",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "futures",
  "git2",
  "glob",
@@ -5379,6 +5576,18 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "go-flag"
@@ -5552,6 +5761,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
 name = "hashlink"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5654,6 +5874,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cfg-if 1.0.3",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "h2 0.4.12",
+ "hickory-proto 0.26.1",
+ "http 1.3.1",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "rand 0.10.1",
+ "rustls 0.23.40",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hickory-proto"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5680,6 +5929,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hickory-resolver"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5687,7 +5956,7 @@ checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
 dependencies = [
  "cfg-if 1.0.3",
  "futures-util",
- "hickory-proto",
+ "hickory-proto 0.25.2",
  "ipconfig",
  "moka",
  "once_cell",
@@ -5697,6 +5966,34 @@ dependencies = [
  "smallvec",
  "thiserror 2.0.17",
  "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+dependencies = [
+ "cfg-if 1.0.3",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto 0.26.1",
+ "ipconfig",
+ "ipnet",
+ "jni 0.22.4",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot 0.12.4",
+ "rand 0.10.1",
+ "resolv-conf",
+ "rustls 0.23.40",
+ "smallvec",
+ "system-configuration 0.7.0",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-rustls 0.26.2",
  "tracing",
 ]
 
@@ -5907,13 +6204,13 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.7.0",
  "hyper-util",
- "rustls 0.23.31",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
  "tower-service",
- "webpki-roots 1.0.2",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -6070,11 +6367,11 @@ dependencies = [
  "clap",
  "config 0.13.4",
  "criterion",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "daemonize",
  "dashmap",
  "dirs 5.0.1",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "fastrand 2.3.0",
  "fred",
  "futures",
@@ -6137,7 +6434,7 @@ dependencies = [
  "rlimit 0.10.2",
  "rmcp",
  "rocksdb",
- "rustls 0.23.31",
+ "rustls 0.23.40",
  "rustls-acme",
  "rustls-pemfile 2.2.0",
  "safetensors 0.4.5",
@@ -6223,7 +6520,7 @@ dependencies = [
  "async-trait",
  "capnp",
  "capnpc",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "hyprstream-rpc",
  "hyprstream-rpc-build",
  "hyprstream-rpc-derive",
@@ -6258,7 +6555,7 @@ dependencies = [
  "parking_lot 0.12.4",
  "prost 0.13.5",
  "rlimit 0.10.2",
- "rustls 0.23.31",
+ "rustls 0.23.40",
  "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
@@ -6327,10 +6624,10 @@ dependencies = [
  "chrono",
  "ciborium",
  "coset",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "dashmap",
  "dirs 5.0.1",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "futures",
  "getrandom 0.2.16",
  "h3",
@@ -6343,9 +6640,11 @@ dependencies = [
  "hyprstream-rpc-build",
  "hyprstream-rpc-derive",
  "inventory",
+ "iroh",
  "js-sys",
  "ml-dsa",
  "ml-kem",
+ "moq-net",
  "nix 0.27.1",
  "once_cell",
  "p256",
@@ -6353,7 +6652,7 @@ dependencies = [
  "quinn",
  "rand 0.8.5",
  "rcgen",
- "rustls 0.23.31",
+ "rustls 0.23.40",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
@@ -6372,6 +6671,8 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "web-time",
+ "web-transport-iroh",
+ "web-transport-trait",
  "webpki-roots 0.26.11",
  "whoami",
  "zeroize",
@@ -6438,7 +6739,7 @@ dependencies = [
  "chrono",
  "dashmap",
  "dirs 5.0.1",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "futures",
  "hyprstream-discovery",
  "hyprstream-rpc",
@@ -6523,9 +6824,9 @@ dependencies = [
  "capnpc",
  "ch-config",
  "chrono",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "dashmap",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "fuse-backend-rs 0.12.1",
  "futures",
  "glob",
@@ -6578,7 +6879,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.0",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -6689,6 +6990,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "identity-hash"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfdd7caa900436d8f13b2346fe10257e0c05c1f1f9e351f4f5d57c03bd5f45da"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6732,9 +7039,9 @@ dependencies = [
  "if-addrs",
  "ipnet",
  "log",
- "netlink-packet-core",
- "netlink-packet-route",
- "netlink-proto",
+ "netlink-packet-core 0.7.0",
+ "netlink-packet-route 0.17.1",
+ "netlink-proto 0.11.5",
  "netlink-sys",
  "rtnetlink",
  "system-configuration 0.6.1",
@@ -6959,9 +7266,12 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -6971,6 +7281,177 @@ checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "iroh"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98e206e3d3f2642f5c08c413755fc0ac19b54ae1a656af88be03454ce3ed2e6"
+dependencies = [
+ "backon",
+ "blake3",
+ "bytes",
+ "cfg_aliases",
+ "ctutils",
+ "data-encoding",
+ "derive_more",
+ "ed25519-dalek 3.0.0-pre.7",
+ "futures-util",
+ "getrandom 0.4.2",
+ "hickory-resolver 0.26.1",
+ "http 1.3.1",
+ "ipnet",
+ "iroh-base",
+ "iroh-dns",
+ "iroh-metrics",
+ "iroh-relay",
+ "n0-error",
+ "n0-future",
+ "n0-watcher",
+ "netwatch",
+ "noq",
+ "noq-proto",
+ "noq-udp",
+ "papaya",
+ "pin-project",
+ "portable-atomic",
+ "rand 0.10.1",
+ "reqwest 0.13.4",
+ "rustc-hash",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.13",
+ "serde",
+ "smallvec",
+ "strum 0.28.0",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+ "wasm-bindgen-futures",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "iroh-base"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af93d67701c00c504982154569192ad384738c0450ba1196930314b955100552"
+dependencies = [
+ "curve25519-dalek 5.0.0-pre.6",
+ "data-encoding",
+ "data-encoding-macro",
+ "derive_more",
+ "digest 0.11.3",
+ "ed25519-dalek 3.0.0-pre.7",
+ "getrandom 0.4.2",
+ "n0-error",
+ "rand 0.10.1",
+ "serde",
+ "sha2 0.11.0",
+ "url",
+ "zeroize",
+ "zeroize_derive",
+]
+
+[[package]]
+name = "iroh-dns"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de4112c91eb64094d77df9d3112606dcf7ff216421afccd2dc762fda5a7b2879"
+dependencies = [
+ "arc-swap",
+ "cfg_aliases",
+ "derive_more",
+ "hickory-resolver 0.26.1",
+ "iroh-base",
+ "n0-error",
+ "n0-future",
+ "ndk-context",
+ "rand 0.10.1",
+ "reqwest 0.13.4",
+ "rustls 0.23.40",
+ "simple-dns",
+ "strum 0.28.0",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "iroh-metrics"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d102597d0ee523f17fdb672c532395e634dbe945429284c811430d63bacc0d8a"
+dependencies = [
+ "iroh-metrics-derive",
+ "itoa",
+ "n0-error",
+ "portable-atomic",
+ "ryu",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "iroh-metrics-derive"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c8e0c97f1dc787107f388433c349397c565572fe6406d600ff7bb7b7fe3b30"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "iroh-relay"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54f490405e42dd2ecf16be18a3587d2665401e94a498094f12322eaa6d5ebb2b"
+dependencies = [
+ "blake3",
+ "bytes",
+ "cfg_aliases",
+ "data-encoding",
+ "derive_more",
+ "getrandom 0.4.2",
+ "hickory-resolver 0.26.1",
+ "http 1.3.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-util",
+ "iroh-base",
+ "iroh-dns",
+ "iroh-metrics",
+ "lru 0.18.0",
+ "n0-error",
+ "n0-future",
+ "noq",
+ "noq-proto",
+ "num_enum",
+ "pin-project",
+ "postcard",
+ "rand 0.10.1",
+ "reqwest 0.13.4",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "serde",
+ "serde_bytes",
+ "strum 0.28.0",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tokio-util",
+ "tokio-websockets",
+ "tracing",
+ "url",
+ "vergen-gitcl",
+ "webpki-roots 1.0.7",
+ "ws_stream_wasm",
 ]
 
 [[package]]
@@ -7038,7 +7519,7 @@ dependencies = [
  "cesu8",
  "cfg-if 1.0.3",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.0",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -7046,10 +7527,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if 1.0.3",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.17",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.111",
+]
 
 [[package]]
 name = "jobserver"
@@ -7115,7 +7645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
  "base64 0.22.1",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "getrandom 0.2.16",
  "hmac 0.12.1",
  "js-sys",
@@ -7243,6 +7773,15 @@ dependencies = [
  "security-framework 3.5.0",
  "windows-sys 0.60.2",
  "zeroize",
+]
+
+[[package]]
+name = "kio"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32311a076e65af53bebb6ba1d6808aae929453800cbebc12e1fa561624baa808"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -7578,7 +8117,7 @@ checksum = "0b770c1c8476736ca98c578cba4b505104ff8e842c2876b528925f9766379f9a"
 dependencies = [
  "async-trait",
  "futures",
- "hickory-resolver",
+ "hickory-resolver 0.25.2",
  "libp2p-core",
  "libp2p-identity",
  "parking_lot 0.12.4",
@@ -7614,7 +8153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3104e13b51e4711ff5738caa1fb54467c8604c2e94d607e27745bcf709068774"
 dependencies = [
  "bs58",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "hkdf",
  "multihash",
  "quick-protobuf",
@@ -7659,7 +8198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c66872d0f1ffcded2788683f76931be1c52e27f343edb93bc6d0bcd8887be443"
 dependencies = [
  "futures",
- "hickory-proto",
+ "hickory-proto 0.25.2",
  "if-watch",
  "libp2p-core",
  "libp2p-identity",
@@ -7726,7 +8265,7 @@ dependencies = [
  "quinn",
  "rand 0.8.5",
  "ring",
- "rustls 0.23.31",
+ "rustls 0.23.40",
  "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
@@ -7811,8 +8350,8 @@ dependencies = [
  "libp2p-identity",
  "rcgen",
  "ring",
- "rustls 0.23.31",
- "rustls-webpki 0.103.6",
+ "rustls 0.23.40",
+ "rustls-webpki 0.103.13",
  "thiserror 2.0.17",
  "x509-parser 0.17.0",
  "yasna",
@@ -8058,6 +8597,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if 1.0.3",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8073,6 +8625,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfe949189f46fabb938b3a9a0be30fdd93fd8a09260da863399a8cf3db756ec8"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+dependencies = [
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -8119,6 +8680,12 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[package]]
+name = "mac-addr"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d25b0e0b648a86960ac23b7ad4abb9717601dec6f66c165f5b037f3f03065f"
 
 [[package]]
 name = "macro_rules_attribute"
@@ -8471,6 +9038,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "moq-net"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e6df8317fbac0fc334536c85ad8b2ff7e880d11802f1f93af56f1e30486ed0e"
+dependencies = [
+ "bytes",
+ "futures",
+ "kio",
+ "num_enum",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "web-async",
+ "web-transport-trait",
+]
+
+[[package]]
 name = "more-asserts"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8570,6 +9157,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "n0-error"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "223e946a84aa91644507a6b7865cfebbb9a231ace499041c747ab0fd30408212"
+dependencies = [
+ "n0-error-macros",
+ "spez",
+]
+
+[[package]]
+name = "n0-error-macros"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "565305a21e6b3bf26640ad98f05a0fda12d3ab4315394566b52a7bddb8b34828"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "n0-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2ab99dfb861450e68853d34ae665243a88b8c493d01ba957321a1e9b2312bbe"
+dependencies = [
+ "cfg_aliases",
+ "derive_more",
+ "futures-buffered",
+ "futures-lite 2.6.1",
+ "futures-util",
+ "js-sys",
+ "pin-project",
+ "send_wrapper",
+ "tokio",
+ "tokio-util",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
+name = "n0-watcher"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928d8039a66cce5efcfd35e88b32d3defc8eba630b3ac451522997f563956a52"
+dependencies = [
+ "derive_more",
+ "n0-error",
+ "n0-future",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8602,6 +9242,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "netdev"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57bacaf873ee4eab5646f99b381b271ec75e716902a67cf962c0f328c5eb5bfb"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "dlopen2",
+ "ipnet",
+ "libc",
+ "mac-addr",
+ "netlink-packet-core 0.8.1",
+ "netlink-packet-route 0.29.0",
+ "netlink-sys",
+ "objc2-core-foundation",
+ "objc2-core-wlan",
+ "objc2-foundation",
+ "objc2-system-configuration",
+ "once_cell",
+ "plist",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
 name = "netlink-packet-core"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8610,6 +9280,15 @@ dependencies = [
  "anyhow",
  "byteorder",
  "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-core"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
+dependencies = [
+ "paste",
 ]
 
 [[package]]
@@ -8622,8 +9301,32 @@ dependencies = [
  "bitflags 1.3.2",
  "byteorder",
  "libc",
- "netlink-packet-core",
+ "netlink-packet-core 0.7.0",
  "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9854ea6ad14e3f4698a7f03b65bce0833dd2d81d594a0e4a984170537146b6"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "log",
+ "netlink-packet-core 0.8.1",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "log",
+ "netlink-packet-core 0.8.1",
 ]
 
 [[package]]
@@ -8647,22 +9350,72 @@ dependencies = [
  "bytes",
  "futures",
  "log",
- "netlink-packet-core",
+ "netlink-packet-core 0.7.0",
+ "netlink-sys",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "netlink-proto"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "netlink-packet-core 0.8.1",
  "netlink-sys",
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "netlink-sys"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16c903aa70590cb93691bf97a767c8d1d6122d2cc9070433deb3bbf36ce8bd23"
+checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
 dependencies = [
  "bytes",
- "futures",
+ "futures-util",
  "libc",
  "log",
  "tokio",
+]
+
+[[package]]
+name = "netwatch"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5bfbba77b994ce69f1d40fc66fd8abbd23df62ce4aea61fbb34d638106a2549"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "cfg_aliases",
+ "derive_more",
+ "js-sys",
+ "libc",
+ "n0-error",
+ "n0-future",
+ "n0-watcher",
+ "netdev",
+ "netlink-packet-core 0.8.1",
+ "netlink-packet-route 0.30.0",
+ "netlink-proto 0.12.0",
+ "netlink-sys",
+ "noq-udp",
+ "objc2-core-foundation",
+ "objc2-system-configuration",
+ "pin-project-lite",
+ "serde",
+ "socket2 0.6.0",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "web-sys",
+ "windows 0.62.2",
+ "windows-result 0.4.1",
+ "wmi",
 ]
 
 [[package]]
@@ -8771,6 +9524,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "noq"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22739e0831e40f5ab7d6ac5317ed80bfe5fb3f44be57d23fa2eea8bff83fb303"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "derive_more",
+ "noq-proto",
+ "noq-udp",
+ "pin-project-lite",
+ "rustc-hash",
+ "rustls 0.23.40",
+ "socket2 0.6.0",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "noq-proto"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cee32450cf726b223ac4154003c93cb52fbde159ab1240990e88945bf3ae35e"
+dependencies = [
+ "aes-gcm",
+ "bytes",
+ "derive_more",
+ "enum-assoc",
+ "getrandom 0.4.2",
+ "identity-hash",
+ "lru-slab",
+ "rand 0.10.1",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "slab",
+ "sorted-index-buffer",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "noq-udp"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78633d1fe1bde91d12bcabb230ac9edb890857414c6d44f3212e0d309525b5ff"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "socket2 0.6.0",
+ "tracing",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
 name = "notify"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8876,9 +9691,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -8929,6 +9744,28 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -9187,7 +10024,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.0",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
 ]
 
@@ -9205,6 +10044,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-wlan"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e34919aba0d701380d911702455038a8a3587467fe0141d6a71501e7ffe48"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-security",
+ "objc2-security-foundation",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9217,6 +10070,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
+ "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -9230,6 +10085,41 @@ dependencies = [
  "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-security-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef76382e9cedd18123099f17638715cc3d81dba3637d4c0d39ab69df2ef345a5"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "bitflags 2.11.0",
+ "dispatch2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-security",
 ]
 
 [[package]]
@@ -9569,7 +10459,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "ecdsa",
  "elliptic-curve",
  "primeorder",
@@ -9600,6 +10490,16 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "windows 0.58.0",
+]
+
+[[package]]
+name = "papaya"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "997ee03cd38c01469a7046643714f0ad28880bcb9e6679ff0666e24817ca19b7"
+dependencies = [
+ "equivalent",
+ "seize 0.5.1",
 ]
 
 [[package]]
@@ -9801,6 +10701,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9896,6 +10805,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.12.1",
  "serde",
+]
+
+[[package]]
+name = "pharos"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
+dependencies = [
+ "futures",
+ "rustc_version",
 ]
 
 [[package]]
@@ -10656,6 +11575,9 @@ name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "portable-atomic-util"
@@ -10664,6 +11586,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "postcard-derive",
+ "serde",
+]
+
+[[package]]
+name = "postcard-derive"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0232bd009a197ceec9cc881ba46f727fcd8060a2d8d6a9dde7a69030a6fe2bb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -10714,6 +11660,17 @@ checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
 ]
 
 [[package]]
@@ -11217,7 +12174,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.31",
+ "rustls 0.23.40",
  "socket2 0.6.0",
  "thiserror 2.0.17",
  "tokio",
@@ -11238,7 +12195,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls 0.23.31",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "slab",
@@ -11321,6 +12278,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20 0.10.0",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11372,6 +12340,15 @@ checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -11616,7 +12593,7 @@ dependencies = [
  "cfg-if 1.0.3",
  "libc",
  "rustix 1.1.2",
- "windows 0.62.0",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -11697,7 +12674,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots 0.25.4",
  "winreg",
@@ -11730,7 +12707,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.31",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "rustls-pki-types",
  "serde",
@@ -11747,9 +12724,46 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots 1.0.2",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tokio-util",
+ "tower 0.5.2",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
+ "web-sys",
 ]
 
 [[package]]
@@ -12021,10 +13035,10 @@ checksum = "7a552eb82d19f38c3beed3f786bd23aa434ceb9ac43ab44419ca6d67a7e186c0"
 dependencies = [
  "futures",
  "log",
- "netlink-packet-core",
- "netlink-packet-route",
+ "netlink-packet-core 0.7.0",
+ "netlink-packet-route 0.17.1",
  "netlink-packet-utils",
- "netlink-proto",
+ "netlink-proto 0.11.5",
  "netlink-sys",
  "nix 0.26.4",
  "thiserror 1.0.69",
@@ -12055,9 +13069,9 @@ dependencies = [
  "byteorder",
  "bytes",
  "cbc",
- "chacha20",
+ "chacha20 0.9.1",
  "ctr",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "delegate",
  "des",
  "digest 0.10.7",
@@ -12120,7 +13134,7 @@ dependencies = [
  "der 0.7.10",
  "digest 0.10.7",
  "ecdsa",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "elliptic-curve",
  "futures",
  "getrandom 0.2.16",
@@ -12320,16 +13334,16 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.31"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.6",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -12410,13 +13424,13 @@ checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
- "rustls 0.23.31",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.6",
+ "rustls-webpki 0.103.13",
  "security-framework 3.5.0",
  "security-framework-sys",
  "webpki-root-certs",
@@ -12441,9 +13455,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.6"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -12627,7 +13641,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "der 0.7.10",
  "generic-array",
  "pkcs8 0.10.2",
@@ -12706,10 +13720,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "689224d06523904ebcc9b482c6a3f4f7fb396096645c4cd10c0d2ff7371a34d3"
 
 [[package]]
+name = "seize"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "sendfd"
@@ -12787,6 +13817,16 @@ dependencies = [
  "js-sys",
  "serde",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -12899,6 +13939,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
+ "serde",
+]
+
+[[package]]
+name = "sfv"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d471eaefb14f4b30032525bdb124b36e55ba9cb1292080e06f1a236cd10fe87"
+dependencies = [
+ "base64 0.22.1",
+ "indexmap 2.12.1",
+ "ref-cast",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12938,6 +13999,17 @@ dependencies = [
  "cpufeatures 0.2.17",
  "digest 0.10.7",
  "sha2-asm",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if 1.0.3",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -13055,10 +14127,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple-dns"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a75cbde1bf934313596a004973e462f9a82caa814dcf1a5f507bdf51597eeb4"
+dependencies = [
+ "bitflags 2.11.0",
+]
 
 [[package]]
 name = "simple_asn1"
@@ -13219,7 +14310,7 @@ dependencies = [
  "aes-gcm",
  "blake2",
  "chacha20poly1305",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "ring",
  "rustc_version",
@@ -13258,6 +14349,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "sorted-index-buffer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea06cc588e43c632923a55450401b8f25e628131571d4e1baea1bdfdb2b5ed06"
+
+[[package]]
+name = "spez"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87e960f4dca2788eeb86bbdde8dd246be8948790b7618d656e68f9b720a86e8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13268,6 +14376,12 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spki"
@@ -13363,7 +14477,7 @@ dependencies = [
  "aes",
  "aes-gcm",
  "cbc",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "ctr",
  "poly1305",
@@ -13379,7 +14493,7 @@ checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
 dependencies = [
  "base64ct",
  "bytes",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
  "sha2 0.10.9",
 ]
 
@@ -13390,7 +14504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3"
 dependencies = [
  "bcrypt-pbkdf",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "num-bigint-dig",
  "p256",
  "p384",
@@ -13474,6 +14588,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13491,6 +14614,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -13662,6 +14797,17 @@ name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys 0.6.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.9.4",
@@ -13905,31 +15051,33 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.43"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
+ "js-sys",
  "libc",
  "num-conv",
  "num_threads",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -14100,7 +15248,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.31",
+ "rustls 0.23.40",
  "tokio",
 ]
 
@@ -14169,6 +15317,29 @@ dependencies = [
  "libc",
  "tokio",
  "vsock",
+]
+
+[[package]]
+name = "tokio-websockets"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad543404f98bfc969aeb71994105c592acfc6c43323fddcd016bb208d1c65cb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "getrandom 0.4.2",
+ "http 1.3.1",
+ "httparse",
+ "rand 0.10.1",
+ "ring",
+ "rustls-pki-types",
+ "sha1_smol",
+ "simdutf8",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tokio-util",
 ]
 
 [[package]]
@@ -14424,9 +15595,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -14448,9 +15619,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14459,9 +15630,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -14785,7 +15956,7 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
- "rustls 0.23.31",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -14901,6 +16072,43 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vergen"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-gitcl"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ff3b5300a085d6bcd8fc96a507f706a28ae3814693236c9b409db71a1d15b9"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+ "time",
+ "vergen",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+]
 
 [[package]]
 name = "version-compare"
@@ -15309,6 +16517,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-timer"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15346,6 +16567,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-async"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5414b65d9a5094649bb99987bb74db71febfdfa3677b7954a0a05c99d0424e8"
+dependencies = [
+ "tokio",
+ "tracing",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15363,6 +16595,47 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-transport-iroh"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4ebffba98c30a0ac3560c4d7c595e61a5ad040049d65ff5c91304e5ee5f5ee"
+dependencies = [
+ "bytes",
+ "http 1.3.1",
+ "iroh",
+ "n0-error",
+ "n0-future",
+ "tokio",
+ "tracing",
+ "url",
+ "web-transport-proto",
+ "web-transport-trait",
+]
+
+[[package]]
+name = "web-transport-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0225d295c8ac00a2e9a498aefeaf3f3c6186da12a251c938189b15b82ea22808"
+dependencies = [
+ "bytes",
+ "http 1.3.1",
+ "sfv",
+ "thiserror 2.0.17",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "web-transport-trait"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc5f83d19cf6c8ba147f4e1e5935a8a115c91f6abbf714d740a83b967d558e6e"
+dependencies = [
+ "bytes",
 ]
 
 [[package]]
@@ -15386,14 +16659,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.2",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.2"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -15508,24 +16781,23 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.62.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9579d0e6970fd5250aa29aba5994052385ff55cf7b28a059e484bb79ea842e42"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.62.0",
+ "windows-core 0.62.2",
  "windows-future",
- "windows-link 0.2.0",
  "windows-numerics",
 ]
 
 [[package]]
 name = "windows-collections"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90dd7a7b86859ec4cdf864658b311545ef19dbcf17a672b52ab7cefe80c336f"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -15565,25 +16837,25 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.62.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.0",
- "windows-interface 0.59.1",
- "windows-link 0.2.0",
- "windows-result 0.4.0",
- "windows-strings 0.5.0",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
 name = "windows-future"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2194dee901458cb79e1148a4e9aac2b164cc95fa431891e7b296ff0b2f1d8a6"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.0",
- "windows-link 0.2.0",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
  "windows-threading",
 ]
 
@@ -15611,9 +16883,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -15644,9 +16916,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -15661,18 +16933,18 @@ checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce3498fe0aba81e62e477408383196b4b0363db5e0c27646f932676283b43d8"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.0",
- "windows-link 0.2.0",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -15715,11 +16987,11 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -15743,11 +17015,11 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -15801,7 +17073,7 @@ version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -15869,11 +17141,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab47f085ad6932defa48855254c758cdd0e2f2d48e62a34118a268d8f345e118"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -16185,10 +17457,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "wmi"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c81b85c57a57500e56669586496bf2abd5cf082b9d32995251185d105208b64"
+dependencies = [
+ "chrono",
+ "futures",
+ "log",
+ "serde",
+ "thiserror 2.0.17",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "ws_stream_wasm"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c173014acad22e83f16403ee360115b38846fe754e735c5d9d3803fe70c6abc"
+dependencies = [
+ "async_io_stream",
+ "futures",
+ "js-sys",
+ "log",
+ "pharos",
+ "rustc_version",
+ "send_wrapper",
+ "thiserror 2.0.17",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "wyz"
@@ -16222,7 +17528,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "serde",
  "zeroize",
@@ -16618,9 +17924,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6619,6 +6619,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "blake3",
+ "bs58",
  "bytes",
  "capnp",
  "capnpc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5359,8 +5359,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -6667,12 +6667,14 @@ dependencies = [
  "tokio-test",
  "tokio-util",
  "tracing",
+ "url",
  "uuid 1.18.1",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "web-time",
  "web-transport-iroh",
+ "web-transport-quinn",
  "web-transport-trait",
  "webpki-roots 0.26.11",
  "whoami",
@@ -6880,7 +6882,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -16628,6 +16630,26 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "url",
+]
+
+[[package]]
+name = "web-transport-quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cac11b6caf163be7f980442a26fcba15e8074a5f22e85fbb71f0f77d11cecf60"
+dependencies = [
+ "bytes",
+ "futures",
+ "http 1.3.1",
+ "quinn",
+ "rustls 0.23.40",
+ "rustls-native-certs",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "url",
+ "web-transport-proto",
+ "web-transport-trait",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6679,6 +6679,7 @@ dependencies = [
  "web-transport-trait",
  "webpki-roots 0.26.11",
  "whoami",
+ "yamux 0.13.7",
  "zeroize",
  "zmq",
  "zmq-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ libc = "0.2"
 
 # Async runtime
 tokio = { version = "1.43.0", features = ["rt-multi-thread", "signal", "fs", "process", "sync", "time", "macros"] }
-tokio-util = { version = "0.7", features = ["rt"] }
+tokio-util = { version = "0.7", features = ["rt", "compat"] }
 tokio-stream = { version = "0.1.17", features = ["sync"] }
 tokio-test = "0.4"
 tokio-rustls = "0.26.1"
@@ -139,6 +139,9 @@ moq-net = "0.1"
 web-transport-iroh = { version = "0.5.1", default-features = false, features = ["ring"] }
 web-transport-quinn = { version = "0.11.9", default-features = false, features = ["ring"] }
 web-transport-trait = "0.3"
+# Stream multiplexer for the UDS transport (`web_transport_trait::Session` over a
+# single UnixStream). Already in the lock graph via libp2p/iroh — no new tree.
+yamux = "0.13"
 
 # Data processing
 polars = "0.45.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,7 @@ http = "1"
 iroh = { version = "=1.0.0-rc.0", default-features = false, features = ["tls-ring"] }
 moq-net = "0.1"
 web-transport-iroh = { version = "0.5.1", default-features = false, features = ["ring"] }
+web-transport-quinn = { version = "0.11.9", default-features = false, features = ["ring"] }
 web-transport-trait = "0.3"
 
 # Data processing

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,14 @@ h3-quinn = { version = "0.0.10", features = ["datagram"] }
 h3-webtransport = "0.1.2"
 http = "1"
 
+# Iroh + Media-over-QUIC (Epic #131 — Phase 1 substrate)
+# iroh re-exported via web-transport-iroh — match its major to avoid duplicate copies.
+# Note: web-transport-iroh 0.5.x pins iroh =1.0.0-rc.0 exactly; co-bump these together.
+iroh = { version = "=1.0.0-rc.0", default-features = false, features = ["tls-ring"] }
+moq-net = "0.1"
+web-transport-iroh = { version = "0.5.1", default-features = false, features = ["ring"] }
+web-transport-trait = "0.3"
+
 # Data processing
 polars = "0.45.1"
 sqlparser = "0.39.0"

--- a/crates/hyprstream-compositor/src/lib.rs
+++ b/crates/hyprstream-compositor/src/lib.rs
@@ -411,12 +411,12 @@ impl Compositor {
                                 return vec![CompositorOutput::Redraw];
                             }
                         }
-                        ShellMode::WorkerManager { ref mut sandbox_sel, show_containers: false, .. } => {
-                            if idx < self.chrome.worker_list.len() {
-                                *sandbox_sel = idx;
-                                let out = self.chrome.handle_key(waxterm::input::KeyPress::Enter);
-                                return self.dispatch_chrome(out);
-                            }
+                        ShellMode::WorkerManager { ref mut sandbox_sel, show_containers: false, .. }
+                            if idx < self.chrome.worker_list.len() =>
+                        {
+                            *sandbox_sel = idx;
+                            let out = self.chrome.handle_key(waxterm::input::KeyPress::Enter);
+                            return self.dispatch_chrome(out);
                         }
                         _ => {}
                     }

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -4,7 +4,7 @@
 //! socket kinds, and schemas via the standard ZMQ REQ/REP transport.
 
 use async_trait::async_trait;
-use hyprstream_rpc::service::{EnvelopeContext, ZmqService};
+use hyprstream_rpc::service::{EnvelopeContext, RequestService};
 use hyprstream_rpc::transport::TransportConfig;
 use hyprstream_rpc::registry::{self, EndpointRegistry, SocketKind};
 use hyprstream_rpc::resolver::Resolver;
@@ -94,7 +94,7 @@ pub struct DiscoveryService {
     signing_key: Arc<SigningKey>,
     /// JWT verifying key for service JWT verification (derived from root via HKDF)
     jwt_verifying_key: hyprstream_rpc::prelude::VerifyingKey,
-    /// JWT key source for client JWT verification (ZmqService trait)
+    /// JWT key source for client JWT verification (RequestService trait)
     jwt_key_source: Option<std::sync::Arc<dyn hyprstream_rpc::auth::JwtKeySource>>,
     /// OAuth issuer URL for RFC 9728 metadata (None = not configured)
     oauth_issuer_url: Option<String>,
@@ -110,7 +110,7 @@ pub struct DiscoveryService {
     /// Consumed by FederationKeyResolver before falling back to HTTPS.
     entity_statements: RwLock<HashMap<String, CachedEntityStatement>>,
     /// Phase 0.5 Stage D — cached envelope COSE_KeySets per service did:web.
-    /// Pushed by each service at startup + rotation. Consumed by ZmqService
+    /// Pushed by each service at startup + rotation. Consumed by RequestService
     /// receivers verifying COSE_Sign1 envelope signatures.
     envelope_keysets: RwLock<HashMap<String, CachedEnvelopeKeyset>>,
     /// Pre-computed TLS endorsement: Sign(tls_key, ed25519_pubkey || domain).
@@ -723,11 +723,11 @@ impl DiscoveryHandler for DiscoveryService {
 }
 
 // ============================================================================
-// ZmqService implementation
+// RequestService implementation
 // ============================================================================
 
 #[async_trait(?Send)]
-impl ZmqService for DiscoveryService {
+impl RequestService for DiscoveryService {
     async fn handle_request(
         &self,
         ctx: &EnvelopeContext,

--- a/crates/hyprstream-rpc-derive/src/codegen/client.rs
+++ b/crates/hyprstream-rpc-derive/src/codegen/client.rs
@@ -496,39 +496,41 @@ pub fn generate_constructors(service_name: &str) -> TokenStream {
                 signing_key: hyprstream_rpc::crypto::SigningKey,
                 destination: hyprstream_rpc::crypto::VerifyingKey,
                 token: Option<String>,
-            ) -> Self {
-                let endpoint = hyprstream_rpc::registry::try_global()
+            ) -> anyhow::Result<Self> {
+                let transport = hyprstream_rpc::registry::try_global()
                     .map(|r| r.endpoint(#service_name_lit, hyprstream_rpc::registry::SocketKind::Rep))
                     .unwrap_or_else(|| hyprstream_rpc::transport::TransportConfig::inproc(
                         concat!("hyprstream/", #service_name_lit)
-                    ))
-                    .to_zmq_string();
-                Self::for_endpoint(&endpoint, signing_key, destination, token)
+                    ));
+                Self::dial_transport(&transport, signing_key, destination, token)
             }
 
-            /// Create a new client connected to a specific endpoint.
-            ///
-            /// `destination` is the target service's Ed25519 verifying key,
-            /// used to verify response signatures.
+            /// Create a new client connected to a specific endpoint string
+            /// (`inproc://…` / `ipc://…`). Parsed to a `TransportConfig` and routed
+            /// through [`hyprstream_rpc::dial::dial`] — the one place transport
+            /// selection happens. For networked (quic/iroh) targets, prefer
+            /// [`Self::from_resolver`], which carries the full auth config.
             pub fn for_endpoint(
                 endpoint: &str,
                 signing_key: hyprstream_rpc::crypto::SigningKey,
                 destination: hyprstream_rpc::crypto::VerifyingKey,
                 token: Option<String>,
-            ) -> Self {
+            ) -> anyhow::Result<Self> {
+                let transport = hyprstream_rpc::transport::TransportConfig::from_endpoint(endpoint);
+                Self::dial_transport(&transport, signing_key, destination, token)
+            }
+
+            /// Build a client for an already-resolved `TransportConfig` (the one
+            /// place the generated client meets `dial()`).
+            fn dial_transport(
+                transport: &hyprstream_rpc::transport::TransportConfig,
+                signing_key: hyprstream_rpc::crypto::SigningKey,
+                destination: hyprstream_rpc::crypto::VerifyingKey,
+                token: Option<String>,
+            ) -> anyhow::Result<Self> {
                 let signer = hyprstream_rpc::signer::LocalSigner::new(signing_key);
-                let transport = hyprstream_rpc::zmq_connection::ZmqConnection::new(
-                    endpoint,
-                    hyprstream_rpc::zmq_context::global_context(),
-                );
-                let rpc = hyprstream_rpc::rpc_client::RpcClientImpl::new(
-                    signer, transport, Some(destination),
-                );
-                let rpc = match token {
-                    Some(t) => rpc.with_default_jwt(t),
-                    None => rpc,
-                };
-                Self::new(std::sync::Arc::new(rpc) as std::sync::Arc<dyn hyprstream_rpc::RpcClient>)
+                let rpc = hyprstream_rpc::dial::dial(transport, signer, Some(destination), token)?;
+                Ok(Self::new(rpc))
             }
 
             /// Create a new client by resolving the service endpoint via a `Resolver`.
@@ -538,29 +540,35 @@ pub fn generate_constructors(service_name: &str) -> TokenStream {
                 destination: hyprstream_rpc::crypto::VerifyingKey,
                 token: Option<String>,
             ) -> anyhow::Result<Self> {
-                let endpoint = resolver
+                let transport = resolver
                     .resolve(Self::SERVICE_NAME, hyprstream_rpc::registry::SocketKind::Rep)
-                    .await?
-                    .to_zmq_string();
-                Ok(Self::for_endpoint(&endpoint, signing_key, destination, token))
+                    .await?;
+                Self::dial_transport(&transport, signing_key, destination, token)
             }
 
             /// Create a client from an `IdentityProvider` with automatic endpoint resolution.
             pub async fn from_provider(
                 provider: &dyn hyprstream_rpc::identity::IdentityProvider,
             ) -> anyhow::Result<Self> {
-                let endpoint = hyprstream_rpc::registry::try_global()
+                let transport = hyprstream_rpc::registry::try_global()
                     .map(|r| r.endpoint(#service_name_lit, hyprstream_rpc::registry::SocketKind::Rep))
                     .unwrap_or_else(|| hyprstream_rpc::transport::TransportConfig::inproc(
                         concat!("hyprstream/", #service_name_lit)
-                    ))
-                    .to_zmq_string();
-                Self::from_provider_at(&endpoint, provider).await
+                    ));
+                Self::from_provider_at_transport(&transport, provider).await
             }
 
-            /// Create a client from an `IdentityProvider` at a specific endpoint.
+            /// Create a client from an `IdentityProvider` at a specific endpoint string.
             pub async fn from_provider_at(
                 endpoint: &str,
+                provider: &dyn hyprstream_rpc::identity::IdentityProvider,
+            ) -> anyhow::Result<Self> {
+                let transport = hyprstream_rpc::transport::TransportConfig::from_endpoint(endpoint);
+                Self::from_provider_at_transport(&transport, provider).await
+            }
+
+            async fn from_provider_at_transport(
+                transport: &hyprstream_rpc::transport::TransportConfig,
                 provider: &dyn hyprstream_rpc::identity::IdentityProvider,
             ) -> anyhow::Result<Self> {
                 let handle = provider.identity_open(concat!("hyprstream-", #service_name_lit, "-v1")).await?;
@@ -568,14 +576,8 @@ pub fn generate_constructors(service_name: &str) -> TokenStream {
                 let server_vk = hyprstream_rpc::crypto::VerifyingKey::from_bytes(&pubkey)
                     .map_err(|e| anyhow::anyhow!("invalid derived pubkey: {}", e))?;
                 let signer = hyprstream_rpc::signer::IdentitySigner::new(handle);
-                let transport = hyprstream_rpc::zmq_connection::ZmqConnection::new(
-                    endpoint,
-                    hyprstream_rpc::zmq_context::global_context(),
-                );
-                let rpc = hyprstream_rpc::rpc_client::RpcClientImpl::new(
-                    signer, transport, Some(server_vk),
-                );
-                Ok(Self::new(std::sync::Arc::new(rpc) as std::sync::Arc<dyn hyprstream_rpc::RpcClient>))
+                let rpc = hyprstream_rpc::dial::dial(transport, signer, Some(server_vk), None)?;
+                Ok(Self::new(rpc))
             }
         }
     }

--- a/crates/hyprstream-rpc/Cargo.toml
+++ b/crates/hyprstream-rpc/Cargo.toml
@@ -47,6 +47,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 base64 = { workspace = true }
 hex = { workspace = true }
+bs58 = "0.5"                              # multibase base58btc for DID-doc transport service entries
 chrono = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }

--- a/crates/hyprstream-rpc/Cargo.toml
+++ b/crates/hyprstream-rpc/Cargo.toml
@@ -88,7 +88,9 @@ http = { workspace = true }
 iroh = { workspace = true }
 moq-net = { workspace = true }
 web-transport-iroh = { workspace = true }
+web-transport-quinn = { workspace = true }
 web-transport-trait = { workspace = true }
+url = { workspace = true }
 
 # Async runtime
 tokio = { workspace = true, features = ["io-util", "net"] }

--- a/crates/hyprstream-rpc/Cargo.toml
+++ b/crates/hyprstream-rpc/Cargo.toml
@@ -84,6 +84,12 @@ h3-quinn = { workspace = true }
 h3-webtransport = { workspace = true }
 http = { workspace = true }
 
+# Iroh + MoQ (Epic #131 — Phase 1 substrate). See transport::iroh_substrate.
+iroh = { workspace = true }
+moq-net = { workspace = true }
+web-transport-iroh = { workspace = true }
+web-transport-trait = { workspace = true }
+
 # Async runtime
 tokio = { workspace = true, features = ["io-util", "net"] }
 tokio-util = { workspace = true }

--- a/crates/hyprstream-rpc/Cargo.toml
+++ b/crates/hyprstream-rpc/Cargo.toml
@@ -34,9 +34,10 @@ rand = { workspace = true }
 # FIPS mode (optional)
 p256 = { workspace = true, optional = true }
 
-# Post-quantum hybrid (optional)
-ml-dsa = { workspace = true, optional = true }
-ml-kem = { workspace = true, optional = true }
+# Post-quantum hybrid — always compiled (PQ mode is selected at RUNTIME via
+# CryptoPolicy, not at compile time). See M3 (#152).
+ml-dsa = { workspace = true }
+ml-kem = { workspace = true }
 
 # Shared deps — all targets
 anyhow = { workspace = true }
@@ -114,7 +115,10 @@ systemd = { version = "0.10", optional = true }
 [features]
 default = []
 fips = ["p256", "hmac"]  # FIPS mode uses P-256 + HMAC-SHA256 (hkdf is always enabled)
-pq-hybrid = ["ml-dsa", "ml-kem"]  # Post-quantum hybrid: ML-DSA-65 signatures + ML-KEM-768 KEM
+# `pq-hybrid` is retained as a NO-OP alias for source/build compatibility.
+# Post-quantum primitives (ML-DSA-65 + ML-KEM-768) are now ALWAYS compiled;
+# Classical vs Hybrid is selected at runtime via `crypto::CryptoPolicy`. See M3.
+pq-hybrid = []
 systemd = ["dep:systemd"]
 
 [build-dependencies]

--- a/crates/hyprstream-rpc/Cargo.toml
+++ b/crates/hyprstream-rpc/Cargo.toml
@@ -92,6 +92,7 @@ moq-net = { workspace = true }
 web-transport-iroh = { workspace = true }
 web-transport-quinn = { workspace = true }
 web-transport-trait = { workspace = true }
+yamux = { workspace = true }  # UDS transport: stream-multiplexer for Session-over-UnixStream
 url = { workspace = true }
 
 # Async runtime

--- a/crates/hyprstream-rpc/schema/common.capnp
+++ b/crates/hyprstream-rpc/schema/common.capnp
@@ -72,13 +72,18 @@ struct RequestEnvelope {
 #   Decryption: X25519 DH(server_sk, clientEphemeralPublic) -> AES-256-GCM-SIV
 struct SignedEnvelope {
   envelope @0 :RequestEnvelope;    # Cleartext envelope (used when encryptedEnvelope is absent)
-  sig @1 :Data $fixedSize(64);     # Ed25519 signature (64 bytes)
-  cnf @2 :Data $fixedSize(32);     # Ed25519 public key (32 bytes)
+  sig @1 :Data $fixedSize(64);     # Ed25519 signature (64 bytes) — cnf, sig retained for the
+  cnf @2 :Data $fixedSize(32);     # signer-pubkey advertisement + transition; auth comes from `cose`.
   encryptedEnvelope @3 :Data;      # AES-256-GCM-SIV ciphertext of serialized RequestEnvelope
   clientEphemeralPublic @4 :Data $fixedSize(32);  # X25519 ephemeral public key for DH
-  pqSig @5 :Data;                  # ML-DSA-65 signature (3309 bytes when present, pq-hybrid)
-  pqCnf @6 :Data;                  # ML-DSA-65 verifying key (1952 bytes when present, pq-hybrid)
-  pqKemCiphertext @7 :Data;        # ML-KEM-768 ciphertext (1088 bytes when present, pq-hybrid)
+  # M3 (#152): COSE composite signature (RFC 9052 COSE_Sign), detached over the
+  # canonical RequestEnvelope (cleartext) or the encrypted signing-data.
+  #   - Classical mode: ONE EdDSA COSE_Signature entry.
+  #   - Hybrid mode: TWO entries (EdDSA + ML-DSA-65).
+  # The ML-DSA-65 verifying key is NOT carried here; it is resolved by kid from
+  # the trust store (kid-anchored), fixing the prior self-certification gap.
+  cose @5 :Data;                   # CBOR-encoded COSE_Sign (composite signatures)
+  pqKemCiphertext @6 :Data;        # ML-KEM-768 ciphertext (1088 bytes) for hybrid encryption
 }
 
 # Signed response envelope

--- a/crates/hyprstream-rpc/src/auth/federation.rs
+++ b/crates/hyprstream-rpc/src/auth/federation.rs
@@ -11,7 +11,7 @@ use ed25519_dalek::VerifyingKey;
 ///
 /// Implemented by `hyprstream::auth::FederationKeyResolver`. Services that
 /// serve external traffic return `Some(Arc<dyn FederationKeySource>)` from
-/// `ZmqService::federation_key_source()` so the default `verify_claims()`
+/// `RequestService::federation_key_source()` so the default `verify_claims()`
 /// can perform real key resolution instead of rejecting federated JWTs.
 ///
 /// # Note on `Send` bounds
@@ -19,10 +19,10 @@ use ed25519_dalek::VerifyingKey;
 /// `get_key` uses the default (`Send`) flavour of `#[async_trait]` because
 /// `FederationKeyResolver` performs real async I/O (HTTPS JWKS fetch) whose
 /// future must be `Send`. Call sites inside `#[async_trait(?Send)]` contexts
-/// (e.g. `ZmqService::verify_claims`) may `.await` this future directly:
+/// (e.g. `RequestService::verify_claims`) may `.await` this future directly:
 /// it is valid in Rust to await a `Send` future from within a `!Send`
 /// async function — the `?Send` bound constrains the outer function's
-/// future, not the futures it polls. `ZmqService::verify_claims` does
+/// future, not the futures it polls. `RequestService::verify_claims` does
 /// exactly this and compiles correctly.
 #[async_trait::async_trait]
 pub trait FederationKeySource: Send + Sync + 'static {

--- a/crates/hyprstream-rpc/src/auth/jwt.rs
+++ b/crates/hyprstream-rpc/src/auth/jwt.rs
@@ -30,7 +30,6 @@ pub enum JwkThumbprintInput<'a> {
     Rsa { n: &'a str, e: &'a str },
     /// AKP / ML-DSA-65 (draft-ietf-cose-dilithium-11): canonical
     /// `{"alg":"ML-DSA-65","kty":"AKP","pub":"<base64url>"}`
-    #[cfg(feature = "pq-hybrid")]
     Akp { alg: &'a str, pub_bytes: &'a [u8] },
 }
 
@@ -52,7 +51,6 @@ pub fn jwk_thumbprint(input: &JwkThumbprintInput<'_>) -> String {
         JwkThumbprintInput::Rsa { n, e } => {
             format!(r#"{{"e":"{}","kty":"RSA","n":"{}"}}"#, e, n)
         }
-        #[cfg(feature = "pq-hybrid")]
         JwkThumbprintInput::Akp { alg, pub_bytes } => {
             let pub_b64 = URL_SAFE_NO_PAD.encode(pub_bytes);
             format!(r#"{{"alg":"{}","kty":"AKP","pub":"{}"}}"#, alg, pub_b64)
@@ -320,7 +318,6 @@ pub fn decode_unverified(token: &str) -> Result<Claims, JwtError> {
 /// Uses lenient audience validation (same as `decode_with_key`): if
 /// `expected_aud` is `Some`, a wrong `aud` is rejected but an absent
 /// `aud` is accepted.
-#[cfg(feature = "pq-hybrid")]
 pub fn decode_ml_dsa_65(
     token: &str,
     vk: &crate::crypto::pq::MlDsaVerifyingKey,
@@ -379,7 +376,6 @@ pub fn decode_ml_dsa_65(
 ///
 /// Per draft-ietf-jose-pq-composite-sigs, the signature is
 /// `ml_dsa_sig (3309 bytes) ∥ ed25519_sig (64 bytes)`.
-#[cfg(feature = "pq-hybrid")]
 pub fn decode_composite(
     token: &str,
     ml_dsa_vk: &crate::crypto::pq::MlDsaVerifyingKey,

--- a/crates/hyprstream-rpc/src/auth/key_source.rs
+++ b/crates/hyprstream-rpc/src/auth/key_source.rs
@@ -23,6 +23,12 @@
 //! let service = MyService::new(...).with_jwt_key_source(key_source);
 //! ```
 
+// The ML-DSA-65 verifying-key list is shared across crates (the rotation task
+// in `hyprstream` and the service factory in `hyprstream-service`) via an
+// `Arc<std::sync::RwLock<..>>` contract, so this module intentionally uses
+// `std::sync::RwLock` for that field rather than `parking_lot::RwLock`.
+#![allow(clippy::disallowed_types)]
+
 use anyhow::Result;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use ed25519_dalek::VerifyingKey;
@@ -64,7 +70,6 @@ pub trait JwtKeySource: Send + Sync + 'static {
     ///
     /// Returns keys for all rotation slots (drain/active/lead) so that tokens
     /// signed by any current slot can be verified. Empty vec disables PQ verification.
-    #[cfg(feature = "pq-hybrid")]
     fn ml_dsa_verifying_keys(&self) -> Vec<crate::crypto::pq::MlDsaVerifyingKey> {
         vec![]
     }
@@ -95,7 +100,6 @@ pub struct ClusterKeySource {
     ca_verifying_key: VerifyingKey,
     local_issuer_url: String,
     local_issuers_vec: Vec<String>,
-    #[cfg(feature = "pq-hybrid")]
     ml_dsa_vks: Arc<std::sync::RwLock<Vec<crate::crypto::pq::MlDsaVerifyingKey>>>,
 }
 
@@ -116,7 +120,6 @@ impl ClusterKeySource {
             ca_verifying_key,
             local_issuer_url,
             local_issuers_vec,
-            #[cfg(feature = "pq-hybrid")]
             ml_dsa_vks: Arc::new(std::sync::RwLock::new(Vec::new())),
         }
     }
@@ -124,7 +127,6 @@ impl ClusterKeySource {
     /// Set the shared ML-DSA-65 verifying key list for PQ-hybrid JWT verification.
     ///
     /// The Arc is shared with the rotation task so keys stay current.
-    #[cfg(feature = "pq-hybrid")]
     pub fn with_ml_dsa_verifying_keys(mut self, vks: Arc<std::sync::RwLock<Vec<crate::crypto::pq::MlDsaVerifyingKey>>>) -> Self {
         self.ml_dsa_vks = vks;
         self
@@ -159,9 +161,8 @@ impl JwtKeySource for ClusterKeySource {
         &self.local_issuers_vec
     }
 
-    #[cfg(feature = "pq-hybrid")]
     fn ml_dsa_verifying_keys(&self) -> Vec<crate::crypto::pq::MlDsaVerifyingKey> {
-        self.ml_dsa_vks.read().unwrap_or_else(|p| p.into_inner()).clone()
+        self.ml_dsa_vks.read().unwrap_or_else(std::sync::PoisonError::into_inner).clone()
     }
 }
 
@@ -214,7 +215,6 @@ impl JwtKeySource for FederatedKeySource {
         self.local.local_issuers()
     }
 
-    #[cfg(feature = "pq-hybrid")]
     fn ml_dsa_verifying_keys(&self) -> Vec<crate::crypto::pq::MlDsaVerifyingKey> {
         self.local.ml_dsa_verifying_keys()
     }
@@ -283,7 +283,6 @@ pub struct JwksKeySource {
     soft_ttl: std::time::Duration,
     /// Negative cache TTL (unknown kids cached as missing for this duration)
     negative_ttl: std::time::Duration,
-    #[cfg(feature = "pq-hybrid")]
     ml_dsa_vks: Arc<std::sync::RwLock<Vec<crate::crypto::pq::MlDsaVerifyingKey>>>,
 }
 
@@ -305,13 +304,11 @@ impl JwksKeySource {
             fetch_semaphore: Semaphore::new(4),
             soft_ttl: std::time::Duration::from_secs(300),
             negative_ttl: std::time::Duration::from_secs(5),
-            #[cfg(feature = "pq-hybrid")]
             ml_dsa_vks: Arc::new(std::sync::RwLock::new(Vec::new())),
         }
     }
 
     /// Set the shared ML-DSA-65 verifying key list for PQ-hybrid JWT verification.
-    #[cfg(feature = "pq-hybrid")]
     pub fn with_ml_dsa_verifying_keys(mut self, vks: Arc<std::sync::RwLock<Vec<crate::crypto::pq::MlDsaVerifyingKey>>>) -> Self {
         self.ml_dsa_vks = vks;
         self
@@ -491,9 +488,8 @@ impl JwtKeySource for JwksKeySource {
         &self.local_issuers_vec
     }
 
-    #[cfg(feature = "pq-hybrid")]
     fn ml_dsa_verifying_keys(&self) -> Vec<crate::crypto::pq::MlDsaVerifyingKey> {
-        self.ml_dsa_vks.read().unwrap_or_else(|p| p.into_inner()).clone()
+        self.ml_dsa_vks.read().unwrap_or_else(std::sync::PoisonError::into_inner).clone()
     }
 
     fn kid_algs(&self, kid: &str) -> Vec<String> {

--- a/crates/hyprstream-rpc/src/crypto/cose_sign.rs
+++ b/crates/hyprstream-rpc/src/crypto/cose_sign.rs
@@ -1,0 +1,563 @@
+//! Nested-COSE **Strong-Non-Separable (SNS)** composite signing for the
+//! hyprstream `SignedEnvelope` (EdDSA + ML-DSA-65).
+//!
+//! M3 (#152) migrates envelope authentication to a **nested COSE composite**.
+//! A prior design used a `COSE_Sign` with two *independent* signatures over the
+//! same payload (concatenation / Weak-Non-Separable, WNS). A security review
+//! found that scheme **fail-open + strippable**: an attacker could remove the
+//! ML-DSA-65 signature and the remaining EdDSA-only object still verified under
+//! a verifier that did not actively require the PQ entry. This module replaces
+//! it with a **Strong-Non-Separable (SNS)** nesting:
+//!
+//! ```text
+//! Classical:
+//!   inner  = EdDSA   COSE_Sign1 over  payload                       (detached)
+//!
+//! Hybrid (SNS):
+//!   inner  = EdDSA   COSE_Sign1 over  payload                       (detached)
+//!   outer  = ML-DSA  COSE_Sign1 over  payload ‖ inner_eddsa_sig     (detached)
+//! ```
+//!
+//! Both layers bind the same `external_aad` (the CBOR `[envelope_schema_id,
+//! inner_type_id]` schema binding, see [`crate::crypto::cose_sign1::build_external_aad`]).
+//!
+//! # Why this is SNS
+//!
+//! - The OUTER ML-DSA-65 signature covers `payload ‖ inner_eddsa_signature`, so
+//!   the inner signature is *part of the outer's signed message*. Tampering with
+//!   or removing the inner EdDSA signature invalidates the outer.
+//! - Under Hybrid policy the verifier REQUIRES the outer ML-DSA-65 layer and an
+//!   anchored PQ key. **Stripping the outer fails the policy** (there is no
+//!   valid outer to verify), so a downgrade-to-classical attack is rejected.
+//! - The PQ key is kid-anchored: it is resolved from a [`PqTrustStore`] keyed by
+//!   the EdDSA signer identity, never self-asserted in the COSE object. This
+//!   closes the prior self-certification weakness.
+//!
+//! # Wire shape (`SignedEnvelope.cose`)
+//!
+//! A definite-length CBOR array of two entries:
+//!
+//! ```text
+//! [ inner_cose_sign1_bytes : bstr,
+//!   outer_cose_sign1_bytes : bstr / null ]   ; null in Classical mode
+//! ```
+//!
+//! The signed payloads are *detached* (never embedded). Each COSE_Sign1 carries
+//! its signer's `kid` + `alg` in its protected header.
+
+use anyhow::{anyhow, bail, Context, Result};
+use ciborium::value::Value as CborValue;
+use coset::{
+    iana::{self, EnumI64},
+    CborSerializable, CoseSign1, CoseSign1Builder, HeaderBuilder,
+};
+
+use crate::crypto::pq::{ml_dsa_sign, ml_dsa_verify, MlDsaSigningKey, MlDsaVerifyingKey};
+
+/// IANA COSE algorithm id for ML-DSA-65 (FIPS 204, draft-ietf-cose-dilithium).
+pub const ALG_ML_DSA_65: i64 = iana::Algorithm::ML_DSA_65 as i64;
+
+/// EdDSA kid convention: raw 32-byte Ed25519 verifying key.
+fn eddsa_kid(vk: &ed25519_dalek::VerifyingKey) -> Vec<u8> {
+    vk.to_bytes().to_vec()
+}
+
+/// ML-DSA-65 kid convention: raw verifying key bytes (1952 bytes).
+fn ml_dsa_kid(vk: &MlDsaVerifyingKey) -> Vec<u8> {
+    crate::crypto::pq::ml_dsa_vk_bytes(vk)
+}
+
+/// Build the inner EdDSA `COSE_Sign1` over the detached `payload`.
+fn build_inner_eddsa(
+    ed_sk: &ed25519_dalek::SigningKey,
+    payload: &[u8],
+    external_aad: &[u8],
+) -> Result<CoseSign1> {
+    use ed25519_dalek::Signer as _;
+    let protected = HeaderBuilder::new()
+        .algorithm(iana::Algorithm::EdDSA)
+        .key_id(eddsa_kid(&ed_sk.verifying_key()))
+        .build();
+    Ok(CoseSign1Builder::new()
+        .protected(protected)
+        .create_detached_signature(payload, external_aad, |tbs| {
+            ed_sk.sign(tbs).to_bytes().to_vec()
+        })
+        .build())
+}
+
+/// Build the outer ML-DSA-65 `COSE_Sign1` over the detached
+/// `payload ‖ inner_eddsa_signature` (the SNS binding).
+fn build_outer_mldsa(
+    pq_sk: &MlDsaSigningKey,
+    outer_payload: &[u8],
+    external_aad: &[u8],
+) -> Result<CoseSign1> {
+    use ml_dsa::Keypair;
+    let pq_vk = pq_sk.verifying_key().clone();
+    let protected = HeaderBuilder::new()
+        .algorithm(iana::Algorithm::ML_DSA_65)
+        .key_id(ml_dsa_kid(&pq_vk))
+        .build();
+    Ok(CoseSign1Builder::new()
+        .protected(protected)
+        .create_detached_signature(outer_payload, external_aad, |tbs| ml_dsa_sign(pq_sk, tbs))
+        .build())
+}
+
+/// Encode the nested composite as a 2-element CBOR array
+/// `[inner_bstr, outer_bstr | null]`.
+fn encode_composite(inner: Vec<u8>, outer: Option<Vec<u8>>) -> Result<Vec<u8>> {
+    let arr = CborValue::Array(vec![
+        CborValue::Bytes(inner),
+        match outer {
+            Some(o) => CborValue::Bytes(o),
+            None => CborValue::Null,
+        },
+    ]);
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&arr, &mut buf)
+        .map_err(|e| anyhow!("failed to encode nested COSE composite: {e}"))?;
+    Ok(buf)
+}
+
+/// Decode the nested composite back into `(inner_bytes, Option<outer_bytes>)`.
+fn decode_composite(bytes: &[u8]) -> Result<(Vec<u8>, Option<Vec<u8>>)> {
+    let value: CborValue = ciborium::de::from_reader(bytes)
+        .map_err(|e| anyhow!("malformed nested COSE composite: {e}"))?;
+    let arr = match value {
+        CborValue::Array(a) => a,
+        _ => bail!("nested COSE composite must be a CBOR array"),
+    };
+    if arr.len() != 2 {
+        bail!("nested COSE composite must have exactly 2 elements, got {}", arr.len());
+    }
+    let inner = match &arr[0] {
+        CborValue::Bytes(b) => b.clone(),
+        _ => bail!("nested COSE composite inner entry must be a byte string"),
+    };
+    let outer = match &arr[1] {
+        CborValue::Null => None,
+        CborValue::Bytes(b) => Some(b.clone()),
+        _ => bail!("nested COSE composite outer entry must be a byte string or null"),
+    };
+    Ok((inner, outer))
+}
+
+/// The raw inner EdDSA signature bytes (64) extracted from an inner COSE_Sign1.
+fn inner_signature_bytes(inner: &CoseSign1) -> &[u8] {
+    &inner.signature
+}
+
+/// Compute the outer payload for the SNS binding: `payload ‖ inner_eddsa_sig`.
+fn outer_payload(payload: &[u8], inner_sig: &[u8]) -> Vec<u8> {
+    let mut v = Vec::with_capacity(payload.len() + inner_sig.len());
+    v.extend_from_slice(payload);
+    v.extend_from_slice(inner_sig);
+    v
+}
+
+/// Sign `payload` (detached) producing the CBOR-encoded nested COSE composite.
+///
+/// - Classical (`pq_sk = None`): single inner EdDSA COSE_Sign1, outer = null.
+/// - Hybrid (`pq_sk = Some`): inner EdDSA over `payload`, outer ML-DSA-65 over
+///   `payload ‖ inner_eddsa_signature` (SNS).
+pub fn sign_composite(
+    ed_sk: &ed25519_dalek::SigningKey,
+    pq_sk: Option<&MlDsaSigningKey>,
+    payload: &[u8],
+    external_aad: &[u8],
+) -> Result<Vec<u8>> {
+    let inner = build_inner_eddsa(ed_sk, payload, external_aad)?;
+    let inner_sig = inner_signature_bytes(&inner).to_vec();
+    let inner_bytes = inner
+        .to_vec()
+        .map_err(|e| anyhow!("failed to serialize inner EdDSA COSE_Sign1: {e}"))?;
+
+    let outer_bytes = match pq_sk {
+        Some(pq) => {
+            let outer_pl = outer_payload(payload, &inner_sig);
+            let outer = build_outer_mldsa(pq, &outer_pl, external_aad)?;
+            Some(
+                outer
+                    .to_vec()
+                    .map_err(|e| anyhow!("failed to serialize outer ML-DSA COSE_Sign1: {e}"))?,
+            )
+        }
+        None => None,
+    };
+
+    encode_composite(inner_bytes, outer_bytes)
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Out-of-band (async / WASM) signing API for the nested SNS composite.
+//
+// Abstract signers (e.g. the WASM `JsSigner`) cannot run inside a synchronous
+// signing closure, so they compute each layer's to-be-signed bytes, sign them
+// out-of-band, and assemble the composite here. The SNS nesting REQUIRES the
+// outer ML-DSA layer to sign `payload ‖ inner_eddsa_signature`, so callers MUST
+// sign the inner first, take its signature, then sign the outer over
+// [`outer_tbs`].
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Build an unsigned inner EdDSA `COSE_Sign1` (protected header only).
+fn unsigned_inner(ed_kid: Vec<u8>) -> CoseSign1 {
+    CoseSign1Builder::new()
+        .protected(
+            HeaderBuilder::new()
+                .algorithm(iana::Algorithm::EdDSA)
+                .key_id(ed_kid)
+                .build(),
+        )
+        .build()
+}
+
+/// Build an unsigned outer ML-DSA-65 `COSE_Sign1` (protected header only).
+fn unsigned_outer(pq_kid: Vec<u8>) -> CoseSign1 {
+    CoseSign1Builder::new()
+        .protected(
+            HeaderBuilder::new()
+                .algorithm(iana::Algorithm::ML_DSA_65)
+                .key_id(pq_kid)
+                .build(),
+        )
+        .build()
+}
+
+/// Compute the inner EdDSA layer's detached to-be-signed bytes.
+pub fn inner_tbs(ed_kid: Vec<u8>, payload: &[u8], external_aad: &[u8]) -> Vec<u8> {
+    unsigned_inner(ed_kid).tbs_detached_data(payload, external_aad)
+}
+
+/// Compute the outer ML-DSA-65 layer's detached to-be-signed bytes over
+/// `payload ‖ inner_eddsa_signature` (the SNS binding).
+pub fn outer_tbs(
+    pq_kid: Vec<u8>,
+    payload: &[u8],
+    inner_eddsa_sig: &[u8],
+    external_aad: &[u8],
+) -> Vec<u8> {
+    let outer_pl = outer_payload(payload, inner_eddsa_sig);
+    unsigned_outer(pq_kid).tbs_detached_data(&outer_pl, external_aad)
+}
+
+/// Assemble the nested SNS composite from out-of-band signatures.
+///
+/// - `ed = (ed_kid, ed_signature)` — required; `ed_signature` is the raw 64-byte
+///   Ed25519 signature over [`inner_tbs`].
+/// - `pq = Some((pq_kid, pq_signature))` — Hybrid; `pq_signature` is the ML-DSA-65
+///   signature over [`outer_tbs`] (which was computed using `ed_signature`).
+pub fn assemble_composite_nested(
+    ed: (Vec<u8>, Vec<u8>),
+    pq: Option<(Vec<u8>, Vec<u8>)>,
+) -> Result<Vec<u8>> {
+    let (ed_kid, ed_sig) = ed;
+    let mut inner = unsigned_inner(ed_kid);
+    inner.signature = ed_sig;
+    let inner_bytes = inner
+        .to_vec()
+        .map_err(|e| anyhow!("serialize inner EdDSA COSE_Sign1: {e}"))?;
+
+    let outer_bytes = match pq {
+        Some((pq_kid, pq_sig)) => {
+            let mut outer = unsigned_outer(pq_kid);
+            outer.signature = pq_sig;
+            Some(
+                outer
+                    .to_vec()
+                    .map_err(|e| anyhow!("serialize outer ML-DSA COSE_Sign1: {e}"))?,
+            )
+        }
+        None => None,
+    };
+
+    encode_composite(inner_bytes, outer_bytes)
+}
+
+/// Test-only: decode a composite into `(inner_bytes, Option<outer_bytes>)`.
+///
+/// Exposed so integration tests in other modules (e.g. `envelope.rs`) can
+/// simulate an attacker stripping the outer ML-DSA layer.
+#[doc(hidden)]
+pub fn decode_composite_for_test(bytes: &[u8]) -> Result<(Vec<u8>, Option<Vec<u8>>)> {
+    decode_composite(bytes)
+}
+
+/// Test-only: re-encode a composite from `(inner_bytes, Option<outer_bytes>)`.
+#[doc(hidden)]
+pub fn encode_composite_for_test(inner: Vec<u8>, outer: Option<Vec<u8>>) -> Result<Vec<u8>> {
+    encode_composite(inner, outer)
+}
+
+/// Outcome of composite verification.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompositeVerified {
+    /// Inner EdDSA was verified.
+    pub eddsa: bool,
+    /// Outer ML-DSA-65 (SNS) was verified.
+    pub ml_dsa: bool,
+}
+
+/// Verify a CBOR-encoded nested COSE composite against a detached `payload`.
+///
+/// # kid-anchoring
+///
+/// `expected_ed_vk` is the EdDSA verifying key resolved by the caller. When
+/// `expected_pq_vk` is `Some`, it is the trust-anchored ML-DSA-65 key — the
+/// outer COSE entry's kid AND signature must verify against it, closing the
+/// self-certification gap.
+///
+/// # Policy
+///
+/// - `require_pq = true` (Hybrid verifier): the OUTER ML-DSA-65 layer MUST be
+///   present and verify against the anchored key over `payload ‖ inner_sig`, AND
+///   the inner EdDSA layer MUST verify over `payload`. If `expected_pq_vk` is
+///   `None`, verification fails (no anchor — fail-closed). **Stripping the outer
+///   layer (outer = null) is rejected.**
+/// - `require_pq = false` (Classical verifier): only the inner EdDSA layer is
+///   required and verified; any outer ML-DSA layer is IGNORED (skip-unknown
+///   interop — a Hybrid-signed envelope still verifies via its inner EdDSA).
+pub fn verify_composite(
+    cose_composite_bytes: &[u8],
+    expected_ed_vk: &ed25519_dalek::VerifyingKey,
+    expected_pq_vk: Option<&MlDsaVerifyingKey>,
+    payload: &[u8],
+    external_aad: &[u8],
+    require_pq: bool,
+) -> Result<CompositeVerified> {
+    let (inner_bytes, outer_bytes) = decode_composite(cose_composite_bytes)?;
+
+    // --- Inner EdDSA layer (always required) ---
+    let inner = CoseSign1::from_slice(&inner_bytes)
+        .map_err(|e| anyhow!("malformed inner EdDSA COSE_Sign1: {e}"))?;
+
+    let inner_alg = header_alg(&inner)?;
+    if inner_alg != iana::Algorithm::EdDSA.to_i64() {
+        bail!("inner COSE_Sign1 must be EdDSA, got alg={inner_alg}");
+    }
+    let inner_kid = &inner.protected.header.key_id;
+    if !inner_kid.is_empty() && inner_kid.as_slice() != expected_ed_vk.to_bytes() {
+        bail!("inner EdDSA COSE_Sign1 kid does not match anchored EdDSA key");
+    }
+    inner
+        .verify_detached_signature(payload, external_aad, |sig, tbs| {
+            ed_verify(expected_ed_vk, tbs, sig)
+        })
+        .context("inner EdDSA signature verification failed")?;
+    let eddsa_ok = true;
+
+    // Capture the inner signature; it is the SNS binding for the outer layer.
+    let inner_sig = inner_signature_bytes(&inner).to_vec();
+
+    // --- Outer ML-DSA-65 layer (SNS) ---
+    let mut ml_dsa_ok = false;
+
+    match outer_bytes {
+        Some(ref ob) if require_pq || expected_pq_vk.is_some() => {
+            // Anchored PQ key is mandatory to verify the outer layer.
+            let Some(pq_vk) = expected_pq_vk else {
+                if require_pq {
+                    bail!("Hybrid policy requires an anchored ML-DSA-65 key, none provided");
+                }
+                // Classical verifier without an anchor: ignore the outer layer.
+                return Ok(CompositeVerified { eddsa: eddsa_ok, ml_dsa: false });
+            };
+            let outer = CoseSign1::from_slice(ob)
+                .map_err(|e| anyhow!("malformed outer ML-DSA COSE_Sign1: {e}"))?;
+            let outer_alg = header_alg(&outer)?;
+            if outer_alg != ALG_ML_DSA_65 {
+                bail!("outer COSE_Sign1 must be ML-DSA-65, got alg={outer_alg}");
+            }
+            let outer_kid = &outer.protected.header.key_id;
+            if !outer_kid.is_empty() && outer_kid.as_slice() != ml_dsa_kid(pq_vk).as_slice() {
+                bail!("outer ML-DSA-65 COSE_Sign1 kid does not match anchored PQ key (self-cert rejected)");
+            }
+            let outer_pl = outer_payload(payload, &inner_sig);
+            outer
+                .verify_detached_signature(&outer_pl, external_aad, |sig, tbs| {
+                    ml_dsa_verify(pq_vk, tbs, sig)
+                })
+                .context("outer ML-DSA-65 signature verification failed")?;
+            ml_dsa_ok = true;
+        }
+        Some(_) => {
+            // require_pq is false and no anchor: ignore outer (skip-unknown).
+        }
+        None => {
+            // No outer layer present (Classical-signed).
+            if require_pq {
+                bail!("Hybrid policy requires the outer ML-DSA-65 layer, but it is absent (stripped or classical-only)");
+            }
+        }
+    }
+
+    if require_pq && !ml_dsa_ok {
+        bail!("Hybrid policy: outer ML-DSA-65 layer missing or unverified");
+    }
+
+    Ok(CompositeVerified { eddsa: eddsa_ok, ml_dsa: ml_dsa_ok })
+}
+
+/// Extract the IANA alg integer from a COSE_Sign1 protected header.
+fn header_alg(cose: &CoseSign1) -> Result<i64> {
+    match cose.protected.header.alg.as_ref() {
+        Some(coset::Algorithm::Assigned(a)) => Ok(a.to_i64()),
+        Some(coset::Algorithm::PrivateUse(v)) => Ok(*v),
+        Some(coset::Algorithm::Text(s)) => bail!("unsupported text algorithm: {s}"),
+        None => bail!("COSE_Sign1 missing alg in protected header"),
+    }
+}
+
+fn ed_verify(vk: &ed25519_dalek::VerifyingKey, msg: &[u8], sig: &[u8]) -> Result<()> {
+    if sig.len() != 64 {
+        bail!("Ed25519 signature must be 64 bytes, got {}", sig.len());
+    }
+    let mut arr = [0u8; 64];
+    arr.copy_from_slice(sig);
+    let signature = ed25519_dalek::Signature::from_bytes(&arr);
+    vk.verify_strict(msg, &signature)
+        .map_err(|e| anyhow!("Ed25519 verification failed: {e}"))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::crypto::cose_sign1::build_external_aad;
+    use crate::crypto::pq::ml_dsa_generate_keypair;
+    use ed25519_dalek::SigningKey;
+    use rand::rngs::OsRng;
+
+    const SCHEMA_ID: u64 = 0xcf5e_016c_5d4a_af92;
+    const INNER_TYPE_ID: u64 = 0xdead_beef_cafe_babe;
+
+    fn aad() -> Vec<u8> {
+        build_external_aad(SCHEMA_ID, INNER_TYPE_ID)
+    }
+
+    #[test]
+    fn classical_sign_verify() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let payload = b"classical payload";
+        let cose = sign_composite(&ed, None, payload, &aad()).unwrap();
+        let res = verify_composite(&cose, &ed.verifying_key(), None, payload, &aad(), false).unwrap();
+        assert!(res.eddsa);
+        assert!(!res.ml_dsa);
+    }
+
+    #[test]
+    fn hybrid_sign_verify_both() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let (pq_sk, pq_vk) = ml_dsa_generate_keypair();
+        let payload = b"hybrid payload";
+        let cose = sign_composite(&ed, Some(&pq_sk), payload, &aad()).unwrap();
+        let res = verify_composite(&cose, &ed.verifying_key(), Some(&pq_vk), payload, &aad(), true).unwrap();
+        assert!(res.eddsa);
+        assert!(res.ml_dsa);
+    }
+
+    #[test]
+    fn hybrid_signed_verified_by_classical_via_eddsa() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let (pq_sk, _pq_vk) = ml_dsa_generate_keypair();
+        let payload = b"cross payload";
+        let cose = sign_composite(&ed, Some(&pq_sk), payload, &aad()).unwrap();
+        // Classical verifier: no PQ key, require_pq=false → inner EdDSA only.
+        let res = verify_composite(&cose, &ed.verifying_key(), None, payload, &aad(), false).unwrap();
+        assert!(res.eddsa);
+        assert!(!res.ml_dsa);
+    }
+
+    #[test]
+    fn classical_signed_rejected_by_hybrid_policy() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let (_pq_sk, pq_vk) = ml_dsa_generate_keypair();
+        let payload = b"classical only";
+        let cose = sign_composite(&ed, None, payload, &aad()).unwrap();
+        // Hybrid verifier requires the outer layer → absent → rejected.
+        let res = verify_composite(&cose, &ed.verifying_key(), Some(&pq_vk), payload, &aad(), true);
+        assert!(res.is_err(), "hybrid policy must reject classical-only (no outer layer)");
+    }
+
+    #[test]
+    fn self_cert_wrong_pq_key_rejected() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let (pq_sk, _pq_vk) = ml_dsa_generate_keypair();
+        let (_other_sk, other_vk) = ml_dsa_generate_keypair();
+        let payload = b"anchored";
+        let cose = sign_composite(&ed, Some(&pq_sk), payload, &aad()).unwrap();
+        let res = verify_composite(&cose, &ed.verifying_key(), Some(&other_vk), payload, &aad(), true);
+        assert!(res.is_err(), "PQ key not matching kid-anchored key must be rejected");
+    }
+
+    #[test]
+    fn tampered_payload_rejected() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let (pq_sk, pq_vk) = ml_dsa_generate_keypair();
+        let cose = sign_composite(&ed, Some(&pq_sk), b"orig", &aad()).unwrap();
+        let res = verify_composite(&cose, &ed.verifying_key(), Some(&pq_vk), b"tampered", &aad(), true);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn wrong_aad_rejected() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let cose = sign_composite(&ed, None, b"p", &aad()).unwrap();
+        let wrong = build_external_aad(SCHEMA_ID, INNER_TYPE_ID ^ 1);
+        let res = verify_composite(&cose, &ed.verifying_key(), None, b"p", &wrong, false);
+        assert!(res.is_err());
+    }
+
+    /// SNS: stripping the outer ML-DSA layer (set to null) must be rejected
+    /// under Hybrid policy. This is the attack the review found accepted before.
+    #[test]
+    fn strip_outer_mldsa_rejected_under_hybrid() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let (pq_sk, pq_vk) = ml_dsa_generate_keypair();
+        let payload = b"strip me";
+        let cose = sign_composite(&ed, Some(&pq_sk), payload, &aad()).unwrap();
+
+        // Strip: rebuild the composite with the outer set to null.
+        let (inner, _outer) = decode_composite(&cose).unwrap();
+        let stripped = encode_composite(inner, None).unwrap();
+
+        let res = verify_composite(&stripped, &ed.verifying_key(), Some(&pq_vk), payload, &aad(), true);
+        assert!(res.is_err(), "stripping the outer ML-DSA layer must fail Hybrid policy");
+    }
+
+    /// SNS: tampering with the inner EdDSA signature invalidates the outer,
+    /// because the outer signs `payload ‖ inner_sig`.
+    #[test]
+    fn tamper_inner_eddsa_invalidates_outer() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let (pq_sk, pq_vk) = ml_dsa_generate_keypair();
+        let payload = b"sns binding";
+        let cose = sign_composite(&ed, Some(&pq_sk), payload, &aad()).unwrap();
+
+        // Re-sign the inner with a DIFFERENT EdDSA key but keep the original
+        // outer. The inner kid won't match the anchored ed_vk, and even if it
+        // did, the outer was bound to the original inner_sig.
+        let (_inner, outer) = decode_composite(&cose).unwrap();
+        let other_ed = SigningKey::generate(&mut OsRng);
+        let forged_inner = build_inner_eddsa(&other_ed, payload, &aad()).unwrap();
+        let forged_inner_bytes = forged_inner.to_vec().unwrap();
+        let tampered = encode_composite(forged_inner_bytes, outer).unwrap();
+
+        // Verify under the ORIGINAL ed_vk + anchored pq_vk: inner kid mismatch
+        // OR outer-binding mismatch → reject.
+        let res = verify_composite(&tampered, &ed.verifying_key(), Some(&pq_vk), payload, &aad(), true);
+        assert!(res.is_err(), "tampering the inner EdDSA must invalidate the composite");
+    }
+
+    /// Hybrid policy with no anchored PQ key must fail closed.
+    #[test]
+    fn hybrid_no_anchor_rejected() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let (pq_sk, _pq_vk) = ml_dsa_generate_keypair();
+        let payload = b"no anchor";
+        let cose = sign_composite(&ed, Some(&pq_sk), payload, &aad()).unwrap();
+        let res = verify_composite(&cose, &ed.verifying_key(), None, payload, &aad(), true);
+        assert!(res.is_err(), "Hybrid policy requires an anchored PQ key");
+    }
+}

--- a/crates/hyprstream-rpc/src/crypto/cose_sign.rs
+++ b/crates/hyprstream-rpc/src/crypto/cose_sign.rs
@@ -1,19 +1,45 @@
-//! Nested-COSE **Strong-Non-Separable (SNS)** composite signing for the
-//! hyprstream `SignedEnvelope` (EdDSA + ML-DSA-65).
+//! Nested-COSE hybrid composite signing for the hyprstream `SignedEnvelope`
+//! (EdDSA + ML-DSA-65).
 //!
-//! M3 (#152) migrates envelope authentication to a **nested COSE composite**.
-//! A prior design used a `COSE_Sign` with two *independent* signatures over the
-//! same payload (concatenation / Weak-Non-Separable, WNS). A security review
-//! found that scheme **fail-open + strippable**: an attacker could remove the
-//! ML-DSA-65 signature and the remaining EdDSA-only object still verified under
-//! a verifier that did not actively require the PQ entry. This module replaces
-//! it with a **Strong-Non-Separable (SNS)** nesting:
+//! ## Where this sits in the PQUIP hybrid-signature taxonomy
+//!
+//! In the taxonomy of `draft-ietf-pquip-hybrid-signature-spectrums` §1.3.4 this
+//! construction is **Weak Non-Separable (WNS)**, *not* Strong Non-Separable
+//! (SNS). SNS requires *fusion* — the two algorithms' signatures combined into a
+//! single object that cannot be verified by either component alone. We do not do
+//! that: we emit two distinct COSE_Sign1 signatures and bind them by nesting
+//! (the outer signs `payload ‖ inner_sig`). A classical-only verifier can — and,
+//! per [`verify_composite`]'s `require_pq = false` path, deliberately does —
+//! accept the inner EdDSA signature on its own. That standalone-acceptability is
+//! exactly what SNS precludes, so labelling this SNS would overstate the
+//! cryptographic guarantee.
+//!
+//! **Downgrade resistance here is enforced by *verifier policy*, not by the
+//! crypto.** It rests on two policy mechanisms, not on non-separability:
+//!   1. `require_pq` (fail-closed Hybrid policy): a Hybrid verifier rejects any
+//!      envelope lacking a valid outer ML-DSA-65 layer, so an attacker who strips
+//!      the outer layer is rejected by *policy* (not because the inner is
+//!      cryptographically unusable without it).
+//!   2. kid-anchoring: the PQ key is resolved from a [`PqTrustStore`] keyed by
+//!      the EdDSA signer identity, never self-asserted in the COSE object —
+//!      closing the self-certification gap a naïve two-signature scheme has.
+//!
+//! ## What the nesting *does* buy
+//!
+//! M3 (#152) replaced an earlier `COSE_Sign` with two *independent* signatures
+//! over the same payload (a fail-open, trivially strippable scheme). The nesting
+//! below is a real improvement over that: because the outer ML-DSA-65 signature
+//! covers `payload ‖ inner_eddsa_signature`, the inner signature is part of the
+//! outer's signed message — so once a verifier has *committed to checking the
+//! outer* (Hybrid policy), it cannot be fed a mismatched inner/outer pair. The
+//! nesting binds the two layers together; the *requirement* to check the outer
+//! at all comes from policy.
 //!
 //! ```text
 //! Classical:
 //!   inner  = EdDSA   COSE_Sign1 over  payload                       (detached)
 //!
-//! Hybrid (SNS):
+//! Hybrid (WNS, policy-enforced):
 //!   inner  = EdDSA   COSE_Sign1 over  payload                       (detached)
 //!   outer  = ML-DSA  COSE_Sign1 over  payload ‖ inner_eddsa_sig     (detached)
 //! ```
@@ -21,17 +47,12 @@
 //! Both layers bind the same `external_aad` (the CBOR `[envelope_schema_id,
 //! inner_type_id]` schema binding, see [`crate::crypto::cose_sign1::build_external_aad`]).
 //!
-//! # Why this is SNS
-//!
-//! - The OUTER ML-DSA-65 signature covers `payload ‖ inner_eddsa_signature`, so
-//!   the inner signature is *part of the outer's signed message*. Tampering with
-//!   or removing the inner EdDSA signature invalidates the outer.
-//! - Under Hybrid policy the verifier REQUIRES the outer ML-DSA-65 layer and an
-//!   anchored PQ key. **Stripping the outer fails the policy** (there is no
-//!   valid outer to verify), so a downgrade-to-classical attack is rejected.
-//! - The PQ key is kid-anchored: it is resolved from a [`PqTrustStore`] keyed by
-//!   the EdDSA signer identity, never self-asserted in the COSE object. This
-//!   closes the prior self-certification weakness.
+//! Note the `external_aad` does **not** currently carry a hybrid-composite
+//! algorithm identifier, so the inner EdDSA COSE_Sign1 produced in Hybrid mode is
+//! byte-identical to one produced in Classical mode. Binding a composite alg-id
+//! into the AAD would move this construction closer to true non-separability —
+//! but at the cost of the deliberate classical-verifier interop documented on
+//! [`verify_composite`]. That trade-off is tracked as a follow-up; see #152.
 //!
 //! # Wire shape (`SignedEnvelope.cose`)
 //!
@@ -87,7 +108,7 @@ fn build_inner_eddsa(
 }
 
 /// Build the outer ML-DSA-65 `COSE_Sign1` over the detached
-/// `payload ‖ inner_eddsa_signature` (the SNS binding).
+/// `payload ‖ inner_eddsa_signature` (the inner→outer binding).
 fn build_outer_mldsa(
     pq_sk: &MlDsaSigningKey,
     outer_payload: &[u8],
@@ -149,7 +170,7 @@ fn inner_signature_bytes(inner: &CoseSign1) -> &[u8] {
     &inner.signature
 }
 
-/// Compute the outer payload for the SNS binding: `payload ‖ inner_eddsa_sig`.
+/// Compute the outer payload for the inner→outer binding: `payload ‖ inner_eddsa_sig`.
 fn outer_payload(payload: &[u8], inner_sig: &[u8]) -> Vec<u8> {
     let mut v = Vec::with_capacity(payload.len() + inner_sig.len());
     v.extend_from_slice(payload);
@@ -161,7 +182,7 @@ fn outer_payload(payload: &[u8], inner_sig: &[u8]) -> Vec<u8> {
 ///
 /// - Classical (`pq_sk = None`): single inner EdDSA COSE_Sign1, outer = null.
 /// - Hybrid (`pq_sk = Some`): inner EdDSA over `payload`, outer ML-DSA-65 over
-///   `payload ‖ inner_eddsa_signature` (SNS).
+///   `payload ‖ inner_eddsa_signature` (the inner→outer binding).
 pub fn sign_composite(
     ed_sk: &ed25519_dalek::SigningKey,
     pq_sk: Option<&MlDsaSigningKey>,
@@ -191,11 +212,11 @@ pub fn sign_composite(
 }
 
 // ────────────────────────────────────────────────────────────────────────────
-// Out-of-band (async / WASM) signing API for the nested SNS composite.
+// Out-of-band (async / WASM) signing API for the nested WNS composite.
 //
 // Abstract signers (e.g. the WASM `JsSigner`) cannot run inside a synchronous
 // signing closure, so they compute each layer's to-be-signed bytes, sign them
-// out-of-band, and assemble the composite here. The SNS nesting REQUIRES the
+// out-of-band, and assemble the composite here. The nesting REQUIRES the
 // outer ML-DSA layer to sign `payload ‖ inner_eddsa_signature`, so callers MUST
 // sign the inner first, take its signature, then sign the outer over
 // [`outer_tbs`].
@@ -231,7 +252,7 @@ pub fn inner_tbs(ed_kid: Vec<u8>, payload: &[u8], external_aad: &[u8]) -> Vec<u8
 }
 
 /// Compute the outer ML-DSA-65 layer's detached to-be-signed bytes over
-/// `payload ‖ inner_eddsa_signature` (the SNS binding).
+/// `payload ‖ inner_eddsa_signature` (the inner→outer binding).
 pub fn outer_tbs(
     pq_kid: Vec<u8>,
     payload: &[u8],
@@ -242,7 +263,7 @@ pub fn outer_tbs(
     unsigned_outer(pq_kid).tbs_detached_data(&outer_pl, external_aad)
 }
 
-/// Assemble the nested SNS composite from out-of-band signatures.
+/// Assemble the nested WNS composite from out-of-band signatures.
 ///
 /// - `ed = (ed_kid, ed_signature)` — required; `ed_signature` is the raw 64-byte
 ///   Ed25519 signature over [`inner_tbs`].
@@ -295,7 +316,7 @@ pub fn encode_composite_for_test(inner: Vec<u8>, outer: Option<Vec<u8>>) -> Resu
 pub struct CompositeVerified {
     /// Inner EdDSA was verified.
     pub eddsa: bool,
-    /// Outer ML-DSA-65 (SNS) was verified.
+    /// Outer ML-DSA-65 layer was verified.
     pub ml_dsa: bool,
 }
 
@@ -347,10 +368,10 @@ pub fn verify_composite(
         .context("inner EdDSA signature verification failed")?;
     let eddsa_ok = true;
 
-    // Capture the inner signature; it is the SNS binding for the outer layer.
+    // Capture the inner signature; it is bound into the outer layer's signed message.
     let inner_sig = inner_signature_bytes(&inner).to_vec();
 
-    // --- Outer ML-DSA-65 layer (SNS) ---
+    // --- Outer ML-DSA-65 layer (inner→outer binding) ---
     let mut ml_dsa_ok = false;
 
     match outer_bytes {
@@ -509,7 +530,7 @@ mod tests {
         assert!(res.is_err());
     }
 
-    /// SNS: stripping the outer ML-DSA layer (set to null) must be rejected
+    /// Policy-enforced: stripping the outer ML-DSA layer (set to null) must be rejected
     /// under Hybrid policy. This is the attack the review found accepted before.
     #[test]
     fn strip_outer_mldsa_rejected_under_hybrid() {
@@ -526,7 +547,7 @@ mod tests {
         assert!(res.is_err(), "stripping the outer ML-DSA layer must fail Hybrid policy");
     }
 
-    /// SNS: tampering with the inner EdDSA signature invalidates the outer,
+    /// inner→outer binding: tampering with the inner EdDSA signature invalidates the outer,
     /// because the outer signs `payload ‖ inner_sig`.
     #[test]
     fn tamper_inner_eddsa_invalidates_outer() {

--- a/crates/hyprstream-rpc/src/crypto/envelope_crypto.rs
+++ b/crates/hyprstream-rpc/src/crypto/envelope_crypto.rs
@@ -99,7 +99,6 @@ pub fn decrypt_envelope(
 ///
 /// Two shared secrets are derived independently and combined via KDF.
 /// Returns `(ciphertext, ephemeral_public, kem_ciphertext)`.
-#[cfg(feature = "pq-hybrid")]
 pub fn encrypt_envelope_hybrid(
     plaintext: &[u8],
     server_ed25519_pubkey: &VerifyingKey,
@@ -132,7 +131,6 @@ pub fn encrypt_envelope_hybrid(
 }
 
 /// Hybrid envelope decryption: X25519 DH + ML-KEM-768 + AES-256-GCM-SIV.
-#[cfg(feature = "pq-hybrid")]
 pub fn decrypt_envelope_hybrid(
     ciphertext: &[u8],
     client_ephemeral_public: &[u8; 32],
@@ -161,7 +159,6 @@ pub fn decrypt_envelope_hybrid(
 }
 
 /// Derive AES-256 key from combined X25519 + ML-KEM shared secrets.
-#[cfg(feature = "pq-hybrid")]
 fn derive_hybrid_envelope_key(
     shared_x25519: &[u8; 32],
     shared_kem: &[u8; 32],
@@ -238,7 +235,6 @@ mod tests {
         assert_ne!(ct1, ct2);
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn hybrid_roundtrip() {
         let server_key = SigningKey::generate(&mut OsRng);
@@ -257,7 +253,6 @@ mod tests {
         assert_eq!(decrypted, plaintext);
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn hybrid_wrong_kem_key_fails() {
         let server_key = SigningKey::generate(&mut OsRng);

--- a/crates/hyprstream-rpc/src/crypto/mod.rs
+++ b/crates/hyprstream-rpc/src/crypto/mod.rs
@@ -28,14 +28,41 @@
 
 pub mod backend;
 pub mod cose_sign1;
+pub mod cose_sign;
 pub mod envelope_crypto;
 pub mod event_crypto;
 pub mod hmac;
 pub mod key_exchange;
 pub mod notification;
-#[cfg(feature = "pq-hybrid")]
 pub mod pq;
 pub mod signing;
+
+/// Runtime crypto mode selecting how envelopes/tokens are signed and verified.
+///
+/// This REPLACES the old compile-time `pq-hybrid` cargo feature. PQ primitives
+/// (ML-DSA-65, ML-KEM-768) are always compiled; the policy chooses whether they
+/// are used at runtime.
+///
+/// - `Hybrid` (default): sign with a COSE composite (EdDSA + ML-DSA-65) and
+///   REQUIRE both components to verify.
+/// - `Classical`: sign with EdDSA only and accept EdDSA-only signatures. A
+///   `Classical` verifier still accepts a `Hybrid`-signed item via its EdDSA
+///   component (RFC 7517 skip-unknown interop).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CryptoPolicy {
+    /// EdDSA only (classical).
+    Classical,
+    /// EdDSA + ML-DSA-65 composite (post-quantum hybrid). Default.
+    #[default]
+    Hybrid,
+}
+
+impl CryptoPolicy {
+    /// Whether this policy emits/requires the post-quantum (ML-DSA-65) component.
+    pub fn uses_pq(self) -> bool {
+        matches!(self, CryptoPolicy::Hybrid)
+    }
+}
 
 pub use backend::{derive_key, keyed_mac, keyed_mac_truncated};
 pub use hmac::StreamHmacState;

--- a/crates/hyprstream-rpc/src/crypto/pq.rs
+++ b/crates/hyprstream-rpc/src/crypto/pq.rs
@@ -1,6 +1,7 @@
 //! Post-quantum hybrid cryptographic primitives (ML-DSA-65 + ML-KEM-768).
 //!
-//! Gated behind `#[cfg(feature = "pq-hybrid")]`. Provides:
+//! Always compiled (M3 #152). Whether these are USED is a runtime decision via
+//! [`crate::crypto::CryptoPolicy`], not a compile-time cargo feature. Provides:
 //! - ML-DSA-65 (FIPS 204) digital signatures
 //! - ML-KEM-768 (FIPS 203) key encapsulation
 

--- a/crates/hyprstream-rpc/src/dial.rs
+++ b/crates/hyprstream-rpc/src/dial.rs
@@ -132,12 +132,23 @@ where
             Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
                 as Arc<dyn RpcClient>)
         }
-        endpoint @ (EndpointType::Ipc { .. }
-        | EndpointType::SystemdFd { .. }
-        | EndpointType::Quic { .. }) => bail!(
-            "dial(): endpoint {endpoint:?} is not yet served by the dial factory \
-             — lazy quinn/iroh/moq transports land in a later #151(a) increment; \
-             ZMQ ipc/systemd endpoints stay on the codegen path during the transition"
+        EndpointType::Quic { addr, cert_pin: Some(pin), .. } => {
+            // Pinned QUIC peer: the transport authenticates the server (pinned
+            // TLS), so a `None` server_verifying_key is sound here — response
+            // signatures are still verified against the envelope-embedded key.
+            let transport = crate::transport::lazy_quinn::LazyQuinnTransport::new(*addr, *pin);
+            Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
+                as Arc<dyn RpcClient>)
+        }
+        EndpointType::Quic { cert_pin: None, .. } => bail!(
+            "dial(): QUIC endpoint has no cert pin — cannot authenticate the server. \
+             The resolver must supply EndpointType::Quic.cert_pin (the server cert's \
+             SHA-256), e.g. via TransportConfig::quic_pinned"
+        ),
+        endpoint @ (EndpointType::Ipc { .. } | EndpointType::SystemdFd { .. }) => bail!(
+            "dial(): endpoint {endpoint:?} is not served by the dial factory — \
+             ZMQ ipc/systemd endpoints stay on the codegen path during the transition; \
+             iroh/moq lazy transports land in a later #151(a) increment"
         ),
     }
 }
@@ -208,5 +219,21 @@ mod tests {
         let cfg = TransportConfig::ipc("/tmp/hyprstream-test.sock");
         let err = dial(&cfg, test_signer(), None);
         assert!(err.is_err(), "ipc dial is not yet served by the factory");
+    }
+
+    #[test]
+    fn dial_quic_without_cert_pin_errors() {
+        // Plain `quic()` has no pin → cannot authenticate the server → must bail.
+        let cfg = TransportConfig::quic("127.0.0.1:9999".parse().unwrap(), "localhost");
+        let err = dial(&cfg, test_signer(), None);
+        assert!(err.is_err(), "QUIC dial without a cert pin must error");
+    }
+
+    #[test]
+    fn dial_quic_with_cert_pin_builds_client() {
+        // With a pin, dial() builds a (lazy, not-yet-connected) client — sync, no I/O.
+        let cfg = TransportConfig::quic_pinned("127.0.0.1:9999".parse().unwrap(), "localhost", [7u8; 32]);
+        let client = dial(&cfg, test_signer(), None);
+        assert!(client.is_ok(), "pinned QUIC dial must build a client without connecting");
     }
 }

--- a/crates/hyprstream-rpc/src/dial.rs
+++ b/crates/hyprstream-rpc/src/dial.rs
@@ -133,9 +133,19 @@ where
                 as Arc<dyn RpcClient>)
         }
         EndpointType::Quic { addr, cert_pin: Some(pin), .. } => {
-            // Pinned QUIC peer: the transport authenticates the server (pinned
-            // TLS), so a `None` server_verifying_key is sound here — response
-            // signatures are still verified against the envelope-embedded key.
+            // SECURITY (#185): the pin authenticates the TLS *channel* ("a server
+            // presenting this cert"), not the peer's DID identity. Identity comes
+            // from the response signature. With `None` here that signature is
+            // still verified, but only against the envelope-embedded key (no
+            // identity pinning) — so for a *networked* peer, prefer passing the
+            // resolver-known verifying key. Warn when we can't.
+            if server_verifying_key.is_none() {
+                tracing::debug!(
+                    %addr,
+                    "dial: networked QUIC peer with no expected verifying key — \
+                     response identity is unpinned (cert pin authenticates the channel only, #185)"
+                );
+            }
             let transport = crate::transport::lazy_quinn::LazyQuinnTransport::new(*addr, *pin);
             Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
                 as Arc<dyn RpcClient>)

--- a/crates/hyprstream-rpc/src/dial.rs
+++ b/crates/hyprstream-rpc/src/dial.rs
@@ -180,11 +180,23 @@ where
             Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
                 as Arc<dyn RpcClient>)
         }
-        endpoint @ (EndpointType::Ipc { .. } | EndpointType::SystemdFd { .. }) => bail!(
-            "dial(): endpoint {endpoint:?} is not served by the dial factory — \
-             ZMQ ipc/systemd endpoints stay on the codegen path during the transition; \
-             iroh/moq lazy transports land in a later #151(a) increment"
-        ),
+        // Same-host `ipc` plane: connect a UdsSession (RPC plane) at the socket
+        // path. systemd socket-activation is the same client-side dial — the fd
+        // is the *server's* pre-bound listener; clients connect by `client_path`.
+        // UDS has no transport-level peer identity; the app-layer SignedEnvelope
+        // is the authentication (a `None` server_verifying_key leaves the
+        // response identity unpinned but still signature-verified). Socket perms
+        // + SO_PEERCRED are daemon-owned defense-in-depth (#207).
+        EndpointType::Ipc { path } => {
+            let transport = crate::transport::lazy_uds::LazyUdsTransport::new(path.clone());
+            Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
+                as Arc<dyn RpcClient>)
+        }
+        EndpointType::SystemdFd { client_path, .. } => {
+            let transport = crate::transport::lazy_uds::LazyUdsTransport::new(client_path.clone());
+            Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
+                as Arc<dyn RpcClient>)
+        }
     }
 }
 
@@ -251,10 +263,20 @@ mod tests {
     }
 
     #[test]
-    fn dial_unsupported_endpoint_errors() {
-        let cfg = TransportConfig::ipc("/tmp/hyprstream-test.sock");
-        let err = dial(&cfg, test_signer(), None);
-        assert!(err.is_err(), "ipc dial is not yet served by the factory");
+    fn dial_ipc_builds_lazy_client() {
+        // ipc dial builds a lazy UdsSession client — sync, no I/O, connects on
+        // first send (the socket need not exist yet at dial() time).
+        let cfg = TransportConfig::ipc("/tmp/hyprstream-test-dial.sock");
+        let client = dial(&cfg, test_signer(), None);
+        assert!(client.is_ok(), "ipc dial must build a lazy client without connecting");
+    }
+
+    #[test]
+    fn dial_systemd_fd_builds_lazy_client() {
+        // systemd socket-activation: client dials the client_path via UDS.
+        let cfg = TransportConfig::systemd_fd(7, "/tmp/hyprstream-test-systemd.sock");
+        let client = dial(&cfg, test_signer(), None);
+        assert!(client.is_ok(), "systemd-fd dial must build a lazy client via client_path");
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/dial.rs
+++ b/crates/hyprstream-rpc/src/dial.rs
@@ -1,0 +1,156 @@
+//! The `dial()` factory: the single place transport choice is made.
+//!
+//! Today transport selection leaks into generated client code, which hardcodes
+//! `ZmqConnection::new(...)`. Per the A1 addressing spike, that decision belongs
+//! in exactly one place: [`dial`] takes a resolved [`TransportConfig`] and
+//! returns a ready [`Arc<dyn RpcClient>`], erasing the concrete transport behind
+//! the object-safe client trait (`Transport` itself is not object-safe — it has
+//! `Sub`/`Pub` associated types — so erasure happens at the `RpcClient` layer).
+//!
+//! # Inproc dial table
+//!
+//! `inproc://` names resolve through a process-local registry mapping a name to
+//! a co-located service's [`IrohRequestProcessor`]. The registry — not the
+//! [`TransportConfig`] — holds the live handle: a `TransportConfig` is
+//! `Clone + Eq` and wire-publishable (DiscoveryService), so an `Arc<dyn
+//! IrohRequestProcessor>` cannot live inside it. Naming (resolver →
+//! `TransportConfig`) and handles (registry → processor) stay separate; `dial()`
+//! is where they meet.
+//!
+//! # Construction is synchronous; transports connect lazily
+//!
+//! `dial()` is sync and does no I/O — the inproc arm only looks up an existing
+//! processor. Networked transports (quinn/iroh/moq) connect lazily on first
+//! `send()` (cached like `ZmqConnection`), so dialing never blocks and the
+//! `inventory`-registered sync factory pattern is preserved. Those arms land in
+//! a follow-up increment of #151(a); ZMQ ipc/systemd endpoints stay on the
+//! existing codegen path during the transition.
+
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
+
+use anyhow::{anyhow, bail, Result};
+use parking_lot::RwLock;
+
+use crate::crypto::VerifyingKey;
+use crate::rpc_client::{RpcClient, RpcClientImpl};
+use crate::transport::in_memory::InMemoryTransport;
+use crate::transport::rpc_session::IrohRequestProcessor;
+use crate::transport::{EndpointType, TransportConfig};
+use crate::transport_traits::Signer;
+
+/// Process-local map of inproc endpoint name → co-located request processor.
+type InprocRegistry = RwLock<HashMap<String, Arc<dyn IrohRequestProcessor>>>;
+
+static INPROC_REGISTRY: OnceLock<InprocRegistry> = OnceLock::new();
+
+fn registry() -> &'static InprocRegistry {
+    INPROC_REGISTRY.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+/// Register a co-located service's request processor under an `inproc://` name.
+///
+/// Called at service spawn. The `name` is the endpoint without the scheme
+/// (e.g. `hyprstream/registry` for `inproc://hyprstream/registry`). Returns the
+/// previous processor if one was registered under the same name.
+pub fn register_inproc(
+    name: impl Into<String>,
+    processor: Arc<dyn IrohRequestProcessor>,
+) -> Option<Arc<dyn IrohRequestProcessor>> {
+    registry().write().insert(name.into(), processor)
+}
+
+/// Remove a co-located service's processor (called at service shutdown).
+pub fn unregister_inproc(name: &str) -> Option<Arc<dyn IrohRequestProcessor>> {
+    registry().write().remove(name)
+}
+
+/// Look up a co-located service's processor by inproc name.
+pub fn lookup_inproc(name: &str) -> Option<Arc<dyn IrohRequestProcessor>> {
+    registry().read().get(name).cloned()
+}
+
+/// Dial a resolved [`TransportConfig`], returning a ready RPC client.
+///
+/// `server_verifying_key` is the destination's response-verification key
+/// (`None` skips response signature verification — only sound when the
+/// transport itself authenticates the peer, e.g. pinned TLS). The inproc path
+/// is verified end-to-end via the in-process processor's signed responses, so
+/// callers may pass the service's verifying key here.
+pub fn dial<S>(
+    target: &TransportConfig,
+    signer: S,
+    server_verifying_key: Option<VerifyingKey>,
+) -> Result<Arc<dyn RpcClient>>
+where
+    S: Signer + 'static,
+{
+    match &target.endpoint {
+        EndpointType::Inproc { endpoint } => {
+            let processor = lookup_inproc(endpoint).ok_or_else(|| {
+                anyhow!("no in-process service registered for inproc endpoint '{endpoint}'")
+            })?;
+            let transport = InMemoryTransport::new(processor);
+            Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
+                as Arc<dyn RpcClient>)
+        }
+        other => bail!(
+            "dial(): endpoint {other:?} is not yet served by the dial factory \
+             — lazy quinn/iroh/moq transports land in a later #151(a) increment; \
+             ZMQ ipc/systemd endpoints stay on the codegen path during the transition"
+        ),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::crypto::SigningKey;
+    use crate::signer::LocalSigner;
+    use crate::transport::rpc_session::from_fn;
+    use bytes::Bytes;
+    use rand::rngs::OsRng;
+
+    fn test_signer() -> LocalSigner {
+        LocalSigner::new(SigningKey::generate(&mut OsRng))
+    }
+
+    #[test]
+    fn register_lookup_unregister() {
+        let name = "test/dial/register_lookup_unregister";
+        assert!(lookup_inproc(name).is_none());
+        let proc = Arc::new(from_fn(|r: Bytes| async move { Ok(r) }));
+        assert!(register_inproc(name, proc).is_none());
+        assert!(lookup_inproc(name).is_some());
+        assert!(unregister_inproc(name).is_some());
+        assert!(lookup_inproc(name).is_none());
+    }
+
+    #[test]
+    fn dial_inproc_resolves_registered_processor() {
+        let name = "test/dial/dial_inproc_resolves";
+        let proc = Arc::new(from_fn(|r: Bytes| async move { Ok(r) }));
+        register_inproc(name, proc);
+
+        let cfg = TransportConfig::inproc(name);
+        let client = dial(&cfg, test_signer(), None);
+        assert!(client.is_ok(), "dialing a registered inproc endpoint must succeed");
+
+        unregister_inproc(name);
+    }
+
+    #[test]
+    fn dial_inproc_unregistered_errors() {
+        let cfg = TransportConfig::inproc("test/dial/never_registered");
+        let err = dial(&cfg, test_signer(), None);
+        assert!(err.is_err(), "dialing an unregistered inproc endpoint must error");
+    }
+
+    #[test]
+    fn dial_unsupported_endpoint_errors() {
+        let cfg = TransportConfig::ipc("/tmp/hyprstream-test.sock");
+        let err = dial(&cfg, test_signer(), None);
+        assert!(err.is_err(), "ipc dial is not yet served by the factory");
+    }
+}

--- a/crates/hyprstream-rpc/src/dial.rs
+++ b/crates/hyprstream-rpc/src/dial.rs
@@ -36,7 +36,7 @@ use crate::crypto::VerifyingKey;
 use crate::rpc_client::{RpcClient, RpcClientImpl};
 use crate::transport::in_memory::InMemoryTransport;
 use crate::transport::rpc_session::IrohRequestProcessor;
-use crate::transport::{EndpointType, TransportConfig};
+use crate::transport::{EndpointType, QuicServerAuth, TransportConfig};
 use crate::transport_traits::Signer;
 
 /// Process-local map of inproc endpoint name → co-located request processor.
@@ -132,29 +132,33 @@ where
             Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
                 as Arc<dyn RpcClient>)
         }
-        EndpointType::Quic { addr, cert_pin: Some(pin), .. } => {
-            // SECURITY (#185): the pin authenticates the TLS *channel* ("a server
-            // presenting this cert"), not the peer's DID identity. Identity comes
-            // from the response signature. With `None` here that signature is
-            // still verified, but only against the envelope-embedded key (no
-            // identity pinning) — so for a *networked* peer, prefer passing the
-            // resolver-known verifying key. Warn when we can't.
+        EndpointType::Quic { auth: QuicServerAuth::RawPublicKey(_), .. } => bail!(
+            "dial(): QUIC RFC 7250 raw-public-key auth is not yet implemented (#200) — \
+             use iroh for identity-bound transport, or QuicServerAuth::Pinned / WebPki"
+        ),
+        EndpointType::Quic { addr, server_name, auth } => {
+            // SECURITY (#185): WebPki/Pinned authenticate the TLS *channel* (a CA
+            // chain, or a specific cert), not the peer's DID identity. Identity
+            // comes from the response signature, which is still verified against
+            // the envelope-embedded key when `server_verifying_key` is `None` —
+            // just not *pinned* to an expected identity. For a networked peer,
+            // prefer passing the resolver-known key; warn when we can't. (iroh's
+            // arm needs no such warning — it is identity-bound at the transport.)
             if server_verifying_key.is_none() {
                 tracing::debug!(
                     %addr,
                     "dial: networked QUIC peer with no expected verifying key — \
-                     response identity is unpinned (cert pin authenticates the channel only, #185)"
+                     response identity unpinned (channel-level auth only, #185)"
                 );
             }
-            let transport = crate::transport::lazy_quinn::LazyQuinnTransport::new(*addr, *pin);
+            let transport = crate::transport::lazy_quinn::LazyQuinnTransport::new(
+                *addr,
+                server_name.clone(),
+                auth.clone(),
+            );
             Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
                 as Arc<dyn RpcClient>)
         }
-        EndpointType::Quic { cert_pin: None, .. } => bail!(
-            "dial(): QUIC endpoint has no cert pin — cannot authenticate the server. \
-             The resolver must supply EndpointType::Quic.cert_pin (the server cert's \
-             SHA-256), e.g. via TransportConfig::quic_pinned"
-        ),
         EndpointType::Iroh { direct_addrs, relay_url, .. }
             if direct_addrs.is_empty() && relay_url.is_none() =>
         {
@@ -256,18 +260,35 @@ mod tests {
     }
 
     #[test]
-    fn dial_quic_without_cert_pin_errors() {
-        // Plain `quic()` has no pin → cannot authenticate the server → must bail.
+    fn dial_quic_webpki_builds_client() {
+        // Plain `quic()` = WebPKI/CA validation — a valid auth policy, so dial()
+        // builds a (lazy, not-yet-connected) client.
         let cfg = TransportConfig::quic("127.0.0.1:9999".parse().unwrap(), "localhost");
-        let err = dial(&cfg, test_signer(), None);
-        assert!(err.is_err(), "QUIC dial without a cert pin must error");
+        let client = dial(&cfg, test_signer(), None);
+        assert!(client.is_ok(), "WebPKI QUIC dial must build a client without connecting");
     }
 
     #[test]
-    fn dial_quic_with_cert_pin_builds_client() {
-        // With a pin, dial() builds a (lazy, not-yet-connected) client — sync, no I/O.
+    fn dial_quic_pinned_builds_client() {
+        // Cert-hash-pinned QUIC: builds a lazy client — sync, no I/O.
         let cfg = TransportConfig::quic_pinned("127.0.0.1:9999".parse().unwrap(), "localhost", [7u8; 32]);
         let client = dial(&cfg, test_signer(), None);
         assert!(client.is_ok(), "pinned QUIC dial must build a client without connecting");
+    }
+
+    #[test]
+    fn dial_quic_raw_public_key_errors() {
+        // RFC 7250 raw-public-key auth is not yet implemented → fail fast.
+        let cfg = TransportConfig {
+            endpoint: EndpointType::Quic {
+                addr: "127.0.0.1:9999".parse().unwrap(),
+                server_name: "localhost".to_owned(),
+                auth: QuicServerAuth::RawPublicKey([9u8; 32]),
+            },
+            curve: None,
+            bind_mode: crate::transport::BindMode::Connect,
+        };
+        let err = dial(&cfg, test_signer(), None);
+        assert!(err.is_err(), "RFC 7250 QUIC auth must error until implemented");
     }
 }

--- a/crates/hyprstream-rpc/src/dial.rs
+++ b/crates/hyprstream-rpc/src/dial.rs
@@ -116,10 +116,31 @@ pub fn dial<S>(
     target: &TransportConfig,
     signer: S,
     server_verifying_key: Option<VerifyingKey>,
+    token: Option<String>,
 ) -> Result<Arc<dyn RpcClient>>
 where
     S: Signer + 'static,
 {
+    /// Wrap a built transport as an `RpcClient`, applying the optional default
+    /// JWT (CA-signed trust cert included in request envelopes) if present.
+    fn build_client<S2, T2>(
+        signer: S2,
+        transport: T2,
+        vk: Option<VerifyingKey>,
+        token: Option<String>,
+    ) -> Arc<dyn RpcClient>
+    where
+        S2: Signer + 'static,
+        T2: crate::transport_traits::Transport + 'static,
+    {
+        let rpc = RpcClientImpl::new(signer, transport, vk);
+        let rpc = match token {
+            Some(t) => rpc.with_default_jwt(t),
+            None => rpc,
+        };
+        Arc::new(rpc) as Arc<dyn RpcClient>
+    }
+
     // Matched exhaustively on purpose: this is the one place transport choice is
     // made, so a newly-added EndpointType variant MUST be a compile error here
     // rather than silently falling through to a runtime bail.
@@ -129,8 +150,7 @@ where
                 anyhow!("no in-process service registered for inproc endpoint '{endpoint}'")
             })?;
             let transport = InMemoryTransport::new(processor);
-            Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
-                as Arc<dyn RpcClient>)
+            Ok(build_client(signer, transport, server_verifying_key, token))
         }
         EndpointType::Quic { addr, server_name, auth } => {
             // SECURITY (#185): QUIC channel auth (WebPKI / cert-hash pin) binds the
@@ -153,8 +173,7 @@ where
                 server_name.clone(),
                 auth.clone(),
             );
-            Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
-                as Arc<dyn RpcClient>)
+            Ok(build_client(signer, transport, server_verifying_key, token))
         }
         EndpointType::Iroh { direct_addrs, relay_url, .. }
             if direct_addrs.is_empty() && relay_url.is_none() =>
@@ -177,8 +196,7 @@ where
                 direct_addrs.clone(),
                 relay_url.clone(),
             );
-            Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
-                as Arc<dyn RpcClient>)
+            Ok(build_client(signer, transport, server_verifying_key, token))
         }
         // Same-host `ipc` plane: connect a UdsSession (RPC plane) at the socket
         // path. systemd socket-activation is the same client-side dial — the fd
@@ -189,13 +207,11 @@ where
         // + SO_PEERCRED are daemon-owned defense-in-depth (#207).
         EndpointType::Ipc { path } => {
             let transport = crate::transport::lazy_uds::LazyUdsTransport::new(path.clone());
-            Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
-                as Arc<dyn RpcClient>)
+            Ok(build_client(signer, transport, server_verifying_key, token))
         }
         EndpointType::SystemdFd { client_path, .. } => {
             let transport = crate::transport::lazy_uds::LazyUdsTransport::new(client_path.clone());
-            Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
-                as Arc<dyn RpcClient>)
+            Ok(build_client(signer, transport, server_verifying_key, token))
         }
     }
 }
@@ -249,7 +265,7 @@ mod tests {
         register_inproc(name, &proc);
 
         let cfg = TransportConfig::inproc(name);
-        let client = dial(&cfg, test_signer(), None);
+        let client = dial(&cfg, test_signer(), None, None);
         assert!(client.is_ok(), "dialing a registered inproc endpoint must succeed");
 
         unregister_inproc(name);
@@ -258,7 +274,7 @@ mod tests {
     #[test]
     fn dial_inproc_unregistered_errors() {
         let cfg = TransportConfig::inproc("test/dial/never_registered");
-        let err = dial(&cfg, test_signer(), None);
+        let err = dial(&cfg, test_signer(), None, None);
         assert!(err.is_err(), "dialing an unregistered inproc endpoint must error");
     }
 
@@ -267,7 +283,7 @@ mod tests {
         // ipc dial builds a lazy UdsSession client — sync, no I/O, connects on
         // first send (the socket need not exist yet at dial() time).
         let cfg = TransportConfig::ipc("/tmp/hyprstream-test-dial.sock");
-        let client = dial(&cfg, test_signer(), None);
+        let client = dial(&cfg, test_signer(), None, None);
         assert!(client.is_ok(), "ipc dial must build a lazy client without connecting");
     }
 
@@ -275,7 +291,7 @@ mod tests {
     fn dial_systemd_fd_builds_lazy_client() {
         // systemd socket-activation: client dials the client_path via UDS.
         let cfg = TransportConfig::systemd_fd(7, "/tmp/hyprstream-test-systemd.sock");
-        let client = dial(&cfg, test_signer(), None);
+        let client = dial(&cfg, test_signer(), None, None);
         assert!(client.is_ok(), "systemd-fd dial must build a lazy client via client_path");
     }
 
@@ -284,7 +300,7 @@ mod tests {
         // Plain `quic()` = WebPKI/CA validation — a valid auth policy, so dial()
         // builds a (lazy, not-yet-connected) client.
         let cfg = TransportConfig::quic("127.0.0.1:9999".parse().unwrap(), "localhost");
-        let client = dial(&cfg, test_signer(), None);
+        let client = dial(&cfg, test_signer(), None, None);
         assert!(client.is_ok(), "WebPKI QUIC dial must build a client without connecting");
     }
 
@@ -292,7 +308,7 @@ mod tests {
     fn dial_quic_pinned_builds_client() {
         // Cert-hash-pinned QUIC: builds a lazy client — sync, no I/O.
         let cfg = TransportConfig::quic_pinned("127.0.0.1:9999".parse().unwrap(), "localhost", [7u8; 32]);
-        let client = dial(&cfg, test_signer(), None);
+        let client = dial(&cfg, test_signer(), None, None);
         assert!(client.is_ok(), "pinned QUIC dial must build a client without connecting");
     }
 
@@ -308,7 +324,7 @@ mod tests {
             curve: None,
             bind_mode: crate::transport::BindMode::Connect,
         };
-        let client = dial(&cfg, test_signer(), None);
+        let client = dial(&cfg, test_signer(), None, None);
         assert!(client.is_ok(), "WebPKI+pin QUIC dial must build a client");
     }
 

--- a/crates/hyprstream-rpc/src/dial.rs
+++ b/crates/hyprstream-rpc/src/dial.rs
@@ -27,7 +27,7 @@
 //! existing codegen path during the transition.
 
 use std::collections::HashMap;
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, OnceLock, Weak};
 
 use anyhow::{anyhow, bail, Result};
 use parking_lot::RwLock;
@@ -40,7 +40,14 @@ use crate::transport::{EndpointType, TransportConfig};
 use crate::transport_traits::Signer;
 
 /// Process-local map of inproc endpoint name → co-located request processor.
-type InprocRegistry = RwLock<HashMap<String, Arc<dyn IrohRequestProcessor>>>;
+///
+/// Entries are `Weak`: the registry is a *lookup index*, not the owner. The
+/// service spawn site retains the strong `Arc` for the service's lifetime, so
+/// dropping the service (e.g. on shutdown) automatically tears down its bridge
+/// thread AND leaves a dead `Weak` here that self-evicts on the next lookup —
+/// no leak-by-forgotten-unregister, and no strong ref pinning a bridge thread
+/// past shutdown.
+type InprocRegistry = RwLock<HashMap<String, Weak<dyn IrohRequestProcessor>>>;
 
 static INPROC_REGISTRY: OnceLock<InprocRegistry> = OnceLock::new();
 
@@ -51,32 +58,60 @@ fn registry() -> &'static InprocRegistry {
 /// Register a co-located service's request processor under an `inproc://` name.
 ///
 /// Called at service spawn. The `name` is the endpoint without the scheme
-/// (e.g. `hyprstream/registry` for `inproc://hyprstream/registry`). Returns the
-/// previous processor if one was registered under the same name.
-pub fn register_inproc(
-    name: impl Into<String>,
-    processor: Arc<dyn IrohRequestProcessor>,
-) -> Option<Arc<dyn IrohRequestProcessor>> {
-    registry().write().insert(name.into(), processor)
+/// (e.g. `hyprstream/registry` for `inproc://hyprstream/registry`). The caller
+/// MUST retain `processor` (the strong `Arc`) for as long as the service should
+/// be dialable — the registry only holds a `Weak`.
+///
+/// Overwriting a name whose service is still live is almost always a bug
+/// (name-squatting / double-spawn); it is logged loudly. Existing dialed
+/// clients keep the processor they captured; only future dials see the new one.
+pub fn register_inproc(name: impl Into<String>, processor: &Arc<dyn IrohRequestProcessor>) {
+    let name = name.into();
+    let mut map = registry().write();
+    if map.get(&name).is_some_and(|w| w.strong_count() > 0) {
+        tracing::warn!(
+            endpoint = %name,
+            "register_inproc: overwriting a still-live in-process service registration"
+        );
+    }
+    map.insert(name, Arc::downgrade(processor));
 }
 
-/// Remove a co-located service's processor (called at service shutdown).
-pub fn unregister_inproc(name: &str) -> Option<Arc<dyn IrohRequestProcessor>> {
-    registry().write().remove(name)
+/// Explicitly drop a name's registration (best-effort; dead entries also
+/// self-evict on lookup once the service's strong `Arc` is gone).
+pub fn unregister_inproc(name: &str) {
+    registry().write().remove(name);
 }
 
-/// Look up a co-located service's processor by inproc name.
+/// Look up a co-located service's processor by inproc name, upgrading the
+/// `Weak`. A stale (dead-service) entry is pruned in passing.
 pub fn lookup_inproc(name: &str) -> Option<Arc<dyn IrohRequestProcessor>> {
-    registry().read().get(name).cloned()
+    let mut map = registry().write();
+    match map.get(name).and_then(Weak::upgrade) {
+        Some(arc) => Some(arc),
+        None => {
+            // Present-but-dead → evict; absent → no-op.
+            map.remove(name);
+            None
+        }
+    }
 }
 
 /// Dial a resolved [`TransportConfig`], returning a ready RPC client.
 ///
-/// `server_verifying_key` is the destination's response-verification key
-/// (`None` skips response signature verification — only sound when the
-/// transport itself authenticates the peer, e.g. pinned TLS). The inproc path
-/// is verified end-to-end via the in-process processor's signed responses, so
-/// callers may pass the service's verifying key here.
+/// `server_verifying_key` is the destination's response-verification key.
+/// `None` does NOT disable signature verification — the response is still
+/// cryptographically verified against the key embedded in its envelope; `None`
+/// only declines to pin *which* identity that key must be. Passing `None` is
+/// only sound when the transport itself authenticates the peer (e.g. pinned
+/// TLS / QUIC cert).
+///
+/// **For `inproc://` there is no transport-level peer authentication** (it is a
+/// function call into a registry-resolved processor), so `None` is *discouraged*
+/// on the inproc path: without it, a name-squatting registration could be dialed
+/// without detection. Callers SHOULD pass the resolved service verifying key for
+/// inproc. (The codegen wire-up will thread the resolver-supplied key through;
+/// see #151(a) follow-up.)
 pub fn dial<S>(
     target: &TransportConfig,
     signer: S,
@@ -85,6 +120,9 @@ pub fn dial<S>(
 where
     S: Signer + 'static,
 {
+    // Matched exhaustively on purpose: this is the one place transport choice is
+    // made, so a newly-added EndpointType variant MUST be a compile error here
+    // rather than silently falling through to a runtime bail.
     match &target.endpoint {
         EndpointType::Inproc { endpoint } => {
             let processor = lookup_inproc(endpoint).ok_or_else(|| {
@@ -94,8 +132,10 @@ where
             Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
                 as Arc<dyn RpcClient>)
         }
-        other => bail!(
-            "dial(): endpoint {other:?} is not yet served by the dial factory \
+        endpoint @ (EndpointType::Ipc { .. }
+        | EndpointType::SystemdFd { .. }
+        | EndpointType::Quic { .. }) => bail!(
+            "dial(): endpoint {endpoint:?} is not yet served by the dial factory \
              — lazy quinn/iroh/moq transports land in a later #151(a) increment; \
              ZMQ ipc/systemd endpoints stay on the codegen path during the transition"
         ),
@@ -116,22 +156,38 @@ mod tests {
         LocalSigner::new(SigningKey::generate(&mut OsRng))
     }
 
+    fn echo() -> Arc<dyn IrohRequestProcessor> {
+        Arc::new(from_fn(|r: Bytes| async move { Ok(r) }))
+    }
+
     #[test]
     fn register_lookup_unregister() {
         let name = "test/dial/register_lookup_unregister";
         assert!(lookup_inproc(name).is_none());
-        let proc = Arc::new(from_fn(|r: Bytes| async move { Ok(r) }));
-        assert!(register_inproc(name, proc).is_none());
+        let proc = echo();
+        register_inproc(name, &proc);
         assert!(lookup_inproc(name).is_some());
-        assert!(unregister_inproc(name).is_some());
+        unregister_inproc(name);
         assert!(lookup_inproc(name).is_none());
+    }
+
+    #[test]
+    fn lookup_self_evicts_when_service_dropped() {
+        let name = "test/dial/self_evict";
+        let proc = echo();
+        register_inproc(name, &proc);
+        assert!(lookup_inproc(name).is_some());
+        // Service shuts down: drop the only strong ref. The Weak in the
+        // registry is now dead and must not resolve (and is pruned).
+        drop(proc);
+        assert!(lookup_inproc(name).is_none(), "dead-service entry must not resolve");
     }
 
     #[test]
     fn dial_inproc_resolves_registered_processor() {
         let name = "test/dial/dial_inproc_resolves";
-        let proc = Arc::new(from_fn(|r: Bytes| async move { Ok(r) }));
-        register_inproc(name, proc);
+        let proc = echo();
+        register_inproc(name, &proc);
 
         let cfg = TransportConfig::inproc(name);
         let client = dial(&cfg, test_signer(), None);

--- a/crates/hyprstream-rpc/src/dial.rs
+++ b/crates/hyprstream-rpc/src/dial.rs
@@ -142,8 +142,9 @@ where
             // comes from the response signature, which is still verified against
             // the envelope-embedded key when `server_verifying_key` is `None` —
             // just not *pinned* to an expected identity. For a networked peer,
-            // prefer passing the resolver-known key; warn when we can't. (iroh's
-            // arm needs no such warning — it is identity-bound at the transport.)
+            // prefer passing the resolver-known key; note (debug) when we can't.
+            // (iroh's arm needs no such note — it is identity-bound at the
+            // transport.)
             if server_verifying_key.is_none() {
                 tracing::debug!(
                     %addr,

--- a/crates/hyprstream-rpc/src/dial.rs
+++ b/crates/hyprstream-rpc/src/dial.rs
@@ -36,7 +36,7 @@ use crate::crypto::VerifyingKey;
 use crate::rpc_client::{RpcClient, RpcClientImpl};
 use crate::transport::in_memory::InMemoryTransport;
 use crate::transport::rpc_session::IrohRequestProcessor;
-use crate::transport::{EndpointType, QuicServerAuth, TransportConfig};
+use crate::transport::{EndpointType, TransportConfig};
 use crate::transport_traits::Signer;
 
 /// Process-local map of inproc endpoint name → co-located request processor.
@@ -132,19 +132,15 @@ where
             Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
                 as Arc<dyn RpcClient>)
         }
-        EndpointType::Quic { auth: QuicServerAuth::RawPublicKey(_), .. } => bail!(
-            "dial(): QUIC RFC 7250 raw-public-key auth is not yet implemented (#200) — \
-             use iroh for identity-bound transport, or QuicServerAuth::Pinned / WebPki"
-        ),
         EndpointType::Quic { addr, server_name, auth } => {
-            // SECURITY (#185): WebPki/Pinned authenticate the TLS *channel* (a CA
-            // chain, or a specific cert), not the peer's DID identity. Identity
-            // comes from the response signature, which is still verified against
-            // the envelope-embedded key when `server_verifying_key` is `None` —
+            // SECURITY (#185): QUIC channel auth (WebPKI / cert-hash pin) binds the
+            // *channel*, not the peer's DID identity. Identity is established at the
+            // application layer — the response signature is verified against the
+            // envelope-embedded key even when `server_verifying_key` is `None`,
             // just not *pinned* to an expected identity. For a networked peer,
             // prefer passing the resolver-known key; note (debug) when we can't.
             // (iroh's arm needs no such note — it is identity-bound at the
-            // transport.)
+            // transport, RFC 7250.)
             if server_verifying_key.is_none() {
                 tracing::debug!(
                     %addr,
@@ -197,6 +193,7 @@ where
 mod tests {
     use super::*;
     use crate::crypto::SigningKey;
+    use crate::transport::QuicServerAuth;
     use crate::signer::LocalSigner;
     use crate::transport::rpc_session::from_fn;
     use bytes::Bytes;
@@ -278,18 +275,25 @@ mod tests {
     }
 
     #[test]
-    fn dial_quic_raw_public_key_errors() {
-        // RFC 7250 raw-public-key auth is not yet implemented → fail fast.
+    fn dial_quic_web_pki_pinned_builds_client() {
+        // WebPKI + pin (defence in depth): builds a lazy client.
         let cfg = TransportConfig {
             endpoint: EndpointType::Quic {
                 addr: "127.0.0.1:9999".parse().unwrap(),
                 server_name: "localhost".to_owned(),
-                auth: QuicServerAuth::RawPublicKey([9u8; 32]),
+                auth: QuicServerAuth::web_pki_pinned(vec![[9u8; 32]]).unwrap(),
             },
             curve: None,
             bind_mode: crate::transport::BindMode::Connect,
         };
-        let err = dial(&cfg, test_signer(), None);
-        assert!(err.is_err(), "RFC 7250 QUIC auth must error until implemented");
+        let client = dial(&cfg, test_signer(), None);
+        assert!(client.is_ok(), "WebPKI+pin QUIC dial must build a client");
+    }
+
+    #[test]
+    fn quic_server_auth_rejects_no_requirement() {
+        assert!(QuicServerAuth::pinned(vec![]).is_err(), "empty pin set is no auth");
+        assert!(QuicServerAuth::web_pki_pinned(vec![]).is_err(), "empty pin set is no auth");
+        assert!(QuicServerAuth::web_pki().require_web_pki());
     }
 }

--- a/crates/hyprstream-rpc/src/dial.rs
+++ b/crates/hyprstream-rpc/src/dial.rs
@@ -155,6 +155,19 @@ where
              The resolver must supply EndpointType::Quic.cert_pin (the server cert's \
              SHA-256), e.g. via TransportConfig::quic_pinned"
         ),
+        EndpointType::Iroh { node_id, direct_addrs, relay_url } => {
+            // iroh binds the connection to the peer's EndpointId (its pubkey),
+            // so the transport authenticates the peer *identity* — a `None`
+            // server_verifying_key is sound (response sig still verified, and
+            // the channel is identity-bound, unlike QUIC's cert pin).
+            let transport = crate::transport::lazy_iroh::LazyIrohTransport::new(
+                *node_id,
+                direct_addrs.clone(),
+                relay_url.clone(),
+            );
+            Ok(Arc::new(RpcClientImpl::new(signer, transport, server_verifying_key))
+                as Arc<dyn RpcClient>)
+        }
         endpoint @ (EndpointType::Ipc { .. } | EndpointType::SystemdFd { .. }) => bail!(
             "dial(): endpoint {endpoint:?} is not served by the dial factory — \
              ZMQ ipc/systemd endpoints stay on the codegen path during the transition; \

--- a/crates/hyprstream-rpc/src/dial.rs
+++ b/crates/hyprstream-rpc/src/dial.rs
@@ -155,6 +155,17 @@ where
              The resolver must supply EndpointType::Quic.cert_pin (the server cert's \
              SHA-256), e.g. via TransportConfig::quic_pinned"
         ),
+        EndpointType::Iroh { direct_addrs, relay_url, .. }
+            if direct_addrs.is_empty() && relay_url.is_none() =>
+        {
+            // Fail fast rather than hand iroh an EndpointId with no reachability,
+            // which would fall through to discovery and time out (~10-30s). The
+            // resolver is expected to supply at least one direct addr or a relay.
+            bail!(
+                "dial(): iroh endpoint has neither direct addrs nor a relay URL — \
+                 not dialable; the resolver must supply reachability"
+            )
+        }
         EndpointType::Iroh { node_id, direct_addrs, relay_url } => {
             // iroh binds the connection to the peer's EndpointId (its pubkey),
             // so the transport authenticates the peer *identity* — a `None`

--- a/crates/hyprstream-rpc/src/envelope.rs
+++ b/crates/hyprstream-rpc/src/envelope.rs
@@ -33,7 +33,7 @@ use crate::common_capnp;
 use crate::crypto::{SigningKey, VerifyingKey};
 use crate::error::{EnvelopeError, EnvelopeResult};
 use anyhow::{anyhow, Result};
-use ed25519_dalek::{Signature, Signer};
+use ed25519_dalek::Signer;
 use subtle::ConstantTimeEq;
 use std::fmt;
 use std::str::FromStr;
@@ -223,6 +223,19 @@ pub enum EnvelopeVerification<'a> {
 }
 
 /// Options controlling envelope unwrap, verification, and optional decryption.
+///
+/// # Crypto policy (fail-closed default)
+///
+/// `verify_policy` defaults to [`CryptoPolicy::default()`] which is **Hybrid
+/// ENFORCED**. Under Hybrid the verifier REQUIRES the outer ML-DSA-65 SNS layer
+/// anchored to a [`PqTrustStore`] entry — stripping the outer layer or signing
+/// classical-only is rejected. To verify against a kid-anchored PQ key, callers
+/// MUST supply `pq_store`; under Hybrid with no resolvable anchor the envelope
+/// is **rejected** (fail-closed), never accepted as classical.
+///
+/// Callers that genuinely need the legacy classical-only path (e.g. WASM in-
+/// browser verification without a PQ trust store) must explicitly downgrade via
+/// [`UnwrapOptions::classical`].
 pub struct UnwrapOptions<'a> {
     /// How to verify the envelope signer.
     pub verification: EnvelopeVerification<'a>,
@@ -232,27 +245,61 @@ pub struct UnwrapOptions<'a> {
     /// When present and the envelope has `encrypted_envelope`, the server's
     /// Ed25519 key is converted to X25519 for DH decryption.
     pub decryption_key: Option<&'a crate::crypto::SigningKey>,
+    /// kid-anchored ML-DSA-65 trust store used to resolve the PQ verifying key
+    /// for the envelope's EdDSA signer. Required under Hybrid policy.
+    pub pq_store: Option<&'a dyn PqTrustStore>,
+    /// Verification policy enforced at this site. Defaults to Hybrid (enforced).
+    pub verify_policy: crate::crypto::CryptoPolicy,
 }
 
 impl<'a> UnwrapOptions<'a> {
+    /// Fixed-signer verification under the default (Hybrid-enforced) policy.
     pub fn fixed_signer(pubkey: &'a VerifyingKey, nonce_cache: &'a dyn NonceCache) -> Self {
         Self {
             verification: EnvelopeVerification::FixedSigner(pubkey),
             nonce_cache,
             decryption_key: None,
+            pq_store: None,
+            verify_policy: crate::crypto::CryptoPolicy::default(),
         }
     }
 
+    /// Any-signer verification under the default (Hybrid-enforced) policy.
     pub fn any_signer(nonce_cache: &'a dyn NonceCache) -> Self {
         Self {
             verification: EnvelopeVerification::AnySigner,
             nonce_cache,
             decryption_key: None,
+            pq_store: None,
+            verify_policy: crate::crypto::CryptoPolicy::default(),
         }
     }
 
     pub fn with_decryption_key(mut self, key: &'a crate::crypto::SigningKey) -> Self {
         self.decryption_key = Some(key);
+        self
+    }
+
+    /// Attach a kid-anchored ML-DSA-65 trust store (required under Hybrid).
+    pub fn with_pq_store(mut self, store: &'a dyn PqTrustStore) -> Self {
+        self.pq_store = Some(store);
+        self
+    }
+
+    /// Set the verification policy explicitly.
+    pub fn with_verify_policy(mut self, policy: crate::crypto::CryptoPolicy) -> Self {
+        self.verify_policy = policy;
+        self
+    }
+
+    /// Explicitly downgrade this site to the legacy classical-only verifier.
+    ///
+    /// Use ONLY for surfaces that cannot carry a PQ trust store (e.g. external
+    /// JOSE/classical interop). This accepts a single-EdDSA composite and
+    /// ignores any outer ML-DSA layer.
+    pub fn classical(mut self) -> Self {
+        self.verify_policy = crate::crypto::CryptoPolicy::Classical;
+        self.pq_store = None;
         self
     }
 }
@@ -661,14 +708,164 @@ pub struct SignedEnvelope {
     /// X25519 ephemeral public key for DH key agreement (present when encrypted)
     pub client_ephemeral_public: Option<[u8; 32]>,
 
-    /// ML-DSA-65 signature (3309 bytes, present when pq-hybrid is enabled)
-    pub pq_sig: Option<Vec<u8>>,
+    /// M3 (#152): CBOR-encoded COSE_Sign composite signature (detached).
+    ///
+    /// Authoritative authentication mechanism. Carries one EdDSA entry
+    /// (Classical) or EdDSA + ML-DSA-65 entries (Hybrid) over the canonical
+    /// signing-data. The ML-DSA-65 verifying key is NOT embedded; it is
+    /// resolved by kid from a trust store (kid-anchored), which fixes the
+    /// prior self-certification weakness.
+    ///
+    /// `sig`/`cnf` remain populated with the raw EdDSA signature + signer
+    /// public key for backward compatibility and for the JWT `cnf` key-binding
+    /// path, but the COSE composite is what `verify*` enforces.
+    pub cose: Vec<u8>,
 
-    /// ML-DSA-65 verifying key (1952 bytes, present when pq-hybrid is enabled)
-    pub pq_cnf: Option<Vec<u8>>,
+    /// Runtime crypto policy used when this envelope was signed.
+    pub policy: crate::crypto::CryptoPolicy,
 
     /// ML-KEM-768 ciphertext (1088 bytes, present when hybrid encryption is used)
     pub pq_kem_ciphertext: Option<Vec<u8>>,
+}
+
+/// Cap'n Proto file id of `common.capnp` (the envelope schema). Used as the
+/// first component of the COSE `external_aad` schema-binding.
+pub const ENVELOPE_SCHEMA_ID: u64 = 0xb3e9_f4a1_c7d8_2056;
+
+/// Stable inner-type id for `RequestEnvelope` in the COSE `external_aad`.
+/// Distinct from any payload schema id; binds the COSE signature to the
+/// envelope structure to prevent schema-confusion / cross-protocol replay.
+pub const REQUEST_ENVELOPE_TYPE_ID: u64 = 0x5265_7145_6e76_3031; // "ReqEnv01"
+
+/// Stable inner-type id for `ResponseEnvelope`, distinct from
+/// [`REQUEST_ENVELOPE_TYPE_ID`]. Even though responses currently use a separate
+/// raw-Ed25519 signing domain (`request_id ‖ payload`, not COSE), keeping a
+/// distinct type-id documents/enforces the request↔response domain separation
+/// so a response can never be replayed as a request (LOW finding).
+pub const RESPONSE_ENVELOPE_TYPE_ID: u64 = 0x5265_7350_456e_7631; // "RsPEnv1"
+
+/// Build the COSE external_aad used for all envelope signatures.
+fn envelope_external_aad() -> Vec<u8> {
+    crate::crypto::cose_sign1::build_external_aad(ENVELOPE_SCHEMA_ID, REQUEST_ENVELOPE_TYPE_ID)
+}
+
+/// Resolves the anchored ML-DSA-65 verifying key for an EdDSA signer identity.
+///
+/// kid-anchoring: the envelope's EdDSA signer key (`cnf`, 32 bytes) is the
+/// identity. A `PqTrustStore` maps that identity to its trusted ML-DSA-65 key.
+/// The COSE ML-DSA-65 entry must verify against this anchored key (and its kid
+/// must match), so an attacker cannot strip + re-sign with their own PQ key.
+pub trait PqTrustStore: Send + Sync {
+    /// Return the trusted ML-DSA-65 verifying key bound to the given Ed25519
+    /// signer public key, or `None` if no binding is known.
+    fn ml_dsa_key_for(&self, ed25519_pubkey: &[u8; 32]) -> Option<crate::crypto::pq::MlDsaVerifyingKey>;
+}
+
+/// In-memory kid-anchored ML-DSA-65 trust store mapping an Ed25519 signer
+/// identity to its trusted ML-DSA-65 verifying key.
+///
+/// This is the authoritative anchor for the mesh/streaming/browser SNS
+/// composite. Bindings come from the node's own hybrid identity and from
+/// attested peer identities. Entries MUST be established out-of-band (peer
+/// attestation / trust-store), never from the self-asserted COSE object.
+#[derive(Default)]
+pub struct KeyedPqTrustStore {
+    bindings: std::collections::HashMap<[u8; 32], Vec<u8>>,
+}
+
+impl KeyedPqTrustStore {
+    /// Create an empty store.
+    pub fn new() -> Self {
+        Self { bindings: std::collections::HashMap::new() }
+    }
+
+    /// Bind an Ed25519 signer identity to its trusted ML-DSA-65 verifying key
+    /// (stored as raw vk bytes; re-decoded on lookup).
+    pub fn bind(&mut self, ed25519_pubkey: [u8; 32], ml_dsa_vk: &crate::crypto::pq::MlDsaVerifyingKey) {
+        self.bindings
+            .insert(ed25519_pubkey, crate::crypto::pq::ml_dsa_vk_bytes(ml_dsa_vk));
+    }
+
+    /// Number of bindings.
+    pub fn len(&self) -> usize {
+        self.bindings.len()
+    }
+
+    /// Whether the store has no bindings.
+    pub fn is_empty(&self) -> bool {
+        self.bindings.is_empty()
+    }
+}
+
+impl PqTrustStore for KeyedPqTrustStore {
+    fn ml_dsa_key_for(&self, ed25519_pubkey: &[u8; 32]) -> Option<crate::crypto::pq::MlDsaVerifyingKey> {
+        self.bindings
+            .get(ed25519_pubkey)
+            .and_then(|bytes| crate::crypto::pq::ml_dsa_vk_from_bytes(bytes).ok())
+    }
+}
+
+// ============================================================================
+// Process-global envelope verify configuration (closes the fail-open).
+// ============================================================================
+
+/// Process-wide envelope verification configuration shared by all production
+/// verify sites (`process_request` / `RequestLoop`, `StreamService` register).
+///
+/// Holds the enforced [`CryptoPolicy`] and the kid-anchored [`PqTrustStore`].
+/// The daemon installs this at startup with `Hybrid` + a real store wired from
+/// the node's hybrid identity (see `key_rotation`). When unset (libraries, unit
+/// tests that don't opt in), verification defaults to `Classical` so unrelated
+/// code paths keep working — production code MUST call [`install_verify_config`].
+pub struct EnvelopeVerifyConfig {
+    pub policy: crate::crypto::CryptoPolicy,
+    pub pq_store: Option<std::sync::Arc<dyn PqTrustStore>>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+static VERIFY_CONFIG: std::sync::OnceLock<EnvelopeVerifyConfig> = std::sync::OnceLock::new();
+
+/// Install the process-global envelope verify configuration. First write wins.
+///
+/// Returns `Err` if a configuration was already installed.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn install_verify_config(config: EnvelopeVerifyConfig) -> Result<()> {
+    VERIFY_CONFIG
+        .set(config)
+        .map_err(|_| anyhow!("envelope verify config already installed"))
+}
+
+/// Whether a process-global verify configuration has been installed.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn verify_config_installed() -> bool {
+    VERIFY_CONFIG.get().is_some()
+}
+
+/// The enforced verify policy: the installed policy, else `Classical`.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn global_verify_policy() -> crate::crypto::CryptoPolicy {
+    VERIFY_CONFIG
+        .get()
+        .map(|c| c.policy)
+        .unwrap_or(crate::crypto::CryptoPolicy::Classical)
+}
+
+/// The installed kid-anchored PQ trust store, if any.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn global_pq_store() -> Option<std::sync::Arc<dyn PqTrustStore>> {
+    VERIFY_CONFIG.get().and_then(|c| c.pq_store.clone())
+}
+
+/// Apply the process-global verify configuration to an `UnwrapOptions`,
+/// unless it has already been explicitly downgraded/overridden.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn apply_global_verify_config<'a>(
+    mut opts: UnwrapOptions<'a>,
+    store_holder: &'a Option<std::sync::Arc<dyn PqTrustStore>>,
+) -> UnwrapOptions<'a> {
+    opts.verify_policy = global_verify_policy();
+    opts.pq_store = store_holder.as_deref();
+    opts
 }
 
 /// Replay protection cache interface.
@@ -825,39 +1022,40 @@ impl SignedEnvelope {
     /// The signature covers the Cap'n Proto serialized bytes of the envelope.
     /// If the authorization is `IdJag` and `wth` is not already set, `wth`
     /// is auto-populated as SHA-256(jwt) per the WIMSE wth binding.
-    pub fn new_signed(mut envelope: RequestEnvelope, signing_key: &SigningKey) -> Self {
-        // Auto-populate wth from IdJag JWT when present and not already set
-        if envelope.wth.is_none() {
-            if let Some(jwt) = envelope.jwt_token() {
-                use sha2::{Digest, Sha256};
-                envelope.wth = Some(Sha256::digest(jwt.as_bytes()).into());
-            }
-        }
-
-        // Serialize the envelope to get canonical bytes
-        let envelope_bytes = envelope.to_bytes();
-
-        // Sign the serialized envelope
-        let signature = signing_key.sign(&envelope_bytes);
-
-        Self {
-            envelope,
-            sig: signature.to_bytes(),
-            cnf: signing_key.verifying_key().to_bytes(),
-            encrypted_envelope: None,
-            client_ephemeral_public: None,
-            pq_sig: None,
-            pq_cnf: None,
-            pq_kem_ciphertext: None,
-        }
+    pub fn new_signed(envelope: RequestEnvelope, signing_key: &SigningKey) -> Self {
+        // Default policy is Classical for the bare Ed25519-only constructor so
+        // that callers that don't supply a PQ key produce verifiable envelopes.
+        Self::new_signed_with_policy(envelope, signing_key, None, crate::crypto::CryptoPolicy::Classical)
     }
 
-    /// Create and dual-sign a new envelope with Ed25519 + ML-DSA-65.
-    #[cfg(feature = "pq-hybrid")]
+    /// Create and dual-sign a new envelope with Ed25519 + ML-DSA-65 (Hybrid).
     pub fn new_signed_hybrid(
-        mut envelope: RequestEnvelope,
+        envelope: RequestEnvelope,
         signing_key: &SigningKey,
         pq_signing_key: &crate::crypto::pq::MlDsaSigningKey,
+    ) -> Self {
+        Self::new_signed_with_policy(
+            envelope,
+            signing_key,
+            Some(pq_signing_key),
+            crate::crypto::CryptoPolicy::Hybrid,
+        )
+    }
+
+    /// Create and sign a new envelope under an explicit [`CryptoPolicy`].
+    ///
+    /// - `Classical`: emits a single-EdDSA COSE composite. `pq_signing_key` is
+    ///   ignored.
+    /// - `Hybrid`: emits an EdDSA + ML-DSA-65 COSE composite. `pq_signing_key`
+    ///   MUST be `Some`; if `None`, falls back to Classical (defensive).
+    ///
+    /// `sig`/`cnf` are always populated with the raw EdDSA signature + signer
+    /// public key for the cnf key-binding path.
+    pub fn new_signed_with_policy(
+        mut envelope: RequestEnvelope,
+        signing_key: &SigningKey,
+        pq_signing_key: Option<&crate::crypto::pq::MlDsaSigningKey>,
+        policy: crate::crypto::CryptoPolicy,
     ) -> Self {
         if envelope.wth.is_none() {
             if let Some(jwt) = envelope.jwt_token() {
@@ -868,10 +1066,13 @@ impl SignedEnvelope {
 
         let envelope_bytes = envelope.to_bytes();
         let signature = signing_key.sign(&envelope_bytes);
-        let pq_sig = crate::crypto::pq::ml_dsa_sign(pq_signing_key, &envelope_bytes);
-        let pq_cnf = crate::crypto::pq::ml_dsa_vk_bytes(
-            &ml_dsa::Keypair::verifying_key(pq_signing_key),
-        );
+        // SECURITY: no empty-cose fallback. A COSE build failure is a
+        // should-never-happen crypto-encoding error (CBOR-encoding fixed-shape
+        // COSE_Sign1 structures over valid keys); fail loud rather than silently
+        // emit an empty (and thus potentially fail-open) composite.
+        #[allow(clippy::expect_used)]
+        let cose = Self::build_cose(signing_key, pq_signing_key, policy, &envelope_bytes)
+            .expect("COSE composite signing must not fail for valid keys");
 
         Self {
             envelope,
@@ -879,61 +1080,77 @@ impl SignedEnvelope {
             cnf: signing_key.verifying_key().to_bytes(),
             encrypted_envelope: None,
             client_ephemeral_public: None,
-            pq_sig: Some(pq_sig),
-            pq_cnf: Some(pq_cnf),
+            cose,
+            policy,
             pq_kem_ciphertext: None,
         }
     }
 
-    /// Create, encrypt, and sign a new envelope (encrypt-then-sign).
+    /// Build the nested COSE composite signature for the given signing-data per
+    /// policy. Returns `Err` on encoding failure — callers MUST NOT substitute
+    /// an empty cose (that would fail open at verify time).
+    fn build_cose(
+        signing_key: &SigningKey,
+        pq_signing_key: Option<&crate::crypto::pq::MlDsaSigningKey>,
+        policy: crate::crypto::CryptoPolicy,
+        signing_data: &[u8],
+    ) -> Result<Vec<u8>> {
+        let pq = if policy.uses_pq() { pq_signing_key } else { None };
+        let aad = envelope_external_aad();
+        crate::crypto::cose_sign::sign_composite(signing_key, pq, signing_data, &aad)
+    }
+
+    /// Create, encrypt, and sign a new envelope (encrypt-then-sign), Classical.
     ///
     /// The envelope is serialized, encrypted with AES-256-GCM-SIV using a key
     /// derived from X25519 DH(client_ephemeral, server_static), then signed.
-    /// The signature covers `encrypted_envelope || client_ephemeral_public`.
+    /// The COSE signature covers `encrypted_envelope || client_ephemeral_public`.
     pub fn new_signed_encrypted(
-        mut envelope: RequestEnvelope,
+        envelope: RequestEnvelope,
         signing_key: &SigningKey,
         server_pubkey: &VerifyingKey,
     ) -> EnvelopeResult<Self> {
-        use crate::crypto::envelope_crypto::encrypt_envelope;
-
-        if envelope.wth.is_none() {
-            if let Some(jwt) = envelope.jwt_token() {
-                use sha2::{Digest, Sha256};
-                envelope.wth = Some(Sha256::digest(jwt.as_bytes()).into());
-            }
-        }
-
-        let envelope_bytes = envelope.to_bytes();
-        let (ciphertext, eph_public) = encrypt_envelope(&envelope_bytes, server_pubkey)?;
-
-        let mut signing_data = Vec::with_capacity(ciphertext.len() + 32);
-        signing_data.extend_from_slice(&ciphertext);
-        signing_data.extend_from_slice(&eph_public);
-        let signature = signing_key.sign(&signing_data);
-
-        Ok(Self {
+        Self::new_signed_encrypted_with_policy(
             envelope,
-            sig: signature.to_bytes(),
-            cnf: signing_key.verifying_key().to_bytes(),
-            encrypted_envelope: Some(ciphertext),
-            client_ephemeral_public: Some(eph_public),
-            pq_sig: None,
-            pq_cnf: None,
-            pq_kem_ciphertext: None,
-        })
+            signing_key,
+            server_pubkey,
+            None,
+            None,
+            crate::crypto::CryptoPolicy::Classical,
+        )
     }
 
     /// Create, encrypt (hybrid X25519+ML-KEM-768), and dual-sign with Ed25519 + ML-DSA-65.
-    #[cfg(feature = "pq-hybrid")]
     pub fn new_signed_encrypted_hybrid(
-        mut envelope: RequestEnvelope,
+        envelope: RequestEnvelope,
         signing_key: &SigningKey,
         server_pubkey: &VerifyingKey,
         pq_signing_key: &crate::crypto::pq::MlDsaSigningKey,
         server_kem_ek: &crate::crypto::pq::MlKemEncapsKey,
     ) -> EnvelopeResult<Self> {
-        use crate::crypto::envelope_crypto::encrypt_envelope_hybrid;
+        Self::new_signed_encrypted_with_policy(
+            envelope,
+            signing_key,
+            server_pubkey,
+            Some(pq_signing_key),
+            Some(server_kem_ek),
+            crate::crypto::CryptoPolicy::Hybrid,
+        )
+    }
+
+    /// Encrypt-then-sign under an explicit [`CryptoPolicy`].
+    ///
+    /// In `Hybrid` mode both `pq_signing_key` and `server_kem_ek` must be
+    /// supplied (ML-KEM-768 hybrid encryption + ML-DSA-65 composite signature).
+    pub fn new_signed_encrypted_with_policy(
+        mut envelope: RequestEnvelope,
+        signing_key: &SigningKey,
+        server_pubkey: &VerifyingKey,
+        pq_signing_key: Option<&crate::crypto::pq::MlDsaSigningKey>,
+        server_kem_ek: Option<&crate::crypto::pq::MlKemEncapsKey>,
+        policy: crate::crypto::CryptoPolicy,
+    ) -> EnvelopeResult<Self> {
+        use crate::crypto::envelope_crypto::{encrypt_envelope, encrypt_envelope_hybrid};
 
         if envelope.wth.is_none() {
             if let Some(jwt) = envelope.jwt_token() {
@@ -943,19 +1160,30 @@ impl SignedEnvelope {
         }
 
         let envelope_bytes = envelope.to_bytes();
-        let (ciphertext, eph_public, kem_ct) =
-            encrypt_envelope_hybrid(&envelope_bytes, server_pubkey, server_kem_ek)?;
 
-        // Sign ciphertext ∥ eph_x25519_public ∥ kem_ciphertext
-        let mut signing_data = Vec::with_capacity(ciphertext.len() + 32 + kem_ct.len());
+        let (ciphertext, eph_public, kem_ct) = if policy.uses_pq() {
+            let kem_ek = server_kem_ek.ok_or_else(|| {
+                EnvelopeError::Encryption("Hybrid policy requires server ML-KEM key".into())
+            })?;
+            let (ct, eph, kem) = encrypt_envelope_hybrid(&envelope_bytes, server_pubkey, kem_ek)?;
+            (ct, eph, Some(kem))
+        } else {
+            let (ct, eph) = encrypt_envelope(&envelope_bytes, server_pubkey)?;
+            (ct, eph, None)
+        };
+
+        // Signing data: ciphertext ∥ eph_x25519_public ∥ [kem_ciphertext]
+        let kem_len = kem_ct.as_ref().map_or(0, Vec::len);
+        let mut signing_data = Vec::with_capacity(ciphertext.len() + 32 + kem_len);
         signing_data.extend_from_slice(&ciphertext);
         signing_data.extend_from_slice(&eph_public);
-        signing_data.extend_from_slice(&kem_ct);
+        if let Some(ref kem) = kem_ct {
+            signing_data.extend_from_slice(kem);
+        }
+
         let signature = signing_key.sign(&signing_data);
-        let pq_sig = crate::crypto::pq::ml_dsa_sign(pq_signing_key, &signing_data);
-        let pq_cnf = crate::crypto::pq::ml_dsa_vk_bytes(
-            &ml_dsa::Keypair::verifying_key(pq_signing_key),
-        );
+        let cose = Self::build_cose(signing_key, pq_signing_key, policy, &signing_data)
+            .map_err(|e| EnvelopeError::Encryption(format!("COSE composite signing failed: {e}")))?;
 
         Ok(Self {
             envelope,
@@ -963,9 +1191,9 @@ impl SignedEnvelope {
             cnf: signing_key.verifying_key().to_bytes(),
             encrypted_envelope: Some(ciphertext),
             client_ephemeral_public: Some(eph_public),
-            pq_sig: Some(pq_sig),
-            pq_cnf: Some(pq_cnf),
-            pq_kem_ciphertext: Some(kem_ct),
+            cose,
+            policy,
+            pq_kem_ciphertext: kem_ct,
         })
     }
 
@@ -993,6 +1221,26 @@ impl SignedEnvelope {
         expected_pubkey: &VerifyingKey,
         nonce_cache: &dyn NonceCache,
     ) -> EnvelopeResult<()> {
+        self.verify_with(expected_pubkey, nonce_cache, None, crate::crypto::CryptoPolicy::Classical)
+    }
+
+    /// Verify with an explicit kid-anchored PQ trust store and verify policy.
+    ///
+    /// - `pq_store`: when `Some`, resolves the trust-anchored ML-DSA-65 key for
+    ///   the envelope's EdDSA signer (`cnf`). The COSE ML-DSA-65 entry must
+    ///   verify against this key and its kid must match (kid-anchoring) —
+    ///   fixing the self-certification weakness.
+    /// - `verify_policy`: `Hybrid` REQUIRES a valid ML-DSA-65 entry anchored to
+    ///   the trust store (rejects classical-only and self-asserted PQ keys);
+    ///   `Classical` verifies only EdDSA and SKIPS any PQ entry (RFC 7517
+    ///   skip-unknown interop).
+    pub fn verify_with(
+        &self,
+        expected_pubkey: &VerifyingKey,
+        nonce_cache: &dyn NonceCache,
+        pq_store: Option<&dyn PqTrustStore>,
+        verify_policy: crate::crypto::CryptoPolicy,
+    ) -> EnvelopeResult<()> {
         // 1. Verify signer matches expected (constant-time comparison)
         if !bool::from(self.cnf.ct_eq(&expected_pubkey.to_bytes())) {
             return Err(EnvelopeError::SignerMismatch {
@@ -1001,38 +1249,8 @@ impl SignedEnvelope {
             });
         }
 
-        // 2. Check timestamp window
-        let now = current_timestamp();
-
-        let age = now - self.envelope.iat;
-        if age > MAX_TIMESTAMP_AGE_MS {
-            return Err(EnvelopeError::ReplayAttack(format!(
-                "timestamp too old: {age}ms > {MAX_TIMESTAMP_AGE_MS}ms"
-            )));
-        }
-        if age < -MAX_CLOCK_SKEW_MS {
-            return Err(EnvelopeError::ReplayAttack(format!(
-                "timestamp in future: {}ms beyond clock skew tolerance",
-                -age - MAX_CLOCK_SKEW_MS
-            )));
-        }
-
-        // 3. Check nonce not seen before
-        if !nonce_cache.check_and_insert(&self.envelope.nonce) {
-            return Err(EnvelopeError::ReplayAttack(
-                "nonce already seen".to_owned(),
-            ));
-        }
-
-        // 4. Verify signature (strict: rejects small-order public keys)
-        let signing_data = self.signed_bytes();
-        let signature = Signature::from_bytes(&self.sig);
-        expected_pubkey.verify_strict(&signing_data, &signature)?;
-
-        // 5. Verify PQ signature
-        self.verify_pq_signature(&signing_data, None)?;
-
-        Ok(())
+        self.check_replay(nonce_cache)?;
+        self.verify_cose(expected_pubkey, pq_store, verify_policy)
     }
 
     /// Verify signature only (skip replay protection).
@@ -1045,13 +1263,23 @@ impl SignedEnvelope {
                 actual: hex::encode(self.cnf),
             });
         }
+        self.verify_cose(expected_pubkey, None, crate::crypto::CryptoPolicy::Classical)
+    }
 
-        let signing_data = self.signed_bytes();
-        let signature = Signature::from_bytes(&self.sig);
-        expected_pubkey.verify_strict(&signing_data, &signature)?;
-        self.verify_pq_signature(&signing_data, None)?;
-
-        Ok(())
+    /// Verify signature only under an explicit policy + PQ trust store.
+    pub fn verify_signature_only_with(
+        &self,
+        expected_pubkey: &VerifyingKey,
+        pq_store: Option<&dyn PqTrustStore>,
+        verify_policy: crate::crypto::CryptoPolicy,
+    ) -> EnvelopeResult<()> {
+        if !bool::from(self.cnf.ct_eq(&expected_pubkey.to_bytes())) {
+            return Err(EnvelopeError::SignerMismatch {
+                expected: hex::encode(expected_pubkey.to_bytes()),
+                actual: hex::encode(self.cnf),
+            });
+        }
+        self.verify_cose(expected_pubkey, pq_store, verify_policy)
     }
 
     /// Verify against the envelope's own embedded signer pubkey.
@@ -1062,11 +1290,24 @@ impl SignedEnvelope {
         &self,
         nonce_cache: &dyn NonceCache,
     ) -> EnvelopeResult<()> {
-        // 1. Reconstruct the verifying key from the embedded pubkey
+        self.verify_any_signer_with(nonce_cache, None, crate::crypto::CryptoPolicy::Classical)
+    }
+
+    /// `verify_any_signer` with an explicit kid-anchored PQ trust store + policy.
+    pub fn verify_any_signer_with(
+        &self,
+        nonce_cache: &dyn NonceCache,
+        pq_store: Option<&dyn PqTrustStore>,
+        verify_policy: crate::crypto::CryptoPolicy,
+    ) -> EnvelopeResult<()> {
         let verifying_key = VerifyingKey::from_bytes(&self.cnf)
             .map_err(|_| EnvelopeError::InvalidPublicKey { expected: 32, actual: 0 })?;
+        self.check_replay(nonce_cache)?;
+        self.verify_cose(&verifying_key, pq_store, verify_policy)
+    }
 
-        // 2. Check timestamp window
+    /// Timestamp window + nonce replay check.
+    fn check_replay(&self, nonce_cache: &dyn NonceCache) -> EnvelopeResult<()> {
         let now = current_timestamp();
         let age = now - self.envelope.iat;
         if age > MAX_TIMESTAMP_AGE_MS {
@@ -1080,72 +1321,50 @@ impl SignedEnvelope {
                 -age - MAX_CLOCK_SKEW_MS
             )));
         }
-
-        // 3. Check nonce not seen before
         if !nonce_cache.check_and_insert(&self.envelope.nonce) {
-            return Err(EnvelopeError::ReplayAttack(
-                "nonce already seen".to_owned(),
-            ));
+            return Err(EnvelopeError::ReplayAttack("nonce already seen".to_owned()));
         }
-
-        // 4. Verify signature against the embedded public key
-        let signing_data = self.signed_bytes();
-        let signature = Signature::from_bytes(&self.sig);
-        verifying_key.verify_strict(&signing_data, &signature)?;
-
-        // 5. Verify PQ signature
-        self.verify_pq_signature(&signing_data, None)?;
-
         Ok(())
     }
 
-    /// Verify ML-DSA-65 post-quantum signature if present.
+    /// Verify the COSE composite signature (authoritative auth check).
     ///
-    /// When `pq-hybrid` feature is enabled, PQ signatures are mandatory —
-    /// envelopes without them are rejected.
-    ///
-    /// When `expected_pq_cnf` is `Some`, the envelope's `pq_cnf` must match
-    /// (constant-time comparison). This binds the PQ key to an identity,
-    /// preventing an attacker from stripping the PQ signature and re-signing
-    /// with their own ML-DSA key. When `None`, the PQ key is self-certified
-    /// and the hybrid scheme degrades to Ed25519-level authentication.
-    fn verify_pq_signature(&self, signing_data: &[u8], expected_pq_cnf: Option<&[u8]>) -> EnvelopeResult<()> {
-        match (&self.pq_sig, &self.pq_cnf) {
-            (Some(sig), Some(cnf)) => {
-                #[cfg(feature = "pq-hybrid")]
-                {
-                    if let Some(expected) = expected_pq_cnf {
-                        if cnf.len() != expected.len()
-                            || !bool::from(cnf.as_slice().ct_eq(expected))
-                        {
-                            return Err(EnvelopeError::PqSignatureInvalid(
-                                "pq_cnf does not match expected PQ verifying key".to_owned(),
-                            ));
-                        }
-                    }
-                    let vk = crate::crypto::pq::ml_dsa_vk_from_bytes(cnf)
-                        .map_err(|e| EnvelopeError::PqSignatureInvalid(e.to_string()))?;
-                    crate::crypto::pq::ml_dsa_verify(&vk, signing_data, sig)
-                        .map_err(|e| EnvelopeError::PqSignatureInvalid(e.to_string()))?;
-                }
-                #[cfg(not(feature = "pq-hybrid"))]
-                {
-                    let _ = (sig, cnf, signing_data, expected_pq_cnf);
-                }
-                Ok(())
-            }
-            (None, None) => {
-                #[cfg(feature = "pq-hybrid")]
-                return Err(EnvelopeError::PqSignatureInvalid(
-                    "missing mandatory PQ signature".to_owned(),
-                ));
-                #[cfg(not(feature = "pq-hybrid"))]
-                Ok(())
-            }
-            _ => Err(EnvelopeError::PqSignatureInvalid(
-                "incomplete PQ signature fields (need both pq_sig and pq_cnf)".to_owned(),
-            )),
+    /// The raw EdDSA `sig`/`cnf` advertisement is NOT trusted on its own; this
+    /// re-verifies the EdDSA component inside the COSE composite against
+    /// `ed_vk`, and (under Hybrid policy) the kid-anchored ML-DSA-65 component.
+    fn verify_cose(
+        &self,
+        ed_vk: &VerifyingKey,
+        pq_store: Option<&dyn PqTrustStore>,
+        verify_policy: crate::crypto::CryptoPolicy,
+    ) -> EnvelopeResult<()> {
+        let signing_data = self.signed_bytes();
+        let aad = envelope_external_aad();
+
+        // kid-anchor: resolve the trusted ML-DSA-65 key for this EdDSA identity.
+        let anchored_pq = pq_store.and_then(|s| s.ml_dsa_key_for(&self.cnf));
+
+        // Hybrid enforcement requires an anchored PQ key; without one we cannot
+        // safely require PQ (resolving from the self-asserted COSE entry would
+        // reintroduce the self-cert weakness). Treat as a policy error.
+        let require_pq = verify_policy.uses_pq();
+        if require_pq && anchored_pq.is_none() {
+            return Err(EnvelopeError::PqSignatureInvalid(
+                "Hybrid policy requires a kid-anchored ML-DSA-65 key, none resolved".to_owned(),
+            ));
         }
+
+        crate::crypto::cose_sign::verify_composite(
+            &self.cose,
+            ed_vk,
+            anchored_pq.as_ref(),
+            &signing_data,
+            &aad,
+            require_pq,
+        )
+        .map_err(|e| EnvelopeError::PqSignatureInvalid(e.to_string()))?;
+
+        Ok(())
     }
 
     /// Compute the bytes that were signed.
@@ -1199,7 +1418,6 @@ impl SignedEnvelope {
     }
 
     /// Decrypt a hybrid-encrypted envelope in-place (X25519 + ML-KEM-768).
-    #[cfg(feature = "pq-hybrid")]
     pub fn decrypt_in_place_hybrid(
         &mut self,
         server_signing_key: &crate::crypto::SigningKey,
@@ -1362,12 +1580,7 @@ impl ToCapnp for SignedEnvelope {
         if let Some(ref eph) = self.client_ephemeral_public {
             builder.set_client_ephemeral_public(eph);
         }
-        if let Some(ref pq_sig) = self.pq_sig {
-            builder.set_pq_sig(pq_sig);
-        }
-        if let Some(ref pq_cnf) = self.pq_cnf {
-            builder.set_pq_cnf(pq_cnf);
-        }
+        builder.set_cose(&self.cose);
         if let Some(ref kem_ct) = self.pq_kem_ciphertext {
             builder.set_pq_kem_ciphertext(kem_ct);
         }
@@ -1425,29 +1638,23 @@ impl FromCapnp for SignedEnvelope {
             }
         };
 
-        let pq_sig = {
-            let data = reader.get_pq_sig()?;
-            if data.is_empty() { None } else { Some(data.to_vec()) }
-        };
-
-        let pq_cnf = {
-            let data = reader.get_pq_cnf()?;
-            if data.is_empty() { None } else { Some(data.to_vec()) }
-        };
+        let cose = reader.get_cose()?.to_vec();
 
         let pq_kem_ciphertext = {
             let data = reader.get_pq_kem_ciphertext()?;
             if data.is_empty() { None } else { Some(data.to_vec()) }
         };
 
+        // `policy` is a signing-time concept; the verifier supplies the verify
+        // policy explicitly, so decode to the default here.
         Ok(Self {
             envelope: RequestEnvelope::read_from(reader.get_envelope()?)?,
             sig,
             cnf,
             encrypted_envelope,
             client_ephemeral_public,
-            pq_sig,
-            pq_cnf,
+            cose,
+            policy: crate::crypto::CryptoPolicy::default(),
             pq_kem_ciphertext,
         })
     }
@@ -1587,10 +1794,10 @@ pub fn unwrap_and_verify(
 
     match &opts.verification {
         EnvelopeVerification::FixedSigner(pubkey) => {
-            signed.verify(pubkey, opts.nonce_cache)?;
+            signed.verify_with(pubkey, opts.nonce_cache, opts.pq_store, opts.verify_policy)?;
         }
         EnvelopeVerification::AnySigner => {
-            signed.verify_any_signer(opts.nonce_cache)?;
+            signed.verify_any_signer_with(opts.nonce_cache, opts.pq_store, opts.verify_policy)?;
         }
     }
 
@@ -1698,20 +1905,32 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "pq-hybrid")]
-    fn test_pq_keypair() -> crate::crypto::pq::MlDsaSigningKey {
-        let (sk, _vk) = crate::crypto::pq::ml_dsa_generate_keypair();
-        sk
+    /// Test envelopes default to Classical signing; the existing tests exercise
+    /// the EdDSA path. Hybrid/cross-compat is covered by the dedicated M3 tests
+    /// below.
+    fn test_new_signed(envelope: RequestEnvelope, signing_key: &SigningKey) -> SignedEnvelope {
+        SignedEnvelope::new_signed(envelope, signing_key)
     }
 
-    fn test_new_signed(envelope: RequestEnvelope, signing_key: &SigningKey) -> SignedEnvelope {
-        #[cfg(feature = "pq-hybrid")]
-        {
-            let pq_sk = test_pq_keypair();
-            SignedEnvelope::new_signed_hybrid(envelope, signing_key, &pq_sk)
+    /// In-memory kid-anchored PQ trust store for tests.
+    struct TestPqStore {
+        bindings: Vec<([u8; 32], crate::crypto::pq::MlDsaVerifyingKey)>,
+    }
+    impl PqTrustStore for TestPqStore {
+        fn ml_dsa_key_for(
+            &self,
+            ed25519_pubkey: &[u8; 32],
+        ) -> Option<crate::crypto::pq::MlDsaVerifyingKey> {
+            self.bindings
+                .iter()
+                .find(|(k, _)| k == ed25519_pubkey)
+                .map(|(_, vk)| {
+                    crate::crypto::pq::ml_dsa_vk_from_bytes(
+                        &crate::crypto::pq::ml_dsa_vk_bytes(vk),
+                    )
+                    .expect("re-decode pq vk")
+                })
         }
-        #[cfg(not(feature = "pq-hybrid"))]
-        SignedEnvelope::new_signed(envelope, signing_key)
     }
 
     #[test]
@@ -2149,5 +2368,224 @@ mod tests {
 
         let result = signed.verify_signature_only(&verifying_key);
         assert!(result.is_err(), "Tampered wth must invalidate signature");
+    }
+
+    // =========================================================================
+    // M3 (#152): COSE composite envelope — both schemes + cross-compat + anchor
+    // =========================================================================
+
+    use crate::crypto::CryptoPolicy;
+
+    fn pq_store_for(ed_pubkey: [u8; 32], pq_vk: &crate::crypto::pq::MlDsaVerifyingKey) -> TestPqStore {
+        let vk = crate::crypto::pq::ml_dsa_vk_from_bytes(
+            &crate::crypto::pq::ml_dsa_vk_bytes(pq_vk),
+        )
+        .expect("decode pq vk");
+        TestPqStore { bindings: vec![(ed_pubkey, vk)] }
+    }
+
+    /// classical_only: sign + verify in Classical mode.
+    #[test]
+    fn m3_classical_only() -> crate::EnvelopeResult<()> {
+        let (sk, vk) = generate_signing_keypair();
+        let cache = TestNonceCache::new();
+        let signed = SignedEnvelope::new_signed_with_policy(
+            RequestEnvelope::anonymous(vec![1, 2, 3]),
+            &sk,
+            None,
+            CryptoPolicy::Classical,
+        );
+        signed.verify_with(&vk, &cache, None, CryptoPolicy::Classical)?;
+        Ok(())
+    }
+
+    /// hybrid: sign + verify composite (both EdDSA + ML-DSA-65 checked).
+    #[test]
+    fn m3_hybrid_both_checked() -> crate::EnvelopeResult<()> {
+        let (sk, vk) = generate_signing_keypair();
+        let (pq_sk, pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
+        let cache = TestNonceCache::new();
+        let signed = SignedEnvelope::new_signed_hybrid(
+            RequestEnvelope::anonymous(vec![4, 5, 6]),
+            &sk,
+            &pq_sk,
+        );
+        let store = pq_store_for(vk.to_bytes(), &pq_vk);
+        signed.verify_with(&vk, &cache, Some(&store), CryptoPolicy::Hybrid)?;
+        Ok(())
+    }
+
+    /// cross_pq_signer_classical_verifier: a Hybrid-signed envelope verifies
+    /// under a Classical verifier via the EdDSA component + skip-unknown.
+    #[test]
+    fn m3_cross_hybrid_signer_classical_verifier() -> crate::EnvelopeResult<()> {
+        let (sk, vk) = generate_signing_keypair();
+        let (pq_sk, _pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
+        let cache = TestNonceCache::new();
+        let signed = SignedEnvelope::new_signed_hybrid(
+            RequestEnvelope::anonymous(vec![7, 8, 9]),
+            &sk,
+            &pq_sk,
+        );
+        // Classical verifier: no PQ store, Classical policy → skips ML-DSA entry.
+        signed.verify_with(&vk, &cache, None, CryptoPolicy::Classical)?;
+        Ok(())
+    }
+
+    /// cross_classical_signer_hybrid_verifier: a Classical-signed item under a
+    /// Hybrid verifier — the policy knob. Hybrid REQUIRES PQ → rejected.
+    #[test]
+    fn m3_cross_classical_signer_hybrid_verifier_rejected() {
+        let (sk, vk) = generate_signing_keypair();
+        let (_pq_sk, pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
+        let cache = TestNonceCache::new();
+        let signed = SignedEnvelope::new_signed(RequestEnvelope::anonymous(vec![1]), &sk);
+        let store = pq_store_for(vk.to_bytes(), &pq_vk);
+        let res = signed.verify_with(&vk, &cache, Some(&store), CryptoPolicy::Hybrid);
+        assert!(res.is_err(), "Hybrid policy must reject a classical-only envelope");
+    }
+
+    /// Classical signer accepted by a verifier whose policy permits classical.
+    #[test]
+    fn m3_classical_signer_classical_policy_accepted() -> crate::EnvelopeResult<()> {
+        let (sk, vk) = generate_signing_keypair();
+        let cache = TestNonceCache::new();
+        let signed = SignedEnvelope::new_signed(RequestEnvelope::anonymous(vec![1]), &sk);
+        signed.verify_with(&vk, &cache, None, CryptoPolicy::Classical)?;
+        Ok(())
+    }
+
+    /// self_cert_fix: an envelope whose ML-DSA key doesn't match the
+    /// kid-resolved key is REJECTED (proves the kid-anchoring).
+    #[test]
+    fn m3_self_cert_fix_wrong_anchored_pq_key_rejected() {
+        let (sk, vk) = generate_signing_keypair();
+        let (pq_sk, _pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
+        // Attacker/foreign anchored key that does NOT match the signer's PQ key.
+        let (_other_sk, other_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
+        let cache = TestNonceCache::new();
+        let signed = SignedEnvelope::new_signed_hybrid(
+            RequestEnvelope::anonymous(vec![1, 2, 3]),
+            &sk,
+            &pq_sk,
+        );
+        let store = pq_store_for(vk.to_bytes(), &other_vk);
+        let res = signed.verify_with(&vk, &cache, Some(&store), CryptoPolicy::Hybrid);
+        assert!(
+            res.is_err(),
+            "PQ key not matching the kid-anchored key must be rejected (self-cert fix)"
+        );
+    }
+
+    /// Hybrid policy with NO anchored key must fail closed (cannot trust a
+    /// self-asserted PQ key — this is the core of the self-cert fix).
+    #[test]
+    fn m3_hybrid_policy_without_anchor_rejected() {
+        let (sk, vk) = generate_signing_keypair();
+        let (pq_sk, _pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
+        let cache = TestNonceCache::new();
+        let signed = SignedEnvelope::new_signed_hybrid(
+            RequestEnvelope::anonymous(vec![1]),
+            &sk,
+            &pq_sk,
+        );
+        let res = signed.verify_with(&vk, &cache, None, CryptoPolicy::Hybrid);
+        assert!(res.is_err(), "Hybrid policy requires a kid-anchored PQ key");
+    }
+
+    // -- SNS-specific: strip the outer ML-DSA layer at the cose level and prove
+    //    Hybrid policy rejects it (the attack the review found accepted before).
+    #[test]
+    fn m3_sns_strip_outer_mldsa_rejected() {
+        let (sk, vk) = generate_signing_keypair();
+        let (pq_sk, pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
+        let cache = TestNonceCache::new();
+        let mut signed = SignedEnvelope::new_signed_hybrid(
+            RequestEnvelope::anonymous(vec![1, 2, 3]),
+            &sk,
+            &pq_sk,
+        );
+        // Strip: re-encode the composite with the outer set to null.
+        let (inner, outer) =
+            crate::crypto::cose_sign::decode_composite_for_test(&signed.cose).expect("decode");
+        assert!(outer.is_some(), "hybrid envelope must have an outer layer");
+        signed.cose =
+            crate::crypto::cose_sign::encode_composite_for_test(inner, None).expect("encode");
+
+        let store = pq_store_for(vk.to_bytes(), &pq_vk);
+        let res = signed.verify_with(&vk, &cache, Some(&store), CryptoPolicy::Hybrid);
+        assert!(res.is_err(), "stripping the outer ML-DSA layer must fail Hybrid policy");
+    }
+
+    /// Integration at the `unwrap_and_verify` level (prod-wiring path the review
+    /// flagged as missing): sign Hybrid, strip the outer, serialize to wire, and
+    /// assert `unwrap_and_verify` REJECTS under a Hybrid deployment.
+    #[test]
+    fn m3_unwrap_and_verify_strip_rejected_under_hybrid() {
+        let (sk, vk) = generate_signing_keypair();
+        let (pq_sk, pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
+        let cache = TestNonceCache::new();
+
+        // Sign Hybrid, then strip the outer layer.
+        let mut signed = SignedEnvelope::new_signed_hybrid(
+            RequestEnvelope::anonymous(vec![9, 9, 9]),
+            &sk,
+            &pq_sk,
+        );
+        let (inner, _outer) =
+            crate::crypto::cose_sign::decode_composite_for_test(&signed.cose).expect("decode");
+        signed.cose =
+            crate::crypto::cose_sign::encode_composite_for_test(inner, None).expect("encode");
+
+        // Serialize to wire bytes.
+        let mut message = capnp::message::Builder::new_default();
+        {
+            let mut builder = message.init_root::<common_capnp::signed_envelope::Builder>();
+            signed.write_to(&mut builder);
+        }
+        let mut wire = Vec::new();
+        capnp::serialize::write_message(&mut wire, &message).expect("serialize");
+
+        // Verify under a Hybrid deployment via unwrap_and_verify.
+        let store = pq_store_for(vk.to_bytes(), &pq_vk);
+        let opts = UnwrapOptions::fixed_signer(&vk, &cache)
+            .with_verify_policy(CryptoPolicy::Hybrid)
+            .with_pq_store(&store);
+        let res = unwrap_and_verify(&wire, &opts);
+        assert!(
+            res.is_err(),
+            "unwrap_and_verify must reject a stripped Hybrid envelope (prod fail-open closed)"
+        );
+    }
+
+    /// Integration: a well-formed Hybrid envelope passes unwrap_and_verify under
+    /// a Hybrid deployment with the correct anchor.
+    #[test]
+    fn m3_unwrap_and_verify_hybrid_round_trip() -> crate::EnvelopeResult<()> {
+        let (sk, vk) = generate_signing_keypair();
+        let (pq_sk, pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
+        let cache = TestNonceCache::new();
+
+        let signed = SignedEnvelope::new_signed_hybrid(
+            RequestEnvelope::anonymous(vec![4, 2]),
+            &sk,
+            &pq_sk,
+        );
+        let mut message = capnp::message::Builder::new_default();
+        {
+            let mut builder = message.init_root::<common_capnp::signed_envelope::Builder>();
+            signed.write_to(&mut builder);
+        }
+        let mut wire = Vec::new();
+        capnp::serialize::write_message(&mut wire, &message).expect("serialize");
+
+        let store = pq_store_for(vk.to_bytes(), &pq_vk);
+        let opts = UnwrapOptions::fixed_signer(&vk, &cache)
+            .with_verify_policy(CryptoPolicy::Hybrid)
+            .with_pq_store(&store);
+        let (_signed, payload) = unwrap_and_verify(&wire, &opts)
+            .map_err(|e| EnvelopeError::PqSignatureInvalid(e.to_string()))?;
+        assert_eq!(payload, vec![4, 2]);
+        Ok(())
     }
 }

--- a/crates/hyprstream-rpc/src/envelope.rs
+++ b/crates/hyprstream-rpc/src/envelope.rs
@@ -841,13 +841,43 @@ pub fn verify_config_installed() -> bool {
     VERIFY_CONFIG.get().is_some()
 }
 
-/// The enforced verify policy: the installed policy, else `Classical`.
+/// The enforced verify policy.
+///
+/// When a config has been installed, its policy is returned verbatim.
+///
+/// When **uninstalled**, the default is **fail-closed**: production builds
+/// default to [`CryptoPolicy::Hybrid`] so that any verify site reached before
+/// `install_verify_config` (subprocess-spawner services, early init) rejects
+/// classical-only envelopes rather than silently accepting EdDSA-only ones
+/// (#160 — this previously defaulted `Classical`, re-opening the M3 fail-open).
+///
+/// Under `cfg(test)` the uninstalled default stays `Classical`: in-process unit
+/// tests share one `OnceLock` and rely on per-call `UnwrapOptions` overrides
+/// rather than a global install. Integration tests (which compile this crate in
+/// non-test mode) must call [`install_verify_config`] explicitly.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn global_verify_policy() -> crate::crypto::CryptoPolicy {
-    VERIFY_CONFIG
-        .get()
-        .map(|c| c.policy)
-        .unwrap_or(crate::crypto::CryptoPolicy::Classical)
+    if let Some(c) = VERIFY_CONFIG.get() {
+        return c.policy;
+    }
+    #[cfg(test)]
+    {
+        crate::crypto::CryptoPolicy::Classical
+    }
+    #[cfg(not(test))]
+    {
+        // Fail-closed default. Loud (once — this is on the per-request verify
+        // path), because reaching a verify site with no installed config in
+        // production is a wiring bug (#160).
+        static WARNED: std::sync::Once = std::sync::Once::new();
+        WARNED.call_once(|| {
+            tracing::warn!(
+                "envelope verify config not installed; defaulting to fail-closed Hybrid \
+                 policy. Production code MUST call install_verify_config() at startup."
+            );
+        });
+        crate::crypto::CryptoPolicy::Hybrid
+    }
 }
 
 /// The installed kid-anchored PQ trust store, if any.

--- a/crates/hyprstream-rpc/src/envelope.rs
+++ b/crates/hyprstream-rpc/src/envelope.rs
@@ -618,42 +618,28 @@ impl RequestEnvelope {
     /// These bytes are what gets signed in a SignedEnvelope.
     pub fn to_bytes(&self) -> Vec<u8> {
         use capnp::message::Builder;
-        use capnp::serialize;
         use capnp::Word;
 
-        // Step 1: Build the message
+        // Build the message.
         let mut message = Builder::new_default();
         {
             let mut builder = message.init_root::<common_capnp::request_envelope::Builder>();
             self.write_to(&mut builder);
         }
 
-        // Step 2: Serialize to bytes first (to create a reader)
-        let mut temp_bytes = Vec::new();
-        if let Err(_e) = serialize::write_message(&mut temp_bytes, &message) {
-            #[cfg(not(target_arch = "wasm32"))]
-            tracing::error!("RequestEnvelope temporary serialization failed: {}", _e);
-            return Vec::new();
-        }
-
-        // Step 3: Read back to get a Reader
-        let reader = match serialize::read_message(
-            &mut std::io::Cursor::new(&temp_bytes),
-            envelope_reader_options(),
-        ) {
-            Ok(r) => r,
-            Err(_e) => {
-                #[cfg(not(target_arch = "wasm32"))]
-                tracing::error!("RequestEnvelope reader creation failed: {}", _e);
-                return Vec::new();
-            }
-        };
-
-        // Step 4: CRITICAL - Canonicalize before signing
-        // This ensures deterministic serialization as required by Cap'n Proto spec.
-        // Non-canonical serialization can produce different bytes for identical data,
-        // breaking signature verification across platforms/versions.
-        let canonical_words = match reader.canonicalize() {
+        // Canonicalize directly from the builder (#178). Cap'n Proto is
+        // zero-copy; the previous implementation defeated that on the signing
+        // hot path by serializing to a temp Vec and reparsing it just to obtain
+        // a Reader. `Builder::into_reader()` reads the builder's own segments in
+        // place — no temp serialize, no reparse. Canonicalization is still
+        // REQUIRED: capnp messages aren't canonical by default, and signatures
+        // must be over deterministic bytes for cross-platform verification.
+        //
+        // `into_reader()` uses unlimited traversal, which is correct here: the
+        // message is self-produced (not untrusted input), and it removes a
+        // latent bug where the old 1-MiB-limited reader silently returned empty
+        // bytes — breaking signing — for envelopes larger than 1 MiB.
+        let canonical_words = match message.into_reader().canonicalize() {
             Ok(words) => words,
             Err(_e) => {
                 #[cfg(not(target_arch = "wasm32"))]
@@ -662,7 +648,7 @@ impl RequestEnvelope {
             }
         };
 
-        // Step 5: Convert Words to bytes (raw segment data, NO stream framing)
+        // Convert Words to bytes (raw segment data, NO stream framing).
         Word::words_to_bytes(&canonical_words).to_vec()
     }
 }

--- a/crates/hyprstream-rpc/src/lib.rs
+++ b/crates/hyprstream-rpc/src/lib.rs
@@ -136,6 +136,8 @@ pub mod zmq_context;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod streaming;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod moq_stream;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod transport;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod notify;

--- a/crates/hyprstream-rpc/src/lib.rs
+++ b/crates/hyprstream-rpc/src/lib.rs
@@ -142,6 +142,8 @@ pub mod transport;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod dial;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod service_entry;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod notify;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod paths;

--- a/crates/hyprstream-rpc/src/lib.rs
+++ b/crates/hyprstream-rpc/src/lib.rs
@@ -140,6 +140,8 @@ pub mod moq_stream;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod transport;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod dial;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod notify;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod paths;

--- a/crates/hyprstream-rpc/src/lib.rs
+++ b/crates/hyprstream-rpc/src/lib.rs
@@ -180,9 +180,9 @@ pub use crypto::{generate_ephemeral_keypair, ristretto_dh, RistrettoPublic, Rist
 
 pub use envelope::{
     unwrap_and_verify,
-    Authorization, EnvelopeVerification, FederatedToken, InMemoryNonceCache, NonceCache,
-    RequestEnvelope, ResponseEnvelope, SignedEnvelope, Subject, TokenClaims, UnwrapOptions,
-    MAX_CLOCK_SKEW_MS, MAX_TIMESTAMP_AGE_MS,
+    Authorization, EnvelopeVerification, FederatedToken, InMemoryNonceCache, KeyedPqTrustStore,
+    NonceCache, PqTrustStore, RequestEnvelope, ResponseEnvelope, SignedEnvelope, Subject,
+    TokenClaims, UnwrapOptions, MAX_CLOCK_SKEW_MS, MAX_TIMESTAMP_AGE_MS,
 };
 #[cfg(not(target_arch = "wasm32"))]
 pub use envelope::unwrap_envelope;

--- a/crates/hyprstream-rpc/src/lib.rs
+++ b/crates/hyprstream-rpc/src/lib.rs
@@ -200,7 +200,11 @@ pub use resolver::Resolver;
 pub use registry::SocketKind;
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use service::{Continuation, EnvelopeContext, RequestLoop, Spawnable, ServiceHandle, ZmqService};
+pub use service::{Continuation, EnvelopeContext, RequestLoop, Spawnable, ServiceHandle, RequestService};
+/// Transitional compat alias for the former `ZmqService` (#166); removed in #138.
+#[cfg(not(target_arch = "wasm32"))]
+#[doc(hidden)]
+pub use service::RequestService as ZmqService;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use streaming::{
@@ -232,7 +236,7 @@ pub mod prelude {
         // Error
         EnvelopeError, EnvelopeResult, Result, RpcError,
         // Service (transport)
-        EnvelopeContext, RequestLoop, ServiceHandle, ZmqService,
+        EnvelopeContext, RequestLoop, ServiceHandle, RequestService,
         // Streaming
         StreamContext, StreamPublisher,
     };

--- a/crates/hyprstream-rpc/src/moq_stream.rs
+++ b/crates/hyprstream-rpc/src/moq_stream.rs
@@ -1,0 +1,388 @@
+//! moq-lite streaming plane (M2a of epic #134).
+//!
+//! This is the moq-native replacement for the ZMQ PULL→XPUB queuing proxy in
+//! [`crate::service::streaming`]. Instead of a forwarding proxy with a custom
+//! per-topic queue + late-join rejoin buffer, in-process publishers append
+//! directly to a shared `moq_net::Origin`, and external subscribers consume the
+//! *same* origin over the `moql` ALPN via
+//! [`crate::transport::iroh_moq::IrohMoqProtocolHandler`].
+//!
+//! # Topic → Track mapping
+//!
+//! The existing call-site contract is a topic string (64-hex DH-derived, or a
+//! `notify-*` / control topic) plus opaque payload bytes. We map:
+//!
+//! ```text
+//!   topic-string  ->  moq Broadcast path  {tenant}/{service}/{topic}/{instance}
+//!   StreamBlock   ->  one moq Group (sequence = block index)
+//!                       containing one Frame = capnp_bytes || mac[16]
+//! ```
+//!
+//! For the in-process / direct path (M2a), the broadcast path is built from a
+//! caller-supplied `{tenant}/{service}/.../{instance}` prefix joined with the
+//! opaque topic. The topic itself stays opaque (and, for the relay'd path in
+//! M2b, DH-derived/unguessable). A single track name (`STREAM_TRACK`) carries
+//! the block sequence.
+//!
+//! # §7.5 chained-HMAC tokenstream
+//!
+//! The chained-HMAC envelope is preserved 1:1: each Group's Frame payload is
+//! the same `[capnp StreamBlock || 16-byte truncated MAC]` that the ZMQ wire
+//! format carried in frames 1+2 (frame 0, the topic, is now the Track/Broadcast
+//! path and is therefore dropped from the payload). [`StreamHmacState`] /
+//! [`StreamVerifier`] are reused unchanged, so the MAC chain — which binds each
+//! block to its predecessor — is byte-identical to the ZMQ path.
+//!
+//! Late-join is now moq's job: a subscriber that joins late is served the
+//! latest Group natively by the moq Track cache (respecting upstream Group
+//! cache consts), so the custom `StreamResume` / rejoin-buffer code is gone.
+
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+use bytes::Bytes;
+use moq_net::{BroadcastProducer, Group, OriginConsumer, OriginProducer, Track, TrackProducer};
+use parking_lot::Mutex;
+use tokio_util::sync::CancellationToken;
+
+use crate::crypto::StreamHmacState;
+use crate::streaming::{StreamContext, StreamPayloadData, StreamVerifier};
+
+/// The single track name that carries StreamBlock groups for a broadcast.
+pub const STREAM_TRACK: &str = "stream";
+
+/// Default `{tenant}/{service}` broadcast-path prefix for the in-process plane.
+///
+/// The instance segment is appended per-publisher (the opaque topic). Callers
+/// that want tenant isolation pass their own prefix to
+/// [`MoqStreamOrigin::with_prefix`].
+pub const DEFAULT_PREFIX: &str = "local/streams";
+
+/// Shared moq origin for the streaming plane, plus the in-process publish gate.
+///
+/// Holds the `OriginProducer` (what in-process publishers append into) and the
+/// `OriginConsumer` (handed to `moq_net::Server` to serve external subscribers).
+/// This is the moq replacement for [`crate::service::StreamService`]'s ZMQ
+/// proxy: there is no forwarding loop — producers and consumers share one tree.
+#[derive(Clone)]
+pub struct MoqStreamOrigin {
+    inner: Arc<OriginInner>,
+}
+
+/// Builder for [`MoqStreamOrigin`] — set the prefix and publish gate before the
+/// shared `Arc` is constructed (avoids clone-on-write of the origin tree).
+pub struct MoqStreamOriginBuilder {
+    producer: OriginProducer,
+    consumer: OriginConsumer,
+    prefix: String,
+    authorize_signer: Option<Arc<dyn Fn(&[u8; 32]) -> bool + Send + Sync>>,
+}
+
+impl MoqStreamOriginBuilder {
+    /// Set the `{tenant}/{service}` broadcast-path prefix.
+    pub fn with_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.prefix = prefix.into();
+        self
+    }
+
+    /// Install the in-process publish gate (mirrors
+    /// `StreamService::with_authorize_signer`).
+    pub fn with_authorize_signer(
+        mut self,
+        f: impl Fn(&[u8; 32]) -> bool + Send + Sync + 'static,
+    ) -> Self {
+        self.authorize_signer = Some(Arc::new(f));
+        self
+    }
+
+    /// Finish building.
+    pub fn build(self) -> MoqStreamOrigin {
+        MoqStreamOrigin {
+            inner: Arc::new(OriginInner {
+                producer: self.producer,
+                consumer: self.consumer,
+                prefix: self.prefix,
+                authorize_signer: self.authorize_signer,
+                broadcasts: Mutex::new(Vec::new()),
+            }),
+        }
+    }
+}
+
+struct OriginInner {
+    producer: OriginProducer,
+    consumer: OriginConsumer,
+    /// `{tenant}/{service}` prefix for broadcast paths.
+    prefix: String,
+    /// Optional in-process publish gate (mirrors `StreamService::authorize_signer`).
+    ///
+    /// When set, [`MoqStreamOrigin::authorize_signer`] must return `true` before
+    /// a publisher is created for a topic. `None` accepts any caller
+    /// (testing/bootstrap), matching the ZMQ default.
+    authorize_signer: Option<Arc<dyn Fn(&[u8; 32]) -> bool + Send + Sync>>,
+    /// Keep broadcast producers alive for the lifetime of their publishers.
+    broadcasts: Mutex<Vec<BroadcastProducer>>,
+}
+
+impl MoqStreamOrigin {
+    /// Begin building from an existing producer/consumer pair (e.g. the one
+    /// held by [`crate::transport::iroh_moq::IrohMoqProtocolHandler`]).
+    pub fn builder(producer: OriginProducer, consumer: OriginConsumer) -> MoqStreamOriginBuilder {
+        MoqStreamOriginBuilder {
+            producer,
+            consumer,
+            prefix: DEFAULT_PREFIX.to_owned(),
+            authorize_signer: None,
+        }
+    }
+
+    /// Build directly from a producer/consumer pair with defaults.
+    pub fn from_pair(producer: OriginProducer, consumer: OriginConsumer) -> Self {
+        Self::builder(producer, consumer).build()
+    }
+
+    /// Begin building a standalone origin with a fresh random id.
+    ///
+    /// Used when no shared substrate origin is available yet (M2a bootstrap).
+    /// Callers that have the substrate's `IrohMoqProtocolHandler` should use
+    /// [`Self::builder`] with its `origin_producer()` / `origin_consumer()`
+    /// instead, so external subscribers see the same tree.
+    pub fn standalone() -> MoqStreamOriginBuilder {
+        let producer = moq_net::Origin::random().produce();
+        let consumer = producer.consume();
+        Self::builder(producer, consumer)
+    }
+
+    /// Borrow the consumer (hand this to `moq_net::Server::with_publish`).
+    pub fn consumer(&self) -> &OriginConsumer {
+        &self.inner.consumer
+    }
+
+    /// Borrow the producer.
+    pub fn producer(&self) -> &OriginProducer {
+        &self.inner.producer
+    }
+
+    /// Check the in-process publish gate for a signer pubkey.
+    ///
+    /// Returns `true` when no gate is installed (bootstrap/testing).
+    pub fn authorize_signer(&self, signer: &[u8; 32]) -> bool {
+        match &self.inner.authorize_signer {
+            Some(f) => f(signer),
+            None => true,
+        }
+    }
+
+    /// Build the broadcast path for an opaque topic: `{prefix}/{topic}`.
+    pub fn broadcast_path(&self, topic: &str) -> String {
+        format!("{}/{}", self.inner.prefix, topic)
+    }
+
+    /// Create an in-process publisher for `ctx`'s topic.
+    ///
+    /// Creates (or replaces) the broadcast at `{prefix}/{topic}` with a single
+    /// [`STREAM_TRACK`] track, and returns a [`MoqStreamPublisher`] whose
+    /// chained-HMAC state is seeded from `ctx.mac_key()` / `ctx.topic()` — i.e.
+    /// byte-identical to the ZMQ `StreamBuilder`.
+    pub fn publisher(&self, ctx: &StreamContext) -> Result<MoqStreamPublisher> {
+        let path = self.broadcast_path(ctx.topic());
+        let mut broadcast = self
+            .inner
+            .producer
+            .create_broadcast(path.as_str())
+            .ok_or_else(|| anyhow!("create_broadcast denied for {path}"))?;
+        let track = broadcast.create_track(Track::new(STREAM_TRACK))?;
+
+        // Retain the broadcast producer so it stays announced for the
+        // publisher's lifetime (dropping it would unannounce the broadcast).
+        self.inner.broadcasts.lock().push(broadcast);
+
+        Ok(MoqStreamPublisher {
+            hmac_state: StreamHmacState::new(*ctx.mac_key(), ctx.topic().to_owned()),
+            track,
+            next_group: 0,
+            cancel_token: ctx.cancel_token().clone(),
+            terminated: false,
+            topic: ctx.topic().to_owned(),
+        })
+    }
+}
+
+/// In-process moq publisher with the §7.5 chained-HMAC tokenstream.
+///
+/// API mirrors [`crate::streaming::StreamPublisher`] (`publish_data`,
+/// `publish_error`, `complete`, ...) but appends to a moq Track instead of a
+/// ZMQ PUSH socket. Each call produces one StreamBlock = one moq Group whose
+/// single Frame payload is `capnp_bytes || mac[16]`.
+/// NOTE (M2a vs M2b): the StreamBlock *encoding* + HMAC chain are byte-identical
+/// to the ZMQ path (shared `encode_stream_block`), but the *batching policy*
+/// differs — this emits one payload per block/Group, whereas the ZMQ
+/// `StreamBuilder` adaptively batches multiple payloads per block. The MAC
+/// chain is valid either way (the verifier is batch-agnostic). Port
+/// `BatchingConfig` in M2b for granularity parity.
+pub struct MoqStreamPublisher {
+    hmac_state: StreamHmacState,
+    track: TrackProducer,
+    next_group: u64,
+    cancel_token: CancellationToken,
+    terminated: bool,
+    topic: String,
+}
+
+impl MoqStreamPublisher {
+    /// Publish one binary payload as a StreamBlock group.
+    pub async fn publish_data(&mut self, data: &[u8]) -> Result<()> {
+        if self.cancel_token.is_cancelled() {
+            anyhow::bail!("stream cancelled");
+        }
+        self.write_block(&[StreamPayloadData::Data(data.to_vec())])
+    }
+
+    /// Publish an error payload (terminal).
+    pub async fn publish_error(&mut self, message: &str) -> Result<()> {
+        self.terminated = true;
+        self.write_block(&[StreamPayloadData::Error(message.to_owned())])
+    }
+
+    /// Complete the stream with metadata (terminal).
+    pub async fn complete(mut self, metadata: &[u8]) -> Result<()> {
+        self.complete_ref(metadata).await
+    }
+
+    /// Complete the stream without consuming `self`.
+    pub async fn complete_ref(&mut self, metadata: &[u8]) -> Result<()> {
+        self.terminated = true;
+        self.write_block(&[StreamPayloadData::Complete(metadata.to_vec())])
+    }
+
+    /// The opaque topic this publisher serves.
+    pub fn topic(&self) -> &str {
+        &self.topic
+    }
+
+    /// Whether a terminal frame (Error/Complete) was sent.
+    pub fn is_terminated(&self) -> bool {
+        self.terminated
+    }
+
+    /// Whether the stream has been cancelled.
+    pub fn is_cancelled(&self) -> bool {
+        self.cancel_token.is_cancelled()
+    }
+
+    /// Serialize payloads into a StreamBlock, chain the MAC, and append as a
+    /// moq Group (one Frame = `capnp || mac`).
+    fn write_block(&mut self, payloads: &[StreamPayloadData]) -> Result<()> {
+        let capnp_bytes = crate::streaming::encode_stream_block(
+            self.hmac_state.prev_mac_bytes(),
+            payloads,
+        )?;
+        let mac = self.hmac_state.compute_next(&capnp_bytes);
+
+        let mut frame = Vec::with_capacity(capnp_bytes.len() + 16);
+        frame.extend_from_slice(&capnp_bytes);
+        frame.extend_from_slice(&mac);
+
+        let seq = self.next_group;
+        self.next_group += 1;
+        let mut group = self.track.create_group(Group::from(seq))?;
+        group.write_frame(Bytes::from(frame))?;
+        group.finish()?;
+        Ok(())
+    }
+}
+
+/// Consumer-side helper: split a moq Frame payload back into the ZMQ-style
+/// `[topic, capnp, mac]` frames expected by [`StreamVerifier::verify`], then
+/// verify and parse it.
+///
+/// `topic` is the opaque topic (not the broadcast path) and must match the
+/// verifier's topic, exactly as the ZMQ frame-0 contract required.
+pub fn verify_moq_frame(
+    verifier: &mut StreamVerifier,
+    topic: &str,
+    frame: &[u8],
+) -> Result<Vec<crate::streaming::StreamPayload>> {
+    if frame.len() < 16 {
+        anyhow::bail!("moq frame too short: {} bytes", frame.len());
+    }
+    let split = frame.len() - 16;
+    let capnp = frame[..split].to_vec();
+    let mac = frame[split..].to_vec();
+    verifier.verify(&[topic.as_bytes().to_vec(), capnp, mac])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::streaming::StreamPayload;
+    use moq_net::Origin;
+
+    fn origin() -> MoqStreamOrigin {
+        let producer = Origin::random().produce();
+        let consumer = producer.consume();
+        MoqStreamOrigin::from_pair(producer, consumer)
+    }
+
+    /// In-process publish → in-process consume over the *same* origin (the data
+    /// an external moq subscriber sees on the wire), verifying the chained-HMAC.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn moq_stream_round_trip() -> Result<()> {
+        let origin = origin();
+        let (_client_secret, client_pub) = crate::crypto::generate_ephemeral_keypair();
+        let ctx = StreamContext::from_dh(&client_pub.to_bytes())?;
+        let topic = ctx.topic().to_owned();
+        let mac_key = *ctx.mac_key();
+
+        let mut pub_ = origin.publisher(&ctx)?;
+        pub_.publish_data(b"hello").await?;
+        pub_.publish_data(b"world").await?;
+        pub_.complete_ref(b"{}").await?;
+
+        // Consume from the shared origin (same bytes a wire subscriber reads).
+        let path = origin.broadcast_path(&topic);
+        let bc = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            origin.consumer().announced_broadcast(path.as_str()),
+        )
+        .await?
+        .ok_or_else(|| anyhow!("broadcast not announced"))?;
+        let mut track = bc.subscribe_track(&Track::new(STREAM_TRACK))?;
+
+        let mut verifier = StreamVerifier::new(mac_key, topic.clone());
+        let mut got: Vec<StreamPayload> = Vec::new();
+        for _ in 0..3 {
+            let mut group = tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                track.next_group(),
+            )
+            .await??
+            .ok_or_else(|| anyhow!("next_group None"))?;
+            let frame = tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                group.read_frame(),
+            )
+            .await??
+            .ok_or_else(|| anyhow!("read_frame None"))?;
+            got.extend(verify_moq_frame(&mut verifier, &topic, &frame)?);
+        }
+
+        assert!(matches!(&got[0], StreamPayload::Data(d) if d == b"hello"));
+        assert!(matches!(&got[1], StreamPayload::Data(d) if d == b"world"));
+        assert!(matches!(&got[2], StreamPayload::Complete(_)));
+        Ok(())
+    }
+
+    #[test]
+    fn authorize_signer_gate() {
+        let producer = Origin::random().produce();
+        let consumer = producer.consume();
+        let gated = MoqStreamOrigin::builder(producer, consumer)
+            .with_authorize_signer(|pk| pk[0] == 1)
+            .build();
+        assert!(gated.authorize_signer(&[1u8; 32]));
+        assert!(!gated.authorize_signer(&[2u8; 32]));
+        // No gate -> accept all.
+        assert!(origin().authorize_signer(&[9u8; 32]));
+    }
+}

--- a/crates/hyprstream-rpc/src/registry/mod.rs
+++ b/crates/hyprstream-rpc/src/registry/mod.rs
@@ -254,7 +254,12 @@ impl EndpointRegistry {
 
     /// Generate a default endpoint for a service and socket type.
     fn default_endpoint(&self, name: &str, socket_kind: SocketKind) -> TransportConfig {
-        // QUIC endpoints are always TCP-based, independent of ZMQ endpoint mode
+        // QUIC endpoints are always TCP-based, independent of ZMQ endpoint mode.
+        // This is a non-dialable PLACEHOLDER (port 0), returned only when a
+        // service has no real registration; a genuine QUIC endpoint is
+        // registered by the serving loop *pinned* with its cert hash (see
+        // QuicServiceLoop::registrations and the unified loop's QUIC
+        // registration). The WebPki policy here is moot — :0 can't be connected.
         if socket_kind == SocketKind::Quic {
             return TransportConfig::quic(
                 std::net::SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), 0),

--- a/crates/hyprstream-rpc/src/rpc_client.rs
+++ b/crates/hyprstream-rpc/src/rpc_client.rs
@@ -291,19 +291,55 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
         }
 
         let canonical = envelope.to_bytes();
+        let ed_pubkey = self.signer.pubkey();
+
+        // Raw EdDSA signature (sig/cnf) retained for signer-pubkey advertisement
+        // + the JWT cnf key-binding path.
         let signature = self.signer.sign(&canonical).await?;
 
-        let pq_sig = self.signer.pq_sign(&canonical).await?;
-        let pq_cnf = self.signer.pq_pubkey();
+        // Build the COSE composite (M3 #152) by signing each entry's
+        // Sig_structure out-of-band via the (possibly async/WASM) Signer.
+        let aad = crate::crypto::cose_sign1::build_external_aad(
+            crate::envelope::ENVELOPE_SCHEMA_ID,
+            crate::envelope::REQUEST_ENVELOPE_TYPE_ID,
+        );
+        // Nested SNS composite: sign the inner EdDSA layer first, then sign the
+        // outer ML-DSA-65 layer over `canonical ‖ inner_eddsa_signature` so the
+        // inner signature is bound into the outer (Strong-Non-Separable).
+        let ed_kid = ed_pubkey.to_vec();
+        let ed_tbs = crate::crypto::cose_sign::inner_tbs(ed_kid.clone(), &canonical, &aad);
+        let ed_sig = self.signer.sign(&ed_tbs).await?.to_vec();
+
+        // Hybrid component when the signer exposes an ML-DSA-65 key.
+        let pq_entry = if let Some(pq_kid) = self.signer.pq_pubkey() {
+            let pq_tbs = crate::crypto::cose_sign::outer_tbs(
+                pq_kid.clone(),
+                &canonical,
+                &ed_sig,
+                &aad,
+            );
+            self.signer
+                .pq_sign(&pq_tbs)
+                .await?
+                .map(|pq_sig| (pq_kid, pq_sig))
+        } else {
+            None
+        };
+        let policy = if pq_entry.is_some() {
+            crate::crypto::CryptoPolicy::Hybrid
+        } else {
+            crate::crypto::CryptoPolicy::Classical
+        };
+        let cose = crate::crypto::cose_sign::assemble_composite_nested((ed_kid, ed_sig), pq_entry)?;
 
         let signed = SignedEnvelope {
             envelope,
             sig: signature,
-            cnf: self.signer.pubkey(),
+            cnf: ed_pubkey,
             encrypted_envelope: None,
             client_ephemeral_public: None,
-            pq_sig,
-            pq_cnf,
+            cose,
+            policy,
             pq_kem_ciphertext: None,
         };
 

--- a/crates/hyprstream-rpc/src/service/dispatch.rs
+++ b/crates/hyprstream-rpc/src/service/dispatch.rs
@@ -36,9 +36,22 @@ pub use crate::envelope::EnvelopeVerification;
 /// 3. Dispatch to `service.handle_request()` with a verified `EnvelopeContext`.
 /// 4. Sign the response with the server's `signing_key`.
 ///
+/// # Streaming
+///
+/// A streaming handler returns a `Continuation` (the server-side streaming
+/// response that runs after the reply). As of #186 that task is spawned
+/// **here**, via [`crate::streaming::spawn_streaming_response`], rather than
+/// handed back to the transport front-end — so every front-end (ZMQ
+/// `RequestLoop`, WebTransport server, generic-plane `LocalServiceBridge`) is
+/// uniform "bytes in → bytes out" and the generic plane no longer has to spawn
+/// (or, worse, reject) continuations itself. **Invariant:** `process_request`
+/// must therefore run on a `tokio::task::LocalSet` (it already did —
+/// `RequestService` is `?Send`); the spawned task is `?Send`.
+///
 /// # Returns
 ///
-/// * `Ok((response_bytes, continuation))` - Signed response and optional continuation
+/// * `Ok(response_bytes)` - Signed response. Any streaming pump has already been
+///   spawned onto the current `LocalSet`.
 /// * `Err(e)` - Processing error (already logged)
 pub async fn process_request<S>(
     raw_bytes: &[u8],
@@ -46,7 +59,7 @@ pub async fn process_request<S>(
     verification: EnvelopeVerification<'_>,
     signing_key: &ed25519_dalek::SigningKey,
     nonce_cache: &crate::envelope::InMemoryNonceCache,
-) -> Result<(Vec<u8>, Option<crate::service::Continuation>)>
+) -> Result<Vec<u8>>
 where
     S: crate::service::RequestService,
 {
@@ -79,7 +92,7 @@ where
 
             let mut bytes = Vec::new();
             serialize::write_message(&mut bytes, &message)?;
-            return Ok((bytes, None));
+            return Ok(bytes);
         }
     };
 
@@ -106,7 +119,7 @@ where
 
         let mut bytes = Vec::new();
         serialize::write_message(&mut bytes, &message)?;
-        return Ok((bytes, None));
+        return Ok(bytes);
     }
 
     // 3. Handle request
@@ -128,5 +141,13 @@ where
     let mut bytes = Vec::new();
     serialize::write_message(&mut bytes, &message)?;
 
-    Ok((bytes, continuation))
+    // 5. Spawn the server-side streaming response (if any) onto the current
+    //    LocalSet, so the reply is all the transport front-end has to deal with
+    //    (#186). Bounded by a per-service admission permit; see
+    //    spawn_streaming_response.
+    if let Some(cont) = continuation {
+        crate::streaming::spawn_streaming_response(service.name(), cont);
+    }
+
+    Ok(bytes)
 }

--- a/crates/hyprstream-rpc/src/service/dispatch.rs
+++ b/crates/hyprstream-rpc/src/service/dispatch.rs
@@ -1,0 +1,132 @@
+//! Transport-neutral request dispatch core (#148).
+//!
+//! `process_request` is the single envelope-verify → JWT/DPoP → Casbin →
+//! `handle_request` → signed-response pipeline shared by every front-end:
+//! the ZMQ `RequestLoop`, the WebTransport server, and the generic RPC plane's
+//! `LocalServiceBridge`. It contains no transport-specific code (no ZMQ, no
+//! quinn) — extracted out of `transport/zmtp_quic.rs` so the ZMQ-specific
+//! remainder of that file can be deleted in #138 without touching this.
+
+use anyhow::Result;
+use tracing::{debug, error, warn};
+
+/// Envelope signer verification mode (re-exported from `crate::envelope`).
+///
+/// - **FixedSigner**: internal service-to-service — envelope signer must match
+///   a known `server_pubkey` for mutual authentication. Peers pre-share keys.
+/// - **AnySigner**: external clients (e.g. browser over WebTransport) — any
+///   valid signer accepted; transport TLS provides peer authentication.
+pub use crate::envelope::EnvelopeVerification;
+
+/// Process a request through the full envelope verification pipeline.
+///
+/// Unified handler for all transport front-ends. The only difference between
+/// them is envelope signer verification, controlled by `verification`.
+///
+/// # Pipeline
+///
+/// 1. Unwrap `SignedEnvelope` and verify the signature (mode-dependent), under
+///    the process-global verify policy + kid-anchored PQ trust store.
+/// 2. Verify JWT claims (`sub`, `exp`, `aud`, `scope`, downgrade protection).
+/// 3. Dispatch to `service.handle_request()` with a verified `EnvelopeContext`.
+/// 4. Sign the response with the server's `signing_key`.
+///
+/// # Returns
+///
+/// * `Ok((response_bytes, continuation))` - Signed response and optional continuation
+/// * `Err(e)` - Processing error (already logged)
+pub async fn process_request<S>(
+    raw_bytes: &[u8],
+    service: &S,
+    verification: EnvelopeVerification<'_>,
+    signing_key: &ed25519_dalek::SigningKey,
+    nonce_cache: &crate::envelope::InMemoryNonceCache,
+) -> Result<(Vec<u8>, Option<crate::service::Continuation>)>
+where
+    S: crate::service::RequestService,
+{
+    use crate::ToCapnp;
+    use crate::envelope::ResponseEnvelope;
+    use capnp::message::Builder;
+    use capnp::serialize;
+
+    // 1. Unwrap, verify, and optionally decrypt the SignedEnvelope.
+    //    The verify policy + kid-anchored PQ trust store come from the
+    //    process-global verify configuration installed at startup (Hybrid
+    //    ENFORCED in the daemon). This closes the prior fail-open where the
+    //    site hardcoded Classical / no PQ store.
+    let pq_store_holder = crate::envelope::global_pq_store();
+    let base = match verification {
+        EnvelopeVerification::FixedSigner(pubkey) =>
+            crate::envelope::UnwrapOptions::fixed_signer(pubkey, nonce_cache),
+        EnvelopeVerification::AnySigner =>
+            crate::envelope::UnwrapOptions::any_signer(nonce_cache),
+    }.with_decryption_key(signing_key);
+    let opts =
+        crate::envelope::apply_global_verify_config(base, &pq_store_holder);
+
+    let (mut ctx, payload) = match crate::envelope::unwrap_envelope(raw_bytes, &opts) {
+        Ok(result) => result,
+        Err(e) => {
+            warn!("{} envelope verification failed: {}", service.name(), e);
+            // Build error response with request_id=0 (envelope is invalid)
+            let error_payload = service.build_error_payload(0, &format!("envelope verification failed: {}", e));
+            let signed_response = ResponseEnvelope::new_signed(0, error_payload, signing_key);
+
+            let mut message = Builder::new_default();
+            let mut builder = message.init_root::<crate::common_capnp::response_envelope::Builder>();
+            signed_response.write_to(&mut builder);
+
+            let mut bytes = Vec::new();
+            serialize::write_message(&mut bytes, &message)?;
+            return Ok((bytes, None));
+        }
+    };
+
+    let request_id = ctx.request_id;
+    debug!(
+        "{} verified request from {} (id={})",
+        service.name(),
+        ctx.subject(),
+        request_id
+    );
+
+    // 2. Verify claims (E2E JWT, downgrade protection)
+    if let Err(e) = service.verify_claims(&mut ctx).await {
+        warn!(
+            "{} claims verification failed for {} (id={}): {}",
+            service.name(), ctx.subject(), request_id, e
+        );
+        let error_payload = service.build_error_payload(request_id, &e.to_string());
+        let signed_response = ResponseEnvelope::new_signed(request_id, error_payload, signing_key);
+
+        let mut message = Builder::new_default();
+        let mut builder = message.init_root::<crate::common_capnp::response_envelope::Builder>();
+        signed_response.write_to(&mut builder);
+
+        let mut bytes = Vec::new();
+        serialize::write_message(&mut bytes, &message)?;
+        return Ok((bytes, None));
+    }
+
+    // 3. Handle request
+    let (response_payload, continuation) = match service.handle_request(&ctx, &payload).await {
+        Ok((resp, cont)) => (resp, cont),
+        Err(e) => {
+            error!("{} request handling error: {}", service.name(), e);
+            (service.build_error_payload(request_id, &e.to_string()), None)
+        }
+    };
+
+    // 4. Sign and serialize response
+    let signed_response = ResponseEnvelope::new_signed(request_id, response_payload, signing_key);
+
+    let mut message = Builder::new_default();
+    let mut builder = message.init_root::<crate::common_capnp::response_envelope::Builder>();
+    signed_response.write_to(&mut builder);
+
+    let mut bytes = Vec::new();
+    serialize::write_message(&mut bytes, &message)?;
+
+    Ok((bytes, continuation))
+}

--- a/crates/hyprstream-rpc/src/service/dispatch.rs
+++ b/crates/hyprstream-rpc/src/service/dispatch.rs
@@ -8,7 +8,12 @@
 //! remainder of that file can be deleted in #138 without touching this.
 
 use anyhow::Result;
+use capnp::message::Builder;
+use capnp::serialize;
 use tracing::{debug, error, warn};
+
+use crate::envelope::ResponseEnvelope;
+use crate::ToCapnp;
 
 /// Envelope signer verification mode (re-exported from `crate::envelope`).
 ///
@@ -45,11 +50,6 @@ pub async fn process_request<S>(
 where
     S: crate::service::RequestService,
 {
-    use crate::ToCapnp;
-    use crate::envelope::ResponseEnvelope;
-    use capnp::message::Builder;
-    use capnp::serialize;
-
     // 1. Unwrap, verify, and optionally decrypt the SignedEnvelope.
     //    The verify policy + kid-anchored PQ trust store come from the
     //    process-global verify configuration installed at startup (Hybrid

--- a/crates/hyprstream-rpc/src/service/mod.rs
+++ b/crates/hyprstream-rpc/src/service/mod.rs
@@ -1,7 +1,7 @@
 //! Service-side RPC infrastructure.
 //!
 //! This module provides:
-//! - `ZmqService`, `RequestLoop`, `ZmqClient` - ZMQ REQ/REP service infrastructure
+//! - `RequestService`, `RequestLoop`, `ZmqClient` - ZMQ REQ/REP service infrastructure
 //! - `EnvelopeContext` - Verified request context passed to handlers
 //! - `ServiceHandle` - Handle for managing running services
 //! - `RpcService`, `RpcHandler` - Lower-level RPC traits
@@ -18,7 +18,12 @@ pub mod doc;
 
 pub use traits::{RpcHandler, RpcRequest, RpcService};
 #[allow(deprecated)]
-pub use zmq::{AuthorizeFn, Continuation, EnvelopeContext, QuicLoopConfig, ServiceHandle, RequestLoop, UnifiedRequestLoop, ZmqService};
+pub use zmq::{AuthorizeFn, Continuation, EnvelopeContext, QuicLoopConfig, ServiceHandle, RequestLoop, UnifiedRequestLoop, RequestService};
+/// Transitional compatibility alias for the former `ZmqService` name (#166).
+/// Lets stacked epic branches rebase onto this rename without simultaneous
+/// edits; removed in #138 when ZMQ is torn down.
+#[doc(hidden)]
+pub use zmq::RequestService as ZmqService;
 pub use streaming::StreamService;
 pub use spawnable::Spawnable;
 pub use metadata::{MethodMeta, ParamMeta, SchemaMetadataFn, ScopedSchemaMetadataFn, ScopedClientTreeNode};

--- a/crates/hyprstream-rpc/src/service/mod.rs
+++ b/crates/hyprstream-rpc/src/service/mod.rs
@@ -11,12 +11,15 @@
 
 mod traits;
 mod zmq;
+pub mod dispatch;
 pub mod streaming;
 pub mod spawnable;
 pub mod metadata;
 pub mod doc;
 
 pub use traits::{RpcHandler, RpcRequest, RpcService};
+/// Transport-neutral request dispatch core (#148) — shared by all front-ends.
+pub use dispatch::process_request;
 #[allow(deprecated)]
 pub use zmq::{AuthorizeFn, Continuation, EnvelopeContext, QuicLoopConfig, ServiceHandle, RequestLoop, UnifiedRequestLoop, RequestService};
 /// Transitional compatibility alias for the former `ZmqService` name (#166).

--- a/crates/hyprstream-rpc/src/service/mod.rs
+++ b/crates/hyprstream-rpc/src/service/mod.rs
@@ -13,6 +13,7 @@ mod traits;
 mod zmq;
 pub mod dispatch;
 pub mod streaming;
+pub mod serve;
 pub mod spawnable;
 pub mod metadata;
 pub mod doc;

--- a/crates/hyprstream-rpc/src/service/serve.rs
+++ b/crates/hyprstream-rpc/src/service/serve.rs
@@ -1,0 +1,110 @@
+//! Bridged serve helper for the post-ZMQ spawn path (#136).
+//!
+//! The RPC cutover replaces every `RequestLoop::new(..).run(service)` (ZMQ
+//! ROUTER) with this: bridge the service to a `Send` processor
+//! ([`LocalServiceBridge`](crate::transport::iroh_rpc::LocalServiceBridge)), then
+//! serve it over its *registered* transport via the same `process_request`
+//! dispatch core the quinn/iroh planes use.
+//!
+//! Spawn-path transports (from `EndpointRegistry::endpoint(name, Rep)`):
+//! - `Inproc{endpoint}` (default daemon mode) → register the processor in the
+//!   in-memory dial registry ([`register_inproc`](crate::dial::register_inproc));
+//!   **no socket**. The registry holds only a `Weak`, so the strong `processor`
+//!   `Arc` is retained here for the service's lifetime.
+//! - `Ipc{path}` (`--ipc`) → bind a `UnixListener` at `path`, run
+//!   [`UdsRpcServer`].
+//! - `SystemdFd{fd,..}` → adopt the systemd-passed listener fd, run [`UdsRpcServer`].
+//! - `Quic`/`Iroh` are *dialed*, never bound on the spawn path → error.
+
+use std::sync::Arc;
+
+use anyhow::{anyhow, bail, Result};
+use ed25519_dalek::SigningKey;
+use tokio::sync::Notify;
+
+use crate::transport::rpc_session::{IrohRequestProcessor, DEFAULT_STREAM_LIMIT};
+use crate::transport::uds_server::UdsRpcServer;
+use crate::transport::{EndpointType, TransportConfig};
+
+/// Signal startup readiness: fire the `on_ready` oneshot (spawner waits on it)
+/// and notify systemd (`Type=notify`).
+fn signal_ready(on_ready: Option<tokio::sync::oneshot::Sender<()>>) {
+    if let Some(tx) = on_ready {
+        let _ = tx.send(());
+    }
+    let _ = crate::notify::ready();
+}
+
+/// Serve a bridged request `processor` over its registered `transport` until
+/// `shutdown` fires. See the module docs for the per-transport behaviour.
+///
+/// `processor` MUST be the bridge wrapping the spawn-path service (built via
+/// [`LocalServiceBridge::spawn`](crate::transport::iroh_rpc::LocalServiceBridge::spawn)
+/// or `spawn_with`). This fn holds it for the serve lifetime.
+pub async fn serve_bridged(
+    transport: &TransportConfig,
+    processor: Arc<dyn IrohRequestProcessor>,
+    signing_key: SigningKey,
+    shutdown: Arc<Notify>,
+    on_ready: Option<tokio::sync::oneshot::Sender<()>>,
+) -> Result<()> {
+    match &transport.endpoint {
+        EndpointType::Inproc { endpoint } => {
+            crate::dial::register_inproc(endpoint.clone(), &processor);
+            signal_ready(on_ready);
+            shutdown.notified().await;
+            crate::dial::unregister_inproc(endpoint);
+            // Drop the strong Arc → bridge thread exits its receive loop.
+            drop(processor);
+            Ok(())
+        }
+        EndpointType::Ipc { path } => {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)
+                    .map_err(|e| anyhow!("create uds dir {}: {e}", parent.display()))?;
+            }
+            // Clear a stale socket left by a prior unclean shutdown.
+            let _ = std::fs::remove_file(path);
+            let listener = tokio::net::UnixListener::bind(path)
+                .map_err(|e| anyhow!("bind uds {}: {e}", path.display()))?;
+            signal_ready(on_ready);
+            run_uds(listener, processor, signing_key, shutdown).await
+        }
+        EndpointType::SystemdFd { fd, .. } => {
+            use std::os::unix::io::FromRawFd;
+            // The fd is the systemd-passed, already-bound server listener.
+            let std_listener = unsafe { std::os::unix::net::UnixListener::from_raw_fd(*fd) };
+            std_listener
+                .set_nonblocking(true)
+                .map_err(|e| anyhow!("systemd fd set_nonblocking: {e}"))?;
+            let listener = tokio::net::UnixListener::from_std(std_listener)
+                .map_err(|e| anyhow!("adopt systemd uds fd: {e}"))?;
+            signal_ready(on_ready);
+            run_uds(listener, processor, signing_key, shutdown).await
+        }
+        other => bail!(
+            "serve_bridged: {other:?} is not a spawn-path RPC endpoint \
+             (Quic/Iroh are dialed via dial(), not bound here)"
+        ),
+    }
+}
+
+/// Run a [`UdsRpcServer`] until it ends or `shutdown` fires (graceful drain).
+async fn run_uds(
+    listener: tokio::net::UnixListener,
+    processor: Arc<dyn IrohRequestProcessor>,
+    signing_key: SigningKey,
+    shutdown: Arc<Notify>,
+) -> Result<()> {
+    let server = UdsRpcServer::with_capacity(listener, processor, signing_key, DEFAULT_STREAM_LIMIT);
+    let token = server.shutdown_token();
+    let limit = server.stream_limit();
+    let cap = server.capacity();
+    tokio::select! {
+        r = server.run() => r,
+        _ = shutdown.notified() => {
+            UdsRpcServer::shutdown(&limit, cap, &token).await;
+            Ok(())
+        }
+    }
+}

--- a/crates/hyprstream-rpc/src/service/spawnable.rs
+++ b/crates/hyprstream-rpc/src/service/spawnable.rs
@@ -9,7 +9,7 @@ use tokio::sync::Notify;
 
 use crate::error::{Result, RpcError};
 use crate::registry::SocketKind;
-use crate::service::{RequestLoop, ZmqService};
+use crate::service::{RequestLoop, RequestService};
 use crate::transport::TransportConfig;
 
 /// Trait for services that can be spawned by ServiceSpawner.
@@ -46,28 +46,28 @@ pub trait Spawnable: Send + 'static {
 }
 
 // ============================================================================
-// Blanket Spawnable impl for ZmqService
+// Blanket Spawnable impl for RequestService
 // ============================================================================
 
-/// Every `ZmqService + Send + Sync` is automatically `Spawnable`.
+/// Every `RequestService + Send + Sync` is automatically `Spawnable`.
 ///
 /// This blanket implementation eliminates the need for wrapper types.
-/// Services that implement `ZmqService` include their infrastructure
+/// Services that implement `RequestService` include their infrastructure
 /// (context, transport, verifying_key) and can be spawned directly.
 ///
 /// Services not satisfying `Send + Sync` (e.g., those using `Rc` or `!Send` fields)
 /// must implement `Spawnable` directly (as `InferenceServiceConfig` does).
-impl<S: ZmqService + Send + Sync> Spawnable for S {
+impl<S: RequestService + Send + Sync> Spawnable for S {
     fn name(&self) -> &str {
-        ZmqService::name(self)
+        RequestService::name(self)
     }
 
     fn context(&self) -> &Arc<zmq::Context> {
-        ZmqService::context(self)
+        RequestService::context(self)
     }
 
     fn registrations(&self) -> Vec<(SocketKind, TransportConfig)> {
-        vec![(SocketKind::Rep, ZmqService::transport(self).clone())]
+        vec![(SocketKind::Rep, RequestService::transport(self).clone())]
     }
 
     fn run(
@@ -75,9 +75,9 @@ impl<S: ZmqService + Send + Sync> Spawnable for S {
         shutdown: Arc<Notify>,
         on_ready: Option<tokio::sync::oneshot::Sender<()>>,
     ) -> Result<()> {
-        let transport = ZmqService::transport(&*self).clone();
-        let context = Arc::clone(ZmqService::context(&*self));
-        let signing_key = ZmqService::signing_key(&*self);
+        let transport = RequestService::transport(&*self).clone();
+        let context = Arc::clone(RequestService::context(&*self));
+        let signing_key = RequestService::signing_key(&*self);
 
         let rt = tokio::runtime::Builder::new_multi_thread()
             .enable_all()

--- a/crates/hyprstream-rpc/src/service/spawnable.rs
+++ b/crates/hyprstream-rpc/src/service/spawnable.rs
@@ -9,7 +9,7 @@ use tokio::sync::Notify;
 
 use crate::error::{Result, RpcError};
 use crate::registry::SocketKind;
-use crate::service::{RequestLoop, RequestService};
+use crate::service::RequestService;
 use crate::transport::TransportConfig;
 
 /// Trait for services that can be spawned by ServiceSpawner.
@@ -76,7 +76,6 @@ impl<S: RequestService + Send + Sync> Spawnable for S {
         on_ready: Option<tokio::sync::oneshot::Sender<()>>,
     ) -> Result<()> {
         let transport = RequestService::transport(&*self).clone();
-        let context = Arc::clone(RequestService::context(&*self));
         let signing_key = RequestService::signing_key(&*self);
 
         let rt = tokio::runtime::Builder::new_multi_thread()
@@ -84,22 +83,18 @@ impl<S: RequestService + Send + Sync> Spawnable for S {
             .build()
             .map_err(|e| RpcError::SpawnFailed(format!("runtime: {e}")))?;
 
-        let local = tokio::task::LocalSet::new();
-        local.block_on(&rt, async move {
-            let runner = RequestLoop::new(transport, context, signing_key);
-
-            match runner.run(*self).await {
-                Ok(mut handle) => {
-                    if let Some(tx) = on_ready {
-                        let _ = tx.send(());
-                    }
-                    let _ = crate::notify::ready();
-                    shutdown.notified().await;
-                    handle.stop().await;
-                    Ok(())
-                }
-                Err(e) => Err(RpcError::SpawnFailed(e.to_string())),
-            }
+        // Post-ZMQ serve (#136): bridge the service to a Send processor on its own
+        // LocalSet thread, then serve it over its registered transport (inproc →
+        // in-memory dial registry; ipc/systemd → UdsRpcServer). No ZMQ ROUTER.
+        rt.block_on(async move {
+            let nonce_cache = Arc::new(crate::envelope::InMemoryNonceCache::new());
+            let bridge = crate::transport::iroh_rpc::LocalServiceBridge::spawn(*self, nonce_cache, 0)
+                .map_err(|e| RpcError::SpawnFailed(format!("bridge: {e}")))?;
+            let processor: Arc<dyn crate::transport::rpc_session::IrohRequestProcessor> =
+                Arc::new(bridge);
+            crate::service::serve::serve_bridged(&transport, processor, signing_key, shutdown, on_ready)
+                .await
+                .map_err(|e| RpcError::SpawnFailed(e.to_string()))
         })
     }
 }

--- a/crates/hyprstream-rpc/src/service/streaming.rs
+++ b/crates/hyprstream-rpc/src/service/streaming.rs
@@ -290,8 +290,16 @@ impl StreamService {
         let signed_reader = reader.get_root::<common_capnp::signed_envelope::Reader>()?;
         let signed = SignedEnvelope::read_from(signed_reader)?;
 
-        // Verify signature against the envelope's embedded pubkey.
-        signed.verify_any_signer(&*self.nonce_cache)?;
+        // Verify signature against the envelope's embedded pubkey, enforcing
+        // the process-global crypto policy (Hybrid in the daemon) with the
+        // kid-anchored PQ trust store. Closes the prior fail-open where this
+        // site hardcoded Classical / no PQ store.
+        let pq_store = crate::envelope::global_pq_store();
+        signed.verify_any_signer_with(
+            &*self.nonce_cache,
+            pq_store.as_deref(),
+            crate::envelope::global_verify_policy(),
+        )?;
 
         // Reject signers not attested in the trust store.
         if let Some(ref authorize) = self.authorize_signer {

--- a/crates/hyprstream-rpc/src/service/streaming.rs
+++ b/crates/hyprstream-rpc/src/service/streaming.rs
@@ -150,6 +150,16 @@ pub struct StreamService {
     /// a StreamRegister. Returns `true` if the key is trusted.
     /// When `None`, any valid signature is accepted (testing/bootstrap).
     authorize_signer: Option<Arc<dyn Fn(&[u8; 32]) -> bool + Send + Sync>>,
+
+    /// moq-lite streaming plane (epic #134 M2a).
+    ///
+    /// When set, in-process publishers can append directly to the shared
+    /// `moq_net::Origin` (via [`crate::moq_stream::MoqStreamOrigin::publisher`])
+    /// and external subscribers consume the same origin over the `moql` ALPN.
+    /// The ZMQ PULL→XPUB proxy below remains as a parallel path until the
+    /// substrate is wired into service bootstrap. The in-process publish gate
+    /// (`authorize_signer`) is mirrored onto the moq origin by the factory.
+    moq: Option<crate::moq_stream::MoqStreamOrigin>,
 }
 
 impl StreamService {
@@ -205,7 +215,23 @@ impl StreamService {
             nonce_cache: Arc::new(InMemoryNonceCache::new()),
             verifying_key,
             authorize_signer: None,
+            moq: None,
         }
+    }
+
+    /// Attach a moq-lite streaming origin (epic #134 M2a).
+    ///
+    /// The origin should already carry the same `authorize_signer` gate as this
+    /// service (use `MoqStreamOrigin::builder(..).with_authorize_signer(..)`).
+    /// In-process publishers obtain it via [`Self::moq_origin`].
+    pub fn with_moq_origin(mut self, origin: crate::moq_stream::MoqStreamOrigin) -> Self {
+        self.moq = Some(origin);
+        self
+    }
+
+    /// Borrow the moq streaming origin, if configured.
+    pub fn moq_origin(&self) -> Option<&crate::moq_stream::MoqStreamOrigin> {
+        self.moq.as_ref()
     }
 
     /// Configure buffer sizes and TTL

--- a/crates/hyprstream-rpc/src/service/zmq.rs
+++ b/crates/hyprstream-rpc/src/service/zmq.rs
@@ -476,7 +476,6 @@ pub trait RequestService: 'static {
 
         // Route verification by algorithm
         let verified = match alg.as_str() {
-            #[cfg(feature = "pq-hybrid")]
             "ML-DSA-65" => {
                 let vks = key_source.ml_dsa_verifying_keys();
                 if vks.is_empty() {
@@ -499,7 +498,6 @@ pub trait RequestService: 'static {
                     }
                 }
             }
-            #[cfg(feature = "pq-hybrid")]
             "ML-DSA-65-Ed25519" => {
                 let vks = key_source.ml_dsa_verifying_keys();
                 if vks.is_empty() {

--- a/crates/hyprstream-rpc/src/service/zmq.rs
+++ b/crates/hyprstream-rpc/src/service/zmq.rs
@@ -244,7 +244,7 @@ impl EnvelopeContext {
 ///
 /// This is the unified trait for services that:
 /// 1. Handle requests via `handle_request()`
-/// 2. Are automatically spawnable (blanket `impl Spawnable for S: ZmqService`)
+/// 2. Are automatically spawnable (blanket `impl Spawnable for S: RequestService`)
 ///
 /// Services include their infrastructure (context, transport, verifying key) so they
 /// can be spawned directly without wrapping.
@@ -266,7 +266,7 @@ impl EnvelopeContext {
 ///     verifying_key: VerifyingKey,
 /// }
 ///
-/// impl ZmqService for MyService {
+/// impl RequestService for MyService {
 ///     fn handle_request(&self, ctx: &EnvelopeContext, payload: &[u8]) -> Result<(Vec<u8>, Option<Continuation>)> {
 ///         // ctx.identity is already verified
 ///         info!("Request from {} (id={})", ctx.subject(), ctx.request_id);
@@ -283,7 +283,7 @@ impl EnvelopeContext {
 /// manager.spawn(Box::new(my_service)).await?;
 /// ```
 #[async_trait(?Send)]
-pub trait ZmqService: 'static {
+pub trait RequestService: 'static {
     /// Process a request and return a response with optional continuation.
     ///
     /// # Arguments
@@ -645,7 +645,7 @@ pub trait ZmqService: 'static {
     }
 }
 
-/// REQ/REP message loop for ZmqService.
+/// REQ/REP message loop for RequestService.
 ///
 /// Runs the REQ/REP message loop as an async task with TMQ for I/O.
 /// Uses proper async/await with epoll integration instead of blocking threads.
@@ -662,7 +662,7 @@ pub trait ZmqService: 'static {
 ///
 /// # Usage
 ///
-/// Typically used internally by the blanket `Spawnable` impl for `ZmqService`.
+/// Typically used internally by the blanket `Spawnable` impl for `RequestService`.
 /// Direct usage is for advanced cases only.
 /// REQ/REP message loop with ZMQ ROUTER + optional QUIC accept.
 ///
@@ -748,7 +748,7 @@ impl RequestLoop {
     /// Run the unified service loop as an async task.
     ///
     /// Spawns on `LocalSet` via `spawn_local` — supports `!Send` services.
-    pub async fn run<S: ZmqService>(self, service: S) -> Result<ServiceHandle> {
+    pub async fn run<S: RequestService>(self, service: S) -> Result<ServiceHandle> {
         let transport = self.transport.clone();
         let context = Arc::clone(&self.context);
         let server_pubkey = self.server_pubkey;
@@ -795,7 +795,7 @@ impl RequestLoop {
     /// Accepts requests from both ZMQ ROUTER and WebTransport server,
     /// dispatching both through `process_request`.
     #[allow(clippy::too_many_arguments)]
-    async fn unified_loop<S: ZmqService>(
+    async fn unified_loop<S: RequestService>(
         transport: TransportConfig,
         context: Arc<zmq::Context>,
         service: Rc<S>,

--- a/crates/hyprstream-rpc/src/service/zmq.rs
+++ b/crates/hyprstream-rpc/src/service/zmq.rs
@@ -938,10 +938,6 @@ impl RequestLoop {
             });
         }
 
-        // Bounded semaphore for continuations
-        const MAX_INFLIGHT_CONTINUATIONS: usize = 16;
-        let continuation_semaphore = Arc::new(tokio::sync::Semaphore::new(MAX_INFLIGHT_CONTINUATIONS));
-
         // Use futures traits for Router async I/O
         use futures::{SinkExt, StreamExt};
         let mut router_stream = router;
@@ -1005,18 +1001,18 @@ impl RequestLoop {
                     // not a shared root key. The envelope signature is still verified —
                     // JWT claims + Casbin handle authorization.
                     // subsecond::call wraps the dispatch so handler code can be hot-patched during dev.
-                    let (response_bytes, continuation) = match subsecond::call(|| crate::service::dispatch::process_request(
+                    let response_bytes = match subsecond::call(|| crate::service::dispatch::process_request(
                         &request,
                         &*service,
                         crate::envelope::EnvelopeVerification::AnySigner,
                         &signing_key,
                         &nonce_cache,
                     )).await {
-                        Ok(result) => result,
+                        Ok(bytes) => bytes,
                         Err(e) => {
                             error!("{} request processing error: {}", service.name(), e);
                             let error_payload = service.build_error_payload(0, &e.to_string());
-                            (Self::wrap_response(0, error_payload, &signing_key)?, None)
+                            Self::wrap_response(0, error_payload, &signing_key)?
                         }
                     };
 
@@ -1030,18 +1026,8 @@ impl RequestLoop {
                     if let Err(e) = router_stream.send(response_msg).await {
                         error!("{} ROUTER send error: {}", service.name(), e);
                     }
-
-                    // Spawn continuation after response is sent
-                    if let Some(future) = continuation {
-                        let sem = continuation_semaphore.clone();
-                        tokio::task::spawn_local(async move {
-                            let Ok(_permit) = sem.acquire_owned().await else {
-                                warn!("continuation semaphore closed");
-                                return;
-                            };
-                            future.await;
-                        });
-                    }
+                    // Any streaming pump was already spawned inside
+                    // process_request (#186); nothing to do here.
                 }
             }
         }

--- a/crates/hyprstream-rpc/src/service/zmq.rs
+++ b/crates/hyprstream-rpc/src/service/zmq.rs
@@ -869,12 +869,21 @@ impl RequestLoop {
                         actual_addr,
                         cert_hash,
                     );
-                    // Register QUIC endpoint in the global registry for discovery
+                    // Register QUIC endpoint in the global registry for discovery.
+                    // The server is self-signed, so register it *pinned* by the
+                    // leaf cert's SHA-256 — otherwise a client dialing this config
+                    // would attempt CA validation (WebPki) against a self-signed
+                    // cert and fail.
                     if let Some(reg) = crate::registry::try_global() {
+                        let pin = crate::transport::zmtp_quic::cert_sha256(&qc.cert_chain[0]);
                         reg.register(
                             service.name(),
                             crate::registry::SocketKind::Quic,
-                            crate::transport::TransportConfig::quic(actual_addr, &qc.server_name),
+                            crate::transport::TransportConfig::quic_pinned(
+                                actual_addr,
+                                &qc.server_name,
+                                pin,
+                            ),
                             None,
                         );
                     }

--- a/crates/hyprstream-rpc/src/service/zmq.rs
+++ b/crates/hyprstream-rpc/src/service/zmq.rs
@@ -996,10 +996,10 @@ impl RequestLoop {
                     // not a shared root key. The envelope signature is still verified —
                     // JWT claims + Casbin handle authorization.
                     // subsecond::call wraps the dispatch so handler code can be hot-patched during dev.
-                    let (response_bytes, continuation) = match subsecond::call(|| crate::transport::zmtp_quic::process_request(
+                    let (response_bytes, continuation) = match subsecond::call(|| crate::service::dispatch::process_request(
                         &request,
                         &*service,
-                        crate::transport::zmtp_quic::EnvelopeVerification::AnySigner,
+                        crate::envelope::EnvelopeVerification::AnySigner,
                         &signing_key,
                         &nonce_cache,
                     )).await {

--- a/crates/hyprstream-rpc/src/service_entry.rs
+++ b/crates/hyprstream-rpc/src/service_entry.rs
@@ -1,0 +1,311 @@
+//! DID-document transport `service`-entry codec.
+//!
+//! The canonical encoder/decoder for the typed transport entries a node
+//! publishes in its DID document, shared by the producer (the did:web document
+//! builder) and the consumer (the DID resolver that feeds [`crate::dial::dial`]).
+//!
+//! # Layering (settled design)
+//!
+//! Peer **identity** is established at the application layer — the response
+//! `SignedEnvelope` is verified against the node's published keys (the `#mesh`
+//! verification method / JWKS). The transport entries here carry **reach info +
+//! channel auth**, not the identity root. For iroh the `nodeId` *is* the
+//! Ed25519 identity key (so [`DecodedEntry::identity_key`] is populated and the
+//! resolver can bind it to `#mesh`); for QUIC, identity comes from `#mesh`
+//! separately and the cert pin is channel-only (#185).
+//!
+//! # Wire shape
+//!
+//! `serviceEndpoint` is a DIDComm-style map (W3C DID Core §5.4 permits a map).
+//! Binary values use multibase (`z` = base58btc) over a multiformats prefix,
+//! matching the doc's existing `Ed25519VerificationKey2020` `publicKeyMultibase`
+//! encoding:
+//!
+//! ```jsonc
+//! // type: "IrohTransport"
+//! { "nodeId": "z<multicodec ed25519-pub || key>", "relays": ["https://…"], "accept": ["hyprstream-rpc/1","moql"] }
+//! // type: "QuicTransport"
+//! { "uri": "https://host:port", "webpki": false,
+//!   "certHashes": ["z<multihash sha2-256 || digest>"], "accept": [...] }
+//! ```
+//!
+//! `certHashes` is a multibase-encoded **multihash** (self-describing algorithm,
+//! `sha2-256` = 0x12), a **set** so cert rotation can overlap. Whole-cert pins
+//! are the browser-compatible projection of the identity key — see #185 / #200.
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde_json::{json, Value};
+
+use crate::transport::{QuicServerAuth, TransportConfig};
+
+/// multicodec `ed25519-pub` varint prefix (did:key spec).
+const MULTICODEC_ED25519_PUB: [u8; 2] = [0xed, 0x01];
+/// multihash prefix for `sha2-256` with a 32-byte digest (`0x12` code, `0x20` len).
+const MULTIHASH_SHA2_256: [u8; 2] = [0x12, 0x20];
+
+/// A decoded transport entry: a dialable config plus, for identity-bearing
+/// transports, the peer's identity public key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecodedEntry {
+    /// Dial target for [`crate::dial::dial`].
+    pub config: TransportConfig,
+    /// The peer's Ed25519 identity key, when the transport binds to it
+    /// (iroh: the `nodeId`). `None` for QUIC, where identity comes from the
+    /// `#mesh` verification method separately.
+    pub identity_key: Option<[u8; 32]>,
+}
+
+// ── multibase helpers ────────────────────────────────────────────────────────
+
+fn multibase_encode(prefix: &[u8], payload: &[u8]) -> String {
+    let mut buf = Vec::with_capacity(prefix.len() + payload.len());
+    buf.extend_from_slice(prefix);
+    buf.extend_from_slice(payload);
+    format!("z{}", bs58::encode(buf).into_string())
+}
+
+/// Decode a multibase base58btc string carrying `prefix || <32-byte payload>`.
+fn multibase_decode_32(s: &str, prefix: [u8; 2], what: &str) -> Result<[u8; 32]> {
+    let b58 = s
+        .strip_prefix('z')
+        .ok_or_else(|| anyhow!("{what}: expected multibase base58btc ('z' prefix)"))?;
+    let bytes = bs58::decode(b58)
+        .into_vec()
+        .map_err(|e| anyhow!("{what}: invalid base58: {e}"))?;
+    if bytes.len() != prefix.len() + 32 {
+        bail!("{what}: expected {} bytes, got {}", prefix.len() + 32, bytes.len());
+    }
+    if bytes[..2] != prefix[..] {
+        bail!("{what}: wrong multiformats prefix");
+    }
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&bytes[2..]);
+    Ok(out)
+}
+
+// ── encode (producer side) ───────────────────────────────────────────────────
+
+/// Encode an `IrohTransport` `serviceEndpoint` map for a peer identified by
+/// `node_id` (its Ed25519 `EndpointId`), reachable via `relays`.
+pub fn encode_iroh(node_id: &[u8; 32], relays: &[String], accept: &[&str]) -> Value {
+    json!({
+        "nodeId": multibase_encode(&MULTICODEC_ED25519_PUB, node_id),
+        "relays": relays,
+        "accept": accept,
+    })
+}
+
+/// Encode a `QuicTransport` `serviceEndpoint` map.
+pub fn encode_quic(uri: &str, auth: &QuicServerAuth, accept: &[&str]) -> Value {
+    let cert_hashes: Vec<String> = auth
+        .accept_cert_hashes()
+        .iter()
+        .map(|h| multibase_encode(&MULTIHASH_SHA2_256, h))
+        .collect();
+    json!({
+        "uri": uri,
+        "webpki": auth.require_web_pki(),
+        "certHashes": cert_hashes,
+        "accept": accept,
+    })
+}
+
+// ── decode (consumer / resolver side) ────────────────────────────────────────
+
+/// Decode one DID-doc transport `service` entry (`{type, serviceEndpoint}`) into
+/// a dialable [`DecodedEntry`]. Unknown `type`s error so the caller can skip
+/// them.
+pub fn decode_service_entry(entry: &Value) -> Result<DecodedEntry> {
+    let ty = entry
+        .get("type")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("service entry missing string `type`"))?;
+    let svc = entry
+        .get("serviceEndpoint")
+        .ok_or_else(|| anyhow!("service entry missing `serviceEndpoint`"))?;
+    match ty {
+        "IrohTransport" => decode_iroh(svc),
+        "QuicTransport" => decode_quic(svc),
+        other => bail!("unsupported transport service type: {other}"),
+    }
+}
+
+fn decode_iroh(svc: &Value) -> Result<DecodedEntry> {
+    let node_id = multibase_decode_32(
+        svc.get("nodeId").and_then(Value::as_str).ok_or_else(|| anyhow!("iroh: missing `nodeId`"))?,
+        MULTICODEC_ED25519_PUB,
+        "iroh nodeId",
+    )?;
+    let relays: Vec<String> = svc
+        .get("relays")
+        .and_then(Value::as_array)
+        .map(|a| a.iter().filter_map(|v| v.as_str().map(str::to_owned)).collect())
+        .unwrap_or_default();
+    // Direct addresses are not published (privacy + iroh discovery); the resolver
+    // supplies a relay and lets iroh discover direct paths.
+    let relay_url = relays.into_iter().next();
+    Ok(DecodedEntry {
+        config: TransportConfig::iroh(node_id, Vec::new(), relay_url),
+        identity_key: Some(node_id),
+    })
+}
+
+fn decode_quic(svc: &Value) -> Result<DecodedEntry> {
+    let uri = svc.get("uri").and_then(Value::as_str).ok_or_else(|| anyhow!("quic: missing `uri`"))?;
+    let (host, port) = parse_https_authority(uri)?;
+    // Default `webpki` to true (safe-by-default: a CA-fronted public peer).
+    let require_web_pki = svc.get("webpki").and_then(Value::as_bool).unwrap_or(true);
+    let cert_hashes: Vec<[u8; 32]> = svc
+        .get("certHashes")
+        .and_then(Value::as_array)
+        .map(|a| -> Result<Vec<[u8; 32]>> {
+            a.iter()
+                .map(|v| {
+                    let s = v.as_str().ok_or_else(|| anyhow!("quic certHashes: non-string entry"))?;
+                    multibase_decode_32(s, MULTIHASH_SHA2_256, "quic certHash")
+                })
+                .collect()
+        })
+        .transpose()?
+        .unwrap_or_default();
+
+    let auth = match (require_web_pki, cert_hashes.is_empty()) {
+        (true, true) => QuicServerAuth::web_pki(),
+        (false, false) => QuicServerAuth::pinned(cert_hashes)?,
+        (true, false) => QuicServerAuth::web_pki_pinned(cert_hashes)?,
+        (false, true) => bail!("quic entry has no auth (webpki=false and no certHashes)"),
+    };
+
+    // Pinned dials by IP; WebPKI dials by `server_name` (DNS), ignoring the IP —
+    // so a hostname `uri` gets an unspecified placeholder address with the real
+    // port, and the host becomes the validation name.
+    let addr: SocketAddr = match host.parse::<IpAddr>() {
+        Ok(ip) => SocketAddr::new(ip, port),
+        Err(_) => SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port),
+    };
+    Ok(DecodedEntry {
+        config: TransportConfig::quic_with_auth(addr, host, auth),
+        identity_key: None,
+    })
+}
+
+/// Parse `https://host:port` (or `quic://…`) into `(host, port)`. Defaults to
+/// 443 when no port is given.
+fn parse_https_authority(uri: &str) -> Result<(String, u16)> {
+    let url = url::Url::parse(uri).with_context(|| format!("quic uri parse: {uri}"))?;
+    let host = url.host_str().ok_or_else(|| anyhow!("quic uri has no host: {uri}"))?.to_owned();
+    let port = url.port().unwrap_or(443);
+    Ok((host, port))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::transport::EndpointType;
+
+    #[test]
+    fn iroh_round_trip() {
+        let node_id = [7u8; 32];
+        let relays = vec!["https://relay.example".to_owned()];
+        let entry = json!({
+            "id": "did:web:ex#iroh",
+            "type": "IrohTransport",
+            "serviceEndpoint": encode_iroh(&node_id, &relays, &["hyprstream-rpc/1", "moql"]),
+        });
+        let decoded = decode_service_entry(&entry).unwrap();
+        assert_eq!(decoded.identity_key, Some(node_id));
+        match &decoded.config.endpoint {
+            EndpointType::Iroh { node_id: n, relay_url, direct_addrs } => {
+                assert_eq!(*n, node_id);
+                assert_eq!(relay_url.as_deref(), Some("https://relay.example"));
+                assert!(direct_addrs.is_empty());
+            }
+            other => panic!("expected Iroh, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn quic_pinned_round_trip() {
+        let auth = QuicServerAuth::pinned(vec![[1u8; 32], [2u8; 32]]).unwrap();
+        let entry = json!({
+            "type": "QuicTransport",
+            "serviceEndpoint": encode_quic("https://10.0.0.1:4433", &auth, &["hyprstream-rpc/1"]),
+        });
+        let decoded = decode_service_entry(&entry).unwrap();
+        assert_eq!(decoded.identity_key, None);
+        match &decoded.config.endpoint {
+            EndpointType::Quic { addr, server_name, auth: a } => {
+                assert_eq!(addr.to_string(), "10.0.0.1:4433");
+                assert_eq!(server_name, "10.0.0.1");
+                assert!(!a.require_web_pki());
+                assert_eq!(a.accept_cert_hashes(), &[[1u8; 32], [2u8; 32]]);
+            }
+            other => panic!("expected Quic, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn quic_webpki_default_and_hostname_placeholder() {
+        // No `webpki` field ⇒ default true; no certHashes ⇒ WebPKI only.
+        let entry = json!({
+            "type": "QuicTransport",
+            "serviceEndpoint": { "uri": "https://host.example:8443", "accept": ["hyprstream-rpc/1"] },
+        });
+        let decoded = decode_service_entry(&entry).unwrap();
+        match &decoded.config.endpoint {
+            EndpointType::Quic { addr, server_name, auth } => {
+                assert!(auth.require_web_pki());
+                assert!(auth.accept_cert_hashes().is_empty());
+                assert_eq!(server_name, "host.example");
+                assert_eq!(addr.port(), 8443);
+                assert!(addr.ip().is_unspecified(), "hostname ⇒ placeholder IP");
+            }
+            other => panic!("expected Quic, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn quic_web_pki_pinned() {
+        let entry = json!({
+            "type": "QuicTransport",
+            "serviceEndpoint": {
+                "uri": "https://host.example:4433",
+                "webpki": true,
+                "certHashes": [multibase_encode(&MULTIHASH_SHA2_256, &[9u8; 32])],
+            },
+        });
+        let decoded = decode_service_entry(&entry).unwrap();
+        if let EndpointType::Quic { auth, .. } = &decoded.config.endpoint {
+            assert!(auth.require_web_pki());
+            assert_eq!(auth.accept_cert_hashes(), &[[9u8; 32]]);
+        } else {
+            panic!("expected Quic");
+        }
+    }
+
+    #[test]
+    fn rejects_no_auth_and_unknown_type() {
+        // webpki:false + no certHashes ⇒ no auth ⇒ reject.
+        let bad = json!({
+            "type": "QuicTransport",
+            "serviceEndpoint": { "uri": "https://10.0.0.1:4433", "webpki": false },
+        });
+        assert!(decode_service_entry(&bad).is_err());
+
+        let unknown = json!({ "type": "OnionTransport", "serviceEndpoint": {} });
+        assert!(decode_service_entry(&unknown).is_err());
+    }
+
+    #[test]
+    fn rejects_malformed_multibase() {
+        // Wrong multicodec prefix (a sha2-256 multihash where an ed25519 key is expected).
+        let entry = json!({
+            "type": "IrohTransport",
+            "serviceEndpoint": { "nodeId": multibase_encode(&MULTIHASH_SHA2_256, &[0u8; 32]), "relays": [] },
+        });
+        assert!(decode_service_entry(&entry).is_err());
+    }
+}

--- a/crates/hyprstream-rpc/src/signer.rs
+++ b/crates/hyprstream-rpc/src/signer.rs
@@ -17,7 +17,6 @@ use crate::transport_traits::Signer;
 /// Used for server-to-server RPC where the signing key is local.
 pub struct LocalSigner {
     signing_key: SigningKey,
-    #[cfg(feature = "pq-hybrid")]
     pq_signing_key: Option<crate::crypto::pq::MlDsaSigningKey>,
 }
 
@@ -25,7 +24,6 @@ impl LocalSigner {
     pub fn new(signing_key: SigningKey) -> Self {
         Self {
             signing_key,
-            #[cfg(feature = "pq-hybrid")]
             pq_signing_key: {
                 let (sk, _) = crate::crypto::pq::ml_dsa_generate_keypair();
                 Some(sk)
@@ -33,7 +31,6 @@ impl LocalSigner {
         }
     }
 
-    #[cfg(feature = "pq-hybrid")]
     pub fn with_pq_key(mut self, key: crate::crypto::pq::MlDsaSigningKey) -> Self {
         self.pq_signing_key = Some(key);
         self
@@ -57,29 +54,16 @@ impl Signer for LocalSigner {
     }
 
     fn pq_pubkey(&self) -> Option<Vec<u8>> {
-        #[cfg(feature = "pq-hybrid")]
-        {
-            self.pq_signing_key.as_ref().map(|sk| {
-                let vk = ml_dsa::Keypair::verifying_key(sk);
-                crate::crypto::pq::ml_dsa_vk_bytes(&vk)
-            })
-        }
-        #[cfg(not(feature = "pq-hybrid"))]
-        None
+        self.pq_signing_key.as_ref().map(|sk| {
+            let vk = ml_dsa::Keypair::verifying_key(sk);
+            crate::crypto::pq::ml_dsa_vk_bytes(&vk)
+        })
     }
 
     async fn pq_sign(&self, canonical_bytes: &[u8]) -> Result<Option<Vec<u8>>> {
-        #[cfg(feature = "pq-hybrid")]
-        {
-            return match &self.pq_signing_key {
-                Some(sk) => Ok(Some(crate::crypto::pq::ml_dsa_sign(sk, canonical_bytes))),
-                None => Ok(None),
-            };
-        }
-        #[cfg(not(feature = "pq-hybrid"))]
-        {
-            let _ = canonical_bytes;
-            Ok(None)
+        match &self.pq_signing_key {
+            Some(sk) => Ok(Some(crate::crypto::pq::ml_dsa_sign(sk, canonical_bytes))),
+            None => Ok(None),
         }
     }
 }

--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -1360,8 +1360,14 @@ impl Stream for StreamHandle {
 pub struct StreamChannel {
     /// ZMQ context (shared)
     context: Arc<zmq::Context>,
-    /// Signing key for stream registration
+    /// Ed25519 signing key for stream registration
     signing_key: SigningKey,
+    /// ML-DSA-65 signing key for the post-quantum half of the StreamRegister
+    /// composite signature. Mirrors `LocalSigner` on the RPC plane so the
+    /// streaming control plane signs under the same policy (#161). Auto-
+    /// generated; the node's persistent ML-DSA identity is wired in via
+    /// [`Self::with_pq_key`] once peer attestation lands (#157).
+    pq_signing_key: Option<crate::crypto::pq::MlDsaSigningKey>,
     /// Lazy-initialized async PUSH socket to StreamService (wrapped in Arc for sharing)
     push_socket: OnceCell<Arc<tokio::sync::Mutex<tmq::push::Push>>>,
     /// Channel to send subscription requests to the ctrl listener task
@@ -1372,14 +1378,30 @@ pub struct StreamChannel {
 
 impl StreamChannel {
     /// Create a new stream channel.
+    ///
+    /// Auto-generates an ML-DSA-65 key for the post-quantum half of the
+    /// StreamRegister composite, mirroring `LocalSigner::new` on the RPC
+    /// plane. Use [`Self::with_pq_key`] to install the node's persistent
+    /// ML-DSA identity (#157).
     pub fn new(context: Arc<zmq::Context>, signing_key: SigningKey) -> Self {
+        let (pq_sk, _) = crate::crypto::pq::ml_dsa_generate_keypair();
         Self {
             context,
             signing_key,
+            pq_signing_key: Some(pq_sk),
             push_socket: OnceCell::new(),
             ctrl_sub_tx: OnceCell::new(),
             cancel_tokens: Arc::new(DashMap::new()),
         }
+    }
+
+    /// Install the node's persistent ML-DSA-65 signing key, replacing the
+    /// auto-generated one. The matching public key must be anchored in the
+    /// StreamService verifier's PQ trust store for Hybrid verification to
+    /// succeed (peer attestation, #157).
+    pub fn with_pq_key(mut self, key: crate::crypto::pq::MlDsaSigningKey) -> Self {
+        self.pq_signing_key = Some(key);
+        self
     }
 
     /// Prepare a stream with DH key exchange and pre-authorization.
@@ -1478,6 +1500,7 @@ impl StreamChannel {
             topic,
             expiry,
             &self.signing_key,
+            self.pq_signing_key.as_ref(),
             claims,
         );
 
@@ -1854,6 +1877,7 @@ fn build_stream_register_envelope(
     topic: &str,
     expiry: i64,
     signing_key: &SigningKey,
+    pq_signing_key: Option<&crate::crypto::pq::MlDsaSigningKey>,
     _claims: Option<Claims>,
 ) -> Vec<u8> {
     use crate::common_capnp;
@@ -1879,7 +1903,18 @@ fn build_stream_register_envelope(
     let envelope = RequestEnvelope::new(inner_bytes);
     // Claims are no longer carried in the envelope — authorization is via JWT/Authorization field
 
-    let signed = SignedEnvelope::new_signed(envelope, signing_key);
+    // Sign under the same policy mechanism as the RPC plane (#161): Hybrid
+    // (EdDSA + ML-DSA-65 SNS composite) when a PQ key is present, else
+    // Classical. This removes the prior unconditional `new_signed` (Classical)
+    // that the StreamService verifier — enforcing the global Hybrid policy —
+    // would either reject or accept as a strict downgrade vs RPC.
+    let policy = if pq_signing_key.is_some() {
+        crate::crypto::CryptoPolicy::Hybrid
+    } else {
+        crate::crypto::CryptoPolicy::Classical
+    };
+    let signed =
+        SignedEnvelope::new_signed_with_policy(envelope, signing_key, pq_signing_key, policy);
 
     let mut msg = Builder::new_default();
     {
@@ -1926,6 +1961,66 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #161: a StreamRegister built with a PQ key is a Hybrid (SNS) composite
+    /// that verifies under the global Hybrid policy when the signer's ML-DSA
+    /// key is anchored in the PQ trust store — and fail-closes when it isn't,
+    /// exactly mirroring the RPC plane (no silent Classical downgrade).
+    #[test]
+    fn stream_register_hybrid_verifies_only_when_pq_anchored() -> anyhow::Result<()> {
+        use crate::crypto::pq::{ml_dsa_generate_keypair, ml_dsa_vk_from_bytes};
+        use crate::crypto::CryptoPolicy;
+        use crate::envelope::{
+            InMemoryNonceCache, KeyedPqTrustStore, SignedEnvelope,
+        };
+        use crate::common_capnp;
+        use crate::FromCapnp;
+
+        let signing_key = SigningKey::from_bytes(&[7u8; 32]);
+        let (pq_sk, pq_vk) = ml_dsa_generate_keypair();
+
+        let bytes = build_stream_register_envelope(
+            "deadbeef".repeat(8).as_str(),
+            i64::MAX,
+            &signing_key,
+            Some(&pq_sk),
+            None,
+        );
+        assert!(!bytes.is_empty(), "register envelope must serialize");
+
+        let reader = serialize::read_message(
+            &mut std::io::Cursor::new(&bytes[..]),
+            capnp::message::ReaderOptions::default(),
+        )?;
+        let signed = SignedEnvelope::read_from(
+            reader.get_root::<common_capnp::signed_envelope::Reader>()?,
+        )?;
+
+        assert_eq!(signed.policy, CryptoPolicy::Hybrid, "must sign Hybrid with PQ key");
+
+        // Anchored: the signer's ML-DSA vk is bound to its Ed25519 identity.
+        let mut store = KeyedPqTrustStore::new();
+        let vk = ml_dsa_vk_from_bytes(&crate::crypto::pq::ml_dsa_vk_bytes(&pq_vk))?;
+        store.bind(signing_key.verifying_key().to_bytes(), &vk);
+        let nonce_ok = InMemoryNonceCache::new();
+        assert!(
+            signed
+                .verify_any_signer_with(&nonce_ok, Some(&store), CryptoPolicy::Hybrid)
+                .is_ok(),
+            "anchored Hybrid register must verify"
+        );
+
+        // Not anchored: empty store under Hybrid fails closed.
+        let empty = KeyedPqTrustStore::new();
+        let nonce_empty = InMemoryNonceCache::new();
+        assert!(
+            signed
+                .verify_any_signer_with(&nonce_empty, Some(&empty), CryptoPolicy::Hybrid)
+                .is_err(),
+            "unanchored Hybrid register must fail closed (no Classical downgrade)"
+        );
+        Ok(())
+    }
 
     #[test]
     fn test_batching_config_default() {

--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -1818,6 +1818,125 @@ impl StreamGuard {
 }
 
 // ============================================================================
+// Streaming-response concurrency (#186)
+// ============================================================================
+
+/// Default ceiling on **concurrent server-side streaming responses per
+/// service** — i.e. how many streaming RPCs one service may be actively pushing
+/// data for at once. Overridable via [`install_max_concurrent_streams_per_service`]
+/// (wired from `ServerConfig::max_concurrent_streams_per_service`).
+///
+/// This is the former per-`RequestLoop` `MAX_INFLIGHT_CONTINUATIONS` (16). When
+/// the spawn moved out of the transport front-ends into the dispatch core
+/// (#186) the bound is keyed by service name rather than living on each loop —
+/// the *same* granularity, since each service has exactly one `RequestLoop`.
+/// Keeping it per-service (not process-wide) preserves the original isolation:
+/// one service's stuck or long-lived streams cannot starve another's.
+pub const DEFAULT_MAX_CONCURRENT_STREAMS_PER_SERVICE: usize = 16;
+
+/// Process-global override for the per-service concurrent-streams cap.
+/// First-write-wins, mirroring `install_verify_config`; installed once at
+/// startup from the loaded `ServerConfig`. Read when a service's semaphore is
+/// first created, so it must be installed before serving (it always is — the
+/// daemon installs it right after loading config).
+static MAX_CONCURRENT_STREAMS_PER_SERVICE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+
+/// Install the per-service concurrent-streams cap. Call once at startup with
+/// `ServerConfig::max_concurrent_streams_per_service`. Values are clamped to a
+/// minimum of 1. Returns `Err(existing)` if already installed (first-write-wins).
+pub fn install_max_concurrent_streams_per_service(n: usize) -> Result<(), usize> {
+    MAX_CONCURRENT_STREAMS_PER_SERVICE.set(n.max(1))
+}
+
+/// The effective cap: the installed value, or [`DEFAULT_MAX_CONCURRENT_STREAMS_PER_SERVICE`].
+fn max_concurrent_streams_per_service() -> usize {
+    MAX_CONCURRENT_STREAMS_PER_SERVICE
+        .get()
+        .copied()
+        .unwrap_or(DEFAULT_MAX_CONCURRENT_STREAMS_PER_SERVICE)
+}
+
+/// Per-service admission semaphores, created on first use at the effective cap.
+/// A permit is held for the full lifetime of a streaming response (which is
+/// itself bounded by the stream's JWT/TTL cancel token in `StreamChannel`, so
+/// permits are always eventually released — there is no unbounded hold). The map
+/// only ever grows by the number of distinct services (small, bounded), so it is
+/// never pruned.
+fn stream_admission_semaphore(service_name: &str) -> std::sync::Arc<tokio::sync::Semaphore> {
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+    static MAP: std::sync::OnceLock<RwLock<HashMap<String, std::sync::Arc<tokio::sync::Semaphore>>>> =
+        std::sync::OnceLock::new();
+    let map = MAP.get_or_init(|| RwLock::new(HashMap::new()));
+    if let Some(sem) = map.read().get(service_name) {
+        return std::sync::Arc::clone(sem);
+    }
+    std::sync::Arc::clone(
+        map.write()
+            .entry(service_name.to_owned())
+            .or_insert_with(|| {
+                std::sync::Arc::new(tokio::sync::Semaphore::new(max_concurrent_streams_per_service()))
+            }),
+    )
+}
+
+/// Spawn the server-side half of a streaming RPC — the task that keeps pushing
+/// data *after* the `StreamInfo` reply has been sent — onto the current
+/// `LocalSet`, bounded by a per-service admission permit.
+///
+/// Replaces the former "transport front-end spawns the continuation it got back
+/// from `process_request`" model (#186): the dispatch core now spawns this task
+/// itself and returns only the reply bytes, so the streaming lifecycle is no
+/// longer threaded through every transport's request/response path. This is the
+/// M1 shape; in M2 the streaming transport (`StreamChannel`) moves to a
+/// service-owned moq broadcast and this coarse per-service cap is replaced by
+/// the StreamPolicy backpressure axes (#134).
+///
+/// `service_name` keys the per-service permit pool (see
+/// [`DEFAULT_MAX_CONCURRENT_STREAMS_PER_SERVICE`] and
+/// [`install_max_concurrent_streams_per_service`]). When the pool is saturated
+/// the task waits for a permit rather than being dropped — and the wait is
+/// logged so saturation is observable rather than a silent stall.
+///
+/// # Invariant
+///
+/// MUST be called from within a `tokio::task::LocalSet`: the task is `?Send`
+/// (like every [`RequestService`](crate::service::RequestService)), and
+/// `spawn_local` panics outside a `LocalSet`. Every
+/// [`process_request`](crate::service::dispatch::process_request) caller already
+/// runs on a `LocalSet` (ZMQ `RequestLoop`, the WebTransport server, and the
+/// generic plane's `LocalServiceBridge`), which is the only place this is
+/// invoked.
+pub fn spawn_streaming_response(service_name: &str, continuation: crate::service::Continuation) {
+    let sem = stream_admission_semaphore(service_name);
+    let service_name = service_name.to_owned();
+    tokio::task::spawn_local(async move {
+        // Observe saturation: a permit that isn't immediately available means
+        // this service is at its concurrent-streams cap and new streams are
+        // queueing behind running ones.
+        let permit = match sem.clone().try_acquire_owned() {
+            Ok(p) => p,
+            Err(_) => {
+                tracing::warn!(
+                    service = %service_name,
+                    cap = max_concurrent_streams_per_service(),
+                    "concurrent-streams cap reached; new stream waiting for a slot"
+                );
+                // The semaphore is a static that is never closed, so
+                // acquire_owned cannot fail; if it somehow did, drop the stream.
+                let Ok(p) = sem.acquire_owned().await else {
+                    tracing::error!(service = %service_name, "stream admission semaphore closed; dropping stream");
+                    return;
+                };
+                p
+            }
+        };
+        let _permit = permit; // held for the streaming response's lifetime
+        continuation.await;
+    });
+}
+
+// ============================================================================
 // Helpers
 // ============================================================================
 

--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -397,44 +397,9 @@ impl StreamBuilder {
         let payloads = std::mem::take(&mut self.pending);
         self.pending_bytes = 0;
 
-        // Build StreamBlock capnp message
-        let mut msg = Builder::new_default();
-        {
-            let mut block = msg.init_root::<streaming_capnp::stream_block::Builder>();
-            block.set_prev_mac(self.hmac_state.prev_mac_bytes());
-
-            // Cap'n Proto uses u32 for list lengths
-            let payloads_len = u32::try_from(payloads.len()).unwrap_or(u32::MAX);
-            let mut list = block.init_payloads(payloads_len);
-            for (i, payload) in payloads.iter().enumerate() {
-                let idx = u32::try_from(i).unwrap_or(u32::MAX);
-                let mut p = list.reborrow().get(idx);
-                match payload {
-                    StreamPayloadData::Data(data) => {
-                        p.set_data(data);
-                    }
-                    StreamPayloadData::Error(message) => {
-                        let mut err = p.init_error();
-                        err.set_message(message);
-                        err.set_code("");
-                        err.set_details("");
-                    }
-                    StreamPayloadData::Complete(data) => {
-                        p.set_complete(data);
-                    }
-                    StreamPayloadData::Tagged { tag, payload, nonce, key_commitment } => {
-                        let mut tagged = p.init_tagged();
-                        tagged.set_tag(tag);
-                        tagged.set_payload(payload);
-                        tagged.set_nonce(nonce);
-                        tagged.set_key_commitment(key_commitment);
-                    }
-                }
-            }
-        }
-
-        let mut capnp_bytes = Vec::new();
-        serialize::write_message(&mut capnp_bytes, &msg)?;
+        // Build StreamBlock capnp message (shared encoder; also used by the
+        // moq plane in `moq_stream.rs`).
+        let capnp_bytes = encode_stream_block(self.hmac_state.prev_mac_bytes(), &payloads)?;
 
         let mac = self.hmac_state.compute_next(&capnp_bytes);
 
@@ -1832,6 +1797,55 @@ impl StreamGuard {
 // ============================================================================
 // Helpers
 // ============================================================================
+
+/// Encode a `StreamBlock` capnp message from a `prev_mac` + payload list.
+///
+/// Factored out of [`StreamBuilder::flush`] so the moq streaming plane
+/// (`crate::moq_stream`) can produce byte-identical StreamBlocks for the §7.5
+/// chained-HMAC tokenstream.
+pub fn encode_stream_block(
+    prev_mac: &[u8],
+    payloads: &[StreamPayloadData],
+) -> Result<Vec<u8>> {
+    let mut msg = Builder::new_default();
+    {
+        let mut block = msg.init_root::<streaming_capnp::stream_block::Builder>();
+        block.set_prev_mac(prev_mac);
+
+        // Cap'n Proto uses u32 for list lengths
+        let payloads_len = u32::try_from(payloads.len()).unwrap_or(u32::MAX);
+        let mut list = block.init_payloads(payloads_len);
+        for (i, payload) in payloads.iter().enumerate() {
+            let idx = u32::try_from(i).unwrap_or(u32::MAX);
+            let mut p = list.reborrow().get(idx);
+            match payload {
+                StreamPayloadData::Data(data) => {
+                    p.set_data(data);
+                }
+                StreamPayloadData::Error(message) => {
+                    let mut err = p.init_error();
+                    err.set_message(message);
+                    err.set_code("");
+                    err.set_details("");
+                }
+                StreamPayloadData::Complete(data) => {
+                    p.set_complete(data);
+                }
+                StreamPayloadData::Tagged { tag, payload, nonce, key_commitment } => {
+                    let mut tagged = p.init_tagged();
+                    tagged.set_tag(tag);
+                    tagged.set_payload(payload);
+                    tagged.set_nonce(nonce);
+                    tagged.set_key_commitment(key_commitment);
+                }
+            }
+        }
+    }
+
+    let mut capnp_bytes = Vec::new();
+    serialize::write_message(&mut capnp_bytes, &msg)?;
+    Ok(capnp_bytes)
+}
 
 /// Build a StreamRegister message wrapped in SignedEnvelope.
 ///

--- a/crates/hyprstream-rpc/src/transport/in_memory.rs
+++ b/crates/hyprstream-rpc/src/transport/in_memory.rs
@@ -43,6 +43,12 @@ use crate::transport_traits::Transport;
 /// Default ceiling on a single in-process request, mirroring the networked
 /// RPC transport. A wedged co-located handler should surface as a timeout
 /// rather than hanging the caller indefinitely.
+///
+/// Note this deadline also covers *enqueue* latency: `LocalServiceBridge`
+/// forwards over a bounded mpsc, so a saturated bridge can make `send()` block
+/// on the channel and eventually trip this timeout. The error therefore
+/// conflates "handler wedged" with "bridge backpressure" — acceptable for the
+/// transport surface, but not a substitute for a real backpressure signal.
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// In-process RPC transport over an [`IrohRequestProcessor`].

--- a/crates/hyprstream-rpc/src/transport/in_memory.rs
+++ b/crates/hyprstream-rpc/src/transport/in_memory.rs
@@ -1,0 +1,133 @@
+//! In-process RPC transport for co-located services.
+//!
+//! Dials a service running in the *same process* without a network socket.
+//! This is the in-memory dial target the [`crate::dial`] factory selects for
+//! `inproc://` endpoints — the replacement for ZMQ's `inproc://` transport.
+//!
+//! # No second security model
+//!
+//! [`InMemoryTransport::send`] forwards the canonical request bytes to an
+//! [`IrohRequestProcessor`] (in production a
+//! [`LocalServiceBridge`](crate::transport::iroh_rpc::LocalServiceBridge),
+//! which isolates `!Send` `tch`-holding services on a dedicated `LocalSet`
+//! thread and exposes only a `Send` `Bytes`-in/`Bytes`-out surface) and returns
+//! the signed response bytes. The envelope is signed and verified by the exact
+//! same `process_request` path a networked transport uses — co-located calls
+//! skip *serialization to a socket*, never authentication or Casbin authz. This
+//! is behaviourally identical to ZMQ's `inproc://` (serialize once, no socket),
+//! so there is no distinct trust path to review.
+//!
+//! Per the A1 addressing spike, every in-process call goes through the bridge
+//! (one channel hop — the same cost as inproc-ZMQ today). A zero-hop tier that
+//! calls `process_request` directly is inexpressible while `RequestService` is
+//! unconditionally `?Send`; it is a deliberate later follow-up, not part of this
+//! change.
+//!
+//! # RPC plane only
+//!
+//! Like [`SessionRpcTransport`](crate::transport::rpc_session::SessionRpcTransport),
+//! this transport is request-response only; `subscribe`/`publish` bail. The
+//! streaming plane (moq-net) carries SUB/PUB, and in-process streaming is
+//! deferred with the streaming substrate (#134).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Result};
+use async_trait::async_trait;
+use bytes::Bytes;
+
+use crate::transport::rpc_session::{IrohRequestProcessor, RpcPendingStream, RpcPublishStub};
+use crate::transport_traits::Transport;
+
+/// Default ceiling on a single in-process request, mirroring the networked
+/// RPC transport. A wedged co-located handler should surface as a timeout
+/// rather than hanging the caller indefinitely.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// In-process RPC transport over an [`IrohRequestProcessor`].
+///
+/// Cheaply cloneable: holds an `Arc` to the shared processor.
+#[derive(Clone)]
+pub struct InMemoryTransport {
+    processor: Arc<dyn IrohRequestProcessor>,
+}
+
+impl InMemoryTransport {
+    /// Dial a co-located service by its already-resolved request processor.
+    pub fn new(processor: Arc<dyn IrohRequestProcessor>) -> Self {
+        Self { processor }
+    }
+}
+
+#[async_trait]
+impl Transport for InMemoryTransport {
+    type Sub = RpcPendingStream;
+    type Pub = RpcPublishStub;
+
+    async fn send(&self, payload: Vec<u8>, timeout_ms: Option<i32>) -> Result<Vec<u8>> {
+        let timeout = timeout_ms
+            .map(|ms| Duration::from_millis(ms.max(0) as u64))
+            .unwrap_or(DEFAULT_TIMEOUT);
+        let processor = Arc::clone(&self.processor);
+        let fut = async move { processor.process(Bytes::from(payload)).await };
+        let resp = tokio::time::timeout(timeout, fut)
+            .await
+            .map_err(|_| anyhow!("in-process RPC timeout after {timeout:?}"))??;
+        Ok(resp.to_vec())
+    }
+
+    async fn subscribe(&self, _topic: &[u8]) -> Result<Self::Sub> {
+        bail!("in-process RPC transport does not support SUB — streaming moves to moq-net (#134)")
+    }
+
+    async fn publish(&self, _topic: &[u8]) -> Result<Self::Pub> {
+        bail!("in-process RPC transport does not support PUB — streaming moves to moq-net (#134)")
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::transport::rpc_session::from_fn;
+
+    fn echo_processor() -> Arc<dyn IrohRequestProcessor> {
+        Arc::new(from_fn(|req: Bytes| async move { Ok(req) }))
+    }
+
+    #[tokio::test]
+    async fn send_roundtrips_through_processor() {
+        let t = InMemoryTransport::new(echo_processor());
+        let resp = t.send(b"ping".to_vec(), None).await.unwrap();
+        assert_eq!(resp, b"ping");
+    }
+
+    #[tokio::test]
+    async fn subscribe_and_publish_bail() {
+        let t = InMemoryTransport::new(echo_processor());
+        assert!(t.subscribe(b"topic").await.is_err());
+        assert!(t.publish(b"topic").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn slow_processor_times_out() {
+        let slow = Arc::new(from_fn(|req: Bytes| async move {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            Ok(req)
+        }));
+        let t = InMemoryTransport::new(slow);
+        let err = t.send(b"x".to_vec(), Some(20)).await;
+        assert!(err.is_err(), "a handler exceeding the deadline must time out");
+    }
+
+    #[tokio::test]
+    async fn processor_error_propagates() {
+        let failing = Arc::new(from_fn(|_req: Bytes| async move {
+            Err(anyhow!("handler boom"))
+        }));
+        let t = InMemoryTransport::new(failing);
+        let err = t.send(b"x".to_vec(), None).await;
+        assert!(err.is_err());
+    }
+}

--- a/crates/hyprstream-rpc/src/transport/iroh_moq.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_moq.rs
@@ -1,0 +1,265 @@
+//! Iroh streaming plane — moq-lite (`moql` ALPN) protocol handler.
+//!
+//! Part of Epic #131 Phase 3 (#134). This module ships the wire layer for
+//! the streaming plane:
+//!
+//! - [`IrohMoqProtocolHandler`] plugs into [`crate::transport::iroh_substrate`]
+//!   under the `moql` ALPN, wrapping each accepted iroh `Connection` as a
+//!   `web_transport_iroh::Session` and handing it to `moq_net::Server`,
+//!   which spawns the moq-lite session machinery internally.
+//! - One shared [`OriginShared`] (an `OriginProducer` + matching
+//!   `OriginConsumer`) is held by the handler; the *same* origin is used
+//!   for **in-process publishing** (callers obtain it via
+//!   [`IrohMoqProtocolHandler::origin_producer`] and create broadcasts
+//!   directly) **and for external subscribers** — per spike #94's finding,
+//!   `moq_net::Server` does exactly this.
+//!
+//! **Trust model**: §7.5 unchanged. The transport is unauthenticated;
+//! subscribers learn the DH-derived (unguessable) Track path out-of-band
+//! via authenticated RPC (a signed `StreamInfo`), and the per-Frame
+//! payload carries the chained-HMAC envelope. CDN-portability per §10.x
+//! of the Federated Agentic Namespaces doc.
+//!
+//! **What this module does NOT do**: refactor `StreamService` or
+//! `EventService` to use this. That lands in Phase 3 part 2+ along with
+//! the §7.5 chained-HMAC tokenstream port.
+
+use std::sync::Arc;
+
+use iroh::endpoint::Connection;
+use iroh::protocol::{AcceptError, ProtocolHandler};
+use moq_net::{Origin, OriginConsumer, OriginProducer, Server, StatsHandle};
+use tokio_util::sync::CancellationToken;
+use web_transport_iroh::Session;
+
+/// Shared `Origin` clone-pair held by the handler.
+///
+/// - `producer` is what *we* publish into (call `create_broadcast`, `create_track`, etc.).
+/// - `consumer` is what *remote subscribers* read from (handed to `Server::with_publish`).
+///
+/// Both reference the same underlying tree — broadcasts created via
+/// `producer` are visible to remote subscribers consuming via `consumer`.
+#[derive(Clone)]
+pub struct OriginShared {
+    producer: OriginProducer,
+    consumer: OriginConsumer,
+}
+
+impl OriginShared {
+    /// Build a fresh origin pair with a random id.
+    pub fn new() -> Self {
+        let producer = Origin::random().produce();
+        let consumer = producer.consume();
+        Self { producer, consumer }
+    }
+
+    pub fn producer(&self) -> &OriginProducer {
+        &self.producer
+    }
+
+    pub fn consumer(&self) -> &OriginConsumer {
+        &self.consumer
+    }
+}
+
+impl Default for OriginShared {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// iroh `ProtocolHandler` for the `moql` ALPN. Each accepted connection is
+/// wrapped as a `web_transport_iroh::Session` and handed to
+/// `moq_net::Server::accept`, which performs the moq handshake and spawns
+/// the session machinery.
+#[derive(Clone)]
+pub struct IrohMoqProtocolHandler {
+    inner: Arc<HandlerInner>,
+}
+
+struct HandlerInner {
+    origin: OriginShared,
+    stats: StatsHandle,
+    /// Triggered by `ProtocolHandler::shutdown` so accept handlers stop
+    /// waiting for `Session::closed()` and exit promptly.
+    shutdown: CancellationToken,
+}
+
+impl std::fmt::Debug for IrohMoqProtocolHandler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IrohMoqProtocolHandler").finish_non_exhaustive()
+    }
+}
+
+impl IrohMoqProtocolHandler {
+    /// Build with a fresh origin pair (use [`Self::origin_producer`] to
+    /// publish broadcasts).
+    pub fn new() -> Self {
+        Self::with_origin(OriginShared::new())
+    }
+
+    /// Build with a caller-supplied origin pair. Useful when one origin is
+    /// shared across multiple substrates or with an existing service.
+    pub fn with_origin(origin: OriginShared) -> Self {
+        Self {
+            inner: Arc::new(HandlerInner {
+                origin,
+                stats: StatsHandle::default(),
+                shutdown: CancellationToken::new(),
+            }),
+        }
+    }
+
+    /// Borrow the shared origin pair.
+    pub fn origin(&self) -> &OriginShared {
+        &self.inner.origin
+    }
+
+    /// Borrow the producer (for in-process publishing).
+    pub fn origin_producer(&self) -> &OriginProducer {
+        self.inner.origin.producer()
+    }
+
+    /// Borrow the consumer (for in-process subscribing — same data as a
+    /// remote subscriber sees on the wire).
+    pub fn origin_consumer(&self) -> &OriginConsumer {
+        self.inner.origin.consumer()
+    }
+}
+
+impl Default for IrohMoqProtocolHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ProtocolHandler for IrohMoqProtocolHandler {
+    async fn accept(&self, conn: Connection) -> Result<(), AcceptError> {
+        let session = Session::raw(conn);
+        let server = Server::new()
+            .with_publish(self.inner.origin.consumer.clone())
+            // Subscribe slot is None for v1 — we only serve broadcasts;
+            // accepting remote announces (cross-instance fan-out) lands
+            // in Phase 3 part N (#142).
+            .with_stats(self.inner.stats.clone());
+        let moq_session = server
+            .accept(session)
+            .await
+            .map_err(AcceptError::from_err)?;
+
+        // Hold the session alive until either the connection closes or
+        // shutdown is requested. Server::accept has already spawned the
+        // session's pump tasks; dropping `moq_session` tears them down.
+        tokio::select! {
+            biased;
+            _ = self.inner.shutdown.cancelled() => {
+                tracing::debug!("iroh-moq: shutdown signalled, dropping session");
+            }
+            res = moq_session.closed() => {
+                tracing::debug!(result = ?res, "iroh-moq: session closed");
+            }
+        }
+        Ok(())
+    }
+
+    async fn shutdown(&self) {
+        self.inner.shutdown.cancel();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transport::iroh_substrate::{
+        ALPN_MOQ_LITE, IrohSubstrate, NoopHandler,
+    };
+    use bytes::Bytes;
+    use iroh::{EndpointAddr, TransportAddr};
+    use moq_net::{Client, Group, Track};
+    use rand::RngCore;
+
+    fn fresh_key() -> [u8; 32] {
+        let mut k = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut k);
+        k
+    }
+
+    fn direct_addr(substrate: &IrohSubstrate) -> EndpointAddr {
+        EndpointAddr::from_parts(
+            substrate.endpoint_id(),
+            substrate
+                .endpoint()
+                .bound_sockets()
+                .into_iter()
+                .map(TransportAddr::Ip),
+        )
+    }
+
+    /// In-process publisher writes one Frame to a Track on a Broadcast;
+    /// an external subscriber connects over iroh, navigates the same
+    /// broadcast/track path, and reads back the same Frame bytes.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn moq_publish_subscribe_round_trip() -> anyhow::Result<()> {
+        // ─── Server side ──────────────────────────────────────────────
+        let handler = IrohMoqProtocolHandler::new();
+        let producer = handler.origin_producer().clone();
+        let server = IrohSubstrate::new(
+            fresh_key(),
+            handler,
+            NoopHandler::new("rpc-not-wired"),
+        )
+        .await?;
+        let server_addr = direct_addr(&server);
+
+        // Publish a broadcast with one track before the subscriber connects.
+        let mut broadcast = producer
+            .create_broadcast("alice/run-1")
+            .ok_or_else(|| anyhow::anyhow!("create_broadcast denied"))?;
+        let mut track = broadcast.create_track(Track::new("tokens"))?;
+        let mut group = track.create_group(Group::from(0u64))?;
+        group.write_frame(Bytes::from_static(b"hello-moq"))?;
+        drop(group);
+
+        // ─── Client side: connect via iroh, run moq Client to negotiate,
+        // then subscribe to the known broadcast path. ─────────────────
+        let client = IrohSubstrate::new(
+            fresh_key(),
+            NoopHandler::new("c-moq"),
+            NoopHandler::new("c-rpc"),
+        )
+        .await?;
+        let conn = client.connect(server_addr, ALPN_MOQ_LITE).await?;
+        let session = Session::raw(conn);
+        let client_origin: OriginProducer = Origin::random().produce();
+        let client_consumer: OriginConsumer = client_origin.consume();
+        let moq_client = Client::new().with_consume(client_origin);
+        let _moq_session = moq_client.connect(session).await?;
+
+        // Subscribe to alice/run-1 and read the first group's frame.
+        let broadcast_consumer = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            client_consumer.announced_broadcast("alice/run-1"),
+        )
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("broadcast not announced"))?;
+        let mut track_consumer =
+            broadcast_consumer.subscribe_track(&Track::new("tokens"))?;
+        let mut group_consumer = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            track_consumer.next_group(),
+        )
+        .await??
+        .ok_or_else(|| anyhow::anyhow!("next_group returned None"))?;
+        let frame: Bytes = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            group_consumer.read_frame(),
+        )
+        .await??
+        .ok_or_else(|| anyhow::anyhow!("read_frame returned None"))?;
+        assert_eq!(&frame[..], b"hello-moq");
+
+        client.shutdown().await?;
+        server.shutdown().await?;
+        Ok(())
+    }
+}

--- a/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
@@ -1,64 +1,89 @@
 //! Iroh RPC plane — server-side protocol handler for ALPN `hyprstream-rpc/1`.
 //!
-//! Part of Epic #131 Phase 2 (#133). This module ships the wire layer:
+//! Part of Epic #131 Phase 2 (#133). This module ships:
 //!
-//! - A length-prefixed framing over an iroh bidi stream (`accept_bi`/`open_bi`).
-//! - An [`IrohRpcProtocolHandler`] that plugs into [`crate::transport::iroh_substrate`]
-//!   under the `hyprstream-rpc/1` ALPN.
-//! - An [`IrohRequestProcessor`] trait that callers implement to wire actual
+//! - [`IrohRpcProtocolHandler`] — iroh [`ProtocolHandler`] that plugs into
+//!   [`crate::transport::iroh_substrate`] under the `hyprstream-rpc/1` ALPN.
+//!   Enforces a per-connection cap on concurrent streams (DoS bound) and
+//!   drains in-flight requests on `ProtocolHandler::shutdown`.
+//! - [`IrohRequestProcessor`] — trait callers implement to wire actual
 //!   request processing (envelope verification + service dispatch).
+//! - [`LocalServiceBridge`] — adapts a [`crate::service::ZmqService`]
+//!   (potentially `!Send`) to the Send-bounded [`IrohRequestProcessor`].
 //!
-//! **Trust model**: The protocol handler does not verify `SignedEnvelope`
-//! itself — it forwards the raw bytes to the [`IrohRequestProcessor`], which
-//! is where envelope verification, JWT/DPoP checks, and `authorize_signer`
-//! enforcement happen. This matches the ZMTP path's separation of concerns
-//! (`transport::zmtp_quic::process_request`) and keeps the wire dumb.
+//! **Trust model**: The protocol handler does not parse `SignedEnvelope` —
+//! it forwards opaque bytes to the [`IrohRequestProcessor`]. Envelope
+//! verification, JWT/DPoP, and `authorize_signer` enforcement happen inside
+//! the processor (which is `LocalServiceBridge` in production, delegating
+//! to [`crate::transport::zmtp_quic::process_request`]). The handler does
+//! hold a signing key, but uses it only to produce signed error envelopes
+//! when the processor itself returns `Err` (a wire-level failure), so the
+//! client always sees a parseable `ResponseEnvelope` rather than an opaque
+//! EOF + Cap'n Proto parse error.
 //!
-//! **Wire framing**: each message is a 4-byte big-endian length followed by
-//! that many opaque bytes (Cap'n Proto-encoded `SignedEnvelope`). The bidi
-//! stream is request-response: one request frame, one response frame, then
-//! both sides close. No multipart, no ZMTP framing — both endpoints are our
-//! code; iroh's QUIC TLS handles peer authentication at the transport layer.
-//!
-//! **Service integration** lands in a follow-up: the canary `PolicyClient`
-//! port (the rest of #133) wraps the existing `ZmqService` trait — including
-//! the `Rc<S>`/`!Send` constraint for services like inference — behind an
-//! `IrohRequestProcessor` adapter that bridges to a per-service LocalSet.
+//! **Wire framing**: each request is the opaque bytes of a Cap'n Proto-encoded
+//! [`crate::envelope::SignedEnvelope`] written to a freshly-opened iroh bidi
+//! stream. The response is symmetric. Both endpoints are our code; iroh's
+//! QUIC TLS already authenticates the connection peer's Ed25519 NodeId at
+//! the transport layer.
 
 use std::future::Future;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use bytes::Bytes;
+use ed25519_dalek::SigningKey;
 use iroh::endpoint::Connection;
 use iroh::protocol::{AcceptError, ProtocolHandler};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio_util::sync::CancellationToken;
 
-/// Hard cap on inbound message size, to avoid unbounded memory growth from
-/// a misbehaving peer. Matches the ZMTP-over-QUIC server-side cap used in
-/// [`crate::transport::zmtp_quic`].
-const MAX_REQUEST_BYTES: usize = 64 * 1024 * 1024; // 64 MiB
+/// Hard cap on per-frame size (request or response). Mirrors the WebTransport
+/// server-side cap used in [`crate::transport::zmtp_quic`].
+pub const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024; // 64 MiB
+
+/// Default per-connection concurrent-stream cap. Caps memory usage from a
+/// hostile peer to `MAX_FRAME_BYTES × DEFAULT_STREAM_LIMIT` per connection
+/// (4 GiB at defaults). Configurable via [`IrohRpcProtocolHandlerBuilder`].
+pub const DEFAULT_STREAM_LIMIT: usize = 64;
+
+/// Grace period for `SendStream::stopped()` after writing the response — if
+/// the peer crashes without acking the FIN, we don't leak a task forever.
+const STOPPED_GRACE: Duration = Duration::from_secs(5);
+
+// ============================================================================
+// IrohRequestProcessor — pluggable request handling trait
+// ============================================================================
 
 /// Trait implemented by callers to wire actual request processing.
 ///
 /// The processor receives the raw request bytes (a Cap'n Proto-encoded
-/// `SignedEnvelope`) and returns the raw response bytes. Verification,
-/// authorization, and service dispatch all happen inside the implementation.
+/// `SignedEnvelope`) and returns the raw response bytes.
+///
+/// **Contract for `process`**:
+/// - **`Ok(bytes)`** — `bytes` MUST be a valid Cap'n Proto-encoded
+///   `ResponseEnvelope` and is written verbatim to the bidi stream.
+///   Application-layer errors (verification failure, handler error, etc.)
+///   MUST be returned this way as signed error envelopes — the handler
+///   forwards them unchanged.
+/// - **`Err(_)`** — wire-level fatal: the processor cannot produce *any*
+///   response (channel closed during shutdown, etc.). The handler responds
+///   with its own signed error envelope (`request_id = 0`) so the client
+///   sees a parseable error rather than a Cap'n Proto parse failure.
 ///
 /// Implementations MUST be `Send + Sync + 'static` because iroh's accept
 /// loop runs on a multi-threaded tokio runtime. For services that are
-/// `!Send` (e.g. those holding `tch-rs` tensors), implement this trait by
-/// forwarding to a dedicated `LocalSet` via an `mpsc` channel — same
-/// pattern used today for the inference service.
+/// `!Send` (e.g. those holding `tch-rs` tensors), use [`LocalServiceBridge`].
 pub trait IrohRequestProcessor: Send + Sync + 'static {
-    /// Process one request and return the response bytes.
     fn process(
         &self,
         request: Bytes,
     ) -> std::pin::Pin<Box<dyn Future<Output = Result<Bytes>> + Send + '_>>;
 }
 
-/// Convenience: implement [`IrohRequestProcessor`] from a `Send + Sync`
-/// async closure. Useful for tests and simple processors.
+/// Convenience: build an [`IrohRequestProcessor`] from a `Send + Sync`
+/// async closure. Useful for tests.
 pub fn from_fn<F, Fut>(f: F) -> impl IrohRequestProcessor
 where
     F: Fn(Bytes) -> Fut + Send + Sync + 'static,
@@ -80,98 +105,343 @@ where
     FnProcessor(f)
 }
 
+// ============================================================================
+// IrohRpcProtocolHandler — iroh ProtocolHandler with concurrency cap + drain
+// ============================================================================
+
 /// Iroh protocol handler that terminates `hyprstream-rpc/1` bidi streams,
-/// applies length-prefixed framing, and dispatches each request through
-/// the wrapped [`IrohRequestProcessor`].
+/// dispatches each request through the wrapped [`IrohRequestProcessor`],
+/// caps concurrent streams per connection, and drains in-flight requests
+/// on `ProtocolHandler::shutdown` (called by `Router::shutdown`).
 #[derive(Clone)]
 pub struct IrohRpcProtocolHandler {
+    inner: Arc<HandlerInner>,
+}
+
+struct HandlerInner {
     processor: Arc<dyn IrohRequestProcessor>,
+    /// Used to produce signed error envelopes when the processor itself
+    /// returns `Err` (wire-level fatal). Application errors come back from
+    /// the processor pre-wrapped as signed `ResponseEnvelope` bytes.
+    signing_key: SigningKey,
+    /// Caps concurrent bidi streams in flight. Hold one permit per stream.
+    stream_limit: Arc<Semaphore>,
+    stream_limit_capacity: u32,
+    /// Level-triggered shutdown signal: once `cancel()` is called, every
+    /// future and current `cancelled().await` resolves immediately. Used
+    /// instead of `tokio::sync::Notify` because `Notify::notify_waiters`
+    /// is edge-triggered and a shutdown signal landing between accept-loop
+    /// iterations would be lost.
+    shutdown: CancellationToken,
 }
 
 impl std::fmt::Debug for IrohRpcProtocolHandler {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("IrohRpcProtocolHandler").finish_non_exhaustive()
+        f.debug_struct("IrohRpcProtocolHandler")
+            .field("stream_limit", &self.inner.stream_limit_capacity)
+            .finish_non_exhaustive()
     }
 }
 
 impl IrohRpcProtocolHandler {
-    pub fn new<P: IrohRequestProcessor>(processor: P) -> Self {
-        Self {
-            processor: Arc::new(processor),
-        }
+    /// Build a handler with default per-connection stream limit
+    /// ([`DEFAULT_STREAM_LIMIT`]).
+    pub fn new<P: IrohRequestProcessor>(processor: P, signing_key: SigningKey) -> Self {
+        Self::with_stream_limit(Arc::new(processor), signing_key, DEFAULT_STREAM_LIMIT)
     }
 
-    pub fn from_arc(processor: Arc<dyn IrohRequestProcessor>) -> Self {
-        Self { processor }
+    /// Build a handler with an explicit per-connection stream limit.
+    pub fn with_stream_limit(
+        processor: Arc<dyn IrohRequestProcessor>,
+        signing_key: SigningKey,
+        stream_limit: usize,
+    ) -> Self {
+        let stream_limit_capacity = u32::try_from(stream_limit).unwrap_or(u32::MAX);
+        Self {
+            inner: Arc::new(HandlerInner {
+                processor,
+                signing_key,
+                stream_limit: Arc::new(Semaphore::new(stream_limit)),
+                stream_limit_capacity,
+                shutdown: CancellationToken::new(),
+            }),
+        }
     }
 }
 
 impl ProtocolHandler for IrohRpcProtocolHandler {
     async fn accept(&self, conn: Connection) -> Result<(), AcceptError> {
-        // Accept bidi streams on this connection until the peer goes away.
-        // Each stream is one request-response pair, processed concurrently.
         loop {
-            let (mut send, mut recv) = match conn.accept_bi().await {
-                Ok(streams) => streams,
-                Err(e) => {
-                    tracing::debug!(error = ?e, "iroh-rpc: connection closed");
+            tokio::select! {
+                biased;
+                _ = self.inner.shutdown.cancelled() => {
+                    tracing::debug!("iroh-rpc: accept loop cancelled");
                     return Ok(());
                 }
-            };
+                streams = conn.accept_bi() => {
+                    let (send, recv) = match streams {
+                        Ok(pair) => pair,
+                        Err(e) => {
+                            tracing::debug!(error = ?e, "iroh-rpc: connection closed");
+                            return Ok(());
+                        }
+                    };
 
-            let processor = Arc::clone(&self.processor);
-            tokio::spawn(async move {
-                // Read full request (length-prefixed).
-                let request = match recv.read_to_end(MAX_REQUEST_BYTES).await {
-                    Ok(buf) => Bytes::from(buf),
-                    Err(e) => {
-                        tracing::warn!(error = ?e, "iroh-rpc: failed reading request");
-                        return;
-                    }
-                };
+                    // Acquire a permit to cap concurrent streams. If the
+                    // semaphore is closed (shutdown), exit cleanly.
+                    let permit = match Arc::clone(&self.inner.stream_limit).acquire_owned().await {
+                        Ok(p) => p,
+                        Err(_) => return Ok(()),
+                    };
 
-                // Process.
-                let response = match processor.process(request).await {
-                    Ok(bytes) => bytes,
-                    Err(e) => {
-                        tracing::warn!(error = ?e, "iroh-rpc: processor returned error");
-                        // Close the send side without a body; client will see EOF.
-                        let _ = send.finish();
-                        return;
-                    }
-                };
-
-                // Write response.
-                if let Err(e) = send.write_all(&response).await {
-                    tracing::warn!(error = ?e, "iroh-rpc: failed writing response");
-                    return;
+                    let inner = Arc::clone(&self.inner);
+                    tokio::spawn(handle_stream(send, recv, inner, permit));
                 }
-                if let Err(e) = send.finish() {
-                    tracing::warn!(error = ?e, "iroh-rpc: failed finishing send");
-                }
-                // Optional: wait for peer to read.
-                let _ = send.stopped().await;
-            });
+            }
         }
     }
+
+    async fn shutdown(&self) {
+        // Stop the accept loop from taking new streams. Level-triggered:
+        // even if cancel() lands between iterations, the next time the
+        // loop hits `cancelled().await` it returns immediately.
+        self.inner.shutdown.cancel();
+        // Wait for all in-flight streams to release their permits.
+        // `acquire_many` succeeds only once every permit is returned.
+        let cap = self.inner.stream_limit_capacity;
+        match self.inner.stream_limit.acquire_many(cap).await {
+            Ok(permits) => {
+                // Keep permits drained so any post-shutdown accept also
+                // sees a closed semaphore.
+                permits.forget();
+                self.inner.stream_limit.close();
+            }
+            Err(_) => {
+                // Already closed; nothing to drain.
+            }
+        }
+    }
+}
+
+/// Handle one bidi stream end-to-end: read request, dispatch to processor,
+/// write response (or signed error envelope on processor failure).
+async fn handle_stream(
+    mut send: iroh::endpoint::SendStream,
+    mut recv: iroh::endpoint::RecvStream,
+    inner: Arc<HandlerInner>,
+    permit: OwnedSemaphorePermit,
+) {
+    // Permit is released when this function returns.
+    let _permit = permit;
+
+    let request = match recv.read_to_end(MAX_FRAME_BYTES).await {
+        Ok(buf) => Bytes::from(buf),
+        Err(e) => {
+            tracing::warn!(error = ?e, "iroh-rpc: failed reading request");
+            return;
+        }
+    };
+
+    let response = match inner.processor.process(request).await {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            tracing::warn!(error = ?e, "iroh-rpc: processor error, sending stub error envelope");
+            build_error_envelope(&inner.signing_key, &format!("processor error: {e}"))
+        }
+    };
+
+    if let Err(e) = send.write_all(&response).await {
+        tracing::warn!(error = ?e, "iroh-rpc: failed writing response");
+        return;
+    }
+    if let Err(e) = send.finish() {
+        tracing::warn!(error = ?e, "iroh-rpc: failed finishing send");
+        return;
+    }
+    // Wait for the peer to ack the FIN, but cap it so a dead peer can't
+    // leak this task forever.
+    let _ = tokio::time::timeout(STOPPED_GRACE, send.stopped()).await;
+}
+
+/// Build a signed `ResponseEnvelope` (request_id = 0) carrying `message` as
+/// the payload. Used when the processor itself fails — guarantees the client
+/// sees a parseable envelope rather than EOF.
+fn build_error_envelope(signing_key: &SigningKey, message: &str) -> Bytes {
+    use crate::ToCapnp;
+    use capnp::{message::Builder, serialize};
+    let envelope =
+        crate::envelope::ResponseEnvelope::new_signed(0, message.as_bytes().to_vec(), signing_key);
+    let mut msg = Builder::new_default();
+    {
+        let mut builder = msg.init_root::<crate::common_capnp::response_envelope::Builder>();
+        envelope.write_to(&mut builder);
+    }
+    let mut bytes = Vec::new();
+    if let Err(e) = serialize::write_message(&mut bytes, &msg) {
+        // Last-ditch: if even this fails, return empty bytes — client will
+        // see Cap'n Proto parse error, which is no worse than the original
+        // behaviour. This should be unreachable in practice.
+        tracing::error!(error = ?e, "iroh-rpc: failed serializing error envelope");
+        return Bytes::new();
+    }
+    Bytes::from(bytes)
 }
 
 /// Client-side helper: open a bidi stream on `hyprstream-rpc/1` against an
 /// already-connected iroh [`Connection`], write the request, read the response.
 ///
-/// This is a primitive — the real per-service RPC clients (generated by
-/// `hyprstream_rpc_derive::generate_rpc_service!`) will wrap it with their
-/// own envelope construction and response decoding. Used directly only in
-/// tests during Phase 2.
+/// Primitive used by tests and internally by
+/// [`super::iroh_transport::IrohTransport`] — production callers should
+/// construct an `IrohTransport` + [`crate::rpc_client::RpcClientImpl`] instead.
 pub async fn client_request(conn: &Connection, request: &[u8]) -> Result<Bytes> {
     let (mut send, mut recv) = conn.open_bi().await.context("open_bi")?;
     send.write_all(request).await.context("write request")?;
     send.finish().context("finish send")?;
     let buf = recv
-        .read_to_end(MAX_REQUEST_BYTES)
+        .read_to_end(MAX_FRAME_BYTES)
         .await
         .context("read response")?;
     Ok(Bytes::from(buf))
+}
+
+// ============================================================================
+// LocalServiceBridge — adapt a (possibly `!Send`) ZmqService to the Send-bound
+// IrohRequestProcessor trait by running the service on a dedicated LocalSet
+// thread and forwarding requests over an mpsc channel.
+// ============================================================================
+
+/// Per-request payload + response slot exchanged with the bridge thread.
+struct BridgeMessage {
+    request: Bytes,
+    respond: tokio::sync::oneshot::Sender<Result<Bytes>>,
+}
+
+/// Adapt a [`crate::service::ZmqService`] to [`IrohRequestProcessor`].
+///
+/// Spins up a dedicated thread running a single-threaded tokio runtime with
+/// a `LocalSet`. The service runs on that thread (compatible with both `Send`
+/// and `!Send` services like inference); requests arriving on the iroh accept
+/// loop are forwarded via an `mpsc` channel and awaited via `oneshot`.
+///
+/// **Lifecycle**: in-flight requests are drained when the
+/// [`IrohRpcProtocolHandler`] holding this bridge is shut down via
+/// `Router::shutdown` (each in-flight handler task holds a semaphore permit;
+/// the handler's drain waits for all permits to return, which only happens
+/// once the bridge has produced each response). After that, dropping the
+/// last `Arc<LocalServiceBridge>` closes the mpsc Sender, the bridge thread
+/// exits its receive loop, and `LocalSet::block_on` returns.
+pub struct LocalServiceBridge {
+    tx: tokio::sync::mpsc::Sender<BridgeMessage>,
+}
+
+impl LocalServiceBridge {
+    /// Spawn a dedicated bridge thread that owns `service` and forwards
+    /// requests through [`crate::transport::zmtp_quic::process_request`].
+    ///
+    /// The response signing key is taken from `service.signing_key()` — there
+    /// is no separate parameter to avoid drift between the service's identity
+    /// and the key used to sign responses.
+    ///
+    /// `queue_depth` is the mpsc channel capacity — backpressure point when
+    /// the bridge falls behind. Pass `0` for default (128).
+    pub fn spawn<S>(
+        service: S,
+        nonce_cache: Arc<crate::envelope::InMemoryNonceCache>,
+        queue_depth: usize,
+    ) -> Result<Self>
+    where
+        S: crate::service::ZmqService + Send + 'static,
+    {
+        let cap = if queue_depth == 0 { 128 } else { queue_depth };
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<BridgeMessage>(cap);
+        let service_name = service.name().to_owned();
+
+        std::thread::Builder::new()
+            .name(format!("iroh-rpc-bridge:{service_name}"))
+            .spawn(move || {
+                let rt = match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(rt) => rt,
+                    Err(e) => {
+                        tracing::error!(error = ?e, "bridge: failed to build runtime");
+                        return;
+                    }
+                };
+                let local = tokio::task::LocalSet::new();
+                local.spawn_local(async move {
+                    let service = std::rc::Rc::new(service);
+                    while let Some(msg) = rx.recv().await {
+                        let service = std::rc::Rc::clone(&service);
+                        let nonce_cache = Arc::clone(&nonce_cache);
+                        // Each request gets its own local task so a slow
+                        // handler doesn't head-of-line the queue.
+                        tokio::task::spawn_local(async move {
+                            // Re-derive the signing key per call: cheap clone,
+                            // tracks any future rotation in the service.
+                            let signing_key = service.signing_key();
+                            let result = crate::transport::zmtp_quic::process_request(
+                                msg.request.as_ref(),
+                                &*service,
+                                crate::envelope::EnvelopeVerification::AnySigner,
+                                &signing_key,
+                                &nonce_cache,
+                            )
+                            .await
+                            .and_then(|(bytes, cont)| {
+                                // Streaming continuations are not wired on
+                                // the iroh RPC plane — streaming moves to
+                                // moq-net (`moql` ALPN, Phase 3, #134). In
+                                // debug, panic loudly; in release, return an
+                                // error so the wire emits a signed error
+                                // envelope (handler's build_error_envelope)
+                                // rather than silently dropping the stream.
+                                if cont.is_some() {
+                                    debug_assert!(
+                                        false,
+                                        "iroh-rpc bridge: streaming continuation not supported \
+                                         — wait for Phase 3 (#134)"
+                                    );
+                                    return Err(anyhow::anyhow!(
+                                        "iroh-rpc bridge: service returned a streaming \
+                                         continuation, which is not supported on the iroh \
+                                         RPC plane (Phase 3 / #134 moves streaming to moq-net)"
+                                    ));
+                                }
+                                Ok(Bytes::from(bytes))
+                            });
+                            let _ = msg.respond.send(result);
+                        });
+                    }
+                });
+                rt.block_on(local);
+            })
+            .map_err(|e| anyhow::anyhow!("spawn iroh-rpc bridge thread: {e}"))?;
+
+        Ok(Self { tx })
+    }
+}
+
+impl IrohRequestProcessor for LocalServiceBridge {
+    fn process(
+        &self,
+        request: Bytes,
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<Bytes>> + Send + '_>> {
+        let tx = self.tx.clone();
+        Box::pin(async move {
+            let (respond_tx, respond_rx) = tokio::sync::oneshot::channel();
+            tx.send(BridgeMessage {
+                request,
+                respond: respond_tx,
+            })
+            .await
+            .map_err(|_| anyhow::anyhow!("iroh-rpc bridge: channel closed"))?;
+            respond_rx
+                .await
+                .map_err(|_| anyhow::anyhow!("iroh-rpc bridge: response dropped"))?
+        })
+    }
 }
 
 #[cfg(test)]
@@ -189,6 +459,10 @@ mod tests {
         k
     }
 
+    fn fresh_signing_key() -> SigningKey {
+        SigningKey::from_bytes(&fresh_key())
+    }
+
     fn direct_addr(substrate: &IrohSubstrate) -> EndpointAddr {
         EndpointAddr::from_parts(
             substrate.endpoint_id(),
@@ -200,9 +474,6 @@ mod tests {
         )
     }
 
-    /// End-to-end: server runs an `IrohRpcProtocolHandler` wired to a
-    /// closure-based processor that prepends a magic byte to the request,
-    /// client sends one request and reads the response.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn rpc_request_response_round_trip() -> Result<()> {
         let processor = from_fn(|req: Bytes| async move {
@@ -211,14 +482,10 @@ mod tests {
             out.extend_from_slice(&req);
             Ok(Bytes::from(out))
         });
-        let rpc_handler = IrohRpcProtocolHandler::new(processor);
+        let rpc_handler = IrohRpcProtocolHandler::new(processor, fresh_signing_key());
 
-        let server = IrohSubstrate::new(
-            fresh_key(),
-            NoopHandler::new("moq-not-wired"),
-            rpc_handler,
-        )
-        .await?;
+        let server =
+            IrohSubstrate::new(fresh_key(), NoopHandler::new("moq-not-wired"), rpc_handler).await?;
         let server_addr = direct_addr(&server);
 
         let client = IrohSubstrate::new(
@@ -228,13 +495,10 @@ mod tests {
         )
         .await?;
 
-        let conn = client
-            .connect(server_addr, ALPN_HYPRSTREAM_RPC)
-            .await?;
+        let conn = client.connect(server_addr, ALPN_HYPRSTREAM_RPC).await?;
         let resp = client_request(&conn, b"ping").await?;
         assert_eq!(&resp[..], b"\xABping");
 
-        // Sanity: moq ALPN still routes to the noop handler (does not crash).
         let conn2 = client.connect(direct_addr(&server), ALPN_MOQ_LITE).await?;
         drop(conn2);
 
@@ -243,12 +507,9 @@ mod tests {
         Ok(())
     }
 
-    /// Multiple concurrent requests on the same connection round-trip
-    /// independently and arrive at the correct caller.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn rpc_concurrent_requests() -> Result<()> {
         let processor = from_fn(|req: Bytes| async move {
-            // Echo with a trailing marker so we can verify correlation.
             let mut out = req.to_vec();
             out.push(b'!');
             Ok(Bytes::from(out))
@@ -256,7 +517,7 @@ mod tests {
         let server = IrohSubstrate::new(
             fresh_key(),
             NoopHandler::new("moq"),
-            IrohRpcProtocolHandler::new(processor),
+            IrohRpcProtocolHandler::new(processor, fresh_signing_key()),
         )
         .await?;
         let server_addr = direct_addr(&server);
@@ -267,11 +528,7 @@ mod tests {
             NoopHandler::new("c-rpc"),
         )
         .await?;
-        let conn = Arc::new(
-            client
-                .connect(server_addr, ALPN_HYPRSTREAM_RPC)
-                .await?,
-        );
+        let conn = Arc::new(client.connect(server_addr, ALPN_HYPRSTREAM_RPC).await?);
 
         let mut handles = Vec::new();
         for i in 0..8u8 {
@@ -288,6 +545,160 @@ mod tests {
 
         client.shutdown().await?;
         server.shutdown().await?;
+        Ok(())
+    }
+
+    /// Processor returns `Err` → client gets a parseable signed
+    /// `ResponseEnvelope` carrying the error message (request_id = 0), not
+    /// an opaque EOF / Cap'n Proto parse failure. (Fix for review finding #4.)
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rpc_processor_error_yields_parseable_envelope() -> Result<()> {
+        let server_signing = fresh_signing_key();
+        let server_vk = server_signing.verifying_key();
+
+        let processor =
+            from_fn(|_req: Bytes| async move { Err(anyhow::anyhow!("boom from processor")) });
+        let handler = IrohRpcProtocolHandler::new(processor, server_signing);
+
+        let server = IrohSubstrate::new(fresh_key(), NoopHandler::new("moq"), handler).await?;
+        let server_addr = direct_addr(&server);
+
+        let client = IrohSubstrate::new(
+            fresh_key(),
+            NoopHandler::new("c-moq"),
+            NoopHandler::new("c-rpc"),
+        )
+        .await?;
+        let conn = client.connect(server_addr, ALPN_HYPRSTREAM_RPC).await?;
+
+        // Send any bytes; the processor will Err regardless. The interesting
+        // assertion is what comes back: a verifiable ResponseEnvelope.
+        let resp_bytes = client_request(&conn, b"anything").await?;
+        let (request_id, payload) = crate::envelope::unwrap_response(&resp_bytes, Some(&server_vk))?;
+        assert_eq!(request_id, 0, "error envelope uses request_id=0");
+        let body = std::str::from_utf8(&payload)?;
+        assert!(body.contains("boom from processor"), "got: {body}");
+
+        client.shutdown().await?;
+        server.shutdown().await?;
+        Ok(())
+    }
+
+    /// Concurrency cap is enforced: with a stream_limit of 2, a third
+    /// concurrent slow request must wait for one of the first two to finish.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rpc_stream_limit_enforced() -> Result<()> {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let in_flight_c = Arc::clone(&in_flight);
+        let peak_c = Arc::clone(&peak);
+
+        let processor = from_fn(move |_req: Bytes| {
+            let in_flight = Arc::clone(&in_flight_c);
+            let peak = Arc::clone(&peak_c);
+            async move {
+                let cur = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                // Update peak.
+                let mut p = peak.load(Ordering::SeqCst);
+                while cur > p {
+                    match peak.compare_exchange_weak(p, cur, Ordering::SeqCst, Ordering::SeqCst) {
+                        Ok(_) => break,
+                        Err(prev) => p = prev,
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(200)).await;
+                in_flight.fetch_sub(1, Ordering::SeqCst);
+                Ok(Bytes::from_static(b"ok"))
+            }
+        });
+        let handler = IrohRpcProtocolHandler::with_stream_limit(
+            Arc::new(processor),
+            fresh_signing_key(),
+            2,
+        );
+
+        let server = IrohSubstrate::new(fresh_key(), NoopHandler::new("moq"), handler).await?;
+        let server_addr = direct_addr(&server);
+
+        let client = IrohSubstrate::new(
+            fresh_key(),
+            NoopHandler::new("c-moq"),
+            NoopHandler::new("c-rpc"),
+        )
+        .await?;
+        let conn = Arc::new(client.connect(server_addr, ALPN_HYPRSTREAM_RPC).await?);
+
+        let mut handles = Vec::new();
+        for _ in 0..6 {
+            let conn = Arc::clone(&conn);
+            handles.push(tokio::spawn(async move {
+                let _ = client_request(&conn, b"x").await?;
+                anyhow::Ok(())
+            }));
+        }
+        for h in handles {
+            h.await??;
+        }
+
+        assert!(
+            peak.load(Ordering::SeqCst) <= 2,
+            "stream_limit=2 violated, observed peak={}",
+            peak.load(Ordering::SeqCst)
+        );
+
+        client.shutdown().await?;
+        server.shutdown().await?;
+        Ok(())
+    }
+
+    /// `Router::shutdown` (via `IrohSubstrate::shutdown`) drains in-flight
+    /// requests before returning — a request in-progress when shutdown
+    /// starts still gets a clean response. (Fix for review round-1 #1.)
+    ///
+    /// Uses an explicit `Notify` to synchronise "processor has entered the
+    /// long sleep" with "now safe to shut down" — replaces the previous
+    /// 50ms `tokio::sleep` that was flaky on loaded CI runners.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rpc_shutdown_drains_in_flight() -> Result<()> {
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let entered_c = Arc::clone(&entered);
+        let processor = from_fn(move |_req: Bytes| {
+            let entered = Arc::clone(&entered_c);
+            async move {
+                entered.notify_one();
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                Ok(Bytes::from_static(b"drained-ok"))
+            }
+        });
+        let handler = IrohRpcProtocolHandler::new(processor, fresh_signing_key());
+
+        let server = IrohSubstrate::new(fresh_key(), NoopHandler::new("moq"), handler).await?;
+        let server_addr = direct_addr(&server);
+
+        let client = IrohSubstrate::new(
+            fresh_key(),
+            NoopHandler::new("c-moq"),
+            NoopHandler::new("c-rpc"),
+        )
+        .await?;
+        let conn = client.connect(server_addr, ALPN_HYPRSTREAM_RPC).await?;
+
+        let req_task = {
+            let conn = conn.clone();
+            tokio::spawn(async move { client_request(&conn, b"slow").await })
+        };
+
+        // Synchronise: wait until the processor signals it has entered the
+        // sleep, *then* shut down. No wall-clock guesses.
+        entered.notified().await;
+        server.shutdown().await?;
+
+        let resp = req_task.await??;
+        assert_eq!(&resp[..], b"drained-ok");
+
+        client.shutdown().await?;
         Ok(())
     }
 }

--- a/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
@@ -8,7 +8,7 @@
 //!   drains in-flight requests on `ProtocolHandler::shutdown`.
 //! - [`IrohRequestProcessor`] — trait callers implement to wire actual
 //!   request processing (envelope verification + service dispatch).
-//! - [`LocalServiceBridge`] — adapts a [`crate::service::ZmqService`]
+//! - [`LocalServiceBridge`] — adapts a [`crate::service::RequestService`]
 //!   (potentially `!Send`) to the Send-bounded [`IrohRequestProcessor`].
 //!
 //! **Trust model**: The protocol handler does not parse `SignedEnvelope` —
@@ -212,7 +212,7 @@ pub async fn client_request(conn: &Connection, request: &[u8]) -> Result<Bytes> 
 }
 
 // ============================================================================
-// LocalServiceBridge — adapt a (possibly `!Send`) ZmqService to the Send-bound
+// LocalServiceBridge — adapt a (possibly `!Send`) RequestService to the Send-bound
 // IrohRequestProcessor trait by running the service on a dedicated LocalSet
 // thread and forwarding requests over an mpsc channel.
 // ============================================================================
@@ -223,7 +223,7 @@ struct BridgeMessage {
     respond: tokio::sync::oneshot::Sender<Result<Bytes>>,
 }
 
-/// Adapt a [`crate::service::ZmqService`] to [`IrohRequestProcessor`].
+/// Adapt a [`crate::service::RequestService`] to [`IrohRequestProcessor`].
 ///
 /// Spins up a dedicated thread running a single-threaded tokio runtime with
 /// a `LocalSet`. The service runs on that thread (compatible with both `Send`
@@ -257,7 +257,7 @@ impl LocalServiceBridge {
         queue_depth: usize,
     ) -> Result<Self>
     where
-        S: crate::service::ZmqService + Send + 'static,
+        S: crate::service::RequestService + Send + 'static,
     {
         let cap = if queue_depth == 0 { 128 } else { queue_depth };
         let (tx, mut rx) = tokio::sync::mpsc::channel::<BridgeMessage>(cap);

--- a/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
@@ -29,81 +29,21 @@
 
 use std::future::Future;
 use std::sync::Arc;
-use std::time::Duration;
 
 use anyhow::{Context, Result};
 use bytes::Bytes;
 use ed25519_dalek::SigningKey;
 use iroh::endpoint::Connection;
 use iroh::protocol::{AcceptError, ProtocolHandler};
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 
-/// Hard cap on per-frame size (request or response). Mirrors the WebTransport
-/// server-side cap used in [`crate::transport::zmtp_quic`].
-pub const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024; // 64 MiB
-
-/// Default per-connection concurrent-stream cap. Caps memory usage from a
-/// hostile peer to `MAX_FRAME_BYTES × DEFAULT_STREAM_LIMIT` per connection
-/// (4 GiB at defaults). Configurable via [`IrohRpcProtocolHandlerBuilder`].
-pub const DEFAULT_STREAM_LIMIT: usize = 64;
-
-/// Grace period for `SendStream::stopped()` after writing the response — if
-/// the peer crashes without acking the FIN, we don't leak a task forever.
-const STOPPED_GRACE: Duration = Duration::from_secs(5);
-
-// ============================================================================
-// IrohRequestProcessor — pluggable request handling trait
-// ============================================================================
-
-/// Trait implemented by callers to wire actual request processing.
-///
-/// The processor receives the raw request bytes (a Cap'n Proto-encoded
-/// `SignedEnvelope`) and returns the raw response bytes.
-///
-/// **Contract for `process`**:
-/// - **`Ok(bytes)`** — `bytes` MUST be a valid Cap'n Proto-encoded
-///   `ResponseEnvelope` and is written verbatim to the bidi stream.
-///   Application-layer errors (verification failure, handler error, etc.)
-///   MUST be returned this way as signed error envelopes — the handler
-///   forwards them unchanged.
-/// - **`Err(_)`** — wire-level fatal: the processor cannot produce *any*
-///   response (channel closed during shutdown, etc.). The handler responds
-///   with its own signed error envelope (`request_id = 0`) so the client
-///   sees a parseable error rather than a Cap'n Proto parse failure.
-///
-/// Implementations MUST be `Send + Sync + 'static` because iroh's accept
-/// loop runs on a multi-threaded tokio runtime. For services that are
-/// `!Send` (e.g. those holding `tch-rs` tensors), use [`LocalServiceBridge`].
-pub trait IrohRequestProcessor: Send + Sync + 'static {
-    fn process(
-        &self,
-        request: Bytes,
-    ) -> std::pin::Pin<Box<dyn Future<Output = Result<Bytes>> + Send + '_>>;
-}
-
-/// Convenience: build an [`IrohRequestProcessor`] from a `Send + Sync`
-/// async closure. Useful for tests.
-pub fn from_fn<F, Fut>(f: F) -> impl IrohRequestProcessor
-where
-    F: Fn(Bytes) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = Result<Bytes>> + Send + 'static,
-{
-    struct FnProcessor<F>(F);
-    impl<F, Fut> IrohRequestProcessor for FnProcessor<F>
-    where
-        F: Fn(Bytes) -> Fut + Send + Sync + 'static,
-        Fut: Future<Output = Result<Bytes>> + Send + 'static,
-    {
-        fn process(
-            &self,
-            request: Bytes,
-        ) -> std::pin::Pin<Box<dyn Future<Output = Result<Bytes>> + Send + '_>> {
-            Box::pin((self.0)(request))
-        }
-    }
-    FnProcessor(f)
-}
+// Transport-generic core lives in `super::rpc_session`. Re-export the shared
+// surface from here so existing `iroh_rpc::{...}` imports keep working.
+pub use super::rpc_session::{
+    DEFAULT_STREAM_LIMIT, IrohRequestProcessor, MAX_FRAME_BYTES, build_error_envelope, from_fn,
+    read_to_cap, serve_rpc_connection,
+};
 
 // ============================================================================
 // IrohRpcProtocolHandler — iroh ProtocolHandler with concurrency cap + drain
@@ -171,34 +111,19 @@ impl IrohRpcProtocolHandler {
 
 impl ProtocolHandler for IrohRpcProtocolHandler {
     async fn accept(&self, conn: Connection) -> Result<(), AcceptError> {
-        loop {
-            tokio::select! {
-                biased;
-                _ = self.inner.shutdown.cancelled() => {
-                    tracing::debug!("iroh-rpc: accept loop cancelled");
-                    return Ok(());
-                }
-                streams = conn.accept_bi() => {
-                    let (send, recv) = match streams {
-                        Ok(pair) => pair,
-                        Err(e) => {
-                            tracing::debug!(error = ?e, "iroh-rpc: connection closed");
-                            return Ok(());
-                        }
-                    };
-
-                    // Acquire a permit to cap concurrent streams. If the
-                    // semaphore is closed (shutdown), exit cleanly.
-                    let permit = match Arc::clone(&self.inner.stream_limit).acquire_owned().await {
-                        Ok(p) => p,
-                        Err(_) => return Ok(()),
-                    };
-
-                    let inner = Arc::clone(&self.inner);
-                    tokio::spawn(handle_stream(send, recv, inner, permit));
-                }
-            }
-        }
+        // Adapt the raw iroh `Connection` to the transport-generic `Session`
+        // abstraction and delegate to the shared accept loop. Drain semantics
+        // (`shutdown` below draining the same `Semaphore`) are unchanged.
+        let session = web_transport_iroh::Session::raw(conn);
+        serve_rpc_connection(
+            session,
+            Arc::clone(&self.inner.processor),
+            self.inner.signing_key.clone(),
+            Arc::clone(&self.inner.stream_limit),
+            self.inner.shutdown.clone(),
+        )
+        .await
+        .map_err(|e| AcceptError::from_err(std::io::Error::other(e.to_string())))
     }
 
     async fn shutdown(&self) {
@@ -221,70 +146,6 @@ impl ProtocolHandler for IrohRpcProtocolHandler {
             }
         }
     }
-}
-
-/// Handle one bidi stream end-to-end: read request, dispatch to processor,
-/// write response (or signed error envelope on processor failure).
-async fn handle_stream(
-    mut send: iroh::endpoint::SendStream,
-    mut recv: iroh::endpoint::RecvStream,
-    inner: Arc<HandlerInner>,
-    permit: OwnedSemaphorePermit,
-) {
-    // Permit is released when this function returns.
-    let _permit = permit;
-
-    let request = match recv.read_to_end(MAX_FRAME_BYTES).await {
-        Ok(buf) => Bytes::from(buf),
-        Err(e) => {
-            tracing::warn!(error = ?e, "iroh-rpc: failed reading request");
-            return;
-        }
-    };
-
-    let response = match inner.processor.process(request).await {
-        Ok(bytes) => bytes,
-        Err(e) => {
-            tracing::warn!(error = ?e, "iroh-rpc: processor error, sending stub error envelope");
-            build_error_envelope(&inner.signing_key, &format!("processor error: {e}"))
-        }
-    };
-
-    if let Err(e) = send.write_all(&response).await {
-        tracing::warn!(error = ?e, "iroh-rpc: failed writing response");
-        return;
-    }
-    if let Err(e) = send.finish() {
-        tracing::warn!(error = ?e, "iroh-rpc: failed finishing send");
-        return;
-    }
-    // Wait for the peer to ack the FIN, but cap it so a dead peer can't
-    // leak this task forever.
-    let _ = tokio::time::timeout(STOPPED_GRACE, send.stopped()).await;
-}
-
-/// Build a signed `ResponseEnvelope` (request_id = 0) carrying `message` as
-/// the payload. Used when the processor itself fails — guarantees the client
-/// sees a parseable envelope rather than EOF.
-fn build_error_envelope(signing_key: &SigningKey, message: &str) -> Bytes {
-    use crate::ToCapnp;
-    use capnp::{message::Builder, serialize};
-    let envelope =
-        crate::envelope::ResponseEnvelope::new_signed(0, message.as_bytes().to_vec(), signing_key);
-    let mut msg = Builder::new_default();
-    {
-        let mut builder = msg.init_root::<crate::common_capnp::response_envelope::Builder>();
-        envelope.write_to(&mut builder);
-    }
-    let mut bytes = Vec::new();
-    if let Err(e) = serialize::write_message(&mut bytes, &msg) {
-        // Last-ditch: if even this fails, return empty bytes — client will
-        // see Cap'n Proto parse error, which is no worse than the original
-        // behaviour. This should be unreachable in practice.
-        tracing::error!(error = ?e, "iroh-rpc: failed serializing error envelope");
-        return Bytes::new();
-    }
-    Bytes::from(bytes)
 }
 
 /// Client-side helper: open a bidi stream on `hyprstream-rpc/1` against an
@@ -452,6 +313,7 @@ mod tests {
     };
     use iroh::{EndpointAddr, TransportAddr};
     use rand::RngCore;
+    use std::time::Duration;
 
     fn fresh_key() -> [u8; 32] {
         let mut k = [0u8; 32];

--- a/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
@@ -288,6 +288,14 @@ impl LocalServiceBridge {
                             // Re-derive the signing key per call: cheap clone,
                             // tracks any future rotation in the service.
                             let signing_key = service.signing_key();
+                            // As of #186 process_request spawns any streaming
+                            // pump itself (onto this bridge's LocalSet, where
+                            // this task already runs, bounded by a per-service
+                            // admission permit) and returns only the reply bytes,
+                            // so the generic plane is uniform "bytes in → bytes
+                            // out" like every other front-end. (Previously the
+                            // bridge spawned the continuation here; that worked
+                            // but duplicated the spawn logic per transport.)
                             let result = crate::service::dispatch::process_request(
                                 msg.request.as_ref(),
                                 &*service,
@@ -296,20 +304,7 @@ impl LocalServiceBridge {
                                 &nonce_cache,
                             )
                             .await
-                            .map(|(bytes, cont)| {
-                                // The continuation is the streaming pump — it
-                                // publishes to the moq/notification plane,
-                                // independent of the RPC transport — so spawn it
-                                // on this bridge LocalSet after the response,
-                                // exactly as RequestLoop / WebTransportServer do.
-                                // (Without this, streaming services like model /
-                                // tui would have their continuation dropped and
-                                // the stream would never be served.)
-                                if let Some(cont) = cont {
-                                    tokio::task::spawn_local(cont);
-                                }
-                                Bytes::from(bytes)
-                            });
+                            .map(Bytes::from);
                             let _ = msg.respond.send(result);
                         });
                     }
@@ -378,6 +373,8 @@ impl LocalServiceBridge {
                         let nonce_cache = Arc::clone(&nonce_cache);
                         tokio::task::spawn_local(async move {
                             let signing_key = service.signing_key();
+                            // process_request spawns any streaming pump itself
+                            // (#186); the bridge just relays the reply bytes.
                             let result = crate::service::dispatch::process_request(
                                 msg.request.as_ref(),
                                 &*service,
@@ -386,14 +383,7 @@ impl LocalServiceBridge {
                                 &nonce_cache,
                             )
                             .await
-                            .map(|(bytes, cont)| {
-                                // Spawn the streaming pump on this bridge LocalSet
-                                // (see spawn() for the rationale).
-                                if let Some(cont) = cont {
-                                    tokio::task::spawn_local(cont);
-                                }
-                                Bytes::from(bytes)
-                            });
+                            .map(Bytes::from);
                             let _ = msg.respond.send(result);
                         });
                     }

--- a/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
@@ -328,6 +328,91 @@ impl LocalServiceBridge {
 
         Ok(Self { tx })
     }
+
+    /// Like [`LocalServiceBridge::spawn`], but constructs the service ON the
+    /// bridge thread via the async `build` closure. For services whose
+    /// construction is itself `!Send` or async (e.g. GPU init that must happen on
+    /// the serve thread, like `InferenceService`): the built service value never
+    /// has to be `Send`-moved across threads — only the builder's captured inputs
+    /// do (`F: Send`), and the `!Send` result lives only on the bridge thread.
+    ///
+    /// Returns the bridge plus a readiness receiver that resolves once `build`
+    /// completes: `Ok(())` when the service is built and serving, or the build
+    /// error. Callers MUST await it before advertising the service (a build
+    /// failure otherwise surfaces only as "channel closed" on the first request).
+    pub fn spawn_with<F, Fut, S>(
+        thread_name: impl Into<String>,
+        build: F,
+        nonce_cache: Arc<crate::envelope::InMemoryNonceCache>,
+        queue_depth: usize,
+    ) -> Result<(Self, tokio::sync::oneshot::Receiver<Result<()>>)>
+    where
+        F: FnOnce() -> Fut + Send + 'static,
+        Fut: Future<Output = Result<S>>,
+        S: crate::service::RequestService + 'static,
+    {
+        let cap = if queue_depth == 0 { 128 } else { queue_depth };
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<BridgeMessage>(cap);
+        let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<Result<()>>();
+        let thread_name = thread_name.into();
+
+        std::thread::Builder::new()
+            .name(format!("rpc-bridge:{thread_name}"))
+            .spawn(move || {
+                let rt = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
+                    Ok(rt) => rt,
+                    Err(e) => {
+                        let _ = ready_tx.send(Err(anyhow::anyhow!("bridge runtime: {e}")));
+                        return;
+                    }
+                };
+                let local = tokio::task::LocalSet::new();
+                local.spawn_local(async move {
+                    // Build on-thread; a failure (e.g. GPU init) is reported via
+                    // the readiness channel and the bridge thread exits.
+                    let service = match build().await {
+                        Ok(s) => std::rc::Rc::new(s),
+                        Err(e) => {
+                            let _ = ready_tx.send(Err(e));
+                            return;
+                        }
+                    };
+                    if ready_tx.send(Ok(())).is_err() {
+                        // Caller gave up waiting; no point serving.
+                        return;
+                    }
+                    while let Some(msg) = rx.recv().await {
+                        let service = std::rc::Rc::clone(&service);
+                        let nonce_cache = Arc::clone(&nonce_cache);
+                        tokio::task::spawn_local(async move {
+                            let signing_key = service.signing_key();
+                            let result = crate::service::dispatch::process_request(
+                                msg.request.as_ref(),
+                                &*service,
+                                crate::envelope::EnvelopeVerification::AnySigner,
+                                &signing_key,
+                                &nonce_cache,
+                            )
+                            .await
+                            .and_then(|(bytes, cont)| {
+                                if cont.is_some() {
+                                    return Err(anyhow::anyhow!(
+                                        "rpc bridge: streaming continuation unsupported \
+                                         (streaming is on the moq plane, #134)"
+                                    ));
+                                }
+                                Ok(Bytes::from(bytes))
+                            });
+                            let _ = msg.respond.send(result);
+                        });
+                    }
+                });
+                rt.block_on(local);
+            })
+            .map_err(|e| anyhow::anyhow!("spawn rpc bridge thread: {e}"))?;
+
+        Ok((Self { tx }, ready_rx))
+    }
 }
 
 impl IrohRequestProcessor for LocalServiceBridge {
@@ -380,6 +465,78 @@ mod tests {
                 .into_iter()
                 .map(TransportAddr::Ip),
         )
+    }
+
+    /// Minimal `RequestService` for `spawn_with` tests.
+    struct BridgeEcho {
+        name: String,
+        ctx: Arc<zmq::Context>,
+        transport: crate::transport::TransportConfig,
+        signing_key: SigningKey,
+    }
+    impl BridgeEcho {
+        fn new(signing_key: SigningKey) -> Self {
+            Self {
+                name: "bridge-echo".to_owned(),
+                ctx: Arc::new(zmq::Context::new()),
+                transport: crate::transport::TransportConfig::inproc("bridge-echo-unused"),
+                signing_key,
+            }
+        }
+    }
+    #[async_trait::async_trait(?Send)]
+    impl crate::service::RequestService for BridgeEcho {
+        async fn handle_request(
+            &self,
+            _ctx: &crate::service::EnvelopeContext,
+            payload: &[u8],
+        ) -> Result<(Vec<u8>, Option<crate::service::Continuation>)> {
+            let mut out = vec![0xBE];
+            out.extend_from_slice(payload);
+            Ok((out, None))
+        }
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn context(&self) -> &Arc<zmq::Context> {
+            &self.ctx
+        }
+        fn transport(&self) -> &crate::transport::TransportConfig {
+            &self.transport
+        }
+        fn signing_key(&self) -> SigningKey {
+            self.signing_key.clone()
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn spawn_with_readiness_ok_on_success_err_on_failure() -> Result<()> {
+        let nonce = Arc::new(crate::envelope::InMemoryNonceCache::new());
+
+        // Builder succeeds → readiness resolves Ok and the bridge serves.
+        let sk = fresh_signing_key();
+        let (_bridge, ready) = LocalServiceBridge::spawn_with(
+            "ok",
+            move || async move { Ok(BridgeEcho::new(sk)) },
+            Arc::clone(&nonce),
+            0,
+        )?;
+        ready.await.map_err(|_| anyhow::anyhow!("readiness dropped"))??;
+
+        // Builder fails (e.g. GPU init error) → the error surfaces on readiness,
+        // not silently as a later channel-closed.
+        let (_bridge2, ready2) = LocalServiceBridge::spawn_with::<_, _, BridgeEcho>(
+            "fail",
+            move || async move { Err(anyhow::anyhow!("boom")) },
+            nonce,
+            0,
+        )?;
+        let build_result = ready2.await.map_err(|_| anyhow::anyhow!("readiness dropped"))?;
+        assert!(
+            build_result.is_err(),
+            "a build failure must surface on the readiness channel"
+        );
+        Ok(())
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
@@ -118,6 +118,10 @@ impl IrohRpcProtocolHandler {
     pub fn with_read_timeout(mut self, read_timeout: std::time::Duration) -> Self {
         // `inner` is freshly built here (no other Arc clones yet), so this
         // get_mut always succeeds; fall back to a rebuild if it somehow doesn't.
+        debug_assert!(
+            Arc::strong_count(&self.inner) == 1,
+            "with_read_timeout called on a shared handler; rebuilding inner"
+        );
         match Arc::get_mut(&mut self.inner) {
             Some(inner) => inner.read_timeout = read_timeout,
             None => {

--- a/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
@@ -1,0 +1,293 @@
+//! Iroh RPC plane — server-side protocol handler for ALPN `hyprstream-rpc/1`.
+//!
+//! Part of Epic #131 Phase 2 (#133). This module ships the wire layer:
+//!
+//! - A length-prefixed framing over an iroh bidi stream (`accept_bi`/`open_bi`).
+//! - An [`IrohRpcProtocolHandler`] that plugs into [`crate::transport::iroh_substrate`]
+//!   under the `hyprstream-rpc/1` ALPN.
+//! - An [`IrohRequestProcessor`] trait that callers implement to wire actual
+//!   request processing (envelope verification + service dispatch).
+//!
+//! **Trust model**: The protocol handler does not verify `SignedEnvelope`
+//! itself — it forwards the raw bytes to the [`IrohRequestProcessor`], which
+//! is where envelope verification, JWT/DPoP checks, and `authorize_signer`
+//! enforcement happen. This matches the ZMTP path's separation of concerns
+//! (`transport::zmtp_quic::process_request`) and keeps the wire dumb.
+//!
+//! **Wire framing**: each message is a 4-byte big-endian length followed by
+//! that many opaque bytes (Cap'n Proto-encoded `SignedEnvelope`). The bidi
+//! stream is request-response: one request frame, one response frame, then
+//! both sides close. No multipart, no ZMTP framing — both endpoints are our
+//! code; iroh's QUIC TLS handles peer authentication at the transport layer.
+//!
+//! **Service integration** lands in a follow-up: the canary `PolicyClient`
+//! port (the rest of #133) wraps the existing `ZmqService` trait — including
+//! the `Rc<S>`/`!Send` constraint for services like inference — behind an
+//! `IrohRequestProcessor` adapter that bridges to a per-service LocalSet.
+
+use std::future::Future;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use bytes::Bytes;
+use iroh::endpoint::Connection;
+use iroh::protocol::{AcceptError, ProtocolHandler};
+
+/// Hard cap on inbound message size, to avoid unbounded memory growth from
+/// a misbehaving peer. Matches the ZMTP-over-QUIC server-side cap used in
+/// [`crate::transport::zmtp_quic`].
+const MAX_REQUEST_BYTES: usize = 64 * 1024 * 1024; // 64 MiB
+
+/// Trait implemented by callers to wire actual request processing.
+///
+/// The processor receives the raw request bytes (a Cap'n Proto-encoded
+/// `SignedEnvelope`) and returns the raw response bytes. Verification,
+/// authorization, and service dispatch all happen inside the implementation.
+///
+/// Implementations MUST be `Send + Sync + 'static` because iroh's accept
+/// loop runs on a multi-threaded tokio runtime. For services that are
+/// `!Send` (e.g. those holding `tch-rs` tensors), implement this trait by
+/// forwarding to a dedicated `LocalSet` via an `mpsc` channel — same
+/// pattern used today for the inference service.
+pub trait IrohRequestProcessor: Send + Sync + 'static {
+    /// Process one request and return the response bytes.
+    fn process(
+        &self,
+        request: Bytes,
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<Bytes>> + Send + '_>>;
+}
+
+/// Convenience: implement [`IrohRequestProcessor`] from a `Send + Sync`
+/// async closure. Useful for tests and simple processors.
+pub fn from_fn<F, Fut>(f: F) -> impl IrohRequestProcessor
+where
+    F: Fn(Bytes) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<Bytes>> + Send + 'static,
+{
+    struct FnProcessor<F>(F);
+    impl<F, Fut> IrohRequestProcessor for FnProcessor<F>
+    where
+        F: Fn(Bytes) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<Bytes>> + Send + 'static,
+    {
+        fn process(
+            &self,
+            request: Bytes,
+        ) -> std::pin::Pin<Box<dyn Future<Output = Result<Bytes>> + Send + '_>> {
+            Box::pin((self.0)(request))
+        }
+    }
+    FnProcessor(f)
+}
+
+/// Iroh protocol handler that terminates `hyprstream-rpc/1` bidi streams,
+/// applies length-prefixed framing, and dispatches each request through
+/// the wrapped [`IrohRequestProcessor`].
+#[derive(Clone)]
+pub struct IrohRpcProtocolHandler {
+    processor: Arc<dyn IrohRequestProcessor>,
+}
+
+impl std::fmt::Debug for IrohRpcProtocolHandler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IrohRpcProtocolHandler").finish_non_exhaustive()
+    }
+}
+
+impl IrohRpcProtocolHandler {
+    pub fn new<P: IrohRequestProcessor>(processor: P) -> Self {
+        Self {
+            processor: Arc::new(processor),
+        }
+    }
+
+    pub fn from_arc(processor: Arc<dyn IrohRequestProcessor>) -> Self {
+        Self { processor }
+    }
+}
+
+impl ProtocolHandler for IrohRpcProtocolHandler {
+    async fn accept(&self, conn: Connection) -> Result<(), AcceptError> {
+        // Accept bidi streams on this connection until the peer goes away.
+        // Each stream is one request-response pair, processed concurrently.
+        loop {
+            let (mut send, mut recv) = match conn.accept_bi().await {
+                Ok(streams) => streams,
+                Err(e) => {
+                    tracing::debug!(error = ?e, "iroh-rpc: connection closed");
+                    return Ok(());
+                }
+            };
+
+            let processor = Arc::clone(&self.processor);
+            tokio::spawn(async move {
+                // Read full request (length-prefixed).
+                let request = match recv.read_to_end(MAX_REQUEST_BYTES).await {
+                    Ok(buf) => Bytes::from(buf),
+                    Err(e) => {
+                        tracing::warn!(error = ?e, "iroh-rpc: failed reading request");
+                        return;
+                    }
+                };
+
+                // Process.
+                let response = match processor.process(request).await {
+                    Ok(bytes) => bytes,
+                    Err(e) => {
+                        tracing::warn!(error = ?e, "iroh-rpc: processor returned error");
+                        // Close the send side without a body; client will see EOF.
+                        let _ = send.finish();
+                        return;
+                    }
+                };
+
+                // Write response.
+                if let Err(e) = send.write_all(&response).await {
+                    tracing::warn!(error = ?e, "iroh-rpc: failed writing response");
+                    return;
+                }
+                if let Err(e) = send.finish() {
+                    tracing::warn!(error = ?e, "iroh-rpc: failed finishing send");
+                }
+                // Optional: wait for peer to read.
+                let _ = send.stopped().await;
+            });
+        }
+    }
+}
+
+/// Client-side helper: open a bidi stream on `hyprstream-rpc/1` against an
+/// already-connected iroh [`Connection`], write the request, read the response.
+///
+/// This is a primitive — the real per-service RPC clients (generated by
+/// `hyprstream_rpc_derive::generate_rpc_service!`) will wrap it with their
+/// own envelope construction and response decoding. Used directly only in
+/// tests during Phase 2.
+pub async fn client_request(conn: &Connection, request: &[u8]) -> Result<Bytes> {
+    let (mut send, mut recv) = conn.open_bi().await.context("open_bi")?;
+    send.write_all(request).await.context("write request")?;
+    send.finish().context("finish send")?;
+    let buf = recv
+        .read_to_end(MAX_REQUEST_BYTES)
+        .await
+        .context("read response")?;
+    Ok(Bytes::from(buf))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transport::iroh_substrate::{
+        ALPN_HYPRSTREAM_RPC, ALPN_MOQ_LITE, IrohSubstrate, NoopHandler,
+    };
+    use iroh::{EndpointAddr, TransportAddr};
+    use rand::RngCore;
+
+    fn fresh_key() -> [u8; 32] {
+        let mut k = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut k);
+        k
+    }
+
+    fn direct_addr(substrate: &IrohSubstrate) -> EndpointAddr {
+        EndpointAddr::from_parts(
+            substrate.endpoint_id(),
+            substrate
+                .endpoint()
+                .bound_sockets()
+                .into_iter()
+                .map(TransportAddr::Ip),
+        )
+    }
+
+    /// End-to-end: server runs an `IrohRpcProtocolHandler` wired to a
+    /// closure-based processor that prepends a magic byte to the request,
+    /// client sends one request and reads the response.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rpc_request_response_round_trip() -> Result<()> {
+        let processor = from_fn(|req: Bytes| async move {
+            let mut out = Vec::with_capacity(1 + req.len());
+            out.push(0xAB);
+            out.extend_from_slice(&req);
+            Ok(Bytes::from(out))
+        });
+        let rpc_handler = IrohRpcProtocolHandler::new(processor);
+
+        let server = IrohSubstrate::new(
+            fresh_key(),
+            NoopHandler::new("moq-not-wired"),
+            rpc_handler,
+        )
+        .await?;
+        let server_addr = direct_addr(&server);
+
+        let client = IrohSubstrate::new(
+            fresh_key(),
+            NoopHandler::new("client moq"),
+            NoopHandler::new("client rpc"),
+        )
+        .await?;
+
+        let conn = client
+            .connect(server_addr, ALPN_HYPRSTREAM_RPC)
+            .await?;
+        let resp = client_request(&conn, b"ping").await?;
+        assert_eq!(&resp[..], b"\xABping");
+
+        // Sanity: moq ALPN still routes to the noop handler (does not crash).
+        let conn2 = client.connect(direct_addr(&server), ALPN_MOQ_LITE).await?;
+        drop(conn2);
+
+        client.shutdown().await?;
+        server.shutdown().await?;
+        Ok(())
+    }
+
+    /// Multiple concurrent requests on the same connection round-trip
+    /// independently and arrive at the correct caller.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rpc_concurrent_requests() -> Result<()> {
+        let processor = from_fn(|req: Bytes| async move {
+            // Echo with a trailing marker so we can verify correlation.
+            let mut out = req.to_vec();
+            out.push(b'!');
+            Ok(Bytes::from(out))
+        });
+        let server = IrohSubstrate::new(
+            fresh_key(),
+            NoopHandler::new("moq"),
+            IrohRpcProtocolHandler::new(processor),
+        )
+        .await?;
+        let server_addr = direct_addr(&server);
+
+        let client = IrohSubstrate::new(
+            fresh_key(),
+            NoopHandler::new("c-moq"),
+            NoopHandler::new("c-rpc"),
+        )
+        .await?;
+        let conn = Arc::new(
+            client
+                .connect(server_addr, ALPN_HYPRSTREAM_RPC)
+                .await?,
+        );
+
+        let mut handles = Vec::new();
+        for i in 0..8u8 {
+            let conn = Arc::clone(&conn);
+            handles.push(tokio::spawn(async move {
+                let resp = client_request(&conn, &[i]).await?;
+                assert_eq!(&resp[..], &[i, b'!']);
+                anyhow::Ok(())
+            }));
+        }
+        for h in handles {
+            h.await??;
+        }
+
+        client.shutdown().await?;
+        server.shutdown().await?;
+        Ok(())
+    }
+}

--- a/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
@@ -296,27 +296,19 @@ impl LocalServiceBridge {
                                 &nonce_cache,
                             )
                             .await
-                            .and_then(|(bytes, cont)| {
-                                // Streaming continuations are not wired on
-                                // the iroh RPC plane — streaming moves to
-                                // moq-net (`moql` ALPN, Phase 3, #134). In
-                                // debug, panic loudly; in release, return an
-                                // error so the wire emits a signed error
-                                // envelope (handler's build_error_envelope)
-                                // rather than silently dropping the stream.
-                                if cont.is_some() {
-                                    debug_assert!(
-                                        false,
-                                        "iroh-rpc bridge: streaming continuation not supported \
-                                         — wait for Phase 3 (#134)"
-                                    );
-                                    return Err(anyhow::anyhow!(
-                                        "iroh-rpc bridge: service returned a streaming \
-                                         continuation, which is not supported on the iroh \
-                                         RPC plane (Phase 3 / #134 moves streaming to moq-net)"
-                                    ));
+                            .map(|(bytes, cont)| {
+                                // The continuation is the streaming pump — it
+                                // publishes to the moq/notification plane,
+                                // independent of the RPC transport — so spawn it
+                                // on this bridge LocalSet after the response,
+                                // exactly as RequestLoop / WebTransportServer do.
+                                // (Without this, streaming services like model /
+                                // tui would have their continuation dropped and
+                                // the stream would never be served.)
+                                if let Some(cont) = cont {
+                                    tokio::task::spawn_local(cont);
                                 }
-                                Ok(Bytes::from(bytes))
+                                Bytes::from(bytes)
                             });
                             let _ = msg.respond.send(result);
                         });
@@ -394,14 +386,13 @@ impl LocalServiceBridge {
                                 &nonce_cache,
                             )
                             .await
-                            .and_then(|(bytes, cont)| {
-                                if cont.is_some() {
-                                    return Err(anyhow::anyhow!(
-                                        "rpc bridge: streaming continuation unsupported \
-                                         (streaming is on the moq plane, #134)"
-                                    ));
+                            .map(|(bytes, cont)| {
+                                // Spawn the streaming pump on this bridge LocalSet
+                                // (see spawn() for the rationale).
+                                if let Some(cont) = cont {
+                                    tokio::task::spawn_local(cont);
                                 }
-                                Ok(Bytes::from(bytes))
+                                Bytes::from(bytes)
                             });
                             let _ = msg.respond.send(result);
                         });

--- a/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
@@ -4,7 +4,7 @@
 //!
 //! - [`IrohRpcProtocolHandler`] — iroh [`ProtocolHandler`] that plugs into
 //!   [`crate::transport::iroh_substrate`] under the `hyprstream-rpc/1` ALPN.
-//!   Enforces a per-connection cap on concurrent streams (DoS bound) and
+//!   Enforces a server-wide cap on concurrent streams (DoS bound) and
 //!   drains in-flight requests on `ProtocolHandler::shutdown`.
 //! - [`IrohRequestProcessor`] — trait callers implement to wire actual
 //!   request processing (envelope verification + service dispatch).
@@ -51,7 +51,8 @@ pub use super::rpc_session::{
 
 /// Iroh protocol handler that terminates `hyprstream-rpc/1` bidi streams,
 /// dispatches each request through the wrapped [`IrohRequestProcessor`],
-/// caps concurrent streams per connection, and drains in-flight requests
+/// caps concurrent streams server-wide (shared semaphore), and drains
+/// in-flight requests
 /// on `ProtocolHandler::shutdown` (called by `Router::shutdown`).
 #[derive(Clone)]
 pub struct IrohRpcProtocolHandler {
@@ -67,6 +68,8 @@ struct HandlerInner {
     /// Caps concurrent bidi streams in flight. Hold one permit per stream.
     stream_limit: Arc<Semaphore>,
     stream_limit_capacity: u32,
+    /// Per-stream request-read timeout (#159 slowloris bound).
+    read_timeout: std::time::Duration,
     /// Level-triggered shutdown signal: once `cancel()` is called, every
     /// future and current `cancelled().await` resolves immediately. Used
     /// instead of `tokio::sync::Notify` because `Notify::notify_waiters`
@@ -84,13 +87,13 @@ impl std::fmt::Debug for IrohRpcProtocolHandler {
 }
 
 impl IrohRpcProtocolHandler {
-    /// Build a handler with default per-connection stream limit
+    /// Build a handler with the default server-wide stream limit
     /// ([`DEFAULT_STREAM_LIMIT`]).
     pub fn new<P: IrohRequestProcessor>(processor: P, signing_key: SigningKey) -> Self {
         Self::with_stream_limit(Arc::new(processor), signing_key, DEFAULT_STREAM_LIMIT)
     }
 
-    /// Build a handler with an explicit per-connection stream limit.
+    /// Build a handler with an explicit server-wide stream limit.
     pub fn with_stream_limit(
         processor: Arc<dyn IrohRequestProcessor>,
         signing_key: SigningKey,
@@ -103,9 +106,33 @@ impl IrohRpcProtocolHandler {
                 signing_key,
                 stream_limit: Arc::new(Semaphore::new(stream_limit)),
                 stream_limit_capacity,
+                read_timeout: super::rpc_session::REQUEST_READ_TIMEOUT,
                 shutdown: CancellationToken::new(),
             }),
         }
+    }
+
+    /// Override the per-stream request-read timeout (#159). Primarily for
+    /// tests that need a short slowloris bound; production uses the default
+    /// [`super::rpc_session::REQUEST_READ_TIMEOUT`].
+    pub fn with_read_timeout(mut self, read_timeout: std::time::Duration) -> Self {
+        // `inner` is freshly built here (no other Arc clones yet), so this
+        // get_mut always succeeds; fall back to a rebuild if it somehow doesn't.
+        match Arc::get_mut(&mut self.inner) {
+            Some(inner) => inner.read_timeout = read_timeout,
+            None => {
+                let i = &self.inner;
+                self.inner = Arc::new(HandlerInner {
+                    processor: Arc::clone(&i.processor),
+                    signing_key: i.signing_key.clone(),
+                    stream_limit: Arc::clone(&i.stream_limit),
+                    stream_limit_capacity: i.stream_limit_capacity,
+                    read_timeout,
+                    shutdown: i.shutdown.clone(),
+                });
+            }
+        }
+        self
     }
 }
 
@@ -120,6 +147,7 @@ impl ProtocolHandler for IrohRpcProtocolHandler {
             Arc::clone(&self.inner.processor),
             self.inner.signing_key.clone(),
             Arc::clone(&self.inner.stream_limit),
+            self.inner.read_timeout,
             self.inner.shutdown.clone(),
         )
         .await
@@ -132,17 +160,31 @@ impl ProtocolHandler for IrohRpcProtocolHandler {
         // loop hits `cancelled().await` it returns immediately.
         self.inner.shutdown.cancel();
         // Wait for all in-flight streams to release their permits.
-        // `acquire_many` succeeds only once every permit is returned.
+        // `acquire_many` succeeds only once every permit is returned. Bounded
+        // (#159) so a wedged processor/transport can't hang shutdown forever;
+        // on timeout we close() and proceed (remaining tasks die with the conn).
         let cap = self.inner.stream_limit_capacity;
-        match self.inner.stream_limit.acquire_many(cap).await {
-            Ok(permits) => {
+        match tokio::time::timeout(
+            super::rpc_session::DRAIN_TIMEOUT,
+            self.inner.stream_limit.acquire_many(cap),
+        )
+        .await
+        {
+            Ok(Ok(permits)) => {
                 // Keep permits drained so any post-shutdown accept also
                 // sees a closed semaphore.
                 permits.forget();
                 self.inner.stream_limit.close();
             }
-            Err(_) => {
+            Ok(Err(_)) => {
                 // Already closed; nothing to drain.
+            }
+            Err(_) => {
+                tracing::warn!(
+                    timeout = ?super::rpc_session::DRAIN_TIMEOUT,
+                    "iroh-rpc: drain timed out, forcing teardown"
+                );
+                self.inner.stream_limit.close();
             }
         }
     }
@@ -510,6 +552,52 @@ mod tests {
             peak.load(Ordering::SeqCst)
         );
 
+        client.shutdown().await?;
+        server.shutdown().await?;
+        Ok(())
+    }
+
+    /// #159: a stalled (slowloris) stream that holds a permit without sending
+    /// FIN must be abandoned after the read timeout, releasing its permit so a
+    /// well-behaved request can still be served. With `stream_limit=1`, the
+    /// stall grabs the only permit; without the read-timeout fix the normal
+    /// request would block forever and this test would hang.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rpc_slowloris_stream_is_timed_out_and_permit_released() -> Result<()> {
+        let processor = from_fn(move |_req: Bytes| async move { Ok(Bytes::from_static(b"ok")) });
+        let handler = IrohRpcProtocolHandler::with_stream_limit(
+            Arc::new(processor),
+            fresh_signing_key(),
+            1,
+        )
+        .with_read_timeout(Duration::from_millis(300));
+
+        let server = IrohSubstrate::new(fresh_key(), NoopHandler::new("moq"), handler).await?;
+        let server_addr = direct_addr(&server);
+
+        let client = IrohSubstrate::new(
+            fresh_key(),
+            NoopHandler::new("c-moq"),
+            NoopHandler::new("c-rpc"),
+        )
+        .await?;
+        let conn = client.connect(server_addr, ALPN_HYPRSTREAM_RPC).await?;
+
+        // Slowloris: open a bidi stream, dribble one byte, never finish.
+        let (mut stall_send, _stall_recv) = conn.open_bi().await.context("open_bi stall")?;
+        stall_send.write_all(b"x").await.context("write stall byte")?;
+        // Deliberately DO NOT call finish(); keep the stream (and its server-side
+        // permit) alive. Hold the handle so it isn't dropped/reset early.
+
+        // A normal request must still succeed once the stalled stream's read
+        // times out (~300ms) and its permit is released. Bound the wait well
+        // above the read timeout but far below "forever".
+        let resp = tokio::time::timeout(Duration::from_secs(5), client_request(&conn, b"req"))
+            .await
+            .context("normal request hung — permit was not released (slowloris not bounded)")??;
+        assert_eq!(&resp[..], b"ok");
+
+        drop(stall_send);
         client.shutdown().await?;
         server.shutdown().await?;
         Ok(())

--- a/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
@@ -15,7 +15,7 @@
 //! it forwards opaque bytes to the [`IrohRequestProcessor`]. Envelope
 //! verification, JWT/DPoP, and `authorize_signer` enforcement happen inside
 //! the processor (which is `LocalServiceBridge` in production, delegating
-//! to [`crate::transport::zmtp_quic::process_request`]). The handler does
+//! to [`crate::service::dispatch::process_request`]). The handler does
 //! hold a signing key, but uses it only to produce signed error envelopes
 //! when the processor itself returns `Err` (a wire-level failure), so the
 //! client always sees a parseable `ResponseEnvelope` rather than an opaque
@@ -243,7 +243,7 @@ pub struct LocalServiceBridge {
 
 impl LocalServiceBridge {
     /// Spawn a dedicated bridge thread that owns `service` and forwards
-    /// requests through [`crate::transport::zmtp_quic::process_request`].
+    /// requests through [`crate::service::dispatch::process_request`].
     ///
     /// The response signing key is taken from `service.signing_key()` — there
     /// is no separate parameter to avoid drift between the service's identity
@@ -288,7 +288,7 @@ impl LocalServiceBridge {
                             // Re-derive the signing key per call: cheap clone,
                             // tracks any future rotation in the service.
                             let signing_key = service.signing_key();
-                            let result = crate::transport::zmtp_quic::process_request(
+                            let result = crate::service::dispatch::process_request(
                                 msg.request.as_ref(),
                                 &*service,
                                 crate::envelope::EnvelopeVerification::AnySigner,

--- a/crates/hyprstream-rpc/src/transport/iroh_substrate.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_substrate.rs
@@ -1,0 +1,237 @@
+//! Iroh transport substrate — Phase 1 of Epic #131 (ZMQ → moq-net + iroh).
+//!
+//! Builds a shared `iroh::Endpoint` from an Ed25519 node key and wires an
+//! [`iroh::protocol::Router`] with two ALPN slots:
+//!
+//! - [`ALPN_MOQ_LITE`] (`moql`) — moq-net session handler. Wired in Phase 3
+//!   (issue hyprstream/hyprstream#134) to dispatch into an in-process
+//!   `moq_net::Origin` for the streaming plane.
+//! - [`ALPN_HYPRSTREAM_RPC`] (`hyprstream-rpc/1`) — raw Cap'n Proto bidi
+//!   handler. Wired in Phase 2 (issue hyprstream/hyprstream#133) to terminate
+//!   `IrohRpcTransport` for the RPC plane.
+//!
+//! Phase 1 ships the substrate, a [`NoopHandler`] placeholder, and a smoke
+//! test verifying that two endpoints can dial each other directly and open a
+//! bidi stream on each ALPN. No production code consumes this module yet.
+
+use anyhow::Result;
+use iroh::endpoint::{Connection, presets};
+use iroh::protocol::{AcceptError, DynProtocolHandler, ProtocolHandler, Router};
+use iroh::{Endpoint, EndpointAddr, EndpointId, SecretKey};
+
+/// ALPN for moq-net (moq-lite). Must equal `moq_net::version::ALPN_LITE`.
+pub const ALPN_MOQ_LITE: &[u8] = b"moql";
+
+/// ALPN for the raw Cap'n Proto bidi RPC plane.
+pub const ALPN_HYPRSTREAM_RPC: &[u8] = b"hyprstream-rpc/1";
+
+/// Two-plane iroh substrate: one shared QUIC endpoint, two ALPN-dispatched
+/// protocol handlers.
+///
+/// Drop to abort the accept loop; call [`IrohSubstrate::shutdown`] for a
+/// clean shutdown that drains protocol handlers and closes the endpoint.
+pub struct IrohSubstrate {
+    endpoint: Endpoint,
+    router: Router,
+}
+
+impl IrohSubstrate {
+    /// Build the substrate from raw 32-byte Ed25519 secret key material.
+    ///
+    /// Uses iroh's `presets::N0` for discovery (n0 DNS + pkarr) and relay
+    /// fallback. Operators wanting self-hosted discovery should bypass this
+    /// constructor and use [`IrohSubstrate::from_endpoint`] with a
+    /// pre-configured `iroh::Endpoint`.
+    pub async fn new<M, R>(
+        secret_key_bytes: [u8; 32],
+        moq_handler: M,
+        rpc_handler: R,
+    ) -> Result<Self>
+    where
+        M: Into<Box<dyn DynProtocolHandler>>,
+        R: Into<Box<dyn DynProtocolHandler>>,
+    {
+        let endpoint = Endpoint::builder(presets::N0)
+            .secret_key(SecretKey::from_bytes(&secret_key_bytes))
+            .bind()
+            .await
+            .map_err(|e| anyhow::anyhow!("iroh endpoint bind: {e}"))?;
+
+        Ok(Self::from_endpoint(endpoint, moq_handler, rpc_handler))
+    }
+
+    /// Wrap a caller-built endpoint. Useful when the caller wants
+    /// non-default discovery (e.g. self-hosted `iroh-dns-server`), a
+    /// non-default crypto provider, or to share an existing endpoint
+    /// across substrates.
+    pub fn from_endpoint<M, R>(
+        endpoint: Endpoint,
+        moq_handler: M,
+        rpc_handler: R,
+    ) -> Self
+    where
+        M: Into<Box<dyn DynProtocolHandler>>,
+        R: Into<Box<dyn DynProtocolHandler>>,
+    {
+        let router = Router::builder(endpoint.clone())
+            .accept(ALPN_MOQ_LITE, moq_handler.into())
+            .accept(ALPN_HYPRSTREAM_RPC, rpc_handler.into())
+            .spawn();
+        Self { endpoint, router }
+    }
+
+    /// Endpoint id = our Ed25519 public key. Published in JWKS for
+    /// federation peer binding (Phase 6, issue #137).
+    pub fn endpoint_id(&self) -> EndpointId {
+        self.endpoint.id()
+    }
+
+    /// Borrow the underlying endpoint, e.g. to issue outbound connects on
+    /// an ALPN not served by this substrate's router.
+    pub fn endpoint(&self) -> &Endpoint {
+        &self.endpoint
+    }
+
+    /// Borrow the router (e.g. to inspect or to share lifetime).
+    pub fn router(&self) -> &Router {
+        &self.router
+    }
+
+    /// Dial a peer for the given ALPN.
+    pub async fn connect(&self, addr: EndpointAddr, alpn: &[u8]) -> Result<Connection> {
+        self.endpoint
+            .connect(addr, alpn)
+            .await
+            .map_err(|e| anyhow::anyhow!("iroh connect: {e}"))
+    }
+
+    /// Drain handlers and close the endpoint.
+    pub async fn shutdown(self) -> Result<()> {
+        self.router
+            .shutdown()
+            .await
+            .map_err(|e| anyhow::anyhow!("router shutdown: {e}"))?;
+        Ok(())
+    }
+}
+
+/// Placeholder protocol handler that accepts an incoming connection and
+/// immediately returns. Used until Phase 2 / Phase 3 wire the real handlers.
+#[derive(Debug, Clone, Default)]
+pub struct NoopHandler {
+    reason: &'static str,
+}
+
+impl NoopHandler {
+    pub fn new(reason: &'static str) -> Self {
+        Self { reason }
+    }
+}
+
+impl ProtocolHandler for NoopHandler {
+    async fn accept(&self, _conn: Connection) -> Result<(), AcceptError> {
+        tracing::trace!(reason = %self.reason, "NoopHandler accepted (no-op)");
+        Ok(())
+    }
+}
+
+/// Test-only handler that accepts one bidi stream, reads one length-prefixed
+/// message, echoes it back, then closes. Used by the Phase 1 smoke test to
+/// verify that both ALPN slots route correctly.
+#[derive(Debug, Clone, Default)]
+pub struct EchoHandler;
+
+impl ProtocolHandler for EchoHandler {
+    async fn accept(&self, conn: Connection) -> Result<(), AcceptError> {
+        let (mut send, mut recv) = conn
+            .accept_bi()
+            .await
+            .map_err(|e| AcceptError::from_err(e))?;
+        let buf = recv
+            .read_to_end(1024)
+            .await
+            .map_err(|e| AcceptError::from_err(e))?;
+        send.write_all(&buf)
+            .await
+            .map_err(|e| AcceptError::from_err(e))?;
+        send.finish().map_err(|e| AcceptError::from_err(e))?;
+        // Cleanly wait for the peer to acknowledge by reading the final FIN.
+        let _ = send.stopped().await;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iroh::TransportAddr;
+    use rand::RngCore;
+
+    fn fresh_key() -> [u8; 32] {
+        let mut k = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut k);
+        k
+    }
+
+    /// Build an `EndpointAddr` for a server directly from its bound sockets +
+    /// endpoint id. Skips the n0 relay/pkarr resolution path, which keeps the
+    /// smoke test hermetic — no DNS lookup, no network egress.
+    fn direct_addr(substrate: &IrohSubstrate) -> EndpointAddr {
+        EndpointAddr::from_parts(
+            substrate.endpoint_id(),
+            substrate
+                .endpoint()
+                .bound_sockets()
+                .into_iter()
+                .map(TransportAddr::Ip),
+        )
+    }
+
+    /// Smoke test: build two substrates, dial direct (no DNS/pkarr), echo a
+    /// message on each ALPN. Verifies the router dispatches by ALPN and that
+    /// both planes terminate distinct handlers.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn smoke_two_endpoints_two_alpns() -> Result<()> {
+        // Server with EchoHandler on both ALPNs.
+        let server = IrohSubstrate::new(fresh_key(), EchoHandler, EchoHandler).await?;
+        let server_id = server.endpoint_id();
+        let server_addr = direct_addr(&server);
+
+        // Client with no-op handlers (it only originates).
+        let client = IrohSubstrate::new(
+            fresh_key(),
+            NoopHandler::new("client moq"),
+            NoopHandler::new("client rpc"),
+        )
+        .await?;
+
+        // RPC plane round-trip.
+        {
+            let conn = client
+                .connect(server_addr.clone(), ALPN_HYPRSTREAM_RPC)
+                .await?;
+            let (mut send, mut recv) = conn.open_bi().await?;
+            send.write_all(b"hello rpc").await?;
+            send.finish()?;
+            let got = recv.read_to_end(64).await?;
+            assert_eq!(&got, b"hello rpc");
+        }
+
+        // Streaming plane round-trip (echo here; real moq-net wiring lands in Phase 3).
+        {
+            let conn = client.connect(server_addr.clone(), ALPN_MOQ_LITE).await?;
+            let (mut send, mut recv) = conn.open_bi().await?;
+            send.write_all(b"hello moq").await?;
+            send.finish()?;
+            let got = recv.read_to_end(64).await?;
+            assert_eq!(&got, b"hello moq");
+        }
+
+        // Sanity: server id is stable.
+        assert_eq!(server.endpoint_id(), server_id);
+
+        client.shutdown().await?;
+        server.shutdown().await?;
+        Ok(())
+    }
+}

--- a/crates/hyprstream-rpc/src/transport/iroh_transport.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_transport.rs
@@ -1,0 +1,110 @@
+//! Iroh client-side transport — Phase 2 part 2 of Epic #131 (#133).
+//!
+//! Implements [`Transport`] over an iroh [`Connection`] so existing
+//! [`RpcClientImpl<S, T>`] consumers can ride the `hyprstream-rpc/1` ALPN
+//! with zero changes to envelope signing, JWT handling, or response parsing.
+//!
+//! Each `send()` opens a fresh bidi stream on the connection, writes the
+//! length-prefixed `SignedEnvelope` bytes, and reads the response — matching
+//! the [`IrohRpcProtocolHandler`] (`transport::iroh_rpc`) accept loop on the
+//! server side.
+//!
+//! **Out of scope** (Phase 3): the [`Transport::subscribe`] and
+//! [`Transport::publish`] methods are streaming-plane concerns. They return
+//! errors here; subscribers go through `moq-net` on the `moql` ALPN instead.
+//!
+//! [`IrohRpcProtocolHandler`]: super::iroh_rpc::IrohRpcProtocolHandler
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Result, anyhow, bail};
+use async_trait::async_trait;
+use iroh::endpoint::Connection;
+
+use crate::transport::iroh_rpc::MAX_FRAME_BYTES;
+use crate::transport_traits::{PublishSink, Transport};
+
+/// Default per-call timeout when the caller passes `None`.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Wraps an iroh [`Connection`] as a [`Transport`] for RPC plane traffic.
+///
+/// Clone-cheap — the connection itself is reference-counted internally by
+/// iroh, and we share it via `Arc` so the same `IrohTransport` can be
+/// installed in multiple `RpcClientImpl`s if a service holds parallel
+/// per-tenant clients.
+#[derive(Clone)]
+pub struct IrohTransport {
+    conn: Arc<Connection>,
+}
+
+impl IrohTransport {
+    /// Build from an already-established iroh connection on
+    /// [`super::iroh_substrate::ALPN_HYPRSTREAM_RPC`].
+    pub fn new(conn: Connection) -> Self {
+        Self {
+            conn: Arc::new(conn),
+        }
+    }
+
+    /// Borrow the underlying iroh connection (e.g. for inspection).
+    pub fn connection(&self) -> &Connection {
+        &self.conn
+    }
+}
+
+/// Stub stream type for [`Transport::Sub`]. Always pending — the iroh RPC
+/// plane does not carry SUB-style topic streams; those live on the `moql`
+/// ALPN under Phase 3.
+pub type IrohPendingStream = futures::stream::Pending<Result<Vec<Vec<u8>>>>;
+
+/// Stub publish sink for [`Transport::Pub`]. Errors on any `send_frames`
+/// call; iroh-rpc is request-response only.
+pub struct IrohPublishStub;
+
+#[async_trait]
+impl PublishSink for IrohPublishStub {
+    async fn send_frames(&self, _frames: &[&[u8]]) -> Result<()> {
+        bail!("iroh RPC plane does not support PUB/PUSH — use moq-net on the `moql` ALPN")
+    }
+}
+
+#[async_trait]
+impl Transport for IrohTransport {
+    type Sub = IrohPendingStream;
+    type Pub = IrohPublishStub;
+
+    async fn send(&self, payload: Vec<u8>, timeout_ms: Option<i32>) -> Result<Vec<u8>> {
+        let timeout = timeout_ms
+            .map(|ms| Duration::from_millis(ms.max(0) as u64))
+            .unwrap_or(DEFAULT_TIMEOUT);
+        let fut = async {
+            let (mut send, mut recv) = self
+                .conn
+                .open_bi()
+                .await
+                .map_err(|e| anyhow!("iroh open_bi: {e}"))?;
+            send.write_all(&payload)
+                .await
+                .map_err(|e| anyhow!("iroh write_all: {e}"))?;
+            send.finish().map_err(|e| anyhow!("iroh finish: {e}"))?;
+            let buf = recv
+                .read_to_end(MAX_FRAME_BYTES)
+                .await
+                .map_err(|e| anyhow!("iroh read_to_end: {e}"))?;
+            Ok(buf)
+        };
+        tokio::time::timeout(timeout, fut)
+            .await
+            .map_err(|_| anyhow!("iroh RPC timeout after {timeout:?}"))?
+    }
+
+    async fn subscribe(&self, _topic: &[u8]) -> Result<Self::Sub> {
+        bail!("iroh RPC plane does not support SUB — use moq-net on the `moql` ALPN")
+    }
+
+    async fn publish(&self, _topic: &[u8]) -> Result<Self::Pub> {
+        bail!("iroh RPC plane does not support PUB — use moq-net on the `moql` ALPN")
+    }
+}

--- a/crates/hyprstream-rpc/src/transport/iroh_transport.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_transport.rs
@@ -1,12 +1,14 @@
 //! Iroh client-side transport — Phase 2 part 2 of Epic #131 (#133).
 //!
-//! Implements [`Transport`] over an iroh [`Connection`] so existing
-//! [`RpcClientImpl<S, T>`] consumers can ride the `hyprstream-rpc/1` ALPN
-//! with zero changes to envelope signing, JWT handling, or response parsing.
+//! Thin wrapper over the transport-generic [`SessionRpcTransport`] (see
+//! [`super::rpc_session`]) specialised to iroh's [`web_transport_iroh::Session`]
+//! so existing [`RpcClientImpl<S, T>`] consumers can ride the
+//! `hyprstream-rpc/1` ALPN with zero changes to envelope signing, JWT handling,
+//! or response parsing.
 //!
 //! Each `send()` opens a fresh bidi stream on the connection, writes the
-//! length-prefixed `SignedEnvelope` bytes, and reads the response — matching
-//! the [`IrohRpcProtocolHandler`] (`transport::iroh_rpc`) accept loop on the
+//! `SignedEnvelope` bytes, and reads the response (bounded) — matching the
+//! [`IrohRpcProtocolHandler`] (`transport::iroh_rpc`) accept loop on the
 //! server side.
 //!
 //! **Out of scope** (Phase 3): the [`Transport::subscribe`] and
@@ -15,28 +17,23 @@
 //!
 //! [`IrohRpcProtocolHandler`]: super::iroh_rpc::IrohRpcProtocolHandler
 
-use std::sync::Arc;
-use std::time::Duration;
-
-use anyhow::{Result, anyhow, bail};
+use anyhow::Result;
 use async_trait::async_trait;
 use iroh::endpoint::Connection;
 
-use crate::transport::iroh_rpc::MAX_FRAME_BYTES;
-use crate::transport_traits::{PublishSink, Transport};
-
-/// Default per-call timeout when the caller passes `None`.
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+use crate::transport::rpc_session::{
+    RpcPendingStream, RpcPublishStub, SessionRpcTransport,
+};
+use crate::transport_traits::Transport;
 
 /// Wraps an iroh [`Connection`] as a [`Transport`] for RPC plane traffic.
 ///
-/// Clone-cheap — the connection itself is reference-counted internally by
-/// iroh, and we share it via `Arc` so the same `IrohTransport` can be
-/// installed in multiple `RpcClientImpl`s if a service holds parallel
-/// per-tenant clients.
+/// Clone-cheap — delegates to the transport-generic [`SessionRpcTransport`]
+/// over iroh's `web-transport` session, which is itself reference-counted.
 #[derive(Clone)]
 pub struct IrohTransport {
-    conn: Arc<Connection>,
+    // NOTE: removed unused connection() accessor in M1.
+    inner: SessionRpcTransport<web_transport_iroh::Session>,
 }
 
 impl IrohTransport {
@@ -44,31 +41,16 @@ impl IrohTransport {
     /// [`super::iroh_substrate::ALPN_HYPRSTREAM_RPC`].
     pub fn new(conn: Connection) -> Self {
         Self {
-            conn: Arc::new(conn),
+            inner: SessionRpcTransport::new(web_transport_iroh::Session::raw(conn)),
         }
     }
-
-    /// Borrow the underlying iroh connection (e.g. for inspection).
-    pub fn connection(&self) -> &Connection {
-        &self.conn
-    }
 }
 
-/// Stub stream type for [`Transport::Sub`]. Always pending — the iroh RPC
-/// plane does not carry SUB-style topic streams; those live on the `moql`
-/// ALPN under Phase 3.
-pub type IrohPendingStream = futures::stream::Pending<Result<Vec<Vec<u8>>>>;
+/// Re-export the generic pending-stream stub under the historical name.
+pub type IrohPendingStream = RpcPendingStream;
 
-/// Stub publish sink for [`Transport::Pub`]. Errors on any `send_frames`
-/// call; iroh-rpc is request-response only.
-pub struct IrohPublishStub;
-
-#[async_trait]
-impl PublishSink for IrohPublishStub {
-    async fn send_frames(&self, _frames: &[&[u8]]) -> Result<()> {
-        bail!("iroh RPC plane does not support PUB/PUSH — use moq-net on the `moql` ALPN")
-    }
-}
+/// Re-export the generic publish stub under the historical name.
+pub type IrohPublishStub = RpcPublishStub;
 
 #[async_trait]
 impl Transport for IrohTransport {
@@ -76,35 +58,14 @@ impl Transport for IrohTransport {
     type Pub = IrohPublishStub;
 
     async fn send(&self, payload: Vec<u8>, timeout_ms: Option<i32>) -> Result<Vec<u8>> {
-        let timeout = timeout_ms
-            .map(|ms| Duration::from_millis(ms.max(0) as u64))
-            .unwrap_or(DEFAULT_TIMEOUT);
-        let fut = async {
-            let (mut send, mut recv) = self
-                .conn
-                .open_bi()
-                .await
-                .map_err(|e| anyhow!("iroh open_bi: {e}"))?;
-            send.write_all(&payload)
-                .await
-                .map_err(|e| anyhow!("iroh write_all: {e}"))?;
-            send.finish().map_err(|e| anyhow!("iroh finish: {e}"))?;
-            let buf = recv
-                .read_to_end(MAX_FRAME_BYTES)
-                .await
-                .map_err(|e| anyhow!("iroh read_to_end: {e}"))?;
-            Ok(buf)
-        };
-        tokio::time::timeout(timeout, fut)
-            .await
-            .map_err(|_| anyhow!("iroh RPC timeout after {timeout:?}"))?
+        self.inner.send(payload, timeout_ms).await
     }
 
-    async fn subscribe(&self, _topic: &[u8]) -> Result<Self::Sub> {
-        bail!("iroh RPC plane does not support SUB — use moq-net on the `moql` ALPN")
+    async fn subscribe(&self, topic: &[u8]) -> Result<Self::Sub> {
+        self.inner.subscribe(topic).await
     }
 
-    async fn publish(&self, _topic: &[u8]) -> Result<Self::Pub> {
-        bail!("iroh RPC plane does not support PUB — use moq-net on the `moql` ALPN")
+    async fn publish(&self, topic: &[u8]) -> Result<Self::Pub> {
+        self.inner.publish(topic).await
     }
 }

--- a/crates/hyprstream-rpc/src/transport/lazy_iroh.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_iroh.rs
@@ -206,8 +206,51 @@ mod tests {
         assert_eq!(resp, b"ping");
         assert!(t.cached.lock().await.is_some(), "session cached after first send");
 
-        client.shutdown().await.unwrap();
         server.shutdown().await.unwrap();
+        // NOTE: do NOT shut down `client` — its endpoint is installed in the
+        // process-global IROH_CLIENT_ENDPOINT (install-once), so tearing it down
+        // would break the shared dialer for any other test. Drop it; the global
+        // Arc clone keeps the endpoint alive (matches the never-reset prod lifecycle).
+        drop(client);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn wrong_node_id_rejected() {
+        // Server we'll dial the *address* of, but with a different identity.
+        let server = IrohSubstrate::new(fresh_key(), EchoHandler, EchoHandler).await.unwrap();
+        let direct: Vec<SocketAddr> = server.endpoint().bound_sockets().into_iter().collect();
+
+        let client = IrohSubstrate::new(
+            fresh_key(),
+            NoopHandler::new("client moq"),
+            NoopHandler::new("client rpc"),
+        )
+        .await
+        .unwrap();
+        // First-write-wins; may already be installed by another test (same global).
+        let _ = install_iroh_client_endpoint(client.endpoint().clone());
+
+        // A *valid* but wrong EndpointId (a third node's), so this tests handshake
+        // identity rejection — not a malformed key.
+        let other = IrohSubstrate::new(fresh_key(), NoopHandler::new("o1"), NoopHandler::new("o2"))
+            .await
+            .unwrap();
+        let wrong_id: [u8; 32] = *other.endpoint_id().as_bytes();
+
+        let t = LazyIrohTransport::new(wrong_id, direct, None);
+        let res = tokio::time::timeout(Duration::from_secs(8), t.send(b"x".to_vec(), Some(3_000)))
+            .await
+            .expect("send must complete (with an error) — wrong identity should reject, not hang");
+        assert!(res.is_err(), "dialing a server's address under a wrong EndpointId must fail");
+        assert!(t.cached.lock().await.is_none(), "a failed handshake caches nothing");
+
+        other.shutdown().await.unwrap();
+        server.shutdown().await.unwrap();
+        // NOTE: do NOT shut down `client` — its endpoint is installed in the
+        // process-global IROH_CLIENT_ENDPOINT (install-once), so tearing it down
+        // would break the shared dialer for any other test. Drop it; the global
+        // Arc clone keeps the endpoint alive (matches the never-reset prod lifecycle).
+        drop(client);
     }
 
     #[tokio::test]

--- a/crates/hyprstream-rpc/src/transport/lazy_iroh.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_iroh.rs
@@ -1,0 +1,219 @@
+//! Lazy-connecting iroh RPC transport (optional NAT-traversing dial).
+//!
+//! Mirrors [`LazyQuinnTransport`](super::lazy_quinn::LazyQuinnTransport): the
+//! [`dial`](crate::dial::dial) factory is synchronous, so this holds the dial
+//! target (the peer's `EndpointId` + addresses) and connects on the **first
+//! `send()`**, caching the session — preserving sync, zero-I/O construction.
+//!
+//! # The shared client endpoint
+//!
+//! Unlike quinn (where `connect_pinned_sha256` builds its own one-shot client),
+//! iroh dials from a long-lived [`iroh::Endpoint`] that holds the node's
+//! identity and bound sockets. There is exactly one client endpoint per
+//! process; it is installed once at startup via
+//! [`install_iroh_client_endpoint`] (the daemon provisions it during bootstrap),
+//! the same install-once pattern as the inproc registry and the envelope verify
+//! config. Until it is installed, the iroh dial arm errors loudly rather than
+//! silently falling back.
+//!
+//! # Identity
+//!
+//! iroh binds the connection to the peer's `EndpointId` (its Ed25519 public
+//! key), so the transport authenticates the peer **identity** — stronger than
+//! quinn's channel-only cert pin, and it closes the transport half of the
+//! cert↔identity gap (#185) for this dial.
+//!
+//! Re-dial/self-heal semantics match `LazyQuinnTransport`: a per-request timeout
+//! keeps the session; a transport-fatal error drops it so the next call
+//! re-dials. Refined liveness-based re-dial + backoff is #156's job.
+
+use std::net::SocketAddr;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Result};
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+
+use crate::transport::iroh_substrate::ALPN_HYPRSTREAM_RPC;
+use crate::transport::iroh_transport::{IrohPendingStream, IrohPublishStub, IrohTransport};
+use crate::transport_traits::Transport;
+
+/// Default per-request deadline when the caller passes `None`.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Process-wide client iroh endpoint, installed once at startup.
+static IROH_CLIENT_ENDPOINT: OnceLock<iroh::Endpoint> = OnceLock::new();
+
+/// Install the process-global client iroh [`Endpoint`](iroh::Endpoint) used to
+/// originate outbound RPC dials. First-write-wins (mirrors
+/// `install_verify_config`); returns `Err(endpoint)` if one is already set.
+///
+/// The daemon calls this once during bootstrap with the shared endpoint (the
+/// same one its inbound iroh substrate listens on, so outbound dials reuse the
+/// node identity).
+pub fn install_iroh_client_endpoint(endpoint: iroh::Endpoint) -> Result<(), iroh::Endpoint> {
+    IROH_CLIENT_ENDPOINT.set(endpoint)
+}
+
+/// The installed client endpoint, cloned (cheap — iroh `Endpoint` is `Arc`-backed).
+fn iroh_client_endpoint() -> Option<iroh::Endpoint> {
+    IROH_CLIENT_ENDPOINT.get().cloned()
+}
+
+/// An iroh RPC transport that connects on first use and caches the session.
+pub struct LazyIrohTransport {
+    node_id: [u8; 32],
+    direct_addrs: Vec<SocketAddr>,
+    relay_url: Option<String>,
+    cached: Mutex<Option<IrohTransport>>,
+}
+
+impl LazyIrohTransport {
+    /// Create a lazy transport for the iroh peer identified by `node_id`. No
+    /// connection is made until the first `send()`.
+    pub fn new(node_id: [u8; 32], direct_addrs: Vec<SocketAddr>, relay_url: Option<String>) -> Self {
+        Self {
+            node_id,
+            direct_addrs,
+            relay_url,
+            cached: Mutex::new(None),
+        }
+    }
+
+    /// Build the iroh `EndpointAddr` for the peer from the stored primitives.
+    fn endpoint_addr(&self) -> Result<iroh::EndpointAddr> {
+        use iroh::{EndpointAddr, EndpointId, TransportAddr};
+        let id = EndpointId::from_bytes(&self.node_id)
+            .map_err(|e| anyhow!("invalid iroh node_id: {e}"))?;
+        let mut transport_addrs: Vec<TransportAddr> =
+            self.direct_addrs.iter().copied().map(TransportAddr::Ip).collect();
+        if let Some(url) = &self.relay_url {
+            let relay = url
+                .parse()
+                .map_err(|e| anyhow!("invalid iroh relay_url '{url}': {e}"))?;
+            transport_addrs.push(TransportAddr::Relay(relay));
+        }
+        Ok(EndpointAddr::from_parts(id, transport_addrs))
+    }
+
+    /// Return the cached connected transport, dialing once (single-flight under
+    /// the lock) if not yet connected.
+    async fn connected(&self) -> Result<IrohTransport> {
+        let mut guard = self.cached.lock().await;
+        if let Some(transport) = guard.as_ref() {
+            return Ok(transport.clone());
+        }
+        let endpoint = iroh_client_endpoint().ok_or_else(|| {
+            anyhow!(
+                "no iroh client endpoint installed — call \
+                 install_iroh_client_endpoint() at startup before dialing iroh peers"
+            )
+        })?;
+        let addr = self.endpoint_addr()?;
+        let conn = endpoint
+            .connect(addr, ALPN_HYPRSTREAM_RPC)
+            .await
+            .map_err(|e| anyhow!("iroh connect: {e}"))?;
+        let transport = IrohTransport::new(conn);
+        *guard = Some(transport.clone());
+        Ok(transport)
+    }
+
+    /// Drop the cached session so the next `send()` re-dials.
+    async fn invalidate(&self) {
+        *self.cached.lock().await = None;
+    }
+}
+
+#[async_trait]
+impl Transport for LazyIrohTransport {
+    type Sub = IrohPendingStream;
+    type Pub = IrohPublishStub;
+
+    async fn send(&self, payload: Vec<u8>, timeout_ms: Option<i32>) -> Result<Vec<u8>> {
+        let transport = self.connected().await?;
+
+        // Our deadline is authoritative so a per-request timeout (busy peer —
+        // keep the session) is distinguishable from a transport-fatal error
+        // (re-dial), matching LazyQuinnTransport.
+        let deadline = timeout_ms
+            .map(|ms| Duration::from_millis(ms.max(0) as u64))
+            .unwrap_or(DEFAULT_TIMEOUT);
+        let inner_ceiling_ms = deadline.as_millis().saturating_mul(2).min(i32::MAX as u128) as i32;
+
+        match tokio::time::timeout(deadline, transport.send(payload, Some(inner_ceiling_ms))).await {
+            Err(_elapsed) => Err(anyhow!("iroh RPC timeout after {deadline:?}")),
+            Ok(Ok(resp)) => Ok(resp),
+            Ok(Err(e)) => {
+                self.invalidate().await;
+                Err(e)
+            }
+        }
+    }
+
+    async fn subscribe(&self, _topic: &[u8]) -> Result<Self::Sub> {
+        bail!("lazy iroh RPC transport does not support SUB — streaming is on the moq plane")
+    }
+
+    async fn publish(&self, _topic: &[u8]) -> Result<Self::Pub> {
+        bail!("lazy iroh RPC transport does not support PUB — streaming is on the moq plane")
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::transport::iroh_substrate::{EchoHandler, IrohSubstrate, NoopHandler};
+
+    fn fresh_key() -> [u8; 32] {
+        use rand::RngCore;
+        let mut k = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut k);
+        k
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn lazy_iroh_connects_on_first_send_and_caches() {
+        // Echo server substrate.
+        let server = IrohSubstrate::new(fresh_key(), EchoHandler, EchoHandler).await.unwrap();
+        let server_id = server.endpoint_id();
+        let direct: Vec<SocketAddr> = server.endpoint().bound_sockets().into_iter().collect();
+
+        // Client substrate (originates only); install its endpoint as the global.
+        let client = IrohSubstrate::new(
+            fresh_key(),
+            NoopHandler::new("client moq"),
+            NoopHandler::new("client rpc"),
+        )
+        .await
+        .unwrap();
+        let _ = install_iroh_client_endpoint(client.endpoint().clone());
+
+        let node_id: [u8; 32] = *server_id.as_bytes();
+        let t = LazyIrohTransport::new(node_id, direct, None);
+        assert!(t.cached.lock().await.is_none(), "no connection before first send");
+
+        // EchoHandler echoes the bytes written on the bidi stream, which is the
+        // same shape SessionRpcTransport::send uses (write payload → read to
+        // FIN), so the lazy transport round-trips them. (EchoHandler is a
+        // one-shot smoke handler — it closes the connection after a single
+        // stream, so we don't test session *reuse* here; the multiplexed-stream
+        // path is covered by quinn_transport's round-trip test against a real
+        // QuinnRpcServer, which IrohTransport shares via SessionRpcTransport.)
+        let resp = t.send(b"ping".to_vec(), Some(4_000)).await.unwrap();
+        assert_eq!(resp, b"ping");
+        assert!(t.cached.lock().await.is_some(), "session cached after first send");
+
+        client.shutdown().await.unwrap();
+        server.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn subscribe_publish_bail() {
+        let t = LazyIrohTransport::new([0u8; 32], vec![], None);
+        assert!(t.subscribe(b"topic").await.is_err());
+        assert!(t.publish(b"topic").await.is_err());
+    }
+}

--- a/crates/hyprstream-rpc/src/transport/lazy_iroh.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_iroh.rs
@@ -42,6 +42,11 @@ use crate::transport_traits::Transport;
 /// Default per-request deadline when the caller passes `None`.
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Ceiling on the lazy connect (iroh dial + handshake). The per-request deadline
+/// wraps only the request; without this an unreachable peer would hang the first
+/// `send()` indefinitely.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Process-wide client iroh endpoint, installed once at startup.
 static IROH_CLIENT_ENDPOINT: OnceLock<iroh::Endpoint> = OnceLock::new();
 
@@ -111,9 +116,9 @@ impl LazyIrohTransport {
             )
         })?;
         let addr = self.endpoint_addr()?;
-        let conn = endpoint
-            .connect(addr, ALPN_HYPRSTREAM_RPC)
+        let conn = tokio::time::timeout(CONNECT_TIMEOUT, endpoint.connect(addr, ALPN_HYPRSTREAM_RPC))
             .await
+            .map_err(|_| anyhow!("iroh connect timed out after {CONNECT_TIMEOUT:?}"))?
             .map_err(|e| anyhow!("iroh connect: {e}"))?;
         let transport = IrohTransport::new(conn);
         *guard = Some(transport.clone());

--- a/crates/hyprstream-rpc/src/transport/lazy_quinn.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_quinn.rs
@@ -30,8 +30,9 @@ use async_trait::async_trait;
 use tokio::sync::Mutex;
 
 use crate::transport::quinn_transport::{
-    connect_pinned_sha256, QuinnPendingStream, QuinnPublishStub, QuinnTransport,
+    connect_pinned_sha256, connect_webpki, QuinnPendingStream, QuinnPublishStub, QuinnTransport,
 };
+use crate::transport::QuicServerAuth;
 use crate::transport_traits::Transport;
 
 /// Default per-request deadline when the caller passes `None`, mirroring
@@ -41,31 +42,42 @@ const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 /// A quinn RPC transport that connects on first use and caches the session.
 pub struct LazyQuinnTransport {
     addr: SocketAddr,
-    cert_pin: [u8; 32],
+    server_name: String,
+    auth: QuicServerAuth,
     /// `None` until the first successful dial, and reset to `None` after a
     /// `send()` failure so the next call re-dials.
     cached: Mutex<Option<QuinnTransport>>,
 }
 
 impl LazyQuinnTransport {
-    /// Create a lazy transport for a QUIC peer pinned by `cert_pin` (the SHA-256
-    /// of its self-signed cert). No connection is made until the first `send()`.
-    pub fn new(addr: SocketAddr, cert_pin: [u8; 32]) -> Self {
+    /// Create a lazy transport for a QUIC peer, authenticated per `auth`
+    /// (WebPKI, cert-hash pin, or — later — RFC 7250 raw key). No connection is
+    /// made until the first `send()`.
+    pub fn new(addr: SocketAddr, server_name: impl Into<String>, auth: QuicServerAuth) -> Self {
         Self {
             addr,
-            cert_pin,
+            server_name: server_name.into(),
+            auth,
             cached: Mutex::new(None),
         }
     }
 
     /// Return the cached connected transport, dialing once (under the lock —
-    /// single-flight) if not yet connected.
+    /// single-flight) if not yet connected. The connect path is chosen by the
+    /// server-auth policy.
     async fn connected(&self) -> Result<QuinnTransport> {
         let mut guard = self.cached.lock().await;
         if let Some(transport) = guard.as_ref() {
             return Ok(transport.clone());
         }
-        let session = connect_pinned_sha256(self.addr, self.cert_pin).await?;
+        let session = match &self.auth {
+            QuicServerAuth::WebPki => connect_webpki(&self.server_name, self.addr.port()).await?,
+            QuicServerAuth::Pinned(hash) => connect_pinned_sha256(self.addr, *hash).await?,
+            QuicServerAuth::RawPublicKey(_) => bail!(
+                "RFC 7250 raw-public-key QUIC auth is not yet implemented (#200) — use iroh \
+                 for identity-bound transport, or QuicServerAuth::Pinned / WebPki"
+            ),
+        };
         let transport = QuinnTransport::new(session);
         *guard = Some(transport.clone());
         Ok(transport)
@@ -178,7 +190,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn lazy_connects_on_first_send_and_caches() {
         let (addr, pin, shutdown) = spawn_echo_server();
-        let t = LazyQuinnTransport::new(addr, pin);
+        let t = LazyQuinnTransport::new(addr, "localhost", QuicServerAuth::Pinned(pin));
 
         assert!(t.cached.lock().await.is_none(), "no connection before first send");
 
@@ -195,7 +207,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn wrong_cert_pin_does_not_connect() {
         let (addr, _pin, shutdown) = spawn_echo_server();
-        let t = LazyQuinnTransport::new(addr, [0u8; 32]); // wrong fingerprint
+        let t = LazyQuinnTransport::new(addr, "localhost", QuicServerAuth::Pinned([0u8; 32])); // wrong fingerprint
         // The TLS handshake must *promptly reject* a wrong pin: the send must
         // COMPLETE with an error well within the hang-guard. If the guard fires
         // (i.e. send hung), the test fails — so a hang can't masquerade as a pass.
@@ -209,7 +221,11 @@ mod tests {
 
     #[tokio::test]
     async fn subscribe_publish_bail() {
-        let t = LazyQuinnTransport::new("127.0.0.1:1".parse().unwrap(), [0u8; 32]);
+        let t = LazyQuinnTransport::new(
+            "127.0.0.1:1".parse().unwrap(),
+            "localhost",
+            QuicServerAuth::Pinned([0u8; 32]),
+        );
         assert!(t.subscribe(b"topic").await.is_err());
         assert!(t.publish(b"topic").await.is_err());
     }

--- a/crates/hyprstream-rpc/src/transport/lazy_quinn.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_quinn.rs
@@ -23,8 +23,9 @@
 //! lock — only the dial does.
 
 use std::net::SocketAddr;
+use std::time::Duration;
 
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 use async_trait::async_trait;
 use tokio::sync::Mutex;
 
@@ -32,6 +33,10 @@ use crate::transport::quinn_transport::{
     connect_pinned_sha256, QuinnPendingStream, QuinnPublishStub, QuinnTransport,
 };
 use crate::transport_traits::Transport;
+
+/// Default per-request deadline when the caller passes `None`, mirroring
+/// `SessionRpcTransport`.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// A quinn RPC transport that connects on first use and caches the session.
 pub struct LazyQuinnTransport {
@@ -79,9 +84,28 @@ impl Transport for LazyQuinnTransport {
 
     async fn send(&self, payload: Vec<u8>, timeout_ms: Option<i32>) -> Result<Vec<u8>> {
         let transport = self.connected().await?;
-        match transport.send(payload, timeout_ms).await {
-            Ok(resp) => Ok(resp),
-            Err(e) => {
+
+        // Make *our* deadline authoritative so we can tell a per-request timeout
+        // (the connection is probably fine — keep it) apart from a transport-fatal
+        // error (re-dial). The inner transport gets a generous ceiling that fires
+        // only if ours somehow doesn't.
+        let deadline = timeout_ms
+            .map(|ms| Duration::from_millis(ms.max(0) as u64))
+            .unwrap_or(DEFAULT_TIMEOUT);
+        let inner_ceiling_ms = deadline
+            .as_millis()
+            .saturating_mul(2)
+            .min(i32::MAX as u128) as i32;
+
+        match tokio::time::timeout(deadline, transport.send(payload, Some(inner_ceiling_ms))).await {
+            // Our deadline fired: a slow/stalled request, not necessarily a dead
+            // connection. Keep the cached session — re-dialing on every timeout
+            // would thrash a merely-busy peer. (#156 owns liveness-based re-dial.)
+            Err(_elapsed) => Err(anyhow!("quinn RPC timeout after {deadline:?}")),
+            Ok(Ok(resp)) => Ok(resp),
+            // Transport-fatal (open_bi/write/read failed): the session is likely
+            // dead — drop it so the next call re-dials, like ZmqConnection.
+            Ok(Err(e)) => {
                 self.invalidate().await;
                 Err(e)
             }
@@ -172,11 +196,13 @@ mod tests {
     async fn wrong_cert_pin_does_not_connect() {
         let (addr, _pin, shutdown) = spawn_echo_server();
         let t = LazyQuinnTransport::new(addr, [0u8; 32]); // wrong fingerprint
-        let res = tokio::time::timeout(Duration::from_secs(5), t.send(b"x".to_vec(), Some(2_000)))
-            .await;
-        // Either the dial errors, or it times out — never a successful echo.
-        let connected = matches!(&res, Ok(Ok(_)));
-        assert!(!connected, "a wrong cert pin must not yield a working connection");
+        // The TLS handshake must *promptly reject* a wrong pin: the send must
+        // COMPLETE with an error well within the hang-guard. If the guard fires
+        // (i.e. send hung), the test fails — so a hang can't masquerade as a pass.
+        let res = tokio::time::timeout(Duration::from_secs(8), t.send(b"x".to_vec(), Some(3_000)))
+            .await
+            .expect("send must complete (with an error) — a wrong pin should reject, not hang");
+        assert!(res.is_err(), "a wrong cert pin must make send fail");
         assert!(t.cached.lock().await.is_none(), "failed dial leaves nothing cached");
         shutdown.cancel();
     }

--- a/crates/hyprstream-rpc/src/transport/lazy_quinn.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_quinn.rs
@@ -1,0 +1,190 @@
+//! Lazy-connecting quinn RPC transport.
+//!
+//! The [`dial`](crate::dial::dial) factory is synchronous and does no I/O, but a
+//! networked QUIC peer must be connected before the first request. This wrapper
+//! bridges that: it holds the dial target (`addr` + the server cert's SHA-256
+//! pin) and connects on the **first `send()`**, caching the established session
+//! for subsequent calls — exactly the lazy-connect model `ZmqConnection` uses,
+//! so sync construction + zero I/O at dial time is preserved (A1 spike).
+//!
+//! # Re-dial / self-heal
+//!
+//! On a `send()` error the cached session is dropped, so the next call re-dials
+//! — like `ZmqConnection`, which a dead cached session would otherwise not
+//! recover from. This is deliberately **coarse**: it re-dials on *any* failure,
+//! including a per-request timeout on an otherwise-live connection. Refined,
+//! liveness-based re-dial with backoff is the connection-manager's job (#156);
+//! this wrapper only needs to not strand a dead session.
+//!
+//! Concurrent first-sends are **single-flighted**: the dial happens under the
+//! cache lock, so N racing callers dial once and the rest reuse the session.
+//! The connected handle is cloned out from under the lock (both `QuinnTransport`
+//! and its `Session` are cheap `Clone`), so `send()` itself never holds the
+//! lock — only the dial does.
+
+use std::net::SocketAddr;
+
+use anyhow::{bail, Result};
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+
+use crate::transport::quinn_transport::{
+    connect_pinned_sha256, QuinnPendingStream, QuinnPublishStub, QuinnTransport,
+};
+use crate::transport_traits::Transport;
+
+/// A quinn RPC transport that connects on first use and caches the session.
+pub struct LazyQuinnTransport {
+    addr: SocketAddr,
+    cert_pin: [u8; 32],
+    /// `None` until the first successful dial, and reset to `None` after a
+    /// `send()` failure so the next call re-dials.
+    cached: Mutex<Option<QuinnTransport>>,
+}
+
+impl LazyQuinnTransport {
+    /// Create a lazy transport for a QUIC peer pinned by `cert_pin` (the SHA-256
+    /// of its self-signed cert). No connection is made until the first `send()`.
+    pub fn new(addr: SocketAddr, cert_pin: [u8; 32]) -> Self {
+        Self {
+            addr,
+            cert_pin,
+            cached: Mutex::new(None),
+        }
+    }
+
+    /// Return the cached connected transport, dialing once (under the lock —
+    /// single-flight) if not yet connected.
+    async fn connected(&self) -> Result<QuinnTransport> {
+        let mut guard = self.cached.lock().await;
+        if let Some(transport) = guard.as_ref() {
+            return Ok(transport.clone());
+        }
+        let session = connect_pinned_sha256(self.addr, self.cert_pin).await?;
+        let transport = QuinnTransport::new(session);
+        *guard = Some(transport.clone());
+        Ok(transport)
+    }
+
+    /// Drop the cached session so the next `send()` re-dials.
+    async fn invalidate(&self) {
+        *self.cached.lock().await = None;
+    }
+}
+
+#[async_trait]
+impl Transport for LazyQuinnTransport {
+    type Sub = QuinnPendingStream;
+    type Pub = QuinnPublishStub;
+
+    async fn send(&self, payload: Vec<u8>, timeout_ms: Option<i32>) -> Result<Vec<u8>> {
+        let transport = self.connected().await?;
+        match transport.send(payload, timeout_ms).await {
+            Ok(resp) => Ok(resp),
+            Err(e) => {
+                self.invalidate().await;
+                Err(e)
+            }
+        }
+    }
+
+    async fn subscribe(&self, _topic: &[u8]) -> Result<Self::Sub> {
+        bail!("lazy quinn RPC transport does not support SUB — streaming is on the moq plane")
+    }
+
+    async fn publish(&self, _topic: &[u8]) -> Result<Self::Pub> {
+        bail!("lazy quinn RPC transport does not support PUB — streaming is on the moq plane")
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::transport::quinn_transport::QuinnRpcServer;
+    use bytes::Bytes;
+    use ed25519_dalek::SigningKey;
+    use rand::RngCore;
+    use std::time::Duration;
+    use tokio_util::sync::CancellationToken;
+
+    fn fresh_signing_key() -> SigningKey {
+        let mut k = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut k);
+        SigningKey::from_bytes(&k)
+    }
+
+    fn sha256_32(bytes: &[u8]) -> [u8; 32] {
+        use sha2::{Digest, Sha256};
+        let mut h = [0u8; 32];
+        h.copy_from_slice(&Sha256::digest(bytes));
+        h
+    }
+
+    /// Hermetic loopback WebTransport echo server. Returns the bound addr, the
+    /// server cert's SHA-256 pin, and a shutdown token. (Mirrors the harness in
+    /// `quinn_transport::tests`; `build_server` there is test-private.)
+    fn spawn_echo_server() -> (SocketAddr, [u8; 32], CancellationToken) {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let cert_key =
+            rcgen::generate_simple_self_signed(vec!["localhost".to_owned()]).unwrap();
+        let cert_der = cert_key.cert.der().to_vec();
+        let key_der = cert_key.key_pair.serialize_der();
+        let chain = vec![rustls::pki_types::CertificateDer::from(cert_der.clone())];
+        let key = rustls::pki_types::PrivateKeyDer::Pkcs8(
+            rustls::pki_types::PrivatePkcs8KeyDer::from(key_der),
+        );
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let server = web_transport_quinn::ServerBuilder::new()
+            .with_addr(addr)
+            .with_certificate(chain, key)
+            .unwrap();
+        let bound = server.local_addr().unwrap();
+
+        let processor =
+            crate::transport::rpc_session::from_fn(|req: Bytes| async move { Ok(req) });
+        let rpc_server = QuinnRpcServer::new(server, processor, fresh_signing_key());
+        let shutdown = rpc_server.shutdown_token();
+        tokio::spawn(rpc_server.run());
+
+        (bound, sha256_32(&cert_der), shutdown)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn lazy_connects_on_first_send_and_caches() {
+        let (addr, pin, shutdown) = spawn_echo_server();
+        let t = LazyQuinnTransport::new(addr, pin);
+
+        assert!(t.cached.lock().await.is_none(), "no connection before first send");
+
+        let resp = t.send(b"hello".to_vec(), Some(5_000)).await.unwrap();
+        assert_eq!(resp, b"hello");
+        assert!(t.cached.lock().await.is_some(), "session cached after first send");
+
+        let resp2 = t.send(b"again".to_vec(), Some(5_000)).await.unwrap();
+        assert_eq!(resp2, b"again");
+
+        shutdown.cancel();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn wrong_cert_pin_does_not_connect() {
+        let (addr, _pin, shutdown) = spawn_echo_server();
+        let t = LazyQuinnTransport::new(addr, [0u8; 32]); // wrong fingerprint
+        let res = tokio::time::timeout(Duration::from_secs(5), t.send(b"x".to_vec(), Some(2_000)))
+            .await;
+        // Either the dial errors, or it times out — never a successful echo.
+        let connected = matches!(&res, Ok(Ok(_)));
+        assert!(!connected, "a wrong cert pin must not yield a working connection");
+        assert!(t.cached.lock().await.is_none(), "failed dial leaves nothing cached");
+        shutdown.cancel();
+    }
+
+    #[tokio::test]
+    async fn subscribe_publish_bail() {
+        let t = LazyQuinnTransport::new("127.0.0.1:1".parse().unwrap(), [0u8; 32]);
+        assert!(t.subscribe(b"topic").await.is_err());
+        assert!(t.publish(b"topic").await.is_err());
+    }
+}

--- a/crates/hyprstream-rpc/src/transport/lazy_quinn.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_quinn.rs
@@ -2,10 +2,12 @@
 //!
 //! The [`dial`](crate::dial::dial) factory is synchronous and does no I/O, but a
 //! networked QUIC peer must be connected before the first request. This wrapper
-//! bridges that: it holds the dial target (`addr` + the server cert's SHA-256
-//! pin) and connects on the **first `send()`**, caching the established session
-//! for subsequent calls — exactly the lazy-connect model `ZmqConnection` uses,
-//! so sync construction + zero I/O at dial time is preserved (A1 spike).
+//! bridges that: it holds the dial target (`addr` + `server_name` + the
+//! [`QuicServerAuth`](crate::transport::QuicServerAuth) policy) and connects on
+//! the **first `send()`**, caching the established session for subsequent calls
+//! — exactly the lazy-connect model `ZmqConnection` uses, so sync construction +
+//! zero I/O at dial time is preserved (A1 spike). The connect path (WebPKI vs
+//! cert-hash pin) is selected by the auth policy.
 //!
 //! # Re-dial / self-heal
 //!
@@ -39,6 +41,11 @@ use crate::transport_traits::Transport;
 /// `SessionRpcTransport`.
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Ceiling on the lazy connect itself (TLS handshake + dial). The per-request
+/// deadline wraps only the *request*; without this a dead/misrouted address (or
+/// a stalled handshake) would hang the first `send()` indefinitely.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// A quinn RPC transport that connects on first use and caches the session.
 pub struct LazyQuinnTransport {
     addr: SocketAddr,
@@ -70,14 +77,19 @@ impl LazyQuinnTransport {
         if let Some(transport) = guard.as_ref() {
             return Ok(transport.clone());
         }
-        let session = match &self.auth {
-            QuicServerAuth::WebPki => connect_webpki(&self.server_name, self.addr.port()).await?,
-            QuicServerAuth::Pinned(hash) => connect_pinned_sha256(self.addr, *hash).await?,
-            QuicServerAuth::RawPublicKey(_) => bail!(
-                "RFC 7250 raw-public-key QUIC auth is not yet implemented (#200) — use iroh \
-                 for identity-bound transport, or QuicServerAuth::Pinned / WebPki"
-            ),
+        let connect = async {
+            match &self.auth {
+                QuicServerAuth::WebPki => connect_webpki(&self.server_name, self.addr.port()).await,
+                QuicServerAuth::Pinned(hash) => connect_pinned_sha256(self.addr, *hash).await,
+                QuicServerAuth::RawPublicKey(_) => bail!(
+                    "RFC 7250 raw-public-key QUIC auth is not yet implemented (#200) — use iroh \
+                     for identity-bound transport, or QuicServerAuth::Pinned / WebPki"
+                ),
+            }
         };
+        let session = tokio::time::timeout(CONNECT_TIMEOUT, connect)
+            .await
+            .map_err(|_| anyhow!("quinn connect timed out after {CONNECT_TIMEOUT:?}"))??;
         let transport = QuinnTransport::new(session);
         *guard = Some(transport.clone());
         Ok(transport)
@@ -217,6 +229,23 @@ mod tests {
         assert!(res.is_err(), "a wrong cert pin must make send fail");
         assert!(t.cached.lock().await.is_none(), "failed dial leaves nothing cached");
         shutdown.cancel();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dead_address_send_fails_fast_not_hang() {
+        // No server at 127.0.0.1:1 → the lazy connect must fail (or hit
+        // CONNECT_TIMEOUT) so `send()` returns an error rather than hanging
+        // forever. The guard (> CONNECT_TIMEOUT) fails the test if it hangs.
+        let t = LazyQuinnTransport::new(
+            "127.0.0.1:1".parse().unwrap(),
+            "localhost",
+            QuicServerAuth::Pinned([0u8; 32]),
+        );
+        let res = tokio::time::timeout(Duration::from_secs(13), t.send(b"x".to_vec(), Some(2_000)))
+            .await
+            .expect("send must complete (with an error) within the connect timeout, not hang");
+        assert!(res.is_err(), "a dead address must yield an error, not a connection");
+        assert!(t.cached.lock().await.is_none(), "a failed connect caches nothing");
     }
 
     #[tokio::test]

--- a/crates/hyprstream-rpc/src/transport/lazy_quinn.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_quinn.rs
@@ -32,7 +32,8 @@ use async_trait::async_trait;
 use tokio::sync::Mutex;
 
 use crate::transport::quinn_transport::{
-    connect_pinned_sha256, connect_webpki, QuinnPendingStream, QuinnPublishStub, QuinnTransport,
+    connect_pinned_hashes, connect_webpki, verify_peer_cert_pinned, QuinnPendingStream,
+    QuinnPublishStub, QuinnTransport,
 };
 use crate::transport::QuicServerAuth;
 use crate::transport_traits::Transport;
@@ -78,13 +79,22 @@ impl LazyQuinnTransport {
             return Ok(transport.clone());
         }
         let connect = async {
-            match &self.auth {
-                QuicServerAuth::WebPki => connect_webpki(&self.server_name, self.addr.port()).await,
-                QuicServerAuth::Pinned(hash) => connect_pinned_sha256(self.addr, *hash).await,
-                QuicServerAuth::RawPublicKey(_) => bail!(
-                    "RFC 7250 raw-public-key QUIC auth is not yet implemented (#200) — use iroh \
-                     for identity-bound transport, or QuicServerAuth::Pinned / WebPki"
-                ),
+            let hashes = self.auth.accept_cert_hashes();
+            match (self.auth.require_web_pki(), hashes.is_empty()) {
+                // WebPKI only.
+                (true, true) => connect_webpki(&self.server_name, self.addr.port()).await,
+                // Pin only (self-signed) — verified in-handshake by cert-hash.
+                (false, false) => connect_pinned_hashes(self.addr, hashes).await,
+                // WebPKI + pin: CA-validate in the handshake, then enforce the
+                // pin on the established session before any RPC flows.
+                (true, false) => {
+                    let session = connect_webpki(&self.server_name, self.addr.port()).await?;
+                    verify_peer_cert_pinned(&session, hashes)?;
+                    Ok(session)
+                }
+                // No auth at all — unreachable: QuicServerAuth's constructors
+                // reject the empty case.
+                (false, true) => bail!("QUIC endpoint has no server-auth requirement"),
             }
         };
         let session = tokio::time::timeout(CONNECT_TIMEOUT, connect)
@@ -202,7 +212,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn lazy_connects_on_first_send_and_caches() {
         let (addr, pin, shutdown) = spawn_echo_server();
-        let t = LazyQuinnTransport::new(addr, "localhost", QuicServerAuth::Pinned(pin));
+        let t = LazyQuinnTransport::new(addr, "localhost", QuicServerAuth::pinned(vec![pin]).unwrap());
 
         assert!(t.cached.lock().await.is_none(), "no connection before first send");
 
@@ -219,7 +229,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn wrong_cert_pin_does_not_connect() {
         let (addr, _pin, shutdown) = spawn_echo_server();
-        let t = LazyQuinnTransport::new(addr, "localhost", QuicServerAuth::Pinned([0u8; 32])); // wrong fingerprint
+        let t = LazyQuinnTransport::new(addr, "localhost", QuicServerAuth::pinned(vec![[0u8; 32]]).unwrap()); // wrong fingerprint
         // The TLS handshake must *promptly reject* a wrong pin: the send must
         // COMPLETE with an error well within the hang-guard. If the guard fires
         // (i.e. send hung), the test fails — so a hang can't masquerade as a pass.
@@ -239,7 +249,7 @@ mod tests {
         let t = LazyQuinnTransport::new(
             "127.0.0.1:1".parse().unwrap(),
             "localhost",
-            QuicServerAuth::Pinned([0u8; 32]),
+            QuicServerAuth::pinned(vec![[0u8; 32]]).unwrap(),
         );
         let res = tokio::time::timeout(Duration::from_secs(13), t.send(b"x".to_vec(), Some(2_000)))
             .await
@@ -253,7 +263,7 @@ mod tests {
         let t = LazyQuinnTransport::new(
             "127.0.0.1:1".parse().unwrap(),
             "localhost",
-            QuicServerAuth::Pinned([0u8; 32]),
+            QuicServerAuth::pinned(vec![[0u8; 32]]).unwrap(),
         );
         assert!(t.subscribe(b"topic").await.is_err());
         assert!(t.publish(b"topic").await.is_err());

--- a/crates/hyprstream-rpc/src/transport/lazy_uds.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_uds.rs
@@ -1,0 +1,209 @@
+//! Lazy-connecting UDS RPC transport (same-host `ipc` plane).
+//!
+//! Mirrors [`LazyQuinnTransport`](super::lazy_quinn::LazyQuinnTransport) and
+//! [`LazyIrohTransport`](super::lazy_iroh::LazyIrohTransport): the
+//! [`dial`](crate::dial::dial) factory is synchronous, so this holds the socket
+//! path and connects on the **first `send()`**, caching the session — preserving
+//! sync, zero-I/O construction.
+//!
+//! The connection is a [`UdsSession`](super::uds_session::UdsSession) on the RPC
+//! plane (`PLANE_RPC`), wrapped as a [`SessionRpcTransport`] — the *same* generic
+//! client used by the quinn and iroh backends, so the ipc plane carries the
+//! identical Cap'n Proto bidi wire protocol with no transport-specific RPC code.
+//! This is the post-ZMQ `ipc` transport: same-host processes keep `ipc`,
+//! re-platformed off ZMQ framing onto SignedEnvelope-over-UDS.
+//!
+//! # Identity
+//!
+//! UDS has no transport-level peer identity; same-host trust + the app-layer
+//! `SignedEnvelope` (verified against the response key) are the authentication.
+//! Socket-file permissions + `SO_PEERCRED` are defense-in-depth owned by the
+//! daemon that binds the listener (see #207). A `None` `server_verifying_key`
+//! leaves the response identity unpinned (the envelope sig is still verified),
+//! matching the quinn arm.
+//!
+//! Re-dial/self-heal semantics match the other lazy transports: a per-request
+//! timeout keeps the session; a transport-fatal error drops it so the next call
+//! re-dials.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Result};
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+
+use super::rpc_session::{RpcPendingStream, RpcPublishStub, SessionRpcTransport};
+use super::uds_session::{connect_uds, UdsSession, PLANE_RPC};
+use crate::transport_traits::Transport;
+
+/// Default per-request deadline when the caller passes `None`.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Ceiling on the lazy connect (UDS connect + yamux/SETUP). The per-request
+/// deadline wraps only the request; without this a missing socket would hang the
+/// first `send()`.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// A UDS RPC transport that connects on first use and caches the session.
+pub struct LazyUdsTransport {
+    path: PathBuf,
+    cached: Mutex<Option<SessionRpcTransport<UdsSession>>>,
+}
+
+impl LazyUdsTransport {
+    /// Create a lazy transport for the UDS endpoint at `path`. No connection is
+    /// made until the first `send()`.
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            cached: Mutex::new(None),
+        }
+    }
+
+    /// Return the cached connected transport, connecting once (single-flight
+    /// under the lock) if not yet connected.
+    async fn connected(&self) -> Result<SessionRpcTransport<UdsSession>> {
+        let mut guard = self.cached.lock().await;
+        if let Some(transport) = guard.as_ref() {
+            return Ok(transport.clone());
+        }
+        let session = tokio::time::timeout(CONNECT_TIMEOUT, connect_uds(&self.path, PLANE_RPC))
+            .await
+            .map_err(|_| {
+                anyhow!(
+                    "uds connect to {} timed out after {CONNECT_TIMEOUT:?}",
+                    self.path.display()
+                )
+            })?
+            .map_err(|e| anyhow!("uds connect to {}: {e}", self.path.display()))?;
+        let transport = SessionRpcTransport::new(session);
+        *guard = Some(transport.clone());
+        Ok(transport)
+    }
+
+    /// Drop the cached session so the next `send()` re-connects.
+    async fn invalidate(&self) {
+        *self.cached.lock().await = None;
+    }
+}
+
+#[async_trait]
+impl Transport for LazyUdsTransport {
+    type Sub = RpcPendingStream;
+    type Pub = RpcPublishStub;
+
+    async fn send(&self, payload: Vec<u8>, timeout_ms: Option<i32>) -> Result<Vec<u8>> {
+        let transport = self.connected().await?;
+
+        // Our deadline is authoritative so a per-request timeout (busy peer —
+        // keep the session) is distinguishable from a transport-fatal error
+        // (re-connect), matching the other lazy transports.
+        let deadline = timeout_ms
+            .map(|ms| Duration::from_millis(ms.max(0) as u64))
+            .unwrap_or(DEFAULT_TIMEOUT);
+        let inner_ceiling_ms = deadline.as_millis().saturating_mul(2).min(i32::MAX as u128) as i32;
+
+        match tokio::time::timeout(deadline, transport.send(payload, Some(inner_ceiling_ms))).await {
+            Err(_elapsed) => Err(anyhow!("uds RPC timeout after {deadline:?}")),
+            Ok(Ok(resp)) => Ok(resp),
+            Ok(Err(e)) => {
+                self.invalidate().await;
+                Err(e)
+            }
+        }
+    }
+
+    async fn subscribe(&self, _topic: &[u8]) -> Result<Self::Sub> {
+        bail!("lazy UDS RPC transport does not support SUB — streaming is on the moq plane")
+    }
+
+    async fn publish(&self, _topic: &[u8]) -> Result<Self::Pub> {
+        bail!("lazy UDS RPC transport does not support PUB — streaming is on the moq plane")
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::transport::rpc_session::{
+        from_fn, serve_rpc_connection, DEFAULT_STREAM_LIMIT, REQUEST_READ_TIMEOUT,
+    };
+    use crate::transport::uds_session::accept_uds;
+    use bytes::Bytes;
+    use std::sync::Arc;
+    use tokio::sync::Semaphore;
+    use tokio_util::sync::CancellationToken;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn lazy_uds_connects_on_first_send_and_caches() {
+        let dir = std::env::temp_dir().join(format!("lazy-uds-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("rpc.sock");
+        let _ = std::fs::remove_file(&path);
+        let listener = tokio::net::UnixListener::bind(&path).unwrap();
+
+        // Echo RPC server over UDS.
+        let shutdown = CancellationToken::new();
+        let shutdown_srv = shutdown.clone();
+        let srv = tokio::spawn(async move {
+            let (sk, _vk) = crate::generate_signing_keypair();
+            let processor = Arc::new(from_fn(|req: Bytes| async move { Ok(req) }));
+            let limit = Arc::new(Semaphore::new(DEFAULT_STREAM_LIMIT));
+            loop {
+                tokio::select! {
+                    _ = shutdown_srv.cancelled() => break,
+                    accepted = listener.accept() => {
+                        let (stream, _) = accepted.unwrap();
+                        let (plane, session) = accept_uds(stream).await.unwrap();
+                        assert_eq!(plane, PLANE_RPC);
+                        let p = Arc::clone(&processor);
+                        let l = Arc::clone(&limit);
+                        let sk = sk.clone();
+                        let sd = shutdown_srv.clone();
+                        tokio::spawn(async move {
+                            let _ = serve_rpc_connection(
+                                session, p, sk, l, REQUEST_READ_TIMEOUT, sd,
+                            )
+                            .await;
+                        });
+                    }
+                }
+            }
+        });
+
+        let t = LazyUdsTransport::new(path.clone());
+        assert!(t.cached.lock().await.is_none(), "no connection before first send");
+        let resp = t.send(b"ping".to_vec(), Some(4_000)).await.unwrap();
+        assert_eq!(resp, b"ping");
+        assert!(t.cached.lock().await.is_some(), "session cached after first send");
+        // Second call reuses the cached session (multiplexed stream).
+        let resp2 = t.send(b"pong".to_vec(), Some(4_000)).await.unwrap();
+        assert_eq!(resp2, b"pong");
+
+        shutdown.cancel();
+        let _ = srv.await;
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_dir(&dir);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn lazy_uds_missing_socket_errors_without_hang() {
+        let path = std::env::temp_dir().join(format!("lazy-uds-absent-{}.sock", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        let t = LazyUdsTransport::new(path);
+        let res = tokio::time::timeout(Duration::from_secs(5), t.send(b"x".to_vec(), Some(2_000)))
+            .await
+            .expect("send must complete (with an error), not hang");
+        assert!(res.is_err(), "dialing an absent socket must fail");
+        assert!(t.cached.lock().await.is_none(), "a failed connect caches nothing");
+    }
+
+    #[tokio::test]
+    async fn subscribe_publish_bail() {
+        let t = LazyUdsTransport::new(PathBuf::from("/nonexistent.sock"));
+        assert!(t.subscribe(b"topic").await.is_err());
+        assert!(t.publish(b"topic").await.is_err());
+    }
+}

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -11,6 +11,8 @@ mod traits;
 pub mod sockopt;
 pub mod zmtp_quic;
 pub mod quic_stream_bridge;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod iroh_substrate;
 
 use std::net::SocketAddr;
 use std::os::unix::io::RawFd;

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -33,6 +33,8 @@ pub mod lazy_iroh;
 pub mod uds_session;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod lazy_uds;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod uds_server;
 
 use std::net::SocketAddr;
 use std::os::unix::io::RawFd;

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -15,6 +15,8 @@ pub mod quic_stream_bridge;
 pub mod iroh_substrate;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod iroh_rpc;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod iroh_transport;
 
 use std::net::SocketAddr;
 use std::os::unix::io::RawFd;

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -13,6 +13,8 @@ pub mod zmtp_quic;
 pub mod quic_stream_bridge;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod iroh_substrate;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod iroh_rpc;
 
 use std::net::SocketAddr;
 use std::os::unix::io::RawFd;

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -335,6 +335,17 @@ impl TransportConfig {
         }
     }
 
+    /// Create a client QUIC endpoint with an explicit channel-auth policy
+    /// (used by the DID-doc service-entry codec, which may produce any of
+    /// WebPKI / Pinned / WebPKI+pin).
+    pub fn quic_with_auth(addr: SocketAddr, server_name: impl Into<String>, auth: QuicServerAuth) -> Self {
+        Self {
+            endpoint: EndpointType::Quic { addr, server_name: server_name.into(), auth },
+            curve: None,
+            bind_mode: BindMode::Connect,
+        }
+    }
+
     /// Create a client iroh endpoint dialing the peer identified by `node_id`
     /// (its `EndpointId` / Ed25519 public key), with optional direct addresses
     /// and relay URL for NAT traversal.

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -129,6 +129,38 @@ pub struct TransportConfig {
     pub bind_mode: BindMode,
 }
 
+/// How a QUIC client authenticates the server it dials.
+///
+/// Server authentication is a *policy*, not a single mechanism — this replaces
+/// the earlier hardcoded SHA-256 cert pin. All variants carry only
+/// serializable, public material so `TransportConfig` stays `Clone + Eq` and
+/// wire-publishable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QuicServerAuth {
+    /// Standard WebPKI / CA-chain validation against the system root store,
+    /// matching the server's DNS `server_name`. For public peers fronted by a
+    /// CA-issued certificate (dialed by hostname).
+    WebPki,
+    /// Pin the server's (self-signed) certificate by its SHA-256 fingerprint
+    /// (`with_server_certificate_hashes`) — the internal-mesh model, dialed by
+    /// IP. The resolver / DID doc vouches for the hash.
+    ///
+    /// SECURITY: authenticates the *channel* ("a server holding this cert"), not
+    /// the peer's DID *identity* (#185). For identity-bound transport use iroh
+    /// (which is RFC 7250 — the connection is bound to the peer's public key).
+    Pinned([u8; 32]),
+    /// RFC 7250 raw-public-key identity binding: the server proves possession of
+    /// this Ed25519 key during the TLS handshake.
+    ///
+    /// **Not yet implemented** — `web_transport_quinn`'s builder exposes no
+    /// raw-key/custom-verifier hook, so this needs a custom rustls verifier + a
+    /// raw `quinn` connect + `Session::raw`, plus a server-side raw-key config.
+    /// It is also browser-incompatible (WebTransport mandates cert hashes) and
+    /// overlaps iroh (which already provides RFC 7250). Tracked in #200; use
+    /// iroh for identity-bound native transport today.
+    RawPublicKey([u8; 32]),
+}
+
 /// Endpoint type (without encryption config)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EndpointType {
@@ -164,15 +196,13 @@ pub enum EndpointType {
     Quic {
         /// Socket address to bind (server) or connect (client)
         addr: SocketAddr,
-        /// Server hostname for TLS certificate validation
+        /// Server hostname — used as the WebPKI validation name (`WebPki`) and
+        /// the TLS SNI. Ignored by `Pinned` (which dials by IP and matches the
+        /// cert hash).
         server_name: String,
-        /// SHA-256 fingerprint of the server's self-signed certificate, for
-        /// client-side cert pinning (`with_server_certificate_hashes`). `None`
-        /// for the server/bind side or when peer authentication is provided
-        /// some other way (e.g. an expected response-signing key). Carrying the
-        /// 32-byte hash (not the full cert) keeps `TransportConfig` compact and
-        /// wire-publishable. Public fingerprint — not secret.
-        cert_pin: Option<[u8; 32]>,
+        /// How the client authenticates this server (WebPKI, cert-hash pin, or
+        /// — later — RFC 7250 raw key). Public material only.
+        auth: QuicServerAuth,
     },
 
     /// iroh transport endpoint (RPC over `ALPN_HYPRSTREAM_RPC`).
@@ -248,7 +278,7 @@ impl TransportConfig {
             endpoint: EndpointType::Quic {
                 addr,
                 server_name: server_name.into(),
-                cert_pin: None,
+                auth: QuicServerAuth::WebPki,
             },
             curve: None, // QUIC has TLS 1.3 built-in, no CurveZMQ needed
             bind_mode: BindMode::Bind,
@@ -256,14 +286,14 @@ impl TransportConfig {
     }
 
     /// Create a client QUIC endpoint that pins the server's self-signed cert by
-    /// its SHA-256 fingerprint (`cert_pin`). This is the dial target the
-    /// resolver/`dial()` produce for a networked RPC peer.
-    pub fn quic_pinned(addr: SocketAddr, server_name: impl Into<String>, cert_pin: [u8; 32]) -> Self {
+    /// its SHA-256 fingerprint. This is the dial target the resolver/`dial()`
+    /// produce for an internal-mesh RPC peer (dialed by IP).
+    pub fn quic_pinned(addr: SocketAddr, server_name: impl Into<String>, cert_hash: [u8; 32]) -> Self {
         Self {
             endpoint: EndpointType::Quic {
                 addr,
                 server_name: server_name.into(),
-                cert_pin: Some(cert_pin),
+                auth: QuicServerAuth::Pinned(cert_hash),
             },
             curve: None,
             bind_mode: BindMode::Connect,

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -17,6 +17,8 @@ pub mod iroh_substrate;
 pub mod iroh_rpc;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod iroh_transport;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod iroh_moq;
 
 use std::net::SocketAddr;
 use std::os::unix::io::RawFd;

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -129,36 +129,70 @@ pub struct TransportConfig {
     pub bind_mode: BindMode,
 }
 
-/// How a QUIC client authenticates the server it dials.
+/// How a QUIC client authenticates the **channel** to the server it dials.
 ///
-/// Server authentication is a *policy*, not a single mechanism — this replaces
-/// the earlier hardcoded SHA-256 cert pin. All variants carry only
-/// serializable, public material so `TransportConfig` stays `Clone + Eq` and
-/// wire-publishable.
+/// # This is channel auth, not identity auth
+///
+/// Peer *identity* ("which node is this") is established at the **application
+/// layer** — every response is a signed COSE `SignedEnvelope` verified against
+/// the peer's published keys (the DID-doc `#mesh` verification method / JWKS).
+/// That works identically on native and in WASM, because it is our code, not the
+/// browser's TLS stack. This type only decides how the *TLS channel* is
+/// authenticated (confidentiality + anti-active-MITM); it is defence in depth,
+/// not the trust root (#185).
+///
+/// Channel auth is a small lattice of independent requirements, not a fixed set
+/// of modes, so it is a validated struct rather than an enum of combinations:
+///   - `require_web_pki` — the leaf must chain to a system-trusted CA and match
+///     `server_name` (public peers, dialed by hostname).
+///   - `accept_cert_hashes` — a **set** of acceptable leaf-cert SHA-256s. A set
+///     (not one hash) so cert rotation can overlap (`{current, next}`) and
+///     load-balanced endpoints with distinct certs work. The resolver / DID doc
+///     supplies these — they are directory-distributed pins, not trust-on-first-
+///     use. (For browsers this is the *only* knob the WebTransport API exposes.)
+///
+/// The verifier ANDs the active requirements. At least one must be active —
+/// `{web_pki: false, hashes: []}` is no auth and is rejected at construction.
+///
+/// RFC 7250 raw-public-key binding (bind the channel to the published key
+/// directly, so native QUIC reuses the identity key instead of a cert hash) is
+/// tracked in #200; it is channel hygiene, not an identity requirement (identity
+/// is app-layer regardless). iroh already does it natively.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum QuicServerAuth {
-    /// Standard WebPKI / CA-chain validation against the system root store,
-    /// matching the server's DNS `server_name`. For public peers fronted by a
-    /// CA-issued certificate (dialed by hostname).
-    WebPki,
-    /// Pin the server's (self-signed) certificate by its SHA-256 fingerprint
-    /// (`with_server_certificate_hashes`) — the internal-mesh model, dialed by
-    /// IP. The resolver / DID doc vouches for the hash.
-    ///
-    /// SECURITY: authenticates the *channel* ("a server holding this cert"), not
-    /// the peer's DID *identity* (#185). For identity-bound transport use iroh
-    /// (which is RFC 7250 — the connection is bound to the peer's public key).
-    Pinned([u8; 32]),
-    /// RFC 7250 raw-public-key identity binding: the server proves possession of
-    /// this Ed25519 key during the TLS handshake.
-    ///
-    /// **Not yet implemented** — `web_transport_quinn`'s builder exposes no
-    /// raw-key/custom-verifier hook, so this needs a custom rustls verifier + a
-    /// raw `quinn` connect + `Session::raw`, plus a server-side raw-key config.
-    /// It is also browser-incompatible (WebTransport mandates cert hashes) and
-    /// overlaps iroh (which already provides RFC 7250). Tracked in #200; use
-    /// iroh for identity-bound native transport today.
-    RawPublicKey([u8; 32]),
+pub struct QuicServerAuth {
+    require_web_pki: bool,
+    accept_cert_hashes: Vec<[u8; 32]>,
+}
+
+impl QuicServerAuth {
+    /// WebPKI / CA-chain validation only (public, CA-fronted peer).
+    pub fn web_pki() -> Self {
+        Self { require_web_pki: true, accept_cert_hashes: Vec::new() }
+    }
+
+    /// Pin the leaf cert to one of `hashes` (SHA-256), no CA requirement — the
+    /// self-signed internal-mesh model. Errors if `hashes` is empty.
+    pub fn pinned(hashes: Vec<[u8; 32]>) -> anyhow::Result<Self> {
+        anyhow::ensure!(!hashes.is_empty(), "QuicServerAuth::pinned requires >= 1 cert hash");
+        Ok(Self { require_web_pki: false, accept_cert_hashes: hashes })
+    }
+
+    /// WebPKI validation **and** the leaf must be one of `hashes` — defence in
+    /// depth against CA mis-issuance (HPKP-style). Errors if `hashes` is empty.
+    pub fn web_pki_pinned(hashes: Vec<[u8; 32]>) -> anyhow::Result<Self> {
+        anyhow::ensure!(!hashes.is_empty(), "QuicServerAuth::web_pki_pinned requires >= 1 cert hash");
+        Ok(Self { require_web_pki: true, accept_cert_hashes: hashes })
+    }
+
+    /// Whether CA-chain validation is required.
+    pub fn require_web_pki(&self) -> bool {
+        self.require_web_pki
+    }
+
+    /// The set of accepted leaf-cert SHA-256 pins (empty => no pin requirement).
+    pub fn accept_cert_hashes(&self) -> &[[u8; 32]] {
+        &self.accept_cert_hashes
+    }
 }
 
 /// Endpoint type (without encryption config)
@@ -278,7 +312,7 @@ impl TransportConfig {
             endpoint: EndpointType::Quic {
                 addr,
                 server_name: server_name.into(),
-                auth: QuicServerAuth::WebPki,
+                auth: QuicServerAuth::web_pki(),
             },
             curve: None, // QUIC has TLS 1.3 built-in, no CurveZMQ needed
             bind_mode: BindMode::Bind,
@@ -293,7 +327,8 @@ impl TransportConfig {
             endpoint: EndpointType::Quic {
                 addr,
                 server_name: server_name.into(),
-                auth: QuicServerAuth::Pinned(cert_hash),
+                // In-module: construct directly (a one-element set is always valid).
+                auth: QuicServerAuth { require_web_pki: false, accept_cert_hashes: vec![cert_hash] },
             },
             curve: None,
             bind_mode: BindMode::Connect,

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -27,6 +27,8 @@ pub mod iroh_moq;
 pub mod in_memory;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod lazy_quinn;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod lazy_iroh;
 
 use std::net::SocketAddr;
 use std::os::unix::io::RawFd;
@@ -172,6 +174,24 @@ pub enum EndpointType {
         /// wire-publishable. Public fingerprint — not secret.
         cert_pin: Option<[u8; 32]>,
     },
+
+    /// iroh transport endpoint (RPC over `ALPN_HYPRSTREAM_RPC`).
+    ///
+    /// The optional NAT-traversing dial. Unlike QUIC's channel-only cert pin,
+    /// iroh binds the connection to the peer's `EndpointId` (its Ed25519 public
+    /// key), so the transport itself authenticates the peer *identity*. All
+    /// fields are serializable primitives so `TransportConfig` stays
+    /// `Clone + Eq` and wire-publishable (a DID-doc `service` entry).
+    ///
+    /// Format: `iroh://{hex node_id}`
+    Iroh {
+        /// Peer's iroh `EndpointId` = its Ed25519 public key (32 bytes).
+        node_id: [u8; 32],
+        /// Known direct socket addresses for hole-punching / direct dial.
+        direct_addrs: Vec<SocketAddr>,
+        /// Optional relay URL for NAT traversal when no direct path exists.
+        relay_url: Option<String>,
+    },
 }
 
 impl TransportConfig {
@@ -244,6 +264,25 @@ impl TransportConfig {
                 addr,
                 server_name: server_name.into(),
                 cert_pin: Some(cert_pin),
+            },
+            curve: None,
+            bind_mode: BindMode::Connect,
+        }
+    }
+
+    /// Create a client iroh endpoint dialing the peer identified by `node_id`
+    /// (its `EndpointId` / Ed25519 public key), with optional direct addresses
+    /// and relay URL for NAT traversal.
+    pub fn iroh(
+        node_id: [u8; 32],
+        direct_addrs: Vec<SocketAddr>,
+        relay_url: Option<String>,
+    ) -> Self {
+        Self {
+            endpoint: EndpointType::Iroh {
+                node_id,
+                direct_addrs,
+                relay_url,
             },
             curve: None,
             bind_mode: BindMode::Connect,
@@ -327,6 +366,10 @@ impl TransportConfig {
             }
             EndpointType::Quic { addr, server_name, .. } => {
                 format!("quic://{server_name}:{addr}")
+            }
+            EndpointType::Iroh { node_id, .. } => {
+                let hex: String = node_id.iter().map(|b| format!("{b:02x}")).collect();
+                format!("iroh://{hex}")
             }
         }
     }
@@ -439,8 +482,11 @@ impl TransportConfig {
                 socket.bind(&self.zmq_endpoint())?;
                 Ok(())
             }
-            EndpointType::Quic { .. } => {
-                anyhow::bail!("QUIC endpoints require QuicRep::bind(), not ZMQ socket bind")
+            EndpointType::Quic { .. } | EndpointType::Iroh { .. } => {
+                anyhow::bail!(
+                    "QUIC/iroh endpoints are not ZMQ sockets — they are dialed via \
+                     the transport/dial() layer, not bound here"
+                )
             }
         }
     }
@@ -462,8 +508,11 @@ impl TransportConfig {
                 socket.connect(&self.zmq_endpoint())?;
                 Ok(())
             }
-            EndpointType::Quic { .. } => {
-                anyhow::bail!("QUIC endpoints require QuicReq::connect(), not ZMQ socket connect")
+            EndpointType::Quic { .. } | EndpointType::Iroh { .. } => {
+                anyhow::bail!(
+                    "QUIC/iroh endpoints are not ZMQ sockets — they are dialed via \
+                     the transport/dial() layer, not connected here"
+                )
             }
         }
     }

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -29,6 +29,8 @@ pub mod in_memory;
 pub mod lazy_quinn;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod lazy_iroh;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod uds_session;
 
 use std::net::SocketAddr;
 use std::os::unix::io::RawFd;

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -23,6 +23,8 @@ pub mod quinn_transport;
 pub mod iroh_transport;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod iroh_moq;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod in_memory;
 
 use std::net::SocketAddr;
 use std::os::unix::io::RawFd;

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -14,7 +14,11 @@ pub mod quic_stream_bridge;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod iroh_substrate;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod rpc_session;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod iroh_rpc;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod quinn_transport;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod iroh_transport;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -31,6 +31,8 @@ pub mod lazy_quinn;
 pub mod lazy_iroh;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod uds_session;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod lazy_uds;
 
 use std::net::SocketAddr;
 use std::os::unix::io::RawFd;

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -25,6 +25,8 @@ pub mod iroh_transport;
 pub mod iroh_moq;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod in_memory;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod lazy_quinn;
 
 use std::net::SocketAddr;
 use std::os::unix::io::RawFd;
@@ -162,6 +164,13 @@ pub enum EndpointType {
         addr: SocketAddr,
         /// Server hostname for TLS certificate validation
         server_name: String,
+        /// SHA-256 fingerprint of the server's self-signed certificate, for
+        /// client-side cert pinning (`with_server_certificate_hashes`). `None`
+        /// for the server/bind side or when peer authentication is provided
+        /// some other way (e.g. an expected response-signing key). Carrying the
+        /// 32-byte hash (not the full cert) keeps `TransportConfig` compact and
+        /// wire-publishable. Public fingerprint — not secret.
+        cert_pin: Option<[u8; 32]>,
     },
 }
 
@@ -219,9 +228,25 @@ impl TransportConfig {
             endpoint: EndpointType::Quic {
                 addr,
                 server_name: server_name.into(),
+                cert_pin: None,
             },
             curve: None, // QUIC has TLS 1.3 built-in, no CurveZMQ needed
             bind_mode: BindMode::Bind,
+        }
+    }
+
+    /// Create a client QUIC endpoint that pins the server's self-signed cert by
+    /// its SHA-256 fingerprint (`cert_pin`). This is the dial target the
+    /// resolver/`dial()` produce for a networked RPC peer.
+    pub fn quic_pinned(addr: SocketAddr, server_name: impl Into<String>, cert_pin: [u8; 32]) -> Self {
+        Self {
+            endpoint: EndpointType::Quic {
+                addr,
+                server_name: server_name.into(),
+                cert_pin: Some(cert_pin),
+            },
+            curve: None,
+            bind_mode: BindMode::Connect,
         }
     }
 
@@ -300,7 +325,7 @@ impl TransportConfig {
             EndpointType::SystemdFd { client_path, .. } => {
                 format!("ipc://{}", client_path.display())
             }
-            EndpointType::Quic { addr, server_name } => {
+            EndpointType::Quic { addr, server_name, .. } => {
                 format!("quic://{server_name}:{addr}")
             }
         }
@@ -317,7 +342,7 @@ impl TransportConfig {
     /// Returns `https://{server_name}:{port}` for QUIC endpoints, `None` otherwise.
     pub fn quic_webtransport_url(&self) -> Option<String> {
         match &self.endpoint {
-            EndpointType::Quic { addr, server_name } => {
+            EndpointType::Quic { addr, server_name, .. } => {
                 Some(format!("https://{}:{}", server_name, addr.port()))
             }
             _ => None,

--- a/crates/hyprstream-rpc/src/transport/quinn_transport.rs
+++ b/crates/hyprstream-rpc/src/transport/quinn_transport.rs
@@ -17,6 +17,7 @@
 //! identical, so the generic core is reused unchanged.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
@@ -48,6 +49,8 @@ pub struct QuinnRpcServer {
     /// `acquire_many` to wait for every in-flight stream to complete.
     stream_limit: Arc<Semaphore>,
     stream_limit_capacity: u32,
+    /// Per-stream request-read timeout (#159 slowloris bound).
+    read_timeout: Duration,
     shutdown: CancellationToken,
 }
 
@@ -75,6 +78,7 @@ impl QuinnRpcServer {
             signing_key,
             stream_limit: Arc::new(Semaphore::new(stream_limit)),
             stream_limit_capacity: u32::try_from(stream_limit).unwrap_or(u32::MAX),
+            read_timeout: super::rpc_session::REQUEST_READ_TIMEOUT,
             shutdown: CancellationToken::new(),
         }
     }
@@ -83,6 +87,13 @@ impl QuinnRpcServer {
     pub fn with_stream_limit(mut self, limit: usize) -> Self {
         self.stream_limit = Arc::new(Semaphore::new(limit));
         self.stream_limit_capacity = u32::try_from(limit).unwrap_or(u32::MAX);
+        self
+    }
+
+    /// Override the per-stream request-read timeout (#159). Primarily for
+    /// tests; production uses [`super::rpc_session::REQUEST_READ_TIMEOUT`].
+    pub fn with_read_timeout(mut self, read_timeout: Duration) -> Self {
+        self.read_timeout = read_timeout;
         self
     }
 
@@ -109,14 +120,29 @@ impl QuinnRpcServer {
     pub async fn shutdown(stream_limit: &Arc<Semaphore>, capacity: u32, token: &CancellationToken) {
         // Stop accepting new streams (level-triggered).
         token.cancel();
-        // Wait for all in-flight streams to release their permits.
-        match stream_limit.acquire_many(capacity).await {
-            Ok(permits) => {
+        // Wait for all in-flight streams to release their permits, but bound
+        // the wait (#159): a wedged processor/transport must not hang shutdown
+        // forever. On timeout we close() and proceed — remaining tasks are torn
+        // down when the connection drops.
+        match tokio::time::timeout(
+            super::rpc_session::DRAIN_TIMEOUT,
+            stream_limit.acquire_many(capacity),
+        )
+        .await
+        {
+            Ok(Ok(permits)) => {
                 permits.forget();
                 stream_limit.close();
             }
-            Err(_) => {
+            Ok(Err(_)) => {
                 // Already closed; nothing to drain.
+            }
+            Err(_) => {
+                tracing::warn!(
+                    timeout = ?super::rpc_session::DRAIN_TIMEOUT,
+                    "quinn-rpc: drain timed out, forcing teardown"
+                );
+                stream_limit.close();
             }
         }
     }
@@ -160,6 +186,7 @@ impl QuinnRpcServer {
                     let processor = Arc::clone(&self.processor);
                     let signing_key = self.signing_key.clone();
                     let stream_limit = Arc::clone(&self.stream_limit);
+                    let read_timeout = self.read_timeout;
                     let shutdown = self.shutdown.clone();
                     tokio::spawn(async move {
                         if let Err(e) = serve_rpc_connection(
@@ -167,6 +194,7 @@ impl QuinnRpcServer {
                             processor,
                             signing_key,
                             stream_limit,
+                            read_timeout,
                             shutdown,
                         )
                         .await

--- a/crates/hyprstream-rpc/src/transport/quinn_transport.rs
+++ b/crates/hyprstream-rpc/src/transport/quinn_transport.rs
@@ -1,0 +1,357 @@
+//! Quinn WebTransport RPC plane — moq M1 (#151).
+//!
+//! A second backend for the transport-generic RPC core (see
+//! [`super::rpc_session`]), proving the RPC plane is transport-pluggable: the
+//! exact same Cap'n Proto bidi wire protocol, DoS bounds, graceful-drain, and
+//! error-envelope semantics run over quinn's [`web_transport_quinn::Session`]
+//! instead of iroh's.
+//!
+//! - [`QuinnRpcServer`] — accepts WebTransport sessions on a quinn endpoint and
+//!   runs [`serve_rpc_connection`] per session.
+//! - [`QuinnTransport`] — client transport wrapping
+//!   [`SessionRpcTransport<web_transport_quinn::Session>`].
+//!
+//! Unlike the iroh substrate (which terminates raw QUIC bidi streams under a
+//! custom ALPN), web-transport-quinn speaks the full WebTransport handshake
+//! (HTTP/3 CONNECT, ALPN `h3`). The wire framing *inside* each bidi stream is
+//! identical, so the generic core is reused unchanged.
+
+use std::sync::Arc;
+
+use anyhow::{Result, anyhow};
+use async_trait::async_trait;
+use ed25519_dalek::SigningKey;
+use tokio::sync::Semaphore;
+use tokio_util::sync::CancellationToken;
+
+use crate::transport::rpc_session::{
+    DEFAULT_STREAM_LIMIT, IrohRequestProcessor, RpcPendingStream, RpcPublishStub,
+    SessionRpcTransport, serve_rpc_connection,
+};
+use crate::transport_traits::Transport;
+
+/// A quinn-backed WebTransport server for the RPC plane.
+///
+/// Accepts WebTransport sessions and spawns [`serve_rpc_connection`] for each.
+/// Caps concurrent streams *server-wide* via a single shared [`Semaphore`] (DoS
+/// bound) passed into every connection, matching the iroh handler's
+/// shared-semaphore drain. [`QuinnRpcServer::shutdown`] cancels the accept loop
+/// and then drains all in-flight streams before returning, so detached
+/// `handle_stream` tasks finish writing their responses rather than being
+/// abandoned mid-flight.
+pub struct QuinnRpcServer {
+    server: web_transport_quinn::Server,
+    processor: Arc<dyn IrohRequestProcessor>,
+    signing_key: SigningKey,
+    /// Server-wide concurrent-stream cap. Shared across all connections; one
+    /// permit is held per in-flight bidi stream. `shutdown` drains it via
+    /// `acquire_many` to wait for every in-flight stream to complete.
+    stream_limit: Arc<Semaphore>,
+    stream_limit_capacity: u32,
+    shutdown: CancellationToken,
+}
+
+impl QuinnRpcServer {
+    /// Build a server from a quinn endpoint configured for WebTransport (ALPN
+    /// `h3`). Use [`web_transport_quinn::ServerBuilder`] to construct one.
+    pub fn new<P: IrohRequestProcessor>(
+        server: web_transport_quinn::Server,
+        processor: P,
+        signing_key: SigningKey,
+    ) -> Self {
+        Self::with_capacity(server, Arc::new(processor), signing_key, DEFAULT_STREAM_LIMIT)
+    }
+
+    /// Build a server with an explicit server-wide concurrent-stream cap.
+    pub fn with_capacity(
+        server: web_transport_quinn::Server,
+        processor: Arc<dyn IrohRequestProcessor>,
+        signing_key: SigningKey,
+        stream_limit: usize,
+    ) -> Self {
+        Self {
+            server,
+            processor,
+            signing_key,
+            stream_limit: Arc::new(Semaphore::new(stream_limit)),
+            stream_limit_capacity: u32::try_from(stream_limit).unwrap_or(u32::MAX),
+            shutdown: CancellationToken::new(),
+        }
+    }
+
+    /// Override the server-wide concurrent-stream cap (builder style).
+    pub fn with_stream_limit(mut self, limit: usize) -> Self {
+        self.stream_limit = Arc::new(Semaphore::new(limit));
+        self.stream_limit_capacity = u32::try_from(limit).unwrap_or(u32::MAX);
+        self
+    }
+
+    /// A handle that, when cancelled, stops the accept loop and per-connection
+    /// serve loops.
+    ///
+    /// Note: cancelling this token alone does **not** drain in-flight streams.
+    /// To wait for in-flight responses to complete, hold a clone of the server
+    /// and call [`QuinnRpcServer::shutdown`] instead (or use it via a shared
+    /// handle). The token is exposed primarily for tests and for callers that
+    /// want to stop accepting without a graceful drain.
+    pub fn shutdown_token(&self) -> CancellationToken {
+        self.shutdown.clone()
+    }
+
+    /// Graceful shutdown mirroring [`super::iroh_rpc::IrohRpcProtocolHandler::shutdown`]:
+    /// cancel the accept loop, then wait for every in-flight stream to release
+    /// its permit (`acquire_many(capacity)`), then `forget()` + `close()` the
+    /// semaphore so any post-shutdown accept sees a closed semaphore and exits.
+    ///
+    /// Takes the shared `Semaphore` + token by reference, so it can be called
+    /// through a clone of the relevant handles while [`QuinnRpcServer::run`]
+    /// owns `self`. See the `quinn_shutdown_drains_in_flight` test.
+    pub async fn shutdown(stream_limit: &Arc<Semaphore>, capacity: u32, token: &CancellationToken) {
+        // Stop accepting new streams (level-triggered).
+        token.cancel();
+        // Wait for all in-flight streams to release their permits.
+        match stream_limit.acquire_many(capacity).await {
+            Ok(permits) => {
+                permits.forget();
+                stream_limit.close();
+            }
+            Err(_) => {
+                // Already closed; nothing to drain.
+            }
+        }
+    }
+
+    /// The shared concurrent-stream semaphore. Pair with [`QuinnRpcServer::capacity`]
+    /// and [`QuinnRpcServer::shutdown_token`] to perform a graceful
+    /// [`QuinnRpcServer::shutdown`] while [`QuinnRpcServer::run`] owns `self`.
+    pub fn stream_limit(&self) -> Arc<Semaphore> {
+        Arc::clone(&self.stream_limit)
+    }
+
+    /// The configured server-wide concurrent-stream capacity.
+    pub fn capacity(&self) -> u32 {
+        self.stream_limit_capacity
+    }
+
+    /// Run the accept loop until `shutdown` is cancelled. Each accepted session
+    /// is served on its own task by the transport-generic core, sharing the
+    /// server-wide [`Semaphore`] so [`QuinnRpcServer::shutdown`] can drain every
+    /// in-flight stream regardless of which connection it belongs to.
+    pub async fn run(mut self) -> Result<()> {
+        loop {
+            tokio::select! {
+                biased;
+                _ = self.shutdown.cancelled() => {
+                    tracing::debug!("quinn-rpc: accept loop cancelled");
+                    return Ok(());
+                }
+                request = self.server.accept() => {
+                    let Some(request) = request else {
+                        tracing::debug!("quinn-rpc: server endpoint closed");
+                        return Ok(());
+                    };
+                    let session = match request.ok().await {
+                        Ok(s) => s,
+                        Err(e) => {
+                            tracing::warn!(error = ?e, "quinn-rpc: handshake failed");
+                            continue;
+                        }
+                    };
+                    let processor = Arc::clone(&self.processor);
+                    let signing_key = self.signing_key.clone();
+                    let stream_limit = Arc::clone(&self.stream_limit);
+                    let shutdown = self.shutdown.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = serve_rpc_connection(
+                            session,
+                            processor,
+                            signing_key,
+                            stream_limit,
+                            shutdown,
+                        )
+                        .await
+                        {
+                            tracing::debug!(error = ?e, "quinn-rpc: connection serve ended");
+                        }
+                    });
+                }
+            }
+        }
+    }
+}
+
+/// Wraps a quinn [`web_transport_quinn::Session`] as a [`Transport`] for RPC
+/// plane traffic. Delegates to the transport-generic [`SessionRpcTransport`].
+#[derive(Clone)]
+pub struct QuinnTransport {
+    inner: SessionRpcTransport<web_transport_quinn::Session>,
+}
+
+impl QuinnTransport {
+    /// Build from an already-established WebTransport session.
+    pub fn new(session: web_transport_quinn::Session) -> Self {
+        Self {
+            inner: SessionRpcTransport::new(session),
+        }
+    }
+}
+
+/// Re-export the generic stubs under quinn-flavoured names.
+pub type QuinnPendingStream = RpcPendingStream;
+pub type QuinnPublishStub = RpcPublishStub;
+
+#[async_trait]
+impl Transport for QuinnTransport {
+    type Sub = QuinnPendingStream;
+    type Pub = QuinnPublishStub;
+
+    async fn send(&self, payload: Vec<u8>, timeout_ms: Option<i32>) -> Result<Vec<u8>> {
+        self.inner.send(payload, timeout_ms).await
+    }
+
+    async fn subscribe(&self, topic: &[u8]) -> Result<Self::Sub> {
+        self.inner.subscribe(topic).await
+    }
+
+    async fn publish(&self, topic: &[u8]) -> Result<Self::Pub> {
+        self.inner.publish(topic).await
+    }
+}
+
+/// Helper to build a quinn WebTransport client session against a self-signed
+/// server, pinning the server cert by its sha256 fingerprint. Hermetic: dials
+/// an IP-literal URL so no DNS lookup or network egress occurs.
+pub async fn connect_pinned(
+    addr: std::net::SocketAddr,
+    cert_der: &[u8],
+) -> Result<web_transport_quinn::Session> {
+    let client = web_transport_quinn::ClientBuilder::new()
+        .with_server_certificate_hashes(vec![sha256(cert_der)])
+        .map_err(|e| anyhow!("quinn client build: {e}"))?;
+    let url = url::Url::parse(&format!("https://{addr}/"))
+        .map_err(|e| anyhow!("quinn url: {e}"))?;
+    client
+        .connect(url)
+        .await
+        .map_err(|e| anyhow!("quinn connect: {e}"))
+}
+
+fn sha256(bytes: &[u8]) -> Vec<u8> {
+    use sha2::{Digest, Sha256};
+    Sha256::digest(bytes).to_vec()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use rand::RngCore;
+    use std::time::Duration;
+
+    fn fresh_signing_key() -> SigningKey {
+        let mut k = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut k);
+        SigningKey::from_bytes(&k)
+    }
+
+    /// Build a hermetic quinn WebTransport server bound to loopback with a
+    /// self-signed cert. Returns (server, bound_addr, cert_der).
+    fn build_server() -> Result<(web_transport_quinn::Server, std::net::SocketAddr, Vec<u8>)> {
+        let cert_key = rcgen::generate_simple_self_signed(vec!["localhost".to_owned()])?;
+        let cert_der = cert_key.cert.der().to_vec();
+        let key_der = cert_key.key_pair.serialize_der();
+
+        let chain = vec![rustls::pki_types::CertificateDer::from(cert_der.clone())];
+        let key = rustls::pki_types::PrivateKeyDer::Pkcs8(
+            rustls::pki_types::PrivatePkcs8KeyDer::from(key_der),
+        );
+
+        let addr: std::net::SocketAddr = "127.0.0.1:0".parse()?;
+        let server = web_transport_quinn::ServerBuilder::new()
+            .with_addr(addr)
+            .with_certificate(chain, key)
+            .map_err(|e| anyhow!("quinn server build: {e}"))?;
+        let bound = server.local_addr()?;
+        Ok((server, bound, cert_der))
+    }
+
+    /// Round-trip: client sends a request, a closure-processor echoes it back
+    /// with a 0xCD marker prefix, client asserts on the response.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn quinn_rpc_round_trip() -> Result<()> {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let processor = crate::transport::rpc_session::from_fn(|req: Bytes| async move {
+            let mut out = Vec::with_capacity(1 + req.len());
+            out.push(0xCD);
+            out.extend_from_slice(&req);
+            Ok(Bytes::from(out))
+        });
+
+        let (server, addr, cert_der) = build_server()?;
+        let rpc_server = QuinnRpcServer::new(server, processor, fresh_signing_key());
+        let shutdown = rpc_server.shutdown_token();
+        let server_task = tokio::spawn(rpc_server.run());
+
+        let session = connect_pinned(addr, &cert_der).await?;
+        let client = QuinnTransport::new(session);
+
+        let resp = client.send(b"ping".to_vec(), Some(5_000)).await?;
+        assert_eq!(&resp[..], b"\xCDping");
+
+        shutdown.cancel();
+        let _ = server_task.await;
+        Ok(())
+    }
+
+    /// Graceful shutdown drains in-flight requests: a request in-progress when
+    /// `shutdown()` starts still completes with its real response rather than
+    /// being abandoned mid-flight. Mirrors `iroh_rpc::rpc_shutdown_drains_in_flight`.
+    ///
+    /// Uses a `Notify` to synchronise "processor has entered the long sleep"
+    /// with "now safe to shut down" — no wall-clock sleep races.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn quinn_shutdown_drains_in_flight() -> Result<()> {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let entered_c = Arc::clone(&entered);
+        let processor = crate::transport::rpc_session::from_fn(move |_req: Bytes| {
+            let entered = Arc::clone(&entered_c);
+            async move {
+                entered.notify_one();
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                Ok(Bytes::from_static(b"drained-ok"))
+            }
+        });
+
+        let (server, addr, cert_der) = build_server()?;
+        let rpc_server = QuinnRpcServer::new(server, processor, fresh_signing_key());
+        // Grab the shared drain handles before `run()` consumes the server.
+        let stream_limit = rpc_server.stream_limit();
+        let capacity = rpc_server.capacity();
+        let token = rpc_server.shutdown_token();
+        let server_task = tokio::spawn(rpc_server.run());
+
+        let session = connect_pinned(addr, &cert_der).await?;
+        let client = QuinnTransport::new(session);
+
+        // Fire the slow request on its own task.
+        let req_task = {
+            let client = client.clone();
+            tokio::spawn(async move { client.send(b"slow".to_vec(), Some(10_000)).await })
+        };
+
+        // Synchronise: wait until the processor has entered the sleep, then
+        // drain-shutdown. No wall-clock guesses.
+        entered.notified().await;
+        QuinnRpcServer::shutdown(&stream_limit, capacity, &token).await;
+
+        // The in-flight request must still complete with its real response.
+        let resp = req_task.await??;
+        assert_eq!(&resp[..], b"drained-ok");
+
+        let _ = server_task.await;
+        Ok(())
+    }
+}

--- a/crates/hyprstream-rpc/src/transport/quinn_transport.rs
+++ b/crates/hyprstream-rpc/src/transport/quinn_transport.rs
@@ -286,13 +286,31 @@ impl Transport for QuinnTransport {
     }
 }
 
+/// Build a quinn WebTransport client session against a server with a CA-issued
+/// certificate, validated via the system root store and the DNS `server_name`
+/// (`QuicServerAuth::WebPki`). Dials `https://{server_name}:{port}/`.
+pub async fn connect_webpki(
+    server_name: &str,
+    port: u16,
+) -> Result<web_transport_quinn::Session> {
+    let client = web_transport_quinn::ClientBuilder::new()
+        .with_system_roots()
+        .map_err(|e| anyhow!("quinn client (system roots): {e}"))?;
+    let url = url::Url::parse(&format!("https://{server_name}:{port}/"))
+        .map_err(|e| anyhow!("quinn url: {e}"))?;
+    client
+        .connect(url)
+        .await
+        .map_err(|e| anyhow!("quinn connect (webpki): {e}"))
+}
+
 /// Build a quinn WebTransport client session against a self-signed server,
 /// pinning the server cert by its **SHA-256 fingerprint** (the 32-byte hash
-/// carried in `EndpointType::Quic { cert_pin }`). Hermetic: dials an IP-literal
-/// URL so no DNS lookup or network egress occurs.
+/// carried in `QuicServerAuth::Pinned`). Hermetic: dials an IP-literal URL so no
+/// DNS lookup or network egress occurs.
 ///
-/// This is the connect path the lazy dial transport uses — the resolver/DID doc
-/// publishes the compact hash, not the full cert.
+/// This is the connect path the lazy dial transport uses for internal-mesh
+/// peers — the resolver/DID doc publishes the compact hash, not the full cert.
 pub async fn connect_pinned_sha256(
     addr: std::net::SocketAddr,
     cert_sha256: [u8; 32],

--- a/crates/hyprstream-rpc/src/transport/quinn_transport.rs
+++ b/crates/hyprstream-rpc/src/transport/quinn_transport.rs
@@ -49,6 +49,9 @@ pub struct QuinnRpcServer {
     /// `acquire_many` to wait for every in-flight stream to complete.
     stream_limit: Arc<Semaphore>,
     stream_limit_capacity: u32,
+    /// Cap on concurrent accepted connections (#162). One permit per live
+    /// connection; connections beyond the cap are rejected, not queued.
+    connection_limit: Arc<Semaphore>,
     /// Per-stream request-read timeout (#159 slowloris bound).
     read_timeout: Duration,
     shutdown: CancellationToken,
@@ -78,9 +81,18 @@ impl QuinnRpcServer {
             signing_key,
             stream_limit: Arc::new(Semaphore::new(stream_limit)),
             stream_limit_capacity: u32::try_from(stream_limit).unwrap_or(u32::MAX),
+            connection_limit: Arc::new(Semaphore::new(
+                super::rpc_session::DEFAULT_CONNECTION_LIMIT,
+            )),
             read_timeout: super::rpc_session::REQUEST_READ_TIMEOUT,
             shutdown: CancellationToken::new(),
         }
+    }
+
+    /// Override the concurrent-connection cap (#162, builder style).
+    pub fn with_connection_limit(mut self, limit: usize) -> Self {
+        self.connection_limit = Arc::new(Semaphore::new(limit));
+        self
     }
 
     /// Override the server-wide concurrent-stream cap (builder style).
@@ -176,19 +188,47 @@ impl QuinnRpcServer {
                         tracing::debug!("quinn-rpc: server endpoint closed");
                         return Ok(());
                     };
-                    let session = match request.ok().await {
-                        Ok(s) => s,
-                        Err(e) => {
-                            tracing::warn!(error = ?e, "quinn-rpc: handshake failed");
+
+                    // Connection cap (#162): take a permit before doing any
+                    // per-connection work. try_acquire → reject (drop) when at
+                    // cap rather than queueing, so a flood can't build backlog.
+                    let conn_permit = match Arc::clone(&self.connection_limit).try_acquire_owned() {
+                        Ok(p) => p,
+                        Err(_) => {
+                            tracing::warn!("quinn-rpc: connection cap reached, rejecting connection");
+                            drop(request);
                             continue;
                         }
                     };
+
                     let processor = Arc::clone(&self.processor);
                     let signing_key = self.signing_key.clone();
                     let stream_limit = Arc::clone(&self.stream_limit);
                     let read_timeout = self.read_timeout;
                     let shutdown = self.shutdown.clone();
                     tokio::spawn(async move {
+                        let _conn_permit = conn_permit; // released when this connection ends
+                        // Resolve the handshake INSIDE the task, bounded (#162),
+                        // so a slow/stalled CONNECT never blocks the accept loop.
+                        let session = match tokio::time::timeout(
+                            super::rpc_session::HANDSHAKE_TIMEOUT,
+                            request.ok(),
+                        )
+                        .await
+                        {
+                            Ok(Ok(s)) => s,
+                            Ok(Err(e)) => {
+                                tracing::warn!(error = ?e, "quinn-rpc: handshake failed");
+                                return;
+                            }
+                            Err(_) => {
+                                tracing::warn!(
+                                    timeout = ?super::rpc_session::HANDSHAKE_TIMEOUT,
+                                    "quinn-rpc: handshake timed out"
+                                );
+                                return;
+                            }
+                        };
                         if let Err(e) = serve_rpc_connection(
                             session,
                             processor,
@@ -326,6 +366,51 @@ mod tests {
 
         let resp = client.send(b"ping".to_vec(), Some(5_000)).await?;
         assert_eq!(&resp[..], b"\xCDping");
+
+        shutdown.cancel();
+        let _ = server_task.await;
+        Ok(())
+    }
+
+    /// #162: with a connection cap of 1, a second concurrent connection is
+    /// rejected while the first is still live. The first keeps working.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn quinn_connection_cap_rejects_excess() -> Result<()> {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let processor =
+            crate::transport::rpc_session::from_fn(|req: Bytes| async move { Ok(req) });
+
+        let (server, addr, cert_der) = build_server()?;
+        let rpc_server =
+            QuinnRpcServer::new(server, processor, fresh_signing_key()).with_connection_limit(1);
+        let shutdown = rpc_server.shutdown_token();
+        let server_task = tokio::spawn(rpc_server.run());
+
+        // First connection takes the only permit and works.
+        let session1 = connect_pinned(addr, &cert_der).await?;
+        let client1 = QuinnTransport::new(session1);
+        let resp1 = client1.send(b"one".to_vec(), Some(5_000)).await?;
+        assert_eq!(&resp1[..], b"one");
+
+        // Second connection: the server rejects it (drops the request before
+        // accepting), so a request on it must fail rather than be served.
+        // connect_pinned itself may or may not error depending on timing; the
+        // load-bearing assertion is that no request succeeds on conn #2.
+        let second = async {
+            let session2 = connect_pinned(addr, &cert_der).await?;
+            let client2 = QuinnTransport::new(session2);
+            client2.send(b"two".to_vec(), Some(2_000)).await
+        }
+        .await;
+        assert!(
+            second.is_err(),
+            "second connection over the cap must not be served, got {second:?}"
+        );
+
+        // First connection still works after the rejection.
+        let resp1b = client1.send(b"again".to_vec(), Some(5_000)).await?;
+        assert_eq!(&resp1b[..], b"again");
 
         shutdown.cancel();
         let _ = server_task.await;

--- a/crates/hyprstream-rpc/src/transport/quinn_transport.rs
+++ b/crates/hyprstream-rpc/src/transport/quinn_transport.rs
@@ -19,7 +19,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{Result, anyhow};
+use anyhow::{Result, anyhow, bail};
 use async_trait::async_trait;
 use ed25519_dalek::SigningKey;
 use tokio::sync::Semaphore;
@@ -288,7 +288,7 @@ impl Transport for QuinnTransport {
 
 /// Build a quinn WebTransport client session against a server with a CA-issued
 /// certificate, validated via the system root store and the DNS `server_name`
-/// (`QuicServerAuth::WebPki`). Dials `https://{server_name}:{port}/`.
+/// (`QuicServerAuth::web_pki`). Dials `https://{server_name}:{port}/`.
 pub async fn connect_webpki(
     server_name: &str,
     port: u16,
@@ -305,18 +305,17 @@ pub async fn connect_webpki(
 }
 
 /// Build a quinn WebTransport client session against a self-signed server,
-/// pinning the server cert by its **SHA-256 fingerprint** (the 32-byte hash
-/// carried in `QuicServerAuth::Pinned`). Hermetic: dials an IP-literal URL so no
-/// DNS lookup or network egress occurs.
-///
-/// This is the connect path the lazy dial transport uses for internal-mesh
-/// peers — the resolver/DID doc publishes the compact hash, not the full cert.
-pub async fn connect_pinned_sha256(
+/// accepting the leaf cert if its **SHA-256 fingerprint** is any of
+/// `cert_hashes` (`QuicServerAuth::accept_cert_hashes` — a set so rotation can
+/// overlap). Hermetic: dials an IP-literal URL so no DNS lookup or network
+/// egress occurs.
+pub async fn connect_pinned_hashes(
     addr: std::net::SocketAddr,
-    cert_sha256: [u8; 32],
+    cert_hashes: &[[u8; 32]],
 ) -> Result<web_transport_quinn::Session> {
+    let hashes: Vec<Vec<u8>> = cert_hashes.iter().map(|h| h.to_vec()).collect();
     let client = web_transport_quinn::ClientBuilder::new()
-        .with_server_certificate_hashes(vec![cert_sha256.to_vec()])
+        .with_server_certificate_hashes(hashes)
         .map_err(|e| anyhow!("quinn client build: {e}"))?;
     let url = url::Url::parse(&format!("https://{addr}/"))
         .map_err(|e| anyhow!("quinn url: {e}"))?;
@@ -324,6 +323,33 @@ pub async fn connect_pinned_sha256(
         .connect(url)
         .await
         .map_err(|e| anyhow!("quinn connect: {e}"))
+}
+
+/// Verify the peer's leaf-cert SHA-256 is one of `accept` — the post-connect pin
+/// check for the WebPKI+pin mode (CA validation runs in the handshake; this adds
+/// the pin on top). Call immediately after connect, before any RPC. The cert
+/// fingerprint is public, so a plain comparison is fine (no secret to leak).
+pub fn verify_peer_cert_pinned(
+    session: &web_transport_quinn::Session,
+    accept: &[[u8; 32]],
+) -> Result<()> {
+    // `Session` derefs to `quinn::Connection`, exposing `peer_identity()`.
+    let identity = session
+        .peer_identity()
+        .ok_or_else(|| anyhow!("peer presented no certificate"))?;
+    let certs = identity
+        .downcast_ref::<Vec<rustls::pki_types::CertificateDer<'static>>>()
+        .ok_or_else(|| anyhow!("unexpected peer-identity type (not an X.509 chain)"))?;
+    let leaf = certs
+        .first()
+        .ok_or_else(|| anyhow!("peer cert chain is empty"))?;
+    let mut leaf_hash = [0u8; 32];
+    leaf_hash.copy_from_slice(&sha256(leaf.as_ref()));
+    if accept.contains(&leaf_hash) {
+        Ok(())
+    } else {
+        bail!("peer leaf-cert SHA-256 is not in the configured pin set")
+    }
 }
 
 /// Convenience: pin by the full server cert DER (hashes it for you). Used by
@@ -334,7 +360,7 @@ pub async fn connect_pinned(
 ) -> Result<web_transport_quinn::Session> {
     let mut hash = [0u8; 32];
     hash.copy_from_slice(&sha256(cert_der));
-    connect_pinned_sha256(addr, hash).await
+    connect_pinned_hashes(addr, &[hash]).await
 }
 
 fn sha256(bytes: &[u8]) -> Vec<u8> {
@@ -399,6 +425,32 @@ mod tests {
 
         let resp = client.send(b"ping".to_vec(), Some(5_000)).await?;
         assert_eq!(&resp[..], b"\xCDping");
+
+        shutdown.cancel();
+        let _ = server_task.await;
+        Ok(())
+    }
+
+    /// Isolated test of the WebPKI+pin post-connect check: against the hermetic
+    /// self-signed server, the leaf hash must match the pin set (right => Ok,
+    /// wrong => Err, empty set => Err = fail-closed).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn verify_peer_cert_pinned_accepts_right_rejects_wrong() -> Result<()> {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let processor =
+            crate::transport::rpc_session::from_fn(|req: Bytes| async move { Ok(req) });
+        let (server, addr, cert_der) = build_server()?;
+        let rpc_server = QuinnRpcServer::new(server, processor, fresh_signing_key());
+        let shutdown = rpc_server.shutdown_token();
+        let server_task = tokio::spawn(rpc_server.run());
+
+        let session = connect_pinned(addr, &cert_der).await?;
+        let mut right = [0u8; 32];
+        right.copy_from_slice(&sha256(&cert_der));
+
+        assert!(verify_peer_cert_pinned(&session, &[right]).is_ok(), "matching leaf hash must pass");
+        assert!(verify_peer_cert_pinned(&session, &[[0u8; 32]]).is_err(), "wrong hash must reject");
+        assert!(verify_peer_cert_pinned(&session, &[]).is_err(), "empty pin set must reject (fail-closed)");
 
         shutdown.cancel();
         let _ = server_task.await;

--- a/crates/hyprstream-rpc/src/transport/quinn_transport.rs
+++ b/crates/hyprstream-rpc/src/transport/quinn_transport.rs
@@ -286,15 +286,19 @@ impl Transport for QuinnTransport {
     }
 }
 
-/// Helper to build a quinn WebTransport client session against a self-signed
-/// server, pinning the server cert by its sha256 fingerprint. Hermetic: dials
-/// an IP-literal URL so no DNS lookup or network egress occurs.
-pub async fn connect_pinned(
+/// Build a quinn WebTransport client session against a self-signed server,
+/// pinning the server cert by its **SHA-256 fingerprint** (the 32-byte hash
+/// carried in `EndpointType::Quic { cert_pin }`). Hermetic: dials an IP-literal
+/// URL so no DNS lookup or network egress occurs.
+///
+/// This is the connect path the lazy dial transport uses — the resolver/DID doc
+/// publishes the compact hash, not the full cert.
+pub async fn connect_pinned_sha256(
     addr: std::net::SocketAddr,
-    cert_der: &[u8],
+    cert_sha256: [u8; 32],
 ) -> Result<web_transport_quinn::Session> {
     let client = web_transport_quinn::ClientBuilder::new()
-        .with_server_certificate_hashes(vec![sha256(cert_der)])
+        .with_server_certificate_hashes(vec![cert_sha256.to_vec()])
         .map_err(|e| anyhow!("quinn client build: {e}"))?;
     let url = url::Url::parse(&format!("https://{addr}/"))
         .map_err(|e| anyhow!("quinn url: {e}"))?;
@@ -302,6 +306,17 @@ pub async fn connect_pinned(
         .connect(url)
         .await
         .map_err(|e| anyhow!("quinn connect: {e}"))
+}
+
+/// Convenience: pin by the full server cert DER (hashes it for you). Used by
+/// tests and callers that hold the cert rather than its fingerprint.
+pub async fn connect_pinned(
+    addr: std::net::SocketAddr,
+    cert_der: &[u8],
+) -> Result<web_transport_quinn::Session> {
+    let mut hash = [0u8; 32];
+    hash.copy_from_slice(&sha256(cert_der));
+    connect_pinned_sha256(addr, hash).await
 }
 
 fn sha256(bytes: &[u8]) -> Vec<u8> {

--- a/crates/hyprstream-rpc/src/transport/rpc_session.rs
+++ b/crates/hyprstream-rpc/src/transport/rpc_session.rs
@@ -42,17 +42,35 @@ use crate::transport_traits::{PublishSink, Transport};
 /// server-side cap used in [`crate::transport::zmtp_quic`].
 pub const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024; // 64 MiB
 
-/// Default per-connection concurrent-stream cap. Caps memory usage from a
-/// hostile peer to `MAX_FRAME_BYTES × DEFAULT_STREAM_LIMIT` per connection
-/// (4 GiB at defaults).
+/// Default concurrent-stream cap. NOTE: the `Arc<Semaphore>` this sizes is
+/// shared **server-wide** across all connections (one `Arc<HandlerInner>`),
+/// not per-connection — so this bounds total in-flight streams for the whole
+/// server, capping memory to `MAX_FRAME_BYTES × DEFAULT_STREAM_LIMIT`.
 pub const DEFAULT_STREAM_LIMIT: usize = 64;
 
 /// Grace period for [`SendStream::closed`] after writing the response — if
 /// the peer crashes without acking the FIN, we don't leak a task forever.
 pub const STOPPED_GRACE: Duration = Duration::from_secs(5);
 
+/// Maximum wall-clock time the server will spend reading a single request
+/// frame before abandoning the stream and releasing its semaphore permit.
+///
+/// SECURITY (#159): without this bound an UNAUTHENTICATED peer can open
+/// `DEFAULT_STREAM_LIMIT` bidi streams, send one byte on each, and stall —
+/// each stalled read holds a server-wide permit forever, wedging the whole
+/// server before any envelope is verified (a pre-auth slowloris) and hanging
+/// the shutdown drain. Bounding the *total* read (not just per-`read()` idle)
+/// also defeats a trickle attacker who dribbles one byte per idle window.
+pub const REQUEST_READ_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Default per-call timeout when the caller passes `None` on the client side.
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Upper bound on how long graceful shutdown waits for in-flight streams to
+/// drain before forcing teardown. With [`REQUEST_READ_TIMEOUT`] bounding each
+/// read, well-behaved drains finish quickly; this is a backstop so a wedged
+/// processor or transport can't hang shutdown forever (#159).
+pub const DRAIN_TIMEOUT: Duration = Duration::from_secs(40);
 
 // ============================================================================
 // IrohRequestProcessor — pluggable request handling trait
@@ -160,6 +178,7 @@ pub async fn serve_rpc_connection<S>(
     processor: Arc<dyn IrohRequestProcessor>,
     signing_key: SigningKey,
     stream_limit: Arc<Semaphore>,
+    read_timeout: Duration,
     shutdown: CancellationToken,
 ) -> Result<()>
 where
@@ -199,7 +218,7 @@ where
                 tokio::spawn(async move {
                     let _permit = permit; // released on task end
                     let _keepalive = session_keepalive;
-                    handle_stream::<S>(send, recv, processor, signing_key).await;
+                    handle_stream::<S>(send, recv, processor, signing_key, read_timeout).await;
                 });
             }
         }
@@ -213,13 +232,25 @@ async fn handle_stream<S>(
     mut recv: S::RecvStream,
     processor: Arc<dyn IrohRequestProcessor>,
     signing_key: SigningKey,
+    read_timeout: Duration,
 ) where
     S: Session,
 {
-    let request = match read_to_cap(&mut recv, MAX_FRAME_BYTES).await {
-        Ok(buf) => buf,
-        Err(e) => {
+    // SECURITY (#159): bound the request read in wall-clock time. On timeout
+    // we return, dropping `recv`/`send` (which resets the stream) and releasing
+    // the semaphore permit held by the caller — so a stalled/trickling peer
+    // cannot pin a server-wide permit indefinitely.
+    let request = match tokio::time::timeout(read_timeout, read_to_cap(&mut recv, MAX_FRAME_BYTES)).await {
+        Ok(Ok(buf)) => buf,
+        Ok(Err(e)) => {
             tracing::warn!(error = ?e, "rpc-session: failed reading request");
+            return;
+        }
+        Err(_) => {
+            tracing::warn!(
+                timeout = ?read_timeout,
+                "rpc-session: request read timed out, abandoning stream"
+            );
             return;
         }
     };

--- a/crates/hyprstream-rpc/src/transport/rpc_session.rs
+++ b/crates/hyprstream-rpc/src/transport/rpc_session.rs
@@ -72,6 +72,19 @@ const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 /// processor or transport can't hang shutdown forever (#159).
 pub const DRAIN_TIMEOUT: Duration = Duration::from_secs(40);
 
+/// Default cap on concurrent accepted connections per server (#162). Bounds
+/// fd/memory from a peer that opens many connections that each sit idle (no
+/// streams) — the per-stream [`DEFAULT_STREAM_LIMIT`] does not cover that.
+/// Connections beyond the cap are rejected (dropped) rather than queued, so a
+/// flood can't build unbounded backpressure.
+pub const DEFAULT_CONNECTION_LIMIT: usize = 256;
+
+/// Maximum time the server waits for a peer's WebTransport/QUIC handshake to
+/// complete before abandoning it (#162). Bounds a peer that completes the QUIC
+/// handshake then stalls the WebTransport CONNECT. Resolved inside the
+/// per-connection task so a slow handshake never blocks the accept loop.
+pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(15);
+
 // ============================================================================
 // IrohRequestProcessor — pluggable request handling trait
 // ============================================================================

--- a/crates/hyprstream-rpc/src/transport/rpc_session.rs
+++ b/crates/hyprstream-rpc/src/transport/rpc_session.rs
@@ -1,0 +1,348 @@
+//! Transport-generic RPC plane core — Epic #131 / moq M1 (#151).
+//!
+//! This module generalises the iroh-specific RPC server/client (originally in
+//! [`super::iroh_rpc`] and [`super::iroh_transport`]) over the
+//! [`web_transport_trait::Session`] abstraction, so the RPC plane is
+//! transport-pluggable: any `Session` impl (iroh's `web-transport-iroh`,
+//! quinn's `web-transport-quinn`, or a future WASM `web-transport-web`) can
+//! carry the exact same Cap'n Proto bidi wire protocol with identical DoS
+//! bounds, graceful-drain, and error-envelope semantics.
+//!
+//! - [`serve_rpc_connection`] — the generic server accept loop. Terminates
+//!   `SignedEnvelope` bidi streams on a [`Session`], dispatches each through an
+//!   [`IrohRequestProcessor`], caps concurrent streams per connection (DoS
+//!   bound) and drains in-flight requests on `shutdown`.
+//! - [`SessionRpcTransport`] — the generic client transport implementing
+//!   [`crate::transport_traits::Transport`] over a [`Session`]. Each `send()`
+//!   opens a fresh bidi stream.
+//! - [`IrohRequestProcessor`] — the pluggable request-processing trait
+//!   (retained under its original name to avoid churn in callers).
+//! - [`build_error_envelope`] — signed error-envelope synthesis.
+//!
+//! **Wire framing**: each request/response is the opaque bytes of a
+//! Cap'n Proto-encoded envelope written to a freshly-opened bidi stream. The
+//! length is delimited by stream FIN (no explicit length prefix); reads are
+//! bounded by [`MAX_FRAME_BYTES`] via [`read_to_cap`].
+
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Result, anyhow, bail};
+use async_trait::async_trait;
+use bytes::Bytes;
+use ed25519_dalek::SigningKey;
+use tokio::sync::Semaphore;
+use tokio_util::sync::CancellationToken;
+use web_transport_trait::{RecvStream, SendStream, Session};
+
+use crate::transport_traits::{PublishSink, Transport};
+
+/// Hard cap on per-frame size (request or response). Mirrors the WebTransport
+/// server-side cap used in [`crate::transport::zmtp_quic`].
+pub const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024; // 64 MiB
+
+/// Default per-connection concurrent-stream cap. Caps memory usage from a
+/// hostile peer to `MAX_FRAME_BYTES × DEFAULT_STREAM_LIMIT` per connection
+/// (4 GiB at defaults).
+pub const DEFAULT_STREAM_LIMIT: usize = 64;
+
+/// Grace period for [`SendStream::closed`] after writing the response — if
+/// the peer crashes without acking the FIN, we don't leak a task forever.
+pub const STOPPED_GRACE: Duration = Duration::from_secs(5);
+
+/// Default per-call timeout when the caller passes `None` on the client side.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+// ============================================================================
+// IrohRequestProcessor — pluggable request handling trait
+// ============================================================================
+
+/// Trait implemented by callers to wire actual request processing.
+///
+/// The processor receives the raw request bytes (a Cap'n Proto-encoded
+/// `SignedEnvelope`) and returns the raw response bytes.
+///
+/// **Contract for `process`**:
+/// - **`Ok(bytes)`** — `bytes` MUST be a valid Cap'n Proto-encoded
+///   `ResponseEnvelope` and is written verbatim to the bidi stream.
+///   Application-layer errors (verification failure, handler error, etc.)
+///   MUST be returned this way as signed error envelopes — the server
+///   forwards them unchanged.
+/// - **`Err(_)`** — wire-level fatal: the processor cannot produce *any*
+///   response. The server responds with its own signed error envelope
+///   (`request_id = 0`) so the client sees a parseable error rather than a
+///   Cap'n Proto parse failure.
+///
+/// Implementations MUST be `Send + Sync + 'static` because accept loops run on
+/// a multi-threaded tokio runtime. For services that are `!Send` (e.g. those
+/// holding `tch-rs` tensors), use [`super::iroh_rpc::LocalServiceBridge`].
+///
+/// (Name retained from the iroh-only era to avoid churn in callers.)
+pub trait IrohRequestProcessor: Send + Sync + 'static {
+    fn process(
+        &self,
+        request: Bytes,
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<Bytes>> + Send + '_>>;
+}
+
+/// Convenience: build an [`IrohRequestProcessor`] from a `Send + Sync`
+/// async closure. Useful for tests.
+pub fn from_fn<F, Fut>(f: F) -> impl IrohRequestProcessor
+where
+    F: Fn(Bytes) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<Bytes>> + Send + 'static,
+{
+    struct FnProcessor<F>(F);
+    impl<F, Fut> IrohRequestProcessor for FnProcessor<F>
+    where
+        F: Fn(Bytes) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<Bytes>> + Send + 'static,
+    {
+        fn process(
+            &self,
+            request: Bytes,
+        ) -> std::pin::Pin<Box<dyn Future<Output = Result<Bytes>> + Send + '_>> {
+            Box::pin((self.0)(request))
+        }
+    }
+    FnProcessor(f)
+}
+
+// ============================================================================
+// Bounded read helper
+// ============================================================================
+
+/// Read an entire stream into [`Bytes`], capping the total at `cap` bytes.
+///
+/// [`RecvStream::read_all`] is unbounded and a hostile peer could exhaust
+/// memory with it. This loops over [`RecvStream::read`] into a growing buffer,
+/// erroring out if the peer sends more than `cap` bytes before FIN.
+pub async fn read_to_cap<R: RecvStream>(recv: &mut R, cap: usize) -> Result<Bytes> {
+    // Chunk size for each read. Bounded so a single read can't over-allocate.
+    const CHUNK: usize = 64 * 1024;
+    let mut out: Vec<u8> = Vec::new();
+    let mut scratch = vec![0u8; CHUNK];
+    loop {
+        match recv
+            .read(&mut scratch)
+            .await
+            .map_err(|e| anyhow!("recv read: {e}"))?
+        {
+            None => break, // FIN
+            Some(0) => continue,
+            Some(n) => {
+                if out.len() + n > cap {
+                    bail!("frame exceeds {cap} byte cap");
+                }
+                out.extend_from_slice(&scratch[..n]);
+            }
+        }
+    }
+    Ok(Bytes::from(out))
+}
+
+// ============================================================================
+// serve_rpc_connection — transport-generic server accept loop
+// ============================================================================
+
+/// Serve one accepted [`Session`] until the peer closes it or `shutdown` is
+/// cancelled. Terminates `hyprstream-rpc/1`-style bidi streams, caps concurrent
+/// streams via the shared `stream_limit`, and (in concert with the caller's
+/// drain on that same `stream_limit`) drains in-flight requests on shutdown.
+///
+/// The caller owns the drain: it holds the same `Arc<Semaphore>` and, on
+/// shutdown, cancels `shutdown` then `acquire_many(capacity)`s every permit so
+/// detached `handle_stream` tasks finish before teardown. This fn only acquires
+/// one per-stream permit per accepted bidi stream.
+pub async fn serve_rpc_connection<S>(
+    session: S,
+    processor: Arc<dyn IrohRequestProcessor>,
+    signing_key: SigningKey,
+    stream_limit: Arc<Semaphore>,
+    shutdown: CancellationToken,
+) -> Result<()>
+where
+    S: Session,
+{
+    loop {
+        tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => {
+                tracing::debug!("rpc-session: accept loop cancelled");
+                return Ok(());
+            }
+            streams = session.accept_bi() => {
+                let (send, recv) = match streams {
+                    Ok(pair) => pair,
+                    Err(e) => {
+                        tracing::debug!(error = ?e, "rpc-session: connection closed");
+                        return Ok(());
+                    }
+                };
+
+                // Acquire a permit to cap concurrent streams. If the semaphore
+                // is closed (shutdown drained it), exit cleanly.
+                let permit = match Arc::clone(&stream_limit).acquire_owned().await {
+                    Ok(p) => p,
+                    Err(_) => return Ok(()),
+                };
+
+                let processor = Arc::clone(&processor);
+                let signing_key = signing_key.clone();
+                // Hold a clone of the session in the per-stream task so the
+                // underlying QUIC connection stays alive until the response is
+                // fully written, even if the accept loop exits first on
+                // shutdown (some `Session` impls — e.g. web-transport-quinn —
+                // close the connection when the last `Session` handle drops).
+                let session_keepalive = session.clone();
+                tokio::spawn(async move {
+                    let _permit = permit; // released on task end
+                    let _keepalive = session_keepalive;
+                    handle_stream::<S>(send, recv, processor, signing_key).await;
+                });
+            }
+        }
+    }
+}
+
+/// Handle one bidi stream end-to-end: read request, dispatch to processor,
+/// write response (or signed error envelope on processor failure).
+async fn handle_stream<S>(
+    mut send: S::SendStream,
+    mut recv: S::RecvStream,
+    processor: Arc<dyn IrohRequestProcessor>,
+    signing_key: SigningKey,
+) where
+    S: Session,
+{
+    let request = match read_to_cap(&mut recv, MAX_FRAME_BYTES).await {
+        Ok(buf) => buf,
+        Err(e) => {
+            tracing::warn!(error = ?e, "rpc-session: failed reading request");
+            return;
+        }
+    };
+
+    let response = match processor.process(request).await {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            tracing::warn!(error = ?e, "rpc-session: processor error, sending stub error envelope");
+            build_error_envelope(&signing_key, &format!("processor error: {e}"))
+        }
+    };
+
+    if let Err(e) = send.write_all(&response).await {
+        tracing::warn!(error = ?e, "rpc-session: failed writing response");
+        return;
+    }
+    if let Err(e) = send.finish() {
+        tracing::warn!(error = ?e, "rpc-session: failed finishing send");
+        return;
+    }
+    // Wait for the peer to ack the FIN, but cap it so a dead peer can't leak
+    // this task forever.
+    let _ = tokio::time::timeout(STOPPED_GRACE, send.closed()).await;
+}
+
+/// Build a signed `ResponseEnvelope` (request_id = 0) carrying `message` as
+/// the payload. Used when the processor itself fails — guarantees the client
+/// sees a parseable envelope rather than EOF.
+pub fn build_error_envelope(signing_key: &SigningKey, message: &str) -> Bytes {
+    use crate::ToCapnp;
+    use capnp::{message::Builder, serialize};
+    let envelope =
+        crate::envelope::ResponseEnvelope::new_signed(0, message.as_bytes().to_vec(), signing_key);
+    let mut msg = Builder::new_default();
+    {
+        let mut builder = msg.init_root::<crate::common_capnp::response_envelope::Builder>();
+        envelope.write_to(&mut builder);
+    }
+    let mut bytes = Vec::new();
+    if let Err(e) = serialize::write_message(&mut bytes, &msg) {
+        // Last-ditch: if even this fails, return empty bytes — client will see
+        // a Cap'n Proto parse error, which is no worse than the original
+        // behaviour. This should be unreachable in practice.
+        tracing::error!(error = ?e, "rpc-session: failed serializing error envelope");
+        return Bytes::new();
+    }
+    Bytes::from(bytes)
+}
+
+// ============================================================================
+// SessionRpcTransport — transport-generic client
+// ============================================================================
+
+/// Wraps a [`web_transport_trait::Session`] as a [`Transport`] for RPC plane
+/// traffic. Generic over the session impl, so the same client logic rides iroh,
+/// quinn, or any future `Session` backend.
+///
+/// Clone-cheap — `Session` is `Clone` (reference-counted internally by the
+/// underlying QUIC connection).
+#[derive(Clone)]
+pub struct SessionRpcTransport<S: Session> {
+    session: S,
+}
+
+impl<S: Session> SessionRpcTransport<S> {
+    /// Build from an already-established session on the RPC ALPN.
+    pub fn new(session: S) -> Self {
+        Self { session }
+    }
+
+    /// Borrow the underlying session (e.g. for inspection).
+    pub fn session(&self) -> &S {
+        &self.session
+    }
+}
+
+/// Stub stream type for [`Transport::Sub`]. Always pending — the RPC plane does
+/// not carry SUB-style topic streams; those live on the streaming plane.
+pub type RpcPendingStream = futures::stream::Pending<Result<Vec<Vec<u8>>>>;
+
+/// Stub publish sink for [`Transport::Pub`]. Errors on any `send_frames` call;
+/// the RPC plane is request-response only.
+pub struct RpcPublishStub;
+
+#[async_trait]
+impl PublishSink for RpcPublishStub {
+    async fn send_frames(&self, _frames: &[&[u8]]) -> Result<()> {
+        bail!("RPC plane does not support PUB/PUSH — use moq-net on the streaming ALPN")
+    }
+}
+
+#[async_trait]
+impl<S: Session> Transport for SessionRpcTransport<S> {
+    type Sub = RpcPendingStream;
+    type Pub = RpcPublishStub;
+
+    async fn send(&self, payload: Vec<u8>, timeout_ms: Option<i32>) -> Result<Vec<u8>> {
+        let timeout = timeout_ms
+            .map(|ms| Duration::from_millis(ms.max(0) as u64))
+            .unwrap_or(DEFAULT_TIMEOUT);
+        let session = self.session.clone();
+        let fut = async move {
+            let (mut send, mut recv) = session
+                .open_bi()
+                .await
+                .map_err(|e| anyhow!("session open_bi: {e}"))?;
+            send.write_all(&payload)
+                .await
+                .map_err(|e| anyhow!("session write_all: {e}"))?;
+            send.finish().map_err(|e| anyhow!("session finish: {e}"))?;
+            let buf = read_to_cap(&mut recv, MAX_FRAME_BYTES).await?;
+            Ok::<Vec<u8>, anyhow::Error>(buf.to_vec())
+        };
+        tokio::time::timeout(timeout, fut)
+            .await
+            .map_err(|_| anyhow!("RPC timeout after {timeout:?}"))?
+    }
+
+    async fn subscribe(&self, _topic: &[u8]) -> Result<Self::Sub> {
+        bail!("RPC plane does not support SUB — use moq-net on the streaming ALPN")
+    }
+
+    async fn publish(&self, _topic: &[u8]) -> Result<Self::Pub> {
+        bail!("RPC plane does not support PUB — use moq-net on the streaming ALPN")
+    }
+}

--- a/crates/hyprstream-rpc/src/transport/uds_server.rs
+++ b/crates/hyprstream-rpc/src/transport/uds_server.rs
@@ -1,0 +1,280 @@
+//! UDS RPC server — the same-host `ipc` serve path, post-ZMQ.
+//!
+//! Mirrors [`QuinnRpcServer`](super::quinn_transport::QuinnRpcServer): a
+//! `UnixListener` accept loop that hands each accepted connection to the
+//! transport-generic [`serve_rpc_connection`] over a
+//! [`UdsSession`](super::uds_session::UdsSession). Same DoS discipline — a
+//! server-wide concurrent-stream semaphore (drained on shutdown), a
+//! per-connection cap, a bounded handshake, and the per-stream read timeout —
+//! and the same `process_request` dispatch core, so the ipc plane is identical
+//! to the quinn/iroh planes save for the socket underneath.
+//!
+//! The daemon binds the `UnixListener` (choosing the path + file mode; peer
+//! creds are #207) and runs one of these per spawn-path service. A
+//! `!Send` service is bridged to the `Send`-bound processor via
+//! [`LocalServiceBridge`](super::iroh_rpc::LocalServiceBridge), exactly as the
+//! quinn/iroh serve paths do.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use ed25519_dalek::SigningKey;
+use tokio::net::UnixListener;
+use tokio::sync::Semaphore;
+use tokio_util::sync::CancellationToken;
+
+use super::rpc_session::{
+    serve_rpc_connection, IrohRequestProcessor, DEFAULT_CONNECTION_LIMIT, DEFAULT_STREAM_LIMIT,
+    DRAIN_TIMEOUT, REQUEST_READ_TIMEOUT,
+};
+use super::uds_session::{accept_uds, PLANE_MOQ, PLANE_RPC};
+
+/// A `UnixListener`-backed RPC server for the same-host `ipc` plane.
+pub struct UdsRpcServer {
+    listener: UnixListener,
+    processor: Arc<dyn IrohRequestProcessor>,
+    signing_key: SigningKey,
+    /// Server-wide concurrent-stream cap, shared across all connections; one
+    /// permit per in-flight bidi stream. `shutdown` drains it via `acquire_many`.
+    stream_limit: Arc<Semaphore>,
+    stream_limit_capacity: u32,
+    /// Cap on concurrent accepted connections (#162). Connections beyond the cap
+    /// are rejected (dropped), not queued.
+    connection_limit: Arc<Semaphore>,
+    /// Per-stream request-read timeout (#159 slowloris bound).
+    read_timeout: Duration,
+    shutdown: CancellationToken,
+}
+
+impl UdsRpcServer {
+    /// Build a server over an already-bound [`UnixListener`].
+    pub fn new<P: IrohRequestProcessor>(
+        listener: UnixListener,
+        processor: P,
+        signing_key: SigningKey,
+    ) -> Self {
+        Self::with_capacity(listener, Arc::new(processor), signing_key, DEFAULT_STREAM_LIMIT)
+    }
+
+    /// Build a server with an explicit server-wide concurrent-stream cap.
+    pub fn with_capacity(
+        listener: UnixListener,
+        processor: Arc<dyn IrohRequestProcessor>,
+        signing_key: SigningKey,
+        stream_limit: usize,
+    ) -> Self {
+        Self {
+            listener,
+            processor,
+            signing_key,
+            stream_limit: Arc::new(Semaphore::new(stream_limit)),
+            stream_limit_capacity: u32::try_from(stream_limit).unwrap_or(u32::MAX),
+            connection_limit: Arc::new(Semaphore::new(DEFAULT_CONNECTION_LIMIT)),
+            read_timeout: REQUEST_READ_TIMEOUT,
+            shutdown: CancellationToken::new(),
+        }
+    }
+
+    /// Override the concurrent-connection cap (builder style).
+    pub fn with_connection_limit(mut self, limit: usize) -> Self {
+        self.connection_limit = Arc::new(Semaphore::new(limit));
+        self
+    }
+
+    /// Override the server-wide concurrent-stream cap (builder style).
+    pub fn with_stream_limit(mut self, limit: usize) -> Self {
+        self.stream_limit = Arc::new(Semaphore::new(limit));
+        self.stream_limit_capacity = u32::try_from(limit).unwrap_or(u32::MAX);
+        self
+    }
+
+    /// Override the per-stream request-read timeout (#159). Primarily for tests.
+    pub fn with_read_timeout(mut self, read_timeout: Duration) -> Self {
+        self.read_timeout = read_timeout;
+        self
+    }
+
+    /// A handle that, when cancelled, stops the accept loop and per-connection
+    /// serve loops. Does not by itself drain in-flight streams — use
+    /// [`UdsRpcServer::shutdown`] for a graceful drain.
+    pub fn shutdown_token(&self) -> CancellationToken {
+        self.shutdown.clone()
+    }
+
+    /// The shared concurrent-stream semaphore (pair with [`UdsRpcServer::capacity`]
+    /// + [`UdsRpcServer::shutdown_token`] to drain while `run` owns `self`).
+    pub fn stream_limit(&self) -> Arc<Semaphore> {
+        Arc::clone(&self.stream_limit)
+    }
+
+    /// The configured server-wide concurrent-stream capacity.
+    pub fn capacity(&self) -> u32 {
+        self.stream_limit_capacity
+    }
+
+    /// Graceful shutdown: cancel the accept loop, then wait (bounded by
+    /// [`DRAIN_TIMEOUT`]) for every in-flight stream to release its permit, then
+    /// close the semaphore. Mirrors [`QuinnRpcServer::shutdown`](super::quinn_transport::QuinnRpcServer::shutdown).
+    pub async fn shutdown(stream_limit: &Arc<Semaphore>, capacity: u32, token: &CancellationToken) {
+        token.cancel();
+        match tokio::time::timeout(DRAIN_TIMEOUT, stream_limit.acquire_many(capacity)).await {
+            Ok(Ok(permits)) => {
+                permits.forget();
+                stream_limit.close();
+            }
+            Ok(Err(_)) => { /* already closed */ }
+            Err(_) => {
+                tracing::warn!(timeout = ?DRAIN_TIMEOUT, "uds-rpc: drain timed out, forcing teardown");
+                stream_limit.close();
+            }
+        }
+    }
+
+    /// Run the accept loop until `shutdown` is cancelled. Each accepted
+    /// connection is served on its own task by [`serve_rpc_connection`], sharing
+    /// the server-wide [`Semaphore`] so [`UdsRpcServer::shutdown`] can drain
+    /// every in-flight stream regardless of which connection it belongs to.
+    pub async fn run(self) -> Result<()> {
+        loop {
+            tokio::select! {
+                biased;
+                _ = self.shutdown.cancelled() => {
+                    tracing::debug!("uds-rpc: accept loop cancelled");
+                    return Ok(());
+                }
+                accepted = self.listener.accept() => {
+                    let stream = match accepted {
+                        Ok((stream, _addr)) => stream,
+                        Err(e) => {
+                            tracing::debug!(error = %e, "uds-rpc: listener accept error");
+                            continue;
+                        }
+                    };
+
+                    // Connection cap (#162): reject (drop) at cap rather than queue.
+                    let conn_permit = match Arc::clone(&self.connection_limit).try_acquire_owned() {
+                        Ok(p) => p,
+                        Err(_) => {
+                            tracing::warn!("uds-rpc: connection cap reached, rejecting connection");
+                            drop(stream);
+                            continue;
+                        }
+                    };
+
+                    let processor = Arc::clone(&self.processor);
+                    let signing_key = self.signing_key.clone();
+                    let stream_limit = Arc::clone(&self.stream_limit);
+                    let read_timeout = self.read_timeout;
+                    let shutdown = self.shutdown.clone();
+                    tokio::spawn(async move {
+                        let _conn_permit = conn_permit; // released when this connection ends
+
+                        // Read the plane byte + spin up the yamux session, bounded
+                        // so a stalled handshake never pins a connection permit.
+                        let (plane, session) = match tokio::time::timeout(
+                            super::rpc_session::HANDSHAKE_TIMEOUT,
+                            accept_uds(stream),
+                        )
+                        .await
+                        {
+                            Ok(Ok(pair)) => pair,
+                            Ok(Err(e)) => {
+                                tracing::debug!(error = %e, "uds-rpc: accept_uds failed");
+                                return;
+                            }
+                            Err(_) => {
+                                tracing::warn!("uds-rpc: plane handshake timed out");
+                                return;
+                            }
+                        };
+
+                        match plane {
+                            PLANE_RPC => {
+                                if let Err(e) = serve_rpc_connection(
+                                    session, processor, signing_key, stream_limit, read_timeout, shutdown,
+                                )
+                                .await
+                                {
+                                    tracing::debug!(error = ?e, "uds-rpc: serve connection ended with error");
+                                }
+                            }
+                            PLANE_MOQ => {
+                                // moq streaming over UDS is a later increment; the
+                                // same UdsSession is moq-capable, but the daemon
+                                // does not yet wire a moq Server on this listener.
+                                tracing::warn!("uds-rpc: PLANE_MOQ on the RPC listener — not yet served, closing");
+                            }
+                            other => {
+                                tracing::warn!(plane = other, "uds-rpc: unknown plane, closing");
+                            }
+                        }
+                    });
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::transport::lazy_uds::LazyUdsTransport;
+    use crate::transport::rpc_session::from_fn;
+    use crate::transport_traits::Transport;
+    use bytes::Bytes;
+
+    fn temp_sock(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("uds-server-{}-{}", tag, std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        dir.join("rpc.sock")
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn uds_server_round_trips_via_lazy_client() {
+        let path = temp_sock("rt");
+        let _ = std::fs::remove_file(&path);
+        let listener = UnixListener::bind(&path).unwrap();
+
+        let (sk, _vk) = crate::generate_signing_keypair();
+        let processor = from_fn(|req: Bytes| async move { Ok(req) }); // echo
+        let server = UdsRpcServer::new(listener, processor, sk);
+        let token = server.shutdown_token();
+        let srv = tokio::spawn(server.run());
+
+        let client = LazyUdsTransport::new(path.clone());
+        let r1 = client.send(b"ping".to_vec(), Some(4_000)).await.unwrap();
+        assert_eq!(r1, b"ping");
+        // Reuse the cached session over a second multiplexed stream.
+        let r2 = client.send(b"pong".to_vec(), Some(4_000)).await.unwrap();
+        assert_eq!(r2, b"pong");
+
+        token.cancel();
+        let _ = srv.await;
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn uds_server_shutdown_drains() {
+        let path = temp_sock("drain");
+        let _ = std::fs::remove_file(&path);
+        let listener = UnixListener::bind(&path).unwrap();
+
+        let (sk, _vk) = crate::generate_signing_keypair();
+        let processor = from_fn(|req: Bytes| async move { Ok(req) });
+        let server = UdsRpcServer::new(listener, processor, sk);
+        let token = server.shutdown_token();
+        let stream_limit = server.stream_limit();
+        let capacity = server.capacity();
+        let srv = tokio::spawn(server.run());
+
+        let client = LazyUdsTransport::new(path.clone());
+        assert_eq!(client.send(b"x".to_vec(), Some(4_000)).await.unwrap(), b"x");
+
+        // Graceful drain completes promptly with no in-flight streams.
+        UdsRpcServer::shutdown(&stream_limit, capacity, &token).await;
+        let _ = srv.await;
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/crates/hyprstream-rpc/src/transport/uds_session.rs
+++ b/crates/hyprstream-rpc/src/transport/uds_session.rs
@@ -1,0 +1,813 @@
+//! `UdsSession` — one [`web_transport_trait::Session`] over a Unix-domain socket.
+//!
+//! Epic #131 / moq M1. Same-host processes keep an `ipc` transport after the ZMQ
+//! removal, but re-platformed off ZMQ framing onto the *same* generic plane that
+//! quinn and iroh use: a [`web_transport_trait::Session`]. Because both the RPC
+//! plane ([`super::rpc_session::SessionRpcTransport`] /
+//! [`super::rpc_session::serve_rpc_connection`]) and the streaming plane
+//! (`moq_net::{Client, Server}`) are generic over `Session`, **one** `UdsSession`
+//! impl carries *both* over a single `UnixStream` — exactly as the QUIC/iroh
+//! sessions do.
+//!
+//! # Why a multiplexer
+//!
+//! `web_transport_trait::Session` is a *stream-multiplexed* abstraction
+//! (`open_bi`/`open_uni`/`accept_bi`/`accept_uni`). QUIC and iroh provide that
+//! natively; a `UnixStream` is a single ordered byte-stream. So `UdsSession`
+//! carries a [`yamux`] multiplexer — flow-controlled, head-of-line-correct
+//! concurrent substreams over the one socket. moq-lite needs exactly this: one
+//! bidi SETUP control stream plus one uni stream per Group. It never uses
+//! datagrams, so those trait methods are stubbed (`max_datagram_size() == 0`).
+//!
+//! # Two wire conventions (UDS has neither ALPN nor a uni/bidi distinction)
+//!
+//! 1. **Plane byte** ([`PLANE_RPC`] / [`PLANE_MOQ`]) — written once on the raw
+//!    `UnixStream` *before* yamux wraps it. Replaces ALPN: the listener reads it
+//!    to route the connection to the RPC dispatcher vs `moq_net::Server::accept`.
+//! 2. **Substream tag** ([`TAG_BIDI`] / [`TAG_UNI`]) — yamux substreams are all
+//!    bidirectional, so the opener prefixes each new substream with one tag byte
+//!    and the acceptor reads it to route the substream to `accept_bi` vs
+//!    `accept_uni`. A uni opener simply never reads its half.
+//!
+//! # Driver
+//!
+//! yamux's `Connection` is single-owner and poll-driven (not `Clone`), but
+//! `Session: Clone` and is called concurrently. So one **driver task** owns the
+//! `Connection` and services `open_*`/inbound-stream work over channels; cloned
+//! `UdsSession` handles all talk to it. This mirrors `libp2p-yamux`.
+
+use std::collections::VecDeque;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use anyhow::Result;
+use bytes::Bytes;
+use futures::io::{AsyncReadExt, AsyncWriteExt, ReadHalf, WriteHalf};
+use tokio::sync::{mpsc, oneshot, Mutex, Notify};
+use tokio_util::compat::TokioAsyncReadCompatExt;
+use web_transport_trait::Session;
+
+/// Connection-plane selector written as the first byte on the raw socket. The
+/// RPC dispatcher and the moq server are distinct planes (as ALPN distinguishes
+/// them on QUIC); one `UnixStream` serves exactly one.
+pub const PLANE_RPC: u8 = 0x01;
+/// See [`PLANE_RPC`]. Routes the connection to `moq_net::Server::accept`.
+pub const PLANE_MOQ: u8 = 0x02;
+
+/// Substream-kind tag: the opener intends a bidirectional stream.
+const TAG_BIDI: u8 = 0x01;
+/// Substream-kind tag: the opener intends a unidirectional stream (writer only).
+const TAG_UNI: u8 = 0x02;
+
+/// Bound on queued accepted substreams and pending opens before backpressure.
+const ACCEPT_CHANNEL_BOUND: usize = 64;
+const CMD_CHANNEL_BOUND: usize = 64;
+
+/// Hard cap on concurrent yamux substreams per connection. Bounds the inbound
+/// classification fan-out (one task + one stream slot each) so a hostile local
+/// peer cannot open an unbounded number of substreams. yamux enforces this at
+/// the protocol layer (excess opens are refused), giving the transport a DoS
+/// bound independent of the downstream rpc_session semaphore.
+const MAX_CONCURRENT_STREAMS: usize = 256;
+
+/// Per-substream deadline for reading the 1-byte UNI/BIDI tag. Without it, a
+/// peer that opens a substream and never sends the tag pins a classification
+/// task and a yamux stream slot forever — a pre-dispatch slowloris that evades
+/// rpc_session's `REQUEST_READ_TIMEOUT` (which only starts after classification).
+const TAG_READ_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// The concrete yamux substream type once wrapped over a compat `UnixStream`.
+type YamuxStream = yamux::Stream;
+
+// ============================================================================
+// Error
+// ============================================================================
+
+/// Error type for [`UdsSession`] and its streams.
+#[derive(Debug, Clone)]
+pub struct UdsError(String);
+
+impl UdsError {
+    fn new(msg: impl Into<String>) -> Self {
+        Self(msg.into())
+    }
+    fn closed() -> Self {
+        Self("uds session closed".to_owned())
+    }
+    fn io(e: std::io::Error) -> Self {
+        Self(format!("uds io: {e}"))
+    }
+    fn conn(e: yamux::ConnectionError) -> Self {
+        Self(format!("uds yamux: {e}"))
+    }
+}
+
+impl std::fmt::Display for UdsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for UdsError {}
+
+impl web_transport_trait::Error for UdsError {
+    fn session_error(&self) -> Option<(u32, String)> {
+        Some((0, self.0.clone()))
+    }
+}
+
+// ============================================================================
+// Streams
+// ============================================================================
+
+/// Outbound half of a UDS substream. Wraps the yamux write half; `finish`
+/// half-closes (sends FIN) so the peer's read sees EOF.
+pub struct UdsSendStream {
+    // `None` after finish()/reset() so further writes error.
+    inner: Option<WriteHalf<YamuxStream>>,
+}
+
+impl UdsSendStream {
+    fn new(wh: WriteHalf<YamuxStream>) -> Self {
+        Self { inner: Some(wh) }
+    }
+}
+
+impl web_transport_trait::SendStream for UdsSendStream {
+    type Error = UdsError;
+
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        let wh = self
+            .inner
+            .as_mut()
+            .ok_or_else(|| UdsError::new("write after finish/reset"))?;
+        wh.write(buf).await.map_err(UdsError::io)
+    }
+
+    fn set_priority(&mut self, _order: u8) {
+        // yamux has no per-stream priority; no-op.
+    }
+
+    fn finish(&mut self) -> Result<(), Self::Error> {
+        // `finish` is sync but yamux close is async; send the FIN on a detached
+        // task. Subsequent writes error (inner is now None). The driver pumps the
+        // connection so the FIN reaches the peer.
+        if let Some(mut wh) = self.inner.take() {
+            tokio::spawn(async move {
+                if let Err(e) = wh.close().await {
+                    tracing::debug!(error = %e, "uds: send-stream FIN flush failed");
+                }
+            });
+        }
+        Ok(())
+    }
+
+    fn reset(&mut self, _code: u32) {
+        // Drop the write half without a graceful FIN; yamux signals the peer.
+        self.inner = None;
+    }
+
+    async fn closed(&mut self) -> Result<(), Self::Error> {
+        // `closed` must DETECT closure, never CAUSE it. After finish()/reset()
+        // the FIN/RST was already initiated, so report closed. While the stream
+        // is still open we have no portable way to observe a peer STOP_SENDING
+        // through yamux's WriteHalf, so we pend — returning early here would make
+        // moq's `select! { biased; _ = closed() => cancel }` abort a live group
+        // right after its header, dropping every frame.
+        if self.inner.is_some() {
+            std::future::pending::<()>().await;
+        }
+        Ok(())
+    }
+}
+
+/// Inbound half of a UDS substream. Wraps the yamux read half.
+pub struct UdsRecvStream {
+    inner: ReadHalf<YamuxStream>,
+}
+
+impl UdsRecvStream {
+    fn new(rh: ReadHalf<YamuxStream>) -> Self {
+        Self { inner: rh }
+    }
+}
+
+impl web_transport_trait::RecvStream for UdsRecvStream {
+    type Error = UdsError;
+
+    async fn read(&mut self, dst: &mut [u8]) -> Result<Option<usize>, Self::Error> {
+        match self.inner.read(dst).await.map_err(UdsError::io)? {
+            0 => Ok(None), // EOF (FIN)
+            n => Ok(Some(n)),
+        }
+    }
+
+    fn stop(&mut self, _code: u32) {
+        // Best-effort: the read half closes on drop of this `UdsRecvStream`,
+        // which yamux surfaces to the peer. No separate sync close path.
+    }
+
+    async fn closed(&mut self) -> Result<(), Self::Error> {
+        // Must DETECT closure without CONSUMING data — moq selects on
+        // `recv.closed()` concurrently with reads, so draining here would steal
+        // frame bytes. We have no portable yamux peek for a peer FIN/RST on the
+        // ReadHalf, so we pend; the stream closes for real when this
+        // `UdsRecvStream` drops. (A `read()` returning `None` is the actual
+        // EOF signal moq relies on.)
+        std::future::pending::<()>().await;
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Driver
+// ============================================================================
+
+/// Command from a [`UdsSession`] handle to its driver task.
+enum DriverCmd {
+    /// Open a new outbound yamux substream; the tag byte is written by the
+    /// `open_*` method after it receives the stream.
+    OpenOutbound(oneshot::Sender<Result<YamuxStream, yamux::ConnectionError>>),
+    /// Begin a graceful connection close.
+    Close,
+}
+
+/// Read the 1-byte substream tag and route the substream to the matching accept
+/// queue. Runs as its own task so the tag read is driven by the still-pumping
+/// connection driver (it never blocks the driver loop).
+async fn classify_inbound(
+    mut stream: YamuxStream,
+    bi_tx: mpsc::Sender<(UdsSendStream, UdsRecvStream)>,
+    uni_tx: mpsc::Sender<UdsRecvStream>,
+) {
+    let mut tag = [0u8; 1];
+    // Bound the tag read so a peer that opens a substream and never tags it
+    // cannot pin this task + a yamux stream slot indefinitely.
+    match tokio::time::timeout(TAG_READ_TIMEOUT, stream.read_exact(&mut tag)).await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            tracing::debug!(error = %e, "uds: inbound substream closed before tagging");
+            return;
+        }
+        Err(_) => {
+            tracing::warn!(
+                timeout = ?TAG_READ_TIMEOUT,
+                "uds: inbound substream did not send its tag in time, dropping"
+            );
+            return;
+        }
+    }
+    match tag[0] {
+        TAG_BIDI => {
+            let (rh, wh) = stream.split();
+            let _ = bi_tx.send((UdsSendStream::new(wh), UdsRecvStream::new(rh))).await;
+        }
+        TAG_UNI => {
+            let (rh, _wh) = stream.split();
+            // Uni: peer only writes; we keep the read half, drop the write half.
+            let _ = uni_tx.send(UdsRecvStream::new(rh)).await;
+        }
+        unknown => {
+            tracing::warn!(tag = unknown, "uds: unknown substream tag, dropping");
+        }
+    }
+}
+
+/// The connection driver: owns the yamux `Connection` and pumps it forever,
+/// servicing outbound-open commands and routing inbound substreams, until the
+/// connection ends or all handles drop. A single `poll_fn` keeps exclusive
+/// `&mut conn` per poll, avoiding the borrow dance of `select!`.
+async fn drive_connection<T>(
+    socket: T,
+    mode: yamux::Mode,
+    mut cmd_rx: mpsc::Receiver<DriverCmd>,
+    bi_tx: mpsc::Sender<(UdsSendStream, UdsRecvStream)>,
+    uni_tx: mpsc::Sender<UdsRecvStream>,
+    is_closed: Arc<AtomicBool>,
+    closed_notify: Arc<Notify>,
+) where
+    T: futures::AsyncRead + futures::AsyncWrite + Unpin + Send + 'static,
+{
+    let mut cfg = yamux::Config::default();
+    // Cap concurrent substreams (DoS bound on inbound classification fan-out).
+    cfg.set_max_num_streams(MAX_CONCURRENT_STREAMS);
+    let mut conn = yamux::Connection::new(socket, cfg, mode);
+    let mut pending_opens: VecDeque<oneshot::Sender<Result<YamuxStream, yamux::ConnectionError>>> =
+        VecDeque::new();
+    let mut closing = false;
+
+    std::future::poll_fn(|cx: &mut Context<'_>| {
+        // 1. Ingest outbound-open / close commands (non-blocking drain).
+        if !closing {
+            loop {
+                match cmd_rx.poll_recv(cx) {
+                    Poll::Ready(Some(DriverCmd::OpenOutbound(reply))) => {
+                        pending_opens.push_back(reply);
+                    }
+                    // Explicit close, or all `UdsSession` handles dropped
+                    // (nothing more will be requested) — begin close either way.
+                    Poll::Ready(Some(DriverCmd::Close)) | Poll::Ready(None) => {
+                        closing = true;
+                        break;
+                    }
+                    Poll::Pending => break,
+                }
+            }
+        }
+
+        // 2. Service queued outbound opens (skip while closing).
+        if !closing {
+            while !pending_opens.is_empty() {
+                match conn.poll_new_outbound(cx) {
+                    Poll::Ready(result) => {
+                        let is_err = result.is_err();
+                        if let Some(reply) = pending_opens.pop_front() {
+                            let _ = reply.send(result);
+                        }
+                        if is_err {
+                            closing = true;
+                            break;
+                        }
+                    }
+                    Poll::Pending => break,
+                }
+            }
+        }
+
+        // 3. Closing path: drive the close handshake to completion.
+        if closing {
+            return match conn.poll_close(cx) {
+                Poll::Ready(_) => Poll::Ready(()),
+                Poll::Pending => Poll::Pending,
+            };
+        }
+
+        // 4. Drive inbound: each accepted substream is classified on its own task.
+        loop {
+            match conn.poll_next_inbound(cx) {
+                Poll::Ready(Some(Ok(stream))) => {
+                    tokio::spawn(classify_inbound(stream, bi_tx.clone(), uni_tx.clone()));
+                }
+                Poll::Ready(Some(Err(_))) | Poll::Ready(None) => return Poll::Ready(()),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    })
+    .await;
+
+    // Connection ended: wake `closed()` waiters; dropping bi_tx/uni_tx closes the
+    // accept channels so pending `accept_*` calls observe closure.
+    is_closed.store(true, Ordering::Release);
+    closed_notify.notify_waiters();
+}
+
+// ============================================================================
+// Session
+// ============================================================================
+
+struct Inner {
+    cmd_tx: mpsc::Sender<DriverCmd>,
+    accept_bi_rx: Mutex<mpsc::Receiver<(UdsSendStream, UdsRecvStream)>>,
+    accept_uni_rx: Mutex<mpsc::Receiver<UdsRecvStream>>,
+    is_closed: Arc<AtomicBool>,
+    closed_notify: Arc<Notify>,
+}
+
+/// A [`web_transport_trait::Session`] over a Unix-domain socket, multiplexed by
+/// yamux. Clone-cheap (shares one driver via `Arc`). Carries both the RPC and
+/// moq planes — see the module docs.
+#[derive(Clone)]
+pub struct UdsSession {
+    inner: Arc<Inner>,
+}
+
+impl UdsSession {
+    /// Wrap an established, plane-selected socket and spawn its driver task.
+    /// `socket` must already have had the [`PLANE_RPC`]/[`PLANE_MOQ`] byte
+    /// consumed (see [`connect_uds`] / [`accept_uds`]).
+    fn spawn<T>(socket: T, mode: yamux::Mode) -> Self
+    where
+        T: futures::AsyncRead + futures::AsyncWrite + Unpin + Send + 'static,
+    {
+        let (cmd_tx, cmd_rx) = mpsc::channel(CMD_CHANNEL_BOUND);
+        let (bi_tx, bi_rx) = mpsc::channel(ACCEPT_CHANNEL_BOUND);
+        let (uni_tx, uni_rx) = mpsc::channel(ACCEPT_CHANNEL_BOUND);
+        let is_closed = Arc::new(AtomicBool::new(false));
+        let closed_notify = Arc::new(Notify::new());
+
+        tokio::spawn(drive_connection(
+            socket,
+            mode,
+            cmd_rx,
+            bi_tx,
+            uni_tx,
+            Arc::clone(&is_closed),
+            Arc::clone(&closed_notify),
+        ));
+
+        Self {
+            inner: Arc::new(Inner {
+                cmd_tx,
+                accept_bi_rx: Mutex::new(bi_rx),
+                accept_uni_rx: Mutex::new(uni_rx),
+                is_closed,
+                closed_notify,
+            }),
+        }
+    }
+
+    /// Request a fresh outbound yamux substream from the driver.
+    async fn open_outbound(&self) -> Result<YamuxStream, UdsError> {
+        let (tx, rx) = oneshot::channel();
+        self.inner
+            .cmd_tx
+            .send(DriverCmd::OpenOutbound(tx))
+            .await
+            .map_err(|_| UdsError::closed())?;
+        rx.await.map_err(|_| UdsError::closed())?.map_err(UdsError::conn)
+    }
+}
+
+impl Session for UdsSession {
+    type SendStream = UdsSendStream;
+    type RecvStream = UdsRecvStream;
+    type Error = UdsError;
+
+    async fn accept_uni(&self) -> Result<Self::RecvStream, Self::Error> {
+        let mut rx = self.inner.accept_uni_rx.lock().await;
+        rx.recv().await.ok_or_else(UdsError::closed)
+    }
+
+    async fn accept_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
+        let mut rx = self.inner.accept_bi_rx.lock().await;
+        rx.recv().await.ok_or_else(UdsError::closed)
+    }
+
+    async fn open_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
+        let mut stream = self.open_outbound().await?;
+        // Tag + flush so the acceptor can classify before any plane data.
+        stream.write_all(&[TAG_BIDI]).await.map_err(UdsError::io)?;
+        stream.flush().await.map_err(UdsError::io)?;
+        let (rh, wh) = stream.split();
+        Ok((UdsSendStream::new(wh), UdsRecvStream::new(rh)))
+    }
+
+    async fn open_uni(&self) -> Result<Self::SendStream, Self::Error> {
+        let mut stream = self.open_outbound().await?;
+        stream.write_all(&[TAG_UNI]).await.map_err(UdsError::io)?;
+        stream.flush().await.map_err(UdsError::io)?;
+        let (_rh, wh) = stream.split();
+        Ok(UdsSendStream::new(wh))
+    }
+
+    fn send_datagram(&self, _payload: Bytes) -> Result<(), Self::Error> {
+        Err(UdsError::new("UDS transport does not support datagrams"))
+    }
+
+    async fn recv_datagram(&self) -> Result<Bytes, Self::Error> {
+        // UDS has no datagram channel; moq-lite never calls this. Never resolves.
+        std::future::pending().await
+    }
+
+    fn max_datagram_size(&self) -> usize {
+        0
+    }
+
+    fn protocol(&self) -> Option<&str> {
+        None
+    }
+
+    fn close(&self, _code: u32, _reason: &str) {
+        // Best-effort: signal the driver. If the channel is full/closed the
+        // connection is already going down.
+        let _ = self.inner.cmd_tx.try_send(DriverCmd::Close);
+    }
+
+    async fn closed(&self) -> Self::Error {
+        loop {
+            if self.inner.is_closed.load(Ordering::Acquire) {
+                return UdsError::closed();
+            }
+            let notified = self.inner.closed_notify.notified();
+            // Re-check after arming to avoid missing a wake between the load and
+            // the await.
+            if self.inner.is_closed.load(Ordering::Acquire) {
+                return UdsError::closed();
+            }
+            notified.await;
+        }
+    }
+}
+
+// ============================================================================
+// Connect / accept helpers
+// ============================================================================
+
+/// Connect to a UDS endpoint, select `plane`, and return a multiplexed session.
+///
+/// Writes the [`PLANE_RPC`]/[`PLANE_MOQ`] byte on the raw socket, then wraps it
+/// in a client-mode yamux session.
+pub async fn connect_uds(path: impl AsRef<Path>, plane: u8) -> Result<UdsSession> {
+    let mut stream = tokio::net::UnixStream::connect(path.as_ref()).await?;
+    tokio::io::AsyncWriteExt::write_all(&mut stream, &[plane]).await?;
+    Ok(UdsSession::spawn(stream.compat(), yamux::Mode::Client))
+}
+
+/// Accept side: read the plane byte from a freshly-accepted `UnixStream`, then
+/// wrap it in a server-mode yamux session. The caller routes by `plane`
+/// ([`PLANE_RPC`] → RPC dispatcher, [`PLANE_MOQ`] → `moq_net::Server::accept`).
+pub async fn accept_uds(mut stream: tokio::net::UnixStream) -> Result<(u8, UdsSession)> {
+    let mut plane = [0u8; 1];
+    tokio::io::AsyncReadExt::read_exact(&mut stream, &mut plane).await?;
+    // Fail closed on an unrecognized plane selector rather than handing an
+    // ambiguous connection to a caller that would have to guess how to route it.
+    if !matches!(plane[0], PLANE_RPC | PLANE_MOQ) {
+        anyhow::bail!("uds: unknown plane selector byte 0x{:02x}", plane[0]);
+    }
+    Ok((plane[0], UdsSession::spawn(stream.compat(), yamux::Mode::Server)))
+}
+
+// Compile-time assertion that our types satisfy the native `MaybeSend` bound
+// (= `Send`) the moq/rpc planes require.
+const _: fn() = || {
+    fn assert_send<T: Send>() {}
+    assert_send::<UdsSession>();
+    assert_send::<UdsSendStream>();
+    assert_send::<UdsRecvStream>();
+};
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use web_transport_trait::{RecvStream as _, SendStream as _};
+
+    /// Spawn a connected client/server `UdsSession` pair over an in-process
+    /// socketpair (no filesystem path needed), with the given plane byte already
+    /// consumed.
+    async fn session_pair() -> (UdsSession, UdsSession) {
+        let (a, b) = tokio::net::UnixStream::pair().unwrap();
+        let client = UdsSession::spawn(a.compat(), yamux::Mode::Client);
+        let server = UdsSession::spawn(b.compat(), yamux::Mode::Server);
+        (client, server)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn bidi_round_trip() {
+        let (client, server) = session_pair().await;
+
+        let srv = tokio::spawn(async move {
+            let (mut send, mut recv) = server.accept_bi().await.unwrap();
+            let mut buf = vec![0u8; 5];
+            let n = recv.read(&mut buf).await.unwrap().unwrap();
+            buf.truncate(n);
+            send.write_all(&buf).await.unwrap(); // echo
+            send.finish().unwrap();
+            // keep the session alive until the client has read the echo
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        });
+
+        let (mut send, mut recv) = client.open_bi().await.unwrap();
+        send.write_all(b"hello").await.unwrap();
+        send.finish().unwrap();
+        let mut got = Vec::new();
+        let mut scratch = [0u8; 64];
+        while let Some(n) = recv.read(&mut scratch).await.unwrap() {
+            got.extend_from_slice(&scratch[..n]);
+        }
+        assert_eq!(&got, b"hello");
+        srv.await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn many_concurrent_uni_streams() {
+        let (client, server) = session_pair().await;
+        const N: usize = 8;
+
+        let srv = tokio::spawn(async move {
+            let mut totals = Vec::new();
+            for _ in 0..N {
+                let mut recv = server.accept_uni().await.unwrap();
+                let data = recv.read_all().await.unwrap();
+                totals.push(data.to_vec());
+            }
+            totals
+        });
+
+        // Open N uni streams concurrently, each carrying its index byte.
+        let mut handles = Vec::new();
+        for i in 0..N {
+            let c = client.clone();
+            handles.push(tokio::spawn(async move {
+                let mut send = c.open_uni().await.unwrap();
+                send.write_all(&[i as u8; 4]).await.unwrap();
+                send.finish().unwrap();
+                // Hold the stream briefly so FIN flushes.
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+        let mut got = srv.await.unwrap();
+        got.sort();
+        let mut want: Vec<Vec<u8>> = (0..N).map(|i| vec![i as u8; 4]).collect();
+        want.sort();
+        assert_eq!(got, want);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn uni_stream_server_to_client() {
+        // moq publishes group frames as server->client uni streams, so verify
+        // that direction explicitly (the other uni test is client->server).
+        let (client, server) = session_pair().await;
+
+        let cli = tokio::spawn(async move {
+            let mut recv = client.accept_uni().await.unwrap();
+            recv.read_all().await.unwrap()
+        });
+
+        let mut send = server.open_uni().await.unwrap();
+        send.write_all(b"srv->cli").await.unwrap();
+        send.finish().unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+        let got = cli.await.unwrap();
+        assert_eq!(&got[..], b"srv->cli");
+        // keep server alive until client read
+        drop(server);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn datagrams_unsupported() {
+        let (client, _server) = session_pair().await;
+        assert_eq!(client.max_datagram_size(), 0);
+        assert!(client.send_datagram(Bytes::from_static(b"x")).is_err());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn closed_fires_when_peer_drops() {
+        let (client, server) = session_pair().await;
+        drop(server);
+        // The driver should observe the broken connection and fire `closed`.
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), client.closed())
+            .await
+            .expect("closed() must resolve after peer drop");
+    }
+
+    // ── Integration: the real RPC plane rides UdsSession unchanged ──────────
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rpc_plane_round_trip_over_uds() {
+        use crate::transport::rpc_session::{
+            from_fn, serve_rpc_connection, SessionRpcTransport, DEFAULT_STREAM_LIMIT,
+            REQUEST_READ_TIMEOUT,
+        };
+        use crate::transport_traits::Transport;
+        use std::sync::Arc;
+        use tokio::sync::Semaphore;
+        use tokio_util::sync::CancellationToken;
+
+        let (client_session, server_session) = session_pair().await;
+
+        let (sk, _vk) = crate::generate_signing_keypair();
+        let processor = Arc::new(from_fn(|req: Bytes| async move { Ok(req) })); // echo
+        let limit = Arc::new(Semaphore::new(DEFAULT_STREAM_LIMIT));
+        let shutdown = CancellationToken::new();
+
+        let srv = tokio::spawn(serve_rpc_connection(
+            server_session,
+            processor,
+            sk,
+            limit,
+            REQUEST_READ_TIMEOUT,
+            shutdown.clone(),
+        ));
+
+        // Two sequential calls prove the session multiplexes fresh bidi streams.
+        let client = SessionRpcTransport::new(client_session);
+        let r1 = client.send(b"ping".to_vec(), Some(4_000)).await.unwrap();
+        assert_eq!(r1, b"ping");
+        let r2 = client.send(b"pong".to_vec(), Some(4_000)).await.unwrap();
+        assert_eq!(r2, b"pong");
+
+        shutdown.cancel();
+        let _ = srv.await;
+    }
+
+    // ── Integration: the real moq streaming plane rides UdsSession unchanged ──
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn moq_plane_publish_subscribe_over_uds() {
+        use moq_net::{Client, Group, Origin, Server, Track};
+        use std::time::Duration;
+
+        let (client_session, server_session) = session_pair().await;
+
+        // Publisher origin: publish a fully-formed broadcast/track/group (one
+        // frame, group closed) before the subscriber connects, so the served
+        // group is complete — matches the known-good iroh_moq round-trip.
+        let producer = Origin::random().produce();
+        let consumer = producer.consume();
+        let mut broadcast = producer.create_broadcast("alice/run-1").unwrap();
+        let mut track = broadcast.create_track(Track::new("tokens")).unwrap();
+        let mut group = track.create_group(Group::from(0u64)).unwrap();
+        group.write_frame(Bytes::from_static(b"hello-uds-moq")).unwrap();
+        drop(group);
+
+        // The moq handshake is bidirectional (client opens the SETUP stream, the
+        // server accepts it), so server.accept and client.connect must run
+        // concurrently — over iroh/quinn the server side lives in a spawned
+        // accept loop; here we spawn it explicitly.
+        let server = Server::new().with_publish(consumer);
+        let server_task = tokio::spawn(async move { server.accept(server_session).await });
+
+        // Client: run moq Client over the UDS session, subscribe, read the frame.
+        let client_origin = Origin::random().produce();
+        let client_consumer = client_origin.consume();
+        let moq_client = Client::new().with_consume(client_origin);
+        let _moq_session = tokio::time::timeout(Duration::from_secs(8), moq_client.connect(client_session))
+            .await
+            .expect("client.connect hung")
+            .unwrap();
+        let _moq_server = tokio::time::timeout(Duration::from_secs(8), server_task)
+            .await
+            .expect("server.accept hung")
+            .unwrap()
+            .unwrap();
+
+        let bc = tokio::time::timeout(
+            Duration::from_secs(5),
+            client_consumer.announced_broadcast("alice/run-1"),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let mut tc = bc.subscribe_track(&Track::new("tokens")).unwrap();
+
+        let mut gc = tokio::time::timeout(Duration::from_secs(5), tc.next_group())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        let frame = tokio::time::timeout(Duration::from_secs(5), gc.read_frame())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(&frame[..], b"hello-uds-moq");
+
+        // Keep broadcast/track alive until the read completes.
+        drop(track);
+        drop(broadcast);
+    }
+
+    // ── connect_uds / accept_uds plane handshake over a real listener ────────
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn plane_handshake_over_listener() {
+        let dir = std::env::temp_dir().join(format!("uds-test-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("plane.sock");
+        let _ = std::fs::remove_file(&path);
+        let listener = tokio::net::UnixListener::bind(&path).unwrap();
+
+        let srv = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (plane, session) = accept_uds(stream).await.unwrap();
+            assert_eq!(plane, PLANE_RPC);
+            // echo one bidi stream
+            let (mut send, mut recv) = session.accept_bi().await.unwrap();
+            let data = recv.read_all().await.unwrap();
+            send.write_all(&data).await.unwrap();
+            send.finish().unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        });
+
+        let client = connect_uds(&path, PLANE_RPC).await.unwrap();
+        let (mut send, mut recv) = client.open_bi().await.unwrap();
+        send.write_all(b"plane-ok").await.unwrap();
+        send.finish().unwrap();
+        let got = recv.read_all().await.unwrap();
+        assert_eq!(&got[..], b"plane-ok");
+
+        srv.await.unwrap();
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_dir(&dir);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn accept_uds_rejects_unknown_plane() {
+        let (a, b) = tokio::net::UnixStream::pair().unwrap();
+        // Client writes a bogus plane selector.
+        let cli = tokio::spawn(async move {
+            let mut a = a;
+            tokio::io::AsyncWriteExt::write_all(&mut a, &[0xFF]).await.unwrap();
+            // Hold the socket open so the server's read sees the byte, not EOF.
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        });
+        let res = accept_uds(b).await;
+        assert!(res.is_err(), "unknown plane selector must be rejected");
+        cli.await.unwrap();
+    }
+}

--- a/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
+++ b/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
@@ -384,7 +384,7 @@ impl QuicRep {
         Ok(())
     }
 
-    /// Accept loop for ZmqService handlers.
+    /// Accept loop for RequestService handlers.
     ///
     /// This variant handles the full envelope processing pipeline:
     /// 1. ZMTP handshake
@@ -392,11 +392,11 @@ impl QuicRep {
     /// 3. Service handle_request dispatch
     /// 4. Signed response serialization
     ///
-    /// Uses `spawn_local` because `ZmqService` is `?Send`.
+    /// Uses `spawn_local` because `RequestService` is `?Send`.
     ///
     /// # Arguments
     ///
-    /// * `service` - ZmqService implementation (wrapped in Rc)
+    /// * `service` - RequestService implementation (wrapped in Rc)
     /// * `server_pubkey` - Server's Ed25519 verifying key
     /// * `signing_key` - Server's Ed25519 signing key
     /// * `nonce_cache` - Nonce cache for replay protection (wrapped in Arc)
@@ -410,7 +410,7 @@ impl QuicRep {
         shutdown: Arc<Notify>,
     ) -> Result<()>
     where
-        S: crate::service::ZmqService + 'static,
+        S: crate::service::RequestService + 'static,
     {
         loop {
             tokio::select! {
@@ -419,7 +419,7 @@ impl QuicRep {
                     let nonce_cache = Arc::clone(&nonce_cache);
                     let signing_key = signing_key.clone();  // Clone before spawn
 
-                    // Use spawn_local because ZmqService is ?Send
+                    // Use spawn_local because RequestService is ?Send
                     tokio::task::spawn_local(async move {
                         match incoming.await {
                             Ok(conn) => {
@@ -459,7 +459,7 @@ impl QuicRep {
         nonce_cache: Arc<crate::envelope::InMemoryNonceCache>,
     ) -> Result<()>
     where
-        S: crate::service::ZmqService + 'static,
+        S: crate::service::RequestService + 'static,
     {
         let remote = conn.remote_address();
         debug!(?remote, "QUIC connection established");
@@ -508,7 +508,7 @@ impl QuicRep {
         nonce_cache: Arc<crate::envelope::InMemoryNonceCache>,
     ) -> Result<()>
     where
-        S: crate::service::ZmqService + 'static,
+        S: crate::service::RequestService + 'static,
     {
         let mut stream = ZmtpStream::new(QuicStream { send, recv });
 
@@ -1229,14 +1229,14 @@ impl<S: AsyncWrite + Unpin, R: Unpin> AsyncWrite for WtStream<S, R> {
 // QuicServiceLoop - QUIC Transport Service Loop
 // ============================================================================
 
-/// Service loop for hosting ZmqService over QUIC transport.
+/// Service loop for hosting RequestService over QUIC transport.
 ///
-/// This struct wraps a `QuicRep` socket and a `ZmqService` implementation,
+/// This struct wraps a `QuicRep` socket and a `RequestService` implementation,
 /// running the QUIC accept loop in a dedicated thread with its own tokio runtime.
 ///
 /// # Threading Model
 ///
-/// `ZmqService` is `#[async_trait(?Send)]` - handlers are not `Send`. This requires:
+/// `RequestService` is `#[async_trait(?Send)]` - handlers are not `Send`. This requires:
 /// - Single-threaded runtime (`new_current_thread`)
 /// - `LocalSet` for non-Send futures
 /// - `spawn_local` instead of `tokio::spawn`
@@ -1260,7 +1260,7 @@ impl<S: AsyncWrite + Unpin, R: Unpin> AsyncWrite for WtStream<S, R> {
 /// ```
 pub struct QuicServiceLoop<S>
 where
-    S: crate::service::ZmqService + Send + Sync + 'static,
+    S: crate::service::RequestService + Send + Sync + 'static,
 {
     rep: QuicRep,
     service: S,
@@ -1276,7 +1276,7 @@ where
 
 impl<S> QuicServiceLoop<S>
 where
-    S: crate::service::ZmqService + Send + Sync + 'static,
+    S: crate::service::RequestService + Send + Sync + 'static,
 {
     /// Create a new QUIC service loop.
     pub fn new(rep: QuicRep, service: S, cert_der: Vec<u8>) -> Result<Self> {
@@ -1300,7 +1300,7 @@ where
 
 impl<S> crate::service::Spawnable for QuicServiceLoop<S>
 where
-    S: crate::service::ZmqService + Send + Sync + 'static,
+    S: crate::service::RequestService + Send + Sync + 'static,
 {
     fn name(&self) -> &str {
         &self.name
@@ -1358,7 +1358,7 @@ where
 /// WebTransport server for browser clients.
 ///
 /// Accepts WebTransport sessions (HTTP/3) from browsers and handles
-/// ZMTP requests using the same ZmqService handlers as native QUIC.
+/// ZMTP requests using the same RequestService handlers as native QUIC.
 ///
 /// # Browser Compatibility
 ///
@@ -1441,7 +1441,7 @@ impl WebTransportServer {
 
     /// Accept connections and dispatch HTTP/3 + WebTransport.
     ///
-    /// Uses `spawn_local` because `ZmqService` is `?Send`.
+    /// Uses `spawn_local` because `RequestService` is `?Send`.
     pub async fn accept_loop_service<S>(
         self,
         service: Rc<S>,
@@ -1451,7 +1451,7 @@ impl WebTransportServer {
         shutdown: Arc<Notify>,
     ) -> Result<()>
     where
-        S: crate::service::ZmqService + 'static,
+        S: crate::service::RequestService + 'static,
     {
         let metadata_json = self.protected_resource_json.map(Arc::new);
         let cert_hash_hex = Arc::new(cert_hash_hex(&self.cert_der));
@@ -1498,7 +1498,7 @@ impl WebTransportServer {
         cert_hash_hex: Arc<String>,
     ) -> Result<()>
     where
-        S: crate::service::ZmqService + 'static,
+        S: crate::service::RequestService + 'static,
     {
         let quinn_conn = incoming.await?;
         let h3_conn = h3_quinn::Connection::new(quinn_conn);
@@ -1599,7 +1599,7 @@ impl WebTransportServer {
         metadata_json: Option<Arc<Vec<u8>>>,
     ) -> Result<()>
     where
-        S: crate::service::ZmqService + 'static,
+        S: crate::service::RequestService + 'static,
     {
         debug!("WebTransport session established");
         loop {
@@ -1653,7 +1653,7 @@ impl WebTransportServer {
         nonce_cache: Arc<crate::envelope::InMemoryNonceCache>,
     ) -> Result<()>
     where
-        S: crate::service::ZmqService + 'static,
+        S: crate::service::RequestService + 'static,
     {
         use h3::quic::BidiStream as H3BidiStream;
         let (send, recv) = H3BidiStream::split(stream);
@@ -1984,7 +1984,7 @@ pub use crate::envelope::EnvelopeVerification;
 /// # Arguments
 ///
 /// * `raw_bytes` - Raw Cap'n Proto bytes containing a `SignedEnvelope`
-/// * `service` - The ZmqService to dispatch to
+/// * `service` - The RequestService to dispatch to
 /// * `verification` - Envelope signer verification mode
 /// * `signing_key` - Server's signing key for response
 /// * `nonce_cache` - Nonce cache for replay protection
@@ -2001,7 +2001,7 @@ pub async fn process_request<S>(
     nonce_cache: &crate::envelope::InMemoryNonceCache,
 ) -> Result<(Vec<u8>, Option<crate::service::Continuation>)>
 where
-    S: crate::service::ZmqService,
+    S: crate::service::RequestService,
 {
     use crate::ToCapnp;
     use crate::envelope::ResponseEnvelope;

--- a/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
+++ b/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
@@ -1863,7 +1863,7 @@ pub fn cert_hash(cert_der: &[u8]) -> String {
 }
 
 /// SHA-256 fingerprint of a certificate as raw bytes — the pin carried in
-/// `QuicServerAuth::Pinned` and matched by `connect_pinned_sha256`. A
+/// `QuicServerAuth::accept_cert_hashes` and matched by `connect_pinned_hashes`. A
 /// self-signed QUIC server registers `TransportConfig::quic_pinned(addr, name,
 /// cert_sha256(leaf_cert))` so clients can pin it.
 pub fn cert_sha256(cert_der: &[u8]) -> [u8; 32] {

--- a/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
+++ b/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
@@ -2010,12 +2010,19 @@ where
     use tracing::warn;
 
     // 1. Unwrap, verify, and optionally decrypt the SignedEnvelope.
-    let opts = match verification {
+    //    The verify policy + kid-anchored PQ trust store come from the
+    //    process-global verify configuration installed at startup (Hybrid
+    //    ENFORCED in the daemon). This closes the prior fail-open where the
+    //    site hardcoded Classical / no PQ store.
+    let pq_store_holder = crate::envelope::global_pq_store();
+    let base = match verification {
         EnvelopeVerification::FixedSigner(pubkey) =>
             crate::envelope::UnwrapOptions::fixed_signer(pubkey, nonce_cache),
         EnvelopeVerification::AnySigner =>
             crate::envelope::UnwrapOptions::any_signer(nonce_cache),
     }.with_decryption_key(signing_key);
+    let opts =
+        crate::envelope::apply_global_verify_config(base, &pq_store_holder);
 
     let (mut ctx, payload) = match crate::envelope::unwrap_envelope(raw_bytes, &opts) {
         Ok(result) => result,

--- a/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
+++ b/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
@@ -529,7 +529,7 @@ impl QuicRep {
         // just don't pin it to the server's own key. JWT claims + Casbin handle
         // authorization.
         // subsecond::call wraps dispatch for hot-patching during dev
-        let (response_bytes, continuation) = subsecond::call(|| process_request(
+        let (response_bytes, continuation) = subsecond::call(|| crate::service::dispatch::process_request(
             raw_bytes,
             &*service,
             EnvelopeVerification::AnySigner,
@@ -1673,7 +1673,7 @@ impl WebTransportServer {
                 ensure!(!request.parts.is_empty(), "Empty RPC request");
                 let raw_bytes = &request.parts[0];
 
-                match subsecond::call(|| process_request(
+                match subsecond::call(|| crate::service::dispatch::process_request(
                     raw_bytes,
                     &*service,
                     EnvelopeVerification::AnySigner,
@@ -1969,126 +1969,8 @@ pub fn client_tls_system_roots() -> Result<rustls::ClientConfig> {
 /// verification. The only difference is step 1 of 4 in the verification pipeline.
 pub use crate::envelope::EnvelopeVerification;
 
-/// Process a request through the full envelope verification pipeline.
-///
-/// Unified handler for both ZMQ (ROUTER) and WebTransport paths. The only
-/// difference is envelope signer verification, controlled by `verification`.
-///
-/// # Pipeline
-///
-/// 1. Unwrap `SignedEnvelope` and verify Ed25519 signature (mode-dependent)
-/// 2. Verify JWT claims (`sub`, `exp`, `aud`, `scope`, downgrade protection)
-/// 3. Dispatch to `service.handle_request()` with verified `EnvelopeContext`
-/// 4. Sign response with server's `signing_key`
-///
-/// # Arguments
-///
-/// * `raw_bytes` - Raw Cap'n Proto bytes containing a `SignedEnvelope`
-/// * `service` - The RequestService to dispatch to
-/// * `verification` - Envelope signer verification mode
-/// * `signing_key` - Server's signing key for response
-/// * `nonce_cache` - Nonce cache for replay protection
-///
-/// # Returns
-///
-/// * `Ok((response_bytes, continuation))` - Signed response and optional continuation
-/// * `Err(e)` - Processing error (already logged)
-pub async fn process_request<S>(
-    raw_bytes: &[u8],
-    service: &S,
-    verification: EnvelopeVerification<'_>,
-    signing_key: &ed25519_dalek::SigningKey,
-    nonce_cache: &crate::envelope::InMemoryNonceCache,
-) -> Result<(Vec<u8>, Option<crate::service::Continuation>)>
-where
-    S: crate::service::RequestService,
-{
-    use crate::ToCapnp;
-    use crate::envelope::ResponseEnvelope;
-    use capnp::message::Builder;
-    use capnp::serialize;
-    use tracing::warn;
-
-    // 1. Unwrap, verify, and optionally decrypt the SignedEnvelope.
-    //    The verify policy + kid-anchored PQ trust store come from the
-    //    process-global verify configuration installed at startup (Hybrid
-    //    ENFORCED in the daemon). This closes the prior fail-open where the
-    //    site hardcoded Classical / no PQ store.
-    let pq_store_holder = crate::envelope::global_pq_store();
-    let base = match verification {
-        EnvelopeVerification::FixedSigner(pubkey) =>
-            crate::envelope::UnwrapOptions::fixed_signer(pubkey, nonce_cache),
-        EnvelopeVerification::AnySigner =>
-            crate::envelope::UnwrapOptions::any_signer(nonce_cache),
-    }.with_decryption_key(signing_key);
-    let opts =
-        crate::envelope::apply_global_verify_config(base, &pq_store_holder);
-
-    let (mut ctx, payload) = match crate::envelope::unwrap_envelope(raw_bytes, &opts) {
-        Ok(result) => result,
-        Err(e) => {
-            warn!("{} envelope verification failed: {}", service.name(), e);
-            // Build error response with request_id=0 (envelope is invalid)
-            let error_payload = service.build_error_payload(0, &format!("envelope verification failed: {}", e));
-            let signed_response = ResponseEnvelope::new_signed(0, error_payload, signing_key);
-
-            let mut message = Builder::new_default();
-            let mut builder = message.init_root::<crate::common_capnp::response_envelope::Builder>();
-            signed_response.write_to(&mut builder);
-
-            let mut bytes = Vec::new();
-            serialize::write_message(&mut bytes, &message)?;
-            return Ok((bytes, None));
-        }
-    };
-
-    let request_id = ctx.request_id;
-    debug!(
-        "{} verified request from {} (id={})",
-        service.name(),
-        ctx.subject(),
-        request_id
-    );
-
-    // 2. Verify claims (E2E JWT, downgrade protection)
-    if let Err(e) = service.verify_claims(&mut ctx).await {
-        warn!(
-            "{} claims verification failed for {} (id={}): {}",
-            service.name(), ctx.subject(), request_id, e
-        );
-        let error_payload = service.build_error_payload(request_id, &e.to_string());
-        let signed_response = ResponseEnvelope::new_signed(request_id, error_payload, signing_key);
-
-        let mut message = Builder::new_default();
-        let mut builder = message.init_root::<crate::common_capnp::response_envelope::Builder>();
-        signed_response.write_to(&mut builder);
-
-        let mut bytes = Vec::new();
-        serialize::write_message(&mut bytes, &message)?;
-        return Ok((bytes, None));
-    }
-
-    // 3. Handle request
-    let (response_payload, continuation) = match service.handle_request(&ctx, &payload).await {
-        Ok((resp, cont)) => (resp, cont),
-        Err(e) => {
-            error!("{} request handling error: {}", service.name(), e);
-            (service.build_error_payload(request_id, &e.to_string()), None)
-        }
-    };
-
-    // 4. Sign and serialize response
-    let signed_response = ResponseEnvelope::new_signed(request_id, response_payload, signing_key);
-
-    let mut message = Builder::new_default();
-    let mut builder = message.init_root::<crate::common_capnp::response_envelope::Builder>();
-    signed_response.write_to(&mut builder);
-
-    let mut bytes = Vec::new();
-    serialize::write_message(&mut bytes, &message)?;
-
-    Ok((bytes, continuation))
-}
+// process_request moved to crate::service::dispatch (#148) — transport-neutral
+// dispatch core, shared by RequestLoop / WebTransport / LocalServiceBridge.
 
 // ============================================================================
 // Tests

--- a/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
+++ b/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
@@ -1264,8 +1264,9 @@ where
 {
     rep: QuicRep,
     service: S,
-    /// Server certificate DER bytes (for registration)
-    _cert_der: Vec<u8>,
+    /// Server leaf certificate DER bytes — used to pin the registered QUIC
+    /// endpoint (self-signed, so clients pin the SHA-256 rather than CA-validate).
+    cert_der: Vec<u8>,
     /// ZMQ context (for Spawnable trait)
     context: Arc<zmq::Context>,
     /// Service name
@@ -1285,7 +1286,7 @@ where
         Ok(Self {
             rep,
             service,
-            _cert_der: cert_der,
+            cert_der,
             context: Arc::new(zmq::Context::new()),
             name,
             addr,
@@ -1311,10 +1312,13 @@ where
     }
 
     fn registrations(&self) -> Vec<(crate::registry::SocketKind, crate::transport::TransportConfig)> {
-        // Register QUIC endpoint
+        // Register the QUIC endpoint *pinned* by the self-signed leaf cert's
+        // SHA-256 — a plain (WebPki) registration would make clients CA-validate
+        // a self-signed cert and fail.
+        let pin = cert_sha256(&self.cert_der);
         vec![(
             crate::registry::SocketKind::Rep,
-            crate::transport::TransportConfig::quic(self.addr, "hyprstream.local"),
+            crate::transport::TransportConfig::quic_pinned(self.addr, "hyprstream.local", pin),
         )]
     }
 
@@ -1856,6 +1860,17 @@ pub fn cert_hash(cert_der: &[u8]) -> String {
     use sha2::{Sha256, Digest};
     let hash = Sha256::digest(cert_der);
     base64::engine::general_purpose::STANDARD.encode(hash)
+}
+
+/// SHA-256 fingerprint of a certificate as raw bytes — the pin carried in
+/// `QuicServerAuth::Pinned` and matched by `connect_pinned_sha256`. A
+/// self-signed QUIC server registers `TransportConfig::quic_pinned(addr, name,
+/// cert_sha256(leaf_cert))` so clients can pin it.
+pub fn cert_sha256(cert_der: &[u8]) -> [u8; 32] {
+    use sha2::{Digest, Sha256};
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&Sha256::digest(cert_der));
+    out
 }
 
 /// Compute SHA-256 hash of certificate as hex string.

--- a/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
+++ b/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
@@ -529,7 +529,7 @@ impl QuicRep {
         // just don't pin it to the server's own key. JWT claims + Casbin handle
         // authorization.
         // subsecond::call wraps dispatch for hot-patching during dev
-        let (response_bytes, continuation) = subsecond::call(|| crate::service::dispatch::process_request(
+        let response_bytes = subsecond::call(|| crate::service::dispatch::process_request(
             raw_bytes,
             &*service,
             EnvelopeVerification::AnySigner,
@@ -543,14 +543,9 @@ impl QuicRep {
         };
         stream.send_multipart(&response.parts).await?;
 
-        // Signal end of response
+        // Signal end of response. Any streaming pump was already spawned inside
+        // process_request (#186).
         stream.stream.send.finish()?;
-
-        // Handle continuation if present (for streaming)
-        if let Some(cont) = continuation {
-            // Spawn continuation on LocalSet (streaming handler is ?Send)
-            tokio::task::spawn_local(cont);
-        }
 
         Ok(())
     }
@@ -1684,14 +1679,12 @@ impl WebTransportServer {
                     &signing_key,
                     &nonce_cache,
                 )).await {
-                    Ok((response_bytes, continuation)) => {
+                    Ok(response_bytes) => {
                         zmtp.send_multipart(&[Bytes::from(response_bytes)]).await?;
                         zmtp.stream.send.shutdown().await
                             .map_err(std::io::Error::other)?;
-
-                        if let Some(cont) = continuation {
-                            tokio::task::spawn_local(cont);
-                        }
+                        // Any streaming pump was already spawned inside
+                        // process_request (#186).
                     }
                     Err(e) => {
                         warn!("WebTransport RPC error: {}", e);

--- a/crates/hyprstream-rpc/src/wasm_api.rs
+++ b/crates/hyprstream-rpc/src/wasm_api.rs
@@ -271,7 +271,12 @@ pub fn verify_signed_envelope(
         .map_err(|e| JsError::new(&format!("invalid verifying key: {}", e)))?;
 
     let nonce_cache = WASM_NONCE_CACHE.with(|c| c.clone());
-    let opts = UnwrapOptions::fixed_signer(&verifying_key, &*nonce_cache);
+    // WASM/browser verify currently uses the classical (EdDSA) verifier: the
+    // in-browser side has no kid-anchored ML-DSA trust store wired yet. A
+    // Hybrid-signed envelope still verifies here via its inner EdDSA layer
+    // (skip-unknown). Provisioning a WASM-side PqTrustStore to enforce the SNS
+    // outer layer in the browser is residual integration work.
+    let opts = UnwrapOptions::fixed_signer(&verifying_key, &*nonce_cache).classical();
 
     let (_signed, payload) = unwrap_and_verify(envelope_bytes, &opts)
         .map_err(|e| JsError::new(&format!("envelope verification failed: {}", e)))?;

--- a/crates/hyprstream-rpc/tests/envelope_canonicalization.rs
+++ b/crates/hyprstream-rpc/tests/envelope_canonicalization.rs
@@ -3,12 +3,9 @@ use ed25519_dalek::SigningKey;
 use rand::rngs::OsRng;
 
 fn make_signed(envelope: RequestEnvelope, signing_key: &SigningKey) -> SignedEnvelope {
-    #[cfg(feature = "pq-hybrid")]
-    {
-        let (pq_sk, _) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();
-        SignedEnvelope::new_signed_hybrid(envelope, signing_key, &pq_sk)
-    }
-    #[cfg(not(feature = "pq-hybrid"))]
+    // Classical so the raw Ed25519 `sig` field is deterministic (ML-DSA-65
+    // signatures are randomized/hedged). Composite behavior is tested in the
+    // envelope `cose::`/`crypto::` suites.
     SignedEnvelope::new_signed(envelope, signing_key)
 }
 
@@ -90,8 +87,8 @@ fn test_envelope_signature_verification_stable() {
         cnf: signed1.cnf,
         encrypted_envelope: None,
         client_ephemeral_public: None,
-        pq_sig: signed1.pq_sig.clone(),
-        pq_cnf: signed1.pq_cnf.clone(),
+        cose: signed1.cose.clone(),
+        policy: signed1.policy,
         pq_kem_ciphertext: None,
     };
 

--- a/crates/hyprstream-rpc/tests/inproc_bridged_e2e.rs
+++ b/crates/hyprstream-rpc/tests/inproc_bridged_e2e.rs
@@ -1,0 +1,128 @@
+//! End-to-end test for the default (inproc) flipped serve path — the #136 cut's
+//! most-used path, previously untested (the UDS canary covers ipc only).
+//!
+//! Wires a `RequestService` through the exact bridged inproc path the daemon uses:
+//! `LocalServiceBridge` → `register_inproc` (in-memory dial registry) → `dial()`
+//! (InMemoryTransport) → `RpcClientImpl`. A real SignedEnvelope round-trips, and —
+//! crucially — the service returns a streaming **continuation** that must be
+//! spawned by the bridge (the #186 StreamInfo pump). This guards against the
+//! regression where the bridge dropped/rejected continuations, silently breaking
+//! streaming services (model / tui).
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use rand::RngCore;
+use tokio::sync::Mutex;
+
+use hyprstream_rpc::dial::{dial, register_inproc};
+use hyprstream_rpc::envelope::InMemoryNonceCache;
+use hyprstream_rpc::service::{Continuation, EnvelopeContext, RequestService};
+use hyprstream_rpc::signer::LocalSigner;
+use hyprstream_rpc::transport::iroh_rpc::LocalServiceBridge;
+use hyprstream_rpc::transport::rpc_session::IrohRequestProcessor;
+use hyprstream_rpc::transport::TransportConfig;
+
+/// Echoes the payload AND returns a continuation that fires a oneshot — so the
+/// test can assert the bridge actually spawned the streaming pump.
+struct StreamingEcho {
+    name: String,
+    ctx: Arc<zmq::Context>,
+    transport: TransportConfig,
+    signing_key: SigningKey,
+    fired: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+}
+
+#[async_trait(?Send)]
+impl RequestService for StreamingEcho {
+    async fn handle_request(
+        &self,
+        _ctx: &EnvelopeContext,
+        payload: &[u8],
+    ) -> Result<(Vec<u8>, Option<Continuation>)> {
+        let tx = self.fired.lock().await.take();
+        let cont: Continuation = Box::pin(async move {
+            if let Some(tx) = tx {
+                let _ = tx.send(());
+            }
+        });
+        Ok((payload.to_vec(), Some(cont)))
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn context(&self) -> &Arc<zmq::Context> {
+        &self.ctx
+    }
+    fn transport(&self) -> &TransportConfig {
+        &self.transport
+    }
+    fn signing_key(&self) -> SigningKey {
+        self.signing_key.clone()
+    }
+}
+
+fn fresh_key() -> SigningKey {
+    let mut b = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut b);
+    SigningKey::from_bytes(&b)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn inproc_bridged_round_trip_and_continuation_spawned() -> Result<()> {
+    // Integration test → hyprstream-rpc in non-test mode → verify policy
+    // fail-closes to Hybrid (#160); opt into the Classical policy this exercises.
+    let _ = hyprstream_rpc::envelope::install_verify_config(
+        hyprstream_rpc::envelope::EnvelopeVerifyConfig {
+            policy: hyprstream_rpc::crypto::CryptoPolicy::Classical,
+            pq_store: None,
+        },
+    );
+
+    const NAME: &str = "test/inproc-stream-echo";
+
+    let server_key = fresh_key();
+    let server_vk: VerifyingKey = server_key.verifying_key();
+    let (fired_tx, fired_rx) = tokio::sync::oneshot::channel();
+
+    let svc = StreamingEcho {
+        name: NAME.to_owned(),
+        ctx: Arc::new(zmq::Context::new()),
+        transport: TransportConfig::inproc(NAME),
+        signing_key: server_key,
+        fired: Mutex::new(Some(fired_tx)),
+    };
+
+    // Server side: bridge + register in the in-memory dial registry. Keep the
+    // strong processor Arc alive for the duration (registry holds only a Weak).
+    let nonce = Arc::new(InMemoryNonceCache::new());
+    let bridge = LocalServiceBridge::spawn(svc, nonce, 0)?;
+    let processor: Arc<dyn IrohRequestProcessor> = Arc::new(bridge);
+    register_inproc(NAME, &processor);
+
+    // Client side: dial inproc → InMemoryTransport → real SignedEnvelope.
+    let client = dial(
+        &TransportConfig::inproc(NAME),
+        LocalSigner::new(fresh_key()),
+        Some(server_vk),
+        None,
+    )?;
+    let resp = client.call(b"hello-inproc".to_vec()).await?;
+    assert_eq!(&resp[..], b"hello-inproc");
+
+    // The streaming continuation must have been spawned by the bridge and run.
+    tokio::time::timeout(std::time::Duration::from_secs(3), fired_rx)
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "continuation did not run — regression: the bridge dropped/rejected \
+                 the streaming continuation, which silently breaks streaming services"
+            )
+        })??;
+
+    drop(processor);
+    Ok(())
+}

--- a/crates/hyprstream-rpc/tests/iroh_rpc_e2e.rs
+++ b/crates/hyprstream-rpc/tests/iroh_rpc_e2e.rs
@@ -1,0 +1,160 @@
+//! End-to-end Phase 2 canary: real SignedEnvelope round-trip over iroh.
+//!
+//! Wires a minimal [`ZmqService`] through:
+//! 1. [`LocalServiceBridge`] (dedicated LocalSet thread)
+//! 2. [`IrohRpcProtocolHandler`] on ALPN `hyprstream-rpc/1`
+//! 3. iroh `Connection` (direct dial, no DNS/pkarr)
+//! 4. [`IrohTransport`] (client wire)
+//! 5. [`RpcClientImpl`] (envelope sign + JWT + response unwrap)
+//!
+//! Verifies the canary exit criterion's wire-and-envelope half: a real
+//! `SignedEnvelope` issued by `RpcClientImpl::call` traverses iroh and
+//! arrives at the service's `handle_request` with verified identity, and
+//! the signed response verifies back at the client.
+//!
+//! Full PolicyClient integration (running the whole `services/policy/tests/`
+//! suite over iroh) requires `services/factories.rs` wiring — tracked as
+//! Phase 2 part 3 of #133.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use ed25519_dalek::{SigningKey, VerifyingKey};
+
+use hyprstream_rpc::envelope::InMemoryNonceCache;
+use hyprstream_rpc::rpc_client::RpcClientImpl;
+use hyprstream_rpc::service::{Continuation, EnvelopeContext, ZmqService};
+use hyprstream_rpc::signer::LocalSigner;
+use hyprstream_rpc::transport::iroh_rpc::{IrohRpcProtocolHandler, LocalServiceBridge};
+use hyprstream_rpc::transport::iroh_substrate::{
+    ALPN_HYPRSTREAM_RPC, IrohSubstrate, NoopHandler,
+};
+use hyprstream_rpc::transport::iroh_transport::IrohTransport;
+use hyprstream_rpc::transport::TransportConfig;
+use iroh::{EndpointAddr, TransportAddr};
+use rand::RngCore;
+
+/// Minimal `ZmqService` for the canary: echoes the request payload with a
+/// 1-byte prefix so the test can verify identity round-trip.
+struct EchoService {
+    name: String,
+    ctx: Arc<zmq::Context>,
+    transport: TransportConfig,
+    signing_key: SigningKey,
+}
+
+impl EchoService {
+    fn new(signing_key: SigningKey) -> Self {
+        Self {
+            name: "iroh-echo".to_owned(),
+            ctx: Arc::new(zmq::Context::new()),
+            transport: TransportConfig::inproc("iroh-echo-unused"),
+            signing_key,
+        }
+    }
+}
+
+#[async_trait(?Send)]
+impl ZmqService for EchoService {
+    async fn handle_request(
+        &self,
+        _ctx: &EnvelopeContext,
+        payload: &[u8],
+    ) -> Result<(Vec<u8>, Option<Continuation>)> {
+        let mut out = Vec::with_capacity(1 + payload.len());
+        out.push(0xEC);
+        out.extend_from_slice(payload);
+        Ok((out, None))
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn context(&self) -> &Arc<zmq::Context> {
+        &self.ctx
+    }
+
+    fn transport(&self) -> &TransportConfig {
+        &self.transport
+    }
+
+    fn signing_key(&self) -> SigningKey {
+        self.signing_key.clone()
+    }
+}
+
+fn fresh_signing_key() -> SigningKey {
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    SigningKey::from_bytes(&bytes)
+}
+
+fn fresh_node_key() -> [u8; 32] {
+    let mut k = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut k);
+    k
+}
+
+fn direct_addr(substrate: &IrohSubstrate) -> EndpointAddr {
+    EndpointAddr::from_parts(
+        substrate.endpoint_id(),
+        substrate
+            .endpoint()
+            .bound_sockets()
+            .into_iter()
+            .map(TransportAddr::Ip),
+    )
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn signed_envelope_round_trip_over_iroh() -> Result<()> {
+    // ─── Server side ──────────────────────────────────────────────────────
+    let server_signing = fresh_signing_key();
+    let server_verifying: VerifyingKey = server_signing.verifying_key();
+    let server_nonce_cache = Arc::new(InMemoryNonceCache::new());
+
+    let bridge = LocalServiceBridge::spawn(
+        EchoService::new(server_signing.clone()),
+        server_nonce_cache,
+        0,
+    )?;
+
+    let server = IrohSubstrate::new(
+        fresh_node_key(),
+        NoopHandler::new("moq-not-wired"),
+        IrohRpcProtocolHandler::new(bridge, server_signing.clone()),
+    )
+    .await?;
+    let server_addr = direct_addr(&server);
+
+    // ─── Client side ──────────────────────────────────────────────────────
+    let client_signing = fresh_signing_key();
+    let client = IrohSubstrate::new(
+        fresh_node_key(),
+        NoopHandler::new("client-moq"),
+        NoopHandler::new("client-rpc"),
+    )
+    .await?;
+
+    let conn = client.connect(server_addr, ALPN_HYPRSTREAM_RPC).await?;
+    let transport = IrohTransport::new(conn);
+    let rpc = RpcClientImpl::new(
+        LocalSigner::new(client_signing.clone()),
+        transport,
+        Some(server_verifying),
+    );
+
+    // Real signed envelope round-trip.
+    let response = rpc.call(b"ping-payload".to_vec()).await?;
+    assert_eq!(&response[..], b"\xECping-payload");
+
+    // Second call on the same connection to exercise multiple bidi streams.
+    let response2 = rpc.call(b"second".to_vec()).await?;
+    assert_eq!(&response2[..], b"\xECsecond");
+
+    client.shutdown().await?;
+    server.shutdown().await?;
+    Ok(())
+}

--- a/crates/hyprstream-rpc/tests/iroh_rpc_e2e.rs
+++ b/crates/hyprstream-rpc/tests/iroh_rpc_e2e.rs
@@ -110,6 +110,19 @@ fn direct_addr(substrate: &IrohSubstrate) -> EndpointAddr {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn signed_envelope_round_trip_over_iroh() -> Result<()> {
+    // This canary exercises the classical (EdDSA-only) wire+envelope path. As
+    // an integration test it compiles hyprstream-rpc in non-test mode, where
+    // the uninstalled global verify policy now fail-closes to Hybrid (#160).
+    // Opt in to the Classical policy this test actually validates. `set` is
+    // idempotent-by-first-write; ignore the error if another test in this
+    // binary already installed a (matching) config.
+    let _ = hyprstream_rpc::envelope::install_verify_config(
+        hyprstream_rpc::envelope::EnvelopeVerifyConfig {
+            policy: hyprstream_rpc::crypto::CryptoPolicy::Classical,
+            pq_store: None,
+        },
+    );
+
     // ─── Server side ──────────────────────────────────────────────────────
     let server_signing = fresh_signing_key();
     let server_verifying: VerifyingKey = server_signing.verifying_key();

--- a/crates/hyprstream-rpc/tests/iroh_rpc_e2e.rs
+++ b/crates/hyprstream-rpc/tests/iroh_rpc_e2e.rs
@@ -1,6 +1,6 @@
 //! End-to-end Phase 2 canary: real SignedEnvelope round-trip over iroh.
 //!
-//! Wires a minimal [`ZmqService`] through:
+//! Wires a minimal [`RequestService`] through:
 //! 1. [`LocalServiceBridge`] (dedicated LocalSet thread)
 //! 2. [`IrohRpcProtocolHandler`] on ALPN `hyprstream-rpc/1`
 //! 3. iroh `Connection` (direct dial, no DNS/pkarr)
@@ -24,7 +24,7 @@ use ed25519_dalek::{SigningKey, VerifyingKey};
 
 use hyprstream_rpc::envelope::InMemoryNonceCache;
 use hyprstream_rpc::rpc_client::RpcClientImpl;
-use hyprstream_rpc::service::{Continuation, EnvelopeContext, ZmqService};
+use hyprstream_rpc::service::{Continuation, EnvelopeContext, RequestService};
 use hyprstream_rpc::signer::LocalSigner;
 use hyprstream_rpc::transport::iroh_rpc::{IrohRpcProtocolHandler, LocalServiceBridge};
 use hyprstream_rpc::transport::iroh_substrate::{
@@ -35,7 +35,7 @@ use hyprstream_rpc::transport::TransportConfig;
 use iroh::{EndpointAddr, TransportAddr};
 use rand::RngCore;
 
-/// Minimal `ZmqService` for the canary: echoes the request payload with a
+/// Minimal `RequestService` for the canary: echoes the request payload with a
 /// 1-byte prefix so the test can verify identity round-trip.
 struct EchoService {
     name: String,
@@ -56,7 +56,7 @@ impl EchoService {
 }
 
 #[async_trait(?Send)]
-impl ZmqService for EchoService {
+impl RequestService for EchoService {
     async fn handle_request(
         &self,
         _ctx: &EnvelopeContext,

--- a/crates/hyprstream-rpc/tests/uds_rpc_e2e.rs
+++ b/crates/hyprstream-rpc/tests/uds_rpc_e2e.rs
@@ -1,0 +1,144 @@
+//! End-to-end canary: real SignedEnvelope round-trip over the same-host UDS plane.
+//!
+//! Mirrors `iroh_rpc_e2e.rs` but over a Unix-domain socket, exercising the exact
+//! bridged serve path the daemon will use for the post-ZMQ `ipc` transport:
+//! 1. [`LocalServiceBridge`] — a (possibly `!Send`) [`RequestService`] on its own
+//!    LocalSet thread, exposed as a `Send` processor.
+//! 2. [`UdsRpcServer`] — UnixListener accept loop → `serve_rpc_connection` over a
+//!    `UdsSession` (PLANE_RPC), feeding the same `process_request` dispatch core.
+//! 3. [`LazyUdsTransport`] — client wire (connect-on-first-send, yamux-muxed).
+//! 4. [`RpcClientImpl`] — envelope sign + response verify.
+//!
+//! Verifies that a real `SignedEnvelope` issued by `RpcClientImpl::call` traverses
+//! the UDS plane, arrives at the service's `handle_request` with verified
+//! identity, and the signed response verifies back at the client — the same
+//! exit criterion the iroh canary proves, on the ipc transport.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use rand::RngCore;
+
+use hyprstream_rpc::envelope::InMemoryNonceCache;
+use hyprstream_rpc::rpc_client::RpcClientImpl;
+use hyprstream_rpc::service::{Continuation, EnvelopeContext, RequestService};
+use hyprstream_rpc::signer::LocalSigner;
+use hyprstream_rpc::transport::iroh_rpc::LocalServiceBridge;
+use hyprstream_rpc::transport::lazy_uds::LazyUdsTransport;
+use hyprstream_rpc::transport::uds_server::UdsRpcServer;
+use hyprstream_rpc::transport::TransportConfig;
+use tokio::net::UnixListener;
+
+/// Minimal `RequestService` for the canary: echoes the request payload with a
+/// 1-byte prefix so the test can verify the identity round-trip.
+struct EchoService {
+    name: String,
+    ctx: Arc<zmq::Context>,
+    transport: TransportConfig,
+    signing_key: SigningKey,
+}
+
+impl EchoService {
+    fn new(signing_key: SigningKey) -> Self {
+        Self {
+            name: "uds-echo".to_owned(),
+            ctx: Arc::new(zmq::Context::new()),
+            transport: TransportConfig::inproc("uds-echo-unused"),
+            signing_key,
+        }
+    }
+}
+
+#[async_trait(?Send)]
+impl RequestService for EchoService {
+    async fn handle_request(
+        &self,
+        _ctx: &EnvelopeContext,
+        payload: &[u8],
+    ) -> Result<(Vec<u8>, Option<Continuation>)> {
+        let mut out = Vec::with_capacity(1 + payload.len());
+        out.push(0xEC);
+        out.extend_from_slice(payload);
+        Ok((out, None))
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn context(&self) -> &Arc<zmq::Context> {
+        &self.ctx
+    }
+
+    fn transport(&self) -> &TransportConfig {
+        &self.transport
+    }
+
+    fn signing_key(&self) -> SigningKey {
+        self.signing_key.clone()
+    }
+}
+
+fn fresh_signing_key() -> SigningKey {
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    SigningKey::from_bytes(&bytes)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn signed_envelope_round_trip_over_uds() -> Result<()> {
+    // As an integration test this compiles hyprstream-rpc in non-test mode, where
+    // the uninstalled global verify policy fail-closes to Hybrid (#160). Opt in to
+    // the Classical policy this canary validates. `set`-by-first-write: ignore the
+    // error if another test in this binary already installed a matching config.
+    let _ = hyprstream_rpc::envelope::install_verify_config(
+        hyprstream_rpc::envelope::EnvelopeVerifyConfig {
+            policy: hyprstream_rpc::crypto::CryptoPolicy::Classical,
+            pq_store: None,
+        },
+    );
+
+    // ─── Server side: bridge the service, serve it over a UnixListener ────────
+    let server_signing = fresh_signing_key();
+    let server_verifying: VerifyingKey = server_signing.verifying_key();
+    let server_nonce_cache = Arc::new(InMemoryNonceCache::new());
+
+    let bridge = LocalServiceBridge::spawn(
+        EchoService::new(server_signing.clone()),
+        server_nonce_cache,
+        0,
+    )?;
+
+    let dir = std::env::temp_dir().join(format!("uds-e2e-{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&dir);
+    let path = dir.join("rpc.sock");
+    let _ = std::fs::remove_file(&path);
+    let listener = UnixListener::bind(&path)?;
+
+    let server = UdsRpcServer::new(listener, bridge, server_signing.clone());
+    let token = server.shutdown_token();
+    let srv = tokio::spawn(server.run());
+
+    // ─── Client side: real signed envelope over LazyUdsTransport ─────────────
+    let client_signing = fresh_signing_key();
+    let rpc = RpcClientImpl::new(
+        LocalSigner::new(client_signing.clone()),
+        LazyUdsTransport::new(path.clone()),
+        Some(server_verifying),
+    );
+
+    let response = rpc.call(b"ping-payload".to_vec()).await?;
+    assert_eq!(&response[..], b"\xECping-payload");
+
+    // Second call reuses the cached session over a fresh multiplexed bidi stream.
+    let response2 = rpc.call(b"second".to_vec()).await?;
+    assert_eq!(&response2[..], b"\xECsecond");
+
+    token.cancel();
+    let _ = srv.await;
+    let _ = std::fs::remove_file(&path);
+    let _ = std::fs::remove_dir(&dir);
+    Ok(())
+}

--- a/crates/hyprstream-service/Cargo.toml
+++ b/crates/hyprstream-service/Cargo.toml
@@ -67,7 +67,7 @@ zbus_systemd = { version = "0.0.11", features = ["login1", "systemd1"], optional
 [features]
 default = []
 systemd = ["dep:systemd", "dep:zbus_systemd"]
-pq-hybrid = ["hyprstream-rpc/pq-hybrid"]
+pq-hybrid = []  # NO-OP alias (PQ always compiled; runtime CryptoPolicy). See M3 #152.
 
 [lints]
 workspace = true

--- a/crates/hyprstream-service/src/lib.rs
+++ b/crates/hyprstream-service/src/lib.rs
@@ -9,7 +9,7 @@
 //! # Architecture
 //!
 //! ```text
-//! hyprstream-rpc       (transport: ZmqService, RequestLoop, Resolver)
+//! hyprstream-rpc       (transport: RequestService, RequestLoop, Resolver)
 //!     ↑
 //! hyprstream-service   (orchestration: spawner, factory, manager)
 //!     ↑

--- a/crates/hyprstream-service/src/service/factory.rs
+++ b/crates/hyprstream-service/src/service/factory.rs
@@ -635,7 +635,7 @@ impl ServiceContext {
         std::sync::Arc::new(rpc)
     }
 
-    /// Wrap a ZmqService for spawning with a per-service QUIC port.
+    /// Wrap a RequestService for spawning with a per-service QUIC port.
     ///
     /// - `quic_port: None` → use ephemeral port (0) when QUIC is globally enabled
     /// - `quic_port: Some(0)` → ephemeral (OS-assigned) port
@@ -644,7 +644,7 @@ impl ServiceContext {
     /// When `[quic] enabled = true` in config, all services get QUIC on
     /// auto-assigned ephemeral ports by default. Set an explicit port to
     /// control which port a service uses.
-    pub fn into_spawnable_quic<S: hyprstream_rpc::service::ZmqService + Send + Sync + 'static>(
+    pub fn into_spawnable_quic<S: hyprstream_rpc::service::RequestService + Send + Sync + 'static>(
         &self,
         service: S,
         quic_port: Option<u16>,
@@ -687,10 +687,10 @@ impl ServiceContext {
         }
     }
 
-    /// Wrap a ZmqService for spawning, enabling QUIC when globally configured.
+    /// Wrap a RequestService for spawning, enabling QUIC when globally configured.
     ///
     /// Uses ephemeral port (0) for QUIC when `[quic] enabled = true`.
-    pub fn into_spawnable<S: hyprstream_rpc::service::ZmqService + Send + Sync + 'static>(
+    pub fn into_spawnable<S: hyprstream_rpc::service::RequestService + Send + Sync + 'static>(
         &self,
         service: S,
     ) -> Box<dyn Spawnable> {

--- a/crates/hyprstream-service/src/service/factory.rs
+++ b/crates/hyprstream-service/src/service/factory.rs
@@ -234,7 +234,10 @@ pub struct ServiceContext {
 
     /// Shared ML-DSA-65 verifying keys for PQ-hybrid JWT verification.
     /// Updated by the rotation task; shared across all key sources.
-    #[cfg(feature = "pq-hybrid")]
+    ///
+    /// Uses `std::sync::RwLock` to match the cross-crate `Arc<RwLock<..>>`
+    /// contract with `hyprstream::auth::key_rotation` and `JwtKeySource`.
+    #[allow(clippy::disallowed_types)]
     ml_dsa_verifying_keys: std::sync::Arc<std::sync::RwLock<Vec<hyprstream_rpc::crypto::pq::MlDsaVerifyingKey>>>,
 }
 
@@ -263,19 +266,21 @@ impl ServiceContext {
             service_keys: HashMap::new(),
             ca_verifying_key: None,
             jwks_fetcher: None,
-            #[cfg(feature = "pq-hybrid")]
-            ml_dsa_verifying_keys: std::sync::Arc::new(std::sync::RwLock::new(Vec::new())),
+            ml_dsa_verifying_keys: {
+                #[allow(clippy::disallowed_types)]
+                std::sync::Arc::new(std::sync::RwLock::new(Vec::new()))
+            },
         }
     }
 
     /// Set the shared ML-DSA-65 verifying keys for PQ-hybrid JWT verification.
-    #[cfg(feature = "pq-hybrid")]
+    #[allow(clippy::disallowed_types)]
     pub fn set_ml_dsa_verifying_keys(&mut self, keys: std::sync::Arc<std::sync::RwLock<Vec<hyprstream_rpc::crypto::pq::MlDsaVerifyingKey>>>) {
         self.ml_dsa_verifying_keys = keys;
     }
 
     /// Get a clone of the shared ML-DSA verifying keys Arc.
-    #[cfg(feature = "pq-hybrid")]
+    #[allow(clippy::disallowed_types)]
     pub fn ml_dsa_verifying_keys_arc(&self) -> std::sync::Arc<std::sync::RwLock<Vec<hyprstream_rpc::crypto::pq::MlDsaVerifyingKey>>> {
         self.ml_dsa_verifying_keys.clone()
     }
@@ -556,7 +561,6 @@ impl ServiceContext {
                 issuer_url,
                 fetcher.clone(),
             );
-            #[cfg(feature = "pq-hybrid")]
             let source = source.with_ml_dsa_verifying_keys(self.ml_dsa_verifying_keys.clone());
             std::sync::Arc::new(source)
         } else {
@@ -564,7 +568,6 @@ impl ServiceContext {
                 self.jwt_verifying_key(),
                 issuer_url,
             );
-            #[cfg(feature = "pq-hybrid")]
             let source = source.with_ml_dsa_verifying_keys(self.ml_dsa_verifying_keys.clone());
             std::sync::Arc::new(source)
         }

--- a/crates/hyprstream-service/src/service/factory.rs
+++ b/crates/hyprstream-service/src/service/factory.rs
@@ -159,11 +159,17 @@ impl QuicSharedConfig {
                         let _ = policy_vk; // suppress unused warning
                     }
 
-                    let client = hyprstream_discovery::DiscoveryClient::for_service(
+                    let client = match hyprstream_discovery::DiscoveryClient::for_service(
                         sk,
                         discovery_vk,
                         None,
-                    );
+                    ) {
+                        Ok(c) => c,
+                        Err(e) => {
+                            tracing::warn!("Failed to build DiscoveryClient: {}", e);
+                            return;
+                        }
+                    };
                     match client.announce(&hyprstream_discovery::ServiceAnnouncement {
                         service_name: svc_name,
                         socket_kind: "quic".to_owned(),

--- a/crates/hyprstream-service/src/service/spawner/mod.rs
+++ b/crates/hyprstream-service/src/service/spawner/mod.rs
@@ -14,7 +14,7 @@
 //!     └── SystemdBackend (systemd-run)
 //!         └── Transient units in hyprstream-workers.slice
 //!
-//! ServiceSpawner (ZmqService hosting)
+//! ServiceSpawner (RequestService hosting)
 //!     ├── Tokio mode (tokio::spawn)
 //!     ├── Thread mode (std::thread + runtime)
 //!     └── Subprocess mode (ProcessSpawner)

--- a/crates/hyprstream-service/src/service/spawner/service.rs
+++ b/crates/hyprstream-service/src/service/spawner/service.rs
@@ -1,6 +1,6 @@
-//! Unified service spawner for ZmqService hosting.
+//! Unified service spawner for RequestService hosting.
 //!
-//! Provides a single API for spawning ZmqService implementations with different
+//! Provides a single API for spawning RequestService implementations with different
 //! execution modes (Tokio task, dedicated thread, or subprocess).
 
 use std::path::PathBuf;
@@ -12,7 +12,7 @@ use tokio::sync::Notify;
 use super::{ProcessConfig, ProcessSpawner, SpawnedProcess};
 use hyprstream_rpc::error::Result;
 use hyprstream_rpc::registry::{ServiceRegistration, SocketKind};
-use hyprstream_rpc::service::ZmqService;
+use hyprstream_rpc::service::RequestService;
 use hyprstream_rpc::transport::TransportConfig;
 
 // Import anyhow! macro for error creation in ServiceManager impl
@@ -322,36 +322,36 @@ impl Spawnable for LoadBalancerService {
 // QuicServiceLoop — Spawnable wrapper for QUIC-only service loop
 // ============================================================================
 
-/// Spawnable wrapper that runs a ZmqService with explicit QUIC configuration.
+/// Spawnable wrapper that runs a RequestService with explicit QUIC configuration.
 ///
 /// This is used when a service factory wants to pass a `QuicLoopConfig` to
 /// `RequestLoop::with_quic()` without relying on the blanket `Spawnable` impl.
 ///
-/// The blanket `impl Spawnable for S: ZmqService` creates a plain `RequestLoop`;
+/// The blanket `impl Spawnable for S: RequestService` creates a plain `RequestLoop`;
 /// this wrapper additionally enables QUIC when `quic_config` is `Some`.
-pub struct UnifiedServiceConfig<S: ZmqService + Send + 'static> {
+pub struct UnifiedServiceConfig<S: RequestService + Send + 'static> {
     service: S,
     quic_config: Option<hyprstream_rpc::service::QuicLoopConfig>,
 }
 
-impl<S: ZmqService + Send + 'static> UnifiedServiceConfig<S> {
+impl<S: RequestService + Send + 'static> UnifiedServiceConfig<S> {
     /// Create a unified service config with optional QUIC.
     pub fn new(service: S, quic_config: Option<hyprstream_rpc::service::QuicLoopConfig>) -> Self {
         Self { service, quic_config }
     }
 }
 
-impl<S: ZmqService + Send + Sync + 'static> Spawnable for UnifiedServiceConfig<S> {
+impl<S: RequestService + Send + Sync + 'static> Spawnable for UnifiedServiceConfig<S> {
     fn name(&self) -> &str {
-        ZmqService::name(&self.service)
+        RequestService::name(&self.service)
     }
 
     fn context(&self) -> &Arc<zmq::Context> {
-        ZmqService::context(&self.service)
+        RequestService::context(&self.service)
     }
 
     fn registrations(&self) -> Vec<(SocketKind, TransportConfig)> {
-        vec![(SocketKind::Rep, ZmqService::transport(&self.service).clone())]
+        vec![(SocketKind::Rep, RequestService::transport(&self.service).clone())]
     }
 
     fn run(
@@ -360,9 +360,9 @@ impl<S: ZmqService + Send + Sync + 'static> Spawnable for UnifiedServiceConfig<S
         on_ready: Option<tokio::sync::oneshot::Sender<()>>,
     ) -> Result<()> {
         let UnifiedServiceConfig { service, quic_config } = *self;
-        let transport = ZmqService::transport(&service).clone();
-        let context = Arc::clone(ZmqService::context(&service));
-        let signing_key = ZmqService::signing_key(&service);
+        let transport = RequestService::transport(&service).clone();
+        let context = Arc::clone(RequestService::context(&service));
+        let signing_key = RequestService::signing_key(&service);
 
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -423,8 +423,8 @@ pub enum ServiceMode {
 /// use hyprstream_rpc::service::spawner::{ServiceSpawner, ProxyService};
 /// use hyprstream_rpc::transport::TransportConfig;
 ///
-/// // Spawn a REQ/REP service (ZmqService implementations are directly Spawnable)
-/// let service = MyZmqService::new(ctx, transport, verifying_key);
+/// // Spawn a REQ/REP service (RequestService implementations are directly Spawnable)
+/// let service = MyRequestService::new(ctx, transport, verifying_key);
 /// let spawner = ServiceSpawner::tokio();
 /// let spawned = spawner.spawn(service).await?;
 ///
@@ -487,7 +487,7 @@ impl ServiceSpawner {
     /// Spawn any Spawnable service with registry integration.
     ///
     /// This is the unified spawning API that works with both:
-    /// - Any `S: ZmqService` - REQ/REP services (directly Spawnable via blanket impl)
+    /// - Any `S: RequestService` - REQ/REP services (directly Spawnable via blanket impl)
     /// - `ProxyService` - XSUB/XPUB proxies
     ///
     /// The service is automatically registered with the EndpointRegistry and
@@ -496,8 +496,8 @@ impl ServiceSpawner {
     /// # Example
     ///
     /// ```ignore
-    /// // Spawn a REQ/REP service (ZmqService implementations are directly Spawnable)
-    /// let service = MyZmqService::new(ctx, transport, verifying_key);
+    /// // Spawn a REQ/REP service (RequestService implementations are directly Spawnable)
+    /// let service = MyRequestService::new(ctx, transport, verifying_key);
     /// let spawned = spawner.spawn(service).await?;
     ///
     /// // Spawn a proxy
@@ -1007,7 +1007,7 @@ mod tests {
     use super::*;
     use hyprstream_rpc::crypto::generate_signing_keypair;
     use hyprstream_rpc::prelude::SigningKey;
-    use hyprstream_rpc::service::ZmqService;
+    use hyprstream_rpc::service::RequestService;
     use anyhow::Result as AnyhowResult;
 
     /// Test service that includes infrastructure (new pattern)
@@ -1024,7 +1024,7 @@ mod tests {
     }
 
     #[async_trait::async_trait(?Send)]
-    impl ZmqService for EchoService {
+    impl RequestService for EchoService {
         async fn handle_request(
             &self,
             _ctx: &hyprstream_rpc::service::EnvelopeContext,

--- a/crates/hyprstream-workers/src/events/secure_publisher.rs
+++ b/crates/hyprstream-workers/src/events/secure_publisher.rs
@@ -47,13 +47,13 @@ pub enum RekeyPolicy {
 impl RekeyPolicy {
     pub fn validate(&self) -> Result<(), String> {
         match self {
-            Self::Scheduled { interval } | Self::Jittered { interval, .. } => {
-                if *interval > MAX_KEY_LIFETIME {
-                    return Err(format!(
-                        "interval {:?} exceeds MAX_KEY_LIFETIME ({:?})",
-                        interval, MAX_KEY_LIFETIME
-                    ));
-                }
+            Self::Scheduled { interval } | Self::Jittered { interval, .. }
+                if *interval > MAX_KEY_LIFETIME =>
+            {
+                return Err(format!(
+                    "interval {:?} exceeds MAX_KEY_LIFETIME ({:?})",
+                    interval, MAX_KEY_LIFETIME
+                ));
             }
             _ => {}
         }

--- a/crates/hyprstream-workers/src/runtime/mod.rs
+++ b/crates/hyprstream-workers/src/runtime/mod.rs
@@ -7,7 +7,7 @@
 //! # Architecture
 //!
 //! ```text
-//! WorkerService (ZmqService)
+//! WorkerService (RequestService)
 //!     │
 //!     ├── RuntimeClient trait (client-side interface)
 //!     │     ├── run_pod_sandbox()    → Creates Kata VM
@@ -78,7 +78,7 @@ pub use pool::{PoolStats, SandboxPool};
 pub use sandbox::PodSandbox;
 pub use service::WorkerService;
 // Re-export service infrastructure from hyprstream-rpc for convenience
-pub use hyprstream_rpc::service::{EnvelopeContext, ServiceHandle, ZmqService};
+pub use hyprstream_rpc::service::{EnvelopeContext, ServiceHandle, RequestService};
 pub use virtiofs::{SandboxVirtiofs, SandboxVirtiofsBuilder};
 
 /// CRI runtime version

--- a/crates/hyprstream-workers/src/runtime/service.rs
+++ b/crates/hyprstream-workers/src/runtime/service.rs
@@ -1,6 +1,6 @@
 //! WorkerService - CRI RuntimeClient + ImageClient via ZMQ
 //!
-//! Implements ZmqService trait for handling CRI-aligned requests.
+//! Implements RequestService trait for handling CRI-aligned requests.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -13,7 +13,7 @@ use tracing::{debug, info, warn};
 
 // Import ZMQ service infrastructure from hyprstream-rpc
 use hyprstream_rpc::prelude::SigningKey;
-use hyprstream_rpc::service::{AuthorizeFn, EnvelopeContext, ZmqService};
+use hyprstream_rpc::service::{AuthorizeFn, EnvelopeContext, RequestService};
 use hyprstream_rpc::streaming::{StreamChannel, StreamPublisher};
 use hyprstream_rpc::transport::TransportConfig;
 
@@ -58,7 +58,7 @@ const SERVICE_NAME: &str = "worker";
 
 /// WorkerService handles CRI RuntimeClient and ImageClient requests
 ///
-/// Implements the ZmqService trait for integration with hyprstream's ZMQ infrastructure.
+/// Implements the RequestService trait for integration with hyprstream's ZMQ infrastructure.
 pub struct WorkerService {
     // Business logic
     /// Sandbox pool for VM management
@@ -1281,11 +1281,11 @@ impl WorkerHandler for WorkerService {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// ZmqService Implementation — delegates to generated dispatch_worker
+// RequestService Implementation — delegates to generated dispatch_worker
 // ═══════════════════════════════════════════════════════════════════════════════
 
 #[async_trait(?Send)]
-impl ZmqService for WorkerService {
+impl RequestService for WorkerService {
     async fn handle_request(&self, ctx: &EnvelopeContext, payload: &[u8]) -> AnyhowResult<(Vec<u8>, Option<hyprstream_rpc::service::Continuation>)> {
         debug!(
             "Worker request from {} (request_id={})",

--- a/crates/hyprstream-workers/src/workflow/mod.rs
+++ b/crates/hyprstream-workers/src/workflow/mod.rs
@@ -6,7 +6,7 @@
 //! # Architecture
 //!
 //! ```text
-//! WorkflowService (ZmqService)
+//! WorkflowService (RequestService)
 //!     │
 //!     ├── scan_repo()       → Discover .github/workflows/*.yml
 //!     ├── subscribe()       → Register event triggers

--- a/crates/hyprstream-workers/src/workflow/service.rs
+++ b/crates/hyprstream-workers/src/workflow/service.rs
@@ -1,4 +1,4 @@
-//! WorkflowService - ZmqService implementation for workflow orchestration
+//! WorkflowService - RequestService implementation for workflow orchestration
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -9,7 +9,7 @@ use tokio_util::sync::CancellationToken;
 use anyhow::Result as AnyhowResult;
 use async_trait::async_trait;
 use hyprstream_rpc::prelude::SigningKey;
-use hyprstream_rpc::service::{AuthorizeFn, EnvelopeContext, ZmqService};
+use hyprstream_rpc::service::{AuthorizeFn, EnvelopeContext, RequestService};
 use hyprstream_rpc::transport::TransportConfig;
 
 use hyprstream_vfs::Namespace;
@@ -99,7 +99,7 @@ pub struct WorkflowService {
     /// Background event loop handle
     event_loop_handle: tokio::sync::Mutex<Option<JoinHandle<()>>>,
 
-    // Infrastructure (for ZmqService / Spawnable)
+    // Infrastructure (for RequestService / Spawnable)
     /// Transport configuration
     transport: TransportConfig,
     /// Signing key for message authentication
@@ -613,11 +613,11 @@ impl WorkflowHandler for WorkflowService {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// ZmqService Implementation — delegates to generated dispatch_workflow
+// RequestService Implementation — delegates to generated dispatch_workflow
 // ═══════════════════════════════════════════════════════════════════════════════
 
 #[async_trait(?Send)]
-impl ZmqService for WorkflowService {
+impl RequestService for WorkflowService {
     async fn handle_request(&self, ctx: &EnvelopeContext, payload: &[u8]) -> AnyhowResult<(Vec<u8>, Option<hyprstream_rpc::service::Continuation>)> {
         tracing::debug!(
             "Workflow request from {} (request_id={})",

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -48,7 +48,7 @@ serde_yaml.workspace = true
 git2.workspace = true  # Still needed by git2db internally
 git2db = { path = "../git2db", features = ["overlayfs"] }  # High-level git library with overlayfs
 hyprstream-rpc = { path = "../hyprstream-rpc" }  # RPC infrastructure (Cap'n Proto + ZMQ)
-ml-dsa = { workspace = true, optional = true }  # ML-DSA-65 (pq-hybrid JWT signing)
+ml-dsa = { workspace = true }  # ML-DSA-65 — always compiled (runtime CryptoPolicy selects PQ). See M3 #152.
 hyprstream-rpc-std = { path = "../hyprstream-rpc-std" }  # Standard service schemas + clients
 hyprstream-discovery = { path = "../hyprstream-discovery" }  # Service discovery
 hyprstream-service = { path = "../hyprstream-service" }  # Service orchestration
@@ -202,7 +202,7 @@ download-libtorch = ["tch/download-libtorch"]
 overlayfs = ["git2db/overlayfs"]  # Enable overlayfs-backed worktrees (delegated to git2db)
 systemd = ["hyprstream-rpc/systemd", "hyprstream-service/systemd", "hyprstream-workers/systemd", "dep:listenfd"]  # Systemd integration (socket activation, service units)
 experimental = ["hyprstream-compositor/experimental"]  # EXPERIMENTAL: Enable service/worker panels, git write operations
-pq-hybrid = ["hyprstream-rpc/pq-hybrid", "hyprstream-service/pq-hybrid", "dep:ml-dsa"]  # Post-quantum hybrid: ML-DSA-65 + ML-KEM-768
+pq-hybrid = []  # NO-OP alias: PQ primitives always compiled; Classical/Hybrid selected at runtime. See M3 #152.
 
 [build-dependencies]
 capnpc.workspace = true  # Cap'n Proto schema compiler

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -214,6 +214,9 @@ hyprstream-rpc-build.workspace = true  # Shared annotation extraction
 criterion.workspace = true
 tempfile.workspace = true
 tokio-stream.workspace = true
+# Test-only: iroh substrate types used by `tests/policy_over_iroh.rs`.
+iroh.workspace = true
+rand.workspace = true
 
 [lints]
 workspace = true

--- a/crates/hyprstream/src/auth/jwt.rs
+++ b/crates/hyprstream/src/auth/jwt.rs
@@ -74,7 +74,6 @@ pub fn generate_es256_key() -> Es256SigningKey {
 // ── ML-DSA-65 JWT encoding (draft-ietf-cose-dilithium-11) ──────────────
 
 /// Encode and sign a JWT with ML-DSA-65 (`alg: "ML-DSA-65"`, `kty: "AKP"`).
-#[cfg(feature = "pq-hybrid")]
 pub fn encode_ml_dsa_65(
     claims: &Claims,
     signing_key: &hyprstream_rpc::crypto::pq::MlDsaSigningKey,
@@ -109,7 +108,6 @@ pub fn encode_ml_dsa_65(
 ///
 /// Signature = ML-DSA-65 sig (3309 bytes) ∥ Ed25519 sig (64 bytes).
 /// Per draft-ietf-jose-pq-composite-sigs.
-#[cfg(feature = "pq-hybrid")]
 pub fn encode_composite_ml_dsa_65_ed25519(
     claims: &Claims,
     ml_dsa_key: &hyprstream_rpc::crypto::pq::MlDsaSigningKey,
@@ -155,7 +153,6 @@ pub fn encode_composite_ml_dsa_65_ed25519(
 }
 
 /// Encode a service WIT (`typ: "wit+jwt"`) with ML-DSA-65-Ed25519 composite signature.
-#[cfg(feature = "pq-hybrid")]
 pub fn encode_composite_service_jwt(
     claims: &Claims,
     ml_dsa_key: &hyprstream_rpc::crypto::pq::MlDsaSigningKey,
@@ -201,7 +198,6 @@ pub fn encode_composite_service_jwt(
 }
 
 /// Build a JWK for an ML-DSA-65 key (`kty: "AKP"`).
-#[cfg(feature = "pq-hybrid")]
 pub fn ml_dsa_65_jwk(
     vk: &hyprstream_rpc::crypto::pq::MlDsaVerifyingKey,
 ) -> serde_json::Value {
@@ -222,7 +218,6 @@ pub fn ml_dsa_65_jwk(
 }
 
 /// Build a JWK for a composite ML-DSA-65-Ed25519 key (`kty: "AKP"`).
-#[cfg(feature = "pq-hybrid")]
 pub fn composite_jwk(
     ml_dsa_vk: &hyprstream_rpc::crypto::pq::MlDsaVerifyingKey,
     ed25519_vk: &ed25519_dalek::VerifyingKey,
@@ -313,7 +308,6 @@ mod tests {
         assert!(decoded.jti.is_some());
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn ml_dsa_65_roundtrip() {
         let (sk, vk) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();
@@ -334,7 +328,6 @@ mod tests {
         assert!(decoded.jti.is_some());
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn ml_dsa_65_jwk_structure() {
         let (sk, _) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();
@@ -347,7 +340,6 @@ mod tests {
         assert!(jwk["pub"].as_str().is_some());
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn composite_ml_dsa_65_ed25519_roundtrip() {
         let (ml_dsa_sk, ml_dsa_vk) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();
@@ -371,7 +363,6 @@ mod tests {
         assert!(decoded.jti.is_some());
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn composite_jwk_structure() {
         let (ml_dsa_sk, _) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();
@@ -387,7 +378,6 @@ mod tests {
         assert!(jwk["pub"].as_str().is_some());
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn ml_dsa_65_wrong_key_rejects() {
         let (sk, _) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();
@@ -397,7 +387,6 @@ mod tests {
         assert!(hyprstream_rpc::auth::jwt::decode_ml_dsa_65(&token, &wrong_vk, None).is_err());
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn composite_wrong_ed25519_key_rejects() {
         let (ml_dsa_sk, ml_dsa_vk) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();
@@ -411,7 +400,6 @@ mod tests {
         ).is_err());
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn ml_dsa_65_expired_token_rejected() {
         let (sk, vk) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();
@@ -421,7 +409,6 @@ mod tests {
         assert!(matches!(err, hyprstream_rpc::auth::JwtError::Expired));
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn composite_expired_token_rejected() {
         let (ml_dsa_sk, ml_dsa_vk) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();
@@ -435,7 +422,6 @@ mod tests {
         assert!(matches!(err, hyprstream_rpc::auth::JwtError::Expired));
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn ml_dsa_65_rejects_eddsa_token() {
         let ed25519_sk = ed25519_dalek::SigningKey::from_bytes(&[42u8; 32]);
@@ -445,7 +431,6 @@ mod tests {
         assert!(hyprstream_rpc::auth::jwt::decode_ml_dsa_65(&token, &vk, None).is_err());
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn ml_dsa_65_lenient_audience() {
         let (sk, vk) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();
@@ -457,7 +442,6 @@ mod tests {
         ).is_ok());
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn ml_dsa_65_wrong_audience_rejected() {
         let (sk, vk) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();

--- a/crates/hyprstream/src/auth/key_rotation.rs
+++ b/crates/hyprstream/src/auth/key_rotation.rs
@@ -25,11 +25,13 @@ use crate::config::OAuthConfig;
 /// Populated at startup from the ML-DSA rotation store's current slots.
 /// Updated by the rotation task after each promotion. Services read from this
 /// via their `JwtKeySource` implementation.
-#[cfg(feature = "pq-hybrid")]
+// Cross-crate `Arc<std::sync::RwLock<..>>` contract with `JwtKeySource` and the
+// service factory; intentionally `std::sync::RwLock`, not `parking_lot`.
+#[allow(clippy::disallowed_types)]
 static ML_DSA_VERIFYING_KEYS: std::sync::OnceLock<std::sync::Arc<std::sync::RwLock<Vec<hyprstream_rpc::crypto::pq::MlDsaVerifyingKey>>>> = std::sync::OnceLock::new();
 
 /// Get or initialize the global ML-DSA verifying keys Arc.
-#[cfg(feature = "pq-hybrid")]
+#[allow(clippy::disallowed_types)]
 pub fn global_ml_dsa_verifying_keys() -> std::sync::Arc<std::sync::RwLock<Vec<hyprstream_rpc::crypto::pq::MlDsaVerifyingKey>>> {
     ML_DSA_VERIFYING_KEYS.get_or_init(|| {
         std::sync::Arc::new(std::sync::RwLock::new(Vec::new()))
@@ -40,13 +42,11 @@ pub fn global_ml_dsa_verifying_keys() -> std::sync::Arc<std::sync::RwLock<Vec<hy
 ///
 /// Ensures all services (PolicyService, OAuthService, rotation task) share
 /// the same store instance — rotation applies universally.
-#[cfg(feature = "pq-hybrid")]
 static ML_DSA_SIGNING_STORE: std::sync::OnceLock<Arc<MlDsaSigningKeyStore>> = std::sync::OnceLock::new();
 
 /// Get or initialize the global ML-DSA signing key store.
 ///
 /// First call initializes from disk; subsequent calls return the same Arc.
-#[cfg(feature = "pq-hybrid")]
 pub fn global_ml_dsa_key_store(secrets_dir: &Path, config: &OAuthConfig) -> Arc<MlDsaSigningKeyStore> {
     ML_DSA_SIGNING_STORE.get_or_init(|| {
         Arc::new(load_or_init_ml_dsa_key_store(secrets_dir, config))
@@ -307,7 +307,6 @@ pub async fn rotate_jwt_keys(
 /// Additional stores to rotate alongside the primary Ed25519 store.
 pub struct RotationStores {
     pub es256: Option<Arc<Es256SigningKeyStore>>,
-    #[cfg(feature = "pq-hybrid")]
     pub ml_dsa: Option<Arc<MlDsaSigningKeyStore>>,
 }
 
@@ -329,12 +328,11 @@ pub fn spawn_rotation_task(
             if let Some(ref es256) = extra.es256 {
                 rotate_es256_keys(&config, &secrets_dir, es256, now).await;
             }
-            #[cfg(feature = "pq-hybrid")]
             if let Some(ref ml_dsa) = extra.ml_dsa {
                 rotate_ml_dsa_keys(&config, &secrets_dir, ml_dsa, now).await;
                 // Refresh the global verifying key snapshot.
                 let vks: Vec<_> = ml_dsa.all_slots_snapshot().await.iter()
-                    .map(|slot| slot.verifying_key())
+                    .map(ml_dsa_rotation::MlDsaKeySlot::verifying_key)
                     .collect();
                 let shared = global_ml_dsa_verifying_keys();
                 let _ = shared.write().map(|mut guard| *guard = vks);
@@ -533,10 +531,9 @@ pub async fn rotate_es256_keys(
 }
 
 // ════════════════════════════════════════════════════════════════════════════════
-// ML-DSA-65 Key Rotation Store (pq-hybrid feature)
+// ML-DSA-65 Key Rotation Store (always compiled; runtime CryptoPolicy)
 // ════════════════════════════════════════════════════════════════════════════════
 
-#[cfg(feature = "pq-hybrid")]
 mod ml_dsa_rotation {
     use super::*;
     use hyprstream_rpc::crypto::pq::{
@@ -684,8 +681,9 @@ mod ml_dsa_rotation {
         let drain_secs = config.drain_secs();
 
         // Phase 1: promote lead → active
-        if let Some(ref lead) = slots.lead {
-            if lead.nbf <= now {
+        let lead_ready = slots.lead.as_ref().is_some_and(|lead| lead.nbf <= now);
+        if lead_ready {
+            if let Some(new_active) = slots.lead.take() {
                 if let Some(old_active) = slots.active.take() {
                     delete_ml_dsa_slot(secrets_dir, "drain");
                     if let Err(e) = persist_ml_dsa_slot(secrets_dir, "drain", &old_active) {
@@ -693,7 +691,6 @@ mod ml_dsa_rotation {
                     }
                     slots.drain = Some(old_active);
                 }
-                let new_active = slots.lead.take().unwrap();
                 if let Err(e) = persist_ml_dsa_slot(secrets_dir, "active", &new_active) {
                     warn!("ML-DSA: failed to persist promoted active: {e}");
                 }
@@ -729,7 +726,6 @@ mod ml_dsa_rotation {
     }
 }
 
-#[cfg(feature = "pq-hybrid")]
 pub use ml_dsa_rotation::{MlDsaKeySlot, MlDsaKeySlots, MlDsaSigningKeyStore, load_or_init_ml_dsa_key_store, rotate_ml_dsa_keys};
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -927,7 +923,6 @@ mod tests {
 
     // ── ML-DSA store tests ─────────────────────────────────────────────────
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn ml_dsa_load_or_init_creates_active_key() {
         let dir = TempDir::new().unwrap();
@@ -938,7 +933,6 @@ mod tests {
         assert!(key.is_some());
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[test]
     fn ml_dsa_persist_and_reload() {
         let dir = TempDir::new().unwrap();
@@ -957,7 +951,6 @@ mod tests {
         assert_eq!(vk1, vk2, "ML-DSA key must survive reload from disk");
     }
 
-    #[cfg(feature = "pq-hybrid")]
     #[tokio::test]
     async fn ml_dsa_rotate_promotes_lead() {
         use super::ml_dsa_rotation::*;

--- a/crates/hyprstream/src/auth/mod.rs
+++ b/crates/hyprstream/src/auth/mod.rs
@@ -23,7 +23,6 @@ pub mod valkey;
 pub use federation::FederationKeyResolver;
 pub use jwt::{Claims, JwtError};
 pub use key_rotation::{SigningKeyStore, Es256SigningKeyStore, Es256KeySlot, RotationStores};
-#[cfg(feature = "pq-hybrid")]
 pub use key_rotation::{MlDsaSigningKeyStore, MlDsaKeySlot};
 pub use policy_manager::{PolicyManager, PolicyError, write_policy_file, global_policy_manager, set_global_policy_manager};
 pub use policy_migration::migrate_policy_csv;

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1944,7 +1944,6 @@ fn main() -> Result<()> {
                                 }
 
                                 // Populate ML-DSA-65 verifying keys for PQ-hybrid JWT verification.
-                                #[cfg(feature = "pq-hybrid")]
                                 {
                                     let secrets_dir = hyprstream_core::config::HyprConfig::resolve_secrets_dir();
                                     let ml_dsa_store = hyprstream_core::auth::key_rotation::global_ml_dsa_key_store(
@@ -1956,12 +1955,80 @@ fn main() -> Result<()> {
                                         rt.block_on(ml_dsa_store.all_slots_snapshot())
                                     })
                                     .iter()
-                                    .map(|slot| slot.verifying_key())
+                                    .map(hyprstream_core::auth::MlDsaKeySlot::verifying_key)
                                     .collect();
                                     let shared_vks = hyprstream_core::auth::key_rotation::global_ml_dsa_verifying_keys();
                                     let _ = shared_vks.write().map(|mut guard| *guard = vks);
                                     ctx.set_ml_dsa_verifying_keys(shared_vks);
                                     tracing::info!("PQ-hybrid: ML-DSA-65 verifying keys loaded for JWT verification");
+                                }
+
+                                // M3 (#152): install the process-global envelope
+                                // verify configuration that closes the fail-open
+                                // at the ZMQ RequestLoop + StreamService verify
+                                // sites.
+                                //
+                                // KEY SEPARATION (PQUIP key-reuse restriction):
+                                // the mesh hybrid identity's ML-DSA key MUST be
+                                // distinct from the JWT-signing ML-DSA keyset
+                                // (`global_ml_dsa_verifying_keys`, loaded above).
+                                // We therefore DO NOT seed the mesh PqTrustStore
+                                // from the JWT keyset. The mesh store is keyed by
+                                // Ed25519 signer identity and is populated from
+                                // attested peer identities (peer-attestation
+                                // registry — residual integration work).
+                                //
+                                // Policy: Hybrid is enforced by default. Operators
+                                // mid-rollout (before peer ML-DSA bindings are
+                                // provisioned) may set
+                                // HYPRSTREAM_ENVELOPE_POLICY=classical to keep the
+                                // legacy EdDSA-only verifier. Under Hybrid with no
+                                // anchored key the verifier FAILS CLOSED.
+                                {
+                                    use hyprstream_rpc::envelope::{
+                                        install_verify_config, EnvelopeVerifyConfig, KeyedPqTrustStore,
+                                    };
+                                    use hyprstream_rpc::crypto::CryptoPolicy;
+
+                                    let policy = match std::env::var("HYPRSTREAM_ENVELOPE_POLICY")
+                                        .ok()
+                                        .as_deref()
+                                    {
+                                        Some("classical") => CryptoPolicy::Classical,
+                                        Some("hybrid") | None => CryptoPolicy::Hybrid,
+                                        Some(other) => {
+                                            tracing::warn!(
+                                                "unknown HYPRSTREAM_ENVELOPE_POLICY={other:?}, defaulting to Hybrid"
+                                            );
+                                            CryptoPolicy::Hybrid
+                                        }
+                                    };
+
+                                    // Mesh kid-anchored PQ trust store. Peer
+                                    // bindings (Ed25519 signer -> trusted ML-DSA)
+                                    // are added by the attestation layer; an empty
+                                    // store under Hybrid fails closed for unknown
+                                    // peers (correct, by design).
+                                    let pq_store: std::sync::Arc<dyn hyprstream_rpc::envelope::PqTrustStore> =
+                                        std::sync::Arc::new(KeyedPqTrustStore::new());
+
+                                    if install_verify_config(EnvelopeVerifyConfig {
+                                        policy,
+                                        pq_store: Some(pq_store),
+                                    })
+                                    .is_ok()
+                                    {
+                                        match policy {
+                                            CryptoPolicy::Hybrid => tracing::info!(
+                                                "envelope verify policy: HYBRID enforced (SNS nested COSE); \
+                                                 peer ML-DSA bindings required for cross-node traffic"
+                                            ),
+                                            CryptoPolicy::Classical => tracing::warn!(
+                                                "envelope verify policy: CLASSICAL (EdDSA-only) — \
+                                                 set HYPRSTREAM_ENVELOPE_POLICY=hybrid to enforce PQ"
+                                            ),
+                                        }
+                                    }
                                 }
 
                                 let manager = InprocManager::new();

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1442,6 +1442,13 @@ fn main() -> Result<()> {
         .validate()
         .context("Configuration validation failed")?;
 
+    // Install the per-service streaming-response concurrency cap from config
+    // (#186) before any RPC service starts. First-write-wins; ignore if already
+    // installed on this process.
+    let _ = hyprstream_rpc::streaming::install_max_concurrent_streams_per_service(
+        config.server.max_concurrent_streams_per_service,
+    );
+
     // ========== TRACING INITIALIZATION (before service startup) ==========
     let is_service_command = matches.subcommand_name() == Some("service");
     let _log_guard: Option<tracing_appender::non_blocking::WorkerGuard>;

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -490,7 +490,7 @@ fn handle_quick_command(
                     signing_key,
                     model_server_vk,
                     None,
-                );
+                )?;
                 let filters = parse_filters(&filter)?;
                 let status_filter = parse_status_filter(&status)?;
                 handle_list(ctx.registry(), model_client, &filters, &status_filter).await
@@ -1090,7 +1090,7 @@ fn handle_quick_command(
                             resolve_service_vk("policy")
                                 .ok_or_else(|| anyhow::anyhow!("Cannot resolve policy pubkey. Run wizard."))?,
                             None,
-                        );
+                        )?;
                         worker_service.set_authorize_fn(
                             hyprstream_core::services::build_authorize_fn(worker_policy_client),
                         );
@@ -1115,7 +1115,7 @@ fn handle_quick_command(
                     let worker_server_vk = resolve_service_vk("worker")
                         .ok_or_else(|| anyhow::anyhow!("Cannot resolve worker pubkey. Run wizard."))?;
                     let worker_client =
-                        WorkerClient::for_service(signing_key, worker_server_vk, None);
+                        WorkerClient::for_service(signing_key, worker_server_vk, None)?;
 
                     match action {
                         WorkerAction::List {
@@ -1643,7 +1643,7 @@ fn main() -> Result<()> {
                 signing_key.clone(),
                 registry_vk,
                 None,
-            );
+            )?;
 
             Ok::<_, anyhow::Error>((client, signing_key, verifying_key))
         })
@@ -1768,7 +1768,7 @@ fn main() -> Result<()> {
                                         resolve_service_vk("policy")
                                             .ok_or_else(|| anyhow::anyhow!("Cannot resolve policy pubkey. Run wizard."))?,
                                         None,
-                                    );
+                                    )?;
 
                                     let runtime_config =
                                         hyprstream_core::runtime::RuntimeConfig::default();

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1095,6 +1095,11 @@ fn handle_quick_command(
                             hyprstream_core::services::build_authorize_fn(worker_policy_client),
                         );
 
+                        // Standalone worker entrypoint serves RPC, so it must
+                        // install the verify config too (#160) — otherwise the
+                        // fail-closed default rejects all mesh traffic.
+                        install_envelope_verify_config();
+
                         let manager = InprocManager::new();
                         Some(
                             manager
@@ -1296,6 +1301,58 @@ fn resolve_service_vk(service_name: &str) -> Option<VerifyingKey> {
         }
     }
     trust.resolve_one(service_name)
+}
+
+/// Install the process-global envelope verify configuration (#152, #160).
+///
+/// MUST be called once at startup on **every** process entrypoint that serves
+/// RPC — the inproc daemon AND standalone service entrypoints (e.g. a lone
+/// worker). When uninstalled, `global_verify_policy()` fail-closes to Hybrid
+/// (#160), so a missing call here breaks mesh verification loudly rather than
+/// silently downgrading to EdDSA-only. `install_verify_config` is first-write-
+/// wins, so calling it from multiple stages within one process is harmless.
+///
+/// Policy default is Hybrid (SNS nested COSE); operators mid-rollout, before
+/// peer ML-DSA bindings are provisioned, may set
+/// `HYPRSTREAM_ENVELOPE_POLICY=classical`. Under Hybrid with no anchored peer
+/// key the verifier fails closed (correct, by design).
+fn install_envelope_verify_config() {
+    use hyprstream_rpc::crypto::CryptoPolicy;
+    use hyprstream_rpc::envelope::{
+        install_verify_config, EnvelopeVerifyConfig, KeyedPqTrustStore, PqTrustStore,
+    };
+
+    let policy = match std::env::var("HYPRSTREAM_ENVELOPE_POLICY").ok().as_deref() {
+        Some("classical") => CryptoPolicy::Classical,
+        Some("hybrid") | None => CryptoPolicy::Hybrid,
+        Some(other) => {
+            tracing::warn!("unknown HYPRSTREAM_ENVELOPE_POLICY={other:?}, defaulting to Hybrid");
+            CryptoPolicy::Hybrid
+        }
+    };
+
+    // Mesh kid-anchored PQ trust store. Peer bindings (Ed25519 signer ->
+    // trusted ML-DSA) are added by the attestation layer; an empty store under
+    // Hybrid fails closed for unknown peers (correct, by design).
+    let pq_store: std::sync::Arc<dyn PqTrustStore> = std::sync::Arc::new(KeyedPqTrustStore::new());
+
+    if install_verify_config(EnvelopeVerifyConfig {
+        policy,
+        pq_store: Some(pq_store),
+    })
+    .is_ok()
+    {
+        match policy {
+            CryptoPolicy::Hybrid => tracing::info!(
+                "envelope verify policy: HYBRID enforced (SNS nested COSE); \
+                 peer ML-DSA bindings required for cross-node traffic"
+            ),
+            CryptoPolicy::Classical => tracing::warn!(
+                "envelope verify policy: CLASSICAL (EdDSA-only) — \
+                 set HYPRSTREAM_ENVELOPE_POLICY=hybrid to enforce PQ"
+            ),
+        }
+    }
 }
 
 fn main() -> Result<()> {
@@ -1984,52 +2041,7 @@ fn main() -> Result<()> {
                                 // HYPRSTREAM_ENVELOPE_POLICY=classical to keep the
                                 // legacy EdDSA-only verifier. Under Hybrid with no
                                 // anchored key the verifier FAILS CLOSED.
-                                {
-                                    use hyprstream_rpc::envelope::{
-                                        install_verify_config, EnvelopeVerifyConfig, KeyedPqTrustStore,
-                                    };
-                                    use hyprstream_rpc::crypto::CryptoPolicy;
-
-                                    let policy = match std::env::var("HYPRSTREAM_ENVELOPE_POLICY")
-                                        .ok()
-                                        .as_deref()
-                                    {
-                                        Some("classical") => CryptoPolicy::Classical,
-                                        Some("hybrid") | None => CryptoPolicy::Hybrid,
-                                        Some(other) => {
-                                            tracing::warn!(
-                                                "unknown HYPRSTREAM_ENVELOPE_POLICY={other:?}, defaulting to Hybrid"
-                                            );
-                                            CryptoPolicy::Hybrid
-                                        }
-                                    };
-
-                                    // Mesh kid-anchored PQ trust store. Peer
-                                    // bindings (Ed25519 signer -> trusted ML-DSA)
-                                    // are added by the attestation layer; an empty
-                                    // store under Hybrid fails closed for unknown
-                                    // peers (correct, by design).
-                                    let pq_store: std::sync::Arc<dyn hyprstream_rpc::envelope::PqTrustStore> =
-                                        std::sync::Arc::new(KeyedPqTrustStore::new());
-
-                                    if install_verify_config(EnvelopeVerifyConfig {
-                                        policy,
-                                        pq_store: Some(pq_store),
-                                    })
-                                    .is_ok()
-                                    {
-                                        match policy {
-                                            CryptoPolicy::Hybrid => tracing::info!(
-                                                "envelope verify policy: HYBRID enforced (SNS nested COSE); \
-                                                 peer ML-DSA bindings required for cross-node traffic"
-                                            ),
-                                            CryptoPolicy::Classical => tracing::warn!(
-                                                "envelope verify policy: CLASSICAL (EdDSA-only) — \
-                                                 set HYPRSTREAM_ENVELOPE_POLICY=hybrid to enforce PQ"
-                                            ),
-                                        }
-                                    }
-                                }
+                                install_envelope_verify_config();
 
                                 let manager = InprocManager::new();
                                 let mut handles = Vec::new();

--- a/crates/hyprstream/src/cli/git_handlers.rs
+++ b/crates/hyprstream/src/cli/git_handlers.rs
@@ -1268,7 +1268,7 @@ pub async fn handle_infer(
         let policy_vk = signing_key.verifying_key();
         let policy_client = crate::services::PolicyClient::for_service(
             signing_key.clone(), policy_vk, None,
-        );
+        )?;
         let resp = policy_client.resolve_service_key(
             &crate::services::generated::policy_client::ResolveServiceKey {
                 service_name: "model".to_owned(),
@@ -1283,7 +1283,7 @@ pub async fn handle_infer(
         signing_key.clone(),
         model_server_vk,
         None,
-    );
+    )?;
 
     // Apply chat template to the prompt via ModelService
     let messages = vec![ChatMessage {
@@ -1445,7 +1445,7 @@ pub async fn handle_load(
     let policy_vk = signing_key.verifying_key();
     let policy_client = crate::services::PolicyClient::for_service(
         signing_key.clone(), policy_vk, None,
-    );
+    )?;
 
     // If --wait, subscribe to notifications BEFORE issuing load request
     // (ensures no events are missed between load and subscribe)
@@ -1469,7 +1469,7 @@ pub async fn handle_load(
             signing_key.clone(),
             notif_vk,
             None,
-        );
+        )?;
 
         let sub_resp = notif_client.subscribe(&SubscribeRequest {
             scope_pattern: scope_pattern.clone(),
@@ -1517,7 +1517,7 @@ pub async fn handle_load(
         signing_key.clone(),
         model_vk,
         None,
-    );
+    )?;
     let model_ref_owned = model_ref_str.to_owned();
     match model_client.load(&LoadModelRequest {
         model_ref: model_ref_owned.clone(),
@@ -1775,7 +1775,7 @@ async fn handle_notify_subscribe(
     let policy_vk = signing_key.verifying_key();
     let policy_client = crate::services::PolicyClient::for_service(
         signing_key.clone(), policy_vk, None,
-    );
+    )?;
     let notif_key_resp = policy_client.resolve_service_key(
         &crate::services::generated::policy_client::ResolveServiceKey {
             service_name: "notification".to_owned(),
@@ -1789,7 +1789,7 @@ async fn handle_notify_subscribe(
         signing_key,
         notif_server_vk,
         None,
-    );
+    )?;
 
     // Subscribe with maximum TTL for long-running listeners
     let ttl = if timeout_secs == 0 { 3600u32 } else { (timeout_secs as u32).min(3600) };
@@ -1929,7 +1929,7 @@ pub async fn handle_unload(
         let policy_vk = signing_key.verifying_key();
         let policy_client = crate::services::PolicyClient::for_service(
             signing_key.clone(), policy_vk, None,
-        );
+        )?;
         let resp = policy_client.resolve_service_key(
             &crate::services::generated::policy_client::ResolveServiceKey {
                 service_name: "model".to_owned(),
@@ -1940,7 +1940,7 @@ pub async fn handle_unload(
                 .map_err(|_| anyhow::anyhow!("Invalid key length"))?,
         ).map_err(|e| anyhow::anyhow!("Invalid key: {e}"))?
     };
-    let model_client = ModelClient::for_service(signing_key, model_server_vk, None);
+    let model_client = ModelClient::for_service(signing_key, model_server_vk, None)?;
 
     model_client.unload(&UnloadModelRequest { model_ref: model_ref_str.to_owned() }).await?;
 

--- a/crates/hyprstream/src/cli/policy_handlers.rs
+++ b/crates/hyprstream/src/cli/policy_handlers.rs
@@ -27,7 +27,7 @@ use std::process::Command;
 /// Create a PolicyClient for RPC calls.
 ///
 /// Bootstrap: PolicyService key needed to create the PolicyClient for peer key resolution.
-fn create_policy_client(signing_key: &SigningKey) -> PolicyClient {
+fn create_policy_client(signing_key: &SigningKey) -> Result<PolicyClient> {
     PolicyClient::for_service(
         signing_key.clone(),
         // Bootstrap: PolicyService uses the root key
@@ -41,7 +41,7 @@ pub async fn handle_policy_show(
     signing_key: &SigningKey,
     raw: bool,
 ) -> Result<()> {
-    let client = create_policy_client(signing_key);
+    let client = create_policy_client(signing_key)?;
     let policy_info = client.get_policy().await
         .context("Failed to get policy from PolicyService. Are services running?")?;
 
@@ -113,7 +113,7 @@ pub async fn handle_policy_history(
     count: usize,
     _oneline: bool,
 ) -> Result<()> {
-    let client = create_policy_client(signing_key);
+    let client = create_policy_client(signing_key)?;
     let history = client.get_history(&GetHistory { count: count as u32 }).await
         .context("Failed to get policy history from PolicyService. Are services running?")?;
 
@@ -160,7 +160,7 @@ pub async fn handle_policy_edit(
     }
 
     // Check for draft changes via PolicyService RPC
-    let client = create_policy_client(signing_key);
+    let client = create_policy_client(signing_key)?;
     match client.get_draft_status().await {
         Ok(draft) if draft.has_changes => {
             println!();
@@ -182,7 +182,7 @@ pub async fn handle_policy_diff(
     signing_key: &SigningKey,
     against: Option<String>,
 ) -> Result<()> {
-    let client = create_policy_client(signing_key);
+    let client = create_policy_client(signing_key)?;
     let git_ref = against.as_deref().unwrap_or("");
 
     let diff_text = client.get_diff(&GetDiff { git_ref: Some(git_ref.to_owned()) }).await
@@ -217,7 +217,7 @@ pub async fn handle_policy_apply(
     dry_run: bool,
     message: Option<String>,
 ) -> Result<()> {
-    let client = create_policy_client(signing_key);
+    let client = create_policy_client(signing_key)?;
 
     // Check for uncommitted changes via RPC
     let draft = client.get_draft_status().await
@@ -268,7 +268,7 @@ pub async fn handle_policy_rollback(
     git_ref: &str,
     dry_run: bool,
 ) -> Result<()> {
-    let client = create_policy_client(signing_key);
+    let client = create_policy_client(signing_key)?;
 
     if dry_run {
         // Use history RPC to show what we'd be rolling back to
@@ -316,7 +316,7 @@ pub async fn handle_policy_check(
     resource: &str,
     action: &str,
 ) -> Result<()> {
-    let client = create_policy_client(signing_key);
+    let client = create_policy_client(signing_key)?;
 
     let allowed = client.check(&PolicyCheck { subject: user.to_owned(), domain: "*".to_owned(), resource: resource.to_owned(), operation: action.to_owned() }).await
         .context("Failed to check policy via PolicyService. Are services running?")?;
@@ -534,7 +534,7 @@ pub async fn handle_policy_role_add(
         return Ok(());
     }
 
-    let client = create_policy_client(signing_key);
+    let client = create_policy_client(signing_key)?;
     let sha = client.add_grouping(&AddGrouping { user: user.to_owned(), role: role.to_owned() }).await
         .context("Failed to add role assignment via PolicyService. Are services running?")?;
 
@@ -562,7 +562,7 @@ pub async fn handle_policy_role_remove(
         }
     }
 
-    let client = create_policy_client(signing_key);
+    let client = create_policy_client(signing_key)?;
     let sha = client.remove_grouping(&RemoveGrouping { user: user.to_owned(), role: role.to_owned() }).await
         .context("Failed to remove role assignment via PolicyService. Are services running?")?;
 
@@ -576,7 +576,7 @@ pub async fn handle_policy_role_list(
     user: Option<&str>,
     role: Option<&str>,
 ) -> Result<()> {
-    let client = create_policy_client(signing_key);
+    let client = create_policy_client(signing_key)?;
     let policy_info = client.get_policy().await
         .context("Failed to get policy from PolicyService. Are services running?")?;
 
@@ -646,7 +646,7 @@ pub async fn handle_policy_apply_template(
     }
 
     // Use PolicyService RPC to apply the template (writes file, validates, stages, commits)
-    let client = create_policy_client(signing_key);
+    let client = create_policy_client(signing_key)?;
     let result_msg = client.apply_template(&ApplyTemplate { name: template_name.to_owned() }).await
         .context("Failed to apply template via PolicyService. Are services running?")?;
 

--- a/crates/hyprstream/src/cli/schema_cli.rs
+++ b/crates/hyprstream/src/cli/schema_cli.rs
@@ -366,7 +366,7 @@ async fn resolve_key_via_policy(
     let policy_vk = signing_key.verifying_key();
     let policy_client = PolicyClient::for_service(
         signing_key.clone(), policy_vk, None,
-    );
+    )?;
     let resp = policy_client.resolve_service_key(
         &crate::services::generated::policy_client::ResolveServiceKey {
             service_name: service_name.to_owned(),
@@ -390,23 +390,23 @@ async fn dispatch_top_level(
             let server_vk = resolve_key_via_policy(&signing_key, "registry").await?;
             let client: RegistryClient = RegistryClient::for_service(
                 signing_key, server_vk, None,
-            );
+            )?;
             client.call_method(method, args).await
         }
         "model" => {
             let server_vk = resolve_key_via_policy(&signing_key, "model").await?;
-            let client = ModelClient::for_service(signing_key, server_vk, None);
+            let client = ModelClient::for_service(signing_key, server_vk, None)?;
             client.call_method(method, args).await
         }
         "inference" => {
             let server_vk = resolve_key_via_policy(&signing_key, "inference").await?;
-            let client = InferenceClient::for_service(signing_key, server_vk, None);
+            let client = InferenceClient::for_service(signing_key, server_vk, None)?;
             client.call_method(method, args).await
         }
         "policy" => {
             // Bootstrap: PolicyService uses the root key
             let server_vk = signing_key.verifying_key();
-            let client = PolicyClient::for_service(signing_key, server_vk, None);
+            let client = PolicyClient::for_service(signing_key, server_vk, None)?;
             client.call_method(method, args).await
         }
         "worker" => {
@@ -432,17 +432,17 @@ async fn dispatch_scoped_dynamic(
             let server_vk = resolve_key_via_policy(&signing_key, "registry").await?;
             let client: RegistryClient = RegistryClient::for_service(
                 signing_key, server_vk, None,
-            );
+            )?;
             client.call_scoped_method(scope_chain, method, args).await
         }
         "model" => {
             let server_vk = resolve_key_via_policy(&signing_key, "model").await?;
-            let client = ModelClient::for_service(signing_key, server_vk, None);
+            let client = ModelClient::for_service(signing_key, server_vk, None)?;
             client.call_scoped_method(scope_chain, method, args).await
         }
         "worker" => {
             let server_vk = resolve_key_via_policy(&signing_key, "worker").await?;
-            let client = WorkerClient::for_service(signing_key, server_vk, None);
+            let client = WorkerClient::for_service(signing_key, server_vk, None)?;
             client.call_scoped_method(scope_chain, method, args).await
         }
         _ => bail!("Service '{}' has no scoped methods", service),

--- a/crates/hyprstream/src/cli/shell_handlers.rs
+++ b/crates/hyprstream/src/cli/shell_handlers.rs
@@ -166,7 +166,7 @@ pub async fn handle_shell_tui(
         signing_key.clone(),
         policy_vk,
         None,
-    );
+    )?;
     let model_vk_resp = policy_client.resolve_service_key(
         &crate::services::generated::policy_client::ResolveServiceKey {
             service_name: "model".to_owned(),
@@ -190,7 +190,7 @@ pub async fn handle_shell_tui(
             signing_key.clone(),
             model_server_vk,
             None,
-        )
+        )?
     };
     // Worker client for sandbox/container/image management.
     let worker_client = {
@@ -198,7 +198,7 @@ pub async fn handle_shell_tui(
             signing_key.clone(),
             worker_server_vk,
             None,
-        )
+        )?
     };
     let registry_server_vk = match policy_client.resolve_service_key(
         &crate::services::generated::policy_client::ResolveServiceKey {
@@ -214,7 +214,7 @@ pub async fn handle_shell_tui(
         signing_key.clone(),
         registry_server_vk,
         None,
-    );
+    )?;
 
     let (model_status_tx, mut model_status_rx) =
         tokio::sync::mpsc::channel::<ModelStatusUpdate>(32);
@@ -1688,9 +1688,15 @@ async fn fetch_models(
 
     // Resolve registry + model keys via PolicyClient
     let policy_vk = signing_key.verifying_key();
-    let policy_client = crate::services::PolicyClient::for_service(
+    let policy_client = match crate::services::PolicyClient::for_service(
         signing_key.clone(), policy_vk, None,
-    );
+    ) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("Failed to create PolicyClient: {e}");
+            return Vec::new();
+        }
+    };
     let registry_server_vk = match policy_client.resolve_service_key(
         &crate::services::generated::policy_client::ResolveServiceKey {
             service_name: "registry".to_owned(),
@@ -1725,17 +1731,29 @@ async fn fetch_models(
     let registry_endpoint = hyprstream_rpc::registry::global()
         .endpoint("registry", hyprstream_rpc::registry::SocketKind::Rep)
         .to_zmq_string();
-    let registry: crate::services::RegistryClient = crate::services::RegistryClient::for_endpoint(
+    let registry: crate::services::RegistryClient = match crate::services::RegistryClient::for_endpoint(
         &registry_endpoint,
         signing_key.clone(),
         registry_server_vk,
         None,
-    );
-    let model_client_for_status = crate::services::generated::model_client::ModelClient::for_service(
+    ) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("Failed to create RegistryClient: {e}");
+            return Vec::new();
+        }
+    };
+    let model_client_for_status = match crate::services::generated::model_client::ModelClient::for_service(
         signing_key.clone(),
         model_server_vk,
         None,
-    );
+    ) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("Failed to create ModelClient: {e}");
+            return Vec::new();
+        }
+    };
     let registry_models_dir = models_dir.to_path_buf();
     let status_timeout = std::time::Duration::from_millis(500);
 

--- a/crates/hyprstream/src/cli/training_handlers.rs
+++ b/crates/hyprstream/src/cli/training_handlers.rs
@@ -397,7 +397,7 @@ pub async fn handle_training_infer(
     let policy_vk = signing_key.verifying_key();
     let policy_client = crate::services::PolicyClient::for_service(
         signing_key.clone(), policy_vk, None,
-    );
+    )?;
     let key_resp = policy_client.resolve_service_key(
         &crate::services::generated::policy_client::ResolveServiceKey {
             service_name: "inference".to_owned(),
@@ -411,7 +411,7 @@ pub async fn handle_training_infer(
         signing_key.clone(),
         inference_vk,
         None,
-    );
+    )?;
 
     // Apply chat template
     let messages = vec![ChatMessage { role: "user".into(), content: prompt.into(), tool_calls: vec![], tool_call_id: String::new() }];
@@ -706,7 +706,7 @@ pub async fn handle_training_batch(
     let policy_vk = signing_key.verifying_key();
     let policy_client = crate::services::PolicyClient::for_service(
         signing_key.clone(), policy_vk, None,
-    );
+    )?;
     let key_resp = policy_client.resolve_service_key(
         &crate::services::generated::policy_client::ResolveServiceKey {
             service_name: "inference".to_owned(),
@@ -720,7 +720,7 @@ pub async fn handle_training_batch(
         signing_key.clone(),
         inference_vk,
         None,
-    );
+    )?;
 
     // Get adapter info for checkpoint saves
     let adapter_manager = AdapterManager::new(&model_path);

--- a/crates/hyprstream/src/cli/tui_handlers.rs
+++ b/crates/hyprstream/src/cli/tui_handlers.rs
@@ -32,9 +32,12 @@ pub fn create_tui_client(signing_key: &SigningKey) -> TuiClient {
 
     // Bootstrap: PolicyService uses the root key in inproc mode
     let policy_vk = signing_key.verifying_key();
-    let policy_client = crate::services::PolicyClient::for_service(
+    let policy_client = match crate::services::PolicyClient::for_service(
         sk.clone(), policy_vk, None,
-    );
+    ) {
+        Ok(c) => c,
+        Err(e) => panic!("Failed to create PolicyClient: {e}"),
+    };
     let server_vk = {
         let resp = tokio::task::block_in_place(|| {
             let rt = tokio::runtime::Handle::current();
@@ -56,7 +59,10 @@ pub fn create_tui_client(signing_key: &SigningKey) -> TuiClient {
         }
     };
 
-    TuiClient::for_endpoint(&endpoint, sk, server_vk, None)
+    match TuiClient::for_endpoint(&endpoint, sk, server_vk, None) {
+        Ok(c) => c,
+        Err(e) => panic!("Failed to create TuiClient: {e}"),
+    }
 }
 
 /// Attach to an existing TUI session.

--- a/crates/hyprstream/src/config/server.rs
+++ b/crates/hyprstream/src/config/server.rs
@@ -165,6 +165,12 @@ pub struct ServerConfig {
     #[serde(default = "default_cancellation_check_interval")]
     pub cancellation_check_interval: u64,
 
+    /// Max concurrent server-side streaming responses **per service** — how many
+    /// streaming RPCs one service may actively push data for at once. Bounds the
+    /// streaming-response tasks spawned by the RPC dispatch core (#186).
+    #[serde(default = "default_max_concurrent_streams_per_service")]
+    pub max_concurrent_streams_per_service: usize,
+
     /// Maximum context length for KV cache allocation.
     /// Overrides model's max_position_embeddings to reduce GPU memory.
     /// None = use model's default, Some(n) = cap at n tokens
@@ -236,6 +242,9 @@ fn default_max_concurrent_requests() -> usize {
 fn default_cancellation_check_interval() -> u64 {
     100
 }
+fn default_max_concurrent_streams_per_service() -> usize {
+    hyprstream_rpc::streaming::DEFAULT_MAX_CONCURRENT_STREAMS_PER_SERVICE
+}
 fn default_tls_min_version() -> String {
     "1.2".to_owned()
 }
@@ -253,6 +262,7 @@ impl Default for ServerConfig {
             request_timeout_secs: default_request_timeout_secs(),
             max_concurrent_requests: default_max_concurrent_requests(),
             cancellation_check_interval: default_cancellation_check_interval(),
+            max_concurrent_streams_per_service: default_max_concurrent_streams_per_service(),
             max_context: None, // Use model's default max_position_embeddings
             kv_quant: KVQuantArg::None,
             cors: CorsConfig::default(),

--- a/crates/hyprstream/src/runtime/model_config.rs
+++ b/crates/hyprstream/src/runtime/model_config.rs
@@ -543,13 +543,11 @@ impl ModelConfig {
                     self.rope_theta = 10_000_000.0; // Qwen3.5 uses 10M
                 }
             }
-            ModelArchitecture::Gemma => {
-                if self.vocab_size == 262144 {
-                    self.rope_theta = 1_000_000.0;
-                    self.use_qk_norm = true;
-                    self.scale_embeddings = true;
-                    self.query_pre_attn_scalar = Some(256.0);
-                }
+            ModelArchitecture::Gemma if self.vocab_size == 262144 => {
+                self.rope_theta = 1_000_000.0;
+                self.use_qk_norm = true;
+                self.scale_embeddings = true;
+                self.query_pre_attn_scalar = Some(256.0);
             }
             _ => {}
         }

--- a/crates/hyprstream/src/server/routes/openai.rs
+++ b/crates/hyprstream/src/server/routes/openai.rs
@@ -482,7 +482,13 @@ async fn chat_completions(
             return (StatusCode::INTERNAL_SERVER_ERROR, "Key resolution failed").into_response();
         }
     };
-    let model_client = ModelClient::for_service((*state.signing_key).clone(), model_server_vk, None);
+    let model_client = match ModelClient::for_service((*state.signing_key).clone(), model_server_vk, None) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!("Failed to create ModelClient: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "Client creation failed").into_response();
+        }
+    };
     let _claims = claims_from_auth(&user, jwt_token.as_deref(), jwt_exp);
     // Note: OAI adapter currently creates a fresh client per request.
     // For bearer delegation, use: model_client.request().delegated_bearer(jwt).call(payload)
@@ -711,7 +717,14 @@ async fn stream_chat(state: ServerState, _headers: HeaderMap, request: ChatCompl
                 return;
             }
         };
-        let model_client = ModelClient::for_service((*state.signing_key).clone(), model_server_vk, None);
+        let model_client = match ModelClient::for_service((*state.signing_key).clone(), model_server_vk, None) {
+            Ok(c) => c,
+            Err(e) => {
+                error!("Failed to create ModelClient: {}", e);
+                let _ = tx.send(Err(anyhow::anyhow!("Client creation failed: {}", e))).await;
+                return;
+            }
+        };
         let _claims = claims_from_auth(&user, jwt_token.as_deref(), jwt_exp);
         // Note: For bearer delegation, use: model_client.request().delegated_bearer(jwt).call(payload)
         use crate::services::generated::model_client::InferRpc;
@@ -1059,7 +1072,13 @@ async fn completions(
             return (StatusCode::INTERNAL_SERVER_ERROR, "Key resolution failed").into_response();
         }
     };
-    let model_client = ModelClient::for_service((*state.signing_key).clone(), model_server_vk, None);
+    let model_client = match ModelClient::for_service((*state.signing_key).clone(), model_server_vk, None) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!("Failed to create ModelClient: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "Client creation failed").into_response();
+        }
+    };
     let _claims = claims_from_auth(&user, jwt_token.as_deref(), jwt_exp);
     let result = collect_stream_to_result(&model_client, &request.model, &gen_request).await;
 

--- a/crates/hyprstream/src/services/core.rs
+++ b/crates/hyprstream/src/services/core.rs
@@ -1,6 +1,6 @@
 //! Core service infrastructure — re-exports from `hyprstream-rpc`.
 
-pub use hyprstream_rpc::service::{Continuation, EnvelopeContext, ZmqService};
+pub use hyprstream_rpc::service::{Continuation, EnvelopeContext, RequestService};
 
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::print_stdout)]
@@ -32,7 +32,7 @@ mod tests {
     }
 
     #[async_trait::async_trait(?Send)]
-    impl ZmqService for EchoService {
+    impl RequestService for EchoService {
         async fn handle_request(&self, ctx: &EnvelopeContext, payload: &[u8]) -> Result<(Vec<u8>, Option<crate::services::Continuation>)> {
             let user = ctx.user();
             let mut response = format!("from {}:", user).into_bytes();

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -403,6 +403,26 @@ fn create_streams_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawna
     // PULL backend - publishers connect via PUSH
     let pull_transport = global_registry().endpoint("streams", SocketKind::Push);
 
+    // In-process publish gate: only accept signers attested in the trust store.
+    // Shared by the ZMQ StreamRegister path and the moq in-process plane (M2a).
+    let gate = |pubkey: &[u8; 32]| -> bool {
+        use ed25519_dalek::VerifyingKey;
+        let Ok(vk) = VerifyingKey::from_bytes(pubkey) else {
+            return false;
+        };
+        hyprstream_service::global_trust_store().get(&vk).is_some()
+    };
+
+    // moq-lite streaming origin (epic #134 M2a). A standalone origin is built
+    // here so StreamService holds it and in-process publishers can append to it.
+    // When the iroh substrate is wired into bootstrap (M2b), this origin will be
+    // the substrate's shared `IrohMoqProtocolHandler` origin so external moq
+    // subscribers consume the same tree over the `moql` ALPN.
+    let moq_origin = hyprstream_rpc::moq_stream::MoqStreamOrigin::standalone()
+        .with_prefix("local/streams")
+        .with_authorize_signer(gate)
+        .build();
+
     let stream_service = StreamService::new(
         "streams",
         global_context(),
@@ -410,13 +430,8 @@ fn create_streams_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawna
         pull_transport,
         ctx.verifying_key(),
     )
-    .with_authorize_signer(|pubkey| {
-        use ed25519_dalek::VerifyingKey;
-        let Ok(vk) = VerifyingKey::from_bytes(pubkey) else {
-            return false;
-        };
-        hyprstream_service::global_trust_store().get(&vk).is_some()
-    });
+    .with_authorize_signer(gate)
+    .with_moq_origin(moq_origin);
 
     Ok(Box::new(stream_service))
 }

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -109,7 +109,7 @@ fn register_service_key(
         signing_key.clone(),
         policy_vk,
         Some(jwt.clone()),
-    );
+    )?;
 
     let request = RegisterServiceKey {
         service_name: service_name.to_owned(),
@@ -206,7 +206,13 @@ fn spawn_jwt_renewal_task(
                 (vk, svc_jwt)
             };
 
-            let policy_client = PolicyClient::for_service(signing_key.clone(), policy_vk, Some(current_jwt));
+            let policy_client = match PolicyClient::for_service(signing_key.clone(), policy_vk, Some(current_jwt)) {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::warn!(service = service_name, error = %e, "failed to create PolicyClient; skipping JWT renewal");
+                    continue;
+                }
+            };
             let req = RefreshServiceTokenRequest { ttl_seconds: 2_592_000 };
 
             match policy_client.refresh_service_token(&req).await {
@@ -365,7 +371,7 @@ fn create_registry_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawn
     let policy_vk = hyprstream_service::global_trust_store()
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
-    let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("registry"));
+    let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("registry"))?;
 
     // Create registry service with infrastructure (blocking since we're in sync context)
     let mut registry_service = tokio::task::block_in_place(|| {
@@ -456,7 +462,7 @@ fn create_model_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnabl
     let policy_vk = hyprstream_service::global_trust_store()
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
-    let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("model"));
+    let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("model"))?;
 
     // Create registry client
     let registry_vk = hyprstream_service::global_trust_store()
@@ -466,7 +472,7 @@ fn create_model_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnabl
         sk.clone(),
         registry_vk,
         service_token("model"),
-    );
+    )?;
 
     #[allow(clippy::expect_used)]
     let mut model_service = tokio::task::block_in_place(|| {
@@ -577,7 +583,7 @@ fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
         sk.clone(),
         policy_vk,
         service_token("worker"),
-    );
+    )?;
     worker_service.set_authorize_fn(super::worker::build_authorize_fn(policy_client));
     if let Some(issuer) = ctx.oauth_issuer_url() {
         worker_service.set_expected_audience(issuer.to_owned());
@@ -614,11 +620,11 @@ fn create_oai_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
     let model_vk = hyprstream_service::global_trust_store()
         .resolve_one("model")
         .ok_or_else(|| anyhow::anyhow!("trust store has no model key"))?;
-    let model_client = ModelClient::for_service(sk.clone(), model_vk, service_token("oai"));
+    let model_client = ModelClient::for_service(sk.clone(), model_vk, service_token("oai"))?;
     let policy_vk = hyprstream_service::global_trust_store()
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
-    let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("oai"));
+    let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("oai"))?;
 
     // Create registry client
     let registry_vk = hyprstream_service::global_trust_store()
@@ -628,7 +634,7 @@ fn create_oai_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
         sk.clone(),
         registry_vk,
         service_token("oai"),
-    );
+    )?;
 
     // Create server state (blocking since we're in sync context)
     let resource_url = config.oai.resource_url();
@@ -693,7 +699,7 @@ fn create_flight_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
                 sk.clone(),
                 registry_vk,
                 service_token("flight"),
-            );
+            )?;
             Some(Arc::new(zmq_client))
         } else {
             None
@@ -814,7 +820,7 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
                 ctx.service_signing_key("mcp"),
                 policy_vk,
                 service_token("mcp"),
-            ));
+            )?);
             std::sync::Arc::new(
                 crate::auth::FederationKeyResolver::new(&config.oauth.trusted_issuers)
                     .with_policy_client(fallback_policy_client)
@@ -1062,7 +1068,7 @@ fn create_tui_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
     let policy_vk = hyprstream_service::global_trust_store()
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
-    let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("tui"));
+    let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("tui"))?;
 
     // Build VFS namespace for ChatApps spawned via TUI RPC.
     let (vfs_ns, vfs_subject) = crate::tui::vfs::build_chat_vfs_namespace(&sk)?;
@@ -1105,7 +1111,7 @@ fn create_discovery_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spaw
     let policy_vk = hyprstream_service::global_trust_store()
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
-    let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("discovery"));
+    let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("discovery"))?;
     let auth_provider = crate::services::discovery::PolicyAuthProvider::new(policy_client);
 
     let mut discovery_service = DiscoveryService::new(
@@ -1163,7 +1169,7 @@ fn create_notification_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn S
     let policy_vk = hyprstream_service::global_trust_store()
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
-    let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("notification"));
+    let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("notification"))?;
 
     let mut notification_service = crate::services::NotificationService::new(
         Arc::new(sk),
@@ -1225,7 +1231,7 @@ fn create_metrics_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawna
     let policy_vk = hyprstream_service::global_trust_store()
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
-    let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("metrics"));
+    let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("metrics"))?;
 
     let mut metrics_service = MetricsService::new(
         orchestrator,

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -338,7 +338,6 @@ fn create_policy_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
     let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir();
     let es256_store = crate::auth::key_rotation::global_es256_key_store(&secrets_dir, &config.oauth);
     policy_service = policy_service.with_es256_key_store(es256_store);
-    #[cfg(feature = "pq-hybrid")]
     {
         let ml_dsa_store = crate::auth::key_rotation::global_ml_dsa_key_store(&secrets_dir, &config.oauth);
         policy_service = policy_service.with_ml_dsa_key_store(ml_dsa_store);

--- a/crates/hyprstream/src/services/inference.rs
+++ b/crates/hyprstream/src/services/inference.rs
@@ -2702,74 +2702,94 @@ impl hyprstream_service::Spawnable for InferenceServiceConfig {
         on_ready: Option<tokio::sync::oneshot::Sender<()>>,
     ) -> hyprstream_rpc::error::Result<()> {
         let transport = self.transport.clone();
-        let context = Arc::clone(&self.zmq_context);
-        let signing_key = self.signing_key.clone();
+        let server_signing_key = self.signing_key.clone();
 
-        let rt = tokio::runtime::Builder::new_current_thread()
+        // Post-ZMQ serve (#136): the GPU `InferenceService` is `!Send`, so build it
+        // on a dedicated LocalServiceBridge thread via `spawn_with`, then serve the
+        // resulting processor over the registered transport with `serve_bridged`.
+        // No ZMQ ROUTER. (QUIC is not enabled on this service.)
+        let rt = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()
             .map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(format!("runtime: {e}")))?;
 
-        let local = tokio::task::LocalSet::new();
-        local.block_on(&rt, async move {
-            // Create nonce cache (shared between service and RequestLoop)
+        rt.block_on(async move {
+            // Shared between the bridge dispatch and the InferenceService.
             let nonce_cache = Arc::new(InMemoryNonceCache::new());
+            let bridge_nonce = Arc::clone(&nonce_cache);
 
-            // Bootstrap: Create PolicyClient HERE, inside the service thread's runtime,
-            // so ZMQ sockets are registered with the correct reactor.
-            let policy_vk = match hyprstream_service::global_trust_store().resolve_one("policy") {
-                Some(vk) => vk,
-                None => {
-                    return Err(hyprstream_rpc::error::RpcError::SpawnFailed(
-                        "trust store has no policy key — startup must populate it".to_owned(),
-                    ));
-                }
-            };
-            let policy_client = PolicyClient::for_service(
-                self.policy_signing_key.clone(),
-                policy_vk,
-                None,
-            );
+            // Destructure so the (Send) config moves into the on-thread builder.
+            let InferenceServiceConfig {
+                model_path,
+                config,
+                server_pubkey,
+                signing_key: svc_signing_key,
+                policy_signing_key,
+                zmq_context,
+                transport: _transport,
+                fs,
+                expected_audience,
+                jwt_key_source,
+            } = *self;
+            let adapter_transport = transport.clone();
 
-            // GPU initialization happens HERE, on the service thread
-            let service = InferenceService::initialize(
-                self.model_path,
-                self.config,
-                self.server_pubkey,
-                self.signing_key.clone(),
-                Arc::clone(&nonce_cache),
-                policy_client,
-                self.fs,
+            // Build PolicyClient + GPU service + adapter ON the bridge thread.
+            let (bridge, ready) = hyprstream_rpc::transport::iroh_rpc::LocalServiceBridge::spawn_with(
+                "inference",
+                move || async move {
+                    let policy_vk = hyprstream_service::global_trust_store()
+                        .resolve_one("policy")
+                        .ok_or_else(|| {
+                            anyhow::anyhow!("trust store has no policy key — startup must populate it")
+                        })?;
+                    let policy_client =
+                        PolicyClient::for_service(policy_signing_key, policy_vk, None)?;
+                    let service = InferenceService::initialize(
+                        model_path,
+                        config,
+                        server_pubkey,
+                        svc_signing_key.clone(),
+                        Arc::clone(&bridge_nonce),
+                        policy_client,
+                        fs,
+                    )
+                    .await
+                    .map_err(|e| anyhow::anyhow!("inference init: {e}"))?;
+                    Ok(InferenceZmqAdapter {
+                        service,
+                        zmq_context,
+                        transport: adapter_transport,
+                        signing_key: svc_signing_key,
+                        expected_audience,
+                        jwt_key_source,
+                    })
+                },
+                nonce_cache,
+                0,
+            )
+            .map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(format!("bridge: {e}")))?;
+
+            // Surface GPU-init failure before advertising readiness.
+            ready
+                .await
+                .map_err(|_| {
+                    hyprstream_rpc::error::RpcError::SpawnFailed(
+                        "inference bridge readiness dropped".to_owned(),
+                    )
+                })?
+                .map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(format!("init: {e}")))?;
+
+            let processor: Arc<dyn hyprstream_rpc::transport::rpc_session::IrohRequestProcessor> =
+                Arc::new(bridge);
+            hyprstream_rpc::service::serve::serve_bridged(
+                &transport,
+                processor,
+                server_signing_key,
+                shutdown,
+                on_ready,
             )
             .await
-            .map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(format!("init: {e}")))?;
-
-            // Create RequestService adapter for RequestLoop
-            let adapter = InferenceZmqAdapter {
-                service,
-                zmq_context: context.clone(),
-                transport: transport.clone(),
-                signing_key: signing_key.clone(),
-                expected_audience: self.expected_audience,
-                jwt_key_source: self.jwt_key_source,
-            };
-
-            // Use shared nonce cache between service and RequestLoop
-            let runner = RequestLoop::new(transport, context, signing_key)
-                .with_nonce_cache(nonce_cache);
-            let mut handle = runner.run(adapter).await
-                .map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(format!("loop: {e}")))?;
-
-            if let Some(tx) = on_ready {
-                let _ = tx.send(());
-            }
-
-            // Notify systemd that service is ready (for Type=notify services)
-            let _ = hyprstream_rpc::notify::ready();
-
-            shutdown.notified().await;
-            handle.stop().await;
-            Ok::<_, hyprstream_rpc::error::RpcError>(())
+            .map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(e.to_string()))
         })
     }
 }

--- a/crates/hyprstream/src/services/inference.rs
+++ b/crates/hyprstream/src/services/inference.rs
@@ -2543,15 +2543,15 @@ impl InferenceHandler for InferenceService {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// ZmqService adapter and Spawnable implementation
+// RequestService adapter and Spawnable implementation
 // ═══════════════════════════════════════════════════════════════════════════════
 
-// verify_claims is now handled by the default ZmqService::verify_claims() implementation
+// verify_claims is now handled by the default RequestService::verify_claims() implementation
 // in hyprstream-rpc (E2E JWT verification for all non-local identities).
 
-/// ZmqService adapter for InferenceService.
+/// RequestService adapter for InferenceService.
 ///
-/// Wraps `InferenceService` to implement `ZmqService` for use with `RequestLoop`.
+/// Wraps `InferenceService` to implement `RequestService` for use with `RequestLoop`.
 /// This adapter is created inside `Spawnable::run()` on the service thread —
 /// it never crosses thread boundaries.
 struct InferenceZmqAdapter {
@@ -2564,7 +2564,7 @@ struct InferenceZmqAdapter {
 }
 
 #[async_trait::async_trait(?Send)]
-impl hyprstream_rpc::service::ZmqService for InferenceZmqAdapter {
+impl hyprstream_rpc::service::RequestService for InferenceZmqAdapter {
     async fn handle_request(
         &self,
         ctx: &EnvelopeContext,
@@ -2744,7 +2744,7 @@ impl hyprstream_service::Spawnable for InferenceServiceConfig {
             .await
             .map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(format!("init: {e}")))?;
 
-            // Create ZmqService adapter for RequestLoop
+            // Create RequestService adapter for RequestLoop
             let adapter = InferenceZmqAdapter {
                 service,
                 zmq_context: context.clone(),

--- a/crates/hyprstream/src/services/mcp_service.rs
+++ b/crates/hyprstream/src/services/mcp_service.rs
@@ -428,12 +428,12 @@ fn register_scoped_tools_recursive(
                                     let server_vk = ctx.resolve_peer_key("registry").await?;
                                     let client: RegistryClient = RegistryClient::for_service(
                                         ctx.signing_key, server_vk, None,
-                                    );
+                                    )?;
                                     client.call_scoped_streaming_method(&scope_refs, &method, &ctx.args, client_pubkey_bytes).await?
                                 }
                                 "model" => {
                                     let server_vk = ctx.resolve_peer_key("model").await?;
-                                    let client = ModelClient::for_service(ctx.signing_key, server_vk, None);
+                                    let client = ModelClient::for_service(ctx.signing_key, server_vk, None)?;
                                     client.call_scoped_streaming_method(&scope_refs, &method, &ctx.args, client_pubkey_bytes).await?
                                 }
                                 _ => anyhow::bail!("No scoped streaming dispatch for service: {service}"),
@@ -515,12 +515,12 @@ async fn dispatch_scoped_call(
             let server_vk = ctx.resolve_peer_key("registry").await?;
             let client: RegistryClient = RegistryClient::for_service(
                 ctx.signing_key.clone(), server_vk, None,
-            );
+            )?;
             client.call_scoped_method(scopes, method, &ctx.args).await?
         }
         "model" => {
             let server_vk = ctx.resolve_peer_key("model").await?;
-            let client = ModelClient::for_service(ctx.signing_key.clone(), server_vk, None);
+            let client = ModelClient::for_service(ctx.signing_key.clone(), server_vk, None)?;
             client.call_scoped_method(scopes, method, &ctx.args).await?
         }
         _ => anyhow::bail!("No scoped dispatch for service: {service}"),
@@ -583,17 +583,17 @@ fn register_streaming_tool(
                         let server_vk = ctx.resolve_peer_key("registry").await?;
                         let client: RegistryClient = RegistryClient::for_service(
                             ctx.signing_key, server_vk, None,
-                        );
+                        )?;
                         client.call_streaming_method(&method, &ctx.args, client_pubkey_bytes).await?
                     }
                     "model" => {
                         let server_vk = ctx.resolve_peer_key("model").await?;
-                        let client = ModelClient::for_service(ctx.signing_key, server_vk, None);
+                        let client = ModelClient::for_service(ctx.signing_key, server_vk, None)?;
                         client.call_streaming_method(&method, &ctx.args, client_pubkey_bytes).await?
                     }
                     "tui" => {
                         let server_vk = ctx.resolve_peer_key("tui").await?;
-                        let client = TuiClient::for_service(ctx.signing_key, server_vk, None);
+                        let client = TuiClient::for_service(ctx.signing_key, server_vk, None)?;
                         client.call_streaming_method(&method, &ctx.args, client_pubkey_bytes).await?
                     }
                     _ => anyhow::bail!("No streaming support for service: {}", service),
@@ -676,24 +676,24 @@ async fn dispatch_schema_call(service: &str, method: &str, ctx: &ToolCallContext
     match service {
         "model" => {
             let server_vk = ctx.resolve_peer_key("model").await?;
-            let client = ModelClient::for_service(signing_key, server_vk, None);
+            let client = ModelClient::for_service(signing_key, server_vk, None)?;
             client.call_method(method, &ctx.args).await
         }
         "registry" => {
             let server_vk = ctx.resolve_peer_key("registry").await?;
             let client: RegistryClient = RegistryClient::for_service(
                 signing_key, server_vk, None,
-            );
+            )?;
             client.call_method(method, &ctx.args).await
         }
         "policy" => {
             let server_vk = ctx.resolve_peer_key("policy").await?;
-            let client = PolicyClient::for_service(signing_key, server_vk, None);
+            let client = PolicyClient::for_service(signing_key, server_vk, None)?;
             client.call_method(method, &ctx.args).await
         }
         "tui" => {
             let server_vk = ctx.resolve_peer_key("tui").await?;
-            let client = TuiClient::for_service(signing_key, server_vk, None);
+            let client = TuiClient::for_service(signing_key, server_vk, None)?;
             client.call_method(method, &ctx.args).await
         }
         _ => anyhow::bail!("Unknown service: {service}"),
@@ -743,7 +743,7 @@ impl McpService {
             config.signing_key.clone(),
             config.policy_verifying_key,
             None,
-        );
+        )?;
 
         Ok(Self {
             registry: Arc::new(RwLock::new(tool_reg)),
@@ -1039,7 +1039,7 @@ impl McpHandler for McpService {
                 self.signing_key.clone(),
                 server_vk,
                 None,
-            );
+            )?;
             client.status(&crate::services::generated::model_client::StatusRequest { model_ref: String::new() }).await
                 .map(|models| models.len() as u32)
                 .unwrap_or(0)

--- a/crates/hyprstream/src/services/mcp_service.rs
+++ b/crates/hyprstream/src/services/mcp_service.rs
@@ -34,7 +34,7 @@ use ed25519_dalek::{SigningKey, VerifyingKey};
 use futures::future::BoxFuture;
 use hyprstream_rpc::auth::jwt;
 use hyprstream_service::ServiceContext;
-use hyprstream_rpc::service::ZmqService;
+use hyprstream_rpc::service::RequestService;
 use hyprstream_rpc::streaming::{StreamHandle, StreamPayload};
 use hyprstream_rpc::transport::TransportConfig;
 use rmcp::{
@@ -712,7 +712,7 @@ pub struct McpService {
     stdio_token: Option<String>,
     /// Verifying key for JWT validation
     verifying_key: VerifyingKey,
-    // === ZmqService infrastructure ===
+    // === RequestService infrastructure ===
     context: Arc<zmq::Context>,
     transport: TransportConfig,
     signing_key: SigningKey,
@@ -1136,11 +1136,11 @@ impl McpHandler for McpService {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// ZmqService Implementation (internal control plane)
+// RequestService Implementation (internal control plane)
 // ═══════════════════════════════════════════════════════════════════════════════
 
 #[async_trait(?Send)]
-impl ZmqService for McpService {
+impl RequestService for McpService {
     async fn handle_request(&self, ctx: &crate::services::EnvelopeContext, payload: &[u8]) -> anyhow::Result<(Vec<u8>, Option<crate::services::Continuation>)> {
         trace!(
             "McpService request from {} (id={})",

--- a/crates/hyprstream/src/services/metrics.rs
+++ b/crates/hyprstream/src/services/metrics.rs
@@ -21,7 +21,7 @@ use hyprstream_rpc::streaming::StreamChannel;
 use hyprstream_rpc::transport::TransportConfig;
 use tracing::{error, trace};
 
-use crate::services::{Continuation, EnvelopeContext, PolicyClient, ZmqService};
+use crate::services::{Continuation, EnvelopeContext, PolicyClient, RequestService};
 use crate::services::generated::policy_client::PolicyCheck;
 use crate::services::generated::metrics_client::{
     MetricsHandler, MetricsResponseVariant,
@@ -585,11 +585,11 @@ impl MetricsHandler for MetricsService {
 }
 
 // ============================================================================
-// ZmqService
+// RequestService
 // ============================================================================
 
 #[async_trait(?Send)]
-impl ZmqService for MetricsService {
+impl RequestService for MetricsService {
     async fn handle_request(
         &self,
         ctx: &EnvelopeContext,

--- a/crates/hyprstream/src/services/metrics.rs
+++ b/crates/hyprstream/src/services/metrics.rs
@@ -695,7 +695,7 @@ mod tests {
             signing_key.clone(),
             signing_key.verifying_key(),
             None,
-        );
+        ).expect("create policy client");
 
         // In-memory DuckDB backend + metrics table creation.
         let backend = Arc::new(
@@ -735,7 +735,7 @@ mod tests {
             signing_key.clone(),
             signing_key.verifying_key(),
             None,
-        );
+        ).expect("create metrics client");
 
         (client, manager)
     }

--- a/crates/hyprstream/src/services/mod.rs
+++ b/crates/hyprstream/src/services/mod.rs
@@ -15,7 +15,7 @@
 //! ```text
 //! ┌─────────────────────────────────────────────────────────────┐
 //! │  hyprstream/src/services/                                   │
-//! │  ├── core.rs      ← ZmqService trait, runners, clients     │
+//! │  ├── core.rs      ← RequestService trait, runners, clients     │
 //! │  ├── types.rs     ← Shared types (FsDirEntry, ModelInfo, etc.)│
 //! │  ├── registry.rs  ← Registry service (REP) + client (REQ)  │
 //! │  └── inference.rs ← Inference service (REP) + client (REQ) │
@@ -24,11 +24,11 @@
 //!
 //! # Usage
 //!
-//! Services implement `ZmqService` with infrastructure methods and are automatically
+//! Services implement `RequestService` with infrastructure methods and are automatically
 //! `Spawnable` via blanket impl:
 //!
 //! ```rust,ignore
-//! use crate::services::{EnvelopeContext, ZmqService};
+//! use crate::services::{EnvelopeContext, RequestService};
 //! use hyprstream_rpc::prelude::*;
 //! use hyprstream_rpc::service::{InprocManager, ServiceManager, Spawnable};
 //! use hyprstream_rpc::transport::TransportConfig;
@@ -41,7 +41,7 @@
 //!     verifying_key: VerifyingKey,
 //! }
 //!
-//! impl ZmqService for MyService {
+//! impl RequestService for MyService {
 //!     fn handle_request(&self, ctx: &EnvelopeContext, payload: &[u8]) -> Result<(Vec<u8>, Option<Continuation>)> {
 //!         // ctx.identity is already verified
 //!         println!("Request from: {}", ctx.subject());
@@ -95,7 +95,7 @@ pub mod typed;
 pub mod worker;
 
 pub use core::{
-    Continuation, EnvelopeContext, ZmqService,
+    Continuation, EnvelopeContext, RequestService,
 };
 
 // Generated client types — the public API

--- a/crates/hyprstream/src/services/model.rs
+++ b/crates/hyprstream/src/services/model.rs
@@ -390,7 +390,7 @@ impl ModelService {
         let fs: Option<crate::services::WorktreeClient> = Some(repo_client.worktree(&branch_name));
 
         // Start InferenceService for this model via standard Spawnable infrastructure
-        let zmq_ctx = Arc::clone(hyprstream_rpc::ZmqService::context(self));
+        let zmq_ctx = Arc::clone(hyprstream_rpc::RequestService::context(self));
         let spawner = hyprstream_service::ServiceSpawner::threaded();
 
         let transport = hyprstream_rpc::transport::TransportConfig::from_endpoint(&endpoint);
@@ -1297,11 +1297,11 @@ impl ModelService {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// ZmqService Implementation — delegates to generated dispatch_model
+// RequestService Implementation — delegates to generated dispatch_model
 // ═══════════════════════════════════════════════════════════════════════════════
 
 #[async_trait(?Send)]
-impl crate::services::ZmqService for ModelService {
+impl crate::services::RequestService for ModelService {
     async fn handle_request(&self, ctx: &EnvelopeContext, payload: &[u8]) -> Result<(Vec<u8>, Option<crate::services::Continuation>)> {
         debug!(
             "Model request from {} (id={})",

--- a/crates/hyprstream/src/services/model.rs
+++ b/crates/hyprstream/src/services/model.rs
@@ -204,7 +204,7 @@ impl ModelService {
             signing_key.clone(),
             notif_vk,
             None,
-        );
+        )?;
         let notification_publisher = NotificationPublisher::new(notif_client, signing_key.clone());
 
         Ok(Self { inner: Arc::new(ModelServiceInner {
@@ -282,7 +282,7 @@ impl ModelService {
             signing_key.clone(),
             notif_vk,
             None,
-        );
+        )?;
         let notification_publisher = NotificationPublisher::new(notif_client, signing_key.clone());
 
         Ok(Self { inner: Arc::new(ModelServiceInner {
@@ -420,7 +420,7 @@ impl ModelService {
             self.signing_key.clone(),
             self.signing_key.verifying_key(),
             None,
-        );
+        )?;
 
         // Load TTT config from model's config.json (if TTT is enabled)
         let ttt_config = crate::runtime::model_config::ModelConfig::load_training_config(&model_path)

--- a/crates/hyprstream/src/services/notification.rs
+++ b/crates/hyprstream/src/services/notification.rs
@@ -31,7 +31,7 @@ use parking_lot::RwLock;
 use tracing::{debug, error, trace, warn};
 use uuid::Uuid;
 
-use crate::services::{Continuation, EnvelopeContext, PolicyClient, ZmqService};
+use crate::services::{Continuation, EnvelopeContext, PolicyClient, RequestService};
 use crate::services::generated::policy_client::PolicyCheck;
 use crate::services::generated::notification_client::{
     NotificationClient, NotificationHandler, NotificationResponseVariant,
@@ -766,11 +766,11 @@ impl NotificationHandler for NotificationService {
 }
 
 // ============================================================================
-// ZmqService implementation
+// RequestService implementation
 // ============================================================================
 
 #[async_trait(?Send)]
-impl ZmqService for NotificationService {
+impl RequestService for NotificationService {
     async fn handle_request(
         &self,
         ctx: &EnvelopeContext,

--- a/crates/hyprstream/src/services/oauth/did_document.rs
+++ b/crates/hyprstream/src/services/oauth/did_document.rs
@@ -12,6 +12,14 @@
 //! the `Ed25519VerificationKey2020` verification-method type (Multibase z6Mk
 //! encoding per the spec).
 //!
+//! The **root** document is additionally **atproto-compatible** (#154): when an
+//! ES256 key store is present it carries a P-256 `#atproto` `Multikey`, an
+//! `#atproto_pds` service, and `alsoKnownAs at://{handle}` — the shape existing
+//! atproto resolvers expect. Our Ed25519 mesh verification method and any typed
+//! transport `service` entries (IrohTransport/QuicTransport/OnionTransport) are
+//! **optional, additive**, and ignored by atproto (which matches by id/type).
+//! P-256 satisfies atproto (it accepts p256/k256); k256 is not used.
+//!
 //! The format produced here matches the architecture-doc Subject Identity
 //! Format section and is consumed by:
 //!   - Federation peers verifying did:web subjects in tokens
@@ -58,6 +66,66 @@ fn ed25519_to_multibase(vk: &VerifyingKey) -> String {
     format!("z{}", bs58::encode(payload).into_string())
 }
 
+/// Extract the origin (scheme://authority) from the OAuth issuer URL.
+///
+/// atproto's `#atproto_pds` serviceEndpoint must be an origin only — scheme,
+/// host, optional port — with no path. (atproto/specs/did)
+fn issuer_origin(issuer_url: &str) -> Option<String> {
+    let (scheme, rest) = issuer_url.split_once("://")?;
+    let authority = rest.split('/').next().unwrap_or(rest);
+    if authority.is_empty() {
+        None
+    } else {
+        Some(format!("{scheme}://{authority}"))
+    }
+}
+
+/// Build the multibase z-encoded P-256 public key per the `Multikey` /
+/// did:key conventions used by atproto.
+///
+/// Multibase prefix `z` (base58btc); payload is the multicodec `p256-pub`
+/// unsigned-varint header (`0x1200` → bytes `0x80 0x24`) followed by the
+/// **compressed** SEC1 point (33 bytes). atproto requires compressed pubkeys.
+fn p256_to_multibase(vk: &p256::ecdsa::VerifyingKey) -> String {
+    let point = vk.to_encoded_point(true); // compressed
+    let compressed = point.as_bytes();
+    let mut payload = Vec::with_capacity(2 + compressed.len());
+    payload.push(0x80);
+    payload.push(0x24);
+    payload.extend_from_slice(compressed);
+    format!("z{}", bs58::encode(payload).into_string())
+}
+
+/// The node's atproto-native identity to embed in the root DID document:
+/// the P-256 signing key (published as the `#atproto` Multikey) plus the
+/// account handle (published in `alsoKnownAs` as `at://{handle}`).
+pub struct AtprotoIdentity<'a> {
+    pub p256_vk: &'a p256::ecdsa::VerifyingKey,
+    pub handle: &'a str,
+}
+
+/// An optional, additive transport endpoint advertised as a typed `service`
+/// entry (DIDComm-style map). atproto resolvers ignore these; the mesh dial
+/// resolves by `service.type`.
+pub struct TransportEndpoint {
+    /// Fragment id, e.g. `"iroh"` → `{did}#iroh`.
+    pub fragment: String,
+    /// Service `type`, e.g. `"IrohTransport"`.
+    pub vm_type: String,
+    /// The `serviceEndpoint` map (e.g. `{ "uri": ..., "accept": [...] }`).
+    pub endpoint: Value,
+}
+
+/// Build the atproto `#atproto` verification method (P-256 `Multikey`).
+fn atproto_verification_method(did: &str, vk: &p256::ecdsa::VerifyingKey) -> Value {
+    json!({
+        "id": format!("{did}#atproto"),
+        "type": "Multikey",
+        "controller": did,
+        "publicKeyMultibase": p256_to_multibase(vk),
+    })
+}
+
 /// Build the verification-method JSON for a single Ed25519 key under a
 /// did:web subject.
 fn ed25519_verification_method(did: &str, key_id: &str, vk: &VerifyingKey) -> Value {
@@ -88,39 +156,87 @@ fn ed25519_verification_method_jwk(did: &str, key_id: &str, vk: &VerifyingKey) -
 ///
 /// `did` is the full did:web identifier; `keys` is the ordered list of
 /// `(key_id, VerifyingKey)` pairs to include as verification methods.
+/// `atproto` (when `Some`) makes this an atproto-compatible identity document:
+/// the P-256 `#atproto` Multikey is listed FIRST in `verificationMethod`, an
+/// `#atproto_pds` service is added FIRST in `service`, and `alsoKnownAs` carries
+/// `at://{handle}`. The Ed25519 `keys` remain as additional (mesh) verification
+/// methods, and `transports` are additional typed `service` entries — both are
+/// ignored by atproto resolvers (which match by id/type) but used by our mesh.
 fn build_did_document(
     did: &str,
     issuer_url: &str,
     keys: &[(String, VerifyingKey)],
+    atproto: Option<&AtprotoIdentity<'_>>,
+    transports: &[TransportEndpoint],
 ) -> Value {
-    let mut verification_methods = Vec::with_capacity(keys.len() * 2);
-    let mut authentication_refs = Vec::with_capacity(keys.len() * 2);
+    let mut verification_methods = Vec::with_capacity(keys.len() * 2 + 1);
+    let mut authentication_refs = Vec::with_capacity(keys.len() * 2 + 1);
+    let mut assertion_refs = Vec::with_capacity(keys.len() * 2 + 1);
 
+    // atproto signing key FIRST (atproto takes the first matching entry).
+    if let Some(at) = atproto {
+        verification_methods.push(atproto_verification_method(did, at.p256_vk));
+        let atproto_vm_id = format!("{did}#atproto");
+        authentication_refs.push(Value::String(atproto_vm_id.clone()));
+        assertion_refs.push(Value::String(atproto_vm_id));
+    }
+
+    // Ed25519 mesh / OAuth verification methods (multibase + JWK).
     for (key_id, vk) in keys {
         let vm_id = format!("{did}#{key_id}");
         let vm_id_jwk = format!("{did}#{key_id}-jwk");
         verification_methods.push(ed25519_verification_method(did, key_id, vk));
         verification_methods.push(ed25519_verification_method_jwk(did, key_id, vk));
-        authentication_refs.push(Value::String(vm_id));
-        authentication_refs.push(Value::String(vm_id_jwk));
+        authentication_refs.push(Value::String(vm_id.clone()));
+        authentication_refs.push(Value::String(vm_id_jwk.clone()));
+        assertion_refs.push(Value::String(vm_id));
+        assertion_refs.push(Value::String(vm_id_jwk));
     }
 
-    json!({
+    // Services: atproto PDS first, then the legacy HyprstreamService, then any
+    // typed transport endpoints (optional, atproto-ignored).
+    let mut services = Vec::with_capacity(2 + transports.len());
+    if atproto.is_some() {
+        if let Some(origin) = issuer_origin(issuer_url) {
+            services.push(json!({
+                "id": format!("{did}#atproto_pds"),
+                "type": "AtprotoPersonalDataServer",
+                "serviceEndpoint": origin,
+            }));
+        }
+    }
+    services.push(json!({
+        "id": format!("{did}#hyprstream"),
+        "type": "HyprstreamService",
+        "serviceEndpoint": issuer_url,
+    }));
+    for t in transports {
+        services.push(json!({
+            "id": format!("{did}#{}", t.fragment),
+            "type": t.vm_type,
+            "serviceEndpoint": t.endpoint,
+        }));
+    }
+
+    let mut doc = json!({
         "@context": [
             "https://www.w3.org/ns/did/v1",
+            "https://w3id.org/security/multikey/v1",
             "https://w3id.org/security/suites/ed25519-2020/v1",
             "https://w3id.org/security/suites/jws-2020/v1",
         ],
         "id": did,
         "verificationMethod": verification_methods,
         "authentication": authentication_refs,
-        "assertionMethod": authentication_refs,
-        "service": [{
-            "id": format!("{did}#hyprstream"),
-            "type": "HyprstreamService",
-            "serviceEndpoint": issuer_url,
-        }],
-    })
+        "assertionMethod": assertion_refs,
+        "service": services,
+    });
+
+    if let Some(at) = atproto {
+        doc["alsoKnownAs"] = json!([format!("at://{}", at.handle)]);
+    }
+
+    doc
 }
 
 /// `GET /.well-known/did.json` — root deployment DID document.
@@ -149,7 +265,32 @@ pub async fn root_did_document(
     };
     let vk = sk.verifying_key();
 
-    let doc = build_did_document(&did, &state.issuer_url, &[("key-1".to_owned(), vk)]);
+    // atproto-native identity: the active P-256 key from the ES256 rotation
+    // store becomes the `#atproto` Multikey; the issuer authority is the handle.
+    let atproto_sk = match state.es256_key_store.as_ref() {
+        Some(store) => store.active_key().await,
+        None => None,
+    };
+    // The atproto handle is a bare hostname (no port); strip any port the
+    // authority carries (the DID identifier keeps the port, the handle does not).
+    let handle = authority.split(':').next().unwrap_or(authority.as_str());
+    let atproto_vk = atproto_sk.as_ref().map(|sk| sk.verifying_key());
+    let atproto = atproto_vk.map(|vk| AtprotoIdentity {
+        p256_vk: vk,
+        handle,
+    });
+
+    // Transport `service` entries are populated by the addressing layer (#151
+    // dial endpoints) once available; empty until then.
+    let transports: Vec<TransportEndpoint> = Vec::new();
+
+    let doc = build_did_document(
+        &did,
+        &state.issuer_url,
+        &[("key-1".to_owned(), vk)],
+        atproto.as_ref(),
+        &transports,
+    );
     (
         StatusCode::OK,
         [(header::CONTENT_TYPE, "application/did+json")],
@@ -201,7 +342,7 @@ pub async fn user_did_document(
         None => Vec::new(),
     };
 
-    let doc = build_did_document(&did, &state.issuer_url, &keys);
+    let doc = build_did_document(&did, &state.issuer_url, &keys, None, &[]);
     (
         StatusCode::OK,
         [(header::CONTENT_TYPE, "application/did+json")],
@@ -240,7 +381,7 @@ pub async fn client_did_document(
     // lookup + extract_ed25519_keys_from_jwks call.
     let keys: Vec<(String, VerifyingKey)> = Vec::new();
 
-    let doc = build_did_document(&did, &state.issuer_url, &keys);
+    let doc = build_did_document(&did, &state.issuer_url, &keys, None, &[]);
     (
         StatusCode::OK,
         [(header::CONTENT_TYPE, "application/did+json")],
@@ -340,6 +481,8 @@ mod tests {
             did,
             "https://hyprstream.example.com",
             &[("key-1".to_owned(), sk.verifying_key())],
+            None,
+            &[],
         );
         assert_eq!(doc["id"].as_str().unwrap(), did);
         assert!(doc["@context"].is_array());
@@ -354,10 +497,70 @@ mod tests {
     #[test]
     fn build_did_doc_empty_keys_is_valid() {
         let did = "did:web:example.com:users:alice";
-        let doc = build_did_document(did, "https://example.com", &[]);
+        let doc = build_did_document(did, "https://example.com", &[], None, &[]);
         assert_eq!(doc["id"].as_str().unwrap(), did);
         assert_eq!(doc["verificationMethod"].as_array().unwrap().len(), 0);
         assert_eq!(doc["authentication"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn p256_multibase_format() {
+        let sk = p256::ecdsa::SigningKey::random(&mut OsRng);
+        let mb = p256_to_multibase(sk.verifying_key());
+        assert!(mb.starts_with('z'), "must use base58btc multibase prefix");
+        let decoded = bs58::decode(&mb[1..]).into_vec().unwrap();
+        // multicodec p256-pub = 0x1200 → unsigned-varint [0x80, 0x24].
+        assert_eq!(decoded[0], 0x80);
+        assert_eq!(decoded[1], 0x24);
+        // Compressed SEC1 point: 33 bytes, leading 0x02/0x03.
+        assert_eq!(decoded.len(), 2 + 33);
+        assert!(decoded[2] == 0x02 || decoded[2] == 0x03);
+    }
+
+    #[test]
+    fn build_did_doc_atproto_identity() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let p256_sk = p256::ecdsa::SigningKey::random(&mut OsRng);
+        let p256_vk = p256_sk.verifying_key();
+        let did = "did:web:hyprstream.example.com";
+        let atproto = AtprotoIdentity { p256_vk, handle: "hyprstream.example.com" };
+        let transports = [TransportEndpoint {
+            fragment: "iroh".to_owned(),
+            vm_type: "IrohTransport".to_owned(),
+            endpoint: json!({ "uri": "iroh:abc", "accept": ["hyprstream-rpc/1", "moql"] }),
+        }];
+        let doc = build_did_document(
+            did,
+            // issuer URL with a path — origin must strip it for #atproto_pds.
+            "https://hyprstream.example.com/oauth",
+            &[("key-1".to_owned(), ed.verifying_key())],
+            Some(&atproto),
+            &transports,
+        );
+
+        // #atproto Multikey is FIRST and p256.
+        let vms = doc["verificationMethod"].as_array().unwrap();
+        assert_eq!(vms[0]["id"].as_str().unwrap(), format!("{did}#atproto"));
+        assert_eq!(vms[0]["type"].as_str().unwrap(), "Multikey");
+        assert!(vms[0]["publicKeyMultibase"].as_str().unwrap().starts_with('z'));
+        // Ed25519 mesh VMs still present after it.
+        assert_eq!(vms.len(), 1 + 2);
+
+        // #atproto_pds first, origin-only (no path), correct type.
+        let svcs = doc["service"].as_array().unwrap();
+        assert_eq!(svcs[0]["id"].as_str().unwrap(), format!("{did}#atproto_pds"));
+        assert_eq!(svcs[0]["type"].as_str().unwrap(), "AtprotoPersonalDataServer");
+        assert_eq!(
+            svcs[0]["serviceEndpoint"].as_str().unwrap(),
+            "https://hyprstream.example.com"
+        );
+        // transport entry present as a typed map service.
+        let iroh = svcs.iter().find(|s| s["type"] == "IrohTransport").unwrap();
+        assert_eq!(iroh["id"].as_str().unwrap(), format!("{did}#iroh"));
+        assert!(iroh["serviceEndpoint"]["accept"].is_array());
+
+        // alsoKnownAs handle.
+        assert_eq!(doc["alsoKnownAs"][0].as_str().unwrap(), "at://hyprstream.example.com");
     }
 
     #[test]

--- a/crates/hyprstream/src/services/oauth/dpop.rs
+++ b/crates/hyprstream/src/services/oauth/dpop.rs
@@ -27,9 +27,7 @@ use subtle::ConstantTimeEq;
 pub enum DpopKey {
     Ed25519 { bytes: [u8; 32] },
     Es256 { x: [u8; 32], y: [u8; 32] },
-    #[cfg(feature = "pq-hybrid")]
     MlDsa65 { pub_bytes: Vec<u8> },
-    #[cfg(feature = "pq-hybrid")]
     MlDsa65Ed25519 { pub_bytes: Vec<u8> },
 }
 
@@ -42,11 +40,9 @@ impl DpopKey {
             DpopKey::Es256 { x, y } => {
                 jwk_thumbprint(&JwkThumbprintInput::Es256 { x, y })
             }
-            #[cfg(feature = "pq-hybrid")]
             DpopKey::MlDsa65 { pub_bytes } => {
                 jwk_thumbprint(&JwkThumbprintInput::Akp { alg: "ML-DSA-65", pub_bytes })
             }
-            #[cfg(feature = "pq-hybrid")]
             DpopKey::MlDsa65Ed25519 { pub_bytes } => {
                 jwk_thumbprint(&JwkThumbprintInput::Akp { alg: "ML-DSA-65-Ed25519", pub_bytes })
             }
@@ -163,8 +159,7 @@ pub fn verify_dpop_proof(
         let (x, y) = extract_p256_key(jwk)?;
         verify_es256(&x, &y, signing_input.as_bytes(), &sig_bytes)?;
         DpopKey::Es256 { x, y }
-    } else if cfg!(feature = "pq-hybrid") && alg == "ML-DSA-65" {
-        #[cfg(feature = "pq-hybrid")]
+    } else if alg == "ML-DSA-65" {
         {
             let pub_bytes = extract_akp_pub(jwk)?;
             let vk = hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(&pub_bytes)
@@ -173,10 +168,7 @@ pub fn verify_dpop_proof(
                 .map_err(|_| DpopError::SignatureInvalid)?;
             DpopKey::MlDsa65 { pub_bytes }
         }
-        #[cfg(not(feature = "pq-hybrid"))]
-        return Err(DpopError::WrongAlg(alg.to_owned()))
-    } else if cfg!(feature = "pq-hybrid") && alg == "ML-DSA-65-Ed25519" {
-        #[cfg(feature = "pq-hybrid")]
+    } else if alg == "ML-DSA-65-Ed25519" {
         {
             let pub_bytes = extract_akp_pub(jwk)?;
             // Composite: ML-DSA-65 vk (1952) + Ed25519 vk (32) = 1984
@@ -203,8 +195,6 @@ pub fn verify_dpop_proof(
                 .map_err(|_| DpopError::SignatureInvalid)?;
             DpopKey::MlDsa65Ed25519 { pub_bytes }
         }
-        #[cfg(not(feature = "pq-hybrid"))]
-        return Err(DpopError::WrongAlg(alg.to_owned()))
     } else {
         return Err(DpopError::WrongAlg(alg.to_owned()));
     };
@@ -298,7 +288,6 @@ fn extract_p256_key(jwk: &serde_json::Value) -> Result<([u8; 32], [u8; 32]), Dpo
     Ok((x_bytes, y_bytes))
 }
 
-#[cfg(feature = "pq-hybrid")]
 fn extract_akp_pub(jwk: &serde_json::Value) -> Result<Vec<u8>, DpopError> {
     if jwk["kty"].as_str() != Some("AKP") {
         return Err(DpopError::InvalidJwk);
@@ -435,10 +424,9 @@ mod dpop_nonce_tests {
 
 /// Regression test: take a JWT-style DPoP proof signed with a composite alg,
 /// strip the ML-DSA-65 sig half, confirm `verify_dpop_proof` rejects.
-#[cfg(all(test, feature = "pq-hybrid"))]
+#[cfg(test)]
 mod dpop_stripping_tests {
     use super::*;
-    use base64::Engine as _;
     use ed25519_dalek::Signer as _;
 
     #[test]

--- a/crates/hyprstream/src/services/oauth/federation_entity.rs
+++ b/crates/hyprstream/src/services/oauth/federation_entity.rs
@@ -115,7 +115,6 @@ pub async fn build_entity_configuration_jwt(state: &OAuthState) -> Result<String
     }
 
     // ML-DSA-65 keys from rotation store.
-    #[cfg(feature = "pq-hybrid")]
     if let Some(ref store) = state.ml_dsa_key_store {
         for slot in store.all_slots_snapshot().await {
             let ml_vk = ml_dsa::Keypair::verifying_key(&*slot.key);

--- a/crates/hyprstream/src/services/oauth/jwks.rs
+++ b/crates/hyprstream/src/services/oauth/jwks.rs
@@ -91,7 +91,6 @@ pub async fn jwks(State(state): State<Arc<OAuthState>>) -> impl IntoResponse {
     }
 
     // ML-DSA-65 from rotation store — publish all slots + composite pairing
-    #[cfg(feature = "pq-hybrid")]
     if let Some(ref store) = state.ml_dsa_key_store {
         for slot in store.all_slots_snapshot().await {
             let vk = ml_dsa::Keypair::verifying_key(&*slot.key);

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -446,12 +446,10 @@ impl Spawnable for OAuthService {
             );
             info!("ES256 (P-256) signing key rotation store loaded");
 
-            #[cfg(feature = "pq-hybrid")]
             let ml_dsa_store = crate::auth::key_rotation::global_ml_dsa_key_store(
                 &secrets_dir,
                 &self.config,
             );
-            #[cfg(feature = "pq-hybrid")]
             info!("ML-DSA-65 signing key rotation store loaded");
 
             let (ca_jwt_key, signing_key_store) = match crate::auth::identity_store::load_ca_signing_key(&credentials_dir) {
@@ -473,7 +471,6 @@ impl Spawnable for OAuthService {
                         Arc::clone(&store_arc),
                         crate::auth::key_rotation::RotationStores {
                             es256: Some(Arc::clone(&es256_store)),
-                            #[cfg(feature = "pq-hybrid")]
                             ml_dsa: Some(Arc::clone(&ml_dsa_store)),
                         },
                     );
@@ -513,7 +510,6 @@ impl Spawnable for OAuthService {
                 oauth_state = oauth_state.with_signing_key_store(store);
             }
             oauth_state = oauth_state.with_es256_key_store(Arc::clone(&es256_store));
-            #[cfg(feature = "pq-hybrid")]
             {
                 oauth_state = oauth_state.with_ml_dsa_key_store(Arc::clone(&ml_dsa_store));
             }

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -70,7 +70,7 @@ use axum::{
     Router,
 };
 use hyprstream_rpc::registry::SocketKind;
-use hyprstream_rpc::service::{RequestLoop, ZmqService};
+use hyprstream_rpc::service::{RequestLoop, RequestService};
 use hyprstream_rpc::transport::TransportConfig;
 use hyprstream_service::Spawnable;
 use tokio::sync::Notify;
@@ -655,9 +655,9 @@ impl Spawnable for OAuthService {
                     zmq_transport,
                     zmq_signing_key,
                 );
-                let zmq_transport = ZmqService::transport(&handler).clone();
-                let zmq_context = Arc::clone(ZmqService::context(&handler));
-                let zmq_signing_key = ZmqService::signing_key(&handler);
+                let zmq_transport = RequestService::transport(&handler).clone();
+                let zmq_context = Arc::clone(RequestService::context(&handler));
+                let zmq_signing_key = RequestService::signing_key(&handler);
                 let loop_ = RequestLoop::new(zmq_transport, zmq_context, zmq_signing_key);
                 if let Err(e) = loop_.run(handler).await {
                     tracing::error!("OAuth ZMQ loop error: {}", e);

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -688,8 +688,11 @@ impl Spawnable for OAuthService {
             // Run HTTP(S) server with graceful shutdown
             let _ = crate::server::tls::serve_app(addr, app, rustls_config, shutdown, "OAuthService").await;
 
-            // HTTP server stopped — stop the RPC serve and join it.
-            serve_shutdown.notify_waiters();
+            // HTTP server stopped — stop the RPC serve and join it. notify_one
+            // (not notify_waiters) stores a permit if the serve task hasn't yet
+            // armed its `notified()` await, so the signal can't be missed even if
+            // the HTTP server exited before the RPC task reached serve_bridged.
+            serve_shutdown.notify_one();
             let _ = rpc_loop.await;
 
             Ok(())

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -70,7 +70,6 @@ use axum::{
     Router,
 };
 use hyprstream_rpc::registry::SocketKind;
-use hyprstream_rpc::service::{RequestLoop, RequestService};
 use hyprstream_rpc::transport::TransportConfig;
 use hyprstream_service::Spawnable;
 use tokio::sync::Notify;
@@ -360,7 +359,9 @@ impl Spawnable for OAuthService {
                 self.signing_key.clone(),
                 policy_vk,
                 None,
-            );
+            ).map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(
+                format!("failed to create PolicyClient: {e}"),
+            ))?;
 
             // Get discovery key from trust store (populated by depends_on = ["discovery"]).
             // Using trust store avoids RPC calls which require LocalSet context.
@@ -376,7 +377,9 @@ impl Spawnable for OAuthService {
                 self.signing_key.clone(),
                 discovery_vk,
                 None,
-            );
+            ).map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(
+                format!("failed to create DiscoveryClient: {e}"),
+            ))?;
 
             let credentials_dir = crate::config::HyprConfig::load()
                 .map(|c| c.config_dir().join("credentials"))
@@ -638,32 +641,56 @@ impl Spawnable for OAuthService {
 
             let _ = hyprstream_rpc::notify::ready();
 
-            // ZMQ RPC loop for user CRUD (alongside HTTP server)
-            // Must use spawn_local because RequestLoop uses spawn_local internally
-            let zmq_transport = self.control_transport.clone();
-            let zmq_context = Arc::clone(&self.context);
-            let zmq_signing_key = self.signing_key.clone();
-            let zmq_state = state.clone();
-            let zmq_loop = tokio::task::spawn_local(async move {
+            // User-CRUD RPC serve, alongside the HTTP server. #136: bridged
+            // dispatch over the registered transport (inproc/ipc) instead of the
+            // ZMQ ROUTER. A dedicated `serve_shutdown` stops it once the HTTP
+            // server exits, so the task joins cleanly.
+            let control_transport = self.control_transport.clone();
+            let rpc_context = Arc::clone(&self.context);
+            let rpc_signing_key = self.signing_key.clone();
+            let rpc_state = state.clone();
+            let serve_shutdown = Arc::new(Notify::new());
+            let serve_shutdown_task = Arc::clone(&serve_shutdown);
+            let rpc_loop = tokio::task::spawn_local(async move {
                 let handler = zmq_handler::OAuthZmqHandler::new(
-                    zmq_state,
-                    zmq_context,
-                    zmq_transport,
-                    zmq_signing_key,
+                    rpc_state,
+                    rpc_context,
+                    control_transport.clone(),
+                    rpc_signing_key.clone(),
                 );
-                let zmq_transport = RequestService::transport(&handler).clone();
-                let zmq_context = Arc::clone(RequestService::context(&handler));
-                let zmq_signing_key = RequestService::signing_key(&handler);
-                let loop_ = RequestLoop::new(zmq_transport, zmq_context, zmq_signing_key);
-                if let Err(e) = loop_.run(handler).await {
-                    tracing::error!("OAuth ZMQ loop error: {}", e);
+                let nonce_cache = Arc::new(hyprstream_rpc::envelope::InMemoryNonceCache::new());
+                let bridge = match hyprstream_rpc::transport::iroh_rpc::LocalServiceBridge::spawn(
+                    handler,
+                    nonce_cache,
+                    0,
+                ) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        tracing::error!("OAuth RPC bridge spawn error: {}", e);
+                        return;
+                    }
+                };
+                let processor: Arc<dyn hyprstream_rpc::transport::rpc_session::IrohRequestProcessor> =
+                    Arc::new(bridge);
+                if let Err(e) = hyprstream_rpc::service::serve::serve_bridged(
+                    &control_transport,
+                    processor,
+                    rpc_signing_key,
+                    serve_shutdown_task,
+                    None,
+                )
+                .await
+                {
+                    tracing::error!("OAuth RPC serve error: {}", e);
                 }
             });
 
             // Run HTTP(S) server with graceful shutdown
             let _ = crate::server::tls::serve_app(addr, app, rustls_config, shutdown, "OAuthService").await;
 
-            let _ = zmq_loop.await;
+            // HTTP server stopped — stop the RPC serve and join it.
+            serve_shutdown.notify_waiters();
+            let _ = rpc_loop.await;
 
             Ok(())
         })

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -367,7 +367,6 @@ pub struct OAuthState {
     /// ES256 (P-256) signing key rotation store for JWKS and DPoP/atproto interop.
     pub es256_key_store: Option<Arc<crate::auth::Es256SigningKeyStore>>,
     /// ML-DSA-65 signing key rotation store for PQ-hybrid JWT issuance.
-    #[cfg(feature = "pq-hybrid")]
     pub ml_dsa_key_store: Option<Arc<crate::auth::MlDsaSigningKeyStore>>,
 }
 
@@ -417,7 +416,6 @@ impl OAuthState {
             signing_key_store: None,
             jti_blocklist: None,
             es256_key_store: None,
-            #[cfg(feature = "pq-hybrid")]
             ml_dsa_key_store: None,
         }
     }
@@ -456,7 +454,6 @@ impl OAuthState {
     }
 
     /// Attach the ML-DSA-65 key rotation store.
-    #[cfg(feature = "pq-hybrid")]
     pub fn with_ml_dsa_key_store(mut self, store: Arc<crate::auth::MlDsaSigningKeyStore>) -> Self {
         self.ml_dsa_key_store = Some(store);
         self

--- a/crates/hyprstream/src/services/oauth/zmq_handler.rs
+++ b/crates/hyprstream/src/services/oauth/zmq_handler.rs
@@ -1,7 +1,7 @@
 //! ZMQ RPC handler for user CRUD operations.
 //!
 //! Implements the `OauthHandler` trait (generated from `oauth.capnp`)
-//! and `ZmqService` for ZMQ transport. Delegates to `UserService` for
+//! and `RequestService` for ZMQ transport. Delegates to `UserService` for
 //! shared CRUD logic.
 
 use std::sync::Arc;
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use hyprstream_rpc::prelude::*;
-use hyprstream_rpc::service::{Continuation, EnvelopeContext, ZmqService};
+use hyprstream_rpc::service::{Continuation, EnvelopeContext, RequestService};
 use hyprstream_rpc::transport::TransportConfig;
 
 use crate::auth::{UserFilter, decode_pubkey_base64};
@@ -25,7 +25,7 @@ use super::state::OAuthState;
 /// ZMQ RPC handler for OAuth user management.
 ///
 /// Wraps `UserService` and implements the generated `OauthHandler` trait
-/// for Cap'n Proto serialization, and `ZmqService` for ZMQ transport.
+/// for Cap'n Proto serialization, and `RequestService` for ZMQ transport.
 pub struct OAuthZmqHandler {
     state: Arc<OAuthState>,
     context: Arc<zmq::Context>,
@@ -266,7 +266,7 @@ impl OauthHandler for OAuthZmqHandler {
 
 
 #[async_trait(?Send)]
-impl ZmqService for OAuthZmqHandler {
+impl RequestService for OAuthZmqHandler {
     async fn handle_request(
         &self,
         ctx: &EnvelopeContext,

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -1560,11 +1560,10 @@ pub(crate) async fn watch_policy_file(
     let mut watcher = match notify::recommended_watcher(move |res: Result<Event, notify::Error>| {
         if let Ok(event) = res {
             match event.kind {
-                EventKind::Modify(_) | EventKind::Create(_) => {
-                    // Only trigger for events involving our policy.csv
-                    if event.paths.iter().any(|p| p.ends_with("policy.csv")) {
-                        let _ = tx.blocking_send(());
-                    }
+                EventKind::Modify(_) | EventKind::Create(_)
+                    if event.paths.iter().any(|p| p.ends_with("policy.csv")) =>
+                {
+                    let _ = tx.blocking_send(());
                 }
                 _ => {}
             }

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -1,12 +1,12 @@
 //! Policy service for authorization checks over ZMQ
 //!
-//! Wraps PolicyManager and exposes it as a ZmqService.
+//! Wraps PolicyManager and exposes it as a RequestService.
 //! Handlers are async and use `.await` directly (compatible with single-threaded runtime).
 
 use async_trait::async_trait;
 use crate::auth::PolicyManager;
 use crate::auth::policy_templates;
-use crate::services::{EnvelopeContext, ZmqService};
+use crate::services::{EnvelopeContext, RequestService};
 use crate::services::generated::policy_client::{
     ErrorInfo, PolicyHandler, PolicyResponseVariant, TokenInfo, ScopeList,
     PolicyCheck, IssueToken,
@@ -1470,7 +1470,7 @@ impl PolicyHandler for PolicyService {
 }
 
 #[async_trait(?Send)]
-impl ZmqService for PolicyService {
+impl RequestService for PolicyService {
     async fn handle_request(&self, ctx: &EnvelopeContext, payload: &[u8]) -> Result<(Vec<u8>, Option<crate::services::Continuation>)> {
         trace!(
             "Policy request from {} (id={})",

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -78,7 +78,6 @@ pub struct PolicyService {
     /// ES256 (P-256) key rotation store for DPoP/atproto interop.
     es256_key_store: Option<Arc<crate::auth::Es256SigningKeyStore>>,
     /// ML-DSA-65 key rotation store for PQ-hybrid composite token issuance.
-    #[cfg(feature = "pq-hybrid")]
     ml_dsa_key_store: Option<Arc<crate::auth::MlDsaSigningKeyStore>>,
 }
 
@@ -109,7 +108,6 @@ impl PolicyService {
             event_prefixes: RwLock::new(HashMap::new()),
             jti_blocklist: Arc::new(hyprstream_rpc::auth::InMemoryJtiBlocklist::new()),
             es256_key_store: None,
-            #[cfg(feature = "pq-hybrid")]
             ml_dsa_key_store: None,
         }
     }
@@ -127,7 +125,6 @@ impl PolicyService {
 
     /// Sign a token with composite PQ signature when available, falling back to Ed25519.
     async fn sign_token(&self, claims: &hyprstream_rpc::auth::Claims, is_service: bool) -> String {
-        #[cfg(feature = "pq-hybrid")]
         {
             let ml_dsa_key = if let Some(ref store) = self.ml_dsa_key_store {
                 store.active_key().await
@@ -169,7 +166,6 @@ impl PolicyService {
     }
 
     /// Attach the ML-DSA-65 key rotation store for composite token issuance.
-    #[cfg(feature = "pq-hybrid")]
     pub fn with_ml_dsa_key_store(mut self, store: Arc<crate::auth::MlDsaSigningKeyStore>) -> Self {
         self.ml_dsa_key_store = Some(store);
         self

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -6,7 +6,7 @@
 use crate::services::PolicyClient;
 use crate::services::types::{MAX_FDS_GLOBAL, MAX_FDS_PER_CLIENT};
 use hyprstream_containedfs::{ContainedFs, FsError, FsHandle};
-use crate::services::{EnvelopeContext, ZmqService};
+use crate::services::{EnvelopeContext, RequestService};
 use hyprstream_rpc::transport::TransportConfig;
 use hyprstream_rpc::prelude::*;
 use hyprstream_rpc::registry::{global as endpoint_registry, SocketKind};
@@ -297,7 +297,7 @@ impl FidTable {
 /// 4. Continuation publishes clone progress via PUB/SUB
 ///
 /// The registry is wrapped in RwLock for interior mutability since some operations
-/// (like clone) require mutable access but ZmqService::handle_request takes &self.
+/// (like clone) require mutable access but RequestService::handle_request takes &self.
 pub struct RegistryService {
     // Business logic
     registry: Arc<RwLock<Git2DB>>,
@@ -2660,7 +2660,7 @@ impl WorktreeHandler for RegistryService {
 }
 
 #[async_trait(?Send)]
-impl ZmqService for RegistryService {
+impl RequestService for RegistryService {
     async fn handle_request(&self, ctx: &EnvelopeContext, payload: &[u8]) -> Result<(Vec<u8>, Option<crate::services::Continuation>)> {
         dispatch_registry(self, ctx, payload).await
     }

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -2791,7 +2791,7 @@ mod tests {
             signing_key.clone(),
             signing_key.verifying_key(),
             None,
-        );
+        ).expect("test: create policy client");
 
         // Start the registry service with policy client
         let registry_transport = TransportConfig::inproc("test-registry-health");
@@ -2810,7 +2810,7 @@ mod tests {
             signing_key.clone(),
             signing_key.verifying_key(),
             None,
-        );
+        ).expect("test: create registry client");
         // health_check returns () on success
         let result = client.health_check().await;
         assert!(result.is_ok(), "health_check should succeed: {:?}", result.err());

--- a/crates/hyprstream/src/services/worker.rs
+++ b/crates/hyprstream/src/services/worker.rs
@@ -45,7 +45,7 @@ use crate::services::PolicyClient;
 /// Build an `AuthorizeFn` backed by a `PolicyClient`.
 ///
 /// The returned closure is async-compatible (returns a boxed future) so it
-/// works on single-threaded runtimes used by ZmqService.
+/// works on single-threaded runtimes used by RequestService.
 pub fn build_authorize_fn(policy_client: PolicyClient) -> AuthorizeFn {
     Arc::new(move |subject: String, resource: String, operation: String| {
         let client = policy_client.clone();

--- a/crates/hyprstream/src/tui/service.rs
+++ b/crates/hyprstream/src/tui/service.rs
@@ -1011,7 +1011,7 @@ impl TuiService {
                                             let stage = parts[0];
                                             let current: u64 = parts[1].parse().unwrap_or(0);
                                             let total: u64 = parts[2].parse().unwrap_or(0);
-                                            let pct = if total > 0 { ((current * 70) / total).min(70) as u8 } else { 0 };
+                                            let pct = (current * 70).checked_div(total).map(|v| v.min(70) as u8).unwrap_or(0);
                                             let label = match stage {
                                                 "fetch" => "Fetching objects",
                                                 "indexing" => "Indexing",

--- a/crates/hyprstream/src/tui/service.rs
+++ b/crates/hyprstream/src/tui/service.rs
@@ -825,7 +825,7 @@ impl TuiService {
             self.signing_key.clone(),
             policy_vk,
             None,
-        );
+        )?;
 
         let registry_key_resp = policy_client.resolve_service_key(
             &crate::services::generated::policy_client::ResolveServiceKey {
@@ -857,12 +857,12 @@ impl TuiService {
                     self.signing_key.clone(),
                     registry_vk,
                     None,
-                );
+                )?;
             let model_client_for_status = crate::services::generated::model_client::ModelClient::for_service(
                 self.signing_key.clone(),
                 model_vk,
                 None,
-            );
+            )?;
             let status_timeout = std::time::Duration::from_millis(500);
             let all_status_req = crate::services::generated::model_client::StatusRequest { model_ref: String::new() };
             let (repos_result, status_result) = tokio::join!(
@@ -912,11 +912,17 @@ impl TuiService {
                 let vk  = model_vk_load;
                 // Submit load — returns "accepted" immediately (Continuation pattern).
                 h.block_on(async {
-                    let client = crate::services::generated::model_client::ModelClient::for_service(
+                    let client = match crate::services::generated::model_client::ModelClient::for_service(
                         sk.clone(),
                         vk,
                         None,
-                    );
+                    ) {
+                        Ok(c) => c,
+                        Err(e) => {
+                            tracing::warn!("Failed to create ModelClient: {e}");
+                            return;
+                        }
+                    };
                     let _ = client.load(&crate::services::generated::model_client::LoadModelRequest {
                         model_ref: mr.clone(),
                         max_context: None,
@@ -932,11 +938,17 @@ impl TuiService {
                     for _ in 0..60u32 {   // max ~2 minutes (60 × 2 s)
                         std::thread::sleep(std::time::Duration::from_secs(2));
                         let loaded = h_poll.block_on(async {
-                            let client = crate::services::generated::model_client::ModelClient::for_service(
+                            let client = match crate::services::generated::model_client::ModelClient::for_service(
                                 sk_poll.clone(),
                                 vk_poll,
                                 None,
-                            );
+                            ) {
+                                Ok(c) => c,
+                                Err(e) => {
+                                    tracing::warn!("Failed to create ModelClient: {e}");
+                                    return false;
+                                }
+                            };
                             client.status(&crate::services::generated::model_client::StatusRequest { model_ref: mr_poll.clone() }).await
                                 .is_ok_and(|es| es.iter().any(|e| e.status == "loaded"))
                         });
@@ -956,11 +968,17 @@ impl TuiService {
             let sk = sk_unload.clone();
             let mr = model_ref.to_owned();
             handle_unload.block_on(async move {
-                let client = crate::services::generated::model_client::ModelClient::for_service(
+                let client = match crate::services::generated::model_client::ModelClient::for_service(
                     sk.clone(),
                     model_vk_unload,
                     None,
-                );
+                ) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        tracing::warn!("Failed to create ModelClient: {e}");
+                        return false;
+                    }
+                };
                 client.unload(&crate::services::generated::model_client::UnloadModelRequest { model_ref: mr.clone() }).await.is_ok()
             })
         });
@@ -981,7 +999,13 @@ impl TuiService {
                 let rmd = rmd_clone.clone();
                 std::thread::spawn(move || {
                     h.block_on(async {
-                        let registry = crate::services::RegistryClient::for_service(sk, rvk, None);
+                        let registry = match crate::services::RegistryClient::for_service(sk, rvk, None) {
+                            Ok(c) => c,
+                            Err(e) => {
+                                let _ = tx.send(GitOpProgress::Failed(format!("Failed to create RegistryClient: {e}")));
+                                return;
+                            }
+                        };
                         let model_name = name.unwrap_or_else(|| {
                             url.rsplit('/').next().unwrap_or("model")
                                 .trim_end_matches(".git").to_owned()
@@ -1076,7 +1100,13 @@ impl TuiService {
                 let rvk = rvk_pull;
                 std::thread::spawn(move || {
                     h.block_on(async {
-                        let registry = crate::services::RegistryClient::for_service(sk, rvk, None);
+                        let registry = match crate::services::RegistryClient::for_service(sk, rvk, None) {
+                            Ok(c) => c,
+                            Err(e) => {
+                                let _ = tx.send(GitOpProgress::Failed(format!("Failed to create RegistryClient: {e}")));
+                                return;
+                            }
+                        };
                         let model_name = model_ref.split(':').next().unwrap_or(&model_ref);
                         let tracked = match registry.get_by_name(model_name).await {
                             Ok(t) => t,
@@ -1111,7 +1141,13 @@ impl TuiService {
                 let rvk = rvk_push;
                 std::thread::spawn(move || {
                     h.block_on(async {
-                        let registry = crate::services::RegistryClient::for_service(sk, rvk, None);
+                        let registry = match crate::services::RegistryClient::for_service(sk, rvk, None) {
+                            Ok(c) => c,
+                            Err(e) => {
+                                let _ = tx.send(GitOpProgress::Failed(format!("Failed to create RegistryClient: {e}")));
+                                return;
+                            }
+                        };
                         let model_name = model_ref.split(':').next().unwrap_or(&model_ref);
                         let branch = model_ref.split(':').nth(1).unwrap_or("main");
                         let tracked = match registry.get_by_name(model_name).await {
@@ -1152,7 +1188,13 @@ impl TuiService {
                 let rvk = rvk_status;
                 std::thread::spawn(move || {
                     h.block_on(async {
-                        let registry = crate::services::RegistryClient::for_service(sk, rvk, None);
+                        let registry = match crate::services::RegistryClient::for_service(sk, rvk, None) {
+                            Ok(c) => c,
+                            Err(e) => {
+                                tracing::warn!("Failed to create RegistryClient: {e}");
+                                return;
+                            }
+                        };
                         for mr in model_refs {
                             let model_name = mr.split(':').next().unwrap_or(&mr);
                             if let Ok(tracked) = registry.get_by_name(model_name).await {

--- a/crates/hyprstream/src/tui/service.rs
+++ b/crates/hyprstream/src/tui/service.rs
@@ -1,6 +1,6 @@
 //! TuiService — ZMQ RPC service for the TUI multiplexer.
 //!
-//! Implements `ZmqService` for the TUI display server. Manages sessions,
+//! Implements `RequestService` for the TUI display server. Manages sessions,
 //! windows, and panes via RPC. Frame publishing is handled separately
 //! by the frame loop task (not in the service struct).
 
@@ -21,7 +21,7 @@ use hyprstream_rpc::prelude::*;
 use hyprstream_rpc::streaming::{
     BatchingConfig, StreamChannel, StreamContext, StreamPublisher, StreamPublisherConfig,
 };
-use hyprstream_rpc::{EnvelopeContext, ZmqService, Continuation};
+use hyprstream_rpc::{EnvelopeContext, RequestService, Continuation};
 
 use crate::tui_capnp;
 use crate::services::PolicyClient;
@@ -134,11 +134,11 @@ pub struct TuiService {
     state: Arc<RwLock<TuiState>>,
     /// Next viewer ID counter (atomic for Send+Sync).
     next_viewer_id: AtomicU32,
-    /// ZMQ context (required by ZmqService).
+    /// ZMQ context (required by RequestService).
     context: Arc<zmq::Context>,
-    /// Transport config (required by ZmqService).
+    /// Transport config (required by RequestService).
     transport: TransportConfig,
-    /// Signing key (required by ZmqService).
+    /// Signing key (required by RequestService).
     signing_key: SigningKey,
     /// Per-session viewer registration channels + frame loop tokens.
     sessions: SessionRegistry,
@@ -1614,7 +1614,7 @@ impl TuiService {
 }
 
 #[async_trait(?Send)]
-impl ZmqService for TuiService {
+impl RequestService for TuiService {
     async fn handle_request(
         &self,
         _ctx: &EnvelopeContext,

--- a/crates/hyprstream/src/tui/vfs.rs
+++ b/crates/hyprstream/src/tui/vfs.rs
@@ -117,7 +117,7 @@ pub fn build_chat_vfs_namespace(
         signing_key.clone(),
         policy_vk,
         None,
-    );
+    )?;
     let model_vk_resp = tokio::task::block_in_place(|| {
         let rt = tokio::runtime::Handle::current();
         rt.block_on(policy_client.resolve_service_key(
@@ -137,7 +137,7 @@ pub fn build_chat_vfs_namespace(
         signing_key.clone(),
         model_vk,
         None,
-    );
+    )?;
     let remote_model_mount = crate::services::remote_mount::RemoteModelMount::new(model_client);
     let _ = ns.mount("/srv/model", Arc::new(remote_model_mount));
 

--- a/crates/hyprstream/src/tui/vte_parser.rs
+++ b/crates/hyprstream/src/tui/vte_parser.rs
@@ -671,11 +671,9 @@ impl<'a> vte::Perform for PanePerformer<'a> {
         }
         // OSC 0 or 2: set title
         match params[0] {
-            b"0" | b"2" => {
-                if params.len() > 1 {
-                    if let Ok(title) = std::str::from_utf8(params[1]) {
-                        self.pane.title = title.to_owned();
-                    }
+            b"0" | b"2" if params.len() > 1 => {
+                if let Ok(title) = std::str::from_utf8(params[1]) {
+                    self.pane.title = title.to_owned();
                 }
             }
             _ => {}
@@ -1018,7 +1016,7 @@ mod tests {
         }
         // Bottom row (row 9, 0-indexed) should have been cleared with the
         // current background color, not Color::Reset.
-        let last_row = (pane.primary.buffer.area().height - 1) as u16;
+        let last_row = pane.primary.buffer.area().height - 1;
         let cell = &pane.primary.buffer[(0, last_row)];
         assert_eq!(
             cell.bg,

--- a/crates/hyprstream/src/tui/zmq_transport.rs
+++ b/crates/hyprstream/src/tui/zmq_transport.rs
@@ -61,11 +61,17 @@ pub fn make_chat_spawner(
             rt.block_on(async move {
                 // Resolve model service key via PolicyClient.
                 let policy_vk = sk_inner.verifying_key();
-                let policy_client = crate::services::PolicyClient::for_service(
+                let policy_client = match crate::services::PolicyClient::for_service(
                     sk_inner.clone(),
                     policy_vk,
                     None,
-                );
+                ) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        let _ = tx.send(ChatEvent::StreamError(format!("Failed to create PolicyClient: {e}")));
+                        return;
+                    }
+                };
                 let model_key_resp = match policy_client.resolve_service_key(
                     &crate::services::generated::policy_client::ResolveServiceKey {
                         service_name: "model".to_owned(),
@@ -91,7 +97,13 @@ pub fn make_chat_spawner(
                     }
                 };
                 let model_client =
-                    ModelClient::for_service(sk_inner.clone(), model_vk, None);
+                    match ModelClient::for_service(sk_inner.clone(), model_vk, None) {
+                        Ok(c) => c,
+                        Err(e) => {
+                            let _ = tx.send(ChatEvent::StreamError(format!("Failed to create ModelClient: {e}")));
+                            return;
+                        }
+                    };
 
                 // Map ChatHistoryEntry → ChatMessage, handling all roles.
                 // Skip the trailing empty assistant placeholder — it's only a
@@ -275,7 +287,7 @@ pub fn make_tool_caller(
                     sk_fetch.clone(),
                     policy_vk,
                     None,
-                );
+                ).ok()?;
                 let mcp_key_resp = policy_client.resolve_service_key(
                     &crate::services::generated::policy_client::ResolveServiceKey {
                         service_name: "mcp".to_owned(),
@@ -285,7 +297,7 @@ pub fn make_tool_caller(
                     mcp_key_resp.verifying_key.as_slice().try_into().ok()?
                 ).ok()?;
                 let gen: GenMcpClient =
-                    GenMcpClient::for_endpoint(&endpoint, sk_fetch, mcp_vk, None);
+                    GenMcpClient::for_endpoint(&endpoint, sk_fetch, mcp_vk, None).ok()?;
                 let tool_list = gen.list_tools().await.ok()?;
                 let mut descs = HashMap::new();
                 let mut tools = Vec::new();
@@ -329,11 +341,14 @@ pub fn make_tool_caller(
                     rt.block_on(async move {
                         // Resolve MCP service key via PolicyClient.
                         let policy_vk = sk_c.verifying_key();
-                        let policy_client = crate::services::PolicyClient::for_service(
+                        let policy_client = match crate::services::PolicyClient::for_service(
                             sk_c.clone(),
                             policy_vk,
                             None,
-                        );
+                        ) {
+                            Ok(c) => c,
+                            Err(e) => return format!("error: failed to create PolicyClient: {e}"),
+                        };
                         let mcp_vk = match policy_client.resolve_service_key(
                             &crate::services::generated::policy_client::ResolveServiceKey {
                                 service_name: "mcp".to_owned(),
@@ -351,7 +366,11 @@ pub fn make_tool_caller(
                             },
                             Err(e) => return format!("error: failed to resolve MCP key: {e}"),
                         };
-                        match GenMcpClient::for_endpoint(&endpoint, sk_c, mcp_vk, None)
+                        let mcp_client = match GenMcpClient::for_endpoint(&endpoint, sk_c, mcp_vk, None) {
+                            Ok(c) => c,
+                            Err(e) => return format!("error: failed to create McpClient: {e}"),
+                        };
+                        match mcp_client
                             .call_tool(&crate::services::generated::mcp_client::CallTool {
                                 tool_name: uuid_c,
                                 arguments,

--- a/crates/hyprstream/tests/policy_over_iroh.rs
+++ b/crates/hyprstream/tests/policy_over_iroh.rs
@@ -83,7 +83,7 @@ async fn make_policy_service() -> Result<(PolicyService, SigningKey, TempDir)> {
         TokenConfig::default(),
         git2db,
         // Unused on the iroh path — the bridge never touches the ZMQ
-        // transport bits of ZmqService, just `handle_request` + envelope
+        // transport bits of RequestService, just `handle_request` + envelope
         // metadata.
         Arc::new(zmq::Context::new()),
         TransportConfig::inproc("policy-over-iroh-unused"),

--- a/crates/hyprstream/tests/policy_over_iroh.rs
+++ b/crates/hyprstream/tests/policy_over_iroh.rs
@@ -1,0 +1,233 @@
+//! Phase 2 part 3: real `PolicyService` exercised end-to-end over iroh.
+//!
+//! Constructs a real `PolicyService` (PolicyManager + Git2DB + signing key,
+//! all in a `TempDir`), serves it through a `LocalServiceBridge` behind an
+//! `IrohRpcProtocolHandler` on ALPN `hyprstream-rpc/1`, and drives the
+//! generated `PolicyClient` against it via `IrohTransport` + `RpcClientImpl`.
+//!
+//! This validates the canary path for #133: every byte that the production
+//! `create_policy_service` factory would terminate on the ZMTP wire also
+//! works unchanged over iroh, because we reuse the same `process_request`
+//! envelope-verify/JWT/Casbin path via the bridge.
+//!
+//! Factory wiring (so deployments actually serve over iroh) is a separate
+//! follow-up under Phase 5 (#136), since every service will need the same
+//! change at the same place.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use ed25519_dalek::SigningKey;
+use rand::RngCore;
+use tempfile::TempDir;
+use tokio::sync::RwLock;
+
+use git2db::Git2DB;
+use hyprstream_core::auth::PolicyManager;
+use hyprstream_core::config::TokenConfig;
+use hyprstream_core::services::PolicyService;
+use hyprstream_core::services::generated::policy_client::{PolicyCheck, PolicyClient};
+
+use hyprstream_rpc::envelope::InMemoryNonceCache;
+use hyprstream_rpc::rpc_client::RpcClientImpl;
+use hyprstream_rpc::signer::LocalSigner;
+use hyprstream_rpc::transport::TransportConfig;
+use hyprstream_rpc::transport::iroh_rpc::{IrohRpcProtocolHandler, LocalServiceBridge};
+use hyprstream_rpc::transport::iroh_substrate::{
+    ALPN_HYPRSTREAM_RPC, IrohSubstrate, NoopHandler,
+};
+use hyprstream_rpc::transport::iroh_transport::IrohTransport;
+
+use iroh::{EndpointAddr, TransportAddr};
+
+fn fresh_node_key() -> [u8; 32] {
+    let mut k = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut k);
+    k
+}
+
+fn fresh_signing_key() -> SigningKey {
+    SigningKey::from_bytes(&fresh_node_key())
+}
+
+fn direct_addr(substrate: &IrohSubstrate) -> EndpointAddr {
+    EndpointAddr::from_parts(
+        substrate.endpoint_id(),
+        substrate
+            .endpoint()
+            .bound_sockets()
+            .into_iter()
+            .map(TransportAddr::Ip),
+    )
+}
+
+/// Stand up a real `PolicyService` in a fresh tempdir and return it
+/// alongside its signing key and the tempdir guard (which must outlive
+/// the service).
+async fn make_policy_service() -> Result<(PolicyService, SigningKey, TempDir)> {
+    let temp = TempDir::new()?;
+    let models_dir = temp.path().to_path_buf();
+    let policies_dir = models_dir.join(".registry").join("policies");
+
+    // PolicyManager bootstraps with SERVICE_BASE_POLICIES so service:*
+    // authorization works without any extra rule writes.
+    let policy_manager = Arc::new(PolicyManager::new(&policies_dir).await?);
+
+    // Git2DB::open initializes .registry as a git repo at this path.
+    let git2db = Arc::new(RwLock::new(Git2DB::open(&models_dir).await?));
+
+    let signing_key = fresh_signing_key();
+    let service = PolicyService::new(
+        policy_manager,
+        Arc::new(signing_key.clone()),
+        TokenConfig::default(),
+        git2db,
+        // Unused on the iroh path — the bridge never touches the ZMQ
+        // transport bits of ZmqService, just `handle_request` + envelope
+        // metadata.
+        Arc::new(zmq::Context::new()),
+        TransportConfig::inproc("policy-over-iroh-unused"),
+    );
+
+    Ok((service, signing_key, temp))
+}
+
+/// Build the iroh server side: PolicyService → LocalServiceBridge →
+/// IrohRpcProtocolHandler → IrohSubstrate.
+async fn serve_over_iroh(
+    service: PolicyService,
+    server_signing: SigningKey,
+) -> Result<(IrohSubstrate, EndpointAddr)> {
+    let nonce_cache = Arc::new(InMemoryNonceCache::new());
+    let bridge = LocalServiceBridge::spawn(service, nonce_cache, 0)?;
+
+    let substrate = IrohSubstrate::new(
+        fresh_node_key(),
+        NoopHandler::new("moq-not-wired"),
+        IrohRpcProtocolHandler::new(bridge, server_signing),
+    )
+    .await?;
+    let addr = direct_addr(&substrate);
+    Ok((substrate, addr))
+}
+
+/// Build the client side: iroh dial → IrohTransport → RpcClientImpl →
+/// PolicyClient.
+async fn client_for(
+    server_addr: EndpointAddr,
+    server_vk: ed25519_dalek::VerifyingKey,
+) -> Result<(IrohSubstrate, PolicyClient)> {
+    let client_substrate = IrohSubstrate::new(
+        fresh_node_key(),
+        NoopHandler::new("c-moq"),
+        NoopHandler::new("c-rpc"),
+    )
+    .await?;
+
+    let conn = client_substrate
+        .connect(server_addr, ALPN_HYPRSTREAM_RPC)
+        .await?;
+    let transport = IrohTransport::new(conn);
+    let rpc = RpcClientImpl::new(LocalSigner::new(fresh_signing_key()), transport, Some(server_vk));
+    let policy_client = PolicyClient::new(Arc::new(rpc));
+    Ok((client_substrate, policy_client))
+}
+
+/// Real PolicyService over iroh — verifies the canary path end-to-end with
+/// a representative `check` RPC, including both ALLOW and DENY outcomes
+/// produced by the bootstrap `SERVICE_BASE_POLICIES`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn policy_check_allow_and_deny_over_iroh() -> Result<()> {
+    let (service, server_signing, _temp) = make_policy_service().await?;
+    let server_vk = server_signing.verifying_key();
+
+    let (server, server_addr) = serve_over_iroh(service, server_signing).await?;
+    let (client_substrate, policy) = client_for(server_addr, server_vk).await?;
+
+    // ALLOW: service:oauth → policy:ResolveServiceKey:query (from
+    // SERVICE_BASE_POLICIES, asserted in policy_manager.rs base-rules test).
+    let allow_resp = policy
+        .check(&PolicyCheck {
+            subject: "service:oauth".to_owned(),
+            domain: "*".to_owned(),
+            resource: "policy:ResolveServiceKey".to_owned(),
+            operation: "query".to_owned(),
+        })
+        .await?;
+    assert!(allow_resp, "service:oauth must be allowed: {allow_resp:?}");
+
+    // DENY: service:unknown is not in the base policies.
+    let deny_resp = policy
+        .check(&PolicyCheck {
+            subject: "service:unknown".to_owned(),
+            domain: "*".to_owned(),
+            resource: "policy:ResolveServiceKey".to_owned(),
+            operation: "query".to_owned(),
+        })
+        .await?;
+    assert!(!deny_resp, "service:unknown must be denied: {deny_resp:?}");
+
+    client_substrate.shutdown().await?;
+    server.shutdown().await?;
+    Ok(())
+}
+
+/// Concurrent `check` calls on the same `PolicyClient` (one iroh connection,
+/// many bidi streams) — verifies the wire layer's per-stream correlation
+/// holds under a real service's response shape.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn policy_concurrent_checks_over_iroh() -> Result<()> {
+    let (service, server_signing, _temp) = make_policy_service().await?;
+    let server_vk = server_signing.verifying_key();
+
+    let (server, server_addr) = serve_over_iroh(service, server_signing).await?;
+    let (client_substrate, policy) = client_for(server_addr, server_vk).await?;
+    let policy = Arc::new(policy);
+
+    // Cases chosen so wildcard base rules don't interfere:
+    //   - policy:ResolveServiceKey:query is granted ONLY to specific services
+    //     (service:oauth, service:policy, service:model, service:registry,
+    //     service:worker, service:mcp), so unknown service:* subjects deny.
+    //   - policy:Check:check is similarly per-service.
+    //   - Non-`service:` subjects (e.g. "alice") deny on everything below
+    //     unless explicitly granted.
+    let cases: Vec<(&str, &str, &str, bool)> = vec![
+        ("service:oauth", "policy:ResolveServiceKey", "query", true),
+        ("service:policy", "policy:ResolveServiceKey", "query", true),
+        ("service:model", "policy:Check", "check", true),
+        ("service:oauth", "policy:IssueToken", "manage", true),
+        ("service:bogus0", "policy:ResolveServiceKey", "query", false),
+        ("service:bogus1", "policy:Check", "check", false),
+        ("alice", "policy:ResolveServiceKey", "query", false),
+        ("alice", "policy:IssueToken", "manage", false),
+    ];
+    let mut handles = Vec::new();
+    for (subject, resource, operation, expect_allow) in cases {
+        let policy = Arc::clone(&policy);
+        let subject = subject.to_owned();
+        let resource = resource.to_owned();
+        let operation = operation.to_owned();
+        handles.push(tokio::spawn(async move {
+            let resp = policy
+                .check(&PolicyCheck {
+                    subject: subject.clone(),
+                    domain: "*".to_owned(),
+                    resource: resource.clone(),
+                    operation,
+                })
+                .await?;
+            assert_eq!(
+                resp, expect_allow,
+                "{subject} -> {resource}: expected allow={expect_allow}, got {resp:?}"
+            );
+            anyhow::Ok(())
+        }));
+    }
+    for h in handles {
+        h.await??;
+    }
+
+    client_substrate.shutdown().await?;
+    server.shutdown().await?;
+    Ok(())
+}

--- a/docs/plans/2026-06-11-136-rpc-cutover.md
+++ b/docs/plans/2026-06-11-136-rpc-cutover.md
@@ -1,0 +1,140 @@
+# #136 — RPC production cutover (M1 exit)
+
+2026-06-11. Replace the ZMQ `RequestLoop`/ROUTER on the spawn path with the
+generic dispatch plane over the dial layer, for **all spawn-path services at
+once** (one switch, not a parallel plane). This is the M1 flip everything in the
+`#151(a)` sub-stack was built to enable.
+
+## Prereqs — all landed (the dial-layer sub-stack)
+
+| Piece | Branch | Status |
+|---|---|---|
+| `process_request` dispatch core | `moq-148` (#194) | merged-track |
+| `dial()` factory + in-process transport + inproc registry | `moq-151a` (#195) | reviewed |
+| `LazyQuinnTransport` + cert-pin Quic | `moq-151b` (#198) | reviewed |
+| `LazyIrohTransport` + iroh dial | `moq-151c` (#199) | reviewed |
+| `QuicServerAuth` policy (WebPKI / pin-set / WebPKI+pin) | `moq-151d`/`151e` | reviewed |
+| DID-doc transport service-entry codec | `moq-151f` | reviewed |
+| `UdsSession` — `Session` over UnixStream (ipc plane, RPC + moq) | `moq-151g` | reviewed (#207 follow-up) |
+| `Continuation` killed at the dispatch boundary | `moq-186` (#196) | reviewed |
+
+So the client dial path, channel auth, addressing wire format, and streaming
+bootstrap are all in place. `#136` is the **server-side flip** + wiring.
+
+## The pieces of the cutover
+
+1. **Daemon provisions prod transport listeners.** Today `QuinnRpcServer` /
+   iroh substrate are test-only. The daemon must, at bootstrap, bind the QUIC
+   baseline listener (+ optional iroh) and register each service's endpoint
+   **pinned** (`quic_pinned`, already wired in `moq-151e`'s registration sites)
+   so clients can dial it. Server cert chain/key live *outside* `TransportConfig`
+   (it is wire-published) — keep them in a server-config path.
+
+2. **Resolver registration.** `resolver::set_global(...)` so `dial()`/codegen can
+   turn a service name → `TransportConfig`. Bootstrap can register the existing
+   `EndpointRegistry` resolver immediately (local, already implemented); the
+   `DidWebResolver` (HTTPS fetch + `#mesh` binding, consuming `moq-151f`'s codec)
+   slots in later for cross-node did:web dialing.
+
+3. **Codegen de-leak (R3).** Rewire generated `for_endpoint` to call `dial()`
+   instead of hardcoding `ZmqConnection::new`. This **changes generated client
+   constructor signatures** (takes `TransportConfig`, not an endpoint string)
+   across ~95 call sites — the highest-blast-radius change. ZMQ `ipc://`/systemd
+   endpoints stay on the codegen path during the transition (`dial()` bails on
+   them today, by design).
+
+4. **`Spawnable::run` cutover.** Replace the ZMQ `RequestLoop` with the generic
+   serve path (`QuinnRpcServer` / the iroh accept loop driving `process_request`)
+   for all spawn-path services. Note the runtime-shape gap (spike): `Spawnable::run`
+   is sync with its own `LocalSet`; `QuinnRpcServer::run` is async on the main
+   runtime — needs a Spawnable adapter.
+
+5. **Streaming bootstrap** — already de-coupled (`#186`): `process_request` spawns
+   the streaming pump itself; nothing to thread.
+
+## Approach: hard cut (settled 2026-06-11)
+
+Nothing here is merged or deployed; there are no production users and no prior
+release in production. So there is **no rollback path to preserve** and **no
+feature flag** — a parallel ZMQ-RPC plane behind a config knob would be pure dead
+weight (two code paths, doubled test matrix) guarding a safety net no one can
+use. The spawn-path RPC services flip from the ZMQ `RequestLoop` to the
+dial/dispatch plane in one go.
+
+"Irreversible" is the wrong frame: anything pre-merge reverts trivially. The two
+real constraints are ordinary:
+
+- **Commit sequencing (keep the stack green), not rollback.** Each stacked commit
+  must still build + test. Land the listener provisioning + `resolver::set_global`
+  *before/with* the codegen de-leak, so the moment generated clients call
+  `dial()` there is something to dial. This is "no broken intermediate commit,"
+  not "keep an escape hatch."
+- **The codegen de-leak is atomic, not irreversible.** ~95 generated
+  `for_endpoint` sites change constructor signature in one sweep — do it all at
+  once and verify with the build; it can't land half-done. Annoying to review,
+  trivial to revert.
+
+Scope note: the cut is narrower than "rip out ZMQ." `#136` is **RPC spawn-path
+services only**; ZMQ-the-dependency stays in-tree for the planes this ticket
+doesn't touch (EventService, CLI/SUB → #138/N-cli). Confirm no spawn-path service
+must stay on ZMQ past the switch (`zmq_connection.rs` consumers are M5/#138).
+
+### Still open — one technical spike (not a policy call)
+
+- **`Spawnable::run` runtime-shape gap.** `Spawnable::run` is sync with its own
+  `LocalSet`; `QuinnRpcServer::run` is async on the main runtime. The serve path
+  needs a small adapter. See the spike notes below.
+- **#187 (per-listener vs process-global verify policy)** — closed as superseded
+  by #158, but re-check if the cutover runs a Classical-tolerant browser listener
+  in-process before #158.
+
+## Spike: `Spawnable::run` runtime-shape gap — resolved (the adapter exists)
+
+Investigated 2026-06-11. The gap is real but **already solved by an existing
+component** — it's a wiring choice, not new architecture.
+
+The shapes:
+- `Spawnable::run` (`service/spawnable.rs`) is **sync/blocking**, runs on a
+  **dedicated OS thread**, builds its own runtime + **`LocalSet`**, and drives
+  `RequestLoop`, which wraps the service in `Rc<>` — so spawn-path services may
+  be **`!Send`** (e.g. `InferenceService` holding tch-rs tensors).
+- `QuinnRpcServer::run` / `serve_rpc_connection` are **async on the shared
+  multi-thread runtime** and require the processor (`IrohRequestProcessor`) to be
+  **`Send + Sync + 'static`**.
+
+The adapter: **`LocalServiceBridge`** (`transport/iroh_rpc.rs`) already bridges
+exactly this. It spins a dedicated thread with a current-thread runtime +
+`LocalSet`, keeps the `!Send` service there (wrapped in `Rc`), and exposes a
+`Send + Sync` `IrohRequestProcessor` via an mpsc request + oneshot response
+channel. The iroh accept loop already uses it; quinn and UDS serve paths take the
+same `Arc<dyn IrohRequestProcessor>`, so they reuse it unchanged.
+
+**Chosen shape (a):** keep each spawn-path service on its own OS thread +
+`LocalSet`; wrap it in `LocalServiceBridge`; hand the bridge to
+`QuinnRpcServer` / the iroh handler / the UDS `UnixListener` accept loop. No
+service rewrite, GPU/tensor thread-confinement preserved. Rejected: (b) moving
+services onto the shared runtime is infeasible — tch-rs is genuinely `!Send`.
+
+Bonus cleanup this enables: `InferenceService`'s current `unsafe impl Send + Sync`
+(a soundness smell that only holds because the service never actually crosses
+threads) can be **removed** — the bridge keeps it authentically `!Send` and
+thread-confined. The serve path needs the bridge, not a fake `Send` claim.
+
+Cutover wiring touch-points: `ServiceSpawner` (wrap service in
+`LocalServiceBridge` before the serve path), the quinn/iroh/UDS handler
+construction (accept `Arc<dyn IrohRequestProcessor>`), and removing the
+`unsafe impl` in `inference.rs`. `Spawnable::run`'s signature does **not** change.
+
+## Out of scope (later milestones)
+
+EventService/StreamService → moq (M2: #167/#134/N6/N7), CLI/client migration
+(N-cli), ZMQ teardown + `cargo deny` no-zmq gate (M5/#138), browser FE reframe
+(M4). `#136` is **RPC spawn-path services only**.
+
+## Exit criteria
+
+Daemon serves all spawn-path RPC over the QUIC baseline (+ ipc via `UdsSession`)
+through `dial()` + the generic dispatch plane; the ZMQ `RequestLoop`/ROUTER path
+is deleted for those services and the full test suite is green. `grep` still
+shows ZMQ for the not-yet-migrated planes (EventService, CLI) — those are
+separate tickets.

--- a/docs/plans/2026-06-11-uds-session-spike.md
+++ b/docs/plans/2026-06-11-uds-session-spike.md
@@ -1,0 +1,135 @@
+# Spike — `UdsSession`: one `web_transport_trait::Session` over UnixStream
+
+> **STATUS (2026-06-11): BUILT** as `moq-151g`
+> (`crates/hyprstream-rpc/src/transport/uds_session.rs`, yamux-backed). 9 tests
+> green (incl. real RPC plane via `SessionRpcTransport`/`serve_rpc_connection`
+> and full moq publish/subscribe over UDS); release clippy clean. Code +
+> security review done — fixes applied (concurrent-stream cap, tag-read timeout,
+> fail-closed plane validation, observability). One follow-up filed: **#207**
+> (socket perms + `SO_PEERCRED`, daemon/#136 scope). Feeds #136's `dial()` ipc
+> arm + daemon `UnixListener` provisioning.
+>
+> Review caught a real defect: `SendStream::closed()` must *detect* closure, not
+> *cause* it — an early impl called `close()` inside `closed()`, so moq's
+> `select! { biased; _ = stream.closed() => cancel }` in `serve_group` aborted
+> every group right after its header, truncating all frames. Fixed.
+
+2026-06-11. Decision input for the ipc-transport re-platform (ZMQ-over-`ipc://` →
+SignedEnvelope-over-UDS) and #136's `dial()` ipc arm. Question answered:
+**can the same UDS transport carry both the RPC plane and the moq streaming
+plane?** Answer: **yes**, via one `web_transport_trait::Session` impl.
+
+## Why one impl covers both planes
+
+`moq-net 0.1.8` is fully generic over `web_transport_trait::Session`:
+
+- `Server::accept<S: web_transport_trait::Session>(&self, session: S)` — `server.rs:54`
+- `Client::connect<S: web_transport_trait::Session>(&self, session: S)` — `client.rs:54`
+- `moq_net::Session` type-erases via blanket `impl<S: web_transport_trait::Session>
+  SessionInner for S` → `Arc<dyn SessionInner>` — `session.rs:144`
+- moq-net's own tests ship a hand-rolled `FakeSession` (non-quinn/non-iroh) and run
+  full SETUP negotiation over it — the genericity is real, not incidental.
+
+So one `UdsSession: web_transport_trait::Session` serves:
+- **RPC plane** → `SessionRpcTransport` (`open_bi` → SignedEnvelope req/resp)
+- **Streaming plane** → `moq_net::Client::connect(uds_session)` / `Server::accept`
+
+exactly as quinn/iroh do today. Everything layered above the trait is transport-agnostic.
+
+## What moq-lite actually requires of the Session (the contract)
+
+| Capability | Required by moq-lite? | Evidence | UDS impl |
+|---|---|---|---|
+| `open_bi` / `accept_bi` | **Yes** — one SETUP control stream | `coding/stream.rs:25` `Stream::open`→`open_bi`; client negotiates Lite version over it (`client.rs:180+`) | mux bidi stream |
+| `open_uni` / `accept_uni` | **Yes** — one per Group | `lite/publisher.rs:484`, `lite/subscriber.rs:93` | mux uni stream |
+| `send_datagram` / `recv_datagram` / `max_datagram_size` | **No** — zero datagram refs in `lite/`; datagrams are IETF-draft-only (`ietf/adapter.rs`) | trait still requires the methods | stub: `max_datagram_size()→0`, `send/recv → Err(Closed)` |
+| ALPN `protocol()` | optional | `None` → manual version negotiation arm `Some(ALPN_LITE) | None` (`client.rs:174`) | return `None`; moq negotiates Lite over the control stream |
+
+Net: genuine concurrent stream multiplexing (1 bidi + N uni), **no datagrams, no ALPN**.
+
+## Multiplexer: yamux (already in-tree)
+
+A `UnixStream` is one ordered byte-stream; QUIC/iroh provide stream multiplexing
+natively, UDS does not. `UdsSession` carries a multiplexer.
+
+- **yamux 0.13.7 / 0.12.1 already in `Cargo.lock`** (via libp2p/iroh) — adding
+  `yamux` to `hyprstream-rpc` pulls in nothing new.
+- `yamux::Stream: futures::io::AsyncRead + AsyncWrite` → wrap as the trait's
+  `SendStream`/`RecvStream`.
+- yamux gives **flow control + HOL-correct concurrent streams** for free — the
+  exact thing a raw socket lacks and we'd otherwise hand-roll incorrectly.
+- Rejected alternatives: hand-rolled framing mux (~350 LOC, reinvents flow
+  control); `SOCK_SEQPACKET`/fd-passing (no independent flow-controlled streams).
+
+### The one real integration cost — actor wrapper
+
+`yamux::Connection<T>` is a single-owner, poll-driven driver: **not `Clone`**, must
+be polled by exactly one task (`poll_next_inbound` also drives outbound). But
+`web_transport_trait::Session: Clone` and is called concurrently from many tasks.
+
+Standard fix (what `libp2p-yamux` does): one **driver task** owns the `Connection`;
+`open_bi`/`open_uni`/`accept_bi`/`accept_uni` are channel RPCs to it.
+
+```
+UdsSession (Clone)            driver task (owns yamux::Connection<Compat<UnixStream>>)
+  open_bi  ─ mpsc ─────────▶  poll_new_outbound → tag BIDI → oneshot back (send,recv)
+  open_uni ─ mpsc ─────────▶  poll_new_outbound → tag UNI  → oneshot back (send)
+  accept_* ◀── mpsc queues ── poll_next_inbound → read 1-byte tag → route uni|bidi queue
+```
+
+Sizing: ~150 LOC actor + ~120 LOC stream-type wrappers (`SendStream::{write,
+write_buf, finish, reset, set_priority}`, `RecvStream::{read, read_buf, stop}`).
+
+### Two wire conventions to lock in (trivial)
+
+1. **uni-vs-bidi tag** — yamux substreams are all bidi; prefix each new substream
+   with a 1-byte `UNI`/`BIDI` marker. Acceptor reads it first and routes to the
+   matching `accept_*` queue. Uni opener simply never reads its half.
+2. **plane select** — 1-byte handshake at socket-open (`RPC` vs `MOQ`) in place of
+   ALPN, since UDS has none. Server's `UnixListener` accept loop dispatches the
+   connection to the RPC dispatcher or `moq_net::Server::accept` on that byte.
+
+### Adapter glue
+
+- `tokio::net::UnixStream` is `tokio::io::AsyncRead/Write`; yamux wants
+  `futures::io::AsyncRead/Write` → bridge with
+  `tokio_util::compat::TokioAsyncReadCompatExt` (`tokio-util` already a dep).
+- Error-code mapping is lossy and that's fine (local socket): `finish`→close write
+  half; `reset`/`stop`→drop/close; session `close(code,reason)`→`poll_close`.
+
+## Build outline (its own increment, feeds #136 ipc arm)
+
+1. `transport/uds_session.rs` — `UdsSession` + driver actor + `UdsSendStream`/
+   `UdsRecvStream`; `impl web_transport_trait::Session`.
+2. Client `connect(path) -> UdsSession` (yamux `Mode::Client`); server
+   `UnixListener` accept loop → 1-byte plane select → `Mode::Server` `UdsSession`.
+3. RPC plane: reuse `SessionRpcTransport` over `UdsSession` (no new RPC code).
+4. Streaming plane: `moq_net::{Client,Server}` over the same `UdsSession`.
+5. `dial()` ipc arm constructs `UdsSession`; daemon binds the `UnixListener`.
+6. Tests: loopback `UdsSession` pair — bidi echo, N concurrent uni streams,
+   SETUP negotiation, then a full moq publish/subscribe over UDS.
+
+## Open question deferred → filed as #207
+
+- **Peer auth on UDS** — same-host identity via `SO_PEERCRED` (uid/pid) plus
+  socket-file permissions is defense-in-depth; the SignedEnvelope app-layer
+  identity already authenticates the caller regardless of transport. Owned by
+  the daemon listener bootstrap (where the bind path + mode are chosen), not the
+  Session primitive. Tracked in **#207** (coordinate with #136).
+
+## Review outcomes applied in moq-151g
+
+- **Tag-read timeout** (`TAG_READ_TIMEOUT`) on `classify_inbound` — a substream
+  that never sends its UNI/BIDI tag can't pin a task + yamux slot forever
+  (pre-dispatch slowloris that bypassed rpc_session's `REQUEST_READ_TIMEOUT`).
+- **Concurrent-substream cap** (`MAX_CONCURRENT_STREAMS` via yamux
+  `set_max_num_streams`) — bounds the inbound classification fan-out.
+- **Fail-closed plane validation** in `accept_uds` — unknown selector → error.
+- **Observability** — warn/debug logs on unknown tag, untagged-timeout, FIN-flush
+  failure.
+- Rejected (by-design, evidenced): `closed()` pends rather than reporting
+  spurious closure (moq relies on `read()==None` for EOF); the
+  `tokio::sync::Mutex` around the accept receiver is held across `await` by
+  design (single-consumer mpsc). The detached `finish()` close task is correct —
+  writes are queued into yamux's send buffer before `finish`, proven by the moq
+  round-trip delivering the full frame.


### PR DESCRIPTION
# Epic #131: ZMQ → moq-net + iroh transport replacement (integration branch)

> [!warning] **Tracking PR — DO NOT MERGE yet.**
> `ewindisch/epic-moq` is the integration branch that the moq-* PR stack lands on
> via merge-commits. It is **not** ready for `main`: the epic is partially complete
> (the IPC/spawn-path RPC cutover lands here; several milestones remain). This PR
> exists to track integration state and surface the aggregate diff. It will be
> retargeted/refreshed as remaining milestones land.

## What has landed on this branch (53 commits, 96 files)

The full moq-* stack, merged bottom-up as merge-commits (PRs #189, #190, #191,
#192, #193, #194, #195, #198, #199, #203, #204, #205, #208, #206):

- **moq-net generic transport** over `web_transport_trait::Session` (m1/m2a/m3).
- **#154** did:web atproto-compat identity doc.
- **#148** extract `process_request` → dispatch core.
- **#151(a–g)** sync `dial()` + lazy-connect transports (inproc/ipc/quic/iroh),
  in-memory inproc registry, `DidWebResolver`, cert-pinned Quic, and the
  yamux-backed **`UdsSession`** (RPC + moq over one UnixStream).
- **#136 RPC cutover (hard cut, staged):** spawn-path RPC services flipped from
  ZMQ `RequestLoop` to the bridged dial/dispatch plane (`LocalServiceBridge` +
  `serve_bridged`); generated clients de-leaked to `dial()`. Inproc (default
  daemon mode) and IPC/systemd-fd paths fully on the new plane.

## What this delivers if/when merged

Functional, updated **IPC** RPC with ZMQ removed from that path; ZMQ retained
only for remote access (`UnifiedServiceConfig`, opt-in, scoped to **#209**).

## Remaining before this can target main (epic not complete)

- **M2** event/streaming bus, **M4** browser transport, **M5 (#138)** ZMQ teardown
  (`zmq`/`tmq` deps still present).
- **#196 / moq-186** fork (spawn streaming pump in dispatch core) — reconciliation
  decision pending; deliberately **not** in this chain.
- Follow-ups: **#200** RawPublicKey, **#207**, **#209**, **#210**, **#211**.

Epic tracker: **#131**.
