### PR TITLE
feat(#495): port hyprstream-vfsd FUSE/virtio-fs adapter + implement DAX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3797,7 +3797,7 @@ dependencies = [
  "thiserror 1.0.69",
  "vfio-bindings 0.3.1",
  "vfio-ioctls",
- "virtio-queue",
+ "virtio-queue 0.7.1",
  "vm-memory 0.10.0",
  "vmm-sys-util 0.11.2",
 ]
@@ -3874,8 +3874,8 @@ dependencies = [
  "threadpool",
  "timerfd",
  "vhost",
- "virtio-bindings",
- "virtio-queue",
+ "virtio-bindings 0.1.0",
+ "virtio-queue 0.7.1",
  "vm-memory 0.10.0",
  "vmm-sys-util 0.11.2",
 ]
@@ -4312,7 +4312,7 @@ dependencies = [
  "tracing",
  "vfio-bindings 0.3.1",
  "vfio-ioctls",
- "virtio-queue",
+ "virtio-queue 0.7.1",
  "vm-memory 0.10.0",
  "vmm-sys-util 0.11.2",
 ]
@@ -5097,7 +5097,7 @@ dependencies = [
  "log",
  "mio 0.8.11",
  "nix 0.24.3",
- "virtio-queue",
+ "virtio-queue 0.7.1",
  "vm-memory 0.10.0",
  "vmm-sys-util 0.11.2",
 ]
@@ -5118,6 +5118,7 @@ dependencies = [
  "mio 0.8.11",
  "nix 0.24.3",
  "radix_trie",
+ "virtio-queue 0.12.0",
  "vm-memory 0.14.1",
  "vmm-sys-util 0.12.1",
 ]
@@ -6827,6 +6828,22 @@ dependencies = [
  "async-trait",
  "hyprstream-rpc",
  "tokio",
+]
+
+[[package]]
+name = "hyprstream-vfsd"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "dashmap",
+ "fuse-backend-rs 0.12.1",
+ "hyprstream-rpc",
+ "hyprstream-vfs",
+ "libc",
+ "parking_lot 0.12.4",
+ "tempfile",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -16166,15 +16183,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff512178285488516ed85f15b5d0113a7cdb89e9e8a760b269ae4f02b84bd6b"
 
 [[package]]
+name = "virtio-bindings"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091f1f09cfbf2a78563b562e7a949465cce1aef63b6065645188d995162f8868"
+
+[[package]]
 name = "virtio-queue"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ba81e2bcc21c0d2fc5e6683e79367e26ad219197423a498df801d79d5ba77bd"
 dependencies = [
  "log",
- "virtio-bindings",
+ "virtio-bindings 0.1.0",
  "vm-memory 0.10.0",
  "vmm-sys-util 0.11.2",
+]
+
+[[package]]
+name = "virtio-queue"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07d8406e7250c934462de585d8f2d2781c31819bca1fbb7c5e964ca6bbaabfe8"
+dependencies = [
+ "log",
+ "virtio-bindings 0.2.7",
+ "vm-memory 0.14.1",
+ "vmm-sys-util 0.12.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "crates/hyprstream-rpc-std",
     "crates/hyprstream-9p",
     "crates/hyprstream-pds",
+    "crates/hyprstream-vfsd",
 ]
 # bitsandbytes-sys is standalone - only built when bnb feature is enabled
 exclude = ["crates/bitsandbytes-sys"]

