### PR TITLE
fix(#143): qwen3 tokenizer vocab padding skipped (LlamaModel::architecture returned Llama for Qwen) — CUDA OOB

### DIFF
--- a/crates/hyprstream/src/runtime/architectures/llama.rs
+++ b/crates/hyprstream/src/runtime/architectures/llama.rs
@@ -194,6 +194,17 @@ pub struct LlamaConfig {
     pub layer_types: Vec<String>,
     /// RoPE theta for local attention layers (Gemma3)
     pub rope_local_base_freq: Option<f32>,
+    /// The *real* model architecture this LlamaModel stands in for.
+    ///
+    /// `LlamaModel` is reused as the runtime for several architecturally-llama
+    /// families (Llama, Qwen, Mistral). The tokenizer-config dispatch keys on
+    /// `ModelOperations::architecture()`, so a Qwen3 checkpoint loaded via
+    /// `create_qwen_model` must report `Qwen` here — otherwise the
+    /// `QwenTokenizerConfig` (which pads the tokenizer vocab up to the model's
+    /// embedding size) is never applied and the tokenizer/embedding vocab
+    /// mismatch silently causes a CUDA index-out-of-bounds on the embedding
+    /// lookup (#143). Defaults to `Llama`; `create_qwen_model` overrides it.
+    pub model_architecture: ModelArchitecture,
 }
 
 /// RoPE scaling configuration (Llama 3)
@@ -227,6 +238,7 @@ impl Default for LlamaConfig {
             scale_embeddings: false,
             layer_types: vec![],
             rope_local_base_freq: None,
+            model_architecture: ModelArchitecture::Llama { version: 2 },
         }
     }
 }
@@ -258,6 +270,7 @@ impl LlamaConfig {
             scale_embeddings: false,
             layer_types: vec![],
             rope_local_base_freq: None,
+            model_architecture: ModelArchitecture::Llama { version: 3 },
         }
     }
 
@@ -287,6 +300,7 @@ impl LlamaConfig {
             scale_embeddings: false,
             layer_types: vec![],
             rope_local_base_freq: None,
+            model_architecture: ModelArchitecture::Llama { version: 3 },
         }
     }
 }
@@ -2124,6 +2138,31 @@ impl LlamaModel {
             scale_embeddings: false, // Will be set based on vocab size or explicit config
             layer_types: vec![],
             rope_local_base_freq: None,
+            // Best-effort architecture hint from model_type so tokenizer-config
+            // dispatch sees Qwen when this path is used directly. The factory's
+            // authoritative `create_*_model` path overwrites this via the unified
+            // ModelConfig (#143).
+            model_architecture: json
+                .get("model_type")
+                .and_then(|v| v.as_str())
+                .map(|mt| {
+                    let mt = mt.to_lowercase();
+                    match mt.as_str() {
+                        "qwen" | "qwen2" | "qwen3" => ModelArchitecture::Qwen {
+                            version: if mt.starts_with("qwen3") { 3 }
+                                else if mt.starts_with("qwen2") { 2 }
+                                else { 1 },
+                            is_moe: false,
+                            context_length: json["max_position_embeddings"]
+                                .as_u64()
+                                .unwrap_or(4096) as usize,
+                        },
+                        "mistral" => ModelArchitecture::Mistral,
+                        "gemma" => ModelArchitecture::Gemma,
+                        _ => ModelArchitecture::Llama { version: 2 },
+                    }
+                })
+                .unwrap_or(ModelArchitecture::Llama { version: 2 }),
         };
 
         // Parse rope scaling if present
