### PR TITLE
feat(#552): S1 — #mesh-kem PQ keyAgreement identity + trust store (DID wiring WIP, libtorch-gated)

### DIFF
--- a/crates/hyprstream-rpc/src/crypto/hybrid_kem.rs
+++ b/crates/hyprstream-rpc/src/crypto/hybrid_kem.rs
@@ -187,6 +187,16 @@ pub trait KemComponent {
 
     /// Decapsulate `ct` with `decap_key`, returning the shared secret.
     fn decapsulate(&self, decap_key: &[u8], ct: &[u8]) -> Result<Zeroizing<Vec<u8>>>;
+
+    /// Byte length of the deterministic seed consumed by
+    /// [`KemComponent::recipient_from_seed`].
+    fn seed_len(&self) -> usize;
+
+    /// Deterministically derive a recipient keypair from `seed` (length
+    /// [`KemComponent::seed_len`]), returning `(decap_key_bytes, encap_key_bytes)`.
+    /// Stable identity keys (e.g. `#mesh-kem`) use this so they survive restarts,
+    /// unlike the OsRng [`KemComponent::generate_recipient_keypair`].
+    fn recipient_from_seed(&self, seed: &[u8]) -> Result<(Zeroizing<Vec<u8>>, Vec<u8>)>;
 }
 
 fn arr32(b: &[u8]) -> Result<[u8; 32]> {
@@ -260,6 +270,21 @@ impl KemComponent for X25519Kem {
         }
         Ok(Zeroizing::new(ss.to_bytes().to_vec()))
     }
+
+    fn seed_len(&self) -> usize {
+        32
+    }
+
+    fn recipient_from_seed(&self, seed: &[u8]) -> Result<(Zeroizing<Vec<u8>>, Vec<u8>)> {
+        // The 32-byte seed is the X25519 secret scalar (clamped internally by
+        // `x25519-dalek` at DH time); `to_bytes()` round-trips it.
+        let sk = StaticSecret::from(arr32(seed)?);
+        let pk = PublicKey::from(&sk);
+        Ok((
+            Zeroizing::new(sk.to_bytes().to_vec()),
+            pk.to_bytes().to_vec(),
+        ))
+    }
 }
 
 /// ML-KEM-768 (FIPS 203) component. The recipient decapsulation key is carried
@@ -299,6 +324,19 @@ impl KemComponent for MlKem768Kem {
         let dk = pq::ml_kem_decaps_from_seed(&seed);
         let ss = pq::ml_kem_decapsulate(&dk, ct)?;
         Ok(Zeroizing::new(ss.to_vec()))
+    }
+
+    fn seed_len(&self) -> usize {
+        64
+    }
+
+    fn recipient_from_seed(&self, seed: &[u8]) -> Result<(Zeroizing<Vec<u8>>, Vec<u8>)> {
+        // FIPS 203 expandedPrivateKey seed `d ‖ z` (64 bytes); the decap key is
+        // carried as this seed (matching `decapsulate`).
+        let s = arr64(seed)?;
+        let dk = pq::ml_kem_decaps_from_seed(&s);
+        let ek_bytes = pq::ml_kem_ek_of_dk(&dk);
+        Ok((Zeroizing::new(seed.to_vec()), ek_bytes))
     }
 }
 
@@ -524,6 +562,49 @@ pub fn generate_recipient(suite: SuiteId) -> Result<RecipientKeypair> {
     })
 }
 
+/// Deterministically build a recipient keypair for `suite` from per-component
+/// seeds — one per suite component, in suite order, each of that component's
+/// [`KemComponent::seed_len`].
+///
+/// Used for stable identity keys such as `#mesh-kem` (whose component seeds are
+/// HKDF-derived from the node Ed25519 root, see
+/// `crate::node_identity::derive_mesh_kem_recipient`), which MUST be stable
+/// across restarts — unlike [`generate_recipient`], which draws fresh OS
+/// randomness each call.
+pub fn recipient_from_seeds(suite: SuiteId, seeds: &[&[u8]]) -> Result<RecipientKeypair> {
+    let comps = suite.components();
+    if seeds.len() != comps.len() {
+        bail!(
+            "suite {} needs {} component seeds, got {}",
+            suite.as_str(),
+            comps.len(),
+            seeds.len()
+        );
+    }
+    let mut dks = Vec::with_capacity(comps.len());
+    let mut eks = Vec::with_capacity(comps.len());
+    for (i, &kem) in comps.iter().enumerate() {
+        let c = kem.component();
+        if seeds[i].len() != c.seed_len() {
+            bail!(
+                "suite {} component {:?} seed length {} != expected {}",
+                suite.as_str(),
+                kem,
+                seeds[i].len(),
+                c.seed_len()
+            );
+        }
+        let (dk, ek) = c.recipient_from_seed(seeds[i])?;
+        dks.push(dk);
+        eks.push(ek);
+    }
+    Ok(RecipientKeypair {
+        suite_id: suite,
+        dks,
+        eks,
+    })
+}
+
 /// Encapsulate to a recipient's public material, returning the wire
 /// [`HybridKemMaterial`] (the per-component ciphertexts) and the combined 32-byte
 /// shared secret.
