### PR TITLE
feat(auth): inference-mesh policy vocab — mesh:rpc / infer.stage / delta.submit (#319)

### DIFF
--- a/crates/hyprstream/src/auth/mod.rs
+++ b/crates/hyprstream/src/auth/mod.rs
@@ -55,6 +55,29 @@ pub enum Operation {
     Spawn,
     /// Create a resource (r)
     Create,
+    // ─────────────────────────────────────────────────────────────────────
+    // Inference-mesh (#319) — host↔host pipeline RPC abilities.
+    //
+    // These gate calls between inference hosts on the cluster mesh (e.g. the
+    // router→host activation hand-off and host→aggregator delta submission).
+    // They are split read-vs-authority so an operator can grant a *group* of
+    // hosts the read ability cheaply while keeping the authority abilities
+    // strictly per-host least-privilege (see policy_templates::mesh-host).
+    //
+    // The dot-strings are designed to map 1:1 onto a future UCAN `cmd`:
+    //   Operation::MeshInvoke   ⇄ cmd=/mesh/rpc        (umbrella invoke right)
+    //   Operation::MeshStage    ⇄ cmd=/mesh/infer/stage
+    //   Operation::MeshDelta    ⇄ cmd=/mesh/delta/submit
+    //   Operation::MeshStatus   ⇄ cmd=/mesh/query/status
+    // (resource caveats — tenant/job/layers — live in the `mesh://` path).
+    /// Umbrella mesh invoke right — `inference:peer-call` / `mesh:rpc` (authority).
+    MeshInvoke,
+    /// Submit an inference activation/stage to a peer host (authority).
+    MeshStage,
+    /// Submit a TTT delta to a peer/aggregator host (authority).
+    MeshDelta,
+    /// Read a peer host's mesh job/pipeline status (read-only).
+    MeshStatus,
 }
 
 impl Operation {
@@ -70,6 +93,12 @@ impl Operation {
             Operation::Context => 'c',
             Operation::Spawn => 'p',
             Operation::Create => 'r',
+            // Mesh ops (#319) — distinct codes; not part of the model-capability
+            // bitmask (`all()`), so these never collide in `check_all`.
+            Operation::MeshInvoke => 'e',
+            Operation::MeshStage => 'g',
+            Operation::MeshDelta => 'd',
+            Operation::MeshStatus => 'u',
         }
     }
 
@@ -97,13 +126,26 @@ impl Operation {
         match self {
             Operation::Infer   => "infer.generate",
             Operation::Train   => "ttt.train",
-            Operation::Query   => "query.status",
+            // `Query` (model status) and `MeshStatus` (mesh read ability) are
+            // the SAME wire action `query.status` by design — the mesh read
+            // right IS the canonical status read (#319). `from_dot_str` resolves
+            // the string back to `Query` (its canonical owner).
+            Operation::Query | Operation::MeshStatus => "query.status",
             Operation::Write   => "persist.save",
             Operation::Serve   => "serve.api",
             Operation::Manage  => "ttt.writeback",
             Operation::Context => "context.augment",
             Operation::Spawn   => "spawn",
             Operation::Create  => "create",
+            // Mesh (#319). `mesh.rpc` is the umbrella invoke right (alias
+            // `inference:peer-call` accepted on parse). The authority actions
+            // `infer.stage` / `delta.submit` are deliberately distinct strings
+            // from the model-namespace `infer.generate` / `persist.save` so a
+            // model grant can never satisfy a mesh-authority gate. (The read
+            // ability `MeshStatus` shares the `query.status` arm above.)
+            Operation::MeshInvoke => "mesh.rpc",
+            Operation::MeshStage  => "infer.stage",
+            Operation::MeshDelta  => "delta.submit",
         }
     }
 
@@ -124,6 +166,11 @@ impl Operation {
             "serve.api" | "serve" => Some(Self::Serve),
             "spawn" => Some(Self::Spawn),
             "create" => Some(Self::Create),
+            // Mesh (#319). `query.status` (the mesh read ability) is owned by
+            // `Query` above, so it is intentionally NOT repeated here.
+            "mesh.rpc" | "mesh:rpc" | "inference:peer-call" => Some(Self::MeshInvoke),
+            "infer.stage" => Some(Self::MeshStage),
+            "delta.submit" => Some(Self::MeshDelta),
             _ => None,
         }
     }
