### PR TITLE
design(#507): inventory backend registry + fail-closed select-by-name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6917,6 +6917,7 @@ dependencies = [
  "hyprstream-tcl",
  "hyprstream-vfs",
  "hyprstream-vfs-server",
+ "inventory",
  "kata-sys-util",
  "kata-types",
  "libc",

--- a/crates/hyprstream-workers/Cargo.toml
+++ b/crates/hyprstream-workers/Cargo.toml
@@ -50,6 +50,9 @@ glob = { workspace = true }
 nix = { workspace = true }
 which = { workspace = true }
 
+# Compile-time backend registry (sandbox backends self-register via inventory::submit!)
+inventory = { workspace = true }
+
 # Service management utilities (merged into hyprstream-rpc)
 
 # D-Bus integration (optional, for container D-Bus proxy)

--- a/crates/hyprstream-workers/src/config.rs
+++ b/crates/hyprstream-workers/src/config.rs
@@ -9,33 +9,31 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-/// Sandbox backend type
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum BackendType {
-    /// Kata Containers (default — full VM isolation)
-    #[default]
-    Kata,
-    /// systemd-nspawn (lightweight container, rootless, host filesystem)
-    Nspawn,
-}
-
-impl std::fmt::Display for BackendType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Kata => write!(f, "kata"),
-            Self::Nspawn => write!(f, "nspawn"),
-        }
-    }
+/// Default value for [`WorkerConfig::backend`].
+///
+/// `"auto"` asks the runtime to pick the highest-priority *available* registered
+/// sandbox backend (see [`crate::runtime::resolve_backend`]).
+fn default_backend() -> String {
+    "auto".to_owned()
 }
 
 /// Top-level configuration for the workers crate
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
-#[derive(Default)]
 pub struct WorkerConfig {
-    /// Sandbox backend to use for isolation
-    pub backend: BackendType,
+    /// Sandbox backend selection (operator-driven).
+    ///
+    /// A registered backend name or `"auto"`:
+    /// * `"auto"` (default) — pick the highest-priority *available* registered
+    ///   backend.
+    /// * `"kata"` — full VM isolation (only available in `kata-vm` builds).
+    /// * `"nspawn"` — systemd-nspawn lightweight container.
+    ///
+    /// Resolved fail-closed at startup against the inventory backend registry —
+    /// an unavailable or unknown name errors rather than silently downgrading
+    /// isolation. See [`crate::runtime::resolve_backend`].
+    #[serde(default = "default_backend")]
+    pub backend: String,
 
     /// Pool configuration for VM management
     pub pool: PoolConfig,
@@ -52,6 +50,19 @@ pub struct WorkerConfig {
     /// QUIC/WebTransport port. None = no QUIC, Some(0) = ephemeral, Some(N) = explicit.
     #[serde(default)]
     pub quic_port: Option<u16>,
+}
+
+impl Default for WorkerConfig {
+    fn default() -> Self {
+        Self {
+            backend: default_backend(),
+            pool: PoolConfig::default(),
+            images: ImageConfig::default(),
+            workflow: WorkflowConfig::default(),
+            events: EventConfig::default(),
+            quic_port: None,
+        }
+    }
 }
 
 
@@ -298,25 +309,29 @@ mod tests {
     }
 
     #[test]
-    fn test_backend_type_default() {
-        assert_eq!(BackendType::default(), BackendType::Kata);
+    fn test_backend_default_is_auto() {
+        // Default selection is "auto": pick the strongest *available* registered
+        // backend at startup (resolved fail-closed, never silent downgrade).
+        assert_eq!(WorkerConfig::default().backend, "auto");
     }
 
     #[test]
-    fn test_backend_type_serialization() -> Result<(), Box<dyn std::error::Error>> {
-        let yaml = "backend: nspawn\n";
-        let config: WorkerConfig = serde_yaml::from_str(yaml)?;
-        assert_eq!(config.backend, BackendType::Nspawn);
-
-        let yaml = "backend: kata\n";
-        let config: WorkerConfig = serde_yaml::from_str(yaml)?;
-        assert_eq!(config.backend, BackendType::Kata);
+    fn test_backend_string_parses_verbatim() -> Result<(), Box<dyn std::error::Error>> {
+        // `backend` is a free-form string matched against the registry by name;
+        // config parsing does not validate it (resolution does, fail-closed).
+        for name in ["auto", "kata", "nspawn", "anything"] {
+            let yaml = format!("backend: {name}\n");
+            let config: WorkerConfig = serde_yaml::from_str(&yaml)?;
+            assert_eq!(config.backend, name);
+        }
         Ok(())
     }
 
     #[test]
-    fn test_backend_type_display() {
-        assert_eq!(BackendType::Kata.to_string(), "kata");
-        assert_eq!(BackendType::Nspawn.to_string(), "nspawn");
+    fn test_backend_absent_defaults_to_auto() -> Result<(), Box<dyn std::error::Error>> {
+        // Missing `backend` key falls back to the field default ("auto"), not "".
+        let config: WorkerConfig = serde_yaml::from_str("pool:\n  max_sandboxes: 5\n")?;
+        assert_eq!(config.backend, "auto");
+        Ok(())
     }
 }

--- a/crates/hyprstream-workers/src/lib.rs
+++ b/crates/hyprstream-workers/src/lib.rs
@@ -63,11 +63,13 @@ pub mod events;
 pub mod dbus;
 
 // Re-export main types
-pub use config::{BackendType, HypervisorType, ImageConfig, PoolConfig, WorkerConfig, WorkflowConfig};
+pub use config::{HypervisorType, ImageConfig, PoolConfig, WorkerConfig, WorkflowConfig};
 pub use error::WorkerError;
 
 // Re-export service types
 pub use runtime::{WorkerService, SandboxBackend, SandboxHandle, NspawnBackend, NspawnConfig};
+// Inventory-based backend registry + fail-closed selection spine (#507)
+pub use runtime::{resolve_backend, BackendCtx, BackendRegistration};
 #[cfg(feature = "kata-vm")]
 pub use runtime::KataBackend;
 #[cfg(feature = "kata-vm")]

--- a/crates/hyprstream-workers/src/runtime/kata_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/kata_backend.rs
@@ -84,6 +84,13 @@ impl KataBackend {
         }
     }
 
+    /// Runtime prerequisite probe for the backend registry: a `cloud-hypervisor`
+    /// binary must be on PATH. Mirrors the instance-level
+    /// [`SandboxBackend::is_available`] check.
+    fn registry_is_available() -> bool {
+        which::which("cloud-hypervisor").is_ok()
+    }
+
     /// Build a `HypervisorConfig` from `PoolConfig`.
     fn build_hypervisor_config(pool_config: &PoolConfig) -> HypervisorConfig {
         let mut config = HypervisorConfig::default();
@@ -557,6 +564,31 @@ impl SandboxBackend for KataBackend {
         Err(WorkerError::ExecFailed(
             "not supported by Kata backend (requires agent)".into(),
         ))
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Backend registry self-registration (#507 / #518)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// This whole file only compiles under `kata-vm` (see runtime/mod.rs), so this
+// `submit!` is feature-gated by construction: the `kata` backend is a selectable
+// name *only* in builds that include the VM toolchain. In a non-`kata-vm` binary
+// there is no registration, and selecting `kata` fails closed with a build hint.
+//
+// Highest priority → preferred by `auto` (strongest isolation). Construction
+// pulls the RAFS image store from the per-call BackendCtx.
+inventory::submit! {
+    crate::runtime::selection::BackendRegistration {
+        name: "kata",
+        priority: 100,
+        is_available: KataBackend::registry_is_available,
+        construct: |ctx| {
+            Ok(Arc::new(KataBackend::new(
+                ctx.image_config.clone(),
+                Arc::clone(&ctx.rafs_store),
+            )) as Arc<dyn crate::runtime::SandboxBackend>)
+        },
     }
 }
 

--- a/crates/hyprstream-workers/src/runtime/mod.rs
+++ b/crates/hyprstream-workers/src/runtime/mod.rs
@@ -33,6 +33,8 @@ mod sandbox;
 // (composes a RAFS rootfs and serves it over vhost-user-fs to a CH guest).
 #[cfg(all(not(target_arch = "wasm32"), feature = "kata-vm"))]
 pub mod sandbox_fs;
+// Canonical backend taxonomy + fail-closed selection (Phase 0 of #508, #507).
+pub mod selection;
 mod service;
 pub mod spawner;
 // VirtioFS daemon wrapper (nydus-service) — VM-only.
@@ -81,6 +83,8 @@ pub use backend::{SandboxBackend, SandboxHandle};
 #[cfg(feature = "kata-vm")]
 pub use kata_backend::{KataBackend, KataHandle};
 pub use nspawn::{NspawnBackend, NspawnConfig, NspawnHandle};
+// Inventory-based backend registry + fail-closed selection spine (#507)
+pub use selection::{resolve_backend, BackendCtx, BackendRegistration};
 // Domain entities (business logic only)
 pub use container::Container;
 pub use pool::{PoolStats, SandboxPool};

--- a/crates/hyprstream-workers/src/runtime/nspawn.rs
+++ b/crates/hyprstream-workers/src/runtime/nspawn.rs
@@ -125,6 +125,13 @@ impl NspawnBackend {
         Self { config }
     }
 
+    /// Runtime prerequisite probe for the backend registry: both
+    /// `systemd-nspawn` and `machinectl` must be on PATH. Mirrors the
+    /// instance-level [`SandboxBackend::is_available`] check.
+    fn registry_is_available() -> bool {
+        which::which("systemd-nspawn").is_ok() && which::which("machinectl").is_ok()
+    }
+
     /// Build the `systemd-nspawn` argument list for a sandbox.
     fn build_nspawn_args(
         &self,
@@ -501,6 +508,27 @@ impl SandboxBackend for NspawnBackend {
         }
 
         Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Backend registry self-registration (#507 / #518)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// systemd-nspawn is always compiled in (no feature gate), so it is always a
+// registered selectable backend. It is the lowest-priority auto pick — chosen
+// only when no stronger isolation tier is available. Selection still fails
+// closed: if nspawn's prerequisites are missing, an explicit `nspawn` request or
+// an `auto` with nothing else available errors rather than running unisolated.
+inventory::submit! {
+    crate::runtime::selection::BackendRegistration {
+        name: "nspawn",
+        priority: 10,
+        is_available: NspawnBackend::registry_is_available,
+        construct: |_ctx| {
+            Ok(std::sync::Arc::new(NspawnBackend::new(NspawnConfig::default()))
+                as std::sync::Arc<dyn crate::runtime::SandboxBackend>)
+        },
     }
 }
 

--- a/crates/hyprstream-workers/src/runtime/selection.rs
+++ b/crates/hyprstream-workers/src/runtime/selection.rs
@@ -1,0 +1,322 @@
+//! Inventory-based sandbox backend registry + fail-closed selection (#507).
+//!
+//! This is the *spine* of the unified sandbox taxonomy: one [`SandboxBackend`]
+//! seam, one selection model shared by every call site (no per-site ad-hoc
+//! `match` with a silent `_ => nspawn` catch-all).
+//!
+//! Backends are **not** a hardcoded enum. Each concrete backend self-registers a
+//! [`BackendRegistration`] via `inventory::submit!` next to its implementation,
+//! feature-gated by the `#[cfg]` that compiles that backend in (#518). The
+//! registry is therefore *exactly* the set of backends built into this binary:
+//!
+//! * `nspawn` — always registered (systemd-nspawn lightweight container).
+//! * `kata`   — registered only under the `kata-vm` feature (full VM isolation).
+//!
+//! YAGNI: speculative tiers (Oci/Cri/Wasm) are intentionally **not** registered.
+//! They gain a `submit!` when their phase actually builds them; until then they
+//! simply do not exist as selectable names (an explicit request errors).
+//!
+//! Selection is **config-driven** via `worker.backend` (a string: a registered
+//! backend name, or `"auto"`):
+//!
+//! * `"auto"` → pick the highest-[`priority`](BackendRegistration::priority)
+//!   registration whose [`is_available`](BackendRegistration::is_available)
+//!   probe passes. The choice is logged. If nothing is available, error — never
+//!   run a workload without isolation.
+//! * a concrete name → that registration, **iff** it is registered *and* its
+//!   prerequisites are present. Otherwise error. We never substitute a different
+//!   (weaker) backend (the #486 fail-open bug).
+//!
+//! The cardinal rule is **fail-closed**: an unavailable or unknown backend
+//! returns an error, never a silent downgrade to weaker isolation.
+
+use std::sync::Arc;
+
+use crate::config::PoolConfig;
+use crate::error::{Result, WorkerError};
+
+#[cfg(feature = "kata-vm")]
+use crate::config::ImageConfig;
+#[cfg(feature = "kata-vm")]
+use crate::image::RafsStore;
+
+use super::SandboxBackend;
+
+/// Per-call construction context threaded to a backend's `construct` fn.
+///
+/// `inventory` items are `'static`, so [`BackendRegistration::construct`] must be
+/// a bare `fn` pointer that cannot capture per-call state. This struct carries
+/// everything a backend constructor needs at selection time.
+pub struct BackendCtx {
+    /// Sandbox pool configuration (paths, hypervisor, limits).
+    pub pool_config: PoolConfig,
+
+    /// Image storage configuration. Only the VM (`kata-vm`) path consumes the
+    /// RAFS/nydus image store, so this field only exists on that build.
+    #[cfg(feature = "kata-vm")]
+    pub image_config: ImageConfig,
+
+    /// RAFS/nydus image store — VM-only (`kata-vm`).
+    #[cfg(feature = "kata-vm")]
+    pub rafs_store: Arc<RafsStore>,
+}
+
+/// A compile-time sandbox-backend registration, collected via `inventory`.
+///
+/// Each backend submits one of these next to its implementation, gated by the
+/// `#[cfg]` feature that compiles the backend in. The registry is enumerated by
+/// [`resolve_backend`]; there is no central enum to keep in sync.
+#[derive(Debug)]
+pub struct BackendRegistration {
+    /// Stable selector name, e.g. `"kata"`, `"nspawn"`. Matched against
+    /// `worker.backend` (case-insensitively).
+    pub name: &'static str,
+
+    /// Auto-selection precedence: higher is preferred. `"auto"` picks the
+    /// highest-priority *available* registration.
+    pub priority: i32,
+
+    /// Runtime prerequisite probe (PATH lookups, socket existence, …). Returns
+    /// `true` when this backend can actually run on this host *right now*. Used
+    /// to inform `"auto"` and to fail-close explicit requests whose prereqs are
+    /// missing.
+    pub is_available: fn() -> bool,
+
+    /// Construct the concrete backend from per-call [`BackendCtx`] state.
+    pub construct: fn(&BackendCtx) -> anyhow::Result<Arc<dyn SandboxBackend>>,
+}
+
+inventory::collect!(BackendRegistration);
+
+/// Comma-separated registered backend names, for error messages.
+fn registered_names(regs: &[&BackendRegistration]) -> String {
+    let mut names: Vec<&str> = regs.iter().map(|r| r.name).collect();
+    names.sort_unstable();
+    names.join(", ")
+}
+
+/// Pure selection over a registration set, with an injectable availability
+/// oracle. Factored out of [`resolve_backend`] so the fail-closed / auto-priority
+/// / unknown-name logic is unit-testable without depending on which runtimes
+/// happen to be installed on the test host.
+fn select_registration<'a>(
+    name: &str,
+    regs: &[&'a BackendRegistration],
+    is_available: impl Fn(&BackendRegistration) -> bool,
+) -> Result<&'a BackendRegistration> {
+    // ── Auto: highest-priority *available* registration wins ──
+    if name.eq_ignore_ascii_case("auto") {
+        let mut candidates: Vec<&'a BackendRegistration> = regs.to_vec();
+        // Highest priority first; ties broken by name for determinism.
+        candidates.sort_by(|a, b| b.priority.cmp(&a.priority).then_with(|| a.name.cmp(b.name)));
+        for reg in candidates {
+            if is_available(reg) {
+                return Ok(reg);
+            }
+        }
+        return Err(WorkerError::ConfigError(format!(
+            "auto backend selection found no available sandbox backend among [{}]. \
+             Install a supported runtime or set `worker.backend` to an explicit \
+             backend; refusing to run a workload without isolation (fail-closed).",
+            registered_names(regs)
+        )));
+    }
+
+    // ── Explicit request: authoritative, fail-closed ──
+    match regs.iter().find(|r| r.name.eq_ignore_ascii_case(name)) {
+        Some(reg) if is_available(reg) => Ok(reg),
+        Some(reg) => Err(WorkerError::ConfigError(format!(
+            "sandbox backend '{}' was requested but its runtime prerequisites are \
+             missing. Refusing to silently downgrade isolation to a weaker backend \
+             (fail-closed).",
+            reg.name
+        ))),
+        None => {
+            let mut msg = format!(
+                "unknown sandbox backend '{name}'; registered backends are [{}] (or \"auto\")",
+                registered_names(regs)
+            );
+            // Helpful hint for the most common misconfiguration: requesting the
+            // VM backend in a binary built without it.
+            if name.eq_ignore_ascii_case("kata") {
+                msg.push_str(
+                    ". The `kata` backend is only present when built with \
+                     `--features kata-vm`",
+                );
+            }
+            Err(WorkerError::ConfigError(msg))
+        }
+    }
+}
+
+/// Resolve `worker.backend` to a constructed [`SandboxBackend`], fail-closed.
+///
+/// `name` is either a registered backend name or `"auto"`. This is the single
+/// function both `factories.rs` and `bin/main.rs` route through — no scattered
+/// `#[cfg]`, no `_ => nspawn` fallback.
+///
+/// * **`"auto"`** → highest-[`priority`](BackendRegistration::priority)
+///   registration whose [`is_available`](BackendRegistration::is_available) is
+///   true; error if none.
+/// * **concrete name** → that registration if present *and* available; otherwise
+///   error (unavailable → fail-closed; unknown → error listing the registry).
+pub fn resolve_backend(name: &str, ctx: &BackendCtx) -> Result<Arc<dyn SandboxBackend>> {
+    let regs: Vec<&'static BackendRegistration> =
+        inventory::iter::<BackendRegistration>().collect();
+
+    let reg = select_registration(name, &regs, |r| (r.is_available)())?;
+
+    tracing::info!(
+        backend = reg.name,
+        requested = name,
+        priority = reg.priority,
+        "sandbox backend selected (fail-closed)"
+    );
+
+    (reg.construct)(ctx).map_err(|e| {
+        WorkerError::ConfigError(format!(
+            "failed to construct sandbox backend '{}': {e:#}",
+            reg.name
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Synthetic registrations for deterministic selection-logic tests ──
+    //
+    // These never touch the real `is_available` probes or `construct` fns; they
+    // exercise the pure `select_registration` spine (auto-priority, fail-closed,
+    // unknown-name) independent of what runtimes are installed.
+
+    fn never_available(_: &BackendCtx) -> anyhow::Result<Arc<dyn SandboxBackend>> {
+        unreachable!("construct is not called in selection-logic tests")
+    }
+
+    const HIGH: BackendRegistration = BackendRegistration {
+        name: "high-tier",
+        priority: 100,
+        is_available: || true,
+        construct: never_available,
+    };
+    const LOW: BackendRegistration = BackendRegistration {
+        name: "low-tier",
+        priority: 10,
+        is_available: || true,
+        construct: never_available,
+    };
+
+    fn regs() -> Vec<&'static BackendRegistration> {
+        vec![&HIGH, &LOW]
+    }
+
+    #[test]
+    fn auto_picks_highest_priority_available() {
+        // Both available → strongest (highest priority) wins.
+        let r = select_registration("auto", &regs(), |_| true).unwrap();
+        assert_eq!(r.name, "high-tier");
+    }
+
+    #[test]
+    fn auto_skips_unavailable_to_next_priority() {
+        // Strongest unavailable → auto must fall to the next available tier,
+        // never error while a usable backend remains.
+        let r = select_registration("auto", &regs(), |reg| reg.name != "high-tier").unwrap();
+        assert_eq!(r.name, "low-tier");
+    }
+
+    #[test]
+    fn auto_errors_when_nothing_available() {
+        let err = select_registration("auto", &regs(), |_| false).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("no available sandbox backend"), "got: {msg}");
+        assert!(msg.contains("fail-closed"), "got: {msg}");
+    }
+
+    #[test]
+    fn explicit_available_resolves_exactly() {
+        let r = select_registration("low-tier", &regs(), |_| true).unwrap();
+        assert_eq!(r.name, "low-tier");
+        // Case-insensitive.
+        let r = select_registration("LOW-TIER", &regs(), |_| true).unwrap();
+        assert_eq!(r.name, "low-tier");
+    }
+
+    #[test]
+    fn explicit_unavailable_fails_closed_no_downgrade() {
+        // "high-tier" requested but unavailable → error, must NOT downgrade to
+        // the available "low-tier" backend.
+        let err =
+            select_registration("high-tier", &regs(), |reg| reg.name == "low-tier").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("prerequisites are missing"), "got: {msg}");
+        assert!(msg.contains("fail-closed"), "got: {msg}");
+        // Must not name the weaker backend it could have silently fallen back to.
+        assert!(!msg.contains("low-tier"), "must not mention a downgrade target: {msg}");
+    }
+
+    #[test]
+    fn unknown_name_errors_listing_registry() {
+        let err = select_registration("bogus", &regs(), |_| true).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("unknown sandbox backend 'bogus'"), "got: {msg}");
+        assert!(msg.contains("high-tier"), "should list registered names: {msg}");
+        assert!(msg.contains("low-tier"), "should list registered names: {msg}");
+    }
+
+    #[test]
+    fn unknown_kata_hints_about_feature() {
+        // Asking for kata when it isn't registered (e.g. kata-vm off) gives a
+        // build-feature hint rather than a bare unknown error.
+        let err = select_registration("kata", &regs(), |_| true).unwrap_err();
+        assert!(err.to_string().contains("kata-vm"), "got: {err}");
+    }
+
+    // ── The real inventory must reflect the build's feature set ──
+
+    #[test]
+    fn registry_contains_nspawn_always() {
+        let names: Vec<&str> = inventory::iter::<BackendRegistration>()
+            .map(|r| r.name)
+            .collect();
+        assert!(names.contains(&"nspawn"), "nspawn must always register; got {names:?}");
+    }
+
+    #[test]
+    fn registry_contains_kata_only_under_feature() {
+        let has_kata = inventory::iter::<BackendRegistration>().any(|r| r.name == "kata");
+        assert_eq!(
+            has_kata,
+            cfg!(feature = "kata-vm"),
+            "kata registration must track the kata-vm feature"
+        );
+    }
+
+    #[test]
+    fn no_speculative_backends_registered() {
+        // YAGNI: Oci/Cri/Wasm must not be in the registry until built.
+        for name in ["oci", "cri", "wasm"] {
+            assert!(
+                !inventory::iter::<BackendRegistration>().any(|r| r.name == name),
+                "speculative backend '{name}' must not be registered (YAGNI)"
+            );
+        }
+    }
+
+    #[cfg(feature = "kata-vm")]
+    #[test]
+    fn kata_outranks_nspawn_in_priority() {
+        let kata = inventory::iter::<BackendRegistration>()
+            .find(|r| r.name == "kata")
+            .unwrap();
+        let nspawn = inventory::iter::<BackendRegistration>()
+            .find(|r| r.name == "nspawn")
+            .unwrap();
+        assert!(
+            kata.priority > nspawn.priority,
+            "kata (VM) must outrank nspawn for auto-selection"
+        );
+    }
+}

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1075,26 +1075,36 @@ fn handle_quick_command(
                     };
 
                     let _worker_handle = if !worker_already_running {
-                        use hyprstream_workers::runtime::SandboxBackend;
+                        use hyprstream_workers::runtime::{
+                            resolve_backend, BackendCtx, SandboxBackend,
+                        };
 
-                        // VM path (kata-vm): Kata backend + RAFS image store.
+                        // RAFS image store is only built on the VM path (kata-vm).
                         #[cfg(feature = "kata-vm")]
                         let rafs_store = {
                             use hyprstream_workers::image::RafsStore;
                             Arc::new(RafsStore::new(image_config.clone())?)
                         };
-                        #[cfg(feature = "kata-vm")]
-                        let backend: Arc<dyn SandboxBackend> = {
-                            use hyprstream_workers::runtime::KataBackend;
-                            Arc::new(KataBackend::new(image_config, Arc::clone(&rafs_store)))
+
+                        // Resolve + construct the backend fail-closed against the
+                        // inventory registry: "auto" (default) picks the strongest
+                        // available backend; an explicit name must be registered
+                        // and available, else error. No silent nspawn fallback.
+                        let backend_name: String = ctx
+                            .config()
+                            .worker
+                            .as_ref()
+                            .map(|w| w.backend.clone())
+                            .unwrap_or_else(|| "auto".to_owned());
+                        let backend_ctx = BackendCtx {
+                            pool_config: pool_config.clone(),
+                            #[cfg(feature = "kata-vm")]
+                            image_config,
+                            #[cfg(feature = "kata-vm")]
+                            rafs_store: Arc::clone(&rafs_store),
                         };
-                        // Without kata-vm the CLI worker entrypoint falls back to
-                        // the lightweight nspawn backend.
-                        #[cfg(not(feature = "kata-vm"))]
-                        let backend: Arc<dyn SandboxBackend> = {
-                            use hyprstream_workers::{NspawnBackend, NspawnConfig};
-                            Arc::new(NspawnBackend::new(NspawnConfig::default()))
-                        };
+                        let backend: Arc<dyn SandboxBackend> =
+                            resolve_backend(&backend_name, &backend_ctx)?;
 
                         let worker_transport =
                             TransportConfig::inproc("hyprstream/workers");

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -652,22 +652,24 @@ fn create_model_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnabl
 fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>> {
     info!("Creating WorkerService");
 
-    use hyprstream_workers::config::{BackendType, PoolConfig};
+    use hyprstream_workers::config::PoolConfig;
     #[cfg(feature = "kata-vm")]
     use hyprstream_workers::config::ImageConfig;
     #[cfg(feature = "kata-vm")]
     use hyprstream_workers::image::RafsStore;
-    #[cfg(feature = "kata-vm")]
-    use hyprstream_workers::KataBackend;
-    use hyprstream_workers::{WorkerService, SandboxBackend, NspawnBackend, NspawnConfig};
+    use hyprstream_workers::{resolve_backend, BackendCtx, SandboxBackend, WorkerService};
 
     let config = load_config();
     let worker_quic_port = config.worker.as_ref().and_then(|w| w.quic_port);
-    let backend_type = config.worker.as_ref()
-        .map(|w| w.backend)
-        .unwrap_or_default();
+    // Operator-selected backend name ("auto" or a registered backend); resolved
+    // fail-closed against the inventory registry below.
+    let backend_name: String = config
+        .worker
+        .as_ref()
+        .map(|w| w.backend.clone())
+        .unwrap_or_else(|| "auto".to_owned());
 
-    info!("WorkerService using {} backend", backend_type);
+    info!("WorkerService backend selection: {}", backend_name);
 
     // Use default paths based on XDG directories
     let data_dir = dirs::data_local_dir()
@@ -704,19 +706,19 @@ fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
     #[cfg(feature = "kata-vm")]
     let rafs_store = Arc::new(RafsStore::new(image_config.clone())?);
 
-    // Construct the sandbox backend based on configuration.
-    let backend: Arc<dyn SandboxBackend> = match backend_type {
+    // Resolve + construct the backend fail-closed against the inventory registry
+    // (config-driven by name; explicit requests are authoritative, missing
+    // prerequisites error out rather than silently downgrading isolation; "auto"
+    // picks the strongest available). Single seam — no scattered cfg, no
+    // `_ => nspawn` fallback (#507 / #518).
+    let backend_ctx = BackendCtx {
+        pool_config: pool_config.clone(),
         #[cfg(feature = "kata-vm")]
-        BackendType::Kata => Arc::new(KataBackend::new(image_config, Arc::clone(&rafs_store))),
-        #[cfg(not(feature = "kata-vm"))]
-        BackendType::Kata => {
-            return Err(anyhow::anyhow!(
-                "worker backend `kata` requires the `kata-vm` feature; \
-                 this binary was built without kata-vm support (use the `nspawn` backend)"
-            ));
-        }
-        BackendType::Nspawn => Arc::new(NspawnBackend::new(NspawnConfig::default())),
+        image_config,
+        #[cfg(feature = "kata-vm")]
+        rafs_store: Arc::clone(&rafs_store),
     };
+    let backend: Arc<dyn SandboxBackend> = resolve_backend(&backend_name, &backend_ctx)?;
 
     let sk = ctx.service_signing_key("worker");
 


### PR DESCRIPTION
## Summary

Reworks the sandbox backend taxonomy (#507) from a hardcoded `BackendType` enum (with unimplemented Oci/Cri/Wasm stub arms) into an **`inventory`-based backend registry** selected by **string name** via a new operator config field. Per-backend feature-gating (#518) is folded in.

## Inventory registry (not an enum)

`crates/hyprstream-workers/src/runtime/selection.rs`:

```rust
pub struct BackendRegistration {
    pub name: &'static str,          // "kata", "nspawn"
    pub priority: i32,               // higher = preferred under "auto"
    pub is_available: fn() -> bool,  // runtime prereq probe (PATH, etc.)
    pub construct: fn(&BackendCtx) -> anyhow::Result<Arc<dyn SandboxBackend>>,
}
inventory::collect!(BackendRegistration);
```

`construct` is a bare `fn` pointer (inventory items are `'static`, so it cannot capture). Per-call state — `pool_config`, plus the kata-vm-gated `image_config` / `rafs_store` — is threaded through a `BackendCtx` struct.

The `BackendType` / `BackendSelection` enums are **removed entirely**. Selection is by string name against the registry.

## Each backend self-registers, feature-gated (folds in #518)

- `nspawn` — `inventory::submit!` next to `NspawnBackend`, **always** compiled in, `priority: 10`.
- `kata` — `inventory::submit!` next to `KataBackend`; the whole `kata_backend.rs` file is `#[cfg(feature = "kata-vm")]`, so the registration is gated by construction, `priority: 100`.

**YAGNI:** Oci/Cri/Wasm are **not** registered and have **no** enum variants or stub arms. They each get a `submit!` when their phase actually builds them — until then they simply don't exist as selectable names.

## Selection: config-driven, fail-closed, by name

`resolve_backend(name: &str, &BackendCtx) -> Result<Arc<dyn SandboxBackend>>`:

- `"auto"` → highest-`priority` registration whose `is_available()` is true; **error** if none (never run a workload without isolation).
- a concrete name → that registration **iff** registered *and* available; otherwise error. Unknown name → error listing the registered names (plus a `kata-vm` build hint for `"kata"`).
- **Never** a silent downgrade to weaker isolation (the #486 fail-open bug).

Both `factories.rs` and `bin/main.rs` route through this single function — no scattered `#[cfg]`, no `_ => nspawn` fallback (keeps #516's win).

## HyprConfig field

`WorkerConfig.backend` is now a `String` (default `"auto"`), reachable from the operator surface (`[worker] backend = "..."` in the config file, or `HYPRSTREAM__WORKER__BACKEND`) via `HyprConfig.worker`. Documented in the field doc: valid = any registered backend name or `"auto"`.

## Constraints honored

- **Fail-closed AAA:** unavailable/unknown backend → error, never a weaker-isolation fallback.
- **YAGNI:** registry contains only Kata + Nspawn (the backends that exist today).
- **No capnp/RPC schema change** — internal config + registry only.
- Existing Kata/Nspawn behavior preserved, just routed through the registry.

## Verification

`cargo check -p hyprstream-workers -p hyprstream` clean with **kata-vm on and off**.

Tests (both feature configs) cover:
- auto picks highest-priority available; skips unavailable to next tier; errors when none available
- explicit unavailable → fail-closed, no downgrade
- unknown name → error listing the registry
- the real `inventory::iter::<BackendRegistration>()` contains `"nspawn"` always, `"kata"` only under `kata-vm`, and no speculative backends; `kata` outranks `nspawn`

`cargo test -p hyprstream-workers`: 14/14 (kata-vm off), 32/32 (kata-vm on). Clippy clean on the workers crate.

> Note: history was rewritten (amended the single design commit, force-with-lease) so the PR presents the inventory design directly rather than introducing then deleting an enum.

https://claude.ai/code/session_01U3qgsHTDWME66JFGZGS3ZA