@@ -617,6 +698,93 @@ pub fn decapsulate(
     }
 
     Ok(combine(suite, &sss, &cts, &eks))
+}
+
+// ============================================================================
+// #mesh-kem trust store (kid-anchored recipient public keys)
+// ============================================================================
+
+/// Resolves the anchored hybrid-KEM recipient public material for a peer's
+/// Ed25519 signer identity (its `#mesh-kem` keyAgreement key).
+///
+/// The confidentiality-side mirror of [`crate::envelope::PqTrustStore`]: the
+/// binding is established out-of-band (DID `keyAgreement` resolution / peer
+/// attestation), NEVER self-asserted on the wire. **Fail-closed:** an unanchored
+/// peer returns `None`, and callers MUST reject rather than fall back to a
+/// classical or self-asserted key (epic #550 principle 1 — mandatory hybrid, no
+/// in-band downgrade).
+pub trait KemTrustStore: Send + Sync {
+    /// The anchored `#mesh-kem` recipient public bound to `ed25519_pubkey`, or
+    /// `None` if unknown (caller fails closed).
+    fn kem_recipient_for(&self, ed25519_pubkey: &[u8; 32]) -> Option<RecipientPublic>;
+}
+
+/// In-memory kid-anchored `#mesh-kem` trust store: Ed25519 signer identity →
+/// anchored hybrid-KEM [`RecipientPublic`]. Bindings come from the node's own
+/// hybrid identity and from attested peer identities (their resolved DID
+/// `keyAgreement`), established out-of-band — never from wire-asserted material.
+#[derive(Default, Clone)]
+pub struct KeyedKemTrustStore {
+    bindings: std::collections::HashMap<[u8; 32], RecipientPublic>,
+}
+
+impl KeyedKemTrustStore {
+    /// Create an empty store.
+    pub fn new() -> Self {
+        Self {
+            bindings: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Bind an Ed25519 signer identity to its anchored `#mesh-kem` recipient public.
+    pub fn bind(&mut self, ed25519_pubkey: [u8; 32], recipient: RecipientPublic) {
+        self.bindings.insert(ed25519_pubkey, recipient);
+    }
+
+    /// Number of bindings.
+    pub fn len(&self) -> usize {
+        self.bindings.len()
+    }
+
+    /// Whether the store has no bindings.
+    pub fn is_empty(&self) -> bool {
+        self.bindings.is_empty()
+    }
+}
+
+impl KemTrustStore for KeyedKemTrustStore {
+    fn kem_recipient_for(&self, ed25519_pubkey: &[u8; 32]) -> Option<RecipientPublic> {
+        self.bindings.get(ed25519_pubkey).cloned()
+    }
+}
+
+// ============================================================================
+// #mesh-kem prekey seam (forward secrecy for the one-shot envelope, S4 / #555)
+// ============================================================================
+
+/// A short-lived, rotated `#mesh-kem` recipient prekey.
+///
+/// The one-shot request envelope (#555) encapsulates to a *published* recipient
+/// key, so — unlike streams — it cannot get forward secrecy from a per-session
+/// ephemeral key. The standard remedy (X3DH-style) is to publish short-lived
+/// rotated prekeys and drop the matching decapsulation key after expiry, so a
+/// later key compromise cannot decrypt past envelopes. This type is the seam:
+/// the publisher advertises the current `recipient` + `key_id`; the decryptor
+/// keeps the matching [`RecipientKeypair`] only until `not_after_unix_ms`.
+///
+/// The full rotation scheduler + keystore are follow-up work (tracked under
+/// #552); this fixes the wire/identity shape that #555 binds to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KemPrekey {
+    /// Stable id of this prekey, bound into the envelope so the decryptor can
+    /// select the matching decapsulation key.
+    pub key_id: [u8; 16],
+    /// The rotated recipient public material (suite + encap keys).
+    pub recipient: RecipientPublic,
+    /// Expiry (Unix ms). The decryptor MUST drop the matching decap key after
+    /// this instant, which is what gives the envelope forward secrecy across
+    /// rotation.
+    pub not_after_unix_ms: i64,
 }
 
 #[cfg(test)]
@@ -845,5 +1013,60 @@ mod tests {
         // or length-prefixing) was altered — review before updating.
         const KAT: &str = "00f1efc789785e571aa6e985a9f2567cca39dfc7dc272b514380b212524ce031";
         assert_eq!(got, KAT, "combiner KAT changed — construction altered!");
+    }
+
+    // ---- deterministic seed-based recipient (stable identity keys, S1) ----
+
+    #[test]
+    fn recipient_from_seeds_is_deterministic_and_roundtrips() {
+        let suite = SuiteId::HyKemX25519MlKem768;
+        let x_seed = [0x07u8; 32];
+        let m_seed = [0x09u8; 64];
+        let seeds: [&[u8]; 2] = [&x_seed, &m_seed];
+
+        let kp1 = recipient_from_seeds(suite, &seeds).unwrap();
+        let kp2 = recipient_from_seeds(suite, &seeds).unwrap();
+        // Same seeds → identical published encap keys (stable across restarts).
+        assert_eq!(kp1.public(), kp2.public());
+
+        // The deterministic recipient interoperates with encap/decap.
+        let (material, ss_enc) = encapsulate_to(&kp1.public()).unwrap();
+        let ss_dec = decapsulate(&kp2, &material).unwrap();
+        assert_eq!(*ss_enc, *ss_dec);
+    }
+
+    #[test]
+    fn recipient_from_seeds_rejects_wrong_lengths() {
+        let suite = SuiteId::HyKemX25519MlKem768;
+        let bad_x: [&[u8]; 2] = [&[0u8; 31], &[0u8; 64]];
+        assert!(recipient_from_seeds(suite, &bad_x).is_err());
+        let bad_m: [&[u8]; 2] = [&[0u8; 32], &[0u8; 63]];
+        assert!(recipient_from_seeds(suite, &bad_m).is_err());
+        let wrong_count: [&[u8]; 1] = [&[0u8; 32]];
+        assert!(recipient_from_seeds(suite, &wrong_count).is_err());
+    }
+
+    // ---- #mesh-kem trust store (fail-closed, S1) ----
+
+    #[test]
+    fn kem_trust_store_binds_and_fails_closed() {
+        let suite = SuiteId::HyKemX25519MlKem768;
+        let kp = generate_recipient(suite).unwrap();
+        let id = [0x42u8; 32];
+
+        let mut store = KeyedKemTrustStore::new();
+        assert!(store.is_empty());
+        assert!(
+            store.kem_recipient_for(&id).is_none(),
+            "unanchored identity must resolve to None (fail closed)"
+        );
+
+        store.bind(id, kp.public());
+        assert_eq!(store.len(), 1);
+        assert_eq!(store.kem_recipient_for(&id), Some(kp.public()));
+        assert!(
+            store.kem_recipient_for(&[0x43u8; 32]).is_none(),
+            "a different identity stays unanchored"
+        );
     }
 }

