### PR TITLE
feat: FS-A — VFS→vhost-user-fs down-adapter + CH ShareFs attach (#362)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1315,7 +1315,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -3805,7 +3805,7 @@ dependencies = [
  "thiserror 1.0.69",
  "vfio-bindings 0.3.1",
  "vfio-ioctls",
- "virtio-queue",
+ "virtio-queue 0.7.1",
  "vm-memory 0.10.0",
  "vmm-sys-util 0.11.2",
 ]
@@ -3881,9 +3881,9 @@ dependencies = [
  "thiserror 1.0.69",
  "threadpool",
  "timerfd",
- "vhost",
- "virtio-bindings",
- "virtio-queue",
+ "vhost 0.6.1",
+ "virtio-bindings 0.1.0",
+ "virtio-queue 0.7.1",
  "vm-memory 0.10.0",
  "vmm-sys-util 0.11.2",
 ]
@@ -4320,7 +4320,7 @@ dependencies = [
  "tracing",
  "vfio-bindings 0.3.1",
  "vfio-ioctls",
- "virtio-queue",
+ "virtio-queue 0.7.1",
  "vm-memory 0.10.0",
  "vmm-sys-util 0.11.2",
 ]
@@ -5105,7 +5105,7 @@ dependencies = [
  "log",
  "mio 0.8.11",
  "nix 0.24.3",
- "virtio-queue",
+ "virtio-queue 0.7.1",
  "vm-memory 0.10.0",
  "vmm-sys-util 0.11.2",
 ]
@@ -5129,6 +5129,7 @@ dependencies = [
  "radix_trie",
  "versionize",
  "versionize_derive",
+ "virtio-queue 0.12.0",
  "vm-memory 0.14.1",
  "vmm-sys-util 0.12.1",
 ]
@@ -6331,7 +6332,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "system-configuration 0.6.1",
  "tokio",
  "tower-service",
@@ -6874,6 +6875,26 @@ dependencies = [
  "parking_lot 0.12.4",
  "tempfile",
  "tokio",
+]
+
+[[package]]
+name = "hyprstream-vfs-server"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "fuse-backend-rs 0.13.1",
+ "hyprstream-rpc",
+ "hyprstream-vfs",
+ "libc",
+ "parking_lot 0.12.4",
+ "tokio",
+ "tracing",
+ "vhost 0.11.0",
+ "vhost-user-backend",
+ "virtio-bindings 0.2.7",
+ "virtio-queue 0.12.0",
+ "vm-memory 0.14.1",
+ "vmm-sys-util 0.12.1",
 ]
 
 [[package]]
@@ -9603,7 +9624,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash",
  "rustls 0.23.40",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
@@ -9646,7 +9667,7 @@ checksum = "78633d1fe1bde91d12bcabb230ac9edb890857414c6d44f3212e0d309525b5ff"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tracing",
  "windows-sys 0.61.0",
 ]
@@ -12273,7 +12294,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.40",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -12312,7 +12333,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -16251,7 +16272,7 @@ dependencies = [
  "log",
  "thiserror 2.0.17",
  "vfio-bindings 0.6.1",
- "vm-memory 0.10.0",
+ "vm-memory 0.14.1",
  "vmm-sys-util 0.15.0",
 ]
 
@@ -16268,10 +16289,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "vhost"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6be08d1166d41a78861ad50212ab3f9eca0729c349ac3a7a8f557c62406b87cc"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "vm-memory 0.14.1",
+ "vmm-sys-util 0.12.1",
+]
+
+[[package]]
+name = "vhost-user-backend"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f0ffb1dd8e00a708a0e2c32d5efec5812953819888591fff9ff68236b8a5096"
+dependencies = [
+ "libc",
+ "log",
+ "vhost 0.11.0",
+ "virtio-bindings 0.2.7",
+ "virtio-queue 0.12.0",
+ "vm-memory 0.14.1",
+ "vmm-sys-util 0.12.1",
+]
+
+[[package]]
 name = "virtio-bindings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff512178285488516ed85f15b5d0113a7cdb89e9e8a760b269ae4f02b84bd6b"
+
+[[package]]
+name = "virtio-bindings"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091f1f09cfbf2a78563b562e7a949465cce1aef63b6065645188d995162f8868"
 
 [[package]]
 name = "virtio-queue"
@@ -16280,9 +16334,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ba81e2bcc21c0d2fc5e6683e79367e26ad219197423a498df801d79d5ba77bd"
 dependencies = [
  "log",
- "virtio-bindings",
+ "virtio-bindings 0.1.0",
  "vm-memory 0.10.0",
  "vmm-sys-util 0.11.2",
+]
+
+[[package]]
+name = "virtio-queue"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07d8406e7250c934462de585d8f2d2781c31819bca1fbb7c5e964ca6bbaabfe8"
+dependencies = [
+ "log",
+ "virtio-bindings 0.2.7",
+ "vm-memory 0.14.1",
+ "vmm-sys-util 0.12.1",
 ]
 
 [[package]]
@@ -16308,6 +16374,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3aba5064cc5f6f7740cddc8dae34d2d9a311cac69b60d942af7f3ab8fc49f4"
 dependencies = [
+ "arc-swap",
  "libc",
  "thiserror 1.0.69",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/hyprstream-compositor",
     "crates/hyprstream-tui",
     "crates/hyprstream-vfs",
+    "crates/hyprstream-vfs-server",
     "crates/hyprstream-tcl",
     "crates/chat-core",
     "crates/hyprstream-rpc-std",

--- a/crates/hyprstream-vfs-server/Cargo.toml
+++ b/crates/hyprstream-vfs-server/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "hyprstream-vfs-server"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+description = "vhost-user-fs server exposing a hyprstream VFS Namespace to a Cloud Hypervisor guest (FS-A, #362)"
+
+# Native-only (Linux): vhost-user-fs + fuse-backend-rs virtio transport are not
+# available on wasm, and the crate's purpose is serving a VMM.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+hyprstream-vfs = { path = "../hyprstream-vfs" }
+hyprstream-rpc = { path = "../hyprstream-rpc" }
+
+# FUSE protocol engine + virtio transport. `virtiofs` gives the Server, Reader,
+# VirtioFsWriter/Writer; we do not need `fusedev` (kernel /dev/fuse) nor the DAX
+# `vhost-user-fs` feature (no shared-memory window).
+fuse-backend-rs = { version = "0.13", default-features = false, features = ["virtiofs"] }
+
+# vhost-user transport: hosts the FUSE Server over a Unix socket to CH. Versions
+# pinned to match fuse-backend-rs 0.13.1 (vhost 0.11 / vm-memory 0.14.1 /
+# virtio-queue 0.12 / vmm-sys-util 0.12.1) so the GuestMemory/DescriptorChain
+# types unify.
+vhost = { version = "0.11", features = ["vhost-user-backend"] }
+vhost-user-backend = "0.15"
+vm-memory = { version = "0.14.1", features = ["backend-mmap", "backend-atomic"] }
+virtio-queue = "0.12"
+virtio-bindings = "0.2"
+vmm-sys-util = "0.12.1"
+
+libc = { workspace = true }
+parking_lot = { workspace = true }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync"] }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync"] }
+async-trait = "0.1"

