### PR TITLE
feat(#320): InferenceService network reach via the existing Resolver

### DIFF
--- a/crates/hyprstream-rpc-derive/src/codegen/client.rs
+++ b/crates/hyprstream-rpc-derive/src/codegen/client.rs
@@ -524,6 +524,21 @@ pub fn generate_constructors(service_name: &str) -> TokenStream {
                 Self::dial_transport(&transport, signing_key, destination, token)
             }
 
+            /// Create a client for an already-resolved typed
+            /// [`hyprstream_rpc::transport::TransportConfig`] (the Inproc arm for
+            /// a co-located service, or a networked Quic/Iroh reach). Prefer this
+            /// over [`Self::for_endpoint`] when the caller already holds a typed
+            /// transport (e.g. the inference router, #320) — it skips string
+            /// parsing and routes straight through [`hyprstream_rpc::dial::dial`].
+            pub fn for_transport(
+                transport: &hyprstream_rpc::transport::TransportConfig,
+                signing_key: hyprstream_rpc::crypto::SigningKey,
+                destination: hyprstream_rpc::crypto::VerifyingKey,
+                token: Option<String>,
+            ) -> anyhow::Result<Self> {
+                Self::dial_transport(transport, signing_key, destination, token)
+            }
+
             /// Build a client for an already-resolved `TransportConfig` (the one
             /// place the generated client meets `dial()`).
             fn dial_transport(

--- a/crates/hyprstream-rpc-std/schema/model.capnp
+++ b/crates/hyprstream-rpc-std/schema/model.capnp
@@ -8,6 +8,7 @@ using import "/annotations.capnp".docExample;
 using import "/annotations.capnp".optional;
 using import "/annotations.capnp".serdeRename;
 using import "/streaming.capnp".StreamInfo;
+using import "/streaming.capnp".TransportConfig;
 using import "/inference.capnp".ChatMessage;
 using import "/inference.capnp".ToolCall;
 using import "/inference.capnp".ToolCallFunction;
@@ -266,10 +267,18 @@ struct UnloadModelRequest {
   modelRef @0 :Text;
 }
 
-# Response when model is loaded
+# Response when model is loaded.
+#
+# `reach` is the network-routable reach list for this model's InferenceService
+# (#320): the typed `TransportConfig` union resolved via the Resolver, replacing
+# the old local-only `endpoint :Text`. Only network-routable arms (Iroh; Quic)
+# are carried — a co-located caller (same process as ModelService) ignores it and
+# uses the in-process dial registry fast path, so an EMPTY list means
+# "co-located only, no remote reach published". The router single-selects ONE
+# reach per request (List is the seam for future replica balancing).
 struct LoadedModelResponse {
   modelRef @0 :Text;
-  endpoint @1 :Text;  # inproc://hyprstream/inference/{model_ref}
+  reach @1 :List(TransportConfig);
 }
 
 # Status request: empty modelRef = all known models; non-empty = specific model (0 or 1 result)
@@ -294,7 +303,7 @@ struct GenerationDefaults {
 struct ModelStatusEntry {
   modelRef   @0 :Text;
   status     @1 :Text;    # "loaded" | "loading"
-  endpoint   @2 :Text;    # empty if loading
+  reach      @2 :List(TransportConfig);  # network reach (#320); empty if loading or co-located-only
   loadedAt   @3 :Int64;   # ms elapsed since load (0 if loading)
   lastUsed   @4 :Int64;   # ms elapsed since last use (0 if loading)
   onlineTrainingConfig @5 :OnlineTrainingConfig;
@@ -319,7 +328,7 @@ struct ModelStatusResponse {
   loaded @0 :Bool;
   memoryBytes @1 :UInt64;
   sessionCount @2 :UInt32;
-  endpoint @3 :Text;       # Only set if loaded
+  reach @3 :List(TransportConfig);  # network reach (#320); empty if co-located-only / not loaded
 
   # Online training configuration (if model loaded)
   onlineTrainingConfig @4 :OnlineTrainingConfig;
@@ -380,10 +389,11 @@ struct AdapterInfo {
 # socket, and sends Register. ModelService then uses the same connection for
 # commands (LoadModel, Infer, Shutdown). This eliminates race conditions.
 
-# Sent by InferenceService when it connects back to ModelService
+# Sent by InferenceService when it connects back to ModelService.
+# (`streamEndpoint @1 :Text` was a ZMQ-XPUB vestige with no live readers — the
+# stream reach is published in StreamInfo.reach now — removed in #320.)
 struct Register {
   id @0 :Text;              # Instance ID (e.g., "inference-a1b2c3d4")
-  streamEndpoint @1 :Text;  # XPUB endpoint for token streaming
 }
 
 # Response to Register (optional, for acknowledgment)

--- a/crates/hyprstream-rpc/schema/streaming.capnp
+++ b/crates/hyprstream-rpc/schema/streaming.capnp
@@ -165,14 +165,20 @@ enum Role {
 # Network-routable transport for a reach. A union so new transports (e.g. Iroh)
 # can be added later without a wire break. Each arm is a struct so its fields —
 # including `List(Data)` cert pins — are covered by the generated codec.
+#
+# Only network-routable reaches are encoded here. Same-host endpoints
+# (`inproc`/`ipc`/UDS) are NEVER carried on the wire: a co-located caller
+# resolves them from LOCAL config / the in-process dial registry, never from an
+# advertised reach (#320). An empty reach list therefore means "co-located fast
+# path only" — there is intentionally no Inproc arm.
 struct TransportConfig {
   union {
     # Quic / WebTransport (web-transport-quinn). Dialed over `web_transport_quinn`.
     quic @0 :QuicReach;
-    # Reserved for NAT-traversing iroh dial (#274 follow-up). Capnp requires a
-    # union to have >= 2 members; this placeholder leaves room without a wire
-    # break when the iroh reach lands.
-    iroh @1 :Void;
+    # NAT-traversing iroh dial (#320, dial side wired by #282/S2). The `nodeId`
+    # IS the peer's Ed25519 identity, so this arm is identity-bound at the
+    # transport (RFC 7250), unlike QUIC's channel-only cert pin.
+    iroh @1 :IrohReach;
   }
 }
 
@@ -181,6 +187,17 @@ struct QuicReach {
   addr       @0 :Text;        # "host:port" socket address to dial.
   serverName @1 :Text;        # TLS SNI / WebPKI validation name.
   certHashes @2 :List(Data);  # Acceptable leaf-cert SHA-256 pins (self-signed mesh).
+}
+
+# Dial parameters for the iroh arm (#320). The single capnp encoding of an iroh
+# reach — `dial()`/`dial_stream` consume the decoded form
+# (`EndpointType::Iroh`); the DID-doc `IrohTransport` service-entry codec
+# (`service_entry.rs`) is the JSON projection of this same shape (one source of
+# truth: ed25519 nodeId + relay).
+struct IrohReach {
+  nodeId   @0 :Data $fixedSize(32);  # ed25519 node_id — real identity binding.
+  alpn     @1 :Text;                  # e.g. "hyprstream-rpc/1" (RPC) or "moql" (stream).
+  relayUrl @2 :Text;                  # optional iroh relay; empty = direct/pkarr (#282).
 }
 
 # Stream metadata returned when starting a stream

--- a/crates/hyprstream-rpc/src/moq_stream.rs
+++ b/crates/hyprstream-rpc/src/moq_stream.rs
@@ -865,12 +865,24 @@ async fn moq_stream_handle_task(
 ///
 /// Only the network-routable transports map; same-host endpoints are never
 /// carried in `reach` (co-located clients use the UDS fast path).
-fn reach_to_transport_config(
+pub fn reach_to_transport_config(
     reach: &crate::stream_info::Destination,
+) -> Option<crate::transport::TransportConfig> {
+    wire_transport_to_dial(&reach.transport)
+}
+
+/// The single wire→dial reach codec (#274/#320): map one wire
+/// [`crate::stream_info::TransportConfig`] union arm to the local dialable
+/// [`crate::transport::TransportConfig`]. Returns `None` for an un-routable arm
+/// (e.g. an iroh reach with no relay). Shared by the streaming plane
+/// ([`reach_to_transport_config`]) and the RPC inference router (#320), so there
+/// is exactly ONE iroh/quic reach decoding.
+pub fn wire_transport_to_dial(
+    wire: &crate::stream_info::TransportConfig,
 ) -> Option<crate::transport::TransportConfig> {
     use crate::stream_info::TransportConfig as ReachTransport;
     use crate::transport::{QuicServerAuth, TransportConfig};
-    match &reach.transport {
+    match wire {
         ReachTransport::Quic(q) => {
             let addr: std::net::SocketAddr = q.addr.parse().ok()?;
             // Fixed-size cert pins (SHA-256 = 32 bytes); skip any malformed entry.
@@ -887,14 +899,54 @@ fn reach_to_transport_config(
             };
             Some(TransportConfig::quic_with_auth(addr, q.server_name.clone(), auth))
         }
-        // #282 SEAM: `dial_stream` now dials an iroh `moql` reach
-        // (`EndpointType::Iroh { node_id, .. }`), but the **wire** reach enum's
-        // `Iroh` variant is a unit variant carrying no `node_id`/relay payload
-        // (it is code-generated from `stream.capnp`). Until that schema grows a
-        // `nodeId`/`relays` field, a StreamInfo cannot publish a dialable iroh
-        // reach, so this maps to `None` (publishers carry the Quic reach). The
-        // local `dial_stream` iroh arm is covered by the dial.rs loopback test.
-        ReachTransport::Iroh => None,
+        // #320: the wire `iroh` arm now carries the dialable `IrohReach`
+        // (nodeId + relay). Decode it into `EndpointType::Iroh`; `dial_stream`'s
+        // iroh arm (#282/S2) dials the `moql` ALPN from it. An empty `relayUrl`
+        // (and no direct addrs, which the wire reach never carries) leaves the
+        // reach un-dialable — `dial`/`dial_stream` fail-fast on it rather than
+        // hang in discovery (pkarr dial-by-node_id alone is deferred to #282).
+        ReachTransport::Iroh(i) => {
+            let relay_url = if i.relay_url.is_empty() { None } else { Some(i.relay_url.clone()) };
+            Some(TransportConfig::iroh(i.node_id, Vec::new(), relay_url))
+        }
+    }
+}
+
+/// The single dial→wire reach codec (#320): map a local dialable
+/// [`crate::transport::TransportConfig`] to a wire-publishable
+/// [`crate::stream_info::TransportConfig`] union arm.
+///
+/// Returns `None` for same-host endpoints (`Inproc`/`Ipc`/`SystemdFd`) — these
+/// are NEVER advertised on the wire (a remote caller could not dial them; a
+/// co-located caller resolves them from local config). So a co-located-only
+/// service yields an empty published reach list. The inverse of
+/// [`wire_transport_to_dial`]; both live here as the one reach codec.
+pub fn dial_transport_to_wire(
+    dial: &crate::transport::TransportConfig,
+) -> Option<crate::stream_info::TransportConfig> {
+    use crate::stream_info::{IrohReach, QuicReach, TransportConfig as ReachTransport};
+    use crate::transport::EndpointType;
+    match &dial.endpoint {
+        EndpointType::Quic { addr, server_name, auth } => Some(ReachTransport::Quic(QuicReach {
+            addr: addr.to_string(),
+            server_name: server_name.clone(),
+            cert_hashes: auth.accept_cert_hashes().iter().map(|h| h.to_vec()).collect(),
+        })),
+        // The wire iroh reach carries identity (nodeId) + relay only; direct
+        // addrs are not published (privacy + iroh discovery), matching the
+        // DID-doc `IrohTransport` entry shape (#280/#282).
+        EndpointType::Iroh { node_id, relay_url, .. } => Some(ReachTransport::Iroh(IrohReach {
+            node_id: *node_id,
+            alpn: String::from_utf8_lossy(
+                crate::transport::iroh_substrate::ALPN_HYPRSTREAM_RPC,
+            )
+            .into_owned(),
+            relay_url: relay_url.clone().unwrap_or_default(),
+        })),
+        // Same-host endpoints are never wire-advertised (#320).
+        EndpointType::Inproc { .. }
+        | EndpointType::Ipc { .. }
+        | EndpointType::SystemdFd { .. } => None,
     }
 }
 
@@ -1254,6 +1306,60 @@ mod tests {
         assert!(matches!(&got[0], StreamPayload::Data(d) if d == b"ping"));
         assert!(matches!(&got[1], StreamPayload::Complete(_)));
         Ok(())
+    }
+
+    /// #320: the iroh reach codec round-trips dial↔wire and preserves identity
+    /// (nodeId) + relay; an empty-relay reach is decoded but is not dialable
+    /// (dial/dial_stream fail-fast on it — pkarr-only is deferred to #282).
+    #[test]
+    fn iroh_reach_dial_wire_roundtrip() {
+        use crate::transport::{EndpointType, TransportConfig};
+        let node_id = [0x42u8; 32];
+        let dial = TransportConfig::iroh(node_id, Vec::new(), Some("https://relay.example".to_owned()));
+        let wire = dial_transport_to_wire(&dial).expect("iroh dial → wire");
+        match &wire {
+            crate::stream_info::TransportConfig::Iroh(i) => {
+                assert_eq!(i.node_id, node_id);
+                assert_eq!(i.relay_url, "https://relay.example");
+                assert_eq!(i.alpn, "hyprstream-rpc/1");
+            }
+            other => panic!("expected wire Iroh, got {other:?}"),
+        }
+        let back = wire_transport_to_dial(&wire).expect("iroh wire → dial");
+        match back.endpoint {
+            EndpointType::Iroh { node_id: n, relay_url, direct_addrs } => {
+                assert_eq!(n, node_id);
+                assert_eq!(relay_url.as_deref(), Some("https://relay.example"));
+                assert!(direct_addrs.is_empty(), "wire iroh reach never carries direct addrs");
+            }
+            other => panic!("expected dial Iroh, got {other:?}"),
+        }
+    }
+
+    /// #320: same-host endpoints (Inproc/Ipc) are NEVER advertised on the wire —
+    /// `dial_transport_to_wire` returns None (a co-located-only service yields an
+    /// empty published reach list).
+    #[test]
+    fn same_host_endpoints_never_wire_advertised() {
+        use crate::transport::TransportConfig;
+        assert!(dial_transport_to_wire(&TransportConfig::inproc("hyprstream/inference-x")).is_none());
+        assert!(dial_transport_to_wire(&TransportConfig::ipc("/tmp/x.sock")).is_none());
+    }
+
+    /// #320: a wire iroh reach with an empty relayUrl decodes (identity preserved)
+    /// but is not dialable — `dial` fails fast rather than hang in discovery.
+    #[test]
+    fn iroh_reach_empty_relay_decodes_but_not_dialable() {
+        use crate::stream_info::{IrohReach, TransportConfig as ReachTransport};
+        let wire = ReachTransport::Iroh(IrohReach {
+            node_id: [9u8; 32],
+            alpn: "moql".to_owned(),
+            relay_url: String::new(),
+        });
+        let dial = wire_transport_to_dial(&wire).expect("decodes");
+        // No relay + no direct addrs ⇒ dial() fail-fast.
+        let signer = crate::signer::LocalSigner::new(crate::crypto::SigningKey::generate(&mut rand::rngs::OsRng));
+        assert!(crate::dial::dial(&dial, signer, None, None).is_err(), "unreachable iroh reach must not dial");
     }
 
     /// #275: a StreamInfo carrying a dialable Quic reach must be classified as

--- a/crates/hyprstream-rpc/src/stream_info.rs
+++ b/crates/hyprstream-rpc/src/stream_info.rs
@@ -28,8 +28,8 @@
 // `Role` / `TransportConfig` / `QuicReach` types — is also code-generated here
 // from `streaming.capnp` (native capnp, no JSON-in-Text on the wire).
 pub use crate::streaming_types::{
-    Completion, Delivery, Ordering, OverflowPolicy, QuicReach, Destination, Retention, Role,
-    StreamInfo, StreamOpt, TransportConfig,
+    Completion, Delivery, IrohReach, Ordering, OverflowPolicy, QuicReach, Destination, Retention,
+    Role, StreamInfo, StreamOpt, TransportConfig,
 };
 
 /// Marker trait for typed stream QoS presets.

--- a/crates/hyprstream-rpc/tests/stream_opt_codegen.rs
+++ b/crates/hyprstream-rpc/tests/stream_opt_codegen.rs
@@ -8,8 +8,8 @@
 
 use hyprstream_rpc::capnp::{FromCapnp, ToCapnp};
 use hyprstream_rpc::stream_info::{
-    Completion, Delivery, Job, Log, Ordering, OverflowPolicy, Pipe, QuicReach, Destination,
-    Retention, Role, StreamInfo, StreamOpt, StreamOptPreset, TransportConfig,
+    Completion, Delivery, IrohReach, Job, Log, Ordering, OverflowPolicy, Pipe, QuicReach,
+    Destination, Retention, Role, StreamInfo, StreamOpt, StreamOptPreset, TransportConfig,
 };
 
 /// Serialize a `StreamInfo` through a Cap'n Proto message and read it back.
@@ -94,6 +94,89 @@ fn non_default_arms_roundtrip() {
         retention: Retention::Seconds(300),
         ..StreamOpt::default()
     });
+}
+
+/// Round-trip a single wire `TransportConfig` union through capnp and back.
+fn roundtrip_transport(t: &TransportConfig) -> TransportConfig {
+    let mut message = capnp::message::Builder::new_default();
+    {
+        let mut builder =
+            message.init_root::<hyprstream_rpc::streaming_capnp::transport_config::Builder>();
+        t.write_to(&mut builder);
+    }
+    let mut bytes = Vec::new();
+    capnp::serialize::write_message(&mut bytes, &message).expect("write_message");
+    let reader = capnp::serialize::read_message(
+        &mut std::io::Cursor::new(&bytes),
+        capnp::message::ReaderOptions::default(),
+    )
+    .expect("read_message");
+    let r = reader
+        .get_root::<hyprstream_rpc::streaming_capnp::transport_config::Reader>()
+        .expect("get_root");
+    TransportConfig::read_from(r).expect("read_from")
+}
+
+#[test]
+fn transport_config_iroh_arm_roundtrips() {
+    // #320: the iroh arm now carries a real IrohReach (nodeId + alpn + relay).
+    let t = TransportConfig::Iroh(IrohReach {
+        node_id: [0x5Au8; 32],
+        alpn: "hyprstream-rpc/1".to_owned(),
+        relay_url: "https://relay.example".to_owned(),
+    });
+    let back = roundtrip_transport(&t);
+    assert_eq!(t, back);
+    match back {
+        TransportConfig::Iroh(i) => {
+            assert_eq!(i.node_id, [0x5Au8; 32]);
+            assert_eq!(i.alpn, "hyprstream-rpc/1");
+            assert_eq!(i.relay_url, "https://relay.example");
+        }
+        other => panic!("expected Iroh, got {other:?}"),
+    }
+}
+
+#[test]
+fn transport_config_iroh_empty_relay_roundtrips() {
+    // Empty relayUrl (= direct/pkarr, #282) survives the round-trip as empty.
+    let t = TransportConfig::Iroh(IrohReach {
+        node_id: [1u8; 32],
+        alpn: "moql".to_owned(),
+        relay_url: String::new(),
+    });
+    assert_eq!(t, roundtrip_transport(&t));
+}
+
+#[test]
+fn transport_config_quic_arm_roundtrips() {
+    let t = TransportConfig::Quic(QuicReach {
+        addr: "10.0.0.1:4433".to_owned(),
+        server_name: "mesh.local".to_owned(),
+        cert_hashes: vec![vec![9u8; 32]],
+    });
+    assert_eq!(t, roundtrip_transport(&t));
+}
+
+/// #320: a `StreamInfo` whose reach carries the iroh arm round-trips end to end.
+#[test]
+fn stream_info_iroh_reach_roundtrips() {
+    let info = StreamInfo {
+        stream_id: "stream-320".to_owned(),
+        dh_public: [3u8; 32],
+        qos: StreamOpt::default(),
+        broadcast_path: "local/streams/iroh".to_owned(),
+        announced_at: vec![Destination {
+            role: Role::Direct,
+            transport: TransportConfig::Iroh(IrohReach {
+                node_id: [0x7Bu8; 32],
+                alpn: "moql".to_owned(),
+                relay_url: "https://r.example".to_owned(),
+            }),
+        }],
+    };
+    let back = roundtrip(&info);
+    assert_eq!(info.announced_at, back.announced_at);
 }
 
 #[test]

--- a/crates/hyprstream/src/services/model.rs
+++ b/crates/hyprstream/src/services/model.rs
@@ -44,6 +44,7 @@ use anyhow::{anyhow, Result};
 use hyprstream_rpc::prelude::*;
 use hyprstream_rpc::registry::{global as registry, SocketKind};
 use hyprstream_rpc::transport::TransportConfig;
+use hyprstream_rpc::stream_info::TransportConfig as WireTransportConfig;
 use lru::LruCache;
 use std::collections::HashSet;
 use std::num::NonZeroUsize;
@@ -64,11 +65,16 @@ pub const MODEL_ENDPOINT: &str = "inproc://hyprstream/model";
 pub struct LoadedModel {
     /// Model reference string (e.g., "qwen3-small:main")
     pub model_ref: String,
-    /// ZMQ endpoint for this model's InferenceService
-    pub endpoint: String,
+    /// Resolved transport for this model's InferenceService (#320). For a
+    /// co-located service this is the `Inproc` arm registered in the in-process
+    /// dial registry by the spawner; the cross-host/Iroh reach (when an
+    /// inference service has a network endpoint) is resolved via the Resolver.
+    /// The router single-selects this to talk to the inference service.
+    pub transport: TransportConfig,
     /// Handle to stop the InferenceService
     pub service_handle: hyprstream_service::SpawnedService,
-    /// Client for communicating with the InferenceService
+    /// Client for communicating with the InferenceService (built from
+    /// `transport` via `dial()` — the co-located fast path).
     pub client: InferenceClient,
     /// When the model was loaded
     pub loaded_at: Instant,
@@ -226,11 +232,66 @@ impl ModelService {
         self
     }
 
-    /// Derive the deterministic IPC endpoint for a model reference.
-    fn inference_endpoint(model_ref_str: &str) -> String {
+    /// Derive the deterministic InferenceService transport for a model ref (#320).
+    ///
+    /// Resolved via the registry (the local [`hyprstream_rpc::Resolver`] backend):
+    /// the `Inproc` arm for a co-located service. The spawner registers it in the
+    /// in-process dial registry and the router dials it via `dial()`.
+    fn inference_transport(model_ref_str: &str) -> TransportConfig {
         let safe_name = model_ref_str.replace([':', '/', '\\'], "-");
         let service_name = format!("inference-{safe_name}");
-        registry().endpoint(&service_name, SocketKind::Rep).endpoint_string()
+        registry().endpoint(&service_name, SocketKind::Rep)
+    }
+
+    /// The deterministic InferenceService endpoint *string* for a model ref.
+    ///
+    /// Retained only for human-facing display and the JSON `model.loaded` event
+    /// (`EventPayload::ModelLoaded`); the routable reach is the typed
+    /// [`Self::inference_transport`] / the capnp `reach` list (#320).
+    fn inference_endpoint(model_ref_str: &str) -> String {
+        Self::inference_transport(model_ref_str).endpoint_string()
+    }
+
+    /// The network-routable reach list a remote caller would use to dial this
+    /// model's InferenceService (#320). For a co-located service the transport is
+    /// the `Inproc` arm, which is NEVER advertised on the wire (a remote caller
+    /// can't dial it; a co-located caller uses the in-process fast path), so this
+    /// returns an EMPTY list. A networked (Quic/Iroh) inference reach maps to the
+    /// corresponding wire arm via the single dial→wire reach codec.
+    fn model_reach(transport: &TransportConfig) -> Vec<WireTransportConfig> {
+        hyprstream_rpc::moq_stream::dial_transport_to_wire(transport)
+            .into_iter()
+            .collect()
+    }
+
+    /// Router seam (#320): single-select ONE InferenceService for a request from
+    /// a loaded model's reach. Today a model maps 1:1 to one InferenceService, so
+    /// this returns that service's client — preferring the co-located fast path
+    /// (the in-process `Inproc` client built at load time) when present, else it
+    /// would dial a networked (Iroh) reach. This is req/rep single-select: NO
+    /// load-balancing, NO fanout. The reach `List` is left as the seam for future
+    /// replica balancing (round-robin / least-loaded / GPU-affinity).
+    fn select_inference_server(model: &LoadedModel) -> InferenceClient {
+        // The co-located fast path: `model.client` was dialed from the resolved
+        // transport at load time (the `Inproc` arm locally, or a networked Iroh
+        // reach for a remote service). When a model gains multiple network
+        // replicas, this is where ONE reach is single-selected and dialed.
+        //
+        // AUTHZ SEAM (#319/#328 mesh policy) — GAP, intentionally not wired here:
+        // a co-located `Inproc` selection is an in-process call within the same
+        // trust domain, so no mesh policy fires. When this seam grows a branch
+        // that DIALS a networked (Iroh) reach to a remote InferenceService, that
+        // dial MUST first be gated by the #319 mesh check on the target host
+        // identity — `mesh.rpc` / `infer.stage` for the `service:inference:host-<id>`
+        // subject in the tenant domain (the `mesh-host` policy template in
+        // `auth::policy_templates`, deny-by-default, never wildcard). The vocab +
+        // per-host identity (`node_identity::inference_host_subject`) exist; the
+        // enforcement call belongs on that future networked branch, not on the
+        // co-located fast path. (Per-host identity:
+        // `hyprstream_rpc::node_identity::mesh_host_subject`.) Cross-host
+        // inference spawn/discovery is deferred to #282, so no networked
+        // selection happens in #320 yet.
+        model.client.clone()
     }
 
     /// Resolve a model identifier string to a [`ModelRef`], supporting MIR.
@@ -289,8 +350,8 @@ impl ModelService {
             let mut cache = self.loaded_models.write().await;
             if let Some(model) = cache.get_mut(model_ref_str) {
                 model.last_used = Instant::now();
-                debug!("Model {} already loaded at {}", model_ref_str, model.endpoint);
-                return Ok(model.endpoint.clone());
+                debug!("Model {} already loaded", model_ref_str);
+                return Ok(Self::inference_endpoint(model_ref_str));
             }
         }
 
@@ -364,13 +425,20 @@ impl ModelService {
         // Start InferenceService for this model via standard Spawnable infrastructure
         let spawner = hyprstream_service::ServiceSpawner::threaded();
 
-        let transport = hyprstream_rpc::transport::TransportConfig::from_endpoint(&endpoint);
+        // Resolve the InferenceService transport via the typed `TransportConfig`
+        // (#320). For a co-located service this is the `Inproc` arm; the spawner
+        // registers it in the in-process dial registry (`register_inproc`) and
+        // the same typed transport builds the client below — no string parsing on
+        // the inference client path. (The cross-host/Iroh reach is resolved via
+        // the Resolver when an inference service has a network endpoint; pkarr
+        // auto-discovery stays deferred to #282.)
+        let transport = Self::inference_transport(model_ref_str);
         let mut service_config = crate::services::InferenceServiceConfig::new(
             &model_path,
             runtime_config,
             self.signing_key.verifying_key(),
             self.signing_key.clone(),
-            transport,
+            transport.clone(),
             fs,
         );
         if let Some(ref aud) = self.expected_audience {
@@ -382,11 +450,11 @@ impl ModelService {
         let service_handle = spawner.spawn(service_config).await
             .map_err(|e| anyhow!("Failed to spawn inference service: {}", e))?;
 
-        // Create client for this service.
-        // Inference services share the model service's signing key (line 401),
-        // so use our own verifying key directly — no PolicyService lookup needed.
-        let client = InferenceClient::for_endpoint(
-            &endpoint,
+        // Create client for this service from the typed transport (#320).
+        // Inference services share the model service's signing key, so use our
+        // own verifying key directly — no PolicyService lookup needed.
+        let client = InferenceClient::for_transport(
+            &transport,
             self.signing_key.clone(),
             self.signing_key.verifying_key(),
             None,
@@ -434,7 +502,7 @@ impl ModelService {
                 model_ref_str.to_owned(),
                 LoadedModel {
                     model_ref: model_ref_str.to_owned(),
-                    endpoint: endpoint.clone(),
+                    transport,
                     service_handle,
                     client,
                     loaded_at: Instant::now(),
@@ -507,7 +575,7 @@ impl ModelService {
             .map(|(_, model)| GenModelStatusEntry {
                 model_ref: model.model_ref.clone(),
                 status: "loaded".to_owned(),
-                endpoint: model.endpoint.clone(),
+                reach: Self::model_reach(&model.transport),
                 loaded_at: model.loaded_at.elapsed().as_millis() as i64,
                 last_used: model.last_used.elapsed().as_millis() as i64,
                 online_training_config: model.ttt_config.as_ref()
@@ -521,7 +589,7 @@ impl ModelService {
                 entries.push(GenModelStatusEntry {
                     model_ref: model_ref.clone(),
                     status: "loading".to_owned(),
-                    endpoint: String::new(),
+                    reach: Vec::new(),
                     loaded_at: 0,
                     last_used: 0,
                     online_training_config: GenOnlineTrainingConfig::default(),
@@ -539,7 +607,7 @@ impl ModelService {
             return vec![GenModelStatusEntry {
                 model_ref: model_ref_str.to_owned(),
                 status: "loaded".to_owned(),
-                endpoint: model.endpoint.clone(),
+                reach: Self::model_reach(&model.transport),
                 loaded_at: model.loaded_at.elapsed().as_millis() as i64,
                 last_used: model.last_used.elapsed().as_millis() as i64,
                 online_training_config: model.ttt_config.as_ref()
@@ -553,7 +621,7 @@ impl ModelService {
             vec![GenModelStatusEntry {
                 model_ref: model_ref_str.to_owned(),
                 status: "loading".to_owned(),
-                endpoint: String::new(),
+                reach: Vec::new(),
                 loaded_at: 0,
                 last_used: 0,
                 online_training_config: GenOnlineTrainingConfig::default(),
@@ -570,7 +638,7 @@ impl ModelService {
         if let Some(model) = cache.peek(model_ref_str) {
             ModelStatusResponse {
                 loaded: true,
-                endpoint: model.endpoint.clone(),
+                reach: Self::model_reach(&model.transport),
                 online_training_config: model.ttt_config.as_ref()
                     .map(Self::ttt_config_to_wire)
                     .unwrap_or_default(),
@@ -587,7 +655,8 @@ impl ModelService {
             .get_mut(model_ref_str)
             .ok_or_else(|| anyhow!("Model {} not found after loading", model_ref_str))?;
         model.last_used = Instant::now();
-        let client = model.client.clone();
+        // Router seam (#320): single-select one InferenceService for this request.
+        let client = Self::select_inference_server(model);
         // TODO: Forward user JWT to worker via per-call builder (delegated_bearer or
         // request().jwt(token).call(payload)) once inference methods support CallOptions.
         // The previous with_jwt() call was mutating shared state — unsafe with pooling.
@@ -989,9 +1058,9 @@ impl ModelHandler for ModelService {
         let kv_q = data.kv_quant.filter(|q| *q != KVQuantType::None);
         let model_ref = &data.model_ref;
         match self.load_model(model_ref, max_ctx, kv_q).await {
-            Ok(endpoint) => Ok(ModelResponseVariant::LoadResult(LoadedModelResponse {
+            Ok(_endpoint) => Ok(ModelResponseVariant::LoadResult(LoadedModelResponse {
                 model_ref: model_ref.to_owned(),
-                endpoint,
+                reach: Self::model_reach(&Self::inference_transport(model_ref)),
             })),
             Err(e) => Ok(ModelResponseVariant::Error(ErrorInfo {
                 message: format!("Failed to load model: {e}"),
@@ -1293,23 +1362,22 @@ impl crate::services::RequestService for ModelService {
                     let response = serialize_response(request_id, &ModelResponseVariant::LoadResult(
                         LoadedModelResponse {
                             model_ref: load_data.model_ref.clone(),
-                            endpoint: model.endpoint.clone(),
+                            reach: Self::model_reach(&model.transport),
                         },
                     ))?;
                     return Ok((response, None));
                 }
             }
-            // If already being loaded by another request, return the endpoint
+            // If already being loaded by another request, return the reach
             // without spawning a duplicate continuation
             {
                 let pending = self.pending_loads.lock().await;
                 if pending.contains(&load_data.model_ref) {
                     debug!("Model {} already being loaded, deduplicating", load_data.model_ref);
-                    let endpoint = Self::inference_endpoint(&load_data.model_ref);
                     let response = serialize_response(request_id, &ModelResponseVariant::LoadResult(
                         LoadedModelResponse {
                             model_ref: load_data.model_ref.clone(),
-                            endpoint,
+                            reach: Self::model_reach(&Self::inference_transport(&load_data.model_ref)),
                         },
                     ))?;
                     return Ok((response, None));
@@ -1320,11 +1388,10 @@ impl crate::services::RequestService for ModelService {
             let model_ref = load_data.model_ref.clone();
             info!("Load request accepted for {} (async)", model_ref);
 
-            let endpoint = Self::inference_endpoint(&model_ref);
             let response = serialize_response(request_id, &ModelResponseVariant::LoadResult(
                 LoadedModelResponse {
                     model_ref: model_ref.clone(),
-                    endpoint,
+                    reach: Self::model_reach(&Self::inference_transport(&model_ref)),
                 },
             ))?;
 
@@ -1427,5 +1494,52 @@ mod tests {
         assert_eq!(config.max_models, 5);
         assert_eq!(config.max_context, None);
         assert_eq!(config.kv_quant, KVQuantType::None);
+    }
+
+    /// #320: the co-located InferenceService resolves (via the local Resolver
+    /// registry) to an `Inproc` transport — the same arm the spawner registers in
+    /// the in-process dial registry and the router single-selects.
+    #[test]
+    fn inference_transport_is_inproc_co_located() {
+        // Default registry mode is Inproc; idempotent if another test inited it.
+        hyprstream_rpc::registry::init(hyprstream_rpc::registry::EndpointMode::Inproc, None);
+        let t = ModelService::inference_transport("qwen3-small:main");
+        match &t.endpoint {
+            hyprstream_rpc::transport::EndpointType::Inproc { endpoint } => {
+                assert!(
+                    endpoint.contains("inference-qwen3-small-main"),
+                    "deterministic per-model inproc name, got {endpoint}"
+                );
+            }
+            other => panic!("expected Inproc co-located transport, got {other:?}"),
+        }
+    }
+
+    /// #320: a co-located (`Inproc`) service publishes an EMPTY wire reach list —
+    /// same-host endpoints are never advertised; the co-located caller uses the
+    /// in-process fast path. (This is what the router's single-select consumes:
+    /// empty list ⇒ co-located fast path.)
+    #[test]
+    fn model_reach_co_located_is_empty() {
+        let inproc = TransportConfig::inproc("hyprstream/inference-x");
+        assert!(
+            ModelService::model_reach(&inproc).is_empty(),
+            "co-located Inproc reach must not be wire-advertised"
+        );
+    }
+
+    /// #320: a networked (Iroh) inference reach maps to exactly ONE wire arm —
+    /// the seam the router single-selects an Iroh reach from when no co-located
+    /// fast path is present. Identity (nodeId) is preserved (real identity bind).
+    #[test]
+    fn model_reach_networked_iroh_single_select() {
+        let node_id = [0xEEu8; 32];
+        let iroh = TransportConfig::iroh(node_id, Vec::new(), Some("https://relay.example".to_owned()));
+        let reach = ModelService::model_reach(&iroh);
+        assert_eq!(reach.len(), 1, "single-select: exactly one reach per service");
+        match &reach[0] {
+            WireTransportConfig::Iroh(i) => assert_eq!(i.node_id, node_id),
+            other => panic!("expected wire Iroh reach, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
Closes #320 (P2, multi-GPU epic #310). Addresses the loaded-model addressing seam from the spike (`docs/plans/2026-06-18-multi-gpu-multi-host-inference-spike.md`): replaces the single local-only `endpoint :Text` with a network-routable `reach :List(TransportConfig)`, routed through the **existing** `Resolver`/`dial()` path — **no new registry type**.

## Schema diff (capnp)

### `streaming.capnp` — light up the iroh arm (additive Void→struct)
```diff
 struct TransportConfig {
   union {
     quic @0 :QuicReach;
-    iroh @1 :Void;        # placeholder
+    iroh @1 :IrohReach;   # #320 — identity-bound iroh dial
   }
 }
+struct IrohReach {
+  nodeId   @0 :Data $fixedSize(32);  # ed25519 node_id — real identity binding
+  alpn     @1 :Text;                  # "hyprstream-rpc/1" (RPC) | "moql" (stream)
+  relayUrl @2 :Text;                  # optional iroh relay; empty = direct/pkarr (#282)
+}
```
Reconciles with the already-wired `dial_stream` iroh arm (S2/#282). The iroh shape (ed25519 nodeId + relay) is the **one** encoding shared with the DID-doc `IrohTransport` service entry (`service_entry.rs`) — no second iroh encoding introduced.

### `model.capnp` — typed reach List replaces the endpoint string (dense ordinal reuse)
```diff
+using import "/streaming.capnp".TransportConfig;
 struct LoadedModelResponse { modelRef @0 :Text;  -endpoint @1 :Text;  +reach @1 :List(TransportConfig); }
 struct ModelStatusEntry    { ...  -endpoint @2 :Text;  +reach @2 :List(TransportConfig);  ... }
 struct ModelStatusResponse { ...  -endpoint @3 :Text;  +reach @3 :List(TransportConfig);  ... }
 struct Register            { id @0 :Text;  -streamEndpoint @1 :Text; }   # dead ZMQ-XPUB vestige, 0 readers
```
**Dense id-spin:** each `endpoint :Text` is replaced **in place** with `reach :List(TransportConfig)` at the same ordinal — contiguous `@0..@N`, no gaps, no reserved placeholder. `Register.streamEndpoint @1` removed (verified zero live readers — always set empty in code).

**Ordinal-reuse-safety finding:** all three responses are **RPC-response-only** types, built fresh per call — grep confirmed **none is persisted/cached/written to disk** (no redb/sled/file serialization). Reusing the ordinal with a changed type is wire-safe. ✅

## How reach routes through the existing Resolver (no new registry)
`ModelService::inference_transport(model_ref)` resolves each in-process InferenceService to a typed `TransportConfig` via the registry (the local `Resolver` backend) — the `Inproc` arm for co-located. The spawner registers it (`register_inproc`); the **same** typed transport builds the `InferenceClient` (new generated `for_transport`), so the inference client path no longer parses inproc strings. The cross-host/Iroh reach comes from the resolver/DID path (publish explicit reach; pkarr auto-discovery stays deferred to #282).

## Single-select router (List = seam, no fanout)
`select_inference_server(&LoadedModel) -> InferenceClient` single-selects **one** InferenceService per request: the co-located in-process fast path today (`model.client`, built from the resolved `Inproc` transport at load time). **No load-balancing, no fanout** — req/rep picks exactly one. The reach `List` is documented as the seam for future replica balancing.

**One reach codec:** `moq_stream::{wire_transport_to_dial, dial_transport_to_wire}` — the inverse pair, reusing the existing streaming reach decoding (the prior `reach_to_transport_config` now delegates to it). Same-host endpoints (`Inproc`/`Ipc`/`SystemdFd`) are **never wire-advertised** → a co-located-only service publishes an **empty** reach list (matching streaming.capnp's deliberate "no inproc on the wire" design); a remote caller dials the Iroh/Quic arm. This is why no Inproc wire arm was added — staying exactly within the specified surface (`IrohReach` + reach List + dense spin).

## Legacy cleanup (scoped)
- Inference **client** path off the string endpoint: `model.rs` now uses `inference_transport()` + `InferenceClient::for_transport` instead of `from_endpoint`/`for_endpoint`.
- `TransportConfig::from_endpoint` **kept**: it has generic callers (generated `for_endpoint`/`from_provider_at`). Its inproc-string parsing was NOT removed — non-inference call sites still depend on it.
- `cli/training_handlers.rs` (381/689) still call `from_endpoint(INFERENCE_ENDPOINT)` to build a **spawn** transport (not a client) and dial via `for_service`, not `for_endpoint` — left as-is to keep the PR scoped; not an inference-client `for_endpoint` site.
- Did **not** take on the SocketKind ZMQ-vocabulary sweep (#380).

## Authz wiring/gap
#319/#328 mesh vocab exists (`service:inference:host-<id>` subjects, `mesh.rpc`/`infer.stage`/`query.status`, the `mesh-host` policy template, `node_identity::mesh_host_subject`). The co-located fast path is an in-process call within one trust domain, so **no mesh policy fires**. The networked-dial gate is documented as a seam at `select_inference_server`: when the router gains a branch that dials a networked (Iroh) reach to a remote host, that dial MUST first be gated by the #319 check on the target `service:inference:host-<id>`. Cross-host inference dial is deferred to #282, so no networked selection happens in #320 yet — **noted, not invented.**

## Send/Sync notes
Transport/routing only — no engine `Tensor` (`!Send`) crosses threads. The typed reach avoids string parsing; nodeId is a zero-copy fixed-size `[u8; 32]`.

## Files changed
- `crates/hyprstream-rpc/schema/streaming.capnp` — `IrohReach` + iroh arm
- `crates/hyprstream-rpc-std/schema/model.capnp` — `reach` List (dense spin) + drop `streamEndpoint`
- `crates/hyprstream-rpc/src/moq_stream.rs` — the one reach codec (wire↔dial, both arms) + tests
- `crates/hyprstream-rpc/src/stream_info.rs` — re-export `IrohReach`
- `crates/hyprstream-rpc-derive/src/codegen/client.rs` — generated `for_transport`
- `crates/hyprstream/src/services/model.rs` — typed transport, `select_inference_server`, `model_reach`, producers/consumers + tests
- `crates/hyprstream-rpc/tests/stream_opt_codegen.rs` — iroh-arm capnp round-trip tests

## Verification (build env: `OPENSSL_NO_VENDOR=1 LIBTORCH_USE_PYTORCH=1 LIBTORCH_BYPASS_VERSION_CHECK=1`)
- `cargo build -p hyprstream-rpc -p hyprstream-rpc-std -p hyprstream` — **clean** (codec regenerates).
- `cargo test -p hyprstream-rpc` — 434 pass, **new** iroh/reach tests green; the **1 failure (`moq_event::moq_event_pub_sub_roundtrip`) is pre-existing #148** (confirmed by stashing — fails on base da75c8a81 too).
- `cargo test -p hyprstream-rpc-std` / `-p hyprstream-rpc-derive` — pass.
- `cargo test -p hyprstream` — **713 lib + integration pass, 0 fail.**
- `cargo clippy --release -p hyprstream-rpc -p hyprstream-rpc-std -p hyprstream -- -D warnings` — **clean** (also clean in debug).
- wasm (`cargo check --target wasm32-unknown-unknown -p hyprstream-rpc`, CI target): the **pre-existing** `node_identity.rs` `tracing` gap / `web_sys::WebTransport` errors remain — confirmed present on base by stashing; #320 touches only native-cfg modules + capnp codegen, no wasm regression.

No schema surface beyond spec was needed (`IrohReach` + reach List + dense spin only).