### PR TITLE
feat: iroh+pkarr direct reach for native peers (S2, #357)

### DIFF
--- a/crates/hyprstream-rpc/schema/streaming.capnp
+++ b/crates/hyprstream-rpc/schema/streaming.capnp
@@ -169,10 +169,10 @@ struct TransportConfig {
   union {
     # Quic / WebTransport (web-transport-quinn). Dialed over `web_transport_quinn`.
     quic @0 :QuicReach;
-    # Reserved for NAT-traversing iroh dial (#274 follow-up). Capnp requires a
-    # union to have >= 2 members; this placeholder leaves room without a wire
-    # break when the iroh reach lands.
-    iroh @1 :Void;
+    # NAT-traversing iroh dial (#357). Carries the producer's iroh node_id so a
+    # native peer can dial-by-node_id over the `moql` ALPN, resolving addresses
+    # via pkarr / n0 DNS discovery (the shared client endpoint's `presets::N0`).
+    iroh @1 :IrohReach;
   }
 }
 
@@ -181,6 +181,18 @@ struct QuicReach {
   addr       @0 :Text;        # "host:port" socket address to dial.
   serverName @1 :Text;        # TLS SNI / WebPKI validation name.
   certHashes @2 :List(Data);  # Acceptable leaf-cert SHA-256 pins (self-signed mesh).
+}
+
+# Dial parameters for the iroh (NAT-traversing) arm (#357).
+#
+# Only the `nodeId` (the producer's iroh `EndpointId` = its Ed25519 public key)
+# is carried: iroh binds the dialed connection to this identity, and pkarr / n0
+# DNS discovery resolves the routable addresses on the shared client endpoint, so
+# a native peer dials by node_id alone (no addrs/relay on the wire). Reachability
+# hints (direct addrs, relay URL) are a deliberate follow-up (S6) — keeping the
+# advertised reach to the identity avoids leaking the producer's network topology.
+struct IrohReach {
+  nodeId @0 :Data $fixedSize(32);  # iroh EndpointId (Ed25519 public key, 32 bytes).
 }
 
 # Stream metadata returned when starting a stream

--- a/crates/hyprstream-rpc/src/dial.rs
+++ b/crates/hyprstream-rpc/src/dial.rs
@@ -287,20 +287,15 @@ pub async fn dial_stream(
             };
             Ok(MoqStreamSession::Quinn(session))
         }
