### PR TITLE
docs(#352): document nydus crates.io vs git-dep status + cleanup

### DIFF
--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -1093,7 +1093,7 @@ mod tests {
             &mut slice,
             capnp::message::ReaderOptions::default(),
         )
-        .expect("flat-slice reader must parse from an unaligned buffer");
+        .unwrap();
         let block = reader
             .get_root::<crate::streaming_capnp::stream_block::Reader>()
             .unwrap();

--- a/crates/hyprstream-workers/Cargo.toml
+++ b/crates/hyprstream-workers/Cargo.toml
@@ -58,8 +58,21 @@ zbus = { version = "4", features = ["tokio"], optional = true }
 # Nydus libraries (Dragonfly-native blob fetching) — gated behind `kata-vm`.
 # Only the RAFS image-pull + virtiofs path (consumed by the Kata/CH VM backend)
 # needs these; the lightweight nspawn backend bind-mounts the host root.
-# NOTE: Using git deps because published crates.io versions have API mismatch
-# (nydus-storage 0.7.1 references field missing from nydus-api 0.4.0)
+#
+# Crates.io availability (verified 2026-06-26 against dragonflyoss/nydus v2.4.0):
+#   nydus-api     0.4.1  — ON crates.io, but mixed with git siblings causes type
+#                           mismatch: nydus-storage git uses nydus-api git types
+#                           internally; mixing crates.io nydus-api with git
+#                           nydus-storage/builder/rafs/utils/service produces
+#                           "expected nydus_api::…, found nydus_api::…" errors.
+#   nydus-storage 0.7.2  — ON crates.io (same mixing problem as above)
+#   nydus-builder        — NOT on crates.io; git dep unavoidable
+#   nydus-rafs           — NOT on crates.io; git dep unavoidable
+#   nydus-utils          — NOT on crates.io; git dep unavoidable
+#   nydus-service        — NOT on crates.io; git dep unavoidable
+#
+# Until all six nydus crates are published together on crates.io we must pin
+# the full set to the same git tag to keep types coherent.
 nydus-api = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0", optional = true }
 nydus-storage = { git = "https://github.com/dragonflyoss/nydus", tag = "v2.4.0", optional = true, features = [
     "backend-registry",


### PR DESCRIPTION
## Summary

Closes #352 (T3-D: Nydus dependency cleanup).

### Investigation findings

Tested replacing `nydus-api` and `nydus-storage` git deps with their crates.io counterparts:
- **nydus-api 0.4.1** — published on crates.io ✓
- **nydus-storage 0.7.2** — published on crates.io ✓
- **nydus-builder** — NOT on crates.io ✗
- **nydus-rafs** — NOT on crates.io ✗
- **nydus-utils** — NOT on crates.io ✗
- **nydus-service** — NOT on crates.io ✗

**However**, mixing crates.io `nydus-api`/`nydus-storage` with the git siblings fails to compile with `mismatched types` errors:
```
expected `nydus_api::config::ConfigV2`, found `ConfigV2`
```
Cargo treats `nydus-api` from crates.io and `nydus-api` from the git source as distinct crates, so types don't unify. Until all six nydus crates are co-published on crates.io from the same release, the entire set must pin the same git tag.

### Changes
- Updated `hyprstream-workers/Cargo.toml` comment to document per-crate crates.io status and the type-unification blocker
- Fixed pre-existing `clippy::expect_used` lint in `hyprstream-rpc/src/streaming.rs` test (function already has `#[allow(clippy::unwrap_used)]`)

## Test plan
- [x] Pre-commit clippy hook passes
- [ ] CI green on `feature/kata-ga-epic`