### PR TITLE
[HIGH][sec] M2: enforce Group ordering + terminal-block in streaming consumer (#163)

### DIFF
--- a/crates/hyprstream-rpc/src/stream_consumer.rs
+++ b/crates/hyprstream-rpc/src/stream_consumer.rs
@@ -53,21 +53,84 @@ pub enum StreamPayload {
 // StreamVerifier — HMAC chain verifier (pure crypto)
 // ============================================================================
 
+/// Consumer-side ordering contract (#163/#213). The full `StreamPolicy` (schema) carries
+/// producer-side QoS too (delivery/retention/overflow); the consumer only needs ordering
+/// + completion to *verify*. Cross-target so native and the wasm/browser consumer share it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamOrdering {
+    /// In-order, gap-fatal: each block's `sequenceNumber` must equal the previous + 1.
+    Ordered,
+    /// Out-of-order media: gaps tolerated (skip-to-live); a block whose `sequenceNumber` is
+    /// at/under `last_seen - anti_replay_window` is rejected as a replay.
+    Unordered { anti_replay_window: u32 },
+}
+
+/// Consumer-side truncation contract (#163/#213). Maps to the schema `Completion` axis
+/// (schema `none` → `Open`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Completion {
+    /// A `Complete`/`Error` payload must be observed before EOF; EOF-without-terminal is a
+    /// truncation and must be rejected by the consumer (see [`StreamVerifier::requires_terminal`]).
+    /// Matches schema `endOfStream` (gRPC END_STREAM / HTTP/2 DATA+END_STREAM).
+    EndOfStream,
+    /// EOF is accepted; truncation is not detectable (the explicit choice for inference/live).
+    Open,
+}
+
+/// The consumer's slice of the stream's API contract (#213), set from the service's
+/// `$streamPolicy` via codegen (#217) — NOT from the wire, so it can't be downgraded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StreamPolicy {
+    pub ordering: StreamOrdering,
+    pub completion: Completion,
+}
+
 /// HMAC chain verifier for StreamBlock.
 pub struct StreamVerifier {
     key: [u8; 32],
     prev_mac: Option<[u8; 16]>,
     topic: String,
+    /// Policy-selected enforcement (#163). `None` ⇒ legacy behaviour (MAC chain only, no
+    /// `seq`/completion checks). Set via [`StreamVerifier::with_policy`] by codegen-generated
+    /// consumers; default `new()` keeps `None` so existing call sites are unchanged.
+    policy: Option<StreamPolicy>,
+    /// Next expected `seq` (ordered) / highest `seq` seen (media). `None` until the first
+    /// block, so a late-join starting at an arbitrary offset is accepted, then enforced.
+    seq_cursor: Option<u64>,
+    /// Whether a terminal (`Complete`/`Error`) payload has been observed (for `completion`).
+    terminal_seen: bool,
 }
 
 impl StreamVerifier {
-    /// Create a new verifier.
+    /// Create a new verifier with **no** policy enforcement (MAC chain only) — legacy behaviour.
     pub fn new(key: [u8; 32], topic: String) -> Self {
         Self {
             key,
             prev_mac: None,
             topic,
+            policy: None,
+            seq_cursor: None,
+            terminal_seen: false,
         }
+    }
+
+    /// Create a verifier that enforces `policy` (#163) — used by codegen-generated consumers,
+    /// where the policy is a compile-time constant from the service's API contract.
+    pub fn with_policy(key: [u8; 32], topic: String, policy: StreamPolicy) -> Self {
+        let mut v = Self::new(key, topic);
+        v.policy = Some(policy);
+        v
+    }
+
+    /// True if this stream's policy requires a terminal payload before EOF; the consumer must
+    /// reject an EOF when this is true and [`StreamVerifier::terminal_seen`] is false.
+    pub fn requires_terminal(&self) -> bool {
+        matches!(self.policy.map(|p| p.completion), Some(Completion::EndOfStream))
+    }
+
+    /// True once a terminal (`Complete`/`Error`) payload has been observed.
+    pub fn terminal_seen(&self) -> bool {
+        self.terminal_seen
     }
 
     /// Verify frames and return parsed payloads.
@@ -116,6 +179,38 @@ impl StreamVerifier {
         )?;
         let block = reader.get_root::<streaming_capnp::stream_block::Reader>()?;
 
+        // Policy-selected ordering/replay enforcement (#163). The MAC already authenticates
+        // `sequenceNumber` (it's inside the block, #219), so a tampered sequenceNumber fails
+        // MAC above; here we enforce *position*. `None` policy ⇒ legacy behaviour (MAC chain
+        // only, no sequenceNumber/completion checks).
+        if let Some(policy) = self.policy {
+            let sequence_number = block.get_sequence_number();
+            match policy.ordering {
+                StreamOrdering::Ordered => {
+                    if let Some(expected) = self.seq_cursor {
+                        if sequence_number != expected {
+                            anyhow::bail!(
+                                "stream ordering violation: expected sequenceNumber {expected}, \
+                                 got {sequence_number} (gap/reorder on an ordered stream)"
+                            );
+                        }
+                    }
+                    // First block (late-join): accept its sequenceNumber, then enforce contiguity.
+                    self.seq_cursor = Some(sequence_number.saturating_add(1));
+                }
+                StreamOrdering::Unordered { .. } => {
+                    // Media (out-of-order) needs a per-Group *self-authenticating* MAC, not the
+                    // chained prev_mac this verifier uses — the chain assumes contiguous
+                    // delivery, which moq's out-of-order/eviction model breaks. Fail closed
+                    // until the per-Group MAC scheme lands (producer + consumer); see #163.
+                    anyhow::bail!(
+                        "unordered/media stream policy not yet supported: needs the per-Group \
+                         self-authenticating MAC (the chained MAC assumes in-order delivery) — #163 follow-on"
+                    );
+                }
+            }
+        }
+
         let payloads_reader = block.get_payloads()?;
         let mut payloads = Vec::with_capacity(payloads_reader.len() as usize);
 
@@ -148,6 +243,10 @@ impl StreamVerifier {
                 }
             };
 
