### PR TITLE
feat: wire DevicePool→LayerDeviceMap through TorchEngine for multi-device pipeline

### DIFF
--- a/crates/hyprstream/src/runtime/model_factory.rs
+++ b/crates/hyprstream/src/runtime/model_factory.rs
@@ -10,6 +10,7 @@ use tch::{Device, Kind as DType, Tensor};
 use tracing::{debug, info, instrument, warn};
 
 use super::architectures::{gemma::GemmaModel, llama::LlamaModel, ModelOperations};
+use super::device_pool::DevicePool;
 use super::KVQuantType;
 use super::model_config::{ModelArchitecture, ModelConfig};
 use super::torch_utils::{safe_to_device, estimate_tensor_size_mb};
@@ -134,13 +135,26 @@ impl ModelFactory {
 
     /// Create a model from a directory containing weights and optionally config.json
     /// This is the ONLY way models should be created to ensure consistency
-    #[instrument(name = "model_factory.create", skip(device, dtype), fields(model_path = %model_path.display()))]
+    ///
+    /// # Multi-device pipeline (#314 wiring, #310 epic)
+    ///
+    /// Pass `device_pool = Some(pool)` with a pool of >1 device to build the model
+    /// as a single multi-device pipeline stage: decoder layers are spread across
+    /// the pool's devices via [`LayerDeviceMap::even_split`], and the model's
+    /// `forward_layers` performs the lone cross-device copy at each stage boundary.
+    /// `device` must be the pool's primary (first) device — non-layer weights
+    /// (embeddings, final norm, lm_head) live there. When `device_pool` is `None`
+    /// or holds a single device, construction is unchanged (whole model on
+    /// `device`). At runtime this depends on #405 (from_weights device-placement
+    /// fix) to actually place per-layer tensors on non-primary devices.
+    #[instrument(name = "model_factory.create", skip(device, dtype, device_pool), fields(model_path = %model_path.display()))]
     pub async fn create(
         model_path: &Path,
         device: &Device,
         dtype: DType,
         max_context: Option<usize>,
         kv_quant_type: KVQuantType,
+        device_pool: Option<&DevicePool>,
     ) -> Result<Box<dyn ModelOperations>> {
         info!("Loading model: {}", model_path.display());
         if let Some(mc) = max_context {
@@ -148,6 +162,17 @@ impl ModelFactory {
         }
         if kv_quant_type != KVQuantType::None {
             info!("Using KV cache quantization: {:?}", kv_quant_type);
+        }
+        if let Some(pool) = device_pool {
+            if !pool.is_single() {
+                info!(
+                    "🔀 Multi-device pipeline: spreading layers across {} device(s) {:?} \
+                     (primary {:?}); depends on #405 for correct per-layer placement",
+                    pool.len(),
+                    pool.devices(),
+                    pool.primary(),
+                );
+            }
         }
 
         // Check if we have sharded files that need incremental loading
@@ -159,12 +184,12 @@ impl ModelFactory {
                 "📦 Using incremental loading for {} shards",
                 shard_files.len()
             );
-            Self::create_incremental(model_path, device, dtype, shard_files, max_context, kv_quant_type).await
+            Self::create_incremental(model_path, device, dtype, shard_files, max_context, kv_quant_type, device_pool).await
         } else {
             // Standard loading for single files or small models
             let weights = Self::load_weights(model_path, device, dtype).await?;
             let config = ModelConfig::load(model_path, &weights)?;
-            let model = Self::create_model_from_config(config, weights, device, dtype, max_context, kv_quant_type, model_path)?;
+            let model = Self::create_model_from_config(config, weights, device, dtype, max_context, kv_quant_type, model_path, device_pool)?;
             info!("✅ ModelFactory: Model created successfully");
             Ok(model)
         }
@@ -225,7 +250,7 @@ impl ModelFactory {
     }
 
     /// Create model using incremental loading for large sharded models
-    #[instrument(name = "model_factory.create_incremental", skip(device, dtype, shard_files), fields(shard_count = shard_files.len()))]
+    #[instrument(name = "model_factory.create_incremental", skip(device, dtype, shard_files, device_pool), fields(shard_count = shard_files.len()))]
     async fn create_incremental(
         model_path: &Path,
         device: &Device,
@@ -233,6 +258,7 @@ impl ModelFactory {
         shard_files: Vec<std::path::PathBuf>,
         max_context: Option<usize>,
         kv_quant_type: KVQuantType,
+        device_pool: Option<&DevicePool>,
     ) -> Result<Box<dyn ModelOperations>> {
         // For now, we still need to load all weights, but we do it more efficiently
         // by processing shards sequentially and immediately transferring to GPU
@@ -255,7 +281,7 @@ impl ModelFactory {
 
         // Load config and create model
         let config = ModelConfig::load(model_path, &all_weights)?;
-        let model = Self::create_model_from_config(config, all_weights, device, dtype, max_context, kv_quant_type, model_path)?;
+        let model = Self::create_model_from_config(config, all_weights, device, dtype, max_context, kv_quant_type, model_path, device_pool)?;
 
         info!("Model loaded");
         Ok(model)
@@ -635,6 +661,7 @@ impl ModelFactory {
         max_context: Option<usize>,
         kv_quant_type: KVQuantType,
         model_path: &Path,
+        device_pool: Option<&DevicePool>,
     ) -> Result<Box<dyn ModelOperations>> {
         // Run TTN analysis: Tier 1 (embedded) → Tier 2 (cached) → Tier 3 (weight entropy SVD).
         // Weights are available here, enabling Tier 3 for unknown models.
@@ -644,14 +671,20 @@ impl ModelFactory {
             tracing::warn!("TTN profile analysis failed (non-fatal): {e}");
         }
 
+        // Multi-device is only wired for Llama-family architectures today (the
+        // only family with a `stage_from_weights_with_config` that honors a
+        // `LayerDeviceMap`). Other architectures log and fall back to the
+        // single-device path on the primary device.
+        let wants_multi = device_pool.is_some_and(|p| !p.is_single());
+
         match config.architecture {
             ModelArchitecture::Llama => {
                 info!("Creating Llama model");
-                Self::create_llama_model(config, weights, device, dtype, max_context, kv_quant_type)
+                Self::create_llama_model(config, weights, device, dtype, max_context, kv_quant_type, device_pool)
             }
             ModelArchitecture::Qwen => {
                 info!("Creating Qwen model");
-                Self::create_qwen_model(config, weights, device, dtype, max_context, kv_quant_type)
+                Self::create_qwen_model(config, weights, device, dtype, max_context, kv_quant_type, device_pool)
             }
             ModelArchitecture::Gemma => {
                 info!("Creating Gemma model");
@@ -660,7 +693,7 @@ impl ModelFactory {
             ModelArchitecture::Mistral => {
                 info!("Creating Mistral model");
                 // For now, Mistral uses Llama architecture
-                Self::create_llama_model(config, weights, device, dtype, max_context, kv_quant_type)
+                Self::create_llama_model(config, weights, device, dtype, max_context, kv_quant_type, device_pool)
             }
             ModelArchitecture::Janus => {
                 info!("Creating Janus multimodal model");
@@ -668,6 +701,13 @@ impl ModelFactory {
             }
             ModelArchitecture::Qwen3_5 => {
                 info!("Creating Qwen3.5 hybrid SSM/attention model");
+                if wants_multi {
+                    warn!(
+                        "Multi-device requested for Qwen3.5, which does not yet implement the \
+                         layer-split path; building single-device on {:?}",
+                        device
+                    );
+                }
                 Self::create_qwen3_5_model(config, weights, device, dtype, max_context, kv_quant_type)
             }
             ModelArchitecture::Unknown(arch) => Err(anyhow!("Unknown architecture: {}", arch)),
@@ -681,8 +721,10 @@ impl ModelFactory {
         dtype: DType,
         max_context: Option<usize>,
         kv_quant_type: KVQuantType,
+        device_pool: Option<&DevicePool>,
     ) -> Result<Box<dyn ModelOperations>> {
         use super::architectures::llama::LlamaConfig;
+        use super::device_pool::LayerDeviceMap;
 
         // Apply max_context override if specified
         let effective_max_pos = max_context.unwrap_or(config.max_position_embeddings);
@@ -745,14 +787,41 @@ impl ModelFactory {
             llama_config.max_position_embeddings
         );
 
-        // Pass mutable reference to allow incremental tensor freeing during construction
-        let model = LlamaModel::from_weights_with_config(
-            &mut weights,
-            llama_config,
-            device,
-            dtype,
-            kv_quant_type,
-        )?;
+        // Multi-device pipeline (#314 wiring): when a multi-device `DevicePool`
+        // is present, spread all decoder layers `[0..num_hidden_layers)` across
+        // the pool via an even (parameter-balanced) split and build the model as
+        // a single stage owning the full range with that device map. The
+        // architecture's `forward_layers` then performs the lone cross-device
+        // copy at each stage boundary. Single-device pools and `None` take the
+        // original whole-model path unchanged.
+        let num_layers = llama_config.num_hidden_layers as usize;
+        let model = if let Some(pool) = device_pool.filter(|p| !p.is_single()) {
+            let device_map = LayerDeviceMap::even_split(pool, num_layers)?;
+            info!(
+                "🔀 Building Llama model as a multi-device pipeline: {} layer(s) across \
+                 {} device(s) ({} stage boundary copies per forward)",
+                num_layers,
+                pool.len(),
+                pool.len() - 1,
+            );
+            LlamaModel::stage_from_weights_with_config(
+                &mut weights,
+                llama_config,
+                &device_map,
+                0..num_layers,
+                dtype,
+                kv_quant_type,
+            )?
+        } else {
+            // Pass mutable reference to allow incremental tensor freeing during construction
+            LlamaModel::from_weights_with_config(
+                &mut weights,
+                llama_config,
+                device,
+                dtype,
+                kv_quant_type,
+            )?
+        };
 
         Ok(Box::new(model))
     }
@@ -764,12 +833,13 @@ impl ModelFactory {
         dtype: DType,
         max_context: Option<usize>,
         kv_quant_type: KVQuantType,
+        device_pool: Option<&DevicePool>,
     ) -> Result<Box<dyn ModelOperations>> {
         // Qwen uses Llama architecture with specific configuration
         // The key difference is in the config values, not the architecture
         info!("   Using Llama architecture with Qwen configuration");
         info!("   rope_theta: {} (from config)", config.rope_theta);
-        Self::create_llama_model(config, weights, device, dtype, max_context, kv_quant_type)
+        Self::create_llama_model(config, weights, device, dtype, max_context, kv_quant_type, device_pool)
     }
 
     fn create_gemma_model(
@@ -928,7 +998,7 @@ impl ModelFactory {
     /// Uses FsOps::read_file() instead of direct filesystem access.
     /// The `model_path` is still needed for ModelConfig and architecture detection
     /// (which parse config.json), but weight data is read through FsOps.
-    #[instrument(name = "model_factory.create_with_fs", skip(device, dtype, fs), fields(model_path = %model_path.display()))]
+    #[instrument(name = "model_factory.create_with_fs", skip(device, dtype, fs, device_pool), fields(model_path = %model_path.display()))]
     pub async fn create_with_fs(
         model_path: &Path,
         device: &Device,
@@ -936,6 +1006,7 @@ impl ModelFactory {
         max_context: Option<usize>,
         kv_quant_type: KVQuantType,
         fs: &WorktreeClient,
+        device_pool: Option<&DevicePool>,
     ) -> Result<Box<dyn ModelOperations>> {
         info!("Loading model via FsOps: {}", model_path.display());
 
@@ -947,7 +1018,7 @@ impl ModelFactory {
 
         let weights = Self::load_weights_fs(fs, &shard_names, device, dtype).await?;
         let config = ModelConfig::load(model_path, &weights)?;
-        let model = Self::create_model_from_config(config, weights, device, dtype, max_context, kv_quant_type, model_path)?;
+        let model = Self::create_model_from_config(config, weights, device, dtype, max_context, kv_quant_type, model_path, device_pool)?;
         info!("Model created successfully via FsOps");
         Ok(model)
     }

--- a/crates/hyprstream/src/runtime/torch_engine.rs
+++ b/crates/hyprstream/src/runtime/torch_engine.rs
@@ -55,8 +55,20 @@ pub struct TorchEngine {
     tokenizer: Arc<Mutex<Option<Tokenizer>>>,
     /// Template engine for chat formatting
     template_engine: Arc<Mutex<Option<TemplateEngine>>>,
-    /// Device for computation (CPU/CUDA/ROCm) - immutable after construction
+    /// Device for computation (CPU/CUDA/ROCm) - immutable after construction.
+    ///
+    /// For a multi-device engine this is the pool's **primary** (first) device —
+    /// the home of non-layer weights (embeddings, final norm, lm_head) and the
+    /// device inputs are placed on before the first decoder layer. Per-layer
+    /// placement is driven by the model's own `LayerDeviceMap` (`forward_layers`).
     device: Device,
+    /// Resolved multi-device pool, when the engine was built from >1 device
+    /// (#314 wiring). `None` for single-device engines (the common case). When
+    /// `Some` and non-single, the loaded model is built as a single pipeline
+    /// stage spanning `[0..num_hidden_layers)` with a layer→device map derived
+    /// from this pool. Held as `Option<Arc<...>>` because `TorchEngine` is
+    /// `Clone` and the pool is `Send + Sync` (it holds only `Device` values).
+    device_pool: Option<Arc<crate::runtime::DevicePool>>,
     /// Runtime configuration - immutable after construction
     config: RuntimeConfig,
     /// Generation configuration with defaults
@@ -108,6 +120,31 @@ impl TorchEngine {
     /// Get the device this engine is using for computation
     pub fn device(&self) -> Device {
         self.device
+    }
+
+    /// The resolved multi-device pool, if this engine was built with >1 device.
+    ///
+    /// Returns `None` for single-device engines (the common case, including the
+    /// legacy single-`gpu_device_id` path and CPU). When `Some` and non-single,
+    /// the loaded model is built as a single pipeline stage with a layer→device
+    /// map derived from this pool (#314 wiring). The pool's primary equals
+    /// [`Self::device`].
+    #[must_use]
+    pub fn device_pool(&self) -> Option<&crate::runtime::DevicePool> {
+        self.device_pool.as_deref()
+    }
+
+    /// Whether this engine is configured to build a multi-device pipeline.
+    ///
+    /// True exactly when [`Self::device_pool`] is `Some` and holds >1 device.
+    /// The model is constructed with `LayerDeviceMap::even_split` across the
+    /// pool; single-device engines return `false` and build the whole model on
+    /// [`Self::device`].
+    #[must_use]
+    pub fn is_multi_device(&self) -> bool {
+        self.device_pool
+            .as_deref()
+            .is_some_and(|p| !p.is_single())
     }
 
     // ============================================================================
@@ -315,25 +352,34 @@ impl TorchEngine {
 
     /// Internal sync constructor
     fn new_sync(config: RuntimeConfig) -> Result<Self> {
-        // Multi-GPU foundation (#313, epic #310): when devices are *explicitly*
-        // requested via `RuntimeConfig.devices` / `HYPRSTREAM_GPU_DEVICES`,
-        // resolve them through `DevicePool`, which validates them fail-fast (no
-        // silent CPU downgrade) and is the seam for later replication (#313/2a)
-        // and the layer device_map (#314). This PR only uses the pool's *primary*
-        // device, so single-GPU runtime behavior is unchanged; the legacy
-        // single-`gpu_device_id` path below is left intact (including its
-        // existing soft CPU fallback) to avoid changing that behavior here.
+        // Multi-GPU foundation (#313/#314, epic #310): when devices are
+        // *explicitly* requested via `RuntimeConfig.devices` /
+        // `HYPRSTREAM_GPU_DEVICES`, resolve them through `DevicePool`, which
+        // validates them fail-fast (no silent CPU downgrade). When the pool
+        // holds >1 device the engine keeps the whole pool and threads it into
+        // model construction so the model is built as a single multi-device
+        // pipeline stage (layers spread via `LayerDeviceMap::even_split`,
+        // `forward_layers` performs the stage-boundary copies). Single-pool and
+        // legacy single-`gpu_device_id` paths are unchanged.
         if config.use_gpu {
             if let Some(indices) = config.resolve_explicit_multi_device_indices()? {
                 let pool = crate::runtime::DevicePool::from_cuda_indices(&indices)?;
                 let device = pool.primary();
+                if pool.is_single() {
+                    info!(
+                        "🚀 DevicePool resolved a single device {:?}; building single-device engine",
+                        device
+                    );
+                    return Self::with_device(config, device, None);
+                }
                 info!(
-                    "🚀 Multi-GPU DevicePool resolved {} device(s) {:?}; using primary {:?}",
+                    "🚀 Multi-GPU DevicePool resolved {} device(s) {:?}; building a multi-device \
+                     pipeline (primary {:?} hosts embeddings/lm_head)",
                     pool.len(),
                     pool.devices(),
                     device
                 );
-                return Self::with_device(config, device);
+                return Self::with_device(config, device, Some(Arc::new(pool)));
             }
         }
 
@@ -386,16 +432,23 @@ impl TorchEngine {
             Device::Cpu
         };
 
-        Self::with_device(config, device)
+        Self::with_device(config, device, None)
     }
 
-    /// Construct an engine pinned to an already-resolved [`Device`].
+    /// Construct an engine pinned to an already-resolved primary [`Device`].
     ///
-    /// Single-device by design: a `TorchEngine` owns exactly one immutable
-    /// device and stays thread-pinned because `tch` tensors are `!Send`. The
-    /// multi-device `DevicePool` selects *which* device (its primary, for now);
-    /// the multi-engine/replication routing across the pool is a later PR (#313/2a).
-    fn with_device(config: RuntimeConfig, device: Device) -> Result<Self> {
+    /// Pass `device_pool = Some(pool)` with a multi-device pool to build the
+    /// model as a single pipeline stage spanning the whole decoder stack with a
+    /// layer→device map (the #314 multi-device path). The engine's `device`
+    /// remains the pool's primary (first) device — the home of embeddings, final
+    /// norm, and lm_head, and where inputs land before the first layer.
+    /// `device_pool = None` (or a single-device pool) preserves the original
+    /// whole-model-on-one-device behavior.
+    fn with_device(
+        config: RuntimeConfig,
+        device: Device,
+        device_pool: Option<Arc<crate::runtime::DevicePool>>,
+    ) -> Result<Self> {
         Ok(Self {
             var_store: Arc::new(Mutex::new(None)),
             model_architecture: Arc::new(Mutex::new(None)),
@@ -404,6 +457,7 @@ impl TorchEngine {
             tokenizer: Arc::new(Mutex::new(None)),
             template_engine: Arc::new(Mutex::new(None)),
             device,
+            device_pool,
             config: config.clone(),
             generation_config: GenerationConfig {
                 max_tokens: 2048,
@@ -612,7 +666,9 @@ impl TorchEngine {
             model_info.architecture = config.model_type.clone();
         }
 
-        // Use the factory to create the model
+        // Use the factory to create the model. When `device_pool` is set and
+        // multi-device, the factory builds the model as a single pipeline stage
+        // spanning all decoder layers with a layer→device map (#314 wiring).
         let factory_start = std::time::Instant::now();
         let model = ModelFactory::create(
             model_path,
@@ -620,6 +676,7 @@ impl TorchEngine {
             tch::Kind::BFloat16,
             self.config.max_context.map(|v| v as usize),
             self.config.kv_quant_type,
+            self.device_pool.as_deref(),
         ).await?;
         let factory_time = factory_start.elapsed();
         info!("✅ Model weights loaded in {:.2}s", factory_time.as_secs_f64());
@@ -1997,6 +2054,7 @@ impl Drop for TorchEngine {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 
@@ -2023,6 +2081,71 @@ mod tests {
             gen_config.max_tokens, 2048,
             "TorchEngine should initialize with max_tokens=2048"
         );
+    }
+
+    /// `with_device(.., None)` — the single-device path used by every legacy
+    /// caller — must produce an engine that reports single-device and exposes
+    /// no pool. This is the regression guard that the #314 wiring does not
+    /// perturb single-GPU/CPU construction.
+    #[test]
+    fn single_device_engine_is_not_multi_device() {
+        let engine =
+            super::TorchEngine::with_device(RuntimeConfig::default(), Device::Cpu, None).unwrap();
+        assert!(!engine.is_multi_device());
+        assert!(engine.device_pool().is_none());
+        assert_eq!(engine.device(), Device::Cpu);
+    }
+
+    /// `with_device(.., Some(multi_pool))` must mark the engine multi-device and
+    /// expose the pool with the right primary. We build the pool from explicit
+    /// `Device::Cuda` values via `DevicePool::from_devices` (which does not probe
+    /// CUDA), so this runs on CPU-only CI — we never construct a model here, we
+    /// only exercise the engine-struct wiring (#314 selection logic).
+    #[test]
+    fn multi_device_pool_marks_engine_multi_device() {
+        use crate::runtime::device_pool::DevicePool;
+        let pool = DevicePool::from_devices(vec![Device::Cuda(0), Device::Cuda(1)]).unwrap();
+        assert_eq!(pool.len(), 2);
+        let primary = pool.primary();
+        let engine = super::TorchEngine::with_device(
+            RuntimeConfig::default(),
+            primary,
+            Some(std::sync::Arc::new(pool.clone())),
+        )
+        .unwrap();
+        assert!(engine.is_multi_device());
+        let exposed = engine
+            .device_pool()
+            .expect("multi-device engine must expose its pool");
+        assert_eq!(exposed.devices(), pool.devices());
+        assert_eq!(exposed.primary(), primary);
+        assert_eq!(engine.device(), primary);
+    }
+
+    /// The map the factory would build for a 2-device pool must be a contiguous
+    /// prefix-heavy split with exactly one stage boundary — the invariant the
+    /// `forward_layers` path relies on. This pins the planner the wiring hands
+    /// to model construction (#314 → #310 epic).
+    #[test]
+    fn engine_multi_device_map_has_one_boundary_per_stage_gap() {
+        use crate::runtime::device_pool::{DevicePool, LayerDeviceMap};
+        let pool = DevicePool::from_devices(vec![Device::Cuda(0), Device::Cuda(1)]).unwrap();
+        // 7 layers over 2 devices → [0,0,0,0, 1,1,1] (prefix gets the extra).
+        let map = LayerDeviceMap::even_split(&pool, 7).unwrap();
+        assert_eq!(map.len(), 7);
+        let mut boundaries = 0;
+        let mut prev = map.device_for(0);
+        for g in 1..map.len() {
+            if map.is_boundary(prev, g) {
+                boundaries += 1;
+            }
+            prev = map.device_for(g);
+        }
+        assert_eq!(
+            boundaries, 1,
+            "2-device even_split has exactly one cross-device copy per forward"
+        );
+        assert!(!map.is_single_device());
     }
 }
 


### PR DESCRIPTION
The 'next PR' #314 anticipated. `TorchEngine::new_sync` now keeps the full `DevicePool` (instead of discarding to `pool.primary()`) and wires `LayerDeviceMap::even_split` through `ModelFactory::create` when >1 device is configured.

Single-device path is a regression-guarded no-op (legacy `gpu_device_id` / CPU untouched). Multi-device: `stage_from_weights_with_config` + per-layer `device_map` in `forward_layers`.

3 new tests (no CUDA needed — `DevicePool::from_devices` doesn't probe). Existing 29/29 #314 split-vs-whole equivalence tests still pass. Pre-commit full-workspace clippy PASSED.

Depends on #405 (merged — from_weights device-placement fix) for runtime correctness.

Claude-Session: https://claude.ai/code/session_01U3qgsHTDWME66JFGZGS3ZA