### PR TITLE
fix: no-fragile-fallbacks hardening in load/device path (#315)

### DIFF
--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -1603,6 +1603,18 @@ pub struct RuntimeConfig {
     /// consumed by `runtime::DevicePool`.
     #[serde(default)]
     pub devices: Vec<usize>,
+    /// Fail fast when a *requested* GPU is unavailable instead of silently
+    /// downgrading to CPU (#315, epic #310).
+    ///
+    /// A process told to run on GPU 3 that silently lands on CPU tanks a pipeline
+    /// split, so strictness is the safe default for the multi-GPU path. This only
+    /// affects the case where a GPU was *explicitly* requested (`use_gpu` with an
+    /// explicit `gpu_device_id`/`devices`); pure auto-detect (`use_gpu` with no
+    /// device requested) still falls back to CPU so the legacy single-GPU
+    /// "use a GPU if there is one" behavior is unchanged.
+    /// Defaults to `true`; override with `HYPRSTREAM_STRICT_DEVICE=0`.
+    #[serde(default = "default_strict_device")]
+    pub strict_device: bool,
     /// GPU layers to offload (None = auto)
     pub gpu_layers: Option<usize>,
     /// Use memory mapping for model files
@@ -1616,6 +1628,15 @@ pub struct RuntimeConfig {
     pub max_concurrent_generations: usize,
     pub default_generation_timeout_ms: u64,
     pub default_model_load_timeout_ms: u64,
+}
+
+/// Default for [`RuntimeConfig::strict_device`]: strict (fail-fast) unless
+/// `HYPRSTREAM_STRICT_DEVICE` is set to a falsy value. Strictness is the safe
+/// default for the multi-GPU path (#315).
+fn default_strict_device() -> bool {
+    std::env::var("HYPRSTREAM_STRICT_DEVICE")
+        .map(|v| !matches!(v.trim().to_lowercase().as_str(), "0" | "false" | "no" | "off"))
+        .unwrap_or(true)
 }
 
 impl Default for RuntimeConfig {
@@ -1660,6 +1681,7 @@ impl Default for RuntimeConfig {
             use_gpu: true,
             gpu_device_id, // From env or None (auto-detect device 0)
             devices,       // From HYPRSTREAM_GPU_DEVICES or empty (→ fall back to gpu_device_id)
+            strict_device: default_strict_device(),
             gpu_layers: None,
             mmap: true,
             kv_cache_size_mb: 2048,
@@ -2668,6 +2690,34 @@ mod tests {
                 cfg.resolve_explicit_multi_device_indices().unwrap(),
                 Some(vec![5])
             );
+        }
+    }
+
+    /// Serializes tests mutating the shared `HYPRSTREAM_STRICT_DEVICE` env var.
+    static STRICT_DEVICE_ENV_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+
+    /// #315: strict_device defaults to fail-fast, and can be opted out via env.
+    #[test]
+    fn strict_device_defaults_to_true_and_respects_env() {
+        let _serial = STRICT_DEVICE_ENV_LOCK.lock();
+
+        {
+            let _g = EnvVarGuard::unset("HYPRSTREAM_STRICT_DEVICE");
+            assert!(
+                RuntimeConfig::default().strict_device,
+                "strict_device must default to true (safe default for multi-GPU)"
+            );
+        }
+        for falsy in ["0", "false", "no", "off"] {
+            let _g = EnvVarGuard::set("HYPRSTREAM_STRICT_DEVICE", falsy);
+            assert!(
+                !RuntimeConfig::default().strict_device,
+                "HYPRSTREAM_STRICT_DEVICE={falsy} must disable strict_device"
+            );
+        }
+        {
+            let _g = EnvVarGuard::set("HYPRSTREAM_STRICT_DEVICE", "1");
+            assert!(RuntimeConfig::default().strict_device);
         }
     }
 

--- a/crates/hyprstream/src/runtime/model_config.rs
+++ b/crates/hyprstream/src/runtime/model_config.rs
@@ -3,7 +3,7 @@
 //! This module provides a single source of truth for model configurations,
 //! resolving the current chaos of multiple override points.
 
-use anyhow::Result;
+use anyhow::{bail, Context, Result};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -135,22 +135,67 @@ pub struct NestedModelConfig {
     pub torch_dtype: Option<String>,
 }
 
+/// Opt-in escape hatch: when set to a truthy value (`1`/`true`), a missing
+/// `config.json` falls back to the fragile weight-name-scan heuristic instead of
+/// hard-failing. The model's own `config.json` is authoritative; this exists only
+/// for legacy/dev checkpoints that ship raw weights with no metadata.
+const ALLOW_WEIGHT_DETECT_ENV: &str = "HYPRSTREAM_ALLOW_WEIGHT_DETECT";
+
+/// Returns true when an env var is set to a recognized truthy value.
+fn env_flag(name: &str) -> bool {
+    std::env::var(name)
+        .map(|v| matches!(v.trim().to_lowercase().as_str(), "1" | "true" | "yes" | "on"))
+        .unwrap_or(false)
+}
+
+/// Extract a mandatory unsigned integer field from a config JSON object, failing
+/// fast with a clear error (including the config path) when it is absent or not a
+/// non-negative integer. Used for the architectural dimensions that must never be
+/// silently defaulted (#315).
+fn require_u64(source: &serde_json::Value, field: &str, config_path: &Path) -> Result<u64> {
+    source[field].as_u64().with_context(|| {
+        format!(
+            "config.json ({path}) is missing required field `{field}` (or it is not a non-negative integer)",
+            path = config_path.display()
+        )
+    })
+}
+
 impl ModelConfig {
-    /// Load configuration with clear priority:
-    /// 1. config.json (if exists)
-    /// 2. Weight detection (fill missing values)
-    /// 3. Architecture defaults (last resort)
+    /// Load configuration, treating the model's own `config.json` as authoritative.
+    ///
+    /// No-fragile-fallbacks (#315): `config.json` is **required** by default. If it
+    /// is absent, loading is a hard error — a silently-guessed config can corrupt a
+    /// pipeline split (e.g. a wrong layer count). The legacy weight-name-scan
+    /// heuristic remains available only behind the explicit
+    /// `HYPRSTREAM_ALLOW_WEIGHT_DETECT=1` opt-in.
+    ///
+    /// When `model.safetensors.index.json` is present, `num_hidden_layers` is
+    /// cross-checked against the shard manifest's `weight_map`; a mismatch is a
+    /// hard error rather than a silent corruption.
     pub fn load(model_path: &Path, weights: &HashMap<String, Tensor>) -> Result<Self> {
-        // Step 1: Try to load config.json
+        // Step 1: config.json is authoritative and required.
         let config_path = model_path.join("config.json");
         let mut config = if config_path.exists() {
             info!("Loading model configuration");
             Self::from_json_file(&config_path)?
-        } else {
-            info!("⚠️ No config.json found, detecting from weights");
+        } else if env_flag(ALLOW_WEIGHT_DETECT_ENV) {
+            info!(
+                "⚠️ No config.json in {}; {ALLOW_WEIGHT_DETECT_ENV} is set, detecting from weights (fragile)",
+                model_path.display()
+            );
             Self::detect_from_weights(weights)?
+        } else {
+            bail!(
+                "config.json is required but was not found in {}. \
+                 A model's config.json is authoritative for its architecture; refusing to guess. \
+                 Set {ALLOW_WEIGHT_DETECT_ENV}=1 to opt into the legacy weight-name heuristic.",
+                model_path.display()
+            );
         };
 
+        // Step 1b: cross-check num_hidden_layers against the shard manifest.
+        config.validate_against_index(model_path)?;
 
         // Step 2: Validate against weights
         config.validate_with_weights(weights)?;
@@ -205,29 +250,51 @@ impl ModelConfig {
         // Choose config source based on architecture
         let config_source = nested_json_opt.as_ref().unwrap_or(&json);
 
+        // No-fragile-fallbacks (#315): the core architectural dimensions are
+        // *mandatory* when config.json is present. A wrong layer count or hidden
+        // size silently corrupts inference (and a pipeline split), so a
+        // missing/unparseable value is a hard error rather than a magic default.
+        // `num_hidden_layers` falls back to the top-level config for nested
+        // (Janus/Qwen3.5) layouts that carry it outside the sub-config.
+        let num_hidden_layers = config_source["num_hidden_layers"]
+            .as_u64()
+            .or_else(|| json["num_hidden_layers"].as_u64())
+            .map(|v| v as usize)
+            .with_context(|| {
+                format!(
+                    "config.json ({path}) is missing required field `num_hidden_layers`",
+                    path = path.display()
+                )
+            })?;
+        let hidden_size = require_u64(config_source, "hidden_size", path)? as usize;
+        let num_attention_heads = require_u64(config_source, "num_attention_heads", path)? as usize;
+        if num_attention_heads == 0 || num_hidden_layers == 0 || hidden_size == 0 {
+            bail!(
+                "config.json ({}) has invalid zero dimension(s): \
+                 hidden_size={hidden_size}, num_hidden_layers={num_hidden_layers}, \
+                 num_attention_heads={num_attention_heads}",
+                path.display()
+            );
+        }
+
         // Extract all configuration values from the appropriate source
         let config = Self {
             architecture: architecture.clone(),
             model_type: json["model_type"].as_str().unwrap_or("unknown").to_owned(),
             version: Self::detect_version(&json, &architecture),
 
-            hidden_size: config_source["hidden_size"].as_u64().unwrap_or(4096) as usize,
-            num_hidden_layers: config_source["num_hidden_layers"].as_u64()
-                .or_else(|| json["num_hidden_layers"].as_u64())
-                .unwrap_or(32) as usize,
-            num_attention_heads: config_source["num_attention_heads"].as_u64().unwrap_or(32) as usize,
+            hidden_size,
+            num_hidden_layers,
+            num_attention_heads,
+            // KV heads legitimately default to attention heads (MHA, not GQA).
             num_key_value_heads: config_source["num_key_value_heads"]
                 .as_u64()
-                .or_else(|| config_source["num_attention_heads"].as_u64())
-                .unwrap_or(32) as usize,
+                .map(|v| v as usize)
+                .unwrap_or(num_attention_heads),
+            // head_dim is derivable from hidden_size / heads when omitted.
             head_dim: config_source["head_dim"].as_u64()
-                .or_else(|| {
-                    // Calculate from hidden_size / num_attention_heads
-                    let hidden = config_source["hidden_size"].as_u64()?;
-                    let heads = config_source["num_attention_heads"].as_u64()?;
-                    Some(hidden / heads)
-                })
-                .unwrap_or(128) as usize,
+                .map(|v| v as usize)
+                .unwrap_or(hidden_size / num_attention_heads),
             intermediate_size: config_source["intermediate_size"].as_u64().unwrap_or(11008) as usize,
 
             vocab_size: config_source["vocab_size"].as_u64().unwrap_or(32000) as usize,
@@ -264,9 +331,7 @@ impl ModelConfig {
                 None
             },
             layer_types: if architecture == ModelArchitecture::Qwen3_5 {
-                let num_layers = config_source["num_hidden_layers"].as_u64()
-                    .or_else(|| json["num_hidden_layers"].as_u64())
-                    .unwrap_or(32) as usize;
+                let num_layers = num_hidden_layers;
                 config_source["layer_types"].as_array()
                     .map(|a| {
                         a.iter()
@@ -553,6 +618,72 @@ impl ModelConfig {
         }
     }
 
+    /// Cross-check `num_hidden_layers` against the shard manifest's `weight_map`.
+    ///
+    /// When `model.safetensors.index.json` is present, the number of distinct
+    /// `model.layers.<i>.` (or `*.layers.<i>.` for nested layouts) indices listed
+    /// in its `weight_map` must equal the config's `num_hidden_layers`. A mismatch
+    /// means the config and the actual checkpoint disagree about depth, which would
+    /// silently truncate or over-allocate a pipeline split — so it is a hard error.
+    ///
+    /// If the index file is absent this is a no-op: per #315 the index is required
+    /// only where the *loader* consumes it (multi-shard models, validated in
+    /// `model_factory`); a single-file model legitimately has no manifest.
+    fn validate_against_index(&self, model_path: &Path) -> Result<()> {
+        let index_path = model_path.join("model.safetensors.index.json");
+        if !index_path.exists() {
+            return Ok(());
+        }
+
+        let content = std::fs::read_to_string(&index_path).with_context(|| {
+            format!("failed to read shard manifest {}", index_path.display())
+        })?;
+        let index: serde_json::Value = serde_json::from_str(&content).with_context(|| {
+            format!("failed to parse shard manifest {}", index_path.display())
+        })?;
+        let weight_map = index["weight_map"].as_object().ok_or_else(|| {
+            anyhow::anyhow!(
+                "shard manifest {} is missing required `weight_map` object",
+                index_path.display()
+            )
+        })?;
+
+        let mut layer_indices = std::collections::HashSet::new();
+        if let Some(ref regex) = *LAYER_REGEX {
+            for key in weight_map.keys() {
+                if let Some(captures) = regex.captures(key) {
+                    if let Ok(idx) = captures[1].parse::<usize>() {
+                        layer_indices.insert(idx);
+                    }
+                }
+            }
+        }
+
+        // Only enforce when the manifest actually encodes per-layer weights.
+        // (Some manifests for non-transformer components may carry none.)
+        if layer_indices.is_empty() {
+            return Ok(());
+        }
+
+        let manifest_layers = layer_indices.len();
+        if manifest_layers != self.num_hidden_layers {
+            bail!(
+                "num_hidden_layers mismatch: config.json declares {} but \
+                 {} lists {} distinct transformer layers in its weight_map. \
+                 Refusing to load with a layer count that disagrees with the checkpoint.",
+                self.num_hidden_layers,
+                index_path.display(),
+                manifest_layers
+            );
+        }
+
+        info!(
+            "✅ num_hidden_layers ({}) matches shard manifest weight_map",
+            self.num_hidden_layers
+        );
+        Ok(())
+    }
+
     /// Validate configuration against actual weights
     fn validate_with_weights(&mut self, weights: &HashMap<String, Tensor>) -> Result<()> {
         // Check if detected values match weights
@@ -679,5 +810,157 @@ impl ModelConfig {
         );
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use tch::Tensor;
+
+    fn empty_weights() -> HashMap<String, Tensor> {
+        HashMap::new()
+    }
+
+    fn write(dir: &Path, name: &str, contents: &str) {
+        std::fs::write(dir.join(name), contents).unwrap();
+    }
+
+    /// A minimal-but-valid Llama-style config.json.
+    fn valid_config_json(num_layers: usize) -> String {
+        format!(
+            r#"{{
+                "model_type": "llama",
+                "hidden_size": 4096,
+                "num_hidden_layers": {num_layers},
+                "num_attention_heads": 32,
+                "num_key_value_heads": 8,
+                "intermediate_size": 11008,
+                "vocab_size": 32000,
+                "max_position_embeddings": 4096,
+                "rms_norm_eps": 1e-5
+            }}"#
+        )
+    }
+
+    /// Happy path: a model that ships a proper config.json loads with the
+    /// declared dimensions (no magic-number substitution).
+    #[test]
+    fn valid_config_loads_with_declared_dims() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "config.json", &valid_config_json(40));
+
+        let cfg = ModelConfig::load(dir.path(), &empty_weights()).expect("valid config must load");
+        assert_eq!(cfg.num_hidden_layers, 40);
+        assert_eq!(cfg.hidden_size, 4096);
+        assert_eq!(cfg.num_attention_heads, 32);
+        // head_dim derived from hidden_size / heads.
+        assert_eq!(cfg.head_dim, 128);
+        // KV heads honored (GQA), not silently set to attention-head count.
+        assert_eq!(cfg.num_key_value_heads, 8);
+    }
+
+    /// #315: a missing config.json is a hard error by default (no silent guess).
+    #[test]
+    fn missing_config_is_hard_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = ModelConfig::load(dir.path(), &empty_weights())
+            .expect_err("missing config.json must fail");
+        assert!(
+            err.to_string().contains("config.json is required"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// #315: the silent magic-number default for num_hidden_layers is gone — a
+    /// config.json present but missing the field is a hard error (not 32).
+    #[test]
+    fn missing_num_hidden_layers_is_hard_error() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "config.json",
+            r#"{"model_type":"llama","hidden_size":4096,"num_attention_heads":32}"#,
+        );
+        let err = ModelConfig::load(dir.path(), &empty_weights())
+            .expect_err("missing num_hidden_layers must fail");
+        assert!(
+            err.to_string().contains("num_hidden_layers"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// #315: the silent magic-number default for hidden_size is gone.
+    #[test]
+    fn missing_hidden_size_is_hard_error() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "config.json",
+            r#"{"model_type":"llama","num_hidden_layers":32,"num_attention_heads":32}"#,
+        );
+        let err = ModelConfig::load(dir.path(), &empty_weights())
+            .expect_err("missing hidden_size must fail");
+        assert!(err.to_string().contains("hidden_size"), "unexpected error: {err}");
+    }
+
+    /// #315: num_hidden_layers must match the shard manifest's weight_map.
+    #[test]
+    fn index_layer_count_mismatch_is_hard_error() {
+        let dir = tempfile::tempdir().unwrap();
+        // config says 4 layers...
+        write(dir.path(), "config.json", &valid_config_json(4));
+        // ...but the manifest only has weights for layers 0,1,2 (3 layers).
+        write(
+            dir.path(),
+            "model.safetensors.index.json",
+            r#"{"weight_map":{
+                "model.layers.0.self_attn.q_proj.weight":"model-00001-of-00002.safetensors",
+                "model.layers.1.self_attn.q_proj.weight":"model-00001-of-00002.safetensors",
+                "model.layers.2.self_attn.q_proj.weight":"model-00002-of-00002.safetensors",
+                "model.embed_tokens.weight":"model-00001-of-00002.safetensors"
+            }}"#,
+        );
+        let err = ModelConfig::load(dir.path(), &empty_weights())
+            .expect_err("layer-count mismatch must fail");
+        assert!(
+            err.to_string().contains("num_hidden_layers mismatch"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// Happy path: config and manifest agree on layer count → loads cleanly.
+    #[test]
+    fn index_layer_count_match_loads() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "config.json", &valid_config_json(3));
+        write(
+            dir.path(),
+            "model.safetensors.index.json",
+            r#"{"weight_map":{
+                "model.layers.0.self_attn.q_proj.weight":"model-00001-of-00002.safetensors",
+                "model.layers.1.self_attn.q_proj.weight":"model-00001-of-00002.safetensors",
+                "model.layers.2.self_attn.q_proj.weight":"model-00002-of-00002.safetensors"
+            }}"#,
+        );
+        let cfg = ModelConfig::load(dir.path(), &empty_weights())
+            .expect("matching layer counts must load");
+        assert_eq!(cfg.num_hidden_layers, 3);
+    }
+
+    /// A zero architectural dimension is rejected (avoids div-by-zero / corruption).
+    #[test]
+    fn zero_dimension_is_hard_error() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "config.json",
+            r#"{"model_type":"llama","hidden_size":4096,"num_hidden_layers":0,"num_attention_heads":32}"#,
+        );
+        let err =
+            ModelConfig::load(dir.path(), &empty_weights()).expect_err("zero dimension must fail");
+        assert!(err.to_string().contains("zero dimension"), "unexpected error: {err}");
     }
 }