@@ -2687,8 +2726,17 @@ impl LlamaModel {
 
 impl ModelOperations for LlamaModel {
     fn architecture(&self) -> ModelArchitecture {
-        ModelArchitecture::Llama {
-            version: self.config.version,
+        // Report the *real* family (Qwen/Mistral/...), not the Llama stand-in,
+        // so architecture-keyed dispatch (notably tokenizer-config padding for
+        // Qwen, #143) targets the correct implementation. Falls back to Llama
+        // with the parsed version when no override was set.
+        match &self.config.model_architecture {
+            ModelArchitecture::Llama { .. } | ModelArchitecture::Custom(_) => {
+                ModelArchitecture::Llama {
+                    version: self.config.version,
+                }
+            }
+            other => other.clone(),
         }
     }
 
@@ -3171,6 +3219,7 @@ mod pipeline_tests {
             scale_embeddings: false,
             layer_types: vec![],
             rope_local_base_freq: None,
+            model_architecture: ModelArchitecture::Llama { version: 2 },
         }
     }
 

--- a/crates/hyprstream/src/runtime/model_factory.rs
+++ b/crates/hyprstream/src/runtime/model_factory.rs
@@ -711,6 +711,33 @@ impl ModelFactory {
             scale_embeddings: config.scale_embeddings,
             layer_types: vec![],
             rope_local_base_freq: None,
+            // Preserve the *real* architecture so tokenizer-config dispatch (and
+            // any other architecture-keyed behavior) sees Qwen/Mistral rather
+            // than the Llama stand-in. Without this, a Qwen3 checkpoint loaded
+            // via create_qwen_model→create_llama_model reports `Llama`, the
+            // QwenTokenizerConfig (which pads the tokenizer vocab to the model's
+            // embedding size) is never applied, and the tokenizer/embedding vocab
+            // mismatch causes a CUDA index-out-of-bounds on the embedding lookup (#143).
+            model_architecture: match config.architecture {
+                super::model_config::ModelArchitecture::Qwen => {
+                    super::architectures::ModelArchitecture::Qwen {
+                        version: config.version as u8,
+                        is_moe: config.is_moe,
+                        context_length: config.max_position_embeddings,
+                    }
+                }
+                super::model_config::ModelArchitecture::Mistral => {
+                    super::architectures::ModelArchitecture::Mistral
+                }
+                super::model_config::ModelArchitecture::Gemma => {
+                    super::architectures::ModelArchitecture::Gemma
+                }
+                // Llama, Janus, Qwen3_5 (not routed through LlamaModel), and unknowns
+                // keep the Llama identity with the parsed version.
+                _ => super::architectures::ModelArchitecture::Llama {
+                    version: config.version as u8,
+                },
+            },
         };
 
         info!(
@@ -798,6 +825,7 @@ impl ModelFactory {
                 scale_embeddings: config.scale_embeddings,
                 layer_types: vec!["global".to_owned(); config.num_hidden_layers],
                 rope_local_base_freq: None,
+                model_architecture: super::architectures::ModelArchitecture::Llama { version: 3 },
             }),
             vision_config: VisionEncoderConfig {
                 encoder_type: VisionEncoderType::SigLIP {

--- a/crates/hyprstream/src/runtime/tokenizer_config.rs
+++ b/crates/hyprstream/src/runtime/tokenizer_config.rs
@@ -146,7 +146,13 @@ impl TokenizerConfig for QwenTokenizerConfig {
                 added, missing_count - 1
             );
 
-            // Verify they were actually added
+            // Verify they were actually added. A tokenizer/embedding vocab
+            // mismatch is the documented cause of CUDA index-out-of-bounds on
+            // the embedding lookup (#143): the model can sample or be fed a
+            // token id in [tokenizer_vocab, embedding_vocab), which the
+            // tokenizer cannot decode and which — if the embedding matrix was
+            // allocated to the smaller tokenizer size — faults the GPU. So a
+            // short-fall here is a hard error, not a warning.
             let new_size = tokenizer.get_vocab_size(true);
             if new_size == model_vocab_size {
                 tracing::info!("✅ Vocabulary successfully expanded from {} to {}", current_vocab_size, new_size);
@@ -155,10 +161,20 @@ impl TokenizerConfig for QwenTokenizerConfig {
                     "✅ Vocabulary expanded from {} to {} (added {} tokens)",
                     current_vocab_size, new_size, new_size - current_vocab_size
                 );
-            } else {
-                tracing::warn!(
-                    "⚠️ Failed to expand vocabulary: size remains at {} (expected {})",
-                    new_size, model_vocab_size
+            }
+            // new_size < current_vocab_size only happens if add_special_tokens
+            // no-ops entirely (e.g. all candidates already present) — still a
+            // mismatch when model_vocab_size > new_size.
+            if new_size != model_vocab_size {
+                anyhow::bail!(
+                    "Qwen tokenizer vocab ({}) could not be expanded to the model's \
+                     embedding size ({}): add_special_tokens reported {}, final size {}. \
+                     A tokenizer/embedding vocab mismatch causes a CUDA \
+                     index-out-of-bounds on the embedding lookup; refusing to load.",
+                    current_vocab_size,
+                    model_vocab_size,
+                    added,
+                    new_size
                 );
             }
         }


### PR DESCRIPTION
Closes #143.

## Root cause
Qwen3 checkpoints load via `create_qwen_model → create_llama_model` as a `LlamaModel`. But `LlamaModel::architecture()` unconditionally returned `ModelArchitecture::Llama`, so `load_tokenizer`'s config dispatch picked `LlamaTokenizerConfig` (no-op) instead of `QwenTokenizerConfig` — which pads the tokenizer vocab from 151669 to the embedding's 151936 (`<|extra_0|>`..`<|extra_266|>`). The tokenizer stayed at 151669; token IDs in [151669, 151936) hit `index_select` OOB on the embedding.

## Fix (3 files, +100/−7)
- `llama.rs`: `LlamaConfig::model_architecture` field (defaults Llama); `LlamaModel::architecture()` returns the real family (Qwen/Mistral/...).
- `model_factory.rs`: `create_llama_model` sets `model_architecture` from `ModelConfig.architecture`.
- `tokenizer_config.rs`: `QwenTokenizerConfig` vocab shortfall now `bail!` (hard error) not `warn!` — regression can't recur silently.

## Verified on cuda130/RTX 5090
Tokenizer pads 151669→151936 correctly; prefill + generation completes exit 0. Pre-commit clippy hook passed. 9 model_config + tokenizer tests pass.

Claude-Session: https://claude.ai/code/session_01U3qgsHTDWME66JFGZGS3ZA