### PR TITLE
feat(#384): per-server reach context + per-stream relay override (de-singletonize GLOBAL_RELAY_REACH)

### DIFF
--- a/crates/hyprstream-rpc/src/moq_stream.rs
+++ b/crates/hyprstream-rpc/src/moq_stream.rs
@@ -199,55 +199,175 @@ pub fn global_relay_reach() -> Option<&'static crate::stream_info::TransportConf
     GLOBAL_RELAY_REACH.get()
 }
 
+// ============================================================================
+// Per-server reach context (#384) — de-singletonize GLOBAL_RELAY_REACH.
+//
+// Relay/reach choice is logically PER-STREAM, but was historically wired
+// PER-PROCESS through three `OnceLock` singletons (`GLOBAL_IROH_NODE_ID`,
+// `GLOBAL_PRODUCER_REACH`, `GLOBAL_RELAY_REACH`). That granularity prevented a
+// relay-only-anonymized stream X from coexisting with a direct stream Y in the
+// same process, blocked per-tenant relay isolation, and the first-write-wins
+// `OnceLock` semantics silently clobbered later writes.
+//
+// [`ProducerReachConfig`] carries the node/server's reach inputs as plain,
+// `Clone` config data (trivially `Send + Sync`). The reach list is built by its
+// [`ProducerReachConfig::reach`] METHOD reading its OWN fields — never process
+// globals. A per-stream relay override
+// ([`ProducerReachConfig::reach_with_relay`]) lets one stream pick a different
+// relay (or go relay-only / anonymized) while another in the same process stays
+// direct — the heterogeneous-anonymization property #384 requires.
+//
+// The process globals remain ONLY as a populated-once compatibility source for
+// the deprecated free-function [`producer_reach`]; new code threads a
+// `ProducerReachConfig` (see [`global_reach_config`]). (Tier 3 — scheduled
+// relay selection — is deliberately not built but not structurally precluded:
+// a scheduler can simply hand a per-stream override to `reach_with_relay`.)
+// ============================================================================
+
+/// A node/server's moq reach inputs (#384) — the per-server context that builds
+/// a producer's `StreamInfo.reach`, replacing the three `OnceLock` singletons.
+///
+/// Plain config data (`Clone`, `Send + Sync`). The common-case relay is a
+/// server-global value (often an anycast PDS / federation-anchor address)
+/// carried in [`relay`]; a per-stream override is supplied at build time via
+/// [`ProducerReachConfig::reach_with_relay`].
+#[derive(Clone, Debug, Default)]
+pub struct ProducerReachConfig {
+    /// The node's own iroh `EndpointId` (Ed25519 public key, 32 bytes) when the
+    /// iroh substrate is bound (#357). `None` → no iroh-direct reach advertised.
+    pub iroh_node_id: Option<[u8; 32]>,
+    /// The node's network-routable Quic / WebTransport reach (the bound QUIC
+    /// address + TLS name + leaf-cert pins). `None` → no Quic-direct reach
+    /// (UDS-only / unit-test deployments).
+    pub quic_reach: Option<NodeStreamReach>,
+    /// The server-global producer-chosen relay (#358), in wire-reach form.
+    /// `None` → direct-only advertisement (S1/S2 behaviour). A per-stream
+    /// override may supersede this for an individual stream.
+    pub relay: Option<crate::stream_info::TransportConfig>,
+}
+
+impl ProducerReachConfig {
+    /// Build this server's `StreamInfo.reach` using its server-global relay.
+    ///
+    /// Equivalent to `reach_with_relay(RelayChoice::ServerDefault)`. See
+    /// [`ProducerReachConfig::reach_with_relay`] for the per-stream override and
+    /// the reach-ordering contract.
+    pub fn reach(&self) -> Vec<crate::stream_info::Destination> {
+        self.reach_with_relay(RelayChoice::ServerDefault)
+    }
+
+    /// Build a stream's `StreamInfo.reach`, applying a per-stream relay choice (#384).
+    ///
+    /// Reach ORDERING contract (unchanged — `select_reach` does the QoS reorder
+    /// downstream): **iroh-direct first, then Quic, then relay** ("direct-first"
+    /// wire order). Server authority is preserved: the client may only route
+    /// among the reaches advertised here, so a relay-only stream
+    /// ([`RelayChoice::Only`]) omits the direct reaches and stays anonymized.
+    pub fn reach_with_relay(
+        &self,
+        relay_choice: RelayChoice,
+    ) -> Vec<crate::stream_info::Destination> {
+        use crate::stream_info::{Destination, IrohReach, QuicReach, Role, TransportConfig};
+        let mut reach = Vec::new();
+
+        // A per-stream `Only` (relay-only / anonymized) override omits ALL direct
+        // reaches so the client cannot route around the relay (server authority).
+        let relay_only = matches!(relay_choice, RelayChoice::Only(_));
+
+        if !relay_only {
+            // iroh-direct first (#357): native peers prefer the NAT-traversing,
+            // pkarr-discoverable direct path. Listed ahead of Quic so the shared
+            // resolver (`connect_moq_reach`) tries it before the Quic/UDS
+            // fallbacks. `None` when iroh is disabled/unbound (Quic-only).
+            if let Some(node_id) = self.iroh_node_id {
+                reach.push(Destination {
+                    role: Role::Direct,
+                    transport: TransportConfig::Iroh(IrohReach { node_id }),
+                });
+            }
+
+            // Quic / WebTransport reach: directly-reachable peers + browsers.
+            // Kept as a fallback alongside iroh (S1's fallbacks preserved).
+            if let Some(r) = &self.quic_reach {
+                reach.push(Destination {
+                    role: Role::Direct,
+                    transport: TransportConfig::Quic(QuicReach {
+                        addr: r.addr.to_string(),
+                        server_name: r.server_name.clone(),
+                        cert_hashes: r.cert_hashes.iter().map(|h| h.to_vec()).collect(),
+                    }),
+                });
+            }
+        }
+
+        // Relay reach (#358): the rendezvous endpoint. A subscriber that cannot
+        // (or, per QoS, prefers not to) reach the producer directly rendezvouses
+        // through it instead. Listed AFTER the direct reaches ("direct-first"
+        // wire order); the QoS-aware `select_reach` reorders relay-first for
+        // resumable/retained/fan-out streams (Job/Log).
+        //
+        // The per-stream choice picks WHICH relay (or none):
+        //   - `ServerDefault` → this server's `self.relay` (the common case),
+        //   - `Override(r)`   → a per-stream relay (per-tenant isolation),
+        //   - `Only(r)`       → a per-stream relay, direct reaches omitted,
+        //   - `None`          → no relay reach (direct-only for this stream).
+        let relay = match relay_choice {
+            RelayChoice::ServerDefault => self.relay.clone(),
+            RelayChoice::Override(r) | RelayChoice::Only(r) => Some(r),
+            RelayChoice::None => None,
+        };
+        if let Some(relay) = relay {
+            reach.push(Destination { role: Role::Relay, transport: relay });
+        }
+
+        reach
+    }
+}
+
+/// Per-stream relay selection for [`ProducerReachConfig::reach_with_relay`] (#384).
+///
+/// Lets one stream pick a relay (or go relay-only / direct-only) independently
+/// of another in the SAME process — the heterogeneous-anonymization property.
+#[derive(Clone, Debug, Default)]
+pub enum RelayChoice {
+    /// Use the server-global relay ([`ProducerReachConfig::relay`]) — the common
+    /// case. Falls back to direct-only when the server has no relay configured.
+    #[default]
+    ServerDefault,
+    /// Override the server-global relay with a per-stream relay (e.g. per-tenant
+    /// isolation). Direct reaches are still advertised alongside it.
+    Override(crate::stream_info::TransportConfig),
+    /// Relay-ONLY (anonymized): use this per-stream relay and OMIT all direct
+    /// reaches, so the client can only route through the relay (server authority).
+    Only(crate::stream_info::TransportConfig),
+    /// No relay reach for this stream — advertise the direct reaches only.
+    None,
+}
+
+/// Snapshot the process globals into a [`ProducerReachConfig`] (#384 compat).
+///
+/// Bridges the deprecated [`producer_reach`] free function (and call sites not
+/// yet threaded with a `ProducerReachConfig`) to the per-server context. New
+/// code should thread an explicit [`ProducerReachConfig`] instead — this reads
+/// the `OnceLock` singletons whose first-write-wins clobbering #384 removes.
+pub fn global_reach_config() -> ProducerReachConfig {
+    ProducerReachConfig {
+        iroh_node_id: global_iroh_node_id().copied(),
+        quic_reach: global_producer_reach().cloned(),
+        relay: global_relay_reach().cloned(),
+    }
+}
+
 /// Build the `StreamInfo.reach` list for a producer on this node (#274).
 ///