--- a/crates/hyprstream-vfsd/Cargo.toml
+++ b/crates/hyprstream-vfsd/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "hyprstream-vfsd"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+description = "FUSE/virtio-fs adapter bridging VFS Mount trait to guest VMs"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+fuse-backend-rs = { version = "0.12", features = ["virtiofs"] }
+hyprstream-vfs = { path = "../hyprstream-vfs" }
+hyprstream-rpc = { path = "../hyprstream-rpc" }
+libc = { workspace = true }
+tokio = { workspace = true }
+dashmap = { workspace = true }
+parking_lot = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+hyprstream-vfs = { path = "../hyprstream-vfs" }
+hyprstream-rpc = { path = "../hyprstream-rpc" }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
+async-trait = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/hyprstream-vfsd/src/daemon.rs
+++ b/crates/hyprstream-vfsd/src/daemon.rs
@@ -1,0 +1,356 @@
+//! VFS daemon — serves a VFS `Namespace` to guest VMs via vhost-user-fs.
+//!
+//! The `VfsDaemon` wraps a `VfsFuse` adapter around a `Mount` and exposes it
+//! over a vhost-user-fs Unix socket. Guest VMs (e.g., Kata worker VMs) mount
+//! the socket as a virtio-fs device to access the host VFS namespace.
+//!
+//! # Architecture
+//!
+//! ```text
+//! Guest VM (mount -t virtiofs tag /mnt)
+//!      |
+//! vhost-user-fs socket (Unix domain)
+//!      |
+//! fuse-backend-rs Server<VfsFuse<M>>
+//!      |
+//! VfsFuse<M>  (this crate, FUSE <-> Mount adapter)
+//!      |
+//! hyprstream-vfs Mount trait
+//! ```
+//!
+//! # KataBackend integration (documentation)
+//!
+//! To wire `VfsDaemon` into `KataBackend::start()`:
+//!
+//! 1. Build a `Namespace` with the authorized mounts for this sandbox:
+//!    ```ignore
+//!    let mut ns = Namespace::new();
+//!    ns.mount("/srv/model", Arc::new(model_mount)).unwrap();
+//!    ns.mount("/srv/tcl", Arc::new(tcl_mount)).unwrap();
+//!    ```
+//!
+//! 2. Create and start a `VfsDaemon` on the sandbox's virtiofs socket:
+//!    ```ignore
+//!    let daemon = VfsDaemon::new(namespace_mount, socket_path);
+//!    daemon.start()?;
+//!    ```
+//!
+//! 3. Pass the socket to cloud-hypervisor via `--fs` flag:
+//!    ```text
+//!    cloud-hypervisor ... --fs socket=<socket_path>,tag=hyprfs,num_queues=1,queue_size=1024
+//!    ```
+//!
+//! 4. In the guest VM, mount via:
+//!    ```text
+//!    mount -t virtiofs hyprfs /srv
+//!    ```
+//!
+//! 5. Store the `VfsDaemon` in `KataHandle` alongside the existing `virtiofs_daemon`:
+//!    ```ignore
+//!    pub struct KataHandle {
+//!        // ... existing fields ...
+//!        pub vfs_daemon: Option<Arc<VfsDaemon<NamespaceMount>>>,
+//!    }
+//!    ```
+//!
+//! 6. On `stop()` / `destroy()`, call `daemon.stop()` to clean up.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+
+use fuse_backend_rs::api::server::Server;
+
+use hyprstream_vfs::Mount;
+
+use crate::dax::DaxMount;
+use crate::VfsFuse;
+
+/// Daemon serving a VFS mount over a vhost-user-fs socket.
+///
+/// Lifecycle follows the `SandboxVirtiofs` pattern:
+/// - `new()` configures the daemon (socket path, mount)
+/// - `start()` spawns the vhost-user-fs listener thread
+/// - `stop()` signals the listener to shut down
+///
+/// The daemon owns a `Server<VfsFuse<M>>` which translates between the
+/// virtio-fs protocol and the VFS `Mount` trait.
+pub struct VfsDaemon<M: Mount + 'static> {
+    /// Socket path for vhost-user-fs connection.
+    socket_path: PathBuf,
+    /// The FUSE server wrapping our VFS mount.
+    server: Arc<Server<VfsFuse<M>>>,
+    /// Whether the daemon is running.
+    running: Arc<AtomicBool>,
+    /// Listener thread handle.
+    thread_handle: Option<JoinHandle<()>>,
+}
+
+impl<M: Mount + 'static> VfsDaemon<M> {
+    /// Create a new VFS daemon.
+    ///
+    /// # Arguments
+    /// * `mount` - The VFS mount to serve (typically a `Namespace` adapter or a single service mount)
+    /// * `socket_path` - Unix socket path for the vhost-user-fs connection
+    pub fn new(mount: M, socket_path: impl Into<PathBuf>) -> Self {
+        let rt = tokio::runtime::Handle::current();
+        let vfs_fuse = VfsFuse::new(mount, rt);
+        let server = Arc::new(Server::new(vfs_fuse));
+
+        Self {
+            socket_path: socket_path.into(),
+            server,
+            running: Arc::new(AtomicBool::new(false)),
+            thread_handle: None,
+        }
+    }
+}
+
+impl<M: DaxMount + 'static> VfsDaemon<M> {
+    /// Create a new VFS daemon with DAX (direct-access) support enabled.
+    ///
+    /// Available only when `M: DaxMount`. Guests may then map DAX-capable
+    /// files directly into their DAX window (zero-copy weight access); other
+    /// files fall back to the FUSE read path. The VMM must be launched with a
+    /// DAX-enabled `--fs` device (`dax=on,cache_size=<window>`).
+    pub fn with_dax(mount: M, socket_path: impl Into<PathBuf>) -> Self {
+        let rt = tokio::runtime::Handle::current();
+        let vfs_fuse = VfsFuse::with_dax(mount, rt);
+        let server = Arc::new(Server::new(vfs_fuse));
+
+        Self {
+            socket_path: socket_path.into(),
+            server,
+            running: Arc::new(AtomicBool::new(false)),
+            thread_handle: None,
+        }
+    }
+}
+
+impl<M: Mount + 'static> VfsDaemon<M> {
+    /// Start the vhost-user-fs daemon.
+    ///
+    /// Spawns a dedicated thread that listens on the Unix socket for
+    /// virtio-fs requests from the guest VM. The thread processes FUSE
+    /// requests synchronously via `Server::handle_message()`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the socket directory cannot be created or if
+    /// the listener thread fails to start.
+    pub fn start(&mut self) -> std::io::Result<()> {
+        if self.running.load(Ordering::Acquire) {
+            return Ok(());
+        }
+
+        // Ensure the socket parent directory exists.
+        if let Some(parent) = self.socket_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        // Remove stale socket if present.
+        if self.socket_path.exists() {
+            std::fs::remove_file(&self.socket_path)?;
+        }
+
+        self.running.store(true, Ordering::Release);
+
+        let running = Arc::clone(&self.running);
+        let _server = Arc::clone(&self.server);
+        let socket_path = self.socket_path.clone();
+
+        // NOTE: Full vhost-user-fs listener implementation requires:
+        //
+        // 1. Create a Unix listener socket at `socket_path`
+        // 2. Accept a connection from the VMM (cloud-hypervisor)
+        // 3. Negotiate the vhost-user protocol (feature flags, memory mapping)
+        // 4. Process virtio-queue descriptors, translating to FUSE requests
+        // 5. Dispatch FUSE requests to `server.handle_message()`
+        //
+        // The fuse-backend-rs crate provides the `Server` for FUSE request
+        // handling and the `virtiofs` transport module for descriptor chain
+        // I/O. The vhost-user protocol negotiation is provided by the
+        // `vhost` crate (not currently a dependency).
+        //
+        // For now, we create the socket to signal readiness and log the
+        // configuration. Full implementation requires adding:
+        //   - `vhost` crate dependency (vhost-user slave)
+        //   - Virtio queue setup and memory region mapping
+        //   - Request processing loop
+        //
+        // See: https://github.com/rust-vmm/vhost for the vhost-user slave.
+
+        let handle = std::thread::Builder::new()
+            .name(format!("vfsd-{}", socket_path.display()))
+            .spawn(move || {
+                tracing::info!(
+                    socket = %socket_path.display(),
+                    "VFS daemon started (awaiting vhost-user-fs implementation)"
+                );
+
+                // Create the socket file to signal readiness to the VMM.
+                // In production, this would be replaced by the actual
+                // vhost-user listener socket.
+                if let Err(e) = std::os::unix::net::UnixListener::bind(&socket_path) {
+                    tracing::error!(
+                        socket = %socket_path.display(),
+                        error = %e,
+                        "Failed to bind vhost-user-fs socket"
+                    );
+                    running.store(false, Ordering::Release);
+                    return;
+                }
+
+                tracing::info!(
+                    socket = %socket_path.display(),
+                    "VFS daemon socket bound, waiting for VMM connection"
+                );
+
+                // Placeholder: wait until signaled to stop.
+                // In production this would be the vhost-user request loop.
+                while running.load(Ordering::Acquire) {
+                    std::thread::sleep(std::time::Duration::from_millis(100));
+                }
+
+                // Clean up socket.
+                let _ = std::fs::remove_file(&socket_path);
+                tracing::info!("VFS daemon stopped");
+            })
+            .map_err(std::io::Error::other)?;
+
+        self.thread_handle = Some(handle);
+        Ok(())
+    }
+
+    /// Stop the daemon and clean up.
+    pub fn stop(&mut self) {
+        self.running.store(false, Ordering::Release);
+
+        if let Some(handle) = self.thread_handle.take() {
+            let _ = handle.join();
+        }
+
+        // Best-effort socket cleanup.
+        if self.socket_path.exists() {
+            let _ = std::fs::remove_file(&self.socket_path);
+        }
+    }
+
+    /// Check if the daemon is running.
+    pub fn is_running(&self) -> bool {
+        self.running.load(Ordering::Acquire)
+    }
+
+    /// Get the socket path.
+    pub fn socket_path(&self) -> &Path {
+        &self.socket_path
+    }
+}
+
+impl<M: Mount + 'static> Drop for VfsDaemon<M> {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use hyprstream_rpc::Subject;
+    use hyprstream_vfs::{DirEntry, Fid, MountError, Stat};
+
+    /// Minimal mount for testing daemon lifecycle.
+    struct StubMount;
+
+    struct StubFid;
+
+    #[async_trait]
+    impl Mount for StubMount {
+        async fn walk(&self, _c: &[&str], _caller: &Subject) -> Result<Fid, MountError> {
+            Ok(Fid::new(StubFid))
+        }
+        async fn open(&self, _fid: &mut Fid, _mode: u8, _caller: &Subject) -> Result<(), MountError> {
+            Ok(())
+        }
+        async fn read(&self, _fid: &Fid, _offset: u64, _count: u32, _caller: &Subject) -> Result<Vec<u8>, MountError> {
+            Ok(b"stub".to_vec())
+        }
+        async fn write(&self, _fid: &Fid, _offset: u64, _data: &[u8], _caller: &Subject) -> Result<u32, MountError> {
+            Ok(0)
+        }
+        async fn readdir(&self, _fid: &Fid, _caller: &Subject) -> Result<Vec<DirEntry>, MountError> {
+            Ok(vec![])
+        }
+        async fn stat(&self, _fid: &Fid, _caller: &Subject) -> Result<Stat, MountError> {
+            Ok(Stat { qtype: 0, size: 0, name: String::new(), mtime: 0, path: 0, version: 0 })
+        }
+        async fn clunk(&self, _fid: Fid, _caller: &Subject) {}
+    }
+
+    /// Wait for the socket to appear (thread needs time to bind).
+    async fn wait_for_socket(path: &Path) {
+        for _ in 0..20 {
+            if path.exists() { return; }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn daemon_lifecycle() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("test-vfsd.sock");
+
+        let mut daemon = VfsDaemon::new(StubMount, &sock);
+        assert!(!daemon.is_running());
+
+        daemon.start().unwrap();
+        assert!(daemon.is_running());
+        wait_for_socket(&sock).await;
+        assert!(sock.exists(), "socket should be created");
+
+        daemon.stop();
+        assert!(!daemon.is_running());
+        assert!(!sock.exists(), "socket should be cleaned up");
+    }
+
+    #[tokio::test]
+    async fn daemon_double_start_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("test-vfsd2.sock");
+
+        let mut daemon = VfsDaemon::new(StubMount, &sock);
+        daemon.start().unwrap();
+        wait_for_socket(&sock).await;
+        // Second start should be a no-op.
+        daemon.start().unwrap();
+        assert!(daemon.is_running());
+
+        daemon.stop();
+    }
+
+    #[tokio::test]
+    async fn daemon_drop_cleans_up() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("test-vfsd3.sock");
+
+        {
+            let mut daemon = VfsDaemon::new(StubMount, &sock);
+            daemon.start().unwrap();
+            wait_for_socket(&sock).await;
+            assert!(sock.exists());
+        }
+        // After drop, socket should be removed.
+        // Give thread a moment to clean up.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        assert!(!sock.exists(), "socket should be cleaned up on drop");
+    }
+
+    #[tokio::test]
+    async fn socket_path_accessor() {
+        let daemon = VfsDaemon::new(StubMount, "/tmp/test-vfsd-accessor.sock");
+        assert_eq!(daemon.socket_path(), Path::new("/tmp/test-vfsd-accessor.sock"));
+    }
+}

