### PR TITLE
feat(#409): browser both-paths — WT RPC dial factory (dial_wasm) + WanixMount wiring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6698,6 +6698,7 @@ dependencies = [
  "capnp",
  "capnpc",
  "console_error_panic_hook",
+ "hyprstream-9p",
  "hyprstream-rpc",
  "hyprstream-rpc-build",
  "hyprstream-rpc-derive",

--- a/crates/hyprstream-rpc-std/Cargo.toml
+++ b/crates/hyprstream-rpc-std/Cargo.toml
@@ -30,6 +30,10 @@ serde-wasm-bindgen = "0.6"
 js-sys = "0.3"
 console_error_panic_hook = "0.1"
 web-sys = { version = "0.3", features = ["console"] }
+# #409 Path B: WanixMount (Wanix-native VFS via 9P2000.L over SharedArrayBuffer
+# DMA). Only needed on the browser target; the DMA + WanixMount modules in
+# hyprstream-9p are themselves `#[cfg(target_arch = "wasm32")]`.
+hyprstream-9p = { path = "../hyprstream-9p" }
 
 [build-dependencies]
 capnpc = { workspace = true }

--- a/crates/hyprstream-rpc-std/src/vfs_mount.rs
+++ b/crates/hyprstream-rpc-std/src/vfs_mount.rs
@@ -7,6 +7,9 @@
 //! Mount points:
 //!   /srv/{service}     → ServiceMount (ctl for mutations, cat for queries)
 //!   /srv/{service}/doc → DocMount (man pages from schema annotations)
+//!   /wanix             → WanixMount (Wanix-native VFS via 9P2000.L over DMA;
+//!                        optional — mounted only when running under Wanix,
+//!                        see [`mount_wanix`]). #409 Path B.
 
 #![cfg(target_arch = "wasm32")]
 
@@ -518,5 +521,68 @@ pub fn build_browser_namespace(
         Arc::clone(&stream_registry),
     ))).expect("mount /stream");
 
+    // `/wanix` is NOT mounted here: it needs a Wanix-provided SharedArrayBuffer
+    // that the browser only has when running under Wanix. Wire it separately
+    // via [`mount_wanix`] after this builder returns. See #409 Path B.
+
     (ns, stream_registry)
+}
+
+// ============================================================================
+// WanixMount wiring — #409 Path B (Wanix-native VFS access)
+// ============================================================================
+
+/// Wire [`hyprstream_9p::wanix_mount::WanixMount`] into an existing browser
+/// namespace at `/wanix`.
+///
+/// # Why a separate helper, not a `build_browser_namespace` parameter
+///
+/// `build_browser_namespace` is synchronous; constructing a `WanixMount`
+/// requires the 9P2000.L version + attach handshake ([`P9Client::connect`]),
+/// which is async because the DMA transport round-trips to the Wanix Go host
+/// over the SharedArrayBuffer. Rather than force the whole namespace builder
+/// to be async for an optional path, the caller invokes this helper after
+/// `build_browser_namespace` when it actually has a Wanix SAB.
+///
+/// # Arguments
+///
+/// * `ns` — The namespace to mount into (must be behind a `RefCell`/`Mutex` if
+///   shared, since this mutates it).
+/// * `sab` — The `SharedArrayBuffer` shared with the Wanix host's DMA ring.
+///   Layout is documented in `hyprstream_9p::dma` (control region + two ring
+///   buffers); the Wanix host allocates and hands this to the browser.
+/// * `uname`, `aname` — 9P attach credentials / root aname. Pass `"root"`
+///   / `"/"` for the Wanix root tree.
+///
+/// # Errors
+///
+/// Returns an error if the 9P handshake (version/attach) fails — typically
+/// because the Wanix host isn't responding on the DMA ring or speaks an
+/// incompatible 9P variant.
+///
+/// # Coexistence
+///
+/// `/wanix` coexists with the RPC-client-backed paths (`/srv/registry`,
+/// `/srv/model`, `/stream`, etc.). The two access styles serve different
+/// needs: `/wanix` exposes the Wanix-native filesystem (real `walk`/`stat`
+/// qids over DMA), while `/srv/*` exposes hyprstream services via
+/// `GenericServiceMount` (ctl-style service-as-files over WebTransport RPC).
+pub async fn mount_wanix(
+    ns: &mut hyprstream_vfs::Namespace,
+    sab: &js_sys::SharedArrayBuffer,
+    uname: &str,
+    aname: &str,
+) -> anyhow::Result<()> {
+    use hyprstream_9p::client::P9Client;
+    use hyprstream_9p::dma::DmaTransport;
+    use hyprstream_9p::wanix_mount::WanixMount;
+
+    // `client_endpoint = true`: we write T-messages to chan0, read R-messages
+    // from chan1 (the Wanix Go host has the reverse assignment).
+    let transport = DmaTransport::new(sab, true);
+    let client = P9Client::connect(transport, uname, aname).await?;
+    let mount: hyprstream_vfs::MountTarget = Arc::new(WanixMount::new(client));
+    ns.mount("/wanix", mount)
+        .map_err(|e| anyhow::anyhow!("mount /wanix failed: {e}"))?;
+    Ok(())
 }