-        EndpointType::Iroh { direct_addrs, relay_url, .. }
-            if direct_addrs.is_empty() && relay_url.is_none() =>
-        {
-            // No reachability supplied → fail fast rather than hand iroh a bare
-            // EndpointId that falls through to discovery and times out (~10-30s).
-            // (Dial-by-node_id-alone via pkarr/DNS discovery is available on the
-            // shared endpoint, but the resolver is expected to supply at least a
-            // relay; see #282 pkarr seam.)
-            bail!(
-                "dial_stream(): iroh streaming reach has neither direct addrs nor a \
-                 relay URL — not dialable; the resolver must supply reachability"
-            )
-        }
         EndpointType::Iroh { node_id, direct_addrs, relay_url } => {
+            // #357: dial-by-node_id-alone is now supported — when no direct addrs
+            // or relay are supplied, the shared client endpoint's pkarr / n0 DNS
+            // discovery (`presets::N0`) resolves the routable addresses from the
+            // `EndpointId`. This is the S2 native-peer direct path (the wire
+            // `IrohReach` carries only the node_id). When the resolver *does*
+            // supply direct addrs / a relay, they are used as hints to skip /
+            // accelerate discovery (faster than waiting on pkarr).
+            //
             // #282: dial the iroh `moql` ALPN from the shared process-wide client
             // endpoint (the SAME endpoint the daemon's inbound iroh substrate
             // listens on, installed once at startup), then wrap the authenticated
@@ -483,12 +478,22 @@ mod tests {
     }
 
     #[test]
-    fn dial_stream_iroh_without_reach_fails_fast() {
-        // An iroh reach with neither direct addrs nor a relay is not dialable —
-        // dial_stream must fail fast rather than hang in discovery.
+    fn dial_stream_iroh_node_id_alone_requires_installed_endpoint() {
+        // #357: dial-by-node_id-alone is supported (pkarr / n0 DNS discovery
+        // resolves addresses from the EndpointId on the shared client endpoint),
+        // so an iroh reach with no direct addrs / relay is no longer rejected
+        // up-front. With no client endpoint installed, the dial still fails — but
+        // because the shared dialer is missing, not because reachability is absent.
         let cfg = TransportConfig::iroh([1u8; 32], Vec::new(), None);
-        let res = futures::executor::block_on(dial_stream(&cfg));
-        assert!(res.is_err(), "iroh reach with no reachability must fail fast");
+        let err = match futures::executor::block_on(dial_stream(&cfg)) {
+            Ok(_) => panic!("dial must fail with no installed iroh client endpoint"),
+            Err(e) => e,
+        };
+        assert!(
+            err.to_string().contains("no iroh client endpoint installed"),
+            "expected an install-endpoint error (node_id-alone is dialable once an \
+             endpoint is installed); got: {err}"
+        );
     }
 
     /// #282: `dial_stream`'s iroh arm dials the `moql` ALPN and returns a live

--- a/crates/hyprstream-rpc/src/moq_stream.rs
+++ b/crates/hyprstream-rpc/src/moq_stream.rs
@@ -107,6 +107,11 @@ pub struct NodeStreamReach {
     pub server_name: String,
     /// Acceptable leaf-cert SHA-256 pins (self-signed mesh; rotation = multiple).
     pub cert_hashes: Vec<[u8; 32]>,
+    /// The node's own iroh `EndpointId` (Ed25519 public key, 32 bytes) when the
+    /// iroh substrate is bound (#357). `None` when iroh is disabled / unbound —
+    /// the node then advertises the Quic reach only. Native peers prefer this
+    /// direct, NAT-traversing, pkarr-discoverable reach (see [`producer_reach`]).
+    pub iroh_node_id: Option<[u8; 32]>,
 }
 
 /// Register the node's network-routable moq reach (idempotent — first wins).
@@ -123,6 +128,27 @@ pub fn global_producer_reach() -> Option<&'static NodeStreamReach> {
     GLOBAL_PRODUCER_REACH.get()
 }
 
+/// The node's own iroh `EndpointId` (Ed25519 public key) once the iroh substrate
+/// is bound (#357). Registered separately from [`GLOBAL_PRODUCER_REACH`] because
+/// the QUIC reach is set when the quinn server binds, whereas iroh binds slightly
+/// later in the same bootstrap; folding it back into the first-wins
+/// [`NodeStreamReach`] would require reordering the bind sequence.
+static GLOBAL_IROH_NODE_ID: OnceLock<[u8; 32]> = OnceLock::new();
+
+/// Register the node's iroh `EndpointId` so [`producer_reach`] can advertise an
+/// iroh-direct [`Destination`] for native peers (#357). Idempotent (first wins).
+///
+/// Called once when the daemon binds its iroh substrate (the `node_id` ==
+/// `signing_key.verifying_key()`, already covered by the node's DID).
+pub fn init_global_iroh_node_id(node_id: [u8; 32]) -> bool {
+    GLOBAL_IROH_NODE_ID.set(node_id).is_ok()
+}
+
+/// Borrow the node's registered iroh `EndpointId`, if the iroh substrate is bound.
+pub fn global_iroh_node_id() -> Option<&'static [u8; 32]> {
+    GLOBAL_IROH_NODE_ID.get()
+}
+
 /// Build the `StreamInfo.reach` list for a producer on this node (#274).
 ///
 /// Centralised so every producer site emits an identical reach, sourced from the
