### PR TITLE
security(#528): decrypt Tagged AEAD frames on consume (wire decrypt_event_full + enc_key)

### DIFF
--- a/crates/hyprstream-rpc/tests/moq_relay_rendezvous.rs
+++ b/crates/hyprstream-rpc/tests/moq_relay_rendezvous.rs
@@ -106,6 +106,9 @@ async fn moq_relay_rendezvous() -> Result<()> {
     let ctx = StreamContext::from_dh(&client_pub.to_bytes())?;
     let topic = ctx.topic().to_owned();
     let mac_key = *ctx.mac_key();
+    // #321/#528: the DH path seals every frame into a `Tagged` AEAD block, so the
+    // consumer needs the matching `enc_key` to open it back to plaintext `Data`.
+    let enc_key = *ctx.enc_key().expect("DH ctx has enc_key");
 
     // ── PRODUCER: a LOCAL origin, never bound to a network endpoint ────────────
     // The producer is NOT directly reachable (no QuinnRpcServer of its own). Its
@@ -155,8 +158,10 @@ async fn moq_relay_rendezvous() -> Result<()> {
     .ok_or_else(|| anyhow!("broadcast not announced via relay"))?;
     let mut track = bc.subscribe_track(&moq_net::Track::new(STREAM_TRACK))?;
 
-    // ── Publish through the relay; verify the chained-HMAC end-to-end ──────────
-    let mut verifier = StreamVerifier::new(mac_key, topic.clone());
+    // ── Publish through the relay; verify the chained-HMAC + AEAD end-to-end ────
+    // The HMAC chain runs first over the sealed block, then the `Tagged` payload is
+    // AEAD-opened back to `Data`/`Complete` (#528): the consumer holds `enc_key`.
+    let mut verifier = StreamVerifier::new(mac_key, topic.clone()).with_enc_key(enc_key);
     let mut got: Vec<StreamPayload> = Vec::new();
 
     // Publish one group at a time and drain it so the ordered chain is observed.
@@ -310,6 +315,9 @@ async fn relay_choice_only_anonymizes_stream_end_to_end() -> Result<()> {
     let ctx = StreamContext::from_dh(&client_pub.to_bytes())?;
     let topic = ctx.topic().to_owned();
     let mac_key = *ctx.mac_key();
+    // #321/#528: DH path is AEAD-on — the consumer needs the `enc_key` to open the
+    // sealed `Tagged` frames back into plaintext `Data`.
+    let enc_key = *ctx.enc_key().expect("DH ctx has enc_key");
 
     // Producer is a LOCAL origin, never network-bound — reachable ONLY via relay.
     let producer_origin = {
@@ -353,7 +361,7 @@ async fn relay_choice_only_anonymizes_stream_end_to_end() -> Result<()> {
     .ok_or_else(|| anyhow!("broadcast not announced via relay"))?;
     let track = bc.subscribe_track(&moq_net::Track::new(STREAM_TRACK))?;
 
-    let mut verifier = StreamVerifier::new(mac_key, topic.clone());
+    let mut verifier = StreamVerifier::new(mac_key, topic.clone()).with_enc_key(enc_key);
     // Publish FIRST, then read the group (the moq group exists once published) —
     // matches the `next_frame` ordering in `moq_relay_rendezvous`.
     publisher.publish_data(b"anon").await?;


### PR DESCRIPTION
## The gap (#528)

The streaming AEAD consume side was **half-wired**. The DH (mesh) path seals every frame into a `StreamPayload::Tagged` AEAD block, but the `moq_relay_rendezvous` integration test constructed its `StreamVerifier` **without** the matching `enc_key`. So sealed frames passed through the `Which::Tagged` arm undecrypted and the test deterministically failed on `main` — `got Tagged { ... }`, expected `Data`.

Note: the issue was filed against an older tree (line numbers `stream_consumer.rs:250`, `decrypt_event_full` only called from tests). The production consume side has **since** been wired in `main`:
- `derive_stream_keys` already derives `"hyprstream stream-keys v1 enc"` alongside `mac_key` (`crypto/key_exchange.rs`).
- The `Which::Tagged` arm already calls `open_sealed_payload` → `event_crypto::decrypt_event_full` (HMAC chain first over the sealed block, then AEAD-open; fail-closed on tamper / wrong key) when the verifier holds `enc_key` (`stream_consumer.rs`).
- Production consumers thread it: `StreamHandleImpl::open` + the `moq_stream` consume helpers use `StreamVerifier::with_enc_key`.

The only remaining piece for #528 was the integration test, which had not been updated to provide the `enc_key`.

## The fix

Thread `enc_key = *ctx.enc_key()` into **both** `moq_relay_rendezvous` verifiers (`StreamVerifier::new(mac_key, topic).with_enc_key(enc_key)`), matching the established pattern in `moq_stream`'s round-trip tests. The HMAC chain runs first over the sealed block (ordering / anti-replay unchanged), then the `Tagged` payload is AEAD-opened back into plaintext `Data` / `Complete`. The relay-blind wrong-key assertion is unchanged — a wrong `mac_key` is rejected at the MAC step before AEAD.

Crypto stays library-internal; **no schema change** (TaggedPayload already exists). Seal→open round-trip is now exercised end-to-end through the relay; AEAD tamper / wrong-key detection is covered by `crypto::event_crypto` unit tests and `stream_consumer::policy_tests::relay_dhpublic_substitution_is_rejected`.

## Verify

`OPENSSL_NO_VENDOR=1 cargo test -p hyprstream-rpc` (TMPDIR redirected off the full `/tmp` tmpfs):

```
running 2 tests
test moq_relay_rendezvous ... ok
test relay_choice_only_anonymizes_stream_end_to_end ... ok
test result: ok. 2 passed; 0 failed

# crypto::event_crypto + stream_consumer::policy_tests
test result: ok. 26 passed; 0 failed; 456 filtered out
```

This also clears the deterministic **main-red** `moq_relay_rendezvous` failure.

## AUTH/CRYPTO — needs sign-off

Crypto/security surface. Opened as a **draft**; do **not** merge without human sign-off.

Closes #528.