--- a/crates/hyprstream-vfsd/src/dax.rs
+++ b/crates/hyprstream-vfsd/src/dax.rs
@@ -1,0 +1,54 @@
+//! DAX (Direct Access) mount trait for zero-copy file access.
+//!
+//! Mounts that can provide a backing file descriptor enable virtio-fs DAX
+//! window mapping, allowing the guest to mmap model weights directly from
+//! the host without copying through the FUSE data path.
+
+use std::os::fd::OwnedFd;
+
+use hyprstream_vfs::{Fid, Mount};
+
+/// Extension trait for mounts that support DAX (direct memory-mapped access).
+///
+/// When a mount implements this trait, the [`crate::VfsFuse`] adapter can use
+/// `setupmapping` / `removemapping` to map file regions directly into the
+/// guest's DAX window, bypassing FUSE read/write for large files.
+///
+/// Primary use case: model weight files (`.safetensors`) where zero-copy
+/// access from the guest eliminates data path overhead and double page-cache
+/// buffering.
+///
+/// # Permissions — SECURITY
+///
+/// The returned descriptor's open mode IS the enforcement boundary for DAX
+/// writes: a read-only file MUST return a descriptor opened `O_RDONLY` so a
+/// guest cannot obtain a writable mapping of host memory it may not modify.
+/// The adapter additionally rejects writable mappings against read-only opens
+/// as defense-in-depth (see `VfsFuse::setupmapping`).
+pub trait DaxMount: Mount {
+    /// Return a file descriptor backing the given fid, if DAX-capable.
+    ///
+    /// Returns `None` if the fid does not support direct mapping (e.g.
+    /// synthetic ctl files, directories, or dynamic content); the adapter
+    /// then falls back to the normal FUSE read/write path.
+    fn backing_fd(&self, fid: &Fid) -> Option<OwnedFd>;
+}
+
+/// Object-safe erasure of [`DaxMount`] so that [`crate::VfsFuse`], which is
+/// generic over `M: Mount`, can hold an optional DAX capability without
+/// constraining every `VfsFuse<M>` to `M: DaxMount`.
+///
+/// A `VfsFuse` built from a plain `Mount` carries `dax = None` and transparently
+/// reports `ENOSYS` for mapping requests; one built via
+/// [`crate::VfsFuse::with_dax`] (where `M: DaxMount`) stores a second `Arc`
+/// to the same mount as `Arc<dyn ErasedDax>`. DAX is therefore an *optional
+/// capability of the adapter*, not a special-cased second code path.
+pub(crate) trait ErasedDax: Send + Sync {
+    fn backing_fd(&self, fid: &Fid) -> Option<OwnedFd>;
+}
+
+impl<T: DaxMount + Send + Sync> ErasedDax for T {
+    fn backing_fd(&self, fid: &Fid) -> Option<OwnedFd> {
+        DaxMount::backing_fd(self, fid)
+    }
+}

