### PR TITLE
feat(#282): activate iroh substrate + pkarr discovery; wire #137 gate into iroh accept

### DIFF
--- a/crates/hyprstream-rpc/src/dial.rs
+++ b/crates/hyprstream-rpc/src/dial.rs
@@ -220,6 +220,35 @@ where
 /// streaming plane (default path → RPC). Both server and client use this.
 pub const MOQ_PATH: &str = "/moq";
 
+/// A dialed moq streaming session, erased over the concrete transport.
+///
+/// [`dial_stream`] returns this so a caller can dial the streaming plane over
+/// either quinn/WebTransport (`/moq` path-dispatch) **or** iroh (the `moql`
+/// ALPN) and hand the result straight to `moq_net::Client::connect`, which is
+/// generic over `web_transport_trait::Session`. The two underlying session
+/// types (`web_transport_quinn::Session` / `web_transport_iroh::Session`) do not
+/// share a concrete type, so this enum dispatches at the `connect` call.
+pub enum MoqStreamSession {
+    /// quinn / WebTransport `/moq` session (#274).
+    Quinn(web_transport_quinn::Session),
+    /// iroh `moql`-ALPN session (#282).
+    Iroh(web_transport_iroh::Session),
+}
+
+impl MoqStreamSession {
+    /// Run the moq-lite handshake over this session, returning the live
+    /// `moq_net::Session`. Dispatches to the concrete transport's `connect`.
+    pub async fn connect_moq(
+        self,
+        client: &moq_net::Client,
+    ) -> std::result::Result<moq_net::Session, moq_net::Error> {
+        match self {
+            MoqStreamSession::Quinn(s) => client.connect(s).await,
+            MoqStreamSession::Iroh(s) => client.connect(s).await,
+        }
+    }
+}
+
 /// Dial the moq streaming plane for a network-routable reach, returning a live
 /// [`web_transport_quinn::Session`] (#274).
 ///
@@ -234,7 +263,7 @@ pub const MOQ_PATH: &str = "/moq";
 /// the same-host UDS fast path instead of dialing.
 pub async fn dial_stream(
     target: &TransportConfig,
-) -> Result<web_transport_quinn::Session> {
+) -> Result<MoqStreamSession> {
     use crate::transport::quinn_transport::{
         connect_pinned_hashes_path, connect_webpki_path, verify_peer_cert_pinned,
     };
@@ -256,13 +285,33 @@ pub async fn dial_stream(
                 }
                 connect_pinned_hashes_path(*addr, pins, MOQ_PATH).await?
             };
-            Ok(session)
+            Ok(MoqStreamSession::Quinn(session))
         }
-        EndpointType::Iroh { .. } => {
+        EndpointType::Iroh { direct_addrs, relay_url, .. }
+            if direct_addrs.is_empty() && relay_url.is_none() =>
+        {
+            // No reachability supplied → fail fast rather than hand iroh a bare
+            // EndpointId that falls through to discovery and times out (~10-30s).
+            // (Dial-by-node_id-alone via pkarr/DNS discovery is available on the
+            // shared endpoint, but the resolver is expected to supply at least a
+            // relay; see #282 pkarr seam.)
             bail!(
-                "dial_stream(): iroh streaming reach is not yet supported — \
-                 the reach list should carry a Quic/WebTransport option"
+                "dial_stream(): iroh streaming reach has neither direct addrs nor a \
+                 relay URL — not dialable; the resolver must supply reachability"
             )
+        }
+        EndpointType::Iroh { node_id, direct_addrs, relay_url } => {
+            // #282: dial the iroh `moql` ALPN from the shared process-wide client
+            // endpoint (the SAME endpoint the daemon's inbound iroh substrate
+            // listens on, installed once at startup), then wrap the authenticated
+            // iroh Connection as a `web_transport_iroh::Session` for moq-net.
+            //
+            // iroh binds the connection to the peer's EndpointId (its Ed25519
+            // pubkey), so the channel is identity-bound (stronger than quinn's
+            // cert-hash pin); the per-Frame chained-HMAC envelope (§7.5) remains
+            // the application-layer integrity check the subscriber verifies.
+            let session = dial_iroh_moq(node_id, direct_addrs, relay_url).await?;
+            Ok(MoqStreamSession::Iroh(session))
         }
         EndpointType::Ipc { .. }
         | EndpointType::SystemdFd { .. }
@@ -274,6 +323,45 @@ pub async fn dial_stream(
             )
         }
     }
+}
+
+/// Dial the iroh `moql` (moq-lite) ALPN to `node_id` and wrap the connection as
+/// a `web_transport_iroh::Session` ready for `moq_net::Client::connect`.
+///
+/// Uses the process-wide client iroh endpoint installed at startup
+/// ([`crate::transport::lazy_iroh::install_iroh_client_endpoint`]) — the same
+/// install-once dialer the RPC plane's `LazyIrohTransport` uses, so the streaming
+/// dial reuses the node identity and bound sockets. Mirrors
+/// [`crate::transport::iroh_substrate::IrohSubstrate::connect`].
+async fn dial_iroh_moq(
+    node_id: &[u8; 32],
+    direct_addrs: &[std::net::SocketAddr],
+    relay_url: &Option<String>,
+) -> Result<web_transport_iroh::Session> {
+    use crate::transport::iroh_substrate::ALPN_MOQ_LITE;
+    use iroh::{EndpointAddr, EndpointId, TransportAddr};
+
+    let endpoint = crate::transport::lazy_iroh::iroh_client_endpoint().ok_or_else(|| {
+        anyhow!(
+            "dial_stream(): no iroh client endpoint installed — call \
+             install_iroh_client_endpoint() at startup before dialing iroh streams"
+        )
+    })?;
+
+    let id = EndpointId::from_bytes(node_id).map_err(|e| anyhow!("invalid iroh node_id: {e}"))?;
+    let mut transport_addrs: Vec<TransportAddr> =
+        direct_addrs.iter().copied().map(TransportAddr::Ip).collect();
+    if let Some(url) = relay_url {
+        let relay = url.parse().map_err(|e| anyhow!("invalid iroh relay_url '{url}': {e}"))?;
+        transport_addrs.push(TransportAddr::Relay(relay));
+    }
+    let addr = EndpointAddr::from_parts(id, transport_addrs);
+
+    let conn = endpoint
+        .connect(addr, ALPN_MOQ_LITE)
+        .await
+        .map_err(|e| anyhow!("iroh moql connect: {e}"))?;
+    Ok(web_transport_iroh::Session::raw(conn))
 }
 
 #[cfg(test)]
