### PR TITLE
packaging: RPM build with CI release + Fedora/Rocky install check

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -43,13 +43,17 @@ jobs:
             $PM config-manager --set-enabled crb || \
               $PM config-manager --set-enabled powertools || true
           fi
-          $PM install -y \
+          # NOTE: do not list `curl` here — Rocky 9 ships `curl-minimal`, and
+          # `dnf install curl` errors with a curl/curl-minimal file conflict.
+          # The curl binary is already present (curl-minimal on Rocky, curl on
+          # Fedora) and is used by the rustup step below.
+          $PM install -y --allowerasing \
             rpm-build rpmdevtools \
             gcc gcc-c++ cmake make pkgconfig \
             openssl-devel systemd-devel capnproto \
             perl-interpreter perl-FindBin \
             git git-lfs ca-certificates \
-            curl tar gzip findutils which
+            tar gzip findutils which
 
       - name: Install Rust (rustup; distro rust is often too old)
         run: |
@@ -78,6 +82,10 @@ jobs:
 
       - name: Build RPM
         run: |
+          # pipefail so a build-rpm.sh / rpmbuild failure fails this step instead
+          # of being masked by `tee` (which would leave $RPM unset and surface as
+          # a confusing "RPM: unbound variable" in the install step).
+          set -euo pipefail
           chmod +x packaging/rpm/build-rpm.sh
           packaging/rpm/build-rpm.sh "${{ steps.ver.outputs.version }}" | tee /tmp/build.log
           grep '^RPM=' /tmp/build.log | tail -1 >> "$GITHUB_ENV"

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -47,11 +47,13 @@ jobs:
           # `dnf install curl` errors with a curl/curl-minimal file conflict.
           # The curl binary is already present (curl-minimal on Rocky, curl on
           # Fedora) and is used by the rustup step below.
+          # patchelf: set the binary RUNPATH to the bundled libtorch (see spec).
+          # perl is intentionally absent: OPENSSL_NO_VENDOR=1 disables the only
+          # openssl-sys code path that would invoke it.
           $PM install -y --allowerasing \
             rpm-build rpmdevtools \
             gcc gcc-c++ cmake make pkgconfig \
-            openssl-devel systemd-devel capnproto \
-            perl-interpreter perl-FindBin \
+            openssl-devel systemd-devel capnproto patchelf \
             git git-lfs ca-certificates \
             tar gzip findutils which
 
@@ -69,6 +71,15 @@ jobs:
 
       - name: Mark workspace safe for git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      # Cache the cargo registry + git deps (notably the tch-rs git dependency)
+      # to cut PR build time. rpmbuild compiles in ~/rpmbuild/BUILD with its own
+      # target dir, so target-artifact caching does not apply here.
+      - name: Cache cargo registry
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: rpm-${{ matrix.distro.name }}
+          cache-targets: false
 
       - name: Resolve version
         id: ver
@@ -93,12 +104,17 @@ jobs:
       - name: Install the RPM and verify it runs
         run: |
           set -eux
-          # Exercise the weak-dep override path: GPU stacks must NOT be required.
+          # Weak-dep contract: GPU stacks are Recommends, never hard Requires.
+          # Assert on the package file BEFORE install (vendor repos aren't configured).
+          rpm -qp --requires   "$RPM" | grep -Eiq 'cuda-toolkit|^rocm' && exit 1 || true
+          rpm -qp --recommends "$RPM" | grep -Eiq 'cuda-toolkit' || { echo "missing CUDA recommend"; exit 1; }
+          rpm -qp --recommends "$RPM" | grep -Eiq 'rocm'         || { echo "missing ROCm recommend"; exit 1; }
+
+          # Install with weak deps disabled: must succeed without any GPU stack.
           dnf install -y --setopt=install_weak_deps=False "$RPM"
-          hyprstream --version
           rpm -q hyprstream
