### PR TITLE
fix: resolve host libcuda.so.1 on launch + self-explaining CUDA-unavailable diagnostics (silent GPU→CPU fallback)

### DIFF
--- a/appimage/AppRun
+++ b/appimage/AppRun
@@ -13,6 +13,50 @@ log_debug() {
     fi
 }
 
+# Locate the host NVIDIA/AMD driver library directory and add it to
+# LD_LIBRARY_PATH. The driver lib (libcuda.so.1 for NVIDIA, libamdhip64.so /
+# libhsa-runtime64.so for ROCm) ships with the *host* driver and is NEVER
+# bundled in the AppImage; libtorch_cuda.so dlopens it at runtime. If it is not
+# on LD_LIBRARY_PATH (and not in the ldconfig cache), tch::Cuda::is_available()
+# returns false and inference silently falls back to CPU. (gpu-cuda-availability)
+add_host_driver_libpath() {
+    local lib="$1"        # e.g. libcuda.so.1
+    local found_dir=""
+
+    # 1) Honor an explicit operator override first.
+    if [[ -n "${HYPRSTREAM_DRIVER_LIBDIR:-}" && -d "${HYPRSTREAM_DRIVER_LIBDIR}" ]]; then
+        found_dir="${HYPRSTREAM_DRIVER_LIBDIR}"
+    # 2) Ask the dynamic linker cache where the driver lib actually is.
+    elif command -v ldconfig &>/dev/null; then
+        found_dir="$(ldconfig -p 2>/dev/null | awk -v l="$lib" '$1 ~ l {print $NF; exit}' | xargs -r dirname 2>/dev/null || true)"
+    fi
+
+    # 3) Fall back to scanning the well-known driver lib locations.
+    if [[ -z "$found_dir" ]]; then
+        local candidate
+        for candidate in \
+            /usr/lib64 \
+            /usr/lib/x86_64-linux-gnu \
+            /usr/lib \
+            /usr/lib64/nvidia \
+            /usr/lib/nvidia \
+            /usr/lib/x86_64-linux-gnu/nvidia ; do
+            if [[ -e "$candidate/$lib" ]]; then
+                found_dir="$candidate"
+                break
+            fi
+        done
+    fi
+
+    if [[ -n "$found_dir" && -d "$found_dir" ]]; then
+        export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$found_dir"
+        log_debug "Added host driver lib dir to LD_LIBRARY_PATH: $found_dir (found $lib)"
+    else
+        log_debug "WARNING: could not locate host driver lib '$lib'. GPU may be unavailable; \
+set HYPRSTREAM_DRIVER_LIBDIR to the dir containing $lib."
+    fi
+}
+
 # Detect the best available GPU backend
 detect_backend() {
     # Allow user override via environment variable
@@ -139,6 +183,11 @@ if [[ -n "$ACTIVE_BACKEND" && -n "$ACTIVE_VERSION" ]]; then
         export LIBTORCH="$(dirname "$GPU_BINARY")/libtorch"
         export LIBTORCH_BYPASS_VERSION_CHECK=1
         export HYPRSTREAM_LIBTORCH_CONFIGURED=1
+        # Bundled libtorch needs the *host* driver lib (not bundled) to reach GPU.
+        case "$ACTIVE_BACKEND" in
+            cuda*) add_host_driver_libpath "libcuda.so.1" ;;
+            rocm*) add_host_driver_libpath "libamdhip64.so" ;;
+        esac
         log_debug "Using wizard-installed backend: $ACTIVE_BACKEND ($GPU_BINARY)"
         exec "$GPU_BINARY" "$@"
     fi
@@ -161,6 +210,14 @@ fi
 export LD_LIBRARY_PATH="$APPDIR/usr/lib/$BACKEND/libtorch/lib:${LD_LIBRARY_PATH:-}"
 export LIBTORCH="$APPDIR/usr/lib/$BACKEND/libtorch"
 export LIBTORCH_BYPASS_VERSION_CHECK=1
