### PR TITLE
feat: feature-gate kata/nydus VM toolchain behind kata-vm (#347)

### DIFF
--- a/crates/hyprstream-workers/Cargo.toml
+++ b/crates/hyprstream-workers/Cargo.toml
@@ -15,7 +15,8 @@ hyprstream-vfs = { path = "../hyprstream-vfs" }
 # FS-A's vhost-user-fs server (native-only): serves a composed per-sandbox
 # Namespace to a Cloud Hypervisor guest. FS-D wires the compose→serve→attach
 # flow. Native-only (vhost-user-fs/fuse-backend-rs transport are Linux-only).
-hyprstream-vfs-server = { path = "../hyprstream-vfs-server" }
+# Gated behind `kata-vm`: only the VM/CH ShareFs path attaches this server.
+hyprstream-vfs-server = { path = "../hyprstream-vfs-server", optional = true }
 hyprstream-tcl = { path = "../hyprstream-tcl" }
 
 # Async runtime
@@ -54,27 +55,29 @@ which = { workspace = true }
 # D-Bus integration (optional, for container D-Bus proxy)
 zbus = { version = "4", features = ["tokio"], optional = true }
 
-# Nydus libraries (Dragonfly-native blob fetching)
+# Nydus libraries (Dragonfly-native blob fetching) — gated behind `kata-vm`.
+# Only the RAFS image-pull + virtiofs path (consumed by the Kata/CH VM backend)
+# needs these; the lightweight nspawn backend bind-mounts the host root.
 # NOTE: Using git deps because published crates.io versions have API mismatch
 # (nydus-storage 0.7.1 references field missing from nydus-api 0.4.0)
-nydus-api = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0" }
-nydus-storage = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0", features = [
+nydus-api = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0", optional = true }
+nydus-storage = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0", optional = true, features = [
     "backend-registry",
     "backend-localfs",
 ] }
 # FS-B0: in-process RAFS bootstrap builder. TarballBuilder converts pulled OCI
 # layer tarballs into a RAFS bootstrap (.meta) + dedup data blobs, no external
 # nydus-image binary required.
-nydus-builder = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0" }
-nydus-rafs = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0" }
-nydus-utils = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0" }
+nydus-builder = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0", optional = true }
+nydus-rafs = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0", optional = true }
+nydus-utils = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0", optional = true }
 
 # Phase 2: VM Runtime (nydus-service for virtiofs)
-nydus-service = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0" }
+nydus-service = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0", optional = true }
 # 0.13 to unify with nydus (`nydus-rafs` v2.4.0 builds against 0.13.1): FS-B
 # (#363) wraps the in-process RAFS `Rafs` as an overlay lower, so its `Layer`
 # type must match `hyprstream-vfs`'s `BoxedLayer`.
-fuse-backend-rs = "0.13"
+fuse-backend-rs = { version = "0.13", optional = true }
 
 # Minimal HTTP for manifest fetching only (blobs go through nydus-storage)
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
@@ -91,16 +94,36 @@ blake3 = { workspace = true }
 rand = { workspace = true }
 zeroize = { workspace = true }
 
-# Kata Containers runtime-rs (hypervisor abstraction)
-kata-hypervisor = { git = "https://github.com/kata-containers/kata-containers", tag = "3.31.0", package = "hypervisor", features = ["cloud-hypervisor"] }
-kata-types = { git = "https://github.com/kata-containers/kata-containers", tag = "3.31.0" }
-kata-sys-util = { git = "https://github.com/kata-containers/kata-containers", tag = "3.31.0" }
-ch-config = { git = "https://github.com/kata-containers/kata-containers", tag = "3.31.0" }
+# Kata Containers runtime-rs (hypervisor abstraction) — gated behind `kata-vm`.
+kata-hypervisor = { git = "https://github.com/kata-containers/kata-containers", tag = "3.31.0", package = "hypervisor", features = ["cloud-hypervisor"], optional = true }
+kata-types = { git = "https://github.com/kata-containers/kata-containers", tag = "3.31.0", optional = true }
+kata-sys-util = { git = "https://github.com/kata-containers/kata-containers", tag = "3.31.0", optional = true }
+ch-config = { git = "https://github.com/kata-containers/kata-containers", tag = "3.31.0", optional = true }
 
 [features]
 default = []
