### PR TITLE
feat(#283): adopt MIR (Machine Intelligence Resource) model-naming in the registry

### DIFF
--- a/crates/hyprstream/src/services/model.rs
+++ b/crates/hyprstream/src/services/model.rs
@@ -233,6 +233,55 @@ impl ModelService {
         registry().endpoint(&service_name, SocketKind::Rep).endpoint_string()
     }
 
+    /// Resolve a model identifier string to a [`ModelRef`], supporting MIR.
+    ///
+    /// Accepts three identifier forms:
+    /// - a registry name / HF repo id (e.g. `Qwen3-0.6B`, optionally `name:ref`),
+    /// - a MIR string (e.g. `mir:model.transformer.clip-l:stable-diffusion-xl`).
+    ///
+    /// MIR strings are matched against registered models by comparing the MIR
+    /// `series` to the series-key of each registered model's name (see
+    /// [`crate::storage::mir`] for the mapping + lossiness notes). MIR carries no
+    /// git revision, so the resolved ref uses the default branch.
+    async fn resolve_model_ref(&self, model_ref_str: &str) -> Result<ModelRef> {
+        if crate::storage::mir::is_mir(model_ref_str) {
+            let mir = crate::storage::mir::Mir::parse(model_ref_str)
+                .map_err(|e| anyhow!("Invalid MIR '{}': {}", model_ref_str, e))?;
+
+            let repos = self
+                .registry
+                .list()
+                .await
+                .map_err(|e| anyhow!("Failed to list registry for MIR resolution: {}", e))?;
+
+            let names: Vec<String> = repos.into_iter().map(|r| r.name).collect();
+            let name = crate::storage::mir::resolve_mir_against_names(
+                &mir,
+                names.iter().map(String::as_str),
+            )
+            .map_err(|e| anyhow!("Failed to resolve MIR '{}': {}", mir, e))?;
+            ModelRef::parse(&name)
+        } else {
+            ModelRef::parse(model_ref_str)
+        }
+    }
+
+    /// Emit a MIR for a registered model name.
+    ///
+    /// LOSSY: domain defaults to `model`, architecture to `unclassified`,
+    /// variant to `base`; only the series is derived from the name. See
+    /// [`crate::storage::mir::mir_from_internal_name`].
+    pub async fn mir_for_model(&self, model_ref_str: &str) -> Result<crate::storage::mir::Mir> {
+        let parsed = ModelRef::parse(model_ref_str)?;
+        // Verify the model exists in the registry before emitting a MIR.
+        self.registry
+            .get_by_name(&parsed.model)
+            .await
+            .map_err(|e| anyhow!("Model '{}' not found in registry: {}", parsed.model, e))?;
+        crate::storage::mir::mir_from_internal_name(&parsed.model)
+            .map_err(|e| anyhow!("Cannot derive MIR for '{}': {}", parsed.model, e))
+    }
+
     /// Load a model by reference with optional per-model config, returns the inference endpoint
     async fn load_model(&self, model_ref_str: &str, max_context: Option<u32>, kv_quant: Option<KVQuantType>) -> Result<String> {
         // Check if already loaded
@@ -271,8 +320,8 @@ impl ModelService {
 
     /// Inner model loading logic, called by load_model() which manages pending_loads.
     async fn load_model_inner(&self, model_ref_str: &str, max_context: Option<u32>, kv_quant: Option<KVQuantType>) -> Result<String> {
-        // Parse model reference
-        let model_ref = ModelRef::parse(model_ref_str)?;
+        // Parse/resolve model reference (supports MIR identifiers)
+        let model_ref = self.resolve_model_ref(model_ref_str).await?;
 
         // Get model path from registry
         let tracked = self.registry.get_by_name(&model_ref.model).await
@@ -717,8 +766,8 @@ impl TttHandler for ModelService {
         &self, _ctx: &EnvelopeContext, _request_id: u64,
         model_ref: &str, data: &WriteTttConfigRequest,
     ) -> Result<()> {
-        // 1. Parse model ref and resolve worktree path
-        let parsed = ModelRef::parse(model_ref)?;
+        // 1. Parse/resolve model ref (supports MIR) and resolve worktree path
+        let parsed = self.resolve_model_ref(model_ref).await?;
         let tracked = self.registry.get_by_name(&parsed.model).await
             .map_err(|e| anyhow!("Model '{}' not found in registry: {}", parsed.model, e))?;
         let repo_client = self.registry.repo(&tracked.id);
@@ -817,8 +866,8 @@ impl AdapterHandler for ModelService {
         &self, _ctx: &EnvelopeContext, _request_id: u64,
         model_ref: &str, value: &str,
     ) -> Result<AdapterInfo> {
-        // Resolve model_ref to a worktree client (does NOT require model loaded in memory)
-        let parsed = ModelRef::parse(model_ref)?;
+        // Resolve model_ref (supports MIR) to a worktree client (does NOT require model loaded in memory)
+        let parsed = self.resolve_model_ref(model_ref).await?;
         let tracked = self.registry.get_by_name(&parsed.model).await
             .map_err(|e| anyhow!("Model '{}' not found in registry: {}", parsed.model, e))?;
         let repo_client = self.registry.repo(&tracked.id);

--- a/crates/hyprstream/src/storage/mir.rs
+++ b/crates/hyprstream/src/storage/mir.rs
@@ -1,0 +1,900 @@
+//! MIR — Machine Intelligence Resource — model-naming/classification schema.
+//!
+//! MIR is the model-identity vocabulary defined by Tiles (tiles.run). It gives a
+//! cross-system, reproducible way to classify a model independent of where it
+//! lives (HuggingFace repo id, Modelfile `FROM`, local registry name).
+//!
+//! # Grammar
+//!
+//! ```text
+//! mir:<domain>.<arch>.<variant>:<series>
+//! ```
+//!
+//! Example: `mir:model.transformer.clip-l:stable-diffusion-xl`
+//!
+//! - `domain`  — one of `dev`, `model`, `ops`, `info`, `arch` (the issue's
+//!   authoritative grammar uses `dev/model/ops/info`; Tiles also documents an
+//!   `arch`/"architecture" domain, which we accept as a superset).
+//! - `arch`    — an architecture taxonomy label (e.g. `resnet`, `lstm`, `vae`,
+//!   `transformer`, `moe`, `lora`, ...). Unknown labels are accepted as an
+//!   [`Arch::Extension`] (superset behaviour) rather than rejected, so a label
+//!   Tiles adds later does not hard-fail us.
+//! - `variant` — a free-form, normalized sub-classification (e.g. `clip-l`).
+//! - `series`  — the normalized model series (e.g. `stable-diffusion-xl`),
+//!   subject to the series-normalization rules below.
+//!
+//! # Source / fidelity note
+//!
+//! The taxonomy + normalization rules here are transcribed from the MIR section
+//! of <https://www.tiles.run/llms-full.txt> (fetched 2026-06) cross-checked
+//! against the issue (#283). The Tiles prose is loose about whether the third
+//! dot-field is the "variant" or "series"; the issue's authoritative grammar
+//! names the third dot-field `variant` and the post-colon field `series`, which
+//! is what we implement. The canonical example
+//! `mir:model.transformer.clip-l:stable-diffusion-xl` parses under this grammar.
+//!
+//! See `docs/interop/tiles-alignment.md` for the internal-id <-> MIR mapping.
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+/// The MIR scheme prefix (`mir:`).
+pub const MIR_SCHEME: &str = "mir:";
+
+/// Errors produced while parsing or validating a [`Mir`].
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum MirError {
+    /// String does not start with the `mir:` scheme.
+    #[error("not a MIR identifier (missing `mir:` scheme): {0:?}")]
+    MissingScheme(String),
+    /// The `domain.arch.variant` body or `series` segment is missing.
+    #[error("malformed MIR `{0:?}`: expected `mir:<domain>.<arch>.<variant>:<series>`")]
+    Malformed(String),
+    /// The domain segment is empty or not a recognized domain.
+    #[error("invalid MIR domain {0:?}: expected one of dev/model/ops/info/arch")]
+    InvalidDomain(String),
+    /// The architecture segment is empty or syntactically invalid.
+    #[error("invalid MIR architecture {0:?}")]
+    InvalidArch(String),
+    /// The variant segment is empty or syntactically invalid.
+    #[error("invalid MIR variant {0:?}")]
+    InvalidVariant(String),
+    /// The series segment is empty or syntactically invalid.
+    #[error("invalid MIR series {0:?}")]
+    InvalidSeries(String),
+}
+
+/// MIR domain — the broadest classification axis, ordered most-specific to
+/// most-general per the Tiles spec.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Domain {
+    /// Pre-release items under evaluation.
+    Dev,
+    /// Publicly released ML models with identifiers.
+    Model,
+    /// Optimization / manipulation techniques.
+    Ops,
+    /// Metadata about layer names and settings.
+    Info,
+    /// Broad, general system-architecture terms (Tiles "Architecture" domain).
+    Arch,
+}
+
+impl Domain {
+    /// Canonical lowercase token for this domain.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Domain::Dev => "dev",
+            Domain::Model => "model",
+            Domain::Ops => "ops",
+            Domain::Info => "info",
+            Domain::Arch => "arch",
+        }
+    }
+
+    fn parse(s: &str) -> Result<Self, MirError> {
+        match s.to_ascii_lowercase().as_str() {
+            "dev" => Ok(Domain::Dev),
+            "model" => Ok(Domain::Model),
+            "ops" => Ok(Domain::Ops),
+            "info" => Ok(Domain::Info),
+            // Tiles documents the broad-architecture domain as "Architecture";
+            // accept both `arch` and `architecture` as a superset.
+            "arch" | "architecture" => Ok(Domain::Arch),
+            _ => Err(MirError::InvalidDomain(s.to_owned())),
+        }
+    }
+}
+
+impl fmt::Display for Domain {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// The MIR architecture taxonomy.
+///
+/// Known labels are transcribed from the Tiles MIR taxonomy. Unknown labels are
+/// preserved as [`Arch::Extension`] so MIR remains a superset: a label Tiles
+/// adds later (or a project-local extension) parses rather than hard-failing,
+/// while canonical emission stays stable (always lowercase).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Arch {
+    /// A known taxonomy label, stored canonically (lowercase).
+    Known(KnownArch),
+    /// An out-of-taxonomy label, preserved verbatim (lowercased).
+    Extension(String),
+}
+
+/// Architectures enumerated in the Tiles MIR taxonomy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum KnownArch {
+    /// Gated Recurrent Unit.
+    Gru,
+    /// Restricted Boltzmann Machine.
+    Rbm,
+    /// Tiny Autoencoder.
+    Tae,
+    /// Variational Autoencoder.
+    Vae,
+    /// Long Short-Term Memory.
+    Lstm,
+    /// Residual Network.
+    Resnet,
+    /// Convolutional Neural Network.
+    Cnn,
+    /// Region-based Convolutional Neural Network.
+    Rcnn,
+    /// Recurrent Neural Network.
+    Rnn,
+    /// Bi-directional Recurrent Neural Network.
+    Brnn,
+    /// Generative Adversarial Network.
+    Gan,
+    /// State-Space Model.
+    Ssm,
+    /// Detection Transformer.
+    Detr,
+    /// Vision Transformer.
+    Vit,
+    /// Mixture of Experts.
+    Moe,
+    /// Autoencoding Transformer.
+    Aet,
+    /// Sequence-to-Sequence Transformer.
+    Stst,
+    /// Autoregressive Transformer.
+    Art,
+    /// Low-Rank Adaptation.
+    Lora,
+    /// ControlNet.
+    Controlnet,
+    /// Unknown / unclassified architecture.
+    Unclassified,
+    /// Generic transformer (used by the canonical Tiles example; not in the
+    /// abbreviation table but a first-class label in the spec's examples).
+    Transformer,
+}
+
+impl KnownArch {
+    /// Canonical lowercase token for this architecture.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            KnownArch::Gru => "gru",
+            KnownArch::Rbm => "rbm",
+            KnownArch::Tae => "tae",
+            KnownArch::Vae => "vae",
+            KnownArch::Lstm => "lstm",
+            KnownArch::Resnet => "resnet",
+            KnownArch::Cnn => "cnn",
+            KnownArch::Rcnn => "rcnn",
+            KnownArch::Rnn => "rnn",
+            KnownArch::Brnn => "brnn",
+            KnownArch::Gan => "gan",
+            KnownArch::Ssm => "ssm",
+            KnownArch::Detr => "detr",
+            KnownArch::Vit => "vit",
+            KnownArch::Moe => "moe",
+            KnownArch::Aet => "aet",
+            KnownArch::Stst => "stst",
+            KnownArch::Art => "art",
+            KnownArch::Lora => "lora",
+            KnownArch::Controlnet => "controlnet",
+            KnownArch::Unclassified => "unclassified",
+            KnownArch::Transformer => "transformer",
+        }
+    }
+
+    fn from_token(s: &str) -> Option<Self> {
+        Some(match s {
+            "gru" => KnownArch::Gru,
+            "rbm" => KnownArch::Rbm,
+            "tae" => KnownArch::Tae,
+            "vae" => KnownArch::Vae,
+            "lstm" => KnownArch::Lstm,
+            "resnet" => KnownArch::Resnet,
+            "cnn" => KnownArch::Cnn,
+            "rcnn" => KnownArch::Rcnn,
+            "rnn" => KnownArch::Rnn,
+            "brnn" => KnownArch::Brnn,
+            "gan" => KnownArch::Gan,
+            "ssm" => KnownArch::Ssm,
+            "detr" => KnownArch::Detr,
+            "vit" => KnownArch::Vit,
+            "moe" => KnownArch::Moe,
+            "aet" => KnownArch::Aet,
+            "stst" => KnownArch::Stst,
+            "art" => KnownArch::Art,
+            "lora" => KnownArch::Lora,
+            "controlnet" => KnownArch::Controlnet,
+            "unclassified" => KnownArch::Unclassified,
+            "transformer" => KnownArch::Transformer,
+            _ => return None,
+        })
+    }
+}
+
+impl Arch {
+    /// Parse an architecture token. Known taxonomy labels become
+    /// [`Arch::Known`]; any other syntactically-valid token becomes
+    /// [`Arch::Extension`] (superset behaviour).
+    fn parse(s: &str) -> Result<Self, MirError> {
+        let lower = s.to_ascii_lowercase();
+        if lower.is_empty() || !is_valid_token(&lower) {
+            return Err(MirError::InvalidArch(s.to_owned()));
+        }
+        Ok(match KnownArch::from_token(&lower) {
+            Some(known) => Arch::Known(known),
+            None => Arch::Extension(lower),
+        })
+    }
+
+    /// Canonical lowercase token for this architecture.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Arch::Known(k) => k.as_str(),
+            Arch::Extension(s) => s.as_str(),
+        }
+    }
+
+    /// Whether this architecture is part of the standard Tiles taxonomy.
+    pub fn is_known(&self) -> bool {
+        matches!(self, Arch::Known(_))
+    }
+}
+
+impl fmt::Display for Arch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A parsed, canonical MIR identifier.
+///
+/// Round-trip guarantee: for any valid `s`, `Mir::parse(s)?.to_string()` equals
+/// the canonical form of `s` (lowercase, normalized series). Parsing the
+/// canonical form again yields an identical `Mir` (idempotent).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Mir {
+    /// Classification domain.
+    pub domain: Domain,
+    /// Architecture taxonomy label.
+    pub arch: Arch,
+    /// Free-form normalized variant (e.g. `clip-l`).
+    pub variant: String,
+    /// Normalized model series (e.g. `stable-diffusion-xl`).
+    pub series: String,
+}
+
+impl Mir {
+    /// Construct from already-parsed parts, validating + normalizing each field.
+    pub fn new(
+        domain: Domain,
+        arch: Arch,
+        variant: impl Into<String>,
+        series: impl Into<String>,
+    ) -> Result<Self, MirError> {
+        let variant = normalize_token(&variant.into());
+        if variant.is_empty() || !is_valid_token(&variant) {
+            return Err(MirError::InvalidVariant(variant));
+        }
+        let series = normalize_series(&series.into());
+        if series.is_empty() || !is_valid_token(&series) {
+            return Err(MirError::InvalidSeries(series));
+        }
+        Ok(Self { domain, arch, variant, series })
+    }
+
+    /// Parse a `mir:domain.arch.variant:series` string into a canonical [`Mir`].
+    ///
+    /// Rejects: a missing/incorrect scheme, fewer than three dot-fields in the
+    /// body, a missing series, an unknown domain, or any empty/invalid segment.
+    /// Accepts unknown architecture labels as extensions.
+    pub fn parse(s: &str) -> Result<Self, MirError> {
+        let s = s.trim();
+        // Scheme match is case-insensitive (MIR: / mir:); the body is normalized
+        // to lowercase per-field below, so canonical emission is always lowercase.
+        let scheme_len = MIR_SCHEME.len();
+        if s.len() < scheme_len || !s[..scheme_len].eq_ignore_ascii_case(MIR_SCHEME) {
+            return Err(MirError::MissingScheme(s.to_owned()));
+        }
+        let rest = &s[scheme_len..];
+
+        // Split body (domain.arch.variant) from series at the FIRST remaining
+        // colon. The series itself must not contain a colon.
+        let (body, series_raw) = rest
+            .split_once(':')
+            .ok_or_else(|| MirError::Malformed(s.to_owned()))?;
+        if series_raw.contains(':') {
+            return Err(MirError::Malformed(s.to_owned()));
+        }
+
+        // Body must be exactly domain.arch.variant. The variant may itself
+        // contain hyphens but not dots (dots are field separators), so splitn(3)
+        // would wrongly fold a 4th dot-field into the variant — require exactly 3.
+        let parts: Vec<&str> = body.split('.').collect();
+        if parts.len() != 3 {
+            return Err(MirError::Malformed(s.to_owned()));
+        }
+        let domain = Domain::parse(parts[0])?;
+        let arch = Arch::parse(parts[1])?;
+
+        let variant = normalize_token(parts[2]);
+        if variant.is_empty() || !is_valid_token(&variant) {
+            return Err(MirError::InvalidVariant(parts[2].to_owned()));
+        }
+
+        let series = normalize_series(series_raw);
+        if series.is_empty() || !is_valid_token(&series) {
+            return Err(MirError::InvalidSeries(series_raw.to_owned()));
+        }
+
+        Ok(Self { domain, arch, variant, series })
+    }
+
+    /// Canonical string form (`mir:domain.arch.variant:series`).
+    pub fn to_canonical_string(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl fmt::Display for Mir {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}{}.{}.{}:{}",
+            MIR_SCHEME, self.domain, self.arch, self.variant, self.series
+        )
+    }
+}
+
+impl FromStr for Mir {
+    type Err = MirError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Mir::parse(s)
+    }
+}
+
+/// Whether a string is a `mir:` identifier (cheap, case-insensitive prefix
+/// check; does not validate).
+pub fn is_mir(s: &str) -> bool {
+    let s = s.trim_start();
+    s.len() >= MIR_SCHEME.len() && s[..MIR_SCHEME.len()].eq_ignore_ascii_case(MIR_SCHEME)
+}
+
+/// Normalize a single token: lowercase, collapse whitespace/underscores/slashes
+/// to hyphens, strip leading/trailing hyphens. Used for variant + as the base of
+/// series normalization.
+fn normalize_token(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            'A'..='Z' => out.push(ch.to_ascii_lowercase()),
+            'a'..='z' | '0'..='9' | '-' | '.' => out.push(ch),
+            ' ' | '\t' | '_' | '/' => out.push('-'),
+            _ => {} // drop anything else
+        }
+    }
+    // collapse consecutive hyphens
+    let mut collapsed = String::with_capacity(out.len());
+    let mut prev_hyphen = false;
+    for ch in out.chars() {
+        if ch == '-' {
+            if !prev_hyphen {
+                collapsed.push(ch);
+            }
+            prev_hyphen = true;
+        } else {
+            collapsed.push(ch);
+            prev_hyphen = false;
+        }
+    }
+    collapsed.trim_matches('-').to_owned()
+}
+
+/// Apply MIR series-normalization rules:
+///
+/// - Lowercase, hyphen-only separators.
+/// - Strip any library/org prefix (drop everything before the last `/`).
+/// - Remove parameter-size tokens (e.g. `7b`, `0.6b`, `13B`).
+/// - Remove non-breaking semantic version suffixes, keeping only the breaking
+///   (major) version (e.g. `v1.2` -> `v1`).
+/// - Strip known library-name suffixes (e.g. `-diffusers`).
+///
+/// Examples (from the Tiles spec):
+/// - `tencent-hunyuan/hunyuandiT-v1.2-diffusers` -> `hunyuandit-v1`
+/// - `black-forest-labs/FLUX.1-dev` -> `flux1dev`
+///
+/// # Spec ambiguity (documented)
+///
+/// The two Tiles examples differ in separator handling: hunyuan keeps the `-`
+/// before its `v1` version (`hunyuandit-v1`); flux drops all separators
+/// (`flux1dev`). The distinguishing feature is that flux contains a *dotted
+/// bare-number* token (`FLUX.1`) that merges a digit into the name, whereas
+/// hunyuan/SDXL use clean word/`vN` boundaries. We reconcile both with one
+/// deterministic rule:
+///
+/// - If any surviving token is a **dotted bare-number** (e.g. `flux.1`):
+///   flatten the whole series to a single lowercase alnum run. => `flux1dev`.
+/// - Otherwise: keep `-` separators between tokens, collapse `vN.M` -> `vN`,
+///   and drop any stray `.`. => `hunyuandit-v1`, `stable-diffusion-xl`,
+///   `qwen3`, `llama-2`.
+///
+/// This is a superset choice; see `docs/interop/tiles-alignment.md`.
+fn normalize_series(s: &str) -> String {
+    // Strip org/library prefix: keep the segment after the last '/'.
+    let base = s.rsplit('/').next().unwrap_or(s);
+
+    // Lowercase + hyphenate separators, but keep '.' for now so we can reason
+    // about version numbers before flattening.
+    let lowered = normalize_token(base);
+
+    // Tokenize on hyphens; drop noise tokens; collapse minor versions.
+    let mut tokens: Vec<String> = Vec::new();
+    let mut has_dotted_bare_number = false;
+    for tok in lowered.split('-') {
+        if tok.is_empty() {
+            continue;
+        }
+        // Drop known library-name suffix tokens.
+        if is_library_token(tok) {
+            continue;
+        }
+        // Drop parameter-size tokens like 7b / 0.6b / 13b.
+        if is_param_size_token(tok) {
+            continue;
+        }
+        if is_dotted_bare_number(tok) {
+            has_dotted_bare_number = true;
+        }
+        // Collapse non-breaking semver: v1.2.3 -> v1, 1.2 -> 1.
+        tokens.push(strip_minor_version(tok));
+    }
+
+    if has_dotted_bare_number {
+        // Flatten everything to a single alnum run (flux1dev).
+        tokens
+            .into_iter()
+            .flat_map(|t| t.chars().collect::<Vec<_>>())
+            .filter(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+            .collect()
+    } else {
+        // Keep hyphen separators; drop any '.' left in tokens.
+        let kept: Vec<String> = tokens
+            .into_iter()
+            .map(|t| t.chars().filter(|&c| c != '.').collect::<String>())
+            .filter(|t| !t.is_empty())
+            .collect();
+        kept.join("-").trim_matches('-').to_owned()
+    }
+}
+
+/// Whether a token mixes a *name* with a dotted number (e.g. `flux.1`), the
+/// flux-style marker that triggers full series flattening. Excludes explicit
+/// version tokens like `v1.2` (which are handled as versions, keeping hyphens).
+fn is_dotted_bare_number(tok: &str) -> bool {
+    if !tok.contains('.') {
+        return false;
+    }
+    // Exclude version tokens: `v` + dotted digits (e.g. `v1.2`).
+    if let Some(rest) = tok.strip_prefix('v') {
+        if rest.split('.').all(|p| !p.is_empty() && p.chars().all(|c| c.is_ascii_digit())) {
+            return false;
+        }
+    }
+    let has_alpha = tok.chars().any(|c| c.is_ascii_alphabetic());
+    let tail = tok.rsplit('.').next().unwrap_or("");
+    has_alpha && !tail.is_empty() && tail.chars().all(|c| c.is_ascii_digit())
+}
+
+/// Known library-name tokens that should be stripped from a series.
+fn is_library_token(tok: &str) -> bool {
+    matches!(
+        tok,
+        "diffusers" | "transformers" | "gguf" | "safetensors" | "onnx" | "ggml"
+    )
+}
+
+/// Whether a token is a parameter-size marker (e.g. `7b`, `0.6b`, `13b`, `70m`).
+fn is_param_size_token(tok: &str) -> bool {
+    let suffix = tok.chars().last();
+    if !matches!(suffix, Some('b') | Some('m') | Some('k')) {
+        return false;
+    }
+    let num = &tok[..tok.len() - 1];
+    !num.is_empty()
+        && num.chars().all(|c| c.is_ascii_digit() || c == '.')
+        && num.chars().any(|c| c.is_ascii_digit())
+}
+
+/// Collapse a non-breaking semantic version to its breaking (major) component:
+/// `v1.2.3` -> `v1`, `1.2` -> `1`. Non-version tokens are returned unchanged.
+fn strip_minor_version(tok: &str) -> String {
+    let (prefix, ver) = if let Some(rest) = tok.strip_prefix('v') {
+        ("v", rest)
+    } else {
+        ("", tok)
+    };
+    // Only treat as a version if it looks like a dotted number.
+    if ver.contains('.') && ver.split('.').all(|p| !p.is_empty() && p.chars().all(|c| c.is_ascii_digit())) {
+        let major = ver.split('.').next().unwrap_or(ver);
+        return format!("{prefix}{major}");
+    }
+    tok.to_owned()
+}
+
+/// Validate a normalized token: lowercase alnum, hyphens, dots; non-empty; no
+/// leading/trailing hyphen or dot; no consecutive dots.
+fn is_valid_token(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+    if s.starts_with('-') || s.ends_with('-') || s.starts_with('.') || s.ends_with('.') {
+        return false;
+    }
+    if s.contains("..") {
+        return false;
+    }
+    s.chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '.')
+}
+
+// ============================================================================
+// Internal model-id  <->  MIR mapping
+// ============================================================================
+//
+// Our internal model identity is `ModelRef { model, git_ref }`, where `model`
+// is a registry name that is typically a HuggingFace-style id (`org/repo`,
+// e.g. `Qwen/Qwen3-0.6B`) or a bare local name (e.g. `llama3`). The MIR
+// `series` field is the normalized model series. The git_ref/branch is NOT
+// represented in MIR (MIR classifies the model, not a specific revision).
+//
+// Mapping directions and lossiness:
+//
+//   internal-id  ->  MIR     (LOSSY): the domain defaults to `model` and the
+//       architecture defaults to `unclassified` because neither can be derived
+//       from a HF repo id alone. The variant defaults to `base`. Only `series`
+//       is derived (via series normalization). Callers that know the arch/
+//       domain/variant should supply them via [`Mir::new`] instead.
+//
+//   MIR  ->  internal-id     (LOSSY, partial inverse): we recover the registry
+//       name candidate from the `series` (the org/library prefix and the exact
+//       casing/param-size of the original HF id are NOT recoverable). Use this
+//       to *match* against registered models rather than to reconstruct the
+//       canonical HF id.
+//
+// Because of the lossy directions there is no exact bijection. The round-trip
+// that IS defined and tested: `mir_from_series(mir.series) == mir.series` for
+// any already-normalized series (series normalization is idempotent), so
+// `internal -> MIR -> series` is stable once normalized.
+
+/// Default variant used when mapping an internal id with no known sub-variant.
+pub const DEFAULT_VARIANT: &str = "base";
+
+/// Derive a MIR from an internal model name (HF repo id or local name).
+///
+/// LOSSY: defaults domain=`model`, arch=`unclassified`, variant=`base`; only
+/// the series is derived from the name. Prefer [`Mir::new`] when arch/variant
+/// are known. Returns an error only if the name yields an empty series.
+pub fn mir_from_internal_name(name: &str) -> Result<Mir, MirError> {
+    Mir::new(Domain::Model, Arch::Known(KnownArch::Unclassified), DEFAULT_VARIANT, name)
+}
+
+/// Derive a MIR from an internal name with a known architecture and variant.
+///
+/// Still lossy on domain (defaults to `model`); series is derived from `name`.
+pub fn mir_from_internal_name_with(
+    name: &str,
+    arch: Arch,
+    variant: &str,
+) -> Result<Mir, MirError> {
+    Mir::new(Domain::Model, arch, variant, name)
+}
+
+/// Recover the candidate internal series name from a MIR.
+///
+/// This is the normalized series only — it does NOT recover the org/library
+/// prefix or original casing of a HF repo id. Use it to match registered model
+/// names (after applying the same normalization to them).
+pub fn internal_series_from_mir(mir: &Mir) -> String {
+    mir.series.clone()
+}
+
+/// Normalize an internal model name to the MIR series form, for matching.
+///
+/// Two internal names map to the same model iff their normalized series match.
+pub fn series_key_for_name(name: &str) -> String {
+    normalize_series(name)
+}
+
+/// Resolve a MIR against a set of registered model names, returning the unique
+/// matching name (the core of `ModelService::resolve_model_ref`, factored out
+/// for testability without a live registry).
+///
+/// Matches a registered name iff its series-key equals the MIR's series. Returns
+/// `Err` for no match or an ambiguous (>1) match.
+pub fn resolve_mir_against_names<'a>(
+    mir: &Mir,
+    registered_names: impl IntoIterator<Item = &'a str>,
+) -> Result<String, MirResolveError> {
+    let target = internal_series_from_mir(mir);
+    let mut matches: Vec<String> = registered_names
+        .into_iter()
+        .filter(|n| !n.is_empty())
+        .filter(|n| series_key_for_name(n) == target)
+        .map(ToOwned::to_owned)
+        .collect();
+    matches.sort();
+    matches.dedup();
+    match matches.len() {
+        0 => Err(MirResolveError::NotFound(target)),
+        1 => Ok(matches.remove(0)),
+        _ => Err(MirResolveError::Ambiguous { series: target, candidates: matches }),
+    }
+}
+
+/// Error from [`resolve_mir_against_names`].
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum MirResolveError {
+    /// No registered model has a matching series key.
+    #[error("no registered model matches MIR series {0:?}")]
+    NotFound(String),
+    /// More than one registered model matches the series key.
+    #[error("MIR series {series:?} is ambiguous; candidates: {candidates:?}")]
+    Ambiguous {
+        /// The normalized series that was searched for.
+        series: String,
+        /// The registered names that matched.
+        candidates: Vec<String>,
+    },
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_canonical_example() {
+        let mir = Mir::parse("mir:model.transformer.clip-l:stable-diffusion-xl").unwrap();
+        assert_eq!(mir.domain, Domain::Model);
+        assert_eq!(mir.arch, Arch::Known(KnownArch::Transformer));
+        assert_eq!(mir.variant, "clip-l");
+        assert_eq!(mir.series, "stable-diffusion-xl");
+    }
+
+    #[test]
+    fn display_roundtrip_is_canonical() {
+        let canonical = "mir:model.transformer.clip-l:stable-diffusion-xl";
+        let mir = Mir::parse(canonical).unwrap();
+        assert_eq!(mir.to_string(), canonical);
+        // idempotent re-parse
+        assert_eq!(Mir::parse(&mir.to_string()).unwrap(), mir);
+    }
+
+    #[test]
+    fn parse_normalizes_case() {
+        let mir = Mir::parse("MIR:MODEL.TRANSFORMER.CLIP-L:Stable-Diffusion-XL").unwrap();
+        assert_eq!(mir.to_string(), "mir:model.transformer.clip-l:stable-diffusion-xl");
+    }
+
+    #[test]
+    fn known_arch_parses() {
+        for label in [
+            "gru", "rbm", "tae", "vae", "lstm", "resnet", "cnn", "rcnn", "rnn", "brnn", "gan",
+            "ssm", "detr", "vit", "moe", "aet", "stst", "art", "lora", "controlnet",
+            "unclassified", "transformer",
+        ] {
+            let s = format!("mir:model.{label}.base:demo");
+            let mir = Mir::parse(&s).unwrap();
+            assert!(mir.arch.is_known(), "{label} should be known");
+            assert_eq!(mir.arch.as_str(), label);
+        }
+    }
+
+    #[test]
+    fn unknown_arch_is_extension_superset() {
+        let mir = Mir::parse("mir:model.mamba2.base:falcon").unwrap();
+        assert_eq!(mir.arch, Arch::Extension("mamba2".to_owned()));
+        assert!(!mir.arch.is_known());
+        // canonical emission stays stable
+        assert_eq!(mir.to_string(), "mir:model.mamba2.base:falcon");
+    }
+
+    #[test]
+    fn all_domains_parse() {
+        for (label, dom) in [
+            ("dev", Domain::Dev),
+            ("model", Domain::Model),
+            ("ops", Domain::Ops),
+            ("info", Domain::Info),
+            ("arch", Domain::Arch),
+            ("architecture", Domain::Arch),
+        ] {
+            let mir = Mir::parse(&format!("mir:{label}.vae.base:demo")).unwrap();
+            assert_eq!(mir.domain, dom);
+        }
+    }
+
+    #[test]
+    fn reject_missing_scheme() {
+        assert!(matches!(
+            Mir::parse("model.transformer.clip-l:sdxl"),
+            Err(MirError::MissingScheme(_))
+        ));
+    }
+
+    #[test]
+    fn reject_missing_series() {
+        assert!(matches!(
+            Mir::parse("mir:model.transformer.clip-l"),
+            Err(MirError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn reject_missing_domain_or_arch() {
+        // only two dot-fields -> malformed (no variant)
+        assert!(matches!(
+            Mir::parse("mir:model.transformer:sdxl"),
+            Err(MirError::Malformed(_))
+        ));
+        // empty domain
+        assert!(matches!(
+            Mir::parse("mir:.transformer.clip:sdxl"),
+            Err(MirError::InvalidDomain(_))
+        ));
+    }
+
+    #[test]
+    fn reject_bad_domain() {
+        assert!(matches!(
+            Mir::parse("mir:bogus.vae.base:demo"),
+            Err(MirError::InvalidDomain(_))
+        ));
+    }
+
+    #[test]
+    fn reject_extra_colon_in_series() {
+        assert!(matches!(
+            Mir::parse("mir:model.vae.base:demo:extra"),
+            Err(MirError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn reject_four_dot_fields() {
+        assert!(matches!(
+            Mir::parse("mir:model.vae.base.extra:demo"),
+            Err(MirError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn series_normalization_hunyuan() {
+        // tencent-hunyuan/hunyuandiT-v1.2-diffusers -> hunyuandit-v1
+        assert_eq!(normalize_series("tencent-hunyuan/hunyuandiT-v1.2-diffusers"), "hunyuandit-v1");
+    }
+
+    #[test]
+    fn series_normalization_flux() {
+        // black-forest-labs/FLUX.1-dev -> flux1dev
+        assert_eq!(normalize_series("black-forest-labs/FLUX.1-dev"), "flux1dev");
+    }
+
+    #[test]
+    fn series_normalization_strips_param_size() {
+        assert_eq!(normalize_series("Qwen/Qwen3-0.6B"), "qwen3");
+        // clean word boundaries -> hyphens kept (param-size 7b stripped)
+        assert_eq!(normalize_series("meta-llama/Llama-2-7b"), "llama-2");
+    }
+
+    #[test]
+    fn new_validates_and_normalizes() {
+        let mir = Mir::new(Domain::Model, Arch::Known(KnownArch::Vae), "Clip_L", "Stable Diffusion XL").unwrap();
+        assert_eq!(mir.variant, "clip-l");
+        assert_eq!(mir.series, "stable-diffusion-xl");
+        assert_eq!(mir.to_string(), "mir:model.vae.clip-l:stable-diffusion-xl");
+    }
+
+    #[test]
+    fn is_mir_detects_scheme() {
+        assert!(is_mir("mir:model.vae.base:demo"));
+        assert!(is_mir("  mir:model.vae.base:demo"));
+        assert!(!is_mir("Qwen/Qwen3-0.6B"));
+        assert!(!is_mir("llama3:main"));
+    }
+
+    #[test]
+    fn internal_name_to_mir_lossy() {
+        let mir = mir_from_internal_name("Qwen/Qwen3-0.6B").unwrap();
+        assert_eq!(mir.domain, Domain::Model);
+        assert_eq!(mir.arch, Arch::Known(KnownArch::Unclassified));
+        assert_eq!(mir.variant, "base");
+        assert_eq!(mir.series, "qwen3");
+        assert_eq!(mir.to_string(), "mir:model.unclassified.base:qwen3");
+    }
+
+    #[test]
+    fn internal_name_to_mir_with_arch() {
+        let mir = mir_from_internal_name_with(
+            "stabilityai/stable-diffusion-xl",
+            Arch::Known(KnownArch::Transformer),
+            "clip-l",
+        )
+        .unwrap();
+        assert_eq!(mir.to_string(), "mir:model.transformer.clip-l:stable-diffusion-xl");
+    }
+
+    #[test]
+    fn mir_to_internal_series_roundtrip() {
+        // internal name -> MIR -> series, stable once normalized
+        let name = "Qwen/Qwen3-0.6B";
+        let mir = mir_from_internal_name(name).unwrap();
+        let series = internal_series_from_mir(&mir);
+        assert_eq!(series, "qwen3");
+        // series_key matching: the normalized key of the original name matches
+        assert_eq!(series_key_for_name(name), series);
+        // re-deriving from the recovered series is idempotent
+        let mir2 = mir_from_internal_name(&series).unwrap();
+        assert_eq!(mir2.series, mir.series);
+    }
+
+    #[test]
+    fn series_key_matches_across_aliases() {
+        // org-prefixed and bare names normalize to the same key
+        assert_eq!(series_key_for_name("Qwen/Qwen3-0.6B"), series_key_for_name("Qwen3-0.6B"));
+    }
+
+    #[test]
+    fn registry_resolves_model_by_mir() {
+        // A MIR string resolves to a registered model name by series match.
+        let names = ["Qwen3-0.6B", "Llama-2-7b", "stable-diffusion-xl"];
+        let mir = Mir::parse("mir:model.unclassified.base:qwen3").unwrap();
+        let resolved = resolve_mir_against_names(&mir, names).unwrap();
+        assert_eq!(resolved, "Qwen3-0.6B");
+    }
+
+    #[test]
+    fn registry_resolve_mir_not_found() {
+        let names = ["Qwen3-0.6B"];
+        let mir = Mir::parse("mir:model.vae.base:mistral").unwrap();
+        assert!(matches!(
+            resolve_mir_against_names(&mir, names),
+            Err(MirResolveError::NotFound(_))
+        ));
+    }
+
+    #[test]
+    fn registry_resolve_mir_ambiguous() {
+        // Two registered names normalizing to the same series -> ambiguous.
+        let names = ["Qwen/Qwen3-0.6B", "qwen3"];
+        let mir = Mir::parse("mir:model.unclassified.base:qwen3").unwrap();
+        assert!(matches!(
+            resolve_mir_against_names(&mir, names),
+            Err(MirResolveError::Ambiguous { .. })
+        ));
+    }
+}

--- a/crates/hyprstream/src/storage/mod.rs
+++ b/crates/hyprstream/src/storage/mod.rs
@@ -10,6 +10,7 @@
 //! - Git-native model registry
 pub mod adapter_manager;
 pub mod errors;
+pub mod mir;
 pub mod model_ref;
 pub mod paths;
 pub mod release_store;
@@ -17,6 +18,7 @@ pub mod release_store;
 // Re-export types for backward compatibility
 pub use adapter_manager::{AdapterConfig, AdapterInfo, AdapterManager};
 pub use errors::{ModelRefError, ModelRefResult};
+pub use mir::{Arch, Domain, KnownArch, Mir, MirError};
 pub use model_ref::{validate_model_name, GitRef, ModelRef};
 pub use paths::StoragePaths;
 

--- a/docs/interop/tiles-alignment.md
+++ b/docs/interop/tiles-alignment.md
@@ -1,0 +1,147 @@
+# Tiles interop: MIR (Machine Intelligence Resource) alignment
+
+This document records how hyprstream adopts the **MIR** model-naming/classification
+schema defined by Tiles ([tiles.run](https://www.tiles.run)) and how MIR maps to
+our internal model identifiers. Implements GitHub #283 (epic #131).
+
+Source of truth for the grammar/taxonomy: the MIR section of
+<https://www.tiles.run/llms-full.txt> (fetched 2026-06), cross-checked against
+issue #283. Implementation: `crates/hyprstream/src/storage/mir.rs`.
+
+## Grammar
+
+```
+mir:<domain>.<arch>.<variant>:<series>
+```
+
+Example: `mir:model.transformer.clip-l:stable-diffusion-xl`
+
+| Field     | Meaning                                              | Example               |
+|-----------|-----------------------------------------------------|-----------------------|
+| `domain`  | broadest classification axis                        | `model`               |
+| `arch`    | architecture taxonomy label                         | `transformer`         |
+| `variant` | free-form normalized sub-classification             | `clip-l`              |
+| `series`  | normalized model series                             | `stable-diffusion-xl` |
+
+The Tiles prose is loose about whether the third dot-field is the "variant" or
+"series"; issue #283's authoritative grammar names the third dot-field `variant`
+and the post-colon field `series`. We implement that. The canonical example
+parses under this grammar.
+
+### Domains
+
+`dev`, `model`, `ops`, `info`, and `arch` (Tiles also writes the last as
+`architecture`; we accept both). Ordered most-specific to most-general.
+
+### Architecture taxonomy
+
+Known labels (transcribed from the Tiles taxonomy; canonical emission is
+lowercase): `gru`, `rbm`, `tae`, `vae`, `lstm`, `resnet`, `cnn`, `rcnn`, `rnn`,
+`brnn`, `gan`, `ssm`, `detr`, `vit`, `moe`, `aet`, `stst`, `art`, `lora`,
+`controlnet`, `unclassified`, plus `transformer` (used by the canonical example).
+
+**Superset behaviour:** an architecture label that is *not* in the taxonomy is
+accepted as an extension (`Arch::Extension`) rather than rejected, so a label
+Tiles adds later — or a project-local one — parses instead of hard-failing.
+Canonical emission stays stable (always lowercase).
+
+### Series normalization
+
+Rules (from the Tiles spec):
+
+- Lowercase, hyphen-only separators.
+- Strip org/library prefix (drop everything before the last `/`).
+- Remove parameter-size tokens (`7b`, `0.6b`, `13b`, ...).
+- Collapse non-breaking semantic versions to the breaking/major component
+  (`v1.2` -> `v1`).
+- Strip known library-name suffixes (`-diffusers`, `-transformers`, ...).
+
+Spec examples:
+
+| Input                                          | Output            |
+|------------------------------------------------|-------------------|
+| `tencent-hunyuan/hunyuandiT-v1.2-diffusers`    | `hunyuandit-v1`   |
+| `black-forest-labs/FLUX.1-dev`                 | `flux1dev`        |
+
+**Documented spec ambiguity:** the two examples disagree on separators — hunyuan
+keeps the `-` before `v1`, flux drops all separators. The distinguishing feature
+is that flux contains a *dotted bare-number* token (`FLUX.1`) that merges a digit
+into the name. We reconcile both deterministically:
+
+- If any surviving token is a dotted bare-number (e.g. `flux.1`): flatten the
+  whole series to a single lowercase alnum run -> `flux1dev`.
+- Otherwise: keep `-` separators, collapse `vN.M` -> `vN`, drop stray `.` ->
+  `hunyuandit-v1`, `stable-diffusion-xl`, `qwen3`, `llama-2`.
+
+## Internal model identity
+
+Our internal identity is `ModelRef { model, git_ref }`
+(`crates/hyprstream/src/storage/model_ref.rs`), where `model` is a registry name
+that is typically a HuggingFace-style id (`org/repo`, e.g. `Qwen/Qwen3-0.6B`) or
+a bare local name (e.g. `llama3`), and `git_ref` selects a revision. Models are
+tracked repositories in the git-native registry (`git2db`), cloned from URLs like
+`https://huggingface.co/Qwen/Qwen3-0.6B`. A model is resolved by name via
+`registry.get_by_name(name)`.
+
+## Internal id <-> MIR mapping
+
+| Direction          | Function                                | Lossy?                                   |
+|--------------------|-----------------------------------------|------------------------------------------|
+| internal -> MIR    | `mir_from_internal_name(name)`          | **Yes** — see below                      |
+| internal -> MIR    | `mir_from_internal_name_with(name, arch, variant)` | partial — domain still defaults to `model` |
+| MIR -> internal    | `internal_series_from_mir(mir)`         | **Yes** — recovers series only           |
+| name match key     | `series_key_for_name(name)`             | normalization key for resolution         |
+
+### internal -> MIR (lossy)
+
+A HF repo id / local name carries no architecture, domain, or variant
+information, so `mir_from_internal_name` defaults:
+
+- `domain = model`
+- `arch = unclassified`
+- `variant = base`
+- `series = normalize_series(name)`
+
+e.g. `Qwen/Qwen3-0.6B` -> `mir:model.unclassified.base:qwen3`. Callers that know
+the architecture/variant should use `mir_from_internal_name_with(...)` or
+`Mir::new(...)`.
+
+### MIR -> internal (lossy, partial inverse)
+
+`internal_series_from_mir` recovers the normalized **series** only. The
+org/library prefix, the original casing, and the parameter-size of the source HF
+id are not recoverable. The series is therefore used as a *match key* against the
+registry rather than to reconstruct a canonical HF id.
+
+### No exact bijection
+
+Because both directions lose information there is no exact round-trip between a
+HF repo id and a MIR. The round-trip that **is** defined and tested:
+series normalization is idempotent, so `internal -> MIR -> series` is stable once
+normalized (`series_key_for_name(name) == internal_series_from_mir(mir_from_internal_name(name))`).
+
+## Registry integration
+
+`ModelService` (`crates/hyprstream/src/services/model.rs`) resolves a model
+identifier through `resolve_model_ref`, which accepts:
+
+- a registry name / HF repo id (`Qwen3-0.6B`, optionally `name:ref`), and
+- a MIR string (`mir:...`).
+
+For a MIR string it lists registered models and matches the MIR `series` against
+each model's `series_key_for_name(name)` (via
+`mir::resolve_mir_against_names`). A unique match resolves to that model's
+`ModelRef` (default branch — MIR carries no revision); zero matches or an
+ambiguous (>1) match is an error. The HF-repo-id and `name:ref` paths are
+unchanged.
+
+`ModelService::mir_for_model(name)` emits a (lossy) MIR for a registered model.
+
+## Tests
+
+`crates/hyprstream/src/storage/mir.rs` `#[cfg(test)]` covers: parse of the
+canonical example; all domains; every known arch label; unknown-arch extension;
+malformed rejection (missing scheme/series/domain/arch, extra colon, 4 dot
+fields); `Display` round-trip + idempotency; case normalization; series
+normalization (hunyuan, flux, param-size); internal<->MIR mapping round-trip;
+and registry resolution by MIR (match, not-found, ambiguous).


### PR DESCRIPTION
Adopt Tiles' MIR schema as a model identifier alongside HF repo ids + Modelfile
FROM, for cross-system model classification/interop. Superset: extend within MIR
rather than fork.

- storage/mir.rs (new): Mir type for `mir:<domain>.<arch>.<variant>:<series>`
  (e.g. mir:model.transformer.clip-l:stable-diffusion-xl). Domain enum
  (dev/model/ops/info/arch); Arch taxonomy (all 21 Tiles labels + transformer),
  unknown labels → Arch::Extension (lowercased, stable canonical emission) rather
  than hard-fail; series normalization (lowercase/hyphen, strip org-prefix, drop
  param-size, collapse vN.M→vN, strip lib suffixes). Parse / Display / validate;
  internal↔MIR mapping; resolve_mir_against_names. 24 tests.
- services/model.rs: resolve_model_ref choke-point detects `mir:` and resolves by
  matching MIR series against each registered model's series key — unique match →
  ModelRef (default branch; MIR carries no revision), zero/ambiguous → error
  (fail-closed). Routed load_model_inner / handle_write_ttt_config / handle_inspect
  through it; HF and name:ref paths unchanged. mir_for_model() for emission.
- docs/interop/tiles-alignment.md (new): MIR grammar/taxonomy/normalization +
  internal↔MIR mapping table + documented lossiness.

Mapping is lossy by nature (a bare model name carries no arch/domain/variant →
defaults; MIR→internal recovers normalized series only). Defined round-trip:
series normalization is idempotent, so internal→MIR→series is stable.

Grammar sourced from the MIR section of tiles.run/llms-full.txt + issue #283; the
one genuine spec ambiguity (the hunyuan-v1 vs flux1dev separator disagreement) is
reconciled deterministically (dotted-bare-number token → flatten; clean word/vN
boundary → keep hyphens) and documented.

Tests: 24 mir (canonical parse, all domains/archs, unknown-arch extension,
malformed rejection, Display round-trip + idempotency, normalization incl. both
spec examples, mapping round-trip, registry resolve match/not-found/ambiguous);
storage 36, model 19. cargo build + clippy -p hyprstream clean. (wasm N/A — the
native libtorch hyprstream crate isn't in the wasm set.)

Issue #283. Part of epic #131.
