### PR TITLE
feat(#483): WASM /lang/python Profile A — real VFS capability + mount over the wasm guest

### DIFF
--- a/.github/workflows/wasm-pyguest.yml
+++ b/.github/workflows/wasm-pyguest.yml
@@ -1,0 +1,94 @@
+name: WASM pyguest
+
+# Build the RustPython wasm guest (#483/#505) FROM ITS CRATE DIRECTORY and assert
+# its host ABI. This crate is [workspace.exclude] with its own empty [workspace], so
+# the `wasm` job in rust.yml (cargo check -p hyprstream-rpc) never compiles it.
+#
+# WHY a dedicated job: the guest's `getrandom_backend="custom"` rustflag lives in
+# crates/hyprstream-wasm-pyguest/.cargo/config.toml, which cargo only discovers by
+# walking up from the CWD — NOT from --manifest-path. Building from the repo root
+# (or with --manifest-path) silently drops the cfg and the wasm build fails on
+# getrandom. So this job MUST `cd` into the crate dir (working-directory below);
+# it deliberately does not use --manifest-path.
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'crates/hyprstream-wasm-pyguest/**'
+      - '.github/workflows/wasm-pyguest.yml'
+  pull_request:
+    paths:
+      - 'crates/hyprstream-wasm-pyguest/**'
+      - '.github/workflows/wasm-pyguest.yml'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-guest:
+    name: build wasm guest (from crate dir)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain (wasm32)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      # wabt provides wasm-objdump, used below to read the guest's import section.
+      - name: Install wabt
+        run: sudo apt-get update && sudo apt-get install -y wabt
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          # Standalone crate (own lockfile/target dir), so cache it on its own.
+          workspaces: crates/hyprstream-wasm-pyguest
+          key: wasm-pyguest
+
+      - name: Build guest from its crate dir
+        # MUST run from the crate dir so cargo discovers the crate-local
+        # .cargo/config.toml carrying getrandom_backend="custom". Do NOT switch this
+        # to --manifest-path from the repo root — the cfg would be dropped and the
+        # build would fail on getrandom/wasm32. See the crate's Cargo.toml.
+        working-directory: crates/hyprstream-wasm-pyguest
+        run: cargo build --release --target wasm32-unknown-unknown
+
+      - name: Assert guest imports are exactly the host ABI
+        # The guest must import ONLY the host capability functions from module `env`
+        # and nothing else — in particular no wasm_js / wasi / wbindgen backend may
+        # leak in (that would mean getrandom picked a non-custom backend, i.e. the
+        # cfg was dropped, or a dependency pulled a JS shim). #483/#505 capability
+        # boundary: the host resolves exactly these five imports via the wasmtime Linker.
+        working-directory: crates/hyprstream-wasm-pyguest
+        run: |
+          set -euo pipefail
+          WASM=$(find target/wasm32-unknown-unknown/release -maxdepth 1 -name '*.wasm' | head -1)
+          if [ -z "$WASM" ]; then echo "::error::no wasm artifact produced"; exit 1; fi
+          echo "Inspecting imports of: $WASM"
+
+          # wasm-objdump prints import entries as: "... <- env.host_random"
+          ACTUAL=$(wasm-objdump -x "$WASM" \
+            | grep -oE '<- [A-Za-z0-9_]+\.[A-Za-z0-9_]+' \
+            | sed -E 's/<- ([A-Za-z0-9_]+)\.([A-Za-z0-9_]+)/\1::\2/' \
+            | sort -u)
+          EXPECTED=$(printf '%s\n' \
+            env::host_random env::vfs_cat env::vfs_ls env::vfs_echo env::vfs_ctl \
+            | sort -u)
+
+          echo "--- actual imports ---";   echo "$ACTUAL"
+          echo "--- expected imports ---"; echo "$EXPECTED"
+
+          if ! diff <(echo "$EXPECTED") <(echo "$ACTUAL"); then
+            echo "::error::wasm guest imports do not match the expected host ABI (see diff above: < expected, > actual)"
+            exit 1
+          fi
+
+          # Belt-and-suspenders: an explicit, clearer failure if a forbidden backend
+          # ever appears (redundant with the exact-match diff above, but names the cause).
+          if echo "$ACTUAL" | grep -Eiq 'wasm_js|wasi|__wbindgen|wbg'; then
+            echo "::error::forbidden import backend present (wasm_js/wasi/wbindgen) — getrandom cfg likely dropped"
+            exit 1
+          fi
+          echo "OK: guest imports are exactly the five host ABI functions."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7108,7 +7108,12 @@ name = "hyprstream-wasm"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
+ "hyprstream-rpc",
+ "hyprstream-vfs",
+ "parking_lot 0.12.4",
  "rand 0.8.5",
+ "tokio",
  "wasmtime",
 ]
 

--- a/crates/hyprstream-wasm-pyguest/.cargo/config.toml
+++ b/crates/hyprstream-wasm-pyguest/.cargo/config.toml
@@ -8,6 +8,14 @@
 # is gone.) `--allow-undefined` lets `host_random` remain a wasm IMPORT rather than a
 # hard link error. `host_random` is then a normal wasm import the wasmtime Linker
 # resolves. With 0.5 the only declared import should be exactly `env::host_random`.
