### PR TITLE
feat(#347): feature-gate kata/nydus/nspawn/podman worker backends

### DIFF
--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -1093,7 +1093,7 @@ mod tests {
             &mut slice,
             capnp::message::ReaderOptions::default(),
         )
-        .expect("flat-slice reader must parse from an unaligned buffer");
+        .unwrap();
         let block = reader
             .get_root::<crate::streaming_capnp::stream_block::Reader>()
             .unwrap();

--- a/crates/hyprstream-workers/Cargo.toml
+++ b/crates/hyprstream-workers/Cargo.toml
@@ -54,27 +54,29 @@ which = { workspace = true }
 # D-Bus integration (optional, for container D-Bus proxy)
 zbus = { version = "4", features = ["tokio"], optional = true }
 
-# Nydus libraries (Dragonfly-native blob fetching)
-# NOTE: Using git deps because published crates.io versions have API mismatch
-# (nydus-storage 0.7.1 references field missing from nydus-api 0.4.0)
-nydus-api = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0" }
+# Nydus libraries (Dragonfly-native blob fetching) — optional, gated by `nydus` feature.
+# NOTE: Using git deps because nydus-builder/nydus-rafs/nydus-utils/nydus-service are
+# not published to crates.io; nydus-api and nydus-storage published versions had an API
+# mismatch (nydus-storage 0.7.1 references a field missing in nydus-api 0.4.0) that
+# required pinning to git. See #352 for dep cleanup tracking.
+nydus-api = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0", optional = true }
 nydus-storage = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0", features = [
     "backend-registry",
     "backend-localfs",
-] }
+], optional = true }
 # FS-B0: in-process RAFS bootstrap builder. TarballBuilder converts pulled OCI
 # layer tarballs into a RAFS bootstrap (.meta) + dedup data blobs, no external
 # nydus-image binary required.
-nydus-builder = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0" }
-nydus-rafs = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0" }
-nydus-utils = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0" }
+nydus-builder = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0", optional = true }
+nydus-rafs = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0", optional = true }
+nydus-utils = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0", optional = true }
 
-# Phase 2: VM Runtime (nydus-service for virtiofs)
-nydus-service = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0" }
+# Phase 2: VM Runtime (nydus-service for virtiofs) — optional, gated by `nydus` feature.
+nydus-service = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0", optional = true }
 # 0.13 to unify with nydus (`nydus-rafs` v2.4.0 builds against 0.13.1): FS-B
 # (#363) wraps the in-process RAFS `Rafs` as an overlay lower, so its `Layer`
 # type must match `hyprstream-vfs`'s `BoxedLayer`.
-fuse-backend-rs = "0.13"
+fuse-backend-rs = { version = "0.13", optional = true }
 
 # Minimal HTTP for manifest fetching only (blobs go through nydus-storage)
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
@@ -91,16 +93,26 @@ blake3 = { workspace = true }
 rand = { workspace = true }
 zeroize = { workspace = true }
 
-# Kata Containers runtime-rs (hypervisor abstraction)
-kata-hypervisor = { git = "https://github.com/kata-containers/kata-containers", tag = "3.25.0", package = "hypervisor", features = ["cloud-hypervisor"] }
-kata-types = { git = "https://github.com/kata-containers/kata-containers", tag = "3.25.0" }
-kata-sys-util = { git = "https://github.com/kata-containers/kata-containers", tag = "3.25.0" }
-ch-config = { git = "https://github.com/kata-containers/kata-containers", tag = "3.25.0" }
+# Kata Containers runtime-rs (hypervisor abstraction) — optional, gated by `kata` feature.
+kata-hypervisor = { git = "https://github.com/kata-containers/kata-containers", tag = "3.25.0", package = "hypervisor", features = ["cloud-hypervisor"], optional = true }
+kata-types = { git = "https://github.com/kata-containers/kata-containers", tag = "3.25.0", optional = true }
+kata-sys-util = { git = "https://github.com/kata-containers/kata-containers", tag = "3.25.0", optional = true }
+ch-config = { git = "https://github.com/kata-containers/kata-containers", tag = "3.25.0", optional = true }
 
 [features]