-/// Centralised so every producer site emits an identical reach, sourced from the
-/// one [`NodeStreamReach`] the QUIC bind registered. Returns an empty list when
-/// the node has no networked reach (UDS-only); co-located clients fall back to
-/// the same-host UDS fast path and ignore `reach` entirely.
+/// **Deprecated (#384):** reads the process-global `OnceLock` singletons, which
+/// cannot express per-stream / per-tenant relay choice and clobber on a second
+/// write. New code should construct a [`ProducerReachConfig`] (threaded from the
+/// daemon bind site) and call [`ProducerReachConfig::reach`] /
+/// [`ProducerReachConfig::reach_with_relay`]. Retained as a thin compatibility
+/// shim over [`global_reach_config`] for call sites not yet threaded.
 pub fn producer_reach() -> Vec<crate::stream_info::Destination> {
-    use crate::stream_info::{IrohReach, QuicReach, Destination, Role, TransportConfig};
-    let mut reach = Vec::new();
-
-    // iroh-direct first (#357): native peers prefer the NAT-traversing,
-    // pkarr-discoverable direct path. Listed ahead of Quic so the shared
-    // resolver (`connect_moq_reach`) tries it before the Quic/UDS fallbacks.
-    // The node_id comes from the iroh substrate bind (== signing_key pubkey),
-    // and is `None` when iroh is disabled/unbound (Quic-only advertisement).
-    if let Some(node_id) = global_iroh_node_id() {
-        reach.push(Destination {
-            role: Role::Direct,
-            transport: TransportConfig::Iroh(IrohReach { node_id: *node_id }),
-        });
-    }
-
-    // Quic / WebTransport reach: directly-reachable peers + browsers. Kept as a
-    // fallback alongside iroh (S1's fallbacks are preserved).
-    if let Some(r) = global_producer_reach() {
-        reach.push(Destination {
-            role: Role::Direct,
-            transport: TransportConfig::Quic(QuicReach {
-                addr: r.addr.to_string(),
-                server_name: r.server_name.clone(),
-                cert_hashes: r.cert_hashes.iter().map(|h| h.to_vec()).collect(),
-            }),
-        });
-    }
-
-    // Relay reach (#358): the producer-chosen rendezvous endpoint. Advertised so
-    // a subscriber that cannot (or, per QoS, prefers not to) reach the producer
-    // directly rendezvouses through the relay instead — neither side needs to be
-    // directly reachable by the other. Listed AFTER the direct reaches so the
-    // reach list is "direct first" in wire order; the QoS-aware selector
-    // (`select_reach`) reorders relay-first for resumable/retained/fan-out
-    // streams (Job/Log). A service that wants its stream relay-ONLY (anonymized)
-    // simply omits the direct reaches by not registering a producer/iroh reach;
-    // the client can only route among what is advertised here (server authority).
-    if let Some(relay) = global_relay_reach() {
-        reach.push(Destination { role: Role::Relay, transport: relay.clone() });
-    }
-
-    reach
+    global_reach_config().reach()
 }
 
 /// Build the producer-chosen relay's wire-reach [`crate::stream_info::TransportConfig`]
