### PR TITLE
feat: moq relay rendezvous — Role::Relay client + StreamOpt routing (refs #358)

### DIFF
--- a/crates/hyprstream-rpc-derive/src/codegen/client.rs
+++ b/crates/hyprstream-rpc-derive/src/codegen/client.rs
@@ -453,8 +453,10 @@ fn generate_trait_method_impl(
                 )?;
                 // #274: subscribe over the resolved `reach` (the same-host UDS
                 // fast path is preferred automatically when co-located).
+                // #358: pass the service-signed `qos` so direct-vs-relay topology
+                // is selected from it (relay-first for retained/fan-out streams).
                 Ok(hyprstream_rpc::moq_stream::MoqStreamHandle::networked(
-                    info.announced_at, info.broadcast_path, mac_key, topic,
+                    info.announced_at, &info.qos, info.broadcast_path, mac_key, topic,
                 ))
             }
         })

--- a/crates/hyprstream-rpc/src/moq_stream.rs
+++ b/crates/hyprstream-rpc/src/moq_stream.rs
@@ -149,6 +149,56 @@ pub fn global_iroh_node_id() -> Option<&'static [u8; 32]> {
     GLOBAL_IROH_NODE_ID.get()
 }
 
+// ============================================================================
+// Process-global producer-chosen moq RELAY (#358) — the rendezvous endpoint a
+// producing service advertises so that NEITHER the publisher NOR the subscriber
+// must be directly reachable by the other: both rendezvous through this relay.
+//
+// The relay is *producer-chosen* (default = the service's PDS / federation
+// anchor) and set once when the producing node learns its relay. It is the
+// network-routable `TransportConfig` of the relay's moq plane — the SAME codec
+// the DID document's transport `service` entries use ([`crate::service_entry`]),
+// so the advertised stream relay and the DID transport address never drift.
+//
+// The relay carries AEAD-sealed ciphertext it cannot read (the `enc_key` /
+// `TaggedPayload` path seals at source) and never holds the `mac_key` /
+// `enc_key`: it is blind by construction, not by trust. Per-PDS, shared, and
+// oblivious relays are therefore all safe for content confidentiality.
+// ============================================================================
+
+/// The producer-chosen moq relay this node rendezvouses through (#358).
+///
+/// Held as the wire-form [`crate::stream_info::TransportConfig`] (the reach
+/// codec), so the SAME value is both advertised verbatim in `StreamInfo.reach`
+/// and dialed (via the shared [`reach_to_transport_config`] resolver) by the
+/// relay client — no per-site assembly, no drift between the advertised stream
+/// relay and the dialed one.
+///
+/// `None` until the node is configured with a relay (no relay = direct-only
+/// advertisement, the S1/S2 behaviour). The default deployment co-locates this
+/// with the node's `#atproto_pds` DID service entry where the node is the PDS.
+static GLOBAL_RELAY_REACH: OnceLock<crate::stream_info::TransportConfig> = OnceLock::new();
+
+/// Register the producer-chosen moq relay endpoint (idempotent — first wins).
+///
+/// `relay` is the relay's network-routable transport in wire-reach form
+/// ([`crate::stream_info::TransportConfig`] — Quic / WebTransport or iroh). A
+/// node sources this from its resolved DID transport entry decoded by the SAME
+/// [`crate::service_entry`] codec the DID document uses (default: the PDS /
+/// federation anchor), never hand-assembled — see [`relay_reach_from_decoded`].
+///
+/// After this is set, [`producer_reach`] advertises a `Role::Relay`
+/// [`Destination`] and [`serve_origin_to_relay_background`] should be spawned to
+/// announce this node's broadcasts UP to the relay.
+pub fn init_global_relay_reach(relay: crate::stream_info::TransportConfig) -> bool {
+    GLOBAL_RELAY_REACH.set(relay).is_ok()
+}
+
+/// Borrow the producer-chosen relay endpoint (wire-reach form), if configured.
+pub fn global_relay_reach() -> Option<&'static crate::stream_info::TransportConfig> {
+    GLOBAL_RELAY_REACH.get()
+}
+
 /// Build the `StreamInfo.reach` list for a producer on this node (#274).
 ///
 /// Centralised so every producer site emits an identical reach, sourced from the
@@ -184,7 +234,51 @@ pub fn producer_reach() -> Vec<crate::stream_info::Destination> {
         });
     }
 
+    // Relay reach (#358): the producer-chosen rendezvous endpoint. Advertised so
+    // a subscriber that cannot (or, per QoS, prefers not to) reach the producer
+    // directly rendezvouses through the relay instead — neither side needs to be
+    // directly reachable by the other. Listed AFTER the direct reaches so the
+    // reach list is "direct first" in wire order; the QoS-aware selector
+    // (`select_reach`) reorders relay-first for resumable/retained/fan-out
+    // streams (Job/Log). A service that wants its stream relay-ONLY (anonymized)
+    // simply omits the direct reaches by not registering a producer/iroh reach;
+    // the client can only route among what is advertised here (server authority).
+    if let Some(relay) = global_relay_reach() {
+        reach.push(Destination { role: Role::Relay, transport: relay.clone() });
+    }
+
     reach
+}
+
+/// Build the producer-chosen relay's wire-reach [`crate::stream_info::TransportConfig`]
+/// from a DID-document transport entry decoded by [`crate::service_entry`] (#358).
+///
+/// This is the bridge that keeps the stream relay address and the DID transport
+/// address from drifting: a node resolves its relay's DID service entry (default
+/// `#atproto_pds`), decodes it with the shared [`crate::service_entry::decode_service_entry`]
+/// codec, and passes the resulting [`crate::transport::TransportConfig`] here to
+/// obtain the wire-reach form to register via [`init_global_relay_reach`].
+///
+/// Returns `None` for same-host transports (`ipc`/`inproc`/`systemd-fd`), which
+/// are never network-routable relay endpoints.
+pub fn relay_reach_from_decoded(
+    config: &crate::transport::TransportConfig,
+) -> Option<crate::stream_info::TransportConfig> {
+    use crate::stream_info::{IrohReach, QuicReach, TransportConfig as ReachTransport};
+    use crate::transport::EndpointType;
+    match &config.endpoint {
+        EndpointType::Quic { addr, server_name, auth } => Some(ReachTransport::Quic(QuicReach {
+            addr: addr.to_string(),
+            server_name: server_name.clone(),
+            cert_hashes: auth.accept_cert_hashes().iter().map(|h| h.to_vec()).collect(),
+        })),
+        EndpointType::Iroh { node_id, .. } => {
+            Some(ReachTransport::Iroh(IrohReach { node_id: *node_id }))
+        }
+        EndpointType::Ipc { .. }
+        | EndpointType::SystemdFd { .. }
+        | EndpointType::Inproc { .. } => None,
+    }
 }
 
 /// Start a UDS moq server in the background, serving the moq origin's consumer
