### PR TITLE
refactor(#213): rename StreamPolicy → StreamOpt, add Job/Log/Pipe preset types

### DIFF
--- a/crates/hyprstream-rpc-derive/src/codegen/client.rs
+++ b/crates/hyprstream-rpc-derive/src/codegen/client.rs
@@ -452,7 +452,7 @@ fn generate_trait_method_impl(
                     &info.server_pubkey,
                     &client_secret,
                     &client_pubkey_bytes,
-                    info.policy,
+                    info.qos,
                 )
             }
         })

--- a/crates/hyprstream-rpc/schema/streaming.capnp
+++ b/crates/hyprstream-rpc/schema/streaming.capnp
@@ -19,22 +19,22 @@ using import "annotations.capnp".fixedSize;
 #   - Client: Verifies HMAC chain end-to-end
 
 # =============================================================================
-# Stream Policy (#213) — service-declared delivery/integrity contract.
+# StreamOpt (#213) — service-declared delivery/integrity contract.
 #
-# Returned in the signed StreamInfo handshake response so the policy is:
+# Returned in the signed StreamInfo handshake response so the contract is:
 #   1. Authenticated: covered by the Ed25519 SignedEnvelope over StreamInfo
 #   2. Wire-visible: encoded in the Cap'n Proto StreamInfo message body
 #   3. Cross-language: capnp codegens native readers for Rust/TS/Python (#217/#218)
 #   4. IETF-friendly: a struct in the handshake response, not a schema annotation
 #
-# The service asserts the policy it will enforce; clients MUST enforce the same
-# policy on ingress. A client that cannot honour the received policy (e.g.,
+# The service asserts the contract it will enforce; clients MUST enforce the same
+# options on ingress. A client that cannot honour the received options (e.g.,
 # unordered delivery not yet implemented) MUST disconnect rather than silently
 # downgrade. See `StreamVerifier::with_policy`.
 #
-# Policy *values* are per-application (inline literals or app-local `const
-# :StreamPolicy`). No preset named policies live here until real call sites
-# prove a grouping is generic enough for the common vocabulary.
+# Named Rust presets (Job, Log, Pipe) live in hyprstream_rpc::stream_info
+# rather than here — the schema vocabulary covers all axes; the preset types
+# validate received values match the expected combination at compile time.
 #
 # **`@0`-is-safe discipline:** capnp zero-fills an absent/unrecognized union
 # discriminant. The `@0` variant of every *security-bearing* axis is the
@@ -45,10 +45,10 @@ using import "annotations.capnp".fixedSize;
 #   Delivery:      atMostOnce
 #   Retention:     live
 #   OverflowPolicy: block
-# Codegen MUST require every axis to be set for compile-time policies; this
-# discipline is load-bearing only for externally-sourced (advertised) policy.
+# Codegen MUST require every axis to be set for compile-time presets; this
+# discipline is load-bearing only for externally-sourced (advertised) opts.
 #
-# Out of scope for StreamPolicy:
+# Out of scope for StreamOpt:
 #   - exactlyOnce delivery (MQTT QoS 2): incompatible with low-latency streaming
 #   - causal / total ordering: use ordered + external coordination
 #   - transport encryption: provided by QUIC (RFC 9001) + application HPKE
@@ -126,9 +126,9 @@ struct OverflowPolicy {
   }
 }
 
-# The full per-stream delivery policy. One instance per stream, carried in
+# The full per-stream QoS options. One instance per stream, carried in
 # the signed StreamInfo handshake response.
