### PR TITLE
fix: review findings — event bus, UDS race, input validation, qwen3 panic, tests, docs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,9 +47,9 @@ jobs:
     - name: Install cargo-deny
       run: cargo install cargo-deny --locked 2>/dev/null || true
     - name: Check bans
-      # ZMQ deps emit warnings (not errors) until #138 removes them. When #138
-      # lands, flip the warn entries in deny.toml to deny entries.
-      run: cargo deny check bans licenses 2>&1 || true
+      # ZMQ crates are deny-listed in deny.toml (#138 complete). This gate must
+      # be able to fail — do NOT add `|| true`.
+      run: cargo deny check bans licenses
 
   wasm:
     name: WASM (browser client)

--- a/crates/hyprstream-rpc-std/schema/notification.capnp
+++ b/crates/hyprstream-rpc-std/schema/notification.capnp
@@ -79,10 +79,10 @@ struct NotificationResponse {
 
 struct SubscribeResponse {
   subscriptionId @0 :Text;
-  assignedTopic @1 :Text;      # XPUB topic (pre-registered with StreamService)
-  streamEndpoint @2 :Text;     # StreamService XPUB endpoint; empty when moq is active
-  moqUdsPath @3 :Text;         # Path to moq UDS socket; empty when ZMQ is active
-  moqBroadcastPath @4 :Text;   # moq broadcast path for the assigned topic; empty when ZMQ is active
+  assignedTopic @1 :Text;      # moq broadcast track name for the assigned subscription
+  streamEndpoint @2 :Text;     # always empty (ZMQ StreamService removed in #131/#138)
+  moqUdsPath @3 :Text;         # Path to moq UDS socket
+  moqBroadcastPath @4 :Text;   # moq broadcast path for the assigned topic
 }
 
 struct PublishIntentResponse {

--- a/crates/hyprstream-rpc/README.md
+++ b/crates/hyprstream-rpc/README.md
@@ -25,7 +25,7 @@ hyprstream-{rpc-std,discovery,service,workers,vfs,9p}
 hyprstream               (application, factories, OAuth, CLI)
 ```
 
-ZMQ/ZMTP is being removed; all new transport code lives here.
+ZMQ/ZMTP was removed in #131/#138; all transport code lives here.
 
 ## Key types
 
@@ -37,6 +37,9 @@ ZMQ/ZMTP is being removed; all new transport code lives here.
 | `LocalServiceBridge` | Bridge a `RequestService` to an `IrohRequestProcessor` |
 | `SignedEnvelope` | COSE_Sign1 wrapper for authenticated RPC payloads |
 | `RpcClient` | Async bidi-stream RPC client |
+| `RpcConfig` | Server-side concurrency + timeout configuration |
+| `MoqStreamHandle` | Reconnectable moq-lite stream consumer handle |
+| `RpcServerConfig` | QUIC/iroh server bind configuration |
 
 ## Feature flags
 

--- a/crates/hyprstream-rpc/src/moq_event.rs
+++ b/crates/hyprstream-rpc/src/moq_event.rs
@@ -20,7 +20,7 @@
 //! auditable streams. `SecureEventPublisher` / `SecureEventSubscriber` (Phase 7)
 //! layer group-key encryption on top and are unaffected by this transport change.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
@@ -80,7 +80,8 @@ struct EventOriginInner {
     /// Consumer over the same origin tree (for subscribers).
     consumer: OriginConsumer,
     /// Keep `BroadcastProducer`s alive so their broadcasts stay announced.
-    broadcasts: Mutex<Vec<BroadcastProducer>>,
+    /// Keyed by source name so re-registration replaces the stale producer.
+    broadcasts: Mutex<HashMap<String, BroadcastProducer>>,
 }
 
 impl MoqEventOrigin {
@@ -92,7 +93,7 @@ impl MoqEventOrigin {
             inner: Arc::new(EventOriginInner {
                 producer,
                 consumer,
-                broadcasts: Mutex::new(Vec::new()),
+                broadcasts: Mutex::new(HashMap::new()),
             }),
         }
     }
@@ -104,7 +105,7 @@ impl MoqEventOrigin {
             inner: Arc::new(EventOriginInner {
                 producer,
                 consumer,
-                broadcasts: Mutex::new(Vec::new()),
+                broadcasts: Mutex::new(HashMap::new()),
             }),
         }
     }
@@ -123,7 +124,8 @@ impl MoqEventOrigin {
         let track = broadcast.create_track(Track::new(EVENT_TRACK))?;
 
         // Retain the broadcast producer so it stays announced for the publisher's lifetime.
-        self.inner.broadcasts.lock().push(broadcast);
+        // HashMap keyed by source: re-registration replaces the stale producer atomically.
+        self.inner.broadcasts.lock().insert(source.to_owned(), broadcast);
 
         Ok(MoqEventPublisher {
             track,
@@ -317,14 +319,24 @@ async fn run_subscriber_task(
     patterns: Vec<String>,
     tx: mpsc::Sender<(String, Vec<u8>)>,
 ) {
+    use tokio::task::JoinSet;
+
     let patterns = Arc::new(patterns);
 
     // Scope the consumer to the `local/events` subtree, then further narrow by
     // source names extracted from the patterns.
-    let scoped_consumer = scope_consumer_for_patterns(&consumer, &patterns);
-    if let Some(c) = scoped_consumer {
-        consumer = c;
+    match scope_consumer_for_patterns(&consumer, &patterns) {
+        Some(c) => consumer = c,
+        None => {
+            // Origin has no `local/events` tree yet — using the root consumer would
+            // expose all RPC traffic to the event channel. Abort instead.
+            tracing::warn!("event subscriber: origin has no event scope; subscriber task exiting");
+            return;
+        }
     }
+
+    // Track per-broadcast read tasks so they are cancelled when this loop exits.
+    let mut tasks: JoinSet<()> = JoinSet::new();
 
     loop {
         let (path, broadcast) = match consumer.announced().await {
@@ -337,10 +349,11 @@ async fn run_subscriber_task(
         let patterns2 = patterns.clone();
         let path_str = path.as_str().to_owned();
 
-        tokio::spawn(async move {
+        tasks.spawn(async move {
             read_event_broadcast(broadcast, path_str, patterns2, tx2).await;
         });
     }
+    // Dropping `tasks` here cancels all per-broadcast read tasks.
 }
 
 /// Scope the origin consumer to `local/events/{sources}` based on patterns.
@@ -410,7 +423,11 @@ async fn read_event_broadcast(
 
         let frame = match group.read_frame().await {
             Ok(Some(f)) => f,
-            _ => continue,
+            Ok(None) => break,   // group ended without a frame
+            Err(e) => {
+                tracing::warn!(error = %e, "event broadcast: frame read error");
+                break;
+            }
         };
 
         // Decode: [4 bytes topic_len BE][topic][payload]

--- a/crates/hyprstream-rpc/src/moq_stream.rs
+++ b/crates/hyprstream-rpc/src/moq_stream.rs
@@ -97,23 +97,42 @@ pub fn serve_moq_uds_background(origin: MoqStreamOrigin, path: PathBuf) {
     use crate::transport::uds_session::{accept_uds, PLANE_MOQ};
     use moq_net::Server as MoqServer;
 
-    if GLOBAL_MOQ_UDS_PATH.set(path.clone()).is_err() {
-        return; // already started
-    }
-
     // Remove stale socket from a previous run (best-effort).
     let _ = std::fs::remove_file(&path);
 
-    tokio::spawn(async move {
-        let listener = match tokio::net::UnixListener::bind(&path) {
-            Ok(l) => l,
-            Err(e) => {
-                tracing::error!(path = %path.display(), "moq UDS bind failed: {e}");
-                return;
-            }
-        };
-        tracing::info!(path = %path.display(), "moq UDS listener ready");
+    // Bind synchronously so the socket exists before we advertise the path.
+    // Any caller reading global_moq_uds_path() is guaranteed the socket is ready.
+    let listener = match std::os::unix::net::UnixListener::bind(&path) {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::error!(path = %path.display(), "moq UDS bind failed: {e}");
+            return;
+        }
+    };
 
+    // 0o600: owner read/write only; SO_PEERCRED enforces uid match on Linux (see uds_server.rs).
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+    }
+
+    // Convert to async and publish the path only after the socket is bound.
+    let listener = match tokio::net::UnixListener::from_std(listener) {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::error!("moq UDS listener conversion failed: {e}");
+            return;
+        }
+    };
+
+    if GLOBAL_MOQ_UDS_PATH.set(path.clone()).is_err() {
+        return; // already started (concurrent call)
+    }
+
+    tracing::info!(path = %path.display(), "moq UDS listener ready");
+
+    tokio::spawn(async move {
         loop {
             let stream = match listener.accept().await {
                 Ok((s, _)) => s,
@@ -515,6 +534,7 @@ impl futures::Stream for MoqStreamHandle {
     }
 }
 
+// TODO: add reconnect backoff on UDS disconnect (ZMQ auto-reconnect parity)
 async fn moq_stream_handle_task(
     uds_path: String,
     broadcast_path: String,

--- a/crates/hyprstream-rpc/src/stream_consumer.rs
+++ b/crates/hyprstream-rpc/src/stream_consumer.rs
@@ -530,6 +530,27 @@ mod policy_tests {
     }
 
     #[test]
+    fn tampered_mac_is_rejected() {
+        // Exercises the subtle::ConstantTimeEq path in StreamVerifier::verify.
+        let key = [0xAAu8; 32];
+        let topic = "tamper";
+        let mut v = StreamVerifier::with_policy(
+            key,
+            topic.to_owned(),
+            VerifierContract { ordering: StreamOrdering::Ordered, completion: Completion::Open },
+        );
+        let (mut frame, _) = frame(&key, topic, None, 0, false);
+        // Corrupt the MAC part (last element of the frame).
+        let mac = frame.last_mut().unwrap();
+        mac[0] ^= 0xFF; // flip a bit — constant_time_eq must reject this
+        let err = v.verify(&frame).unwrap_err().to_string();
+        assert!(
+            err.contains("MAC") || err.contains("mac") || err.contains("HMAC") || err.contains("invalid"),
+            "tampered MAC should be rejected, got: {err}"
+        );
+    }
+
+    #[test]
     fn ordered_accepts_contiguous_and_rejects_gap() {
         let key = [7u8; 32];
         let topic = "tok";

--- a/crates/hyprstream-rpc/src/transport/uds_server.rs
+++ b/crates/hyprstream-rpc/src/transport/uds_server.rs
@@ -181,6 +181,7 @@ impl UdsRpcServer {
                                     }
                                 }
                             }
+                            // TODO: add getpeereid() check for macOS/FreeBSD via nix crate
                             stream
                         }
                         Err(e) => {

--- a/crates/hyprstream-workers/README.md
+++ b/crates/hyprstream-workers/README.md
@@ -36,6 +36,8 @@ hyprstream               (WorkerService factory, WorkflowService factory)
 | `WorkflowService` | Workflow discovery + trigger + execution orchestration |
 | `PodSandboxConfig` | CRI pod sandbox configuration |
 | `ContainerConfig` | OCI container spec |
+| `EventPublisher` | Async moq-lite event publisher (per-service lifecycle events) |
+| `EventSubscriber` | Async moq-lite event subscriber with dot-prefix filtering |
 
 ## Feature flags
 

--- a/crates/hyprstream/src/auth/policy_manager.rs
+++ b/crates/hyprstream/src/auth/policy_manager.rs
@@ -111,6 +111,12 @@ fn validate_policy_component(component: &str, name: &str) -> Result<(), PolicyEr
         )));
     }
 
+    if component.contains('*') {
+        return Err(PolicyError::ValidationError(format!(
+            "{name} contains wildcard '*' (not allowed in user-supplied policy subjects)"
+        )));
+    }
+
     Ok(())
 }
 

--- a/crates/hyprstream/src/cli/bootstrap_manager.rs
+++ b/crates/hyprstream/src/cli/bootstrap_manager.rs
@@ -337,6 +337,15 @@ impl WizardBackend for BootstrapManager {
     }
 
     fn add_user(&mut self, username: &str, role: &str) {
+        if !VALID_INITIAL_ROLES.contains(&role) {
+            tracing::error!(
+                role,
+                valid = VALID_INITIAL_ROLES.join(", "),
+                "unknown --initial-user-role; aborting bootstrap"
+            );
+            std::process::exit(1);
+        }
+
         // Register identity first — UserStore is authoritative
         self.register_local_identity(username);
 
@@ -458,6 +467,8 @@ impl WizardBackend for BootstrapManager {
             .collect()
     }
 }
+
+pub const VALID_INITIAL_ROLES: &[&str] = &["admin", "operator", "viewer", "trainer"];
 
 /// Predefined role rules (mirrors wizard_handlers.rs).
 fn predefined_role_rules(role: &str) -> Vec<(&'static str, &'static str)> {

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -1215,6 +1215,7 @@ fn default_rpc_drain_timeout_secs() -> u64 { hyprstream_rpc::transport::rpc_sess
 
 impl RpcServerConfig {
     /// Convert to the `hyprstream_rpc` wire type consumed by server builders.
+    // TODO: wire into serve_bridged / QuinnRpcServer init paths (tracking issue #197)
     pub fn to_rpc_config(&self) -> hyprstream_rpc::transport::rpc_session::RpcConfig {
         use std::time::Duration;
         hyprstream_rpc::transport::rpc_session::RpcConfig {
@@ -1257,17 +1258,20 @@ pub struct StreamingConfig {
 
     /// Timeout (seconds) waiting for the moq origin to announce a broadcast.
     /// Default: 10
+    // TODO: wire into moq_stream.rs BROADCAST_ANNOUNCE_TIMEOUT constant (tracking issue #NNN)
     #[serde(default = "default_broadcast_announce_timeout_secs")]
     pub broadcast_announce_timeout_secs: u64,
 
     /// Timeout (seconds) between consecutive moq Groups on a subscribed track.
     /// A subscriber that sees no new Group for this long treats the publisher as gone.
     /// Default: 30
+    // TODO: wire into moq_stream.rs GROUP_IDLE_TIMEOUT constant (tracking issue #NNN)
     #[serde(default = "default_group_idle_timeout_secs")]
     pub group_idle_timeout_secs: u64,
 
     /// Timeout (seconds) reading a single Frame from an already-opened moq Group.
     /// Default: 5
+    // TODO: wire into moq_stream.rs FRAME_READ_TIMEOUT constant (tracking issue #NNN)
     #[serde(default = "default_frame_read_timeout_secs")]
     pub frame_read_timeout_secs: u64,
 }

--- a/crates/hyprstream/src/runtime/architectures/qwen3_5.rs
+++ b/crates/hyprstream/src/runtime/architectures/qwen3_5.rs
@@ -1689,16 +1689,20 @@ impl ModelOperations for Qwen3_5Model {
 
     fn forward_with_cache(&self, input: &Tensor, start_pos: usize) -> Result<Tensor> {
         let hidden = self.forward_inner(Some(input), None, start_pos, None)?;
+        let seq_len = hidden.size()[1];
+        anyhow::ensure!(seq_len > 0, "forward_with_cache: empty token sequence (seq_len=0)");
         // Prefill optimization (#201): only run the expensive LM-head matmul over the
         // last position — the caller always discards all but the last token's logits.
-        let last = hidden.narrow(1, hidden.size()[1] - 1, 1);
+        let last = hidden.narrow(1, seq_len - 1, 1);
         let normed = self.norm.forward(&last)?;
         self.lm_head_apply(&normed)
     }
 
     fn forward_from_embeddings(&self, embeddings: &Tensor, start_pos: usize) -> Result<Tensor> {
         let hidden = self.forward_inner(None, Some(embeddings), start_pos, None)?;
-        let last = hidden.narrow(1, hidden.size()[1] - 1, 1);
+        let seq_len = hidden.size()[1];
+        anyhow::ensure!(seq_len > 0, "forward_from_embeddings: empty embedding sequence (seq_len=0)");
+        let last = hidden.narrow(1, seq_len - 1, 1);
         let normed = self.norm.forward(&last)?;
         self.lm_head_apply(&normed)
     }
@@ -1710,7 +1714,9 @@ impl ModelOperations for Qwen3_5Model {
         delta: Option<&crate::training::TenantDelta>,
     ) -> Result<Tensor> {
         let hidden = self.forward_inner(Some(input), None, start_pos, delta)?;
-        let last = hidden.narrow(1, hidden.size()[1] - 1, 1);
+        let seq_len = hidden.size()[1];
+        anyhow::ensure!(seq_len > 0, "forward_with_cache_and_delta: empty token sequence (seq_len=0)");
+        let last = hidden.narrow(1, seq_len - 1, 1);
         let normed = self.norm.forward(&last)?;
         self.lm_head_apply(&normed)
     }

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -762,12 +762,12 @@ fn create_flight_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
             let registry_vk = hyprstream_service::global_trust_store()
                 .resolve_one("registry")
                 .ok_or_else(|| anyhow::anyhow!("trust store has no registry key"))?;
-            let zmq_client: RegistryClient = RegistryClient::for_service(
+            let registry_client: RegistryClient = RegistryClient::for_service(
                 sk.clone(),
                 registry_vk,
                 service_token("flight"),
             )?;
-            Some(Arc::new(zmq_client))
+            Some(Arc::new(registry_client))
         } else {
             None
         };

--- a/crates/hyprstream/src/services/flight.rs
+++ b/crates/hyprstream/src/services/flight.rs
@@ -1,8 +1,8 @@
-//! FlightService - Arrow Flight SQL with ZMQ control channel
+//! FlightService - Arrow Flight SQL with RPC control channel
 //!
 //! Dual-protocol service:
 //! - gRPC server for Flight SQL queries (data plane)
-//! - ZMQ REQ/REP for health, metrics, shutdown (control plane)
+//! - RPC (iroh/UDS) for health, metrics, shutdown (control plane)
 //!
 //! # Architecture
 //!
@@ -11,7 +11,7 @@
 //!                             │
 //!                             └──► DuckDB / Dataset Backend
 //!
-//! Control ──► ZMQ REP Socket ──► FlightService (health, metrics)
+//! Control ──► RPC endpoint ──► FlightService (health, metrics)
 //! ```
 //!
 //! # Usage
@@ -42,11 +42,11 @@ use tracing::{error, info};
 /// Service name for registry and logging
 pub const SERVICE_NAME: &str = "flight";
 
-/// FlightService - Arrow Flight SQL with ZMQ control channel
+/// FlightService - Arrow Flight SQL with RPC control channel
 ///
 /// This service provides:
 /// - gRPC server with Flight SQL protocol for dataset queries
-/// - ZMQ REQ/REP control channel for health checks
+/// - RPC control channel for health checks
 ///
 /// The Flight server uses hyprstream-flight crate for the actual
 /// Flight SQL implementation with DuckDB backend.
@@ -57,7 +57,7 @@ pub struct FlightService {
     /// Optional registry client for dataset lookup
     registry_client: Option<Arc<dyn hyprstream_metrics::RegistryClient>>,
 
-    /// Transport configuration for ZMQ control channel
+    /// Transport configuration for RPC control channel
     control_transport: TransportConfig,
 
     /// Verifying key for envelope verification
@@ -72,7 +72,7 @@ impl FlightService {
     ///
     /// * `config` - Flight configuration (host, port, dataset)
     /// * `registry_client` - Optional registry client for dataset lookup
-    /// * `control_transport` - Transport for ZMQ control channel
+    /// * `control_transport` - Transport for RPC control channel
     /// * `verifying_key` - Key for verifying signed envelopes
     pub fn new(
         config: HyprFlightConfig,

--- a/crates/hyprstream/src/services/mcp_service.rs
+++ b/crates/hyprstream/src/services/mcp_service.rs
@@ -654,8 +654,13 @@ fn parse_stream_info(
     let server_pubkey: Vec<u8> = json["serverPubkey"].as_array()
         .ok_or_else(|| anyhow::anyhow!("missing serverPubkey in streaming response"))?
         .iter()
-        .map(|v| v.as_u64().unwrap_or(0) as u8)
-        .collect();
+        .enumerate()
+        .map(|(i, v)| {
+            v.as_u64()
+                .and_then(|n| u8::try_from(n).ok())
+                .ok_or_else(|| anyhow::anyhow!("serverPubkey[{i}]: value out of u8 range"))
+        })
+        .collect::<anyhow::Result<Vec<u8>>>()?;
     let qos: hyprstream_rpc::stream_info::StreamOpt = if json["qos"].is_object() {
         serde_json::from_value(json["qos"].clone()).unwrap_or_default()
     } else {

--- a/crates/hyprstream/src/services/oai.rs
+++ b/crates/hyprstream/src/services/oai.rs
@@ -1,18 +1,18 @@
-//! OAIService - OpenAI-compatible HTTP API with ZMQ control channel
+//! OAIService - OpenAI-compatible HTTP API with RPC control channel
 //!
 //! Dual-protocol service:
 //! - HTTP server for OpenAI API requests (data plane)
-//! - ZMQ REQ/REP for health, metrics, shutdown (control plane)
+//! - RPC (iroh/UDS) for health, metrics, shutdown (control plane)
 //!
 //! # Architecture
 //!
 //! ```text
 //! HTTP Clients ──► HTTP Server (Axum) ──► OAIService
 //!                        │
-//!                        ├──► ModelZmqClient ──► ModelService
+//!                        ├──► ModelClient ──► ModelService
 //!                        └──► PolicyClient ──► PolicyService
 //!
-//! Control ──► ZMQ REP Socket ──► OAIService (health, metrics)
+//! Control ──► RPC endpoint ──► OAIService (health, metrics)
 //! ```
 //!
 //! # Usage
@@ -45,14 +45,14 @@ use tracing::info;
 /// Service name for registry and logging
 pub const SERVICE_NAME: &str = "oai";
 
-/// OAIService - OpenAI-compatible HTTP API with ZMQ control channel
+/// OAIService - OpenAI-compatible HTTP API with RPC control channel
 ///
 /// This service provides:
 /// - HTTP server with OpenAI-compatible API endpoints
-/// - ZMQ REQ/REP control channel for health checks and metrics
+/// - RPC control channel for health checks and metrics
 ///
-/// The HTTP server handles all inference requests via ModelZmqClient,
-/// which communicates with ModelService over ZMQ.
+/// The HTTP server handles all inference requests via ModelClient,
+/// which communicates with ModelService over the RPC transport.
 pub struct OAIService {
     /// OAI-specific configuration (host, port, TLS)
     config: OAIConfig,
@@ -63,7 +63,7 @@ pub struct OAIService {
     /// Shared server state containing clients and metrics
     server_state: ServerState,
 
-    /// Transport configuration for ZMQ control channel
+    /// Transport configuration for RPC control channel
     control_transport: TransportConfig,
 
     /// Verifying key for envelope verification
@@ -78,8 +78,8 @@ impl OAIService {
     ///
     /// * `config` - OAI configuration (host, port, TLS settings)
     /// * `tls_config` - Global TLS configuration
-    /// * `server_state` - Shared state with ZMQ clients and metrics
-    /// * `control_transport` - Transport for ZMQ control channel
+    /// * `server_state` - Shared state with RPC clients and metrics
+    /// * `control_transport` - Transport for RPC control channel
     /// * `verifying_key` - Key for verifying signed envelopes
     pub fn new(
         config: OAIConfig,

--- a/crates/hyprstream/src/storage/paths.rs
+++ b/crates/hyprstream/src/storage/paths.rs
@@ -24,7 +24,15 @@ impl StoragePaths {
     /// the same host (mirrors the socket-path isolation in hyprstream-rpc/paths.rs).
     pub fn new() -> Result<Self> {
         let prefix = match std::env::var("HYPRSTREAM_INSTANCE") {
-            Ok(inst) if !inst.is_empty() => format!("{APP_NAME}/instances/{inst}"),
+            Ok(inst) if !inst.is_empty() => {
+                if inst.contains('/') || inst.contains("..") {
+                    return Err(anyhow!(
+                        "HYPRSTREAM_INSTANCE must not contain '/' or '..': {:?}",
+                        inst
+                    ));
+                }
+                format!("{APP_NAME}/instances/{inst}")
+            }
             _ => APP_NAME.to_owned(),
         };
         let base_dirs = BaseDirectories::with_prefix(&prefix)

--- a/crates/hyprstream/tests/policy_over_iroh.rs
+++ b/crates/hyprstream/tests/policy_over_iroh.rs
@@ -28,7 +28,8 @@ use hyprstream_core::config::TokenConfig;
 use hyprstream_core::services::PolicyService;
 use hyprstream_core::services::generated::policy_client::{PolicyCheck, PolicyClient};
 
-use hyprstream_rpc::envelope::InMemoryNonceCache;
+use hyprstream_rpc::envelope::{EnvelopeVerifyConfig, InMemoryNonceCache, install_verify_config};
+use hyprstream_rpc::crypto::CryptoPolicy;
 use hyprstream_rpc::rpc_client::RpcClientImpl;
 use hyprstream_rpc::signer::LocalSigner;
 use hyprstream_rpc::transport::TransportConfig;
@@ -134,6 +135,13 @@ async fn client_for(
 /// produced by the bootstrap `SERVICE_BASE_POLICIES`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn policy_check_allow_and_deny_over_iroh() -> Result<()> {
+    // Opt in to Classical so the test is order-independent w.r.t. process-global
+    // verify config; fail-close default is Hybrid which requires PQ keys.
+    let _ = install_verify_config(EnvelopeVerifyConfig {
+        policy: CryptoPolicy::Classical,
+        pq_store: None,
+    });
+
     let (service, server_signing, _temp) = make_policy_service().await?;
     let server_vk = server_signing.verifying_key();
 

--- a/docs/eventservice-architecture.md
+++ b/docs/eventservice-architecture.md
@@ -110,8 +110,8 @@ Async subscriber backed by `MoqEventSubscriber`. Dot-separated prefix filtering.
 **Location:** `crates/hyprstream-workers/src/events/subscriber.rs`
 
 ```rust
-let mut subscriber = EventSubscriber::new(origin.clone());
-subscriber.subscribe("worker.").await?;  // All worker events
+let mut subscriber = EventSubscriber::new()?;
+subscriber.subscribe("worker.")?;  // All worker events
 
 while let Ok((topic, payload)) = subscriber.recv().await {
     println!("Received: {} ({} bytes)", topic, payload.len());


### PR DESCRIPTION
## Summary

Addresses all fixable findings from the post-moq-213 code review (security, correctness, tests, docs). Stacked on top of #271.

- **fix(moq_event):** `broadcasts` Vec → HashMap to prevent stale-sender leak on re-registration; `scope_consumer_for_patterns` None arm now warns + returns instead of silently using unscoped root consumer (data leak); frame read errors no longer swallowed; per-broadcast tasks tracked in `JoinSet` so they're aborted on subscriber exit
- **fix(uds):** bind `UnixListener` synchronously before setting `GLOBAL_MOQ_UDS_PATH` (eliminates connect-before-bind race); socket permissions `0o700` → `0o600`
- **fix(validation):** remove `|| true` from `cargo deny` CI gate so the ZMQ ban can actually fail builds; add `*` wildcard to `validate_policy_component` rejection set; reject `HYPRSTREAM_INSTANCE` values containing `/` or `..`; `serverPubkey` bytes parsed with `u8::try_from()` instead of silent `as u8` truncation; unknown `--initial-user-role` values now error instead of silently granting zero policies
- **fix(qwen3_5):** `anyhow::ensure!(seq_len > 0)` before `hidden.narrow(1, seq_len - 1, 1)` on all three forward variants — was a guaranteed panic on empty input
- **test:** `policy_over_iroh` — add `install_verify_config(Classical)` for process-global order-independence; `stream_consumer` — add `tampered_mac_is_rejected` test exercising the `subtle::ConstantTimeEq` path
- **docs:** fix stale ZMQ references in `oai.rs`, `flight.rs`, `notification.capnp`; update `hyprstream-rpc/README.md` and `hyprstream-workers/README.md` key-types tables; fix wrong `EventSubscriber` API in `eventservice-architecture.md`; add TODO comments for deferred items (StreamingConfig wiring, RpcServerConfig wiring, macOS SO_PEERCRED, reconnect backoff)

## Skipped / deferred

| Finding | Reason |
|---------|--------|
| StreamingConfig moq timeouts not wired | TODO comment added; wiring owns init-path statics — separate ticket |
| RpcServerConfig not wired to production | TODO comment added; separate PR |
| MoqStreamHandle no reconnect | TODO comment added; large feature — ZMQ auto-reconnect parity |
| SO_PEERCRED Linux-only | TODO comment added; `getpeereid` via `nix` is a separate PR |
| WASM PQ_BINDINGS thread-local race | JS single-threaded per Worker; SharedArrayBuffer multi-Worker case needs analysis |
| QUIC cert hash staleness | Depends on library non-WebPKI expiry enforcement; verify before fixing |
| MoqStreamHandle integration test | Requires full UDS server + publisher + consumer — separate ticket |

## Test plan

- [ ] `cargo test -p hyprstream-rpc -- stream_consumer moq_event policy_over_iroh`
- [ ] `cargo test -p hyprstream -- forward_with_cache`
- [ ] `cargo deny check bans licenses` (verify CI gate fires without `|| true`)
- [ ] Clippy passes (enforced by pre-commit hook on each commit)