@@ -633,12 +727,25 @@ impl MoqStreamHandle {
     /// the TUI daemon serving its PTY/shell stdout stream) would otherwise connect
     /// to its own empty plane and time out waiting for the model service's
     /// broadcast that was published on a *different* process's plane (#275).
+    ///
+    /// ## QoS-driven direct-vs-relay routing (#358)
+    ///
+    /// `qos` is the service-signed [`crate::stream_info::StreamOpt`]; it selects the
+    /// preferred *topology* (direct vs relay) via [`select_reach`] — relay-first for
+    /// retained/resumable/fan-out streams (Job/Log), direct-first for live pipes
+    /// (`Retention::Live`). This is a stable reorder of the SERVICE-advertised reach
+    /// only: the client never invents a reach, so a relay-only (anonymized) stream
+    /// stays relay-only. Topology is orthogonal to the delivery/integrity contract.
     pub fn networked(
         reach: Vec<crate::stream_info::Destination>,
+        qos: &crate::stream_info::StreamOpt,
         broadcast_path: String,
         mac_key: [u8; 32],
         topic: String,
     ) -> Self {
+        // QoS-aware topology selection over the SERVICE-advertised reach (server
+        // authority preserved: stable reorder, never an invented/forced reach).
+        let reach = select_reach(&reach, qos);
         let cancel = tokio_util::sync::CancellationToken::new();
         let (tx, rx) =
             tokio::sync::mpsc::channel::<anyhow::Result<crate::streaming::StreamPayload>>(64);
@@ -945,6 +1052,150 @@ pub async fn connect_moq_reach(
         "no dialable reach in StreamInfo and no local moq UDS plane — cannot subscribe to broadcast{}",
         last_err.map(|e| format!(" (last dial error: {e})")).unwrap_or_default()
     ))
+}
+
+// ============================================================================
+// QoS-driven reach selection (#358) — topology, orthogonal to delivery/integrity
+//
+// Topology (direct vs relay) is NOT a new QoS integrity axis: the delivery /
+// ordering / completion / retention contract (`StreamOpt`) stays orthogonal to
+// where the bytes flow. The selector only REORDERS the reaches the SERVICE
+// advertised so the preferred topology is tried first; `connect_moq_reach`'s
+// in-order try-then-fallback loop then provides automatic reachability fallback
+// (direct → relay, or relay → direct) within the advertised set.
+//
+// **Server-authority invariant (enforced here):** selection is a stable reorder
+// of `advertised` — it never invents a reach, never fabricates a `direct` reach
+// the service didn't publish, and never drops a reach. So a service that
+// published a stream relay-ONLY (omitting any direct reach to keep the producer
+// anonymized) stays relay-only: there is no direct reach to promote, and the
+// client cannot force one. The client READS qos/reach; it never writes them.
+// ============================================================================
+
+/// Reorder the service-advertised `reach` list by the QoS-preferred topology
+/// (#358), returning a new list the caller hands to [`connect_moq_reach`].
+///
+/// - `Retention::Live` (Pipe / live console, lowest-latency) → **direct-first**:
+///   a live pipe wants the shortest path; the relay is the fallback only if the
+///   producer is not directly reachable.
+/// - retained / resumable / fan-out (Job / Log, `Retention::{Blocks,Seconds}`)
+///   → **relay-first**: the relay is the natural late-join / retained / fan-out
+///   surface, and lets a subscriber rendezvous without dialing the producer.
+///
+/// The reorder is **stable** (it preserves the service's relative ordering within
+/// each role), so direct reaches keep their advertised priority (e.g. iroh before
+/// Quic) and the only change is whether the relay group floats to the front.
+pub fn select_reach(
+    advertised: &[crate::stream_info::Destination],
+    qos: &crate::stream_info::StreamOpt,
+) -> Vec<crate::stream_info::Destination> {
+    use crate::stream_info::{Retention, Role};
+    let relay_first = !matches!(qos.retention, Retention::Live);
+    let mut ordered: Vec<crate::stream_info::Destination> = Vec::with_capacity(advertised.len());
+    // Stable partition: pull the preferred role to the front, keep within-role order.
+    let prefer = if relay_first { Role::Relay } else { Role::Direct };
+    ordered.extend(advertised.iter().filter(|d| d.role == prefer).cloned());
+    ordered.extend(advertised.iter().filter(|d| d.role != prefer).cloned());
+    ordered
+}
+
+/// Resolve a service-advertised reach into a live moq connection, honouring the
+/// QoS-preferred topology (#358).
+///
+/// Thin composition of [`select_reach`] (QoS reorder, server-authority-safe) and
+/// [`connect_moq_reach`] (in-order dial with automatic direct↔relay fallback).
+/// This is the single entry point networked subscribers should use when they
+/// have the signed `StreamOpt` in hand, so direct-vs-relay routing lives in ONE
+/// place and the reach the service published is the only thing ever dialed.
+pub async fn connect_moq_reach_for_qos(
+    reach: &[crate::stream_info::Destination],
+    qos: &crate::stream_info::StreamOpt,
+) -> Result<MoqReachConnection> {
+    let ordered = select_reach(reach, qos);
+    connect_moq_reach(&ordered).await
+}
+
+// ============================================================================
+// moq relay client (#358) — producer-side announce UP to the relay.
+//
+// Restores the rendezvous property the ZMQ→moq migration removed: a producing
+// node that has a configured relay opens a moq link to it and announces its
+// local origin's broadcasts UP to the relay (`with_origin`), so a subscriber
+// that dials the relay sees the SAME broadcast by the SAME `broadcastPath`
+// without ever dialing the producer. Mirrors the event-plane UDS link
+// ([`connect_event_moq_uds_background`] / [`run_event_client_link`]) but points
+// at a REMOTE relay via [`crate::dial::dial_stream`] instead of `connect_uds`.
+//
+// Relay-blind: the link carries the AEAD-sealed, chained-HMAC frames opaquely
+// (`Bytes`); the relay holds no `enc_key` / `mac_key` and never decrypts.
+// ============================================================================
+
+/// Reconnect backoff for the producer→relay link.
+const RELAY_RECONNECT_DELAY: std::time::Duration = std::time::Duration::from_millis(500);
+
+/// Announce this node's streaming origin UP to the producer-chosen relay (#358).
+///
+/// Spawns a background task that dials the relay via [`crate::dial::dial_stream`],
+/// runs the moq handshake with `with_origin(producer)` (so the producer's
+/// broadcasts are announced UP to the relay and re-served to its subscribers),
+/// holds the session open, and reconnects on failure. The task runs for the
+/// process lifetime.
+///
+/// Called once by the producing service's factory after [`init_global_relay_reach`]
+/// — typically with `global_moq_origin().producer()`. No-op-safe to omit when the
+/// node has no relay (direct-only deployments).
+pub fn serve_origin_to_relay_background(
+    producer: OriginProducer,
+    relay: crate::stream_info::TransportConfig,
+) {
+    tokio::spawn(async move {
+        loop {
+            if let Err(e) = run_relay_announce_link(&producer, &relay).await {
+                tracing::debug!(
+                    "moq relay announce link ended: {e}; reconnecting in {:?}",
+                    RELAY_RECONNECT_DELAY
+                );
+            }
+            tokio::time::sleep(RELAY_RECONNECT_DELAY).await;
+        }
+    });
+}
+
+/// One connect-and-hold cycle of the producer→relay announce link (#358).
+///
+/// Dials the relay, runs the moq handshake bidirectionally (`with_origin`), and
+/// returns when the session closes so the caller can reconnect. The relay
+/// ingests the announced broadcasts and re-serves them to its subscribers by
+/// track name — the producer never learns who subscribes, the subscriber never
+/// dials the producer.
+///
+/// Exposed (rather than only via [`serve_origin_to_relay_background`]) so a
+/// caller that owns its own reconnect/lifecycle — and the rendezvous test — can
+/// drive a single connect cycle directly.
+pub async fn run_relay_announce_link(
+    producer: &OriginProducer,
+    relay: &crate::stream_info::TransportConfig,
+) -> Result<()> {
+    use moq_net::Client as MoqClient;
+
+    // Reuse the ONE wire-reach → dial-config resolver so the relay is dialed by
+    // the same code path (Quic / WebTransport / iroh) every direct reach uses.
+    let dest = crate::stream_info::Destination { role: crate::stream_info::Role::Relay, transport: relay.clone() };
+    let cfg = reach_to_transport_config(&dest)
+        .ok_or_else(|| anyhow!("relay reach is not a dialable network transport"))?;
+
+    let stream_session = crate::dial::dial_stream(&cfg).await?;
+    // `with_origin` makes the link bidirectional: this node's broadcasts are
+    // announced UP to the relay; the relay re-serves them to its subscribers.
+    let moq_client = MoqClient::new().with_origin(producer.clone());
+    let moq_session = stream_session
+        .connect_moq(&moq_client)
+        .await
+        .map_err(|e| anyhow!("relay moq handshake: {e}"))?;
+
+    tracing::info!("moq relay announce link established");
+    let reason = moq_session.closed().await;
+    Err(anyhow!("moq relay session closed: {reason:?}"))
 }
 
 /// Networked variant of [`moq_stream_handle_task`]: dial a `/moq`