--- a/crates/hyprstream-rpc/src/node_identity.rs
+++ b/crates/hyprstream-rpc/src/node_identity.rs
@@ -80,6 +80,58 @@ pub fn derive_mesh_mldsa_key(ed25519_key: &SigningKey) -> crate::crypto::pq::MlD
     sk
 }
 
+/// HKDF purpose-label namespace for the node's `#mesh-kem` hybrid keyAgreement
+/// identity (S1 / #552). Distinct from the Ed25519, JWT, and [`MESH_MLDSA_PURPOSE`]
+/// labels so the KEM identity is key-separated (PQUIP key separation). Each suite
+/// component derives an independent seed under a per-component sub-label
+/// `"<MESH_KEM_PURPOSE>/<kem>"`.
+pub const MESH_KEM_PURPOSE: &str = "hyprstream-mesh-kem-v1";
+
+/// Expand `out.len()` bytes from the node root via HKDF-SHA256 (node-identity
+/// salt, given `info`). Used for the variable-length `#mesh-kem` component seeds
+/// (X25519 = 32B, ML-KEM-768 = 64B), which [`derive_purpose_key`] (fixed 32B)
+/// cannot produce.
+fn expand_purpose_bytes(root_key: &SigningKey, info: &[u8], out: &mut [u8]) {
+    let hk = Hkdf::<Sha256>::new(Some(NODE_IDENTITY_SALT), &root_key.to_bytes());
+    #[allow(clippy::expect_used)] // HKDF-SHA256 expand of <= 255*32 bytes cannot fail
+    hk.expand(info, out)
+        .expect("HKDF-SHA256 expand within the length bound cannot fail");
+}
+
+/// Deterministically derive the node's `#mesh-kem` hybrid-KEM recipient keypair
+/// (S1 / #552) from its persisted Ed25519 root key — the confidentiality-side
+/// parallel of [`derive_mesh_mldsa_key`].
+///
+/// Each suite component gets an independent HKDF-derived seed under a distinct
+/// per-component sub-label (`"<MESH_KEM_PURPOSE>/<kem>"`), so the X25519 and
+/// ML-KEM-768 legs are independent of each other and key-separated from the
+/// Ed25519 identity and the `#mesh-mldsa` key. Stable across restarts (no key
+/// file). The published [`crate::crypto::hybrid_kem::RecipientPublic`] is what
+/// peers anchor in their [`crate::crypto::hybrid_kem::KemTrustStore`] (resolved
+/// from the DID `keyAgreement` set).
+pub fn derive_mesh_kem_recipient(
+    ed25519_key: &SigningKey,
+) -> anyhow::Result<crate::crypto::hybrid_kem::RecipientKeypair> {
+    use crate::crypto::hybrid_kem::{recipient_from_seeds, KemId, SuiteId};
+    let suite = SuiteId::HyKemX25519MlKem768;
+    // Fail closed if the pinned suite's shape ever changes out from under this
+    // hard-coded per-component seeding (a new suite must update this derivation).
+    debug_assert_eq!(suite.components(), &[KemId::X25519, KemId::MlKem768]);
+
+    let x_info = format!("{MESH_KEM_PURPOSE}/x25519");
+    let m_info = format!("{MESH_KEM_PURPOSE}/mlkem768");
+    let mut x_seed = [0u8; 32];
+    let mut m_seed = [0u8; 64];
+    expand_purpose_bytes(ed25519_key, x_info.as_bytes(), &mut x_seed);
+    expand_purpose_bytes(ed25519_key, m_info.as_bytes(), &mut m_seed);
+
+    let seeds: [&[u8]; 2] = [&x_seed, &m_seed];
+    let kp = recipient_from_seeds(suite, &seeds);
+    x_seed.zeroize();
+    m_seed.zeroize();
+    kp
+}
+
 /// A purpose-derived Ed25519 signing identity.
 /// Inner SigningKey is zeroized on drop via ed25519-dalek's `zeroize` feature.
 struct DerivedIdentity {
@@ -445,6 +497,48 @@ mod tests {
             salted.verifying_key().to_bytes(),
             unsalted.verifying_key().to_bytes(),
             "Salted and unsalted HKDF must produce different keys"
+        );
+    }
+
+    // ---- #mesh-kem hybrid keyAgreement identity (S1 / #552) ----
+
+    #[allow(clippy::unwrap_used)]
+    #[test]
+    fn mesh_kem_recipient_is_deterministic() {
+        // Same node root must derive the same #mesh-kem public material so it
+        // survives restarts without a key file.
+        let root = SigningKey::from_bytes(&[5u8; 32]);
+        let a = derive_mesh_kem_recipient(&root).unwrap();
+        let b = derive_mesh_kem_recipient(&root).unwrap();
+        assert_eq!(a.public(), b.public());
+    }
+
+    #[allow(clippy::unwrap_used)]
+    #[test]
+    fn mesh_kem_recipient_differs_per_node() {
+        let a = derive_mesh_kem_recipient(&SigningKey::from_bytes(&[1u8; 32])).unwrap();
+        let b = derive_mesh_kem_recipient(&SigningKey::from_bytes(&[2u8; 32])).unwrap();
+        assert_ne!(a.public(), b.public());
+    }
+
+    #[allow(clippy::unwrap_used)]
+    #[test]
+    fn mesh_kem_is_key_separated() {
+        // The #mesh-kem X25519 leg must differ from the Ed25519 identity key and
+        // from the bare purpose-key derivation (PQUIP key separation).
+        let root = SigningKey::from_bytes(&[9u8; 32]);
+        let pubs = derive_mesh_kem_recipient(&root).unwrap().public();
+        let x25519_ek = &pubs.eks[0]; // suite component 0 = X25519 (32 bytes)
+        assert_ne!(
+            x25519_ek.as_slice(),
+            &root.verifying_key().to_bytes()[..],
+            "#mesh-kem X25519 key must differ from the Ed25519 identity key"
+        );
+        let bare = derive_purpose_key(&root, MESH_KEM_PURPOSE).to_bytes();
+        assert_ne!(
+            x25519_ek.as_slice(),
+            &bare[..],
+            "per-component sub-label seed must differ from the bare purpose key"
         );
     }
 }

