### PR TITLE
fix: unify StreamInfo reach (tui/notification) + fix #142 + TUI cross-process bug (S1)

### DIFF
--- a/crates/hyprstream-rpc-std/schema/notification.capnp
+++ b/crates/hyprstream-rpc-std/schema/notification.capnp
@@ -9,6 +9,10 @@
 using import "/common.capnp".ErrorInfo;
 using import "/annotations.capnp".mcpScope;
 using import "/annotations.capnp".mcpDescription;
+# #356: the canonical networked moq reach model. A cross-instance subscriber dials
+# the producer's wire-advertised reach rather than its own co-located UDS plane.
+# Shared 1:1 with the inference StreamInfo's `announcedAt` (streaming.capnp).
+using import "/streaming.capnp".Destination;
 
 struct NotificationRequest {
   id @0 :UInt64;
@@ -80,9 +84,15 @@ struct NotificationResponse {
 struct SubscribeResponse {
   subscriptionId @0 :Text;
   assignedTopic @1 :Text;      # moq broadcast track name for the assigned subscription
-  streamEndpoint @2 :Text;     # always empty (ZMQ StreamService removed in #131/#138)
-  moqUdsPath @3 :Text;         # Path to moq UDS socket
-  moqBroadcastPath @4 :Text;   # moq broadcast path for the assigned topic
+  # moq broadcast path for the assigned topic ("{prefix}/{topic}").
+  broadcastPath @2 :Text;
+  # #356: network-routable ways to reach the NotificationService's moq plane,
+  # mirroring the inference StreamInfo's `announcedAt`. A subscriber dials the
+  # first reach it supports (see `dial_stream`) and subscribes to `broadcastPath`,
+  # so cross-instance model-load notifications work (fixes #142). Co-located
+  # subscribers ignore this and use the same-host UDS fast path resolved from
+  # LOCAL config — the UDS path is NEVER advertised on the wire.
+  announcedAt @3 :List(Destination);
 }
 
 struct PublishIntentResponse {

--- a/crates/hyprstream-rpc/src/moq_stream.rs
+++ b/crates/hyprstream-rpc/src/moq_stream.rs
@@ -41,7 +41,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use bytes::Bytes;
 use moq_net::{BroadcastProducer, Group, OriginConsumer, OriginProducer, Track, TrackProducer};
 use parking_lot::Mutex;
@@ -824,6 +824,87 @@ fn reach_to_transport_config(
     }
 }
 
+/// A live moq subscriber connection resolved from a producer's reach (#356).
+///
+/// Holds the `OriginConsumer` callers `announced_broadcast` + `subscribe_track`
+/// against, plus the underlying `moq_net::Session` which MUST be kept alive for
+/// the duration of the subscription (dropping it tears the transport down).
+pub struct MoqReachConnection {
+    /// The consumer side of the client origin the producer's broadcast is
+    /// announced into. Subscribe to the producer's `broadcast_path` on this.
+    pub consumer: OriginConsumer,
+    /// The live moq session. Held only to keep the transport open; not used
+    /// directly by callers, but must not be dropped before the consumer.
+    _session: moq_net::Session,
+}
+
+/// Resolve a producer's reach into a live moq subscriber connection (#356).
+///
+/// This is the **single** reach→connection resolver shared by every networked
+/// subscriber (the inference [`MoqStreamHandle::networked`] task and the CLI
+/// model-load / `notify subscribe` consumers). It enforces one transport policy
+/// in one place:
+///
+///   1. **Networked first** — dial the first dialable `Destination` in `reach`
+///      (the producer's wire-advertised QUIC/`/moq` endpoint) via
+///      [`crate::dial::dial_stream`]. This is the source of truth: the stream
+///      lives wherever the *producer* advertised, so cross-process / cross-
+///      instance subscribers reach it (fixes #142 + the TUI cross-process bug).
+///   2. **Local UDS fallback** — only when `reach` carries NO dialable network
+///      reach (UDS-only / unit-test deployments) do we connect to *this
+///      process's* local moq UDS plane ([`global_moq_uds_path`]). The UDS path is
+///      resolved from LOCAL knowledge, never from the wire — a same-host fast
+///      path, never advertised.
+///   3. **Fail closed** — if neither is available, return an error rather than
+///      connecting to an empty/wrong plane and timing out.
+///
+/// The UDS fast path is NEVER preferred over a present networked reach: the local
+/// UDS plane only carries the producer's broadcast when the producer is co-located
+/// in this very process, so preferring it silently breaks cross-process delivery.
+pub async fn connect_moq_reach(
+    reach: &[crate::stream_info::Destination],
+) -> Result<MoqReachConnection> {
+    use crate::transport::uds_session::{connect_uds, PLANE_MOQ};
+    use moq_net::{Client as MoqClient, Origin};
+
+    let client_origin = Origin::random().produce();
+    let consumer = client_origin.consume();
+    let moq_client = MoqClient::new().with_consume(client_origin);
+
+    // 1. Networked reach (source of truth): dial the first reach we can resolve.
+    let mut last_err: Option<String> = None;
+    for dest in reach {
+        let Some(cfg) = reach_to_transport_config(dest) else {
+            continue;
+        };
+        match crate::dial::dial_stream(&cfg).await {
+            Ok(stream_session) => match stream_session.connect_moq(&moq_client).await {
+                Ok(session) => return Ok(MoqReachConnection { consumer, _session: session }),
+                Err(e) => last_err = Some(format!("moq handshake: {e}")),
+            },
+            Err(e) => last_err = Some(e.to_string()),
+        }
+    }
+
+    // 2. Local UDS fallback (same-host fast path, resolved from LOCAL config).
+    if let Some(uds) = global_moq_uds_path() {
+        let session = connect_uds(uds, PLANE_MOQ)
+            .await
+            .with_context(|| format!("moq UDS connect {}", uds.display()))?;
+        let session = moq_client
+            .connect(session)
+            .await
+            .map_err(|e| anyhow!("moq UDS handshake: {e}"))?;
+        return Ok(MoqReachConnection { consumer, _session: session });
+    }
+
+    // 3. Fail closed.
+    Err(anyhow!(
+        "no dialable reach in StreamInfo and no local moq UDS plane — cannot subscribe to broadcast{}",
+        last_err.map(|e| format!(" (last dial error: {e})")).unwrap_or_default()
+    ))
+}
+
 /// Networked variant of [`moq_stream_handle_task`]: dial a `/moq`
 /// `web_transport_quinn` session from the `reach` list instead of the UDS
 /// plane, then run the identical subscribe + chained-HMAC verify loop (#274).
@@ -836,41 +917,20 @@ async fn moq_stream_handle_task_networked(
     cancel: tokio_util::sync::CancellationToken,
 ) {
     use crate::streaming::StreamVerifier;
-    use moq_net::{Client as MoqClient, Origin, Track};
+    use moq_net::Track;
 
-    // Dial the first reach we can resolve + connect.
-    let mut session = None;
-    let mut last_err: Option<String> = None;
-    for opt in &reach {
-        let Some(cfg) = reach_to_transport_config(opt) else {
-            continue;
-        };
-        match crate::dial::dial_stream(&cfg).await {
-            Ok(s) => {
-                session = Some(s);
-                break;
-            }
-            Err(e) => last_err = Some(e.to_string()),
-        }
-    }
-    let Some(session) = session else {
-        let msg = last_err.unwrap_or_else(|| "no dialable reach in StreamInfo".to_owned());
-        let _ = tx.send(Err(anyhow!("moq networked dial failed: {msg}"))).await;
-        return;
-    };
-
-    let client_origin = Origin::random().produce();
-    let client_consumer = client_origin.consume();
-    let moq_client = MoqClient::new().with_consume(client_origin);
-    // `session` is a `MoqStreamSession` (quinn or iroh, #282) — dispatch the moq
-    // handshake to the concrete transport.
-    let _session = match session.connect_moq(&moq_client).await {
-        Ok(s) => s,
+    // Resolve the producer's reach into a live moq connection via the single
+    // shared resolver (networked-first, local-UDS fallback, fail-closed; #356).
+    let conn = match connect_moq_reach(&reach).await {
+        Ok(c) => c,
         Err(e) => {
-            let _ = tx.send(Err(anyhow!("moq handshake: {e}"))).await;
+            let _ = tx.send(Err(anyhow!("moq networked dial failed: {e}"))).await;
             return;
         }
     };
+    // Borrow the consumer from `conn`; `conn` (and its session) stays alive for
+    // the whole subscribe loop.
+    let client_consumer = &conn.consumer;
     let bc = match tokio::time::timeout(
         BROADCAST_ANNOUNCE_TIMEOUT,
         client_consumer.announced_broadcast(&broadcast_path),

--- a/crates/hyprstream/schema/tui.capnp
+++ b/crates/hyprstream/schema/tui.capnp
@@ -375,25 +375,29 @@ struct ConnectResult {
   windows @3 :List(WindowInfo);
 }
 
-# Stream connection info
+# Stream connection info.
+#
+# #356: migrated onto the canonical networked reach model (matching the inference
+# StreamInfo in streaming.capnp). The dead UDS/ZMQ fields (`subEndpoint`,
+# `moqUdsPath`, `moqBroadcastPath`) are gone — the same-host UDS fast path is
+# resolved from LOCAL config and is NEVER advertised on the wire. A cross-process
+# viewer dials the first `announcedAt` reach it supports and subscribes to
+# `broadcastPath`.
 struct StreamInfo {
-  # Topic to subscribe to for frame data
+  # Opaque DH-derived topic to subscribe to for frame data.
   topic @0 :Text;
-  # SUB endpoint (ZMQ path; empty when moq is active)
-  subEndpoint @1 :Text;
-  # MAC key for HMAC verification (32 bytes)
-  macKey @2 :Data;
-  # moq broadcast path: "{prefix}/{topic}" (empty when ZMQ is active)
-  moqBroadcastPath @3 :Text;
-  # UDS socket path for the moq streaming plane (empty when ZMQ is active)
-  moqUdsPath @4 :Text;
-  # #275: network-routable ways to reach the producer's moq plane (mirrors the
-  # inference StreamInfo's `announcedAt`). A cross-process viewer dials the first
-  # reach it supports (see `dial_stream`) and subscribes to `moqBroadcastPath`,
-  # rather than connecting to its OWN local moq UDS plane — which only carries the
-  # producer's broadcast when the producer is co-located in the very same process.
-  # Co-located clients ignore this and use the same-host UDS fast path (`moqUdsPath`).
-  reach @5 :List(Destination);
+  # MAC key for the chained-HMAC verification (32 bytes).
+  macKey @1 :Data;
+  # moq broadcast path: "{prefix}/{topic}".
+  broadcastPath @2 :Text;
+  # Network-routable ways to reach the producer's moq plane (mirrors the inference
+  # StreamInfo's `announcedAt`). A cross-process viewer dials the first reach it
+  # supports (see `dial_stream`) and subscribes to `broadcastPath`, rather than
+  # connecting to its OWN local moq UDS plane — which only carries the producer's
+  # broadcast when the producer is co-located in the very same process. Co-located
+  # viewers ignore this and use the same-host UDS fast path resolved from LOCAL
+  # config (never advertised here).
+  announcedAt @3 :List(Destination);
 }
 
 # Window information

--- a/crates/hyprstream/src/cli/git_handlers.rs
+++ b/crates/hyprstream/src/cli/git_handlers.rs
@@ -1476,14 +1476,15 @@ pub async fn handle_load(
         }).await?;
 
         anyhow::ensure!(
-            !sub_resp.moq_uds_path.is_empty(),
-            "NotificationService did not return a moq UDS path — server may be in ZMQ-only mode"
+            !sub_resp.broadcast_path.is_empty(),
+            "NotificationService did not return a moq broadcast path — server may be in ZMQ-only mode"
         );
 
         debug!(
             subscription_id = %sub_resp.subscription_id,
             topic = %sub_resp.assigned_topic,
-            uds_path = %sub_resp.moq_uds_path,
+            broadcast_path = %sub_resp.broadcast_path,
+            reach_count = sub_resp.announced_at.len(),
             "Subscribed to notification stream via moq"
         );
 
@@ -1540,8 +1541,8 @@ pub async fn handle_load(
         );
 
         let result = wait_for_model_notification(
-            &sub_resp.moq_uds_path,
-            &sub_resp.moq_broadcast_path,
+            &sub_resp.announced_at,
+            &sub_resp.broadcast_path,
             &sub_resp.assigned_topic,
             &decryptor,
             model_ref_str,
@@ -1577,9 +1578,15 @@ enum NotificationOutcome {
     Failed { error: String },
 }
 
-/// Wait for a model.loaded or model.failed notification via moq UDS.
+/// Wait for a model.loaded or model.failed notification over the moq plane.
+///
+/// #142/#356: consumes the NotificationService's NETWORKED reach (`announcedAt`)
+/// via the shared [`connect_moq_reach`] resolver, so a model loaded on a DIFFERENT
+/// PDS instance is reached by dialing the producer's QUIC `/moq` endpoint. The
+/// old UDS-only path connected to *this* process's local moq plane, which never
+/// carries another instance's broadcast — silently failing cross-instance.
 async fn wait_for_model_notification(
-    uds_path: &str,
+    reach: &[hyprstream_rpc::stream_info::Destination],
     broadcast_path: &str,
     topic: &str,
     decryptor: &hyprstream_rpc::crypto::notification::BroadcastDecryptor,
@@ -1587,19 +1594,13 @@ async fn wait_for_model_notification(
     deadline: tokio::time::Instant,
 ) -> Result<NotificationOutcome> {
     use crate::events::{EventEnvelope, EventPayload};
-    use hyprstream_rpc::moq_stream::STREAM_TRACK;
-    use hyprstream_rpc::transport::uds_session::{connect_uds, PLANE_MOQ};
-    use moq_net::{Client as MoqClient, Origin};
+    use hyprstream_rpc::moq_stream::{connect_moq_reach, STREAM_TRACK};
 
-    let session = connect_uds(uds_path, PLANE_MOQ).await
-        .context("moq UDS connect for notifications")?;
-    let client_origin = Origin::random().produce();
-    let client_consumer = client_origin.consume();
-    let _session = MoqClient::new().with_consume(client_origin).connect(session).await
-        .context("moq handshake for notifications")?;
+    let conn = connect_moq_reach(reach).await
+        .context("moq connect for notifications")?;
     let bc = tokio::time::timeout(
         std::time::Duration::from_secs(10),
-        client_consumer.announced_broadcast(broadcast_path),
+        conn.consumer.announced_broadcast(broadcast_path),
     ).await
     .context("timeout waiting for notification broadcast")?
     .ok_or_else(|| anyhow::anyhow!("notification broadcast {} not found", broadcast_path))?;
@@ -1783,30 +1784,26 @@ async fn handle_notify_subscribe(
     }).await?;
 
     anyhow::ensure!(
-        !sub_resp.moq_uds_path.is_empty(),
-        "NotificationService did not return a moq UDS path — server may be in ZMQ-only mode"
+        !sub_resp.broadcast_path.is_empty(),
+        "NotificationService did not return a moq broadcast path — server may be in ZMQ-only mode"
     );
 
     eprintln!("Subscribed to: {}", pattern);
     eprintln!("  Subscription ID: {}", sub_resp.subscription_id);
     eprintln!("  Topic: {}", sub_resp.assigned_topic);
 
-    use hyprstream_rpc::moq_stream::STREAM_TRACK;
-    use hyprstream_rpc::transport::uds_session::{connect_uds, PLANE_MOQ};
-    use moq_net::{Client as MoqClient, Origin};
+    use hyprstream_rpc::moq_stream::{connect_moq_reach, STREAM_TRACK};
 
-    let session = connect_uds(&sub_resp.moq_uds_path, PLANE_MOQ).await
-        .context("moq UDS connect for notifications")?;
-    let client_origin = Origin::random().produce();
-    let client_consumer = client_origin.consume();
-    let _session = MoqClient::new().with_consume(client_origin).connect(session).await
-        .context("moq handshake for notifications")?;
+    // #142/#356: dial the NotificationService's networked reach (or local UDS
+    // fast path) via the shared resolver, so cross-instance notifications work.
+    let conn = connect_moq_reach(&sub_resp.announced_at).await
+        .context("moq connect for notifications")?;
     let bc = tokio::time::timeout(
         std::time::Duration::from_secs(10),
-        client_consumer.announced_broadcast(&sub_resp.moq_broadcast_path),
+        conn.consumer.announced_broadcast(&sub_resp.broadcast_path),
     ).await
     .context("timeout waiting for notification broadcast")?
-    .ok_or_else(|| anyhow::anyhow!("notification broadcast {} not found", sub_resp.moq_broadcast_path))?;
+    .ok_or_else(|| anyhow::anyhow!("notification broadcast {} not found", sub_resp.broadcast_path))?;
     let mut track = bc.subscribe_track(&moq_net::Track::new(STREAM_TRACK))
         .context("subscribe_track for notifications")?;
 

--- a/crates/hyprstream/src/cli/shell_handlers.rs
+++ b/crates/hyprstream/src/cli/shell_handlers.rs
@@ -237,7 +237,7 @@ pub async fn handle_shell_tui(
 
     use hyprstream_rpc::moq_stream::MoqStreamHandle;
 
-    let broadcast_path = stdout_stream.moq_broadcast_path.clone();
+    let broadcast_path = stdout_stream.broadcast_path.clone();
     anyhow::ensure!(
         !broadcast_path.is_empty(),
         "TUI service did not return a moq broadcast path — server did not initialize moq transport"
@@ -245,15 +245,15 @@ pub async fn handle_shell_tui(
 
     let (frame_tx, mut frame_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(64);
 
-    // #275: dial the producer's networked reach (the TUI service's bound QUIC
+    // #356: dial the producer's networked reach (the TUI service's bound QUIC
     // `/moq` endpoint) rather than this process's OWN local moq UDS plane. The
-    // shared `MoqStreamHandle::networked` consumer prefers the StreamInfo's reach
-    // and falls back to the local UDS only when no dialable reach is present —
-    // mirroring the chat-inference consumer that this fix is modeled on. (Before
-    // the fix this bespoke loop did `connect_uds(moq_uds_path)`, which timed out
-    // because the PTY broadcast lives on the *TUI service's* plane, a different
-    // process from this viewer.)
-    let reach = stdout_stream.reach.clone();
+    // shared `MoqStreamHandle::networked` consumer prefers the StreamInfo's
+    // `announcedAt` reach and falls back to the local UDS only when no dialable
+    // reach is present — mirroring the chat-inference consumer that this fix is
+    // modeled on. (Before the fix this bespoke loop did `connect_uds(moq_uds_path)`,
+    // which timed out because the PTY broadcast lives on the *TUI service's* plane,
+    // a different process from this viewer.)
+    let reach = stdout_stream.announced_at.clone();
     let mut handle = MoqStreamHandle::networked(reach, broadcast_path, mac_key, topic);
     let _recv_handle = tokio::spawn(async move {
         loop {

--- a/crates/hyprstream/src/cli/tui_handlers.rs
+++ b/crates/hyprstream/src/cli/tui_handlers.rs
@@ -85,7 +85,7 @@ pub async fn handle_tui_attach(signing_key: &SigningKey, session_id: Option<u32>
         if !si.topic.is_empty() {
             info!(
                 topic = %si.topic,
-                endpoint = %si.sub_endpoint,
+                broadcast_path = %si.broadcast_path,
                 "Stream info received"
             );
         }
@@ -122,7 +122,7 @@ async fn run_attach_loop(
     use hyprstream_rpc::moq_stream::MoqStreamHandle;
     use hyprstream_rpc::streaming::StreamPayload;
 
-    let broadcast_path = stream_info.moq_broadcast_path.clone();
+    let broadcast_path = stream_info.broadcast_path.clone();
     anyhow::ensure!(
         !broadcast_path.is_empty(),
         "TUI service did not return a moq broadcast path — server may be in ZMQ-only mode"
@@ -141,13 +141,13 @@ async fn run_attach_loop(
 
     let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(64);
 
-    // #275: dial the producer's networked reach (the TUI service's QUIC `/moq`
+    // #356: dial the producer's networked reach (the TUI service's QUIC `/moq`
     // endpoint) via the shared `MoqStreamHandle::networked` consumer, which prefers
-    // the StreamInfo's reach and falls back to the local moq UDS plane only when no
-    // dialable reach is present. `attach` is a cross-process viewer, so the old
-    // `connect_uds(moq_uds_path)` connected to *this* process's empty plane and
-    // timed out waiting for the producer's broadcast.
-    let reach = stream_info.reach.clone();
+    // the StreamInfo's `announcedAt` reach and falls back to the local moq UDS plane
+    // only when no dialable reach is present. `attach` is a cross-process viewer, so
+    // the old `connect_uds(moq_uds_path)` connected to *this* process's empty plane
+    // and timed out waiting for the producer's broadcast.
+    let reach = stream_info.announced_at.clone();
     let mut handle = MoqStreamHandle::networked(reach, broadcast_path, mac_key, topic);
     let recv_handle = tokio::spawn(async move {
         loop {

--- a/crates/hyprstream/src/services/mcp_service.rs
+++ b/crates/hyprstream/src/services/mcp_service.rs
@@ -437,20 +437,12 @@ fn register_scoped_tools_recursive(
                                 _ => anyhow::bail!("No scoped streaming dispatch for service: {service}"),
                             };
 
-                            let handle = match decode_stream_reach(&stream_info_json)? {
-                                DecodedStreamReach::Networked { dh_public, reach, broadcast_path } => {
-                                    let (mac_key, topic) = hyprstream_rpc::derive_client_stream_keys(
-                                        &client_secret, &client_pubkey_bytes, &dh_public,
-                                    )?;
-                                    MoqStreamHandle::networked(reach, broadcast_path, mac_key, topic)
-                                }
-                                DecodedStreamReach::Uds { dh_public, uds_path, broadcast_path } => {
-                                    let (mac_key, topic) = hyprstream_rpc::derive_client_stream_keys(
-                                        &client_secret, &client_pubkey_bytes, &dh_public,
-                                    )?;
-                                    MoqStreamHandle::new(uds_path, broadcast_path, mac_key, topic)
-                                }
-                            };
+                            let DecodedStreamReach { dh_public, reach, broadcast_path } =
+                                decode_stream_reach(&stream_info_json)?;
+                            let (mac_key, topic) = hyprstream_rpc::derive_client_stream_keys(
+                                &client_secret, &client_pubkey_bytes, &dh_public,
+                            )?;
+                            let handle = MoqStreamHandle::networked(reach, broadcast_path, mac_key, topic);
 
                             Ok(ToolResult::Stream(Box::new(handle)))
                         })
@@ -601,20 +593,12 @@ fn register_streaming_tool(
                     _ => anyhow::bail!("No streaming support for service: {}", service),
                 };
 
-                let handle = match decode_stream_reach(&stream_info_json)? {
-                    DecodedStreamReach::Networked { dh_public, reach, broadcast_path } => {
-                        let (mac_key, topic) = hyprstream_rpc::derive_client_stream_keys(
-                            &client_secret, &client_pubkey_bytes, &dh_public,
-                        )?;
-                        MoqStreamHandle::networked(reach, broadcast_path, mac_key, topic)
-                    }
-                    DecodedStreamReach::Uds { dh_public, uds_path, broadcast_path } => {
-                        let (mac_key, topic) = hyprstream_rpc::derive_client_stream_keys(
-                            &client_secret, &client_pubkey_bytes, &dh_public,
-                        )?;
-                        MoqStreamHandle::new(uds_path, broadcast_path, mac_key, topic)
-                    }
-                };
+                let DecodedStreamReach { dh_public, reach, broadcast_path } =
+                    decode_stream_reach(&stream_info_json)?;
+                let (mac_key, topic) = hyprstream_rpc::derive_client_stream_keys(
+                    &client_secret, &client_pubkey_bytes, &dh_public,
+                )?;
+                let handle = MoqStreamHandle::networked(reach, broadcast_path, mac_key, topic);
 
                 Ok(ToolResult::Stream(Box::new(handle)))
             })
@@ -660,63 +644,40 @@ fn params_to_json_schema(params: &[(&str, &str, bool, &str)]) -> Value {
     })
 }
 
-/// The transport-resolved shape of a decoded streaming response (#274).
-enum DecodedStreamReach {
-    /// New `StreamInfo`: subscribe over the wire `reach` (or local UDS fast path).
-    Networked {
-        dh_public: [u8; 32],
-        reach: Vec<hyprstream_rpc::stream_info::Destination>,
-        broadcast_path: String,
-    },
-    /// Legacy UDS-only producers (out-of-scope `tui.capnp` `StreamInfo`).
-    Uds {
-        dh_public: Vec<u8>,
-        uds_path: String,
-        broadcast_path: String,
-    },
+/// The transport-resolved shape of a decoded streaming response (#356).
+///
+/// A single networked shape: every producer now advertises its moq reach via the
+/// canonical `StreamInfo.announcedAt` list (or an empty list when UDS-only, which
+/// `connect_moq_reach`/`MoqStreamHandle::networked` resolve to the same-host UDS
+/// fast path from LOCAL config). There is no longer a wire-published UDS path.
+struct DecodedStreamReach {
+    dh_public: [u8; 32],
+    reach: Vec<hyprstream_rpc::stream_info::Destination>,
+    broadcast_path: String,
 }
 
-/// Decode a streaming response into its moq reach (#274).
+/// Decode a streaming response into its moq reach (#356).
 ///
 /// The signed `StreamInfo` is decoded via the generated library type
 /// (`hyprstream_rpc::stream_info::StreamInfo`) — no bespoke `serde_json` field
-/// scraping for the in-scope path — yielding the native-capnp `reach` list +
-/// `broadcastPath`. Falls back to the legacy UDS fields (`moqUdsPath` /
-/// `moqBroadcastPath`) only for out-of-scope producers (the TUI service's
-/// parallel `tui.capnp` `StreamInfo`, deliberately left on UDS).
+/// scraping — yielding the native-capnp `announcedAt` reach list + `broadcastPath`.
+/// Fails closed when the response carries no broadcast path or DH key.
 fn decode_stream_reach(json: &Value) -> anyhow::Result<DecodedStreamReach> {
-    // Preferred path: the new streaming.capnp StreamInfo decodes cleanly into the
-    // library type, carrying the native-capnp `reach` list + `broadcastPath`.
-    if let Ok(info) = serde_json::from_value::<hyprstream_rpc::stream_info::StreamInfo>(json.clone()) {
-        if !info.broadcast_path.is_empty() {
-            if info.dh_public == [0u8; 32] {
-                anyhow::bail!("server did not provide DH public key for streaming");
-            }
-            return Ok(DecodedStreamReach::Networked {
-                dh_public: info.dh_public,
-                reach: info.announced_at,
-                broadcast_path: info.broadcast_path,
-            });
-        }
+    let info = serde_json::from_value::<hyprstream_rpc::stream_info::StreamInfo>(json.clone())
+        .map_err(|e| anyhow::anyhow!("failed to decode StreamInfo: {e}"))?;
+    if info.broadcast_path.is_empty() {
+        anyhow::bail!(
+            "missing broadcastPath in streaming response — server did not initialize moq transport"
+        );
     }
-
-    // Legacy UDS fallback (out-of-scope producers still on the UDS moq plane).
-    let dh_public: Vec<u8> = json["dhPublic"].as_array()
-        .ok_or_else(|| anyhow::anyhow!("missing dhPublic in streaming response"))?
-        .iter()
-        .enumerate()
-        .map(|(i, v)| {
-            v.as_u64()
-                .and_then(|n| u8::try_from(n).ok())
-                .ok_or_else(|| anyhow::anyhow!("dhPublic[{i}]: value out of u8 range"))
-        })
-        .collect::<anyhow::Result<Vec<u8>>>()?;
-    let uds_path = json["moqUdsPath"].as_str().unwrap_or("").to_owned();
-    let broadcast_path = json["moqBroadcastPath"].as_str().unwrap_or("").to_owned();
-    if uds_path.is_empty() {
-        anyhow::bail!("missing reach/broadcastPath in streaming response — server did not initialize moq transport");
+    if info.dh_public == [0u8; 32] {
+        anyhow::bail!("server did not provide DH public key for streaming");
     }
-    Ok(DecodedStreamReach::Uds { dh_public, uds_path, broadcast_path })
+    Ok(DecodedStreamReach {
+        dh_public: info.dh_public,
+        reach: info.announced_at,
+        broadcast_path: info.broadcast_path,
+    })
 }
 
 /// Dispatch a method call to the appropriate generated client.

--- a/crates/hyprstream/src/services/notification.rs
+++ b/crates/hyprstream/src/services/notification.rs
@@ -463,23 +463,26 @@ impl NotificationHandler for NotificationService {
 
         debug!("Subscriber {} registered for topic {}", sub_id, topic);
 
-        let moq_uds_path = hyprstream_rpc::moq_stream::global_moq_uds_path()
-            .ok_or_else(|| anyhow::anyhow!("moq stream origin not initialized — server misconfiguration"))?
-            .to_string_lossy()
-            .into_owned();
-        let moq_broadcast_path = format!(
+        // The broadcast is served on this node's moq plane; require it to be live.
+        if hyprstream_rpc::moq_stream::global_moq_origin().is_none() {
+            anyhow::bail!("moq stream origin not initialized — server misconfiguration");
+        }
+        let broadcast_path = format!(
             "{}/{}",
             hyprstream_rpc::moq_stream::DEFAULT_PREFIX,
             topic
         );
-        let stream_endpoint = String::new();
+        // #356: advertise the node's network-routable moq reach so cross-instance
+        // subscribers dial the producer directly (fixes #142). Co-located
+        // subscribers fall back to the same-host UDS fast path (resolved from
+        // LOCAL config by `connect_moq_reach`) — never advertised on the wire.
+        let announced_at = hyprstream_rpc::moq_stream::producer_reach();
 
         Ok(NotificationResponseVariant::SubscribeResult(SubscribeResponse {
             subscription_id: sub_id.to_string(),
             assigned_topic: topic,
-            stream_endpoint,
-            moq_uds_path,
-            moq_broadcast_path,
+            broadcast_path,
+            announced_at,
         }))
     }
 
@@ -926,6 +929,7 @@ impl NotificationPublisher {
 // ============================================================================
 
 #[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
 
@@ -1040,5 +1044,84 @@ mod tests {
         assert_eq!(reg.count(), 1);
         assert_eq!(reg.expire(now), 1);
         assert_eq!(reg.count(), 0);
+    }
+
+    /// #142 regression guard: a `SubscribeResponse` MUST carry the producer's
+    /// NETWORKED reach (`announcedAt`) so a model loaded on a DIFFERENT PDS
+    /// instance is reachable. Before #356 the response only carried a same-host
+    /// `moqUdsPath`, so cross-instance model-load notifications silently failed
+    /// (the subscriber connected to its own empty local moq plane and timed out).
+    ///
+    /// This builds the response the way `handle_subscribe` does (reach from the
+    /// single `producer_reach()` builder), round-trips it through the generated
+    /// capnp codec, and asserts the Quic dial parameters survive intact and that
+    /// no same-host UDS path is advertised on the wire.
+    #[test]
+    fn subscribe_response_carries_networked_reach() {
+        use crate::notification_capnp;
+        use crate::services::generated::notification_client::SubscribeResponse;
+        use capnp::message::Builder;
+        use hyprstream_rpc::capnp::FromCapnp;
+        use hyprstream_rpc::moq_stream::{
+            init_global_producer_reach, producer_reach, NodeStreamReach,
+        };
+
+        // Register a networked reach exactly as the QUIC bind does (idempotent —
+        // first wins; ignore the result so concurrent tests don't fail this one).
+        let addr: std::net::SocketAddr = "127.0.0.1:4433".parse().expect("addr");
+        let _ = init_global_producer_reach(NodeStreamReach {
+            addr,
+            server_name: "localhost".to_owned(),
+            cert_hashes: vec![[0x22u8; 32]],
+        });
+        let reach = producer_reach();
+        assert!(
+            !reach.is_empty(),
+            "producer_reach() must be non-empty after registering a NodeStreamReach"
+        );
+
+        // Build a SubscribeResponse the same way handle_subscribe does.
+        let mut msg = Builder::new_default();
+        {
+            let mut sr = msg.init_root::<notification_capnp::subscribe_response::Builder<'_>>();
+            sr.set_subscription_id("sub-1");
+            sr.set_assigned_topic("notify/test");
+            sr.set_broadcast_path("local/streams/notify-test");
+            let mut reach_list = sr.reborrow().init_announced_at(reach.len() as u32);
+            for (j, dest) in reach.iter().enumerate() {
+                let mut db = reach_list.reborrow().get(j as u32);
+                hyprstream_rpc::capnp::ToCapnp::write_to(dest, &mut db);
+            }
+        }
+        let mut buf = Vec::new();
+        capnp::serialize::write_message(&mut buf, &msg).expect("serialize");
+
+        // Decode through the generated client type and assert the networked reach.
+        let reader =
+            capnp::serialize::read_message(&buf[..], capnp::message::ReaderOptions::new())
+                .expect("read");
+        let sr_reader = reader
+            .get_root::<notification_capnp::subscribe_response::Reader<'_>>()
+            .expect("root");
+        let decoded = SubscribeResponse::read_from(sr_reader).expect("decode");
+
+        assert!(
+            !decoded.broadcast_path.is_empty(),
+            "SubscribeResponse must carry a broadcast path"
+        );
+        assert_eq!(
+            decoded.announced_at.len(),
+            reach.len(),
+            "SubscribeResponse.announcedAt must round-trip the producer reach (#142)"
+        );
+        let dest = &decoded.announced_at[0];
+        match &dest.transport {
+            hyprstream_rpc::stream_info::TransportConfig::Quic(q) => {
+                assert_eq!(q.addr, "127.0.0.1:4433");
+                assert_eq!(q.server_name, "localhost");
+                assert_eq!(q.cert_hashes.len(), 1);
+            }
+            other => panic!("expected a Quic reach, got {other:?}"),
+        }
     }
 }

--- a/crates/hyprstream/src/tui/service.rs
+++ b/crates/hyprstream/src/tui/service.rs
@@ -354,11 +354,9 @@ impl TuiService {
         let stdin_ctx = make_stream_ctx("stdin")?;
         let stdout_ctx = make_stream_ctx("stdout")?;
 
-        // Build moq metadata (broadcast paths + UDS socket) when moq is active.
-        let moq_uds_path = global_moq_origin()
-            .and_then(|_| hyprstream_rpc::moq_stream::global_moq_uds_path())
-            .map(|p| p.to_string_lossy().into_owned())
-            .unwrap_or_default();
+        // Build the moq broadcast paths when moq is active. The same-host UDS
+        // path is NOT advertised (#356): co-located viewers resolve it from LOCAL
+        // config, and cross-process viewers dial the networked reach instead.
         let stdin_moq_path = global_moq_origin()
             .map(|o| o.broadcast_path(stdin_ctx.topic()))
             .unwrap_or_default();
@@ -366,12 +364,10 @@ impl TuiService {
             .map(|o| o.broadcast_path(stdout_ctx.topic()))
             .unwrap_or_default();
 
-        let sub_endpoint = String::new();
-
-        // (topic, sub_endpoint, mac_key, moq_broadcast_path, moq_uds_path)
-        let streams: [(&str, &str, &[u8; 32], &str, &str); 2] = [
-            (stdin_ctx.topic(), &sub_endpoint, stdin_ctx.mac_key(), &stdin_moq_path, &moq_uds_path),
-            (stdout_ctx.topic(), &sub_endpoint, stdout_ctx.mac_key(), &stdout_moq_path, &moq_uds_path),
+        // (topic, mac_key, broadcast_path)
+        let streams: [(&str, &[u8; 32], &str); 2] = [
+            (stdin_ctx.topic(), stdin_ctx.mac_key(), &stdin_moq_path),
+            (stdout_ctx.topic(), stdout_ctx.mac_key(), &stdout_moq_path),
         ];
 
         let response = self.build_connect_response(
@@ -1595,8 +1591,8 @@ impl TuiService {
         viewer_id: u32,
         session_id: u32,
         windows: &[(u32, String, Vec<(u32, (u16, u16), bool)>, u32)],
-        // (topic, sub_endpoint, mac_key, moq_broadcast_path, moq_uds_path)
-        streams: &[(&str, &str, &[u8; 32], &str, &str)],
+        // (topic, mac_key, broadcast_path)
+        streams: &[(&str, &[u8; 32], &str)],
     ) -> Result<Vec<u8>> {
         let mut msg = Builder::new_default();
         {
@@ -1606,26 +1602,25 @@ impl TuiService {
             connect.set_viewer_id(viewer_id);
             connect.set_session_id(session_id);
 
-            // #275: the node's network-routable moq reach (the bound QUIC `/moq`
+            // #356: the node's network-routable moq reach (the bound QUIC `/moq`
             // endpoint, registered when the daemon's web_transport_quinn server
-            // binds). Shared across all FD streams — they all live on this node's
-            // one moq plane. A cross-process viewer dials this reach instead of its
-            // own local moq UDS plane (see StreamInfo.reach docs / MoqStreamHandle::networked).
+            // binds), sourced from the single shared `producer_reach()` builder.
+            // Shared across all FD streams — they all live on this node's one moq
+            // plane. A cross-process viewer dials this reach instead of its own
+            // local moq UDS plane (see StreamInfo.announcedAt docs / connect_moq_reach).
             let reach = hyprstream_rpc::moq_stream::producer_reach();
 
             // FD-indexed streams: [0]=stdin (input relay), [1]=stdout (frames)
             let mut stream_list = connect.reborrow().init_streams(streams.len() as u32);
-            for (i, (topic, sub_endpoint, mac_key, moq_path, moq_uds)) in streams.iter().enumerate() {
+            for (i, (topic, mac_key, broadcast_path)) in streams.iter().enumerate() {
                 let mut si = stream_list.reborrow().get(i as u32);
                 si.set_topic(topic);
-                si.set_sub_endpoint(sub_endpoint);
                 si.set_mac_key(*mac_key);
-                si.set_moq_broadcast_path(moq_path);
-                si.set_moq_uds_path(moq_uds);
+                si.set_broadcast_path(broadcast_path);
                 // Encode the networked reach via the shared generated ToCapnp impl
                 // (Destination::write_to), so the wire bytes match the inference
                 // StreamInfo's `announcedAt` 1:1.
-                let mut reach_list = si.reborrow().init_reach(reach.len() as u32);
+                let mut reach_list = si.reborrow().init_announced_at(reach.len() as u32);
                 for (j, dest) in reach.iter().enumerate() {
                     let mut db = reach_list.reborrow().get(j as u32);
                     hyprstream_rpc::capnp::ToCapnp::write_to(dest, &mut db);
@@ -2465,12 +2460,12 @@ mod tests {
         assert_ne!(DisplayMode::Capnp, DisplayMode::Structured);
     }
 
-    /// #275: the PTY StreamInfo must carry the producer's networked reach so a
+    /// #356: the PTY StreamInfo must carry the producer's networked reach so a
     /// cross-process viewer dials the TUI service's QUIC `/moq` endpoint instead
     /// of its own local moq UDS plane. This exercises the exact encode path
     /// `build_connect_response` uses — `producer_reach()` → `Destination::write_to`
-    /// into the tui StreamInfo capnp `reach` field — and reads it back through the
-    /// generated `tui_client::StreamInfo` decoder, asserting the Quic dial params
+    /// into the tui StreamInfo capnp `announcedAt` field — and reads it back through
+    /// the generated `tui_client::StreamInfo` decoder, asserting the Quic dial params
     /// survive the round-trip intact (the chat-inference fix relied on the same
     /// reach being present; the bug was the TUI StreamInfo not carrying it).
     #[test]
@@ -2498,9 +2493,8 @@ mod tests {
             let mut si = msg.init_root::<tui_capnp::stream_info::Builder<'_>>();
             si.set_topic("deadbeef");
             si.set_mac_key(&[7u8; 32]);
-            si.set_moq_broadcast_path("local/streams/deadbeef");
-            si.set_moq_uds_path("/run/hyprstream/moq.sock");
-            let mut reach_list = si.reborrow().init_reach(reach.len() as u32);
+            si.set_broadcast_path("local/streams/deadbeef");
+            let mut reach_list = si.reborrow().init_announced_at(reach.len() as u32);
             for (j, dest) in reach.iter().enumerate() {
                 let mut db = reach_list.reborrow().get(j as u32);
                 hyprstream_rpc::capnp::ToCapnp::write_to(dest, &mut db);
@@ -2520,18 +2514,24 @@ mod tests {
             crate::services::generated::tui_client::StreamInfo::read_from(si_reader).expect("decode");
 
         assert_eq!(
-            decoded.reach.len(),
+            decoded.announced_at.len(),
             reach.len(),
-            "decoded StreamInfo.reach must round-trip the producer reach"
+            "decoded StreamInfo.announcedAt must round-trip the producer reach"
         );
-        // The single reach must be a Quic destination with our dial params.
-        let dest = &decoded.reach[0];
-        match &dest.transport {
+        // The round-tripped reach must match the registered producer reach
+        // exactly. (Compare against the captured `producer_reach()` rather than a
+        // hardcoded cert hash: the process-global `NodeStreamReach` is first-wins,
+        // so a sibling test that registers first wins the OnceLock — what matters
+        // is that the encode/decode round-trip is lossless.)
+        assert_eq!(
+            decoded.announced_at, reach,
+            "decoded StreamInfo.announcedAt must round-trip the producer reach exactly"
+        );
+        match &decoded.announced_at[0].transport {
             hyprstream_rpc::stream_info::TransportConfig::Quic(q) => {
                 assert_eq!(q.addr, "127.0.0.1:4433");
                 assert_eq!(q.server_name, "localhost");
                 assert_eq!(q.cert_hashes.len(), 1);
-                assert_eq!(q.cert_hashes[0], vec![0x11u8; 32]);
             }
             other => panic!("expected a Quic reach, got {other:?}"),
         }


### PR DESCRIPTION
## S1 — unify StreamInfo reach across tui/notification + fix the two live cross-instance bugs

Part of the Streaming Plane Restoration epic (#355). S1 migrates the two divergent reach schemas onto the canonical networked model, unifies reach assembly onto one builder, and fixes the two live cross-instance bugs.

### Schema spins (capnp — user-authorized)

Dense id-spin (capnp forbids ordinal gaps; safe because pre-release + these are built-fresh-and-consumed-in-handshake, never persisted):

**`tui.capnp` `StreamInfo`** — dropped dead `subEndpoint`/`moqBroadcastPath`/`moqUdsPath`; kept `topic` + `macKey`; added `broadcastPath @2` + `announcedAt @3 :List(Destination)` (imported from `streaming.capnp`).

**`notification.capnp` `SubscribeResponse`** — dropped dead `streamEndpoint`/`moqUdsPath`/`moqBroadcastPath`; added `broadcastPath @2` + `announcedAt @3 :List(Destination)`.

The same-host UDS fast path is **never advertised on the wire** — co-located clients resolve it from LOCAL config; cross-instance/cross-process peers dial the producer's networked reach.

### Unified reach builder

- New `moq_stream::connect_moq_reach(reach) -> MoqReachConnection`: the **single** reach→connection resolver — networked-first (`dial_stream`), local-UDS fallback, **fail-closed**. `moq_stream_handle_task_networked` refactored onto it (no more per-task dial/connect duplication).
- `producer_reach()` remains the one reach **encoder** (iroh arm left Direct/Quic-only — S2 owns iroh reach).
- `mcp_service`: collapsed `DecodedStreamReach` enum (dropped the `Uds` arm + the `moqUdsPath`/`moqBroadcastPath` `serde_json` fallback) to one networked struct decoded via the generated `StreamInfo` type, fail-closed.
- `notification` service: advertises `producer_reach()` in `SubscribeResponse` instead of a wire-published UDS path.

### Bug fixes

- **#142 (cross-instance model-load notifications):** `git_handlers` `wait_for_model_notification` (~:1581) and `handle_notify_subscribe` (~:1786) now consume the networked `SubscribeResponse.announcedAt` via `connect_moq_reach` instead of `connect_uds(moqUdsPath, PLANE_MOQ)`. A model loaded on a **different** PDS instance is now reached by dialing the producer's QUIC `/moq` endpoint instead of silently connecting to this process's empty local plane.
- **TUI cross-process (#275-class):** the migrated tui `StreamInfo` carries `announcedAt`; `tui_handlers` (`attach`) and `shell_handlers` consume it, so a cross-process TUI viewer dials the producer instead of falling onto a co-located-only UDS path.

### Tests

- `notification::tests::subscribe_response_carries_networked_reach` — **#142 regression guard**: `SubscribeResponse` round-trips the Quic reach through the capnp codec and advertises no UDS path.
- `tui::service::tests::pty_stream_info_carries_dialable_reach` — migrated to `announcedAt`; lossless reach round-trip.

### Build / clippy / test

- `cargo build -p hyprstream-rpc -p hyprstream-rpc-std -p hyprstream -p hyprstream-tui` — green.
- `cargo clippy` (touched crates, lib + all-targets) — green. The one remaining clippy `expect()` (in `hyprstream-rpc/src/streaming.rs`, a test committed 2026-06-18 before this work) is **pre-existing and untouched**.
- Both reach tests pass.

### Scope boundaries

Did **not** touch S4's turf (`StreamRegister`/`StreamResume`, workers/events) or implement iroh reach (S2). Files changed: `tui.capnp`, `notification.capnp`, `moq_stream.rs`, `mcp_service.rs`, `git_handlers.rs`, `shell_handlers.rs`, `tui_handlers.rs`, `notification.rs` (service), `tui/service.rs`.

Closes #356
Part of #355
Refs #142