### PR TITLE
feat(#500): serve /.well-known/atproto-did (atproto handle→DID HTTP resolution)

### DIFF
--- a/crates/hyprstream/src/services/oauth/did_document.rs
+++ b/crates/hyprstream/src/services/oauth/did_document.rs
@@ -406,6 +406,35 @@ pub async fn root_did_document(
     ).into_response()
 }
 
+/// `GET /.well-known/atproto-did` — atproto handle→DID resolution (HTTP method).
+///
+/// Per the atproto Handle spec (https://atproto.com/specs/handle), the HTTPS
+/// well-known method returns the **bare DID string** as `text/plain` (no JSON
+/// or wrapper) so this deployment's handle (its authority hostname) resolves to
+/// its `did:web:{authority}`. Companion to `/.well-known/did.json`, which serves
+/// the full W3C DID document for the same subject.
+///
+/// Consumed by the frontend handle resolver
+/// (`www-cyberdione-ai/src/api/atproto.ts:resolveHandleToDid`). This is a
+/// CORS-simple GET (no custom request headers → no preflight), so it needs only
+/// cross-origin readability from the public CORS layer, not permissive headers.
+pub async fn atproto_did(
+    State(state): State<Arc<OAuthState>>,
+) -> Response {
+    let Some(authority) = issuer_authority(&state.issuer_url) else {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "issuer URL has no authority",
+        ).into_response();
+    };
+    let did = format!("did:web:{authority}");
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+        did,
+    ).into_response()
+}
+
 /// `GET /users/:username/did.json` — per-user DID document.
 ///
 /// `id = did:web:{authority}:users:{username}`. Verification methods:

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -127,6 +127,8 @@ pub fn create_app(state: Arc<OAuthState>, cors_config: &crate::config::CorsConfi
         .route("/oauth/revoke", post(revocation::revoke_token))
         // Phase 0c — did:web document endpoints
         .route("/.well-known/did.json", get(did_document::root_did_document))
+        // atproto handle→DID HTTP resolution (#500) — plaintext bare DID
+        .route("/.well-known/atproto-did", get(did_document::atproto_did))
         .route("/users/:username/did.json", get(did_document::user_did_document))
         .route("/clients/:client_id/did.json", get(did_document::client_did_document))
         .route("/oauth/logout", post(handle_logout))


### PR DESCRIPTION
Closes #500.

## What
Adds `GET /.well-known/atproto-did` next to the existing `/.well-known/did.json` route. Returns the root deployment DID (`did:web:{authority}` — the same value `root_did_document` already computes via `issuer_authority`) as **`text/plain`, bare DID, no JSON wrapper**, per the atproto Handle spec (https://atproto.com/specs/handle).

## Why
The frontend handle resolver `www-cyberdione-ai/src/api/atproto.ts:resolveHandleToDid` already fetches this endpoint and its own comment says "the backend publishes" it — but the backend only served the W3C `did.json` family, never `atproto-did`. This closes that live client↔server gap. Backend counterpart to frontend #461; under epic #460.

## Files
- `crates/hyprstream/src/services/oauth/did_document.rs` — new `atproto_did` handler (mirrors `root_did_document`'s authority→DID derivation).
- `crates/hyprstream/src/services/oauth/mod.rs` — route registration.

## CORS note (relates to #472/#474)
This is a CORS-**simple** GET (no custom request headers → no preflight), so it needs only the public CORS layer's cross-origin readability — **not** the permissive-header change in #472/#474. Confirms that #474's mention of `atproto-did` as a route needing `allow_any_header()` was aspirational; the endpoint as consumed does not require it.

## Scope guard
No capnp/RPC schema change. No authorization-logic change — this publishes the host's own already-computed DID as plaintext, a sibling of the existing public `did.json` endpoint (#69). Identity-publishing surface; flagging for awareness given the auth-adjacent area, but it changes no policy/authz path.

https://claude.ai/code/session_01U3qgsHTDWME66JFGZGS3ZA