### PR TITLE
feat(#505): P1 wasm host — rustpython 0.5 green path, Subject-scoped Store, epoch bound

### DIFF
--- a/crates/hyprstream-wasm-pyguest/.cargo/config.toml
+++ b/crates/hyprstream-wasm-pyguest/.cargo/config.toml
@@ -3,11 +3,11 @@
 # `__getrandom_v03_custom` which we implement in src/lib.rs to delegate to the
 # wasmtime host import. This keeps the wasm guest free of any WASI / wasm_js path.
 #
-# We only need this for the wasm target. (getrandom 0.2's custom backend uses a
-# macro + the `custom` cargo feature instead — handled in Cargo.toml + lib.rs.)
-# `--allow-undefined` lets `host_random` (and the harmless wasm-bindgen describe
-# stubs from js-sys in the dep graph) remain as wasm IMPORTS rather than hard link
-# errors. `host_random` is then a normal wasm import the wasmtime Linker resolves.
+# We only need this for the wasm target. (As of rustpython-vm 0.5 there is only a
+# single getrandom major — 0.3 — in the tree; the P0-era getrandom 0.2 dual backend
+# is gone.) `--allow-undefined` lets `host_random` remain a wasm IMPORT rather than a
+# hard link error. `host_random` is then a normal wasm import the wasmtime Linker
+# resolves. With 0.5 the only declared import should be exactly `env::host_random`.
 [target.wasm32-unknown-unknown]
 rustflags = [
     '--cfg', 'getrandom_backend="custom"',

--- a/crates/hyprstream-wasm-pyguest/Cargo.lock
+++ b/crates/hyprstream-wasm-pyguest/Cargo.lock
@@ -16,6 +16,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,10 +34,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.103"
+name = "ar_archive_writer"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "4087686b4b0a3427190bae57a1d9a478dbb2d40c5dc1bd6e2b6d797913bdd348"
+dependencies = [
+ "object",
+]
 
 [[package]]
 name = "ascii"
@@ -37,14 +49,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
+name = "attribute-derive"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+checksum = "05832cdddc8f2650cc2cc187cc2e952b8c133a48eb055f35211f61ee81502d77"
 dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
+ "attribute-derive-macro",
+ "derive-where",
+ "manyhow",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "attribute-derive-macro"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7cdbbd4bd005c5d3e2e9c885e6fa575db4f4a3572335b974d8db853b6beb61"
+dependencies = [
+ "collection_literals",
+ "interpolator",
+ "manyhow",
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+ "quote-use",
+ "syn",
 ]
 
 [[package]]
@@ -60,14 +91,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
-name = "bstr"
-version = "0.2.17"
+name = "bitflagset"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+checksum = "64b6ee310aa7af14142c8c9121775774ff601ae055ed98ba7fac96098bcde1b9"
 dependencies = [
- "lazy_static",
+ "num-integer",
+ "num-traits",
+ "radium",
+ "ref-cast",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+dependencies = [
  "memchr",
  "regex-automata",
+ "serde_core",
 ]
 
 [[package]]
@@ -77,12 +120,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "caseless"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6fd507454086c8edfd769ca6ada439193cdb209c7681712ef6275cccbfe5d8"
 dependencies = [
  "unicode-normalization",
+]
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -103,9 +161,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -114,9 +172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -128,6 +184,32 @@ checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
 ]
+
+[[package]]
+name = "collection_literals"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2550f75b8cfac212855f6b1885455df8eaee8fe8e246b647d69146142e016084"
+
+[[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "core-foundation-sys"
@@ -148,24 +230,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "derive_more"
-version = "1.0.0"
+name = "derive-where"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
- "unicode-xid",
+ "syn",
 ]
 
 [[package]]
@@ -209,13 +281,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "fd-lock"
 version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -224,6 +302,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "futures-core"
@@ -250,12 +334,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "get-size-derive2"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b6d1e2f75c16bfbcd0f95d84f99858a6e2f885c2287d1f5c3a96e8444a34b4"
+dependencies = [
+ "attribute-derive",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "get-size2"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49cf31a6d70300cf81461098f7797571362387ef4bf85d32ac47eaa59b3a5a1a"
+dependencies = [
+ "compact_str",
+ "get-size-derive2",
+ "hashbrown 0.16.1",
+ "ordermap",
+ "smallvec",
+]
+
+[[package]]
 name = "getopts"
 version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
- "unicode-width 0.2.2",
+ "unicode-width",
 ]
 
 [[package]]
@@ -265,10 +373,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -291,17 +397,22 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "half"
-version = "1.8.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "ahash",
+ "foldhash",
 ]
 
 [[package]]
@@ -312,24 +423,9 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -362,8 +458,8 @@ dependencies = [
 name = "hyprstream-wasm-pyguest"
 version = "0.1.0"
 dependencies = [
- "getrandom 0.2.17",
  "getrandom 0.3.4",
+ "rustpython-pylib",
  "rustpython-vm",
 ]
 
@@ -379,7 +475,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -402,25 +498,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "interpolator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
+
+[[package]]
 name = "is-macro"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d57a3e447e24c22647738e4607f1df1e0ec6f72e16182c4cd199f647cdfb0e4"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
@@ -434,46 +542,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "lalrpop-util"
-version = "0.20.2"
+name = "junction"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
+dependencies = [
+ "scopeguard",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "lexical-parse-float"
-version = "0.8.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
 dependencies = [
  "lexical-parse-integer",
  "lexical-util",
- "static_assertions",
 ]
 
 [[package]]
 name = "lexical-parse-integer"
-version = "0.8.6"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
 dependencies = [
  "lexical-util",
- "static_assertions",
 ]
 
 [[package]]
 name = "lexical-util"
-version = "0.8.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc"
-dependencies = [
- "static_assertions",
-]
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
 
 [[package]]
 name = "libc"
@@ -482,16 +583,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libffi"
+version = "5.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed185dbb87539a100c1b36c219e16e71572c6d4d4fed3ded898140f755adeaaf"
+dependencies = [
+ "libc",
+ "libffi-sys",
+]
+
+[[package]]
+name = "libffi-sys"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25831b230b6a90bdea9f28339c1d00d59773a1c492e8ca09b1ad80e56394c261"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -516,31 +640,20 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.6"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 dependencies = [
  "twox-hash",
 ]
 
 [[package]]
-name = "malachite"
-version = "0.4.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbdf9cb251732db30a7200ebb6ae5d22fe8e11397364416617d2c2cf0c51cb5"
-dependencies = [
- "malachite-base",
- "malachite-nz",
- "malachite-q",
-]
-
-[[package]]
 name = "malachite-base"
-version = "0.4.22"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea0ed76adf7defc1a92240b5c36d5368cfe9251640dcce5bd2d0b7c1fd87aeb"
+checksum = "a4f44099731f17094b07825c88ccb5fbd1bfa1f82fafff7daa33e8b8652db16e"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
  "itertools",
  "libm",
  "ryu",
@@ -548,12 +661,12 @@ dependencies = [
 
 [[package]]
 name = "malachite-bigint"
-version = "0.2.3"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d149aaa2965d70381709d9df4c7ee1fc0de1c614a4efc2ee356f5e43d68749f8"
+checksum = "cc58206ba15e9c406e20c95c5f86efa07b12f94080945908e910b3a0faa23fef"
 dependencies = [
- "derive_more",
- "malachite",
+ "malachite-base",
+ "malachite-nz",
  "num-integer",
  "num-traits",
  "paste",
@@ -561,24 +674,49 @@ dependencies = [
 
 [[package]]
 name = "malachite-nz"
-version = "0.4.22"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34a79feebb2bc9aa7762047c8e5495269a367da6b5a90a99882a0aeeac1841f7"
+checksum = "a137660cdba20f136c8a223125f08088adb4e0b72fbb8466f08c43e31cc0427d"
 dependencies = [
  "itertools",
  "libm",
  "malachite-base",
+ "wide",
 ]
 
 [[package]]
 name = "malachite-q"
-version = "0.4.22"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f235d5747b1256b47620f5640c2a17a88c7569eebdf27cd9cb130e1a619191"
+checksum = "5ffcbeed95e34c0fcc3864ccd146e129cbbf7de1513d3afbcfb47c7674c82d94"
 dependencies = [
  "itertools",
+ "libm",
  "malachite-base",
  "malachite-nz",
+]
+
+[[package]]
+name = "manyhow"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b33efb3ca6d3b07393750d4030418d594ab1139cee518f0dc88db70fec873587"
+dependencies = [
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46fce34d199b78b6e6073abf984c9cf5fd3e9330145a93ee0738a7443e371495"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -619,26 +757,15 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.27.1"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
-dependencies = [
- "bitflags",
- "cfg-if",
- "libc",
- "memoffset",
-]
-
-[[package]]
-name = "nix"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -674,7 +801,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "libc",
 ]
 
@@ -694,10 +821,18 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -711,6 +846,15 @@ name = "optional"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978aa494585d3ca4ad74929863093e87cac9790d81fe7aba2b3dc2890643a0fc"
+
+[[package]]
+name = "ordermap"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7476a5b122ff1fce7208e7ee9dccd0a516e835f5b8b19b8f3c98a34cf757c1"
+dependencies = [
+ "indexmap",
+]
 
 [[package]]
 name = "parking_lot"
@@ -747,7 +891,17 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -756,8 +910,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -766,8 +920,31 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -776,7 +953,16 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher 1.0.3",
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -787,13 +973,13 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pmutil"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3894e5d549cccbe44afecf72922f277f603cd4bb0219c8342631ef18fffbe004"
+checksum = "52a40bc70c2c58040d2d8b167ba9a5ff59fc9dab7ad44771cfde3dcfde7a09c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -806,12 +992,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.5.0"
+name = "proc-macro-utils"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+checksum = "eeaf08a13de400bc215877b5bdc088f241b12eb42f0a548d3390dc1c56bb7071"
 dependencies = [
- "toml_edit",
+ "proc-macro2",
+ "quote",
+ "smallvec",
 ]
 
 [[package]]
@@ -824,12 +1012,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "quote-use"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9619db1197b497a36178cfc736dc96b271fe918875fbf1344c436a7e93d0321e"
+dependencies = [
+ "quote",
+ "quote-use-macros",
+]
+
+[[package]]
+name = "quote-use-macros"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82ebfb7faafadc06a7ab141a6f67bcfb24cb8beb158c6fe933f2f035afa99f35"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -840,9 +1060,12 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "radium"
-version = "0.7.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+checksum = "1775bc532a9bfde46e26eba441ca1171b91608d14a3bae71fea371f18a00cffe"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "radix_trie"
@@ -894,60 +1117,57 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-automata"
-version = "0.1.10"
+name = "ref-cast"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 
 [[package]]
 name = "result-like"
-version = "0.4.6"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc7ce6435c33898517a30e85578cd204cbb696875efb93dec19a2d31294f810"
+checksum = "bffa194499266bd8a1ac7da6ac7355aa0f81ffa1a5db2baaf20dd13854fd6f4e"
 dependencies = [
  "result-like-derive",
 ]
 
 [[package]]
 name = "result-like-derive"
-version = "0.4.6"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fabf0a2e54f711c68c50d49f648a1a8a37adcb57353f518ac4df374f0788f42"
+checksum = "01d3b03471c9700a3a6bd166550daaa6124cb4a146ea139fb028e4edaa8f4277"
 dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "syn-ext",
+ "syn",
 ]
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
-name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -958,286 +1178,319 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "rustpython-ast"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c72612d246194023a643d342ac53e4118c300cbc3ada31ff1245e7636db860"
-dependencies = [
- "is-macro",
- "malachite-bigint",
- "rustpython-literal",
- "rustpython-parser-core",
- "static_assertions",
-]
-
-[[package]]
 name = "rustpython-codegen"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964cbc9d7870b4d092eecd66049ab0cd93fb5f3f40a408f78bf4415a5d25d3a3"
+checksum = "12e4fc1331357a7afc6d52d637796a946b1efaaca07c914132f8fd4fd69d595f"
 dependencies = [
  "ahash",
  "bitflags",
  "indexmap",
  "itertools",
  "log",
+ "malachite-bigint",
+ "memchr",
  "num-complex",
  "num-traits",
- "rustpython-ast",
  "rustpython-compiler-core",
- "rustpython-parser-core",
+ "rustpython-literal",
+ "rustpython-ruff_python_ast",
+ "rustpython-ruff_text_size",
+ "rustpython-wtf8",
+ "thiserror",
+ "unicode_names2 2.0.0",
 ]
 
 [[package]]
 name = "rustpython-common"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5b1bae2d3bd9c18a74a835a496b2f7dedcea692e66d47ff56a1dd100ed35c9"
+checksum = "9f3c0808a170ea900e0489a06d6aa04ce5d27d62b347836c2f98df958f47f243"
 dependencies = [
  "ascii",
  "bitflags",
- "bstr",
  "cfg-if",
+ "getrandom 0.3.4",
  "itertools",
  "libc",
  "lock_api",
  "malachite-base",
  "malachite-bigint",
  "malachite-q",
+ "nix",
  "num-complex",
  "num-traits",
- "once_cell",
  "radium",
- "rand",
- "rustpython-format",
- "siphasher 0.3.11",
- "volatile",
+ "rustpython-literal",
+ "rustpython-wtf8",
+ "siphasher",
+ "unicode_names2 2.0.0",
  "widestring",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustpython-compiler"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad4849236178a0296808c30fca6f7bf8030b57a9b6e85223129b23ae5bfb9fa3"
+checksum = "f7fa83b852bbc5461c5214060099d7597785d201aa0bf1a87d77967518f60144"
 dependencies = [
  "rustpython-codegen",
  "rustpython-compiler-core",
- "rustpython-parser",
+ "rustpython-ruff_python_ast",
+ "rustpython-ruff_python_parser",
+ "rustpython-ruff_source_file",
+ "rustpython-ruff_text_size",
+ "thiserror",
 ]
 
 [[package]]
 name = "rustpython-compiler-core"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bf4f4dabec9dec0250c2544bab9229428c7a6af04dba34508476e975fbbc3a1"
+checksum = "e9f18ba67b55aec49c3e2d223bbdcacff0d7e0f5d304fb0e64b044b8dca13c7c"
 dependencies = [
  "bitflags",
+ "bitflagset",
  "itertools",
  "lz4_flex",
  "malachite-bigint",
  "num-complex",
- "rustpython-parser-core",
+ "rustpython-ruff_source_file",
+ "rustpython-wtf8",
 ]
 
 [[package]]
 name = "rustpython-derive"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcac29b3573c59fa22e2d7457b12c07e502b7dfbd38ce62bdd23a25f3d8a8eb"
+checksum = "6ba6c04350bee9e54b241b93675a0558c2b33fe982213e47a6da0924898af0f2"
 dependencies = [
  "rustpython-compiler",
  "rustpython-derive-impl",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "rustpython-derive-impl"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afe0c74ae690e16c0d08a07236d5736989a3c9a5fc793e04f5ee4b8fbd3c60a9"
+checksum = "322d64ea8a21d52cd769db0f6190b6e7c17963b13c8c17f39d7364e68af96731"
 dependencies = [
  "itertools",
  "maplit",
- "once_cell",
  "proc-macro2",
  "quote",
  "rustpython-compiler-core",
  "rustpython-doc",
- "rustpython-parser-core",
- "syn 1.0.109",
+ "syn",
  "syn-ext",
  "textwrap",
 ]
 
 [[package]]
 name = "rustpython-doc"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885d19895d9d29656a8a2b33e967a482b92f3d891b4fd923e40849714051bcd"
+checksum = "f286d8b5872aa53dceb7a8d8c6a29fe85150f0a137fecf1c9a3e0a8345cbc19b"
 dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "rustpython-format"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba07bbc520a3884d6c7c91bdcc2d49b6645b8d8ea6d13c4bf8300a7ddea3ad72"
-dependencies = [
- "bitflags",
- "itertools",
- "malachite-bigint",
- "num-traits",
- "rustpython-literal",
+ "phf 0.13.1",
 ]
 
 [[package]]
 name = "rustpython-literal"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443cbcbd1a87a27be77e24b16654716900dc9151db57c02380a2b480ecce72c0"
+checksum = "bcb46f7afce00e4797f82062e09881ec5e7226d858104bf4a8a9c3b996de2b4a"
 dependencies = [
  "hexf-parse",
  "is-macro",
  "lexical-parse-float",
  "num-traits",
+ "rustpython-wtf8",
  "unic-ucd-category",
 ]
 
 [[package]]
-name = "rustpython-parser"
-version = "0.3.1"
+name = "rustpython-pylib"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e73421499eff08722b979d8494c3f1bc035908931a28607a9f17be6143ac11"
+checksum = "9f1878a8c2fb45dfcbcee1d4bba8d4a3d9b65c4f20dc70d08179c3efa223bbab"
 dependencies = [
- "anyhow",
+ "glob",
+ "rustpython-compiler-core",
+ "rustpython-derive",
+]
+
+[[package]]
+name = "rustpython-ruff_python_ast"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f021ff72cabf5e2cd6d8ec8813d376a8445a228dc610ab56c27bd9054cda70d4"
+dependencies = [
+ "aho-corasick",
+ "bitflags",
+ "compact_str",
+ "get-size2",
  "is-macro",
- "itertools",
- "lalrpop-util",
- "log",
- "malachite-bigint",
- "num-traits",
- "phf",
- "phf_codegen",
+ "memchr",
  "rustc-hash",
- "rustpython-ast",
- "rustpython-parser-core",
- "tiny-keccak",
- "unic-emoji-char",
- "unic-ucd-ident",
- "unicode_names2",
+ "rustpython-ruff_python_trivia",
+ "rustpython-ruff_source_file",
+ "rustpython-ruff_text_size",
+ "thiserror",
 ]
 
 [[package]]
-name = "rustpython-parser-core"
-version = "0.3.1"
+name = "rustpython-ruff_python_parser"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47f9465e822d45e05304c08f168dd1ffea05d8d95b7a4e18651ef1acb4df097f"
+checksum = "01e6ee78bd9671fb5766664b2695fe1f2a92a961f4d9101646c570d8acdb1e0b"
 dependencies = [
- "is-macro",
+ "bitflags",
+ "bstr",
+ "compact_str",
+ "get-size2",
  "memchr",
- "rustpython-parser-vendored",
+ "rustc-hash",
+ "rustpython-ruff_python_ast",
+ "rustpython-ruff_python_trivia",
+ "rustpython-ruff_text_size",
+ "static_assertions",
+ "unicode-ident",
+ "unicode-normalization",
+ "unicode_names2 1.3.0",
 ]
 
 [[package]]
-name = "rustpython-parser-vendored"
-version = "0.3.1"
+name = "rustpython-ruff_python_trivia"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e43398f39b5e4ce129cb95a8d7b87c6378b056d66c978da86ea2296d861c8f"
+checksum = "79e7cfd1056f3a02ff0d2d0e4474286ca963260782f878b7b81c1dd87432e682"
+dependencies = [
+ "itertools",
+ "rustpython-ruff_source_file",
+ "rustpython-ruff_text_size",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustpython-ruff_source_file"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "948107aad62ddb12a11fc7bf68a49e52a0b0a3737d415a2505e54f5a9edac737"
 dependencies = [
  "memchr",
- "once_cell",
+ "rustpython-ruff_text_size",
+]
+
+[[package]]
+name = "rustpython-ruff_text_size"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8291ee0f5a779e54ccd4e0151a0c426f8b49a123f99b5b6545db17ccdd4277aa"
+dependencies = [
+ "get-size2",
 ]
 
 [[package]]
 name = "rustpython-sre_engine"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf3bb085265414a74cc9c6e90316ea6e423f582c3ca86c34430a39b9f150d93"
+checksum = "ad4b7bd82b2a531f7c2ad96864ce11285959fc7d8524f1ba54db8ce3a23a3d2c"
 dependencies = [
  "bitflags",
  "num_enum",
  "optional",
+ "rustpython-wtf8",
 ]
 
 [[package]]
 name = "rustpython-vm"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d304aecce4f914def54abf331e458ee99f611b862580acb0c448e67a8237d28d"
+checksum = "1880770161cef896bf9c7e065dae574e3b4c3cf6172e485f1ce86f0483816ab2"
 dependencies = [
  "ahash",
  "ascii",
- "atty",
  "bitflags",
  "bstr",
  "caseless",
  "cfg-if",
  "chrono",
+ "constant_time_eq",
  "crossbeam-utils",
+ "errno",
  "exitcode",
- "getrandom 0.2.17",
+ "getrandom 0.3.4",
  "glob",
  "half",
  "hex",
  "indexmap",
  "is-macro",
  "itertools",
+ "junction",
  "libc",
+ "libffi",
+ "libloading",
  "log",
  "malachite-bigint",
  "memchr",
- "memoffset",
- "nix 0.27.1",
+ "nix",
  "num-complex",
  "num-integer",
  "num-traits",
  "num_cpus",
  "num_enum",
- "once_cell",
  "optional",
  "parking_lot",
  "paste",
- "rand",
+ "psm",
  "result-like",
- "rustc_version",
- "rustpython-ast",
+ "rustix",
  "rustpython-codegen",
  "rustpython-common",
  "rustpython-compiler",
  "rustpython-compiler-core",
  "rustpython-derive",
- "rustpython-format",
  "rustpython-literal",
- "rustpython-parser",
- "rustpython-parser-core",
+ "rustpython-ruff_python_ast",
+ "rustpython-ruff_python_parser",
+ "rustpython-ruff_text_size",
  "rustpython-sre_engine",
  "rustyline",
- "schannel",
+ "scoped-tls",
+ "scopeguard",
  "static_assertions",
  "strum",
  "strum_macros",
  "thiserror",
- "thread_local",
  "timsort",
  "uname",
  "unic-ucd-bidi",
  "unic-ucd-category",
  "unic-ucd-ident",
  "unicode-casing",
- "unicode_names2",
- "wasm-bindgen",
  "which",
  "widestring",
- "windows",
- "windows-sys 0.52.0",
- "winreg",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustpython-wtf8"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada88d2f69ff5516d69e0f3294e9db2ff8ee71a15291b8f3f8584f07ad1ca28d"
+dependencies = [
+ "ascii",
+ "bstr",
+ "itertools",
+ "memchr",
 ]
 
 [[package]]
@@ -1248,9 +1501,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustyline"
-version = "14.0.0"
+version = "17.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
+checksum = "e902948a25149d50edc1a8e0141aad50f54e22ba83ff988cf8f7c9ef07f50564"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1260,12 +1513,12 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix 0.28.0",
+ "nix",
  "radix_trie",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width",
  "utf8parse",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1275,25 +1528,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "schannel"
-version = "0.1.29"
+name = "safe_arch"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+checksum = "1f7caad094bd561859bcd467734a720c3c1f5d1f338995351fefe2190c45efed"
 dependencies = [
- "windows-sys 0.61.2",
+ "bytemuck",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde_core"
@@ -1312,7 +1565,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1320,12 +1573,6 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
-
-[[package]]
-name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "siphasher"
@@ -1353,32 +1600,20 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strum"
-version = "0.24.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 
 [[package]]
 name = "strum_macros"
-version = "0.24.3"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
- "rustversion",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
+ "syn",
 ]
 
 [[package]]
@@ -1394,46 +1629,39 @@ dependencies = [
 
 [[package]]
 name = "syn-ext"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b86cb2b68c5b3c078cac02588bc23f3c04bb828c5d3aedd17980876ec6a7be6"
+checksum = "b126de4ef6c2a628a68609dd00733766c3b015894698a438ebdf374933fc31d1"
 dependencies = [
- "syn 1.0.109",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "textwrap"
-version = "0.15.2"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
-dependencies = [
- "cfg-if",
+ "syn",
 ]
 
 [[package]]
@@ -1441,15 +1669,6 @@ name = "timsort"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "639ce8ef6d2ba56be0383a94dd13b92138d58de44c62618303bb798fa92bdc00"
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
-]
 
 [[package]]
 name = "tinyvec"
@@ -1465,36 +1684,6 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "toml_parser",
- "winnow",
-]
-
-[[package]]
-name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
-dependencies = [
- "winnow",
-]
 
 [[package]]
 name = "twox-hash"
@@ -1531,17 +1720,6 @@ name = "unic-common"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc"
-
-[[package]]
-name = "unic-emoji-char"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b07221e68897210270a38bde4babb655869637af0f69407f96053a34f76494d"
-dependencies = [
- "unic-char-property",
- "unic-char-range",
- "unic-ucd-version",
-]
 
 [[package]]
 name = "unic-ucd-bidi"
@@ -1615,21 +1793,9 @@ checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unicode_names2"
@@ -1637,8 +1803,18 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1673eca9782c84de5f81b82e4109dcfb3611c8ba0d52930ec4a9478f547b2dd"
 dependencies = [
- "phf",
- "unicode_names2_generator",
+ "phf 0.11.3",
+ "unicode_names2_generator 1.3.0",
+]
+
+[[package]]
+name = "unicode_names2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d189085656ca1203291e965444e7f6a2723fbdd1dd9f34f8482e79bafd8338a0"
+dependencies = [
+ "phf 0.11.3",
+ "unicode_names2_generator 2.0.0",
 ]
 
 [[package]]
@@ -1654,6 +1830,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode_names2_generator"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1262662dc96937c71115228ce2e1d30f41db71a7a45d3459e98783ef94052214"
+dependencies = [
+ "phf_codegen",
+ "rand",
+]
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1664,12 +1850,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "volatile"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8e76fae08f03f96e166d2dfda232190638c10e0383841252416f9cfe2ae60e6"
 
 [[package]]
 name = "wasi"
@@ -1718,7 +1898,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1733,14 +1913,21 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.4.2"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
 dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
+ "libc",
+]
+
+[[package]]
+name = "wide"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfdfe6a32973f2d1b268b8895845a8a96cac2f0191e72c27cc929036060dbf89"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]
@@ -1748,47 +1935,6 @@ name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
-dependencies = [
- "windows-core 0.52.0",
- "windows-targets",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets",
-]
 
 [[package]]
 name = "windows-core"
@@ -1811,7 +1957,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1822,7 +1968,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1851,20 +1997,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1882,14 +2028,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -1899,10 +2062,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1911,10 +2086,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1923,10 +2110,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1935,28 +2134,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "1.0.3"
+name = "windows_x86_64_msvc"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
-dependencies = [
- "winapi",
-]
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
@@ -1981,5 +2174,5 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]

--- a/crates/hyprstream-wasm-pyguest/Cargo.toml
+++ b/crates/hyprstream-wasm-pyguest/Cargo.toml
@@ -3,15 +3,14 @@ name = "hyprstream-wasm-pyguest"
 version = "0.1.0"
 edition = "2021"
 license = "MIT"
-description = "RustPython guest compiled to wasm32-unknown-unknown for the #505 capability sandbox spike"
+description = "RustPython guest compiled to wasm32-unknown-unknown for the #505 capability sandbox (P1 host)"
 
 # This crate is intentionally NOT a workspace member. It is listed in the root
 # Cargo.toml [workspace.exclude] so a host-target workspace build never tries to
 # compile a wasm-only cdylib (which would also drag in libtorch deps transitively
 # via the workspace). Build explicitly:
-#   cargo build --target wasm32-unknown-unknown -p hyprstream-wasm-pyguest
-# or via this manifest path.
-
+#   cargo build --target wasm32-unknown-unknown --manifest-path crates/hyprstream-wasm-pyguest/Cargo.toml
+#
 # Empty [workspace] table makes this a standalone package (own lockfile/target),
 # belt-and-suspenders alongside the root [workspace.exclude] entry. A wasm-only
 # cdylib has no business in the host workspace's dependency resolution.
@@ -21,27 +20,42 @@ description = "RustPython guest compiled to wasm32-unknown-unknown for the #505 
 crate-type = ["cdylib"]
 
 [dependencies]
-# RustPython VM. default-features=false strips the std/threading/jit pieces that
-# do not exist on wasm32-unknown-unknown. We keep:
-#   compiler       — compile source -> bytecode (no precompiled-only mode)
-#   encodings      — text codecs (utf-8 etc.), needed for str handling
-#   freeze-stdlib  — embed the pure-python stdlib into the binary so there is NO
-#                    filesystem import path at all (capability point: no FS = no os.* host effect)
-rustpython-vm = { version = "0.3", default-features = false, features = ["compiler", "encodings", "freeze-stdlib"] }
+# RustPython VM, bumped 0.3 -> 0.5 (the P1 green path; see FINDINGS.md).
+#   * 0.5 declares getrandom 0.3 with NO `js` feature, so the wasm32-unknown-unknown
+#     custom getrandom-0.3 backend is actually reachable (0.3.1 force-enabled
+#     getrandom/js, which out-ranked the custom backend and trapped at VM bootstrap).
+# default-features=false strips the std/threading/jit pieces that do not exist on
+# wasm32-unknown-unknown. We keep:
+#   compiler       — compile source -> bytecode
+#   encodings      — text codecs (utf-8 etc.), needed for str handling AND essential init
+#   freeze-stdlib  — make the VM expect the frozen stdlib during init (no FS import path).
+#                    NOTE: on rustpython-vm 0.5 this feature is just an alias for
+#                    `encodings` and does NOT itself embed the stdlib — the frozen
+#                    modules come from the `rustpython-pylib` crate (below), which we
+#                    register via `Interpreter::builder().add_frozen_modules(FROZEN_STDLIB)`.
+#   stdio          — wire `sys.stdout`/`stderr` so `print(...)` works. Crucially we do
+#                    NOT enable `host_env`, so the VM uses its SANDBOX stdio path
+#                    (`SandboxStdio` -> `std::io::stdout()`), which on
+#                    wasm32-unknown-unknown discards output (no real fd) — a capability
+#                    win: print succeeds (status 0) with zero host effect. Without this
+#                    feature `sys.stdout` is `None` and `print()` raises.
+# We deliberately OMIT `host_env` (which would wire the native `posix`/`os` backend),
+# `wasmbind` (which pulls wasm-bindgen/js — the very thing we eliminated), `gc`, `jit`,
+# and `threading`. With host_env off, `import os` resolves to a frozen pure-Python shim
+# whose host-touching functions have no native backend, so `os.system(...)` raises.
+rustpython-vm = { version = "0.5", default-features = false, features = ["compiler", "encodings", "freeze-stdlib", "stdio"] }
 
-# RESOLVED via `cargo tree -i getrandom` (see FINDINGS.md):
-#   The RUNTIME-critical RNG path is getrandom 0.2.17:
-#     getrandom 0.2.17 <- rand_core 0.6.4 <- rand 0.8.6 <- rustpython-common <- rustpython-vm
-#   (There is also a getrandom 0.3.4 in the tree via ahash<-hashbrown<-malachite, but
-#    ahash only touches getrandom for its optional runtime-rng and is not the VM RNG.)
-#
-# Two getrandom MAJORs are in the tree and BOTH must be satisfied on wasm:
-#   * getrandom 0.2.17 (runtime RNG: rand 0.8 <- rustpython-common <- rustpython-vm)
-#       -> `custom` feature + `register_custom_getrandom!` macro (lib.rs)
-#   * getrandom 0.3.4  (ahash runtime-rng <- hashbrown <- malachite)
-#       -> build cfg `getrandom_backend="custom"` (.cargo/config.toml) + the
-#          `#[no_mangle] __getrandom_v03_custom` extern symbol (lib.rs)
-# Both delegate to the same host import `host_random`.
+# The actual frozen pure-Python stdlib bytecode, embedded into the binary. Required
+# because rustpython-vm 0.5's `freeze-stdlib` feature no longer embeds it itself; the
+# embedder must register `rustpython_pylib::FROZEN_STDLIB` on the InterpreterBuilder.
+# Without this, VirtualMachine::initialize() panics ("essential initialization failed")
+# trying to `import encodings` with an empty frozen set.
+rustpython-pylib = { version = "0.5", features = ["freeze-stdlib"] }
+
+# getrandom 0.3 ONLY (the 0.2 dual-backend from the P0 spike is dropped: rustpython 0.5
+# no longer pulls a getrandom-0.2 RNG path that forces `js`). 0.3 selects its backend
+# via the build cfg `getrandom_backend="custom"` (in .cargo/config.toml) plus the
+# `#[no_mangle] __getrandom_v03_custom` extern symbol in lib.rs, both delegating to the
+# single host import `host_random`. No `js`, no `wasm_js`, no WASI.
 [target.wasm32-unknown-unknown.dependencies]
-getrandom02 = { package = "getrandom", version = "0.2", features = ["custom"] }
-getrandom03 = { package = "getrandom", version = "0.3" }
+getrandom = { version = "0.3" }

--- a/crates/hyprstream-wasm-pyguest/src/lib.rs
+++ b/crates/hyprstream-wasm-pyguest/src/lib.rs
@@ -1,4 +1,4 @@
-//! RustPython guest for the #505 capability-sandbox build-viability spike.
+//! RustPython guest for the #505 capability sandbox (P1 host).
 //!
 //! Compiled to `wasm32-unknown-unknown` (NOT wasi). There is deliberately NO WASI
 //! import in this module: the only thing the guest can reach outside its linear
@@ -6,24 +6,36 @@
 //! therefore has nothing to call — it is inert by construction.
 //!
 //! Build:
-//!   cargo build --target wasm32-unknown-unknown -p hyprstream-wasm-pyguest
+//!   cargo build --target wasm32-unknown-unknown --manifest-path crates/hyprstream-wasm-pyguest/Cargo.toml
 //!
 //! Exports:
 //!   - `eval(ptr, len) -> i32`  : run UTF-8 python source, 0 = ok, nonzero = py error
 //!   - `alloc(len) -> *mut u8`  : let the host allocate guest memory to write source into
 //!   - `dealloc(ptr, len)`      : free it again
+//!
+//! P1 changes vs. the P0 spike:
+//!   * rustpython-vm bumped 0.3 -> 0.5 (0.3.1 force-enabled getrandom/js, which
+//!     out-ranked the custom backend and trapped at VM bootstrap reaching for
+//!     undefined `__wbindgen_placeholder__` JS imports). 0.5 uses getrandom 0.3
+//!     with no `js`, so the custom backend is actually reachable.
+//!   * Dropped the getrandom-0.2 dual backend; ONLY the getrandom-0.3 custom
+//!     backend remains.
+//!   * Construct via `Interpreter::builder(Settings).add_frozen_modules(...)` rather
+//!     than `Interpreter::without_stdlib` (which panics under freeze-stdlib in 0.5
+//!     because it registers an EMPTY frozen set, and essential init then fails to
+//!     `import encodings`).
 
 use rustpython_vm as vm;
 
 // ---------------------------------------------------------------------------
-// getrandom 0.2 custom backend -> host import.
+// getrandom 0.3 custom backend -> host import.
 //
-// rustpython-vm pulls rand 0.8 -> rand_core -> getrandom 0.2. On
-// wasm32-unknown-unknown getrandom 0.2 has no default backend, so without this
-// any call to getrandom (e.g. seeding the hash randomization / `random` module)
-// would be a link error. We register a custom backend that delegates to a host
-// function `host_random`, which the wasmtime host (crate `hyprstream-wasm`) fills
-// from its OWN entropy source. The guest never has direct OS entropy access.
+// rustpython-vm 0.5 pulls getrandom 0.3 (no `js` feature). On
+// wasm32-unknown-unknown getrandom 0.3 has no default backend, so the build cfg
+// `getrandom_backend="custom"` (see .cargo/config.toml) selects an external symbol
+// `__getrandom_v03_custom`, which we provide here and which delegates to a host
+// function `host_random`. The wasmtime host (crate `hyprstream-wasm`) fills it from
+// its OWN entropy source. The guest never has direct OS entropy access.
 // ---------------------------------------------------------------------------
 extern "C" {
     /// Host import: fill `len` bytes at guest `ptr` with random data.
@@ -31,32 +43,19 @@ extern "C" {
     fn host_random(ptr: *mut u8, len: usize);
 }
 
-/// Shared backend: fill `buf` from the host import.
-fn fill_from_host(buf: &mut [u8]) {
-    // SAFETY: `buf` is a valid, exclusively-borrowed slice for `buf.len()` bytes.
-    // The host writes exactly `len` bytes into that range.
-    unsafe {
-        host_random(buf.as_mut_ptr(), buf.len());
-    }
-}
-
-// --- getrandom 0.2 custom backend (macro + `custom` feature) ---
-fn custom_getrandom02(buf: &mut [u8]) -> Result<(), getrandom02::Error> {
-    fill_from_host(buf);
-    Ok(())
-}
-getrandom02::register_custom_getrandom!(custom_getrandom02);
-
-// --- getrandom 0.3 custom backend (cfg getrandom_backend="custom" + extern symbol) ---
-// getrandom 0.3 looks up `__getrandom_v03_custom` by symbol when the build cfg is set.
-// Signature is `fn(*mut u8, usize) -> Result<(), getrandom03::Error>`.
+/// getrandom 0.3 custom backend: getrandom looks this symbol up by name when the
+/// build cfg `getrandom_backend="custom"` is set. Signature is fixed by getrandom 0.3:
+/// `fn(*mut u8, usize) -> Result<(), getrandom::Error>`.
+///
+/// # Safety
+/// `dest`..`dest+len` must be a valid, exclusively-borrowable region; getrandom
+/// guarantees this for the buffer it passes.
 #[no_mangle]
-unsafe fn __getrandom_v03_custom(
-    dest: *mut u8,
-    len: usize,
-) -> Result<(), getrandom03::Error> {
+unsafe fn __getrandom_v03_custom(dest: *mut u8, len: usize) -> Result<(), getrandom::Error> {
+    // SAFETY: getrandom 0.3 passes a valid writable `dest`/`len`; the host writes
+    // exactly `len` bytes into that range.
     let buf = std::slice::from_raw_parts_mut(dest, len);
-    fill_from_host(buf);
+    host_random(buf.as_mut_ptr(), buf.len());
     Ok(())
 }
 
@@ -87,6 +86,20 @@ pub unsafe extern "C" fn dealloc(ptr: *mut u8, len: usize) {
     }
 }
 
+/// Build a fresh interpreter WITH the frozen stdlib registered.
+///
+/// rustpython-vm 0.5: `Interpreter::without_stdlib` registers an empty frozen set,
+/// so under the `freeze-stdlib` feature `VirtualMachine::initialize` panics
+/// ("essential initialization failed") trying to `import encodings`. The supported
+/// embedding path is the builder, registering `rustpython_pylib::FROZEN_STDLIB`
+/// (the bytecode-frozen pure-Python stdlib baked into the binary — no filesystem
+/// import path, a capability win).
+fn build_interpreter() -> vm::Interpreter {
+    vm::Interpreter::builder(vm::Settings::default())
+        .add_frozen_modules(rustpython_pylib::FROZEN_STDLIB)
+        .build()
+}
+
 /// Interpret UTF-8 Python source in a fresh interpreter.
 ///
 /// Returns 0 on success, nonzero on any Python or decode error.
@@ -102,13 +115,11 @@ pub unsafe extern "C" fn eval(ptr: *const u8, len: usize) -> i32 {
     };
 
     // Fresh interpreter per call: no shared mutable state across evaluations.
-    let interp = vm::Interpreter::without_stdlib(Default::default());
+    let interp = build_interpreter();
 
     interp.enter(|vm| {
         let scope = vm.new_scope_with_builtins();
-        let code = match vm
-            .compile(src, vm::compiler::Mode::Exec, "<guest>".to_owned())
-        {
+        let code = match vm.compile(src, vm::compiler::Mode::Exec, "<guest>".to_owned()) {
             Ok(c) => c,
             Err(_) => return 3, // compile error
         };

--- a/crates/hyprstream-wasm/FINDINGS.md
+++ b/crates/hyprstream-wasm/FINDINGS.md
@@ -1,5 +1,12 @@
 # #505 P0 — WASM substrate build-viability spike: FINDINGS
 
+> **P1 UPDATE (host crate, branch `ewindisch/505-wasm-p1-host`).** The P0 blockers
+> below are RESOLVED. The guest now actually runs Python: `Sandbox::eval("print(1 + 1)")`
+> returns status **0** (no trap), and `wasm-tools print` confirms the guest imports
+> EXACTLY `{ env::host_random }` (zero JS/WASI/wasm-bindgen). See the appended
+> **"P1 RESOLUTIONS"** section at the end of this file for the exact APIs used; the P0
+> body below is preserved for historical context.
+
 Goal: prove RustPython can run as a `wasm32-unknown-unknown` guest under an embedded
 wasmtime host with ZERO WASI and a host-provided RNG — an untrusted-Python capability
 sandbox where `import os; os.system(...)` is inert by construction.
@@ -204,3 +211,103 @@ epoch bound):
 3. Add a real epoch bound: spawn an Engine::increment_epoch() timer thread and set a
    per-call set_epoch_deadline(n) so wall-clock DoS (not just fuel) is enforced; keep
    define_unknown_imports_as_traps as the deny-by-default capability fence.
+
+---
+
+## P1 RESOLUTIONS (branch `ewindisch/505-wasm-p1-host`)
+
+All four P1 deliverables landed; `cargo test -p hyprstream-wasm` is 9/9 green and
+`cargo clippy -p hyprstream-wasm --tests` is warning-clean.
+
+### 1. Green path — `print(1 + 1)` returns status 0; guest imports = `{ env::host_random }`
+
+- **Guest bump 0.3 -> 0.5.** `rustpython-vm = "0.5"` declares getrandom 0.3 (NO `js`),
+  so the custom getrandom-0.3 backend is finally reachable. Dropped the getrandom-0.2
+  dual backend entirely; the guest now keeps ONLY:
+  - `.cargo/config.toml`: `--cfg getrandom_backend="custom"` (+ `-C link-arg=--allow-undefined`)
+  - `lib.rs`: `#[no_mangle] unsafe fn __getrandom_v03_custom(*mut u8, usize) -> Result<(), getrandom::Error>`
+    delegating to the host import `host_random`.
+- **Frozen-stdlib construction (the exact 0.5 API).** `Interpreter::without_stdlib` +
+  `freeze-stdlib` panics in `VirtualMachine::initialize` ("essential initialization
+  failed") because it registers an EMPTY frozen set and essential init then fails to
+  `import encodings`. The supported embedded path is the BUILDER, registering the
+  frozen stdlib from the **`rustpython-pylib`** crate:
+
+  ```rust
+  use rustpython_vm as vm;
+  vm::Interpreter::builder(vm::Settings::default())
+      .add_frozen_modules(rustpython_pylib::FROZEN_STDLIB)
+      .build()
+  ```
+
+  KEY GOTCHA: on rustpython-vm 0.5 the `freeze-stdlib` cargo feature is merely an
+  alias for `encodings` — it does NOT itself embed the stdlib bytecode. You MUST add
+  `rustpython-pylib = { version = "0.5", features = ["freeze-stdlib"] }` as a direct
+  dependency and pass `rustpython_pylib::FROZEN_STDLIB` (a `&FrozenLib`, which iterates
+  as `(&'static str, FrozenModule)` — exactly what `add_frozen_modules` wants).
+- **`print` needs the `stdio` feature.** With `default-features=false` and no `stdio`,
+  `sys.stdout` is `None` and `print(...)` raises (eval returned status 1). Enabling the
+  `stdio` feature WITHOUT `host_env` selects the VM's SANDBOX stdio path
+  (`stdlib::sys::SandboxStdio` -> `std::io::stdout()`), which on
+  wasm32-unknown-unknown discards output (no real fd) — a capability WIN: `print`
+  succeeds (status 0) with ZERO host effect. Final guest feature set:
+  `["compiler", "encodings", "freeze-stdlib", "stdio"]`. We deliberately OMIT
+  `host_env` (would wire native `posix`/`os`), `wasmbind` (pulls wasm-bindgen/js — the
+  exact thing we eliminated), `gc`, `jit`, `threading`.
+- **Verified imports.** `wasm-tools print … | grep '(import '` on the release guest
+  shows EXACTLY `(import "env" "host_random" …)` — nothing else.
+- **`import os; os.system('echo PWNED')` is inert.** With `host_env` off there is no
+  native posix backend, so `os.system` raises a Python exception (eval status 1, NOT a
+  trap, NOT a host process). `case2_os_system_is_inert` asserts it never returns 0.
+
+### 2. Subject-scoped Store
+
+- New LOCAL newtype `Subject(pub Option<String>)` in `hyprstream-wasm` (no dep on
+  hyprstream-rpc/hyprstream-vfs yet — just the seam). `Subject::anonymous()` /
+  `Subject::named(id)` / `id()`.
+- P0's fixed `HostState` is generalized to `SandboxState { subject: Subject, rng_bytes }`,
+  carried as the wasmtime `Store` data. `host_random` reads `caller.data().subject` —
+  capability host fns are Subject-scoped by construction.
+- `Sandbox` is bound to one `Subject` at construction (`from_bytes_for(wasm, subject)`;
+  `from_bytes` = anonymous). Each `eval` builds a FRESH `Store` from the sandbox's own
+  subject — no global/thread-local state (the leak that killed native #488).
+- `subject_isolation_no_leak` test: two sandboxes bound to `alice` / `bob` keep
+  independent subjects across evals — PASSES.
+
+### 3. Real wall-clock DoS bound
+
+- New `EpochTimer::spawn(engine, tick)` — a background thread calling
+  `engine.increment_epoch()` every `tick` (default test cadence 10ms); `Drop` stops it.
+  The `Engine` is cheaply cloned (shared epoch counter) into the thread.
+- `Sandbox::eval_with_epoch_deadline(src, ticks)` sets `store.set_fuel(u64::MAX)` so the
+  EPOCH (not fuel) is the limiter, then `store.set_epoch_deadline(ticks)`. The P0 gotcha
+  holds: with `epoch_interruption(true)` every store defaults to deadline 0 and traps
+  immediately unless pushed out — the fuel path sets `set_epoch_deadline(u64::MAX)`.
+- `epoch_wall_clock_bound_traps_runaway` test: timer at 10ms + deadline 20 ticks traps
+  `while True: pass` with "wasm trap: interrupt" within ~hundreds of ms — PASSES. Fuel
+  remains the deterministic test option (`eval(src, fuel)`,
+  `case3_infinite_loop_is_fuel_bounded`).
+
+### 4. VFS host-fn seam (sketch for #483)
+
+- New module `hyprstream_wasm::vfs`. Trait `VfsCapability` with the Profile-A surface:
+  `vfs_walk / vfs_open / vfs_read / vfs_write / vfs_stat / vfs_ls / vfs_create`, each
+  taking `&Subject` (matching `hyprstream_vfs::Mount`'s methods, which already take
+  `&Subject`). `UnimplementedVfs` is the `Err(VfsError::Unimplemented)` default; an
+  in-memory test stub proves the Subject threads through and scopes (a "denied" subject
+  is refused). A `// P1b/#483:` comment documents that the real backing is
+  `hyprstream_vfs::spawn_vfs_proxy(ns, subject) -> Sender<VfsRequest>` held in Store
+  data, with sync wasm host fns submitting `VfsRequest { op, reply }` over it (the
+  proxy's `VfsOp` deliberately excludes mount/bind/unmount). `hyprstream-vfs` is NOT
+  pulled in (would drag the RPC/tokio stack into this minimal crate).
+
+### Remaining notes / next step
+
+- `import io` (the pure-Python frozen `io` module) still returns status 1 — it is not
+  needed for `print` (which uses native `_io` + sandbox stdio directly) and no test
+  depends on it. If a future guest needs `io`, investigate the frozen `io` module's
+  init under the sandbox stdio path. NOT a blocker for P1.
+- Next step (P1b/#483): replace `vfs::UnimplementedVfs` with the real
+  `spawn_vfs_proxy`-backed impl held in `SandboxState`, and add the `env::vfs_*` host
+  fns to `build_linker` (sync shims over the proxy `Sender`), reading
+  `caller.data().subject` for scoping.

--- a/crates/hyprstream-wasm/src/lib.rs
+++ b/crates/hyprstream-wasm/src/lib.rs
@@ -1,4 +1,4 @@
-//! Embedded wasmtime host for the #505 untrusted-Python capability sandbox spike.
+//! Embedded wasmtime host for the #505 untrusted-Python capability sandbox.
 //!
 //! The whole point: run the RustPython guest (`hyprstream-wasm-pyguest`, compiled
 //! to `wasm32-unknown-unknown`) under wasmtime with a BESPOKE `Linker` that exposes
@@ -6,27 +6,96 @@
 //! WASI. No `wasmtime-wasi`, no `add_to_linker`, no preopens. Therefore the guest's
 //! `import os; os.system(...)` cannot reach a real OS: there is no syscall surface.
 //!
-//! DoS guards available on the `Store` (wasmtime 46.0.1 spellings):
+//! P1 additions vs. the P0 spike:
+//!   * The guest now actually RUNS Python: rustpython-vm 0.5 + a single
+//!     `env::host_random` import (verified) means `print(1 + 1)` returns status 0.
+//!   * The `Store` data is generalized from a fixed `HostState` into a
+//!     [`SandboxState`] that carries a per-call [`Subject`] (tenant/identity).
+//!     Capability host fns (today `host_random`, tomorrow VFS — see [`vfs`]) are
+//!     Subject-scoped BY CONSTRUCTION: they read the Subject out of the Store.
+//!   * A real wall-clock DoS bound: an [`EpochTimer`] thread advances the engine
+//!     epoch on a fixed cadence, and [`Sandbox::eval`] sets a per-call epoch
+//!     deadline, so a runaway guest (`while True: pass`) traps within ~the timeout
+//!     in PRODUCTION, not just in the fuel test path.
+//!
+//! DoS guards on the `Store` (wasmtime 46.0.1 spellings):
 //!   * fuel  (`Config::consume_fuel(true)` + `Store::set_fuel(u64)`)
-//!   * epoch (`Config::epoch_interruption(true)` + `Store::set_epoch_deadline(u64)` +
-//!            `Engine::increment_epoch()`)
+//!   * epoch (`Config::epoch_interruption(true)` + `Store::set_epoch_deadline(u64)`
+//!     + `Engine::increment_epoch()`)
 //!
 //! NB: wasmtime 46 ships its OWN error type (`wasmtime::Error` / `wasmtime::Result`,
 //! NOT `anyhow::Error`), with an inherent `wasmtime::Context` trait. We use those.
 
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Boxed entropy source: fills a byte buffer. Boxed so [`SandboxState`] can hold an
+/// OS-backed or deterministic-test RNG behind the same field.
+type RngFill = Box<dyn FnMut(&mut [u8]) + Send>;
+
 use wasmtime::error::Context as _;
 use wasmtime::{bail, Caller, Config, Engine, Extern, Linker, Memory, Module, Result, Store};
 
-/// Per-instance host state. Holds an RNG used by the single capability function.
-pub struct HostState {
-    rng_bytes: Box<dyn FnMut(&mut [u8]) + Send>,
+pub mod vfs;
+
+// ---------------------------------------------------------------------------
+// Subject: the identity/tenant a sandbox call runs as.
+// ---------------------------------------------------------------------------
+
+/// The identity a sandbox evaluation runs as.
+///
+/// Modelled as a LOCAL newtype for now (P1): deliberately NOT a dependency on
+/// `hyprstream-rpc`/`hyprstream-vfs` yet — we are only defining the seam so that
+/// future capability host-fns are Subject-scoped by construction. When #483 / the
+/// native MAC authz epic re-cuts this, swap the inner representation for the real
+/// `RequestIdentity` / VFS namespace key without touching the Linker wiring.
+///
+/// `None` is the anonymous subject (no bound identity).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Subject(pub Option<String>);
+
+impl Subject {
+    /// An anonymous subject (no bound identity).
+    pub fn anonymous() -> Self {
+        Self(None)
+    }
+
+    /// A subject bound to a named identity/tenant.
+    pub fn named(id: impl Into<String>) -> Self {
+        Self(Some(id.into()))
+    }
+
+    /// The bound identity, if any.
+    pub fn id(&self) -> Option<&str> {
+        self.0.as_deref()
+    }
 }
 
-impl HostState {
-    /// Default host state: fills randomness from the OS via `rand`/`getrandom`.
-    /// (The HOST has OS entropy; the guest only sees it through `host_random`.)
-    pub fn new() -> Self {
+// ---------------------------------------------------------------------------
+// Per-call Store data.
+// ---------------------------------------------------------------------------
+
+/// Per-call host state carried in the wasmtime `Store` data.
+///
+/// Generalizes the P0 `HostState` (which held only an RNG) to ALSO carry the
+/// [`Subject`] the call runs as. Every capability host function gets a
+/// `Caller<'_, SandboxState>` and so can read `caller.data().subject` — the
+/// capability surface is Subject-parameterized without any global/thread-local
+/// state (the leak that killed the native #488 design).
+pub struct SandboxState {
+    /// The identity this evaluation runs as. Future capability host-fns
+    /// (`vfs_*`, etc.) are authorized/scoped against this.
+    pub subject: Subject,
+    /// Entropy source for the single `host_random` capability. The HOST has OS
+    /// entropy; the guest only ever sees it through this function.
+    rng_bytes: RngFill,
+}
+
+impl SandboxState {
+    /// Host state for the given subject, drawing randomness from the OS.
+    pub fn new(subject: Subject) -> Self {
         Self {
+            subject,
             rng_bytes: Box::new(|buf| {
                 use rand::RngCore;
                 rand::thread_rng().fill_bytes(buf);
@@ -35,8 +104,9 @@ impl HostState {
     }
 
     /// Deterministic host state for tests (fills with a fixed pattern).
-    pub fn deterministic(seed: u8) -> Self {
+    pub fn deterministic(subject: Subject, seed: u8) -> Self {
         Self {
+            subject,
             rng_bytes: Box::new(move |buf| {
                 for (i, b) in buf.iter_mut().enumerate() {
                     *b = seed.wrapping_add(i as u8);
@@ -44,11 +114,10 @@ impl HostState {
             }),
         }
     }
-}
 
-impl Default for HostState {
-    fn default() -> Self {
-        Self::new()
+    /// The subject this state is bound to.
+    pub fn subject(&self) -> &Subject {
+        &self.subject
     }
 }
 
@@ -57,26 +126,91 @@ pub fn build_engine() -> Result<Engine> {
     let mut config = Config::new();
     // Epoch interruption: cooperative deadline interruption (cheap, no per-op cost).
     config.epoch_interruption(true);
-    // Fuel: deterministic instruction budget (used by the DoS test).
+    // Fuel: deterministic instruction budget (used by the deterministic DoS test).
     config.consume_fuel(true);
     Engine::new(&config).context("build wasmtime engine")
 }
 
+// ---------------------------------------------------------------------------
+// Epoch timer: the real wall-clock DoS bound.
+// ---------------------------------------------------------------------------
+
+/// A background thread that advances an [`Engine`]'s epoch at a fixed cadence.
+///
+/// wasmtime's epoch interruption is the cheap, production-grade way to enforce a
+/// WALL-CLOCK timeout (fuel is deterministic but instruction-count based, which is
+/// the right tool for tests, not for "kill anything that runs longer than N ms").
+/// This timer ticks every `tick`; a per-call `Store::set_epoch_deadline(n)` then
+/// means the guest traps with "interrupt" after roughly `n * tick` of wall time.
+///
+/// Dropping the timer stops the thread (cooperatively, within one tick).
+pub struct EpochTimer {
+    handle: Option<std::thread::JoinHandle<()>>,
+    stop: Arc<std::sync::atomic::AtomicBool>,
+    tick: Duration,
+}
+
+impl EpochTimer {
+    /// Spawn a timer that calls `engine.increment_epoch()` every `tick`.
+    pub fn spawn(engine: &Engine, tick: Duration) -> Self {
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        // The Engine is cheaply cloneable (Arc inside) and the clone shares the
+        // same epoch counter, so the timer's increments are observed by stores
+        // created from the original engine.
+        let engine = engine.clone();
+        let stop_clone = stop.clone();
+        let handle = std::thread::Builder::new()
+            .name("hyprstream-wasm-epoch".into())
+            .spawn(move || {
+                while !stop_clone.load(std::sync::atomic::Ordering::Relaxed) {
+                    std::thread::sleep(tick);
+                    engine.increment_epoch();
+                }
+            })
+            .expect("spawn epoch timer thread");
+        Self {
+            handle: Some(handle),
+            stop,
+            tick,
+        }
+    }
+
+    /// The cadence at which this timer advances the epoch.
+    pub fn tick(&self) -> Duration {
+        self.tick
+    }
+}
+
+impl Drop for EpochTimer {
+    fn drop(&mut self) {
+        self.stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+    }
+}
+
 /// Construct the bespoke Linker exposing ONLY `env::host_random`.
 ///
-/// Every other import the guest declares (the dead chrono/js-sys/getrandom-js
-/// `__wbindgen_placeholder__` stubs that RustPython drags in on the wasm target)
-/// is wired to a trap via `define_unknown_imports_as_traps` — so if guest code ever
-/// actually reached for them it would trap rather than silently linking to nothing.
-/// This is what keeps the capability surface to exactly one function.
-pub fn build_linker(engine: &Engine, module: &Module) -> Result<Linker<HostState>> {
-    let mut linker: Linker<HostState> = Linker::new(engine);
+/// Every other import the guest declares is wired to a trap via
+/// `define_unknown_imports_as_traps` — so if guest code ever actually reached for
+/// them it would trap rather than silently linking to nothing. This is what keeps
+/// the capability surface to exactly one function. (With rustpython-vm 0.5 the guest
+/// declares EXACTLY `env::host_random` and nothing else — but the trap-everything
+/// fence stays as a deny-by-default belt-and-suspenders for any future guest.)
+pub fn build_linker(engine: &Engine, module: &Module) -> Result<Linker<SandboxState>> {
+    let mut linker: Linker<SandboxState> = Linker::new(engine);
 
     // The ONE capability: fill guest memory[ptr..ptr+len] with host randomness.
+    // It reads its Subject from the Store data (`caller.data().subject`), so it is
+    // Subject-scoped by construction — the seam future capability fns reuse.
     linker.func_wrap(
         "env",
         "host_random",
-        |mut caller: Caller<'_, HostState>, ptr: i32, len: i32| -> Result<()> {
+        |mut caller: Caller<'_, SandboxState>, ptr: i32, len: i32| -> Result<()> {
+            // Subject is available here for scoping/auditing (RNG is granted to all
+            // subjects; the point is the seam, not a denial for entropy).
+            let _subject = caller.data().subject.clone();
             let memory = match caller.get_export("memory") {
                 Some(Extern::Memory(m)) => m,
                 _ => bail!("guest has no exported memory"),
@@ -90,8 +224,7 @@ pub fn build_linker(engine: &Engine, module: &Module) -> Result<Linker<HostState
     )?;
 
     // Wire every OTHER declared import to a trap. This is the explicit, auditable
-    // statement that the guest gets NO other host capability — any dead JS/WASI-ish
-    // import becomes a trap-if-called rather than an instantiation failure.
+    // statement that the guest gets NO other host capability.
     linker.define_unknown_imports_as_traps(module)?;
 
     Ok(linker)
@@ -99,7 +232,7 @@ pub fn build_linker(engine: &Engine, module: &Module) -> Result<Linker<HostState
 
 fn write_memory(
     memory: &Memory,
-    store: &mut Caller<'_, HostState>,
+    store: &mut Caller<'_, SandboxState>,
     offset: usize,
     data: &[u8],
 ) -> Result<()> {
@@ -115,16 +248,28 @@ fn write_memory(
     Ok(())
 }
 
-/// A loaded, ready-to-run sandbox over a single guest module.
+/// A loaded, ready-to-run sandbox over a single guest module, bound to one
+/// [`Subject`].
+///
+/// Constructing a `Sandbox` binds it to a Subject; every `eval` on it runs as that
+/// Subject. Two `Sandbox`es bound to different Subjects keep independent Store
+/// identity (no shared global/thread-local state) — see the `subject_isolation`
+/// test.
 pub struct Sandbox {
     engine: Engine,
     module: Module,
-    linker: Linker<HostState>,
+    linker: Linker<SandboxState>,
+    subject: Subject,
 }
 
 impl Sandbox {
-    /// Load a guest module from raw wasm bytes.
+    /// Load a guest module from raw wasm bytes, bound to the anonymous subject.
     pub fn from_bytes(wasm: &[u8]) -> Result<Self> {
+        Self::from_bytes_for(wasm, Subject::anonymous())
+    }
+
+    /// Load a guest module from raw wasm bytes, bound to `subject`.
+    pub fn from_bytes_for(wasm: &[u8], subject: Subject) -> Result<Self> {
         let engine = build_engine()?;
         let module = Module::new(&engine, wasm).context("compile guest module")?;
         let linker = build_linker(&engine, &module)?;
@@ -132,24 +277,58 @@ impl Sandbox {
             engine,
             module,
             linker,
+            subject,
         })
+    }
+
+    /// The subject this sandbox is bound to.
+    pub fn subject(&self) -> &Subject {
+        &self.subject
+    }
+
+    /// Fresh per-call Store for this sandbox's subject, with the epoch pushed out
+    /// of the way (so the caller chooses fuel- or epoch-bounding explicitly).
+    fn new_store(&self) -> Store<SandboxState> {
+        Store::new(&self.engine, SandboxState::new(self.subject.clone()))
     }
 
     /// Run `source` in a fresh interpreter with the given fuel budget.
     ///
     /// Returns the guest `eval` status (0 = ok, nonzero = python error) on normal
-    /// completion, or `Err` if the guest TRAPPED (e.g. ran out of fuel / hit the
-    /// epoch deadline / a dead import was actually called).
+    /// completion, or `Err` if the guest TRAPPED (e.g. ran out of fuel / a dead
+    /// import was actually called). Deterministic; preferred for tests.
     pub fn eval(&self, source: &str, fuel: u64) -> Result<i32> {
-        let mut store = Store::new(&self.engine, HostState::new());
+        let mut store = self.new_store();
         // DoS guard #1: instruction budget.
         store.set_fuel(fuel).context("set fuel")?;
         // Because the engine has epoch_interruption(true), EVERY store defaults to
         // an epoch deadline of 0 and would trap immediately ("wasm trap: interrupt")
         // unless we push the deadline out. For the fuel-bounded path we disable the
-        // epoch by setting it effectively infinite, so fuel is the only limiter here.
+        // epoch by setting it effectively infinite, so fuel is the only limiter.
         store.set_epoch_deadline(u64::MAX);
+        self.run(store, source)
+    }
 
+    /// Run `source` with a WALL-CLOCK epoch deadline of `ticks` epoch increments.
+    ///
+    /// This is the PRODUCTION DoS bound: paired with an [`EpochTimer`] spawned on
+    /// [`Sandbox::engine`] ticking every `t`, the guest traps with "interrupt"
+    /// after roughly `ticks * t` of wall time. Fuel is set effectively infinite so
+    /// the epoch (not fuel) is the limiter.
+    ///
+    /// The caller owns the [`EpochTimer`]; this method does not start one (so the
+    /// timer cadence/lifetime is explicit and the engine is shared by reference).
+    pub fn eval_with_epoch_deadline(&self, source: &str, ticks: u64) -> Result<i32> {
+        let mut store = self.new_store();
+        // Give plenty of fuel so the EPOCH deadline (not fuel) is the limiter here.
+        store.set_fuel(u64::MAX).context("set fuel")?;
+        // DoS guard #2: epoch deadline. Trap once the engine epoch advances `ticks`.
+        store.set_epoch_deadline(ticks);
+        self.run(store, source)
+    }
+
+    /// Shared instantiate + ship-source + call-eval body.
+    fn run(&self, mut store: Store<SandboxState>, source: &str) -> Result<i32> {
         let instance = self
             .linker
             .instantiate(&mut store, &self.module)
@@ -175,34 +354,8 @@ impl Sandbox {
         status.context("guest eval trapped")
     }
 
-    /// Run with an EPOCH deadline instead of fuel (demonstrates the epoch path).
-    ///
-    /// The caller is responsible for calling `engine().increment_epoch()` from
-    /// another thread/timer to actually fire the deadline. This method exists to
-    /// prove the epoch API compiles and is wired; the fuel test is the deterministic
-    /// DoS assertion.
-    pub fn eval_with_epoch_deadline(&self, source: &str, ticks: u64) -> Result<i32> {
-        let mut store = Store::new(&self.engine, HostState::new());
-        // Give plenty of fuel so the EPOCH deadline (not fuel) is the limiter here.
-        store.set_fuel(u64::MAX).context("set fuel")?;
-        // DoS guard #2: epoch deadline. Trap once the engine epoch advances `ticks`.
-        store.set_epoch_deadline(ticks);
-
-        let instance = self.linker.instantiate(&mut store, &self.module)?;
-        let alloc = instance.get_typed_func::<i32, i32>(&mut store, "alloc")?;
-        let eval = instance.get_typed_func::<(i32, i32), i32>(&mut store, "eval")?;
-        let memory = match instance.get_memory(&mut store, "memory") {
-            Some(m) => m,
-            None => bail!("guest memory export"),
-        };
-
-        let bytes = source.as_bytes();
-        let len = bytes.len() as i32;
-        let ptr = alloc.call(&mut store, len)?;
-        memory.write(&mut store, ptr as usize, bytes)?;
-        eval.call(&mut store, (ptr, len)).context("guest eval trapped")
-    }
-
+    /// The engine backing this sandbox. Spawn an [`EpochTimer`] on it to enable the
+    /// wall-clock bound used by [`Sandbox::eval_with_epoch_deadline`].
     pub fn engine(&self) -> &Engine {
         &self.engine
     }

--- a/crates/hyprstream-wasm/src/vfs.rs
+++ b/crates/hyprstream-wasm/src/vfs.rs
@@ -1,0 +1,304 @@
+//! VFS host-function seam (Profile-A capability surface) — SKETCH for #483.
+//!
+//! This module is a DESIGN SEAM, not a working implementation. It records the
+//! shape of the VFS capability host functions as they will be wired into the
+//! wasmtime [`Linker`](wasmtime::Linker) so that a future guest can do file I/O —
+//! but ONLY against a per-[`Subject`](crate::Subject) VFS namespace, never the host
+//! filesystem.
+//!
+//! ## How it will wire up (Profile A)
+//!
+//! Each host fn below maps 1:1 to a method on `hyprstream_vfs`'s `Mount`/`Namespace`
+//! surface, every one of which already takes a `&Subject`:
+//!
+//! ```text
+//!   vfs_walk   -> Namespace::walk     (resolve a path to a Fid)
+//!   vfs_open   -> Mount::open
+//!   vfs_read   -> Namespace::read_one / Mount::read
+//!   vfs_write  -> Mount::write
+//!   vfs_stat   -> Mount::stat
+//!   vfs_ls     -> Namespace::ls / Mount::readdir
+//!   vfs_create -> Namespace::create / Mount::create
+//! ```
+//!
+//! The Store data ([`crate::SandboxState`]) already carries the bound `Subject`;
+//! the wired host fns will read `caller.data().subject` and pass it straight to the
+//! VFS, so file access is Subject-scoped BY CONSTRUCTION (same pattern as
+//! `host_random`).
+//!
+// P1b/#483: the concrete backing will be a `hyprstream_vfs::spawn_vfs_proxy(ns, subject)
+// -> tokio::sync::mpsc::Sender<VfsRequest>` held in the Store data. The host fns here
+// become sync shims that submit a `VfsRequest { op, reply }` over that Sender and block
+// on the reply channel (the proxy bridges sync wasm calls to the async Namespace, and
+// its `VfsOp` enum DELIBERATELY excludes mount/bind/unmount — scripts cannot remount).
+// We do NOT pull in `hyprstream-vfs` yet (it would drag the RPC/tokio stack into this
+// otherwise-minimal host crate); this seam exists only so the design compiles and the
+// #483 re-cut has a typed target.
+//
+//! Until #483, the trait below is backed by a trivial in-memory stub
+//! ([`InMemoryVfs`]) used only by the seam test, so the surface compiles and is
+//! legible.
+
+use crate::Subject;
+
+/// Errors a VFS capability host fn can return to the guest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VfsError {
+    /// The subject is not authorized to touch this path.
+    Denied,
+    /// No such path / fid.
+    NotFound,
+    /// Not implemented yet (the #483 default).
+    Unimplemented,
+    /// Any other backend error, stringified.
+    Other(String),
+}
+
+impl std::fmt::Display for VfsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VfsError::Denied => write!(f, "vfs: permission denied"),
+            VfsError::NotFound => write!(f, "vfs: not found"),
+            VfsError::Unimplemented => write!(f, "vfs: unimplemented (P1b/#483)"),
+            VfsError::Other(s) => write!(f, "vfs: {s}"),
+        }
+    }
+}
+
+impl std::error::Error for VfsError {}
+
+/// An opaque file handle (mirrors `hyprstream_vfs::mount::Fid`).
+pub type Fid = u64;
+
+/// A directory entry (the subset the guest needs).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DirEntry {
+    pub name: String,
+    pub is_dir: bool,
+}
+
+/// File metadata (the subset the guest needs).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Stat {
+    pub len: u64,
+    pub is_dir: bool,
+}
+
+/// The Profile-A VFS capability surface, as it will be exposed to the guest.
+///
+/// EVERY method takes the call's [`Subject`] so the implementation can scope/authorize
+/// per identity. This is the exact set of host fns the Linker will define under `env`
+/// (`vfs_walk`, `vfs_open`, ...). The ABI those host fns present to wasm (ptr/len pairs
+/// into guest linear memory, return-code conventions) is out of scope for this sketch;
+/// this trait captures the typed Rust surface they delegate to.
+pub trait VfsCapability {
+    /// Resolve a path to a file handle. -> `Namespace::walk`.
+    fn vfs_walk(&self, subject: &Subject, path: &str) -> Result<Fid, VfsError>;
+
+    /// Open an existing handle with the given mode bits. -> `Mount::open`.
+    fn vfs_open(&self, subject: &Subject, fid: Fid, mode: u8) -> Result<(), VfsError>;
+
+    /// Read `count` bytes at `offset` from a handle. -> `Mount::read`.
+    fn vfs_read(
+        &self,
+        subject: &Subject,
+        fid: Fid,
+        offset: u64,
+        count: u32,
+    ) -> Result<Vec<u8>, VfsError>;
+
+    /// Write `data` at `offset` to a handle, returning bytes written. -> `Mount::write`.
+    fn vfs_write(
+        &self,
+        subject: &Subject,
+        fid: Fid,
+        offset: u64,
+        data: &[u8],
+    ) -> Result<u32, VfsError>;
+
+    /// Stat a handle. -> `Mount::stat`.
+    fn vfs_stat(&self, subject: &Subject, fid: Fid) -> Result<Stat, VfsError>;
+
+    /// List a directory handle. -> `Mount::readdir` / `Namespace::ls`.
+    fn vfs_ls(&self, subject: &Subject, fid: Fid) -> Result<Vec<DirEntry>, VfsError>;
+
+    /// Create a new file under a directory handle. -> `Mount::create`.
+    fn vfs_create(&self, subject: &Subject, dir: Fid, name: &str) -> Result<Fid, VfsError>;
+}
+
+/// The #483 default: every VFS call is unimplemented until the real
+/// `hyprstream_vfs` proxy is wired in.
+///
+/// Kept as a typed placeholder so the Linker-wiring code can be written against
+/// [`VfsCapability`] today and only the backing object swapped later.
+pub struct UnimplementedVfs;
+
+impl VfsCapability for UnimplementedVfs {
+    fn vfs_walk(&self, _subject: &Subject, _path: &str) -> Result<Fid, VfsError> {
+        // P1b/#483: replace with a VfsRequest over spawn_vfs_proxy's Sender.
+        Err(VfsError::Unimplemented)
+    }
+    fn vfs_open(&self, _subject: &Subject, _fid: Fid, _mode: u8) -> Result<(), VfsError> {
+        Err(VfsError::Unimplemented)
+    }
+    fn vfs_read(
+        &self,
+        _subject: &Subject,
+        _fid: Fid,
+        _offset: u64,
+        _count: u32,
+    ) -> Result<Vec<u8>, VfsError> {
+        Err(VfsError::Unimplemented)
+    }
+    fn vfs_write(
+        &self,
+        _subject: &Subject,
+        _fid: Fid,
+        _offset: u64,
+        _data: &[u8],
+    ) -> Result<u32, VfsError> {
+        Err(VfsError::Unimplemented)
+    }
+    fn vfs_stat(&self, _subject: &Subject, _fid: Fid) -> Result<Stat, VfsError> {
+        Err(VfsError::Unimplemented)
+    }
+    fn vfs_ls(&self, _subject: &Subject, _fid: Fid) -> Result<Vec<DirEntry>, VfsError> {
+        Err(VfsError::Unimplemented)
+    }
+    fn vfs_create(&self, _subject: &Subject, _dir: Fid, _name: &str) -> Result<Fid, VfsError> {
+        Err(VfsError::Unimplemented)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    /// A trivial in-memory VFS used ONLY to prove the seam is legible and that the
+    /// Subject is threaded through every call. Not a real namespace; #483 replaces
+    /// it with the `hyprstream_vfs` proxy. Single-threaded test stub, so a
+    /// `RefCell` is sufficient for interior mutability.
+    struct InMemoryVfs {
+        // fid -> (name, contents). Subject "denied" is refused, to show scoping.
+        files: RefCell<HashMap<Fid, (String, Vec<u8>)>>,
+    }
+
+    impl InMemoryVfs {
+        fn new() -> Self {
+            let mut files = HashMap::new();
+            files.insert(1u64, ("hello.txt".to_string(), b"hi".to_vec()));
+            Self {
+                files: RefCell::new(files),
+            }
+        }
+
+        fn check(subject: &Subject) -> Result<(), VfsError> {
+            if subject.id() == Some("denied") {
+                return Err(VfsError::Denied);
+            }
+            Ok(())
+        }
+    }
+
+    impl VfsCapability for InMemoryVfs {
+        fn vfs_walk(&self, subject: &Subject, path: &str) -> Result<Fid, VfsError> {
+            Self::check(subject)?;
+            let files = self.files.borrow();
+            files
+                .iter()
+                .find(|(_, (name, _))| name == path)
+                .map(|(fid, _)| *fid)
+                .ok_or(VfsError::NotFound)
+        }
+        fn vfs_open(&self, subject: &Subject, fid: Fid, _mode: u8) -> Result<(), VfsError> {
+            Self::check(subject)?;
+            if self.files.borrow().contains_key(&fid) {
+                Ok(())
+            } else {
+                Err(VfsError::NotFound)
+            }
+        }
+        fn vfs_read(
+            &self,
+            subject: &Subject,
+            fid: Fid,
+            offset: u64,
+            count: u32,
+        ) -> Result<Vec<u8>, VfsError> {
+            Self::check(subject)?;
+            let files = self.files.borrow();
+            let (_, data) = files.get(&fid).ok_or(VfsError::NotFound)?;
+            let start = (offset as usize).min(data.len());
+            let end = (start + count as usize).min(data.len());
+            Ok(data[start..end].to_vec())
+        }
+        fn vfs_write(
+            &self,
+            subject: &Subject,
+            fid: Fid,
+            _offset: u64,
+            data: &[u8],
+        ) -> Result<u32, VfsError> {
+            Self::check(subject)?;
+            let mut files = self.files.borrow_mut();
+            let entry = files.get_mut(&fid).ok_or(VfsError::NotFound)?;
+            entry.1 = data.to_vec();
+            Ok(data.len() as u32)
+        }
+        fn vfs_stat(&self, subject: &Subject, fid: Fid) -> Result<Stat, VfsError> {
+            Self::check(subject)?;
+            let files = self.files.borrow();
+            let (_, data) = files.get(&fid).ok_or(VfsError::NotFound)?;
+            Ok(Stat {
+                len: data.len() as u64,
+                is_dir: false,
+            })
+        }
+        fn vfs_ls(&self, subject: &Subject, _fid: Fid) -> Result<Vec<DirEntry>, VfsError> {
+            Self::check(subject)?;
+            Ok(self
+                .files
+                .borrow()
+                .values()
+                .map(|(name, _)| DirEntry {
+                    name: name.clone(),
+                    is_dir: false,
+                })
+                .collect())
+        }
+        fn vfs_create(&self, subject: &Subject, _dir: Fid, name: &str) -> Result<Fid, VfsError> {
+            Self::check(subject)?;
+            let mut files = self.files.borrow_mut();
+            let fid = files.keys().max().copied().unwrap_or(0) + 1;
+            files.insert(fid, (name.to_string(), Vec::new()));
+            Ok(fid)
+        }
+    }
+
+    #[test]
+    fn unimplemented_seam_is_inert() {
+        let vfs = UnimplementedVfs;
+        let s = Subject::anonymous();
+        assert_eq!(vfs.vfs_walk(&s, "x"), Err(VfsError::Unimplemented));
+        assert_eq!(vfs.vfs_stat(&s, 0), Err(VfsError::Unimplemented));
+    }
+
+    #[test]
+    fn seam_threads_subject_through_and_scopes() {
+        let vfs = InMemoryVfs::new();
+        let ok = Subject::named("alice");
+        let denied = Subject::named("denied");
+
+        // The Subject reaches the backend: "denied" is refused at the seam.
+        assert_eq!(vfs.vfs_walk(&denied, "hello.txt"), Err(VfsError::Denied));
+
+        // An allowed subject can resolve + read.
+        let fid = vfs.vfs_walk(&ok, "hello.txt").expect("walk");
+        vfs.vfs_open(&ok, fid, 0).expect("open");
+        let data = vfs.vfs_read(&ok, fid, 0, 8).expect("read");
+        assert_eq!(data, b"hi");
+        assert_eq!(vfs.vfs_stat(&ok, fid).unwrap().len, 2);
+    }
+}

--- a/crates/hyprstream-wasm/tests/sandbox.rs
+++ b/crates/hyprstream-wasm/tests/sandbox.rs
@@ -1,4 +1,4 @@
-//! Integration tests for the #505 capability-sandbox spike.
+//! Integration tests for the #505 capability sandbox (P1 host).
 //!
 //! These tests need the guest wasm artifact built first:
 //!   cargo build --release --target wasm32-unknown-unknown \
@@ -11,20 +11,18 @@
 //! Set HYPRSTREAM_PYGUEST_WASM to override the path. If the artifact is absent the
 //! tests SKIP (return early) rather than fail.
 //!
-//! IMPORTANT (see FINDINGS.md): with rustpython-vm 0.3 the VM bootstrap traps at
-//! `VirtualMachine::new` because rustpython-vm 0.3.1 force-enables `getrandom/js`,
-//! whose backend OUTRANKS the registered custom backend and reaches for undefined
-//! `__wbindgen_placeholder__` JS imports. That trap is itself a capability proof:
-//! the guest reaches for something the host did not grant and is stopped. The clean
-//! GREEN path (single `host_random` import, no JS) is rustpython-vm 0.5 + getrandom
-//! 0.3 custom backend — validated in FINDINGS.md. These tests therefore accept EITHER
-//! a clean status code OR a trap, and assert the structural invariant: the host can
-//! never have produced an external side effect, because the Linker defines exactly
-//! one function (`host_random`) and traps every other import.
+//! P1 (rustpython-vm 0.5): the guest now ACTUALLY runs Python. The guest declares
+//! exactly one import, `env::host_random` (verified with wasm-tools), and the host
+//! Linker defines exactly that function and traps every other import. So:
+//!   * case1 `print(1 + 1)` returns a CLEAN status 0 (no trap),
+//!   * case2 `import os; os.system('echo PWNED')` is inert (python exception, never
+//!     a host process — there is no syscall surface),
+//!   * the fuel and epoch DoS guards trap as expected.
 
 use std::path::PathBuf;
+use std::time::{Duration, Instant};
 
-use hyprstream_wasm::Sandbox;
+use hyprstream_wasm::{EpochTimer, Sandbox, Subject};
 
 fn guest_wasm() -> Option<Vec<u8>> {
     if let Ok(p) = std::env::var("HYPRSTREAM_PYGUEST_WASM") {
@@ -52,41 +50,40 @@ fn guest_wasm() -> Option<Vec<u8>> {
 const BIG_FUEL: u64 = 50_000_000_000;
 
 /// The Linker must accept ANY guest module and expose exactly one host import,
-/// trapping everything else. Loading must succeed regardless of rustpython version.
+/// trapping everything else. Loading must succeed.
 #[test]
 fn sandbox_loads_with_single_capability() {
     let Some(wasm) = guest_wasm() else {
         eprintln!("SKIP: guest wasm not built");
         return;
     };
-    // from_bytes builds the engine (fuel+epoch), compiles the module, and wires the
-    // bespoke Linker (host_random + define_unknown_imports_as_traps). If this errors,
-    // the host-side capability wiring is broken.
     Sandbox::from_bytes(&wasm).expect("sandbox must load any guest with the 1-capability linker");
 }
 
-/// Case 1: `print(1 + 1)`. On the green (0.5) path returns status 0. On the 0.3
-/// path it traps at VM init (getrandom/js). Either way: no host side effect.
+/// Case 1: `print(1 + 1)` — the green path. With rustpython-vm 0.5 + frozen stdlib
+/// the VM boots and runs, so this returns a CLEAN status 0 (no trap, no host effect).
 #[test]
-fn case1_arithmetic() {
+fn case1_arithmetic_is_green() {
     let Some(wasm) = guest_wasm() else {
         eprintln!("SKIP case1: guest wasm not built");
         return;
     };
     let sandbox = Sandbox::from_bytes(&wasm).expect("load sandbox");
-    match sandbox.eval("print(1 + 1)", BIG_FUEL) {
-        Ok(0) => eprintln!("case1: GREEN — print(1+1) succeeded (status 0)"),
-        Ok(n) => eprintln!("case1: python error status {n} (still no host effect)"),
-        Err(t) => eprintln!("case1: trapped at VM bootstrap: {t} (still no host effect)"),
-    }
+    let status = sandbox
+        .eval("print(1 + 1)", BIG_FUEL)
+        .expect("print(1+1) must NOT trap on the 0.5 green path");
+    assert_eq!(status, 0, "print(1+1) must return status 0 (clean run)");
+    eprintln!("case1: GREEN — print(1+1) returned status 0");
 }
 
-/// Case 2: `import os; os.system('echo PWNED')`. The capability proof.
+/// Case 2: `import os; os.system('echo PWNED')` — the capability proof.
 ///
 /// The HARD guarantee is structural: the guest has NO syscall surface — only
 /// `host_random`. The host Linker wires no process spawner, so `echo PWNED` cannot
-/// execute. Whatever happens at the Python layer (exception or trap), there is
-/// provably no host process.
+/// execute. On the 0.5 green path the VM boots and `os.system` raises a Python
+/// exception (no native backend), so `eval` returns a NONZERO status WITHOUT
+/// trapping and without any host process. We assert it is inert: either a nonzero
+/// python-error status or a trap, never status 0, and never a host effect.
 #[test]
 fn case2_os_system_is_inert() {
     let Some(wasm) = guest_wasm() else {
@@ -95,47 +92,115 @@ fn case2_os_system_is_inert() {
     };
     let sandbox = Sandbox::from_bytes(&wasm).expect("load sandbox");
     match sandbox.eval("import os; os.system('echo PWNED')", BIG_FUEL) {
-        Ok(n) => eprintln!("case2: returned status {n}; no host process possible"),
-        Err(t) => eprintln!("case2: trapped: {t}; no host process possible"),
+        Ok(0) => panic!("os.system must NOT succeed — there is no host syscall surface"),
+        Ok(n) => eprintln!("case2: inert — python error status {n}; no host process possible"),
+        Err(t) => eprintln!("case2: inert — trapped: {t}; no host process possible"),
     }
     // No host-side assertion is needed: the Linker defines exactly host_random and
     // traps everything else, so a host process is structurally unreachable.
 }
 
-/// Case 3 (DoS guard): a fuel-bounded `while True: pass` must TRAP deterministically
-/// rather than hang the host. We assert a trap occurs. Whether it is the fuel trap
-/// (green path, VM boots then loops) or a bootstrap trap (0.3 path), the host is
-/// protected from an unbounded guest.
+/// Case 3 (deterministic DoS guard): a fuel-bounded `while True: pass` must TRAP
+/// ("all fuel consumed") rather than hang the host.
 #[test]
-fn case3_infinite_loop_is_bounded() {
+fn case3_infinite_loop_is_fuel_bounded() {
     let Some(wasm) = guest_wasm() else {
         eprintln!("SKIP case3: guest wasm not built");
         return;
     };
     let sandbox = Sandbox::from_bytes(&wasm).expect("load sandbox");
+    // Boot the VM with ample fuel, then loop — but cap total fuel so the loop trips it.
     let result = sandbox.eval("while True:\n    pass\n", BIG_FUEL);
     assert!(
         result.is_err(),
-        "unbounded guest must trap (fuel or bootstrap), got Ok({result:?})"
+        "unbounded guest must trap on fuel, got Ok({result:?})"
     );
-    eprintln!("case3: bounded — guest trapped: {:?}", result.unwrap_err());
+    eprintln!("case3: fuel-bounded — guest trapped: {:?}", result.unwrap_err());
 }
 
-/// Proves the epoch-deadline API path compiles and is wired (set_epoch_deadline).
-/// With a deadline of 0 and no `increment_epoch`, instantiation/exec traps with
-/// "interrupt" immediately — demonstrating the epoch limiter is live.
+/// Subject scoping: two sandboxes bound to DIFFERENT subjects keep independent
+/// Store identity — the subject set on one never leaks into the other. This is the
+/// no-global/no-thread-local invariant that killed the native #488 design.
 #[test]
-fn epoch_deadline_path_compiles_and_traps() {
+fn subject_isolation_no_leak() {
+    let alice = Subject::named("alice");
+    let bob = Subject::named("bob");
+
+    // Bind two sandboxes to different subjects (no guest wasm needed for identity).
+    let Some(wasm) = guest_wasm() else {
+        // Even without the guest we can assert the Subject binding is per-sandbox.
+        eprintln!("SKIP subject (no wasm): asserting Subject newtype identity only");
+        assert_ne!(alice, bob);
+        assert_eq!(alice.id(), Some("alice"));
+        return;
+    };
+    let sb_alice = Sandbox::from_bytes_for(&wasm, alice.clone()).expect("load alice");
+    let sb_bob = Sandbox::from_bytes_for(&wasm, bob.clone()).expect("load bob");
+
+    assert_eq!(sb_alice.subject(), &alice);
+    assert_eq!(sb_bob.subject(), &bob);
+    assert_ne!(sb_alice.subject(), sb_bob.subject());
+
+    // Each eval builds a FRESH Store from the sandbox's own subject; running one
+    // does not mutate the other's bound identity (no shared global state).
+    let _ = sb_alice.eval("x = 1", BIG_FUEL);
+    assert_eq!(sb_alice.subject(), &alice, "alice subject must be stable");
+    assert_eq!(sb_bob.subject(), &bob, "bob subject must be unaffected");
+    eprintln!("subject: isolated — alice={alice:?} bob={bob:?}, no leak");
+}
+
+/// Real wall-clock DoS bound: an `EpochTimer` advancing the engine epoch every 10ms,
+/// plus a per-call epoch deadline, traps `while True: pass` as "interrupt" within
+/// roughly the timeout. This is the PRODUCTION bound, not just the fuel path.
+#[test]
+fn epoch_wall_clock_bound_traps_runaway() {
     let Some(wasm) = guest_wasm() else {
         eprintln!("SKIP epoch: guest wasm not built");
         return;
     };
     let sandbox = Sandbox::from_bytes(&wasm).expect("load sandbox");
-    // ticks=0 => the default-epoch store is already at/over deadline => trap.
+
+    // Spawn the timer on THIS sandbox's engine. 10ms cadence; deadline of a few
+    // ticks gives a ~tens-of-ms wall-clock bound.
+    let tick = Duration::from_millis(10);
+    let _timer = EpochTimer::spawn(sandbox.engine(), tick);
+
+    // Deadline = 20 ticks ≈ 200ms wall clock. Generous enough that VM bootstrap
+    // (which the epoch is also counting) completes, but the infinite loop trips it.
+    let start = Instant::now();
+    let result = sandbox.eval_with_epoch_deadline("while True:\n    pass\n", 20);
+    let elapsed = start.elapsed();
+
+    assert!(
+        result.is_err(),
+        "runaway guest must trap on the epoch deadline, got Ok({result:?})"
+    );
+    let err = format!("{:?}", result.unwrap_err());
+    assert!(
+        err.contains("interrupt"),
+        "epoch trap should be an interrupt, got: {err}"
+    );
+    // Sanity: it should not run for many seconds. Generous upper bound for CI.
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "epoch bound did not fire promptly: {elapsed:?}"
+    );
+    eprintln!("epoch: wall-clock bound fired after {elapsed:?} — {err}");
+}
+
+/// The epoch limiter is live even with a deadline of 0 (default-epoch store is
+/// already over the line) — proves the limiter is wired, no timer needed.
+#[test]
+fn epoch_deadline_zero_traps_immediately() {
+    let Some(wasm) = guest_wasm() else {
+        eprintln!("SKIP epoch0: guest wasm not built");
+        return;
+    };
+    let sandbox = Sandbox::from_bytes(&wasm).expect("load sandbox");
     let result = sandbox.eval_with_epoch_deadline("print(1)", 0);
     assert!(
         result.is_err(),
         "epoch deadline of 0 must trap immediately, got Ok({result:?})"
     );
-    eprintln!("epoch: trapped as expected: {:?}", result.unwrap_err());
+    eprintln!("epoch0: trapped as expected: {:?}", result.unwrap_err());
 }


### PR DESCRIPTION
> **Draft — #505 P1.** Stacked on the P0 spike (#576). Turns the build-viability spike into a host
> crate that actually **runs** Subject-scoped Python under a real wall-clock bound. Committed
> `--no-verify` (pre-commit clippy needs LIBTORCH); scoped builds + 9 tests green.

## What P1 delivers

**1. Green path — the substrate runs real Python.** Guest bumped to `rustpython-vm = "0.5"` (+
`rustpython-pylib 0.5` `freeze-stdlib`); getrandom-0.2 dual-backend dropped, **getrandom 0.3 custom
backend only**. `Sandbox::eval("print(1 + 1)")` now returns status **0** (no trap), and `wasm-tools
print` confirms the guest's imports are **exactly `{ env::host_random }`** — zero JS/WASI/wasm-bindgen.
`case2` (`import os; os.system('echo PWNED')`) returns a nonzero Python-error status — never 0, never a
host process (no native posix backend is wired).

- The exact 0.5 embedded-frozen-stdlib construction (non-obvious — `without_stdlib` panics under
  `freeze-stdlib`):
  ```rust
  vm::Interpreter::builder(vm::Settings::default())
      .add_frozen_modules(rustpython_pylib::FROZEN_STDLIB)
      .build()
  ```
  with guest features `["compiler","encodings","freeze-stdlib","stdio"]` — `stdio` *without* `host_env`
  selects the VM's sandbox stdio path (discards on wasm32-unknown-unknown: capability-clean). Detail in
  `FINDINGS.md` → "P1 RESOLUTIONS".

**2. Subject-scoped Store (kills the #488 cross-tenant bug).** Local `Subject(Option<String>)` newtype
(no rpc/vfs dep yet); P0's fixed `HostState` → `SandboxState { subject, rng }` carried as Store data;
`host_random` reads `caller.data().subject`. A `Sandbox` binds one Subject at construction
(`from_bytes_for`) and each `eval` builds a fresh Store from it — **no global/thread-local state**.
`subject_isolation_no_leak` (alice vs bob) passes.

**3. Real wall-clock DoS bound.** `EpochTimer::spawn(engine, tick)` runs an `increment_epoch()` thread
(stopped on Drop); `eval_with_epoch_deadline` sets the epoch as the production limiter (fuel →
`u64::MAX`). `epoch_wall_clock_bound_traps_runaway` traps `while True: pass` as "interrupt" within ~the
timeout. Fuel stays the deterministic test path.

**4. VFS host-fn seam for #483 (sketch, not wired).** New `hyprstream_wasm::vfs`: trait `VfsCapability`
(`vfs_walk/open/read/write/stat/ls/create`, each `&Subject` — mirrors `hyprstream_vfs::Mount`),
`UnimplementedVfs` default, an in-memory test stub proving the Subject threads + scopes. A `// P1b/#483:`
comment documents the real backing (`spawn_vfs_proxy(ns, subject) -> Sender<VfsRequest>` in Store data).
`hyprstream-vfs` is **not** pulled in.

## Verification
`cargo test -p hyprstream-wasm` = **9/9**; `cargo clippy -p hyprstream-wasm --tests` warning-clean; guest
builds to wasm32-unknown-unknown with a single import. All changes confined to the two wasm crates.

## Next (fans out in parallel once this lands)
- **#483** (Python, Profile A): swap `UnimplementedVfs` for the real `spawn_vfs_proxy`-backed impl in
  `SandboxState`, add `env::vfs_*` host fns to `build_linker`, re-expose `/lang/python` (re-cut #488).
- **#505 P2**: `BackendType::Wasm` into the `SandboxBackend` seam (#508) + `resolve()`/feature-gate.

Refs #505 · epic #341 · stacked on #576.
