### PR TITLE
feat(#554): S3 — hybrid PQ stream key agreement + epoch ratchet (rpc core)

### DIFF
--- a/crates/hyprstream-rpc/schema/common.capnp
+++ b/crates/hyprstream-rpc/schema/common.capnp
@@ -54,7 +54,8 @@ struct RequestEnvelope {
   authorization @4 :Authorization; # Authorization context
   delegationToken @5 :Text $optional;  # Delegation token relayed by a trusted service
   wth @6 :Data $fixedSize(32) $optional;  # SHA-256 of jwtToken (WIT binding)
-  clientDhPublic @7 :Data $fixedSize(32) $optional;  # Ephemeral DH public key for stream key derivation
+  clientDhPublic @7 :Data $fixedSize(32) $optional;  # LEGACY classical DH pubkey (removed at S5 #556; superseded by clientKemPublic)
+  clientKemPublic @8 :Data $optional;  # S3 #554: client ephemeral hybrid-KEM RecipientPublic.encode() (X25519+ML-KEM-768) for PQ stream key agreement
 }
 
 # Signed wrapper - signature covers serialized RequestEnvelope bytes

--- a/crates/hyprstream-rpc/schema/streaming.capnp
+++ b/crates/hyprstream-rpc/schema/streaming.capnp
@@ -227,6 +227,11 @@ struct StreamInfo {
   # first reach it supports (see `dial_stream`) and subscribes to `broadcastPath`.
   # Co-located clients ignore this and use the same-host UDS fast path.
   announcedAt @4 :List(Destination);
+  # S3 #554: server's hybrid-KEM ciphertexts (HybridKemMaterial.encode(),
+  # X25519+ML-KEM-768) — the client decapsulates with its ephemeral keypair to
+  # derive the same stream keys. Supersedes the classical `dhPublic` (kept for the
+  # legacy path until the S5 #556 fail-closed flip). Empty on the legacy path.
+  kemCiphertexts @5 :Data;
 }
 
 # Stream registration - wrapped in SignedEnvelope for authorization

--- a/crates/hyprstream-rpc/src/crypto/hybrid_kem.rs
+++ b/crates/hyprstream-rpc/src/crypto/hybrid_kem.rs
@@ -504,6 +504,75 @@ impl RecipientKeypair {
     }
 }
 
+impl RecipientPublic {
+    /// Canonical length-prefixed encoding of the recipient's per-component
+    /// encapsulation keys, mirroring [`HybridKemMaterial::encode`]:
+    /// `be16(suite_id) ‖ be16(n) ‖ Σ_i (be16(kem_id) ‖ be32(len) ‖ ek_bytes)`.
+    ///
+    /// This is what the stream client sends as its ephemeral public material
+    /// (`RequestEnvelope.clientKemPublic`, S3 #554), and what `#mesh-kem`
+    /// publishes for the envelope path (S4 #555).
+    pub fn encode(&self) -> Vec<u8> {
+        let comps = self.suite_id.components();
+        let mut out = Vec::new();
+        out.extend_from_slice(&self.suite_id.as_u16().to_be_bytes());
+        out.extend_from_slice(&(self.eks.len() as u16).to_be_bytes());
+        for (i, ek) in self.eks.iter().enumerate() {
+            // Component order is the suite's; tag each ek with its kem id so the
+            // decoder can fail closed on a reordered / wrong-suite encoding.
+            out.extend_from_slice(&comps[i].as_u16().to_be_bytes());
+            out.extend_from_slice(&(ek.len() as u32).to_be_bytes());
+            out.extend_from_slice(ek);
+        }
+        out
+    }
+
+    /// Parse + validate the canonical encoding. Rejects unknown suites/kem-ids,
+    /// wrong component count or order, wrong ek length, truncation, or trailing
+    /// bytes — fail-closed against malformed client public material.
+    pub fn decode(buf: &[u8]) -> Result<Self> {
+        let mut r = Reader { buf, pos: 0 };
+        let suite_id = SuiteId::from_u16(r.u16()?)
+            .ok_or_else(|| anyhow::anyhow!("unknown hybrid-KEM suite id"))?;
+        let n = r.u16()? as usize;
+        let comps = suite_id.components();
+        if n != comps.len() {
+            bail!(
+                "ek count {n} does not match suite {} ({} components)",
+                suite_id.as_str(),
+                comps.len()
+            );
+        }
+        let mut eks = Vec::with_capacity(n);
+        for (i, &want) in comps.iter().enumerate() {
+            let kem_id =
+                KemId::from_u16(r.u16()?).ok_or_else(|| anyhow::anyhow!("unknown kem id"))?;
+            if kem_id != want {
+                bail!(
+                    "ek {i} kem id {:?} does not match suite component {:?}",
+                    kem_id,
+                    want
+                );
+            }
+            let len = r.u32()? as usize;
+            let bytes = r.take(len)?.to_vec();
+            if bytes.len() != want.component().ek_len() {
+                bail!(
+                    "ek {i} ({:?}) length {} != expected {}",
+                    want,
+                    bytes.len(),
+                    want.component().ek_len()
+                );
+            }
+            eks.push(bytes);
+        }
+        if r.pos != buf.len() {
+            bail!("trailing bytes after recipient public material");
+        }
+        Ok(Self { suite_id, eks })
+    }
+}
+
 // ============================================================================
 // High-level hybrid KEM API
 // ============================================================================
