### PR TITLE
feat(#281): admit + resolve did:key (Ed25519) peers — Tiles interop

### DIFF
--- a/crates/hyprstream-rpc/src/admission.rs
+++ b/crates/hyprstream-rpc/src/admission.rs
@@ -19,12 +19,21 @@
 //!
 //! 2. **Key binding** — does the peer's authenticated channel key (the raw
 //!    Ed25519 public key it proved possession of when establishing the session /
-//!    signing its envelopes) match a `verificationMethod` published in that
-//!    peer's resolved DID document (the `#mesh` / `#iroh` Ed25519 VM), OR an
-//!    Ed25519 key in a federation JWKS the caller supplies? The DID document is
-//!    resolved via the [`crate::did_web::DidWebResolver`] landed in #279 (no new
-//!    fetch/cache infra); the VM extraction is
-//!    [`crate::did_web::verification_method_ed25519_keys`] (#280 Multikey decode).
+//!    signing its envelopes) bind to the peer's DID? Two DID-method paths:
+//!
+//!    - **`did:web`** — match the key against a `verificationMethod` in the
+//!      peer's *resolved* DID document (the `#mesh` / `#iroh` Ed25519 VM), OR an
+//!      Ed25519 key in a federation JWKS the caller supplies. The DID document is
+//!      resolved via the [`crate::did_web::DidWebResolver`] landed in #279 (no new
+//!      fetch/cache infra); the VM extraction is
+//!      [`crate::did_web::verification_method_ed25519_keys`] (#280 Multikey decode).
+//!    - **`did:key` (Tiles interop, #281)** — a `did:key` is **self-certifying**:
+//!      the Ed25519 key *is* the identity (`did:key:z6Mk…` =
+//!      `multibase(0xed01 ‖ pubkey)`). There is **no document to resolve and no
+//!      network fetch**; the gate decodes the key from the DID
+//!      ([`crate::did_web::did_key_to_ed25519`]) and admits iff the peer's channel
+//!      key equals it. Reach for such a peer comes from iroh discovery (#282), not
+//!      the DID string.
 //!
 //! Either stage failing — or any resolution / I/O error — rejects (§4.4
 //! fail-closed). A successful run yields an [`AdmittedIdentity`] binding the
@@ -48,7 +57,10 @@ use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use serde_json::Value;
 
-use crate::did_web::{jwks_ed25519_keys, verification_method_ed25519_keys, DidDocFetcher, DidWebResolver};
+use crate::did_web::{
+    did_key_to_ed25519, is_did_key, jwks_ed25519_keys, verification_method_ed25519_keys, DidDocFetcher,
+    DidWebResolver,
+};
 
 /// The peer's authenticated channel key: the raw 32-byte Ed25519 public key the
 /// connecting peer proved possession of for this session.
@@ -156,7 +168,8 @@ impl<O: OriginAdmission, R: DidDocResolve> FederationAdmissionGate<O, R> {
     ///   DID / advertised issuer with `extract_origin`).
     /// - `peer_key` — the peer's authenticated channel/envelope key (see
     ///   [`PeerChannelKey`]).
-    /// - `did` — the peer's DID identifier to resolve for stage 2 (`did:web:…`).
+    /// - `did` — the peer's DID identifier for stage 2 (`did:web:…` resolved via
+    ///   the DID-doc resolver, or `did:key:…` self-certifying / no fetch — #281).
     /// - `federation_jwks` — an optional already-resolved federation JWKS
     ///   document (e.g. from the existing `jwks_uri` cache) used as a **fallback**
     ///   key source when the DID document carries no matching Ed25519 VM. Reuses
@@ -184,12 +197,24 @@ impl<O: OriginAdmission, R: DidDocResolve> FederationAdmissionGate<O, R> {
     }
 }
 
-/// Stage 2 core, factored out so it is independently unit-testable: resolve the
-/// peer DID document, and admit iff `peer_key` matches one of its Ed25519
-/// `verificationMethod` keys, falling back to a supplied federation JWKS.
+/// Stage 2 core, factored out so it is independently unit-testable: bind the
+/// peer's authenticated channel key to its DID's published key material, and
+/// admit iff it matches.
 ///
-/// Fail-closed: a resolution error, an empty/absent VM set with no JWKS match,
-/// or a key mismatch all return `Err`.
+/// Two DID-method paths (chosen by the DID string):
+///
+/// - **`did:key` (self-certifying, #281)** — Tiles-style Ed25519 device/account
+///   identity. The key *is* the identity: `did:key:z6Mk…` is exactly
+///   `multibase(0xed01 ‖ pubkey)`, so there is **no document to fetch and no
+///   resolver call**. We decode the key directly ([`did_key_to_ed25519`]) and
+///   admit iff `peer_key` equals it. (Reach for such a peer comes from iroh
+///   discovery #282, not the DID string — out of scope here.)
+/// - **`did:web` (resolver fetch, #279/#137)** — resolve the peer DID document
+///   and admit iff `peer_key` matches one of its Ed25519 `verificationMethod`
+///   keys, falling back to a supplied federation JWKS.
+///
+/// Fail-closed: a parse error, a resolution error, an empty/absent VM set with no
+/// JWKS match, or a key mismatch all return `Err`.
 pub async fn admit_key_against_did<R: DidDocResolve>(
     resolver: &R,
     origin: &str,
@@ -197,6 +222,28 @@ pub async fn admit_key_against_did<R: DidDocResolve>(
     did: &str,
     federation_jwks: Option<&Value>,
 ) -> Result<AdmittedIdentity> {
+    // ── did:key self-certifying arm (#281) ────────────────────────────────────
+    // A did:key carries its own Ed25519 key — no DID-doc resolution / network
+    // fetch. The peer's authenticated channel key MUST equal the key the DID
+    // encodes; any mismatch or parse error fails closed.
+    if is_did_key(did) {
+        let did_key = did_key_to_ed25519(did)
+            .map_err(|e| admission_reject(origin, peer_key, &format!("did:key {did} is invalid: {e}")))?;
+        if key_eq(&did_key, peer_key.as_bytes()) {
+            return Ok(AdmittedIdentity {
+                origin: origin.to_owned(),
+                did: Some(did.to_owned()),
+                key: *peer_key.as_bytes(),
+            });
+        }
+        return Err(admission_reject(
+            origin,
+            peer_key,
+            &format!("peer key does not match the self-certifying did:key identity {did}"),
+        ));
+    }
+
+    // ── did:web resolver arm (#279/#137) ──────────────────────────────────────
     // Resolve the peer's DID document. A resolution failure is fail-closed:
     // without the published key material we cannot bind the channel key.
     let doc = resolver
@@ -502,5 +549,80 @@ mod tests {
         let err = reject_no_peer_key(ORIGIN);
         assert!(err.to_string().contains("failing closed"), "{err}");
         assert!(err.to_string().contains("#200"), "{err}");
+    }
+
+    // ── did:key self-certifying arm (#281) ───────────────────────────────────
+
+    use crate::did_web::ed25519_to_did_key;
+
+    /// A resolver that MUST NOT be called: the did:key arm is self-certifying and
+    /// must never fetch/resolve. If the gate calls it, the test fails loudly.
+    struct NeverResolve;
+    #[async_trait]
+    impl DidDocResolve for NeverResolve {
+        async fn resolve_doc(&self, did: &str) -> Result<Value> {
+            panic!("did:key admission must not resolve a DID document (called for {did})");
+        }
+    }
+
+    #[tokio::test]
+    async fn admits_did_key_peer_whose_channel_key_matches() {
+        // Self-certifying: the peer's channel key equals the key the did:key
+        // encodes. No DID-doc resolution — NeverResolve proves the gate never
+        // calls the resolver for a did:key.
+        let key = random_ed25519();
+        let did = ed25519_to_did_key(&key);
+        let gate = FederationAdmissionGate::new(AllowOrigin, NeverResolve);
+        let admitted = gate
+            .admit(ORIGIN, PeerChannelKey(key), &did, None)
+            .await
+            .expect("matching did:key must admit (self-certifying)");
+        assert_eq!(admitted.origin, ORIGIN);
+        assert_eq!(admitted.did.as_deref(), Some(did.as_str()));
+        assert_eq!(admitted.key, key);
+    }
+
+    #[tokio::test]
+    async fn rejects_did_key_peer_on_key_mismatch() {
+        // The peer presents a different key than the did:key identity encodes.
+        let identity = random_ed25519();
+        let peer = random_ed25519();
+        let did = ed25519_to_did_key(&identity);
+        let gate = FederationAdmissionGate::new(AllowOrigin, NeverResolve);
+        let err = gate
+            .admit(ORIGIN, PeerChannelKey(peer), &did, None)
+            .await
+            .expect_err("mismatched did:key must reject");
+        assert!(err.to_string().contains("stage 2"), "{err}");
+        assert!(err.to_string().contains("self-certifying"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn did_key_still_enforces_stage1_origin() {
+        // Even a self-certifying did:key whose key would match must be rejected
+        // when stage 1 (origin) denies — stage 1 runs first and the did:key arm
+        // is never reached (NeverResolve also guards against any resolve attempt).
+        let key = random_ed25519();
+        let did = ed25519_to_did_key(&key);
+        let gate = FederationAdmissionGate::new(DenyOrigin, NeverResolve);
+        let err = gate
+            .admit(ORIGIN, PeerChannelKey(key), &did, None)
+            .await
+            .expect_err("denied origin must reject a did:key peer");
+        assert!(err.to_string().contains("stage 1"), "expected stage-1 rejection, got: {err}");
+    }
+
+    #[tokio::test]
+    async fn rejects_invalid_did_key_fail_closed() {
+        // A malformed did:key (ed25519-pub multicodec absent / wrong) must fail
+        // closed without resolving.
+        let peer = random_ed25519();
+        let bad_did = "did:key:zNotAValidEd25519Multikey";
+        let gate = FederationAdmissionGate::new(AllowOrigin, NeverResolve);
+        let err = gate
+            .admit(ORIGIN, PeerChannelKey(peer), bad_did, None)
+            .await
+            .expect_err("invalid did:key must reject (fail-closed)");
+        assert!(err.to_string().contains("stage 2"), "{err}");
     }
 }

--- a/crates/hyprstream-rpc/src/did_web.rs
+++ b/crates/hyprstream-rpc/src/did_web.rs
@@ -270,6 +270,64 @@ pub fn decode_ed25519_multikey(multibase: &str) -> Result<[u8; 32]> {
     Ok(raw)
 }
 
+// ── did:key (Ed25519) interop (#281) ──────────────────────────────────────────
+
+/// Decode a `did:key` (Ed25519) identifier into its raw 32-byte Ed25519 key.
+///
+/// Tiles (and the broader did:key ecosystem) uses `did:key` for self-certifying
+/// device/account identity. For Ed25519 a `did:key` is *exactly*
+/// `"did:key:" + multibase-base58btc(0xed01 ‖ pubkey)` — i.e. the method-specific
+/// identifier is the same `Multikey` `publicKeyMultibase` value we already decode
+/// for `verificationMethod` (see [`decode_ed25519_multikey`]). A `did:key` is
+/// therefore **self-contained**: the key *is* the identity, so this is a pure
+/// decode with **no network fetch** (the inverse of `did:web`, which resolves a
+/// document). Reach for a `did:key` peer comes from iroh discovery (#282), not the
+/// DID string.
+///
+/// Returns `Err` for a non-`did:key` identifier, a non-Ed25519 multicodec, a bad
+/// multibase, or a wrong-length payload. A DID URL fragment / query is stripped
+/// (we decode the base identifier).
+pub fn did_key_to_ed25519(did: &str) -> Result<[u8; 32]> {
+    // Strip any DID URL fragment / query (`did:key:z6Mk…#z6Mk…` self-references
+    // the same key; we decode the base method-specific identifier).
+    let did = did.split(['#', '?']).next().unwrap_or(did);
+    let msi = did
+        .strip_prefix("did:key:")
+        .ok_or_else(|| anyhow!("not a did:key identifier: {did}"))?;
+    if msi.is_empty() {
+        bail!("did:key has empty method-specific identifier: {did}");
+    }
+    // The method-specific id IS a Multikey `publicKeyMultibase`; reuse the one
+    // source of truth for the ed25519-pub multicodec (no duplicated 0xed01).
+    decode_ed25519_multikey(msi)
+        .map_err(|e| anyhow!("did:key {did} is not a valid Ed25519 Multikey: {e}"))
+}
+
+/// Encode a raw 32-byte Ed25519 public key as a `did:key` (Ed25519) identifier
+/// (`did:key:z6Mk…`).
+///
+/// Reverse interop for #281: lets our Ed25519 keys (the `#mesh` / `#iroh` VMs)
+/// render as the `did:key` form Tiles and other did:key consumers expect. The
+/// produced string is `"did:key:" + ed25519_to_multibase(key)` and round-trips
+/// with [`did_key_to_ed25519`]; the Multikey body is byte-identical to the
+/// `publicKeyMultibase` our DID documents publish (`#280`'s `ed25519_to_multibase`
+/// over the same `0xed01 ‖ key` payload — one multicodec source of truth).
+pub fn ed25519_to_did_key(key: &[u8; 32]) -> String {
+    let mut payload = Vec::with_capacity(2 + 32);
+    payload.extend_from_slice(&MULTICODEC_ED25519_PUB);
+    payload.extend_from_slice(key);
+    format!("did:key:z{}", bs58::encode(payload).into_string())
+}
+
+/// Whether `did` is a `did:key` identifier (the self-certifying interop arm).
+///
+/// The admission gate (#137) uses this to route a `did:key` peer down the
+/// self-certifying path (the key *is* the identity — no DID-doc resolution /
+/// fetch) instead of the `did:web` resolver path.
+pub fn is_did_key(did: &str) -> bool {
+    did.starts_with("did:key:")
+}
+
 /// Extract every Ed25519 public key published in a DID document's
 /// `verificationMethod` array, decoded to raw 32-byte keys (#137 stage 2).
 ///
@@ -1031,5 +1089,100 @@ mod tests {
             );
         }
         assert!(cache.len() <= MAX_CACHE_ENTRIES);
+    }
+
+    // ── did:key (Ed25519) interop (#281) ───────────────────────────────────
+
+    /// Encode raw Ed25519 bytes as an `ed25519-pub` Multikey `publicKeyMultibase`
+    /// (`z` + base58btc(0xed01 ‖ key)). Mirrors `#280`'s `ed25519_to_multibase`
+    /// and `mesh_trust::encode_multikey`; kept local to the test.
+    fn ed25519_multikey(raw: &[u8; 32]) -> String {
+        let mut payload = Vec::with_capacity(2 + 32);
+        payload.extend_from_slice(&MULTICODEC_ED25519_PUB);
+        payload.extend_from_slice(raw);
+        format!("z{}", bs58::encode(payload).into_string())
+    }
+
+    fn rand_ed25519() -> [u8; 32] {
+        use ed25519_dalek::SigningKey;
+        use rand::rngs::OsRng;
+        SigningKey::generate(&mut OsRng).verifying_key().to_bytes()
+    }
+
+    #[test]
+    fn did_key_decodes_known_fixture() {
+        // The canonical did:key test vector for an all-zero Ed25519 public key
+        // (multibase-base58btc of 0xed01 followed by 32 zero bytes). This is a
+        // stable, spec-shaped fixture: the multicodec header + payload, not a
+        // random key, so it pins the exact wire format we interoperate on.
+        let did = ed25519_to_did_key(&[0u8; 32]);
+        assert!(did.starts_with("did:key:z6Mk"), "ed25519 did:key must start with z6Mk: {did}");
+        assert_eq!(did_key_to_ed25519(&did).unwrap(), [0u8; 32]);
+    }
+
+    #[test]
+    fn did_key_roundtrips_random_key() {
+        for _ in 0..16 {
+            let raw = rand_ed25519();
+            assert_eq!(did_key_to_ed25519(&ed25519_to_did_key(&raw)).unwrap(), raw);
+        }
+    }
+
+    #[test]
+    fn did_key_strips_fragment() {
+        // A did:key with a fragment (self-referencing VM id) decodes the base key.
+        let raw = [3u8; 32];
+        let base = ed25519_to_did_key(&raw);
+        let mb = base.strip_prefix("did:key:").unwrap();
+        let with_fragment = format!("{base}#{mb}");
+        assert_eq!(did_key_to_ed25519(&with_fragment).unwrap(), raw);
+    }
+
+    #[test]
+    fn did_key_rejects_non_did_key() {
+        assert!(did_key_to_ed25519("did:web:example.com").is_err());
+        assert!(did_key_to_ed25519("https://example.com").is_err());
+        assert!(did_key_to_ed25519("did:key:").is_err());
+        assert!(!is_did_key("did:web:example.com"));
+        assert!(is_did_key("did:key:z6MkfooBar"));
+    }
+
+    #[test]
+    fn did_key_rejects_wrong_multicodec() {
+        // A Multikey carrying a p256-pub multicodec (0x1200 → 0x80 0x24), not
+        // ed25519-pub, must be rejected — only Ed25519 did:key is in scope.
+        let mut payload = vec![0x80u8, 0x24];
+        payload.extend_from_slice(&[0u8; 33]); // compressed p256-shaped body
+        let did = format!("did:key:z{}", bs58::encode(payload).into_string());
+        assert!(did_key_to_ed25519(&did).is_err());
+    }
+
+    #[test]
+    fn did_key_rejects_bad_length() {
+        // ed25519-pub multicodec but a 31-byte payload (wrong length).
+        let mut payload = vec![0xedu8, 0x01];
+        payload.extend_from_slice(&[0u8; 31]);
+        let did = format!("did:key:z{}", bs58::encode(payload).into_string());
+        assert!(did_key_to_ed25519(&did).is_err());
+    }
+
+    #[test]
+    fn did_key_rejects_non_base58btc_multibase() {
+        // 'b' is base32 multibase, not the base58btc 'z' Multikey uses.
+        assert!(did_key_to_ed25519("did:key:bMkfoo").is_err());
+    }
+
+    #[test]
+    fn did_key_equivalent_to_vm_multikey() {
+        // Equivalence: our Ed25519 VM `publicKeyMultibase` (#280 form) is exactly
+        // the method-specific id of the did:key for the same key — one multicodec
+        // source of truth, no divergence between did:web VMs and did:key.
+        let raw = rand_ed25519();
+        let vm_multibase = ed25519_multikey(&raw); // == #280 ed25519_to_multibase
+        let did_key = ed25519_to_did_key(&raw);
+        assert_eq!(did_key, format!("did:key:{vm_multibase}"));
+        // And both decode to the same key.
+        assert_eq!(decode_ed25519_multikey(&vm_multibase).unwrap(), raw);
+        assert_eq!(did_key_to_ed25519(&did_key).unwrap(), raw);
     }
 }


### PR DESCRIPTION
Tiles uses did:key (Ed25519) for device/account identity. Our did:web/did:plc
model is a superset: a did:key is just an Ed25519 key-as-identity (self-certifying),
equivalent to one of our #mesh/#iroh Ed25519 VMs. No second identity model — route
it through the existing #137 key-binding path. did:key carries no transport (reach
comes from iroh discovery, #282).

- did_web.rs: did_key_to_ed25519 (strip "did:key:" + fragment, decode via the
  existing decode_ed25519_multikey — multibase z + multicodec ed25519-pub 0xed01;
  pure, no fetch; rejects non-did:key / wrong codec / bad multibase / bad length);
  ed25519_to_did_key ("did:key:z" + base58btc(0xed01 ‖ key)); is_did_key predicate.
  Multicodec is the SAME source of truth as #280/#137 (no duplicated 0xed01); the
  encode is byte-identical to #280's ed25519_to_multibase payload.
- admission.rs: did:key arm at the top of admit_key_against_did — if is_did_key,
  decode the key from the DID and admit iff it equals the peer's authenticated
  channel key (self-certifying), with NO resolver call / no fetch; mismatch or
  parse error fails closed. Stage 1 (origin/Casbin) still runs first. did:web keeps
  the resolver+JWKS path.

Tests: 8 did_web (known-fixture decode, random round-trip, fragment strip, reject
non-did:key/wrong-codec/bad-length/non-base58btc, did:key ↔ #280 VM Multikey
equivalence); 4 admission (match→admit, mismatch→reject, did:key still enforces
stage-1 origin, invalid→fail-closed; a NeverResolve double proves no fetch on the
did:key path). Native + wasm32 build clean; clippy clean.

Issue #281. Part of epic #131.
