### PR TITLE
feat(#134): migrate TuiService frame publishing to AnyStreamPublisher

### DIFF
--- a/crates/hyprstream-rpc/src/moq_stream.rs
+++ b/crates/hyprstream-rpc/src/moq_stream.rs
@@ -426,6 +426,20 @@ impl AnyStreamPublisher {
             Self::Moq(p) => p.is_cancelled(),
         }
     }
+
+    /// Non-blocking publish with HWM back-pressure detection (ZMQ path only).
+    ///
+    /// On the moq path every publish succeeds immediately (no HWM concept) and
+    /// always returns `Ok(true)`. The `rate` hint is ignored on the moq path.
+    pub async fn try_publish_data(&mut self, data: &[u8], rate: f32) -> Result<bool> {
+        match self {
+            Self::Zmq(p) => p.try_publish_data(data, rate).await,
+            Self::Moq(p) => {
+                let _ = rate;
+                p.publish_data(data).await.map(|_| true)
+            }
+        }
+    }
 }
 
 /// Consumer-side helper: split a moq Frame payload back into the ZMQ-style

--- a/crates/hyprstream/src/cli/tui_handlers.rs
+++ b/crates/hyprstream/src/cli/tui_handlers.rs
@@ -21,13 +21,9 @@ use crate::services::generated::tui_client::{TuiClient, ConnectRequest, DisplayM
 
 /// Create a TuiClient for RPC calls.
 ///
-/// Resolves the TUI service endpoint from the registry and creates a client
-/// with the given signing key and local identity. Uses PolicyClient to resolve
-/// the TUI service's verifying key at runtime.
+/// Resolves the TUI service verifying key via PolicyService, then dials the
+/// TUI service via the registry (inproc or QUIC — transport-agnostic).
 pub fn create_tui_client(signing_key: &SigningKey) -> TuiClient {
-    use hyprstream_rpc::registry::{global as registry, SocketKind};
-
-    let endpoint = registry().endpoint("tui", SocketKind::Rep).to_zmq_string();
     let sk = signing_key.clone();
 
     // Bootstrap: PolicyService uses the root key in inproc mode
@@ -59,7 +55,7 @@ pub fn create_tui_client(signing_key: &SigningKey) -> TuiClient {
         }
     };
 
-    match TuiClient::for_endpoint(&endpoint, sk, server_vk, None) {
+    match TuiClient::for_service(sk, server_vk, None) {
         Ok(c) => c,
         Err(e) => panic!("Failed to create TuiClient: {e}"),
     }
@@ -119,6 +115,12 @@ pub async fn handle_tui_attach(signing_key: &SigningKey, session_id: Option<u32>
 /// Uses `StreamVerifier` for Blake3 HMAC chain verification of incoming
 /// StreamBlock messages. The verifier checks that each block's MAC is
 /// valid relative to the previous block, ensuring no reordering or tampering.
+// TODO(#134/moq-sub): On the moq path `run_attach_loop` must subscribe to the
+// viewer's track via WebTransport QUIC rather than a raw ZMQ SUB socket.
+// The ConnectResult currently only carries a ZMQ sub_endpoint.  When moq is
+// the active transport the service should instead return the server's WebTransport
+// URL + broadcast path so the client can open a moq subscriber session here.
+// Until that wire change lands this function stays on the ZMQ path unchanged.
 async fn run_attach_loop(
     stream_info: &crate::services::generated::tui_client::StreamInfo,
     client: &TuiClient,

--- a/crates/hyprstream/src/tui/rpc_transport.rs
+++ b/crates/hyprstream/src/tui/rpc_transport.rs
@@ -263,7 +263,6 @@ pub fn make_chat_spawner(
 pub fn make_tool_caller(
     signing_key: &SigningKey,
 ) -> (hyprstream_tui::chat_app::ToolCaller, HashMap<String, String>, Vec<serde_json::Value>) {
-    use hyprstream_rpc::registry::{global as registry, SocketKind};
     use crate::services::generated::mcp_client::McpClient as GenMcpClient;
     use hyprstream_tui::chat_app::ChatEvent;
 
@@ -275,7 +274,6 @@ pub fn make_tool_caller(
     let sk_fetch = sk.clone();
     let (descriptions, openai_tools): (HashMap<String, String>, Vec<serde_json::Value>) =
         std::thread::spawn(move || {
-            let endpoint = registry().endpoint("mcp", SocketKind::Rep).to_zmq_string();
             let rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
@@ -297,7 +295,7 @@ pub fn make_tool_caller(
                     mcp_key_resp.verifying_key.as_slice().try_into().ok()?
                 ).ok()?;
                 let gen: GenMcpClient =
-                    GenMcpClient::for_endpoint(&endpoint, sk_fetch, mcp_vk, None).ok()?;
+                    GenMcpClient::for_service(sk_fetch, mcp_vk, None).ok()?;
                 let tool_list = gen.list_tools().await.ok()?;
                 let mut descs = HashMap::new();
                 let mut tools = Vec::new();
@@ -330,7 +328,6 @@ pub fn make_tool_caller(
             let uuid_c = uuid.clone();
             std::thread::spawn(move || {
                 let result_str: String = (move || {
-                    let endpoint = registry().endpoint("mcp", SocketKind::Rep).to_zmq_string();
                     let rt = match tokio::runtime::Builder::new_current_thread()
                         .enable_all()
                         .build()
@@ -366,7 +363,7 @@ pub fn make_tool_caller(
                             },
                             Err(e) => return format!("error: failed to resolve MCP key: {e}"),
                         };
-                        let mcp_client = match GenMcpClient::for_endpoint(&endpoint, sk_c, mcp_vk, None) {
+                        let mcp_client = match GenMcpClient::for_service(sk_c, mcp_vk, None) {
                             Ok(c) => c,
                             Err(e) => return format!("error: failed to create McpClient: {e}"),
                         };

--- a/crates/hyprstream/src/tui/service.rs
+++ b/crates/hyprstream/src/tui/service.rs
@@ -17,6 +17,7 @@ use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
+use hyprstream_rpc::moq_stream::{AnyStreamPublisher, global_moq_origin};
 use hyprstream_rpc::prelude::*;
 use hyprstream_rpc::streaming::{
     BatchingConfig, StreamChannel, StreamContext, StreamPublisher, StreamPublisherConfig,
@@ -47,16 +48,18 @@ pub enum DisplayMode {
 
 /// A connected viewer's handle — tracks its publisher and health.
 ///
-/// This is `!Send` because `StreamPublisher` contains a `tmq::push::Push` socket.
-/// Viewer handles live on the frame loop's local task (spawned via `spawn_local`).
+/// On the ZMQ path `AnyStreamPublisher::Zmq` wraps a `tmq::push::Push` socket
+/// (`!Send`); viewer handles therefore live on the frame loop's local task
+/// (spawned via `spawn_local`).  On the moq path the publisher is `Send`, but
+/// `spawn_local` is kept for uniformity.
 struct ViewerHandle {
     /// Viewer ID.
     id: u32,
     /// FD 1 (stdout): dedicated publisher for this viewer's frame stream.
-    publisher: StreamPublisher,
+    publisher: AnyStreamPublisher,
     /// FD 0 (stdin): publisher for relaying viewer input back to the CLI process.
     /// Only populated when a session has a remote process that needs input relay.
-    stdin_publisher: Option<StreamPublisher>,
+    stdin_publisher: Option<AnyStreamPublisher>,
     /// How this viewer wants frames encoded.
     display_mode: DisplayMode,
     /// Consecutive frames that failed to send (HWM full).
@@ -382,7 +385,6 @@ impl TuiService {
         // Build continuation: send viewer registration to frame loop
         let sessions_reg = Arc::clone(&self.sessions);
         let tui_state = Arc::clone(&self.state);
-        let zmq_context = Arc::clone(&self.context);
         let sk = self.signing_key.clone();
         let stdin_queues = Arc::clone(&self.stdin_queues);
         let continuation: Continuation = Box::pin(async move {
@@ -393,9 +395,8 @@ impl TuiService {
                 // Spawn frame loop for this session
                 let s = Arc::clone(&tui_state);
                 let c = cancel.clone();
-                let ctx = Arc::clone(&zmq_context);
                 let sq = Arc::clone(&stdin_queues);
-                tokio::task::spawn_local(run_frame_loop(s, sid, rx, ctx, sk, c, sq));
+                tokio::task::spawn_local(run_frame_loop(s, sid, rx, sk, c, sq));
                 info!(session_id = sid, "Frame loop spawned");
                 (tx, cancel)
             });
@@ -1839,7 +1840,6 @@ pub(crate) async fn run_frame_loop(
     state: Arc<RwLock<TuiState>>,
     session_id: u32,
     mut cmd_rx: CommandReceiver,
-    zmq_context: Arc<zmq::Context>,
     signing_key: SigningKey,
     cancel: CancellationToken,
     stdin_queues: StdinQueues,
@@ -1850,23 +1850,22 @@ pub(crate) async fn run_frame_loop(
         s.subscribe()
     };
 
-    // Viewer list lives here (local, !Send is OK)
+    // Viewer list lives here (local, !Send is OK on ZMQ path)
     let mut viewers: Vec<ViewerHandle> = Vec::new();
     // Hosted processes attached to panes (pane_id → PaneProcess)
     let mut processes: HashMap<u32, super::process::PaneProcess> = HashMap::new();
     // Previous frame snapshot for incremental diffs (per-pane, keyed by pane_id)
     let mut prev_cells: HashMap<u32, Vec<Cell>> = HashMap::new();
     let mut has_damage = false;
-    // Delayed initial frame: after a viewer registers, wait for the ZMQ SUB to connect
-    // before publishing the first frame (avoids "slow joiner" race condition).
+    // Delayed initial frame: after a viewer registers, wait for ZMQ SUB to connect
+    // (slow-joiner race) or for the moq subscriber to appear before the first publish.
     let mut initial_frame_at: Option<tokio::time::Instant> = None;
     // Periodic heartbeat: re-publish a full frame every 2s when viewers are present.
-    // This guarantees late-joining viewers (whose SUB socket connected after the
-    // initial_frame_at fired) receive current state without waiting for new damage.
+    // This guarantees late-joining viewers receive current state without waiting for new damage.
     let mut heartbeat_at = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
 
-    // StreamChannel for creating dedicated publisher sockets
-    let stream_channel = StreamChannel::new(zmq_context, signing_key);
+    // StreamChannel for creating publisher sockets (ZMQ or moq, auto-dispatched).
+    let stream_channel = StreamChannel::new(crate::zmq::global_context(), signing_key);
 
     info!(session_id, "Frame loop started");
 
@@ -1883,8 +1882,7 @@ pub(crate) async fn run_frame_loop(
             Some(cmd) = cmd_rx.recv() => {
                 match cmd {
                     FrameLoopCommand::RegisterViewer(pending) => {
-                        // Pre-authorize stream topics with the StreamService proxy.
-                        // Without this, the proxy rejects subscriptions.
+                        // ZMQ-only: dedicated socket config + batching for frame publishing.
                         let publisher_config = StreamPublisherConfig { sndhwm: 100, dedicated: true };
                         let batching = BatchingConfig {
                             min_batch_size: 1,
@@ -1894,23 +1892,39 @@ pub(crate) async fn run_frame_loop(
                             max_rate: 30.0,
                         };
                         let exp = chrono::Utc::now().timestamp() + 86400; // 24h expiry
+                        let use_zmq = global_moq_origin().is_none();
 
                         // FD 0 (stdin): input relay publisher — only for Capnp-mode viewers
                         // (i.e. the CLI cast player). Ansi-mode viewers don't need it;
                         // their keyboard input falls through to VTE when no producer exists.
-                        let stdin_publisher = if pending.display_mode == DisplayMode::Capnp {
+                        let stdin_publisher: Option<AnyStreamPublisher> = if pending.display_mode == DisplayMode::Capnp {
                             if let Some(stdin_ctx) = pending.stream_ctxs.first() {
                                 let topic = stdin_ctx.topic().to_owned();
-                                if let Err(e) = stream_channel.register_topic(&topic, exp, None).await {
-                                    warn!(viewer_id = pending.id, error = %e, "Failed to register stdin topic");
+                                // ZMQ path: pre-register with StreamService proxy so subscriptions
+                                // aren't rejected. moq Origin handles access control natively.
+                                if use_zmq {
+                                    if let Err(e) = stream_channel.register_topic(&topic, exp, None).await {
+                                        warn!(viewer_id = pending.id, error = %e, "Failed to register stdin topic");
+                                    }
                                 }
-                                match stream_channel.create_publisher_socket(&publisher_config) {
-                                    Ok(socket) => Some(StreamPublisher::with_dedicated_socket(
-                                        socket, stdin_ctx, batching.clone(),
-                                    )),
+                                match stream_channel.publisher(stdin_ctx).await {
+                                    Ok(pub_) => Some(pub_),
                                     Err(e) => {
-                                        warn!(viewer_id = pending.id, error = %e, "Failed to create stdin publisher");
-                                        None
+                                        if use_zmq {
+                                            // ZMQ dedicated socket: fall back to custom batching config
+                                            match stream_channel.create_publisher_socket(&publisher_config) {
+                                                Ok(socket) => Some(AnyStreamPublisher::Zmq(
+                                                    StreamPublisher::with_dedicated_socket(socket, stdin_ctx, batching.clone()),
+                                                )),
+                                                Err(e2) => {
+                                                    warn!(viewer_id = pending.id, error = %e2, "Failed to create stdin publisher");
+                                                    None
+                                                }
+                                            }
+                                        } else {
+                                            warn!(viewer_id = pending.id, error = %e, "Failed to create stdin publisher");
+                                            None
+                                        }
                                     }
                                 }
                             } else {
@@ -1929,10 +1943,13 @@ pub(crate) async fn run_frame_loop(
                             }
                         };
                         let stdout_topic = stdout_ctx.topic().to_owned();
-                        if let Err(e) = stream_channel.register_topic(&stdout_topic, exp, None).await {
-                            warn!(viewer_id = pending.id, error = %e, "Failed to register stdout topic");
-                        } else {
-                            debug!(viewer_id = pending.id, topic = %stdout_topic, "Stream topic registered with proxy");
+                        // ZMQ path only: pre-register topic with StreamService proxy.
+                        if use_zmq {
+                            if let Err(e) = stream_channel.register_topic(&stdout_topic, exp, None).await {
+                                warn!(viewer_id = pending.id, error = %e, "Failed to register stdout topic");
+                            } else {
+                                debug!(viewer_id = pending.id, topic = %stdout_topic, "Stream topic registered with proxy");
+                            }
                         }
 
                         // Register a stdin queue for Capnp-mode viewers so they can
@@ -1942,11 +1959,20 @@ pub(crate) async fn run_frame_loop(
                             queues.entry(pending.id).or_default();
                         }
 
-                        match stream_channel.create_publisher_socket(&publisher_config) {
-                            Ok(socket) => {
-                                let publisher = StreamPublisher::with_dedicated_socket(
+                        // Build stdout publisher: moq path via stream_channel.publisher();
+                        // ZMQ path uses a dedicated socket with custom batching config.
+                        let publisher_result: Result<AnyStreamPublisher, _> = if use_zmq {
+                            stream_channel.create_publisher_socket(&publisher_config).map(|socket| {
+                                AnyStreamPublisher::Zmq(StreamPublisher::with_dedicated_socket(
                                     socket, stdout_ctx, batching,
-                                );
+                                ))
+                            })
+                        } else {
+                            stream_channel.publisher(stdout_ctx).await
+                        };
+
+                        match publisher_result {
+                            Ok(publisher) => {
                                 viewers.push(ViewerHandle {
                                     id: pending.id,
                                     publisher,

--- a/crates/hyprstream/src/tui/service.rs
+++ b/crates/hyprstream/src/tui/service.rs
@@ -849,12 +849,8 @@ impl TuiService {
         ).map_err(|e| anyhow::anyhow!("Invalid model key: {e}"))?;
 
         let models = {
-            let registry_endpoint = hyprstream_rpc::registry::global()
-                .endpoint("registry", hyprstream_rpc::registry::SocketKind::Rep)
-                .to_zmq_string();
             let registry_client: crate::services::RegistryClient =
-                crate::services::RegistryClient::for_endpoint(
-                    &registry_endpoint,
+                crate::services::RegistryClient::for_service(
                     self.signing_key.clone(),
                     registry_vk,
                     None,


### PR DESCRIPTION
## Summary
- Adds `try_publish_data` to `AnyStreamPublisher` in `moq_stream.rs` (moq arm: `Ok(true)`; ZMQ arm: delegates with HWM detection)
- Changes `ViewerHandle.publisher` and `stdin_publisher` from `StreamPublisher` → `AnyStreamPublisher` — frame loop now works on both transports
- Removes `zmq_context` parameter from `run_frame_loop`; uses `crate::zmq::global_context()` internally
- Conditionalizes `register_topic` calls behind `global_moq_origin().is_none()` — moq Origin handles access control natively
- ZMQ path keeps dedicated-socket + custom batching config for frame-rate throttle compatibility; moq path uses `stream_channel.publisher(ctx).await`
- Switches `TuiClient::for_endpoint` → `TuiClient::for_service` in `tui_handlers::create_tui_client`
- Annotates `run_attach_loop` with `TODO(#134/moq-sub)`: cross-process frame subscription requires WebTransport moq subscriber + ConnectResult wire changes (ZMQ SUB path unchanged)
- `tui/service.rs`: `RegistryClient::for_endpoint` → `for_service` in `handle_list_models`
- `tui/rpc_transport.rs`: `GenMcpClient::for_endpoint` → `for_service` for tool-list fetch + tool call invocations; drops manual registry endpoint construction

## Remaining ZMQ in TuiService / CLI
- `run_attach_loop` (ZMQ SUB for frame stream from separate process) — blocked on WebTransport moq subscriber client + ConnectResult carrying WebTransport URL + broadcast path instead of ZMQ sub_endpoint
- `handle_shell_tui` in `shell_handlers.rs` — same cross-process subscribe problem
- `git_handlers` notification SUB + InferenceServiceConfig callback DEALER

Part of epic #131 / issue #134.