### PR TITLE
feat(#276): moq subscribe-time authz + per-tenant announce scoping (metadata defense-in-depth)

### DIFF
--- a/crates/hyprstream-rpc/src/lib.rs
+++ b/crates/hyprstream-rpc/src/lib.rs
@@ -152,6 +152,8 @@ pub mod streaming;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod moq_stream;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod moq_authz;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod moq_event;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod transport;

--- a/crates/hyprstream-rpc/src/moq_authz.rs
+++ b/crates/hyprstream-rpc/src/moq_authz.rs
@@ -1,0 +1,490 @@
+//! Subscribe-time authorization + per-tenant announce scoping for the moq
+//! streaming plane (#276).
+//!
+//! ## Why this module exists
+//!
+//! #274 made the moq streaming plane network-reachable (served on
+//! `web_transport_quinn` at `/moq`, and over the iroh `moql` ALPN via
+//! [`crate::transport::iroh_moq::IrohMoqProtocolHandler`]). That moved the
+//! *open-subscribe surface* onto the network. This is **not** a content hole —
+//! stream content is already protected by the §7.5 trust model (a 64-hex
+//! DH-derived HKDF-of-ECDH capability **topic**, unguessable and learned only
+//! from a signed `StreamInfo` over authenticated RPC, plus a per-frame chained
+//! HMAC). #276 is **metadata defense-in-depth**:
+//!
+//! 1. A *connected* peer can announce-enumerate broadcast (topic) names — moq
+//!    announces broadcasts by prefix, so a subscriber's `announced()` cursor
+//!    sees every broadcast under its allowed prefix. Without scoping, a peer in
+//!    tenant `A` could enumerate tenant `B`'s broadcast names.
+//! 2. Subscribe-time authorization: a *public* stream stays open (preserving
+//!    the working same-tenant subscribe model), but a *private* stream is gated
+//!    through the existing policy engine.
+//!
+//! ## moq-net's authorization primitive
+//!
+//! `moq_net::Server` exposes **no per-subscribe callback**. Authorization in
+//! moq-net is enforced *structurally*: a session can only enumerate/subscribe
+//! to broadcasts that are visible through the [`OriginConsumer`] handed to
+//! `Server::with_publish`. [`OriginConsumer::scope`] / [`OriginConsumer::with_root`]
+//! narrow that visibility by path prefix. So **per-tenant announce scoping** is
+//! implemented by handing each accepted session a tenant-scoped consumer
+//! (see [`tenant_scoped_consumer`]) — a subscriber that cannot *see* a
+//! broadcast cannot subscribe to it either.
+//!
+//! The **subscribe authorization hook** ([`SubscribeAuthorizer`]) is the
+//! pluggable policy layer on top of that structural scoping, for the
+//! public-vs-private distinction within a tenant. It is wired where the peer
+//! identity needed to evaluate policy is actually available (see the wiring
+//! notes on [`SubscribeAuthorizer`]).
+//!
+//! Track names are hierarchical `{tenant}/{service}/{topic}/{instance}` (the
+//! #134 CDN-portability invariant). The first path segment is the tenant.
+
+use std::sync::Arc;
+
+#[cfg(not(target_arch = "wasm32"))]
+use moq_net::{OriginConsumer, Path};
+
+/// The hierarchical track-name separator (`{tenant}/{service}/{topic}/{instance}`).
+pub const TRACK_NAME_SEP: char = '/';
+
+/// Extract the `{tenant}` segment from a hierarchical track / broadcast name.
+///
+/// Names are `{tenant}/{service}/{topic}/{instance}`; the tenant is the first
+/// path segment. Returns `None` for an empty name or a name whose first segment
+/// is empty (e.g. a leading `/`).
+///
+/// ```
+/// use hyprstream_rpc::moq_authz::tenant_of;
+/// assert_eq!(tenant_of("alice/streams/run-1/i0"), Some("alice"));
+/// assert_eq!(tenant_of("alice"), Some("alice"));
+/// assert_eq!(tenant_of(""), None);
+/// assert_eq!(tenant_of("/leading"), None);
+/// ```
+pub fn tenant_of(track_name: &str) -> Option<&str> {
+    match track_name.split(TRACK_NAME_SEP).next() {
+        Some(t) if !t.is_empty() => Some(t),
+        _ => None,
+    }
+}
+
+/// Build the tenant prefix (`{tenant}/`) used to scope announce enumeration.
+///
+/// The trailing separator is significant: moq prefix matching is segment-aware,
+/// so `"alice/"` matches `alice/...` but NOT a sibling tenant `alicent/...`.
+pub fn tenant_prefix(tenant: &str) -> String {
+    format!("{tenant}{TRACK_NAME_SEP}")
+}
+
+/// Pure per-tenant announce filter — the independently-testable core of the
+/// scoping behaviour.
+///
+/// Given a set of broadcast/track names and a tenant, returns only the names
+/// belonging to that tenant (i.e. whose first `{tenant}` segment equals
+/// `tenant`). This is what a peer in `tenant` is permitted to enumerate; names
+/// from other tenants are filtered out so cross-tenant broadcast-name
+/// enumeration is impossible.
+///
+/// Matching is segment-exact on the tenant (`alice` does not match `alicent`).
+pub fn filter_announces_by_tenant<'a, I>(names: I, tenant: &str) -> Vec<&'a str>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    names
+        .into_iter()
+        .filter(|name| tenant_of(name) == Some(tenant))
+        .collect()
+}
+
+/// Restrict an [`OriginConsumer`] to a single tenant's broadcasts.
+///
+/// This is the live, network-side enforcement of per-tenant announce scoping:
+/// the returned consumer's `announced()` cursor only ever yields broadcasts
+/// under `{tenant}/`, and `subscribe`/`announced_broadcast` for any path outside
+/// that prefix returns `None`. Hand the scoped consumer to
+/// `moq_net::Server::with_publish` for the accepted session and the peer cannot
+/// see — let alone subscribe to — another tenant's broadcasts.
+///
+/// Returns `None` if the requested prefix is outside the consumer's existing
+/// allowed prefixes (the moq-net `scope` contract); callers should treat that
+/// as "this tenant has no visible broadcasts" (serve an empty scope) rather
+/// than falling back to the unscoped consumer.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn tenant_scoped_consumer(consumer: &OriginConsumer, tenant: &str) -> Option<OriginConsumer> {
+    let prefix = tenant_prefix(tenant);
+    consumer.scope(&[Path::new(&prefix)])
+}
+
+/// Whether a stream is publicly subscribable or policy-gated.
+///
+/// Public streams preserve the existing open model (any connected, correctly
+/// tenant-scoped peer may subscribe). Private streams are gated through
+/// [`SubscribeAuthorizer`] / the policy engine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Visibility {
+    /// Open subscribe (subject only to tenant scoping).
+    Public,
+    /// Subscribe must be authorized by policy.
+    Private,
+}
+
+/// The outcome of a subscribe-authorization check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubscribeDecision {
+    /// The subscribe is permitted.
+    Allow,
+    /// The subscribe is denied (fail-closed for private + unauthorized).
+    Deny,
+}
+
+impl SubscribeDecision {
+    /// `true` iff the decision permits the subscribe.
+    pub fn is_allowed(self) -> bool {
+        matches!(self, SubscribeDecision::Allow)
+    }
+}
+
+/// Identity of the subscribing peer, as far as the moq accept path can
+/// determine it.
+///
+/// On the iroh `moql` path this is the authenticated remote node id
+/// (`Connection::remote_node_id()`); on the anonymous quinn `/moq` path no
+/// peer identity is available at the TLS layer (the server presents a pinned
+/// cert; the client is not mutually authenticated), so `subject` is `None`
+/// there. Authorizers must treat `subject == None` as an unauthenticated peer.
+#[derive(Debug, Clone, Default)]
+pub struct PeerIdentity {
+    /// Stable subject string for policy lookups (e.g. an iroh node id), or
+    /// `None` for an unauthenticated/anonymous peer.
+    pub subject: Option<String>,
+}
+
+impl PeerIdentity {
+    /// An anonymous peer (no authenticated identity).
+    pub fn anonymous() -> Self {
+        Self { subject: None }
+    }
+
+    /// A peer authenticated as `subject`.
+    pub fn authenticated(subject: impl Into<String>) -> Self {
+        Self {
+            subject: Some(subject.into()),
+        }
+    }
+
+    /// `true` iff this peer carries an authenticated subject.
+    pub fn is_authenticated(&self) -> bool {
+        self.subject.is_some()
+    }
+}
+
+/// Pluggable subscribe-time authorization hook for the moq accept path.
+///
+/// Implementors decide, given the (best-effort) peer identity and the
+/// hierarchical track name, whether a subscribe is permitted. The intended
+/// composition is: **structural tenant scoping** ([`tenant_scoped_consumer`])
+/// gates *visibility / cross-tenant enumeration*, and this hook gates
+/// *public-vs-private* within what's visible.
+///
+/// ## Wiring status
+///
+/// - **iroh `moql` path** ([`crate::transport::iroh_moq::IrohMoqProtocolHandler`]):
+///   the accepted `Connection` carries an authenticated `remote_node_id()`, so a
+///   real [`PeerIdentity`] is available and the hook can enforce policy.
+/// - **quinn `/moq` path** ([`crate::transport::quinn_transport::QuinnRpcServer`]):
+///   the WebTransport CONNECT is *not* mutually authenticated, so no peer
+///   identity is available at accept time. The hook is still invoked with
+///   [`PeerIdentity::anonymous`]; a policy-gated authorizer will therefore deny
+///   *private* subscribes from anonymous quinn peers (fail-closed) while public
+///   broadcasts remain open. See the wiring TODO in `quinn_transport.rs`.
+pub trait SubscribeAuthorizer: Send + Sync {
+    /// Decide whether `peer` may subscribe to `track_name`.
+    fn authorize(&self, peer: &PeerIdentity, track_name: &str) -> SubscribeDecision;
+}
+
+/// Classifies a track name as public or private. Returning [`Visibility::Public`]
+/// keeps the existing open model; [`Visibility::Private`] routes through the
+/// policy gate.
+pub type VisibilityFn = Arc<dyn Fn(&str) -> Visibility + Send + Sync>;
+
+/// Evaluates a policy decision for a (subject, tenant, track) tuple. Returns
+/// `true` to allow. This is the seam onto the existing Casbin/PolicyService
+/// (`PolicyManager::check_with_domain`) without `hyprstream-rpc` depending on
+/// the `hyprstream` crate.
+pub type PolicyGate = Arc<dyn Fn(&PeerIdentity, &str) -> bool + Send + Sync>;
+
+/// Default authorizer: **public streams are open, private streams are
+/// policy-gated, and unknown classification fails closed for safety**.
+///
+/// - If [`Visibility::Public`] → always [`SubscribeDecision::Allow`] (preserves
+///   the working same-tenant open-subscribe model).
+/// - If [`Visibility::Private`] → delegate to the [`PolicyGate`]; allow iff the
+///   gate returns `true`. With no gate installed, private subscribes are denied
+///   (fail-closed) — we never invent fail-dangerous behaviour.
+///
+/// When constructed with [`DefaultAuthorizer::permissive`], every track is
+/// treated as public (the pre-#276 behaviour) — used as the default until a
+/// deployment opts into private-stream classification.
+#[derive(Clone)]
+pub struct DefaultAuthorizer {
+    visibility: VisibilityFn,
+    policy: Option<PolicyGate>,
+}
+
+impl DefaultAuthorizer {
+    /// Permissive default: every track is treated as public (open subscribe).
+    /// Per-tenant announce scoping still applies independently.
+    pub fn permissive() -> Self {
+        Self {
+            visibility: Arc::new(|_| Visibility::Public),
+            policy: None,
+        }
+    }
+
+    /// Build with a custom visibility classifier and a policy gate for private
+    /// streams. Private + (no gate or gate-denied) → denied.
+    pub fn new(visibility: VisibilityFn, policy: Option<PolicyGate>) -> Self {
+        Self { visibility, policy }
+    }
+
+    /// Set/replace the visibility classifier.
+    pub fn with_visibility(mut self, visibility: VisibilityFn) -> Self {
+        self.visibility = visibility;
+        self
+    }
+
+    /// Set/replace the policy gate used for private streams.
+    pub fn with_policy(mut self, policy: PolicyGate) -> Self {
+        self.policy = Some(policy);
+        self
+    }
+}
+
+impl SubscribeAuthorizer for DefaultAuthorizer {
+    fn authorize(&self, peer: &PeerIdentity, track_name: &str) -> SubscribeDecision {
+        match (self.visibility)(track_name) {
+            Visibility::Public => SubscribeDecision::Allow,
+            Visibility::Private => match &self.policy {
+                // Fail-closed: a private stream with no policy gate is denied.
+                None => SubscribeDecision::Deny,
+                Some(gate) => {
+                    if gate(peer, track_name) {
+                        SubscribeDecision::Allow
+                    } else {
+                        SubscribeDecision::Deny
+                    }
+                }
+            },
+        }
+    }
+}
+
+/// Shared handle to a [`SubscribeAuthorizer`] suitable for stashing on a
+/// long-lived server/handler.
+pub type SharedSubscribeAuthorizer = Arc<dyn SubscribeAuthorizer>;
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tenant_of_extracts_first_segment() {
+        assert_eq!(tenant_of("alice/streams/run-1/i0"), Some("alice"));
+        assert_eq!(tenant_of("bob/svc/topic/inst"), Some("bob"));
+        assert_eq!(tenant_of("solo"), Some("solo"));
+        assert_eq!(tenant_of(""), None);
+        assert_eq!(tenant_of("/leading"), None);
+    }
+
+    #[test]
+    fn tenant_prefix_is_segment_significant() {
+        assert_eq!(tenant_prefix("alice"), "alice/");
+    }
+
+    #[test]
+    fn announce_filter_scopes_to_one_tenant() {
+        let names = [
+            "alice/streams/run-1/i0",
+            "alice/streams/run-2/i0",
+            "bob/streams/run-9/i0",
+            "carol/streams/run-3/i0",
+        ];
+        let a = filter_announces_by_tenant(names.iter().copied(), "alice");
+        assert_eq!(a, vec!["alice/streams/run-1/i0", "alice/streams/run-2/i0"]);
+        // Tenant A sees ONLY A's names — not B's or C's.
+        assert!(!a.iter().any(|n| n.starts_with("bob/")));
+        assert!(!a.iter().any(|n| n.starts_with("carol/")));
+
+        let b = filter_announces_by_tenant(names.iter().copied(), "bob");
+        assert_eq!(b, vec!["bob/streams/run-9/i0"]);
+    }
+
+    #[test]
+    fn announce_filter_is_segment_exact_no_prefix_bleed() {
+        // "alice" must NOT match a sibling tenant "alicent".
+        let names = ["alice/s/t/i", "alicent/s/t/i"];
+        let a = filter_announces_by_tenant(names.iter().copied(), "alice");
+        assert_eq!(a, vec!["alice/s/t/i"]);
+    }
+
+    #[test]
+    fn announce_filter_empty_for_unknown_tenant() {
+        let names = ["alice/s/t/i", "bob/s/t/i"];
+        assert!(filter_announces_by_tenant(names.iter().copied(), "zzz").is_empty());
+    }
+
+    #[test]
+    fn public_stream_is_allowed_even_anonymous() {
+        let authz = DefaultAuthorizer::permissive();
+        let decision = authz.authorize(&PeerIdentity::anonymous(), "alice/s/t/i");
+        assert_eq!(decision, SubscribeDecision::Allow);
+        assert!(decision.is_allowed());
+    }
+
+    #[test]
+    fn private_stream_without_gate_is_denied() {
+        // All-private classifier, no gate installed → fail-closed deny.
+        let authz =
+            DefaultAuthorizer::new(Arc::new(|_| Visibility::Private), None);
+        let decision = authz.authorize(&PeerIdentity::authenticated("did:key:z6Mk..."), "alice/s/t/i");
+        assert_eq!(decision, SubscribeDecision::Deny);
+    }
+
+    #[test]
+    fn private_stream_authorized_peer_is_allowed() {
+        // Private classifier + gate that allows a specific subject.
+        let gate: PolicyGate = Arc::new(|peer: &PeerIdentity, _track: &str| {
+            peer.subject.as_deref() == Some("alice-node")
+        });
+        let authz =
+            DefaultAuthorizer::new(Arc::new(|_| Visibility::Private), Some(gate));
+
+        let allowed =
+            authz.authorize(&PeerIdentity::authenticated("alice-node"), "alice/s/t/i");
+        assert_eq!(allowed, SubscribeDecision::Allow);
+    }
+
+    #[test]
+    fn private_stream_unauthorized_peer_is_rejected() {
+        let gate: PolicyGate = Arc::new(|peer: &PeerIdentity, _track: &str| {
+            peer.subject.as_deref() == Some("alice-node")
+        });
+        let authz =
+            DefaultAuthorizer::new(Arc::new(|_| Visibility::Private), Some(gate));
+
+        // Different subject → denied.
+        let denied =
+            authz.authorize(&PeerIdentity::authenticated("mallory-node"), "alice/s/t/i");
+        assert_eq!(denied, SubscribeDecision::Deny);
+
+        // Anonymous peer on a private stream → denied (fail-closed).
+        let anon = authz.authorize(&PeerIdentity::anonymous(), "alice/s/t/i");
+        assert_eq!(anon, SubscribeDecision::Deny);
+    }
+
+    #[test]
+    fn mixed_visibility_routes_public_open_private_gated() {
+        // Public iff under "pub/" prefix; everything else private.
+        let visibility: VisibilityFn = Arc::new(|track: &str| {
+            if tenant_of(track) == Some("pub") {
+                Visibility::Public
+            } else {
+                Visibility::Private
+            }
+        });
+        let gate: PolicyGate = Arc::new(|peer: &PeerIdentity, _| {
+            peer.subject.as_deref() == Some("priv-allowed")
+        });
+        let authz = DefaultAuthorizer::new(visibility, Some(gate));
+
+        // Public stream: open even to anonymous.
+        assert_eq!(
+            authz.authorize(&PeerIdentity::anonymous(), "pub/s/t/i"),
+            SubscribeDecision::Allow
+        );
+        // Private stream: authorized subject allowed.
+        assert_eq!(
+            authz.authorize(&PeerIdentity::authenticated("priv-allowed"), "alice/s/t/i"),
+            SubscribeDecision::Allow
+        );
+        // Private stream: other subject denied.
+        assert_eq!(
+            authz.authorize(&PeerIdentity::authenticated("nope"), "alice/s/t/i"),
+            SubscribeDecision::Deny
+        );
+    }
+
+    #[test]
+    fn peer_identity_constructors() {
+        assert!(!PeerIdentity::anonymous().is_authenticated());
+        assert!(PeerIdentity::authenticated("x").is_authenticated());
+        assert_eq!(
+            PeerIdentity::authenticated("x").subject.as_deref(),
+            Some("x")
+        );
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod scope_tests {
+    use super::*;
+    use moq_net::Origin;
+
+    /// A tenant-scoped consumer sees ONLY its own tenant's broadcasts on the
+    /// announce cursor — the live (network-side) analogue of
+    /// [`filter_announces_by_tenant`]. Tenant A must not enumerate B's names.
+    #[tokio::test]
+    async fn tenant_scoped_consumer_filters_announces() {
+        let producer = Origin::random().produce();
+        let base = producer.consume();
+
+        // Publish broadcasts for two tenants.
+        let _a1 = producer.create_broadcast("alice/streams/run-1/i0").unwrap();
+        let _a2 = producer.create_broadcast("alice/streams/run-2/i0").unwrap();
+        let _b1 = producer.create_broadcast("bob/streams/run-9/i0").unwrap();
+
+        // Scope a consumer to tenant "alice".
+        let mut scoped =
+            tenant_scoped_consumer(&base, "alice").expect("alice scope should exist");
+
+        // Drain everything currently announced through the scoped cursor.
+        // `OriginAnnounce` is `(path, Some(broadcast))` for an announce and
+        // `(path, None)` for an unannounce; we only collect announces.
+        let mut seen = Vec::new();
+        while let Some((path, active)) = scoped.try_announced() {
+            if active.is_some() {
+                // path is absolute and always under the scoped prefix.
+                seen.push(path.as_str().to_owned());
+            }
+        }
+        seen.sort();
+
+        assert_eq!(
+            seen,
+            vec![
+                "alice/streams/run-1/i0".to_owned(),
+                "alice/streams/run-2/i0".to_owned(),
+            ]
+        );
+        // Crucially: bob's broadcast is NOT visible to the alice-scoped consumer.
+        assert!(!seen.iter().any(|n| n.starts_with("bob/")));
+    }
+
+    /// A scoped consumer cannot subscribe to another tenant's broadcast even by
+    /// exact path: `announced_broadcast` for an out-of-scope path returns None.
+    #[tokio::test]
+    async fn tenant_scoped_consumer_cannot_reach_other_tenant() {
+        let producer = Origin::random().produce();
+        let base = producer.consume();
+        let _b1 = producer.create_broadcast("bob/streams/run-9/i0").unwrap();
+
+        let scoped =
+            tenant_scoped_consumer(&base, "alice").expect("alice scope should exist");
+
+        // bob/... is outside alice's scope → not reachable.
+        let reached = scoped.announced_broadcast("bob/streams/run-9/i0").await;
+        assert!(reached.is_none(), "alice-scoped consumer must not reach bob's broadcast");
+    }
+}

--- a/crates/hyprstream-rpc/src/transport/iroh_moq.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_moq.rs
@@ -32,6 +32,33 @@ use moq_net::{Origin, OriginConsumer, OriginProducer, Server, StatsHandle};
 use tokio_util::sync::CancellationToken;
 use web_transport_iroh::Session;
 
+use crate::moq_authz::{tenant_scoped_consumer, PeerIdentity, SharedSubscribeAuthorizer};
+
+/// Resolves the tenant a connected peer belongs to, from its (authenticated)
+/// identity. Returning `Some(tenant)` scopes that peer's view of announces to
+/// `{tenant}/`; returning `None` leaves the peer unscoped (the pre-#276 open
+/// model). Wired by the caller, which owns the peer↔tenant policy.
+pub type PeerTenantResolver = Arc<dyn Fn(&PeerIdentity) -> Option<String> + Send + Sync>;
+
+/// #276 authorization config for a moq accept path: an optional subscribe
+/// authorizer and an optional peer→tenant resolver for per-tenant announce
+/// scoping. Both default to "off" so existing open same-tenant subscribe keeps
+/// working until a deployment opts in.
+#[derive(Clone, Default)]
+pub struct MoqAuthzConfig {
+    /// Subscribe-time authorization hook (public-open / private-gated).
+    pub authorizer: Option<SharedSubscribeAuthorizer>,
+    /// Maps a peer identity to its tenant for per-tenant announce scoping.
+    pub tenant_resolver: Option<PeerTenantResolver>,
+}
+
+impl MoqAuthzConfig {
+    /// Resolve the tenant for `peer`, if a resolver is configured.
+    pub fn tenant_for(&self, peer: &PeerIdentity) -> Option<String> {
+        self.tenant_resolver.as_ref().and_then(|r| r(peer))
+    }
+}
+
 /// Shared `Origin` clone-pair held by the handler.
 ///
 /// - `producer` is what *we* publish into (call `create_broadcast`, `create_track`, etc.).
@@ -80,6 +107,9 @@ pub struct IrohMoqProtocolHandler {
 struct HandlerInner {
     origin: OriginShared,
     stats: StatsHandle,
+    /// #276 subscribe-authz + per-tenant announce scoping config. Defaults to
+    /// "off" (open same-tenant subscribe preserved).
+    authz: MoqAuthzConfig,
     /// Triggered by `ProtocolHandler::shutdown` so accept handlers stop
     /// waiting for `Session::closed()` and exit promptly.
     shutdown: CancellationToken,
@@ -105,9 +135,32 @@ impl IrohMoqProtocolHandler {
             inner: Arc::new(HandlerInner {
                 origin,
                 stats: StatsHandle::default(),
+                authz: MoqAuthzConfig::default(),
                 shutdown: CancellationToken::new(),
             }),
         }
+    }
+
+    /// Install the #276 subscribe-authz + per-tenant announce-scoping config.
+    ///
+    /// On this (iroh) path the accepted connection is authenticated, so the
+    /// `tenant_resolver` receives a real [`PeerIdentity`] (the remote endpoint
+    /// id) and per-tenant scoping is enforced live by handing the moq session a
+    /// tenant-scoped [`OriginConsumer`].
+    pub fn with_authz(mut self, authz: MoqAuthzConfig) -> Self {
+        if let Some(inner) = Arc::get_mut(&mut self.inner) {
+            inner.authz = authz;
+        } else {
+            // Inner already shared (cloned handler); rebuild a fresh Arc.
+            let old = &*self.inner;
+            self.inner = Arc::new(HandlerInner {
+                origin: old.origin.clone(),
+                stats: old.stats.clone(),
+                authz,
+                shutdown: old.shutdown.clone(),
+            });
+        }
+        self
     }
 
     /// Borrow the shared origin pair.
@@ -135,9 +188,55 @@ impl Default for IrohMoqProtocolHandler {
 
 impl ProtocolHandler for IrohMoqProtocolHandler {
     async fn accept(&self, conn: Connection) -> Result<(), AcceptError> {
+        // #276: peer identity IS available here — an accepted iroh connection
+        // is authenticated by the remote endpoint's public key. Use it to
+        // derive the peer's tenant and scope the consumer it's served.
+        let peer = PeerIdentity::authenticated(conn.remote_id().to_string());
+
+        // Per-tenant announce scoping (live): if the caller installed a
+        // peer→tenant resolver, hand this session a consumer narrowed to its
+        // own `{tenant}/` prefix so it cannot enumerate or subscribe to other
+        // tenants' broadcasts. No resolver → unscoped (pre-#276 open model).
+        let publish_consumer = match self.inner.authz.tenant_for(&peer) {
+            Some(tenant) => {
+                // `scope` returns None when the tenant prefix is outside the
+                // origin's allowed prefixes — serve that peer nothing rather
+                // than falling back to the unscoped consumer (fail-closed for
+                // cross-tenant enumeration).
+                match tenant_scoped_consumer(&self.inner.origin.consumer, &tenant) {
+                    Some(scoped) => {
+                        tracing::debug!(peer = %peer.subject.as_deref().unwrap_or("?"), %tenant, "iroh-moq: tenant-scoped consumer");
+                        scoped
+                    }
+                    None => {
+                        tracing::debug!(%tenant, "iroh-moq: tenant has no visible broadcasts; serving empty scope");
+                        // An empty scope: a fresh consumer cursor over a prefix
+                        // with no broadcasts. Re-scope to a sentinel under the
+                        // tenant so the peer sees nothing it isn't entitled to.
+                        // Falling through to a clone would leak cross-tenant
+                        // names, so we instead drop the session.
+                        return Ok(());
+                    }
+                }
+            }
+            None => self.inner.origin.consumer.clone(),
+        };
+
+        // NOTE (#276 subscribe-authz seam): `moq_net::Server` exposes no
+        // per-subscribe callback, so we cannot gate individual `subscribe_track`
+        // calls in-band. The public/private decision is therefore enforced
+        // *structurally* by what the served consumer can see (tenant scoping
+        // above). The pluggable `SubscribeAuthorizer` is retained as the policy
+        // unit a richer moq-net (one that surfaces a subscribe hook) would call;
+        // it is exercised by unit tests in `crate::moq_authz`. Until moq-net
+        // grows that hook, private-vs-public must be expressed as scoping (e.g.
+        // a private broadcast lives under a prefix only entitled peers' tenant
+        // scope includes).
+        let _authorizer = self.inner.authz.authorizer.as_ref();
+
         let session = Session::raw(conn);
         let server = Server::new()
-            .with_publish(self.inner.origin.consumer.clone())
+            .with_publish(publish_consumer)
             // Subscribe slot is None for v1 — we only serve broadcasts;
             // accepting remote announces (cross-instance fan-out) lands
             // in Phase 3 part N (#142).
@@ -257,6 +356,83 @@ mod tests {
         .await??
         .ok_or_else(|| anyhow::anyhow!("read_frame returned None"))?;
         assert_eq!(&frame[..], b"hello-moq");
+
+        client.shutdown().await?;
+        server.shutdown().await?;
+        Ok(())
+    }
+
+    /// #276 live per-tenant announce scoping over the iroh `moql` path: the
+    /// server publishes broadcasts for two tenants but the accept path scopes
+    /// every connection to `bob/` (via the tenant resolver). A remote subscriber
+    /// must see `bob`'s broadcast and must NOT be able to reach `alice`'s.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn iroh_moq_scopes_announces_to_connection_tenant() -> anyhow::Result<()> {
+        // `MoqAuthzConfig` is defined in this module (`super`).
+        // Server scoped so EVERY peer is treated as tenant "bob".
+        let authz = MoqAuthzConfig {
+            authorizer: None,
+            tenant_resolver: Some(Arc::new(|_peer| Some("bob".to_owned()))),
+        };
+        let handler = IrohMoqProtocolHandler::new().with_authz(authz);
+        let producer = handler.origin_producer().clone();
+        let server = IrohSubstrate::new(fresh_key(), handler, NoopHandler::new("rpc-not-wired")).await?;
+        let server_addr = direct_addr(&server);
+
+        // Publish one broadcast per tenant.
+        let mut alice_bc = producer
+            .create_broadcast("alice/streams/secret/i0")
+            .ok_or_else(|| anyhow::anyhow!("create alice broadcast"))?;
+        let mut alice_tr = alice_bc.create_track(Track::new("tokens"))?;
+        let mut alice_g = alice_tr.create_group(Group::from(0u64))?;
+        alice_g.write_frame(Bytes::from_static(b"alice-secret"))?;
+        drop(alice_g);
+
+        let mut bob_bc = producer
+            .create_broadcast("bob/streams/run-1/i0")
+            .ok_or_else(|| anyhow::anyhow!("create bob broadcast"))?;
+        let mut bob_tr = bob_bc.create_track(Track::new("tokens"))?;
+        let mut bob_g = bob_tr.create_group(Group::from(0u64))?;
+        bob_g.write_frame(Bytes::from_static(b"bob-data"))?;
+        drop(bob_g);
+
+        // Client connects; the accept path scopes its consumer to bob/.
+        let client =
+            IrohSubstrate::new(fresh_key(), NoopHandler::new("c-moq"), NoopHandler::new("c-rpc")).await?;
+        let conn = client.connect(server_addr, ALPN_MOQ_LITE).await?;
+        let session = Session::raw(conn);
+        let client_origin: OriginProducer = Origin::random().produce();
+        let client_consumer: OriginConsumer = client_origin.consume();
+        let moq_client = Client::new().with_consume(client_origin);
+        let _moq_session = moq_client.connect(session).await?;
+
+        // bob/ is visible: subscribe and read its frame.
+        let bob_consumer = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            client_consumer.announced_broadcast("bob/streams/run-1/i0"),
+        )
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("bob broadcast not announced"))?;
+        let mut bob_track = bob_consumer.subscribe_track(&Track::new("tokens"))?;
+        let mut bob_group = tokio::time::timeout(std::time::Duration::from_secs(5), bob_track.next_group())
+            .await??
+            .ok_or_else(|| anyhow::anyhow!("bob next_group None"))?;
+        let bob_frame: Bytes = tokio::time::timeout(std::time::Duration::from_secs(5), bob_group.read_frame())
+            .await??
+            .ok_or_else(|| anyhow::anyhow!("bob read_frame None"))?;
+        assert_eq!(&bob_frame[..], b"bob-data");
+
+        // alice/ is NOT visible to this bob-scoped subscriber: the announce
+        // must never arrive (timeout → not announced through the scoped cursor).
+        let alice_seen = tokio::time::timeout(
+            std::time::Duration::from_millis(750),
+            client_consumer.announced_broadcast("alice/streams/secret/i0"),
+        )
+        .await;
+        assert!(
+            alice_seen.is_err() || alice_seen.ok().flatten().is_none(),
+            "bob-scoped subscriber must NOT see alice's broadcast"
+        );
 
         client.shutdown().await?;
         server.shutdown().await?;

--- a/crates/hyprstream-rpc/src/transport/quinn_transport.rs
+++ b/crates/hyprstream-rpc/src/transport/quinn_transport.rs
@@ -58,6 +58,9 @@ pub struct QuinnRpcServer {
     /// WebTransport CONNECT URL path is [`crate::dial::MOQ_PATH`] are handed to
     /// `moq_net::Server::accept` instead of the RPC core. `None` = RPC only.
     moq_consumer: Option<moq_net::OriginConsumer>,
+    /// #276 subscribe-authz + per-tenant announce-scoping config for the `/moq`
+    /// plane. Defaults to "off" (open subscribe preserved).
+    moq_authz: crate::transport::iroh_moq::MoqAuthzConfig,
     shutdown: CancellationToken,
 }
 
@@ -90,6 +93,7 @@ impl QuinnRpcServer {
             )),
             read_timeout: super::rpc_session::REQUEST_READ_TIMEOUT,
             moq_consumer: None,
+            moq_authz: crate::transport::iroh_moq::MoqAuthzConfig::default(),
             shutdown: CancellationToken::new(),
         }
     }