@@ -392,5 +480,95 @@ mod tests {
         assert!(QuicServerAuth::pinned(vec![]).is_err(), "empty pin set is no auth");
         assert!(QuicServerAuth::web_pki_pinned(vec![]).is_err(), "empty pin set is no auth");
         assert!(QuicServerAuth::web_pki().require_web_pki());
+    }
+
+    #[test]
+    fn dial_stream_iroh_without_reach_fails_fast() {
+        // An iroh reach with neither direct addrs nor a relay is not dialable —
+        // dial_stream must fail fast rather than hang in discovery.
+        let cfg = TransportConfig::iroh([1u8; 32], Vec::new(), None);
+        let res = futures::executor::block_on(dial_stream(&cfg));
+        assert!(res.is_err(), "iroh reach with no reachability must fail fast");
+    }
+
+    /// #282: `dial_stream`'s iroh arm dials the `moql` ALPN and returns a live
+    /// moq session. A loopback: a server `IrohSubstrate` serves the moq handler
+    /// with one published broadcast; the client installs its endpoint as the
+    /// process-global dialer, then `dial_stream(EndpointType::Iroh{..})` →
+    /// `connect_moq` → subscribe → read the same frame back.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dial_stream_iroh_moql_loopback_round_trip() -> Result<()> {
+        use crate::transport::iroh_moq::{IrohMoqProtocolHandler, OriginShared};
+        use crate::transport::iroh_substrate::{IrohSubstrate, NoopHandler};
+        use crate::transport::lazy_iroh::install_iroh_client_endpoint;
+        use moq_net::{Client, Group, Origin, OriginConsumer, OriginProducer, Track};
+        use rand::RngCore;
+
+        fn fresh_key() -> [u8; 32] {
+            let mut k = [0u8; 32];
+            rand::thread_rng().fill_bytes(&mut k);
+            k
+        }
+
+        // ── Server: moq handler on the `moql` ALPN with one broadcast ──────────
+        let shared = OriginShared::new();
+        let producer = shared.producer().clone();
+        let moq_handler = IrohMoqProtocolHandler::with_origin(shared);
+        let server =
+            IrohSubstrate::new(fresh_key(), moq_handler, NoopHandler::new("rpc")).await?;
+        let server_id: [u8; 32] = *server.endpoint_id().as_bytes();
+        let direct: Vec<std::net::SocketAddr> =
+            server.endpoint().bound_sockets().into_iter().collect();
+
+        let mut broadcast = producer
+            .create_broadcast("alice/run-1")
+            .ok_or_else(|| anyhow!("create_broadcast denied"))?;
+        let mut track = broadcast.create_track(Track::new("tokens"))?;
+        let mut group = track.create_group(Group::from(0u64))?;
+        group.write_frame(bytes::Bytes::from_static(b"hello-dial-stream"))?;
+        drop(group);
+
+        // ── Client: install its endpoint as the process-global dialer ──────────
+        let client = IrohSubstrate::new(
+            fresh_key(),
+            NoopHandler::new("c-moq"),
+            NoopHandler::new("c-rpc"),
+        )
+        .await?;
+        let _ = install_iroh_client_endpoint(client.endpoint().clone());
+
+        // ── dial_stream over iroh → MoqStreamSession::Iroh ─────────────────────
+        let cfg = TransportConfig::iroh(server_id, direct, None);
+        let session = dial_stream(&cfg).await?;
+        assert!(matches!(session, MoqStreamSession::Iroh(_)), "must be an iroh session");
+
+        // Run the moq handshake via the enum dispatcher and subscribe.
+        let client_origin: OriginProducer = Origin::random().produce();
+        let client_consumer: OriginConsumer = client_origin.consume();
+        let moq_client = Client::new().with_consume(client_origin);
+        let _moq_session = session
+            .connect_moq(&moq_client)
+            .await
+            .map_err(|e| anyhow!("moq handshake: {e}"))?;
+
+        let bc = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            client_consumer.announced_broadcast("alice/run-1"),
+        )
+        .await?
+        .ok_or_else(|| anyhow!("broadcast not announced"))?;
+        let mut tc = bc.subscribe_track(&Track::new("tokens"))?;
+        let mut gc = tokio::time::timeout(std::time::Duration::from_secs(5), tc.next_group())
+            .await??
+            .ok_or_else(|| anyhow!("next_group None"))?;
+        let frame = tokio::time::timeout(std::time::Duration::from_secs(5), gc.read_frame())
+            .await??
+            .ok_or_else(|| anyhow!("read_frame None"))?;
+        assert_eq!(&frame[..], b"hello-dial-stream");
+
+        server.shutdown().await?;
+        // Do NOT shut down `client`: its endpoint is the install-once global.
+        drop(client);
+        Ok(())
     }
 }

--- a/crates/hyprstream-rpc/src/moq_stream.rs
+++ b/crates/hyprstream-rpc/src/moq_stream.rs
@@ -764,7 +764,13 @@ fn reach_to_transport_config(
             };
             Some(TransportConfig::quic_with_auth(addr, q.server_name.clone(), auth))
         }
-        // Reserved (#274 follow-up): no dialable Iroh reach yet.
+        // #282 SEAM: `dial_stream` now dials an iroh `moql` reach
+        // (`EndpointType::Iroh { node_id, .. }`), but the **wire** reach enum's
+        // `Iroh` variant is a unit variant carrying no `node_id`/relay payload
+        // (it is code-generated from `stream.capnp`). Until that schema grows a
+        // `nodeId`/`relays` field, a StreamInfo cannot publish a dialable iroh
+        // reach, so this maps to `None` (publishers carry the Quic reach). The
+        // local `dial_stream` iroh arm is covered by the dial.rs loopback test.
         ReachTransport::Iroh => None,
     }
 }
