### PR TITLE
fix(auth): per-host mesh identity — fix fail-unsafe ClusterKeySource/"system" collapse (#328)

### DIFF
--- a/crates/hyprstream-rpc/src/auth/key_source.rs
+++ b/crates/hyprstream-rpc/src/auth/key_source.rs
@@ -95,6 +95,20 @@ pub trait JwtKeySource: Send + Sync + 'static {
 /// This is the common case: all services in a cluster trust one PolicyService,
 /// identified by its OAuth issuer URL. JWTs with empty `iss` or matching the
 /// local issuer URL are verified against the CA key.
+///
+/// # NOT a mesh authority (#328)
+///
+/// `ClusterKeySource` holds a SINGLE shared CA key and treats an empty `iss` as
+/// always-trusted/local. That is correct for the in-cluster bare-`sub` token
+/// plane, but it MUST NOT be the verification authority for networked **mesh
+/// peers**: a single shared key cannot distinguish per-host peers, and the
+/// empty-`iss` shortcut would let a networked peer inherit local trust. Mesh
+/// peer identity is established by the per-host key roster (Ed25519 signer →
+/// `service:inference:host-<label>`, resolved fail-closed via
+/// `RequestService::resolve_key_subject`), and the empty-`iss` shortcut is
+/// confined to genuine in-process callers in `verify_claims`
+/// (`EnvelopeContext::is_local_caller`). For kid-routed multi-key verification
+/// prefer [`JwksKeySource`], which honors the `kid` hint.
 #[derive(Clone)]
 pub struct ClusterKeySource {
     ca_verifying_key: VerifyingKey,
@@ -149,7 +163,11 @@ impl JwtKeySource for ClusterKeySource {
     }
 
     fn is_trusted(&self, issuer: &str) -> bool {
-        // Empty issuer is always local
+        // Empty issuer is treated as local here. This is SOUND only because the
+        // empty-`iss` shortcut is gated by transport upstream in
+        // `verify_claims` (#328): a networked / mesh caller presenting an
+        // empty-`iss` token is rejected before this is consulted, so empty `iss`
+        // reaches here only for genuine in-process / IPC callers.
         if issuer.is_empty() {
             return true;
         }

--- a/crates/hyprstream-rpc/src/node_identity.rs
+++ b/crates/hyprstream-rpc/src/node_identity.rs
@@ -14,7 +14,7 @@ use async_trait::async_trait;
 use ed25519_dalek::SigningKey;
 use hkdf::Hkdf;
 use sha2::Sha256;
-use std::collections::HashSet;
+use std::collections::HashMap;
 use parking_lot::RwLock;
 use zeroize::Zeroize;
 
@@ -24,6 +24,17 @@ use crate::Subject;
 /// Domain-separated HKDF salt for node identity derivation.
 /// Prevents cross-protocol confusion if the same seed material is used elsewhere.
 const NODE_IDENTITY_SALT: &[u8] = b"hyprstream-node-identity-hkdf-v1";
+
+/// Build the per-host mesh-peer subject for an enrolled host label (#328).
+///
+/// Extends the existing `service:<name>` convention (see
+/// `EnvelopeContext::from_callback_service`) with a per-host third segment so
+/// every mesh peer authenticates as its OWN granular principal
+/// (`service:inference:host-<label>`) rather than collapsing to the omnipotent
+/// `"system"` principal. The label is the operator-assigned `mesh_peers` key.
+pub fn mesh_host_subject(label: &str) -> Subject {
+    Subject::new(format!("service:inference:host-{label}"))
+}
 
 /// Derive a purpose-keyed Ed25519 signing key from a root key.
 ///
@@ -91,14 +102,22 @@ impl SigningIdentity for DerivedIdentity {
 
 /// Native identity provider backed by a root Ed25519 key.
 ///
-/// Derives purpose-keyed identities via HKDF. Tracks all derived pubkeys
-/// so `resolve()` can map them back to the node's "system" subject.
+/// Derives purpose-keyed identities via HKDF. Maps every recognized pubkey to a
+/// specific authorization [`Subject`] (#328): the node's own root/derived keys
+/// map to `"system"` (genuine in-process authority), while enrolled mesh-peer
+/// keys map to their per-host subject (`service:inference:host-<label>`). An
+/// unrecognized pubkey resolves to [`Subject::anonymous`] — deny-by-default,
+/// never the `"system"` god principal.
 pub struct NodeIdentityProvider {
     root_seed: [u8; 32],
     #[allow(dead_code)]
     node_pubkey: [u8; 32],
-    /// All pubkeys derived from this node's root — recognized as "system".
-    known_pubkeys: RwLock<HashSet<[u8; 32]>>,
+    /// Recognized pubkey → authorization subject.
+    ///
+    /// The node's own root and purpose-derived keys are inserted with
+    /// `Subject::new("system")`; mesh peers are inserted via
+    /// [`NodeIdentityProvider::register_peer`] with their per-host subject.
+    known_pubkeys: RwLock<HashMap<[u8; 32], Subject>>,
 }
 
 impl Drop for NodeIdentityProvider {
@@ -111,8 +130,9 @@ impl NodeIdentityProvider {
     /// Create from a root signing key.
     pub fn new(root_key: &SigningKey) -> Self {
         let node_pubkey = root_key.verifying_key().to_bytes();
-        let mut known = HashSet::new();
-        known.insert(node_pubkey);
+        let mut known = HashMap::new();
+        // The node's own root key is genuine in-process authority → "system".
+        known.insert(node_pubkey, Subject::new("system"));
         Self {
             root_seed: root_key.to_bytes(),
             node_pubkey,
@@ -140,18 +160,47 @@ impl NodeIdentityProvider {
 
     /// Pre-register a purpose so its derived pubkey is recognized by `resolve()`.
     ///
-    /// Called automatically by `identity_open()`, but can also be called
-    /// at startup to register purposes used by remote peers.
+    /// The derived key belongs to THIS node, so it maps to the in-process
+    /// `"system"` authority. Called automatically by `identity_open()`, but can
+    /// also be called at startup to register purposes used internally.
     pub fn register_purpose(&self, purpose: &str) -> Result<[u8; 32]> {
         let key = self.derive(purpose)?;
         let pubkey = key.verifying_key().to_bytes();
-        self.known_pubkeys.write().insert(pubkey);
+        self.known_pubkeys.write().insert(pubkey, Subject::new("system"));
         Ok(pubkey)
     }
 
-    /// Check if a pubkey belongs to this node (root or any derived purpose).
+    /// Enroll a networked mesh peer's Ed25519 signer key → per-host subject (#328).
+    ///
+    /// The peer authenticates as its OWN granular principal
+    /// (`service:inference:host-<label>`), NEVER as `"system"`. The roster is
+    /// populated from the operator-configured `mesh_peers` enrollment record
+    /// (see `hyprstream::auth::mesh_trust`), so a peer whose key is not enrolled
+    /// resolves to [`Subject::anonymous`] (fail-closed, deny-by-default).
+    ///
+    /// A peer key MUST NOT shadow the node's own `"system"` keys: if the pubkey
+    /// is already registered (e.g. the node's root/derived key), the existing
+    /// binding is kept and the peer entry is rejected to prevent a misconfigured
+    /// roster from downgrading in-process authority.
+    pub fn register_peer(&self, pubkey: [u8; 32], subject: Subject) {
+        let mut map = self.known_pubkeys.write();
+        match map.entry(pubkey) {
+            std::collections::hash_map::Entry::Occupied(existing) => {
+                tracing::warn!(
+                    existing = ?existing.get().name(),
+                    rejected = ?subject.name(),
+                    "node_identity: mesh peer key collides with an existing binding; keeping existing, rejecting peer enrollment"
+                );
+            }
+            std::collections::hash_map::Entry::Vacant(slot) => {
+                slot.insert(subject);
+            }
+        }
+    }
+
+    /// Check if a pubkey is recognized by this node (root, derived, or enrolled peer).
     pub fn is_known(&self, pubkey: &[u8; 32]) -> bool {
-        self.known_pubkeys.read().contains(pubkey)
+        self.known_pubkeys.read().contains_key(pubkey)
     }
 }
 
@@ -161,17 +210,20 @@ impl IdentityProvider for NodeIdentityProvider {
     async fn identity_open(&self, purpose: &str) -> Result<Box<dyn SigningIdentity>> {
         let signing_key = self.derive(purpose)?;
         let pubkey = signing_key.verifying_key().to_bytes();
-        // Track this derived pubkey so resolve() recognizes it
-        self.known_pubkeys.write().insert(pubkey);
+        // Track this derived pubkey so resolve() recognizes it as in-process "system".
+        self.known_pubkeys.write().insert(pubkey, Subject::new("system"));
         Ok(Box::new(DerivedIdentity { signing_key, pubkey }))
     }
 
     fn resolve(&self, pubkey: &[u8; 32]) -> Subject {
-        if self.known_pubkeys.read().contains(pubkey) {
-            Subject::new("system")
-        } else {
-            Subject::anonymous()
-        }
+        // Return the per-key subject: "system" for the node's own root/derived
+        // keys, a per-host subject for enrolled mesh peers, anonymous otherwise
+        // (#328 — no "any known key → system" collapse, deny-by-default).
+        self.known_pubkeys
+            .read()
+            .get(pubkey)
+            .cloned()
+            .unwrap_or_else(Subject::anonymous)
     }
 }
 
@@ -245,6 +297,69 @@ mod tests {
 
         // Unknown key still anonymous
         assert_eq!(provider.resolve(&[0u8; 32]).name(), None);
+    }
+
+    #[allow(clippy::unwrap_used)]
+    #[test]
+    fn enrolled_peer_resolves_to_per_host_subject() {
+        // #328: an enrolled mesh peer must resolve to its OWN granular per-host
+        // subject, never to "system".
+        let root = SigningKey::generate(&mut rand::rngs::OsRng);
+        let provider = NodeIdentityProvider::new(&root);
+
+        let peer = SigningKey::generate(&mut rand::rngs::OsRng);
+        let peer_pub = peer.verifying_key().to_bytes();
+        provider.register_peer(peer_pub, mesh_host_subject("gpu-node-7"));
+
+        assert_eq!(
+            provider.resolve(&peer_pub).name(),
+            Some("service:inference:host-gpu-node-7"),
+        );
+    }
+
+    #[allow(clippy::unwrap_used)]
+    #[test]
+    fn unenrolled_peer_resolves_to_anonymous_not_system() {
+        // #328 regression: the old "any known key → system god principal"
+        // behavior is gone. A networked peer key that is NOT in the roster must
+        // resolve to anonymous, never "system".
+        let root = SigningKey::generate(&mut rand::rngs::OsRng);
+        let provider = NodeIdentityProvider::new(&root);
+
+        let stranger = SigningKey::generate(&mut rand::rngs::OsRng);
+        let stranger_pub = stranger.verifying_key().to_bytes();
+
+        let resolved = provider.resolve(&stranger_pub);
+        assert!(resolved.is_anonymous(), "unenrolled peer must be anonymous");
+        assert_ne!(resolved.name(), Some("system"));
+    }
+
+    #[allow(clippy::unwrap_used)]
+    #[test]
+    fn node_root_key_still_resolves_to_system() {
+        // #328 no-regression: the node's own root key (genuine in-process
+        // authority) must keep resolving to "system".
+        let root = SigningKey::generate(&mut rand::rngs::OsRng);
+        let node_pub = root.verifying_key().to_bytes();
+        let provider = NodeIdentityProvider::new(&root);
+        assert_eq!(provider.resolve(&node_pub).name(), Some("system"));
+    }
+
+    #[allow(clippy::unwrap_used)]
+    #[test]
+    fn peer_enrollment_cannot_shadow_system_keys() {
+        // #328: a misconfigured roster must not be able to downgrade the node's
+        // own "system" authority by re-binding the node's root key.
+        let root = SigningKey::generate(&mut rand::rngs::OsRng);
+        let node_pub = root.verifying_key().to_bytes();
+        let provider = NodeIdentityProvider::new(&root);
+
+        provider.register_peer(node_pub, mesh_host_subject("evil"));
+        assert_eq!(
+            provider.resolve(&node_pub).name(),
+            Some("system"),
+            "existing system binding must win over a colliding peer enrollment"
+        );
     }
 
     #[allow(clippy::unwrap_used)]

--- a/crates/hyprstream-rpc/src/service/svc.rs
+++ b/crates/hyprstream-rpc/src/service/svc.rs
@@ -104,6 +104,17 @@ pub struct EnvelopeContext {
     /// Client's ephemeral DH public key for stream key derivation.
     /// Present on streaming requests; extracted from `RequestEnvelope.client_dh_public`.
     client_dh_public: Option<[u8; 32]>,
+
+    /// Whether this request originated from a genuine in-process / IPC caller
+    /// (the `FixedSigner` mutual-auth plane), as opposed to a networked peer
+    /// (the `AnySigner` plane used by ZMQ-QUIC / iroh / WebTransport).
+    ///
+    /// `true` ONLY for `from_verified_as_system` and `from_callback_service`
+    /// (genuine local callers). Networked callers (`from_verified`) are `false`.
+    /// Gates the empty-`iss` JWT shortcut (#328): an empty issuer is the local
+    /// PolicyService's bare-`sub` token and is accepted ONLY for local callers;
+    /// a networked peer presenting an empty-`iss` token is rejected (fail-closed).
+    is_local_caller: bool,
 }
 
 impl EnvelopeContext {
@@ -124,6 +135,8 @@ impl EnvelopeContext {
             cnf: envelope.cnf,
             envelope_wit_hash: envelope.envelope.wth,
             client_dh_public: envelope.envelope.client_dh_public,
+            // AnySigner / networked plane — NOT a local caller (#328).
+            is_local_caller: false,
         }
     }
 
@@ -142,6 +155,8 @@ impl EnvelopeContext {
             cnf: envelope.cnf,
             envelope_wit_hash: envelope.envelope.wth,
             client_dh_public: envelope.envelope.client_dh_public,
+            // FixedSigner mutual-auth plane — genuine in-process / IPC caller (#328).
+            is_local_caller: true,
         }
     }
 
@@ -164,6 +179,8 @@ impl EnvelopeContext {
             cnf: [0u8; 32],
             envelope_wit_hash: None,
             client_dh_public: None,
+            // Internal self-call that never crosses a network boundary (#328).
+            is_local_caller: true,
         }
     }
 
@@ -228,6 +245,15 @@ impl EnvelopeContext {
     /// Used by streaming handlers to derive shared secrets for HMAC chain keys.
     pub fn ephemeral_pubkey(&self) -> Option<[u8; 32]> {
         self.client_dh_public
+    }
+
+    /// Whether this request came from a genuine in-process / IPC caller (#328).
+    ///
+    /// `true` for the `FixedSigner` mutual-auth plane and internal self-calls;
+    /// `false` for networked / mesh peers (`AnySigner`). Used to confine the
+    /// empty-`iss` JWT shortcut to local callers.
+    pub fn is_local_caller(&self) -> bool {
+        self.is_local_caller
     }
 
 }
@@ -394,6 +420,21 @@ pub trait RequestService: 'static {
         // Decode the JWT to get claims for issuer routing
         let unverified = crate::auth::decode_unverified(&token)
             .map_err(|e| anyhow::anyhow!("JWT decode failed: {}", e))?;
+
+        // Empty-`iss` gate (#328): an empty issuer denotes the local
+        // PolicyService's bare-`sub` token, which the key sources treat as
+        // "always local/trusted". That is only safe for genuine in-process /
+        // IPC callers (the FixedSigner plane). A networked / mesh peer
+        // (AnySigner) presenting an empty-`iss` token would otherwise inherit
+        // local trust — reject it fail-closed; mesh peers must present an
+        // explicit issuer (or authenticate via the key roster, no JWT).
+        if unverified.iss.is_empty() && !ctx.is_local_caller {
+            tracing::warn!(
+                service = self.name(),
+                "rejecting empty-iss JWT from a networked caller (empty issuer is in-process only) (#328)"
+            );
+            anyhow::bail!("empty JWT issuer is only accepted from in-process callers");
+        }
 
         // Extract kid from JOSE header for key selection
         let kid = crate::auth::header_kid(&token)
@@ -714,6 +755,120 @@ impl ServiceHandle {
     /// Check if the service is still running
     pub fn is_running(&self) -> bool {
         self.task.as_ref().map(|t| !t.is_finished()).unwrap_or(true)
+    }
+}
+
+/// Empty-`iss` transport-gating tests (#328).
+///
+/// An empty JWT issuer denotes the local PolicyService's bare-`sub` token, which
+/// the key sources treat as always-trusted/local. That shortcut is confined to
+/// genuine in-process / IPC callers (`EnvelopeContext::is_local_caller`); a
+/// networked / mesh peer presenting an empty-`iss` token is rejected fail-closed.
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod empty_iss_gate_tests {
+    use super::*;
+    use crate::auth::{Claims, ClusterKeySource};
+    use crate::transport::TransportConfig;
+    use ed25519_dalek::SigningKey;
+
+    /// Minimal mock service exposing a `ClusterKeySource` for JWT verification.
+    /// `require_cnf_binding` is disabled so the empty-`iss` gate is exercised in
+    /// isolation (without a cnf-binding rejection masking the result).
+    struct MockService {
+        signing_key: SigningKey,
+        transport: TransportConfig,
+        key_source: std::sync::Arc<dyn crate::auth::JwtKeySource>,
+    }
+
+    #[async_trait(?Send)]
+    impl RequestService for MockService {
+        async fn handle_request(&self, _ctx: &EnvelopeContext, _payload: &[u8]) -> Result<(Vec<u8>, Option<Continuation>)> {
+            Ok((vec![], None))
+        }
+        fn name(&self) -> &str { "mock" }
+        fn transport(&self) -> &TransportConfig { &self.transport }
+        fn signing_key(&self) -> SigningKey { self.signing_key.clone() }
+        fn jwt_key_source(&self) -> Option<std::sync::Arc<dyn crate::auth::JwtKeySource>> {
+            Some(self.key_source.clone())
+        }
+        fn require_cnf_binding(&self) -> bool { false }
+        fn pq_signing_key(&self) -> Option<crate::crypto::pq::MlDsaSigningKey> { None }
+    }
+
+    /// Build an `EnvelopeContext` carrying `jwt_token`, with the chosen
+    /// transport provenance.
+    fn ctx_with_token(token: String, is_local_caller: bool) -> EnvelopeContext {
+        EnvelopeContext {
+            request_id: 1,
+            claims: None,
+            jwt_token: Some(token),
+            key_derived_subject: Subject::anonymous(),
+            jwt_subject: None,
+            cnf: [0u8; 32],
+            envelope_wit_hash: None,
+            client_dh_public: None,
+            is_local_caller,
+        }
+    }
+
+    fn mock_service() -> (MockService, SigningKey) {
+        // The CA key signs the bare-sub (empty-iss) token; the ClusterKeySource
+        // anchors that same CA key with an empty local issuer URL (so empty iss
+        // is "local").
+        let ca = SigningKey::from_bytes(&[7u8; 32]);
+        let key_source = std::sync::Arc::new(ClusterKeySource::new(
+            ca.verifying_key(),
+            String::new(),
+        ));
+        let svc = MockService {
+            signing_key: SigningKey::from_bytes(&[8u8; 32]),
+            transport: TransportConfig::inproc("mock"),
+            key_source,
+        };
+        (svc, ca)
+    }
+
+    fn empty_iss_token(ca: &SigningKey) -> String {
+        // iss defaults to empty in Claims::new — the local bare-sub token.
+        let now = chrono::Utc::now().timestamp();
+        let claims = Claims::new("alice".to_owned(), now, now + 3600);
+        assert!(claims.iss.is_empty(), "test token must have empty iss");
+        crate::auth::jwt::encode(&claims, ca)
+    }
+
+    #[tokio::test]
+    async fn empty_iss_rejected_for_networked_caller() {
+        let (svc, ca) = mock_service();
+        let token = empty_iss_token(&ca);
+        let mut ctx = ctx_with_token(token, /* is_local_caller */ false);
+
+        let result = svc.verify_claims(&mut ctx).await;
+        assert!(result.is_err(), "networked empty-iss token must be rejected");
+        let msg = result.err().map(|e| e.to_string()).unwrap_or_default();
+        assert!(
+            msg.contains("empty JWT issuer is only accepted from in-process callers"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_iss_accepted_for_inproc_caller() {
+        let (svc, ca) = mock_service();
+        let token = empty_iss_token(&ca);
+        let mut ctx = ctx_with_token(token, /* is_local_caller */ true);
+
+        let result = svc.verify_claims(&mut ctx).await;
+        assert!(result.is_ok(), "in-process empty-iss token must pass the gate: {result:?}");
+        // And the local bare-sub subject is resolved.
+        assert_eq!(ctx.subject().name(), Some("alice"));
+    }
+
+    #[test]
+    fn constructor_provenance_flags() {
+        // from_callback_service is a genuine in-process self-call.
+        let cb = EnvelopeContext::from_callback_service(1, "inference");
+        assert!(cb.is_local_caller());
     }
 }
 

--- a/crates/hyprstream/src/auth/mesh_trust.rs
+++ b/crates/hyprstream/src/auth/mesh_trust.rs
@@ -16,6 +16,7 @@
 //! behavior (Hybrid fails closed for unknown peers).
 
 use hyprstream_rpc::envelope::KeyedPqTrustStore;
+use hyprstream_rpc::Subject;
 
 use crate::config::OAuthConfig;
 
@@ -87,6 +88,49 @@ pub fn build_mesh_pq_trust_store(oauth: &OAuthConfig) -> KeyedPqTrustStore {
         tracing::info!("mesh_peer '{label}': anchored ML-DSA-65 key for Ed25519 signer identity");
     }
     store
+}
+
+/// Build the per-host mesh identity roster from the admin-configured
+/// `mesh_peers` (#328): each peer's Ed25519 signer pubkey → its per-host
+/// authorization subject (`service:inference:host-<label>`).
+///
+/// Reuses the SAME `mesh_peers` enrollment record as
+/// [`build_mesh_pq_trust_store`] (no new roster type): the Ed25519 key is the
+/// envelope signer identity, and the operator-assigned label is the host id.
+/// An invalid Ed25519 multibase is logged and skipped (fail-safe — never trust
+/// a malformed identity). An empty/absent `mesh_peers` yields an empty roster.
+///
+/// This is the source for fail-closed per-host identity resolution: a networked
+/// peer whose key is NOT in this roster resolves to `anonymous`, never the
+/// `"system"` god principal (#328).
+pub fn build_mesh_identity_roster(oauth: &OAuthConfig) -> Vec<([u8; 32], Subject)> {
+    let mut roster = Vec::new();
+    for (label, peer) in &oauth.mesh_peers {
+        let ed_bytes = match decode_multikey(&peer.ed25519_multibase, &MULTICODEC_ED25519_PUB) {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::error!("mesh_peer '{label}': invalid ed25519_multibase, skipping identity roster entry: {e}");
+                continue;
+            }
+        };
+        let ed_pubkey: [u8; 32] = match ed_bytes.as_slice().try_into() {
+            Ok(a) => a,
+            Err(_) => {
+                tracing::error!(
+                    "mesh_peer '{label}': ed25519 key is {} bytes (expected 32), skipping identity roster entry",
+                    ed_bytes.len()
+                );
+                continue;
+            }
+        };
+        let subject = hyprstream_rpc::node_identity::mesh_host_subject(label);
+        tracing::info!(
+            "mesh_peer '{label}': enrolled as per-host subject {:?}",
+            subject.name()
+        );
+        roster.push((ed_pubkey, subject));
+    }
+    roster
 }
 
 /// Encode raw key bytes as a `Multikey` `publicKeyMultibase` string (base58btc,
@@ -172,6 +216,52 @@ mod tests {
         )]);
         let store = build_mesh_pq_trust_store(&oauth);
         assert!(store.is_empty(), "malformed entry must be skipped, not trusted");
+    }
+
+    #[test]
+    fn identity_roster_maps_peers_to_per_host_subjects() {
+        // #328: each enrolled peer's Ed25519 key maps to its own granular
+        // per-host subject (service:inference:host-<label>), reusing the SAME
+        // mesh_peers enrollment record.
+        let peer_ed = SigningKey::generate(&mut OsRng);
+        let peer_pq_sk = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&peer_ed);
+        let ed_mb = encode_multikey(&peer_ed.verifying_key().to_bytes(), &MULTICODEC_ED25519_PUB);
+        let pq_mb = encode_multikey(
+            &pq::ml_dsa_sk_to_vk_bytes(&peer_pq_sk),
+            &MULTICODEC_ML_DSA_65_PUB,
+        );
+        let oauth = oauth_with_peers(vec![(
+            "gpu-node-3",
+            MeshPeerConfig { ed25519_multibase: ed_mb, mldsa65_multibase: pq_mb },
+        )]);
+
+        let roster = build_mesh_identity_roster(&oauth);
+        assert_eq!(roster.len(), 1);
+        let (pubkey, subject) = &roster[0];
+        assert_eq!(*pubkey, peer_ed.verifying_key().to_bytes());
+        assert_eq!(subject.name(), Some("service:inference:host-gpu-node-3"));
+        // Crucially, NOT "system".
+        assert_ne!(subject.name(), Some("system"));
+    }
+
+    #[test]
+    fn identity_roster_skips_malformed_entries() {
+        let good_pq = encode_multikey(&vec![0u8; 1952], &MULTICODEC_ML_DSA_65_PUB);
+        let oauth = oauth_with_peers(vec![(
+            "bad-peer",
+            MeshPeerConfig {
+                ed25519_multibase: "not-multibase".to_owned(),
+                mldsa65_multibase: good_pq,
+            },
+        )]);
+        let roster = build_mesh_identity_roster(&oauth);
+        assert!(roster.is_empty(), "malformed entry must be skipped, not enrolled");
+    }
+
+    #[test]
+    fn empty_mesh_peers_yields_empty_identity_roster() {
+        let roster = build_mesh_identity_roster(&OAuthConfig::default());
+        assert!(roster.is_empty());
     }
 
     #[test]

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1349,6 +1349,34 @@ fn install_envelope_verify_config(oauth: Option<&hyprstream_core::config::OAuthC
         None => KeyedPqTrustStore::new(),
     };
     tracing::info!("mesh PQ trust store installed with {} peer binding(s)", keyed_store.len());
+
+    // Per-host mesh identity roster (#328): bind each enrolled peer's Ed25519
+    // signer key to its OWN per-host subject (`service:inference:host-<label>`)
+    // in the global trust store, so a verified mesh peer resolves to its
+    // granular principal — never the `"system"` god principal. Reuses the SAME
+    // `mesh_peers` enrollment record as the PQ store above (no new roster type).
+    // A networked peer whose key is NOT enrolled resolves to anonymous
+    // (deny-by-default, fail-closed).
+    if let Some(oauth) = oauth {
+        let roster = hyprstream_core::auth::mesh_trust::build_mesh_identity_roster(oauth);
+        let trust = hyprstream_service::global_trust_store();
+        for (ed_pubkey, subject) in &roster {
+            if let Ok(vk) = VerifyingKey::from_bytes(ed_pubkey) {
+                trust.insert(
+                    vk,
+                    hyprstream_service::Attestation {
+                        scopes: std::iter::once("inference".to_owned()).collect(),
+                        subject: subject.name().map(ToOwned::to_owned),
+                        jwt: None,
+                        // Admin-anchored, out-of-band enrollment: no expiry (0).
+                        expires_at: 0,
+                        attested_by: None,
+                    },
+                );
+            }
+        }
+        tracing::info!("mesh identity roster installed with {} per-host binding(s)", roster.len());
+    }
     // Shared Arc: the SAME admin-anchored store backs both the request-side and
     // response-side verify configs — built once, anchored once (#277 reuse of
     // #157). The server's `#mesh-pq` ML-DSA-65 key (keyed by its Ed25519 mesh

--- a/crates/hyprstream/src/services/inference.rs
+++ b/crates/hyprstream/src/services/inference.rs
@@ -2355,6 +2355,18 @@ impl hyprstream_rpc::service::RequestService for InferenceZmqAdapter {
         self.jwt_key_source.clone()
     }
 
+    /// Resolve a verified mesh-peer signer key to its per-host subject (#328).
+    ///
+    /// Routes through the global trust store, which is populated at startup from
+    /// the admin-anchored `mesh_peers` roster (see
+    /// `hyprstream::auth::mesh_trust::build_mesh_identity_roster`). A networked
+    /// peer whose key is enrolled resolves to `service:inference:host-<label>`;
+    /// an unenrolled peer resolves to `None` → anonymous (fail-closed,
+    /// deny-by-default — never the `"system"` god principal).
+    fn resolve_key_subject(&self, signer_pubkey: &[u8; 32]) -> Option<hyprstream_rpc::envelope::Subject> {
+        hyprstream_service::global_trust_store().resolve_subject(signer_pubkey)
+    }
+
     fn build_error_payload(&self, request_id: u64, error: &str) -> Vec<u8> {
         let variant = InferenceResponseVariant::Error(ErrorInfo {
             message: error.to_owned(),


### PR DESCRIPTION
## #328 — per-host mesh identity (Part of #310)

Closes the highest-severity authz defect in the multi-GPU epic: **today one leaked key authenticates as the omnipotent `"system"` principal.** Scope is the **identity layer only** — this does NOT build the #319 mesh policy vocab (gated on an open design decision).

### The 5-step fix (per `docs/plans/2026-06-18-phase2-cluster-trust-spike.md` / `svid-scope-and-328.md`)

1. **`node_identity.rs`** — `known_pubkeys` is now `HashMap<[u8;32], Subject>`. `resolve()` returns the **mapped per-key subject**:
   - the node's own root/derived keys → `"system"` (genuine in-process authority, unchanged),
   - enrolled mesh peers → their per-host subject `service:inference:host-<label>` (extends the existing `service:<name>` convention),
   - unknown keys → `anonymous` (deny-by-default).
   The "any known key → system god principal" collapse is **gone**. `register_peer()` refuses to shadow an existing `"system"` binding (a misconfigured roster can't downgrade in-process authority).

2. **`mesh_trust.rs`** — new `build_mesh_identity_roster()` yields `(ed25519_pubkey → Subject)` from the **same `oauth.mesh_peers` enrollment record** already used by `build_mesh_pq_trust_store`. **No new roster type** — `mesh_peers` config is the enrollment record.

3. **Routed through the per-host roster, not the single-key `ClusterKeySource`.** Mesh peers resolve via the kid-keyed roster (global trust store, consulted by `resolve_key_subject`). `ClusterKeySource` (single shared key + empty-iss-trust) is documented as **NOT a mesh authority**; `JwksKeySource` (honors `kid`) remains the multi-key path.

4. **Empty-`iss` rejected on the networked/mesh path.** `verify_claims` gates the empty-issuer shortcut by `EnvelopeContext::is_local_caller`: accepted **only** for genuine `Inproc`/IPC (`FixedSigner`) callers, rejected for networked `AnySigner` peers — so a mesh peer can't inherit local trust via a bare-`sub` token.

5. **`svc.rs` / `inference.rs`** — the `"system"` / `resolve_key_subject` shortcut is confined to genuine in-process callers; networked mesh peers resolve via the roster → host subject (deny → `anonymous`), **fail-closed**.

### What stays `"system"` / Inproc-only
The node's own root and purpose-derived keys, plus internal self-calls (`from_verified_as_system`, `from_callback_service`). Existing OAuth / WIT / browser (`AnySigner`) flows are untouched.

### Roster reuse
The `mesh_peers` config (Ed25519 + ML-DSA-65 Multikey per host) is the single enrollment record: `build_mesh_pq_trust_store` already anchors the PQ key; `build_mesh_identity_roster` now also yields the per-host **subject**, installed into the global trust store at startup alongside the PQ store.

### Threats closed
- **C-IDENT** — per-host identity proof (cluster-trust spike).
- **T1** — key leak → omnipotent `system` (threat-model matrix).
- **T11** — empty-`iss` trust on the networked path.

### Wire/schema
**No capnp schema or RPC wire-format change** — reuses the existing envelope / COSE / `cnf` and the `mesh_peers` config.

### Tests (security-critical)
- networked peer key NOT in the roster → `anonymous` (never `system`)
- roster peer key → its specific `service:inference:host-<id>`
- empty-`iss` rejected off-`Inproc`, still accepted for `Inproc`
- node's own root/derived key still → `system` (no regression)
- regression: the old "any known key → system" behavior is gone
- roster mapping + malformed-entry-skip (fail-safe)

**Build/verify:** `hyprstream-rpc` 419 + 3 new pass (1 pre-existing `#148` `moq_event` flake, unrelated/untouched); `hyprstream` `mesh_trust` 7 pass; `cargo clippy -p hyprstream-rpc -p hyprstream --all-targets -D warnings` clean on both crates.

> Security-critical auth path — please review before merge; do not auto-merge.