### PR TITLE
feat(#273): capnp derive — general unions + group arms; generate StreamInfo/StreamOpt codec

### DIFF
--- a/crates/hyprstream-rpc-build/src/schema/cgr_reader.rs
+++ b/crates/hyprstream-rpc-build/src/schema/cgr_reader.rs
@@ -562,6 +562,205 @@ fn extract_union_variants(
 }
 
 // ---------------------------------------------------------------------------
+// Field / union-arm extraction
+// ---------------------------------------------------------------------------
+
+/// Annotation node IDs used when building a `FieldDef` from a slot.
+///
+/// Bundled into a struct so the same set can be threaded through the struct-field
+/// loop and the union-arm group-leaf loop without drift.
+#[derive(Clone, Copy)]
+struct FieldAnnotationIds {
+    mcp_desc_id: Option<u64>,
+    param_desc_id: Option<u64>,
+    fixed_size_id: Option<u64>,
+    optional_id: Option<u64>,
+    serde_rename_id: Option<u64>,
+}
+
+/// Build a `FieldDef` from a `Slot` field reader.
+///
+/// Shared by the struct-field loop and the union-arm group-leaf loop so the two
+/// can't drift in how they resolve type names, sections, offsets, and annotations.
+fn field_def_from_slot(
+    field: capnp::schema_capnp::field::Reader,
+    slot: capnp::schema_capnp::field::slot::Reader,
+    node_map: &BTreeMap<u64, NodeInfo>,
+    ann: FieldAnnotationIds,
+) -> Result<FieldDef, String> {
+    let field_name = field
+        .get_name()
+        .map_err(|e| format!("{e}"))?
+        .to_str()
+        .map_err(|e| format!("{e}"))?
+        .to_owned();
+
+    let type_reader = slot.get_type().map_err(|e| format!("{e}"))?;
+    let type_name = resolve_type_name(type_reader, node_map);
+    let slot_offset = slot.get_offset();
+    let section = field_section_from_type(type_reader);
+    let disc = field.get_discriminant_value();
+
+    let description = {
+        let annotations = field.get_annotations().map_err(|e| format!("{e}"))?;
+        let desc = extract_annotation_text(annotations, ann.param_desc_id);
+        if desc.is_empty() {
+            extract_annotation_text(
+                field.get_annotations().map_err(|e| format!("{e}"))?,
+                ann.mcp_desc_id,
+            )
+        } else {
+            desc
+        }
+    };
+
+    let fixed_size = extract_annotation_u32(
+        field.get_annotations().map_err(|e| format!("{e}"))?,
+        ann.fixed_size_id,
+    );
+
+    let optional = has_annotation(
+        field.get_annotations().map_err(|e| format!("{e}"))?,
+        ann.optional_id,
+    );
+
+    let serde_rename = {
+        let sr = extract_annotation_text(
+            field.get_annotations().map_err(|e| format!("{e}"))?,
+            ann.serde_rename_id,
+        );
+        if sr.is_empty() {
+            None
+        } else {
+            Some(sr)
+        }
+    };
+
+    Ok(FieldDef {
+        name: field_name,
+        type_name,
+        description,
+        fixed_size,
+        optional,
+        slot_offset,
+        section,
+        discriminant_value: disc,
+        serde_rename,
+    })
+}
+
+/// Extract the structured union arms from a struct node.
+///
+/// For each field with `discriminant_value != 0xFFFF` (sorted by discriminant),
+/// classify the arm payload:
+/// - `Slot` of `Void`  → `ArmPayload::Void`
+/// - `Slot` of any other type → `ArmPayload::Type(name)`
+/// - `Group` → `ArmPayload::Group(leaf FieldDefs)`, resolved by looking up the
+///   synthetic nested struct node via `Group::get_type_id()`.
+///
+/// Returns an error on a missing group node id or a nested `Group` inside a group
+/// arm (unsupported — capnp groups don't nest in a way this codegen models).
+fn extract_union_arms(
+    struct_reader: capnp::schema_capnp::node::struct_::Reader,
+    nodes: &capnp::struct_list::Reader<capnp::schema_capnp::node::Owned>,
+    node_map: &BTreeMap<u64, NodeInfo>,
+    ann: FieldAnnotationIds,
+) -> Result<Vec<UnionArm>, String> {
+    let fields = struct_reader.get_fields().map_err(|e| format!("{e}"))?;
+
+    // Collect union fields (discriminant != 0xFFFF), sorted by discriminant.
+    let mut union_fields: Vec<(u16, u32)> = Vec::new();
+    for i in 0..fields.len() {
+        let field = fields.get(i);
+        let disc = field.get_discriminant_value();
+        if disc != 0xFFFF {
+            union_fields.push((disc, i));
+        }
+    }
+    union_fields.sort_by_key(|(disc, _)| *disc);
+
+    let mut arms = Vec::with_capacity(union_fields.len());
+    for (disc, idx) in union_fields {
+        let field = fields.get(idx);
+        let name = field
+            .get_name()
+            .map_err(|e| format!("{e}"))?
+            .to_str()
+            .map_err(|e| format!("{e}"))?
+            .to_owned();
+
+        let description = {
+            let annotations = field.get_annotations().map_err(|e| format!("{e}"))?;
+            let desc = extract_annotation_text(annotations, ann.param_desc_id);
+            if desc.is_empty() {
+                extract_annotation_text(
+                    field.get_annotations().map_err(|e| format!("{e}"))?,
+                    ann.mcp_desc_id,
+                )
+            } else {
+                desc
+            }
+        };
+
+        let payload = match field.which() {
+            Ok(capnp::schema_capnp::field::Slot(slot)) => {
+                let type_reader = slot.get_type().map_err(|e| format!("{e}"))?;
+                let tn = resolve_type_name(type_reader, node_map);
+                if tn == "Void" {
+                    ArmPayload::Void
+                } else {
+                    ArmPayload::Type(tn)
+                }
+            }
+            Ok(capnp::schema_capnp::field::Group(g)) => {
+                let group_type_id = g.get_type_id();
+                let group_info = node_map.get(&group_type_id).ok_or_else(|| {
+                    format!(
+                        "union arm '{name}': group type id {group_type_id} not found in node map"
+                    )
+                })?;
+                let group_node = nodes.get(group_info.index);
+                let group_struct = match group_node.which() {
+                    Ok(capnp::schema_capnp::node::Struct(s)) => s,
+                    _ => {
+                        return Err(format!(
+                            "union arm '{name}': group type id {group_type_id} is not a struct node"
+                        ))
+                    }
+                };
+                let group_fields = group_struct.get_fields().map_err(|e| format!("{e}"))?;
+                let mut leaves = Vec::with_capacity(group_fields.len() as usize);
+                for k in 0..group_fields.len() {
+                    let leaf = group_fields.get(k);
+                    match leaf.which() {
+                        Ok(capnp::schema_capnp::field::Slot(leaf_slot)) => {
+                            leaves.push(field_def_from_slot(leaf, leaf_slot, node_map, ann)?);
+                        }
+                        Ok(capnp::schema_capnp::field::Group(_)) => {
+                            return Err(format!(
+                                "union arm '{name}': nested groups inside a group arm are unsupported"
+                            ))
+                        }
+                        Err(e) => return Err(format!("group leaf error in arm '{name}': {e}")),
+                    }
+                }
+                ArmPayload::Group(leaves)
+            }
+            Err(e) => return Err(format!("union arm '{name}' field error: {e}")),
+        };
+
+        arms.push(UnionArm {
+            name,
+            discriminant_value: disc,
+            description,
+            payload,
+        });
+    }
+
+    Ok(arms)
+}
+
+// ---------------------------------------------------------------------------
 // Struct extraction
 // ---------------------------------------------------------------------------
 
@@ -570,6 +769,7 @@ fn extract_union_variants(
 fn extract_struct_from_node(
     node: capnp::schema_capnp::node::Reader,
     info: &NodeInfo,
+    nodes: &capnp::struct_list::Reader<capnp::schema_capnp::node::Owned>,
     node_map: &BTreeMap<u64, NodeInfo>,
     mcp_desc_id: Option<u64>,
     param_desc_id: Option<u64>,
@@ -583,6 +783,15 @@ fn extract_struct_from_node(
         Ok(capnp::schema_capnp::node::Struct(s)) => s,
         _ => return Ok(None),
     };
+
+    // Synthetic group nodes (capnp emits one per `:group { ... }` arm, named
+    // `Parent.armName`) are NOT standalone types in any language binding — their
+    // leaf fields are inlined into the parent. Their dotted name is also not a
+    // valid Rust/TS identifier. Skip them: their structured shape is captured in
+    // the parent union's `union_arms`.
+    if struct_reader.get_is_group() {
+        return Ok(None);
+    }
 
     let domain_type = {
         let annotations = node.get_annotations().map_err(|e| format!("{e}"))?;
@@ -604,6 +813,14 @@ fn extract_struct_from_node(
     let mut fields = Vec::new();
     let mut has_union = false;
 
+    let ann = FieldAnnotationIds {
+        mcp_desc_id,
+        param_desc_id,
+        fixed_size_id,
+        optional_id,
+        serde_rename_id,
+    };
+
     for j in 0..fields_reader.len() {
         let field = fields_reader.get(j);
         let disc = field.get_discriminant_value();
@@ -612,79 +829,94 @@ fn extract_struct_from_node(
             has_union = true;
         }
 
-        let field_name = field
-            .get_name()
-            .map_err(|e| format!("{e}"))?
-            .to_str()
-            .map_err(|e| format!("{e}"))?
-            .to_owned();
-
-        let (type_name, slot_offset, section) = match field.which() {
+        // Slot fields go through the shared `field_def_from_slot` helper (also used
+        // by the union-arm group-leaf loop) so the two can't drift. Group fields
+        // keep the flat `("Group", 0, Group)` fallback so the TS/wire-format path is
+        // byte-for-byte unchanged — their structured shape lives in `union_arms`.
+        let field_def = match field.which() {
             Ok(capnp::schema_capnp::field::Slot(slot)) => {
-                let type_reader = slot.get_type().map_err(|e| format!("{e}"))?;
-                let tn = resolve_type_name(type_reader, node_map);
-                let offset = slot.get_offset();
-                let sec = field_section_from_type(type_reader);
-                (tn, offset, sec)
+                field_def_from_slot(field, slot, node_map, ann)?
             }
-            Ok(capnp::schema_capnp::field::Group(_)) => ("Group".into(), 0, FieldSection::Group),
+            Ok(capnp::schema_capnp::field::Group(_)) => {
+                let field_name = field
+                    .get_name()
+                    .map_err(|e| format!("{e}"))?
+                    .to_str()
+                    .map_err(|e| format!("{e}"))?
+                    .to_owned();
+                let description = {
+                    let annotations = field.get_annotations().map_err(|e| format!("{e}"))?;
+                    let desc = extract_annotation_text(annotations, param_desc_id);
+                    if desc.is_empty() {
+                        extract_annotation_text(
+                            field.get_annotations().map_err(|e| format!("{e}"))?,
+                            mcp_desc_id,
+                        )
+                    } else {
+                        desc
+                    }
+                };
+                let fixed_size = extract_annotation_u32(
+                    field.get_annotations().map_err(|e| format!("{e}"))?,
+                    fixed_size_id,
+                );
+                let optional = has_annotation(
+                    field.get_annotations().map_err(|e| format!("{e}"))?,
+                    optional_id,
+                );
+                let serde_rename = {
+                    let sr = extract_annotation_text(
+                        field.get_annotations().map_err(|e| format!("{e}"))?,
+                        serde_rename_id,
+                    );
+                    if sr.is_empty() {
+                        None
+                    } else {
+                        Some(sr)
+                    }
+                };
+                FieldDef {
+                    name: field_name,
+                    type_name: "Group".into(),
+                    description,
+                    fixed_size,
+                    optional,
+                    slot_offset: 0,
+                    section: FieldSection::Group,
+                    discriminant_value: disc,
+                    serde_rename,
+                }
+            }
             Err(e) => return Err(format!("Field error: {e}")),
         };
 
-        let description = {
-            let annotations = field.get_annotations().map_err(|e| format!("{e}"))?;
-            let desc = extract_annotation_text(annotations, param_desc_id);
-            if desc.is_empty() {
-                extract_annotation_text(
-                    field.get_annotations().map_err(|e| format!("{e}"))?,
-                    mcp_desc_id,
-                )
-            } else {
-                desc
-            }
-        };
-
-        let fixed_size = extract_annotation_u32(
-            field.get_annotations().map_err(|e| format!("{e}"))?,
-            fixed_size_id,
-        );
-
-        let optional = has_annotation(
-            field.get_annotations().map_err(|e| format!("{e}"))?,
-            optional_id,
-        );
-
-        let serde_rename = {
-            let sr = extract_annotation_text(
-                field.get_annotations().map_err(|e| format!("{e}"))?,
-                serde_rename_id,
-            );
-            if sr.is_empty() {
-                None
-            } else {
-                Some(sr)
-            }
-        };
-
-        // For non-union fields, skip adding to fields if it's a union member
-        // (union members are handled by the variant extraction path)
-        // We include ALL fields now (including union members) for wire format completeness
-        fields.push(FieldDef {
-            name: field_name,
-            type_name,
-            description,
-            fixed_size,
-            optional,
-            slot_offset,
-            section,
-            discriminant_value: disc,
-            serde_rename,
-        });
+        // We include ALL fields (including union members) for wire-format completeness.
+        fields.push(field_def);
     }
 
     if struct_reader.get_discriminant_count() > 0 {
         has_union = true;
     }
+
+    // Structured union-arm view (Void / single-type / group) for Rust enum codegen.
+    // Only populated for unions; non-union structs leave this empty so the flat
+    // `fields` path is byte-for-byte unchanged.
+    let union_arms = if discriminant_count > 0 {
+        extract_union_arms(
+            struct_reader,
+            nodes,
+            node_map,
+            FieldAnnotationIds {
+                mcp_desc_id,
+                param_desc_id,
+                fixed_size_id,
+                optional_id,
+                serde_rename_id,
+            },
+        )?
+    } else {
+        Vec::new()
+    };
 
     Ok(Some(StructDef {
         name: info.short_name.clone(),
@@ -696,6 +928,7 @@ fn extract_struct_from_node(
         pointer_words,
         discriminant_count,
         discriminant_offset,
+        union_arms,
     }))
 }
 
@@ -729,6 +962,7 @@ fn extract_all_structs(
         if let Some(s) = extract_struct_from_node(
             node,
             info,
+            nodes,
             node_map,
             mcp_desc_id,
             param_desc_id,
@@ -757,6 +991,19 @@ fn extract_all_structs(
         for s in &structs {
             for f in &s.fields {
                 collect_type_refs(&f.type_name, &mut referenced_names);
+            }
+            // Group-arm leaf types are not in the flat `fields` list, so feed them
+            // (and single-type arm payloads, for robustness) into the ref collector.
+            for arm in &s.union_arms {
+                match &arm.payload {
+                    ArmPayload::Type(name) => collect_type_refs(name, &mut referenced_names),
+                    ArmPayload::Group(leaves) => {
+                        for leaf in leaves {
+                            collect_type_refs(&leaf.type_name, &mut referenced_names);
+                        }
+                    }
+                    ArmPayload::Void => {}
+                }
             }
         }
 
@@ -796,6 +1043,7 @@ fn extract_all_structs(
                     if let Some(s) = extract_struct_from_node(
                         node,
                         info,
+                        nodes,
                         node_map,
                         mcp_desc_id,
                         param_desc_id,

--- a/crates/hyprstream-rpc-build/src/schema/types.rs
+++ b/crates/hyprstream-rpc-build/src/schema/types.rs
@@ -35,6 +35,41 @@ pub struct UnionVariant {
     pub doc_example: String,
 }
 
+/// Payload carried by a tagged-union arm.
+///
+/// Distinguishes the three shapes a Cap'n Proto union member can take:
+/// a `Void` arm (no payload), a single-type arm (scalar/Text/Data/enum/struct),
+/// and a `group` arm (an inlined anonymous struct with its own leaf fields).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ArmPayload {
+    /// `arm @N :Void;` — unit variant, no payload.
+    Void,
+    /// `arm @N :T;` — carries a single value of capnp type `T`
+    /// (a scalar, `Text`, `Data`, an enum, or a struct).
+    Type(String),
+    /// `arm @N :group { ... }` — carries an inlined anonymous struct;
+    /// the leaf fields are the group's slots (all non-union).
+    Group(Vec<FieldDef>),
+}
+
+/// A single arm of a tagged union (one member of a capnp `union { ... }`).
+///
+/// Populated for pure-union structs so Rust codegen can emit a native `enum`
+/// (one variant per arm) instead of an empty struct. The flat `fields` list on
+/// `StructDef` still carries every union member (for the TS/wire-format path);
+/// `union_arms` is the structured view layered on top.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UnionArm {
+    /// capnp arm name (camelCase, e.g. `atLeastOnce`).
+    pub name: String,
+    /// Union discriminant ordinal for this arm.
+    pub discriminant_value: u16,
+    /// Description from `$paramDescription`/`$mcpDescription` (may be empty).
+    pub description: String,
+    /// The payload this arm carries.
+    pub payload: ArmPayload,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct StructDef {
     pub name: String,
@@ -55,6 +90,14 @@ pub struct StructDef {
     pub discriminant_count: u16,
     /// Offset of the discriminant in the data section (in u16 units).
     pub discriminant_offset: u32,
+    /// Structured view of the union arms (when `discriminant_count > 0`).
+    ///
+    /// Empty for non-union structs. Layered on top of the flat `fields` list:
+    /// `fields` still carries every union member for the wire-format/TS path,
+    /// while `union_arms` carries the per-arm payload shape (Void / single-type /
+    /// group) that Rust enum codegen consumes.
+    #[serde(default)]
+    pub union_arms: Vec<UnionArm>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/hyprstream-rpc-build/tests/union_arms.rs
+++ b/crates/hyprstream-rpc-build/tests/union_arms.rs
@@ -1,0 +1,104 @@
+//! Fixture parse test for tagged-union arm extraction (#273).
+//!
+//! Compiles a tiny Cap'n Proto schema containing a union with a Void arm, a
+//! scalar arm, and a `group` arm, then asserts the parsed `StructDef.union_arms`
+//! captures the right `ArmPayload` shape for each — including the group's leaf
+//! `FieldDef`s.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::path::Path;
+
+use hyprstream_rpc_build::schema::parse_from_cgr_path;
+use hyprstream_rpc_build::schema::types::{ArmPayload, StructDef};
+
+const TINY_SCHEMA: &str = r#"
+@0xc0ffeec0ffeec0ff;
+
+struct Knob {
+  union {
+    off @0 :Void;
+    level @1 :UInt32;
+    ranged :group {
+      lo @2 :UInt32;
+      hi @3 :UInt32;
+      wrap @4 :Bool;
+    }
+  }
+}
+"#;
+
+/// Compile `TINY_SCHEMA` to a CGR file and parse it via the CGR reader.
+fn parse_tiny() -> Vec<StructDef> {
+    let tmp = std::env::temp_dir().join(format!("hyprstream_union_arms_{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).expect("create temp dir");
+
+    let capnp_path = tmp.join("tiny.capnp");
+    std::fs::write(&capnp_path, TINY_SCHEMA).expect("write tiny.capnp");
+
+    let cgr_path = tmp.join("tiny.cgr");
+    capnpc::CompilerCommand::new()
+        .src_prefix(&tmp)
+        .file(&capnp_path)
+        .raw_code_generator_request_path(&cgr_path)
+        .run()
+        .expect("compile tiny.capnp to CGR");
+
+    let parsed = parse_from_cgr_path(Path::new(&cgr_path), "tiny").expect("parse CGR");
+
+    let _ = std::fs::remove_dir_all(&tmp);
+    parsed.structs
+}
+
+#[test]
+fn union_arms_capture_void_scalar_and_group() {
+    let structs = parse_tiny();
+
+    let knob = structs
+        .iter()
+        .find(|s| s.name == "Knob")
+        .expect("Knob struct present");
+
+    // The synthetic group node (`Knob.ranged`) must NOT appear as a standalone struct.
+    assert!(
+        !structs.iter().any(|s| s.name.contains('.')),
+        "synthetic group nodes should be excluded from structs: {:?}",
+        structs.iter().map(|s| &s.name).collect::<Vec<_>>()
+    );
+
+    assert_eq!(knob.discriminant_count, 3, "three union arms");
+    assert_eq!(knob.union_arms.len(), 3, "three union arms extracted");
+
+    // Arms are sorted by discriminant: off (0), level (1), ranged (2).
+    let off = &knob.union_arms[0];
+    assert_eq!(off.name, "off");
+    assert_eq!(off.discriminant_value, 0);
+    assert!(matches!(off.payload, ArmPayload::Void), "off is Void");
+
+    let level = &knob.union_arms[1];
+    assert_eq!(level.name, "level");
+    assert_eq!(level.discriminant_value, 1);
+    match &level.payload {
+        ArmPayload::Type(t) => assert_eq!(t, "UInt32"),
+        other => panic!("level should be Type(UInt32), got {other:?}"),
+    }
+
+    let ranged = &knob.union_arms[2];
+    assert_eq!(ranged.name, "ranged");
+    assert_eq!(ranged.discriminant_value, 2);
+    match &ranged.payload {
+        ArmPayload::Group(leaves) => {
+            assert_eq!(leaves.len(), 3, "group has three leaf fields");
+            assert_eq!(leaves[0].name, "lo");
+            assert_eq!(leaves[0].type_name, "UInt32");
+            assert_eq!(leaves[1].name, "hi");
+            assert_eq!(leaves[1].type_name, "UInt32");
+            assert_eq!(leaves[2].name, "wrap");
+            assert_eq!(leaves[2].type_name, "Bool");
+            // Leaf fields are non-union members.
+            for leaf in leaves {
+                assert_eq!(leaf.discriminant_value, 0xFFFF);
+            }
+        }
+        other => panic!("ranged should be Group, got {other:?}"),
+    }
+}

--- a/crates/hyprstream-rpc-derive/src/codegen/client.rs
+++ b/crates/hyprstream-rpc-derive/src/codegen/client.rs
@@ -442,14 +442,14 @@ fn generate_trait_method_impl(
                 let (client_secret, client_pubkey) = hyprstream_rpc::crypto::generate_ephemeral_keypair();
                 let client_pubkey_bytes: [u8; 32] = client_pubkey.to_bytes();
                 let info = Self::#method_name(self #(, #args)*, client_pubkey_bytes).await?;
-                if info.server_pubkey == [0u8; 32] {
+                if info.dh_public == [0u8; 32] {
                     anyhow::bail!("Server did not provide DH public key for streaming");
                 }
                 if info.moq_uds_path.is_empty() {
                     anyhow::bail!("Server did not provide moq transport path — moq transport not initialized");
                 }
                 let (mac_key, topic) = hyprstream_rpc::derive_client_stream_keys(
-                    &client_secret, &client_pubkey_bytes, &info.server_pubkey,
+                    &client_secret, &client_pubkey_bytes, &info.dh_public,
                 )?;
                 Ok(hyprstream_rpc::moq_stream::MoqStreamHandle::new(
                     info.moq_uds_path, info.moq_broadcast_path, mac_key, topic,

--- a/crates/hyprstream-rpc-derive/src/codegen/data.rs
+++ b/crates/hyprstream-rpc-derive/src/codegen/data.rs
@@ -49,6 +49,13 @@ pub fn generate_data_structs(
         collect_list_struct_types(resolved.raw)
     };
     for type_name in &list_struct_types {
+        // Synthetic capnp group nodes are named `Parent.armName` (e.g.
+        // `Ordering.unordered`). They are not standalone Rust types — their leaf
+        // fields are folded into the parent union's enum variant — and the dotted
+        // name is not a valid Rust identifier, so skip them here.
+        if type_name.contains('.') {
+            continue;
+        }
         if let Some(s) = resolved.find_struct(type_name) {
             // Skip Option* wrapper structs — they become Option<T> fields, not standalone types
             if s.option_inner_type().is_some() {
@@ -92,6 +99,17 @@ pub fn generate_data_structs(
                 service_name,
                 types_crate,
             );
+
+            // Pure tagged-union structs (a capnp `union { ... }` with no sibling
+            // non-union fields) become native Rust enums — one variant per arm —
+            // instead of an (empty) struct. Option<T> wrappers are handled above.
+            if s.is_pure_union() && s.option_inner_type().is_none() {
+                tokens.extend(generate_union_enum(type_name, s, resolved));
+                tokens.extend(generate_union_to_capnp_impl(type_name, s, resolved, &capnp_mod, service_name, types_crate));
+                tokens.extend(generate_union_from_capnp_impl(type_name, s, resolved, &capnp_mod, service_name, types_crate));
+                continue;
+            }
+
             tokens.extend(generate_data_struct(type_name, s, resolved));
             tokens.extend(generate_to_capnp_impl(type_name, s, resolved, &capnp_mod, service_name, types_crate));
             tokens.extend(generate_from_capnp_impl(type_name, s, resolved, &capnp_mod, service_name, types_crate));
@@ -184,10 +202,319 @@ fn generate_data_struct(
 
     quote! {
         #[doc = #doc]
-        #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+        #[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
         #[serde(rename_all = "camelCase")]
         pub struct #data_name {
             #(#fields,)*
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tagged-union (pure-union struct) → Rust enum generation
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Owned Rust type tokens for a single-type union-arm payload.
+fn arm_payload_type_tokens(type_name: &str, resolved: &ResolvedSchema) -> TokenStream {
+    rust_type_tokens(&resolved.resolve_type(type_name).rust_owned)
+}
+
+/// Generate a Rust `enum` for a pure-union capnp struct.
+///
+/// Each arm maps to a variant: Void → unit, single-type → tuple, group → struct.
+/// The discriminant-0 arm carries `#[default]`.
+fn generate_union_enum(
+    type_name: &str,
+    s: &StructDef,
+    resolved: &ResolvedSchema,
+) -> TokenStream {
+    let enum_name = format_ident!("{}", type_name);
+    let doc = format!("Generated from Cap'n Proto union {type_name}");
+
+    // The discriminant-0 arm is the capnp zero-fill default. If it's a Void arm
+    // we can use `#[derive(Default)]` + `#[default]` (requires a unit variant);
+    // otherwise we drop `Default` from the derive and emit a manual `impl Default`
+    // that builds the @0 variant with default-valued payload.
+    let default_arm = s.union_arms.iter().find(|a| a.discriminant_value == 0);
+    let default_is_unit = matches!(default_arm.map(|a| &a.payload), Some(ArmPayload::Void));
+
+    let variants: Vec<TokenStream> = s
+        .union_arms
+        .iter()
+        .map(|arm| {
+            let variant_ident = resolved.name(&arm.name).pascal_ident.clone();
+            let default_attr = if arm.discriminant_value == 0 && default_is_unit {
+                quote! { #[default] }
+            } else {
+                TokenStream::new()
+            };
+            match &arm.payload {
+                ArmPayload::Void => quote! { #default_attr #variant_ident },
+                ArmPayload::Type(t) => {
+                    let ty = arm_payload_type_tokens(t, resolved);
+                    quote! { #default_attr #variant_ident(#ty) }
+                }
+                ArmPayload::Group(leaves) => {
+                    let fields: Vec<TokenStream> = leaves
+                        .iter()
+                        .map(|leaf| {
+                            let leaf_name = resolved.name(&leaf.name).snake_ident.clone();
+                            let leaf_ty = arm_payload_type_tokens(&leaf.type_name, resolved);
+                            quote! { #leaf_name: #leaf_ty }
+                        })
+                        .collect();
+                    quote! { #default_attr #variant_ident { #(#fields,)* } }
+                }
+            }
+        })
+        .collect();
+
+    let (derive_default, manual_default) = if default_is_unit {
+        (quote! { Default, }, TokenStream::new())
+    } else {
+        // Manual Default for a data-carrying @0 arm.
+        let manual = default_arm.map(|arm| {
+            let variant_ident = resolved.name(&arm.name).pascal_ident.clone();
+            let ctor = match &arm.payload {
+                ArmPayload::Void => quote! { Self::#variant_ident },
+                ArmPayload::Type(_) => quote! { Self::#variant_ident(Default::default()) },
+                ArmPayload::Group(leaves) => {
+                    let fields: Vec<TokenStream> = leaves.iter().map(|leaf| {
+                        let leaf_name = resolved.name(&leaf.name).snake_ident.clone();
+                        quote! { #leaf_name: Default::default() }
+                    }).collect();
+                    quote! { Self::#variant_ident { #(#fields,)* } }
+                }
+            };
+            quote! {
+                impl Default for #enum_name {
+                    fn default() -> Self { #ctor }
+                }
+            }
+        }).unwrap_or_default();
+        (TokenStream::new(), manual)
+    };
+
+    quote! {
+        #[doc = #doc]
+        #[derive(Debug, Clone, #derive_default PartialEq, serde::Serialize, serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        pub enum #enum_name {
+            #(#variants,)*
+        }
+        #manual_default
+    }
+}
+
+/// Generate the value-setter for a scalar/Text/Data/enum/struct union-arm payload.
+///
+/// `value` is a binding (e.g. `v`) holding `&T` for the arm's owned Rust type.
+/// `setter`/`init` are the capnp builder method idents for this arm.
+fn union_arm_value_setter(
+    type_name: &str,
+    value: &TokenStream,
+    setter: &proc_macro2::Ident,
+    init: &proc_macro2::Ident,
+    resolved: &ResolvedSchema,
+    capnp_mod: &TokenStream,
+    service_name: &str,
+    types_crate: Option<&syn::Path>,
+) -> TokenStream {
+    let ct = resolved.resolve_type(type_name).capnp_type.clone();
+    match ct {
+        CapnpType::Bool | CapnpType::UInt8 | CapnpType::UInt16 | CapnpType::UInt32 | CapnpType::UInt64
+        | CapnpType::Int8 | CapnpType::Int16 | CapnpType::Int32 | CapnpType::Int64
+        | CapnpType::Float32 | CapnpType::Float64 => {
+            quote! { builder.#setter(*#value); }
+        }
+        CapnpType::Text => quote! { builder.#setter(#value.as_str()); },
+        CapnpType::Data => quote! { builder.#setter(#value.as_slice()); },
+        CapnpType::Enum(ref name) => {
+            if let Some(e) = resolved.find_enum(name) {
+                let field_capnp_mod = resolve_capnp_mod(
+                    lookup_origin_file(name, resolved),
+                    service_name,
+                    types_crate,
+                );
+                let enum_rust = format_ident!("{}", name);
+                let type_ident = format_ident!("{}", name);
+                let arms: Vec<TokenStream> = e.variants.iter().map(|(vname, _)| {
+                    let vp = resolved.name(vname).pascal_ident.clone();
+                    quote! { #enum_rust::#vp => #field_capnp_mod::#type_ident::#vp }
+                }).collect();
+                quote! { builder.#setter(match #value { #(#arms,)* }); }
+            } else {
+                TokenStream::new()
+            }
+        }
+        CapnpType::Struct(_) => {
+            quote! {
+                let mut __arm = builder.reborrow().#init();
+                hyprstream_rpc::capnp::ToCapnp::write_to(#value, &mut __arm);
+            }
+        }
+        _ => {
+            let _ = capnp_mod;
+            TokenStream::new()
+        }
+    }
+}
+
+/// Generate `ToCapnp` for a pure-union enum.
+fn generate_union_to_capnp_impl(
+    type_name: &str,
+    s: &StructDef,
+    resolved: &ResolvedSchema,
+    capnp_mod: &TokenStream,
+    service_name: &str,
+    types_crate: Option<&syn::Path>,
+) -> TokenStream {
+    let enum_name = format_ident!("{}", type_name);
+    let capnp_struct = format_ident!("{}", to_capnp_module_name(type_name));
+
+    let arms: Vec<TokenStream> = s.union_arms.iter().map(|arm| {
+        let variant = resolved.name(&arm.name).pascal_ident.clone();
+        let arm_snake = &resolved.name(&arm.name).snake;
+        let setter = format_ident!("set_{}", arm_snake);
+        let init = format_ident!("init_{}", arm_snake);
+        match &arm.payload {
+            ArmPayload::Void => {
+                quote! { Self::#variant => builder.#setter(()), }
+            }
+            ArmPayload::Type(t) => {
+                let value = quote! { v };
+                let set = union_arm_value_setter(t, &value, &setter, &init, resolved, capnp_mod, service_name, types_crate);
+                quote! { Self::#variant(v) => { #set } }
+            }
+            ArmPayload::Group(leaves) => {
+                let leaf_binds: Vec<TokenStream> = leaves.iter().map(|leaf| {
+                    let leaf_name = resolved.name(&leaf.name).snake_ident.clone();
+                    quote! { #leaf_name }
+                }).collect();
+                let leaf_sets: Vec<TokenStream> = leaves.iter().map(|leaf| {
+                    let leaf_snake = &resolved.name(&leaf.name).snake;
+                    let leaf_name = resolved.name(&leaf.name).snake_ident.clone();
+                    let leaf_setter = format_ident!("set_{}", leaf_snake);
+                    let ct = resolved.resolve_type(&leaf.type_name).capnp_type.clone();
+                    match ct {
+                        CapnpType::Text => quote! { __g.#leaf_setter(#leaf_name.as_str()); },
+                        CapnpType::Data => quote! { __g.#leaf_setter(#leaf_name.as_slice()); },
+                        CapnpType::Struct(_) => quote! {
+                            hyprstream_rpc::capnp::ToCapnp::write_to(#leaf_name, &mut __g.reborrow().#leaf_setter());
+                        },
+                        _ => quote! { __g.#leaf_setter(*#leaf_name); },
+                    }
+                }).collect();
+                quote! {
+                    Self::#variant { #(#leaf_binds,)* } => {
+                        let mut __g = builder.reborrow().#init();
+                        #(#leaf_sets)*
+                    }
+                }
+            }
+        }
+    }).collect();
+
+    quote! {
+        impl hyprstream_rpc::capnp::ToCapnp for #enum_name {
+            type Builder<'a> = #capnp_mod::#capnp_struct::Builder<'a>;
+
+            #[allow(unused_variables, unused_mut)]
+            fn write_to(&self, builder: &mut Self::Builder<'_>) {
+                match self {
+                    #(#arms)*
+                }
+            }
+        }
+    }
+}
+
+/// Generate `FromCapnp` for a pure-union enum.
+fn generate_union_from_capnp_impl(
+    type_name: &str,
+    s: &StructDef,
+    resolved: &ResolvedSchema,
+    capnp_mod: &TokenStream,
+    service_name: &str,
+    types_crate: Option<&syn::Path>,
+) -> TokenStream {
+    let enum_name = format_ident!("{}", type_name);
+    let capnp_struct = format_ident!("{}", to_capnp_module_name(type_name));
+    let union_mod = format_ident!("{}", to_capnp_module_name(type_name));
+
+    let arms: Vec<TokenStream> = s.union_arms.iter().map(|arm| {
+        let variant = resolved.name(&arm.name).pascal_ident.clone();
+        match &arm.payload {
+            ArmPayload::Void => {
+                quote! { #capnp_mod::#union_mod::Which::#variant(()) => Self::#variant, }
+            }
+            ArmPayload::Type(t) => {
+                let ct = resolved.resolve_type(t).capnp_type.clone();
+                match ct {
+                    // Scalars bind the value directly; no Result.
+                    CapnpType::Bool | CapnpType::UInt8 | CapnpType::UInt16 | CapnpType::UInt32 | CapnpType::UInt64
+                    | CapnpType::Int8 | CapnpType::Int16 | CapnpType::Int32 | CapnpType::Int64
+                    | CapnpType::Float32 | CapnpType::Float64 => {
+                        quote! { #capnp_mod::#union_mod::Which::#variant(v) => Self::#variant(v), }
+                    }
+                    // Text / Data / Struct bind a Result<Reader> — unwrap with `?`.
+                    CapnpType::Text => {
+                        quote! { #capnp_mod::#union_mod::Which::#variant(v) => Self::#variant(v?.to_str()?.to_string()), }
+                    }
+                    CapnpType::Data => {
+                        quote! { #capnp_mod::#union_mod::Which::#variant(v) => Self::#variant(v?.to_vec()), }
+                    }
+                    CapnpType::Enum(ref name) => {
+                        if let Some(e) = resolved.find_enum(name) {
+                            let field_capnp_mod = resolve_capnp_mod(
+                                lookup_origin_file(name, resolved),
+                                service_name,
+                                types_crate,
+                            );
+                            let enum_rust = format_ident!("{}", name);
+                            let type_ident = format_ident!("{}", name);
+                            let match_arms: Vec<TokenStream> = e.variants.iter().map(|(vname, _)| {
+                                let vp = resolved.name(vname).pascal_ident.clone();
+                                quote! { #field_capnp_mod::#type_ident::#vp => #enum_rust::#vp }
+                            }).collect();
+                            quote! { #capnp_mod::#union_mod::Which::#variant(v) => Self::#variant(match v? { #(#match_arms,)* }), }
+                        } else {
+                            quote! { #capnp_mod::#union_mod::Which::#variant(_) => Self::#variant(Default::default()), }
+                        }
+                    }
+                    CapnpType::Struct(_) => {
+                        quote! { #capnp_mod::#union_mod::Which::#variant(r) => Self::#variant(hyprstream_rpc::capnp::FromCapnp::read_from(r?)?), }
+                    }
+                    _ => quote! { #capnp_mod::#union_mod::Which::#variant(_) => Self::#variant(Default::default()), },
+                }
+            }
+            ArmPayload::Group(leaves) => {
+                let leaf_reads: Vec<TokenStream> = leaves.iter().map(|leaf| {
+                    let leaf_name = resolved.name(&leaf.name).snake_ident.clone();
+                    let leaf_getter = format_ident!("get_{}", resolved.name(&leaf.name).snake);
+                    let ct = resolved.resolve_type(&leaf.type_name).capnp_type.clone();
+                    match ct {
+                        CapnpType::Text => quote! { #leaf_name: g.#leaf_getter()?.to_str()?.to_string() },
+                        CapnpType::Data => quote! { #leaf_name: g.#leaf_getter()?.to_vec() },
+                        CapnpType::Struct(_) => quote! { #leaf_name: hyprstream_rpc::capnp::FromCapnp::read_from(g.#leaf_getter()?)? },
+                        _ => quote! { #leaf_name: g.#leaf_getter() },
+                    }
+                }).collect();
+                quote! { #capnp_mod::#union_mod::Which::#variant(g) => Self::#variant { #(#leaf_reads,)* }, }
+            }
+        }
+    }).collect();
+
+    quote! {
+        impl hyprstream_rpc::capnp::FromCapnp for #enum_name {
+            type Reader<'a> = #capnp_mod::#capnp_struct::Reader<'a>;
+
+            #[allow(unused_variables)]
+            fn read_from(reader: Self::Reader<'_>) -> anyhow::Result<Self> {
+                Ok(match reader.which()? {
+                    #(#arms)*
+                })
+            }
         }
     }
 }
@@ -472,10 +799,14 @@ fn generate_data_field_reader(
                     if n <= 32 {
                         quote! { #rust_name: {
                             let v = reader.#getter_name()?;
-                            if v.is_empty() { None } else {
+                            if v.is_empty() {
+                                None
+                            } else if v.len() == #n_usize {
                                 let mut arr = [0u8; #n_usize];
                                 arr.copy_from_slice(&v[..#n_usize]);
                                 Some(arr)
+                            } else {
+                                anyhow::bail!("optional fixed-size field: expected {} bytes, got {}", #n_usize, v.len());
                             }
                         }, }
                     } else {

--- a/crates/hyprstream-rpc-derive/src/codegen/dispatch.rs
+++ b/crates/hyprstream-rpc-derive/src/codegen/dispatch.rs
@@ -340,7 +340,7 @@ pub fn generate_portable_dispatch(
             /// Normal response — serialized JSON string.
             Response(String),
             /// Streaming response — JSON string of the parsed StreamInfo.
-            /// The caller should parse this to get endpoint, serverPubkey, streamId,
+            /// The caller should parse this to get endpoint, dhPublic, streamId,
             /// then set up the SUB subscription.
             Stream(String),
         }

--- a/crates/hyprstream-rpc-derive/src/resolve.rs
+++ b/crates/hyprstream-rpc-derive/src/resolve.rs
@@ -96,6 +96,23 @@ impl<'a> ResolvedSchema<'a> {
                 name_strings.insert(f.name.clone());
                 type_strings.insert(f.type_name.clone());
             }
+            // Walk union arms: arm names become Rust enum variant idents, and arm /
+            // group-leaf type names need classification so codegen can resolve them.
+            for arm in &s.union_arms {
+                name_strings.insert(arm.name.clone());
+                match &arm.payload {
+                    ArmPayload::Void => {}
+                    ArmPayload::Type(name) => {
+                        type_strings.insert(name.clone());
+                    }
+                    ArmPayload::Group(leaves) => {
+                        for leaf in leaves {
+                            name_strings.insert(leaf.name.clone());
+                            type_strings.insert(leaf.type_name.clone());
+                        }
+                    }
+                }
+            }
         }
 
         // Walk enums

--- a/crates/hyprstream-rpc-derive/src/schema/types.rs
+++ b/crates/hyprstream-rpc-derive/src/schema/types.rs
@@ -41,6 +41,20 @@ pub fn collect_list_struct_types(schema: &ParsedSchema) -> Vec<String> {
         for f in s.non_union_fields() {
             add_type(&f.type_name, &mut types);
         }
+        // Union-arm payload types are referenced by the generated enum variants
+        // (e.g. `WorktreeResult(WorktreeResponse)`), so they must be generated too.
+        // The flat `non_union_fields` walk above does not cover them.
+        for arm in &s.union_arms {
+            match &arm.payload {
+                ArmPayload::Void => {}
+                ArmPayload::Type(name) => add_type(name, &mut types),
+                ArmPayload::Group(leaves) => {
+                    for leaf in leaves {
+                        add_type(&leaf.type_name, &mut types);
+                    }
+                }
+            }
+        }
     }
     for v in &schema.request_variants {
         add_type(&v.type_name, &mut types);

--- a/crates/hyprstream-rpc-derive/src/util.rs
+++ b/crates/hyprstream-rpc-derive/src/util.rs
@@ -229,6 +229,7 @@ mod tests {
             pointer_words: 0,
             discriminant_count: 0,
             discriminant_offset: 0,
+            union_arms: vec![],
         }]
     }
 

--- a/crates/hyprstream-rpc/src/lib.rs
+++ b/crates/hyprstream-rpc/src/lib.rs
@@ -97,6 +97,22 @@ pub mod common_types {
     hyprstream_rpc_derive::generate_rpc_service!("common");
 }
 
+/// Code-generated streaming data types (#273): `StreamInfo`, `StreamOpt`, and the
+/// five QoS axis unions (`Ordering`/`Delivery`/`Completion`/`Retention`/
+/// `OverflowPolicy`). Re-exported through `stream_info` (the canonical hub) so
+/// service codegen and call sites keep resolving `hyprstream_rpc::stream_info::*`.
+///
+/// NOTE: this module also generates the wire types (`StreamBlock`, `StreamPayload`,
+/// `StreamControl`, etc.). Those are NOT re-exported — `streaming.rs` remains the
+/// authoritative hand-written implementation for the wire path; the generated
+/// duplicates live here unused (`#![allow(dead_code)]`).
+pub mod streaming_types {
+    #![allow(dead_code, unused_imports, unused_variables)]
+    #![allow(clippy::all)]
+    extern crate self as hyprstream_rpc;
+    hyprstream_rpc_derive::generate_rpc_service!("streaming");
+}
+
 pub mod capnp;
 pub mod crypto;
 pub mod envelope;

--- a/crates/hyprstream-rpc/src/stream_consumer.rs
+++ b/crates/hyprstream-rpc/src/stream_consumer.rs
@@ -296,9 +296,16 @@ impl<T: Transport> StreamHandleImpl<T> {
         client_secret: &[u8; 32],
         client_pubkey: &[u8; 32],
     ) -> Result<Self> {
-        // Pure crypto — same code, both targets
-        let shared_secret = dh_compute_raw(client_secret, &stream_info.server_pubkey)?;
-        let keys = derive_stream_keys(&shared_secret, client_pubkey, &stream_info.server_pubkey)?;
+        // Pure crypto — same code, both targets.
+        // `dh_public` is the server's ephemeral Ristretto255 DH public key (one
+        // input to the ECDH that derives the topic + MAC keys). Trust in this
+        // field comes from the signed RPC `ResponseEnvelope` wrapping StreamInfo,
+        // not from the field itself. NOTE: that response signature is currently
+        // classical Ed25519 only — unlike the request-side `SignedEnvelope`, the
+        // `ResponseEnvelope` does not yet carry a COSE/ML-DSA-65 hybrid layer, so
+        // StreamInfo authentication is not PQ-ready. See `ResponseEnvelope`.
+        let shared_secret = dh_compute_raw(client_secret, &stream_info.dh_public)?;
+        let keys = derive_stream_keys(&shared_secret, client_pubkey, &stream_info.dh_public)?;
 
         // Transport-abstracted — ZMQ or WebTransport
         let subscriber = transport.subscribe(keys.topic.as_bytes()).await?;

--- a/crates/hyprstream-rpc/src/stream_info.rs
+++ b/crates/hyprstream-rpc/src/stream_info.rs
@@ -5,101 +5,27 @@
 //!
 //! Service codegen modules emit `pub type StreamInfo = hyprstream_rpc::stream_info::StreamInfo;`
 //! (and similar aliases for the StreamOpt axis types) rather than generating duplicates.
+//!
+//! #273: `StreamInfo`, `StreamOpt`, and the five QoS axis unions are now fully
+//! code-generated from `streaming.capnp` into [`crate::streaming_types`] (the
+//! Cap'n Proto derive macro supports tagged-unions + data-carrying `group` arms).
+//! This module re-exports them as the canonical hub and keeps the hand-authored
+//! `Job`/`Log`/`Pipe` presets, which encode specific `StreamOpt` combinations.
 
 // ─── StreamOpt axis types ──────────────────────────────────────────────────────
-
-/// Ordered delivery — gaps are fatal (DTLS anti-replay, RFC 9147 §4.2.3).
-/// Unordered delivery with an anti-replay window (SRTP RFC 3711 §3.3).
-///
-/// `@0 = ordered` is the fail-closed default: capnp zero-fills an absent field.
-#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
-#[serde(tag = "type", rename_all = "camelCase")]
-pub enum Ordering {
-    #[default]
-    Ordered,
-    Unordered {
-        /// Reject block with seq ≤ (highest-seen − antiReplayWindow).
-        anti_replay_window: u32,
-    },
-}
-
-/// Delivery guarantee aligned with MQTT QoS 0/1 (OASIS MQTT 5.0 §4.3).
-/// exactlyOnce (QoS 2) is intentionally out of scope.
-///
-/// `@0 = atMostOnce` is the fail-closed default.
-#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
-#[serde(tag = "type", rename_all = "camelCase")]
-pub enum Delivery {
-    #[default]
-    AtMostOnce,
-    AtLeastOnce {
-        /// Number of recent sequence numbers remembered for client-side dedup.
-        dedup_window: u32,
-        /// Resume delivery from last-acked seq after reconnect.
-        resumable: bool,
-    },
-}
-
-/// Stream termination policy. `endOfStream` requires a `complete`/`error`
-/// StreamPayload before EOF; absence is a truncation and MUST be rejected.
-/// Analogous to gRPC END_STREAM / HTTP/2 DATA+END_STREAM / WebTransport FIN.
-///
-/// `@0 = endOfStream` is the fail-closed default.
-#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub enum Completion {
-    #[default]
-    EndOfStream,
-    None,
-}
-
-/// Relay-side retention / late-join buffer policy.
-/// `live` is the smallest attack surface (no buffering beyond the live window).
-/// NOTE: `live` is declared by the qos but enforced by the client (via epoch
-/// binding), not the relay (which is blind to MAC keys).
-///
-/// `@0 = live` is the fail-closed default.
-#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
-#[serde(tag = "type", rename_all = "camelCase")]
-pub enum Retention {
-    #[default]
-    Live,
-    /// Retain N delivery blocks (~N MoQ Transport Groups).
-    Blocks(u32),
-    /// Retain for N wall-clock seconds.
-    Seconds(u32),
-}
-
-/// Application-layer publish-path overflow policy.
-/// `block` = lossless EAGAIN-style backpressure on the publisher.
-/// NOTE: distinct from QUIC flow control (RFC 9000 §4) which operates at the
-/// transport layer independently.
-///
-/// `@0 = block` is the fail-closed (lossless) default.
-#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
-#[serde(tag = "type", rename_all = "camelCase")]
-pub enum OverflowPolicy {
-    #[default]
-    Block,
-    DropOldest {
-        high_water_mark: u32,
-    },
-}
-
-/// Full per-stream QoS options. Carried in the signed StreamInfo handshake
-/// response so the contract is Ed25519-authenticated and wire-visible.
-///
-/// All axes default to their fail-closed (`@0`) variants per the schema
-/// discipline — safe under capnp zero-fill of absent/unknown discriminants.
-#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct StreamOpt {
-    pub ordering: Ordering,
-    pub delivery: Delivery,
-    pub completion: Completion,
-    pub retention: Retention,
-    pub overflow_policy: OverflowPolicy,
-}
+//
+// Code-generated (#273). The generated enums/struct match the historic
+// hand-written shapes exactly, so the presets and all call sites compile unchanged:
+//   Ordering::{Ordered, Unordered{anti_replay_window}}
+//   Delivery::{AtMostOnce, AtLeastOnce{dedup_window, resumable}}
+//   Completion::{EndOfStream, None}
+//   Retention::{Live, Blocks(u32), Seconds(u32)}
+//   OverflowPolicy::{Block, DropOldest{high_water_mark}}
+//   StreamOpt { ordering, delivery, completion, retention, overflow_policy }
+//   StreamInfo { stream_id, endpoint, dh_public: [u8; 32], qos, moq_uds_path, moq_broadcast_path }
+pub use crate::streaming_types::{
+    Completion, Delivery, Ordering, OverflowPolicy, Retention, StreamInfo, StreamOpt,
+};
 
 /// Marker trait for typed stream QoS presets.
 ///
@@ -169,169 +95,4 @@ impl StreamOptPreset for Pipe {
             overflow_policy: OverflowPolicy::Block,
         }
     }
-}
-
-// ─── StreamInfo ───────────────────────────────────────────────────────────────
-
-/// Canonical stream info returned by streaming RPC methods.
-///
-/// Wrapped in a `SignedEnvelope` (Ed25519) so the `qos` field is authenticated.
-/// Service codegen modules alias this type from `hyprstream_rpc::stream_info`.
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct StreamInfo {
-    pub stream_id: String,
-    /// Reserved — was the ZMQ XPUB endpoint. Empty on moq-only paths.
-    pub endpoint: String,
-    pub server_pubkey: [u8; 32],
-    pub qos: StreamOpt,
-    /// UDS socket path for cross-process moq subscription.
-    pub moq_uds_path: String,
-    /// moq broadcast path within the origin (e.g. `"local/streams/{topic_hex}"`).
-    pub moq_broadcast_path: String,
-}
-
-impl crate::capnp::ToCapnp for StreamInfo {
-    type Builder<'a> = crate::streaming_capnp::stream_info::Builder<'a>;
-
-    fn write_to(&self, builder: &mut Self::Builder<'_>) {
-        builder.set_stream_id(&self.stream_id);
-        builder.set_endpoint(&self.endpoint);
-        builder.set_dh_public(&self.server_pubkey);
-        let mut qos_builder = builder.reborrow().init_qos();
-        write_stream_qos(&self.qos, &mut qos_builder);
-        builder.set_moq_uds_path(&self.moq_uds_path);
-        builder.set_moq_broadcast_path(&self.moq_broadcast_path);
-    }
-}
-
-impl crate::capnp::FromCapnp for StreamInfo {
-    type Reader<'a> = crate::streaming_capnp::stream_info::Reader<'a>;
-
-    fn read_from(reader: Self::Reader<'_>) -> anyhow::Result<Self> {
-        let pubkey_data = reader.get_dh_public()?;
-        let mut server_pubkey = [0u8; 32];
-        if pubkey_data.len() == 32 {
-            server_pubkey.copy_from_slice(pubkey_data);
-        }
-        let qos = if reader.has_qos() {
-            read_stream_qos(reader.get_qos()?)?
-        } else {
-            StreamOpt::default()
-        };
-        Ok(Self {
-            stream_id: reader.get_stream_id()?.to_str()?.to_owned(),
-            endpoint: reader.get_endpoint()?.to_str()?.to_owned(),
-            server_pubkey,
-            qos,
-            moq_uds_path: reader.get_moq_uds_path()?.to_str()?.to_owned(),
-            moq_broadcast_path: reader.get_moq_broadcast_path()?.to_str()?.to_owned(),
-        })
-    }
-}
-
-// ─── capnp serialization helpers (not pub — internal to this module) ─────────
-
-fn write_stream_qos(
-    qos: &StreamOpt,
-    builder: &mut crate::streaming_capnp::stream_opt::Builder<'_>,
-) {
-    // ordering
-    {
-        let mut b = builder.reborrow().init_ordering();
-        match &qos.ordering {
-            Ordering::Ordered => b.set_ordered(()),
-            Ordering::Unordered { anti_replay_window } => {
-                b.init_unordered().set_anti_replay_window(*anti_replay_window);
-            }
-        }
-    }
-    // delivery
-    {
-        let mut b = builder.reborrow().init_delivery();
-        match &qos.delivery {
-            Delivery::AtMostOnce => b.set_at_most_once(()),
-            Delivery::AtLeastOnce { dedup_window, resumable } => {
-                let mut g = b.init_at_least_once();
-                g.set_dedup_window(*dedup_window);
-                g.set_resumable(*resumable);
-            }
-        }
-    }
-    // completion
-    {
-        let mut b = builder.reborrow().init_completion();
-        match &qos.completion {
-            Completion::EndOfStream => b.set_end_of_stream(()),
-            Completion::None => b.set_none(()),
-        }
-    }
-    // retention
-    {
-        let mut b = builder.reborrow().init_retention();
-        match &qos.retention {
-            Retention::Live => b.set_live(()),
-            Retention::Blocks(n) => b.set_blocks(*n),
-            Retention::Seconds(n) => b.set_seconds(*n),
-        }
-    }
-    // overflow_policy
-    {
-        let mut b = builder.reborrow().init_overflow_policy();
-        match &qos.overflow_policy {
-            OverflowPolicy::Block => b.set_block(()),
-            OverflowPolicy::DropOldest { high_water_mark } => {
-                b.init_drop_oldest().set_high_water_mark(*high_water_mark);
-            }
-        }
-    }
-}
-
-fn read_stream_qos(
-    reader: crate::streaming_capnp::stream_opt::Reader<'_>,
-) -> anyhow::Result<StreamOpt> {
-    use crate::streaming_capnp::{
-        completion, delivery, ordering, overflow_policy, retention,
-    };
-
-    let ordering = match reader.get_ordering()?.which()? {
-        ordering::Which::Ordered(()) => Ordering::Ordered,
-        ordering::Which::Unordered(g) => Ordering::Unordered {
-            anti_replay_window: g.get_anti_replay_window(),
-        },
-    };
-
-    let delivery = match reader.get_delivery()?.which()? {
-        delivery::Which::AtMostOnce(()) => Delivery::AtMostOnce,
-        delivery::Which::AtLeastOnce(g) => Delivery::AtLeastOnce {
-            dedup_window: g.get_dedup_window(),
-            resumable: g.get_resumable(),
-        },
-    };
-
-    let completion = match reader.get_completion()?.which()? {
-        completion::Which::EndOfStream(()) => Completion::EndOfStream,
-        completion::Which::None(()) => Completion::None,
-    };
-
-    let retention = match reader.get_retention()?.which()? {
-        retention::Which::Live(()) => Retention::Live,
-        retention::Which::Blocks(n) => Retention::Blocks(n),
-        retention::Which::Seconds(n) => Retention::Seconds(n),
-    };
-
-    let overflow_policy = match reader.get_overflow_policy()?.which()? {
-        overflow_policy::Which::Block(()) => OverflowPolicy::Block,
-        overflow_policy::Which::DropOldest(g) => OverflowPolicy::DropOldest {
-            high_water_mark: g.get_high_water_mark(),
-        },
-    };
-
-    Ok(StreamOpt {
-        ordering,
-        delivery,
-        completion,
-        retention,
-        overflow_policy,
-    })
 }

--- a/crates/hyprstream-rpc/tests/stream_opt_codegen.rs
+++ b/crates/hyprstream-rpc/tests/stream_opt_codegen.rs
@@ -1,0 +1,120 @@
+//! Round-trip tests for the code-generated `StreamInfo`/`StreamOpt` codec (#273).
+//!
+//! The Cap'n Proto derive macro now generates the `ToCapnp`/`FromCapnp` impls for
+//! the tagged-union QoS axes and the `StreamInfo`/`StreamOpt` structs that were
+//! previously hand-written. These tests prove the generated codec is correct by
+//! serializing through a real Cap'n Proto message and reading it back.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use hyprstream_rpc::capnp::{FromCapnp, ToCapnp};
+use hyprstream_rpc::stream_info::{
+    Completion, Delivery, Job, Log, Ordering, OverflowPolicy, Pipe, Retention, StreamInfo,
+    StreamOpt, StreamOptPreset,
+};
+
+/// Serialize a `StreamInfo` through a Cap'n Proto message and read it back.
+fn roundtrip(info: &StreamInfo) -> StreamInfo {
+    let mut message = capnp::message::Builder::new_default();
+    {
+        let mut builder =
+            message.init_root::<hyprstream_rpc::streaming_capnp::stream_info::Builder>();
+        info.write_to(&mut builder);
+    }
+
+    let mut bytes = Vec::new();
+    capnp::serialize::write_message(&mut bytes, &message).expect("write_message");
+
+    let reader = capnp::serialize::read_message(
+        &mut std::io::Cursor::new(&bytes),
+        capnp::message::ReaderOptions::default(),
+    )
+    .expect("read_message");
+    let si_reader = reader
+        .get_root::<hyprstream_rpc::streaming_capnp::stream_info::Reader>()
+        .expect("get_root");
+    StreamInfo::read_from(si_reader).expect("read_from")
+}
+
+fn sample_info(qos: StreamOpt) -> StreamInfo {
+    StreamInfo {
+        stream_id: "stream-273".to_owned(),
+        endpoint: "".to_owned(),
+        // `dh_public` = server's ephemeral Ristretto255 DH public key.
+        dh_public: [7u8; 32],
+        qos,
+        moq_uds_path: "/tmp/moq.sock".to_owned(),
+        moq_broadcast_path: "local/streams/deadbeef".to_owned(),
+    }
+}
+
+fn assert_roundtrips(qos: StreamOpt) {
+    let info = sample_info(qos);
+    let back = roundtrip(&info);
+    assert_eq!(info.stream_id, back.stream_id);
+    assert_eq!(info.endpoint, back.endpoint);
+    assert_eq!(info.dh_public, back.dh_public);
+    assert_eq!(info.moq_uds_path, back.moq_uds_path);
+    assert_eq!(info.moq_broadcast_path, back.moq_broadcast_path);
+    assert_eq!(info.qos, back.qos);
+}
+
+#[test]
+fn default_qos_roundtrips() {
+    assert_roundtrips(StreamOpt::default());
+}
+
+#[test]
+fn presets_roundtrip() {
+    assert_roundtrips(Job::stream_opt());
+    assert_roundtrips(Log::stream_opt());
+    assert_roundtrips(Pipe::stream_opt());
+}
+
+#[test]
+fn non_default_arms_roundtrip() {
+    // Each axis exercised with a non-@0 arm, including all three group arms,
+    // both scalar Retention arms, and the Void Completion::None arm.
+    let qos = StreamOpt {
+        ordering: Ordering::Unordered { anti_replay_window: 7 },
+        delivery: Delivery::AtLeastOnce { dedup_window: 4096, resumable: true },
+        completion: Completion::None,
+        retention: Retention::Blocks(256),
+        overflow_policy: OverflowPolicy::DropOldest { high_water_mark: 1024 },
+    };
+    assert_roundtrips(qos);
+
+    // Retention::Seconds is the other scalar arm.
+    assert_roundtrips(StreamOpt {
+        retention: Retention::Seconds(300),
+        ..StreamOpt::default()
+    });
+}
+
+#[test]
+fn group_arm_field_values_preserved() {
+    // Explicitly assert the group-arm leaf values survive the round-trip
+    // (not just structural equality), since group arms are the new codegen path.
+    let info = sample_info(StreamOpt {
+        ordering: Ordering::Unordered { anti_replay_window: 42 },
+        delivery: Delivery::AtLeastOnce { dedup_window: 99, resumable: false },
+        overflow_policy: OverflowPolicy::DropOldest { high_water_mark: 8 },
+        ..StreamOpt::default()
+    });
+    let back = roundtrip(&info);
+
+    match back.qos.ordering {
+        Ordering::Unordered { anti_replay_window } => assert_eq!(anti_replay_window, 42),
+        other => panic!("expected Unordered, got {other:?}"),
+    }
+    match back.qos.delivery {
+        Delivery::AtLeastOnce { dedup_window, resumable } => {
+            assert_eq!(dedup_window, 99);
+            assert!(!resumable);
+        }
+        other => panic!("expected AtLeastOnce, got {other:?}"),
+    }
+    match back.qos.overflow_policy {
+        OverflowPolicy::DropOldest { high_water_mark } => assert_eq!(high_water_mark, 8),
+        other => panic!("expected DropOldest, got {other:?}"),
+    }
+}

--- a/crates/hyprstream-workers/src/runtime/service.rs
+++ b/crates/hyprstream-workers/src/runtime/service.rs
@@ -839,7 +839,7 @@ impl WorkerService {
         let stream_info = StreamInfo {
             stream_id,
             endpoint: String::new(),
-            server_pubkey: *stream_ctx.server_pubkey(),
+            dh_public: *stream_ctx.server_pubkey(),
             qos: stream_ctx.qos().clone(),
             moq_uds_path,
             moq_broadcast_path,

--- a/crates/hyprstream/src/services/inference.rs
+++ b/crates/hyprstream/src/services/inference.rs
@@ -1051,7 +1051,7 @@ impl InferenceService {
         let stream_info = crate::services::generated::inference_client::StreamInfo {
             stream_id,
             endpoint: String::new(),
-            server_pubkey,
+            dh_public: server_pubkey,
             qos: stream_ctx.qos().clone(),
             moq_uds_path,
             moq_broadcast_path,
@@ -1898,7 +1898,7 @@ impl InferenceHandler for InferenceService {
         let stream_info = crate::services::generated::inference_client::StreamInfo {
             stream_id,
             endpoint: String::new(),
-            server_pubkey,
+            dh_public: server_pubkey,
             qos: <hyprstream_rpc::stream_info::Job as hyprstream_rpc::stream_info::StreamOptPreset>::stream_opt(),
             moq_uds_path,
             moq_broadcast_path,
@@ -2112,7 +2112,7 @@ impl InferenceHandler for InferenceService {
         let stream_info = crate::services::generated::inference_client::StreamInfo {
             stream_id,
             endpoint: String::new(),
-            server_pubkey,
+            dh_public: server_pubkey,
             qos: stream_ctx.qos().clone(),
             moq_uds_path,
             moq_broadcast_path,

--- a/crates/hyprstream/src/services/mcp_service.rs
+++ b/crates/hyprstream/src/services/mcp_service.rs
@@ -651,14 +651,16 @@ fn parse_stream_info(
 ) -> anyhow::Result<(String, Vec<u8>, hyprstream_rpc::stream_info::StreamOpt, String, String)> {
     let stream_id = json["streamId"].as_str()
         .ok_or_else(|| anyhow::anyhow!("missing streamId in streaming response"))?.to_owned();
-    let server_pubkey: Vec<u8> = json["serverPubkey"].as_array()
-        .ok_or_else(|| anyhow::anyhow!("missing serverPubkey in streaming response"))?
+    // StreamInfo's `dh_public` field serializes as `dhPublic` under camelCase
+    // (was `serverPubkey` before #273 renamed the field to match the capnp schema).
+    let server_pubkey: Vec<u8> = json["dhPublic"].as_array()
+        .ok_or_else(|| anyhow::anyhow!("missing dhPublic in streaming response"))?
         .iter()
         .enumerate()
         .map(|(i, v)| {
             v.as_u64()
                 .and_then(|n| u8::try_from(n).ok())
-                .ok_or_else(|| anyhow::anyhow!("serverPubkey[{i}]: value out of u8 range"))
+                .ok_or_else(|| anyhow::anyhow!("dhPublic[{i}]: value out of u8 range"))
         })
         .collect::<anyhow::Result<Vec<u8>>>()?;
     let qos: hyprstream_rpc::stream_info::StreamOpt = if json["qos"].is_object() {

--- a/crates/hyprstream/src/services/metrics.rs
+++ b/crates/hyprstream/src/services/metrics.rs
@@ -327,7 +327,7 @@ impl MetricsHandler for MetricsService {
         let stream_info = StreamInfo {
             stream_id: stream_ctx.stream_id().to_owned(),
             endpoint: String::new(),
-            server_pubkey: *stream_ctx.server_pubkey(),
+            dh_public: *stream_ctx.server_pubkey(),
             moq_uds_path,
             moq_broadcast_path,
             ..Default::default()

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -759,7 +759,7 @@ impl RegistryService {
         let stream_info = StreamInfo {
             stream_id: stream_ctx.stream_id().to_owned(),
             endpoint: String::new(),
-            server_pubkey: *stream_ctx.server_pubkey(),
+            dh_public: *stream_ctx.server_pubkey(),
             moq_uds_path,
             moq_broadcast_path,
             ..Default::default()


### PR DESCRIPTION
Teach the Cap'n Proto derive macro to model general N-way tagged-unions and
data-carrying group arms, so StreamOpt's five QoS axis unions
(Ordering/Delivery/Completion/Retention/OverflowPolicy) generate as Rust enums
and StreamInfo's codec is fully generated — deleting the hand-written
ToCapnp/FromCapnp + write_stream_qos/read_stream_qos (~180 lines).

- hyprstream-rpc-build: add UnionArm/ArmPayload + StructDef.union_arms; cgr_reader
  descends a group field into its synthetic struct node via get_type_id (shared
  field_def_from_slot helper; guards missing-node / nested-group). Flat-field and
  TS-codegen paths unchanged; Pass-2 ref discovery feeds arm/group-leaf types.
- hyprstream-rpc-derive: resolve pre-caches arm names/types; codegen/data.rs emits a
  Rust enum per pure union (Void->unit, scalar/struct->tuple, group->struct variant)
  + generated ToCapnp/FromCapnp, gated on option_inner_type().is_none() so the
  none/some Option special-case keeps precedence. collect_list_struct_types now
  collects union-arm payload types.
- hyprstream-rpc: generated streaming types live in a new streaming_types module;
  stream_info re-exports StreamInfo/StreamOpt/the five axis enums and keeps the
  hand-authored StreamOptPreset + Job/Log/Pipe presets.

The generated StreamInfo DH field follows the schema name dhPublic @2 -> dh_public
(the deleted hand-written codec had manually remapped it to server_pubkey). Update
the call sites that read/construct it to dh_public: stream_consumer (2 DH reads),
the generated streaming client (codegen/client.rs), and the 6 StreamInfo
construction sites (hyprstream-workers runtime; hyprstream metrics/registry/
inference x3). StreamContext.server_pubkey() and the Ed25519 server_pubkey params
are a separate concern, untouched. Schema unchanged (dhPublic @2 retained).

Side effect: every pure-union struct across all schemas (previously generated as
empty structs) is now a proper enum with a working codec — a strict correctness
improvement beyond StreamOpt.

Tests: stream_opt_codegen (round-trip per preset + per non-default arm + group-arm
field values) and union_arms (cgr void/scalar/group descent). Workspace builds;
clippy --all-targets clean.

Issue #273. Part of epic #131.