@@ -807,7 +813,9 @@ async fn moq_stream_handle_task_networked(
     let client_origin = Origin::random().produce();
     let client_consumer = client_origin.consume();
     let moq_client = MoqClient::new().with_consume(client_origin);
-    let _session = match moq_client.connect(session).await {
+    // `session` is a `MoqStreamSession` (quinn or iroh, #282) — dispatch the moq
+    // handshake to the concrete transport.
+    let _session = match session.connect_moq(&moq_client).await {
         Ok(s) => s,
         Err(e) => {
             let _ = tx.send(Err(anyhow!("moq handshake: {e}"))).await;

--- a/crates/hyprstream-rpc/src/service/svc.rs
+++ b/crates/hyprstream-rpc/src/service/svc.rs
@@ -650,6 +650,25 @@ pub struct QuicLoopConfig {
     /// Callback invoked after QUIC binding succeeds, with (service_name, actual_addr, server_name).
     /// Used to announce endpoints to the DiscoveryService.
     pub on_quic_bound: Option<Box<dyn FnOnce(String, std::net::SocketAddr, String) + Send>>,
+    /// #282: when `true`, the spawner binds an `IrohSubstrate` in PARALLEL to the
+    /// quinn endpoint, serving BOTH ALPNs (`hyprstream-rpc/1` + `moql`) with the
+    /// same request processor + moq origin, and installs the shared client
+    /// endpoint for outbound iroh dials. Native-only. Defaults to `false`
+    /// (off) so the working quinn-only deployment is unchanged unless opted in.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub iroh_enabled: bool,
+    /// #282: optional #137 federation admission hook applied at the iroh accept
+    /// path (origin + key-binding against `remote_id()`). `None` = open (the
+    /// pre-#282 accept-open behaviour). Native-only.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub iroh_admission:
+        Option<crate::transport::iroh_admission::SharedIrohAdmission>,
+    /// #282: callback invoked after the iroh substrate binds, with
+    /// (service_name, node_id) where `node_id` is the endpoint's 32-byte Ed25519
+    /// public key. Used to advertise the `#iroh` VM + `IrohTransport` service
+    /// entry in the DID document only when iroh is actually bound.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub on_iroh_bound: Option<Box<dyn FnOnce(String, [u8; 32]) + Send>>,
 }
 
 /// Handle for a running service

--- a/crates/hyprstream-rpc/src/transport/iroh_admission.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_admission.rs
@@ -1,0 +1,144 @@
+//! #137 federation admission at the live iroh accept path (#282).
+//!
+//! The transport-agnostic two-stage gate
+//! ([`crate::admission::FederationAdmissionGate`]) needs three inputs per inbound
+//! peer: an RFC 6454 **origin**, the peer's authenticated **channel key**
+//! ([`crate::admission::PeerChannelKey`]), and the peer's **DID**. On the iroh
+//! accept path the channel key is no longer a documented seam (#137 lacked it on
+//! the quinn path): an accepted iroh `Connection` is authenticated by the remote
+//! endpoint's Ed25519 public key, surfaced as `Connection::remote_id()`. This
+//! module turns that `remote_id()` into the gate inputs and defines the
+//! object-safe hook the iroh `ProtocolHandler`s call.
+//!
+//! # What `remote_id()` resolves (and the origin seam)
+//!
+//! - **Channel key** — `remote_id().as_bytes()` is the peer's Ed25519 public key,
+//!   exactly the `PeerChannelKey` the gate's key-binding stage matches. No mTLS
+//!   client cert, no RFC 7250 plumbing (#200) needed: iroh's QUIC TLS already
+//!   bound the channel to this key.
+//! - **DID** — for a raw inbound iroh peer the self-certifying `did:key`
+//!   ([`crate::did_web::ed25519_to_did_key`]) of `remote_id()` is the peer's
+//!   identity: the key *is* the DID (Tiles interop, #281). The gate's key-binding
+//!   stage then trivially admits (self-certifying), so the load-bearing decision
+//!   is **stage 1 (origin)**.
+//! - **Origin** — this is the residual seam. An RFC 6454 origin for an inbound
+//!   iroh peer is *not* carried on the iroh channel itself; it arrives in the
+//!   app-layer signed envelope / JWT (`iss`). At the raw accept loop we therefore
+//!   only have the `did:key` (no http origin). The default policy-bound impl in
+//!   the `hyprstream` crate treats the `did:key` string as the admission subject
+//!   (the same shape `did:key` peers register under, #281), and the per-request
+//!   app-layer path still re-verifies the envelope signer == `remote_id()`.
+//!
+//! # Fail-closed
+//!
+//! When an admission hook is installed and it rejects (or errors), the accept
+//! handler MUST drop the connection. When no hook is installed the path is
+//! open (pre-#282 behaviour) so existing single-tenant / loopback deployments
+//! keep working until an operator opts into federation gating.
+
+use std::sync::Arc;
+
+/// Object-safe per-connection admission decision for an inbound iroh peer.
+///
+/// Implemented in the `hyprstream` crate over the #137
+/// [`crate::admission::FederationAdmissionGate`] (which owns the `PolicyService`
+/// origin stage + the `did:web`/`did:key` key-binding stage). Defined here —
+/// where the iroh `ProtocolHandler`s live — so the handlers can invoke it
+/// without a `hyprstream-rpc` → `hyprstream` dependency cycle.
+///
+/// **Fail-closed contract:** return `Ok(())` only when the peer is affirmatively
+/// admitted; return `Err(_)` on denial **or** any inability to reach the
+/// decision. The caller drops the connection on `Err`.
+#[async_trait::async_trait]
+pub trait IrohPeerAdmission: Send + Sync {
+    /// Decide whether the peer identified by its authenticated Ed25519
+    /// `node_id` (the iroh `remote_id()` bytes) may be admitted.
+    async fn admit_peer(&self, node_id: &[u8; 32]) -> anyhow::Result<()>;
+}
+
+/// A shared, optional admission hook installed on an iroh accept handler.
+pub type SharedIrohAdmission = Arc<dyn IrohPeerAdmission>;
+
+/// Run an optional admission hook for an accepted iroh connection, returning
+/// `true` if the connection should proceed (admitted, or no hook installed) and
+/// `false` if it must be dropped (rejected / fail-closed).
+///
+/// Centralised so both the RPC (`hyprstream-rpc/1`) and streaming (`moql`)
+/// accept paths apply identical semantics.
+pub async fn check_admission(hook: Option<&SharedIrohAdmission>, node_id: &[u8; 32]) -> bool {
+    match hook {
+        None => true,
+        Some(gate) => match gate.admit_peer(node_id).await {
+            Ok(()) => true,
+            Err(e) => {
+                tracing::warn!(
+                    node_id = %short_node_id(node_id),
+                    "iroh accept: federation admission rejected — dropping connection: {e}"
+                );
+                false
+            }
+        },
+    }
+}
+
+/// Short hex fingerprint of a node_id for logs (never the full key).
+fn short_node_id(node_id: &[u8; 32]) -> String {
+    format!("{:02x}{:02x}{:02x}{:02x}…", node_id[0], node_id[1], node_id[2], node_id[3])
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct Allow;
+    #[async_trait::async_trait]
+    impl IrohPeerAdmission for Allow {
+        async fn admit_peer(&self, _node_id: &[u8; 32]) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct Deny;
+    #[async_trait::async_trait]
+    impl IrohPeerAdmission for Deny {
+        async fn admit_peer(&self, _node_id: &[u8; 32]) -> anyhow::Result<()> {
+            anyhow::bail!("nope")
+        }
+    }
+
+    struct CountCalls(Arc<AtomicUsize>);
+    #[async_trait::async_trait]
+    impl IrohPeerAdmission for CountCalls {
+        async fn admit_peer(&self, _node_id: &[u8; 32]) -> anyhow::Result<()> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn no_hook_admits_open() {
+        assert!(check_admission(None, &[0u8; 32]).await);
+    }
+
+    #[tokio::test]
+    async fn allow_hook_admits() {
+        let hook: SharedIrohAdmission = Arc::new(Allow);
+        assert!(check_admission(Some(&hook), &[7u8; 32]).await);
+    }
+
+    #[tokio::test]
+    async fn deny_hook_rejects_fail_closed() {
+        let hook: SharedIrohAdmission = Arc::new(Deny);
+        assert!(!check_admission(Some(&hook), &[7u8; 32]).await);
+    }
+
+    #[tokio::test]
+    async fn hook_is_actually_invoked_with_node_id() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let hook: SharedIrohAdmission = Arc::new(CountCalls(Arc::clone(&calls)));
+        assert!(check_admission(Some(&hook), &[1u8; 32]).await);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+}

--- a/crates/hyprstream-rpc/src/transport/iroh_moq.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_moq.rs
@@ -80,6 +80,13 @@ impl OriginShared {
         Self { producer, consumer }
     }
 
+    /// Wrap an existing producer/consumer pair (e.g. the process-global moq
+    /// origin) so the iroh `moql` accept path serves the SAME broadcasts the
+    /// quinn `/moq` path does (#282 parallel bind).
+    pub fn from_pair(producer: OriginProducer, consumer: OriginConsumer) -> Self {
+        Self { producer, consumer }
+    }
+
     pub fn producer(&self) -> &OriginProducer {
         &self.producer
     }
@@ -110,6 +117,10 @@ struct HandlerInner {
     /// #276 subscribe-authz + per-tenant announce scoping config. Defaults to
     /// "off" (open same-tenant subscribe preserved).
     authz: MoqAuthzConfig,
+    /// #137/#282 federation admission hook. `None` = open (pre-#282). When set,
+    /// an inbound connection whose `remote_id()` is not admitted is dropped
+    /// (fail-closed) before any moq session is served.
+    admission: Option<crate::transport::iroh_admission::SharedIrohAdmission>,
     /// Triggered by `ProtocolHandler::shutdown` so accept handlers stop
     /// waiting for `Session::closed()` and exit promptly.
     shutdown: CancellationToken,
@@ -136,9 +147,21 @@ impl IrohMoqProtocolHandler {
                 origin,
                 stats: StatsHandle::default(),
                 authz: MoqAuthzConfig::default(),
+                admission: None,
                 shutdown: CancellationToken::new(),
             }),
         }
+    }
+
+    /// Install the #137/#282 federation admission hook. When set, an inbound
+    /// connection whose authenticated `remote_id()` is not admitted by the gate
+    /// is dropped (fail-closed) before any moq session is served.
+    pub fn with_admission(
+        mut self,
+        admission: crate::transport::iroh_admission::SharedIrohAdmission,
+    ) -> Self {
+        self.rebuild_inner(|i| i.admission = Some(admission));
+        self
     }
 
     /// Install the #276 subscribe-authz + per-tenant announce-scoping config.
@@ -148,19 +171,28 @@ impl IrohMoqProtocolHandler {
     /// id) and per-tenant scoping is enforced live by handing the moq session a
     /// tenant-scoped [`OriginConsumer`].
     pub fn with_authz(mut self, authz: MoqAuthzConfig) -> Self {
+        self.rebuild_inner(|i| i.authz = authz);
+        self
+    }
+
+    /// Mutate the inner config, cloning the shared `Arc<HandlerInner>` only when
+    /// it is already shared (cloned handler) so builder calls compose without
+    /// dropping previously-installed fields (authz / admission).
+    fn rebuild_inner(&mut self, f: impl FnOnce(&mut HandlerInner)) {
         if let Some(inner) = Arc::get_mut(&mut self.inner) {
-            inner.authz = authz;
+            f(inner);
         } else {
-            // Inner already shared (cloned handler); rebuild a fresh Arc.
             let old = &*self.inner;
-            self.inner = Arc::new(HandlerInner {
+            let mut cloned = HandlerInner {
                 origin: old.origin.clone(),
                 stats: old.stats.clone(),
-                authz,
+                authz: old.authz.clone(),
+                admission: old.admission.clone(),
                 shutdown: old.shutdown.clone(),
-            });
+            };
+            f(&mut cloned);
+            self.inner = Arc::new(cloned);
         }
-        self
     }
 
     /// Borrow the shared origin pair.
@@ -188,6 +220,20 @@ impl Default for IrohMoqProtocolHandler {
 
 impl ProtocolHandler for IrohMoqProtocolHandler {
     async fn accept(&self, conn: Connection) -> Result<(), AcceptError> {
+        // #137/#282 federation admission: the accepted iroh connection is
+        // authenticated to the remote endpoint's Ed25519 key (`remote_id()`).
+        // Run the gate (origin + key-binding) before serving any broadcast; on
+        // rejection, fail-closed by dropping the connection. No hook = open.
+        let remote = *conn.remote_id().as_bytes();
+        if !crate::transport::iroh_admission::check_admission(
+            self.inner.admission.as_ref(),
+            &remote,
+        )
+        .await
+        {
+            return Ok(());
+        }
+
         // #276: peer identity IS available here — an accepted iroh connection
         // is authenticated by the remote endpoint's public key. Use it to
         // derive the peer's tenant and scope the consumer it's served.

--- a/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
@@ -76,6 +76,10 @@ struct HandlerInner {
     connection_limit: Arc<Semaphore>,
     /// Per-stream request-read timeout (#159 slowloris bound).
     read_timeout: std::time::Duration,
+    /// #137/#282 federation admission hook. `None` = open (pre-#282). When set,
+    /// an inbound connection whose `remote_id()` is not admitted is dropped
+    /// (fail-closed) before any stream is served.
+    admission: Option<super::iroh_admission::SharedIrohAdmission>,
     /// Level-triggered shutdown signal: once `cancel()` is called, every
     /// future and current `cancelled().await` resolves immediately. Used
     /// instead of `tokio::sync::Notify` because `Notify::notify_waiters`
@@ -116,9 +120,21 @@ impl IrohRpcProtocolHandler {
                     super::rpc_session::DEFAULT_CONNECTION_LIMIT,
                 )),
                 read_timeout: super::rpc_session::REQUEST_READ_TIMEOUT,
+                admission: None,
                 shutdown: CancellationToken::new(),
             }),
         }
+    }
+
+    /// Install the #137/#282 federation admission hook. When set, an inbound
+    /// connection whose authenticated `remote_id()` is not admitted by the gate
+    /// is dropped (fail-closed) before any RPC stream is served.
+    pub fn with_admission(
+        mut self,
+        admission: super::iroh_admission::SharedIrohAdmission,
+    ) -> Self {
+        self.mutate_inner(|i| i.admission = Some(admission));
+        self
     }
 
     /// Override the per-stream request-read timeout (#159). Primarily for
@@ -152,9 +168,14 @@ impl IrohRpcProtocolHandler {
     pub fn with_rpc_config(self, cfg: &super::rpc_session::RpcConfig) -> Self {
         let processor = Arc::clone(&self.inner.processor);
         let signing_key = self.inner.signing_key.clone();
-        Self::with_stream_limit(processor, signing_key, cfg.stream_limit)
+        let admission = self.inner.admission.clone();
+        let mut built = Self::with_stream_limit(processor, signing_key, cfg.stream_limit)
             .with_read_timeout(cfg.request_read_timeout)
-            .with_connection_limit(cfg.connection_limit)
+            .with_connection_limit(cfg.connection_limit);
+        if let Some(a) = admission {
+            built = built.with_admission(a);
+        }
+        built
     }
 }
 
@@ -172,6 +193,16 @@ impl ProtocolHandler for IrohRpcProtocolHandler {
                 return Ok(());
             }
         };
+
+        // #137/#282 federation admission: iroh authenticated this connection to
+        // the remote endpoint's Ed25519 key (`remote_id()`). Run the gate (origin
+        // stage + key-binding stage) against it; on rejection, fail-closed by
+        // returning Ok(()) (drop the connection without serving any stream). When
+        // no hook is installed the path is open (pre-#282).
+        let remote = *conn.remote_id().as_bytes();
+        if !super::iroh_admission::check_admission(self.inner.admission.as_ref(), &remote).await {
+            return Ok(());
+        }
 
         // Adapt the raw iroh `Connection` to the transport-generic `Session`
         // abstraction and delegate to the shared accept loop. Drain semantics
@@ -801,6 +832,86 @@ mod tests {
         assert_eq!(&resp[..], b"drained-ok");
 
         client.shutdown().await?;
+        Ok(())
+    }
+
+    // ── #137/#282 federation admission at the live iroh accept path ───────────
+
+    use super::super::iroh_admission::{IrohPeerAdmission, SharedIrohAdmission};
+
+    /// Admit iff the peer's node_id equals an expected key — mirrors the #137
+    /// key-binding stage (here against a fixed expected node_id).
+    struct AdmitExpected([u8; 32]);
+    #[async_trait::async_trait]
+    impl IrohPeerAdmission for AdmitExpected {
+        async fn admit_peer(&self, node_id: &[u8; 32]) -> Result<()> {
+            if node_id == &self.0 {
+                Ok(())
+            } else {
+                anyhow::bail!("node_id not admitted")
+            }
+        }
+    }
+
+    /// #282: a gate that admits the client's `remote_id()` lets RPC through; the
+    /// gate is invoked with the authenticated Ed25519 key (no #200/#185 seam).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn admission_admits_known_remote_id() -> Result<()> {
+        // Build the client first so we know the node_id it will present.
+        let client = IrohSubstrate::new(
+            fresh_key(),
+            NoopHandler::new("c-moq"),
+            NoopHandler::new("c-rpc"),
+        )
+        .await?;
+        let client_node_id: [u8; 32] = *client.endpoint_id().as_bytes();
+
+        let processor = from_fn(|req: Bytes| async move { Ok(req) });
+        let gate: SharedIrohAdmission = Arc::new(AdmitExpected(client_node_id));
+        let handler = IrohRpcProtocolHandler::new(processor, fresh_signing_key())
+            .with_admission(gate);
+        let server = IrohSubstrate::new(fresh_key(), NoopHandler::new("moq"), handler).await?;
+        let server_addr = direct_addr(&server);
+
+        let conn = client.connect(server_addr, ALPN_HYPRSTREAM_RPC).await?;
+        let resp = client_request(&conn, b"hi").await?;
+        assert_eq!(&resp[..], b"hi", "admitted peer must be served");
+
+        client.shutdown().await?;
+        server.shutdown().await?;
+        Ok(())
+    }
+
+    /// #282: a gate that does NOT admit the client's `remote_id()` drops the
+    /// connection fail-closed — the RPC request must not succeed.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn admission_rejects_unknown_remote_id_fail_closed() -> Result<()> {
+        let processor = from_fn(|req: Bytes| async move { Ok(req) });
+        // Gate expects a different node_id than any real client → reject all.
+        let gate: SharedIrohAdmission = Arc::new(AdmitExpected([0xAAu8; 32]));
+        let handler = IrohRpcProtocolHandler::new(processor, fresh_signing_key())
+            .with_admission(gate);
+        let server = IrohSubstrate::new(fresh_key(), NoopHandler::new("moq"), handler).await?;
+        let server_addr = direct_addr(&server);
+
+        let client = IrohSubstrate::new(
+            fresh_key(),
+            NoopHandler::new("c-moq"),
+            NoopHandler::new("c-rpc"),
+        )
+        .await?;
+        let conn = client.connect(server_addr, ALPN_HYPRSTREAM_RPC).await?;
+
+        // The handler returns Ok(()) (drops the connection) without serving any
+        // stream, so the client's request must fail (reset/closed), not hang.
+        let res = tokio::time::timeout(Duration::from_secs(5), client_request(&conn, b"hi")).await;
+        match res {
+            Ok(inner) => assert!(inner.is_err(), "rejected peer must not be served"),
+            Err(_) => panic!("rejected request must fail promptly, not hang"),
+        }
+
+        client.shutdown().await?;
+        server.shutdown().await?;
         Ok(())
     }
 }