@@ -140,6 +187,11 @@ impl Operation {
             'c' => Some(Operation::Context),
             'p' => Some(Operation::Spawn),
             'r' => Some(Operation::Create),
+            // Mesh (#319)
+            'e' => Some(Operation::MeshInvoke),
+            'g' => Some(Operation::MeshStage),
+            'd' => Some(Operation::MeshDelta),
+            'u' => Some(Operation::MeshStatus),
             _ => None,
         }
     }
@@ -278,6 +330,34 @@ mod tests {
             assert_eq!(&parsed, op);
         }
         assert!(Operation::from_str("foo").is_err());
+    }
+
+    #[test]
+    fn test_mesh_operation_vocab() {
+        // Authority + umbrella mesh actions round-trip via their distinct strings.
+        assert_eq!(Operation::MeshInvoke.as_str(), "mesh.rpc");
+        assert_eq!(Operation::MeshStage.as_str(), "infer.stage");
+        assert_eq!(Operation::MeshDelta.as_str(), "delta.submit");
+        assert_eq!(Operation::from_dot_str("mesh.rpc"), Some(Operation::MeshInvoke));
+        assert_eq!(Operation::from_dot_str("mesh:rpc"), Some(Operation::MeshInvoke));
+        assert_eq!(Operation::from_dot_str("inference:peer-call"), Some(Operation::MeshInvoke));
+        assert_eq!(Operation::from_dot_str("infer.stage"), Some(Operation::MeshStage));
+        assert_eq!(Operation::from_dot_str("delta.submit"), Some(Operation::MeshDelta));
+        // The mesh-authority strings are DISTINCT from the model-namespace
+        // strings, so a model grant can never satisfy a mesh-authority gate.
+        assert_ne!(Operation::MeshStage.as_str(), Operation::Infer.as_str());
+        assert_ne!(Operation::MeshDelta.as_str(), Operation::Write.as_str());
+        // The mesh read ability reuses the canonical `query.status` wire action.
+        assert_eq!(Operation::MeshStatus.as_str(), "query.status");
+        assert_eq!(Operation::from_dot_str("query.status"), Some(Operation::Query));
+        // Codes are distinct from the model-capability codes.
+        for op in [Operation::MeshInvoke, Operation::MeshStage, Operation::MeshDelta, Operation::MeshStatus] {
+            assert_eq!(Operation::from_code(op.code()), Some(op));
+        }
+        // Mesh ops are NOT part of the model-capability set.
+        for op in &[Operation::MeshInvoke, Operation::MeshStage, Operation::MeshDelta, Operation::MeshStatus] {
+            assert!(!Operation::all().contains(op));
+        }
     }
 
     #[test]

