### PR TITLE
fix(#446): resolve service-to-service IPC callers as service:<name> via authoritative key binding (not anonymous)

### DIFF
--- a/crates/hyprstream-rpc/src/auth/key_source.rs
+++ b/crates/hyprstream-rpc/src/auth/key_source.rs
@@ -302,6 +302,18 @@ pub struct JwksKeySource {
     /// Negative cache TTL (unknown kids cached as missing for this duration)
     negative_ttl: std::time::Duration,
     ml_dsa_vks: Arc<std::sync::RwLock<Vec<crate::crypto::pq::MlDsaVerifyingKey>>>,
+    /// Authoritative local CA verifying key (on-disk, from PolicyService).
+    ///
+    /// Lets local-issuer JWTs — notably service-to-service WIT JWTs signed by
+    /// the CA over the local IPC plane — verify WITHOUT a network round-trip to
+    /// `/oauth/jwks`. The HTTP JWKS endpoint is not guaranteed to be up during
+    /// service startup (and #441 makes registration a hard precondition), so
+    /// depending on it for local service auth is a startup-ordering fail.
+    /// Consulted only for local issuers (`is_local`), and only when the JOSE
+    /// `kid` matches this key's JWK thumbprint — so it never overrides a
+    /// rotated/JWKS-published key, and is irrelevant to federated issuers.
+    local_ca_key: Option<VerifyingKey>,
+    local_ca_kid: Option<String>,
 }
 
 impl JwksKeySource {
@@ -323,12 +335,24 @@ impl JwksKeySource {
             soft_ttl: std::time::Duration::from_secs(300),
             negative_ttl: std::time::Duration::from_secs(5),
             ml_dsa_vks: Arc::new(std::sync::RwLock::new(Vec::new())),
+            local_ca_key: None,
+            local_ca_kid: None,
         }
     }
 
     /// Set the shared ML-DSA-65 verifying key list for PQ-hybrid JWT verification.
     pub fn with_ml_dsa_verifying_keys(mut self, vks: Arc<std::sync::RwLock<Vec<crate::crypto::pq::MlDsaVerifyingKey>>>) -> Self {
         self.ml_dsa_vks = vks;
+        self
+    }
+
+    /// Provide the authoritative local CA verifying key for offline resolution
+    /// of local-issuer (service) JWTs. See the `local_ca_key` field docs.
+    pub fn with_local_ca_key(mut self, ca_vk: VerifyingKey) -> Self {
+        self.local_ca_kid = Some(crate::auth::jwt::jwk_thumbprint(
+            &crate::auth::jwt::JwkThumbprintInput::Ed25519 { x: ca_vk.as_bytes() },
+        ));
+        self.local_ca_key = Some(ca_vk);
         self
     }
 
@@ -439,6 +463,20 @@ impl JwtKeySource for JwksKeySource {
 
         // Try cache first
         if let Some(kid_str) = kid {
+            // Authoritative local CA key (offline): for a LOCAL issuer whose
+            // `kid` matches the on-disk CA key thumbprint, resolve without any
+            // network fetch. This is the service-to-service WIT JWT path; the
+            // HTTP /oauth/jwks endpoint may not be up yet during startup, and
+            // #441 makes service-key registration a hard precondition, so this
+            // resolution must not depend on it. Never overrides a JWKS-published
+            // (rotated) key because it's keyed on the exact CA thumbprint.
+            if self.is_local(issuer) {
+                if let (Some(ca_kid), Some(ca_key)) = (self.local_ca_kid.as_deref(), self.local_ca_key) {
+                    if ca_kid == kid_str {
+                        return Ok(ca_key);
+                    }
+                }
+            }
             {
                 let cache = self.cache.read().await;
                 if let Some(entry) = cache.get(kid_str) {
@@ -536,6 +574,62 @@ mod tests {
         let key = ks.get_key("http://localhost:9080", None).await?;
         assert_eq!(key, test_ca_key());
         Ok(())
+    }
+
+    /// #441/AAA: a JwksKeySource with a local CA key resolves a local-issuer
+    /// service JWT OFFLINE (no JWKS fetch) when the JOSE `kid` matches the CA
+    /// thumbprint — the service-to-service auth path must not depend on the HTTP
+    /// /oauth/jwks endpoint being up during startup.
+    #[tokio::test]
+    async fn jwks_source_resolves_local_ca_key_offline() -> anyhow::Result<()> {
+        // A fetcher that always fails — proves resolution does NOT touch it.
+        let fetcher: JwksFetcher = std::sync::Arc::new(|_url: String| {
+            Box::pin(async move { anyhow::bail!("network must not be used for local CA resolution") })
+        });
+        let ca_sk = SigningKey::from_bytes(&[7u8; 32]);
+        let ca_vk = ca_sk.verifying_key();
+        let ca_kid = crate::auth::jwt::kid_for_key(&ca_sk);
+
+        let ks = JwksKeySource::new(
+            JwksMode::Isolated { jwks_url: "http://127.0.0.1:1/oauth/jwks".to_owned() },
+            "http://localhost:9080".to_owned(),
+            fetcher,
+        )
+        .with_local_ca_key(ca_vk);
+
+        // Local issuer + matching kid -> resolved offline to the CA key.
+        let key = ks.get_key("http://localhost:9080", Some(&ca_kid)).await?;
+        assert_eq!(key, ca_vk);
+
+        // Empty issuer is also local (in-process plane) -> same offline resolution.
+        let key = ks.get_key("", Some(&ca_kid)).await?;
+        assert_eq!(key, ca_vk);
+
+        Ok(())
+    }
+
+    /// The offline CA fallback must NOT fire for a non-matching kid (forces a
+    /// JWKS fetch, which fails here) nor for a non-local issuer — it is scoped
+    /// strictly to local-issuer tokens signed by the exact CA key.
+    #[tokio::test]
+    async fn jwks_source_local_ca_key_scoped_to_matching_kid_and_local_issuer() {
+        let fetcher: JwksFetcher = std::sync::Arc::new(|_url: String| {
+            Box::pin(async move { anyhow::bail!("no network") })
+        });
+        let ca_vk = SigningKey::from_bytes(&[7u8; 32]).verifying_key();
+        let ks = JwksKeySource::new(
+            JwksMode::Isolated { jwks_url: "http://127.0.0.1:1/oauth/jwks".to_owned() },
+            "http://localhost:9080".to_owned(),
+            fetcher,
+        )
+        .with_local_ca_key(ca_vk);
+
+        // Local issuer but a different kid -> CA fallback does NOT fire; the
+        // JWKS fetch is attempted and fails -> error (not the CA key).
+        assert!(ks.get_key("http://localhost:9080", Some("some-other-kid")).await.is_err());
+
+        // Non-local issuer is untrusted in isolated mode regardless of kid.
+        assert!(ks.get_key("https://evil.example.com", Some("some-other-kid")).await.is_err());
     }
 
     #[tokio::test]

--- a/crates/hyprstream-rpc/src/auth/key_subject_resolver.rs
+++ b/crates/hyprstream-rpc/src/auth/key_subject_resolver.rs
@@ -1,0 +1,76 @@
+//! Global signer-key → authorization-subject resolver (#446).
+//!
+//! # Why this exists
+//!
+//! The shared dispatch core ([`crate::service::dispatch::process_request`])
+//! verifies every socket-served request — including same-uid local IPC over
+//! Unix domain sockets — under [`crate::envelope::EnvelopeVerification::AnySigner`]
+//! (`iroh_rpc.rs::run_bridge_dispatch_loop` hardcodes `AnySigner`, used by both
+//! the iroh network plane and `uds_server`). `AnySigner` cryptographically
+//! verifies the COSE composite against the envelope's `cnf` (the signer's
+//! Ed25519 pubkey) but produces `key_derived_subject = anonymous` — so a
+//! signed IPC request from one service to another loses its identity and is
+//! denied any policy-gated write (e.g. `discovery:Announce`).
+//!
+//! The authoritative key→subject binding lives in the trust store
+//! (`hyprstream-service::TrustStore`, populated fail-closed under #441), but
+//! that crate sits *above* `hyprstream-rpc` in the dependency graph and cannot
+//! be referenced from the dispatch core. This module is the inversion-of-control
+//! seam: `hyprstream-service` installs a [`KeySubjectResolver`] at startup, and
+//! the default [`crate::service::RequestService::resolve_key_subject`] consults
+//! it. That makes *every* service (DiscoveryService included — it lives in
+//! `hyprstream-discovery`, which also cannot see the trust store) resolve a
+//! verified signer key to its authoritative `service:<name>` subject without
+//! each service crate having to depend on the trust store.
+//!
+//! # Fail-closed invariant
+//!
+//! Resolution NEVER fabricates an identity: an unregistered signer key resolves
+//! to `None` → `anonymous`. A genuinely anonymous caller (no registered key)
+//! therefore stays denied for policy-gated writes. This only honors the
+//! cryptographically-verified, *registered* identity of a legitimate signer —
+//! it never loosens a grant to `anonymous`.
+
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+use crate::envelope::Subject;
+
+/// Resolves a verified Ed25519 signer pubkey to its authorization subject.
+///
+/// Implemented by the trust store layer (`hyprstream-service`) and installed
+/// via [`set_global`]. The input is the envelope `cnf` — the signer's Ed25519
+/// public key, already cryptographically verified by the COSE signature check
+/// before resolution is attempted.
+pub trait KeySubjectResolver: Send + Sync {
+    /// Resolve a verified signer pubkey to its authoritative subject.
+    ///
+    /// Returns `Some(subject)` only for a *registered* key (e.g.
+    /// `service:discovery`, or a user's bare `sub`). Returns `None` for an
+    /// unregistered/unknown key — the caller then stays `anonymous`
+    /// (fail-closed). Implementations MUST NOT derive a fallback identity.
+    fn resolve_subject(&self, signer_pubkey: &[u8; 32]) -> Option<Subject>;
+}
+
+static GLOBAL_KEY_SUBJECT_RESOLVER: RwLock<Option<Arc<dyn KeySubjectResolver>>> = RwLock::new(None);
+
+/// Install the global key→subject resolver.
+///
+/// Called once during startup by the trust-store layer. Idempotent —
+/// re-installing replaces the previous resolver.
+pub fn set_global(resolver: Arc<dyn KeySubjectResolver>) {
+    *GLOBAL_KEY_SUBJECT_RESOLVER.write() = Some(resolver);
+}
+
+/// Resolve a signer key to a subject via the installed global resolver.
+///
+/// Returns `None` if no resolver is installed (e.g. WASM client, tests that
+/// don't bootstrap the trust store) or the key is unregistered — both yield
+/// `anonymous`, preserving the fail-closed default.
+pub fn resolve_subject(signer_pubkey: &[u8; 32]) -> Option<Subject> {
+    GLOBAL_KEY_SUBJECT_RESOLVER
+        .read()
+        .as_ref()
+        .and_then(|r| r.resolve_subject(signer_pubkey))
+}

--- a/crates/hyprstream-rpc/src/auth/mod.rs
+++ b/crates/hyprstream-rpc/src/auth/mod.rs
@@ -14,6 +14,8 @@ pub mod jti_blocklist;
 pub mod jwt;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod key_source;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod key_subject_resolver;
 pub mod scope;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod scope_registry;
@@ -25,6 +27,8 @@ pub use federation::FederationKeySource;
 pub use jwt::{decode, decode_unverified, decode_with_key, encode, encode_service_jwt, header_alg, header_kid, jwk_thumbprint, JwkThumbprintInput, JwtError};
 #[cfg(not(target_arch = "wasm32"))]
 pub use key_source::{ClusterKeySource, FederatedKeySource, IssuerResolver, JwksFetcher, JwksKeySource, JwksMode, JwtKeySource};
+#[cfg(not(target_arch = "wasm32"))]
+pub use key_subject_resolver::{KeySubjectResolver, set_global as set_global_key_subject_resolver};
 pub use scope::Scope;
 #[cfg(not(target_arch = "wasm32"))]
 pub use scope_registry::ScopeDefinition;

--- a/crates/hyprstream-rpc/src/service/svc.rs
+++ b/crates/hyprstream-rpc/src/service/svc.rs
@@ -358,10 +358,31 @@ pub trait RequestService: 'static {
         None
     }
 
-    /// Resolve a signer key to an authorization subject via the trust store.
+    /// Resolve a verified signer key to an authorization subject (#446).
     ///
-    /// Returns `Some(subject)` if the key is cached and not expired.
-    /// Default implementation returns `None` (no trust store available).
+    /// Consulted by `verify_claims` for an unauthenticated (no-JWT) request: the
+    /// envelope `cnf` (the signer's Ed25519 pubkey, already verified by the COSE
+    /// signature check) is mapped to its authoritative subject so a *signed*
+    /// service-to-service IPC caller resolves as its `service:<name>` identity
+    /// instead of `anonymous`.
+    ///
+    /// The default routes through the process-global [key→subject
+    /// resolver](crate::auth::key_subject_resolver), which the trust-store layer
+    /// (`hyprstream-service`, populated fail-closed under #441) installs at
+    /// startup. This wires *every* service — including those whose crate cannot
+    /// depend on the trust store (e.g. `DiscoveryService`) — without each one
+    /// re-implementing the lookup.
+    ///
+    /// Fail-closed: an unregistered key resolves to `None` → `anonymous`, so a
+    /// genuinely anonymous caller stays denied for policy-gated writes. Override
+    /// only to bypass or narrow this resolution; never to fabricate identity.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn resolve_key_subject(&self, signer_pubkey: &[u8; 32]) -> Option<crate::envelope::Subject> {
+        crate::auth::key_subject_resolver::resolve_subject(signer_pubkey)
+    }
+
+    /// Resolve a signer key to a subject (WASM: no trust store available).
+    #[cfg(target_arch = "wasm32")]
     fn resolve_key_subject(&self, _signer_pubkey: &[u8; 32]) -> Option<crate::envelope::Subject> {
         None
     }
@@ -870,6 +891,127 @@ mod empty_iss_gate_tests {
         // from_callback_service is a genuine in-process self-call.
         let cb = EnvelopeContext::from_callback_service(1, "inference");
         assert!(cb.is_local_caller());
+    }
+}
+
+/// Service-to-service IPC identity resolution (#446).
+///
+/// A signed IPC request carries the caller's verified Ed25519 signer pubkey in
+/// `cnf` (the `AnySigner` plane used by UDS/iroh verifies the COSE composite
+/// against it). Without a JWT, `verify_claims` must map that key to its
+/// authoritative `service:<name>` subject via the process-global key→subject
+/// resolver (the trust-store seam installed under #441) — instead of falling
+/// back to `anonymous`. A genuinely anonymous caller (unregistered key) must
+/// STILL resolve to `anonymous` so policy-gated writes stay denied (fail-closed).
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod ipc_key_identity_tests {
+    use super::*;
+    use crate::auth::key_subject_resolver::{set_global as set_key_resolver, KeySubjectResolver};
+    use crate::transport::TransportConfig;
+    use ed25519_dalek::SigningKey;
+    use parking_lot::Mutex;
+    use std::collections::HashMap;
+
+    /// Serializes tests that install the process-global key→subject resolver.
+    static RESOLVER_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Minimal service that uses the DEFAULT `resolve_key_subject` (the #446
+    /// seam under test) — it does not override identity resolution.
+    struct PlainService {
+        signing_key: SigningKey,
+        transport: TransportConfig,
+    }
+
+    #[async_trait(?Send)]
+    impl RequestService for PlainService {
+        async fn handle_request(&self, _ctx: &EnvelopeContext, _payload: &[u8]) -> Result<(Vec<u8>, Option<Continuation>)> {
+            Ok((vec![], None))
+        }
+        fn name(&self) -> &str { "discovery" }
+        fn transport(&self) -> &TransportConfig { &self.transport }
+        fn signing_key(&self) -> SigningKey { self.signing_key.clone() }
+        fn pq_signing_key(&self) -> Option<crate::crypto::pq::MlDsaSigningKey> { None }
+    }
+
+    /// Test resolver mapping a fixed set of pubkeys → subjects (the trust store
+    /// stand-in). Unknown keys resolve to `None`.
+    struct MapResolver {
+        bindings: HashMap<[u8; 32], String>,
+    }
+
+    impl KeySubjectResolver for MapResolver {
+        fn resolve_subject(&self, signer_pubkey: &[u8; 32]) -> Option<Subject> {
+            self.bindings.get(signer_pubkey).map(|s| Subject::new(s.clone()))
+        }
+    }
+
+    /// Build a no-JWT context whose `cnf` is the given signer pubkey (the
+    /// AnySigner/UDS plane: identity carried only by the verified signer key).
+    fn ctx_for_signer(signer_pubkey: [u8; 32]) -> EnvelopeContext {
+        EnvelopeContext {
+            request_id: 1,
+            claims: None,
+            jwt_token: None,
+            key_derived_subject: Subject::anonymous(),
+            jwt_subject: None,
+            cnf: signer_pubkey,
+            envelope_wit_hash: None,
+            client_dh_public: None,
+            // AnySigner / networked-or-UDS plane.
+            is_local_caller: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn registered_service_key_resolves_as_service_subject() {
+        let _guard = RESOLVER_LOCK.lock();
+
+        let caller = SigningKey::from_bytes(&[11u8; 32]);
+        let caller_pub = caller.verifying_key().to_bytes();
+
+        // Trust store has the caller's key bound to service:discovery (#441).
+        let mut bindings = HashMap::new();
+        bindings.insert(caller_pub, "service:discovery".to_owned());
+        set_key_resolver(std::sync::Arc::new(MapResolver { bindings }));
+
+        let svc = PlainService {
+            signing_key: SigningKey::from_bytes(&[22u8; 32]),
+            transport: TransportConfig::inproc("discovery"),
+        };
+
+        let mut ctx = ctx_for_signer(caller_pub);
+        svc.verify_claims(&mut ctx).await.expect("verify_claims ok");
+
+        // The signed IPC caller resolves as its authoritative service identity,
+        // NOT anonymous — so the existing discovery:* grant applies.
+        assert_eq!(ctx.subject().to_string(), "service:discovery");
+        assert!(!ctx.subject().is_anonymous());
+    }
+
+    #[tokio::test]
+    async fn unregistered_key_stays_anonymous() {
+        let _guard = RESOLVER_LOCK.lock();
+
+        // Resolver knows ONLY about some other (registered) key.
+        let registered = SigningKey::from_bytes(&[33u8; 32]).verifying_key().to_bytes();
+        let mut bindings = HashMap::new();
+        bindings.insert(registered, "service:discovery".to_owned());
+        set_key_resolver(std::sync::Arc::new(MapResolver { bindings }));
+
+        let svc = PlainService {
+            signing_key: SigningKey::from_bytes(&[22u8; 32]),
+            transport: TransportConfig::inproc("discovery"),
+        };
+
+        // A genuinely anonymous caller signs with an UNREGISTERED key.
+        let anon_pub = SigningKey::from_bytes(&[44u8; 32]).verifying_key().to_bytes();
+        let mut ctx = ctx_for_signer(anon_pub);
+        svc.verify_claims(&mut ctx).await.expect("verify_claims ok");
+
+        // Fail-closed: no registered binding → anonymous → still denied writes.
+        assert!(ctx.subject().is_anonymous());
+        assert_eq!(ctx.subject().to_string(), "anonymous");
     }
 }
 

--- a/crates/hyprstream-service/src/service/factory.rs
+++ b/crates/hyprstream-service/src/service/factory.rs
@@ -570,6 +570,9 @@ impl ServiceContext {
                 fetcher.clone(),
             );
             let source = source.with_ml_dsa_verifying_keys(self.ml_dsa_verifying_keys.clone());
+            // Authoritative local CA key for offline service-JWT resolution
+            // (no dependency on the HTTP /oauth/jwks endpoint at startup).
+            let source = source.with_local_ca_key(self.jwt_verifying_key());
             std::sync::Arc::new(source)
         } else {
             let source = hyprstream_rpc::auth::ClusterKeySource::new(

--- a/crates/hyprstream-service/src/service/trust_store.rs
+++ b/crates/hyprstream-service/src/service/trust_store.rs
@@ -217,13 +217,45 @@ impl Default for TrustStore {
     }
 }
 
+/// Adapter exposing the global trust store as the `hyprstream-rpc`
+/// signer-key → subject resolver (#446).
+///
+/// `hyprstream-rpc`'s dispatch core cannot reference the trust store directly
+/// (the dependency points the other way), so it defines a
+/// [`hyprstream_rpc::auth::KeySubjectResolver`] seam. This adapter wires the
+/// authoritative trust store (populated fail-closed under #441) into that seam
+/// so a signed service-to-service IPC caller resolves as its `service:<name>`
+/// identity instead of `anonymous`. Unregistered keys resolve to `None`
+/// (fail-closed); resolution never fabricates an identity.
+struct TrustStoreSubjectResolver;
+
+impl hyprstream_rpc::auth::KeySubjectResolver for TrustStoreSubjectResolver {
+    fn resolve_subject(
+        &self,
+        signer_pubkey: &[u8; 32],
+    ) -> Option<hyprstream_rpc::envelope::Subject> {
+        global_trust_store().resolve_subject(signer_pubkey)
+    }
+}
+
 /// Global trust store singleton.
 ///
 /// Set once during startup (before any service threads spawn), readable
 /// from any thread thereafter. This is the "CA bundle" — the set of
 /// keys the process trusts.
-static TRUST_STORE: once_cell::sync::Lazy<TrustStore> =
-    once_cell::sync::Lazy::new(TrustStore::new);
+///
+/// On first access the trust store also installs itself as the process-global
+/// `hyprstream-rpc` key→subject resolver (#446), so every dispatched request
+/// (across all service crates) maps a verified signer key to its authoritative
+/// `service:<name>`/user subject via this store. The trust store is always
+/// touched during startup, so this guarantees the resolver is wired before any
+/// request is served.
+static TRUST_STORE: once_cell::sync::Lazy<TrustStore> = once_cell::sync::Lazy::new(|| {
+    hyprstream_rpc::auth::set_global_key_subject_resolver(std::sync::Arc::new(
+        TrustStoreSubjectResolver,
+    ));
+    TrustStore::new()
+});
 
 /// Get the global trust store.
 pub fn global_trust_store() -> &'static TrustStore {
@@ -380,5 +412,39 @@ mod tests {
 
         store.remove(&key);
         assert!(!store.is_authorized(&key, "model"));
+    }
+
+    /// #446: accessing the global trust store installs it as the `hyprstream-rpc`
+    /// signer-key → subject resolver, and a registered service key resolves to
+    /// its authoritative `service:<scope>` subject through that seam (so a signed
+    /// service-to-service IPC caller is no longer anonymous). An unregistered key
+    /// resolves to `None` (fail-closed → anonymous).
+    #[test]
+    fn global_resolver_resolves_registered_service_key() {
+        // Touching the global store installs the global key→subject resolver.
+        let store = global_trust_store();
+        let (_, service_key) = random_key();
+        let (_, unregistered) = random_key();
+        store.insert(service_key, make_attestation(&["discovery"], 0));
+
+        // The rpc-layer global resolver routes through this same trust store.
+        let registered = hyprstream_rpc::auth::key_subject_resolver::resolve_subject(
+            &service_key.to_bytes(),
+        );
+        assert_eq!(
+            registered.map(|s| s.to_string()),
+            Some("service:discovery".to_owned()),
+            "registered service key must resolve as service:discovery, not anonymous"
+        );
+
+        // Fail-closed: an unregistered key resolves to None → anonymous.
+        assert!(
+            hyprstream_rpc::auth::key_subject_resolver::resolve_subject(&unregistered.to_bytes())
+                .is_none(),
+            "unregistered key must NOT resolve to any identity"
+        );
+
+        // Cleanup so we don't leak into other tests sharing the global store.
+        store.remove(&service_key);
     }
 }

--- a/crates/hyprstream-service/src/service/trust_store.rs
+++ b/crates/hyprstream-service/src/service/trust_store.rs
@@ -264,6 +264,25 @@ mod tests {
         assert!(!store.is_authorized(&key, "policy"));
     }
 
+    /// #441 invariant: authoritative service-key resolution.
+    /// A registered service resolves to *exactly* the registered key; an
+    /// unregistered service resolves to `None` (which `handle_resolve_service_key`
+    /// turns into a "service key '<name>' not registered" error — never a
+    /// CA-derived guess).
+    #[test]
+    fn resolve_one_returns_registered_key_or_none() {
+        let store = TrustStore::new();
+        let (_, registered) = random_key();
+        store.insert(registered, make_attestation(&["model"], 0));
+
+        // Registered → exactly the registered key.
+        assert_eq!(store.resolve_one("model"), Some(registered));
+
+        // Unregistered scope → None (handler converts this to a clear error;
+        // it must NOT derive a fallback key).
+        assert_eq!(store.resolve_one("worker"), None);
+    }
+
     #[test]
     fn expired_attestation_is_not_authorized() {
         let store = TrustStore::new();

--- a/crates/hyprstream/src/auth/policy_templates.rs
+++ b/crates/hyprstream/src/auth/policy_templates.rs
@@ -108,6 +108,24 @@ pub const SERVICE_BASE_POLICIES: &[ServicePolicyRule] = &[
     ServicePolicyRule { subject: "service:model", domain: "*", resource: "discovery:*", action: "*", effect: "allow" },
     ServicePolicyRule { subject: "service:oai", domain: "*", resource: "discovery:*", action: "*", effect: "allow" },
     ServicePolicyRule { subject: "service:worker", domain: "*", resource: "discovery:*", action: "*", effect: "allow" },
+    // #446: EVERY socket-served service announces its own QUIC endpoint to
+    // DiscoveryService on startup (the generic `factory.rs` announce hook). Now
+    // that those IPC callers resolve as their authoritative `service:<name>`
+    // identity (not `anonymous`), they need the least-privilege grant to write
+    // their OWN announcement. Scoped to `discovery:Announce` + `write` only
+    // (NOT `discovery:*`), so these services can register their endpoint but not
+    // mutate the rest of the discovery namespace. The services already granted
+    // broad `discovery:*` above (discovery/model/oai/worker) are unaffected.
+    ServicePolicyRule { subject: "service:mcp", domain: "*", resource: "discovery:Announce", action: "write", effect: "allow" },
+    ServicePolicyRule { subject: "service:metrics", domain: "*", resource: "discovery:Announce", action: "write", effect: "allow" },
+    ServicePolicyRule { subject: "service:notification", domain: "*", resource: "discovery:Announce", action: "write", effect: "allow" },
+    ServicePolicyRule { subject: "service:registry", domain: "*", resource: "discovery:Announce", action: "write", effect: "allow" },
+    ServicePolicyRule { subject: "service:tui", domain: "*", resource: "discovery:Announce", action: "write", effect: "allow" },
+    ServicePolicyRule { subject: "service:oauth", domain: "*", resource: "discovery:Announce", action: "write", effect: "allow" },
+    ServicePolicyRule { subject: "service:event", domain: "*", resource: "discovery:Announce", action: "write", effect: "allow" },
+    ServicePolicyRule { subject: "service:streams", domain: "*", resource: "discovery:Announce", action: "write", effect: "allow" },
+    ServicePolicyRule { subject: "service:flight", domain: "*", resource: "discovery:Announce", action: "write", effect: "allow" },
+    ServicePolicyRule { subject: "service:policy", domain: "*", resource: "discovery:Announce", action: "write", effect: "allow" },
     // NOTE: Federation (`federation:register` resource) is deny-by-default.
     // This is the single, atproto-style trust gate that governs both:
     //   - third-party clients registering via CIMD (Client ID Metadata

--- a/crates/hyprstream/src/auth/service_jwt.rs
+++ b/crates/hyprstream/src/auth/service_jwt.rs
@@ -23,6 +23,7 @@ pub fn issue_or_load_service_jwt(
     service_name: &str,
     ca_jwt_key: &SigningKey,
     service_vk: &VerifyingKey,
+    local_issuer_url: &str,
     now: i64,
 ) -> Result<String> {
     let existing = super::identity_store::load_service_jwt(credentials_dir, service_name)?;
@@ -30,7 +31,10 @@ pub fn issue_or_load_service_jwt(
         None => true,
         Some(ref jwt) => {
             let exp = decode_jwt_exp(jwt).unwrap_or(0);
-            (exp - now) <= RENEW_THRESHOLD
+            // Re-issue if near expiry OR if the persisted token has no `iss`
+            // (older bootstraps minted empty-issuer service JWTs, which the
+            // #328 gate rejects on the IPC/AnySigner plane — see below).
+            (exp - now) <= RENEW_THRESHOLD || decode_jwt_iss(jwt).is_none_or(|s| s.is_empty())
         }
     };
 
@@ -41,12 +45,26 @@ pub fn issue_or_load_service_jwt(
     }
 
     let expiry = now + NEW_EXPIRY_TTL;
-    let claims = hyprstream_rpc::auth::Claims::new(
+    // Set `iss` to the local issuer URL — NOT empty.
+    //
+    // Service JWTs are presented service->service over the local IPC (UDS)
+    // plane, which the dispatch core verifies as `AnySigner`. The #328 gate
+    // rejects an EMPTY `iss` from any `AnySigner` (non-`is_local_caller`)
+    // caller, so an empty-issuer service JWT is rejected on exactly the plane
+    // it is meant for, and (with #441's fail-closed registration) the service
+    // refuses to start. Stamping the local issuer URL makes the token pass
+    // `ClusterKeySource::is_trusted` (issuer == local_issuer_url -> CA key)
+    // WITHOUT weakening #328: a networked peer still cannot present an
+    // empty-`iss` token, and a non-local issuer is still rejected.
+    let mut claims = hyprstream_rpc::auth::Claims::new(
         format!("service:{service_name}"),
         now,
         expiry,
     )
     .with_cnf_jwk(service_vk.as_bytes());
+    if !local_issuer_url.is_empty() {
+        claims = claims.with_issuer(local_issuer_url.to_owned());
+    }
 
     Ok(hyprstream_rpc::auth::jwt::encode_service_jwt(&claims, ca_jwt_key))
 }
@@ -56,4 +74,67 @@ fn decode_jwt_exp(jwt: &str) -> Option<i64> {
     let payload = URL_SAFE_NO_PAD.decode(payload_b64).ok()?;
     let value: serde_json::Value = serde_json::from_slice(&payload).ok()?;
     value.get("exp")?.as_i64()
+}
+
+/// Decode the `iss` claim without verifying the signature. Used only to detect
+/// legacy empty-issuer service JWTs that must be re-minted (see the #328 note
+/// in `issue_or_load_service_jwt`). Returns `None` if the token is malformed or
+/// carries no `iss` claim.
+fn decode_jwt_iss(jwt: &str) -> Option<String> {
+    let payload_b64 = jwt.split('.').nth(1)?;
+    let payload = URL_SAFE_NO_PAD.decode(payload_b64).ok()?;
+    let value: serde_json::Value = serde_json::from_slice(&payload).ok()?;
+    value.get("iss")?.as_str().map(ToOwned::to_owned)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+
+    /// A freshly issued service JWT carries the local issuer URL (NOT empty).
+    /// Empty `iss` is rejected on the IPC/AnySigner plane by the #328 gate, so
+    /// stamping the local issuer is what lets service-to-service registration
+    /// succeed fail-closed (with #441).
+    #[test]
+    fn issued_service_jwt_carries_local_issuer() {
+        let dir = tempfile::tempdir().unwrap();
+        let ca = SigningKey::from_bytes(&[3u8; 32]);
+        let svc = SigningKey::from_bytes(&[4u8; 32]);
+        let issuer = "http://localhost:6791";
+
+        let jwt = issue_or_load_service_jwt(
+            dir.path(), "model", &ca, &svc.verifying_key(), issuer, 1_000_000,
+        )
+        .unwrap();
+
+        assert_eq!(decode_jwt_iss(&jwt).as_deref(), Some(issuer));
+    }
+
+    /// A persisted legacy empty-issuer token is re-minted with the issuer set,
+    /// rather than being returned as-is — so an upgrade heals the #328 mismatch
+    /// on the next wizard/bootstrap run without manual intervention.
+    #[test]
+    fn empty_issuer_legacy_jwt_is_reissued_with_issuer() {
+        let dir = tempfile::tempdir().unwrap();
+        let ca = SigningKey::from_bytes(&[3u8; 32]);
+        let svc = SigningKey::from_bytes(&[4u8; 32]);
+
+        // Mint a legacy token with NO issuer and a far-future expiry, persist it.
+        let now = 1_000_000;
+        let legacy_claims =
+            hyprstream_rpc::auth::Claims::new("service:model".to_owned(), now, now + 30 * 86_400)
+                .with_cnf_jwk(svc.verifying_key().as_bytes());
+        let legacy = hyprstream_rpc::auth::jwt::encode_service_jwt(&legacy_claims, &ca);
+        assert!(decode_jwt_iss(&legacy).is_none_or(|s| s.is_empty()));
+        super::super::identity_store::write_service_jwt(dir.path(), "model", &legacy).unwrap();
+
+        // Even though it is far from expiry, the empty-iss legacy token forces a
+        // re-issue carrying the issuer.
+        let jwt = issue_or_load_service_jwt(
+            dir.path(), "model", &ca, &svc.verifying_key(), "http://localhost:6791", now,
+        )
+        .unwrap();
+        assert_eq!(decode_jwt_iss(&jwt).as_deref(), Some("http://localhost:6791"));
+    }
 }

--- a/crates/hyprstream/src/cli/bootstrap_manager.rs
+++ b/crates/hyprstream/src/cli/bootstrap_manager.rs
@@ -77,6 +77,56 @@ impl Drop for BootstrapManager {
     }
 }
 
+/// Resolve the local OS username exactly as the CLI presents it in `sub`.
+///
+/// Must stay in lockstep with `sign_challenge.rs::load_user_signing_key`
+/// (`$USER` → `$LOGNAME` → `"anonymous"`), so the identity the wizard registers
+/// matches the subject the CLI authenticates as.
+fn os_username() -> String {
+    std::env::var("USER")
+        .or_else(|_| std::env::var("LOGNAME"))
+        .unwrap_or_else(|_| "anonymous".to_owned())
+}
+
+/// Bind a user-signing-key public key to `username`, idempotently and
+/// collision-safely.
+///
+/// `add_pubkey` rejects a fingerprint that is already bound (to the same or a
+/// different user), so we resolve the current binding first:
+/// - already bound to `username` → no-op (the key is already recognized),
+/// - bound to a *different* user (e.g. an `anonymous` record left by a prior
+///   partial run) → re-point it: remove from the old user, add to `username`,
+/// - unbound → add it.
+///
+/// Re-pointing is the least-surprising behavior: there is exactly one local
+/// user-signing-key, so it should map to exactly one identity — the one the
+/// operator is setting up.
+async fn bind_user_signing_key(
+    store: &RocksDbUserStore,
+    username: &str,
+    vk: ed25519_dalek::VerifyingKey,
+) -> anyhow::Result<()> {
+    let fingerprint = crate::auth::user_store::pubkey_fingerprint(&vk);
+
+    match store.get_pubkey_user(&fingerprint).await? {
+        Some(existing) if existing == username => {
+            // Already bound to this user — nothing to do.
+            return Ok(());
+        }
+        Some(existing) => {
+            // Bound to a different (likely stale `anonymous`) user — re-point.
+            tracing::info!("Re-pointing user-signing-key from '{existing}' to '{username}'");
+            store.remove_pubkey(&existing, &fingerprint).await?;
+        }
+        None => {}
+    }
+
+    store
+        .add_pubkey(username, vk, Some("wizard".to_owned()))
+        .await?;
+    Ok(())
+}
+
 /// Returns true if this is the first run (no bootstrap completed yet).
 ///
 /// Used by the no-args entry point to decide between wizard and ShellClient.
@@ -148,31 +198,74 @@ impl BootstrapManager {
             )
     }
 
-    /// Register user identity in UserStore for the local OS user.
+    /// Register a user identity in UserStore and bind the CLI's user-signing-key
+    /// public key to it.
+    ///
+    /// The wizard has the local user-signing-key (the credential the CLI signs
+    /// auth challenges with), so any username it is asked to register — the OS
+    /// user (non-interactive) or an operator-entered name (interactive) — can be
+    /// bound to that key. Without the binding the server can never resolve the
+    /// CLI's signature back to a subject and falls back to `anonymous` (#438).
+    ///
+    /// Idempotent and collision-safe (see `bind_user_signing_key`).
     fn register_local_identity(&mut self, username: &str) {
-        if username != self.local_username().as_str() {
-            return;
-        }
         let credentials_dir = self.credentials_dir();
         let store = match RocksDbUserStore::open(&credentials_dir) {
             Ok(s) => s,
             Err(e) => {
                 tracing::warn!(
                     username, ?credentials_dir,
-                    "Failed to load UserStore during bootstrap — user OAuth identity will not be registered: {e}"
+                    "Failed to load UserStore during bootstrap — user identity will not be registered: {e}"
                 );
                 return;
             }
         };
-        if self.rt.block_on(store.get_profile(username)).ok().flatten().is_some() {
-            return; // already registered
+
+        // Register the user record if it doesn't already exist. `register`
+        // overwrites pubkeys on an existing record, so only call it when absent.
+        if self.rt.block_on(store.get_profile(username)).ok().flatten().is_none() {
+            if let Err(e) = self.rt.block_on(store.register(username)) {
+                tracing::warn!(
+                    username,
+                    "Failed to register user identity in UserStore — user identity will not be registered: {e}"
+                );
+                return;
+            }
         }
-        if let Err(e) = self.rt.block_on(store.register(username)) {
+
+        // Load the user-signing-key from the SAME secrets dir the CLI uses, so
+        // the bound fingerprint matches the key the CLI signs with.
+        let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir();
+        let vk = match identity_store::load_or_generate_user_signing_key(&secrets_dir) {
+            Ok((_sk, vk)) => vk,
+            Err(e) => {
+                tracing::warn!(
+                    username, ?secrets_dir,
+                    "Failed to load user-signing-key — CLI signing key will not be bound to '{username}': {e}"
+                );
+                return;
+            }
+        };
+
+        if let Err(e) = self.bind_user_signing_key(&store, username, vk) {
             tracing::warn!(
                 username,
-                "Failed to register user identity in UserStore — user OAuth identity will not be registered: {e}"
+                "Failed to bind user-signing-key pubkey to '{username}': {e}"
             );
         }
+    }
+
+    /// Bind the user-signing-key public key to `username`.
+    ///
+    /// Blocking wrapper over [`bind_user_signing_key`] (the free async fn holds
+    /// the idempotency/collision logic and is unit-tested directly).
+    fn bind_user_signing_key(
+        &self,
+        store: &RocksDbUserStore,
+        username: &str,
+        vk: ed25519_dalek::VerifyingKey,
+    ) -> anyhow::Result<()> {
+        self.rt.block_on(bind_user_signing_key(store, username, vk))
     }
 
     /// Ensure the signing key is loaded.
@@ -454,7 +547,7 @@ impl WizardBackend for BootstrapManager {
     }
 
     fn local_username(&self) -> String {
-        "anonymous".to_owned()
+        os_username()
     }
 
     fn templates(&self) -> Vec<TemplateInfo> {
@@ -715,4 +808,113 @@ async fn do_bootstrap(
 
     let _ = tx.send(BootstrapPoll::Done(steps));
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::{RocksDbUserStore, UserStore};
+    use tempfile::TempDir;
+
+    /// Replicates the register + bind sequence performed by
+    /// `register_local_identity` against a temp store/secrets dir, then asserts
+    /// the identity↔key binding the CLI relies on actually exists (#438).
+    #[tokio::test]
+    async fn register_and_bind_creates_identity_and_reverse_maps_pubkey() -> anyhow::Result<()> {
+        let creds = TempDir::new()?;
+        let secrets = TempDir::new()?;
+        let username = "alice";
+
+        // CLI's signing key lives in the secrets dir.
+        let (_sk, vk) =
+            identity_store::load_or_generate_user_signing_key(secrets.path())?;
+
+        let store = RocksDbUserStore::open(creds.path())?;
+        // Register (user did not exist yet) + bind, exactly like the wizard path.
+        store.register(username).await?;
+        bind_user_signing_key(&store, username, vk).await?;
+
+        // 1. UserStore has a record for the username.
+        assert!(
+            store.get_profile(username).await?.is_some(),
+            "expected a UserStore record for '{username}'"
+        );
+
+        // 2. The signing key's fingerprint reverse-maps to that username.
+        let fingerprint = crate::auth::user_store::pubkey_fingerprint(&vk);
+        assert_eq!(
+            store.get_pubkey_user(&fingerprint).await?,
+            Some(username.to_owned()),
+            "user-signing-key fingerprint must reverse-map to '{username}'"
+        );
+
+        Ok(())
+    }
+
+    /// Binding is idempotent (re-running the wizard) and re-points a key left
+    /// bound to a stale `anonymous` record from a prior partial run.
+    #[tokio::test]
+    async fn bind_is_idempotent_and_repoints_from_anonymous() -> anyhow::Result<()> {
+        let creds = TempDir::new()?;
+        let secrets = TempDir::new()?;
+        let (_sk, vk) =
+            identity_store::load_or_generate_user_signing_key(secrets.path())?;
+        let fingerprint = crate::auth::user_store::pubkey_fingerprint(&vk);
+
+        let store = RocksDbUserStore::open(creds.path())?;
+
+        // Simulate a prior partial run: key bound to "anonymous".
+        store.register("anonymous").await?;
+        bind_user_signing_key(&store, "anonymous", vk).await?;
+        assert_eq!(
+            store.get_pubkey_user(&fingerprint).await?,
+            Some("anonymous".to_owned())
+        );
+
+        // Wizard now registers the real user and binds — must re-point.
+        store.register("alice").await?;
+        bind_user_signing_key(&store, "alice", vk).await?;
+        assert_eq!(
+            store.get_pubkey_user(&fingerprint).await?,
+            Some("alice".to_owned()),
+            "key should be re-pointed from anonymous to alice"
+        );
+
+        // Re-running for the same user is a no-op (must not error/duplicate).
+        bind_user_signing_key(&store, "alice", vk).await?;
+        assert_eq!(
+            store.get_pubkey_user(&fingerprint).await?,
+            Some("alice".to_owned())
+        );
+        assert_eq!(
+            store.list_pubkeys("alice").await?.len(),
+            1,
+            "idempotent re-bind must not duplicate the pubkey"
+        );
+
+        Ok(())
+    }
+
+    /// `local_username()` (via `os_username`) returns the OS user — not the old
+    /// hardcoded "anonymous" — matching the `sub` the CLI presents.
+    #[test]
+    fn os_username_returns_user_env_not_anonymous() {
+        // Save/restore env to avoid cross-test contamination.
+        let prev_user = std::env::var("USER").ok();
+        let prev_logname = std::env::var("LOGNAME").ok();
+
+        std::env::set_var("USER", "alice");
+        std::env::remove_var("LOGNAME");
+        assert_eq!(os_username(), "alice");
+        assert_ne!(os_username(), "anonymous");
+
+        // Restore.
+        match prev_user {
+            Some(v) => std::env::set_var("USER", v),
+            None => std::env::remove_var("USER"),
+        }
+        if let Some(v) = prev_logname {
+            std::env::set_var("LOGNAME", v);
+        }
+    }
 }

--- a/crates/hyprstream/src/cli/bootstrap_manager.rs
+++ b/crates/hyprstream/src/cli/bootstrap_manager.rs
@@ -737,6 +737,14 @@ async fn do_bootstrap(
                     .join("credentials")
             });
 
+        // Local issuer URL stamped into service JWTs so they verify on the
+        // local IPC/AnySigner plane without tripping the #328 empty-`iss` gate.
+        // Must match the issuer the services' ClusterKeySource trusts
+        // (oauth.issuer_url(), the same value `cluster_key_source()` uses).
+        let local_issuer_url = crate::config::HyprConfig::load()
+            .map(|c| c.oauth.issuer_url())
+            .unwrap_or_default();
+
         // CA JWT signing key (purpose-derived for JWT signature separation).
         // Derived BEFORE writing ca-pubkey so we can store the JWT key's verifying key,
         // not the root key's verifying key. Services verify JWTs with the derived key.
@@ -785,7 +793,7 @@ async fn do_bootstrap(
             let service_vk = service_key.verifying_key();
 
             let jwt = crate::auth::service_jwt::issue_or_load_service_jwt(
-                &credentials_dir, service_name, &ca_jwt_key, &service_vk, now,
+                &credentials_dir, service_name, &ca_jwt_key, &service_vk, &local_issuer_url, now,
             )?;
             identity_store::write_service_jwt(&credentials_dir, service_name, &jwt)?;
 

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -76,10 +76,78 @@ fn get_or_init_git2db(models_dir: &std::path::Path) -> anyhow::Result<Arc<RwLock
     Ok(Arc::clone(SHARED_GIT2DB.get_or_init(|| shared)))
 }
 
+/// Resolve the credentials directory used to load service JWTs at startup.
+///
+/// Mirrors the resolution in `main.rs`: systemd/IPC mode honors
+/// `HYPRSTREAM__SECRETS__PATH`; otherwise it is `<config_dir>/credentials`.
+/// This is the same on-disk location the wizard/bootstrap manager writes
+/// service JWTs to (`credentials/{service}/service-jwt`).
+fn credentials_dir() -> std::path::PathBuf {
+    if let Ok(p) = std::env::var("HYPRSTREAM__SECRETS__PATH") {
+        return std::path::PathBuf::from(p);
+    }
+    HyprConfig::load()
+        .map(|c| c.config_dir().join("credentials"))
+        .unwrap_or_else(|_| {
+            dirs::config_dir()
+                .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
+                .join("hyprstream")
+                .join("credentials")
+        })
+}
+
+/// Resolve the CA-signed JWT used to register a service's signing key.
+///
+/// Fail-closed (issue #441): returns the JWT (preferring one already in the
+/// trust store, falling back to the authoritative on-disk credential), or an
+/// ERROR naming the real cause. It never silently returns "skip" — a service
+/// that cannot produce its JWT must not come up serving signed responses.
+fn resolve_registration_jwt(
+    service_name: &str,
+    creds_dir: &std::path::Path,
+    from_trust: Option<String>,
+) -> anyhow::Result<String> {
+    if let Some(jwt) = from_trust {
+        return Ok(jwt);
+    }
+    match crate::auth::identity_store::load_service_jwt(creds_dir, service_name) {
+        Ok(Some(jwt)) => Ok(jwt),
+        Ok(None) => anyhow::bail!(
+            "service '{service_name}' cannot register its signing key: \
+             no CA-signed JWT found in trust store or on disk at {}. \
+             Run 'hyprstream wizard' to provision service credentials; \
+             a service must not serve signed responses without a registered key.",
+            creds_dir.display(),
+        ),
+        Err(e) => anyhow::bail!(
+            "service '{service_name}' cannot register its signing key: \
+             failed to read CA-signed JWT from {}: {e}",
+            creds_dir.display(),
+        ),
+    }
+}
+
 /// Register this service's verifying key with the PolicyService CA.
 ///
 /// Called by each non-policy factory so that peer services can resolve
 /// our pubkey via `resolveServiceKey` RPC.  No-op for PolicyService itself.
+///
+/// # Fail-closed (issue #441)
+///
+/// A service that cannot obtain its CA-signed JWT (and therefore cannot
+/// register its signing key) MUST NOT come up serving signed responses —
+/// every peer would resolve a key/JWT that disagrees with what we actually
+/// sign with, surfacing three layers away as a cryptic "Response signed by
+/// unexpected key". So registration is a hard precondition: if we cannot get
+/// a JWT, we return an error and the factory (and thus the service) fails to
+/// start, naming the real cause.
+///
+/// The authoritative source of the service JWT is on disk
+/// (`credentials/{service}/service-jwt`), written by the wizard/bootstrap
+/// manager. At process startup only the bootstrap *pubkeys* are seeded into
+/// the trust store (with `jwt: None`); the JWT itself is loaded here and
+/// seeded into the trust store so that peer-client construction
+/// (`service_token`) and the background renewal task can read it.
 fn register_service_key(
     _ctx: &ServiceContext,
     service_name: &str,
@@ -90,23 +158,40 @@ fn register_service_key(
         return Ok(());
     }
 
-    let jwt = {
+    let creds_dir = credentials_dir();
+
+    // The JWT may already be in the trust store (e.g. seeded by an earlier
+    // registration in this process); otherwise load it from disk — the
+    // authoritative location the wizard/bootstrap manager wrote it to.
+    let from_trust = {
         let trust = hyprstream_service::global_trust_store();
-        let vk = match trust.resolve_one(service_name) {
-            Some(vk) => vk,
-            None => {
-                tracing::warn!(service = service_name, "trust store has no key — skipping registerServiceKey");
-                return Ok(());
-            }
-        };
-        match trust.get(&vk).and_then(|att| att.jwt.clone()) {
-            Some(jwt) => jwt,
-            None => {
-                tracing::warn!(service = service_name, "trust store has no JWT — skipping registerServiceKey");
-                return Ok(());
-            }
-        }
+        trust
+            .resolve_one(service_name)
+            .and_then(|vk| trust.get(&vk))
+            .and_then(|att| att.jwt.clone())
     };
+    let jwt = resolve_registration_jwt(service_name, &creds_dir, from_trust)?;
+
+    // Seed the loaded JWT into the trust store so that peer-client construction
+    // (`service_token`) and the background renewal task can read it. Bind it to
+    // this service's own verifying key — the key we actually sign with — so the
+    // advertised key == the actual signer (the #441 invariant).
+    {
+        let vk = signing_key.verifying_key();
+        let trust = hyprstream_service::global_trust_store();
+        let expires_at = decode_jwt_exp(&jwt).unwrap_or(0);
+        let mut att = trust.get(&vk).unwrap_or_else(|| hyprstream_service::Attestation {
+            scopes: std::iter::once(service_name.to_owned()).collect(),
+            subject: None,
+            jwt: None,
+            expires_at: 0,
+            attested_by: None,
+        });
+        att.scopes.insert(service_name.to_owned());
+        att.jwt = Some(jwt.clone());
+        att.expires_at = expires_at;
+        trust.insert(vk, att);
+    }
 
     let policy_vk = hyprstream_service::global_trust_store()
         .resolve_one("policy")
@@ -131,15 +216,7 @@ fn register_service_key(
     info!(service = service_name, "Registered verifying key with PolicyService");
 
     // Spawn background JWT renewal for this service
-    let credentials_dir = HyprConfig::load()
-        .map(|c| c.config_dir().join("credentials"))
-        .unwrap_or_else(|_| {
-            dirs::config_dir()
-                .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
-                .join("hyprstream")
-                .join("credentials")
-        });
-    spawn_jwt_renewal_task(service_name, signing_key.clone(), credentials_dir);
+    spawn_jwt_renewal_task(service_name, signing_key.clone(), creds_dir);
 
     Ok(())
 }
@@ -1485,6 +1562,46 @@ mod tests {
         msg.extend_from_slice(ed25519_pubkey);
         msg.extend_from_slice(domain.as_bytes());
         msg
+    }
+
+    /// #441 fail-closed: with no JWT in the trust store and none on disk,
+    /// registration MUST error (naming the real cause) rather than silently
+    /// skip — a service that can't register its key must not serve signed
+    /// responses.
+    #[test]
+    fn resolve_registration_jwt_fails_closed_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = resolve_registration_jwt("model", dir.path(), None)
+            .expect_err("missing JWT must fail closed, not skip");
+        let msg = err.to_string();
+        assert!(msg.contains("model"), "error names the service: {msg}");
+        assert!(
+            msg.contains("cannot register its signing key"),
+            "error names the real cause: {msg}",
+        );
+    }
+
+    /// A JWT already present in the trust store is used directly (no disk read).
+    #[test]
+    fn resolve_registration_jwt_prefers_trust_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let jwt = resolve_registration_jwt(
+            "model",
+            dir.path(),
+            Some("trust.jwt.token".to_owned()),
+        )
+        .unwrap();
+        assert_eq!(jwt, "trust.jwt.token");
+    }
+
+    /// When not in the trust store, the authoritative on-disk JWT is loaded.
+    #[test]
+    fn resolve_registration_jwt_falls_back_to_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        crate::auth::identity_store::write_service_jwt(dir.path(), "model", "disk.jwt.token")
+            .unwrap();
+        let jwt = resolve_registration_jwt("model", dir.path(), None).unwrap();
+        assert_eq!(jwt, "disk.jwt.token");
     }
 
     #[test]

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -1257,11 +1257,17 @@ impl PolicyHandler for PolicyService {
         _request_id: u64,
         data: &ResolveServiceKey,
     ) -> Result<PolicyResponseVariant> {
+        // #441: authoritative resolution — return the REGISTERED key or ERROR.
+        // We never derive an "expected" key from the root CA as a fallback: a
+        // consumer must never receive a key the signer didn't actually register,
+        // because a guessed key produces a silent mis-verify ("Response signed by
+        // unexpected key") three layers away at the envelope check. Registered-or-
+        // error converts that into a clear, early failure.
         let trust = hyprstream_service::global_trust_store();
         let vk = trust.resolve_one(&data.service_name)
-            .ok_or_else(|| anyhow!("No verifying key registered for service '{}'", data.service_name))?;
+            .ok_or_else(|| anyhow!("service key '{}' not registered", data.service_name))?;
         let att = trust.get(&vk)
-            .ok_or_else(|| anyhow!("No attestation for service '{}'", data.service_name))?;
+            .ok_or_else(|| anyhow!("service key '{}' not registered (no attestation)", data.service_name))?;
         debug!("Resolved service key for '{}'", data.service_name);
         Ok(PolicyResponseVariant::ResolveServiceKeyResult(
             ServiceKeyResponse {

--- a/docs/users.md
+++ b/docs/users.md
@@ -91,16 +91,22 @@ purpose tag.
 
 ## Wizard behavior
 
-`hyprstream wizard --non-interactive --start` will, for the local OS user:
+Both the non-interactive (`hyprstream wizard --non-interactive --start`, using
+the local OS username) and the interactive path (operator-entered username +
+role) register identity the same way, via `register_local_identity`:
 
 1. Generate `user-signing-key` if absent.
-2. Create a user record using the local OS username.
-3. Call `add_pubkey(<username>, <pubkey>, label="wizard")` to register the
-   pubkey.
-4. Issue an initial bearer token for the user and print it.
+2. Create a user record for the username (OS user, or the entered name).
+3. Call `add_pubkey(<username>, <pubkey>, label="wizard")` to bind the
+   `user-signing-key` pubkey — this is the credential the CLI authenticates
+   with, so it must be bound or the CLI falls back to `anonymous`.
+4. (Non-interactive `--start`) Issue an initial bearer token for the user.
 
-If the user already exists, it leaves the record alone but may re-import the
-pubkey (a no-op when fingerprint matches).
+If the user already exists, the record is left alone and the pubkey bind is a
+no-op when the fingerprint already matches. If the `user-signing-key` pubkey
+was previously bound to a *different* user (e.g. an `anonymous` record left by a
+prior partial run), it is **re-pointed** to the current user — there is exactly
+one local user-signing-key, so it maps to exactly one identity.
 
 ## Key rotation
 

--- a/scripts/aaa-e2e.sh
+++ b/scripts/aaa-e2e.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# Autonomous AAA (Authentication / Authorization / Accounting) e2e harness for
+# hyprstream. Validates the #438 (user-key binding) + #441 (authoritative
+# service-key) fixes on the aaa-integration worktree.
+#
+# FULLY ISOLATED: a fresh run dir holds HOME / XDG_CONFIG_HOME / XDG_DATA_HOME /
+# XDG_RUNTIME_DIR so it NEVER reads or writes the user's live
+# ~/.config/hyprstream credentials.
+#
+# tmux: the daemon (all services, --standalone, IPC sockets in $XDG_RUNTIME_DIR)
+# runs in one pane; the CLI is driven from this script (same isolated env, so it
+# connects to the daemon's IPC sockets). Services are long-running; we wait for
+# readiness then drive + observe.
+#
+# AAA chain validated:
+#   AUTHN  — enrolled user (wizard, #438) authenticates as that user, not anon.
+#            Deny path: anonymous is DENIED a write.
+#   AUTHZ  — role gates correctly: admin allowed a privileged (write) op; a
+#            viewer/anonymous is DENIED it. Both allow AND deny paths asserted.
+#   SVCKEY — #441: services register their keys; resolve_service_key returns the
+#            registered key; a cross-service signed RPC (CLI -> PolicyService,
+#            CLI -> Registry) verifies WITHOUT "Response signed by unexpected key".
+#   ACCT   — best-effort: audit/log attribution of the request to the user.
+#
+# Exit 0 = AAA validated. Non-zero = a specific assertion failed (see code).
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+
+WT="${WT:?set WT to the integration worktree path under test}"
+# RUN must be SHORT: it holds Unix-domain sockets (XDG_RUNTIME_DIR + tmux),
+# whose paths are capped at ~108 bytes (sun_path). The session scratchpad path
+# alone is ~150 chars, which overflows — so the run dir lives under /tmp with a
+# short name. It is still fully isolated (fresh dir, dedicated HOME/XDG; it never
+# reads or writes the user's live ~/.config/hyprstream).
+RUN="${RUN:-$(mktemp -d /tmp/hs-aaa.XXXXXX)}"
+ROLE="${ROLE:-admin}"          # initial user role for the wizard enrollment
+BUILD="${BUILD:-1}"            # set BUILD=0 to skip the cargo build (binary present)
+
+# ── env: torch libs + isolation ─────────────────────────────────────────────
+export OPENSSL_NO_VENDOR=1 LIBTORCH_USE_PYTORCH=1 LIBTORCH_BYPASS_VERSION_CHECK=1
+# Capture the torch path BEFORE we clobber HOME (build/run both need it).
+TORCH_LIB="$(ls -d "$HOME"/.local/lib/python*/site-packages/torch/lib 2>/dev/null | head -1)"
+
+export HOME="$RUN/home"
+export XDG_CONFIG_HOME="$RUN/home/.config"
+export XDG_DATA_HOME="$RUN/home/.local/share"
+export XDG_CACHE_HOME="$RUN/home/.cache"
+export XDG_RUNTIME_DIR="$RUN/run"
+export USER="testuser"
+export LOGNAME="testuser"
+unset HYPRSTREAM_INSTANCE           # avoid instance-namespaced runtime dir surprises
+mkdir -p "$HOME" "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME" "$XDG_RUNTIME_DIR"
+chmod 700 "$XDG_RUNTIME_DIR"
+
+# Re-point LD_LIBRARY_PATH to the captured torch path (HOME just changed).
+[ -n "$TORCH_LIB" ] && export LD_LIBRARY_PATH="$TORCH_LIB:${LD_LIBRARY_PATH:-}"
+
+LOG="$RUN/harness.log"
+DLOG="$RUN/daemon.log"
+BIN="$WT/target/debug/hyprstream"
+TMUX_SOCK="$RUN/tmux.sock"
+SESSION="aaa"
+
+: > "$LOG"
+note(){ echo "[harness $(date +%T)] $*" | tee -a "$LOG"; }
+fail(){ note "FAIL($1): ${*:2}"; dump_diag; cleanup; exit "$1"; }
+pass(){ note "PASS: $*"; }
+
+dump_diag(){
+  note "──── daemon log (tail 60) ────"
+  tail -60 "$DLOG" 2>/dev/null | sed 's/^/[daemon] /' | tee -a "$LOG"
+}
+
+cleanup(){
+  tmux -S "$TMUX_SOCK" kill-server 2>/dev/null || true
+  pkill -f "$XDG_RUNTIME_DIR" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# bin wrapper — every CLI call runs in the isolated env.
+hs(){ "$BIN" "$@"; }
+
+# ── STEP 0: build ────────────────────────────────────────────────────────────
+if [ "$BUILD" = "1" ]; then
+  note "=== STEP 0: build (nice -n 10, jobs capped via ~/.cargo/config.toml) ==="
+  ( cd "$WT" && nice -n 10 cargo build -p hyprstream --bin hyprstream 2>&1 | tail -3 ) | tee -a "$LOG"
+fi
+[ -x "$BIN" ] || fail 10 "binary not built at $BIN"
+pass "binary present: $BIN"
+
+# ── STEP 1: enroll the user via the wizard (the #438 flow) ───────────────────
+note "=== STEP 1: wizard enroll (user=$USER role=$ROLE) ==="
+hs wizard --non-interactive --initial-user-role "$ROLE" >>"$LOG" 2>&1
+rc=$?
+note "wizard exit=$rc"
+[ $rc -eq 0 ] || fail 11 "wizard --non-interactive failed (rc=$rc)"
+
+# ── STEP 2: assert the user is enrolled with a bound key (not orphaned) ───────
+note "=== STEP 2: user enrolled + key bound (#438) ==="
+hs user list >"$RUN/userlist.txt" 2>>"$LOG"
+cat "$RUN/userlist.txt" | tee -a "$LOG"
+grep -q "$USER" "$RUN/userlist.txt" || fail 12 "user '$USER' not in 'user list' — wizard dropped the identity (#438 regression)"
+pass "user '$USER' registered in UserStore"
+
+hs user keys list "$USER" >"$RUN/keys.txt" 2>>"$LOG"
+cat "$RUN/keys.txt" | tee -a "$LOG"
+if grep -Eqi "fingerprint|sha256|wizard|ed25519|[0-9a-f]{16}" "$RUN/keys.txt"; then
+  pass "user '$USER' has a bound signing-key pubkey (#438 binding present)"
+else
+  fail 13 "user '$USER' has NO bound key — orphaned admin policy, CLI would fall back to anonymous (#438 not effective)"
+fi
+
+# ── STEP 3: start all services in a tmux pane (long-running daemon) ───────────
+note "=== STEP 3: start daemon (service start --standalone) in tmux ==="
+tmux -S "$TMUX_SOCK" kill-server 2>/dev/null || true
+tmux -S "$TMUX_SOCK" new-session -d -s "$SESSION" -x 220 -y 50
+for v in HOME XDG_CONFIG_HOME XDG_DATA_HOME XDG_CACHE_HOME XDG_RUNTIME_DIR USER LOGNAME \
+         OPENSSL_NO_VENDOR LIBTORCH_USE_PYTORCH LIBTORCH_BYPASS_VERSION_CHECK LD_LIBRARY_PATH; do
+  tmux -S "$TMUX_SOCK" send-keys -t "$SESSION" "export $v=$(printf %q "${!v}")" Enter
+done
+tmux -S "$TMUX_SOCK" send-keys -t "$SESSION" "unset HYPRSTREAM_INSTANCE" Enter
+tmux -S "$TMUX_SOCK" send-keys -t "$SESSION" \
+  "exec '$BIN' service start --standalone 2>&1 | tee '$DLOG'" Enter
+
+# ── wait for readiness: PolicyService socket present ──────────────────────────
+note "waiting for daemon readiness (policy IPC socket)…"
+SOCKDIR="$XDG_RUNTIME_DIR/hyprstream"
+ready=0
+for i in $(seq 1 90); do
+  if ls "$SOCKDIR"/policy*.sock >/dev/null 2>&1; then ready=1; break; fi
+  if grep -Eqi "panicked|fatal|cannot register its signing key|Address already in use" "$DLOG" 2>/dev/null; then
+    note "daemon emitted an error during startup:"; tail -25 "$DLOG" | sed 's/^/[daemon] /' | tee -a "$LOG"
+    break
+  fi
+  sleep 1
+done
+[ "$ready" = "1" ] || fail 20 "daemon not ready: no policy IPC socket at $SOCKDIR after 90s"
+sleep 3   # let remaining services finish registering their keys
+pass "daemon ready (sockets): $(ls "$SOCKDIR" 2>/dev/null | tr '\n' ' ')"
+
+# ── STEP 4: SERVICE-KEY (#441) — cross-service signed RPC, no key mismatch ────
+note "=== STEP 4: service-key resolution + cross-service RPC (#441) ==="
+hs quick policy show >"$RUN/policyshow.txt" 2>&1
+rc=$?
+cat "$RUN/policyshow.txt" >>"$LOG"
+if grep -qi "unexpected key\|signed by unexpected" "$RUN/policyshow.txt" "$LOG"; then
+  fail 30 "'Response signed by unexpected key' on policy RPC — #441 service-key binding NOT effective"
+fi
+[ $rc -eq 0 ] || fail 31 "policy show RPC failed (rc=$rc) — PolicyService not serving / key issue"
+pass "CLI -> PolicyService signed RPC verified (no key mismatch)"
+
+# `tool registry list` exercises resolve_service_key('registry') (#441) then a
+# signed Registry RPC. The `tool` CLI signs with the node key over the IPC
+# AnySigner plane and carries no user JWT, so the Registry authorizes it as
+# `anonymous`. The #441 path is VALIDATED when the call reaches the Registry and
+# returns a clean authorization decision (here: anonymous denied a query) WITHOUT
+# a key-resolution error ("not registered" / "unexpected key"). A key error here
+# would mean #441 is broken; an authz denial means the signed RPC round-tripped.
+hs tool registry list >"$RUN/reglist.txt" 2>&1
+rc=$?
+cat "$RUN/reglist.txt" >>"$LOG"
+if grep -qi "unexpected key\|signed by unexpected\|not registered\|No verifying key\|No attestation" "$RUN/reglist.txt"; then
+  fail 32 "registry key resolution failed — resolve_service_key error or unexpected key (#441)"
+fi
+if [ $rc -eq 0 ]; then
+  pass "CLI -> resolve_service_key('registry') -> signed Registry RPC verified, list returned (#441)"
+elif grep -qi "Unauthorized: anonymous" "$RUN/reglist.txt"; then
+  # Key resolution succeeded; the signed RPC round-tripped and the Registry
+  # returned a fail-closed authz denial for the anonymous tool caller. This both
+  # validates #441 (no key error) AND is an additional AUTHN/AUTHZ deny-path
+  # data point (anonymous denied a registry query).
+  pass "CLI -> resolve_service_key('registry') -> signed RPC round-tripped; anonymous tool caller fail-closed denied (#441 OK, deny-path bonus)"
+else
+  fail 33 "tool registry list failed unexpectedly (rc=$rc) — see $RUN/reglist.txt"
+fi
+
+# ── STEP 5: AUTHN + AUTHZ matrix via the live PolicyService oracle ───────────
+note "=== STEP 5: AUTHN/AUTHZ allow+deny matrix (live PolicyService) ==="
+check(){  # check <subject> <resource> <action> -> ALLOWED|DENIED|KEYERR|ERR
+  hs quick policy check "$1" "$2" "$3" >"$RUN/chk.txt" 2>&1
+  cat "$RUN/chk.txt" >>"$LOG"
+  if grep -qi "unexpected key\|not registered" "$RUN/chk.txt"; then echo "KEYERR"; return; fi
+  if grep -q "ALLOWED" "$RUN/chk.txt"; then echo "ALLOWED";
+  elif grep -q "DENIED" "$RUN/chk.txt"; then echo "DENIED";
+  else echo "ERR"; fi
+}
+
+r=$(check anonymous "registry:*" write)
+note "authn deny: anonymous registry:* write => $r"
+[ "$r" = "DENIED" ] || fail 40 "anonymous was NOT denied a write (got $r) — fail-OPEN to anonymous"
+pass "AUTHN deny: anonymous denied registry write (fail-closed by default)"
+
+r=$(check "$USER" "registry:*" write)
+note "authz allow: $USER registry:* write => $r"
+if [ "$ROLE" = "admin" ]; then
+  [ "$r" = "ALLOWED" ] || fail 41 "enrolled admin '$USER' was NOT allowed a write (got $r) — authz allow path broken"
+  pass "AUTHZ allow: admin '$USER' allowed registry write"
+fi
+
+r=$(check "viewer-probe" "registry:*" write)
+note "authz deny: viewer-probe registry:* write => $r"
+[ "$r" = "DENIED" ] || fail 42 "unprivileged 'viewer-probe' was NOT denied a write (got $r) — authz deny path broken / allow-all policy"
+pass "AUTHZ deny: unprivileged subject denied registry write"
+
+r=$(check "$USER" "model:*" query)
+note "authz allow (query): $USER model:* query => $r"
+
+# ── STEP 6: ACCOUNTING (best-effort) ─────────────────────────────────────────
+note "=== STEP 6: accounting / audit attribution (best-effort) ==="
+if grep -Eqi "subject=$USER|sub=\"?$USER|user=$USER" "$DLOG" 2>/dev/null; then
+  pass "ACCOUNTING: requests attributed to '$USER' in daemon audit log"
+else
+  note "GAP: per-request accounting attribution to '$USER' not confirmed in daemon logs"
+  echo "ACCT_GAP=1" >"$RUN/acct_gap"
+fi
+
+# ── DONE ─────────────────────────────────────────────────────────────────────
+note "════════════════════════════════════════════════════════════════════════"
+note "AAA VALIDATED:"
+note "  AUTHN  allow: enrolled user; deny: anonymous denied write"
+note "  AUTHZ  allow: admin write allowed; deny: unprivileged denied write"
+note "  SVCKEY (#441): CLI->PolicyService + CLI->Registry signed RPC, no key mismatch"
+[ -f "$RUN/acct_gap" ] && note "  ACCT   gap noted (see ticket)" || note "  ACCT   attribution observed"
+note "════════════════════════════════════════════════════════════════════════"
+cleanup
+exit 0


### PR DESCRIPTION
Closes #446. Completes the authoritative-binding model over IPC/UDS — the last AAA gap.

**Finding: signed, identity dropped (not unsigned).** IPC requests over UDS reach `process_request` on the AnySigner plane; the COSE composite IS cryptographically verified against the caller's pubkey (`ctx.cnf`). The identity was present and verified — just never *resolved*: `resolve_key_subject` defaulted to `None` → `anonymous`. **No wire change** — the signer identity was already on the wire.

**Fix:** process-global resolver seam (`hyprstream-rpc::auth::key_subject_resolver`, new). `verify_claims` (no-JWT path) maps verified `ctx.cnf` → authoritative `service:<name>`/user subject. The hyprstream-service trust store (the #441 binding source) installs itself as the resolver, wiring every service crate incl. hyprstream-discovery (which can't depend on the trust store). Fail-closed: unregistered key → `None` → `anonymous`.

**Second in-scope gap fixed (least-privilege):** once services resolved as themselves, they hit a missing `discovery:Announce` grant (generic factory announce hook means every service announces, but the base policy only granted discovery/model/oai/worker). Added `discovery:Announce`/`write` grants for the announcing services that lacked one — NOT `discovery:*`, NOT anonymous.

**AAA harness re-run GREEN:** `scripts/aaa-e2e.sh` exits 0. 0 announce denials, 7 services announce successfully. All deny paths hold (anonymous denied, viewer-probe denied, admin allowed) — no regression.

**Tests:** ipc_key_identity_tests (registered→service:discovery, unregistered→anonymous); trust_store global-resolver test. hyprstream-rpc 467 pass / 1 pre-existing #148 moq_event fail (untouched file). hyprstream-service 26 pass, policy 28 pass. **Consumer build green.** No capnp change.

⚠️ HUMAN REVIEW (auth/policy gate).

Claude-Session: https://claude.ai/code/session_01U3qgsHTDWME66JFGZGS3ZA