--- a/crates/hyprstream-rpc/src/transport/lazy_iroh.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_iroh.rs
@@ -63,7 +63,11 @@ pub fn install_iroh_client_endpoint(endpoint: iroh::Endpoint) -> Result<(), iroh
 }
 
 /// The installed client endpoint, cloned (cheap — iroh `Endpoint` is `Arc`-backed).
-fn iroh_client_endpoint() -> Option<iroh::Endpoint> {
+///
+/// Exposed crate-internally so the streaming-plane dialer
+/// ([`crate::dial::dial_stream`]'s iroh arm, #282) can reuse the same install-once
+/// endpoint the RPC plane dials from.
+pub(crate) fn iroh_client_endpoint() -> Option<iroh::Endpoint> {
     IROH_CLIENT_ENDPOINT.get().cloned()
 }
 

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -22,6 +22,8 @@ pub mod iroh_transport;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod iroh_moq;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod iroh_admission;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod in_memory;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod lazy_quinn;

--- a/crates/hyprstream-service/src/service/factory.rs
+++ b/crates/hyprstream-service/src/service/factory.rs
@@ -52,6 +52,10 @@ pub struct QuicSharedConfig {
     /// JWT verifying key (derived from root via HKDF "hyprstream-jwt-v1").
     /// Published as `x_root_pubkey` in RFC 9728 metadata for client-side trust pinning.
     pub jwt_verifying_key: Option<ed25519_dalek::VerifyingKey>,
+    /// #282: bind an iroh substrate (ALPNs `hyprstream-rpc/1` + `moql`) in
+    /// parallel to the quinn endpoint for every QUIC-enabled service. Off by
+    /// default; an operator opts in via `[quic] iroh = true`.
+    pub iroh_enabled: bool,
 }
 
 impl QuicSharedConfig {
@@ -84,6 +88,14 @@ impl QuicSharedConfig {
             server_name: self.server_name.clone(),
             protected_resource_json: metadata,
             on_quic_bound: None,
+            // #282: bind iroh in parallel when the deployment opted in. The
+            // admission hook + on_iroh_bound advert callback are threaded by the
+            // service factory (which owns PolicyService / OAuthState); left None
+            // here so iroh, when enabled, runs accept-open until that wiring lands
+            // (documented seam — see service.rs spawner).
+            iroh_enabled: self.iroh_enabled,
+            iroh_admission: None,
+            on_iroh_bound: None,
         }
     }
 

--- a/crates/hyprstream-service/src/service/spawner/service.rs
+++ b/crates/hyprstream-service/src/service/spawner/service.rs
@@ -161,7 +161,96 @@ impl<S: RequestService + Send + Sync + 'static> Spawnable for UnifiedServiceConf
                     },
                 );
                 if let Some(cb) = qc.on_quic_bound.take() {
-                    cb(service_name, actual_addr, qc.server_name.clone());
+                    cb(service_name.clone(), actual_addr, qc.server_name.clone());
+                }
+
+                // #282: bind an iroh substrate in PARALLEL to the quinn endpoint,
+                // serving BOTH ALPNs (`hyprstream-rpc/1` + `moql`) with the SAME
+                // request processor + moq origin. The iroh endpoint's node key is
+                // the service's Ed25519 signing key, so its `node_id` (==
+                // `signing_key.verifying_key()`) is already covered by the node's
+                // published DID verification methods — and the #137 gate, when
+                // installed, matches an inbound peer's `remote_id()` against its
+                // DID. Discovery is iroh's built-in pkarr publisher + n0 DNS
+                // (`presets::N0`), so this node is dial-by-node_id-discoverable.
+                //
+                // Kept alive in this scope via `_iroh_substrate`; on shutdown the
+                // spawned task calls `IrohSubstrate::shutdown` to drain handlers.
+                let _iroh_substrate_guard = if qc.iroh_enabled {
+                    let iroh_secret = signing_key.to_bytes();
+                    let node_id: [u8; 32] = signing_key.verifying_key().to_bytes();
+                    // moq plane: reuse the SAME global origin the quinn `/moq`
+                    // path serves, so broadcasts are visible over both transports.
+                    let moq_handler = match hyprstream_rpc::moq_stream::global_moq_origin() {
+                        Some(origin) => {
+                            let shared = hyprstream_rpc::transport::iroh_moq::OriginShared::from_pair(
+                                origin.producer().clone(),
+                                origin.consumer().clone(),
+                            );
+                            hyprstream_rpc::transport::iroh_moq::IrohMoqProtocolHandler::with_origin(shared)
+                        }
+                        None => hyprstream_rpc::transport::iroh_moq::IrohMoqProtocolHandler::new(),
+                    };
+                    // RPC plane: same processor + signing key as the quinn path.
+                    let mut rpc_handler =
+                        hyprstream_rpc::transport::iroh_rpc::IrohRpcProtocolHandler::with_stream_limit(
+                            Arc::clone(&processor),
+                            signing_key.clone(),
+                            hyprstream_rpc::transport::rpc_session::DEFAULT_STREAM_LIMIT,
+                        );
+                    let mut moq_handler = moq_handler;
+                    // #137/#282: apply the federation admission gate at both iroh
+                    // accept paths (origin + key-binding against `remote_id()`),
+                    // fail-closed. `None` → accept-open (documented seam until the
+                    // factory threads a gate down).
+                    if let Some(gate) = qc.iroh_admission.take() {
+                        rpc_handler = rpc_handler.with_admission(gate.clone());
+                        moq_handler = moq_handler.with_admission(gate);
+                    }
+                    match hyprstream_rpc::transport::iroh_substrate::IrohSubstrate::new(
+                        iroh_secret, moq_handler, rpc_handler,
+                    )
+                    .await
+                    {
+                        Ok(substrate) => {
+                            // Install the shared client endpoint (install-once) so
+                            // outbound iroh RPC/stream dials reuse this identity.
+                            let _ = hyprstream_rpc::transport::lazy_iroh::install_iroh_client_endpoint(
+                                substrate.endpoint().clone(),
+                            );
+                            // Advertise the `#iroh` VM only now that iroh is bound.
+                            if let Some(cb) = qc.on_iroh_bound.take() {
+                                cb(service_name.clone(), node_id);
+                            }
+                            tracing::info!(
+                                service = %service_name,
+                                node_id = %hex_short(&node_id),
+                                "iroh substrate bound (ALPNs hyprstream-rpc/1 + moql)"
+                            );
+                            Some(substrate)
+                        }
+                        Err(e) => {
+                            // Fail soft: an iroh bind failure must not take down the
+                            // working quinn plane. Log and continue quinn-only.
+                            tracing::warn!(
+                                service = %service_name,
+                                "iroh substrate bind failed; continuing quinn-only: {e}"
+                            );
+                            None
+                        }
+                    }
+                } else {
+                    None
+                };
+                // Drain the iroh substrate on shutdown (parallel to quinn drain).
+                if let Some(substrate) = _iroh_substrate_guard {
+                    let iroh_shutdown = Arc::clone(&shutdown);
+                    tokio::spawn(async move {
+                        iroh_shutdown.notified().await;
+                        if let Err(e) = substrate.shutdown().await {
+                            tracing::warn!("iroh substrate shutdown error: {e}");
+                        }
+                    });
                 }
 
                 // Bridge the `Notify` shutdown to the server's graceful drain.
