### PR TITLE
fix(#211): dial-layer hardening — delete dead rpc_client + from_endpoint fail-closed

### DIFF
--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -421,8 +421,17 @@ impl TransportConfig {
             EndpointType::Ipc {
                 path: PathBuf::from(path),
             }
+        } else if endpoint.contains("://") {
+            // Unknown scheme — fail-closed: misrouting to inproc would yield a
+            // cryptic "no in-process service registered" error at dial time.
+            // Networked transports (quic://, iroh://, tcp://) are obtained via
+            // TransportConfig::from_resolver(), not from_endpoint().
+            panic!(
+                "TransportConfig::from_endpoint: unknown scheme in '{endpoint}'; \
+                 use from_resolver() for networked transports"
+            );
         } else {
-            // Default to inproc if no scheme
+            // Bare name (no scheme) — defaults to inproc
             EndpointType::Inproc {
                 endpoint: endpoint.to_owned(),
             }

--- a/crates/hyprstream-service/src/service/factory.rs
+++ b/crates/hyprstream-service/src/service/factory.rs
@@ -626,24 +626,6 @@ impl ServiceContext {
         }
     }
 
-    /// Create a typed client for a compile-time-known service.
-    ///
-    /// Uses `RpcClient<LocalSigner, ZmqConnection>` via the generated `connect_to()` constructor.
-    pub fn rpc_client(&self, service: &str) -> std::sync::Arc<dyn hyprstream_rpc::RpcClient> {
-        let endpoint = self.endpoint(service, SocketKind::Rep).to_zmq_string();
-        let signer = hyprstream_rpc::signer::LocalSigner::new(
-            self.signing_key.clone(),
-        );
-        let transport = hyprstream_rpc::zmq_connection::ZmqConnection::new(
-            &endpoint,
-            self.zmq_context.clone(),
-        );
-        let rpc = hyprstream_rpc::rpc_client::RpcClientImpl::new(
-            signer, transport, Some(self.verifying_key),
-        );
-        std::sync::Arc::new(rpc)
-    }
-
     /// Wrap a RequestService for spawning with a per-service QUIC port.
     ///
     /// - `quic_port: None` → use ephemeral port (0) when QUIC is globally enabled


### PR DESCRIPTION
Part of epic #131, addresses #211. Follow-up to #136 code review.

Stacked on #239.

## Summary
- Deletes `ServiceContext::rpc_client()` — dead method with no callers, used `ZmqConnection` internally
- `TransportConfig::from_endpoint` now panics on unknown `://` schemes instead of silently defaulting to inproc (e.g., `from_endpoint("quic://host:port")` previously produced an inproc config)
- Bare names (no scheme) still default to inproc as intended
- Item 3 (lazy inproc dial retry) deferred — mitigated by ordered startup; low priority without evidence of real race

## Test plan
- [ ] `cargo build` passes
- [ ] `grep -r rpc_client` returns no results
- [ ] `from_endpoint("quic://host:port")` panics with a clear message
- [ ] `from_endpoint("my-service")` still produces `EndpointType::Inproc`