### PR TITLE
fix: stack-review follow-ups (#278 robustness, #280 cosmetic)

### DIFF
--- a/crates/hyprstream-rpc/src/crypto/cose_sign.rs
+++ b/crates/hyprstream-rpc/src/crypto/cose_sign.rs
@@ -145,10 +145,13 @@ pub fn build_hybrid_external_aad(base_aad: &[u8]) -> Vec<u8> {
         CborValue::Bytes(HYBRID_COMPOSITE_ALG_ID.to_vec()),
     ]);
     let mut buf = Vec::with_capacity(base_aad.len() + HYBRID_COMPOSITE_ALG_ID.len() + 8);
-    if ciborium::ser::into_writer(&value, &mut buf).is_err() {
-        // Infallible for this fixed shape into an unbounded Vec; never panic.
-        return Vec::new();
-    }
+    // Infallible for this fixed [bstr,bstr] shape into an unbounded Vec. Fail
+    // LOUD rather than silently degrading the hybrid-alg-id binding to an empty
+    // (classical-equivalent) AAD on BOTH sign and verify — a silent empty return
+    // would erode the #278 non-separability property invisibly (review finding).
+    #[allow(clippy::expect_used)]
+    ciborium::ser::into_writer(&value, &mut buf)
+        .expect("CBOR serialization of the hybrid external_aad is infallible");
     buf
 }
 

--- a/crates/hyprstream-rpc/src/rpc_client.rs
+++ b/crates/hyprstream-rpc/src/rpc_client.rs
@@ -399,10 +399,24 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
                 &ed_sig,
                 &aad,
             );
-            self.signer
+            // The inner EdDSA above was already bound to the hybrid-composite
+            // alg-id (`hybrid = pq_pubkey().is_some()`), so it cannot fall back to
+            // a classical inner. A signer that advertises a PQ key but declines to
+            // sign must therefore be a HARD ERROR, not a silent downgrade that
+            // would desync inner-AAD (hybrid) from outer-presence (none) and make
+            // the peer's inner verification fail (#278 review).
+            let pq_sig = self
+                .signer
                 .pq_sign(&pq_tbs)
                 .await?
-                .map(|pq_sig| (pq_kid, pq_sig))
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "signer exposes a PQ public key but pq_sign() returned no \
+                         signature; refusing to emit a hybrid-bound inner without \
+                         its ML-DSA-65 outer (#278)"
+                    )
+                })?;
+            Some((pq_kid, pq_sig))
         } else {
             None
         };

--- a/crates/hyprstream/src/services/oauth/did_document.rs
+++ b/crates/hyprstream/src/services/oauth/did_document.rs
@@ -280,7 +280,6 @@ fn build_did_document(
         "@context": [
             "https://www.w3.org/ns/did/v1",
             "https://w3id.org/security/multikey/v1",
-            "https://w3id.org/security/suites/ed25519-2020/v1",
             "https://w3id.org/security/suites/jws-2020/v1",
         ],
         "id": did,


### PR DESCRIPTION
Low/latent nits surfaced by the cross-stack review, landed as one cleanup PR at
the tip (matching the repo's moq-*-review-fixes/-cleanup convention) rather than
deep-amending mid-stack commits that share these files.

- #278 (cose_sign.rs): build_hybrid_external_aad now FAILS LOUD (expect) instead
  of silently returning an empty Vec on a (claimed-infallible) ciborium error —
  a silent empty AAD on both sign and verify would erode the hybrid-alg-id
  non-separability property invisibly.
- #278 (rpc_client.rs): a signer that advertises a PQ public key but whose
  pq_sign() returns None is now a hard error. Previously the inner EdDSA was
  bound to the hybrid-composite alg-id (hybrid = pq_pubkey().is_some()) while the
  outer could be silently omitted — desyncing inner-AAD (hybrid) from
  outer-presence (none) and making the peer's inner verification fail. Now
  inner-hybrid and outer-presence are driven consistently from PQ-key presence.
- #280 (did_document.rs): drop the unused
  https://w3id.org/security/suites/ed25519-2020/v1 @context entry — no
  verification method uses Ed25519VerificationKey2020 after the Multikey switch;
  multikey/v1 + jws-2020/v1 cover the live VM types.

(The #280-review "stale #[allow(dead_code)] on mldsa65_verification_method" was
already resolved — that fn is used by build_did_document; the remaining allow is
on extract_ed25519_keys_from_jwks, which is legitimately dead pending a
RegisteredClient.jwks field.)

Build + clippy clean; cose_sign 22 + did_document 17 tests pass.

Refs #278, #280. Part of epic #131.
