### PR TITLE
fix(#405): move top-level weights to device in from_weights (embed/lm_head/norm — llama/qwen3_5/gemma)

### DIFF
--- a/crates/hyprstream/src/runtime/architectures/gemma.rs
+++ b/crates/hyprstream/src/runtime/architectures/gemma.rs
@@ -660,18 +660,21 @@ impl GemmaModel {
         device: &Device,
         dtype: DType,
     ) -> Result<Self> {
-        // Extract embeddings
+        // Extract embeddings.
+        // #405: place top-level weights on `device` here. Without this,
+        // constructing from CPU weights with device=Cuda(0) leaves
+        // embed/lm_head/norm on CPU while layers move to CUDA.
         let embed_tokens = weights
             .get("model.embed_tokens.weight")
             .or_else(|| weights.get("embed_tokens.weight"))
-            .map(tch::Tensor::shallow_clone);
+            .map(|w| w.shallow_clone().to_device(*device));
 
         // Gemma uses weight tying - lm_head shares weights with embed_tokens
         // Keep lm_head as [vocab_size, hidden_size], transpose during use
         let lm_head = weights
             .get("lm_head.weight")
             .or_else(|| weights.get("model.lm_head.weight"))
-            .map(tch::Tensor::shallow_clone);
+            .map(|w| w.shallow_clone().to_device(*device));
 
         if lm_head.is_none() && embed_tokens.is_some() {
             tracing::info!("Gemma model uses weight tying (lm_head = embed_tokens.T)");
@@ -684,7 +687,7 @@ impl GemmaModel {
             .get("model.norm.weight")
             .or_else(|| weights.get("norm.weight"))
             .map(|w| RMSNorm {
-                weight: w.shallow_clone(),
+                weight: w.shallow_clone().to_device(*device),
                 eps: config.rms_norm_eps,
                 add_unit_offset: is_gemma3,
             });

--- a/crates/hyprstream/src/runtime/architectures/llama.rs
+++ b/crates/hyprstream/src/runtime/architectures/llama.rs
@@ -1392,7 +1392,11 @@ impl LlamaModel {
             kv_quant_type
         );
 
-        // Extract key tensors (with padding for models that need it)
+        // Extract key tensors (with padding for models that need it).
+        // #405: place top-level weights on `device` here, mirroring the
+        // `build_layer`→`into_device` move applied to decoder layers. Without
+        // this, constructing from CPU weights with device=Cuda(0) leaves
+        // embed_tokens on CPU while layers move to CUDA — a mixed-device model.
         let embed_tokens = weights
             .get("model.embed_tokens.weight")
             .or_else(|| weights.get("embed_tokens.weight"))
@@ -1403,7 +1407,7 @@ impl LlamaModel {
                 // Pad vocabulary size to multiple of 64 for models that need it
                 let padded_vocab_size = calculate_padded_vocab_size(vocab_size);
 
-                if padded_vocab_size > vocab_size {
+                let placed = if padded_vocab_size > vocab_size {
                     tracing::info!(
                         "Padding embedding vocab size from {} to {} (multiple of 64)",
                         vocab_size, padded_vocab_size
@@ -1420,7 +1424,8 @@ impl LlamaModel {
                     padded
                 } else {
                     w.shallow_clone()
-                }
+                };
+                placed.to_device(*device)
             });
 
         // Update config with padded vocab size if needed
@@ -1473,8 +1478,9 @@ impl LlamaModel {
                     w.shallow_clone()
                 };
 
-                // We need [hidden_size, vocab_size] for matmul
-                padded_w.transpose(0, 1).contiguous()
+                // We need [hidden_size, vocab_size] for matmul.
+                // #405: place on `device` (see embed_tokens note above).
+                padded_w.transpose(0, 1).contiguous().to_device(*device)
             });
 
         // Pre-compute transposed lm_head for tied weights case
@@ -1490,12 +1496,12 @@ impl LlamaModel {
             None
         };
 
-        // Extract final layer norm
+        // Extract final layer norm (#405: place on `device`).
         let norm = weights
             .get("model.norm.weight")
             .or_else(|| weights.get("norm.weight"))
             .map(|w| RMSNorm {
-                weight: w.shallow_clone(),
+                weight: w.shallow_clone().to_device(*device),
                 eps: config.rms_norm_eps,
             });
 

--- a/crates/hyprstream/src/runtime/architectures/qwen3_5.rs
+++ b/crates/hyprstream/src/runtime/architectures/qwen3_5.rs
@@ -1451,10 +1451,16 @@ impl Qwen3_5Model {
         // Remove MTP (multi-token prediction) weights silently
         weights.retain(|k, _| !k.starts_with("mtp."));
 
+        // #405: place top-level weights on `device`, mirroring the
+        // `into_device` move that `stage_from_weights_with_config` applies.
+        // Without this, constructing from CPU weights with device=Cuda(0)
+        // leaves embed/norm/lm_head on CPU — a mixed-device model.
         let embed = weights.remove("model.embed_tokens.weight")
-            .ok_or_else(|| anyhow!("Missing model.embed_tokens.weight"))?;
+            .ok_or_else(|| anyhow!("Missing model.embed_tokens.weight"))?
+            .to_device(*device);
         let norm_w = weights.remove("model.norm.weight")
-            .ok_or_else(|| anyhow!("Missing model.norm.weight"))?;
+            .ok_or_else(|| anyhow!("Missing model.norm.weight"))?
+            .to_device(*device);
         let lm_head_w = if let Some(w) = weights.remove("lm_head.weight") {
             // Cast FP8 lm_head to BF16, applying the companion block scale if present.
             // Without this the raw FP8 values (~448) are used instead of the true weights (~0.09),
@@ -1470,12 +1476,12 @@ impl Qwen3_5Model {
                         let bc = ws[1] / ss[1];
                         let w_4d = w_bf.view([ss[0], br, ss[1], bc]);
                         let s_4d = s.to_kind(tch::Kind::BFloat16).view([ss[0], 1i64, ss[1], 1i64]);
-                        Some((w_4d * s_4d).reshape([ws[0], ws[1]]))
+                        Some((w_4d * s_4d).reshape([ws[0], ws[1]]).to_device(*device))
                     } else {
-                        Some(w_bf)
+                        Some(w_bf.to_device(*device))
                     }
                 }
-                _ => Some(w),
+                _ => Some(w.to_device(*device)),
             }
         } else {
             None


### PR DESCRIPTION
Closes #405.

`from_weights_with_config`/`from_weights` took `device: &Device` but stored `embed_tokens`/`lm_head`/`norm` via `shallow_clone()` without `.to_device(device)`. Only decoder layers were moved. Result: mixed-device model when building from CPU weights with device=Cuda(0). Masked in production by ModelFactory pre-moving tensors, but crashes any stage-aware multi-device loader.

Fix: `.to_device(*device)` on embed/lm_head/norm in llama.rs, qwen3_5.rs, gemma.rs. Audited janus.rs/siglip.rs (already correct). Pre-commit full-workspace clippy PASSED. 139 tests pass.

Claude-Session: https://claude.ai/code/session_01U3qgsHTDWME66JFGZGS3ZA