### PR TITLE
fix(#202): cap Tier 3 entropy-based LoRA rank at 8 for unrecognized models

### DIFF
--- a/crates/hyprstream/src/runtime/ttn_profile.rs
+++ b/crates/hyprstream/src/runtime/ttn_profile.rs
@@ -339,7 +339,10 @@ pub fn compute_weight_entropy_profile(
             0.95 // Default: near-uniform → low rank
         };
 
-        let recommended_rank = entropy_to_rank(avg_normalized);
+        // Conservative cap: Tier 3 entropy-based ranks are unvalidated for models outside
+        // the embedded profile registry. Cap at 8 (uniform fallback) until ablation
+        // results land (#202). The runtime-correction loop raises utilised rank over time.
+        let recommended_rank = entropy_to_rank(avg_normalized).min(8);
 
         // Target modules: default ["q_proj", "v_proj"] for standard (R2-I4 fix)
         let target_modules = match layer_type {
@@ -449,6 +452,12 @@ pub fn get_layer_profile(
 
     // Tier 3: Compute from weights (~2-5s)
     if let Some(weights) = weights {
+        warn!(
+            model_type = %config.model_type,
+            "Unknown model — Tier 3 entropy-based rank allocation is unvalidated \
+             (no embedded ablation data). Conservative cap (rank ≤ 8) applied until \
+             ablation spike lands (#202). Consider contributing an embedded profile."
+        );
         info!("Computing TTN profile for new model (one-time analysis)...");
         return compute_weight_entropy_profile(weights, config, model_path);
     }


### PR DESCRIPTION
## Summary
- Tier 3 entropy→rank mapping (Tier 3) was calibrated only against Qwen3.5-0.8B ablation data. Allocating ranks up to 32 for models with no embedded profile was unvalidated and could cause TTT divergence.
- Interim guardrail: cap `recommended_rank` at 8 (matching the uniform fallback) inside `compute_weight_entropy_profile()`.
- Adds a `warn!` at the Tier 3 dispatch site in `get_layer_profile()` so operators can see when a model is unrecognized.
- The cap will be lifted once the ablation spike completes and results are encoded in an embedded profile for the model.
- The runtime-correction loop (`delta_rank_utilization`) will raise effective rank over time as needed.

Partial close of #202 (ablation spike + validated Tier 3 calibration deferred)