### PR TITLE
ci: install cargo-deny so the bans+licenses job actually runs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,7 +45,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install cargo-deny
-      run: cargo install cargo-deny --locked 2>/dev/null || true
+      # Prebuilt binary — reliable and fast. The previous `cargo install ...
+      # 2>/dev/null || true` masked install failures, so when the install failed
+      # the next step ran `cargo deny` with the binary absent and the job died
+      # with `error: no such command: deny` (failing on every PR).
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-deny
     - name: Check bans
       # ZMQ crates are deny-listed in deny.toml (#138 complete). This gate must
       # be able to fail — do NOT add `|| true`.


### PR DESCRIPTION
## Problem
The `cargo-deny (bans + licenses)` job fails on **every** PR (seen on #330) at the "Check bans" step with:
```
error: no such command: `deny`
```

## Root cause
The install step was:
```yaml
- name: Install cargo-deny
  run: cargo install cargo-deny --locked 2>/dev/null || true
```
The `2>/dev/null || true` **masks install failure**, so when the install fails the next step runs `cargo deny check ...` with the binary absent → `no such command: deny`. Net effect: the bans/licenses gate (which enforces the #138 ZMQ deny-list) has not actually been running.

## Fix
Install cargo-deny via `taiki-e/install-action@v2` (prebuilt binary — reliable, fast, no compile, no masking). The `Check bans` step is unchanged and still able to fail as intended (no `|| true` added).

```yaml
- name: Install cargo-deny
  uses: taiki-e/install-action@v2
  with:
    tool: cargo-deny
- name: Check bans
  run: cargo deny check bans licenses
```

YAML validated locally. One-line change to `.github/workflows/rust.yml`.