### PR TITLE
cleanup(#213): moq/RPC code quality, config wiring, DRY timeouts

### DIFF
--- a/crates/hyprstream-rpc/src/moq_event.rs
+++ b/crates/hyprstream-rpc/src/moq_event.rs
@@ -288,8 +288,15 @@ impl MoqEventSubscriber {
     }
 
     /// Try to receive without blocking.
-    pub async fn try_recv(&mut self) -> Result<Option<(String, Vec<u8>)>> {
-        self.recv_timeout(Duration::from_millis(0)).await
+    pub fn try_recv(&mut self) -> Result<Option<(String, Vec<u8>)>> {
+        let rx = self.ensure_started()?;
+        match rx.try_recv() {
+            Ok(msg) => Ok(Some(msg)),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty) => Ok(None),
+            Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
+                Err(anyhow!("event subscriber closed"))
+            }
+        }
     }
 }
 
@@ -320,14 +327,10 @@ async fn run_subscriber_task(
     }
 
     loop {
-        let (path, broadcast_opt) = match consumer.announced().await {
-            Some(update) => update,
-            None => break, // origin closed
-        };
-
-        let broadcast = match broadcast_opt {
-            Some(b) => b,
-            None => continue, // unannounce
+        let (path, broadcast) = match consumer.announced().await {
+            None => break,               // origin closed
+            Some((_, None)) => continue, // unannounce
+            Some((path, Some(b))) => (path, b),
         };
 
         let tx2 = tx.clone();
@@ -393,9 +396,16 @@ async fn read_event_broadcast(
     };
 
     loop {
-        let mut group = match track.next_group().await {
-            Ok(Some(g)) => g,
-            _ => break,
+        let mut group = match tokio::time::timeout(
+            crate::moq_stream::GROUP_IDLE_TIMEOUT,
+            track.next_group(),
+        ).await {
+            Ok(Ok(Some(g))) => g,
+            Ok(Ok(None)) | Ok(Err(_)) => break,
+            Err(_elapsed) => {
+                tracing::debug!("event subscriber idle timeout — source broadcast may be gone");
+                break;
+            }
         };
 
         let frame = match group.read_frame().await {

--- a/crates/hyprstream-rpc/src/moq_stream.rs
+++ b/crates/hyprstream-rpc/src/moq_stream.rs
@@ -143,6 +143,16 @@ pub fn serve_moq_uds_background(origin: MoqStreamOrigin, path: PathBuf) {
     });
 }
 
+/// Timeout waiting for the moq origin to announce a broadcast at startup.
+pub const BROADCAST_ANNOUNCE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Timeout between consecutive moq Groups on a subscribed track.
+/// A timeout here signals the publisher is gone; the subscriber breaks out.
+pub const GROUP_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Timeout reading a single Frame from an already-opened Group.
+pub const FRAME_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
 /// The single track name that carries StreamBlock groups for a broadcast.
 pub const STREAM_TRACK: &str = "stream";
 
@@ -404,31 +414,16 @@ impl MoqStreamPublisher {
 
 /// Publisher for the moq-lite streaming plane.
 ///
-/// All call sites that receive a publisher via closure (e.g.
-/// `StreamChannel::run_stream`) use this type; the ZMQ PUSH variant was
-/// removed in the N4 hard cutover (#138/#213).
-pub enum AnyStreamPublisher {
-    /// moq-lite in-process path.
-    Moq(MoqStreamPublisher),
-}
+/// Type alias for [`MoqStreamPublisher`]; the ZMQ variant was removed in the
+/// N4 hard cutover (#138/#213). Retained as an alias so existing call sites
+/// compile unchanged.
+pub type AnyStreamPublisher = MoqStreamPublisher;
 
-impl AnyStreamPublisher {
-    /// Publish binary data.
-    pub async fn publish_data(&mut self, data: &[u8]) -> Result<()> {
-        match self {
-            Self::Moq(p) => p.publish_data(data).await,
-        }
-    }
-
-    /// Publish binary data with a rate hint (ignored on the moq path; each
-    /// call maps 1:1 to one moq Group).
+impl MoqStreamPublisher {
+    /// Publish binary data with a rate hint (ignored — each call maps 1:1 to one moq Group).
     pub async fn publish_data_with_rate(&mut self, data: &[u8], rate: f32) -> Result<()> {
-        match self {
-            Self::Moq(p) => {
-                let _ = rate;
-                p.publish_data(data).await
-            }
-        }
+        let _ = rate;
+        self.publish_data(data).await
     }
 
     /// Publish a progress update (`stage:current:total`).
@@ -437,64 +432,16 @@ impl AnyStreamPublisher {
         self.publish_data(data.as_bytes()).await
     }
 
-    /// Publish an error payload (terminal).
-    pub async fn publish_error(&mut self, message: &str) -> Result<()> {
-        match self {
-            Self::Moq(p) => p.publish_error(message).await,
-        }
-    }
-
-    /// Complete the stream with app-specific metadata (consumes self).
-    pub async fn complete(self, metadata: &[u8]) -> Result<()> {
-        match self {
-            Self::Moq(p) => p.complete(metadata).await,
-        }
-    }
-
-    /// Complete the stream without consuming self (for use inside `run_stream`).
-    pub async fn complete_ref(&mut self, metadata: &[u8]) -> Result<()> {
-        match self {
-            Self::Moq(p) => p.complete_ref(metadata).await,
-        }
-    }
-
-    /// Flush — no-op on the moq path (each block is published immediately).
+    /// Flush — no-op (each block is published immediately).
     pub async fn flush(&mut self) -> Result<()> {
-        match self {
-            Self::Moq(_) => Ok(()),
-        }
+        Ok(())
     }
 
-    /// The opaque topic this publisher serves.
-    pub fn topic(&self) -> &str {
-        match self {
-            Self::Moq(p) => p.topic(),
-        }
-    }
-
-    /// Whether a terminal frame (Error/Complete) has been sent.
-    pub fn is_terminated(&self) -> bool {
-        match self {
-            Self::Moq(p) => p.is_terminated(),
-        }
-    }
-
-    /// Whether the stream has been cancelled via the `CancellationToken`.
-    pub fn is_cancelled(&self) -> bool {
-        match self {
-            Self::Moq(p) => p.is_cancelled(),
-        }
-    }
-
-    /// Non-blocking publish — on the moq path every publish succeeds immediately
-    /// (no HWM concept) and always returns `Ok(true)`. The `rate` hint is ignored.
+    /// Non-blocking publish — always succeeds immediately (no HWM concept).
+    /// The `rate` hint is ignored.
     pub async fn try_publish_data(&mut self, data: &[u8], rate: f32) -> Result<bool> {
-        match self {
-            Self::Moq(p) => {
-                let _ = rate;
-                p.publish_data(data).await.map(|_| true)
-            }
-        }
+        let _ = rate;
+        self.publish_data(data).await.map(|_| true)
     }
 }
 
@@ -592,7 +539,7 @@ async fn moq_stream_handle_task(
         Err(e) => { let _ = tx.send(Err(anyhow!("moq handshake: {e}"))).await; return; }
     };
     let bc = match tokio::time::timeout(
-        std::time::Duration::from_secs(10),
+        BROADCAST_ANNOUNCE_TIMEOUT,
         client_consumer.announced_broadcast(&broadcast_path),
     ).await {
         Ok(Some(bc)) => bc,
@@ -614,23 +561,35 @@ async fn moq_stream_handle_task(
         if cancel.is_cancelled() {
             break;
         }
-        let mut group = match tokio::time::timeout(
-            std::time::Duration::from_secs(30),
-            track.next_group(),
-        ).await {
+        let mut group = match tokio::time::timeout(GROUP_IDLE_TIMEOUT, track.next_group()).await {
             Ok(Ok(Some(g))) => g,
-            Ok(Ok(None)) | Err(_) => break, // end of track or timeout
+            Ok(Ok(None)) => break, // track ended cleanly
+            Err(_elapsed) => {
+                let _ = tx.send(Err(anyhow!(
+                    "stream idle: no group for {}s",
+                    GROUP_IDLE_TIMEOUT.as_secs()
+                ))).await;
+                break;
+            }
             Ok(Err(e)) => {
                 let _ = tx.send(Err(anyhow!("moq next_group: {e}"))).await;
                 break;
             }
         };
-        let frame: bytes::Bytes = match tokio::time::timeout(
-            std::time::Duration::from_secs(5),
-            group.read_frame(),
-        ).await {
+        let frame: bytes::Bytes = match tokio::time::timeout(FRAME_READ_TIMEOUT, group.read_frame()).await {
             Ok(Ok(Some(f))) => f,
-            _ => continue,
+            Ok(Ok(None)) => break, // group ended without a frame
+            Ok(Err(e)) => {
+                let _ = tx.send(Err(anyhow!("frame read error: {e}"))).await;
+                break;
+            }
+            Err(_elapsed) => {
+                let _ = tx.send(Err(anyhow!(
+                    "frame read timeout after {}s",
+                    FRAME_READ_TIMEOUT.as_secs()
+                ))).await;
+                break;
+            }
         };
         match verify_moq_frame(&mut verifier, &topic, &frame) {
             Ok(payloads) => {
@@ -737,8 +696,8 @@ mod tests {
         Ok(())
     }
 
-    /// `AnyStreamPublisher::Moq` round-trip: publish via the enum wrapper and
-    /// verify the same bytes arrive on the moq consumer side.
+    /// `AnyStreamPublisher` round-trip: publish via the type alias and verify
+    /// the same bytes arrive on the moq consumer side.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn any_stream_publisher_moq_round_trip() -> Result<()> {
         let origin = origin();
@@ -747,8 +706,7 @@ mod tests {
         let topic = ctx.topic().to_owned();
         let mac_key = *ctx.mac_key();
 
-        // Publish via AnyStreamPublisher::Moq (the primary M2a path)
-        let mut any_pub = AnyStreamPublisher::Moq(origin.publisher(&ctx)?);
+        let mut any_pub: AnyStreamPublisher = origin.publisher(&ctx)?;
         any_pub.publish_data(b"ping").await?;
         any_pub.complete_ref(b"{}").await?;
 

--- a/crates/hyprstream-rpc/src/stream_consumer.rs
+++ b/crates/hyprstream-rpc/src/stream_consumer.rs
@@ -259,16 +259,9 @@ impl StreamVerifier {
     }
 }
 
-/// Constant-time byte slice comparison.
 fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    let mut diff = 0u8;
-    for (x, y) in a.iter().zip(b.iter()) {
-        diff |= x ^ y;
-    }
-    diff == 0
+    use subtle::ConstantTimeEq;
+    a.ct_eq(b).into()
 }
 
 // ============================================================================

--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -542,7 +542,7 @@ impl StreamChannel {
     pub async fn publisher(&self, ctx: &StreamContext) -> Result<crate::moq_stream::AnyStreamPublisher> {
         let origin = crate::moq_stream::global_moq_origin()
             .ok_or_else(|| anyhow::anyhow!("no moq stream origin — server not initialized"))?;
-        Ok(crate::moq_stream::AnyStreamPublisher::Moq(origin.publisher(ctx)?))
+        origin.publisher(ctx)
     }
 
     /// Run a streaming operation with framework-guaranteed terminal frame.

--- a/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
@@ -59,6 +59,7 @@ pub struct IrohRpcProtocolHandler {
     inner: Arc<HandlerInner>,
 }
 
+#[derive(Clone)]
 struct HandlerInner {
     processor: Arc<dyn IrohRequestProcessor>,
     /// Used to produce signed error envelopes when the processor itself
@@ -124,49 +125,27 @@ impl IrohRpcProtocolHandler {
     /// tests that need a short slowloris bound; production uses the default
     /// [`super::rpc_session::REQUEST_READ_TIMEOUT`].
     pub fn with_read_timeout(mut self, read_timeout: std::time::Duration) -> Self {
-        // `inner` is freshly built here (no other Arc clones yet), so this
-        // get_mut always succeeds; fall back to a rebuild if it somehow doesn't.
-        debug_assert!(
-            Arc::strong_count(&self.inner) == 1,
-            "with_read_timeout called on a shared handler; rebuilding inner"
-        );
-        match Arc::get_mut(&mut self.inner) {
-            Some(inner) => inner.read_timeout = read_timeout,
-            None => {
-                let i = &self.inner;
-                self.inner = Arc::new(HandlerInner {
-                    processor: Arc::clone(&i.processor),
-                    signing_key: i.signing_key.clone(),
-                    stream_limit: Arc::clone(&i.stream_limit),
-                    stream_limit_capacity: i.stream_limit_capacity,
-                    connection_limit: Arc::clone(&i.connection_limit),
-                    read_timeout,
-                    shutdown: i.shutdown.clone(),
-                });
-            }
-        }
+        self.mutate_inner(|i| i.read_timeout = read_timeout);
         self
     }
 
     /// Override the concurrent-connection cap (builder style, mirrors
     /// [`super::quinn_transport::QuinnRpcServer::with_connection_limit`]).
     pub fn with_connection_limit(mut self, connection_limit: usize) -> Self {
+        self.mutate_inner(|i| i.connection_limit = Arc::new(Semaphore::new(connection_limit)));
+        self
+    }
+
+    /// Mutate the inner config, cloning `Arc<HandlerInner>` only if it is shared.
+    fn mutate_inner(&mut self, f: impl FnOnce(&mut HandlerInner)) {
         match Arc::get_mut(&mut self.inner) {
-            Some(inner) => inner.connection_limit = Arc::new(Semaphore::new(connection_limit)),
+            Some(inner) => f(inner),
             None => {
-                let i = &self.inner;
-                self.inner = Arc::new(HandlerInner {
-                    processor: Arc::clone(&i.processor),
-                    signing_key: i.signing_key.clone(),
-                    stream_limit: Arc::clone(&i.stream_limit),
-                    stream_limit_capacity: i.stream_limit_capacity,
-                    connection_limit: Arc::new(Semaphore::new(connection_limit)),
-                    read_timeout: i.read_timeout,
-                    shutdown: i.shutdown.clone(),
-                });
+                let mut cloned = (*self.inner).clone();
+                f(&mut cloned);
+                self.inner = Arc::new(cloned);
             }
         }
-        self
     }
 
     /// Apply all tunables from an [`super::rpc_session::RpcConfig`] in one call (#197).
@@ -275,6 +254,35 @@ struct BridgeMessage {
     respond: tokio::sync::oneshot::Sender<Result<Bytes>>,
 }
 
+/// Shared dispatch loop body: relay `BridgeMessage`s from `rx` to `service`,
+/// each in its own `spawn_local` task so a slow handler never head-of-lines
+/// the queue.
+async fn run_bridge_dispatch_loop<S>(
+    service: std::rc::Rc<S>,
+    mut rx: tokio::sync::mpsc::Receiver<BridgeMessage>,
+    nonce_cache: Arc<crate::envelope::InMemoryNonceCache>,
+) where
+    S: crate::service::RequestService + 'static,
+{
+    while let Some(msg) = rx.recv().await {
+        let service = std::rc::Rc::clone(&service);
+        let nonce_cache = Arc::clone(&nonce_cache);
+        tokio::task::spawn_local(async move {
+            let signing_key = service.signing_key();
+            let result = crate::service::dispatch::process_request(
+                msg.request.as_ref(),
+                &*service,
+                crate::envelope::EnvelopeVerification::AnySigner,
+                &signing_key,
+                &nonce_cache,
+            )
+            .await
+            .map(Bytes::from);
+            let _ = msg.respond.send(result);
+        });
+    }
+}
+
 /// Adapt a [`crate::service::RequestService`] to [`IrohRequestProcessor`].
 ///
 /// Spins up a dedicated thread running a single-threaded tokio runtime with
@@ -312,7 +320,7 @@ impl LocalServiceBridge {
         S: crate::service::RequestService + Send + 'static,
     {
         let cap = if queue_depth == 0 { 128 } else { queue_depth };
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<BridgeMessage>(cap);
+        let (tx, rx) = tokio::sync::mpsc::channel::<BridgeMessage>(cap);
         let service_name = service.name().to_owned();
 
         std::thread::Builder::new()
@@ -329,38 +337,11 @@ impl LocalServiceBridge {
                     }
                 };
                 let local = tokio::task::LocalSet::new();
-                local.spawn_local(async move {
-                    let service = std::rc::Rc::new(service);
-                    while let Some(msg) = rx.recv().await {
-                        let service = std::rc::Rc::clone(&service);
-                        let nonce_cache = Arc::clone(&nonce_cache);
-                        // Each request gets its own local task so a slow
-                        // handler doesn't head-of-line the queue.
-                        tokio::task::spawn_local(async move {
-                            // Re-derive the signing key per call: cheap clone,
-                            // tracks any future rotation in the service.
-                            let signing_key = service.signing_key();
-                            // As of #186 process_request spawns any streaming
-                            // pump itself (onto this bridge's LocalSet, where
-                            // this task already runs, bounded by a per-service
-                            // admission permit) and returns only the reply bytes,
-                            // so the generic plane is uniform "bytes in → bytes
-                            // out" like every other front-end. (Previously the
-                            // bridge spawned the continuation here; that worked
-                            // but duplicated the spawn logic per transport.)
-                            let result = crate::service::dispatch::process_request(
-                                msg.request.as_ref(),
-                                &*service,
-                                crate::envelope::EnvelopeVerification::AnySigner,
-                                &signing_key,
-                                &nonce_cache,
-                            )
-                            .await
-                            .map(Bytes::from);
-                            let _ = msg.respond.send(result);
-                        });
-                    }
-                });
+                local.spawn_local(run_bridge_dispatch_loop(
+                    std::rc::Rc::new(service),
+                    rx,
+                    nonce_cache,
+                ));
                 rt.block_on(local);
             })
             .map_err(|e| anyhow::anyhow!("spawn iroh-rpc bridge thread: {e}"))?;
@@ -391,7 +372,7 @@ impl LocalServiceBridge {
         S: crate::service::RequestService + 'static,
     {
         let cap = if queue_depth == 0 { 128 } else { queue_depth };
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<BridgeMessage>(cap);
+        let (tx, rx) = tokio::sync::mpsc::channel::<BridgeMessage>(cap);
         let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<Result<()>>();
         let thread_name = thread_name.into();
 
@@ -420,25 +401,7 @@ impl LocalServiceBridge {
                         // Caller gave up waiting; no point serving.
                         return;
                     }
-                    while let Some(msg) = rx.recv().await {
-                        let service = std::rc::Rc::clone(&service);
-                        let nonce_cache = Arc::clone(&nonce_cache);
-                        tokio::task::spawn_local(async move {
-                            let signing_key = service.signing_key();
-                            // process_request spawns any streaming pump itself
-                            // (#186); the bridge just relays the reply bytes.
-                            let result = crate::service::dispatch::process_request(
-                                msg.request.as_ref(),
-                                &*service,
-                                crate::envelope::EnvelopeVerification::AnySigner,
-                                &signing_key,
-                                &nonce_cache,
-                            )
-                            .await
-                            .map(Bytes::from);
-                            let _ = msg.respond.send(result);
-                        });
-                    }
+                    run_bridge_dispatch_loop(service, rx, nonce_cache).await;
                 });
                 rt.block_on(local);
             })

--- a/crates/hyprstream-rpc/src/transport/rpc_session.rs
+++ b/crates/hyprstream-rpc/src/transport/rpc_session.rs
@@ -69,13 +69,17 @@ pub const STOPPED_GRACE: Duration = Duration::from_secs(5);
 /// also defeats a trickle attacker who dribbles one byte per idle window.
 pub const REQUEST_READ_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Default per-call timeout when the caller passes `None` on the client side.
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+/// Default per-call timeout on the client side when the caller passes `None`.
+/// Distinct from [`REQUEST_READ_TIMEOUT`] (server-side per-request read budget).
+const DEFAULT_CLIENT_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Upper bound on how long graceful shutdown waits for in-flight streams to
 /// drain before forcing teardown. With [`REQUEST_READ_TIMEOUT`] bounding each
 /// read, well-behaved drains finish quickly; this is a backstop so a wedged
 /// processor or transport can't hang shutdown forever (#159).
+///
+/// Must exceed [`REQUEST_READ_TIMEOUT`] (30 s) so in-flight requests can finish
+/// before the connection tears down. The 10 s margin is intentional.
 pub const DRAIN_TIMEOUT: Duration = Duration::from_secs(40);
 
 /// Default cap on concurrent accepted connections per server (#162). Bounds
@@ -409,7 +413,7 @@ impl<S: Session> Transport for SessionRpcTransport<S> {
     async fn send(&self, payload: Vec<u8>, timeout_ms: Option<i32>) -> Result<Vec<u8>> {
         let timeout = timeout_ms
             .map(|ms| Duration::from_millis(ms.max(0) as u64))
-            .unwrap_or(DEFAULT_TIMEOUT);
+            .unwrap_or(DEFAULT_CLIENT_TIMEOUT);
         let session = self.session.clone();
         let fut = async move {
             let (mut send, mut recv) = session

--- a/crates/hyprstream-workers/src/events/subscriber.rs
+++ b/crates/hyprstream-workers/src/events/subscriber.rs
@@ -76,8 +76,8 @@ impl EventSubscriber {
     }
 
     /// Try to receive without blocking.
-    pub async fn try_recv(&mut self) -> Result<Option<(String, Vec<u8>)>> {
-        self.inner.try_recv().await
+    pub fn try_recv(&mut self) -> Result<Option<(String, Vec<u8>)>> {
+        self.inner.try_recv()
     }
 }
 

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -93,6 +93,14 @@ pub struct HyprConfig {
     #[serde(default)]
     pub streaming: StreamingConfig,
 
+    /// RPC transport server tunables (stream cap, connection cap, timeouts).
+    ///
+    /// All values default to the process-wide constants in `hyprstream-rpc`
+    /// (`DEFAULT_STREAM_LIMIT=64`, `DEFAULT_CONNECTION_LIMIT=256`, etc.).
+    /// Override via `[rpc]` in the config file or `HYPRSTREAM__RPC__*` env vars.
+    #[serde(default)]
+    pub rpc: RpcServerConfig,
+
     /// TLS configuration for HTTP services (OAI, OAuth, MCP)
     ///
     /// Enabled by default. Auto-generates self-signed cert when paths are unset.
@@ -1160,23 +1168,79 @@ fn default_jwt_key_drain_days() -> u32 { 30 }
 
 /// StreamService configuration
 ///
-/// Controls the PULL/XPUB streaming proxy behavior including buffer sizes,
-/// message TTL, retransmission settings, and StreamBlock batching.
+/// RPC transport server tunables. Mirrors `hyprstream_rpc::transport::rpc_session::RpcConfig`
+/// so operators can tune these via the config file or `HYPRSTREAM__RPC__*` env vars.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RpcServerConfig {
+    /// Max concurrent in-flight bidi streams (server-wide semaphore).
+    #[serde(default = "default_rpc_stream_limit")]
+    pub stream_limit: usize,
+    /// Max concurrent accepted connections per server.
+    #[serde(default = "default_rpc_connection_limit")]
+    pub connection_limit: usize,
+    /// Max wall-clock seconds to read a single request frame.
+    #[serde(default = "default_rpc_request_read_timeout_secs")]
+    pub request_read_timeout_secs: u64,
+    /// Max seconds for a peer's QUIC/WebTransport handshake to complete.
+    #[serde(default = "default_rpc_handshake_timeout_secs")]
+    pub handshake_timeout_secs: u64,
+    /// Grace period (seconds) after writing a response for the peer to ack FIN.
+    #[serde(default = "default_rpc_stopped_grace_secs")]
+    pub stopped_grace_secs: u64,
+    /// Max seconds for graceful drain on shutdown.
+    #[serde(default = "default_rpc_drain_timeout_secs")]
+    pub drain_timeout_secs: u64,
+}
+
+impl Default for RpcServerConfig {
+    fn default() -> Self {
+        use hyprstream_rpc::transport::rpc_session as rpc;
+        Self {
+            stream_limit: rpc::DEFAULT_STREAM_LIMIT,
+            connection_limit: rpc::DEFAULT_CONNECTION_LIMIT,
+            request_read_timeout_secs: rpc::REQUEST_READ_TIMEOUT.as_secs(),
+            handshake_timeout_secs: rpc::HANDSHAKE_TIMEOUT.as_secs(),
+            stopped_grace_secs: rpc::STOPPED_GRACE.as_secs(),
+            drain_timeout_secs: rpc::DRAIN_TIMEOUT.as_secs(),
+        }
+    }
+}
+
+fn default_rpc_stream_limit() -> usize { hyprstream_rpc::transport::rpc_session::DEFAULT_STREAM_LIMIT }
+fn default_rpc_connection_limit() -> usize { hyprstream_rpc::transport::rpc_session::DEFAULT_CONNECTION_LIMIT }
+fn default_rpc_request_read_timeout_secs() -> u64 { hyprstream_rpc::transport::rpc_session::REQUEST_READ_TIMEOUT.as_secs() }
+fn default_rpc_handshake_timeout_secs() -> u64 { hyprstream_rpc::transport::rpc_session::HANDSHAKE_TIMEOUT.as_secs() }
+fn default_rpc_stopped_grace_secs() -> u64 { hyprstream_rpc::transport::rpc_session::STOPPED_GRACE.as_secs() }
+fn default_rpc_drain_timeout_secs() -> u64 { hyprstream_rpc::transport::rpc_session::DRAIN_TIMEOUT.as_secs() }
+
+impl RpcServerConfig {
+    /// Convert to the `hyprstream_rpc` wire type consumed by server builders.
+    pub fn to_rpc_config(&self) -> hyprstream_rpc::transport::rpc_session::RpcConfig {
+        use std::time::Duration;
+        hyprstream_rpc::transport::rpc_session::RpcConfig {
+            stream_limit: self.stream_limit,
+            connection_limit: self.connection_limit,
+            request_read_timeout: Duration::from_secs(self.request_read_timeout_secs),
+            handshake_timeout: Duration::from_secs(self.handshake_timeout_secs),
+            stopped_grace: Duration::from_secs(self.stopped_grace_secs),
+            drain_timeout: Duration::from_secs(self.drain_timeout_secs),
+        }
+    }
+}
+
+/// moq streaming plane configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StreamingConfig {
-    /// Maximum pending messages per topic (for pre-subscribe queue and retransmit buffer)
-    /// Default: 1000
-    #[serde(default = "default_max_pending_per_topic")]
+    /// Deprecated ZMQ-era field — no longer used. Retained for config compat.
+    #[serde(default = "default_max_pending_per_topic", skip_serializing)]
     pub max_pending_per_topic: usize,
 
-    /// Message TTL in seconds - messages older than this are dropped
-    /// Default: 30
-    #[serde(default = "default_message_ttl_secs")]
+    /// Deprecated ZMQ-era field — no longer used. Retained for config compat.
+    #[serde(default = "default_message_ttl_secs", skip_serializing)]
     pub message_ttl_secs: u64,
 
-    /// Interval between compaction runs in seconds
-    /// Default: 5
-    #[serde(default = "default_compact_interval_secs")]
+    /// Deprecated ZMQ-era field — no longer used. Retained for config compat.
+    #[serde(default = "default_compact_interval_secs", skip_serializing)]
     pub compact_interval_secs: u64,
 
     /// StreamBlock batching configuration (rate control)
@@ -1190,6 +1254,22 @@ pub struct StreamingConfig {
     /// QUIC/WebTransport port. None = no QUIC, Some(0) = ephemeral, Some(N) = explicit.
     #[serde(default)]
     pub quic_port: Option<u16>,
+
+    /// Timeout (seconds) waiting for the moq origin to announce a broadcast.
+    /// Default: 10
+    #[serde(default = "default_broadcast_announce_timeout_secs")]
+    pub broadcast_announce_timeout_secs: u64,
+
+    /// Timeout (seconds) between consecutive moq Groups on a subscribed track.
+    /// A subscriber that sees no new Group for this long treats the publisher as gone.
+    /// Default: 30
+    #[serde(default = "default_group_idle_timeout_secs")]
+    pub group_idle_timeout_secs: u64,
+
+    /// Timeout (seconds) reading a single Frame from an already-opened moq Group.
+    /// Default: 5
+    #[serde(default = "default_frame_read_timeout_secs")]
+    pub frame_read_timeout_secs: u64,
 }
 
 impl Default for StreamingConfig {
@@ -1200,6 +1280,9 @@ impl Default for StreamingConfig {
             compact_interval_secs: default_compact_interval_secs(),
             batching: hyprstream_rpc::streaming::BatchingConfig::default(),
             quic_port: None,
+            broadcast_announce_timeout_secs: default_broadcast_announce_timeout_secs(),
+            group_idle_timeout_secs: default_group_idle_timeout_secs(),
+            frame_read_timeout_secs: default_frame_read_timeout_secs(),
         }
     }
 }
@@ -1207,6 +1290,15 @@ impl Default for StreamingConfig {
 fn default_max_pending_per_topic() -> usize { 1000 }
 fn default_message_ttl_secs() -> u64 { 30 }
 fn default_compact_interval_secs() -> u64 { 5 }
+fn default_broadcast_announce_timeout_secs() -> u64 {
+    hyprstream_rpc::moq_stream::BROADCAST_ANNOUNCE_TIMEOUT.as_secs()
+}
+fn default_group_idle_timeout_secs() -> u64 {
+    hyprstream_rpc::moq_stream::GROUP_IDLE_TIMEOUT.as_secs()
+}
+fn default_frame_read_timeout_secs() -> u64 {
+    hyprstream_rpc::moq_stream::FRAME_READ_TIMEOUT.as_secs()
+}
 
 /// Storage paths and directories configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1678,6 +1770,7 @@ impl HyprConfigBuilder {
             oauth: self.oauth,
             credentials: Default::default(),
             streaming: self.streaming,
+            rpc: Default::default(),
             tls: self.tls,
             quic: self.quic,
             event: self.event,

--- a/crates/hyprstream/src/tui/service.rs
+++ b/crates/hyprstream/src/tui/service.rs
@@ -46,7 +46,7 @@ pub enum DisplayMode {
 
 /// A connected viewer's handle — tracks its publisher and health.
 ///
-/// On the ZMQ path `AnyStreamPublisher::Zmq` wraps a `tmq::push::Push` socket
+/// On the moq path `AnyStreamPublisher` wraps a `MoqStreamPublisher`.
 /// (`!Send`); viewer handles therefore live on the frame loop's local task
 /// (spawned via `spawn_local`).  On the moq path the publisher is `Send`, but
 /// `spawn_local` is kept for uniformity.


### PR DESCRIPTION
## Summary
- Extracts named pub timeout constants (`BROADCAST_ANNOUNCE_TIMEOUT`, `GROUP_IDLE_TIMEOUT`, `FRAME_READ_TIMEOUT`) in `moq_stream.rs`; `moq_event.rs` consumes them instead of duplicating magic numbers.
- Converts `AnyStreamPublisher` single-variant enum → type alias (`= MoqStreamPublisher`); moves `publish_data_with_rate`, `publish_progress`, `flush`, `try_publish_data` directly onto `MoqStreamPublisher`.
- Fixes split match arms in `moq_stream_handle_task` (was swallowing `Ok(Err(e))`); fixes frame-read error propagation.
- Adds idle-timeout guard around `next_group()` in `read_event_broadcast` (uses `GROUP_IDLE_TIMEOUT`).
- Collapses two sequential matches in `run_subscriber_task` into a single three-arm match.
- Converts `MoqEventSubscriber::try_recv` from `async fn` → `fn`; fixes `EventSubscriber::try_recv` wrapper accordingly.
- Replaces hand-rolled `constant_time_eq` with `subtle::ConstantTimeEq` in `stream_consumer.rs`.
- Adds `#[derive(Clone)]` to `HandlerInner`; extracts `mutate_inner` COW helper for builder methods.
- Extracts `run_bridge_dispatch_loop` shared loop from `LocalServiceBridge::spawn` and `spawn_with`; fixes unused `mut` warnings.
- Adds `RpcServerConfig` struct + `to_rpc_config()` to `config/mod.rs`; `HyprConfig` gains `rpc: RpcServerConfig` field.
- Updates `StreamingConfig` docs and marks ZMQ vestigial fields with `skip_serializing`.
- Fixes stale ZMQ comment in `tui/service.rs`.

## Test plan
- [ ] `cargo check -p hyprstream` — clean
- [ ] `cargo clippy --release -p hyprstream-rpc -p hyprstream-workers` — clean (pre-commit hook verified)
- [ ] CI green on moq stack

Part of epic #131 / issue #213.