--- a/crates/hyprstream/src/services/oauth/did_document.rs
+++ b/crates/hyprstream/src/services/oauth/did_document.rs
@@ -184,6 +184,108 @@ fn mldsa65_verification_method(did: &str, key_id: &str, vk_bytes: &[u8]) -> Valu
     })
 }
 
+// ============================================================================
+// #mesh-kem hybrid keyAgreement identity (S1 / #552, epic #550)
+//
+// NOTE: this crate requires libtorch to compile, which was unavailable in the
+// implementing fork — the helpers below are faithful mirrors of the working
+// `#mesh-pq` / p256 multibase helpers above but are NOT compile-verified here.
+// Integration into `build_did_document` (push these into a `keyAgreement` array)
+// is a deliberate follow-up: it touches the builder signature + every caller, so
+// it is left to a pass that can compile the `hyprstream` crate.
+// ============================================================================
+
+/// multicodec `x25519-pub` unsigned-varint prefix (`0xec` → bytes `0xec 0x01`).
+const MULTICODEC_X25519_PUB: [u8; 2] = [0xec, 0x01];
+
+/// multicodec `ml-kem-768-pub` unsigned-varint prefix.
+///
+/// PROVISIONAL: code point `0x120b` (ML-KEM-768 / FIPS 203 encapsulation key) as
+/// an unsigned varint → bytes `0x8b 0x24` (same shape as `ml-dsa-65-pub`
+/// `0x1211` → `0x91 0x24`). **Confirm against the multiformats multicodec
+/// registry / draft-ietf-cose-mlkem before production** — the exact ML-KEM code
+/// point must match what peers decode.
+const MULTICODEC_ML_KEM_768_PUB: [u8; 2] = [0x8b, 0x24];
+
+/// Multibase z-encode (base58btc, multicodec-prefixed) a raw X25519 encapsulation
+/// key (32 bytes) as a `Multikey` `publicKeyMultibase`.
+#[allow(dead_code)] // wired into build_did_document's keyAgreement set by the #552 follow-up
+fn x25519_to_multibase(ek_bytes: &[u8]) -> String {
+    let mut payload = Vec::with_capacity(MULTICODEC_X25519_PUB.len() + ek_bytes.len());
+    payload.extend_from_slice(&MULTICODEC_X25519_PUB);
+    payload.extend_from_slice(ek_bytes);
+    format!("z{}", bs58::encode(payload).into_string())
+}
+
+/// Multibase z-encode a raw ML-KEM-768 encapsulation key (1184 bytes) as a
+/// `Multikey` `publicKeyMultibase`.
+#[allow(dead_code)]
+fn mlkem768_to_multibase(ek_bytes: &[u8]) -> String {
+    let mut payload = Vec::with_capacity(MULTICODEC_ML_KEM_768_PUB.len() + ek_bytes.len());
+    payload.extend_from_slice(&MULTICODEC_ML_KEM_768_PUB);
+    payload.extend_from_slice(ek_bytes);
+    format!("z{}", bs58::encode(payload).into_string())
+}
+
+/// Build the `#mesh-kem` **keyAgreement** verification methods for the node's
+/// hybrid-KEM identity (S1 / #552): one `Multikey` per suite leg (X25519 +
+/// ML-KEM-768). These belong in the DID document's `keyAgreement` relationship
+/// (NOT `verificationMethod`/`assertionMethod` — they are key-agreement, not
+/// signing, keys). Peers reconstruct the policy-pinned hybrid recipient
+/// (`SuiteId::HyKemX25519MlKem768`) from the two legs and anchor it in their
+/// `crate`-side `KemTrustStore`.
+///
+/// `x25519_ek` / `mlkem768_ek` are the raw encapsulation keys in suite-component
+/// order, from `hyprstream_rpc::node_identity::derive_mesh_kem_recipient(..)
+/// .public().eks`.
+#[allow(dead_code)] // build_did_document integration is the #552 follow-up (needs libtorch to verify)
+fn mesh_kem_key_agreement_methods(did: &str, x25519_ek: &[u8], mlkem768_ek: &[u8]) -> Vec<Value> {
+    vec![
+        json!({
+            "id": format!("{did}#mesh-kem-x25519"),
+            "type": "Multikey",
+            "controller": did,
+            "publicKeyMultibase": x25519_to_multibase(x25519_ek),
+        }),
+        json!({
+            "id": format!("{did}#mesh-kem-mlkem768"),
+            "type": "Multikey",
+            "controller": did,
+            "publicKeyMultibase": mlkem768_to_multibase(mlkem768_ek),
+        }),
+    ]
+}
+
+#[cfg(test)]
+mod mesh_kem_did_tests {
+    use super::*;
+
+    #[test]
+    fn mesh_kem_methods_shape_and_multicodec() {
+        let did = "did:web:example.com";
+        let x_ek = [0x11u8; 32];
+        let m_ek = [0x22u8; 1184];
+        let vms = mesh_kem_key_agreement_methods(did, &x_ek, &m_ek);
+        assert_eq!(vms.len(), 2);
+        assert_eq!(vms[0]["id"], format!("{did}#mesh-kem-x25519"));
+        assert_eq!(vms[0]["type"], "Multikey");
+        assert_eq!(vms[1]["id"], format!("{did}#mesh-kem-mlkem768"));
+        assert_eq!(vms[1]["type"], "Multikey");
+
+        // publicKeyMultibase = 'z' + base58btc(multicodec ‖ key); decode + check.
+        let mb = vms[0]["publicKeyMultibase"].as_str().unwrap();
+        assert!(mb.starts_with('z'));
+        let decoded = bs58::decode(&mb[1..]).into_vec().unwrap();
+        assert_eq!(&decoded[..2], &MULTICODEC_X25519_PUB);
+        assert_eq!(decoded.len(), 2 + 32);
+
+        let mb2 = vms[1]["publicKeyMultibase"].as_str().unwrap();
+        let decoded2 = bs58::decode(&mb2[1..]).into_vec().unwrap();
+        assert_eq!(&decoded2[..2], &MULTICODEC_ML_KEM_768_PUB);
+        assert_eq!(decoded2.len(), 2 + 1184);
+    }
+}
+
 /// Build a JWK fallback verification method (useful for consumers that
 /// don't speak Multibase but understand JWK).
 fn ed25519_verification_method_jwk(did: &str, key_id: &str, vk: &VerifyingKey) -> Value {


### PR DESCRIPTION
Part of #550, closes #552 **once the DID wiring below is completed + libtorch-verified**. Builds on S0 (#551).

PQ keyAgreement identity (`#mesh-kem`) — the key-distribution path the orphaned hybrid envelope KEM never had.

## Done + verified (hyprstream-rpc, libtorch-free)
- **Deterministic, key-separated derivation** (`node_identity.rs`): `MESH_KEM_PURPOSE = "hyprstream-mesh-kem-v1"`; per-leg HKDF-SHA256 (`…/x25519`→32B, `…/mlkem768`→64B seed) over the Ed25519 root. Separated from the Ed25519 identity and `#mesh-mldsa`; deterministic across restarts; seeds zeroized. Added `seed_len()`/`recipient_from_seed()` to S0's `KemComponent` + `recipient_from_seeds()`.
- **`KemTrustStore` (fail-closed)**: `KeyedKemTrustStore` mirroring `KeyedPqTrustStore`; unanchored identity → `None` (callers reject; no classical/self-asserted fallback).
- **`KemPrekey` seam** for S4's one-shot-envelope forward secrecy (rotation scheduler = follow-up).
- Tests: `node_identity::` 18 + `crypto::hybrid_kem::` 17 green.

## ⚠️ Remaining before merge (libtorch-gated)
- `did_document.rs` adds the `#mesh-kem` multibase/Multikey helpers (`x25519-pub`, `ml-kem-768-pub`) but they are **`#[allow(dead_code)]`, NOT wired into `build_did_document`** and **NOT compile-verified** (no libtorch in the build env). Needs: (1) wire the `keyAgreement` array into `build_did_document` (+ thread the param through all callers — cross-cutting), (2) a libtorch compile pass, (3) confirm the **provisional** ML-KEM-768 multicodec (`0x120b` / `[0x8b,0x24]`) against the multiformats registry / draft-ietf-cose-mlkem.

Do not merge until the three items above are resolved.
