### PR TITLE
fix(test/#528): give moq_relay_rendezvous verifier the AEAD enc_key

### DIFF
--- a/crates/hyprstream-rpc/tests/moq_relay_rendezvous.rs
+++ b/crates/hyprstream-rpc/tests/moq_relay_rendezvous.rs
@@ -156,7 +156,12 @@ async fn moq_relay_rendezvous() -> Result<()> {
     let mut track = bc.subscribe_track(&moq_net::Track::new(STREAM_TRACK))?;
 
     // ── Publish through the relay; verify the chained-HMAC end-to-end ──────────
-    let mut verifier = StreamVerifier::new(mac_key, topic.clone());
+    // The producer (`from_dh` ctx) seals each payload under the DH `enc_key` (#321),
+    // so the verifier must open it with the SAME key — otherwise `Tagged` frames pass
+    // through undecrypted and never become `Data`/`Complete`. Mirrors the production
+    // consumers (stream_consumer.rs + moq_stream.rs all call `.with_enc_key`).
+    let mut verifier = StreamVerifier::new(mac_key, topic.clone())
+        .with_enc_key(*ctx.enc_key().expect("from_dh ctx derives the AEAD enc_key (#321)"));
     let mut got: Vec<StreamPayload> = Vec::new();
 
     // Publish one group at a time and drain it so the ordered chain is observed.
@@ -353,7 +358,12 @@ async fn relay_choice_only_anonymizes_stream_end_to_end() -> Result<()> {
     .ok_or_else(|| anyhow!("broadcast not announced via relay"))?;
     let track = bc.subscribe_track(&moq_net::Track::new(STREAM_TRACK))?;
 
-    let mut verifier = StreamVerifier::new(mac_key, topic.clone());
+    // The producer (`from_dh` ctx) seals each payload under the DH `enc_key` (#321),
+    // so the verifier must open it with the SAME key — otherwise `Tagged` frames pass
+    // through undecrypted and never become `Data`/`Complete`. Mirrors the production
+    // consumers (stream_consumer.rs + moq_stream.rs all call `.with_enc_key`).
+    let mut verifier = StreamVerifier::new(mac_key, topic.clone())
+        .with_enc_key(*ctx.enc_key().expect("from_dh ctx derives the AEAD enc_key (#321)"));
     // Publish FIRST, then read the group (the moq group exists once published) —
     // matches the `next_frame` ordering in `moq_relay_rendezvous`.
     publisher.publish_data(b"anon").await?;


### PR DESCRIPTION
Closes #528.

## What #528 actually is (re-diagnosed against `main`)
#528 was filed from a **stale branch** where the AEAD consume path looked unwired. On `main` it is **fully wired**: `StreamKeys.enc_key` is derived, `StreamVerifier` has `.with_enc_key()`, the `Which::Tagged` arm decrypts via `open_sealed_payload` + `stream_aead_aad`, and **every production consumer already enables it** (`stream_consumer.rs:459` + 6 sites in `moq_stream.rs`). So the consumer *does* decrypt in production — no product bug.

## The real bug (test-only)
`tests/moq_relay_rendezvous.rs` builds the producer via `StreamContext::from_dh()` (which **seals** payloads under the DH `enc_key`, #321) but built the verifier as `StreamVerifier::new(mac_key, topic)` — **without `.with_enc_key()`**. With the AEAD key absent, the `Tagged` arm passes sealed frames through, so `got[0]` was `StreamPayload::Tagged` and `assert!(matches!(.., Data("alpha")))` failed. Both rendezvous tests had this omission.

## Fix
Open with the same `enc_key` the producer sealed with (`ctx.enc_key()`), mirroring the production consumers. **Test-only; zero product change.** The `blind_verifier` wrong-key relay-blind assertions are untouched.

## Verification
`OPENSSL_NO_VENDOR=1 cargo test -p hyprstream-rpc --test moq_relay_rendezvous` → **2 passed; 0 failed** (was 2/2 failing). This clears the deterministic `moq_relay_rendezvous` failure that was contributing to main-red (separate from the iroh test-stabilization in #517).

Not an auth/crypto product change — it corrects a test to exercise the (already-correct) sealed path.

https://claude.ai/code/session_01U3qgsHTDWME66JFGZGS3ZA