### PR TITLE
[M2-A1] Wire StreamPolicy into consumer — codegen + WASM path + mcp_service (#217/#218)

### DIFF
--- a/crates/hyprstream-rpc-derive/src/codegen/client.rs
+++ b/crates/hyprstream-rpc-derive/src/codegen/client.rs
@@ -452,6 +452,7 @@ fn generate_trait_method_impl(
                     &info.server_pubkey,
                     &client_secret,
                     &client_pubkey_bytes,
+                    info.policy,
                 )
             }
         })

--- a/crates/hyprstream-rpc/src/stream_consumer.rs
+++ b/crates/hyprstream-rpc/src/stream_consumer.rs
@@ -311,8 +311,12 @@ impl<T: Transport> StreamHandleImpl<T> {
         let subscriber = transport.subscribe(keys.topic.as_bytes()).await?;
         let publisher = transport.publish(keys.ctrl_topic.as_bytes()).await.ok();
 
-        // Pure crypto
-        let verifier = StreamVerifier::new(*keys.mac_key, keys.topic.clone());
+        // Policy from the signed StreamInfo handshake — enforced for both native and WASM paths.
+        let verifier = StreamVerifier::with_policy(
+            *keys.mac_key,
+            keys.topic.clone(),
+            stream_info.policy.into(),
+        );
 
         Ok(Self {
             subscriber,
@@ -463,6 +467,28 @@ impl StreamHandle for Box<dyn StreamHandle> {
 
     fn is_completed(&self) -> bool {
         (**self).is_completed()
+    }
+}
+
+// ─── Conversion from wire StreamPolicy ────────────────────────────────────────
+
+/// Convert the full wire `StreamPolicy` (5 axes) to the consumer's 2-axis slice.
+///
+/// The delivery, retention, and overflow_policy axes are producer-side concerns;
+/// the consumer only enforces ordering + completion.
+impl From<crate::stream_info::StreamPolicy> for StreamPolicy {
+    fn from(p: crate::stream_info::StreamPolicy) -> Self {
+        let ordering = match p.ordering {
+            crate::stream_info::Ordering::Ordered => StreamOrdering::Ordered,
+            crate::stream_info::Ordering::Unordered { anti_replay_window } => {
+                StreamOrdering::Unordered { anti_replay_window }
+            }
+        };
+        let completion = match p.completion {
+            crate::stream_info::Completion::EndOfStream => Completion::EndOfStream,
+            crate::stream_info::Completion::None => Completion::Open,
+        };
+        StreamPolicy { ordering, completion }
     }
 }
 

--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -1048,6 +1048,7 @@ impl StreamHandle {
         server_pubkey: &[u8],
         client_secret: &DhSecret,
         client_pubkey: &[u8],
+        policy: crate::stream_info::StreamPolicy,
     ) -> Result<Self> {
         // Perform DH
         let server_pub = DhPublic::from_slice(server_pubkey)
@@ -1076,7 +1077,7 @@ impl StreamHandle {
             "Subscribed to E2E authenticated stream"
         );
 
-        let verifier = StreamVerifier::new(*keys.mac_key, keys.topic.clone());
+        let verifier = StreamVerifier::with_policy(*keys.mac_key, keys.topic.clone(), policy.into());
 
         // Set up control channel PUSH socket (consumer → StreamService → producer)
         let ctrl_push = context.socket(zmq::PUSH).ok();

--- a/crates/hyprstream/src/services/mcp_service.rs
+++ b/crates/hyprstream/src/services/mcp_service.rs
@@ -439,7 +439,7 @@ fn register_scoped_tools_recursive(
                                 _ => anyhow::bail!("No scoped streaming dispatch for service: {service}"),
                             };
 
-                            let (stream_id, endpoint, server_pubkey) = parse_stream_info(&stream_info_json)?;
+                            let (stream_id, endpoint, server_pubkey, policy) = parse_stream_info(&stream_info_json)?;
 
                             let handle = StreamHandle::new(
                                 &ctx.zmq_context,
@@ -448,6 +448,7 @@ fn register_scoped_tools_recursive(
                                 &server_pubkey,
                                 &client_secret,
                                 &client_pubkey_bytes,
+                                policy,
                             )?;
 
                             Ok(ToolResult::Stream(Box::new(handle)))
@@ -599,7 +600,7 @@ fn register_streaming_tool(
                     _ => anyhow::bail!("No streaming support for service: {}", service),
                 };
 
-                let (stream_id, endpoint, server_pubkey) = parse_stream_info(&stream_info_json)?;
+                let (stream_id, endpoint, server_pubkey, policy) = parse_stream_info(&stream_info_json)?;
 
                 let handle = StreamHandle::new(
                     &ctx.zmq_context,
@@ -608,6 +609,7 @@ fn register_streaming_tool(
                     &server_pubkey,
                     &client_secret,
                     &client_pubkey_bytes,
+                    policy,
                 )?;
 
                 Ok(ToolResult::Stream(Box::new(handle)))
@@ -654,9 +656,9 @@ fn params_to_json_schema(params: &[(&str, &str, bool, &str)]) -> Value {
     })
 }
 
-/// Parse streamId, endpoint, and serverPubkey from a streaming response JSON.
+/// Parse streamId, endpoint, serverPubkey, and policy from a streaming response JSON.
 /// StreamInfo serializes with `#[serde(rename_all = "camelCase")]`, so all keys are camelCase.
-fn parse_stream_info(json: &Value) -> anyhow::Result<(String, String, Vec<u8>)> {
+fn parse_stream_info(json: &Value) -> anyhow::Result<(String, String, Vec<u8>, hyprstream_rpc::stream_info::StreamPolicy)> {
     let stream_id = json["streamId"].as_str()
         .ok_or_else(|| anyhow::anyhow!("missing streamId in streaming response"))?.to_owned();
     let endpoint = json["endpoint"].as_str()
@@ -666,7 +668,12 @@ fn parse_stream_info(json: &Value) -> anyhow::Result<(String, String, Vec<u8>)> 
         .iter()
         .map(|v| v.as_u64().unwrap_or(0) as u8)
         .collect();
-    Ok((stream_id, endpoint, server_pubkey))
+    let policy: hyprstream_rpc::stream_info::StreamPolicy = if json["policy"].is_object() {
+        serde_json::from_value(json["policy"].clone()).unwrap_or_default()
+    } else {
+        hyprstream_rpc::stream_info::StreamPolicy::default()
+    };
+    Ok((stream_id, endpoint, server_pubkey, policy))
 }
 
 /// Dispatch a method call to the appropriate generated client.


### PR DESCRIPTION
Part of epic #131, addresses #217 (and partially #218). Depends on #215 (schema) + #220 (moq-primary).

Stacked on #236.

## Summary
- Codegen (`hyprstream-rpc-derive`) emits matched producer + consumer from resolved `$streamPolicy`
- Consumer path enforces policy at the `StreamVerifier` level (ordered/unordered, delivery mode)
- WASM path (`hyprstream-rpc-std`) compiles with policy enforcement
- `mcp_service` wires the resolved policy into its stream registration
- Fail-closed build gate: missing or unresolvable policy annotation → compile error

Note: TS/browser codegen (#218) deferred to #226/M4.

## Test plan
- [ ] `cargo test` for codegen derive crate
- [ ] WASM build succeeds with policy enforcement
- [ ] Fail-closed: unknown policy annotation → compile error (not runtime panic)