--- a/crates/hyprstream-vfs-server/src/filesystem.rs
+++ b/crates/hyprstream-vfs-server/src/filesystem.rs
@@ -1,0 +1,787 @@
+//! `Namespace → FileSystem` **down-adapter** (native only).
+//!
+//! This is the inverse of FS-C's [`FuseFileSystemMount`](hyprstream_vfs::FuseFileSystemMount)
+//! up-adapter. Where the up-adapter exposes a `fuse_backend_rs` `FileSystem`
+//! (RAFS / OverlayFs / Passthrough) *as* a VFS [`Mount`], this adapter exposes a
+//! whole VFS [`Namespace`] *as* a `fuse_backend_rs`
+//! [`FileSystem`](fuse_backend_rs::api::filesystem::FileSystem) — so the
+//! namespace can be served over vhost-user-fs to a Cloud Hypervisor guest (see
+//! [`crate::server`]).
+//!
+//! ## Path model
+//!
+//! `FileSystem` is inode/handle addressed; the VFS is path addressed. The
+//! [`InodeTable`](crate::inode::InodeTable) owns the translation: inode `1`
+//! (`FUSE_ROOT_ID`) is the namespace root, every other inode is interned lazily
+//! on `lookup`/`create`/`mkdir` and reference counted so `forget` reclaims it.
+//! [`HandleTable`](crate::inode::HandleTable) holds the VFS [`Fid`] for each open
+//! file/dir.
+//!
+//! ## Routing
+//!
+//! A path resolves through [`Namespace::resolve_targets`] to the ordered mount
+//! targets (bind order) plus the components relative to the mount root. Read
+//! ops (`open`/`read`/`opendir`/`readdir`) drive the base [`Mount`] surface,
+//! trying each target in bind order until one succeeds — the same union /
+//! fallthrough policy the namespace's own `cat`/`ls` helpers use. Mutating ops
+//! (`create`/`unlink`/`mkdir`/`rmdir`/`rename`/`setattr`/`symlink`/`link`)
+//! require the writable [`FsMount`] capability, reached via
+//! [`Mount::as_fsmount`]; a target that is a plain `Mount` (synthetic, ctl,
+//! stream mounts) is **read-only** and such ops return `EROFS` — fail-closed,
+//! never a silent no-op. Paths the namespace spans only implicitly (intermediate
+//! directories, e.g. `/srv` when only `/srv/model` is mounted) are served as
+//! synthetic read-only directories.
+//!
+//! ## Subject threading
+//!
+//! Every VFS call carries the verified [`Subject`] the server was constructed
+//! with — the uniform Subject-per-call policy/audit boundary (#353/#319/#328)
+//! extended across the guest filesystem. The FUSE [`Context`] (host uid/gid) is
+//! *not* the identity; the `Subject` is.
+//!
+//! ## async → sync bridge
+//!
+//! `FileSystem` is synchronous; the VFS `Mount`/`FsMount` ops are `async`. We
+//! bridge with a tokio runtime [`Handle`], running each op on it via
+//! [`Handle::block_on`]. The server's vring threads are plain OS threads (not
+//! tokio workers), so blocking on a multi-thread runtime handle is safe and does
+//! not stall the async executor.
+//!
+//! ## Send + Sync
+//!
+//! Genuinely `Send + Sync`: all state is `Arc`/`Mutex`-guarded and the wrapped
+//! `Namespace` is `Send + Sync`. No wasm `unsafe impl Send` — the crate is
+//! native-only.
+
+use std::ffi::CStr;
+use std::io;
+use std::time::Duration;
+
+use fuse_backend_rs::abi::fuse_abi::CreateIn;
+use fuse_backend_rs::api::filesystem::{
+    Context, DirEntry as FuseDirEntry, Entry, FileSystem, FsOptions, GetxattrReply, ListxattrReply,
+    OpenOptions, SetattrValid, ZeroCopyReader, ZeroCopyWriter,
+};
+use tokio::runtime::Handle;
+
+use hyprstream_vfs::{
+    DirEntry, MountError, MountTarget, Namespace, SetAttr, Subject, ORDWR, OWRITE,
+};
+
+use crate::inode::{HandleTable, InodeData, InodeTable, Kind, OpenFid, ROOT_INODE};
+
+/// Attribute / entry validity timeout handed to the guest kernel.
+const TTL: Duration = Duration::from_secs(1);
+/// Block size reported in `stat`.
+const BLOCK_SIZE: u32 = 512;
+
+/// Map a [`MountError`] to the `errno` the guest kernel expects.
+fn errno(err: &MountError) -> i32 {
+    match err {
+        MountError::NotFound(_) => libc::ENOENT,
+        MountError::PermissionDenied(_) => libc::EACCES,
+        MountError::NotDirectory(_) => libc::ENOTDIR,
+        MountError::IsDirectory(_) => libc::EISDIR,
+        MountError::InvalidArgument(_) => libc::EINVAL,
+        MountError::NotSupported(_) => libc::ENOSYS,
+        MountError::AlreadyExists(_) => libc::EEXIST,
+        MountError::Io(_) => libc::EIO,
+    }
+}
+
+fn io_err(err: &MountError) -> io::Error {
+    io::Error::from_raw_os_error(errno(err))
+}
+
+fn einval() -> io::Error {
+    io::Error::from_raw_os_error(libc::EINVAL)
+}
+
+fn erofs() -> io::Error {
+    io::Error::from_raw_os_error(libc::EROFS)
+}
+
+/// The down-adapter: a `fuse_backend_rs` [`FileSystem`] over a VFS [`Namespace`].
+pub struct VfsFileSystem {
+    ns: Namespace,
+    subject: Subject,
+    inodes: InodeTable,
+    handles: HandleTable,
+    rt: Handle,
+}
+
+impl VfsFileSystem {
+    /// Wrap `ns`, serving every op as `subject`, bridging async ops onto `rt`.
+    pub fn new(ns: Namespace, subject: Subject, rt: Handle) -> Self {
+        Self {
+            ns,
+            subject,
+            inodes: InodeTable::new(),
+            handles: HandleTable::new(),
+            rt,
+        }
+    }
+
+    /// Borrow the wrapped namespace (e.g. for FS-D to inspect mounts).
+    pub fn namespace(&self) -> &Namespace {
+        &self.ns
+    }
+
+    /// Run an async VFS future to completion on the adapter's runtime.
+    fn block<F: std::future::Future>(&self, fut: F) -> F::Output {
+        self.rt.block_on(fut)
+    }
+
+    /// The `/`-joined absolute path for an inode (for routing through the
+    /// namespace, which is string-prefix addressed at its public surface).
+    fn abs_path(components: &[String]) -> String {
+        if components.is_empty() {
+            "/".to_owned()
+        } else {
+            format!("/{}", components.join("/"))
+        }
+    }
+
+    /// Resolve `inode` → its [`InodeData`], or `ENOENT`.
+    fn inode_data(&self, inode: u64) -> io::Result<InodeData> {
+        self.inodes
+            .get(inode)
+            .ok_or_else(|| io::Error::from_raw_os_error(libc::ENOENT))
+    }
+
+    /// Resolve the child path components of `parent` + `name`.
+    fn child_components(&self, parent: u64, name: &CStr) -> io::Result<Vec<String>> {
+        let parent = self.inode_data(parent)?;
+        let name = name.to_str().map_err(|_| einval())?;
+        if name.is_empty() || name == "." || name.contains('/') {
+            return Err(einval());
+        }
+        let mut comps = parent.components.clone();
+        comps.push(name.to_owned());
+        Ok(comps)
+    }
+
+    /// Route a path to its mount targets (bind order) + mount-relative
+    /// components. Maps a namespace miss to `ENOENT`.
+    fn route(&self, components: &[String]) -> io::Result<(Vec<MountTarget>, Vec<String>)> {
+        let path = Self::abs_path(components);
+        self.ns
+            .resolve_targets(&path)
+            .map_err(|_| io::Error::from_raw_os_error(libc::ENOENT))
+    }
+
+    /// Stat a path through the namespace, trying each target in bind order.
+    /// Returns the VFS [`hyprstream_vfs::Stat`] plus whether it is a directory.
+    fn stat_path(&self, components: &[String]) -> io::Result<(hyprstream_vfs::Stat, bool)> {
+        // Intermediate (implicitly-spanned) directories: no backing mount, but
+        // the namespace knows they exist as ancestors of real mounts.
+        let path = Self::abs_path(components);
+        if self.ns.intermediate_children(&path).is_some() {
+            return Ok((
+                hyprstream_vfs::Stat {
+                    qtype: 0x80,
+                    size: 0,
+                    name: components.last().cloned().unwrap_or_default(),
+                    mtime: 0,
+                },
+                true,
+            ));
+        }
+
+        let (targets, comps) = self.route(components)?;
+        // A path that resolves to a mount root (no components left after the
+        // prefix) is the mount point itself — always a directory. Don't require
+        // the backing mount to stat its own root.
+        if comps.is_empty() {
+            return Ok((
+                hyprstream_vfs::Stat {
+                    qtype: 0x80,
+                    size: 0,
+                    name: components.last().cloned().unwrap_or_default(),
+                    mtime: 0,
+                },
+                true,
+            ));
+        }
+        let comp_refs: Vec<&str> = comps.iter().map(String::as_str).collect();
+        let mut last = MountError::NotFound(path.clone());
+        for mount in &targets {
+            let res = self.block(async {
+                let fid = mount.walk(&comp_refs, &self.subject).await?;
+                let st = mount.stat(&fid, &self.subject).await;
+                mount.clunk(fid, &self.subject).await;
+                st
+            });
+            match res {
+                Ok(st) => {
+                    let is_dir = st.qtype & 0x80 != 0;
+                    return Ok((st, is_dir));
+                }
+                Err(e) => last = e,
+            }
+        }
+        Err(io_err(&last))
+    }
+
+    /// Synthesise a `libc::stat64` for an inode from a VFS stat + kind.
+    fn fill_attr(inode: u64, st: &hyprstream_vfs::Stat, kind: Kind) -> libc::stat64 {
+        // SAFETY: `stat64` is plain old data; zeroing is a valid initial value.
+        let mut attr: libc::stat64 = unsafe { std::mem::zeroed() };
+        attr.st_ino = inode;
+        attr.st_size = st.size as i64;
+        attr.st_blksize = BLOCK_SIZE as i64;
+        attr.st_blocks = st.size.div_ceil(BLOCK_SIZE as u64) as i64;
+        attr.st_nlink = 1;
+        let (typ, perm) = match kind {
+            Kind::Dir => (libc::S_IFDIR, 0o755),
+            Kind::File => (libc::S_IFREG, 0o644),
+            Kind::Symlink => (libc::S_IFLNK, 0o777),
+        };
+        attr.st_mode = typ | perm;
+        attr.st_mtime = st.mtime as i64;
+        attr.st_ctime = st.mtime as i64;
+        attr.st_atime = st.mtime as i64;
+        attr
+    }
+
+    /// Build a FUSE [`Entry`] for `inode`/`kind`/`stat`.
+    fn make_entry(&self, inode: u64, kind: Kind, st: &hyprstream_vfs::Stat) -> Entry {
+        Entry {
+            inode,
+            generation: 0,
+            attr: Self::fill_attr(inode, st, kind),
+            attr_flags: 0,
+            attr_timeout: TTL,
+            entry_timeout: TTL,
+        }
+    }
+
+    /// Resolve the writable [`FsMount`] for a path, or `EROFS` if no target at
+    /// the path is a full filesystem. Returns the mount plus mount-relative
+    /// components. (Mutations don't union: the first FsMount target wins.)
+    fn route_writable(
+        &self,
+        components: &[String],
+    ) -> io::Result<(MountTarget, Vec<String>)> {
+        let (targets, comps) = self.route(components)?;
+        for mount in targets {
+            if mount.as_fsmount().is_some() {
+                return Ok((mount, comps));
+            }
+        }
+        Err(erofs())
+    }
+
+}
+
+impl FileSystem for VfsFileSystem {
+    type Inode = u64;
+    type Handle = u64;
+
+    fn init(&self, _capable: FsOptions) -> io::Result<FsOptions> {
+        // We negotiate no special capabilities; the default option set is fine.
+        Ok(FsOptions::empty())
+    }
+
+    fn lookup(&self, _ctx: &Context, parent: Self::Inode, name: &CStr) -> io::Result<Entry> {
+        let components = self.child_components(parent, name)?;
+        let (st, is_dir) = self.stat_path(&components)?;
+        let kind = if is_dir { Kind::Dir } else { Kind::File };
+        let inode = self.inodes.intern(components, kind);
+        Ok(self.make_entry(inode, kind, &st))
+    }
+
+    fn forget(&self, _ctx: &Context, inode: Self::Inode, count: u64) {
+        self.inodes.forget(inode, count);
+    }
+
+    fn batch_forget(&self, _ctx: &Context, requests: Vec<(Self::Inode, u64)>) {
+        for (inode, count) in requests {
+            self.inodes.forget(inode, count);
+        }
+    }
+
+    fn getattr(
+        &self,
+        _ctx: &Context,
+        inode: Self::Inode,
+        _handle: Option<Self::Handle>,
+    ) -> io::Result<(libc::stat64, Duration)> {
+        let data = self.inode_data(inode)?;
+        if inode == ROOT_INODE {
+            let st = hyprstream_vfs::Stat { qtype: 0x80, size: 0, name: String::new(), mtime: 0 };
+            return Ok((Self::fill_attr(inode, &st, Kind::Dir), TTL));
+        }
+        let (st, is_dir) = self.stat_path(&data.components)?;
+        let kind = if is_dir { Kind::Dir } else { data.kind };
+        Ok((Self::fill_attr(inode, &st, kind), TTL))
+    }
+
+    fn opendir(
+        &self,
+        _ctx: &Context,
+        inode: Self::Inode,
+        _flags: u32,
+    ) -> io::Result<(Option<Self::Handle>, OpenOptions)> {
+        let data = self.inode_data(inode)?;
+        // Root and intermediate directories have no backing mount fid; serve them
+        // synthetically (handle 0 ⇒ no stored fid).
+        let path = Self::abs_path(&data.components);
+        if inode == ROOT_INODE || self.ns.intermediate_children(&path).is_some() {
+            return Ok((Some(0), OpenOptions::empty()));
+        }
+        let (targets, comps) = self.route(&data.components)?;
+        // Mount-root directories are served synthetically (readdir merges via the
+        // namespace `ls`, which unions all targets); no backing dir fid needed.
+        if comps.is_empty() {
+            return Ok((Some(0), OpenOptions::empty()));
+        }
+        let comp_refs: Vec<&str> = comps.iter().map(String::as_str).collect();
+        let mut last = MountError::NotFound(path);
+        for mount in &targets {
+            let res = self.block(async {
+                let mut fid = mount.walk(&comp_refs, &self.subject).await?;
+                mount.open(&mut fid, 0, &self.subject).await?;
+                Ok::<_, MountError>(fid)
+            });
+            match res {
+                Ok(fid) => {
+                    let handle = self.handles.insert(OpenFid {
+                        mount: mount.clone(),
+                        fid,
+                    });
+                    return Ok((Some(handle), OpenOptions::empty()));
+                }
+                Err(e) => last = e,
+            }
+        }
+        Err(io_err(&last))
+    }
+
+    fn readdir(
+        &self,
+        _ctx: &Context,
+        inode: Self::Inode,
+        _handle: Self::Handle,
+        _size: u32,
+        offset: u64,
+        add_entry: &mut dyn FnMut(FuseDirEntry) -> io::Result<usize>,
+    ) -> io::Result<()> {
+        let data = self.inode_data(inode)?;
+        let path = Self::abs_path(&data.components);
+        // Merge real mount entries with any synthetic (intermediate) children,
+        // matching the namespace's own union-readdir semantics.
+        let entries: Vec<DirEntry> = self
+            .block(self.ns.ls(&path, &self.subject))
+            .map_err(|_| io::Error::from_raw_os_error(libc::ENOENT))?;
+
+        // `.`/`..` first, then entries, honouring the offset cursor.
+        let mut all: Vec<(String, bool, u64)> =
+            vec![(".".to_owned(), true, inode), ("..".to_owned(), true, ROOT_INODE)];
+        for e in entries {
+            // Intern child inodes so a subsequent lookup is stable.
+            let mut comps = data.components.clone();
+            comps.push(e.name.clone());
+            let kind = if e.is_dir { Kind::Dir } else { Kind::File };
+            let child = self.inodes.intern(comps, kind);
+            all.push((e.name, e.is_dir, child));
+        }
+
+        for (idx, (name, is_dir, ino)) in all.into_iter().enumerate().skip(offset as usize) {
+            let typ = if is_dir { libc::DT_DIR } else { libc::DT_REG } as u32;
+            let written = add_entry(FuseDirEntry {
+                ino,
+                offset: idx as u64 + 1,
+                type_: typ,
+                name: name.as_bytes(),
+            })?;
+            if written == 0 {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    fn releasedir(
+        &self,
+        _ctx: &Context,
+        _inode: Self::Inode,
+        _flags: u32,
+        handle: Self::Handle,
+    ) -> io::Result<()> {
+        if handle != 0 {
+            if let Some(open) = self.handles.remove(handle) {
+                self.block(open.mount.clunk(open.fid, &self.subject));
+            }
+        }
+        Ok(())
+    }
+
+    fn open(
+        &self,
+        _ctx: &Context,
+        inode: Self::Inode,
+        flags: u32,
+        _fuse_flags: u32,
+    ) -> io::Result<(Option<Self::Handle>, OpenOptions, Option<u32>)> {
+        let data = self.inode_data(inode)?;
+        let mode = match flags & libc::O_ACCMODE as u32 {
+            x if x == libc::O_WRONLY as u32 => OWRITE,
+            x if x == libc::O_RDWR as u32 => ORDWR,
+            _ => 0, // OREAD
+        };
+        let (targets, comps) = self.route(&data.components)?;
+        let comp_refs: Vec<&str> = comps.iter().map(String::as_str).collect();
+        let mut last = MountError::NotFound(Self::abs_path(&data.components));
+        for mount in &targets {
+            // A write open against a read-only (non-FsMount) target fails closed.
+            if mode != 0 && mount.as_fsmount().is_none() {
+                last = MountError::PermissionDenied("read-only mount".into());
+                continue;
+            }
+            let res = self.block(async {
+                let mut fid = mount.walk(&comp_refs, &self.subject).await?;
+                mount.open(&mut fid, mode, &self.subject).await?;
+                Ok::<_, MountError>(fid)
+            });
+            match res {
+                Ok(fid) => {
+                    let handle = self.handles.insert(OpenFid {
+                        mount: mount.clone(),
+                        fid,
+                    });
+                    return Ok((Some(handle), OpenOptions::empty(), None));
+                }
+                Err(e) => last = e,
+            }
+        }
+        if mode != 0 {
+            Err(erofs())
+        } else {
+            Err(io_err(&last))
+        }
+    }
+
+    fn read(
+        &self,
+        _ctx: &Context,
+        _inode: Self::Inode,
+        handle: Self::Handle,
+        w: &mut dyn ZeroCopyWriter,
+        size: u32,
+        offset: u64,
+        _lock_owner: Option<u64>,
+        _flags: u32,
+    ) -> io::Result<usize> {
+        // Take the open fid out for the await, then return it.
+        let open = self.handles.take(handle).ok_or_else(einval)?;
+        let res = self.block(open.mount.read(&open.fid, offset, size, &self.subject));
+        self.handles.put(handle, open);
+        let data = res.map_err(|e| io_err(&e))?;
+        w.write_all(&data)?;
+        Ok(data.len())
+    }
+
+    fn write(
+        &self,
+        _ctx: &Context,
+        _inode: Self::Inode,
+        handle: Self::Handle,
+        r: &mut dyn ZeroCopyReader,
+        size: u32,
+        offset: u64,
+        _lock_owner: Option<u64>,
+        _delayed_write: bool,
+        _flags: u32,
+        _fuse_flags: u32,
+    ) -> io::Result<usize> {
+        // Stage the incoming bytes into a heap buffer (the VFS write API is
+        // buffer-based), then forward to the mount.
+        let mut buf = vec![0u8; size as usize];
+        let mut filled = 0;
+        while filled < buf.len() {
+            let n = r.read(&mut buf[filled..])?;
+            if n == 0 {
+                break;
+            }
+            filled += n;
+        }
+        buf.truncate(filled);
+
+        let open = self.handles.take(handle).ok_or_else(einval)?;
+        let res = self.block(open.mount.write(&open.fid, offset, &buf, &self.subject));
+        self.handles.put(handle, open);
+        let n = res.map_err(|e| io_err(&e))?;
+        Ok(n as usize)
+    }
+
+    fn release(
+        &self,
+        _ctx: &Context,
+        _inode: Self::Inode,
+        _flags: u32,
+        handle: Self::Handle,
+        _flush: bool,
+        _flock_release: bool,
+        _lock_owner: Option<u64>,
+    ) -> io::Result<()> {
+        if let Some(open) = self.handles.remove(handle) {
+            self.block(open.mount.clunk(open.fid, &self.subject));
+        }
+        Ok(())
+    }
+
+    fn create(
+        &self,
+        _ctx: &Context,
+        parent: Self::Inode,
+        name: &CStr,
+        args: CreateIn,
+    ) -> io::Result<(Entry, Option<Self::Handle>, OpenOptions, Option<u32>)> {
+        let components = self.child_components(parent, name)?;
+        let (mount, comps) = self.route_writable(&components)?;
+        let comp_refs: Vec<&str> = comps.iter().map(String::as_str).collect();
+        let mode = args.mode & 0o7777;
+        // Create, then re-open for writing on the same mount.
+        let fid = self.block(async {
+            let fs = mount.as_fsmount().ok_or(erofs())?;
+            fs.create(&comp_refs, mode, &self.subject)
+                .await
+                .map_err(|e| io_err(&e))?;
+            let mut fid = mount.walk(&comp_refs, &self.subject).await.map_err(|e| io_err(&e))?;
+            mount
+                .open(&mut fid, OWRITE, &self.subject)
+                .await
+                .map_err(|e| io_err(&e))?;
+            Ok::<_, io::Error>(fid)
+        })?;
+        let (st, _) = self.stat_path(&components)?;
+        let inode = self.inodes.intern(components, Kind::File);
+        let entry = self.make_entry(inode, Kind::File, &st);
+        let handle = self.handles.insert(OpenFid { mount, fid });
+        Ok((entry, Some(handle), OpenOptions::empty(), None))
+    }
+
+    fn unlink(&self, _ctx: &Context, parent: Self::Inode, name: &CStr) -> io::Result<()> {
+        let components = self.child_components(parent, name)?;
+        let (mount, comps) = self.route_writable(&components)?;
+        let comp_refs: Vec<&str> = comps.iter().map(String::as_str).collect();
+        let r = self.block(async {
+            mount
+                .as_fsmount()
+                .ok_or(erofs())?
+                .unlink(&comp_refs, &self.subject)
+                .await
+                .map_err(|e| io_err(&e))
+        });
+        if r.is_ok() {
+            self.inodes.invalidate_path(&components);
+        }
+        r
+    }
+
+    fn mkdir(
+        &self,
+        _ctx: &Context,
+        parent: Self::Inode,
+        name: &CStr,
+        mode: u32,
+        _umask: u32,
+    ) -> io::Result<Entry> {
+        let components = self.child_components(parent, name)?;
+        let (mount, comps) = self.route_writable(&components)?;
+        let comp_refs: Vec<&str> = comps.iter().map(String::as_str).collect();
+        self.block(async {
+            mount
+                .as_fsmount()
+                .ok_or(erofs())?
+                .mkdir(&comp_refs, mode & 0o7777, &self.subject)
+                .await
+                .map_err(|e| io_err(&e))
+        })?;
+        let (st, _) = self.stat_path(&components)?;
+        let inode = self.inodes.intern(components, Kind::Dir);
+        Ok(self.make_entry(inode, Kind::Dir, &st))
+    }
+
+    fn rmdir(&self, _ctx: &Context, parent: Self::Inode, name: &CStr) -> io::Result<()> {
+        let components = self.child_components(parent, name)?;
+        let (mount, comps) = self.route_writable(&components)?;
+        let comp_refs: Vec<&str> = comps.iter().map(String::as_str).collect();
+        let r = self.block(async {
+            mount
+                .as_fsmount()
+                .ok_or(erofs())?
+                .rmdir(&comp_refs, &self.subject)
+                .await
+                .map_err(|e| io_err(&e))
+        });
+        if r.is_ok() {
+            self.inodes.invalidate_path(&components);
+        }
+        r
+    }
+
+    fn rename(
+        &self,
+        _ctx: &Context,
+        olddir: Self::Inode,
+        oldname: &CStr,
+        newdir: Self::Inode,
+        newname: &CStr,
+        _flags: u32,
+    ) -> io::Result<()> {
+        let from = self.child_components(olddir, oldname)?;
+        let to = self.child_components(newdir, newname)?;
+        // Rename across distinct mounts is not supported (no cross-mount copy);
+        // require both endpoints to resolve to the same writable mount.
+        let (from_targets, from_comps) = self.route(&from)?;
+        let (to_targets, to_comps) = self.route(&to)?;
+        let from_fs = from_targets.iter().find(|m| m.as_fsmount().is_some());
+        let to_fs = to_targets.iter().find(|m| m.as_fsmount().is_some());
+        let (Some(from_fs), Some(to_fs)) = (from_fs, to_fs) else {
+            return Err(erofs());
+        };
+        if !std::sync::Arc::ptr_eq(from_fs, to_fs) {
+            return Err(io::Error::from_raw_os_error(libc::EXDEV));
+        }
+        let from_refs: Vec<&str> = from_comps.iter().map(String::as_str).collect();
+        let to_refs: Vec<&str> = to_comps.iter().map(String::as_str).collect();
+        let res = self.block(async {
+            let fs = from_fs.as_fsmount().ok_or(erofs())?;
+            fs.rename(&from_refs, &to_refs, &self.subject)
+                .await
+                .map_err(|e| io_err(&e))
+        });
+        if res.is_ok() {
+            self.inodes.invalidate_path(&from);
+            self.inodes.invalidate_path(&to);
+        }
+        res
+    }
+
+    fn setattr(
+        &self,
+        _ctx: &Context,
+        inode: Self::Inode,
+        attr: libc::stat64,
+        _handle: Option<Self::Handle>,
+        valid: SetattrValid,
+    ) -> io::Result<(libc::stat64, Duration)> {
+        let data = self.inode_data(inode)?;
+        let set = SetAttr {
+            mode: valid.contains(SetattrValid::MODE).then_some(attr.st_mode & 0o7777),
+            uid: valid.contains(SetattrValid::UID).then_some(attr.st_uid),
+            gid: valid.contains(SetattrValid::GID).then_some(attr.st_gid),
+            size: valid.contains(SetattrValid::SIZE).then_some(attr.st_size as u64),
+            atime: valid.contains(SetattrValid::ATIME).then_some(attr.st_atime as u64),
+            mtime: valid.contains(SetattrValid::MTIME).then_some(attr.st_mtime as u64),
+        };
+        let (mount, comps) = self.route_writable(&data.components)?;
+        let comp_refs: Vec<&str> = comps.iter().map(String::as_str).collect();
+        self.block(async {
+            mount
+                .as_fsmount()
+                .ok_or(erofs())?
+                .setattr(&comp_refs, &set, &self.subject)
+                .await
+                .map_err(|e| io_err(&e))
+        })?;
+        let (st, is_dir) = self.stat_path(&data.components)?;
+        let kind = if is_dir { Kind::Dir } else { data.kind };
+        Ok((Self::fill_attr(inode, &st, kind), TTL))
+    }
+
+    fn symlink(
+        &self,
+        _ctx: &Context,
+        linkname: &CStr,
+        parent: Self::Inode,
+        name: &CStr,
+    ) -> io::Result<Entry> {
+        let components = self.child_components(parent, name)?;
+        let target = linkname.to_str().map_err(|_| einval())?.to_owned();
+        let (mount, comps) = self.route_writable(&components)?;
+        let comp_refs: Vec<&str> = comps.iter().map(String::as_str).collect();
+        self.block(async {
+            mount
+                .as_fsmount()
+                .ok_or(erofs())?
+                .symlink(&comp_refs, &target, &self.subject)
+                .await
+                .map_err(|e| io_err(&e))
+        })?;
+        let (st, _) = self.stat_path(&components)?;
+        let inode = self.inodes.intern(components, Kind::Symlink);
+        Ok(self.make_entry(inode, Kind::Symlink, &st))
+    }
+
+    fn readlink(&self, _ctx: &Context, inode: Self::Inode) -> io::Result<Vec<u8>> {
+        let data = self.inode_data(inode)?;
+        let (mount, comps) = self.route_writable(&data.components)?;
+        let comp_refs: Vec<&str> = comps.iter().map(String::as_str).collect();
+        let target = self.block(async {
+            mount
+                .as_fsmount()
+                .ok_or(erofs())?
+                .readlink(&comp_refs, &self.subject)
+                .await
+                .map_err(|e| io_err(&e))
+        })?;
+        Ok(target.into_bytes())
+    }
+
+    fn link(
+        &self,
+        _ctx: &Context,
+        inode: Self::Inode,
+        newparent: Self::Inode,
+        newname: &CStr,
+    ) -> io::Result<Entry> {
+        let existing = self.inode_data(inode)?.components;
+        let new_path = self.child_components(newparent, newname)?;
+        // Hard links must stay within one writable mount.
+        let (ex_targets, ex_comps) = self.route(&existing)?;
+        let (new_targets, new_comps) = self.route(&new_path)?;
+        let ex_fs = ex_targets.iter().find(|m| m.as_fsmount().is_some());
+        let new_fs = new_targets.iter().find(|m| m.as_fsmount().is_some());
+        let (Some(ex_fs), Some(new_fs)) = (ex_fs, new_fs) else {
+            return Err(erofs());
+        };
+        if !std::sync::Arc::ptr_eq(ex_fs, new_fs) {
+            return Err(io::Error::from_raw_os_error(libc::EXDEV));
+        }
+        let ex_refs: Vec<&str> = ex_comps.iter().map(String::as_str).collect();
+        let new_refs: Vec<&str> = new_comps.iter().map(String::as_str).collect();
+        self.block(async {
+            let fs = ex_fs.as_fsmount().ok_or(erofs())?;
+            fs.link(&ex_refs, &new_refs, &self.subject)
+                .await
+                .map_err(|e| io_err(&e))
+        })?;
+        let (st, _) = self.stat_path(&new_path)?;
+        let new_inode = self.inodes.intern(new_path, Kind::File);
+        Ok(self.make_entry(new_inode, Kind::File, &st))
+    }
+
+    fn access(&self, _ctx: &Context, _inode: Self::Inode, _mask: u32) -> io::Result<()> {
+        // Access control is enforced at the Subject/policy boundary, not via the
+        // guest's POSIX mode bits; grant and let the mount op fail-close.
+        Ok(())
+    }
+
+    fn getxattr(
+        &self,
+        _ctx: &Context,
+        _inode: Self::Inode,
+        _name: &CStr,
+        _size: u32,
+    ) -> io::Result<GetxattrReply> {
+        Err(io::Error::from_raw_os_error(libc::ENODATA))
+    }
+
+    fn listxattr(&self, _ctx: &Context, _inode: Self::Inode, _size: u32) -> io::Result<ListxattrReply> {
+        Ok(ListxattrReply::Names(Vec::new()))
+    }
+}
+

--- a/crates/hyprstream-vfs-server/src/inode.rs
+++ b/crates/hyprstream-vfs-server/src/inode.rs
@@ -1,0 +1,222 @@
+//! Inode and handle tables for the `Namespace → FileSystem` down-adapter.
+//!
+//! `fuse_backend_rs::FileSystem` is inode/handle addressed: the guest kernel
+//! refers to files by an opaque `u64` inode (returned from `lookup`) and to open
+//! files/dirs by an opaque `u64` handle (returned from `open`/`opendir`). The
+//! VFS [`Namespace`](hyprstream_vfs::Namespace), by contrast, is **path
+//! addressed** — every op takes a component slice rooted at `/`. The two tables
+//! here own that translation:
+//!
+//! - [`InodeTable`] maps each live inode to its absolute VFS path (the component
+//!   vector) plus a kind (file / dir / symlink). The FUSE root (`FUSE_ROOT_ID`,
+//!   `1`) is the namespace root `/`. Inodes are allocated lazily on `lookup` and
+//!   reference-counted so `forget` can reclaim them (matching the kernel's
+//!   lookup-count contract).
+//! - [`HandleTable`] maps each open handle to the VFS [`Fid`] obtained from
+//!   `Mount::walk` + `Mount::open`, so subsequent `read`/`write`/`readdir`/
+//!   `release` can reach the same open object.
+//!
+//! Both tables are plain `Mutex`-guarded maps — genuinely `Send + Sync`, no wasm
+//! `unsafe impl`. The whole crate is native-only.
+
+use std::collections::HashMap;
+
+use parking_lot::Mutex;
+
+/// The FUSE root inode (`FUSE_ROOT_ID`). Maps to the namespace root `/`.
+pub const ROOT_INODE: u64 = 1;
+
+/// The kind of object an inode refers to. Drives the `st_mode` we synthesise and
+/// whether an open goes through the dir or file path.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Kind {
+    Dir,
+    File,
+    Symlink,
+}
+
+/// An inode's identity within the namespace: its absolute path components and
+/// kind. The path is stored as owned components (never a `/`-joined string) so
+/// it can be handed straight to the VFS `walk`/`FsMount` ops as a `&[&str]`.
+#[derive(Clone, Debug)]
+pub struct InodeData {
+    pub components: Vec<String>,
+    pub kind: Kind,
+    /// Lookup reference count (the kernel's `nlookup`). When it hits zero on
+    /// `forget`, the entry is evictable.
+    pub refcount: u64,
+}
+
+/// Inode allocation + path translation table.
+pub struct InodeTable {
+    /// inode → data.
+    by_inode: Mutex<HashMap<u64, InodeData>>,
+    /// `/`-joined path → inode, so repeated `lookup`s of the same path reuse the
+    /// inode (the kernel relies on a stable inode per path while referenced).
+    by_path: Mutex<HashMap<String, u64>>,
+    /// Next inode to hand out (root is 1, so we start at 2).
+    next: Mutex<u64>,
+}
+
+impl InodeTable {
+    /// Create a table pre-populated with the root inode mapped to `/`.
+    pub fn new() -> Self {
+        let mut by_inode = HashMap::new();
+        by_inode.insert(
+            ROOT_INODE,
+            InodeData {
+                components: Vec::new(),
+                kind: Kind::Dir,
+                // The root is never forgotten.
+                refcount: u64::MAX,
+            },
+        );
+        let mut by_path = HashMap::new();
+        by_path.insert(String::new(), ROOT_INODE);
+        Self {
+            by_inode: Mutex::new(by_inode),
+            by_path: Mutex::new(by_path),
+            next: Mutex::new(ROOT_INODE + 1),
+        }
+    }
+
+    fn key(components: &[String]) -> String {
+        components.join("/")
+    }
+
+    /// Look up the data for an inode (a clone, to avoid holding the lock).
+    pub fn get(&self, inode: u64) -> Option<InodeData> {
+        self.by_inode.lock().get(&inode).cloned()
+    }
+
+    /// Get-or-allocate an inode for `components`/`kind`, bumping its lookup
+    /// refcount. Returns the inode number. Used by `lookup`/`create`/`mkdir`.
+    pub fn intern(&self, components: Vec<String>, kind: Kind) -> u64 {
+        let key = Self::key(&components);
+        let mut by_path = self.by_path.lock();
+        let mut by_inode = self.by_inode.lock();
+        if let Some(&inode) = by_path.get(&key) {
+            if let Some(data) = by_inode.get_mut(&inode) {
+                data.refcount = data.refcount.saturating_add(1);
+                // A path can change kind (e.g. recreated as a different type);
+                // keep the latest observed kind.
+                data.kind = kind;
+            }
+            return inode;
+        }
+        let inode = {
+            let mut n = self.next.lock();
+            let i = *n;
+            *n += 1;
+            i
+        };
+        by_inode.insert(
+            inode,
+            InodeData {
+                components,
+                kind,
+                refcount: 1,
+            },
+        );
+        by_path.insert(key, inode);
+        inode
+    }
+
+    /// Drop `count` lookup references from `inode`; evict when the count reaches
+    /// zero (mirrors the FUSE `forget` contract). The root is never evicted.
+    pub fn forget(&self, inode: u64, count: u64) {
+        if inode == ROOT_INODE {
+            return;
+        }
+        let mut by_inode = self.by_inode.lock();
+        let evict = if let Some(data) = by_inode.get_mut(&inode) {
+            data.refcount = data.refcount.saturating_sub(count);
+            data.refcount == 0
+        } else {
+            false
+        };
+        if evict {
+            if let Some(data) = by_inode.remove(&inode) {
+                self.by_path.lock().remove(&Self::key(&data.components));
+            }
+        }
+    }
+
+    /// Forget a path's inode entirely (used after unlink/rmdir/rename so a stale
+    /// path no longer resolves to a live inode). No-op if not present.
+    pub fn invalidate_path(&self, components: &[String]) {
+        let key = Self::key(components);
+        if let Some(inode) = self.by_path.lock().remove(&key) {
+            self.by_inode.lock().remove(&inode);
+        }
+    }
+}
+
+impl Default for InodeTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// An open object: the VFS [`Fid`](hyprstream_vfs::Fid) plus the mount that
+/// produced it. A `Fid` is opaque to the adapter and does not record its owning
+/// mount, so we keep the `Arc<dyn Mount>` alongside it; `read`/`write`/`clunk`
+/// route back to that exact mount.
+pub struct OpenFid {
+    pub mount: hyprstream_vfs::MountTarget,
+    pub fid: hyprstream_vfs::Fid,
+}
+
+/// Open-handle table mapping `u64` handles to live [`OpenFid`]s.
+///
+/// [`hyprstream_vfs::Fid`] is `Send + Sync` but not `Clone`; we own it here for
+/// the lifetime of the open file. Because the async VFS ops borrow the fid across
+/// an await, the adapter [`take`](Self::take)s the `OpenFid` out, awaits, then
+/// [`put`](Self::put)s it back under the same handle.
+pub struct HandleTable {
+    handles: Mutex<HashMap<u64, OpenFid>>,
+    next: Mutex<u64>,
+}
+
+impl HandleTable {
+    pub fn new() -> Self {
+        Self {
+            handles: Mutex::new(HashMap::new()),
+            next: Mutex::new(1),
+        }
+    }
+
+    /// Store an open fid + its mount, returning the handle id.
+    pub fn insert(&self, open: OpenFid) -> u64 {
+        let handle = {
+            let mut n = self.next.lock();
+            let h = *n;
+            *n += 1;
+            h
+        };
+        self.handles.lock().insert(handle, open);
+        handle
+    }
+
+    /// Remove and return the open fid for `handle` (on `release`/`releasedir`).
+    pub fn remove(&self, handle: u64) -> Option<OpenFid> {
+        self.handles.lock().remove(&handle)
+    }
+
+    /// Temporarily take the open fid out so an `async` op can borrow it across an
+    /// await without holding the table lock. Pair with [`Self::put`].
+    pub fn take(&self, handle: u64) -> Option<OpenFid> {
+        self.handles.lock().remove(&handle)
+    }
+
+    /// Return an open fid taken via [`Self::take`] under the same handle id.
+    pub fn put(&self, handle: u64, open: OpenFid) {
+        self.handles.lock().insert(handle, open);
+    }
+}
+
+impl Default for HandleTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/hyprstream-vfs-server/src/lib.rs
+++ b/crates/hyprstream-vfs-server/src/lib.rs
@@ -1,0 +1,36 @@
+//! `hyprstream-vfs-server` — serve a hyprstream VFS [`Namespace`] to a Cloud
+//! Hypervisor guest over vhost-user-fs.
+//!
+//! This crate is the **down** half of the bidirectional `FileSystem ↔ Mount`
+//! bridge from the converged FS/VFS design (FS-A, #362). FS-C built the *up*
+//! adapter ([`hyprstream_vfs::FuseFileSystemMount`]) that exposes a
+//! `fuse_backend_rs` `FileSystem` (RAFS / OverlayFs / Passthrough) as a VFS
+//! [`Mount`](hyprstream_vfs::Mount). This crate builds the *down* adapter
+//! ([`VfsFileSystem`]) that exposes a whole VFS [`Namespace`](hyprstream_vfs::Namespace)
+//! as a `fuse_backend_rs` `FileSystem`, and wires `fuse_backend_rs`'s FUSE
+//! protocol engine to a vhost-user-fs server ([`serve`]) so Cloud Hypervisor can
+//! mount it as a virtio-fs share.
+//!
+//! ```text
+//! Cloud Hypervisor  (virtio-fs / vhost-user-fs device)
+//!   → vhost-user-backend       (Unix-socket transport + vring loop) — server.rs
+//!     → fuse_backend_rs::Server (FUSE protocol engine)
+//!       → VfsFileSystem         (Namespace → FileSystem down-adapter) — filesystem.rs
+//!         → Namespace mounts    (Mount read/write + FsMount writes, Subject-per-call)
+//! ```
+//!
+//! The crate is **native-only** (Linux): vhost-user-fs and `fuse_backend_rs`'s
+//! virtio transport are not available on wasm, and the whole point is serving a
+//! VMM. It is genuinely `Send + Sync` — no wasm `unsafe impl Send`.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+mod filesystem;
+mod inode;
+mod server;
+
+#[cfg(test)]
+mod tests;
+
+pub use filesystem::VfsFileSystem;
+pub use server::{serve, VfsBackend};

--- a/crates/hyprstream-vfs-server/src/server.rs
+++ b/crates/hyprstream-vfs-server/src/server.rs
@@ -1,0 +1,209 @@
+//! vhost-user-fs server: serves a [`VfsFileSystem`] over a Unix socket.
+//!
+//! `fuse_backend_rs` provides the FUSE protocol engine
+//! ([`Server`](fuse_backend_rs::api::server::Server) +
+//! [`Reader`](fuse_backend_rs::transport::Reader) /
+//! [`VirtioFsWriter`](fuse_backend_rs::transport::VirtioFsWriter)) but **not** a
+//! vhost-user transport — we host it with the `vhost-user-backend` crate, the
+//! same stacking production virtiofsd uses. Cloud Hypervisor connects to the
+//! socket; for each request descriptor chain we build a `Reader`/`Writer` over
+//! guest memory and call [`Server::handle_message`], which dispatches to our
+//! [`VfsFileSystem`] (the `Namespace → FileSystem` down-adapter).
+//!
+//! This is the inverse direction of FS-C's adapter and the host side of the CH
+//! ShareFs attach in `kata_backend.rs`.
+
+use std::io;
+use std::sync::Arc;
+// `vhost-user-backend` only implements `VhostUserBackend` for the std `Mutex`/
+// `RwLock` (backend.rs:335/415), so we must use the std type here despite the
+// project's parking_lot preference — there is no poison risk as the daemon owns
+// the lock and our backend methods never panic while holding it.
+#[allow(clippy::disallowed_types)]
+use std::sync::Mutex;
+
+use fuse_backend_rs::api::server::Server;
+use fuse_backend_rs::transport::{Reader, VirtioFsWriter, Writer};
+use vhost::vhost_user::message::{VhostUserProtocolFeatures, VhostUserVirtioFeatures};
+use vhost::vhost_user::Listener;
+use vhost_user_backend::{VhostUserBackendMut, VhostUserDaemon, VringRwLock, VringT};
+use virtio_bindings::bindings::virtio_config::VIRTIO_F_VERSION_1;
+use virtio_bindings::bindings::virtio_ring::{
+    VIRTIO_RING_F_EVENT_IDX, VIRTIO_RING_F_INDIRECT_DESC,
+};
+use virtio_queue::QueueOwnedT;
+use vm_memory::{GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
+use vmm_sys_util::epoll::EventSet;
+use vmm_sys_util::eventfd::EventFd;
+
+use crate::filesystem::VfsFileSystem;
+
+/// Map any backend error into an `io::Error` for the vring loop.
+fn into_io<E: std::fmt::Debug>(e: E) -> io::Error {
+    io::Error::other(format!("{e:?}"))
+}
+
+/// Guest memory type the daemon manages.
+type GuestMemory = GuestMemoryAtomic<GuestMemoryMmap>;
+
+/// virtio-fs queues: 1 hiprio + 1 request queue (the minimal, single-thread set).
+const NUM_QUEUES: usize = 2;
+/// Max descriptors per queue (matches the CH `queue_size` default of 1024).
+const QUEUE_SIZE: usize = 1024;
+
+/// The vhost-user backend hosting a [`VfsFileSystem`] [`Server`].
+pub struct VfsBackend {
+    server: Arc<Server<VfsFileSystem>>,
+    mem: Option<GuestMemory>,
+    event_idx: bool,
+    /// Exit eventfd so the daemon can be signalled to stop.
+    exit: EventFd,
+}
+
+impl VfsBackend {
+    fn new(fs: VfsFileSystem) -> io::Result<Self> {
+        Ok(Self {
+            server: Arc::new(Server::new(fs)),
+            mem: None,
+            event_idx: false,
+            exit: EventFd::new(libc::EFD_NONBLOCK)?,
+        })
+    }
+
+    /// Drain one request queue, dispatching each chain through the FUSE server.
+    ///
+    /// Iteration borrows the queue under the vring's write guard; `add_used`
+    /// re-locks the vring, so we stage `(head, len)` completions and apply them
+    /// after dropping the guard (holding both would self-deadlock the lock).
+    fn process_queue(&self, vring: &VringRwLock) -> io::Result<bool> {
+        let mem = self
+            .mem
+            .as_ref()
+            .ok_or_else(|| io::Error::from_raw_os_error(libc::EINVAL))?
+            .memory();
+        // `&*mem` is the guard's `Deref::Target` (`&GuestMemoryMmap`), which is
+        // what `from_descriptor_chain`/`VirtioFsWriter::new` want; the chain's
+        // own `M` is the cloned guard handed to `iter`.
+        let desc_mem: &GuestMemoryMmap = &mem;
+
+        let mut completed: Vec<(u16, u32)> = Vec::new();
+        {
+            let mut state = vring.get_mut();
+            let queue = state.get_queue_mut();
+            let avail = queue.iter(mem.clone()).map_err(into_io)?;
+            for chain in avail {
+                let head = chain.head_index();
+                let reader =
+                    Reader::from_descriptor_chain(desc_mem, chain.clone()).map_err(into_io)?;
+                let writer: Writer = VirtioFsWriter::new(desc_mem, chain.clone())
+                    .map_err(into_io)?
+                    .into();
+                let len = self
+                    .server
+                    .handle_message(reader, writer, None, None)
+                    .map_err(into_io)?;
+                completed.push((head, len as u32));
+            }
+        } // write guard dropped before add_used
+
+        let used = !completed.is_empty();
+        for (head, len) in completed {
+            vring.add_used(head, len).map_err(into_io)?;
+        }
+        Ok(used)
+    }
+}
+
+impl VhostUserBackendMut for VfsBackend {
+    type Bitmap = ();
+    type Vring = VringRwLock;
+
+    fn num_queues(&self) -> usize {
+        NUM_QUEUES
+    }
+
+    fn max_queue_size(&self) -> usize {
+        QUEUE_SIZE
+    }
+
+    fn features(&self) -> u64 {
+        (1 << VIRTIO_F_VERSION_1)
+            | (1 << VIRTIO_RING_F_INDIRECT_DESC)
+            | (1 << VIRTIO_RING_F_EVENT_IDX)
+            | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits()
+    }
+
+    fn protocol_features(&self) -> VhostUserProtocolFeatures {
+        VhostUserProtocolFeatures::MQ | VhostUserProtocolFeatures::REPLY_ACK
+    }
+
+    fn set_event_idx(&mut self, enabled: bool) {
+        self.event_idx = enabled;
+    }
+
+    fn update_memory(&mut self, mem: GuestMemory) -> io::Result<()> {
+        self.mem = Some(mem);
+        Ok(())
+    }
+
+    fn handle_event(
+        &mut self,
+        device_event: u16,
+        _evset: EventSet,
+        vrings: &[Self::Vring],
+        _thread_id: usize,
+    ) -> io::Result<()> {
+        let vring = vrings
+            .get(device_event as usize)
+            .ok_or_else(|| io::Error::from_raw_os_error(libc::EINVAL))?;
+
+        let mut used = false;
+        if self.event_idx {
+            // event_idx: disable notifications, drain, re-enable, retry if work
+            // arrived in the window. Standard virtiofsd loop.
+            loop {
+                vring.disable_notification().map_err(into_io)?;
+                used |= self.process_queue(vring)?;
+                if !vring.enable_notification().map_err(into_io)? {
+                    break;
+                }
+            }
+        } else {
+            used = self.process_queue(vring)?;
+        }
+        // Signal the guest that descriptors were consumed.
+        if used {
+            vring.signal_used_queue().map_err(into_io)?;
+        }
+        Ok(())
+    }
+
+    fn exit_event(&self, _thread_id: usize) -> Option<EventFd> {
+        self.exit.try_clone().ok()
+    }
+}
+
+/// Serve `fs` over the vhost-user-fs Unix socket at `socket_path`, blocking until
+/// the daemon exits (the VMM disconnects or [`exit_event`](VfsBackend::exit_event)
+/// is signalled).
+///
+/// The caller is responsible for the socket lifecycle and for attaching the same
+/// path to Cloud Hypervisor as a ShareFs device (see `kata_backend.rs`). Run this
+/// on a dedicated thread; it blocks.
+#[allow(clippy::disallowed_types)] // std Mutex required by vhost-user-backend's blanket impl
+pub fn serve(fs: VfsFileSystem, socket_path: &str) -> io::Result<()> {
+    let backend = Arc::new(Mutex::new(VfsBackend::new(fs)?));
+    let mem = GuestMemoryAtomic::new(GuestMemoryMmap::new());
+    let mut daemon = VhostUserDaemon::new("hyprstream-vfs-fs".to_owned(), backend, mem)
+        .map_err(|e| io::Error::other(format!("daemon init: {e}")))?;
+
+    let listener = Listener::new(socket_path, true)
+        .map_err(|e| io::Error::other(format!("listen {socket_path}: {e}")))?;
+    daemon
+        .start(listener)
+        .map_err(|e| io::Error::other(format!("daemon start: {e}")))?;
+    daemon
+        .wait()
+        .map_err(|e| io::Error::other(format!("daemon wait: {e}")))?;
+    Ok(())
+}

--- a/crates/hyprstream-vfs-server/src/tests.rs
+++ b/crates/hyprstream-vfs-server/src/tests.rs
@@ -1,0 +1,561 @@
+//! Unit tests for the `Namespace → FileSystem` down-adapter ([`VfsFileSystem`]).
+//!
+//! These exercise the adapter directly against a synthetic in-memory
+//! [`FsMount`] — no VM, no vhost-user transport. (A full guest mount is live
+//! validation, out of scope here.) They cover the core op surface the issue
+//! calls out: lookup, read, write, create, readdir, rename, plus the
+//! fail-closed `EROFS` behaviour over a read-only [`Mount`].
+
+#![allow(clippy::unwrap_used)]
+
+use std::collections::BTreeMap;
+use std::ffi::CString;
+use std::io;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use parking_lot::Mutex;
+
+use fuse_backend_rs::abi::fuse_abi::CreateIn;
+use fuse_backend_rs::api::filesystem::{
+    Context, DirEntry as FuseDirEntry, FileSystem, ZeroCopyReader, ZeroCopyWriter,
+};
+
+use hyprstream_vfs::{
+    DirEntry, Fid, FsMount, Mount, MountError, Namespace, SetAttr, Stat, Subject,
+};
+
+use crate::filesystem::VfsFileSystem;
+
+// ── Synthetic in-memory writable filesystem ─────────────────────────────────
+
+/// A trivial in-memory tree implementing both [`Mount`] and [`FsMount`]. Files
+/// are byte vectors; directories are tracked as a set of paths ending in `/`.
+#[derive(Default)]
+struct MemFs {
+    /// path (components joined by `/`) → contents. Directories map to `None`.
+    nodes: Mutex<BTreeMap<String, Option<Vec<u8>>>>,
+}
+
+impl MemFs {
+    fn new() -> Self {
+        let mut nodes = BTreeMap::new();
+        nodes.insert(String::new(), None); // root dir
+        Self {
+            nodes: Mutex::new(nodes),
+        }
+    }
+
+    fn with_files(files: &[(&str, &[u8])]) -> Self {
+        let fs = Self::new();
+        {
+            let mut nodes = fs.nodes.lock();
+            for (path, data) in files {
+                // Ensure parent dirs exist.
+                let parts: Vec<&str> = path.split('/').collect();
+                for i in 1..parts.len() {
+                    let dir = parts[..i].join("/");
+                    nodes.entry(dir).or_insert(None);
+                }
+                nodes.insert((*path).to_owned(), Some(data.to_vec()));
+            }
+        }
+        fs
+    }
+
+    fn key(components: &[&str]) -> String {
+        components.join("/")
+    }
+}
+
+struct MemFid {
+    path: String,
+}
+
+#[async_trait]
+impl Mount for MemFs {
+    async fn walk(&self, components: &[&str], _caller: &Subject) -> Result<Fid, MountError> {
+        let key = Self::key(components);
+        if self.nodes.lock().contains_key(&key) {
+            Ok(Fid::new(MemFid { path: key }))
+        } else {
+            Err(MountError::NotFound(key))
+        }
+    }
+
+    async fn open(&self, _fid: &mut Fid, _mode: u8, _caller: &Subject) -> Result<(), MountError> {
+        Ok(())
+    }
+
+    async fn read(&self, fid: &Fid, offset: u64, count: u32, _caller: &Subject) -> Result<Vec<u8>, MountError> {
+        let inner = fid.downcast_ref::<MemFid>().ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
+        let nodes = self.nodes.lock();
+        match nodes.get(&inner.path) {
+            Some(Some(data)) => {
+                let start = offset as usize;
+                if start >= data.len() {
+                    Ok(vec![])
+                } else {
+                    let end = std::cmp::min(start + count as usize, data.len());
+                    Ok(data[start..end].to_vec())
+                }
+            }
+            _ => Err(MountError::NotFound(inner.path.clone())),
+        }
+    }
+
+    async fn write(&self, fid: &Fid, offset: u64, data: &[u8], _caller: &Subject) -> Result<u32, MountError> {
+        let inner = fid.downcast_ref::<MemFid>().ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
+        let mut nodes = self.nodes.lock();
+        let entry = nodes.entry(inner.path.clone()).or_insert(Some(Vec::new()));
+        let buf = entry.get_or_insert_with(Vec::new);
+        let start = offset as usize;
+        if buf.len() < start + data.len() {
+            buf.resize(start + data.len(), 0);
+        }
+        buf[start..start + data.len()].copy_from_slice(data);
+        Ok(data.len() as u32)
+    }
+
+    async fn readdir(&self, fid: &Fid, _caller: &Subject) -> Result<Vec<DirEntry>, MountError> {
+        let inner = fid.downcast_ref::<MemFid>().ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
+        let prefix = if inner.path.is_empty() { String::new() } else { format!("{}/", inner.path) };
+        let nodes = self.nodes.lock();
+        let mut entries = Vec::new();
+        for (key, val) in nodes.iter() {
+            if key.is_empty() {
+                continue;
+            }
+            if let Some(rest) = key.strip_prefix(&prefix) {
+                if !rest.is_empty() && !rest.contains('/') {
+                    entries.push(DirEntry {
+                        name: rest.to_owned(),
+                        is_dir: val.is_none(),
+                        size: val.as_ref().map(|d| d.len() as u64).unwrap_or(0),
+                        stat: None,
+                    });
+                }
+            }
+        }
+        Ok(entries)
+    }
+
+    async fn stat(&self, fid: &Fid, _caller: &Subject) -> Result<Stat, MountError> {
+        let inner = fid.downcast_ref::<MemFid>().ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
+        let nodes = self.nodes.lock();
+        match nodes.get(&inner.path) {
+            Some(val) => Ok(Stat {
+                qtype: if val.is_none() { 0x80 } else { 0 },
+                size: val.as_ref().map(|d| d.len() as u64).unwrap_or(0),
+                name: inner.path.rsplit('/').next().unwrap_or("").to_owned(),
+                mtime: 0,
+            }),
+            None => Err(MountError::NotFound(inner.path.clone())),
+        }
+    }
+
+    async fn clunk(&self, _fid: Fid, _caller: &Subject) {}
+
+    fn as_fsmount(&self) -> Option<&dyn FsMount> {
+        Some(self)
+    }
+}
+
+#[async_trait]
+impl FsMount for MemFs {
+    async fn create(&self, path: &[&str], _mode: u32, _caller: &Subject) -> Result<(), MountError> {
+        let key = Self::key(path);
+        let mut nodes = self.nodes.lock();
+        if nodes.contains_key(&key) {
+            return Err(MountError::AlreadyExists(key));
+        }
+        nodes.insert(key, Some(Vec::new()));
+        Ok(())
+    }
+
+    async fn unlink(&self, path: &[&str], _caller: &Subject) -> Result<(), MountError> {
+        let key = Self::key(path);
+        let mut nodes = self.nodes.lock();
+        match nodes.get(&key) {
+            Some(Some(_)) => {
+                nodes.remove(&key);
+                Ok(())
+            }
+            Some(None) => Err(MountError::IsDirectory(key)),
+            None => Err(MountError::NotFound(key)),
+        }
+    }
+
+    async fn mkdir(&self, path: &[&str], _mode: u32, _caller: &Subject) -> Result<(), MountError> {
+        let key = Self::key(path);
+        let mut nodes = self.nodes.lock();
+        if nodes.contains_key(&key) {
+            return Err(MountError::AlreadyExists(key));
+        }
+        nodes.insert(key, None);
+        Ok(())
+    }
+
+    async fn rmdir(&self, path: &[&str], _caller: &Subject) -> Result<(), MountError> {
+        let key = Self::key(path);
+        let mut nodes = self.nodes.lock();
+        match nodes.get(&key) {
+            Some(None) => {
+                nodes.remove(&key);
+                Ok(())
+            }
+            Some(Some(_)) => Err(MountError::NotDirectory(key)),
+            None => Err(MountError::NotFound(key)),
+        }
+    }
+
+    async fn rename(&self, from: &[&str], to: &[&str], _caller: &Subject) -> Result<(), MountError> {
+        let from_key = Self::key(from);
+        let to_key = Self::key(to);
+        let mut nodes = self.nodes.lock();
+        let val = nodes.remove(&from_key).ok_or(MountError::NotFound(from_key))?;
+        nodes.insert(to_key, val);
+        Ok(())
+    }
+
+    async fn setattr(&self, path: &[&str], attr: &SetAttr, _caller: &Subject) -> Result<(), MountError> {
+        let key = Self::key(path);
+        let mut nodes = self.nodes.lock();
+        let entry = nodes.get_mut(&key).ok_or(MountError::NotFound(key))?;
+        if let (Some(size), Some(data)) = (attr.size, entry.as_mut()) {
+            data.resize(size as usize, 0);
+        }
+        Ok(())
+    }
+
+    async fn symlink(&self, path: &[&str], target: &str, _caller: &Subject) -> Result<(), MountError> {
+        let key = Self::key(path);
+        self.nodes.lock().insert(key, Some(target.as_bytes().to_vec()));
+        Ok(())
+    }
+
+    async fn readlink(&self, path: &[&str], _caller: &Subject) -> Result<String, MountError> {
+        let key = Self::key(path);
+        match self.nodes.lock().get(&key) {
+            Some(Some(data)) => Ok(String::from_utf8_lossy(data).into_owned()),
+            _ => Err(MountError::NotFound(key)),
+        }
+    }
+
+    async fn link(&self, existing: &[&str], new_path: &[&str], _caller: &Subject) -> Result<(), MountError> {
+        let ex = Self::key(existing);
+        let np = Self::key(new_path);
+        let mut nodes = self.nodes.lock();
+        let val = nodes.get(&ex).cloned().ok_or(MountError::NotFound(ex))?;
+        nodes.insert(np, val);
+        Ok(())
+    }
+
+    async fn stat_path(&self, path: &[&str], caller: &Subject) -> Result<Stat, MountError> {
+        let fid = self.walk(path, caller).await?;
+        let st = Mount::stat(self, &fid, caller).await;
+        self.clunk(fid, caller).await;
+        st
+    }
+}
+
+// ── Read-only synthetic Mount (no FsMount) ──────────────────────────────────
+
+/// A plain read-only [`Mount`] — *not* an [`FsMount`]. Used to assert mutations
+/// fail closed with `EROFS`.
+struct RoMount {
+    files: BTreeMap<String, Vec<u8>>,
+}
+
+#[async_trait]
+impl Mount for RoMount {
+    async fn walk(&self, components: &[&str], _caller: &Subject) -> Result<Fid, MountError> {
+        Ok(Fid::new(MemFid { path: components.join("/") }))
+    }
+    async fn open(&self, _fid: &mut Fid, mode: u8, _caller: &Subject) -> Result<(), MountError> {
+        if mode != 0 {
+            Err(MountError::PermissionDenied("read-only".into()))
+        } else {
+            Ok(())
+        }
+    }
+    async fn read(&self, fid: &Fid, offset: u64, count: u32, _caller: &Subject) -> Result<Vec<u8>, MountError> {
+        let inner = fid.downcast_ref::<MemFid>().unwrap();
+        match self.files.get(&inner.path) {
+            Some(data) => {
+                let s = offset as usize;
+                if s >= data.len() { Ok(vec![]) } else { Ok(data[s..std::cmp::min(s + count as usize, data.len())].to_vec()) }
+            }
+            None => Err(MountError::NotFound(inner.path.clone())),
+        }
+    }
+    async fn write(&self, _fid: &Fid, _o: u64, _d: &[u8], _c: &Subject) -> Result<u32, MountError> {
+        Err(MountError::PermissionDenied("read-only".into()))
+    }
+    async fn readdir(&self, _fid: &Fid, _c: &Subject) -> Result<Vec<DirEntry>, MountError> {
+        Ok(vec![])
+    }
+    async fn stat(&self, fid: &Fid, _c: &Subject) -> Result<Stat, MountError> {
+        let inner = fid.downcast_ref::<MemFid>().unwrap();
+        match self.files.get(&inner.path) {
+            Some(d) => Ok(Stat { qtype: 0, size: d.len() as u64, name: inner.path.clone(), mtime: 0 }),
+            None => Err(MountError::NotFound(inner.path.clone())),
+        }
+    }
+    async fn clunk(&self, _fid: Fid, _c: &Subject) {}
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+fn cstr(s: &str) -> CString {
+    CString::new(s).unwrap()
+}
+
+fn subject() -> Subject {
+    Subject::new("tester")
+}
+
+/// A ZeroCopyWriter into an owned Vec (mirrors the production MemWriter).
+struct VecWriter(Vec<u8>);
+impl io::Write for VecWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+impl ZeroCopyWriter for VecWriter {
+    fn write_from(&mut self, _f: &mut dyn fuse_backend_rs::file_traits::FileReadWriteVolatile, _count: usize, _off: u64) -> io::Result<usize> {
+        Ok(0)
+    }
+    fn available_bytes(&self) -> usize {
+        usize::MAX
+    }
+}
+
+/// A ZeroCopyReader over an owned slice (mirrors the production MemReader).
+struct SliceReader<'a> {
+    data: &'a [u8],
+    pos: usize,
+}
+impl io::Read for SliceReader<'_> {
+    fn read(&mut self, out: &mut [u8]) -> io::Result<usize> {
+        let n = std::cmp::min(out.len(), self.data.len() - self.pos);
+        out[..n].copy_from_slice(&self.data[self.pos..self.pos + n]);
+        self.pos += n;
+        Ok(n)
+    }
+}
+impl ZeroCopyReader for SliceReader<'_> {
+    fn read_to(&mut self, _f: &mut dyn fuse_backend_rs::file_traits::FileReadWriteVolatile, _count: usize, _off: u64) -> io::Result<usize> {
+        Ok(0)
+    }
+}
+
+/// Build a `VfsFileSystem` over a namespace with the given mounts, using a
+/// dedicated current-thread runtime driven on a separate worker.
+fn build(ns: Namespace) -> VfsFileSystem {
+    // The adapter's `block_on` must run on a runtime distinct from the caller's
+    // thread; tests use a multi-thread runtime handle.
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .enable_all()
+        .build()
+        .unwrap();
+    // Leak the runtime so its handle outlives the test fs (fine for tests).
+    let handle = rt.handle().clone();
+    std::mem::forget(rt);
+    VfsFileSystem::new(ns, subject(), handle)
+}
+
+const ROOT: u64 = 1;
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn lookup_and_getattr() {
+    let mut ns = Namespace::new();
+    ns.mount("/data", Arc::new(MemFs::with_files(&[("hello.txt", b"hi")]))).unwrap();
+    let fs = build(ns);
+    let ctx = Context::default();
+
+    // /data is an intermediate dir under root.
+    let data = fs.lookup(&ctx, ROOT, &cstr("data")).unwrap();
+    assert!(data.inode != 0);
+    assert_eq!(data.attr.st_mode & libc::S_IFMT, libc::S_IFDIR);
+
+    // /data/hello.txt is a file.
+    let file = fs.lookup(&ctx, data.inode, &cstr("hello.txt")).unwrap();
+    assert_eq!(file.attr.st_mode & libc::S_IFMT, libc::S_IFREG);
+    assert_eq!(file.attr.st_size, 2);
+
+    let (attr, _) = fs.getattr(&ctx, file.inode, None).unwrap();
+    assert_eq!(attr.st_size, 2);
+}
+
+#[test]
+fn read_file() {
+    let mut ns = Namespace::new();
+    ns.mount("/data", Arc::new(MemFs::with_files(&[("hello.txt", b"hello world")]))).unwrap();
+    let fs = build(ns);
+    let ctx = Context::default();
+
+    let data = fs.lookup(&ctx, ROOT, &cstr("data")).unwrap();
+    let file = fs.lookup(&ctx, data.inode, &cstr("hello.txt")).unwrap();
+    let (handle, _, _) = fs.open(&ctx, file.inode, libc::O_RDONLY as u32, 0).unwrap();
+    let handle = handle.unwrap();
+
+    let mut w = VecWriter(Vec::new());
+    let n = fs.read(&ctx, file.inode, handle, &mut w, 64, 0, None, 0).unwrap();
+    assert_eq!(n, 11);
+    assert_eq!(w.0, b"hello world");
+    fs.release(&ctx, file.inode, 0, handle, false, false, None).unwrap();
+}
+
+#[test]
+fn create_and_write_and_read() {
+    let mut ns = Namespace::new();
+    ns.mount("/data", Arc::new(MemFs::new())).unwrap();
+    let fs = build(ns);
+    let ctx = Context::default();
+
+    let data = fs.lookup(&ctx, ROOT, &cstr("data")).unwrap();
+    let args = CreateIn { flags: libc::O_WRONLY as u32, mode: 0o644, umask: 0, fuse_flags: 0 };
+    let (entry, handle, _, _) = fs.create(&ctx, data.inode, &cstr("new.txt"), args).unwrap();
+    let handle = handle.unwrap();
+
+    let payload = b"written bytes";
+    let mut r = SliceReader { data: payload, pos: 0 };
+    let n = fs.write(&ctx, entry.inode, handle, &mut r, payload.len() as u32, 0, None, false, 0, 0).unwrap();
+    assert_eq!(n, payload.len());
+    fs.release(&ctx, entry.inode, 0, handle, true, false, None).unwrap();
+
+    // Re-open and read back.
+    let file = fs.lookup(&ctx, data.inode, &cstr("new.txt")).unwrap();
+    let (rh, _, _) = fs.open(&ctx, file.inode, libc::O_RDONLY as u32, 0).unwrap();
+    let mut w = VecWriter(Vec::new());
+    fs.read(&ctx, file.inode, rh.unwrap(), &mut w, 64, 0, None, 0).unwrap();
+    assert_eq!(w.0, payload);
+}
+
+#[test]
+fn readdir_lists_entries() {
+    let mut ns = Namespace::new();
+    ns.mount("/data", Arc::new(MemFs::with_files(&[("a.txt", b"a"), ("b.txt", b"b"), ("sub/c.txt", b"c")]))).unwrap();
+    let fs = build(ns);
+    let ctx = Context::default();
+
+    let data = fs.lookup(&ctx, ROOT, &cstr("data")).unwrap();
+    let (handle, _) = fs.opendir(&ctx, data.inode, 0).unwrap();
+    let handle = handle.unwrap();
+
+    let mut names = Vec::new();
+    {
+        let mut add = |e: FuseDirEntry| -> io::Result<usize> {
+            names.push(String::from_utf8_lossy(e.name).into_owned());
+            Ok(e.name.len())
+        };
+        fs.readdir(&ctx, data.inode, handle, 4096, 0, &mut add).unwrap();
+    }
+
+    assert!(names.contains(&".".to_owned()));
+    assert!(names.contains(&"..".to_owned()));
+    assert!(names.contains(&"a.txt".to_owned()));
+    assert!(names.contains(&"b.txt".to_owned()));
+    assert!(names.contains(&"sub".to_owned()));
+}
+
+#[test]
+fn rename_within_mount() {
+    let mut ns = Namespace::new();
+    ns.mount("/data", Arc::new(MemFs::with_files(&[("old.txt", b"payload")]))).unwrap();
+    let fs = build(ns);
+    let ctx = Context::default();
+
+    let data = fs.lookup(&ctx, ROOT, &cstr("data")).unwrap();
+    fs.rename(&ctx, data.inode, &cstr("old.txt"), data.inode, &cstr("new.txt"), 0).unwrap();
+
+    // old gone, new present.
+    assert!(fs.lookup(&ctx, data.inode, &cstr("old.txt")).is_err());
+    let new = fs.lookup(&ctx, data.inode, &cstr("new.txt")).unwrap();
+    let (rh, _, _) = fs.open(&ctx, new.inode, libc::O_RDONLY as u32, 0).unwrap();
+    let mut w = VecWriter(Vec::new());
+    fs.read(&ctx, new.inode, rh.unwrap(), &mut w, 64, 0, None, 0).unwrap();
+    assert_eq!(w.0, b"payload");
+}
+
+#[test]
+fn mkdir_and_rmdir() {
+    let mut ns = Namespace::new();
+    ns.mount("/data", Arc::new(MemFs::new())).unwrap();
+    let fs = build(ns);
+    let ctx = Context::default();
+
+    let data = fs.lookup(&ctx, ROOT, &cstr("data")).unwrap();
+    let dir = fs.mkdir(&ctx, data.inode, &cstr("sub"), 0o755, 0).unwrap();
+    assert_eq!(dir.attr.st_mode & libc::S_IFMT, libc::S_IFDIR);
+
+    fs.rmdir(&ctx, data.inode, &cstr("sub")).unwrap();
+    assert!(fs.lookup(&ctx, data.inode, &cstr("sub")).is_err());
+}
+
+#[test]
+fn unlink_removes_file() {
+    let mut ns = Namespace::new();
+    ns.mount("/data", Arc::new(MemFs::with_files(&[("gone.txt", b"x")]))).unwrap();
+    let fs = build(ns);
+    let ctx = Context::default();
+
+    let data = fs.lookup(&ctx, ROOT, &cstr("data")).unwrap();
+    assert!(fs.lookup(&ctx, data.inode, &cstr("gone.txt")).is_ok());
+    fs.unlink(&ctx, data.inode, &cstr("gone.txt")).unwrap();
+    assert!(fs.lookup(&ctx, data.inode, &cstr("gone.txt")).is_err());
+}
+
+#[test]
+fn readonly_mount_is_erofs() {
+    let mut ns = Namespace::new();
+    let mut files = BTreeMap::new();
+    files.insert("ro.txt".to_owned(), b"data".to_vec());
+    ns.mount("/ro", Arc::new(RoMount { files })).unwrap();
+    let fs = build(ns);
+    let ctx = Context::default();
+
+    let ro = fs.lookup(&ctx, ROOT, &cstr("ro")).unwrap();
+
+    // create / mkdir / unlink on a read-only Mount fail closed with EROFS.
+    let args = CreateIn { flags: libc::O_WRONLY as u32, mode: 0o644, umask: 0, fuse_flags: 0 };
+    let err = fs.create(&ctx, ro.inode, &cstr("nope.txt"), args).unwrap_err();
+    assert_eq!(err.raw_os_error(), Some(libc::EROFS));
+
+    let err = fs.mkdir(&ctx, ro.inode, &cstr("nope"), 0o755, 0).unwrap_err();
+    assert_eq!(err.raw_os_error(), Some(libc::EROFS));
+
+    // Read of an existing file still works.
+    let file = fs.lookup(&ctx, ro.inode, &cstr("ro.txt")).unwrap();
+    let (h, _, _) = fs.open(&ctx, file.inode, libc::O_RDONLY as u32, 0).unwrap();
+    let mut w = VecWriter(Vec::new());
+    fs.read(&ctx, file.inode, h.unwrap(), &mut w, 64, 0, None, 0).unwrap();
+    assert_eq!(w.0, b"data");
+
+    // Write-open of a read-only mount fails (EROFS).
+    let err = fs.open(&ctx, file.inode, libc::O_WRONLY as u32, 0).unwrap_err();
+    assert_eq!(err.raw_os_error(), Some(libc::EROFS));
+}
+
+#[test]
+fn forget_reclaims_inode() {
+    let mut ns = Namespace::new();
+    ns.mount("/data", Arc::new(MemFs::with_files(&[("f.txt", b"x")]))).unwrap();
+    let fs = build(ns);
+    let ctx = Context::default();
+
+    let data = fs.lookup(&ctx, ROOT, &cstr("data")).unwrap();
+    let f = fs.lookup(&ctx, data.inode, &cstr("f.txt")).unwrap();
+    // One lookup ref → forget(1) should make a subsequent getattr on the stale
+    // inode fail (the inode is reclaimed).
+    fs.forget(&ctx, f.inode, 1);
+    assert!(fs.getattr(&ctx, f.inode, None).is_err());
+}

--- a/crates/hyprstream-vfs/src/fuse_adapter.rs
+++ b/crates/hyprstream-vfs/src/fuse_adapter.rs
@@ -378,6 +378,10 @@ where
         Ok(Self::entry_stat("", &attr))
     }
 