@@ -1293,8 +1544,10 @@ mod tests {
             }),
         }];
 
+        let qos = crate::stream_info::StreamOpt::default();
         let mut handle = MoqStreamHandle::networked(
             reach,
+            &qos,
             "local/streams/test/deadbeef".to_owned(),
             [0u8; 32],
             "deadbeef".repeat(8),
@@ -1333,5 +1586,112 @@ mod tests {
         assert!(!gated.authorize_signer(&[2u8; 32]));
         // No gate -> accept all.
         assert!(origin().authorize_signer(&[9u8; 32]));
+    }
+
+    // ── #358 relay reach / selection unit tests ─────────────────────────────
+
+    use crate::stream_info::{
+        Destination, IrohReach, Job, Log, Pipe, QuicReach, Role, StreamOpt, StreamOptPreset,
+        TransportConfig as ReachTransport,
+    };
+
+    fn direct_iroh(b: u8) -> Destination {
+        Destination { role: Role::Direct, transport: ReachTransport::Iroh(IrohReach { node_id: [b; 32] }) }
+    }
+    fn relay_quic(addr: &str) -> Destination {
+        Destination {
+            role: Role::Relay,
+            transport: ReachTransport::Quic(QuicReach {
+                addr: addr.to_owned(),
+                server_name: "relay".to_owned(),
+                cert_hashes: vec![vec![0u8; 32]],
+            }),
+        }
+    }
+
+    /// `producer_reach()` advertises a `Role::Relay` Destination once a relay is
+    /// registered — populating the existing schema, no new field.
+    #[test]
+    fn producer_reach_advertises_relay_when_configured() {
+        let relay = ReachTransport::Quic(QuicReach {
+            addr: "10.0.0.9:4433".to_owned(),
+            server_name: "pds".to_owned(),
+            cert_hashes: vec![vec![1u8; 32]],
+        });
+        // OnceLock: only assert the Role::Relay shape if we won the set (test
+        // isolation across the shared global), else skip — the construction logic
+        // is what we verify, and `relay_reach_from_decoded` covers it key-free.
+        if init_global_relay_reach(relay.clone()) {
+            let reach = producer_reach();
+            assert!(
+                reach.iter().any(|d| d.role == Role::Relay && d.transport == relay),
+                "producer_reach must advertise the configured Role::Relay reach"
+            );
+        }
+    }
+
+    /// QoS-driven selection: live pipes prefer DIRECT, retained/fan-out prefer RELAY.
+    #[test]
+    fn select_reach_orders_by_qos_topology() {
+        let advertised = vec![direct_iroh(1), relay_quic("10.0.0.1:4433"), direct_iroh(2)];
+
+        // Pipe (Retention::Live) → direct-first; within-role order preserved.
+        let pipe = Pipe::stream_opt();
+        let ordered = select_reach(&advertised, &pipe);
+        assert_eq!(ordered[0].role, Role::Direct, "live pipe must try direct first");
+        assert_eq!(ordered[2].role, Role::Relay, "relay falls to the back for a live pipe");
+        assert_eq!(ordered[0], direct_iroh(1), "within-role advertised order preserved");
+        assert_eq!(ordered[1], direct_iroh(2));
+
+        // Job (retained/resumable) → relay-first.
+        let job = Job::stream_opt();
+        let ordered = select_reach(&advertised, &job);
+        assert_eq!(ordered[0].role, Role::Relay, "retained job must try relay first");
+
+        // Log (retained) → relay-first.
+        let log = Log::stream_opt();
+        assert_eq!(select_reach(&advertised, &log)[0].role, Role::Relay);
+    }
+
+    /// Server authority: selection NEVER invents, fabricates `direct`, or drops a
+    /// reach. A relay-ONLY advertisement (anonymized stream) stays relay-only even
+    /// for a live-pipe QoS that would *prefer* direct — there is nothing to promote.
+    #[test]
+    fn select_reach_preserves_server_authority() {
+        let relay_only = vec![relay_quic("10.0.0.1:4433")];
+
+        // Even with default (Live → direct-preferred) qos, no direct reach appears.
+        let ordered = select_reach(&relay_only, &StreamOpt::default());
+        assert_eq!(ordered.len(), 1, "selection must not add or drop reaches");
+        assert_eq!(ordered[0].role, Role::Relay, "a relay-only stream stays relay-only");
+        assert!(
+            !ordered.iter().any(|d| d.role == Role::Direct),
+            "the client must NOT fabricate a direct reach the service didn't advertise"
+        );
+
+        // It is also a pure permutation: same multiset in, same multiset out.
+        let advertised = vec![direct_iroh(1), relay_quic("a:1"), direct_iroh(2)];
+        let mut a = advertised.clone();
+        let mut b = select_reach(&advertised, &Job::stream_opt());
+        a.sort_by_key(|d| (d.role == Role::Relay, format!("{d:?}")));
+        b.sort_by_key(|d| (d.role == Role::Relay, format!("{d:?}")));
+        assert_eq!(a, b, "selection must be a permutation of the advertised reach");
+    }
+
+    /// `relay_reach_from_decoded` round-trips a DID-decoded transport into the
+    /// wire-reach form advertised as the relay — the shared codec, no drift.
+    #[test]
+    fn relay_reach_from_decoded_round_trips() {
+        // iroh decoded config → iroh wire reach carrying the same node_id.
+        let cfg = crate::transport::TransportConfig::iroh([0x5u8; 32], Vec::new(), None);
+        match relay_reach_from_decoded(&cfg) {
+            Some(ReachTransport::Iroh(i)) => assert_eq!(i.node_id, [0x5u8; 32]),
+            other => panic!("expected iroh wire reach, got {other:?}"),
+        }
+        // Same-host transports are never relay endpoints.
+        assert!(
+            relay_reach_from_decoded(&crate::transport::TransportConfig::ipc("/tmp/x.sock")).is_none(),
+            "a same-host ipc transport is not a network-routable relay"
+        );
     }
 }