--- a/crates/hyprstream/src/runtime/model_factory.rs
+++ b/crates/hyprstream/src/runtime/model_factory.rs
@@ -7,13 +7,65 @@ use anyhow::{anyhow, Result};
 use std::collections::HashMap;
 use std::path::Path;
 use tch::{Device, Kind as DType, Tensor};
-use tracing::{debug, info, instrument};
+use tracing::{debug, info, instrument, warn};
 
 use super::architectures::{gemma::GemmaModel, llama::LlamaModel, ModelOperations};
 use super::KVQuantType;
 use super::model_config::{ModelArchitecture, ModelConfig};
 use super::torch_utils::{safe_to_device, estimate_tensor_size_mb};
 use crate::services::WorktreeClient;
+
+/// Strict-loader opt-in (#315): when set truthy, multi-shard models that lack a
+/// `model.safetensors.index.json` manifest are rejected instead of silently
+/// reconstructing the shard set from a filename glob (which is fragile across
+/// model families and can silently drop/duplicate shards).
+const STRICT_LOADER_ENV: &str = "HYPRSTREAM_STRICT_LOADER";
+
+fn strict_loader_enabled() -> bool {
+    std::env::var(STRICT_LOADER_ENV)
+        .map(|v| matches!(v.trim().to_lowercase().as_str(), "1" | "true" | "yes" | "on"))
+        .unwrap_or(false)
+}
+
+/// Glob-fallback shard discovery, shared by the sync/async loader paths.
+///
+/// Loud by design (#315): a multi-shard model reached via glob (no index.json) is
+/// a silent-degrade path — it warns, and under [`STRICT_LOADER_ENV`] it is a hard
+/// error. A single globbed shard is unambiguous and passes quietly.
+fn glob_shard_files(model_path: &Path) -> Result<Vec<std::path::PathBuf>> {
+    let mut shard_files = Vec::new();
+    for entry in std::fs::read_dir(model_path)? {
+        let entry = entry?;
+        if let Some(name) = entry.file_name().to_str() {
+            if (name.starts_with("model-") || name.starts_with("model.safetensors-"))
+                && name.ends_with(".safetensors")
+            {
+                shard_files.push(entry.path());
+            }
+        }
+    }
+    shard_files.sort();
+
+    if shard_files.len() > 1 {
+        if strict_loader_enabled() {
+            return Err(anyhow!(
+                "{} multi-shard safetensors files found in {} but no \
+                 model.safetensors.index.json manifest; refusing to reconstruct the \
+                 shard set from a filename glob under {STRICT_LOADER_ENV}. \
+                 Provide the index.json manifest.",
+                shard_files.len(),
+                model_path.display()
+            ));
+        }
+        warn!(
+            "⚠️ No model.safetensors.index.json in {}; reconstructing {} shards from a \
+             filename glob (fragile). Set {STRICT_LOADER_ENV}=1 to require the manifest.",
+            model_path.display(),
+            shard_files.len()
+        );
+    }
+    Ok(shard_files)
+}
 
 /// Factory for creating models with proper configuration management
 pub struct ModelFactory;
