### PR TITLE
build: bump embedded Kata runtime-rs deps 3.25.0 -> 3.31.0 (#342)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,9 +221,10 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 [[package]]
 name = "api_client"
 version = "0.1.0"
-source = "git+https://github.com/cloud-hypervisor/cloud-hypervisor?tag=v27.0#2ba6a9bfcfd79629aecf77504fa554ab821d138e"
+source = "git+https://github.com/cloud-hypervisor/cloud-hypervisor?tag=v51.0#00e106e53e7ba48b01f194f7887b20b9a0bfb905"
 dependencies = [
- "vmm-sys-util 0.10.0",
+ "thiserror 2.0.18",
+ "vmm-sys-util 0.14.0",
 ]
 
 [[package]]
@@ -234,6 +235,12 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
 ]
+
+[[package]]
+name = "arbitrary-int"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993a810118f8f37e9c4411c86f1c4c940a09a7ab34b7bf2d88d06f50c553fab7"
 
 [[package]]
 name = "arboard"
@@ -617,7 +624,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -1298,6 +1305,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bilge"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279c74986684d5cc7bbbd079aa448e8f852992cd385d85bb3a37e374c087b065"
+dependencies = [
+ "arbitrary-int",
+ "bilge-impl",
+]
+
+[[package]]
+name = "bilge-impl"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1176e49f42fe135cd2b56465e4f7d07038d3728f5e9f27fb2f08ed3fef75339"
+dependencies = [
+ "itertools 0.13.0",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1768,7 +1798,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-retry",
  "tower-service",
@@ -1800,7 +1830,7 @@ dependencies = [
  "more-asserts",
  "rand 0.9.2",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1817,7 +1847,7 @@ dependencies = [
  "merklehash",
  "serde",
  "serde_repr",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1914,7 +1944,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "ch-config"
 version = "0.1.0"
-source = "git+https://github.com/kata-containers/kata-containers?tag=3.25.0#17472f3f10c83a8626ea2bde8c4d4868f6ee95b4"
+source = "git+https://github.com/kata-containers/kata-containers?tag=3.31.0#cec98e0d976bbf4cae016298ffea269f57294264"
 dependencies = [
  "anyhow",
  "api_client",
@@ -1923,7 +1953,7 @@ dependencies = [
  "nix 0.26.4",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -2010,7 +2040,7 @@ dependencies = [
  "mockall",
  "once_cell",
  "rand 0.9.2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "utils",
@@ -2137,7 +2167,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2178,12 +2208,6 @@ dependencies = [
  "strum_macros 0.26.4",
  "unicode-width 0.2.1",
 ]
-
-[[package]]
-name = "common-path"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2382f75942f4b3be3690fe4f86365e9c853c1587d6ee58212cebf6e2a9ccd101"
 
 [[package]]
 name = "compact_str"
@@ -2864,16 +2888,6 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
-dependencies = [
- "darling_core 0.14.4",
- "darling_macro 0.14.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
@@ -2890,19 +2904,6 @@ checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core 0.23.0",
  "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2930,17 +2931,6 @@ dependencies = [
  "quote",
  "strsim",
  "syn 2.0.111",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
-dependencies = [
- "darling_core 0.14.4",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -3018,7 +3008,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "ulid",
@@ -3698,23 +3688,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbs-acpi"
+version = "0.1.0"
+source = "git+https://github.com/kata-containers/kata-containers?tag=3.31.0#cec98e0d976bbf4cae016298ffea269f57294264"
+dependencies = [
+ "vm-memory 0.17.1",
+]
+
+[[package]]
 name = "dbs-address-space"
 version = "0.3.0"
-source = "git+https://github.com/kata-containers/kata-containers?tag=3.25.0#17472f3f10c83a8626ea2bde8c4d4868f6ee95b4"
+source = "git+https://github.com/kata-containers/kata-containers?tag=3.31.0#cec98e0d976bbf4cae016298ffea269f57294264"
 dependencies = [
  "arc-swap",
  "lazy_static",
  "libc",
  "nix 0.23.2",
  "thiserror 1.0.69",
- "vm-memory 0.10.0",
- "vmm-sys-util 0.11.2",
+ "vm-memory 0.17.1",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
 name = "dbs-allocator"
 version = "0.1.1"
-source = "git+https://github.com/kata-containers/kata-containers?tag=3.25.0#17472f3f10c83a8626ea2bde8c4d4868f6ee95b4"
+source = "git+https://github.com/kata-containers/kata-containers?tag=3.31.0#cec98e0d976bbf4cae016298ffea269f57294264"
 dependencies = [
  "thiserror 1.0.69",
 ]
@@ -3722,36 +3720,36 @@ dependencies = [
 [[package]]
 name = "dbs-arch"
 version = "0.2.3"
-source = "git+https://github.com/kata-containers/kata-containers?tag=3.25.0#17472f3f10c83a8626ea2bde8c4d4868f6ee95b4"
+source = "git+https://github.com/kata-containers/kata-containers?tag=3.31.0#cec98e0d976bbf4cae016298ffea269f57294264"
 dependencies = [
- "kvm-bindings 0.6.0",
- "kvm-ioctls 0.12.1",
+ "kvm-bindings",
+ "kvm-ioctls",
  "libc",
  "memoffset 0.6.5",
  "thiserror 1.0.69",
- "vm-memory 0.10.0",
- "vmm-sys-util 0.11.2",
+ "vm-memory 0.17.1",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
 name = "dbs-boot"
 version = "0.4.0"
-source = "git+https://github.com/kata-containers/kata-containers?tag=3.25.0#17472f3f10c83a8626ea2bde8c4d4868f6ee95b4"
+source = "git+https://github.com/kata-containers/kata-containers?tag=3.31.0#cec98e0d976bbf4cae016298ffea269f57294264"
 dependencies = [
  "dbs-arch",
- "kvm-bindings 0.6.0",
- "kvm-ioctls 0.12.1",
+ "kvm-bindings",
+ "kvm-ioctls",
  "lazy_static",
  "libc",
  "thiserror 1.0.69",
  "vm-fdt",
- "vm-memory 0.10.0",
+ "vm-memory 0.17.1",
 ]
 
 [[package]]
 name = "dbs-device"
 version = "0.2.0"
-source = "git+https://github.com/kata-containers/kata-containers?tag=3.25.0#17472f3f10c83a8626ea2bde8c4d4868f6ee95b4"
+source = "git+https://github.com/kata-containers/kata-containers?tag=3.31.0#cec98e0d976bbf4cae016298ffea269f57294264"
 dependencies = [
  "thiserror 1.0.69",
 ]
@@ -3759,20 +3757,21 @@ dependencies = [
 [[package]]
 name = "dbs-interrupt"
 version = "0.2.2"
-source = "git+https://github.com/kata-containers/kata-containers?tag=3.25.0#17472f3f10c83a8626ea2bde8c4d4868f6ee95b4"
+source = "git+https://github.com/kata-containers/kata-containers?tag=3.31.0#cec98e0d976bbf4cae016298ffea269f57294264"
 dependencies = [
+ "bilge",
  "dbs-arch",
  "dbs-device",
- "kvm-bindings 0.6.0",
- "kvm-ioctls 0.12.1",
+ "kvm-bindings",
+ "kvm-ioctls",
  "libc",
- "vmm-sys-util 0.11.2",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
 name = "dbs-legacy-devices"
 version = "0.1.1"
-source = "git+https://github.com/kata-containers/kata-containers?tag=3.25.0#17472f3f10c83a8626ea2bde8c4d4868f6ee95b4"
+source = "git+https://github.com/kata-containers/kata-containers?tag=3.31.0#cec98e0d976bbf4cae016298ffea269f57294264"
 dependencies = [
  "dbs-device",
  "dbs-utils",
@@ -3780,13 +3779,13 @@ dependencies = [
  "log",
  "serde",
  "vm-superio",
- "vmm-sys-util 0.11.2",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
 name = "dbs-pci"
 version = "0.1.0"
-source = "git+https://github.com/kata-containers/kata-containers?tag=3.25.0#17472f3f10c83a8626ea2bde8c4d4868f6ee95b4"
+source = "git+https://github.com/kata-containers/kata-containers?tag=3.31.0#cec98e0d976bbf4cae016298ffea269f57294264"
 dependencies = [
  "byteorder",
  "dbs-address-space",
@@ -3796,18 +3795,16 @@ dependencies = [
  "dbs-interrupt",
  "dbs-utils",
  "dbs-virtio-devices",
- "downcast-rs",
- "kvm-bindings 0.6.0",
- "kvm-ioctls 0.12.1",
+ "kvm-bindings",
+ "kvm-ioctls",
  "libc",
  "log",
  "serde",
  "thiserror 1.0.69",
- "vfio-bindings 0.3.1",
+ "vfio-bindings",
  "vfio-ioctls",
- "virtio-queue 0.7.1",
- "vm-memory 0.10.0",
- "vmm-sys-util 0.11.2",
+ "virtio-queue 0.17.0",
+ "vm-memory 0.17.1",
 ]
 
 [[package]]
@@ -3826,9 +3823,8 @@ dependencies = [
 [[package]]
 name = "dbs-upcall"
 version = "0.3.0"
-source = "git+https://github.com/kata-containers/kata-containers?tag=3.25.0#17472f3f10c83a8626ea2bde8c4d4868f6ee95b4"
+source = "git+https://github.com/kata-containers/kata-containers?tag=3.31.0#cec98e0d976bbf4cae016298ffea269f57294264"
 dependencies = [
- "anyhow",
  "dbs-utils",
  "dbs-virtio-devices",
  "log",
@@ -3839,7 +3835,7 @@ dependencies = [
 [[package]]
 name = "dbs-utils"
 version = "0.2.1"
-source = "git+https://github.com/kata-containers/kata-containers?tag=3.25.0#17472f3f10c83a8626ea2bde8c4d4868f6ee95b4"
+source = "git+https://github.com/kata-containers/kata-containers?tag=3.31.0#cec98e0d976bbf4cae016298ffea269f57294264"
 dependencies = [
  "anyhow",
  "event-manager",
@@ -3848,13 +3844,13 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
  "timerfd",
- "vmm-sys-util 0.11.2",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
 name = "dbs-virtio-devices"
 version = "0.3.1"
-source = "git+https://github.com/kata-containers/kata-containers?tag=3.25.0#17472f3f10c83a8626ea2bde8c4d4868f6ee95b4"
+source = "git+https://github.com/kata-containers/kata-containers?tag=3.31.0#cec98e0d976bbf4cae016298ffea269f57294264"
 dependencies = [
  "byteorder",
  "caps",
@@ -3864,16 +3860,17 @@ dependencies = [
  "dbs-interrupt",
  "dbs-utils",
  "epoll",
- "fuse-backend-rs 0.10.5",
+ "fuse-backend-rs 0.14.0",
  "io-uring",
- "kvm-bindings 0.6.0",
- "kvm-ioctls 0.12.1",
+ "kata-sys-util",
+ "kvm-bindings",
+ "kvm-ioctls",
  "libc",
  "log",
  "nix 0.24.3",
- "nydus-api 0.3.1",
- "nydus-rafs 0.3.2",
- "nydus-storage 0.6.4",
+ "nydus-api 0.4.1",
+ "nydus-rafs 0.4.1",
+ "nydus-storage 0.7.2",
  "rlimit 0.7.0",
  "sendfd",
  "serde",
@@ -3881,11 +3878,11 @@ dependencies = [
  "thiserror 1.0.69",
  "threadpool",
  "timerfd",
- "vhost 0.6.1",
- "virtio-bindings 0.1.0",
- "virtio-queue 0.7.1",
- "vm-memory 0.10.0",
- "vmm-sys-util 0.11.2",
+ "vhost 0.15.0",
+ "virtio-bindings",
+ "virtio-queue 0.17.0",
+ "vm-memory 0.17.1",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
@@ -4274,20 +4271,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
-name = "downcast-rs"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
-
-[[package]]
 name = "dragonball"
 version = "0.1.0"
-source = "git+https://github.com/kata-containers/kata-containers?tag=3.25.0#17472f3f10c83a8626ea2bde8c4d4868f6ee95b4"
+source = "git+https://github.com/kata-containers/kata-containers?tag=3.31.0#cec98e0d976bbf4cae016298ffea269f57294264"
 dependencies = [
  "anyhow",
  "arc-swap",
  "bytes",
  "crossbeam-channel",
+ "dbs-acpi",
  "dbs-address-space",
  "dbs-allocator",
  "dbs-arch",
@@ -4300,9 +4292,9 @@ dependencies = [
  "dbs-utils",
  "dbs-virtio-devices",
  "derivative",
- "fuse-backend-rs 0.10.5",
- "kvm-bindings 0.6.0",
- "kvm-ioctls 0.12.1",
+ "kata-sys-util",
+ "kvm-bindings",
+ "kvm-ioctls",
  "lazy_static",
  "libc",
  "linux-loader",
@@ -4318,11 +4310,11 @@ dependencies = [
  "slog-scope",
  "thiserror 1.0.69",
  "tracing",
- "vfio-bindings 0.3.1",
+ "vfio-bindings",
  "vfio-ioctls",
- "virtio-queue 0.7.1",
- "vm-memory 0.10.0",
- "vmm-sys-util 0.11.2",
+ "virtio-queue 0.17.0",
+ "vm-memory 0.17.1",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
@@ -4378,7 +4370,7 @@ dependencies = [
  "chrono",
  "rust_decimal",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "winnow 0.7.13",
 ]
@@ -4747,12 +4739,12 @@ dependencies = [
 
 [[package]]
 name = "event-manager"
-version = "0.2.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377fa591135fbe23396a18e2655a6d5481bf7c5823cdfa3cc81b01a229cbe640"
+checksum = "13bdac971eb2efaceffca0976058ab80c715945cc565c8a4aa1ed3bb0dc8d0e4"
 dependencies = [
  "libc",
- "vmm-sys-util 0.15.0",
+ "vmm-sys-util 0.12.1",
 ]
 
 [[package]]
@@ -5092,26 +5084,6 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fuse-backend-rs"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f85357722be4bf3d0b7548bedf7499686c77628c2c61cb99c6519463f7a9e5f0"
-dependencies = [
- "arc-swap",
- "bitflags 1.3.2",
- "caps",
- "core-foundation-sys",
- "lazy_static",
- "libc",
- "log",
- "mio 0.8.11",
- "nix 0.24.3",
- "virtio-queue 0.7.1",
- "vm-memory 0.10.0",
- "vmm-sys-util 0.11.2",
-]
-
-[[package]]
-name = "fuse-backend-rs"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39179fe2c126f4695984992b6ce08b3b90994b1b1b581c3c58ca29585a56ca81"
@@ -5132,6 +5104,27 @@ dependencies = [
  "virtio-queue 0.12.0",
  "vm-memory 0.14.1",
  "vmm-sys-util 0.12.1",
+]
+
+[[package]]
+name = "fuse-backend-rs"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d8148185e731fa601a078e4ae8c742bf4b69e86e19136848780deaef08fd7d"
+dependencies = [
+ "arc-swap",
+ "bitflags 1.3.2",
+ "caps",
+ "core-foundation-sys",
+ "lazy_static",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "nix 0.24.3",
+ "radix_trie",
+ "virtio-queue 0.17.0",
+ "vm-memory 0.17.1",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
@@ -5331,7 +5324,7 @@ dependencies = [
  "log",
  "rustversion",
  "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -5555,7 +5548,7 @@ dependencies = [
  "gix-trace",
  "kstring",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "unicode-bom",
 ]
 
@@ -5590,7 +5583,7 @@ dependencies = [
  "bstr",
  "gix-trace",
  "gix-validate",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5601,7 +5594,7 @@ checksum = "1b005c550bf84de3b24aa5e540a23e6146a1c01c7d30470e35d75a12f827f969"
 dependencies = [
  "bstr",
  "gix-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5627,7 +5620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b1e63a5b516e970a594f870ed4571a8fdcb8a344e7bd407a20db8bd61dbfde4"
 dependencies = [
  "bstr",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5953,7 +5946,7 @@ dependencies = [
  "jni 0.22.4",
  "rand 0.10.1",
  "rustls 0.23.40",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -5980,7 +5973,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "socket2 0.5.10",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tokio",
  "tracing",
@@ -6001,7 +5994,7 @@ dependencies = [
  "prefix-trie",
  "rand 0.10.1",
  "ring",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "url",
@@ -6023,7 +6016,7 @@ dependencies = [
  "rand 0.9.2",
  "resolv-conf",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -6050,7 +6043,7 @@ dependencies = [
  "rustls 0.23.40",
  "smallvec",
  "system-configuration 0.7.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls 0.26.2",
  "tracing",
@@ -6173,7 +6166,7 @@ dependencies = [
  "reqwest 0.12.28",
  "reqwest-middleware",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "urlencoding",
 ]
 
@@ -6210,7 +6203,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -6356,7 +6349,7 @@ dependencies = [
 [[package]]
 name = "hypervisor"
 version = "0.1.0"
-source = "git+https://github.com/kata-containers/kata-containers?tag=3.25.0#17472f3f10c83a8626ea2bde8c4d4868f6ee95b4"
+source = "git+https://github.com/kata-containers/kata-containers?tag=3.31.0#cec98e0d976bbf4cae016298ffea269f57294264"
 dependencies = [
  "actix-rt",
  "anyhow",
@@ -6375,21 +6368,20 @@ dependencies = [
  "libc",
  "logging",
  "nix 0.26.4",
- "oci-spec",
+ "once_cell",
  "path-clean",
  "persist",
- "protobuf",
  "protocols",
  "qapi",
  "qapi-qmp",
  "qapi-spec",
- "rand 0.8.5",
+ "rand 0.10.1",
+ "regex",
  "rust-ini 0.18.0",
  "safe-path 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "seccompiler",
  "serde",
  "serde_json",
- "shim-interface",
  "slog",
  "slog-scope",
  "tests_utils",
@@ -6398,7 +6390,7 @@ dependencies = [
  "tracing",
  "ttrpc",
  "ttrpc-codegen",
- "vmm-sys-util 0.11.2",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
@@ -6617,7 +6609,7 @@ dependencies = [
  "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls 0.26.2",
  "tokio-stream",
@@ -6891,7 +6883,7 @@ dependencies = [
  "tracing",
  "vhost 0.11.0",
  "vhost-user-backend",
- "virtio-bindings 0.2.7",
+ "virtio-bindings",
  "virtio-queue 0.12.0",
  "vm-memory 0.14.1",
  "vmm-sys-util 0.12.1",
@@ -6968,7 +6960,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -7627,7 +7619,7 @@ dependencies = [
  "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "walkdir",
  "windows-link 0.2.1",
 ]
@@ -7756,31 +7748,26 @@ checksum = "8fe90c1150662e858c7d5f945089b7517b0a80d8bf7ba4b1b5ffc984e7230a5b"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "kata-sys-util"
 version = "0.1.0"
-source = "git+https://github.com/kata-containers/kata-containers?tag=3.25.0#17472f3f10c83a8626ea2bde8c4d4868f6ee95b4"
+source = "git+https://github.com/kata-containers/kata-containers?tag=3.31.0#cec98e0d976bbf4cae016298ffea269f57294264"
 dependencies = [
  "anyhow",
  "byteorder",
- "chrono",
- "common-path",
  "fail",
  "hex",
  "kata-types",
  "lazy_static",
  "libc",
- "mockall",
  "nix 0.26.4",
  "oci-spec",
- "once_cell",
  "pci-ids",
- "rand 0.8.5",
+ "rand 0.10.1",
  "runtime-spec",
- "safe-path 0.1.0 (git+https://github.com/kata-containers/kata-containers?tag=3.25.0)",
  "serde",
  "serde_json",
  "slog",
@@ -7792,7 +7779,7 @@ dependencies = [
 [[package]]
 name = "kata-types"
 version = "0.1.0"
-source = "git+https://github.com/kata-containers/kata-containers?tag=3.25.0#17472f3f10c83a8626ea2bde8c4d4868f6ee95b4"
+source = "git+https://github.com/kata-containers/kata-containers?tag=3.31.0#cec98e0d976bbf4cae016298ffea269f57294264"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -7800,18 +7787,19 @@ dependencies = [
  "byte-unit",
  "flate2",
  "glob",
- "hex",
  "lazy_static",
+ "nix 0.26.4",
  "num_cpus",
  "oci-spec",
  "regex",
- "safe-path 0.1.0 (git+https://github.com/kata-containers/kata-containers?tag=3.25.0)",
+ "safe-path 0.1.0 (git+https://github.com/kata-containers/kata-containers?tag=3.31.0)",
  "serde",
  "serde-enum-str",
  "serde_json",
  "sha2 0.10.9",
  "slog",
  "slog-scope",
+ "sysctl",
  "sysinfo 0.34.2",
  "thiserror 1.0.69",
  "toml 0.5.11",
@@ -7921,15 +7909,6 @@ dependencies = [
 
 [[package]]
 name = "kvm-bindings"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efe70e65a5b092161d17f5005b66e5eefe7a94a70c332e755036fc4af78c4e79"
-dependencies = [
- "vmm-sys-util 0.11.2",
-]
-
-[[package]]
-name = "kvm-bindings"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b3c06ff73c7ce03e780887ec2389d62d2a2a9ddf471ab05c2ff69207cd3f3b4"
@@ -7939,23 +7918,12 @@ dependencies = [
 
 [[package]]
 name = "kvm-ioctls"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d592c9b0da14bacab1fe89c78e7ed873b20cf7f502d0fc26f628d733215b1e5"
-dependencies = [
- "kvm-bindings 0.6.0",
- "libc",
- "vmm-sys-util 0.11.2",
-]
-
-[[package]]
-name = "kvm-ioctls"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "333f77a20344a448f3f70664918135fddeb804e938f28a99d685bd92926e0b19"
 dependencies = [
  "bitflags 2.11.0",
- "kvm-bindings 0.14.0",
+ "kvm-bindings",
  "libc",
  "vmm-sys-util 0.15.0",
 ]
@@ -7968,7 +7936,7 @@ checksum = "49fefd6652c57d68aaa32544a4c0e642929725bdc1fd929367cdeb673ab81088"
 dependencies = [
  "enumflags2",
  "libc",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8147,7 +8115,7 @@ dependencies = [
  "multiaddr",
  "pin-project",
  "rw-stream-sink",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8191,7 +8159,7 @@ dependencies = [
  "quick-protobuf",
  "rand 0.8.5",
  "rw-stream-sink",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "unsigned-varint 0.8.0",
  "web-time",
@@ -8230,7 +8198,7 @@ dependencies = [
  "quick-protobuf",
  "quick-protobuf-codec",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -8247,7 +8215,7 @@ dependencies = [
  "quick-protobuf",
  "rand 0.8.5",
  "sha2 0.10.9",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "zeroize",
 ]
@@ -8273,7 +8241,7 @@ dependencies = [
  "rand 0.8.5",
  "sha2 0.10.9",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "uint",
  "web-time",
@@ -8332,7 +8300,7 @@ dependencies = [
  "rand 0.8.5",
  "snow",
  "static_assertions",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "x25519-dalek",
  "zeroize",
@@ -8355,7 +8323,7 @@ dependencies = [
  "ring",
  "rustls 0.23.40",
  "socket2 0.5.10",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -8440,7 +8408,7 @@ dependencies = [
  "ring",
  "rustls 0.23.40",
  "rustls-webpki 0.103.13",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "x509-parser 0.17.0",
  "yasna",
 ]
@@ -8469,7 +8437,7 @@ dependencies = [
  "either",
  "futures",
  "libp2p-core",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "yamux 0.12.1",
  "yamux 0.13.7",
@@ -8593,11 +8561,11 @@ dependencies = [
 
 [[package]]
 name = "linux-loader"
-version = "0.8.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9259ddbfbb52cc918f6bbc60390004ddd0228cf1d85f402009ff2b3d95de83f"
+checksum = "de72cb02c55ecffcf75fe78295926f872eb6eb0a58d629c58a8c324dc26380f6"
 dependencies = [
- "vm-memory 0.10.0",
+ "vm-memory 0.17.1",
 ]
 
 [[package]]
@@ -8671,7 +8639,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 [[package]]
 name = "logging"
 version = "0.1.0"
-source = "git+https://github.com/kata-containers/kata-containers?tag=3.25.0#17472f3f10c83a8626ea2bde8c4d4868f6ee95b4"
+source = "git+https://github.com/kata-containers/kata-containers?tag=3.31.0#cec98e0d976bbf4cae016298ffea269f57294264"
 dependencies = [
  "arc-swap",
  "lazy_static",
@@ -8871,7 +8839,7 @@ dependencies = [
  "serde",
  "static_assertions",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "utils",
@@ -9138,7 +9106,7 @@ dependencies = [
  "rand 0.9.2",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-async",
@@ -9440,7 +9408,7 @@ dependencies = [
  "log",
  "netlink-packet-core 0.7.0",
  "netlink-sys",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9454,7 +9422,7 @@ dependencies = [
  "log",
  "netlink-packet-core 0.8.1",
  "netlink-sys",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9627,7 +9595,7 @@ dependencies = [
  "rustc-hash",
  "rustls 0.23.40",
  "socket2 0.6.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -9655,7 +9623,7 @@ dependencies = [
  "rustls-pki-types",
  "slab",
  "sorted-index-buffer",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -9851,7 +9819,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -9874,21 +9842,22 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "nydus-api"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64c62d8a36c10b654b87246a39861b2c05f68e96ab3b2f002f5a54f406d5e0e"
+version = "0.4.0"
+source = "git+https://github.com/dragonflyoss/nydus?tag=v2.4.0#5a9d42d8b5cae5052b678ce324d79098f8ae19c1"
 dependencies = [
  "libc",
  "log",
  "serde",
  "serde_json",
+ "thiserror 1.0.69",
  "toml 0.5.11",
 ]
 
 [[package]]
 name = "nydus-api"
-version = "0.4.0"
-source = "git+https://github.com/dragonflyoss/nydus?tag=v2.4.0#5a9d42d8b5cae5052b678ce324d79098f8ae19c1"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed56c108f48e33f960f22a669416eaede90fb28ccbc565ac76b8447183e40d9e"
 dependencies = [
  "libc",
  "log",
@@ -9926,28 +9895,6 @@ dependencies = [
 
 [[package]]
 name = "nydus-rafs"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adde865ef71c91c5f139c4c05ca5aedb6fbd53f530d646b13409ac5220b85467"
-dependencies = [
- "anyhow",
- "arc-swap",
- "bitflags 1.3.2",
- "fuse-backend-rs 0.10.5",
- "lazy_static",
- "libc",
- "log",
- "nix 0.24.3",
- "nydus-api 0.3.1",
- "nydus-storage 0.6.4",
- "nydus-utils 0.4.3",
- "serde",
- "serde_json",
- "vm-memory 0.10.0",
-]
-
-[[package]]
-name = "nydus-rafs"
 version = "0.4.0"
 source = "git+https://github.com/dragonflyoss/nydus?tag=v2.4.0#5a9d42d8b5cae5052b678ce324d79098f8ae19c1"
 dependencies = [
@@ -9966,6 +9913,29 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "vm-memory 0.14.1",
+]
+
+[[package]]
+name = "nydus-rafs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d90338636ae60ef22ef901acc3f3c77a6a00fe7a60868d0e88f10330bc9d409f"
+dependencies = [
+ "anyhow",
+ "arc-swap",
+ "bitflags 1.3.2",
+ "fuse-backend-rs 0.14.0",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix 0.24.3",
+ "nydus-api 0.4.1",
+ "nydus-storage 0.7.2",
+ "nydus-utils 0.5.1",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "vm-memory 0.17.1",
 ]
 
 [[package]]
@@ -9996,35 +9966,6 @@ dependencies = [
 
 [[package]]
 name = "nydus-storage"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4023f15303dbbda47797d07e9acd2045862ce82c7e28cd66f70b09bda5584cbb"
-dependencies = [
- "arc-swap",
- "base64 0.21.7",
- "bitflags 1.3.2",
- "fuse-backend-rs 0.10.5",
- "hex",
- "hmac 0.12.1",
- "httpdate",
- "lazy_static",
- "libc",
- "log",
- "nix 0.24.3",
- "nydus-api 0.3.1",
- "nydus-utils 0.4.3",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "sha1",
- "tar",
- "tokio",
- "url",
- "vm-memory 0.10.0",
-]
-
-[[package]]
-name = "nydus-storage"
 version = "0.7.1"
 source = "git+https://github.com/dragonflyoss/nydus?tag=v2.4.0#5a9d42d8b5cae5052b678ce324d79098f8ae19c1"
 dependencies = [
@@ -10049,6 +9990,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "nydus-storage"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d61347d0314a138dff519bb866ef97f25380f9688b5194aa1718381b441cb0e"
+dependencies = [
+ "arc-swap",
+ "base64 0.21.7",
+ "bitflags 1.3.2",
+ "fuse-backend-rs 0.14.0",
+ "hex",
+ "hmac 0.12.1",
+ "httpdate",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix 0.24.3",
+ "nydus-api 0.4.1",
+ "nydus-utils 0.5.1",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha1",
+ "tar",
+ "tokio",
+ "url",
+ "vm-memory 0.17.1",
+]
+
+[[package]]
 name = "nydus-upgrade"
 version = "0.2.0"
 source = "git+https://github.com/dragonflyoss/nydus?tag=v2.4.0#5a9d42d8b5cae5052b678ce324d79098f8ae19c1"
@@ -10058,31 +10028,6 @@ dependencies = [
  "thiserror 1.0.69",
  "versionize",
  "versionize_derive",
-]
-
-[[package]]
-name = "nydus-utils"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1f7bcde0f3906cf49101f2d40e485b0155eee97e3358eefd4783448c4f69c96"
-dependencies = [
- "blake3",
- "flate2",
- "httpdate",
- "lazy_static",
- "libc",
- "libz-sys",
- "log",
- "lz4",
- "lz4-sys",
- "nix 0.24.3",
- "nydus-api 0.3.1",
- "openssl",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "tokio",
- "zstd 0.11.2+zstd.1.5.2",
 ]
 
 [[package]]
@@ -10102,6 +10047,33 @@ dependencies = [
  "lz4-sys",
  "nix 0.24.3",
  "nydus-api 0.4.0",
+ "openssl",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "tokio",
+ "zstd 0.11.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "nydus-utils"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2daddb9896199e2df5c76b1693b1766c7d8156d88f29b08eae01196fa4ee17"
+dependencies = [
+ "blake3",
+ "crc",
+ "flate2",
+ "httpdate",
+ "lazy_static",
+ "libc",
+ "libz-sys",
+ "log",
+ "lz4",
+ "lz4-sys",
+ "nix 0.24.3",
+ "nydus-api 0.4.1",
  "openssl",
  "serde",
  "serde_json",
@@ -10252,7 +10224,7 @@ dependencies = [
  "itertools 0.14.0",
  "parking_lot 0.12.4",
  "percent-encoding",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -10275,7 +10247,7 @@ dependencies = [
  "serde_json",
  "strum 0.27.2",
  "strum_macros 0.27.2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -10416,7 +10388,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -10446,7 +10418,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost 0.13.5",
  "reqwest 0.12.28",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tonic 0.13.1",
  "tracing",
@@ -10494,7 +10466,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.9.2",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
 ]
@@ -10764,7 +10736,7 @@ dependencies = [
  "rustversion",
  "static_assertions",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -10839,17 +10811,15 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "persist"
 version = "0.1.0"
-source = "git+https://github.com/kata-containers/kata-containers?tag=3.25.0#17472f3f10c83a8626ea2bde8c4d4868f6ee95b4"
+source = "git+https://github.com/kata-containers/kata-containers?tag=3.31.0#cec98e0d976bbf4cae016298ffea269f57294264"
 dependencies = [
  "anyhow",
  "async-trait",
  "kata-sys-util",
  "kata-types",
- "libc",
- "safe-path 0.1.0 (git+https://github.com/kata-containers/kata-containers?tag=3.25.0)",
+ "safe-path 0.1.0 (git+https://github.com/kata-containers/kata-containers?tag=3.31.0)",
  "serde",
  "serde_json",
- "shim-interface",
 ]
 
 [[package]]
@@ -10859,7 +10829,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21e0a3a33733faeaf8651dfee72dd0f388f0c8e5ad496a3478fa5a922f49cfa8"
 dependencies = [
  "memchr",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "ucd-trie",
 ]
 
@@ -11269,7 +11239,7 @@ dependencies = [
  "rayon",
  "regex",
  "strum_macros 0.26.4",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "version_check",
  "xxhash-rust",
 ]
@@ -11283,7 +11253,7 @@ dependencies = [
  "polars-arrow-format",
  "regex",
  "simdutf8",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11926,7 +11896,7 @@ dependencies = [
  "parking_lot 0.12.4",
  "procfs 0.17.0",
  "protobuf",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -12109,7 +12079,7 @@ dependencies = [
 [[package]]
 name = "protocols"
 version = "0.1.0"
-source = "git+https://github.com/kata-containers/kata-containers?tag=3.25.0#17472f3f10c83a8626ea2bde8c4d4868f6ee95b4"
+source = "git+https://github.com/kata-containers/kata-containers?tag=3.31.0#cec98e0d976bbf4cae016298ffea269f57294264"
 dependencies = [
  "async-trait",
  "oci-spec",
@@ -12297,7 +12267,7 @@ dependencies = [
  "rustc-hash",
  "rustls 0.23.40",
  "socket2 0.6.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -12320,7 +12290,7 @@ dependencies = [
  "rustls-pki-types",
  "rustls-platform-verifier",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -12515,7 +12485,7 @@ dependencies = [
  "kasuari",
  "lru 0.16.1",
  "strum 0.27.2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.1",
@@ -12682,7 +12652,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -13072,7 +13042,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sse-stream",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -13169,9 +13139,8 @@ dependencies = [
 [[package]]
 name = "runtime-spec"
 version = "0.1.0"
-source = "git+https://github.com/kata-containers/kata-containers?tag=3.25.0#17472f3f10c83a8626ea2bde8c4d4868f6ee95b4"
+source = "git+https://github.com/kata-containers/kata-containers?tag=3.31.0#cec98e0d976bbf4cae016298ffea269f57294264"
 dependencies = [
- "libc",
  "serde",
  "serde_derive",
  "serde_json",
@@ -13305,7 +13274,7 @@ dependencies = [
  "flurry",
  "log",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
 ]
@@ -13633,7 +13602,7 @@ dependencies = [
 [[package]]
 name = "safe-path"
 version = "0.1.0"
-source = "git+https://github.com/kata-containers/kata-containers?tag=3.25.0#17472f3f10c83a8626ea2bde8c4d4868f6ee95b4"
+source = "git+https://github.com/kata-containers/kata-containers?tag=3.31.0#cec98e0d976bbf4cae016298ffea269f57294264"
 dependencies = [
  "libc",
 ]
@@ -13889,26 +13858,26 @@ dependencies = [
 
 [[package]]
 name = "serde-attributes"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eb8ec7724e4e524b2492b510e66957fe1a2c76c26a6975ec80823f2439da685"
+checksum = "a57f1caf4b79918ded05d624e4da4d85201c38b6ad5bbcec5b0a5fca5aabe0cb"
 dependencies = [
- "darling_core 0.14.4",
+ "darling_core 0.23.0",
  "serde-rename-rule",
- "syn 1.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "serde-enum-str"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26416dc95fcd46b0e4b12a3758043a229a6914050aaec2e8191949753ed4e9aa"
+checksum = "548ed7cf39ded10383d58de438d120c2b019cf882d0d7e99a7500724090200bf"
 dependencies = [
- "darling 0.14.4",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "serde-attributes",
- "syn 1.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -14171,20 +14140,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shim-interface"
-version = "0.1.0"
-source = "git+https://github.com/kata-containers/kata-containers?tag=3.25.0#17472f3f10c83a8626ea2bde8c4d4868f6ee95b4"
-dependencies = [
- "anyhow",
- "hyper 0.14.32",
- "hyperlocal",
- "kata-sys-util",
- "kata-types",
- "nix 0.26.4",
- "tokio",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14280,7 +14235,7 @@ checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -14777,7 +14732,7 @@ dependencies = [
  "memmap2",
  "serde",
  "subsecond-types",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -14871,9 +14826,23 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "walkdir",
  "yaml-rust",
+]
+
+[[package]]
+name = "sysctl"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cca424247104946a59dacd27eaad296223b7feec3d168a6dd04585183091eb0b"
+dependencies = [
+ "bitflags 2.11.0",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror 2.0.18",
+ "walkdir",
 ]
 
 [[package]]
@@ -15052,11 +15021,11 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 [[package]]
 name = "tests_utils"
 version = "0.1.0"
-source = "git+https://github.com/kata-containers/kata-containers?tag=3.25.0#17472f3f10c83a8626ea2bde8c4d4868f6ee95b4"
+source = "git+https://github.com/kata-containers/kata-containers?tag=3.31.0#cec98e0d976bbf4cae016298ffea269f57294264"
 dependencies = [
  "anyhow",
  "kata-types",
- "rand 0.8.5",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -15079,11 +15048,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -15099,9 +15068,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -15266,7 +15235,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spm_precompiled",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "unicode-normalization-alignments",
  "unicode-segmentation",
  "unicode_categories",
@@ -16137,7 +16106,7 @@ dependencies = [
  "merklehash",
  "pin-project",
  "shellexpand",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -16161,6 +16130,7 @@ checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",
+ "rand 0.9.2",
  "serde",
  "sha1_smol",
  "wasm-bindgen",
@@ -16251,43 +16221,25 @@ dependencies = [
 
 [[package]]
 name = "vfio-bindings"
-version = "0.3.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43449b404c488f70507dca193debd4bea361fe8089869b947adc19720e464bce"
-
-[[package]]
-name = "vfio-bindings"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4bc5b4aade27640cea4ee1ce50ef3614598050dc97e44714b9daea779d1b59a"
+checksum = "188dac3057a0cbc94470085204c84b82ff7ec5dac629a514323cd133d1f9abe0"
 
 [[package]]
 name = "vfio-ioctls"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068bac78842164a8ecc1d1a84a8d8a9168ab29fa3c96942689e286a30ae22ac4"
-dependencies = [
- "byteorder",
- "kvm-bindings 0.14.0",
- "kvm-ioctls 0.24.0",
- "libc",
- "log",
- "thiserror 2.0.17",
- "vfio-bindings 0.6.1",
- "vm-memory 0.14.1",
- "vmm-sys-util 0.15.0",
-]
-
-[[package]]
-name = "vhost"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6769e8dbf5276b4376439fbf36bb880d203bf614bf7ef444198edc24b5a9f35"
+checksum = "4e5ea6ba374c4ca77ee8cde0b927a40083dd2388dc0fb464fed6fef62edc3566"
 dependencies = [
- "bitflags 1.3.2",
+ "byteorder",
+ "kvm-bindings",
+ "kvm-ioctls",
  "libc",
- "vm-memory 0.10.0",
- "vmm-sys-util 0.11.2",
+ "log",
+ "thiserror 2.0.18",
+ "vfio-bindings",
+ "vm-memory 0.17.1",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
@@ -16303,6 +16255,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "vhost"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c76d90ce3c6b37d610a5304c9a445cfff580cf8b4b9fd02fb256aaf68552c28a"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "uuid 1.18.1",
+ "vm-memory 0.17.1",
+ "vmm-sys-util 0.15.0",
+]
+
+[[package]]
 name = "vhost-user-backend"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16311,17 +16276,11 @@ dependencies = [
  "libc",
  "log",
  "vhost 0.11.0",
- "virtio-bindings 0.2.7",
+ "virtio-bindings",
  "virtio-queue 0.12.0",
  "vm-memory 0.14.1",
  "vmm-sys-util 0.12.1",
 ]
-
-[[package]]
-name = "virtio-bindings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff512178285488516ed85f15b5d0113a7cdb89e9e8a760b269ae4f02b84bd6b"
 
 [[package]]
 name = "virtio-bindings"
@@ -16331,44 +16290,34 @@ checksum = "091f1f09cfbf2a78563b562e7a949465cce1aef63b6065645188d995162f8868"
 
 [[package]]
 name = "virtio-queue"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ba81e2bcc21c0d2fc5e6683e79367e26ad219197423a498df801d79d5ba77bd"
-dependencies = [
- "log",
- "virtio-bindings 0.1.0",
- "vm-memory 0.10.0",
- "vmm-sys-util 0.11.2",
-]
-
-[[package]]
-name = "virtio-queue"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07d8406e7250c934462de585d8f2d2781c31819bca1fbb7c5e964ca6bbaabfe8"
 dependencies = [
  "log",
- "virtio-bindings 0.2.7",
+ "virtio-bindings",
  "vm-memory 0.14.1",
  "vmm-sys-util 0.12.1",
 ]
 
 [[package]]
-name = "vm-fdt"
-version = "0.2.0"
+name = "virtio-queue"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43fb5a6bd1a7d423ad72802801036719b7546cf847a103f8fe4575f5b0d45a6"
+checksum = "e358084f32ed165fddb41d98ff1b7ff3c08b9611d8d6114a1b422e2e85688baf"
+dependencies = [
+ "libc",
+ "log",
+ "virtio-bindings",
+ "vm-memory 0.17.1",
+ "vmm-sys-util 0.15.0",
+]
 
 [[package]]
-name = "vm-memory"
-version = "0.10.0"
+name = "vm-fdt"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688a70366615b45575a424d9c665561c1b5ab2224d494f706b6a6812911a827c"
-dependencies = [
- "arc-swap",
- "libc",
- "winapi",
-]
+checksum = "7e21282841a059bb62627ce8441c491f09603622cd5a21c43bfedc85a2952f23"
 
 [[package]]
 name = "vm-memory"
@@ -16383,36 +16332,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "vm-memory"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f39348a049689cabd3377cdd9182bf526ec76a6f823b79903896452e9d7a7380"
+dependencies = [
+ "arc-swap",
+ "libc",
+ "thiserror 2.0.18",
+ "winapi",
+]
+
+[[package]]
 name = "vm-superio"
-version = "0.5.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b5231d334edbc03b22704caa1a022e4c07491d6df736593f26094df8b04a51"
-
-[[package]]
-name = "vmm-sys-util"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08604d7be03eb26e33b3cee3ed4aef2bf550b305d1cca60e84da5d28d3790b62"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
-]
-
-[[package]]
-name = "vmm-sys-util"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48b7b084231214f7427041e4220d77dfe726897a6d41fddee450696e66ff2a29"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
-]
+checksum = "69c376a9b84afdf97bddd2628096cf3554208b2a676cf06b4532e0f433a54e02"
 
 [[package]]
 name = "vmm-sys-util"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1435039746e20da4f8d507a72ee1b916f7b4b05af7a91c093d2c6561934ede"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
+name = "vmm-sys-util"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d21f366bf22bfba3e868349978766a965cbe628c323d58e026be80b8357ab789"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
@@ -16769,7 +16720,7 @@ dependencies = [
  "bytes",
  "http 1.3.1",
  "sfv",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "url",
 ]
@@ -16786,7 +16737,7 @@ dependencies = [
  "quinn",
  "rustls 0.23.40",
  "rustls-native-certs",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -17631,7 +17582,7 @@ dependencies = [
  "futures",
  "log",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "windows 0.62.2",
  "windows-core 0.62.2",
 ]
@@ -17655,7 +17606,7 @@ dependencies = [
  "pharos",
  "rustc_version",
  "send_wrapper",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -17729,7 +17680,7 @@ dependencies = [
  "nom",
  "oid-registry 0.8.1",
  "rusticata-macros",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -17785,7 +17736,7 @@ dependencies = [
  "libc",
  "oneshot",
  "reqwest 0.12.28",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "utils",

--- a/crates/hyprstream-workers/Cargo.toml
+++ b/crates/hyprstream-workers/Cargo.toml
@@ -92,10 +92,10 @@ rand = { workspace = true }
 zeroize = { workspace = true }
 
 # Kata Containers runtime-rs (hypervisor abstraction)
-kata-hypervisor = { git = "https://github.com/kata-containers/kata-containers", tag = "3.25.0", package = "hypervisor", features = ["cloud-hypervisor"] }
-kata-types = { git = "https://github.com/kata-containers/kata-containers", tag = "3.25.0" }
-kata-sys-util = { git = "https://github.com/kata-containers/kata-containers", tag = "3.25.0" }
-ch-config = { git = "https://github.com/kata-containers/kata-containers", tag = "3.25.0" }
+kata-hypervisor = { git = "https://github.com/kata-containers/kata-containers", tag = "3.31.0", package = "hypervisor", features = ["cloud-hypervisor"] }
+kata-types = { git = "https://github.com/kata-containers/kata-containers", tag = "3.31.0" }
+kata-sys-util = { git = "https://github.com/kata-containers/kata-containers", tag = "3.31.0" }
+ch-config = { git = "https://github.com/kata-containers/kata-containers", tag = "3.31.0" }
 
 [features]
 default = []


### PR DESCRIPTION
## T1-A — bump embedded Kata runtime-rs deps

Per decision #343 (EMBED the runtime-rs hypervisor crate, no shim) and the Kata research spike: this is a **pin bump + Cargo.lock churn**, not a rewrite. No `4.0.0` tag exists yet (4.0 = preview; "runtime-rs GA + default" is a packaging change, not a new crate-API generation), and the API deltas for `kata_backend.rs` are empty.

### Version bumps (before → after)

| Crate | Before | After |
|---|---|---|
| `kata-hypervisor` (pkg `hypervisor`) | 3.25.0 | **3.31.0** |
| `kata-types` | 3.25.0 | **3.31.0** |
| `kata-sys-util` | 3.25.0 | **3.31.0** |
| `ch-config` | 3.25.0 | **3.31.0** |
| `api_client` (cloud-hypervisor) | v27.0 | **v51.0** |

3.31.0 is the newest stable 3.x tag (3.32+ do not exist).

### Cloud Hypervisor lockstep

As the spike anticipated (~v50), `ch-config`'s pinned `api_client` (cloud-hypervisor HTTP API) moves **v27.0 → v51.0**. This is driven transitively by the bumped `ch-config` crate's own deps — no manual CH pin in our tree. Resolved the resulting `Cargo.lock` churn, including shared VMM crates: `vhost` 0.6→0.15, `vm-memory` 0.10→0.17, `virtio-queue` 0.7→0.17, `vmm-sys-util` →0.14, `vfio-ioctls`/`vfio-bindings`, `linux-loader` 0.8→0.13, and the transitive nydus re-resolution (nydus-storage 0.7.1, nydus-rafs 0.4.0, etc.).

### Source edits

**None.** Verified the FS-A ShareFs attach path compiles unchanged:
- `attach_share_fs` → `Hypervisor::add_device(DeviceType::ShareFs(ShareFsDevice::new(..., &ShareFsConfig{...})))` between `prepare_vm` and `start_vm` builds against 3.31.0.
- `ShareFsConfig` / `ShareFsDevice` / `ShareFsMountConfig` structs are **byte-identical** between 3.25.0 and 3.31.0.
- The only upstream `Hypervisor` trait deltas are arch-gating `cfg` attributes (firecracker/dragonball now gated to `x86_64`/`aarch64`) — no effect on our targets or the trait methods we call.

`dragonball`/`dbus`/`systemd` feature gating left **as-is** (feature-gating the backends is #347, next on this branch — kept scoped to dependency versions so #347's Cargo.toml feature work merges cleanly).

### Build / test / clippy (build env: `OPENSSL_NO_VENDOR=1 LIBTORCH_USE_PYTORCH=1 LIBTORCH_BYPASS_VERSION_CHECK=1` + libtorch `LD_LIBRARY_PATH`)

- `cargo build -p hyprstream-workers` — **clean**
- `cargo build -p hyprstream-vfs -p hyprstream-vfs-server` (share the re-resolved nydus deps) — **clean**
- `cargo test -p hyprstream-workers --lib` — **105 passed, 0 failed, 2 ignored** (incl. all `kata_backend` tests)
- `cargo clippy -p hyprstream-workers --all-targets -- -D warnings` — **clean**

Closes #342
Part of #341