### PR TITLE
fix(aaa): service JWTs carry local issuer + offline local-CA resolution (unblocks #441 fail-closed startup)

### DIFF
--- a/crates/hyprstream-rpc/src/auth/key_source.rs
+++ b/crates/hyprstream-rpc/src/auth/key_source.rs
@@ -302,6 +302,18 @@ pub struct JwksKeySource {
     /// Negative cache TTL (unknown kids cached as missing for this duration)
     negative_ttl: std::time::Duration,
     ml_dsa_vks: Arc<std::sync::RwLock<Vec<crate::crypto::pq::MlDsaVerifyingKey>>>,
+    /// Authoritative local CA verifying key (on-disk, from PolicyService).
+    ///
+    /// Lets local-issuer JWTs — notably service-to-service WIT JWTs signed by
+    /// the CA over the local IPC plane — verify WITHOUT a network round-trip to
+    /// `/oauth/jwks`. The HTTP JWKS endpoint is not guaranteed to be up during
+    /// service startup (and #441 makes registration a hard precondition), so
+    /// depending on it for local service auth is a startup-ordering fail.
+    /// Consulted only for local issuers (`is_local`), and only when the JOSE
+    /// `kid` matches this key's JWK thumbprint — so it never overrides a
+    /// rotated/JWKS-published key, and is irrelevant to federated issuers.
+    local_ca_key: Option<VerifyingKey>,
+    local_ca_kid: Option<String>,
 }
 
 impl JwksKeySource {
@@ -323,12 +335,24 @@ impl JwksKeySource {
             soft_ttl: std::time::Duration::from_secs(300),
             negative_ttl: std::time::Duration::from_secs(5),
             ml_dsa_vks: Arc::new(std::sync::RwLock::new(Vec::new())),
+            local_ca_key: None,
+            local_ca_kid: None,
         }
     }
 
     /// Set the shared ML-DSA-65 verifying key list for PQ-hybrid JWT verification.
     pub fn with_ml_dsa_verifying_keys(mut self, vks: Arc<std::sync::RwLock<Vec<crate::crypto::pq::MlDsaVerifyingKey>>>) -> Self {
         self.ml_dsa_vks = vks;
+        self
+    }
+
+    /// Provide the authoritative local CA verifying key for offline resolution
+    /// of local-issuer (service) JWTs. See the `local_ca_key` field docs.
+    pub fn with_local_ca_key(mut self, ca_vk: VerifyingKey) -> Self {
+        self.local_ca_kid = Some(crate::auth::jwt::jwk_thumbprint(
+            &crate::auth::jwt::JwkThumbprintInput::Ed25519 { x: ca_vk.as_bytes() },
+        ));
+        self.local_ca_key = Some(ca_vk);
         self
     }
 
@@ -439,6 +463,20 @@ impl JwtKeySource for JwksKeySource {
 
         // Try cache first
         if let Some(kid_str) = kid {
+            // Authoritative local CA key (offline): for a LOCAL issuer whose
+            // `kid` matches the on-disk CA key thumbprint, resolve without any
+            // network fetch. This is the service-to-service WIT JWT path; the
+            // HTTP /oauth/jwks endpoint may not be up yet during startup, and
+            // #441 makes service-key registration a hard precondition, so this
+            // resolution must not depend on it. Never overrides a JWKS-published
+            // (rotated) key because it's keyed on the exact CA thumbprint.
+            if self.is_local(issuer) {
+                if let (Some(ca_kid), Some(ca_key)) = (self.local_ca_kid.as_deref(), self.local_ca_key) {
+                    if ca_kid == kid_str {
+                        return Ok(ca_key);
+                    }
+                }
+            }
             {
                 let cache = self.cache.read().await;
                 if let Some(entry) = cache.get(kid_str) {
@@ -536,6 +574,62 @@ mod tests {
         let key = ks.get_key("http://localhost:9080", None).await?;
         assert_eq!(key, test_ca_key());
         Ok(())
+    }
+
+    /// #441/AAA: a JwksKeySource with a local CA key resolves a local-issuer
+    /// service JWT OFFLINE (no JWKS fetch) when the JOSE `kid` matches the CA
+    /// thumbprint — the service-to-service auth path must not depend on the HTTP
+    /// /oauth/jwks endpoint being up during startup.
+    #[tokio::test]
+    async fn jwks_source_resolves_local_ca_key_offline() -> anyhow::Result<()> {
+        // A fetcher that always fails — proves resolution does NOT touch it.
+        let fetcher: JwksFetcher = std::sync::Arc::new(|_url: String| {
+            Box::pin(async move { anyhow::bail!("network must not be used for local CA resolution") })
+        });
+        let ca_sk = SigningKey::from_bytes(&[7u8; 32]);
+        let ca_vk = ca_sk.verifying_key();
+        let ca_kid = crate::auth::jwt::kid_for_key(&ca_sk);
+
+        let ks = JwksKeySource::new(
+            JwksMode::Isolated { jwks_url: "http://127.0.0.1:1/oauth/jwks".to_owned() },
+            "http://localhost:9080".to_owned(),
+            fetcher,
+        )
+        .with_local_ca_key(ca_vk);
+
+        // Local issuer + matching kid -> resolved offline to the CA key.
+        let key = ks.get_key("http://localhost:9080", Some(&ca_kid)).await?;
+        assert_eq!(key, ca_vk);
+
+        // Empty issuer is also local (in-process plane) -> same offline resolution.
+        let key = ks.get_key("", Some(&ca_kid)).await?;
+        assert_eq!(key, ca_vk);
+
+        Ok(())
+    }
+
+    /// The offline CA fallback must NOT fire for a non-matching kid (forces a
+    /// JWKS fetch, which fails here) nor for a non-local issuer — it is scoped
+    /// strictly to local-issuer tokens signed by the exact CA key.
+    #[tokio::test]
+    async fn jwks_source_local_ca_key_scoped_to_matching_kid_and_local_issuer() {
+        let fetcher: JwksFetcher = std::sync::Arc::new(|_url: String| {
+            Box::pin(async move { anyhow::bail!("no network") })
+        });
+        let ca_vk = SigningKey::from_bytes(&[7u8; 32]).verifying_key();
+        let ks = JwksKeySource::new(
+            JwksMode::Isolated { jwks_url: "http://127.0.0.1:1/oauth/jwks".to_owned() },
+            "http://localhost:9080".to_owned(),
+            fetcher,
+        )
+        .with_local_ca_key(ca_vk);
+
+        // Local issuer but a different kid -> CA fallback does NOT fire; the
+        // JWKS fetch is attempted and fails -> error (not the CA key).
+        assert!(ks.get_key("http://localhost:9080", Some("some-other-kid")).await.is_err());
+
+        // Non-local issuer is untrusted in isolated mode regardless of kid.
+        assert!(ks.get_key("https://evil.example.com", Some("some-other-kid")).await.is_err());
     }
 
     #[tokio::test]

--- a/crates/hyprstream-service/src/service/factory.rs
+++ b/crates/hyprstream-service/src/service/factory.rs
@@ -570,6 +570,9 @@ impl ServiceContext {
                 fetcher.clone(),
             );
             let source = source.with_ml_dsa_verifying_keys(self.ml_dsa_verifying_keys.clone());
+            // Authoritative local CA key for offline service-JWT resolution
+            // (no dependency on the HTTP /oauth/jwks endpoint at startup).
+            let source = source.with_local_ca_key(self.jwt_verifying_key());
             std::sync::Arc::new(source)
         } else {
             let source = hyprstream_rpc::auth::ClusterKeySource::new(

--- a/crates/hyprstream/src/auth/service_jwt.rs
+++ b/crates/hyprstream/src/auth/service_jwt.rs
@@ -23,6 +23,7 @@ pub fn issue_or_load_service_jwt(
     service_name: &str,
     ca_jwt_key: &SigningKey,
     service_vk: &VerifyingKey,
+    local_issuer_url: &str,
     now: i64,
 ) -> Result<String> {
     let existing = super::identity_store::load_service_jwt(credentials_dir, service_name)?;
@@ -30,7 +31,10 @@ pub fn issue_or_load_service_jwt(
         None => true,
         Some(ref jwt) => {
             let exp = decode_jwt_exp(jwt).unwrap_or(0);
-            (exp - now) <= RENEW_THRESHOLD
+            // Re-issue if near expiry OR if the persisted token has no `iss`
+            // (older bootstraps minted empty-issuer service JWTs, which the
+            // #328 gate rejects on the IPC/AnySigner plane — see below).
+            (exp - now) <= RENEW_THRESHOLD || decode_jwt_iss(jwt).is_none_or(|s| s.is_empty())
         }
     };
 
@@ -41,12 +45,26 @@ pub fn issue_or_load_service_jwt(
     }
 
     let expiry = now + NEW_EXPIRY_TTL;
-    let claims = hyprstream_rpc::auth::Claims::new(
+    // Set `iss` to the local issuer URL — NOT empty.
+    //
+    // Service JWTs are presented service->service over the local IPC (UDS)
+    // plane, which the dispatch core verifies as `AnySigner`. The #328 gate
+    // rejects an EMPTY `iss` from any `AnySigner` (non-`is_local_caller`)
+    // caller, so an empty-issuer service JWT is rejected on exactly the plane
+    // it is meant for, and (with #441's fail-closed registration) the service
+    // refuses to start. Stamping the local issuer URL makes the token pass
+    // `ClusterKeySource::is_trusted` (issuer == local_issuer_url -> CA key)
+    // WITHOUT weakening #328: a networked peer still cannot present an
+    // empty-`iss` token, and a non-local issuer is still rejected.
+    let mut claims = hyprstream_rpc::auth::Claims::new(
         format!("service:{service_name}"),
         now,
         expiry,
     )
     .with_cnf_jwk(service_vk.as_bytes());
+    if !local_issuer_url.is_empty() {
+        claims = claims.with_issuer(local_issuer_url.to_owned());
+    }
 
     Ok(hyprstream_rpc::auth::jwt::encode_service_jwt(&claims, ca_jwt_key))
 }
@@ -56,4 +74,67 @@ fn decode_jwt_exp(jwt: &str) -> Option<i64> {
     let payload = URL_SAFE_NO_PAD.decode(payload_b64).ok()?;
     let value: serde_json::Value = serde_json::from_slice(&payload).ok()?;
     value.get("exp")?.as_i64()
+}
+
+/// Decode the `iss` claim without verifying the signature. Used only to detect
+/// legacy empty-issuer service JWTs that must be re-minted (see the #328 note
+/// in `issue_or_load_service_jwt`). Returns `None` if the token is malformed or
+/// carries no `iss` claim.
+fn decode_jwt_iss(jwt: &str) -> Option<String> {
+    let payload_b64 = jwt.split('.').nth(1)?;
+    let payload = URL_SAFE_NO_PAD.decode(payload_b64).ok()?;
+    let value: serde_json::Value = serde_json::from_slice(&payload).ok()?;
+    value.get("iss")?.as_str().map(ToOwned::to_owned)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+
+    /// A freshly issued service JWT carries the local issuer URL (NOT empty).
+    /// Empty `iss` is rejected on the IPC/AnySigner plane by the #328 gate, so
+    /// stamping the local issuer is what lets service-to-service registration
+    /// succeed fail-closed (with #441).
+    #[test]
+    fn issued_service_jwt_carries_local_issuer() {
+        let dir = tempfile::tempdir().unwrap();
+        let ca = SigningKey::from_bytes(&[3u8; 32]);
+        let svc = SigningKey::from_bytes(&[4u8; 32]);
+        let issuer = "http://localhost:6791";
+
+        let jwt = issue_or_load_service_jwt(
+            dir.path(), "model", &ca, &svc.verifying_key(), issuer, 1_000_000,
+        )
+        .unwrap();
+
+        assert_eq!(decode_jwt_iss(&jwt).as_deref(), Some(issuer));
+    }
+
+    /// A persisted legacy empty-issuer token is re-minted with the issuer set,
+    /// rather than being returned as-is — so an upgrade heals the #328 mismatch
+    /// on the next wizard/bootstrap run without manual intervention.
+    #[test]
+    fn empty_issuer_legacy_jwt_is_reissued_with_issuer() {
+        let dir = tempfile::tempdir().unwrap();
+        let ca = SigningKey::from_bytes(&[3u8; 32]);
+        let svc = SigningKey::from_bytes(&[4u8; 32]);
+
+        // Mint a legacy token with NO issuer and a far-future expiry, persist it.
+        let now = 1_000_000;
+        let legacy_claims =
+            hyprstream_rpc::auth::Claims::new("service:model".to_owned(), now, now + 30 * 86_400)
+                .with_cnf_jwk(svc.verifying_key().as_bytes());
+        let legacy = hyprstream_rpc::auth::jwt::encode_service_jwt(&legacy_claims, &ca);
+        assert!(decode_jwt_iss(&legacy).is_none_or(|s| s.is_empty()));
+        super::super::identity_store::write_service_jwt(dir.path(), "model", &legacy).unwrap();
+
+        // Even though it is far from expiry, the empty-iss legacy token forces a
+        // re-issue carrying the issuer.
+        let jwt = issue_or_load_service_jwt(
+            dir.path(), "model", &ca, &svc.verifying_key(), "http://localhost:6791", now,
+        )
+        .unwrap();
+        assert_eq!(decode_jwt_iss(&jwt).as_deref(), Some("http://localhost:6791"));
+    }
 }

--- a/crates/hyprstream/src/cli/bootstrap_manager.rs
+++ b/crates/hyprstream/src/cli/bootstrap_manager.rs
@@ -644,6 +644,14 @@ async fn do_bootstrap(
                     .join("credentials")
             });
 
+        // Local issuer URL stamped into service JWTs so they verify on the
+        // local IPC/AnySigner plane without tripping the #328 empty-`iss` gate.
+        // Must match the issuer the services' ClusterKeySource trusts
+        // (oauth.issuer_url(), the same value `cluster_key_source()` uses).
+        let local_issuer_url = crate::config::HyprConfig::load()
+            .map(|c| c.oauth.issuer_url())
+            .unwrap_or_default();
+
         // CA JWT signing key (purpose-derived for JWT signature separation).
         // Derived BEFORE writing ca-pubkey so we can store the JWT key's verifying key,
         // not the root key's verifying key. Services verify JWTs with the derived key.
@@ -692,7 +700,7 @@ async fn do_bootstrap(
             let service_vk = service_key.verifying_key();
 
             let jwt = crate::auth::service_jwt::issue_or_load_service_jwt(
-                &credentials_dir, service_name, &ca_jwt_key, &service_vk, now,
+                &credentials_dir, service_name, &ca_jwt_key, &service_vk, &local_issuer_url, now,
             )?;
             identity_store::write_service_jwt(&credentials_dir, service_name, &jwt)?;
 


### PR DESCRIPTION
Stacked on #444 (#441). A real fail-interaction the AAA e2e loop discovered: #441's fail-closed registration exposed a `--standalone` daemon startup crash (`registerServiceKey ... empty JWT issuer is only accepted from in-process callers`).

Two minimal, #328-preserving fixes:
- Service JWTs now carry the local issuer URL (not empty `iss`).
- `JwksKeySource` resolves local-issuer service JWTs **offline** against the on-disk CA key (scoped to the exact CA `kid`), so service-to-service auth doesn't depend on the HTTP `/oauth/jwks` endpoint being up at boot.

With unit tests; crate-scoped cargo test green. This is what makes #441's fail-closed registration actually start cleanly standalone — validated as part of the AAA e2e harness (auth allow+deny, authz allow+deny, service-key no-mismatch all pass).

⚠️ HUMAN REVIEW (auth/policy gate). Discovered + fixed autonomously during AAA validation.

Claude-Session: https://claude.ai/code/session_01U3qgsHTDWME66JFGZGS3ZA