### PR TITLE
ewindisch/policy wildcard fix authz tests

### DIFF
--- a/crates/hyprstream/src/auth/policy_manager.rs
+++ b/crates/hyprstream/src/auth/policy_manager.rs
@@ -111,11 +111,17 @@ fn validate_policy_component(component: &str, name: &str) -> Result<(), PolicyEr
         )));
     }
 
-    if component.contains('*') {
-        return Err(PolicyError::ValidationError(format!(
-            "{name} contains wildcard '*' (not allowed in user-supplied policy subjects)"
-        )));
-    }
+    // NOTE: wildcards ('*') are intentionally NOT rejected here. The Casbin model
+    // (DEFAULT_MODEL_CONF) is wildcard-based: every rule carries domain="*", and
+    // legitimate features rely on wildcard subjects/resources/actions — public
+    // models ("*" subject, see PolicyService::handle_set_branch_visibility),
+    // role-scoped resource grants ("model:*"), action namespaces ("ttt.*"), and
+    // the OIDC self-ownership grant. A blanket '*' ban here broke all of those
+    // (and made add_policy() — which injects domain="*" — always fail) while
+    // adding no real protection: who may mutate policy is enforced at the
+    // PolicyService RPC authz layer (the correct place for anti-escalation), not
+    // by banning '*' in policy *content*. The null/newline/comma/length checks
+    // above remain — those are genuine CSV-injection / DoS guards.
 
     Ok(())
 }
@@ -1028,5 +1034,124 @@ mod tests {
         }
 
         assert!(allowed, "service:oauth should be able to query policy:ResolveServiceKey");
+    }
+
+    // ========================================================================
+    // atproto-scoped authorization invariants
+    //
+    // These assert *behavioral* contracts that any authorization model must
+    // hold (deny-by-default, per-identity isolation, public/private visibility,
+    // stream isolation) — NOT the current Casbin mechanism/vocabulary. They are
+    // written to survive the future tiles.run / atproto authz alignment: the
+    // new model has to satisfy the same invariants, so these double as a
+    // conformance harness. Resource identifiers go through the helpers below so
+    // that when model resources move toward MIR / AT-URI form the naming changes
+    // in one place, not every assertion. (OAuth scope-vocabulary tests are
+    // intentionally deferred — hyprstream's `action:service:*` scopes are not
+    // the access gate and will be replaced by atproto scopes.)
+    // ========================================================================
+
+    /// Resource string for a model branch. Centralized for atproto/MIR forward-compat.
+    fn model_resource(name: &str, branch: &str) -> String {
+        format!("model:{name}:{branch}")
+    }
+    /// Resource pattern for an identity's own namespace (self-ownership).
+    fn user_ns(subject: &str) -> String {
+        format!("user:{subject}:*")
+    }
+    /// Resource string for a moq event-prefix subscribe scope.
+    fn subscribe_scope(prefix: &str) -> String {
+        format!("subscribe:events:{prefix}.*")
+    }
+
+    /// Regression guard for the wildcard-validation bug: `add_policy` injects
+    /// domain="*", so a blanket '*' ban made it always fail (even on
+    /// wildcard-free input). It must succeed and take effect.
+    #[tokio::test]
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
+    async fn test_add_policy_succeeds_with_default_domain() {
+        let pm = PolicyManager::new_in_memory().await.unwrap();
+        // Wildcard-free 3-arg add_policy (internally domain="*") must succeed.
+        pm.add_policy("alice", &model_resource("qwen3", "main"), "infer.generate")
+            .await
+            .expect("add_policy must succeed (domain=* is the legitimate global domain)");
+        assert!(
+            pm.check("alice", &model_resource("qwen3", "main"), Operation::Infer).await,
+            "the rule add_policy created must take effect"
+        );
+    }
+
+    /// P0a — self-namespace isolation: an identity may reach its own namespace,
+    /// and MUST NOT reach another identity's namespace (cross-identity denial).
+    #[tokio::test]
+    #[allow(clippy::unwrap_used)]
+    async fn test_self_namespace_isolation() {
+        let pm = PolicyManager::new_in_memory().await.unwrap();
+        // The self-ownership grant the OIDC callback issues on first login.
+        pm.add_policy_with_domain("alice", "*", &user_ns("alice"), "*", "allow")
+            .await
+            .unwrap();
+        pm.add_policy_with_domain("bob", "*", &user_ns("bob"), "*", "allow")
+            .await
+            .unwrap();
+
+        // Each identity reaches its own namespace.
+        assert!(pm.check_with_domain("alice", "*", "user:alice:model1", "ttt.writeback").await);
+        assert!(pm.check_with_domain("bob", "*", "user:bob:model1", "ttt.writeback").await);
+
+        // Neither identity may reach the other's namespace.
+        assert!(!pm.check_with_domain("alice", "*", "user:bob:model1", "infer.generate").await,
+            "alice must not access bob's namespace");
+        assert!(!pm.check_with_domain("bob", "*", "user:alice:model1", "ttt.writeback").await,
+            "bob must not access alice's namespace");
+    }
+
+    /// P1a — deny-by-default and least-privilege: an unknown subject is denied,
+    /// a scoped grant authorizes only that exact (resource, action) pair, and
+    /// does not leak to other resources or actions.
+    #[tokio::test]
+    #[allow(clippy::unwrap_used)]
+    async fn test_deny_by_default_and_least_privilege() {
+        let pm = PolicyManager::new_in_memory().await.unwrap();
+        let resource = model_resource("qwen3", "main");
+
+        // Deny-by-default: nobody is authorized until granted.
+        assert!(!pm.check_with_domain("mallory", "*", &resource, "infer.generate").await);
+
+        // Grant alice exactly infer on this model.
+        pm.add_policy_with_domain("alice", "*", &resource, "infer.generate", "allow")
+            .await
+            .unwrap();
+
+        assert!(pm.check_with_domain("alice", "*", &resource, "infer.generate").await);
+        // Grant does not leak to other actions...
+        assert!(!pm.check_with_domain("alice", "*", &resource, "ttt.writeback").await,
+            "infer grant must not confer manage");
+        // ...nor to other resources...
+        assert!(!pm.check_with_domain("alice", "*", &model_resource("llama", "main"), "infer.generate").await,
+            "grant on one model must not confer another");
+        // ...nor to other subjects.
+        assert!(!pm.check_with_domain("mallory", "*", &resource, "infer.generate").await);
+    }
+
+    /// P2a — moq subscribe-prefix isolation: a subscribe grant on one event
+    /// prefix MUST NOT authorize a sibling/private prefix (no cross-tenant leak
+    /// via prefix matching).
+    #[tokio::test]
+    #[allow(clippy::unwrap_used)]
+    async fn test_subscribe_prefix_isolation() {
+        let pm = PolicyManager::new_in_memory().await.unwrap();
+        // alice may subscribe under the "public" prefix only.
+        pm.add_policy_with_domain("alice", "*", &subscribe_scope("public"), "subscribe", "allow")
+            .await
+            .unwrap();
+
+        assert!(pm.check_with_domain("alice", "*", "subscribe:events:public.metrics", "subscribe").await,
+            "alice may subscribe within her granted prefix");
+        // A private prefix is NOT covered by the public-prefix grant.
+        assert!(!pm.check_with_domain("alice", "*", "subscribe:events:private.secrets", "subscribe").await,
+            "public-prefix grant must not leak to a private prefix");
+        // An ungranted subject is denied entirely.
+        assert!(!pm.check_with_domain("bob", "*", "subscribe:events:public.metrics", "subscribe").await);
     }
 }