@@ -130,18 +156,35 @@ pub fn global_producer_reach() -> Option<&'static NodeStreamReach> {
 /// the node has no networked reach (UDS-only); co-located clients fall back to
 /// the same-host UDS fast path and ignore `reach` entirely.
 pub fn producer_reach() -> Vec<crate::stream_info::Destination> {
-    use crate::stream_info::{QuicReach, Destination, Role, TransportConfig};
-    match global_producer_reach() {
-        Some(r) => vec![Destination {
+    use crate::stream_info::{IrohReach, QuicReach, Destination, Role, TransportConfig};
+    let mut reach = Vec::new();
+
+    // iroh-direct first (#357): native peers prefer the NAT-traversing,
+    // pkarr-discoverable direct path. Listed ahead of Quic so the shared
+    // resolver (`connect_moq_reach`) tries it before the Quic/UDS fallbacks.
+    // The node_id comes from the iroh substrate bind (== signing_key pubkey),
+    // and is `None` when iroh is disabled/unbound (Quic-only advertisement).
+    if let Some(node_id) = global_iroh_node_id() {
+        reach.push(Destination {
+            role: Role::Direct,
+            transport: TransportConfig::Iroh(IrohReach { node_id: *node_id }),
+        });
+    }
+
+    // Quic / WebTransport reach: directly-reachable peers + browsers. Kept as a
+    // fallback alongside iroh (S1's fallbacks are preserved).
+    if let Some(r) = global_producer_reach() {
+        reach.push(Destination {
             role: Role::Direct,
             transport: TransportConfig::Quic(QuicReach {
                 addr: r.addr.to_string(),
                 server_name: r.server_name.clone(),
                 cert_hashes: r.cert_hashes.iter().map(|h| h.to_vec()).collect(),
             }),
-        }],
-        None => Vec::new(),
+        });
     }
+
+    reach
 }
 
 /// Start a UDS moq server in the background, serving the moq origin's consumer
@@ -813,14 +856,13 @@ fn reach_to_transport_config(
             };
             Some(TransportConfig::quic_with_auth(addr, q.server_name.clone(), auth))
         }
-        // #282 SEAM: `dial_stream` now dials an iroh `moql` reach
-        // (`EndpointType::Iroh { node_id, .. }`), but the **wire** reach enum's
-        // `Iroh` variant is a unit variant carrying no `node_id`/relay payload
-        // (it is code-generated from `stream.capnp`). Until that schema grows a
-        // `nodeId`/`relays` field, a StreamInfo cannot publish a dialable iroh
-        // reach, so this maps to `None` (publishers carry the Quic reach). The
-        // local `dial_stream` iroh arm is covered by the dial.rs loopback test.
-        ReachTransport::Iroh => None,
+        // #357: dial the wire-advertised iroh reach by node_id alone. iroh binds
+        // the dialed `moql` connection to this `EndpointId` (its Ed25519 pubkey),
+        // and the shared client endpoint's pkarr / n0 DNS discovery (`presets::N0`)
+        // resolves the routable addresses — so no direct addrs / relay are carried
+        // on the wire (see `IrohReach` in streaming.capnp). `dial_stream`'s iroh
+        // arm consumes this and opens the `moql` session.
+        ReachTransport::Iroh(i) => Some(TransportConfig::iroh(i.node_id, Vec::new(), None)),
     }
 }
 
@@ -1167,6 +1209,53 @@ mod tests {
             reach_to_transport_config(&reach).is_some(),
             "a Quic reach must resolve to a dialable TransportConfig (selects the \
              networked dial_stream path, not the local UDS)"
+        );
+    }
+
+    /// #357: an advertised iroh reach (carrying only the producer's node_id) must
+    /// resolve to a dialable `EndpointType::Iroh { node_id, .. }` — the dial-by-
+    /// node_id-alone path `dial_stream` opens over the `moql` ALPN (pkarr / n0 DNS
+    /// discovery resolves the addresses on the shared client endpoint). This is
+    /// the encode→resolve round-trip for the iroh-direct reach.
+    #[test]
+    fn iroh_reach_resolves_to_node_id() {
+        use crate::stream_info::{Destination, IrohReach, Role, TransportConfig as ReachTransport};
+        use crate::transport::EndpointType;
+
+        let node_id = [0x7u8; 32];
+        // This is exactly the Destination `producer_reach()` emits for the iroh arm.
+        let reach = Destination {
+            role: Role::Direct,
+            transport: ReachTransport::Iroh(IrohReach { node_id }),
+        };
+        assert_eq!(reach.role, Role::Direct, "iroh reach is a direct producer reach");
+
+        let cfg = reach_to_transport_config(&reach)
+            .expect("an iroh reach with a node_id must resolve to a dialable TransportConfig");
+        match cfg.endpoint {
+            EndpointType::Iroh { node_id: got, direct_addrs, relay_url } => {
+                assert_eq!(got, node_id, "resolved node_id must round-trip the advertised one");
+                // S2 advertises node_id alone; discovery supplies reachability.
+                assert!(direct_addrs.is_empty(), "S2 iroh reach carries no direct addrs (pkarr)");
+                assert!(relay_url.is_none(), "S2 iroh reach carries no relay URL (pkarr)");
+            }
+            other => panic!("iroh reach must resolve to EndpointType::Iroh, got {other:?}"),
+        }
+    }
+
+    /// #357: an iroh-only reach list must be classified as dialable, so a
+    /// native peer routes to the producer's iroh reach rather than falling
+    /// through to the local UDS plane (the source-of-truth ordering S1 established).
+    #[test]
+    fn iroh_reach_is_dialable() {
+        use crate::stream_info::{Destination, IrohReach, Role, TransportConfig as ReachTransport};
+        let reach = [Destination {
+            role: Role::Direct,
+            transport: ReachTransport::Iroh(IrohReach { node_id: [0xABu8; 32] }),
+        }];
+        assert!(
+            reach.iter().any(|d| reach_to_transport_config(d).is_some()),
+            "an iroh reach must resolve to a dialable TransportConfig"
         );
     }
 