--- a/crates/hyprstream-vfsd/src/fuse_fs.rs
+++ b/crates/hyprstream-vfsd/src/fuse_fs.rs
@@ -1,0 +1,699 @@
+//! FUSE FileSystem implementation backed by the VFS Mount trait.
+//!
+//! Translates between the fuse-backend-rs `FileSystem` trait (Linux FUSE protocol)
+//! and the hyprstream-vfs `Mount` trait (Plan9-inspired VFS).
+
+use std::ffi::CStr;
+use std::io;
+use std::os::fd::AsRawFd;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use fuse_backend_rs::abi::fuse_abi::{stat64, FsOptions};
+use fuse_backend_rs::abi::virtio_fs::RemovemappingOne;
+use fuse_backend_rs::api::filesystem::{
+    Context, DirEntry as FuseDirEntry, Entry, FileSystem, ZeroCopyReader, ZeroCopyWriter,
+};
+use fuse_backend_rs::transport::FsCacheReqHandler;
+use parking_lot::RwLock;
+
+use hyprstream_rpc::Subject;
+use hyprstream_vfs::{Fid, Mount, OREAD, OWRITE};
+
+use crate::dax::{DaxMount, ErasedDax};
+use crate::inode_table::{InodeTable, ROOT_INODE};
+
+/// Default TTL for directory/attribute caches (1 second).
+const DEFAULT_TTL: Duration = Duration::from_secs(1);
+
+/// `SetupmappingFlags::WRITE` bit from the virtio-fs ABI (fuse.h
+/// `FUSE_SETUPMAPPING_FLAG_WRITE`). fuse-backend-rs does not re-export the
+/// flags type publicly, so the bit is mirrored here.
+const SETUPMAPPING_FLAG_WRITE: u64 = 0x1;
+
+/// Per-handle state tracking an open VFS fid.
+struct HandleData {
+    fid: RwLock<Fid>,
+    #[allow(dead_code)] // Retained for diagnostics.
+    inode: u64,
+    /// Whether the handle was opened for writing — gates writable DAX mappings.
+    write: bool,
+}
+
+/// FUSE filesystem adapter that bridges a VFS `Mount` to the FUSE protocol.
+///
+/// Maps FUSE inodes to VFS paths via an [`InodeTable`], and translates
+/// FUSE operations (lookup, getattr, read, write, readdir) to Mount trait calls.
+///
+/// All operations use an anonymous `Subject` since FUSE context (uid/gid)
+/// does not map directly to hyprstream's identity model. The virtio-fs
+/// daemon should enforce access control at a higher layer.
+pub struct VfsFuse<M: Mount> {
+    mount: Arc<M>,
+    /// Optional DAX capability, present iff the adapter was built via
+    /// [`VfsFuse::with_dax`] from a mount implementing [`DaxMount`]. Points at
+    /// the same instance as `mount`. `None` → DAX mapping requests return
+    /// `ENOSYS` and the guest falls back to the FUSE read path.
+    dax: Option<Arc<dyn ErasedDax>>,
+    inodes: InodeTable,
+    /// Monotonic handle allocator.
+    next_handle: AtomicU64,
+    /// Open handle table: handle_id -> HandleData.
+    handles: dashmap::DashMap<u64, HandleData>,
+    /// Tokio runtime handle for blocking on async Mount calls from sync FUSE callbacks.
+    rt: tokio::runtime::Handle,
+}
+
+impl<M: Mount> VfsFuse<M> {
+    /// Create a new FUSE adapter wrapping the given VFS mount, without DAX.
+    ///
+    /// Requires a tokio runtime handle because FUSE callbacks are synchronous
+    /// but the Mount trait is async. Each callback uses `block_on()`.
+    pub fn new(mount: M, rt: tokio::runtime::Handle) -> Self {
+        Self {
+            mount: Arc::new(mount),
+            dax: None,
+            inodes: InodeTable::new(),
+            next_handle: AtomicU64::new(1),
+            handles: dashmap::DashMap::new(),
+            rt,
+        }
+    }
+}
+
+impl<M: DaxMount + 'static> VfsFuse<M> {
+    /// Create a FUSE adapter with DAX (direct-access) support enabled.
+    ///
+    /// Available only when `M: DaxMount`. The guest can then request
+    /// `setupmapping`/`removemapping` to map DAX-capable files directly into
+    /// its DAX window; files for which [`DaxMount::backing_fd`] returns `None`
+    /// transparently fall back to the FUSE read path.
+    pub fn with_dax(mount: M, rt: tokio::runtime::Handle) -> Self {
+        let mount = Arc::new(mount);
+        let dax: Arc<dyn ErasedDax> = mount.clone();
+        Self {
+            mount,
+            dax: Some(dax),
+            inodes: InodeTable::new(),
+            next_handle: AtomicU64::new(1),
+            handles: dashmap::DashMap::new(),
+            rt,
+        }
+    }
+}
+
+impl<M: Mount> VfsFuse<M> {
+    /// Get the anonymous caller subject used for all VFS operations.
+    fn caller() -> Subject {
+        Subject::anonymous()
+    }
+
+    /// Build a stat64 for a directory inode.
+    fn dir_stat(ino: u64) -> stat64 {
+        let mut st: stat64 = unsafe { std::mem::zeroed() };
+        st.st_ino = ino;
+        st.st_mode = libc::S_IFDIR | 0o555;
+        st.st_nlink = 2;
+        st
+    }
+
+    /// Build a stat64 for a file inode with the given size.
+    fn file_stat(ino: u64, size: u64) -> stat64 {
+        let mut st: stat64 = unsafe { std::mem::zeroed() };
+        st.st_ino = ino;
+        st.st_mode = libc::S_IFREG | 0o444;
+        st.st_nlink = 1;
+        st.st_size = size as i64;
+        st
+    }
+
+    /// Walk path components and stat the result to determine if dir or file.
+    fn walk_and_stat(
+        &self,
+        components: &[String],
+    ) -> io::Result<(bool, u64)> {
+        let refs: Vec<&str> = components.iter().map(String::as_str).collect();
+        let caller = Self::caller();
+        let fid = self.rt
+            .block_on(self.mount.walk(&refs, &caller))
+            .map_err(mount_err_to_io)?;
+        let stat = self.rt
+            .block_on(self.mount.stat(&fid, &caller))
+            .map_err(mount_err_to_io)?;
+        let is_dir = stat.qtype & 0x80 != 0; // QTDIR
+        let size = stat.size;
+        self.rt.block_on(self.mount.clunk(fid, &caller));
+        Ok((is_dir, size))
+    }
+}
+
+impl<M: Mount + 'static> FileSystem for VfsFuse<M> {
+    type Inode = u64;
+    type Handle = u64;
+
+    fn init(&self, _capable: FsOptions) -> io::Result<FsOptions> {
+        Ok(FsOptions::empty())
+    }
+
+    fn destroy(&self) {}
+
+    fn lookup(&self, _ctx: &Context, parent: u64, name: &CStr) -> io::Result<Entry> {
+        let name_str = name
+            .to_str()
+            .map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+
+        // Build the full path from parent inode + child name.
+        let parent_path = self
+            .inodes
+            .path_of(parent)
+            .ok_or_else(|| io::Error::from_raw_os_error(libc::ENOENT))?;
+
+        let mut child_path = parent_path;
+        child_path.push(name_str.to_owned());
+
+        // Walk the VFS to verify existence and get metadata.
+        let (is_dir, size) = self.walk_and_stat(&child_path)?;
+
+        // Allocate or reuse an inode.
+        let ino = self.inodes.lookup_or_insert(child_path, is_dir);
+
+        let attr = if is_dir {
+            Self::dir_stat(ino)
+        } else {
+            Self::file_stat(ino, size)
+        };
+
+        Ok(Entry {
+            inode: ino,
+            generation: 0,
+            attr,
+            attr_flags: 0,
+            attr_timeout: DEFAULT_TTL,
+            entry_timeout: DEFAULT_TTL,
+        })
+    }
+
+    fn forget(&self, _ctx: &Context, inode: u64, count: u64) {
+        self.inodes.forget(inode, count);
+    }
+
+    fn getattr(
+        &self,
+        _ctx: &Context,
+        inode: u64,
+        _handle: Option<u64>,
+    ) -> io::Result<(stat64, Duration)> {
+        if inode == ROOT_INODE {
+            return Ok((Self::dir_stat(ROOT_INODE), DEFAULT_TTL));
+        }
+
+        let path = self
+            .inodes
+            .path_of(inode)
+            .ok_or_else(|| io::Error::from_raw_os_error(libc::ENOENT))?;
+
+        let is_dir = self
+            .inodes
+            .get(inode)
+            .map(|d| d.is_dir)
+            .unwrap_or(false);
+
+        let attr = if is_dir {
+            Self::dir_stat(inode)
+        } else {
+            // Walk to get current size.
+            let refs: Vec<&str> = path.iter().map(String::as_str).collect();
+            let caller = Self::caller();
+            let fid = self.rt
+                .block_on(self.mount.walk(&refs, &caller))
+                .map_err(mount_err_to_io)?;
+            let stat = self.rt
+                .block_on(self.mount.stat(&fid, &caller))
+                .map_err(mount_err_to_io)?;
+            self.rt.block_on(self.mount.clunk(fid, &caller));
+            Self::file_stat(inode, stat.size)
+        };
+
+        Ok((attr, DEFAULT_TTL))
+    }
+
+    fn open(
+        &self,
+        _ctx: &Context,
+        inode: u64,
+        flags: u32,
+        _fuse_flags: u32,
+    ) -> io::Result<(Option<u64>, fuse_backend_rs::api::filesystem::OpenOptions, Option<u32>)> {
+        let path = self
+            .inodes
+            .path_of(inode)
+            .ok_or_else(|| io::Error::from_raw_os_error(libc::ENOENT))?;
+
+        let refs: Vec<&str> = path.iter().map(String::as_str).collect();
+        let caller = Self::caller();
+
+        let mut fid = self.rt
+            .block_on(self.mount.walk(&refs, &caller))
+            .map_err(mount_err_to_io)?;
+
+        // Map POSIX open flags to 9P mode. O_WRONLY and O_RDWR both imply write.
+        let acc = flags & libc::O_ACCMODE as u32;
+        let write = acc == libc::O_WRONLY as u32 || acc == libc::O_RDWR as u32;
+        let mode = if write { OWRITE } else { OREAD };
+
+        self.rt
+            .block_on(self.mount.open(&mut fid, mode, &caller))
+            .map_err(mount_err_to_io)?;
+
+        let handle_id = self.next_handle.fetch_add(1, Ordering::Relaxed);
+        self.handles.insert(
+            handle_id,
+            HandleData {
+                fid: RwLock::new(fid),
+                inode,
+                write,
+            },
+        );
+
+        Ok((
+            Some(handle_id),
+            fuse_backend_rs::api::filesystem::OpenOptions::empty(),
+            None,
+        ))
+    }
+
+    fn read(
+        &self,
+        _ctx: &Context,
+        _inode: u64,
+        handle: u64,
+        w: &mut dyn ZeroCopyWriter,
+        size: u32,
+        offset: u64,
+        _lock_owner: Option<u64>,
+        _flags: u32,
+    ) -> io::Result<usize> {
+        let entry = self
+            .handles
+            .get(&handle)
+            .ok_or_else(|| io::Error::from_raw_os_error(libc::EBADF))?;
+
+        let fid = entry.fid.read();
+        let caller = Self::caller();
+        let data = self.rt
+            .block_on(self.mount.read(&fid, offset, size, &caller))
+            .map_err(mount_err_to_io)?;
+
+        let len = data.len();
+        w.write_all(&data)?;
+        Ok(len)
+    }
+
+    fn write(
+        &self,
+        _ctx: &Context,
+        _inode: u64,
+        handle: u64,
+        r: &mut dyn ZeroCopyReader,
+        size: u32,
+        offset: u64,
+        _lock_owner: Option<u64>,
+        _delayed_write: bool,
+        _flags: u32,
+        _fuse_flags: u32,
+    ) -> io::Result<usize> {
+        let entry = self
+            .handles
+            .get(&handle)
+            .ok_or_else(|| io::Error::from_raw_os_error(libc::EBADF))?;
+
+        let mut buf = vec![0u8; size as usize];
+        r.read_exact(&mut buf)?;
+
+        let fid = entry.fid.read();
+        let caller = Self::caller();
+        let written = self.rt
+            .block_on(self.mount.write(&fid, offset, &buf, &caller))
+            .map_err(mount_err_to_io)?;
+
+        Ok(written as usize)
+    }
+
+    fn release(
+        &self,
+        _ctx: &Context,
+        _inode: u64,
+        _flags: u32,
+        handle: u64,
+        _flush: bool,
+        _flock_release: bool,
+        _lock_owner: Option<u64>,
+    ) -> io::Result<()> {
+        if let Some((_, data)) = self.handles.remove(&handle) {
+            let caller = Self::caller();
+            let fid = data.fid.into_inner();
+            self.rt.block_on(self.mount.clunk(fid, &caller));
+        }
+        Ok(())
+    }
+
+    fn opendir(
+        &self,
+        _ctx: &Context,
+        inode: u64,
+        _flags: u32,
+    ) -> io::Result<(Option<u64>, fuse_backend_rs::api::filesystem::OpenOptions)> {
+        let path = self
+            .inodes
+            .path_of(inode)
+            .ok_or_else(|| io::Error::from_raw_os_error(libc::ENOENT))?;
+
+        let refs: Vec<&str> = path.iter().map(String::as_str).collect();
+        let caller = Self::caller();
+
+        let mut fid = self.rt
+            .block_on(self.mount.walk(&refs, &caller))
+            .map_err(mount_err_to_io)?;
+
+        self.rt
+            .block_on(self.mount.open(&mut fid, OREAD, &caller))
+            .map_err(mount_err_to_io)?;
+
+        let handle_id = self.next_handle.fetch_add(1, Ordering::Relaxed);
+        self.handles.insert(
+            handle_id,
+            HandleData {
+                fid: RwLock::new(fid),
+                inode,
+                write: false,
+            },
+        );
+
+        Ok((
+            Some(handle_id),
+            fuse_backend_rs::api::filesystem::OpenOptions::empty(),
+        ))
+    }
+
+    fn readdir(
+        &self,
+        _ctx: &Context,
+        inode: u64,
+        handle: u64,
+        _size: u32,
+        offset: u64,
+        add_entry: &mut dyn FnMut(FuseDirEntry<'_>) -> io::Result<usize>,
+    ) -> io::Result<()> {
+        let entry = self
+            .handles
+            .get(&handle)
+            .ok_or_else(|| io::Error::from_raw_os_error(libc::EBADF))?;
+
+        let fid = entry.fid.read();
+        let caller = Self::caller();
+        let entries = self.rt
+            .block_on(self.mount.readdir(&fid, &caller))
+            .map_err(mount_err_to_io)?;
+
+        // Get parent path for building child paths.
+        let parent_path = self
+            .inodes
+            .path_of(inode)
+            .unwrap_or_default();
+
+        for (i, vfs_entry) in entries.iter().enumerate() {
+            let idx = i as u64 + 1; // 1-based offset
+            if idx <= offset {
+                continue;
+            }
+
+            // Build child path and allocate inode.
+            let mut child_path = parent_path.clone();
+            child_path.push(vfs_entry.name.clone());
+            let child_ino = self
+                .inodes
+                .lookup_or_insert(child_path, vfs_entry.is_dir);
+
+            let dtype = if vfs_entry.is_dir {
+                libc::DT_DIR as u32
+            } else {
+                libc::DT_REG as u32
+            };
+
+            let fuse_entry = FuseDirEntry {
+                ino: child_ino,
+                offset: idx,
+                type_: dtype,
+                name: vfs_entry.name.as_bytes(),
+            };
+
+            match add_entry(fuse_entry) {
+                Ok(0) => break, // Buffer full.
+                Ok(_) => {}
+                Err(e) => return Err(e),
+            }
+        }
+
+        Ok(())
+    }
+
+    fn releasedir(
+        &self,
+        _ctx: &Context,
+        _inode: u64,
+        _flags: u32,
+        handle: u64,
+    ) -> io::Result<()> {
+        if let Some((_, data)) = self.handles.remove(&handle) {
+            let caller = Self::caller();
+            let fid = data.fid.into_inner();
+            self.rt.block_on(self.mount.clunk(fid, &caller));
+        }
+        Ok(())
+    }
+
+    /// DAX setup: map a region of the backing file directly into the guest's
+    /// DAX window so the guest can `mmap` it without a FUSE read round-trip.
+    ///
+    /// Returns `ENOSYS` (so the guest falls back to the FUSE read path) when
+    /// the adapter has no DAX capability, or when the open fid has no
+    /// directly-mappable backing file (synthetic/ctl/dynamic content).
+    /// Rejects a writable mapping against a read-only handle with `EACCES`.
+    fn setupmapping(
+        &self,
+        _ctx: &Context,
+        _inode: u64,
+        handle: u64,
+        foffset: u64,
+        len: u64,
+        flags: u64,
+        moffset: u64,
+        vu_req: &mut dyn FsCacheReqHandler,
+    ) -> io::Result<()> {
+        // No DAX capability → fall back to the FUSE read path.
+        let dax = self
+            .dax
+            .as_ref()
+            .ok_or_else(|| io::Error::from_raw_os_error(libc::ENOSYS))?;
+
+        let entry = self
+            .handles
+            .get(&handle)
+            .ok_or_else(|| io::Error::from_raw_os_error(libc::EBADF))?;
+
+        // Defense-in-depth: never grant a writable host mapping through a
+        // read-only handle. (The backing fd's open mode is the primary guard.)
+        if flags & SETUPMAPPING_FLAG_WRITE != 0 && !entry.write {
+            return Err(io::Error::from_raw_os_error(libc::EACCES));
+        }
+
+        let fid = entry.fid.read();
+        let fd = match dax.backing_fd(&fid) {
+            Some(fd) => fd,
+            // Not directly mappable → let the guest use the FUSE read path.
+            None => return Err(io::Error::from_raw_os_error(libc::ENOSYS)),
+        };
+
+        // The VMM duplicates the fd over the vhost-user socket (SCM_RIGHTS)
+        // during `map`, so the local `OwnedFd` may be dropped (closed) once
+        // `map` returns — matching virtiofsd's fd lifetime.
+        vu_req.map(foffset, moffset, len, flags, fd.as_raw_fd())
+    }
+
+    /// DAX teardown: remove previously-established DAX window mappings.
+    fn removemapping(
+        &self,
+        _ctx: &Context,
+        _inode: u64,
+        requests: Vec<RemovemappingOne>,
+        vu_req: &mut dyn FsCacheReqHandler,
+    ) -> io::Result<()> {
+        vu_req.unmap(requests)
+    }
+}
+
+/// Convert a VFS MountError to a std::io::Error with appropriate errno.
+fn mount_err_to_io(e: hyprstream_vfs::MountError) -> io::Error {
+    use hyprstream_vfs::MountError;
+    let errno = match &e {
+        MountError::NotFound(_) => libc::ENOENT,
+        MountError::PermissionDenied(_) => libc::EACCES,
+        MountError::NotDirectory(_) => libc::ENOTDIR,
+        MountError::IsDirectory(_) => libc::EISDIR,
+        MountError::InvalidArgument(_) => libc::EINVAL,
+        MountError::NotSupported(_) => libc::ENOSYS,
+        MountError::AlreadyExists(_) => libc::EEXIST,
+        MountError::Io(_) => libc::EIO,
+    };
+    io::Error::from_raw_os_error(errno)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+    use std::os::fd::OwnedFd;
+
+    use async_trait::async_trait;
+    use fuse_backend_rs::api::filesystem::Context;
+    use hyprstream_vfs::{DirEntry, MountError, Stat};
+
+    use crate::dax::DaxMount;
+    use crate::inode_table::ROOT_INODE;
+
+    /// Stub mount: every file is a 1 KiB regular file; `dax` controls whether
+    /// it advertises a backing fd.
+    struct StubMount {
+        dax: bool,
+    }
+
+    #[async_trait]
+    impl Mount for StubMount {
+        async fn walk(&self, _c: &[&str], _caller: &Subject) -> Result<Fid, MountError> {
+            Ok(Fid::new(()))
+        }
+        async fn open(&self, _fid: &mut Fid, _mode: u8, _caller: &Subject) -> Result<(), MountError> {
+            Ok(())
+        }
+        async fn read(&self, _fid: &Fid, _off: u64, _n: u32, _caller: &Subject) -> Result<Vec<u8>, MountError> {
+            Ok(vec![0u8; 16])
+        }
+        async fn write(&self, _fid: &Fid, _off: u64, data: &[u8], _caller: &Subject) -> Result<u32, MountError> {
+            Ok(data.len() as u32)
+        }
+        async fn readdir(&self, _fid: &Fid, _caller: &Subject) -> Result<Vec<DirEntry>, MountError> {
+            Ok(vec![])
+        }
+        async fn stat(&self, _fid: &Fid, _caller: &Subject) -> Result<Stat, MountError> {
+            // qtype 0 == regular file (QTDIR bit 0x80 clear).
+            Ok(Stat { qtype: 0, size: 1024, name: "weights".into(), mtime: 0, path: 0, version: 0 })
+        }
+        async fn clunk(&self, _fid: Fid, _caller: &Subject) {}
+    }
+
+    impl DaxMount for StubMount {
+        fn backing_fd(&self, _fid: &Fid) -> Option<OwnedFd> {
+            if !self.dax {
+                return None;
+            }
+            // A real, mappable fd. /dev/null is always present and read-only here.
+            std::fs::File::open("/dev/null").ok().map(OwnedFd::from)
+        }
+    }
+
+    /// Records the DAX window operations the adapter forwards.
+    #[derive(Default)]
+    struct MockReq {
+        mapped: u32,
+        unmapped: u32,
+    }
+    impl FsCacheReqHandler for MockReq {
+        fn map(&mut self, _fo: u64, _mo: u64, _len: u64, _flags: u64, _fd: std::os::fd::RawFd) -> io::Result<()> {
+            self.mapped += 1;
+            Ok(())
+        }
+        fn unmap(&mut self, requests: Vec<RemovemappingOne>) -> io::Result<()> {
+            self.unmapped += requests.len() as u32;
+            Ok(())
+        }
+    }
+
+    /// Open a read- or write-mode handle on a freshly-looked-up file inode.
+    fn open_handle<M: Mount + 'static>(fs: &VfsFuse<M>, write: bool) -> u64 {
+        let ctx = Context::default();
+        let name = CString::new("weights").unwrap();
+        fs.lookup(&ctx, ROOT_INODE, &name).unwrap();
+        let ino = fs.inodes.lookup_or_insert(vec!["weights".into()], false);
+        let flags = if write { libc::O_WRONLY as u32 } else { libc::O_RDONLY as u32 };
+        let (handle, _, _) = fs.open(&ctx, ino, flags, 0).unwrap();
+        handle.unwrap()
+    }
+
+    #[test]
+    fn non_dax_adapter_reports_enosys() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let fs = VfsFuse::new(StubMount { dax: false }, rt.handle().clone());
+        let handle = open_handle(&fs, false);
+        let mut req = MockReq::default();
+        let err = fs
+            .setupmapping(&Context::default(), 0, handle, 0, 4096, 0, 0, &mut req)
+            .unwrap_err();
+        assert_eq!(err.raw_os_error(), Some(libc::ENOSYS));
+        assert_eq!(req.mapped, 0);
+    }
+
+    #[test]
+    fn dax_setupmapping_maps_then_removemapping_unmaps() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let fs = VfsFuse::with_dax(StubMount { dax: true }, rt.handle().clone());
+        let handle = open_handle(&fs, false);
+        let mut req = MockReq::default();
+
+        fs.setupmapping(&Context::default(), 0, handle, 0, 4096, 0, 0, &mut req)
+            .unwrap();
+        assert_eq!(req.mapped, 1, "DAX-capable mount should program the window");
+
+        let removes = vec![RemovemappingOne { moffset: 0, len: 4096 }];
+        fs.removemapping(&Context::default(), 0, removes, &mut req)
+            .unwrap();
+        assert_eq!(req.unmapped, 1);
+    }
+
+    #[test]
+    fn dax_falls_back_to_enosys_when_no_backing_fd() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        // DAX enabled on the adapter, but the mount returns no backing fd.
+        let fs = VfsFuse::with_dax(StubMount { dax: false }, rt.handle().clone());
+        let handle = open_handle(&fs, false);
+        let mut req = MockReq::default();
+        let err = fs
+            .setupmapping(&Context::default(), 0, handle, 0, 4096, 0, 0, &mut req)
+            .unwrap_err();
+        assert_eq!(err.raw_os_error(), Some(libc::ENOSYS));
+        assert_eq!(req.mapped, 0);
+    }
+
+    #[test]
+    fn writable_mapping_on_readonly_handle_is_denied() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let fs = VfsFuse::with_dax(StubMount { dax: true }, rt.handle().clone());
+        let handle = open_handle(&fs, false); // read-only open
+        let mut req = MockReq::default();
+        let err = fs
+            .setupmapping(
+                &Context::default(),
+                0,
+                handle,
+                0,
+                4096,
+                SETUPMAPPING_FLAG_WRITE,
+                0,
+                &mut req,
+            )
+            .unwrap_err();
+        assert_eq!(err.raw_os_error(), Some(libc::EACCES));
+        assert_eq!(req.mapped, 0);
+    }
+}

