### PR TITLE
perf(#201): prefill LM-head slice — run norm+matmul over last position only

### DIFF
--- a/crates/hyprstream-9p/README.md
+++ b/crates/hyprstream-9p/README.md
@@ -1,0 +1,35 @@
+# hyprstream-9p
+
+Minimal 9P2000.L server for bridging the hyprstream VFS to Wanix via DMA ring buffers.
+
+## What it does
+
+Implements the subset of the 9P2000.L wire protocol needed for read/write filesystem access:
+
+| Message pair | Purpose |
+|---|---|
+| `Tversion` / `Rversion` | Protocol negotiation |
+| `Tattach` / `Rattach` | Attach to root fid |
+| `Twalk` / `Rwalk` | Path traversal (resolve fid) |
+| `Tlopen` / `Rlopen` | Open file (9P2000.L variant) |
+| `Tread` / `Rread` | Read data |
+| `Twrite` / `Rwrite` | Write data |
+| `Treaddir` / `Rreaddir` | List directory |
+| `Tgetattr` / `Rgetattr` | Stat file |
+| `Tclunk` / `Rclunk` | Close fid |
+| `Rlerror` | Error response |
+
+**Wire format**: all messages are 4-byte LE length-prefixed, matching the DMA ring buffer framing used by the Wanix WASM runtime.
+
+**WASM extras** (`target_arch = "wasm32"`): `dma` module (SAB ring-buffer transport) and `wanix_mount` (mount the VFS into the Wanix namespace via DMA).
+
+## Architecture position
+
+```
+hyprstream-vfs           (Mount trait, Namespace, Fid)
+    ↑
+hyprstream-9p            ← you are here
+    ↑
+hyprstream               (9P server factory)
+www-cyberdione-ai        (Wanix WASM: mounts via DMA ring buffer)
+```

--- a/crates/hyprstream-discovery/README.md
+++ b/crates/hyprstream-discovery/README.md
@@ -1,0 +1,40 @@
+# hyprstream-discovery
+
+Service discovery and endpoint resolution for the hyprstream cluster.
+
+## What it does
+
+`DiscoveryService` is the authoritative source for service endpoint lookup. It wraps the `EndpointRegistry` from `hyprstream-rpc` and exposes it as:
+
+1. A local `Resolver` implementation — in-process lookup for services in the same daemon.
+2. A Cap'n Proto RPC service — remote endpoint queries from clients or peer daemons.
+
+### Operations
+
+- `list_services` — enumerate registered services + their endpoint sets (QUIC, iroh, UDS, inproc).
+- `get_endpoints(name)` — resolve all endpoints for a named service.
+- `ping` — liveness check with latency measurement.
+- `announce` — register a service endpoint (used at startup by each service).
+- `auth_metadata` — return OAuth metadata for a service (issuer URL, scopes).
+
+## Key types
+
+| Type | Description |
+|------|-------------|
+| `DiscoveryService` | `RequestService` impl; wraps `EndpointRegistry`, authorises via `AuthorizationProvider` |
+| `DiscoveryClient` | Generated typed client for the discovery RPC service |
+| `AuthorizationProvider` | Trait: `authorize(subject, operation) → bool` |
+| `ServiceEndpoints` | Name + list of `EndpointInfo` (kind, addr/nodeId, accept protocols) |
+
+## Architecture position
+
+```
+hyprstream-rpc           (EndpointRegistry, Resolver trait, SocketKind)
+    ↑
+hyprstream-discovery     ← you are here
+    ↑
+hyprstream               (DiscoveryService factory, DiscoveryClient in OAuthService)
+hyprstream-rpc-std       (re-exports DiscoveryClient for browser use)
+```
+
+Built as `rlib` only — `OnceLock` singletons must be shared across the workspace, not duplicated per cdylib.

--- a/crates/hyprstream-rpc-build/README.md
+++ b/crates/hyprstream-rpc-build/README.md
@@ -1,0 +1,36 @@
+# hyprstream-rpc-build
+
+Build-time helpers: Cap'n Proto schema compilation, annotation extraction, TypeScript codegen, and RPC diagram generation.
+
+## What it does
+
+### Library (`lib.rs`)
+
+- `compile_schemas(schema_dir, out_dir, import_paths, names)` — compile `.capnp` files via `capnpc`, save raw `CodeGeneratorRequest` (`.cgr`) files, and extract annotation metadata to JSON. Used in `build.rs` of every crate with Cap'n Proto schemas.
+- Schema types (`ParsedSchema`, `StructDef`, `FieldDef`, `EnumDef`, …) — shared between `build.rs` code and the proc-macro crate so annotation metadata can be merged at compile time.
+
+### Binaries
+
+| Binary | Purpose |
+|--------|---------|
+| `hyprstream-ts-codegen` | Read compiled `.cgr` + metadata JSON → emit TypeScript client types for `www-cyberdione-ai` |
+| `generate-rpc-diagrams` | Scan service schemas → emit Mermaid/PlantUML RPC topology diagrams |
+
+## Usage (in a crate's `build.rs`)
+
+```rust
+fn main() {
+    let schema_dir = Path::new("src/schemas");
+    let out_dir = Path::new(&std::env::var("OUT_DIR").unwrap());
+    hyprstream_rpc_build::compile_schemas(
+        schema_dir,
+        out_dir,
+        &[],
+        &["inference", "model", "registry"],
+    );
+}
+```
+
+## Architecture position
+
+Build-time only — not linked into any runtime binary. The TypeScript codegen binary is run as part of the `www-cyberdione-ai` build to keep the browser client in sync with Cap'n Proto schema changes.

--- a/crates/hyprstream-rpc-derive/README.md
+++ b/crates/hyprstream-rpc-derive/README.md
@@ -1,0 +1,53 @@
+# hyprstream-rpc-derive
+
+Proc-macro crate for Cap'n Proto serialization and RPC service code generation.
+
+## What it does
+
+Provides four derive macros and one declarative macro:
+
+| Macro | Purpose |
+|-------|---------|
+| `#[derive(ToCapnp)]` | Generate `impl ToCapnp for T` — serialize a Rust struct into a Cap'n Proto builder |
+| `#[derive(FromCapnp)]` | Generate `impl FromCapnp for T` — deserialize a Cap'n Proto reader into a Rust struct |
+| `#[derive(authorize)]` | Attach scope/policy checks to RPC handler methods |
+| `#[service_factory]` | Generate service factory boilerplate (handler registration, dispatch table) |
+| `generate_rpc_service!("name", scope)` | Emit a complete typed client + handler + dispatch fn from a compiled schema |
+
+## Usage
+
+```rust
+use hyprstream_rpc::prelude::*;
+
+#[derive(ToCapnp)]
+#[capnp(registry_capnp::clone_request)]
+pub struct CloneRequest {
+    pub url: String,
+    pub name: String,
+    #[capnp(rename = "maxDepth")]
+    pub depth: u32,
+}
+
+#[derive(FromCapnp)]
+#[capnp(registry_capnp::clone_response)]
+pub struct CloneResponse {
+    pub repo_id: String,
+    pub success: bool,
+}
+```
+
+## Field attributes
+
+- `#[capnp(schema::path)]` on the struct — required, maps to the generated schema type.
+- `#[capnp(skip)]` on a field — omit from serialization.
+- `#[capnp(rename = "camelCase")]` on a field — use a different Cap'n Proto field name.
+
+## Architecture position
+
+```
+hyprstream-rpc-derive    ← you are here (proc macros)
+    ↓ (used by)
+hyprstream-rpc           (re-exports the derive macros)
+hyprstream-rpc-std       (generate_rpc_service! for each service schema)
+hyprstream-{discovery,workers,...}
+```

--- a/crates/hyprstream-rpc-std/README.md
+++ b/crates/hyprstream-rpc-std/README.md
@@ -1,0 +1,37 @@
+# hyprstream-rpc-std
+
+Cap'n Proto service schemas and generated RPC clients for all standard hyprstream services.
+
+## What it does
+
+This crate bundles:
+
+- **Cap'n Proto generated modules** for every first-party service: `inference_capnp`, `model_capnp`, `registry_capnp`, `policy_capnp`, `mcp_capnp`, `metrics_capnp`, `notification_capnp`, `discovery_capnp`, and more.
+- **Generated typed clients** (`InferenceClient`, `ModelClient`, `PolicyClient`, etc.) produced by `hyprstream-rpc-derive`'s `generate_rpc_service!` macro.
+- **WASM bindings** (`wasm_api.rs`): `wasm_bindgen` exports for the browser RPC client — `send_rpc`, `verify_signed_envelope`, `register_pq_trust`, `unregister_pq_trust`, `clear_pq_trust`.
+
+## Targets
+
+Compiles to both native (`rlib`) and `wasm32-unknown-unknown` (`cdylib`). The WASM build is the browser client bundle used by `www-cyberdione-ai`. The native build is used by `hyprstream` for embedding client logic.
+
+## Architecture position
+
+```
+hyprstream-rpc           (transport, envelope, Cap'n Proto codec)
+    ↑
+hyprstream-rpc-std       ← you are here (schemas + generated clients + WASM)
+    ↑
+hyprstream               (embeds generated clients)
+www-cyberdione-ai        (loads the WASM cdylib in a Web Worker)
+```
+
+## Key exports
+
+| Export | Description |
+|--------|-------------|
+| `InferenceClient` | Typed client for the inference service |
+| `ModelClient` | Typed client for the model registry |
+| `PolicyClient` | Typed client for the policy/authz service |
+| `wasm_api::send_rpc` | WASM: make a Cap'n Proto call over WebTransport |
+| `wasm_api::verify_signed_envelope` | WASM: verify COSE envelope signature |
+| `wasm_api::register_pq_trust` | WASM: bind an Ed25519 pubkey → ML-DSA-65 vk for hybrid enforcement |

--- a/crates/hyprstream-rpc/README.md
+++ b/crates/hyprstream-rpc/README.md
@@ -1,0 +1,45 @@
+# hyprstream-rpc
+
+Core RPC infrastructure for the hyprstream service mesh.
+
+## What it does
+
+This crate is the foundation of the RPC plane. It provides:
+
+- **Transport abstraction**: `TransportConfig` + `EndpointType` (QUIC/WebTransport, iroh, UDS inproc, in-memory). All transports implement the same bidi-stream interface.
+- **Lazy transports**: `LazyQuinnTransport`, `LazyIrohTransport`, `LazyUdsTransport` — reconnect on demand with exponential backoff.
+- **Dial**: `dial()` — resolve a `TransportConfig` to a live `RpcClient`.
+- **Signed envelopes**: COSE_Sign1 request/response envelopes (Ed25519 + ML-DSA-65 hybrid). Every RPC call is authenticated at the application layer independent of transport.
+- **Cap'n Proto codec**: `ToCapnp` / `FromCapnp` traits + generated schema modules (`common_capnp`, `events_capnp`, `streaming_capnp`, `nine_capnp`, `annotations_capnp`).
+- **Service dispatch**: `RequestService` + `IrohRequestProcessor` + `LocalServiceBridge` — the post-ZMQ server-side dispatch path.
+- **In-memory registry**: `register_inproc` / `lookup_inproc` — zero-copy inproc dial for same-process services.
+- **DID-doc service entry codec**: `service_entry` — encode/decode `IrohTransport` and `QuicTransport` entries in DID documents.
+
+## Architecture position
+
+```
+hyprstream-rpc           ← you are here
+    ↑
+hyprstream-{rpc-std,discovery,service,workers,vfs,9p}
+    ↑
+hyprstream               (application, factories, OAuth, CLI)
+```
+
+ZMQ/ZMTP is being removed; all new transport code lives here.
+
+## Key types
+
+| Type | Purpose |
+|------|---------|
+| `TransportConfig` | Dialable endpoint (QUIC, iroh, UDS, inproc) |
+| `QuicServerAuth` | TLS auth policy for QUIC dial (WebPKI / pinned cert hash) |
+| `LazyState<T>` | Cached session + `ReconnectBackoff` under one `Mutex` |
+| `LocalServiceBridge` | Bridge a `RequestService` to an `IrohRequestProcessor` |
+| `SignedEnvelope` | COSE_Sign1 wrapper for authenticated RPC payloads |
+| `RpcClient` | Async bidi-stream RPC client |
+
+## Feature flags
+
+- Default: Ristretto255 DH, BLAKE3 MAC.
+- `fips`: ECDH P-256 + HMAC-SHA256 for FIPS 140-2.
+- `wasm32`: transport subset (no ZMQ, no UDS); WASM bindings in `hyprstream-rpc-std`.

--- a/crates/hyprstream-service/README.md
+++ b/crates/hyprstream-service/README.md
@@ -1,0 +1,40 @@
+# hyprstream-service
+
+Pluggable service orchestration: lifecycle management, trust store, and factory helpers.
+
+## What it does
+
+Three subsystems:
+
+**Spawner** — run a `Spawnable` service as a process or in-process task:
+- `ServiceSpawner` — dispatch table: look up a `ServiceFactory` by name, spawn it.
+- `Spawnable` trait — implemented by every service type (already blanket-impl'd for `RequestService + Send + Sync`).
+- `ProcessBackend`, `StandaloneBackend`, `SystemdBackend` — control how the process is started (fork, systemd unit, etc).
+- `InprocManager` — run services on an in-process tokio LocalSet (the post-ZMQ default).
+
+**Factory** — inventory-based service registration:
+- `ServiceFactory` / `ServiceFactoryFn` — a constructor that returns `Box<dyn Spawnable>`.
+- `get_factory(name)` / `list_factories()` — global inventory keyed by service name.
+- `ServiceContext` — per-service context: signing key, ZMQ context, transport configs, verifying key derivation.
+- `QuicSharedConfig` — QUIC cert + endpoint shared across all QUIC-serving services.
+
+**Trust store** — peer key distribution at startup:
+- `TrustStore` + `global_trust_store()` — maps service name → `VerifyingKey`; populated by each service factory before dependents start.
+- `Attestation` — optional signed proof of key ownership.
+
+## Architecture position
+
+```
+hyprstream-rpc           (RequestService, Spawnable trait, transport)
+hyprstream-discovery     (DiscoveryService for startup ordering)
+    ↑
+hyprstream-service       ← you are here
+    ↑
+hyprstream               (calls get_factory / ServiceSpawner in main.rs)
+```
+
+Built as `rlib` only — `OnceLock` global state must not be duplicated across cdylib boundaries.
+
+## Key re-exports
+
+`ServiceSpawner`, `Spawnable`, `ServiceFactory`, `ServiceContext`, `TrustStore`, `global_trust_store`, `ServiceManager`, `startup_stages`.

--- a/crates/hyprstream-vfs/README.md
+++ b/crates/hyprstream-vfs/README.md
@@ -1,0 +1,41 @@
+# hyprstream-vfs
+
+Plan 9-inspired VFS namespace multiplexer for hyprstream.
+
+## What it does
+
+A client-side mount table that routes 9P operations by path prefix. Services are auto-mounted under `/srv/{name}` from discovery. The namespace is composable — any `Mount` implementation can be bound at any path.
+
+```
+/bin/cat                        → filesystem command (CtlFile)
+/env/temperature                → session variable (DynamicDir)
+/srv/model/qwen3:main/status    → ModelService (via RPC or IPC)
+/srv/mcp/summarize/schema       → McpService
+/config/temperature             → in-process (Mount)
+/net/peer-a/srv/model/...       → federated peer
+```
+
+All types are WASM-compatible. Transport is abstracted via the `Mount` trait — the same namespace API works over in-process calls, RPC, and the 9P wire protocol.
+
+## Key types
+
+| Type | Description |
+|------|-------------|
+| `Namespace` | Mount table with prefix routing; `bind()`, `walk()`, `open()`, `read()`, `write()` |
+| `Mount` | Trait implemented by any VFS backend (filesystem, RPC proxy, synthetic dir) |
+| `Fid` | Open file handle (maps to 9P `fid`) |
+| `Stat` | File metadata |
+| `BindFlag` | `Replace`, `Before`, `After` — controls union mount ordering |
+| `MountTarget` | Destination for a bind (path or special targets) |
+
+## Architecture position
+
+```
+hyprstream-vfs           ← you are here
+    ↑ (depends on)
+hyprstream-rpc           (Subject for caller identity)
+    ↑ (used by)
+hyprstream-9p            (9P wire protocol server)
+hyprstream-workers       (container I/O paths)
+hyprstream               (VFS service factory, /srv mounts)
+```

--- a/crates/hyprstream-workers/README.md
+++ b/crates/hyprstream-workers/README.md
@@ -1,0 +1,42 @@
+# hyprstream-workers
+
+Isolated workload execution using Kata Container VMs with CRI-aligned APIs.
+
+## What it does
+
+Two services:
+
+**`WorkerService`** — CRI-aligned container runtime (mirrors the Kubernetes CRI interface):
+- `PodSandbox` = Kata VM (hardware-isolated via KVM)
+- `Container` = OCI container inside the VM
+- `ImageClient` backed by Nydus RAFS for chunk-level image deduplication
+- Exposes `RuntimeClient` and `ImageClient` traits over Cap'n Proto RPC
+
+**`WorkflowService`** — GitHub Actions-compatible CI/CD orchestration:
+- Discovers `.github/workflows/*.yml` from `RegistryService` repos
+- Subscribes to the event bus (`git2db.{repo_id}.push`, `training.{model_id}.completed`, `metrics.{model_id}.breach`)
+- Spawns pods/containers via `WorkerService` on trigger
+
+## Architecture position
+
+```
+hyprstream-rpc           (transport + envelope)
+hyprstream-vfs           (VFS for container I/O)
+    ↑
+hyprstream-workers       ← you are here
+    ↑
+hyprstream               (WorkerService factory, WorkflowService factory)
+```
+
+## Key types
+
+| Type | Description |
+|------|-------------|
+| `WorkerService` | Combined `RuntimeClient` + `ImageClient` implementation |
+| `WorkflowService` | Workflow discovery + trigger + execution orchestration |
+| `PodSandboxConfig` | CRI pod sandbox configuration |
+| `ContainerConfig` | OCI container spec |
+
+## Feature flags
+
+- `dbus` — D-Bus integration for host notification / systemd interaction

--- a/crates/hyprstream/src/runtime/architectures/qwen3_5.rs
+++ b/crates/hyprstream/src/runtime/architectures/qwen3_5.rs
@@ -1689,13 +1689,17 @@ impl ModelOperations for Qwen3_5Model {
 
     fn forward_with_cache(&self, input: &Tensor, start_pos: usize) -> Result<Tensor> {
         let hidden = self.forward_inner(Some(input), None, start_pos, None)?;
-        let normed = self.norm.forward(&hidden)?;
+        // Prefill optimization (#201): only run the expensive LM-head matmul over the
+        // last position — the caller always discards all but the last token's logits.
+        let last = hidden.narrow(1, hidden.size()[1] - 1, 1);
+        let normed = self.norm.forward(&last)?;
         self.lm_head_apply(&normed)
     }
 
     fn forward_from_embeddings(&self, embeddings: &Tensor, start_pos: usize) -> Result<Tensor> {
         let hidden = self.forward_inner(None, Some(embeddings), start_pos, None)?;
-        let normed = self.norm.forward(&hidden)?;
+        let last = hidden.narrow(1, hidden.size()[1] - 1, 1);
+        let normed = self.norm.forward(&last)?;
         self.lm_head_apply(&normed)
     }
 
@@ -1706,7 +1710,8 @@ impl ModelOperations for Qwen3_5Model {
         delta: Option<&crate::training::TenantDelta>,
     ) -> Result<Tensor> {
         let hidden = self.forward_inner(Some(input), None, start_pos, delta)?;
-        let normed = self.norm.forward(&hidden)?;
+        let last = hidden.narrow(1, hidden.size()[1] - 1, 1);
+        let normed = self.norm.forward(&last)?;
         self.lm_head_apply(&normed)
     }
 


### PR DESCRIPTION
## Summary
- `forward_with_cache`, `forward_from_embeddings`, `forward_with_cache_and_delta` in `qwen3_5.rs` were running the full-sequence RMSNorm + LM-head matmul over all positions even though callers always kept only the last token.
- Fix: narrow to last position before norm+lm_head (`hidden.narrow(1, seq-1, 1)`).
- For Qwen3.5 (vocab ≈ 152K) this reduces prefill LM-head work from O(seq_len) to O(1).

Closes #201