### PR TITLE
feat(#557): S6 — transport PQ-hybrid X25519MLKEM768 (ring→aws-lc-rs)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,9 @@ futures = { version = "0.3.31", features = ["alloc"] }
 futures-util = "0.3.31"
 pin-project-lite = "0.2"
 tonic = { version = "0.12.3", features = ["transport", "codegen", "prost", "tls"] }
-rustls = { version = "0.23.1", features = ["ring"] }
+# aws_lc_rs enables the X25519MLKEM768 PQ-hybrid kx group (#557); ring kept for
+# any classical-only path. prefer-post-quantum orders the PQ group first.
+rustls = { version = "0.23.1", features = ["ring", "aws_lc_rs", "prefer-post-quantum"] }
 rustls-pemfile = "2.1.0"
 rustls-acme = { version = "0.11", features = ["tokio"] }
 axum = { version = "0.7", features = ["macros", "tokio"] }

--- a/crates/hyprstream-rpc/Cargo.toml
+++ b/crates/hyprstream-rpc/Cargo.toml
@@ -105,7 +105,7 @@ n0-error = "=1.0.0-rc.0"
 # QUIC transport (HTTP/3 + WebTransport + ZMTP over QUIC)
 quinn = { workspace = true }
 rcgen = { workspace = true }
-rustls = { workspace = true, features = ["ring"] }
+rustls = { workspace = true, features = ["ring", "aws_lc_rs"] }
 h3 = { workspace = true }
 h3-quinn = { workspace = true }
 h3-webtransport = { workspace = true }

--- a/crates/hyprstream-rpc/src/transport/iroh_substrate.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_substrate.rs
@@ -73,6 +73,10 @@ impl IrohSubstrate {
     {
         let endpoint = Endpoint::builder(presets::N0)
             .secret_key(SecretKey::from_bytes(&secret_key_bytes))
+            // PQ-hybrid TLS: pin X25519MLKEM768 on the iroh QUIC channel (#557 / S6).
+            // Overrides the preset's default (ring) provider; RFC 7250 raw-public-key
+            // identity binding is orthogonal to kx_groups and unaffected.
+            .crypto_provider(crate::transport::pq_provider::pq_crypto_provider())
             .bind()
             .await
             .map_err(|e| anyhow::anyhow!("iroh endpoint bind: {e}"))?;

--- a/crates/hyprstream-rpc/src/transport/lazy_quinn.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_quinn.rs
@@ -197,7 +197,7 @@ mod tests {
     /// server cert's SHA-256 pin, and a shutdown token. (Mirrors the harness in
     /// `quinn_transport::tests`; `build_server` there is test-private.)
     fn spawn_echo_server() -> (SocketAddr, [u8; 32], CancellationToken) {
-        let _ = rustls::crypto::ring::default_provider().install_default();
+        crate::transport::pq_provider::install_pq_crypto_provider();
 
         let cert_key =
             rcgen::generate_simple_self_signed(vec!["localhost".to_owned()]).unwrap();

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -10,6 +10,10 @@
 mod traits;
 pub mod zmtp_quic;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod pq_provider;
+#[cfg(not(target_arch = "wasm32"))]
+pub use pq_provider::{install_pq_crypto_provider, pq_crypto_provider};
+#[cfg(not(target_arch = "wasm32"))]
 pub mod iroh_substrate;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod rpc_session;

--- a/crates/hyprstream-rpc/src/transport/pq_provider.rs
+++ b/crates/hyprstream-rpc/src/transport/pq_provider.rs
@@ -1,0 +1,85 @@
+//! Post-quantum hybrid TLS crypto provider (#557 / S6 of epic #550).
+//!
+//! Pins the TLS 1.3 key exchange to **X25519MLKEM768** (the hybrid PQ group of
+//! draft-ietf-tls-ecdhe-mlkem / RFC 9370 framing) with classical **X25519** as a
+//! fallback for interop with non-PQ peers. ML-KEM is only available via the
+//! **aws-lc-rs** rustls provider — the `ring` provider this replaces has no
+//! ML-KEM, which is why every `ring::default_provider().install_default()` site
+//! is swapped for [`install_pq_crypto_provider`].
+//!
+//! This is transport-layer **defense-in-depth**. The real, transport-independent
+//! confidentiality guarantee is the application-layer hybrid KEM (`HyKEM`,
+//! [`crate::crypto::hybrid_kem`], S0) which also covers the wasm/browser path
+//! where we cannot touch the WebTransport TLS handshake. Here we harden the QUIC
+//! channel on the paths we own (zmtp, iroh, quinn/WebTransport).
+//!
+//! Native-only: rustls/aws-lc-rs are not part of the wasm32 build.
+
+use std::sync::Arc;
+
+use rustls::crypto::{aws_lc_rs, CryptoProvider};
+
+/// Build the pinned PQ-hybrid crypto provider: aws-lc-rs with
+/// `kx_groups = [X25519MLKEM768, X25519]` (hybrid first, classical fallback). All
+/// other parameters are aws-lc-rs defaults (cipher suites, signature schemes).
+///
+/// Pinning `kx_groups` explicitly (rather than relying on the `prefer-post-quantum`
+/// default order) makes the policy deterministic and auditable: a PQ-capable peer
+/// negotiates X25519MLKEM768; a classical-only peer falls back to X25519 (the
+/// channel is then classical, but the app-layer HyKEM stays hybrid).
+fn build_provider() -> CryptoProvider {
+    CryptoProvider {
+        kx_groups: vec![
+            aws_lc_rs::kx_group::X25519MLKEM768,
+            aws_lc_rs::kx_group::X25519,
+        ],
+        ..aws_lc_rs::default_provider()
+    }
+}
+
+pub fn pq_crypto_provider() -> Arc<CryptoProvider> {
+    Arc::new(build_provider())
+}
+
+/// Install [`pq_crypto_provider`] as the process-wide rustls default.
+///
+/// Idempotent — the first install in the process wins and later calls are a
+/// no-op (`install_default` returns `Err` once set; we ignore it). Must run
+/// before any rustls `ServerConfig`/`ClientConfig::builder()`, quinn endpoint, or
+/// web-transport endpoint that resolves the process default
+/// (`CryptoProvider::get_default()`). This is the single replacement for the
+/// former `rustls::crypto::ring::default_provider().install_default()` calls; it
+/// also covers the WebTransport (`web-transport-quinn`) path, whose builder has
+/// no provider setter and resolves the process default.
+pub fn install_pq_crypto_provider() {
+    // `install_default` consumes an owned `CryptoProvider` (not an `Arc`); the
+    // first install in the process wins and returns `Ok`, later calls return
+    // `Err(already_set)` which we ignore.
+    let _ = build_provider().install_default();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The PQ-hybrid group MUST be offered first, with classical X25519 as the
+    /// only fallback — a regression here would silently drop transport PQ.
+    #[test]
+    fn pins_x25519mlkem768_first_then_x25519() {
+        let provider = build_provider();
+        let names: Vec<rustls::NamedGroup> = provider.kx_groups.iter().map(|g| g.name()).collect();
+        assert_eq!(
+            names.first().copied(),
+            Some(rustls::NamedGroup::X25519MLKEM768),
+            "X25519MLKEM768 must be the first (preferred) kx group"
+        );
+        let pq = names
+            .iter()
+            .position(|n| *n == rustls::NamedGroup::X25519MLKEM768);
+        let classical = names.iter().position(|n| *n == rustls::NamedGroup::X25519);
+        assert!(
+            matches!((pq, classical), (Some(p), Some(c)) if p < c),
+            "PQ-hybrid must be offered ahead of classical X25519, got {names:?}"
+        );
+    }
+}

--- a/crates/hyprstream-rpc/src/transport/quinn_transport.rs
+++ b/crates/hyprstream-rpc/src/transport/quinn_transport.rs
@@ -629,7 +629,7 @@ mod tests {
     /// with a 0xCD marker prefix, client asserts on the response.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn quinn_rpc_round_trip() -> Result<()> {
-        let _ = rustls::crypto::ring::default_provider().install_default();
+        crate::transport::pq_provider::install_pq_crypto_provider();
 
         let processor = crate::transport::rpc_session::from_fn(|req: Bytes| async move {
             let mut out = Vec::with_capacity(1 + req.len());
@@ -659,7 +659,7 @@ mod tests {
     /// wrong => Err, empty set => Err = fail-closed).
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn verify_peer_cert_pinned_accepts_right_rejects_wrong() -> Result<()> {
-        let _ = rustls::crypto::ring::default_provider().install_default();
+        crate::transport::pq_provider::install_pq_crypto_provider();
         let processor =
             crate::transport::rpc_session::from_fn(|req: Bytes| async move { Ok(req) });
         let (server, addr, cert_der) = build_server()?;
@@ -684,7 +684,7 @@ mod tests {
     /// rejected while the first is still live. The first keeps working.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn quinn_connection_cap_rejects_excess() -> Result<()> {
-        let _ = rustls::crypto::ring::default_provider().install_default();
+        crate::transport::pq_provider::install_pq_crypto_provider();
 
         let processor =
             crate::transport::rpc_session::from_fn(|req: Bytes| async move { Ok(req) });
@@ -733,7 +733,7 @@ mod tests {
     /// with "now safe to shut down" — no wall-clock sleep races.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn quinn_shutdown_drains_in_flight() -> Result<()> {
-        let _ = rustls::crypto::ring::default_provider().install_default();
+        crate::transport::pq_provider::install_pq_crypto_provider();
 
         let entered = Arc::new(tokio::sync::Notify::new());
         let entered_c = Arc::clone(&entered);

--- a/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
+++ b/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
@@ -1309,12 +1309,14 @@ pub fn cert_hash(cert_der: &[u8]) -> String {
 // TLS Helpers
 // ============================================================================
 
-/// Install the ring crypto provider for rustls (required for QUIC/TLS).
+/// Install the PQ-hybrid (aws-lc-rs, X25519MLKEM768) crypto provider for rustls
+/// (required for QUIC/TLS), replacing the former ring provider (#557 / S6).
 ///
 /// Must be called before creating any rustls `ServerConfig` or quinn endpoint.
-/// No-op if already installed (safe to call multiple times).
+/// No-op if already installed (safe to call multiple times). See
+/// [`crate::transport::pq_provider`].
 pub fn ensure_crypto_provider() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
+    crate::transport::pq_provider::install_pq_crypto_provider();
 }
 
 /// Generate a self-signed TLS certificate for development/testing.

--- a/crates/hyprstream-rpc/tests/moq_networked.rs
+++ b/crates/hyprstream-rpc/tests/moq_networked.rs
@@ -50,7 +50,7 @@ fn build_server() -> Result<(web_transport_quinn::Server, std::net::SocketAddr, 
 /// via `dial_stream`, subscribes, and receives MAC-verified frames.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn networked_moq_subscribe_receives_mac_verified_frames() -> Result<()> {
-    let _ = rustls::crypto::ring::default_provider().install_default();
+    hyprstream_rpc::transport::install_pq_crypto_provider();
 
     // Server-side moq origin (the shared broadcast tree external subscribers see).
     let producer = moq_net::Origin::random().produce();

--- a/crates/hyprstream-rpc/tests/moq_relay_rendezvous.rs
+++ b/crates/hyprstream-rpc/tests/moq_relay_rendezvous.rs
@@ -68,7 +68,7 @@ fn build_server() -> Result<(web_transport_quinn::Server, std::net::SocketAddr, 
 /// ever learns the other's address.
 #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn moq_relay_rendezvous() -> Result<()> {
-    let _ = rustls::crypto::ring::default_provider().install_default();
+    hyprstream_rpc::transport::install_pq_crypto_provider();
 
     // ── RELAY: a bidirectional /moq endpoint (ingest + re-serve), no keys ──────
     // Its origin starts EMPTY — the broadcast exists only on the producer until
@@ -228,7 +228,7 @@ async fn moq_relay_rendezvous() -> Result<()> {
 /// learn or dial the producer's direct address.
 #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn relay_choice_only_anonymizes_stream_end_to_end() -> Result<()> {
-    let _ = rustls::crypto::ring::default_provider().install_default();
+    hyprstream_rpc::transport::install_pq_crypto_provider();
 
     // ── RELAY: bidirectional /moq endpoint, no keys (same as rendezvous) ───────
     let relay_producer = moq_net::Origin::random().produce();

--- a/crates/hyprstream/src/server/tls.rs
+++ b/crates/hyprstream/src/server/tls.rs
@@ -105,10 +105,11 @@ pub async fn resolve_rustls_config(
         return Ok(None);
     }
 
-    // Ensure the ring crypto provider is installed for rustls.
-    // Services that don't use QUIC (which installs it via quinn) need this
-    // before any RustlsConfig can be created. Idempotent — ignores if already set.
-    let _ = rustls::crypto::ring::default_provider().install_default();
+    // Ensure the PQ-hybrid (aws-lc-rs, X25519MLKEM768) crypto provider is
+    // installed for rustls (#557 / S6). Services that don't use QUIC (which
+    // installs it via quinn) need this before any RustlsConfig can be created.
+    // Idempotent — ignores if already set.
+    hyprstream_rpc::transport::install_pq_crypto_provider();
 
     // Per-service override: both cert and key must be set
     if let (Some(cert), Some(key)) = (service_cert, service_key) {


### PR DESCRIPTION
Closes #557 (S6 of epic #550).

Transport-layer PQ-hybrid: pin TLS 1.3 KEX to **X25519MLKEM768** by swapping the rustls provider `ring`→`aws-lc-rs` (ring has no ML-KEM; aws-lc-rs 1.14 already in the tree). Defense-in-depth beneath the app-layer HyKEM (which is the real, transport-independent, wasm-covering guarantee).

## What
- `transport/pq_provider.rs` (new): `build_provider()` → `CryptoProvider { kx_groups: [X25519MLKEM768, X25519], ..aws_lc_rs::default_provider() }` (PQ pinned first, classical fallback for interop); `pq_crypto_provider() -> Arc<_>` (iroh); `install_pq_crypto_provider()` (idempotent process default).
- **Every** `ring::default_provider().install_default()` site swapped to the single helper (zmtp `ensure_crypto_provider`, `server/tls.rs`, quinn/lazy_quinn/moq test sites) → exactly one provider installs process-wide (no ring/aws-lc-rs conflict).
- **iroh**: `Endpoint::builder().crypto_provider(pq_crypto_provider())` (RPK identity binding orthogonal to kx_groups). **zmtp**: flows through `QuicClientConfig::try_from` unchanged. **WebTransport h3**: covered by the process default (no builder setter); web-transport-iroh inherits iroh's provider.
- Cargo: rustls `aws_lc_rs` + `prefer-post-quantum` features.

## Tests / scope
`cargo check -p hyprstream-rpc` clean (merged with S0+S2). Guard test `pins_x25519mlkem768_first_then_x25519` passes; existing loopback QUIC/moq round-trips now run under the PQ provider on both peers. Native-only (gated off wasm). Follow-up: no live negotiated-`NamedGroup` assertion (quinn doesn't surface it ergonomically); `server/tls.rs` one-line swap not libtorch-compiled here.

Reviewed by the orchestrating agent: kx_groups order, single install path (no ring remnants), iroh/zmtp/WebTransport wiring, wasm gating.