@@ -135,20 +187,8 @@ impl ModelFactory {
             return Ok(vec![single_file]);
         }
 
-        // 3. Fallback: glob for known shard naming patterns
-        let mut shard_files = Vec::new();
-        for entry in std::fs::read_dir(model_path)? {
-            let entry = entry?;
-            if let Some(name) = entry.file_name().to_str() {
-                if (name.starts_with("model-") || name.starts_with("model.safetensors-"))
-                    && name.ends_with(".safetensors")
-                {
-                    shard_files.push(entry.path());
-                }
-            }
-        }
-        shard_files.sort();
-        Ok(shard_files)
+        // 3. Fallback: glob for known shard naming patterns (loud / strict-gated)
+        glob_shard_files(model_path)
     }
 
     /// Parse shard filenames from `model.safetensors.index.json`.
@@ -245,20 +285,8 @@ impl ModelFactory {
                 if index_path.exists() {
                     return Self::shard_files_from_index(&model_path_buf, &index_path);
                 }
-                // Fallback glob
-                let mut files = Vec::new();
-                for entry in std::fs::read_dir(&model_path_buf)? {
-                    let entry = entry?;
-                    if let Some(name) = entry.file_name().to_str() {
-                        if (name.starts_with("model-") || name.starts_with("model.safetensors-"))
-                            && name.ends_with(".safetensors")
-                        {
-                            files.push(entry.path());
-                        }
-                    }
-                }
-                files.sort();
-                Ok(files)
+                // Fallback glob (loud / strict-gated)
+                glob_shard_files(&model_path_buf)
             })
             .await??;
 
