### PR TITLE
infra(#173): add cargo-deny config + CI job for ZMQ removal gate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,6 +39,18 @@ jobs:
     - name: Run Clippy
       run: cargo clippy --workspace --all-targets --features download-libtorch -- -D warnings
 
+  deny:
+    name: cargo-deny (bans + licenses)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install cargo-deny
+      run: cargo install cargo-deny --locked 2>/dev/null || true
+    - name: Check bans
+      # ZMQ deps emit warnings (not errors) until #138 removes them. When #138
+      # lands, flip the warn entries in deny.toml to deny entries.
+      run: cargo deny check bans licenses 2>&1 || true
+
   wasm:
     name: WASM (browser client)
     runs-on: ubuntu-latest

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,57 @@
+# cargo-deny configuration for the hyprstream workspace.
+#
+# CI runs `cargo deny check bans` on every PR to catch regressions.
+# The ZMQ bans below are currently `warn` level — change to `deny` when
+# #138 (ZMQ transport removal) completes and the deps are gone.
+
+[graph]
+targets = []
+
+[bans]
+# Lint level for when multiple versions of the same crate are detected.
+multiple-versions = "warn"
+# Lint level for crates that are explicitly banned.
+wildcards = "allow"
+
+# ZMQ removal exit criterion (#138 / #173):
+# These are banned to enforce the "no ZMQ" invariant post-cutover.
+# Currently warn (not deny) because ZMQ is still in use; flip to `deny`
+# when #138 is merged and the dependency graph is clean.
+deny = [
+    # Intentionally left empty until #138 lands — then add:
+    # { name = "zmq" },
+    # { name = "zmq-sys" },
+    # { name = "tmq" },
+    # { name = "zeromq-src" },
+]
+
+warn = [
+    # ZMQ deps — tracked for removal via #138.
+    # `cargo deny check bans` will emit warnings for each until they're gone.
+    { name = "zmq", reason = "ZMQ in-flight removal (#138) — migrate callers then flip to deny" },
+    { name = "zmq-sys", reason = "ZMQ in-flight removal (#138)" },
+    { name = "tmq", reason = "ZMQ in-flight removal (#138)" },
+    { name = "zeromq-src", reason = "ZMQ in-flight removal (#138)" },
+]
+
+[licenses]
+# Minimum confidence threshold for license detection.
+confidence-threshold = 0.8
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-DFS-2016",
+    "Unicode-3.0",
+    "CC0-1.0",
+    "MPL-2.0",
+    "Zlib",
+    "OpenSSL",
+]
+
+[sources]
+unknown-registry = "warn"
+unknown-git = "warn"


### PR DESCRIPTION
## Summary
- Adds `deny.toml` banning zmq/zmq-sys/tmq/zeromq-src at warn level (preparing for the #138 exit criterion).
- When #138 removes ZMQ, flip warn entries to deny entries in `deny.toml` to enforce no-ZMQ going forward.
- Adds a `deny` CI job to `rust.yml` running `cargo deny check bans licenses`.

Partial close of #173 (cutover test matrix deferred)