-default = []
-# Enable Dragonball built-in VMM support (alternative to cloud-hypervisor)
-dragonball = ["kata-hypervisor/dragonball"]
+# Kata Containers VM-based sandbox backend (cloud-hypervisor + runtime-rs). Implies nydus.
+kata = ["nydus", "dep:kata-hypervisor", "dep:kata-types", "dep:kata-sys-util", "dep:ch-config"]
+# Nydus RAFS image store (chunk-level CAS, lazy-load, OCI pull). Used by kata backend.
+nydus = ["dep:nydus-api", "dep:nydus-storage", "dep:nydus-builder", "dep:nydus-rafs", "dep:nydus-utils", "dep:nydus-service", "dep:fuse-backend-rs"]
+# systemd-nspawn lightweight container backend (no extra crate deps — uses nspawn binary).
+nspawn = []
+# Podman/Docker rootless OCI backend (casual-install path, no VM toolchain required).
+# Implementation added by T2-A (#484); this feature flag establishes the gate.
+podman = []
+# Light default for casual installs: nspawn only (no Kata/Nydus/cloud-hypervisor compile).
+default = ["nspawn"]
+# Enable Dragonball built-in VMM support (alternative to cloud-hypervisor, requires kata)
+dragonball = ["kata", "kata-hypervisor/dragonball"]
 # Enable D-Bus bridge for container access to host D-Bus services
 dbus = ["dep:zbus"]
 # Systemd integration (socket activation, service units)

--- a/crates/hyprstream-workers/src/config.rs
+++ b/crates/hyprstream-workers/src/config.rs
@@ -10,21 +10,42 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 /// Sandbox backend type
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum BackendType {
-    /// Kata Containers (default — full VM isolation)
-    #[default]
+    /// Kata Containers (full VM isolation). Requires the `kata` cargo feature.
+    #[cfg(feature = "kata")]
     Kata,
-    /// systemd-nspawn (lightweight container, rootless, host filesystem)
+    /// systemd-nspawn (lightweight container, rootless, host filesystem).
+    /// Requires the `nspawn` cargo feature.
+    #[cfg(feature = "nspawn")]
     Nspawn,
+    /// Podman/Docker rootless OCI container. Requires the `podman` cargo feature.
+    #[cfg(feature = "podman")]
+    Podman,
+}
+
+impl Default for BackendType {
+    fn default() -> Self {
+        // Prefer kata for power installs; fall back to lighter backends.
+        #[cfg(feature = "kata")]
+        return Self::Kata;
+        #[cfg(all(not(feature = "kata"), feature = "nspawn"))]
+        return Self::Nspawn;
+        #[cfg(all(not(feature = "kata"), not(feature = "nspawn"), feature = "podman"))]
+        return Self::Podman;
+    }
 }
 
 impl std::fmt::Display for BackendType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            #[cfg(feature = "kata")]
             Self::Kata => write!(f, "kata"),
+            #[cfg(feature = "nspawn")]
             Self::Nspawn => write!(f, "nspawn"),
+            #[cfg(feature = "podman")]
+            Self::Podman => write!(f, "podman"),
         }
     }
 }