-# Enable Dragonball built-in VMM support (alternative to cloud-hypervisor)
-dragonball = ["kata-hypervisor/dragonball"]
+# Kata/Cloud-Hypervisor VM backend + the RAFS/nydus image-pull + virtiofs
+# toolchain it consumes. Opt-in so casual users who only want the lightweight
+# `systemd-nspawn` backend don't compile the entire VM stack. When this feature
+# is off, `BackendType::Kata` selection and CRI image ops return a clean
+# runtime error rather than failing to compile.
+kata-vm = [
+    "dep:kata-hypervisor",
+    "dep:kata-types",
+    "dep:kata-sys-util",
+    "dep:ch-config",
+    "dep:nydus-api",
+    "dep:nydus-storage",
+    "dep:nydus-builder",
+    "dep:nydus-rafs",
+    "dep:nydus-utils",
+    "dep:nydus-service",
+    "dep:fuse-backend-rs",
+    "dep:hyprstream-vfs-server",
+]
+# Enable Dragonball built-in VMM support (alternative to cloud-hypervisor).
+# Implies `kata-vm` since it tunes the kata hypervisor abstraction.
+dragonball = ["kata-vm", "kata-hypervisor/dragonball"]
 # Enable D-Bus bridge for container access to host D-Bus services
 dbus = ["dep:zbus"]
 # Systemd integration (socket activation, service units)

--- a/crates/hyprstream-workers/src/lib.rs
+++ b/crates/hyprstream-workers/src/lib.rs
@@ -51,6 +51,10 @@ pub mod error;
 pub use hyprstream_rpc::paths;
 
 pub mod runtime;
+// The `image` module is the RAFS/nydus image store — only the VM path consumes
+// it. Gated behind `kata-vm`; the lightweight nspawn backend bind-mounts the
+// host root and never touches RAFS.
+#[cfg(feature = "kata-vm")]
 pub mod image;
 pub mod workflow;
 pub mod events;
@@ -63,7 +67,10 @@ pub use config::{BackendType, HypervisorType, ImageConfig, PoolConfig, WorkerCon
 pub use error::WorkerError;
 
 // Re-export service types
-pub use runtime::{WorkerService, SandboxBackend, SandboxHandle, KataBackend, NspawnBackend, NspawnConfig};
+pub use runtime::{WorkerService, SandboxBackend, SandboxHandle, NspawnBackend, NspawnConfig};
+#[cfg(feature = "kata-vm")]
+pub use runtime::KataBackend;
+#[cfg(feature = "kata-vm")]
 pub use image::RafsStore;
 pub use workflow::WorkflowService;
 pub use events::{

--- a/crates/hyprstream-workers/src/runtime/mod.rs
+++ b/crates/hyprstream-workers/src/runtime/mod.rs
@@ -23,15 +23,20 @@
 pub mod backend;
 mod client;
 mod container;
+// Kata/CH VM backend — gated behind `kata-vm` (pulls the kata/nydus toolchain).
+#[cfg(feature = "kata-vm")]
 pub mod kata_backend;
 pub mod nspawn;
 mod pool;
 mod sandbox;
-// Per-sandbox VFS composition + serve (FS-D, #365): native-only.
-#[cfg(not(target_arch = "wasm32"))]
+// Per-sandbox VFS composition + serve (FS-D, #365): native-only + VM-only
+// (composes a RAFS rootfs and serves it over vhost-user-fs to a CH guest).
+#[cfg(all(not(target_arch = "wasm32"), feature = "kata-vm"))]
 pub mod sandbox_fs;
 mod service;
 pub mod spawner;
+// VirtioFS daemon wrapper (nydus-service) — VM-only.
+#[cfg(feature = "kata-vm")]
 mod virtiofs;
 
 // Generated wire types — canonical OCI/CRI-aligned names (no Gen*/Wire/Enum aliases)
@@ -73,17 +78,19 @@ pub use client::{
 };
 // Backend trait and implementations
 pub use backend::{SandboxBackend, SandboxHandle};
+#[cfg(feature = "kata-vm")]
 pub use kata_backend::{KataBackend, KataHandle};
 pub use nspawn::{NspawnBackend, NspawnConfig, NspawnHandle};
 // Domain entities (business logic only)
 pub use container::Container;
 pub use pool::{PoolStats, SandboxPool};
 pub use sandbox::PodSandbox;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "kata-vm"))]
 pub use sandbox_fs::{InjectedMounts, SandboxFs, SandboxFsServer, VFS_SOCKET_NAME};
 pub use service::WorkerService;
 // Re-export service infrastructure from hyprstream-rpc for convenience
 pub use hyprstream_rpc::service::{EnvelopeContext, ServiceHandle, RequestService};