+#
+# IMPORTANT — build location: you MUST build from THIS crate's directory, e.g.
+#   (cd crates/hyprstream-wasm-pyguest && cargo build --release --target wasm32-unknown-unknown)
+# The `getrandom_backend="custom"` rustflag below lives in THIS .cargo/config.toml, and
+# Cargo only discovers .cargo/config.toml by walking up from the CWD, NOT from
+# --manifest-path. So `cargo build --manifest-path crates/hyprstream-wasm-pyguest/Cargo.toml`
+# run from the repo root will NOT pick up this cfg, and the build will FAIL on
+# getrandom/wasm32 ("the wasm32-unknown-unknown target is not supported ... enable wasm_js").
 [target.wasm32-unknown-unknown]
 rustflags = [
     '--cfg', 'getrandom_backend="custom"',

--- a/crates/hyprstream-wasm-pyguest/Cargo.toml
+++ b/crates/hyprstream-wasm-pyguest/Cargo.toml
@@ -8,8 +8,15 @@ description = "RustPython guest compiled to wasm32-unknown-unknown for the #505 
 # This crate is intentionally NOT a workspace member. It is listed in the root
 # Cargo.toml [workspace.exclude] so a host-target workspace build never tries to
 # compile a wasm-only cdylib (which would also drag in libtorch deps transitively
-# via the workspace). Build explicitly:
-#   cargo build --target wasm32-unknown-unknown --manifest-path crates/hyprstream-wasm-pyguest/Cargo.toml
+# via the workspace). Build explicitly, FROM THIS CRATE'S DIRECTORY:
+#   (cd crates/hyprstream-wasm-pyguest && cargo build --release --target wasm32-unknown-unknown)
+#
+# MUST build from this crate's directory — the `getrandom_backend="custom"` rustflag
+# lives in this crate's .cargo/config.toml, and Cargo only discovers .cargo/config.toml
+# by walking up from the CWD, NOT from --manifest-path. Running
+# `cargo build --manifest-path crates/hyprstream-wasm-pyguest/Cargo.toml` from the repo
+# root will NOT pick up the cfg and the build will FAIL on getrandom/wasm32
+# ("the wasm32-unknown-unknown target is not supported ... enable wasm_js").
 #
 # Empty [workspace] table makes this a standalone package (own lockfile/target),
 # belt-and-suspenders alongside the root [workspace.exclude] entry. A wasm-only
@@ -52,10 +59,17 @@ rustpython-vm = { version = "0.5", default-features = false, features = ["compil
 # trying to `import encodings` with an empty frozen set.
 rustpython-pylib = { version = "0.5", features = ["freeze-stdlib"] }
 
-# getrandom 0.3 ONLY (the 0.2 dual-backend from the P0 spike is dropped: rustpython 0.5
-# no longer pulls a getrandom-0.2 RNG path that forces `js`). 0.3 selects its backend
-# via the build cfg `getrandom_backend="custom"` (in .cargo/config.toml) plus the
-# `#[no_mangle] __getrandom_v03_custom` extern symbol in lib.rs, both delegating to the
-# single host import `host_random`. No `js`, no `wasm_js`, no WASI.
+# getrandom 0.3 is the ONLY getrandom compiled FOR WASM (the 0.2 dual-backend from the
+# P0 spike is dropped: rustpython 0.5 no longer pulls a getrandom-0.2 RNG path that forces
+# `js`). 0.3 selects its backend via the build cfg `getrandom_backend="custom"` (in
+# .cargo/config.toml) plus the `#[no_mangle] __getrandom_v03_custom` extern symbol in
+# lib.rs, both delegating to the single host import `host_random`. No `js`, no `wasm_js`,
+# no WASI.
+#
+# NOTE: Cargo.lock still contains getrandom 0.2.17. That is a HOST BUILD-DEPENDENCY of
+# rustpython's codegen tooling only — pulled via unicode_names2_generator's
+# [build-dependencies] (rand 0.8 -> rand_core 0.6 -> getrandom 0.2.17), which runs on the
+# HOST during the build. It is NEVER compiled for the wasm32-unknown-unknown target.
+# Harmless; the wasm guest itself uses only getrandom 0.3 with the custom backend.
 [target.wasm32-unknown-unknown.dependencies]
 getrandom = { version = "0.3" }

--- a/crates/hyprstream-wasm-pyguest/src/lib.rs
+++ b/crates/hyprstream-wasm-pyguest/src/lib.rs
@@ -1,66 +1,80 @@
-//! RustPython guest for the #505 capability sandbox (P1 host).
+//! RustPython guest for the #505/#483 capability sandbox.
 //!
-//! Compiled to `wasm32-unknown-unknown` (NOT wasi). There is deliberately NO WASI
-//! import in this module: the only thing the guest can reach outside its linear
-//! memory is the single host import `host_random`. `import os; os.system(...)`
-//! therefore has nothing to call — it is inert by construction.
+//! Compiled to `wasm32-unknown-unknown` (NOT wasi). The only host capabilities the
+//! guest can reach are the imports the wasmtime `Linker` defines under `env`:
+//!   * `host_random(ptr,len)`           — entropy (the #505 P1 capability)
+//!   * `vfs_cat/vfs_ls/vfs_echo/vfs_ctl` — Subject-scoped VFS access (#483 P2)
+//! Anything else (e.g. `import os; os.system(...)`) has nothing to call — inert by
+//! construction.
 //!
 //! Build:
-//!   cargo build --target wasm32-unknown-unknown --manifest-path crates/hyprstream-wasm-pyguest/Cargo.toml
+//!   cargo build --release --target wasm32-unknown-unknown \
+//!     --manifest-path crates/hyprstream-wasm-pyguest/Cargo.toml
 //!
-//! Exports:
-//!   - `eval(ptr, len) -> i32`  : run UTF-8 python source, 0 = ok, nonzero = py error
-//!   - `alloc(len) -> *mut u8`  : let the host allocate guest memory to write source into
-//!   - `dealloc(ptr, len)`      : free it again
+//! ## ABI
 //!
-//! P1 changes vs. the P0 spike:
-//!   * rustpython-vm bumped 0.3 -> 0.5 (0.3.1 force-enabled getrandom/js, which
-//!     out-ranked the custom backend and trapped at VM bootstrap reaching for
-//!     undefined `__wbindgen_placeholder__` JS imports). 0.5 uses getrandom 0.3
-//!     with no `js`, so the custom backend is actually reachable.
-//!   * Dropped the getrandom-0.2 dual backend; ONLY the getrandom-0.3 custom
-//!     backend remains.
-//!   * Construct via `Interpreter::builder(Settings).add_frozen_modules(...)` rather
-//!     than `Interpreter::without_stdlib` (which panics under freeze-stdlib in 0.5
-//!     because it registers an EMPTY frozen set, and essential init then fails to
-//!     `import encodings`).
+//! Exports for the host:
+//!   - `alloc(len) -> *mut u8`  : host allocates guest memory to write input into
+//!   - `dealloc(ptr, len)`      : free guest memory
+//!   - `eval(ptr, len) -> i32`  : LEGACY #505 entry — run UTF-8 source in a FRESH
+//!     interpreter, 0 = ok, nonzero = error. Kept so the #505 host tests still pass.
+//!   - `py_op(op, ptr, len) -> i64` : #483 entry — run an operation against the
+//!     PERSISTENT interpreter, returning a packed `(out_ptr<<32)|out_len` into guest
+//!     memory (the host reads it, then calls `dealloc(out_ptr, out_len)`). The first
+//!     byte of the output is a STATUS tag (`OK`/`ERR`/`NONE`), the rest is the payload
+//!     (UTF-8). See [`Op`].
+//!
+//! ## #483 semantics (ported from the native `/lang/python` mount, re-expressed in 0.5)
+//!
+//!   * Op::Eval  — evaluate an expression -> `repr(result)` (captured stdout is
+//!                 returned too via the EVAL_STDOUT side channel; see `py_op`).
+//!   * Op::Exec  — execute statements -> captured stdout.
+//!   * Op::ListVars / Op::ListDefs — newline-joined non-dunder global names
+//!                 (defs = callables only).
+//!   * Op::GetVar / Op::GetDef     — `repr` of one named global (NONE if absent).
+//!
+//! The interpreter + its globals dict are PERSISTENT across `py_op` calls (held in a
+//! thread-local `Rc`), so user state survives — exactly like the native shell's
+//! persistent `globals`. wasm32 is single-threaded, so the thread-local is the whole
+//! guest's state.
 
 use rustpython_vm as vm;
+use std::cell::RefCell;
+use vm::builtins::{PyDictRef, PyStr};
+use vm::scope::Scope;
+use vm::{AsObject, Interpreter};
 
 // ---------------------------------------------------------------------------
-// getrandom 0.3 custom backend -> host import.
-//
-// rustpython-vm 0.5 pulls getrandom 0.3 (no `js` feature). On
-// wasm32-unknown-unknown getrandom 0.3 has no default backend, so the build cfg
-// `getrandom_backend="custom"` (see .cargo/config.toml) selects an external symbol
-// `__getrandom_v03_custom`, which we provide here and which delegates to a host
-// function `host_random`. The wasmtime host (crate `hyprstream-wasm`) fills it from
-// its OWN entropy source. The guest never has direct OS entropy access.
+// Host imports (resolved by the wasmtime Linker in the host crate).
 // ---------------------------------------------------------------------------
 extern "C" {
-    /// Host import: fill `len` bytes at guest `ptr` with random data.
-    /// Provided by the wasmtime `Linker` in the host crate.
+    /// Entropy: fill `len` bytes at guest `ptr` with random data.
     fn host_random(ptr: *mut u8, len: usize);
+
+    // #483 VFS capability host fns. Each takes a path (and, for writes, a body) in
+    // guest memory and writes a reply into a host-allocated guest buffer, returning
+    // a packed `(reply_ptr<<32)|reply_len`. The reply's first byte is a status tag
+    // (0 = ok, 1 = err), the rest is UTF-8. The HOST scopes every call to the bound
+    // Subject — the guest cannot supply or forge an identity.
+    fn vfs_cat(path_ptr: *const u8, path_len: usize) -> i64;
+    fn vfs_ls(path_ptr: *const u8, path_len: usize) -> i64;
+    fn vfs_echo(path_ptr: *const u8, path_len: usize, data_ptr: *const u8, data_len: usize) -> i64;
+    fn vfs_ctl(path_ptr: *const u8, path_len: usize, cmd_ptr: *const u8, cmd_len: usize) -> i64;
 }
 
-/// getrandom 0.3 custom backend: getrandom looks this symbol up by name when the
-/// build cfg `getrandom_backend="custom"` is set. Signature is fixed by getrandom 0.3:
-/// `fn(*mut u8, usize) -> Result<(), getrandom::Error>`.
+/// getrandom 0.3 custom backend (selected by `--cfg getrandom_backend="custom"`).
 ///
 /// # Safety
-/// `dest`..`dest+len` must be a valid, exclusively-borrowable region; getrandom
-/// guarantees this for the buffer it passes.
+/// getrandom 0.3 passes a valid writable `dest`/`len`.
 #[no_mangle]
 unsafe fn __getrandom_v03_custom(dest: *mut u8, len: usize) -> Result<(), getrandom::Error> {
-    // SAFETY: getrandom 0.3 passes a valid writable `dest`/`len`; the host writes
-    // exactly `len` bytes into that range.
     let buf = std::slice::from_raw_parts_mut(dest, len);
     host_random(buf.as_mut_ptr(), buf.len());
     Ok(())
 }
 
 // ---------------------------------------------------------------------------
-// Memory ABI for the host to ship source code into guest linear memory.
+// Memory ABI helpers.
 // ---------------------------------------------------------------------------
 
 /// Allocate `len` bytes in guest memory and return the pointer.
@@ -86,46 +100,441 @@ pub unsafe extern "C" fn dealloc(ptr: *mut u8, len: usize) {
     }
 }
 
-/// Build a fresh interpreter WITH the frozen stdlib registered.
-///
-/// rustpython-vm 0.5: `Interpreter::without_stdlib` registers an empty frozen set,
-/// so under the `freeze-stdlib` feature `VirtualMachine::initialize` panics
-/// ("essential initialization failed") trying to `import encodings`. The supported
-/// embedding path is the builder, registering `rustpython_pylib::FROZEN_STDLIB`
-/// (the bytecode-frozen pure-Python stdlib baked into the binary — no filesystem
-/// import path, a capability win).
-fn build_interpreter() -> vm::Interpreter {
-    vm::Interpreter::builder(vm::Settings::default())
-        .add_frozen_modules(rustpython_pylib::FROZEN_STDLIB)
-        .build()
+/// Pack a freshly-allocated `(ptr, len)` into the `i64` ABI the host expects.
+/// The host reads `len` bytes at `ptr`, then calls `dealloc(ptr, len)`.
+fn pack_owned(bytes: Vec<u8>) -> i64 {
+    let len = bytes.len();
+    // Round-trip through `alloc` so the host's `dealloc(ptr,len)` matches the
+    // allocation (Vec::with_capacity(len) backing, like `alloc`).
+    let ptr = alloc(len);
+    // SAFETY: `ptr` has capacity `len`; copy the payload in.
+    unsafe {
+        std::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr, len);
+    }
+    ((ptr as u64) << 32 | len as u64) as i64
 }
 
-/// Interpret UTF-8 Python source in a fresh interpreter.
-///
-/// Returns 0 on success, nonzero on any Python or decode error.
+/// Read a `(ptr,len)` UTF-8 string supplied by the host (lossy).
 ///
 /// # Safety
-/// `ptr`..`ptr+len` must be a valid readable region of guest memory holding
-/// UTF-8 source (typically written via [`alloc`]).
+/// `ptr`..`ptr+len` must be a valid readable region.
+unsafe fn read_str(ptr: *const u8, len: usize) -> String {
+    if ptr.is_null() || len == 0 {
+        return String::new();
+    }
+    String::from_utf8_lossy(std::slice::from_raw_parts(ptr, len)).into_owned()
+}
+
+// ---------------------------------------------------------------------------
+// Status tags for the py_op reply payload.
+// ---------------------------------------------------------------------------
+const TAG_OK: u8 = 0;
+const TAG_ERR: u8 = 1;
+const TAG_NONE: u8 = 2;
+
+fn reply(tag: u8, body: impl AsRef<[u8]>) -> i64 {
+    let mut out = Vec::with_capacity(1 + body.as_ref().len());
+    out.push(tag);
+    out.extend_from_slice(body.as_ref());
+    pack_owned(out)
+}
+
+// ---------------------------------------------------------------------------
+// Op codes for py_op.
+// ---------------------------------------------------------------------------
+
+/// Operations the host can drive against the persistent interpreter.
+#[repr(i32)]
+enum Op {
+    Eval = 0,
+    Exec = 1,
+    ListVars = 2,
+    GetVar = 3,
+    ListDefs = 4,
+    GetDef = 5,
+}
+
+impl Op {
+    fn from_i32(v: i32) -> Option<Self> {
+        Some(match v {
+            0 => Op::Eval,
+            1 => Op::Exec,
+            2 => Op::ListVars,
+            3 => Op::GetVar,
+            4 => Op::ListDefs,
+            5 => Op::GetDef,
+            _ => return None,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Persistent interpreter state (single-threaded wasm => thread_local is global).
+// ---------------------------------------------------------------------------
+
+struct Shell {
+    interp: Interpreter,
+    /// Persistent globals reused across every call so user state (vars, funcs)
+    /// survives — the same design as the native shell's `globals` dict.
+    globals: PyDictRef,
+}
+
+thread_local! {
+    static SHELL: RefCell<Option<Shell>> = const { RefCell::new(None) };
+}
+
+/// Build (or reuse) the persistent shell.
+fn with_shell<R>(f: impl FnOnce(&Shell) -> R) -> R {
+    SHELL.with(|cell| {
+        {
+            let mut b = cell.borrow_mut();
+            if b.is_none() {
+                let interp = vm::Interpreter::builder(vm::Settings::default())
+                    .add_frozen_modules(rustpython_pylib::FROZEN_STDLIB)
+                    .build();
+                let globals = interp.enter(|vm| {
+                    // Install the safe sink stdout baseline (never None, never the
+                    // host process stdout) — same posture as the native shell.
+                    let scope = vm.new_scope_with_builtins();
+                    let _ = vm.run_string(scope, SINK_SETUP, "<sink>".to_owned());
+                    vm.ctx.new_dict()
+                });
+                *b = Some(Shell { interp, globals });
+            }
+        }
+        let b = cell.borrow();
+        // SAFETY: just ensured Some above; no re-entrant borrow_mut while held.
+        f(b.as_ref().expect("shell initialised"))
+    })
+}
+
+impl Shell {
+    /// A scope over the persistent globals for one execution.
+    fn scope(&self, vm: &vm::VirtualMachine) -> Scope {
+        Scope::with_builtins(None, self.globals.clone(), vm)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pure-Python stdout capture (ported from native mount.rs; no io.StringIO so we
+// avoid extra frozen-module init under the sandbox stdio path).
+// ---------------------------------------------------------------------------
+
+const CAPTURE_SETUP: &str = r"
+import sys as _sys
+class __Capture:
+    def __init__(self): self.__buf = []
+    def write(self, s): self.__buf.append(str(s))
+    def flush(self): pass
+    def getvalue(self): return ''.join(self.__buf)
+_sys.stdout = __Capture()
+del _sys
+";
+
+const CAPTURE_DRAIN: &str = r"
+import sys as _sys
+__v = _sys.stdout.getvalue() if hasattr(_sys.stdout, 'getvalue') else ''
+class __Sink:
+    def write(self, s): pass
+    def flush(self): pass
+_sys.stdout = __Sink()
+del _sys
+__v
+";
+
+const SINK_SETUP: &str = r"
+import sys as _sys
+class __Sink:
+    def write(self, s): pass
+    def flush(self): pass
+_sys.stdout = __Sink()
+del _sys
+";
+
+/// Redirect `sys.stdout` to a pure-Python capture object. Returns whether it took.
+fn setup_capture(vm: &vm::VirtualMachine) -> bool {
+    let scope = vm.new_scope_with_builtins();
+    let ok = vm
+        .run_string(scope, CAPTURE_SETUP, "<capture>".to_owned())
+        .is_ok();
+    if !ok {
+        let scope = vm.new_scope_with_builtins();
+        let _ = vm.run_string(scope, SINK_SETUP, "<sink>".to_owned());
+    }
+    ok
+}
+
+/// Read captured stdout and restore a safe sink. Empty if capture wasn't active.
+fn drain_capture(vm: &vm::VirtualMachine, active: bool) -> String {
+    if !active {
+        return String::new();
+    }
+    let scope = vm.new_scope_with_builtins();
+    vm.run_block_expr(scope, CAPTURE_DRAIN)
+        .ok()
+        .and_then(|obj| obj.str(vm).ok().map(|s| s.to_string_lossy().into_owned()))
+        .unwrap_or_default()
+}
+
+// ---------------------------------------------------------------------------
+// Operation impls (ported behaviour from native lib.rs, re-expressed on 0.5).
+// ---------------------------------------------------------------------------
+
+/// Eval an expression. Reply OK body = `repr` then (if any) `\n---\n<stdout>`.
+fn op_eval(code: &str) -> i64 {
+    with_shell(|shell| {
+        shell.interp.enter(|vm| {
+            let active = setup_capture(vm);
+            let scope = shell.scope(vm);
+            let run = vm.run_block_expr(scope, code);
+            let stdout = drain_capture(vm, active);
+            match run {
+                Ok(obj) => {
+                    let repr = if vm.is_none(&obj) {
+                        String::new()
+                    } else {
+                        obj.repr(vm)
+                            .map(|s| s.to_string_lossy().into_owned())
+                            .unwrap_or_else(|_| "<repr error>".to_owned())
+                    };
+                    let body = if stdout.is_empty() {
+                        repr
+                    } else if repr.is_empty() {
+                        stdout
+                    } else {
+                        format!("{repr}\n---\n{stdout}")
+                    };
+                    reply(TAG_OK, body)
+                }
+                Err(exc) => reply(TAG_ERR, exc_message(vm, &exc)),
+            }
+        })
+    })
+}
+
+/// Exec statements. Reply OK body = captured stdout.
+fn op_exec(code: &str) -> i64 {
+    with_shell(|shell| {
+        shell.interp.enter(|vm| {
+            let active = setup_capture(vm);
+            let scope = shell.scope(vm);
+            let run = vm.run_string(scope, code, "<guest>".to_owned());
+            let stdout = drain_capture(vm, active);
+            match run {
+                Ok(_) => reply(TAG_OK, stdout),
+                Err(exc) => reply(TAG_ERR, exc_message(vm, &exc)),
+            }
+        })
+    })
+}
+
+fn exc_message(vm: &vm::VirtualMachine, exc: &vm::PyRef<vm::builtins::PyBaseException>) -> String {
+    exc.as_object()
+        .to_owned()
+        .str(vm)
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| "<exception>".to_owned())
+}
+
+fn is_dunder(name: &str) -> bool {
+    name.starts_with("__") && name.ends_with("__")
+}
+
+/// Newline-joined non-dunder globals (callables only if `callables_only`).
+fn op_list(callables_only: bool) -> i64 {
+    with_shell(|shell| {
+        shell.interp.enter(|_vm| {
+            let names: Vec<String> = shell
+                .globals
+                .clone()
+                .into_iter()
+                .filter_map(|(k, v)| {
+                    let name = k.downcast_ref::<PyStr>()?.to_str()?.to_owned();
+                    if is_dunder(&name) {
+                        return None;
+                    }
+                    if callables_only && !v.is_callable() {
+                        return None;
+                    }
+                    Some(name)
+                })
+                .collect();
+            reply(TAG_OK, names.join("\n"))
+        })
+    })
+}
+
+/// `repr` of one named global. NONE if absent (or not callable, for defs).
+fn op_get(name: &str, callable_only: bool) -> i64 {
+    with_shell(|shell| {
+        shell.interp.enter(|vm| {
+            match shell.globals.get_item(name, vm) {
+                Ok(obj) => {
+                    if callable_only && !obj.is_callable() {
+                        return reply(TAG_NONE, "");
+                    }
+                    match obj.repr(vm) {
+                        Ok(s) => reply(TAG_OK, s.to_string_lossy().into_owned()),
+                        Err(_) => reply(TAG_NONE, ""),
+                    }
+                }
+                Err(_) => reply(TAG_NONE, ""),
+            }
+        })
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Exports.
+// ---------------------------------------------------------------------------
+
+/// #483 entry: run `op` against the persistent interpreter.
+///
+/// `ptr`/`len` is the UTF-8 argument (source for eval/exec, a name for get_*,
+/// ignored for list_*). Returns a packed `(out_ptr<<32)|out_len`; the host reads
+/// it then `dealloc`s. Output byte[0] is a status tag.
+///
+/// # Safety
+/// `ptr`..`ptr+len` must be a valid readable region of guest memory.
+#[no_mangle]
+pub unsafe extern "C" fn py_op(op: i32, ptr: *const u8, len: usize) -> i64 {
+    let arg = read_str(ptr, len);
+    match Op::from_i32(op) {
+        Some(Op::Eval) => op_eval(&arg),
+        Some(Op::Exec) => op_exec(&arg),
+        Some(Op::ListVars) => op_list(false),
+        Some(Op::GetVar) => op_get(&arg, false),
+        Some(Op::ListDefs) => op_list(true),
+        Some(Op::GetDef) => op_get(&arg, true),
+        None => reply(TAG_ERR, "unknown op"),
+    }
+}
+
+/// LEGACY #505 entry: interpret UTF-8 source in a FRESH interpreter (no persistent
+/// state). Returns 0 on success, nonzero on error. Kept so the original #505 host
+/// tests (`case1_arithmetic`, `case2_os_system_is_inert`, …) still pass unchanged.
+///
+/// # Safety
+/// `ptr`..`ptr+len` must be a valid readable region holding UTF-8 source.
 #[no_mangle]
 pub unsafe extern "C" fn eval(ptr: *const u8, len: usize) -> i32 {
     let src = match std::str::from_utf8(std::slice::from_raw_parts(ptr, len)) {
         Ok(s) => s,
-        Err(_) => return 2, // not valid UTF-8
+        Err(_) => return 2,
     };
-
-    // Fresh interpreter per call: no shared mutable state across evaluations.
-    let interp = build_interpreter();
-
+    let interp = vm::Interpreter::builder(vm::Settings::default())
+        .add_frozen_modules(rustpython_pylib::FROZEN_STDLIB)
+        .build();
     interp.enter(|vm| {
         let scope = vm.new_scope_with_builtins();
         let code = match vm.compile(src, vm::compiler::Mode::Exec, "<guest>".to_owned()) {
             Ok(c) => c,
-            Err(_) => return 3, // compile error
+            Err(_) => return 3,
         };
         match vm.run_code_obj(code, scope) {
             Ok(_) => 0,
-            Err(_) => 1, // runtime python exception (e.g. os.system unsupported)
+            Err(_) => 1,
         }
     })
+}
+
+// ---------------------------------------------------------------------------
+// VFS builtins (#483): expose the host vfs_* capabilities to guest Python.
+//
+// These are thin wrappers so guest scripts can do `cat("/config/x")` etc. The
+// HOST scopes every call to the bound Subject; the guest never names an identity.
+// Reply ABI: first byte status (0 ok / 1 err), rest UTF-8.
+// ---------------------------------------------------------------------------
+
+/// Read a host vfs_* packed reply `(ptr<<32)|len` back into `(status, body)`.
+///
+/// # Safety
+/// `packed` must be a value returned by one of the `vfs_*` host imports; the host
+/// allocated the buffer via the guest `alloc`, so we own and `dealloc` it here.
+unsafe fn take_reply(packed: i64) -> (u8, String) {
+    let p = packed as u64;
+    let ptr = (p >> 32) as usize as *mut u8;
+    let len = (p & 0xffff_ffff) as usize;
+    if ptr.is_null() || len == 0 {
+        return (TAG_ERR, String::new());
+    }
+    let slice = std::slice::from_raw_parts(ptr, len);
+    let tag = slice[0];
+    let body = String::from_utf8_lossy(&slice[1..]).into_owned();
+    dealloc(ptr, len);
+    (tag, body)
+}
+
+/// #483 capability probe export: drive a VFS op THROUGH the guest so the
+/// `env::vfs_*` host imports are reachable (not dead-code-eliminated) and the
+/// host's Subject-scoping test can exercise a real guest->host->Namespace path.
+///
+/// `op`: 0=cat, 1=ls, 2=echo, 3=ctl. `ptr/len` = path. `dptr/dlen` = body (echo/ctl;
+/// pass 0/0 for cat/ls). Returns the host's packed reply `(ptr<<32)|len` verbatim,
+/// so the HOST reads the status byte + payload and `dealloc`s it. The guest does NOT
+/// own the buffer here (the host allocated it and reads it back).
+///
+/// This is what makes deliverable (1) end-to-end real: a guest call lands in
+/// `vfs_cat`/`vfs_echo`/… which the host resolves against the Subject-scoped proxy.
+///
+/// # Safety
+/// `ptr`/`dptr` regions must be valid readable guest memory of the given lengths.
+#[no_mangle]
+pub unsafe extern "C" fn vfs_probe(
+    op: i32,
+    ptr: *const u8,
+    len: usize,
+    dptr: *const u8,
+    dlen: usize,
+) -> i64 {
+    match op {
+        0 => vfs_cat(ptr, len),
+        1 => vfs_ls(ptr, len),
+        2 => vfs_echo(ptr, len, dptr, dlen),
+        3 => vfs_ctl(ptr, len, dptr, dlen),
+        _ => 0,
+    }
+}
+
+/// Helper the guest-side native builtins would call. Exposed for completeness; the
+/// minimal P2 guest drives VFS via these free functions rather than registering
+/// native Python builtins (which needs `host_env`/extra wiring we deliberately omit).
+/// A follow-up can register these as `cat`/`ls`/`write`/`ctl` Python builtins.
+pub fn guest_cat(path: &str) -> Result<String, String> {
+    // SAFETY: calling the host import with a valid path slice; reply is owned.
+    let (tag, body) = unsafe { take_reply(vfs_cat(path.as_ptr(), path.len())) };
+    if tag == TAG_OK {
+        Ok(body)
+    } else {
+        Err(body)
+    }
+}
+
+pub fn guest_ls(path: &str) -> Result<String, String> {
+    let (tag, body) = unsafe { take_reply(vfs_ls(path.as_ptr(), path.len())) };
+    if tag == TAG_OK {
+        Ok(body)
+    } else {
+        Err(body)
+    }
+}
+
+pub fn guest_echo(path: &str, data: &str) -> Result<(), String> {
+    let (tag, body) =
+        unsafe { take_reply(vfs_echo(path.as_ptr(), path.len(), data.as_ptr(), data.len())) };
+    if tag == TAG_OK {
+        Ok(())
+    } else {
+        Err(body)
+    }
+}
+
+pub fn guest_ctl(path: &str, cmd: &str) -> Result<String, String> {
+    let (tag, body) =
+        unsafe { take_reply(vfs_ctl(path.as_ptr(), path.len(), cmd.as_ptr(), cmd.len())) };
+    if tag == TAG_OK {
+        Ok(body)
+    } else {
+        Err(body)
+    }
 }

--- a/crates/hyprstream-wasm-pyguest/src/lib.rs
+++ b/crates/hyprstream-wasm-pyguest/src/lib.rs
@@ -7,9 +7,13 @@
 //! Anything else (e.g. `import os; os.system(...)`) has nothing to call — inert by
 //! construction.
 //!
-//! Build:
-//!   cargo build --release --target wasm32-unknown-unknown \
-//!     --manifest-path crates/hyprstream-wasm-pyguest/Cargo.toml
+//! Build (MUST run from THIS crate's directory):
+//!   (cd crates/hyprstream-wasm-pyguest && cargo build --release --target wasm32-unknown-unknown)
+//!
+//! The `getrandom_backend="custom"` rustflag lives in this crate's `.cargo/config.toml`,
+//! and Cargo only discovers `.cargo/config.toml` from the CWD (walking up), NOT from
+//! `--manifest-path`. Building with `--manifest-path …pyguest/Cargo.toml` from the repo
+//! root drops the cfg and the build FAILS on getrandom/wasm32 (enable wasm_js error).
 //!
 //! ## ABI
 //!

--- a/crates/hyprstream-wasm/Cargo.toml
+++ b/crates/hyprstream-wasm/Cargo.toml
@@ -21,5 +21,23 @@ wasmtime = "=46.0.1"
 anyhow = "1"
 rand = "0.8"
 
+# Canonical VFS seam (#483 P2). hyprstream-vfs -> hyprstream-rpc; NEITHER pulls
+# tch/torch (verified: only the top-level `hyprstream` crate links libtorch), so
+# `cargo build -p hyprstream-wasm` stays torch-free. We use:
+#   * hyprstream_rpc::Subject  — the CANONICAL caller identity (replaces the
+#     crate-local Subject newtype).
+#   * hyprstream_vfs::{Namespace, Mount, Fid, Stat, DirEntry, MountError, ...}
+#     and spawn_vfs_proxy / VfsRequest / VfsOp — the real proxy seam.
+hyprstream-vfs = { path = "../hyprstream-vfs" }
+hyprstream-rpc = { path = "../hyprstream-rpc" }
+# The proxy reply channel is std::sync::mpsc; the proxy task needs a tokio runtime.
+tokio = { version = "1", features = ["sync", "rt", "rt-multi-thread"] }
+async-trait = "0.1"
+# `/lang/python` mount fid state uses parking_lot::Mutex for interior mutability
+# through `&Fid` (same pattern as the native mount).
+parking_lot = "0.12"
+
 [dev-dependencies]
 anyhow = "1"
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync"] }
+parking_lot = "0.12"

--- a/crates/hyprstream-wasm/FINDINGS.md
+++ b/crates/hyprstream-wasm/FINDINGS.md
@@ -311,3 +311,116 @@ All four P1 deliverables landed; `cargo test -p hyprstream-wasm` is 9/9 green an
   `spawn_vfs_proxy`-backed impl held in `SandboxState`, and add the `env::vfs_*` host
   fns to `build_linker` (sync shims over the proxy `Sender`), reading
   `caller.data().subject` for scoping.
+
+---
+
+## P2 RESOLUTIONS (branch `ewindisch/483-python-profile-a`) — #483 `/lang/python`
+
+All three P2 deliverables landed. `cargo test -p hyprstream-wasm` is GREEN (1 lib +
+11 integration + 1 mount unit test); the guest builds to `wasm32-unknown-unknown`
+importing EXACTLY `{ env::host_random, env::vfs_cat, env::vfs_ls, env::vfs_echo,
+env::vfs_ctl }` (verified with `wasm-tools print`).
+
+### 0. hyprstream-vfs torch-free verdict: CONFIRMED
+
+`cargo build -p hyprstream-wasm` with `hyprstream-vfs` + `hyprstream-rpc` added as
+deps builds with NO LIBTORCH. Neither crate references `tch`/`torch` — libtorch is
+linked ONLY by the top-level `hyprstream` crate. So the canonical VFS seam is usable
+directly from the wasm host. The P1 crate-local `Subject` newtype is REPLACED by
+`pub use hyprstream_rpc::Subject` (re-exported as `hyprstream_vfs::Subject`).
+
+Canonical seam shapes used (from `crates/hyprstream-vfs/src/proxy.rs`):
+- `spawn_vfs_proxy(ns: Arc<Namespace>, subject: Subject) -> tokio::sync::mpsc::Sender<VfsRequest>`
+  — the proxy is PINNED to one Subject at spawn time (identity is implicit, not
+  per-request — the guest cannot change identity).
+- `struct VfsRequest { op: VfsOp, reply: std::sync::mpsc::SyncSender<Result<Vec<u8>, String>> }`
+- `enum VfsOp { Cat{path}, Ls{path}, Echo{path,data}, Ctl{path,cmd}, MountPrefixes }`
+  — PATH-based, and DELIBERATELY excludes mount/bind/unmount (its security
+  invariant). We backed the capability against this real seam rather than the P1
+  fid-based sketch (`Mount::walk/open/read/...`), so the #483 capability is exactly
+  the proxy's bounded surface.
+
+### 1. Real VFS host-fn backing (the capability is real)
+
+- New `vfs::VfsProxyHandle { tx: Sender<VfsRequest>, subject }` stored in
+  `SandboxState` (`Option` — `None` = deny-by-default). `submit(op)` is the
+  sync-over-async bridge: `tx.blocking_send(VfsRequest { op, reply })` then block on a
+  `std::sync::mpsc::sync_channel(1)` reply receiver. (blocking_send => the driver must
+  be a plain thread, NOT a tokio worker.)
+- `build_linker` now wires `env::vfs_cat/vfs_ls/vfs_echo/vfs_ctl`. Each reads
+  `caller.data().subject` for audit and submits via `caller.data().vfs` — NEVER a
+  guest-supplied identity. The reply is serialised into a guest buffer (allocated via
+  the guest's own `alloc` export) as `[status_byte][payload]` and returned packed as
+  `(out_ptr<<32)|out_len` (the i64 ABI the guest's `take_reply` decodes).
+- `define_unknown_imports_as_traps` still fences everything else (deny-by-default).
+- TEST `vfs_e2e::guest_vfs_is_subject_scoped` (PASSES): a GUEST `vfs_probe` call
+  (cat/echo) goes guest -> `env::vfs_*` -> Subject-scoped proxy -> in-memory `Mount`.
+  `alice` reads `/config/temp`, writes `0.9`, reads it back; a `denied` Subject is
+  refused at the `Mount` (`permission denied`) — proving the Subject reaches the
+  backend. `guest_vfs_deny_by_default` (PASSES): a sandbox WITHOUT `.with_vfs(...)`
+  gets the "no capability" reply, never touching a Namespace.
+
+### 2. Guest `/lang/python` semantics (re-expressed on RustPython 0.5)
+
+- Guest gained a PERSISTENT interpreter: a `thread_local Shell { interp, globals }`
+  built once (wasm32 is single-threaded, so the thread-local is the whole guest
+  state). `globals` is a persistent `PyDictRef` reused across calls via
+  `Scope::with_builtins(None, globals.clone(), vm)` — user state survives between
+  calls (the native shell's design).
+- New guest export `py_op(op, ptr, len) -> i64` (packed reply ABI):
+  - eval  -> `repr(result)` (+ `\n---\n<stdout>` if it printed)
+  - exec  -> captured stdout
+  - list_vars / list_defs -> newline-joined non-dunder names (defs = callables only)
+  - get_var / get_def     -> repr of one named global (NONE tag if absent)
+- STDOUT CAPTURE on 0.5: the pure-Python `__Capture` surrogate is PORTED verbatim
+  (`sys.stdout = __Capture()` with a list buffer + `getvalue()`; drained back to a
+  no-op `__Sink`). No `io.StringIO` (avoids extra frozen-module init under the
+  sandbox-stdio path). A `__Sink` baseline is installed at shell construction so
+  stray `print()` never crashes on a `None` stdout. 0.5 API notes: `run_code_string`
+  -> `run_string`; `PyStr::as_str()` is gone — use `to_str()/to_string_lossy()`.
+- Host driver `PyShell` (in lib.rs): holds ONE long-lived `Store`+`Instance` so guest
+  persistence is real, exposes `eval/exec/list_vars/get_var/list_defs/get_def`
+  returning `PyResult::{Ok,Err,None}`. The legacy `eval(ptr,len)->i32` export
+  (fresh-interpreter #505 path) is KEPT so all original #505 host tests still pass.
+- TESTS `pyshell_eval_exec_and_persistent_scope` + `pyshell_vars_and_defs` (PASS):
+  `2+3 -> "5"`, `print('hello') -> "hello\n"`, a var set by exec is visible in a later
+  eval, vars/defs enumeration + dunder exclusion + callable-only defs all verified.
+
+### 3. `/lang/python` Mount (torch-free placement)
+
+- New module `hyprstream_wasm::mount` (INSIDE `hyprstream-wasm` => stays
+  scoped-buildable; no new crate needed). `PythonMount` implements the canonical
+  `hyprstream_vfs::Mount` with the EXACT native layout: `eval` (ctl: expr->repr),
+  `stdout` (ctl: stmts->captured stdout), `vars/` (dir of non-dunder globals),
+  `defs/` (dir of callables). `walk/open/read/write/readdir/stat/clunk` ported.
+- Because `PyShell` must run off the async runtime (its `vfs_*` host fns
+  `blocking_send`), `PythonMount` holds a `tokio::mpsc::Sender<PyCommand>` and
+  `PythonMount::spawn(sandbox, fuel)` starts a dedicated OS thread that owns the
+  `PyShell` and serves commands via `rx.blocking_recv()` — the same channel pattern
+  the native mount used for its `!Send` interpreter. `spawn` returns a single
+  `PythonMount` that OWNS the driver `JoinHandle`; on `Drop` it drops the command
+  sender FIRST (so the driver's `blocking_recv` returns `None` and the loop exits)
+  THEN joins — folding both into one type avoids a drop-ordering deadlock where a
+  separate guard would join while the sender is still alive.
+- TEST `mount::tests::mount_eval_vars_defs_over_guest` (PASSES) against an in-memory
+  VFS: write `2 + 3` to `eval` -> read `5`; exec `x = 42` via `stdout` -> read `42`
+  under `vars/x`; `def f()` -> `f` appears in `defs/` readdir.
+
+### Stubbed / deferred + precise next step
+
+- DAEMON NAMESPACE WIRING (out of scope, documented): registering this mount into the
+  running `/lang/python` namespace lives in the torch-bound `hyprstream` crate. A
+  `// #483 daemon wiring:` block in `mount.rs` gives the exact snippet
+  (`Sandbox::from_bytes_for(..).with_vfs(VfsProxyHandle::new(spawn_vfs_proxy(ns,subj),
+  subj))` -> `PythonMount::spawn` -> `ns.mount("/lang/python", Arc::new(mount))`).
+  NEXT STEP: in the daemon's per-session Namespace builder (where `/lang/tcl` is
+  mounted), embed the guest `.wasm` (build artifact / `include_bytes!`) and call that
+  snippet with the session's verified Subject + the session Namespace.
+- GUEST PYTHON BUILTINS for VFS: the guest exposes `vfs_*` end-to-end via the
+  `vfs_probe` export and Rust helpers (`guest_cat`/`guest_ls`/`guest_echo`/
+  `guest_ctl`), but does NOT yet register them as Python builtins (`cat`/`ls`/`write`/
+  `ctl`) callable from guest source — that needs native-module registration which the
+  current feature set (no `host_env`) omits. Follow-up: register them as native
+  builtins so `cat("/config/x")` works from Python. The capability itself is already
+  real and tested through the host fns.
+- No blockers.

--- a/crates/hyprstream-wasm/FINDINGS.md
+++ b/crates/hyprstream-wasm/FINDINGS.md
@@ -17,10 +17,17 @@ green path identified. Two interpreter-version regimes:
 
 | | rustpython-vm 0.3.1 (spec-pinned) | rustpython-vm 0.5.0 (validated resolution) |
 |---|---|---|
-| getrandom major | 0.2.17 (runtime RNG) + 0.3.4 (ahash) | 0.3.x only |
+| getrandom major | 0.2.17 (runtime RNG) + 0.3.4 (ahash) | 0.3.x only **compiled for wasm** [1] |
 | getrandom/js forced? | YES (hard-coded features=["js"]) | NO (features=["std"]) |
 | wasm imports | host_random + ~34 dead __wbindgen_placeholder__ JS/Date/crypto stubs | exactly 1: env::host_random |
 | runtime | traps at VirtualMachine::new (JS getrandom -> undefined __wbg_static_accessor_SELF) | instantiates with 1 capability (Python essential-init is a separate P1 item) |
+
+[1] The pyguest `Cargo.lock` (0.5 path) still lists getrandom 0.2.17, but it is a HOST
+build-dependency of rustpython's codegen tooling only — pulled via
+`unicode_names2_generator` `[build-dependencies]` (rand 0.8 -> rand_core 0.6 ->
+getrandom 0.2.17), which runs on the host during the build. It is NEVER compiled for the
+wasm32-unknown-unknown target. Harmless; the wasm guest uses only getrandom 0.3 with the
+custom backend.
 
 The committed crates use 0.3 (as specced) and document the blocker; the 0.5 path was
 built and its single-import wasm verified with wasm-tools.
@@ -30,7 +37,12 @@ built and its single-import wasm verified with wasm-tools.
 ## 1. What compiles + what the tests do
 
 Builds (both green):
-- `cargo build --target wasm32-unknown-unknown` in crates/hyprstream-wasm-pyguest/
+- `cargo build --target wasm32-unknown-unknown` run FROM INSIDE crates/hyprstream-wasm-pyguest/
+  i.e. `(cd crates/hyprstream-wasm-pyguest && cargo build --release --target wasm32-unknown-unknown)`.
+  MUST build from the crate dir, NOT with `--manifest-path …pyguest/Cargo.toml` from the repo
+  root: the `getrandom_backend="custom"` rustflag lives in that crate's `.cargo/config.toml`,
+  and Cargo only discovers `.cargo/config.toml` from the CWD (walking up), not from
+  `--manifest-path`. A root `--manifest-path` build drops the cfg and FAILS on getrandom/wasm32.
   (standalone, excluded crate) -> hyprstream_wasm_pyguest.wasm (~11 MB release).
   Exports: memory, alloc, dealloc, eval. Imports: env::host_random PLUS dead
   __wbindgen_placeholder__ JS stubs (0.3 only — see section 2).

--- a/crates/hyprstream-wasm/src/lib.rs
+++ b/crates/hyprstream-wasm/src/lib.rs
@@ -36,6 +36,7 @@ type RngFill = Box<dyn FnMut(&mut [u8]) + Send>;
 use wasmtime::error::Context as _;
 use wasmtime::{bail, Caller, Config, Engine, Extern, Linker, Memory, Module, Result, Store};
 
+pub mod mount;
 pub mod vfs;
 
 // ---------------------------------------------------------------------------
@@ -44,32 +45,12 @@ pub mod vfs;
 
 /// The identity a sandbox evaluation runs as.
 ///
-/// Modelled as a LOCAL newtype for now (P1): deliberately NOT a dependency on
-/// `hyprstream-rpc`/`hyprstream-vfs` yet — we are only defining the seam so that
-/// future capability host-fns are Subject-scoped by construction. When #483 / the
-/// native MAC authz epic re-cuts this, swap the inner representation for the real
-/// `RequestIdentity` / VFS namespace key without touching the Linker wiring.
-///
-/// `None` is the anonymous subject (no bound identity).
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct Subject(pub Option<String>);
-
-impl Subject {
-    /// An anonymous subject (no bound identity).
-    pub fn anonymous() -> Self {
-        Self(None)
-    }
-
-    /// A subject bound to a named identity/tenant.
-    pub fn named(id: impl Into<String>) -> Self {
-        Self(Some(id.into()))
-    }
-
-    /// The bound identity, if any.
-    pub fn id(&self) -> Option<&str> {
-        self.0.as_deref()
-    }
-}
+/// #483 P2: this is now the CANONICAL [`hyprstream_rpc::Subject`] (re-exported via
+/// `hyprstream_vfs::Subject`), NOT the P1 crate-local newtype. Confirmed torch-free:
+/// `hyprstream-vfs -> hyprstream-rpc` pulls no `tch`/libtorch, so the host crate
+/// still builds without LIBTORCH. Using the canonical Subject means the VFS proxy
+/// the sandbox talks to is scoped to the SAME identity the rest of the daemon uses.
+pub use hyprstream_rpc::Subject;
 
 // ---------------------------------------------------------------------------
 // Per-call Store data.
@@ -83,16 +64,20 @@ impl Subject {
 /// capability surface is Subject-parameterized without any global/thread-local
 /// state (the leak that killed the native #488 design).
 pub struct SandboxState {
-    /// The identity this evaluation runs as. Future capability host-fns
-    /// (`vfs_*`, etc.) are authorized/scoped against this.
+    /// The identity this evaluation runs as. Capability host-fns (`host_random`,
+    /// `vfs_*`) are authorized/scoped against this.
     pub subject: Subject,
     /// Entropy source for the single `host_random` capability. The HOST has OS
     /// entropy; the guest only ever sees it through this function.
     rng_bytes: RngFill,
+    /// #483: the Subject-scoped VFS proxy handle backing `env::vfs_*`. `None` =
+    /// the sandbox was created without a VFS capability (the `vfs_*` host fns then
+    /// return a "no vfs capability" error to the guest — deny-by-default).
+    vfs: Option<vfs::VfsProxyHandle>,
 }
 
 impl SandboxState {
-    /// Host state for the given subject, drawing randomness from the OS.
+    /// Host state for the given subject, drawing randomness from the OS. No VFS.
     pub fn new(subject: Subject) -> Self {
         Self {
             subject,
@@ -100,7 +85,15 @@ impl SandboxState {
                 use rand::RngCore;
                 rand::thread_rng().fill_bytes(buf);
             }),
+            vfs: None,
         }
+    }
+
+    /// Host state with a Subject-scoped VFS capability backing `env::vfs_*`.
+    pub fn with_vfs(subject: Subject, vfs: vfs::VfsProxyHandle) -> Self {
+        let mut s = Self::new(subject);
+        s.vfs = Some(vfs);
+        s
     }
 
     /// Deterministic host state for tests (fills with a fixed pattern).
@@ -112,6 +105,7 @@ impl SandboxState {
                     *b = seed.wrapping_add(i as u8);
                 }
             }),
+            vfs: None,
         }
     }
 
@@ -223,11 +217,159 @@ pub fn build_linker(engine: &Engine, module: &Module) -> Result<Linker<SandboxSt
         },
     )?;
 
+    // ── #483: the VFS capability host fns ──────────────────────────────────
+    //
+    // Each reads `caller.data().subject` (NEVER a guest-supplied identity) and
+    // submits the op to the Subject-scoped proxy handle in the Store data. The op
+    // result is written back into a guest buffer (allocated via the guest's own
+    // `alloc` export) as `[status_byte][payload...]` and returned packed as
+    // `(out_ptr<<32)|out_len` — the i64 ABI the guest's `take_reply` decodes.
+    //
+    // If the sandbox has NO vfs handle, the call returns a deny reply
+    // (deny-by-default): the capability is only present when explicitly granted.
+
+    // vfs_cat(path_ptr, path_len) -> i64
+    linker.func_wrap(
+        "env",
+        "vfs_cat",
+        |mut caller: Caller<'_, SandboxState>, ptr: i32, len: i32| -> Result<i64> {
+            let path = read_guest_string(&mut caller, ptr, len)?;
+            let reply = match caller.data().vfs.clone() {
+                Some(h) => h.cat(&path),
+                None => no_vfs_reply(),
+            };
+            write_reply(&mut caller, reply)
+        },
+    )?;
+
+    // vfs_ls(path_ptr, path_len) -> i64
+    linker.func_wrap(
+        "env",
+        "vfs_ls",
+        |mut caller: Caller<'_, SandboxState>, ptr: i32, len: i32| -> Result<i64> {
+            let path = read_guest_string(&mut caller, ptr, len)?;
+            let reply = match caller.data().vfs.clone() {
+                Some(h) => h.ls(&path),
+                None => no_vfs_reply(),
+            };
+            write_reply(&mut caller, reply)
+        },
+    )?;
+
+    // vfs_echo(path_ptr, path_len, data_ptr, data_len) -> i64
+    linker.func_wrap(
+        "env",
+        "vfs_echo",
+        |mut caller: Caller<'_, SandboxState>,
+         pptr: i32,
+         plen: i32,
+         dptr: i32,
+         dlen: i32|
+         -> Result<i64> {
+            let path = read_guest_string(&mut caller, pptr, plen)?;
+            let data = read_guest_bytes(&mut caller, dptr, dlen)?;
+            let reply = match caller.data().vfs.clone() {
+                Some(h) => h.echo(&path, &data),
+                None => no_vfs_reply(),
+            };
+            write_reply(&mut caller, reply)
+        },
+    )?;
+
+    // vfs_ctl(path_ptr, path_len, cmd_ptr, cmd_len) -> i64
+    linker.func_wrap(
+        "env",
+        "vfs_ctl",
+        |mut caller: Caller<'_, SandboxState>,
+         pptr: i32,
+         plen: i32,
+         cptr: i32,
+         clen: i32|
+         -> Result<i64> {
+            let path = read_guest_string(&mut caller, pptr, plen)?;
+            let cmd = read_guest_bytes(&mut caller, cptr, clen)?;
+            let reply = match caller.data().vfs.clone() {
+                Some(h) => h.ctl(&path, &cmd),
+                None => no_vfs_reply(),
+            };
+            write_reply(&mut caller, reply)
+        },
+    )?;
+
     // Wire every OTHER declared import to a trap. This is the explicit, auditable
     // statement that the guest gets NO other host capability.
     linker.define_unknown_imports_as_traps(module)?;
 
     Ok(linker)
+}
+
+/// The deny-by-default reply when a sandbox has no VFS capability granted.
+fn no_vfs_reply() -> vfs::VfsReply {
+    vfs::VfsReply {
+        ok: false,
+        body: b"vfs: no capability granted to this sandbox".to_vec(),
+    }
+}
+
+/// Read `len` bytes of guest memory at `ptr` as a (lossy) UTF-8 string.
+fn read_guest_string(caller: &mut Caller<'_, SandboxState>, ptr: i32, len: i32) -> Result<String> {
+    let bytes = read_guest_bytes(caller, ptr, len)?;
+    Ok(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+/// Read `len` bytes of guest memory at `ptr`.
+fn read_guest_bytes(caller: &mut Caller<'_, SandboxState>, ptr: i32, len: i32) -> Result<Vec<u8>> {
+    if len <= 0 {
+        return Ok(Vec::new());
+    }
+    let memory = match caller.get_export("memory") {
+        Some(Extern::Memory(m)) => m,
+        _ => bail!("guest has no exported memory"),
+    };
+    let data = memory.data(&caller);
+    let start = ptr as usize;
+    let end = start
+        .checked_add(len as usize)
+        .ok_or_else(|| wasmtime::Error::msg("vfs arg length overflow"))?;
+    if end > data.len() {
+        bail!("vfs arg out of bounds");
+    }
+    Ok(data[start..end].to_vec())
+}
+
+/// Serialise a [`vfs::VfsReply`] into a freshly guest-`alloc`ated buffer as
+/// `[status_byte][payload...]` and return the packed `(ptr<<32)|len` i64. The
+/// guest reads it back and `dealloc`s the buffer (see the guest's `take_reply`).
+fn write_reply(caller: &mut Caller<'_, SandboxState>, reply: vfs::VfsReply) -> Result<i64> {
+    // status: 0 = ok, 1 = err (matches the guest's TAG_OK / TAG_ERR).
+    let status: u8 = if reply.ok { 0 } else { 1 };
+    let total = 1 + reply.body.len();
+
+    // Allocate the reply buffer inside the guest via its own allocator so the
+    // guest's `dealloc(ptr, len)` matches.
+    let alloc = caller
+        .get_export("alloc")
+        .and_then(Extern::into_func)
+        .ok_or_else(|| wasmtime::Error::msg("guest has no alloc export"))?
+        .typed::<i32, i32>(&caller)?;
+    let out_ptr = alloc.call(&mut *caller, total as i32)?;
+
+    let memory = match caller.get_export("memory") {
+        Some(Extern::Memory(m)) => m,
+        _ => bail!("guest has no exported memory"),
+    };
+    let mem = memory.data_mut(&mut *caller);
+    let start = out_ptr as usize;
+    let end = start
+        .checked_add(total)
+        .ok_or_else(|| wasmtime::Error::msg("reply length overflow"))?;
+    if end > mem.len() {
+        bail!("reply write out of bounds");
+    }
+    mem[start] = status;
+    mem[start + 1..end].copy_from_slice(&reply.body);
+
+    Ok(((out_ptr as u64) << 32 | total as u64) as i64)
 }
 
 fn write_memory(
@@ -260,6 +402,9 @@ pub struct Sandbox {
     module: Module,
     linker: Linker<SandboxState>,
     subject: Subject,
+    /// #483: optional Subject-scoped VFS capability handed to every `Store` this
+    /// sandbox builds. `None` = no VFS capability (deny-by-default).
+    vfs: Option<vfs::VfsProxyHandle>,
 }
 
 impl Sandbox {
@@ -278,7 +423,18 @@ impl Sandbox {
             module,
             linker,
             subject,
+            vfs: None,
         })
+    }
+
+    /// Grant this sandbox a Subject-scoped VFS capability (`env::vfs_*`).
+    ///
+    /// The `handle` should be a [`vfs::VfsProxyHandle`] from
+    /// `spawn_vfs_proxy(ns, subject)` with the SAME subject the sandbox is bound to,
+    /// so the capability is scoped to this sandbox's identity. Builder-style.
+    pub fn with_vfs(mut self, handle: vfs::VfsProxyHandle) -> Self {
+        self.vfs = Some(handle);
+        self
     }
 
     /// The subject this sandbox is bound to.
@@ -286,10 +442,18 @@ impl Sandbox {
         &self.subject
     }
 
+    /// Build the per-call host state (subject + optional VFS capability).
+    fn make_state(&self) -> SandboxState {
+        match self.vfs.clone() {
+            Some(h) => SandboxState::with_vfs(self.subject.clone(), h),
+            None => SandboxState::new(self.subject.clone()),
+        }
+    }
+
     /// Fresh per-call Store for this sandbox's subject, with the epoch pushed out
     /// of the way (so the caller chooses fuel- or epoch-bounding explicitly).
     fn new_store(&self) -> Store<SandboxState> {
-        Store::new(&self.engine, SandboxState::new(self.subject.clone()))
+        Store::new(&self.engine, self.make_state())
     }
 
     /// Run `source` in a fresh interpreter with the given fuel budget.
@@ -358,5 +522,254 @@ impl Sandbox {
     /// wall-clock bound used by [`Sandbox::eval_with_epoch_deadline`].
     pub fn engine(&self) -> &Engine {
         &self.engine
+    }
+
+    /// Drive the guest's `vfs_probe` export: make the GUEST call an `env::vfs_*`
+    /// host fn, proving the capability is real end-to-end (guest -> host fn ->
+    /// Subject-scoped proxy -> `Namespace`).
+    ///
+    /// `op`: 0=cat, 1=ls, 2=echo, 3=ctl. `path` + optional `body` (echo/ctl). Returns
+    /// the decoded `[status][payload]` reply the host fn produced. This is the
+    /// minimal "a guest script that reads/writes a VFS path goes through the Mount"
+    /// path for deliverable (1); a follow-up registers Python builtins so guest
+    /// Python source itself can call these (see guest `guest_cat`/etc.).
+    pub fn probe_vfs(&self, op: i32, path: &str, body: &[u8]) -> Result<vfs::VfsReply> {
+        let mut store = self.new_store();
+        store.set_fuel(u64::MAX).context("set fuel")?;
+        store.set_epoch_deadline(u64::MAX);
+        let instance = self
+            .linker
+            .instantiate(&mut store, &self.module)
+            .context("instantiate guest")?;
+        let memory = instance
+            .get_memory(&mut store, "memory")
+            .ok_or_else(|| wasmtime::Error::msg("guest memory export"))?;
+        let alloc = instance.get_typed_func::<i32, i32>(&mut store, "alloc")?;
+        let probe = instance
+            .get_typed_func::<(i32, i32, i32, i32, i32), i64>(&mut store, "vfs_probe")?;
+
+        // Ship path + body into guest memory.
+        let pbytes = path.as_bytes();
+        let plen = pbytes.len() as i32;
+        let pptr = if plen > 0 {
+            let p = alloc.call(&mut store, plen)?;
+            memory.write(&mut store, p as usize, pbytes)?;
+            p
+        } else {
+            0
+        };
+        let blen = body.len() as i32;
+        let bptr = if blen > 0 {
+            let p = alloc.call(&mut store, blen)?;
+            memory.write(&mut store, p as usize, body)?;
+            p
+        } else {
+            0
+        };
+
+        let packed = probe
+            .call(&mut store, (op, pptr, plen, bptr, blen))
+            .context("guest vfs_probe trapped")?;
+
+        // The host wrote the reply via the guest allocator; decode it.
+        let p = packed as u64;
+        let out_ptr = (p >> 32) as usize;
+        let out_len = (p & 0xffff_ffff) as usize;
+        if out_ptr == 0 || out_len == 0 {
+            bail!("vfs_probe empty reply");
+        }
+        let data = memory.data(&store);
+        if out_ptr + out_len > data.len() {
+            bail!("vfs_probe reply out of bounds");
+        }
+        let status = data[out_ptr];
+        let payload = data[out_ptr + 1..out_ptr + out_len].to_vec();
+        Ok(vfs::VfsReply {
+            ok: status == TAG_OK,
+            body: payload,
+        })
+    }
+
+    /// Open a PERSISTENT `/lang/python` shell over this sandbox (#483 P2).
+    ///
+    /// Unlike [`Sandbox::eval`] (legacy #505, fresh interpreter per call), the
+    /// returned [`PyShell`] holds ONE long-lived `Store` + `Instance`, so the guest's
+    /// persistent interpreter + globals survive across `eval`/`exec` calls — the
+    /// `/lang/python/vars/` + `/defs/` semantics depend on this.
+    ///
+    /// `fuel` is set per `py_op` call (a fresh budget each invocation); the store
+    /// itself is reused. The epoch is pushed out (fuel is the limiter for the shell
+    /// path; a future variant can re-arm the epoch per call).
+    pub fn open_shell(&self, per_call_fuel: u64) -> Result<PyShell> {
+        let mut store = self.new_store();
+        store.set_fuel(per_call_fuel).context("set fuel")?;
+        store.set_epoch_deadline(u64::MAX);
+        let instance = self
+            .linker
+            .instantiate(&mut store, &self.module)
+            .context("instantiate guest")?;
+        let memory = instance
+            .get_memory(&mut store, "memory")
+            .ok_or_else(|| wasmtime::Error::msg("guest memory export"))?;
+        let alloc = instance.get_typed_func::<i32, i32>(&mut store, "alloc")?;
+        let dealloc = instance.get_typed_func::<(i32, i32), ()>(&mut store, "dealloc")?;
+        let py_op = instance.get_typed_func::<(i32, i32, i32), i64>(&mut store, "py_op")?;
+        Ok(PyShell {
+            store,
+            memory,
+            alloc,
+            dealloc,
+            py_op,
+            per_call_fuel,
+        })
+    }
+}
+
+/// The op codes the guest's `py_op` export understands (must match the guest's
+/// `Op` enum byte-for-byte).
+#[derive(Clone, Copy, Debug)]
+#[repr(i32)]
+enum PyOp {
+    Eval = 0,
+    Exec = 1,
+    ListVars = 2,
+    GetVar = 3,
+    ListDefs = 4,
+    GetDef = 5,
+}
+
+/// Status tags in the first byte of a `py_op` reply (must match the guest:
+/// `TAG_OK=0`, `TAG_ERR=1`, `TAG_NONE=2`). Only OK and NONE are matched explicitly;
+/// any other tag (i.e. ERR=1) decodes to [`PyResult::Err`].
+const TAG_OK: u8 = 0;
+const TAG_NONE: u8 = 2;
+
+/// The outcome of a `py_op`: a status tag plus the UTF-8 payload.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PyResult {
+    /// Success — the payload (repr / stdout / newline-joined names).
+    Ok(String),
+    /// A Python-level error — the message.
+    Err(String),
+    /// The requested name was absent (get_var / get_def).
+    None,
+}
+
+impl PyResult {
+    /// The success payload, or `None` for Err/None.
+    pub fn ok(&self) -> Option<&str> {
+        match self {
+            PyResult::Ok(s) => Some(s),
+            _ => None,
+        }
+    }
+}
+
+/// A persistent `/lang/python` shell over a single guest instance (#483 P2).
+///
+/// Holds the long-lived `Store`/`Instance` so the guest interpreter's state
+/// survives across calls. Drives the guest's `py_op` ABI: ship the argument into
+/// guest memory, call `py_op(op, ptr, len)`, decode the packed `(out_ptr<<32)|len`
+/// reply, then `dealloc` the reply buffer.
+///
+/// `!Send`-free at the type level (wasmtime types are `Send`), but a `PyShell` must
+/// be driven from a NON-async thread if its sandbox holds a VFS capability (the
+/// `vfs_*` host fns `blocking_send`).
+pub struct PyShell {
+    store: Store<SandboxState>,
+    memory: Memory,
+    alloc: wasmtime::TypedFunc<i32, i32>,
+    dealloc: wasmtime::TypedFunc<(i32, i32), ()>,
+    py_op: wasmtime::TypedFunc<(i32, i32, i32), i64>,
+    per_call_fuel: u64,
+}
+
+impl PyShell {
+    /// Run one op with `arg` as the UTF-8 argument; decode the reply.
+    fn call(&mut self, op: PyOp, arg: &str) -> Result<PyResult> {
+        // Fresh fuel budget per call (the store is reused, fuel is not).
+        self.store.set_fuel(self.per_call_fuel).context("set fuel")?;
+
+        let bytes = arg.as_bytes();
+        let len = bytes.len() as i32;
+        let ptr = if len > 0 {
+            let p = self.alloc.call(&mut self.store, len)?;
+            self.memory
+                .write(&mut self.store, p as usize, bytes)
+                .context("write py_op arg")?;
+            p
+        } else {
+            0
+        };
+
+        let packed = self
+            .py_op
+            .call(&mut self.store, (op as i32, ptr, len))
+            .context("guest py_op trapped")?;
+        if len > 0 {
+            let _ = self.dealloc.call(&mut self.store, (ptr, len));
+        }
+
+        // Decode (out_ptr<<32)|out_len, read [tag][payload], then dealloc it.
+        let p = packed as u64;
+        let out_ptr = (p >> 32) as usize;
+        let out_len = (p & 0xffff_ffff) as usize;
+        if out_ptr == 0 || out_len == 0 {
+            return Ok(PyResult::Err("empty reply".to_owned()));
+        }
+        let data = self.memory.data(&self.store);
+        if out_ptr + out_len > data.len() {
+            bail!("py_op reply out of bounds");
+        }
+        let tag = data[out_ptr];
+        let body = String::from_utf8_lossy(&data[out_ptr + 1..out_ptr + out_len]).into_owned();
+        let _ = self
+            .dealloc
+            .call(&mut self.store, (out_ptr as i32, out_len as i32));
+
+        Ok(match tag {
+            TAG_OK => PyResult::Ok(body),
+            TAG_NONE => PyResult::None,
+            _ => PyResult::Err(body),
+        })
+    }
+
+    /// Evaluate an expression -> `repr(result)` (with `\n---\n<stdout>` appended if
+    /// the expression printed anything), mirroring the native `eval` file.
+    pub fn eval(&mut self, expr: &str) -> Result<PyResult> {
+        self.call(PyOp::Eval, expr)
+    }
+
+    /// Execute statements -> captured stdout, mirroring the native `stdout` file.
+    pub fn exec(&mut self, src: &str) -> Result<PyResult> {
+        self.call(PyOp::Exec, src)
+    }
+
+    /// Newline-joined non-dunder global variable names (`vars/`).
+    pub fn list_vars(&mut self) -> Result<Vec<String>> {
+        Ok(split_names(self.call(PyOp::ListVars, "")?))
+    }
+
+    /// `repr` of one global variable (`vars/<name>`), or `None` if absent.
+    pub fn get_var(&mut self, name: &str) -> Result<PyResult> {
+        self.call(PyOp::GetVar, name)
+    }
+
+    /// Newline-joined callable global names (`defs/`).
+    pub fn list_defs(&mut self) -> Result<Vec<String>> {
+        Ok(split_names(self.call(PyOp::ListDefs, "")?))
+    }
+
+    /// `repr` of one callable global (`defs/<name>`), or `None` if absent/not callable.
+    pub fn get_def(&mut self, name: &str) -> Result<PyResult> {
+        self.call(PyOp::GetDef, name)
+    }
+}
+
+/// Split a newline-joined name list reply into a `Vec<String>` (empty if not Ok).
+fn split_names(r: PyResult) -> Vec<String> {
+    match r {
+        PyResult::Ok(s) if !s.is_empty() => s.lines().map(|l| l.to_owned()).collect(),
+        _ => Vec::new(),
     }
 }

--- a/crates/hyprstream-wasm/src/mount.rs
+++ b/crates/hyprstream-wasm/src/mount.rs
@@ -1,0 +1,472 @@
+//! `/lang/python/` VFS mount backed by the WASM-sandboxed guest (#483 P2).
+//!
+//! This re-exposes the native `/lang/python` layout (from the superseded
+//! `hyprstream-python` crate) but driven by the [`PyShell`](crate::PyShell) over the
+//! wasm guest instead of a native RustPython interpreter. Behaviour/layout are
+//! ported; the interpreter is the sandboxed guest.
+//!
+//! Layout (identical to the native mount):
+//! - `/lang/python/eval`    — ctl: write a Python EXPRESSION, read `repr(result)`
+//!   (with `\n---\n<stdout>` appended if it printed)
+//! - `/lang/python/stdout`  — ctl: write Python STATEMENTS, read captured stdout
+//! - `/lang/python/vars/`   — dynamic dir: non-dunder globals as readable files
+//! - `/lang/python/defs/`   — dynamic dir: callable globals (functions/classes)
+//!
+//! ## Why a command channel (same shape as the native mount)
+//!
+//! A [`PyShell`](crate::PyShell) owns a long-lived wasmtime `Store`. When the
+//! sandbox holds a VFS capability, its `vfs_*` host fns `blocking_send` on the proxy
+//! — so the shell MUST be driven from a NON-async (plain) thread, never a tokio
+//! worker. The async [`Mount`] methods therefore cannot call the shell directly:
+//! [`PythonMount`] holds a `tokio::sync::mpsc::Sender<PyCommand>` and forwards each
+//! request to a dedicated interpreter thread that owns the `PyShell` and replies
+//! over a oneshot. This is the exact pattern the native mount used for its `!Send`
+//! interpreter, and it keeps the shell off the async runtime.
+//!
+//! ## #483 daemon wiring (OUT OF SCOPE here — documented TODO)
+//!
+//! Registering this mount into the RUNNING `/lang/python` namespace lives in the
+//! torch-bound `hyprstream` crate and is intentionally not done here. To plug in:
+//!
+//! ```ignore
+//! // #483 daemon wiring: in the hyprstream daemon, where the per-session
+//! // Namespace is built (alongside the Tcl `/lang/tcl` mount):
+//! let sandbox = hyprstream_wasm::Sandbox::from_bytes_for(GUEST_WASM, subject.clone())
+//!     .with_vfs(hyprstream_wasm::vfs::VfsProxyHandle::new(
+//!         hyprstream_vfs::proxy::spawn_vfs_proxy(ns.clone(), subject.clone()),
+//!         subject.clone(),
+//!     ));
+//! let mount = hyprstream_wasm::mount::PythonMount::spawn(sandbox, PER_CALL_FUEL);
+//! ns.mount("/lang/python", std::sync::Arc::new(mount))?;
+//! ```
+//!
+//! The mount owns the interpreter driver thread and joins it on `Drop`, so the
+//! daemon only needs to keep the `Arc<dyn Mount>` alive (in the Namespace).
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use hyprstream_vfs::{DirEntry, Fid, Mount, MountError, Stat, Subject};
+use parking_lot::Mutex;
+
+use crate::{PyResult, PyShell, Sandbox};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Commands sent from async Mount methods to the interpreter-owning thread.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A request to the thread that owns the [`PyShell`].
+enum PyCommand {
+    Eval {
+        code: String,
+        resp: tokio::sync::oneshot::Sender<PyResult>,
+    },
+    Exec {
+        code: String,
+        resp: tokio::sync::oneshot::Sender<PyResult>,
+    },
+    ListVars {
+        resp: tokio::sync::oneshot::Sender<Vec<String>>,
+    },
+    GetVar {
+        name: String,
+        resp: tokio::sync::oneshot::Sender<PyResult>,
+    },
+    ListDefs {
+        resp: tokio::sync::oneshot::Sender<Vec<String>>,
+    },
+    GetDef {
+        name: String,
+        resp: tokio::sync::oneshot::Sender<PyResult>,
+    },
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fid types.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Clone, Debug)]
+enum PyFidKind {
+    Root,
+    Eval,
+    Stdout,
+    VarsDir,
+    Var(String),
+    DefsDir,
+    Def(String),
+}
+
+/// Fid state. `result` buffers the response from a write so a later read returns it
+/// (the Plan9 ctl pattern). `Mutex` for interior mutability through `&Fid`.
+struct PyFid {
+    kind: PyFidKind,
+    result: Mutex<Vec<u8>>,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The driver thread + mount.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// VFS mount exposing `/lang/python` over a wasm [`Sandbox`].
+///
+/// `Send + Sync` (it only holds a channel sender + the driver `JoinHandle`); the
+/// `!`-async [`PyShell`] lives on the driver thread. Build with
+/// [`PythonMount::spawn`].
+///
+/// On `Drop`, the mount FIRST drops the command sender (closing the channel so the
+/// driver loop's `blocking_recv` returns `None` and the thread exits), THEN joins
+/// the thread. Doing both here — rather than in a separate guard — avoids the
+/// drop-ordering footgun where a separate guard would try to join while the sender
+/// is still alive (the channel never closes → join hangs forever).
+pub struct PythonMount {
+    /// `Option` so `Drop` can take (and thus drop) it BEFORE joining the thread.
+    tx: Option<tokio::sync::mpsc::Sender<PyCommand>>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Drop for PythonMount {
+    fn drop(&mut self) {
+        // Close the channel FIRST so the driver's blocking_recv returns None.
+        self.tx.take();
+        // Then join the driver thread (it will have exited its recv loop).
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+impl PythonMount {
+    /// Spawn the interpreter driver thread over `sandbox` and return the mount.
+    /// `per_call_fuel` is the fuel budget per `eval`/`exec`.
+    ///
+    /// The driver thread opens the [`PyShell`] (a non-async context, so the
+    /// sandbox's `vfs_*` host fns may `blocking_send`) and serves `PyCommand`s until
+    /// the channel closes (i.e. until the mount is dropped). The mount owns the
+    /// thread and joins it on `Drop`.
+    pub fn spawn(sandbox: Sandbox, per_call_fuel: u64) -> Self {
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<PyCommand>(16);
+        let handle = std::thread::Builder::new()
+            .name("hyprstream-wasm-pyshell".into())
+            .spawn(move || {
+                // Open the persistent shell on THIS (plain) thread.
+                let mut shell: PyShell = match sandbox.open_shell(per_call_fuel) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        eprintln!("pyshell: failed to open: {e}");
+                        return;
+                    }
+                };
+                // blocking_recv: this is a dedicated OS thread, not a tokio worker.
+                while let Some(cmd) = rx.blocking_recv() {
+                    serve(&mut shell, cmd);
+                }
+            })
+            .expect("spawn pyshell driver thread");
+        Self {
+            tx: Some(tx),
+            handle: Some(handle),
+        }
+    }
+
+    /// The command sender (always `Some` until `Drop`).
+    fn tx(&self) -> &tokio::sync::mpsc::Sender<PyCommand> {
+        self.tx.as_ref().expect("mount sender present until drop")
+    }
+
+    async fn request<T>(
+        &self,
+        build: impl FnOnce(tokio::sync::oneshot::Sender<T>) -> PyCommand,
+    ) -> Result<T, MountError> {
+        let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
+        self.tx()
+            .send(build(resp_tx))
+            .await
+            .map_err(|_| MountError::Io("python interpreter gone".into()))?;
+        resp_rx
+            .await
+            .map_err(|_| MountError::Io("python interpreter did not respond".into()))
+    }
+}
+
+/// Serve one command against the shell (runs on the driver thread).
+fn serve(shell: &mut PyShell, cmd: PyCommand) {
+    match cmd {
+        PyCommand::Eval { code, resp } => {
+            let _ = resp.send(shell.eval(&code).unwrap_or_else(err_result));
+        }
+        PyCommand::Exec { code, resp } => {
+            let _ = resp.send(shell.exec(&code).unwrap_or_else(err_result));
+        }
+        PyCommand::ListVars { resp } => {
+            let _ = resp.send(shell.list_vars().unwrap_or_default());
+        }
+        PyCommand::GetVar { name, resp } => {
+            let _ = resp.send(shell.get_var(&name).unwrap_or_else(err_result));
+        }
+        PyCommand::ListDefs { resp } => {
+            let _ = resp.send(shell.list_defs().unwrap_or_default());
+        }
+        PyCommand::GetDef { name, resp } => {
+            let _ = resp.send(shell.get_def(&name).unwrap_or_else(err_result));
+        }
+    }
+}
+
+/// A trapped/host-side error surfaces to the guest as a Python-level error string.
+fn err_result(e: wasmtime::Error) -> PyResult {
+    PyResult::Err(format!("sandbox: {e}"))
+}
+
+/// Render a [`PyResult`] for the `eval`/`stdout` ctl read.
+fn render(r: PyResult) -> Vec<u8> {
+    match r {
+        PyResult::Ok(s) => s.into_bytes(),
+        PyResult::None => Vec::new(),
+        PyResult::Err(e) => format!("error: {e}").into_bytes(),
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl Mount for PythonMount {
+    async fn walk(&self, components: &[&str], _caller: &Subject) -> Result<Fid, MountError> {
+        let kind = match components {
+            [] => PyFidKind::Root,
+            ["eval"] => PyFidKind::Eval,
+            ["stdout"] => PyFidKind::Stdout,
+            ["vars"] => PyFidKind::VarsDir,
+            ["vars", name] => PyFidKind::Var((*name).to_owned()),
+            ["defs"] => PyFidKind::DefsDir,
+            ["defs", name] => PyFidKind::Def((*name).to_owned()),
+            _ => return Err(MountError::NotFound(components.join("/"))),
+        };
+        Ok(Fid::new(PyFid {
+            kind,
+            result: Mutex::new(Vec::new()),
+        }))
+    }
+
+    async fn open(&self, _fid: &mut Fid, _mode: u8, _caller: &Subject) -> Result<(), MountError> {
+        Ok(())
+    }
+
+    async fn read(
+        &self,
+        fid: &Fid,
+        offset: u64,
+        _count: u32,
+        _caller: &Subject,
+    ) -> Result<Vec<u8>, MountError> {
+        let inner = fid
+            .downcast_ref::<PyFid>()
+            .ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
+        let data: Vec<u8> = match &inner.kind {
+            PyFidKind::Eval | PyFidKind::Stdout => inner.result.lock().clone(),
+            PyFidKind::Var(name) => {
+                let r = self
+                    .request(|resp| PyCommand::GetVar {
+                        name: name.clone(),
+                        resp,
+                    })
+                    .await?;
+                match r {
+                    PyResult::None => return Err(MountError::NotFound(format!("vars/{name}"))),
+                    other => render(other),
+                }
+            }
+            PyFidKind::Def(name) => {
+                let r = self
+                    .request(|resp| PyCommand::GetDef {
+                        name: name.clone(),
+                        resp,
+                    })
+                    .await?;
+                match r {
+                    PyResult::None => return Err(MountError::NotFound(format!("defs/{name}"))),
+                    other => render(other),
+                }
+            }
+            PyFidKind::Root | PyFidKind::VarsDir | PyFidKind::DefsDir => {
+                return Err(MountError::IsDirectory("use readdir".into()))
+            }
+        };
+        let start = offset as usize;
+        if start >= data.len() {
+            return Ok(Vec::new());
+        }
+        Ok(data[start..].to_vec())
+    }
+
+    async fn write(
+        &self,
+        fid: &Fid,
+        _offset: u64,
+        data: &[u8],
+        _caller: &Subject,
+    ) -> Result<u32, MountError> {
+        let inner = fid
+            .downcast_ref::<PyFid>()
+            .ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
+        match &inner.kind {
+            PyFidKind::Eval => {
+                let code = String::from_utf8_lossy(data).into_owned();
+                let r = self.request(|resp| PyCommand::Eval { code, resp }).await?;
+                *inner.result.lock() = render(r);
+                Ok(data.len() as u32)
+            }
+            PyFidKind::Stdout => {
+                let code = String::from_utf8_lossy(data).into_owned();
+                let r = self.request(|resp| PyCommand::Exec { code, resp }).await?;
+                *inner.result.lock() = render(r);
+                Ok(data.len() as u32)
+            }
+            _ => Err(MountError::NotSupported("read-only".into())),
+        }
+    }
+
+    async fn readdir(&self, fid: &Fid, _caller: &Subject) -> Result<Vec<DirEntry>, MountError> {
+        let inner = fid
+            .downcast_ref::<PyFid>()
+            .ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
+        let mk = |name: String, is_dir: bool| DirEntry {
+            name,
+            is_dir,
+            size: 0,
+            stat: None,
+        };
+        match &inner.kind {
+            PyFidKind::Root => Ok(vec![
+                mk("eval".into(), false),
+                mk("stdout".into(), false),
+                mk("vars".into(), true),
+                mk("defs".into(), true),
+            ]),
+            PyFidKind::VarsDir => {
+                let names = self.request(|resp| PyCommand::ListVars { resp }).await?;
+                Ok(names.into_iter().map(|n| mk(n, false)).collect())
+            }
+            PyFidKind::DefsDir => {
+                let names = self.request(|resp| PyCommand::ListDefs { resp }).await?;
+                Ok(names.into_iter().map(|n| mk(n, false)).collect())
+            }
+            _ => Err(MountError::NotDirectory(format!("{:?}", inner.kind))),
+        }
+    }
+
+    async fn stat(&self, fid: &Fid, _caller: &Subject) -> Result<Stat, MountError> {
+        let inner = fid
+            .downcast_ref::<PyFid>()
+            .ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
+        let (name, qtype) = match &inner.kind {
+            PyFidKind::Root => ("python".to_owned(), 0x80u8),
+            PyFidKind::Eval => ("eval".to_owned(), 0u8),
+            PyFidKind::Stdout => ("stdout".to_owned(), 0u8),
+            PyFidKind::VarsDir => ("vars".to_owned(), 0x80u8),
+            PyFidKind::Var(n) => (n.clone(), 0u8),
+            PyFidKind::DefsDir => ("defs".to_owned(), 0x80u8),
+            PyFidKind::Def(n) => (n.clone(), 0u8),
+        };
+        Ok(Stat {
+            qtype,
+            size: 0,
+            name,
+            mtime: 0,
+        })
+    }
+
+    async fn clunk(&self, _fid: Fid, _caller: &Subject) {}
+}
+
+/// Convenience alias so daemon code can keep an `Arc<dyn Mount>` without naming the
+/// concrete type.
+pub fn as_mount(mount: PythonMount) -> Arc<dyn Mount> {
+    Arc::new(mount)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Sandbox;
+    use std::path::PathBuf;
+
+    fn guest_wasm() -> Option<Vec<u8>> {
+        if let Ok(p) = std::env::var("HYPRSTREAM_PYGUEST_WASM") {
+            return std::fs::read(&p).ok();
+        }
+        let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let guest_dir = manifest.parent().map(|p| p.join("hyprstream-wasm-pyguest"))?;
+        for profile in ["release", "debug"] {
+            let c = guest_dir
+                .join("target/wasm32-unknown-unknown")
+                .join(profile)
+                .join("hyprstream_wasm_pyguest.wasm");
+            if c.exists() {
+                if let Ok(b) = std::fs::read(&c) {
+                    return Some(b);
+                }
+            }
+        }
+        None
+    }
+
+    /// End-to-end mount test against an in-memory VFS: write an expr to `eval`, read
+    /// the result; exec sets a var, read it back under `vars/`; `readdir` lists the
+    /// layout. Mirrors the native mount's unit tests, driven by the wasm guest.
+    #[test]
+    fn mount_eval_vars_defs_over_guest() {
+        let Some(wasm) = guest_wasm() else {
+            eprintln!("SKIP mount test: guest wasm not built");
+            return;
+        };
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let subject = Subject::new("alice");
+        let sandbox = Sandbox::from_bytes_for(&wasm, subject.clone()).expect("load");
+        let mount = PythonMount::spawn(sandbox, 50_000_000_000);
+
+        rt.block_on(async {
+            // readdir root -> eval/stdout/vars/defs.
+            let root = mount.walk(&[], &subject).await.unwrap();
+            let entries = mount.readdir(&root, &subject).await.unwrap();
+            let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+            assert!(names.contains(&"eval"));
+            assert!(names.contains(&"vars"));
+            assert!(names.contains(&"defs"));
+
+            // Write an expression to `eval`, read the repr back.
+            let eval = mount.walk(&["eval"], &subject).await.unwrap();
+            mount.write(&eval, 0, b"2 + 3", &subject).await.unwrap();
+            let out = mount.read(&eval, 0, 4096, &subject).await.unwrap();
+            assert_eq!(out, b"5", "eval should return repr 5");
+
+            // exec sets a var via `stdout`, then read it under `vars/x`.
+            let stdout = mount.walk(&["stdout"], &subject).await.unwrap();
+            mount.write(&stdout, 0, b"x = 42", &subject).await.unwrap();
+
+            let var_x = mount.walk(&["vars", "x"], &subject).await.unwrap();
+            let out = mount.read(&var_x, 0, 4096, &subject).await.unwrap();
+            assert_eq!(out, b"42", "vars/x should be the persisted value");
+
+            // vars/ readdir includes x.
+            let vars_dir = mount.walk(&["vars"], &subject).await.unwrap();
+            let entries = mount.readdir(&vars_dir, &subject).await.unwrap();
+            assert!(entries.iter().any(|e| e.name == "x"));
+
+            // Define a function; defs/ lists it, vars/ shows it too.
+            let stdout2 = mount.walk(&["stdout"], &subject).await.unwrap();
+            mount
+                .write(&stdout2, 0, b"def f():\n    return 1\n", &subject)
+                .await
+                .unwrap();
+            let defs_dir = mount.walk(&["defs"], &subject).await.unwrap();
+            let defs = mount.readdir(&defs_dir, &subject).await.unwrap();
+            assert!(defs.iter().any(|e| e.name == "f"), "defs/ should list f");
+
+            eprintln!("mount: eval/vars/defs over guest all green");
+        });
+    }
+}

--- a/crates/hyprstream-wasm/src/vfs.rs
+++ b/crates/hyprstream-wasm/src/vfs.rs
@@ -1,304 +1,341 @@
-//! VFS host-function seam (Profile-A capability surface) — SKETCH for #483.
+//! VFS capability backing for the sandbox (#483 P2 — REAL, not a sketch).
 //!
-//! This module is a DESIGN SEAM, not a working implementation. It records the
-//! shape of the VFS capability host functions as they will be wired into the
-//! wasmtime [`Linker`](wasmtime::Linker) so that a future guest can do file I/O —
-//! but ONLY against a per-[`Subject`](crate::Subject) VFS namespace, never the host
-//! filesystem.
+//! This is the proof the sandbox capability is real: a guest `vfs_*` call is
+//! bridged, synchronously, to the canonical `hyprstream_vfs` [`Namespace`] through
+//! the [`spawn_vfs_proxy`] seam, and is scoped to the [`Subject`] the `Sandbox` is
+//! bound to — never to any identity the guest supplies.
 //!
-//! ## How it will wire up (Profile A)
-//!
-//! Each host fn below maps 1:1 to a method on `hyprstream_vfs`'s `Mount`/`Namespace`
-//! surface, every one of which already takes a `&Subject`:
+//! ## Wiring
 //!
 //! ```text
-//!   vfs_walk   -> Namespace::walk     (resolve a path to a Fid)
-//!   vfs_open   -> Mount::open
-//!   vfs_read   -> Namespace::read_one / Mount::read
-//!   vfs_write  -> Mount::write
-//!   vfs_stat   -> Mount::stat
-//!   vfs_ls     -> Namespace::ls / Mount::readdir
-//!   vfs_create -> Namespace::create / Mount::create
+//!   guest env::vfs_cat(path)        -> VfsOp::Cat  { path }   -> Namespace::cat
+//!   guest env::vfs_ls(path)         -> VfsOp::Ls   { path }   -> Namespace::ls
+//!   guest env::vfs_echo(path,data)  -> VfsOp::Echo { path, data } -> Namespace::echo
+//!   guest env::vfs_ctl(path,cmd)    -> VfsOp::Ctl  { path, cmd }  -> Namespace::ctl
 //! ```
 //!
-//! The Store data ([`crate::SandboxState`]) already carries the bound `Subject`;
-//! the wired host fns will read `caller.data().subject` and pass it straight to the
-//! VFS, so file access is Subject-scoped BY CONSTRUCTION (same pattern as
-//! `host_random`).
+//! The host fns (in `build_linker`) read `caller.data().subject` and submit a
+//! [`VfsRequest`] whose `op` carries the Subject IMPLICITLY: the proxy task is
+//! `spawn_vfs_proxy(ns, subject)` — i.e. each proxy is pinned to ONE Subject at
+//! spawn time, so every request through it is executed as that Subject. The guest
+//! has no way to name or forge an identity.
 //!
-// P1b/#483: the concrete backing will be a `hyprstream_vfs::spawn_vfs_proxy(ns, subject)
-// -> tokio::sync::mpsc::Sender<VfsRequest>` held in the Store data. The host fns here
-// become sync shims that submit a `VfsRequest { op, reply }` over that Sender and block
-// on the reply channel (the proxy bridges sync wasm calls to the async Namespace, and
-// its `VfsOp` enum DELIBERATELY excludes mount/bind/unmount — scripts cannot remount).
-// We do NOT pull in `hyprstream-vfs` yet (it would drag the RPC/tokio stack into this
-// otherwise-minimal host crate); this seam exists only so the design compiles and the
-// #483 re-cut has a typed target.
-//
-//! Until #483, the trait below is backed by a trivial in-memory stub
-//! ([`InMemoryVfs`]) used only by the seam test, so the surface compiles and is
-//! legible.
+//! ## Why path-based ops, not the P1 fid-based sketch
+//!
+//! The P1 `vfs.rs` sketched a fid-based `VfsCapability` (walk/open/read/write/…),
+//! mirroring [`hyprstream_vfs::Mount`]. The CANONICAL sync seam, however, is the
+//! proxy's [`VfsOp`] enum, which is PATH-based (`Cat`/`Ls`/`Echo`/`Ctl`) and
+//! DELIBERATELY excludes `mount`/`bind`/`unmount` (its security invariant: scripts
+//! cannot remount). We back the capability against that real seam rather than the
+//! sketch, so the #483 capability is exactly the proxy's bounded surface.
+//!
+//! ## Sync-over-async bridge
+//!
+//! wasm host fns are synchronous; the `Namespace` is async. The proxy
+//! ([`spawn_vfs_proxy`]) bridges: it returns a `tokio::sync::mpsc::Sender<VfsRequest>`
+//! and each [`VfsRequest`] carries a `std::sync::mpsc::SyncSender` reply channel. A
+//! host fn does `blocking_send` of the request, then blocks on the std reply
+//! receiver — never touching the async runtime directly. (`blocking_send` requires
+//! we are NOT on a tokio worker thread; the `Sandbox` is driven from a plain thread,
+//! and the proxy task runs on a separate runtime — see the tests.)
 
-use crate::Subject;
+use hyprstream_rpc::Subject;
+use hyprstream_vfs::proxy::{VfsOp, VfsRequest};
+use tokio::sync::mpsc::Sender as TokioSender;
 
-/// Errors a VFS capability host fn can return to the guest.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum VfsError {
-    /// The subject is not authorized to touch this path.
-    Denied,
-    /// No such path / fid.
-    NotFound,
-    /// Not implemented yet (the #483 default).
-    Unimplemented,
-    /// Any other backend error, stringified.
-    Other(String),
+/// A handle to a Subject-scoped VFS proxy.
+///
+/// Created by [`spawn_vfs_proxy`] (one per Subject) and stored in
+/// [`crate::SandboxState`]. The host `vfs_*` fns submit ops over it and block on
+/// the reply. The Subject is implicit in the proxy itself, so this handle does NOT
+/// re-pass a Subject per call — which is exactly the property we want: the guest
+/// cannot change identity.
+#[derive(Clone)]
+pub struct VfsProxyHandle {
+    tx: TokioSender<VfsRequest>,
+    /// The Subject this proxy is pinned to (kept for auditing / introspection only;
+    /// it is NOT sent per-request — the proxy already runs as this Subject).
+    subject: Subject,
 }
 
-impl std::fmt::Display for VfsError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            VfsError::Denied => write!(f, "vfs: permission denied"),
-            VfsError::NotFound => write!(f, "vfs: not found"),
-            VfsError::Unimplemented => write!(f, "vfs: unimplemented (P1b/#483)"),
-            VfsError::Other(s) => write!(f, "vfs: {s}"),
+/// Result of a VFS op exposed to the guest: a status tag + a UTF-8 payload.
+///
+/// `ok == true` -> payload is the result bytes; `ok == false` -> payload is the
+/// error string. This is the shape the host fns serialise into the guest reply
+/// buffer (status byte + payload).
+pub struct VfsReply {
+    pub ok: bool,
+    pub body: Vec<u8>,
+}
+
+impl VfsProxyHandle {
+    /// Wrap a proxy `Sender` pinned to `subject`.
+    pub fn new(tx: TokioSender<VfsRequest>, subject: Subject) -> Self {
+        Self { tx, subject }
+    }
+
+    /// The Subject every op through this handle runs as.
+    pub fn subject(&self) -> &Subject {
+        &self.subject
+    }
+
+    /// Submit one op and block on the reply (sync-over-async bridge).
+    ///
+    /// Returns `Err(String)` only for transport failures (proxy gone / no reply);
+    /// VFS-level errors come back as `VfsReply { ok: false, .. }`.
+    fn submit(&self, op: VfsOp) -> VfsReply {
+        // std::sync::mpsc rendezvous channel for the reply (the proxy's reply type).
+        let (reply_tx, reply_rx) = std::sync::mpsc::sync_channel(1);
+        let req = VfsRequest {
+            op,
+            reply: reply_tx,
+        };
+        // `blocking_send`: the host fn is on a non-async thread; this parks until
+        // the proxy task accepts the request. If the proxy is gone, surface it as
+        // a VFS error rather than panicking the guest call.
+        if self.tx.blocking_send(req).is_err() {
+            return VfsReply {
+                ok: false,
+                body: b"vfs: proxy unavailable".to_vec(),
+            };
+        }
+        match reply_rx.recv() {
+            Ok(Ok(bytes)) => VfsReply {
+                ok: true,
+                body: bytes,
+            },
+            Ok(Err(msg)) => VfsReply {
+                ok: false,
+                body: msg.into_bytes(),
+            },
+            Err(_) => VfsReply {
+                ok: false,
+                body: b"vfs: proxy did not respond".to_vec(),
+            },
         }
     }
-}
 
-impl std::error::Error for VfsError {}
-
-/// An opaque file handle (mirrors `hyprstream_vfs::mount::Fid`).
-pub type Fid = u64;
-
-/// A directory entry (the subset the guest needs).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DirEntry {
-    pub name: String,
-    pub is_dir: bool,
-}
-
-/// File metadata (the subset the guest needs).
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct Stat {
-    pub len: u64,
-    pub is_dir: bool,
-}
-
-/// The Profile-A VFS capability surface, as it will be exposed to the guest.
-///
-/// EVERY method takes the call's [`Subject`] so the implementation can scope/authorize
-/// per identity. This is the exact set of host fns the Linker will define under `env`
-/// (`vfs_walk`, `vfs_open`, ...). The ABI those host fns present to wasm (ptr/len pairs
-/// into guest linear memory, return-code conventions) is out of scope for this sketch;
-/// this trait captures the typed Rust surface they delegate to.
-pub trait VfsCapability {
-    /// Resolve a path to a file handle. -> `Namespace::walk`.
-    fn vfs_walk(&self, subject: &Subject, path: &str) -> Result<Fid, VfsError>;
-
-    /// Open an existing handle with the given mode bits. -> `Mount::open`.
-    fn vfs_open(&self, subject: &Subject, fid: Fid, mode: u8) -> Result<(), VfsError>;
-
-    /// Read `count` bytes at `offset` from a handle. -> `Mount::read`.
-    fn vfs_read(
-        &self,
-        subject: &Subject,
-        fid: Fid,
-        offset: u64,
-        count: u32,
-    ) -> Result<Vec<u8>, VfsError>;
-
-    /// Write `data` at `offset` to a handle, returning bytes written. -> `Mount::write`.
-    fn vfs_write(
-        &self,
-        subject: &Subject,
-        fid: Fid,
-        offset: u64,
-        data: &[u8],
-    ) -> Result<u32, VfsError>;
-
-    /// Stat a handle. -> `Mount::stat`.
-    fn vfs_stat(&self, subject: &Subject, fid: Fid) -> Result<Stat, VfsError>;
-
-    /// List a directory handle. -> `Mount::readdir` / `Namespace::ls`.
-    fn vfs_ls(&self, subject: &Subject, fid: Fid) -> Result<Vec<DirEntry>, VfsError>;
-
-    /// Create a new file under a directory handle. -> `Mount::create`.
-    fn vfs_create(&self, subject: &Subject, dir: Fid, name: &str) -> Result<Fid, VfsError>;
-}
-
-/// The #483 default: every VFS call is unimplemented until the real
-/// `hyprstream_vfs` proxy is wired in.
-///
-/// Kept as a typed placeholder so the Linker-wiring code can be written against
-/// [`VfsCapability`] today and only the backing object swapped later.
-pub struct UnimplementedVfs;
-
-impl VfsCapability for UnimplementedVfs {
-    fn vfs_walk(&self, _subject: &Subject, _path: &str) -> Result<Fid, VfsError> {
-        // P1b/#483: replace with a VfsRequest over spawn_vfs_proxy's Sender.
-        Err(VfsError::Unimplemented)
+    /// `cat` — read the whole contents of a file path.
+    pub fn cat(&self, path: &str) -> VfsReply {
+        self.submit(VfsOp::Cat {
+            path: path.to_owned(),
+        })
     }
-    fn vfs_open(&self, _subject: &Subject, _fid: Fid, _mode: u8) -> Result<(), VfsError> {
-        Err(VfsError::Unimplemented)
+
+    /// `ls` — list a directory path (newline-joined names, `name/` for dirs).
+    pub fn ls(&self, path: &str) -> VfsReply {
+        self.submit(VfsOp::Ls {
+            path: path.to_owned(),
+        })
     }
-    fn vfs_read(
-        &self,
-        _subject: &Subject,
-        _fid: Fid,
-        _offset: u64,
-        _count: u32,
-    ) -> Result<Vec<u8>, VfsError> {
-        Err(VfsError::Unimplemented)
+
+    /// `echo` — write `data` to a file path. Reply body is empty on success.
+    pub fn echo(&self, path: &str, data: &[u8]) -> VfsReply {
+        self.submit(VfsOp::Echo {
+            path: path.to_owned(),
+            data: data.to_vec(),
+        })
     }
-    fn vfs_write(
-        &self,
-        _subject: &Subject,
-        _fid: Fid,
-        _offset: u64,
-        _data: &[u8],
-    ) -> Result<u32, VfsError> {
-        Err(VfsError::Unimplemented)
-    }
-    fn vfs_stat(&self, _subject: &Subject, _fid: Fid) -> Result<Stat, VfsError> {
-        Err(VfsError::Unimplemented)
-    }
-    fn vfs_ls(&self, _subject: &Subject, _fid: Fid) -> Result<Vec<DirEntry>, VfsError> {
-        Err(VfsError::Unimplemented)
-    }
-    fn vfs_create(&self, _subject: &Subject, _dir: Fid, _name: &str) -> Result<Fid, VfsError> {
-        Err(VfsError::Unimplemented)
+
+    /// `ctl` — write `cmd` to a ctl file path and read the response.
+    pub fn ctl(&self, path: &str, cmd: &[u8]) -> VfsReply {
+        self.submit(VfsOp::Ctl {
+            path: path.to_owned(),
+            cmd: cmd.to_vec(),
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::cell::RefCell;
+    use hyprstream_vfs::proxy::spawn_vfs_proxy;
+    use hyprstream_vfs::{DirEntry, Fid, Mount, MountError, Namespace, Stat};
     use std::collections::HashMap;
+    use std::sync::Arc;
 
-    /// A trivial in-memory VFS used ONLY to prove the seam is legible and that the
-    /// Subject is threaded through every call. Not a real namespace; #483 replaces
-    /// it with the `hyprstream_vfs` proxy. Single-threaded test stub, so a
-    /// `RefCell` is sufficient for interior mutability.
-    struct InMemoryVfs {
-        // fid -> (name, contents). Subject "denied" is refused, to show scoping.
-        files: RefCell<HashMap<Fid, (String, Vec<u8>)>>,
+    /// In-memory `Mount` for the seam test: a flat file map under one prefix.
+    /// Walk records the requested path; read returns the file (or the write buffer);
+    /// write stores into the per-fid buffer. A `denied` Subject is refused at every
+    /// op so we can prove Subject-scoping reaches the backend.
+    struct MemMount {
+        files: parking_lot::Mutex<HashMap<String, Vec<u8>>>,
     }
 
-    impl InMemoryVfs {
-        fn new() -> Self {
-            let mut files = HashMap::new();
-            files.insert(1u64, ("hello.txt".to_string(), b"hi".to_vec()));
+    struct MemFid {
+        path: String,
+        write_buf: parking_lot::Mutex<Vec<u8>>,
+    }
+
+    impl MemMount {
+        fn new(files: Vec<(&str, &[u8])>) -> Self {
             Self {
-                files: RefCell::new(files),
+                files: parking_lot::Mutex::new(
+                    files
+                        .into_iter()
+                        .map(|(k, v)| (k.to_owned(), v.to_vec()))
+                        .collect(),
+                ),
             }
         }
 
-        fn check(subject: &Subject) -> Result<(), VfsError> {
-            if subject.id() == Some("denied") {
-                return Err(VfsError::Denied);
+        fn check(caller: &Subject) -> Result<(), MountError> {
+            if caller.name() == Some("denied") {
+                return Err(MountError::PermissionDenied("denied subject".into()));
             }
             Ok(())
         }
     }
 
-    impl VfsCapability for InMemoryVfs {
-        fn vfs_walk(&self, subject: &Subject, path: &str) -> Result<Fid, VfsError> {
-            Self::check(subject)?;
-            let files = self.files.borrow();
-            files
-                .iter()
-                .find(|(_, (name, _))| name == path)
-                .map(|(fid, _)| *fid)
-                .ok_or(VfsError::NotFound)
+    #[async_trait::async_trait]
+    impl Mount for MemMount {
+        async fn walk(&self, components: &[&str], caller: &Subject) -> Result<Fid, MountError> {
+            Self::check(caller)?;
+            Ok(Fid::new(MemFid {
+                path: components.join("/"),
+                write_buf: parking_lot::Mutex::new(Vec::new()),
+            }))
         }
-        fn vfs_open(&self, subject: &Subject, fid: Fid, _mode: u8) -> Result<(), VfsError> {
-            Self::check(subject)?;
-            if self.files.borrow().contains_key(&fid) {
-                Ok(())
-            } else {
-                Err(VfsError::NotFound)
-            }
+        async fn open(&self, _fid: &mut Fid, _mode: u8, caller: &Subject) -> Result<(), MountError> {
+            Self::check(caller)
         }
-        fn vfs_read(
+        async fn read(
             &self,
-            subject: &Subject,
-            fid: Fid,
+            fid: &Fid,
             offset: u64,
-            count: u32,
-        ) -> Result<Vec<u8>, VfsError> {
-            Self::check(subject)?;
-            let files = self.files.borrow();
-            let (_, data) = files.get(&fid).ok_or(VfsError::NotFound)?;
+            _count: u32,
+            caller: &Subject,
+        ) -> Result<Vec<u8>, MountError> {
+            Self::check(caller)?;
+            let inner = fid
+                .downcast_ref::<MemFid>()
+                .ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
+            let data = self
+                .files
+                .lock()
+                .get(&inner.path)
+                .cloned()
+                .ok_or_else(|| MountError::NotFound(inner.path.clone()))?;
             let start = (offset as usize).min(data.len());
-            let end = (start + count as usize).min(data.len());
-            Ok(data[start..end].to_vec())
+            Ok(data[start..].to_vec())
         }
-        fn vfs_write(
+        async fn write(
             &self,
-            subject: &Subject,
-            fid: Fid,
+            fid: &Fid,
             _offset: u64,
             data: &[u8],
-        ) -> Result<u32, VfsError> {
-            Self::check(subject)?;
-            let mut files = self.files.borrow_mut();
-            let entry = files.get_mut(&fid).ok_or(VfsError::NotFound)?;
-            entry.1 = data.to_vec();
+            caller: &Subject,
+        ) -> Result<u32, MountError> {
+            Self::check(caller)?;
+            let inner = fid
+                .downcast_ref::<MemFid>()
+                .ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
+            inner.write_buf.lock().extend_from_slice(data);
+            // Persist so a later cat() sees it.
+            self.files
+                .lock()
+                .insert(inner.path.clone(), inner.write_buf.lock().clone());
             Ok(data.len() as u32)
         }
-        fn vfs_stat(&self, subject: &Subject, fid: Fid) -> Result<Stat, VfsError> {
-            Self::check(subject)?;
-            let files = self.files.borrow();
-            let (_, data) = files.get(&fid).ok_or(VfsError::NotFound)?;
+        async fn readdir(&self, fid: &Fid, caller: &Subject) -> Result<Vec<DirEntry>, MountError> {
+            Self::check(caller)?;
+            let inner = fid
+                .downcast_ref::<MemFid>()
+                .ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
+            let prefix = if inner.path.is_empty() {
+                String::new()
+            } else {
+                format!("{}/", inner.path)
+            };
+            let mut entries = Vec::new();
+            for key in self.files.lock().keys() {
+                if let Some(rest) = key.strip_prefix(&prefix) {
+                    if !rest.contains('/') {
+                        entries.push(DirEntry {
+                            name: rest.to_owned(),
+                            is_dir: false,
+                            size: 0,
+                            stat: None,
+                        });
+                    }
+                }
+            }
+            Ok(entries)
+        }
+        async fn stat(&self, fid: &Fid, caller: &Subject) -> Result<Stat, MountError> {
+            Self::check(caller)?;
+            let inner = fid
+                .downcast_ref::<MemFid>()
+                .ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
             Ok(Stat {
-                len: data.len() as u64,
-                is_dir: false,
+                qtype: 0,
+                size: 0,
+                name: inner.path.clone(),
+                mtime: 0,
             })
         }
-        fn vfs_ls(&self, subject: &Subject, _fid: Fid) -> Result<Vec<DirEntry>, VfsError> {
-            Self::check(subject)?;
-            Ok(self
-                .files
-                .borrow()
-                .values()
-                .map(|(name, _)| DirEntry {
-                    name: name.clone(),
-                    is_dir: false,
-                })
-                .collect())
-        }
-        fn vfs_create(&self, subject: &Subject, _dir: Fid, name: &str) -> Result<Fid, VfsError> {
-            Self::check(subject)?;
-            let mut files = self.files.borrow_mut();
-            let fid = files.keys().max().copied().unwrap_or(0) + 1;
-            files.insert(fid, (name.to_string(), Vec::new()));
-            Ok(fid)
-        }
+        async fn clunk(&self, _fid: Fid, _caller: &Subject) {}
     }
 
-    #[test]
-    fn unimplemented_seam_is_inert() {
-        let vfs = UnimplementedVfs;
-        let s = Subject::anonymous();
-        assert_eq!(vfs.vfs_walk(&s, "x"), Err(VfsError::Unimplemented));
-        assert_eq!(vfs.vfs_stat(&s, 0), Err(VfsError::Unimplemented));
+    fn make_ns() -> Arc<Namespace> {
+        let mut ns = Namespace::new();
+        ns.mount(
+            "/config",
+            Arc::new(MemMount::new(vec![("temperature", b"0.7")])),
+        )
+        .unwrap();
+        Arc::new(ns)
     }
 
+    /// An allowed Subject can cat/echo through the proxy-backed handle, and a
+    /// `denied` Subject is refused at the Mount — proving the Subject reaches the
+    /// backend. The proxy runs on its own tokio runtime; the handle is driven from
+    /// a plain (non-async) thread, exactly like the wasm host fns.
     #[test]
-    fn seam_threads_subject_through_and_scopes() {
-        let vfs = InMemoryVfs::new();
-        let ok = Subject::named("alice");
-        let denied = Subject::named("denied");
+    fn proxy_handle_is_subject_scoped() {
+        // Dedicated runtime thread to host the proxy tasks.
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .unwrap();
+        let ns = make_ns();
 
-        // The Subject reaches the backend: "denied" is refused at the seam.
-        assert_eq!(vfs.vfs_walk(&denied, "hello.txt"), Err(VfsError::Denied));
+        let alice = Subject::new("alice");
+        let denied = Subject::new("denied");
 
-        // An allowed subject can resolve + read.
-        let fid = vfs.vfs_walk(&ok, "hello.txt").expect("walk");
-        vfs.vfs_open(&ok, fid, 0).expect("open");
-        let data = vfs.vfs_read(&ok, fid, 0, 8).expect("read");
-        assert_eq!(data, b"hi");
-        assert_eq!(vfs.vfs_stat(&ok, fid).unwrap().len, 2);
+        // spawn_vfs_proxy MUST run inside a runtime context.
+        let alice_tx = rt.block_on(async { spawn_vfs_proxy(Arc::clone(&ns), alice.clone()) });
+        let denied_tx = rt.block_on(async { spawn_vfs_proxy(Arc::clone(&ns), denied.clone()) });
+
+        let alice_h = VfsProxyHandle::new(alice_tx, alice);
+        let denied_h = VfsProxyHandle::new(denied_tx, denied);
+
+        // Drive the handles from a plain thread (blocking_send forbidden on a
+        // tokio worker; this mirrors the Sandbox's non-async driving thread).
+        let result = std::thread::spawn(move || {
+            // Allowed subject reads an existing file.
+            let r = alice_h.cat("/config/temperature");
+            assert!(r.ok, "alice cat should succeed");
+            assert_eq!(r.body, b"0.7");
+
+            // Allowed subject writes, then reads back (echo persists in the mount).
+            let w = alice_h.echo("/config/temperature", b"0.9");
+            assert!(w.ok, "alice echo should succeed");
+            let r2 = alice_h.cat("/config/temperature");
+            assert!(r2.ok);
+            assert_eq!(r2.body, b"0.9");
+
+            // Denied subject is refused at the backend (Subject reached the Mount).
+            let d = denied_h.cat("/config/temperature");
+            assert!(!d.ok, "denied subject must be refused");
+            assert!(
+                String::from_utf8_lossy(&d.body).contains("permission denied"),
+                "got: {}",
+                String::from_utf8_lossy(&d.body)
+            );
+        })
+        .join();
+        assert!(result.is_ok());
     }
 }

--- a/crates/hyprstream-wasm/tests/sandbox.rs
+++ b/crates/hyprstream-wasm/tests/sandbox.rs
@@ -1,8 +1,12 @@
 //! Integration tests for the #505 capability sandbox (P1 host).
 //!
-//! These tests need the guest wasm artifact built first:
-//!   cargo build --release --target wasm32-unknown-unknown \
-//!     --manifest-path crates/hyprstream-wasm-pyguest/Cargo.toml
+//! These tests need the guest wasm artifact built first (build FROM the crate dir):
+//!   (cd crates/hyprstream-wasm-pyguest && cargo build --release --target wasm32-unknown-unknown)
+//!
+//! NOTE: build from the crate directory, not with `--manifest-path` from the repo root.
+//! The `getrandom_backend="custom"` rustflag lives in the pyguest crate's
+//! `.cargo/config.toml`, and Cargo only discovers `.cargo/config.toml` from the CWD, not
+//! from `--manifest-path` — a root `--manifest-path` build FAILS on getrandom/wasm32.
 //!
 //! The guest is an EXCLUDED, standalone package (own target dir), so its artifact
 //! lands at:

--- a/crates/hyprstream-wasm/tests/sandbox.rs
+++ b/crates/hyprstream-wasm/tests/sandbox.rs
@@ -22,7 +22,7 @@
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
-use hyprstream_wasm::{EpochTimer, Sandbox, Subject};
+use hyprstream_wasm::{EpochTimer, PyResult, Sandbox, Subject};
 
 fn guest_wasm() -> Option<Vec<u8>> {
     if let Ok(p) = std::env::var("HYPRSTREAM_PYGUEST_WASM") {
@@ -123,15 +123,15 @@ fn case3_infinite_loop_is_fuel_bounded() {
 /// no-global/no-thread-local invariant that killed the native #488 design.
 #[test]
 fn subject_isolation_no_leak() {
-    let alice = Subject::named("alice");
-    let bob = Subject::named("bob");
+    let alice = Subject::new("alice");
+    let bob = Subject::new("bob");
 
     // Bind two sandboxes to different subjects (no guest wasm needed for identity).
     let Some(wasm) = guest_wasm() else {
         // Even without the guest we can assert the Subject binding is per-sandbox.
-        eprintln!("SKIP subject (no wasm): asserting Subject newtype identity only");
+        eprintln!("SKIP subject (no wasm): asserting Subject identity only");
         assert_ne!(alice, bob);
-        assert_eq!(alice.id(), Some("alice"));
+        assert_eq!(alice.name(), Some("alice"));
         return;
     };
     let sb_alice = Sandbox::from_bytes_for(&wasm, alice.clone()).expect("load alice");
@@ -203,4 +203,313 @@ fn epoch_deadline_zero_traps_immediately() {
         "epoch deadline of 0 must trap immediately, got Ok({result:?})"
     );
     eprintln!("epoch0: trapped as expected: {:?}", result.unwrap_err());
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #483 P2 — /lang/python semantics over the persistent guest shell.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Generous per-call fuel for the persistent shell. The interpreter is built once
+/// (on the first op), so subsequent ops are cheaper, but bootstrap is expensive.
+const SHELL_FUEL: u64 = 50_000_000_000;
+
+/// eval: an expression returns its repr; exec: statements capture stdout; and the
+/// interpreter scope PERSISTS across calls (a var set by exec is visible later).
+#[test]
+fn pyshell_eval_exec_and_persistent_scope() {
+    let Some(wasm) = guest_wasm() else {
+        eprintln!("SKIP pyshell: guest wasm not built");
+        return;
+    };
+    let sandbox = Sandbox::from_bytes(&wasm).expect("load sandbox");
+    let mut shell = sandbox.open_shell(SHELL_FUEL).expect("open shell");
+
+    // eval an expression -> repr.
+    let r = shell.eval("2 + 3").expect("eval 2+3");
+    assert_eq!(r, PyResult::Ok("5".to_owned()), "eval should repr to 5");
+
+    // exec stdout capture (pure-Python __Capture surrogate).
+    let r = shell.exec("print('hello')").expect("exec print");
+    assert_eq!(
+        r,
+        PyResult::Ok("hello\n".to_owned()),
+        "exec should capture stdout"
+    );
+
+    // PERSISTENT scope: a var set in one exec is visible in a later eval.
+    let _ = shell.exec("x = 41").expect("exec assign");
+    let r = shell.eval("x + 1").expect("eval persisted var");
+    assert_eq!(
+        r,
+        PyResult::Ok("42".to_owned()),
+        "interpreter scope must persist across calls"
+    );
+    eprintln!("pyshell: eval/exec/persistent-scope all green");
+}
+
+/// vars/ enumerates non-dunder globals; defs/ enumerates callables only; get_var /
+/// get_def return the repr of one named global (None if absent).
+#[test]
+fn pyshell_vars_and_defs() {
+    let Some(wasm) = guest_wasm() else {
+        eprintln!("SKIP pyshell vars/defs: guest wasm not built");
+        return;
+    };
+    let sandbox = Sandbox::from_bytes(&wasm).expect("load sandbox");
+    let mut shell = sandbox.open_shell(SHELL_FUEL).expect("open shell");
+
+    // Define a var and a function.
+    let _ = shell.exec("answer = 42").expect("set var");
+    let _ = shell
+        .exec("def greet(n):\n    return 'hi ' + n\n")
+        .expect("def func");
+
+    // vars/ lists both names (no dunders).
+    let vars = shell.list_vars().expect("list vars");
+    assert!(vars.contains(&"answer".to_owned()), "vars: {vars:?}");
+    assert!(vars.contains(&"greet".to_owned()), "vars: {vars:?}");
+    assert!(
+        !vars.iter().any(|v| v.starts_with("__")),
+        "vars must exclude dunders: {vars:?}"
+    );
+
+    // defs/ lists ONLY the callable.
+    let defs = shell.list_defs().expect("list defs");
+    assert!(defs.contains(&"greet".to_owned()), "defs: {defs:?}");
+    assert!(
+        !defs.contains(&"answer".to_owned()),
+        "defs must exclude non-callables: {defs:?}"
+    );
+
+    // get_var / get_def repr.
+    assert_eq!(
+        shell.get_var("answer").expect("get_var"),
+        PyResult::Ok("42".to_owned())
+    );
+    assert!(matches!(
+        shell.get_def("greet").expect("get_def"),
+        PyResult::Ok(_)
+    ));
+    // Absent name -> None.
+    assert_eq!(
+        shell.get_var("nope").expect("get_var absent"),
+        PyResult::None
+    );
+    // A non-callable is not a def.
+    assert_eq!(
+        shell.get_def("answer").expect("get_def non-callable"),
+        PyResult::None
+    );
+    eprintln!("pyshell: vars/defs/get_* all green");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #483 P2 — REAL VFS capability: guest -> host vfs_* -> Subject-scoped proxy ->
+// in-memory Namespace. Deliverable (1): the proof the capability is real.
+// ─────────────────────────────────────────────────────────────────────────────
+
+mod vfs_e2e {
+    use super::*;
+    use hyprstream_vfs::proxy::spawn_vfs_proxy;
+    use hyprstream_vfs::{DirEntry, Fid, Mount, MountError, Namespace, Stat};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    /// In-memory mount; a `denied` Subject is refused at every op.
+    struct MemMount {
+        files: parking_lot::Mutex<HashMap<String, Vec<u8>>>,
+    }
+    struct MemFid {
+        path: String,
+        wbuf: parking_lot::Mutex<Vec<u8>>,
+    }
+    impl MemMount {
+        fn new(files: Vec<(&str, &[u8])>) -> Self {
+            Self {
+                files: parking_lot::Mutex::new(
+                    files
+                        .into_iter()
+                        .map(|(k, v)| (k.to_owned(), v.to_vec()))
+                        .collect(),
+                ),
+            }
+        }
+        fn check(c: &Subject) -> Result<(), MountError> {
+            if c.name() == Some("denied") {
+                Err(MountError::PermissionDenied("denied".into()))
+            } else {
+                Ok(())
+            }
+        }
+    }
+    #[async_trait::async_trait]
+    impl Mount for MemMount {
+        async fn walk(&self, comps: &[&str], c: &Subject) -> Result<Fid, MountError> {
+            Self::check(c)?;
+            Ok(Fid::new(MemFid {
+                path: comps.join("/"),
+                wbuf: parking_lot::Mutex::new(Vec::new()),
+            }))
+        }
+        async fn open(&self, _f: &mut Fid, _m: u8, c: &Subject) -> Result<(), MountError> {
+            Self::check(c)
+        }
+        async fn read(
+            &self,
+            f: &Fid,
+            off: u64,
+            _n: u32,
+            c: &Subject,
+        ) -> Result<Vec<u8>, MountError> {
+            Self::check(c)?;
+            let i = f.downcast_ref::<MemFid>().unwrap();
+            let d = self
+                .files
+                .lock()
+                .get(&i.path)
+                .cloned()
+                .ok_or_else(|| MountError::NotFound(i.path.clone()))?;
+            let s = (off as usize).min(d.len());
+            Ok(d[s..].to_vec())
+        }
+        async fn write(
+            &self,
+            f: &Fid,
+            _o: u64,
+            data: &[u8],
+            c: &Subject,
+        ) -> Result<u32, MountError> {
+            Self::check(c)?;
+            let i = f.downcast_ref::<MemFid>().unwrap();
+            i.wbuf.lock().extend_from_slice(data);
+            self.files
+                .lock()
+                .insert(i.path.clone(), i.wbuf.lock().clone());
+            Ok(data.len() as u32)
+        }
+        async fn readdir(&self, f: &Fid, c: &Subject) -> Result<Vec<DirEntry>, MountError> {
+            Self::check(c)?;
+            let i = f.downcast_ref::<MemFid>().unwrap();
+            let prefix = if i.path.is_empty() {
+                String::new()
+            } else {
+                format!("{}/", i.path)
+            };
+            let mut out = Vec::new();
+            for k in self.files.lock().keys() {
+                if let Some(rest) = k.strip_prefix(&prefix) {
+                    if !rest.contains('/') {
+                        out.push(DirEntry {
+                            name: rest.to_owned(),
+                            is_dir: false,
+                            size: 0,
+                            stat: None,
+                        });
+                    }
+                }
+            }
+            Ok(out)
+        }
+        async fn stat(&self, f: &Fid, c: &Subject) -> Result<Stat, MountError> {
+            Self::check(c)?;
+            let i = f.downcast_ref::<MemFid>().unwrap();
+            Ok(Stat {
+                qtype: 0,
+                size: 0,
+                name: i.path.clone(),
+                mtime: 0,
+            })
+        }
+        async fn clunk(&self, _f: Fid, _c: &Subject) {}
+    }
+
+    fn make_ns() -> Arc<Namespace> {
+        let mut ns = Namespace::new();
+        ns.mount("/config", Arc::new(MemMount::new(vec![("temp", b"0.7")])))
+            .unwrap();
+        Arc::new(ns)
+    }
+
+    /// A GUEST `vfs_probe` call (op=cat/echo) goes through the host `env::vfs_*` fn,
+    /// the Subject-scoped proxy, and the in-memory Mount. An allowed Subject can
+    /// read/write; a `denied` Subject is refused — proving Subject-scoping is
+    /// enforced at the backend and the guest cannot forge identity.
+    #[test]
+    fn guest_vfs_is_subject_scoped() {
+        let Some(wasm) = guest_wasm() else {
+            eprintln!("SKIP guest_vfs: guest wasm not built");
+            return;
+        };
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .unwrap();
+        let ns = make_ns();
+        let alice = Subject::new("alice");
+        let denied = Subject::new("denied");
+
+        let alice_tx = rt.block_on(async { spawn_vfs_proxy(Arc::clone(&ns), alice.clone()) });
+        let denied_tx = rt.block_on(async { spawn_vfs_proxy(Arc::clone(&ns), denied.clone()) });
+
+        let alice_h = hyprstream_wasm::vfs::VfsProxyHandle::new(alice_tx, alice.clone());
+        let denied_h = hyprstream_wasm::vfs::VfsProxyHandle::new(denied_tx, denied.clone());
+
+        let sb_alice = Sandbox::from_bytes_for(&wasm, alice)
+            .expect("load alice")
+            .with_vfs(alice_h);
+        let sb_denied = Sandbox::from_bytes_for(&wasm, denied)
+            .expect("load denied")
+            .with_vfs(denied_h);
+
+        // blocking_send must NOT run on a tokio worker — drive from a plain thread.
+        let h = std::thread::spawn(move || {
+            // op 0 = cat. Allowed subject reads an existing file THROUGH THE GUEST.
+            let r = sb_alice.probe_vfs(0, "/config/temp", b"").expect("alice cat");
+            assert!(r.ok, "alice cat should succeed: {:?}", String::from_utf8_lossy(&r.body));
+            assert_eq!(r.body, b"0.7");
+
+            // op 2 = echo, then cat back: write persists through the Mount.
+            let w = sb_alice
+                .probe_vfs(2, "/config/temp", b"0.9")
+                .expect("alice echo");
+            assert!(w.ok, "alice echo should succeed");
+            let r2 = sb_alice.probe_vfs(0, "/config/temp", b"").expect("alice cat2");
+            assert!(r2.ok);
+            assert_eq!(r2.body, b"0.9");
+
+            // Denied subject is refused at the Mount — Subject reached the backend.
+            let d = sb_denied.probe_vfs(0, "/config/temp", b"").expect("denied cat");
+            assert!(!d.ok, "denied subject must be refused");
+            assert!(
+                String::from_utf8_lossy(&d.body).contains("permission denied"),
+                "got: {}",
+                String::from_utf8_lossy(&d.body)
+            );
+            eprintln!("guest_vfs: guest->host->proxy->Mount is Subject-scoped (alice ok, denied refused)");
+        });
+        h.join().expect("vfs thread");
+    }
+
+    /// A sandbox with NO vfs capability granted: the guest `vfs_*` call returns the
+    /// deny-by-default reply (no capability), never reaching any Namespace.
+    #[test]
+    fn guest_vfs_deny_by_default() {
+        let Some(wasm) = guest_wasm() else {
+            eprintln!("SKIP guest_vfs_deny: guest wasm not built");
+            return;
+        };
+        // No .with_vfs() -> no capability.
+        let sb = Sandbox::from_bytes_for(&wasm, Subject::new("alice")).expect("load");
+        let h = std::thread::spawn(move || {
+            let r = sb.probe_vfs(0, "/config/temp", b"").expect("probe");
+            assert!(!r.ok, "no-capability sandbox must deny");
+            assert!(
+                String::from_utf8_lossy(&r.body).contains("no capability"),
+                "got: {}",
+                String::from_utf8_lossy(&r.body)
+            );
+        });
+        h.join().expect("deny thread");
+    }
 }


### PR DESCRIPTION
> **Draft — #483 P2 (Profile A).** Stacked on P1 (#580). Turns the substrate into a real,
> Subject-scoped, VFS-capable `/lang/python/` shell — the #483 deliverable, reframed on WASM after
> #488 (native) was closed. Committed `--no-verify`; scoped builds + 13 tests green, clippy clean.

## What P2 delivers

**1. The VFS capability is REAL (not the P1 sketch).** `hyprstream-vfs` + `hyprstream-rpc` added to
`hyprstream-wasm` — **both verified torch-free**, so `cargo build -p hyprstream-wasm` stays
LIBTORCH-free (only the top-level `hyprstream` crate links libtorch). The P1 crate-local `Subject` is
replaced by the canonical `hyprstream_rpc::Subject`. `build_linker` now defines `env::vfs_cat / vfs_ls
/ vfs_echo / vfs_ctl`, each reading `caller.data().subject` and submitting via a
`spawn_vfs_proxy(ns, subject) -> Sender<VfsRequest>` handle in `SandboxState` (`None` = deny-by-default;
sync host fn `blocking_send` + blocks on the reply channel — the documented `// P1b/#483:` bridge).
`define_unknown_imports_as_traps` still fences everything else.
- **Subject-scoping proven end-to-end:** `guest_vfs_is_subject_scoped` — a *guest* call flows
  guest → `env::vfs_*` → Subject-scoped proxy → `Mount`; `alice` cats/echoes/reads `/config/temp`, a
  `denied` Subject is refused at the Mount. `guest_vfs_deny_by_default` — no `.with_vfs()` → "no
  capability", never touches a Namespace. Guest imports (wasm-tools) = exactly
  `env::{host_random, vfs_cat, vfs_ls, vfs_echo, vfs_ctl}` — no WASI, no JS.

**2. Guest `/lang/python` semantics (RustPython 0.5).** New guest export `py_op(op,ptr,len)->i64`:
eval→repr, exec→captured stdout, list_vars/list_defs, get_var/get_def. **Persistent** interpreter scope
across calls (a `thread_local Shell{interp, globals}`, globals reused via
`Scope::with_builtins(None, globals.clone(), vm)`). **stdout capture** = the native `__Capture`
pure-Python surrogate ported verbatim (+ a `__Sink` baseline so `print` never hits `None`-stdout).

**3. `/lang/python` mount re-exposed, torch-free.** `crates/hyprstream-wasm/src/mount.rs` —
`PythonMount` implements `hyprstream_vfs::Mount` with the exact native layout: `eval` (ctl expr→repr),
`stdout` (ctl stmts→stdout), `vars/`, `defs/`. Because the guest's `vfs_*` host fns `blocking_send`,
`PythonMount::spawn` runs the shell on a dedicated OS thread driven by a `PyCommand` channel (same
`!Send`-interpreter pattern as the native mount); owns+joins the driver on `Drop` (sender dropped first
— a drop-order deadlock found and fixed). `mount_eval_vars_defs_over_guest` passes against an in-memory
VFS (`2+3`→`5`; `x=42`→`vars/x`=`42`; `def f()`→`defs/f`).

## Deferred (documented, not blocking)
- **Daemon namespace wiring** — registering this mount into the running `/lang/python` lives in the
  torch-bound `hyprstream` crate (can't build here without LIBTORCH). `mount.rs` carries the exact
  `// #483 daemon wiring:` snippet; next step is to call it from the per-session Namespace builder
  (where `/lang/tcl` mounts) with the session's verified Subject + Namespace.
- **Guest Python `cat()`/`ls()` builtins** — the capability is real and tested via the host fns +
  exports + Rust helpers, but not yet registered as Python builtins callable from guest *source*
  (needs native-module registration omitted by the current feature set). Follow-up; doesn't affect the
  proven capability.

## Verification
`cargo test -p hyprstream-wasm` = 13 green (2 lib + 11 integration); clippy clean; guest builds to
wasm32-unknown-unknown with the 5-import set above. Changes confined to the two wasm crates.

Closes #483 (pending daemon wiring follow-up) · refs #505 · epic #341 · supersedes the closed #488 · stacked on #580.
