### PR TITLE
feat(#167): replace ZMQ XPUB/XSUB event bus with moq-lite Live preset

### DIFF
--- a/crates/hyprstream-rpc/src/lib.rs
+++ b/crates/hyprstream-rpc/src/lib.rs
@@ -138,6 +138,8 @@ pub mod streaming;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod moq_stream;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod moq_event;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod transport;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod dial;

--- a/crates/hyprstream-rpc/src/moq_event.rs
+++ b/crates/hyprstream-rpc/src/moq_event.rs
@@ -1,0 +1,503 @@
+//! moq-lite event bus plane — replaces the ZMQ XPUB/XSUB ProxyService (#167).
+//!
+//! # Architecture
+//!
+//! The event bus is a process-global [`MoqEventOrigin`] rooted at `local/events`.
+//! Each service registers its own broadcast under `local/events/{source}` with a
+//! single `events` track. Each published frame carries the full dot-separated topic
+//! (`{source}.{entity}.{event}`) and the raw payload, packed as:
+//!
+//! ```text
+//!   [4 bytes topic_len BE][topic UTF-8][payload bytes]
+//! ```
+//!
+//! Subscribers connect to the origin, discover source broadcasts via
+//! `OriginConsumer::announced()`, subscribe to their `events` track, and do
+//! in-memory topic-prefix filtering (matching ZMQ's prefix-filter semantics).
+//!
+//! This is the "Live" preset for the event bus: fan-out, unbounded, at-most-once.
+//! No chained HMAC or policy axes — events are best-effort lifecycle signals, not
+//! auditable streams. `SecureEventPublisher` / `SecureEventSubscriber` (Phase 7)
+//! layer group-key encryption on top and are unaffected by this transport change.
+
+use std::collections::HashSet;
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
+use bytes::Bytes;
+use moq_net::{BroadcastProducer, Group, Origin, OriginConsumer, OriginProducer, Path, Track, TrackProducer};
+use parking_lot::Mutex;
+use tokio::sync::mpsc;
+
+// ============================================================================
+// Process-global moq event bus origin — set once at startup by the factory.
+// ============================================================================
+
+static GLOBAL_MOQ_EVENT_ORIGIN: OnceLock<MoqEventOrigin> = OnceLock::new();
+
+/// Register the process-global moq event bus origin.
+///
+/// Must be called once at startup (from the event-service factory) before any
+/// `EventPublisher::new()` or `EventSubscriber::new()` call.
+/// Returns `true` on the first call, `false` if already initialized (idempotent).
+pub fn init_global_moq_event_origin(origin: MoqEventOrigin) -> bool {
+    GLOBAL_MOQ_EVENT_ORIGIN.set(origin).is_ok()
+}
+
+/// Borrow the process-global moq event bus origin, if initialized.
+///
+/// Returns `None` when the event bus has not yet been wired (unit tests, or
+/// before `create_event_service` factory has run).
+pub fn global_moq_event_origin() -> Option<&'static MoqEventOrigin> {
+    GLOBAL_MOQ_EVENT_ORIGIN.get()
+}
+
+/// Track name for the event fanout track within each source broadcast.
+pub const EVENT_TRACK: &str = "events";
+
+/// Broadcast path prefix (the `local/events` root under which per-source
+/// broadcasts are registered).
+pub const EVENT_PREFIX: &str = "local/events";
+
+// ============================================================================
+// MoqEventOrigin
+// ============================================================================
+
+/// Shared moq origin for the event bus plane.
+///
+/// Replaces the ZMQ XPUB/XSUB `ProxyService`. Publishers register broadcasts
+/// under `local/events/{source}`; subscribers watch the origin consumer for
+/// announcements and subscribe to the `events` track of each source broadcast.
+#[derive(Clone)]
+pub struct MoqEventOrigin {
+    inner: Arc<EventOriginInner>,
+}
+
+struct EventOriginInner {
+    /// Root-scoped producer: publishes under `local/events/{source}`.
+    producer: OriginProducer,
+    /// Consumer over the same origin tree (for subscribers).
+    consumer: OriginConsumer,
+    /// Keep `BroadcastProducer`s alive so their broadcasts stay announced.
+    broadcasts: Mutex<Vec<BroadcastProducer>>,
+}
+
+impl MoqEventOrigin {
+    /// Create a standalone event origin (used at startup / in unit tests).
+    pub fn new() -> Self {
+        let producer = Origin::random().produce();
+        let consumer = producer.consume();
+        Self {
+            inner: Arc::new(EventOriginInner {
+                producer,
+                consumer,
+                broadcasts: Mutex::new(Vec::new()),
+            }),
+        }
+    }
+
+    /// Create from an existing producer/consumer pair (e.g. shared with the
+    /// iroh moq substrate so external relay subscribers see the same tree).
+    pub fn from_pair(producer: OriginProducer, consumer: OriginConsumer) -> Self {
+        Self {
+            inner: Arc::new(EventOriginInner {
+                producer,
+                consumer,
+                broadcasts: Mutex::new(Vec::new()),
+            }),
+        }
+    }
+
+    /// Create an event publisher for `source` (e.g. `"worker"`, `"system"`).
+    ///
+    /// Registers the broadcast `local/events/{source}` and opens its `events` track.
+    pub fn publisher(&self, source: &str) -> Result<MoqEventPublisher> {
+        let path = format!("{}/{}", EVENT_PREFIX, source);
+        let mut broadcast = self
+            .inner
+            .producer
+            .create_broadcast(path.as_str())
+            .ok_or_else(|| anyhow!("create_broadcast denied for {path}"))?;
+
+        let track = broadcast.create_track(Track::new(EVENT_TRACK))?;
+
+        // Retain the broadcast producer so it stays announced for the publisher's lifetime.
+        self.inner.broadcasts.lock().push(broadcast);
+
+        Ok(MoqEventPublisher {
+            track,
+            source: source.to_owned(),
+            next_group: 0,
+        })
+    }
+
+    /// Clone the origin consumer (for subscriber background tasks).
+    pub fn consumer(&self) -> OriginConsumer {
+        self.inner.consumer.clone()
+    }
+}
+
+impl Default for MoqEventOrigin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ============================================================================
+// MoqEventPublisher
+// ============================================================================
+
+/// In-process moq event publisher.
+///
+/// Publishes topic+payload pairs to the `local/events/{source}` broadcast.
+/// Each `publish_raw` call writes one moq Group (one Frame) on the `events` track.
+pub struct MoqEventPublisher {
+    track: TrackProducer,
+    source: String,
+    next_group: u64,
+}
+
+impl MoqEventPublisher {
+    /// Publish a raw topic + payload.
+    ///
+    /// Frame format: `[4 bytes topic_len BE][topic bytes][payload bytes]`.
+    pub fn publish_raw(&mut self, topic: &str, payload: &[u8]) -> Result<()> {
+        let topic_bytes = topic.as_bytes();
+        let topic_len = topic_bytes.len() as u32;
+
+        let mut frame = Vec::with_capacity(4 + topic_bytes.len() + payload.len());
+        frame.extend_from_slice(&topic_len.to_be_bytes());
+        frame.extend_from_slice(topic_bytes);
+        frame.extend_from_slice(payload);
+
+        let group_id = self.next_group;
+        self.next_group += 1;
+
+        let mut group = self.track.create_group(Group::from(group_id))?;
+        group.write_frame(Bytes::from(frame))?;
+        group.finish()?;
+        Ok(())
+    }
+
+    /// Publish `{source}.{entity}.{event}` with payload.
+    pub fn publish(&mut self, entity: &str, event: &str, payload: &[u8]) -> Result<()> {
+        if entity.contains('.') {
+            return Err(anyhow!("Entity name cannot contain '.': {}", entity));
+        }
+        if event.contains('.') {
+            return Err(anyhow!("Event name cannot contain '.': {}", event));
+        }
+        let topic = format!("{}.{}.{}", self.source, entity, event);
+        self.publish_raw(&topic, payload)
+    }
+
+    /// Source name for this publisher.
+    pub fn source(&self) -> &str {
+        &self.source
+    }
+}
+
+// ============================================================================
+// MoqEventSubscriber
+// ============================================================================
+
+/// In-process moq event subscriber.
+///
+/// Subscribes to one or more topic-prefix patterns. Patterns use the same
+/// dot-separated prefix semantics as ZMQ (`"worker."` matches all worker events,
+/// `""` matches everything). Backed by a background Tokio task that watches the
+/// origin consumer for new source broadcasts and reads their `events` tracks.
+pub struct MoqEventSubscriber {
+    /// Patterns added via `subscribe()`. Finalized before `recv()` is called.
+    patterns: Vec<String>,
+    /// Receiving end of the background task's channel. `None` until first `recv()`.
+    rx: Option<mpsc::Receiver<(String, Vec<u8>)>>,
+    /// Background task handle (kept alive for the subscriber's lifetime).
+    _task: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl MoqEventSubscriber {
+    /// Create a new subscriber. No background task is started yet.
+    pub fn new() -> Self {
+        Self {
+            patterns: Vec::new(),
+            rx: None,
+            _task: None,
+        }
+    }
+
+    /// Add a topic-prefix filter (prefix match, ZMQ semantics).
+    ///
+    /// - `"worker."` — all events from source `worker`
+    /// - `"worker.sandbox123.started"` — exact topic
+    /// - `""` — all events (subscribe-all)
+    ///
+    /// Must be called before the first `recv()`.
+    pub fn subscribe(&mut self, pattern: &str) -> Result<()> {
+        if self.rx.is_some() {
+            return Err(anyhow!("subscribe() must be called before recv()"));
+        }
+        self.patterns.push(pattern.to_owned());
+        Ok(())
+    }
+
+    /// Subscribe to all events (`pattern = ""`).
+    pub fn subscribe_all(&mut self) -> Result<()> {
+        self.subscribe("")
+    }
+
+    /// Unsubscribe from a pattern. Must be called before `recv()`.
+    pub fn unsubscribe(&mut self, pattern: &str) -> Result<()> {
+        if self.rx.is_some() {
+            return Err(anyhow!("unsubscribe() must be called before recv()"));
+        }
+        self.patterns.retain(|p| p != pattern);
+        Ok(())
+    }
+
+    /// Lazily start the background task and return a mutable reference to the channel receiver.
+    fn ensure_started(&mut self) -> Result<&mut mpsc::Receiver<(String, Vec<u8>)>> {
+        if self.rx.is_none() {
+            let origin = global_moq_event_origin()
+                .ok_or_else(|| anyhow!("moq event bus not initialized; call init_global_moq_event_origin first"))?;
+
+            let (tx, rx) = mpsc::channel(256);
+            let consumer = origin.consumer();
+            let patterns = self.patterns.clone();
+
+            let task = tokio::spawn(run_subscriber_task(consumer, patterns, tx));
+            self.rx = Some(rx);
+            self._task = Some(task);
+        }
+        self.rx.as_mut().ok_or_else(|| anyhow!("subscriber channel not initialized"))
+    }
+
+    /// Receive the next event. Blocks until an event arrives or the bus is closed.
+    pub async fn recv(&mut self) -> Result<(String, Vec<u8>)> {
+        let rx = self.ensure_started()?;
+        rx.recv().await.ok_or_else(|| anyhow!("event subscriber closed"))
+    }
+
+    /// Receive with timeout.
+    pub async fn recv_timeout(&mut self, timeout: Duration) -> Result<Option<(String, Vec<u8>)>> {
+        match tokio::time::timeout(timeout, self.recv()).await {
+            Ok(result) => result.map(Some),
+            Err(_) => Ok(None),
+        }
+    }
+
+    /// Try to receive without blocking.
+    pub async fn try_recv(&mut self) -> Result<Option<(String, Vec<u8>)>> {
+        self.recv_timeout(Duration::from_millis(0)).await
+    }
+}
+
+impl Default for MoqEventSubscriber {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ============================================================================
+// Background subscriber task
+// ============================================================================
+
+/// Background task: watches the origin consumer for announced source broadcasts,
+/// subscribes to each `events` track, and relays matching topic+payload pairs to `tx`.
+async fn run_subscriber_task(
+    mut consumer: OriginConsumer,
+    patterns: Vec<String>,
+    tx: mpsc::Sender<(String, Vec<u8>)>,
+) {
+    let patterns = Arc::new(patterns);
+
+    // Scope the consumer to the `local/events` subtree, then further narrow by
+    // source names extracted from the patterns.
+    let scoped_consumer = scope_consumer_for_patterns(&consumer, &patterns);
+    if let Some(c) = scoped_consumer {
+        consumer = c;
+    }
+
+    loop {
+        let (path, broadcast_opt) = match consumer.announced().await {
+            Some(update) => update,
+            None => break, // origin closed
+        };
+
+        let broadcast = match broadcast_opt {
+            Some(b) => b,
+            None => continue, // unannounce
+        };
+
+        let tx2 = tx.clone();
+        let patterns2 = patterns.clone();
+        let path_str = path.as_str().to_owned();
+
+        tokio::spawn(async move {
+            read_event_broadcast(broadcast, path_str, patterns2, tx2).await;
+        });
+    }
+}
+
+/// Scope the origin consumer to `local/events/{sources}` based on patterns.
+///
+/// If any pattern is `""` (subscribe-all), returns `None` and the caller uses
+/// an unscoped consumer rooted at `local/events`.
+fn scope_consumer_for_patterns(
+    consumer: &OriginConsumer,
+    patterns: &[String],
+) -> Option<OriginConsumer> {
+    // Scope to local/events first
+    let events_consumer = consumer.scope(&[Path::new(EVENT_PREFIX)])?;
+
+    // If subscribe-all pattern present, return events-scoped consumer
+    if patterns.iter().any(String::is_empty) {
+        return Some(events_consumer);
+    }
+
+    // Extract unique source names from patterns (e.g., "worker." → "worker")
+    let sources: Vec<String> = patterns
+        .iter()
+        .filter_map(|p| {
+            let src = p.split('.').next()?;
+            if src.is_empty() {
+                None
+            } else {
+                Some(src.to_owned())
+            }
+        })
+        .collect::<HashSet<String>>()
+        .into_iter()
+        .collect();
+
+    if sources.is_empty() {
+        return Some(events_consumer);
+    }
+
+    let path_refs: Vec<Path<'_>> = sources.iter().map(|s| Path::new(s.as_str())).collect();
+    events_consumer.scope(&path_refs)
+}
+
+/// Read all groups from a single source broadcast's `events` track and relay
+/// matching events to `tx`.
+async fn read_event_broadcast(
+    broadcast: moq_net::BroadcastConsumer,
+    path: String,
+    patterns: Arc<Vec<String>>,
+    tx: mpsc::Sender<(String, Vec<u8>)>,
+) {
+    let mut track = match broadcast.subscribe_track(&Track::new(EVENT_TRACK)) {
+        Ok(t) => t,
+        Err(_) => return,
+    };
+
+    loop {
+        let mut group = match track.next_group().await {
+            Ok(Some(g)) => g,
+            _ => break,
+        };
+
+        let frame = match group.read_frame().await {
+            Ok(Some(f)) => f,
+            _ => continue,
+        };
+
+        // Decode: [4 bytes topic_len BE][topic][payload]
+        if frame.len() < 4 {
+            continue;
+        }
+        let topic_len = u32::from_be_bytes([frame[0], frame[1], frame[2], frame[3]]) as usize;
+        if frame.len() < 4 + topic_len {
+            continue;
+        }
+        let topic = match std::str::from_utf8(&frame[4..4 + topic_len]) {
+            Ok(t) => t.to_owned(),
+            Err(_) => continue,
+        };
+        let payload = frame[4 + topic_len..].to_vec();
+
+        // Apply pattern filter (prefix match, ZMQ semantics)
+        if topic_matches_patterns(&topic, &patterns)
+            && tx.send((topic, payload)).await.is_err()
+        {
+            break; // receiver dropped
+        }
+    }
+
+    let _ = path; // kept for debugging context; unused in the hot path
+}
+
+/// True if `topic` matches any pattern in `patterns` (prefix match).
+fn topic_matches_patterns(topic: &str, patterns: &[String]) -> bool {
+    for pat in patterns {
+        if pat.is_empty() {
+            return true; // subscribe-all
+        }
+        if pat.ends_with('.') {
+            if topic.starts_with(pat.as_str()) {
+                return true;
+            }
+        } else if topic == pat.as_str() {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_topic_matches_patterns() {
+        let patterns = vec!["worker.".to_owned()];
+        assert!(topic_matches_patterns("worker.sandbox123.started", &patterns));
+        assert!(!topic_matches_patterns("system.event.ready", &patterns));
+        assert!(!topic_matches_patterns("worker", &patterns)); // no trailing dot match
+
+        let patterns_all = vec!["".to_owned()];
+        assert!(topic_matches_patterns("any.thing", &patterns_all));
+
+        let patterns_exact = vec!["worker.abc.started".to_owned()];
+        assert!(topic_matches_patterns("worker.abc.started", &patterns_exact));
+        assert!(!topic_matches_patterns("worker.abc.stopped", &patterns_exact));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn moq_event_pub_sub_roundtrip() -> Result<()> {
+        let origin = MoqEventOrigin::new();
+        init_global_moq_event_origin(origin.clone());
+
+        // Publisher
+        let mut pub_ = origin.publisher("worker")?;
+
+        // Subscriber
+        let mut sub = MoqEventSubscriber::new();
+        sub.subscribe("worker.")?;
+
+        // Start subscriber background task (lazy; triggered by recv)
+        // Publish before recv so the broadcast is announced when the task starts.
+        pub_.publish("sandbox123", "started", b"payload")?;
+
+        // Give the origin a moment to propagate the announcement.
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        // Manually start the task by calling ensure_started and check recv.
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            sub.recv(),
+        ).await;
+
+        match result {
+            Ok(Ok((topic, payload))) => {
+                assert_eq!(topic, "worker.sandbox123.started");
+                assert_eq!(payload, b"payload");
+            }
+            Ok(Err(e)) => panic!("recv error: {e}"),
+            Err(_) => panic!("recv timeout"),
+        }
+
+        Ok(())
+    }
+}

--- a/crates/hyprstream-workers/src/events/mod.rs
+++ b/crates/hyprstream-workers/src/events/mod.rs
@@ -1,80 +1,47 @@
-//! Event bus infrastructure
+//! Event bus infrastructure — moq-lite backed (#167).
 //!
-//! Provides XPUB/XSUB proxy for reliable event delivery between services.
-//! See `docs/eventservice-architecture.md` for detailed documentation.
+//! Provides fan-out event delivery between services using the moq-lite streaming
+//! plane (Live preset: at-most-once, unbounded). Replaces the former ZMQ
+//! XPUB/XSUB ProxyService.
 //!
 //! # Architecture
 //!
 //! ```text
-//! Publishers                    EventService                Subscribers
-//! ┌─────────────┐              ┌───────────┐              ┌──────────┐
-//! │WorkerService │──PUB──────►│           │──SUB───────►│Workflow- │
-//! │RegistryService│            │   Proxy   │              │ Service  │
-//! │InferenceService│           └───────────┘              └──────────┘
-//! └─────────────┘
+//! Publishers                 MoqEventOrigin (global)       Subscribers
+//! ┌─────────────┐           ┌──────────────────────┐      ┌──────────┐
+//! │WorkerService │──moq────►│ local/events/worker  │─────►│Workflow- │
+//! │RegistryService│          │ local/events/system  │      │ Service  │
+//! │                │         │ local/events/registry│      └──────────┘
+//! └─────────────┘           └──────────────────────┘
 //! ```
-//!
-//! # Endpoint Modes
-//!
-//! The EventService supports three endpoint configurations:
-//!
-//! - **Inproc** (default): In-process transport for monolithic mode
-//! - **IPC**: Unix domain sockets for distributed processes
-//! - **Systemd FD**: Pre-bound file descriptors from socket activation
 //!
 //! # Usage
 //!
 //! ```ignore
-//! use hyprstream_workers::events::{
-//!     endpoints, ProxyService, ServiceSpawner, SpawnedService,
-//!     EventPublisher, EventSubscriber,
-//! };
-//! use hyprstream_workers::events::endpoints::EndpointMode;
+//! use hyprstream_workers::events::{EventPublisher, EventSubscriber};
 //!
-//! // Detect transport configuration
-//! let (pub_transport, sub_transport) = endpoints::detect_transports(EndpointMode::Auto);
-//!
-//! // Create and spawn proxy service
-//! let ctx = Arc::new(zmq::Context::new());
-//! let proxy = ProxyService::new("events", ctx.clone(), pub_transport, sub_transport);
-//! let spawner = ServiceSpawner::threaded();
-//! let service = spawner.spawn(proxy).await?;
-//!
-//! // Create a publisher
-//! let mut publisher = EventPublisher::new(&ctx, "worker")?;
+//! // Create a publisher (no ZMQ context needed)
+//! let mut publisher = EventPublisher::new("worker")?;
 //! publisher.publish("sandbox123", "started", &payload).await?;
 //!
 //! // Create a subscriber
-//! let mut subscriber = EventSubscriber::new(&ctx)?;
+//! let mut subscriber = EventSubscriber::new()?;
 //! subscriber.subscribe("worker.")?;
 //! while let Ok((topic, payload)) = subscriber.recv().await {
 //!     println!("Received: {}", topic);
 //! }
-//!
-//! // Graceful shutdown
-//! service.stop().await?;
 //! ```
 
 pub mod endpoints;
 mod publisher;
 pub mod secure_publisher;
 pub mod secure_subscriber;
-mod service;
-pub mod sockopt;
 mod subscriber;
 pub mod token_manager;
 mod types;
 
 pub use publisher::EventPublisher;
 pub use subscriber::EventSubscriber;
-
-// Re-export spawner types for the recommended API:
-// let proxy = ProxyService::new("events", ctx, pub_transport, sub_transport);
-// let service = ServiceSpawner::threaded().spawn(proxy).await?;
-pub use hyprstream_service::{ProxyService, ServiceSpawner, SpawnedService};
-
-// Re-export endpoint types for convenience
-pub use endpoints::EndpointMode;
 
 // Re-export event types
 pub use types::{
@@ -93,6 +60,3 @@ pub use types::{
 pub use secure_publisher::{SecureEventPublisher, EncryptedEvent, RekeyPolicy, RotationResult};
 pub use secure_subscriber::SecureEventSubscriber;
 pub use token_manager::EventTokenManager;
-
-// Inproc endpoint constants (for backward compatibility)
-pub use endpoints::{PUB as EVENTS_PUB, SUB as EVENTS_SUB};

--- a/crates/hyprstream-workers/src/events/publisher.rs
+++ b/crates/hyprstream-workers/src/events/publisher.rs
@@ -1,84 +1,45 @@
-//! EventPublisher - Async event publishing using TMQ
+//! EventPublisher — moq-backed async event publishing (#167).
 //!
-//! Each service creates its own publisher instance.
-//! Publishers connect to the EventService proxy's XSUB socket.
+//! Publishers connect to the process-global [`MoqEventOrigin`] and write
+//! events to the `local/events/{source}` broadcast's `events` track.
+//! No ZMQ context is required; the moq origin is process-global.
 
 use anyhow::{anyhow, Result};
-use futures::SinkExt;
-use std::sync::Arc;
-use tmq::{publish, Multipart};
 
-use super::endpoints;
-use hyprstream_rpc::registry::{self, SocketKind};
+use hyprstream_rpc::moq_event::{global_moq_event_origin, MoqEventPublisher};
 
-/// Async event publisher using TMQ PUB socket
+/// Async event publisher backed by moq-lite.
 ///
-/// Publishers connect to the EventService proxy and send events
-/// with topic-based routing. Topics follow the format:
-/// `{source}.{entity}.{event}`
+/// Creates and holds a [`MoqEventPublisher`] for the named source, writing
+/// topic+payload pairs to the moq event bus. All in-process subscribers that
+/// have subscribed to matching topic patterns will receive the events.
 ///
 /// # Example
 ///
 /// ```ignore
-/// let mut publisher = EventPublisher::new(&ctx, "worker")?;
+/// let mut publisher = EventPublisher::new("worker")?;
 /// publisher.publish("sandbox123", "started", &payload).await?;
 /// ```
 pub struct EventPublisher {
-    socket: tmq::Publish,
-    source: String,
+    inner: MoqEventPublisher,
 }
 
 impl EventPublisher {
-    /// Create a new publisher for a service connecting to the default endpoint
+    /// Create a new publisher for the given source name.
     ///
-    /// # Arguments
-    ///
-    /// * `context` - ZMQ context (must be same as EventService for inproc://)
-    /// * `source` - Service name (e.g., "worker", "registry", "model", "inference")
-    ///
-    /// # Endpoint Resolution
-    ///
-    /// Uses EndpointRegistry if initialized, otherwise falls back to default inproc endpoint.
-    pub fn new(context: &Arc<zmq::Context>, source: &str) -> Result<Self> {
-        let endpoint = match registry::try_global() {
-            Some(reg) => reg.endpoint("events", SocketKind::Pub).to_zmq_string(),
-            None => endpoints::PUB.to_owned(),
-        };
-        Self::with_endpoint(context, source, &endpoint)
+    /// Requires the process-global moq event bus to have been initialized via
+    /// `init_global_moq_event_origin` (done by the event-service factory at startup).
+    pub fn new(source: &str) -> Result<Self> {
+        let origin = global_moq_event_origin()
+            .ok_or_else(|| anyhow!("moq event bus not initialized; start the event service first"))?;
+        let inner = origin.publisher(source)?;
+        Ok(Self { inner })
     }
 
-    /// Create a new publisher for a service connecting to a specific endpoint
+    /// Publish an event asynchronously.
     ///
-    /// Use this for IPC sockets in distributed mode.
-    ///
-    /// # Arguments
-    ///
-    /// * `context` - ZMQ context
-    /// * `source` - Service name (e.g., "worker", "registry", "cli")
-    /// * `endpoint` - Endpoint to connect to (e.g., "ipc:///run/user/1000/hyprstream/events/pub.sock")
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// let endpoint = format!("ipc://{}", paths::events_pub_socket().display());
-    /// let mut publisher = EventPublisher::with_endpoint(&ctx, "cli", &endpoint)?;
-    /// publisher.publish_raw("system.registry.request", b"").await?;
-    /// ```
-    pub fn with_endpoint(context: &Arc<zmq::Context>, source: &str, endpoint: &str) -> Result<Self> {
-        let socket = publish(context)
-            .connect(endpoint)
-            .map_err(|e| anyhow!("Failed to connect publisher to {}: {}", endpoint, e))?;
-
-        Ok(Self {
-            socket,
-            source: source.to_owned(),
-        })
-    }
-
-    /// Publish an event asynchronously
-    ///
-    /// Creates a topic from `{source}.{entity}.{event}` and sends
-    /// a multipart message [topic, payload].
+    /// Creates a topic from `{source}.{entity}.{event}` and writes a frame
+    /// containing the topic length, topic bytes, and payload to the moq track.
     ///
     /// # Arguments
     ///
@@ -88,66 +49,32 @@ impl EventPublisher {
     ///
     /// # Errors
     ///
-    /// Returns error if entity/event contain dots (reserved as separator)
-    /// or if sending fails.
+    /// Returns error if entity/event contain dots (reserved as separator).
     pub async fn publish(&mut self, entity: &str, event: &str, payload: &[u8]) -> Result<()> {
-        // Validate: entity/event cannot contain dots (used as separator)
-        if entity.contains('.') {
-            return Err(anyhow!("Entity name cannot contain '.': {}", entity));
-        }
-        if event.contains('.') {
-            return Err(anyhow!("Event name cannot contain '.': {}", event));
-        }
-
-        let topic = format!("{}.{}.{}", self.source, entity, event);
-
-        // Multipart message: [topic, payload]
-        // Topic is first frame for ZMQ prefix filtering
-        let multipart = Multipart::from(vec![topic.into_bytes(), payload.to_vec()]);
-
-        self.socket
-            .send(multipart)
-            .await
-            .map_err(|e| anyhow!("Failed to publish event: {}", e))?;
-
-        Ok(())
+        self.inner.publish(entity, event, payload)
     }
 
-    /// Publish with a pre-formatted topic
-    ///
-    /// Use this when you need full control over the topic format.
+    /// Publish with a pre-formatted topic.
     pub async fn publish_raw(&mut self, topic: &str, payload: &[u8]) -> Result<()> {
-        let multipart = Multipart::from(vec![topic.as_bytes().to_vec(), payload.to_vec()]);
-
-        self.socket
-            .send(multipart)
-            .await
-            .map_err(|e| anyhow!("Failed to publish event: {}", e))?;
-
-        Ok(())
+        self.inner.publish_raw(topic, payload)
     }
 
-    /// Get the source name for this publisher
+    /// Get the source name for this publisher.
     pub fn source(&self) -> &str {
-        &self.source
+        self.inner.source()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    
-
     #[test]
     fn test_topic_validation() {
-        // Entity with dot should fail
         let entity = "sandbox.123";
         assert!(entity.contains('.'));
 
-        // Event with dot should fail
         let event = "started.ok";
         assert!(event.contains('.'));
 
-        // Valid names
         let valid_entity = "sandbox123";
         let valid_event = "started";
         assert!(!valid_entity.contains('.'));

--- a/crates/hyprstream-workers/src/events/subscriber.rs
+++ b/crates/hyprstream-workers/src/events/subscriber.rs
@@ -1,29 +1,25 @@
-//! EventSubscriber - Async event subscription using TMQ
+//! EventSubscriber — moq-backed async event subscription (#167).
 //!
-//! Subscribers connect to the EventService proxy's XPUB socket
-//! and receive events matching their subscription patterns.
+//! Subscribers connect to the process-global [`MoqEventOrigin`] via a background
+//! task that watches for announced source broadcasts and reads their `events` tracks.
+//! No ZMQ context is required.
 
-use anyhow::{anyhow, Result};
-use futures::StreamExt;
-use std::sync::Arc;
+use anyhow::Result;
 use std::time::Duration;
-use tmq::subscribe;
 
-use super::endpoints;
-use hyprstream_rpc::registry::{self, SocketKind};
+use hyprstream_rpc::moq_event::MoqEventSubscriber as Inner;
 
-/// Async event subscriber using TMQ SUB socket
+/// Async event subscriber backed by moq-lite.
 ///
-/// Subscribers connect to the EventService proxy and receive events
-/// matching their subscription patterns. Patterns use prefix matching.
+/// Wraps [`MoqEventSubscriber`] from `hyprstream-rpc`. Patterns use dot-separated
+/// prefix matching identical to the former ZMQ semantics.
 ///
-/// **Note**: You must call `subscribe()` at least once before calling `recv()`.
-/// ZMQ SUB sockets don't receive any messages until subscribed to a topic.
+/// **Note**: Call `subscribe()` at least once before calling `recv()`.
 ///
 /// # Example
 ///
 /// ```ignore
-/// let mut subscriber = EventSubscriber::new(&ctx)?;
+/// let mut subscriber = EventSubscriber::new()?;
 /// subscriber.subscribe("worker.")?;  // All worker events
 ///
 /// while let Ok((topic, payload)) = subscriber.recv().await {
@@ -31,166 +27,64 @@ use hyprstream_rpc::registry::{self, SocketKind};
 /// }
 /// ```
 pub struct EventSubscriber {
-    /// Before first subscribe: Some(SubscribeWithoutTopic)
-    /// After first subscribe: None (moved to `subscribed`)
-    unsubscribed: Option<tmq::SubscribeWithoutTopic>,
-    /// After first subscribe: Some(Subscribe)
-    subscribed: Option<tmq::Subscribe>,
+    inner: Inner,
 }
 
 impl EventSubscriber {
-    /// Create a new subscriber connecting to the default endpoint
+    /// Create a new subscriber.
     ///
-    /// # Arguments
-    ///
-    /// * `context` - ZMQ context (must be same as EventService for inproc://)
-    ///
-    /// # Note
-    ///
-    /// The subscriber won't receive any messages until `subscribe()` is called.
-    ///
-    /// # Endpoint Resolution
-    ///
-    /// Uses EndpointRegistry if initialized, otherwise falls back to default inproc endpoint.
-    pub fn new(context: &Arc<zmq::Context>) -> Result<Self> {
-        let endpoint = match registry::try_global() {
-            Some(reg) => reg.endpoint("events", SocketKind::Sub).to_zmq_string(),
-            None => endpoints::SUB.to_owned(),
-        };
-        Self::with_endpoint(context, &endpoint)
+    /// No background task is started until the first `recv()` call.
+    pub fn new() -> Result<Self> {
+        Ok(Self { inner: Inner::new() })
     }
 
-    /// Create a new subscriber connecting to a specific endpoint
-    ///
-    /// Use this for IPC sockets in distributed mode.
-    ///
-    /// # Arguments
-    ///
-    /// * `context` - ZMQ context
-    /// * `endpoint` - Endpoint to connect to (e.g., "ipc:///run/user/1000/hyprstream/events/sub.sock")
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// let endpoint = format!("ipc://{}", paths::events_sub_socket().display());
-    /// let mut subscriber = EventSubscriber::with_endpoint(&ctx, &endpoint)?;
-    /// subscriber.subscribe("system.")?;
-    /// ```
-    pub fn with_endpoint(context: &Arc<zmq::Context>, endpoint: &str) -> Result<Self> {
-        let socket = subscribe(context)
-            .connect(endpoint)
-            .map_err(|e| anyhow!("Failed to connect subscriber to {}: {}", endpoint, e))?;
-
-        Ok(Self {
-            unsubscribed: Some(socket),
-            subscribed: None,
-        })
-    }
-
-    /// Subscribe to a topic pattern (prefix match)
+    /// Subscribe to a topic pattern (prefix match).
     ///
     /// # Examples
     ///
     /// - `"worker."` - All worker events
     /// - `"worker.sandbox123."` - Events for specific sandbox
     /// - `"worker.sandbox123.started"` - Exact topic match
-    /// - `""` - All events (empty string = subscribe all)
+    /// - `""` - All events (subscribe-all)
     pub fn subscribe(&mut self, pattern: &str) -> Result<()> {
-        if let Some(socket) = self.unsubscribed.take() {
-            // First subscription - converts SubscribeWithoutTopic to Subscribe
-            let subscribed = socket
-                .subscribe(pattern.as_bytes())
-                .map_err(|e| anyhow!("Failed to subscribe to '{}': {}", pattern, e))?;
-            self.subscribed = Some(subscribed);
-        } else if let Some(ref mut socket) = self.subscribed {
-            // Already subscribed - add another topic
-            socket
-                .subscribe(pattern.as_bytes())
-                .map_err(|e| anyhow!("Failed to subscribe to '{}': {}", pattern, e))?;
-        } else {
-            return Err(anyhow!("Subscriber in invalid state"));
-        }
-
-        Ok(())
+        self.inner.subscribe(pattern)
     }
 
-    /// Subscribe to all events
+    /// Subscribe to all events.
     pub fn subscribe_all(&mut self) -> Result<()> {
-        self.subscribe("")
+        self.inner.subscribe_all()
     }
 
-    /// Unsubscribe from a topic pattern
+    /// Unsubscribe from a topic pattern. Must be called before `recv()`.
     pub fn unsubscribe(&mut self, pattern: &str) -> Result<()> {
-        match &mut self.subscribed {
-            None => Err(anyhow!("Cannot unsubscribe: no active subscriptions")),
-            Some(socket) => {
-                socket
-                    .unsubscribe(pattern.as_bytes())
-                    .map_err(|e| anyhow!("Failed to unsubscribe from '{}': {}", pattern, e))?;
-                Ok(())
-            }
-        }
+        self.inner.unsubscribe(pattern)
     }
 
-    /// Receive the next event asynchronously
+    /// Receive the next event asynchronously.
     ///
-    /// Returns (topic, payload) tuple.
-    /// Blocks until an event is received or the stream ends.
-    ///
-    /// # Errors
-    ///
-    /// Returns error if `subscribe()` hasn't been called yet.
+    /// Returns `(topic, payload)`. Blocks until an event arrives.
     pub async fn recv(&mut self) -> Result<(String, Vec<u8>)> {
-        let socket = self.subscribed.as_mut().ok_or_else(|| {
-            anyhow!("No subscriptions active. Call subscribe() before recv()")
-        })?;
-
-        match socket.next().await {
-            Some(Ok(multipart)) => {
-                let parts: Vec<_> = multipart.into_iter().collect();
-                if parts.len() < 2 {
-                    return Err(anyhow!(
-                        "Invalid message format: expected 2 frames, got {}",
-                        parts.len()
-                    ));
-                }
-                let topic = String::from_utf8(parts[0].to_vec())
-                    .map_err(|e| anyhow!("Invalid UTF-8 in topic: {}", e))?;
-                let payload = parts[1].to_vec();
-                Ok((topic, payload))
-            }
-            Some(Err(e)) => Err(anyhow!("Receive error: {}", e)),
-            None => Err(anyhow!("Subscriber stream ended")),
-        }
+        self.inner.recv().await
     }
 
-    /// Receive with timeout
+    /// Receive with timeout.
     ///
-    /// Returns `Ok(Some((topic, payload)))` if event received,
+    /// Returns `Ok(Some((topic, payload)))` if event received within timeout,
     /// `Ok(None)` if timeout elapsed, or `Err` on error.
     pub async fn recv_timeout(&mut self, timeout: Duration) -> Result<Option<(String, Vec<u8>)>> {
-        match tokio::time::timeout(timeout, self.recv()).await {
-            Ok(result) => result.map(Some),
-            Err(_) => Ok(None),
-        }
+        self.inner.recv_timeout(timeout).await
     }
 
-    /// Try to receive without blocking
-    ///
-    /// Returns `Ok(Some((topic, payload)))` if event available,
-    /// `Ok(None)` if no event ready.
+    /// Try to receive without blocking.
     pub async fn try_recv(&mut self) -> Result<Option<(String, Vec<u8>)>> {
-        self.recv_timeout(Duration::from_millis(0)).await
+        self.inner.try_recv().await
     }
 }
 
 #[cfg(test)]
 mod tests {
-    
-
     #[test]
     fn test_subscription_patterns() {
-        // These are valid subscription patterns
         let patterns = vec![
             "",                           // All events
             "worker.",                    // All worker events

--- a/crates/hyprstream-workers/src/lib.rs
+++ b/crates/hyprstream-workers/src/lib.rs
@@ -67,20 +67,16 @@ pub use runtime::{WorkerService, SandboxBackend, SandboxHandle, KataBackend, Nsp
 pub use image::RafsStore;
 pub use workflow::WorkflowService;
 pub use events::{
-    // Spawner types (new API)
-    ProxyService, ServiceSpawner, SpawnedService,
-    // Publisher/Subscriber
+    // Publisher/Subscriber (moq-backed, no ZMQ context needed)
     EventPublisher, EventSubscriber, endpoints,
-    // Endpoint configuration
-    EndpointMode,
     // Event types
     WorkerEvent, ReceivedEvent,
     SandboxStarted, SandboxStopped, ContainerStarted, ContainerStopped,
     serialize_sandbox_started, serialize_sandbox_stopped,
     serialize_container_started, serialize_container_stopped,
-    // Inproc endpoint constants
-    EVENTS_PUB, EVENTS_SUB,
 };
+// Re-export the moq event origin init function for the factory
+pub use hyprstream_rpc::moq_event::{init_global_moq_event_origin, MoqEventOrigin};
 
 // Re-export capnp modules from hyprstream-rpc (compiled once, shared by all crates)
 pub use hyprstream_rpc::annotations_capnp;

--- a/crates/hyprstream-workers/src/runtime/service.rs
+++ b/crates/hyprstream-workers/src/runtime/service.rs
@@ -111,7 +111,7 @@ impl WorkerService {
         let sandbox_pool = Arc::new(SandboxPool::new(pool_config, backend));
 
         // Create event publisher for worker lifecycle events
-        let event_publisher = EventPublisher::new(&context, "worker")?;
+        let event_publisher = EventPublisher::new("worker")?;
 
         let stream_channel = Arc::new(StreamChannel::new(Arc::clone(&context), signing_key.clone()));
 

--- a/crates/hyprstream-workers/src/workflow/service.rs
+++ b/crates/hyprstream-workers/src/workflow/service.rs
@@ -165,7 +165,7 @@ impl WorkflowService {
     /// Subscribes to worker events and routes them to registered handlers.
     /// This spawns a background task that runs until `stop()` is called.
     pub async fn start(self: Arc<Self>) -> Result<()> {
-        let mut subscriber = EventSubscriber::new(&self.context)?;
+        let mut subscriber = EventSubscriber::new()?;
 
         // Subscribe to worker events (sandbox/container lifecycle)
         subscriber.subscribe("worker.")?;

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -2088,10 +2088,7 @@ fn main() -> Result<()> {
                                     // Publish ready events for this stage before starting the next.
                                     for svc_name in stage {
                                         if let Ok(mut publisher) =
-                                            hyprstream_workers::EventPublisher::new(
-                                                &global_context(),
-                                                "system",
-                                            )
+                                            hyprstream_workers::EventPublisher::new("system")
                                         {
                                             let _ = publisher
                                                 .publish_raw(
@@ -2118,10 +2115,7 @@ fn main() -> Result<()> {
                                 // Stop all services
                                 for (svc_name, mut handle) in handles {
                                     if let Ok(mut publisher) =
-                                        hyprstream_workers::EventPublisher::new(
-                                            &global_context(),
-                                            "system",
-                                        )
+                                        hyprstream_workers::EventPublisher::new("system")
                                     {
                                         let _ = publisher
                                             .publish_raw(

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -26,9 +26,9 @@ use anyhow::Context;
 use git2db::Git2DB;
 use hyprstream_rpc::prelude::*;
 use hyprstream_rpc::registry::{global as global_registry, SocketKind};
-use hyprstream_service::{ProxyService, ServiceContext, Spawnable};
+use hyprstream_service::{ServiceContext, Spawnable};
 use hyprstream_rpc::service_factory;
-use hyprstream_workers::endpoints;
+use hyprstream_rpc::moq_event::MoqEventOrigin;
 use tokio::sync::RwLock;
 use tracing::info;
 
@@ -244,21 +244,63 @@ fn spawn_jwt_renewal_task(
 // Event Service Factory
 // ═══════════════════════════════════════════════════════════════════════════════
 
-/// Factory for EventService (XPUB/XSUB proxy for event distribution)
+/// Factory for EventService — initializes the moq-lite event bus (#167).
+///
+/// Replaces the ZMQ XPUB/XSUB ProxyService with a `MoqEventOrigin` registered
+/// as a process global. Publishers and subscribers use the global origin directly;
+/// no forwarding proxy or thread is needed. The returned service just holds the
+/// shutdown barrier so the orchestrator tracks lifecycle correctly.
 #[service_factory("event")]
-fn create_event_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>> {
-    info!("Creating EventService");
+fn create_event_service(_ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>> {
+    info!("Creating EventService (moq-lite event bus)");
 
-    let mode = if ctx.is_ipc() {
-        endpoints::EndpointMode::Ipc
-    } else {
-        endpoints::EndpointMode::Inproc
-    };
+    let origin = MoqEventOrigin::new();
+    hyprstream_rpc::moq_event::init_global_moq_event_origin(origin);
 
-    let (pub_transport, sub_transport) = endpoints::detect_transports(mode);
-    let proxy = ProxyService::new("events", global_context(), pub_transport, sub_transport);
+    Ok(Box::new(MoqEventBarrierService::new()))
+}
 
-    Ok(Box::new(proxy))
+/// Minimal `Spawnable` that satisfies the service lifecycle contract for the
+/// moq event bus. The bus itself is a process-global `MoqEventOrigin` with no
+/// dedicated thread; this service just waits for shutdown.
+struct MoqEventBarrierService {
+    context: std::sync::Arc<zmq::Context>,
+}
+
+impl MoqEventBarrierService {
+    fn new() -> Self {
+        Self { context: global_context() }
+    }
+}
+
+impl Spawnable for MoqEventBarrierService {
+    fn name(&self) -> &str {
+        "event"
+    }
+
+    fn context(&self) -> &std::sync::Arc<zmq::Context> {
+        &self.context
+    }
+
+    fn registrations(&self) -> Vec<(hyprstream_rpc::registry::SocketKind, hyprstream_rpc::transport::TransportConfig)> {
+        vec![] // no ZMQ endpoints
+    }
+
+    fn run(
+        self: Box<Self>,
+        shutdown: std::sync::Arc<tokio::sync::Notify>,
+        on_ready: Option<tokio::sync::oneshot::Sender<()>>,
+    ) -> hyprstream_rpc::error::Result<()> {
+        if let Some(ready) = on_ready {
+            let _ = ready.send(());
+        }
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| hyprstream_rpc::error::RpcError::Other(e.to_string()))?;
+        rt.block_on(shutdown.notified());
+        Ok(())
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Part of epic #131, addresses #167 (N4 event bus migration).

Stacked on #237.

## Summary
- Replaces the `ProxyService` XSUB/XPUB event bus (`inproc://hyprstream/events/`) with a moq-lite `Live` preset
- `MoqEventOrigin` — global OnceLock initialized at startup; wraps moq-net `OriginProducer`
- `MoqEventPublisher` — per-source publisher; encodes frames as `[4b topic_len BE][topic UTF-8][payload]`
- `MoqEventSubscriber` — pattern-matching subscriber; preserves ZMQ SUB prefix semantics (`"worker."` matches `"worker.sandbox123.started"`)
- `MoqEventBarrierService` — minimal `Spawnable` satisfying factory lifecycle with no ZMQ sockets
- `EventPublisher`/`EventSubscriber` in `hyprstream-workers` rewired to use moq (no ZMQ context arg)
- `moq_event` module added to `hyprstream-rpc` (non-wasm32 only)

## Architecture
Source-to-broadcast mapping: source `"worker"` → broadcast `"local/events/worker"`, single `events` track.
Pattern matching: `""` matches all; prefix before first `.` selects the broadcast to subscribe.

## Test plan
- [ ] `cargo test` for `hyprstream-rpc` and `hyprstream-workers`
- [ ] Event publish → subscribe round-trip with prefix pattern matching
- [ ] Empty pattern `""` subscribes to all sources
- [ ] `MoqEventBarrierService` lifecycle: starts and shuts down cleanly