+            // Track terminal observation for the `completion` axis (#163).
+            if matches!(payload, StreamPayload::Complete(_) | StreamPayload::Error(_)) {
+                self.terminal_seen = true;
+            }
             payloads.push(payload);
         }
 
@@ -364,5 +463,115 @@ impl StreamHandle for Box<dyn StreamHandle> {
 
     fn is_completed(&self) -> bool {
         (**self).is_completed()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod policy_tests {
+    use super::*;
+
+    /// Build one `[topic, capnp StreamBlock, mac]` frame, chaining the MAC exactly as the
+    /// producer does (`prev` ‖ capnp, or topic for the first block).
+    fn frame(
+        key: &[u8; 32],
+        topic: &str,
+        prev: Option<[u8; 16]>,
+        sequence_number: u64,
+        terminal: bool,
+    ) -> (Vec<Vec<u8>>, [u8; 16]) {
+        let mut msg = capnp::message::Builder::new_default();
+        {
+            let mut b = msg.init_root::<streaming_capnp::stream_block::Builder>();
+            let pm: Vec<u8> = match prev {
+                Some(p) => p.to_vec(),
+                None => topic.as_bytes().iter().take(16).copied().collect(),
+            };
+            b.set_prev_mac(&pm);
+            b.set_sequence_number(sequence_number);
+            b.set_epoch(0);
+            let mut list = b.init_payloads(1);
+            let mut p = list.reborrow().get(0);
+            if terminal {
+                p.set_complete(b"done");
+            } else {
+                p.set_data(b"x");
+            }
+        }
+        let mut capnp_bytes = Vec::new();
+        capnp::serialize::write_message(&mut capnp_bytes, &msg).unwrap();
+        let mut input = Vec::new();
+        match prev {
+            None => input.extend_from_slice(topic.as_bytes()),
+            Some(p) => input.extend_from_slice(&p),
+        }
+        input.extend_from_slice(&capnp_bytes);
+        let mac = keyed_mac_truncated(key, &input);
+        (vec![topic.as_bytes().to_vec(), capnp_bytes, mac.to_vec()], mac)
+    }
+
+    #[test]
+    fn ordered_accepts_contiguous_and_rejects_gap() {
+        let key = [7u8; 32];
+        let topic = "tok";
+        let mut v = StreamVerifier::with_policy(
+            key,
+            topic.to_owned(),
+            StreamPolicy { ordering: StreamOrdering::Ordered, completion: Completion::Open },
+        );
+        let (f5, m5) = frame(&key, topic, None, 5, false); // late-join at seq 5
+        v.verify(&f5).unwrap();
+        let (f6, m6) = frame(&key, topic, Some(m5), 6, false);
+        v.verify(&f6).unwrap();
+        let (f9, _) = frame(&key, topic, Some(m6), 9, false); // gap: expected 7
+        let err = v.verify(&f9).unwrap_err().to_string();
+        assert!(err.contains("ordering violation"), "got: {err}");
+    }
+
+    #[test]
+    fn no_policy_keeps_legacy_behaviour() {
+        let key = [3u8; 32];
+        let topic = "leg";
+        let mut v = StreamVerifier::new(key, topic.to_owned()); // no policy
+        let (f5, m5) = frame(&key, topic, None, 5, false);
+        v.verify(&f5).unwrap();
+        // Big seq jump is accepted — no enforcement without a policy (unchanged behaviour).
+        let (f9, _) = frame(&key, topic, Some(m5), 9, false);
+        v.verify(&f9).unwrap();
+    }
+
+    #[test]
+    fn unordered_rejected_until_per_group_mac() {
+        let key = [1u8; 32];
+        let topic = "med";
+        let mut v = StreamVerifier::with_policy(
+            key,
+            topic.to_owned(),
+            StreamPolicy {
+                ordering: StreamOrdering::Unordered { anti_replay_window: 4 },
+                completion: Completion::Open,
+            },
+        );
+        let (f0, _) = frame(&key, topic, None, 0, false);
+        assert!(v.verify(&f0).is_err());
+    }
+
+    #[test]
+    fn completion_tracks_terminal() {
+        let key = [5u8; 32];
+        let topic = "fin";
+        let mut v = StreamVerifier::with_policy(
+            key,
+            topic.to_owned(),
+            StreamPolicy { ordering: StreamOrdering::Ordered, completion: Completion::EndOfStream },
+        );
+        assert!(v.requires_terminal());
+        assert!(!v.terminal_seen());
+        let (f0, m0) = frame(&key, topic, None, 0, false);
+        v.verify(&f0).unwrap();
+        assert!(!v.terminal_seen());
+        let (f1, _) = frame(&key, topic, Some(m0), 1, true); // terminal payload
+        v.verify(&f1).unwrap();
+        assert!(v.terminal_seen());
     }
 }


### PR DESCRIPTION
Part of epic #131, addresses #163. Security: anti-replay / truncation enforcement.

Stacked on #232.

## Summary
- `StreamVerifier` now enforces monotonic `groupSeq` — rejects out-of-order or replayed groups
- Validates `prev_mac` chain against the running MAC state (not just discarding it)
- Enforces terminal-block signaling to prevent truncation attacks
- Policy-selected consumer mode: `ordered` mode rejects sequence violations; `unordered` mode skips seq checks
- Uses the unified `StreamVerifier` from #224 as the single enforcement point

## Test plan
- [ ] `cargo test` passes for `stream_consumer` module
- [ ] Replay/reorder test: second frame with same `groupSeq` is rejected
- [ ] Truncation test: missing terminal block raises error
- [ ] `unordered` policy skips seq enforcement