### PR TITLE
fix(stream): read moq groups by exact sequence (get_group) to stop tail-group skip

### DIFF
--- a/crates/hyprstream-rpc/src/moq_stream.rs
+++ b/crates/hyprstream-rpc/src/moq_stream.rs
@@ -714,16 +714,24 @@ async fn moq_stream_handle_task(
             return;
         }
     };
-    let mut track = match bc.subscribe_track(&Track::new(STREAM_TRACK)) {
+    let track = match bc.subscribe_track(&Track::new(STREAM_TRACK)) {
         Ok(t) => t,
         Err(e) => { let _ = tx.send(Err(anyhow!("subscribe_track: {e}"))).await; return; }
     };
     let mut verifier = StreamVerifier::new(mac_key, topic.clone());
+    // #145: read groups by EXACT sequence (get_group), not arrival-order next_group.
+    // Each Group is served on its own QUIC uni-stream, so Groups can arrive out of
+    // order; next_group's monotonic cursor returns the first Group with sequence >=
+    // its cursor in *arrival* order, so a lower-seq Group that arrives after a higher
+    // one (e.g. the small terminal / always-retained max_sequence Group) is skipped —
+    // fatally breaking the ordered, gap-fatal chained HMAC. get_group(seq) waits for
+    // each exact Group (even out-of-order), guaranteeing in-order, gap-free delivery.
+    let mut expected_seq = 0u64;
     loop {
         if cancel.is_cancelled() {
             break;
         }
-        let mut group = match tokio::time::timeout(GROUP_IDLE_TIMEOUT, track.next_group()).await {
+        let mut group = match tokio::time::timeout(GROUP_IDLE_TIMEOUT, track.get_group(expected_seq)).await {
             Ok(Ok(Some(g))) => g,
             Ok(Ok(None)) => break, // track ended cleanly
             Err(_elapsed) => {
@@ -738,6 +746,7 @@ async fn moq_stream_handle_task(
                 break;
             }
         };
+        expected_seq += 1;
         let frame: bytes::Bytes = match tokio::time::timeout(FRAME_READ_TIMEOUT, group.read_frame()).await {
             Ok(Ok(Some(f))) => f,
             Ok(Ok(None)) => break, // group ended without a frame
@@ -880,7 +889,7 @@ async fn moq_stream_handle_task_networked(
             return;
         }
     };
-    let mut track = match bc.subscribe_track(&Track::new(STREAM_TRACK)) {
+    let track = match bc.subscribe_track(&Track::new(STREAM_TRACK)) {
         Ok(t) => t,
         Err(e) => {
             let _ = tx.send(Err(anyhow!("subscribe_track: {e}"))).await;
@@ -888,11 +897,19 @@ async fn moq_stream_handle_task_networked(
         }
     };
     let mut verifier = StreamVerifier::new(mac_key, topic.clone());
+    // #145: read groups by EXACT sequence (get_group), not arrival-order next_group.
+    // Each Group is served on its own QUIC uni-stream, so Groups can arrive out of
+    // order; next_group's monotonic cursor returns the first Group with sequence >=
+    // its cursor in *arrival* order, so a lower-seq Group that arrives after a higher
+    // one (e.g. the small terminal / always-retained max_sequence Group) is skipped —
+    // fatally breaking the ordered, gap-fatal chained HMAC. get_group(seq) waits for
+    // each exact Group (even out-of-order), guaranteeing in-order, gap-free delivery.
+    let mut expected_seq = 0u64;
     loop {
         if cancel.is_cancelled() {
             break;
         }
-        let mut group = match tokio::time::timeout(GROUP_IDLE_TIMEOUT, track.next_group()).await {
+        let mut group = match tokio::time::timeout(GROUP_IDLE_TIMEOUT, track.get_group(expected_seq)).await {
             Ok(Ok(Some(g))) => g,
             Ok(Ok(None)) => break,
             Err(_elapsed) => {
@@ -906,6 +923,7 @@ async fn moq_stream_handle_task_networked(
                 break;
             }
         };
+        expected_seq += 1;
         let frame: bytes::Bytes = match tokio::time::timeout(FRAME_READ_TIMEOUT, group.read_frame()).await {
             Ok(Ok(Some(f))) => f,
             Ok(Ok(None)) => break,


### PR DESCRIPTION
The inference stream's HMAC is an ordered, gap-fatal chain (mac_n =
HMAC(key, mac_{n-1} || data_n)). The consumer read groups with
TrackConsumer::next_group(), whose cursor returns the first group with
sequence >= its monotonic cursor in *arrival* order. moq serves each Group on
its own QUIC uni-stream, so Groups can arrive out of order; when the small
terminal Group (the always-retained max_sequence) arrived before the
penultimate one, next_group returned it and advanced the cursor past the
penultimate, permanently skipping it — fatally breaking the chain and failing
every inference after the first ('MAC verification failed' / 'timeout waiting
for broadcast'). The first stream worked only because its consumer subscribed
during production and read every Group live, in order.

Switch both networked and UDS stream consumers to a get_group(expected_seq)
loop: get_group waits for each exact sequence (even out-of-order arrivals) and
returns None only at/after final_sequence, guaranteeing in-order, gap-free
delivery. Fixes multi-turn TUI/CLI inference (#145). Validated: 10/10
consecutive inferences (was 1/8).
