### PR TITLE
fix(#181): apply HYPRSTREAM_INSTANCE namespace to StoragePaths

### DIFF
--- a/crates/hyprstream/src/storage/paths.rs
+++ b/crates/hyprstream/src/storage/paths.rs
@@ -16,9 +16,18 @@ pub struct StoragePaths {
 }
 
 impl StoragePaths {
-    /// Create a new storage paths manager
+    /// Create a new storage paths manager.
+    ///
+    /// Respects `HYPRSTREAM_INSTANCE`: when set, uses
+    /// `hyprstream/instances/{value}` as the XDG prefix so that credentials,
+    /// registry state, and models are isolated between concurrent instances on
+    /// the same host (mirrors the socket-path isolation in hyprstream-rpc/paths.rs).
     pub fn new() -> Result<Self> {
-        let base_dirs = BaseDirectories::with_prefix(APP_NAME)
+        let prefix = match std::env::var("HYPRSTREAM_INSTANCE") {
+            Ok(inst) if !inst.is_empty() => format!("{APP_NAME}/instances/{inst}"),
+            _ => APP_NAME.to_owned(),
+        };
+        let base_dirs = BaseDirectories::with_prefix(&prefix)
             .map_err(|e| anyhow!("Failed to create XDG base directories: {}", e))?;
 
         Ok(Self { base_dirs })


### PR DESCRIPTION
## Summary
- `StoragePaths::new()` now reads `HYPRSTREAM_INSTANCE` and sets XDG prefix to `hyprstream/instances/{inst}` when set, preventing config/data collisions between multiple instances on the same host.

Closes #181