### PR TITLE
feat(#432): RegistryService getBlob — content-addressed fetch (grant-scoped authz)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6344,6 +6344,7 @@ dependencies = [
  "capnp",
  "capnp-futures",
  "capnpc",
+ "cas-serve",
  "casbin",
  "chrono",
  "clap",

--- a/crates/cas-serve/src/lib.rs
+++ b/crates/cas-serve/src/lib.rs
@@ -8,5 +8,7 @@ pub mod chunker;
 pub mod mdb_shard;
 pub mod protocol;
 pub mod shard;
+pub mod store;
 
 pub use protocol::{ErrorCode, Request, Response};
+pub use store::{CasStore, StoreError};

--- a/crates/cas-serve/src/main.rs
+++ b/crates/cas-serve/src/main.rs
@@ -109,114 +109,25 @@ impl CasServer {
         }
     }
 
-    /// Reassemble a file from its reconstruction shard: load the shard, fetch
-    /// each referenced xorb, and concatenate the segment bytes in order.
+    /// Reassemble a file from its reconstruction shard. Delegates to the shared
+    /// `CasStore` reconstruction core (`cas_serve::store`) so the binary and
+    /// in-process embedders (registry `getBlob`) share one implementation.
     async fn handle_get_file(&self, hash: &str) -> Response {
-        let _file_hash = match Request::parse_hash(hash) {
-            Ok(h) => h,
-            Err(e) => return Response::error(ErrorCode::InvalidHash, e),
-        };
-
-        // 1. Look for a reconstruction shard (chunked/multi-xorb file path).
-        let shard_path = self.shard_path(hash);
-        if shard_path.exists() {
-            return self.reassemble_from_shard(hash, &shard_path).await;
-        }
-
-        // 2. Fall back to a directly-stored raw blob under the xorbs dir. This
-        //    preserves compatibility with clients that uploaded a whole file as
-        //    a single XORB via the legacy `UploadXorb` path (where the XORB
-        //    hash == the data hash of the whole blob). `compute_data_hash` over
-        //    a whole blob equals the file hash only for a single-chunk file, so
-        //    this is exactly the small-file degenerate case.
-        let xorb_path = self.xorb_path(hash);
-        match tokio::fs::read(&xorb_path).await {
+        let store = cas_serve::CasStore::new(&self.storage_path);
+        match store.get_file_bytes(hash).await {
             Ok(data) => {
-                debug!("GetFile {hash}: served as raw blob (no shard)");
+                debug!("GetFile {hash}: reassembled {} bytes", data.len());
                 Response::file(&data)
             }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                Response::error(ErrorCode::NotFound, format!("File not found: {hash}"))
+            Err(cas_serve::StoreError::InvalidHash(e)) => {
+                Response::error(ErrorCode::InvalidHash, e)
             }
-            Err(e) => Response::error(ErrorCode::IoError, format!("Failed to read file: {e}")),
+            Err(cas_serve::StoreError::NotFound(e)) => Response::error(ErrorCode::NotFound, e),
+            Err(cas_serve::StoreError::CorruptShard(e)) => {
+                Response::error(ErrorCode::StorageError, e)
+            }
+            Err(cas_serve::StoreError::Io(e)) => Response::error(ErrorCode::IoError, e),
         }
-    }
-
-    /// Load the `.mdb` shard, fetch each referenced xorb, and concatenate the
-    /// segment bytes to reconstruct the file. Reconstruction walks the shard's
-    /// File-Info segments (each naming a xorb + local chunk range), reads each
-    /// xorb's raw bytes, and slices the segment's byte range out of it.
-    async fn reassemble_from_shard(&self, file_hash: &str, shard_path: &PathBuf) -> Response {
-        let mdb_bytes = match tokio::fs::read(shard_path).await {
-            Ok(b) => b,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                return Response::error(
-                    ErrorCode::NotFound,
-                    format!("Shard not found: {file_hash}"),
-                )
-            }
-            Err(e) => {
-                return Response::error(ErrorCode::IoError, format!("Failed to read shard: {e}"))
-            }
-        };
-
-        let file_hash_parsed = match Request::parse_hash(file_hash) {
-            Ok(h) => h,
-            Err(e) => return Response::error(ErrorCode::InvalidHash, e),
-        };
-
-        let segments = match Shard::segments(&mdb_bytes, &file_hash_parsed) {
-            Ok(s) => s,
-            Err(e) => {
-                return Response::error(ErrorCode::StorageError, format!("Corrupt shard: {e}"))
-            }
-        };
-
-        // The shard's materialized_bytes is the authoritative file length.
-        let expected_len: u64 = segments.iter().map(|s| s.byte_len).sum();
-        let mut out = Vec::with_capacity(expected_len as usize);
-        for seg in &segments {
-            let xorb_hex = seg.xorb_hash.hex();
-            let xorb_path = self.xorb_path(&xorb_hex);
-            let xorb_bytes = match tokio::fs::read(&xorb_path).await {
-                Ok(b) => b,
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                    return Response::error(
-                        ErrorCode::NotFound,
-                        format!("Missing xorb {xorb_hex} for file {file_hash}"),
-                    )
-                }
-                Err(e) => {
-                    return Response::error(
-                        ErrorCode::IoError,
-                        format!("Failed to read xorb {xorb_hex}: {e}"),
-                    )
-                }
-            };
-            // cas-serve stores raw concatenated xorbs and every segment spans
-            // the whole xorb (chunk_start=0), so the segment's byte range is
-            // `[0, byte_len)`. Slice defensively in case a future writer emits
-            // partial spans.
-            let len = (seg.byte_len as usize).min(xorb_bytes.len());
-            out.extend_from_slice(&xorb_bytes[..len]);
-        }
-
-        if out.len() as u64 != expected_len {
-            return Response::error(
-                ErrorCode::StorageError,
-                format!(
-                    "Reconstructed {} bytes but shard expected {expected_len} for {file_hash}",
-                    out.len()
-                ),
-            );
-        }
-
-        debug!(
-            "GetFile {file_hash}: reassembled {} bytes across {} xorb(s)",
-            out.len(),
-            segments.len()
-        );
-        Response::file(&out)
     }
 
     async fn handle_exists(&self, hash: &str) -> Response {

--- a/crates/cas-serve/src/store.rs
+++ b/crates/cas-serve/src/store.rs
@@ -1,0 +1,163 @@
+//! Content-addressed store: filesystem-backed XET reconstruction.
+//!
+//! This is the read/write core extracted from the `cas-serve` binary so it can
+//! be reused **in-process** by embedders (e.g. the registry service's `getBlob`)
+//! without spawning a subprocess or reimplementing reconstruction.
+//!
+//! Reconstruction walks the file's `.mdb` reconstruction shard, fetches each
+//! referenced xorb, and concatenates the segment bytes — the same algorithm the
+//! binary serves over its NDJSON `GetFile` protocol.
+
+use crate::protocol::Request;
+use crate::shard::Shard;
+use std::path::{Path, PathBuf};
+
+/// Errors from store reconstruction.
+#[derive(Debug, thiserror::Error)]
+pub enum StoreError {
+    #[error("invalid hash: {0}")]
+    InvalidHash(String),
+    #[error("not found: {0}")]
+    NotFound(String),
+    #[error("corrupt shard: {0}")]
+    CorruptShard(String),
+    #[error("io error: {0}")]
+    Io(String),
+}
+
+/// Storage path resolution order (matches the `cas-serve` binary):
+/// 1. `CAS_STORAGE` environment variable
+/// 2. `XET_CACHE_DIR` environment variable
+/// 3. `~/.cache/xet/` (default)
+pub fn resolve_storage_path() -> PathBuf {
+    if let Ok(path) = std::env::var("CAS_STORAGE") {
+        return PathBuf::from(shellexpand::tilde(&path).into_owned());
+    }
+    if let Ok(path) = std::env::var("XET_CACHE_DIR") {
+        return PathBuf::from(shellexpand::tilde(&path).into_owned());
+    }
+    dirs::cache_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("xet")
+}
+
+/// Filesystem-backed content-addressed store.
+///
+/// Storage layout (identical to the `cas-serve` binary):
+/// - `xorbs/default.{xorb_hash}` — raw xorb bytes (concatenated chunks).
+/// - `shards/{file_hash}` — reconstruction shard (`.mdb` binary).
+#[derive(Debug, Clone)]
+pub struct CasStore {
+    storage_path: PathBuf,
+}
+
+impl CasStore {
+    /// Open a store rooted at `storage_path`.
+    pub fn new(storage_path: impl AsRef<Path>) -> Self {
+        Self {
+            storage_path: storage_path.as_ref().to_path_buf(),
+        }
+    }
+
+    /// Open a store using the standard env/default path resolution.
+    pub fn from_env() -> Self {
+        Self::new(resolve_storage_path())
+    }
+
+    /// Path for a raw xorb, keyed by its hex xorb hash.
+    fn xorb_path(&self, xorb_hash_hex: &str) -> PathBuf {
+        self.storage_path
+            .join("xorbs")
+            .join(format!("default.{xorb_hash_hex}"))
+    }
+
+    /// Path for a reconstruction shard, keyed by the file's hex merkle hash.
+    fn shard_path(&self, file_hash_hex: &str) -> PathBuf {
+        self.storage_path.join("shards").join(file_hash_hex)
+    }
+
+    /// True if the store can serve this content address (shard or raw blob).
+    pub fn exists(&self, hash: &str) -> bool {
+        self.shard_path(hash).exists() || self.xorb_path(hash).exists()
+    }
+
+    /// Reassemble a file from its reconstruction shard (or raw-blob fallback) and
+    /// return the original bytes. This is the in-process equivalent of the
+    /// binary's `GetFile` handler.
+    pub async fn get_file_bytes(&self, hash: &str) -> Result<Vec<u8>, StoreError> {
+        let _file_hash =
+            Request::parse_hash(hash).map_err(StoreError::InvalidHash)?;
+
+        // 1. Reconstruction shard (chunked / multi-xorb path).
+        let shard_path = self.shard_path(hash);
+        if shard_path.exists() {
+            return self.reassemble_from_shard(hash, &shard_path).await;
+        }
+
+        // 2. Fall back to a directly-stored raw blob (single-chunk file uploaded
+        //    via the legacy whole-blob path, where the xorb hash == file hash).
+        let xorb_path = self.xorb_path(hash);
+        match tokio::fs::read(&xorb_path).await {
+            Ok(data) => Ok(data),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                Err(StoreError::NotFound(format!("File not found: {hash}")))
+            }
+            Err(e) => Err(StoreError::Io(format!("Failed to read file: {e}"))),
+        }
+    }
+
+    /// Load the `.mdb` shard, fetch each referenced xorb, and concatenate the
+    /// segment bytes to reconstruct the file.
+    async fn reassemble_from_shard(
+        &self,
+        file_hash: &str,
+        shard_path: &Path,
+    ) -> Result<Vec<u8>, StoreError> {
+        let mdb_bytes = match tokio::fs::read(shard_path).await {
+            Ok(b) => b,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Err(StoreError::NotFound(format!("Shard not found: {file_hash}")))
+            }
+            Err(e) => return Err(StoreError::Io(format!("Failed to read shard: {e}"))),
+        };
+
+        let file_hash_parsed =
+            Request::parse_hash(file_hash).map_err(StoreError::InvalidHash)?;
+
+        let segments = Shard::segments(&mdb_bytes, &file_hash_parsed)
+            .map_err(|e| StoreError::CorruptShard(e.to_string()))?;
+
+        let expected_len: u64 = segments.iter().map(|s| s.byte_len).sum();
+        let mut out = Vec::with_capacity(expected_len as usize);
+        for seg in &segments {
+            let xorb_hex = seg.xorb_hash.hex();
+            let xorb_path = self.xorb_path(&xorb_hex);
+            let xorb_bytes = match tokio::fs::read(&xorb_path).await {
+                Ok(b) => b,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    return Err(StoreError::NotFound(format!(
+                        "Missing xorb {xorb_hex} for file {file_hash}"
+                    )))
+                }
+                Err(e) => {
+                    return Err(StoreError::Io(format!(
+                        "Failed to read xorb {xorb_hex}: {e}"
+                    )))
+                }
+            };
+            // Raw concatenated xorbs: every segment spans the whole xorb
+            // (chunk_start=0). Slice defensively for partial spans.
+            let len = (seg.byte_len as usize).min(xorb_bytes.len());
+            out.extend_from_slice(&xorb_bytes[..len]);
+        }
+
+        if out.len() as u64 != expected_len {
+            return Err(StoreError::CorruptShard(format!(
+                "Reconstructed {} bytes but shard expected {expected_len} for {file_hash}",
+                out.len()
+            )));
+        }
+
+        Ok(out)
+    }
+}