@@ -299,24 +320,39 @@ mod tests {
 
     #[test]
     fn test_backend_type_default() {
+        // Default is kata when kata feature is on, else nspawn, else podman.
+        #[cfg(feature = "kata")]
         assert_eq!(BackendType::default(), BackendType::Kata);
+        #[cfg(all(not(feature = "kata"), feature = "nspawn"))]
+        assert_eq!(BackendType::default(), BackendType::Nspawn);
+        #[cfg(all(not(feature = "kata"), not(feature = "nspawn"), feature = "podman"))]
+        assert_eq!(BackendType::default(), BackendType::Podman);
     }
 
     #[test]
     fn test_backend_type_serialization() -> Result<(), Box<dyn std::error::Error>> {
-        let yaml = "backend: nspawn\n";
-        let config: WorkerConfig = serde_yaml::from_str(yaml)?;
-        assert_eq!(config.backend, BackendType::Nspawn);
-
-        let yaml = "backend: kata\n";
-        let config: WorkerConfig = serde_yaml::from_str(yaml)?;
-        assert_eq!(config.backend, BackendType::Kata);
+        #[cfg(feature = "nspawn")]
+        {
+            let yaml = "backend: nspawn\n";
+            let config: WorkerConfig = serde_yaml::from_str(yaml)?;
+            assert_eq!(config.backend, BackendType::Nspawn);
+        }
+        #[cfg(feature = "kata")]
+        {
+            let yaml = "backend: kata\n";
+            let config: WorkerConfig = serde_yaml::from_str(yaml)?;
+            assert_eq!(config.backend, BackendType::Kata);
+        }
         Ok(())
     }
 
     #[test]
     fn test_backend_type_display() {
+        #[cfg(feature = "kata")]
         assert_eq!(BackendType::Kata.to_string(), "kata");
+        #[cfg(feature = "nspawn")]
         assert_eq!(BackendType::Nspawn.to_string(), "nspawn");
+        #[cfg(feature = "podman")]
+        assert_eq!(BackendType::Podman.to_string(), "podman");
     }
 }

--- a/crates/hyprstream-workers/src/image/mod.rs
+++ b/crates/hyprstream-workers/src/image/mod.rs
@@ -34,10 +34,12 @@ mod client;
 mod manifest;
 // `pub(crate)` so sibling-module tests (e.g. runtime::sandbox_fs, FS-D #365)
 // can synthesize RAFS images. The builder fn stays crate-internal.
+// Requires `nydus` feature (nydus-builder dep).
+#[cfg(feature = "nydus")]
 pub(crate) mod rafs_builder;
 // FS-B (#363): per-sandbox RootfsMount = OverlayFs(in-process RAFS lower +
 // writable upper). Native-only (the overlay/RAFS FileSystem stack is Linux).
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "nydus"))]
 mod rootfs_mount;
 mod store;
 
@@ -46,6 +48,6 @@ pub use crate::generated::worker_client::{
     AuthConfig, FilesystemUsage, FilesystemIdentifier,
 };
 pub use manifest::{ImageReference, ManifestFetcher, ManifestResult, OciManifest};
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "nydus"))]
 pub use rootfs_mount::{rootfs_mount_for, rootfs_mount_from_rafs};
 pub use store::{GcStats, ImageMetadata, RafsStore};

--- a/crates/hyprstream-workers/src/image/store.rs
+++ b/crates/hyprstream-workers/src/image/store.rs
@@ -17,34 +17,38 @@
 //! [`RafsStore::bootstrap_path`] resolves to a real RAFS bootstrap consumable by
 //! an in-process RAFS `FileSystem` (FS-B, #363) or nydusd (FS-B0, #366).
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
+
+#[cfg(feature = "nydus")]
+use std::path::Path;
+#[cfg(feature = "nydus")]
 use std::sync::Arc;
 
+#[cfg(feature = "nydus")]
 use sha2::{Digest, Sha256};
 
+#[cfg(feature = "nydus")]
 use nydus_api::RegistryConfig;
+#[cfg(feature = "nydus")]
 use nydus_storage::backend::registry::Registry;
+#[cfg(feature = "nydus")]
 use nydus_storage::backend::{BlobBackend, BlobBufReader};
 
 use crate::config::ImageConfig;
 use crate::error::{Result, WorkerError};
 
-use super::{AuthConfig as GenAuthConfig, ImageSpec, ImageInfo, ImageStatusResult, FilesystemUsage, FilesystemIdentifier};
+#[cfg(feature = "nydus")]
+use super::AuthConfig as GenAuthConfig;
+use super::{ImageSpec, ImageInfo, ImageStatusResult, FilesystemUsage, FilesystemIdentifier};
+#[cfg(feature = "nydus")]
 use super::manifest::{AuthConfig, ImageReference, ManifestFetcher, ManifestResult};
 
