### PR TITLE
feat: DevicePool + RuntimeConfig.devices for multi-GPU (#313)

### DIFF
--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -1589,8 +1589,20 @@ pub struct RuntimeConfig {
     pub cpu_threads: Option<usize>,
     /// Use GPU acceleration
     pub use_gpu: bool,
-    /// GPU device ID (None = auto-detect, typically device 0)
+    /// GPU device ID (None = auto-detect, typically device 0).
+    ///
+    /// Legacy single-GPU selector. For multi-GPU, prefer [`Self::devices`];
+    /// this field remains the back-compat fallback when `devices` is empty.
     pub gpu_device_id: Option<usize>,
+    /// Explicit set of GPU device indices for multi-GPU (#313, epic #310).
+    ///
+    /// Empty = unset → fall back to the single [`Self::gpu_device_id`] /
+    /// `HYPRSTREAM_GPU_DEVICE` (existing single-GPU behavior is unchanged).
+    /// Parsed from `HYPRSTREAM_GPU_DEVICES` (comma-separated, e.g. `0,1`).
+    /// Resolution + validation lives in [`Self::resolve_device_indices`] and is
+    /// consumed by `runtime::DevicePool`.
+    #[serde(default)]
+    pub devices: Vec<usize>,
     /// GPU layers to offload (None = auto)
     pub gpu_layers: Option<usize>,
     /// Use memory mapping for model files
@@ -1615,6 +1627,15 @@ impl Default for RuntimeConfig {
             .ok()
             .and_then(|s| s.parse::<usize>().ok());
 
+        // `devices` is populated leniently here (Default cannot return errors);
+        // the authoritative strict parse + validation lives in
+        // `RuntimeConfig::resolve_device_indices`, which re-reads the env var and
+        // turns parse errors into hard errors.
+        let devices = std::env::var("HYPRSTREAM_GPU_DEVICES")
+            .ok()
+            .and_then(|s| Self::parse_device_list(&s).ok())
+            .unwrap_or_default();
+
         let max_context = std::env::var("HYPRSTREAM_MAX_CONTEXT")
             .ok()
             .and_then(|s| s.parse::<u32>().ok());
@@ -1638,6 +1659,7 @@ impl Default for RuntimeConfig {
             cpu_threads: None,
             use_gpu: true,
             gpu_device_id, // From env or None (auto-detect device 0)
+            devices,       // From HYPRSTREAM_GPU_DEVICES or empty (→ fall back to gpu_device_id)
             gpu_layers: None,
             mmap: true,
             kv_cache_size_mb: 2048,
@@ -1647,6 +1669,95 @@ impl Default for RuntimeConfig {
             default_generation_timeout_ms: 120000, // 2 minutes
             default_model_load_timeout_ms: 300000, // 5 minutes
         }
+    }
+}
+
+impl RuntimeConfig {
+    /// Parse a comma-separated GPU device list (e.g. `"0,1"`), strictly.
+    ///
+    /// Whitespace around entries is trimmed. Any non-numeric entry, or a
+    /// trailing/empty field (e.g. `"0,"` or `"0,,1"`), is a hard error — there
+    /// is no silent default. Returns the parsed indices (possibly with
+    /// duplicates; dedup/validation is the caller's job).
+    fn parse_device_list(raw: &str) -> anyhow::Result<Vec<usize>> {
+        raw.split(',')
+            .map(|part| {
+                let trimmed = part.trim();
+                trimmed.parse::<usize>().map_err(|e| {
+                    anyhow::anyhow!(
+                        "invalid GPU device index {trimmed:?} in HYPRSTREAM_GPU_DEVICES={raw:?}: {e}"
+                    )
+                })
+            })
+            .collect()
+    }
+
+    /// Resolve the explicitly-requested *multi-GPU* device set, fail-fast.
+    ///
+    /// This is the seam the multi-GPU foundation uses to decide whether to engage
+    /// the new `DevicePool` path. It considers **only** the explicit multi-GPU
+    /// inputs and deliberately excludes the legacy single [`Self::gpu_device_id`]
+    /// so that existing single-GPU behavior is left entirely on its old code
+    /// path (#313 introduces the pool without changing single-GPU runtime
+    /// behavior). Precedence:
+    ///
+    /// 1. `HYPRSTREAM_GPU_DEVICES` env var (re-parsed here strictly, so a
+    ///    malformed value is a hard error rather than a silent fallback).
+    /// 2. The [`Self::devices`] field (e.g. from a config file / CLI).
+    ///
+    /// Returns `Ok(None)` when no explicit multi-GPU set was requested,
+    /// `Ok(Some(indices))` (non-empty, duplicate-free) otherwise, and `Err` on
+    /// parse errors or duplicate indices.
+    pub fn resolve_explicit_multi_device_indices(&self) -> anyhow::Result<Option<Vec<usize>>> {
+        // (1) env var wins and is parsed strictly here. An absent or
+        //     empty/whitespace-only value is treated as "unset" so resolution
+        //     falls through to (2) the struct field (config file / CLI).
+        let env_raw = std::env::var("HYPRSTREAM_GPU_DEVICES").ok();
+        let env_trimmed = env_raw.as_deref().map(str::trim).filter(|s| !s.is_empty());
+        let indices = match env_trimmed {
+            Some(raw) => Self::parse_device_list(raw)?,
+            None => self.devices.clone(),
+        };
+
+        Self::validate_index_set(indices)
+    }
+
+    /// Resolve the GPU device indices to use, fail-fast, including the legacy
+    /// single-GPU fallback.
+    ///
+    /// This is the full-precedence resolver consumed by
+    /// `runtime::DevicePool::from_config`. It is
+    /// [`Self::resolve_explicit_multi_device_indices`] plus a final fallback to
+    /// the legacy single [`Self::gpu_device_id`] (mapped to a one-element set),
+    /// preserving back-compat for callers that build a pool directly from config.
+    ///
+    /// `Ok(None)` means nothing was requested (caller should auto-detect).
+    pub fn resolve_device_indices(&self) -> anyhow::Result<Option<Vec<usize>>> {
+        if let Some(indices) = self.resolve_explicit_multi_device_indices()? {
+            return Ok(Some(indices));
+        }
+        // Legacy single-GPU selector as the final fallback.
+        match self.gpu_device_id {
+            Some(id) => Self::validate_index_set(vec![id]),
+            None => Ok(None),
+        }
+    }
+
+    /// Shared post-processing for a resolved index list: empty → `None`, reject
+    /// duplicates, otherwise `Some(indices)`.
+    fn validate_index_set(indices: Vec<usize>) -> anyhow::Result<Option<Vec<usize>>> {
+        if indices.is_empty() {
+            return Ok(None);
+        }
+        let mut seen = std::collections::HashSet::with_capacity(indices.len());
+        for &idx in &indices {
+            if !seen.insert(idx) {
+                return Err(anyhow::anyhow!(
+                    "duplicate GPU device index {idx} in requested set {indices:?}"
+                ));
+            }
+        }
+        Ok(Some(indices))
     }
 }
 
@@ -2451,6 +2562,140 @@ mod tests {
         let cfg = result.expect("config should parse with env var");
         assert_eq!(cfg.oauth.jwt_key_active_secs, Some(30), "jwt_key_active_secs should be 30 from env");
         assert_eq!(cfg.oauth.active_secs(), 30);
+    }
+
+    // ---- Multi-GPU device resolution (#313) ----
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn parse_device_list_basic() {
+        assert_eq!(RuntimeConfig::parse_device_list("0,1").unwrap(), vec![0, 1]);
+        // Whitespace around entries is tolerated.
+        assert_eq!(RuntimeConfig::parse_device_list(" 0 , 2 ").unwrap(), vec![0, 2]);
+        assert_eq!(RuntimeConfig::parse_device_list("3").unwrap(), vec![3]);
+    }
+
+    #[test]
+    fn parse_device_list_rejects_garbage() {
+        // Non-numeric, empty fields, and negatives are hard errors (no silent default).
+        assert!(RuntimeConfig::parse_device_list("0,foo").is_err());
+        assert!(RuntimeConfig::parse_device_list("0,").is_err());
+        assert!(RuntimeConfig::parse_device_list("0,,1").is_err());
+        assert!(RuntimeConfig::parse_device_list("-1").is_err());
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn validate_index_set_dedup_and_empty() {
+        // Empty → None (auto-detect).
+        assert_eq!(RuntimeConfig::validate_index_set(vec![]).unwrap(), None);
+        // Duplicates → error.
+        assert!(RuntimeConfig::validate_index_set(vec![0, 0]).is_err());
+        // Distinct → Some, order preserved.
+        assert_eq!(
+            RuntimeConfig::validate_index_set(vec![2, 0, 1]).unwrap(),
+            Some(vec![2, 0, 1])
+        );
+    }
+
+    /// Serializes the two tests that mutate the shared `HYPRSTREAM_GPU_DEVICES`
+    /// process env var so they don't race under the parallel test runner.
+    static GPU_DEVICES_ENV_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn resolve_uses_devices_field_and_legacy_fallback() {
+        let _serial = GPU_DEVICES_ENV_LOCK.lock();
+        // Guard against the env var leaking from the ambient environment so the
+        // struct-field/legacy precedence is exercised deterministically.
+        let _guard = EnvVarGuard::unset("HYPRSTREAM_GPU_DEVICES");
+
+        // Explicit multi-device field wins.
+        let mut cfg = RuntimeConfig::default();
+        cfg.devices = vec![0, 1];
+        cfg.gpu_device_id = Some(7);
+        assert_eq!(
+            cfg.resolve_explicit_multi_device_indices().unwrap(),
+            Some(vec![0, 1])
+        );
+        assert_eq!(cfg.resolve_device_indices().unwrap(), Some(vec![0, 1]));
+
+        // No explicit multi-device set → explicit resolver is None, but the full
+        // resolver falls back to the legacy single gpu_device_id.
+        let mut legacy = RuntimeConfig::default();
+        legacy.devices = vec![];
+        legacy.gpu_device_id = Some(3);
+        assert_eq!(legacy.resolve_explicit_multi_device_indices().unwrap(), None);
+        assert_eq!(legacy.resolve_device_indices().unwrap(), Some(vec![3]));
+
+        // Nothing requested anywhere → None (auto-detect path preserved).
+        let mut none = RuntimeConfig::default();
+        none.devices = vec![];
+        none.gpu_device_id = None;
+        assert_eq!(none.resolve_device_indices().unwrap(), None);
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn resolve_env_var_overrides_and_is_strict() {
+        let _serial = GPU_DEVICES_ENV_LOCK.lock();
+        let mut cfg = RuntimeConfig::default();
+        cfg.devices = vec![5];
+        cfg.gpu_device_id = Some(9);
+
+        {
+            let _g = EnvVarGuard::set("HYPRSTREAM_GPU_DEVICES", "0,1,2");
+            assert_eq!(
+                cfg.resolve_explicit_multi_device_indices().unwrap(),
+                Some(vec![0, 1, 2]),
+                "env var must override the devices field"
+            );
+        }
+        {
+            // Malformed env var is a hard error (not a silent fallback to field).
+            let _g = EnvVarGuard::set("HYPRSTREAM_GPU_DEVICES", "0,nope");
+            assert!(cfg.resolve_explicit_multi_device_indices().is_err());
+        }
+        {
+            // Duplicate in env var → error.
+            let _g = EnvVarGuard::set("HYPRSTREAM_GPU_DEVICES", "1,1");
+            assert!(cfg.resolve_explicit_multi_device_indices().is_err());
+        }
+        {
+            // Explicitly-empty env var is treated as unset (falls back to field).
+            let _g = EnvVarGuard::set("HYPRSTREAM_GPU_DEVICES", "  ");
+            assert_eq!(
+                cfg.resolve_explicit_multi_device_indices().unwrap(),
+                Some(vec![5])
+            );
+        }
+    }
+
+    /// RAII guard to set/unset a process env var for the duration of a test and
+    /// restore the previous value, keeping env-mutating tests from leaking state.
+    struct EnvVarGuard {
+        key: String,
+        prev: Option<String>,
+    }
+    impl EnvVarGuard {
+        fn set(key: &str, val: &str) -> Self {
+            let prev = std::env::var(key).ok();
+            std::env::set_var(key, val);
+            Self { key: key.to_owned(), prev }
+        }
+        fn unset(key: &str) -> Self {
+            let prev = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key: key.to_owned(), prev }
+        }
+    }
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.prev {
+                Some(v) => std::env::set_var(&self.key, v),
+                None => std::env::remove_var(&self.key),
+            }
+        }
     }
 }
 