@@ -193,6 +282,11 @@ impl<S: RequestService + Send + Sync + 'static> Spawnable for UnifiedServiceConf
             }
         })
     }
+}
+
+/// Short hex fingerprint of a 32-byte node_id for logs (never the full key).
+fn hex_short(id: &[u8; 32]) -> String {
+    format!("{:02x}{:02x}{:02x}{:02x}…", id[0], id[1], id[2], id[3])
 }
 
 /// Mode for spawning services.

--- a/crates/hyprstream/src/auth/federation_admission.rs
+++ b/crates/hyprstream/src/auth/federation_admission.rs
@@ -30,8 +30,11 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
-use hyprstream_rpc::admission::{FederationAdmissionGate, OriginAdmission};
-use hyprstream_rpc::did_web::{DidWebResolver, HttpDidDocFetcher};
+use hyprstream_rpc::admission::{
+    DidDocResolve, FederationAdmissionGate, OriginAdmission, PeerChannelKey,
+};
+use hyprstream_rpc::did_web::{ed25519_to_did_key, DidWebResolver, HttpDidDocFetcher};
+use hyprstream_rpc::transport::iroh_admission::IrohPeerAdmission;
 
 use crate::services::PolicyClient;
 
@@ -112,4 +115,129 @@ pub fn build_federation_admission_gate(
         PolicyOriginAdmission::new(policy_client),
         resolver,
     ))