@@ -845,5 +914,47 @@ mod tests {
         // or length-prefixing) was altered — review before updating.
         const KAT: &str = "00f1efc789785e571aa6e985a9f2567cca39dfc7dc272b514380b212524ce031";
         assert_eq!(got, KAT, "combiner KAT changed — construction altered!");
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod recipient_public_codec_tests {
+    use super::*;
+
+    #[test]
+    fn recipient_public_roundtrip() {
+        let kp = generate_recipient(SuiteId::HyKemX25519MlKem768).unwrap();
+        let pubmat = kp.public();
+        let enc = pubmat.encode();
+        let dec = RecipientPublic::decode(&enc).unwrap();
+        assert_eq!(dec, pubmat);
+        assert_eq!(dec.encode(), enc, "encoding is canonical");
+        // The decoded public actually works for encapsulation.
+        let (material, _secret) = encapsulate_to(&dec).unwrap();
+        assert_eq!(material.suite_id, SuiteId::HyKemX25519MlKem768);
+    }
+
+    #[test]
+    fn recipient_public_rejects_malformed() {
+        assert!(RecipientPublic::decode(&[]).is_err());
+        assert!(RecipientPublic::decode(b"garbage bytes here").is_err());
+        let kp = generate_recipient(SuiteId::HyKemX25519MlKem768).unwrap();
+        // Truncation.
+        let mut enc = kp.public().encode();
+        enc.truncate(enc.len() - 1);
+        assert!(RecipientPublic::decode(&enc).is_err());
+        // Trailing bytes.
+        let mut enc2 = kp.public().encode();
+        enc2.push(0xff);
+        assert!(RecipientPublic::decode(&enc2).is_err());
+    }
+
+    #[test]
+    fn recipient_public_rejects_wrong_ek_length() {
+        let kp = generate_recipient(SuiteId::HyKemX25519MlKem768).unwrap();
+        let mut bad = kp.public();
+        bad.eks[0] = vec![0u8; 31]; // wrong X25519 ek length (must be 32)
+        assert!(RecipientPublic::decode(&bad.encode()).is_err());
     }
 }

--- a/crates/hyprstream-rpc/src/crypto/key_exchange.rs
+++ b/crates/hyprstream-rpc/src/crypto/key_exchange.rs
@@ -197,7 +197,88 @@ pub fn derive_stream_keys(
     // Zeroize IKM containing the shared secret (mirrors derive_notification_keys).
     ikm.zeroize();
 
-    Ok(StreamKeys::with_ctrl(topic, mac_key, enc_key, ctrl_topic, ctrl_mac_key))
+    Ok(StreamKeys::with_ctrl(
+        topic,
+        mac_key,
+        enc_key,
+        ctrl_topic,
+        ctrl_mac_key,
+    ))
+}
+
+// ============================================================================
+// Hybrid post-quantum stream key agreement (S3 #554, epic #550)
+// ============================================================================
+//
+// Replaces the classical Ristretto255/X25519 stream DH with the S0 hybrid
+// multi-KEM (`crate::crypto::hybrid_kem`). The combiner secret is already
+// transcript-bound (it mixes every component ciphertext + recipient ek) and is
+// fed into `derive_stream_keys` as the IKM. The two 32-byte salt halves that
+// `derive_stream_keys` expects are domain-separated digests of the client public
+// material and the server ciphertexts — guaranteed distinct (different labels) so
+// the self-connection check never trips.
+//
+// Direction: stream data flows server -> client, so the CLIENT is the KEM
+// recipient (it decapsulates). The client sends a fresh ephemeral
+// `RecipientPublic` (forward secrecy via the ephemeral X25519 + ML-KEM legs); the
+// server encapsulates and returns the ciphertexts in `StreamInfo`.
+
+const HYBRID_CLIENT_SALT_CTX: &str = "hyprstream hybrid-stream client v1";
+const HYBRID_SERVER_SALT_CTX: &str = "hyprstream hybrid-stream server v1";
+
+/// Domain-separated 32-byte digest of handshake transcript bytes (a salt half
+/// for [`derive_stream_keys`]).
+fn hybrid_salt(label: &str, bytes: &[u8]) -> [u8; 32] {
+    derive_key(label, bytes)
+}
+
+/// Server side of the hybrid stream handshake (S3 #554).
+///
+/// `client_kem_public` is the client's encoded ephemeral
+/// [`RecipientPublic`](crate::crypto::hybrid_kem::RecipientPublic) from
+/// `RequestEnvelope.clientKemPublic`. Encapsulate to it, derive the stream keys
+/// from the hybrid combiner secret, and return the per-component ciphertexts to
+/// emit in `StreamInfo.kemCiphertexts`. Fail-closed on malformed/wrong-suite input.
+pub fn server_hybrid_stream_keys(
+    client_kem_public: &[u8],
+) -> EnvelopeResult<(crate::crypto::hybrid_kem::HybridKemMaterial, StreamKeys)> {
+    let client_pub = crate::crypto::hybrid_kem::RecipientPublic::decode(client_kem_public)
+        .map_err(|e| EnvelopeError::KeyExchange(format!("invalid client KEM public: {e}")))?;
+    let (material, secret) = crate::crypto::hybrid_kem::encapsulate_to(&client_pub)
+        .map_err(|e| EnvelopeError::KeyExchange(format!("hybrid encapsulate failed: {e}")))?;
+    let client_salt = hybrid_salt(HYBRID_CLIENT_SALT_CTX, client_kem_public);
+    let server_salt = hybrid_salt(HYBRID_SERVER_SALT_CTX, &material.encode());
+    let keys = derive_stream_keys(&secret, &client_salt, &server_salt)?;
+    Ok((material, keys))
+}
+
+/// Client side of the hybrid stream handshake (S3 #554).
+///
+/// Given the client's ephemeral
+/// [`RecipientKeypair`](crate::crypto::hybrid_kem::RecipientKeypair) and the
+/// server's encoded ciphertexts from `StreamInfo.kemCiphertexts`, decapsulate and
+/// derive the SAME [`StreamKeys`].
+pub fn client_hybrid_stream_keys(
+    keypair: &crate::crypto::hybrid_kem::RecipientKeypair,
+    kem_ciphertexts: &[u8],
+) -> EnvelopeResult<StreamKeys> {
+    let material = crate::crypto::hybrid_kem::HybridKemMaterial::decode(kem_ciphertexts)
+        .map_err(|e| EnvelopeError::KeyExchange(format!("invalid KEM ciphertexts: {e}")))?;
+    let secret = crate::crypto::hybrid_kem::decapsulate(keypair, &material)
+        .map_err(|e| EnvelopeError::KeyExchange(format!("hybrid decapsulate failed: {e}")))?;
+    let client_salt = hybrid_salt(HYBRID_CLIENT_SALT_CTX, &keypair.public().encode());
+    let server_salt = hybrid_salt(HYBRID_SERVER_SALT_CTX, kem_ciphertexts);
+    derive_stream_keys(&secret, &client_salt, &server_salt)
+}
+
+/// One-way epoch ratchet for long-lived streams (S3 #554 / #223).
+///
+/// Derive the next epoch's key from the current one via a one-way KDF: a
+/// compromise of the current epoch key cannot recover any earlier epoch (forward
+/// secrecy across rekeys). Bump `epoch`, ratchet the key, reset `seq` — keeping
+/// the `(epoch, seq)` AEAD nonce (see `crypto::cose_encrypt`) unique-forever.
+pub fn ratchet_stream_key(current: &[u8; 32]) -> Zeroizing<[u8; 32]> {
+    Zeroizing::new(derive_key("hyprstream stream ratchet v1", current))
 }
 
 // ============================================================================
@@ -540,9 +621,7 @@ mod ristretto_impl {
             .ok_or_else(|| EnvelopeError::KeyExchange("invalid blinding scalar".into()))?;
         let combined = secret.scalar() + r;
         if bool::from(combined.ct_eq(&Scalar::ZERO)) {
-            return Err(EnvelopeError::KeyExchange(
-                "combined scalar is zero".into(),
-            ));
+            return Err(EnvelopeError::KeyExchange("combined scalar is zero".into()));
         }
         let shared_point = their_pubkey.point() * combined;
         Ok(shared_point.compress().to_bytes())
@@ -555,7 +634,10 @@ mod ristretto_impl {
     /// Ristretto255 DH from raw scalar and pubkey bytes.
     ///
     /// Used by `BroadcastEncryptor` where typed key objects aren't available.
-    pub fn ristretto_dh_raw(secret_bytes: &[u8; 32], their_pub_bytes: &[u8; 32]) -> EnvelopeResult<[u8; 32]> {
+    pub fn ristretto_dh_raw(
+        secret_bytes: &[u8; 32],
+        their_pub_bytes: &[u8; 32],
+    ) -> EnvelopeResult<[u8; 32]> {
         let scalar = Scalar::from_canonical_bytes(*secret_bytes)
             .into_option()
             .ok_or_else(|| EnvelopeError::KeyExchange("invalid secret scalar".into()))?;
@@ -603,9 +685,9 @@ mod ristretto_impl {
             .ok_or_else(|| EnvelopeError::KeyExchange("invalid blinding scalar".into()))?;
         let compressed = CompressedRistretto::from_slice(subscriber_pub_bytes)
             .map_err(|_| EnvelopeError::KeyExchange("invalid subscriber pubkey length".into()))?;
-        let sub_point = compressed
-            .decompress()
-            .ok_or_else(|| EnvelopeError::KeyExchange("invalid subscriber ristretto point".into()))?;
+        let sub_point = compressed.decompress().ok_or_else(|| {
+            EnvelopeError::KeyExchange("invalid subscriber ristretto point".into())
+        })?;
         let blinded = sub_point + r * RISTRETTO_BASEPOINT_POINT;
         Ok(blinded.compress().to_bytes())
     }
@@ -613,9 +695,9 @@ mod ristretto_impl {
 
 #[cfg(not(feature = "fips"))]
 pub use ristretto_impl::{
-    blinded_dh, blinded_dh_raw, generate_ephemeral_keypair,
-    reconstruct_blinded_pub_raw, rerandomize_pubkey, ristretto_dh, ristretto_dh_raw,
-    RistrettoKeyExchange, RistrettoPublic, RistrettoSecret,
+    blinded_dh, blinded_dh_raw, generate_ephemeral_keypair, reconstruct_blinded_pub_raw,
+    rerandomize_pubkey, ristretto_dh, ristretto_dh_raw, RistrettoKeyExchange, RistrettoPublic,
+    RistrettoSecret,
 };
 
 // ============================================================================
@@ -827,7 +909,10 @@ mod tests {
         let mut invalid = [0u8; 32];
         invalid[31] = 0x80; // Set high bit - invalid for Ristretto
         let result = RistrettoPublic::from_bytes(&invalid);
-        assert!(result.is_none(), "Non-canonical encoding should be rejected");
+        assert!(
+            result.is_none(),
+            "Non-canonical encoding should be rejected"
+        );
     }
 
     #[cfg(not(feature = "fips"))]
@@ -874,9 +959,18 @@ mod tests {
         let keys1 = derive_stream_keys(&shared_secret, &client_pub, &server_pub)?;
         let keys2 = derive_stream_keys(&shared_secret, &client_pub, &server_pub)?;
 
-        assert_eq!(*keys1.enc_key, *keys2.enc_key, "enc_key must be deterministic");
-        assert_ne!(*keys1.enc_key, *keys1.mac_key, "enc_key must differ from mac_key");
-        assert_ne!(*keys1.enc_key, *keys1.ctrl_mac_key, "enc_key must differ from ctrl_mac_key");
+        assert_eq!(
+            *keys1.enc_key, *keys2.enc_key,
+            "enc_key must be deterministic"
+        );
+        assert_ne!(
+            *keys1.enc_key, *keys1.mac_key,
+            "enc_key must differ from mac_key"
+        );
+        assert_ne!(
+            *keys1.enc_key, *keys1.ctrl_mac_key,
+            "enc_key must differ from ctrl_mac_key"
+        );
         Ok(())
     }
 
@@ -1048,8 +1142,14 @@ mod tests {
 
         let keys = derive_stream_keys(&shared_secret, &client_pub, &server_pub)?;
 
-        assert_ne!(keys.topic, keys.ctrl_topic, "ctrl_topic must differ from data topic");
-        assert_ne!(*keys.mac_key, *keys.ctrl_mac_key, "ctrl_mac_key must differ from data mac_key");
+        assert_ne!(
+            keys.topic, keys.ctrl_topic,
+            "ctrl_topic must differ from data topic"
+        );
+        assert_ne!(
+            *keys.mac_key, *keys.ctrl_mac_key,
+            "ctrl_mac_key must differ from data mac_key"
+        );
         Ok(())
     }
 
@@ -1122,5 +1222,67 @@ mod tests {
         assert_ne!(client_keys.topic, client_keys.ctrl_topic);
         assert_ne!(*client_keys.mac_key, *client_keys.ctrl_mac_key);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod hybrid_stream_tests {
+    use super::*;
+    use crate::crypto::hybrid_kem::{generate_recipient, SuiteId};
+
+    #[test]
+    fn hybrid_stream_handshake_roundtrip() {
+        // Client makes a fresh ephemeral hybrid keypair + sends its public; server
+        // encapsulates + derives keys; client decapsulates + derives the SAME keys.
+        let client_kp = generate_recipient(SuiteId::HyKemX25519MlKem768).unwrap();
+        let client_pub_enc = client_kp.public().encode();
+
+        let (material, server_keys) = server_hybrid_stream_keys(&client_pub_enc).unwrap();
+        let client_keys = client_hybrid_stream_keys(&client_kp, &material.encode()).unwrap();
+
+        assert_eq!(server_keys.topic, client_keys.topic);
+        assert_eq!(*server_keys.mac_key, *client_keys.mac_key);
+        assert_eq!(*server_keys.enc_key, *client_keys.enc_key);
+        assert_eq!(server_keys.ctrl_topic, client_keys.ctrl_topic);
+        assert_eq!(*server_keys.ctrl_mac_key, *client_keys.ctrl_mac_key);
+    }
+
+    #[test]
+    fn hybrid_stream_wrong_keypair_diverges() {
+        let client_kp = generate_recipient(SuiteId::HyKemX25519MlKem768).unwrap();
+        let (material, server_keys) =
+            server_hybrid_stream_keys(&client_kp.public().encode()).unwrap();
+        // A different keypair → different decapsulated secret (ML-KEM implicit
+        // rejection + different X25519 DH) AND a different transcript salt → keys diverge.
+        let other_kp = generate_recipient(SuiteId::HyKemX25519MlKem768).unwrap();
+        let other_keys = client_hybrid_stream_keys(&other_kp, &material.encode()).unwrap();
+        assert_ne!(server_keys.topic, other_keys.topic);
+        assert_ne!(*server_keys.mac_key, *other_keys.mac_key);
+    }
+
+    #[test]
+    fn hybrid_stream_rejects_malformed_client_public() {
+        // Fail-closed: a classical-only / missing / garbage clientKemPublic is rejected.
+        assert!(server_hybrid_stream_keys(b"not a recipient public").is_err());
+        assert!(server_hybrid_stream_keys(&[]).is_err());
+    }
+
+    #[test]
+    fn hybrid_stream_rejects_malformed_ciphertexts() {
+        let client_kp = generate_recipient(SuiteId::HyKemX25519MlKem768).unwrap();
+        assert!(client_hybrid_stream_keys(&client_kp, b"garbage").is_err());
+        assert!(client_hybrid_stream_keys(&client_kp, &[]).is_err());
+    }
+
+    #[test]
+    fn epoch_ratchet_is_one_way_and_deterministic() {
+        let k0 = [7u8; 32];
+        let k1 = ratchet_stream_key(&k0);
+        let k1b = ratchet_stream_key(&k0);
+        assert_eq!(*k1, *k1b, "ratchet must be deterministic");
+        assert_ne!(*k1, k0, "ratchet must advance the key");
+        let k2 = ratchet_stream_key(&k1);
+        assert_ne!(*k2, *k1, "each epoch key differs");
     }
 }

--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -218,6 +218,12 @@ pub struct StreamContext {
     /// one-time per-stream snapshot (the documented compat source), not a
     /// per-`reach()`-call global read.
     reach_config: crate::moq_stream::ProducerReachConfig,
+
+    /// Hybrid KEM ciphertexts to emit in `StreamInfo.kemCiphertexts` (S3 #554).
+    /// `Some` on the hybrid post-quantum path ([`from_hybrid`](Self::from_hybrid));
+    /// `None` on the legacy classical [`from_dh`](Self::from_dh) and the keyless
+    /// [`new`](Self::new) paths.
+    kem_ciphertexts: Option<Vec<u8>>,
 }
 
 impl StreamContext {
@@ -244,6 +250,8 @@ impl StreamContext {
             // which never call `reach()`); default to an empty reach config. A
             // networked producer threads a real one via `with_reach_config`.
             reach_config: crate::moq_stream::ProducerReachConfig::default(),
+            // Keyless path: no hybrid KEM material.
+            kem_ciphertexts: None,
         }
     }
 
@@ -290,7 +298,56 @@ impl StreamContext {
             // `with_reach_config` (prepare_stream), making the base reach fully
             // per-stream rather than global-sourced.
             reach_config: crate::moq_stream::global_reach_config(),
+            // Classical (legacy) path: no hybrid KEM material; the client keys
+            // off the server ephemeral `dhPublic`. Removed at the S5 fail-closed
+            // flip (#556) once all call-sites use `from_hybrid`.
+            kem_ciphertexts: None,
         })
+    }
+
+    /// Create a stream context via the **hybrid post-quantum** handshake (S3 #554).
+    ///
+    /// `client_kem_public` is the client's encoded ephemeral `RecipientPublic`
+    /// (from `RequestEnvelope.clientKemPublic`). The server encapsulates to it and
+    /// derives the stream keys from the hybrid combiner secret; the per-component
+    /// ciphertexts are stored in [`kem_ciphertexts`](Self::kem_ciphertexts) for
+    /// emission in `StreamInfo.kemCiphertexts`. Forward secrecy comes from the
+    /// client's ephemeral keypair (X25519 + ML-KEM legs).
+    ///
+    /// Fail-closed: a malformed / wrong-suite `client_kem_public` is rejected.
+    /// This is the post-quantum replacement for [`from_dh`](Self::from_dh).
+    pub fn from_hybrid(client_kem_public: &[u8]) -> Result<Self> {
+        let (material, keys) =
+            crate::crypto::key_exchange::server_hybrid_stream_keys(client_kem_public)
+                .map_err(|e| anyhow::anyhow!("hybrid stream handshake: {e}"))?;
+
+        let stream_id = format!("stream-{}", uuid::Uuid::new_v4());
+
+        Ok(Self {
+            stream_id,
+            topic: keys.topic,
+            mac_key: *keys.mac_key,
+            // Hybrid path: AEAD ON for the mesh stream plane (#321), keyed by the
+            // post-quantum combiner secret.
+            enc_key: Some(*keys.enc_key),
+            // No classical server ephemeral pubkey on the hybrid path; the client
+            // keys off `kem_ciphertexts`, not `dhPublic`.
+            server_pubkey: [0u8; 32],
+            ctrl_topic: keys.ctrl_topic,
+            ctrl_mac_key: *keys.ctrl_mac_key,
+            cancel_token: CancellationToken::new(),
+            qos: crate::stream_info::StreamOpt::default(),
+            relay_choice: crate::moq_stream::RelayChoice::default(),
+            reach_config: crate::moq_stream::global_reach_config(),
+            kem_ciphertexts: Some(material.encode()),
+        })
+    }
+
+    /// The hybrid KEM ciphertexts to emit in `StreamInfo.kemCiphertexts` (S3 #554):
+    /// `Some` on the hybrid path ([`from_hybrid`](Self::from_hybrid)), `None`
+    /// otherwise.
+    pub fn kem_ciphertexts(&self) -> Option<&[u8]> {
+        self.kem_ciphertexts.as_deref()
     }
 
     /// Get the stream ID (for logging/display).


### PR DESCRIPTION
Part of #550, advances #554 (S3). Builds on S0+S2. **rpc-crypto core; service call-sites deferred to the libtorch pass + S5.**

Replaces the classical Ristretto255 stream DH with the S0 hybrid multi-KEM.

## Construction
Stream data flows server→client, so the **client is the KEM recipient**: it makes a *fresh ephemeral* hybrid `RecipientKeypair` per stream (FS via the X25519 + ML-KEM legs) and sends `RecipientPublic.encode()` as `RequestEnvelope.clientKemPublic @8`. Server `encapsulate_to` → emits `HybridKemMaterial` as `StreamInfo.kemCiphertexts @5`; client `decapsulate`s to the same 32-byte combiner secret. That secret is the IKM to the unchanged `derive_stream_keys`; the two salt halves are label-distinct transcript digests of the client public material and the server ciphertexts (so the self-connection check never trips and both sides derive identical keys). Fail-closed on malformed/missing/wrong-suite input.

**Epoch ratchet (#223):** `ratchet_stream_key(k) = KDF("hyprstream stream ratchet v1", k)` — one-way, so a compromised epoch key can't recover earlier epochs. Bump epoch + ratchet + reset seq → `(epoch,seq)` AEAD nonce (S2) stays unique-forever.

## Files
`hybrid_kem.rs` (+`RecipientPublic::{encode,decode}`), `key_exchange.rs` (+`server_hybrid_stream_keys`/`client_hybrid_stream_keys`/`ratchet_stream_key`), `streaming.rs` (+`StreamContext::from_hybrid` + `kem_ciphertexts`), `common.capnp` (RequestEnvelope.clientKemPublic @8), `streaming.capnp` (StreamInfo.kemCiphertexts @5). Only touches `RequestEnvelope` (S4 owns `SignedEnvelope`).

## Tests
`crypto::` 132 pass (hybrid handshake round-trip, wrong-keypair divergence, malformed/fail-closed rejection, ratchet one-way/deterministic, `RecipientPublic` codec round-trip/truncation/wrong-len); `stream` 64 pass; clippy clean; wasm32 only pre-existing `web_sys` errors.

## Deferred (libtorch-gated service wiring + S5)
Client request builder (gen ephemeral keypair, set `clientKemPublic`); server inference path (`from_hybrid` + emit ciphertexts); consumer open path (`client_hybrid_stream_keys`); `moq_stream.rs` publisher ratchet loop (epoch still 0); removing the classical `from_dh`/`clientDhPublic` + enforcing fail-closed = S5 (#556).

Reviewed by the orchestrating agent: handshake direction, both-sides key agreement, salt distinctness, ratchet one-wayness, fail-closed handling.