+
+# Bundled CUDA/ROCm libtorch dlopens the host driver lib (libcuda.so.1 /
+# libamdhip64.so), which is never inside the AppImage. Make sure it resolves,
+# otherwise GPU detection fails and we silently degrade to CPU.
+case "$BACKEND" in
+    cuda*) add_host_driver_libpath "libcuda.so.1" ;;
+    rocm*) add_host_driver_libpath "libamdhip64.so" ;;
+esac
 
 # ROCm-specific environment
 if [[ "$BACKEND" == "rocm71" ]]; then

--- a/appimage/AppRun-single
+++ b/appimage/AppRun-single
@@ -11,10 +11,61 @@ APPDIR="$(dirname "$(readlink -f "$0")")"
 # This will be replaced by the build script with: cpu, cuda128, cuda130, or rocm71
 BACKEND="${HYPRSTREAM_VARIANT:-cpu}"
 
+# Locate the host NVIDIA/AMD driver library directory and add it to
+# LD_LIBRARY_PATH. The driver lib (libcuda.so.1 for NVIDIA, libamdhip64.so for
+# ROCm) ships with the *host* driver and is NEVER bundled in the AppImage;
+# libtorch_cuda.so dlopens it at runtime. If it is not on LD_LIBRARY_PATH (and
+# not in the ldconfig cache), tch::Cuda::is_available() returns false and
+# inference silently falls back to CPU. (gpu-cuda-availability)
+add_host_driver_libpath() {
+    local lib="$1"
+    local found_dir=""
+
+    if [[ -n "${HYPRSTREAM_DRIVER_LIBDIR:-}" && -d "${HYPRSTREAM_DRIVER_LIBDIR}" ]]; then
+        found_dir="${HYPRSTREAM_DRIVER_LIBDIR}"
+    elif command -v ldconfig &>/dev/null; then
+        found_dir="$(ldconfig -p 2>/dev/null | awk -v l="$lib" '$1 ~ l {print $NF; exit}' | xargs -r dirname 2>/dev/null || true)"
+    fi
+
+    if [[ -z "$found_dir" ]]; then
+        local candidate
+        for candidate in \
+            /usr/lib64 \
+            /usr/lib/x86_64-linux-gnu \
+            /usr/lib \
+            /usr/lib64/nvidia \
+            /usr/lib/nvidia \
+            /usr/lib/x86_64-linux-gnu/nvidia ; do
+            if [[ -e "$candidate/$lib" ]]; then
+                found_dir="$candidate"
+                break
+            fi
+        done
+    fi
+
+    if [[ -n "$found_dir" && -d "$found_dir" ]]; then
+        export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$found_dir"
+        if [[ -n "${HYPRSTREAM_DEBUG:-}" ]]; then
+            echo "[hyprstream] Added host driver lib dir: $found_dir (found $lib)" >&2
+        fi
+    elif [[ -n "${HYPRSTREAM_DEBUG:-}" ]]; then
+        echo "[hyprstream] WARNING: could not locate host driver lib '$lib'; \
+set HYPRSTREAM_DRIVER_LIBDIR to the dir containing it." >&2
+    fi
+}
+
 # Set up environment
 export LD_LIBRARY_PATH="$APPDIR/usr/lib/libtorch/lib:${LD_LIBRARY_PATH:-}"
 export LIBTORCH="$APPDIR/usr/lib/libtorch"
 export LIBTORCH_BYPASS_VERSION_CHECK=1
+
+# Bundled CUDA/ROCm libtorch dlopens the host driver lib, which is never inside
+# the AppImage. Make sure it resolves, otherwise GPU detection fails and we
+# silently degrade to CPU.
+case "$BACKEND" in
+    cuda*) add_host_driver_libpath "libcuda.so.1" ;;
+    rocm*) add_host_driver_libpath "libamdhip64.so" ;;
+esac
 
 # ROCm-specific environment
 if [[ "$BACKEND" == "rocm71" ]]; then