--- a/crates/hyprstream/src/auth/policy_manager.rs
+++ b/crates/hyprstream/src/auth/policy_manager.rs
@@ -1063,6 +1063,15 @@ mod tests {
     fn subscribe_scope(prefix: &str) -> String {
         format!("subscribe:events:{prefix}.*")
     }
+    /// Resource string for an inference-mesh job (#319). The tenant is the first
+    /// path segment so the caveat survives translation to a UCAN delegation.
+    fn mesh_job(tenant: &str, job: &str) -> String {
+        format!("mesh://{tenant}/job/{job}")
+    }
+    /// Per-host mesh authorization subject (#328).
+    fn mesh_host(id: &str) -> String {
+        format!("service:inference:host-{id}")
+    }
 
     /// Regression guard for the wildcard-validation bug: `add_policy` injects
     /// domain="*", so a blanket '*' ban made it always fail (even on
@@ -1153,5 +1162,146 @@ mod tests {
             "public-prefix grant must not leak to a private prefix");
         // An ungranted subject is denied entirely.
         assert!(!pm.check_with_domain("bob", "*", "subscribe:events:public.metrics", "subscribe").await);
+    }
+
+    // ========================================================================
+    // Inference-mesh authorization invariants (#319)
+    //
+    // The mesh authority actions (`infer.stage`, `delta.submit`, `mesh.rpc`)
+    // must be deny-by-default, granted ONLY to non-wildcard
+    // `service:inference:host-<id>` subjects, scoped to a single tenant. The
+    // read ability (`query.status`) may be granted to a host group. These
+    // mirror the atproto-scoped invariant style above and double as the #319
+    // security harness.
+    // ========================================================================
+
+    /// Apply the worked-example `mesh-host` template rules to an enforcer.
+    /// Mirrors what `policy apply-template mesh-host` does at runtime.
+    #[allow(clippy::unwrap_used)]
+    async fn apply_template(pm: &PolicyManager, name: &str) {
+        let tmpl = crate::auth::policy_templates::get_template(name)
+            .unwrap_or_else(|| panic!("template {name} must exist"));
+        for r in tmpl.expanded_policies() {
+            pm.add_policy_with_domain(r.subject, r.domain, r.resource, r.action, r.effect)
+                .await
+                .unwrap();
+        }
+        if let Some(groupings) = tmpl.groupings {
+            for g in groupings {
+                pm.add_role_for_user(g.user, g.role).await.unwrap();
+            }
+        }
+    }
+
+    /// #319 invariant — the mesh authority actions are NEVER reachable by a
+    /// wildcard (`*`) or `anonymous` subject, even when a `federation-open`-style
+    /// wildcard rule AND the public-inference template are both loaded. Only a
+    /// specific enrolled host subject may stage/submit.
+    #[tokio::test]
+    #[allow(clippy::unwrap_used)]
+    async fn test_mesh_authority_never_matches_wildcard_or_anonymous() {
+        let pm = PolicyManager::new_in_memory().await.unwrap();
+        // Load a broad wildcard rule (federation-open) and the public-inference
+        // template — neither must leak into mesh authority.
+        apply_template(&pm, "federation-open").await;
+        apply_template(&pm, "public-inference").await;
+        // And the real per-host mesh grants for tenant acme.
+        apply_template(&pm, "mesh-host").await;
+
+        let job = mesh_job("acme", "j7");
+        for action in ["infer.stage", "delta.submit", "mesh.rpc"] {
+            assert!(
+                !pm.check_with_domain("*", "acme", &job, action).await,
+                "wildcard subject must NEVER match mesh authority action {action}"
+            );
+            assert!(
+                !pm.check_with_domain("anonymous", "acme", &job, action).await,
+                "anonymous must NEVER match mesh authority action {action}"
+            );
+            // A non-enrolled host subject is likewise denied.
+            assert!(
+                !pm.check_with_domain(&mesh_host("99"), "acme", &job, action).await,
+                "un-enrolled host must be denied mesh authority action {action}"
+            );
+        }
+        // Positive control: an enrolled host CAN stage within its tenant.
+        assert!(
+            pm.check_with_domain(&mesh_host("1"), "acme", &job, "infer.stage").await,
+            "enrolled host-1 must be able to infer.stage in its tenant"
+        );
+    }
+
+    /// #319 invariant — tenant isolation: a host enrolled for tenant `acme`
+    /// cannot exercise ANY mesh action against tenant `beta`'s resources, even
+    /// for the same job name. The Casbin domain exact-match is the gate.
+    #[tokio::test]
+    #[allow(clippy::unwrap_used)]
+    async fn test_mesh_tenant_isolation() {
+        let pm = PolicyManager::new_in_memory().await.unwrap();
+        // host-1 is granted on tenant acme via the worked-example template.
+        apply_template(&pm, "mesh-host").await;
+
+        // In its own tenant: allowed.
+        assert!(
+            pm.check_with_domain(&mesh_host("1"), "acme", &mesh_job("acme", "j7"), "infer.stage").await
+        );
+        // Cross-tenant (domain beta): denied for every action, even though the
+        // host holds the same grant in acme.
+        for action in ["infer.stage", "delta.submit", "mesh.rpc", "query.status"] {
+            assert!(
+                !pm.check_with_domain(&mesh_host("1"), "beta", &mesh_job("beta", "j7"), action).await,
+                "acme-scoped host-1 must NOT reach tenant beta for {action}"
+            );
+        }
+        // Even pointing the resource path at beta while claiming the acme domain
+        // must not match the acme rule (resource prefix differs).
+        assert!(
+            !pm.check_with_domain(&mesh_host("1"), "acme", &mesh_job("beta", "j7"), "infer.stage").await,
+            "acme-domain rule must not match a beta resource path"
+        );
+    }
+
+    /// #319 invariant — group read, per-host authority: a host group may be
+    /// granted the read ability (`query.status`) via Casbin grouping, but the
+    /// group MUST NOT confer any authority action.
+    #[tokio::test]
+    #[allow(clippy::unwrap_used)]
+    async fn test_mesh_group_read_not_authority() {
+        let pm = PolicyManager::new_in_memory().await.unwrap();
+        apply_template(&pm, "mesh-host-group").await;
+
+        let job = mesh_job("acme", "j7");
+        // host-1 inherits the group read grant.
+        assert!(
+            pm.check_with_domain(&mesh_host("1"), "acme", &job, "query.status").await,
+            "grouped host must inherit the read ability"
+        );
+        // But the group does NOT confer authority.
+        for action in ["infer.stage", "delta.submit", "mesh.rpc"] {
+            assert!(
+                !pm.check_with_domain(&mesh_host("1"), "acme", &job, action).await,
+                "read group must NOT confer authority action {action}"
+            );
+        }
+        // A host NOT in the group gets nothing.
+        assert!(
+            !pm.check_with_domain(&mesh_host("3"), "acme", &job, "query.status").await,
+            "un-grouped host must not inherit the read ability"
+        );
+    }
+
+    /// #319 invariant — deny-by-default: with no mesh template applied, an
+    /// enrolled-looking host subject is denied every mesh action.
+    #[tokio::test]
+    #[allow(clippy::unwrap_used)]
+    async fn test_mesh_deny_by_default() {
+        let pm = PolicyManager::new_in_memory().await.unwrap();
+        let job = mesh_job("acme", "j7");
+        for action in ["infer.stage", "delta.submit", "mesh.rpc", "query.status"] {
+            assert!(
+                !pm.check_with_domain(&mesh_host("1"), "acme", &job, action).await,
+                "un-granted host must be denied {action} (deny-by-default)"
+            );
+        }
     }
 }

