### PR TITLE
feat(#184): --initial-user-role for wizard --non-interactive (least-privilege tests)

### DIFF
--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -193,6 +193,13 @@ fn build_cli() -> ClapCommand {
                     .long("enable-federation")
                     .action(clap::ArgAction::SetTrue)
                     .help("Apply the federation-open policy template — accept third-party apps AND remote peer servers from any HTTPS origin (atproto-style federation). Default is disabled; under -y this flag is the only way to enable it."),
+            )
+            .arg(
+                Arg::new("initial_user_role")
+                    .long("initial-user-role")
+                    .value_name("ROLE")
+                    .default_value("admin")
+                    .help("Role to assign the local user under --non-interactive (admin|operator|trainer|viewer). Default is admin; use operator/viewer in tests for least-privilege."),
             ),
     );
 
@@ -1597,6 +1604,10 @@ fn main() -> Result<()> {
                 let start_services = sub_m.get_flag("start");
                 let bootstrap_only = sub_m.get_flag("bootstrap_only");
                 let enable_federation = sub_m.get_flag("enable_federation");
+                let initial_user_role = sub_m
+                    .get_one::<String>("initial_user_role")
+                    .cloned()
+                    .unwrap_or_else(|| "admin".to_owned());
                 let use_tui = tui_mode || (!non_interactive && !bootstrap_only && supports_tui());
                 return with_runtime(
                     RuntimeConfig { device: DeviceConfig::request_cpu(), multi_threaded: true },
@@ -1606,7 +1617,7 @@ fn main() -> Result<()> {
                         } else {
                             hyprstream_core::cli::handle_wizard(
                                 &models_dir, &services, non_interactive, start_services,
-                                bootstrap_only, enable_federation,
+                                bootstrap_only, enable_federation, &initial_user_role,
                             ).await
                         }
                     },
@@ -1622,7 +1633,7 @@ fn main() -> Result<()> {
                         // First-run fallback (no `wizard` subcommand) defaults
                         // federation to off — explicit opt-in only.
                         hyprstream_core::cli::handle_wizard(
-                            &models_dir, &services, false, false, false, false,
+                            &models_dir, &services, false, false, false, false, "admin",
                         ).await
                     }
                 },
@@ -2363,7 +2374,7 @@ fn main() -> Result<()> {
                         } else {
                             // First-run auto-wizard defaults federation to off.
                             hyprstream_core::cli::handle_wizard(
-                                &models_dir, &services, false, false, false, false,
+                                &models_dir, &services, false, false, false, false, "admin",
                             ).await
                         }
                     },

--- a/crates/hyprstream/src/cli/wizard_handlers.rs
+++ b/crates/hyprstream/src/cli/wizard_handlers.rs
@@ -90,6 +90,9 @@ pub async fn handle_wizard_tui(models_dir: &Path, config_services: &[String]) ->
 /// Handle `hyprstream wizard` — interactive setup wizard.
 ///
 /// When `bootstrap_only` is true, only phase 1 (trust-root setup) runs.
+/// `initial_user_role` overrides the default "admin" role assigned to the
+/// local user under `--non-interactive`; use "operator" or "viewer" for
+/// least-privilege test setups (#184).
 pub async fn handle_wizard(
     models_dir: &Path,
     config_services: &[String],
@@ -97,6 +100,7 @@ pub async fn handle_wizard(
     start_services: bool,
     bootstrap_only: bool,
     enable_federation: bool,
+    initial_user_role: &str,
 ) -> Result<()> {
     // Install systemd units before entering spawn_blocking (async operation).
     if !bootstrap_only && hyprstream_rpc::has_systemd() {
@@ -106,6 +110,7 @@ pub async fn handle_wizard(
     let rt = tokio::runtime::Handle::current();
     let models_dir = models_dir.to_path_buf();
     let config_services = config_services.to_vec();
+    let initial_user_role = initial_user_role.to_owned();
 
     tokio::task::spawn_blocking(move || {
         let mut backend =
@@ -116,6 +121,7 @@ pub async fn handle_wizard(
             bootstrap_only,
             start_services,
             enable_federation,
+            &initial_user_role,
             &config_services,
         )
     })
@@ -134,6 +140,7 @@ fn run_text_wizard(
     bootstrap_only: bool,
     start_services_flag: bool,
     enable_federation: bool,
+    initial_user_role: &str,
     config_services: &[String],
 ) -> Result<()> {
     println!();
@@ -157,7 +164,7 @@ fn run_text_wizard(
     text_phase_templates(backend, non_interactive, enable_federation, &mut summary)?;
 
     // Phase 4: User/role creation
-    text_phase_users(backend, non_interactive, &mut summary)?;
+    text_phase_users(backend, non_interactive, initial_user_role, &mut summary)?;
 
     // Phase 5: Token generation
     text_phase_tokens(backend, non_interactive, &mut summary)?;
@@ -434,6 +441,7 @@ fn apply_federation_template(backend: &mut impl WizardBackend, summary: &mut Tex
 fn text_phase_users(
     backend: &mut impl WizardBackend,
     non_interactive: bool,
+    initial_user_role: &str,
     summary: &mut TextWizardSummary,
 ) -> Result<()> {
     println!("  Phase 4: Users & Roles");
@@ -442,11 +450,11 @@ fn text_phase_users(
 
     if non_interactive {
         let local_user = backend.local_username();
-        backend.add_user(&local_user, "admin");
-        print_check(&local_user, CheckStatus::Ok, "admin");
+        backend.add_user(&local_user, initial_user_role);
+        print_check(&local_user, CheckStatus::Ok, initial_user_role);
         summary
             .users_created
-            .push((local_user, "admin".to_owned()));
+            .push((local_user, initial_user_role.to_owned()));
         println!();
         return Ok(());
     }


### PR DESCRIPTION
## Summary
- Adds `--initial-user-role <ROLE>` (default: admin) to `hyprstream wizard --non-interactive`.
- Tests can pass `--initial-user-role operator` to avoid the wildcard admin policy, so authz regressions are caught.
- Companion change: `tests/fixtures/hyprstream.ts` in www-cyberdione-ai updated to use `--initial-user-role operator`.

Partial close of #184 (server-mediated registration path deferred)