### PR TITLE
#186: spawn streaming pump in dispatch core + per-service cap (reconciled onto epic-moq)

### DIFF
--- a/crates/hyprstream-rpc/src/service/dispatch.rs
+++ b/crates/hyprstream-rpc/src/service/dispatch.rs
@@ -36,9 +36,22 @@ pub use crate::envelope::EnvelopeVerification;
 /// 3. Dispatch to `service.handle_request()` with a verified `EnvelopeContext`.
 /// 4. Sign the response with the server's `signing_key`.
 ///
+/// # Streaming
+///
+/// A streaming handler returns a `Continuation` (the server-side streaming
+/// response that runs after the reply). As of #186 that task is spawned
+/// **here**, via [`crate::streaming::spawn_streaming_response`], rather than
+/// handed back to the transport front-end — so every front-end (ZMQ
+/// `RequestLoop`, WebTransport server, generic-plane `LocalServiceBridge`) is
+/// uniform "bytes in → bytes out" and the generic plane no longer has to spawn
+/// (or, worse, reject) continuations itself. **Invariant:** `process_request`
+/// must therefore run on a `tokio::task::LocalSet` (it already did —
+/// `RequestService` is `?Send`); the spawned task is `?Send`.
+///
 /// # Returns
 ///
-/// * `Ok((response_bytes, continuation))` - Signed response and optional continuation
+/// * `Ok(response_bytes)` - Signed response. Any streaming pump has already been
+///   spawned onto the current `LocalSet`.
 /// * `Err(e)` - Processing error (already logged)
 pub async fn process_request<S>(
     raw_bytes: &[u8],
@@ -46,7 +59,7 @@ pub async fn process_request<S>(
     verification: EnvelopeVerification<'_>,
     signing_key: &ed25519_dalek::SigningKey,
     nonce_cache: &crate::envelope::InMemoryNonceCache,
-) -> Result<(Vec<u8>, Option<crate::service::Continuation>)>
+) -> Result<Vec<u8>>
 where
     S: crate::service::RequestService,
 {
@@ -79,7 +92,7 @@ where
 
             let mut bytes = Vec::new();
             serialize::write_message(&mut bytes, &message)?;
-            return Ok((bytes, None));
+            return Ok(bytes);
         }
     };
 
@@ -106,7 +119,7 @@ where
 
         let mut bytes = Vec::new();
         serialize::write_message(&mut bytes, &message)?;
-        return Ok((bytes, None));
+        return Ok(bytes);
     }
 
     // 3. Handle request
@@ -128,5 +141,13 @@ where
     let mut bytes = Vec::new();
     serialize::write_message(&mut bytes, &message)?;
 
-    Ok((bytes, continuation))
+    // 5. Spawn the server-side streaming response (if any) onto the current
+    //    LocalSet, so the reply is all the transport front-end has to deal with
+    //    (#186). Bounded by a per-service admission permit; see
+    //    spawn_streaming_response.
+    if let Some(cont) = continuation {
+        crate::streaming::spawn_streaming_response(service.name(), cont);
+    }
+
+    Ok(bytes)
 }

--- a/crates/hyprstream-rpc/src/service/zmq.rs
+++ b/crates/hyprstream-rpc/src/service/zmq.rs
@@ -938,10 +938,6 @@ impl RequestLoop {
             });
         }
 
-        // Bounded semaphore for continuations
-        const MAX_INFLIGHT_CONTINUATIONS: usize = 16;
-        let continuation_semaphore = Arc::new(tokio::sync::Semaphore::new(MAX_INFLIGHT_CONTINUATIONS));
-
         // Use futures traits for Router async I/O
         use futures::{SinkExt, StreamExt};
         let mut router_stream = router;
