### PR TITLE
ci: Arch Linux build workflow (archlinux/ path-scoped)

### DIFF
--- a/.github/workflows/archlinux.yml
+++ b/.github/workflows/archlinux.yml
@@ -1,0 +1,56 @@
+name: Arch Linux build
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'archlinux/**'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'archlinux/**'
+
+jobs:
+  pkgbuild:
+    name: makepkg (archlinux container)
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install base-devel + makedepends
+      run: |
+        pacman -Syu --noconfirm
+        pacman -S --noconfirm \
+          base-devel \
+          rustup \
+          cmake \
+          capnproto \
+          openssl \
+          pkg-config \
+          systemd \
+          git
+
+    - name: Set up Rust toolchain
+      run: rustup default stable
+
+    - name: Cache Rust dependencies
+      uses: Swatinem/rust-cache@v2
+      with:
+        shared-key: arch-rust-deps
+
+    - name: Validate PKGBUILD syntax
+      run: |
+        cd archlinux
+        bash -n PKGBUILD
+
+    - name: Build (CPU-only, no CUDA)
+      # Full makepkg would need cuda + python-pytorch-opt-cuda from AUR.
+      # We validate the build itself using the same flags as CI (download-libtorch),
+      # which exercises the same code path without requiring GPU hardware.
+      run: |
+        cargo build --bin hyprstream --release --features download-libtorch
+      env:
+        CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/archlinux.yml` — triggers only when files under `archlinux/` change
- Runs in an `archlinux:latest` container (no VM needed)
- Validates PKGBUILD syntax (`bash -n`)
- Builds `hyprstream` binary with `--features download-libtorch` to avoid needing `cuda`/`python-pytorch-opt-cuda` AUR packages in CI
- Uses `Swatinem/rust-cache` on a separate `arch-rust-deps` key so it doesn't pollute the main cache

## Why container and not VM

The Arch official container image is sufficient. CUDA runtime deps (`cuda`, `python-pytorch-opt-cuda`) can't run headlessly in CI anyway; `--features download-libtorch` exercises the same build path CI already validates on ubuntu runners.

## Test plan
- [ ] Merge this + PR #101 and push a change to `archlinux/PKGBUILD` — action should trigger
- [ ] Push a change outside `archlinux/` — action should NOT trigger

https://claude.ai/code/session_01U3qgsHTDWME66JFGZGS3ZA