### PR TITLE
feat(phase2): iroh wasm32 peer + pkarr lookup in browser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6659,6 +6659,7 @@ dependencies = [
  "ml-dsa",
  "ml-kem",
  "moq-net",
+ "n0-error",
  "nix 0.27.1",
  "once_cell",
  "p256",

--- a/crates/hyprstream-rpc-std/src/iroh_exports.rs
+++ b/crates/hyprstream-rpc-std/src/iroh_exports.rs
@@ -1,0 +1,136 @@
+//! wasm-bindgen exports for iroh peer identity + pkarr discovery (Phase 2).
+//!
+//! Wraps `hyprstream_rpc::iroh_peer` with wasm-bindgen so JavaScript can:
+//!
+//! 1. Generate an ephemeral iroh identity (`IrohPeer::new()`).
+//! 2. Get the browser's NodeId as bytes or as a `did:key` DID.
+//! 3. Resolve a peer's relay URL from the N0 pkarr relay
+//!    (replaces the manual HTTP fetch + DNS-wire parse in `atproto.ts`).
+//!
+//! # Usage (TypeScript)
+//!
+//! ```ts
+//! import { IrohPeer, irohNodeIdFromDidKey, irohDidKeyFromNodeId,
+//!          irohResolvePkarrRelayUrl } from 'hyprstream-rpc-std';
+//!
+//! // Generate a fresh browser identity.
+//! const peer = IrohPeer.new();
+//! console.log("NodeId (z32):", peer.nodeIdZ32());
+//! console.log("did:key:", peer.didKey());
+//!
+//! // Convert a did:key to raw NodeId bytes (for pkarr lookup).
+//! const nodeId = irohNodeIdFromDidKey("did:key:z6Mk...");
+//!
+//! // Resolve a peer's relay URL.
+//! const relayUrl = await irohResolvePkarrRelayUrl(nodeId);
+//! ```
+
+#![cfg(target_arch = "wasm32")]
+
+use wasm_bindgen::prelude::*;
+
+use hyprstream_rpc::iroh_peer::{
+    BrowserIrohPeer, did_key_from_node_id, node_id_from_did_key, resolve_pkarr_relay_url,
+};
+
+// ============================================================================
+// IrohPeer — ephemeral browser iroh identity
+// ============================================================================
+
+/// An ephemeral iroh peer identity for the browser.
+///
+/// Generates a fresh Ed25519 `SecretKey` on construction and derives the
+/// corresponding `EndpointId` (NodeId). This gives the browser a stable iroh
+/// identity for the session without binding a full `iroh::Endpoint`.
+#[wasm_bindgen(js_name = "IrohPeer")]
+pub struct WasmIrohPeer {
+    inner: BrowserIrohPeer,
+}
+
+#[wasm_bindgen(js_class = "IrohPeer")]
+impl WasmIrohPeer {
+    /// Generate a fresh ephemeral iroh peer identity.
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> WasmIrohPeer {
+        WasmIrohPeer {
+            inner: BrowserIrohPeer::new(),
+        }
+    }
+
+    /// The NodeId as a 32-byte `Uint8Array` (raw Ed25519 public key).
+    #[wasm_bindgen(js_name = "nodeIdBytes")]
+    pub fn node_id_bytes(&self) -> Vec<u8> {
+        self.inner.node_id_bytes().to_vec()
+    }
+
+    /// The NodeId encoded as z-base32 (used in pkarr gateway URLs).
+    #[wasm_bindgen(js_name = "nodeIdZ32")]
+    pub fn node_id_z32(&self) -> String {
+        self.inner.node_id_z32()
+    }
+
+    /// This peer's identity as a W3C `did:key` DID.
+    ///
+    /// E.g. `did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK`
+    #[wasm_bindgen(js_name = "didKey")]
+    pub fn did_key(&self) -> String {
+        self.inner.did_key()
+    }
+}
+
+impl Default for WasmIrohPeer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ============================================================================
+// did:key ↔ NodeId helpers (free functions)
+// ============================================================================
+
+/// Convert a `did:key:z6Mk...` DID to a 32-byte NodeId (`Uint8Array`).
+///
+/// Throws if the DID is not a valid ed25519 `did:key`.
+#[wasm_bindgen(js_name = "irohNodeIdFromDidKey")]
+pub fn node_id_from_did_key_js(did: &str) -> Result<Vec<u8>, JsError> {
+    node_id_from_did_key(did)
+        .map(|b| b.to_vec())
+        .map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Convert a 32-byte NodeId (`Uint8Array`) to a `did:key:z6Mk...` DID.
+///
+/// Throws if `node_id` is not exactly 32 bytes.
+#[wasm_bindgen(js_name = "irohDidKeyFromNodeId")]
+pub fn did_key_from_node_id_js(node_id: &[u8]) -> Result<String, JsError> {
+    let bytes: [u8; 32] = node_id
+        .try_into()
+        .map_err(|_| JsError::new("node_id must be exactly 32 bytes"))?;
+    Ok(did_key_from_node_id(&bytes))
+}
+
+// ============================================================================
+// Pkarr relay lookup
+// ============================================================================
+
+/// Resolve a peer's relay URL from the N0 pkarr relay.
+///
+/// - `node_id`: 32-byte Ed25519 pubkey (`Uint8Array`).
+/// - Returns the relay URL string, or `null` if the peer has no record.
+/// - Throws on network or parse errors.
+///
+/// This replaces the manual HTTP fetch + DNS-wire parse in `atproto.ts`'s
+/// `resolveDidKey()`. Both hit `https://dns.iroh.link/pkarr/<z32>`, but
+/// this path uses iroh's signature-verifying parser.
+#[wasm_bindgen(js_name = "irohResolvePkarrRelayUrl")]
+pub async fn resolve_pkarr_relay_url_js(node_id: &[u8]) -> Result<JsValue, JsError> {
+    let bytes: [u8; 32] = node_id
+        .try_into()
+        .map_err(|_| JsError::new("node_id must be exactly 32 bytes"))?;
+
+    match resolve_pkarr_relay_url(&bytes).await {
+        Ok(Some(url)) => Ok(JsValue::from_str(&url)),
+        Ok(None) => Ok(JsValue::NULL),
+        Err(e) => Err(JsError::new(&e.to_string())),
+    }
+}

--- a/crates/hyprstream-rpc-std/src/iroh_exports.rs
+++ b/crates/hyprstream-rpc-std/src/iroh_exports.rs
@@ -14,7 +14,7 @@
 //!          irohResolvePkarrRelayUrl } from 'hyprstream-rpc-std';
 //!
 //! // Generate a fresh browser identity.
-//! const peer = IrohPeer.new();
+//! const peer = new IrohPeer();
 //! console.log("NodeId (z32):", peer.nodeIdZ32());
 //! console.log("did:key:", peer.didKey());
 //!

--- a/crates/hyprstream-rpc-std/src/lib.rs
+++ b/crates/hyprstream-rpc-std/src/lib.rs
@@ -169,3 +169,6 @@ pub mod stream_mount;
 pub mod wasm_exports;
 #[cfg(target_arch = "wasm32")]
 pub mod wasm_rpc_client;
+// Phase 2: iroh peer identity + pkarr helpers exported to JavaScript.
+#[cfg(target_arch = "wasm32")]
+pub mod iroh_exports;

--- a/crates/hyprstream-rpc/Cargo.toml
+++ b/crates/hyprstream-rpc/Cargo.toml
@@ -75,6 +75,25 @@ getrandom = { version = "0.2", features = ["js"] }  # rand 0.8 uses getrandom 0.
 # Declare it (renamed to coexist with the 0.2 entry) so the feature unifies onto the
 # transitive 0.4 dep and the browser/WebTransport consumer compiles for wasm (#225).
 getrandom_v04 = { package = "getrandom", version = "0.4", features = ["wasm_js"] }
+# moq-net → rand 0.9.2 → getrandom 0.3 (distinct from 0.2 and 0.4 above).
+# Must enable wasm_js on this generation too or it refuses to build on wasm32.
+# iroh browser peer (Phase 2): iroh 1.0.0-rc.0 has upstream wasm32 support via
+# cfg(wasm_browser) = cfg(all(target_family="wasm", target_os="unknown")).
+# On wasm32, iroh uses PkarrResolver for peer discovery instead of DNS, and
+# WebTransport/relay as the bearer instead of UDP. The browser becomes a full
+# iroh peer with its own NodeId — same Rust code as native, compiled to wasm32.
+# Enables did:key resolution by NodeId via pkarr natively in the browser,
+# eliminating the pkarr HTTP gateway workaround in atproto.ts.
+iroh = { workspace = true }
+# web-transport-trait: the Session abstraction used by iroh's wasm32 bearer.
+web-transport-trait = { workspace = true }
+# url: needed by iroh_peer.rs to construct the pkarr relay URL for lookups.
+url = { workspace = true }
+# NOTE: moq-net is NOT added here. moq-net 0.1.8 has Session+Sync bounds that
+# conflict with browser WebTransport types (!Sync on wasm32). This requires an
+# upstream fix in moq-net before it can compile for wasm32-unknown-unknown.
+# Tracked separately; moq track subscribe/publish in the browser follows once
+# the upstream Send/Sync bounds are resolved.
 
 # Native-only deps (not compiled for wasm32)
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/hyprstream-rpc/Cargo.toml
+++ b/crates/hyprstream-rpc/Cargo.toml
@@ -89,6 +89,11 @@ iroh = { workspace = true }
 web-transport-trait = { workspace = true }
 # url: needed by iroh_peer.rs to construct the pkarr relay URL for lookups.
 url = { workspace = true }
+# n0-error: iroh's error type (`address_lookup::Error`) is type-erased through
+# n0-error's `AnyError`. iroh_peer.rs needs the `StackError` trait to walk the
+# source chain and downcast a pkarr 404 to `Ok(None)` (#475). Pinned to iroh's
+# transitive version so the `PkarrError` downcast resolves the same type.
+n0-error = "=1.0.0-rc.0"
 # NOTE: moq-net is NOT added here. moq-net 0.1.8 has Session+Sync bounds that
 # conflict with browser WebTransport types (!Sync on wasm32). This requires an
 # upstream fix in moq-net before it can compile for wasm32-unknown-unknown.

--- a/crates/hyprstream-rpc/src/did_key.rs
+++ b/crates/hyprstream-rpc/src/did_key.rs
@@ -1,0 +1,134 @@
+//! Shared `did:key` (Ed25519) ⇄ raw-key codec.
+//!
+//! This is the **single source of truth** for the `ed25519-pub` multicodec
+//! prefix, the base58btc multibase encoding, and DID-URL fragment/query
+//! stripping used to convert between a raw 32-byte Ed25519 public key and its
+//! `did:key:z6Mk…` / Multikey `publicKeyMultibase` forms.
+//!
+//! It is compiled on **all targets** (unlike `did_web`, which is native-only,
+//! and `iroh_peer`, which is wasm32-only) precisely so the native `did:web`
+//! admission resolver and the wasm32 `iroh_peer` browser identity helpers share
+//! one implementation and can never drift (#281/#475). `did_web` re-exports
+//! these as `crate::did_web::{decode_ed25519_multikey, did_key_to_ed25519,
+//! ed25519_to_did_key}` for source compatibility with existing callers.
+
+use anyhow::{anyhow, bail, Result};
+
+/// Multicodec `ed25519-pub` unsigned-varint prefix (`0xed01` → bytes `0xed 0x01`).
+///
+/// Mirrors `hyprstream::auth::mesh_trust::MULTICODEC_ED25519_PUB`; duplicated
+/// across the `hyprstream`/`hyprstream-rpc` crate boundary (a 2-byte constant)
+/// because `hyprstream-rpc` is the lower crate and cannot depend on `hyprstream`.
+/// Within `hyprstream-rpc`, however, this is the one definition every `did:key`
+/// codepath shares.
+pub(crate) const MULTICODEC_ED25519_PUB: [u8; 2] = [0xed, 0x01];
+
+/// Decode a `Multikey` `publicKeyMultibase` string into raw Ed25519 key bytes.
+///
+/// Verifies the base58btc multibase prefix (`z`) and the `ed25519-pub` multicodec
+/// header, returning the 32-byte payload.
+///
+/// Returns `Err` for a wrong multibase, an undecodable base58, a non-Ed25519
+/// codec, or a payload that is not exactly 32 bytes.
+pub fn decode_ed25519_multikey(multibase: &str) -> Result<[u8; 32]> {
+    let body = multibase
+        .strip_prefix('z')
+        .ok_or_else(|| anyhow!("Multikey must use base58btc multibase ('z') prefix"))?;
+    let decoded = bs58::decode(body)
+        .into_vec()
+        .map_err(|e| anyhow!("invalid base58btc Multikey: {e}"))?;
+    if decoded.len() < 2 || decoded[..2] != MULTICODEC_ED25519_PUB {
+        bail!(
+            "unexpected multicodec prefix (expected ed25519-pub {MULTICODEC_ED25519_PUB:02x?}, got {:02x?})",
+            decoded.get(..2).unwrap_or(&decoded)
+        );
+    }
+    let raw: [u8; 32] = decoded[2..]
+        .try_into()
+        .map_err(|_| anyhow!("ed25519 Multikey payload is {} bytes (expected 32)", decoded.len() - 2))?;
+    Ok(raw)
+}
+
+/// Decode a `did:key` (Ed25519) identifier into its raw 32-byte Ed25519 key.
+///
+/// For Ed25519 a `did:key` is *exactly* `"did:key:" + multibase-base58btc(0xed01
+/// ‖ pubkey)` — i.e. the method-specific identifier is the same `Multikey`
+/// `publicKeyMultibase` value [`decode_ed25519_multikey`] decodes. A `did:key`
+/// is therefore **self-contained**: the key *is* the identity, so this is a pure
+/// decode with **no network fetch**.
+///
+/// Returns `Err` for a non-`did:key` identifier, a non-Ed25519 multicodec, a bad
+/// multibase, or a wrong-length payload. A DID URL fragment / query is stripped
+/// (`did:key:z6Mk…#z6Mk…` self-references the same key; we decode the base
+/// method-specific identifier).
+pub fn did_key_to_ed25519(did: &str) -> Result<[u8; 32]> {
+    // Strip any DID URL fragment / query before decoding (a `#fragment` or
+    // `?query` would otherwise corrupt the base58btc body).
+    let did = did.split(['#', '?']).next().unwrap_or(did);
+    let msi = did
+        .strip_prefix("did:key:")
+        .ok_or_else(|| anyhow!("not a did:key identifier: {did}"))?;
+    if msi.is_empty() {
+        bail!("did:key has empty method-specific identifier: {did}");
+    }
+    // The method-specific id IS a Multikey `publicKeyMultibase`; reuse the one
+    // source of truth for the ed25519-pub multicodec (no duplicated 0xed01).
+    decode_ed25519_multikey(msi)
+        .map_err(|e| anyhow!("did:key {did} is not a valid Ed25519 Multikey: {e}"))
+}
+
+/// Encode a raw 32-byte Ed25519 public key as a `did:key` (Ed25519) identifier
+/// (`did:key:z6Mk…`).
+///
+/// The produced string is `"did:key:" + ed25519_to_multibase(key)` and
+/// round-trips with [`did_key_to_ed25519`]; the Multikey body is byte-identical
+/// to the `publicKeyMultibase` our DID documents publish (one multicodec source
+/// of truth over the same `0xed01 ‖ key` payload).
+pub fn ed25519_to_did_key(key: &[u8; 32]) -> String {
+    let mut payload = Vec::with_capacity(2 + 32);
+    payload.extend_from_slice(&MULTICODEC_ED25519_PUB);
+    payload.extend_from_slice(key);
+    format!("did:key:z{}", bs58::encode(payload).into_string())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn rand_ed25519() -> [u8; 32] {
+        use ed25519_dalek::SigningKey;
+        use rand::rngs::OsRng;
+        SigningKey::generate(&mut OsRng).verifying_key().to_bytes()
+    }
+
+    #[test]
+    fn did_key_roundtrips_random_key() {
+        for _ in 0..16 {
+            let raw = rand_ed25519();
+            assert_eq!(did_key_to_ed25519(&ed25519_to_did_key(&raw)).unwrap(), raw);
+        }
+    }
+
+    #[test]
+    fn did_key_strips_fragment_and_query() {
+        let raw = [3u8; 32];
+        let base = ed25519_to_did_key(&raw);
+        let mb = base.strip_prefix("did:key:").unwrap();
+        // Self-referencing fragment (`#z6Mk…`) — the common DID-URL VM id form.
+        assert_eq!(did_key_to_ed25519(&format!("{base}#{mb}")).unwrap(), raw);
+        // Query parameter.
+        assert_eq!(did_key_to_ed25519(&format!("{base}?versionId=1")).unwrap(), raw);
+    }
+
+    #[test]
+    fn did_key_rejects_malformed() {
+        assert!(did_key_to_ed25519("did:web:example.com").is_err());
+        assert!(did_key_to_ed25519("did:key:").is_err());
+        // ed25519-pub multicodec but a 31-byte payload (wrong length).
+        let mut payload = vec![0xedu8, 0x01];
+        payload.extend_from_slice(&[0u8; 31]);
+        let did = format!("did:key:z{}", bs58::encode(payload).into_string());
+        assert!(did_key_to_ed25519(&did).is_err());
+    }
+}

--- a/crates/hyprstream-rpc/src/did_web.rs
+++ b/crates/hyprstream-rpc/src/did_web.rs
@@ -233,91 +233,17 @@ pub fn preferred_transport(doc: &Value, kind: Option<SocketKind>) -> Option<Tran
 
 // ── DID-doc → verification-method keys (#137 admission stage 2) ────────────────
 
-/// Multicodec `ed25519-pub` unsigned-varint prefix (`0xed01` → bytes `0xed 0x01`).
-///
-/// Mirrors `hyprstream::auth::mesh_trust::MULTICODEC_ED25519_PUB`; duplicated here
-/// (a 2-byte constant) because `hyprstream-rpc` is the lower crate and cannot
-/// depend on `hyprstream` for the `verificationMethod` decode the admission gate
-/// (#137) needs at this layer.
-const MULTICODEC_ED25519_PUB: [u8; 2] = [0xed, 0x01];
-
-/// Decode a `Multikey` `publicKeyMultibase` string into raw Ed25519 key bytes.
-///
-/// Verifies the base58btc multibase prefix (`z`) and the `ed25519-pub` multicodec
-/// header, returning the 32-byte payload. This is the `did_web`/`hyprstream-rpc`
-/// sibling of `hyprstream::auth::mesh_trust::decode_multikey` (kept local because
-/// `hyprstream-rpc` cannot depend on `hyprstream`); both are exercised against the
-/// same `encode_multikey` output in tests.
-///
-/// Returns `Err` for a wrong multibase, an undecodable base58, a non-Ed25519
-/// codec, or a payload that is not exactly 32 bytes.
-pub fn decode_ed25519_multikey(multibase: &str) -> Result<[u8; 32]> {
-    let body = multibase
-        .strip_prefix('z')
-        .ok_or_else(|| anyhow!("Multikey must use base58btc multibase ('z') prefix"))?;
-    let decoded = bs58::decode(body)
-        .into_vec()
-        .map_err(|e| anyhow!("invalid base58btc Multikey: {e}"))?;
-    if decoded.len() < 2 || decoded[..2] != MULTICODEC_ED25519_PUB {
-        bail!(
-            "unexpected multicodec prefix (expected ed25519-pub {MULTICODEC_ED25519_PUB:02x?}, got {:02x?})",
-            decoded.get(..2).unwrap_or(&decoded)
-        );
-    }
-    let raw: [u8; 32] = decoded[2..]
-        .try_into()
-        .map_err(|_| anyhow!("ed25519 Multikey payload is {} bytes (expected 32)", decoded.len() - 2))?;
-    Ok(raw)
-}
-
-// ── did:key (Ed25519) interop (#281) ──────────────────────────────────────────
-
-/// Decode a `did:key` (Ed25519) identifier into its raw 32-byte Ed25519 key.
-///
-/// Tiles (and the broader did:key ecosystem) uses `did:key` for self-certifying
-/// device/account identity. For Ed25519 a `did:key` is *exactly*
-/// `"did:key:" + multibase-base58btc(0xed01 ‖ pubkey)` — i.e. the method-specific
-/// identifier is the same `Multikey` `publicKeyMultibase` value we already decode
-/// for `verificationMethod` (see [`decode_ed25519_multikey`]). A `did:key` is
-/// therefore **self-contained**: the key *is* the identity, so this is a pure
-/// decode with **no network fetch** (the inverse of `did:web`, which resolves a
-/// document). Reach for a `did:key` peer comes from iroh discovery (#282), not the
-/// DID string.
-///
-/// Returns `Err` for a non-`did:key` identifier, a non-Ed25519 multicodec, a bad
-/// multibase, or a wrong-length payload. A DID URL fragment / query is stripped
-/// (we decode the base identifier).
-pub fn did_key_to_ed25519(did: &str) -> Result<[u8; 32]> {
-    // Strip any DID URL fragment / query (`did:key:z6Mk…#z6Mk…` self-references
-    // the same key; we decode the base method-specific identifier).
-    let did = did.split(['#', '?']).next().unwrap_or(did);
-    let msi = did
-        .strip_prefix("did:key:")
-        .ok_or_else(|| anyhow!("not a did:key identifier: {did}"))?;
-    if msi.is_empty() {
-        bail!("did:key has empty method-specific identifier: {did}");
-    }
-    // The method-specific id IS a Multikey `publicKeyMultibase`; reuse the one
-    // source of truth for the ed25519-pub multicodec (no duplicated 0xed01).
-    decode_ed25519_multikey(msi)
-        .map_err(|e| anyhow!("did:key {did} is not a valid Ed25519 Multikey: {e}"))
-}
-
-/// Encode a raw 32-byte Ed25519 public key as a `did:key` (Ed25519) identifier
-/// (`did:key:z6Mk…`).
-///
-/// Reverse interop for #281: lets our Ed25519 keys (the `#mesh` / `#iroh` VMs)
-/// render as the `did:key` form Tiles and other did:key consumers expect. The
-/// produced string is `"did:key:" + ed25519_to_multibase(key)` and round-trips
-/// with [`did_key_to_ed25519`]; the Multikey body is byte-identical to the
-/// `publicKeyMultibase` our DID documents publish (`#280`'s `ed25519_to_multibase`
-/// over the same `0xed01 ‖ key` payload — one multicodec source of truth).
-pub fn ed25519_to_did_key(key: &[u8; 32]) -> String {
-    let mut payload = Vec::with_capacity(2 + 32);
-    payload.extend_from_slice(&MULTICODEC_ED25519_PUB);
-    payload.extend_from_slice(key);
-    format!("did:key:z{}", bs58::encode(payload).into_string())
-}
+// The `did:key` (Ed25519) codec — `MULTICODEC_ED25519_PUB`,
+// `decode_ed25519_multikey`, `did_key_to_ed25519`, `ed25519_to_did_key` — lives
+// in the cross-target [`crate::did_key`] module so the native `did_web` resolver
+// (#279/#137/#281) and the wasm32 `iroh_peer` browser identity helpers (#475)
+// share one implementation and cannot drift. They are re-exported here so
+// existing `crate::did_web::*` callers (admission gate, federation tests) are
+// unaffected.
+pub use crate::did_key::{decode_ed25519_multikey, did_key_to_ed25519, ed25519_to_did_key};
+// Only the test multikey helper references the raw multicodec constant now.
+#[cfg(test)]
+use crate::did_key::MULTICODEC_ED25519_PUB;
 
 /// Whether `did` is a `did:key` identifier (the self-certifying interop arm).
 ///

--- a/crates/hyprstream-rpc/src/iroh_peer.rs
+++ b/crates/hyprstream-rpc/src/iroh_peer.rs
@@ -96,49 +96,35 @@ impl Default for BrowserIrohPeer {
 // ============================================================================
 // did:key ↔ NodeId conversions
 // ============================================================================
+//
+// The actual `did:key` (Ed25519) codec lives in the cross-target
+// [`crate::did_key`] module — the SAME implementation the native `did_web`
+// resolver uses (#475). An iroh NodeId IS a 32-byte Ed25519 public key, so the
+// NodeId ⇄ did:key mapping is exactly the Ed25519 ⇄ did:key codec. Delegating
+// here keeps the multicodec constant and the DID-URL fragment/query stripping in
+// one place so the native and wasm32 paths can never drift.
 
 /// Convert a 32-byte iroh NodeId to a `did:key:z6Mk...` DID.
 ///
-/// Encodes the pubkey with multicodec prefix `0xed 0x01` (ed25519-pub) in
-/// base58btc, then prepends `did:key:z`.
+/// Thin wasm32 alias for [`crate::did_key::ed25519_to_did_key`] (the NodeId is
+/// the Ed25519 public key).
 pub fn did_key_from_node_id(node_id_bytes: &[u8; 32]) -> String {
-    let mut payload = Vec::with_capacity(34);
-    payload.push(0xed); // multicodec ed25519-pub high byte (varint)
-    payload.push(0x01); // multicodec ed25519-pub low byte
-    payload.extend_from_slice(node_id_bytes);
-    let encoded = bs58::encode(&payload).into_string();
-    format!("did:key:z{encoded}")
+    crate::did_key::ed25519_to_did_key(node_id_bytes)
 }
 
 /// Extract the raw 32-byte NodeId from a `did:key:z6Mk...` DID.
 ///
-/// The `did:key` spec encodes ed25519 keys as multibase base58btc (`z` prefix)
-/// with the `0xed 0x01` multicodec prefix. The 32 bytes following the
-/// multicodec prefix are the iroh `EndpointId`.
+/// Thin wasm32 alias for [`crate::did_key::did_key_to_ed25519`]. The 32 decoded
+/// bytes are the iroh `EndpointId`. Unlike the previous local copy, this strips a
+/// DID URL fragment / query (`did:key:z6Mk…#z6Mk…`) before decoding, matching the
+/// native `did_web` behavior.
 ///
 /// # Errors
 ///
 /// Returns an error if the DID is not base58btc, not an ed25519 key, or
 /// malformed.
 pub fn node_id_from_did_key(did: &str) -> Result<[u8; 32]> {
-    if !did.starts_with("did:key:z") {
-        return Err(anyhow!(
-            "did:key must use base58btc multibase (z-prefix), got: {did}"
-        ));
-    }
-    let encoded = &did["did:key:z".len()..];
-    let decoded = bs58::decode(encoded)
-        .into_vec()
-        .map_err(|e| anyhow!("base58btc decode failed: {e}"))?;
-
-    if decoded.len() < 34 || decoded[0] != 0xed || decoded[1] != 0x01 {
-        return Err(anyhow!(
-            "did:key is not an ed25519 key (expected multicodec 0xed01): {did}"
-        ));
-    }
-    decoded[2..34]
-        .try_into()
-        .map_err(|_| anyhow!("truncated did:key pubkey"))
+    crate::did_key::did_key_to_ed25519(did)
 }
 
 // ============================================================================

--- a/crates/hyprstream-rpc/src/iroh_peer.rs
+++ b/crates/hyprstream-rpc/src/iroh_peer.rs
@@ -31,7 +31,9 @@
 #![cfg(target_arch = "wasm32")]
 
 use anyhow::{anyhow, Result};
+use iroh::address_lookup::PkarrError;
 use iroh::{EndpointId, SecretKey};
+use n0_error::StackError;
 
 // ============================================================================
 // BrowserIrohPeer — ephemeral iroh identity without a full Endpoint bind
@@ -154,10 +156,17 @@ pub async fn resolve_pkarr_relay_url(node_id_bytes: &[u8; 32]) -> Result<Option<
 
     let client = iroh::address_lookup::PkarrRelayClient::new(pkarr_relay_url);
 
-    let signed_packet = client
-        .resolve(node_id)
-        .await
-        .map_err(|e| anyhow!("pkarr resolve failed: {e:?}"))?;
+    let signed_packet = match client.resolve(node_id).await {
+        Ok(packet) => packet,
+        // The pkarr relay returns HTTP 404 when the peer has never published a
+        // record. That is a *negative answer*, not a failure — surface it as
+        // `Ok(None)` so callers can distinguish "peer not found" from a genuine
+        // network/transport error (which stays `Err`). Without this the 404
+        // `PkarrError::HttpRequest` would bubble up as a thrown JsError and the
+        // documented `Ok(None)` branch would be dead code.
+        Err(e) if is_pkarr_not_found(&e) => return Ok(None),
+        Err(e) => return Err(anyhow!("pkarr resolve failed: {e:?}")),
+    };
 
     // Parse the DNS wire packet into EndpointInfo and extract the first relay URL.
     let endpoint_info = iroh::endpoint_info::EndpointInfo::from_pkarr_signed_packet(&signed_packet)
@@ -169,4 +178,22 @@ pub async fn resolve_pkarr_relay_url(node_id_bytes: &[u8; 32]) -> Result<Option<
         .map(|url| url.to_string());
 
     Ok(relay_url)
+}
+
+/// Whether a pkarr resolve error is the "no record for this peer" case (HTTP
+/// 404), as opposed to a genuine network/transport/verification failure.
+///
+/// `PkarrRelayClient::resolve` returns the type-erased
+/// [`iroh::address_lookup::Error`], which wraps the underlying [`PkarrError`]
+/// through n0-error's `AnyError`. We walk the [`StackError`] source chain and
+/// downcast each link to [`PkarrError`], matching the `HttpRequest { status }`
+/// variant carrying a `404 Not Found`. Any other status (or a `HttpSend` /
+/// `Verify` / etc. variant) is a real error the caller should see.
+fn is_pkarr_not_found(err: &iroh::address_lookup::Error) -> bool {
+    err.stack().any(|source| {
+        matches!(
+            source.downcast_ref::<PkarrError>(),
+            Some(PkarrError::HttpRequest { status, .. }) if status.as_u16() == 404
+        )
+    })
 }

--- a/crates/hyprstream-rpc/src/iroh_peer.rs
+++ b/crates/hyprstream-rpc/src/iroh_peer.rs
@@ -1,0 +1,186 @@
+//! Browser (wasm32) iroh peer identity and pkarr helpers.
+//!
+//! Phase 2 adds iroh as a first-class wasm32 dependency, enabling:
+//!
+//! 1. **Browser iroh identity** — `BrowserIrohPeer` generates a fresh Ed25519
+//!    SecretKey and exposes the derived NodeId / EndpointId, which equals the
+//!    32-byte pubkey. The NodeId IS the iroh peer identity.
+//!
+//! 2. **did:key ↔ NodeId helpers** — bidirectional conversion between iroh's
+//!    `EndpointId` (32-byte ed25519 pubkey) and the W3C `did:key` DID that
+//!    atproto and hyprstream use to identify peers.
+//!
+//! 3. **Pkarr lookup** — `resolve_pkarr` wraps `PkarrRelayClient` to fetch a
+//!    peer's relay URL from the N0 pkarr relay without a full iroh endpoint bind.
+//!    This replaces the manual HTTP fetch + DNS-wire parse in `atproto.ts`.
+//!
+//! # What's NOT in Phase 2
+//!
+//! **Full iroh Endpoint bind**: creating a listening `iroh::Endpoint` (own relay
+//! address, pkarr publisher, relay keep-alive) is expensive and deferred. It's
+//! needed for dial_iroh_reach() (Phase 3) but not for identity + resolution.
+//!
+//! **moq-net wasm32**: moq-net 0.1.8 has `Session + Sync` bounds incompatible
+//! with browser `!Sync` types. Upstream fix needed before moq subscribe/publish
+//! can be wired into the browser via the same wasm seam.
+//!
+//! **dial_iroh_reach()**: connecting to a hyprstream server by iroh NodeId
+//! requires a new RPC transport over `iroh::Connection` bidi streams. Deferred;
+//! current browser RPC still uses ZMTP/WebTransport (`dial_wasm::dial`).
+
+#![cfg(target_arch = "wasm32")]
+
+use anyhow::{anyhow, Result};
+use iroh::{EndpointId, SecretKey};
+
+// ============================================================================
+// BrowserIrohPeer — ephemeral iroh identity without a full Endpoint bind
+// ============================================================================
+
+/// A browser iroh peer identity.
+///
+/// Generates a fresh Ed25519 `SecretKey` and derives the corresponding
+/// `EndpointId` (NodeId). This provides the browser with a stable iroh
+/// identity for the session without the cost of binding a full
+/// `iroh::Endpoint` (relay connection, pkarr publisher, background tasks).
+///
+/// The SecretKey is held in memory only; it is not persisted. Each call to
+/// `new()` produces a fresh identity.
+pub struct BrowserIrohPeer {
+    secret_key: SecretKey,
+}
+
+impl BrowserIrohPeer {
+    /// Generate a fresh ephemeral iroh peer identity.
+    pub fn new() -> Self {
+        Self {
+            secret_key: SecretKey::generate(),
+        }
+    }
+
+    /// The iroh `EndpointId` (NodeId) for this peer.
+    ///
+    /// The EndpointId is the Ed25519 public key corresponding to `secret_key`.
+    /// It is stable for the lifetime of this struct.
+    pub fn endpoint_id(&self) -> EndpointId {
+        self.secret_key.public()
+    }
+
+    /// The NodeId as a 32-byte array (raw Ed25519 pubkey).
+    pub fn node_id_bytes(&self) -> [u8; 32] {
+        *self.secret_key.public().as_bytes()
+    }
+
+    /// Encode the NodeId as z-base32 (Zooko's base32).
+    ///
+    /// Used in pkarr gateway URLs: `https://dns.iroh.link/pkarr/<z32>`.
+    pub fn node_id_z32(&self) -> String {
+        self.endpoint_id().to_z32()
+    }
+
+    /// Express this peer's NodeId as a W3C `did:key`.
+    ///
+    /// The did:key format encodes Ed25519 keys as base58btc multibase with the
+    /// `0xed 0x01` multicodec prefix.
+    pub fn did_key(&self) -> String {
+        did_key_from_node_id(&self.node_id_bytes())
+    }
+}
+
+impl Default for BrowserIrohPeer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ============================================================================
+// did:key ↔ NodeId conversions
+// ============================================================================
+
+/// Convert a 32-byte iroh NodeId to a `did:key:z6Mk...` DID.
+///
+/// Encodes the pubkey with multicodec prefix `0xed 0x01` (ed25519-pub) in
+/// base58btc, then prepends `did:key:z`.
+pub fn did_key_from_node_id(node_id_bytes: &[u8; 32]) -> String {
+    let mut payload = Vec::with_capacity(34);
+    payload.push(0xed); // multicodec ed25519-pub high byte (varint)
+    payload.push(0x01); // multicodec ed25519-pub low byte
+    payload.extend_from_slice(node_id_bytes);
+    let encoded = bs58::encode(&payload).into_string();
+    format!("did:key:z{encoded}")
+}
+
+/// Extract the raw 32-byte NodeId from a `did:key:z6Mk...` DID.
+///
+/// The `did:key` spec encodes ed25519 keys as multibase base58btc (`z` prefix)
+/// with the `0xed 0x01` multicodec prefix. The 32 bytes following the
+/// multicodec prefix are the iroh `EndpointId`.
+///
+/// # Errors
+///
+/// Returns an error if the DID is not base58btc, not an ed25519 key, or
+/// malformed.
+pub fn node_id_from_did_key(did: &str) -> Result<[u8; 32]> {
+    if !did.starts_with("did:key:z") {
+        return Err(anyhow!(
+            "did:key must use base58btc multibase (z-prefix), got: {did}"
+        ));
+    }
+    let encoded = &did["did:key:z".len()..];
+    let decoded = bs58::decode(encoded)
+        .into_vec()
+        .map_err(|e| anyhow!("base58btc decode failed: {e}"))?;
+
+    if decoded.len() < 34 || decoded[0] != 0xed || decoded[1] != 0x01 {
+        return Err(anyhow!(
+            "did:key is not an ed25519 key (expected multicodec 0xed01): {did}"
+        ));
+    }
+    decoded[2..34]
+        .try_into()
+        .map_err(|_| anyhow!("truncated did:key pubkey"))
+}
+
+// ============================================================================
+// Pkarr relay lookup (N0 relay — same HTTP endpoint as atproto.ts fallback)
+// ============================================================================
+
+/// Resolve a peer's relay URL from the N0 pkarr relay via iroh's PkarrRelayClient.
+///
+/// Fetches `https://dns.iroh.link/pkarr/<z32-node-id>` using the iroh
+/// `PkarrRelayClient`. The client verifies the Ed25519 signature on the
+/// response and parses the `EndpointInfo` (relay URLs + IP addresses).
+///
+/// This is equivalent to the `atproto.ts` HTTP-fetch workaround but uses
+/// iroh's verified parser instead of manual DNS-wire parsing.
+///
+/// # Returns
+///
+/// `Ok(Some(relay_url))` if the peer has published a relay URL.
+/// `Ok(None)` if the peer has no record or no relay URL in the record.
+/// `Err(_)` if the pkarr relay is unreachable or the response is invalid.
+pub async fn resolve_pkarr_relay_url(node_id_bytes: &[u8; 32]) -> Result<Option<String>> {
+    let node_id = EndpointId::from_bytes(node_id_bytes)
+        .map_err(|e| anyhow!("invalid node_id bytes: {e:?}"))?;
+    let pkarr_relay_url: url::Url = "https://dns.iroh.link/pkarr"
+        .parse()
+        .expect("N0 pkarr relay URL is valid");
+
+    let client = iroh::address_lookup::PkarrRelayClient::new(pkarr_relay_url);
+
+    let signed_packet = client
+        .resolve(node_id)
+        .await
+        .map_err(|e| anyhow!("pkarr resolve failed: {e:?}"))?;
+
+    // Parse the DNS wire packet into EndpointInfo and extract the first relay URL.
+    let endpoint_info = iroh::endpoint_info::EndpointInfo::from_pkarr_signed_packet(&signed_packet)
+        .map_err(|e| anyhow!("EndpointInfo parse failed: {e:?}"))?;
+
+    let relay_url = endpoint_info
+        .relay_urls()
+        .next()
+        .map(|url| url.to_string());
+
+    Ok(relay_url)
+}

--- a/crates/hyprstream-rpc/src/lib.rs
+++ b/crates/hyprstream-rpc/src/lib.rs
@@ -188,6 +188,11 @@ pub mod web_transport;
 // native `dial()` (which is itself `#[cfg(not(target_arch = "wasm32"))]`).
 #[cfg(target_arch = "wasm32")]
 pub mod dial_wasm;
+// Phase 2: iroh peer identity + pkarr helpers for wasm32. Adds iroh as a
+// first-class wasm32 dep — browser gets own NodeId, did:key conversion,
+// and native pkarr lookup. Full dial_iroh_reach() is Phase 3.
+#[cfg(target_arch = "wasm32")]
+pub mod iroh_peer;
 
 // ============================================================================
 // Re-exports available on ALL targets

--- a/crates/hyprstream-rpc/src/lib.rs
+++ b/crates/hyprstream-rpc/src/lib.rs
@@ -164,6 +164,10 @@ pub mod transport;
 pub mod dial;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod service_entry;
+// Shared `did:key` (Ed25519) codec — compiled on all targets so the native
+// `did_web` resolver and the wasm32 `iroh_peer` identity helpers share one
+// implementation (#475). `did_web` re-exports its public fns for compatibility.
+pub mod did_key;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod did_web;
 #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
## Summary

Adds iroh as a wasm32 dependency in `hyprstream-rpc`, making the browser a full iroh peer with its own NodeId and pkarr-based address discovery. This is the backend half of Phase 2 — the frontend `transport.ts` becomes a thin binding over these wasm exports instead of a hand-rolled JS WebTransport dialer.

## What lands

- `crates/hyprstream-rpc/src/iroh_peer.rs`: `BrowserIrohPeer` — iroh peer lifecycle, NodeId, `did:key` helpers, pkarr HTTP gateway lookup
- `crates/hyprstream-rpc/src/iroh_exports.rs`: `#[wasm_bindgen]` exports: `IrohPeer` class + `resolve_did_key_pkarr()` free function

## What's deferred (upstream blocker)

`moq-net 0.1.8` requires `Session: Sync`, which is incompatible with browser WebTransport's `!Sync` types. `dial_iroh_reach()` (moq track subscribe/publish over iroh in the browser) is deferred until this is fixed upstream or worked around. See upstream issue (to be filed). The existing `QuicReach` WebTransport path continues to handle browser streaming in the interim.

## CI

`cargo check --target wasm32-unknown-unknown -p hyprstream-rpc` passes (same gate as the CI `wasm` job).

## Sequencing

- Phase 1 (atproto identity, GitLab !18): independent, can merge now
- This PR (Phase 2a): iroh peer + pkarr in browser
- Phase 2b: `dial_iroh_reach()` — gated on moq-net upstream Sync fix
- Phase 3 (StreamInfo regen): gated on #471 merging

Claude-Session: https://claude.ai/code/session_01U3qgsHTDWME66JFGZGS3ZA