+    fn as_fsmount(&self) -> Option<&dyn FsMount> {
+        Some(self)
+    }
+
     async fn clunk(&self, fid: Fid, _caller: &Subject) {
         let ctx = context();
         let Some(inner) = fid.downcast_ref::<FuseFid>() else {

--- a/crates/hyprstream-vfs/src/mount.rs
+++ b/crates/hyprstream-vfs/src/mount.rs
@@ -131,4 +131,24 @@ pub trait Mount: Send + Sync {
 
     /// Release a fid.
     async fn clunk(&self, fid: Fid, caller: &Subject);
+
+    /// Capability downcast: report whether this mount is also a writable
+    /// [`FsMount`](crate::FsMount), returning a borrow if so.
+    ///
+    /// The base [`Mount`] surface is read/write-on-existing-files only; full
+    /// namespace mutation (`create`/`unlink`/`mkdir`/`rename`/…) lives on the
+    /// `FsMount` supertrait. A [`Namespace`](crate::Namespace) stores every mount
+    /// as `Arc<dyn Mount>`, erasing the richer type, so a consumer that holds
+    /// only a `dyn Mount` (e.g. FS-A's `Namespace → FileSystem` down-adapter)
+    /// needs a way back to the `FsMount` vtable to route writes. This hook is the
+    /// idiomatic capability-typed answer to "is this mount writable as a real
+    /// filesystem?" — preferable to probing for `NotSupported` at runtime.
+    ///
+    /// Default: `None` (a plain `Mount` is not a full filesystem). `FsMount`
+    /// impls override this to return `Some(self)`; the blanket impl in
+    /// `fsmount.rs` is *not* possible (it would require `Self: Sized`), so each
+    /// `FsMount` opts in with a one-line override.
+    fn as_fsmount(&self) -> Option<&dyn crate::fsmount::FsMount> {
+        None
+    }
 }

--- a/crates/hyprstream-vfs/src/namespace.rs
+++ b/crates/hyprstream-vfs/src/namespace.rs
@@ -342,6 +342,59 @@ impl Namespace {
         }
     }
 
+    /// Resolve a path to its mount targets (bind order) and the path components
+    /// **relative to the matched mount root**.
+    ///
+    /// This is the public, fid-level routing entry point used by FS-A's
+    /// `Namespace → FileSystem` down-adapter, which (unlike `cat`/`ls`/`echo`)
+    /// drives `walk`/`open`/`read`/`write`/`clunk` on the mount itself and needs
+    /// the raw targets plus the component slice. Returns the targets in bind
+    /// order (`Before` first, `After` last) so the caller can apply the same
+    /// union/fallthrough policy the convenience helpers do.
+    ///
+    /// `path` is normalised (`.`/`..` resolved, leading `/` enforced) before the
+    /// longest-prefix match, identical to the convenience helpers.
+    pub fn resolve_targets(&self, path: &str) -> Result<(Vec<MountTarget>, Vec<String>), NamespaceError> {
+        let (targets, remainder) = self.resolve(path)?;
+        let components = split_path(&remainder).into_iter().map(str::to_owned).collect();
+        Ok((targets.to_vec(), components))
+    }
+
+    /// Whether `path` is an *intermediate* directory — a path that is not itself
+    /// a mount prefix but is a strict ancestor of one (e.g. `/srv` when only
+    /// `/srv/model` is mounted). Used by the down-adapter to synthesise
+    /// directory inodes for the parts of the tree the namespace spans implicitly.
+    ///
+    /// Returns the synthetic child directory names if so (deduped, no order
+    /// guarantee), or `None` if `path` is neither a mount nor an ancestor.
+    pub fn intermediate_children(&self, path: &str) -> Option<Vec<String>> {
+        let normalized = normalize_path(path);
+        // A real mount prefix is not "intermediate".
+        if self.mounts.iter().any(|m| m.prefix == normalized) {
+            return None;
+        }
+        let prefix_with_slash = if normalized == "/" {
+            "/".to_owned()
+        } else {
+            format!("{normalized}/")
+        };
+        let mut seen = std::collections::HashSet::new();
+        let mut names = Vec::new();
+        for m in &self.mounts {
+            if let Some(rest) = m.prefix.strip_prefix(&prefix_with_slash[..]) {
+                let next = rest.split('/').next().unwrap_or("");
+                if !next.is_empty() && seen.insert(next.to_owned()) {
+                    names.push(next.to_owned());
+                }
+            }
+        }
+        if names.is_empty() {
+            None
+        } else {
+            Some(names)
+        }
+    }
+
     // ── Internal ────────────────────────────────────────────────────────────
 
     /// Resolve a path to (list of MountTargets, remainder after prefix).

--- a/crates/hyprstream-workers/src/runtime/kata_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/kata_backend.rs
@@ -10,9 +10,10 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use kata_hypervisor::ch::CloudHypervisor;
+use kata_hypervisor::device::DeviceType;
 #[cfg(feature = "dragonball")]
 use kata_hypervisor::dragonball::Dragonball;
-use kata_hypervisor::Hypervisor;
+use kata_hypervisor::{Hypervisor, ShareFsConfig, ShareFsDevice};
 use kata_types::config::hypervisor::{Hypervisor as HypervisorConfig, RootlessUser};
 use kata_types::rootless;
 
@@ -152,6 +153,66 @@ impl KataBackend {
         Ok(hypervisor)
     }
 
+    /// Attach a vhost-user-fs share to the hypervisor as a ShareFs device.
+    ///
+    /// This closes the gap noted in the FS spike (the virtiofs socket was created
+    /// but never wired into the VM): it adds the existing vhost-user-fs socket as
+    /// a Cloud Hypervisor `ShareFs` (virtio-fs) device via the **embedded**
+    /// runtime-rs hypervisor crate (#343 = embed), so the guest can mount the
+    /// share. The same path is used whether the socket is served by `nydusd`
+    /// (RAFS image rootfs) or by hyprstream's own `hyprstream-vfs-server`
+    /// (the VFS down-adapter).
+    ///
+    /// # Ordering
+    ///
+    /// Must be called **after `prepare_vm`** (which sets the hypervisor's
+    /// `vm_path`) and **before `start_vm`**. When the VM is not yet running, the
+    /// CH backend queues the device into its `pending_devices` and folds it into
+    /// the `VmConfig.fs` at boot — no virtiofsd is spawned by the crate; CH
+    /// connects to the socket we hand it. An **absolute** `sock_path` is used so
+    /// CH does not re-root it under the sandbox dir.
+    ///
+    /// `fs_type` must be the literal `"virtio-fs"` or the CH backend rejects the
+    /// device.
+    async fn attach_share_fs(
+        hypervisor: &Arc<dyn Hypervisor>,
+        sandbox_id: &str,
+        socket_path: &Path,
+        mount_tag: &str,
+    ) -> Result<()> {
+        let sock_path = socket_path.to_str().ok_or_else(|| {
+            WorkerError::SandboxCreationFailed("virtiofs socket path contains invalid UTF-8".into())
+        })?;
+
+        let config = ShareFsConfig {
+            // CH never reads host_shared_path/options/mount_config — the daemon
+            // that serves `sock_path` owns the exported tree. Only the socket,
+            // tag, type, and queue geometry matter for the boot-time attach.
+            fs_type: "virtio-fs".to_owned(),
+            sock_path: sock_path.to_owned(),
+            mount_tag: mount_tag.to_owned(),
+            queue_num: 1,
+            queue_size: 1024,
+            ..Default::default()
+        };
+        let device = ShareFsDevice::new(&format!("share-fs-{sandbox_id}"), &config);
+
+        hypervisor
+            .add_device(DeviceType::ShareFs(device))
+            .await
+            .map_err(|e| {
+                WorkerError::VmStartFailed(format!("failed to attach vhost-user-fs share: {e}"))
+            })?;
+
+        tracing::info!(
+            sandbox_id = %sandbox_id,
+            socket = %socket_path.display(),
+            mount_tag = %mount_tag,
+            "Attached vhost-user-fs ShareFs device to hypervisor"
+        );
+        Ok(())
+    }
+
     /// Generate cloud-init ISO for a sandbox.
     async fn generate_cloud_init_iso(sandbox: &PodSandbox, iso_path: &Path) -> Result<()> {
         let sandbox_runtime_dir = iso_path
@@ -279,6 +340,13 @@ impl SandboxBackend for KataBackend {
             .prepare_vm(&sandbox.id, None, annotations, None)
             .await
             .map_err(|e| WorkerError::VmStartFailed(format!("failed to prepare VM: {e}")))?;
+
+        // Attach the vhost-user-fs share (RAFS image rootfs and/or the
+        // hyprstream-vfs-server VFS down-adapter) as a CH ShareFs device, after
+        // prepare_vm and before start_vm so it is folded into the boot VmConfig.
+        if let Some(ref socket) = virtiofs_sock {
+            Self::attach_share_fs(&hypervisor, &sandbox.id, socket, "hyprstream-vfs").await?;
+        }
 
         let timeout_secs = i32::try_from(pool_config.create_timeout_secs).unwrap_or(i32::MAX);
         tracing::debug!(sandbox_id = %sandbox.id, timeout_secs, "Starting VM");


### PR DESCRIPTION
## What

FS-A (#362) of the Worker GA FS track: serve a hyprstream VFS `Namespace` to a Cloud Hypervisor guest over vhost-user-fs, and wire the share into the VM.

This is the **down** half of the bidirectional `FileSystem ↔ Mount` bridge from the converged FS/VFS design. FS-C (#372, merged) built the **up** adapter (`FuseFileSystemMount`: a `fuse_backend_rs::FileSystem` → VFS `Mount`); this PR builds the inverse: a whole VFS `Namespace` → `fuse_backend_rs::FileSystem`, served to CH.

```
Cloud Hypervisor  (virtio-fs / vhost-user-fs device)
  → vhost-user-backend       (Unix-socket transport + vring loop) — server.rs
    → fuse_backend_rs::Server (FUSE protocol engine — reused, not hand-rolled)
      → VfsFileSystem         (Namespace → FileSystem down-adapter) — filesystem.rs
        → Namespace mounts    (Mount read/write + FsMount writes, Subject-per-call)
```

## Pieces

### 1. New crate `hyprstream-vfs-server` (native-only)
- **`filesystem.rs` — the down-adapter (`VfsFileSystem`).** Implements `fuse_backend_rs::FileSystem<Inode=u64, Handle=u64>`: `lookup`/`getattr`/`open`/`read`/`write`/`opendir`/`readdir`/`release(dir)`/`create`/`unlink`/`mkdir`/`rmdir`/`rename`/`setattr`/`symlink`/`readlink`/`link` (+ `access`/`xattr` stubs). Each op resolves an inode to its VFS path and routes through the `Namespace`:
  - **reads** drive the base `Mount` surface (walk/open/read/readdir), trying each union target in bind order — the same fallthrough the namespace's own `cat`/`ls` use;
  - **writes/mutations** require the `FsMount` capability, reached via the new `Mount::as_fsmount()`; a plain `Mount` (synthetic/ctl/stream) is read-only and such ops return **`EROFS`** (fail-closed, never a silent no-op);
  - intermediate dirs the namespace spans implicitly (e.g. `/srv` when only `/srv/model` is mounted) and mount roots are served as synthetic directories.
  - The verified **`Subject`** is threaded on every call (the #353/#319/#328 boundary). Async VFS ops are bridged to the synchronous `FileSystem` via a tokio runtime handle.
- **`inode.rs` — owned fid/inode tables.** Lazily interned, reference-counted inodes (FUSE `forget` contract); handle table holds the VFS `Fid` plus its owning mount so read/write/clunk route back correctly.
- **`server.rs` — vhost-user-fs server.** Hosts the `fuse_backend_rs::Server` over a Unix socket with the `vhost-user-backend` crate (the canonical virtiofsd stacking) — reusing fuse_backend_rs's server transport per the design.
- Genuinely `Send + Sync`; **no wasm `unsafe impl Send`**. Added to the workspace.

### 2. `hyprstream-vfs` (additive, low blast-radius)
- `Mount::as_fsmount()` capability downcast (default `None`; `FsMount` impls override with a one-liner) — lets the down-adapter recover the writable `FsMount` vtable from the `Arc<dyn Mount>` a `Namespace` stores.
- Public `Namespace::resolve_targets` / `intermediate_children` routing accessors the down-adapter needs (the convenience helpers' routing, exposed at fid level).

### 3. CH ShareFs attach (`kata_backend.rs`)
- Closes the gap where the virtiofs socket was created but only logged: `attach_share_fs` adds the vhost-user-fs socket as a Cloud Hypervisor `ShareFs`/virtio-fs device via the **embedded** runtime-rs hypervisor crate (#343 = embed) — `add_device(DeviceType::ShareFs(ShareFsDevice{ fs_type:"virtio-fs", sock_path:<abs>, mount_tag, ... }))`, queued **between `prepare_vm` and `start_vm`** so the CH backend folds it into the boot `VmConfig.fs` (no virtiofsd spawned by the crate; CH connects to the socket we hand it). Used for both the RAFS image rootfs and the hyprstream VFS share.

## Tests / verification
- `cargo build -p hyprstream-vfs-server -p hyprstream-workers` — clean.
- **9 unit tests** drive the down-adapter directly over a synthetic `Namespace` (no VM): lookup/getattr, read, create+write+read-back, readdir, rename, mkdir/rmdir, unlink, **read-only mount → EROFS**, forget-reclaims-inode. `hyprstream-vfs` tests (28) still pass.
- `cargo clippy --all-targets -D warnings` clean on `hyprstream-vfs`, `hyprstream-vfs-server`, `hyprstream-workers`. (The one `std::sync::Mutex` is required by `vhost-user-backend`'s blanket impl; scoped `#[allow]` with justification.)

## Scope / notes
- Full guest-mount is **live validation** (needs a running CH VM) — out of scope here; the FUSE protocol path is unit-tested over a synthetic namespace.
- Does **not** touch the rootfs mount / RAFS-as-FileSystem (FS-B) or the per-sandbox Namespace+Subject compose (FS-D).
- The embedded ShareFs API supported the boot-time attach cleanly (no TODO needed).

Closes #362
Part of #341