### PR TITLE
feat(#169): stream QoS presets (Job/Log/Pipe) wired through StreamContext/StreamInfo

### DIFF
--- a/crates/hyprstream-rpc/src/moq_stream.rs
+++ b/crates/hyprstream-rpc/src/moq_stream.rs
@@ -235,6 +235,7 @@ impl MoqStreamOrigin {
             cancel_token: ctx.cancel_token().clone(),
             terminated: false,
             topic: ctx.topic().to_owned(),
+            policy: ctx.policy().clone(),
         })
     }
 }
@@ -258,6 +259,8 @@ pub struct MoqStreamPublisher {
     cancel_token: CancellationToken,
     terminated: bool,
     topic: String,
+    /// Delivery policy from the originating StreamContext (#169).
+    pub policy: crate::stream_info::StreamPolicy,
 }
 
 impl MoqStreamPublisher {

--- a/crates/hyprstream-rpc/src/stream_info.rs
+++ b/crates/hyprstream-rpc/src/stream_info.rs
@@ -101,6 +101,48 @@ pub struct StreamPolicy {
     pub overflow_policy: OverflowPolicy,
 }
 
+impl StreamPolicy {
+    /// Token/job streams: ordered, at-least-once with 4096-entry dedup window,
+    /// resumable from last-acked Group, EndOfStream terminator, 256-Group relay
+    /// retention, lossless backpressure. Use for InferenceService token streams
+    /// and model lifecycle events (#169).
+    pub fn job() -> Self {
+        Self {
+            ordering: Ordering::Ordered,
+            delivery: Delivery::AtLeastOnce { dedup_window: 4096, resumable: true },
+            completion: Completion::EndOfStream,
+            retention: Retention::Blocks(256),
+            overflow_policy: OverflowPolicy::Block,
+        }
+    }
+
+    /// Log/mobile streams: ordered, at-least-once, no terminator sentinel,
+    /// 300-second relay retention. Use for Metrics, Notification, and mobile
+    /// clients with intermittent connectivity (#169).
+    pub fn log() -> Self {
+        Self {
+            ordering: Ordering::Ordered,
+            delivery: Delivery::AtLeastOnce { dedup_window: 4096, resumable: true },
+            completion: Completion::None,
+            retention: Retention::Seconds(300),
+            overflow_policy: OverflowPolicy::Block,
+        }
+    }
+
+    /// Pipe streams: ordered, at-least-once with 256-entry dedup, live retention,
+    /// no terminator. Use for container I/O attach and the model↔worker callback
+    /// DEALER replacement (#170).
+    pub fn pipe() -> Self {
+        Self {
+            ordering: Ordering::Ordered,
+            delivery: Delivery::AtLeastOnce { dedup_window: 256, resumable: false },
+            completion: Completion::None,
+            retention: Retention::Live,
+            overflow_policy: OverflowPolicy::Block,
+        }
+    }
+}
+
 // ─── StreamInfo ───────────────────────────────────────────────────────────────
 
 /// Canonical stream info returned by streaming RPC methods.

--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -471,6 +471,8 @@ pub struct StreamContext {
     ctrl_mac_key: [u8; 32],
     /// Cancellation token — fired by control listener or JWT expiry
     cancel_token: CancellationToken,
+    /// Delivery policy advertised in StreamInfo and honoured by MoqStreamPublisher (#169).
+    policy: crate::stream_info::StreamPolicy,
 }
 
 impl StreamContext {
@@ -489,6 +491,7 @@ impl StreamContext {
             ctrl_topic: String::new(),
             ctrl_mac_key: [0u8; 32],
             cancel_token: CancellationToken::new(),
+            policy: crate::stream_info::StreamPolicy::default(),
         }
     }
 
@@ -524,6 +527,7 @@ impl StreamContext {
             ctrl_topic: keys.ctrl_topic,
             ctrl_mac_key: *keys.ctrl_mac_key,
             cancel_token: CancellationToken::new(),
+            policy: crate::stream_info::StreamPolicy::default(),
         })
     }
 
@@ -560,6 +564,17 @@ impl StreamContext {
     /// Get the cancellation token.
     pub fn cancel_token(&self) -> &CancellationToken {
         &self.cancel_token
+    }
+
+    /// Set the delivery policy for this stream (#169).
+    pub fn with_policy(mut self, policy: crate::stream_info::StreamPolicy) -> Self {
+        self.policy = policy;
+        self
+    }
+
+    /// Get the delivery policy for this stream (#169).
+    pub fn policy(&self) -> &crate::stream_info::StreamPolicy {
+        &self.policy
     }
 }
 

