### PR TITLE
cleanup(#155): dedup JWK thumbprint + remove dead subject() shim

### DIFF
--- a/crates/hyprstream-rpc/src/auth/claims.rs
+++ b/crates/hyprstream-rpc/src/auth/claims.rs
@@ -13,16 +13,11 @@ use serde::{Deserialize, Serialize, Serializer, Deserializer};
 
 /// Compute the RFC 7638 JWK Thumbprint for an Ed25519 key.
 ///
-/// The thumbprint is SHA-256 of the lexicographic canonical JWK JSON:
-/// `{"crv":"Ed25519","kty":"OKP","x":"<base64url>"}` — keys in lexicographic order.
+/// Delegates to [`crate::auth::jwk_thumbprint`] — kept as a named entry-point
+/// so callers that only have a raw `[u8; 32]` don't need to construct a
+/// [`crate::auth::JwkThumbprintInput`] themselves. (#155 cleanup)
 pub fn compute_jkt(key_bytes: &[u8; 32]) -> String {
-    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
-    use sha2::{Digest, Sha256};
-    let x = URL_SAFE_NO_PAD.encode(key_bytes);
-    // Keys in lexicographic order per RFC 7638 § 3.
-    let canonical = format!(r#"{{"crv":"Ed25519","kty":"OKP","x":"{x}"}}"#);
-    let hash = Sha256::digest(canonical.as_bytes());
-    URL_SAFE_NO_PAD.encode(hash)
+    crate::auth::jwk_thumbprint(&crate::auth::JwkThumbprintInput::Ed25519 { x: key_bytes })
 }
 
 /// Returns true if `iss` belongs to a local node.

--- a/crates/hyprstream-rpc/src/envelope.rs
+++ b/crates/hyprstream-rpc/src/envelope.rs
@@ -1478,13 +1478,6 @@ impl SignedEnvelope {
         &self.envelope.authorization
     }
 
-    // --- Temporary compatibility shims (TODO: remove in Phase 2) ---
-
-    /// Compatibility shim: get the authorization subject (always anonymous from envelope).
-    pub fn subject(&self) -> Subject {
-        Subject::anonymous()
-    }
-
 }
 
 impl ToCapnp for RequestEnvelope {


### PR DESCRIPTION
## Summary
- `compute_jkt()` now delegates to `jwk_thumbprint(JwkThumbprintInput::Ed25519)` instead of reimplementing RFC 7638.
- Removes `RequestEnvelope::subject()` dead shim (always returned anonymous, no callers).

Closes #155