### PR TITLE
feat(#408): Kata 9P server-side translator (TCP transport + bidirectional 9P codec)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6365,6 +6365,7 @@ dependencies = [
  "hkdf",
  "hmac 0.12.1",
  "http 1.3.1",
+ "hyprstream-9p",
  "hyprstream-compositor",
  "hyprstream-containedfs",
  "hyprstream-discovery",
@@ -6463,9 +6464,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "dashmap",
  "hyprstream-rpc",
  "hyprstream-vfs",
  "js-sys",
+ "parking_lot 0.12.4",
+ "tokio",
+ "tracing",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]

--- a/crates/hyprstream-9p/Cargo.toml
+++ b/crates/hyprstream-9p/Cargo.toml
@@ -3,7 +3,7 @@ name = "hyprstream-9p"
 version = "0.1.0"
 edition.workspace = true
 license = "MIT"
-description = "Minimal 9P2000.L server for bridging VFS to Wanix via DMA"
+description = "9P2000.L codec and server-side translator bridging 9P to hyprstream RPC (capnp)"
 
 [lib]
 crate-type = ["rlib"]
@@ -13,8 +13,18 @@ hyprstream-vfs = { path = "../hyprstream-vfs" }
 hyprstream-rpc = { path = "../hyprstream-rpc" }
 async-trait = { workspace = true }
 anyhow = { workspace = true }
+tokio = { version = "1", features = ["net", "io-util", "rt", "sync", "macros"] }
+tracing = { workspace = true }
+dashmap = { workspace = true }
+parking_lot = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+
+[features]
+default = []

--- a/crates/hyprstream-9p/README.md
+++ b/crates/hyprstream-9p/README.md
@@ -23,13 +23,37 @@ Implements the subset of the 9P2000.L wire protocol needed for read/write filesy
 
 **WASM extras** (`target_arch = "wasm32"`): `dma` module (SAB ring-buffer transport) and `wanix_mount` (mount the VFS into the Wanix namespace via DMA).
 
+## Server-side translator (Kata 9P)
+
+`translator::Translator` is a server-side 9P2000.L translator: it accepts 9P
+connections (TCP transport now, for standalone testing; virtio-9P later) and
+translates each T-message into a [`backend::Backend`] call. The codec is
+bidirectional — `msg.rs` provides T-message parsers + R-message encoders
+(server side) alongside the original T-message encoders + R-message parsers
+(client side).
+
+The backend is the capnp-RPC seam. The `hyprstream` binary crate ships
+`services::kata_9p_backend::ModelBackend`, which wraps the generated
+`ModelClient` and turns each `Backend` call into a `nine.capnp` envelope
+against the model service's `fs` scope — the inverse of `RemoteModelMount`
+(VFS → RPC):
+
+```
+Kata guest (virtio-9P / TCP) ─► Translator ─► ModelBackend ─► ModelClient.fs()
+   9P2000.L wire                 fid table       capnp RPC (nine.capnp)
+```
+
+`memory::MemoryBackend` is an in-process backend used by the integration tests
+in `tests/tcp_translator.rs` so the translator can be exercised with no
+network and no model service running.
+
 ## Architecture position
 
 ```
 hyprstream-vfs           (Mount trait, Namespace, Fid)
     ↑
-hyprstream-9p            ← you are here
+hyprstream-9p            ← you are here  (codec + translator + Backend trait)
     ↑
-hyprstream               (9P server factory)
+hyprstream               (ModelBackend: 9P → model-service capnp RPC)
 www-cyberdione-ai        (Wanix WASM: mounts via DMA ring buffer)
 ```

--- a/crates/hyprstream-9p/src/backend.rs
+++ b/crates/hyprstream-9p/src/backend.rs
@@ -1,0 +1,84 @@
+//! Backend trait — the capnp-RPC-shaped seam the translator dispatches to.
+//!
+//! Each method mirrors a 9P2000.L filesystem operation as expressed in
+//! `nine.capnp` (NpWalk / NpOpen / NpRead / NpWrite / NpClunk / NpStatReq).
+//! The translator owns the server-side fid table and calls these methods
+//! after resolving the incoming 9P fid.
+//!
+//! `MemoryBackend` ([`crate::memory::MemoryBackend`]) provides an
+//! in-process implementation for standalone tests; the `hyprstream` binary
+//! crate ships a `ModelBackend` that wraps the generated `ModelClient` and
+//! turns each call into a capnp RPC against the model service's `fs` scope
+//! (the inverse of `RemoteModelMount`, which goes VFS → RPC).
+
+use async_trait::async_trait;
+
+use crate::msg::Qid;
+
+/// Result of a walk: the qid of the resolved path and, for directories, the
+/// qids of each intermediate component. For a single-component walk (the
+/// common case for this translator) `qids` holds exactly the leaf qid.
+#[derive(Debug, Clone)]
+pub struct WalkResult {
+    /// Qids for each path component successfully walked (length matches the
+    /// number of components traversed; the client treats a short list as
+    /// "walk stopped early").
+    pub qids: Vec<Qid>,
+}
+
+/// Result of an open/lopen.
+#[derive(Debug, Clone)]
+pub struct OpenResult {
+    pub qid: Qid,
+    /// Maximum read/write unit the backend will accept in a single call.
+    pub iounit: u32,
+}
+
+/// Result of a stat/getattr.
+#[derive(Debug, Clone)]
+pub struct StatResult {
+    pub qid: Qid,
+    /// Unix mode bits (e.g. `0o040755` for a dir).
+    pub mode: u32,
+    pub size: u64,
+    pub mtime_sec: u64,
+}
+
+/// 9P filesystem backend.
+///
+/// All methods are async and `Send`-safe so the translator can drive them on
+/// a multi-threaded tokio runtime. Fid numbers are opaque to the backend —
+/// the translator allocates and tracks them; the backend sees a stable fid
+/// per walked path.
+#[async_trait]
+pub trait Backend: Send + Sync {
+    /// Walk `components` from `fid` (the previously-walked parent, or the
+    /// attach root). Allocates internal state for `newfid`.
+    async fn walk(
+        &self,
+        fid: u32,
+        newfid: u32,
+        components: &[String],
+    ) -> anyhow::Result<WalkResult>;
+
+    /// Open `fid` with Linux-style `flags` (Tlopen). Returns the leaf qid
+    /// and the negotiated iounit.
+    async fn open(&self, fid: u32, flags: u32) -> anyhow::Result<OpenResult>;
+
+    /// Read up to `count` bytes from `fid` at `offset`.
+    async fn read(&self, fid: u32, offset: u64, count: u32) -> anyhow::Result<Vec<u8>>;
+
+    /// Write `data` to `fid` at `offset`. Returns the number of bytes written.
+    async fn write(&self, fid: u32, offset: u64, data: &[u8]) -> anyhow::Result<u32>;
+
+    /// Stat `fid`.
+    async fn stat(&self, fid: u32) -> anyhow::Result<StatResult>;
+
+    /// List directory entries under `fid` (a directory). The returned bytes
+    /// are 9P readdir records; the translator passes them through verbatim.
+    async fn readdir(&self, fid: u32, offset: u64, count: u32) -> anyhow::Result<Vec<u8>>;
+
+    /// Release `fid`. Best-effort — errors are logged and ignored by the
+    /// translator (the fid is dropped from its table regardless).
+    async fn clunk(&self, fid: u32) -> anyhow::Result<()>;
+}

