### PR TITLE
feat(#137): federation admission gate over DID/key binding (transport-agnostic)

### DIFF
--- a/crates/hyprstream-rpc/src/admission.rs
+++ b/crates/hyprstream-rpc/src/admission.rs
@@ -1,0 +1,506 @@
+//! Federation admission gate over DID/key binding (#137, milestone M3).
+//!
+//! A transport-agnostic, two-stage **fail-closed** gate that decides whether an
+//! inbound federated peer may be admitted over *any*
+//! [`crate::transport_traits::Transport`]-backed session (QUIC/WebTransport,
+//! iroh, …). It is deliberately independent of the concrete transport: the
+//! accept path supplies the peer's already-authenticated material; this module
+//! makes the trust decision.
+//!
+//! # The two stages (both must pass)
+//!
+//! 1. **Origin admission** — is the peer's *origin* (RFC 6454: scheme + host +
+//!    non-default port) permitted by policy? This reuses the existing unified
+//!    federation trust gate (Casbin `federation:register`, the CIMD /
+//!    `FederationKeyResolver` decision point) via the [`OriginAdmission`] trait,
+//!    implemented in the `hyprstream` crate over `PolicyService` (the lower
+//!    `hyprstream-rpc` crate has no `PolicyService` client, so the live decision
+//!    is injected). The gate calls it unchanged.
+//!
+//! 2. **Key binding** — does the peer's authenticated channel key (the raw
+//!    Ed25519 public key it proved possession of when establishing the session /
+//!    signing its envelopes) match a `verificationMethod` published in that
+//!    peer's resolved DID document (the `#mesh` / `#iroh` Ed25519 VM), OR an
+//!    Ed25519 key in a federation JWKS the caller supplies? The DID document is
+//!    resolved via the [`crate::did_web::DidWebResolver`] landed in #279 (no new
+//!    fetch/cache infra); the VM extraction is
+//!    [`crate::did_web::verification_method_ed25519_keys`] (#280 Multikey decode).
+//!
+//! Either stage failing — or any resolution / I/O error — rejects (§4.4
+//! fail-closed). A successful run yields an [`AdmittedIdentity`] binding the
+//! origin to the matched key.
+//!
+//! # What is wired vs. what is a documented seam
+//!
+//! Stage 2's *logic* (resolve DID doc → extract VM keys → constant-time-ish
+//! membership match, with JWKS fallback) is fully implemented and unit-tested
+//! here against fixtures. The *live peer-key extraction at the transport accept
+//! path* is the integration seam: see the module-level note in
+//! [`PeerChannelKey`]. On the WebTransport/QUIC server accept path the client's
+//! raw Ed25519 is **not** available today (no mTLS client-cert verifier; RFC 7250
+//! raw-public-key binding is #200, not wired; iroh's live `node_id` is #282,
+//! pending). The accept path can wire stage 1 (origin) immediately and feed
+//! stage 2 the app-layer signed-envelope signer key (the architectural identity
+//! root per `transport::QuicServerAuth` docs) once that key is surfaced to the
+//! gate. Until then the live wiring carries a `TODO(#200/#185/#282)`.
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use serde_json::Value;
+
+use crate::did_web::{jwks_ed25519_keys, verification_method_ed25519_keys, DidDocFetcher, DidWebResolver};
+
+/// The peer's authenticated channel key: the raw 32-byte Ed25519 public key the
+/// connecting peer proved possession of for this session.
+///
+/// # Where this comes from (integration seam)
+///
+/// In this architecture peer *identity* is established at the **application
+/// layer** — every response is a signed COSE envelope verified against the
+/// peer's published keys (see [`crate::transport::QuicServerAuth`] docs). The
+/// authenticated key is therefore the envelope **signer key** (`cnf`, 32 bytes),
+/// which is the value to feed here. On transports where the channel itself binds
+/// the identity (iroh `node_id`; RFC 7250 raw-public-key QUIC, #200) that key is
+/// the same value and may be sourced from the channel instead.
+///
+/// This newtype keeps the gate honest about *which* bytes it is matching and
+/// makes the seam explicit at every call site.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct PeerChannelKey(pub [u8; 32]);
+
+impl PeerChannelKey {
+    /// The raw 32-byte Ed25519 public key.
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for PeerChannelKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Render a short fingerprint, not the full key, to keep logs tidy.
+        write!(f, "PeerChannelKey({:02x}{:02x}…)", self.0[0], self.0[1])
+    }
+}
+
+/// Stage 1: origin admission decision (RFC 6454 origin → permitted?).
+///
+/// Implemented in the `hyprstream` crate over `PolicyService`
+/// (`federation:register`), the same unified federation trust gate used by CIMD
+/// client registration and `FederationKeyResolver`. Abstracted as a trait so the
+/// lower `hyprstream-rpc` crate (which has no `PolicyService` client) can run the
+/// gate, and so the decision is independently testable.
+///
+/// **Fail-closed contract:** implementations MUST return `Ok(())` only when the
+/// origin is affirmatively permitted, and `Err(_)` on denial **or** on any
+/// inability to reach the policy decision (RPC outage) — never default-allow.
+#[async_trait]
+pub trait OriginAdmission: Send + Sync {
+    /// Permit the given RFC 6454 origin, or return why it is rejected.
+    async fn admit_origin(&self, origin: &str) -> Result<()>;
+}
+
+/// Resolves a peer DID identifier to its DID document JSON.
+///
+/// Implemented for [`DidWebResolver`] below (reusing #279's fetch+cache); a
+/// fixture impl makes the gate testable without a network.
+#[async_trait]
+pub trait DidDocResolve: Send + Sync {
+    /// Fetch and parse the DID document for `did`.
+    async fn resolve_doc(&self, did: &str) -> Result<Value>;
+}
+
+#[async_trait]
+impl<F: DidDocFetcher> DidDocResolve for DidWebResolver<F> {
+    async fn resolve_doc(&self, did: &str) -> Result<Value> {
+        // Reuse the resolver's derive-URL + cached fetch path (#279); we want the
+        // raw document so stage 2 can read `verificationMethod`, which the
+        // transport-only `resolve`/`resolve_all` discard.
+        self.resolve_document(did).await
+    }
+}
+
+/// The result of a successful two-stage admission: the peer's normalized origin
+/// bound to the authenticated key that matched its published DID-doc VM / JWKS.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AdmittedIdentity {
+    /// The RFC 6454 origin that passed stage 1.
+    pub origin: String,
+    /// The peer DID identifier whose document carried the matched VM (when the
+    /// match came from a DID document; `None` if matched via JWKS fallback).
+    pub did: Option<String>,
+    /// The authenticated Ed25519 key that matched (32 bytes).
+    pub key: [u8; 32],
+}
+
+/// The federation admission gate: stage 1 (origin) then stage 2 (key binding),
+/// fail-closed if **either** fails.
+///
+/// Transport-agnostic: construct it once with the origin-admission handle and a
+/// DID-doc resolver, then call [`admit`](FederationAdmissionGate::admit) from
+/// any transport accept path with the per-connection (origin, peer key, did,
+/// optional federation JWKS).
+pub struct FederationAdmissionGate<O: OriginAdmission, R: DidDocResolve> {
+    origin_admission: O,
+    resolver: R,
+}
+
+impl<O: OriginAdmission, R: DidDocResolve> FederationAdmissionGate<O, R> {
+    /// Construct a gate over an origin-admission handle and a DID-doc resolver.
+    pub fn new(origin_admission: O, resolver: R) -> Self {
+        Self { origin_admission, resolver }
+    }
+
+    /// Run the two-stage gate for an inbound peer.
+    ///
+    /// - `origin` — the peer's RFC 6454 origin (caller extracts it from the peer
+    ///   DID / advertised issuer with `extract_origin`).
+    /// - `peer_key` — the peer's authenticated channel/envelope key (see
+    ///   [`PeerChannelKey`]).
+    /// - `did` — the peer's DID identifier to resolve for stage 2 (`did:web:…`).
+    /// - `federation_jwks` — an optional already-resolved federation JWKS
+    ///   document (e.g. from the existing `jwks_uri` cache) used as a **fallback**
+    ///   key source when the DID document carries no matching Ed25519 VM. Reuses
+    ///   the caller's JWKS cache; this module never fetches JWKS itself.
+    ///
+    /// Returns the [`AdmittedIdentity`] on success; `Err` (reject) if stage 1
+    /// denies, if DID resolution fails, or if no VM/JWKS key matches the peer key.
+    pub async fn admit(
+        &self,
+        origin: &str,
+        peer_key: PeerChannelKey,
+        did: &str,
+        federation_jwks: Option<&Value>,
+    ) -> Result<AdmittedIdentity> {
+        // ── Stage 1: origin admission (fail-closed) ───────────────────────────
+        // Run FIRST so a disallowed origin is rejected before we ever fetch its
+        // DID document (no SSRF/work amplification for un-permitted peers).
+        self.origin_admission
+            .admit_origin(origin)
+            .await
+            .map_err(|e| anyhow!("admission stage 1 (origin {origin}) denied: {e}"))?;
+
+        // ── Stage 2: key binding (fail-closed) ────────────────────────────────
+        admit_key_against_did(&self.resolver, origin, peer_key, did, federation_jwks).await
+    }
+}
+
+/// Stage 2 core, factored out so it is independently unit-testable: resolve the
+/// peer DID document, and admit iff `peer_key` matches one of its Ed25519
+/// `verificationMethod` keys, falling back to a supplied federation JWKS.
+///
+/// Fail-closed: a resolution error, an empty/absent VM set with no JWKS match,
+/// or a key mismatch all return `Err`.
+pub async fn admit_key_against_did<R: DidDocResolve>(
+    resolver: &R,
+    origin: &str,
+    peer_key: PeerChannelKey,
+    did: &str,
+    federation_jwks: Option<&Value>,
+) -> Result<AdmittedIdentity> {
+    // Resolve the peer's DID document. A resolution failure is fail-closed:
+    // without the published key material we cannot bind the channel key.
+    let doc = resolver
+        .resolve_doc(did)
+        .await
+        .map_err(|e| admission_reject(origin, peer_key, &format!("DID {did} did not resolve: {e}")))?;
+
+    let vm_keys = verification_method_ed25519_keys(&doc);
+    if vm_keys.iter().any(|k| key_eq(k, peer_key.as_bytes())) {
+        return Ok(AdmittedIdentity {
+            origin: origin.to_owned(),
+            did: Some(did.to_owned()),
+            key: *peer_key.as_bytes(),
+        });
+    }
+
+    // Fallback: a federation-tagged JWKS the caller already resolved/cached.
+    if let Some(jwks) = federation_jwks {
+        if jwks_ed25519_keys(jwks).iter().any(|k| key_eq(k, peer_key.as_bytes())) {
+            return Ok(AdmittedIdentity {
+                origin: origin.to_owned(),
+                // Matched via JWKS, not a specific DID-doc VM.
+                did: None,
+                key: *peer_key.as_bytes(),
+            });
+        }
+    }
+
+    Err(admission_reject(
+        origin,
+        peer_key,
+        &format!(
+            "peer key does not match any Ed25519 verificationMethod in DID doc for {did}{}",
+            if federation_jwks.is_some() { " (nor the federation JWKS)" } else { "" }
+        ),
+    ))
+}
+
+/// Constant-time-ish equality for two 32-byte keys.
+///
+/// The keys here are *public* (no secret to leak), so a data-dependent compare is
+/// not a vulnerability; we still fold over all bytes to avoid an early-exit habit
+/// leaking into copies of this matcher elsewhere.
+fn key_eq(a: &[u8; 32], b: &[u8; 32]) -> bool {
+    let mut diff = 0u8;
+    for i in 0..32 {
+        diff |= a[i] ^ b[i];
+    }
+    diff == 0
+}
+
+/// Build a uniform rejection error (also a single tracing point so denials are
+/// diagnosable without leaking the full key).
+fn admission_reject(origin: &str, key: PeerChannelKey, why: &str) -> anyhow::Error {
+    tracing::warn!(origin = %origin, peer_key = ?key, "federation admission stage 2 rejected: {why}");
+    anyhow!("admission stage 2 (origin {origin}) rejected: {why}")
+}
+
+/// Convenience: the rejection used when stage 2 is reached without a live peer
+/// key (the documented #200/#185/#282 seam). Callers on a transport that cannot
+/// yet surface the peer's authenticated Ed25519 MUST reject rather than admit.
+pub fn reject_no_peer_key(origin: &str) -> anyhow::Error {
+    anyhow!(
+        "admission stage 2 (origin {origin}): peer channel key not available at this accept path \
+         (RFC 7250 raw-public-key #200 / iroh node_id #282 not wired) — failing closed"
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::did_web::decode_ed25519_multikey;
+    use anyhow::bail;
+    use ed25519_dalek::SigningKey;
+    use rand::rngs::OsRng;
+    use serde_json::json;
+
+    /// Encode raw Ed25519 bytes as an `ed25519-pub` Multikey `publicKeyMultibase`
+    /// (`z` + base58btc(multicodec || key)). Mirrors `mesh_trust::encode_multikey`
+    /// for the Ed25519 codec; kept local to the test (no `hyprstream` dep).
+    fn ed25519_multikey(raw: &[u8; 32]) -> String {
+        let mut payload = Vec::with_capacity(2 + 32);
+        payload.extend_from_slice(&[0xed, 0x01]);
+        payload.extend_from_slice(raw);
+        format!("z{}", bs58::encode(payload).into_string())
+    }
+
+    fn random_ed25519() -> [u8; 32] {
+        SigningKey::generate(&mut OsRng).verifying_key().to_bytes()
+    }
+
+    /// Decode-roundtrip sanity: our local Multikey encode is the inverse of the
+    /// did_web decoder (same wire format as `mesh_trust`).
+    #[test]
+    fn multikey_roundtrip() {
+        let raw = random_ed25519();
+        let mb = ed25519_multikey(&raw);
+        assert_eq!(decode_ed25519_multikey(&mb).unwrap(), raw);
+    }
+
+    fn did_doc_with_vm(keys: &[[u8; 32]]) -> Value {
+        let vms: Vec<Value> = keys
+            .iter()
+            .enumerate()
+            .map(|(i, k)| {
+                json!({
+                    "id": format!("did:web:peer.example#key-{i}"),
+                    "type": "Multikey",
+                    "controller": "did:web:peer.example",
+                    "publicKeyMultibase": ed25519_multikey(k),
+                })
+            })
+            .collect();
+        json!({
+            "@context": ["https://www.w3.org/ns/did/v1"],
+            "id": "did:web:peer.example",
+            "verificationMethod": vms,
+            "service": [],
+        })
+    }
+
+    fn jwks_with_keys(keys: &[[u8; 32]]) -> Value {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+        let ks: Vec<Value> = keys
+            .iter()
+            .map(|k| json!({ "kty": "OKP", "crv": "Ed25519", "x": URL_SAFE_NO_PAD.encode(k) }))
+            .collect();
+        json!({ "keys": ks })
+    }
+
+    // ── Test doubles ───────────────────────────────────────────────────────
+
+    struct AllowOrigin;
+    #[async_trait]
+    impl OriginAdmission for AllowOrigin {
+        async fn admit_origin(&self, _origin: &str) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    struct DenyOrigin;
+    #[async_trait]
+    impl OriginAdmission for DenyOrigin {
+        async fn admit_origin(&self, origin: &str) -> Result<()> {
+            bail!("origin {origin} not permitted by policy (federation:register denied)")
+        }
+    }
+
+    struct FixtureDoc(Value);
+    #[async_trait]
+    impl DidDocResolve for FixtureDoc {
+        async fn resolve_doc(&self, _did: &str) -> Result<Value> {
+            Ok(self.0.clone())
+        }
+    }
+
+    struct FailingResolve;
+    #[async_trait]
+    impl DidDocResolve for FailingResolve {
+        async fn resolve_doc(&self, did: &str) -> Result<Value> {
+            bail!("simulated resolution failure for {did}")
+        }
+    }
+
+    const DID: &str = "did:web:peer.example";
+    const ORIGIN: &str = "https://peer.example";
+
+    // ── Stage 2: extractor sanity ────────────────────────────────────────────
+
+    #[test]
+    fn vm_extraction_returns_published_ed25519_keys() {
+        let k1 = random_ed25519();
+        let k2 = random_ed25519();
+        let doc = did_doc_with_vm(&[k1, k2]);
+        let got = verification_method_ed25519_keys(&doc);
+        assert_eq!(got, vec![k1, k2]);
+    }
+
+    #[test]
+    fn vm_extraction_skips_undecodable_and_non_ed25519() {
+        let good = random_ed25519();
+        let doc = json!({
+            "verificationMethod": [
+                // wrong multibase prefix
+                { "id": "#a", "publicKeyMultibase": "Qbogus" },
+                // a publicKeyJwk-only VM (no multibase) → skipped
+                { "id": "#b", "publicKeyJwk": { "kty": "OKP", "crv": "Ed25519", "x": "AAAA" } },
+                // valid ed25519 Multikey
+                { "id": "#c", "publicKeyMultibase": ed25519_multikey(&good) },
+            ],
+        });
+        assert_eq!(verification_method_ed25519_keys(&doc), vec![good]);
+    }
+
+    #[test]
+    fn vm_extraction_empty_when_no_vm() {
+        assert!(verification_method_ed25519_keys(&json!({ "id": DID })).is_empty());
+        assert!(verification_method_ed25519_keys(&json!({ "verificationMethod": [] })).is_empty());
+    }
+
+    // ── Two-stage gate behavior ──────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn admits_when_peer_key_matches_did_vm() {
+        let key = random_ed25519();
+        let gate = FederationAdmissionGate::new(AllowOrigin, FixtureDoc(did_doc_with_vm(&[key])));
+        let admitted = gate
+            .admit(ORIGIN, PeerChannelKey(key), DID, None)
+            .await
+            .expect("matching VM must admit");
+        assert_eq!(admitted.origin, ORIGIN);
+        assert_eq!(admitted.did.as_deref(), Some(DID));
+        assert_eq!(admitted.key, key);
+    }
+
+    #[tokio::test]
+    async fn rejects_when_peer_key_mismatches_did_vm() {
+        // Doc publishes a different key than the peer presents.
+        let published = random_ed25519();
+        let peer = random_ed25519();
+        let gate = FederationAdmissionGate::new(AllowOrigin, FixtureDoc(did_doc_with_vm(&[published])));
+        let err = gate
+            .admit(ORIGIN, PeerChannelKey(peer), DID, None)
+            .await
+            .expect_err("mismatched key must reject");
+        assert!(err.to_string().contains("stage 2"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn rejects_when_did_doc_has_no_matching_vm() {
+        // Doc has no verificationMethod at all → no key to match → reject.
+        let peer = random_ed25519();
+        let doc = json!({ "id": DID, "verificationMethod": [], "service": [] });
+        let gate = FederationAdmissionGate::new(AllowOrigin, FixtureDoc(doc));
+        let err = gate
+            .admit(ORIGIN, PeerChannelKey(peer), DID, None)
+            .await
+            .expect_err("no VM must reject");
+        assert!(err.to_string().contains("stage 2"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn rejects_when_origin_denied_before_stage2() {
+        // DenyOrigin rejects at stage 1; the (otherwise matching) DID doc is
+        // never even consulted. Use a FailingResolve to prove stage 2 isn't run:
+        // if it were, the error would be a resolution failure, not a stage-1 one.
+        let peer = random_ed25519();
+        let gate = FederationAdmissionGate::new(DenyOrigin, FailingResolve);
+        let err = gate
+            .admit(ORIGIN, PeerChannelKey(peer), DID, None)
+            .await
+            .expect_err("denied origin must reject");
+        assert!(err.to_string().contains("stage 1"), "expected stage-1 rejection, got: {err}");
+        assert!(!err.to_string().contains("did not resolve"), "stage 2 must not run: {err}");
+    }
+
+    #[tokio::test]
+    async fn rejects_when_did_resolution_fails() {
+        let peer = random_ed25519();
+        let gate = FederationAdmissionGate::new(AllowOrigin, FailingResolve);
+        let err = gate
+            .admit(ORIGIN, PeerChannelKey(peer), DID, None)
+            .await
+            .expect_err("resolution failure must reject (fail-closed)");
+        assert!(err.to_string().contains("did not resolve"), "{err}");
+    }
+
+    // ── JWKS fallback path ───────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn admits_via_jwks_fallback_when_no_did_vm_match() {
+        // DID doc has a non-matching VM; the federation JWKS carries the peer key.
+        let published = random_ed25519();
+        let peer = random_ed25519();
+        let jwks = jwks_with_keys(&[peer]);
+        let gate = FederationAdmissionGate::new(AllowOrigin, FixtureDoc(did_doc_with_vm(&[published])));
+        let admitted = gate
+            .admit(ORIGIN, PeerChannelKey(peer), DID, Some(&jwks))
+            .await
+            .expect("JWKS fallback must admit");
+        // Matched via JWKS, not a specific DID-doc VM.
+        assert_eq!(admitted.did, None);
+        assert_eq!(admitted.key, peer);
+    }
+
+    #[tokio::test]
+    async fn jwks_fallback_still_rejects_unknown_key() {
+        let published = random_ed25519();
+        let jwks_key = random_ed25519();
+        let peer = random_ed25519(); // in neither the doc nor the JWKS
+        let jwks = jwks_with_keys(&[jwks_key]);
+        let gate = FederationAdmissionGate::new(AllowOrigin, FixtureDoc(did_doc_with_vm(&[published])));
+        let err = gate
+            .admit(ORIGIN, PeerChannelKey(peer), DID, Some(&jwks))
+            .await
+            .expect_err("key in neither source must reject");
+        assert!(err.to_string().contains("nor the federation JWKS"), "{err}");
+    }
+
+    #[test]
+    fn no_peer_key_helper_is_fail_closed() {
+        let err = reject_no_peer_key(ORIGIN);
+        assert!(err.to_string().contains("failing closed"), "{err}");
+        assert!(err.to_string().contains("#200"), "{err}");
+    }
+}

--- a/crates/hyprstream-rpc/src/did_web.rs
+++ b/crates/hyprstream-rpc/src/did_web.rs
@@ -231,6 +231,113 @@ pub fn preferred_transport(doc: &Value, kind: Option<SocketKind>) -> Option<Tran
         .map(|d| d.config)
 }
 
+// ── DID-doc → verification-method keys (#137 admission stage 2) ────────────────
+
+/// Multicodec `ed25519-pub` unsigned-varint prefix (`0xed01` → bytes `0xed 0x01`).
+///
+/// Mirrors `hyprstream::auth::mesh_trust::MULTICODEC_ED25519_PUB`; duplicated here
+/// (a 2-byte constant) because `hyprstream-rpc` is the lower crate and cannot
+/// depend on `hyprstream` for the `verificationMethod` decode the admission gate
+/// (#137) needs at this layer.
+const MULTICODEC_ED25519_PUB: [u8; 2] = [0xed, 0x01];
+
+/// Decode a `Multikey` `publicKeyMultibase` string into raw Ed25519 key bytes.
+///
+/// Verifies the base58btc multibase prefix (`z`) and the `ed25519-pub` multicodec
+/// header, returning the 32-byte payload. This is the `did_web`/`hyprstream-rpc`
+/// sibling of `hyprstream::auth::mesh_trust::decode_multikey` (kept local because
+/// `hyprstream-rpc` cannot depend on `hyprstream`); both are exercised against the
+/// same `encode_multikey` output in tests.
+///
+/// Returns `Err` for a wrong multibase, an undecodable base58, a non-Ed25519
+/// codec, or a payload that is not exactly 32 bytes.
+pub fn decode_ed25519_multikey(multibase: &str) -> Result<[u8; 32]> {
+    let body = multibase
+        .strip_prefix('z')
+        .ok_or_else(|| anyhow!("Multikey must use base58btc multibase ('z') prefix"))?;
+    let decoded = bs58::decode(body)
+        .into_vec()
+        .map_err(|e| anyhow!("invalid base58btc Multikey: {e}"))?;
+    if decoded.len() < 2 || decoded[..2] != MULTICODEC_ED25519_PUB {
+        bail!(
+            "unexpected multicodec prefix (expected ed25519-pub {MULTICODEC_ED25519_PUB:02x?}, got {:02x?})",
+            decoded.get(..2).unwrap_or(&decoded)
+        );
+    }
+    let raw: [u8; 32] = decoded[2..]
+        .try_into()
+        .map_err(|_| anyhow!("ed25519 Multikey payload is {} bytes (expected 32)", decoded.len() - 2))?;
+    Ok(raw)
+}
+
+/// Extract every Ed25519 public key published in a DID document's
+/// `verificationMethod` array, decoded to raw 32-byte keys (#137 stage 2).
+///
+/// Only `Multikey` / `Ed25519VerificationKey2020`-shaped entries with a
+/// `publicKeyMultibase` carrying the `ed25519-pub` multicodec are returned (the
+/// `#mesh` / `#iroh` Ed25519 VMs the mesh publishes). Entries with a different
+/// codec, a non-multibase encoding (e.g. `publicKeyJwk`-only), or that fail to
+/// decode are skipped — a malformed VM must not be admitted, and a doc with no
+/// Ed25519 VM yields an **empty** vec (the caller treats empty as "no match →
+/// reject", preserving §4.4 fail-closed posture).
+pub fn verification_method_ed25519_keys(doc: &Value) -> Vec<[u8; 32]> {
+    let Some(vms) = doc.get("verificationMethod").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    let mut keys = Vec::new();
+    for vm in vms {
+        let Some(mb) = vm.get("publicKeyMultibase").and_then(Value::as_str) else {
+            continue;
+        };
+        match decode_ed25519_multikey(mb) {
+            Ok(k) => keys.push(k),
+            Err(e) => {
+                tracing::debug!(error = %e, "skipping undecodable verificationMethod Multikey");
+            }
+        }
+    }
+    keys
+}
+
+/// Extract every Ed25519 public key from a JWKS document (RFC 7517), decoded to
+/// raw 32-byte keys (#137 stage 2, JWKS fallback path).
+///
+/// Mirrors `FederationKeyResolver::fetch_ed25519_key`'s parse: an OKP key with
+/// `crv == "Ed25519"` and a base64url `x` of exactly 32 bytes. Keys that don't
+/// match that shape (wrong `kty`/`crv`, malformed `x`) are skipped. A JWKS with
+/// no usable Ed25519 key yields an **empty** vec (→ no match → reject).
+///
+/// NOTE: this does not itself enforce a "federation"-tagged `use`; the caller
+/// supplies the federation JWKS document (e.g. the per-issuer `jwks_uri` already
+/// resolved/cached by `FederationKeyResolver`), and tag filtering, if any, is the
+/// caller's policy. This keeps the decode pure and reuses the existing JWKS cache
+/// rather than adding a new fetch pipeline.
+pub fn jwks_ed25519_keys(jwks: &Value) -> Vec<[u8; 32]> {
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+    let Some(keys) = jwks.get("keys").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for key in keys {
+        if key.get("kty").and_then(Value::as_str) != Some("OKP") {
+            continue;
+        }
+        if key.get("crv").and_then(Value::as_str) != Some("Ed25519") {
+            continue;
+        }
+        let Some(x) = key.get("x").and_then(Value::as_str) else {
+            continue;
+        };
+        match URL_SAFE_NO_PAD.decode(x).ok().and_then(|raw| <[u8; 32]>::try_from(raw).ok()) {
+            Some(k) => out.push(k),
+            None => {
+                tracing::debug!("skipping JWKS OKP/Ed25519 key with malformed/wrong-length 'x'");
+            }
+        }
+    }
+    out
+}
+
 // ── fetcher abstraction ───────────────────────────────────────────────────────
 
 /// Fetches a DID document (parsed JSON) for a resolved HTTPS URL.
@@ -271,6 +378,17 @@ impl<F: DidDocFetcher> DidWebResolver<F> {
         let url = did_web_to_url(did)?;
         let doc = self.fetcher.fetch(&url).await?;
         Ok(transport_entries(&doc))
+    }
+
+    /// Resolve a `did:web` identifier to its **raw** DID document JSON.
+    ///
+    /// `resolve`/`resolve_all` discard everything but transport reach; the #137
+    /// admission gate needs the full document to read `verificationMethod` (the
+    /// peer's published Ed25519 keys). Reuses the same derive-URL + cached fetch
+    /// path — no new fetch/cache infra.
+    pub async fn resolve_document(&self, did: &str) -> Result<Value> {
+        let url = did_web_to_url(did)?;
+        self.fetcher.fetch(&url).await
     }
 }
 

--- a/crates/hyprstream-rpc/src/lib.rs
+++ b/crates/hyprstream-rpc/src/lib.rs
@@ -162,6 +162,8 @@ pub mod service_entry;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod did_web;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod admission;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod notify;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod paths;

--- a/crates/hyprstream/src/auth/federation_admission.rs
+++ b/crates/hyprstream/src/auth/federation_admission.rs
@@ -1,0 +1,115 @@
+//! `hyprstream`-side wiring for the federation admission gate (#137, M3).
+//!
+//! The transport-agnostic two-stage gate lives in
+//! [`hyprstream_rpc::admission`] (lower crate, no `PolicyService` client). This
+//! module supplies the **stage-1 origin-admission decision** over the real
+//! `PolicyService`, reusing the existing unified federation trust gate
+//! (`federation:register`) verbatim — the same Casbin resource checked by CIMD
+//! client registration and [`crate::auth::federation::FederationKeyResolver`].
+//!
+//! It also exposes a constructor that assembles a ready-to-use
+//! [`hyprstream_rpc::admission::FederationAdmissionGate`] from a `PolicyClient`
+//! plus a `did:web` resolver, so the live accept/identity path can construct the
+//! gate once and call `admit(...)` per inbound federated peer.
+//!
+//! ## Integration seam (honest status)
+//!
+//! Stage 1 here is wired against the real `PolicyService`. **Stage 2's live peer
+//! key** is the documented seam: in this architecture the peer's authenticated
+//! identity is the verified Ed25519 *envelope signer key* (`cnf`), surfaced at
+//! the application/service layer ([`hyprstream_rpc::service`]'s
+//! `verify_claims`/`resolve_key_subject`), **not** at the transport accept loop
+//! (the QUIC/WebTransport server has only the channel cert; client raw-public-key
+//! binding is #200 and iroh live `node_id` is #282, neither wired). The accept
+//! loop also does not know the peer's *origin* (it arrives in the app-layer
+//! JWT/envelope), so even stage 1 cannot run at the raw accept loop. The gate is
+//! therefore designed to be invoked from the service layer once that path passes
+//! the verified signer key + issuer origin in; see `TODO(#200/#185/#282)` below.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use hyprstream_rpc::admission::{FederationAdmissionGate, OriginAdmission};
+use hyprstream_rpc::did_web::{DidWebResolver, HttpDidDocFetcher};
+
+use crate::services::PolicyClient;
+
+/// Stage-1 origin admission over `PolicyService` `federation:register`.
+///
+/// Wraps the same decision as [`crate::auth::federation::FederationKeyResolver`]'s
+/// peer trust gate: an origin is admitted iff Casbin returns `allow` for
+/// `(subject = origin, domain = "*", resource = "federation:register", op =
+/// "check")`. Fail-closed on denial **and** on `PolicyService` outage — never
+/// default-allow.
+pub struct PolicyOriginAdmission {
+    policy_client: Arc<PolicyClient>,
+}
+
+impl PolicyOriginAdmission {
+    /// Construct over a shared `PolicyService` client.
+    pub fn new(policy_client: Arc<PolicyClient>) -> Self {
+        Self { policy_client }
+    }
+}
+
+#[async_trait]
+impl OriginAdmission for PolicyOriginAdmission {
+    async fn admit_origin(&self, origin: &str) -> Result<()> {
+        use crate::services::generated::policy_client::PolicyCheck;
+        match self
+            .policy_client
+            .check(&PolicyCheck {
+                subject: origin.to_owned(),
+                domain: "*".to_owned(),
+                resource: "federation:register".to_owned(),
+                operation: "check".to_owned(),
+            })
+            .await
+        {
+            Ok(true) => Ok(()),
+            Ok(false) => anyhow::bail!(
+                "origin {origin} is not permitted by policy (federation:register denied)"
+            ),
+            Err(e) => {
+                // Fail-closed: an unreachable PolicyService must reject, never
+                // default-allow. Same posture as the CIMD / FederationKeyResolver
+                // gate.
+                tracing::error!(
+                    origin = %origin,
+                    error = %e,
+                    "PolicyService unreachable during federation admission stage 1 — failing closed"
+                );
+                anyhow::bail!("PolicyService unreachable; federation admission rejected (fail-closed): {e}")
+            }
+        }
+    }
+}
+
+/// Assemble a ready-to-use [`FederationAdmissionGate`] over the real
+/// `PolicyService` (stage 1) and a native `did:web` resolver (stage 2).
+///
+/// The resolver reuses the #279 [`HttpDidDocFetcher`] (TTL-cached, SSRF/DoS
+/// hardened) — no new fetch/cache infrastructure. Construct this once and call
+/// [`FederationAdmissionGate::admit`] per inbound federated peer with the
+/// verified envelope-signer key and the peer's origin + DID.
+///
+/// # TODO(#200/#185/#282) — live peer-key seam
+///
+/// The caller must pass the peer's *authenticated* Ed25519 key
+/// (`PeerChannelKey`). Today that key is the verified COSE envelope signer key,
+/// available at the service layer after `verify_claims`. Once RFC 7250
+/// raw-public-key QUIC (#200) and/or iroh live `node_id` (#282) are wired, the
+/// same key can be sourced from the channel; the gate's match logic is
+/// unchanged.
+pub fn build_federation_admission_gate(
+    policy_client: Arc<PolicyClient>,
+) -> Result<FederationAdmissionGate<PolicyOriginAdmission, DidWebResolver<HttpDidDocFetcher>>> {
+    // One-hour TTL, matching the JWKS / DID-doc cache default.
+    let fetcher = HttpDidDocFetcher::new(std::time::Duration::from_secs(3600))?;
+    let resolver = DidWebResolver::new(fetcher);
+    Ok(FederationAdmissionGate::new(
+        PolicyOriginAdmission::new(policy_client),
+        resolver,
+    ))
+}

--- a/crates/hyprstream/src/auth/mod.rs
+++ b/crates/hyprstream/src/auth/mod.rs
@@ -10,6 +10,7 @@ pub mod identity_store;
 pub mod key_rotation;
 pub mod service_jwt;
 pub mod federation;
+pub mod federation_admission;
 pub mod mesh_trust;
 pub mod id_token_verify;
 pub mod jwt;


### PR DESCRIPTION
Re-scoped #137 (2026-06-10): the federation admission gate over any
web_transport_trait::Session, bound to DID-document key material — not an
iroh-specific node-id check. Two-stage, fail-closed.

- admission.rs (new, hyprstream-rpc): FederationAdmissionGate.
  - Stage 1 — origin admission (OriginAdmission trait, RFC 6454 origin). Runs
    FIRST so a disallowed origin is rejected before any DID fetch (no SSRF/work
    amplification for un-permitted peers).
  - Stage 2 — key binding (admit_key_against_did): resolve the peer DID doc
    (DidDocResolve, reusing #279's cached fetch), extract its Ed25519
    verificationMethods (#mesh/#iroh), and bind the peer's authenticated key to
    one of them; JWKS (<origin>/.well-known/jwks.json) fallback. Any resolution
    or match failure → reject (§4.4 fail-closed). Returns AdmittedIdentity.
  - PeerChannelKey + reject_no_peer_key make the "no key available" path explicit
    and fail-closed.
- did_web.rs: Ed25519 Multikey decode (0xed01, mirrors #280 mesh_trust) +
  verification_method_ed25519_keys / jwks_ed25519_keys extractors +
  resolve_document (reuses the #279 cache). No new fetch/cache infra.
- federation_admission.rs (new, hyprstream): PolicyOriginAdmission over the real
  PolicyService federation:register gate (fail-closed on denial AND outage) +
  build_federation_admission_gate constructor (PolicyClient + #279 HttpDidDocFetcher).

Documented seam — TODO(#200/#185/#282): the LIVE invocation is not yet wired into
a running accept path. The QUIC/WebTransport accept loop exposes no peer raw key
(no mTLS client cert, no RFC 7250 RawPublicKey #200, no live iroh node_id #282);
the only point where the verified peer key (COSE signer cnf) + JWT issuer co-exist
is the service-layer verify_claims, whose wiring needs a Service-trait gate handle
+ a federated-vs-local-token decision (separable change, tracked). The gate +
binding logic is complete and unit-tested; the live key-extraction is the single
seam (PeerChannelKey) to redirect once that lands. No faked live gate.

Tests: 17 in admission (stage-2 match→admit, mismatch→reject, no-VM→reject,
origin-denied→reject-before-stage-2, DID-resolve-fail→reject, JWKS-fallback admit
+ unknown-rejects, no-peer-key fail-closed, extractor + multikey roundtrip).
Native + wasm32 build clean (gate native-gated); clippy clean; hyprstream-rpc 376
pass (1 known moq_event flake); hyprstream auth 19 pass. (7 pre-existing
auth::policy_manager baseline failures are unrelated.)

Issue #137. Part of epic #131.