@@ -1005,18 +1001,18 @@ impl RequestLoop {
                     // not a shared root key. The envelope signature is still verified —
                     // JWT claims + Casbin handle authorization.
                     // subsecond::call wraps the dispatch so handler code can be hot-patched during dev.
-                    let (response_bytes, continuation) = match subsecond::call(|| crate::service::dispatch::process_request(
+                    let response_bytes = match subsecond::call(|| crate::service::dispatch::process_request(
                         &request,
                         &*service,
                         crate::envelope::EnvelopeVerification::AnySigner,
                         &signing_key,
                         &nonce_cache,
                     )).await {
-                        Ok(result) => result,
+                        Ok(bytes) => bytes,
                         Err(e) => {
                             error!("{} request processing error: {}", service.name(), e);
                             let error_payload = service.build_error_payload(0, &e.to_string());
-                            (Self::wrap_response(0, error_payload, &signing_key)?, None)
+                            Self::wrap_response(0, error_payload, &signing_key)?
                         }
                     };
 
@@ -1030,18 +1026,8 @@ impl RequestLoop {
                     if let Err(e) = router_stream.send(response_msg).await {
                         error!("{} ROUTER send error: {}", service.name(), e);
                     }
-
-                    // Spawn continuation after response is sent
-                    if let Some(future) = continuation {
-                        let sem = continuation_semaphore.clone();
-                        tokio::task::spawn_local(async move {
-                            let Ok(_permit) = sem.acquire_owned().await else {
-                                warn!("continuation semaphore closed");
-                                return;
-                            };
-                            future.await;
-                        });
-                    }
+                    // Any streaming pump was already spawned inside
+                    // process_request (#186); nothing to do here.
                 }
             }
         }

--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -1818,6 +1818,125 @@ impl StreamGuard {
 }
 
 // ============================================================================
+// Streaming-response concurrency (#186)
+// ============================================================================
+
+/// Default ceiling on **concurrent server-side streaming responses per
+/// service** — i.e. how many streaming RPCs one service may be actively pushing
+/// data for at once. Overridable via [`install_max_concurrent_streams_per_service`]
+/// (wired from `ServerConfig::max_concurrent_streams_per_service`).
+///
+/// This is the former per-`RequestLoop` `MAX_INFLIGHT_CONTINUATIONS` (16). When
+/// the spawn moved out of the transport front-ends into the dispatch core
+/// (#186) the bound is keyed by service name rather than living on each loop —
+/// the *same* granularity, since each service has exactly one `RequestLoop`.
+/// Keeping it per-service (not process-wide) preserves the original isolation:
+/// one service's stuck or long-lived streams cannot starve another's.
+pub const DEFAULT_MAX_CONCURRENT_STREAMS_PER_SERVICE: usize = 16;
+
+/// Process-global override for the per-service concurrent-streams cap.
+/// First-write-wins, mirroring `install_verify_config`; installed once at
+/// startup from the loaded `ServerConfig`. Read when a service's semaphore is
+/// first created, so it must be installed before serving (it always is — the
+/// daemon installs it right after loading config).
+static MAX_CONCURRENT_STREAMS_PER_SERVICE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+
+/// Install the per-service concurrent-streams cap. Call once at startup with
+/// `ServerConfig::max_concurrent_streams_per_service`. Values are clamped to a
+/// minimum of 1. Returns `Err(existing)` if already installed (first-write-wins).
+pub fn install_max_concurrent_streams_per_service(n: usize) -> Result<(), usize> {
+    MAX_CONCURRENT_STREAMS_PER_SERVICE.set(n.max(1))
+}
+
+/// The effective cap: the installed value, or [`DEFAULT_MAX_CONCURRENT_STREAMS_PER_SERVICE`].
+fn max_concurrent_streams_per_service() -> usize {
+    MAX_CONCURRENT_STREAMS_PER_SERVICE
+        .get()
+        .copied()
+        .unwrap_or(DEFAULT_MAX_CONCURRENT_STREAMS_PER_SERVICE)
+}
+
+/// Per-service admission semaphores, created on first use at the effective cap.
+/// A permit is held for the full lifetime of a streaming response (which is
+/// itself bounded by the stream's JWT/TTL cancel token in `StreamChannel`, so
+/// permits are always eventually released — there is no unbounded hold). The map
+/// only ever grows by the number of distinct services (small, bounded), so it is
+/// never pruned.
+fn stream_admission_semaphore(service_name: &str) -> std::sync::Arc<tokio::sync::Semaphore> {
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+    static MAP: std::sync::OnceLock<RwLock<HashMap<String, std::sync::Arc<tokio::sync::Semaphore>>>> =
+        std::sync::OnceLock::new();
+    let map = MAP.get_or_init(|| RwLock::new(HashMap::new()));
+    if let Some(sem) = map.read().get(service_name) {
+        return std::sync::Arc::clone(sem);
+    }
+    std::sync::Arc::clone(
+        map.write()
+            .entry(service_name.to_owned())
+            .or_insert_with(|| {
+                std::sync::Arc::new(tokio::sync::Semaphore::new(max_concurrent_streams_per_service()))
+            }),
+    )
+}
+
+/// Spawn the server-side half of a streaming RPC — the task that keeps pushing
+/// data *after* the `StreamInfo` reply has been sent — onto the current
+/// `LocalSet`, bounded by a per-service admission permit.
+///
+/// Replaces the former "transport front-end spawns the continuation it got back
+/// from `process_request`" model (#186): the dispatch core now spawns this task
+/// itself and returns only the reply bytes, so the streaming lifecycle is no
+/// longer threaded through every transport's request/response path. This is the
+/// M1 shape; in M2 the streaming transport (`StreamChannel`) moves to a
+/// service-owned moq broadcast and this coarse per-service cap is replaced by
+/// the StreamPolicy backpressure axes (#134).
+///
+/// `service_name` keys the per-service permit pool (see
+/// [`DEFAULT_MAX_CONCURRENT_STREAMS_PER_SERVICE`] and
+/// [`install_max_concurrent_streams_per_service`]). When the pool is saturated
+/// the task waits for a permit rather than being dropped — and the wait is
+/// logged so saturation is observable rather than a silent stall.
+///
+/// # Invariant
+///
+/// MUST be called from within a `tokio::task::LocalSet`: the task is `?Send`
+/// (like every [`RequestService`](crate::service::RequestService)), and
+/// `spawn_local` panics outside a `LocalSet`. Every
+/// [`process_request`](crate::service::dispatch::process_request) caller already
+/// runs on a `LocalSet` (ZMQ `RequestLoop`, the WebTransport server, and the
+/// generic plane's `LocalServiceBridge`), which is the only place this is
+/// invoked.
+pub fn spawn_streaming_response(service_name: &str, continuation: crate::service::Continuation) {
+    let sem = stream_admission_semaphore(service_name);
+    let service_name = service_name.to_owned();
+    tokio::task::spawn_local(async move {
+        // Observe saturation: a permit that isn't immediately available means
+        // this service is at its concurrent-streams cap and new streams are
+        // queueing behind running ones.
+        let permit = match sem.clone().try_acquire_owned() {
+            Ok(p) => p,
+            Err(_) => {
+                tracing::warn!(
+                    service = %service_name,
+                    cap = max_concurrent_streams_per_service(),
+                    "concurrent-streams cap reached; new stream waiting for a slot"
+                );
+                // The semaphore is a static that is never closed, so
+                // acquire_owned cannot fail; if it somehow did, drop the stream.
+                let Ok(p) = sem.acquire_owned().await else {
+                    tracing::error!(service = %service_name, "stream admission semaphore closed; dropping stream");
+                    return;
+                };
+                p
+            }
+        };
+        let _permit = permit; // held for the streaming response's lifetime
+        continuation.await;
+    });
+}
+
+// ============================================================================
 // Helpers
 // ============================================================================
 

--- a/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
@@ -288,6 +288,14 @@ impl LocalServiceBridge {
                             // Re-derive the signing key per call: cheap clone,
                             // tracks any future rotation in the service.
                             let signing_key = service.signing_key();
+                            // As of #186 process_request spawns any streaming
+                            // pump itself (onto this bridge's LocalSet, where
+                            // this task already runs, bounded by a per-service
+                            // admission permit) and returns only the reply bytes,
+                            // so the generic plane is uniform "bytes in → bytes
+                            // out" like every other front-end. (Previously the
+                            // bridge spawned the continuation here; that worked
+                            // but duplicated the spawn logic per transport.)
                             let result = crate::service::dispatch::process_request(
                                 msg.request.as_ref(),
                                 &*service,
@@ -296,20 +304,7 @@ impl LocalServiceBridge {
                                 &nonce_cache,
                             )
                             .await
-                            .map(|(bytes, cont)| {
-                                // The continuation is the streaming pump — it
-                                // publishes to the moq/notification plane,
-                                // independent of the RPC transport — so spawn it
-                                // on this bridge LocalSet after the response,
-                                // exactly as RequestLoop / WebTransportServer do.
-                                // (Without this, streaming services like model /
-                                // tui would have their continuation dropped and
-                                // the stream would never be served.)
-                                if let Some(cont) = cont {
-                                    tokio::task::spawn_local(cont);
-                                }
-                                Bytes::from(bytes)
-                            });
+                            .map(Bytes::from);
                             let _ = msg.respond.send(result);
                         });
                     }
