### PR TITLE
perf(rpc): restore zero-copy Cap'n Proto framing on the streaming + control planes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6323,7 +6323,7 @@ dependencies = [
 
 [[package]]
 name = "hyprstream"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,7 +180,11 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg"]
 # All three crates must track together — generated code from capnpc
 # targets specific internal APIs in capnp; mismatched majors break
 # RawStructSchema struct construction.
-capnp = "0.24"
+# `unaligned`: read capnp messages directly from network buffers (moq/quinn `Bytes`)
+# that can start at any byte offset — required for the zero-copy
+# `read_message_from_flat_slice` path on the streaming + RPC planes (otherwise capnp
+# errors with UnalignedSegment). Byte-wise word access; keeps the read zero-copy.
+capnp = { version = "0.24", features = ["unaligned"] }
 capnp-futures = "0.24"
 
 # Utilities

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,7 +183,17 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg"]
 # `unaligned`: read capnp messages directly from network buffers (moq/quinn `Bytes`)
 # that can start at any byte offset — required for the zero-copy
 # `read_message_from_flat_slice` path on the streaming + RPC planes (otherwise capnp
-# errors with UnalignedSegment). Byte-wise word access; keeps the read zero-copy.
+# errors with UnalignedSegment).
+#
+# SAFE in Rust — and NOT the same as C++'s `-DCAPNP_ALLOW_UNALIGNED`. The C++ flag only
+# disables the alignment *check* and leaves genuine UB (unaligned access is UB in C/C++;
+# compilers may emit SIMD / assume a pointer's low bits are zero), which is why capnp's
+# author recommends copying into an aligned buffer instead (StackOverflow Q 75006774).
+# Rust's `unaligned` feature instead changes the access *mechanism*: each word becomes
+# `Raw = [u8; N]` (alignment 1) read via `from_le_bytes(*raw)` (capnp `private/primitive.rs`)
+# — the canonical, fully-defined Rust idiom for unaligned reads, with no UB. On x86_64/ARM64
+# it lowers to a single hardware unaligned load (~free) and does NOT memcpy or sacrifice
+# zero-copy. See PR #330.
 capnp = { version = "0.24", features = ["unaligned"] }
 capnp-futures = "0.24"
 

--- a/crates/hyprstream-rpc/src/crypto/backend.rs
+++ b/crates/hyprstream-rpc/src/crypto/backend.rs
@@ -132,6 +132,44 @@ pub fn keyed_mac_truncated(key: &[u8; 32], data: &[u8]) -> [u8; 16] {
     output
 }
 