--- a/crates/hyprstream-rpc/src/stream_info.rs
+++ b/crates/hyprstream-rpc/src/stream_info.rs
@@ -28,8 +28,8 @@
 // `Role` / `TransportConfig` / `QuicReach` types — is also code-generated here
 // from `streaming.capnp` (native capnp, no JSON-in-Text on the wire).
 pub use crate::streaming_types::{
-    Completion, Delivery, Ordering, OverflowPolicy, QuicReach, Destination, Retention, Role,
-    StreamInfo, StreamOpt, TransportConfig,
+    Completion, Delivery, IrohReach, Ordering, OverflowPolicy, QuicReach, Destination, Retention,
+    Role, StreamInfo, StreamOpt, TransportConfig,
 };
 
 /// Marker trait for typed stream QoS presets.

--- a/crates/hyprstream-service/src/service/spawner/service.rs
+++ b/crates/hyprstream-service/src/service/spawner/service.rs
@@ -175,6 +175,10 @@ impl<S: RequestService + Send + Sync + 'static> Spawnable for UnifiedServiceConf
                         addr: advertise_addr,
                         server_name: qc.server_name.clone(),
                         cert_hashes: vec![pin],
+                        // The iroh node_id is registered separately once the iroh
+                        // substrate binds (it is not known at the QUIC-bind point);
+                        // see init_global_iroh_node_id below (#357).
+                        iroh_node_id: None,
                     },
                 );
                 if let Some(cb) = qc.on_quic_bound.take() {
@@ -235,6 +239,10 @@ impl<S: RequestService + Send + Sync + 'static> Spawnable for UnifiedServiceConf
                             let _ = hyprstream_rpc::transport::lazy_iroh::install_iroh_client_endpoint(
                                 substrate.endpoint().clone(),
                             );
+                            // #357: register our iroh node_id so producer_reach()
+                            // advertises an iroh-direct Destination for native
+                            // peers (dial-by-node_id via pkarr; NAT + cross-instance).
+                            let _ = hyprstream_rpc::moq_stream::init_global_iroh_node_id(node_id);
                             // Advertise the `#iroh` VM only now that iroh is bound.
                             if let Some(cb) = qc.on_iroh_bound.take() {
                                 cb(service_name.clone(), node_id);

--- a/crates/hyprstream/src/services/notification.rs
+++ b/crates/hyprstream/src/services/notification.rs
@@ -1065,6 +1065,7 @@ mod tests {
             addr,
             server_name: "localhost".to_owned(),
             cert_hashes: vec![[0x22u8; 32]],
+            iroh_node_id: None,
         });
         let reach = producer_reach();
         assert!(

--- a/crates/hyprstream/src/tui/service.rs
+++ b/crates/hyprstream/src/tui/service.rs
@@ -2480,6 +2480,7 @@ mod tests {
             addr,
             server_name: "localhost".to_owned(),
             cert_hashes: vec![[0x11u8; 32]],
+            iroh_node_id: None,
         });
         let reach = producer_reach();
         assert!(


### PR DESCRIPTION
## S2 — iroh+pkarr direct reach for native peers

Implements **S2** of the Streaming Plane Restoration epic (#355): native peers
dial each other **by iroh node_id** over the `moql` ALPN, with **pkarr / n0 DNS
discovery** resolving addresses — NAT traversal + cross-instance + discovery with
**no content relay**. This is the reach the multi-gpu mesh (#320) depends on.

S1 left the iroh arm as a seam (`producer_reach()` Quic-only;
`reach_to_transport_config()` iroh→`None`); the audit found iroh dial + pkarr were
already wired and the **only** blocker was the schema field. The user authorized
the capnp field change.

### 1. Schema — `TransportConfig.iroh` node_id (`streaming.capnp`)
The iroh union arm changes from `iroh @1 :Void` (the blocker — carried no dial
parameters) to:

```capnp
iroh @1 :IrohReach;
# ...
struct IrohReach {
  nodeId @0 :Data $fixedSize(32);  # iroh EndpointId (Ed25519 public key, 32 bytes).
}
```

Matches the existing `QuicReach` struct-arm style; regenerated via the capnp derive
macro → `TransportConfig::Iroh(IrohReach { node_id: [u8; 32] })`. **node_id alone**:
iroh binds the connection to this identity and discovery resolves the routable
addresses, so no direct addrs / relay URL are leaked on the wire (deliberate S6
follow-up to keep the advertisement to the identity).

### 2. Advertise — `producer_reach()`
Emits an iroh `Destination{Role::Direct, transport: Iroh{node_id}}` **ahead of**
the Quic reach when the iroh substrate is bound, so the shared resolver tries
iroh-direct first. The node's own iroh node_id (== `signing_key.verifying_key()`,
already covered by the node's DID) is registered via a new
`init_global_iroh_node_id()` at the substrate-bind site (spawner) — separate from
the QUIC-bind `NodeStreamReach` because the QUIC reach is set earlier in bootstrap
(first-wins `OnceLock`) and reordering the bind sequence would be invasive.
S1's **Quic + local-UDS fallbacks are preserved**.

### 3. Resolve / dial — pkarr dial-by-node_id
- `reach_to_transport_config()` maps the iroh arm to
  `TransportConfig::iroh(node_id, [], None)` (was `None`).
- The shared `connect_moq_reach()` resolver consumes it via `dial_stream`, whose
  iroh arm now **permits dial-by-node_id-alone**: the old fail-fast-without-
  reachability guard is removed, so the shared client endpoint's pkarr / n0 DNS
  discovery (`presets::N0`) resolves the addresses from the `EndpointId`. Supplied
  direct addrs / relay (none, for S2) would still be used as discovery hints.

Send/Sync unchanged. The DH-blind topic (`derive_stream_keys`) is **untouched**.
No relay built (that's S3).

### Tests
**Unit (green):**
- `iroh_reach_resolves_to_node_id` — encode→resolve round-trip: an advertised iroh
  `Destination` (node_id only) resolves to a dialable `EndpointType::Iroh{node_id}`
  with empty addrs / no relay; the node_id round-trips.
- `iroh_reach_is_dialable` — an iroh-only reach list is classified dialable.
- `dial_stream_iroh_node_id_alone_requires_installed_endpoint` — node_id-alone is
  no longer rejected up-front; it fails only when no client endpoint is installed.
- Existing reach/dial tests stay green (`quic_reach_is_dialable`,
  `networked_prefers_reach_over_local_uds`, `dial_stream_iroh_moql_loopback_round_trip`, …).

**Needs live 2-node validation:** the full pkarr-discovered dial (node A advertises
its node_id, node B dials by node_id alone with no addrs → N0 discovery → `moql`
session). A single process can't exercise N0 discovery; the loopback dial test
covers the `moql` session path with a directly-supplied endpoint.

**Pre-existing, unrelated:** `moq_event::tests::moq_event_pub_sub_roundtrip` fails
on the clean feature tip too (#148 event-plane bug); not touched here.

### Build / clippy
- `cargo build -p hyprstream-rpc -p hyprstream` ✅
- `cargo clippy -p hyprstream-rpc -p hyprstream --all-targets -D warnings` ✅

Closes #357
Part of #355
Unblocks #320