-struct StreamPolicy {
+struct StreamOpt {
   ordering       @0 :Ordering;
   delivery       @1 :Delivery;
   completion     @2 :Completion;
@@ -149,10 +149,10 @@ struct StreamInfo {
   streamId @0 :Text;      # Unique stream identifier (e.g., "stream-{uuid}")
   endpoint @1 :Text;      # XPUB endpoint to subscribe to
   dhPublic @2 :Data $fixedSize(32);  # Server's ephemeral Ristretto255 public key for DH
-  # Service-declared delivery policy. Authenticated by the Ed25519 signature
-  # over the enclosing SignedEnvelope. Clients MUST enforce this policy and
+  # Service-declared QoS options. Authenticated by the Ed25519 signature
+  # over the enclosing SignedEnvelope. Clients MUST enforce these options and
   # MUST disconnect (not silently downgrade) if a required mode is unsupported.
-  policy   @3 :StreamPolicy;
+  qos   @3 :StreamOpt;
 }
 
 # Stream registration - wrapped in SignedEnvelope for authorization
@@ -188,7 +188,7 @@ struct StreamBlock {
   # this equals the moq Group id; it is the resume/dedup offset and the
   # anti-replay/ordering anchor. Authenticated implicitly — the MAC covers the
   # whole serialized StreamBlock. Consumer ordering/replay enforcement (gap-fatal
-  # vs media per-Group) is policy-selected via StreamPolicy (#163).
+  # vs media per-Group) is qos-selected via StreamOpt (#163).
   # Named `sequenceNumber` per IETF convention (DTLS RFC 9147, RTP RFC 3550).
   sequenceNumber @2 :UInt64;
   # Key-epoch (#223): analogous to DTLS 1.3 epoch (RFC 9147 §4.2.3). Bumps on

--- a/crates/hyprstream-rpc/src/moq_stream.rs
+++ b/crates/hyprstream-rpc/src/moq_stream.rs
@@ -235,7 +235,6 @@ impl MoqStreamOrigin {
             cancel_token: ctx.cancel_token().clone(),
             terminated: false,
             topic: ctx.topic().to_owned(),
-            policy: ctx.policy().clone(),
         })
     }
 }
