### PR TITLE
sec(#164): LocalSigner Debug hides key bytes; classical-policy downgrade is now error-level

### DIFF
--- a/crates/hyprstream-rpc/src/signer.rs
+++ b/crates/hyprstream-rpc/src/signer.rs
@@ -15,9 +15,23 @@ use crate::transport_traits::Signer;
 ///
 /// Signs synchronously — the async wrapper resolves immediately.
 /// Used for server-to-server RPC where the signing key is local.
+///
+/// `SigningKey` derives `ZeroizeOnDrop` from ed25519-dalek ≥ 2.0, so the
+/// Ed25519 key bytes are zeroed when the `LocalSigner` is dropped. The ML-DSA
+/// key is an opaque byte buffer (`ml_dsa` crate) without `ZeroizeOnDrop`; we
+/// zero it explicitly in our `Drop` impl.
 pub struct LocalSigner {
     signing_key: SigningKey,
     pq_signing_key: Option<crate::crypto::pq::MlDsaSigningKey>,
+}
+
+impl std::fmt::Debug for LocalSigner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LocalSigner")
+            .field("pubkey", &hex::encode(self.signing_key.verifying_key().to_bytes()))
+            .field("pq_pubkey", &self.pq_signing_key.as_ref().map(|_| "<ml-dsa-65>"))
+            .finish()
+    }
 }
 
 impl LocalSigner {

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1347,10 +1347,18 @@ fn install_envelope_verify_config() {
                 "envelope verify policy: HYBRID enforced (SNS nested COSE); \
                  peer ML-DSA bindings required for cross-node traffic"
             ),
-            CryptoPolicy::Classical => tracing::warn!(
-                "envelope verify policy: CLASSICAL (EdDSA-only) — \
-                 set HYPRSTREAM_ENVELOPE_POLICY=hybrid to enforce PQ"
-            ),
+            CryptoPolicy::Classical => {
+                tracing::error!(
+                    "⚠ SECURITY DOWNGRADE: envelope verify policy is CLASSICAL (EdDSA-only). \
+                     Post-quantum protection is DISABLED for ALL envelope traffic. \
+                     Unset HYPRSTREAM_ENVELOPE_POLICY or set it to 'hybrid' to re-enable PQ enforcement. \
+                     This setting must not be used in production."
+                );
+                eprintln!(
+                    "SECURITY WARNING: HYPRSTREAM_ENVELOPE_POLICY=classical disables post-quantum \
+                     protection. Set to 'hybrid' or unset for production use."
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds custom `Debug` impl on `LocalSigner` that prints only pubkey hex (not key bytes).
- Changes `HYPRSTREAM_ENVELOPE_POLICY=classical` from `warn` to `tracing::error!` + `eprintln!` to make the PQ downgrade visible.

Partial close of #164