### PR TITLE
ewindisch/moq qafix

### DIFF
--- a/crates/hyprstream-rpc/src/moq_event.rs
+++ b/crates/hyprstream-rpc/src/moq_event.rs
@@ -138,12 +138,234 @@ impl MoqEventOrigin {
     pub fn consumer(&self) -> OriginConsumer {
         self.inner.consumer.clone()
     }
+
+    /// Clone the origin producer.
+    ///
+    /// Needed to wire this origin into a `moq_net::Server`/`Client` with
+    /// `with_origin` / `with_consume` so externally-published broadcasts ingest
+    /// into the same tree subscribers read from.
+    pub fn producer(&self) -> OriginProducer {
+        self.inner.producer.clone()
+    }
 }
 
 impl Default for MoqEventOrigin {
     fn default() -> Self {
         Self::new()
     }
+}
+
+// ============================================================================
+// Cross-process event plane over UDS (#275)
+//
+// In the same-process (`InprocManager`) deployment every service shares one
+// process-global `MoqEventOrigin`, so an in-process publisher and subscriber
+// see the same tree. In the systemd / `--ipc` deployment each service runs in
+// its OWN process; only the `event` service's process initializes the global
+// origin via the factory. Other processes (notably `worker`) had no origin at
+// all — `EventPublisher::new` failed with "moq event bus not initialized".
+//
+// The fix mirrors the streaming plane (`moq_stream::serve_moq_uds_background`):
+//
+//   * The `event` service SERVES its origin over a well-known UDS path
+//     ([`serve_event_moq_uds_background`]) using `moq_net::Server::with_origin`
+//     so the session is BIDIRECTIONAL — it both serves announced broadcasts to
+//     subscribers AND ingests broadcasts a connected client publishes.
+//
+//   * Every NON-event process creates its own local `MoqEventOrigin`, registers
+//     it as the process global, then spawns a background task
+//     ([`connect_event_moq_uds_background`]) that connects a `moq_net::Client`
+//     to the event service's UDS with `with_origin(local_producer)`. That makes
+//     the session bidirectional too: locally-published event broadcasts are
+//     announced UP to the event service (which fans them out to all
+//     subscribers), and broadcasts from other processes flow DOWN into the
+//     local origin so local subscribers see them.
+//
+// The UDS path is the stable, cross-process [`crate::paths::event_socket`] —
+// not a per-PID path — so any process can find it without an RPC round-trip.
+// ============================================================================
+
+/// Reconnect backoff for the client-side event plane link.
+const EVENT_RECONNECT_DELAY: Duration = Duration::from_millis(500);
+
+/// Serve the event-bus origin over a UDS socket so cross-process publishers and
+/// subscribers reach the same tree (#275).
+///
+/// Mirrors [`crate::moq_stream::serve_moq_uds_background`], but the moq server is
+/// built with `with_origin` (publish + consume) rather than `with_publish`
+/// alone, because the event plane is bidirectional: a connected client both
+/// announces its own event broadcasts (ingested into this origin) and subscribes
+/// to broadcasts from every other process.
+///
+/// Called once by the event-service factory. Idempotent: a second call is a
+/// no-op (the first bind wins). Connection errors are logged, not fatal.
+pub fn serve_event_moq_uds_background(origin: MoqEventOrigin, path: std::path::PathBuf) {
+    use crate::transport::uds_session::{accept_uds, PLANE_MOQ};
+    use moq_net::Server as MoqServer;
+
+    // Ensure the parent directory exists (runtime_dir may not be created yet).
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    // Remove a stale socket from a previous run (best-effort).
+    let _ = std::fs::remove_file(&path);
+
+    let listener = match std::os::unix::net::UnixListener::bind(&path) {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::error!(path = %path.display(), "event moq UDS bind failed: {e}");
+            return;
+        }
+    };
+
+    // 0o600: owner read/write only; SO_PEERCRED enforces uid match (uds_server.rs).
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+    }
+
+    // tokio requires the listener be non-blocking before adoption.
+    if let Err(e) = listener.set_nonblocking(true) {
+        tracing::error!("event moq UDS set_nonblocking failed: {e}");
+        return;
+    }
+
+    let listener = match tokio::net::UnixListener::from_std(listener) {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::error!("event moq UDS listener conversion failed: {e}");
+            return;
+        }
+    };
+
+    tracing::info!(path = %path.display(), "event moq UDS listener ready");
+
+    tokio::spawn(async move {
+        loop {
+            let stream = match listener.accept().await {
+                Ok((s, _)) => s,
+                Err(e) => {
+                    tracing::warn!("event moq UDS accept error: {e}");
+                    continue;
+                }
+            };
+            // Each session gets its own producer/consumer view of the SAME origin
+            // tree, so a client's published broadcasts are ingested and re-served
+            // to every other connected session.
+            let producer = origin.producer();
+            tokio::spawn(async move {
+                let (plane, session) = match accept_uds(stream).await {
+                    Ok(pair) => pair,
+                    Err(e) => {
+                        tracing::debug!("event moq UDS handshake error: {e}");
+                        return;
+                    }
+                };
+                if plane != PLANE_MOQ {
+                    tracing::debug!("event moq UDS: unexpected plane 0x{plane:02x} — dropping");
+                    return;
+                }
+                // `accept` returns once the handshake completes; the protocol then
+                // runs in the background. The returned `Session` MUST be held —
+                // dropping it closes the connection. Hold it until it closes so
+                // the bidirectional bridge stays live (publish + consume).
+                match MoqServer::new().with_origin(producer).accept(session).await {
+                    Ok(moq_session) => {
+                        let reason = moq_session.closed().await;
+                        tracing::debug!("event moq UDS session closed: {reason:?}");
+                    }
+                    Err(e) => tracing::debug!("event moq UDS accept error: {e}"),
+                }
+            });
+        }
+    });
+}
+
+/// Ensure this process can publish/subscribe events, wiring a CLIENT-mode
+/// event origin connected to the event service's UDS plane if needed (#275).
+///
+/// Idempotent and safe to call from any process at startup:
+///
+///   * If the process-global origin is ALREADY initialized (this process hosts
+///     the `event` service, which calls [`init_global_moq_event_origin`] +
+///     [`serve_event_moq_uds_background`] in its factory), this is a no-op —
+///     the in-process origin is authoritative.
+///
+///   * Otherwise it creates a fresh local origin, registers it as the global,
+///     and spawns the background link to the event service's UDS
+///     ([`connect_event_moq_uds_background`]). After this returns,
+///     `EventPublisher::new` / `EventSubscriber` succeed in this process and
+///     events flow cross-process to the shared bus.
+///
+/// Must be called from within a tokio runtime (it spawns a background task).
+/// `path` is the event service's UDS socket (use [`crate::paths::event_socket`]).
+pub fn ensure_event_client_origin(path: std::path::PathBuf) {
+    if global_moq_event_origin().is_some() {
+        // The event service is co-located in this process; nothing to dial.
+        return;
+    }
+    let origin = MoqEventOrigin::new();
+    // Register first so any `EventPublisher::new` after this point resolves the
+    // global immediately, even before the background link is established (moq
+    // buffers/announces the broadcast and it flows up once the link connects).
+    if !init_global_moq_event_origin(origin.clone()) {
+        // Lost a race with the event factory or a concurrent caller; the global
+        // that won is authoritative, so drop ours.
+        return;
+    }
+    connect_event_moq_uds_background(origin, path);
+}
+
+/// Connect a local event origin to the event service's UDS plane (#275).
+///
+/// Spawns a background task that connects a `moq_net::Client` (built with
+/// `with_origin(local_producer)`) to `path`, keeping the link alive and
+/// reconnecting on failure. The session is bidirectional: locally-published
+/// event broadcasts are announced UP to the event service, and broadcasts from
+/// other processes flow DOWN into `origin` so local subscribers see them.
+///
+/// Called once, in non-event processes, AFTER registering `origin` as the
+/// process global. The task runs for the process lifetime.
+pub fn connect_event_moq_uds_background(origin: MoqEventOrigin, path: std::path::PathBuf) {
+    tokio::spawn(async move {
+        loop {
+            if let Err(e) = run_event_client_link(&origin, &path).await {
+                tracing::debug!(
+                    path = %path.display(),
+                    "event moq client link ended: {e}; reconnecting in {:?}",
+                    EVENT_RECONNECT_DELAY
+                );
+            }
+            tokio::time::sleep(EVENT_RECONNECT_DELAY).await;
+        }
+    });
+}
+
+/// One connect-and-pump cycle of the client-side event link. Returns when the
+/// session closes (so the caller can reconnect).
+async fn run_event_client_link(origin: &MoqEventOrigin, path: &std::path::Path) -> Result<()> {
+    use crate::transport::uds_session::{connect_uds, PLANE_MOQ};
+    use moq_net::Client as MoqClient;
+
+    let session = connect_uds(path, PLANE_MOQ)
+        .await
+        .map_err(|e| anyhow!("event moq UDS connect {}: {e}", path.display()))?;
+
+    // `with_origin` makes this a bidirectional link: publish local broadcasts UP
+    // and consume remote broadcasts DOWN into the SAME origin tree subscribers read.
+    let moq_client = MoqClient::new().with_origin(origin.producer());
+    let moq_session = moq_client
+        .connect(session)
+        .await
+        .map_err(|e| anyhow!("event moq handshake: {e}"))?;
+
+    tracing::info!(path = %path.display(), "event moq client link established");
+
+    // Hold the session open until it closes; broadcasts flow in both directions
+    // for the duration via the origin producer/consumer wired above.
+    let reason = moq_session.closed().await;
+    Err(anyhow!("event moq session closed: {reason:?}"))
 }
 
 // ============================================================================
