### PR TITLE
feat(#563): canonical Did/did:key identity type ( field-level codegen)

### DIFF
--- a/crates/hyprstream-discovery/schema/discovery.capnp
+++ b/crates/hyprstream-discovery/schema/discovery.capnp
@@ -11,6 +11,7 @@ using import "/common.capnp".ErrorInfo;
 using import "/annotations.capnp".mcpScope;
 using import "/annotations.capnp".mcpDescription;
 using import "/annotations.capnp".optional;
+using import "/annotations.capnp".domainType;
 
 # Unified discovery request with union discriminator
 struct DiscoveryRequest {
@@ -217,14 +218,14 @@ struct EntityStatement {
 # Request: push a service's COSE_KeySet (CBOR) for envelope-signing keys
 struct RegisterEnvelopeKeysetRequest {
   # did:web of the service this keyset belongs to
-  serviceDid @0 :Text;
+  serviceDid @0 :Text $domainType("hyprstream_rpc::identity::Did");
   # CBOR-encoded COSE_KeySet (RFC 9052 §7) containing the service's envelope verification keys
   coseKeysetCbor @1 :Data;
 }
 
 # Cached envelope COSE_KeySet
 struct EnvelopeKeyset {
-  serviceDid @0 :Text;
+  serviceDid @0 :Text $domainType("hyprstream_rpc::identity::Did");
   coseKeysetCbor @1 :Data;
   fetchedAt @2 :Int64;
 }

--- a/crates/hyprstream-discovery/src/lib.rs
+++ b/crates/hyprstream-discovery/src/lib.rs
@@ -52,3 +52,74 @@ pub use generated::discovery_client::{
     GetRecordRequest, RecordCar,
     dispatch_discovery, serialize_response,
 };
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod did_field_domain_type_tests {
+    use super::*;
+    use generated::discovery_client::{EnvelopeKeyset, RegisterEnvelopeKeysetRequest};
+    use hyprstream_rpc::identity::Did;
+    use hyprstream_rpc::{serialize_message, FromCapnp, ToCapnp};
+
+    /// Field-level `$domainType("hyprstream_rpc::identity::Did")` on
+    /// `EnvelopeKeyset.serviceDid` must generate a `Did` newtype field (not `String`),
+    /// and the value must round-trip through the capnp wire (which stays `Text`).
+    #[test]
+    fn envelope_keyset_service_did_is_did_and_roundtrips() {
+        let original = EnvelopeKeyset {
+            service_did: Did::new("did:web:registry.example".to_owned()),
+            cose_keyset_cbor: vec![1, 2, 3, 4],
+            fetched_at: 1234,
+        };
+        // Type-level proof: the codegen emitted a `Did` field, not a `String`.
+        let _typecheck: &Did = &original.service_did;
+
+        let bytes = serialize_message(|msg| {
+            let mut b = msg.init_root::<discovery_capnp::envelope_keyset::Builder>();
+            original.write_to(&mut b);
+        })
+        .expect("serialize");
+
+        let reader =
+            capnp::serialize::read_message(&mut &bytes[..], capnp::message::ReaderOptions::new())
+                .expect("read message");
+        let root = reader
+            .get_root::<discovery_capnp::envelope_keyset::Reader>()
+            .expect("root reader");
+        let back = EnvelopeKeyset::read_from(root).expect("read_from");
+
+        assert_eq!(back.service_did, original.service_did);
+        assert_eq!(back.service_did.as_str(), "did:web:registry.example");
+        assert!(back.service_did.is_did_web());
+        assert_eq!(back.cose_keyset_cbor, vec![1, 2, 3, 4]);
+        assert_eq!(back.fetched_at, 1234);
+    }
+
+    /// Same for the request struct's `serviceDid` field.
+    #[test]
+    fn register_envelope_keyset_request_service_did_roundtrips() {
+        let original = RegisterEnvelopeKeysetRequest {
+            service_did: Did::new("did:key:z6Mkexample".to_owned()),
+            cose_keyset_cbor: vec![9, 9, 9],
+        };
+        let _typecheck: &Did = &original.service_did;
+
+        let bytes = serialize_message(|msg| {
+            let mut b =
+                msg.init_root::<discovery_capnp::register_envelope_keyset_request::Builder>();
+            original.write_to(&mut b);
+        })
+        .expect("serialize");
+
+        let reader =
+            capnp::serialize::read_message(&mut &bytes[..], capnp::message::ReaderOptions::new())
+                .expect("read message");
+        let root = reader
+            .get_root::<discovery_capnp::register_envelope_keyset_request::Reader>()
+            .expect("root reader");
+        let back = RegisterEnvelopeKeysetRequest::read_from(root).expect("read_from");
+
+        assert_eq!(back.service_did.as_str(), "did:key:z6Mkexample");
+        assert!(back.service_did.is_did_key());
+    }
+}

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -704,7 +704,7 @@ impl DiscoveryHandler for DiscoveryService {
         _request_id: u64,
         data: &RegisterEnvelopeKeysetRequest,
     ) -> Result<DiscoveryResponseVariant> {
-        if data.service_did.is_empty() {
+        if data.service_did.as_str().is_empty() {
             return Ok(DiscoveryResponseVariant::Error(ErrorInfo {
                 message: "serviceDid is required".to_owned(),
                 code: "INVALID_ARGUMENT".to_owned(),
@@ -724,7 +724,7 @@ impl DiscoveryHandler for DiscoveryService {
             fetched_at: unix_seconds_now(),
         };
         let mut map = self.envelope_keysets.write();
-        map.insert(data.service_did.clone(), cached);
+        map.insert(data.service_did.as_str().to_owned(), cached);
         let total = map.len();
         drop(map);
 
@@ -749,7 +749,7 @@ impl DiscoveryHandler for DiscoveryService {
             Some(cached) => {
                 trace!(service_did = %service_did, "Discovery: envelope keyset cache hit");
                 Ok(DiscoveryResponseVariant::GetEnvelopeKeysetResult(EnvelopeKeyset {
-                    service_did: service_did.to_owned(),
+                    service_did: hyprstream_rpc::identity::Did::new(service_did.to_owned()),
                     cose_keyset_cbor: cached.cose_keyset_cbor.clone(),
                     fetched_at: cached.fetched_at,
                 }))

--- a/crates/hyprstream-rpc-build/src/schema/cgr_reader.rs
+++ b/crates/hyprstream-rpc-build/src/schema/cgr_reader.rs
@@ -576,6 +576,7 @@ struct FieldAnnotationIds {
     fixed_size_id: Option<u64>,
     optional_id: Option<u64>,
     serde_rename_id: Option<u64>,
+    domain_type_id: Option<u64>,
 }
 
 /// Build a `FieldDef` from a `Slot` field reader.
@@ -636,6 +637,20 @@ fn field_def_from_slot(
         }
     };
 
+    // Field-level `$domainType("path::Type")`: maps this field to a Rust newtype while
+    // keeping its capnp wire type. Mirrors the struct-level read in `extract_struct_from_node`.
+    let domain_type = {
+        let dt = extract_annotation_text(
+            field.get_annotations().map_err(|e| format!("{e}"))?,
+            ann.domain_type_id,
+        );
+        if dt.is_empty() {
+            None
+        } else {
+            Some(dt)
+        }
+    };
+
     Ok(FieldDef {
         name: field_name,
         type_name,
@@ -646,6 +661,7 @@ fn field_def_from_slot(
         section,
         discriminant_value: disc,
         serde_rename,
+        domain_type,
     })
 }
 
@@ -819,6 +835,7 @@ fn extract_struct_from_node(
         fixed_size_id,
         optional_id,
         serde_rename_id,
+        domain_type_id,
     };
 
     for j in 0..fields_reader.len() {
@@ -885,6 +902,8 @@ fn extract_struct_from_node(
                     section: FieldSection::Group,
                     discriminant_value: disc,
                     serde_rename,
+                    // Group fields carry no field-level $domainType (they are inlined unions).
+                    domain_type: None,
                 }
             }
             Err(e) => return Err(format!("Field error: {e}")),
@@ -912,6 +931,7 @@ fn extract_struct_from_node(
                 fixed_size_id,
                 optional_id,
                 serde_rename_id,
+                domain_type_id,
             },
         )?
     } else {

--- a/crates/hyprstream-rpc-build/src/schema/types.rs
+++ b/crates/hyprstream-rpc-build/src/schema/types.rs
@@ -120,6 +120,11 @@ pub struct FieldDef {
     pub discriminant_value: u16,
     /// From `$serdeRename("...")` annotation: generates `#[serde(rename = "...")]` on the Rust field.
     pub serde_rename: Option<String>,
+    /// From a field-level `$domainType("path::Type")` annotation: the field maps to this
+    /// Rust newtype while keeping its capnp wire type (e.g. `Text`). The generated struct
+    /// uses this type; ToCapnp writes via `.as_str()` and FromCapnp reads via `Type::new(...)`.
+    #[serde(default)]
+    pub domain_type: Option<String>,
 }
 
 /// Which section of a Cap'n Proto struct a field resides in.

--- a/crates/hyprstream-rpc-derive/src/codegen/data.rs
+++ b/crates/hyprstream-rpc-derive/src/codegen/data.rs
@@ -8,6 +8,16 @@ use crate::schema::types::collect_list_struct_types;
 use crate::schema::types::*;
 use crate::util::*;
 
+/// Resolve a field-level `$domainType("path::Type")` annotation to its Rust type tokens.
+///
+/// Unlike the struct-level `resolve_domain_type` (which prepends the generated crate prefix
+/// for return-type wrappers), field newtypes live in shared crates and are referenced by their
+/// absolute path verbatim (e.g. `hyprstream_rpc::identity::Did`), so the path resolves
+/// identically from every generated module regardless of `types_crate`.
+fn resolve_field_domain_type(domain_path: &str) -> TokenStream {
+    domain_path.parse().unwrap_or_else(|_| quote! { String })
+}
+
 /// Resolve the capnp module path for a type based on its origin file.
 fn resolve_capnp_mod(
     origin_file: Option<&str>,
@@ -163,7 +173,10 @@ fn generate_data_struct(
                 .and_then(|s| s.option_inner_type())
                 .map(|inner_name| rust_type_tokens(&resolved.resolve_type(inner_name).rust_owned));
 
-            let inner_type = if field.type_name == "Data" && field.fixed_size.is_some() {
+            let inner_type = if let Some(dt) = field.domain_type.as_deref() {
+                // Field-level `$domainType`: use the newtype (wire type unchanged).
+                resolve_field_domain_type(dt)
+            } else if field.type_name == "Data" && field.fixed_size.is_some() {
                 let n = field.fixed_size.unwrap_or(0);
                 // Arrays > 32 don't implement Default/Serialize/Deserialize via derive,
                 // so use Vec<u8> in the struct. ToCapnp/FromCapnp handle length validation.
@@ -783,6 +796,17 @@ fn generate_data_field_setter_inner(
     };
 
     match ct {
+        // Field-level `$domainType` newtype over `Text`: write via `.as_str()`.
+        CapnpType::Text if field.domain_type.is_some() => {
+            // Accessor without a leading `&`: optional → `__val` (already `&T`),
+            // non-optional → `self.field`; `.as_str()` borrows in both cases.
+            let val_accessor = if field.optional {
+                quote! { __val }
+            } else {
+                quote! { self.#rust_name }
+            };
+            quote! { builder.#setter_name(#val_accessor.as_str()); }
+        }
         CapnpType::Text | CapnpType::Data => {
             quote! { builder.#setter_name(#val_borrowed); }
         }
@@ -1015,6 +1039,11 @@ fn generate_data_field_reader(
         let getter_name = format_ident!("get_{}", resolved.name(&field.name).snake);
         let ct = resolved.resolve_type(&field.type_name).capnp_type.clone();
         match ct {
+            // Optional field-level `$domainType` newtype over `Text`: empty → None, else `Some(Type::new(..))`.
+            CapnpType::Text if field.domain_type.is_some() => {
+                let dt = resolve_field_domain_type(field.domain_type.as_deref().unwrap_or_default());
+                quote! { #rust_name: { let v = reader.#getter_name()?.to_str()?; if v.is_empty() { None } else { Some(#dt::new(v.to_string())) } }, }
+            }
             CapnpType::Text => {
                 quote! { #rust_name: { let v = reader.#getter_name()?.to_str()?; if v.is_empty() { None } else { Some(v.to_string()) } }, }
             }
@@ -1164,6 +1193,11 @@ fn generate_data_field_reader_inner(
 
     match ct {
         CapnpType::Void => quote! { #rust_name: (), },
+        // Field-level `$domainType` newtype over `Text`: read via `Type::new(String)`.
+        CapnpType::Text if field.domain_type.is_some() => {
+            let dt = resolve_field_domain_type(field.domain_type.as_deref().unwrap_or_default());
+            quote! { #rust_name: #dt::new(reader.#getter_name()?.to_str()?.to_string()), }
+        }
         CapnpType::Text => quote! { #rust_name: reader.#getter_name()?.to_str()?.to_string(), },
         CapnpType::Data if field.fixed_size.is_some() => {
             let n = field.fixed_size.unwrap_or(0);
@@ -1291,5 +1325,109 @@ fn generate_data_field_reader_inner(
             }
         }
         _ => quote! { #rust_name: Default::default(), },
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod field_domain_type_tests {
+    use super::*;
+    use crate::resolve::ResolvedSchema;
+    use crate::schema::types::{FieldDef, FieldSection, ParsedSchema, StructDef};
+
+    fn text_field(name: &str, domain_type: Option<&str>) -> FieldDef {
+        FieldDef {
+            name: name.into(),
+            type_name: "Text".into(),
+            description: String::new(),
+            fixed_size: None,
+            optional: false,
+            slot_offset: 0,
+            section: FieldSection::Pointer,
+            discriminant_value: 0xFFFF,
+            serde_rename: None,
+            domain_type: domain_type.map(String::from),
+        }
+    }
+
+    fn data_only_schema(s: StructDef) -> ParsedSchema {
+        ParsedSchema {
+            request_variants: vec![],
+            response_variants: vec![],
+            structs: vec![s],
+            scoped_clients: vec![],
+            enums: vec![],
+            request_struct: None,
+            response_struct: None,
+        }
+    }
+
+    /// A field carrying `$domainType("hyprstream_rpc::identity::Did")` must emit the newtype
+    /// as the field's Rust type, write via `.as_str()`, and read via `Did::new(...)` — while a
+    /// sibling plain `Text` field stays a `String`.
+    #[test]
+    fn field_level_domain_type_emits_newtype() {
+        let s = StructDef {
+            name: "Sample".into(),
+            fields: vec![
+                text_field("serviceDid", Some("hyprstream_rpc::identity::Did")),
+                text_field("plain", None),
+            ],
+            has_union: false,
+            domain_type: None,
+            origin_file: None,
+            data_words: 0,
+            pointer_words: 2,
+            discriminant_count: 0,
+            discriminant_offset: 0,
+            union_arms: vec![],
+        };
+        let schema = data_only_schema(s);
+        let resolved = ResolvedSchema::from(&schema);
+        let out = generate_data_structs(&resolved, "discovery", None).to_string();
+
+        // Struct field uses the newtype, not String (TokenStream spaces out `::`).
+        assert!(
+            out.contains("service_did : hyprstream_rpc :: identity :: Did"),
+            "expected Did-typed field, got:\n{out}"
+        );
+        // ToCapnp writes the newtype via `.as_str()`.
+        assert!(
+            out.contains("set_service_did") && out.contains("as_str ()"),
+            "expected `.as_str()` write for domain field, got:\n{out}"
+        );
+        // FromCapnp reads via `Did::new(...)`.
+        assert!(
+            out.contains("hyprstream_rpc :: identity :: Did :: new"),
+            "expected `Did::new(...)` read for domain field, got:\n{out}"
+        );
+        // The sibling plain Text field stays a String.
+        assert!(
+            out.contains("plain : String"),
+            "expected plain Text field to remain String, got:\n{out}"
+        );
+    }
+
+    /// Struct-level `$domainType` must keep its existing behavior (it does not turn the
+    /// struct's own fields into newtypes — only field-level annotations do).
+    #[test]
+    fn struct_level_domain_type_unaffected() {
+        let s = StructDef {
+            name: "Wrapped".into(),
+            fields: vec![text_field("value", None)],
+            has_union: false,
+            domain_type: Some("some::DomainType".into()),
+            origin_file: None,
+            data_words: 0,
+            pointer_words: 1,
+            discriminant_count: 0,
+            discriminant_offset: 0,
+            union_arms: vec![],
+        };
+        let schema = data_only_schema(s);
+        let resolved = ResolvedSchema::from(&schema);
+        let out = generate_data_structs(&resolved, "discovery", None).to_string();
+        // Field without a field-level annotation stays a String regardless of struct-level $domainType.
+        assert!(out.contains("value : String"), "got:\n{out}");
     }
 }

--- a/crates/hyprstream-rpc-derive/src/util.rs
+++ b/crates/hyprstream-rpc-derive/src/util.rs
@@ -219,8 +219,8 @@ mod tests {
         vec![StructDef {
             name: "ModelInfo".into(),
             fields: vec![
-                FieldDef { name: "name".into(), type_name: "Text".into(), description: String::new(), fixed_size: None, optional: false, slot_offset: 0, section: FieldSection::Pointer, discriminant_value: 0xFFFF, serde_rename: None },
-                FieldDef { name: "size".into(), type_name: "UInt64".into(), description: String::new(), fixed_size: None, optional: false, slot_offset: 0, section: FieldSection::Data, discriminant_value: 0xFFFF, serde_rename: None },
+                FieldDef { name: "name".into(), type_name: "Text".into(), description: String::new(), fixed_size: None, optional: false, slot_offset: 0, section: FieldSection::Pointer, discriminant_value: 0xFFFF, serde_rename: None, domain_type: None },
+                FieldDef { name: "size".into(), type_name: "UInt64".into(), description: String::new(), fixed_size: None, optional: false, slot_offset: 0, section: FieldSection::Data, discriminant_value: 0xFFFF, serde_rename: None, domain_type: None },
             ],
             has_union: false,
             domain_type: None,

--- a/crates/hyprstream-rpc-std/schema/mcp.capnp
+++ b/crates/hyprstream-rpc-std/schema/mcp.capnp
@@ -13,6 +13,7 @@
 using import "/common.capnp".ErrorInfo;
 using import "/annotations.capnp".mcpScope;
 using import "/annotations.capnp".mcpDescription;
+using import "/annotations.capnp".domainType;
 
 # Unified MCP request with union discriminator
 struct McpRequest {
@@ -46,7 +47,7 @@ struct CallTool {
 
   # Optional caller identity for authorization
   # If None, uses the ZMQ request's identity
-  callerIdentity @2 :Text;
+  callerIdentity @2 :Text $domainType("hyprstream_rpc::identity::Did");
 }
 
 # Unified MCP response

--- a/crates/hyprstream-rpc-std/src/lib.rs
+++ b/crates/hyprstream-rpc-std/src/lib.rs
@@ -172,3 +172,45 @@ pub mod wasm_rpc_client;
 // Phase 2: iroh peer identity + pkarr helpers exported to JavaScript.
 #[cfg(target_arch = "wasm32")]
 pub mod iroh_exports;
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod did_field_domain_type_tests {
+    use crate::mcp_client::CallTool;
+    use hyprstream_rpc::identity::Did;
+    use hyprstream_rpc::{serialize_message, FromCapnp, ToCapnp};
+
+    /// Field-level `$domainType("hyprstream_rpc::identity::Did")` on
+    /// `CallTool.callerIdentity` must generate a `Did` newtype field (not `String`),
+    /// and the value must round-trip through the capnp wire (which stays `Text`).
+    #[test]
+    fn call_tool_caller_identity_is_did_and_roundtrips() {
+        let original = CallTool {
+            tool_name: "model_list".to_owned(),
+            arguments: "{}".to_owned(),
+            caller_identity: Did::new("did:key:z6MkcallerExample".to_owned()),
+        };
+        // Type-level proof: the codegen emitted a `Did` field, not a `String`.
+        let _typecheck: &Did = &original.caller_identity;
+
+        let bytes = serialize_message(|msg| {
+            let mut b = msg.init_root::<crate::mcp_capnp::call_tool::Builder>();
+            original.write_to(&mut b);
+        })
+        .expect("serialize");
+
+        let reader =
+            capnp::serialize::read_message(&mut &bytes[..], capnp::message::ReaderOptions::new())
+                .expect("read message");
+        let root = reader
+            .get_root::<crate::mcp_capnp::call_tool::Reader>()
+            .expect("root reader");
+        let back = CallTool::read_from(root).expect("read_from");
+
+        assert_eq!(back.caller_identity, original.caller_identity);
+        assert_eq!(back.caller_identity.as_str(), "did:key:z6MkcallerExample");
+        assert!(back.caller_identity.is_did_key());
+        assert_eq!(back.tool_name, "model_list");
+        assert_eq!(back.arguments, "{}");
+    }
+}

--- a/crates/hyprstream-rpc/schema/annotations.capnp
+++ b/crates/hyprstream-rpc/schema/annotations.capnp
@@ -50,8 +50,11 @@ annotation docExample(field) :Text;
 annotation optional(field) :Void;
 
 # Domain type path — generated client returns this Rust type via FromCapnp::read_from().
-# Usage: struct Foo $domainType("runtime::VersionResponse") { ... }
-annotation domainType(struct) :Text;
+# Struct-level: the generated client returns this Rust type for the whole struct.
+#   Usage: struct Foo $domainType("runtime::VersionResponse") { ... }
+# Field-level: the field maps to this Rust newtype (wire type unchanged, e.g. Text).
+#   Usage: serviceDid @0 :Text $domainType("hyprstream_rpc::identity::Did");
+annotation domainType(field, struct) :Text;
 
 # Serde field rename — generates #[serde(rename = "...")] on the Rust field.
 # Usage: toolType @1 :Text $serdeRename("type");

--- a/crates/hyprstream-rpc/src/identity.rs
+++ b/crates/hyprstream-rpc/src/identity.rs
@@ -8,10 +8,110 @@
 //! HKDF derivation: `HKDF(root_seed, purpose_bytes)` — no prefix.
 //! The purpose string IS the domain separator.
 
+use std::fmt;
+use std::str::FromStr;
+
 use anyhow::Result;
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 
 use crate::Subject;
+
+/// A W3C Decentralized Identifier (`did:key:…`, `did:web:…`, …), carried on capnp wires as
+/// `Text` (W3C DID strings — see <https://www.w3.org/TR/did-core/>) and mapped to this Rust
+/// newtype via a field-level `$domainType("hyprstream_rpc::identity::Did")` annotation. The
+/// generated ToCapnp/FromCapnp impls write via [`Did::as_str`] and read via [`Did::new`].
+///
+/// Construction is **lenient** — [`Did::new`] performs no validation, so deserializing a
+/// malformed wire value never fails at the boundary. **Strict validation lives at the
+/// admission gate** (`crate::admission`); this type is a typed string, not a policy check.
+///
+/// `did:key` is the self-certifying interop arm (the key *is* the identity; algorithm-agile
+/// via multicodec and iroh-convertible), while `did:web` covers operated nodes whose keys
+/// live as DID-document verification methods.
+///
+/// Wire representation is `Text`; serde (de)serializes transparently as the inner string.
+/// Cloneable, hashable, and usable as a map key.
+/// `Default` yields an empty DID (`Did("")`) — the generated capnp data structs that carry a
+/// `Did` field derive `Default`, and an absent `Text` field reads back as the empty string.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Did(String);
+
+impl Did {
+    /// Wrap a DID string verbatim. **No validation** — strict checks belong at the
+    /// admission gate (see the type docs).
+    pub fn new(did: String) -> Self {
+        Did(did)
+    }
+
+    /// Borrow the underlying DID string.
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    /// Consume the newtype, returning the owned DID string.
+    pub fn into_string(self) -> String {
+        self.0
+    }
+
+    /// Whether this is a `did:key` identifier (the self-certifying interop arm).
+    pub fn is_did_key(&self) -> bool {
+        // `did_web` is native-only; mirror its canonical check on wasm so the API is
+        // uniform across targets. The two implementations are intentionally identical.
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            crate::did_web::is_did_key(self.0.as_str())
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            self.0.starts_with("did:key:")
+        }
+    }
+
+    /// Whether this is a `did:web` identifier (operated nodes resolved via DID document).
+    pub fn is_did_web(&self) -> bool {
+        self.0.starts_with("did:web:")
+    }
+
+    /// Decode the raw 32-byte Ed25519 public key from a `did:key` identifier.
+    ///
+    /// Returns `Err` for a non-`did:key` DID, a non-Ed25519 multicodec, or a malformed body.
+    pub fn to_ed25519(&self) -> Result<[u8; 32]> {
+        crate::did_key::did_key_to_ed25519(self.0.as_str())
+    }
+
+    /// Construct a `did:key` (Ed25519) identifier from a raw 32-byte public key.
+    pub fn from_ed25519(key: &[u8; 32]) -> Self {
+        Did(crate::did_key::ed25519_to_did_key(key))
+    }
+}
+
+impl fmt::Display for Did {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl FromStr for Did {
+    /// Parsing is infallible — construction is lenient (see [`Did::new`]).
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        Ok(Did(s.to_owned()))
+    }
+}
+
+impl From<String> for Did {
+    fn from(s: String) -> Self {
+        Did(s)
+    }
+}
+
+impl From<&str> for Did {
+    fn from(s: &str) -> Self {
+        Did(s.to_owned())
+    }
+}
 
 /// A purpose-keyed signing identity derived from a root seed.
 ///
@@ -46,4 +146,68 @@ pub trait IdentityProvider: Send + Sync {
     /// Called after Ed25519 signature verification succeeds. Maps the
     /// cryptographically verified signer pubkey to a permission subject.
     fn resolve(&self, pubkey: &[u8; 32]) -> Subject;
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod did_tests {
+    use super::*;
+
+    #[test]
+    fn new_as_str_into_string_roundtrip() {
+        let did = Did::new("did:web:example.com".to_owned());
+        assert_eq!(did.as_str(), "did:web:example.com");
+        assert_eq!(did.clone().into_string(), "did:web:example.com");
+    }
+
+    #[test]
+    fn is_did_key_and_is_did_web() {
+        let key = Did::new("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK".to_owned());
+        assert!(key.is_did_key());
+        assert!(!key.is_did_web());
+
+        let web = Did::new("did:web:example.com".to_owned());
+        assert!(web.is_did_web());
+        assert!(!web.is_did_key());
+
+        let neither = Did::new("did:plc:abc123".to_owned());
+        assert!(!neither.is_did_key());
+        assert!(!neither.is_did_web());
+    }
+
+    #[test]
+    fn did_key_ed25519_roundtrip() {
+        // A fixed 32-byte key → did:key → back to the same bytes.
+        let key = [7u8; 32];
+        let did = Did::from_ed25519(&key);
+        assert!(did.is_did_key(), "from_ed25519 must produce a did:key: {did}");
+        assert_eq!(did.to_ed25519().expect("decode"), key);
+    }
+
+    #[test]
+    fn to_ed25519_rejects_non_did_key() {
+        let web = Did::new("did:web:example.com".to_owned());
+        assert!(web.to_ed25519().is_err());
+    }
+
+    #[test]
+    fn from_str_is_infallible() {
+        let did: Did = "did:key:abc".parse().expect("infallible");
+        assert_eq!(did.as_str(), "did:key:abc");
+    }
+
+    #[test]
+    fn display_renders_inner_string() {
+        let did = Did::new("did:web:node.example".to_owned());
+        assert_eq!(format!("{did}"), "did:web:node.example");
+    }
+
+    #[test]
+    fn serde_is_transparent_string() {
+        let did = Did::new("did:key:z6Mkxyz".to_owned());
+        let json = serde_json::to_string(&did).expect("serialize");
+        assert_eq!(json, "\"did:key:z6Mkxyz\"");
+        let back: Did = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, did);
+    }
 }

--- a/crates/hyprstream/src/tui/rpc_transport.rs
+++ b/crates/hyprstream/src/tui/rpc_transport.rs
@@ -371,7 +371,7 @@ pub fn make_tool_caller(
                             .call_tool(&crate::services::generated::mcp_client::CallTool {
                                 tool_name: uuid_c,
                                 arguments,
-                                caller_identity: String::new(),
+                                caller_identity: hyprstream_rpc::identity::Did::new(String::new()),
                             })
                             .await
                         {


### PR DESCRIPTION
Implements #563 (signed off). Introduces a first-class `Did` newtype and the **field-level `$domainType`** codegen needed to adopt it. Wire format is unchanged (`Text`).

## Codegen — field-level `$domainType` (4-step spike)
1. `annotations.capnp`: `annotation domainType(field, struct) :Text;` (was `struct` only).
2. `hyprstream-rpc-build/.../types.rs`: added `FieldDef.domain_type: Option<String>` (`#[serde(default)]`).
3. `hyprstream-rpc-build/.../cgr_reader.rs`: `field_def_from_slot` now reads the per-field `domainType` annotation (threaded through `FieldAnnotationIds`), mirroring the existing struct-level read.
4. `hyprstream-rpc-derive/.../codegen/data.rs`: a field with `$domainType("path::Type")` emits that Rust type for the struct field, **writes via `.as_str()`** and **reads via `Type::new(text.to_string())`** (incl. the `$optional` Text variant). Struct-level `$domainType` behavior is unchanged.

Field-level paths resolve **verbatim** (absolute, e.g. `hyprstream_rpc::identity::Did`) via a new `resolve_field_domain_type`, rather than through struct-level `resolve_domain_type` (which prepends `crate::`/`#tc::`). This is required because the migrated structs are generated in several crates (`hyprstream-discovery`, `hyprstream`, `hyprstream-rpc-std`) that all reference the newtype by absolute path.

## `Did` newtype (`hyprstream-rpc/src/identity.rs`)
`pub struct Did(String)` with lenient `new` (no validation), `as_str`, `into_string`, `is_did_key` (→ `did_web::is_did_key`), `is_did_web`, `to_ed25519` (→ `did_key::did_key_to_ed25519`), `from_ed25519` (→ `did_key::ed25519_to_did_key`). Derives `Clone/Debug/Default/PartialEq/Eq/Hash/Serialize/Deserialize`; impls `Display`, `FromStr` (infallible), `From<String>/<&str>`. Strict validation stays at the admission gate (`admission.rs` untouched).

## Migrated fields (Text on wire → `Did`)
- `discovery.capnp`: `RegisterEnvelopeKeysetRequest.serviceDid`, `EnvelopeKeyset.serviceDid`
- `mcp.capnp`: `CallTool.callerIdentity`
- Call sites updated: discovery `handle_register/get_envelope_keyset` (`.as_str()` / `Did::new`), tui `make_tool_caller`.

`policy.capnp` subject fields deferred (Casbin patterns), per #563.

## Tests
- `Did` unit tests: did:key↔ed25519 roundtrip, `is_did_key`/`is_did_web`, `FromStr`, transparent serde.
- Derive codegen test: a field `$domainType` yields the newtype (field is `Did`, writes `.as_str()`, reads `Did::new`); struct-level `$domainType` unaffected.
- Capnp round-trip tests for all three migrated fields (discovery + rpc-std).

## Status
`cargo build` (full workspace), `cargo test`, and `cargo clippy --all-targets` pass on the affected crates. The only failing test, `moq_event::tests::moq_event_pub_sub_roundtrip`, is **pre-existing on `main`** (verified by stashing this branch) and unrelated (#148).

## Note on invasiveness
The 4-step spike held, with one expected addition: field-level paths needed a dedicated verbatim resolver (`resolve_field_domain_type`) instead of reusing struct-level `resolve_domain_type`, since the newtype lives in a shared crate referenced by absolute path. `Did` also had to derive `Default` because the generated data structs that carry it derive `Default`.