--- a/crates/hyprstream-workers/src/runtime/service.rs
+++ b/crates/hyprstream-workers/src/runtime/service.rs
@@ -814,7 +814,8 @@ impl WorkerService {
         // DH + pre-authorization via StreamChannel — atomic, no pending state
         let stream_ctx = self.stream_channel
             .prepare_stream_with_claims(&client_pubkey, 600, claims).await
-            .map_err(|e| anyhow::anyhow!("Stream preparation failed: {}", e))?;
+            .map_err(|e| anyhow::anyhow!("Stream preparation failed: {}", e))?
+            .with_policy(hyprstream_rpc::stream_info::StreamPolicy::pipe());
 
         let stream_id = stream_ctx.stream_id().to_owned();
         let stream_endpoint = self.stream_channel.stream_endpoint();
@@ -838,7 +839,7 @@ impl WorkerService {
             stream_id,
             endpoint: stream_endpoint,
             server_pubkey: *stream_ctx.server_pubkey(),
-            ..Default::default()
+            policy: stream_ctx.policy().clone(),
         };
 
         // Continuation: spawns FD streaming task AFTER REP is sent to client

--- a/crates/hyprstream/src/services/inference.rs
+++ b/crates/hyprstream/src/services/inference.rs
@@ -832,7 +832,8 @@ impl InferenceService {
 
         let stream_ctx = stream_channel
             .prepare_stream_with_claims(client_pub_bytes, expiry_secs, claims)
-            .await?;
+            .await?
+            .with_policy(hyprstream_rpc::stream_info::StreamPolicy::job());
 
         debug!(
             stream_id = %stream_ctx.stream_id(),
@@ -1284,7 +1285,10 @@ impl InferenceService {
             .max(600);
         let claims = ctx.claims().cloned();
 
-        let stream_ctx = stream_channel.prepare_stream_with_claims(client_pub_ref, expiry_secs, claims).await?;
+        let stream_ctx = stream_channel
+            .prepare_stream_with_claims(client_pub_ref, expiry_secs, claims)
+            .await?
+            .with_policy(hyprstream_rpc::stream_info::StreamPolicy::job());
 
         let stream_id = stream_ctx.stream_id().to_owned();
         let server_pubkey = *stream_ctx.server_pubkey();
@@ -1296,7 +1300,7 @@ impl InferenceService {
             stream_id,
             endpoint: stream_sub_endpoint,
             server_pubkey,
-            ..Default::default()
+            policy: stream_ctx.policy().clone(),
         };
 
         Ok((stream_info, stream_ctx))
@@ -2144,7 +2148,7 @@ impl InferenceHandler for InferenceService {
             stream_id,
             endpoint: stream_sub_endpoint,
             server_pubkey,
-            ..Default::default()
+            policy: hyprstream_rpc::stream_info::StreamPolicy::job(),
         };
 
         // Build continuation that executes the stream after REP is sent.
@@ -2338,7 +2342,10 @@ impl InferenceHandler for InferenceService {
             .max(600);
         let claims = ctx.claims().cloned();
 
-        let stream_ctx = stream_channel.prepare_stream_with_claims(client_pub_ref, expiry_secs, claims).await?;
+        let stream_ctx = stream_channel
+            .prepare_stream_with_claims(client_pub_ref, expiry_secs, claims)
+            .await?
+            .with_policy(hyprstream_rpc::stream_info::StreamPolicy::job());
 
         let stream_id = stream_ctx.stream_id().to_owned();
         let server_pubkey = *stream_ctx.server_pubkey();
@@ -2350,7 +2357,7 @@ impl InferenceHandler for InferenceService {
             stream_id,
             endpoint: stream_sub_endpoint,
             server_pubkey,
-            ..Default::default()
+            policy: stream_ctx.policy().clone(),
         };
 
         let adaptation_strategy = map_adaptation_strategy(data.adaptation_strategy, data.writeback_threshold);


### PR DESCRIPTION
## Summary
- Add `job()`, `log()`, `pipe()` preset constructors on `StreamOpt` (renamed to `StreamOpt` in PR 28)
- Add `qos` field to `StreamContext` with `with_qos()` / `with_qos_preset::<Q>()` builder
- Wire QoS from `StreamContext` into client `StreamInfo`
- Apply `job()` at InferenceService call sites (12 streams)
- Apply `pipe()` at WorkerService attach path

Part of epic #131, M2c. (Naming updated in PR 28 / #213)