--- a/docs/plans/2026-06-17-policy-wildcard-validation-spike.md
+++ b/docs/plans/2026-06-17-policy-wildcard-validation-spike.md
@@ -1,0 +1,98 @@
+# Spike: policy_manager test failures — wildcard validation regression
+
+**Branch:** `ewindisch/spike-policy-manager-tests` (off `ewindisch/stack-test-fixes`, moq epic tip)
+**Date:** 2026-06-17
+**Question:** Are the 7 failing `auth::policy_manager` tests valid issues or stale tests? Security-review the tests and their importance.
+
+## Verdict
+
+**Valid issue — a real, production-affecting regression**, not stale tests. The tests are correct and security-important; they caught a hardening change that broke the runtime authorization-mutation API.
+
+## Root cause
+
+`516b53581` (2026-06-16, *"fix(validation): … policy wildcard …"*, stack-only) added
+`validate_policy_component` (`crates/hyprstream/src/auth/policy_manager.rs:89`), which rejects
+`*` in **every** policy component:
+
+```rust
+if component.contains('*') {
+    return Err(ValidationError("… contains wildcard '*' (not allowed in user-supplied policy subjects)"));
+}
+```
+
+It is called by **all** mutators: `add_policy_with_domain`, `remove_policy_with_domain`,
+`add_role_for_user`, `remove_role_for_user` (and `add_policy`/`remove_policy`, which delegate).
+
+But the Casbin model is **built on wildcards** (`DEFAULT_MODEL_CONF`):
+- `m = … (p.dom == "*" || r.dom == p.dom) && keyMatch(r.obj, p.obj) && (p.act == "*" || keyMatch(r.act, p.act))`
+- Every documented rule is `p, alice, *, *, *, allow` / `p, alice, *, model:*, infer, allow`.
+- `domain="*"` is the **standard global domain** used by every base rule and every production call.
+
+So the wildcard ban contradicts the model it guards.
+
+### Two concrete defects
+
+1. **`add_policy()` can never succeed.** It hardcodes `domain="*"` then calls
+   `add_policy_with_domain`, which validates the domain and rejects `*`. Any 3-arg
+   `add_policy(user, resource, op)` returns `ValidationError` regardless of arguments
+   (proven: `test_policy_manager_from_dir` fails on a wildcard-free call).
+2. **`domain="*"` / `subject="*"` / `action="*"` are all rejected**, breaking legitimate
+   runtime grants.
+
+## Production impact (all silently swallowed via `let _ =`)
+
+| Call site | What breaks |
+|---|---|
+| `services/policy.rs:1023-1031` `handle_set_branch_visibility` | **Make model public/private (#276)** — adds `("*","*",resource,…)`; both `*` rejected → model never becomes public. Error swallowed; `save()` persists nothing. |
+| `services/oauth/oidc_callback.rs:566,587` | **OIDC-login self-ownership grant** — `(subject,"*",ns,"*","allow")` → rejected; a newly-authenticated user does not receive their namespace grant. |
+| `cli/bootstrap_manager.rs:357,374` | Bootstrap per-user grants — `(username,"*",…)` → rejected. |
+| `services/factories.rs:349` | TUI anonymous grant `("anonymous","*","tui:*","*",…)` → rejected, but **masked** by the identical static rule in `default_policy_csv` (`p, anonymous, *, tui:*, *, allow`). |
+
+Production boots and mostly works only because bootstrap loads `policy.csv` and injects
+`SERVICE_BASE_POLICIES` **directly into the enforcer**, bypassing the validator. The
+**authorization decision path (`check`/`check_with_domain`) is unaffected** — it does not
+validate, and wildcard matching works (`test_base_rules_injected_on_init` passes). Only
+**runtime mutations** are broken, and every production caller ignores the error, so the
+breakage is silent (an authz grant that silently no-ops).
+
+## Security review of the tests
+
+All 7 are **valid and important** — they encode the authz contract and must not regress:
+
+| Test | Covers | Verdict |
+|---|---|---|
+| `test_policy_manager_from_dir` | deny-by-default; default files; grant-then-allow | keep |
+| `test_add_and_check_policy` | remove permissive rule → deny; scoped grant; op isolation | keep |
+| `test_role_based_access` | RBAC role inheritance; non-member denied | keep |
+| `test_act_wildcard_keymatch` | action-namespace matching (`ttt.*` matches `ttt.writeback`, not `infer.*`) | keep |
+| `test_set_branch_visibility_adds_removes_rules` | public/private model visibility (#276) | keep |
+| `test_format_policy` | policy/role introspection | keep |
+| `test_input_validation_accepts_valid_input` | validator must **accept** legitimate input incl. `model:qwen3-*` | keep |
+
+The CSV-injection validations (null byte, newline/CR, comma, length cap) are **correct and
+valuable** — their tests (`rejects_null_bytes`, `rejects_line_breaks`, `rejects_long_strings`)
+pass and should stay.
+
+## Assessment of the `*` ban as a security control
+
+The `*` rejection is **mis-targeted**:
+- It does not actually prevent privilege escalation — a caller able to reach `add_policy`
+  could still grant broad non-`*` patterns (e.g., `keyMatch` prefixes).
+- The correct control is **service-level authorization on the policy-mutation RPC** (scope
+  *which* subjects/resources a caller may grant — partly present via `SERVICE_BASE_POLICIES`
+  and the PolicyService's own authz), **not** a syntactic ban on `*` in policy content.
+- It breaks core, intended features (public models, global-domain rules, RBAC resource
+  wildcards) — i.e., it is both **incomplete as security** and **breaks functionality**.
+
+## Recommended fix (not yet applied — security-sensitive, needs sign-off)
+
+1. **Remove the `*` check** from `validate_policy_component`; keep null/newline/CR/comma/length
+   (the genuine CSV-injection + DoS protections).
+2. Enforce grant-scoping at the **PolicyService RPC layer** (who may grant what), where the
+   caller identity is known — the right place for anti-escalation.
+3. Re-run the 7 tests (expected: all pass) and add a regression test asserting
+   `add_policy(user, resource, op)` succeeds (guards the `domain="*"` self-failure).
+
+Until then the failures should **not** be dismissed as "pre-existing/ignore" — they mark a
+live, silent authorization-mutation outage (most visibly: **public/private models and OIDC
+self-grant do not work at runtime**).


### PR DESCRIPTION
- **spike(policy): wildcard validation regression breaks runtime authz mutations**
- **fix(policy): drop wildcard ban; add atproto-scoped authz invariant tests**
