### PR TITLE
[blocker] Fix wasm32/browser build: getrandom wasm_js backend (#225)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6632,6 +6632,7 @@ dependencies = [
  "ed25519-dalek 2.2.0",
  "futures",
  "getrandom 0.2.16",
+ "getrandom 0.4.2",
  "h3",
  "h3-quinn",
  "h3-webtransport",

--- a/crates/hyprstream-rpc/Cargo.toml
+++ b/crates/hyprstream-rpc/Cargo.toml
@@ -69,6 +69,11 @@ web-sys = { version = "0.3.64", features = [
 ] }
 serde-wasm-bindgen = "0.6"
 getrandom = { version = "0.2", features = ["js"] }  # rand 0.8 uses getrandom 0.2
+# The always-on PQ crypto (ml-dsa/ml-kem → sha3/crypto-common) pulls getrandom 0.4, which
+# refuses to build on wasm32-unknown-unknown unless its `wasm_js` backend is enabled.
+# Declare it (renamed to coexist with the 0.2 entry) so the feature unifies onto the
+# transitive 0.4 dep and the browser/WebTransport consumer compiles for wasm (#225).
+getrandom_v04 = { package = "getrandom", version = "0.4", features = ["wasm_js"] }
 
 # Native-only deps (not compiled for wasm32)
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]


### PR DESCRIPTION
Part of epic #131, addresses #225. Pre-existing blocker uncovered during M2 cross-target verification.

Stacked on #233.

## Summary
- Adds `getrandom` with `wasm_js` feature to `hyprstream-rpc` and `hyprstream-rpc-std` (cdylib + wasm-pack targets)
- Ensures PQ crypto pulls in the correct `getrandom` 0.4 backend for wasm32
- Sets `web_sys_unstable_apis` RUSTFLAG in `build-wasm.sh` (required for WebTransport APIs)
- Unblocks the browser streaming consumer path (#226, #217)

## Test plan
- [ ] `wasm-pack build` succeeds for `hyprstream-rpc-std`
- [ ] `cargo build --target wasm32-unknown-unknown` succeeds for `hyprstream-rpc`
- [ ] No regression in native `cargo test`