@@ -1609,8 +1729,11 @@ mod tests {
         }
     }
 
-    /// `producer_reach()` advertises a `Role::Relay` Destination once a relay is
-    /// registered — populating the existing schema, no new field.
+    /// A [`ProducerReachConfig`] with a server-global relay advertises a
+    /// `Role::Relay` Destination — populating the existing schema, no new field.
+    ///
+    /// No `OnceLock` dance (#384): the config is per-instance, so this is
+    /// deterministic regardless of process-global state or test ordering.
     #[test]
     fn producer_reach_advertises_relay_when_configured() {
         let relay = ReachTransport::Quic(QuicReach {
@@ -1618,16 +1741,84 @@ mod tests {
             server_name: "pds".to_owned(),
             cert_hashes: vec![vec![1u8; 32]],
         });
-        // OnceLock: only assert the Role::Relay shape if we won the set (test
-        // isolation across the shared global), else skip — the construction logic
-        // is what we verify, and `relay_reach_from_decoded` covers it key-free.
-        if init_global_relay_reach(relay.clone()) {
-            let reach = producer_reach();
-            assert!(
-                reach.iter().any(|d| d.role == Role::Relay && d.transport == relay),
-                "producer_reach must advertise the configured Role::Relay reach"
-            );
-        }
+        let cfg = ProducerReachConfig { relay: Some(relay.clone()), ..Default::default() };
+        let reach = cfg.reach();
+        assert!(
+            reach.iter().any(|d| d.role == Role::Relay && d.transport == relay),
+            "ProducerReachConfig::reach must advertise the configured Role::Relay reach"
+        );
+    }
+
+    /// #384 regression: two DIFFERENT reach contexts in ONE process produce
+    /// DIFFERENT reach — a relay-only-anonymized stream X coexists with a
+    /// direct stream Y. This is the heterogeneous-anonymization property the
+    /// `OnceLock` singletons structurally prevented (first-write-wins clobber).
+    #[test]
+    fn heterogeneous_reach_in_one_process() {
+        let relay_x = ReachTransport::Quic(QuicReach {
+            addr: "10.0.0.9:4433".to_owned(),
+            server_name: "relay-x".to_owned(),
+            cert_hashes: vec![vec![7u8; 32]],
+        });
+        // A server with BOTH a direct (iroh) reach and a server-global relay.
+        let cfg = ProducerReachConfig {
+            iroh_node_id: Some([3u8; 32]),
+            quic_reach: None,
+            relay: Some(relay_x.clone()),
+        };
+
+        // Stream Y: server default → direct (iroh) THEN relay, direct-first order.
+        let reach_y = cfg.reach();
+        assert_eq!(reach_y[0].role, Role::Direct, "Y must advertise its direct reach first");
+        assert!(
+            reach_y.iter().any(|d| d.role == Role::Relay),
+            "Y must also advertise the server-global relay"
+        );
+
+        // Stream X: relay-ONLY (anonymized) override → NO direct reach, only the
+        // per-stream relay — same process, same config instance, different result.
+        let relay_only = ReachTransport::Quic(QuicReach {
+            addr: "10.0.0.50:4433".to_owned(),
+            server_name: "relay-anon".to_owned(),
+            cert_hashes: vec![vec![9u8; 32]],
+        });
+        let reach_x = cfg.reach_with_relay(RelayChoice::Only(relay_only.clone()));
+        assert_eq!(reach_x.len(), 1, "relay-only stream X must omit all direct reaches");
+        assert_eq!(reach_x[0].role, Role::Relay, "X is relay-only (anonymized)");
+        assert_eq!(reach_x[0].transport, relay_only, "X uses its per-stream relay override");
+        assert!(
+            !reach_x.iter().any(|d| d.role == Role::Direct),
+            "X must NOT leak a direct reach (server authority / anonymization)"
+        );
+
+        // The two streams genuinely differ in the same process — the property the
+        // singletons precluded.
+        assert_ne!(reach_x, reach_y, "X (relay-only) and Y (direct+relay) must differ");
+    }
+
+    /// Per-stream relay `Override` swaps the relay but KEEPS the direct reaches
+    /// (per-tenant isolation without anonymization), preserving direct-first order.
+    #[test]
+    fn per_stream_relay_override_keeps_direct() {
+        let server_relay = ReachTransport::Quic(QuicReach {
+            addr: "10.0.0.1:4433".to_owned(),
+            server_name: "server".to_owned(),
+            cert_hashes: vec![vec![1u8; 32]],
+        });
+        let tenant_relay = ReachTransport::Quic(QuicReach {
+            addr: "10.0.0.2:4433".to_owned(),
+            server_name: "tenant".to_owned(),
+            cert_hashes: vec![vec![2u8; 32]],
+        });
+        let cfg = ProducerReachConfig {
+            iroh_node_id: Some([4u8; 32]),
+            quic_reach: None,
+            relay: Some(server_relay.clone()),
+        };
+        let reach = cfg.reach_with_relay(RelayChoice::Override(tenant_relay.clone()));
+        assert_eq!(reach[0].role, Role::Direct, "override keeps the direct reach, listed first");
+        let relay_d = reach.iter().find(|d| d.role == Role::Relay).expect("relay advertised");
+        assert_eq!(relay_d.transport, tenant_relay, "per-stream override replaces the server relay");
     }
 
     /// QoS-driven selection: live pipes prefer DIRECT, retained/fan-out prefer RELAY.

--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -190,6 +190,13 @@ pub struct StreamContext {
     cancel_token: CancellationToken,
     /// QoS options advertised in StreamInfo and honoured by MoqStreamPublisher (#169).
     qos: crate::stream_info::StreamOpt,
+    /// Per-stream relay selection applied when building this stream's reach (#384).
+    ///
+    /// Server-authored (like `qos` — never client-supplied). Defaults to
+    /// [`crate::moq_stream::RelayChoice::ServerDefault`] (the node's server-global
+    /// relay). Set to `Only` for an anonymized, relay-only stream, or `Override`
+    /// for per-tenant relay isolation.
+    relay_choice: crate::moq_stream::RelayChoice,
 }
 
 impl StreamContext {
@@ -209,6 +216,7 @@ impl StreamContext {
             ctrl_mac_key: [0u8; 32],
             cancel_token: CancellationToken::new(),
             qos: crate::stream_info::StreamOpt::default(),
+            relay_choice: crate::moq_stream::RelayChoice::default(),
         }
     }
 
@@ -245,6 +253,7 @@ impl StreamContext {
             ctrl_mac_key: *keys.ctrl_mac_key,
             cancel_token: CancellationToken::new(),
             qos: crate::stream_info::StreamOpt::default(),
+            relay_choice: crate::moq_stream::RelayChoice::default(),
         })
     }
 