-/// RAFS-backed image store with Dragonfly-native blob fetching
+/// Image store for sandbox workloads.
 ///
-/// Uses nydus-storage's backend-registry for blob operations, which supports
-/// Dragonfly P2P via the `blob_redirected_host` configuration.
-///
-/// Storage layout:
-/// ```text
-/// images/
-/// ├── blobs/sha256/         # Layer blobs (content-addressed)
-/// ├── bootstrap/            # RAFS metadata (per image)
-/// ├── cache/                # nydus-storage blob cache
-/// └── refs/                 # Tag → digest symlinks
-/// ```
+/// When the `nydus` feature is enabled: full RAFS-backed store with
+/// Dragonfly-native blob fetching and chunk-level deduplication.
+/// When disabled: a stub that errors on image ops (suitable for nspawn/podman
+/// backends that manage their own images).
 pub struct RafsStore {
     /// Directory for layer blobs
     blobs_dir: PathBuf,
@@ -58,35 +62,47 @@ pub struct RafsStore {
     /// Cache directory for nydus-storage
     cache_dir: PathBuf,
 
+    #[cfg(feature = "nydus")]
     /// Manifest fetcher (HTTP only, no blob handling)
     manifest_fetcher: Arc<ManifestFetcher>,
 
-    /// Configuration
+    #[cfg_attr(not(feature = "nydus"), allow(dead_code))]
     config: ImageConfig,
 }
 
 impl RafsStore {
-    /// Create a new RafsStore with configuration
+    /// Create a new RafsStore with configuration.
+    ///
+    /// Without the `nydus` feature: returns a stub that errors on image ops.
     pub fn new(config: ImageConfig) -> Result<Self> {
-        let manifest_fetcher = ManifestFetcher::new()
-            .map_err(|e| WorkerError::RafsError(format!("failed to create manifest fetcher: {e}")))?;
+        #[cfg(feature = "nydus")]
+        let manifest_fetcher = {
+            use super::manifest::ManifestFetcher;
+            Arc::new(
+                ManifestFetcher::new()
+                    .map_err(|e| WorkerError::RafsError(format!("failed to create manifest fetcher: {e}")))?,
+            )
+        };
 
         Ok(Self {
             blobs_dir: config.blobs_dir.clone(),
             bootstrap_dir: config.bootstrap_dir.clone(),
             refs_dir: config.refs_dir.clone(),
             cache_dir: config.cache_dir.clone(),
-            manifest_fetcher: Arc::new(manifest_fetcher),
+            #[cfg(feature = "nydus")]
+            manifest_fetcher,
             config,
         })
     }
 
-    /// Pull an image from registry
+    /// Pull an image from registry (requires `nydus` feature).
+    #[cfg(feature = "nydus")]
     pub async fn pull(&self, image_ref: &str) -> Result<String> {
         self.pull_with_auth(image_ref, None).await
     }
 
-    /// Pull an image with authentication
+    /// Pull an image with authentication (requires `nydus` feature).
+    #[cfg(feature = "nydus")]
     pub async fn pull_with_auth(
         &self,
         image_ref: &str,
@@ -258,6 +274,7 @@ impl RafsStore {
     /// Download a blob using nydus-storage's Registry backend.
     ///
     /// This enables Dragonfly P2P when `blob_redirected_host` is configured.
+    #[cfg(feature = "nydus")]
     async fn download_blob(
         &self,
         img_ref: &ImageReference,
@@ -327,6 +344,7 @@ impl RafsStore {
     }
 
     /// Create a nydus-storage RegistryConfig for a blob fetch.
+    #[cfg(feature = "nydus")]
     fn create_registry_config(
         &self,
         img_ref: &ImageReference,
@@ -375,7 +393,8 @@ impl RafsStore {
         config
     }
 
-    /// Ensure storage directories exist
+    /// Ensure storage directories exist (called from pull_with_auth, requires nydus).
+    #[cfg(feature = "nydus")]
     async fn ensure_dirs(&self) -> Result<()> {
         tracing::debug!(path = %self.blobs_dir.display(), "Creating blobs directory");
         tokio::fs::create_dir_all(&self.blobs_dir).await.map_err(|e| {
@@ -404,7 +423,8 @@ impl RafsStore {
         Ok(())
     }
 
-    /// Ensure an image is available locally (pull if needed)
+    /// Ensure an image is available locally (pull if needed). Requires `nydus` feature.
+    #[cfg(feature = "nydus")]
     pub async fn ensure(&self, image_ref: &str) -> Result<String> {
         if self.exists(image_ref) {
             self.get_image_id(image_ref)
@@ -548,7 +568,8 @@ impl RafsStore {
                     // RAFS bootstraps reference data blobs by their RAFS blob
                     // hash (not OCI layer digests), so mark those as referenced
                     // too — otherwise GC would delete blobs a live bootstrap
-                    // depends on.
+                    // depends on. Only available when nydus feature is on.
+                    #[cfg(feature = "nydus")]
                     Some("meta") => {
                         if let Ok(blob_ids) = super::rafs_builder::bootstrap_blob_ids(&path) {
                             for blob_id in blob_ids {
@@ -556,6 +577,8 @@ impl RafsStore {
                             }
                         }
                     }
+                    #[cfg(not(feature = "nydus"))]
+                    Some("meta") => {}
                     _ => {}
                 }
             }

--- a/crates/hyprstream-workers/src/lib.rs
+++ b/crates/hyprstream-workers/src/lib.rs
@@ -63,7 +63,11 @@ pub use config::{BackendType, HypervisorType, ImageConfig, PoolConfig, WorkerCon
 pub use error::WorkerError;
 
 // Re-export service types
-pub use runtime::{WorkerService, SandboxBackend, SandboxHandle, KataBackend, NspawnBackend, NspawnConfig};
+pub use runtime::{WorkerService, SandboxBackend, SandboxHandle};
+#[cfg(feature = "kata")]
+pub use runtime::KataBackend;
+#[cfg(feature = "nspawn")]
+pub use runtime::{NspawnBackend, NspawnConfig};
 pub use image::RafsStore;
 pub use workflow::WorkflowService;
 pub use events::{

--- a/crates/hyprstream-workers/src/runtime/kata_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/kata_backend.rs
@@ -2,6 +2,9 @@
 //!
 //! Implements `SandboxBackend` using Kata's `Hypervisor` trait for full VM
 //! isolation.  Supports Cloud Hypervisor and Dragonball hypervisors.
+//!
+//! Requires the `kata` cargo feature.
+#![cfg(feature = "kata")]
 
 use std::any::Any;
 use std::collections::HashMap;

--- a/crates/hyprstream-workers/src/runtime/mod.rs
+++ b/crates/hyprstream-workers/src/runtime/mod.rs
@@ -23,15 +23,18 @@
 pub mod backend;
 mod client;
 mod container;
+#[cfg(feature = "kata")]
 pub mod kata_backend;
+#[cfg(feature = "nspawn")]
 pub mod nspawn;
 mod pool;
 mod sandbox;
-// Per-sandbox VFS composition + serve (FS-D, #365): native-only.
-#[cfg(not(target_arch = "wasm32"))]
+// Per-sandbox VFS composition + serve (FS-D, #365): native-only, requires nydus.
+#[cfg(all(not(target_arch = "wasm32"), feature = "nydus"))]
 pub mod sandbox_fs;
 mod service;
 pub mod spawner;
+#[cfg(feature = "kata")]
 mod virtiofs;
 
 // Generated wire types — canonical OCI/CRI-aligned names (no Gen*/Wire/Enum aliases)
@@ -73,17 +76,20 @@ pub use client::{
 };
 // Backend trait and implementations
 pub use backend::{SandboxBackend, SandboxHandle};
+#[cfg(feature = "kata")]
 pub use kata_backend::{KataBackend, KataHandle};
+#[cfg(feature = "nspawn")]
 pub use nspawn::{NspawnBackend, NspawnConfig, NspawnHandle};
 // Domain entities (business logic only)
 pub use container::Container;
 pub use pool::{PoolStats, SandboxPool};
 pub use sandbox::PodSandbox;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "nydus"))]
 pub use sandbox_fs::{InjectedMounts, SandboxFs, SandboxFsServer, VFS_SOCKET_NAME};
 pub use service::WorkerService;
 // Re-export service infrastructure from hyprstream-rpc for convenience
 pub use hyprstream_rpc::service::{EnvelopeContext, ServiceHandle, RequestService};
+#[cfg(feature = "kata")]
 pub use virtiofs::{SandboxVirtiofs, SandboxVirtiofsBuilder};
 
 /// CRI runtime version

--- a/crates/hyprstream-workers/src/runtime/nspawn.rs
+++ b/crates/hyprstream-workers/src/runtime/nspawn.rs
@@ -8,6 +8,9 @@
 //! Service discovery uses host-side IPC paths namespaced by
 //! `HYPRSTREAM_INSTANCE` rather than network IP, avoiding timing issues
 //! with veth IP assignment.
+//!
+//! Requires the `nspawn` cargo feature.
+#![cfg(feature = "nspawn")]
 
 use std::any::Any;
 use std::collections::HashMap;

--- a/crates/hyprstream-workers/src/runtime/pool.rs
+++ b/crates/hyprstream-workers/src/runtime/pool.rs
@@ -287,10 +287,13 @@ pub struct PoolStats {
 }
 
 #[cfg(test)]
+#[cfg(any(feature = "kata", feature = "nspawn"))]
 mod tests {
     use super::*;
     use crate::config::{ImageConfig, PoolConfig};
+    #[cfg(feature = "kata")]
     use crate::image::RafsStore;
+    #[cfg(feature = "kata")]
     use crate::runtime::kata_backend::KataBackend;
     use tempfile::TempDir;
 
@@ -325,9 +328,16 @@ mod tests {
         std::fs::create_dir_all(&image_config.cache_dir)?;
         std::fs::create_dir_all(&pool_config.runtime_dir)?;
 
-        let rafs_store = Arc::new(RafsStore::new(image_config.clone())?);
-        let backend: Arc<dyn SandboxBackend> =
-            Arc::new(KataBackend::new(image_config, rafs_store));
+        #[cfg(feature = "kata")]
+        let backend: Arc<dyn SandboxBackend> = {
+            let rafs_store = Arc::new(RafsStore::new(image_config.clone())?);
+            Arc::new(KataBackend::new(image_config, rafs_store))
+        };
+        #[cfg(not(feature = "kata"))]
+        let backend: Arc<dyn SandboxBackend> = {
+            let _ = image_config;
+            Arc::new(crate::runtime::nspawn::NspawnBackend::new(crate::runtime::nspawn::NspawnConfig::default()))
+        };
         let pool = SandboxPool::new(pool_config, backend);
 
         Ok((pool, temp_dir))

--- a/crates/hyprstream-workers/src/runtime/service.rs
+++ b/crates/hyprstream-workers/src/runtime/service.rs
@@ -1248,21 +1248,29 @@ impl ImageHandler for WorkerService {
     }
 
     async fn handle_pull(&self, _ctx: &EnvelopeContext, _request_id: u64, data: &PullImageRequest) -> AnyhowResult<String> {
-        let image_ref = &data.image.image;
-        let auth = if !data.auth.username.is_empty() {
-            Some(crate::image::AuthConfig {
-                username: data.auth.username.clone(),
-                password: data.auth.password.clone(),
-                auth: String::new(),
-                server_address: String::new(),
-                identity_token: String::new(),
-                registry_token: String::new(),
-            })
-        } else {
-            None
-        };
-        let image_id = self.rafs_store.pull_with_auth(image_ref, auth.as_ref()).await?;
-        Ok(image_id)
+        #[cfg(feature = "nydus")]
+        {
+            let image_ref = &data.image.image;
+            let auth = if !data.auth.username.is_empty() {
+                Some(crate::image::AuthConfig {
+                    username: data.auth.username.clone(),
+                    password: data.auth.password.clone(),
+                    auth: String::new(),
+                    server_address: String::new(),
+                    identity_token: String::new(),
+                    registry_token: String::new(),
+                })
+            } else {
+                None
+            };
+            let image_id = self.rafs_store.pull_with_auth(image_ref, auth.as_ref()).await?;
+            Ok(image_id)
+        }
+        #[cfg(not(feature = "nydus"))]
+        {
+            let _ = data;
+            Err(anyhow::anyhow!("image pull requires the `nydus` cargo feature"))
+        }
     }
 
     async fn handle_remove(&self, _ctx: &EnvelopeContext, _request_id: u64, data: &ImageSpec) -> AnyhowResult<()> {
@@ -1337,6 +1345,7 @@ impl RequestService for WorkerService {
 }
 
 #[cfg(test)]
+#[cfg(any(feature = "kata", feature = "nspawn"))]
 #[allow(clippy::print_stderr)]
 mod tests {
     use super::*;
@@ -1386,8 +1395,14 @@ mod tests {
         let transport = TransportConfig::inproc("test-worker-service");
         let (signing_key, _verifying_key) = generate_signing_keypair();
 
+        // Use kata backend when available; fall back to nspawn (the default) for light builds.
+        #[cfg(feature = "kata")]
         let backend: Arc<dyn crate::runtime::backend::SandboxBackend> = Arc::new(
             crate::runtime::kata_backend::KataBackend::new(image_config, Arc::clone(&rafs_store)),
+        );
+        #[cfg(not(feature = "kata"))]
+        let backend: Arc<dyn crate::runtime::backend::SandboxBackend> = Arc::new(
+            crate::runtime::nspawn::NspawnBackend::new(crate::runtime::nspawn::NspawnConfig::default()),
         );
         let service = WorkerService::new(pool_config, backend, rafs_store, transport, signing_key)?;
         Ok((service, temp_dir))

--- a/crates/hyprstream-workers/src/runtime/virtiofs.rs
+++ b/crates/hyprstream-workers/src/runtime/virtiofs.rs
@@ -3,6 +3,9 @@
 //! Provides filesystem service for sandboxes using nydus-service.
 //! Each sandbox gets its own daemon instance to serve RAFS images.
 //!
+//! Requires the `kata` cargo feature (uses nydus-service).
+#![cfg(feature = "kata")]
+//!
 //! # Architecture
 //!
 //! ```text

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -190,7 +190,16 @@ keyring = { version = "3", features = ["windows-native"] }
 keyring = { version = "3", features = ["sync-secret-service", "crypto-rust"] }
 
 [features]
-default = ["gittorrent", "xet", "systemd", "otel"]
+# Power-install default: kata+nydus+nspawn all enabled (backward compat).
+default = ["gittorrent", "xet", "systemd", "otel", "kata", "nydus", "nspawn"]
+# Kata Containers VM backend (enables kata+nydus in the workers crate)
+kata = ["hyprstream-workers/kata"]
+# Nydus RAFS image store (enables nydus in the workers crate)
+nydus = ["hyprstream-workers/nydus"]
+# systemd-nspawn lightweight backend
+nspawn = ["hyprstream-workers/nspawn"]
+# Podman OCI backend (stub, reserved for T2-A)
+podman = ["hyprstream-workers/podman"]
 cuda = []
 valkey = ["dep:fred"]  # Enable Valkey/Redis-backed user and token stores
 bnb = ["dep:bitsandbytes-sys"]  # Enable bitsandbytes KV cache quantization (requires compatible ROCm/CUDA)

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1073,11 +1073,18 @@ fn handle_quick_command(
 
                     let _worker_handle = if !worker_already_running {
                         use hyprstream_workers::image::RafsStore;
-                        use hyprstream_workers::runtime::{SandboxBackend, KataBackend};
+                        use hyprstream_workers::runtime::SandboxBackend;
                         let rafs_store = Arc::new(RafsStore::new(image_config.clone())?);
-                        let backend: Arc<dyn SandboxBackend> = Arc::new(
-                            KataBackend::new(image_config, Arc::clone(&rafs_store)),
-                        );
+                        #[cfg(feature = "kata")]
+                        let backend: Arc<dyn SandboxBackend> = {
+                            use hyprstream_workers::runtime::KataBackend;
+                            Arc::new(KataBackend::new(image_config, Arc::clone(&rafs_store)))
+                        };
+                        #[cfg(all(not(feature = "kata"), feature = "nspawn"))]
+                        let backend: Arc<dyn SandboxBackend> = {
+                            use hyprstream_workers::{NspawnBackend, NspawnConfig};
+                            Arc::new(NspawnBackend::new(NspawnConfig::default()))
+                        };
                         let worker_transport =
                             TransportConfig::inproc("hyprstream/workers");
                         let mut worker_service = WorkerService::new(

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -654,7 +654,11 @@ fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
 
     use hyprstream_workers::config::{BackendType, ImageConfig, PoolConfig};
     use hyprstream_workers::image::RafsStore;
-    use hyprstream_workers::{WorkerService, SandboxBackend, KataBackend, NspawnBackend, NspawnConfig};
+    use hyprstream_workers::{WorkerService, SandboxBackend};
+    #[cfg(feature = "kata")]
+    use hyprstream_workers::KataBackend;
+    #[cfg(feature = "nspawn")]
+    use hyprstream_workers::{NspawnBackend, NspawnConfig};
 
     let config = load_config();
     let worker_quic_port = config.worker.as_ref().and_then(|w| w.quic_port);
@@ -698,8 +702,12 @@ fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
 
     // Construct the sandbox backend based on configuration
     let backend: Arc<dyn SandboxBackend> = match backend_type {
+        #[cfg(feature = "kata")]
         BackendType::Kata => Arc::new(KataBackend::new(image_config, Arc::clone(&rafs_store))),
+        #[cfg(feature = "nspawn")]
         BackendType::Nspawn => Arc::new(NspawnBackend::new(NspawnConfig::default())),
+        #[cfg(feature = "podman")]
+        BackendType::Podman => anyhow::bail!("podman backend not yet implemented"),
     };
 
     let sk = ctx.service_signing_key("worker");


### PR DESCRIPTION
## Summary

Closes #347 (T2-B: Feature-gate worker backends + lightweight default).

- **`kata`** feature gates all kata-containers git deps (kata-hypervisor, kata-types, ch-config, kata-sys-util) and the `kata_backend` / `virtiofs` modules
- **`nydus`** feature gates all nydus-* git deps + fuse-backend-rs; implied by `kata`
- **`nspawn`** feature: no extra crate deps; gates only the nspawn module
- **`podman`** feature: stub, reserved for T2-A (#346)
- `default = ["nspawn"]` in hyprstream-workers — casual installs compile without Kata/Nydus toolchain
- `hyprstream` crate exposes all four features and sets `default` to include kata+nydus+nspawn for backward compat

### Key design choices

- `RafsStore` struct remains always available (nspawn code holds a reference); nydus-specific methods/fields are `#[cfg(feature = "nydus")]`
- `BackendType` enum variants are individually gated; `Default` is implemented manually with priority ordering (kata > nspawn > podman)
- `handle_pull` returns a clear error when nydus feature is off
- Test modules gated with `#[cfg(any(feature = "kata", feature = "nspawn"))]`

### Incidental fix

Pre-existing `clippy::expect_used` lint in `hyprstream-rpc/src/streaming.rs` test (function already has `#[allow(clippy::unwrap_used)]`).

## Test plan

- [x] `cargo clippy -p hyprstream-workers -- -D warnings` (default=nspawn) passes clean
- [x] Pre-commit hook (full workspace clippy) passes
- [ ] CI green on `feature/kata-ga-epic`