### PR TITLE
feat: mandatory AEAD + per-host provenance on the mesh stream plane (#321)

### DIFF
--- a/crates/hyprstream-rpc-derive/src/codegen/client.rs
+++ b/crates/hyprstream-rpc-derive/src/codegen/client.rs
@@ -448,13 +448,14 @@ fn generate_trait_method_impl(
                 if info.broadcast_path.is_empty() {
                     anyhow::bail!("Server did not provide moq broadcast path — moq transport not initialized");
                 }
-                let (mac_key, topic) = hyprstream_rpc::derive_client_stream_keys(
+                let (mac_key, enc_key, topic) = hyprstream_rpc::derive_client_stream_keys(
                     &client_secret, &client_pubkey_bytes, &info.dh_public,
                 )?;
                 // #274: subscribe over the resolved `reach` (the same-host UDS
                 // fast path is preferred automatically when co-located).
+                // #321: enc_key opens the transport-AEAD-sealed Tagged blocks.
                 Ok(hyprstream_rpc::moq_stream::MoqStreamHandle::networked(
-                    info.announced_at, info.broadcast_path, mac_key, topic,
+                    info.announced_at, info.broadcast_path, mac_key, enc_key, topic,
                 ))
             }
         })

--- a/crates/hyprstream-rpc/schema/streaming.capnp
+++ b/crates/hyprstream-rpc/schema/streaming.capnp
@@ -245,6 +245,25 @@ struct StreamBlock {
   # re-key / producer restart so (epoch, sequenceNumber) is globally unique.
   # 0 until the epoch lifecycle lands; ordinal reserved so that change is wire-safe.
   epoch @3 :UInt64;
+  # Per-host provenance signature (#321 / C-PROV / threat T3). Additive, wire-safe:
+  # the HMAC chain proves "held the DH key + in order", NOT "host-X computed this".
+  # `provenance` attaches the producing host's per-host hybrid COSE signature
+  # (EdDSA + ML-DSA-65, #328 `derive_mesh_mldsa_key`) over the canonical signed
+  # region (prevMac ‖ sequenceNumber ‖ epoch ‖ serialized payloads). The consumer
+  # verifies the signature AND that the signer is in the mesh_peers roster (fail-
+  # closed). An absent/zero-length `provenance` (default) means no in-band signer
+  # was attached (the legacy chained-HMAC-only block). Verification is a layer ON
+  # TOP of AEAD + HMAC.
+  provenance @4 :Provenance;
+}
+
+# Per-host provenance for a StreamBlock (#321). `signerKid` is the producing
+# host's key id (its Ed25519 verifying-key bytes, matching the COSE inner kid);
+# `sig` is the CBOR-encoded hybrid COSE_Sign composite over the block's canonical
+# signed region. Empty `sig` ⇒ no provenance attached.
+struct Provenance {
+  signerKid @0 :Data;
+  sig @1 :Data;
 }
 
 # =============================================================================