--- a/crates/hyprstream/src/auth/policy_templates.rs
+++ b/crates/hyprstream/src/auth/policy_templates.rs
@@ -259,6 +259,79 @@ pub fn get_templates() -> &'static [PolicyTemplate] {
                 ServiceGrouping { user: "ttt.agent", role: "ttt.user" },
             ]),
         },
+        // ─────────────────────────────────────────────────────────────────
+        // Inference mesh (#319) — host↔host pipeline RPC authorization.
+        //
+        // SECURITY MODEL (deny-by-default, fail-closed, least-privilege):
+        //   * The mesh AUTHORITY actions (`infer.stage`, `delta.submit`, and the
+        //     `mesh.rpc` umbrella invoke right) are NEVER granted to `*`,
+        //     `service:*`, or `anonymous`. They are granted ONLY to specific,
+        //     non-wildcard `service:inference:host-<id>` subjects (#328), and
+        //     ONLY within a single tenant's domain. A host enrolled for tenant
+        //     `acme` thus cannot stage on tenant `beta` (the Casbin matcher does
+        //     an exact `r.dom == p.dom` check unless the rule's domain is `*`,
+        //     which mesh-authority rules MUST NOT use).
+        //   * The READ ability (`query.status`) MAY be granted to a *group* of
+        //     hosts via Casbin grouping (`g`) — see the `mesh-host-group`
+        //     template — so an operator can give a fleet read visibility without
+        //     per-host duplication. Authority stays per-host.
+        //
+        // RESOURCE SHAPE — `mesh://<tenant>/<job>/<…>` (UCAN-translatable):
+        //   The tenant is BOTH the Casbin domain (for ambient isolation) AND the
+        //   first path segment (so the caveat survives translation to a future
+        //   UCAN delegation, which has no domain column). The 1:1 mapping is:
+        //
+        //     Casbin: p, service:inference:host-7, acme, mesh://acme/job/j7, infer.stage, allow
+        //     UCAN:   { iss: <policy-root>, aud: host-7, sub: <policy-root>,
+        //               cmd: /mesh/infer/stage,
+        //               pol: [["==", ".tenant", "acme"], ["==", ".job", "j7"]] }
+        //
+        //   action ⇄ cmd, subject ⇄ aud, and the tenant/job caveats live in the
+        //   resource path so a future UCAN layer maps without loss. `query.status`
+        //   ⇄ /mesh/query/status, `delta.submit` ⇄ /mesh/delta/submit, the
+        //   `mesh.rpc` umbrella ⇄ /mesh/rpc.
+        //
+        // This template is a WORKED EXAMPLE for two hosts in tenant `acme`.
+        // Operators copy it and substitute their real host labels / tenant /
+        // job via `policy edit` (the per-host authority lines are intentionally
+        // explicit, never wildcarded). It is NOT injected into the base policy.
+        PolicyTemplate {
+            name: "mesh-host",
+            description: "Inference mesh (#319): per-host pipeline RPC grants for tenant `acme` (worked example — substitute real host labels/tenant; authority is strictly non-wildcard per-host)",
+            policies: Some(&[
+                // Router → host: ModelService stages activations onto enrolled
+                // hosts within the tenant. `service:model` is the router identity.
+                ServicePolicyRule { subject: "service:model", domain: "acme", resource: "mesh://acme/*", action: "infer.stage", effect: "allow" },
+                // Host → host: peer activation hand-off + status read.
+                ServicePolicyRule { subject: "service:inference:host-1", domain: "acme", resource: "mesh://acme/*", action: "mesh.rpc", effect: "allow" },
+                ServicePolicyRule { subject: "service:inference:host-1", domain: "acme", resource: "mesh://acme/*", action: "infer.stage", effect: "allow" },
+                ServicePolicyRule { subject: "service:inference:host-1", domain: "acme", resource: "mesh://acme/*", action: "query.status", effect: "allow" },
+                ServicePolicyRule { subject: "service:inference:host-2", domain: "acme", resource: "mesh://acme/*", action: "mesh.rpc", effect: "allow" },
+                ServicePolicyRule { subject: "service:inference:host-2", domain: "acme", resource: "mesh://acme/*", action: "infer.stage", effect: "allow" },
+                ServicePolicyRule { subject: "service:inference:host-2", domain: "acme", resource: "mesh://acme/*", action: "query.status", effect: "allow" },
+                // Host → aggregator: TTT delta submission (authority).
+                ServicePolicyRule { subject: "service:inference:host-1", domain: "acme", resource: "mesh://acme/*", action: "delta.submit", effect: "allow" },
+                ServicePolicyRule { subject: "service:inference:host-2", domain: "acme", resource: "mesh://acme/*", action: "delta.submit", effect: "allow" },
+            ]),
+            groupings: None,
+        },
+        // Group-policy variant: grant the READ ability to a whole fleet via a
+        // Casbin role, WITHOUT per-host duplication, while authority stays
+        // per-host (granted by `mesh-host`). The grouping rule `g,
+        // service:inference:host-<id>, mesh-readers` makes each host inherit the
+        // role's grants; the role gets ONLY `query.status` (read), never an
+        // authority action. Operators add `g, <host>, mesh-readers` per host.
+        PolicyTemplate {
+            name: "mesh-host-group",
+            description: "Inference mesh (#319): grant the read ability (query.status) to the `mesh-readers` host group for tenant `acme` (authority stays per-host via `mesh-host`)",
+            policies: Some(&[
+                ServicePolicyRule { subject: "mesh-readers", domain: "acme", resource: "mesh://acme/*", action: "query.status", effect: "allow" },
+            ]),
+            groupings: Some(&[
+                ServiceGrouping { user: "service:inference:host-1", role: "mesh-readers" },
+                ServiceGrouping { user: "service:inference:host-2", role: "mesh-readers" },
+            ]),
+        },
         PolicyTemplate {
             name: "ttt.privileged",
             description: "TTT privileged: extends ttt.user with ttt.* operations",


### PR DESCRIPTION
Casbin/PolicyService policy vocabulary for inference↔inference mesh RPC. **Pure Rust** — `Operation` enum + policy templates + invariant tests only; **NO capnp/RPC wire change**. The UCAN delegation layer is deferred (this only makes the Casbin grants UCAN-*translatable* in shape).

Part of #310 · Closes #319 · Targets `ewindisch/310-multi-gpu` (NOT main).

## Resource + ability vocab (`crates/hyprstream/src/auth/mod.rs`)
- **Resource:** `mesh://<tenant>/<job>/...` — the tenant is BOTH the Casbin domain (ambient isolation via the matcher's exact `r.dom == p.dom`) AND the first path segment, so the caveat survives translation to a future UCAN delegation (which has no domain column).
- **Abilities, split read vs authority** (new `Operation` variants + dot-strings):

  | variant | wire action | kind |
  |---|---|---|
  | `MeshStatus` | `query.status` | read (reuses the canonical status action) |
  | `MeshStage` | `infer.stage` | authority |
  | `MeshDelta` | `delta.submit` | authority |
  | `MeshInvoke` | `mesh.rpc` (aliases `mesh:rpc`, `inference:peer-call`) | authority umbrella invoke right |

  The mesh-authority strings are deliberately **distinct** from the model-namespace strings (`infer.generate` / `persist.save`) so a model grant can never satisfy a mesh-authority gate.

## Policy rules (`crates/hyprstream/src/auth/policy_templates.rs`)
- **`mesh-host`** template: per-host, **non-wildcard** grants to specific `service:inference:host-<id>` subjects (#328) — plus `service:model` for the router→host `infer.stage` direction — each scoped to a tenant domain. Worked example for tenant `acme`; operators copy & substitute real labels. **Never** a `*` / `service:*` / `anonymous` grant for authority actions.
- **`mesh-host-group`** template: the read ability (`query.status`) granted to a `mesh-readers` host **group** via Casbin grouping (`g`), so a fleet gets read visibility without per-host duplication; **authority stays per-host** least-privilege.
- Not injected into `SERVICE_BASE_POLICIES` (would bake in host labels) — applied per-deployment.

## UCAN-translatable 1:1 mapping (documented in a code comment)
```
Casbin: p, service:inference:host-7, acme, mesh://acme/job/j7, infer.stage, allow
UCAN:   { aud: host-7, cmd: /mesh/infer/stage,
          pol: [["==",".tenant","acme"], ["==",".job","j7"]] }
```
action ⇄ `cmd`, subject ⇄ `aud`, and the tenant/job caveats live in the resource path so a future UCAN layer maps without loss.

## Tenant isolation
A host enrolled for tenant `acme` cannot exercise any mesh action against tenant `beta` — enforced by BOTH the Casbin domain exact-match and the `mesh://<tenant>/` resource prefix.

## Invariant tests (mirror the atproto-scoped tests at `policy_manager.rs`)
- `*` and `anonymous` NEVER match `infer.stage` / `delta.submit` / `mesh.rpc`, even with `federation-open` + `public-inference` loaded.
- Tenant isolation: `acme` host-1 cannot `infer.stage` (or anything) on tenant `beta`.
- Group read grant does not confer authority; un-grouped host gets nothing.
- Deny-by-default: an un-granted host is denied all mesh actions.
- `Operation` vocab unit test for the new variants/aliases/codes.

## Build / test / clippy
- `cargo build -p hyprstream` ✅
- `cargo test -p hyprstream --lib auth` ✅ 244 passed, 0 failed (4 new mesh invariants + new vocab test).
- `cargo clippy -p hyprstream --all-targets -D warnings` ✅ clean.