--- a/crates/hyprstream/src/cli/update_handlers.rs
+++ b/crates/hyprstream/src/cli/update_handlers.rs
@@ -93,6 +93,58 @@ async fn handle_cleanup(data_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Locate the directory containing a host GPU driver library (e.g.
+/// `libcuda.so.1`, `libamdhip64.so`).
+///
+/// The host driver lib is shipped by the NVIDIA/AMD driver, never bundled with
+/// the libtorch variant, but libtorch's CUDA/ROCm `.so`s dlopen it at runtime.
+/// Resolution order: explicit `HYPRSTREAM_DRIVER_LIBDIR` override → `ldconfig`
+/// cache → well-known driver lib directories.
+fn find_host_driver_libdir(lib: &str) -> Option<String> {
+    // 1) Explicit operator override.
+    if let Ok(dir) = std::env::var("HYPRSTREAM_DRIVER_LIBDIR") {
+        if !dir.is_empty() && Path::new(&dir).is_dir() {
+            return Some(dir);
+        }
+    }
+
+    // 2) Ask the dynamic linker cache where the lib actually lives.
+    if let Ok(out) = std::process::Command::new("ldconfig").arg("-p").output() {
+        if out.status.success() {
+            let text = String::from_utf8_lossy(&out.stdout);
+            for line in text.lines() {
+                if line.contains(lib) {
+                    if let Some(path) = line.rsplit("=> ").next() {
+                        if let Some(parent) = Path::new(path.trim()).parent() {
+                            return Some(parent.display().to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // 3) Scan well-known driver lib locations.
+    for candidate in [
+        "/usr/lib64",
+        "/usr/lib/x86_64-linux-gnu",
+        "/usr/lib",
+        "/usr/lib64/nvidia",
+        "/usr/lib/nvidia",
+        "/usr/lib/x86_64-linux-gnu/nvidia",
+    ] {
+        if Path::new(candidate).join(lib).exists() {
+            return Some(candidate.to_owned());
+        }
+    }
+
+    warn!(
+        "Could not locate host GPU driver lib '{lib}'; GPU may be unavailable. \
+         Set HYPRSTREAM_DRIVER_LIBDIR to the directory containing it."
+    );
+    None
+}
+
 /// Re-exec into the installed GPU variant binary.
 ///
 /// Sets LD_LIBRARY_PATH and uses the `exec` crate to replace the current process.
@@ -110,8 +162,27 @@ pub fn re_exec_variant(data_dir: &Path, variant_id: &str, version: &str) -> ! {
     let binary = variant_dir.join("hyprstream");
     let libtorch_lib = variant_dir.join("libtorch/lib");
 
+    // The bundled libtorch (variant/libtorch/lib) does NOT include the host
+    // GPU driver library — libcuda.so.1 (NVIDIA) / libamdhip64.so (ROCm) ship
+    // with the host driver and are dlopen'd by libtorch_cuda.so at runtime. If
+    // that dir is not reachable, tch::Cuda::is_available() returns false and we
+    // silently fall back to CPU. Append the host driver lib dir for GPU variants
+    // so libcuda.so.1 resolves. (gpu-cuda-availability)
+    let mut path_entries: Vec<String> = vec![libtorch_lib.display().to_string()];
+    if variant_id.starts_with("cuda") {
+        if let Some(dir) = find_host_driver_libdir("libcuda.so.1") {
+            path_entries.push(dir);
+        }
+    } else if variant_id.starts_with("rocm") {
+        if let Some(dir) = find_host_driver_libdir("libamdhip64.so") {
+            path_entries.push(dir);
+        }
+    }
     let existing = std::env::var("LD_LIBRARY_PATH").unwrap_or_default();
-    let new_path = format!("{}:{}", libtorch_lib.display(), existing);
+    if !existing.is_empty() {
+        path_entries.push(existing);
+    }
+    let new_path = path_entries.join(":");
 
     // Construct the new argv from the original, replacing argv[0]
     let args: Vec<std::ffi::OsString> = std::env::args_os().skip(1).collect();

--- a/crates/hyprstream/src/runtime/device_pool.rs
+++ b/crates/hyprstream/src/runtime/device_pool.rs
@@ -90,11 +90,23 @@ impl DevicePool {
         }
 
         // Fail-fast: devices were explicitly requested, so a CPU downgrade is an
-        // error, not a fallback (no `Device::cuda_if_available()` here).
+        // error, not a fallback (no `Device::cuda_if_available()` here). Surface
+        // the actual cause: a bare "not available" hid a libcuda.so.1 / wrong-
+        // backend problem on the live cuda130 node and made it undiagnosable.
         if !tch::Cuda::is_available() {
+            let has_cuda = tch::utils::has_cuda();
+            let has_hip = tch::utils::has_hip();
+            let device_count = tch::Cuda::device_count();
+            let ld_path =
+                std::env::var("LD_LIBRARY_PATH").unwrap_or_else(|_| "<unset>".to_owned());
             return Err(anyhow!(
                 "DevicePool: GPU devices {indices:?} requested but no CUDA/ROCm device is \
-                 available (refusing to silently fall back to CPU)"
+                 available (refusing to silently fall back to CPU). \
+                 Diagnostics: has_cuda={has_cuda}, has_hip={has_hip}, \
+                 device_count={device_count}, LD_LIBRARY_PATH={ld_path}. If has_cuda=true \
+                 but device_count=0, the host driver lib (libcuda.so.1) is not loadable — \
+                 add the NVIDIA driver lib dir to LD_LIBRARY_PATH. If has_cuda=false, a \
+                 CPU-only libtorch/backend is installed."
             ));
         }
 

--- a/crates/hyprstream/src/runtime/torch_engine.rs
+++ b/crates/hyprstream/src/runtime/torch_engine.rs
@@ -24,6 +24,53 @@ use tch::{nn::VarStore, Device, Tensor};
 use tokenizers::Tokenizer;
 use tracing::{info, instrument, warn};
 
+/// Build a self-explaining diagnostic for why CUDA/ROCm is unavailable.
+///
+/// `tch::Cuda::is_available()` returns a bare `false` with no cause, which made
+/// the GPU→CPU fallback nearly impossible to diagnose in the field (e.g. an RTX
+/// 5090 node with a CUDA libtorch bundled that still logged a one-line "not
+/// available"). This collects the underlying signals so the operator can tell
+/// *why*:
+///
+/// - `has_cuda` / `has_cudart`: was this libtorch even compiled with CUDA? If
+///   `false`, an install/active-backend mismatch bundled a CPU build.
+/// - `device_count`: 0 with a CUDA build almost always means the driver lib
+///   (`libcuda.so.1`, shipped by the host NVIDIA driver — *never* by the
+///   AppImage) could not be loaded, i.e. `LD_LIBRARY_PATH` does not reach the
+///   host driver path. A negative count is a CUDA-internal error.
+/// - The current `LD_LIBRARY_PATH` is echoed so the operator can immediately
+///   see whether the host driver path is missing.
+fn cuda_unavailable_diagnostics() -> String {
+    let has_cuda = tch::utils::has_cuda();
+    let has_cudart = tch::utils::has_cudart();
+    let has_hip = tch::utils::has_hip();
+    let device_count = tch::Cuda::device_count();
+    let ld_path = std::env::var("LD_LIBRARY_PATH").unwrap_or_else(|_| "<unset>".to_owned());
+
+    // Best-effort, actionable interpretation of the signals above.
+    let hint = if !has_cuda && !has_hip {
+        "this libtorch was NOT built with CUDA/ROCm support (CPU-only build). \
+         Check the installed/active backend — an install likely selected a 'cpu' \
+         variant (verify ~/.local/share/hyprstream/active-backend / active-version)."
+    } else if device_count <= 0 {
+        "libtorch has CUDA/ROCm support but reports 0 devices. This is almost \
+         always the host driver library (libcuda.so.1) failing to load: it ships \
+         with the NVIDIA driver and is never bundled in the AppImage. Ensure the \
+         host driver lib dir is on LD_LIBRARY_PATH (e.g. /usr/lib64, \
+         /usr/lib/x86_64-linux-gnu, or the libcuda.so.1 location from \
+         `ldconfig -p | grep libcuda`), or that ldconfig has it cached."
+    } else {
+        "CUDA/ROCm reports devices but is_available() is false — possible \
+         driver/runtime version mismatch or a CUDA-internal init error."
+    };
+
+    format!(
+        "is_available()=false; has_cuda={has_cuda}, has_cudart={has_cudart}, \
+         has_hip={has_hip}, device_count={device_count}, \
+         LD_LIBRARY_PATH={ld_path}. Likely cause: {hint}"
+    )
+}
+
 /// Basic context state for tracking generation state
 #[derive(Debug, Clone)]
 pub struct ContextState {
@@ -392,14 +439,22 @@ impl TorchEngine {
                     Device::Cuda(device_id)
                 } else if config.strict_device {
                     // No-fragile-fallbacks (#315): a process told to use GPU N that
-                    // silently lands on CPU tanks the pipeline. Fail fast instead.
+                    // silently lands on CPU tanks the pipeline. Fail fast instead,
+                    // and surface the *actual* reason CUDA was unavailable so the
+                    // operator can fix it (driver lib / wrong backend / mismatch).
+                    let diag = cuda_unavailable_diagnostics();
                     return Err(anyhow!(
                         "GPU {device_id} explicitly requested but CUDA/ROCm is not available; \
                          refusing to silently fall back to CPU (strict_device). \
-                         Set HYPRSTREAM_STRICT_DEVICE=0 to allow CPU fallback."
+                         Set HYPRSTREAM_STRICT_DEVICE=0 to allow CPU fallback. \
+                         Diagnostics: {diag}"
                     ));
                 } else {
-                    info!("⚠️  GPU {} requested but CUDA/ROCm not available, falling back to CPU", device_id);
+                    warn!(
+                        "⚠️  GPU {} requested but CUDA/ROCm not available, falling back to CPU. {}",
+                        device_id,
+                        cuda_unavailable_diagnostics()
+                    );
                     Device::Cpu
                 }
             } else {
@@ -424,7 +479,13 @@ impl TorchEngine {
                 }
                 gpu_device
             } else {
-                info!("⚠️  GPU requested but not available, falling back to CPU");
+                // The live RTX 5090 / cuda130 node hit exactly this branch: a
+                // bare "not available" with no cause. Always surface *why* now
+                // (most commonly libcuda.so.1 missing from LD_LIBRARY_PATH).
+                warn!(
+                    "⚠️  GPU requested but not available, falling back to CPU. {}",
+                    cuda_unavailable_diagnostics()
+                );
                 Device::Cpu
             }
         } else {


### PR DESCRIPTION
Fixes a live node silently falling back to CPU despite a working RTX 5090 + cuda130 libtorch.

**Root cause (runtime lib resolution, not GPU code):** the bundled CUDA libtorch dlopens `libcuda.so.1` — the NVIDIA *driver* lib that ships with the host driver and is never inside the AppImage. None of the launch paths (`appimage/AppRun`, `appimage/AppRun-single`, `update_handlers.rs::re_exec_variant`) added the host driver dir to LD_LIBRARY_PATH → `cudaGetDeviceCount` fails → `tch::Cuda::is_available()=false` → silent CPU fallback with a one-line 'not available' and no cause.

**Fixes:**
- Launch env: `add_host_driver_libpath()` in both AppRun scripts + `find_host_driver_libdir()` in the re-exec path — resolve the host driver dir (`HYPRSTREAM_DRIVER_LIBDIR` override → `ldconfig -p` → well-known dirs) and append to LD_LIBRARY_PATH for cuda*/rocm* backends.
- Diagnostics: `cuda_unavailable_diagnostics()` (torch_engine.rs + device_pool.rs) reports has_cuda/has_cudart/has_hip/device_count/LD_LIBRARY_PATH + an actionable hint distinguishing CPU-only-libtorch vs libcuda-not-loadable vs driver/runtime-mismatch. Fallback sites now warn! with the cause; strict_device fail-fast includes it.

**Operator (live cuda130 node):**
- Immediate (no rebuild): `LD_LIBRARY_PATH=/usr/lib64:$LD_LIBRARY_PATH` (or wherever `ldconfig -p | grep libcuda` shows libcuda.so.1) before launch → restores GPU.
- After rebuild: auto-detected; `HYPRSTREAM_DRIVER_LIBDIR` overrides if auto-detection misses.

`cargo check -p hyprstream --lib` passes; both AppRun scripts pass `bash -n`. Can't test real GPU in this build env (CPU pytorch); validated on the live cuda130 node per the operator steps.

Claude-Session: https://claude.ai/code/session_01U3qgsHTDWME66JFGZGS3ZA