### PR TITLE
FS-B0: build RAFS bootstrap from pulled OCI layers (#366)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1315,7 +1315,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1536,6 +1536,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "tinyvec",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -5551,6 +5562,94 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-attributes"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e25825e0430aa11096f8b65ced6780d4a96a133f81904edceebb5344c8dd7f"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "kstring",
+ "smallvec",
+ "thiserror 2.0.17",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-features"
+version = "0.41.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016d6050219458d14520fe22bdfdeb9cb71631dec9bc2724767c983f60109634"
+dependencies = [
+ "gix-trace",
+ "libc",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20972499c03473e773a2099e5fd0c695b9b72465837797a51a43391a1635a030"
+dependencies = [
+ "bitflags 2.11.0",
+ "bstr",
+ "gix-features",
+ "gix-path",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.10.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cb06c3e4f8eed6e24fd915fa93145e28a511f4ea0e768bae16673e05ed3f366"
+dependencies = [
+ "bstr",
+ "gix-trace",
+ "gix-validate",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-quote"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b005c550bf84de3b24aa5e540a23e6146a1c01c7d30470e35d75a12f827f969"
+dependencies = [
+ "bstr",
+ "gix-utils",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-trace"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678"
+
+[[package]]
+name = "gix-utils"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189f8724cf903e7fd57cfe0b7bc209db255cacdcb22c781a022f52c3a774f8d0"
+dependencies = [
+ "fastrand 2.3.0",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b1e63a5b516e970a594f870ed4571a8fdcb8a344e7bd407a20db8bd61dbfde4"
+dependencies = [
+ "bstr",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6252,7 +6351,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "system-configuration 0.6.1",
  "tokio",
  "tower-service",
@@ -6808,6 +6907,7 @@ dependencies = [
  "curve25519-dalek 4.1.3",
  "dashmap",
  "ed25519-dalek 2.2.0",
+ "flate2",
  "fuse-backend-rs 0.12.1",
  "futures",
  "glob",
@@ -6823,8 +6923,11 @@ dependencies = [
  "kata-types",
  "nix 0.27.1",
  "nydus-api 0.4.0",
+ "nydus-builder",
+ "nydus-rafs 0.4.0",
  "nydus-service",
  "nydus-storage 0.7.1",
+ "nydus-utils 0.5.0",
  "parking_lot 0.12.4",
  "rand 0.8.5",
  "reqwest 0.11.27",
@@ -6832,6 +6935,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2 0.10.9",
+ "tar",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -7797,6 +7901,15 @@ checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
+]
+
+[[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "static_assertions",
 ]
 
 [[package]]
@@ -9506,7 +9619,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash",
  "rustls 0.23.40",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
@@ -9549,7 +9662,7 @@ checksum = "78633d1fe1bde91d12bcabb230ac9edb890857414c6d44f3212e0d309525b5ff"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.0",
 ]
@@ -9776,6 +9889,32 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "toml 0.5.11",
+]
+
+[[package]]
+name = "nydus-builder"
+version = "0.2.0"
+source = "git+https://github.com/dragonflyoss/nydus?tag=v2.4.0#5a9d42d8b5cae5052b678ce324d79098f8ae19c1"
+dependencies = [
+ "anyhow",
+ "base64 0.21.7",
+ "gix-attributes",
+ "hex",
+ "indexmap 2.12.1",
+ "libc",
+ "log",
+ "nix 0.24.3",
+ "nydus-api 0.4.0",
+ "nydus-rafs 0.4.0",
+ "nydus-storage 0.7.1",
+ "nydus-utils 0.5.0",
+ "parse-size",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tar",
+ "vmm-sys-util 0.12.1",
+ "xattr",
 ]
 
 [[package]]
@@ -10561,6 +10700,12 @@ dependencies = [
  "twox-hash",
  "zstd 0.13.3",
 ]
+
+[[package]]
+name = "parse-size"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487f2ccd1e17ce8c1bfab3a65c89525af41cfad4c8659021a1e9a2aacd73b89b"
 
 [[package]]
 name = "password-hash"
@@ -12144,7 +12289,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.40",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -12183,7 +12328,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -15786,10 +15931,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicode-bom"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-normalization-alignments"
@@ -16107,7 +16267,7 @@ dependencies = [
  "log",
  "thiserror 2.0.17",
  "vfio-bindings 0.6.1",
- "vm-memory 0.14.1",
+ "vm-memory 0.10.0",
  "vmm-sys-util 0.15.0",
 ]
 

--- a/crates/hyprstream-workers/Cargo.toml
+++ b/crates/hyprstream-workers/Cargo.toml
@@ -58,6 +58,12 @@ nydus-storage = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0",
     "backend-registry",
     "backend-localfs",
 ] }
+# FS-B0: in-process RAFS bootstrap builder. TarballBuilder converts pulled OCI
+# layer tarballs into a RAFS bootstrap (.meta) + dedup data blobs, no external
+# nydus-image binary required.
+nydus-builder = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0" }
+nydus-rafs = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0" }
+nydus-utils = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0" }
 
 # Phase 2: VM Runtime (nydus-service for virtiofs)
 nydus-service = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0" }
@@ -102,6 +108,9 @@ hyprstream-rpc-build = { workspace = true }
 [dev-dependencies]
 tokio-test = { workspace = true }
 tempfile = { workspace = true }
+# FS-B0 RAFS bootstrap builder tests: synthesize small OCI layer tarballs.
+tar = "0.4"
+flate2 = "1"
 
 [lints]
 workspace = true

--- a/crates/hyprstream-workers/src/image/mod.rs
+++ b/crates/hyprstream-workers/src/image/mod.rs
@@ -32,6 +32,7 @@
 
 mod client;
 mod manifest;
+mod rafs_builder;
 mod store;
 
 pub use crate::generated::worker_client::{

--- a/crates/hyprstream-workers/src/image/rafs_builder.rs
+++ b/crates/hyprstream-workers/src/image/rafs_builder.rs
@@ -1,0 +1,328 @@
+//! In-process RAFS bootstrap builder (FS-B0).
+//!
+//! Converts the OCI layer tarballs pulled into the CAS (`blobs/`) into a single
+//! RAFS bootstrap (`.meta`) that can be consumed by an in-process RAFS
+//! `FileSystem` (FS-B, #363) or by `nydusd`.
+//!
+//! # Why in-process
+//!
+//! The `nydus-builder` crate (the same code that backs the `nydus-image create`
+//! binary) is reachable from the dependency tree, so the whole conversion runs
+//! in-process in pure Rust — no external `nydus-image` binary, no shell-out, no
+//! silent fallback. If the conversion fails the caller hard-errors.
+//!
+//! # Approach: layered build
+//!
+//! OCI layers are ordered lower → upper in the manifest. We build them in that
+//! order with [`TarballBuilder`] using [`ConversionType::TargzToRafs`], chaining
+//! each layer's build to the previous layer's bootstrap via
+//! [`BootstrapManager`]'s parent path. This is the same overlay-aware path that
+//! `nydus-image create` uses for multi-layer images:
+//!
+//! - OCI whiteouts (`.wh.*`) from upper layers correctly delete lower entries.
+//! - The builder's `layered_chunk_dict` deduplicates chunks across layers, so a
+//!   chunk that already exists in a lower layer is not written again.
+//!
+//! Data blobs are written content-addressed into `blobs_dir` (named by their
+//! RAFS blob hash). The final layer's bootstrap is written to `bootstrap_path`
+//! (a `SingleFile`), so `RafsStore::bootstrap_path()` resolves to a real RAFS
+//! bootstrap.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use nydus_api::ConfigV2;
+use nydus_builder::attributes::Attributes;
+use nydus_builder::{
+    ArtifactStorage, BlobManager, BootstrapManager, BuildContext, Builder, ConversionType, Features,
+    Prefetch, TarballBuilder, WhiteoutSpec,
+};
+use nydus_rafs::metadata::RafsVersion;
+use nydus_utils::{compress, digest};
+
+use crate::error::{Result, WorkerError};
+
+/// RAFS metadata format version emitted by the builder.
+///
+/// V6 is the EROFS-compatible format used by modern nydusd / Kata virtiofs and
+/// is what FS-B / the in-kernel EROFS path expects.
+const RAFS_FS_VERSION: RafsVersion = RafsVersion::V6;
+
+/// Build a RAFS bootstrap from an ordered set of pulled OCI layer tarballs.
+///
+/// * `layer_blob_paths` — absolute paths to the layer blobs already present in
+///   the CAS, ordered **lower → upper** (i.e. manifest layer order). The blobs
+///   may be gzip-compressed (`*.tar.gz`, the OCI default) or plain tar; the
+///   builder auto-detects.
+/// * `blobs_dir` — directory the generated RAFS data blobs are written into,
+///   content-addressed by their RAFS blob hash.
+/// * `bootstrap_path` — destination for the final RAFS bootstrap (`.meta`).
+///
+/// Returns the path to the produced bootstrap (== `bootstrap_path`). Hard-errors
+/// if no layers are supplied or any layer fails to convert; never leaves a
+/// partial/missing bootstrap silently.
+pub fn build_rafs_bootstrap(
+    layer_blob_paths: &[PathBuf],
+    blobs_dir: &Path,
+    bootstrap_path: &Path,
+) -> Result<PathBuf> {
+    if layer_blob_paths.is_empty() {
+        return Err(WorkerError::RafsError(
+            "cannot build RAFS bootstrap: image has no layers".to_owned(),
+        ));
+    }
+
+    // Shared RAFS configuration. Layered builds require these to be identical
+    // across layers (see `RafsSuperConfig::check_compatibility`).
+    let config = Arc::new(ConfigV2::default());
+
+    // Each intermediate (and the final) bootstrap is written here. The layered
+    // build reads the previous layer's bootstrap as its parent, so we keep a
+    // single rolling bootstrap file and chain to it. The final write lands at
+    // `bootstrap_path`.
+    let mut parent_bootstrap: Option<PathBuf> = None;
+
+    // Intermediate bootstraps for non-final layers live next to the final
+    // bootstrap so the parent reader can find them; the final layer overwrites
+    // `bootstrap_path` itself.
+    let bootstrap_dir = bootstrap_path.parent().ok_or_else(|| {
+        WorkerError::RafsError(format!(
+            "bootstrap path {} has no parent directory",
+            bootstrap_path.display()
+        ))
+    })?;
+
+    let layer_count = layer_blob_paths.len();
+    for (idx, layer_path) in layer_blob_paths.iter().enumerate() {
+        let is_final = idx + 1 == layer_count;
+
+        // Final layer writes directly to the requested bootstrap path; earlier
+        // layers write to a deterministic intermediate path so the next layer
+        // can read it as its parent.
+        let out_bootstrap = if is_final {
+            bootstrap_path.to_path_buf()
+        } else {
+            bootstrap_dir.join(format!(
+                ".rafs-build-{}-layer{}.meta",
+                bootstrap_basename(bootstrap_path),
+                idx
+            ))
+        };
+
+        build_one_layer(
+            layer_path,
+            blobs_dir,
+            &out_bootstrap,
+            parent_bootstrap.as_deref(),
+            idx,
+            config.clone(),
+        )?;
+
+        // Clean up the previous intermediate bootstrap (it has been folded into
+        // the current one) before advancing.
+        if let Some(prev) = parent_bootstrap.take() {
+            if prev != out_bootstrap {
+                let _ = std::fs::remove_file(&prev);
+            }
+        }
+        parent_bootstrap = Some(out_bootstrap);
+    }
+
+    if !bootstrap_path.exists() {
+        return Err(WorkerError::RafsError(format!(
+            "RAFS build completed but bootstrap {} is missing",
+            bootstrap_path.display()
+        )));
+    }
+
+    Ok(bootstrap_path.to_path_buf())
+}
+
+/// Build a single layer into `out_bootstrap`, optionally overlaid on `parent`.
+fn build_one_layer(
+    layer_path: &Path,
+    blobs_dir: &Path,
+    out_bootstrap: &Path,
+    parent: Option<&Path>,
+    layer_idx: usize,
+    config: Arc<ConfigV2>,
+) -> Result<()> {
+    // Data blobs are written into the shared CAS directory, named by their RAFS
+    // blob hash (the empty suffix keeps the bare hash as the filename).
+    let blob_storage = ArtifactStorage::FileDir((blobs_dir.to_path_buf(), String::new()));
+    // The bootstrap is a single explicit file so the caller controls its path.
+    let bootstrap_storage = ArtifactStorage::SingleFile(out_bootstrap.to_path_buf());
+
+    let mut ctx = BuildContext::new(
+        String::new(), // blob_id: derive from blob hash
+        // RAFS v6 (EROFS) requires 4K-aligned chunks; `nydus-image` forces this
+        // on for any v6 build that is not TarToTarfs.
+        true, // aligned_chunk
+        0,    // blob_offset
+        compress::Algorithm::Zstd,   // compressor
+        digest::Algorithm::Sha256,   // digester
+        false,                       // explicit_uidgid (OCI: normalize to 0)
+        WhiteoutSpec::Oci,           // OCI .wh.* whiteout semantics
+        ConversionType::TargzToRafs, // gzip/tar -> RAFS (+ data blob)
+        layer_path.to_path_buf(),    // source_path
+        Prefetch::default(),
+        Some(blob_storage),
+        None,  // external_blob_storage
+        false, // blob_inline_meta: keep bootstrap as a standalone .meta file
+        Features::new(),
+        false, // encrypt
+        Attributes::default(),
+    );
+    ctx.set_fs_version(RAFS_FS_VERSION);
+    ctx.set_configuration(config);
+
+    let mut bootstrap_mgr = BootstrapManager::new(
+        Some(bootstrap_storage),
+        parent.map(|p| p.to_string_lossy().into_owned()),
+    );
+    let mut blob_mgr = BlobManager::new(digest::Algorithm::Sha256, false);
+
+    let mut builder = TarballBuilder::new(ConversionType::TargzToRafs);
+    builder
+        .build(&mut ctx, &mut bootstrap_mgr, &mut blob_mgr)
+        .map_err(|e| {
+            WorkerError::RafsError(format!(
+                "failed to build RAFS layer {} from {}: {e:#}",
+                layer_idx,
+                layer_path.display()
+            ))
+        })?;
+
+    Ok(())
+}
+
+/// List the RAFS data-blob IDs referenced by a bootstrap.
+///
+/// The IDs are the bare blob-hash filenames the data blobs are stored under in
+/// `blobs_dir`. Used by garbage collection so it does not delete the data blobs
+/// a live bootstrap depends on (those blobs are not OCI layer digests and so
+/// are invisible to the OCI-layer-based GC pass).
+pub fn bootstrap_blob_ids(bootstrap_path: &Path) -> Result<Vec<String>> {
+    let config = Arc::new(ConfigV2::default());
+    let (rs, _reader) = nydus_rafs::metadata::RafsSuper::load_from_file(bootstrap_path, config, false)
+        .map_err(|e| {
+            WorkerError::RafsError(format!(
+                "failed to load RAFS bootstrap {}: {e:#}",
+                bootstrap_path.display()
+            ))
+        })?;
+    Ok(rs
+        .superblock
+        .get_blob_infos()
+        .iter()
+        .map(|b| b.blob_id())
+        .collect())
+}
+
+/// Filesystem-safe base name (no extension) used to disambiguate intermediate
+/// bootstraps for concurrent pulls of different images.
+fn bootstrap_basename(path: &Path) -> String {
+    path.file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "image".to_owned())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use flate2::write::GzEncoder;
+    use flate2::Compression;
+    use nydus_rafs::metadata::RafsSuper;
+
+    /// Build a small gzip-compressed tar layer (the OCI default media type)
+    /// with the given (path, contents) regular-file entries.
+    fn make_gzip_layer(path: &Path, entries: &[(&str, &[u8])]) {
+        let file = std::fs::File::create(path).unwrap();
+        let gz = GzEncoder::new(file, Compression::default());
+        let mut tar = tar::Builder::new(gz);
+        for (name, data) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(data.len() as u64);
+            header.set_mode(0o644);
+            header.set_mtime(0);
+            header.set_entry_type(tar::EntryType::Regular);
+            tar.append_data(&mut header, name, *data).unwrap();
+        }
+        let gz = tar.into_inner().unwrap();
+        gz.finish().unwrap();
+    }
+
+    #[test]
+    fn builds_bootstrap_from_single_layer() {
+        let tmp = tempfile::tempdir().unwrap();
+        let blobs_dir = tmp.path().join("blobs");
+        let bootstrap_dir = tmp.path().join("bootstrap");
+        std::fs::create_dir_all(&blobs_dir).unwrap();
+        std::fs::create_dir_all(&bootstrap_dir).unwrap();
+
+        let layer = tmp.path().join("layer0.tar.gz");
+        make_gzip_layer(
+            &layer,
+            &[
+                ("etc/hostname", b"worker\n"),
+                ("usr/bin/app", b"#!/bin/sh\necho hi\n"),
+            ],
+        );
+
+        let bootstrap = bootstrap_dir.join("img.meta");
+        let out = build_rafs_bootstrap(&[layer], &blobs_dir, &bootstrap).unwrap();
+        assert_eq!(out, bootstrap);
+
+        let meta = std::fs::metadata(&bootstrap).unwrap();
+        assert!(meta.len() > 0, "bootstrap must be non-empty");
+
+        // It must parse as a real RAFS bootstrap.
+        let config = Arc::new(ConfigV2::default());
+        let (rs, _reader) =
+            RafsSuper::load_from_file(&bootstrap, config, false).expect("bootstrap must load");
+        assert!(rs.meta.inodes_count > 0, "RAFS must have inodes");
+    }
+
+    #[test]
+    fn builds_bootstrap_from_layered_image() {
+        let tmp = tempfile::tempdir().unwrap();
+        let blobs_dir = tmp.path().join("blobs");
+        let bootstrap_dir = tmp.path().join("bootstrap");
+        std::fs::create_dir_all(&blobs_dir).unwrap();
+        std::fs::create_dir_all(&bootstrap_dir).unwrap();
+
+        let lower = tmp.path().join("layer0.tar.gz");
+        make_gzip_layer(
+            &lower,
+            &[("etc/hostname", b"base\n"), ("etc/config", b"v1\n")],
+        );
+        let upper = tmp.path().join("layer1.tar.gz");
+        // Upper overwrites etc/config and adds a new file.
+        make_gzip_layer(
+            &upper,
+            &[("etc/config", b"v2\n"), ("etc/extra", b"added\n")],
+        );
+
+        let bootstrap = bootstrap_dir.join("img.meta");
+        let out =
+            build_rafs_bootstrap(&[lower, upper], &blobs_dir, &bootstrap).unwrap();
+        assert_eq!(out, bootstrap);
+        assert!(std::fs::metadata(&bootstrap).unwrap().len() > 0);
+
+        let config = Arc::new(ConfigV2::default());
+        let (rs, _reader) =
+            RafsSuper::load_from_file(&bootstrap, config, false).expect("bootstrap must load");
+        assert!(rs.meta.inodes_count > 0);
+
+        // No intermediate bootstraps should be left behind.
+        for entry in std::fs::read_dir(&bootstrap_dir).unwrap() {
+            let name = entry.unwrap().file_name();
+            let name = name.to_string_lossy();
+            assert!(
+                !name.starts_with(".rafs-build-"),
+                "intermediate bootstrap leaked: {name}"
+            );
+        }
+    }
+}

--- a/crates/hyprstream-workers/src/image/store.rs
+++ b/crates/hyprstream-workers/src/image/store.rs
@@ -7,10 +7,15 @@
 //!
 //! Architecture:
 //! ```text
-//! ManifestFetcher (HTTP)  →  nydus-storage Registry backend  →  TarballBuilder
+//! ManifestFetcher (HTTP)  →  nydus-storage Registry backend  →  rafs_builder (TarballBuilder)
 //!      │                              │                              │
-//!      └── OCI manifests only         └── Dragonfly P2P for blobs    └── RAFS output
+//!      └── OCI manifests only         └── Dragonfly P2P for blobs    └── RAFS bootstrap (.meta)
 //! ```
+//!
+//! `pull()` downloads the OCI layer tarballs into the CAS and then converts them
+//! in-process into a RAFS bootstrap (`.meta`) via [`rafs_builder`], so
+//! [`RafsStore::bootstrap_path`] resolves to a real RAFS bootstrap consumable by
+//! an in-process RAFS `FileSystem` (FS-B, #363) or nydusd (FS-B0, #366).
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -183,6 +188,37 @@ impl RafsStore {
         // 6. Generate image ID (SHA256 of config)
         let config_data = tokio::fs::read(&config_path).await?;
         let image_id = format!("sha256:{}", hex::encode(Sha256::digest(&config_data)));
+
+        // 6b. Build the RAFS bootstrap (.meta) from the pulled OCI layer tarballs.
+        //
+        // FS-B0 (#366): the layers above were downloaded into the CAS, but RAFS /
+        // nydusd consume a RAFS *bootstrap*, not raw OCI tarballs. Convert them
+        // in-process via nydus-builder so `bootstrap_path()` resolves to a real
+        // bootstrap. This MUST succeed; a missing/JSON bootstrap is a hard error.
+        let layer_blob_paths: Vec<PathBuf> = manifest
+            .layers
+            .iter()
+            .map(|l| self.blobs_dir.join(digest_to_filename(&l.digest)))
+            .collect();
+        let bootstrap_path = self.bootstrap_path(&image_id);
+        let blobs_dir = self.blobs_dir.clone();
+        let build_layers = layer_blob_paths.clone();
+        let build_bootstrap = bootstrap_path.clone();
+        tracing::info!(
+            image = %image_ref,
+            layers = %build_layers.len(),
+            bootstrap = %build_bootstrap.display(),
+            "Building RAFS bootstrap from OCI layers"
+        );
+        tokio::task::spawn_blocking(move || {
+            super::rafs_builder::build_rafs_bootstrap(&build_layers, &blobs_dir, &build_bootstrap)
+        })
+        .await
+        .map_err(|e| WorkerError::RafsError(format!("RAFS build task panicked: {e}")))?
+        .map_err(|e| WorkerError::ImagePullFailed {
+            image: image_ref.to_owned(),
+            reason: format!("RAFS bootstrap build failed: {e}"),
+        })?;
 
         // 7. Write metadata
         let metadata = ImageMetadata {
@@ -474,6 +510,12 @@ impl RafsStore {
             tokio::fs::remove_file(&metadata_path).await?;
         }
 
+        // Remove the RAFS bootstrap (.meta) built by FS-B0.
+        let bootstrap_path = self.bootstrap_path(image_id);
+        if bootstrap_path.exists() {
+            tokio::fs::remove_file(&bootstrap_path).await?;
+        }
+
         // Note: Blobs are not removed immediately as they may be shared
         // Run gc() to clean up unreferenced blobs
 
@@ -490,15 +532,31 @@ impl RafsStore {
         if self.bootstrap_dir.exists() {
             for entry in std::fs::read_dir(&self.bootstrap_dir)? {
                 let entry = entry?;
-                if entry.path().extension().is_some_and(|e| e == "json") {
-                    if let Ok(metadata_str) = std::fs::read_to_string(entry.path()) {
-                        if let Ok(metadata) = serde_json::from_str::<ImageMetadata>(&metadata_str) {
-                            referenced.insert(digest_to_filename(&metadata.config_digest));
-                            for layer in &metadata.layers {
-                                referenced.insert(digest_to_filename(layer));
+                let path = entry.path();
+                match path.extension().and_then(|e| e.to_str()) {
+                    Some("json") => {
+                        if let Ok(metadata_str) = std::fs::read_to_string(&path) {
+                            if let Ok(metadata) = serde_json::from_str::<ImageMetadata>(&metadata_str)
+                            {
+                                referenced.insert(digest_to_filename(&metadata.config_digest));
+                                for layer in &metadata.layers {
+                                    referenced.insert(digest_to_filename(layer));
+                                }
                             }
                         }
                     }
+                    // RAFS bootstraps reference data blobs by their RAFS blob
+                    // hash (not OCI layer digests), so mark those as referenced
+                    // too — otherwise GC would delete blobs a live bootstrap
+                    // depends on.
+                    Some("meta") => {
+                        if let Ok(blob_ids) = super::rafs_builder::bootstrap_blob_ids(&path) {
+                            for blob_id in blob_ids {
+                                referenced.insert(blob_id);
+                            }
+                        }
+                    }
+                    _ => {}
                 }
             }
         }


### PR DESCRIPTION
## What & why

FS-B0 (#366), the blocking precursor to FS-B (#363) on the Worker GA FS track (#341).

The OCI image store (`crates/hyprstream-workers/src/image/store.rs`) pulled layer tarballs into the CAS but **never produced a RAFS bootstrap**: `pull()` wrote a JSON `ImageMetadata` to `bootstrap_dir/{id}.json`, while `bootstrap_path()` returned `bootstrap_dir/{id}.meta` — a RAFS bootstrap that did not exist. The doc-claimed `TarballBuilder → RAFS` step was absent, so RAFS / nydusd (and the upcoming in-process RAFS `FileSystem` in FS-B) were pointed at a missing `.meta`.

## Approach: in-process, pure Rust (no shell-out)

Investigated the dep tree: `nydus-storage`/`nydus-service`/`nydus-api` (v2.4.0 git) were already deps, and the **`nydus-builder`** crate (the same code path that backs the `nydus-image create` binary) is reachable from the same git workspace. So the conversion runs **entirely in-process** — no external `nydus-image` binary, no gated shell-out, no silent fallback.

New module `image/rafs_builder.rs`:
- `build_rafs_bootstrap(layer_blob_paths, blobs_dir, bootstrap_path)` converts the ordered OCI layer tarballs (lower→upper) into a single **RAFS v6** bootstrap via `TarballBuilder` with `ConversionType::TargzToRafs`.
- **Layered build**: each layer is chained to the previous layer's bootstrap via `BootstrapManager`'s parent path, so OCI `.wh.*` whiteouts apply and the builder's `layered_chunk_dict` **deduplicates chunks across layers**.
- Data blobs are written content-addressed into `blobs_dir` (`ArtifactStorage::FileDir`); the final bootstrap is written to the exact `bootstrap_path()` (`ArtifactStorage::SingleFile`). V6 requires 4K-aligned chunks (`aligned_chunk = true`), matching `nydus-image`'s own behaviour.

Wiring in `store.rs`:
- `pull()` builds the bootstrap (in `spawn_blocking`) after layers download and **hard-errors** if it fails — never leaves a missing/JSON-only bootstrap.
- `remove()` now also deletes the `.meta`.
- `gc()` reads each bootstrap's RAFS blob IDs (`bootstrap_blob_ids()`) so it does not delete the RAFS data blobs a live bootstrap depends on (they are named by RAFS blob hash, not OCI layer digest, so they were previously invisible to the OCI-layer GC pass).

## Tests

`cargo test -p hyprstream-workers --lib image::rafs_builder` — both pass:
- `builds_bootstrap_from_single_layer` — builds a synthetic gzip OCI layer, asserts the `.meta` exists, is non-empty, and parses via `RafsSuper::load_from_file` with inodes.
- `builds_bootstrap_from_layered_image` — two layers (upper overwrites + adds), same assertions, plus verifies no intermediate bootstraps leak.

## Build / clippy

- `cargo build -p hyprstream-workers` — clean (`nydus-builder` compiles in the existing tree).
- `cargo clippy -p hyprstream-workers --all-targets -- -D warnings` — clean.

## Notes

- Bootstrap format is RAFS **v6** (EROFS-compatible), matching modern nydusd / Kata virtiofs / FS-B expectations.
- The OCI compressed layer blobs remain in the CAS (still referenced by the JSON `ImageMetadata` for refs/gc); the RAFS reads go through the new content-addressed data blobs.
- Did not touch `hyprstream-vfs` (FS-C) or kata_backend VM-attach (FS-A).

Closes #366
Part of #341