+}
+
+/// #282: adapt the #137 [`FederationAdmissionGate`] to the iroh accept path's
+/// [`IrohPeerAdmission`] hook.
+///
+/// Bridges the iroh `remote_id()` (the inbound peer's authenticated Ed25519
+/// `node_id`) into the gate's three inputs:
+///
+/// - **DID** — the self-certifying `did:key` of `node_id` (#281). The key *is*
+///   the identity, so the gate's key-binding stage 2 is satisfied without any
+///   network fetch.
+/// - **`PeerChannelKey`** — `node_id` itself: iroh's QUIC TLS already bound the
+///   channel to this key, so it is the authenticated channel key the gate matches
+///   (this is exactly the live peer-key the #137 quinn path lacked).
+/// - **origin (RFC 6454)** — the residual seam. A raw inbound iroh peer carries
+///   no http origin on the channel; the app-layer envelope/JWT `iss` does, but
+///   that is not available at the accept loop. We therefore pass the `did:key`
+///   string as the admission **subject** — the same identifier `did:key` peers
+///   register under (#281) — so stage 1 (`federation:register`) is the
+///   load-bearing decision. The per-request service-layer path still re-verifies
+///   the envelope signer key == `remote_id()`, closing the loop.
+///
+/// Fail-closed: any gate error rejects the connection (the iroh handler drops it).
+pub struct IrohFederationAdmission<O: OriginAdmission, R: DidDocResolve> {
+    gate: Arc<FederationAdmissionGate<O, R>>,
+}
+
+impl<O: OriginAdmission, R: DidDocResolve> IrohFederationAdmission<O, R> {
+    /// Wrap a shared #137 gate as the iroh accept-path admission hook.
+    pub fn new(gate: Arc<FederationAdmissionGate<O, R>>) -> Self {
+        Self { gate }
+    }
+}
+
+#[async_trait]
+impl<O: OriginAdmission + 'static, R: DidDocResolve + 'static> IrohPeerAdmission
+    for IrohFederationAdmission<O, R>
+{
+    async fn admit_peer(&self, node_id: &[u8; 32]) -> Result<()> {
+        // Self-certifying did:key of the authenticated node_id (#281): the key is
+        // the identity, used both as the DID (stage 2 self-cert) and the stage-1
+        // admission subject (origin seam — see struct docs).
+        let did = ed25519_to_did_key(node_id);
+        self.gate
+            .admit(&did, PeerChannelKey(*node_id), &did, None)
+            .await
+            .map(|_admitted| ())
+    }
+}
+
+/// Build the iroh accept-path admission hook over the real `PolicyService`
+/// (stage 1) + native `did:web`/`did:key` resolver (stage 2), ready to install
+/// on an iroh substrate via `QuicLoopConfig::iroh_admission`.
+pub fn build_iroh_admission(
+    policy_client: Arc<PolicyClient>,
+) -> Result<Arc<dyn IrohPeerAdmission>> {
+    let gate = Arc::new(build_federation_admission_gate(policy_client)?);
+    Ok(Arc::new(IrohFederationAdmission::new(gate)))
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod iroh_admission_tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+    use hyprstream_rpc::admission::FederationAdmissionGate;
+    use rand::rngs::OsRng;
+    use serde_json::Value;
+
+    struct AllowAll;
+    #[async_trait]
+    impl OriginAdmission for AllowAll {
+        async fn admit_origin(&self, _origin: &str) -> Result<()> {
+            Ok(())
+        }
+    }
+    struct DenyAll;
+    #[async_trait]
+    impl OriginAdmission for DenyAll {
+        async fn admit_origin(&self, origin: &str) -> Result<()> {
+            anyhow::bail!("origin {origin} denied")
+        }
+    }
+    /// did:key is self-certifying — the resolver must never be called.
+    struct NeverResolve;
+    #[async_trait]
+    impl DidDocResolve for NeverResolve {
+        async fn resolve_doc(&self, did: &str) -> Result<Value> {
+            panic!("did:key admission must not resolve (called for {did})")
+        }
+    }
+
+    fn random_node_id() -> [u8; 32] {
+        SigningKey::generate(&mut OsRng).verifying_key().to_bytes()
+    }
+
+    #[tokio::test]
+    async fn iroh_peer_admitted_when_origin_policy_allows() {
+        // The peer's remote_id() drives a self-certifying did:key; stage 1 allows
+        // the subject → admitted. NeverResolve proves stage 2 is self-certifying.
+        let gate = Arc::new(FederationAdmissionGate::new(AllowAll, NeverResolve));
+        let hook = IrohFederationAdmission::new(gate);
+        assert!(hook.admit_peer(&random_node_id()).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn iroh_peer_rejected_fail_closed_when_policy_denies() {
+        // Stage 1 (federation:register) denies the did:key subject → reject.
+        let gate = Arc::new(FederationAdmissionGate::new(DenyAll, NeverResolve));
+        let hook = IrohFederationAdmission::new(gate);
+        assert!(hook.admit_peer(&random_node_id()).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn node_id_binds_to_its_did_key_iroh_vm() {
+        // The DID the gate matches is exactly the did:key of the node_id, and its
+        // key-binding stage trivially holds (self-certifying). This is the
+        // node_id ↔ #iroh VM binding invariant (#282): the key advertised as the
+        // `#iroh` VM is the node_id, and a peer presenting that node_id binds to
+        // that DID.
+        let node_id = random_node_id();
+        let did = ed25519_to_did_key(&node_id);
+        let decoded = hyprstream_rpc::did_web::did_key_to_ed25519(&did).unwrap();
+        assert_eq!(decoded, node_id, "did:key(node_id) must round-trip to node_id");
+    }
 }

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1969,6 +1969,8 @@ fn main() -> Result<()> {
                                         server_name: qc.server_name.clone(),
                                         oauth_issuer_url: Some(config.oauth.issuer_url()),
                                         jwt_verifying_key: Some(ctx.jwt_verifying_key()),
+                                        // #282: bind iroh in parallel to quinn when opted in.
+                                        iroh_enabled: qc.iroh,
                                     };
                                     ctx = ctx.with_quic(shared);
                                 }

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -340,6 +340,13 @@ pub struct QuicConfig {
     /// Path to TLS private key (PEM). Empty = generate self-signed.
     #[serde(default)]
     pub key_path: String,
+
+    /// #282: bind an iroh substrate (ALPNs `hyprstream-rpc/1` + `moql`) in
+    /// PARALLEL to the quinn/WebTransport endpoint, enabling node_id-addressed
+    /// (pkarr/DNS-discoverable) federation reach. Off by default — quinn-only is
+    /// the unchanged baseline; opt in with `[quic] iroh = true`. Native-only.
+    #[serde(default = "default_iroh_enabled")]
+    pub iroh: bool,
 }
 
 impl Default for QuicConfig {
@@ -350,6 +357,7 @@ impl Default for QuicConfig {
             server_name: default_quic_server_name(),
             cert_path: String::new(),
             key_path: String::new(),
+            iroh: default_iroh_enabled(),
         }
     }
 }
@@ -467,11 +475,19 @@ impl QuicConfig {
             server_name: self.server_name.clone(),
             protected_resource_json: meta_json,
             on_quic_bound: None,
+            // #282: iroh is opt-in and provisioned by the daemon bootstrap
+            // (`QuicSharedConfig`), not this minimal builder. Off here.
+            iroh_enabled: false,
+            iroh_admission: None,
+            on_iroh_bound: None,
         })
     }
 }
 
 fn default_quic_enabled() -> bool { true }
+/// #282: iroh substrate is opt-in (defaults off) so the quinn-only baseline is
+/// unchanged for existing deployments.
+fn default_iroh_enabled() -> bool { false }
 fn default_quic_bind_addr() -> String { "0.0.0.0:4433".to_owned() }
 fn default_quic_server_name() -> String { "localhost".to_owned() }
 

--- a/crates/hyprstream/src/services/oauth/did_document.rs
+++ b/crates/hyprstream/src/services/oauth/did_document.rs
@@ -363,10 +363,39 @@ pub async fn root_did_document(
         }
     }
 
