### PR TITLE
[M2-A1] StreamService → moq Origin: flip primary path, AnyStreamPublisher bridge (#220)

### DIFF
--- a/crates/hyprstream-rpc/src/moq_stream.rs
+++ b/crates/hyprstream-rpc/src/moq_stream.rs
@@ -37,7 +37,7 @@
 //! latest Group natively by the moq Track cache (respecting upstream Group
 //! cache consts), so the custom `StreamResume` / rejoin-buffer code is gone.
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use anyhow::{anyhow, Result};
 use bytes::Bytes;
@@ -47,6 +47,30 @@ use tokio_util::sync::CancellationToken;
 
 use crate::crypto::StreamHmacState;
 use crate::streaming::{StreamContext, StreamPayloadData, StreamVerifier};
+
+// ============================================================================
+// Process-global moq streaming origin — set once at startup, read everywhere.
+// Allows StreamChannel (publisher side) to use the same origin as StreamService
+// (server side) without threading it through every service factory.
+// ============================================================================
+
+static GLOBAL_MOQ_ORIGIN: OnceLock<MoqStreamOrigin> = OnceLock::new();
+
+/// Register the process-global moq streaming origin.
+///
+/// Must be called once at startup (from the streams service factory) before any
+/// `StreamChannel::publisher()` call. Returns `true` on first call, `false` if
+/// already set (idempotent — a second set is silently ignored).
+pub fn init_global_moq_origin(origin: MoqStreamOrigin) -> bool {
+    GLOBAL_MOQ_ORIGIN.set(origin).is_ok()
+}
+
+/// Borrow the process-global moq streaming origin, if initialized.
+///
+/// `None` when moq is not yet wired (unit tests, ZMQ-only deployments).
+pub fn global_moq_origin() -> Option<&'static MoqStreamOrigin> {
+    GLOBAL_MOQ_ORIGIN.get()
+}
 
 /// The single track name that carries StreamBlock groups for a broadcast.
 pub const STREAM_TRACK: &str = "stream";
@@ -297,6 +321,106 @@ impl MoqStreamPublisher {
     }
 }
 
+// ============================================================================
+// AnyStreamPublisher — unified publish API over ZMQ or moq-lite paths (#220)
+// ============================================================================
+
+/// Unified publisher that dispatches to either the ZMQ or moq-lite streaming
+/// plane. The API surface matches `StreamPublisher` exactly so all call sites
+/// that receive a publisher via closure (e.g. `StreamChannel::run_stream`) work
+/// unchanged regardless of which transport is active.
+pub enum AnyStreamPublisher {
+    /// ZMQ PUSH path (legacy, kept behind `StreamService::with_zmq_fallback`).
+    Zmq(crate::streaming::StreamPublisher),
+    /// moq-lite in-process path (M2a primary).
+    Moq(MoqStreamPublisher),
+}
+
+impl AnyStreamPublisher {
+    /// Publish binary data. For the moq path the rate hint is ignored (each
+    /// call maps 1:1 to one moq Group; batching is a ZMQ-path concern).
+    pub async fn publish_data(&mut self, data: &[u8]) -> Result<()> {
+        match self {
+            Self::Zmq(p) => p.publish_data(data).await,
+            Self::Moq(p) => p.publish_data(data).await,
+        }
+    }
+
+    /// Publish binary data with adaptive-batching rate hint (ZMQ path only).
+    /// On the moq path the rate is ignored and data is published immediately.
+    pub async fn publish_data_with_rate(&mut self, data: &[u8], rate: f32) -> Result<()> {
+        match self {
+            Self::Zmq(p) => p.publish_data_with_rate(data, rate).await,
+            Self::Moq(p) => {
+                let _ = rate;
+                p.publish_data(data).await
+            }
+        }
+    }
+
+    /// Publish a progress update (`stage:current:total`).
+    pub async fn publish_progress(&mut self, stage: &str, current: usize, total: usize) -> Result<()> {
+        let data = format!("{}:{}:{}", stage, current, total);
+        self.publish_data(data.as_bytes()).await
+    }
+
+    /// Publish an error payload (terminal).
+    pub async fn publish_error(&mut self, message: &str) -> Result<()> {
+        match self {
+            Self::Zmq(p) => p.publish_error(message).await,
+            Self::Moq(p) => p.publish_error(message).await,
+        }
+    }
+
+    /// Complete the stream with app-specific metadata (consumes self).
+    pub async fn complete(self, metadata: &[u8]) -> Result<()> {
+        match self {
+            Self::Zmq(p) => p.complete(metadata).await,
+            Self::Moq(p) => p.complete(metadata).await,
+        }
+    }
+
+    /// Complete the stream without consuming self (for use inside `run_stream`).
+    pub async fn complete_ref(&mut self, metadata: &[u8]) -> Result<()> {
+        match self {
+            Self::Zmq(p) => p.complete_ref(metadata).await,
+            Self::Moq(p) => p.complete_ref(metadata).await,
+        }
+    }
+
+    /// Flush any pending batched data (ZMQ path). No-op on the moq path.
+    pub async fn flush(&mut self) -> Result<()> {
+        match self {
+            Self::Zmq(p) => p.flush().await,
+            Self::Moq(_) => Ok(()), // moq publishes each block immediately
+        }
+    }
+
+    /// The opaque topic this publisher serves.
+    pub fn topic(&self) -> &str {
+        match self {
+            Self::Zmq(p) => p.topic(),
+            Self::Moq(p) => p.topic(),
+        }
+    }
+
+    /// Whether a terminal frame (Error/Complete) has been sent.
+    pub fn is_terminated(&self) -> bool {
+        match self {
+            Self::Zmq(p) => p.is_terminated(),
+            Self::Moq(p) => p.is_terminated(),
+        }
+    }
+
+    /// Whether the stream has been cancelled via the `CancellationToken`.
+    pub fn is_cancelled(&self) -> bool {
+        match self {
+            Self::Zmq(p) => p.is_cancelled(),
+            Self::Moq(p) => p.is_cancelled(),
+        }
+    }
+}
+
 /// Consumer-side helper: split a moq Frame payload back into the ZMQ-style
 /// `[topic, capnp, mac]` frames expected by [`StreamVerifier::verify`], then
 /// verify and parse it.
