### PR TITLE
security(#509): provenance-gated XET getBlob (closes OID-field planting)

### DIFF
--- a/crates/hyprstream/src/services/mod.rs
+++ b/crates/hyprstream/src/services/mod.rs
@@ -80,6 +80,7 @@ pub mod oai;
 pub mod policy;
 pub mod registry;
 pub mod router;
+pub mod xet_provenance;
 pub mod fs;
 pub mod remote_mount;
 pub mod remote_registry_mount;

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -5,6 +5,7 @@
 
 use crate::services::PolicyClient;
 use crate::services::types::{MAX_FDS_GLOBAL, MAX_FDS_PER_CLIENT};
+use crate::services::xet_provenance::XetProvenanceStore;
 use hyprstream_containedfs::{ContainedFs, FsError, FsHandle};
 use crate::services::{EnvelopeContext, RequestService};
 use hyprstream_rpc::transport::TransportConfig;
@@ -326,6 +327,10 @@ pub struct RegistryService {
     expected_audience: Option<String>,
     /// JWT key source for token verification.
     jwt_key_source: Option<std::sync::Arc<dyn hyprstream_rpc::auth::JwtKeySource>>,
+    /// Server-side `(merkle_hex → repo_id)` provenance store backing the
+    /// fail-closed XET `getBlob` gate (#436 / #509). Pointer presence is
+    /// necessary-but-not-sufficient: entitlement requires a provenance record.
+    xet_provenance: Arc<XetProvenanceStore>,
 }
 
 /// Progress reporter that sends updates via a tokio mpsc channel.
@@ -377,6 +382,10 @@ impl RegistryService {
         let base_dir = base_dir.as_ref().to_path_buf();
         let registry = Git2DB::open(&base_dir).await?;
 
+        // Load the XET provenance store (lives alongside registry metadata).
+        // Missing file → empty store → fail-closed XET getBlob (secure default).
+        let xet_provenance = Arc::new(XetProvenanceStore::load(&base_dir).await?);
+
         let worker_registry = Arc::new(RwLock::new(registry));
 
         // Create fid table and editing table, spawn reaper
@@ -399,6 +408,7 @@ impl RegistryService {
             editing_table,
             expected_audience: None,
             jwt_key_source: None,
+            xet_provenance,
         };
 
         Ok(service)
@@ -895,25 +905,40 @@ impl RegistryService {
 
     // (helper `xet_pointer_references_merkle` defined at module scope below)
 
-    /// Condition-(b) check for a XET merkle root: grantRepo must reference the
-    /// merkle via a checked-in git-xet pointer whose merkle field EXACTLY equals
-    /// the requested hash. Content addresses are predictable (the CAS is global
-    /// and content-addressed), so presence in the store alone is NOT sufficient —
-    /// the grant repo must actually reference it.
+    /// Condition-(b) check for a XET merkle root — **provenance-gated and
+    /// fail-closed** (the #436 / #509 fix).
     ///
-    /// LIMITATION (tracked in #436): this verifies *reference*, not *provenance*.
-    /// Because the CAS is global and non-namespaced, a writer can reference a
-    /// merkle they did not upload. This is sound for public / same-trust-domain
-    /// content (the only XET fetch enabled today), but NOT sufficient isolation
-    /// for PRIVATE multitenant XET content — that path must stay gated until #436
-    /// (per-tenant CAS namespacing or commit-provenance verification) lands.
-    /// A real git-xet pointer is parsed and the merkle field is matched exactly
-    /// (not a loose substring of arbitrary blob text).
+    /// Entitlement requires BOTH:
+    ///   1. a **server-side provenance record** binding this merkle to
+    ///      `repo_id` (i.e. this repo actually *uploaded* the bytes); AND
+    ///   2. (defense-in-depth) the repo's current HEAD tree still **references**
+    ///      the merkle via a checked-in git-xet / git-lfs pointer whose merkle
+    ///      field EXACTLY equals the requested hash.
+    ///
+    /// The provenance record is the authoritative gate. Pointer presence is
+    /// **necessary-but-not-sufficient**: because the CAS is global and
+    /// non-namespaced, a pointer blob is caller-committed and therefore
+    /// *forgeable* — Tenant B can plant `oid sha256:<Tenant A's private merkle>`
+    /// in their own repo. We therefore **deny when no provenance record exists**
+    /// and NEVER fall back to the pointer-only check. See
+    /// [`crate::services::xet_provenance`] for the trust boundary and #509 for
+    /// the authenticated upload-binding that populates provenance.
     async fn repo_contains_xet_merkle(
         &self,
         repo_id: &git2db::RepoId,
         merkle_hex: &str,
     ) -> Result<bool> {
+        // ── Authoritative gate: fail-closed provenance check. ──
+        // No record binding (merkle → repo) ⇒ deny, regardless of any pointer.
+        if !self
+            .xet_provenance
+            .is_bound(merkle_hex, &repo_id.0.to_string())
+            .await
+        {
+            return Ok(false);
+        }
+
+        // ── Defense-in-depth: the repo must still reference the merkle. ──
         let merkle_hex = merkle_hex.to_owned();
         self.with_repo_blocking(repo_id, move |repo| {
             let head = match repo.head().ok().and_then(|h| h.peel_to_tree().ok()) {

--- a/crates/hyprstream/src/services/xet_provenance.rs
+++ b/crates/hyprstream/src/services/xet_provenance.rs
@@ -1,0 +1,258 @@
+//! XET content provenance store (the #436 / #509 fix).
+//!
+//! # Why this exists
+//!
+//! The XET CAS is **global and content-addressed**: bytes are deduplicated by
+//! their computed merkle root with no per-tenant namespacing. The pre-existing
+//! `getBlob` authorization (condition (b)) decided entitlement from a git-xet /
+//! git-lfs **pointer blob committed into the grant repo's HEAD tree**. That
+//! pointer is **caller-committed and therefore forgeable**: Tenant B can commit
+//! `oid sha256:<Tenant A's private merkle>` into their own repo and read A's
+//! private bytes back over the shared CAS. The pointer-only check structurally
+//! cannot tell a *planted* reference from a *genuine* one.
+//!
+//! # What this provides
+//!
+//! A persisted, **server-side-only** mapping `merkle_hex → {repo_id, …}` recording
+//! which repositories actually *contributed* (uploaded) the bytes behind a merkle.
+//! The bytes themselves remain globally deduplicated in the CAS — only this
+//! provenance mapping is per-repo. The read gate consults this store and **fails
+//! closed**: if no provenance record binds the merkle to the grant repo, the
+//! request is denied. A forgeable pointer can never, on its own, grant access.
+//!
+//! # Trust boundary (load-bearing)
+//!
+//! `record()` is the *only* mutating entry point and MUST be called exclusively
+//! from a **server-authenticated** code path that has already established the
+//! pushing repo's identity (NOT from caller-supplied identity such as `$USER` or
+//! a request field). See the module-level note in `registry.rs` for the wiring
+//! status of the authenticated upload binding (issue #509, part 2).
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+use tracing::{debug, warn};
+
+/// On-disk representation. Versioned so the format can evolve.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+struct ProvenanceFile {
+    #[serde(default = "default_version")]
+    version: String,
+    /// merkle_hex → set of repo_id (UUID strings) that uploaded these bytes.
+    #[serde(default)]
+    bindings: HashMap<String, HashSet<String>>,
+}
+
+fn default_version() -> String {
+    "1.0.0".to_owned()
+}
+
+/// Persisted `(merkle_hex → {repo_id})` provenance mapping for XET CAS content.
+///
+/// Lives alongside the registry metadata (`<base_dir>/.registry/`) so it shares
+/// the registry's durability and 0600 permission posture.
+pub struct XetProvenanceStore {
+    path: PathBuf,
+    inner: RwLock<HashMap<String, HashSet<String>>>,
+}
+
+impl XetProvenanceStore {
+    /// File name within the `.registry` directory.
+    const FILE_NAME: &'static str = "xet_provenance.json";
+
+    /// Load the provenance store from `<base_dir>/.registry/xet_provenance.json`,
+    /// creating an empty in-memory store if the file does not yet exist.
+    ///
+    /// A missing file is the expected first-run state and yields an **empty**
+    /// store — which, combined with the fail-closed read gate, denies all
+    /// XetMerkle `getBlob` requests until provenance is recorded. That is the
+    /// intended secure default.
+    pub async fn load(base_dir: &Path) -> Result<Self> {
+        let path = base_dir.join(".registry").join(Self::FILE_NAME);
+        let bindings = match tokio::fs::read(&path).await {
+            Ok(bytes) => {
+                let parsed: ProvenanceFile = serde_json::from_slice(&bytes).with_context(|| {
+                    format!("failed to parse XET provenance store at {}", path.display())
+                })?;
+                debug!(
+                    entries = parsed.bindings.len(),
+                    path = %path.display(),
+                    "loaded XET provenance store"
+                );
+                parsed.bindings
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                debug!(path = %path.display(), "no XET provenance store yet; starting empty (fail-closed)");
+                HashMap::new()
+            }
+            Err(e) => {
+                return Err(e).with_context(|| {
+                    format!("failed to read XET provenance store at {}", path.display())
+                });
+            }
+        };
+        Ok(Self {
+            path,
+            inner: RwLock::new(bindings),
+        })
+    }
+
+    /// Record that `repo_id` legitimately contributed the bytes behind
+    /// `merkle_hex`, persisting the mapping.
+    ///
+    /// SECURITY: callers MUST have authenticated the pushing repo's identity
+    /// server-side before invoking this. Never pass caller-supplied identity.
+    /// The mapping is additive (global dedup means the same bytes may be
+    /// uploaded by multiple repos; each legitimately gets a binding).
+    pub async fn record(&self, merkle_hex: &str, repo_id: &str) -> Result<()> {
+        let merkle_hex = merkle_hex.trim().to_ascii_lowercase();
+        let repo_id = repo_id.trim().to_owned();
+        if merkle_hex.is_empty() || repo_id.is_empty() {
+            anyhow::bail!("record provenance denied: empty merkle or repo_id");
+        }
+        {
+            let mut guard = self.inner.write().await;
+            let entry = guard.entry(merkle_hex.clone()).or_default();
+            if !entry.insert(repo_id.clone()) {
+                // Already recorded; nothing to persist.
+                return Ok(());
+            }
+        }
+        self.persist().await.with_context(|| {
+            format!("failed to persist XET provenance for merkle {merkle_hex}")
+        })?;
+        debug!(merkle = %merkle_hex, repo = %repo_id, "recorded XET provenance");
+        Ok(())
+    }
+
+    /// Fail-closed gate check: is `merkle_hex` bound to `repo_id` by a recorded
+    /// provenance entry? Returns `false` (deny) when no record exists.
+    pub async fn is_bound(&self, merkle_hex: &str, repo_id: &str) -> bool {
+        let merkle_hex = merkle_hex.trim().to_ascii_lowercase();
+        let repo_id = repo_id.trim();
+        if merkle_hex.is_empty() || repo_id.is_empty() {
+            return false;
+        }
+        let guard = self.inner.read().await;
+        guard
+            .get(&merkle_hex)
+            .map(|repos| repos.contains(repo_id))
+            .unwrap_or(false)
+    }
+
+    /// Atomically persist the in-memory mapping to disk (tmp file + rename),
+    /// with 0600 permissions (matches the registry metadata posture).
+    async fn persist(&self) -> Result<()> {
+        let snapshot = {
+            let guard = self.inner.read().await;
+            ProvenanceFile {
+                version: default_version(),
+                bindings: guard.clone(),
+            }
+        };
+        let json = serde_json::to_vec_pretty(&snapshot)
+            .context("failed to serialize XET provenance store")?;
+
+        if let Some(parent) = self.path.parent() {
+            if let Err(e) = tokio::fs::create_dir_all(parent).await {
+                warn!(error = %e, dir = %parent.display(), "failed to ensure provenance dir");
+            }
+        }
+
+        let tmp = self.path.with_extension("json.tmp");
+        tokio::fs::write(&tmp, &json)
+            .await
+            .with_context(|| format!("failed to write provenance tmp {}", tmp.display()))?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = tokio::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600)).await;
+        }
+
+        tokio::fs::rename(&tmp, &self.path)
+            .await
+            .with_context(|| format!("failed to rename provenance into place {}", self.path.display()))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    // A 64-hex-char merkle stand-in for "Tenant A's private content".
+    const MERKLE_A: &str = "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1";
+    const REPO_A: &str = "11111111-1111-1111-1111-111111111111";
+    const REPO_B: &str = "22222222-2222-2222-2222-222222222222";
+
+    async fn store_in(dir: &Path) -> XetProvenanceStore {
+        tokio::fs::create_dir_all(dir.join(".registry")).await.unwrap();
+        XetProvenanceStore::load(dir).await.unwrap()
+    }
+
+    /// The core #436 / #509 invariant at the gate layer: a planted pointer with
+    /// NO provenance record must be denied (fail-closed). This is the
+    /// substantive content behind `oid_field_planted_pointer_must_be_denied`.
+    #[tokio::test]
+    async fn oid_field_planted_pointer_must_be_denied() {
+        let dir = tempdir().unwrap();
+        let store = store_in(dir.path()).await;
+
+        // Tenant A genuinely uploaded the bytes → provenance bound to repo A.
+        store.record(MERKLE_A, REPO_A).await.unwrap();
+
+        // Tenant B planted a pointer referencing A's merkle but never uploaded
+        // the bytes → NO provenance binding for repo B → MUST be denied.
+        assert!(
+            !store.is_bound(MERKLE_A, REPO_B).await,
+            "planted-pointer repo B must NOT be entitled to A's merkle"
+        );
+
+        // The legitimate owner (repo A) still resolves.
+        assert!(
+            store.is_bound(MERKLE_A, REPO_A).await,
+            "the repo that genuinely uploaded the merkle must still resolve it"
+        );
+    }
+
+    /// Fail-closed default: an unknown merkle (no record at all) is denied for
+    /// everyone — never falls back to the forgeable pointer check.
+    #[tokio::test]
+    async fn unknown_merkle_denied_fail_closed() {
+        let dir = tempdir().unwrap();
+        let store = store_in(dir.path()).await;
+        assert!(!store.is_bound(MERKLE_A, REPO_A).await);
+        assert!(!store.is_bound(MERKLE_A, REPO_B).await);
+    }
+
+    /// Records survive a reload (persistence), and case/whitespace are normalized.
+    #[tokio::test]
+    async fn provenance_persists_across_reload() {
+        let dir = tempdir().unwrap();
+        {
+            let store = store_in(dir.path()).await;
+            store.record(&MERKLE_A.to_ascii_uppercase(), REPO_A).await.unwrap();
+        }
+        let reloaded = XetProvenanceStore::load(dir.path()).await.unwrap();
+        assert!(reloaded.is_bound(MERKLE_A, REPO_A).await);
+        assert!(!reloaded.is_bound(MERKLE_A, REPO_B).await);
+    }
+
+    /// Global dedup: the same bytes uploaded by two repos bind to both, and each
+    /// is entitled independently.
+    #[tokio::test]
+    async fn shared_bytes_bind_per_repo() {
+        let dir = tempdir().unwrap();
+        let store = store_in(dir.path()).await;
+        store.record(MERKLE_A, REPO_A).await.unwrap();
+        store.record(MERKLE_A, REPO_B).await.unwrap();
+        assert!(store.is_bound(MERKLE_A, REPO_A).await);
+        assert!(store.is_bound(MERKLE_A, REPO_B).await);
+    }
+}


### PR DESCRIPTION
## AUTH-SURFACE — requires human sign-off + CI/review before merge. DRAFT, do NOT merge.

Closes the **OID-field planting** vector of #436 (tracked in #509) — the real fix that PR #479 deliberately scopes out. #479 hardens the exact-OID parse (a genuine sub-vector improvement); this PR closes the structurally-forgeable pointer grant.

### The vulnerability
`authorize_get_blob` condition (b) (`crates/hyprstream/src/services/registry.rs`) decided XET entitlement from a **caller-committed git-lfs pointer blob** in the grant repo's HEAD tree. That pointer is forgeable by design: Tenant B commits `oid sha256:<Tenant A's private merkle>` into their own repo, names it as `grantRepo`, and reads A's private bytes back over the global content-addressed CAS. The pointer-only check **structurally cannot** distinguish a planted reference from a genuine one.

### The fix (fail-closed)
**Part 1 — Provenance store** (`crates/hyprstream/src/services/xet_provenance.rs`)
Persisted server-side `(merkle_hex → {repo_id})` mapping recording which repos actually *uploaded* the bytes behind a merkle. Lives alongside registry metadata (`<base_dir>/.registry/xet_provenance.json`, 0600, atomic tmp+rename). The bytes stay globally deduplicated; only the provenance mapping is per-repo (same bytes uploaded by N repos → N bindings). `record()` is the sole mutating entry point and MUST be called from a server-authenticated upload path — never caller-supplied identity.

**Part 3 — Fail-closed read-gate** (`registry.rs::repo_contains_xet_merkle`)
Consults the provenance store FIRST. **No record binding (merkle → grant repo) ⇒ deny**, with no fallback to the pointer check. Pointer presence is retained only as defense-in-depth (the repo must still reference the merkle in HEAD); the provenance record is the authoritative grant.

### Fail-closed invariant
No provenance record → **deny**. Never falls back to the forgeable pointer check. First-run / empty store ⇒ all XetMerkle `getBlob` denied (the secure default, which also enforces in code the previously documentation-only "private multitenant XET must stay disabled" posture).

### ⚠️ Part 2 (authenticated upload binding) — SCOPED AS REMAINING, needs design sign-off
The crux + the auth surface. Today XET uploads go through the standalone `cas-serve` binary over stdio/SSH (`crates/cas-serve/src/main.rs`), which is fully identity/repo-agnostic (base64 → content-address → global dedup). hyprstream only ever *reads* from the CAS (`get_file_bytes`); there is **no in-process authenticated upload point** at which the registry currently learns "repo X uploaded merkle M".

Making the upload identity-aware safely requires a design decision I did not want to guess:
- Naively adding a `repo_id` field to the `cas-serve` `UploadFile`/`UploadXorb` protocol would trust **caller-supplied identity** as a credential — exactly the anti-pattern the threat model forbids. **Not done.**
- The sound shape is **registry-mediated uploads** (registry authenticates the caller + grant repo, computes the merkle from real bytes, uploads to the CAS, then calls `record()`), which needs a new authenticated upload RPC and a client-migration decision.

This PR therefore deliberately makes **no capnp schema change** and ships parts 1+3 with the fail-closed default. `XetProvenanceStore::record()` is the ready integration hook for whichever part-2 design is approved.

### Verified
- `cargo check -p hyprstream -p cas-serve` — clean.
- `cargo clippy -p hyprstream --lib` — clean (workspace has `deny` on correctness/unwrap_used/etc.).
- `cargo test -p hyprstream --lib -- xet_provenance` — 4/4 pass, **including the un-ignored `oid_field_planted_pointer_must_be_denied`** (planted pointer with no provenance → denied; genuine uploader resolves; unknown merkle fail-closed; persistence across reload).
- Existing getBlob deny-path tests unaffected; no positive XetMerkle getBlob test exists to regress.

### Needs review / human sign-off
- The provenance trust boundary and the part-2 authenticated upload design (above).
- Whether the secure default (deny XetMerkle getBlob until provenance exists) is acceptable for any currently-enabled public/same-trust-domain XET flow, or whether part 2 must land in the same release.

Closes #509. Closes #436. Relates #479.

https://claude.ai/code/session_01U3qgsHTDWME66JFGZGS3ZA