### PR TITLE
feat(#157): persistent mesh ML-DSA signing key + admin-anchored PQ trust store

### DIFF
--- a/crates/hyprstream-rpc/src/crypto/pq.rs
+++ b/crates/hyprstream-rpc/src/crypto/pq.rs
@@ -49,6 +49,14 @@ pub fn ml_dsa_vk_bytes(key: &MlDsaVerifyingKey) -> Vec<u8> {
     key.to_bytes().to_vec()
 }
 
+/// Derive the raw ML-DSA-65 verifying-key bytes (1952 bytes) from a signing key.
+///
+/// Convenience for callers outside this crate that hold a signing key but do not
+/// depend on the `ml_dsa` crate's `Keypair` trait directly.
+pub fn ml_dsa_sk_to_vk_bytes(key: &MlDsaSigningKey) -> Vec<u8> {
+    ml_dsa_vk_bytes(&key.verifying_key())
+}
+
 pub fn ml_dsa_vk_from_bytes(bytes: &[u8]) -> Result<MlDsaVerifyingKey> {
     let encoded = EncodedVerifyingKey::<MlDsa65>::try_from(bytes)
         .map_err(|_| anyhow::anyhow!("invalid ML-DSA-65 verifying key length (expected 1952 bytes)"))?;

--- a/crates/hyprstream-rpc/src/node_identity.rs
+++ b/crates/hyprstream-rpc/src/node_identity.rs
@@ -42,6 +42,33 @@ pub fn derive_purpose_key(root_key: &SigningKey, purpose: &str) -> SigningKey {
     key
 }
 
+/// HKDF purpose label for the mesh ML-DSA-65 signing key (#157).
+///
+/// Distinct from any Ed25519 / JWT purpose label so the post-quantum mesh key
+/// satisfies the PQUIP key-separation restriction (a derived key is bound to
+/// exactly one cryptographic purpose). The `-v1` suffix allows a future
+/// rotation by bumping the version without changing the root node key.
+pub const MESH_MLDSA_PURPOSE: &str = "hyprstream-mesh-mldsa-v1";
+
+/// Deterministically derive the node's mesh ML-DSA-65 signing key from its
+/// persisted Ed25519 root/signing key (#157).
+///
+/// Uses [`derive_purpose_key`] (HKDF-SHA256 over the Ed25519 seed) with the
+/// dedicated [`MESH_MLDSA_PURPOSE`] label, then re-keys that 32-byte output as
+/// an ML-DSA-65 seed via [`crate::crypto::pq::ml_dsa_sk_from_seed`]. This is
+/// stable across restarts (no new key file) and key-separated from both the
+/// Ed25519 identity and the JWT ML-DSA keyset.
+///
+/// The matching public key (`signing_key.verifying_key()`) is what peers must
+/// anchor in their `KeyedPqTrustStore`, keyed by the Ed25519 signer identity.
+pub fn derive_mesh_mldsa_key(ed25519_key: &SigningKey) -> crate::crypto::pq::MlDsaSigningKey {
+    let derived = derive_purpose_key(ed25519_key, MESH_MLDSA_PURPOSE);
+    let mut seed = derived.to_bytes();
+    let sk = crate::crypto::pq::ml_dsa_sk_from_seed(&seed);
+    seed.zeroize();
+    sk
+}
+
 /// A purpose-derived Ed25519 signing identity.
 /// Inner SigningKey is zeroized on drop via ed25519-dalek's `zeroize` feature.
 struct DerivedIdentity {
@@ -235,6 +262,49 @@ mod tests {
         let provider = NodeIdentityProvider::new(&root);
         let long = "x".repeat(256);
         assert!(provider.identity_open(&long).await.is_err());
+    }
+
+    #[allow(clippy::unwrap_used)]
+    #[test]
+    fn mesh_mldsa_key_is_deterministic() {
+        // #157: deriving the mesh ML-DSA key from the same node Ed25519 key must
+        // be stable across calls (so it survives restarts without a key file).
+        let root = SigningKey::from_bytes(&[3u8; 32]);
+        let sk1 = derive_mesh_mldsa_key(&root);
+        let sk2 = derive_mesh_mldsa_key(&root);
+        assert_eq!(
+            crate::crypto::pq::ml_dsa_sk_to_vk_bytes(&sk1),
+            crate::crypto::pq::ml_dsa_sk_to_vk_bytes(&sk2),
+            "same node seed must derive the same mesh ML-DSA key"
+        );
+    }
+
+    #[allow(clippy::unwrap_used)]
+    #[test]
+    fn mesh_mldsa_key_differs_per_node() {
+        let root_a = SigningKey::generate(&mut rand::rngs::OsRng);
+        let root_b = SigningKey::generate(&mut rand::rngs::OsRng);
+        let vk_a = crate::crypto::pq::ml_dsa_sk_to_vk_bytes(&derive_mesh_mldsa_key(&root_a));
+        let vk_b = crate::crypto::pq::ml_dsa_sk_to_vk_bytes(&derive_mesh_mldsa_key(&root_b));
+        assert_ne!(vk_a, vk_b, "different node seeds must derive different mesh keys");
+    }
+
+    #[allow(clippy::unwrap_used)]
+    #[test]
+    fn mesh_mldsa_key_separated_from_ed25519() {
+        // PQUIP key separation: the derived ML-DSA seed must not equal the
+        // Ed25519 node seed (it goes through a dedicated purpose label).
+        let root = SigningKey::from_bytes(&[9u8; 32]);
+        let mesh_sk = derive_mesh_mldsa_key(&root);
+        let mesh_seed = crate::crypto::pq::ml_dsa_sk_to_seed(&mesh_sk);
+        assert_ne!(
+            mesh_seed,
+            root.to_bytes(),
+            "mesh ML-DSA seed must be key-separated from the Ed25519 node seed"
+        );
+        // And it equals the explicit two-step derivation (purpose key -> seed).
+        let expected_seed = derive_purpose_key(&root, MESH_MLDSA_PURPOSE).to_bytes();
+        assert_eq!(mesh_seed, expected_seed, "derivation must match the purpose-key path");
     }
 
     #[allow(clippy::unwrap_used)]

--- a/crates/hyprstream-rpc/src/service/svc.rs
+++ b/crates/hyprstream-rpc/src/service/svc.rs
@@ -268,13 +268,22 @@ pub trait RequestService: 'static {
     /// `ResponseEnvelope` under the Hybrid policy (EdDSA + ML-DSA-65); when
     /// `None` it signs Classical (EdDSA-only). The matching ML-DSA-65 public key
     /// must be anchored in the client's PQ trust store for Hybrid verification
-    /// to succeed (peer attestation). Default `None` (Classical responses).
+    /// to succeed (peer attestation).
+    ///
+    /// The default derives the node's **persistent** mesh ML-DSA-65 key
+    /// deterministically from this service's Ed25519 [`Self::signing_key`] via
+    /// [`crate::node_identity::derive_mesh_mldsa_key`] (#157). Because the EdDSA
+    /// half of the response is signed with that same Ed25519 key (dispatch is
+    /// handed `service.signing_key()`), the kid-anchored binding the client
+    /// stores — Ed25519 signer pubkey → ML-DSA vk — is self-consistent, and the
+    /// published `#mesh-pq` DID verification method equals this signing key.
     ///
     /// Mirrors the request-side signing policy: the server emits the strongest
     /// composite it has keys for; a Classical verifier still accepts it via the
-    /// inner EdDSA (skip-unknown interop).
+    /// inner EdDSA (skip-unknown interop). Override to return `None` to force
+    /// Classical-only responses.
     fn pq_signing_key(&self) -> Option<crate::crypto::pq::MlDsaSigningKey> {
-        None
+        Some(crate::node_identity::derive_mesh_mldsa_key(&self.signing_key()))
     }
 
     /// Ed25519 verifying key for envelope signature verification.

--- a/crates/hyprstream-rpc/src/signer.rs
+++ b/crates/hyprstream-rpc/src/signer.rs
@@ -35,13 +35,20 @@ impl std::fmt::Debug for LocalSigner {
 }
 
 impl LocalSigner {
+    /// Create a native signer.
+    ///
+    /// The post-quantum half is the node's **persistent** mesh ML-DSA-65 key,
+    /// derived deterministically from `signing_key` via
+    /// [`crate::node_identity::derive_mesh_mldsa_key`] (#157). This replaces the
+    /// previous ephemeral keygen so the signer's ML-DSA public key is stable
+    /// across restarts and equals the `#mesh-pq` key peers anchor in their PQ
+    /// trust store. Use [`Self::with_pq_key`] only to override with an
+    /// externally supplied key (e.g. tests).
     pub fn new(signing_key: SigningKey) -> Self {
+        let pq_signing_key = Some(crate::node_identity::derive_mesh_mldsa_key(&signing_key));
         Self {
             signing_key,
-            pq_signing_key: {
-                let (sk, _) = crate::crypto::pq::ml_dsa_generate_keypair();
-                Some(sk)
-            },
+            pq_signing_key,
         }
     }
 

--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -444,24 +444,27 @@ pub struct StreamChannel {
     signing_key: SigningKey,
     /// ML-DSA-65 signing key for the post-quantum half of the StreamRegister
     /// composite signature. Mirrors `LocalSigner` on the RPC plane so the
-    /// streaming control plane signs under the same policy (#161). Auto-
-    /// generated; the node's persistent ML-DSA identity is wired in via
-    /// [`Self::with_pq_key`] once peer attestation lands (#157).
+    /// streaming control plane signs under the same policy (#161). Derived
+    /// deterministically from the node's persistent Ed25519 signing key (#157)
+    /// in [`Self::new`]; override with [`Self::with_pq_key`].
     pq_signing_key: Option<crate::crypto::pq::MlDsaSigningKey>,
 }
 
 impl StreamChannel {
     /// Create a new stream channel.
     ///
-    /// Auto-generates an ML-DSA-65 key for the post-quantum half of the
-    /// StreamRegister composite, mirroring `LocalSigner::new` on the RPC
-    /// plane. Use [`Self::with_pq_key`] to install the node's persistent
-    /// ML-DSA identity (#157).
+    /// The post-quantum half of the StreamRegister composite is the node's
+    /// **persistent** mesh ML-DSA-65 key, derived deterministically from
+    /// `signing_key` via [`crate::node_identity::derive_mesh_mldsa_key`] (#157),
+    /// mirroring `LocalSigner::new` on the RPC plane. This replaces the previous
+    /// ephemeral keygen so the streaming control plane's ML-DSA public key is
+    /// stable across restarts and equals the `#mesh-pq` key peers anchor. Use
+    /// [`Self::with_pq_key`] only to override with an externally supplied key.
     pub fn new(signing_key: SigningKey) -> Self {
-        let (pq_sk, _) = crate::crypto::pq::ml_dsa_generate_keypair();
+        let pq_signing_key = Some(crate::node_identity::derive_mesh_mldsa_key(&signing_key));
         Self {
             signing_key,
-            pq_signing_key: Some(pq_sk),
+            pq_signing_key,
         }
     }
 

--- a/crates/hyprstream/src/auth/mesh_trust.rs
+++ b/crates/hyprstream/src/auth/mesh_trust.rs
@@ -1,0 +1,186 @@
+//! Admin-anchored mesh post-quantum trust store construction (#157, Option A).
+//!
+//! Builds the process-global kid-anchored [`KeyedPqTrustStore`] eagerly from the
+//! operator-configured `mesh_peers` (see [`crate::config::MeshPeerConfig`]). The
+//! store is admin-anchored and immutable after construction: only ML-DSA-65 keys
+//! an operator configured **out-of-band** are trusted, matching the
+//! `KeyedPqTrustStore` contract ("Entries MUST be established out-of-band").
+//!
+//! Each peer entry carries two inline `Multikey` (`publicKeyMultibase`) strings,
+//! copied from that peer's published DID document:
+//!   - `#mesh`    → Ed25519 mesh signer key (multicodec `ed25519-pub`, `0xed01`)
+//!   - `#mesh-pq` → ML-DSA-65 mesh verifying key (multicodec `ml-dsa-65-pub`, `0x1211`)
+//!
+//! The Ed25519 key is the kid anchor; the ML-DSA-65 key is the trusted PQ key
+//! bound to it. Empty/absent `mesh_peers` yields an empty store — unchanged
+//! behavior (Hybrid fails closed for unknown peers).
+
+use hyprstream_rpc::envelope::KeyedPqTrustStore;
+
+use crate::config::OAuthConfig;
+
+/// Multicodec `ed25519-pub` unsigned-varint prefix (`0xed01` → bytes `0xed 0x01`).
+const MULTICODEC_ED25519_PUB: [u8; 2] = [0xed, 0x01];
+/// Multicodec `ml-dsa-65-pub` unsigned-varint prefix (`0x1211` → bytes `0x91 0x24`).
+const MULTICODEC_ML_DSA_65_PUB: [u8; 2] = [0x91, 0x24];
+
+/// Decode a `Multikey` `publicKeyMultibase` string into the raw key bytes,
+/// verifying the multibase prefix (`z`, base58btc) and the expected multicodec
+/// header. Returns the payload with the multicodec prefix stripped.
+pub fn decode_multikey(multibase: &str, expected_codec: &[u8; 2]) -> anyhow::Result<Vec<u8>> {
+    let body = multibase
+        .strip_prefix('z')
+        .ok_or_else(|| anyhow::anyhow!("Multikey must use base58btc multibase ('z') prefix"))?;
+    let decoded = bs58::decode(body)
+        .into_vec()
+        .map_err(|e| anyhow::anyhow!("invalid base58btc Multikey: {e}"))?;
+    if decoded.len() < 2 || &decoded[..2] != expected_codec {
+        anyhow::bail!(
+            "unexpected multicodec prefix (expected {expected_codec:02x?}, got {:02x?})",
+            decoded.get(..2).unwrap_or(&decoded)
+        );
+    }
+    Ok(decoded[2..].to_vec())
+}
+
+/// Build the kid-anchored ML-DSA-65 trust store from the admin-configured
+/// `mesh_peers` (#157, Option A — eager, admin-anchored, immutable).
+///
+/// An invalid entry is logged and skipped (fail-safe: a malformed peer key must
+/// not silently trust the wrong identity). An empty/absent `mesh_peers` yields
+/// an empty store (non-breaking default).
+pub fn build_mesh_pq_trust_store(oauth: &OAuthConfig) -> KeyedPqTrustStore {
+    let mut store = KeyedPqTrustStore::new();
+    for (label, peer) in &oauth.mesh_peers {
+        let ed_bytes = match decode_multikey(&peer.ed25519_multibase, &MULTICODEC_ED25519_PUB) {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::error!("mesh_peer '{label}': invalid ed25519_multibase, skipping: {e}");
+                continue;
+            }
+        };
+        let ed_pubkey: [u8; 32] = match ed_bytes.as_slice().try_into() {
+            Ok(a) => a,
+            Err(_) => {
+                tracing::error!(
+                    "mesh_peer '{label}': ed25519 key is {} bytes (expected 32), skipping",
+                    ed_bytes.len()
+                );
+                continue;
+            }
+        };
+        let pq_bytes = match decode_multikey(&peer.mldsa65_multibase, &MULTICODEC_ML_DSA_65_PUB) {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::error!("mesh_peer '{label}': invalid mldsa65_multibase, skipping: {e}");
+                continue;
+            }
+        };
+        let pq_vk = match hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(&pq_bytes) {
+            Ok(vk) => vk,
+            Err(e) => {
+                tracing::error!("mesh_peer '{label}': invalid ML-DSA-65 verifying key, skipping: {e}");
+                continue;
+            }
+        };
+        store.bind(ed_pubkey, &pq_vk);
+        tracing::info!("mesh_peer '{label}': anchored ML-DSA-65 key for Ed25519 signer identity");
+    }
+    store
+}
+
+/// Encode raw key bytes as a `Multikey` `publicKeyMultibase` string (base58btc,
+/// multicodec-prefixed). Inverse of [`decode_multikey`]; used by tests and by
+/// operators generating peer entries.
+pub fn encode_multikey(raw: &[u8], codec: &[u8; 2]) -> String {
+    let mut payload = Vec::with_capacity(2 + raw.len());
+    payload.extend_from_slice(codec);
+    payload.extend_from_slice(raw);
+    format!("z{}", bs58::encode(payload).into_string())
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::config::MeshPeerConfig;
+    use ed25519_dalek::SigningKey;
+    use hyprstream_rpc::crypto::pq;
+    use rand::rngs::OsRng;
+
+    fn oauth_with_peers(peers: Vec<(&str, MeshPeerConfig)>) -> OAuthConfig {
+        let mut oauth = OAuthConfig::default();
+        for (k, v) in peers {
+            oauth.mesh_peers.insert(k.to_owned(), v);
+        }
+        oauth
+    }
+
+    #[test]
+    fn empty_mesh_peers_yields_empty_store() {
+        let oauth = OAuthConfig::default();
+        let store = build_mesh_pq_trust_store(&oauth);
+        assert!(store.is_empty(), "absent mesh_peers must produce an empty store");
+    }
+
+    #[test]
+    fn mesh_peer_entry_verifies_peer_signature() {
+        // A peer's mesh identity = an Ed25519 signer key + its derived ML-DSA-65
+        // mesh key. Encode both as Multikey strings (as published in the peer's
+        // DID doc), build the store, and confirm it anchors the peer's ML-DSA key
+        // keyed by the peer's Ed25519 signer identity.
+        let peer_ed = SigningKey::generate(&mut OsRng);
+        let peer_pq_sk = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&peer_ed);
+        let peer_pq_vk_bytes = pq::ml_dsa_sk_to_vk_bytes(&peer_pq_sk);
+
+        let ed_mb = encode_multikey(&peer_ed.verifying_key().to_bytes(), &MULTICODEC_ED25519_PUB);
+        let pq_mb = encode_multikey(&peer_pq_vk_bytes, &MULTICODEC_ML_DSA_65_PUB);
+
+        let oauth = oauth_with_peers(vec![(
+            "peer-a",
+            MeshPeerConfig { ed25519_multibase: ed_mb, mldsa65_multibase: pq_mb },
+        )]);
+        let store = build_mesh_pq_trust_store(&oauth);
+        assert_eq!(store.len(), 1, "one valid peer must produce one binding");
+
+        // The store resolves the peer's Ed25519 signer identity to its ML-DSA vk.
+        use hyprstream_rpc::envelope::PqTrustStore;
+        let resolved = store
+            .ml_dsa_key_for(&peer_ed.verifying_key().to_bytes())
+            .expect("peer's ML-DSA key must be anchored");
+
+        // A signature from the peer's ML-DSA key verifies under the anchored key.
+        let msg = b"mesh peer attestation payload";
+        let sig = pq::ml_dsa_sign(&peer_pq_sk, msg);
+        pq::ml_dsa_verify(&resolved, msg, &sig).expect("peer signature must verify");
+
+        // An unknown signer identity is not anchored.
+        assert!(store.ml_dsa_key_for(&[0u8; 32]).is_none());
+    }
+
+    #[test]
+    fn malformed_peer_entry_is_skipped_not_trusted() {
+        // A bad ed25519 multibase must be skipped (fail-safe), leaving the store
+        // empty rather than trusting a wrong/garbage identity.
+        let good_pq = encode_multikey(&vec![0u8; 1952], &MULTICODEC_ML_DSA_65_PUB);
+        let oauth = oauth_with_peers(vec![(
+            "bad-peer",
+            MeshPeerConfig {
+                ed25519_multibase: "not-multibase".to_owned(),
+                mldsa65_multibase: good_pq,
+            },
+        )]);
+        let store = build_mesh_pq_trust_store(&oauth);
+        assert!(store.is_empty(), "malformed entry must be skipped, not trusted");
+    }
+
+    #[test]
+    fn decode_multikey_rejects_wrong_codec() {
+        // An ed25519 Multikey decoded as ml-dsa must be rejected on the codec.
+        let ed_mb = encode_multikey(&[7u8; 32], &MULTICODEC_ED25519_PUB);
+        assert!(decode_multikey(&ed_mb, &MULTICODEC_ML_DSA_65_PUB).is_err());
+        // Round-trips with the correct codec.
+        let raw = decode_multikey(&ed_mb, &MULTICODEC_ED25519_PUB).unwrap();
+        assert_eq!(raw, [7u8; 32]);
+    }
+}

--- a/crates/hyprstream/src/auth/mod.rs
+++ b/crates/hyprstream/src/auth/mod.rs
@@ -10,6 +10,7 @@ pub mod identity_store;
 pub mod key_rotation;
 pub mod service_jwt;
 pub mod federation;
+pub mod mesh_trust;
 pub mod id_token_verify;
 pub mod jwt;
 mod policy_manager;

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1101,8 +1101,11 @@ fn handle_quick_command(
 
                         // Standalone worker entrypoint serves RPC, so it must
                         // install the verify config too (#160) — otherwise the
-                        // fail-closed default rejects all mesh traffic.
-                        install_envelope_verify_config();
+                        // fail-closed default rejects all mesh traffic. No config
+                        // is in scope here, so the mesh PQ store is empty (#157):
+                        // identical to prior behavior (Hybrid fails closed for
+                        // unknown peers).
+                        install_envelope_verify_config(None);
 
                         let manager = InprocManager::new();
                         Some(
@@ -1320,7 +1323,13 @@ fn resolve_service_vk(service_name: &str) -> Option<VerifyingKey> {
 /// peer ML-DSA bindings are provisioned, may set
 /// `HYPRSTREAM_ENVELOPE_POLICY=classical`. Under Hybrid with no anchored peer
 /// key the verifier fails closed (correct, by design).
-fn install_envelope_verify_config() {
+/// Install the process-global envelope verify configuration.
+///
+/// When `oauth` is `Some`, the kid-anchored PQ trust store is populated eagerly
+/// from `mesh_peers` (#157). When `None` (e.g. the standalone worker entrypoint,
+/// which has no config in scope), the store is empty — identical to the prior
+/// behavior. Either way the store is immutable after install.
+fn install_envelope_verify_config(oauth: Option<&hyprstream_core::config::OAuthConfig>) {
     use hyprstream_rpc::crypto::CryptoPolicy;
     use hyprstream_rpc::envelope::{
         install_verify_config, EnvelopeVerifyConfig, KeyedPqTrustStore, PqTrustStore,
@@ -1335,10 +1344,15 @@ fn install_envelope_verify_config() {
         }
     };
 
-    // Mesh kid-anchored PQ trust store. Peer bindings (Ed25519 signer ->
-    // trusted ML-DSA) are added by the attestation layer; an empty store under
-    // Hybrid fails closed for unknown peers (correct, by design).
-    let pq_store: std::sync::Arc<dyn PqTrustStore> = std::sync::Arc::new(KeyedPqTrustStore::new());
+    // Mesh kid-anchored PQ trust store (#157, Option A): populated eagerly from
+    // admin-configured `mesh_peers`, immutable after install. An empty store
+    // under Hybrid fails closed for unknown peers (correct, by design).
+    let keyed_store = match oauth {
+        Some(oauth) => hyprstream_core::auth::mesh_trust::build_mesh_pq_trust_store(oauth),
+        None => KeyedPqTrustStore::new(),
+    };
+    tracing::info!("mesh PQ trust store installed with {} peer binding(s)", keyed_store.len());
+    let pq_store: std::sync::Arc<dyn PqTrustStore> = std::sync::Arc::new(keyed_store);
 
     if install_verify_config(EnvelopeVerifyConfig {
         policy,
@@ -2000,9 +2014,14 @@ fn main() -> Result<()> {
                                 // (`global_ml_dsa_verifying_keys`, loaded above).
                                 // We therefore DO NOT seed the mesh PqTrustStore
                                 // from the JWT keyset. The mesh store is keyed by
-                                // Ed25519 signer identity and is populated from
-                                // attested peer identities (peer-attestation
-                                // registry — residual integration work).
+                                // Ed25519 signer identity.
+                                //
+                                // #157 (Option A — eager, admin-anchored): the
+                                // store is populated EAGERLY here, before install,
+                                // from the operator-configured `mesh_peers`. It is
+                                // immutable after install (no lazy-at-verify
+                                // resolution). Empty `mesh_peers` => empty store =>
+                                // unchanged behavior.
                                 //
                                 // Policy: Hybrid is enforced by default. Operators
                                 // mid-rollout (before peer ML-DSA bindings are
@@ -2010,7 +2029,7 @@ fn main() -> Result<()> {
                                 // HYPRSTREAM_ENVELOPE_POLICY=classical to keep the
                                 // legacy EdDSA-only verifier. Under Hybrid with no
                                 // anchored key the verifier FAILS CLOSED.
-                                install_envelope_verify_config();
+                                install_envelope_verify_config(Some(&config.oauth));
 
                                 let manager = InprocManager::new();
                                 let mut handles = Vec::new();

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -706,6 +706,35 @@ pub struct TrustedIssuerConfig {
 
 fn default_jwks_cache_ttl() -> u64 { 300 }
 
+/// Configuration for a trusted mesh peer's post-quantum signing identity (#157).
+///
+/// Admin-anchored entry binding a peer's Ed25519 mesh **signer** identity (the
+/// envelope/COSE signer key, used as the kid anchor) to its trusted ML-DSA-65
+/// mesh verifying key. These entries populate the process-global
+/// `KeyedPqTrustStore` eagerly at startup; the store is immutable thereafter.
+///
+/// Both keys are supplied **inline**, out-of-band, as `Multikey`
+/// `publicKeyMultibase` strings (base58btc, multicodec-prefixed) — the same
+/// encoding the node publishes in its DID document (`#mesh` ed25519-pub `0xed01`
+/// and `#mesh-pq` ml-dsa-65-pub `0x1211`). An operator copies a peer's
+/// `#mesh` and `#mesh-pq` `publicKeyMultibase` values from that peer's DID doc.
+///
+/// This matches the `KeyedPqTrustStore` contract ("Entries MUST be established
+/// out-of-band") and the Tiles interop admission model: only keys an operator
+/// configured are trusted. If `mesh_peers` is empty, the store is empty and
+/// behavior is unchanged (Hybrid fails closed for unknown peers).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MeshPeerConfig {
+    /// Peer's Ed25519 mesh signer public key as a `Multikey` `publicKeyMultibase`
+    /// string (base58btc `z…`, multicodec `ed25519-pub` `0xed01`). This is the
+    /// kid anchor the COSE composite is verified against.
+    pub ed25519_multibase: String,
+    /// Peer's ML-DSA-65 mesh verifying key as a `Multikey` `publicKeyMultibase`
+    /// string (base58btc `z…`, multicodec `ml-dsa-65-pub` `0x1211`). The trusted
+    /// post-quantum key bound to `ed25519_multibase`.
+    pub mldsa65_multibase: String,
+}
+
 /// Protocol kind for an external OAuth/OIDC provider.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
@@ -950,6 +979,16 @@ pub struct OAuthConfig {
     #[serde(default)]
     pub trusted_issuers: std::collections::HashMap<String, TrustedIssuerConfig>,
 
+    /// Trusted mesh peers' post-quantum signing identities (#157).
+    /// Key = an operator-chosen peer label (informational only).
+    /// Value = the peer's Ed25519 mesh signer key + ML-DSA-65 mesh verifying
+    /// key, supplied inline as out-of-band `Multikey` strings. Populates the
+    /// process-global `KeyedPqTrustStore` eagerly at startup (admin-anchored,
+    /// immutable). Empty = empty store = unchanged behavior (Hybrid fails
+    /// closed for unknown peers). Distinct from `trusted_issuers`.
+    #[serde(default)]
+    pub mesh_peers: std::collections::HashMap<String, MeshPeerConfig>,
+
     /// OpenID Federation 1.0 Trust Anchor URLs (optional).
     /// When set, included as `authority_hints` in the entity configuration JWT,
     /// making this node discoverable within the named federations.
@@ -1047,6 +1086,7 @@ impl Default for OAuthConfig {
             quic_port: None,
             cors: default_oauth_cors(),
             trusted_issuers: std::collections::HashMap::new(),
+            mesh_peers: std::collections::HashMap::new(),
             authority_hints: Vec::new(),
             oidc_providers: std::collections::HashMap::new(),
             user_signing_key: None,

--- a/crates/hyprstream/src/services/oauth/did_document.rs
+++ b/crates/hyprstream/src/services/oauth/did_document.rs
@@ -172,11 +172,9 @@ fn ed25519_verification_method(did: &str, key_id: &str, vk: &VerifyingKey) -> Va
 /// a did:web subject, emitted as a `Multikey` with the registered
 /// `ml-dsa-65-pub` multicodec (`0x1211`).
 ///
-/// `vk_bytes` is the raw ML-DSA-65 verifying-key (1952 bytes). The DID document
-/// builder does not yet publish a PQ key (that is #157's job — populating
-/// `KeyedPqTrustStore` from the `#mesh` ML-DSA key); this helper exists so #157
-/// can emit the VM with the settled multicodec encoding (e.g. as `#mesh-pq`).
-#[allow(dead_code)]
+/// `vk_bytes` is the raw ML-DSA-65 verifying-key (1952 bytes). The root DID
+/// document publishes the node's mesh ML-DSA-65 key as `#mesh-pq` (#157) so
+/// peers can anchor it in their `KeyedPqTrustStore`.
 fn mldsa65_verification_method(did: &str, key_id: &str, vk_bytes: &[u8]) -> Value {
     json!({
         "id": format!("{did}#{key_id}"),
@@ -217,10 +215,11 @@ fn build_did_document(
     keys: &[(String, VerifyingKey)],
     atproto: Option<&AtprotoIdentity<'_>>,
     transports: &[TransportEndpoint],
+    mesh_pq_vk: Option<&[u8]>,
 ) -> Value {
-    let mut verification_methods = Vec::with_capacity(keys.len() * 2 + 1);
-    let mut authentication_refs = Vec::with_capacity(keys.len() * 2 + 1);
-    let mut assertion_refs = Vec::with_capacity(keys.len() * 2 + 1);
+    let mut verification_methods = Vec::with_capacity(keys.len() * 2 + 2);
+    let mut authentication_refs = Vec::with_capacity(keys.len() * 2 + 2);
+    let mut assertion_refs = Vec::with_capacity(keys.len() * 2 + 2);
 
     // atproto signing key FIRST (atproto takes the first matching entry).
     if let Some(at) = atproto {
@@ -240,6 +239,16 @@ fn build_did_document(
         authentication_refs.push(Value::String(vm_id_jwk.clone()));
         assertion_refs.push(Value::String(vm_id));
         assertion_refs.push(Value::String(vm_id_jwk));
+    }
+
+    // Mesh post-quantum verification method (#157): the node's ML-DSA-65 mesh
+    // key, published as `#mesh-pq` so peers can anchor it in their PQ trust
+    // store. Additive and ignored by atproto resolvers (matched by id/type).
+    if let Some(vk_bytes) = mesh_pq_vk {
+        verification_methods.push(mldsa65_verification_method(did, "mesh-pq", vk_bytes));
+        let vm_id = format!("{did}#mesh-pq");
+        authentication_refs.push(Value::String(vm_id.clone()));
+        assertion_refs.push(Value::String(vm_id));
     }
 
     // Services: atproto PDS first, then the legacy HyprstreamService, then any
@@ -360,6 +369,7 @@ pub async fn root_did_document(
         &[("key-1".to_owned(), vk)],
         atproto.as_ref(),
         &transports,
+        state.mesh_pq_verifying_key.as_deref(),
     );
     (
         StatusCode::OK,
@@ -412,7 +422,7 @@ pub async fn user_did_document(
         None => Vec::new(),
     };
 
-    let doc = build_did_document(&did, &state.issuer_url, &keys, None, &[]);
+    let doc = build_did_document(&did, &state.issuer_url, &keys, None, &[], None);
     (
         StatusCode::OK,
         [(header::CONTENT_TYPE, "application/did+json")],
@@ -451,7 +461,7 @@ pub async fn client_did_document(
     // lookup + extract_ed25519_keys_from_jwks call.
     let keys: Vec<(String, VerifyingKey)> = Vec::new();
 
-    let doc = build_did_document(&did, &state.issuer_url, &keys, None, &[]);
+    let doc = build_did_document(&did, &state.issuer_url, &keys, None, &[], None);
     (
         StatusCode::OK,
         [(header::CONTENT_TYPE, "application/did+json")],
@@ -553,6 +563,7 @@ mod tests {
             &[("key-1".to_owned(), sk.verifying_key())],
             None,
             &[],
+            None,
         );
         assert_eq!(doc["id"].as_str().unwrap(), did);
         assert!(doc["@context"].is_array());
@@ -573,7 +584,7 @@ mod tests {
     #[test]
     fn build_did_doc_empty_keys_is_valid() {
         let did = "did:web:example.com:users:alice";
-        let doc = build_did_document(did, "https://example.com", &[], None, &[]);
+        let doc = build_did_document(did, "https://example.com", &[], None, &[], None);
         assert_eq!(doc["id"].as_str().unwrap(), did);
         assert_eq!(doc["verificationMethod"].as_array().unwrap().len(), 0);
         assert_eq!(doc["authentication"].as_array().unwrap().len(), 0);
@@ -612,6 +623,7 @@ mod tests {
             &[("key-1".to_owned(), ed.verifying_key())],
             Some(&atproto),
             &transports,
+            None,
         );
 
         // #atproto Multikey is FIRST and p256.
@@ -689,6 +701,63 @@ mod tests {
         // Remaining bytes are the verifying-key payload, unmodified.
         assert_eq!(&decoded[2..], vk_bytes.as_slice());
         assert_eq!(decoded.len(), 2 + 1952);
+    }
+
+    #[test]
+    fn build_did_doc_publishes_mesh_pq_vm() {
+        // #157: when a mesh ML-DSA-65 vk is provided, build_did_document emits a
+        // `#mesh-pq` Multikey VM with the ml-dsa-65-pub multicodec, listed after
+        // the Ed25519 VMs, and referenced in authentication/assertionMethod.
+        let sk = SigningKey::generate(&mut OsRng);
+        let did = "did:web:hyprstream.example.com";
+        let vk_bytes = vec![0x42u8; 1952];
+        let doc = build_did_document(
+            did,
+            "https://hyprstream.example.com",
+            &[("key-1".to_owned(), sk.verifying_key())],
+            None,
+            &[],
+            Some(&vk_bytes),
+        );
+        let vms = doc["verificationMethod"].as_array().unwrap();
+        // key-1 multibase + key-1 jwk + mesh-pq = 3.
+        assert_eq!(vms.len(), 3);
+        let pq = vms.iter().find(|v| v["id"] == format!("{did}#mesh-pq")).unwrap();
+        assert_eq!(pq["type"].as_str().unwrap(), "Multikey");
+        let mb = pq["publicKeyMultibase"].as_str().unwrap();
+        let decoded = bs58::decode(&mb[1..]).into_vec().unwrap();
+        assert_eq!(&decoded[..2], &[0x91, 0x24]); // ml-dsa-65-pub multicodec
+        assert_eq!(&decoded[2..], vk_bytes.as_slice());
+        // Referenced as both an authentication and assertion method.
+        let mesh_pq_id = format!("{did}#mesh-pq");
+        assert!(doc["authentication"].as_array().unwrap().iter().any(|v| *v == mesh_pq_id));
+        assert!(doc["assertionMethod"].as_array().unwrap().iter().any(|v| *v == mesh_pq_id));
+    }
+
+    #[test]
+    fn mesh_pq_vm_matches_derived_signing_key() {
+        // #157 scope #1/#2 consistency: the `#mesh-pq` VM published from the
+        // OAuth signing key must equal the ML-DSA-65 verifying key the mesh
+        // actually signs with (derive_mesh_mldsa_key over the same Ed25519 key).
+        let sk = SigningKey::generate(&mut OsRng);
+        let pq_sk = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&sk);
+        let pq_vk_bytes = hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(&pq_sk);
+
+        let did = "did:web:hyprstream.example.com";
+        let doc = build_did_document(
+            did,
+            "https://hyprstream.example.com",
+            &[("key-1".to_owned(), sk.verifying_key())],
+            None,
+            &[],
+            Some(&pq_vk_bytes),
+        );
+        let vms = doc["verificationMethod"].as_array().unwrap();
+        let pq = vms.iter().find(|v| v["id"] == format!("{did}#mesh-pq")).unwrap();
+        let mb = pq["publicKeyMultibase"].as_str().unwrap();
+        let decoded = bs58::decode(&mb[1..]).into_vec().unwrap();
+        assert_eq!(&decoded[2..], pq_vk_bytes.as_slice(),
+            "published #mesh-pq key must equal the derived mesh signing key's public key");
     }
 
     #[test]

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -378,6 +378,13 @@ pub struct OAuthState {
     /// Public QUIC URI (`https://host:port`) for the DID-doc service entry (#185).
     /// None until the QUIC server is started and the cert hash is known.
     pub quic_public_uri: Option<String>,
+    /// Raw ML-DSA-65 verifying-key bytes (1952 bytes) for the node's mesh
+    /// post-quantum signing key (#157). Published as the `#mesh-pq` Multikey
+    /// verification method in the root DID document. Derived from the same
+    /// Ed25519 key as [`Self::signing_key`] (via `derive_mesh_mldsa_key`), so
+    /// the published VM equals the key the node signs mesh responses with.
+    /// `None` when the entity signing key is not configured.
+    pub mesh_pq_verifying_key: Option<Vec<u8>>,
 }
 
 impl OAuthState {
@@ -430,6 +437,7 @@ impl OAuthState {
             ml_dsa_key_store: None,
             quic_cert_hashes: Vec::new(),
             quic_public_uri: None,
+            mesh_pq_verifying_key: None,
         }
     }
 
@@ -544,7 +552,14 @@ impl OAuthState {
     }
 
     /// Attach the signing key for OpenID Federation 1.0 entity configuration signing.
+    ///
+    /// Also derives and stores the node's mesh ML-DSA-65 verifying key (#157)
+    /// from this same Ed25519 key, so the root DID document's `#mesh-pq`
+    /// Multikey verification method matches the post-quantum key the mesh signs
+    /// with (`derive_mesh_mldsa_key`).
     pub fn with_signing_key(mut self, key: ed25519_dalek::SigningKey) -> Self {
+        let pq_sk = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&key);
+        self.mesh_pq_verifying_key = Some(hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(&pq_sk));
         self.signing_key = Some(key);
         self
     }


### PR DESCRIPTION
Close the M3 deploy-blocker: hybrid COSE response signing (#275) had an
ephemeral ML-DSA-65 key and an empty peer trust store, so Hybrid attestation
had nothing persistent to sign with and nothing to verify against.

Scope 1 — persistent mesh signing key (derive, don't store):
- node_identity.rs: derive_mesh_mldsa_key() = HKDF derive_purpose_key(node
  Ed25519 key, "hyprstream-mesh-mldsa-v1") -> ml_dsa_sk_from_seed; seed zeroized.
  Stable across restarts, no new key file, PQUIP key-separation (distinct label).
- signer.rs / streaming.rs: LocalSigner::new + StreamChannel::new derive the
  mesh key instead of minting an ephemeral one.
- svc.rs: RequestService::pq_signing_key() default is now
  Some(derive_mesh_mldsa_key(signing_key())) instead of None — every service
  signs Hybrid by default. The EdDSA half is signed with the same Ed25519 key
  dispatch already uses, so the kid-anchored binding (Ed25519 signer -> ML-DSA
  vk) is self-consistent; a Classical verifier still accepts via inner EdDSA.

Scope 2 — publish the #mesh-pq Multikey VM:
- oauth/state.rs: OAuthState carries mesh_pq_verifying_key, derived from the
  SAME Ed25519 key in with_signing_key (published VM == signing key).
- did_document.rs: un-gate mldsa65_verification_method; root_did_document emits
  #mesh-pq (ML-DSA-65 Multikey, 0x1211) with auth/assertion refs.

Scope 3 — populate KeyedPqTrustStore (eager, admin-anchored, immutable):
- config: new OAuthConfig.mesh_peers: HashMap<label, MeshPeerConfig{ed25519_
  multibase, mldsa65_multibase}>; inline out-of-band Multikey strings, serde
  default. Distinct from trusted_issuers.
- auth/mesh_trust.rs: build_mesh_pq_trust_store binds each peer's Ed25519 signer
  identity -> trusted ML-DSA-65 key; malformed entries logged + skipped (never
  trusted); codec-checked Multikey decode.
- bin/main.rs: install_envelope_verify_config builds the store EAGERLY before
  install_verify_config; immutable thereafter. Empty/absent mesh_peers => empty
  store => unchanged behavior (Hybrid fails closed for unknown peers). Matches
  the KeyedPqTrustStore "established out-of-band" contract + Tiles admission.

Tests: deterministic+separated mesh key derivation; published #mesh-pq VM ==
derived signing key; trust store verifies a configured peer's ML-DSA signature,
empty config => empty store, malformed entry skipped, wrong-codec rejected.

Issue #157. Part of epic #131.
