### PR TITLE
feat(workers): availability-based backend auto-selection (#348)

### DIFF
--- a/crates/hyprstream-workers/src/config.rs
+++ b/crates/hyprstream-workers/src/config.rs
@@ -13,17 +13,49 @@ use std::path::PathBuf;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum BackendType {
-    /// Kata Containers (default — full VM isolation)
+    /// Auto-detect: probe availability in order Kata → Podman → Nspawn and
+    /// pick the best backend available on the current host.  This is the
+    /// operator-friendly default — the same binary works on a developer laptop
+    /// (podman/nspawn) and a production node (Kata/cloud-hypervisor).
     #[default]
+    Auto,
+    /// Kata Containers — full hardware VM isolation (requires cloud-hypervisor).
     Kata,
-    /// systemd-nspawn (lightweight container, rootless, host filesystem)
+    /// Rootless podman (or docker) OCI containers — no hypervisor.
+    Podman,
+    /// systemd-nspawn — lightweight container, rootless, host filesystem.
     Nspawn,
+}
+
+impl BackendType {
+    /// Probe availability of each concrete backend in priority order and return
+    /// the first one whose binary / runtime is present on the host.
+    ///
+    /// Fallback chain: Kata → Podman → Nspawn.
+    /// `Auto` itself resolves to the result of this function; all other
+    /// variants resolve to themselves (no probing needed).
+    pub fn resolve(self) -> Self {
+        if self != Self::Auto {
+            return self;
+        }
+        #[cfg(feature = "kata-vm")]
+        if which::which("cloud-hypervisor").is_ok() {
+            return Self::Kata;
+        }
+        #[cfg(feature = "podman")]
+        if which::which("podman").is_ok() || which::which("docker").is_ok() {
+            return Self::Podman;
+        }
+        Self::Nspawn
+    }
 }
 
 impl std::fmt::Display for BackendType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::Auto => write!(f, "auto"),
             Self::Kata => write!(f, "kata"),
+            Self::Podman => write!(f, "podman"),
             Self::Nspawn => write!(f, "nspawn"),
         }
     }
@@ -299,7 +331,22 @@ mod tests {
 
     #[test]
     fn test_backend_type_default() {
-        assert_eq!(BackendType::default(), BackendType::Kata);
+        // Default is Auto (operator-friendly; resolves at runtime).
+        assert_eq!(BackendType::default(), BackendType::Auto);
+    }
+
+    #[test]
+    fn test_backend_type_resolve_identity() {
+        // Concrete variants are idempotent under resolve().
+        assert_eq!(BackendType::Nspawn.resolve(), BackendType::Nspawn);
+        assert_eq!(BackendType::Kata.resolve(), BackendType::Kata);
+        assert_eq!(BackendType::Podman.resolve(), BackendType::Podman);
+    }
+
+    #[test]
+    fn test_backend_type_auto_resolves_to_concrete() {
+        // Auto must not resolve to itself.
+        assert_ne!(BackendType::Auto.resolve(), BackendType::Auto);
     }
 
     #[test]
@@ -311,12 +358,22 @@ mod tests {
         let yaml = "backend: kata\n";
         let config: WorkerConfig = serde_yaml::from_str(yaml)?;
         assert_eq!(config.backend, BackendType::Kata);
+
+        let yaml = "backend: podman\n";
+        let config: WorkerConfig = serde_yaml::from_str(yaml)?;
+        assert_eq!(config.backend, BackendType::Podman);
+
+        let yaml = "backend: auto\n";
+        let config: WorkerConfig = serde_yaml::from_str(yaml)?;
+        assert_eq!(config.backend, BackendType::Auto);
         Ok(())
     }
 
     #[test]
     fn test_backend_type_display() {
+        assert_eq!(BackendType::Auto.to_string(), "auto");
         assert_eq!(BackendType::Kata.to_string(), "kata");
+        assert_eq!(BackendType::Podman.to_string(), "podman");
         assert_eq!(BackendType::Nspawn.to_string(), "nspawn");
     }
 }