-          # Confirm CUDA/ROCm were not pulled in as hard requirements
-          ! rpm -q --requires hyprstream | grep -Eiq 'cuda-toolkit|^rocm'
+          # Bundled libtorch must resolve via RUNPATH (no LD_LIBRARY_PATH set here).
+          hyprstream --version
 
       - name: Upload RPM artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -22,6 +22,8 @@ jobs:
   build-install:
     name: Build + install (${{ matrix.distro.name }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -53,6 +53,7 @@ jobs:
           $PM install -y --allowerasing \
             rpm-build rpmdevtools \
             gcc gcc-c++ cmake make pkgconfig \
+            clang clang-devel \
             openssl-devel systemd-devel capnproto patchelf \
             git git-lfs ca-certificates \
             tar gzip findutils which

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -1,0 +1,131 @@
+name: RPM Package
+
+on:
+  push:
+    tags:
+      - 'v*'
+  pull_request:
+    paths:
+      - 'packaging/rpm/**'
+      - '.github/workflows/rpm.yml'
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # Build the RPM and install it inside Fedora and Rocky containers.
+  # Runs on every PR touching packaging/build inputs, and on release tags.
+  build-install:
+    name: Build + install (${{ matrix.distro.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - { name: fedora, image: "fedora:43" }
+          - { name: rocky,  image: "rockylinux:9" }
+    container:
+      image: ${{ matrix.distro.image }}
+    steps:
+      - name: Install toolchain and build deps
+        run: |
+          set -eux
+          if command -v dnf >/dev/null; then PM=dnf; else PM=yum; fi
+          # Rocky 9 needs EPEL + CRB for capnproto/systemd-devel
+          if [ "${{ matrix.distro.name }}" = "rocky" ]; then
+            $PM install -y epel-release dnf-plugins-core
+            $PM config-manager --set-enabled crb || \
+              $PM config-manager --set-enabled powertools || true
+          fi
+          $PM install -y \
+            rpm-build rpmdevtools \
+            gcc gcc-c++ cmake make pkgconfig \
+            openssl-devel systemd-devel capnproto \
+            perl-interpreter perl-FindBin \
+            git git-lfs ca-certificates \
+            curl tar gzip findutils which
+
+      - name: Install Rust (rustup; distro rust is often too old)
+        run: |
+          set -eux
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --profile minimal --default-toolchain stable
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Mark workspace safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Resolve version
+        id: ver
+        run: |
+          if [[ "${GITHUB_REF_NAME:-}" == v* ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION="$(grep -m1 '^version' crates/hyprstream/Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Build RPM
+        run: |
+          chmod +x packaging/rpm/build-rpm.sh
+          packaging/rpm/build-rpm.sh "${{ steps.ver.outputs.version }}" | tee /tmp/build.log
+          grep '^RPM=' /tmp/build.log | tail -1 >> "$GITHUB_ENV"
+
+      - name: Install the RPM and verify it runs
+        run: |
+          set -eux
+          # Exercise the weak-dep override path: GPU stacks must NOT be required.
+          dnf install -y --setopt=install_weak_deps=False "$RPM"
+          hyprstream --version
+          rpm -q hyprstream
+          # Confirm CUDA/ROCm were not pulled in as hard requirements
+          ! rpm -q --requires hyprstream | grep -Eiq 'cuda-toolkit|^rocm'
+
+      - name: Upload RPM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpm-${{ matrix.distro.name }}-${{ steps.ver.outputs.version }}
+          path: ${{ env.RPM }}
+          retention-days: 5
+
+  # Publish the Fedora-built RPM to the GitHub Release (tags only).
+  release:
+    name: Attach RPM to release
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build-install
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Extract version
+        id: ver
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Download built RPMs
+        uses: actions/download-artifact@v4
+        with:
+          pattern: rpm-*-${{ steps.ver.outputs.version }}
+          path: rpms/
+          merge-multiple: true
+
+      - name: Checksums
+        run: |
+          cd rpms
+          sha256sum *.rpm > RPM-SHA256SUMS.txt
+          cat RPM-SHA256SUMS.txt
+
+      - name: Publish to release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            rpms/*.rpm
+            rpms/RPM-SHA256SUMS.txt

--- a/packaging/rpm/README.md
+++ b/packaging/rpm/README.md
@@ -35,7 +35,12 @@ sudo dnf install --setopt=install_weak_deps=False hyprstream
 ```
 
 - NVIDIA: `cuda-toolkit-12-8` (driver ≥ 535) or `cuda-toolkit-13-0` (driver ≥ 555)
-- AMD: `rocm >= 7.1` (gfx1151 needs ≥ 7.2)
+- AMD: `rocm >= 7.2` (gfx1151 support)
+
+Note: this RPM bundles the **CPU** libtorch runtime (PyTorch 2.10.0). The weak
+deps prepare a host for GPU use and let an operator pin/override the vendor
+stack; a GPU-accelerated libtorch build is a separate variant (see the ROCm
+AppImage) and not produced by this spec yet.
 
 ## Notes
 

--- a/packaging/rpm/README.md
+++ b/packaging/rpm/README.md
@@ -1,0 +1,47 @@
+# RPM packaging
+
+Builds an RPM of `hyprstream` using the existing Cargo build system.
+
+## Local build
+
+```bash
+# Build deps (Fedora): rpm-build rpmdevtools gcc gcc-c++ cmake make pkgconfig \
+#   openssl-devel systemd-devel capnproto perl-interpreter perl-FindBin git git-lfs
+packaging/rpm/build-rpm.sh            # version from crate (or v-tag)
+packaging/rpm/build-rpm.sh 0.5.0      # explicit version
+```
+
+The script stages the spec with the resolved version, builds a `git archive`
+source tarball, runs `rpmbuild -ba`, and prints `RPM=<path>` on the last line.
+
+## CI
+
+`.github/workflows/rpm.yml`:
+
+- **PR check** — builds the RPM and `dnf install`s it inside **Fedora 43** and
+  **Rocky 9** containers, verifies `hyprstream --version`, and asserts the GPU
+  stacks are *not* hard requirements (installed with `install_weak_deps=False`).
+- **Release** — on `v*` tags, attaches the built RPMs + checksums to the GitHub
+  Release.
+
+## GPU dependencies
+
+CUDA and ROCm are **weak deps** (`Recommends:`), pinned to the versions the
+compiled code targets, so a user can override them with a locally-installed
+version or skip them entirely:
+
+```bash
+sudo dnf install --setopt=install_weak_deps=False hyprstream
+```
+
+- NVIDIA: `cuda-toolkit-12-8` (driver ≥ 535) or `cuda-toolkit-13-0` (driver ≥ 555)
+- AMD: `rocm >= 7.1` (gfx1151 needs ≥ 7.2)
+
+## Notes
+
+- `openssl-sys` would otherwise build OpenSSL from source under `rpmbuild`
+  (rpmbuild exports `CROSS_COMPILE`); the spec unsets it so the system
+  `openssl-devel` is linked.
+- systemd units, shell completions, and a config example are intentionally not
+  packaged yet — they are not present on `main`. Add them to `%install`/`%files`
+  when they land.

--- a/packaging/rpm/build-rpm.sh
+++ b/packaging/rpm/build-rpm.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Build the hyprstream RPM from a source checkout.
+#
+# Usage: packaging/rpm/build-rpm.sh [VERSION]
+#   VERSION defaults to the hyprstream crate version (or the v-tag if set via $GITHUB_REF_NAME).
+#
+# Produces RPM(s) under ~/rpmbuild/RPMS/<arch>/ and prints the primary RPM path
+# to stdout on the last line (RPM=/path/to.rpm).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SPEC="$SCRIPT_DIR/hyprstream.spec"
+
+# --- Resolve version ---------------------------------------------------------
+VERSION="${1:-}"
+if [[ -z "$VERSION" ]]; then
+    if [[ "${GITHUB_REF_NAME:-}" == v* ]]; then
+        VERSION="${GITHUB_REF_NAME#v}"
+    else
+        VERSION="$(grep -m1 '^version' "$REPO_ROOT/crates/hyprstream/Cargo.toml" | sed -E 's/.*"([^"]+)".*/\1/')"
+    fi
+fi
+echo ">> Building hyprstream RPM version $VERSION"
+
+NAME="hyprstream"
+TOPDIR="${HOME}/rpmbuild"
+mkdir -p "$TOPDIR"/{BUILD,BUILDROOT,RPMS,SRPMS,SOURCES,SPECS}
+
+# --- Stage spec with the resolved version ------------------------------------
+STAGED_SPEC="$TOPDIR/SPECS/${NAME}.spec"
+sed "s/^Version:.*/Version:        ${VERSION}/" "$SPEC" > "$STAGED_SPEC"
+
+# --- Build the source tarball (top dir must be name-version) -----------------
+TARBALL="$TOPDIR/SOURCES/${NAME}-${VERSION}.tar.gz"
+echo ">> Creating source tarball $TARBALL"
+git -C "$REPO_ROOT" archive --format=tar.gz \
+    --prefix="${NAME}-${VERSION}/" \
+    -o "$TARBALL" HEAD
+
+# --- Build -------------------------------------------------------------------
+echo ">> rpmbuild -ba"
+rpmbuild -ba "$STAGED_SPEC"
+
+# --- Locate the primary binary RPM -------------------------------------------
+ARCH="$(uname -m)"
+RPM_PATH="$(ls -1 "$TOPDIR/RPMS/$ARCH/${NAME}-${VERSION}"-*.rpm 2>/dev/null | grep -v -- '-debug' | head -1 || true)"
+if [[ -z "$RPM_PATH" ]]; then
+    echo "ERROR: built RPM not found under $TOPDIR/RPMS/$ARCH/" >&2
+    exit 1
+fi
+echo ">> Built: $RPM_PATH"
+echo "RPM=$RPM_PATH"

--- a/packaging/rpm/build-rpm.sh
+++ b/packaging/rpm/build-rpm.sh
@@ -12,6 +12,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 SPEC="$SCRIPT_DIR/hyprstream.spec"
 
+# The Rust toolchain is provided on PATH (rustup), not as an rpm BuildRequires.
+# Fail early with a clear message if it is missing.
+if ! command -v cargo >/dev/null 2>&1; then
+    echo "ERROR: cargo not found on PATH. Install the Rust toolchain (e.g. rustup) first." >&2
+    exit 1
+fi
+
 # --- Resolve version ---------------------------------------------------------
 VERSION="${1:-}"
 if [[ -z "$VERSION" ]]; then

--- a/packaging/rpm/hyprstream.spec
+++ b/packaging/rpm/hyprstream.spec
@@ -24,6 +24,24 @@
 # Private libdir for the bundled libtorch shared objects.
 %global torchlibdir %{_libdir}/%{name}
 
+# --- Bundled libtorch dependency filtering ----------------------------------
+# The libtorch CPU runtime ships privately under %{torchlibdir} and is resolved
+# at runtime via the binary's RUNPATH. RPM's automatic dependency generator must
+# NOT (a) turn the bundled sonames into unsatisfiable system-level Requires, nor
+# (b) leak them as system-level Provides. Two layers:
+#   1. Path scope: skip auto requires/provides for every .so under the private
+#      bundle dir. This covers the bundled libs' inter-dependencies -- e.g.
+#      libtorch_cpu.so -> the hash-mangled libgomp-<hash>.so.1 (and its GOMP_/OMP_
+#      symbol versions) on Fedora, and libc10.so / libtorch_cpu.so on Rocky.
+#   2. Soname scope: the hyprstream binary itself lives in %{_bindir} (outside the
+#      bundle dir) and hard-links the libtorch family via DT_NEEDED, so also drop
+#      those auto-generated Requires by soname. The regex is scoped to the libtorch
+#      soname family ONLY -- it never matches the cuda-toolkit/rocm weak deps
+#      (Recommends) or the manual git/git-lfs/ca-certificates Requires.
+%global __requires_exclude_from ^%{torchlibdir}/.*\.so.*$
+%global __provides_exclude_from ^%{torchlibdir}/.*\.so.*$
+%global __requires_exclude ^lib(c10.*|torch.*|gomp-[0-9a-f]+.*|caffe2.*|shm.*|gloo.*|tensorpipe.*|nnpack.*|pytorch_qnnpack.*|XNNPACK.*|dnnl.*|asmjit.*|fbgemm.*|cpuinfo.*)\.so.*$
+
 Name:           hyprstream
 Version:        0.5.0
 Release:        1%{?dist}

--- a/packaging/rpm/hyprstream.spec
+++ b/packaging/rpm/hyprstream.spec
@@ -1,16 +1,28 @@
 # RPM spec file for hyprstream
 #
-# Build:   rpmbuild -ba packaging/rpm/hyprstream.spec
+# Build:   packaging/rpm/build-rpm.sh   (wrapper that stages version + tarball)
+#          or: rpmbuild -ba packaging/rpm/hyprstream.spec
 # CI:      see .github/workflows/rpm.yml (release publish + PR build/install check)
 #
 # Notes:
 #   * Uses the existing Cargo build system (build.rs handles codegen).
+#   * libtorch is fetched at build time via the `download-libtorch` feature
+#     (PyTorch 2.10.0 CPU). The hyprstream binary links it as a hard DT_NEEDED
+#     dependency (libtorch_cpu.so, libc10.so), so the .so files are bundled into
+#     a private libdir and the binary's RUNPATH is set to find them. Without this
+#     the binary cannot even exec.
 #   * Forces openssl-sys to link the SYSTEM openssl-devel. rpmbuild exports
 #     CROSS_COMPILE, which makes openssl-sys believe it is cross-compiling and
 #     build OpenSSL from source (fails on missing perl-FindBin). We unset it.
 #   * GPU stacks (CUDA / ROCm) are declared as weak deps (Recommends:) so a user
 #     can override with a locally-installed version, or exclude them entirely with
 #     --setopt=install_weak_deps=False. They require external vendor repos.
+
+# Bundled libtorch is prebuilt and has no debug sources; skip debuginfo packaging.
+%global debug_package %{nil}
+
+# Private libdir for the bundled libtorch shared objects.
+%global torchlibdir %{_libdir}/%{name}
 
 Name:           hyprstream
 Version:        0.5.0
@@ -24,8 +36,11 @@ Source0:        %{url}/archive/v%{version}/hyprstream-%{version}.tar.gz
 ExclusiveArch:  x86_64 aarch64
 
 # Build dependencies
-BuildRequires:  cargo
-BuildRequires:  rust
+#
+# NOTE: the Rust toolchain (cargo/rustc) is intentionally NOT a BuildRequires.
+# It is provided on PATH via rustup (distro rust is often too old, and CI uses
+# rustup). rpmbuild checks BuildRequires against the rpm database, which would
+# not see a rustup toolchain. build-rpm.sh guards that cargo is on PATH.
 BuildRequires:  gcc
 BuildRequires:  gcc-c++
 BuildRequires:  cmake
@@ -34,9 +49,9 @@ BuildRequires:  pkgconfig
 BuildRequires:  openssl-devel
 BuildRequires:  systemd-devel
 BuildRequires:  capnproto
-# openssl-sys may still probe for perl; provide it so a source fallback cannot hang the build
-BuildRequires:  perl-interpreter
-BuildRequires:  perl-FindBin
+BuildRequires:  patchelf
+# NOTE: perl is deliberately NOT required. openssl-sys would only invoke perl
+# for a from-source OpenSSL build, which OPENSSL_NO_VENDOR=1 (below) disables.
 
 # Runtime dependencies
 Requires:       git
@@ -52,7 +67,7 @@ Requires:       ca-certificates
 #   * cuda-toolkit-13-0 : requires NVIDIA driver >= 555
 Recommends:     (cuda-toolkit-12-8 or cuda-toolkit-13-0)
 # AMD ROCm (libtorch is built against ROCm 7.x; gfx1151 needs >= 7.2)
-Recommends:     rocm >= 7.1
+Recommends:     rocm >= 7.2
 
 %description
 HyprStream is an agentic cloud infrastructure for applications that learn,
@@ -68,7 +83,7 @@ Features:
 - Optional GPU acceleration (NVIDIA CUDA, AMD ROCm)
 
 Backend support:
-- CPU: all supported architectures
+- CPU: bundled (PyTorch/libtorch CPU runtime)
 - CUDA: requires the NVIDIA vendor repository
 - ROCm: requires the AMD vendor repository
 
@@ -83,6 +98,12 @@ git add -A
 git commit -q -m "RPM build"
 
 %build
+# rpmbuild injects RUSTFLAGS with -Cdebuginfo=2 for the whole dependency graph
+# (arrow/datafusion/tonic/libtorch ...). We do not ship a -debuginfo subpackage
+# (%%debug_package %%{nil}), so that debug info is pure bloat -- it inflated the
+# build tree past 11 GB and exhausted disk. Build without debuginfo.
+export RUSTFLAGS="-Cdebuginfo=0"
+
 # Force openssl-sys to use the system library instead of a vendored source build.
 # Unsetting CROSS_COMPILE is the critical step: rpmbuild sets it, which otherwise
 # triggers openssl-sys's from-source path.
@@ -93,13 +114,29 @@ export OPENSSL_DIR=%{_prefix}
 export OPENSSL_LIB_DIR=%{_libdir}
 export OPENSSL_INCLUDE_DIR=%{_includedir}
 
-# CPU build. libtorch is fetched at build time via the download-libtorch feature.
+# CPU build. libtorch (PyTorch 2.10.0 CPU) is fetched at build time via the
+# download-libtorch feature and extracted under target/.../torch-sys-*/out.
 env -u CROSS_COMPILE cargo build --release \
     --features download-libtorch,otel,gittorrent,xet
 
 %install
 install -d %{buildroot}%{_bindir}
 install -m 0755 target/release/hyprstream %{buildroot}%{_bindir}/hyprstream
+
+# --- Bundle the libtorch runtime the binary links against -------------------
+# download-libtorch extracts libtorch under the torch-sys build output dir.
+torch_lib_dir="$(find target -type d -path '*/torch-sys-*/out/libtorch/libtorch/lib' | head -1)"
+if [ -z "$torch_lib_dir" ]; then
+    echo "ERROR: bundled libtorch lib dir not found under target/" >&2
+    exit 1
+fi
+install -d %{buildroot}%{torchlibdir}
+# Copy the shared objects (follow into any subdirs the runtime needs).
+cp -a "$torch_lib_dir"/*.so* %{buildroot}%{torchlibdir}/
+
+# Point the binary at the bundled libtorch. RUNPATH into a private %{_libdir}/%{name}
+# subdir is accepted by check-rpaths (it is not a standard library search path).
+patchelf --set-rpath %{torchlibdir} %{buildroot}%{_bindir}/hyprstream
 
 # Documentation
 install -d %{buildroot}%{_docdir}/%{name}
@@ -108,9 +145,10 @@ install -m 0644 README.md %{buildroot}%{_docdir}/%{name}/README.md
 cat > %{buildroot}%{_docdir}/%{name}/GPU-SETUP.md << 'EOF'
 # GPU Backend Setup for HyprStream
 
-GPU acceleration is optional and requires an external vendor repository plus a
-matching driver. The RPM declares these as weak dependencies so they can be
-overridden with a locally-installed version, or skipped entirely:
+The CPU backend (libtorch) is bundled and works out of the box. GPU acceleration
+is optional and requires an external vendor repository plus a matching driver.
+The RPM declares these as weak dependencies so they can be overridden with a
+locally-installed version, or skipped entirely:
 
     sudo dnf install --setopt=install_weak_deps=False hyprstream
 
@@ -128,17 +166,22 @@ overridden with a locally-installed version, or skipped entirely:
 EOF
 
 %check
-# Smoke-check the built binary
-target/release/hyprstream --version
+# Smoke-check the built binary. The install-time RUNPATH points at the final
+# (not-yet-installed) path, so resolve libtorch from the buildroot for this check.
+LD_LIBRARY_PATH=%{buildroot}%{torchlibdir} \
+    %{buildroot}%{_bindir}/hyprstream --version
 
 %files
 %license LICENSE-AGPLV3 LICENSE-MIT
 %doc %{_docdir}/%{name}/README.md
 %doc %{_docdir}/%{name}/GPU-SETUP.md
 %{_bindir}/hyprstream
+%dir %{torchlibdir}
+%{torchlibdir}/*.so*
 
 %changelog
-* Thu Jun 26 2026 hyprstream maintainers <dev@hyprstream.com> - 0.5.0-1
+* Fri Jun 26 2026 hyprstream maintainers <dev@hyprstream.com> - 0.5.0-1
 - Initial RPM packaging wired into CI (release publish + Fedora/Rocky build-install check)
+- Bundle libtorch CPU runtime and set RUNPATH (binary hard-links libtorch_cpu.so)
 - Resolve openssl-sys source-build hang under rpmbuild (unset CROSS_COMPILE)
 - GPU stacks declared as version-pinned weak deps (Recommends) for local override

--- a/packaging/rpm/hyprstream.spec
+++ b/packaging/rpm/hyprstream.spec
@@ -1,0 +1,144 @@
+# RPM spec file for hyprstream
+#
+# Build:   rpmbuild -ba packaging/rpm/hyprstream.spec
+# CI:      see .github/workflows/rpm.yml (release publish + PR build/install check)
+#
+# Notes:
+#   * Uses the existing Cargo build system (build.rs handles codegen).
+#   * Forces openssl-sys to link the SYSTEM openssl-devel. rpmbuild exports
+#     CROSS_COMPILE, which makes openssl-sys believe it is cross-compiling and
+#     build OpenSSL from source (fails on missing perl-FindBin). We unset it.
+#   * GPU stacks (CUDA / ROCm) are declared as weak deps (Recommends:) so a user
+#     can override with a locally-installed version, or exclude them entirely with
+#     --setopt=install_weak_deps=False. They require external vendor repos.
+
+Name:           hyprstream
+Version:        0.5.0
+Release:        1%{?dist}
+Summary:        Agentic cloud infrastructure for continuously learning applications
+
+License:        AGPL-3.0-only AND MIT
+URL:            https://github.com/hyprstream/hyprstream
+Source0:        %{url}/archive/v%{version}/hyprstream-%{version}.tar.gz
+
+ExclusiveArch:  x86_64 aarch64
+
+# Build dependencies
+BuildRequires:  cargo
+BuildRequires:  rust
+BuildRequires:  gcc
+BuildRequires:  gcc-c++
+BuildRequires:  cmake
+BuildRequires:  make
+BuildRequires:  pkgconfig
+BuildRequires:  openssl-devel
+BuildRequires:  systemd-devel
+BuildRequires:  capnproto
+# openssl-sys may still probe for perl; provide it so a source fallback cannot hang the build
+BuildRequires:  perl-interpreter
+BuildRequires:  perl-FindBin
+
+# Runtime dependencies
+Requires:       git
+Requires:       git-lfs
+Requires:       ca-certificates
+
+# --- Optional GPU acceleration (weak deps; require external vendor repos) ---
+# Pinned to the versions the compiled code targets. Weak deps can be overridden
+# with a local install or skipped with --setopt=install_weak_deps=False.
+#
+# NVIDIA CUDA  (package name encodes the toolkit version)
+#   * cuda-toolkit-12-8 : requires NVIDIA driver >= 535
+#   * cuda-toolkit-13-0 : requires NVIDIA driver >= 555
+Recommends:     (cuda-toolkit-12-8 or cuda-toolkit-13-0)
+# AMD ROCm (libtorch is built against ROCm 7.x; gfx1151 needs >= 7.2)
+Recommends:     rocm >= 7.1
+
+%description
+HyprStream is an agentic cloud infrastructure for applications that learn,
+build, and run. It provides continuous development, training, integration,
+and deployment of software and AI/ML models.
+
+Features:
+- LLM inference and training engine (Qwen3 architecture)
+- OpenAI-compatible API
+- Git worktrees for model versioning
+- Security: CURVE encryption, Ed25519 signatures, Casbin policy engine
+- Model Context Protocol (MCP) integration
+- Optional GPU acceleration (NVIDIA CUDA, AMD ROCm)
+
+Backend support:
+- CPU: all supported architectures
+- CUDA: requires the NVIDIA vendor repository
+- ROCm: requires the AMD vendor repository
+
+%prep
+%autosetup -p1 -n %{name}-%{version}
+
+# git2 dependency requires a git repository to be present
+git init -q
+git config user.email "rpm-build@localhost.localdomain"
+git config user.name "RPM Build"
+git add -A
+git commit -q -m "RPM build"
+
+%build
+# Force openssl-sys to use the system library instead of a vendored source build.
+# Unsetting CROSS_COMPILE is the critical step: rpmbuild sets it, which otherwise
+# triggers openssl-sys's from-source path.
+unset CROSS_COMPILE
+export OPENSSL_NO_VENDOR=1
+export OPENSSL_STATIC=0
+export OPENSSL_DIR=%{_prefix}
+export OPENSSL_LIB_DIR=%{_libdir}
+export OPENSSL_INCLUDE_DIR=%{_includedir}
+
+# CPU build. libtorch is fetched at build time via the download-libtorch feature.
+env -u CROSS_COMPILE cargo build --release \
+    --features download-libtorch,otel,gittorrent,xet
+
+%install
+install -d %{buildroot}%{_bindir}
+install -m 0755 target/release/hyprstream %{buildroot}%{_bindir}/hyprstream
+
+# Documentation
+install -d %{buildroot}%{_docdir}/%{name}
+install -m 0644 README.md %{buildroot}%{_docdir}/%{name}/README.md
+
+cat > %{buildroot}%{_docdir}/%{name}/GPU-SETUP.md << 'EOF'
+# GPU Backend Setup for HyprStream
+
+GPU acceleration is optional and requires an external vendor repository plus a
+matching driver. The RPM declares these as weak dependencies so they can be
+overridden with a locally-installed version, or skipped entirely:
+
+    sudo dnf install --setopt=install_weak_deps=False hyprstream
+
+## AMD ROCm (gfx1151 requires ROCm >= 7.2)
+
+    sudo dnf config-manager --add-repo https://repo.radeon.com/rocm/rhel9/rocm.repo
+    sudo dnf install rocm
+
+## NVIDIA CUDA
+
+    sudo dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/fedora41/x86_64/cuda-fedora41.repo
+    sudo dnf install cuda-toolkit-12-8   # driver >= 535
+    # or
+    sudo dnf install cuda-toolkit-13-0   # driver >= 555
+EOF
+
+%check
+# Smoke-check the built binary
+target/release/hyprstream --version
+
+%files
+%license LICENSE-AGPLV3 LICENSE-MIT
+%doc %{_docdir}/%{name}/README.md
+%doc %{_docdir}/%{name}/GPU-SETUP.md
+%{_bindir}/hyprstream
+
+%changelog
+* Thu Jun 26 2026 hyprstream maintainers <dev@hyprstream.com> - 0.5.0-1
+- Initial RPM packaging wired into CI (release publish + Fedora/Rocky build-install check)
+- Resolve openssl-sys source-build hang under rpmbuild (unset CROSS_COMPILE)
+- GPU stacks declared as version-pinned weak deps (Recommends) for local override

--- a/packaging/rpm/hyprstream.spec
+++ b/packaging/rpm/hyprstream.spec
@@ -49,6 +49,9 @@ BuildRequires:  pkgconfig
 BuildRequires:  openssl-devel
 BuildRequires:  systemd-devel
 BuildRequires:  capnproto
+# libclang.so for bindgen (aws-lc-sys build script)
+BuildRequires:  clang
+BuildRequires:  clang-devel
 BuildRequires:  patchelf
 # NOTE: perl is deliberately NOT required. openssl-sys would only invoke perl
 # for a from-source OpenSSL build, which OPENSSL_NO_VENDOR=1 (below) disables.
@@ -116,6 +119,9 @@ export OPENSSL_INCLUDE_DIR=%{_includedir}
 
 # CPU build. libtorch (PyTorch 2.10.0 CPU) is fetched at build time via the
 # download-libtorch feature and extracted under target/.../torch-sys-*/out.
+# bindgen (aws-lc-sys) needs libclang; set explicitly so the in-rpmbuild
+# compile finds it even if the environment is scrubbed.
+export LIBCLANG_PATH=%{_libdir}
 env -u CROSS_COMPILE cargo build --release \
     --features download-libtorch,otel,gittorrent,xet
 


### PR DESCRIPTION
Closes #497.

Finishes the work-in-progress RPM packaging that previously lived (blocked) in the `strix` worktree, and wires it into CI.

## What's here

- **`packaging/rpm/hyprstream.spec`** — builds via the existing Cargo build system. Resolves the long-standing blocker: `rpmbuild` exports `CROSS_COMPILE`, which made `openssl-sys` build OpenSSL from source (hangs on missing `perl-FindBin`). The spec now `unset`s `CROSS_COMPILE` so the system `openssl-devel` is linked.
- **GPU deps optional + pinned** — CUDA and ROCm are weak deps (`Recommends:`) so a user can override with a locally-installed version, or skip with `--setopt=install_weak_deps=False`:
  - `(cuda-toolkit-12-8 or cuda-toolkit-13-0)` — driver ≥ 535 / ≥ 555 respectively
  - `rocm >= 7.1` (gfx1151 needs ≥ 7.2)
- **`packaging/rpm/build-rpm.sh`** — version-resolving `rpmbuild` wrapper (also usable locally).
- **`.github/workflows/rpm.yml`**:
  - **PR check** — builds the RPM and `dnf install`s it inside **Fedora 43** and **Rocky 9** containers, runs `hyprstream --version`, and asserts the GPU stacks are *not* hard requirements.
  - **Release** — on `v*` tags, attaches the built RPMs + `RPM-SHA256SUMS.txt` to the GitHub Release (mirrors the AppImage release job).

## Validation

- `rpmspec -P` parses the spec cleanly (rich-dep `Recommends` + version pins verified).
- `bash -n` on the build script and YAML lint on the workflow pass.

## Notes / scope

- systemd units, shell completions, and a config example are intentionally **not** packaged yet — they don't exist on `main`. The spec is structured to add them to `%install`/`%files` when they land. (The old `strix` spec referenced them with invalid `%files ... || true` lines.)
- Spec `Version` defaults to the crate version (`0.5.0`) and is overridden from the release tag in CI.
