### PR TITLE
sec(#162) + fix(#210): lower RPC MAX_FRAME_BYTES to 4 MiB; fix Classical test verify policy

### DIFF
--- a/crates/hyprstream-rpc/src/transport/rpc_session.rs
+++ b/crates/hyprstream-rpc/src/transport/rpc_session.rs
@@ -38,14 +38,20 @@ use web_transport_trait::{RecvStream, SendStream, Session};
 
 use crate::transport_traits::{PublishSink, Transport};
 
-/// Hard cap on per-frame size (request or response). Mirrors the WebTransport
-/// server-side cap used in [`crate::transport::zmtp_quic`].
-pub const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024; // 64 MiB
+/// Hard cap on per-frame size (request or response) for the RPC control plane.
+///
+/// SECURITY (#162): the original 64 MiB cap would let an attacker buffer up to
+/// `64 MiB × DEFAULT_STREAM_LIMIT` (= 4 GiB) across concurrent streams before
+/// any application-layer rejection. The RPC plane carries control messages only
+/// (SQL queries, metric batches, Cap'n Proto envelopes) — no ingest blobs,
+/// no streaming chunks. Those belong on the streaming ALPN (moq-net). 4 MiB is
+/// generous for any realistic control-plane payload.
+pub const MAX_FRAME_BYTES: usize = 4 * 1024 * 1024; // 4 MiB
 
 /// Default concurrent-stream cap. NOTE: the `Arc<Semaphore>` this sizes is
 /// shared **server-wide** across all connections (one `Arc<HandlerInner>`),
 /// not per-connection — so this bounds total in-flight streams for the whole
-/// server, capping memory to `MAX_FRAME_BYTES × DEFAULT_STREAM_LIMIT`.
+/// server, capping memory to `MAX_FRAME_BYTES × DEFAULT_STREAM_LIMIT` = 256 MiB.
 pub const DEFAULT_STREAM_LIMIT: usize = 64;
 
 /// Grace period for [`SendStream::closed`] after writing the response — if

--- a/crates/hyprstream/src/services/core.rs
+++ b/crates/hyprstream/src/services/core.rs
@@ -65,6 +65,14 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_request_loop() {
+        // Tests use Classical (EdDSA-only) keys — install Classical verify
+        // policy so the global fail-closed Hybrid default doesn't reject them.
+        let _ = hyprstream_rpc::envelope::install_verify_config(
+            hyprstream_rpc::envelope::EnvelopeVerifyConfig {
+                policy: hyprstream_rpc::crypto::CryptoPolicy::Classical,
+                pq_store: None,
+            },
+        );
         let local = tokio::task::LocalSet::new();
         local.run_until(async {
             let transport = TransportConfig::inproc("test-echo-service-core");
@@ -88,6 +96,12 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_corrupted_envelope_rejected() {
+        let _ = hyprstream_rpc::envelope::install_verify_config(
+            hyprstream_rpc::envelope::EnvelopeVerifyConfig {
+                policy: hyprstream_rpc::crypto::CryptoPolicy::Classical,
+                pq_store: None,
+            },
+        );
         let local = tokio::task::LocalSet::new();
         local.run_until(async {
             let transport = TransportConfig::inproc("test-corrupted-envelope-core");

--- a/crates/hyprstream/src/services/metrics.rs
+++ b/crates/hyprstream/src/services/metrics.rs
@@ -662,6 +662,14 @@ mod tests {
     async fn start_metrics_service(
         tag: &str,
     ) -> (MetricsClient, InprocManager) {
+        // Tests use Classical (EdDSA-only) keys — install Classical verify
+        // policy so the global fail-closed Hybrid default doesn't reject them.
+        let _ = hyprstream_rpc::envelope::install_verify_config(
+            hyprstream_rpc::envelope::EnvelopeVerifyConfig {
+                policy: hyprstream_rpc::crypto::CryptoPolicy::Classical,
+                pq_store: None,
+            },
+        );
         let (signing_key, _vk) = generate_signing_keypair();
         let context = global_context();
 

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -2763,6 +2763,15 @@ mod tests {
         use hyprstream_service::InprocManager;
         use hyprstream_rpc::transport::TransportConfig;
 
+        // Tests use Classical (EdDSA-only) keys — install Classical verify
+        // policy so the global fail-closed Hybrid default doesn't reject them.
+        let _ = hyprstream_rpc::envelope::install_verify_config(
+            hyprstream_rpc::envelope::EnvelopeVerifyConfig {
+                policy: hyprstream_rpc::crypto::CryptoPolicy::Classical,
+                pq_store: None,
+            },
+        );
+
         let temp_dir = TempDir::new().expect("test: create temp dir");
         let context = crate::zmq::global_context();
 


### PR DESCRIPTION
## Summary
- Lowers `MAX_FRAME_BYTES` from 64 MiB to 4 MiB to bound memory consumption per in-flight RPC request.
- Fixes `tests/` that call `install_verify_config(Classical)` after process-global Hybrid default was set.

Closes #162, closes #210