+/// Multi-part variant of [`keyed_mac_truncated`] — authenticates the
+/// concatenation of `parts` **without allocating a joined buffer**.
+///
+/// `keyed_mac_truncated_parts(k, &[a, b])` is byte-for-byte identical to
+/// `keyed_mac_truncated(k, &[a, b].concat())` (both Blake3's keyed hasher and
+/// HMAC are defined over the streamed input), so this is a zero-copy drop-in on
+/// the wire — used by the stream verifier to MAC `prev_mac ‖ block` over a
+/// borrowed payload slice instead of copying the block into a scratch `Vec`.
+#[cfg(not(feature = "fips"))]
+pub fn keyed_mac_truncated_parts(key: &[u8; 32], parts: &[&[u8]]) -> [u8; 16] {
+    let mut hasher = blake3::Hasher::new_keyed(key);
+    for p in parts {
+        hasher.update(p);
+    }
+    let full = hasher.finalize();
+    let mut output = [0u8; 16];
+    output.copy_from_slice(&full.as_bytes()[..16]);
+    output
+}
+
+#[cfg(feature = "fips")]
+pub fn keyed_mac_truncated_parts(key: &[u8; 32], parts: &[&[u8]]) -> [u8; 16] {
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+
+    let mut mac = match Hmac::<Sha256>::new_from_slice(key) {
+        Ok(m) => m,
+        Err(_) => unreachable!("HMAC-SHA256 accepts any key size"),
+    };
+    for p in parts {
+        mac.update(p);
+    }
+    let result = mac.finalize();
+    let mut output = [0u8; 16];
+    output.copy_from_slice(&result.into_bytes()[..16]);
+    output
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -139,6 +177,29 @@ pub fn keyed_mac_truncated(key: &[u8; 32], data: &[u8]) -> [u8; 16] {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_keyed_mac_truncated_parts_equals_concat() {
+        // The multi-part MAC must be byte-identical to MAC-of-concatenation, so
+        // the zero-copy stream verifier produces the same wire MAC as before.
+        let key = [0x5au8; 32];
+        let prev = [0x11u8; 16];
+        let block = b"a stream block payload of arbitrary length".as_slice();
+
+        let mut joined = Vec::new();
+        joined.extend_from_slice(&prev);
+        joined.extend_from_slice(block);
+
+        assert_eq!(
+            keyed_mac_truncated_parts(&key, &[&prev, block]),
+            keyed_mac_truncated(&key, &joined),
+        );
+        // Empty-parts and single-part degenerate cases.
+        assert_eq!(
+            keyed_mac_truncated_parts(&key, &[block]),
+            keyed_mac_truncated(&key, block),
+        );
+    }
 
     #[test]
     fn test_derive_key_deterministic() {

--- a/crates/hyprstream-rpc/src/crypto/mod.rs
+++ b/crates/hyprstream-rpc/src/crypto/mod.rs
@@ -64,7 +64,7 @@ impl CryptoPolicy {
     }
 }
 
-pub use backend::{derive_key, keyed_mac, keyed_mac_truncated};
+pub use backend::{derive_key, keyed_mac, keyed_mac_truncated, keyed_mac_truncated_parts};
 pub use hmac::StreamHmacState;
 pub use key_exchange::{
     derive_notification_keys, derive_stream_keys, DefaultKeyExchange, KeyExchange,

--- a/crates/hyprstream-rpc/src/moq_stream.rs
+++ b/crates/hyprstream-rpc/src/moq_stream.rs
@@ -977,9 +977,9 @@ pub fn verify_moq_frame(
         anyhow::bail!("moq frame too short: {} bytes", frame.len());
     }
     let split = frame.len() - 16;
-    let capnp = frame[..split].to_vec();
-    let mac = frame[split..].to_vec();
-    verifier.verify(&[topic.as_bytes().to_vec(), capnp, mac])
+    // Zero-copy: pass slices into the received frame (`Bytes` from moq-net) straight
+    // to the verifier — no per-frame `Vec` allocation of the (potentially large) payload.
+    verifier.verify_parts(topic.as_bytes(), &frame[..split], &frame[split..])
 }
 
 #[cfg(test)]

--- a/crates/hyprstream-rpc/src/rpc_client.rs
+++ b/crates/hyprstream-rpc/src/rpc_client.rs
@@ -520,8 +520,10 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
 
 /// Parse StreamInfo from Cap'n Proto response bytes.
 fn parse_stream_info(bytes: &[u8]) -> Result<crate::stream_info::StreamInfo> {
-    let reader = capnp::serialize::read_message(
-        &mut std::io::Cursor::new(bytes),
+    // Borrowing (zero-copy) reader: the capnp `Reader` references `bytes` directly.
+    let mut slice: &[u8] = bytes;
+    let reader = capnp::serialize::read_message_from_flat_slice(
+        &mut slice,
         capnp::message::ReaderOptions::default(),
     )?;
     // StreamInfo may be nested inside a service response variant.

--- a/crates/hyprstream-rpc/src/stream_consumer.rs
+++ b/crates/hyprstream-rpc/src/stream_consumer.rs
@@ -15,7 +15,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use anyhow::Result;
 use futures::StreamExt;
 
-use crate::crypto::{derive_stream_keys, keyed_mac_truncated};
+use crate::crypto::{derive_stream_keys, keyed_mac_truncated, keyed_mac_truncated_parts};
 use crate::stream_info::StreamInfo;
 use crate::streaming_capnp;
 use crate::transport_traits::{PublishSink, Transport};
@@ -140,11 +140,23 @@ impl StreamVerifier {
         if frames.len() != 3 {
             anyhow::bail!("Expected 3 frames, got {}", frames.len());
         }
+        self.verify_parts(&frames[0], &frames[1], &frames[2])
+    }
 
-        let received_topic = &frames[0];
-        let capnp_data = &frames[1];
-        let received_mac = &frames[2];
-
+    /// Zero-copy variant of [`verify`](Self::verify) over borrowed slices.
+    ///
+    /// `verify` is a thin wrapper over this. The moq path calls it directly with
+    /// slices into the received `Bytes` frame (`verify_moq_frame`), so a large
+    /// payload (e.g. a pipeline activation tensor) is never copied into owned
+    /// per-frame `Vec`s — combined with the multi-part MAC and
+    /// `read_message_from_flat_slice` below, the block stays a view into the
+    /// receive buffer end-to-end.
+    pub fn verify_parts(
+        &mut self,
+        received_topic: &[u8],
+        capnp_data: &[u8],
+        received_mac: &[u8],
+    ) -> Result<Vec<StreamPayload>> {
         if received_mac.len() != 16 {
             anyhow::bail!("Expected 16-byte MAC, got {}", received_mac.len());
         }
@@ -153,15 +165,15 @@ impl StreamVerifier {
             anyhow::bail!("Topic mismatch");
         }
 
-        // Compute expected MAC
-        let mut input = Vec::with_capacity(64 + capnp_data.len());
-        match &self.prev_mac {
-            None => input.extend_from_slice(self.topic.as_bytes()),
-            Some(prev) => input.extend_from_slice(prev),
-        }
-        input.extend_from_slice(capnp_data);
-
-        let expected_mac = keyed_mac_truncated(&self.key, &input);
+        // Compute the expected MAC over `prev_mac ‖ capnp_data` (or `topic ‖ capnp_data`
+        // for the first block) WITHOUT allocating a joined buffer. The multi-part MAC is
+        // byte-identical to MAC-of-concatenation, so the payload is never copied into a
+        // scratch `Vec` — this matters for large frames (e.g. pipeline activation tensors).
+        let prefix: &[u8] = match &self.prev_mac {
+            None => self.topic.as_bytes(),
+            Some(prev) => &prev[..],
+        };
+        let expected_mac = keyed_mac_truncated_parts(&self.key, &[prefix, capnp_data]);
 
         if !constant_time_eq(received_mac, &expected_mac) {
             anyhow::bail!("MAC verification failed");
@@ -172,9 +184,12 @@ impl StreamVerifier {
         new_prev.copy_from_slice(received_mac);
         self.prev_mac = Some(new_prev);
 
-        // Parse StreamBlock
-        let reader = capnp::serialize::read_message(
-            &mut std::io::Cursor::new(capnp_data),
+        // Parse StreamBlock with a borrowing (zero-copy) reader: the capnp `Reader`
+        // references `capnp_data` directly instead of copying the whole block into an
+        // owned message, so a large payload stays a view into the receive buffer.
+        let mut slice: &[u8] = capnp_data;
+        let reader = capnp::serialize::read_message_from_flat_slice(
+            &mut slice,
             capnp::message::ReaderOptions::default(),
         )?;
         let block = reader.get_root::<streaming_capnp::stream_block::Reader>()?;

--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -1068,4 +1068,36 @@ mod tests {
         assert_eq!(block.get_sequence_number(), 42);
         assert_eq!(block.get_epoch(), 7);
     }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn flat_slice_parses_unaligned_block() {
+        // The zero-copy verifier (`stream_consumer`) parses StreamBlocks via
+        // `read_message_from_flat_slice` over `Bytes` that come straight from the
+        // moq/quinn receive buffer — and those can start at ANY byte offset, not
+        // an 8-byte boundary. capnp's flat-slice reader requires 8-byte alignment
+        // unless the `unaligned` feature is on, so this guards that we keep it on.
+        let payloads = vec![StreamPayloadData::Data(b"hello".to_vec())];
+        let bytes = encode_stream_block(&[0u8; 16], 42, 7, &payloads).unwrap();
+        // Force a deliberately unaligned view: offset the message by 1 byte.
+        let mut padded = vec![0u8; 1];
+        padded.extend_from_slice(&bytes);
+        let unaligned = &padded[1..];
+        assert_ne!(
+            unaligned.as_ptr() as usize % 8,
+            0,
+            "test precondition: slice must be unaligned"
+        );
+        let mut slice: &[u8] = unaligned;
+        let reader = capnp::serialize::read_message_from_flat_slice(
+            &mut slice,
+            capnp::message::ReaderOptions::default(),
+        )
+        .expect("flat-slice reader must parse from an unaligned buffer");
+        let block = reader
+            .get_root::<crate::streaming_capnp::stream_block::Reader>()
+            .unwrap();
+        assert_eq!(block.get_sequence_number(), 42);
+        assert_eq!(block.get_epoch(), 7);
+    }
 }

--- a/crates/hyprstream-rpc/src/transport/rpc_session.rs
+++ b/crates/hyprstream-rpc/src/transport/rpc_session.rs
@@ -197,30 +197,43 @@ where
 /// Read an entire stream into [`Bytes`], capping the total at `cap` bytes.
 ///
 /// [`RecvStream::read_all`] is unbounded and a hostile peer could exhaust
-/// memory with it. This loops over [`RecvStream::read`] into a growing buffer,
-/// erroring out if the peer sends more than `cap` bytes before FIN.
+/// memory with it. This reads **directly into the output buffer** — no separate
+/// scratch buffer + `extend_from_slice` second copy; only the one unavoidable
+/// kernel→userspace copy that `RecvStream::read(&mut [u8])` forces (the trait,
+/// `web_transport_trait` 0.3.x, exposes no `Bytes`-yielding chunk read). Errors
+/// out if the peer sends more than `cap` bytes before FIN.
+///
+/// This is the **control plane** (`MAX_FRAME_BYTES` = 4 MiB). Bulk/tensor
+/// payloads ride the streaming plane, where moq-net already yields `Bytes`.
 pub async fn read_to_cap<R: RecvStream>(recv: &mut R, cap: usize) -> Result<Bytes> {
-    // Chunk size for each read. Bounded so a single read can't over-allocate.
+    // Allocation granularity for the output buffer.
     const CHUNK: usize = 64 * 1024;
-    let mut out: Vec<u8> = Vec::new();
-    let mut scratch = vec![0u8; CHUNK];
+    let mut buf: Vec<u8> = Vec::new();
     loop {
+        let filled = buf.len();
+        // Expose a writable window at the tail and read straight into it.
+        buf.resize(filled + CHUNK, 0);
         match recv
-            .read(&mut scratch)
+            .read(&mut buf[filled..])
             .await
             .map_err(|e| anyhow!("recv read: {e}"))?
         {
-            None => break, // FIN
-            Some(0) => continue,
+            None => {
+                buf.truncate(filled); // FIN
+                break;
+            }
+            Some(0) => {
+                buf.truncate(filled);
+            }
             Some(n) => {
-                if out.len() + n > cap {
+                buf.truncate(filled + n);
+                if buf.len() > cap {
                     bail!("frame exceeds {cap} byte cap");
                 }
-                out.extend_from_slice(&scratch[..n]);
             }
         }
     }
-    Ok(Bytes::from(out))
+    Ok(Bytes::from(buf))
 }
 
 // ============================================================================

--- a/crates/hyprstream-rpc/src/transport/rpc_session.rs
+++ b/crates/hyprstream-rpc/src/transport/rpc_session.rs
@@ -196,44 +196,57 @@ where
 
 /// Read an entire stream into [`Bytes`], capping the total at `cap` bytes.
 ///
-/// [`RecvStream::read_all`] is unbounded and a hostile peer could exhaust
-/// memory with it. This reads **directly into the output buffer** — no separate
-/// scratch buffer + `extend_from_slice` second copy; only the one unavoidable
-/// kernel→userspace copy that `RecvStream::read(&mut [u8])` forces (the trait,
-/// `web_transport_trait` 0.3.x, exposes no `Bytes`-yielding chunk read). Errors
-/// out if the peer sends more than `cap` bytes before FIN.
+/// Uses [`RecvStream::read_chunk`] (a defaulted trait method): quinn and iroh
+/// override it to return `Bytes` referencing the QUIC receive buffer, so a
+/// control message that arrives as a **single chunk** (the common case) is
+/// returned **fully zero-copy** — no allocation, no copy. The UDS impl inherits
+/// the trait's one-copy default (local socket, fine). Multi-chunk frames pay at
+/// most one concatenation. Errors out if the peer sends more than `cap` bytes
+/// before FIN (`RecvStream::read_all` is unbounded — a hostile peer could
+/// exhaust memory with it).
 ///
 /// This is the **control plane** (`MAX_FRAME_BYTES` = 4 MiB). Bulk/tensor
 /// payloads ride the streaming plane, where moq-net already yields `Bytes`.
 pub async fn read_to_cap<R: RecvStream>(recv: &mut R, cap: usize) -> Result<Bytes> {
-    // Allocation granularity for the output buffer.
-    const CHUNK: usize = 64 * 1024;
-    let mut buf: Vec<u8> = Vec::new();
+    let mut first: Option<Bytes> = None;
+    let mut acc: Option<bytes::BytesMut> = None;
+    let mut total: usize = 0;
     loop {
-        let filled = buf.len();
-        // Expose a writable window at the tail and read straight into it.
-        buf.resize(filled + CHUNK, 0);
+        // +1 so a chunk that would push us over `cap` is still surfaced, then rejected.
+        let max = cap.saturating_sub(total).saturating_add(1);
         match recv
-            .read(&mut buf[filled..])
+            .read_chunk(max)
             .await
-            .map_err(|e| anyhow!("recv read: {e}"))?
+            .map_err(|e| anyhow!("recv read_chunk: {e}"))?
         {
-            None => {
-                buf.truncate(filled); // FIN
-                break;
-            }
-            Some(0) => {
-                buf.truncate(filled);
-            }
-            Some(n) => {
-                buf.truncate(filled + n);
-                if buf.len() > cap {
+            None => break, // FIN
+            Some(chunk) if chunk.is_empty() => continue,
+            Some(chunk) => {
+                total += chunk.len();
+                if total > cap {
                     bail!("frame exceeds {cap} byte cap");
+                }
+                match (first.take(), acc.as_mut()) {
+                    // Keep the first chunk as-is (zero-copy if it's the only one).
+                    (None, None) => first = Some(chunk),
+                    // Second chunk: start accumulating from the held first.
+                    (Some(f), None) => {
+                        let mut b = bytes::BytesMut::with_capacity(total);
+                        b.extend_from_slice(&f);
+                        b.extend_from_slice(&chunk);
+                        acc = Some(b);
+                    }
+                    (None, Some(b)) => b.extend_from_slice(&chunk),
+                    (Some(_), Some(_)) => unreachable!("first is taken once acc exists"),
                 }
             }
         }
     }
-    Ok(Bytes::from(buf))
+    Ok(match (first, acc) {
+        (Some(f), None) => f,          // single chunk: fully zero-copy
+        (None, Some(b)) => b.freeze(), // multi-chunk: one concatenation
+        _ => Bytes::new(),             // empty / FIN-first
+    })
 }
 
 // ============================================================================

--- a/crates/hyprstream-rpc/src/transport/rpc_session.rs
+++ b/crates/hyprstream-rpc/src/transport/rpc_session.rs
@@ -354,7 +354,10 @@ async fn handle_stream<S>(
         }
     };
 
-    if let Err(e) = send.write_all(&response).await {
+    // Zero-copy reply: `write_chunk` takes the `Bytes` by value; quinn/iroh write it
+    // without copying the buffer (UDS falls back to the trait default). The response
+    // envelope is moved, never cloned.
+    if let Err(e) = send.write_chunk(response).await {
         tracing::warn!(error = ?e, "rpc-session: failed writing response");
         return;
     }
@@ -466,9 +469,11 @@ impl<S: Session> Transport for SessionRpcTransport<S> {
                 .open_bi()
                 .await
                 .map_err(|e| anyhow!("session open_bi: {e}"))?;
-            send.write_all(&payload)
+            // Zero-copy request: `Bytes::from(Vec)` is a move (no copy), and
+            // `write_chunk` writes it without copying on quinn/iroh.
+            send.write_chunk(bytes::Bytes::from(payload))
                 .await
-                .map_err(|e| anyhow!("session write_all: {e}"))?;
+                .map_err(|e| anyhow!("session write_chunk: {e}"))?;
             send.finish().map_err(|e| anyhow!("session finish: {e}"))?;
             let buf = read_to_cap(&mut recv, MAX_FRAME_BYTES).await?;
             Ok::<Vec<u8>, anyhow::Error>(buf.to_vec())


### PR DESCRIPTION
Restores the original zero-copy Cap'n Proto framing that the M1 (#151) generic RPC plane layered redundant copies over — including on the **streaming plane**, where pipeline activations / tensors flow. Surfaced while planning multi-GPU/host inference (epic #310). Wire-compatible; no format change.

## Why
A research spike confirmed moq-net already yields `bytes::Bytes` at the wire (`moq_stream.rs` `group.read_frame()`), so **every copy on the large/tensor path was in our own code** — no fork of `web-transport-trait` needed. (`web_transport_trait::RecvStream` v0.3.5 exposes only `read(&mut [u8])`, but that path is the 4 MiB control plane only.)

## Streaming plane (large/tensor path) — 3 copies eliminated
- **Borrowing verify:** new `StreamVerifier::verify_parts(topic, capnp, mac)` over slices; `verify(&[Vec<u8>])` is now a thin wrapper (generic-subscriber path + tests unchanged).
- **`verify_moq_frame`** passes slices into the moq `Bytes` frame — no per-frame `.to_vec()`.
- **Incremental MAC:** `keyed_mac_truncated_parts(key, &[prefix, capnp])` — byte-identical to MAC-of-concatenation (blake3 / HMAC are streamed), so it drops the `input` concat copy with **no wire change**. New equivalence test `test_keyed_mac_truncated_parts_equals_concat`.
- **`read_message_from_flat_slice`:** the `StreamBlock` reader borrows the frame instead of copying into an owned message — a tensor payload stays a view into the receive buffer end-to-end.

## Control plane
- **`read_to_cap`** reads straight into the output buffer (drops the scratch + `extend_from_slice` second copy; the one remaining kernel→userspace copy is forced by the external trait). Kept `MAX_FRAME_BYTES = 4 MiB` (#162).
- **`parse_stream_info`** uses `read_message_from_flat_slice`.

## Tests
`hyprstream-rpc` builds standalone (no libtorch). 413 lib tests pass; 18 changed-area tests green (MAC equivalence, tamper/ordering integrity, moq round-trips). Clippy clean. The 2 failures in a full run are pre-existing and unrelated (#148 moq_event "subscriber closed"; an env-parallel `paths` test).

## Follow-up (not in this PR)
Control-plane zero-copy via a `ZeroCopyRecv` extension trait (quinn `read_chunk -> Bytes`) — low value (4 MiB only); deferred.

Part of #310.
