### PR TITLE
cleanup(#171): drop ZMQ endpoint in fetch_models — use RegistryClient::for_service

### DIFF
--- a/crates/hyprstream/src/cli/shell_handlers.rs
+++ b/crates/hyprstream/src/cli/shell_handlers.rs
@@ -1728,11 +1728,7 @@ async fn fetch_models(
         }
     };
 
-    let registry_endpoint = hyprstream_rpc::registry::global()
-        .endpoint("registry", hyprstream_rpc::registry::SocketKind::Rep)
-        .to_zmq_string();
-    let registry: crate::services::RegistryClient = match crate::services::RegistryClient::for_endpoint(
-        &registry_endpoint,
+    let registry: crate::services::RegistryClient = match crate::services::RegistryClient::for_service(
         signing_key.clone(),
         registry_server_vk,
         None,


### PR DESCRIPTION
## Summary
- `fetch_models()` in `shell_handlers.rs` was the only remaining CLI caller constructing a `RegistryClient` via ZMQ (`for_endpoint` + `to_zmq_string`). All other `RegistryClient` callers already use `for_service`. Switch to the same pattern; the resolved `registry_server_vk` was already in scope.

## Remaining CLI ZMQ callers (out of scope for this PR)
The following still use ZMQ and are blocked on **TuiService moq port** (#134 M2b / #138 scope):
- `tui_handlers::create_tui_client` — `TuiClient::for_endpoint` + ZMQ endpoint
- `tui_handlers::run_attach_loop` — raw `zmq::SUB` socket to XPUB frame stream
- `shell_handlers::handle_shell_tui` — raw `zmq::SUB` for ANSI frame subscription
- `git_handlers` — notification stream `tmq::subscribe` + InferenceZmqAdapter DEALER
- `main.rs` / `training_handlers` — `global_context()` for InferenceServiceConfig callback

TuiService is a 2369-line `ZmqService` impl; its moq port is the critical path to ZMQ dep removal.

Part of epic #131 / issue #171.