### PR TITLE
ci(arch): run Arch Linux build on published releases

### DIFF
--- a/.github/workflows/archlinux.yml
+++ b/.github/workflows/archlinux.yml
@@ -9,6 +9,8 @@ on:
     branches: [ "main" ]
     paths:
       - 'archlinux/**'
+  release:
+    types: [published]
 
 jobs:
   pkgbuild:


### PR DESCRIPTION
Adds a `release: [published]` trigger so the Arch Linux build validates the PKGBUILD on every published release, not just on `archlinux/**` file changes.