### PR TITLE
feat: TTT-on-split — cross-device autograd over the pipeline partition (#316)

### DIFF
--- a/crates/hyprstream/src/runtime/architectures/llama.rs
+++ b/crates/hyprstream/src/runtime/architectures/llama.rs
@@ -2222,6 +2222,79 @@ impl LlamaModel {
 
         Ok(hidden_states)
     }
+
+    /// Training-path sibling of [`Self::forward_layers_inner`] — the cross-device
+    /// autograd primitive for TTT-on-split (#316). See the trait
+    /// `forward_layers_train` docs for the contract.
+    ///
+    /// Identical layer loop to the inference runner with three deliberate
+    /// differences: **no KV cache** (full causal attention, computed fresh from
+    /// the whole context), **`start_pos = 0`** (`position_ids = 0..seq`), and the
+    /// autograd graph is left intact (no `no_grad` guard — the caller wraps this
+    /// in `with_grad`). The lone cross-device `hidden.to_device(next)` carries the
+    /// autograd graph across the boundary, so `loss.backward()` materializes grads
+    /// on each parameter's own device.
+    fn forward_layers_train_inner(
+        &self,
+        hidden: &Tensor,
+        range: std::ops::Range<usize>,
+        delta: Option<&crate::training::TenantDelta>,
+    ) -> Result<Tensor> {
+        let num_global = self.config.num_hidden_layers as usize;
+        if range.end > num_global || range.start >= range.end {
+            return Err(anyhow!(
+                "forward_layers_train: invalid global range {range:?} for {num_global} layers"
+            ));
+        }
+        let owned = self.layer_offset..self.layer_offset + self.layers.len();
+        if range.start < owned.start || range.end > owned.end {
+            return Err(anyhow!(
+                "forward_layers_train: range {range:?} not within this stage's owned layers {owned:?}"
+            ));
+        }
+
+        let mut hidden_states = hidden.shallow_clone();
+
+        // Training path: start_pos is always 0 → position_ids = 0..seq, built on
+        // the input device and moved alongside `hidden` at each device boundary.
+        let seq_len = hidden_states.size()[1];
+        let mut position_ids =
+            Tensor::arange(seq_len, (tch::Kind::Int64, hidden_states.device()));
+
+        // No KV cache in the training path: full causal attention is recomputed
+        // over the entire context every step (compute_attention applies the tril
+        // mask when no cache is present).
+        for g in range {
+            let local_idx = g - self.layer_offset;
+            let layer = &self.layers[local_idx];
+
+            // The single cross-device transfer (autograd-transparent): only when
+            // this layer's mapped device differs from where `hidden` currently is.
+            let target = self.device_map.device_for(g);
+            if hidden_states.device() != target {
+                hidden_states = hidden_states.to_device(target);
+                position_ids = position_ids.to_device(target);
+            }
+
+            let residual = hidden_states.shallow_clone();
+            hidden_states = layer.input_layernorm.forward(&hidden_states)?;
+            let attn_output = layer.self_attn.forward(
+                &hidden_states,
+                Some(&position_ids),
+                None, // no KV cache (training)
+                0,    // start_pos = 0 (training)
+                delta,
+            )?;
+            hidden_states = residual + attn_output;
+
+            let residual = hidden_states.shallow_clone();
+            hidden_states = layer.post_attention_layernorm.forward(&hidden_states)?;
+            let ffn_output = layer.mlp.forward(&hidden_states, delta)?;
+            hidden_states = residual + ffn_output;
+        }
+
+        Ok(hidden_states)
+    }
 }
 
 impl ModelOperations for LlamaModel {
@@ -2540,6 +2613,15 @@ impl ModelOperations for LlamaModel {
         delta: Option<&crate::training::TenantDelta>,
     ) -> Result<Tensor> {
         self.forward_layers_inner(hidden, range, start_pos, delta)
+    }
+
+    fn forward_layers_train(
+        &self,
+        hidden: &Tensor,
+        range: std::ops::Range<usize>,
+        delta: Option<&crate::training::TenantDelta>,
+    ) -> Result<Tensor> {
+        self.forward_layers_train_inner(hidden, range, delta)
     }
 
     fn apply_final_norm(&self, hidden_states: &Tensor) -> Result<Tensor> {
@@ -2879,5 +2961,134 @@ mod pipeline_tests {
         let missing = r#"{"hidden_size":16,"num_hidden_layers":4}"#;
         let err = LlamaModel::parse_config(missing).unwrap_err();
         assert!(err.to_string().contains("num_attention_heads"), "got: {err}");
+    }
+
+    // ========================================================================
+    // #316 — TTT-on-split cross-device autograd equivalence (CPU-verifiable).
+    // ========================================================================
+
+    use crate::training::tenant_delta::{TenantDelta, TenantDeltaConfig};
+
+    /// Build a per-layer q_proj/v_proj LoRA delta on CPU with a deterministic,
+    /// RNG-free A **and** non-zero B so that gradients w.r.t. BOTH A and B are
+    /// non-trivial (B is zero-initialized by default → dL/dA would be zero).
+    fn tiny_delta() -> TenantDelta {
+        let mut dims = std::collections::HashMap::new();
+        dims.insert("q_proj".to_owned(), (HIDDEN as usize, HIDDEN as usize));
+        dims.insert("v_proj".to_owned(), (HIDDEN as usize, HIDDEN as usize));
+        let cfg = TenantDeltaConfig {
+            rank: 2,
+            alpha: 2.0,
+            target_modules: vec!["q_proj".to_owned(), "v_proj".to_owned()],
+            ..Default::default()
+        };
+        let delta = TenantDelta::new(&cfg, &dims, Device::Cpu, LAYERS).unwrap();
+        // Seed deterministic, non-zero A and B in-place (no_grad: weight init, not
+        // graph). Seed by a STABLE per-key offset — HashMap iteration order is not
+        // deterministic, so two independent `tiny_delta()` builds (whole vs split)
+        // must agree key-for-key, not enumeration-index-for-index.
+        let key_offset = |key: &str| -> i64 {
+            key.bytes().map(|b| b as i64).sum::<i64>() % 17
+        };
+        let _g = tch::no_grad_guard();
+        for (k, a) in delta.lora_a.iter() {
+            let n: i64 = a.size().iter().product();
+            let vals = (Tensor::arange(n, (DType::Float, Device::Cpu)) + key_offset(k)).sin() * 0.1;
+            // copy_ needs &mut; shallow_clone shares storage so the delta param is mutated.
+            a.shallow_clone().copy_(&vals.reshape(a.size()));
+        }
+        for (k, b) in delta.lora_b.iter() {
+            let n: i64 = b.size().iter().product();
+            let vals = (Tensor::arange(n, (DType::Float, Device::Cpu)) + key_offset(k) + 7).cos() * 0.1;
+            b.shallow_clone().copy_(&vals.reshape(b.size()));
+        }
+        delta
+    }
+
+    /// Sum of squared L2 grad norms over all delta params, plus a per-key map.
+    fn grad_snapshot(delta: &TenantDelta) -> std::collections::HashMap<String, f64> {
+        let mut out = std::collections::HashMap::new();
+        for (k, a) in &delta.lora_a {
+            assert!(a.grad().defined(), "A grad undefined for {k}");
+            out.insert(format!("A:{k}"), a.grad().norm().double_value(&[]));
+        }
+        for (k, b) in &delta.lora_b {
+            assert!(b.grad().defined(), "B grad undefined for {k}");
+            out.insert(format!("B:{k}"), b.grad().norm().double_value(&[]));
+        }
+        out
+    }
+
+    /// The core correctness guardrail (#316): a TTT/training step (forward_layers_train
+    /// → NTP loss → backward) over a two-stage CPU split must produce the SAME delta
+    /// gradients as the whole-model training forward, within ~1e-4. A wrong
+    /// cross-device autograd hookup or mis-placed grad would diverge.
+    #[test]
+    fn ttt_split_autograd_matches_whole_model_grads() {
+        use crate::training::pipeline::{compute_ntp_loss_split, TrainStage};
+
+        let input = Tensor::from_slice(&[3i64, 7, 1, 4, 9, 2]).reshape([1, 6]);
+
+        // --- (a) whole-model training forward over a single-device map ---
+        let whole = whole_model();
+        let whole_delta = tiny_delta();
+        let whole_stage = [TrainStage { model: &whole, range: 0..LAYERS }];
+        let loss_whole = compute_ntp_loss_split(&whole_stage, &input, Some(&whole_delta)).unwrap();
+        loss_whole.backward();
+        let whole_grads = grad_snapshot(&whole_delta);
+        whole_delta.zero_grad();
+
+        // --- (b) two-stage split over an all-CPU map (exercises the boundary
+        // to_device autograd transparency + global↔local remap) ---
+        let map = LayerDeviceMap::single(Device::Cpu, LAYERS).unwrap();
+        let split = LAYERS / 2;
+        let mut w0 = tiny_weights();
+        let stage0 = LlamaModel::stage_from_weights_with_config(
+            &mut w0, tiny_config(), &map, 0..split, DType::Float, KVQuantType::None,
+        ).unwrap();
+        let mut w1 = tiny_weights();
+        let stage1 = LlamaModel::stage_from_weights_with_config(
+            &mut w1, tiny_config(), &map, split..LAYERS, DType::Float, KVQuantType::None,
+        ).unwrap();
+        let split_delta = tiny_delta();
+        let stages = [
+            TrainStage { model: &stage0, range: 0..split },
+            TrainStage { model: &stage1, range: split..LAYERS },
+        ];
+        let loss_split = compute_ntp_loss_split(&stages, &input, Some(&split_delta)).unwrap();
+        loss_split.backward();
+        let split_grads = grad_snapshot(&split_delta);
+
+        // Losses must match (forward equivalence).
+        let lw = loss_whole.double_value(&[]);
+        let ls = loss_split.double_value(&[]);
+        assert!((lw - ls).abs() < 1e-4, "loss diverged: whole={lw} split={ls}");
+
+        // Per-key gradient norms must match within tolerance (backward equivalence).
+        assert_eq!(whole_grads.len(), split_grads.len());
+        for (k, &gw) in &whole_grads {
+            let gs = *split_grads.get(k).unwrap_or_else(|| panic!("missing grad {k}"));
+            assert!(
+                (gw - gs).abs() <= 1e-4 + 1e-4 * gw.abs(),
+                "grad norm diverged for {k}: whole={gw} split={gs}"
+            );
+            // A non-trivial gradient must actually flow (guards against a silently
+            // detached path that would make both sides spuriously equal at 0).
+            assert!(gw > 0.0, "grad for {k} is zero — autograd path not exercised");
+        }
+    }
+
+    /// `forward_layers_train` must reject ranges outside the stage's owned window
+    /// (same guardrail as the inference runner).
+    #[test]
+    fn forward_layers_train_rejects_out_of_window_range() {
+        let map = LayerDeviceMap::single(Device::Cpu, LAYERS).unwrap();
+        let mut w = tiny_weights();
+        let stage = LlamaModel::stage_from_weights_with_config(
+            &mut w, tiny_config(), &map, 2..LAYERS, DType::Float, KVQuantType::None,
+        ).unwrap();
+        let emb = Tensor::randn([1, 3, HIDDEN], (DType::Float, Device::Cpu));
+        assert!(stage.forward_layers_train(&emb, 0..2, None).is_err(), "range below window");
+        assert!(stage.forward_layers_train(&emb, 2..LAYERS, None).is_ok(), "owned range ok");
     }
 }

--- a/crates/hyprstream/src/runtime/architectures/mod.rs
+++ b/crates/hyprstream/src/runtime/architectures/mod.rs
@@ -384,6 +384,50 @@ pub trait ModelOperations: Send {
         ))
     }
 