--- a/crates/hyprstream-workers/src/lib.rs
+++ b/crates/hyprstream-workers/src/lib.rs
@@ -70,6 +70,8 @@ pub use error::WorkerError;
 pub use runtime::{WorkerService, SandboxBackend, SandboxHandle, NspawnBackend, NspawnConfig};
 #[cfg(feature = "kata-vm")]
 pub use runtime::KataBackend;
+#[cfg(feature = "podman")]
+pub use runtime::{PodmanBackend, PodmanConfig};
 #[cfg(feature = "kata-vm")]
 pub use image::RafsStore;
 pub use workflow::WorkflowService;

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -201,6 +201,7 @@ download-libtorch = ["tch/download-libtorch"]
 overlayfs = ["git2db/overlayfs"]  # Enable overlayfs-backed worktrees (delegated to git2db)
 systemd = ["hyprstream-rpc/systemd", "hyprstream-service/systemd", "hyprstream-workers/systemd", "dep:listenfd"]  # Systemd integration (socket activation, service units)
 kata-vm = ["hyprstream-workers/kata-vm"]  # Kata/Cloud-Hypervisor VM worker backend + RAFS/nydus image stack (in default; drop for an nspawn-only build)
+podman = ["hyprstream-workers/podman"]   # Rootless podman/docker OCI worker backend (auto-selected when kata-vm not built or cloud-hypervisor absent)
 experimental = ["hyprstream-compositor/experimental"]  # EXPERIMENTAL: Enable service/worker panels, git write operations
 pq-hybrid = []  # NO-OP alias: PQ primitives always compiled; Classical/Hybrid selected at runtime. See M3 #152.
 

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1076,24 +1076,39 @@ fn handle_quick_command(
 
                     let _worker_handle = if !worker_already_running {
                         use hyprstream_workers::runtime::SandboxBackend;
+                        use hyprstream_workers::config::BackendType;
 
-                        // VM path (kata-vm): Kata backend + RAFS image store.
+                        // Resolve the backend: read config if available, else auto-detect.
+                        let backend_type = HyprConfig::load()
+                            .ok()
+                            .and_then(|c| c.worker)
+                            .map(|w| w.backend)
+                            .unwrap_or_default()
+                            .resolve();
+
+                        // Always build rafs_store when kata-vm feature is compiled in
+                        // (WorkerService::new requires it regardless of backend chosen).
                         #[cfg(feature = "kata-vm")]
                         let rafs_store = {
                             use hyprstream_workers::image::RafsStore;
                             Arc::new(RafsStore::new(image_config.clone())?)
                         };
-                        #[cfg(feature = "kata-vm")]
-                        let backend: Arc<dyn SandboxBackend> = {
-                            use hyprstream_workers::runtime::KataBackend;
-                            Arc::new(KataBackend::new(image_config, Arc::clone(&rafs_store)))
-                        };
-                        // Without kata-vm the CLI worker entrypoint falls back to
-                        // the lightweight nspawn backend.
-                        #[cfg(not(feature = "kata-vm"))]
-                        let backend: Arc<dyn SandboxBackend> = {
-                            use hyprstream_workers::{NspawnBackend, NspawnConfig};
-                            Arc::new(NspawnBackend::new(NspawnConfig::default()))
+
+                        let backend: Arc<dyn SandboxBackend> = match backend_type {
+                            #[cfg(feature = "kata-vm")]
+                            BackendType::Kata => {
+                                use hyprstream_workers::runtime::KataBackend;
+                                Arc::new(KataBackend::new(image_config, Arc::clone(&rafs_store)))
+                            }
+                            #[cfg(feature = "podman")]
+                            BackendType::Podman => {
+                                use hyprstream_workers::{PodmanBackend, PodmanConfig};
+                                Arc::new(PodmanBackend::new(PodmanConfig::default()))
+                            }
+                            _ => {
+                                use hyprstream_workers::{NspawnBackend, NspawnConfig};
+                                Arc::new(NspawnBackend::new(NspawnConfig::default()))
+                            }
                         };
 
                         let worker_transport =

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -660,14 +660,22 @@ fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
     #[cfg(feature = "kata-vm")]
     use hyprstream_workers::KataBackend;
     use hyprstream_workers::{WorkerService, SandboxBackend, NspawnBackend, NspawnConfig};
+    #[cfg(feature = "podman")]
+    use hyprstream_workers::{PodmanBackend, PodmanConfig};
 
     let config = load_config();
     let worker_quic_port = config.worker.as_ref().and_then(|w| w.quic_port);
-    let backend_type = config.worker.as_ref()
+    let configured_backend = config.worker.as_ref()
         .map(|w| w.backend)
         .unwrap_or_default();
+    // Resolve auto-detection: substitutes the best available concrete backend.
+    let backend_type = configured_backend.resolve();
 
-    info!("WorkerService using {} backend", backend_type);
+    if configured_backend != backend_type {
+        info!("WorkerService: auto-selected {} backend (configured: {})", backend_type, configured_backend);
+    } else {
+        info!("WorkerService using {} backend", backend_type);
+    }
 
     // Use default paths based on XDG directories
     let data_dir = dirs::data_local_dir()
@@ -705,6 +713,7 @@ fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
     let rafs_store = Arc::new(RafsStore::new(image_config.clone())?);
 
     // Construct the sandbox backend based on configuration.
+    // Note: `Auto` has already been resolved above; only concrete variants remain.
     let backend: Arc<dyn SandboxBackend> = match backend_type {
         #[cfg(feature = "kata-vm")]
         BackendType::Kata => Arc::new(KataBackend::new(image_config, Arc::clone(&rafs_store))),
@@ -712,10 +721,21 @@ fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
         BackendType::Kata => {
             return Err(anyhow::anyhow!(
                 "worker backend `kata` requires the `kata-vm` feature; \
-                 this binary was built without kata-vm support (use the `nspawn` backend)"
+                 this binary was built without kata-vm support"
+            ));
+        }
+        #[cfg(feature = "podman")]
+        BackendType::Podman => Arc::new(PodmanBackend::new(PodmanConfig::default())),
+        #[cfg(not(feature = "podman"))]
+        BackendType::Podman => {
+            return Err(anyhow::anyhow!(
+                "worker backend `podman` requires the `podman` feature; \
+                 this binary was built without podman support"
             ));
         }
         BackendType::Nspawn => Arc::new(NspawnBackend::new(NspawnConfig::default())),
+        // Auto is resolved before this match — should not reach here.
+        BackendType::Auto => Arc::new(NspawnBackend::new(NspawnConfig::default())),
     };
 
     let sk = ctx.service_signing_key("worker");


### PR DESCRIPTION
## Summary

- Adds `BackendType::Auto` (new default) and `BackendType::Podman`
- Implements `BackendType::resolve()`: probes Kata → Podman → Nspawn in priority order at runtime
- Wires resolve() into both the factory path (`factories.rs`) and the CLI worker path (`main.rs`)
- Adds `podman` feature to `hyprstream` crate that propagates to `hyprstream-workers/podman`

## Before / After

| | Before | After |
|---|---|---|
| Default backend | `kata` (fails silently without cloud-hypervisor) | `auto` (probes & falls back) |
| Dev laptop (podman installed) | Error at startup | Selects `podman` automatically |
| Dev laptop (nspawn only) | Error at startup | Selects `nspawn` automatically |
| Production (cloud-hypervisor) | Kata (if built with kata-vm) | Kata (same) |

## Auto-detection order

```
Kata  ← requires kata-vm feature + cloud-hypervisor in PATH
  ↓ (not available)
Podman ← requires podman feature + podman/docker in PATH
  ↓ (not available)
Nspawn ← always available (systemd-nspawn)
```

Operators can pin a specific backend via `worker.backend: kata/podman/nspawn` in config.

## Test plan

- [ ] `cargo clippy -p hyprstream-workers --features podman --all-targets` passes (verified locally)
- [ ] `cargo clippy -p hyprstream --features podman --all-targets` passes (verified locally)  
- [ ] `test_backend_type_default`: asserts `Auto` (updated)
- [ ] `test_backend_type_auto_resolves_to_concrete`: new test
- [ ] CI green

Closes #348. Part of epic #341. Stacked on #484.