### PR TITLE
[M2-A1] StreamBlock: producer-assigned seq + epoch, bound into MAC (#219)

### DIFF
--- a/crates/hyprstream-rpc-build/Cargo.toml
+++ b/crates/hyprstream-rpc-build/Cargo.toml
@@ -21,5 +21,11 @@ clap = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 
+# Generate StreamContract (#213/#216) typed readers so the annotation extractor can
+# decode the struct-valued `$streamPolicy` annotation (capnp-rust has no CGR-runtime
+# dynamic reflection, so the generated type is required).
+[build-dependencies]
+capnpc = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/hyprstream-rpc-build/build.rs
+++ b/crates/hyprstream-rpc-build/build.rs
@@ -1,28 +1,4 @@
-//! Compile `StreamContract` (#213/#216) typed readers for the annotation extractor.
-//!
-//! The struct-valued `$streamPolicy` annotation can't be decoded generically from the
-//! CGR — capnp-rust's dynamic reflection needs a `StructSchema` from *generated*
-//! introspection (`StructSchema::new(RawBrandedStructSchema)`), with no CGR constructor.
-//! So we generate the real `streaming.capnp` types (single source of truth) here and the
-//! extractor decodes the annotation value via the typed `stream_contract::Reader`.
-//!
-//! Schemas live in the sibling `hyprstream-rpc` crate; we compile both `annotations.capnp`
-//! (imported by `streaming.capnp`) and `streaming.capnp`.
-
-use std::path::Path;
-
-fn main() {
-    let schema_dir = Path::new("../hyprstream-rpc/schema");
-    for f in ["annotations.capnp", "streaming.capnp"] {
-        println!("cargo:rerun-if-changed=../hyprstream-rpc/schema/{f}");
-    }
-    if let Err(e) = capnpc::CompilerCommand::new()
-        .src_prefix(schema_dir)
-        .import_path(schema_dir)
-        .file(schema_dir.join("annotations.capnp"))
-        .file(schema_dir.join("streaming.capnp"))
-        .run()
-    {
-        panic!("compile streaming.capnp for StreamContract decode (#216): {e}");
-    }
-}
+// hyprstream-rpc-build has no generated types of its own.
+// Schema compilation and annotation extraction happen in the consuming crates'
+// build scripts via `hyprstream_rpc_build::compile_schemas`.
+fn main() {}

--- a/crates/hyprstream-rpc-build/build.rs
+++ b/crates/hyprstream-rpc-build/build.rs
@@ -1,0 +1,28 @@
+//! Compile `StreamContract` (#213/#216) typed readers for the annotation extractor.
+//!
+//! The struct-valued `$streamPolicy` annotation can't be decoded generically from the
+//! CGR — capnp-rust's dynamic reflection needs a `StructSchema` from *generated*
+//! introspection (`StructSchema::new(RawBrandedStructSchema)`), with no CGR constructor.
+//! So we generate the real `streaming.capnp` types (single source of truth) here and the
+//! extractor decodes the annotation value via the typed `stream_contract::Reader`.
+//!
+//! Schemas live in the sibling `hyprstream-rpc` crate; we compile both `annotations.capnp`
+//! (imported by `streaming.capnp`) and `streaming.capnp`.
+
+use std::path::Path;
+
+fn main() {
+    let schema_dir = Path::new("../hyprstream-rpc/schema");
+    for f in ["annotations.capnp", "streaming.capnp"] {
+        println!("cargo:rerun-if-changed=../hyprstream-rpc/schema/{f}");
+    }
+    if let Err(e) = capnpc::CompilerCommand::new()
+        .src_prefix(schema_dir)
+        .import_path(schema_dir)
+        .file(schema_dir.join("annotations.capnp"))
+        .file(schema_dir.join("streaming.capnp"))
+        .run()
+    {
+        panic!("compile streaming.capnp for StreamContract decode (#216): {e}");
+    }
+}

--- a/crates/hyprstream-rpc-build/src/lib.rs
+++ b/crates/hyprstream-rpc-build/src/lib.rs
@@ -13,25 +13,6 @@ pub mod backend;
 pub mod schema;
 pub mod util;
 
-// Generated `StreamContract` (#213/#216) types, used to decode the struct-valued
-// `$streamPolicy` annotation value (see `build.rs`). Crate-private; the generated
-// `streaming_capnp` references its import as `crate::annotations_capnp`, so both modules
-// live at the crate root.
-mod annotations_capnp {
-    #![allow(dead_code, unused_imports)]
-    #![allow(clippy::all, clippy::unwrap_used, clippy::expect_used, clippy::match_same_arms)]
-    #![allow(clippy::semicolon_if_nothing_returned, clippy::doc_markdown, clippy::indexing_slicing)]
-    #![allow(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_possible_wrap)]
-    include!(concat!(env!("OUT_DIR"), "/annotations_capnp.rs"));
-}
-mod streaming_capnp {
-    #![allow(dead_code, unused_imports)]
-    #![allow(clippy::all, clippy::unwrap_used, clippy::expect_used, clippy::match_same_arms)]
-    #![allow(clippy::semicolon_if_nothing_returned, clippy::doc_markdown, clippy::indexing_slicing)]
-    #![allow(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_possible_wrap)]
-    include!(concat!(env!("OUT_DIR"), "/streaming_capnp.rs"));
-}
-
 use std::path::Path;
 
 /// Compile Cap'n Proto schemas with CGR + metadata extraction.
@@ -209,23 +190,7 @@ fn extract_annotations(
         let name = annotation_names.get(&ann_id).cloned().unwrap_or_default();
 
         if let Ok(value) = ann.get_value() {
-            // Struct-valued annotations need the generated typed reader (#216) — capnp has
-            // no CGR-runtime dynamic decode. `$streamPolicy` (:StreamContract) is the one
-            // such annotation; decode it structurally. Any other struct annotation, or a
-            // decode failure, falls through to presence-only so we never silently corrupt.
-            let val = if name == "streamPolicy" {
-                match value.which() {
-                    Ok(capnp::schema_capnp::value::Struct(ptr)) => match extract_stream_contract(ptr) {
-                        Ok(v) => Some(v),
-                        // Fail-closed: an invalid/contradictory $streamPolicy aborts the build
-                        // rather than silently degrading (#213).
-                        Err(e) => panic!("invalid $streamPolicy annotation: {e}"),
-                    },
-                    _ => extract_value_json(value),
-                }
-            } else {
-                extract_value_json(value)
-            };
+            let val = extract_value_json(value);
             match val {
                 Some(v) => result.push(serde_json::json!({
                     "id": ann_id,
@@ -261,134 +226,6 @@ fn extract_value_json(value: capnp::schema_capnp::value::Reader) -> Option<serde
         value::Uint32(n) => Some(serde_json::Value::Number(n.into())),
         value::Enum(ordinal) => Some(serde_json::json!({"enum_ordinal": ordinal})),
         _ => None,
-    }
-}
-
-/// Decode a `$streamPolicy` annotation value (a `StreamContract`, #213/#216) into
-/// structured JSON for the codegen backends. Uses the generated typed reader — capnp-rust
-/// cannot build a `StructSchema` from a raw CGR, so generic dynamic decode isn't possible
-/// (see `build.rs`). Each axis is a union; group variants carry their own params.
-fn extract_stream_contract(
-    ptr: capnp::any_pointer::Reader,
-) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
-    use crate::streaming_capnp::{backpressure, completion, delivery, ordering, retention, stream_contract};
-
-    let c: stream_contract::Reader = ptr.get_as()?;
-
-    // Fail-closed validation (#213): reject contradictory axis combinations at build time.
-    // A returned Err is treated as fatal by the caller (the build aborts) — an invalid
-    // policy must never silently pass through to codegen.
-    let lossy = matches!(c.get_backpressure()?.which()?, backpressure::DropOldest(_));
-    let reliable = matches!(c.get_delivery()?.which()?, delivery::AtLeastOnce(_));
-    if lossy && reliable {
-        return Err("streamPolicy: backpressure=dropOldest contradicts delivery=atLeastOnce \
-                    (a stream cannot be lossless and also drop under load)"
-            .into());
-    }
-    let terminal = matches!(c.get_completion()?.which()?, completion::Terminal(()));
-    let at_most_once = matches!(c.get_delivery()?.which()?, delivery::AtMostOnce(()));
-    if terminal && at_most_once {
-        return Err("streamPolicy: completion=terminal contradicts delivery=atMostOnce \
-                    (truncation detection requires reliable delivery)"
-            .into());
-    }
-
-    let ordering = match c.get_ordering()?.which()? {
-        ordering::Ordered(()) => serde_json::json!({ "ordered": true }),
-        ordering::Unordered(u) => serde_json::json!({
-            "unordered": { "replayWindow": u.get_replay_window() }
-        }),
-    };
-    let delivery = match c.get_delivery()?.which()? {
-        delivery::AtMostOnce(()) => serde_json::json!({ "atMostOnce": true }),
-        delivery::AtLeastOnce(a) => serde_json::json!({
-            "atLeastOnce": { "dedupWindow": a.get_dedup_window(), "resumable": a.get_resumable() }
-        }),
-    };
-    let completion = match c.get_completion()?.which()? {
-        completion::Terminal(()) => "terminal",
-        completion::None(()) => "none",
-    };
-    let retention = match c.get_retention()?.which()? {
-        retention::LiveOnly(()) => serde_json::json!({ "liveOnly": true }),
-        retention::Groups(n) => serde_json::json!({ "groups": n }),
-        retention::Seconds(n) => serde_json::json!({ "seconds": n }),
-    };
-    let backpressure = match c.get_backpressure()?.which()? {
-        backpressure::Block(()) => serde_json::json!({ "block": true }),
-        backpressure::DropOldest(d) => serde_json::json!({
-            "dropOldest": { "highWater": d.get_high_water() }
-        }),
-    };
-
-    Ok(serde_json::json!({
-        "ordering": ordering,
-        "delivery": delivery,
-        "completion": completion,
-        "retention": retention,
-        "backpressure": backpressure,
-    }))
-}
-
-#[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::items_after_test_module)]
-mod stream_contract_tests {
-    use super::extract_stream_contract;
-    use crate::streaming_capnp::stream_contract;
-
-    /// Round-trips a `StreamContract` (ordered / atLeastOnce{256,true} / none / groups=256
-    /// / block) through the typed decoder and asserts the JSON the codegen will consume —
-    /// covering void variants, a group with params, and the scalar-bearing retention variant.
-    #[test]
-    fn stream_contract_decodes_to_json() {
-        let mut msg = capnp::message::Builder::new_default();
-        {
-            let mut c = msg.init_root::<stream_contract::Builder>();
-            c.reborrow().init_ordering().set_ordered(());
-            {
-                let mut a = c.reborrow().init_delivery().init_at_least_once();
-                a.set_dedup_window(256);
-                a.set_resumable(true);
-            }
-            c.reborrow().init_completion().set_none(());
-            c.reborrow().init_retention().set_groups(256);
-            c.reborrow().init_backpressure().set_block(());
-        }
-        let root = msg
-            .get_root_as_reader::<capnp::any_pointer::Reader>()
-            .unwrap();
-        let json = extract_stream_contract(root).unwrap();
-
-        assert_eq!(json["ordering"]["ordered"], serde_json::json!(true));
-        assert_eq!(json["delivery"]["atLeastOnce"]["dedupWindow"], serde_json::json!(256));
-        assert_eq!(json["delivery"]["atLeastOnce"]["resumable"], serde_json::json!(true));
-        assert_eq!(json["completion"], serde_json::json!("none"));
-        assert_eq!(json["retention"]["groups"], serde_json::json!(256));
-        assert_eq!(json["backpressure"]["block"], serde_json::json!(true));
-    }
-
-    /// A contradictory policy (atLeastOnce + dropOldest = lossless yet drops) must be
-    /// rejected by the fail-closed validation, not silently decoded.
-    #[test]
-    fn contradictory_policy_is_rejected() {
-        let mut msg = capnp::message::Builder::new_default();
-        {
-            let mut c = msg.init_root::<stream_contract::Builder>();
-            c.reborrow().init_ordering().set_ordered(());
-            {
-                let mut a = c.reborrow().init_delivery().init_at_least_once();
-                a.set_dedup_window(64);
-                a.set_resumable(true);
-            }
-            c.reborrow().init_completion().set_none(());
-            c.reborrow().init_retention().set_groups(64);
-            c.reborrow().init_backpressure().init_drop_oldest().set_high_water(1024);
-        }
-        let root = msg
-            .get_root_as_reader::<capnp::any_pointer::Reader>()
-            .unwrap();
-        let err = extract_stream_contract(root).unwrap_err().to_string();
-        assert!(err.contains("dropOldest") && err.contains("atLeastOnce"), "got: {err}");
     }
 }
 

--- a/crates/hyprstream-rpc-build/src/lib.rs
+++ b/crates/hyprstream-rpc-build/src/lib.rs
@@ -13,6 +13,25 @@ pub mod backend;
 pub mod schema;
 pub mod util;
 
+// Generated `StreamContract` (#213/#216) types, used to decode the struct-valued
+// `$streamPolicy` annotation value (see `build.rs`). Crate-private; the generated
+// `streaming_capnp` references its import as `crate::annotations_capnp`, so both modules
+// live at the crate root.
+mod annotations_capnp {
+    #![allow(dead_code, unused_imports)]
+    #![allow(clippy::all, clippy::unwrap_used, clippy::expect_used, clippy::match_same_arms)]
+    #![allow(clippy::semicolon_if_nothing_returned, clippy::doc_markdown, clippy::indexing_slicing)]
+    #![allow(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_possible_wrap)]
+    include!(concat!(env!("OUT_DIR"), "/annotations_capnp.rs"));
+}
+mod streaming_capnp {
+    #![allow(dead_code, unused_imports)]
+    #![allow(clippy::all, clippy::unwrap_used, clippy::expect_used, clippy::match_same_arms)]
+    #![allow(clippy::semicolon_if_nothing_returned, clippy::doc_markdown, clippy::indexing_slicing)]
+    #![allow(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_possible_wrap)]
+    include!(concat!(env!("OUT_DIR"), "/streaming_capnp.rs"));
+}
+
 use std::path::Path;
 
 /// Compile Cap'n Proto schemas with CGR + metadata extraction.
@@ -190,14 +209,29 @@ fn extract_annotations(
         let name = annotation_names.get(&ann_id).cloned().unwrap_or_default();
 
         if let Ok(value) = ann.get_value() {
-            match extract_value_json(value) {
-                Some(val) => {
-                    result.push(serde_json::json!({
-                        "id": ann_id,
-                        "name": name,
-                        "value": val,
-                    }));
+            // Struct-valued annotations need the generated typed reader (#216) — capnp has
+            // no CGR-runtime dynamic decode. `$streamPolicy` (:StreamContract) is the one
+            // such annotation; decode it structurally. Any other struct annotation, or a
+            // decode failure, falls through to presence-only so we never silently corrupt.
+            let val = if name == "streamPolicy" {
+                match value.which() {
+                    Ok(capnp::schema_capnp::value::Struct(ptr)) => match extract_stream_contract(ptr) {
+                        Ok(v) => Some(v),
+                        // Fail-closed: an invalid/contradictory $streamPolicy aborts the build
+                        // rather than silently degrading (#213).
+                        Err(e) => panic!("invalid $streamPolicy annotation: {e}"),
+                    },
+                    _ => extract_value_json(value),
                 }
+            } else {
+                extract_value_json(value)
+            };
+            match val {
+                Some(v) => result.push(serde_json::json!({
+                    "id": ann_id,
+                    "name": name,
+                    "value": v,
+                })),
                 None => {
                     // Void annotations (e.g., $cliHidden) -- presence is the value
                     result.push(serde_json::json!({
@@ -227,6 +261,134 @@ fn extract_value_json(value: capnp::schema_capnp::value::Reader) -> Option<serde
         value::Uint32(n) => Some(serde_json::Value::Number(n.into())),
         value::Enum(ordinal) => Some(serde_json::json!({"enum_ordinal": ordinal})),
         _ => None,
+    }
+}
+
+/// Decode a `$streamPolicy` annotation value (a `StreamContract`, #213/#216) into
+/// structured JSON for the codegen backends. Uses the generated typed reader — capnp-rust
+/// cannot build a `StructSchema` from a raw CGR, so generic dynamic decode isn't possible
+/// (see `build.rs`). Each axis is a union; group variants carry their own params.
+fn extract_stream_contract(
+    ptr: capnp::any_pointer::Reader,
+) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+    use crate::streaming_capnp::{backpressure, completion, delivery, ordering, retention, stream_contract};
+
+    let c: stream_contract::Reader = ptr.get_as()?;
+
+    // Fail-closed validation (#213): reject contradictory axis combinations at build time.
+    // A returned Err is treated as fatal by the caller (the build aborts) — an invalid
+    // policy must never silently pass through to codegen.
+    let lossy = matches!(c.get_backpressure()?.which()?, backpressure::DropOldest(_));
+    let reliable = matches!(c.get_delivery()?.which()?, delivery::AtLeastOnce(_));
+    if lossy && reliable {
+        return Err("streamPolicy: backpressure=dropOldest contradicts delivery=atLeastOnce \
+                    (a stream cannot be lossless and also drop under load)"
+            .into());
+    }
+    let terminal = matches!(c.get_completion()?.which()?, completion::Terminal(()));
+    let at_most_once = matches!(c.get_delivery()?.which()?, delivery::AtMostOnce(()));
+    if terminal && at_most_once {
+        return Err("streamPolicy: completion=terminal contradicts delivery=atMostOnce \
+                    (truncation detection requires reliable delivery)"
+            .into());
+    }
+
+    let ordering = match c.get_ordering()?.which()? {
+        ordering::Ordered(()) => serde_json::json!({ "ordered": true }),
+        ordering::Unordered(u) => serde_json::json!({
+            "unordered": { "replayWindow": u.get_replay_window() }
+        }),
+    };
+    let delivery = match c.get_delivery()?.which()? {
+        delivery::AtMostOnce(()) => serde_json::json!({ "atMostOnce": true }),
+        delivery::AtLeastOnce(a) => serde_json::json!({
+            "atLeastOnce": { "dedupWindow": a.get_dedup_window(), "resumable": a.get_resumable() }
+        }),
+    };
+    let completion = match c.get_completion()?.which()? {
+        completion::Terminal(()) => "terminal",
+        completion::None(()) => "none",
+    };
+    let retention = match c.get_retention()?.which()? {
+        retention::LiveOnly(()) => serde_json::json!({ "liveOnly": true }),
+        retention::Groups(n) => serde_json::json!({ "groups": n }),
+        retention::Seconds(n) => serde_json::json!({ "seconds": n }),
+    };
+    let backpressure = match c.get_backpressure()?.which()? {
+        backpressure::Block(()) => serde_json::json!({ "block": true }),
+        backpressure::DropOldest(d) => serde_json::json!({
+            "dropOldest": { "highWater": d.get_high_water() }
+        }),
+    };
+
+    Ok(serde_json::json!({
+        "ordering": ordering,
+        "delivery": delivery,
+        "completion": completion,
+        "retention": retention,
+        "backpressure": backpressure,
+    }))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::items_after_test_module)]
+mod stream_contract_tests {
+    use super::extract_stream_contract;
+    use crate::streaming_capnp::stream_contract;
+
+    /// Round-trips a `StreamContract` (ordered / atLeastOnce{256,true} / none / groups=256
+    /// / block) through the typed decoder and asserts the JSON the codegen will consume —
+    /// covering void variants, a group with params, and the scalar-bearing retention variant.
+    #[test]
+    fn stream_contract_decodes_to_json() {
+        let mut msg = capnp::message::Builder::new_default();
+        {
+            let mut c = msg.init_root::<stream_contract::Builder>();
+            c.reborrow().init_ordering().set_ordered(());
+            {
+                let mut a = c.reborrow().init_delivery().init_at_least_once();
+                a.set_dedup_window(256);
+                a.set_resumable(true);
+            }
+            c.reborrow().init_completion().set_none(());
+            c.reborrow().init_retention().set_groups(256);
+            c.reborrow().init_backpressure().set_block(());
+        }
+        let root = msg
+            .get_root_as_reader::<capnp::any_pointer::Reader>()
+            .unwrap();
+        let json = extract_stream_contract(root).unwrap();
+
+        assert_eq!(json["ordering"]["ordered"], serde_json::json!(true));
+        assert_eq!(json["delivery"]["atLeastOnce"]["dedupWindow"], serde_json::json!(256));
+        assert_eq!(json["delivery"]["atLeastOnce"]["resumable"], serde_json::json!(true));
+        assert_eq!(json["completion"], serde_json::json!("none"));
+        assert_eq!(json["retention"]["groups"], serde_json::json!(256));
+        assert_eq!(json["backpressure"]["block"], serde_json::json!(true));
+    }
+
+    /// A contradictory policy (atLeastOnce + dropOldest = lossless yet drops) must be
+    /// rejected by the fail-closed validation, not silently decoded.
+    #[test]
+    fn contradictory_policy_is_rejected() {
+        let mut msg = capnp::message::Builder::new_default();
+        {
+            let mut c = msg.init_root::<stream_contract::Builder>();
+            c.reborrow().init_ordering().set_ordered(());
+            {
+                let mut a = c.reborrow().init_delivery().init_at_least_once();
+                a.set_dedup_window(64);
+                a.set_resumable(true);
+            }
+            c.reborrow().init_completion().set_none(());
+            c.reborrow().init_retention().set_groups(64);
+            c.reborrow().init_backpressure().init_drop_oldest().set_high_water(1024);
+        }
+        let root = msg
+            .get_root_as_reader::<capnp::any_pointer::Reader>()
+            .unwrap();
+        let err = extract_stream_contract(root).unwrap_err().to_string();
+        assert!(err.contains("dropOldest") && err.contains("atLeastOnce"), "got: {err}");
     }
 }
 

--- a/crates/hyprstream-rpc/schema/streaming.capnp
+++ b/crates/hyprstream-rpc/schema/streaming.capnp
@@ -184,6 +184,17 @@ struct StreamRegister {
 struct StreamBlock {
   prevMac @0 :Data;              # topic[..16] for block 0, mac_{n-1} for block N
   payloads @1 :List(StreamPayload);
+  # Producer-assigned monotonic counter per epoch (#219). On the moq transport
+  # this equals the moq Group id; it is the resume/dedup offset and the
+  # anti-replay/ordering anchor. Authenticated implicitly — the MAC covers the
+  # whole serialized StreamBlock. Consumer ordering/replay enforcement (gap-fatal
+  # vs media per-Group) is policy-selected via StreamPolicy (#163).
+  # Named `sequenceNumber` per IETF convention (DTLS RFC 9147, RTP RFC 3550).
+  sequenceNumber @2 :UInt64;
+  # Key-epoch (#223): analogous to DTLS 1.3 epoch (RFC 9147 §4.2.3). Bumps on
+  # re-key / producer restart so (epoch, sequenceNumber) is globally unique.
+  # 0 until the epoch lifecycle lands; ordinal reserved so that change is wire-safe.
+  epoch @3 :UInt64;
 }
 
 # =============================================================================

--- a/crates/hyprstream-rpc/src/moq_stream.rs
+++ b/crates/hyprstream-rpc/src/moq_stream.rs
@@ -273,8 +273,15 @@ impl MoqStreamPublisher {
     /// Serialize payloads into a StreamBlock, chain the MAC, and append as a
     /// moq Group (one Frame = `capnp || mac`).
     fn write_block(&mut self, payloads: &[StreamPayloadData]) -> Result<()> {
+        // The StreamBlock sequenceNumber (#219) IS the moq Group id — unified so the
+        // in-block sequenceNumber the consumer authenticates matches the transport Group.
+        // epoch is 0 until the #223 key-epoch lifecycle lands.
+        let sequence_number = self.next_group;
+        self.next_group += 1;
         let capnp_bytes = crate::streaming::encode_stream_block(
             self.hmac_state.prev_mac_bytes(),
+            sequence_number,
+            0,
             payloads,
         )?;
         let mac = self.hmac_state.compute_next(&capnp_bytes);
@@ -283,9 +290,7 @@ impl MoqStreamPublisher {
         frame.extend_from_slice(&capnp_bytes);
         frame.extend_from_slice(&mac);
 
-        let seq = self.next_group;
-        self.next_group += 1;
-        let mut group = self.track.create_group(Group::from(seq))?;
+        let mut group = self.track.create_group(Group::from(sequence_number))?;
         group.write_frame(Bytes::from(frame))?;
         group.finish()?;
         Ok(())

--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -292,6 +292,11 @@ pub struct StreamBuilder {
     hmac_state: StreamHmacState,
     pending: Vec<StreamPayloadData>,
     pending_bytes: usize,
+    /// Producer-assigned monotonic counter per epoch (#219). Named `sequenceNumber`
+    /// per IETF convention (DTLS RFC 9147, RTP RFC 3550). Incremented once per
+    /// emitted block; stamped into the block (MAC-covered) for resume/dedup/anti-replay.
+    /// Epoch is 0 until the #223 epoch lifecycle lands.
+    sequence_number: u64,
 }
 
 impl StreamBuilder {
@@ -302,6 +307,7 @@ impl StreamBuilder {
             hmac_state: StreamHmacState::new(mac_key, topic),
             pending: Vec::new(),
             pending_bytes: 0,
+            sequence_number: 0,
         }
     }
 
@@ -399,7 +405,10 @@ impl StreamBuilder {
 
         // Build StreamBlock capnp message (shared encoder; also used by the
         // moq plane in `moq_stream.rs`).
-        let capnp_bytes = encode_stream_block(self.hmac_state.prev_mac_bytes(), &payloads)?;
+        let sequence_number = self.sequence_number;
+        self.sequence_number += 1;
+        // epoch is 0 until the #223 key-epoch lifecycle lands.
+        let capnp_bytes = encode_stream_block(self.hmac_state.prev_mac_bytes(), sequence_number, 0, &payloads)?;
 
         let mac = self.hmac_state.compute_next(&capnp_bytes);
 
@@ -1947,12 +1956,18 @@ pub fn spawn_streaming_response(service_name: &str, continuation: crate::service
 /// chained-HMAC tokenstream.
 pub fn encode_stream_block(
     prev_mac: &[u8],
+    sequence_number: u64,
+    epoch: u64,
     payloads: &[StreamPayloadData],
 ) -> Result<Vec<u8>> {
     let mut msg = Builder::new_default();
     {
         let mut block = msg.init_root::<streaming_capnp::stream_block::Builder>();
         block.set_prev_mac(prev_mac);
+        // Producer-assigned counter (#219); MAC-covered implicitly (whole block is signed).
+        // epoch is 0 until the #223 key-epoch lifecycle lands.
+        block.set_sequence_number(sequence_number);
+        block.set_epoch(epoch);
 
         // Cap'n Proto uses u32 for list lengths
         let payloads_len = u32::try_from(payloads.len()).unwrap_or(u32::MAX);
@@ -2180,5 +2195,25 @@ mod tests {
 
         // Chain state should advance to mac2
         assert_eq!(state.prev_mac_bytes(), &mac2[..]);
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn stream_block_carries_sequence_number_and_epoch() {
+        // #219: the producer stamps sequenceNumber/epoch into the StreamBlock; since the
+        // MAC covers the whole serialized block, they're authenticated implicitly. Confirm
+        // the wire round-trips them (consumer enforcement is policy-selected, #163).
+        let payloads = vec![StreamPayloadData::Data(b"hello".to_vec())];
+        let bytes = encode_stream_block(&[0u8; 16], 42, 7, &payloads).unwrap();
+        let reader = capnp::serialize::read_message(
+            &mut std::io::Cursor::new(&bytes),
+            capnp::message::ReaderOptions::default(),
+        )
+        .unwrap();
+        let block = reader
+            .get_root::<crate::streaming_capnp::stream_block::Reader>()
+            .unwrap();
+        assert_eq!(block.get_sequence_number(), 42);
+        assert_eq!(block.get_epoch(), 7);
     }
 }


### PR DESCRIPTION
Part of epic #131, addresses #219 (and retires #216).

Stacked on #230.

## Summary
- Adds `groupSeq: UInt64` and `epoch: UInt64` to `StreamBlock` in `streaming.capnp`
- Binds seq + epoch into the MAC computation (wire + crypto prep for A2 consumer enforcement)
- Retires #216 (decode struct-valued `$streamPolicy` annotation + fail-closed validation) — merged into this commit

## Test plan
- [ ] `cargo build` passes
- [ ] MAC covers new seq/epoch fields (verified in unit tests)
- [ ] Old frames without seq/epoch remain backward-compatible (zero-default)