+#[cfg(feature = "kata-vm")]
 pub use virtiofs::{SandboxVirtiofs, SandboxVirtiofsBuilder};
 
 /// CRI runtime version

--- a/crates/hyprstream-workers/src/runtime/pool.rs
+++ b/crates/hyprstream-workers/src/runtime/pool.rs
@@ -286,7 +286,8 @@ pub struct PoolStats {
     pub warm_pool_target: usize,
 }
 
-#[cfg(test)]
+// The pool tests build a KataBackend + RafsStore, so they only run under `kata-vm`.
+#[cfg(all(test, feature = "kata-vm"))]
 mod tests {
     use super::*;
     use crate::config::{ImageConfig, PoolConfig};

--- a/crates/hyprstream-workers/src/runtime/service.rs
+++ b/crates/hyprstream-workers/src/runtime/service.rs
@@ -27,6 +27,7 @@ use crate::events::{
     serialize_container_started, serialize_container_stopped,
     serialize_sandbox_started, serialize_sandbox_stopped,
 };
+#[cfg(feature = "kata-vm")]
 use crate::image::RafsStore;
 // Import generated wire types (canonical OCI-aligned names)
 use crate::generated::worker_client::{
@@ -65,7 +66,9 @@ pub struct WorkerService {
     /// Sandbox pool for VM management
     sandbox_pool: Arc<SandboxPool>,
 
-    /// RAFS store for image management
+    /// RAFS store for image management (VM path only). Without `kata-vm`,
+    /// CRI image operations return a clear "built without kata-vm support" error.
+    #[cfg(feature = "kata-vm")]
     rafs_store: Arc<RafsStore>,
 
     /// Active containers (container_id -> Container)
@@ -102,7 +105,9 @@ impl WorkerService {
     pub fn new(
         pool_config: PoolConfig,
         backend: Arc<dyn super::backend::SandboxBackend>,
-        rafs_store: Arc<RafsStore>,
+        // RAFS image store is only meaningful for the VM/CH path; the parameter
+        // is compiled away when `kata-vm` is disabled.
+        #[cfg(feature = "kata-vm")] rafs_store: Arc<RafsStore>,
         transport: TransportConfig,
         signing_key: SigningKey,
     ) -> AnyhowResult<Self> {
@@ -114,6 +119,7 @@ impl WorkerService {
         let stream_channel = Arc::new(StreamChannel::new(signing_key.clone()));
         Ok(Self {
             sandbox_pool,
+            #[cfg(feature = "kata-vm")]
             rafs_store,
             containers: RwLock::new(HashMap::new()),
             container_sandbox_map: RwLock::new(HashMap::new()),
@@ -1233,47 +1239,97 @@ impl ContainerHandler for WorkerService {
 
 }
 
+// CRI image operations are backed by the RAFS/nydus store, which only compiles
+// under `kata-vm`. When the feature is off the handlers stay wired (the RPC
+// surface is unchanged) but return a clear "built without kata-vm support" error
+// instead of failing to compile.
+#[cfg(not(feature = "kata-vm"))]
+fn image_ops_unsupported<T>() -> AnyhowResult<T> {
+    Err(anyhow::anyhow!(
+        "CRI image operations require the `kata-vm` feature (RAFS/nydus image store); \
+         this binary was built without kata-vm support"
+    ))
+}
+
 #[async_trait::async_trait(?Send)]
 impl ImageHandler for WorkerService {
     async fn handle_list(&self, _ctx: &EnvelopeContext, _request_id: u64, filter: &ImageFilter) -> AnyhowResult<Vec<ImageInfo>> {
         let _ = filter; // filter not yet used
-        let images = self.rafs_store.list_images().await?;
-        Ok(images)
+        #[cfg(feature = "kata-vm")]
+        {
+            let images = self.rafs_store.list_images().await?;
+            Ok(images)
+        }
+        #[cfg(not(feature = "kata-vm"))]
+        {
+            image_ops_unsupported()
+        }
     }
 
     async fn handle_status(&self, _ctx: &EnvelopeContext, _request_id: u64, request: &ImageStatusRequest) -> AnyhowResult<ImageStatusResult> {
-        let image_ref = &request.image.image;
-        let status = self.rafs_store.image_status(image_ref, request.verbose).await?;
-        Ok(status)
+        #[cfg(feature = "kata-vm")]
+        {
+            let image_ref = &request.image.image;
+            let status = self.rafs_store.image_status(image_ref, request.verbose).await?;
+            Ok(status)
+        }
+        #[cfg(not(feature = "kata-vm"))]
+        {
+            let _ = request;
+            image_ops_unsupported()
+        }
     }
 
     async fn handle_pull(&self, _ctx: &EnvelopeContext, _request_id: u64, data: &PullImageRequest) -> AnyhowResult<String> {
-        let image_ref = &data.image.image;
-        let auth = if !data.auth.username.is_empty() {
-            Some(crate::image::AuthConfig {
-                username: data.auth.username.clone(),
-                password: data.auth.password.clone(),
-                auth: String::new(),
-                server_address: String::new(),
-                identity_token: String::new(),
-                registry_token: String::new(),
-            })
-        } else {
-            None
-        };
-        let image_id = self.rafs_store.pull_with_auth(image_ref, auth.as_ref()).await?;
-        Ok(image_id)
+        #[cfg(feature = "kata-vm")]
+        {
+            let image_ref = &data.image.image;
+            let auth = if !data.auth.username.is_empty() {
+                Some(crate::image::AuthConfig {
+                    username: data.auth.username.clone(),
+                    password: data.auth.password.clone(),
+                    auth: String::new(),
+                    server_address: String::new(),
+                    identity_token: String::new(),
+                    registry_token: String::new(),
+                })
+            } else {
+                None
+            };
+            let image_id = self.rafs_store.pull_with_auth(image_ref, auth.as_ref()).await?;
+            Ok(image_id)
+        }
+        #[cfg(not(feature = "kata-vm"))]
+        {
+            let _ = data;
+            image_ops_unsupported()
+        }
     }
 
     async fn handle_remove(&self, _ctx: &EnvelopeContext, _request_id: u64, data: &ImageSpec) -> AnyhowResult<()> {
-        let image_ref = &data.image;
-        self.rafs_store.remove_image(image_ref).await?;
-        Ok(())
+        #[cfg(feature = "kata-vm")]
+        {
+            let image_ref = &data.image;
+            self.rafs_store.remove_image(image_ref).await?;
+            Ok(())
+        }
+        #[cfg(not(feature = "kata-vm"))]
+        {
+            let _ = data;
+            image_ops_unsupported()
+        }
     }
 
     async fn handle_fs_info(&self, _ctx: &EnvelopeContext, _request_id: u64) -> AnyhowResult<Vec<FilesystemUsage>> {
-        let usage = self.rafs_store.fs_info().await?;
-        Ok(usage)
+        #[cfg(feature = "kata-vm")]
+        {
+            let usage = self.rafs_store.fs_info().await?;
+            Ok(usage)
+        }
+        #[cfg(not(feature = "kata-vm"))]
+        {
+            image_ops_unsupported()
+        }
     }
 }
 
@@ -1336,7 +1392,9 @@ impl RequestService for WorkerService {
     }
 }
 
-#[cfg(test)]
+// These tests exercise the VM lifecycle (RafsStore + KataBackend), so they only
+// build/run under `kata-vm`.
+#[cfg(all(test, feature = "kata-vm"))]
 #[allow(clippy::print_stderr)]
 mod tests {
     use super::*;

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -190,7 +190,7 @@ keyring = { version = "3", features = ["windows-native"] }
 keyring = { version = "3", features = ["sync-secret-service", "crypto-rust"] }
 
 [features]
-default = ["gittorrent", "xet", "systemd", "otel"]
+default = ["gittorrent", "xet", "systemd", "otel", "kata-vm"]
 cuda = []
 valkey = ["dep:fred"]  # Enable Valkey/Redis-backed user and token stores
 bnb = ["dep:bitsandbytes-sys"]  # Enable bitsandbytes KV cache quantization (requires compatible ROCm/CUDA)
@@ -200,6 +200,7 @@ gittorrent = ["dep:gittorrent", "git2db/gittorrent-transport"]  # Enable P2P mod
 download-libtorch = ["tch/download-libtorch"]
 overlayfs = ["git2db/overlayfs"]  # Enable overlayfs-backed worktrees (delegated to git2db)
 systemd = ["hyprstream-rpc/systemd", "hyprstream-service/systemd", "hyprstream-workers/systemd", "dep:listenfd"]  # Systemd integration (socket activation, service units)
+kata-vm = ["hyprstream-workers/kata-vm"]  # Kata/Cloud-Hypervisor VM worker backend + RAFS/nydus image stack (in default; drop for an nspawn-only build)
 experimental = ["hyprstream-compositor/experimental"]  # EXPERIMENTAL: Enable service/worker panels, git write operations
 pq-hybrid = []  # NO-OP alias: PQ primitives always compiled; Classical/Hybrid selected at runtime. See M3 #152.
 

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -49,7 +49,9 @@ use hyprstream_core::storage::{GitRef, ModelRef};
 use hyprstream_core::services::{PolicyClient, RegistryClient};
 // Worker service for Kata-based workload execution
 use hyprstream_workers::runtime::WorkerService;
-use hyprstream_workers::{ImageConfig, PoolConfig};
+#[cfg(feature = "kata-vm")]
+use hyprstream_workers::ImageConfig;
+use hyprstream_workers::PoolConfig;
 use std::sync::Arc;
 // Unified service manager API
 use hyprstream_service::{get_factory, InprocManager, ServiceContext, ServiceManager};
@@ -1062,6 +1064,7 @@ fn handle_quick_command(
                         cloud_init_dir: data_dir.join("cloud-init"),
                         ..PoolConfig::default()
                     };
+                    #[cfg(feature = "kata-vm")]
                     let image_config = ImageConfig {
                         blobs_dir: data_dir.join("images/blobs"),
                         bootstrap_dir: data_dir.join("images/bootstrap"),
@@ -1072,17 +1075,33 @@ fn handle_quick_command(
                     };
 
                     let _worker_handle = if !worker_already_running {
-                        use hyprstream_workers::image::RafsStore;
-                        use hyprstream_workers::runtime::{SandboxBackend, KataBackend};
-                        let rafs_store = Arc::new(RafsStore::new(image_config.clone())?);
-                        let backend: Arc<dyn SandboxBackend> = Arc::new(
-                            KataBackend::new(image_config, Arc::clone(&rafs_store)),
-                        );
+                        use hyprstream_workers::runtime::SandboxBackend;
+
+                        // VM path (kata-vm): Kata backend + RAFS image store.
+                        #[cfg(feature = "kata-vm")]
+                        let rafs_store = {
+                            use hyprstream_workers::image::RafsStore;
+                            Arc::new(RafsStore::new(image_config.clone())?)
+                        };
+                        #[cfg(feature = "kata-vm")]
+                        let backend: Arc<dyn SandboxBackend> = {
+                            use hyprstream_workers::runtime::KataBackend;
+                            Arc::new(KataBackend::new(image_config, Arc::clone(&rafs_store)))
+                        };
+                        // Without kata-vm the CLI worker entrypoint falls back to
+                        // the lightweight nspawn backend.
+                        #[cfg(not(feature = "kata-vm"))]
+                        let backend: Arc<dyn SandboxBackend> = {
+                            use hyprstream_workers::{NspawnBackend, NspawnConfig};
+                            Arc::new(NspawnBackend::new(NspawnConfig::default()))
+                        };
+
                         let worker_transport =
                             TransportConfig::inproc("hyprstream/workers");
                         let mut worker_service = WorkerService::new(
                             pool_config,
                             backend,
+                            #[cfg(feature = "kata-vm")]
                             rafs_store,
                             worker_transport,
                             signing_key.clone(),

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -652,9 +652,14 @@ fn create_model_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnabl
 fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>> {
     info!("Creating WorkerService");
 
-    use hyprstream_workers::config::{BackendType, ImageConfig, PoolConfig};
+    use hyprstream_workers::config::{BackendType, PoolConfig};
+    #[cfg(feature = "kata-vm")]
+    use hyprstream_workers::config::ImageConfig;
+    #[cfg(feature = "kata-vm")]
     use hyprstream_workers::image::RafsStore;
-    use hyprstream_workers::{WorkerService, SandboxBackend, KataBackend, NspawnBackend, NspawnConfig};
+    #[cfg(feature = "kata-vm")]
+    use hyprstream_workers::KataBackend;
+    use hyprstream_workers::{WorkerService, SandboxBackend, NspawnBackend, NspawnConfig};
 
     let config = load_config();
     let worker_quic_port = config.worker.as_ref().and_then(|w| w.quic_port);
@@ -685,6 +690,8 @@ fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
         ..PoolConfig::default()
     };
 
+    // RAFS/nydus image store is only built for the VM path (kata-vm feature).
+    #[cfg(feature = "kata-vm")]
     let image_config = ImageConfig {
         blobs_dir: data_dir.join("images/blobs"),
         bootstrap_dir: data_dir.join("images/bootstrap"),
@@ -694,11 +701,20 @@ fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
         ..ImageConfig::default()
     };
 
+    #[cfg(feature = "kata-vm")]
     let rafs_store = Arc::new(RafsStore::new(image_config.clone())?);
 
-    // Construct the sandbox backend based on configuration
+    // Construct the sandbox backend based on configuration.
     let backend: Arc<dyn SandboxBackend> = match backend_type {
+        #[cfg(feature = "kata-vm")]
         BackendType::Kata => Arc::new(KataBackend::new(image_config, Arc::clone(&rafs_store))),
+        #[cfg(not(feature = "kata-vm"))]
+        BackendType::Kata => {
+            return Err(anyhow::anyhow!(
+                "worker backend `kata` requires the `kata-vm` feature; \
+                 this binary was built without kata-vm support (use the `nspawn` backend)"
+            ));
+        }
         BackendType::Nspawn => Arc::new(NspawnBackend::new(NspawnConfig::default())),
     };
 
@@ -711,6 +727,7 @@ fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
     let mut worker_service = WorkerService::new(
         pool_config,
         backend,
+        #[cfg(feature = "kata-vm")]
         rafs_store,
         ctx.transport("worker", SocketKind::Rep),
         sk.clone(),


### PR DESCRIPTION
## T2-B: feature-gate worker backends (#347)

`crates/hyprstream-workers/Cargo.toml` pulled the entire Kata /
cloud-hypervisor / nydus / fuse-backend-rs VM toolchain as **unconditional**
dependencies. A casual user who only wants the lightweight `systemd-nspawn`
backend (or a future podman backend) still compiled the whole Kata stack. This
PR makes the VM toolchain optional behind a single cargo feature.

### Feature name + taxonomy
- **`kata-vm`** (single feature). It enables the optional deps:
  `kata-hypervisor` (pkg `hypervisor`), `kata-types`, `kata-sys-util`,
  `ch-config`, all `nydus-*` (`api`/`storage`/`builder`/`rafs`/`utils`/`service`),
  `fuse-backend-rs`, and the sibling `hyprstream-vfs-server` (vhost-user-fs
  server, only the CH ShareFs path attaches it). All of those deps are now
  `optional = true`.
- **`dragonball`** now implies `kata-vm` (`["kata-vm", "kata-hypervisor/dragonball"]`).
- `dbus` / `systemd` unchanged and independent of `kata-vm`.

### Default choice + rationale
`default = []` stays — **kata-vm is opt-in**. The nspawn backend bind-mounts the
host root and needs none of the VM/RAFS stack, so the lightweight path is the
zero-dependency default. The `hyprstream` binary keeps full functionality by
listing `kata-vm` in **its own** `default` feature set (so the assembled product
is unchanged); drop it for an nspawn-only build.

### cfg-gated modules / items
hyprstream-workers:
- `image` module (entirely RAFS/nydus): `image/store.rs`, `image/rafs_builder.rs`,
  `image/rootfs_mount.rs` — gated at the `pub mod image` boundary in `lib.rs`.
- `runtime::kata_backend`, `runtime::virtiofs`, `runtime::sandbox_fs` modules +
  their re-exports in `runtime/mod.rs`.
- `WorkerService.rafs_store` field + the `rafs_store` param of `WorkerService::new`.
- `ImageHandler` impl: handlers stay wired (RPC surface unchanged) but return a
  clear "built without kata-vm support" error when the feature is off.
- Kata/RafsStore-based test modules in `service.rs` and `pool.rs`.

hyprstream (consumer):
- `services/factories.rs` + `bin/main.rs`: cfg-gate the `RafsStore`/`KataBackend`
  construction; `BackendType::Kata` selection returns a clean runtime error
  without the feature (CLI worker entrypoint falls back to nspawn). Added a
  `kata-vm = ["hyprstream-workers/kata-vm"]` passthrough, in `default`.

### Verification (build env: `OPENSSL_NO_VENDOR=1 LIBTORCH_USE_PYTORCH=1 LIBTORCH_BYPASS_VERSION_CHECK=1`)

Default (lightweight):
```
$ cargo build -p hyprstream-workers
    Finished `dev` profile [...]
$ cargo tree -p hyprstream-workers -i hypervisor
error: package ID specification `hypervisor` did not match any packages   # kata excluded
$ cargo tree -p hyprstream-workers -i nydus-storage
error: package ID specification `nydus-storage` did not match any packages
$ cargo test -p hyprstream-workers --lib
test result: ok. 65 passed; 0 failed; 0 ignored
$ cargo clippy -p hyprstream-workers --all-targets -- -D warnings
    Finished [...]   # clean
```

Full VM path (`--features kata-vm`):
```
$ cargo build -p hyprstream-workers --features kata-vm
    Finished [...]   # compiles kata `hypervisor`, ch-config, all nydus-*, fuse-backend-rs
$ cargo test -p hyprstream-workers --lib --features kata-vm
test result: ok. 105 passed; 0 failed; 2 ignored
$ cargo clippy -p hyprstream-workers --features kata-vm --all-targets -- -D warnings
    Finished [...]   # clean
```

Other feature configs:
```
$ cargo build -p hyprstream-workers --features systemd          # clean (no kata pulled)
$ cargo build -p hyprstream-vfs-server                          # clean (standalone)
$ cargo check -p hyprstream                                     # clean (default = kata-vm on)
$ cargo check -p hyprstream --no-default-features \
      --features gittorrent,xet,systemd,otel                    # clean (nspawn-only; no kata/nydus compiled)
```

### Notes
- `fuse-backend-rs` still appears in the default tree, but only transitively via
  `hyprstream-vfs` (the base VFS engine) — **not** via this crate's now-optional
  `dep:fuse-backend-rs`. Out of scope for this gate.
- `--features dragonball` resolves the kata stack correctly, but the build fails
  inside the upstream Kata `dbs-virtio-devices` crate (duplicate `vmm_sys_util`
  versions, `EventSet` type mismatch). This is a **pre-existing upstream issue**
  unrelated to feature-gating — the `dragonball` feature simply re-enables that
  same upstream code path. No version pins were changed (kata 3.31.0,
  fuse-backend-rs 0.13, nydus v2.4.0 untouched).
- `Cargo.lock` unchanged (optional deps stay resolved).
