### PR TITLE
ci: make build+test a merge-queue gate (not a per-PR check)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  merge_group:
 
 env:
   CARGO_TERM_COLOR: always
@@ -90,6 +91,13 @@ jobs:
         RUSTFLAGS: "--cfg=web_sys_unstable_apis"
 
   build:
+    # MERGE GATE — not a per-PR-push check. The heavy build+test runs in the merge
+    # queue (`merge_group`) against latest main + the PR, and on push to `main` — but
+    # NOT on every PR push. PR review keeps the fast jobs (clippy/deny/wasm) for quick
+    # feedback; `build` is the required check enforced by the `protection` ruleset's
+    # merge queue. (Per-PR AppImage artifacts were dropped with the PR build; the
+    # `appimage.yml` workflow still builds the AppImage on push to `main`.)
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs: clippy  # Only build if clippy passes
 
@@ -114,45 +122,3 @@ jobs:
 
     - name: Run tests
       run: cargo test --release --verbose --features download-libtorch
-
-    - name: Cache libtorch
-      if: github.event_name == 'pull_request'
-      uses: actions/cache@v4
-      with:
-        path: libtorch
-        key: libtorch-cpu-2.5.1
-
-    - name: Package AppImage
-      if: github.event_name == 'pull_request'
-      run: |
-        # Extract version from binary
-        VERSION=$(target/release/hyprstream --version | awk '{print $2}')
-        echo "VERSION=$VERSION" >> $GITHUB_ENV
-
-        # Download libtorch CPU (if not cached)
-        if [ ! -d libtorch/lib ]; then
-          curl -sSL -o libtorch.zip "https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-2.5.1%2Bcpu.zip"
-          unzip -q libtorch.zip
-        fi
-
-        # Download appimagetool
-        curl -sSL -o appimagetool "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
-        chmod +x appimagetool
-
-        # Assemble AppDir
-        mkdir -p hyprstream.AppDir/usr/bin hyprstream.AppDir/usr/lib/libtorch
-        cp target/release/hyprstream hyprstream.AppDir/usr/bin/
-        cp -r libtorch/lib hyprstream.AppDir/usr/lib/libtorch/
-        cp appimage/AppRun-single hyprstream.AppDir/AppRun && chmod +x hyprstream.AppDir/AppRun
-        cp appimage/hyprstream.desktop appimage/hyprstream.svg hyprstream.AppDir/
-
-        # Build AppImage with version in filename
-        ARCH=x86_64 ./appimagetool hyprstream.AppDir "hyprstream-${VERSION}-cpu-x86_64.AppImage"
-
-    - name: Upload AppImage
-      if: github.event_name == 'pull_request'
-      uses: actions/upload-artifact@v4
-      with:
-        name: appimage-cpu
-        path: hyprstream-*-cpu-x86_64.AppImage
-        retention-days: 7


### PR DESCRIPTION
Moves the heavy `build` job (cargo build+test --release, libtorch) off per-PR-push and into a **merge-queue gate**.

- `rust.yml`: add `merge_group` trigger; `build` runs on merge-queue + push-to-main, **not** `pull_request` (`if: github.event_name != 'pull_request'`).
- PR review keeps the fast jobs: **Clippy / cargo-deny / WASM**.
- Drop the dead PR-only AppImage steps (`appimage.yml` builds it on push to main).

Follow-up (admin, after merge): enable the merge queue on `main` + make `build` a required check in the `protection` ruleset. The queue builds each PR against latest main, which also removes the need to manually re-sync stale PRs.