### PR TITLE
security(#385): streaming threat-model close-out — metadata-leak doc + dhPublic invariant + relay-substitution test

### DIFF
--- a/crates/hyprstream-rpc/src/stream_consumer.rs
+++ b/crates/hyprstream-rpc/src/stream_consumer.rs
@@ -404,6 +404,25 @@ impl<T: Transport> StreamHandleImpl<T> {
     /// Full streaming setup: ECDH → derive keys → subscribe → open ctrl → create verifier.
     ///
     /// Called by `RpcClient::open_stream()` after the streaming RPC returns `StreamInfo`.
+    ///
+    /// #385 INVARIANT (S8 close-out — `dhPublic` authenticity):
+    /// The entire AEAD + chained-HMAC integrity envelope bootstraps from
+    /// `stream_info.dh_public` — the server's ephemeral Ristretto255 DH public
+    /// key. It is trustworthy ONLY because `StreamInfo` arrives over the
+    /// *authenticated* RPC channel: the RPC reply rides the iroh
+    /// node-id-bound / QUIC-cert-pinned transport, and (per #275) is wrapped in
+    /// a `ResponseEnvelope` carrying a COSE composite signature (EdDSA +
+    /// ML-DSA-65 under Hybrid), so `dhPublic` authentication reaches PQ
+    /// strength. A `dh_public` sourced from an *unauthenticated* path would let
+    /// any MITM substitute its own key, derive the stream keys itself, and forge
+    /// frames — defeating the whole envelope. This entry point is the single
+    /// library/codegen boundary that turns a `StreamInfo` into a live stream;
+    /// `dh_public` MUST therefore arrive here already authenticated. Callers
+    /// MUST NOT construct `StreamInfo` from untrusted input (e.g. a forwarded
+    /// relay advertisement or an unsigned lookup result). See
+    /// [`crate::rpc_client::parse_stream_info`] — the only producer of a
+    /// `StreamInfo` from wire bytes, reached solely via the authenticated
+    /// `call_streaming` RPC reply path.
     pub async fn open(
         transport: &T,
         stream_info: StreamInfo,
@@ -411,13 +430,18 @@ impl<T: Transport> StreamHandleImpl<T> {
         client_pubkey: &[u8; 32],
     ) -> Result<Self> {
         // Pure crypto — same code, both targets.
-        // `dh_public` is the server's ephemeral Ristretto255 DH public key (one
-        // input to the ECDH that derives the topic + MAC keys). Trust in this
-        // field comes from the signed RPC `ResponseEnvelope` wrapping StreamInfo,
-        // not from the field itself. As of #275 the `ResponseEnvelope` carries a
-        // COSE composite (EdDSA + ML-DSA-65 under Hybrid), so StreamInfo
-        // authentication reaches PQ strength on a par with the request-side
-        // `SignedEnvelope`. See `ResponseEnvelope`.
+        // #385: assert the INVARIANT above at the entry point — the envelope's
+        // integrity is a consequence of `dh_public`'s authenticity, so a
+        // zero/empty `dh_public` (an obvious "StreamInfo-from-untrusted-input"
+        // signature) fails fast here rather than producing a silently-weak
+        // handshake. (A *substituted* valid key is not detectable at this layer;
+        // it is detected by the consumer's AEAD/MAC verification failing — see
+        // the `relay_dhpublic_substitution_is_rejected` test.)
+        assert!(
+            stream_info.dh_public.iter().any(|&b| b != 0),
+            "#385 INVARIANT: StreamInfo.dh_public must be a real (non-zero) DH key — \
+             never construct StreamInfo from untrusted input"
+        );
         let shared_secret = dh_compute_raw(client_secret, &stream_info.dh_public)?;
         let keys = derive_stream_keys(&shared_secret, client_pubkey, &stream_info.dh_public)?;
 
@@ -736,5 +760,144 @@ mod policy_tests {
         let (f1, _) = frame(&key, topic, Some(m0), 1, true); // terminal payload
         v.verify(&f1).unwrap();
         assert!(v.terminal_seen());
+    }
+
+    // ── #385 S8 — relay dhPublic-substitution rejection ──────────────────────
+    //
+    // Threat (S3 relay + S5 provenance gap): once a relay is interposed, a MITM
+    // relay could try to substitute its OWN `dhPublic` in the handshake so the
+    // consumer derives keys the relay controls. S5 COSE provenance authenticates
+    // each *frame* to the producing host, but the handshake `dhPublic`→producer
+    // binding is not separately tested. This test closes that gap: it shows the
+    // consumer's AEAD verification FAILS when the keys are derived from a
+    // `dhPublic` the relay substituted, because they do not match the keys the
+    // producer sealed the frame under. The consumer, holding the *authenticated*
+    // `dhPublic` (delivered over the RPC channel — see `StreamHandleImpl::open`
+    // INVARIANT), is never fooled: it never re-derives from a relay-supplied
+    // `dhPublic`. The test asserts the negative — *if* the relay's substituted
+    // key reached the key-derivation, AEAD open would fail — which is exactly
+    // the rejection property.
+    #[test]
+    fn relay_dhpublic_substitution_is_rejected() {
+        use crate::crypto::{derive_stream_keys, generate_ephemeral_keypair, ristretto_dh_raw};
+
+        // Consumer generates an ephemeral keypair (the `client_pubkey` it sends
+        // in the streaming RPC request).
+        let (client_secret, client_pub) = generate_ephemeral_keypair();
+        let client_pub_bytes = client_pub.to_bytes();
+        let client_secret_bytes = client_secret.scalar().to_bytes();
+
+        // Producer's REAL ephemeral keypair — its public half is the `dhPublic`
+        // the authenticated RPC reply carries (the value the consumer trusts).
+        let (producer_secret, producer_pub) = generate_ephemeral_keypair();
+        let real_dh_public = producer_pub.to_bytes();
+
+        // The relay's substituted keypair — the MITM key the relay would inject
+        // in place of `dhPublic` to try to own the derived keys.
+        let (_relay_secret, relay_pub) = generate_ephemeral_keypair();
+        let relay_dh_public = relay_pub.to_bytes();
+        assert_ne!(real_dh_public, relay_dh_public, "test setup: keys must differ");
+
+        // Producer derives the REAL stream keys from the real DH (ECDH with the
+        // client's public) — these are the keys it seals every frame under.
+        let producer_shared =
+            ristretto_dh_raw(&producer_secret.scalar().to_bytes(), &client_pub_bytes).unwrap();
+        let real_keys =
+            derive_stream_keys(&producer_shared, &client_pub_bytes, &real_dh_public).unwrap();
+
+        // Build one AEAD-sealed Tagged payload exactly as the producer does
+        // (`moq_stream::seal_payload`), using the REAL enc_key. This is the
+        // ciphertext the relay forwards verbatim (it is blind to the keys).
+        let epoch = 0u64;
+        let topic = real_keys.topic.clone();
+        let real_enc = *real_keys.enc_key;
+        let plaintext = {
+            let mut p = Vec::with_capacity(1 + b"secret-token".len());
+            p.push(SEALED_KIND_DATA);
+            p.extend_from_slice(b"secret-token");
+            p
+        };
+        use crate::crypto::event_crypto::{encrypt_event, EventPrivacy};
+        let aad = stream_aead_aad(&topic, epoch);
+        let (tag, ciphertext, nonce, key_commitment) =
+            encrypt_event(&real_enc, &aad, &plaintext, EventPrivacy::ZeroKnowledge).unwrap();
+
+        // 1) Consumer holding the AUTHENTICATED keys (the real `dhPublic` arrived
+        //    over the RPC channel) opens the relay-forwarded frame: SUCCESS.
+        let consumer_shared = ristretto_dh_raw(&client_secret_bytes, &real_dh_public).unwrap();
+        let consumer_keys =
+            derive_stream_keys(&consumer_shared, &client_pub_bytes, &real_dh_public).unwrap();
+        assert_eq!(
+            *consumer_keys.enc_key,
+            real_enc,
+            "consumer (real dhPublic) and producer derive the same enc_key"
+        );
+        let opened = open_sealed_payload(
+            &consumer_keys.enc_key,
+            &topic,
+            epoch,
+            &tag,
+            &ciphertext,
+            &nonce,
+            &key_commitment,
+        )
+        .expect("consumer with the authenticated dhPublic opens the frame");
+        assert!(matches!(opened, StreamPayload::Data(d) if d == b"secret-token"));
+
+        // 2) Relay-substitution attack: a consumer that (wrongly) re-derived its
+        //    keys from the RELAY's substituted `dhPublic` cannot open the frame —
+        //    AEAD fails (wrong key). This is the rejection: the relay cannot make
+        //    a substituted `dhPublic` stick, because the keys won't line up with
+        //    the producer's sealed ciphertext. (The honest consumer never enters
+        //    this branch — it keeps the authenticated `dhPublic`; this case shows
+        //    what would happen if the substituted key were used.)
+        let sub_shared = ristretto_dh_raw(&client_secret_bytes, &relay_dh_public).unwrap();
+        let sub_keys = derive_stream_keys(&sub_shared, &client_pub_bytes, &relay_dh_public).unwrap();
+        assert_ne!(
+            *sub_keys.enc_key,
+            real_enc,
+            "substituted dhPublic MUST derive a different enc_key"
+        );
+        let subst_err = open_sealed_payload(
+            &sub_keys.enc_key,
+            &topic,
+            epoch,
+            &tag,
+            &ciphertext,
+            &nonce,
+            &key_commitment,
+        )
+        .unwrap_err();
+        let msg = subst_err.to_string();
+        assert!(
+            msg.contains("AEAD") || msg.contains("commitment") || msg.contains("key"),
+            "substituted-dhPublic AEAD open should fail closed, got: {msg}"
+        );
+
+        // 3) The MAC chain has the same property: a frame chained under the real
+        //    mac_key fails verification under the relay's mac_key. This is the
+        //    belt-and-braces check on the chained-HMAC envelope.
+        let real_mac = *real_keys.mac_key;
+        let sub_mac = *sub_keys.mac_key;
+        assert_ne!(real_mac, sub_mac, "substituted dhPublic MUST derive a different mac_key");
+        let (real_frame, _) = frame(&real_mac, &topic, None, 0, false);
+        // Real consumer (real mac_key) verifies the producer's frame.
+        let mut v_real = StreamVerifier::with_policy(
+            real_mac,
+            topic.clone(),
+            VerifierContract { ordering: StreamOrdering::Ordered, completion: Completion::Open },
+        );
+        assert!(v_real.verify(&real_frame).is_ok(), "real mac_key verifies the frame");
+        // Substituted consumer (relay mac_key) CANNOT verify the producer's frame.
+        let mut v_sub = StreamVerifier::with_policy(
+            sub_mac,
+            topic,
+            VerifierContract { ordering: StreamOrdering::Ordered, completion: Completion::Open },
+        );
+        assert!(
+            v_sub.verify(&real_frame).is_err(),
+            "a frame chained under the producer's mac_key MUST NOT verify under the \
+             relay's substituted-dhPublic mac_key (the consumer rejects the substitution)"
+        );
     }
 }

--- a/crates/hyprstream-rpc/src/transport/iroh_substrate.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_substrate.rs
@@ -42,6 +42,19 @@ impl IrohSubstrate {
     /// fallback. Operators wanting self-hosted discovery should bypass this
     /// constructor and use [`IrohSubstrate::from_endpoint`] with a
     /// pre-configured `iroh::Endpoint`.
+    ///
+    /// #385 threat — discovery metadata leak (S8 close-out):
+    /// pkarr records are *public, signed-but-not-encrypted* packets published on
+    /// the open Mainline DHT. A passive network observer can enumerate which node
+    /// IDs are reachable, observe their home-relay binding, and correlate lookup
+    /// traffic (who is asking for whom) — i.e. discovery is a metadata side
+    /// channel by construction. This is inherent to DHT discovery; the streaming
+    /// plane never claims discovery-metadata privacy. Content confidentiality is
+    /// unaffected (frames are E2E AEAD-sealed at the source; the relay and the
+    /// DHT are blind to plaintext). The mitigation is oblivious-relay (#361):
+    /// hide the lookup pattern itself. Until #361 lands, operators that consider
+    /// the side channel actionable should run a self-hosted `iroh-dns-server`
+    /// via [`Self::from_endpoint`] to keep discovery traffic off the public DHT.
     pub async fn new<M, R>(
         secret_key_bytes: [u8; 32],
         moq_handler: M,


### PR DESCRIPTION
Closes #385 (S8). Part of #355 (Streaming Plane Restoration).

Three security gaps from the 2026-06-22 MITM/discovery review:

**Gap 1 — discovery metadata leak:** documented at the pkarr/DHT path (`iroh_substrate.rs:46-57`). pkarr records are public/signed-not-encrypted on the open Mainline DHT — inherent to DHT discovery; oblivious-relay (#361) is the mitigation. No code change beyond comments.

**Gap 2 — `dhPublic` authenticity invariant:** fail-fast `assert!` + invariant doc at `stream_consumer.rs:413-436` (the single StreamInfo→stream entry point). Rejects zero `dh_public` (obvious untrusted-input signature). Documents that `parse_stream_info` is the only wire→StreamInfo producer, reached solely via authenticated RPC reply.

**Gap 3 — relay `dhPublic`-substitution rejection test:** `stream_consumer.rs:766-887`. Uses the REAL crypto path (`generate_ephemeral_keypair`, `ristretto_dh_raw`, `derive_stream_keys`) to prove: (1) consumer with authenticated dhPublic opens AEAD frame OK; (2) consumer with relay-substituted dhPublic FAILS AEAD open (different enc_key); (3) chained-HMAC has the same property (frame under producer's mac_key fails under relay's mac_key). Belt-and-braces on both AEAD and MAC.

Green: 6 policy tests pass; clippy clean; pre-commit full-workspace release clippy PASSED. 2 files (+183/−7), no capnp.

Claude-Session: https://claude.ai/code/session_01U3qgsHTDWME66JFGZGS3ZA