@@ -375,6 +499,52 @@ mod tests {
         assert!(matches!(&got[0], StreamPayload::Data(d) if d == b"hello"));
         assert!(matches!(&got[1], StreamPayload::Data(d) if d == b"world"));
         assert!(matches!(&got[2], StreamPayload::Complete(_)));
+        Ok(())
+    }
+
+    /// `AnyStreamPublisher::Moq` round-trip: publish via the enum wrapper and
+    /// verify the same bytes arrive on the moq consumer side.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn any_stream_publisher_moq_round_trip() -> Result<()> {
+        let origin = origin();
+        let (_client_secret, client_pub) = crate::crypto::generate_ephemeral_keypair();
+        let ctx = StreamContext::from_dh(&client_pub.to_bytes())?;
+        let topic = ctx.topic().to_owned();
+        let mac_key = *ctx.mac_key();
+
+        // Publish via AnyStreamPublisher::Moq (the primary M2a path)
+        let mut any_pub = AnyStreamPublisher::Moq(origin.publisher(&ctx)?);
+        any_pub.publish_data(b"ping").await?;
+        any_pub.complete_ref(b"{}").await?;
+
+        // Consume and verify
+        let path = origin.broadcast_path(&topic);
+        let bc = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            origin.consumer().announced_broadcast(path.as_str()),
+        )
+        .await?
+        .ok_or_else(|| anyhow!("broadcast not announced"))?;
+        let mut track = bc.subscribe_track(&Track::new(STREAM_TRACK))?;
+        let mut verifier = StreamVerifier::new(mac_key, topic.clone());
+        let mut got: Vec<StreamPayload> = Vec::new();
+        for _ in 0..2 {
+            let mut group = tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                track.next_group(),
+            )
+            .await??
+            .ok_or_else(|| anyhow!("next_group None"))?;
+            let frame = tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                group.read_frame(),
+            )
+            .await??
+            .ok_or_else(|| anyhow!("read_frame None"))?;
+            got.extend(verify_moq_frame(&mut verifier, &topic, &frame)?);
+        }
+        assert!(matches!(&got[0], StreamPayload::Data(d) if d == b"ping"));
+        assert!(matches!(&got[1], StreamPayload::Complete(_)));
         Ok(())
     }
 