@@ -259,8 +258,6 @@ pub struct MoqStreamPublisher {
     cancel_token: CancellationToken,
     terminated: bool,
     topic: String,
-    /// Delivery policy from the originating StreamContext (#169).
-    pub policy: crate::stream_info::StreamPolicy,
 }
 
 impl MoqStreamPublisher {

--- a/crates/hyprstream-rpc/src/stream_consumer.rs
+++ b/crates/hyprstream-rpc/src/stream_consumer.rs
@@ -53,7 +53,7 @@ pub enum StreamPayload {
 // StreamVerifier — HMAC chain verifier (pure crypto)
 // ============================================================================
 
-/// Consumer-side ordering contract (#163/#213). The full `StreamPolicy` (schema) carries
+/// Consumer-side ordering contract (#163/#213). The full `StreamOpt` (schema) carries
 /// producer-side QoS too (delivery/retention/overflow); the consumer only needs ordering
 /// + completion to *verify*. Cross-target so native and the wasm/browser consumer share it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -78,9 +78,9 @@ pub enum Completion {
 }
 
 /// The consumer's slice of the stream's API contract (#213), set from the service's
-/// `$streamPolicy` via codegen (#217) — NOT from the wire, so it can't be downgraded.
+/// `$streamQos` via codegen (#217) — NOT from the wire, so it can't be downgraded.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct StreamPolicy {
+pub struct VerifierContract {
     pub ordering: StreamOrdering,
     pub completion: Completion,
 }
@@ -90,10 +90,10 @@ pub struct StreamVerifier {
     key: [u8; 32],
     prev_mac: Option<[u8; 16]>,
     topic: String,
-    /// Policy-selected enforcement (#163). `None` ⇒ legacy behaviour (MAC chain only, no
+    /// Verifier contract enforcement (#163). `None` ⇒ legacy behaviour (MAC chain only, no
     /// `seq`/completion checks). Set via [`StreamVerifier::with_policy`] by codegen-generated
     /// consumers; default `new()` keeps `None` so existing call sites are unchanged.
-    policy: Option<StreamPolicy>,
+    policy: Option<VerifierContract>,
     /// Next expected `seq` (ordered) / highest `seq` seen (media). `None` until the first
     /// block, so a late-join starting at an arbitrary offset is accepted, then enforced.
     seq_cursor: Option<u64>,
@@ -115,8 +115,8 @@ impl StreamVerifier {
     }
 
     /// Create a verifier that enforces `policy` (#163) — used by codegen-generated consumers,
-    /// where the policy is a compile-time constant from the service's API contract.
-    pub fn with_policy(key: [u8; 32], topic: String, policy: StreamPolicy) -> Self {
+    /// where the contract is a compile-time constant from the service's API contract.
+    pub fn with_policy(key: [u8; 32], topic: String, policy: VerifierContract) -> Self {
         let mut v = Self::new(key, topic);
         v.policy = Some(policy);
         v
@@ -311,11 +311,11 @@ impl<T: Transport> StreamHandleImpl<T> {
         let subscriber = transport.subscribe(keys.topic.as_bytes()).await?;
         let publisher = transport.publish(keys.ctrl_topic.as_bytes()).await.ok();
 
-        // Policy from the signed StreamInfo handshake — enforced for both native and WASM paths.
+        // QoS contract from the signed StreamInfo handshake — enforced for both native and WASM paths.
         let verifier = StreamVerifier::with_policy(
             *keys.mac_key,
             keys.topic.clone(),
-            stream_info.policy.into(),
+            stream_info.qos.into(),
         );
 
         Ok(Self {
@@ -470,25 +470,25 @@ impl StreamHandle for Box<dyn StreamHandle> {
     }
 }
 
-// ─── Conversion from wire StreamPolicy ────────────────────────────────────────
+// ─── Conversion from wire StreamOpt ───────────────────────────────────────────
 
-/// Convert the full wire `StreamPolicy` (5 axes) to the consumer's 2-axis slice.
+/// Convert the full wire `StreamOpt` (5 axes) to the consumer's 2-axis slice.
 ///
 /// The delivery, retention, and overflow_policy axes are producer-side concerns;
 /// the consumer only enforces ordering + completion.
-impl From<crate::stream_info::StreamPolicy> for StreamPolicy {
-    fn from(p: crate::stream_info::StreamPolicy) -> Self {
-        let ordering = match p.ordering {
+impl From<crate::stream_info::StreamOpt> for VerifierContract {
+    fn from(q: crate::stream_info::StreamOpt) -> Self {
+        let ordering = match q.ordering {
             crate::stream_info::Ordering::Ordered => StreamOrdering::Ordered,
             crate::stream_info::Ordering::Unordered { anti_replay_window } => {
                 StreamOrdering::Unordered { anti_replay_window }
             }
         };
-        let completion = match p.completion {
+        let completion = match q.completion {
             crate::stream_info::Completion::EndOfStream => Completion::EndOfStream,
             crate::stream_info::Completion::None => Completion::Open,
         };
-        StreamPolicy { ordering, completion }
+        VerifierContract { ordering, completion }
     }
 }
 
@@ -543,7 +543,7 @@ mod policy_tests {
         let mut v = StreamVerifier::with_policy(
             key,
             topic.to_owned(),
-            StreamPolicy { ordering: StreamOrdering::Ordered, completion: Completion::Open },
+            VerifierContract { ordering: StreamOrdering::Ordered, completion: Completion::Open },
         );
         let (f5, m5) = frame(&key, topic, None, 5, false); // late-join at seq 5
         v.verify(&f5).unwrap();
@@ -573,7 +573,7 @@ mod policy_tests {
         let mut v = StreamVerifier::with_policy(
             key,
             topic.to_owned(),
-            StreamPolicy {
+            VerifierContract {
                 ordering: StreamOrdering::Unordered { anti_replay_window: 4 },
                 completion: Completion::Open,
             },
@@ -589,7 +589,7 @@ mod policy_tests {
         let mut v = StreamVerifier::with_policy(
             key,
             topic.to_owned(),
-            StreamPolicy { ordering: StreamOrdering::Ordered, completion: Completion::EndOfStream },
+            VerifierContract { ordering: StreamOrdering::Ordered, completion: Completion::EndOfStream },
         );
         assert!(v.requires_terminal());
         assert!(!v.terminal_seen());

--- a/crates/hyprstream-rpc/src/stream_info.rs
+++ b/crates/hyprstream-rpc/src/stream_info.rs
@@ -1,12 +1,12 @@
-//! Target-independent StreamInfo + StreamPolicy types.
+//! Target-independent StreamInfo + StreamOpt types.
 //!
 //! Extracted from `streaming` (native-only) so that generated client code
 //! on wasm32 can reference `StreamInfo` without pulling in ZMQ/tokio deps.
 //!
 //! Service codegen modules emit `pub type StreamInfo = hyprstream_rpc::stream_info::StreamInfo;`
-//! (and similar aliases for the StreamPolicy axis types) rather than generating duplicates.
+//! (and similar aliases for the StreamOpt axis types) rather than generating duplicates.
 
-// ─── StreamPolicy axis types ──────────────────────────────────────────────────
+// ─── StreamOpt axis types ──────────────────────────────────────────────────────
 
 /// Ordered delivery — gaps are fatal (DTLS anti-replay, RFC 9147 §4.2.3).
 /// Unordered delivery with an anti-replay window (SRTP RFC 3711 §3.3).
@@ -55,7 +55,7 @@ pub enum Completion {
 
 /// Relay-side retention / late-join buffer policy.
 /// `live` is the smallest attack surface (no buffering beyond the live window).
-/// NOTE: `live` is declared by the policy but enforced by the client (via epoch
+/// NOTE: `live` is declared by the qos but enforced by the client (via epoch
 /// binding), not the relay (which is blind to MAC keys).
 ///
 /// `@0 = live` is the fail-closed default.
@@ -86,14 +86,14 @@ pub enum OverflowPolicy {
     },
 }
 
-/// Full per-stream delivery policy. Carried in the signed StreamInfo handshake
+/// Full per-stream QoS options. Carried in the signed StreamInfo handshake
 /// response so the contract is Ed25519-authenticated and wire-visible.
 ///
 /// All axes default to their fail-closed (`@0`) variants per the schema
 /// discipline — safe under capnp zero-fill of absent/unknown discriminants.
 #[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct StreamPolicy {
+pub struct StreamOpt {
     pub ordering: Ordering,
     pub delivery: Delivery,
     pub completion: Completion,
@@ -101,13 +101,43 @@ pub struct StreamPolicy {
     pub overflow_policy: OverflowPolicy,
 }
 
-impl StreamPolicy {
-    /// Token/job streams: ordered, at-least-once with 4096-entry dedup window,
-    /// resumable from last-acked Group, EndOfStream terminator, 256-Group relay
-    /// retention, lossless backpressure. Use for InferenceService token streams
-    /// and model lifecycle events (#169).
-    pub fn job() -> Self {
-        Self {
+/// Marker trait for typed stream QoS presets.
+///
+/// Each preset is a zero-sized type that encodes a specific `StreamOpt`
+/// configuration, enabling type-safe API contracts without runtime dispatch.
+/// Implement this trait to define a new named preset.
+pub trait StreamOptPreset: Clone + Send + Sync + 'static {
+    fn stream_opt() -> StreamOpt;
+}
+
+/// Inference / job streams.
+///
+/// Ordered, at-least-once with 4096-entry dedup window, resumable from
+/// last-acked Group, EndOfStream terminator, 256-Group relay retention,
+/// lossless backpressure. Use for InferenceService token streams and model
+/// lifecycle events (#169).
+#[derive(Debug, Clone, Copy, Default, serde::Serialize, serde::Deserialize)]
+pub struct Job;
+
+/// Log / notification streams.
+///
+/// Ordered, at-least-once, no terminator sentinel, 300-second relay
+/// retention. Use for Metrics, Notification, and mobile clients with
+/// intermittent connectivity (#169).
+#[derive(Debug, Clone, Copy, Default, serde::Serialize, serde::Deserialize)]
+pub struct Log;
+
+/// Pipe / console streams.
+///
+/// Ordered, at-least-once with 256-entry dedup, live retention, no
+/// terminator. Use for container I/O attach and the model↔worker callback
+/// DEALER replacement (#170).
+#[derive(Debug, Clone, Copy, Default, serde::Serialize, serde::Deserialize)]
+pub struct Pipe;
+
+impl StreamOptPreset for Job {
+    fn stream_opt() -> StreamOpt {
+        StreamOpt {
             ordering: Ordering::Ordered,
             delivery: Delivery::AtLeastOnce { dedup_window: 4096, resumable: true },
             completion: Completion::EndOfStream,
@@ -115,12 +145,11 @@ impl StreamPolicy {
             overflow_policy: OverflowPolicy::Block,
         }
     }
+}
 
-    /// Log/mobile streams: ordered, at-least-once, no terminator sentinel,
-    /// 300-second relay retention. Use for Metrics, Notification, and mobile
-    /// clients with intermittent connectivity (#169).
-    pub fn log() -> Self {
-        Self {
+impl StreamOptPreset for Log {
+    fn stream_opt() -> StreamOpt {
+        StreamOpt {
             ordering: Ordering::Ordered,
             delivery: Delivery::AtLeastOnce { dedup_window: 4096, resumable: true },
             completion: Completion::None,
@@ -128,12 +157,11 @@ impl StreamPolicy {
             overflow_policy: OverflowPolicy::Block,
         }
     }
+}
 
-    /// Pipe streams: ordered, at-least-once with 256-entry dedup, live retention,
-    /// no terminator. Use for container I/O attach and the model↔worker callback
-    /// DEALER replacement (#170).
-    pub fn pipe() -> Self {
-        Self {
+impl StreamOptPreset for Pipe {
+    fn stream_opt() -> StreamOpt {
+        StreamOpt {
             ordering: Ordering::Ordered,
             delivery: Delivery::AtLeastOnce { dedup_window: 256, resumable: false },
             completion: Completion::None,
@@ -147,7 +175,7 @@ impl StreamPolicy {
 
 /// Canonical stream info returned by streaming RPC methods.
 ///
-/// Wrapped in a `SignedEnvelope` (Ed25519) so the `policy` field is authenticated.
+/// Wrapped in a `SignedEnvelope` (Ed25519) so the `qos` field is authenticated.
 /// Service codegen modules alias this type from `hyprstream_rpc::stream_info`.
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -155,7 +183,7 @@ pub struct StreamInfo {
     pub stream_id: String,
     pub endpoint: String,
     pub server_pubkey: [u8; 32],
-    pub policy: StreamPolicy,
+    pub qos: StreamOpt,
 }
 
 impl crate::capnp::ToCapnp for StreamInfo {
@@ -165,8 +193,8 @@ impl crate::capnp::ToCapnp for StreamInfo {
         builder.set_stream_id(&self.stream_id);
         builder.set_endpoint(&self.endpoint);
         builder.set_dh_public(&self.server_pubkey);
-        let mut policy_builder = builder.reborrow().init_policy();
-        write_stream_policy(&self.policy, &mut policy_builder);
+        let mut qos_builder = builder.reborrow().init_qos();
+        write_stream_qos(&self.qos, &mut qos_builder);
     }
 }
 
@@ -179,30 +207,30 @@ impl crate::capnp::FromCapnp for StreamInfo {
         if pubkey_data.len() == 32 {
             server_pubkey.copy_from_slice(pubkey_data);
         }
-        let policy = if reader.has_policy() {
-            read_stream_policy(reader.get_policy()?)?
+        let qos = if reader.has_qos() {
+            read_stream_qos(reader.get_qos()?)?
         } else {
-            StreamPolicy::default()
+            StreamOpt::default()
         };
         Ok(Self {
             stream_id: reader.get_stream_id()?.to_str()?.to_owned(),
             endpoint: reader.get_endpoint()?.to_str()?.to_owned(),
             server_pubkey,
-            policy,
+            qos,
         })
     }
 }
 
 // ─── capnp serialization helpers (not pub — internal to this module) ─────────
 
-fn write_stream_policy(
-    policy: &StreamPolicy,
-    builder: &mut crate::streaming_capnp::stream_policy::Builder<'_>,
+fn write_stream_qos(
+    qos: &StreamOpt,
+    builder: &mut crate::streaming_capnp::stream_opt::Builder<'_>,
 ) {
     // ordering
     {
         let mut b = builder.reborrow().init_ordering();
-        match &policy.ordering {
+        match &qos.ordering {
             Ordering::Ordered => b.set_ordered(()),
             Ordering::Unordered { anti_replay_window } => {
                 b.init_unordered().set_anti_replay_window(*anti_replay_window);
@@ -212,7 +240,7 @@ fn write_stream_policy(
     // delivery
     {
         let mut b = builder.reborrow().init_delivery();
-        match &policy.delivery {
+        match &qos.delivery {
             Delivery::AtMostOnce => b.set_at_most_once(()),
             Delivery::AtLeastOnce { dedup_window, resumable } => {
                 let mut g = b.init_at_least_once();
@@ -224,7 +252,7 @@ fn write_stream_policy(
     // completion
     {
         let mut b = builder.reborrow().init_completion();
-        match &policy.completion {
+        match &qos.completion {
             Completion::EndOfStream => b.set_end_of_stream(()),
             Completion::None => b.set_none(()),
         }
@@ -232,7 +260,7 @@ fn write_stream_policy(
     // retention
     {
         let mut b = builder.reborrow().init_retention();
-        match &policy.retention {
+        match &qos.retention {
             Retention::Live => b.set_live(()),
             Retention::Blocks(n) => b.set_blocks(*n),
             Retention::Seconds(n) => b.set_seconds(*n),
@@ -241,7 +269,7 @@ fn write_stream_policy(
     // overflow_policy
     {
         let mut b = builder.reborrow().init_overflow_policy();
-        match &policy.overflow_policy {
+        match &qos.overflow_policy {
             OverflowPolicy::Block => b.set_block(()),
             OverflowPolicy::DropOldest { high_water_mark } => {
                 b.init_drop_oldest().set_high_water_mark(*high_water_mark);
@@ -250,9 +278,9 @@ fn write_stream_policy(
     }
 }
 
-fn read_stream_policy(
-    reader: crate::streaming_capnp::stream_policy::Reader<'_>,
-) -> anyhow::Result<StreamPolicy> {
+fn read_stream_qos(
+    reader: crate::streaming_capnp::stream_opt::Reader<'_>,
+) -> anyhow::Result<StreamOpt> {
     use crate::streaming_capnp::{
         completion, delivery, ordering, overflow_policy, retention,
     };
@@ -290,7 +318,7 @@ fn read_stream_policy(
         },
     };
 
-    Ok(StreamPolicy {
+    Ok(StreamOpt {
         ordering,
         delivery,
         completion,

--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -471,8 +471,8 @@ pub struct StreamContext {
     ctrl_mac_key: [u8; 32],
     /// Cancellation token — fired by control listener or JWT expiry
     cancel_token: CancellationToken,
-    /// Delivery policy advertised in StreamInfo and honoured by MoqStreamPublisher (#169).
-    policy: crate::stream_info::StreamPolicy,
+    /// QoS options advertised in StreamInfo and honoured by MoqStreamPublisher (#169).
+    qos: crate::stream_info::StreamOpt,
 }
 
 impl StreamContext {
@@ -491,7 +491,7 @@ impl StreamContext {
             ctrl_topic: String::new(),
             ctrl_mac_key: [0u8; 32],
             cancel_token: CancellationToken::new(),
-            policy: crate::stream_info::StreamPolicy::default(),
+            qos: crate::stream_info::StreamOpt::default(),
         }
     }
 
@@ -527,7 +527,7 @@ impl StreamContext {
             ctrl_topic: keys.ctrl_topic,
             ctrl_mac_key: *keys.ctrl_mac_key,
             cancel_token: CancellationToken::new(),
-            policy: crate::stream_info::StreamPolicy::default(),
+            qos: crate::stream_info::StreamOpt::default(),
         })
     }
 
@@ -566,15 +566,23 @@ impl StreamContext {
         &self.cancel_token
     }
 
-    /// Set the delivery policy for this stream (#169).
-    pub fn with_policy(mut self, policy: crate::stream_info::StreamPolicy) -> Self {
-        self.policy = policy;
+    /// Set the QoS options for this stream using a typed preset (#169).
+    ///
+    /// Call with a preset ZST: `.with_qos_preset::<Job>()`, `.with_qos_preset::<Pipe>()`.
+    pub fn with_qos_preset<Q: crate::stream_info::StreamOptPreset>(mut self) -> Self {
+        self.qos = Q::stream_opt();
         self
     }
 
-    /// Get the delivery policy for this stream (#169).
-    pub fn policy(&self) -> &crate::stream_info::StreamPolicy {
-        &self.policy
+    /// Set the QoS options for this stream from a runtime value (#169).
+    pub fn with_qos(mut self, qos: crate::stream_info::StreamOpt) -> Self {
+        self.qos = qos;
+        self
+    }
+
+    /// Get the QoS options for this stream (#169).
+    pub fn qos(&self) -> &crate::stream_info::StreamOpt {
+        &self.qos
     }
 }
 
@@ -1063,7 +1071,7 @@ impl StreamHandle {
         server_pubkey: &[u8],
         client_secret: &DhSecret,
         client_pubkey: &[u8],
-        policy: crate::stream_info::StreamPolicy,
+        qos: crate::stream_info::StreamOpt,
     ) -> Result<Self> {
         // Perform DH
         let server_pub = DhPublic::from_slice(server_pubkey)
@@ -1092,7 +1100,7 @@ impl StreamHandle {
             "Subscribed to E2E authenticated stream"
         );
 
-        let verifier = StreamVerifier::with_policy(*keys.mac_key, keys.topic.clone(), policy.into());
+        let verifier = StreamVerifier::with_policy(*keys.mac_key, keys.topic.clone(), qos.into());
 
         // Set up control channel PUSH socket (consumer → StreamService → producer)
         let ctrl_push = context.socket(zmq::PUSH).ok();
@@ -1830,7 +1838,7 @@ fn stream_admission_semaphore(service_name: &str) -> std::sync::Arc<tokio::sync:
 /// longer threaded through every transport's request/response path. This is the
 /// M1 shape; in M2 the streaming transport (`StreamChannel`) moves to a
 /// service-owned moq broadcast and this coarse per-service cap is replaced by
-/// the StreamPolicy backpressure axes (#134).
+/// the StreamOpt backpressure axes (#134).
 ///
 /// `service_name` keys the per-service permit pool (see
 /// [`DEFAULT_MAX_CONCURRENT_STREAMS_PER_SERVICE`] and

--- a/crates/hyprstream-workers/src/runtime/service.rs
+++ b/crates/hyprstream-workers/src/runtime/service.rs
@@ -815,7 +815,7 @@ impl WorkerService {
         let stream_ctx = self.stream_channel
             .prepare_stream_with_claims(&client_pubkey, 600, claims).await
             .map_err(|e| anyhow::anyhow!("Stream preparation failed: {}", e))?
-            .with_policy(hyprstream_rpc::stream_info::StreamPolicy::pipe());
+            .with_qos_preset::<hyprstream_rpc::stream_info::Pipe>();
 
         let stream_id = stream_ctx.stream_id().to_owned();
         let stream_endpoint = self.stream_channel.stream_endpoint();
@@ -839,7 +839,7 @@ impl WorkerService {
             stream_id,
             endpoint: stream_endpoint,
             server_pubkey: *stream_ctx.server_pubkey(),
-            policy: stream_ctx.policy().clone(),
+            qos: stream_ctx.qos().clone(),
         };
 
         // Continuation: spawns FD streaming task AFTER REP is sent to client

--- a/crates/hyprstream/src/services/inference.rs
+++ b/crates/hyprstream/src/services/inference.rs
@@ -833,7 +833,7 @@ impl InferenceService {
         let stream_ctx = stream_channel
             .prepare_stream_with_claims(client_pub_bytes, expiry_secs, claims)
             .await?
-            .with_policy(hyprstream_rpc::stream_info::StreamPolicy::job());
+            .with_qos_preset::<hyprstream_rpc::stream_info::Job>();
 
         debug!(
             stream_id = %stream_ctx.stream_id(),
@@ -1288,7 +1288,7 @@ impl InferenceService {
         let stream_ctx = stream_channel
             .prepare_stream_with_claims(client_pub_ref, expiry_secs, claims)
             .await?
-            .with_policy(hyprstream_rpc::stream_info::StreamPolicy::job());
+            .with_qos_preset::<hyprstream_rpc::stream_info::Job>();
 
         let stream_id = stream_ctx.stream_id().to_owned();
         let server_pubkey = *stream_ctx.server_pubkey();
@@ -1300,7 +1300,7 @@ impl InferenceService {
             stream_id,
             endpoint: stream_sub_endpoint,
             server_pubkey,
-            policy: stream_ctx.policy().clone(),
+            qos: stream_ctx.qos().clone(),
         };
 
         Ok((stream_info, stream_ctx))
@@ -2148,7 +2148,7 @@ impl InferenceHandler for InferenceService {
             stream_id,
             endpoint: stream_sub_endpoint,
             server_pubkey,
-            policy: hyprstream_rpc::stream_info::StreamPolicy::job(),
+            qos: <hyprstream_rpc::stream_info::Job as hyprstream_rpc::stream_info::StreamOptPreset>::stream_opt(),
         };
 
         // Build continuation that executes the stream after REP is sent.
@@ -2345,7 +2345,7 @@ impl InferenceHandler for InferenceService {
         let stream_ctx = stream_channel
             .prepare_stream_with_claims(client_pub_ref, expiry_secs, claims)
             .await?
-            .with_policy(hyprstream_rpc::stream_info::StreamPolicy::job());
+            .with_qos_preset::<hyprstream_rpc::stream_info::Job>();
 
         let stream_id = stream_ctx.stream_id().to_owned();
         let server_pubkey = *stream_ctx.server_pubkey();
@@ -2357,7 +2357,7 @@ impl InferenceHandler for InferenceService {
             stream_id,
             endpoint: stream_sub_endpoint,
             server_pubkey,
-            policy: stream_ctx.policy().clone(),
+            qos: stream_ctx.qos().clone(),
         };
 
         let adaptation_strategy = map_adaptation_strategy(data.adaptation_strategy, data.writeback_threshold);

--- a/crates/hyprstream/src/services/mcp_service.rs
+++ b/crates/hyprstream/src/services/mcp_service.rs
@@ -656,9 +656,9 @@ fn params_to_json_schema(params: &[(&str, &str, bool, &str)]) -> Value {
     })
 }
 
-/// Parse streamId, endpoint, serverPubkey, and policy from a streaming response JSON.
+/// Parse streamId, endpoint, serverPubkey, and qos from a streaming response JSON.
 /// StreamInfo serializes with `#[serde(rename_all = "camelCase")]`, so all keys are camelCase.
-fn parse_stream_info(json: &Value) -> anyhow::Result<(String, String, Vec<u8>, hyprstream_rpc::stream_info::StreamPolicy)> {
+fn parse_stream_info(json: &Value) -> anyhow::Result<(String, String, Vec<u8>, hyprstream_rpc::stream_info::StreamOpt)> {
     let stream_id = json["streamId"].as_str()
         .ok_or_else(|| anyhow::anyhow!("missing streamId in streaming response"))?.to_owned();
     let endpoint = json["endpoint"].as_str()
@@ -668,12 +668,12 @@ fn parse_stream_info(json: &Value) -> anyhow::Result<(String, String, Vec<u8>, h
         .iter()
         .map(|v| v.as_u64().unwrap_or(0) as u8)
         .collect();
-    let policy: hyprstream_rpc::stream_info::StreamPolicy = if json["policy"].is_object() {
-        serde_json::from_value(json["policy"].clone()).unwrap_or_default()
+    let qos: hyprstream_rpc::stream_info::StreamOpt = if json["qos"].is_object() {
+        serde_json::from_value(json["qos"].clone()).unwrap_or_default()
     } else {
-        hyprstream_rpc::stream_info::StreamPolicy::default()
+        hyprstream_rpc::stream_info::StreamOpt::default()
     };
-    Ok((stream_id, endpoint, server_pubkey, policy))
+    Ok((stream_id, endpoint, server_pubkey, qos))
 }
 
 /// Dispatch a method call to the appropriate generated client.


### PR DESCRIPTION
## Summary
- Renames `StreamPolicy` → `StreamOpt` across capnp schema, Rust types, and all call sites — eliminates confusion with the unrelated `PolicyService`
- Renames capnp field `policy @3 :StreamPolicy` → `qos @3 :StreamOpt` in `StreamInfo`
- Adds typed preset ZSTs `Job`, `Log`, `Pipe` implementing the new `StreamOptPreset` trait, each encoding one named delivery contract
- Renames `StreamContext.with_policy()` → `with_qos()` + adds `with_qos_preset::<Q: StreamOptPreset>()` for type-safe preset selection
- Renames `stream_consumer::StreamPolicy` → `VerifierContract` (consumer-side 2-axis slice)
- Removes unused `policy` field from `MoqStreamPublisher` (never read at runtime)
- Updates proc-macro codegen: `info.policy` → `info.qos`
- Zero behavior change — pure rename + abstraction; all presets encode same axis values as M2c

Part of epic #131 / issue #213.