--- a/crates/hyprstream-9p/src/lib.rs
+++ b/crates/hyprstream-9p/src/lib.rs
@@ -1,23 +1,33 @@
-//! Minimal 9P2000.L server for bridging hyprstream VFS to Wanix via DMA.
+//! 9P2000.L codec and server-side translator for hyprstream.
 //!
-//! Implements only the message types needed for filesystem access:
-//! - Tversion/Rversion — protocol negotiation
-//! - Tattach/Rattach — attach to root
-//! - Twalk/Rwalk — path traversal
-//! - Tlopen/Rlopen — open file (9P2000.L variant)
-//! - Tread/Rread — read data
-//! - Twrite/Rwrite — write data
-//! - Treaddir/Rreaddir — list directory
-//! - Tgetattr/Rgetattr — stat file
-//! - Tclunk/Rclunk — close fid
-//! - Rlerror — error response
+//! Two halves:
 //!
-//! Wire format: all messages are length-prefixed (4-byte LE), matching
-//! the DMA ring buffer's message framing.
+//! - **Codec** ([`msg`]): the full 9P2000.L wire format. `read_from` / `write_to`
+//!   style helpers for *both* client and server sides — T-message parsers +
+//!   R-message encoders live alongside the original client-side encoders +
+//!   R-message parsers.
+//!
+//! - **Translator** ([`translator`]): a server that accepts 9P connections
+//!   (TCP transport now; virtio-9P later), maintains a server-side fid table,
+//!   and translates each T-message into a [`backend::Backend`] call. The
+//!   backend is the capnp-RPC seam: the `hyprstream` binary crate ships a
+//!   `ModelBackend` that turns each call into a `nine.capnp` envelope against
+//!   the model service's `fs` scope — the inverse of `RemoteModelMount`
+//!   (VFS → RPC).
+//!
+//! The client side ([`client`], [`dma`], [`wanix_mount`]) bridges hyprstream's
+//! VFS to Wanix via DMA and is unchanged.
 
 pub mod msg;
 pub mod client;
+pub mod backend;
+pub mod memory;
+pub mod translator;
+
 #[cfg(target_arch = "wasm32")]
 pub mod dma;
 #[cfg(target_arch = "wasm32")]
 pub mod wanix_mount;
+
+pub use backend::{Backend, OpenResult, StatResult, WalkResult};
+pub use translator::{FidTable, Translator};

