### PR TITLE
feat(#156): add exponential reconnect backoff to lazy RPC transports

### DIFF
--- a/crates/hyprstream-rpc/src/transport/backoff.rs
+++ b/crates/hyprstream-rpc/src/transport/backoff.rs
@@ -1,0 +1,122 @@
+//! Reconnect backoff for lazy transports (#156).
+//!
+//! [`ReconnectBackoff`] tracks consecutive failed dial attempts and computes an
+//! exponential-backoff cooldown window between them.  The lazy transports hold one
+//! `ReconnectBackoff` alongside their cached session so failed dials don't
+//! tight-loop on a downed peer — matching the explicit `tokio::time::sleep`
+//! backoff that `zmq_connection.rs` used to perform.
+//!
+//! ## Design
+//!
+//! - [`LazyState`] bundles the optional cached transport + backoff so they stay
+//!   consistent under a single lock: "no cached session" always implies "may be in
+//!   backoff."
+//! - `invalidate()` calls `record_failure()` so a *send-path* transport error
+//!   also counts against the backoff budget (not only dial failures).
+//! - `INITIAL_BACKOFF` is 1 s; subsequent failures double up to `MAX_BACKOFF`
+//!   (30 s), matching the ZMQ reconnect interval cap observed in practice.
+//!
+//! ## What #156 defers
+//!
+//! DID-doc re-resolve on re-dial (so the manager picks up a moved `service`
+//! entry) requires async resolution which can't run inside the sync lock; that
+//! layer is left for a future incremental PR and documented with a TODO below.
+
+use std::time::{Duration, Instant};
+
+const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+const BACKOFF_MULTIPLIER: f64 = 2.0;
+const MAX_BACKOFF: Duration = Duration::from_secs(30);
+
+/// Exponential-backoff cooldown tracker for RPC reconnect attempts.
+#[derive(Debug, Default)]
+pub struct ReconnectBackoff {
+    /// Number of consecutive failed dials (saturates at u32::MAX).
+    failures: u32,
+    /// Reconnect is blocked until this instant; `None` means "go ahead."
+    cooldown_until: Option<Instant>,
+}
+
+impl ReconnectBackoff {
+    /// How long the caller must wait before a reconnect attempt is allowed.
+    /// Returns `None` if a dial may proceed immediately.
+    pub fn cooldown_remaining(&self) -> Option<Duration> {
+        let until = self.cooldown_until?;
+        let now = Instant::now();
+        if now >= until {
+            None
+        } else {
+            Some(until - now)
+        }
+    }
+
+    /// Record a failed dial (or send-path fatal) and schedule the next window.
+    pub fn record_failure(&mut self) {
+        self.failures = self.failures.saturating_add(1);
+        let secs = INITIAL_BACKOFF.as_secs_f64()
+            * BACKOFF_MULTIPLIER.powi(self.failures.saturating_sub(1) as i32);
+        let delay = Duration::from_secs_f64(secs).min(MAX_BACKOFF);
+        self.cooldown_until = Some(Instant::now() + delay);
+    }
+
+    /// Reset backoff after a successful connection.
+    pub fn record_success(&mut self) {
+        self.failures = 0;
+        self.cooldown_until = None;
+    }
+}
+
+/// Combined lazy-connect state: the optional cached transport + reconnect backoff.
+///
+/// Keeping both behind a single lock ensures "session = None" is always
+/// consistent with the backoff state — a race cannot observe a stale cooldown
+/// after a successful reconnect resets it.
+pub struct LazyState<T> {
+    /// `None` until the first successful dial; reset to `None` on transport error.
+    pub cached: Option<T>,
+    pub backoff: ReconnectBackoff,
+}
+
+impl<T> Default for LazyState<T> {
+    fn default() -> Self {
+        Self {
+            cached: None,
+            backoff: ReconnectBackoff::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_failure_sets_cooldown() {
+        let mut b = ReconnectBackoff::default();
+        assert!(b.cooldown_remaining().is_none(), "no cooldown before first failure");
+        b.record_failure();
+        assert!(b.cooldown_remaining().is_some(), "cooldown after first failure");
+    }
+
+    #[test]
+    fn success_resets_backoff() {
+        let mut b = ReconnectBackoff::default();
+        b.record_failure();
+        b.record_success();
+        assert_eq!(b.failures, 0);
+        assert!(b.cooldown_remaining().is_none());
+    }
+
+    #[test]
+    fn backoff_caps_at_max() {
+        let mut b = ReconnectBackoff::default();
+        for _ in 0..64 {
+            b.record_failure();
+        }
+        // Can't inspect the raw cooldown_until, but record_failure must not panic
+        // on saturation and the remaining duration must be ≤ MAX_BACKOFF + epsilon.
+        if let Some(remaining) = b.cooldown_remaining() {
+            assert!(remaining <= MAX_BACKOFF + Duration::from_millis(50));
+        }
+    }
+}

--- a/crates/hyprstream-rpc/src/transport/lazy_iroh.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_iroh.rs
@@ -35,6 +35,7 @@ use anyhow::{anyhow, bail, Result};
 use async_trait::async_trait;
 use tokio::sync::Mutex;
 
+use crate::transport::backoff::LazyState;
 use crate::transport::iroh_substrate::ALPN_HYPRSTREAM_RPC;
 use crate::transport::iroh_transport::{IrohPendingStream, IrohPublishStub, IrohTransport};
 use crate::transport_traits::Transport;
@@ -71,7 +72,8 @@ pub struct LazyIrohTransport {
     node_id: [u8; 32],
     direct_addrs: Vec<SocketAddr>,
     relay_url: Option<String>,
-    cached: Mutex<Option<IrohTransport>>,
+    /// Cached session + reconnect backoff (#156).
+    state: Mutex<LazyState<IrohTransport>>,
 }
 
 impl LazyIrohTransport {
@@ -82,7 +84,7 @@ impl LazyIrohTransport {
             node_id,
             direct_addrs,
             relay_url,
-            cached: Mutex::new(None),
+            state: Mutex::new(LazyState::default()),
         }
     }
 
@@ -103,11 +105,16 @@ impl LazyIrohTransport {
     }
 
     /// Return the cached connected transport, dialing once (single-flight under
-    /// the lock) if not yet connected.
+    /// the lock) if not yet connected. Backs off after consecutive failures (#156).
     async fn connected(&self) -> Result<IrohTransport> {
-        let mut guard = self.cached.lock().await;
-        if let Some(transport) = guard.as_ref() {
+        let mut guard = self.state.lock().await;
+        if let Some(transport) = guard.cached.as_ref() {
             return Ok(transport.clone());
+        }
+        if let Some(remaining) = guard.backoff.cooldown_remaining() {
+            return Err(anyhow!(
+                "iroh peer is in reconnect backoff — retry in {remaining:.1?}"
+            ));
         }
         let endpoint = iroh_client_endpoint().ok_or_else(|| {
             anyhow!(
@@ -116,18 +123,35 @@ impl LazyIrohTransport {
             )
         })?;
         let addr = self.endpoint_addr()?;
-        let conn = tokio::time::timeout(CONNECT_TIMEOUT, endpoint.connect(addr, ALPN_HYPRSTREAM_RPC))
-            .await
-            .map_err(|_| anyhow!("iroh connect timed out after {CONNECT_TIMEOUT:?}"))?
-            .map_err(|e| anyhow!("iroh connect: {e}"))?;
-        let transport = IrohTransport::new(conn);
-        *guard = Some(transport.clone());
-        Ok(transport)
+        match tokio::time::timeout(
+            CONNECT_TIMEOUT,
+            endpoint.connect(addr, ALPN_HYPRSTREAM_RPC),
+        )
+        .await
+        {
+            Err(_) => {
+                guard.backoff.record_failure();
+                Err(anyhow!("iroh connect timed out after {CONNECT_TIMEOUT:?}"))
+            }
+            Ok(Err(e)) => {
+                guard.backoff.record_failure();
+                Err(anyhow!("iroh connect: {e}"))
+            }
+            Ok(Ok(conn)) => {
+                guard.backoff.record_success();
+                let transport = IrohTransport::new(conn);
+                guard.cached = Some(transport.clone());
+                Ok(transport)
+            }
+        }
     }
 
-    /// Drop the cached session so the next `send()` re-dials.
+    /// Drop the cached session and record a failure so the next `send()`
+    /// re-dials after the backoff cooldown (#156).
     async fn invalidate(&self) {
-        *self.cached.lock().await = None;
+        let mut guard = self.state.lock().await;
+        guard.cached = None;
+        guard.backoff.record_failure();
     }
 }
 
@@ -198,7 +222,7 @@ mod tests {
 
         let node_id: [u8; 32] = *server_id.as_bytes();
         let t = LazyIrohTransport::new(node_id, direct, None);
-        assert!(t.cached.lock().await.is_none(), "no connection before first send");
+        assert!(t.state.lock().await.cached.is_none(), "no connection before first send");
 
         // EchoHandler echoes the bytes written on the bidi stream, which is the
         // same shape SessionRpcTransport::send uses (write payload → read to
@@ -209,7 +233,7 @@ mod tests {
         // QuinnRpcServer, which IrohTransport shares via SessionRpcTransport.)
         let resp = t.send(b"ping".to_vec(), Some(4_000)).await.unwrap();
         assert_eq!(resp, b"ping");
-        assert!(t.cached.lock().await.is_some(), "session cached after first send");
+        assert!(t.state.lock().await.cached.is_some(), "session cached after first send");
 
         server.shutdown().await.unwrap();
         // NOTE: do NOT shut down `client` — its endpoint is installed in the
@@ -247,7 +271,7 @@ mod tests {
             .await
             .expect("send must complete (with an error) — wrong identity should reject, not hang");
         assert!(res.is_err(), "dialing a server's address under a wrong EndpointId must fail");
-        assert!(t.cached.lock().await.is_none(), "a failed handshake caches nothing");
+        assert!(t.state.lock().await.cached.is_none(), "a failed handshake caches nothing");
 
         other.shutdown().await.unwrap();
         server.shutdown().await.unwrap();

--- a/crates/hyprstream-rpc/src/transport/lazy_quinn.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_quinn.rs
@@ -31,6 +31,7 @@ use anyhow::{anyhow, bail, Result};
 use async_trait::async_trait;
 use tokio::sync::Mutex;
 
+use crate::transport::backoff::LazyState;
 use crate::transport::quinn_transport::{
     connect_pinned_hashes, connect_webpki, verify_peer_cert_pinned, QuinnPendingStream,
     QuinnPublishStub, QuinnTransport,
@@ -52,9 +53,10 @@ pub struct LazyQuinnTransport {
     addr: SocketAddr,
     server_name: String,
     auth: QuicServerAuth,
-    /// `None` until the first successful dial, and reset to `None` after a
-    /// `send()` failure so the next call re-dials.
-    cached: Mutex<Option<QuinnTransport>>,
+    /// Cached session + reconnect backoff state (#156). `None` until the first
+    /// successful dial; reset to `None` (with backoff recorded) after any
+    /// transport-fatal `send()` error or failed dial.
+    state: Mutex<LazyState<QuinnTransport>>,
 }
 
 impl LazyQuinnTransport {
@@ -66,48 +68,60 @@ impl LazyQuinnTransport {
             addr,
             server_name: server_name.into(),
             auth,
-            cached: Mutex::new(None),
+            state: Mutex::new(LazyState::default()),
         }
     }
 
     /// Return the cached connected transport, dialing once (under the lock —
-    /// single-flight) if not yet connected. The connect path is chosen by the
-    /// server-auth policy.
+    /// single-flight) if not yet connected. Backs off after consecutive failures
+    /// so a downed peer is not tight-looped (#156).
     async fn connected(&self) -> Result<QuinnTransport> {
-        let mut guard = self.cached.lock().await;
-        if let Some(transport) = guard.as_ref() {
+        let mut guard = self.state.lock().await;
+        if let Some(transport) = guard.cached.as_ref() {
             return Ok(transport.clone());
+        }
+        if let Some(remaining) = guard.backoff.cooldown_remaining() {
+            return Err(anyhow!(
+                "quinn peer is in reconnect backoff — retry in {remaining:.1?}"
+            ));
         }
         let connect = async {
             let hashes = self.auth.accept_cert_hashes();
             match (self.auth.require_web_pki(), hashes.is_empty()) {
-                // WebPKI only.
                 (true, true) => connect_webpki(&self.server_name, self.addr.port()).await,
-                // Pin only (self-signed) — verified in-handshake by cert-hash.
                 (false, false) => connect_pinned_hashes(self.addr, hashes).await,
-                // WebPKI + pin: CA-validate in the handshake, then enforce the
-                // pin on the established session before any RPC flows.
                 (true, false) => {
                     let session = connect_webpki(&self.server_name, self.addr.port()).await?;
                     verify_peer_cert_pinned(&session, hashes)?;
                     Ok(session)
                 }
-                // No auth at all — unreachable: QuicServerAuth's constructors
-                // reject the empty case.
                 (false, true) => bail!("QUIC endpoint has no server-auth requirement"),
             }
         };
-        let session = tokio::time::timeout(CONNECT_TIMEOUT, connect)
-            .await
-            .map_err(|_| anyhow!("quinn connect timed out after {CONNECT_TIMEOUT:?}"))??;
-        let transport = QuinnTransport::new(session);
-        *guard = Some(transport.clone());
-        Ok(transport)
+        match tokio::time::timeout(CONNECT_TIMEOUT, connect).await {
+            Err(_) => {
+                guard.backoff.record_failure();
+                Err(anyhow!("quinn connect timed out after {CONNECT_TIMEOUT:?}"))
+            }
+            Ok(Err(e)) => {
+                guard.backoff.record_failure();
+                Err(e)
+            }
+            Ok(Ok(session)) => {
+                guard.backoff.record_success();
+                let transport = QuinnTransport::new(session);
+                guard.cached = Some(transport.clone());
+                Ok(transport)
+            }
+        }
     }
 
-    /// Drop the cached session so the next `send()` re-dials.
+    /// Drop the cached session and record a failure so the next `send()`
+    /// re-dials after the backoff cooldown (#156).
     async fn invalidate(&self) {
-        *self.cached.lock().await = None;
+        let mut guard = self.state.lock().await;
+        guard.cached = None;
+        guard.backoff.record_failure();
     }
 }
 
@@ -214,11 +228,11 @@ mod tests {
         let (addr, pin, shutdown) = spawn_echo_server();
         let t = LazyQuinnTransport::new(addr, "localhost", QuicServerAuth::pinned(vec![pin]).unwrap());
 
-        assert!(t.cached.lock().await.is_none(), "no connection before first send");
+        assert!(t.state.lock().await.cached.is_none(), "no connection before first send");
 
         let resp = t.send(b"hello".to_vec(), Some(5_000)).await.unwrap();
         assert_eq!(resp, b"hello");
-        assert!(t.cached.lock().await.is_some(), "session cached after first send");
+        assert!(t.state.lock().await.cached.is_some(), "session cached after first send");
 
         let resp2 = t.send(b"again".to_vec(), Some(5_000)).await.unwrap();
         assert_eq!(resp2, b"again");
@@ -237,7 +251,7 @@ mod tests {
             .await
             .expect("send must complete (with an error) — a wrong pin should reject, not hang");
         assert!(res.is_err(), "a wrong cert pin must make send fail");
-        assert!(t.cached.lock().await.is_none(), "failed dial leaves nothing cached");
+        assert!(t.state.lock().await.cached.is_none(), "failed dial leaves nothing cached");
         shutdown.cancel();
     }
 
@@ -255,7 +269,7 @@ mod tests {
             .await
             .expect("send must complete (with an error) within the connect timeout, not hang");
         assert!(res.is_err(), "a dead address must yield an error, not a connection");
-        assert!(t.cached.lock().await.is_none(), "a failed connect caches nothing");
+        assert!(t.state.lock().await.cached.is_none(), "a failed connect caches nothing");
     }
 
     #[tokio::test]

--- a/crates/hyprstream-rpc/src/transport/lazy_uds.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_uds.rs
@@ -33,6 +33,7 @@ use anyhow::{anyhow, bail, Result};
 use async_trait::async_trait;
 use tokio::sync::Mutex;
 
+use super::backoff::LazyState;
 use super::rpc_session::{RpcPendingStream, RpcPublishStub, SessionRpcTransport};
 use super::uds_session::{connect_uds, UdsSession, PLANE_RPC};
 use crate::transport_traits::Transport;
@@ -48,7 +49,8 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// A UDS RPC transport that connects on first use and caches the session.
 pub struct LazyUdsTransport {
     path: PathBuf,
-    cached: Mutex<Option<SessionRpcTransport<UdsSession>>>,
+    /// Cached session + reconnect backoff (#156).
+    state: Mutex<LazyState<SessionRpcTransport<UdsSession>>>,
 }
 
 impl LazyUdsTransport {
@@ -57,34 +59,51 @@ impl LazyUdsTransport {
     pub fn new(path: PathBuf) -> Self {
         Self {
             path,
-            cached: Mutex::new(None),
+            state: Mutex::new(LazyState::default()),
         }
     }
 
     /// Return the cached connected transport, connecting once (single-flight
-    /// under the lock) if not yet connected.
+    /// under the lock) if not yet connected. Backs off after consecutive failures
+    /// so a removed/restarting socket is not tight-looped (#156).
     async fn connected(&self) -> Result<SessionRpcTransport<UdsSession>> {
-        let mut guard = self.cached.lock().await;
-        if let Some(transport) = guard.as_ref() {
+        let mut guard = self.state.lock().await;
+        if let Some(transport) = guard.cached.as_ref() {
             return Ok(transport.clone());
         }
-        let session = tokio::time::timeout(CONNECT_TIMEOUT, connect_uds(&self.path, PLANE_RPC))
-            .await
-            .map_err(|_| {
-                anyhow!(
+        if let Some(remaining) = guard.backoff.cooldown_remaining() {
+            return Err(anyhow!(
+                "uds peer at {} is in reconnect backoff — retry in {remaining:.1?}",
+                self.path.display()
+            ));
+        }
+        match tokio::time::timeout(CONNECT_TIMEOUT, connect_uds(&self.path, PLANE_RPC)).await {
+            Err(_) => {
+                guard.backoff.record_failure();
+                Err(anyhow!(
                     "uds connect to {} timed out after {CONNECT_TIMEOUT:?}",
                     self.path.display()
-                )
-            })?
-            .map_err(|e| anyhow!("uds connect to {}: {e}", self.path.display()))?;
-        let transport = SessionRpcTransport::new(session);
-        *guard = Some(transport.clone());
-        Ok(transport)
+                ))
+            }
+            Ok(Err(e)) => {
+                guard.backoff.record_failure();
+                Err(anyhow!("uds connect to {}: {e}", self.path.display()))
+            }
+            Ok(Ok(session)) => {
+                guard.backoff.record_success();
+                let transport = SessionRpcTransport::new(session);
+                guard.cached = Some(transport.clone());
+                Ok(transport)
+            }
+        }
     }
 
-    /// Drop the cached session so the next `send()` re-connects.
+    /// Drop the cached session and record a failure so the next `send()`
+    /// re-connects after the backoff cooldown (#156).
     async fn invalidate(&self) {
-        *self.cached.lock().await = None;
+        let mut guard = self.state.lock().await;
+        guard.cached = None;
+        guard.backoff.record_failure();
     }
 }
 
@@ -174,10 +193,10 @@ mod tests {
         });
 
         let t = LazyUdsTransport::new(path.clone());
-        assert!(t.cached.lock().await.is_none(), "no connection before first send");
+        assert!(t.state.lock().await.cached.is_none(), "no connection before first send");
         let resp = t.send(b"ping".to_vec(), Some(4_000)).await.unwrap();
         assert_eq!(resp, b"ping");
-        assert!(t.cached.lock().await.is_some(), "session cached after first send");
+        assert!(t.state.lock().await.cached.is_some(), "session cached after first send");
         // Second call reuses the cached session (multiplexed stream).
         let resp2 = t.send(b"pong".to_vec(), Some(4_000)).await.unwrap();
         assert_eq!(resp2, b"pong");
@@ -197,7 +216,7 @@ mod tests {
             .await
             .expect("send must complete (with an error), not hang");
         assert!(res.is_err(), "dialing an absent socket must fail");
-        assert!(t.cached.lock().await.is_none(), "a failed connect caches nothing");
+        assert!(t.state.lock().await.cached.is_none(), "a failed connect caches nothing");
     }
 
     #[tokio::test]

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -34,6 +34,8 @@ pub mod uds_session;
 pub mod lazy_uds;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod uds_server;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod backoff;
 
 use std::net::SocketAddr;
 use std::os::unix::io::RawFd;


### PR DESCRIPTION
## Summary
- Adds `ReconnectBackoff` + `LazyState<T>` in `transport/backoff.rs`: exponential cooldown (1s → 2s → 4s → … → 30s cap) between reconnect attempts after dial failure or transport-fatal send error.
- `LazyQuinnTransport`, `LazyIrohTransport`, and `LazyUdsTransport` all adopt `LazyState<T>` (bundles cached session + backoff under one lock for consistency).
- Prevents lazy transports from tight-looping on a downed peer, matching the ZMQ reconnect interval cap.

Deferred to a follow-up: DID-doc re-resolve on re-dial and single-flight-per-DID (require async DID resolution outside the sync lock).

Partial close of #156