@@ -473,6 +695,7 @@ fn topic_matches_patterns(topic: &str, patterns: &[String]) -> bool {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
 
@@ -524,6 +747,102 @@ mod tests {
             Ok(Err(e)) => panic!("recv error: {e}"),
             Err(_) => panic!("recv timeout"),
         }
+
+        Ok(())
+    }
+
+    /// #275 cross-process bug: a non-event process publishes events through a
+    /// CLIENT-mode origin linked over UDS to a separate SERVER-mode origin
+    /// (the event service). A subscriber on the SERVER origin must see the
+    /// event — proving the bus is no longer a process-local island.
+    ///
+    /// This mirrors the systemd / --ipc deployment: the "event service" origin
+    /// is served via `serve_event_moq_uds_background`; the "worker" origin is a
+    /// distinct origin (as in a separate process) wired via
+    /// `connect_event_moq_uds_background`. The publisher resolves against the
+    /// client origin (no in-process event factory ran for it), and the event
+    /// reaches a subscriber reading the server origin's consumer.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn cross_process_event_over_uds_client_link() -> Result<()> {
+        use std::time::Duration;
+
+        // Unique, stable socket path for this test (cross-"process" rendezvous).
+        let sock = std::env::temp_dir()
+            .join(format!("hyprstream-event-test-{}.sock", std::process::id()));
+
+        // ── "event service" process: serve a SERVER-mode origin over UDS ──────
+        let server_origin = MoqEventOrigin::new();
+        serve_event_moq_uds_background(server_origin.clone(), sock.clone());
+        // Let the listener bind.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // ── "worker" process: a DISTINCT origin linked to the event UDS ───────
+        let client_origin = MoqEventOrigin::new();
+        connect_event_moq_uds_background(client_origin.clone(), sock.clone());
+
+        // A publisher built on the client origin (the failing path before #275).
+        let mut publisher = client_origin.publisher("worker")?;
+
+        // Drive the link + announcement by publishing repeatedly; read the
+        // subscriber on the SERVER origin's consumer (a "different process").
+        // Read the server consumer directly (the same data a server-side
+        // EventSubscriber would receive) to avoid depending on the global.
+        let consumer = server_origin.consumer();
+        let scoped = consumer
+            .scope(&[Path::new(EVENT_PREFIX)])
+            .ok_or_else(|| anyhow!("server origin has no event scope yet"))?;
+
+        let recv = tokio::spawn(async move {
+            let mut scoped = scoped;
+            loop {
+                let (_path, bc) = match scoped.announced().await {
+                    None => return None,
+                    Some((_, None)) => continue,
+                    Some((path, Some(b))) => (path, b),
+                };
+                let mut track = match bc.subscribe_track(&Track::new(EVENT_TRACK)) {
+                    Ok(t) => t,
+                    Err(_) => continue,
+                };
+                let mut group = match track.next_group().await {
+                    Ok(Some(g)) => g,
+                    _ => continue,
+                };
+                if let Ok(Some(frame)) = group.read_frame().await {
+                    return Some(frame.to_vec());
+                }
+            }
+        });
+
+        // Re-publish periodically (the moq broadcast is retained by the origin,
+        // but re-asserting it ensures the announcement is live once the
+        // client→server link establishes). Concurrently await the receiver.
+        let publish_loop = async {
+            for _ in 0..50 {
+                let _ = publisher.publish("sandbox123", "started", b"payload");
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+            // Keep the publisher (and its broadcast) alive until the receiver
+            // finishes by parking here.
+            std::future::pending::<()>().await;
+        };
+
+        let got: Option<Vec<u8>> = tokio::select! {
+            r = recv => r.ok().flatten(),
+            _ = publish_loop => None,
+            _ = tokio::time::sleep(Duration::from_secs(10)) => None,
+        };
+
+        let _ = std::fs::remove_file(&sock);
+        let frame = got.expect("event did not cross the UDS link to the server origin");
+
+        // Decode [4 bytes topic_len BE][topic][payload].
+        assert!(frame.len() >= 4, "frame too short");
+        let topic_len = u32::from_be_bytes([frame[0], frame[1], frame[2], frame[3]]) as usize;
+        let topic = std::str::from_utf8(&frame[4..4 + topic_len]).unwrap();
+        let payload = &frame[4 + topic_len..];
+        assert_eq!(topic, "worker.sandbox123.started");
+        assert_eq!(payload, b"payload");
 
         Ok(())
     }

