### PR TITLE
feat: FsMount supertrait + FileSystem→Mount up-adapter + OverlayFs v1 wrap (#364)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6789,7 +6789,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "fuse-backend-rs 0.12.1",
  "hyprstream-rpc",
+ "libc",
+ "parking_lot 0.12.4",
+ "tempfile",
  "tokio",
 ]
 

--- a/crates/hyprstream-vfs/Cargo.toml
+++ b/crates/hyprstream-vfs/Cargo.toml
@@ -18,5 +18,15 @@ tokio = { version = "1", features = ["sync", "rt"] }
 # Error handling
 anyhow = { workspace = true }
 
+# Native filesystem backends for the FsMount overlay adapter (FS-C #364).
+# fuse-backend-rs provides the FileSystem trait, OverlayFs (v1 overlay engine)
+# and PassthroughFs. The overlayfs/passthrough modules are Linux-only, so the
+# dependency is gated to non-wasm targets (the adapter/overlay code is too).
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+fuse-backend-rs = "0.12"
+libc = "0.2"
+parking_lot = { workspace = true }
+
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }
+tempfile = "3"

--- a/crates/hyprstream-vfs/src/fsmount.rs
+++ b/crates/hyprstream-vfs/src/fsmount.rs
@@ -1,0 +1,189 @@
+//! `FsMount` — the writable / overlay filesystem supertrait.
+//!
+//! The base [`Mount`] trait (see `mount.rs`) is deliberately 9P-shaped and
+//! read/write-only: it can `walk`/`open`/`read`/`write`/`readdir`/`stat`/`clunk`
+//! a fid, and the only mutating semantics it carries are the open-mode bits
+//! `OTRUNC` (truncate-on-open) and `ORCLOSE` (remove-on-clunk). That surface is
+//! exactly right for synthetic, control, and stream mounts (`SyntheticTree`,
+//! `EnvMount`, ctl files, `/stream`, …) and we keep it untouched.
+//!
+//! A *full* filesystem — a sandbox rootfs, a writable overlay, a passthrough of
+//! a host directory — needs the rest of the POSIX namespace-mutation surface:
+//! create files, unlink/rmdir, mkdir, rename, change attributes, symlinks and
+//! hard links, plus the overlay-specific whiteout / opaque-dir primitives that
+//! make copy-on-write layering observable. Rather than bloat `Mount` (and force
+//! every existing read/write mount to grow `NotSupported` stubs), `FsMount` is a
+//! **supertrait** that *extends* `Mount`. This is the hyprstream-owned overlay
+//! interface: consumers code against `FsMount`, the v1 backend wraps
+//! `fuse_backend_rs::OverlayFs` (see `overlay.rs`), and a future native
+//! copy-on-write engine (backlog #370) can implement the very same trait with
+//! zero consumer churn.
+//!
+//! ## Why a supertrait, not a `Mount` change
+//!
+//! - **Blast radius.** `SyntheticTree`, `EnvMount`, and friends stay on `Mount`
+//!   verbatim. Only full-filesystem mounts (rootfs, overlay) opt in to
+//!   `FsMount`. No existing impl needs to change.
+//! - **Liskov.** Every `FsMount` *is* a `Mount`, so an `Arc<dyn FsMount>` can be
+//!   coerced to the `Arc<dyn Mount>` a [`Namespace`](crate::Namespace) stores.
+//!   The richer ops are reached by code that holds the concrete `FsMount`.
+//! - **Capability typing.** "Is this mount writable as a real filesystem?" is
+//!   answered by the type (`dyn FsMount`) rather than by probing for runtime
+//!   `NotSupported` errors.
+//!
+//! ## Op semantics
+//!
+//! All ops are **path-addressed** (relative to the mount root, like
+//! [`Mount::walk`]) and take the verified [`Subject`] of the caller for
+//! per-tenant policy enforcement and fid isolation — the uniform
+//! Subject-per-call boundary (#353/#319/#328) extended over the rootfs. Paths
+//! are component slices, never raw strings, so a backend never has to re-parse
+//! `/`-joined input. Mutating ops are **fail-closed**: a backend that cannot
+//! satisfy an op safely must return an error, never silently succeed.
+
+use async_trait::async_trait;
+use hyprstream_rpc::Subject;
+
+use crate::mount::{Mount, MountError, Stat};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Attribute change descriptor
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Attribute changes for [`FsMount::setattr`].
+///
+/// Each `Option` is "leave unchanged" when `None`. This mirrors the
+/// `SetattrValid` bitmask used by FUSE/9P2000.L: only the populated fields are
+/// applied, atomically where the backend supports it. Maps to chmod (`mode`),
+/// chown (`uid`/`gid`), truncate (`size`), and utimes (`atime`/`mtime`).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SetAttr {
+    /// New permission bits (chmod). Lower 12 bits are the POSIX mode.
+    pub mode: Option<u32>,
+    /// New owner uid (chown).
+    pub uid: Option<u32>,
+    /// New owner gid (chown).
+    pub gid: Option<u32>,
+    /// New file length (truncate / extend).
+    pub size: Option<u64>,
+    /// New access time, seconds since the Unix epoch.
+    pub atime: Option<u64>,
+    /// New modification time, seconds since the Unix epoch.
+    pub mtime: Option<u64>,
+}
+
+impl SetAttr {
+    /// True when no field is set — the op would be a no-op.
+    pub fn is_empty(&self) -> bool {
+        self.mode.is_none()
+            && self.uid.is_none()
+            && self.gid.is_none()
+            && self.size.is_none()
+            && self.atime.is_none()
+            && self.mtime.is_none()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FsMount supertrait
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A full, writable filesystem mount — the hyprstream overlay interface.
+///
+/// Extends [`Mount`] (walk/open/read/write/readdir/stat/clunk) with the
+/// namespace-mutation surface a writable or overlay filesystem needs:
+/// `create`, `unlink`/`rmdir`/`mkdir`, `rename`, `setattr`, `symlink`/`readlink`,
+/// `link`, and the overlay whiteout / opaque-dir hooks.
+///
+/// The v1 backend ([`crate::overlay`]) wraps `fuse_backend_rs::OverlayFs`, which
+/// implements copy-up and whiteouts internally — so an `FsMount` impl that
+/// delegates to it does **not** hand-roll copy-on-write. A future native CoW
+/// engine (backlog #370) implements this same trait directly.
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+pub trait FsMount: Mount {
+    /// Create (and leave on disk) a regular file at `path` with `mode`.
+    ///
+    /// Fails with [`MountError::AlreadyExists`] if the final component exists.
+    /// On an overlay this triggers copy-up of the parent directory as needed and
+    /// places the new file in the writable upper layer.
+    async fn create(&self, path: &[&str], mode: u32, caller: &Subject) -> Result<(), MountError>;
+
+    /// Remove a non-directory entry (file, symlink, fifo, …) at `path`.
+    ///
+    /// On an overlay, removing an entry that exists only in a lower (read-only)
+    /// layer is realised as a **whiteout** in the upper layer — the lower entry
+    /// is masked, never mutated.
+    async fn unlink(&self, path: &[&str], caller: &Subject) -> Result<(), MountError>;
+
+    /// Create a directory at `path` with `mode`.
+    async fn mkdir(&self, path: &[&str], mode: u32, caller: &Subject) -> Result<(), MountError>;
+
+    /// Remove an empty directory at `path`.
+    ///
+    /// Fails with [`MountError::NotDirectory`] if `path` is not a directory and
+    /// (per POSIX) an error if it is non-empty. Overlay whiteout rules apply as
+    /// for [`unlink`](Self::unlink).
+    async fn rmdir(&self, path: &[&str], caller: &Subject) -> Result<(), MountError>;
+
+    /// Rename `from` to `to`, atomically replacing `to` if it exists.
+    ///
+    /// `from` and `to` are both rooted at the mount root and may live in
+    /// different directories. Across overlay layers this implies copy-up of the
+    /// source plus a whiteout at the old location, all handled by the backend.
+    async fn rename(&self, from: &[&str], to: &[&str], caller: &Subject) -> Result<(), MountError>;
+
+    /// Change file attributes (chmod / chown / truncate / utimes).
+    ///
+    /// Only the populated fields of [`SetAttr`] are applied. A `size` change on
+    /// a lower-layer file forces copy-up.
+    async fn setattr(&self, path: &[&str], attr: &SetAttr, caller: &Subject) -> Result<(), MountError>;
+
+    /// Create a symbolic link at `path` whose target is `target`.
+    ///
+    /// `target` is stored verbatim (it may be absolute or relative and is *not*
+    /// resolved by this call).
+    async fn symlink(&self, path: &[&str], target: &str, caller: &Subject) -> Result<(), MountError>;
+
+    /// Read the target of the symbolic link at `path`.
+    async fn readlink(&self, path: &[&str], caller: &Subject) -> Result<String, MountError>;
+
+    /// Create a hard link at `new_path` referring to the same inode as
+    /// `existing`.
+    async fn link(&self, existing: &[&str], new_path: &[&str], caller: &Subject) -> Result<(), MountError>;
+
+    // ── Overlay / copy-on-write hooks ───────────────────────────────────────
+    //
+    // Default implementations let non-overlay full filesystems (e.g. a plain
+    // passthrough) ignore overlay semantics. The OverlayFs-backed v1 backend
+    // applies real whiteouts/opaque-dirs internally; these hooks expose that
+    // state to callers (e.g. FS-A's down-adapter) and let a native CoW engine
+    // implement them explicitly.
+
+    /// Report whether `path` resolves to a whiteout — an upper-layer marker that
+    /// masks an entry present in a lower layer. Default: `false` (no overlay).
+    async fn is_whiteout(&self, _path: &[&str], _caller: &Subject) -> Result<bool, MountError> {
+        Ok(false)
+    }
+
+    /// Report whether the directory at `path` is *opaque* — i.e. it hides the
+    /// contents of the same directory in all lower layers. Default: `false`.
+    async fn is_opaque(&self, _path: &[&str], _caller: &Subject) -> Result<bool, MountError> {
+        Ok(false)
+    }
+
+    /// Mark the directory at `path` opaque, hiding lower-layer contents.
+    ///
+    /// Default: [`MountError::NotSupported`] — a backend with no layering cannot
+    /// honour opacity and must say so rather than silently no-op (fail-closed).
+    async fn set_opaque(&self, _path: &[&str], _caller: &Subject) -> Result<(), MountError> {
+        Err(MountError::NotSupported("set_opaque: backend is not an overlay".into()))
+    }
+
+    /// Stat a `path` directly (without holding a fid), returning its metadata.
+    ///
+    /// Convenience over `walk` + `stat` + `clunk` for the mutating ops above,
+    /// which routinely need to probe existence/type. Backends should implement
+    /// it in terms of their own fid machinery.
+    async fn stat_path(&self, path: &[&str], caller: &Subject) -> Result<Stat, MountError>;
+}

--- a/crates/hyprstream-vfs/src/fuse_adapter.rs
+++ b/crates/hyprstream-vfs/src/fuse_adapter.rs
@@ -1,0 +1,584 @@
+//! `FileSystem` → `Mount`/`FsMount` **up-adapter** (native only).
+//!
+//! Anything that is already a [`fuse_backend_rs::api::filesystem::FileSystem`]
+//! — RAFS (via `nydus-rafs`), `OverlayFs`, `PassthroughFs` — can be exposed to
+//! the hyprstream VFS as an [`FsMount`] (and therefore a [`Mount`]) by this
+//! wrapper. It is the "up" half of the bidirectional `FileSystem ↔ Mount`
+//! bridge described in the converged FS/VFS design; the "down" half
+//! (`Namespace → FileSystem`) is FS-A and is intentionally **not** built here.
+//!
+//! ## Path model
+//!
+//! `FileSystem` is inode/handle based and resolves one path component at a time
+//! via `lookup`. The VFS, by contrast, hands a backend a *component slice*
+//! rooted at the mount root. The adapter bridges the two by walking from the
+//! filesystem root inode, calling `lookup` per component and `forget`-ing the
+//! intermediates so the wrapped FS's lookup counts stay balanced.
+//!
+//! ## Subject threading
+//!
+//! Every op carries the verified [`Subject`]. There is no host uid/gid backing
+//! a VFS caller, so the FUSE [`Context`] is constructed neutrally (root creds);
+//! the `Subject` is carried alongside for the policy/audit boundary
+//! (#353/#319/#328) and is where FS-A/FS-D will hook per-tenant enforcement.
+//! Mutating ops are fail-closed: any error from the wrapped FS surfaces as a
+//! [`MountError`].
+//!
+//! ## Send + Sync
+//!
+//! Natively this wrapper is *genuinely* `Send + Sync` (its `FileSystem` is, by
+//! the trait bounds we require) — we do **not** use the wasm `unsafe impl Send`
+//! escape hatch. The whole module is `cfg(not(target_arch = "wasm32"))`.
+
+use std::ffi::CString;
+use std::io;
+
+use async_trait::async_trait;
+use parking_lot::Mutex;
+use fuse_backend_rs::abi::fuse_abi::CreateIn;
+use fuse_backend_rs::api::filesystem::{Context, FileSystem, FsOptions, SetattrValid};
+
+use hyprstream_rpc::Subject;
+
+use crate::fsmount::{FsMount, SetAttr};
+use crate::mount::{DirEntry, Fid, Mount, MountError, Stat, ORDWR, OTRUNC, OWRITE};
+
+mod zerocopy;
+use zerocopy::{MemReader, MemWriter};
+
+/// FUSE root inode (`FUSE_ROOT_ID`).
+const ROOT_INODE: u64 = 1;
+
+/// Map a `std::io::Error` (the wrapped FS's error type) to a [`MountError`].
+fn map_io(err: io::Error, ctx: &str) -> MountError {
+    use io::ErrorKind::*;
+    let msg = format!("{ctx}: {err}");
+    match err.raw_os_error() {
+        Some(libc::ENOENT) => MountError::NotFound(msg),
+        Some(libc::EEXIST) => MountError::AlreadyExists(msg),
+        Some(libc::EACCES) | Some(libc::EPERM) => MountError::PermissionDenied(msg),
+        Some(libc::ENOTDIR) => MountError::NotDirectory(msg),
+        Some(libc::EISDIR) => MountError::IsDirectory(msg),
+        Some(libc::EINVAL) => MountError::InvalidArgument(msg),
+        Some(libc::ENOSYS) | Some(libc::ENOTSUP) => MountError::NotSupported(msg),
+        _ => match err.kind() {
+            NotFound => MountError::NotFound(msg),
+            AlreadyExists => MountError::AlreadyExists(msg),
+            PermissionDenied => MountError::PermissionDenied(msg),
+            InvalidInput => MountError::InvalidArgument(msg),
+            Unsupported => MountError::NotSupported(msg),
+            _ => MountError::Io(msg),
+        },
+    }
+}
+
+fn cstr(name: &str) -> Result<CString, MountError> {
+    CString::new(name).map_err(|_| MountError::InvalidArgument(format!("interior NUL in '{name}'")))
+}
+
+/// A neutral FUSE context. VFS callers have no host uid/gid; the [`Subject`] is
+/// the real identity and is threaded separately for policy/audit.
+fn context() -> Context {
+    Context::default()
+}
+
+/// Per-fid state held inside a [`Fid`]: the resolved inode, the open handle (if
+/// the fid has been `open`ed), the open mode, and whether it is a directory.
+struct FuseFid {
+    inode: u64,
+    handle: Option<u64>,
+    mode: u8,
+    is_dir: bool,
+    /// Whether a remove-on-clunk (`ORCLOSE`) was requested. We need the parent
+    /// inode + name to action it, captured at walk time.
+    rclose: Option<(u64, String, bool)>,
+}
+
+/// Up-adapter: exposes a `fuse_backend_rs` [`FileSystem`] as an [`FsMount`].
+///
+/// `F::Inode` and `F::Handle` are required to be `u64` (which `OverlayFs`,
+/// `PassthroughFs` and RAFS all use) so the adapter can store them in a generic
+/// [`Fid`] without per-FS associated-type juggling.
+pub struct FuseFileSystemMount<F>
+where
+    F: FileSystem<Inode = u64, Handle = u64> + Send + Sync,
+{
+    fs: F,
+    /// Guards lookup-count bookkeeping. The wrapped `FileSystem` ops are `&self`
+    /// and internally synchronised, but per-op walk/forget sequences are
+    /// composite; the mutex keeps a mount's lookup accounting linearizable.
+    lookup_guard: Mutex<()>,
+}
+
+impl<F> FuseFileSystemMount<F>
+where
+    F: FileSystem<Inode = u64, Handle = u64> + Send + Sync,
+{
+    /// Wrap `fs`, running its `init` so option negotiation (writeback, etc.)
+    /// happens once. Use this for filesystems that are ready to serve (e.g. a
+    /// `PassthroughFs` whose `import()` has been called, or an imported
+    /// `OverlayFs`).
+    pub fn new(fs: F) -> Result<Self, MountError> {
+        fs.init(FsOptions::empty())
+            .map_err(|e| map_io(e, "FileSystem::init"))?;
+        Ok(Self {
+            fs,
+            lookup_guard: Mutex::new(()),
+        })
+    }
+
+    /// Borrow the wrapped filesystem (e.g. to call backend-specific setup).
+    pub fn inner(&self) -> &F {
+        &self.fs
+    }
+
+    /// Resolve the parent directory inode plus the final component name.
+    ///
+    /// Empty `path` is the root itself and has no name — callers that need a
+    /// final component (`create`, `unlink`, …) reject it.
+    fn resolve_parent(&self, path: &[&str], ctx: &Context) -> Result<(u64, String), MountError> {
+        let (last, parents) = path
+            .split_last()
+            .ok_or_else(|| MountError::InvalidArgument("operation requires a path".into()))?;
+        let parent = self.resolve(parents, ctx)?;
+        Ok((parent, (*last).to_owned()))
+    }
+
+    /// Walk `components` from the root inode, returning the resolved inode.
+    ///
+    /// Each `lookup` increments the wrapped FS's lookup count; we `forget` every
+    /// intermediate so only the *returned* inode is left referenced. Callers that
+    /// take ownership of the returned inode for a longer-lived fid must `forget`
+    /// it on clunk; transient resolutions should pair with [`Self::forget`].
+    fn resolve(&self, components: &[&str], ctx: &Context) -> Result<u64, MountError> {
+        let mut inode = ROOT_INODE;
+        for (i, comp) in components.iter().enumerate() {
+            if comp.is_empty() || *comp == "." {
+                continue;
+            }
+            let name = cstr(comp)?;
+            let entry = self
+                .fs
+                .lookup(ctx, inode, &name)
+                .map_err(|e| map_io(e, "lookup"))?;
+            if entry.inode == 0 {
+                // Negative entry — release any intermediates we hold.
+                if inode != ROOT_INODE {
+                    self.fs.forget(ctx, inode, 1);
+                }
+                return Err(MountError::NotFound(components[..=i].join("/")));
+            }
+            // Drop the parent's reference now that we've descended.
+            if inode != ROOT_INODE {
+                self.fs.forget(ctx, inode, 1);
+            }
+            inode = entry.inode;
+        }
+        Ok(inode)
+    }
+
+    /// Drop one lookup reference on `inode` (no-op for the root).
+    fn forget(&self, inode: u64, ctx: &Context) {
+        if inode != ROOT_INODE {
+            self.fs.forget(ctx, inode, 1);
+        }
+    }
+
+    /// Convert a FUSE [`Entry`] / `stat64` into the VFS [`Stat`] shape.
+    fn entry_stat(name: &str, attr: &libc::stat64) -> Stat {
+        let is_dir = attr.st_mode & libc::S_IFMT == libc::S_IFDIR;
+        Stat {
+            qtype: if is_dir { 0x80 } else { 0 },
+            size: attr.st_size as u64,
+            name: name.to_owned(),
+            mtime: attr.st_mtime as u64,
+        }
+    }
+
+    /// `getattr` for an inode.
+    fn getattr(&self, inode: u64, ctx: &Context) -> Result<libc::stat64, MountError> {
+        self.fs
+            .getattr(ctx, inode, None)
+            .map(|(st, _)| st)
+            .map_err(|e| map_io(e, "getattr"))
+    }
+}
+
+#[async_trait]
+impl<F> Mount for FuseFileSystemMount<F>
+where
+    F: FileSystem<Inode = u64, Handle = u64> + Send + Sync,
+{
+    async fn walk(&self, components: &[&str], _caller: &Subject) -> Result<Fid, MountError> {
+        let ctx = context();
+        let _g = self.lookup_guard.lock();
+
+        // Capture the parent + name so ORCLOSE can action a remove on clunk.
+        let rclose_target = match components.split_last() {
+            Some((last, parents)) => {
+                let parent = self.resolve(parents, &ctx)?;
+                let name = cstr(last)?;
+                let entry = self
+                    .fs
+                    .lookup(&ctx, parent, &name)
+                    .map_err(|e| map_io(e, "walk lookup"))?;
+                if entry.inode == 0 {
+                    self.forget(parent, &ctx);
+                    return Err(MountError::NotFound(components.join("/")));
+                }
+                let is_dir = entry.attr.st_mode & libc::S_IFMT == libc::S_IFDIR;
+                // Hold the parent ref for the lifetime of the fid (ORCLOSE needs
+                // it); the resolved inode ref is the fid's.
+                Some((parent, last.to_string(), is_dir, entry.inode))
+            }
+            None => None, // root
+        };
+
+        match rclose_target {
+            Some((parent, name, is_dir, inode)) => Ok(Fid::new(FuseFid {
+                inode,
+                handle: None,
+                mode: 0,
+                is_dir,
+                rclose: Some((parent, name, is_dir)),
+            })),
+            None => {
+                let attr = self.getattr(ROOT_INODE, &ctx)?;
+                let is_dir = attr.st_mode & libc::S_IFMT == libc::S_IFDIR;
+                Ok(Fid::new(FuseFid {
+                    inode: ROOT_INODE,
+                    handle: None,
+                    mode: 0,
+                    is_dir,
+                    rclose: None,
+                }))
+            }
+        }
+    }
+
+    async fn open(&self, fid: &mut Fid, mode: u8, _caller: &Subject) -> Result<(), MountError> {
+        let ctx = context();
+        let inner = fid
+            .downcast_mut::<FuseFid>()
+            .ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
+        inner.mode = mode;
+
+        // Truncate-on-open is a setattr(size=0) on the writable layer.
+        if mode & OTRUNC != 0 && !inner.is_dir {
+            let mut attr: libc::stat64 = unsafe { std::mem::zeroed() };
+            attr.st_size = 0;
+            self.fs
+                .setattr(&ctx, inner.inode, attr, None, SetattrValid::SIZE)
+                .map_err(|e| map_io(e, "open OTRUNC"))?;
+        }
+
+        if inner.is_dir {
+            let (handle, _) = self
+                .fs
+                .opendir(&ctx, inner.inode, libc::O_RDONLY as u32)
+                .map_err(|e| map_io(e, "opendir"))?;
+            inner.handle = handle;
+        } else {
+            let flags = match mode & 0x03 {
+                OWRITE => libc::O_WRONLY,
+                ORDWR => libc::O_RDWR,
+                _ => libc::O_RDONLY,
+            } as u32;
+            let (handle, _, _) = self
+                .fs
+                .open(&ctx, inner.inode, flags, 0)
+                .map_err(|e| map_io(e, "open"))?;
+            inner.handle = handle;
+        }
+        Ok(())
+    }
+
+    async fn read(&self, fid: &Fid, offset: u64, count: u32, _caller: &Subject) -> Result<Vec<u8>, MountError> {
+        let ctx = context();
+        let inner = fid
+            .downcast_ref::<FuseFid>()
+            .ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
+        let handle = inner.handle.unwrap_or(0);
+        let mut writer = MemWriter::with_capacity(count as usize);
+        self.fs
+            .read(&ctx, inner.inode, handle, &mut writer, count, offset, None, 0)
+            .map_err(|e| map_io(e, "read"))?;
+        Ok(writer.into_inner())
+    }
+
+    async fn write(&self, fid: &Fid, offset: u64, data: &[u8], _caller: &Subject) -> Result<u32, MountError> {
+        let ctx = context();
+        let inner = fid
+            .downcast_ref::<FuseFid>()
+            .ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
+        let handle = inner.handle.unwrap_or(0);
+        let mut reader = MemReader::new(data);
+        let n = self
+            .fs
+            .write(&ctx, inner.inode, handle, &mut reader, data.len() as u32, offset, None, false, 0, 0)
+            .map_err(|e| map_io(e, "write"))?;
+        Ok(n as u32)
+    }
+
+    async fn readdir(&self, fid: &Fid, _caller: &Subject) -> Result<Vec<DirEntry>, MountError> {
+        let ctx = context();
+        let inner = fid
+            .downcast_ref::<FuseFid>()
+            .ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
+        let handle = inner.handle.unwrap_or(0);
+
+        let mut names: Vec<(String, bool)> = Vec::new();
+        // Page through the directory until a pass yields nothing new.
+        let mut offset = 0u64;
+        loop {
+            let before = names.len();
+            self.fs
+                .readdir(&ctx, inner.inode, handle, 1 << 16, offset, &mut |e| {
+                    offset = e.offset;
+                    let name = String::from_utf8_lossy(e.name).into_owned();
+                    if name != "." && name != ".." {
+                        let is_dir = e.type_ == libc::DT_DIR as u32;
+                        names.push((name, is_dir));
+                    }
+                    Ok(1)
+                })
+                .map_err(|e| map_io(e, "readdir"))?;
+            if names.len() == before {
+                break;
+            }
+        }
+
+        // Resolve sizes/attrs per entry via lookup (best-effort; skip on error).
+        let mut entries = Vec::with_capacity(names.len());
+        for (name, is_dir) in names {
+            let c = match cstr(&name) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            let (size, stat) = match self.fs.lookup(&ctx, inner.inode, &c) {
+                Ok(entry) if entry.inode != 0 => {
+                    let st = Self::entry_stat(&name, &entry.attr);
+                    let size = entry.attr.st_size as u64;
+                    self.forget(entry.inode, &ctx);
+                    (size, Some(st))
+                }
+                _ => (0, None),
+            };
+            entries.push(DirEntry { name, is_dir, size, stat });
+        }
+        Ok(entries)
+    }
+
+    async fn stat(&self, fid: &Fid, _caller: &Subject) -> Result<Stat, MountError> {
+        let ctx = context();
+        let inner = fid
+            .downcast_ref::<FuseFid>()
+            .ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
+        let attr = self.getattr(inner.inode, &ctx)?;
+        Ok(Self::entry_stat("", &attr))
+    }
+
+    async fn clunk(&self, fid: Fid, _caller: &Subject) {
+        let ctx = context();
+        let Some(inner) = fid.downcast_ref::<FuseFid>() else {
+            return;
+        };
+        // Release the open handle, if any.
+        if let Some(handle) = inner.handle {
+            if inner.is_dir {
+                let _ = self.fs.releasedir(&ctx, inner.inode, libc::O_RDONLY as u32, handle);
+            } else {
+                let _ = self.fs.release(&ctx, inner.inode, 0, handle, true, false, None);
+            }
+        }
+        // Action ORCLOSE (remove-on-clunk).
+        if inner.mode & crate::mount::ORCLOSE != 0 {
+            if let Some((parent, name, is_dir)) = &inner.rclose {
+                if let Ok(c) = cstr(name) {
+                    let _ = if *is_dir {
+                        self.fs.rmdir(&ctx, *parent, &c)
+                    } else {
+                        self.fs.unlink(&ctx, *parent, &c)
+                    };
+                }
+            }
+        }
+        // Balance lookup counts: the fid's own inode, and the held parent (if any).
+        self.forget(inner.inode, &ctx);
+        if let Some((parent, _, _)) = &inner.rclose {
+            self.forget(*parent, &ctx);
+        }
+    }
+}
+
+#[async_trait]
+impl<F> FsMount for FuseFileSystemMount<F>
+where
+    F: FileSystem<Inode = u64, Handle = u64> + Send + Sync,
+{
+    async fn create(&self, path: &[&str], mode: u32, caller: &Subject) -> Result<(), MountError> {
+        let ctx = context();
+        let _g = self.lookup_guard.lock();
+        let (parent, name) = self.resolve_parent(path, &ctx)?;
+        let cname = cstr(&name)?;
+        let args = CreateIn {
+            flags: (libc::O_CREAT | libc::O_EXCL | libc::O_WRONLY) as u32,
+            mode,
+            umask: 0,
+            fuse_flags: 0,
+        };
+        let res = self.fs.create(&ctx, parent, &cname, args);
+        self.forget(parent, &ctx);
+        let (entry, handle, _, _) = res.map_err(|e| map_io(e, "create"))?;
+        // We created and opened the file; close the handle immediately — the VFS
+        // create op only guarantees existence, callers re-open to write.
+        if let Some(h) = handle {
+            let _ = self.fs.release(&ctx, entry.inode, args.flags, h, true, false, None);
+        }
+        self.forget(entry.inode, &ctx);
+        let _ = caller; // carried for policy boundary; no host cred mapping yet
+        Ok(())
+    }
+
+    async fn unlink(&self, path: &[&str], _caller: &Subject) -> Result<(), MountError> {
+        let ctx = context();
+        let _g = self.lookup_guard.lock();
+        let (parent, name) = self.resolve_parent(path, &ctx)?;
+        let cname = cstr(&name)?;
+        let res = self.fs.unlink(&ctx, parent, &cname);
+        self.forget(parent, &ctx);
+        res.map_err(|e| map_io(e, "unlink"))
+    }
+
+    async fn mkdir(&self, path: &[&str], mode: u32, _caller: &Subject) -> Result<(), MountError> {
+        let ctx = context();
+        let _g = self.lookup_guard.lock();
+        let (parent, name) = self.resolve_parent(path, &ctx)?;
+        let cname = cstr(&name)?;
+        let res = self.fs.mkdir(&ctx, parent, &cname, mode, 0);
+        self.forget(parent, &ctx);
+        let entry = res.map_err(|e| map_io(e, "mkdir"))?;
+        self.forget(entry.inode, &ctx);
+        Ok(())
+    }
+
+    async fn rmdir(&self, path: &[&str], _caller: &Subject) -> Result<(), MountError> {
+        let ctx = context();
+        let _g = self.lookup_guard.lock();
+        let (parent, name) = self.resolve_parent(path, &ctx)?;
+        let cname = cstr(&name)?;
+        let res = self.fs.rmdir(&ctx, parent, &cname);
+        self.forget(parent, &ctx);
+        res.map_err(|e| map_io(e, "rmdir"))
+    }
+
+    async fn rename(&self, from: &[&str], to: &[&str], _caller: &Subject) -> Result<(), MountError> {
+        let ctx = context();
+        let _g = self.lookup_guard.lock();
+        let (old_dir, old_name) = self.resolve_parent(from, &ctx)?;
+        let (new_dir, new_name) = match self.resolve_parent(to, &ctx) {
+            Ok(v) => v,
+            Err(e) => {
+                self.forget(old_dir, &ctx);
+                return Err(e);
+            }
+        };
+        let old_c = cstr(&old_name)?;
+        let new_c = cstr(&new_name)?;
+        let res = self.fs.rename(&ctx, old_dir, &old_c, new_dir, &new_c, 0);
+        self.forget(old_dir, &ctx);
+        self.forget(new_dir, &ctx);
+        res.map_err(|e| map_io(e, "rename"))
+    }
+
+    async fn setattr(&self, path: &[&str], attr: &SetAttr, _caller: &Subject) -> Result<(), MountError> {
+        let ctx = context();
+        if attr.is_empty() {
+            return Ok(());
+        }
+        let _g = self.lookup_guard.lock();
+        let inode = self.resolve(path, &ctx)?;
+        let mut st: libc::stat64 = unsafe { std::mem::zeroed() };
+        let mut valid = SetattrValid::empty();
+        if let Some(mode) = attr.mode {
+            st.st_mode = mode;
+            valid |= SetattrValid::MODE;
+        }
+        if let Some(uid) = attr.uid {
+            st.st_uid = uid;
+            valid |= SetattrValid::UID;
+        }
+        if let Some(gid) = attr.gid {
+            st.st_gid = gid;
+            valid |= SetattrValid::GID;
+        }
+        if let Some(size) = attr.size {
+            st.st_size = size as i64;
+            valid |= SetattrValid::SIZE;
+        }
+        if let Some(atime) = attr.atime {
+            st.st_atime = atime as i64;
+            valid |= SetattrValid::ATIME;
+        }
+        if let Some(mtime) = attr.mtime {
+            st.st_mtime = mtime as i64;
+            valid |= SetattrValid::MTIME;
+        }
+        let res = self.fs.setattr(&ctx, inode, st, None, valid);
+        self.forget(inode, &ctx);
+        res.map(|_| ()).map_err(|e| map_io(e, "setattr"))
+    }
+
+    async fn symlink(&self, path: &[&str], target: &str, _caller: &Subject) -> Result<(), MountError> {
+        let ctx = context();
+        let _g = self.lookup_guard.lock();
+        let (parent, name) = self.resolve_parent(path, &ctx)?;
+        let cname = cstr(&name)?;
+        let ctarget = cstr(target)?;
+        let res = self.fs.symlink(&ctx, &ctarget, parent, &cname);
+        self.forget(parent, &ctx);
+        let entry = res.map_err(|e| map_io(e, "symlink"))?;
+        self.forget(entry.inode, &ctx);
+        Ok(())
+    }
+
+    async fn readlink(&self, path: &[&str], _caller: &Subject) -> Result<String, MountError> {
+        let ctx = context();
+        let _g = self.lookup_guard.lock();
+        let inode = self.resolve(path, &ctx)?;
+        let res = self.fs.readlink(&ctx, inode);
+        self.forget(inode, &ctx);
+        let bytes = res.map_err(|e| map_io(e, "readlink"))?;
+        Ok(String::from_utf8_lossy(&bytes).into_owned())
+    }
+
+    async fn link(&self, existing: &[&str], new_path: &[&str], _caller: &Subject) -> Result<(), MountError> {
+        let ctx = context();
+        let _g = self.lookup_guard.lock();
+        let inode = self.resolve(existing, &ctx)?;
+        let (new_parent, new_name) = match self.resolve_parent(new_path, &ctx) {
+            Ok(v) => v,
+            Err(e) => {
+                self.forget(inode, &ctx);
+                return Err(e);
+            }
+        };
+        let cname = cstr(&new_name)?;
+        let res = self.fs.link(&ctx, inode, new_parent, &cname);
+        self.forget(inode, &ctx);
+        self.forget(new_parent, &ctx);
+        let entry = res.map_err(|e| map_io(e, "link"))?;
+        self.forget(entry.inode, &ctx);
+        Ok(())
+    }
+
+    async fn stat_path(&self, path: &[&str], _caller: &Subject) -> Result<Stat, MountError> {
+        let ctx = context();
+        let _g = self.lookup_guard.lock();
+        let inode = self.resolve(path, &ctx)?;
+        let attr = self.getattr(inode, &ctx);
+        self.forget(inode, &ctx);
+        let name = path.last().copied().unwrap_or("");
+        Ok(Self::entry_stat(name, &attr?))
+    }
+}

--- a/crates/hyprstream-vfs/src/fuse_adapter/zerocopy.rs
+++ b/crates/hyprstream-vfs/src/fuse_adapter/zerocopy.rs
@@ -1,0 +1,113 @@
+//! In-memory `ZeroCopyReader` / `ZeroCopyWriter` adapters.
+//!
+//! `fuse_backend_rs`'s `read`/`write` ops do not hand back a buffer; they copy
+//! through the `ZeroCopyReader` / `ZeroCopyWriter` traits, which in turn move
+//! bytes to/from the backend's real file via [`FileReadWriteVolatile`]. The VFS
+//! `Mount::read`/`write` API, however, is buffer-based (`Vec<u8>` / `&[u8]`).
+//! These two tiny adapters bridge the gap with a heap buffer — no host fd, no
+//! mmap, so they work uniformly over passthrough, overlay and RAFS backends.
+
+use std::cmp::min;
+use std::io::{self, Read, Write};
+
+use fuse_backend_rs::api::filesystem::{ZeroCopyReader, ZeroCopyWriter};
+use fuse_backend_rs::file_buf::FileVolatileSlice;
+use fuse_backend_rs::file_traits::FileReadWriteVolatile;
+
+/// Chunk size for staging copies through a heap buffer.
+const STAGE_CHUNK: usize = 128 * 1024;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MemWriter — sink for FileSystem::read
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A [`ZeroCopyWriter`] that accumulates everything written into an owned
+/// `Vec<u8>`. Used as the `w` argument of `FileSystem::read`.
+pub struct MemWriter {
+    buf: Vec<u8>,
+}
+
+impl MemWriter {
+    pub fn with_capacity(cap: usize) -> Self {
+        Self { buf: Vec::with_capacity(cap) }
+    }
+
+    pub fn into_inner(self) -> Vec<u8> {
+        self.buf
+    }
+}
+
+impl Write for MemWriter {
+    fn write(&mut self, data: &[u8]) -> io::Result<usize> {
+        self.buf.extend_from_slice(data);
+        Ok(data.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl ZeroCopyWriter for MemWriter {
+    /// Copy up to `count` bytes out of the backend file `f` (starting at `off`)
+    /// into our buffer, staging through a heap chunk.
+    fn write_from(&mut self, f: &mut dyn FileReadWriteVolatile, count: usize, off: u64) -> io::Result<usize> {
+        let mut stage = vec![0u8; min(count, STAGE_CHUNK)];
+        // SAFETY: `stage` is a live, exclusively-borrowed heap buffer for the
+        // duration of the volatile read; no other accessor exists.
+        let slice = unsafe { FileVolatileSlice::from_mut_slice(&mut stage) };
+        let n = f.read_at_volatile(slice, off)?;
+        self.buf.extend_from_slice(&stage[..n]);
+        Ok(n)
+    }
+
+    fn available_bytes(&self) -> usize {
+        // The destination is an unbounded heap Vec.
+        usize::MAX
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MemReader — source for FileSystem::write
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A [`ZeroCopyReader`] backed by a caller-owned byte slice. Used as the `r`
+/// argument of `FileSystem::write`.
+pub struct MemReader<'a> {
+    data: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> MemReader<'a> {
+    pub fn new(data: &'a [u8]) -> Self {
+        Self { data, pos: 0 }
+    }
+}
+
+impl Read for MemReader<'_> {
+    fn read(&mut self, out: &mut [u8]) -> io::Result<usize> {
+        let n = min(out.len(), self.data.len() - self.pos);
+        out[..n].copy_from_slice(&self.data[self.pos..self.pos + n]);
+        self.pos += n;
+        Ok(n)
+    }
+}
+
+impl ZeroCopyReader for MemReader<'_> {
+    /// Copy up to `count` bytes from our slice into the backend file `f` at
+    /// `off`, staging through a heap chunk.
+    fn read_to(&mut self, f: &mut dyn FileReadWriteVolatile, count: usize, off: u64) -> io::Result<usize> {
+        let remaining = self.data.len() - self.pos;
+        let take = min(min(count, remaining), STAGE_CHUNK);
+        if take == 0 {
+            return Ok(0);
+        }
+        let mut stage = self.data[self.pos..self.pos + take].to_vec();
+        // SAFETY: `stage` is a live, exclusively-borrowed heap buffer for the
+        // duration of the volatile write; no other accessor exists.
+        let slice = unsafe { FileVolatileSlice::from_mut_slice(&mut stage) };
+        let n = f.write_at_volatile(slice, off)?;
+        self.pos += n;
+        Ok(n)
+    }
+}

--- a/crates/hyprstream-vfs/src/lib.rs
+++ b/crates/hyprstream-vfs/src/lib.rs
@@ -16,11 +16,24 @@
 //!
 //! All types are WASM-compatible. Transport is abstracted via traits.
 
+mod fsmount;
 mod mount;
 mod namespace;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod proxy;
 
+// Native-only: the `FileSystem → FsMount` up-adapter and the OverlayFs-backed
+// v1 overlay engine. Both wrap `fuse_backend_rs`, whose overlay/passthrough
+// backends are Linux-only.
+#[cfg(not(target_arch = "wasm32"))]
+mod fuse_adapter;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod overlay;
+
+pub use fsmount::{FsMount, SetAttr};
 pub use hyprstream_rpc::Subject;
 pub use mount::{DirEntry, Fid, Mount, MountError, Stat, OREAD, OWRITE, ORDWR, OTRUNC, ORCLOSE};
 pub use namespace::{BindFlag, MountTarget, Namespace, NamespaceError};
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use fuse_adapter::FuseFileSystemMount;

--- a/crates/hyprstream-vfs/src/overlay.rs
+++ b/crates/hyprstream-vfs/src/overlay.rs
@@ -1,0 +1,103 @@
+//! Rootfs overlay — the **v1** overlay backend (native only).
+//!
+//! This is the v1 engine of the hyprstream overlay interface: it builds an
+//! [`FsMount`](crate::FsMount) backed by `fuse_backend_rs::OverlayFs(lower,
+//! upper)`, exposed through the [`FuseFileSystemMount`](crate::FuseFileSystemMount)
+//! up-adapter. Copy-up and whiteouts are performed **by `OverlayFs`** — Kata's
+//! production overlay — not by us. We deliberately do **not** hand-roll
+//! copy-on-write here; a native hyprstream CoW engine (per-tenant writable
+//! layers over shared RO model weights, delta/sandbox snapshots) is the backlog
+//! ticket #370 and will implement the same `FsMount` trait with zero consumer
+//! churn.
+//!
+//! Layers are parameterised as `BoxedLayer`s so FS-B can later pass a RAFS lower
+//! (via `nydus-rafs`) without touching this code. For unit testing — and as the
+//! shape FS-B0/FS-B will reuse — [`passthrough_layer`] wraps a host directory
+//! (`PassthroughFs`) as a layer.
+
+use std::io;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use fuse_backend_rs::api::filesystem::Layer;
+use fuse_backend_rs::overlayfs::{config::Config as OverlayConfig, BoxedLayer, OverlayFs};
+use fuse_backend_rs::passthrough::{Config as PassthroughConfig, PassthroughFs};
+
+use crate::fuse_adapter::FuseFileSystemMount;
+use crate::mount::MountError;
+
+fn map_io(err: io::Error, ctx: &str) -> MountError {
+    MountError::Io(format!("{ctx}: {err}"))
+}
+
+/// Build a `BoxedLayer` from a host directory using `PassthroughFs`.
+///
+/// `read_only` controls only the cache policy hint; OverlayFs enforces the
+/// RO-lower / RW-upper distinction structurally by which slot a layer occupies.
+/// This is the test/bootstrap layer constructor; FS-B swaps the lower for RAFS.
+pub fn passthrough_layer(root: &Path) -> Result<Arc<BoxedLayer>, MountError> {
+    let cfg = PassthroughConfig {
+        root_dir: root.to_string_lossy().into_owned(),
+        // `do_import = false`: the layer is driven through OverlayFs, which
+        // performs the namespace validation itself.
+        do_import: false,
+        writeback: false,
+        xattr: true,
+        ..Default::default()
+    };
+    let fs = PassthroughFs::<()>::new(cfg).map_err(|e| map_io(e, "PassthroughFs::new"))?;
+    fs.import().map_err(|e| map_io(e, "PassthroughFs::import"))?;
+    let layer: Box<dyn Layer<Inode = u64, Handle = u64> + Send + Sync> = Box::new(fs);
+    Ok(Arc::new(layer))
+}
+
+/// Build the v1 rootfs overlay as an [`FsMount`].
+///
+/// `upper` is the single writable layer (copy-ups and whiteouts land here);
+/// `lowers` are the read-only layers, highest priority first. The returned
+/// [`FuseFileSystemMount`] presents the merged view with full overlay semantics
+/// (copy-on-write, whiteout-on-delete, opaque dirs) implemented by `OverlayFs`.
+///
+/// `work` is the overlay work directory (scratch space for atomic operations).
+pub fn rootfs_overlay(
+    upper: Arc<BoxedLayer>,
+    lowers: Vec<Arc<BoxedLayer>>,
+    work: &Path,
+) -> Result<FuseFileSystemMount<OverlayFs>, MountError> {
+    let cfg = OverlayConfig {
+        work: work.to_string_lossy().into_owned(),
+        mountpoint: "/".to_owned(),
+        // `do_import = true`: OverlayFs builds its inode tree from the layers up
+        // front (matches Kata's usage); required before serving.
+        do_import: true,
+        writeback: true,
+        attr_timeout: Duration::from_secs(1),
+        entry_timeout: Duration::from_secs(1),
+        ..Default::default()
+    };
+
+    let overlay =
+        OverlayFs::new(Some(upper), lowers, cfg).map_err(|e| map_io(e, "OverlayFs::new"))?;
+    overlay
+        .import()
+        .map_err(|e| map_io(e, "OverlayFs::import"))?;
+
+    // The up-adapter runs `init` for option negotiation; `import` is already done.
+    FuseFileSystemMount::new(overlay)
+}
+
+/// Convenience: build a passthrough-backed rootfs overlay from host directories.
+///
+/// Wraps `lower` (RO) and `upper` (RW) host dirs as `PassthroughFs` layers and
+/// composes them via [`rootfs_overlay`]. This is the unit-test / bootstrap
+/// shape; production rootfs (FS-B) substitutes a RAFS lower.
+pub fn passthrough_rootfs_overlay(
+    lower: &Path,
+    upper: &Path,
+    work: &Path,
+) -> Result<FuseFileSystemMount<OverlayFs>, MountError> {
+    let upper_layer = passthrough_layer(upper)?;
+    let lower_layer = passthrough_layer(lower)?;
+    rootfs_overlay(upper_layer, vec![lower_layer], work)
+}

--- a/crates/hyprstream-vfs/tests/overlay_fsmount.rs
+++ b/crates/hyprstream-vfs/tests/overlay_fsmount.rs
@@ -1,0 +1,247 @@
+//! FS-C (#364) integration tests: the `FsMount` overlay v1 backend.
+//!
+//! Exercises [`hyprstream_vfs::overlay::passthrough_rootfs_overlay`] — an
+//! `OverlayFs(lower=RO passthrough, upper=RW passthrough)` exposed through the
+//! `FileSystem → FsMount` up-adapter — and asserts genuine overlay behaviour:
+//! copy-up on write, whiteout on delete, rename across layers, plus that the
+//! `Subject` is threaded on every op. The base `Mount` surface (walk/open/
+//! read/write/readdir) is verified too.
+//!
+//! These tests touch the host filesystem via `PassthroughFs` and use OverlayFs
+//! whiteout char-devices (mknod), which require privileges (root or a user
+//! namespace with CAP_MKNOD). When that is unavailable the deletion/whiteout
+//! assertions are skipped with an explanatory message rather than failing — the
+//! copy-up / read / write / Subject paths still run everywhere.
+
+#![cfg(not(target_arch = "wasm32"))]
+#![allow(clippy::unwrap_used)]
+
+use std::fs;
+use std::path::Path;
+
+use hyprstream_vfs::overlay::passthrough_rootfs_overlay;
+use hyprstream_vfs::{FsMount, Mount, MountError, SetAttr, Subject, OREAD, ORDWR, OWRITE};
+
+fn subject() -> Subject {
+    Subject::new("tenant-a")
+}
+
+/// The up-adapter must be *genuinely* `Send + Sync` natively (no wasm
+/// `unsafe impl Send` escape hatch), so it can be stored as `Arc<dyn FsMount>`
+/// in a `Namespace` and used across threads. This is a compile-time assertion.
+#[test]
+fn adapter_is_send_sync() {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<hyprstream_vfs::FuseFileSystemMount<fuse_backend_rs::overlayfs::OverlayFs>>();
+    // And usable as the trait object a Namespace stores.
+    fn _coerce(m: std::sync::Arc<dyn FsMount>) -> std::sync::Arc<dyn Mount> {
+        m
+    }
+}
+
+/// Build lower (RO) + upper (RW) + work tmpdirs and an overlay over them.
+struct Harness {
+    _lower: tempfile::TempDir,
+    _upper: tempfile::TempDir,
+    _work: tempfile::TempDir,
+    lower_path: std::path::PathBuf,
+    overlay: hyprstream_vfs::FuseFileSystemMount<fuse_backend_rs::overlayfs::OverlayFs>,
+}
+
+fn harness(lower_files: &[(&str, &[u8])]) -> Harness {
+    let lower = tempfile::tempdir().unwrap();
+    let upper = tempfile::tempdir().unwrap();
+    let work = tempfile::tempdir().unwrap();
+    for (name, data) in lower_files {
+        let p = lower.path().join(name);
+        if let Some(parent) = p.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&p, data).unwrap();
+    }
+    let overlay =
+        passthrough_rootfs_overlay(lower.path(), upper.path(), work.path()).expect("build overlay");
+    Harness {
+        lower_path: lower.path().to_path_buf(),
+        _lower: lower,
+        _upper: upper,
+        _work: work,
+        overlay,
+    }
+}
+
+/// Read a whole file through the Mount surface (walk/open/read/clunk).
+async fn read_file(m: &impl Mount, path: &[&str], caller: &Subject) -> Result<Vec<u8>, MountError> {
+    let mut fid = m.walk(path, caller).await?;
+    if let Err(e) = m.open(&mut fid, OREAD, caller).await {
+        m.clunk(fid, caller).await;
+        return Err(e);
+    }
+    let mut out = Vec::new();
+    loop {
+        match m.read(&fid, out.len() as u64, 64 * 1024, caller).await {
+            Ok(chunk) if chunk.is_empty() => break,
+            Ok(chunk) => out.extend_from_slice(&chunk),
+            Err(e) => {
+                m.clunk(fid, caller).await;
+                return Err(e);
+            }
+        }
+    }
+    m.clunk(fid, caller).await;
+    Ok(out)
+}
+
+/// True if the host environment can create overlay whiteouts (mknod char dev).
+/// Probe by trying a real whiteout via a deletion and checking for EPERM.
+fn whiteouts_available() -> bool {
+    // mknod of a char device requires privilege; effective uid 0 is the common case.
+    unsafe { libc::geteuid() == 0 }
+}
+
+#[tokio::test]
+async fn lower_file_is_visible_through_overlay() {
+    let h = harness(&[("greeting.txt", b"hello from lower\n")]);
+    let data = read_file(&h.overlay, &["greeting.txt"], &subject()).await.unwrap();
+    assert_eq!(data, b"hello from lower\n");
+}
+
+#[tokio::test]
+async fn write_triggers_copy_up_lower_untouched() {
+    let h = harness(&[("doc.txt", b"original\n")]);
+    let caller = subject();
+
+    // Open the lower file RDWR and overwrite — OverlayFs copies it up to the
+    // writable upper layer.
+    let mut fid = h.overlay.walk(&["doc.txt"], &caller).await.unwrap();
+    h.overlay.open(&mut fid, ORDWR | hyprstream_vfs::OTRUNC, &caller).await.unwrap();
+    let n = h.overlay.write(&fid, 0, b"modified\n", &caller).await.unwrap();
+    assert_eq!(n, b"modified\n".len() as u32);
+    h.overlay.clunk(fid, &caller).await;
+
+    // Overlay shows the new content.
+    let data = read_file(&h.overlay, &["doc.txt"], &caller).await.unwrap();
+    assert_eq!(data, b"modified\n");
+
+    // The RO lower directory on the host is unchanged (copy-up, not in-place).
+    let lower = fs::read(Path::new(&h.lower_path).join("doc.txt")).unwrap();
+    assert_eq!(lower, b"original\n", "lower layer must not be mutated");
+}
+
+#[tokio::test]
+async fn create_new_file_in_upper() {
+    let h = harness(&[]);
+    let caller = subject();
+
+    h.overlay.create(&["fresh.txt"], 0o644, &caller).await.unwrap();
+
+    // Re-open for write and put content in.
+    let mut fid = h.overlay.walk(&["fresh.txt"], &caller).await.unwrap();
+    h.overlay.open(&mut fid, OWRITE, &caller).await.unwrap();
+    h.overlay.write(&fid, 0, b"brand new\n", &caller).await.unwrap();
+    h.overlay.clunk(fid, &caller).await;
+
+    let data = read_file(&h.overlay, &["fresh.txt"], &caller).await.unwrap();
+    assert_eq!(data, b"brand new\n");
+
+    // create on an existing name fails closed.
+    let err = h.overlay.create(&["fresh.txt"], 0o644, &caller).await.unwrap_err();
+    assert!(matches!(err, MountError::AlreadyExists(_)), "got {err:?}");
+}
+
+#[tokio::test]
+async fn mkdir_and_readdir() {
+    let h = harness(&[("a.txt", b"a"), ("b.txt", b"b")]);
+    let caller = subject();
+
+    h.overlay.mkdir(&["sub"], 0o755, &caller).await.unwrap();
+    h.overlay.create(&["sub", "nested.txt"], 0o644, &caller).await.unwrap();
+
+    // readdir of root: lower files + new dir all merged by OverlayFs.
+    let mut fid = h.overlay.walk(&[], &caller).await.unwrap();
+    h.overlay.open(&mut fid, OREAD, &caller).await.unwrap();
+    let entries = h.overlay.readdir(&fid, &caller).await.unwrap();
+    h.overlay.clunk(fid, &caller).await;
+    let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    assert!(names.contains(&"a.txt"), "names={names:?}");
+    assert!(names.contains(&"b.txt"), "names={names:?}");
+    assert!(names.contains(&"sub"), "names={names:?}");
+    assert!(entries.iter().any(|e| e.name == "sub" && e.is_dir));
+}
+
+#[tokio::test]
+async fn setattr_truncate() {
+    let h = harness(&[("big.txt", b"0123456789")]);
+    let caller = subject();
+
+    h.overlay
+        .setattr(&["big.txt"], &SetAttr { size: Some(4), ..Default::default() }, &caller)
+        .await
+        .unwrap();
+
+    let data = read_file(&h.overlay, &["big.txt"], &caller).await.unwrap();
+    assert_eq!(data, b"0123", "truncate via setattr (copy-up) should shorten");
+
+    // stat_path reflects the new size.
+    let st = h.overlay.stat_path(&["big.txt"], &caller).await.unwrap();
+    assert_eq!(st.size, 4);
+}
+
+#[tokio::test]
+async fn subject_threaded_anonymous_vs_named() {
+    // The Subject is carried on every op; both an authenticated and an anonymous
+    // subject reach the backend (per-tenant policy enforcement is FS-A/FS-D).
+    let h = harness(&[("shared.txt", b"data\n")]);
+
+    let named = Subject::new("alice");
+    let data = read_file(&h.overlay, &["shared.txt"], &named).await.unwrap();
+    assert_eq!(data, b"data\n");
+
+    let anon = Subject::anonymous();
+    let data = read_file(&h.overlay, &["shared.txt"], &anon).await.unwrap();
+    assert_eq!(data, b"data\n");
+}
+
+#[tokio::test]
+async fn unlink_lower_file_whiteout() {
+    if !whiteouts_available() {
+        eprintln!("skipping whiteout test: needs root / CAP_MKNOD for overlay char-dev whiteouts");
+        return;
+    }
+    let h = harness(&[("doomed.txt", b"delete me\n"), ("keep.txt", b"keep\n")]);
+    let caller = subject();
+
+    // Sanity: visible before delete.
+    assert!(read_file(&h.overlay, &["doomed.txt"], &caller).await.is_ok());
+
+    // Delete a file that exists only in the RO lower → OverlayFs lays a whiteout
+    // in the upper layer; the lower file is masked, not mutated.
+    h.overlay.unlink(&["doomed.txt"], &caller).await.unwrap();
+
+    let err = read_file(&h.overlay, &["doomed.txt"], &caller).await.unwrap_err();
+    assert!(matches!(err, MountError::NotFound(_)), "got {err:?}");
+
+    // The lower host file still exists (whiteout, not deletion).
+    assert!(Path::new(&h.lower_path).join("doomed.txt").exists());
+
+    // Other lower files remain visible.
+    assert!(read_file(&h.overlay, &["keep.txt"], &caller).await.is_ok());
+}
+
+#[tokio::test]
+async fn rename_across_layers() {
+    if !whiteouts_available() {
+        eprintln!("skipping cross-layer rename test: needs root / CAP_MKNOD for whiteouts");
+        return;
+    }
+    let h = harness(&[("src.txt", b"payload\n")]);
+    let caller = subject();
+
+    // Rename a lower-only file to a new name: OverlayFs copies the source up and
+    // whiteouts the old location.
+    h.overlay.rename(&["src.txt"], &["dst.txt"], &caller).await.unwrap();
+
+    let data = read_file(&h.overlay, &["dst.txt"], &caller).await.unwrap();
+    assert_eq!(data, b"payload\n");
+    assert!(read_file(&h.overlay, &["src.txt"], &caller).await.is_err());
+}


### PR DESCRIPTION
## FS-C (#364) — extend the VFS Mount trait + wrap `fuse_backend_rs::OverlayFs` as the v1 overlay backend

Foundational piece of the Worker GA FS track. Per the converged design (Option B): **hyprstream OWNS the overlay trait; the v1 backend WRAPS `fuse_backend_rs::OverlayFs`.** Native copy-on-write is **not** implemented here — that is backlog **#370**.

All work is confined to `crates/hyprstream-vfs`.

### 1. `FsMount` supertrait — the hyprstream overlay interface
`crates/hyprstream-vfs/src/fsmount.rs`. Extends the existing 9P-shaped `Mount` trait (walk/open/read/write/readdir/stat/clunk) with the writable/overlay op surface:

- `create`, `unlink`, `mkdir`, `rmdir`, `rename`
- `setattr` (chmod / chown / truncate / utimes via a `SetAttr` descriptor)
- `symlink` / `readlink`, `link`
- overlay hooks: `is_whiteout`, `is_opaque`, `set_opaque` (defaulted), plus `stat_path`

**Why a supertrait, not a `Mount` change:** blast-radius containment. `SyntheticTree`, `EnvMount`, ctl/stream mounts stay on `Mount` verbatim — only full-filesystem mounts (rootfs, overlay) opt in to `FsMount`. Every `FsMount` *is* a `Mount`, so an `Arc<dyn FsMount>` coerces to the `Arc<dyn Mount>` a `Namespace` stores. Ops are path-component-addressed, carry the verified `Subject` (the #353/#319/#328 boundary), and are fail-closed.

### 2. `FileSystem → Mount`/`FsMount` up-adapter
`crates/hyprstream-vfs/src/fuse_adapter.rs` (`cfg(not(wasm32))`). `FuseFileSystemMount<F>` exposes any `fuse_backend_rs::FileSystem` (OverlayFs, PassthroughFs, RAFS via nydus-rafs) as an `FsMount`/`Mount`. The "up" half of the bidirectional `FileSystem ↔ Mount` bridge — the "down" half (`Namespace → FileSystem`) is **FS-A** and is intentionally not built here.

- Bridges FUSE's inode/handle, one-component-at-a-time `lookup` model to the VFS component-slice model: walk from the root inode, `lookup` per component, `forget` intermediates so lookup counts stay balanced.
- Threads the `Subject` on every op (neutral FUSE `Context`; the `Subject` is the real identity, carried for the policy/audit boundary FS-A/FS-D will hook).
- **Genuinely `Send + Sync`** (by trait bound on `F`) — no wasm `unsafe impl Send` escape hatch (asserted at compile time in tests).
- In-memory `ZeroCopyReader`/`ZeroCopyWriter` (`fuse_adapter/zerocopy.rs`) bridge the buffer-based VFS read/write to the FileSystem zero-copy traits via a heap-staged `FileVolatileSlice`.

### 3. Rootfs overlay v1 backend
`crates/hyprstream-vfs/src/overlay.rs` (`cfg(not(wasm32))`). `rootfs_overlay(upper, lowers, work)` builds `OverlayFs(upper, lowers)`, imports it, and wraps it via the up-adapter. **Copy-up and whiteouts are performed by `OverlayFs`** (Kata's production overlay) — we do not hand-roll CoW. Layers are parameterized as `BoxedLayer` so **FS-B** can pass a RAFS lower later; `passthrough_rootfs_overlay(lower, upper, work)` wraps host tmpdirs as `PassthroughFs` layers for tests/bootstrap.

### Blast-radius containment
- Supertrait only — `Mount`, `Namespace`, and existing exports are unchanged; no existing mount impl was touched.
- `fuse-backend-rs` / `libc` / `parking_lot` are added as **non-wasm target deps**; the adapter + overlay modules are `cfg`-gated; the `FsMount` supertrait is cross-platform. wasm32 build stays green.

### Tests
`crates/hyprstream-vfs/tests/overlay_fsmount.rs` over `OverlayFs(passthrough RO lower + RW upper)`:
- lower file visible through overlay; write triggers copy-up with the **lower layer left untouched**
- create-in-upper (+ `AlreadyExists` fail-closed); mkdir + readdir layer merge
- `setattr` truncate (copy-up) reflected in `stat_path`
- whiteout-on-delete (lower host file survives); cross-layer rename
- `Subject` threaded (named **and** anonymous reach the backend)
- compile-time `Send + Sync` + `dyn FsMount → dyn Mount` upcast assertion

Whiteout/rename tests self-skip without root/CAP_MKNOD (overlay char-dev whiteouts). **9 new tests pass; existing 19 namespace tests stay green; `cargo clippy -p hyprstream-vfs --all-targets -D warnings` clean.**

---
Closes #364
Part of #341
Native CoW deferred to #370