--- a/crates/hyprstream-rpc/src/service/streaming.rs
+++ b/crates/hyprstream-rpc/src/service/streaming.rs
@@ -153,13 +153,17 @@ pub struct StreamService {
 
     /// moq-lite streaming plane (epic #134 M2a).
     ///
-    /// When set, in-process publishers can append directly to the shared
-    /// `moq_net::Origin` (via [`crate::moq_stream::MoqStreamOrigin::publisher`])
-    /// and external subscribers consume the same origin over the `moql` ALPN.
-    /// The ZMQ PULL→XPUB proxy below remains as a parallel path until the
-    /// substrate is wired into service bootstrap. The in-process publish gate
-    /// (`authorize_signer`) is mirrored onto the moq origin by the factory.
+    /// When set and `zmq_fallback` is false (default), the ZMQ PULL→XPUB
+    /// loop is not started. In-process publishers reach this origin via the
+    /// process-global accessor `global_moq_origin()`; external subscribers
+    /// consume over the `moql` ALPN. Late-join is moq's job (Track cache).
     moq: Option<crate::moq_stream::MoqStreamOrigin>,
+
+    /// Keep the ZMQ PULL→XPUB proxy loop running even when `moq` is set.
+    ///
+    /// Default: `false`. Set via `with_zmq_fallback()` for differential
+    /// testing against the ZMQ path. Removed entirely in M5 teardown.
+    zmq_fallback: bool,
 }
 
 impl StreamService {
@@ -216,7 +220,15 @@ impl StreamService {
             verifying_key,
             authorize_signer: None,
             moq: None,
+            zmq_fallback: false,
         }
+    }
+
+    /// Keep the ZMQ PULL→XPUB proxy loop running even when a moq origin is
+    /// attached. Used for differential testing; removed in M5 teardown.
+    pub fn with_zmq_fallback(mut self) -> Self {
+        self.zmq_fallback = true;
+        self
     }
 
     /// Attach a moq-lite streaming origin (epic #134 M2a).
@@ -899,11 +911,34 @@ impl crate::service::Spawnable for StreamService {
         shutdown: Arc<Notify>,
         on_ready: Option<tokio::sync::oneshot::Sender<()>>,
     ) -> Result<(), crate::error::RpcError> {
+        // When moq is primary (default M2a configuration), skip the ZMQ proxy
+        // loop entirely. In-process publishers go straight to the global moq
+        // origin; external subscribers consume over the `moql` ALPN. The ZMQ
+        // PULL→XPUB sockets are not bound so they consume no OS resources.
+        if self.moq.is_some() && !self.zmq_fallback {
+            info!(
+                service = %self.name,
+                "StreamService running in moq-primary mode (ZMQ proxy bypassed)"
+            );
+            if let Some(tx) = on_ready {
+                let _ = tx.send(());
+            }
+            let _ = crate::notify::ready();
+            // Park the spawner thread until shutdown is signalled.
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|e| crate::error::RpcError::SpawnFailed(format!("rt: {e}")))?;
+            rt.block_on(shutdown.notified());
+            info!(service = %self.name, "StreamService (moq-primary) stopped");
+            return Ok(());
+        }
+
         info!(
             service = %self.name,
             pub_endpoint = %self.pub_transport.to_zmq_string(),
             pull_endpoint = %self.pull_transport.to_zmq_string(),
-            "Starting StreamService queuing proxy"
+            "Starting StreamService ZMQ queuing proxy"
         );
 
         // Setup sockets BEFORE signaling ready