@@ -300,6 +309,30 @@ impl StreamContext {
     /// Get the QoS options for this stream (#169).
     pub fn qos(&self) -> &crate::stream_info::StreamOpt {
         &self.qos
+    }
+
+    /// Set the per-stream relay choice (#384). Server-authored — never from a
+    /// client request. Use [`crate::moq_stream::RelayChoice::Only`] for an
+    /// anonymized relay-only stream, or `Override` for per-tenant isolation.
+    pub fn with_relay_choice(mut self, relay_choice: crate::moq_stream::RelayChoice) -> Self {
+        self.relay_choice = relay_choice;
+        self
+    }
+
+    /// Get the per-stream relay choice (#384).
+    pub fn relay_choice(&self) -> &crate::moq_stream::RelayChoice {
+        &self.relay_choice
+    }
+
+    /// Build this stream's `StreamInfo.reach` from the node's per-server reach
+    /// config and this stream's [`relay_choice`](Self::relay_choice) (#384).
+    ///
+    /// This is the threaded replacement for the deprecated free-function
+    /// `producer_reach()`: a producer that holds a `StreamContext` calls this so
+    /// the stream's relay/anonymization posture is honoured per-stream instead of
+    /// resolving the process-global default.
+    pub fn reach(&self) -> Vec<crate::stream_info::Destination> {
+        crate::moq_stream::global_reach_config().reach_with_relay(self.relay_choice.clone())
     }
 }
 