--- a/crates/hyprstream-rpc/src/moq_stream.rs
+++ b/crates/hyprstream-rpc/src/moq_stream.rs
@@ -177,6 +177,14 @@ pub fn serve_moq_uds_background(origin: MoqStreamOrigin, path: PathBuf) {
         let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
     }
 
+    // tokio requires the listener be non-blocking before adoption; otherwise
+    // `from_std` panics ("Registering a blocking socket with the tokio runtime
+    // is unsupported"). Mirrors the event-bus plane (moq_event.rs).
+    if let Err(e) = listener.set_nonblocking(true) {
+        tracing::error!("moq UDS set_nonblocking failed: {e}");
+        return;
+    }
+
     // Convert to async and publish the path only after the socket is bound.
     let listener = match tokio::net::UnixListener::from_std(listener) {
         Ok(l) => l,

--- a/crates/hyprstream-service/src/service/spawner/service.rs
+++ b/crates/hyprstream-service/src/service/spawner/service.rs
@@ -101,6 +101,23 @@ impl<S: RequestService + Send + Sync + 'static> Spawnable for UnifiedServiceConf
                     .map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(format!("QUIC bind: {e}")))?;
                 let actual_addr = wt_server.local_addr()
                     .map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(format!("QUIC local_addr: {e}")))?;
