### PR TITLE
chore(release): 0.5.0 version bump (stack base)

### DIFF
--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyprstream"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 description = "Agentic Infrastructure"
 documentation = "https://docs.rs/hyprstream"


### PR DESCRIPTION
Bumps `crates/hyprstream/Cargo.toml` 0.4.0 → 0.5.0. Base of the 0.5.0 stack (moq-net + iroh epic #131 + follow-ons rebase onto this). 0.4.0 shipped Nix packaging (#285) + ROCm gfx1151 fix (#229). Do not cut the 0.5.0 release until the stack lands.