### PR TITLE
fix(ci): cargo-deny license failures after #467 — AGPL-3.0-only, LGPL/systemd, CDLA/webpki-roots

### DIFF
--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 description = "Agentic Infrastructure"
 documentation = "https://docs.rs/hyprstream"
 readme = "README.md"
-license = "MIT OR AGPL-3.0"
+license = "MIT OR AGPL-3.0-only"
 exclude = [
     "**/*.pyc",
     "**/__pycache__/",

--- a/deny.toml
+++ b/deny.toml
@@ -38,10 +38,31 @@ allow = [
     "MPL-2.0",
     "Zlib",
     "OpenSSL",
-    "BSL-1.0",       # Boost Software License (permissive)
-    "Unlicense",     # public domain equivalent (permissive)
-    "bzip2-1.0.6",  # bzip2-sys: permissive BSD-like, FSF-free
+    "BSL-1.0",            # Boost Software License (permissive)
+    "Unlicense",          # public domain equivalent (permissive)
+    "bzip2-1.0.6",        # bzip2-sys: permissive BSD-like, FSF-free
+    "CDLA-Permissive-2.0", # Community Data License Agreement (permissive data license — webpki-roots CA certs)
 ]
+
+# hyprstream itself is dual-licensed MIT OR AGPL-3.0-only (first-party).
+# Allow AGPL only for the root binary crate — not as a blanket allow.
+[[licenses.exceptions]]
+name = "hyprstream"
+version = "*"
+allow = ["MIT", "AGPL-3.0-only"]
+
+# systemd/libsystemd-sys are LGPL + GCC exception.
+# The GCC exception permits non-copyleft software to dynamically link against LGPL libraries
+# without triggering the copyleft requirement; hyprstream links libsystemd dynamically.
+[[licenses.exceptions]]
+name = "systemd"
+version = "*"
+allow = ["LGPL-2.1-or-later"]
+
+[[licenses.exceptions]]
+name = "libsystemd-sys"
+version = "*"
+allow = ["LGPL-2.1-or-later"]
 
 # huggingface/xet-core (tag git-xet-v0.2.0) internal workspace crates don't
 # declare `license` in their per-crate Cargo.toml; the root repo is Apache-2.0.

--- a/deny.toml
+++ b/deny.toml
@@ -57,12 +57,12 @@ allow = ["MIT", "AGPL-3.0-only"]
 [[licenses.exceptions]]
 name = "systemd"
 version = "*"
-allow = ["LGPL-2.1-or-later"]
+allow = ["LGPL-2.1-or-later WITH GCC-exception-2.0"]
 
 [[licenses.exceptions]]
 name = "libsystemd-sys"
 version = "*"
-allow = ["LGPL-2.1-or-later"]
+allow = ["LGPL-2.1-or-later WITH GCC-exception-2.0"]
 
 # huggingface/xet-core (tag git-xet-v0.2.0) internal workspace crates don't
 # declare `license` in their per-crate Cargo.toml; the root repo is Apache-2.0.


### PR DESCRIPTION
## Problem

Three `cargo deny check licenses` failures on main after merging #467 (streaming plane restoration / iroh+moq).

## Fixes

### 1. `crates/hyprstream`: `AGPL-3.0` → `AGPL-3.0-only`

The bare `AGPL-3.0` SPDX identifier is deprecated; cargo-deny 0.19.9 rejects it. Corrected to `AGPL-3.0-only` — no legal change, same license, current identifier. Added `[[licenses.exceptions]]` for the `hyprstream` root crate so AGPL-3.0-only is permitted without adding it to the blanket dep allow list (keeps the gate tight).

### 2. `systemd` / `libsystemd-sys`: `LGPL-2.1-or-later WITH GCC-exception-2.0`

The GCC runtime library exception permits dynamic linking against LGPL libraries without copyleft propagation. Added `[[licenses.exceptions]]` for both crates allowing `LGPL-2.1-or-later`.

### 3. `webpki-roots` / `webpki-root-certs`: `CDLA-Permissive-2.0`

Community Data License Agreement — permissive. These crates carry CA certificate bundles (data, not code). Added `CDLA-Permissive-2.0` to the global allow list.

## Verification

```bash
cargo deny check bans licenses
```

Claude-Session: https://claude.ai/code/session_01U3qgsHTDWME66JFGZGS3ZA