### PR TITLE
feat(#183): configurable require_pushed_authorization_requests (RFC 9126)

### DIFF
--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -1009,6 +1009,15 @@ pub struct OAuthConfig {
     /// Override rotation check interval in seconds (default: 21600 = 6 hours).
     #[serde(default)]
     pub jwt_key_rotation_check_secs: Option<u64>,
+
+    /// Enforce RFC 9126 Pushed Authorization Requests at `/oauth/authorize`.
+    ///
+    /// When `true`, the authorization endpoint rejects any request that does
+    /// not arrive via a `request_uri` referencing a prior `/oauth/par` call.
+    /// Advertised in server metadata as `require_pushed_authorization_requests`.
+    /// Defaults to `false` for compatibility.
+    #[serde(default)]
+    pub require_pushed_authorization_requests: bool,
 }
 
 fn default_oauth_cors() -> server::CorsConfig {
@@ -1040,6 +1049,7 @@ impl Default for OAuthConfig {
             jwt_key_lead_secs: None,
             jwt_key_drain_secs: None,
             jwt_key_rotation_check_secs: None,
+            require_pushed_authorization_requests: false,
         }
     }
 }

--- a/crates/hyprstream/src/services/oauth/authorize.rs
+++ b/crates/hyprstream/src/services/oauth/authorize.rs
@@ -447,6 +447,17 @@ async fn resolve_authorize_query(
         return Ok(entry.params);
     }
 
+    // Enforce PAR-required mode (RFC 9126 §10.1): when the server requires PAR,
+    // inline parameters without a request_uri must be rejected.
+    if state.require_pushed_authorization_requests {
+        return Err(error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            "This server requires a Pushed Authorization Request (RFC 9126). \
+             Submit your authorization parameters to /oauth/par first and use the returned request_uri.",
+        ));
+    }
+
     // Inline path: enforce the originally-required fields.
     let AuthorizeQuery {
         client_id,

--- a/crates/hyprstream/src/services/oauth/metadata.rs
+++ b/crates/hyprstream/src/services/oauth/metadata.rs
@@ -10,7 +10,7 @@ use axum::{extract::State, response::IntoResponse, Json};
 use super::state::OAuthState;
 
 /// Base metadata fields shared between RFC 8414 and OIDC discovery.
-fn base_metadata(issuer: &str, scopes: &[String]) -> serde_json::Value {
+fn base_metadata(issuer: &str, scopes: &[String], require_par: bool) -> serde_json::Value {
     serde_json::json!({
         "issuer": issuer,
         "authorization_endpoint": format!("{}/oauth/authorize", issuer),
@@ -18,7 +18,7 @@ fn base_metadata(issuer: &str, scopes: &[String]) -> serde_json::Value {
         "registration_endpoint": format!("{}/oauth/register", issuer),
         "device_authorization_endpoint": format!("{}/oauth/device", issuer),
         "pushed_authorization_request_endpoint": format!("{}/oauth/par", issuer),
-        "require_pushed_authorization_requests": false,
+        "require_pushed_authorization_requests": require_par,
         "jwks_uri": format!("{}/oauth/jwks", issuer),
         "response_types_supported": ["code"],
         "grant_types_supported": ["authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:device_code"],
@@ -33,7 +33,11 @@ fn base_metadata(issuer: &str, scopes: &[String]) -> serde_json::Value {
 pub async fn authorization_server_metadata(
     State(state): State<Arc<OAuthState>>,
 ) -> impl IntoResponse {
-    Json(base_metadata(&state.issuer_url, &state.default_scopes))
+    Json(base_metadata(
+        &state.issuer_url,
+        &state.default_scopes,
+        state.require_pushed_authorization_requests,
+    ))
 }
 
 /// GET /.well-known/openid-configuration (OIDC Discovery 1.0)
@@ -45,7 +49,7 @@ pub async fn openid_configuration(
     State(state): State<Arc<OAuthState>>,
 ) -> impl IntoResponse {
     let issuer = &state.issuer_url;
-    let mut meta = base_metadata(issuer, &state.default_scopes);
+    let mut meta = base_metadata(issuer, &state.default_scopes, state.require_pushed_authorization_requests);
 
     // OIDC-specific fields
     let obj = meta.as_object_mut().unwrap_or_else(|| unreachable!());

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -310,6 +310,9 @@ pub struct OAuthState {
     pub token_ttl: u32,
     /// Refresh token TTL in seconds
     pub refresh_token_ttl: u32,
+    /// When true, `/oauth/authorize` rejects inline params and requires a `request_uri`
+    /// from a prior `/oauth/par` call (RFC 9126). Advertised in server metadata.
+    pub require_pushed_authorization_requests: bool,
     /// HTTP client for fetching Client ID Metadata Documents
     pub http_client: reqwest::Client,
     /// Raw Ed25519 verifying key bytes (32 bytes) for the JWKS endpoint.
@@ -391,6 +394,7 @@ impl OAuthState {
             default_scopes: config.default_scopes.clone(),
             token_ttl: config.token_ttl_seconds,
             refresh_token_ttl: config.refresh_token_ttl_seconds,
+            require_pushed_authorization_requests: config.require_pushed_authorization_requests,
             http_client: reqwest::Client::builder()
                 .timeout(Duration::from_secs(10))
                 .build()


### PR DESCRIPTION
## Summary
- Adds `require_pushed_authorization_requests: bool` to `OAuthConfig` (default false).
- Threads through `OAuthState` → `authorize.rs`; inline authorize path returns 400 `invalid_request` when PAR is required.
- Updates OAuth metadata endpoints to advertise the flag per RFC 9126 §5.

Closes #183