### PR TITLE
fix(rocm): remove MI210-specific overrides that break gfx1151 (Strix Halo)

### DIFF
--- a/appimage/AppRun-single
+++ b/appimage/AppRun-single
@@ -21,7 +21,7 @@ if [[ "$BACKEND" == "rocm71" ]]; then
     if [[ -d /opt/rocm ]]; then
         export ROCM_PATH="${ROCM_PATH:-/opt/rocm}"
     fi
-    export PYTORCH_ROCM_ARCH="${PYTORCH_ROCM_ARCH:-gfx90a;gfx1100;gfx1101}"
+    export PYTORCH_ROCM_ARCH="${PYTORCH_ROCM_ARCH:-gfx90a;gfx1100;gfx1101;gfx1151}"
 fi
 
 # Debug output

--- a/crates/hyprstream-service/src/service/manager/systemd.rs
+++ b/crates/hyprstream-service/src/service/manager/systemd.rs
@@ -19,21 +19,22 @@ pub struct SystemdManager {
     #[allow(dead_code)]
     connection: Connection,
     systemd: ManagerProxy<'static>,
-    #[allow(dead_code)]
-    login: LoginProxy<'static>,
 }
 
 impl SystemdManager {
     /// Create a new SystemdManager
     ///
-    /// Connects to the user session D-Bus and enables user lingering
-    /// so services persist after logout.
+    /// Connects to the user session D-Bus for systemd1 and the system D-Bus
+    /// for login1 (logind). logind lives on the system bus only — connecting
+    /// LoginProxy to the session bus caused set_user_linger() to hang forever
+    /// waiting for a response that never arrives.
     pub async fn new() -> Result<Self> {
         let connection = Connection::session().await?;
         let systemd = ManagerProxy::new(&connection).await?;
-        let login = LoginProxy::new(&connection).await?;
 
-        // Enable linger (services persist after logout)
+        // Enable linger via the system bus (org.freedesktop.login1 is system-only).
+        let system_connection = Connection::system().await?;
+        let login = LoginProxy::new(&system_connection).await?;
         let uid = nix::unistd::getuid().as_raw();
         if let Err(e) = login.set_user_linger(uid, true, false).await {
             debug!("Failed to enable user linger (may already be enabled): {}", e);
@@ -44,7 +45,6 @@ impl SystemdManager {
         Ok(Self {
             connection,
             systemd,
-            login,
         })
     }
 

--- a/crates/hyprstream/src/bin/test_gpu.rs
+++ b/crates/hyprstream/src/bin/test_gpu.rs
@@ -7,12 +7,14 @@ fn main() {
     println!("ROCm GPU Detection Test");
     println!("=======================");
 
-    // Set environment for ROCm
-    std::env::set_var("ROCM_PATH", "/usr");
+    // Set environment for ROCm — use system ROCm path, let HSA select the correct arch natively
+    std::env::set_var("ROCM_PATH", "/opt/rocm");
     std::env::set_var("HIP_VISIBLE_DEVICES", "0");
-    std::env::set_var("HSA_OVERRIDE_GFX_VERSION", "9.0.0");
+    // HSA_OVERRIDE_GFX_VERSION intentionally not set: let ROCm detect the actual GPU arch.
+    // Setting it to a fixed value (e.g. 9.0.0 for gfx90a/MI210) breaks non-MI210 hardware
+    // such as gfx1151 (Strix Halo) by loading the wrong ISA kernels.
 
-    println!("Environment set for ROCm MI210");
+    println!("Environment set for ROCm (auto-detecting GPU arch)");
 
     // Check device
     let device = Device::cuda_if_available();

--- a/crates/hyprstream/src/bin/test_rocm_ffi.rs
+++ b/crates/hyprstream/src/bin/test_rocm_ffi.rs
@@ -18,10 +18,9 @@ fn main() {
     println!("ROCm Direct FFI Test");
     println!("====================");
 
-    // Set ROCm environment
-    std::env::set_var("ROCM_PATH", "/usr");
+    // Set ROCm environment — use system ROCm path, leave arch detection to the runtime
+    std::env::set_var("ROCM_PATH", "/opt/rocm");
     std::env::set_var("HIP_VISIBLE_DEVICES", "0");
-    std::env::set_var("PYTORCH_ROCM_ARCH", "gfx90a");
 
     unsafe {
         let available = torch_cuda_is_available();

--- a/hyprstream.sh
+++ b/hyprstream.sh
@@ -26,8 +26,13 @@ else
   BITSANDBYTES_LIB_DIR=${BITSANDBYTES_LIB_PATH:-$DEPS_DIR/bitsandbytes/bitsandbytes}
 fi
 
-# GPU architecture
-export PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH:-gfx90a}
+# GPU architecture — auto-detect from rocminfo if not already set in the environment.
+# PYTORCH_ROCM_ARCH is used by bitsandbytes-sys at build time; at runtime ROCm selects
+# the correct ISA kernels automatically. Hardcoding gfx90a (MI210) breaks other hardware.
+if [ -z "$PYTORCH_ROCM_ARCH" ]; then
+  DETECTED_ARCH=$(rocminfo 2>/dev/null | awk '/^\s+Name:.*gfx/{print $NF; exit}')
+  export PYTORCH_ROCM_ARCH=${DETECTED_ARCH:-gfx90a}
+fi
 
 # Libtorch build settings
 export LIBTORCH_STATIC=0


### PR DESCRIPTION
Fixes #228

## Summary

- **ROCm gfx1151 fix**: Remove `HSA_OVERRIDE_GFX_VERSION=9.0.0` from `test_gpu.rs` — this forced the ROCm runtime to treat any GPU as gfx90a (MI210/CDNA2), loading the wrong ISA kernels on gfx1151 (Strix Halo / Radeon 8060S) and silently falling back to CPU
- **ROCm paths**: Fix `ROCM_PATH=/usr` → `/opt/rocm` in both test binaries; remove hardcoded `PYTORCH_ROCM_ARCH=gfx90a` from `test_rocm_ffi.rs`
- **AppImage**: Add `gfx1151` to `PYTORCH_ROCM_ARCH` in `AppRun-single` for the rocm71 variant
- **hyprstream.sh**: Replace hardcoded `PYTORCH_ROCM_ARCH=gfx90a` default with `rocminfo`-based auto-detection; falls back to `gfx90a` if `rocminfo` is unavailable
- **service install/wizard hang**: `LoginProxy` (`org.freedesktop.login1` / logind) lives on the D-Bus **system** bus only. Connecting it to the session bus `Connection` caused `set_user_linger()` to await a response that never arrives, hanging `service install` and the wizard indefinitely. Fix: open a separate `Connection::system()` for `LoginProxy`.

## Test plan

- [x] `cargo test --workspace` passes (842 tests, 0 failures)
- [x] `test_gpu`: GPU 0 detected on gfx1151 (Radeon 8060S / Strix Halo)
- [x] `test_rocm_ffi`: GPU available via direct FFI + tch-rs on gfx1151
- [x] `hyprstream-service` compiles cleanly with `--features systemd`
- [ ] `hyprstream service install` no longer hangs
- [ ] `hyprstream wizard` no longer hangs at service start
- [ ] Verify MI210 (gfx90a) still works — fallback in `hyprstream.sh` preserves gfx90a when `rocminfo` is absent

## Notes

libtorch rocm7.1 already ships gfx1151 kernels in both `rocblas` and `hipblaslt` — no library changes needed. ROCm 7.2 natively supports gfx1151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)