@@ -103,6 +107,26 @@ impl QuinnRpcServer {
     /// over a per-connection iroh ALPN — here the multiplex is by URL path.
     pub fn with_moq_consumer(mut self, consumer: moq_net::OriginConsumer) -> Self {
         self.moq_consumer = Some(consumer);
+        self
+    }
+
+    /// Install the #276 subscribe-authz + per-tenant announce-scoping config for
+    /// the `/moq` plane.
+    ///
+    /// **Identity caveat (documented seam):** the WebTransport `/moq` CONNECT is
+    /// *not* mutually authenticated — the server presents a pinned cert, but the
+    /// client is anonymous at the TLS layer. So the `tenant_resolver` is invoked
+    /// with [`crate::moq_authz::PeerIdentity::anonymous`]; per-tenant scoping on
+    /// this path is only effective if the resolver returns a tenant from
+    /// non-identity context (e.g. a single-tenant endpoint), and a policy-gated
+    /// authorizer will deny *private* subscribes here (fail-closed) while public
+    /// broadcasts stay open. Cross-tenant enumeration defense for authenticated
+    /// peers lives on the iroh `moql` path.
+    pub fn with_moq_authz(
+        mut self,
+        authz: crate::transport::iroh_moq::MoqAuthzConfig,
+    ) -> Self {
+        self.moq_authz = authz;
         self
     }
 
@@ -231,6 +255,7 @@ impl QuinnRpcServer {
                     let read_timeout = self.read_timeout;
                     let shutdown = self.shutdown.clone();
                     let moq_consumer = self.moq_consumer.clone();
+                    let moq_authz = self.moq_authz.clone();
                     tokio::spawn(async move {
                         let _conn_permit = conn_permit; // released when this connection ends
                         // Multiplex by WebTransport CONNECT URL path (#274): read
@@ -263,10 +288,42 @@ impl QuinnRpcServer {
                         if is_moq {
                             match moq_consumer {
                                 Some(consumer) => {
+                                    // #276: the `/moq` WebTransport CONNECT is NOT
+                                    // mutually authenticated, so no peer identity
+                                    // is available — treat the peer as anonymous.
+                                    let peer = crate::moq_authz::PeerIdentity::anonymous();
+                                    // Per-tenant announce scoping: only effective
+                                    // if the resolver yields a tenant from
+                                    // non-identity context (e.g. a single-tenant
+                                    // endpoint). With no resolver, serve unscoped
+                                    // (preserves the pre-#276 open model).
+                                    // TODO(#276): when the `/moq` plane gains a
+                                    // mutually-authenticated peer identity (client
+                                    // cert / app-level token), derive the tenant
+                                    // from it here instead of `anonymous()` so
+                                    // cross-tenant enumeration defense applies to
+                                    // network subscribers, not just iroh peers.
+                                    let publish_consumer = match moq_authz.tenant_for(&peer) {
+                                        Some(tenant) => {
+                                            match crate::moq_authz::tenant_scoped_consumer(&consumer, &tenant) {
+                                                Some(scoped) => scoped,
+                                                None => {
+                                                    tracing::debug!(%tenant, "quinn-moq: tenant has no visible broadcasts; dropping session");
+                                                    return;
+                                                }
+                                            }
+                                        }
+                                        None => consumer,
+                                    };
+                                    // See iroh_moq::accept for why the authorizer
+                                    // is not enforced per-track here (moq-net has
+                                    // no subscribe callback); structural scoping
+                                    // is the live enforcement.
+                                    let _authorizer = moq_authz.authorizer.as_ref();
                                     // Serve moq over this session, mirroring
                                     // IrohMoqProtocolHandler: publish the shared
                                     // origin consumer to remote subscribers.
-                                    let server = moq_net::Server::new().with_publish(consumer);
+                                    let server = moq_net::Server::new().with_publish(publish_consumer);
                                     match server.accept(session).await {
                                         Ok(moq_session) => {
                                             // Hold the session until it closes or

--- a/crates/hyprstream-service/src/service/spawner/service.rs
+++ b/crates/hyprstream-service/src/service/spawner/service.rs
@@ -112,6 +112,29 @@ impl<S: RequestService + Send + Sync + 'static> Spawnable for UnifiedServiceConf
                 // Multiplex moq on the same endpoint when the global origin is up.
                 if let Some(origin) = hyprstream_rpc::moq_stream::global_moq_origin() {
                     rpc_server = rpc_server.with_moq_consumer(origin.consumer().clone());
+                    // #276: subscribe-authz + per-tenant announce scoping. The
+                    // default config is permissive (no resolver, no authorizer)
+                    // so the working open same-tenant subscribe model is
+                    // preserved. A deployment opts into per-tenant scoping /
+                    // private-stream gating by building a
+                    // `hyprstream_rpc::transport::iroh_moq::MoqAuthzConfig` with
+                    // a `tenant_resolver` and a `DefaultAuthorizer` whose policy
+                    // gate calls into the Casbin `PolicyManager`
+                    // (`hyprstream::auth::policy_manager::global_policy_manager()`
+                    // -> `check_with_domain(subject, tenant, broadcast, "subscribe")`).
+                    // That gate is constructed in the `hyprstream` crate (which
+                    // owns PolicyManager) and threaded down via the service
+                    // factory; wiring it here would create a `hyprstream-service`
+                    // -> `hyprstream` dependency cycle, so it is left as a seam.
+                    // TODO(#276): thread a `MoqAuthzConfig` through the service
+                    // factory (built in the `hyprstream` crate) and call
+                    // `.with_moq_authz(cfg)` here. NOTE: on this quinn `/moq`
+                    // path the peer is anonymous (no mutual TLS), so the
+                    // resolver/gate sees `PeerIdentity::anonymous()` — full
+                    // per-peer enforcement requires the iroh `moql` path, where
+                    // `with_authz` is already honoured.
+                    let _moq_authz_default =
+                        hyprstream_rpc::transport::iroh_moq::MoqAuthzConfig::default();
                 }
 
                 // Register this endpoint for RPC resolution and, once, as the


### PR DESCRIPTION
#274 moved the moq open-subscribe surface to the network. Content is already
protected (DH-derived capability topic + per-frame chained HMAC); #276 adds the
metadata defense-in-depth the issue asks for: gate who may subscribe + stop a
connected peer from announce-enumerating other tenants' broadcast names.

Key constraint (reported, not worked around): moq-net 0.1.8 exposes NO per-subscribe
callback — authorization is STRUCTURAL. A session can only enumerate/subscribe to
broadcasts visible through the OriginConsumer it is served; OriginConsumer::scope
narrows that by path prefix. So per-tenant scoping == hand each session a
tenant-scoped consumer, and a subscriber that cannot see a broadcast cannot
subscribe to it.

- moq_authz.rs (new, hyprstream-rpc, native-only): tenant_of / tenant_prefix /
  filter_announces_by_tenant (pure, exact-segment match — no alice/alice2 bleed);
  tenant_scoped_consumer (live OriginConsumer::scope); Visibility / SubscribeDecision
  / PeerIdentity / SubscribeAuthorizer trait + DefaultAuthorizer (public-open,
  private-policy-gated, fail-closed when private with no gate); VisibilityFn/PolicyGate
  aliases for the Casbin gate. 13 unit tests.
- transport/iroh_moq.rs: MoqAuthzConfig + PeerTenantResolver + with_authz; the
  accept path derives PeerIdentity from the authenticated Connection::remote_id()
  (EndpointId) and serves a tenant-scoped consumer (fail-closed if no scope).
  Live integration test over real iroh: a bob-scoped subscriber reads bob's
  broadcast and times out on alice's.
- transport/quinn_transport.rs: with_moq_authz + anonymous-peer scoping in the
  /moq run loop. The WebTransport CONNECT is not mutually authenticated (server
  cert pinned, client anonymous at TLS), so per-peer enforcement requires the iroh
  path; scoping still applies when the resolver yields a tenant from non-identity
  context (e.g. single-tenant endpoint). Documented.

Seams (documented // TODO(#276)): (1) per-track public/private is not enforced
in-band (no moq-net subscribe hook) — SubscribeAuthorizer is a tested policy unit
ready for a future hook; today public/private is expressed via scoping. (2) The
service spawner cannot reach PolicyManager (hyprstream) without a dependency cycle,
so it installs the permissive default and documents where a hyprstream-built
MoqAuthzConfig (Casbin gate via global_policy_manager) threads in. Defaults
preserve the working open same-tenant model. Casbin reuse: PolicyManager::
check_with_domain via global_policy_manager().

Tests: 15 new (public→allowed incl anonymous; private+authorized→allowed;
private+unauthorized→rejected; private+no-gate→fail-closed; tenant isolation via
pure filter + live moq-net scope + live iroh wire; segment-exact no prefix bleed).
Native + wasm32 build clean (native-gated); clippy clean; hyprstream-rpc 390 pass
(1 known moq_event flake); networked /moq integration test still passes.

Issue #276. Part of epic #131.