@@ -378,6 +373,8 @@ impl LocalServiceBridge {
                         let nonce_cache = Arc::clone(&nonce_cache);
                         tokio::task::spawn_local(async move {
                             let signing_key = service.signing_key();
+                            // process_request spawns any streaming pump itself
+                            // (#186); the bridge just relays the reply bytes.
                             let result = crate::service::dispatch::process_request(
                                 msg.request.as_ref(),
                                 &*service,
@@ -386,14 +383,7 @@ impl LocalServiceBridge {
                                 &nonce_cache,
                             )
                             .await
-                            .map(|(bytes, cont)| {
-                                // Spawn the streaming pump on this bridge LocalSet
-                                // (see spawn() for the rationale).
-                                if let Some(cont) = cont {
-                                    tokio::task::spawn_local(cont);
-                                }
-                                Bytes::from(bytes)
-                            });
+                            .map(Bytes::from);
                             let _ = msg.respond.send(result);
                         });
                     }

--- a/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
+++ b/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
@@ -529,7 +529,7 @@ impl QuicRep {
         // just don't pin it to the server's own key. JWT claims + Casbin handle
         // authorization.
         // subsecond::call wraps dispatch for hot-patching during dev
-        let (response_bytes, continuation) = subsecond::call(|| crate::service::dispatch::process_request(
+        let response_bytes = subsecond::call(|| crate::service::dispatch::process_request(
             raw_bytes,
             &*service,
             EnvelopeVerification::AnySigner,
@@ -543,14 +543,9 @@ impl QuicRep {
         };
         stream.send_multipart(&response.parts).await?;
 
-        // Signal end of response
+        // Signal end of response. Any streaming pump was already spawned inside
+        // process_request (#186).
         stream.stream.send.finish()?;
-
-        // Handle continuation if present (for streaming)
-        if let Some(cont) = continuation {
-            // Spawn continuation on LocalSet (streaming handler is ?Send)
-            tokio::task::spawn_local(cont);
-        }
 
         Ok(())
     }
@@ -1684,14 +1679,12 @@ impl WebTransportServer {
                     &signing_key,
                     &nonce_cache,
                 )).await {
-                    Ok((response_bytes, continuation)) => {
+                    Ok(response_bytes) => {
                         zmtp.send_multipart(&[Bytes::from(response_bytes)]).await?;
                         zmtp.stream.send.shutdown().await
                             .map_err(std::io::Error::other)?;
-
-                        if let Some(cont) = continuation {
-                            tokio::task::spawn_local(cont);
-                        }
+                        // Any streaming pump was already spawned inside
+                        // process_request (#186).
                     }
                     Err(e) => {
                         warn!("WebTransport RPC error: {}", e);

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1442,6 +1442,13 @@ fn main() -> Result<()> {
         .validate()
         .context("Configuration validation failed")?;
 
+    // Install the per-service streaming-response concurrency cap from config
+    // (#186) before any RPC service starts. First-write-wins; ignore if already
+    // installed on this process.
+    let _ = hyprstream_rpc::streaming::install_max_concurrent_streams_per_service(
+        config.server.max_concurrent_streams_per_service,
+    );
+
     // ========== TRACING INITIALIZATION (before service startup) ==========
     let is_service_command = matches.subcommand_name() == Some("service");
     let _log_guard: Option<tracing_appender::non_blocking::WorkerGuard>;

--- a/crates/hyprstream/src/config/server.rs
+++ b/crates/hyprstream/src/config/server.rs
@@ -165,6 +165,12 @@ pub struct ServerConfig {
     #[serde(default = "default_cancellation_check_interval")]
     pub cancellation_check_interval: u64,
 
+    /// Max concurrent server-side streaming responses **per service** — how many
+    /// streaming RPCs one service may actively push data for at once. Bounds the
+    /// streaming-response tasks spawned by the RPC dispatch core (#186).
+    #[serde(default = "default_max_concurrent_streams_per_service")]
+    pub max_concurrent_streams_per_service: usize,
+
     /// Maximum context length for KV cache allocation.
     /// Overrides model's max_position_embeddings to reduce GPU memory.
     /// None = use model's default, Some(n) = cap at n tokens
@@ -236,6 +242,9 @@ fn default_max_concurrent_requests() -> usize {
 fn default_cancellation_check_interval() -> u64 {
     100
 }
+fn default_max_concurrent_streams_per_service() -> usize {
+    hyprstream_rpc::streaming::DEFAULT_MAX_CONCURRENT_STREAMS_PER_SERVICE
+}
 fn default_tls_min_version() -> String {
     "1.2".to_owned()
 }
@@ -253,6 +262,7 @@ impl Default for ServerConfig {
             request_timeout_secs: default_request_timeout_secs(),
             max_concurrent_requests: default_max_concurrent_requests(),
             cancellation_check_interval: default_cancellation_check_interval(),
+            max_concurrent_streams_per_service: default_max_concurrent_streams_per_service(),
             max_context: None, // Use model's default max_position_embeddings
             kv_quant: KVQuantArg::None,
             cors: CorsConfig::default(),


### PR DESCRIPTION
Reconciles **#196 / moq-186** onto the post-#136-cutover `epic-moq` tree (the original
#196 forked off moq-148, pre-cutover). Decision: *reconcile & land the cap*.

## What it does
`process_request` now spawns any streaming continuation itself
(`streaming::spawn_streaming_response`) and returns only the reply bytes — every transport
front-end (ZMQ `RequestLoop`, `QuicRep`, `WebTransportServer`, and the generic-plane
`LocalServiceBridge`'s two dispatch loops) is uniform "bytes in → bytes out".

The pump is bounded by a **per-service admission semaphore**
(`ServerConfig::max_concurrent_streams_per_service`, default 16). This **closes an
unbounded-spawn DoS gap the #136 cutover left open**: previously only the ZMQ path capped
in-flight streaming pumps; the QUIC/WebTransport/inproc/ipc/iroh paths — the ones the cutover
made primary — spawned unbounded. Saturation now waits for a permit (prior behavior) and is
logged (observability).

## Verification
- ✅ `cargo check` clean (hyprstream-rpc + hyprstream)
- ✅ e2e tests pass (inproc bridged continuation guard + UDS canary)
- ✅ workspace `clippy -D warnings` clean (pre-commit gate)
- ✅ adversarial security+code review: no CRITICAL/HIGH (LocalSet invariant, semaphore
  correctness, DoS/unbounded-growth, behavioral parity, lost-continuations, OnceLock ordering — all PASS)

Closes #196. Closes #186.