--- a/crates/hyprstream-rpc-std/src/wasm_exports.rs
+++ b/crates/hyprstream-rpc-std/src/wasm_exports.rs
@@ -52,10 +52,12 @@ impl VfsShell {
     ) -> Result<VfsShell, JsError> {
         console_error_panic_hook::set_once();
 
-        use hyprstream_rpc::rpc_client::{RpcClientImpl, RpcClient};
-        use hyprstream_rpc::signer::JsSigner;
-        use hyprstream_rpc::web_transport::WtConnection;
         use hyprstream_rpc::crypto::VerifyingKey;
+        // #409 Path A: route through the wasm32 `dial()` factory instead of
+        // hand-assembling `RpcClientImpl` here. This is the browser counterpart
+        // to native `dial()` — same `Arc<dyn RpcClient>` return, hiding the
+        // concrete `WtConnection` transport behind the object-safe trait.
+        use hyprstream_rpc::dial_wasm;
 
         // TODO: Get server verifying key from discovery endpoint
         let server_key = VerifyingKey::from_bytes(&[0u8; 32]).unwrap_or_else(|_| {
@@ -69,24 +71,32 @@ impl VfsShell {
 
         // Connect to registry
         web_sys::console::log_1(&"[VfsShell] Connecting to registry...".into());
-        let reg_transport = WtConnection::connect(registry_url, cert_hash.as_deref())
-            .await.map_err(|e| JsError::new(&e.to_string()))?;
-        let reg_signer = JsSigner::new(signer_pubkey, sign_fn.clone())
+        let reg_signer = hyprstream_rpc::signer::JsSigner::new(signer_pubkey, sign_fn.clone())
             .map_err(|e| JsError::new(&e.to_string()))?;
-        let reg_client: Arc<dyn RpcClient> = Arc::new(
-            RpcClientImpl::new(reg_signer, reg_transport, Some(server_key.clone()))
-        );
+        let reg_client: Arc<dyn hyprstream_rpc::rpc_client::RpcClient> = dial_wasm::dial(
+            registry_url,
+            cert_hash.as_deref(),
+            reg_signer,
+            Some(server_key.clone()),
+            None,
+        )
+        .await
+        .map_err(|e| JsError::new(&e.to_string()))?;
         web_sys::console::log_1(&"[VfsShell] Registry connected".into());
 
         // Connect to model
         web_sys::console::log_1(&"[VfsShell] Connecting to model...".into());
-        let model_transport = WtConnection::connect(model_url, cert_hash.as_deref())
-            .await.map_err(|e| JsError::new(&e.to_string()))?;
-        let model_signer = JsSigner::new(signer_pubkey, sign_fn)
+        let model_signer = hyprstream_rpc::signer::JsSigner::new(signer_pubkey, sign_fn)
             .map_err(|e| JsError::new(&e.to_string()))?;
-        let model_client: Arc<dyn RpcClient> = Arc::new(
-            RpcClientImpl::new(model_signer, model_transport, Some(server_key))
-        );
+        let model_client: Arc<dyn hyprstream_rpc::rpc_client::RpcClient> = dial_wasm::dial(
+            model_url,
+            cert_hash.as_deref(),
+            model_signer,
+            Some(server_key),
+            None,
+        )
+        .await
+        .map_err(|e| JsError::new(&e.to_string()))?;
         web_sys::console::log_1(&"[VfsShell] Model connected".into());
 
         // Build VFS namespace

--- a/crates/hyprstream-rpc/src/dial_wasm.rs
+++ b/crates/hyprstream-rpc/src/dial_wasm.rs
@@ -1,0 +1,116 @@
+//! Browser (wasm32) counterpart to native `dial.rs`.
+//!
+//! # Why a separate module, not an arm in `dial()`
+//!
+//! The native [`crate::dial::dial`] factory is `#[cfg(not(target_arch =
+//! "wasm32"))]`: its arms (Quic / Iroh / Ipc / SystemdFd) pull `quinn`, `iroh`,
+//! `tokio`, and Unix-socket code that do not compile for
+//! `wasm32-unknown-unknown`, and the capnp-over-`web_transport_trait::Session`
+//! framing it would otherwise lean on ([`SessionRpcTransport`]) is itself
+//! native-only — `web-transport-trait` is a native-only dependency and the
+//! whole `transport::rpc_session` submodule is gated off on wasm.
+//!
+//! The browser therefore speaks a *different* RPC wire format than native:
+//! ZMTP framing over a `web_sys::WebTransport` bidi stream (see
+//! [`crate::web_transport::WtConnection`]), matched by the server's
+//! `handle_wt_stream` handler in `transport::zmtp_quic.rs`. Constructing an
+//! `Arc<dyn RpcClient>` for that wire format is what this module does, so the
+//! browser goes through one `dial()`-style entrypoint per platform instead of
+//! hand-assembling `RpcClientImpl` at every call site.
+//!
+//! # What this is (and is not)
+//!
+//! This is the Path-A gap closure from #409: a single factory that takes a
+//! URL + signer + (optional) pin + (optional) JWT and returns a ready
+//! `Arc<dyn RpcClient>`, mirroring native `dial()`'s contract. It hides the
+//! concrete `WtConnection` transport behind the object-safe `RpcClient` trait
+//! exactly as native `dial()` hides `LazyQuinnTransport` / `LazyIrohTransport`
+//! / etc.
+//!
+//! It is **not** a swap-in replacement for `GenericServiceMount`:
+//! `GenericServiceMount` remains the correct VFS mount for the browser. The
+//! "real filesystem walk" alternative ([`RemoteModelMount`] /
+//! [`RemoteRegistryMount`]) lives in the native-only `hyprstream` binary crate
+//! and spins its own `tokio::runtime::Runtime`; it cannot be reached from the
+//! wasm-shared `hyprstream-rpc-std` crate, and porting it across the crate
+//! boundary would be high-risk churn for no functional gain since
+//! `GenericServiceMount` already proxies the same service methods over the
+//! same `Arc<dyn RpcClient>`. See #409 findings.
+
+#![cfg(target_arch = "wasm32")]
+
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+
+use crate::crypto::VerifyingKey;
+use crate::rpc_client::{RpcClient, RpcClientImpl};
+use crate::signer::JsSigner;
+use crate::web_transport::WtConnection;
+
+/// Dial a hyprstream server from the browser over WebTransport, returning a
+/// ready RPC client.
+///
+/// This is the wasm32 mirror of native [`crate::dial::dial`]. It performs the
+/// WT handshake eagerly (unlike native's lazy transports), because the browser
+/// WT API (`new WebTransport(url)`) is itself async and there is no benefit to
+/// deferring it — the first `call()` would block on the same handshake anyway.
+///
+/// # Arguments
+///
+/// * `url` — WebTransport URL of the server (e.g. `https://host:port`).
+/// * `cert_hash` — Optional base64-encoded SHA-256 of the server's leaf
+///   certificate, for self-signed mesh pinning (mirrors native
+///   `QuicServerAuth::pinned`). Omit for WebPKI-validated servers.
+/// * `signer` — A [`JsSigner`] wrapping the caller's Ed25519 signing callback.
+/// * `server_verifying_key` — Optional pinned server identity. `None` does NOT
+///   disable signature verification (the response is still verified against the
+///   key embedded in its envelope); it only declines to pin *which* identity
+///   that key must be. Mirrors the `dial()` contract. For WebTransport the
+///   channel is TLS-authenticated (WebPKI or cert-hash pin), so `None` is sound
+///   in the same way it is for native `Quic` with WebPKI.
+/// * `jwt` — Optional default JWT applied to every request (CA-signed trust
+///   cert included in request envelopes).
+///
+/// # Errors
+///
+/// Returns an error if the WebTransport handshake fails.
+pub async fn dial(
+    url: &str,
+    cert_hash: Option<&str>,
+    signer: JsSigner,
+    server_verifying_key: Option<VerifyingKey>,
+    jwt: Option<String>,
+) -> Result<Arc<dyn RpcClient>> {
+    let transport = WtConnection::connect(url, cert_hash).await?;
+    let client = RpcClientImpl::new(signer, transport, server_verifying_key);
+    let client = match jwt {
+        Some(t) => client.with_default_jwt(t),
+        None => client,
+    };
+    Ok(Arc::new(client) as Arc<dyn RpcClient>)
+}
+
+/// Dial from raw URL + signer bytes, without a pre-built [`JsSigner`].
+///
+/// Convenience wrapper that constructs the [`JsSigner`] from the JS-facing
+/// pubkey + sign-callback pair, then delegates to [`dial`]. This matches the
+/// argument shape of `WasmRpcClient::connect` so callers migrating from
+/// hand-assembled clients keep their call sites.
+///
+/// # Errors
+///
+/// Returns an error if `signer_pubkey` is not 32 bytes, the JS callback is
+/// malformed, or the WebTransport handshake fails.
+pub async fn dial_with_js_signer(
+    url: &str,
+    cert_hash: Option<&str>,
+    signer_pubkey: &[u8],
+    sign_fn: js_sys::Function,
+    server_verifying_key: Option<VerifyingKey>,
+    jwt: Option<String>,
+) -> Result<Arc<dyn RpcClient>> {
+    let signer = JsSigner::new(signer_pubkey, sign_fn)
+        .map_err(|e| anyhow!("dial_with_js_signer: invalid signer: {e}"))?;
+    dial(url, cert_hash, signer, server_verifying_key, jwt).await
+}

--- a/crates/hyprstream-rpc/src/lib.rs
+++ b/crates/hyprstream-rpc/src/lib.rs
@@ -182,6 +182,11 @@ pub mod socket;
 pub mod wasm_api;
 #[cfg(target_arch = "wasm32")]
 pub mod web_transport;
+// #409 Path A: browser counterpart to native `dial`. Compiles only on wasm32;
+// see `dial_wasm.rs` for why this is a separate module rather than an arm in
+// native `dial()` (which is itself `#[cfg(not(target_arch = "wasm32"))]`).
+#[cfg(target_arch = "wasm32")]
+pub mod dial_wasm;
 
 // ============================================================================
 // Re-exports available on ALL targets


### PR DESCRIPTION
Closes #409.

**Path A — WT RPC dial factory** (`dial_wasm.rs`, new, `#[cfg(target_arch = "wasm32")]`):
Browser counterpart to native `dial()`. Returns `Arc<dyn RpcClient>` from a URL + JsSigner + optional cert-pin + optional JWT. Hides `WtConnection` behind the object-safe trait. Wired `VfsShell::connect` through `dial_wasm::dial` instead of hand-assembling `RpcClientImpl`.

Key finding: native `dial()` is `#[cfg(not(target_arch = "wasm32"))]` — the browser speaks a different wire format (ZMTP over `web_sys::WebTransport`), so it needs its own factory. GenericServiceMount kept (not swapped for RemoteModelMount) because RemoteModelMount lives in the native binary crate with its own tokio runtime; GenericServiceMount already proxies the same service methods over the same `Arc<dyn RpcClient>`.

**Path B — WanixMount wiring** (`vfs_mount.rs`):
Added `mount_wanix(ns, sab, uname, aname)` — constructs `DmaTransport` from Wanix SharedArrayBuffer, runs 9P2000.L handshake, mounts `WanixMount` at `/wanix`. Separate async helper (9P handshake is async; namespace builder is sync). `/wanix` coexists with `/srv/*`.

**Pre-existing wasm blocker documented:** `node_identity.rs:189` tracing macro fails on wasm32 (not cfg-gated). One-line fix, separate PR. Zero new wasm errors from #409.

Pre-commit full-workspace clippy PASSED. 15/15 dial tests pass.

Claude-Session: https://claude.ai/code/session_01U3qgsHTDWME66JFGZGS3ZA