--- a/crates/hyprstream-rpc/tests/moq_relay_rendezvous.rs
+++ b/crates/hyprstream-rpc/tests/moq_relay_rendezvous.rs
@@ -28,7 +28,8 @@ use ed25519_dalek::SigningKey;
 use rand::RngCore;
 
 use hyprstream_rpc::moq_stream::{
-    connect_moq_reach_for_qos, run_relay_announce_link, MoqStreamOrigin, STREAM_TRACK,
+    connect_moq_reach_for_qos, run_relay_announce_link, MoqStreamOrigin, ProducerReachConfig,
+    RelayChoice, NodeStreamReach, STREAM_TRACK,
 };
 use hyprstream_rpc::stream_info::{
     Destination, QuicReach, Role, StreamOpt, TransportConfig as ReachTransport,
@@ -205,6 +206,145 @@ async fn moq_relay_rendezvous() -> Result<()> {
     );
 
     // Teardown.
+    relay_shutdown.cancel();
+    link_task.abort();
+    let _ = relay_task.await;
+    drop(producer_origin);
+    Ok(())
+}
+
+/// End-to-end anonymization (#384): a producer that HAS a direct reach but builds
+/// its stream with [`RelayChoice::Only`] advertises a relay-ONLY reach list, and
+/// the stream still delivers through the relay. This proves the per-stream relay
+/// override actually anonymizes — the direct path exists in the node's config yet
+/// is deliberately withheld from the wire for this stream, so a subscriber CANNOT
+/// learn or dial the producer's direct address.
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn relay_choice_only_anonymizes_stream_end_to_end() -> Result<()> {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    // ── RELAY: bidirectional /moq endpoint, no keys (same as rendezvous) ───────
+    let relay_producer = moq_net::Origin::random().produce();
+    let relay_consumer = relay_producer.consume();
+    let relay_origin = MoqStreamOrigin::from_pair(relay_producer.clone(), relay_consumer);
+
+    let (relay_server, relay_addr, relay_cert) = build_server()?;
+    let relay_processor =
+        hyprstream_rpc::transport::rpc_session::from_fn(|req: bytes::Bytes| async move { Ok(req) });
+    let relay_rpc = QuinnRpcServer::with_capacity(
+        relay_server,
+        Arc::new(relay_processor),
+        fresh_signing_key(),
+        hyprstream_rpc::transport::rpc_session::DEFAULT_STREAM_LIMIT,
+    )
+    .with_moq_relay(relay_origin.producer().clone());
+    let relay_shutdown = relay_rpc.shutdown_token();
+    let relay_task = tokio::spawn(relay_rpc.run());
+
+    let relay_pin = cert_sha256(&relay_cert);
+    let relay_reach = ReachTransport::Quic(QuicReach {
+        addr: relay_addr.to_string(),
+        server_name: "localhost".to_owned(),
+        cert_hashes: vec![relay_pin.to_vec()],
+    });
+
+    // ── The node's per-server reach config: a REAL direct Quic reach is present
+    //    alongside the relay. A naive build would advertise the direct address. ──
+    let direct_addr: std::net::SocketAddr = "203.0.113.7:443".parse()?; // TEST-NET-3, unreachable
+    let server_cfg = ProducerReachConfig {
+        iroh_node_id: Some([0x11u8; 32]),
+        quic_reach: Some(NodeStreamReach {
+            addr: direct_addr,
+            server_name: "producer.invalid".to_owned(),
+            cert_hashes: vec![[0x22u8; 32]],
+            iroh_node_id: Some([0x11u8; 32]),
+        }),
+        relay: Some(relay_reach.clone()),
+    };
+
+    // ── ASSERT the anonymization property at the reach-construction layer ───────
+    // ServerDefault would leak the direct reaches; Only(relay) must withhold them.
+    let default_reach = server_cfg.reach_with_relay(RelayChoice::ServerDefault);
+    assert!(
+        default_reach.iter().any(|d| d.role == Role::Direct),
+        "ServerDefault must advertise the configured direct reach(es)"
+    );
+    let only_reach = server_cfg.reach_with_relay(RelayChoice::Only(relay_reach.clone()));
+    assert!(
+        only_reach.iter().all(|d| d.role == Role::Relay),
+        "RelayChoice::Only must omit ALL direct reaches (anonymized): {only_reach:?}"
+    );
+    assert_eq!(only_reach.len(), 1, "Only advertises exactly the one relay reach");
+    assert!(
+        only_reach[0].transport == relay_reach,
+        "the sole advertised reach is the relay"
+    );
+
+    // ── Heterogeneity in one process: a sibling stream stays direct ────────────
+    // (Proves two streams on the SAME node/config can differ — the property the
+    // process-global singleton made impossible.)
+    let sibling_reach = server_cfg.reach_with_relay(RelayChoice::None);
+    assert!(
+        sibling_reach.iter().all(|d| d.role == Role::Direct),
+        "a sibling RelayChoice::None stream stays direct-only while Only is anonymized"
+    );
+
+    // ── Now drive ACTUAL delivery using ONLY the advertised (relay-only) reach ──
+    let (_client_secret, client_pub) = hyprstream_rpc::crypto::generate_ephemeral_keypair();
+    let ctx = StreamContext::from_dh(&client_pub.to_bytes())?;
+    let topic = ctx.topic().to_owned();
+    let mac_key = *ctx.mac_key();
+
+    // Producer is a LOCAL origin, never network-bound — reachable ONLY via relay.
+    let producer_origin = {
+        let p = moq_net::Origin::random().produce();
+        let c = p.consume();
+        MoqStreamOrigin::from_pair(p, c)
+    };
+    let broadcast_path = producer_origin.broadcast_path(&topic);
+    let mut publisher = producer_origin.publisher(&ctx)?;
+
+    let link_relay = relay_reach.clone();
+    let link_producer = producer_origin.producer().clone();
+    let link_task = tokio::spawn(async move {
+        let _ = run_relay_announce_link(&link_producer, &link_relay).await;
+    });
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // The subscriber dials EXACTLY the anonymized reach the producer advertised —
+    // the relay-only list. It has no direct address to fall back to.
+    let qos = StreamOpt::default();
+    let conn = connect_moq_reach_for_qos(&only_reach, &qos)
+        .await
+        .map_err(|e| anyhow!("subscriber failed to connect via anonymized relay reach: {e}"))?;
+
+    let bc = tokio::time::timeout(
+        Duration::from_secs(5),
+        conn.consumer.announced_broadcast(&broadcast_path),
+    )
+    .await
+    .map_err(|_| anyhow!("timeout: broadcast not announced via relay"))?
+    .ok_or_else(|| anyhow!("broadcast not announced via relay"))?;
+    let track = bc.subscribe_track(&moq_net::Track::new(STREAM_TRACK))?;
+
+    let mut verifier = StreamVerifier::new(mac_key, topic.clone());
+    // Publish FIRST, then read the group (the moq group exists once published) —
+    // matches the `next_frame` ordering in `moq_relay_rendezvous`.
+    publisher.publish_data(b"anon").await?;
+    let mut group = tokio::time::timeout(Duration::from_secs(10), track.get_group(0))
+        .await
+        .map_err(|_| anyhow!("timed out waiting for relayed group 0"))??
+        .ok_or_else(|| anyhow!("relay track ended early"))?;
+    let frame = tokio::time::timeout(Duration::from_secs(10), group.read_frame())
+        .await
+        .map_err(|_| anyhow!("timed out reading relayed frame"))??
+        .ok_or_else(|| anyhow!("relayed group 0 had no frame"))?;
+    let got = hyprstream_rpc::moq_stream::verify_moq_frame(&mut verifier, &topic, &frame)?;
+    assert!(
+        matches!(got.first(), Some(StreamPayload::Data(d)) if d == b"anon"),
+        "anonymized stream must deliver through the relay: {got:?}"
+    );
+
     relay_shutdown.cancel();
     link_task.abort();
     let _ = relay_task.await;

--- a/crates/hyprstream-workers/src/runtime/service.rs
+++ b/crates/hyprstream-workers/src/runtime/service.rs
@@ -838,7 +838,7 @@ impl WorkerService {
             dh_public: *stream_ctx.server_pubkey(),
             qos: stream_ctx.qos().clone(),
             broadcast_path,
-            announced_at: hyprstream_rpc::moq_stream::producer_reach(),
+            announced_at: stream_ctx.reach(), // #384: per-stream reach via ctx
         };
 
         // Continuation: spawns FD streaming task AFTER REP is sent to client

--- a/crates/hyprstream/src/services/inference.rs
+++ b/crates/hyprstream/src/services/inference.rs
@@ -595,7 +595,9 @@ impl InferenceService {
         let broadcast_path = hyprstream_rpc::moq_stream::global_moq_origin()
             .map(|o| o.broadcast_path(stream_ctx.topic()))
             .unwrap_or_default();
-        let reach = hyprstream_rpc::moq_stream::producer_reach();
+        // #384: per-stream reach (server-authored RelayChoice on the ctx);
+        // ServerDefault unless set to Only/Override for anonymized/per-tenant.
+        let reach = stream_ctx.reach();
 
         // Delta lookup deferred to execute_stream (after TTT may modify it)
         let pending = PendingWork::Generation {
@@ -1054,7 +1056,7 @@ impl InferenceService {
             dh_public: server_pubkey,
             qos: stream_ctx.qos().clone(),
             broadcast_path,
-            announced_at: hyprstream_rpc::moq_stream::producer_reach(),
+            announced_at: stream_ctx.reach(), // #384: per-stream reach via ctx
         };
 
         Ok((stream_info, stream_ctx))
@@ -2110,7 +2112,7 @@ impl InferenceHandler for InferenceService {
             dh_public: server_pubkey,
             qos: stream_ctx.qos().clone(),
             broadcast_path,
-            announced_at: hyprstream_rpc::moq_stream::producer_reach(),
+            announced_at: stream_ctx.reach(), // #384: per-stream reach via ctx
         };
 
         let adaptation_strategy = map_adaptation_strategy(data.adaptation_strategy, data.writeback_threshold);

--- a/crates/hyprstream/src/services/metrics.rs
+++ b/crates/hyprstream/src/services/metrics.rs
@@ -325,7 +325,7 @@ impl MetricsHandler for MetricsService {
             stream_id: stream_ctx.stream_id().to_owned(),
             dh_public: *stream_ctx.server_pubkey(),
             broadcast_path,
-            announced_at: hyprstream_rpc::moq_stream::producer_reach(),
+            announced_at: stream_ctx.reach(), // #384: per-stream reach via ctx
             ..Default::default()
         };
         let inner = Arc::clone(&self.inner);

--- a/crates/hyprstream/src/services/notification.rs
+++ b/crates/hyprstream/src/services/notification.rs
@@ -468,7 +468,10 @@ impl NotificationHandler for NotificationService {
         // subscribers dial the producer directly (fixes #142). Co-located
         // subscribers fall back to the same-host UDS fast path (resolved from
         // LOCAL config by `connect_moq_reach`) — never advertised on the wire.
-        let announced_at = hyprstream_rpc::moq_stream::producer_reach();
+        // #384: notification streams are node infrastructure (not per-tenant), so
+        // they use the server-global reach (ServerDefault) directly rather than a
+        // per-stream RelayChoice — no anonymized/per-tenant relay posture applies.
+        let announced_at = hyprstream_rpc::moq_stream::global_reach_config().reach();
 
         Ok(NotificationResponseVariant::SubscribeResult(SubscribeResponse {
             subscription_id: sub_id.to_string(),

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -757,7 +757,7 @@ impl RegistryService {
             stream_id: stream_ctx.stream_id().to_owned(),
             dh_public: *stream_ctx.server_pubkey(),
             broadcast_path,
-            announced_at: hyprstream_rpc::moq_stream::producer_reach(),
+            announced_at: stream_ctx.reach(), // #384: per-stream reach via ctx
             ..Default::default()
         };
 

--- a/crates/hyprstream/src/tui/service.rs
+++ b/crates/hyprstream/src/tui/service.rs
@@ -1604,11 +1604,12 @@ impl TuiService {
 
             // #356: the node's network-routable moq reach (the bound QUIC `/moq`
             // endpoint, registered when the daemon's web_transport_quinn server
-            // binds), sourced from the single shared `producer_reach()` builder.
-            // Shared across all FD streams — they all live on this node's one moq
-            // plane. A cross-process viewer dials this reach instead of its own
-            // local moq UDS plane (see StreamInfo.announcedAt docs / connect_moq_reach).
-            let reach = hyprstream_rpc::moq_stream::producer_reach();
+            // binds). Shared across all FD streams — they all live on this node's
+            // one moq plane. A cross-process viewer dials this reach instead of its
+            // own local moq UDS plane (see StreamInfo.announcedAt docs / connect_moq_reach).
+            // #384: TUI FD streams are node-local infrastructure → server-global
+            // reach (ServerDefault); no per-stream RelayChoice posture applies.
+            let reach = hyprstream_rpc::moq_stream::global_reach_config().reach();
 
             // FD-indexed streams: [0]=stdin (input relay), [1]=stdout (frames)
             let mut stream_list = connect.reborrow().init_streams(streams.len() as u32);


### PR DESCRIPTION
Closes #384 (S7). Stacked on \`feature/streaming-plane-restoration\` (PR #378).

## Problem
\`producer_reach()\` sourced relay endpoint from a process-global \`OnceLock\` (\`GLOBAL_RELAY_REACH\`) — wrong granularity: relay choice is logically per-stream but wired per-process → could not have a relay-only-anonymized stream X alongside a direct stream Y in the same process; no per-tenant relay isolation; first-write-wins clobbered later services. (Same class as the RPC worker session-key clobber.)

## What landed (2 commits)
1. \`69620bdf8\` — \`ProducerReachConfig\` (per-server reach as plain Clone config) + \`RelayChoice\` enum (\`ServerDefault\`/\`Override\`/\`Only\`/\`None\`). \`reach_with_relay()\` is the real builder. Order/authority preserved (iroh→quic→relay; \`select_reach\` untouched). Removed the \`OnceLock\`-win test dance.
2. \`c0fcb76f2\` — threaded \`RelayChoice\` through **all 8 producer sites** via \`StreamContext\` (server-authored, mirrors existing \`qos\`; never client-supplied — no wire field). 2 infra sites (notification, tui-FD) explicitly \`ServerDefault\` w/ comments.

## Server vs client
Confirmed: \`RelayChoice\` is server-only (rides \`StreamContext\`); no capnp/wire change. \`Only\` omits direct reaches → server-authority holds by construction.

## e2e proof
\`relay_choice_only_anonymizes_stream_end_to_end\`: a node configured w/ BOTH a real direct reach AND a relay, built w/ \`Only\`, advertises relay-only (asserted) AND delivers an actual frame through the relay; a sibling \`None\` stream stays direct (heterogeneity in one process). This is the #384 regression — the capability the singleton made impossible.

## Green
\`cargo build -p hyprstream-rpc\` + \`-p hyprstream -p hyprstream-service -p hyprstream-workers\`; \`test -p hyprstream-rpc --lib -- reach\` (10 passed) + \`--test moq_relay_rendezvous\` (2 passed, incl. the new \`Only\` test); clippy clean; pre-commit full-workspace release clippy passed.

## Residual (consumer-side, NOT in this PR)
The three \`OnceLock\` singletons remain as the daemon-bind population source feeding \`global_reach_config()\`. The per-stream override is now wired + exercised, but no production caller SETS a non-default \`RelayChoice\` yet — the inference path needs to map tenant/anonymization policy → \`RelayChoice\` at \`setup_stream\`. That's a policy decision (which tenants get anonymized streams?), correctly deferred.

Claude-Session: https://claude.ai/code/session_01U3qgsHTDWME66JFGZGS3ZA