### PR TITLE
sec(#185): publish QUIC cert hash in DID-doc #quic service entry

### DIFF
--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -805,7 +805,8 @@ fn create_oauth_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnabl
         ctx.transport("oauth", SocketKind::Rep),
         ctx.verifying_key(),
         ctx.jwt_verifying_key(),
-    );
+    )
+    .with_quic_config(config.quic.clone());
     if let Some(bl) = SHARED_JTI_BLOCKLIST.get() {
         oauth_service = oauth_service.with_jti_blocklist(Arc::clone(bl));
     } else {

--- a/crates/hyprstream/src/services/oauth/did_document.rs
+++ b/crates/hyprstream/src/services/oauth/did_document.rs
@@ -280,9 +280,30 @@ pub async fn root_did_document(
         handle,
     });
 
-    // Transport `service` entries are populated by the addressing layer (#151
-    // dial endpoints) once available; empty until then.
-    let transports: Vec<TransportEndpoint> = Vec::new();
+    // Transport `service` entries: populate QUIC entry when cert hash is available (#185).
+    // The cert hash was set at OAuthService startup from the node's QUIC TLS cert,
+    // closing the two-trust-roots gap: peers dialing by DID can now pin the cert
+    // instead of accepting it on TOFU.
+    let mut transports: Vec<TransportEndpoint> = Vec::new();
+    if !state.quic_cert_hashes.is_empty() {
+        if let Some(ref quic_uri) = state.quic_public_uri {
+            let auth = match hyprstream_rpc::transport::QuicServerAuth::pinned(
+                state.quic_cert_hashes.clone(),
+            ) {
+                Ok(auth) => auth,
+                Err(_) => hyprstream_rpc::transport::QuicServerAuth::web_pki(),
+            };
+            transports.push(TransportEndpoint {
+                fragment: "quic".to_owned(),
+                vm_type: "QuicTransport".to_owned(),
+                endpoint: hyprstream_rpc::service_entry::encode_quic(
+                    quic_uri,
+                    &auth,
+                    &["hyprstream-rpc/1"],
+                ),
+            });
+        }
+    }
 
     let doc = build_did_document(
         &did,

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -265,6 +265,8 @@ pub struct OAuthService {
     config: OAuthConfig,
     /// Global TLS configuration (passed from factory, avoids re-loading config)
     tls_config: crate::config::TlsConfig,
+    /// Global QUIC configuration for cert-hash publication in DID doc (#185).
+    quic_config: Option<crate::config::QuicConfig>,
     /// Signing key for creating the PolicyClient inside `run()`.
     signing_key: hyprstream_rpc::prelude::SigningKey,
     context: Arc<zmq::Context>,
@@ -291,6 +293,7 @@ impl OAuthService {
         Self {
             config,
             tls_config,
+            quic_config: None,
             signing_key,
             context,
             control_transport,
@@ -298,6 +301,12 @@ impl OAuthService {
             jwt_verifying_key: jwt_verifying_key.to_bytes(),
             jti_blocklist: None,
         }
+    }
+
+    /// Attach the global QUIC configuration for DID-doc cert-hash publication (#185).
+    pub fn with_quic_config(mut self, quic: crate::config::QuicConfig) -> Self {
+        self.quic_config = Some(quic);
+        self
     }
 
     /// Attach the shared JTI blocklist (same Arc as PolicyService).
@@ -608,6 +617,29 @@ impl Spawnable for OAuthService {
             };
             if let Some(_url) = cached_discovery_url {
                 // Discovery URL caching removed - use issuer URL directly
+            }
+
+            // Publish QUIC cert hash in DID doc (#185): close the two-trust-roots / TOFU gap.
+            // The leaf cert hash (SHA-256 of cert DER) is stored in OAuthState and
+            // included in the `#quic` service entry at `GET /.well-known/did.json`.
+            if let Some(ref quic_cfg) = self.quic_config {
+                if quic_cfg.enabled {
+                    if let Ok((cert_chain, _)) = quic_cfg.load_tls_materials() {
+                        if let Some(leaf) = cert_chain.first() {
+                            let mut hash = [0u8; 32];
+                            let digest = ring::digest::digest(&ring::digest::SHA256, leaf);
+                            hash.copy_from_slice(digest.as_ref());
+                            // Derive the public QUIC URI: same host as issuer, port from QUIC bind addr.
+                            let quic_port = quic_cfg.socket_addr().map(|a| a.port()).unwrap_or(4433);
+                            let issuer_host = url::Url::parse(&oauth_state.issuer_url)
+                                .ok()
+                                .and_then(|u| u.host_str().map(str::to_owned))
+                                .unwrap_or_else(|| "localhost".to_owned());
+                            let quic_uri = format!("https://{issuer_host}:{quic_port}");
+                            oauth_state = oauth_state.with_quic_transport(quic_uri, vec![hash]);
+                        }
+                    }
+                }
             }
 
             let state = Arc::new(oauth_state);

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -371,6 +371,13 @@ pub struct OAuthState {
     pub es256_key_store: Option<Arc<crate::auth::Es256SigningKeyStore>>,
     /// ML-DSA-65 signing key rotation store for PQ-hybrid JWT issuance.
     pub ml_dsa_key_store: Option<Arc<crate::auth::MlDsaSigningKeyStore>>,
+    /// QUIC/WebTransport cert hashes (SHA-256 of leaf DER, `sha2-256` multihash encoding).
+    /// Published in the DID-doc `#quic` service entry so peers can pin the cert (#185).
+    /// A set so cert rotation can publish old + new simultaneously.
+    pub quic_cert_hashes: Vec<[u8; 32]>,
+    /// Public QUIC URI (`https://host:port`) for the DID-doc service entry (#185).
+    /// None until the QUIC server is started and the cert hash is known.
+    pub quic_public_uri: Option<String>,
 }
 
 impl OAuthState {
@@ -421,6 +428,8 @@ impl OAuthState {
             jti_blocklist: None,
             es256_key_store: None,
             ml_dsa_key_store: None,
+            quic_cert_hashes: Vec::new(),
+            quic_public_uri: None,
         }
     }
 
@@ -460,6 +469,17 @@ impl OAuthState {
     /// Attach the ML-DSA-65 key rotation store.
     pub fn with_ml_dsa_key_store(mut self, store: Arc<crate::auth::MlDsaSigningKeyStore>) -> Self {
         self.ml_dsa_key_store = Some(store);
+        self
+    }
+
+    /// Set the node's QUIC transport info for DID-doc publication (#185).
+    ///
+    /// `cert_hashes` is the set of SHA-256 cert DER hashes currently in use
+    /// (old + new during rotation). `public_uri` is `https://host:port` that
+    /// external peers dial.
+    pub fn with_quic_transport(mut self, public_uri: String, cert_hashes: Vec<[u8; 32]>) -> Self {
+        self.quic_public_uri = Some(public_uri);
+        self.quic_cert_hashes = cert_hashes;
         self
     }
 


### PR DESCRIPTION
## Summary
- Closes the two-trust-roots / TOFU gap: `/.well-known/did.json` now carries a `#quic` service entry with the node's QUIC leaf cert hash (SHA-256 of DER, multibase sha2-256 multihash).
- `OAuthState` gains `quic_cert_hashes` + `quic_public_uri`; set at OAuthService startup from `QuicConfig`.
- `root_did_document` builds a `QuicTransport` service entry via the existing `service_entry::encode_quic()` codec.
- Peer dialing by DID can now pin the cert rather than accepting on TOFU.

Wire shape:
```jsonc
{ "id": "did:web:host#quic", "type": "QuicTransport",
  "serviceEndpoint": { "uri": "https://host:4433", "webpki": false,
    "certHashes": ["z<multibase sha2-256 || sha256(leaf_der)>"],
    "accept": ["hyprstream-rpc/1"] } }
```

Partial close of #185 (key-derivation path → #200 deferred)