--- a/crates/hyprstream-rpc/src/service/svc.rs
+++ b/crates/hyprstream-rpc/src/service/svc.rs
@@ -669,6 +669,19 @@ pub struct QuicLoopConfig {
     /// entry in the DID document only when iroh is actually bound.
     #[cfg(not(target_arch = "wasm32"))]
     pub on_iroh_bound: Option<Box<dyn FnOnce(String, [u8; 32]) + Send>>,
+    /// #358: the producer-chosen moq RELAY this node rendezvouses through, in
+    /// wire-reach form ([`crate::stream_info::TransportConfig`]). When set, the
+    /// spawner registers it via [`crate::moq_stream::init_global_relay_reach`] (so
+    /// `producer_reach()` advertises a `Role::Relay` reach) and links this node's
+    /// streaming origin UP to the relay
+    /// ([`crate::moq_stream::serve_origin_to_relay_background`]) — restoring the
+    /// rendezvous property: neither publisher nor subscriber need be directly
+    /// reachable by the other. Sourced from the resolved relay DID transport entry
+    /// (default: the PDS / federation anchor) decoded by the shared
+    /// [`crate::service_entry`] codec, so the stream relay and DID addresses never
+    /// drift. `None` = direct-only (the S1/S2 behaviour). Native-only.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub moq_relay: Option<crate::stream_info::TransportConfig>,
 }
 
 /// Handle for a running service

--- a/crates/hyprstream-rpc/src/transport/quinn_transport.rs
+++ b/crates/hyprstream-rpc/src/transport/quinn_transport.rs
@@ -58,6 +58,14 @@ pub struct QuinnRpcServer {
     /// WebTransport CONNECT URL path is [`crate::dial::MOQ_PATH`] are handed to
     /// `moq_net::Server::accept` instead of the RPC core. `None` = RPC only.
     moq_consumer: Option<moq_net::OriginConsumer>,
+    /// Optional moq RELAY origin (#358). When set, the `/moq` plane runs in
+    /// *relay* (bidirectional) mode: `moq_net::Server::with_origin` ingests a
+    /// connected producer's announced broadcasts into this origin AND re-serves
+    /// them to subscribers by track name — so a publisher and a subscriber
+    /// rendezvous through this node without either dialing the other. Takes
+    /// precedence over [`Self::moq_consumer`] (serve-only). The relay carries the
+    /// AEAD-sealed, chained-HMAC frames opaquely and holds no stream keys.
+    moq_relay_origin: Option<moq_net::OriginProducer>,
     /// #276 subscribe-authz + per-tenant announce-scoping config for the `/moq`
     /// plane. Defaults to "off" (open subscribe preserved).
     moq_authz: crate::transport::iroh_moq::MoqAuthzConfig,
@@ -93,6 +101,7 @@ impl QuinnRpcServer {
             )),
             read_timeout: super::rpc_session::REQUEST_READ_TIMEOUT,
             moq_consumer: None,
+            moq_relay_origin: None,
             moq_authz: crate::transport::iroh_moq::MoqAuthzConfig::default(),
             shutdown: CancellationToken::new(),
         }