--- a/crates/hyprstream/src/runtime/device_pool.rs
+++ b/crates/hyprstream/src/runtime/device_pool.rs
@@ -1,0 +1,280 @@
+//! Multi-GPU device abstraction (`DevicePool`).
+//!
+//! This module introduces the device-strategy seam for the multi-GPU epic (#310,
+//! part of #313). It resolves a set of configured device indices
+//! (`RuntimeConfig.devices`) into concrete [`tch::Device`] values and exposes a
+//! small, stable API that the later phases build on:
+//!
+//! - **2a replication** (#313): N `TorchEngine`s, one per local GPU, requests
+//!   routed across [`DevicePool::devices`].
+//! - **2b intra-host pipeline** (#314): a layer→device `device_map` layered on
+//!   top of the same pool (see [`DevicePool`] note on extensibility).
+//!
+//! # Send / !Send boundary
+//!
+//! `tch-rs` tensors are `!Send`: a `Tensor` must never cross a thread boundary,
+//! and engines that hold tensors stay pinned to one thread (as
+//! `services/inference.rs` already does — one thread per engine). However, a
+//! *single* thread may legitimately own tensors on `Cuda(0)` **and** `Cuda(1)`
+//! at once: libtorch dispatches each op to the correct device via a
+//! `DeviceGuard`, so multi-device-on-one-thread is fine; only multi-*thread*
+//! tensor moves are forbidden.
+//!
+//! `DevicePool` deliberately holds **only** device indices / [`tch::Device`]
+//! values (which are `Copy` and contain no tensor state). It is therefore
+//! `Send + Sync` and can be shared across threads (e.g. handed to each
+//! engine-owning thread so each can construct its own thread-pinned engine).
+//! **Do not** add a `Tensor`, `VarStore`, or any `!Send` field to this type — it
+//! would silently make the pool `!Send` and break the replication design.
+
+use anyhow::{anyhow, Result};
+use tch::Device;
+
+/// A resolved, validated set of compute devices a single inference service owns.
+///
+/// Constructed from [`crate::config::RuntimeConfig`] via [`DevicePool::from_config`].
+/// The pool performs **fail-fast** device resolution: when devices are explicitly
+/// requested it never silently downgrades to CPU (see the plan's
+/// "no-fragile-fallbacks", `docs/plans/2026-06-18-multi-gpu-multi-host-inference-spike.md`
+/// §B / rust-M2). A process told to use GPU 1 that would land on CPU is an error,
+/// not a warning.
+///
+/// # Send / Sync
+///
+/// `DevicePool` is `Send + Sync` because it holds only [`Device`] values (no
+/// tensors). See the module-level docs for the `!Send` boundary — keep this type
+/// tensor-free.
+///
+/// # Extensibility (#314)
+///
+/// The pipeline phase needs a layer→device map. That belongs *on* this type
+/// (e.g. a `fn device_for_layer(&self, layer_idx, num_layers) -> Device` or an
+/// explicit `device_map`), reusing the already-resolved [`Self::devices`]. New
+/// strategy methods can be added without changing the existing accessors below,
+/// so current callers (which only need [`Self::primary`]) keep working.
+#[derive(Debug, Clone)]
+pub struct DevicePool {
+    /// Resolved devices, in the order they were requested. Always non-empty.
+    devices: Vec<Device>,
+}
+
+impl DevicePool {
+    /// Build a pool for the given GPU indices, validating availability fail-fast.
+    ///
+    /// `indices` must be non-empty and free of duplicates (the caller —
+    /// [`crate::config::RuntimeConfig::resolve_device_indices`] — guarantees
+    /// this, but it is re-checked here so the type's invariant holds regardless
+    /// of construction path).
+    ///
+    /// Every index is validated against the live CUDA/HIP device count. If CUDA
+    /// is unavailable, or any requested index is out of range, this returns an
+    /// error rather than degrading to CPU — devices were *explicitly* requested.
+    ///
+    /// Note: ROCm presents as [`Device::Cuda`] via HIP, so this path is
+    /// vendor-agnostic and contains no vendor-special casing.
+    pub fn from_cuda_indices(indices: &[usize]) -> Result<Self> {
+        if indices.is_empty() {
+            return Err(anyhow!(
+                "DevicePool requires at least one device index (got none)"
+            ));
+        }
+
+        // Reject duplicates defensively (config layer also enforces this).
+        let mut seen = std::collections::HashSet::with_capacity(indices.len());
+        for &idx in indices {
+            if !seen.insert(idx) {
+                return Err(anyhow!(
+                    "DevicePool: duplicate device index {idx} in requested set {indices:?}"
+                ));
+            }
+        }
+
+        // Fail-fast: devices were explicitly requested, so a CPU downgrade is an
+        // error, not a fallback (no `Device::cuda_if_available()` here).
+        if !tch::Cuda::is_available() {
+            return Err(anyhow!(
+                "DevicePool: GPU devices {indices:?} requested but no CUDA/ROCm device is \
+                 available (refusing to silently fall back to CPU)"
+            ));
+        }
+
+        let available = tch::Cuda::device_count();
+        if available < 0 {
+            return Err(anyhow!(
+                "DevicePool: CUDA reported a negative device count ({available})"
+            ));
+        }
+        let available = available as usize;
+
+        let devices = indices
+            .iter()
+            .map(|&idx| {
+                if idx >= available {
+                    Err(anyhow!(
+                        "DevicePool: GPU device index {idx} is out of range \
+                         (only {available} CUDA/ROCm device(s) present)"
+                    ))
+                } else {
+                    Ok(Device::Cuda(idx))
+                }
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(Self { devices })
+    }
+
+    /// Construct a pool directly from already-resolved [`Device`] values.
+    ///
+    /// Intended for tests and for callers that have an explicit device list
+    /// (e.g. CPU-only setups). Validates only the structural invariants
+    /// (non-empty, no duplicates); it does **not** probe CUDA, so prefer
+    /// [`Self::from_cuda_indices`] / [`Self::from_config`] for GPU resolution.
+    pub fn from_devices(devices: Vec<Device>) -> Result<Self> {
+        if devices.is_empty() {
+            return Err(anyhow!("DevicePool requires at least one device (got none)"));
+        }
+        let mut seen = std::collections::HashSet::with_capacity(devices.len());
+        for dev in &devices {
+            if !seen.insert(*dev) {
+                return Err(anyhow!("DevicePool: duplicate device {dev:?} in {devices:?}"));
+            }
+        }
+        Ok(Self { devices })
+    }
+
+    /// Resolve a [`DevicePool`] from runtime configuration.
+    ///
+    /// Behavior:
+    /// - `use_gpu == false` → a single-entry CPU pool ([`Device::Cpu`]).
+    /// - `use_gpu == true` → resolve the configured indices
+    ///   ([`crate::config::RuntimeConfig::resolve_device_indices`], which honors
+    ///   `devices` then falls back to the legacy single `gpu_device_id`) and
+    ///   validate them fail-fast via [`Self::from_cuda_indices`].
+    ///
+    /// When `use_gpu` is true but no index is configured, this falls back to
+    /// `cuda_if_available()`-style auto-detection of device 0 (preserving the
+    /// pre-existing single-GPU default). That auto-detect path is the *only*
+    /// place a CPU result is allowed when GPU is on, and only because nothing
+    /// was explicitly requested.
+    pub fn from_config(config: &crate::config::RuntimeConfig) -> Result<Self> {
+        if !config.use_gpu {
+            return Self::from_devices(vec![Device::Cpu]);
+        }
+
+        match config.resolve_device_indices()? {
+            // Explicit device(s) requested → strict, fail-fast resolution.
+            Some(indices) => Self::from_cuda_indices(&indices),
+            // Nothing explicitly requested → preserve legacy auto-detect (may
+            // be CPU if no GPU is present; this is NOT a silent downgrade because
+            // the user requested no specific device).
+            None => Self::from_devices(vec![Device::cuda_if_available()]),
+        }
+    }
+
+    /// All resolved devices, in requested order. Always non-empty.
+    ///
+    /// The primary seam for #313/2a replication (one engine per device).
+    #[must_use]
+    pub fn devices(&self) -> &[Device] {
+        &self.devices
+    }
+
+    /// The primary device — the first configured device.
+    ///
+    /// Single-device callers (e.g. today's `TorchEngine`) use this to keep
+    /// existing behavior while the multi-engine routing lands in a later PR.
+    #[must_use]
+    pub fn primary(&self) -> Device {
+        self.devices[0]
+    }
+
+    /// Number of devices in the pool (always >= 1).
+    ///
+    /// No `is_empty()` companion exists: a `DevicePool` is never empty by
+    /// construction. Use [`Self::is_single`] for the meaningful predicate.
+    #[must_use]
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self) -> usize {
+        self.devices.len()
+    }
+
+    /// Whether the pool holds a single device. (`is_empty` is meaningless here —
+    /// the pool is never empty — so this single-device predicate is provided
+    /// instead; clippy's `len`/`is_empty` lint is allowed below.)
+    #[must_use]
+    pub fn is_single(&self) -> bool {
+        self.devices.len() == 1
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_devices_rejects_empty() {
+        let err = DevicePool::from_devices(vec![]).unwrap_err();
+        assert!(err.to_string().contains("at least one device"));
+    }
+
+    #[test]
+    fn from_devices_rejects_duplicates() {
+        let err = DevicePool::from_devices(vec![Device::Cpu, Device::Cpu]).unwrap_err();
+        assert!(err.to_string().contains("duplicate"));
+    }
+
+    #[test]
+    fn from_devices_preserves_order_and_primary() {
+        let pool =
+            DevicePool::from_devices(vec![Device::Cuda(2), Device::Cuda(0)]).unwrap();
+        assert_eq!(pool.devices(), &[Device::Cuda(2), Device::Cuda(0)]);
+        assert_eq!(pool.primary(), Device::Cuda(2));
+        assert_eq!(pool.len(), 2);
+        assert!(!pool.is_single());
+    }
+
+    #[test]
+    fn from_devices_single() {
+        let pool = DevicePool::from_devices(vec![Device::Cpu]).unwrap();
+        assert_eq!(pool.primary(), Device::Cpu);
+        assert!(pool.is_single());
+        assert_eq!(pool.len(), 1);
+    }
+
+    #[test]
+    fn from_cuda_indices_rejects_empty() {
+        let err = DevicePool::from_cuda_indices(&[]).unwrap_err();
+        assert!(err.to_string().contains("at least one device index"));
+    }
+
+    #[test]
+    fn from_cuda_indices_rejects_duplicates_before_probing() {
+        // Duplicate detection must happen before any CUDA probe so it is
+        // deterministic on CPU-only CI.
+        let err = DevicePool::from_cuda_indices(&[1, 1]).unwrap_err();
+        assert!(err.to_string().contains("duplicate"));
+    }
+
+    #[test]
+    fn from_cuda_indices_no_gpu_is_fail_fast() {
+        // On CPU-only CI, requesting an explicit GPU index must error rather
+        // than degrade to CPU. (If CUDA happens to be present, this asserts the
+        // out-of-range guard instead via a deliberately huge index.)
+        if tch::Cuda::is_available() {
+            let err = DevicePool::from_cuda_indices(&[usize::MAX]).unwrap_err();
+            assert!(err.to_string().contains("out of range"));
+        } else {
+            let err = DevicePool::from_cuda_indices(&[0]).unwrap_err();
+            assert!(err.to_string().contains("no CUDA/ROCm device is available"));
+        }
+    }
+
+    #[test]
+    fn pool_is_send_sync() {
+        // Compile-time proof that the !Send boundary is upheld: DevicePool holds
+        // no tensors, so it must be Send + Sync for the replication design.
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<DevicePool>();
+    }
+}

--- a/crates/hyprstream/src/runtime/mod.rs
+++ b/crates/hyprstream/src/runtime/mod.rs
@@ -33,6 +33,7 @@ pub mod generation_metrics; // Quality metrics for self-supervised training
 // KV cache quantization — re-export the generated Cap'n Proto enum as canonical type
 pub use crate::services::generated::model_client::KVQuantType;
 pub mod tensor_sampling; // Device-agnostic tensor-based sampling
+pub mod device_pool; // Multi-GPU device abstraction (DevicePool) — Send+Sync, holds only Device values
 pub mod image_utils; // Image loading and preprocessing for multimodal models
 pub mod kv_cache; // Key-Value caching for efficient autoregressive generation
 pub mod model_config; // Unified model configuration management
@@ -47,6 +48,9 @@ pub mod weight_provider; // Weight provider for streaming large models
 
 // Primary exports - use TorchEngine as default
 pub use torch_engine::{TorchEngine, TextStream, GenerationStats};
+
+// Multi-GPU device abstraction
+pub use device_pool::DevicePool;
 
 // KV cache exports for multi-session support
 pub use kv_cache::{CacheConfig, CacheOwner, KVCacheManager, KVCacheRegistry};

--- a/crates/hyprstream/src/runtime/torch_engine.rs
+++ b/crates/hyprstream/src/runtime/torch_engine.rs
@@ -315,6 +315,28 @@ impl TorchEngine {
 
     /// Internal sync constructor
     fn new_sync(config: RuntimeConfig) -> Result<Self> {
+        // Multi-GPU foundation (#313, epic #310): when devices are *explicitly*
+        // requested via `RuntimeConfig.devices` / `HYPRSTREAM_GPU_DEVICES`,
+        // resolve them through `DevicePool`, which validates them fail-fast (no
+        // silent CPU downgrade) and is the seam for later replication (#313/2a)
+        // and the layer device_map (#314). This PR only uses the pool's *primary*
+        // device, so single-GPU runtime behavior is unchanged; the legacy
+        // single-`gpu_device_id` path below is left intact (including its
+        // existing soft CPU fallback) to avoid changing that behavior here.
+        if config.use_gpu {
+            if let Some(indices) = config.resolve_explicit_multi_device_indices()? {
+                let pool = crate::runtime::DevicePool::from_cuda_indices(&indices)?;
+                let device = pool.primary();
+                info!(
+                    "🚀 Multi-GPU DevicePool resolved {} device(s) {:?}; using primary {:?}",
+                    pool.len(),
+                    pool.devices(),
+                    device
+                );
+                return Self::with_device(config, device);
+            }
+        }
+
         // Determine device based on configuration
         let device = if config.use_gpu {
             // Use specified GPU device ID, or auto-detect
@@ -353,6 +375,16 @@ impl TorchEngine {
             Device::Cpu
         };
 
+        Self::with_device(config, device)
+    }
+
+    /// Construct an engine pinned to an already-resolved [`Device`].
+    ///
+    /// Single-device by design: a `TorchEngine` owns exactly one immutable
+    /// device and stays thread-pinned because `tch` tensors are `!Send`. The
+    /// multi-device `DevicePool` selects *which* device (its primary, for now);
+    /// the multi-engine/replication routing across the pool is a later PR (#313/2a).
+    fn with_device(config: RuntimeConfig, device: Device) -> Result<Self> {
         Ok(Self {
             var_store: Arc::new(Mutex::new(None)),
             model_architecture: Arc::new(Mutex::new(None)),


### PR DESCRIPTION
## Summary

Introduces the multi-GPU **device abstraction + config** foundation for the multi-GPU epic. This PR is intentionally tight: it adds the pool and config plumbing and wires it for *primary-device* selection only. It does **not** change single-GPU runtime behavior.

Closes #313. Part of #310.

### What changed
- **`RuntimeConfig.devices: Vec<usize>`** (`config/mod.rs`) + `HYPRSTREAM_GPU_DEVICES` parsing (comma-separated, e.g. `0,1`).
  - Back-compat: if `devices` is empty, falls back to the existing single `gpu_device_id` / `HYPRSTREAM_GPU_DEVICE` — existing single-GPU behavior is unchanged.
  - **Strict parsing**: malformed values (`0,foo`, `0,`, `0,,1`, negatives) are hard errors; duplicates rejected; non-empty after resolution. No silent default.
  - `resolve_explicit_multi_device_indices()` (env/field only, excludes legacy single id) and `resolve_device_indices()` (full precedence incl. legacy fallback).
- **`runtime::DevicePool`** (new `runtime/device_pool.rs`):
  - Resolves indices → `Vec<tch::Device>` (`Device::Cuda(i)`). ROCm presents as `Cuda(i)` via HIP, so this is vendor-agnostic — no vendor-special code.
  - Clean API for later phases: `devices() -> &[Device]`, `primary() -> Device`, `len()`, `is_single()`, plus `from_config`/`from_cuda_indices`/`from_devices` constructors. Designed so #314 can add a layer→device `device_map`/strategy without breaking these callers.
- **`TorchEngine`** uses `DevicePool::primary()` when an explicit multi-GPU set is configured; the legacy single-`gpu_device_id` path (with its existing soft CPU fallback) is left untouched. Construction refactored into `with_device(config, device)` (single-device, thread-pinned).

### Send / !Send boundary (documented in the module)
`tch` tensors are `!Send` — they never cross threads, and tensor-holding engines stay thread-pinned (as `services/inference.rs` already does). A *single* thread can still own tensors on `Cuda(0)` **and** `Cuda(1)` (libtorch dispatches per-op via `DeviceGuard`); only multi-*thread* moves are forbidden. `DevicePool` holds **only** `Device` values (no tensors), so it is `Send + Sync` and can be shared across the engine-owning threads. A compile-time `assert_send_sync::<DevicePool>()` test enforces this; do not add a `Tensor`/`VarStore` field.

### Fail-fast decision (no fragile fallbacks)
Per the plan's no-fragile-fallbacks guidance: when devices are **explicitly requested**, `DevicePool` validates each index against the live CUDA/HIP device count and **errors** if CUDA is unavailable or an index is out of range — it never silently downgrades to CPU (no `Device::cuda_if_available()` on the explicit path). A process told to use GPU 1 that would land on CPU is an error. The only allowed CPU result under `use_gpu` is the legacy auto-detect path when *nothing* was explicitly requested.

### Deferred
- Layer `device_map` / forward-pass splitting → **#314**
- Broad no-fragile-fallbacks sweep (require config.json/index.json, etc.) → **#315**
- Multi-engine / replication routing across the pool → later (#313/2a)

### Verify
- `cargo build -p hyprstream` — OK
- `cargo test -p hyprstream --lib device_pool` — 8 passed
- `cargo test -p hyprstream --lib config::tests` — 14 passed (incl. new parse/validation/precedence/fail-fast tests)
- `cargo clippy -p hyprstream --all-targets -D warnings` — clean

No capnp schema / RPC API / auth / policy code touched.