--- a/crates/hyprstream-vfsd/src/inode_table.rs
+++ b/crates/hyprstream-vfsd/src/inode_table.rs
@@ -1,0 +1,232 @@
+//! Inode table mapping u64 inode numbers to VFS path components.
+//!
+//! The FUSE protocol addresses files by inode number. This table translates
+//! between FUSE inodes and VFS paths, maintaining lookup counts for proper
+//! lifetime management via FUSE `forget()`.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use dashmap::DashMap;
+
+/// Root inode, always 1 per FUSE convention.
+pub const ROOT_INODE: u64 = 1;
+
+/// Data associated with a single inode.
+pub struct InodeData {
+    /// Path components from root to this node (empty for root).
+    pub path: Vec<String>,
+    /// FUSE lookup count — decremented by forget(), entry removed at zero.
+    pub lookup_count: AtomicU64,
+    /// Whether this inode represents a directory.
+    pub is_dir: bool,
+}
+
+impl InodeData {
+    fn new(path: Vec<String>, is_dir: bool) -> Self {
+        Self {
+            path,
+            lookup_count: AtomicU64::new(1),
+            is_dir,
+        }
+    }
+}
+
+/// Concurrent inode table for FUSE inode <-> VFS path translation.
+///
+/// Thread-safe: uses `DashMap` for lock-free concurrent access from
+/// multiple FUSE worker threads.
+pub struct InodeTable {
+    inodes: DashMap<u64, InodeData>,
+    /// Reverse map: path -> inode for dedup on repeated lookups.
+    paths: DashMap<Vec<String>, u64>,
+    next_inode: AtomicU64,
+}
+
+impl InodeTable {
+    /// Create a new inode table with the root inode pre-allocated.
+    pub fn new() -> Self {
+        let table = Self {
+            inodes: DashMap::new(),
+            paths: DashMap::new(),
+            next_inode: AtomicU64::new(ROOT_INODE + 1),
+        };
+        // Root inode always exists.
+        table
+            .inodes
+            .insert(ROOT_INODE, InodeData::new(vec![], true));
+        table.paths.insert(vec![], ROOT_INODE);
+        table
+    }
+
+    /// Look up or allocate an inode for the given path.
+    ///
+    /// If the path already has an inode, increments its lookup count.
+    /// Otherwise allocates a new inode number.
+    ///
+    /// Returns the inode number.
+    pub fn lookup_or_insert(&self, path: Vec<String>, is_dir: bool) -> u64 {
+        // Check if already exists.
+        if let Some(existing) = self.paths.get(&path) {
+            let ino = *existing;
+            if let Some(entry) = self.inodes.get(&ino) {
+                entry.lookup_count.fetch_add(1, Ordering::Relaxed);
+            }
+            return ino;
+        }
+
+        // Allocate new inode.
+        let ino = self.next_inode.fetch_add(1, Ordering::Relaxed);
+        self.inodes.insert(ino, InodeData::new(path.clone(), is_dir));
+        self.paths.insert(path, ino);
+        ino
+    }
+
+    /// Get a reference to inode data.
+    pub fn get(&self, ino: u64) -> Option<dashmap::mapref::one::Ref<'_, u64, InodeData>> {
+        self.inodes.get(&ino)
+    }
+
+    /// Get the path components for an inode.
+    pub fn path_of(&self, ino: u64) -> Option<Vec<String>> {
+        self.inodes.get(&ino).map(|e| e.path.clone())
+    }
+
+    /// Decrement lookup count. Removes the inode when count reaches zero
+    /// (unless it is the root inode, which is never removed).
+    pub fn forget(&self, ino: u64, nlookup: u64) {
+        if ino == ROOT_INODE {
+            return;
+        }
+        let should_remove = self
+            .inodes
+            .get(&ino)
+            .map(|entry| {
+                let prev = entry.lookup_count.fetch_sub(nlookup, Ordering::Relaxed);
+                prev <= nlookup
+            })
+            .unwrap_or(false);
+
+        if should_remove {
+            if let Some((_, data)) = self.inodes.remove(&ino) {
+                self.paths.remove(&data.path);
+            }
+        }
+    }
+
+    /// Number of active inodes (including root).
+    pub fn len(&self) -> usize {
+        self.inodes.len()
+    }
+
+    /// Whether the table contains only the root inode.
+    pub fn is_empty(&self) -> bool {
+        self.inodes.len() <= 1
+    }
+}
+
+impl Default for InodeTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn root_inode_exists() {
+        let table = InodeTable::new();
+        assert!(table.get(ROOT_INODE).is_some());
+        let root = table.get(ROOT_INODE);
+        assert!(root.as_ref().is_some_and(|r| r.is_dir));
+        assert!(root.as_ref().is_some_and(|r| r.path.is_empty()));
+    }
+
+    #[test]
+    fn lookup_allocates_new_inode() {
+        let table = InodeTable::new();
+        let ino = table.lookup_or_insert(vec!["srv".to_owned()], true);
+        assert!(ino > ROOT_INODE);
+        assert_eq!(table.len(), 2);
+
+        let data = table.get(ino);
+        assert!(data.as_ref().is_some_and(|d| d.is_dir));
+        assert!(
+            data.as_ref()
+                .is_some_and(|d| d.path == vec!["srv".to_owned()])
+        );
+    }
+
+    #[test]
+    fn lookup_deduplicates() {
+        let table = InodeTable::new();
+        let ino1 = table.lookup_or_insert(vec!["srv".to_owned()], true);
+        let ino2 = table.lookup_or_insert(vec!["srv".to_owned()], true);
+        assert_eq!(ino1, ino2);
+        assert_eq!(table.len(), 2); // root + srv
+
+        // Lookup count should be 2 (initial + re-lookup).
+        let data = table.get(ino1);
+        assert!(
+            data.as_ref()
+                .is_some_and(|d| d.lookup_count.load(Ordering::Relaxed) == 2)
+        );
+    }
+
+    #[test]
+    fn forget_removes_inode() {
+        let table = InodeTable::new();
+        let ino = table.lookup_or_insert(vec!["tmp".to_owned()], false);
+        assert_eq!(table.len(), 2);
+
+        table.forget(ino, 1);
+        assert_eq!(table.len(), 1); // Only root remains.
+        assert!(table.get(ino).is_none());
+    }
+
+    #[test]
+    fn forget_root_is_noop() {
+        let table = InodeTable::new();
+        table.forget(ROOT_INODE, 100);
+        assert!(table.get(ROOT_INODE).is_some());
+    }
+
+    #[test]
+    fn forget_partial_keeps_inode() {
+        let table = InodeTable::new();
+        let ino = table.lookup_or_insert(vec!["a".to_owned()], true);
+        // Bump lookup count to 2.
+        table.lookup_or_insert(vec!["a".to_owned()], true);
+
+        table.forget(ino, 1);
+        // Should still exist with count 1.
+        assert!(table.get(ino).is_some());
+        assert_eq!(table.len(), 2);
+    }
+
+    #[test]
+    fn hierarchical_paths() {
+        let table = InodeTable::new();
+        let srv = table.lookup_or_insert(vec!["srv".to_owned()], true);
+        let model = table.lookup_or_insert(vec!["srv".to_owned(), "model".to_owned()], true);
+        let status = table.lookup_or_insert(
+            vec![
+                "srv".to_owned(),
+                "model".to_owned(),
+                "status".to_owned(),
+            ],
+            false,
+        );
+
+        assert_ne!(srv, model);
+        assert_ne!(model, status);
+        assert_eq!(table.len(), 4); // root + 3 nodes
+
+        assert_eq!(table.path_of(status), Some(vec![
+            "srv".to_owned(),
+            "model".to_owned(),
+            "status".to_owned(),
+        ]));
+    }
+}