+    /// Training-path sibling of [`Self::forward_layers`] — the cross-device
+    /// autograd primitive for **TTT-on-split** (#316, M-TRAIN-COUPLING).
+    ///
+    /// TTT is inference-time training that must traverse the **same** layer
+    /// partition inference uses, so the backward pass materializes grads on each
+    /// parameter's own device. This runner builds that autograd graph across the
+    /// [`crate::runtime::device_pool::LayerDeviceMap`]; the lone stage-boundary
+    /// `hidden.to_device(next)` is autograd-transparent (tch `to_device` is
+    /// differentiable), so gradients flow back through it to the previous stage's
+    /// device.
+    ///
+    /// # How it differs from the inference [`Self::forward_layers`]
+    /// The inference and training paths are kept deliberately separate (as the
+    /// whole-model paths already are). The training path:
+    /// - uses **no KV cache** — full causal attention over the entire context;
+    /// - pins **`start_pos = 0`** — `position_ids` are `0..seq`;
+    /// - uses **fresh, call-local recurrent (SSM) state** for hybrid
+    ///   architectures — the persistent inference `conv`/`rec` state is never read
+    ///   or written, so a TTT step cannot pollute the inference recurrent state
+    ///   (and the split is numerically identical to the whole-model training
+    ///   forward, since per-layer recurrent state never crosses a layer boundary).
+    ///
+    /// Everything else — the global↔local layer remap via `layer_offset`, the
+    /// single boundary copy, per-layer delta injection keyed by global index —
+    /// matches [`Self::forward_layers`]. The arch-agnostic stage orchestration is
+    /// identical (`embed_tokens` → `forward_layers_train(0..b)` → … →
+    /// `forward_layers_train(a..N)` → `apply_final_norm` → `lm_head`), and the
+    /// loss/backward is driven by the caller (e.g. the TTT trainer).
+    ///
+    /// The default implementation errors; only architectures that support the
+    /// pipeline split (Llama; Qwen3.5) override it. The single-device whole-model
+    /// training path ([`crate::runtime::TorchEngine::forward_with_delta`]) is
+    /// unaffected — this method is purely additive.
+    fn forward_layers_train(
+        &self,
+        _hidden: &Tensor,
+        _range: std::ops::Range<usize>,
+        _delta: Option<&crate::training::TenantDelta>,
+    ) -> Result<Tensor> {
+        Err(anyhow!(
+            "forward_layers_train (pipeline layer-split training) not implemented for this architecture"
+        ))
+    }
+
     /// Apply final layer normalization
     fn apply_final_norm(&self, _hidden_states: &Tensor) -> Result<Tensor> {
         Err(anyhow!("apply_final_norm not implemented for this architecture"))

--- a/crates/hyprstream/src/runtime/architectures/qwen3_5.rs
+++ b/crates/hyprstream/src/runtime/architectures/qwen3_5.rs
@@ -386,21 +386,40 @@ fn chunked_delta_rule(
 
     // attn = -(k_beta @ k^T * decay_mask).masked_fill(mask0, 0)
     // [B, nv, nc, C, C]
-    let attn = -(k_beta.matmul(&k.transpose(-1, -2)) * &decay_mask)
+    let attn0 = -(k_beta.matmul(&k.transpose(-1, -2)) * &decay_mask)
         .masked_fill(&mask0, 0.0f64);
 
-    // Recursive delta-rule correction (loop over chunk_size positions)
-    for i in 1..CHUNK_SIZE as usize {
-        let i = i as i64;
-        // row = attn[..., i, :i]
-        let row = attn.narrow(-2, i, 1).narrow(-1, 0, i).squeeze_dim(-2); // [B, nv, nc, i]
-        // sub = attn[..., :i, :i]
-        let sub = attn.narrow(-2, 0, i).narrow(-1, 0, i); // [B, nv, nc, i, i]
-        // correction = (row @ sub)  [B, nv, nc, i]
-        let correction = row.unsqueeze(-2).matmul(&sub).squeeze_dim(-2);
-        let new_row = (&row + &correction).unsqueeze(-2); // [B, nv, nc, 1, i]
-        attn.narrow(-2, i, 1).narrow(-1, 0, i).copy_(&new_row);
+    // Recursive delta-rule correction (forward substitution over chunk positions).
+    //
+    // Row `i` of the corrected lower-triangular matrix is
+    //   T[i, :i] = A[i, :i] + A[i, :i] @ T[:i, :i]
+    // i.e. each row depends on the ALREADY-corrected rows above it. The original
+    // implementation built this with an in-place `attn[..i].copy_(row)`, which is
+    // unsafe for autograd (it mutates a tensor saved for backward → "variable
+    // needed for gradient computation modified by an inplace operation"). On the
+    // inference path this ran under `no_grad`; on the TTT-on-split training path
+    // (#316) the graph is live, so we build the rows out-of-place and stack them.
+    // Numerically identical to the in-place form; only the graph differs.
+    let c = CHUNK_SIZE;
+    // Each entry is a full-width row [B, nv, nc, C]; row 0 is unchanged.
+    let mut rows: Vec<Tensor> = Vec::with_capacity(c as usize);
+    rows.push(attn0.narrow(-2, 0, 1).squeeze_dim(-2)); // [B, nv, nc, C]
+    for i in 1..c {
+        // Original row i, columns [0, i) (columns >= i are 0 from mask0).
+        let a_row = attn0.narrow(-2, i, 1).narrow(-1, 0, i).squeeze_dim(-2); // [B, nv, nc, i]
+        // T[:i, :i] — stack the already-corrected rows, take their first i cols.
+        let sub = Tensor::stack(&rows, -2).narrow(-1, 0, i); // [B, nv, nc, i, i]
+        let correction = a_row.unsqueeze(-2).matmul(&sub).squeeze_dim(-2); // [B, nv, nc, i]
+        let corrected = &a_row + &correction; // [B, nv, nc, i]
+        // Re-pad to full width C (columns [i, C) are 0, matching mask0).
+        let pad_cols = c - i;
+        let zeros = Tensor::zeros(
+            [batch, nv, nc, pad_cols],
+            (Kind::Float, device),
+        );
+        rows.push(Tensor::cat(&[corrected, zeros], -1)); // [B, nv, nc, C]
     }
+    let attn = Tensor::stack(&rows, -2); // [B, nv, nc, C, C]
 
     // Add identity
     let eye = Tensor::eye(CHUNK_SIZE, (Kind::Float, device))
@@ -1990,6 +2009,102 @@ impl Qwen3_5Model {
         Ok(hidden)
     }
 
+    /// Training-path sibling of [`Self::forward_layers_inner`] — the cross-device
+    /// autograd primitive for TTT-on-split (#316). See the trait
+    /// `forward_layers_train` docs for the contract.
+    ///
+    /// Differs from the inference runner in three deliberate ways:
+    /// - **no KV cache** — full-attention layers run with full causal attention
+    ///   over the entire context (`start_pos = 0`, no cache);
+    /// - **`start_pos = 0`** — `position_ids = 0..seq`;
+    /// - **fresh, call-local recurrent (SSM) state** — `conv`/`rec` start at
+    ///   `None` for every owned layer and are never written back to
+    ///   `self.conv_states` / `self.rec_states`. This keeps a TTT step from
+    ///   polluting the persistent inference recurrent state, and makes the split
+    ///   numerically identical to the whole-model training forward (per-layer
+    ///   recurrent state never crosses a layer boundary, so partitioning the layer
+    ///   range is exact).
+    ///
+    /// The lone cross-device `hidden.to_device(next)` (carrying `position_ids`) is
+    /// autograd-transparent, so `loss.backward()` materializes grads on each
+    /// parameter's own device.
+    fn forward_layers_train_inner(
+        &self,
+        hidden: &Tensor,
+        range: std::ops::Range<usize>,
+        delta: Option<&crate::training::TenantDelta>,
+    ) -> Result<Tensor> {
+        let num_global = self.config.num_hidden_layers as usize;
+        if range.end > num_global || range.start >= range.end {
+            return Err(anyhow!(
+                "forward_layers_train: invalid global range {range:?} for {num_global} layers"
+            ));
+        }
+        let owned = self.layer_offset..self.layer_offset + self.layers.len();
+        if range.start < owned.start || range.end > owned.end {
+            return Err(anyhow!(
+                "forward_layers_train: range {range:?} not within this stage's owned layers {owned:?}"
+            ));
+        }
+
+        let mut hidden = hidden.shallow_clone();
+
+        // Training path: start_pos is always 0 → position_ids = 0..seq, built on
+        // the input device and moved alongside `hidden` at each device boundary.
+        let seq = hidden.size()[1];
+        let mut position_ids =
+            Tensor::arange(seq, (Kind::Int64, hidden.device()));
+
+        // Fresh, call-local SSM state — never touches the persistent inference
+        // `conv_states`/`rec_states`. Sized to the OWNED layer count and indexed
+        // locally, mirroring the persistent vectors' sizing.
+        let mut conv_local: Vec<Option<Tensor>> =
+            (0..self.layers.len()).map(|_| None).collect();
+        let mut rec_local: Vec<Option<Tensor>> =
+            (0..self.layers.len()).map(|_| None).collect();
+
+        for g in range {
+            let local_idx = g - self.layer_offset;
+
+            // The single cross-device transfer (autograd-transparent): only when
+            // this layer's mapped device differs from where `hidden` currently is.
+            let target = self.device_map.device_for(g);
+            if hidden.device() != target {
+                hidden = hidden.to_device(target);
+                position_ids = position_ids.to_device(target);
+            }
+
+            let layer = &self.layers[local_idx];
+            let residual = hidden.shallow_clone();
+            hidden = layer.input_layernorm.forward(&hidden)?;
+
+            // Delta module lookup uses the GLOBAL layer index (per-layer LoRA is
+            // keyed by global layer, matching whole-model training).
+            let delta_arg = delta.map(|d| (d, g));
+
+            let mixer_out = match &layer.mixer {
+                LayerMixer::LinearAttn(gdn) => gdn.forward(
+                    &hidden,
+                    &mut conv_local[local_idx],
+                    &mut rec_local[local_idx],
+                    delta_arg,
+                )?,
+                LayerMixer::FullAttn(attn) => {
+                    // No KV cache (training): full causal attention, start_pos = 0.
+                    attn.forward(&hidden, Some(&position_ids), None, 0, delta_arg)?
+                }
+            };
+
+            hidden = residual + &mixer_out;
+
+            let residual2 = hidden.shallow_clone();
+            hidden = layer.post_attention_layernorm.forward(&hidden)?;
+            hidden = layer.mlp.forward(&hidden)?;
+            hidden = residual2 + &hidden;
+        }
+        Ok(hidden)
+    }
+
     /// Encode images through the vision encoder and project to text hidden space.
     ///
     /// pixel_values: [B, C, H, W]
@@ -2222,6 +2337,15 @@ impl ModelOperations for Qwen3_5Model {
         delta: Option<&crate::training::TenantDelta>,
     ) -> Result<Tensor> {
         self.forward_layers_inner(hidden, range, start_pos, delta)
+    }
+
+    fn forward_layers_train(
+        &self,
+        hidden: &Tensor,
+        range: std::ops::Range<usize>,
+        delta: Option<&crate::training::TenantDelta>,
+    ) -> Result<Tensor> {
+        self.forward_layers_train_inner(hidden, range, delta)
     }
 
     fn decode_layer(
@@ -2579,5 +2703,142 @@ mod pipeline_tests {
             Ok(_) => panic!("last stage without norm weight must error"),
             Err(e) => assert!(e.to_string().contains("norm"), "got: {e}"),
         }
+    }
+
+    // ========================================================================
+    // #316 — TTT-on-split cross-device autograd equivalence (CPU-verifiable),
+    // exercising the hybrid GDN + full-attention stack across a stage boundary.
+    // ========================================================================
+
+    use crate::training::tenant_delta::{TenantDelta, TenantDeltaConfig};
+
+    /// Per-layer o_proj LoRA delta on CPU. o_proj is the one module BOTH mixer
+    /// kinds inject (GDN out_proj: in=val_dim; full-attn: in=nh*hd), so its dims
+    /// differ per layer type — supplied via per_layer_dims (mirrors
+    /// `TorchEngine::get_per_layer_lora_dims`). Seeds deterministic non-zero A and
+    /// B so gradients w.r.t. both are non-trivial.
+    fn tiny_delta() -> TenantDelta {
+        let hidden = HIDDEN as usize;
+        let gdn_in = LIN_V_HEADS * LIN_V_DIM; // out_proj input dim for GDN layers
+        let full_in = (HEADS * HEAD_DIM) as usize; // o_proj input dim for full-attn layers
+        let mut per_layer: std::collections::HashMap<usize, std::collections::HashMap<String, (usize, usize)>> =
+            std::collections::HashMap::new();
+        for i in 0..LAYERS {
+            let is_full = (i + 1) % 4 == 0;
+            let mut m = std::collections::HashMap::new();
+            let in_dim = if is_full { full_in } else { gdn_in };
+            m.insert("o_proj".to_owned(), (in_dim, hidden));
+            per_layer.insert(i, m);
+        }
+        let cfg = TenantDeltaConfig {
+            rank: 2,
+            alpha: 2.0,
+            target_modules: vec!["o_proj".to_owned()],
+            ..Default::default()
+        };
+        let flat: std::collections::HashMap<String, (usize, usize)> = std::collections::HashMap::new();
+        let delta = TenantDelta::new_with_per_layer_dims(
+            &cfg, &flat, Device::Cpu, LAYERS, Some(&per_layer),
+        ).unwrap();
+
+        // Seed by a STABLE per-key offset (HashMap iteration order is not
+        // deterministic, so independent builds must agree key-for-key).
+        let key_offset = |key: &str| -> i64 {
+            key.bytes().map(|b| b as i64).sum::<i64>() % 17
+        };
+        let _g = tch::no_grad_guard();
+        for (k, a) in delta.lora_a.iter() {
+            let n: i64 = a.size().iter().product();
+            let vals = (Tensor::arange(n, (Kind::Float, Device::Cpu)) + key_offset(k)).sin() * 0.1;
+            // copy_ needs &mut; shallow_clone shares storage so the delta param is mutated.
+            a.shallow_clone().copy_(&vals.reshape(a.size()));
+        }
+        for (k, b) in delta.lora_b.iter() {
+            let n: i64 = b.size().iter().product();
+            let vals = (Tensor::arange(n, (Kind::Float, Device::Cpu)) + key_offset(k) + 7).cos() * 0.1;
+            b.shallow_clone().copy_(&vals.reshape(b.size()));
+        }
+        delta
+    }
+
+    fn grad_snapshot(delta: &TenantDelta) -> std::collections::HashMap<String, f64> {
+        let mut out = std::collections::HashMap::new();
+        for (k, a) in &delta.lora_a {
+            assert!(a.grad().defined(), "A grad undefined for {k}");
+            out.insert(format!("A:{k}"), a.grad().norm().double_value(&[]));
+        }
+        for (k, b) in &delta.lora_b {
+            assert!(b.grad().defined(), "B grad undefined for {k}");
+            out.insert(format!("B:{k}"), b.grad().norm().double_value(&[]));
+        }
+        out
+    }
+
+    /// The #316 correctness guardrail for the hybrid architecture: a TTT/training
+    /// step (forward_layers_train → NTP loss → backward) over a two-stage CPU split
+    /// must produce the SAME delta gradients as the whole-model training forward,
+    /// within ~1e-4. The split point (k=2) keeps the full-attention layer in stage1
+    /// and GDN layers in stage0, so this proves cross-device autograd is correct
+    /// across both mixer kinds AND the (fresh, stage-local) SSM state threading.
+    #[test]
+    fn ttt_split_autograd_matches_whole_model_grads() {
+        use crate::training::pipeline::{compute_ntp_loss_split, TrainStage};
+
+        let input = Tensor::from_slice(&[3i64, 7, 1, 4, 9, 2]).reshape([1, 6]);
+
+        // (a) whole-model training forward over a single-device map.
+        let whole = whole_model();
+        let whole_delta = tiny_delta();
+        let whole_stage = [TrainStage { model: &whole, range: 0..LAYERS }];
+        let loss_whole = compute_ntp_loss_split(&whole_stage, &input, Some(&whole_delta)).unwrap();
+        loss_whole.backward();
+        let whole_grads = grad_snapshot(&whole_delta);
+        whole_delta.zero_grad();
+
+        // (b) two-stage split over an all-CPU map.
+        let map = LayerDeviceMap::single(Device::Cpu, LAYERS).unwrap();
+        let split = LAYERS / 2;
+        let mut w0 = tiny_weights();
+        let stage0 = Qwen3_5Model::stage_from_weights_with_config(
+            &mut w0, tiny_config(), &map, 0..split, Kind::Float, KVQuantType::None,
+        ).unwrap();
+        let mut w1 = tiny_weights();
+        let stage1 = Qwen3_5Model::stage_from_weights_with_config(
+            &mut w1, tiny_config(), &map, split..LAYERS, Kind::Float, KVQuantType::None,
+        ).unwrap();
+        let split_delta = tiny_delta();
+        let stages = [
+            TrainStage { model: &stage0, range: 0..split },
+            TrainStage { model: &stage1, range: split..LAYERS },
+        ];
+        let loss_split = compute_ntp_loss_split(&stages, &input, Some(&split_delta)).unwrap();
+        loss_split.backward();
+        let split_grads = grad_snapshot(&split_delta);
+
+        let lw = loss_whole.double_value(&[]);
+        let ls = loss_split.double_value(&[]);
+        assert!((lw - ls).abs() < 1e-4, "loss diverged: whole={lw} split={ls}");
+
+        assert_eq!(whole_grads.len(), split_grads.len());
+        for (k, &gw) in &whole_grads {
+            let gs = *split_grads.get(k).unwrap_or_else(|| panic!("missing grad {k}"));
+            assert!(
+                (gw - gs).abs() <= 1e-4 + 1e-4 * gw.abs(),
+                "grad norm diverged for {k}: whole={gw} split={gs}"
+            );
+            assert!(gw > 0.0, "grad for {k} is zero — autograd path not exercised");
+        }
+    }
+
+    #[test]
+    fn forward_layers_train_rejects_out_of_window_range() {
+        let map = LayerDeviceMap::single(Device::Cpu, LAYERS).unwrap();
+        let mut w = tiny_weights();
+        let stage = Qwen3_5Model::stage_from_weights_with_config(
+            &mut w, tiny_config(), &map, 2..LAYERS, Kind::Float, KVQuantType::None,
+        ).unwrap();
+        let emb = Tensor::randn([1, 3, HIDDEN], (Kind::Float, Device::Cpu));
+        assert!(stage.forward_layers_train(&emb, 0..2, None).is_err(), "range below window");
+        assert!(stage.forward_layers_train(&emb, 2..LAYERS, None).is_ok(), "owned range ok");
     }
 }

--- a/crates/hyprstream/src/training/mod.rs
+++ b/crates/hyprstream/src/training/mod.rs
@@ -15,6 +15,7 @@ pub mod data_loader;
 pub mod delta_pool;
 pub mod merge;
 pub mod muon;
+pub mod pipeline;
 pub mod quality_filter;
 pub mod tenant_delta;
 pub mod ttt;
@@ -40,3 +41,5 @@ pub use tenant_delta::{TenantDelta, TenantDeltaConfig, SharedTenantDelta, serial
 pub use merge::{MergeStrategy, merge_state_dicts};
 
 pub use ttt::{TTTConfig, TTTContext, TTTOverrides, TTTResult, TTTVerifier, TestTimeTrainer, RankOracle, RankOracleConfig, GradientGatingConfig};
+
+pub use pipeline::{compute_ntp_loss_split, forward_train_pipeline, stage_ranges, TrainStage};

--- a/crates/hyprstream/src/training/pipeline.rs
+++ b/crates/hyprstream/src/training/pipeline.rs
@@ -1,0 +1,212 @@
+//! Pipeline-split (2b) **training** orchestration for TTT-on-split (#316).
+//!
+//! This is the training counterpart to the inference `forward_layers` pipeline
+//! (#314): it drives a TTT/training forward across a set of per-device *stage*
+//! models, building a single autograd graph over the
+//! [`crate::runtime::device_pool::LayerDeviceMap`] so that `loss.backward()`
+//! traverses the same partition inference uses (M-TRAIN-COUPLING). The only
+//! cross-device copies are the stage-boundary `hidden.to_device(next)` transfers
+//! inside each stage's `forward_layers_train`, which tch makes
+//! autograd-transparent — gradients flow back across device boundaries to each
+//! parameter's own device.
+//!
+//! # Stage contract (mirrors the inference pipeline)
+//! Stages are contiguous global layer ranges `[a..b)` derived from the device
+//! map. The first stage owns `embed_tokens`, the last stage owns the final norm
+//! and LM head:
+//! - **stage 0** : `embed_tokens` → `forward_layers_train(0..b)`
+//! - **middle**  : `forward_layers_train(a..b)`
+//! - **last**    : `forward_layers_train(a..N)` → `apply_final_norm` → `lm_head`
+//!
+//! Each stage's training runner uses **no KV cache, full causal attention,
+//! `start_pos = 0`, and fresh call-local recurrent (SSM) state** — see
+//! [`crate::runtime::architectures::ModelOperations::forward_layers_train`].
+//!
+//! # Send / !Send
+//! Like the inference pipeline, the stage models hold `!Send` tch tensors and
+//! must all live on the **one** engine-owning thread; this module never crosses a
+//! thread boundary. Multi-device-on-one-thread is fine (libtorch `DeviceGuard`).
+//! The single-stage case (`stages.len() == 1` over a single-device map) is the
+//! unsplit fast path and is byte-identical to whole-model training.
+
+use anyhow::{anyhow, Result};
+use tch::Tensor;
+
+use crate::runtime::architectures::ModelOperations;
+use crate::runtime::device_pool::LayerDeviceMap;
+use super::tenant_delta::TenantDelta;
+
+/// A single pipeline stage: the stage model plus the global layer range it owns.
+///
+/// `range` is in **global** layer indices `[a..b)`; the stage model remaps to its
+/// local `self.layers` via the `layer_offset` it was constructed with. Built from
+/// `stage_from_weights_with_config` (#314).
+pub struct TrainStage<'a> {
+    /// The stage's model (owns embeddings iff `range.start == 0`; owns final
+    /// norm + LM head iff `range.end == num_layers`).
+    pub model: &'a dyn ModelOperations,
+    /// Global layer range this stage owns.
+    pub range: std::ops::Range<usize>,
+}
+
+/// Derive contiguous stage ranges from a [`LayerDeviceMap`].
+///
+/// Each maximal run of consecutive layers mapped to the same device becomes one
+/// stage `[a..b)`. A single-device map yields exactly one stage `0..N`.
+#[must_use]
+pub fn stage_ranges(map: &LayerDeviceMap) -> Vec<std::ops::Range<usize>> {
+    let n = map.len();
+    let mut ranges = Vec::new();
+    if n == 0 {
+        return ranges;
+    }
+    let mut start = 0usize;
+    let mut prev = map.device_for(0);
+    for g in 1..n {
+        let dev = map.device_for(g);
+        if dev != prev {
+            ranges.push(start..g);
+            start = g;
+            prev = dev;
+        }
+    }
+    ranges.push(start..n);
+    ranges
+}
+
+/// Run the TTT/training forward across pipeline stages and return logits with the
+/// autograd graph intact across device boundaries.
+///
+/// `input_ids` is `[batch, seq]` and must already live on the first stage's
+/// device. Stages must be contiguous, gap-free, and cover `0..num_layers` in
+/// order (validated). The caller is responsible for wrapping this in
+/// `tch::with_grad` and computing/backpropagating the loss.
+pub fn forward_train_pipeline(
+    stages: &[TrainStage<'_>],
+    input_ids: &Tensor,
+    delta: Option<&TenantDelta>,
+) -> Result<Tensor> {
+    if stages.is_empty() {
+        return Err(anyhow!("forward_train_pipeline: no stages provided"));
+    }
+    // Validate contiguity and full coverage (the first stage must start at 0;
+    // each subsequent stage must start where the previous ended).
+    if stages[0].range.start != 0 {
+        return Err(anyhow!(
+            "forward_train_pipeline: first stage must start at layer 0 (got {:?})",
+            stages[0].range
+        ));
+    }
+    for w in stages.windows(2) {
+        if w[0].range.end != w[1].range.start {
+            return Err(anyhow!(
+                "forward_train_pipeline: stages must be contiguous ({:?} then {:?})",
+                w[0].range,
+                w[1].range
+            ));
+        }
+    }
+
+    let first = &stages[0];
+    // Stage 0 owns the embedding; subsequent stages consume the prior hidden.
+    let mut hidden = first.model.embed_tokens(input_ids)?;
+    hidden = first
+        .model
+        .forward_layers_train(&hidden, first.range.clone(), delta)?;
+
+    for stage in &stages[1..] {
+        hidden = stage
+            .model
+            .forward_layers_train(&hidden, stage.range.clone(), delta)?;
+    }
+
+    // The last stage owns the final norm + LM head.
+    let last = stages
+        .last()
+        .ok_or_else(|| anyhow!("forward_train_pipeline: missing last stage"))?;
+    hidden = last.model.apply_final_norm(&hidden)?;
+    last.model.lm_head(&hidden)
+}
+
+/// Compute the next-token-prediction (NTP) cross-entropy loss for a TTT step over
+/// a pipeline split, with the autograd graph intact across device boundaries.
+///
+/// Mirrors `TestTimeTrainer::compute_ntp_loss_with_delta` (the single-device
+/// path) but drives the forward across `stages`. The returned loss tensor's
+/// backward pass materializes gradients on each parameter's own device.
+///
+/// `input_ids` is `[1, seq]` on the first stage's device; the loss is computed on
+/// that same device (the last stage's logits are produced on the last stage's
+/// device, and the shifted targets are taken from `input_ids`, moved to the
+/// logits' device).
+pub fn compute_ntp_loss_split(
+    stages: &[TrainStage<'_>],
+    input_ids: &Tensor,
+    delta: Option<&TenantDelta>,
+) -> Result<Tensor> {
+    tch::with_grad(|| {
+        let logits = forward_train_pipeline(stages, input_ids, delta)?;
+
+        let seq_len = input_ids.size()[1];
+        if seq_len < 2 {
+            return Err(anyhow!(
+                "compute_ntp_loss_split: need at least 2 tokens for NTP loss (got {seq_len})"
+            ));
+        }
+        let vocab_size = logits.size()[2];
+
+        // Shift for next-token prediction. Targets live on `input_ids`' device;
+        // move them to the logits' device (the last stage's) for cross_entropy.
+        let pred_logits = logits.narrow(1, 0, seq_len - 1).reshape([-1, vocab_size]);
+        let target_ids = input_ids
+            .narrow(1, 1, seq_len - 1)
+            .reshape([-1])
+            .to_device(pred_logits.device());
+
+        let loss = pred_logits.cross_entropy_loss::<Tensor>(
+            &target_ids,
+            None,
+            tch::Reduction::Mean,
+            -100,
+            0.0,
+        );
+        Ok(loss)
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use tch::Device;
+
+    #[test]
+    fn stage_ranges_single_device_is_one_stage() {
+        let map = LayerDeviceMap::single(Device::Cpu, 4).expect("map");
+        assert_eq!(stage_ranges(&map), vec![0..4]);
+    }
+
+    #[test]
+    fn stage_ranges_two_device_split() {
+        let map = LayerDeviceMap::from_per_layer(vec![
+            Device::Cpu,
+            Device::Cpu,
+            Device::Cuda(0),
+            Device::Cuda(0),
+        ])
+        .expect("map");
+        assert_eq!(stage_ranges(&map), vec![0..2, 2..4]);
+    }
+
+    #[test]
+    fn stage_ranges_three_stages() {
+        let map = LayerDeviceMap::from_per_layer(vec![
+            Device::Cpu,
+            Device::Cuda(0),
+            Device::Cuda(0),
+            Device::Cuda(1),
+        ])
+        .expect("map");
+        assert_eq!(stage_ranges(&map), vec![0..1, 1..3, 3..4]);
+    }
+}

--- a/crates/hyprstream/src/training/tenant_delta.rs
+++ b/crates/hyprstream/src/training/tenant_delta.rs
@@ -469,7 +469,17 @@ impl TenantDelta {
         // BF16 + fp32 add panics (addmm requires matching dtypes). The cast back is a
         // device-agnostic no-op when input_kind already equals a.kind().
         let input_kind = x.kind();
+        let input_device = x.device();
         let x = x.to_kind(a.kind());
+        // Pipeline-split (#316) cross-device autograd: the delta's VarStore lives on
+        // a single `self.device`, but under a layer-split TTT the activation `x` may
+        // be on a different device than this layer's delta params. Move A/B onto the
+        // activation's device so the matmuls are device-consistent; `to_device` is
+        // autograd-transparent, so gradients flow back to the params on `self.device`.
+        // On the single-device path both moves are no-op views (source == dest),
+        // keeping the existing TTT behavior byte-identical.
+        let a_eff = a_eff.to_device(input_device);
+        let b_eff = b_eff.to_device(input_device);
         let intermediate = x.f_matmul(&a_eff.tr())
             .map_err(|e| anyhow!("Delta forward_2d matmul A failed for '{}': {}", key, e))?;
         let output = intermediate.f_matmul(&b_eff.tr())


### PR DESCRIPTION
Adds the **training counterpart of `forward_layers`** (#314) so test-time training (TTT) works over a layer-split partition, with autograd flowing backward across device boundaries (M-TRAIN-COUPLING). Intra-host only — cross-host pipeline-parallel training (backward comms) is #327.

Closes #316
Part of #310

## `forward_layers_train` design
New trait method `ModelOperations::forward_layers_train(hidden, range, delta)` (default-errors), implemented for **llama** (reference) and **qwen3_5** (v1 target). It mirrors the inference `forward_layers` layer loop with three deliberate differences for the training path:
- **no KV cache** — full causal attention recomputed over the entire context (`compute_attention` applies the `tril` mask when no cache is present);
- **`start_pos = 0`** — `position_ids = 0..seq`;
- **fresh, call-local recurrent (SSM) state** for qwen3_5's GatedDeltaNet layers — `conv`/`rec` start at `None` and are never written back to the persistent `self.conv_states`/`self.rec_states`, so a TTT step can't pollute the inference recurrent state, and the split is numerically identical to whole-model training (per-layer recurrent state never crosses a layer boundary).

Inference and training paths stay separate, exactly as the whole-model paths already are — this is purely additive; the single-device whole-model training path (`TorchEngine::forward_with_delta`) is untouched.

## Cross-device autograd / grad placement
- The lone stage-boundary `hidden.to_device(next)` (carrying `position_ids`) is **autograd-transparent** (tch `to_device` is differentiable), so `loss.backward()` traverses the same partition inference uses and materializes grads on each parameter's own device across the `LayerDeviceMap`.
- `TenantDelta::forward_2d` now moves the LoRA A/B onto the **activation's device** before the matmuls. Under a split the activation may live on a different device than the delta's VarStore; `to_device` is autograd-transparent, so grads still flow back to the params on the delta's device. On the single-device path both moves are no-op views (source == dest), keeping existing TTT byte-identical.
- **qwen3_5 GatedDeltaNet prefill fix:** the chunked delta-rule forward-substitution built its matrix with an in-place `attn[..i].copy_(row)`. That's fine under inference `no_grad`, but on the live training graph it corrupts a tensor saved for backward (`variable needed for gradient computation modified by an inplace operation`). Replaced with an out-of-place row stack — numerically identical, only the graph differs. (This is a prerequisite for any qwen TTT backward through GDN layers, not just the split.)

## Wiring (`training::pipeline`)
- `forward_train_pipeline` / `compute_ntp_loss_split` drive a TTT step across stages: `embed_tokens` → `forward_layers_train(0..b)` → … → `forward_layers_train(a..N)` → `apply_final_norm` → `lm_head`, returning the NTP loss with the autograd graph intact across boundaries. This mirrors `TestTimeTrainer::compute_ntp_loss_with_delta` for the split.
- `stage_ranges` derives contiguous stages from a `LayerDeviceMap`. Single-stage over a single-device map is the unsplit fast path (byte-identical to whole-model training).

## CPU autograd-equivalence results (correctness guardrail)
New tests `*::pipeline_tests::ttt_split_autograd_matches_whole_model_grads` for **both** llama and qwen3_5: run a TTT step (forward_layers_train → NTP loss → backward) over (a) the whole model and (b) a two-stage all-CPU `LayerDeviceMap`, then assert the **loss and every per-key delta gradient match within 1e-4**. The qwen split puts the full-attention layer in stage1 and GDN layers in stage0, exercising both mixer kinds + stage-local SSM threading. Tests also assert each compared gradient is non-zero, guarding against a silently-detached path passing at 0.

Result: **both pass.** (A bug found along the way was in the test fixture, not the impl — seeding delta values by HashMap enumeration index instead of a stable per-key offset; fixed.)

Real 2×MI210 split-TTT-vs-single-GPU validation is **#317**; not attempted here (no multi-GPU HW).

## Single-device byte-identity
`forward_layers_train` over a single-device map runs the identical sequence to the production `decode_layer_with_delta` loop; the delta device-move and the boundary `to_device` are no-ops when source == dest. The existing single-device TTT path is unchanged.

## Build / test / clippy
- `cargo build -p hyprstream` ✅
- `cargo test -p hyprstream --lib` ✅ 686 passed, 0 failed (incl. new autograd-equivalence + pipeline/device_pool/qwen/ttt tests)
- `cargo clippy -p hyprstream --all-targets -D warnings` ✅ clean

## Files changed
- `runtime/architectures/mod.rs` — `forward_layers_train` trait method
- `runtime/architectures/llama.rs` — impl + autograd-equivalence test
- `runtime/architectures/qwen3_5.rs` — impl + GDN prefill autograd-safety fix + autograd-equivalence test
- `training/pipeline.rs` (new) — stage orchestration + split NTP loss
- `training/mod.rs` — module/exports
- `training/tenant_delta.rs` — device-aware `forward_2d`

Did not touch capnp/RPC/auth/policy.