+                // The bound addr is unspecified (0.0.0.0 / ::) when binding all
+                // interfaces — that is NOT a dialable destination, so advertising
+                // it makes dial_stream's QUIC connect time out. Advertise loopback
+                // for same-host (the single-node default); cross-host routable-IP
+                // advertisement is the wire-reach follow-up (#131/#282).
+                let advertise_addr = if actual_addr.ip().is_unspecified() {
+                    match actual_addr {
+                        std::net::SocketAddr::V4(_) => {
+                            std::net::SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, actual_addr.port()))
+                        }
+                        std::net::SocketAddr::V6(_) => {
+                            std::net::SocketAddr::from((std::net::Ipv6Addr::LOCALHOST, actual_addr.port()))
+                        }
+                    }
+                } else {
+                    actual_addr
+                };
                 let pin = hyprstream_rpc::transport::quinn_transport::cert_sha256(&qc.cert_chain[0]);
 
                 let mut rpc_server = hyprstream_rpc::transport::quinn_transport::QuinnRpcServer::with_capacity(
@@ -146,7 +163,7 @@ impl<S: RequestService + Send + Sync + 'static> Spawnable for UnifiedServiceConf
                         &service_name,
                         hyprstream_rpc::registry::SocketKind::Quic,
                         hyprstream_rpc::transport::TransportConfig::quic_pinned(
-                            actual_addr,
+                            advertise_addr,
                             &qc.server_name,
                             pin,
                         ),
@@ -155,13 +172,13 @@ impl<S: RequestService + Send + Sync + 'static> Spawnable for UnifiedServiceConf
                 }
                 hyprstream_rpc::moq_stream::init_global_producer_reach(
                     hyprstream_rpc::moq_stream::NodeStreamReach {
-                        addr: actual_addr,
+                        addr: advertise_addr,
                         server_name: qc.server_name.clone(),
                         cert_hashes: vec![pin],
                     },
                 );
                 if let Some(cb) = qc.on_quic_bound.take() {
-                    cb(service_name.clone(), actual_addr, qc.server_name.clone());
+                    cb(service_name.clone(), advertise_addr, qc.server_name.clone());
                 }
 
                 // #282: bind an iroh substrate in PARALLEL to the quinn endpoint,

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -2050,6 +2050,24 @@ fn main() -> Result<()> {
                                 // Compute dependency-aware startup stages.
                                 let stages = hyprstream_service::startup_stages(&service_names);
 
+                                // #275: in the systemd / --ipc deployment each service
+                                // runs in its OWN process. Only the `event` service's
+                                // process initializes the process-global moq event bus
+                                // origin. If THIS process does not host the `event`
+                                // service, wire a CLIENT-mode event origin connected to
+                                // the event service's UDS plane BEFORE any factory runs
+                                // (so `EventPublisher::new` in e.g. the worker factory
+                                // resolves the global). Idempotent + a no-op when `event`
+                                // is co-located.
+                                let hosts_event_service = stages
+                                    .iter()
+                                    .any(|stage| stage.iter().any(|s| s == "event"));
+                                if !hosts_event_service {
+                                    hyprstream_rpc::moq_event::ensure_event_client_origin(
+                                        hyprstream_rpc::paths::event_socket(),
+                                    );
+                                }
+
                                 for stage in &stages {
                                     for svc_name in stage {
                                         let factory = get_factory(svc_name).ok_or_else(|| {

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -422,6 +422,11 @@ fn create_policy_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
 fn create_registry_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>> {
     info!("Creating RegistryService");
 
+    // RegistryService publishes clone-progress streams via StreamChannel::run_stream
+    // (which fails loudly if no moq origin is registered in this process).
+    // Initialize this process's local moq plane. Idempotent.
+    init_local_moq_stream_plane("registry");
+
     let config = load_config();
     let sk = ctx.service_signing_key("registry");
 
@@ -456,14 +461,30 @@ fn create_registry_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawn
 // Streams Service Factory
 // ═══════════════════════════════════════════════════════════════════════════════
 
-/// Factory for the moq stream origin (#138 N4 — ZMQ StreamService removed).
+/// Initialize this process's local moq stream plane (origin + UDS server).
 ///
-/// Builds the process-global `MoqStreamOrigin`, registers it, and starts the
-/// UDS moq server so cross-process subscribers (e.g. `tui attach`) can
-/// subscribe over moq without any ZMQ sockets.
-#[service_factory("streams")]
-fn create_streams_service(_ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>> {
-    info!("Creating moq stream origin (ZMQ StreamService removed)");
+/// Every service process that **publishes** moq streams (the central `streams`
+/// service, and stream-publisher services such as `tui`/`notification`/`registry`/
+/// `metrics`/`model`) needs its OWN moq plane in-process: the process-global
+/// [`MoqStreamOrigin`] that `StreamChannel::publisher()` appends into, plus a
+/// per-PID UDS moq server so a co-located client can connect directly to the
+/// path returned in the publisher's response.
+///
+/// In a multi-process (systemd one-process-per-service) deployment, only the
+/// `streams` factory used to do this, so other publisher processes had a `None`
+/// origin (nothing to publish to) and returned an empty `moq_uds_path` to the
+/// client (→ client `ensure!` fails). This helper closes that gap.
+///
+/// Idempotent: if the process already has a moq origin (the `streams` factory
+/// ran in this process, or this helper was already called), it returns early
+/// without double-initializing the origin or double-serving the UDS. This lets
+/// it compose with the `streams` factory and with multiple publisher factories
+/// co-located in one process.
+fn init_local_moq_stream_plane(service_name: &str) {
+    // Guard: a moq origin already exists in this process — nothing to do.
+    if hyprstream_rpc::moq_stream::global_moq_origin().is_some() {
+        return;
+    }
 
     let gate = |pubkey: &[u8; 32]| -> bool {
         use ed25519_dalek::VerifyingKey;
@@ -473,14 +494,22 @@ fn create_streams_service(_ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawn
         hyprstream_service::global_trust_store().get(&vk).is_some()
     };
 
+    // Use DEFAULT_PREFIX ("local/streams") so the publisher's broadcast paths
+    // match what consumers reconstruct (NotificationService builds its consumer
+    // path from DEFAULT_PREFIX; TUI/registry/metrics echo the origin's own
+    // broadcast_path back to the client, so any prefix is self-consistent there).
     let moq_origin = hyprstream_rpc::moq_stream::MoqStreamOrigin::standalone()
-        .with_prefix("local/streams")
+        .with_prefix(hyprstream_rpc::moq_stream::DEFAULT_PREFIX)
         .with_authorize_signer(gate)
         .build();
 
-    // Register the global BEFORE signalling ready — downstream services that
-    // call StreamChannel::publisher() will see it immediately.
-    hyprstream_rpc::moq_stream::init_global_moq_origin(moq_origin.clone());
+    // Register the global BEFORE serving — downstream code that calls
+    // StreamChannel::publisher() will see it immediately.
+    if !hyprstream_rpc::moq_stream::init_global_moq_origin(moq_origin.clone()) {
+        // Lost a race to another initializer in this process; that init owns the
+        // UDS server too, so don't start a second one.
+        return;
+    }
 
     let moq_uds_path = {
         let dir = std::env::temp_dir()
@@ -488,7 +517,24 @@ fn create_streams_service(_ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawn
         let _ = std::fs::create_dir_all(&dir);
         dir.join("moq.sock")
     };
+    info!(
+        service = service_name,
+        path = %moq_uds_path.display(),
+        "Initializing local moq stream plane",
+    );
     hyprstream_rpc::moq_stream::serve_moq_uds_background(moq_origin, moq_uds_path);
+}
+
+/// Factory for the moq stream origin (#138 N4 — ZMQ StreamService removed).
+///
+/// Builds the process-global `MoqStreamOrigin`, registers it, and starts the
+/// UDS moq server so cross-process subscribers (e.g. `tui attach`) can
+/// subscribe over moq without any ZMQ sockets.
+#[service_factory("streams")]
+fn create_streams_service(_ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>> {
+    info!("Creating moq stream origin (ZMQ StreamService removed)");
+
+    init_local_moq_stream_plane("streams");
 
     Ok(Box::new(MoqStreamBarrierService::new()))
 }
@@ -541,6 +587,11 @@ impl Spawnable for MoqStreamBarrierService {
 #[service_factory("model", schema = "../../../hyprstream-rpc-std/schema/model.capnp", metadata = crate::services::generated::model_client::schema_metadata, depends_on = ["policy", "registry", "discovery", "notification"])]
 fn create_model_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>> {
     info!("Creating ModelService");
+
+    // ModelService spawns InferenceService instances in-process, which publish
+    // generation streams via StreamChannel::run_stream (fails loudly without a
+    // moq origin). Initialize this process's local moq plane. Idempotent.
+    init_local_moq_stream_plane("model");
 
     use crate::services::{ModelService, ModelServiceConfig};
 
@@ -1144,6 +1195,12 @@ fn create_tui_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
 
     use crate::tui::{TuiState, service::TuiService};
 
+    // TUI publishes terminal frames (stdin/stdout) over moq via
+    // StreamChannel::publisher(), and returns its per-PID moq UDS path to the
+    // client. In a per-process deployment this process has no moq plane unless
+    // we initialize one here. Idempotent — no-op if already set.
+    init_local_moq_stream_plane("tui");
+
     let config = load_config();
     let tui_config = &config.tui;
     let sk = ctx.service_signing_key("tui");
@@ -1251,6 +1308,12 @@ fn create_discovery_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spaw
 fn create_notification_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>> {
     info!("Creating NotificationService");
 
+    // NotificationService publishes broadcast frames over moq and returns its
+    // per-PID moq UDS path to subscribers (notification.rs handle_subscribe).
+    // Initialize this process's local moq plane so that path is non-empty and
+    // the origin exists for StreamChannel::publisher(). Idempotent.
+    init_local_moq_stream_plane("notification");
+
     let sk = ctx.service_signing_key("notification");
 
     // Register this service's verifying key with PolicyService
@@ -1281,6 +1344,11 @@ fn create_notification_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn S
 #[service_factory("metrics", schema = "../../../hyprstream-rpc-std/schema/metrics.capnp", metadata = crate::services::generated::metrics_client::schema_metadata, depends_on = ["policy", "discovery"])]
 fn create_metrics_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>> {
     info!("Creating MetricsService");
+
+    // MetricsService publishes query-result streams via StreamChannel::run_stream
+    // (fails loudly without a moq origin). Initialize this process's local moq
+    // plane. Idempotent.
+    init_local_moq_stream_plane("metrics");
 
     use crate::services::MetricsService;
     use hyprstream_metrics::query::QueryOrchestrator;
@@ -1466,5 +1534,41 @@ mod tests {
         let ed25519_pubkey = [0xAB_u8; 32];
         let result = compute_tls_endorsement(&[0xFF; 32], &ed25519_pubkey, "example.com");
         assert!(result.is_err());
+    }
+
+    /// `init_local_moq_stream_plane` sets both process-global moq state
+    /// (`global_moq_origin` + `global_moq_uds_path`) and is idempotent: a second
+    /// call is a no-op and must not panic (composes with the streams factory and
+    /// multiple co-located publisher factories).
+    ///
+    /// Uses process-global `OnceLock`s, so it runs in a dedicated single-test
+    /// binary (`#[cfg(test)]` integration is impractical for OnceLock); the
+    /// assertions tolerate a plane already initialized by an earlier test in the
+    /// same process — the contract under test is "set after call" + "idempotent".
+    #[tokio::test]
+    async fn init_local_moq_stream_plane_sets_globals_and_is_idempotent() {
+        use hyprstream_rpc::moq_stream::{global_moq_origin, global_moq_uds_path};
+
+        // First call (or pre-set by another test) → plane is initialized.
+        init_local_moq_stream_plane("test");
+        assert!(
+            global_moq_origin().is_some(),
+            "origin must be set after init_local_moq_stream_plane",
+        );
+        let uds = global_moq_uds_path();
+        assert!(
+            uds.is_some(),
+            "uds path must be set after init_local_moq_stream_plane",
+        );
+        let path_after_first = uds.map(std::path::Path::to_path_buf);
+
+        // Second call must be a no-op (idempotent) — no panic, no change.
+        init_local_moq_stream_plane("test");
+        assert!(global_moq_origin().is_some());
+        assert_eq!(
+            global_moq_uds_path().map(std::path::Path::to_path_buf),
+            path_after_first,
+            "second call must not change the served UDS path",
+        );
     }
 }

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -261,7 +261,15 @@ fn create_event_service(_ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
     info!("Creating EventService (moq-lite event bus)");
 
     let origin = MoqEventOrigin::new();
-    hyprstream_rpc::moq_event::init_global_moq_event_origin(origin);
+    hyprstream_rpc::moq_event::init_global_moq_event_origin(origin.clone());
+
+    // #275: serve the event-bus origin over the well-known cross-process UDS path
+    // so OTHER service processes (worker, model, ...) can publish/subscribe events
+    // to this shared bus. In the same-process (InprocManager) deployment every
+    // service shares this global origin directly; this UDS plane is the bridge
+    // for the systemd / --ipc deployment where each service is its own process.
+    let event_moq_path = hyprstream_rpc::paths::event_socket();
+    hyprstream_rpc::moq_event::serve_event_moq_uds_background(origin, event_moq_path);
 
     Ok(Box::new(MoqEventBarrierService::new()))
 }
@@ -589,7 +597,7 @@ fn create_model_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnabl
 ///
 /// Note: This service requires worker configuration. If not configured,
 /// the factory will use sensible defaults.
-#[service_factory("worker", depends_on = ["policy", "discovery"])]
+#[service_factory("worker", depends_on = ["policy", "discovery", "event"])]
 fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>> {
     info!("Creating WorkerService");
 

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -294,6 +294,13 @@ impl Spawnable for MoqEventBarrierService {
         if let Some(ready) = on_ready {
             let _ = ready.send(());
         }
+        // systemd Type=notify: send READY=1 so the unit reaches `active` rather
+        // than timing out (~45s) and restart-looping. These moq barrier services
+        // don't go through the RPC serve path (serve.rs::signal_ready) that
+        // normally notifies systemd, so they must signal readiness themselves —
+        // the moq origin/event-bus is already initialized in the factory before
+        // run() is called, so the service is genuinely ready here.
+        let _ = hyprstream_rpc::notify::ready();
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -502,6 +509,13 @@ impl Spawnable for MoqStreamBarrierService {
         if let Some(ready) = on_ready {
             let _ = ready.send(());
         }
+        // systemd Type=notify: send READY=1 so the unit reaches `active` rather
+        // than timing out (~45s) and restart-looping. These moq barrier services
+        // don't go through the RPC serve path (serve.rs::signal_ready) that
+        // normally notifies systemd, so they must signal readiness themselves —
+        // the moq origin/event-bus is already initialized in the factory before
+        // run() is called, so the service is genuinely ready here.
+        let _ = hyprstream_rpc::notify::ready();
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()


### PR DESCRIPTION
- **fix(streams,event): send systemd READY=1 from moq barrier services**
- **fix(event): cross-process moq event bus — serve over UDS + client-connect**
- **fix(streams): per-process moq stream plane for all publishers + non-blocking UDS**
- **fix(streaming): advertise a dialable moq reach addr (loopback, not 0.0.0.0)**