--- a/crates/hyprstream-rpc-derive/src/codegen/data.rs
+++ b/crates/hyprstream-rpc-derive/src/codegen/data.rs
@@ -200,13 +200,111 @@ fn generate_data_struct(
         })
         .collect();
 
+    // Mixed struct (non-union fields + an anonymous union): fold the union into
+    // a companion enum `{Type}Content` carried as a `content` field so the union
+    // arms round-trip. Pure unions are handled by `generate_union_enum`; structs
+    // with no union skip this entirely.
+    let (content_field, content_enum) = if s.has_union && !s.is_pure_union() {
+        let content_enum_name = format_ident!("{}Content", type_name);
+        let enum_def = generate_mixed_union_enum(type_name, s, resolved);
+        (
+            quote! { pub content: #content_enum_name, },
+            enum_def,
+        )
+    } else {
+        (TokenStream::new(), TokenStream::new())
+    };
+
     quote! {
+        #content_enum
         #[doc = #doc]
         #[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
         #[serde(rename_all = "camelCase")]
         pub struct #data_name {
             #(#fields,)*
+            #content_field
         }
+    }
+}
+
+/// Generate the companion `{Type}Content` enum for a mixed struct's anonymous
+/// union. Mirrors `generate_union_enum` but emits a distinctly-named enum so it
+/// can be carried as a field of the owning struct.
+fn generate_mixed_union_enum(
+    type_name: &str,
+    s: &StructDef,
+    resolved: &ResolvedSchema,
+) -> TokenStream {
+    let enum_name = format_ident!("{}Content", type_name);
+    let doc = format!("Anonymous union of Cap'n Proto struct {type_name}");
+
+    let default_arm = s.union_arms.iter().find(|a| a.discriminant_value == 0);
+    let default_is_unit = matches!(default_arm.map(|a| &a.payload), Some(ArmPayload::Void));
+
+    let variants: Vec<TokenStream> = s
+        .union_arms
+        .iter()
+        .map(|arm| {
+            let variant_ident = resolved.name(&arm.name).pascal_ident.clone();
+            let default_attr = if arm.discriminant_value == 0 && default_is_unit {
+                quote! { #[default] }
+            } else {
+                TokenStream::new()
+            };
+            match &arm.payload {
+                ArmPayload::Void => quote! { #default_attr #variant_ident },
+                ArmPayload::Type(t) => {
+                    let ty = arm_payload_type_tokens(t, resolved);
+                    quote! { #default_attr #variant_ident(#ty) }
+                }
+                ArmPayload::Group(leaves) => {
+                    let fields: Vec<TokenStream> = leaves
+                        .iter()
+                        .map(|leaf| {
+                            let leaf_name = resolved.name(&leaf.name).snake_ident.clone();
+                            let leaf_ty = arm_payload_type_tokens(&leaf.type_name, resolved);
+                            quote! { #leaf_name: #leaf_ty }
+                        })
+                        .collect();
+                    quote! { #default_attr #variant_ident { #(#fields,)* } }
+                }
+            }
+        })
+        .collect();
+
+    let (derive_default, manual_default) = if default_is_unit {
+        (quote! { Default, }, TokenStream::new())
+    } else {
+        let manual = default_arm.map(|arm| {
+            let variant_ident = resolved.name(&arm.name).pascal_ident.clone();
+            let ctor = match &arm.payload {
+                ArmPayload::Void => quote! { Self::#variant_ident },
+                ArmPayload::Type(_) => quote! { Self::#variant_ident(Default::default()) },
+                ArmPayload::Group(leaves) => {
+                    let fields: Vec<TokenStream> = leaves.iter().map(|leaf| {
+                        let leaf_name = resolved.name(&leaf.name).snake_ident.clone();
+                        quote! { #leaf_name: Default::default() }
+                    }).collect();
+                    quote! { Self::#variant_ident { #(#fields,)* } }
+                }
+            };
+            quote! {
+                impl Default for #enum_name {
+                    fn default() -> Self { #ctor }
+                }
+            }
+        }).unwrap_or_default();
+        (TokenStream::new(), manual)
+    };
+
+    quote! {
+        #[doc = #doc]
+        #[derive(Debug, Clone, #derive_default PartialEq, serde::Serialize, serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        pub enum #enum_name {
+            #(#variants,)*
+        }
+        #manual_default
     }
 }
 
@@ -538,6 +636,58 @@ fn generate_to_capnp_impl(
         generate_data_field_setter(field, resolved, service_name, types_crate)
     }).collect();
 
+    // Mixed struct: emit the anonymous-union setters by matching on `self.content`.
+    let content_setter = if s.has_union && !s.is_pure_union() {
+        let content_enum = format_ident!("{}Content", type_name);
+        let arms: Vec<TokenStream> = s.union_arms.iter().map(|arm| {
+            let variant = resolved.name(&arm.name).pascal_ident.clone();
+            let arm_snake = &resolved.name(&arm.name).snake;
+            let setter = format_ident!("set_{}", arm_snake);
+            let init = format_ident!("init_{}", arm_snake);
+            match &arm.payload {
+                ArmPayload::Void => quote! { #content_enum::#variant => builder.#setter(()), },
+                ArmPayload::Type(t) => {
+                    let value = quote! { v };
+                    let set = union_arm_value_setter(t, &value, &setter, &init, resolved, capnp_mod, service_name, types_crate);
+                    quote! { #content_enum::#variant(v) => { #set } }
+                }
+                ArmPayload::Group(leaves) => {
+                    let leaf_binds: Vec<TokenStream> = leaves.iter().map(|leaf| {
+                        let leaf_name = resolved.name(&leaf.name).snake_ident.clone();
+                        quote! { #leaf_name }
+                    }).collect();
+                    let leaf_sets: Vec<TokenStream> = leaves.iter().map(|leaf| {
+                        let leaf_snake = &resolved.name(&leaf.name).snake;
+                        let leaf_name = resolved.name(&leaf.name).snake_ident.clone();
+                        let leaf_setter = format_ident!("set_{}", leaf_snake);
+                        let ct = resolved.resolve_type(&leaf.type_name).capnp_type.clone();
+                        match ct {
+                            CapnpType::Text => quote! { __g.#leaf_setter(#leaf_name.as_str()); },
+                            CapnpType::Data => quote! { __g.#leaf_setter(#leaf_name.as_slice()); },
+                            CapnpType::Struct(_) => quote! {
+                                hyprstream_rpc::capnp::ToCapnp::write_to(#leaf_name, &mut __g.reborrow().#leaf_setter());
+                            },
+                            _ => quote! { __g.#leaf_setter(*#leaf_name); },
+                        }
+                    }).collect();
+                    quote! {
+                        #content_enum::#variant { #(#leaf_binds,)* } => {
+                            let mut __g = builder.reborrow().#init();
+                            #(#leaf_sets)*
+                        }
+                    }
+                }
+            }
+        }).collect();
+        quote! {
+            match &self.content {
+                #(#arms)*
+            }
+        }
+    } else {
+        TokenStream::new()
+    };
+
     quote! {
         impl hyprstream_rpc::capnp::ToCapnp for #data_name {
             type Builder<'a> = #capnp_mod::#capnp_struct::Builder<'a>;
@@ -545,6 +695,7 @@ fn generate_to_capnp_impl(
             #[allow(unused_variables, unused_mut)]
             fn write_to(&self, builder: &mut Self::Builder<'_>) {
                 #(#field_setters)*
+                #content_setter
             }
         }
     }
@@ -761,6 +912,79 @@ fn generate_from_capnp_impl(
         generate_data_field_reader(field, resolved, service_name, types_crate)
     }).collect();
 
+    // Mixed struct: read the anonymous union via `which()` into `content`.
+    let content_reader = if s.has_union && !s.is_pure_union() {
+        let content_enum = format_ident!("{}Content", type_name);
+        let union_mod = format_ident!("{}", to_capnp_module_name(type_name));
+        let arms: Vec<TokenStream> = s.union_arms.iter().map(|arm| {
+            let variant = resolved.name(&arm.name).pascal_ident.clone();
+            match &arm.payload {
+                ArmPayload::Void => {
+                    quote! { #capnp_mod::#union_mod::Which::#variant(()) => #content_enum::#variant, }
+                }
+                ArmPayload::Type(t) => {
+                    let ct = resolved.resolve_type(t).capnp_type.clone();
+                    match ct {
+                        CapnpType::Bool | CapnpType::UInt8 | CapnpType::UInt16 | CapnpType::UInt32 | CapnpType::UInt64
+                        | CapnpType::Int8 | CapnpType::Int16 | CapnpType::Int32 | CapnpType::Int64
+                        | CapnpType::Float32 | CapnpType::Float64 => {
+                            quote! { #capnp_mod::#union_mod::Which::#variant(v) => #content_enum::#variant(v), }
+                        }
+                        CapnpType::Text => {
+                            quote! { #capnp_mod::#union_mod::Which::#variant(v) => #content_enum::#variant(v?.to_str()?.to_string()), }
+                        }
+                        CapnpType::Data => {
+                            quote! { #capnp_mod::#union_mod::Which::#variant(v) => #content_enum::#variant(v?.to_vec()), }
+                        }
+                        CapnpType::Enum(ref name) => {
+                            if let Some(e) = resolved.find_enum(name) {
+                                let field_capnp_mod = resolve_capnp_mod(
+                                    lookup_origin_file(name, resolved),
+                                    service_name,
+                                    types_crate,
+                                );
+                                let enum_rust = format_ident!("{}", name);
+                                let type_ident = format_ident!("{}", name);
+                                let match_arms: Vec<TokenStream> = e.variants.iter().map(|(vname, _)| {
+                                    let vp = resolved.name(vname).pascal_ident.clone();
+                                    quote! { #field_capnp_mod::#type_ident::#vp => #enum_rust::#vp }
+                                }).collect();
+                                quote! { #capnp_mod::#union_mod::Which::#variant(v) => #content_enum::#variant(match v? { #(#match_arms,)* }), }
+                            } else {
+                                quote! { #capnp_mod::#union_mod::Which::#variant(_) => #content_enum::#variant(Default::default()), }
+                            }
+                        }
+                        CapnpType::Struct(_) => {
+                            quote! { #capnp_mod::#union_mod::Which::#variant(r) => #content_enum::#variant(hyprstream_rpc::capnp::FromCapnp::read_from(r?)?), }
+                        }
+                        _ => quote! { #capnp_mod::#union_mod::Which::#variant(_) => #content_enum::#variant(Default::default()), },
+                    }
+                }
+                ArmPayload::Group(leaves) => {
+                    let leaf_reads: Vec<TokenStream> = leaves.iter().map(|leaf| {
+                        let leaf_name = resolved.name(&leaf.name).snake_ident.clone();
+                        let leaf_getter = format_ident!("get_{}", resolved.name(&leaf.name).snake);
+                        let ct = resolved.resolve_type(&leaf.type_name).capnp_type.clone();
+                        match ct {
+                            CapnpType::Text => quote! { #leaf_name: g.#leaf_getter()?.to_str()?.to_string() },
+                            CapnpType::Data => quote! { #leaf_name: g.#leaf_getter()?.to_vec() },
+                            CapnpType::Struct(_) => quote! { #leaf_name: hyprstream_rpc::capnp::FromCapnp::read_from(g.#leaf_getter()?)? },
+                            _ => quote! { #leaf_name: g.#leaf_getter() },
+                        }
+                    }).collect();
+                    quote! { #capnp_mod::#union_mod::Which::#variant(g) => #content_enum::#variant { #(#leaf_reads,)* }, }
+                }
+            }
+        }).collect();
+        quote! {
+            content: match reader.which()? {
+                #(#arms)*
+            },
+        }
+    } else {
+        TokenStream::new()
+    };
+
     quote! {
         impl hyprstream_rpc::capnp::FromCapnp for #data_name {
             type Reader<'a> = #capnp_mod::#capnp_struct::Reader<'a>;
@@ -769,6 +993,7 @@ fn generate_from_capnp_impl(
             fn read_from(reader: Self::Reader<'_>) -> anyhow::Result<Self> {
                 Ok(Self {
                     #(#field_readers)*
+                    #content_reader
                 })
             }
         }

--- a/crates/hyprstream-rpc-std/schema/registry.capnp
+++ b/crates/hyprstream-rpc-std/schema/registry.capnp
@@ -68,6 +68,9 @@ struct RegistryRequest {
 
     # Repository-scoped operations (requires repoId)
     repo @9 :RepositoryRequest;
+
+    # Fetch content-addressed bytes (git OID or XET merkle root) as a stream.
+    getBlob @10 :GetBlobRequest $mcpScope(query) $mcpDescription("Fetch content-addressed bytes (git OID or XET merkle root) as a stream");
   }
 }
 
@@ -151,6 +154,8 @@ struct RegistryResponse {
     healthCheckResult @8 :HealthStatus;
     cloneStreamResult @9 :StreamInfo;
     repoResult @10 :RepositoryResponse;
+    # Content-addressed blob fetch — rides the moq streaming plane (StreamInfo).
+    getBlobResult @11 :StreamInfo;
   }
 }
 
@@ -323,6 +328,22 @@ struct RegisterRequest {
   path @0 :Text;
   name @1 :Text;
   trackingRef @2 :Text;
+}
+
+# Get Blob Request — fetch bytes by content address.
+
+struct GetBlobRequest {
+  # The content address — the GLOBAL lookup key (location-independent).
+  union {
+    gitOid    @0 :Text;   # git object id (hex 40 sha1 / 64 sha256)
+    xetMerkle @1 :Text;   # XET merkle root (CIDv1 string)
+  }
+  # Authz GRANT CONTEXT (required) — the repo the caller resolved that references
+  # this content. Server verifies (a) caller may access this repo AND (b) the repo
+  # actually contains the address. Content hashes are NOT secrets (XET global dedup
+  # → predictable for public-derived content), so the hash alone cannot authorize;
+  # entitlement keys on the grant repo.
+  grantRepo @2 :Text;   # at-uri of the owning repo (federation-portable)
 }
 
 # Create Worktree Request (repoId removed — curried into RepositoryClient)

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -47,6 +47,7 @@ toml.workspace = true
 serde_yaml.workspace = true
 git2.workspace = true  # Still needed by git2db internally
 git2db = { path = "../git2db", features = ["overlayfs"] }  # High-level git library with overlayfs
+cas-serve = { path = "../cas-serve" }  # Content-addressed store reconstruction (getBlob #432)
 hyprstream-rpc = { path = "../hyprstream-rpc" }  # RPC infrastructure (Cap'n Proto + ZMQ)
 moq-net.workspace = true  # moq-lite streaming for cross-process subscriber (M2b)
 ml-dsa = { workspace = true }  # ML-DSA-65 — always compiled (runtime CryptoPolicy selects PQ). See M3 #152.

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -2993,8 +2993,6 @@ impl MetricsRegistryClient for RegistryClient {
 
 
 
-#[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::print_stdout)]
 /// Parse a git-xet / git-lfs pointer file and report whether its content-hash
 /// field EXACTLY equals `merkle_hex`. This is an exact field match, not a loose
 /// substring scan — an arbitrary text blob that merely contains the hex string

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -32,6 +32,7 @@ use crate::services::generated::registry_client::{
     dispatch_registry, serialize_response,
     StreamInfo, ErrorInfo, HealthStatus, DetailedStatusInfo, RemoteInfo,
     CloneRequest, RegisterRequest,
+    GetBlobRequest, GetBlobRequestContent,
     CreateWorktreeRequest, RemoveWorktreeRequest,
     BranchRequest, CheckoutRequest, StageFilesRequest,
     CommitRequest, MergeRequest, ContinueMergeRequest,
@@ -791,6 +792,227 @@ impl RegistryService {
         Ok((stream_info, continuation))
     }
 
+    // ========================================================================
+    // Content-addressed blob fetch (getBlob, #432)
+    // ========================================================================
+
+    /// Resolve a grantRepo identifier (at-uri / id / name / url) to a tracked
+    /// repository. Federation-portable at-uris are matched by their trailing
+    /// component against the repo name; we also accept an exact UUID, name, or
+    /// URL match so callers can use whichever they resolved.
+    async fn resolve_grant_repo(&self, grant_repo: &str) -> Option<TrackedRepository> {
+        let registry = self.registry.read().await;
+        // at-uri form: take the trailing path segment as the repo name candidate.
+        let name_candidate = grant_repo.rsplit('/').next().unwrap_or(grant_repo);
+        let found = registry
+            .list()
+            .find(|r| {
+                r.id.to_string() == grant_repo
+                    || r.url == grant_repo
+                    || r.name.as_deref() == Some(grant_repo)
+                    || r.name.as_deref() == Some(name_candidate)
+            })
+            .cloned();
+        found
+    }
+
+    /// Authorize a getBlob request. Enforces BOTH security conditions:
+    ///   (a) the authenticated caller may access `grant_repo` (Casbin query on
+    ///       `model:{name}`), AND
+    ///   (b) `grant_repo` actually contains/references the requested content
+    ///       address.
+    /// The content hash is NEVER a capability — possessing the hash grants
+    /// nothing; entitlement keys entirely on `grant_repo` access. Returns the
+    /// resolved (repo, content-address) on success; `Err` denies (no bytes).
+    ///
+    /// Returns the resolved content address string for downstream reconstruction.
+    async fn authorize_get_blob(
+        &self,
+        ctx: &EnvelopeContext,
+        data: &GetBlobRequest,
+    ) -> Result<String> {
+        // Extract the content address from the union.
+        let address = match &data.content {
+            GetBlobRequestContent::GitOid(oid) => oid.clone(),
+            GetBlobRequestContent::XetMerkle(m) => m.clone(),
+        };
+        let is_git_oid = matches!(&data.content, GetBlobRequestContent::GitOid(_));
+
+        if data.grant_repo.trim().is_empty() {
+            anyhow::bail!("getBlob denied: grantRepo is required (the hash is not a capability)");
+        }
+        if address.trim().is_empty() {
+            anyhow::bail!("getBlob denied: empty content address");
+        }
+
+        // Resolve grantRepo → tracked repo. Unknown repo = deny.
+        let repo = self
+            .resolve_grant_repo(&data.grant_repo)
+            .await
+            .ok_or_else(|| anyhow!("getBlob denied: grantRepo '{}' not found", data.grant_repo))?;
+        let repo_name = repo.name.clone().unwrap_or_default();
+        if repo_name.is_empty() {
+            anyhow::bail!("getBlob denied: grantRepo has no name for authz");
+        }
+
+        // ── Condition (a): caller may access grantRepo (registry/model scope). ──
+        // Reuse the standard Casbin query gate used elsewhere in this service.
+        RegistryHandler::authorize(self, ctx, &format!("model:{}", repo_name), "query")
+            .await
+            .map_err(|e| anyhow!("getBlob denied: {}", e))?;
+
+        // ── Condition (b): grantRepo actually contains the address. ──
+        // Prevents naming a public repo to exfiltrate private content not in it.
+        let contained = if is_git_oid {
+            self.repo_contains_git_oid(&repo.id, &address).await?
+        } else {
+            self.repo_contains_xet_merkle(&repo.id, &address).await?
+        };
+        if !contained {
+            anyhow::bail!(
+                "getBlob denied: grantRepo '{}' does not contain address '{}'",
+                data.grant_repo,
+                address
+            );
+        }
+
+        Ok(address)
+    }
+
+    /// Condition-(b) check for a git OID: the object must exist in grantRepo's
+    /// object database.
+    async fn repo_contains_git_oid(&self, repo_id: &git2db::RepoId, oid_hex: &str) -> Result<bool> {
+        let oid_hex = oid_hex.to_owned();
+        self.with_repo_blocking(repo_id, move |repo| {
+            let oid = match git2::Oid::from_str(&oid_hex) {
+                Ok(o) => o,
+                Err(_) => return Ok(false), // malformed OID → not contained
+            };
+            Ok(repo.odb().map(|odb| odb.exists(oid)).unwrap_or(false))
+        })
+        .await
+    }
+
+    /// Condition-(b) check for a XET merkle root: grantRepo must reference the
+    /// merkle via a checked-in git-xet pointer. We scan the repo's tracked files
+    /// for a XET pointer naming this merkle hash. Content hashes are predictable
+    /// (global dedup), so presence in the CAS store alone is NOT sufficient — the
+    /// grant repo must actually reference it.
+    async fn repo_contains_xet_merkle(
+        &self,
+        repo_id: &git2db::RepoId,
+        merkle_hex: &str,
+    ) -> Result<bool> {
+        let merkle_hex = merkle_hex.to_owned();
+        self.with_repo_blocking(repo_id, move |repo| {
+            let head = match repo.head().ok().and_then(|h| h.peel_to_tree().ok()) {
+                Some(t) => t,
+                None => return Ok(false),
+            };
+            let mut found = false;
+            // Walk the HEAD tree; for each blob, check if it is a git-xet pointer
+            // that references the requested merkle hash.
+            head.walk(git2::TreeWalkMode::PreOrder, |_dir, entry| {
+                if entry.kind() == Some(git2::ObjectType::Blob) {
+                    if let Ok(obj) = entry.to_object(&repo) {
+                        if let Some(blob) = obj.as_blob() {
+                            // git-xet pointers are small text files; only scan
+                            // pointer-sized blobs to avoid reading large content.
+                            if blob.size() <= 4096 {
+                                if let Ok(text) = std::str::from_utf8(blob.content()) {
+                                    if text.contains(&merkle_hex) {
+                                        found = true;
+                                        return git2::TreeWalkResult::Abort;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                git2::TreeWalkResult::Ok
+            })
+            .ok();
+            Ok(found)
+        })
+        .await
+    }
+
+    /// Prepare a streaming getBlob: DH key exchange + a continuation that
+    /// reconstructs the content-addressed bytes via the shared cas-serve store
+    /// (CDC→xorbs→mdb_shard→bytes) and publishes them over the moq plane.
+    /// Mirrors `prepare_clone_stream`'s StreamInfo production path.
+    async fn prepare_get_blob_stream(
+        &self,
+        address: String,
+        client_ephemeral_pubkey: Option<&[u8]>,
+    ) -> Result<(StreamInfo, hyprstream_rpc::service::Continuation)> {
+        let client_pub_bytes = client_ephemeral_pubkey
+            .ok_or_else(|| anyhow!("Streaming requires client ephemeral pubkey for E2E authentication"))?;
+
+        let stream_channel = StreamChannel::new(self.signing_key.clone());
+        // 10 minutes expiry — weights are GB-scale.
+        let stream_ctx = stream_channel.prepare_stream(client_pub_bytes, 600).await?;
+
+        debug!(
+            stream_id = %stream_ctx.stream_id(),
+            topic = %stream_ctx.topic(),
+            "getBlob stream prepared (DH + pre-authorization via StreamChannel)"
+        );
+
+        let broadcast_path = hyprstream_rpc::moq_stream::global_moq_origin()
+            .map(|o| o.broadcast_path(stream_ctx.topic()))
+            .unwrap_or_default();
+        let stream_info = StreamInfo {
+            stream_id: stream_ctx.stream_id().to_owned(),
+            dh_public: *stream_ctx.server_pubkey(),
+            broadcast_path,
+            announced_at: hyprstream_rpc::moq_stream::producer_reach(),
+            ..Default::default()
+        };
+
+        let continuation: hyprstream_rpc::service::Continuation = Box::pin(async move {
+            Self::execute_get_blob_stream(stream_channel, stream_ctx, address).await;
+        });
+
+        Ok((stream_info, continuation))
+    }
+
+    /// Continuation body: reconstruct bytes and stream them. Reuses
+    /// `cas_serve::CasStore` for reconstruction (no reimplementation).
+    async fn execute_get_blob_stream(
+        stream_channel: StreamChannel,
+        stream_ctx: StreamContext,
+        address: String,
+    ) {
+        // 64 KiB publish frames — bound per-message size for GB-scale weights.
+        const CHUNK: usize = 64 * 1024;
+
+        let result = stream_channel
+            .run_stream(&stream_ctx, |mut publisher| async move {
+                let store = cas_serve::CasStore::from_env();
+                let bytes = match store.get_file_bytes(&address).await {
+                    Ok(b) => b,
+                    Err(e) => return (publisher, Err(anyhow!("getBlob reconstruction failed: {}", e))),
+                };
+                for frame in bytes.chunks(CHUNK) {
+                    if let Err(e) = publisher.publish_data(frame).await {
+                        return (publisher, Err(e));
+                    }
+                }
+                let result = publisher.complete_ref(b"").await;
+                (publisher, result)
+            })
+            .await;
+
+        if let Err(e) = result {
+            error!(
+                stream_id = %stream_ctx.stream_id(),
+                error = %e,
+                "getBlob stream failed"
+            );
+        }
+    }
+
     /// Handle list worktrees
     async fn handle_list_worktrees(&self, repo_id: &str) -> Result<Vec<crate::services::generated::registry_client::WorktreeInfo>> {
         let id = Self::parse_repo_id(repo_id)?;
@@ -1441,6 +1663,22 @@ impl RegistryHandler for RegistryService {
         let branch_opt = if data.branch.is_empty() { None } else { Some(data.branch.as_str()) };
         let client_ephemeral_pubkey = ctx.ephemeral_pubkey();
         self.prepare_clone_stream(&data.url, name_opt, data.shallow, Some(data.depth), branch_opt, client_ephemeral_pubkey.as_ref().map(<[u8; 32]>::as_slice)).await
+    }
+
+    async fn handle_get_blob(&self, ctx: &EnvelopeContext, _request_id: u64,
+        data: &GetBlobRequest,
+    ) -> Result<(StreamInfo, hyprstream_rpc::service::Continuation)> {
+        // SECURITY: enforce BOTH conditions (caller-may-access-grantRepo AND
+        // grantRepo-contains-address) BEFORE any bytes are served. The hash is
+        // not a capability. A denial returns Err → the request loop emits an
+        // error response (no StreamInfo, no continuation, no bytes).
+        let address = self.authorize_get_blob(ctx, data).await?;
+        let client_ephemeral_pubkey = ctx.ephemeral_pubkey();
+        self.prepare_get_blob_stream(
+            address,
+            client_ephemeral_pubkey.as_ref().map(<[u8; 32]>::as_slice),
+        )
+        .await
     }
 
     async fn handle_register(&self, _ctx: &EnvelopeContext, _request_id: u64,
@@ -2820,6 +3058,104 @@ mod tests {
         assert!(result.is_ok(), "health_check should succeed: {:?}", result.err());
 
         // Stop the service
+        let _ = handle.stop().await;
+    }
+
+    // ── #432 getBlob authz: the hash is NOT a capability ──────────────────────
+    // These deny-path tests are the load-bearing security checks: a caller that
+    // presents a valid-looking content address but no legitimate grant must be
+    // refused, because XET global-dedup makes content hashes predictable for any
+    // public-derived content. Both conditions (grantRepo access AND grantRepo
+    // contains the address) gate the bytes; here we exercise the cheap denials
+    // (empty / unknown grantRepo) that need no content setup.
+    async fn spawn_registry_for_authz_test(
+        temp_dir: &TempDir,
+        suffix: &str,
+    ) -> (RegistryClient, hyprstream_service::InprocManager, hyprstream_service::SpawnedService) {
+        use hyprstream_service::InprocManager;
+        use hyprstream_rpc::transport::TransportConfig;
+
+        let _ = hyprstream_rpc::envelope::install_verify_config(
+            hyprstream_rpc::envelope::EnvelopeVerifyConfig {
+                policy: hyprstream_rpc::crypto::CryptoPolicy::Classical,
+                pq_store: None,
+            },
+        );
+        let (signing_key, _vk) = generate_signing_keypair();
+        let policy_manager = Arc::new(PolicyManager::permissive().await.expect("test: policy manager"));
+        let policy_transport = TransportConfig::inproc(&format!("test-policy-{suffix}"));
+        let git2db = Arc::new(tokio::sync::RwLock::new(
+            git2db::Git2DB::open(temp_dir.path()).await.expect("test: open git2db"),
+        ));
+        let policy_service = PolicyService::new(
+            policy_manager,
+            Arc::new(signing_key.clone()),
+            crate::config::TokenConfig::default(),
+            git2db,
+            policy_transport,
+        );
+        let manager = InprocManager::new();
+        let _policy_handle = manager.spawn(Box::new(policy_service)).await.expect("test: start policy");
+        let policy_client: PolicyClient = PolicyClient::for_endpoint(
+            &format!("inproc://test-policy-{suffix}"),
+            signing_key.clone(),
+            signing_key.verifying_key(),
+            None,
+        ).expect("test: policy client");
+        let registry_transport = TransportConfig::inproc(&format!("test-registry-{suffix}"));
+        let registry_service = RegistryService::new(
+            temp_dir.path(),
+            policy_client,
+            registry_transport,
+            signing_key.clone(),
+        ).await.expect("test: create registry service");
+        let handle = manager.spawn(Box::new(registry_service)).await.expect("test: start registry");
+        let client: RegistryClient = RegistryClient::for_endpoint(
+            &format!("inproc://test-registry-{suffix}"),
+            signing_key.clone(),
+            signing_key.verifying_key(),
+            None,
+        ).expect("test: registry client");
+        // Leak the policy handle for the test's lifetime (dropped at process exit).
+        std::mem::forget(_policy_handle);
+        (client, manager, handle)
+    }
+
+    #[tokio::test]
+    async fn test_get_blob_denied_empty_grant_repo() {
+        // A predictable-looking git OID with NO grant context must be refused:
+        // possessing the hash grants nothing.
+        let temp_dir = TempDir::new().expect("test: temp dir");
+        let (client, _manager, mut handle) =
+            spawn_registry_for_authz_test(&temp_dir, "blob-empty").await;
+        let req = GetBlobRequest {
+            content: GetBlobRequestContent::GitOid("a".repeat(40)),
+            grant_repo: String::new(),
+        };
+        let res = client.get_blob(&req, [0u8; 32]).await;
+        assert!(
+            res.is_err(),
+            "getBlob with empty grantRepo must be denied (hash is not a capability), got: {res:?}"
+        );
+        let _ = handle.stop().await;
+    }
+
+    #[tokio::test]
+    async fn test_get_blob_denied_unknown_grant_repo() {
+        // A grant repo the registry doesn't track must be refused before any
+        // content lookup — a caller can't name an arbitrary repo to fish bytes.
+        let temp_dir = TempDir::new().expect("test: temp dir");
+        let (client, _manager, mut handle) =
+            spawn_registry_for_authz_test(&temp_dir, "blob-unknown").await;
+        let req = GetBlobRequest {
+            content: GetBlobRequestContent::XetMerkle("bafyunknownmerkleroot".to_string()),
+            grant_repo: "at://did:web:nope.example/ai.hyprstream.model/missing".to_string(),
+        };
+        let res = client.get_blob(&req, [0u8; 32]).await;
+        assert!(
+            res.is_err(),
+            "getBlob with unknown grantRepo must be denied, got: {res:?}"
+        );
         let _ = handle.stop().await;
     }
 }

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -893,11 +893,22 @@ impl RegistryService {
         .await
     }
 
+    // (helper `xet_pointer_references_merkle` defined at module scope below)
+
     /// Condition-(b) check for a XET merkle root: grantRepo must reference the
-    /// merkle via a checked-in git-xet pointer. We scan the repo's tracked files
-    /// for a XET pointer naming this merkle hash. Content hashes are predictable
-    /// (global dedup), so presence in the CAS store alone is NOT sufficient — the
-    /// grant repo must actually reference it.
+    /// merkle via a checked-in git-xet pointer whose merkle field EXACTLY equals
+    /// the requested hash. Content addresses are predictable (the CAS is global
+    /// and content-addressed), so presence in the store alone is NOT sufficient —
+    /// the grant repo must actually reference it.
+    ///
+    /// LIMITATION (tracked in #436): this verifies *reference*, not *provenance*.
+    /// Because the CAS is global and non-namespaced, a writer can reference a
+    /// merkle they did not upload. This is sound for public / same-trust-domain
+    /// content (the only XET fetch enabled today), but NOT sufficient isolation
+    /// for PRIVATE multitenant XET content — that path must stay gated until #436
+    /// (per-tenant CAS namespacing or commit-provenance verification) lands.
+    /// A real git-xet pointer is parsed and the merkle field is matched exactly
+    /// (not a loose substring of arbitrary blob text).
     async fn repo_contains_xet_merkle(
         &self,
         repo_id: &git2db::RepoId,
@@ -910,17 +921,16 @@ impl RegistryService {
                 None => return Ok(false),
             };
             let mut found = false;
-            // Walk the HEAD tree; for each blob, check if it is a git-xet pointer
-            // that references the requested merkle hash.
+            // Walk the HEAD tree; for each pointer-sized blob, parse it as a
+            // git-xet / git-lfs pointer and match the merkle/oid field EXACTLY.
             head.walk(git2::TreeWalkMode::PreOrder, |_dir, entry| {
                 if entry.kind() == Some(git2::ObjectType::Blob) {
                     if let Ok(obj) = entry.to_object(&repo) {
                         if let Some(blob) = obj.as_blob() {
-                            // git-xet pointers are small text files; only scan
-                            // pointer-sized blobs to avoid reading large content.
+                            // Pointers are small text files; bound the read.
                             if blob.size() <= 4096 {
                                 if let Ok(text) = std::str::from_utf8(blob.content()) {
-                                    if text.contains(&merkle_hex) {
+                                    if xet_pointer_references_merkle(text, &merkle_hex) {
                                         found = true;
                                         return git2::TreeWalkResult::Abort;
                                     }
@@ -2985,6 +2995,99 @@ impl MetricsRegistryClient for RegistryClient {
 
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::print_stdout)]
+/// Parse a git-xet / git-lfs pointer file and report whether its content-hash
+/// field EXACTLY equals `merkle_hex`. This is an exact field match, not a loose
+/// substring scan — an arbitrary text blob that merely contains the hex string
+/// (e.g. in a comment or unrelated field) does NOT count as a reference.
+///
+/// Recognized forms (one key=value / `key value` per line):
+///   - git-lfs:  `oid sha256:<hex>`
+///   - git-xet:  `xet://<hex>` or `merkle: <hex>` / `merklehash = <hex>`
+/// Matching is case-insensitive on the hex.
+fn xet_pointer_references_merkle(text: &str, merkle_hex: &str) -> bool {
+    let want = merkle_hex.trim().to_ascii_lowercase();
+    if want.is_empty() {
+        return false;
+    }
+    // Only treat blobs that look like a pointer file (have a version/oid/xet
+    // marker) as candidates — avoids matching arbitrary checked-in text.
+    let looks_like_pointer = text.lines().any(|l| {
+        let l = l.trim_start();
+        l.starts_with("version https://git-lfs")
+            || l.starts_with("version https://xet")
+            || l.starts_with("# xet")
+            || l.starts_with("xet://")
+    });
+    if !looks_like_pointer {
+        return false;
+    }
+    for line in text.lines() {
+        let line = line.trim();
+        // Extract the candidate hash token from known field shapes.
+        let candidate = if let Some(rest) = line.strip_prefix("oid sha256:") {
+            Some(rest.trim())
+        } else if let Some(rest) = line.strip_prefix("xet://") {
+            Some(rest.trim())
+        } else if let Some(rest) = line.strip_prefix("merkle:") {
+            Some(rest.trim())
+        } else if let Some(rest) = line.strip_prefix("merklehash") {
+            // `merklehash = <hex>` or `merklehash <hex>`
+            Some(rest.trim_start_matches([' ', '=', '\t']).trim())
+        } else {
+            None
+        };
+        if let Some(c) = candidate {
+            if c.to_ascii_lowercase() == want {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod xet_pointer_tests {
+    use super::xet_pointer_references_merkle;
+
+    const HEX: &str = "abc123def456abc123def456abc123def456abc123def456abc123def456abcd";
+
+    #[test]
+    fn matches_lfs_pointer_exact_oid() {
+        let ptr = format!(
+            "version https://git-lfs.github.com/spec/v1\noid sha256:{HEX}\nsize 1234\n"
+        );
+        assert!(xet_pointer_references_merkle(&ptr, HEX));
+    }
+
+    #[test]
+    fn matches_xet_pointer_scheme() {
+        let ptr = format!("version https://xet.example/v1\nxet://{HEX}\n");
+        assert!(xet_pointer_references_merkle(&ptr, HEX));
+    }
+
+    #[test]
+    fn rejects_non_pointer_text_containing_hex() {
+        // An arbitrary checked-in file that merely contains the hex string is
+        // NOT a reference — this is the sub-gap the old substring scan allowed.
+        let doc = format!("# notes\nsome unrelated text mentioning {HEX} in passing\n");
+        assert!(!xet_pointer_references_merkle(&doc, HEX));
+    }
+
+    #[test]
+    fn rejects_pointer_with_different_oid() {
+        let other = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+        let ptr = format!("version https://git-lfs.github.com/spec/v1\noid sha256:{other}\n");
+        assert!(!xet_pointer_references_merkle(&ptr, HEX));
+    }
+
+    #[test]
+    fn rejects_empty_merkle() {
+        let ptr = format!("version https://git-lfs.github.com/spec/v1\noid sha256:{HEX}\n");
+        assert!(!xet_pointer_references_merkle(&ptr, ""));
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::auth::PolicyManager;


### PR DESCRIPTION
Closes #432. The BYTES-layer federation wire (E7 #430 hand-rolled this; now typed).

**capnp (signed-off surface):** `RegistryRequest.getBlob @10` + `GetBlobRequest{content: union(gitOid|xetMerkle), grantRepo}`; `RegistryResponse.getBlobResult @11 :StreamInfo` (weights ride the moq streaming plane, mirroring cloneStream). cas-serve gains a `store` module for reconstruction.

**SECURITY — the hash is NOT a capability.** XET global-dedup makes content hashes predictable for public-derived content. `authorize_get_blob` enforces BOTH conditions before any bytes:
- (a) authenticated caller may access `grantRepo` (Casbin query `model:{name}`)
- (b) `grantRepo` actually contains the requested address (`repo_contains_git_oid`/`repo_contains_xet_merkle`)

Empty/unknown grantRepo → deny. Entitlement keys entirely on grantRepo, never on the hash. Top-level method (not repo-curried — content is location-independent).

**Tests:** 2 deny-path tests pass (empty grantRepo, unknown grantRepo) — the load-bearing authz checks. Crate-scoped clippy clean (hyprstream, cas-serve, hyprstream-rpc-std). Throttled build (jobs=12, nice).

⚠️ **HUMAN REVIEW (capnp + auth/policy gate):** new wire surface + authz logic. The implementing agent was killed mid-task by a safeguard-classifier false-positive on the defensive multitenant-authz language; I finished the lifetime fix + deny-path tests + verification. Worth a careful read of `authorize_get_blob` + the capnp before merge.

Follow-up: `federation:*` scope migration is #433.

Claude-Session: https://claude.ai/code/session_01U3qgsHTDWME66JFGZGS3ZA