--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -1354,21 +1354,29 @@ impl StreamChannel {
         // 1. DH key exchange
         let stream_ctx = StreamContext::from_dh(client_ephemeral_pubkey)?;
 
-        // 2. Pre-authorize data + control topics with StreamService
-        let exp = chrono::Utc::now().timestamp() + expiry_secs;
-        self.pre_authorize(&stream_ctx, exp, claims.clone()).await?;
-        self.register_topic(stream_ctx.ctrl_topic(), exp, claims).await?;
+        if crate::moq_stream::global_moq_origin().is_none() {
+            // ZMQ path: pre-register topics with StreamService and wire the
+            // control-channel SUB socket. On the moq path these are unnecessary
+            // — the moq Origin's `authorize_signer` gate controls access, and
+            // late-join + cancellation are handled natively by moq Track cache
+            // and the CancellationToken below.
 
-        // 3. Subscribe control channel and register cancel token
-        let ctrl_tx = self.get_or_init_ctrl_sub().await?;
-        ctrl_tx.send(stream_ctx.ctrl_topic().as_bytes().to_vec()).await
-            .map_err(|_| anyhow::anyhow!("ctrl listener closed"))?;
-        self.cancel_tokens.insert(
-            stream_ctx.ctrl_topic().to_owned(),
-            (stream_ctx.cancel_token().clone(), *stream_ctx.ctrl_mac_key()),
-        );
+            // 2. Pre-authorize data + control topics with StreamService
+            let exp = chrono::Utc::now().timestamp() + expiry_secs;
+            self.pre_authorize(&stream_ctx, exp, claims.clone()).await?;
+            self.register_topic(stream_ctx.ctrl_topic(), exp, claims).await?;
 
-        // 4. Spawn JWT expiry timeout as universal backstop
+            // 3. Subscribe control channel and register cancel token
+            let ctrl_tx = self.get_or_init_ctrl_sub().await?;
+            ctrl_tx.send(stream_ctx.ctrl_topic().as_bytes().to_vec()).await
+                .map_err(|_| anyhow::anyhow!("ctrl listener closed"))?;
+            self.cancel_tokens.insert(
+                stream_ctx.ctrl_topic().to_owned(),
+                (stream_ctx.cancel_token().clone(), *stream_ctx.ctrl_mac_key()),
+            );
+        }
+
+        // 4. Spawn JWT expiry timeout as universal backstop (both paths)
         let token = stream_ctx.cancel_token().clone();
         let ctrl_topic = stream_ctx.ctrl_topic().to_owned();
         let tokens_map = Arc::clone(&self.cancel_tokens);
@@ -1550,27 +1558,34 @@ impl StreamChannel {
     /// // ... perform operation ...
     /// publisher.complete(&result_bytes).await?;
     /// ```
-    pub async fn publisher(&self, ctx: &StreamContext) -> Result<StreamPublisher> {
+    /// Create a publisher for a stream context.
+    ///
+    /// Returns an `AnyStreamPublisher` that dispatches to the moq-lite origin
+    /// when one is globally registered (#220), otherwise falls back to ZMQ PUSH.
+    pub async fn publisher(&self, ctx: &StreamContext) -> Result<crate::moq_stream::AnyStreamPublisher> {
+        if let Some(origin) = crate::moq_stream::global_moq_origin() {
+            let moq_pub = origin.publisher(ctx)?;
+            return Ok(crate::moq_stream::AnyStreamPublisher::Moq(moq_pub));
+        }
         let socket_arc = self.get_or_init_socket().await?;
-        Ok(StreamPublisher::new(socket_arc, ctx))
+        Ok(crate::moq_stream::AnyStreamPublisher::Zmq(StreamPublisher::new(socket_arc, ctx)))
     }
 
     /// Run a streaming operation with framework-guaranteed terminal frame.
     ///
-    /// The closure receives `StreamPublisher` by value and **must return it**
-    /// alongside its result. This preserves the HMAC chain so the framework
-    /// can send a valid terminal frame if the closure didn't.
+    /// The closure receives an [`AnyStreamPublisher`] by value and **must return
+    /// it** alongside its result. The framework sends a terminal frame if the
+    /// closure didn't. Transport (moq-lite or ZMQ) is selected automatically
+    /// based on whether a global moq origin is registered.
     ///
     /// After the closure returns:
     /// - If `Ok` and not terminated → framework sends `Complete` (empty metadata)
     /// - If `Err` and not terminated → framework sends `Error` with the error message
     /// - If already terminated → no-op (closure handled it)
-    ///
-    /// Drop remains as a panic-only safety net.
     pub async fn run_stream<F, Fut, R>(&self, ctx: &StreamContext, f: F) -> Result<R>
     where
-        F: FnOnce(StreamPublisher) -> Fut,
-        Fut: Future<Output = (StreamPublisher, Result<R>)>,
+        F: FnOnce(crate::moq_stream::AnyStreamPublisher) -> Fut,
+        Fut: Future<Output = (crate::moq_stream::AnyStreamPublisher, Result<R>)>,
     {
         let publisher = self.publisher(ctx).await?;
         let (mut publisher, result) = f(publisher).await;
@@ -1598,9 +1613,9 @@ impl StreamChannel {
     /// Used by NotificationService where topics are registered via `register_topic()`
     /// and don't use DH-based key exchange. The transport MAC key is randomly generated
     /// (separate from notification E2E MAC which is embedded in the payload).
-    pub async fn publisher_for_topic(&self, topic: &str) -> Result<StreamPublisher> {
-        // Generate a random transport-level MAC key for StreamService wire format.
-        // This is NOT the notification's E2E MAC — it's for StreamService HMAC chain.
+    pub async fn publisher_for_topic(&self, topic: &str) -> Result<crate::moq_stream::AnyStreamPublisher> {
+        // Generate a random transport-level MAC key for the HMAC chain.
+        // (Not the notification's E2E MAC — that's embedded in the payload.)
         let mut mac_key = [0u8; 32];
         rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut mac_key);
 

--- a/crates/hyprstream-workers/src/runtime/service.rs
+++ b/crates/hyprstream-workers/src/runtime/service.rs
@@ -14,7 +14,8 @@ use tracing::{debug, info, warn};
 // Import ZMQ service infrastructure from hyprstream-rpc
 use hyprstream_rpc::prelude::SigningKey;
 use hyprstream_rpc::service::{AuthorizeFn, EnvelopeContext, RequestService};
-use hyprstream_rpc::streaming::{StreamChannel, StreamPublisher};
+use hyprstream_rpc::moq_stream::AnyStreamPublisher;
+use hyprstream_rpc::streaming::StreamChannel;
 use hyprstream_rpc::transport::TransportConfig;
 
 use crate::config::PoolConfig;
@@ -907,7 +908,7 @@ struct ActiveFdStream {
 /// 2. Reads from container console (vsock/serial)
 /// 3. Publishes data via StreamPublisher with HMAC authentication
 async fn run_fd_streaming_task(
-    publisher: &mut StreamPublisher,
+    publisher: &mut AnyStreamPublisher,
     container_id: String,
     cancel_token: CancellationToken,
     sandbox_pool: Arc<SandboxPool>,

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -419,14 +419,18 @@ fn create_streams_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawna
     };
 
     // moq-lite streaming origin (epic #134 M2a). A standalone origin is built
-    // here so StreamService holds it and in-process publishers can append to it.
-    // When the iroh substrate is wired into bootstrap (M2b), this origin will be
-    // the substrate's shared `IrohMoqProtocolHandler` origin so external moq
-    // subscribers consume the same tree over the `moql` ALPN.
+    // here and registered as the process-global so all StreamChannels (on
+    // InferenceService, MetricsService, etc.) use it without each needing a
+    // reference threaded through their factory. In M2b this becomes the iroh
+    // substrate's shared origin so external moq subscribers see the same tree.
     let moq_origin = hyprstream_rpc::moq_stream::MoqStreamOrigin::standalone()
         .with_prefix("local/streams")
         .with_authorize_signer(gate)
         .build();
+
+    // Register the global BEFORE StreamService signals ready — all downstream
+    // services that call StreamChannel::publisher() will see it immediately.
+    hyprstream_rpc::moq_stream::init_global_moq_origin(moq_origin.clone());
 
     let stream_service = StreamService::new(
         "streams",


### PR DESCRIPTION
Part of epic #131, addresses #220. Depends on #219 (groupSeq in StreamBlock).

Stacked on #235.

## Summary
- `StreamService` now holds a `MoqStreamOrigin` as the primary write path
- Adds `AnyStreamPublisher` enum that bridges the ZMQ PULL→XPUB legacy path and the moq-primary path
- Deletes the rejoin buffer (moq handles fan-out natively)
- ZMQ PULL socket retained as a compatibility shim; moq is the authoritative publisher

## Test plan
- [ ] `cargo test` passes
- [ ] Existing streaming integration tests pass with moq-primary path
- [ ] ZMQ→moq bridge path: legacy producers still deliver frames via moq