@@ -285,10 +313,16 @@ impl ModelFactory {
         device: &Device,
         dtype: DType,
     ) -> Result<()> {
-        // Check if mmap is enabled via environment variable
+        // Check if mmap is enabled via environment variable.
+        //
+        // #315 note: mmap is an opt-in *optimization* selected solely by this env
+        // var (it is independent of `RuntimeConfig.mmap`, which today gates nothing
+        // here). It is not a correctness fallback — both paths deserialize the same
+        // tensors — so it is left as-is, but logged so the chosen path is explicit.
         let use_mmap = std::env::var("HYPRSTREAM_USE_MMAP")
             .map(|v| v.to_lowercase() == "true" || v == "1")
             .unwrap_or(false);
+        debug!("safetensors load path: {}", if use_mmap { "mmap" } else { "read" });
 
         // Load file data in a blocking task to avoid blocking the async runtime
         let path_buf = path.to_path_buf();

--- a/crates/hyprstream/src/runtime/torch_engine.rs
+++ b/crates/hyprstream/src/runtime/torch_engine.rs
@@ -341,14 +341,25 @@ impl TorchEngine {
         let device = if config.use_gpu {
             // Use specified GPU device ID, or auto-detect
             let gpu_device = if let Some(device_id) = config.gpu_device_id {
-                // Check if CUDA/ROCm is available at all
+                // A GPU was *explicitly* requested. Check if CUDA/ROCm is available.
                 if Device::cuda_if_available() != Device::Cpu {
                     Device::Cuda(device_id)
+                } else if config.strict_device {
+                    // No-fragile-fallbacks (#315): a process told to use GPU N that
+                    // silently lands on CPU tanks the pipeline. Fail fast instead.
+                    return Err(anyhow!(
+                        "GPU {device_id} explicitly requested but CUDA/ROCm is not available; \
+                         refusing to silently fall back to CPU (strict_device). \
+                         Set HYPRSTREAM_STRICT_DEVICE=0 to allow CPU fallback."
+                    ));
                 } else {
                     info!("⚠️  GPU {} requested but CUDA/ROCm not available, falling back to CPU", device_id);
                     Device::Cpu
                 }
             } else {
+                // Pure auto-detect ("use a GPU if there is one"): CPU fallback is
+                // the intended behavior here even under strict_device, since no
+                // specific device was requested.
                 Device::cuda_if_available()
             };
 


### PR DESCRIPTION
Part of #310. Implements #315 (rust M2; user mandate). Plan: `docs/plans/2026-06-18-multi-gpu-multi-host-inference-spike.md` (§ No-fragile-fallbacks sweep).

Extends #313's no-silent-fallback principle from the device-pool path to the **loader / model-config** path. A wrong layer count or a GPU request that silently lands on CPU silently corrupts a pipeline split — so this fails **loudly** on malformed/missing metadata instead. Does **not** touch any capnp schema, RPC surface, or auth/authz/policy code.

## What was hardened

### `runtime/model_config.rs`
- **config.json required (fail-fast).** Missing `config.json` is now a hard error (`config.json is required ...`). The fragile weight-name-scan heuristic (`detect_from_weights`/`count_layers`) is no longer on the default path — it is gated behind the explicit opt-in `HYPRSTREAM_ALLOW_WEIGHT_DETECT=1` escape hatch.
- **Killed silent magic-number defaults.** `num_hidden_layers.unwrap_or(32)`, `hidden_size.unwrap_or(4096)`, and `num_attention_heads.unwrap_or(32)` are gone — when `config.json` is present, these are **mandatory** and a missing/unparseable value is a hard error. Zero dimensions are also rejected (avoids div-by-zero in derived `head_dim`). `num_key_value_heads` (defaults to attention heads = MHA) and `head_dim` (derived from `hidden_size / heads`) remain legitimately optional.
- **index.json cross-validation.** When `model.safetensors.index.json` is present, the count of distinct `*.layers.<i>.` indices in `weight_map` must equal `num_hidden_layers`; mismatch is a hard error.

### `runtime/torch_engine.rs`
- **`strict_device` fail-fast.** A GPU that was *explicitly* requested (`gpu_device_id`/`devices`) but is unavailable now errors instead of silently downgrading to CPU. Pure auto-detect (`use_gpu` with no device requested) still falls back to CPU, so legacy single-GPU "use a GPU if there is one" behavior is unchanged. (The `DevicePool` explicit-multi-GPU path from #313 already fails fast.)

### `config/mod.rs`
- Added `RuntimeConfig.strict_device`.

### `runtime/model_factory.rs`
- The index→glob shard-discovery fallback for **multi-shard** models is now **loud** (`warn!`) and a hard error under `HYPRSTREAM_STRICT_LOADER=1`. A single globbed shard stays quiet (unambiguous). Shared via one `glob_shard_files` helper (DRY across the sync/async loader paths).
- mmap path documented as an opt-in *optimization* (both paths deserialize identical tensors — not a correctness fallback) and left as-is to avoid changing behavior; logs the chosen path.

## strict_device default decision
**`strict_device` defaults to `true`** per the plan ("strictness is the safe default for the multi-GPU path"). Override with `HYPRSTREAM_STRICT_DEVICE=0`. This only bites when a GPU was *explicitly* requested; auto-detect is untouched — so the happy path for single-GPU/CPU users is preserved.

## Happy-path-preserving escape hatches
- `HYPRSTREAM_ALLOW_WEIGHT_DETECT=1` — re-enable the legacy weight-name heuristic for checkpoints with no `config.json`.
- `HYPRSTREAM_STRICT_LOADER` — opt **in** to rejecting index-less multi-shard models (default: warn).
- `HYPRSTREAM_STRICT_DEVICE=0` — opt out of device strictness.

Models shipping a proper `config.json` (+ `index.json`) load with **unchanged** behavior; no currently-valid model is rejected.

## Verified (libtorch)
- `cargo build -p hyprstream` — OK
- `cargo test -p hyprstream` (model_config:: + config::) — **29 passed, 0 failed** (7 new model_config tests + strict_device test)
- `cargo clippy -p hyprstream --all-targets -D warnings` — clean

Part of #310.