### PR TITLE
feat: 2b intra-host pipeline — per-layer device_map + stage-aware load (#314)

### DIFF
--- a/crates/hyprstream/src/runtime/architectures/llama.rs
+++ b/crates/hyprstream/src/runtime/architectures/llama.rs
@@ -2,6 +2,7 @@
 
 use super::{ArchitectureConfig, ModelArchitecture, ModelOperations};
 // use super::lora_adapter::ArchitectureAwareLoRAAdapter; // Module removed
+use crate::runtime::device_pool::LayerDeviceMap;
 use crate::runtime::rope::RoPE;
 use crate::runtime::tensor_helpers::{
     broadcast_add, broadcast_mul, dims3, dims4, scalar_tensor, square_tensor,
@@ -42,6 +43,17 @@ impl LinearProjection {
     #[inline]
     pub(crate) fn with_scale(weight: Tensor, scale: Tensor) -> Self {
         Self { weight, bias: None, scale: Some(scale) }
+    }
+
+    /// Move all owned tensors to `device` (no-op per tensor already there).
+    /// Used by the 2b pipeline to place a layer on its mapped device (#314).
+    #[inline]
+    pub(crate) fn into_device(self, device: Device) -> Self {
+        Self {
+            weight: self.weight.to_device(device),
+            bias: self.bias.map(|b| b.to_device(device)),
+            scale: self.scale.map(|s| s.to_device(device)),
+        }
     }
 
     /// Apply projection to input: output = input @ weight + bias
@@ -333,6 +345,20 @@ pub struct LlamaModel {
     #[allow(dead_code)]
     dtype: DType,
 
+    /// Per-global-layer device assignment (#314, 2b pipeline). For the unsplit
+    /// fast path this is a single-device map of length `num_hidden_layers`
+    /// (`is_single_device() == true`); for a pipeline shard it is the *global*
+    /// map (still length `num_hidden_layers`) and `layer_offset` selects the
+    /// owned window. Drives both per-layer placement at construction and the lone
+    /// boundary `to_device` in `forward_layers`.
+    device_map: LayerDeviceMap,
+
+    /// Global index of `self.layers[0]`. `0` for a whole model; `a` for a shard
+    /// owning global layers `[a..a+self.layers.len())`. The single place a global
+    /// index is needed at runtime is mapping a local KV-cache slot / device
+    /// lookup back to its global layer.
+    layer_offset: usize,
+
     // Model weights
     embed_tokens: Option<Tensor>,
     layers: Vec<LlamaLayer>,
@@ -366,6 +392,20 @@ struct LlamaLayer {
 unsafe impl Send for LlamaLayer {}
 unsafe impl Sync for LlamaLayer {}
 
+impl LlamaLayer {
+    /// Move every weight in this layer to `device` (#314 pipeline placement).
+    /// A no-op per tensor already resident on `device`.
+    #[inline]
+    fn into_device(self, device: Device) -> Self {
+        Self {
+            self_attn: self.self_attn.into_device(device),
+            mlp: self.mlp.into_device(device),
+            input_layernorm: self.input_layernorm.into_device(device),
+            post_attention_layernorm: self.post_attention_layernorm.into_device(device),
+        }
+    }
+}
+
 /// Llama attention with optional GQA support
 struct LlamaAttention {
     q_proj: LinearProjection,
@@ -393,6 +433,20 @@ unsafe impl Send for LlamaAttention {}
 unsafe impl Sync for LlamaAttention {}
 
 impl LlamaAttention {
+    /// Move all projection + QK-norm weights to `device` (#314 pipeline placement).
+    #[inline]
+    fn into_device(self, device: Device) -> Self {
+        Self {
+            q_proj: self.q_proj.into_device(device),
+            k_proj: self.k_proj.into_device(device),
+            v_proj: self.v_proj.into_device(device),
+            o_proj: self.o_proj.into_device(device),
+            q_norm: self.q_norm.map(|t| t.to_device(device)),
+            k_norm: self.k_norm.map(|t| t.to_device(device)),
+            ..self
+        }
+    }
+
     /// Apply attention with optional GQA, KV caching, and delta injection
     fn forward(
         &self,
@@ -864,6 +918,18 @@ unsafe impl Send for LlamaMLP {}
 unsafe impl Sync for LlamaMLP {}
 
 impl LlamaMLP {
+    /// Move all projection weights to `device` (#314 pipeline placement).
+    #[inline]
+    fn into_device(self, device: Device) -> Self {
+        Self {
+            gate_proj: self.gate_proj.into_device(device),
+            up_proj: self.up_proj.into_device(device),
+            down_proj: self.down_proj.into_device(device),
+            activation: self.activation,
+            layer_idx: self.layer_idx,
+        }
+    }
+
     pub(crate) fn forward(
         &self,
         hidden_states: &Tensor,
@@ -1016,6 +1082,14 @@ unsafe impl Send for RMSNorm {}
 unsafe impl Sync for RMSNorm {}
 
 impl RMSNorm {
+    /// Move the norm weight to `device` (#314 pipeline placement).
+    #[inline]
+    fn into_device(self, device: Device) -> Self {
+        Self { weight: self.weight.to_device(device), eps: self.eps }
+    }
+}
+
+impl RMSNorm {
     pub(crate) fn forward(&self, x: &Tensor) -> Result<Tensor> {
         // Compute RMS, preserving the original dtype
         let original_dtype = x.kind();
@@ -1047,10 +1121,16 @@ impl LlamaModel {
         // Load weights from SafeTensors (simplified)
         let layers = Vec::new();
 
+        // Whole-model single-device map (this simplified path has no layers yet;
+        // size the map to the declared depth so the invariant holds).
+        let device_map = LayerDeviceMap::single(*device, (config.num_hidden_layers as usize).max(1))?;
+
         Ok(Self {
             config,
             device: *device,
             dtype,
+            device_map,
+            layer_offset: 0,
             embed_tokens: None,
             layers,
             norm: None,
@@ -1223,10 +1303,17 @@ impl LlamaModel {
             None
         };
 
+        // Unsplit fast path: every layer on the one device. This keeps the
+        // whole-model forward byte-identical — `forward_layers` over this
+        // single-device map performs zero cross-device copies (#314).
+        let device_map = LayerDeviceMap::single(*device, layers.len().max(1))?;
+
         Ok(Self {
             config,
             device: *device,
             dtype,
+            device_map,
+            layer_offset: 0,
             embed_tokens,
             layers,
             norm,
@@ -1235,6 +1322,182 @@ impl LlamaModel {
             kv_cache,
             vs: None, // No VarStore for weight loading - weights are stored directly
         })
+    }
+
+    /// Build a **single pipeline stage** of a Llama model (#314, 2b layer-split).
+    ///
+    /// Loads only global decoder layers `[layer_range.start..layer_range.end)`
+    /// onto their mapped devices (`devices.device_for(g)`), and gates the
+    /// non-layer weights by stage position so middle stages carry none (M-LOAD
+    /// seam #1):
+    /// - `is_first` (`layer_range.start == 0`)  → keep `embed_tokens`.
+    /// - `is_last`  (`layer_range.end == devices.len()`) → keep `norm` + `lm_head`
+    ///   (or the tied transpose).
+    ///
+    /// `weights` must already contain (at least) this stage's tensors; the loader
+    /// is responsible for shard selection (a later ticket). Tensors not on the
+    /// target device are moved with a single `.to()` at construction — the *only*
+    /// placement cost; the forward path then does zero intra-stage copies.
+    ///
+    /// State sizing follows the **owned** layer count, not the global count
+    /// (M-LOAD seam #2): the KV-cache manager and `self.layers` are both sized to
+    /// `layer_range.len()`, and the forward loop indexes them locally.
+    #[allow(clippy::too_many_arguments)]
+    pub fn stage_from_weights_with_config(
+        weights: &mut HashMap<String, Tensor>,
+        mut config: LlamaConfig,
+        devices: &LayerDeviceMap,
+        layer_range: std::ops::Range<usize>,
+        dtype: DType,
+        kv_quant_type: crate::runtime::KVQuantType,
+    ) -> Result<Self> {
+        let num_global = config.num_hidden_layers as usize;
+        if devices.len() != num_global {
+            return Err(anyhow!(
+                "stage_from_weights: device map covers {} layers but config has {} \
+                 (num_hidden_layers)",
+                devices.len(),
+                num_global
+            ));
+        }
+        if layer_range.end > num_global || layer_range.start >= layer_range.end {
+            return Err(anyhow!(
+                "stage_from_weights: invalid layer range {:?} for {} layers",
+                layer_range,
+                num_global
+            ));
+        }
+
+        let is_first = layer_range.start == 0;
+        let is_last = layer_range.end == num_global;
+        let layer_offset = layer_range.start;
+        // Stage device = device of this stage's first owned layer (its inputs and
+        // KV cache live here). `embed_tokens`, when present, lives on the first
+        // stage's first device, which is exactly this when is_first.
+        let stage_device = devices.device_for(layer_range.start);
+
+        // --- Non-layer weights, gated by stage position (M-LOAD seam #1) ---
+        let original_vocab_size = config.vocab_size;
+        let padded_vocab_size = calculate_padded_vocab_size(original_vocab_size);
+        config.original_vocab_size = original_vocab_size;
+        if padded_vocab_size != original_vocab_size {
+            config.vocab_size = padded_vocab_size;
+        }
+
+        let embed_tokens = if is_first {
+            let embed = weights
+                .get("model.embed_tokens.weight")
+                .or_else(|| weights.get("embed_tokens.weight"))
+                .map(|w| Self::pad_embedding_to(w, padded_vocab_size, stage_device))
+                .ok_or_else(|| {
+                    anyhow!("stage_from_weights: first stage requires model.embed_tokens.weight")
+                })?;
+            Some(embed)
+        } else {
+            None
+        };
+
+        let (lm_head, norm) = if is_last {
+            let lm_head = weights
+                .get("lm_head.weight")
+                .or_else(|| weights.get("model.lm_head.weight"))
+                .map(|w| {
+                    Self::pad_embedding_to(w, padded_vocab_size, stage_device)
+                        .transpose(0, 1)
+                        .contiguous()
+                });
+            let norm = weights
+                .get("model.norm.weight")
+                .or_else(|| weights.get("norm.weight"))
+                .map(|w| RMSNorm {
+                    weight: w.shallow_clone().to_device(stage_device),
+                    eps: config.rms_norm_eps,
+                });
+            if norm.is_none() {
+                return Err(anyhow!(
+                    "stage_from_weights: last stage requires model.norm.weight"
+                ));
+            }
+            (lm_head, norm)
+        } else {
+            (None, None)
+        };
+
+        // Tied lm_head: only meaningful on the last stage, and only if it also
+        // holds embed_tokens (single-stage model). A middle/last stage that does
+        // not own the embedding cannot tie — it must ship an explicit lm_head.
+        let lm_head_transposed = if is_last && lm_head.is_none() {
+            embed_tokens
+                .as_ref()
+                .map(|embed| embed.transpose(0, 1).contiguous())
+        } else {
+            None
+        };
+        if is_last && lm_head.is_none() && lm_head_transposed.is_none() {
+            return Err(anyhow!(
+                "stage_from_weights: last stage requires lm_head.weight (no tied embedding present)"
+            ));
+        }
+
+        // --- Owned decoder layers, each on its mapped device (per-layer .to) ---
+        let mut layers = Vec::with_capacity(layer_range.len());
+        for g in layer_range.clone() {
+            let target = devices.device_for(g);
+            match Self::build_layer(g, weights, &config, &target)? {
+                Some(layer) => layers.push(layer.into_device(target)),
+                None => {
+                    return Err(anyhow!(
+                        "stage_from_weights: expected weights for global layer {g} but none found"
+                    ))
+                }
+            }
+        }
+
+        // KV cache sized to the OWNED layer count (M-LOAD seam #2); indexed
+        // locally in the forward loop. Lives on the stage device.
+        let kv_cache = if layers.is_empty() {
+            None
+        } else {
+            Some(std::sync::Arc::new(parking_lot::Mutex::new(
+                crate::runtime::kv_cache::KVCacheManager::new(
+                    layers.len(),
+                    config.max_position_embeddings as usize,
+                    kv_quant_type,
+                ),
+            )))
+        };
+
+        let device_map = devices.clone();
+
+        Ok(Self {
+            config,
+            device: stage_device,
+            dtype,
+            device_map,
+            layer_offset,
+            embed_tokens,
+            layers,
+            norm,
+            lm_head,
+            lm_head_transposed,
+            kv_cache,
+            vs: None,
+        })
+    }
+
+    /// Pad an embedding/lm_head weight `[vocab, hidden]` up to `padded_vocab` (a
+    /// no-op shallow clone when already large enough) and place it on `device`.
+    fn pad_embedding_to(w: &Tensor, padded_vocab: u32, device: Device) -> Tensor {
+        let vocab_size = w.size()[0] as u32;
+        let hidden_size = w.size()[1];
+        let placed = if padded_vocab > vocab_size {
+            let padded = Tensor::zeros([padded_vocab as i64, hidden_size], (w.kind(), w.device()));
+            padded.narrow(0, 0, vocab_size as i64).copy_(w);
+            padded
+        } else {
+            w.shallow_clone()
+        };
+        placed.to_device(device)
     }
 
     /// Detect configuration from weight tensor shapes
@@ -1565,6 +1828,28 @@ impl LlamaModel {
     pub fn parse_config(json_str: &str) -> Result<LlamaConfig> {
         let json: serde_json::Value = serde_json::from_str(json_str)?;
 
+        // Mandatory architectural dimensions — never silently defaulted (mirrors
+        // #315's no-magic-number hardening in model_config.rs). A wrong layer or
+        // head count silently truncates / mis-shapes a pipeline split (#314).
+        let require_u64 = |field: &str| -> Result<u64> {
+            json[field].as_u64().ok_or_else(|| {
+                anyhow!(
+                    "config.json is missing required field `{field}` \
+                     (or it is not a non-negative integer)"
+                )
+            })
+        };
+        let num_attention_heads = require_u64("num_attention_heads")? as u32;
+        let hidden_size = require_u64("hidden_size")? as u32;
+        let num_hidden_layers = require_u64("num_hidden_layers")? as u32;
+        if num_attention_heads == 0 || hidden_size == 0 || num_hidden_layers == 0 {
+            return Err(anyhow!(
+                "config.json has a zero architectural dimension \
+                 (num_attention_heads={num_attention_heads}, hidden_size={hidden_size}, \
+                 num_hidden_layers={num_hidden_layers})"
+            ));
+        }
+
         // Detect version from config
         let version = if json.get("rope_scaling").is_some() {
             3
@@ -1576,27 +1861,24 @@ impl LlamaModel {
 
         let mut config = LlamaConfig {
             version,
-            num_attention_heads: json["num_attention_heads"].as_u64().unwrap_or(32) as u32,
+            num_attention_heads,
+            // num_key_value_heads legitimately defaults to num_attention_heads
+            // (MHA) when absent — an HF-spec optional field, not a magic number.
             num_key_value_heads: json
                 .get("num_key_value_heads")
                 .and_then(serde_json::Value::as_u64)
-                .unwrap_or_else(|| json["num_attention_heads"].as_u64().unwrap_or(32))
-                as u32,
-            hidden_size: json["hidden_size"].as_u64().unwrap_or(4096) as u32,
+                .map(|v| v as u32)
+                .unwrap_or(num_attention_heads),
+            hidden_size,
             head_dim: json
                 .get("head_dim")
                 .and_then(serde_json::Value::as_u64)
                 .map(|v| v as u32)
                 .unwrap_or_else(|| {
-                    // If head_dim not specified, calculate from hidden_size / num_attention_heads
-                    let heads = json
-                        .get("num_attention_heads")
-                        .and_then(serde_json::Value::as_u64)
-                        .unwrap_or(32) as u32;
-                    let hidden = json
-                        .get("hidden_size")
-                        .and_then(serde_json::Value::as_u64)
-                        .unwrap_or(4096) as u32;
+                    // head_dim is optional in HF configs; derive it from the now-
+                    // mandatory hidden_size / num_attention_heads.
+                    let heads = num_attention_heads;
+                    let hidden = hidden_size;
                     // Common head_dim values are 64, 128, 256
                     if hidden.is_multiple_of(heads * 256) {
                         256
@@ -1614,7 +1896,7 @@ impl LlamaModel {
             rms_norm_eps: json["rms_norm_eps"].as_f64().unwrap_or(1e-5) as f32,
             vocab_size: json["vocab_size"].as_u64().unwrap_or(32000) as u32,
             original_vocab_size: json["vocab_size"].as_u64().unwrap_or(32000) as u32,  // Initially same
-            num_hidden_layers: json["num_hidden_layers"].as_u64().unwrap_or(32) as u32,
+            num_hidden_layers,
             rope_theta: json
                 .get("rope_theta")
                 .and_then(serde_json::Value::as_f64)
@@ -1839,6 +2121,102 @@ impl LlamaModel {
                     }
                 }
             }
+        }
+
+        Ok(hidden_states)
+    }
+
+    /// Run global decoder layers `[range.start..range.end)` — the 2b pipeline
+    /// layer-range runner (#314). See the trait docs for the stage contract.
+    ///
+    /// Layers are remapped to local `self.layers` indices via `layer_offset`; the
+    /// per-layer KV cache is indexed locally (sized to the owned count). The lone
+    /// cross-device copy is `hidden.to_device(next)`, inserted only when the next
+    /// layer's mapped device differs from where `hidden` currently lives — never
+    /// within a stage, never when source == dest (the unsplit map is a no-op).
+    fn forward_layers_inner(
+        &self,
+        hidden: &Tensor,
+        range: std::ops::Range<usize>,
+        start_pos: usize,
+        delta: Option<&crate::training::TenantDelta>,
+    ) -> Result<Tensor> {
+        let num_global = self.config.num_hidden_layers as usize;
+        if range.end > num_global || range.start >= range.end {
+            return Err(anyhow!(
+                "forward_layers: invalid global range {range:?} for {num_global} layers"
+            ));
+        }
+        // The owned window must contain the requested range.
+        let owned = self.layer_offset..self.layer_offset + self.layers.len();
+        if range.start < owned.start || range.end > owned.end {
+            return Err(anyhow!(
+                "forward_layers: range {range:?} not within this stage's owned layers {owned:?}"
+            ));
+        }
+
+        let mut hidden_states = hidden.shallow_clone();
+
+        // position_ids recomputed from start_pos + seq (never carried across a
+        // boundary). Built on the *input* device (the first owned layer's), so a
+        // moved first layer still matches at SDPA.
+        let seq_len = hidden_states.size()[1];
+        let position_ids = if start_pos == 0 {
+            Tensor::arange(seq_len, (tch::Kind::Int64, hidden_states.device()))
+        } else {
+            Tensor::arange_start(
+                start_pos as i64,
+                (start_pos + seq_len as usize) as i64,
+                (tch::Kind::Int64, hidden_states.device()),
+            )
+        };
+        // position_ids must follow `hidden` across device boundaries; track it.
+        let mut position_ids = position_ids;
+
+        let cache_guard = self.kv_cache.as_ref().map(|cache_ref| cache_ref.lock());
+
+        for g in range {
+            let local_idx = g - self.layer_offset;
+            let layer = &self.layers[local_idx];
+
+            // The single cross-device transfer: only when this layer's device
+            // differs from where `hidden` currently is (zero-copy otherwise).
+            let target = self.device_map.device_for(g);
+            if hidden_states.device() != target {
+                hidden_states = hidden_states.to_device(target);
+                position_ids = position_ids.to_device(target);
+            }
+
+            let residual = hidden_states.shallow_clone();
+            hidden_states = layer.input_layernorm.forward(&hidden_states)?;
+
+            let attn_output = if let Some(ref cache_manager) = cache_guard {
+                if let Some(result) = cache_manager.with_layer_cache(local_idx, |layer_cache| {
+                    layer.self_attn.forward(
+                        &hidden_states,
+                        Some(&position_ids),
+                        Some(layer_cache),
+                        start_pos,
+                        delta,
+                    )
+                }) {
+                    result?
+                } else {
+                    layer
+                        .self_attn
+                        .forward(&hidden_states, Some(&position_ids), None, start_pos, delta)?
+                }
+            } else {
+                layer
+                    .self_attn
+                    .forward(&hidden_states, Some(&position_ids), None, start_pos, delta)?
+            };
+            hidden_states = residual + attn_output;
+
+            let residual = hidden_states.shallow_clone();
+            hidden_states = layer.post_attention_layernorm.forward(&hidden_states)?;
+            let ffn_output = layer.mlp.forward(&hidden_states, delta)?;
+            hidden_states = residual + ffn_output;
         }
 
         Ok(hidden_states)
@@ -2153,6 +2531,16 @@ impl ModelOperations for LlamaModel {
         Ok((hidden_states, None))
     }
 
+    fn forward_layers(
+        &self,
+        hidden: &Tensor,
+        range: std::ops::Range<usize>,
+        start_pos: usize,
+        delta: Option<&crate::training::TenantDelta>,
+    ) -> Result<Tensor> {
+        self.forward_layers_inner(hidden, range, start_pos, delta)
+    }
+
     fn apply_final_norm(&self, hidden_states: &Tensor) -> Result<Tensor> {
         if let Some(norm) = &self.norm {
             norm.forward(hidden_states)
@@ -2264,3 +2652,231 @@ impl ModelOperations for LlamaModel {
 }
 
 // KV cache methods are now defined in the ModelOperations trait implementation above
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod pipeline_tests {
+    use super::*;
+    use crate::runtime::device_pool::LayerDeviceMap;
+    use crate::runtime::KVQuantType;
+
+    const HIDDEN: i64 = 16;
+    const HEADS: i64 = 2;
+    const HEAD_DIM: i64 = 8; // HEADS * HEAD_DIM == HIDDEN
+    const INTER: i64 = 32;
+    const VOCAB: i64 = 48; // multiple of 64? no → padded to 64; both paths pad identically
+    const LAYERS: usize = 4;
+
+    fn tiny_config() -> LlamaConfig {
+        LlamaConfig {
+            version: 2,
+            num_attention_heads: HEADS as u32,
+            num_key_value_heads: HEADS as u32,
+            hidden_size: HIDDEN as u32,
+            head_dim: HEAD_DIM as u32,
+            intermediate_size: INTER as u32,
+            max_position_embeddings: 64,
+            rms_norm_eps: 1e-5,
+            vocab_size: VOCAB as u32,
+            original_vocab_size: VOCAB as u32,
+            num_hidden_layers: LAYERS as u32,
+            rope_theta: 10000.0,
+            rope_scaling: None,
+            hidden_activation: "silu".to_owned(),
+            query_pre_attn_scalar: None,
+            use_qk_norm: false,
+            scale_embeddings: false,
+            layer_types: vec![],
+            rope_local_base_freq: None,
+        }
+    }
+
+    /// Deterministic small weight set on CPU/f32 so the two construction paths are
+    /// numerically comparable. HF stores projections as `[out, in]`.
+    ///
+    /// Uses a fixed, RNG-free pattern (a bounded sin of the flat index) rather
+    /// than `Tensor::randn`: tests run in parallel and `manual_seed` is global, so
+    /// two `randn`-based builds could interleave and diverge. This makes every
+    /// call byte-identical regardless of scheduling.
+    fn tiny_weights() -> HashMap<String, Tensor> {
+        let opt = (DType::Float, Device::Cpu);
+        let mut w = HashMap::new();
+        let randn = |dims: &[i64]| {
+            let n: i64 = dims.iter().product();
+            // Deterministic small values in roughly [-0.05, 0.05].
+            (Tensor::arange(n, opt) * 0.017).sin().reshape(dims) * 0.05
+        };
+
+        w.insert("model.embed_tokens.weight".to_owned(), randn(&[VOCAB, HIDDEN]));
+        w.insert("model.norm.weight".to_owned(), Tensor::ones([HIDDEN], opt));
+        w.insert("lm_head.weight".to_owned(), randn(&[VOCAB, HIDDEN]));
+
+        for i in 0..LAYERS {
+            let p = format!("model.layers.{i}");
+            // attention projections: q/k/v are [heads*head_dim, hidden]; o is [hidden, heads*head_dim]
+            w.insert(format!("{p}.self_attn.q_proj.weight"), randn(&[HEADS * HEAD_DIM, HIDDEN]));
+            w.insert(format!("{p}.self_attn.k_proj.weight"), randn(&[HEADS * HEAD_DIM, HIDDEN]));
+            w.insert(format!("{p}.self_attn.v_proj.weight"), randn(&[HEADS * HEAD_DIM, HIDDEN]));
+            w.insert(format!("{p}.self_attn.o_proj.weight"), randn(&[HIDDEN, HEADS * HEAD_DIM]));
+            // mlp
+            w.insert(format!("{p}.mlp.gate_proj.weight"), randn(&[INTER, HIDDEN]));
+            w.insert(format!("{p}.mlp.up_proj.weight"), randn(&[INTER, HIDDEN]));
+            w.insert(format!("{p}.mlp.down_proj.weight"), randn(&[HIDDEN, INTER]));
+            // norms
+            w.insert(format!("{p}.input_layernorm.weight"), Tensor::ones([HIDDEN], opt));
+            w.insert(format!("{p}.post_attention_layernorm.weight"), Tensor::ones([HIDDEN], opt));
+        }
+        w
+    }
+
+    fn whole_model() -> LlamaModel {
+        let mut w = tiny_weights();
+        LlamaModel::from_weights_with_config(&mut w, tiny_config(), &Device::Cpu, DType::Float, KVQuantType::None)
+            .unwrap()
+    }
+
+    /// Orchestrate the pipeline path on a model the way an engine would:
+    /// embed → forward_layers(0..N) → final norm → lm_head.
+    fn orchestrated_logits(m: &LlamaModel, input: &Tensor) -> Tensor {
+        let emb = m.embed_tokens(input).unwrap();
+        let h = m.forward_layers(&emb, 0..m.num_layers(), 0, None).unwrap();
+        let h = m.apply_final_norm(&h).unwrap();
+        m.lm_head(&h).unwrap()
+    }
+
+    #[test]
+    fn forward_layers_full_range_matches_whole_model_forward() {
+        // An all-CPU LayerDeviceMap means forward_layers(0..N) must equal the
+        // whole-model single-device forward (the byte-identity equivalence test).
+        let input = Tensor::from_slice(&[1i64, 5, 9, 2]).reshape([1, 4]);
+
+        // Reference: whole-model forward (embed→loop→norm→lm_head w/ vocab mask).
+        let reference = whole_model();
+        let ref_logits = reference.forward_with_cache(&input, 0).unwrap();
+
+        // Pipeline path on a fresh model (independent KV), full range over a
+        // single-device map. Compare on the ORIGINAL vocab columns (the whole-
+        // model path additionally masks padded columns; lm_head() does not).
+        let piped = whole_model();
+        let pipe_logits = orchestrated_logits(&piped, &input);
+
+        let orig = reference.config.original_vocab_size as i64;
+        let ref_c = ref_logits.narrow(2, 0, orig);
+        let pipe_c = pipe_logits.narrow(2, 0, orig);
+        let max_diff = (&ref_c - &pipe_c).abs().max().double_value(&[]);
+        assert!(
+            ref_c.allclose(&pipe_c, 1e-4, 1e-4, false),
+            "forward_layers(0..N) over a single-device map must equal whole-model forward \
+             (max_diff={max_diff}, ref_shape={:?})",
+            ref_c.size()
+        );
+        // Sanity: the device map for a whole model is single-device (zero-copy).
+        assert!(piped.device_map.is_single_device());
+        assert_eq!(piped.layer_offset, 0);
+    }
+
+    #[test]
+    fn staged_split_equals_whole_model() {
+        // Build TWO stages over an all-CPU 2-way split and run them as a pipeline:
+        // stage0: embed → forward_layers(0..b); stage1: forward_layers(b..N) →
+        // norm → lm_head. Result must equal the whole-model forward. This
+        // exercises the global↔local remap, is_first/is_last gating, and the
+        // (zero, since same-device) boundary copy.
+        let input = Tensor::from_slice(&[3i64, 7, 1, 4]).reshape([1, 4]);
+
+        let reference = whole_model();
+        let ref_logits = reference.forward_with_cache(&input, 0).unwrap();
+
+        // Single CPU device but split the layer RANGE across two stages.
+        let map = LayerDeviceMap::single(Device::Cpu, LAYERS).unwrap();
+        let split = LAYERS / 2;
+
+        let mut w0 = tiny_weights();
+        let stage0 = LlamaModel::stage_from_weights_with_config(
+            &mut w0, tiny_config(), &map, 0..split, DType::Float, KVQuantType::None,
+        )
+        .unwrap();
+        assert_eq!(stage0.layer_offset, 0);
+        assert!(stage0.embed_tokens.is_some(), "first stage keeps embed");
+        assert!(stage0.norm.is_none() && stage0.lm_head.is_none(), "first stage has no head");
+
+        let mut w1 = tiny_weights();
+        let stage1 = LlamaModel::stage_from_weights_with_config(
+            &mut w1, tiny_config(), &map, split..LAYERS, DType::Float, KVQuantType::None,
+        )
+        .unwrap();
+        assert_eq!(stage1.layer_offset, split);
+        assert!(stage1.embed_tokens.is_none(), "last stage has no embed");
+        assert!(stage1.norm.is_some(), "last stage keeps final norm");
+
+        // Drive the pipeline.
+        let emb = stage0.embed_tokens(&input).unwrap();
+        let h0 = stage0.forward_layers(&emb, 0..split, 0, None).unwrap();
+        let h1 = stage1.forward_layers(&h0, split..LAYERS, 0, None).unwrap();
+        let h1 = stage1.apply_final_norm(&h1).unwrap();
+        let logits = stage1.lm_head(&h1).unwrap();
+
+        let orig = reference.config.original_vocab_size as i64;
+        let ref_c = ref_logits.narrow(2, 0, orig);
+        let pipe_c = logits.narrow(2, 0, orig);
+        // 1e-4: the lm_head() trait casts the weight and uses f_matmul; the whole-
+        // model path uses plain matmul — float reassociation, not a logic diff.
+        let max_diff = (&ref_c - &pipe_c).abs().max().double_value(&[]);
+        assert!(
+            ref_c.allclose(&pipe_c, 1e-4, 1e-4, false),
+            "two-stage split (same device) must equal whole-model forward (max_diff={max_diff})"
+        );
+        // The last stage built an explicit lm_head (not the tied transpose).
+        assert!(stage1.lm_head_transposed.is_none());
+    }
+
+    #[test]
+    fn forward_layers_rejects_out_of_window_range() {
+        // A stage that owns [2..4) must reject a range outside its window.
+        let map = LayerDeviceMap::single(Device::Cpu, LAYERS).unwrap();
+        let mut w = tiny_weights();
+        let stage = LlamaModel::stage_from_weights_with_config(
+            &mut w, tiny_config(), &map, 2..LAYERS, DType::Float, KVQuantType::None,
+        )
+        .unwrap();
+        let emb = Tensor::randn([1, 3, HIDDEN], (DType::Float, Device::Cpu));
+        assert!(stage.forward_layers(&emb, 0..2, 0, None).is_err(), "range below window");
+        assert!(stage.forward_layers(&emb, 2..LAYERS, 0, None).is_ok(), "owned range ok");
+    }
+
+    #[test]
+    fn boundary_copy_skipped_when_same_device() {
+        // With a single-device map, no layer is a boundary, so forward_layers does
+        // zero `to_device` calls. We can only assert the predicate directly here
+        // (tch gives no copy counter), which the device-map test also covers.
+        let map = LayerDeviceMap::single(Device::Cpu, LAYERS).unwrap();
+        for g in 1..LAYERS {
+            assert!(!map.is_boundary(Device::Cpu, g));
+        }
+    }
+
+    #[test]
+    fn stage_loader_rejects_missing_required_weights() {
+        // Last stage with no norm weight must error (M-LOAD seam #1 gating).
+        let map = LayerDeviceMap::single(Device::Cpu, LAYERS).unwrap();
+        let mut w = tiny_weights();
+        w.remove("model.norm.weight");
+        let result = LlamaModel::stage_from_weights_with_config(
+            &mut w, tiny_config(), &map, 0..LAYERS, DType::Float, KVQuantType::None,
+        );
+        match result {
+            Ok(_) => panic!("last stage without norm weight must error"),
+            Err(e) => assert!(e.to_string().contains("norm"), "got: {e}"),
+        }
+    }
+
+    #[test]
+    fn parse_config_requires_core_dims() {
+        // #315 follow-up: mandatory architectural dims, no silent magic numbers.
+        let ok = r#"{"num_attention_heads":2,"hidden_size":16,"num_hidden_layers":4}"#;
+        assert!(LlamaModel::parse_config(ok).is_ok());
+        let missing = r#"{"hidden_size":16,"num_hidden_layers":4}"#;
+        let err = LlamaModel::parse_config(missing).unwrap_err();
+        assert!(err.to_string().contains("num_attention_heads"), "got: {err}");
+    }
+}

--- a/crates/hyprstream/src/runtime/architectures/mod.rs
+++ b/crates/hyprstream/src/runtime/architectures/mod.rs
@@ -334,6 +334,56 @@ pub trait ModelOperations: Send {
         self.decode_layer(layer_idx, hidden_states, attention_mask, position_ids, past_kv)
     }
 
+    /// Run a contiguous range of decoder layers — the 2b intra-host pipeline
+    /// (layer-split) primitive (#314).
+    ///
+    /// This is the missing layer-range runner that complements the already-
+    /// exposed `embed_tokens` / `forward_from_embeddings` / `apply_final_norm` /
+    /// `lm_head` / `num_layers`. Arch-agnostic orchestration composes them:
+    /// - **stage 0** : `embed_tokens` → `forward_layers(0..b)`
+    /// - **middle**  : `forward_layers(a..b)`
+    /// - **last**    : `forward_layers(a..N)` → `apply_final_norm` → `lm_head`
+    ///
+    /// `is_first`/`is_last` are *implicit* in `range` (`range.start == 0` /
+    /// `range.end == num_layers()`); the runner itself only applies decoder
+    /// layers — never embeddings, final norm, or the LM head.
+    ///
+    /// # Stage-boundary contract
+    /// The only state carried across a stage boundary is `hidden` + `start_pos`.
+    /// `position_ids` is recomputed inside from `start_pos` + seq. Per-layer KV
+    /// cache (and any SSM `conv`/`rec` state) is **stage-local and never
+    /// transferred**. `range` is in **global** layer indices; an implementation
+    /// that owns a shard remaps to its local `self.layers` via the
+    /// `layer_offset` it was constructed with.
+    ///
+    /// # Device placement
+    /// Layer `g` runs on its mapped device; the single cross-device copy is
+    /// `hidden.to_device(next)` inserted only at a boundary where the device
+    /// actually changes (zero copies within a stage or when source == dest).
+    /// The returned tensor lives on the **last owned layer's device**.
+    ///
+    /// # Arguments
+    /// * `hidden` - `[batch, seq, hidden]`; embeddings if `range.start == 0`,
+    ///   otherwise the previous stage's output.
+    /// * `range` - global layer indices this stage owns, `[a..b)`.
+    /// * `start_pos` - KV-cache start position for this forward.
+    /// * `delta` - optional per-tenant LoRA delta (delta-aware inference).
+    ///
+    /// The default implementation errors; only architectures that support the
+    /// pipeline split (Llama; Qwen3.5) override it. The single-device whole-model
+    /// `forward*` paths are unaffected — this method is purely additive.
+    fn forward_layers(
+        &self,
+        _hidden: &Tensor,
+        _range: std::ops::Range<usize>,
+        _start_pos: usize,
+        _delta: Option<&crate::training::TenantDelta>,
+    ) -> Result<Tensor> {
+        Err(anyhow!(
+            "forward_layers (pipeline layer-split) not implemented for this architecture"
+        ))
+    }
+
     /// Apply final layer normalization
     fn apply_final_norm(&self, _hidden_states: &Tensor) -> Result<Tensor> {
         Err(anyhow!("apply_final_norm not implemented for this architecture"))

--- a/crates/hyprstream/src/runtime/architectures/qwen3_5.rs
+++ b/crates/hyprstream/src/runtime/architectures/qwen3_5.rs
@@ -1001,10 +1001,20 @@ impl Qwen3_5FullAttention {
         // Saves ~9 GPU kernels per call (generate_embeddings) after the first token.
         // Same pattern as LlamaModel::apply_rope.
         use std::cell::RefCell;
+        // Cache key includes the DEVICE: the cached RoPE holds sin/cos tables on
+        // a specific device. Under a pipeline split (#314) the same `layer_idx`
+        // could legitimately run on different devices on one thread, so omitting
+        // device would hand back tables on the wrong device. We encode the device
+        // as an i64 (`-1` = CPU, otherwise the CUDA ordinal) since tch::Device is
+        // not Hash. On the single-device path this just adds one constant key dim.
         thread_local! {
-            static ROPE_CACHE: RefCell<HashMap<(usize, u32), RoPE>> =
+            static ROPE_CACHE: RefCell<HashMap<(usize, u32, i64), RoPE>> =
                 RefCell::new(HashMap::new());
         }
+        let device_key: i64 = match device {
+            Device::Cuda(i) => i as i64,
+            _ => -1,
+        };
 
         let rd = self.rotary_dim as i64;
         let seq = x.size()[1];
@@ -1014,7 +1024,7 @@ impl Qwen3_5FullAttention {
 
         ROPE_CACHE.with(|cache| {
             let mut cache = cache.borrow_mut();
-            let key = (self.layer_idx, self.rope_theta.to_bits());
+            let key = (self.layer_idx, self.rope_theta.to_bits(), device_key);
             let rope = match cache.entry(key) {
                 std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
                 std::collections::hash_map::Entry::Vacant(e) => {
@@ -1499,13 +1509,16 @@ impl Qwen3_5Model {
         };
 
         let (_, seq) = (hidden.size()[0], hidden.size()[1]);
-        let device = self.device;
 
-        // Position IDs for full-attention RoPE
+        // Position IDs for full-attention RoPE. Build on the HIDDEN-state device,
+        // not `self.device` — under a pipeline split (#314) the first owned layer
+        // may have been moved off `self.device`, and a mismatched position_ids
+        // device would fault at SDPA. (llama already does this; see
+        // forward_with_cache_inner.) On the single-device path this is identical.
         let position_ids = Tensor::arange_start(
             start_pos as i64,
             start_pos as i64 + seq,
-            (Kind::Int64, device),
+            (Kind::Int64, hidden.device()),
         );
 
         let mut conv_guard = self.conv_states.lock();

--- a/crates/hyprstream/src/runtime/device_pool.rs
+++ b/crates/hyprstream/src/runtime/device_pool.rs
@@ -207,6 +207,152 @@ impl DevicePool {
     }
 }
 
+/// A per-layer device assignment for **2b intra-host pipeline** (#314).
+///
+/// This is the layer→device `device_map` the [`DevicePool`] doc-comment
+/// anticipates. It is a thin, validated newtype over the per-global-layer
+/// `Vec<Device>` derived from a [`DevicePool`]: entry `g` is the device that
+/// owns global decoder layer `g`. A *stage* is a contiguous run of layers that
+/// map to the same device; the only cross-device copy in the forward pass is a
+/// single `hidden.to_device(next)` at a boundary where consecutive layers map to
+/// different devices (see [`LayerDeviceMap::is_boundary`]).
+///
+/// # Why a map over `num_hidden_layers`, not the stage-local count
+///
+/// The map is **global** — indexed by global layer index, length
+/// `num_hidden_layers` — so a single source of truth drives both shard-aware
+/// construction (per-layer placement + per-layer type/RoPE selection, which need
+/// the global index) and the forward loop. A stage that owns layers `[a..b)`
+/// queries the same global map; the architecture is responsible for the
+/// global↔local remap of its own `self.layers` / KV / SSM vectors via the
+/// `layer_offset = a` it was built with.
+///
+/// # Send / Sync
+///
+/// Holds only [`Device`] values (`Copy`, no tensors), so it is `Send + Sync` and
+/// may be handed to an engine-owning thread. Like [`DevicePool`], **never** add a
+/// `Tensor`/`VarStore` field — see the module-level `!Send` boundary note.
+#[derive(Debug, Clone)]
+pub struct LayerDeviceMap {
+    /// One device per global layer index. Always non-empty; `len()` equals the
+    /// model's `num_hidden_layers`.
+    per_layer: Vec<Device>,
+}
+
+impl LayerDeviceMap {
+    /// All layers on a single device — the unsplit fast path.
+    ///
+    /// Used both by single-GPU inference and by the CPU-only equivalence tests
+    /// (`forward_layers(0..N)` over an all-CPU map must equal the whole-model
+    /// forward). `num_layers` must be non-zero.
+    pub fn single(device: Device, num_layers: usize) -> Result<Self> {
+        if num_layers == 0 {
+            return Err(anyhow!("LayerDeviceMap requires num_layers >= 1 (got 0)"));
+        }
+        Ok(Self {
+            per_layer: vec![device; num_layers],
+        })
+    }
+
+    /// Build an explicit per-layer map, validating it is non-empty.
+    ///
+    /// `per_layer[g]` is the device that owns global layer `g`.
+    pub fn from_per_layer(per_layer: Vec<Device>) -> Result<Self> {
+        if per_layer.is_empty() {
+            return Err(anyhow!("LayerDeviceMap requires at least one layer (got none)"));
+        }
+        Ok(Self { per_layer })
+    }
+
+    /// Spread `num_layers` contiguously across a [`DevicePool`]'s devices in
+    /// requested order, balanced as evenly as possible (capacity-symmetric).
+    ///
+    /// Earlier stages get the extra layer when `num_layers` is not divisible by
+    /// the device count, matching the natural prefix-heavy split. This is the
+    /// parameter-balanced planner; the capacity-aware (asymmetric-VRAM) variant
+    /// is a later epic concern (plan §H) and would replace this constructor
+    /// without touching the forward path.
+    ///
+    /// Layers are assigned in **contiguous runs** so each device owns a single
+    /// pipeline stage `[a..b)` — never interleaved — which keeps boundary copies
+    /// to exactly `(num_stages - 1)` per forward.
+    pub fn even_split(pool: &DevicePool, num_layers: usize) -> Result<Self> {
+        if num_layers == 0 {
+            return Err(anyhow!("LayerDeviceMap requires num_layers >= 1 (got 0)"));
+        }
+        let devices = pool.devices();
+        let n_dev = devices.len();
+        let base = num_layers / n_dev;
+        let rem = num_layers % n_dev;
+
+        let mut per_layer = Vec::with_capacity(num_layers);
+        for (d, &dev) in devices.iter().enumerate() {
+            // First `rem` devices get one extra layer (prefix-heavy split).
+            let count = base + usize::from(d < rem);
+            for _ in 0..count {
+                per_layer.push(dev);
+            }
+        }
+        debug_assert_eq!(per_layer.len(), num_layers);
+        Ok(Self { per_layer })
+    }
+
+    /// Device owning global layer `global_layer_idx`.
+    ///
+    /// # Panics
+    /// Panics if `global_layer_idx >= len()` — a programming error (the caller
+    /// iterates a known global range). Use [`Self::try_device_for`] for a checked
+    /// variant.
+    #[must_use]
+    pub fn device_for(&self, global_layer_idx: usize) -> Device {
+        self.per_layer[global_layer_idx]
+    }
+
+    /// Checked [`Self::device_for`].
+    pub fn try_device_for(&self, global_layer_idx: usize) -> Result<Device> {
+        self.per_layer
+            .get(global_layer_idx)
+            .copied()
+            .ok_or_else(|| {
+                anyhow!(
+                    "LayerDeviceMap: global layer index {global_layer_idx} out of range \
+                     (map covers {} layers)",
+                    self.per_layer.len()
+                )
+            })
+    }
+
+    /// Whether a cross-device boundary copy is needed *before* running layer
+    /// `global_layer_idx`, given the device the previous layer's output is on.
+    ///
+    /// Returns `false` for the first layer of a stage when its device equals
+    /// `prev_device` (zero-copy within a stage and across same-device stages), and
+    /// `true` only when the device actually changes. This is the single point
+    /// that gates the lone `hidden.to_device()` in the forward loop.
+    #[must_use]
+    pub fn is_boundary(&self, prev_device: Device, global_layer_idx: usize) -> bool {
+        self.device_for(global_layer_idx) != prev_device
+    }
+
+    /// Number of global layers covered (equals the model's `num_hidden_layers`).
+    #[must_use]
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self) -> usize {
+        self.per_layer.len()
+    }
+
+    /// Whether every layer maps to the same device (the unsplit fast path).
+    ///
+    /// When true, `forward_layers` performs zero cross-device copies and is
+    /// numerically identical to the single-device whole-model forward.
+    #[must_use]
+    pub fn is_single_device(&self) -> bool {
+        self.per_layer
+            .first()
+            .is_some_and(|&first| self.per_layer.iter().all(|&d| d == first))
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -276,5 +422,85 @@ mod tests {
         // no tensors, so it must be Send + Sync for the replication design.
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<DevicePool>();
+        // The layer→device map crosses to the engine thread too, so it must also
+        // be Send + Sync (it holds only Device values).
+        assert_send_sync::<LayerDeviceMap>();
+    }
+
+    #[test]
+    fn layer_map_single_is_zero_copy() {
+        let map = LayerDeviceMap::single(Device::Cpu, 4).unwrap();
+        assert_eq!(map.len(), 4);
+        assert!(map.is_single_device());
+        for g in 0..4 {
+            assert_eq!(map.device_for(g), Device::Cpu);
+        }
+        // No boundary anywhere when every layer is the same device.
+        for g in 1..4 {
+            assert!(!map.is_boundary(Device::Cpu, g));
+        }
+    }
+
+    #[test]
+    fn layer_map_single_rejects_zero() {
+        assert!(LayerDeviceMap::single(Device::Cpu, 0).is_err());
+        assert!(LayerDeviceMap::from_per_layer(vec![]).is_err());
+        let pool = DevicePool::from_devices(vec![Device::Cpu]).unwrap();
+        assert!(LayerDeviceMap::even_split(&pool, 0).is_err());
+    }
+
+    #[test]
+    fn even_split_is_contiguous_and_prefix_heavy() {
+        // 5 layers over 2 devices → [d0,d0,d0, d1,d1] (prefix gets the extra).
+        let pool =
+            DevicePool::from_devices(vec![Device::Cpu, Device::Cuda(0)]).unwrap();
+        let map = LayerDeviceMap::even_split(&pool, 5).unwrap();
+        assert_eq!(map.len(), 5);
+        assert_eq!(map.device_for(0), Device::Cpu);
+        assert_eq!(map.device_for(1), Device::Cpu);
+        assert_eq!(map.device_for(2), Device::Cpu);
+        assert_eq!(map.device_for(3), Device::Cuda(0));
+        assert_eq!(map.device_for(4), Device::Cuda(0));
+        assert!(!map.is_single_device());
+
+        // Exactly one boundary, at the device change (layer 3).
+        let mut boundaries = 0;
+        let mut prev = map.device_for(0);
+        for g in 1..map.len() {
+            if map.is_boundary(prev, g) {
+                boundaries += 1;
+            }
+            prev = map.device_for(g);
+        }
+        assert_eq!(boundaries, 1, "contiguous 2-device split has exactly one boundary");
+    }
+
+    #[test]
+    fn even_split_balanced_when_divisible() {
+        let pool = DevicePool::from_devices(vec![
+            Device::Cpu,
+            Device::Cuda(0),
+            Device::Cuda(1),
+        ])
+        .unwrap();
+        let map = LayerDeviceMap::even_split(&pool, 6).unwrap();
+        assert_eq!(
+            (0..6).map(|g| map.device_for(g)).collect::<Vec<_>>(),
+            vec![
+                Device::Cpu,
+                Device::Cpu,
+                Device::Cuda(0),
+                Device::Cuda(0),
+                Device::Cuda(1),
+                Device::Cuda(1),
+            ]
+        );
+    }
+
+    #[test]
+    fn try_device_for_is_checked() {
+        let map = LayerDeviceMap::single(Device::Cpu, 2).unwrap();
+        assert_eq!(map.try_device_for(1).unwrap(), Device::Cpu);
+        assert!(map.try_device_for(2).unwrap_err().to_string().contains("out of range"));
     }
 }

--- a/crates/hyprstream/src/runtime/model_config.rs
+++ b/crates/hyprstream/src/runtime/model_config.rs
@@ -23,6 +23,21 @@ static LAYER_REGEX: LazyLock<Option<Regex>> = LazyLock::new(|| {
     Regex::new(r"layers\.(\d+)").ok()
 });
 
+/// Regex for extracting **decoder** layer indices from a shard manifest's
+/// `weight_map` keys (#314 follow-up to #315).
+///
+/// Anchored to the language-model decoder namespace — `model.layers.<i>.` or
+/// `language_model.model.layers.<i>.` — so a multimodal checkpoint's *vision
+/// tower* (e.g. `vision_model.encoder.layers.<j>.` /
+/// `visual.blocks.<j>.`) cannot inflate the decoder layer count and corrupt a
+/// pipeline split. The trailing `.` ensures we match a true layer-index segment
+/// (`model.layers.12.` ) and not an unrelated key that merely contains the
+/// substring. Correct for llama/qwen3_5, whose decoder weights are
+/// `model.layers.<i>.…`.
+static DECODER_LAYER_REGEX: LazyLock<Option<Regex>> = LazyLock::new(|| {
+    Regex::new(r"(?:^|\.)(?:language_model\.)?model\.layers\.(\d+)\.").ok()
+});
+
 /// Unified model configuration that combines all sources
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelConfig {
@@ -648,8 +663,11 @@ impl ModelConfig {
             )
         })?;
 
+        // Count only DECODER layers (`model.layers.<i>.`), not a multimodal
+        // vision tower's own `.layers.N` — those would inflate the count and
+        // corrupt a pipeline split (#314 follow-up to #315).
         let mut layer_indices = std::collections::HashSet::new();
-        if let Some(ref regex) = *LAYER_REGEX {
+        if let Some(ref regex) = *DECODER_LAYER_REGEX {
             for key in weight_map.keys() {
                 if let Some(captures) = regex.captures(key) {
                     if let Ok(idx) = captures[1].parse::<usize>() {
@@ -948,6 +966,51 @@ mod tests {
         let cfg = ModelConfig::load(dir.path(), &empty_weights())
             .expect("matching layer counts must load");
         assert_eq!(cfg.num_hidden_layers, 3);
+    }
+
+    /// #314 follow-up: a multimodal vision tower's own `.layers.N` must NOT
+    /// inflate the decoder layer count when cross-checking against the manifest.
+    /// Decoder has 3 layers; the vision tower has 24 — only the decoder counts.
+    #[test]
+    fn vision_tower_layers_do_not_inflate_decoder_count() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "config.json", &valid_config_json(3));
+        write(
+            dir.path(),
+            "model.safetensors.index.json",
+            r#"{"weight_map":{
+                "model.layers.0.self_attn.q_proj.weight":"a.safetensors",
+                "model.layers.1.self_attn.q_proj.weight":"a.safetensors",
+                "model.layers.2.self_attn.q_proj.weight":"a.safetensors",
+                "vision_model.encoder.layers.0.self_attn.q_proj.weight":"v.safetensors",
+                "vision_model.encoder.layers.10.self_attn.q_proj.weight":"v.safetensors",
+                "vision_model.encoder.layers.23.self_attn.q_proj.weight":"v.safetensors",
+                "visual.blocks.5.attn.qkv.weight":"v.safetensors"
+            }}"#,
+        );
+        let cfg = ModelConfig::load(dir.path(), &empty_weights())
+            .expect("decoder layer count (3) must match despite a 24-layer vision tower");
+        assert_eq!(cfg.num_hidden_layers, 3);
+    }
+
+    /// The decoder regex also accepts the `language_model.model.layers.<i>.`
+    /// nesting used by some multimodal checkpoints.
+    #[test]
+    fn nested_language_model_layers_are_counted() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "config.json", &valid_config_json(2));
+        write(
+            dir.path(),
+            "model.safetensors.index.json",
+            r#"{"weight_map":{
+                "language_model.model.layers.0.self_attn.q_proj.weight":"a.safetensors",
+                "language_model.model.layers.1.self_attn.q_proj.weight":"a.safetensors",
+                "vision_model.encoder.layers.0.self_attn.q_proj.weight":"v.safetensors"
+            }}"#,
+        );
+        let cfg = ModelConfig::load(dir.path(), &empty_weights())
+            .expect("nested language_model decoder layers must be counted");
+        assert_eq!(cfg.num_hidden_layers, 2);
     }
 
     /// A zero architectural dimension is rejected (avoids div-by-zero / corruption).


### PR DESCRIPTION
## #314 — 2b intra-host pipeline: per-layer `device_map` + stage-aware load

Part of #310. Adds the **layer-split (pipeline) primitive** for intra-host
multi-GPU: a per-layer device map, a stage-aware shard loader, and the
`forward_layers` layer-range runner — fully implemented and tested for **llama**.
`forward_layers` is kept an **internal trait method** (no schema/RPC/policy
touched — the wire shape is #324, gated).

### `forward_layers` design (as implemented)

New `ModelOperations` method, complementing the already-exposed
`embed_tokens` / `forward_from_embeddings` / `apply_final_norm` / `lm_head` /
`num_layers`:

```rust
fn forward_layers(
    &self,
    hidden: &Tensor,            // [batch, seq, hidden]; embeddings if first stage
    range: std::ops::Range<usize>, // GLOBAL layer indices this stage owns [a..b)
    start_pos: usize,
    delta: Option<&TenantDelta>,
) -> Result<Tensor>;            // hidden after layer b-1, on the last owned layer's device
```

Default impl errors, so non-implementing architectures (gemma, janus, qwen3_5)
are unaffected. Arch-agnostic orchestration (engine-side, a later ticket):
stage-0 `embed_tokens → forward_layers(0..b)`; middle `forward_layers(a..b)`;
last `forward_layers(a..N) → apply_final_norm → lm_head`. `is_first`/`is_last`
are implicit in `range`.

**Invariants:** only `hidden` + `start_pos` cross a stage boundary;
`position_ids` is recomputed inside from `start_pos`+seq on the input device; KV
cache is stage-local (sized to the **owned** layer count) and never transferred.
Global→local remap uses `layer_offset`.

### `LayerDeviceMap` (new, in `runtime/device_pool.rs`)

Send+Sync newtype over the per-global-layer `Vec<Device>` derived from
`DevicePool` (the type its doc-comment anticipated):

```rust
LayerDeviceMap::single(device, num_layers)        // unsplit fast path
LayerDeviceMap::even_split(&pool, num_layers)      // contiguous prefix-heavy split
LayerDeviceMap::from_per_layer(Vec<Device>)
fn device_for(&self, global_layer_idx) -> Device
fn is_boundary(&self, prev_device, global_layer_idx) -> bool
fn is_single_device(&self) -> bool
fn len(&self) -> usize
```

Contiguous runs only → each device owns one stage → exactly `(stages-1)`
boundary copies.

### llama stage loader

`LlamaModel::stage_from_weights_with_config(weights, config, &LayerDeviceMap,
layer_range, dtype, kv_quant)` loads only `[a..b)` onto mapped devices via a
single per-layer `.to()`, gating non-layer weights by stage position. Added
`to_device` to `LlamaLayer`/`LlamaAttention`/`LlamaMLP`/`RMSNorm`/`LinearProjection`.

### Single-device byte-identity guarantee

The existing whole-model `from_weights*` / `forward_with_cache_inner` /
`forward_from_embeddings` paths are **unchanged** — `forward_layers` is purely
additive. The whole-model constructor now builds a single-device `LayerDeviceMap`,
so `forward_layers(0..N)` over it does **zero** cross-device copies and is
numerically identical to the whole-model forward (covered by an equivalence test).

### Zero-copy boundary policy

The only cross-device transfer is `hidden.to_device(next)` (plus `position_ids`),
inserted in the forward loop **only** when `device_for(g) != hidden.device()` —
never within a stage, never when source == dest.

### M-LOAD seams handled (llama)

1. `from_weights` no longer hard-requires embed/norm/lm_head — gated by
   `is_first`/`is_last` (middle stages carry none; clear errors when a required
   weight is missing on first/last).
2. KV / `self.layers` sized to the **owned** count; forward indexes locally.
3. `position_ids` built on `hidden.device()` (also fixed in qwen3_5, see below).
4. Per-layer type/RoPE selection via global index at construction (`layer_offset`).
5. Whole-model fast path kept byte-identical.
6. Prefill last-token narrow stays in the last stage (orchestration-level).
7. `decode_layer` (training path) is **not** reused for `forward_layers`.
8. gemma **excluded** (no `forward_layers`; keeps only whole-model path).

### Folded-in #315 follow-ups (touched files)

- `model_config.rs`: `validate_against_index` now counts only **decoder** layers
  via a new `DECODER_LAYER_REGEX` anchored to `model.layers.<i>.` /
  `language_model.model.layers.<i>.`, so a multimodal vision tower's `.layers.N`
  can't inflate `num_hidden_layers`. (Tests for vision-tower exclusion + nested
  language_model.)
- `llama.rs`: `parse_config` makes `num_attention_heads` / `hidden_size` /
  `num_hidden_layers` mandatory (no `unwrap_or(32)`/`unwrap_or(4096)` magic
  numbers; rejects zero dims), mirroring #315.

### qwen3_5 — latent single-device bug fixes (no `forward_layers` yet)

- `position_ids` built on `hidden.device()` instead of `self.device` (fault under
  a split; identical on single-device).
- thread-local RoPE cache key now includes the device (`(layer_idx, rope_theta,
  device)`) so a split can't hand back sin/cos tables on the wrong device.

### Architecture status

- **llama: landed** (idx loop + KV + delta + all seams; reference impl, tested).
- **qwen3_5: deferred to a follow-up PR** (cheap latent bugs fixed here). Its
  hybrid GatedDeltaNet/full-attention layers carry a **second SSM state vector**
  (`conv_states`/`rec_states`) plus global-index layer-type selection, which
  would roughly double the PR with SSM correctness risk I can't numerically
  validate without 2×GPU hardware (that's #317). Per the ticket's guidance, a
  correct llama + shared infra is shipped instead of a shaky two-arch PR. The
  `forward_layers` skeleton + `LayerDeviceMap` + `stage_from_weights` pattern are
  ready to mirror.
- janus: deferred. gemma: excluded (whole-model only).

### Deferred (out of scope here, documented)

- **perf-M3** (per-stage KV `BlockPool` / `initialize_kv_registry` stage-device
  threading): belongs with engine integration (#324 territory) where the engine
  actually drives `forward_layers`; threading a device through the registry now
  would be dead, untestable code. The `cuda_if_available()` fallback in
  `kv_cache.rs` is left for that ticket.

### Tested (CPU-only; no multi-GPU hardware — numerical 2-GPU validation is #317)

- `forward_layers(0..N)` over an all-CPU map == whole-model `forward_with_cache`
  (equivalence, on the original-vocab columns).
- Two-stage split (`0..b` then `b..N`) driven as a pipeline == whole-model forward
  (global↔local remap + is_first/is_last gating + same-device boundary skip).
- `forward_layers` rejects a range outside a stage's owned window.
- Stage loader errors when a required first/last weight is missing.
- `LayerDeviceMap`: single/even_split contiguity, prefix-heavy split, one
  boundary per device change, Send+Sync, checked accessor.
- `parse_config` mandatory-dim enforcement.
- `validate_against_index` ignores vision-tower layers; counts nested
  `language_model` decoder layers.

`cargo build -p hyprstream` clean; `cargo clippy -p hyprstream --all-targets -D
warnings` clean; targeted tests green.