+    // #282: iroh transport entry — published ONLY when the iroh substrate is
+    // bound (the daemon set `iroh_node_id`). Advertises the `#iroh` Ed25519
+    // verification method (the node_id, as a Multikey) AND an `IrohTransport`
+    // service entry accepting both ALPNs, so a peer can dial either plane by
+    // node_id (reachability via the advertised relays or pkarr/DNS discovery).
+    let mut extra_vms: Vec<(String, VerifyingKey)> = Vec::new();
+    if let Some(node_id) = state.iroh_node_id {
+        // The iroh node key is the node's Ed25519 endpoint id; publish it as the
+        // `#iroh` VM so the #137 key-binding stage can match an inbound iroh
+        // peer's `remote_id()` against this DID.
+        if let Ok(vk) = VerifyingKey::from_bytes(&node_id) {
+            extra_vms.push(("iroh".to_owned(), vk));
+        }
+        transports.push(TransportEndpoint {
+            fragment: "iroh".to_owned(),
+            vm_type: "IrohTransport".to_owned(),
+            endpoint: hyprstream_rpc::service_entry::encode_iroh(
+                &node_id,
+                &state.iroh_relays,
+                &["hyprstream-rpc/1", "moql"],
+            ),
+        });
+    }
+
+    // Root verification methods: the OAuth signing key plus the `#iroh` node key
+    // (when bound). `build_did_document` emits each as a Multikey VM.
+    let mut keys: Vec<(String, VerifyingKey)> = vec![("key-1".to_owned(), vk)];
+    keys.extend(extra_vms);
+
     let doc = build_did_document(
         &did,
         &state.issuer_url,
-        &[("key-1".to_owned(), vk)],
+        &keys,
         atproto.as_ref(),
         &transports,
         state.mesh_pq_verifying_key.as_deref(),
@@ -758,6 +787,90 @@ mod tests {
         let decoded = bs58::decode(&mb[1..]).into_vec().unwrap();
         assert_eq!(&decoded[2..], pq_vk_bytes.as_slice(),
             "published #mesh-pq key must equal the derived mesh signing key's public key");
+    }
+
+    #[test]
+    fn root_doc_advertises_iroh_vm_and_transport_when_bound() {
+        // #282: when the iroh substrate is bound, root_did_document adds the
+        // `#iroh` Ed25519 VM (the node_id) AND an IrohTransport service entry
+        // accepting both ALPNs. Mirror the exact construction root_did_document
+        // does (node_id → #iroh VM key + encode_iroh transport entry).
+        let oauth_sk = SigningKey::generate(&mut OsRng);
+        let node_sk = SigningKey::generate(&mut OsRng);
+        let node_id = node_sk.verifying_key().to_bytes();
+        let did = "did:web:hyprstream.example.com";
+
+        let iroh_vk = VerifyingKey::from_bytes(&node_id).unwrap();
+        let keys = vec![
+            ("key-1".to_owned(), oauth_sk.verifying_key()),
+            ("iroh".to_owned(), iroh_vk),
+        ];
+        let transports = [TransportEndpoint {
+            fragment: "iroh".to_owned(),
+            vm_type: "IrohTransport".to_owned(),
+            endpoint: hyprstream_rpc::service_entry::encode_iroh(
+                &node_id,
+                &[],
+                &["hyprstream-rpc/1", "moql"],
+            ),
+        }];
+        let doc = build_did_document(
+            did,
+            "https://hyprstream.example.com",
+            &keys,
+            None,
+            &transports,
+            None,
+        );
+
+        // The `#iroh` VM is present and carries the node_id as a Multikey.
+        let vms = doc["verificationMethod"].as_array().unwrap();
+        let iroh_vm = vms
+            .iter()
+            .find(|v| v["id"] == format!("{did}#iroh"))
+            .expect("`#iroh` verification method must be advertised");
+        assert_eq!(iroh_vm["type"].as_str().unwrap(), "Multikey");
+        let mb = iroh_vm["publicKeyMultibase"].as_str().unwrap();
+        let decoded = bs58::decode(&mb[1..]).into_vec().unwrap();
+        assert_eq!(&decoded[..2], &[0xed, 0x01], "ed25519-pub multicodec");
+        assert_eq!(&decoded[2..], &node_id, "`#iroh` VM key must equal the node_id");
+
+        // The IrohTransport service entry accepts BOTH ALPNs.
+        let svcs = doc["service"].as_array().unwrap();
+        let iroh_svc = svcs
+            .iter()
+            .find(|s| s["type"] == "IrohTransport")
+            .expect("IrohTransport service entry must be advertised");
+        assert_eq!(iroh_svc["id"].as_str().unwrap(), format!("{did}#iroh"));
+        let accept = iroh_svc["serviceEndpoint"]["accept"].as_array().unwrap();
+        let accept: Vec<&str> = accept.iter().filter_map(|v| v.as_str()).collect();
+        assert!(accept.contains(&"hyprstream-rpc/1"));
+        assert!(accept.contains(&"moql"));
+    }
+
+    #[test]
+    fn root_doc_omits_iroh_when_not_bound() {
+        // No iroh transport configured → no `#iroh` VM, no IrohTransport entry.
+        let sk = SigningKey::generate(&mut OsRng);
+        let did = "did:web:hyprstream.example.com";
+        let doc = build_did_document(
+            did,
+            "https://hyprstream.example.com",
+            &[("key-1".to_owned(), sk.verifying_key())],
+            None,
+            &[],
+            None,
+        );
+        let vms = doc["verificationMethod"].as_array().unwrap();
+        assert!(
+            !vms.iter().any(|v| v["id"] == format!("{did}#iroh")),
+            "no `#iroh` VM when iroh is not bound"
+        );
+        let svcs = doc["service"].as_array().unwrap();
+        assert!(
+            !svcs.iter().any(|s| s["type"] == "IrohTransport"),
+            "no IrohTransport entry when iroh is not bound"
+        );
     }
 
     #[test]

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -261,6 +261,52 @@ async fn oauth_self_protected_resource_metadata(
 /// (separate thread), and ZMQ async I/O (TMQ) registers socket file descriptors
 /// with the current runtime's epoll. A PolicyClient created in the main runtime
 /// would hang when polled from the OAuth runtime.
+/// #282: build the OAuth service's canonical federation iroh substrate.
+///
+/// Serves BOTH ALPNs (`hyprstream-rpc/1` via `processor`, `moql` via the
+/// process-global moq origin) on a single iroh endpoint whose node key is the
+/// OAuth signing key — the same key advertised as the root DID `#iroh` VM. The
+/// #137 admission gate (origin + key-binding vs `remote_id()`) guards both
+/// accept paths, fail-closed. Installs the shared client endpoint for outbound
+/// iroh dials. Native-only.
+async fn build_oauth_iroh_substrate(
+    signing_key: hyprstream_rpc::prelude::SigningKey,
+    processor: Arc<dyn hyprstream_rpc::transport::rpc_session::IrohRequestProcessor>,
+    policy_client: Arc<PolicyClient>,
+) -> anyhow::Result<hyprstream_rpc::transport::iroh_substrate::IrohSubstrate> {
+    use hyprstream_rpc::transport::{iroh_moq, iroh_rpc, iroh_substrate, lazy_iroh, rpc_session};
+
+    let admission = crate::auth::federation_admission::build_iroh_admission(policy_client)?;
+
+    // moq plane: reuse the SAME global origin the quinn `/moq` path serves.
+    let moq_handler = match hyprstream_rpc::moq_stream::global_moq_origin() {
+        Some(origin) => iroh_moq::IrohMoqProtocolHandler::with_origin(
+            iroh_moq::OriginShared::from_pair(origin.producer().clone(), origin.consumer().clone()),
+        ),
+        None => iroh_moq::IrohMoqProtocolHandler::new(),
+    }
+    .with_admission(Arc::clone(&admission));
+
+    let rpc_handler = iroh_rpc::IrohRpcProtocolHandler::with_stream_limit(
+        processor,
+        signing_key.clone(),
+        rpc_session::DEFAULT_STREAM_LIMIT,
+    )
+    .with_admission(admission);
+
+    // The iroh node key IS the OAuth signing key, so node_id == the advertised
+    // `#iroh` VM. `presets::N0` discovery (pkarr publisher + n0 DNS) is enabled by
+    // `IrohSubstrate::new`, so this node is dial-by-node_id-discoverable (#282).
+    let substrate = iroh_substrate::IrohSubstrate::new(
+        signing_key.to_bytes(),
+        moq_handler,
+        rpc_handler,
+    )
+    .await?;
+    let _ = lazy_iroh::install_iroh_client_endpoint(substrate.endpoint().clone());
+    Ok(substrate)
+}
+
 pub struct OAuthService {
     config: OAuthConfig,
     /// Global TLS configuration (passed from factory, avoids re-loading config)
@@ -632,6 +678,22 @@ impl Spawnable for OAuthService {
                             oauth_state = oauth_state.with_quic_transport(quic_uri, vec![hash]);
                         }
                     }
+
+                    // #282: advertise the `#iroh` VM + IrohTransport entry ONLY
+                    // when iroh is enabled. The iroh substrate the spawner binds
+                    // for THIS service uses `RequestService::signing_key` as its
+                    // node key, and that same key is `oauth_state.signing_key`
+                    // (set above via `with_signing_key`), so the published
+                    // `node_id` (== signing_key.verifying_key()) is exactly the
+                    // endpoint id this service's iroh substrate listens on — no
+                    // drift. Relays are left empty: peers resolve reachability by
+                    // node_id via iroh's built-in pkarr/DNS discovery (#282).
+                    if quic_cfg.iroh {
+                        if let Some(ref sk) = oauth_state.signing_key {
+                            let node_id = sk.verifying_key().to_bytes();
+                            oauth_state = oauth_state.with_iroh_transport(node_id, Vec::new());
+                        }
+                    }
                 }
             }
 
