### PR TITLE
refactor(#171): rename zmq_transport → rpc_transport (module is ZMQ-free)

### DIFF
--- a/crates/hyprstream/src/cli/shell_handlers.rs
+++ b/crates/hyprstream/src/cli/shell_handlers.rs
@@ -1093,7 +1093,7 @@ async fn handle_rpc(
             // Fetch tool list once; used by both the spawner (for chat template)
             // and the ChatApp (for dispatch + descriptions).
             let (tool_caller, tool_descriptions, openai_tools) =
-                crate::tui::zmq_transport::make_tool_caller(signing_key);
+                crate::tui::rpc_transport::make_tool_caller(signing_key);
 
             // Shared gen_config Arc — passed to both the spawner and the ChatApp.
             // Use model-specific defaults from RPC if available, otherwise fall back.
@@ -1150,7 +1150,7 @@ async fn handle_rpc(
                     let save_hook: SaveHook = Box::new(move |entries| {
                         let _ = save_store.save(&uuid_for_save, entries);
                     });
-                    let spawner = crate::tui::zmq_transport::make_chat_spawner(
+                    let spawner = crate::tui::rpc_transport::make_chat_spawner(
                         signing_key, &model_ref, Some(openai_tools.clone()),
                         gen_config.clone(),
                     );
@@ -1167,7 +1167,7 @@ async fn handle_rpc(
                         format!("Private store dir unavailable: {e}"),
                         ToastLevel::Warn,
                     );
-                    let spawner = crate::tui::zmq_transport::make_chat_spawner(
+                    let spawner = crate::tui::rpc_transport::make_chat_spawner(
                         signing_key, &model_ref, Some(openai_tools.clone()),
                         gen_config.clone(),
                     );

--- a/crates/hyprstream/src/tui/mod.rs
+++ b/crates/hyprstream/src/tui/mod.rs
@@ -1,4 +1,4 @@
-//! TUI display server — terminal multiplexer over ZMQ RPC.
+//! TUI display server — terminal multiplexer over RPC.
 //!
 //! Provides session persistence, multi-pane layouts, remote access,
 //! and MCP-controllable display surfaces.
@@ -26,7 +26,7 @@ pub mod backend;
 pub mod vte_parser;
 pub mod shell_client;
 pub mod vfs;
-pub mod zmq_transport;
+pub mod rpc_transport;
 
 pub use state::{
     CursorShape, CursorState, IngestionMode, LayoutNode, PaneBuffer, ScrollOp, TuiEvent,

--- a/crates/hyprstream/src/tui/rpc_transport.rs
+++ b/crates/hyprstream/src/tui/rpc_transport.rs
@@ -1,4 +1,4 @@
-//! ZMQ-based StreamSpawner and ToolCaller for ChatApp inference.
+//! RPC-backed StreamSpawner and ToolCaller for ChatApp inference.
 //!
 //! Deduplicated from `shell_handlers.rs` and `service.rs` — both callers now
 //! use `make_chat_spawner` and (optionally) `make_tool_caller` from this module.

--- a/crates/hyprstream/src/tui/service.rs
+++ b/crates/hyprstream/src/tui/service.rs
@@ -1314,12 +1314,12 @@ impl TuiService {
         let model_ref = model_ref.to_owned();
 
         let (tool_caller, tool_descriptions, openai_tools) =
-            super::zmq_transport::make_tool_caller(&self.signing_key);
+            super::rpc_transport::make_tool_caller(&self.signing_key);
 
         let gen_config = std::sync::Arc::new(parking_lot::RwLock::new(
             hyprstream_tui::chat_app::ChatGenConfig::default(),
         ));
-        let spawner = super::zmq_transport::make_chat_spawner(
+        let spawner = super::rpc_transport::make_chat_spawner(
             &self.signing_key,
             &model_ref,
             Some(openai_tools),


### PR DESCRIPTION
## Summary
- Renames `cli/zmq_transport.rs` → `cli/rpc_transport.rs`; module was already ZMQ-free (uses `for_endpoint()`/`dial()` + moq `StreamHandleImpl`).
- Updates all callers.

## Remaining (not in this PR)
CLI SUB callers (`tui_handlers.rs`, `shell_handlers.rs`) still use ZMQ sockets; migration depends on M2 streaming plane (#134).