--- a/crates/hyprstream-vfsd/src/lib.rs
+++ b/crates/hyprstream-vfsd/src/lib.rs
@@ -1,0 +1,38 @@
+//! FUSE/virtio-fs adapter bridging VFS Mount trait to guest VMs.
+//!
+//! This crate implements a FUSE filesystem backed by [`hyprstream_vfs::Mount`],
+//! allowing the VFS namespace to be exposed to guest VMs via virtio-fs.
+//!
+//! Linux-only: depends on fuse-backend-rs for the FUSE protocol implementation.
+//!
+//! # Architecture
+//!
+//! ```text
+//!   Guest VM (virtio-fs mount)
+//!        |
+//!   vhost-user-fs socket
+//!        |
+//!   fuse-backend-rs (FUSE protocol)
+//!        |
+//!   VfsFuse<M: Mount> (this crate)
+//!        |
+//!   hyprstream-vfs Mount trait
+//! ```
+
+#[cfg(target_os = "linux")]
+mod dax;
+#[cfg(target_os = "linux")]
+mod daemon;
+#[cfg(target_os = "linux")]
+mod fuse_fs;
+#[cfg(target_os = "linux")]
+mod inode_table;
+
+#[cfg(target_os = "linux")]
+pub use daemon::VfsDaemon;
+#[cfg(target_os = "linux")]
+pub use dax::DaxMount;
+#[cfg(target_os = "linux")]
+pub use fuse_fs::VfsFuse;
+#[cfg(target_os = "linux")]
+pub use inode_table::{InodeData, InodeTable};