@@ -685,6 +747,27 @@ impl Spawnable for OAuthService {
             let control_transport = self.control_transport.clone();
             let rpc_signing_key = self.signing_key.clone();
             let rpc_state = state.clone();
+            // #282: bind the node's canonical federation iroh substrate for the
+            // OAuth (DID controller) identity when `[quic] iroh = true`. The node
+            // key is this service's signing key (== the root DID `#iroh` VM
+            // advertised above), so the published `node_id` has a live listener.
+            // The #137 admission gate (origin + key-binding vs `remote_id()`)
+            // guards both ALPNs, fail-closed.
+            let iroh_enabled = self.quic_config.as_ref().is_some_and(|q| q.enabled && q.iroh);
+            // Dedicated PolicyClient for the #137 admission gate (the primary
+            // `policy_client` was already moved into OAuthState). Same identity
+            // (this service's signing key) + the resolved policy verifying key.
+            let iroh_policy_client = if iroh_enabled {
+                match PolicyClient::for_service(self.signing_key.clone(), policy_vk, None) {
+                    Ok(pc) => Some(Arc::new(pc)),
+                    Err(e) => {
+                        tracing::warn!("OAuth iroh admission PolicyClient build failed: {e}");
+                        None
+                    }
+                }
+            } else {
+                None
+            };
             let serve_shutdown = Arc::new(Notify::new());
             let serve_shutdown_task = Arc::clone(&serve_shutdown);
             let rpc_loop = tokio::task::spawn_local(async move {
@@ -707,6 +790,27 @@ impl Spawnable for OAuthService {
                 };
                 let processor: Arc<dyn hyprstream_rpc::transport::rpc_session::IrohRequestProcessor> =
                     Arc::new(bridge);
+
+                // #282: parallel iroh substrate (RPC + moq ALPNs) for federation.
+                let _iroh_substrate = match iroh_policy_client {
+                    Some(pc) => match build_oauth_iroh_substrate(
+                        rpc_signing_key.clone(),
+                        Arc::clone(&processor),
+                        pc,
+                    )
+                    .await
+                    {
+                        Ok(substrate) => Some(substrate),
+                        Err(e) => {
+                            tracing::warn!(
+                                "OAuth iroh substrate bind failed; continuing without iroh: {e}"
+                            );
+                            None
+                        }
+                    },
+                    None => None,
+                };
+
                 if let Err(e) = hyprstream_rpc::service::serve::serve_bridged(
                     &control_transport,
                     processor,
@@ -717,6 +821,13 @@ impl Spawnable for OAuthService {
                 .await
                 {
                     tracing::error!("OAuth RPC serve error: {}", e);
+                }
+
+                // Drain the iroh substrate (accept loop + handlers) on shutdown.
+                if let Some(substrate) = _iroh_substrate {
+                    if let Err(e) = substrate.shutdown().await {
+                        tracing::warn!("OAuth iroh substrate shutdown error: {e}");
+                    }
                 }
             });
 

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -385,6 +385,15 @@ pub struct OAuthState {
     /// the published VM equals the key the node signs mesh responses with.
     /// `None` when the entity signing key is not configured.
     pub mesh_pq_verifying_key: Option<Vec<u8>>,
+    /// #282: the node's iroh endpoint id (its Ed25519 `node_id`, 32 bytes),
+    /// published as the `#iroh` verification method + an `IrohTransport` service
+    /// entry in the root DID document — **only** when the iroh substrate is
+    /// actually bound. `None` until the daemon binds iroh and reports it.
+    pub iroh_node_id: Option<[u8; 32]>,
+    /// #282: iroh relay URLs to advertise in the `IrohTransport` entry's
+    /// `relays`. Empty = rely on pkarr/DNS discovery for reachability (the
+    /// peer resolves direct paths by node_id alone).
+    pub iroh_relays: Vec<String>,
 }
 
 impl OAuthState {
@@ -438,6 +447,8 @@ impl OAuthState {
             quic_cert_hashes: Vec::new(),
             quic_public_uri: None,
             mesh_pq_verifying_key: None,
+            iroh_node_id: None,
+            iroh_relays: Vec::new(),
         }
     }
 
@@ -488,6 +499,19 @@ impl OAuthState {
     pub fn with_quic_transport(mut self, public_uri: String, cert_hashes: Vec<[u8; 32]>) -> Self {
         self.quic_public_uri = Some(public_uri);
         self.quic_cert_hashes = cert_hashes;
+        self
+    }
+
+    /// Set the node's iroh transport info for DID-doc publication (#282).
+    ///
+    /// Call this only when the iroh substrate is actually bound: it makes
+    /// `root_did_document` advertise the `#iroh` Ed25519 verification method and
+    /// an `IrohTransport` service entry (`accept: [hyprstream-rpc/1, moql]`).
+    /// `relays` may be empty — peers then resolve reachability by node_id alone
+    /// via iroh's pkarr/DNS discovery.
+    pub fn with_iroh_transport(mut self, node_id: [u8; 32], relays: Vec<String>) -> Self {
+        self.iroh_node_id = Some(node_id);
+        self.iroh_relays = relays;
         self
     }
 


### PR DESCRIPTION
Activate the iroh P2P plane (was test-only) as a shared substrate for Tiles
interop, and give #137's federation gate the real per-connection channel key it
lacked on the quinn path. Config-gated: [quic] iroh (serde default false) — the
quinn/WebTransport-only baseline is unchanged; an operator opts in.

1. Daemon bind (native-only, fail-soft): when [quic] iroh=true the spawner binds
   IrohSubstrate in parallel to the quinn endpoint for each QUIC-enabled service,
   serving both ALPNs (hyprstream-rpc/1 + moql) with the same processor + shared
   global moq Origin, and installs the process-wide iroh client endpoint. OAuth
   (the DID-controller identity) binds its own canonical federation substrate so
   the advertised #iroh node_id has a live listener. Bind failure → quinn continues.
2. dial_stream Iroh arm (replaces the #274 stub): real iroh moql dial via a
   MoqStreamSession{Quinn|Iroh} enum with connect_moq() dispatch. Loopback
   endpoint-to-endpoint moql round-trip tested.
3. DID advertisement: root_did_document advertises the #iroh Ed25519 VM (= node_id
   as Multikey) + an IrohTransport entry accept:[hyprstream-rpc/1, moql], only when
   bound. Verified node_id == the OAuth RPC service signing key (state.signing_key)
   so the advertised endpoint id matches the live listener.
4. #137 in the LIVE iroh accept path: new object-safe IrohPeerAdmission trait in
   hyprstream-rpc (avoids the rpc→hyprstream cycle); both iroh handlers call it with
   remote_id().as_bytes() and DROP the connection fail-closed on reject, before any
   stream is served. The hyprstream adapter (IrohFederationAdmission) maps remote_id()
   → self-certifying did:key (#281) as both the key-binding identity (stage 2,
   self-cert) and the stage-1 federation:register subject, then runs the #137 gate.
   remote_id() is the authenticated Ed25519 (iroh QUIC TLS bound it) — no #200/#185
   seam. The per-request service layer still re-verifies envelope signer == remote_id().
5. pkarr discovery: enabled via iroh presets::N0 (PkarrPublisher + n0-DNS resolver) —
   publish node_id→addresses + dial-by-node_id. Pure node_id↔#iroh/did:key binding
   unit-tested.

Documented seams (infra/schema, not faked): (a) pkarr live DHT round-trip + NAT
traversal need real infra / a second peer — can't be hermetically unit-tested.
(b) wire-reach iroh: reach_to_transport_config's Iroh arm stays None because the
codegen wire reach enum's Iroh is a unit variant with no nodeId/relay payload
(stream.capnp) — a StreamInfo can't yet publish a dialable iroh reach (dial_stream's
local iroh arm works + is tested). (c) non-OAuth spawned services set
iroh_admission=None (accept-open) — threading a PolicyClient through every factory
is a wider change; OAuth (the federation controller) has the full gate. All
mitigated by iroh being default-off.

Tests: dial_stream iroh moql loopback + no-reach fail-fast; iroh accept-path
admit-by-remote_id + reject-fail-closed; IrohPeerAdmission hook open/allow/deny;
federation_admission iroh admit/reject + node_id↔did:key/#iroh binding;
did_document #iroh VM advertised-when-bound/omitted-when-not. Native + wasm32 build
clean (no iroh wasm leak); clippy clean; hyprstream-rpc 410 pass (1 known moq_event
flake, verified on baseline).

Issue #282. Part of epic #131.
