### PR TITLE
feat: RootfsMount = OverlayFs over in-process RAFS lower (#363)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5112,26 +5112,6 @@ dependencies = [
 
 [[package]]
 name = "fuse-backend-rs"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f251e5fd17ca8206cad5d8863f080d11d29646b21a614dba1f1912fa6e4747"
-dependencies = [
- "arc-swap",
- "bitflags 1.3.2",
- "caps",
- "core-foundation-sys",
- "lazy_static",
- "libc",
- "log",
- "mio 0.8.11",
- "nix 0.24.3",
- "radix_trie",
- "vm-memory 0.14.1",
- "vmm-sys-util 0.12.1",
-]
-
-[[package]]
-name = "fuse-backend-rs"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39179fe2c126f4695984992b6ce08b3b90994b1b1b581c3c58ca29585a56ca81"
@@ -6888,7 +6868,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "fuse-backend-rs 0.12.1",
+ "fuse-backend-rs 0.13.1",
  "hyprstream-rpc",
  "libc",
  "parking_lot 0.12.4",
@@ -6912,7 +6892,7 @@ dependencies = [
  "dashmap",
  "ed25519-dalek 2.2.0",
  "flate2",
- "fuse-backend-rs 0.12.1",
+ "fuse-backend-rs 0.13.1",
  "futures",
  "glob",
  "hex",

--- a/crates/hyprstream-vfs/Cargo.toml
+++ b/crates/hyprstream-vfs/Cargo.toml
@@ -22,8 +22,14 @@ anyhow = { workspace = true }
 # fuse-backend-rs provides the FileSystem trait, OverlayFs (v1 overlay engine)
 # and PassthroughFs. The overlayfs/passthrough modules are Linux-only, so the
 # dependency is gated to non-wasm targets (the adapter/overlay code is too).
+#
+# Pinned to 0.13 to match the version nydus (`nydus-rafs`, v2.4.0) builds
+# against, so the RAFS `Rafs` `Layer`/`FileSystem` impl is the *same* type as
+# this crate's `BoxedLayer`/up-adapter — FS-B (#363) passes a RAFS lower into
+# `rootfs_overlay` directly. The OverlayFs/PassthroughFs/FileSystem APIs used
+# here are identical between 0.12 and 0.13.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-fuse-backend-rs = "0.12"
+fuse-backend-rs = "0.13"
 libc = "0.2"
 parking_lot = { workspace = true }
 

--- a/crates/hyprstream-vfs/src/lib.rs
+++ b/crates/hyprstream-vfs/src/lib.rs
@@ -29,6 +29,9 @@ pub mod proxy;
 mod fuse_adapter;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod overlay;
+// Shim that makes a handleless `Layer` (e.g. RAFS) usable as an OverlayFs lower.
+#[cfg(not(target_arch = "wasm32"))]
+mod zero_open;
 
 pub use fsmount::{FsMount, SetAttr};
 pub use hyprstream_rpc::Subject;
@@ -37,3 +40,12 @@ pub use namespace::{BindFlag, MountTarget, Namespace, NamespaceError};
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use fuse_adapter::FuseFileSystemMount;
+
+// Overlay composition surface (FS-C v1 engine). Re-exported so downstream crates
+// (FS-B) can build a RAFS lower as a `BoxedLayer` via [`overlay::layer_from_fs`]
+// and compose it with [`overlay::rootfs_overlay`] without depending on
+// `fuse-backend-rs`'s overlay internals directly.
+#[cfg(not(target_arch = "wasm32"))]
+pub use fuse_backend_rs::overlayfs::BoxedLayer;
+#[cfg(not(target_arch = "wasm32"))]
+pub use zero_open::ZeroOpenLayer;

--- a/crates/hyprstream-vfs/src/overlay.rs
+++ b/crates/hyprstream-vfs/src/overlay.rs
@@ -31,6 +31,22 @@ fn map_io(err: io::Error, ctx: &str) -> MountError {
     MountError::Io(format!("{ctx}: {err}"))
 }
 
+/// Wrap any `fuse_backend_rs` [`Layer`] (a `FileSystem` that also implements the
+/// overlay `Layer` trait) as a [`BoxedLayer`] usable by [`rootfs_overlay`].
+///
+/// This is the generic seam FS-B uses to plug an **in-process RAFS** lower
+/// (`nydus_rafs::fs::Rafs`, which implements `Layer`) into the overlay without
+/// this crate depending on `nydus-rafs`: the caller owns the RAFS type, we only
+/// require it be a `Layer<Inode = u64, Handle = u64>`. The layer must already be
+/// ready to serve (RAFS: `import`ed; PassthroughFs: `import`ed).
+pub fn layer_from_fs<L>(fs: L) -> Arc<BoxedLayer>
+where
+    L: Layer<Inode = u64, Handle = u64> + Send + Sync + 'static,
+{
+    let layer: Box<dyn Layer<Inode = u64, Handle = u64> + Send + Sync> = Box::new(fs);
+    Arc::new(layer)
+}
+
 /// Build a `BoxedLayer` from a host directory using `PassthroughFs`.
 ///
 /// `read_only` controls only the cache policy hint; OverlayFs enforces the
@@ -48,8 +64,7 @@ pub fn passthrough_layer(root: &Path) -> Result<Arc<BoxedLayer>, MountError> {
     };
     let fs = PassthroughFs::<()>::new(cfg).map_err(|e| map_io(e, "PassthroughFs::new"))?;
     fs.import().map_err(|e| map_io(e, "PassthroughFs::import"))?;
-    let layer: Box<dyn Layer<Inode = u64, Handle = u64> + Send + Sync> = Box::new(fs);
-    Ok(Arc::new(layer))
+    Ok(layer_from_fs(fs))
 }
 
 /// Build the v1 rootfs overlay as an [`FsMount`].

--- a/crates/hyprstream-vfs/src/zero_open.rs
+++ b/crates/hyprstream-vfs/src/zero_open.rs
@@ -1,0 +1,259 @@
+//! `ZeroOpenLayer` — make a *handleless* `FileSystem`/`Layer` usable as an
+//! `OverlayFs` lower (native only).
+//!
+//! ## Why
+//!
+//! `fuse_backend_rs::overlayfs::OverlayFs` is handle-based: when it serves
+//! `open`/`read` it calls the underlying layer's `open` and **requires it to
+//! return `Some(handle)`** — a `None` handle is treated as ENOENT (see
+//! `OverlayFs::open`). Some filesystems are *handleless* ("zero-message-open"):
+//! they return `(None, KEEP_CACHE, _)` from `open` and address reads by inode.
+//! The motivating case is **RAFS** (`nydus_rafs::fs::Rafs`), the FS-B (#363)
+//! rootfs lower: its `open` returns no handle, so used directly as an OverlayFs
+//! lower every read of an image file fails with ENOENT.
+//!
+//! ## What
+//!
+//! [`ZeroOpenLayer`] wraps any [`Layer`] and substitutes a constant handle (`0`)
+//! whenever the inner `open`/`opendir` returns `None`, leaving every other op a
+//! straight delegation. The substituted handle is harmless: a handleless backend
+//! ignores the handle on `read`/`readdir` (it resolves by inode), and on
+//! `release`/`releasedir` the wrapper passes it straight back. The overlay stays
+//! in its normal, production (Kata) handle mode — copy-up still routes writes to
+//! the writable upper layer (which keeps real handles); only the read-only lower
+//! is wrapped.
+//!
+//! This keeps the version-pinned overlay engine and the up-adapter unchanged: it
+//! is purely a lower-layer shim.
+
+use std::ffi::CStr;
+use std::io;
+use std::time::Duration;
+
+use fuse_backend_rs::abi::fuse_abi::{stat64, statvfs64};
+use fuse_backend_rs::api::filesystem::{
+    Context, DirEntry, Entry, FileSystem, FsOptions, GetxattrReply, Layer, ListxattrReply,
+    OpenOptions, SetattrValid, ZeroCopyReader, ZeroCopyWriter,
+};
+
+/// Wrap a handleless [`Layer`] so it presents a non-`None` handle to
+/// `OverlayFs`. See the module docs.
+pub struct ZeroOpenLayer<L>
+where
+    L: Layer<Inode = u64, Handle = u64> + Send + Sync,
+{
+    inner: L,
+}
+
+impl<L> ZeroOpenLayer<L>
+where
+    L: Layer<Inode = u64, Handle = u64> + Send + Sync,
+{
+    /// Wrap `inner`. The inner layer must already be ready to serve (e.g. a
+    /// RAFS whose `import` has run).
+    pub fn new(inner: L) -> Self {
+        Self { inner }
+    }
+}
+
+impl<L> FileSystem for ZeroOpenLayer<L>
+where
+    L: Layer<Inode = u64, Handle = u64> + Send + Sync,
+{
+    type Inode = u64;
+    type Handle = u64;
+
+    fn init(&self, capable: FsOptions) -> io::Result<FsOptions> {
+        self.inner.init(capable)
+    }
+
+    fn destroy(&self) {
+        self.inner.destroy()
+    }
+
+    fn lookup(&self, ctx: &Context, parent: u64, name: &CStr) -> io::Result<Entry> {
+        self.inner.lookup(ctx, parent, name)
+    }
+
+    fn forget(&self, ctx: &Context, inode: u64, count: u64) {
+        self.inner.forget(ctx, inode, count)
+    }
+
+    fn batch_forget(&self, ctx: &Context, requests: Vec<(u64, u64)>) {
+        self.inner.batch_forget(ctx, requests)
+    }
+
+    fn getattr(
+        &self,
+        ctx: &Context,
+        inode: u64,
+        handle: Option<u64>,
+    ) -> io::Result<(stat64, Duration)> {
+        self.inner.getattr(ctx, inode, handle)
+    }
+
+    fn setattr(
+        &self,
+        ctx: &Context,
+        inode: u64,
+        attr: stat64,
+        handle: Option<u64>,
+        valid: SetattrValid,
+    ) -> io::Result<(stat64, Duration)> {
+        self.inner.setattr(ctx, inode, attr, handle, valid)
+    }
+
+    fn readlink(&self, ctx: &Context, inode: u64) -> io::Result<Vec<u8>> {
+        self.inner.readlink(ctx, inode)
+    }
+
+    fn unlink(&self, ctx: &Context, parent: u64, name: &CStr) -> io::Result<()> {
+        self.inner.unlink(ctx, parent, name)
+    }
+
+    fn rmdir(&self, ctx: &Context, parent: u64, name: &CStr) -> io::Result<()> {
+        self.inner.rmdir(ctx, parent, name)
+    }
+
+    /// Substitute a constant handle when the inner layer is handleless.
+    fn open(
+        &self,
+        ctx: &Context,
+        inode: u64,
+        flags: u32,
+        fuse_flags: u32,
+    ) -> io::Result<(Option<u64>, OpenOptions, Option<u32>)> {
+        let (handle, opts, passthrough) = self.inner.open(ctx, inode, flags, fuse_flags)?;
+        Ok((Some(handle.unwrap_or(0)), opts, passthrough))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn read(
+        &self,
+        ctx: &Context,
+        inode: u64,
+        handle: u64,
+        w: &mut dyn ZeroCopyWriter,
+        size: u32,
+        offset: u64,
+        lock_owner: Option<u64>,
+        flags: u32,
+    ) -> io::Result<usize> {
+        self.inner
+            .read(ctx, inode, handle, w, size, offset, lock_owner, flags)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn write(
+        &self,
+        ctx: &Context,
+        inode: u64,
+        handle: u64,
+        r: &mut dyn ZeroCopyReader,
+        size: u32,
+        offset: u64,
+        lock_owner: Option<u64>,
+        delayed_write: bool,
+        flags: u32,
+        fuse_flags: u32,
+    ) -> io::Result<usize> {
+        self.inner.write(
+            ctx,
+            inode,
+            handle,
+            r,
+            size,
+            offset,
+            lock_owner,
+            delayed_write,
+            flags,
+            fuse_flags,
+        )
+    }
+
+    fn release(
+        &self,
+        ctx: &Context,
+        inode: u64,
+        flags: u32,
+        handle: u64,
+        flush: bool,
+        flock_release: bool,
+        lock_owner: Option<u64>,
+    ) -> io::Result<()> {
+        self.inner
+            .release(ctx, inode, flags, handle, flush, flock_release, lock_owner)
+    }
+
+    fn statfs(&self, ctx: &Context, inode: u64) -> io::Result<statvfs64> {
+        self.inner.statfs(ctx, inode)
+    }
+
+    fn getxattr(
+        &self,
+        ctx: &Context,
+        inode: u64,
+        name: &CStr,
+        size: u32,
+    ) -> io::Result<GetxattrReply> {
+        self.inner.getxattr(ctx, inode, name, size)
+    }
+
+    fn listxattr(&self, ctx: &Context, inode: u64, size: u32) -> io::Result<ListxattrReply> {
+        self.inner.listxattr(ctx, inode, size)
+    }
+
+    /// Substitute a constant handle when the inner layer is handleless.
+    fn opendir(
+        &self,
+        ctx: &Context,
+        inode: u64,
+        flags: u32,
+    ) -> io::Result<(Option<u64>, OpenOptions)> {
+        let (handle, opts) = self.inner.opendir(ctx, inode, flags)?;
+        Ok((Some(handle.unwrap_or(0)), opts))
+    }
+
+    fn readdir(
+        &self,
+        ctx: &Context,
+        inode: u64,
+        handle: u64,
+        size: u32,
+        offset: u64,
+        add_entry: &mut dyn FnMut(DirEntry) -> io::Result<usize>,
+    ) -> io::Result<()> {
+        self.inner
+            .readdir(ctx, inode, handle, size, offset, add_entry)
+    }
+
+    fn readdirplus(
+        &self,
+        ctx: &Context,
+        inode: u64,
+        handle: u64,
+        size: u32,
+        offset: u64,
+        add_entry: &mut dyn FnMut(DirEntry, Entry) -> io::Result<usize>,
+    ) -> io::Result<()> {
+        self.inner
+            .readdirplus(ctx, inode, handle, size, offset, add_entry)
+    }
+
+    fn releasedir(&self, ctx: &Context, inode: u64, flags: u32, handle: u64) -> io::Result<()> {
+        self.inner.releasedir(ctx, inode, flags, handle)
+    }
+
+    fn access(&self, ctx: &Context, inode: u64, mask: u32) -> io::Result<()> {
+        self.inner.access(ctx, inode, mask)
+    }
+}
+
+impl<L> Layer for ZeroOpenLayer<L>
+where
+    L: Layer<Inode = u64, Handle = u64> + Send + Sync,
+{
+    fn root_inode(&self) -> u64 {
+        self.inner.root_inode()
+    }
+}

--- a/crates/hyprstream-workers/Cargo.toml
+++ b/crates/hyprstream-workers/Cargo.toml
@@ -67,7 +67,10 @@ nydus-utils = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0" }
 
 # Phase 2: VM Runtime (nydus-service for virtiofs)
 nydus-service = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0" }
-fuse-backend-rs = "0.12"
+# 0.13 to unify with nydus (`nydus-rafs` v2.4.0 builds against 0.13.1): FS-B
+# (#363) wraps the in-process RAFS `Rafs` as an overlay lower, so its `Layer`
+# type must match `hyprstream-vfs`'s `BoxedLayer`.
+fuse-backend-rs = "0.13"
 
 # Minimal HTTP for manifest fetching only (blobs go through nydus-storage)
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }

--- a/crates/hyprstream-workers/src/image/mod.rs
+++ b/crates/hyprstream-workers/src/image/mod.rs
@@ -33,6 +33,10 @@
 mod client;
 mod manifest;
 mod rafs_builder;
+// FS-B (#363): per-sandbox RootfsMount = OverlayFs(in-process RAFS lower +
+// writable upper). Native-only (the overlay/RAFS FileSystem stack is Linux).
+#[cfg(not(target_arch = "wasm32"))]
+mod rootfs_mount;
 mod store;
 
 pub use crate::generated::worker_client::{
@@ -40,4 +44,6 @@ pub use crate::generated::worker_client::{
     AuthConfig, FilesystemUsage, FilesystemIdentifier,
 };
 pub use manifest::{ImageReference, ManifestFetcher, ManifestResult, OciManifest};
+#[cfg(not(target_arch = "wasm32"))]
+pub use rootfs_mount::{rootfs_mount_for, rootfs_mount_from_rafs};
 pub use store::{GcStats, ImageMetadata, RafsStore};

--- a/crates/hyprstream-workers/src/image/rootfs_mount.rs
+++ b/crates/hyprstream-workers/src/image/rootfs_mount.rs
@@ -1,0 +1,355 @@
+//! Per-sandbox **RootfsMount** (FS-B, #363).
+//!
+//! Builds the rootfs filesystem for a sandbox as an
+//! [`FsMount`](hyprstream_vfs::FsMount): an `OverlayFs` whose
+//!
+//! - **lower** is the image's RAFS loaded **in-process** as a
+//!   `fuse_backend_rs::FileSystem` (via `nydus-rafs`'s [`Rafs`], which also
+//!   implements the overlay [`Layer`](fuse_backend_rs::api::filesystem::Layer)
+//!   trait) — read-only, lazily fetching chunks from the CAS / Dragonfly P2P, so
+//!   nothing is materialised on disk up front; and
+//! - **upper** is a per-sandbox writable directory (the copy-up / whiteout
+//!   target), so writes never touch the shared image.
+//!
+//! Composition is delegated to FS-C's
+//! [`rootfs_overlay`](hyprstream_vfs::overlay::rootfs_overlay) — copy-on-write,
+//! whiteout-on-delete and opaque dirs are performed by `OverlayFs` (Kata's
+//! production overlay). We do **not** hand-roll CoW here; the native hyprstream
+//! CoW engine (per-tenant writable layers over shared RO model weights, delta /
+//! sandbox snapshots) is the backlog ticket and will implement the same
+//! `FsMount` trait with zero churn here.
+//!
+//! ```text
+//!            RootfsMount  (FsMount)
+//!                 │
+//!         OverlayFs (FS-C rootfs_overlay)
+//!          ┌──────┴──────┐
+//!       upper           lower
+//!   <sandbox>/rootfs/   Rafs (in-process FileSystem)
+//!   {upper,work}/       bootstrap .meta + data blobs (lazy chunk CAS)
+//! ```
+//!
+//! ## In-process RAFS — no external `nydusd`
+//!
+//! [`Rafs::new`] loads the bootstrap super-block and constructs a `BlobDevice`
+//! over a **localfs** backend + **filecache** rooted at the image store's blobs
+//! directory (where FS-B0 wrote the content-addressed RAFS data blobs). RAFS v6
+//! (what FS-B0 emits) *requires* a local blob cache, which the localfs config
+//! supplies. The whole thing runs in this process; there is no `nydusd`, no
+//! FUSE mount, no shell-out.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use fuse_backend_rs::overlayfs::OverlayFs;
+use nydus_api::ConfigV2;
+use nydus_rafs::fs::Rafs;
+
+use hyprstream_vfs::overlay::{layer_from_fs, rootfs_overlay};
+use hyprstream_vfs::{FsMount, FuseFileSystemMount, ZeroOpenLayer};
+
+use crate::error::{Result, WorkerError};
+
+/// Subdirectory under a sandbox dir holding the writable rootfs overlay state.
+const ROOTFS_SUBDIR: &str = "rootfs";
+/// The copy-up / whiteout target (overlay "upper").
+const UPPER_SUBDIR: &str = "upper";
+/// The overlay work directory (scratch for atomic operations).
+const WORK_SUBDIR: &str = "work";
+
+/// Load an image's RAFS bootstrap as an **in-process** read-only `FileSystem`.
+///
+/// * `bootstrap_path` — the RAFS bootstrap (`.meta`) produced by FS-B0
+///   ([`build_rafs_bootstrap`](crate::image::rafs_builder)), resolved via
+///   [`RafsStore::bootstrap_path`](crate::image::RafsStore::bootstrap_path).
+/// * `blobs_dir` — directory holding the content-addressed RAFS data blobs; used
+///   as both the localfs backend dir and the filecache work dir.
+/// * `id` — an identifier for the RAFS instance (metrics / logging only).
+///
+/// The returned [`Rafs`] is `import`ed and ready to serve. Chunks are fetched
+/// lazily on read from `blobs_dir`, preserving the lazy chunk-CAS property.
+fn load_rafs_lower(bootstrap_path: &Path, blobs_dir: &Path, id: &str) -> Result<Rafs> {
+    if !bootstrap_path.exists() {
+        return Err(WorkerError::RafsError(format!(
+            "RAFS bootstrap {} does not exist (image not pulled / built?)",
+            bootstrap_path.display()
+        )));
+    }
+
+    // localfs backend + filecache, both rooted at the blobs dir (RAFS v6
+    // mandates a local blob cache), plus the `rafs` section `Rafs::new`
+    // requires (`get_rafs_config`). `mode = "direct"` is the standard v6
+    // metadata mode; xattrs are enabled so overlay/whiteout xattrs resolve.
+    let blobs = blobs_dir.to_string_lossy();
+    let toml = format!(
+        r#"
+version = 2
+id = "{id}"
+backend.type = "localfs"
+backend.localfs.dir = "{blobs}"
+cache.type = "filecache"
+cache.compressed = false
+cache.validate = false
+cache.filecache.work_dir = "{blobs}"
+rafs.mode = "direct"
+rafs.enable_xattr = true
+"#
+    );
+    let config: ConfigV2 = toml.parse().map_err(|e| {
+        WorkerError::RafsError(format!(
+            "failed to build RAFS config for {}: {e}",
+            blobs_dir.display()
+        ))
+    })?;
+    let config = Arc::new(config);
+
+    let (mut rafs, reader) = Rafs::new(&config, id, bootstrap_path).map_err(|e| {
+        WorkerError::RafsError(format!(
+            "failed to load in-process RAFS from {}: {e}",
+            bootstrap_path.display()
+        ))
+    })?;
+    rafs.import(reader, None).map_err(|e| {
+        WorkerError::RafsError(format!(
+            "failed to import RAFS bootstrap {}: {e}",
+            bootstrap_path.display()
+        ))
+    })?;
+
+    Ok(rafs)
+}
+
+/// Lay out (and create) the per-sandbox writable overlay directories under
+/// `sandbox_dir`, returning `(upper, work)`.
+///
+/// Both live under `<sandbox_dir>/rootfs/`: `upper/` is the copy-up target,
+/// `work/` is `OverlayFs`'s scratch space. They must be on the same filesystem
+/// (they are — siblings) so `OverlayFs` can rename atomically between them.
+fn prepare_upper(sandbox_dir: &Path) -> Result<(PathBuf, PathBuf)> {
+    let rootfs = sandbox_dir.join(ROOTFS_SUBDIR);
+    let upper = rootfs.join(UPPER_SUBDIR);
+    let work = rootfs.join(WORK_SUBDIR);
+    for dir in [&upper, &work] {
+        std::fs::create_dir_all(dir)
+            .map_err(|e| WorkerError::IoError(format!("create {}: {e}", dir.display())))?;
+    }
+    Ok((upper, work))
+}
+
+/// Build a sandbox **RootfsMount** from an already-loaded RAFS lower and explicit
+/// upper/work directories.
+///
+/// The lowest-level constructor: callers that hold a [`Rafs`] (e.g. tests, or a
+/// future caller that loaded RAFS itself) compose it here. Wraps the RAFS as the
+/// single read-only overlay lower and `upper` as the writable layer via FS-C's
+/// [`rootfs_overlay`].
+pub fn rootfs_mount_from_rafs(
+    rafs: Rafs,
+    upper: &Path,
+    work: &Path,
+) -> Result<FuseFileSystemMount<OverlayFs>> {
+    let upper_layer = hyprstream_vfs::overlay::passthrough_layer(upper)
+        .map_err(|e| WorkerError::RafsError(format!("rootfs upper layer: {e}")))?;
+    // The RAFS `Rafs` implements `Layer`, but it is *handleless* (`open` yields
+    // no handle), which OverlayFs rejects as ENOENT for a lower. Wrap it in
+    // `ZeroOpenLayer` so it presents a constant handle; reads still resolve by
+    // inode and writes copy-up to the (handle-based) upper.
+    let lower_layer = layer_from_fs(ZeroOpenLayer::new(rafs));
+    rootfs_overlay(upper_layer, vec![lower_layer], work)
+        .map_err(|e| WorkerError::RafsError(format!("rootfs overlay: {e}")))
+}
+
+/// Build a sandbox **RootfsMount** for `image_id`.
+///
+/// * `bootstrap_path` — the image's RAFS bootstrap (`.meta`).
+/// * `blobs_dir` — the image store's blobs directory (RAFS data blobs).
+/// * `image_id` — the image identifier (used as the RAFS instance id).
+/// * `sandbox_dir` — the per-sandbox directory; the writable upper + work dirs
+///   are created under `<sandbox_dir>/rootfs/`.
+///
+/// Returns the rootfs [`FsMount`]: the RAFS image is the read-only lower, a
+/// per-sandbox directory is the writable upper, composed via `OverlayFs`. The
+/// shared image (RAFS bootstrap + blobs) is never written to — copy-ups and
+/// whiteouts land in the upper.
+pub fn rootfs_mount_for(
+    bootstrap_path: &Path,
+    blobs_dir: &Path,
+    image_id: &str,
+    sandbox_dir: &Path,
+) -> Result<impl FsMount> {
+    let rafs = load_rafs_lower(bootstrap_path, blobs_dir, image_id)?;
+    let (upper, work) = prepare_upper(sandbox_dir)?;
+    rootfs_mount_from_rafs(rafs, &upper, &work)
+}
+
+impl crate::image::RafsStore {
+    /// Build the rootfs [`FsMount`] for an image into a per-sandbox directory.
+    ///
+    /// Resolves the image's RAFS bootstrap and blobs from this store, loads the
+    /// RAFS in-process as the read-only lower, and overlays a per-sandbox
+    /// writable upper under `<sandbox_dir>/rootfs/`. See [`rootfs_mount_for`].
+    pub fn rootfs_mount(&self, image_id: &str, sandbox_dir: &Path) -> Result<impl FsMount> {
+        let bootstrap = self.bootstrap_path(image_id);
+        rootfs_mount_for(&bootstrap, self.blobs_dir(), image_id, sandbox_dir)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use flate2::write::GzEncoder;
+    use flate2::Compression;
+    use hyprstream_rpc::Subject;
+    use hyprstream_vfs::{FsMount, Mount, OREAD, ORDWR};
+
+    use crate::image::rafs_builder::build_rafs_bootstrap;
+
+    /// Build a small gzip tar layer (OCI default) of regular files.
+    fn make_gzip_layer(path: &Path, entries: &[(&str, &[u8])]) {
+        let file = std::fs::File::create(path).unwrap();
+        let gz = GzEncoder::new(file, Compression::default());
+        let mut tar = tar::Builder::new(gz);
+        for (name, data) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(data.len() as u64);
+            header.set_mode(0o644);
+            header.set_mtime(0);
+            header.set_entry_type(tar::EntryType::Regular);
+            tar.append_data(&mut header, name, *data).unwrap();
+        }
+        let gz = tar.into_inner().unwrap();
+        gz.finish().unwrap();
+    }
+
+    /// Build a synthetic RAFS image (bootstrap + data blobs) under `dir`,
+    /// returning `(bootstrap_path, blobs_dir)`.
+    fn build_image(dir: &Path, layers: &[&[(&str, &[u8])]]) -> (PathBuf, PathBuf) {
+        let blobs_dir = dir.join("blobs");
+        let bootstrap_dir = dir.join("bootstrap");
+        std::fs::create_dir_all(&blobs_dir).unwrap();
+        std::fs::create_dir_all(&bootstrap_dir).unwrap();
+
+        let mut layer_paths = Vec::new();
+        for (i, entries) in layers.iter().enumerate() {
+            let p = dir.join(format!("layer{i}.tar.gz"));
+            make_gzip_layer(&p, entries);
+            layer_paths.push(p);
+        }
+
+        let bootstrap = bootstrap_dir.join("img.meta");
+        build_rafs_bootstrap(&layer_paths, &blobs_dir, &bootstrap).unwrap();
+        (bootstrap, blobs_dir)
+    }
+
+    /// Snapshot of the blobs dir (name -> len) to assert the image is untouched.
+    fn blobs_snapshot(blobs_dir: &Path) -> Vec<(String, u64)> {
+        let mut v: Vec<(String, u64)> = std::fs::read_dir(blobs_dir)
+            .unwrap()
+            .map(|e| {
+                let e = e.unwrap();
+                (
+                    e.file_name().to_string_lossy().into_owned(),
+                    e.metadata().unwrap().len(),
+                )
+            })
+            .collect();
+        v.sort();
+        v
+    }
+
+    async fn read_file(mount: &impl FsMount, path: &[&str], subj: &Subject) -> Vec<u8> {
+        let mut fid = mount.walk(path, subj).await.unwrap();
+        mount.open(&mut fid, OREAD, subj).await.unwrap();
+        let data = mount.read(&fid, 0, 1 << 20, subj).await.unwrap();
+        mount.clunk(fid, subj).await;
+        data
+    }
+
+    #[tokio::test]
+    async fn reads_from_rafs_lower_and_copies_up_on_write() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (bootstrap, blobs_dir) = build_image(
+            tmp.path(),
+            &[&[
+                ("etc/hostname", b"worker\n"),
+                ("etc/config", b"v1\n"),
+                ("usr/bin/app", b"#!/bin/sh\necho hi\n"),
+            ]],
+        );
+
+        // Filecache writes into the blobs dir on first chunk read; snapshot the
+        // RAFS *data blobs* (the immutable image content) by name+len. The
+        // filecache materialises sidecar files (different names), so we assert
+        // the original blobs are byte-for-byte unchanged rather than that the
+        // directory is frozen.
+        let before = blobs_snapshot(&blobs_dir);
+
+        let sandbox = tmp.path().join("sandbox-1");
+        let mount = rootfs_mount_for(&bootstrap, &blobs_dir, "img:test", &sandbox).unwrap();
+        let subj = Subject::new("test");
+
+        // 1. Read a file present only in the RAFS lower.
+        let hostname = read_file(&mount, &["etc", "hostname"], &subj).await;
+        assert_eq!(hostname, b"worker\n", "must read through to RAFS lower");
+
+        // 2. Write a brand-new file -> lands in the writable upper.
+        let new_path = ["etc", "greeting"];
+        mount.create(&new_path, 0o644, &subj).await.unwrap();
+        let mut fid = mount.walk(&new_path, &subj).await.unwrap();
+        mount.open(&mut fid, ORDWR, &subj).await.unwrap();
+        let n = mount.write(&fid, 0, b"hello\n", &subj).await.unwrap();
+        assert_eq!(n, 6);
+        mount.clunk(fid, &subj).await;
+
+        // The new file is visible through the overlay...
+        let greeting = read_file(&mount, &new_path, &subj).await;
+        assert_eq!(greeting, b"hello\n");
+        // ...and physically present in the sandbox upper.
+        let upper_file = sandbox
+            .join(ROOTFS_SUBDIR)
+            .join(UPPER_SUBDIR)
+            .join("etc")
+            .join("greeting");
+        assert!(upper_file.exists(), "new file must copy-up into the upper");
+        assert_eq!(std::fs::read(&upper_file).unwrap(), b"hello\n");
+
+        // 3. Overwrite a file that exists in the lower -> copy-up, lower intact.
+        let cfg_path = ["etc", "config"];
+        let mut fid = mount.walk(&cfg_path, &subj).await.unwrap();
+        mount.open(&mut fid, ORDWR, &subj).await.unwrap();
+        mount.write(&fid, 0, b"v2\n", &subj).await.unwrap();
+        mount.clunk(fid, &subj).await;
+        let cfg = read_file(&mount, &cfg_path, &subj).await;
+        assert_eq!(&cfg[..3], b"v2\n", "overwrite visible via overlay");
+        let upper_cfg = sandbox
+            .join(ROOTFS_SUBDIR)
+            .join(UPPER_SUBDIR)
+            .join("etc")
+            .join("config");
+        assert!(upper_cfg.exists(), "modified lower file must copy-up");
+
+        // 4. The RAFS image (data blobs) is untouched: every original blob is
+        // still present with its original length.
+        let after = blobs_snapshot(&blobs_dir);
+        for (name, len) in &before {
+            let found = after.iter().find(|(n, _)| n == name);
+            assert_eq!(
+                found,
+                Some(&(name.clone(), *len)),
+                "RAFS data blob {name} must be unchanged"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_bootstrap_is_fail_closed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let blobs = tmp.path().join("blobs");
+        std::fs::create_dir_all(&blobs).unwrap();
+        let bootstrap = tmp.path().join("nope.meta");
+        let sandbox = tmp.path().join("sandbox");
+        let err = rootfs_mount_for(&bootstrap, &blobs, "img:missing", &sandbox);
+        assert!(err.is_err(), "missing RAFS bootstrap must hard-error");
+    }
+}


### PR DESCRIPTION
## FS-B (#363) — RootfsMount = OverlayFs over in-process RAFS

Composes the two merged precursors into a per-sandbox rootfs mount:
- **FS-B0** (#371) — `build_rafs_bootstrap` + `store.bootstrap_path()` (real RAFS `.meta`).
- **FS-C** (#372) — `rootfs_overlay(upper, lowers)` (`OverlayFs` wrapped as an `FsMount` via the `FileSystem`→`Mount` up-adapter).

### Design

```
        RootfsMount  (FsMount)
             │
     OverlayFs  (FS-C rootfs_overlay — copy-up / whiteouts)
      ┌──────┴──────┐
   upper           lower
 <sandbox>/rootfs/  Rafs (in-process FileSystem, lazy chunk-CAS)
 {upper,work}/      bootstrap .meta + content-addressed data blobs
```

- **Lower = in-process RAFS.** The image's RAFS bootstrap is loaded as a `fuse_backend_rs::FileSystem` via `nydus_rafs::fs::Rafs::{new,import}` over a **localfs backend + filecache** rooted at the image store's blobs dir (RAFS v6 mandates a local blob cache). One hop, lazy chunk fetch preserved — **no external `nydusd`**, no FUSE mount, no shell-out.
- **Upper = per-sandbox writable dir** at `<sandbox_dir>/rootfs/upper/` (with `work/` sibling for OverlayFs scratch). All copy-ups and whiteouts land here; the shared image (bootstrap + data blobs) is never written.
- Composition delegated to FS-C's `rootfs_overlay` — we do **not** hand-roll CoW (the native hyprstream CoW engine remains the backlog ticket behind the same `FsMount` trait).

### Module / API

New module `crates/hyprstream-workers/src/image/rootfs_mount.rs`:

```rust
pub fn rootfs_mount_for(
    bootstrap_path: &Path,
    blobs_dir: &Path,
    image_id: &str,
    sandbox_dir: &Path,
) -> Result<impl FsMount>;

pub fn rootfs_mount_from_rafs(rafs: Rafs, upper: &Path, work: &Path)
    -> Result<FuseFileSystemMount<OverlayFs>>;

impl RafsStore {
    pub fn rootfs_mount(&self, image_id: &str, sandbox_dir: &Path) -> Result<impl FsMount>;
}
```

### vfs (FS-C surface) additions

- `overlay::layer_from_fs` + `BoxedLayer` re-export — lets a RAFS lower plug into `rootfs_overlay` without callers reaching into `fuse-backend-rs` overlay internals (`passthrough_layer` now reuses it; DRY).
- **`ZeroOpenLayer`** — the one real integration snag: RAFS is *handleless* (`open` returns `(None, KEEP_CACHE, _)`, reads address the inode), but `OverlayFs::open` rejects a `None` handle from a lower with **ENOENT**. `ZeroOpenLayer` wraps the read-only lower and presents a constant handle; reads still resolve by inode, and writes copy-up to the (handle-based) upper. The overlay stays in its normal Kata/production handle mode — no `no_open` reconfiguration, up-adapter unchanged.

### Dependency unification

`nydus-rafs` (v2.4.0) builds against `fuse-backend-rs` **0.13.1**, while `hyprstream-vfs`/`-workers` pinned **0.12** — so RAFS's `Layer` was a *different type* from vfs's `BoxedLayer` and could not be passed in. Bumped both crates to `0.13` to unify the tree. The `OverlayFs`/`PassthroughFs`/`FileSystem` APIs used here are byte-identical between 0.12.1 and 0.13.1.

### Tests

`image::rootfs_mount::tests`:
- **RAFS-lower read** — read a file present only in the RAFS image through the overlay.
- **copy-up** — create a new file and overwrite a lower file; assert both land physically in `<sandbox>/rootfs/upper/` and are visible through the overlay.
- **image untouched** — original RAFS data blobs unchanged (byte-for-byte) after writes.
- **fail-closed** — missing bootstrap hard-errors.

FS-C overlay tests (passthrough layers) and FS-B0 builder tests still pass; `cargo clippy -p hyprstream-vfs -p hyprstream-workers --all-targets -D warnings` is clean.

### Scope guardrails

Did **not** touch `kata_backend.rs`, create the FS-A server crate, or build FS-D integration (compose-into-Namespace + serve + VM-attach). This PR produces the rootfs mount only.

Closes #363
Part of #341