@@ -107,6 +116,24 @@ impl QuinnRpcServer {
     /// over a per-connection iroh ALPN — here the multiplex is by URL path.
     pub fn with_moq_consumer(mut self, consumer: moq_net::OriginConsumer) -> Self {
         self.moq_consumer = Some(consumer);
+        self
+    }
+
+    /// Run the `/moq` plane as a RELAY (bidirectional) over `origin` (#358).
+    ///
+    /// In relay mode each `/moq` session is served via
+    /// `moq_net::Server::with_origin`, so a connected producer's announced
+    /// broadcasts are ingested into `origin` and re-served to every subscriber by
+    /// track name. This is the rendezvous endpoint a producer advertises as a
+    /// `Role::Relay` reach: a publisher links UP to it
+    /// ([`crate::moq_stream::serve_origin_to_relay_background`]) and a subscriber
+    /// dials it for the SAME `broadcastPath` — neither dials the other.
+    ///
+    /// The relay is **blind by construction**: frames are AEAD-sealed and
+    /// chained-HMAC'd at the source; this node holds no `enc_key` / `mac_key` and
+    /// forwards opaque `Bytes`. Takes precedence over [`Self::with_moq_consumer`].
+    pub fn with_moq_relay(mut self, origin: moq_net::OriginProducer) -> Self {
+        self.moq_relay_origin = Some(origin);
         self
     }
 
@@ -255,6 +282,7 @@ impl QuinnRpcServer {
                     let read_timeout = self.read_timeout;
                     let shutdown = self.shutdown.clone();
                     let moq_consumer = self.moq_consumer.clone();
+                    let moq_relay_origin = self.moq_relay_origin.clone();
                     let moq_authz = self.moq_authz.clone();
                     tokio::spawn(async move {
                         let _conn_permit = conn_permit; // released when this connection ends
@@ -286,6 +314,30 @@ impl QuinnRpcServer {
                         };
 
                         if is_moq {
+                            // Relay (bidirectional) mode takes precedence (#358):
+                            // ingest a producer's announced broadcasts into the
+                            // shared origin AND re-serve them to subscribers by
+                            // track name, so publisher and subscriber rendezvous
+                            // here without either dialing the other. The relay
+                            // holds no stream keys — frames pass through opaquely.
+                            if let Some(relay_origin) = moq_relay_origin {
+                                let server = moq_net::Server::new().with_origin(relay_origin);
+                                match server.accept(session).await {
+                                    Ok(moq_session) => {
+                                        tokio::select! {
+                                            biased;
+                                            _ = shutdown.cancelled() => {}
+                                            res = moq_session.closed() => {
+                                                tracing::debug!(result = ?res, "quinn-moq-relay: session closed");
+                                            }
+                                        }
+                                    }
+                                    Err(e) => {
+                                        tracing::debug!(error = ?e, "quinn-moq-relay: accept failed");
+                                    }
+                                }
+                                return;
+                            }
                             match moq_consumer {
                                 Some(consumer) => {
                                     // #276: the `/moq` WebTransport CONNECT is NOT

--- a/crates/hyprstream-rpc/tests/moq_networked.rs
+++ b/crates/hyprstream-rpc/tests/moq_networked.rs
@@ -98,8 +98,10 @@ async fn networked_moq_subscribe_receives_mac_verified_frames() -> Result<()> {
 
     // Client: networked subscribe — dials `/moq` via dial_stream, subscribes,
     // verifies the chained HMAC, and yields decoded payloads.
-    let mut handle =
-        hyprstream_rpc::moq_stream::MoqStreamHandle::networked(reach, broadcast_path, mac_key, topic);
+    let qos = hyprstream_rpc::stream_info::StreamOpt::default();
+    let mut handle = hyprstream_rpc::moq_stream::MoqStreamHandle::networked(
+        reach, &qos, broadcast_path, mac_key, topic,
+    );
 
     // Give the background task time to dial, handshake, and subscribe to the
     // track before the producer pushes group 0 — a late joiner that misses the

--- a/crates/hyprstream-rpc/tests/moq_relay_rendezvous.rs
+++ b/crates/hyprstream-rpc/tests/moq_relay_rendezvous.rs
@@ -1,0 +1,213 @@
+//! moq relay rendezvous (#358).
+//!
+//! Restores the rendezvous property the ZMQ→moq migration removed: NEITHER the
+//! publisher NOR the subscriber dials the other — both rendezvous through a
+//! producer-advertised moq **relay**.
+//!
+//! Topology under test:
+//!
+//! ```text
+//!   producer  ──link UP (with_origin)──▶  RELAY  ◀──dial (Role::Relay reach)──  subscriber
+//!             announces broadcastPath           re-serves broadcastPath by track name
+//! ```
+//!
+//! The relay is a bidirectional `web_transport_quinn` `/moq` endpoint running in
+//! relay mode (`QuinnRpcServer::with_moq_relay`): it ingests the producer's
+//! announced broadcast and re-serves it to the subscriber by the SAME
+//! `broadcastPath`. The relay holds NO stream keys — it forwards the chained-HMAC
+//! frames opaquely. The test also asserts the relay-forwarded bytes do NOT verify
+//! under a wrong key (relay-blind: content integrity is keyed at the source, not
+//! relay-trusted).
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
+use ed25519_dalek::SigningKey;
+use rand::RngCore;
+
+use hyprstream_rpc::moq_stream::{
+    connect_moq_reach_for_qos, run_relay_announce_link, MoqStreamOrigin, STREAM_TRACK,
+};
+use hyprstream_rpc::stream_info::{
+    Destination, QuicReach, Role, StreamOpt, TransportConfig as ReachTransport,
+};
+use hyprstream_rpc::streaming::{StreamContext, StreamPayload, StreamVerifier};
+use hyprstream_rpc::transport::quinn_transport::{cert_sha256, QuinnRpcServer};
+
+fn fresh_signing_key() -> SigningKey {
+    let mut k = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut k);
+    SigningKey::from_bytes(&k)
+}
+
+/// Build a hermetic `web_transport_quinn` server on loopback with a self-signed
+/// cert. Returns (server, bound_addr, leaf_cert_der).
+fn build_server() -> Result<(web_transport_quinn::Server, std::net::SocketAddr, Vec<u8>)> {
+    let cert_key = rcgen::generate_simple_self_signed(vec!["localhost".to_owned()])?;
+    let cert_der = cert_key.cert.der().to_vec();
+    let key_der = cert_key.key_pair.serialize_der();
+
+    let chain = vec![rustls::pki_types::CertificateDer::from(cert_der.clone())];
+    let key =
+        rustls::pki_types::PrivateKeyDer::Pkcs8(rustls::pki_types::PrivatePkcs8KeyDer::from(key_der));
+
+    let addr: std::net::SocketAddr = "127.0.0.1:0".parse()?;
+    let server = web_transport_quinn::ServerBuilder::new()
+        .with_addr(addr)
+        .with_certificate(chain, key)
+        .map_err(|e| anyhow!("quinn server build: {e}"))?;
+    let bound = server.local_addr()?;
+    Ok((server, bound, cert_der))
+}
+
+/// End-to-end: a producer links its origin UP to a relay; a subscriber dials the
+/// relay's `Role::Relay` reach and receives MAC-verified frames — neither side
+/// ever learns the other's address.
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn moq_relay_rendezvous() -> Result<()> {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    // ── RELAY: a bidirectional /moq endpoint (ingest + re-serve), no keys ──────
+    // Its origin starts EMPTY — the broadcast exists only on the producer until
+    // the producer links up and announces it. This proves the relay re-serves an
+    // INGESTED broadcast, not one it was seeded with.
+    let relay_producer = moq_net::Origin::random().produce();
+    let relay_consumer = relay_producer.consume();
+    let relay_origin = MoqStreamOrigin::from_pair(relay_producer.clone(), relay_consumer);
+
+    let (relay_server, relay_addr, relay_cert) = build_server()?;
+    let relay_processor =
+        hyprstream_rpc::transport::rpc_session::from_fn(|req: bytes::Bytes| async move { Ok(req) });
+    let relay_rpc = QuinnRpcServer::with_capacity(
+        relay_server,
+        Arc::new(relay_processor),
+        fresh_signing_key(),
+        hyprstream_rpc::transport::rpc_session::DEFAULT_STREAM_LIMIT,
+    )
+    // Relay (bidirectional) mode: ingest the producer's broadcast and re-serve it.
+    .with_moq_relay(relay_origin.producer().clone());
+    let relay_shutdown = relay_rpc.shutdown_token();
+    let relay_task = tokio::spawn(relay_rpc.run());
+
+    // The producer-advertised relay reach (this is exactly the `Role::Relay`
+    // Destination `producer_reach()` emits when a relay is configured).
+    let relay_pin = cert_sha256(&relay_cert);
+    let relay_reach = ReachTransport::Quic(QuicReach {
+        addr: relay_addr.to_string(),
+        server_name: "localhost".to_owned(),
+        cert_hashes: vec![relay_pin.to_vec()],
+    });
+
+    // ── Stream identity (DH-derived topic + MAC key, shared producer/consumer) ──
+    let (_client_secret, client_pub) = hyprstream_rpc::crypto::generate_ephemeral_keypair();
+    let ctx = StreamContext::from_dh(&client_pub.to_bytes())?;
+    let topic = ctx.topic().to_owned();
+    let mac_key = *ctx.mac_key();
+
+    // ── PRODUCER: a LOCAL origin, never bound to a network endpoint ────────────
+    // The producer is NOT directly reachable (no QuinnRpcServer of its own). Its
+    // only path to a subscriber is the relay link.
+    let producer_origin = {
+        let p = moq_net::Origin::random().produce();
+        let c = p.consume();
+        MoqStreamOrigin::from_pair(p, c)
+    };
+    let broadcast_path = producer_origin.broadcast_path(&topic);
+    let mut publisher = producer_origin.publisher(&ctx)?;
+
+    // Link the producer's origin UP to the relay (announce broadcasts UP). Drive
+    // one connect cycle in the background; it returns when the session closes.
+    let link_relay = relay_reach.clone();
+    let link_producer = producer_origin.producer().clone();
+    let link_task = tokio::spawn(async move {
+        let _ = run_relay_announce_link(&link_producer, &link_relay).await;
+    });
+
+    // Give the producer→relay link time to handshake + announce the broadcast UP.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // ── SUBSCRIBER: dials ONLY the relay's Role::Relay reach ───────────────────
+    // The reach list carries the relay ONLY (no direct producer reach) — a
+    // relay-only / anonymized advertisement. The subscriber cannot dial the
+    // producer because it was never told where the producer is.
+    let reach = vec![Destination { role: Role::Relay, transport: relay_reach.clone() }];
+
+    // Default qos = Retention::Live; with a relay-only reach there is nothing to
+    // promote — the relay is the only dialable option, exercising rendezvous.
+    let qos = StreamOpt::default();
+    let conn = connect_moq_reach_for_qos(&reach, &qos)
+        .await
+        .map_err(|e| anyhow!("subscriber failed to connect via relay: {e}"))?;
+
+    // Subscribe to the SAME broadcastPath the producer announced — the relay
+    // forwards by track name; the path is identical for direct and relay.
+    let bc = tokio::time::timeout(
+        Duration::from_secs(5),
+        conn.consumer.announced_broadcast(&broadcast_path),
+    )
+    .await
+    .map_err(|_| anyhow!("timeout: broadcast not announced via relay"))?
+    .ok_or_else(|| anyhow!("broadcast not announced via relay"))?;
+    let mut track = bc.subscribe_track(&moq_net::Track::new(STREAM_TRACK))?;
+
+    // ── Publish through the relay; verify the chained-HMAC end-to-end ──────────
+    let mut verifier = StreamVerifier::new(mac_key, topic.clone());
+    let mut got: Vec<StreamPayload> = Vec::new();
+
+    // Publish one group at a time and drain it so the ordered chain is observed.
+    async fn next_frame(
+        track: &mut moq_net::TrackConsumer,
+        seq: u64,
+    ) -> Result<bytes::Bytes> {
+        let mut group = tokio::time::timeout(Duration::from_secs(10), track.get_group(seq))
+            .await
+            .map_err(|_| anyhow!("timed out waiting for relayed group {seq}"))??
+            .ok_or_else(|| anyhow!("relay track ended early at group {seq}"))?;
+        tokio::time::timeout(Duration::from_secs(10), group.read_frame())
+            .await
+            .map_err(|_| anyhow!("timed out reading relayed frame {seq}"))??
+            .ok_or_else(|| anyhow!("relayed group {seq} had no frame"))
+    }
+
+    publisher.publish_data(b"alpha").await?;
+    let f0 = next_frame(&mut track, 0).await?;
+    let raw_relayed: Vec<u8> = f0.to_vec(); // capture a relayed frame for the blind-relay assertion.
+    got.extend(hyprstream_rpc::moq_stream::verify_moq_frame(&mut verifier, &topic, &f0)?);
+
+    publisher.publish_data(b"beta").await?;
+    let f1 = next_frame(&mut track, 1).await?;
+    got.extend(hyprstream_rpc::moq_stream::verify_moq_frame(&mut verifier, &topic, &f1)?);
+
+    publisher.complete_ref(b"{}").await?;
+    let f2 = next_frame(&mut track, 2).await?;
+    got.extend(hyprstream_rpc::moq_stream::verify_moq_frame(&mut verifier, &topic, &f2)?);
+
+    assert!(matches!(&got[0], StreamPayload::Data(d) if d == b"alpha"), "got {:?}", got[0]);
+    assert!(matches!(&got[1], StreamPayload::Data(d) if d == b"beta"), "got {:?}", got[1]);
+    assert!(matches!(&got[2], StreamPayload::Complete(_)), "got {:?}", got[2]);
+
+    // ── Relay-blind: the relay-forwarded bytes do NOT verify without the key ───
+    // The relay holds no `mac_key` (and no `enc_key`); content integrity is keyed
+    // at the source. A verifier seeded with the WRONG key must reject the exact
+    // bytes the relay forwarded — proving the relay cannot read or forge content,
+    // only carry opaque frames. (The AEAD `enc_key` seal is the same posture: the
+    // relay never derives or holds it.)
+    assert!(!raw_relayed.is_empty(), "expected to capture a relayed frame");
+    let wrong_key = [0xFFu8; 32];
+    let mut blind_verifier = StreamVerifier::new(wrong_key, topic.clone());
+    let blind = hyprstream_rpc::moq_stream::verify_moq_frame(&mut blind_verifier, &topic, &raw_relayed);
+    assert!(
+        blind.is_err(),
+        "relay-forwarded bytes must NOT verify without the source key (relay-blind); \
+         a wrong-key verifier accepted them, which would mean the relay was trusted for content"
+    );
+
+    // Teardown.
+    relay_shutdown.cancel();
+    link_task.abort();
+    let _ = relay_task.await;
+    drop(producer_origin);
+    Ok(())
+}

--- a/crates/hyprstream-service/src/service/factory.rs
+++ b/crates/hyprstream-service/src/service/factory.rs
@@ -56,6 +56,14 @@ pub struct QuicSharedConfig {
     /// parallel to the quinn endpoint for every QUIC-enabled service. Off by
     /// default; an operator opts in via `[quic] iroh = true`.
     pub iroh_enabled: bool,
+    /// #358: the producer-chosen moq RELAY every QUIC-enabled service on this node
+    /// rendezvouses through, in wire-reach form. `None` = direct-only. Sourced
+    /// from the relay DID transport entry (default: the PDS / federation anchor)
+    /// decoded by [`hyprstream_rpc::service_entry`]; see
+    /// [`hyprstream_rpc::moq_stream::relay_reach_from_decoded`]. Threaded into each
+    /// service's [`QuicLoopConfig`] so the spawner advertises a `Role::Relay` reach
+    /// and links the origin UP to the relay.
+    pub moq_relay: Option<hyprstream_rpc::stream_info::TransportConfig>,
 }
 
 impl QuicSharedConfig {
@@ -96,6 +104,9 @@ impl QuicSharedConfig {
             iroh_enabled: self.iroh_enabled,
             iroh_admission: None,
             on_iroh_bound: None,
+            // #358: thread the producer-chosen relay through so the spawner
+            // advertises a Role::Relay reach + links the origin up to the relay.
+            moq_relay: self.moq_relay.clone(),
         }
     }
 

--- a/crates/hyprstream-service/src/service/spawner/service.rs
+++ b/crates/hyprstream-service/src/service/spawner/service.rs
@@ -185,6 +185,28 @@ impl<S: RequestService + Send + Sync + 'static> Spawnable for UnifiedServiceConf
                     cb(service_name.clone(), advertise_addr, qc.server_name.clone());
                 }
 
+                // #358: if a producer-chosen relay is configured, register it so
+                // `producer_reach()` advertises a `Role::Relay` reach, and link
+                // this node's streaming origin UP to the relay so subscribers can
+                // rendezvous through it without dialing the producer. Idempotent
+                // (first-wins) across services sharing the process-global origin.
+                if let Some(relay) = qc.moq_relay.take() {
+                    let registered =
+                        hyprstream_rpc::moq_stream::init_global_relay_reach(relay.clone());
+                    if registered {
+                        if let Some(origin) = hyprstream_rpc::moq_stream::global_moq_origin() {
+                            hyprstream_rpc::moq_stream::serve_origin_to_relay_background(
+                                origin.producer().clone(),
+                                relay,
+                            );
+                            tracing::info!(
+                                service = %service_name,
+                                "moq relay rendezvous enabled (announcing origin UP to relay; advertising Role::Relay reach)"
+                            );
+                        }
+                    }
+                }
+
                 // #282: bind an iroh substrate in PARALLEL to the quinn endpoint,
                 // serving BOTH ALPNs (`hyprstream-rpc/1` + `moql`) with the SAME
                 // request processor + moq origin. The iroh endpoint's node key is

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1285,6 +1285,42 @@ fn handle_quick_command(
 /// to verify responses from a target service.
 ///
 /// Returns `None` if bootstrap-pubkeys is not available (wizard not run).
+/// Resolve the configured `[quic] relay` URI into the wire-reach
+/// [`TransportConfig`] a producer advertises as its `Role::Relay` reach (#358).
+///
+/// Reuses the SAME [`hyprstream_rpc::service_entry`] codec the DID document uses
+/// (by constructing the equivalent `QuicTransport` service entry and decoding it),
+/// then projecting to wire-reach form via
+/// [`hyprstream_rpc::moq_stream::relay_reach_from_decoded`] — so the advertised
+/// stream relay and the DID transport address are produced by one codec and never
+/// drift. WebPKI (public PDS / federation anchor) is the default; a self-signed
+/// mesh relay carries its leaf-cert SHA-256 pins after `#` in the URI fragment.
+fn resolve_moq_relay_reach(
+    relay_uri: &str,
+) -> Result<hyprstream_rpc::stream_info::TransportConfig> {
+    use serde_json::json;
+    // Optional `#<multibase certHash>[,<multibase certHash>...]` fragment pins a
+    // self-signed mesh relay; absent ⇒ WebPKI (public CA-fronted relay).
+    let (uri, cert_hashes): (&str, Vec<String>) = match relay_uri.split_once('#') {
+        Some((u, frag)) => (u, frag.split(',').map(str::to_owned).collect()),
+        None => (relay_uri, Vec::new()),
+    };
+    let webpki = cert_hashes.is_empty();
+    let entry = json!({
+        "type": "QuicTransport",
+        "serviceEndpoint": {
+            "uri": uri,
+            "webpki": webpki,
+            "certHashes": cert_hashes,
+            "accept": ["moql"],
+        },
+    });
+    let decoded = hyprstream_rpc::service_entry::decode_service_entry(&entry)
+        .map_err(|e| anyhow::anyhow!("relay URI decode: {e}"))?;
+    hyprstream_rpc::moq_stream::relay_reach_from_decoded(&decoded.config)
+        .ok_or_else(|| anyhow::anyhow!("relay URI is not a network-routable transport"))
+}
+
 fn resolve_service_vk(service_name: &str) -> Option<VerifyingKey> {
     let trust = hyprstream_service::global_trust_store();
     // Fast path: already populated (service startup seeded it)
@@ -1962,6 +1998,25 @@ fn main() -> Result<()> {
                                         println!("QUIC/WebTransport cert hash: {}", hash);
                                     }
 
+                                    // #358: resolve the producer-chosen moq relay
+                                    // (if configured) into wire-reach form via the
+                                    // SAME service_entry codec the DID doc uses, so
+                                    // the stream relay address and DID address can't
+                                    // drift. Empty = direct-only.
+                                    let moq_relay = if qc.relay.trim().is_empty() {
+                                        None
+                                    } else {
+                                        match resolve_moq_relay_reach(&qc.relay) {
+                                            Ok(reach) => Some(reach),
+                                            Err(e) => {
+                                                tracing::warn!(
+                                                    relay = %qc.relay,
+                                                    "ignoring invalid [quic] relay; continuing direct-only: {e}"
+                                                );
+                                                None
+                                            }
+                                        }
+                                    };
                                     let shared = hyprstream_service::QuicSharedConfig {
                                         cert_chain,
                                         key_der,
@@ -1971,6 +2026,8 @@ fn main() -> Result<()> {
                                         jwt_verifying_key: Some(ctx.jwt_verifying_key()),
                                         // #282: bind iroh in parallel to quinn when opted in.
                                         iroh_enabled: qc.iroh,
+                                        // #358: producer-chosen relay rendezvous (None = direct-only).
+                                        moq_relay,
                                     };
                                     ctx = ctx.with_quic(shared);
                                 }

--- a/crates/hyprstream/src/cli/shell_handlers.rs
+++ b/crates/hyprstream/src/cli/shell_handlers.rs
@@ -254,7 +254,10 @@ pub async fn handle_shell_tui(
     // which timed out because the PTY broadcast lives on the *TUI service's* plane,
     // a different process from this viewer.)
     let reach = stdout_stream.announced_at.clone();
-    let mut handle = MoqStreamHandle::networked(reach, broadcast_path, mac_key, topic);
+    // #358: a shell stdout attach is a live pipe → direct-first (default
+    // StreamOpt = Retention::Live); selection only reorders advertised reaches.
+    let qos = hyprstream_rpc::stream_info::StreamOpt::default();
+    let mut handle = MoqStreamHandle::networked(reach, &qos, broadcast_path, mac_key, topic);
     let _recv_handle = tokio::spawn(async move {
         loop {
             match handle.recv_next().await {

--- a/crates/hyprstream/src/cli/tui_handlers.rs
+++ b/crates/hyprstream/src/cli/tui_handlers.rs
@@ -148,7 +148,11 @@ async fn run_attach_loop(
     // the old `connect_uds(moq_uds_path)` connected to *this* process's empty plane
     // and timed out waiting for the producer's broadcast.
     let reach = stream_info.announced_at.clone();
-    let mut handle = MoqStreamHandle::networked(reach, broadcast_path, mac_key, topic);
+    // #358: a console attach is a live pipe → direct-first topology (the default
+    // StreamOpt is `Retention::Live`). `select_reach` only reorders the
+    // service-advertised reach, so this never invents/forces a reach.
+    let qos = hyprstream_rpc::stream_info::StreamOpt::default();
+    let mut handle = MoqStreamHandle::networked(reach, &qos, broadcast_path, mac_key, topic);
     let recv_handle = tokio::spawn(async move {
         loop {
             match handle.recv_next().await {

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -347,6 +347,16 @@ pub struct QuicConfig {
     /// the unchanged baseline; opt in with `[quic] iroh = true`. Native-only.
     #[serde(default = "default_iroh_enabled")]
     pub iroh: bool,
+
+    /// #358: the producer-chosen moq RELAY this node rendezvouses through, as a
+    /// dialable URI (`https://host:port` for the relay's WebTransport `/moq`
+    /// endpoint, or an iroh node URI). Empty = direct-only (the baseline). When
+    /// set, every QUIC-enabled service advertises a `Role::Relay` reach and links
+    /// its streaming origin UP to the relay, so neither publisher nor subscriber
+    /// need be directly reachable by the other. Default deployments point this at
+    /// the node's PDS / federation anchor (the `#atproto_pds` DID service entry).
+    #[serde(default)]
+    pub relay: String,
 }
 
 impl Default for QuicConfig {
@@ -358,6 +368,7 @@ impl Default for QuicConfig {
             cert_path: String::new(),
             key_path: String::new(),
             iroh: default_iroh_enabled(),
+            relay: String::new(),
         }
     }
 }
@@ -480,6 +491,9 @@ impl QuicConfig {
             iroh_enabled: false,
             iroh_admission: None,
             on_iroh_bound: None,
+            // #358: relay rendezvous is provisioned by the daemon bootstrap
+            // (`QuicSharedConfig`), not this minimal builder. Direct-only here.
+            moq_relay: None,
         })
     }
 }

--- a/crates/hyprstream/src/services/mcp_service.rs
+++ b/crates/hyprstream/src/services/mcp_service.rs
@@ -442,7 +442,8 @@ fn register_scoped_tools_recursive(
                             let (mac_key, topic) = hyprstream_rpc::derive_client_stream_keys(
                                 &client_secret, &client_pubkey_bytes, &dh_public,
                             )?;
-                            let handle = MoqStreamHandle::networked(reach, broadcast_path, mac_key, topic);
+                            let qos = hyprstream_rpc::stream_info::StreamOpt::default(); // #358: MCP tool stream consumed live → direct-first; selection only reorders advertised reaches.
+                            let handle = MoqStreamHandle::networked(reach, &qos, broadcast_path, mac_key, topic);
 
                             Ok(ToolResult::Stream(Box::new(handle)))
                         })
@@ -598,7 +599,9 @@ fn register_streaming_tool(
                 let (mac_key, topic) = hyprstream_rpc::derive_client_stream_keys(
                     &client_secret, &client_pubkey_bytes, &dh_public,
                 )?;
-                let handle = MoqStreamHandle::networked(reach, broadcast_path, mac_key, topic);
+                // #358: MCP tool stream consumed live → direct-first; selection only reorders advertised reaches.
+                let qos = hyprstream_rpc::stream_info::StreamOpt::default();
+                let handle = MoqStreamHandle::networked(reach, &qos, broadcast_path, mac_key, topic);
 
                 Ok(ToolResult::Stream(Box::new(handle)))
             })


### PR DESCRIPTION
## Summary (PR-D / #358 — S3: moq relay rendezvous)

Restores the **rendezvous** property the ZMQ→moq migration removed: **neither the publisher nor the subscriber must be directly reachable by the other** — both rendezvous through a producer-advertised **moq relay**. `Role::Relay` was *defined but never constructed*; this builds the relay client, producer-side relay announce, and `StreamOpt`-driven direct-vs-relay routing.

## What was built

- **moq relay client** (`moq_stream.rs`): `serve_origin_to_relay_background` / `run_relay_announce_link` link a producer's origin **UP** to a remote relay via the existing `dial_stream` chokepoint (Quic/WebTransport native; iroh). Modeled on the event-plane `with_origin` ingest-and-re-serve, pointed at a remote endpoint instead of `connect_uds`.
- **`Role::Relay` construction**: `producer_reach()` advertises a `Destination{ role: Relay, transport }` when a relay is configured — via the **same centralized reach builder** and the **same `service_entry` `TransportConfig` codec** the DID document uses (`relay_reach_from_decoded`), so the advertised stream relay and the DID transport address never drift. Relay is **producer-chosen, default = the PDS / federation anchor**.
- **`dial_stream`-level relay routing**: a `Role::Relay` reach carries a normal `TransportConfig`, so `connect_moq_reach` dials it and subscribes to the **same `broadcastPath`** — the relay forwards by track name; the path is identical for direct and relay.
- **`StreamOpt`-driven reach selection** (`select_reach`): topology (direct vs relay) is **orthogonal** to the delivery/integrity QoS axes — it only **stably reorders** the service-advertised reach. `Pipe`/Live → direct-first; `Job`/`Log` (resumable/retained/fan-out) → relay-first. Reachability fallback is `connect_moq_reach`'s in-order try-next (direct → relay).
- **Server-authority invariant (enforced)**: selection never invents a reach, never fabricates `direct`, never drops a reach — a relay-only (anonymized) stream **stays relay-only**. The client *reads* `StreamOpt`/`reach`; it never writes them.
- **Relay server mode**: `QuinnRpcServer::with_moq_relay` runs the `/moq` plane **bidirectionally** (`Server::with_origin`) so a node can act as a blind relay (ingest a producer's broadcasts + re-serve by track name).
- **Daemon wiring**: `[quic] relay = "<uri>"` → resolved via the shared `service_entry` codec → registered (`init_global_relay_reach`) + origin linked up at service spawn. Empty = direct-only (unchanged S1/S2 baseline).

Crypto + transport stay library-internal: apps `publish_data(plaintext)` / receive plaintext and never see `enc_key`/`mac_key`/`topic`, a `TransportConfig`, or a relay address.

## Relay-blind security argument

Frames are **AEAD-sealed and chained-HMAC'd at the source** (the `enc_key` / `TaggedPayload` path already on the branch). The relay carries opaque `Bytes` and **holds no `enc_key` / `mac_key`** — it is blind **by construction, not by trust**. Per-PDS, shared, and oblivious relays are therefore all safe for content confidentiality. The new `moq_relay_rendezvous` test asserts this directly: the **exact bytes the relay forwarded do NOT verify under a wrong key**, proving content integrity is keyed at the source rather than relay-trusted.

## No schema / RPC change

`ReachOption`/`Role`/`reach`/`broadcastPath` already existed (as `Destination`/`Role`/`announcedAt`/`broadcastPath`) — this **populates** them. No capnp field or RPC method was added or changed.

## Files changed

- `crates/hyprstream-rpc/src/moq_stream.rs` — relay client, relay-reach global + `Role::Relay` in `producer_reach()`, `select_reach` / `connect_moq_reach_for_qos`, `relay_reach_from_decoded`, qos-aware `MoqStreamHandle::networked`, unit tests.
- `crates/hyprstream-rpc/src/transport/quinn_transport.rs` — `with_moq_relay` bidirectional relay-server mode.
- `crates/hyprstream-rpc/src/service/svc.rs`, `crates/hyprstream-service/src/service/{factory.rs,spawner/service.rs}`, `crates/hyprstream/src/{bin/main.rs,config/mod.rs}` — daemon wiring (`[quic] relay` → register + link up).
- `crates/hyprstream-rpc-derive/src/codegen/client.rs`, `crates/hyprstream/src/cli/{tui_handlers,shell_handlers}.rs`, `crates/hyprstream/src/services/mcp_service.rs` — thread `qos` into the networked consumer.
- `crates/hyprstream-rpc/tests/moq_relay_rendezvous.rs` (new), `crates/hyprstream-rpc/tests/moq_networked.rs` (signature).

## Verification

- `cargo build -p hyprstream-rpc -p hyprstream-service -p hyprstream` — **OK**; `cargo build --workspace` — **OK**.
- `cargo check --target wasm32-unknown-unknown -p hyprstream-rpc` (RUSTFLAGS=`--cfg=web_sys_unstable_apis`) — **OK** (streaming modules are native-gated; wasm stays green).
- `cargo test -p hyprstream-rpc` — **417 passed, 1 failed**; the single failure (`moq_event::tests::moq_event_pub_sub_roundtrip`) is **pre-existing on the branch base** (verified by stashing all changes and re-running — fails identically; a global-singleton test-ordering issue in the unrelated event plane).
- New `moq_relay_rendezvous` integration test — **passes** (producer publishes to relay, subscriber subscribes via relay, **neither dials the other**, frames MAC-verify, relay-blind assertion holds). `moq_networked` + `stream_opt_codegen` integration tests — **pass**. New `select_reach` / server-authority / relay-reach-codec unit tests — **pass**.
- `cargo clippy --release -p hyprstream-rpc -- -D warnings` — **clean**; also clean for `--tests` and for `-p hyprstream-service -p hyprstream`.

refs #358