### PR TITLE
fix(#388): widen vfs::Stat with qid version+path; fix parse_dir_stats offset bug

### DIFF
--- a/crates/hyprstream-9p/src/wanix_mount.rs
+++ b/crates/hyprstream-9p/src/wanix_mount.rs
@@ -95,6 +95,8 @@ impl<T: P9Transport + 'static> Mount for WanixMount<T> {
             .map_err(|e| MountError::Io(e.to_string()))?;
         Ok(Stat {
             qtype: qid.qtype,
+            version: qid.version,
+            path: qid.path,
             size,
             name: String::new(), // name comes from walk, not stat
             mtime,

--- a/crates/hyprstream-rpc-std/src/stream_mount.rs
+++ b/crates/hyprstream-rpc-std/src/stream_mount.rs
@@ -364,12 +364,7 @@ impl Mount for StreamMount {
             StreamFidState::Info { .. } => (0, "info"),
             StreamFidState::Ctl { .. } => (0, "ctl"),
         };
-        Ok(Stat {
-            qtype,
-            size: 0,
-            name: name.to_string(),
-            mtime: 0,
-        })
+        Ok(Stat::unknown_qid(qtype, 0, name.to_string(), 0))
     }
 
     async fn clunk(&self, _fid: Fid, _caller: &Subject) {}

--- a/crates/hyprstream-rpc-std/src/vfs_mount.rs
+++ b/crates/hyprstream-rpc-std/src/vfs_mount.rs
@@ -298,12 +298,12 @@ impl Mount for GenericServiceMount {
             .ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
         let (svc_name, _) = self.service.metadata();
         let name = state.path.last().map(|s| s.as_str()).unwrap_or(svc_name);
-        Ok(Stat {
-            qtype: if state.path.is_empty() { 0x80 } else { 0 },
-            size: 0,
-            name: name.to_string(),
-            mtime: 0,
-        })
+        Ok(Stat::unknown_qid(
+            if state.path.is_empty() { 0x80 } else { 0 },
+            0,
+            name.to_string(),
+            0,
+        ))
     }
 
     async fn clunk(&self, _fid: Fid, _caller: &Subject) {}
@@ -386,12 +386,12 @@ impl Mount for DocMount {
         let state = fid.downcast_ref::<VfsFidState>()
             .ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
         let name = state.path.last().map(|s| s.as_str()).unwrap_or("doc");
-        Ok(Stat {
-            qtype: if state.path.is_empty() { 0x80 } else { 0 },
-            size: 0,
-            name: name.to_string(),
-            mtime: 0,
-        })
+        Ok(Stat::unknown_qid(
+            if state.path.is_empty() { 0x80 } else { 0 },
+            0,
+            name.to_string(),
+            0,
+        ))
     }
 
     async fn clunk(&self, _fid: Fid, _caller: &Subject) {}

--- a/crates/hyprstream-tcl/src/lib.rs
+++ b/crates/hyprstream-tcl/src/lib.rs
@@ -351,12 +351,7 @@ mod tests {
 
         async fn stat(&self, fid: &Fid, _caller: &Subject) -> Result<Stat, MountError> {
             let inner = fid.downcast_ref::<MemFid>().ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
-            Ok(Stat {
-                qtype: 0,
-                size: 0,
-                name: inner.path.clone(),
-                mtime: 0,
-            })
+            Ok(Stat::unknown_qid(0, 0, inner.path.clone(), 0))
         }
 
         async fn clunk(&self, _fid: Fid, _caller: &Subject) {}

--- a/crates/hyprstream-tcl/src/mount.rs
+++ b/crates/hyprstream-tcl/src/mount.rs
@@ -285,12 +285,7 @@ impl Mount for TclMount {
             TclFidKind::Proc(n) => (n.clone(), 0),
         };
 
-        Ok(Stat {
-            qtype,
-            size: 0,
-            name,
-            mtime: 0,
-        })
+        Ok(Stat::unknown_qid(qtype, 0, name, 0))
     }
 
     async fn clunk(&self, _fid: Fid, _caller: &Subject) {}

--- a/crates/hyprstream-vfs/src/mount.rs
+++ b/crates/hyprstream-vfs/src/mount.rs
@@ -90,12 +90,52 @@ pub struct DirEntry {
 }
 
 /// File metadata.
+///
+/// # Qid soundness invariant — SECURITY
+///
+/// In 9P, a file's `qid` is its *identity*: two files are the same file if
+/// and only if their qids are equal. A qid is the triple `{qtype, version,
+/// path}`. Historically this struct carried only `qtype`, flattening the qid
+/// and destroying the identity signal — every file looked like the same file
+/// to any qid-keyed consumer.
+///
+/// `version` and `path` are now threaded end-to-end so the surface is sound,
+/// but the *values* are not yet a strong identity:
+///   - Synthetic mounts set `version = 1` constant and `path = fnv64(path)`,
+///     which is non-cryptographic and changes on rename.
+///   - Registry-backed mounts set `path = inode` (rename-stable but subject to
+///     inode reuse) and `version = ctime` (truncated).
+///
+/// **Convention:** `path == 0` means "unknown / not provided" (e.g. non-Unix
+/// registry fallback, or a mount that has no meaningful file identity). It is
+/// NOT a valid identity and must not be treated as one.
+///
+/// **No server authz, cache key, or dedup logic may key on `qid` (version or
+/// path) as a sound identity until #387 lands a content-CID-derived qid with
+/// an AFS-style data-version uniquifier.** Treat the qid fields here as an
+/// advisory identity *hint* only. Authz must continue to key on the verified
+/// `Subject` plus path resolution, never on qid.
 #[derive(Clone, Debug)]
 pub struct Stat {
     pub qtype: u8,
+    /// Qid version (data-version). Advisory hint only — see type-level invariant.
+    pub version: u32,
+    /// Qid path (file identity). `0` means unknown. Advisory hint only — see type-level invariant.
+    pub path: u64,
     pub size: u64,
     pub name: String,
     pub mtime: u64,
+}
+
+impl Stat {
+    /// Construct a `Stat` with `version = 0, path = 0` (qid unknown).
+    ///
+    /// Use this for mounts that have no meaningful file identity (e.g. purely
+    /// synthetic test mounts). The result carries qtype/size/name/mtime and
+    /// signals via `path == 0` that the qid is not a usable identity.
+    pub fn unknown_qid(qtype: u8, size: u64, name: String, mtime: u64) -> Self {
+        Self { qtype, version: 0, path: 0, size, name, mtime }
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/crates/hyprstream-vfs/src/namespace.rs
+++ b/crates/hyprstream-vfs/src/namespace.rs
@@ -499,7 +499,7 @@ mod tests {
 
         async fn stat(&self, fid: &Fid, _caller: &Subject) -> Result<Stat, MountError> {
             let inner = fid.downcast_ref::<MemFid>().ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
-            Ok(Stat { qtype: 0, size: 0, name: inner.path.clone(), mtime: 0 })
+            Ok(Stat::unknown_qid(0, 0, inner.path.clone(), 0))
         }
 
         async fn clunk(&self, _fid: Fid, _caller: &Subject) {}
@@ -608,7 +608,7 @@ mod tests {
             async fn write(&self, _fid: &Fid, _o: u64, d: &[u8], _c: &Subject) -> Result<u32, MountError> { Ok(d.len() as u32) }
             async fn readdir(&self, _fid: &Fid, _c: &Subject) -> Result<Vec<DirEntry>, MountError> { Ok(vec![]) }
             async fn stat(&self, _fid: &Fid, _c: &Subject) -> Result<crate::mount::Stat, MountError> {
-                Ok(crate::mount::Stat { qtype: 0, size: 0, name: String::new(), mtime: 0 })
+                Ok(crate::mount::Stat::unknown_qid(0, 0, String::new(), 0))
             }
             async fn clunk(&self, _fid: Fid, _c: &Subject) {}
         }

--- a/crates/hyprstream-workers/src/workflow/runner.rs
+++ b/crates/hyprstream-workers/src/workflow/runner.rs
@@ -727,12 +727,7 @@ impl hyprstream_vfs::Mount for EnvMount {
         let inner = fid.downcast_ref::<EnvFid>().ok_or_else(|| {
             hyprstream_vfs::MountError::InvalidArgument("bad fid".into())
         })?;
-        Ok(hyprstream_vfs::Stat {
-            qtype: 0,
-            size: 0,
-            name: inner.path.clone(),
-            mtime: 0,
-        })
+        Ok(hyprstream_vfs::Stat::unknown_qid(0, 0, inner.path.clone(), 0))
     }
 
     async fn clunk(&self, _fid: hyprstream_vfs::Fid, _caller: &Subject) {}
@@ -882,12 +877,7 @@ mod tests {
             let inner = fid
                 .downcast_ref::<MemFid>()
                 .ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
-            Ok(Stat {
-                qtype: 0,
-                size: 0,
-                name: inner.path.clone(),
-                mtime: 0,
-            })
+            Ok(Stat::unknown_qid(0, 0, inner.path.clone(), 0))
         }
 
         async fn clunk(&self, _fid: Fid, _caller: &Subject) {}

--- a/crates/hyprstream/src/services/fs.rs
+++ b/crates/hyprstream/src/services/fs.rs
@@ -123,7 +123,13 @@ impl OneshotState {
 // Qid generation for synthetic nodes
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Synthetic Qid: deterministic hash of path as inode, monotonic version.
+/// Synthetic Qid: deterministic FNV-1a hash of the path string as the inode,
+/// with a constant version.
+///
+/// Advisory identity hint only — `version` is constant (no change-detection)
+/// and `path` is non-cryptographic and changes on rename. No authz may key on
+/// this. See the qid-soundness invariant on `hyprstream_vfs::Stat`; the
+/// content-CID-derived qid lands in #387.
 #[derive(Clone, Debug)]
 pub struct SyntheticQid {
     pub qtype: u8,
@@ -773,6 +779,12 @@ impl hyprstream_vfs::Mount for SyntheticTree {
         let (qid, name) = self.stat(fid_u32, &caller.to_string()).map_err(hyprstream_vfs::MountError::Io)?;
         Ok(hyprstream_vfs::Stat {
             qtype: qid.qtype,
+            // SyntheticQid version is a constant (no change-detection); path is
+            // fnv64 of the path string (non-cryptographic, rename-mutable). Both
+            // are threaded for surface soundness — see the qid invariant on
+            // `hyprstream_vfs::Stat`. A content-CID qid lands in #387.
+            version: qid.version,
+            path: qid.path,
             size: 0,
             name,
             mtime: 0,

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -160,6 +160,11 @@ fn now_epoch_secs() -> u64 {
 }
 
 /// Build a Qid from filesystem metadata.
+///
+/// Advisory identity hint only — see the qid-soundness invariant on
+/// `hyprstream_vfs::Stat`. `path = inode` is rename-stable but subject to
+/// inode reuse; `version = ctime` is truncated. No authz may key on this. The
+/// content-CID-derived qid lands in #387.
 #[cfg(unix)]
 fn qid_from_metadata(meta: &std::fs::Metadata) -> Qid {
     use std::os::unix::fs::MetadataExt;
@@ -171,6 +176,9 @@ fn qid_from_metadata(meta: &std::fs::Metadata) -> Qid {
 }
 
 /// Build a Qid from metadata (non-Unix fallback).
+///
+/// `path = 0` by the "0 = unknown" convention (no inode available); this qid
+/// is NOT a usable identity. See `hyprstream_vfs::Stat`.
 #[cfg(not(unix))]
 fn qid_from_metadata(meta: &std::fs::Metadata) -> Qid {
     Qid {
@@ -180,7 +188,7 @@ fn qid_from_metadata(meta: &std::fs::Metadata) -> Qid {
             .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
             .map(|d| d.as_secs() as u32)
             .unwrap_or(0),
-        path: 0, // No inode on non-Unix
+        path: 0, // No inode on non-Unix — "0 = unknown" per vfs::Stat convention
     }
 }
 

--- a/crates/hyprstream/src/services/remote_mount.rs
+++ b/crates/hyprstream/src/services/remote_mount.rs
@@ -257,6 +257,13 @@ impl Mount for RemoteModelMount {
 
         Ok(Stat {
             qtype: np_stat.qid.qtype,
+            // Thread the wire qid version/path through instead of discarding
+            // them. `nine.capnp` already carries these; we were flattening the
+            // qid to qtype only. See the qid-soundness invariant on
+            // `hyprstream_vfs::Stat` — these are advisory identity hints, not
+            // yet a strong identity (content-CID qid lands in #387).
+            version: np_stat.qid.version,
+            path: np_stat.qid.path,
             size: np_stat.length,
             name: np_stat.name.clone(),
             mtime: np_stat.mtime as u64,
@@ -286,7 +293,7 @@ impl Mount for RemoteModelMount {
 /// Parse packed 9P stat entries from a directory read response.
 ///
 /// Each stat entry is: `[2-byte LE size][stat bytes]`.
-/// We extract the name and qtype for DirEntry conversion.
+/// We extract qid (type/version/path), length, mtime, and name for DirEntry.
 fn parse_dir_stats(data: &[u8]) -> Vec<DirEntry> {
     let mut entries = Vec::new();
     let mut offset = 0;
@@ -302,21 +309,31 @@ fn parse_dir_stats(data: &[u8]) -> Vec<DirEntry> {
         let entry_data = &data[offset..offset + entry_size];
         offset += entry_size;
 
-        // 9P stat layout (simplified):
-        //   size(2) + type(2) + dev(4) + qid(13) + mode(4) + atime(4) + mtime(4) + length(8) +
-        //   name_len(2) + name + uid_len(2) + uid + gid_len(2) + gid + muid_len(2) + muid
+        // 9P stat layout. The outer 2-byte size has already been consumed; the
+        // inner bytes are:
+        //   type(2) dev(4) qid.type(1) qid.vers(4) qid.path(8)
+        //   mode(4) atime(4) mtime(4) length(8)   = 39 bytes
+        //   then name_len(2) name ...
         //
-        // But the outer size has already been consumed. The inner layout is:
-        //   type(2) + dev(4) + qid.type(1) + qid.vers(4) + qid.path(8) + mode(4) + atime(4) + mtime(4) + length(8)
-        //   = 39 bytes before name_len
+        // Offsets:
+        //   qid.type  @ 6            (1 byte)
+        //   qid.vers  @ 7..11        (u32 LE)
+        //   qid.path  @ 11..19       (u64 LE)
+        //   mode      @ 19..23
+        //   atime     @ 23..27
+        //   mtime     @ 27..31       (u32 LE)
+        //   length    @ 31..39       (u64 LE)
+        //   name_len  @ 39..41       (u16 LE)
         if entry_data.len() < 41 {
             continue;
         }
 
-        let qtype = entry_data[6]; // qid.type at offset 6 (after type(2) + dev(4))
-        let length = u64::from_le_bytes(entry_data[27..35].try_into().unwrap_or([0; 8]));
+        let qtype = entry_data[6];
+        let qvers = u32::from_le_bytes(entry_data[7..11].try_into().unwrap_or([0; 4]));
+        let qpath = u64::from_le_bytes(entry_data[11..19].try_into().unwrap_or([0; 8]));
+        let mtime = u32::from_le_bytes(entry_data[27..31].try_into().unwrap_or([0; 4])) as u64;
+        let length = u64::from_le_bytes(entry_data[31..39].try_into().unwrap_or([0; 8]));
 
-        // name_len at offset 39
         let name_len = u16::from_le_bytes([entry_data[39], entry_data[40]]) as usize;
         if entry_data.len() < 41 + name_len {
             continue;
@@ -329,9 +346,11 @@ fn parse_dir_stats(data: &[u8]) -> Vec<DirEntry> {
             size: length,
             stat: Some(Stat {
                 qtype,
+                version: qvers,
+                path: qpath,
                 size: length,
                 name,
-                mtime: 0,
+                mtime,
             }),
         });
     }
@@ -353,5 +372,52 @@ mod tests {
         // Size says 100 bytes but only 5 available — should not panic.
         let data = [100, 0, 0, 0, 0];
         assert!(parse_dir_stats(&data).is_empty());
+    }
+
+    /// Build one packed 9P stat entry (inner layout, no outer 2-byte size) and
+    /// verify qid type/version/path, length, mtime, and name are all decoded.
+    #[test]
+    fn parse_dir_stats_decodes_qid_and_fields() {
+        let qtype: u8 = 0x80; // QTDIR
+        let qvers: u32 = 0x0A0B_0C0D;
+        let qpath: u64 = 0x0102_0304_0506_0708;
+        let mtime: u32 = 0x1122_3344;
+        let length: u64 = 0x99AA_BBCC_DDDE_EEF0;
+        let name = b"model-dir";
+
+        // Inner stat: type(2) dev(4) qid.type(1) qid.vers(4) qid.path(8)
+        //             mode(4) atime(4) mtime(4) length(8) name_len(2) name
+        let mut inner = Vec::new();
+        inner.extend_from_slice(&0u16.to_le_bytes()); // type
+        inner.extend_from_slice(&0u32.to_le_bytes()); // dev
+        inner.push(qtype);
+        inner.extend_from_slice(&qvers.to_le_bytes());
+        inner.extend_from_slice(&qpath.to_le_bytes());
+        inner.extend_from_slice(&0u32.to_le_bytes()); // mode
+        inner.extend_from_slice(&0u32.to_le_bytes()); // atime
+        inner.extend_from_slice(&mtime.to_le_bytes());
+        inner.extend_from_slice(&length.to_le_bytes());
+        inner.extend_from_slice(&(name.len() as u16).to_le_bytes());
+        inner.extend_from_slice(name);
+
+        // Prepend the 2-byte LE entry size.
+        let mut data = (inner.len() as u16).to_le_bytes().to_vec();
+        data.extend_from_slice(&inner);
+
+        let entries = parse_dir_stats(&data);
+        assert_eq!(entries.len(), 1);
+        let e = &entries[0];
+        assert_eq!(e.name, "model-dir");
+        assert!(e.is_dir);
+        assert_eq!(e.size, length);
+        let stat = match e.stat.as_ref() {
+            Some(s) => s,
+            None => panic!("stat must be present on parsed dir entry"),
+        };
+        assert_eq!(stat.qtype, qtype);
+        assert_eq!(stat.version, qvers, "qid version must be decoded, not flattened");
+        assert_eq!(stat.path, qpath, "qid path must be decoded, not flattened");
+        assert_eq!(stat.size, length);
+        assert_eq!(stat.mtime, mtime as u64);
     }
 }


### PR DESCRIPTION
Closes #388. Part of #387 (Phase 0b — qid identity soundness foundation).

`vfs::Stat` widened with `version: u32` + `path: u64` (was flattened to qtype only). Threaded through all 12 Mount impls. `Stat::unknown_qid()` constructor for mounts with no meaningful file identity. The qid-soundness invariant ("no authz/cache/dedup may key on qid as a sound identity until #387") is documented on `Stat` itself.

**Bonus latent bug fixed:** `parse_dir_stats` was reading `length` from the wrong offset (`[27..35]` = mtime bytes as length — masked only because producers set both to 0). Now decodes the correct 9P stat layout: `qid.type@6, vers@7..11, path@11..19, mtime@27..31, length@31..39`.

No wire-format change (`nine.capnp` already carries version/path). No `version=0`-immutable sentinel. 12 Mount impls: RemoteModelMount (reads wire qid now), SyntheticTree, WanixMount, GenericServiceMount, DocMount, StreamMount, TclMount, + test mounts.

Green: 96 + 701 tests pass; clippy clean; pre-commit full-workspace release clippy passed.

Claude-Session: https://claude.ai/code/session_01U3qgsHTDWME66JFGZGS3ZA