### PR TITLE
feat(#197): unify RPC transport tunables into RpcConfig

### DIFF
--- a/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
@@ -147,6 +147,36 @@ impl IrohRpcProtocolHandler {
         }
         self
     }
+
+    /// Override the concurrent-connection cap (builder style, mirrors
+    /// [`super::quinn_transport::QuinnRpcServer::with_connection_limit`]).
+    pub fn with_connection_limit(mut self, connection_limit: usize) -> Self {
+        match Arc::get_mut(&mut self.inner) {
+            Some(inner) => inner.connection_limit = Arc::new(Semaphore::new(connection_limit)),
+            None => {
+                let i = &self.inner;
+                self.inner = Arc::new(HandlerInner {
+                    processor: Arc::clone(&i.processor),
+                    signing_key: i.signing_key.clone(),
+                    stream_limit: Arc::clone(&i.stream_limit),
+                    stream_limit_capacity: i.stream_limit_capacity,
+                    connection_limit: Arc::new(Semaphore::new(connection_limit)),
+                    read_timeout: i.read_timeout,
+                    shutdown: i.shutdown.clone(),
+                });
+            }
+        }
+        self
+    }
+
+    /// Apply all tunables from an [`super::rpc_session::RpcConfig`] in one call (#197).
+    pub fn with_rpc_config(self, cfg: &super::rpc_session::RpcConfig) -> Self {
+        let processor = Arc::clone(&self.inner.processor);
+        let signing_key = self.inner.signing_key.clone();
+        Self::with_stream_limit(processor, signing_key, cfg.stream_limit)
+            .with_read_timeout(cfg.request_read_timeout)
+            .with_connection_limit(cfg.connection_limit)
+    }
 }
 
 impl ProtocolHandler for IrohRpcProtocolHandler {

--- a/crates/hyprstream-rpc/src/transport/quinn_transport.rs
+++ b/crates/hyprstream-rpc/src/transport/quinn_transport.rs
@@ -109,6 +109,13 @@ impl QuinnRpcServer {
         self
     }
 
+    /// Apply all tunables from an [`super::rpc_session::RpcConfig`] in one call (#197).
+    pub fn with_rpc_config(self, cfg: &super::rpc_session::RpcConfig) -> Self {
+        self.with_stream_limit(cfg.stream_limit)
+            .with_connection_limit(cfg.connection_limit)
+            .with_read_timeout(cfg.request_read_timeout)
+    }
+
     /// A handle that, when cancelled, stops the accept loop and per-connection
     /// serve loops.
     ///

--- a/crates/hyprstream-rpc/src/transport/rpc_session.rs
+++ b/crates/hyprstream-rpc/src/transport/rpc_session.rs
@@ -92,6 +92,46 @@ pub const DEFAULT_CONNECTION_LIMIT: usize = 256;
 pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(15);
 
 // ============================================================================
+// RpcConfig — unified server-side tunables (#197)
+// ============================================================================
+
+/// Unified RPC transport tunables for server builders.
+///
+/// All values default to the process-global constants; override via
+/// `with_rpc_config()` on any server builder. This consolidates the
+/// previously scattered `with_stream_limit` / `with_connection_limit` /
+/// `with_read_timeout` builder methods behind one struct so a single
+/// config source (e.g. a loaded `HyprConfig`) can tune all planes at once.
+#[derive(Clone, Debug)]
+pub struct RpcConfig {
+    /// Max concurrent in-flight bidi streams (server-wide semaphore).
+    pub stream_limit: usize,
+    /// Max concurrent accepted connections per server.
+    pub connection_limit: usize,
+    /// Max wall-clock time to read a single request frame.
+    pub request_read_timeout: Duration,
+    /// Max time for a peer's QUIC/WebTransport handshake to complete.
+    pub handshake_timeout: Duration,
+    /// Grace period after writing a response for the peer to ack FIN.
+    pub stopped_grace: Duration,
+    /// Max wall-clock time for graceful drain on shutdown.
+    pub drain_timeout: Duration,
+}
+
+impl Default for RpcConfig {
+    fn default() -> Self {
+        Self {
+            stream_limit: DEFAULT_STREAM_LIMIT,
+            connection_limit: DEFAULT_CONNECTION_LIMIT,
+            request_read_timeout: REQUEST_READ_TIMEOUT,
+            handshake_timeout: HANDSHAKE_TIMEOUT,
+            stopped_grace: STOPPED_GRACE,
+            drain_timeout: DRAIN_TIMEOUT,
+        }
+    }
+}
+
+// ============================================================================
 // IrohRequestProcessor — pluggable request handling trait
 // ============================================================================
 

--- a/crates/hyprstream-rpc/src/transport/uds_server.rs
+++ b/crates/hyprstream-rpc/src/transport/uds_server.rs
@@ -95,6 +95,13 @@ impl UdsRpcServer {
         self
     }
 
+    /// Apply all tunables from an [`super::rpc_session::RpcConfig`] in one call (#197).
+    pub fn with_rpc_config(self, cfg: &super::rpc_session::RpcConfig) -> Self {
+        self.with_stream_limit(cfg.stream_limit)
+            .with_connection_limit(cfg.connection_limit)
+            .with_read_timeout(cfg.request_read_timeout)
+    }
+
     /// A handle that, when cancelled, stops the accept loop and per-connection
     /// serve loops. Does not by itself drain in-flight streams — use
     /// [`UdsRpcServer::shutdown`] for a graceful drain.


### PR DESCRIPTION
## Summary
- Adds `RpcConfig` struct to `rpc_session.rs` with all per-server tunables (`stream_limit`, `connection_limit`, `request_read_timeout`, `handshake_timeout`, `stopped_grace`, `drain_timeout`) and a `Default` mapping to existing consts.
- Adds `with_rpc_config()` builder to `QuinnRpcServer`, `IrohRpcProtocolHandler` (+ new `with_connection_limit()`), and `UdsRpcServer`.

Closes #197