--- a/crates/hyprstream-9p/src/memory.rs
+++ b/crates/hyprstream-9p/src/memory.rs
@@ -1,0 +1,214 @@
+//! In-memory [`Backend`] for standalone translator tests.
+//!
+//! Holds a flat map of absolute path → file contents plus a per-fid map of
+//! open state (offset cursor, resolved path). The translator drives this
+//! exactly as it would drive a `ModelBackend` (capnp RPC), so tests exercise
+//! the full 9P codec + fid-table + dispatch path with no network.
+
+use std::collections::HashMap;
+use parking_lot::Mutex;
+
+use async_trait::async_trait;
+
+use crate::backend::{Backend, OpenResult, StatResult, WalkResult};
+use crate::msg::Qid;
+
+/// Path → bytes for a single open file. Fids reference these by allocated id.
+struct FileEntry {
+    bytes: Vec<u8>,
+    qid: Qid,
+}
+
+/// Per-fid live state: which path it points at (None = root).
+#[derive(Clone)]
+struct FidLink {
+    path: Option<String>,
+    qid: Qid,
+    is_dir: bool,
+}
+
+/// In-memory backend.
+#[derive(Default)]
+pub struct MemoryBackend {
+    files: Mutex<HashMap<String, FileEntry>>,
+    fids: Mutex<HashMap<u32, FidLink>>,
+    next_path: Mutex<u64>,
+}
+
+impl MemoryBackend {
+    /// Add a file at an absolute path (e.g. `/hello.txt`).
+    pub fn add_file(&self, path: &str, contents: &[u8]) {
+        let mut path_no_root = path.trim_start_matches('/');
+        // Treat top-level files as single-component names.
+        if let Some(stripped) = path_no_root.strip_prefix('/') {
+            path_no_root = stripped;
+        }
+        let mut files = self.files.lock();
+        let qid = Qid {
+            qtype: 0, // QTFILE
+            version: 1,
+            path: {
+                let mut np = self.next_path.lock();
+                *np += 1;
+                *np
+            },
+        };
+        files.insert(
+            path_no_root.to_owned(),
+            FileEntry { bytes: contents.to_vec(), qid },
+        );
+    }
+
+    fn root_qid() -> Qid {
+        Qid { qtype: 0x80, version: 1, path: 0 } // QTDIR
+    }
+}
+
+#[async_trait]
+impl Backend for MemoryBackend {
+    async fn walk(
+        &self,
+        _fid: u32,
+        newfid: u32,
+        components: &[String],
+    ) -> anyhow::Result<WalkResult> {
+        // Empty walk = clone/attach to root.
+        if components.is_empty() {
+            let link = FidLink { path: None, qid: Self::root_qid(), is_dir: true };
+            self.fids.lock().insert(newfid, link);
+            return Ok(WalkResult { qids: vec![Self::root_qid()] });
+        }
+
+        let name = &components[0];
+        let files = self.files.lock();
+        let entry = files
+            .get(name)
+            .ok_or_else(|| anyhow::anyhow!("no such file: {name}"))?;
+        let qid = entry.qid.clone();
+        drop(files);
+
+        let link = FidLink { path: Some(name.clone()), qid: qid.clone(), is_dir: false };
+        self.fids.lock().insert(newfid, link);
+        Ok(WalkResult { qids: vec![qid] })
+    }
+
+    async fn open(&self, fid: u32, _flags: u32) -> anyhow::Result<OpenResult> {
+        let fids = self.fids.lock();
+        let link = fids
+            .get(&fid)
+            .ok_or_else(|| anyhow::anyhow!("unknown fid {fid}"))?;
+        Ok(OpenResult { qid: link.qid.clone(), iounit: 8 * 1024 })
+    }
+
+    async fn read(&self, fid: u32, offset: u64, count: u32) -> anyhow::Result<Vec<u8>> {
+        let fids = self.fids.lock();
+        let link = fids
+            .get(&fid)
+            .ok_or_else(|| anyhow::anyhow!("unknown fid {fid}"))?;
+        if link.is_dir {
+            // Directory read: synthesize a 9P readdir record per top-level file.
+            let files = self.files.lock();
+            let mut out = Vec::new();
+            for (name, entry) in files.iter() {
+                out.extend_from_slice(&(name.len() as u32).to_le_bytes());
+                out.extend_from_slice(name.as_bytes());
+                out.push(0); // not dir
+                out.extend_from_slice(&(entry.bytes.len() as u64).to_le_bytes());
+            }
+            let off = offset as usize;
+            if off >= out.len() {
+                return Ok(Vec::new());
+            }
+            let end = (off + count as usize).min(out.len());
+            return Ok(out[off..end].to_vec());
+        }
+        let path = link.path.clone().unwrap_or_default();
+        let files = self.files.lock();
+        let entry = files
+            .get(&path)
+            .ok_or_else(|| anyhow::anyhow!("fid {fid} has no backing file"))?;
+        let off = offset as usize;
+        if off >= entry.bytes.len() {
+            return Ok(Vec::new());
+        }
+        let end = (off + count as usize).min(entry.bytes.len());
+        Ok(entry.bytes[off..end].to_vec())
+    }
+
+    async fn write(&self, fid: u32, offset: u64, data: &[u8]) -> anyhow::Result<u32> {
+        let fids = self.fids.lock();
+        let link = fids
+            .get(&fid)
+            .ok_or_else(|| anyhow::anyhow!("unknown fid {fid}"))?;
+        if link.is_dir {
+            anyhow::bail!("cannot write to directory fid {fid}");
+        }
+        let path = link.path.clone().unwrap_or_default();
+        drop(fids);
+
+        let mut files = self.files.lock();
+        let entry = files
+            .get_mut(&path)
+            .ok_or_else(|| anyhow::anyhow!("fid {fid} has no backing file"))?;
+        let off = offset as usize;
+        if off + data.len() > entry.bytes.len() {
+            entry.bytes.resize(off + data.len(), 0);
+        }
+        entry.bytes[off..off + data.len()].copy_from_slice(data);
+        Ok(data.len() as u32)
+    }
+
+    async fn stat(&self, fid: u32) -> anyhow::Result<StatResult> {
+        let fids = self.fids.lock();
+        let link = fids
+            .get(&fid)
+            .ok_or_else(|| anyhow::anyhow!("unknown fid {fid}"))?;
+        let (size, mode) = if link.is_dir {
+            (0, 0o040755)
+        } else {
+            let path = link.path.clone().unwrap_or_default();
+            let files = self.files.lock();
+            let len = files.get(&path).map(|e| e.bytes.len() as u64).unwrap_or(0);
+            (len, 0o100644)
+        };
+        Ok(StatResult { qid: link.qid.clone(), mode, size, mtime_sec: 0 })
+    }
+
+    async fn readdir(&self, fid: u32, offset: u64, count: u32) -> anyhow::Result<Vec<u8>> {
+        // Same encoding as read() for directories.
+        self.read(fid, offset, count).await
+    }
+
+    async fn clunk(&self, fid: u32) -> anyhow::Result<()> {
+        self.fids.lock().remove(&fid);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn walk_read_roundtrip() {
+        let b = MemoryBackend::default();
+        b.add_file("/greeting", b"hi");
+        let w = b.walk(0, 1, &["greeting".into()]).await.unwrap();
+        assert_eq!(w.qids.len(), 1);
+        let o = b.open(1, 0).await.unwrap();
+        assert_eq!(o.iounit, 8 * 1024);
+        let d = b.read(1, 0, 16).await.unwrap();
+        assert_eq!(&d, b"hi");
+        b.clunk(1).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn write_extends_file() {
+        let b = MemoryBackend::default();
+        b.add_file("/log", b"");
+        b.walk(0, 1, &["log".into()]).await.unwrap();
+        b.write(1, 0, b"abc").await.unwrap();
+        let d = b.read(1, 0, 8).await.unwrap();
+        assert_eq!(&d, b"abc");
+    }
+}

--- a/crates/hyprstream-9p/src/msg.rs
+++ b/crates/hyprstream-9p/src/msg.rs
@@ -209,7 +209,230 @@ pub fn treaddir(tag: u16, fid: u32, offset: u64, count: u32) -> Vec<u8> {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// R-messages (server → client) — parsed responses
+// T-messages (client → server) — parsed requests  [server-side codec]
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Parsed T-message from a client.
+///
+/// Mirrors [`Response`] for the server side. Every variant carries the `tag`
+/// out-of-band via [`parse_request`]'s return so callers don't have to thread
+/// it through each arm.
+#[derive(Debug)]
+pub enum Request {
+    Version { msize: u32, version: String },
+    Attach { fid: u32, afid: u32, uname: String, aname: String },
+    Flush { oldtag: u16 },
+    Walk { fid: u32, newfid: u32, wnames: Vec<String> },
+    Lopen { fid: u32, flags: u32 },
+    Read { fid: u32, offset: u64, count: u32 },
+    Write { fid: u32, offset: u64, data: Vec<u8> },
+    Clunk { fid: u32 },
+    Getattr { fid: u32, request_mask: u64 },
+    Readdir { fid: u32, offset: u64, count: u32 },
+}
+
+/// Parse a T-message from wire bytes (including length prefix).
+///
+/// Server-side counterpart to [`parse_response`]. Unknown message types bail
+/// with an error; the caller may encode an `Rlerror` instead.
+pub fn parse_request(buf: &[u8]) -> anyhow::Result<(u16, Request)> {
+    if buf.len() < 7 {
+        anyhow::bail!("9P request too short: {} bytes", buf.len());
+    }
+
+    let mut r = Cursor::new(buf);
+    let _size = read_u32(&mut r)?;
+    let msg_type = read_u8(&mut r)?;
+    let tag = read_u16(&mut r)?;
+
+    let request = match msg_type {
+        TVERSION => {
+            let msize = read_u32(&mut r)?;
+            let version = read_string(&mut r)?;
+            Request::Version { msize, version }
+        }
+        TATTACH => {
+            let fid = read_u32(&mut r)?;
+            let afid = read_u32(&mut r)?;
+            let uname = read_string(&mut r)?;
+            let aname = read_string(&mut r)?;
+            // 9P2000.L: n_uname (ignored)
+            let _n_uname = read_u32(&mut r)?;
+            Request::Attach { fid, afid, uname, aname }
+        }
+        TFLUSH => {
+            let oldtag = read_u16(&mut r)?;
+            Request::Flush { oldtag }
+        }
+        TWALK => {
+            let fid = read_u32(&mut r)?;
+            let newfid = read_u32(&mut r)?;
+            let nwname = read_u16(&mut r)?;
+            let mut wnames = Vec::with_capacity(nwname as usize);
+            for _ in 0..nwname {
+                wnames.push(read_string(&mut r)?);
+            }
+            Request::Walk { fid, newfid, wnames }
+        }
+        TLOPEN => {
+            let fid = read_u32(&mut r)?;
+            let flags = read_u32(&mut r)?;
+            Request::Lopen { fid, flags }
+        }
+        TREAD => {
+            let fid = read_u32(&mut r)?;
+            let offset = read_u64(&mut r)?;
+            let count = read_u32(&mut r)?;
+            Request::Read { fid, offset, count }
+        }
+        TWRITE => {
+            let fid = read_u32(&mut r)?;
+            let offset = read_u64(&mut r)?;
+            let data = read_data(&mut r)?;
+            Request::Write { fid, offset, data }
+        }
+        TCLUNK => {
+            let fid = read_u32(&mut r)?;
+            Request::Clunk { fid }
+        }
+        TGETATTR => {
+            let fid = read_u32(&mut r)?;
+            let request_mask = read_u64(&mut r)?;
+            Request::Getattr { fid, request_mask }
+        }
+        TREADDIR => {
+            let fid = read_u32(&mut r)?;
+            let offset = read_u64(&mut r)?;
+            let count = read_u32(&mut r)?;
+            Request::Readdir { fid, offset, count }
+        }
+        _ => anyhow::bail!("unknown 9P request type: {msg_type}"),
+    };
+
+    Ok((tag, request))
+}
+
+/// 9P2000.L Tflush — not exercised by the client codec but defined for symmetry.
+pub const TFLUSH: u8 = 108;
+pub const RFLUSH: u8 = 109;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// R-messages (server → client) — serialized responses  [server-side codec]
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Serialize an R-message (including length prefix) from a [`Response`].
+///
+/// This is the server-side write path; the client-side reader uses
+/// [`parse_response`]. `tag` is threaded in explicitly since it is a property
+/// of the request being answered, not of the response payload.
+pub fn encode_response(tag: u16, response: &Response) -> Vec<u8> {
+    match response {
+        Response::Error { ecode } => rlerror(tag, *ecode),
+        Response::Version { msize, version } => rversion(tag, *msize, version),
+        Response::Attach { qid } => rattach(tag, qid),
+        Response::Walk { qids } => rwalk(tag, qids),
+        Response::Lopen { qid, iounit } => rlopen(tag, qid, *iounit),
+        Response::Read { data } => rread(tag, data),
+        Response::Write { count } => rwrite(tag, *count),
+        Response::Clunk => rclunk(tag),
+        Response::Getattr { qid, mode, size, mtime_sec } => {
+            rgetattr(tag, qid, *mode, *size, *mtime_sec)
+        }
+        Response::Readdir { data } => rread(tag, data), // same wire shape as Rread
+    }
+}
+
+fn encode_rmessage(tag: u16, msg_type: u8, body: &[u8]) -> Vec<u8> {
+    // identical framing to T-messages
+    encode_tmessage(tag, msg_type, body)
+}
+
+pub fn rlerror(tag: u16, ecode: u32) -> Vec<u8> {
+    encode_rmessage(tag, RLERROR, &ecode.to_le_bytes())
+}
+
+pub fn rversion(tag: u16, msize: u32, version: &str) -> Vec<u8> {
+    let mut body = Vec::new();
+    body.extend_from_slice(&msize.to_le_bytes());
+    write_string(&mut body, version);
+    encode_rmessage(tag, RVERSION, &body)
+}
+
+pub fn rattach(tag: u16, qid: &Qid) -> Vec<u8> {
+    let mut body = Vec::new();
+    qid.write_to(&mut body);
+    encode_rmessage(tag, RATTACH, &body)
+}
+
+pub fn rwalk(tag: u16, qids: &[Qid]) -> Vec<u8> {
+    let mut body = Vec::new();
+    body.extend_from_slice(&(qids.len() as u16).to_le_bytes());
+    for q in qids {
+        q.write_to(&mut body);
+    }
+    encode_rmessage(tag, RWALK, &body)
+}
+
+pub fn rlopen(tag: u16, qid: &Qid, iounit: u32) -> Vec<u8> {
+    let mut body = Vec::new();
+    qid.write_to(&mut body);
+    body.extend_from_slice(&iounit.to_le_bytes());
+    encode_rmessage(tag, RLOPEN, &body)
+}
+
+pub fn rread(tag: u16, data: &[u8]) -> Vec<u8> {
+    let mut body = Vec::new();
+    body.extend_from_slice(&(data.len() as u32).to_le_bytes());
+    body.extend_from_slice(data);
+    encode_rmessage(tag, RREAD, &body)
+}
+
+pub fn rwrite(tag: u16, count: u32) -> Vec<u8> {
+    encode_rmessage(tag, RWRITE, &count.to_le_bytes())
+}
+
+pub fn rclunk(tag: u16) -> Vec<u8> {
+    encode_rmessage(tag, RCLUNK, &[])
+}
+
+pub fn rflush(tag: u16) -> Vec<u8> {
+    encode_rmessage(tag, RFLUSH, &[])
+}
+
+/// Encode an Rgetattr. Only the fields carried by [`Response::Getattr`] are
+/// populated; the rest are zero (matches the subset the client decoder reads).
+#[allow(clippy::too_many_lines)]
+pub fn rgetattr(tag: u16, qid: &Qid, mode: u32, size: u64, mtime_sec: u64) -> Vec<u8> {
+    // valid mask: P9_GETATTR_BASIC = 0x7ff (mode, nlink, uid, gid, rdev, size,
+    // atime, mtime, ctime). We advertise all-basic so Linux clients decode the
+    // fields we do fill.
+    let valid: u64 = 0x7ff;
+    let mut body = Vec::with_capacity(153);
+    body.extend_from_slice(&valid.to_le_bytes());
+    qid.write_to(&mut body);
+    body.extend_from_slice(&mode.to_le_bytes());
+    body.extend_from_slice(&0u32.to_le_bytes()); // uid
+    body.extend_from_slice(&0u32.to_le_bytes()); // gid
+    body.extend_from_slice(&1u64.to_le_bytes()); // nlink
+    body.extend_from_slice(&0u64.to_le_bytes()); // rdev
+    body.extend_from_slice(&size.to_le_bytes());
+    body.extend_from_slice(&4096u64.to_le_bytes()); // blksize
+    body.extend_from_slice(&0u64.to_le_bytes()); // blocks
+    body.extend_from_slice(&mtime_sec.to_le_bytes()); // atime_sec
+    body.extend_from_slice(&0u64.to_le_bytes()); // atime_nsec
+    body.extend_from_slice(&mtime_sec.to_le_bytes()); // mtime_sec
+    body.extend_from_slice(&0u64.to_le_bytes()); // mtime_nsec
+    body.extend_from_slice(&mtime_sec.to_le_bytes()); // ctime_sec
+    body.extend_from_slice(&0u64.to_le_bytes()); // ctime_nsec
+    body.extend_from_slice(&0u64.to_le_bytes()); // btime_sec
+    body.extend_from_slice(&0u64.to_le_bytes()); // btime_nsec
+    body.extend_from_slice(&0u64.to_le_bytes()); // gen
+    body.extend_from_slice(&0u64.to_le_bytes()); // data_version
+    encode_rmessage(tag, RGETATTR, &body)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// R-messages (server → client) — parsed responses  [client-side codec]
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Parsed R-message from server.

--- a/crates/hyprstream-9p/src/translator.rs
+++ b/crates/hyprstream-9p/src/translator.rs
@@ -1,0 +1,373 @@
+//! Server-side 9P2000.L translator.
+//!
+//! Accepts 9P connections (TCP for now; virtio-9P later) and translates each
+//! T-message into a [`Backend`] call. The backend is the capnp-RPC seam:
+//! the `hyprstream` binary crate wraps `ModelClient` to turn each call into a
+//! `nine.capnp` envelope against the model service's `fs` scope, mirroring
+//! `RemoteModelMount` (which goes the other way: VFS → RPC).
+//!
+//! ## Server-side fid table
+//!
+//! The translator owns a [`FidTable`] mapping 9P fid → backend fid + metadata
+//! (qtype, opened flag). This is the inverse of `RemoteModelMount`'s
+//! client-side fid table.
+//!
+//! ## Transport
+//!
+//! [`Translator::serve`] runs a TCP accept loop. Each connection is served on
+//! its own tokio task via [`serve_connection`]. virtio-9P will plug in here
+//! later with a different transport that shares the same per-connection
+//! `handle_message` core.
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use dashmap::DashMap;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tracing::{debug, error, info, warn};
+
+use crate::backend::Backend;
+use crate::msg::{
+    self, encode_response, parse_request, rflush, Request, Response,
+};
+
+/// Negotiated maximum message size. Generous: Kata guest mounts may issue
+/// large read-ahead. The backend's iounit still bounds individual reads.
+const MSG_SIZE: u32 = 8 * 1024;
+
+/// Per-fid state held by the translator (server side).
+#[derive(Clone, Debug)]
+struct FidState {
+    /// Qtype of the walked file (QTDIR=0x80 / QTFILE=0x00).
+    qtype: u8,
+    /// Whether open() has succeeded on this fid.
+    opened: bool,
+}
+
+/// Server-side fid table: 9P fid → state.
+///
+/// `DashMap` so the translator can be shared across per-connection tasks.
+#[derive(Default)]
+pub struct FidTable {
+    fids: DashMap<u32, FidState>,
+}
+
+impl FidTable {
+    /// Insert state for a fid (from walk/attach).
+    pub fn insert(&self, fid: u32, qtype: u8) {
+        self.fids.insert(fid, FidState { qtype, opened: false });
+    }
+
+    /// Mark a fid as opened.
+    pub fn set_opened(&self, fid: u32) {
+        if let Some(mut s) = self.fids.get_mut(&fid) {
+            s.opened = true;
+        }
+    }
+
+    /// Look up a fid's qtype.
+    pub fn qtype(&self, fid: u32) -> Option<u8> {
+        self.fids.get(&fid).map(|s| s.qtype)
+    }
+
+    /// Remove a fid (clunk).
+    pub fn remove(&self, fid: u32) {
+        self.fids.remove(&fid);
+    }
+}
+
+/// The translator: a backend plus a shared fid table.
+///
+/// Cloning is cheap (Arc internals); one translator serves many connections.
+pub struct Translator {
+    backend: Arc<dyn Backend>,
+    fids: Arc<FidTable>,
+}
+
+impl Translator {
+    /// Build a translator over the given backend. The fid table starts empty.
+    pub fn new(backend: Arc<dyn Backend>) -> Self {
+        Self { backend, fids: Arc::new(FidTable::default()) }
+    }
+
+    /// Run a TCP accept loop until the listener errors or is closed.
+    ///
+    /// Each connection runs on its own task. Errors on one connection do not
+    /// affect siblings.
+    pub async fn serve(self, listener: TcpListener) -> Result<()> {
+        let this = Arc::new(self);
+        info!(addr = ?listener.local_addr(), "9P translator: listening");
+        loop {
+            let (stream, peer) = match listener.accept().await {
+                Ok(v) => v,
+                Err(e) => {
+                    error!(error = %e, "9P translator: accept failed, shutting down");
+                    return Err(e).context("9P accept loop terminated");
+                }
+            };
+            let this = Arc::clone(&this);
+            tokio::spawn(async move {
+                debug!(%peer, "9P connection accepted");
+                if let Err(e) = this.serve_connection(stream).await {
+                    warn!(%peer, error = %e, "9P connection ended with error");
+                }
+            });
+        }
+    }
+
+    /// Serve a single connection to completion (until EOF, parse error, or
+    /// the peer resets).
+    pub async fn serve_connection(self: &Arc<Self>, stream: TcpStream) -> Result<()> {
+        let (mut rx, mut tx) = stream.into_split();
+        // Reusable growable read buffer; capped per-message by msize.
+        let mut len_buf = [0u8; 4];
+
+        loop {
+            // Read the 4-byte length prefix.
+            let n = rx.read(&mut len_buf).await?;
+            if n == 0 {
+                debug!("9P peer closed connection");
+                return Ok(());
+            }
+            if n < 4 {
+                rx.read_exact(&mut len_buf[n..]).await?;
+            }
+            let total = u32::from_le_bytes(len_buf) as usize;
+            if total < 7 || total > MSG_SIZE as usize {
+                anyhow::bail!("invalid 9P message length: {total}");
+            }
+
+            // Read the rest of the message.
+            let mut buf = vec![0u8; total];
+            buf[..4].copy_from_slice(&len_buf);
+            rx.read_exact(&mut buf[4..]).await?;
+
+            // Tflush is handled inline: requests are processed serially per
+            // connection, so there is never an outstanding request to cancel —
+            // acknowledge with Rflush and continue. (Response has no Flush
+            // variant because flush is a no-op at this layer.)
+            let msg_type = buf.get(4).copied().unwrap_or(0);
+            if msg_type == msg::TFLUSH {
+                let tag = tag_or_notag(&buf);
+                tx.write_all(&rflush(tag)).await?;
+                continue;
+            }
+
+            let (tag, response) = match self.handle_message(&buf).await {
+                Ok(r) => r,
+                Err(e) => {
+                    // Map a handler error to Rlerror (errno-style code).
+                    // We use a synthetic code; real errno mapping is backend-
+                    // specific and deferred to a later hardening pass.
+                    let err_tag = tag_or_notag(&buf);
+                    warn!(error = %e, tag = err_tag, "9P handler error");
+                    (err_tag, Response::Error { ecode: libc_eio() })
+                }
+            };
+
+            let out = encode_response(tag, &response);
+            tx.write_all(&out).await?;
+        }
+    }
+
+    /// Decode one T-message, dispatch it to the backend, and produce the
+    /// R-message. Returns `(tag, response)`.
+    async fn handle_message(&self, buf: &[u8]) -> Result<(u16, Response)> {
+        let (tag, req) = parse_request(buf).context("decode 9P T-message")?;
+        let resp = match req {
+            Request::Version { msize, version } => self.handle_version(msize, version),
+            Request::Attach { fid, .. } => self.handle_attach(fid).await?,
+            // Flush is intercepted in serve_connection before reaching here;
+            // this arm is unreachable but kept exhaustive.
+            Request::Flush { .. } => Response::Clunk,
+            Request::Walk { fid, newfid, wnames } => {
+                self.handle_walk(fid, newfid, wnames).await?
+            }
+            Request::Lopen { fid, flags } => self.handle_lopen(fid, flags).await?,
+            Request::Read { fid, offset, count } => {
+                self.handle_read(fid, offset, count).await?
+            }
+            Request::Write { fid, offset, data } => {
+                self.handle_write(fid, offset, &data).await?
+            }
+            Request::Clunk { fid } => self.handle_clunk(fid).await,
+            Request::Getattr { fid, .. } => self.handle_getattr(fid).await?,
+            Request::Readdir { fid, offset, count } => {
+                self.handle_readdir(fid, offset, count).await?
+            }
+        };
+        Ok((tag, resp))
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Per-message handlers
+    // ────────────────────────────────────────────────────────────────────
+
+    fn handle_version(&self, requested: u32, version: String) -> Response {
+        if version != "9P2000.L" && !version.starts_with("9P2000") {
+            return Response::Error { ecode: libc_einval() };
+        }
+        let msize = requested.clamp(256, MSG_SIZE);
+        Response::Version { msize, version: "9P2000.L".into() }
+    }
+
+    async fn handle_attach(&self, fid: u32) -> Result<Response> {
+        // Attach establishes the root fid. Walk the empty path to materialize
+        // a root qid from the backend, then record it.
+        let walk = self.backend.walk(fid, fid, &[]).await?;
+        let qtype = walk.qids.last().map(|q| q.qtype).unwrap_or(0);
+        self.fids.insert(fid, qtype);
+        let qid = walk.qids.into_iter().next().unwrap_or_default();
+        Ok(Response::Attach { qid })
+    }
+
+    async fn handle_walk(
+        &self,
+        fid: u32,
+        newfid: u32,
+        wnames: Vec<String>,
+    ) -> Result<Response> {
+        // Mirror of RemoteModelMount::walk: call backend.walk with the source
+        // fid, the new fid, and the path components.
+        let result = self.backend.walk(fid, newfid, &wnames).await?;
+        if let Some(q) = result.qids.last() {
+            self.fids.insert(newfid, q.qtype);
+        }
+        Ok(Response::Walk { qids: result.qids })
+    }
+
+    async fn handle_lopen(&self, fid: u32, flags: u32) -> Result<Response> {
+        let open = self.backend.open(fid, flags).await?;
+        self.fids.set_opened(fid);
+        Ok(Response::Lopen { qid: open.qid, iounit: open.iounit })
+    }
+
+    async fn handle_read(&self, fid: u32, offset: u64, count: u32) -> Result<Response> {
+        let data = self.backend.read(fid, offset, count).await?;
+        Ok(Response::Read { data })
+    }
+
+    async fn handle_write(&self, fid: u32, offset: u64, data: &[u8]) -> Result<Response> {
+        let count = self.backend.write(fid, offset, data).await?;
+        Ok(Response::Write { count })
+    }
+
+    async fn handle_clunk(&self, fid: u32) -> Response {
+        // Best-effort clunk on the backend; the local fid is dropped either way.
+        if let Err(e) = self.backend.clunk(fid).await {
+            debug!(fid, error = %e, "backend clunk failed (ignored)");
+        }
+        self.fids.remove(fid);
+        Response::Clunk
+    }
+
+    async fn handle_getattr(&self, fid: u32) -> Result<Response> {
+        let st = self.backend.stat(fid).await?;
+        Ok(Response::Getattr { qid: st.qid, mode: st.mode, size: st.size, mtime_sec: st.mtime_sec })
+    }
+
+    async fn handle_readdir(&self, fid: u32, offset: u64, count: u32) -> Result<Response> {
+        let data = self.backend.readdir(fid, offset, count).await?;
+        Ok(Response::Readdir { data })
+    }
+}
+
+/// Extract the tag from a raw message for error-path Rlerror encoding.
+fn tag_or_notag(buf: &[u8]) -> u16 {
+    if buf.len() >= 6 {
+        u16::from_le_bytes([buf[5], buf[6]])
+    } else {
+        0xFFFF // NOTAG
+    }
+}
+
+// errno-style codes the translator emits on its own errors. We hardcode the
+// integer values rather than depend on libc so the crate stays wasm-friendly.
+const fn libc_eio() -> u32 {
+    5 // EIO
+}
+const fn libc_einval() -> u32 {
+    22 // EINVAL
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::MemoryBackend;
+    use crate::msg::Qid;
+
+    fn sample_qid(qtype: u8, path: u64) -> Qid {
+        Qid { qtype, version: 1, path }
+    }
+
+    #[tokio::test]
+    async fn version_round_trips() {
+        let t = Translator::new(Arc::new(MemoryBackend::default()));
+        // Build a Tversion by hand via the codec and decode the response.
+        let req = msg::tversion(1, 4096, "9P2000.L");
+        let (tag, resp) = t.handle_message(&req).await.unwrap();
+        assert_eq!(tag, 1);
+        match resp {
+            Response::Version { msize, version } => {
+                assert_eq!(version, "9P2000.L");
+                assert!(msize <= 4096);
+            }
+            other => panic!("expected Version, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn attach_then_walk_open_read_clunk() {
+        let backend = MemoryBackend::default();
+        backend.add_file("/hello.txt", b"hello world");
+        let t = Translator::new(Arc::new(backend));
+
+        // Attach: fid 0 becomes the root.
+        let req = msg::tattach(1, 0, u32::MAX, "user", "/");
+        let (_, resp) = t.handle_message(&req).await.unwrap();
+        assert!(matches!(resp, Response::Attach { .. }));
+
+        // Walk from root (fid 0) to a new fid (1) for the file.
+        let req = msg::twalk(2, 0, 1, &["hello.txt"]);
+        let (_, resp) = t.handle_message(&req).await.unwrap();
+        match resp {
+            Response::Walk { qids } => assert_eq!(qids.len(), 1),
+            other => panic!("expected Walk, got {other:?}"),
+        }
+
+        // Open fid 1 for reading.
+        let req = msg::tlopen(3, 1, 0); // OREAD
+        let (_, resp) = t.handle_message(&req).await.unwrap();
+        assert!(matches!(resp, Response::Lopen { .. }));
+
+        // Read.
+        let req = msg::tread(4, 1, 0, 64);
+        let (_, resp) = t.handle_message(&req).await.unwrap();
+        match resp {
+            Response::Read { data } => assert_eq!(&data, b"hello world"),
+            other => panic!("expected Read, got {other:?}"),
+        }
+
+        // Clunk fid 1.
+        let req = msg::tclunk(5, 1);
+        let (_, resp) = t.handle_message(&req).await.unwrap();
+        assert!(matches!(resp, Response::Clunk));
+    }
+
+    #[tokio::test]
+    async fn fid_table_tracks_open_and_clunk() {
+        let table = FidTable::default();
+        table.insert(7, 0x80);
+        assert_eq!(table.qtype(7), Some(0x80));
+        table.set_opened(7);
+        table.remove(7);
+        assert_eq!(table.qtype(7), None);
+    }
+
+    #[test]
+    fn qid_helpers() {
+        let q = sample_qid(0x80, 42);
+        assert!(q.is_dir());
+    }
+}

--- a/crates/hyprstream-9p/tests/tcp_translator.rs
+++ b/crates/hyprstream-9p/tests/tcp_translator.rs
@@ -1,0 +1,133 @@
+//! End-to-end integration test: the translator serving a real TCP connection.
+//!
+//! Spins up the translator on an ephemeral loopback port with an in-memory
+//! backend, then drives it from a raw `TcpStream` using the 9P codec directly
+//! (version → attach → walk → lopen → read → clunk). This proves the accept
+//! loop, length-prefix framing, fid table, and dispatch all work together.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use hyprstream_9p::memory::MemoryBackend;
+use hyprstream_9p::msg::{self, Response};
+use hyprstream_9p::Translator;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+/// Read one complete 9P message (length-prefixed) from `stream`.
+async fn recv_message(stream: &mut TcpStream) -> Vec<u8> {
+    let mut len = [0u8; 4];
+    stream.read_exact(&mut len).await.unwrap();
+    let total = u32::from_le_bytes(len) as usize;
+    let mut buf = vec![0u8; total];
+    buf[..4].copy_from_slice(&len);
+    stream.read_exact(&mut buf[4..]).await.unwrap();
+    buf
+}
+
+async fn rpc(stream: &mut TcpStream, req: Vec<u8>) -> Response {
+    stream.write_all(&req).await.unwrap();
+    let resp = recv_message(stream).await;
+    let (_, parsed) = msg::parse_response(&resp).unwrap();
+    parsed
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tcp_full_session() {
+    let backend = MemoryBackend::default();
+    backend.add_file("/greeting", b"hello from kata-translator");
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let translator = Translator::new(Arc::new(backend));
+    // Spawn the accept loop; it returns on listener close, which we never
+    // trigger, so unwrap it onto a background task.
+    let server = tokio::spawn(async move {
+        let _ = translator.serve(listener).await;
+    });
+
+    // Give the listener a beat to start accepting.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let mut client = TcpStream::connect(addr).await.unwrap();
+
+    // Version negotiation.
+    match rpc(&mut client, msg::tversion(1, 4096, "9P2000.L")).await {
+        Response::Version { version, .. } => assert_eq!(version, "9P2000.L"),
+        other => panic!("expected Rversion, got {other:?}"),
+    }
+
+    // Attach: fid 0 = root.
+    match rpc(&mut client, msg::tattach(2, 0, u32::MAX, "user", "/")).await {
+        Response::Attach { qid } => assert!(qid.is_dir(), "root qid should be a dir"),
+        other => panic!("expected Rattach, got {other:?}"),
+    }
+
+    // Walk root → fid 1 (the file).
+    match rpc(&mut client, msg::twalk(3, 0, 1, &["greeting"])).await {
+        Response::Walk { qids } => assert_eq!(qids.len(), 1),
+        other => panic!("expected Rwalk, got {other:?}"),
+    }
+
+    // Open fid 1.
+    match rpc(&mut client, msg::tlopen(4, 1, 0)).await {
+        Response::Lopen { iounit, .. } => assert!(iounit > 0),
+        other => panic!("expected Rlopen, got {other:?}"),
+    }
+
+    // Read.
+    match rpc(&mut client, msg::tread(5, 1, 0, 256)).await {
+        Response::Read { data } => {
+            assert_eq!(&data, b"hello from kata-translator");
+        }
+        other => panic!("expected Rread, got {other:?}"),
+    }
+
+    // Stat (getattr).
+    match rpc(&mut client, msg::tgetattr(6, 1, 0x7ff)).await {
+        Response::Getattr { size, .. } => assert_eq!(size, b"hello from kata-translator".len() as u64),
+        other => panic!("expected Rgetattr, got {other:?}"),
+    }
+
+    // Clunk.
+    match rpc(&mut client, msg::tclunk(7, 1)).await {
+        Response::Clunk => {}
+        other => panic!("expected Rclunk, got {other:?}"),
+    }
+
+    server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tcp_write_then_read() {
+    let backend = MemoryBackend::default();
+    backend.add_file("/pipe", b"");
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let translator = Translator::new(Arc::new(backend));
+    let server = tokio::spawn(async move {
+        let _ = translator.serve(listener).await;
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let mut client = TcpStream::connect(addr).await.unwrap();
+    rpc(&mut client, msg::tversion(1, 4096, "9P2000.L")).await;
+    rpc(&mut client, msg::tattach(2, 0, u32::MAX, "user", "/")).await;
+    rpc(&mut client, msg::twalk(3, 0, 1, &["pipe"])).await;
+    rpc(&mut client, msg::tlopen(4, 1, 1 /* OWRITE */)).await;
+
+    // Write, then clunk+reopen to read back.
+    match rpc(&mut client, msg::twrite(5, 1, 0, b"kata-9p-writes-work")).await {
+        Response::Write { count } => assert_eq!(count as usize, b"kata-9p-writes-work".len()),
+        other => panic!("expected Rwrite, got {other:?}"),
+    }
+    rpc(&mut client, msg::tclunk(6, 1)).await;
+    rpc(&mut client, msg::twalk(7, 0, 2, &["pipe"])).await;
+    rpc(&mut client, msg::tlopen(8, 2, 0 /* OREAD */)).await;
+    match rpc(&mut client, msg::tread(9, 2, 0, 256)).await {
+        Response::Read { data } => assert_eq!(&data, b"kata-9p-writes-work"),
+        other => panic!("expected Rread after write, got {other:?}"),
+    }
+
+    server.abort();
+}

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -58,6 +58,7 @@ hyprstream-flight = { path = "../hyprstream-flight" }  # Flight SQL server and c
 hyprstream-metrics = { path = "../hyprstream-metrics" }  # Metrics storage (for RegistryClient trait)
 hyprstream-workers = { path = "../hyprstream-workers" }  # Worker runtime (Kata containers)
 hyprstream-vfs = { path = "../hyprstream-vfs" }  # VFS namespace (Mount trait)
+hyprstream-9p = { path = "../hyprstream-9p" }  # 9P codec + Kata translator (Backend, Translator)
 hyprstream-tcl = { path = "../hyprstream-tcl" }  # Tcl shell (TclMount, TclCommand)
 inventory.workspace = true  # Service factory registration
 gittorrent = { workspace = true, optional = true }  # P2P transport

--- a/crates/hyprstream/src/services/kata_9p_backend.rs
+++ b/crates/hyprstream/src/services/kata_9p_backend.rs
@@ -1,0 +1,221 @@
+//! `ModelBackend` — the capnp-RPC [`Backend`] for the Kata 9P translator.
+//!
+//! This is the production counterpart to the in-memory test backend. It turns
+//! each 9P filesystem operation into a capnp RPC against the model service's
+//! `fs` scope (`nine.capnp` envelope), via the generated `ModelClient`. The
+//! flow is the mirror of [`RemoteModelMount`], which goes VFS → RPC:
+//!
+//! ```text
+//!   Kata guest (virtio-9P) ──► Translator ──► ModelBackend ──► ModelClient.fs()
+//!        9P2000.L wire            fid table      capnp RPC (nine.capnp)
+//! ```
+//!
+//! The model service resolves the synthetic `/srv/model/<ref>/...` tree from
+//! its `FsHandler`/`SyntheticTree`, exactly as it does for the in-process VFS.
+//!
+//! ## Fid numbering
+//!
+//! The translator allocates 9P fids on its side; we forward them unchanged as
+//! the model service's remote fids (same one-to-one scheme `RemoteModelMount`
+//! uses). The first walk component is the model reference; the rest is the
+//! path within the model's synthetic tree.
+
+use std::sync::atomic::AtomicU32;
+
+use async_trait::async_trait;
+use dashmap::DashMap;
+use hyprstream_9p::backend::{Backend, OpenResult, StatResult, WalkResult};
+use hyprstream_9p::msg::Qid;
+
+use crate::services::generated::model_client::{ModelClient, ModelFsClient};
+use crate::services::generated::model_client::{
+    NpClunk, NpOpen, NpRead, NpStatReq, NpWalk, NpWrite, ROpen, RStat, RWalk,
+};
+
+/// Per-fid state cached on the backend side after a walk.
+#[derive(Clone, Debug)]
+struct ModelFidState {
+    /// Model reference this fid belongs to (e.g. "qwen3:main").
+    model_ref: String,
+}
+
+/// `Backend` impl that proxies 9P operations to the model service.
+///
+/// Holds a single-threaded tokio runtime to drive the async client, mirroring
+/// `RemoteModelMount`. If the model service is unreachable, calls return
+/// `anyhow::Error` and the translator surfaces an `Rlerror`.
+pub struct ModelBackend {
+    client: ModelClient,
+    rt: tokio::runtime::Runtime,
+    /// 9P fid → model_ref (resolved on walk).
+    fids: DashMap<u32, ModelFidState>,
+    /// Monotonic counter for locally-synthesized qid path values, used when
+    /// the backend must fabricate a qid (e.g. root attach). Normally the qid
+    /// arrives in the RPC response and this is unused.
+    #[allow(dead_code)]
+    next_path_id: AtomicU32,
+}
+
+impl ModelBackend {
+    /// Wrap a `ModelClient`. The client must already be configured to talk to
+    /// the model service (signing key, server verifying key, subject).
+    #[allow(clippy::expect_used)] // runtime creation is infallible in practice
+    pub fn new(client: ModelClient) -> Self {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("failed to create tokio runtime for ModelBackend");
+        Self {
+            client,
+            rt,
+            fids: DashMap::new(),
+            next_path_id: AtomicU32::new(1),
+        }
+    }
+
+    /// Build the scoped fs client for a model reference.
+    fn fs_client(&self, model_ref: &str) -> ModelFsClient {
+        self.client.fs(model_ref)
+    }
+}
+
+fn qid_from_rpc(q: &crate::services::generated::model_client::Qid) -> Qid {
+    Qid { qtype: q.qtype, version: q.version, path: q.path }
+}
+
+#[async_trait]
+impl Backend for ModelBackend {
+    async fn walk(
+        &self,
+        fid: u32,
+        newfid: u32,
+        components: &[String],
+    ) -> anyhow::Result<WalkResult> {
+        // Resolve model_ref: prefer a previously-walked parent fid, else take
+        // the first walk component as the model_ref.
+        let (model_ref, wnames): (String, Vec<String>) = if components.is_empty() {
+            // Clone / attach — inherit model_ref from the source fid.
+            let mr = self
+                .fids
+                .get(&fid)
+                .map(|s| s.model_ref.clone())
+                .ok_or_else(|| anyhow::anyhow!("walk: source fid {fid} has no model_ref"))?;
+            (mr, Vec::new())
+        } else {
+            let model_ref = components[0].clone();
+            let rest = components[1..].to_vec();
+            (model_ref, rest)
+        };
+
+        // Forward the walk to the model service's fs scope.
+        let fs = self.fs_client(&model_ref);
+        let req = NpWalk { fid, newfid, wnames };
+        let RWalk { qid } = self.rt.block_on(fs.walk(&req))?;
+        self.fids.insert(newfid, ModelFidState { model_ref });
+
+        Ok(WalkResult { qids: vec![qid_from_rpc(&qid)] })
+    }
+
+    async fn open(&self, fid: u32, flags: u32) -> anyhow::Result<OpenResult> {
+        let state = self
+            .fids
+            .get(&fid)
+            .ok_or_else(|| anyhow::anyhow!("open: fid {fid} not walked"))?
+            .clone();
+        let fs = self.fs_client(&state.model_ref);
+        // 9P2000.L lopen flags are Linux O_* bits; the model service's NpOpen
+        // expects a 9P mode byte (OREAD=0, OWRITE=1, ORDWR=2). Truncate the
+        // translation to the low bits for read/write intent.
+        let mode = lopen_flags_to_mode(flags);
+        let req = NpOpen { fid, mode };
+        let ROpen { qid, iounit } = self.rt.block_on(fs.open(&req))?;
+        Ok(OpenResult { qid: qid_from_rpc(&qid), iounit })
+    }
+
+    async fn read(&self, fid: u32, offset: u64, count: u32) -> anyhow::Result<Vec<u8>> {
+        let state = self
+            .fids
+            .get(&fid)
+            .ok_or_else(|| anyhow::anyhow!("read: fid {fid} not walked"))?
+            .clone();
+        let fs = self.fs_client(&state.model_ref);
+        let req = NpRead { fid, offset, count };
+        let result = self.rt.block_on(fs.read(&req))?;
+        Ok(result.data)
+    }
+
+    async fn write(&self, fid: u32, offset: u64, data: &[u8]) -> anyhow::Result<u32> {
+        let state = self
+            .fids
+            .get(&fid)
+            .ok_or_else(|| anyhow::anyhow!("write: fid {fid} not walked"))?
+            .clone();
+        let fs = self.fs_client(&state.model_ref);
+        let req = NpWrite { fid, offset, data: data.to_vec() };
+        let result = self.rt.block_on(fs.write(&req))?;
+        Ok(result.count)
+    }
+
+    async fn stat(&self, fid: u32) -> anyhow::Result<StatResult> {
+        let state = self
+            .fids
+            .get(&fid)
+            .ok_or_else(|| anyhow::anyhow!("stat: fid {fid} not walked"))?
+            .clone();
+        let fs = self.fs_client(&state.model_ref);
+        let req = NpStatReq { fid };
+        let RStat { stat } = self.rt.block_on(fs.stat(&req))?;
+        Ok(StatResult {
+            qid: qid_from_rpc(&stat.qid),
+            mode: stat.mode,
+            size: stat.length,
+            mtime_sec: stat.mtime as u64,
+        })
+    }
+
+    async fn readdir(&self, fid: u32, offset: u64, count: u32) -> anyhow::Result<Vec<u8>> {
+        // The model service encodes directory listings in read() responses
+        // (see RemoteModelMount::readdir): stat-encoded entries served via
+        // NpRead on a directory fid. Reuse that path.
+        self.read(fid, offset, count).await
+    }
+
+    async fn clunk(&self, fid: u32) -> anyhow::Result<()> {
+        // Best-effort remote clunk; drop local state regardless.
+        if let Some((_, state)) = self.fids.remove(&fid) {
+            let fs = self.fs_client(&state.model_ref);
+            let req = NpClunk { fid };
+            let _ = self.rt.block_on(fs.clunk(&req));
+        }
+        Ok(())
+    }
+}
+
+/// Map 9P2000.L Tlopen flags (Linux O_* bits) to a 9P open mode byte.
+///
+/// Only read/write intent is preserved; flags like O_TRUNC / O_APPEND are
+/// advisory here since the model service's synthetic tree is mostly read-only.
+fn lopen_flags_to_mode(flags: u32) -> u8 {
+    const O_WRONLY: u32 = 0o1;
+    const O_RDWR: u32 = 0o2;
+    let acc = flags & 0o3;
+    match acc {
+        O_WRONLY => 1, // OWRITE
+        O_RDWR => 2,   // ORDWR
+        _ => 0,        // OREAD
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lopen_flags_mapping() {
+        assert_eq!(lopen_flags_to_mode(0), 0); // OREAD
+        assert_eq!(lopen_flags_to_mode(0o1), 1); // OWRITE
+        assert_eq!(lopen_flags_to_mode(0o2), 2); // ORDWR
+        assert_eq!(lopen_flags_to_mode(0o100), 0); // O_CREAT + OREAD → OREAD
+        assert_eq!(lopen_flags_to_mode(0o101), 1); // O_CREAT + OWRITE → OWRITE
+    }
+}

--- a/crates/hyprstream/src/services/mod.rs
+++ b/crates/hyprstream/src/services/mod.rs
@@ -80,6 +80,7 @@ pub mod policy;
 pub mod registry;
 pub mod fs;
 pub mod remote_mount;
+pub mod kata_9p_backend;
 pub mod rpc_types;
 pub mod typed;
 pub mod worker;


### PR DESCRIPTION
Closes #408. Part of #341 (Worker GA). Depends on #391 (shared 9P↔RPC translation, merged).

Server-side 9P2000.L translator for Kata guest VMs. Kata guest → virtio-9P → 9P server → capnp RPC (nine.capnp envelope) → hyprstream services.

## What landed

**`hyprstream-9p` crate** (standalone, testable, no libtorch):
- `msg.rs` extended: bidirectional codec — server-side T-message parsing (`parse_request` + `Request` enum) + R-message encoding (`encode_response`). Now serves both client AND server.
- `backend.rs` (new): `Backend` trait — the capnp-RPC-shaped seam (`walk`/`open`/`read`/`write`/`stat`/`readdir`/`clunk`).
- `translator.rs` (new): `Translator` with `DashMap` fid table + TCP accept loop. Per-message dispatch covers version/attach/walk/lopen/read/write/getattr/readdir/clunk.
- `memory.rs` (new): `MemoryBackend` for standalone tests.
- `tests/tcp_translator.rs` (new): end-to-end loopback TCP integration tests.

**`hyprstream` crate:**
- `kata_9p_backend.rs` (new): `ModelBackend` wraps `ModelClient`, proxies 9P ops → capnp RPC (`NpWalk`/`NpOpen`/`NpRead`/`NpWrite`/`NpStatReq`/`NpClunk`). Inverse of `RemoteModelMount`: Kata guest → 9P → ModelBackend → nine.capnp → model service.

Green: 8 tests pass (6 unit + 2 TCP integration); pre-commit full-workspace release clippy PASSED.

virtio-9P transport plugs into `serve_connection` later; `handle_message` is transport-agnostic.

Claude-Session: https://claude.ai/code/session_01U3qgsHTDWME66JFGZGS3ZA