### PR DESCRIPTION
Implements Phase 1 of #495.

## What
Ports the `hyprstream-vfsd` crate (FUSE/virtio-fs host adapter bridging the `hyprstream-vfs::Mount` namespace to guest VMs) from the superseded #120 onto current main, adds it to the workspace, and **implements DAX** (direct-access zero-copy mapping for guest weight loads).

## Changes
- **VfsFuse / InodeTable** — ported verbatim (FUSE FileSystem ⇄ Mount adapter; inode↔path table). Unit-tested.
- **DAX** — `DaxMount` trait + object-safe `ErasedDax` erasure so DAX is an *optional capability* of the adapter (`VfsFuse::with_dax` / `VfsDaemon::with_dax`), not a special-cased fork. Non-DAX mounts transparently report `ENOSYS` and fall back to the FUSE read path.
- **`VfsFuse::{setupmapping,removemapping}`** — program/tear-down the virtio-fs DAX window via `FsCacheReqHandler`. Writable mapping on a read-only handle is denied (`EACCES`); the backing-fd open mode is the primary guard.
- Per-handle write/read mode tracking for the DAX write check.

## Tests
15 pass (4 new DAX: capability gating, setup→remove mapping, no-backing-fd fallback, writable-on-readonly denial). `cargo clippy -p hyprstream-vfsd -- -D warnings` clean.

## Scope / phasing (per #495)
- **This PR (Phase 1):** crate port + DAX adapter, default-off, daemon is a documented scaffold → **no live guest serving, no authz exposure.**
- **Phase 2:** real vhost-user-fs request loop in `VfsDaemon` (rust-vmm `vhost` + fuse-backend-rs virtiofs transport, modeled on `nydus-service`).
- **Phase 3:** KataBackend wiring + per-sandbox namespace authz + uid/gid→Subject. **Authz sign-off required.**

Supersedes the FUSE/vfsd portion of #120.

https://claude.ai/code/session_01U3qgsHTDWME66JFGZGS3ZA