### PR TITLE
sec(#207): restrict UDS socket to owner-only + SO_PEERCRED peer-uid enforcement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9489,6 +9489,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cfg-if 1.0.3",
  "libc",
+ "memoffset 0.9.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,7 @@ sqlparser = "0.39.0"
 json-threat-protection = "0.1.1"
 
 # System utilities
-nix = { version = "0.27", features = ["fs", "process", "signal", "user"] }
+nix = { version = "0.27", features = ["fs", "process", "signal", "socket", "user"] }
 users = "0.11"
 rlimit = "0.10"
 clap = { version = "4.4", features = ["derive", "env"] }

--- a/crates/hyprstream-rpc/src/service/serve.rs
+++ b/crates/hyprstream-rpc/src/service/serve.rs
@@ -67,6 +67,13 @@ pub async fn serve_bridged(
             let _ = std::fs::remove_file(path);
             let listener = tokio::net::UnixListener::bind(path)
                 .map_err(|e| anyhow!("bind uds {}: {e}", path.display()))?;
+            // Restrict to owner-only access (#207): world-accessible sockets would
+            // let any local process connect, undermining same-host trust isolation.
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+                    .map_err(|e| anyhow!("set uds perms {}: {e}", path.display()))?;
+            }
             signal_ready(on_ready);
             run_uds(listener, processor, signing_key, shutdown).await
         }

--- a/crates/hyprstream-rpc/src/transport/uds_server.rs
+++ b/crates/hyprstream-rpc/src/transport/uds_server.rs
@@ -145,7 +145,37 @@ impl UdsRpcServer {
                 }
                 accepted = self.listener.accept() => {
                     let stream = match accepted {
-                        Ok((stream, _addr)) => stream,
+                        Ok((stream, _addr)) => {
+                            // SECURITY (#207): enforce same-uid-only access via
+                            // SO_PEERCRED. The socket is already 0o700 so only the
+                            // daemon's user can connect, but kernel-level peer-cred
+                            // verification adds defense-in-depth against fd-passing
+                            // or capability tricks that bypass filesystem permissions.
+                            #[cfg(target_os = "linux")]
+                            {
+                                use nix::sys::socket::{getsockopt, sockopt::PeerCredentials};
+                                let daemon_uid = nix::unistd::getuid();
+                                match getsockopt(&stream, PeerCredentials) {
+                                    Ok(cred) if cred.uid() == daemon_uid.as_raw() => {}
+                                    Ok(cred) => {
+                                        tracing::warn!(
+                                            peer_uid = cred.uid(),
+                                            daemon_uid = daemon_uid.as_raw(),
+                                            "uds-rpc: peer uid mismatch, rejecting connection"
+                                        );
+                                        continue;
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            error = %e,
+                                            "uds-rpc: SO_PEERCRED failed, rejecting connection"
+                                        );
+                                        continue;
+                                    }
+                                }
+                            }
+                            stream
+                        }
                         Err(e) => {
                             tracing::debug!(error = %e, "uds-rpc: listener accept error");
                             continue;


### PR DESCRIPTION
## Summary
- Sets UDS socket file permissions to 0o600 (owner-only) on bind.
- Adds `SO_PEERCRED` peer-UID check on accepted connections: rejects connections from UIDs other than the server process owner.

Closes #207