### PR TITLE
ewindisch/moq infer dtype

### DIFF
--- a/crates/hyprstream-rpc/src/moq_stream.rs
+++ b/crates/hyprstream-rpc/src/moq_stream.rs
@@ -566,12 +566,30 @@ impl MoqStreamHandle {
 
     /// Construct a handle that subscribes over the **network** (#274).
     ///
-    /// Resolves the signed `StreamInfo`'s `reach` list: if the same-host moq UDS
-    /// plane is available (co-located producer), that fast path is used; else
-    /// the first dialable network reach is dialed via
-    /// [`crate::dial::dial_stream`] over `web_transport_quinn`. After connecting,
-    /// it subscribes to `broadcast_path` and verifies the chained-HMAC frames
-    /// exactly as [`Self::new`] does. Errors/end-of-stream close the channel.
+    /// Resolves the signed `StreamInfo`'s `reach` list and dials the first
+    /// dialable network reach via [`crate::dial::dial_stream`] over
+    /// `web_transport_quinn` — exactly as the working CLI `quick infer` consumer
+    /// does. After connecting, it subscribes to `broadcast_path` and verifies the
+    /// chained-HMAC frames exactly as [`Self::new`] does. Errors/end-of-stream
+    /// close the channel.
+    ///
+    /// ## Transport selection (#275 TUI streaming fix)
+    ///
+    /// The producer's `reach` is the source of truth for where the stream lives.
+    /// A stream is a networked address; the subscriber dials the **producer's**
+    /// reach. Loopback works same-host (the bound QUIC `/moq` endpoint), proven by
+    /// the CLI, so the networked reach is used uniformly whenever the StreamInfo
+    /// carries one.
+    ///
+    /// The local moq UDS plane ([`global_moq_uds_path`]) is used **only as a
+    /// fallback** when the StreamInfo carries no dialable reach (UDS-only /
+    /// unit-test deployments). It must NOT be preferred when a reach is present:
+    /// the local UDS is *this process's own* moq plane, which only carries the
+    /// producer's broadcast if the producer is co-located in this very process.
+    /// A consumer process that runs its own moq plane for unrelated streams (e.g.
+    /// the TUI daemon serving its PTY/shell stdout stream) would otherwise connect
+    /// to its own empty plane and time out waiting for the model service's
+    /// broadcast that was published on a *different* process's plane (#275).
     pub fn networked(
         reach: Vec<crate::stream_info::Destination>,
         broadcast_path: String,
@@ -581,9 +599,21 @@ impl MoqStreamHandle {
         let cancel = tokio_util::sync::CancellationToken::new();
         let (tx, rx) =
             tokio::sync::mpsc::channel::<anyhow::Result<crate::streaming::StreamPayload>>(64);
-        // Same-host fast path: if a local moq UDS plane is serving (co-located
-        // producer), prefer it and ignore the wire reach entirely.
-        if let Some(uds) = global_moq_uds_path() {
+        // Prefer the producer's networked reach (the StreamInfo source of truth):
+        // dial the producer directly, mirroring the CLI. Only fall back to the
+        // local moq UDS plane when the StreamInfo carries no dialable reach —
+        // never the other way around (see method docs; #275).
+        let has_dialable_reach = reach.iter().any(|d| reach_to_transport_config(d).is_some());
+        if has_dialable_reach {
+            tokio::spawn(moq_stream_handle_task_networked(
+                reach,
+                broadcast_path.clone(),
+                mac_key,
+                topic,
+                tx,
+                cancel.clone(),
+            ));
+        } else if let Some(uds) = global_moq_uds_path() {
             let uds_path = uds.to_string_lossy().into_owned();
             tokio::spawn(moq_stream_handle_task(
                 uds_path,
@@ -594,14 +624,16 @@ impl MoqStreamHandle {
                 cancel.clone(),
             ));
         } else {
-            tokio::spawn(moq_stream_handle_task_networked(
-                reach,
-                broadcast_path.clone(),
-                mac_key,
-                topic,
-                tx,
-                cancel.clone(),
-            ));
+            // No dialable reach and no local UDS plane: surface a clear error
+            // rather than spawning a task that cannot connect.
+            tokio::spawn(async move {
+                let _ = tx
+                    .send(Err(anyhow!(
+                        "no dialable reach in StreamInfo and no local moq UDS plane — \
+                         cannot subscribe to broadcast"
+                    )))
+                    .await;
+            });
         }
         Self { rx, broadcast_path, cancel }
     }
@@ -933,6 +965,7 @@ pub fn verify_moq_frame(
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
     use crate::streaming::StreamPayload;
@@ -1036,6 +1069,90 @@ mod tests {
         assert!(matches!(&got[0], StreamPayload::Data(d) if d == b"ping"));
         assert!(matches!(&got[1], StreamPayload::Complete(_)));
         Ok(())
+    }
+
+    /// #275: a StreamInfo carrying a dialable Quic reach must be classified as
+    /// dialable, so `networked()` routes to the producer's networked reach
+    /// (`dial_stream`) rather than this process's local moq UDS plane.
+    #[test]
+    fn quic_reach_is_dialable() {
+        use crate::stream_info::{Destination, QuicReach, Role, TransportConfig as ReachTransport};
+        let reach = Destination {
+            role: Role::Direct,
+            transport: ReachTransport::Quic(QuicReach {
+                addr: "127.0.0.1:4433".to_owned(),
+                server_name: "localhost".to_owned(),
+                cert_hashes: vec![vec![0u8; 32]],
+            }),
+        };
+        assert!(
+            reach_to_transport_config(&reach).is_some(),
+            "a Quic reach must resolve to a dialable TransportConfig (selects the \
+             networked dial_stream path, not the local UDS)"
+        );
+    }
+
+    /// #275: the consumer dials the producer's networked reach even when this
+    /// process also serves its own local moq UDS plane. Regression for the TUI
+    /// timeout: the local UDS must NOT shadow a present reach (it is this
+    /// process's plane, not the producer's).
+    ///
+    /// We assert the branch selection deterministically. With a dialable reach
+    /// present we set the local UDS path to a socket that does NOT exist: the
+    /// **UDS branch** would fail in milliseconds with a connect error naming that
+    /// path, whereas the **networked branch** dials QUIC (which, to a closed
+    /// loopback port, keeps retrying past a short deadline). So: a UDS-path error
+    /// before the deadline ⇒ the pre-fix bug (UDS preferred — FAIL); reaching the
+    /// deadline still trying ⇒ the networked dial was taken (PASS). A networked
+    /// dial error is also an acceptable PASS (reach was dialed).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn networked_prefers_reach_over_local_uds() -> Result<()> {
+        use crate::stream_info::{Destination, QuicReach, Role, TransportConfig as ReachTransport};
+
+        // Pretend this process has a local moq UDS plane (the TUI daemon does, to
+        // serve its PTY stdout). The pre-fix code short-circuited onto this path
+        // and ignored the reach; the fix must dial the reach instead. The path is
+        // distinctive so a UDS connect error is unambiguously identifiable.
+        let uds_marker = "/nonexistent/hyprstream-275-uds-marker.sock";
+        let _ = GLOBAL_MOQ_UDS_PATH.set(PathBuf::from(uds_marker));
+
+        // A dialable Quic reach to a closed loopback port.
+        let reach = vec![Destination {
+            role: Role::Direct,
+            transport: ReachTransport::Quic(QuicReach {
+                addr: "127.0.0.1:1".to_owned(),
+                server_name: "localhost".to_owned(),
+                cert_hashes: vec![[0xABu8; 32].to_vec()],
+            }),
+        }];
+
+        let mut handle = MoqStreamHandle::networked(
+            reach,
+            "local/streams/test/deadbeef".to_owned(),
+            [0u8; 32],
+            "deadbeef".repeat(8),
+        );
+
+        match tokio::time::timeout(std::time::Duration::from_secs(3), handle.recv_next()).await {
+            // Still dialing QUIC at the deadline — the networked branch was taken.
+            Err(_elapsed) => Ok(()),
+            // An early error: it must be a *networked* dial failure, NOT a UDS
+            // connect to our marker path (which would prove the bug).
+            Ok(res) => {
+                let err = res.expect_err("dial to a closed port must not yield a payload");
+                let msg = err.to_string();
+                assert!(
+                    !msg.contains(uds_marker),
+                    "consumer connected to the local UDS plane instead of dialing the \
+                     producer's reach (#275 regression): {msg}"
+                );
+                assert!(
+                    msg.contains("networked dial"),
+                    "expected a networked dial failure (reach was dialed), got: {msg}"
+                );
+                Ok(())
+            }
+        }
     }
 
     #[test]

--- a/crates/hyprstream/schema/tui.capnp
+++ b/crates/hyprstream/schema/tui.capnp
@@ -10,6 +10,10 @@
 using import "/common.capnp".ErrorInfo;
 using import "/annotations.capnp".mcpScope;
 using import "/annotations.capnp".mcpDescription;
+# #275: the moq reach model (network-routable dial parameters) so a cross-process
+# TUI viewer can dial the producer's networked moq plane instead of its own local
+# UDS plane. Shared 1:1 with the inference StreamInfo's reach (streaming.capnp).
+using import "/streaming.capnp".Destination;
 
 # ═══════════════════════════════════════════════════════════════════
 # Frame Types (streamed via StreamPublisher, not RPC)
@@ -383,6 +387,13 @@ struct StreamInfo {
   moqBroadcastPath @3 :Text;
   # UDS socket path for the moq streaming plane (empty when ZMQ is active)
   moqUdsPath @4 :Text;
+  # #275: network-routable ways to reach the producer's moq plane (mirrors the
+  # inference StreamInfo's `announcedAt`). A cross-process viewer dials the first
+  # reach it supports (see `dial_stream`) and subscribes to `moqBroadcastPath`,
+  # rather than connecting to its OWN local moq UDS plane — which only carries the
+  # producer's broadcast when the producer is co-located in the very same process.
+  # Co-located clients ignore this and use the same-host UDS fast path (`moqUdsPath`).
+  reach @5 :List(Destination);
 }
 
 # Window information

--- a/crates/hyprstream/src/cli/shell_handlers.rs
+++ b/crates/hyprstream/src/cli/shell_handlers.rs
@@ -274,9 +274,18 @@ pub async fn handle_shell_tui(
             Err(e) => { tracing::warn!("subscribe_track: {e}"); return; }
         };
         let mut verifier = StreamVerifier::new(mac_key, topic);
+        // The first group only arrives after the model finishes PREFILL, which can
+        // take minutes for a large prompt on slow/CPU hardware; give it a generous
+        // budget. Subsequent decode groups arrive steadily, so a short idle suffices.
+        let mut first_group = true;
         loop {
+            let next_timeout = if first_group {
+                std::time::Duration::from_secs(300)
+            } else {
+                std::time::Duration::from_secs(30)
+            };
             let group_result = tokio::time::timeout(
-                std::time::Duration::from_secs(30),
+                next_timeout,
                 track.next_group(),
             ).await;
             let mut group = match group_result {
@@ -285,6 +294,7 @@ pub async fn handle_shell_tui(
                 Ok(Err(e)) => { tracing::debug!("moq next_group: {e}"); break; }
                 Err(_) => { tracing::debug!("moq next_group timeout"); break; }
             };
+            first_group = false;
             let frame: bytes::Bytes = match tokio::time::timeout(
                 std::time::Duration::from_secs(5),
                 group.read_frame(),

--- a/crates/hyprstream/src/cli/shell_handlers.rs
+++ b/crates/hyprstream/src/cli/shell_handlers.rs
@@ -127,7 +127,7 @@ pub async fn handle_shell_tui(
     use crate::cli::tui_handlers::{
         create_tui_client, enter_raw_mode, restore_terminal, terminal_size,
     };
-    use hyprstream_rpc::streaming::{StreamPayload, StreamVerifier};
+    use hyprstream_rpc::streaming::StreamPayload;
 
     let client = create_tui_client(signing_key);
     let (cols, rows) = terminal_size();
@@ -235,82 +235,42 @@ pub async fn handle_shell_tui(
         .context("mac_key must be 32 bytes")?;
     let topic = stdout_stream.topic.clone();
 
-    use hyprstream_rpc::moq_stream::{verify_moq_frame, STREAM_TRACK};
-    use hyprstream_rpc::transport::uds_session::{connect_uds, PLANE_MOQ};
-    use moq_net::{Client as MoqClient, Origin};
+    use hyprstream_rpc::moq_stream::MoqStreamHandle;
 
+    let broadcast_path = stdout_stream.moq_broadcast_path.clone();
     anyhow::ensure!(
-        !stdout_stream.moq_uds_path.is_empty(),
-        "TUI service did not return a moq UDS path — server did not initialize moq transport"
+        !broadcast_path.is_empty(),
+        "TUI service did not return a moq broadcast path — server did not initialize moq transport"
     );
 
     let (frame_tx, mut frame_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(64);
 
-    let uds_path = stdout_stream.moq_uds_path.clone();
-    let broadcast_path = stdout_stream.moq_broadcast_path.clone();
-    let topic_str = topic.clone();
+    // #275: dial the producer's networked reach (the TUI service's bound QUIC
+    // `/moq` endpoint) rather than this process's OWN local moq UDS plane. The
+    // shared `MoqStreamHandle::networked` consumer prefers the StreamInfo's reach
+    // and falls back to the local UDS only when no dialable reach is present —
+    // mirroring the chat-inference consumer that this fix is modeled on. (Before
+    // the fix this bespoke loop did `connect_uds(moq_uds_path)`, which timed out
+    // because the PTY broadcast lives on the *TUI service's* plane, a different
+    // process from this viewer.)
+    let reach = stdout_stream.reach.clone();
+    let mut handle = MoqStreamHandle::networked(reach, broadcast_path, mac_key, topic);
     let _recv_handle = tokio::spawn(async move {
-        let session = match connect_uds(&uds_path, PLANE_MOQ).await {
-            Ok(s) => s,
-            Err(e) => { tracing::warn!("moq UDS connect: {e}"); return; }
-        };
-        let client_origin = Origin::random().produce();
-        let client_consumer = client_origin.consume();
-        let moq_client = MoqClient::new().with_consume(client_origin);
-        let _session = match moq_client.connect(session).await {
-            Ok(s) => s,
-            Err(e) => { tracing::warn!("moq handshake: {e}"); return; }
-        };
-        let bc = match tokio::time::timeout(
-            std::time::Duration::from_secs(10),
-            client_consumer.announced_broadcast(&broadcast_path),
-        ).await {
-            Ok(Some(bc)) => bc,
-            Ok(None) => { tracing::warn!("broadcast {broadcast_path} not announced"); return; }
-            Err(_) => { tracing::warn!("timeout waiting for broadcast {broadcast_path}"); return; }
-        };
-        let mut track = match bc.subscribe_track(&moq_net::Track::new(STREAM_TRACK)) {
-            Ok(t) => t,
-            Err(e) => { tracing::warn!("subscribe_track: {e}"); return; }
-        };
-        let mut verifier = StreamVerifier::new(mac_key, topic);
-        // The first group only arrives after the model finishes PREFILL, which can
-        // take minutes for a large prompt on slow/CPU hardware; give it a generous
-        // budget. Subsequent decode groups arrive steadily, so a short idle suffices.
-        let mut first_group = true;
         loop {
-            let next_timeout = if first_group {
-                std::time::Duration::from_secs(300)
-            } else {
-                std::time::Duration::from_secs(30)
-            };
-            let group_result = tokio::time::timeout(
-                next_timeout,
-                track.next_group(),
-            ).await;
-            let mut group = match group_result {
-                Ok(Ok(Some(g))) => g,
-                Ok(Ok(None)) => break,
-                Ok(Err(e)) => { tracing::debug!("moq next_group: {e}"); break; }
-                Err(_) => { tracing::debug!("moq next_group timeout"); break; }
-            };
-            first_group = false;
-            let frame: bytes::Bytes = match tokio::time::timeout(
-                std::time::Duration::from_secs(5),
-                group.read_frame(),
-            ).await {
-                Ok(Ok(Some(f))) => f,
-                _ => continue,
-            };
-            match verify_moq_frame(&mut verifier, &topic_str, &frame) {
-                Ok(payloads) => {
-                    for p in payloads {
-                        if let StreamPayload::Data(data) = p {
-                            if frame_tx.send(data).await.is_err() { return; }
-                        }
-                    }
+            match handle.recv_next().await {
+                Ok(Some(StreamPayload::Data(data))) => {
+                    if frame_tx.send(data).await.is_err() { return; }
                 }
-                Err(e) => tracing::warn!("moq frame verify: {e}"),
+                // A terminal Complete payload or a clean end-of-stream both end
+                // the loop cleanly.
+                Ok(Some(StreamPayload::Complete(_))) | Ok(None) => return,
+                Ok(Some(StreamPayload::Error(msg))) => {
+                    tracing::warn!("moq stream error: {msg}");
+                    return;
+                }
+                // Other payloads (e.g. Tagged) carry no ANSI frame bytes.
+                Ok(Some(_)) => continue,
+                Err(e) => { tracing::warn!("moq frame recv: {e}"); return; }
             }
         }
     });

--- a/crates/hyprstream/src/cli/tui_handlers.rs
+++ b/crates/hyprstream/src/cli/tui_handlers.rs
@@ -119,22 +119,19 @@ async fn run_attach_loop(
     client: &TuiClient,
     viewer_id: u32,
 ) -> Result<()> {
-    use hyprstream_rpc::moq_stream::{verify_moq_frame, STREAM_TRACK};
-    use hyprstream_rpc::streaming::{StreamPayload, StreamVerifier};
-    use hyprstream_rpc::transport::uds_session::{connect_uds, PLANE_MOQ};
-    use moq_net::{Client as MoqClient, Origin};
+    use hyprstream_rpc::moq_stream::MoqStreamHandle;
+    use hyprstream_rpc::streaming::StreamPayload;
 
+    let broadcast_path = stream_info.moq_broadcast_path.clone();
     anyhow::ensure!(
-        !stream_info.moq_uds_path.is_empty(),
-        "TUI service did not return a moq UDS path — server may be in ZMQ-only mode"
+        !broadcast_path.is_empty(),
+        "TUI service did not return a moq broadcast path — server may be in ZMQ-only mode"
     );
 
     let mac_key: [u8; 32] = stream_info.mac_key.as_slice()
         .try_into()
         .context("mac_key must be 32 bytes")?;
     let topic = stream_info.topic.clone();
-    let uds_path = stream_info.moq_uds_path.clone();
-    let broadcast_path = stream_info.moq_broadcast_path.clone();
 
     // Enter raw terminal mode
     let orig_termios = enter_raw_mode()?;
@@ -144,69 +141,27 @@ async fn run_attach_loop(
 
     let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(64);
 
+    // #275: dial the producer's networked reach (the TUI service's QUIC `/moq`
+    // endpoint) via the shared `MoqStreamHandle::networked` consumer, which prefers
+    // the StreamInfo's reach and falls back to the local moq UDS plane only when no
+    // dialable reach is present. `attach` is a cross-process viewer, so the old
+    // `connect_uds(moq_uds_path)` connected to *this* process's empty plane and
+    // timed out waiting for the producer's broadcast.
+    let reach = stream_info.reach.clone();
+    let mut handle = MoqStreamHandle::networked(reach, broadcast_path, mac_key, topic);
     let recv_handle = tokio::spawn(async move {
-        let session = match connect_uds(&uds_path, PLANE_MOQ).await {
-            Ok(s) => s,
-            Err(e) => { tracing::warn!("moq UDS connect: {e}"); return; }
-        };
-        let client_origin = Origin::random().produce();
-        let client_consumer = client_origin.consume();
-        let moq_client = MoqClient::new().with_consume(client_origin);
-        let _session = match moq_client.connect(session).await {
-            Ok(s) => s,
-            Err(e) => { tracing::warn!("moq handshake: {e}"); return; }
-        };
-        let bc = match tokio::time::timeout(
-            std::time::Duration::from_secs(10),
-            client_consumer.announced_broadcast(&broadcast_path),
-        ).await {
-            Ok(Some(bc)) => bc,
-            Ok(None) => { tracing::warn!("broadcast {broadcast_path} not announced"); return; }
-            Err(_) => { tracing::warn!("timeout waiting for broadcast {broadcast_path}"); return; }
-        };
-        let mut track = match bc.subscribe_track(&moq_net::Track::new(STREAM_TRACK)) {
-            Ok(t) => t,
-            Err(e) => { tracing::warn!("subscribe_track: {e}"); return; }
-        };
-        let topic_str = topic.clone();
-        let mut verifier = StreamVerifier::new(mac_key, topic);
-        // The first group only arrives after the model finishes PREFILL, which can
-        // take minutes for a large prompt on slow/CPU hardware; give it a generous
-        // budget. Subsequent decode groups arrive steadily, so a short idle suffices.
-        let mut first_group = true;
         loop {
-            let next_timeout = if first_group {
-                std::time::Duration::from_secs(300)
-            } else {
-                std::time::Duration::from_secs(30)
-            };
-            let group_result = tokio::time::timeout(
-                next_timeout,
-                track.next_group(),
-            ).await;
-            let mut group = match group_result {
-                Ok(Ok(Some(g))) => g,
-                Ok(Ok(None)) => break,
-                Ok(Err(e)) => { tracing::debug!("moq next_group: {e}"); break; }
-                Err(_) => { tracing::debug!("moq next_group timeout"); break; }
-            };
-            first_group = false;
-            let frame: bytes::Bytes = match tokio::time::timeout(
-                std::time::Duration::from_secs(5),
-                group.read_frame(),
-            ).await {
-                Ok(Ok(Some(f))) => f,
-                _ => continue,
-            };
-            match verify_moq_frame(&mut verifier, &topic_str, &frame) {
-                Ok(payloads) => {
-                    for payload in payloads {
-                        if let StreamPayload::Data(data) = payload {
-                            if tx.send(data).await.is_err() { return; }
-                        }
-                    }
+            match handle.recv_next().await {
+                Ok(Some(StreamPayload::Data(data))) => {
+                    if tx.send(data).await.is_err() { return; }
                 }
-                Err(e) => tracing::warn!("moq frame verify: {e}"),
+                Ok(Some(StreamPayload::Complete(_))) | Ok(None) => return,
+                Ok(Some(StreamPayload::Error(msg))) => {
+                    tracing::warn!("moq stream error: {msg}");
+                    return;
+                }
+                Ok(Some(_)) => continue,
+                Err(e) => { tracing::warn!("moq frame recv: {e}"); return; }
             }
         }
     });

--- a/crates/hyprstream/src/cli/tui_handlers.rs
+++ b/crates/hyprstream/src/cli/tui_handlers.rs
@@ -170,9 +170,18 @@ async fn run_attach_loop(
         };
         let topic_str = topic.clone();
         let mut verifier = StreamVerifier::new(mac_key, topic);
+        // The first group only arrives after the model finishes PREFILL, which can
+        // take minutes for a large prompt on slow/CPU hardware; give it a generous
+        // budget. Subsequent decode groups arrive steadily, so a short idle suffices.
+        let mut first_group = true;
         loop {
+            let next_timeout = if first_group {
+                std::time::Duration::from_secs(300)
+            } else {
+                std::time::Duration::from_secs(30)
+            };
             let group_result = tokio::time::timeout(
-                std::time::Duration::from_secs(30),
+                next_timeout,
                 track.next_group(),
             ).await;
             let mut group = match group_result {
@@ -181,6 +190,7 @@ async fn run_attach_loop(
                 Ok(Err(e)) => { tracing::debug!("moq next_group: {e}"); break; }
                 Err(_) => { tracing::debug!("moq next_group timeout"); break; }
             };
+            first_group = false;
             let frame: bytes::Bytes = match tokio::time::timeout(
                 std::time::Duration::from_secs(5),
                 group.read_frame(),

--- a/crates/hyprstream/src/runtime/batched_lora.rs
+++ b/crates/hyprstream/src/runtime/batched_lora.rs
@@ -135,9 +135,15 @@ impl BatchedLoRAForward {
                 // A: [rank, in_features] -> A^T: [in_features, rank]
                 // B: [out_features, rank] -> B^T: [rank, out_features]
                 // output = scaling * (x_i @ A^T @ B^T)
-                let intermediate = x[i].matmul(&a.tr()); // [1, seq_len, rank]
+                // A/B are stored in fp32; cast x to A's dtype for the matmul (CPU addmm
+                // requires matching operand dtypes), then cast the correction back to x's
+                // dtype so callers can add it to a base-dtype (e.g. BF16) tensor. Both
+                // casts are device-agnostic no-ops when dtypes already match.
+                let input_kind = x[i].kind();
+                let xi = x[i].to_kind(a.kind());
+                let intermediate = xi.matmul(&a.tr()); // [1, seq_len, rank]
                 let output = intermediate.matmul(&b.tr()); // [1, seq_len, out_features]
-                results.push(output * self.scaling);
+                results.push((output * self.scaling).to_kind(input_kind));
             } else {
                 // No delta for this tenant — zero correction
                 let shape = x[i].size();

--- a/crates/hyprstream/src/training/tenant_delta.rs
+++ b/crates/hyprstream/src/training/tenant_delta.rs
@@ -416,13 +416,19 @@ impl TenantDelta {
         let a_eff = a.narrow(0, 0, eff_rank); // [eff_rank, in_features]
         let b_eff = b.narrow(1, 0, eff_rank); // [out_features, eff_rank]
 
+        // Compute the LoRA correction in A/B's dtype (fp32, see forward_2d docs), then
+        // cast the result back to the input activation's dtype so callers can add it to
+        // base-dtype tensors. Without this, a BF16 base activation + an fp32 correction
+        // panics on CPU (addmm requires matching operand dtypes). Casting back is a
+        // device-agnostic no-op when x already matches a.kind().
+        let input_kind = x.kind();
         let x = x.to_kind(a.kind());
         let intermediate = x.f_matmul(&a_eff.tr())
             .map_err(|e| anyhow!("Delta forward matmul A failed for '{}': {}", key, e))?;
         let output = intermediate.f_matmul(&b_eff.tr())
             .map_err(|e| anyhow!("Delta forward matmul B failed for '{}': {}", key, e))?;
 
-        Ok(output * scaling)
+        Ok((output * scaling).to_kind(input_kind))
     }
 
     /// Compute LoRA correction for 2D tensors at a specific layer: output += scaling * (x @ A^T) @ B^T
@@ -457,13 +463,19 @@ impl TenantDelta {
         let a_eff = a.narrow(0, 0, eff_rank); // [eff_rank, in_features]
         let b_eff = b.narrow(1, 0, eff_rank); // [out_features, eff_rank]
 
+        // Compute in A/B's dtype (fp32 — see doc above for the Muon/NS rationale), then
+        // cast the correction back to the input activation's dtype. The base model is
+        // often BF16; the caller adds this correction to a BF16 tensor, and on CPU a
+        // BF16 + fp32 add panics (addmm requires matching dtypes). The cast back is a
+        // device-agnostic no-op when input_kind already equals a.kind().
+        let input_kind = x.kind();
         let x = x.to_kind(a.kind());
         let intermediate = x.f_matmul(&a_eff.tr())
             .map_err(|e| anyhow!("Delta forward_2d matmul A failed for '{}': {}", key, e))?;
         let output = intermediate.f_matmul(&b_eff.tr())
             .map_err(|e| anyhow!("Delta forward_2d matmul B failed for '{}': {}", key, e))?;
 
-        Ok(output * scaling)
+        Ok((output * scaling).to_kind(input_kind))
     }
 
     /// Compute the ratio of delta norm to a reference norm for drift monitoring
@@ -1220,6 +1232,52 @@ mod tests {
         let x = Tensor::randn([10, 512], (Kind::Float, Device::Cpu));
         let output = delta.forward_2d(&x, "q_proj", 0).unwrap();
         assert_eq!(output.size(), vec![10, 512]);
+    }
+
+    /// Regression test for the CPU dtype-mismatch panic: a BFloat16 base model uses
+    /// fp32-stored LoRA deltas. The delta-application matmul must run without panicking
+    /// and the correction must come back in the base (BF16) dtype so the call site can
+    /// add it to a BF16 activation (CPU `addmm` rejects mixed float dtypes).
+    #[test]
+    fn test_forward_bf16_input_fp32_delta_no_panic() {
+        let config = TenantDeltaConfig {
+            rank: 16,
+            alpha: 32.0,
+            target_modules: vec!["q_proj".to_owned(), "v_proj".to_owned()],
+            ..Default::default()
+        };
+        let dims = test_module_dims();
+        let delta = TenantDelta::new(&config, &dims, Device::Cpu, TEST_NUM_LAYERS).unwrap();
+
+        // Sanity: stored A/B are fp32 (kaiming/zeros default kind).
+        assert_eq!(delta.lora_a["0.q_proj"].kind(), Kind::Float);
+        assert_eq!(delta.lora_b["0.q_proj"].kind(), Kind::Float);
+
+        // BF16 base activation, mirroring a BF16 model on CPU.
+        let x_2d = Tensor::randn([10, 512], (Kind::Float, Device::Cpu)).to_kind(Kind::BFloat16);
+
+        // forward_2d must not panic and must return a BF16 correction.
+        let corr_2d = delta.forward_2d(&x_2d, "q_proj", 0).unwrap();
+        assert_eq!(corr_2d.kind(), Kind::BFloat16);
+        assert_eq!(corr_2d.size(), vec![10, 512]);
+
+        // The exact operation that panicked at the qwen3_5 call site: base + correction,
+        // both BF16. Forcing evaluation (sum) ensures the add actually executes.
+        let base_2d = Tensor::randn([10, 512], (Kind::Float, Device::Cpu)).to_kind(Kind::BFloat16);
+        let combined = &base_2d + &corr_2d;
+        assert_eq!(combined.kind(), Kind::BFloat16);
+        let _ = combined.sum(Kind::Float).double_value(&[]);
+
+        // The 3D `forward` path must behave identically.
+        let x_3d = Tensor::randn([1, 10, 512], (Kind::Float, Device::Cpu)).to_kind(Kind::BFloat16);
+        let corr_3d = delta.forward(&x_3d, "v_proj", 0).unwrap();
+        assert_eq!(corr_3d.kind(), Kind::BFloat16);
+        assert_eq!(corr_3d.size(), vec![1, 10, 512]);
+
+        // fp32 input still yields fp32 output (cast-back is a no-op when dtypes match).
+        let x_f32 = Tensor::randn([10, 512], (Kind::Float, Device::Cpu));
+        let corr_f32 = delta.forward_2d(&x_f32, "q_proj", 0).unwrap();
+        assert_eq!(corr_f32.kind(), Kind::Float);
     }
 
     #[test]

--- a/crates/hyprstream/src/tui/service.rs
+++ b/crates/hyprstream/src/tui/service.rs
@@ -1541,6 +1541,13 @@ impl TuiService {
             connect.set_viewer_id(viewer_id);
             connect.set_session_id(session_id);
 
+            // #275: the node's network-routable moq reach (the bound QUIC `/moq`
+            // endpoint, registered when the daemon's web_transport_quinn server
+            // binds). Shared across all FD streams — they all live on this node's
+            // one moq plane. A cross-process viewer dials this reach instead of its
+            // own local moq UDS plane (see StreamInfo.reach docs / MoqStreamHandle::networked).
+            let reach = hyprstream_rpc::moq_stream::producer_reach();
+
             // FD-indexed streams: [0]=stdin (input relay), [1]=stdout (frames)
             let mut stream_list = connect.reborrow().init_streams(streams.len() as u32);
             for (i, (topic, sub_endpoint, mac_key, moq_path, moq_uds)) in streams.iter().enumerate() {
@@ -1550,6 +1557,14 @@ impl TuiService {
                 si.set_mac_key(*mac_key);
                 si.set_moq_broadcast_path(moq_path);
                 si.set_moq_uds_path(moq_uds);
+                // Encode the networked reach via the shared generated ToCapnp impl
+                // (Destination::write_to), so the wire bytes match the inference
+                // StreamInfo's `announcedAt` 1:1.
+                let mut reach_list = si.reborrow().init_reach(reach.len() as u32);
+                for (j, dest) in reach.iter().enumerate() {
+                    let mut db = reach_list.reborrow().get(j as u32);
+                    hyprstream_rpc::capnp::ToCapnp::write_to(dest, &mut db);
+                }
             }
 
             let mut win_list = connect.init_windows(windows.len() as u32);
@@ -2375,6 +2390,7 @@ pub(crate) async fn run_frame_loop(
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
 
@@ -2382,5 +2398,77 @@ mod tests {
     fn test_display_mode() {
         assert_ne!(DisplayMode::Ansi, DisplayMode::Capnp);
         assert_ne!(DisplayMode::Capnp, DisplayMode::Structured);
+    }
+
+    /// #275: the PTY StreamInfo must carry the producer's networked reach so a
+    /// cross-process viewer dials the TUI service's QUIC `/moq` endpoint instead
+    /// of its own local moq UDS plane. This exercises the exact encode path
+    /// `build_connect_response` uses — `producer_reach()` → `Destination::write_to`
+    /// into the tui StreamInfo capnp `reach` field — and reads it back through the
+    /// generated `tui_client::StreamInfo` decoder, asserting the Quic dial params
+    /// survive the round-trip intact (the chat-inference fix relied on the same
+    /// reach being present; the bug was the TUI StreamInfo not carrying it).
+    #[test]
+    fn pty_stream_info_carries_dialable_reach() {
+        use hyprstream_rpc::capnp::FromCapnp;
+        use hyprstream_rpc::moq_stream::{init_global_producer_reach, producer_reach, NodeStreamReach};
+
+        // Register a networked reach exactly as the QUIC bind does (idempotent —
+        // first wins; ignore the result so concurrent tests don't fail this one).
+        let addr: std::net::SocketAddr = "127.0.0.1:4433".parse().expect("addr");
+        let _ = init_global_producer_reach(NodeStreamReach {
+            addr,
+            server_name: "localhost".to_owned(),
+            cert_hashes: vec![[0x11u8; 32]],
+        });
+        let reach = producer_reach();
+        assert!(
+            !reach.is_empty(),
+            "producer_reach() must be non-empty after registering a NodeStreamReach"
+        );
+
+        // Build a tui StreamInfo capnp the same way build_connect_response does.
+        let mut msg = Builder::new_default();
+        {
+            let mut si = msg.init_root::<tui_capnp::stream_info::Builder<'_>>();
+            si.set_topic("deadbeef");
+            si.set_mac_key(&[7u8; 32]);
+            si.set_moq_broadcast_path("local/streams/deadbeef");
+            si.set_moq_uds_path("/run/hyprstream/moq.sock");
+            let mut reach_list = si.reborrow().init_reach(reach.len() as u32);
+            for (j, dest) in reach.iter().enumerate() {
+                let mut db = reach_list.reborrow().get(j as u32);
+                hyprstream_rpc::capnp::ToCapnp::write_to(dest, &mut db);
+            }
+        }
+        let mut buf = Vec::new();
+        serialize::write_message(&mut buf, &msg).expect("serialize");
+
+        // Decode through the generated client StreamInfo and assert the reach
+        // carries the Quic dial parameters intact.
+        let reader = serialize::read_message(&buf[..], capnp::message::ReaderOptions::new())
+            .expect("read");
+        let si_reader = reader
+            .get_root::<tui_capnp::stream_info::Reader<'_>>()
+            .expect("root");
+        let decoded =
+            crate::services::generated::tui_client::StreamInfo::read_from(si_reader).expect("decode");
+
+        assert_eq!(
+            decoded.reach.len(),
+            reach.len(),
+            "decoded StreamInfo.reach must round-trip the producer reach"
+        );
+        // The single reach must be a Quic destination with our dial params.
+        let dest = &decoded.reach[0];
+        match &dest.transport {
+            hyprstream_rpc::stream_info::TransportConfig::Quic(q) => {
+                assert_eq!(q.addr, "127.0.0.1:4433");
+                assert_eq!(q.server_name, "localhost");
+                assert_eq!(q.cert_hashes.len(), 1);
+                assert_eq!(q.cert_hashes[0], vec![0x11u8; 32]);
+            }
+            other => panic!("expected a Quic reach, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
- **fix(inference): cast LoRA/TTN delta correction to activation dtype (CPU BF16 matmul)**
- **fix(streaming): prefer producer networked reach over local UDS in MoqStreamHandle**
- **fix(streaming): generous first-group timeout in TUI/shell stream consumer (prefill)**
- **fix(tui): PTY/attach stream consumers use networked reach (complete networked-only client)**