--- a/crates/hyprstream-rpc/src/crypto/key_exchange.rs
+++ b/crates/hyprstream-rpc/src/crypto/key_exchange.rs
@@ -51,6 +51,12 @@ pub struct StreamKeys {
     pub topic: String,
     /// HMAC key for MAC chain (zeroized on drop).
     pub mac_key: Zeroizing<[u8; 32]>,
+    /// AES-256-GCM key for transport-level AEAD of stream payloads (#321,
+    /// zeroized on drop). Distinct from `mac_key` via its own derivation context
+    /// (`"hyprstream stream-keys v1 enc"`). The mesh stream plane seals each
+    /// Data/Complete payload under this key; the chained HMAC still runs over the
+    /// (now-encrypted) block, so ordering / anti-replay are unchanged.
+    pub enc_key: Zeroizing<[u8; 32]>,
     /// Control channel topic (64 hex chars, derived from same DH secret).
     pub ctrl_topic: String,
     /// Control channel HMAC key (zeroized on drop).
@@ -59,25 +65,33 @@ pub struct StreamKeys {
 
 impl StreamKeys {
     /// Create from raw topic and mac_key bytes.
+    ///
+    /// The AEAD `enc_key` is deterministically derived from `mac_key` via a
+    /// dedicated context so this constructor stays source-compatible while still
+    /// producing a stable, non-zero, key-separated AEAD key.
     pub fn new(topic: String, mac_key: [u8; 32]) -> Self {
+        let enc_key = derive_key("hyprstream stream-keys v1 enc", &mac_key);
         Self {
             topic,
             mac_key: Zeroizing::new(mac_key),
+            enc_key: Zeroizing::new(enc_key),
             ctrl_topic: String::new(),
             ctrl_mac_key: Zeroizing::new([0u8; 32]),
         }
     }
 
-    /// Create with both data and control channel keys.
+    /// Create with both data and control channel keys plus the AEAD enc_key.
     pub fn with_ctrl(
         topic: String,
         mac_key: [u8; 32],
+        enc_key: [u8; 32],
         ctrl_topic: String,
         ctrl_mac_key: [u8; 32],
     ) -> Self {
         Self {
             topic,
             mac_key: Zeroizing::new(mac_key),
+            enc_key: Zeroizing::new(enc_key),
             ctrl_topic,
             ctrl_mac_key: Zeroizing::new(ctrl_mac_key),
         }
@@ -167,6 +181,12 @@ pub fn derive_stream_keys(
     // Derive mac_key (32 bytes)
     let mac_key = derive_key("hyprstream stream-keys v1 mac", &ikm);
 
+    // Derive AEAD enc_key (32 bytes, #321) — a DISTINCT context from `mac`, so the
+    // transport-AEAD key is cryptographically separated from the HMAC-chain key
+    // (mirrors `derive_notification_keys`'s enc/mac split). The mesh stream plane
+    // seals each Data/Complete payload under this key.
+    let enc_key = derive_key("hyprstream stream-keys v1 enc", &ikm);
+
     // Derive control channel topic (32 bytes -> 64 hex chars)
     let ctrl_topic_bytes = derive_key("hyprstream stream-keys v1 ctrl-topic", &ikm);
     let ctrl_topic = hex::encode(ctrl_topic_bytes);
@@ -174,7 +194,10 @@ pub fn derive_stream_keys(
     // Derive control channel mac_key (32 bytes)
     let ctrl_mac_key = derive_key("hyprstream stream-keys v1 ctrl-mac", &ikm);
 
-    Ok(StreamKeys::with_ctrl(topic, mac_key, ctrl_topic, ctrl_mac_key))
+    // Zeroize IKM containing the shared secret (mirrors derive_notification_keys).
+    ikm.zeroize();
+
+    Ok(StreamKeys::with_ctrl(topic, mac_key, enc_key, ctrl_topic, ctrl_mac_key))
 }
 
 // ============================================================================
@@ -836,6 +859,24 @@ mod tests {
 
         assert_eq!(keys1.topic, keys2.topic);
         assert_eq!(*keys1.mac_key, *keys2.mac_key);
+        Ok(())
+    }
+
+    #[test]
+    fn test_derive_stream_keys_enc_key_distinct_and_deterministic(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // #321: the AEAD enc_key must be deterministic, key-separated from mac_key,
+        // and distinct from the control keys (own derivation context).
+        let shared_secret = [0x42u8; 32];
+        let client_pub = [0x01u8; 32];
+        let server_pub = [0x02u8; 32];
+
+        let keys1 = derive_stream_keys(&shared_secret, &client_pub, &server_pub)?;
+        let keys2 = derive_stream_keys(&shared_secret, &client_pub, &server_pub)?;
+
+        assert_eq!(*keys1.enc_key, *keys2.enc_key, "enc_key must be deterministic");
+        assert_ne!(*keys1.enc_key, *keys1.mac_key, "enc_key must differ from mac_key");
+        assert_ne!(*keys1.enc_key, *keys1.ctrl_mac_key, "enc_key must differ from ctrl_mac_key");
         Ok(())
     }
 

--- a/crates/hyprstream-rpc/src/lib.rs
+++ b/crates/hyprstream-rpc/src/lib.rs
@@ -150,6 +150,8 @@ pub mod service;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod streaming;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod stream_provenance;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod moq_stream;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod moq_authz;

--- a/crates/hyprstream-rpc/src/moq_stream.rs
+++ b/crates/hyprstream-rpc/src/moq_stream.rs
@@ -381,6 +381,20 @@ impl MoqStreamOrigin {
     /// chained-HMAC state is seeded from `ctx.mac_key()` / `ctx.topic()` — i.e.
     /// byte-identical to the ZMQ `StreamBuilder`.
     pub fn publisher(&self, ctx: &StreamContext) -> Result<MoqStreamPublisher> {
+        self.publisher_with_provenance(ctx, None)
+    }
+
+    /// Create an in-process publisher that additionally signs each StreamBlock
+    /// with the node's per-host hybrid COSE identity (#321 provenance / C-PROV).
+    ///
+    /// `provenance = Some(signer)` attaches a `StreamBlock.provenance` signature
+    /// so consumers can attribute each block to the producing host (threat T3);
+    /// `None` keeps the legacy chained-HMAC-only block.
+    pub fn publisher_with_provenance(
+        &self,
+        ctx: &StreamContext,
+        provenance: Option<crate::stream_provenance::ProvenanceSigner>,
+    ) -> Result<MoqStreamPublisher> {
         let path = self.broadcast_path(ctx.topic());
         let mut broadcast = self
             .inner
@@ -397,6 +411,11 @@ impl MoqStreamOrigin {
 
         Ok(MoqStreamPublisher {
             hmac_state: StreamHmacState::new(*ctx.mac_key(), ctx.topic().to_owned()),
+            // #321: AEAD enc_key — `Some` only on the DH (mesh) path. `None` on the
+            // keyless `StreamContext::new` path (NotificationService topics, whose
+            // payloads are already E2E-encrypted), where transport AEAD is skipped.
+            enc_key: ctx.enc_key().copied(),
+            provenance,
             track,
             next_group: 0,
             cancel_token: ctx.cancel_token().clone(),
@@ -420,6 +439,13 @@ impl MoqStreamOrigin {
 /// `BatchingConfig` in M2b for granularity parity.
 pub struct MoqStreamPublisher {
     hmac_state: StreamHmacState,
+    /// Transport-level AEAD key (#321). `Some` ⇒ each Data/Complete payload is
+    /// sealed with AES-256-GCM into a `Tagged` payload before the HMAC chain runs;
+    /// `None` ⇒ cleartext (keyless notification path).
+    enc_key: Option<[u8; 32]>,
+    /// Per-host provenance signer (#321). `Some` ⇒ each StreamBlock carries a
+    /// hybrid COSE signature over its canonical signed region.
+    provenance: Option<crate::stream_provenance::ProvenanceSigner>,
     track: TrackProducer,
     next_group: u64,
     cancel_token: CancellationToken,
@@ -476,12 +502,53 @@ impl MoqStreamPublisher {
         // epoch is 0 until the #223 key-epoch lifecycle lands.
         let sequence_number = self.next_group;
         self.next_group += 1;
-        let capnp_bytes = crate::streaming::encode_stream_block(
+        let epoch = 0u64;
+
+        // #321: on the mesh/DH path (`enc_key = Some`), seal each Data/Complete
+        // payload with AES-256-GCM into a `Tagged` payload BEFORE the HMAC chain
+        // runs (so the chain authenticates the ciphertext — no double-encryption,
+        // ordering/anti-replay unchanged). Error frames stay cleartext (operational
+        // status, terminal). The AEAD AAD/key-commitment are bound to the block's
+        // `epoch` (and topic), so a rekey can't replay a block across epochs.
+        let sealed: Vec<StreamPayloadData>;
+        let payloads: &[StreamPayloadData] = match self.enc_key {
+            Some(ref enc_key) => {
+                sealed = payloads
+                    .iter()
+                    .map(|p| seal_payload(enc_key, &self.topic, epoch, p))
+                    .collect::<Result<Vec<_>>>()?;
+                &sealed
+            }
+            None => payloads,
+        };
+
+        // Canonical signed region (#321): the StreamBlock with provenance EMPTY.
+        // This is what the provenance signature covers and what the consumer
+        // reconstructs; it also equals the legacy block when provenance is off.
+        let signed_region = crate::streaming::encode_stream_block(
             self.hmac_state.prev_mac_bytes(),
             sequence_number,
-            0,
+            epoch,
             payloads,
         )?;
+
+        // #321 provenance: sign the signed region with the host's hybrid identity,
+        // then emit the block WITH the provenance field. The HMAC below covers the
+        // full wire bytes (incl. provenance); the sig covers the signed region, so
+        // verification is a layer on top of HMAC. No provenance ⇒ wire == signed_region.
+        let capnp_bytes = match self.provenance {
+            Some(ref signer) => {
+                let (signer_kid, sig) = signer.sign(&signed_region)?;
+                crate::streaming::encode_stream_block_with_provenance(
+                    self.hmac_state.prev_mac_bytes(),
+                    sequence_number,
+                    epoch,
+                    payloads,
+                    Some((&signer_kid, &sig)),
+                )?
+            }
+            None => signed_region,
+        };
         let mac = self.hmac_state.compute_next(&capnp_bytes);
 
         let mut frame = Vec::with_capacity(capnp_bytes.len() + 16);
@@ -556,11 +623,12 @@ impl MoqStreamHandle {
         uds_path: String,
         broadcast_path: String,
         mac_key: [u8; 32],
+        enc_key: [u8; 32],
         topic: String,
     ) -> Self {
         let cancel = tokio_util::sync::CancellationToken::new();
         let (tx, rx) = tokio::sync::mpsc::channel::<anyhow::Result<crate::streaming::StreamPayload>>(64);
-        tokio::spawn(moq_stream_handle_task(uds_path, broadcast_path.clone(), mac_key, topic, tx, cancel.clone()));
+        tokio::spawn(moq_stream_handle_task(uds_path, broadcast_path.clone(), mac_key, enc_key, topic, tx, cancel.clone()));
         Self { rx, broadcast_path, cancel }
     }
 
@@ -594,6 +662,7 @@ impl MoqStreamHandle {
         reach: Vec<crate::stream_info::Destination>,
         broadcast_path: String,
         mac_key: [u8; 32],
+        enc_key: [u8; 32],
         topic: String,
     ) -> Self {
         let cancel = tokio_util::sync::CancellationToken::new();
@@ -609,6 +678,7 @@ impl MoqStreamHandle {
                 reach,
                 broadcast_path.clone(),
                 mac_key,
+                enc_key,
                 topic,
                 tx,
                 cancel.clone(),
@@ -619,6 +689,7 @@ impl MoqStreamHandle {
                 uds_path,
                 broadcast_path.clone(),
                 mac_key,
+                enc_key,
                 topic,
                 tx,
                 cancel.clone(),
@@ -677,10 +748,12 @@ impl futures::Stream for MoqStreamHandle {
 }
 
 // TODO: add reconnect backoff on UDS disconnect (ZMQ auto-reconnect parity)
+#[allow(clippy::too_many_arguments)]
 async fn moq_stream_handle_task(
     uds_path: String,
     broadcast_path: String,
     mac_key: [u8; 32],
+    enc_key: [u8; 32],
     topic: String,
     tx: tokio::sync::mpsc::Sender<anyhow::Result<crate::streaming::StreamPayload>>,
     cancel: tokio_util::sync::CancellationToken,
@@ -718,7 +791,8 @@ async fn moq_stream_handle_task(
         Ok(t) => t,
         Err(e) => { let _ = tx.send(Err(anyhow!("subscribe_track: {e}"))).await; return; }
     };
-    let mut verifier = StreamVerifier::new(mac_key, topic.clone());
+    // #321: AEAD ON for this DH-keyed mesh stream — open sealed Tagged blocks.
+    let mut verifier = StreamVerifier::new(mac_key, topic.clone()).with_enc_key(enc_key);
     // #145: read groups by EXACT sequence (get_group), not arrival-order next_group.
     // Each Group is served on its own QUIC uni-stream, so Groups can arrive out of
     // order; next_group's monotonic cursor returns the first Group with sequence >=
@@ -827,10 +901,12 @@ fn reach_to_transport_config(
 /// Networked variant of [`moq_stream_handle_task`]: dial a `/moq`
 /// `web_transport_quinn` session from the `reach` list instead of the UDS
 /// plane, then run the identical subscribe + chained-HMAC verify loop (#274).
+#[allow(clippy::too_many_arguments)]
 async fn moq_stream_handle_task_networked(
     reach: Vec<crate::stream_info::Destination>,
     broadcast_path: String,
     mac_key: [u8; 32],
+    enc_key: [u8; 32],
     topic: String,
     tx: tokio::sync::mpsc::Sender<anyhow::Result<crate::streaming::StreamPayload>>,
     cancel: tokio_util::sync::CancellationToken,
@@ -896,7 +972,8 @@ async fn moq_stream_handle_task_networked(
             return;
         }
     };
-    let mut verifier = StreamVerifier::new(mac_key, topic.clone());
+    // #321: AEAD ON for this DH-keyed mesh stream — open sealed Tagged blocks.
+    let mut verifier = StreamVerifier::new(mac_key, topic.clone()).with_enc_key(enc_key);
     // #145: read groups by EXACT sequence (get_group), not arrival-order next_group.
     // Each Group is served on its own QUIC uni-stream, so Groups can arrive out of
     // order; next_group's monotonic cursor returns the first Group with sequence >=
@@ -982,6 +1059,92 @@ pub fn verify_moq_frame(
     verifier.verify_parts(topic.as_bytes(), &frame[..split], &frame[split..])
 }
 
+/// Mesh consumer entry point (#321): verify a moq frame's chained HMAC + AEAD
+/// (via the `verifier`) AND its per-host provenance signature against a roster.
+///
+/// `roster` resolves a signer's anchored ML-DSA-65 key; `is_enrolled` confirms the
+/// signer is a known mesh peer. Provenance is REQUIRED (fail-closed): a block with
+/// no/invalid/unknown signer is rejected. Use [`verify_moq_frame`] for the
+/// non-mesh client path that has no roster.
+pub fn verify_moq_frame_with_provenance(
+    verifier: &mut StreamVerifier,
+    topic: &str,
+    frame: &[u8],
+    roster: &dyn crate::envelope::PqTrustStore,
+    is_enrolled: &dyn Fn(&[u8; 32]) -> bool,
+) -> Result<Vec<crate::streaming::StreamPayload>> {
+    if frame.len() < 16 {
+        anyhow::bail!("moq frame too short: {} bytes", frame.len());
+    }
+    let split = frame.len() - 16;
+    let capnp_data = &frame[..split];
+
+    // 1) Chained HMAC + AEAD open (also rejects topic/order/MAC failures).
+    let payloads = verifier.verify_parts(topic.as_bytes(), capnp_data, &frame[split..])?;
+
+    // 2) Per-host provenance, layered on top: parse the block, reconstruct the
+    //    provenance-cleared signed region, and verify the signature + roster.
+    let mut slice: &[u8] = capnp_data;
+    let reader = capnp::serialize::read_message_from_flat_slice(
+        &mut slice,
+        capnp::message::ReaderOptions::default(),
+    )?;
+    let block = reader.get_root::<crate::streaming_capnp::stream_block::Reader>()?;
+    let prov = block.get_provenance()?;
+    let signer_kid = prov.get_signer_kid()?;
+    let sig = prov.get_sig()?;
+    let signed_region = crate::stream_provenance::signed_region_from_block(&block)?;
+    crate::stream_provenance::verify_provenance(
+        signer_kid,
+        sig,
+        &signed_region,
+        roster,
+        is_enrolled,
+    )?;
+
+    Ok(payloads)
+}
+
+/// Seal a single Data/Complete payload into an AES-256-GCM `Tagged` payload
+/// (#321). The 1-byte kind tag is prepended to the plaintext so the consumer can
+/// restore the original variant. Error/Tagged/other variants pass through
+/// unchanged (Error is operational, already-Tagged is the E2E notification path).
+///
+/// Shares its AAD + kind-tag framing with the cross-target open path
+/// ([`crate::stream_consumer::open_sealed_payload`]).
+fn seal_payload(
+    enc_key: &[u8; 32],
+    topic: &str,
+    epoch: u64,
+    payload: &StreamPayloadData,
+) -> Result<StreamPayloadData> {
+    use crate::crypto::event_crypto::{encrypt_event, EventPrivacy};
+    use crate::stream_consumer::{stream_aead_aad, SEALED_KIND_COMPLETE, SEALED_KIND_DATA};
+
+    let (kind, body): (u8, &[u8]) = match payload {
+        StreamPayloadData::Data(d) => (SEALED_KIND_DATA, d),
+        StreamPayloadData::Complete(d) => (SEALED_KIND_COMPLETE, d),
+        // Leave non-sealed variants untouched.
+        other => return Ok(other.clone()),
+    };
+
+    let mut plaintext = Vec::with_capacity(1 + body.len());
+    plaintext.push(kind);
+    plaintext.extend_from_slice(body);
+
+    let aad = stream_aead_aad(topic, epoch);
+    let (tag, ciphertext, nonce, key_commitment) =
+        encrypt_event(enc_key, &aad, &plaintext, EventPrivacy::ZeroKnowledge)
+            .map_err(|e| anyhow!("stream AEAD seal failed: {e}"))?;
+
+    Ok(StreamPayloadData::Tagged {
+        tag,
+        payload: ciphertext,
+        nonce: nonce.to_vec(),
+        key_commitment: key_commitment.to_vec(),
+    })
+}
+
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
@@ -1004,6 +1167,8 @@ mod tests {
         let ctx = StreamContext::from_dh(&client_pub.to_bytes())?;
         let topic = ctx.topic().to_owned();
         let mac_key = *ctx.mac_key();
+        // #321: DH path is AEAD-on; the verifier shares the same enc_key.
+        let enc_key = *ctx.enc_key().expect("DH ctx has enc_key");
 
         let mut pub_ = origin.publisher(&ctx)?;
         pub_.publish_data(b"hello").await?;
@@ -1020,7 +1185,7 @@ mod tests {
         .ok_or_else(|| anyhow!("broadcast not announced"))?;
         let mut track = bc.subscribe_track(&Track::new(STREAM_TRACK))?;
 
-        let mut verifier = StreamVerifier::new(mac_key, topic.clone());
+        let mut verifier = StreamVerifier::new(mac_key, topic.clone()).with_enc_key(enc_key);
         let mut got: Vec<StreamPayload> = Vec::new();
         for _ in 0..3 {
             let mut group = tokio::time::timeout(
@@ -1053,6 +1218,8 @@ mod tests {
         let ctx = StreamContext::from_dh(&client_pub.to_bytes())?;
         let topic = ctx.topic().to_owned();
         let mac_key = *ctx.mac_key();
+        // #321: DH path is AEAD-on; the verifier shares the same enc_key.
+        let enc_key = *ctx.enc_key().expect("DH ctx has enc_key");
 
         let mut any_pub: AnyStreamPublisher = origin.publisher(&ctx)?;
         any_pub.publish_data(b"ping").await?;
@@ -1067,7 +1234,7 @@ mod tests {
         .await?
         .ok_or_else(|| anyhow!("broadcast not announced"))?;
         let mut track = bc.subscribe_track(&Track::new(STREAM_TRACK))?;
-        let mut verifier = StreamVerifier::new(mac_key, topic.clone());
+        let mut verifier = StreamVerifier::new(mac_key, topic.clone()).with_enc_key(enc_key);
         let mut got: Vec<StreamPayload> = Vec::new();
         for _ in 0..2 {
             let mut group = tokio::time::timeout(
@@ -1148,6 +1315,7 @@ mod tests {
             reach,
             "local/streams/test/deadbeef".to_owned(),
             [0u8; 32],
+            [0u8; 32],
             "deadbeef".repeat(8),
         );
 
@@ -1184,5 +1352,145 @@ mod tests {
         assert!(!gated.authorize_signer(&[2u8; 32]));
         // No gate -> accept all.
         assert!(origin().authorize_signer(&[9u8; 32]));
+    }
+
+    // ── #321 AEAD seal/open ────────────────────────────────────────────────
+
+    #[test]
+    fn aead_seal_open_roundtrip() {
+        let enc_key = [0x42u8; 32];
+        let topic = "deadbeef";
+        let epoch = 7u64;
+        for payload in [
+            StreamPayloadData::Data(b"hello tokens".to_vec()),
+            StreamPayloadData::Complete(b"{\"done\":true}".to_vec()),
+        ] {
+            let sealed = seal_payload(&enc_key, topic, epoch, &payload).unwrap();
+            let StreamPayloadData::Tagged { tag, payload: ct, nonce, key_commitment } = &sealed
+            else {
+                panic!("seal must produce a Tagged payload");
+            };
+            let opened = crate::stream_consumer::open_sealed_payload(
+                &enc_key, topic, epoch, tag, ct, nonce, key_commitment,
+            )
+            .unwrap();
+            match (&payload, &opened) {
+                (StreamPayloadData::Data(a), StreamPayload::Data(b))
+                | (StreamPayloadData::Complete(a), StreamPayload::Complete(b)) => {
+                    assert_eq!(a, b);
+                }
+                _ => panic!("opened variant must match sealed variant"),
+            }
+        }
+    }
+
+    #[test]
+    fn aead_open_rejects_wrong_key_and_tamper() {
+        let enc_key = [0x42u8; 32];
+        let topic = "t";
+        let epoch = 1u64;
+        let sealed =
+            seal_payload(&enc_key, topic, epoch, &StreamPayloadData::Data(b"secret".to_vec()))
+                .unwrap();
+        let StreamPayloadData::Tagged { tag, payload: ct, nonce, key_commitment } = &sealed else {
+            panic!("expected Tagged");
+        };
+
+        // Wrong key.
+        let wrong = [0x99u8; 32];
+        assert!(crate::stream_consumer::open_sealed_payload(
+            &wrong, topic, epoch, tag, ct, nonce, key_commitment
+        )
+        .is_err());
+
+        // Wrong epoch (AAD mismatch) — anti-replay across epochs.
+        assert!(crate::stream_consumer::open_sealed_payload(
+            &enc_key, topic, 2, tag, ct, nonce, key_commitment
+        )
+        .is_err());
+
+        // Tampered ciphertext.
+        let mut bad_ct = ct.clone();
+        if let Some(b) = bad_ct.first_mut() {
+            *b ^= 0xFF;
+        }
+        assert!(crate::stream_consumer::open_sealed_payload(
+            &enc_key, topic, epoch, tag, &bad_ct, nonce, key_commitment
+        )
+        .is_err());
+    }
+
+    // ── #321 provenance over a published block ─────────────────────────────
+
+    /// Publish a block with provenance ON, then verify HMAC + AEAD + provenance
+    /// against a roster; assert wrong/unknown signers are rejected.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn provenance_publish_verify_and_reject() -> Result<()> {
+        use crate::envelope::KeyedPqTrustStore;
+        use crate::stream_provenance::ProvenanceSigner;
+        use ed25519_dalek::SigningKey;
+
+        let origin = origin();
+        let (_cs, client_pub) = crate::crypto::generate_ephemeral_keypair();
+        let ctx = StreamContext::from_dh(&client_pub.to_bytes())?;
+        let topic = ctx.topic().to_owned();
+        let mac_key = *ctx.mac_key();
+        let enc_key = *ctx.enc_key().expect("DH ctx has enc_key");
+
+        let host_ed = SigningKey::from_bytes(&[5u8; 32]);
+        let signer = ProvenanceSigner::from_ed25519(host_ed.clone());
+        let kid = signer.signer_kid();
+
+        let mut pub_ = origin.publisher_with_provenance(&ctx, Some(signer))?;
+        pub_.publish_data(b"hi").await?;
+        pub_.complete_ref(b"{}").await?;
+
+        // Drain the two frames from the shared origin.
+        let path = origin.broadcast_path(&topic);
+        let bc = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            origin.consumer().announced_broadcast(path.as_str()),
+        )
+        .await?
+        .ok_or_else(|| anyhow!("broadcast not announced"))?;
+        let mut track = bc.subscribe_track(&Track::new(STREAM_TRACK))?;
+        let mut frames: Vec<bytes::Bytes> = Vec::new();
+        for _ in 0..2 {
+            let mut group = tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                track.next_group(),
+            )
+            .await??
+            .ok_or_else(|| anyhow!("next_group None"))?;
+            let frame = tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                group.read_frame(),
+            )
+            .await??
+            .ok_or_else(|| anyhow!("read_frame None"))?;
+            frames.push(frame);
+        }
+
+        // Roster anchoring the host's mesh ML-DSA key + enrolled-set closure.
+        use ml_dsa::Keypair;
+        let mut roster = KeyedPqTrustStore::new();
+        roster.bind(kid, &crate::node_identity::derive_mesh_mldsa_key(&host_ed).verifying_key());
+        let enrolled = |k: &[u8; 32]| *k == kid;
+
+        // Valid: verify HMAC + AEAD + provenance.
+        let mut v = StreamVerifier::new(mac_key, topic.clone()).with_enc_key(enc_key);
+        let got = verify_moq_frame_with_provenance(&mut v, &topic, &frames[0], &roster, &enrolled)?;
+        assert!(matches!(&got[0], StreamPayload::Data(d) if d == b"hi"));
+
+        // Unknown signer: empty roster / not enrolled → reject (re-verify frame 0
+        // with a fresh verifier so the HMAC chain restarts at the same block).
+        let empty = KeyedPqTrustStore::new();
+        let none_enrolled = |_: &[u8; 32]| false;
+        let mut v2 = StreamVerifier::new(mac_key, topic.clone()).with_enc_key(enc_key);
+        assert!(verify_moq_frame_with_provenance(
+            &mut v2, &topic, &frames[0], &empty, &none_enrolled
+        )
+        .is_err());
+        Ok(())
     }
 }

--- a/crates/hyprstream-rpc/src/stream_consumer.rs
+++ b/crates/hyprstream-rpc/src/stream_consumer.rs
@@ -88,6 +88,11 @@ pub struct VerifierContract {
 /// HMAC chain verifier for StreamBlock.
 pub struct StreamVerifier {
     key: [u8; 32],
+    /// Transport-level AEAD key (#321). `Some` ⇒ a `Tagged` payload is opened
+    /// (AES-256-GCM, AAD bound to topic+epoch) back into Data/Complete; `None` ⇒
+    /// `Tagged` payloads pass through unchanged (the E2E notification path, which
+    /// the app layer decrypts itself).
+    enc_key: Option<[u8; 32]>,
     prev_mac: Option<[u8; 16]>,
     topic: String,
     /// Verifier contract enforcement (#163). `None` ⇒ legacy behaviour (MAC chain only, no
@@ -103,15 +108,29 @@ pub struct StreamVerifier {
 
 impl StreamVerifier {
     /// Create a new verifier with **no** policy enforcement (MAC chain only) — legacy behaviour.
+    ///
+    /// AEAD opening is OFF (`enc_key = None`); use [`StreamVerifier::with_enc_key`] to
+    /// open transport-sealed `Tagged` payloads (#321).
     pub fn new(key: [u8; 32], topic: String) -> Self {
         Self {
             key,
+            enc_key: None,
             prev_mac: None,
             topic,
             policy: None,
             seq_cursor: None,
             terminal_seen: false,
         }
+    }
+
+    /// Set the transport AEAD key so sealed `Tagged` payloads are opened (#321).
+    ///
+    /// Builder-style; pass the `enc_key` from `derive_client_stream_keys`. With it
+    /// set, the verifier decrypts each `Tagged` block back into Data/Complete and
+    /// fails closed on tamper / wrong key.
+    pub fn with_enc_key(mut self, enc_key: [u8; 32]) -> Self {
+        self.enc_key = Some(enc_key);
+        self
     }
 
     /// Create a verifier that enforces `policy` (#163) — used by codegen-generated consumers,
@@ -226,6 +245,10 @@ impl StreamVerifier {
             }
         }
 
+        // #321: the AEAD AAD binds each sealed payload to (topic, epoch); read the
+        // block epoch so a sealed Tagged payload can only open under its own epoch.
+        let block_epoch = block.get_epoch();
+
         let payloads_reader = block.get_payloads()?;
         let mut payloads = Vec::with_capacity(payloads_reader.len() as usize);
 
@@ -249,11 +272,25 @@ impl StreamVerifier {
                 }
                 Which::Tagged(tagged_result) => {
                     let tagged = tagged_result?;
-                    StreamPayload::Tagged {
-                        tag: tagged.get_tag()?.to_vec(),
-                        payload: tagged.get_payload()?.to_vec(),
-                        nonce: tagged.get_nonce()?.to_vec(),
-                        key_commitment: tagged.get_key_commitment()?.to_vec(),
+                    match self.enc_key {
+                        // #321: transport AEAD ON — open the sealed payload back into
+                        // Data/Complete (fails closed on tamper / wrong key).
+                        Some(ref enc_key) => open_sealed_payload(
+                            enc_key,
+                            &self.topic,
+                            block_epoch,
+                            tagged.get_tag()?,
+                            tagged.get_payload()?,
+                            tagged.get_nonce()?,
+                            tagged.get_key_commitment()?,
+                        )?,
+                        // No transport key (E2E notification path): pass Tagged through.
+                        None => StreamPayload::Tagged {
+                            tag: tagged.get_tag()?.to_vec(),
+                            payload: tagged.get_payload()?.to_vec(),
+                            nonce: tagged.get_nonce()?.to_vec(),
+                            key_commitment: tagged.get_key_commitment()?.to_vec(),
+                        },
                     }
                 }
             };
@@ -277,6 +314,68 @@ impl StreamVerifier {
 fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     use subtle::ConstantTimeEq;
     a.ct_eq(b).into()
+}
+
+// ============================================================================
+// #321 — transport-level AEAD framing (cross-target seal/open glue).
+//
+// The seal side lives in `moq_stream` (native publisher); the open side here is
+// cross-target so the wasm/browser consumer opens sealed blocks too. Both sides
+// share this AAD + kind-tag framing.
+// ============================================================================
+
+/// Plaintext kind tag prepended inside the AEAD-sealed bytes so the open path can
+/// restore the original payload variant (`Data` vs `Complete`) without a schema
+/// change. Authenticated as part of the AEAD plaintext.
+pub(crate) const SEALED_KIND_DATA: u8 = 0x00;
+pub(crate) const SEALED_KIND_COMPLETE: u8 = 0x01;
+
+/// Build the AEAD AAD (also the `encrypt_event` "prefix") binding each sealed
+/// payload to its `topic` and key-`epoch` (#321/#223). Reused verbatim by the
+/// publisher seal path; a block replayed under a different epoch fails AEAD open.
+pub(crate) fn stream_aead_aad(topic: &str, epoch: u64) -> String {
+    format!("{topic}|stream-aead-v1|epoch={epoch}")
+}
+
+/// Open an AEAD-sealed `Tagged` payload (#321), restoring the original
+/// Data/Complete variant. Returns `Err` on tamper / wrong key (fail-closed).
+///
+/// `epoch` is the StreamBlock's epoch and MUST match the seal-side AAD.
+pub(crate) fn open_sealed_payload(
+    enc_key: &[u8; 32],
+    topic: &str,
+    epoch: u64,
+    tag: &[u8],
+    ciphertext: &[u8],
+    nonce: &[u8],
+    key_commitment: &[u8],
+) -> Result<StreamPayload> {
+    use crate::crypto::event_crypto::{check_key_commitment, decrypt_event_full};
+
+    let nonce12: [u8; 12] = nonce
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("stream AEAD: bad nonce length {}", nonce.len()))?;
+    let commitment16: [u8; 16] = key_commitment.try_into().map_err(|_| {
+        anyhow::anyhow!("stream AEAD: bad key_commitment length {}", key_commitment.len())
+    })?;
+
+    // Fast committing-AEAD rejection of a wrong-key block before the GCM open.
+    if !check_key_commitment(enc_key, &nonce12, &commitment16) {
+        anyhow::bail!("stream AEAD: key commitment mismatch (wrong key or tampered block)");
+    }
+
+    let aad = stream_aead_aad(topic, epoch);
+    let plaintext = decrypt_event_full(enc_key, &nonce12, tag, ciphertext, &aad)
+        .map_err(|e| anyhow::anyhow!("stream AEAD open failed: {e}"))?;
+
+    let (&kind, body) = plaintext
+        .split_first()
+        .ok_or_else(|| anyhow::anyhow!("stream AEAD: empty sealed plaintext (missing kind tag)"))?;
+    match kind {
+        SEALED_KIND_DATA => Ok(StreamPayload::Data(body.to_vec())),
+        SEALED_KIND_COMPLETE => Ok(StreamPayload::Complete(body.to_vec())),
+        other => anyhow::bail!("stream AEAD: unknown sealed kind tag {other:#x}"),
+    }
 }
 
 // ============================================================================
@@ -327,11 +426,13 @@ impl<T: Transport> StreamHandleImpl<T> {
         let publisher = transport.publish(keys.ctrl_topic.as_bytes()).await.ok();
 
         // QoS contract from the signed StreamInfo handshake — enforced for both native and WASM paths.
+        // #321: AEAD ON for this DH-keyed (mesh/networked) stream — open sealed Tagged blocks.
         let verifier = StreamVerifier::with_policy(
             *keys.mac_key,
             keys.topic.clone(),
             stream_info.qos.into(),
-        );
+        )
+        .with_enc_key(*keys.enc_key);
 
         Ok(Self {
             subscriber,

--- a/crates/hyprstream-rpc/src/stream_provenance.rs
+++ b/crates/hyprstream-rpc/src/stream_provenance.rs
@@ -1,0 +1,246 @@
+//! Per-host provenance signing/verification for the mesh stream plane (#321).
+//!
+//! The chained HMAC on `StreamBlock` proves "the producer held the DH key and
+//! delivered blocks in order" — it does NOT prove "host-X computed this block"
+//! (threat T3 / C-PROV in the authz threat-model). Provenance closes that gap:
+//! each block is signed with the producing host's **per-host hybrid COSE
+//! identity** (Ed25519 + ML-DSA-65, #328 `derive_mesh_mldsa_key`), and the
+//! consumer verifies the signature AND that the signer key is enrolled in the
+//! mesh roster. This is a layer ON TOP of AEAD + HMAC.
+//!
+//! ## Canonical signed region
+//!
+//! The signature covers the *signed region*: the StreamBlock serialized with the
+//! `provenance` field left empty — i.e. exactly [`crate::streaming::encode_stream_block`]
+//! over `(prevMac, sequenceNumber, epoch, payloads)`. The publisher signs that
+//! region, then attaches the `provenance` field; the consumer reconstructs the
+//! same region from the parsed (provenance-cleared) block and verifies. The
+//! signature therefore binds the post-AEAD payloads, the sequence number, and the
+//! epoch — but is independent of the (circular) provenance bytes themselves.
+
+use anyhow::{anyhow, Result};
+
+use crate::crypto::cose_sign::{sign_composite, verify_composite};
+use crate::crypto::pq::{MlDsaSigningKey, MlDsaVerifyingKey};
+use crate::envelope::PqTrustStore;
+use crate::streaming::StreamPayloadData;
+use crate::streaming_capnp;
+
+/// Cap'n Proto file id of `streaming.capnp` — first half of the COSE
+/// `external_aad` schema binding for provenance (prevents cross-schema replay).
+const STREAMING_SCHEMA_ID: u64 = 0xe7f8_a9b0_c1d2_e3f4;
+
+/// Stable inner-type id binding the provenance COSE composite to the StreamBlock
+/// signed region (≠ any envelope type id, so a provenance signature can never be
+/// replayed as a request/response envelope signature).
+const STREAM_BLOCK_PROVENANCE_TYPE_ID: u64 = 0x5374_726d_4270_3031; // "StrmBp01"
+
+/// COSE `external_aad` for StreamBlock provenance signatures.
+fn provenance_external_aad() -> Vec<u8> {
+    crate::crypto::cose_sign1::build_external_aad(
+        STREAMING_SCHEMA_ID,
+        STREAM_BLOCK_PROVENANCE_TYPE_ID,
+    )
+}
+
+/// The producing host's per-host hybrid signing identity (#328): the node's
+/// Ed25519 mesh signer + its deterministically-derived ML-DSA-65 mesh key.
+#[derive(Clone)]
+pub struct ProvenanceSigner {
+    ed_sk: ed25519_dalek::SigningKey,
+    pq_sk: MlDsaSigningKey,
+}
+
+impl ProvenanceSigner {
+    /// Build from the node's Ed25519 mesh signing key. The ML-DSA-65 half is
+    /// derived deterministically via [`crate::node_identity::derive_mesh_mldsa_key`]
+    /// (#157/#328), so the signer matches the `#mesh-pq` key peers anchor.
+    pub fn from_ed25519(ed_sk: ed25519_dalek::SigningKey) -> Self {
+        let pq_sk = crate::node_identity::derive_mesh_mldsa_key(&ed_sk);
+        Self { ed_sk, pq_sk }
+    }
+
+    /// Build from an explicit Ed25519 + ML-DSA-65 keypair.
+    pub fn new(ed_sk: ed25519_dalek::SigningKey, pq_sk: MlDsaSigningKey) -> Self {
+        Self { ed_sk, pq_sk }
+    }
+
+    /// The host's signer kid = its Ed25519 verifying-key bytes (matches the COSE
+    /// inner kid and the mesh-roster key).
+    pub fn signer_kid(&self) -> [u8; 32] {
+        self.ed_sk.verifying_key().to_bytes()
+    }
+
+    /// Sign the canonical `signed_region` with the hybrid COSE composite (#321),
+    /// returning `(signer_kid, cose_sig_bytes)` for the `provenance` field.
+    pub fn sign(&self, signed_region: &[u8]) -> Result<(Vec<u8>, Vec<u8>)> {
+        let aad = provenance_external_aad();
+        let sig = sign_composite(&self.ed_sk, Some(&self.pq_sk), signed_region, &aad)?;
+        Ok((self.signer_kid().to_vec(), sig))
+    }
+}
+
+/// Verify a StreamBlock's provenance (#321), fail-closed.
+///
+/// `roster` resolves the signer's anchored ML-DSA-65 key (the mesh
+/// `KeyedPqTrustStore`); `is_enrolled` confirms the signer's Ed25519 key is a
+/// known/enrolled mesh peer. Rejects on missing/unknown/invalid signer.
+///
+/// `signed_region` is the provenance-cleared block encoding (see module docs);
+/// `signer_kid`/`sig` come from the wire `StreamBlock.provenance` field.
+pub fn verify_provenance(
+    signer_kid: &[u8],
+    sig: &[u8],
+    signed_region: &[u8],
+    roster: &dyn PqTrustStore,
+    is_enrolled: &dyn Fn(&[u8; 32]) -> bool,
+) -> Result<()> {
+    if sig.is_empty() {
+        anyhow::bail!("stream provenance: missing signature (fail-closed)");
+    }
+    let kid: [u8; 32] = signer_kid
+        .try_into()
+        .map_err(|_| anyhow!("stream provenance: signer kid must be 32 bytes (Ed25519)"))?;
+
+    // The signer must be an enrolled mesh peer — never accept an unknown signer.
+    if !is_enrolled(&kid) {
+        anyhow::bail!("stream provenance: signer is not an enrolled mesh peer (unknown signer)");
+    }
+
+    let ed_vk = ed25519_dalek::VerifyingKey::from_bytes(&kid)
+        .map_err(|e| anyhow!("stream provenance: invalid Ed25519 signer key: {e}"))?;
+
+    // The anchored ML-DSA-65 key for this signer (per-host #mesh-pq). Required:
+    // verify under the Hybrid policy (fail-closed on a stripped/absent PQ layer).
+    let pq_vk: MlDsaVerifyingKey = roster
+        .ml_dsa_key_for(&kid)
+        .ok_or_else(|| anyhow!("stream provenance: no anchored ML-DSA-65 key for signer"))?;
+
+    let aad = provenance_external_aad();
+    verify_composite(sig, &ed_vk, Some(&pq_vk), signed_region, &aad, /* require_pq */ true)
+        .map_err(|e| anyhow!("stream provenance: signature verification failed: {e}"))?;
+    Ok(())
+}
+
+/// Reconstruct the canonical signed region from a parsed (wire) StreamBlock by
+/// re-encoding it with the `provenance` field cleared (#321). Byte-identical to
+/// the publisher's pre-provenance [`crate::streaming::encode_stream_block`].
+pub fn signed_region_from_block(
+    block: &streaming_capnp::stream_block::Reader,
+) -> Result<Vec<u8>> {
+    use streaming_capnp::stream_payload::Which;
+
+    let prev_mac = block.get_prev_mac()?;
+    let sequence_number = block.get_sequence_number();
+    let epoch = block.get_epoch();
+
+    let payloads_reader = block.get_payloads()?;
+    let mut payloads: Vec<StreamPayloadData> = Vec::with_capacity(payloads_reader.len() as usize);
+    for i in 0..payloads_reader.len() {
+        let p = payloads_reader.get(i);
+        let data = match p.which()? {
+            Which::Data(d) => StreamPayloadData::Data(d?.to_vec()),
+            Which::Complete(d) => StreamPayloadData::Complete(d?.to_vec()),
+            Which::Error(e) => {
+                let _ = e?; // error frames are not provenance-signed in practice
+                StreamPayloadData::Error(String::new())
+            }
+            Which::Heartbeat(()) => continue,
+            Which::Tagged(t) => {
+                let t = t?;
+                StreamPayloadData::Tagged {
+                    tag: t.get_tag()?.to_vec(),
+                    payload: t.get_payload()?.to_vec(),
+                    nonce: t.get_nonce()?.to_vec(),
+                    key_commitment: t.get_key_commitment()?.to_vec(),
+                }
+            }
+        };
+        payloads.push(data);
+    }
+
+    crate::streaming::encode_stream_block(prev_mac, sequence_number, epoch, &payloads)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::envelope::KeyedPqTrustStore;
+    use ed25519_dalek::SigningKey;
+
+    fn signer() -> ProvenanceSigner {
+        ProvenanceSigner::from_ed25519(SigningKey::from_bytes(&[7u8; 32]))
+    }
+
+    /// Build a roster anchoring `signer`'s ML-DSA key, plus an enrolled-set closure.
+    fn roster_for(signer: &ProvenanceSigner) -> (KeyedPqTrustStore, [u8; 32]) {
+        use ml_dsa::Keypair;
+        let kid = signer.signer_kid();
+        let mut store = KeyedPqTrustStore::new();
+        let pq_vk = signer.pq_sk.verifying_key();
+        store.bind(kid, &pq_vk);
+        (store, kid)
+    }
+
+    #[test]
+    fn sign_verify_roundtrip() {
+        let s = signer();
+        let (store, kid) = roster_for(&s);
+        let region = b"canonical signed region bytes";
+        let (signer_kid, sig) = s.sign(region).unwrap();
+        assert_eq!(signer_kid, kid.to_vec());
+
+        let enrolled = |k: &[u8; 32]| *k == kid;
+        verify_provenance(&signer_kid, &sig, region, &store, &enrolled)
+            .expect("valid provenance must verify");
+    }
+
+    #[test]
+    fn tampered_region_rejected() {
+        let s = signer();
+        let (store, kid) = roster_for(&s);
+        let (signer_kid, sig) = s.sign(b"original region").unwrap();
+        let enrolled = |k: &[u8; 32]| *k == kid;
+        let res = verify_provenance(&signer_kid, &sig, b"tampered region", &store, &enrolled);
+        assert!(res.is_err(), "tampered region must fail provenance verify");
+    }
+
+    #[test]
+    fn wrong_signer_rejected() {
+        // A different host signs; verifier anchors the EXPECTED host. The kid won't
+        // resolve in the roster / enrolled set → rejected.
+        let real = signer();
+        let attacker = ProvenanceSigner::from_ed25519(SigningKey::from_bytes(&[9u8; 32]));
+        let (store, real_kid) = roster_for(&real);
+        let region = b"region";
+        let (att_kid, att_sig) = attacker.sign(region).unwrap();
+
+        // Only the real host is enrolled; the attacker's kid is unknown.
+        let enrolled = |k: &[u8; 32]| *k == real_kid;
+        let res = verify_provenance(&att_kid, &att_sig, region, &store, &enrolled);
+        assert!(res.is_err(), "wrong (unenrolled) signer must be rejected");
+    }
+
+    #[test]
+    fn unknown_signer_rejected() {
+        // Signer is enrolled in the set but has NO anchored ML-DSA key (roster miss).
+        let s = signer();
+        let kid = s.signer_kid();
+        let region = b"region";
+        let (signer_kid, sig) = s.sign(region).unwrap();
+        let empty_store = KeyedPqTrustStore::new();
+        let enrolled = |k: &[u8; 32]| *k == kid;
+        let res = verify_provenance(&signer_kid, &sig, region, &empty_store, &enrolled);
+        assert!(res.is_err(), "signer without an anchored PQ key must be rejected");
+    }
+
+    #[test]
+    fn empty_signature_rejected() {
+        let s = signer();
+        let (store, kid) = roster_for(&s);
+        let enrolled = |k: &[u8; 32]| *k == kid;
+        let res = verify_provenance(kid.as_ref(), &[], b"region", &store, &enrolled);
+        assert!(res.is_err(), "empty signature must fail closed");
+    }
+}

--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -180,6 +180,12 @@ pub struct StreamContext {
     topic: String,
     /// DH-derived HMAC key for authenticated stream blocks
     mac_key: [u8; 32],
+    /// DH-derived AES-256-GCM key for transport-level AEAD of payloads (#321).
+    /// `Some` only on the DH path (`from_dh`): the mesh/networked stream plane
+    /// seals each Data/Complete payload under this key. `None` on the keyless
+    /// `new()` path (e.g. NotificationService topics, whose payloads are already
+    /// E2E-encrypted at the app layer), where transport AEAD is not applied.
+    enc_key: Option<[u8; 32]>,
     /// Server's ephemeral public key - client needs this for DH
     server_pubkey: [u8; 32],
     /// DH-derived control channel topic (64 hex chars)
@@ -204,6 +210,8 @@ impl StreamContext {
             stream_id,
             topic,
             mac_key,
+            // Keyless path: no shared transport AEAD key (see field docs).
+            enc_key: None,
             server_pubkey,
             ctrl_topic: String::new(),
             ctrl_mac_key: [0u8; 32],
@@ -240,6 +248,8 @@ impl StreamContext {
             stream_id,
             topic: keys.topic,
             mac_key: *keys.mac_key,
+            // DH path: AEAD ON for the mesh stream plane (#321).
+            enc_key: Some(*keys.enc_key),
             server_pubkey: server_pubkey_bytes,
             ctrl_topic: keys.ctrl_topic,
             ctrl_mac_key: *keys.ctrl_mac_key,
@@ -261,6 +271,26 @@ impl StreamContext {
     /// Get the MAC key (for HMAC chain).
     pub fn mac_key(&self) -> &[u8; 32] {
         &self.mac_key
+    }
+
+    /// Get the transport AEAD key (#321), if this is a DH-keyed stream.
+    ///
+    /// `Some` on the DH path (mesh/networked stream — AEAD ON), `None` on the
+    /// keyless `new()` path (payloads already E2E-encrypted at the app layer).
+    pub fn enc_key(&self) -> Option<&[u8; 32]> {
+        self.enc_key.as_ref()
+    }
+
+    /// Disable transport-level AEAD for this stream (#321).
+    ///
+    /// Clears the AEAD key so the publisher emits cleartext (HMAC-chained) blocks.
+    /// Used for streams whose consumer receives only `(mac_key, topic)` out of band
+    /// and never derives the DH `enc_key` (e.g. the TUI PTY/shell stdout viewer,
+    /// a same-host stream). AEAD remains mandatory and ON for the DH-keyed mesh
+    /// inference stream, whose consumer derives `enc_key` from the same DH.
+    pub fn without_aead(mut self) -> Self {
+        self.enc_key = None;
+        self
     }
 
     /// Get the server's ephemeral public key (client needs this for DH).
@@ -439,8 +469,8 @@ pub use crate::stream_consumer::StreamVerifier;
 /// publisher.complete(&metadata).await?;
 /// ```
 pub struct StreamChannel {
-    /// Ed25519 signing key for stream authorization (wired into moq publish claims, N7).
-    #[allow(dead_code)]
+    /// Ed25519 signing key for stream authorization (wired into moq publish claims, N7)
+    /// and the per-host provenance signer (#321).
     signing_key: SigningKey,
     /// ML-DSA-65 signing key for the post-quantum half of the StreamRegister
     /// composite signature. Mirrors `LocalSigner` on the RPC plane so the
@@ -545,7 +575,25 @@ impl StreamChannel {
     pub async fn publisher(&self, ctx: &StreamContext) -> Result<crate::moq_stream::AnyStreamPublisher> {
         let origin = crate::moq_stream::global_moq_origin()
             .ok_or_else(|| anyhow::anyhow!("no moq stream origin — server not initialized"))?;
-        origin.publisher(ctx)
+        // #321: on the DH (mesh) path, sign each StreamBlock with the node's per-host
+        // hybrid identity (Ed25519 + the deterministically-derived mesh ML-DSA key)
+        // so consumers can attribute blocks to this host (C-PROV / threat T3). The
+        // keyless notification path (no DH enc_key) carries no provenance.
+        let provenance = if ctx.enc_key().is_some() {
+            let signer = match &self.pq_signing_key {
+                Some(pq) => crate::stream_provenance::ProvenanceSigner::new(
+                    self.signing_key.clone(),
+                    pq.clone(),
+                ),
+                None => crate::stream_provenance::ProvenanceSigner::from_ed25519(
+                    self.signing_key.clone(),
+                ),
+            };
+            Some(signer)
+        } else {
+            None
+        };
+        origin.publisher_with_provenance(ctx, provenance)
     }
 
     /// Run a streaming operation with framework-guaranteed terminal frame.
@@ -819,6 +867,22 @@ pub fn encode_stream_block(
     epoch: u64,
     payloads: &[StreamPayloadData],
 ) -> Result<Vec<u8>> {
+    encode_stream_block_with_provenance(prev_mac, sequence_number, epoch, payloads, None)
+}
+
+/// Encode a `StreamBlock` with an optional per-host provenance signature (#321).
+///
+/// `provenance = None` produces the canonical *signed region* — byte-identical to
+/// [`encode_stream_block`] — over which the provenance signature is computed (and
+/// which the consumer reconstructs to verify). `provenance = Some((signer_kid,
+/// sig))` additionally populates the wire `StreamBlock.provenance` field.
+pub fn encode_stream_block_with_provenance(
+    prev_mac: &[u8],
+    sequence_number: u64,
+    epoch: u64,
+    payloads: &[StreamPayloadData],
+    provenance: Option<(&[u8], &[u8])>,
+) -> Result<Vec<u8>> {
     let mut msg = Builder::new_default();
     {
         let mut block = msg.init_root::<streaming_capnp::stream_block::Builder>();
@@ -827,6 +891,15 @@ pub fn encode_stream_block(
         // epoch is 0 until the #223 key-epoch lifecycle lands.
         block.set_sequence_number(sequence_number);
         block.set_epoch(epoch);
+
+        // #321: per-host provenance. Set BEFORE the payload list so the canonical
+        // serialization is deterministic regardless of field-set order. Absent ⇒
+        // the field stays default (empty) — the signed-region encoding.
+        if let Some((signer_kid, sig)) = provenance {
+            let mut prov = block.reborrow().init_provenance();
+            prov.set_signer_kid(signer_kid);
+            prov.set_sig(sig);
+        }
 
         // Cap'n Proto uses u32 for list lengths
         let payloads_len = u32::try_from(payloads.len()).unwrap_or(u32::MAX);
@@ -878,7 +951,7 @@ fn pubkey_to_32(pubkey: &[u8]) -> [u8; 32] {
     }
 }
 
-/// Derive the `(mac_key, topic)` pair from a client-side DH exchange.
+/// Derive the `(mac_key, enc_key, topic)` triple from a client-side DH exchange (#321).
 ///
 /// This is the consumer-side counterpart to `StreamContext::from_dh` (the server side).
 /// Call this before constructing a `MoqStreamHandle` when you have the raw keys from
@@ -887,14 +960,15 @@ pub fn derive_client_stream_keys(
     client_secret: &DhSecret,
     client_pubkey: &[u8],
     server_pubkey: &[u8],
-) -> anyhow::Result<([u8; 32], String)> {
+) -> anyhow::Result<([u8; 32], [u8; 32], String)> {
     let server_pub = DhPublic::from_slice(server_pubkey)
         .ok_or_else(|| anyhow::anyhow!("invalid server pubkey length"))?;
     let shared = dh_compute(client_secret, &server_pub);
     let client_pub_32 = pubkey_to_32(client_pubkey);
     let server_pub_32 = pubkey_to_32(server_pubkey);
     let keys = crate::crypto::derive_stream_keys(&shared, &client_pub_32, &server_pub_32)?;
-    Ok((*keys.mac_key, keys.topic.clone()))
+    // #321: also return the AEAD enc_key so the moq consumer can open Tagged blocks.
+    Ok((*keys.mac_key, *keys.enc_key, keys.topic.clone()))
 }
 
 // `constant_time_eq` removed with the duplicate StreamVerifier (#224) — the canonical

--- a/crates/hyprstream-rpc/tests/moq_networked.rs
+++ b/crates/hyprstream-rpc/tests/moq_networked.rs
@@ -63,6 +63,8 @@ async fn networked_moq_subscribe_receives_mac_verified_frames() -> Result<()> {
     let ctx = StreamContext::from_dh(&client_pub.to_bytes())?;
     let topic = ctx.topic().to_owned();
     let mac_key = *ctx.mac_key();
+    // #321: the DH path is AEAD-on; the consumer shares the same enc_key.
+    let enc_key = *ctx.enc_key().expect("DH StreamContext has an AEAD enc_key");
     let broadcast_path = origin.broadcast_path(&topic);
 
     // Stand up the daemon's RPC+moq endpoint: RPC core on default path, moq on
@@ -99,7 +101,7 @@ async fn networked_moq_subscribe_receives_mac_verified_frames() -> Result<()> {
     // Client: networked subscribe — dials `/moq` via dial_stream, subscribes,
     // verifies the chained HMAC, and yields decoded payloads.
     let mut handle =
-        hyprstream_rpc::moq_stream::MoqStreamHandle::networked(reach, broadcast_path, mac_key, topic);
+        hyprstream_rpc::moq_stream::MoqStreamHandle::networked(reach, broadcast_path, mac_key, enc_key, topic);
 
     // Give the background task time to dial, handshake, and subscribe to the
     // track before the producer pushes group 0 — a late joiner that misses the

--- a/crates/hyprstream/src/cli/shell_handlers.rs
+++ b/crates/hyprstream/src/cli/shell_handlers.rs
@@ -254,7 +254,11 @@ pub async fn handle_shell_tui(
     // because the PTY broadcast lives on the *TUI service's* plane, a different
     // process from this viewer.)
     let reach = stdout_stream.reach.clone();
-    let mut handle = MoqStreamHandle::networked(reach, broadcast_path, mac_key, topic);
+    // #321: the TUI stdout stream is published AEAD-off (the viewer gets only
+    // `mac_key`+`topic` out of band), so the transport enc_key is never exercised
+    // here — derive a stable one from mac_key purely to satisfy the consumer API.
+    let enc_key = *hyprstream_rpc::crypto::StreamKeys::new(topic.clone(), mac_key).enc_key;
+    let mut handle = MoqStreamHandle::networked(reach, broadcast_path, mac_key, enc_key, topic);
     let _recv_handle = tokio::spawn(async move {
         loop {
             match handle.recv_next().await {

--- a/crates/hyprstream/src/cli/tui_handlers.rs
+++ b/crates/hyprstream/src/cli/tui_handlers.rs
@@ -148,7 +148,11 @@ async fn run_attach_loop(
     // `connect_uds(moq_uds_path)` connected to *this* process's empty plane and
     // timed out waiting for the producer's broadcast.
     let reach = stream_info.reach.clone();
-    let mut handle = MoqStreamHandle::networked(reach, broadcast_path, mac_key, topic);
+    // #321: the TUI stdout stream is published AEAD-off (the viewer gets only
+    // `mac_key`+`topic` out of band), so the transport enc_key is never exercised
+    // here — derive a stable one from mac_key purely to satisfy the consumer API.
+    let enc_key = *hyprstream_rpc::crypto::StreamKeys::new(topic.clone(), mac_key).enc_key;
+    let mut handle = MoqStreamHandle::networked(reach, broadcast_path, mac_key, enc_key, topic);
     let recv_handle = tokio::spawn(async move {
         loop {
             match handle.recv_next().await {

--- a/crates/hyprstream/src/services/mcp_service.rs
+++ b/crates/hyprstream/src/services/mcp_service.rs
@@ -439,16 +439,16 @@ fn register_scoped_tools_recursive(
 
                             let handle = match decode_stream_reach(&stream_info_json)? {
                                 DecodedStreamReach::Networked { dh_public, reach, broadcast_path } => {
-                                    let (mac_key, topic) = hyprstream_rpc::derive_client_stream_keys(
+                                    let (mac_key, enc_key, topic) = hyprstream_rpc::derive_client_stream_keys(
                                         &client_secret, &client_pubkey_bytes, &dh_public,
                                     )?;
-                                    MoqStreamHandle::networked(reach, broadcast_path, mac_key, topic)
+                                    MoqStreamHandle::networked(reach, broadcast_path, mac_key, enc_key, topic)
                                 }
                                 DecodedStreamReach::Uds { dh_public, uds_path, broadcast_path } => {
-                                    let (mac_key, topic) = hyprstream_rpc::derive_client_stream_keys(
+                                    let (mac_key, enc_key, topic) = hyprstream_rpc::derive_client_stream_keys(
                                         &client_secret, &client_pubkey_bytes, &dh_public,
                                     )?;
-                                    MoqStreamHandle::new(uds_path, broadcast_path, mac_key, topic)
+                                    MoqStreamHandle::new(uds_path, broadcast_path, mac_key, enc_key, topic)
                                 }
                             };
 
@@ -603,16 +603,16 @@ fn register_streaming_tool(
 
                 let handle = match decode_stream_reach(&stream_info_json)? {
                     DecodedStreamReach::Networked { dh_public, reach, broadcast_path } => {
-                        let (mac_key, topic) = hyprstream_rpc::derive_client_stream_keys(
+                        let (mac_key, enc_key, topic) = hyprstream_rpc::derive_client_stream_keys(
                             &client_secret, &client_pubkey_bytes, &dh_public,
                         )?;
-                        MoqStreamHandle::networked(reach, broadcast_path, mac_key, topic)
+                        MoqStreamHandle::networked(reach, broadcast_path, mac_key, enc_key, topic)
                     }
                     DecodedStreamReach::Uds { dh_public, uds_path, broadcast_path } => {
-                        let (mac_key, topic) = hyprstream_rpc::derive_client_stream_keys(
+                        let (mac_key, enc_key, topic) = hyprstream_rpc::derive_client_stream_keys(
                             &client_secret, &client_pubkey_bytes, &dh_public,
                         )?;
-                        MoqStreamHandle::new(uds_path, broadcast_path, mac_key, topic)
+                        MoqStreamHandle::new(uds_path, broadcast_path, mac_key, enc_key, topic)
                     }
                 };
 

--- a/crates/hyprstream/src/tui/service.rs
+++ b/crates/hyprstream/src/tui/service.rs
@@ -332,8 +332,13 @@ impl TuiService {
         // DH key exchange derives context from client's ephemeral pubkey.
         // If no pubkey (local/test connections), generate random standalone contexts.
         let make_stream_ctx = |label: &str| -> Result<StreamContext> {
+            // #321: the TUI PTY/shell viewer receives only `(mac_key, topic)` out of
+            // band (see tui_handlers / shell_handlers) and never derives the DH
+            // `enc_key`, so transport AEAD is disabled for these same-host streams.
+            // The blocks remain HMAC-chain authenticated. (AEAD stays mandatory + ON
+            // for the DH-keyed mesh inference stream, whose consumer derives enc_key.)
             match ctx.ephemeral_pubkey() {
-                Some(pubkey) => StreamContext::from_dh(&pubkey),
+                Some(pubkey) => Ok(StreamContext::from_dh(&pubkey)?.without_aead()),
                 None => {
                     use rand::RngCore;
                     let mut rng = rand::thread_rng();


### PR DESCRIPTION
Implements #321 (epic #310, Phase 2): mandatory transport AEAD and per-host provenance on the existing moq mesh stream plane. Spec: `docs/plans/2026-06-19-phase2-320-321-decision.md` (#321 section).

## Part A — transport AEAD (pure-Rust, no schema change)
- `derive_stream_keys` now derives a key-separated `enc_key` with a distinct context string `"hyprstream stream-keys v1 enc"` (mirrors `derive_notification_keys`'s enc/mac split). The shared-secret IKM is now zeroized after derivation.
- `MoqStreamPublisher::write_block` seals each `Data`/`Complete` payload with AES-256-GCM (`event_crypto::encrypt_event`) into a `Tagged` payload **before** the chained HMAC runs — so the HMAC authenticates the ciphertext, no double-encryption, ordering/anti-replay unchanged. `Error` frames stay cleartext (operational/terminal). A 1-byte kind tag inside the AEAD plaintext restores the `Data` vs `Complete` variant on open (no schema change).
- The AEAD AAD **and** key-commitment are bound to `(topic, epoch)` (`"{topic}|stream-aead-v1|epoch={epoch}"`), so a rekey cannot replay a block across epochs.
- `StreamVerifier::with_enc_key` opens sealed `Tagged` blocks back into `Data`/`Complete` (committing-AEAD fast reject + GCM), **fail-closed** on tamper / wrong key / wrong epoch. The open path lives in cross-target `stream_consumer.rs` so the wasm/browser consumer opens too.

### enc_key derivation
```rust
// crypto/key_exchange.rs::derive_stream_keys (IKM = shared_secret || (client_pub XOR server_pub))
let enc_key = derive_key("hyprstream stream-keys v1 enc", &ikm);
```

### Loopback / mandatory decision
The publish site **can** cleanly distinguish the networked DH-keyed mesh path from the keyless in-process paths, so AEAD is **ALWAYS-ON for the DH (mesh/networked) stream** and disabled only where the consumer never derives the DH `enc_key`:
- NotificationService keyless topic path (`publisher_for_topic` / `StreamContext::new`) — payloads are already E2E-encrypted at the app layer; `StreamContext.enc_key = None`.
- Same-host TUI PTY/shell viewer, which receives only `(mac_key, topic)` out of band (`StreamContext::without_aead()`), no wire field added.

Mesh inference streams (codegen client + `StreamChannel::prepare_stream`/`run_stream`) are AEAD-on end to end.

## Part B — per-host provenance (approved capnp change)
The chained HMAC proves "held the DH key + in order", not "host-X computed this" (threat T3 / C-PROV). Provenance closes that gap.

Schema diff (`streaming.capnp`, additive/wire-safe):
```capnp
struct StreamBlock {
  ...
  epoch @3 :UInt64;
  provenance @4 :Provenance;   # NEW
}

struct Provenance {            # NEW
  signerKid @0 :Data;
  sig @1 :Data;
}
```
- Publish: each `StreamBlock` is signed with the node's per-host hybrid COSE identity (Ed25519 + the deterministically-derived mesh ML-DSA-65 key, `node_identity::derive_mesh_mldsa_key`, #328) via `cose_sign::sign_composite`, over the **canonical signed region** = the provenance-cleared block encoding (`encode_stream_block`). `signerKid` = the host's Ed25519 kid; `sig` = the CBOR COSE composite. HMAC covers the full wire bytes (incl. provenance); the sig covers the signed region — verification is a layer ON TOP of AEAD + HMAC.
- Consume: `verify_moq_frame_with_provenance` verifies the signature against `signerKid` AND that the signer is an enrolled mesh peer with an anchored ML-DSA-65 key in the `KeyedPqTrustStore` roster (Hybrid policy, `require_pq`). Rejects missing / unknown / invalid signers (fail-closed). `verify_moq_frame` stays for the non-mesh client path that has no roster.

## Tests
- `key_exchange`: enc_key distinct from mac/ctrl keys + deterministic.
- `moq_stream`: AEAD seal/open round-trip; wrong-key / wrong-epoch / tampered-ciphertext rejection; publish-with-provenance end-to-end verify + unknown-signer rejected.
- `stream_provenance`: sign/verify round-trip, tampered-region, wrong-signer, unknown-signer (no anchored PQ key), empty-signature — all rejected.
- Existing stream tests stay green; the networked-over-QUIC integration test (`moq_networked`) passes with AEAD on.

## Build / clippy
- `cargo build -p hyprstream-rpc` ✅, `cargo clippy -p hyprstream-rpc --all-targets -D warnings` ✅
- `cargo test -p hyprstream-rpc --lib`: 431 pass; the one failure (`moq_event::tests::moq_event_pub_sub_roundtrip`, #148) is **pre-existing** — verified failing identically on the base commit `a31e90b65` and untouched by this change.
- `hyprstream` crate builds with the libtorch env (call-site updates: codegen client, mcp_service, tui/shell handlers, tui service).

Closes #321
Part of #310