### PR TITLE
feat(security) S4: PDP — TE evaluator + AVC + compiled-policy on S1 Lattice (#570)

### DIFF
--- a/crates/hyprstream/src/lib.rs
+++ b/crates/hyprstream/src/lib.rs
@@ -44,6 +44,7 @@ pub mod error;
 pub mod events;
 pub mod git;
 pub mod inference;
+pub mod mac;
 pub mod runtime;
 pub mod schema;
 pub mod server;

--- a/crates/hyprstream/src/mac/avc.rs
+++ b/crates/hyprstream/src/mac/avc.rs
@@ -1,0 +1,364 @@
+//! Access Vector Cache — the fast local decision cache the PEP consults per op (S4 / #570).
+//!
+//! SELinux-style AVC: the PEP (S2) asks the AVC for a decision on every op; on a hit it
+//! returns a cached [`Decision`] with **no Casbin, no signature verify, no lattice walk** —
+//! just a hash lookup. On a miss it calls the [`TeEvaluator`] (the PDP) once, caches the
+//! result, and returns it. Fail-closed: any ambiguity (wrong generation, poisoned lock,
+//! evaluator absent) → DENY.
+//!
+//! ## The hot path (what must be cheap)
+//!
+//! ```text
+//! PEP.check(op) → AVC.decide(key) ─hit→  return cached Decision        (sub-µs, lock-free read)
+//!                                └miss→  evaluator.evaluate(...) ; insert ; return
+//! ```
+//!
+//! The cache KEY is `(generation, subject_type, clearance, object_type, label, action)` —
+//! all interned ids, so the key is `Copy` and hashes cheaply. We deliberately key on the
+//! *resolved interned context*, not on raw strings/paths: string matching (Casbin's job) is
+//! done once at compile time, never per op.
+//!
+//! ## Token = distributed AVC entry (design §2, §6)
+//!
+//! The OAuth access token IS an AVC entry, minted by the authority and carried by the
+//! subject. It encodes `{label_ceiling, op_set, ttl}` (design §11). The mapping:
+//!
+//! ```text
+//! access token T  ──(verified ONCE at bind/refresh by the PEP)──►  AvcSeed
+//!   T.cnf / sub      → subject_type + clearance (subject ctx, design §2)
+//!   T.label_ceiling  → the max object label the token authorizes (per-op floor still applies)
+//!   T.op_set         → the actions the token authorizes
+//!   T.exp            → AvcEntry.valid_until  (ttl-bounded cache lifetime)
+//! ```
+//!
+//! Verifying the token signature is a **bind/refresh-time** event (design §7: mint per-task,
+//! AVC caches for ttl), NOT per op. Once seeded, per-op decisions are local lookups. The
+//! token's `{label_ceiling, op_set}` are an *additional* deny-only gate the PEP applies via
+//! [`TokenScope`]; the mandatory lattice floor + TE matrix are still evaluated independently
+//! by the PDP (a token can only narrow — design §10).
+
+use crate::mac::te::{Action, Decision, ObjectCtx, ObjectType, SubjectCtx, SubjectType, TeEvaluator};
+use crate::mac::lattice::SecurityLabel;
+use dashmap::DashMap;
+use std::sync::Arc;
+use std::time::Instant;
+
+/// Cache key: the fully-resolved, interned per-op context. All `Copy` ids → cheap hash.
+/// Tagged with `generation` so a policy reload (new generation) misses every stale entry
+/// without an explicit flush walk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AvcKey {
+    pub generation: u64,
+    pub subject_type: SubjectType,
+    pub clearance: SecurityLabel,
+    pub object_type: ObjectType,
+    pub label: SecurityLabel,
+    pub action: Action,
+}
+
+impl AvcKey {
+    /// Assemble a key from the resolved contexts the PEP already has in hand.
+    #[inline]
+    pub fn new(generation: u64, subject: SubjectCtx, object: ObjectCtx, action: Action) -> Self {
+        Self {
+            generation,
+            subject_type: subject.subject_type,
+            clearance: subject.clearance,
+            object_type: object.object_type,
+            label: object.label,
+            action,
+        }
+    }
+}
+
+/// A cached decision. `valid_until` bounds the entry to the token/policy ttl (design §7);
+/// `None` means "valid until the generation rolls" (policy-derived decisions with no token
+/// ttl). Fail-closed: an expired entry is treated as a miss, not a stale permit.
+#[derive(Debug, Clone, Copy)]
+struct AvcEntry {
+    decision: Decision,
+    valid_until: Option<Instant>,
+}
+
+impl AvcEntry {
+    #[inline]
+    fn is_live(&self, now: Instant) -> bool {
+        match self.valid_until {
+            Some(deadline) => now < deadline,
+            None => true,
+        }
+    }
+}
+
+/// The token-derived gate the PEP applies on top of the PDP decision (design §10 / §6).
+/// Deny-only: the token can only *narrow*. The PDP (lattice floor + TE matrix) is evaluated
+/// independently; this just enforces what the access token authorized.
+#[derive(Debug, Clone)]
+pub struct TokenScope {
+    /// Max object label the token authorizes (`object.label ⊑ label_ceiling`). The PEP
+    /// supplies the lattice to compare; here we keep the ceiling and the authorized ops.
+    pub label_ceiling: SecurityLabel,
+    /// The actions the token authorizes (`op ∈ op_set`).
+    pub op_set: Arc<[Action]>,
+    /// When the token (hence this scope) expires — the cache ttl bound.
+    pub valid_until: Instant,
+}
+
+impl TokenScope {
+    /// Does this token authorize `action`? Deny-only check.
+    #[inline]
+    pub fn authorizes_action(&self, action: Action) -> bool {
+        self.op_set.contains(&action)
+    }
+}
+
+/// The Access Vector Cache interface — **what the PEP (S2) calls per op**.
+///
+/// TOTAL + fail-closed. `decide` returns a [`Decision`] for every call and never panics.
+pub trait Avc: Send + Sync {
+    /// Per-op decision. Hit → cached; miss → evaluate-and-cache. Fail-closed.
+    fn decide(&self, subject: SubjectCtx, object: ObjectCtx, action: Action) -> Decision;
+
+    /// Per-op decision additionally gated by a token scope (the distributed-AVC-entry path).
+    /// The result is `Permit` only if the PDP permits AND the token authorizes the action.
+    /// The label-ceiling comparison requires the lattice and is done by the PDP-side floor;
+    /// this method applies the op-set + ttl gate. Default-deny.
+    fn decide_with_token(
+        &self,
+        subject: SubjectCtx,
+        object: ObjectCtx,
+        action: Action,
+        token: &TokenScope,
+    ) -> Decision;
+
+    /// Drop all cached decisions (e.g. on revocation broadcast). Generation rollover already
+    /// invalidates implicitly; this is for explicit revocation (design §6 refresh path).
+    fn flush(&self);
+}
+
+/// Concrete AVC over a [`TeEvaluator`] PDP and a concurrent map. Lock-free reads via
+/// `dashmap`; the only work on a hit is a hash + ttl compare.
+pub struct CachingAvc<E: TeEvaluator> {
+    evaluator: Arc<E>,
+    cache: DashMap<AvcKey, AvcEntry>,
+}
+
+impl<E: TeEvaluator> CachingAvc<E> {
+    /// Wrap a PDP evaluator. The AVC inherits the evaluator's generation for key tagging.
+    pub fn new(evaluator: Arc<E>) -> Self {
+        Self {
+            evaluator,
+            cache: DashMap::new(),
+        }
+    }
+
+    /// Number of live-or-stale cached entries (diagnostics).
+    pub fn len(&self) -> usize {
+        self.cache.len()
+    }
+
+    /// Whether the cache is empty.
+    pub fn is_empty(&self) -> bool {
+        self.cache.is_empty()
+    }
+
+    /// Core lookup-or-evaluate. `valid_until` bounds a freshly computed entry (token ttl).
+    #[inline]
+    fn decide_inner(
+        &self,
+        subject: SubjectCtx,
+        object: ObjectCtx,
+        action: Action,
+        valid_until: Option<Instant>,
+    ) -> Decision {
+        let generation = self.evaluator.generation();
+        let key = AvcKey::new(generation, subject, object, action);
+        let now = Instant::now();
+
+        // Fast path: live hit. `dashmap` read does not block other readers.
+        if let Some(entry) = self.cache.get(&key) {
+            if entry.is_live(now) {
+                return entry.decision;
+            }
+            // Stale/expired → fall through to recompute (treated as a miss, fail-closed).
+        }
+
+        // Miss / expired: evaluate ONCE via the PDP, then cache.
+        let decision = self.evaluator.evaluate(subject, object, action);
+        self.cache.insert(
+            key,
+            AvcEntry {
+                decision,
+                valid_until,
+            },
+        );
+        decision
+    }
+}
+
+impl<E: TeEvaluator> Avc for CachingAvc<E> {
+    #[inline]
+    fn decide(&self, subject: SubjectCtx, object: ObjectCtx, action: Action) -> Decision {
+        self.decide_inner(subject, object, action, None)
+    }
+
+    #[inline]
+    fn decide_with_token(
+        &self,
+        subject: SubjectCtx,
+        object: ObjectCtx,
+        action: Action,
+        token: &TokenScope,
+    ) -> Decision {
+        // Token gate (deny-only): expired token or op not in op_set → DENY without touching
+        // the PDP. (The label_ceiling ⊒ object.label check is the PDP-side lattice floor's
+        // job — the token's ceiling is enforced by seeding subject.clearance ⊓ ceiling at
+        // bind time; see module docs. We keep the ceiling on the scope for that seeding and
+        // for audit, and do not re-walk the lattice here.)
+        if Instant::now() >= token.valid_until {
+            return Decision::Deny;
+        }
+        if !token.authorizes_action(action) {
+            return Decision::Deny;
+        }
+        // PDP decision, cached with the token ttl as the entry lifetime.
+        let decision = self.decide_inner(subject, object, action, Some(token.valid_until));
+        // Conjunction: permit only if the PDP permitted. (Token already gated above.)
+        if decision.is_permit() {
+            Decision::Permit
+        } else {
+            decision
+        }
+    }
+
+    fn flush(&self) {
+        self.cache.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mac::lattice::{SecurityLabel, StubLinearLattice};
+    use crate::mac::te::{LatticeTeEvaluator, TeMatrix, TeRule};
+    use std::collections::HashSet;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::time::Duration;
+
+    fn rule(s: u32, o: u32, a: u32) -> TeRule {
+        TeRule {
+            subject_type: SubjectType(s),
+            object_type: ObjectType(o),
+            action: Action(a),
+        }
+    }
+    fn subj(t: u32, clr: u32) -> SubjectCtx {
+        SubjectCtx { subject_type: SubjectType(t), clearance: SecurityLabel(clr) }
+    }
+    fn obj(t: u32, lbl: u32) -> ObjectCtx {
+        ObjectCtx { object_type: ObjectType(t), label: SecurityLabel(lbl) }
+    }
+
+    fn avc() -> CachingAvc<LatticeTeEvaluator<StubLinearLattice>> {
+        let mut allow = HashSet::new();
+        allow.insert(rule(1, 1, 1));
+        let e = LatticeTeEvaluator::new(TeMatrix::from_allow(allow), StubLinearLattice::new(3), 1);
+        CachingAvc::new(Arc::new(e))
+    }
+
+    #[test]
+    fn hit_returns_cached_decision() {
+        let a = avc();
+        assert_eq!(a.decide(subj(1, 2), obj(1, 1), Action(1)), Decision::Permit);
+        assert_eq!(a.decide(subj(1, 2), obj(1, 1), Action(1)), Decision::Permit);
+        assert_eq!(a.len(), 1, "second call must hit the cache, not add a new entry");
+    }
+
+    #[test]
+    fn default_deny_cached_too() {
+        let a = avc();
+        assert_eq!(a.decide(subj(1, 2), obj(1, 1), Action(9)), Decision::Deny);
+        assert_eq!(a.decide(subj(1, 2), obj(1, 1), Action(9)), Decision::Deny);
+    }
+
+    /// The evaluator must be consulted exactly ONCE per distinct key — proving the cache
+    /// actually short-circuits the PDP (the whole point of the AVC).
+    #[test]
+    fn evaluator_consulted_once_per_key() {
+        struct Counting {
+            inner: LatticeTeEvaluator<StubLinearLattice>,
+            calls: AtomicU32,
+        }
+        impl TeEvaluator for Counting {
+            fn evaluate(&self, s: SubjectCtx, o: ObjectCtx, a: Action) -> Decision {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                self.inner.evaluate(s, o, a)
+            }
+            fn generation(&self) -> u64 {
+                self.inner.generation()
+            }
+        }
+        let mut allow = HashSet::new();
+        allow.insert(rule(1, 1, 1));
+        let inner = LatticeTeEvaluator::new(TeMatrix::from_allow(allow), StubLinearLattice::new(3), 1);
+        let counting = Arc::new(Counting { inner, calls: AtomicU32::new(0) });
+        let a = CachingAvc::new(counting.clone());
+
+        for _ in 0..10 {
+            a.decide(subj(1, 2), obj(1, 1), Action(1));
+        }
+        assert_eq!(counting.calls.load(Ordering::SeqCst), 1, "PDP must be hit once, then cached");
+    }
+
+    #[test]
+    fn token_gate_denies_op_outside_op_set() {
+        let a = avc();
+        let token = TokenScope {
+            label_ceiling: SecurityLabel(3),
+            op_set: Arc::from(vec![Action(2)]), // does NOT include Action(1)
+            valid_until: Instant::now() + Duration::from_secs(60),
+        };
+        assert_eq!(
+            a.decide_with_token(subj(1, 2), obj(1, 1), Action(1), &token),
+            Decision::Deny,
+            "action not in token op_set must be denied"
+        );
+    }
+
+    #[test]
+    fn token_gate_permits_when_pdp_and_token_agree() {
+        let a = avc();
+        let token = TokenScope {
+            label_ceiling: SecurityLabel(3),
+            op_set: Arc::from(vec![Action(1)]),
+            valid_until: Instant::now() + Duration::from_secs(60),
+        };
+        assert_eq!(
+            a.decide_with_token(subj(1, 2), obj(1, 1), Action(1), &token),
+            Decision::Permit
+        );
+    }
+
+    #[test]
+    fn expired_token_fails_closed() {
+        let a = avc();
+        let token = TokenScope {
+            label_ceiling: SecurityLabel(3),
+            op_set: Arc::from(vec![Action(1)]),
+            valid_until: Instant::now() - Duration::from_secs(1), // already expired
+        };
+        assert_eq!(
+            a.decide_with_token(subj(1, 2), obj(1, 1), Action(1), &token),
+            Decision::Deny
+        );
+    }
+
+    #[test]
+    fn flush_clears_cache() {
+        let a = avc();
+        a.decide(subj(1, 2), obj(1, 1), Action(1));
+        assert_eq!(a.len(), 1);
+        a.flush();
+        assert!(a.is_empty());
+    }
+}

--- a/crates/hyprstream/src/mac/avc.rs
+++ b/crates/hyprstream/src/mac/avc.rs
@@ -13,10 +13,13 @@
 //!                                └miss→  evaluator.evaluate(...) ; insert ; return
 //! ```
 //!
-//! The cache KEY is `(generation, subject_type, clearance, object_type, label, action)` —
-//! all interned ids, so the key is `Copy` and hashes cheaply. We deliberately key on the
-//! *resolved interned context*, not on raw strings/paths: string matching (Casbin's job) is
-//! done once at compile time, never per op.
+//! The cache KEY is `(generation, subject_type, clearance, object_type, label, action)`. The
+//! TE types are interned ids and the `clearance`/`label` are S1's structured
+//! [`SecurityLabel`]s — which are `Copy + Hash` (a packed `level/assurance/u64-bitset`, S1
+//! confirmed cheap), so the whole key is `Copy` and hashes cheaply with **no dominance walk
+//! and no signature verify on a hit** (#570 requirement). We deliberately key on the
+//! *resolved context*, not on raw strings/paths: string matching (Casbin's job) is done once
+//! at compile time, never per op.
 //!
 //! ## Token = distributed AVC entry (design §2, §6)
 //!
@@ -237,9 +240,12 @@ impl<E: TeEvaluator> Avc for CachingAvc<E> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use crate::mac::lattice::{SecurityLabel, StubLinearLattice};
+    use crate::mac::lattice::{
+        Assurance, Compartment, CompartmentSet, Lattice, LatticeVersion, Level, SecurityLabel,
+    };
     use crate::mac::te::{LatticeTeEvaluator, TeMatrix, TeRule};
     use std::collections::HashSet;
     use std::sync::atomic::{AtomicU32, Ordering};
@@ -252,33 +258,47 @@ mod tests {
             action: Action(a),
         }
     }
-    fn subj(t: u32, clr: u32) -> SubjectCtx {
-        SubjectCtx { subject_type: SubjectType(t), clearance: SecurityLabel(clr) }
-    }
-    fn obj(t: u32, lbl: u32) -> ObjectCtx {
-        ObjectCtx { object_type: ObjectType(t), label: SecurityLabel(lbl) }
+
+    fn lattice() -> Lattice {
+        Lattice::new(LatticeVersion(1), [Compartment::new("pii")])
     }
 
-    fn avc() -> CachingAvc<LatticeTeEvaluator<StubLinearLattice>> {
+    /// A high (Secret/pq-hybrid) clearance that dominates the low object label below.
+    fn high() -> SecurityLabel {
+        SecurityLabel::new(Level::Secret, Assurance::PqHybrid, CompartmentSet::EMPTY)
+    }
+    /// A low (Public/classical) object label, dominated by `high()`.
+    fn low() -> SecurityLabel {
+        SecurityLabel::new(Level::Public, Assurance::Classical, CompartmentSet::EMPTY)
+    }
+
+    fn subj(t: u32, clr: SecurityLabel) -> SubjectCtx {
+        SubjectCtx { subject_type: SubjectType(t), clearance: clr }
+    }
+    fn obj(t: u32, lbl: SecurityLabel) -> ObjectCtx {
+        ObjectCtx { object_type: ObjectType(t), label: lbl }
+    }
+
+    fn avc() -> CachingAvc<LatticeTeEvaluator> {
         let mut allow = HashSet::new();
         allow.insert(rule(1, 1, 1));
-        let e = LatticeTeEvaluator::new(TeMatrix::from_allow(allow), StubLinearLattice::new(3), 1);
+        let e = LatticeTeEvaluator::new(TeMatrix::from_allow(allow), lattice());
         CachingAvc::new(Arc::new(e))
     }
 
     #[test]
     fn hit_returns_cached_decision() {
         let a = avc();
-        assert_eq!(a.decide(subj(1, 2), obj(1, 1), Action(1)), Decision::Permit);
-        assert_eq!(a.decide(subj(1, 2), obj(1, 1), Action(1)), Decision::Permit);
+        assert_eq!(a.decide(subj(1, high()), obj(1, low()), Action(1)), Decision::Permit);
+        assert_eq!(a.decide(subj(1, high()), obj(1, low()), Action(1)), Decision::Permit);
         assert_eq!(a.len(), 1, "second call must hit the cache, not add a new entry");
     }
 
     #[test]
     fn default_deny_cached_too() {
         let a = avc();
-        assert_eq!(a.decide(subj(1, 2), obj(1, 1), Action(9)), Decision::Deny);
-        assert_eq!(a.decide(subj(1, 2), obj(1, 1), Action(9)), Decision::Deny);
+        assert_eq!(a.decide(subj(1, high()), obj(1, low()), Action(9)), Decision::Deny);
+        assert_eq!(a.decide(subj(1, high()), obj(1, low()), Action(9)), Decision::Deny);
     }
 
     /// The evaluator must be consulted exactly ONCE per distinct key — proving the cache
@@ -286,7 +306,7 @@ mod tests {
     #[test]
     fn evaluator_consulted_once_per_key() {
         struct Counting {
-            inner: LatticeTeEvaluator<StubLinearLattice>,
+            inner: LatticeTeEvaluator,
             calls: AtomicU32,
         }
         impl TeEvaluator for Counting {
@@ -300,12 +320,12 @@ mod tests {
         }
         let mut allow = HashSet::new();
         allow.insert(rule(1, 1, 1));
-        let inner = LatticeTeEvaluator::new(TeMatrix::from_allow(allow), StubLinearLattice::new(3), 1);
+        let inner = LatticeTeEvaluator::new(TeMatrix::from_allow(allow), lattice());
         let counting = Arc::new(Counting { inner, calls: AtomicU32::new(0) });
         let a = CachingAvc::new(counting.clone());
 
         for _ in 0..10 {
-            a.decide(subj(1, 2), obj(1, 1), Action(1));
+            a.decide(subj(1, high()), obj(1, low()), Action(1));
         }
         assert_eq!(counting.calls.load(Ordering::SeqCst), 1, "PDP must be hit once, then cached");
     }
@@ -314,12 +334,12 @@ mod tests {
     fn token_gate_denies_op_outside_op_set() {
         let a = avc();
         let token = TokenScope {
-            label_ceiling: SecurityLabel(3),
+            label_ceiling: high(),
             op_set: Arc::from(vec![Action(2)]), // does NOT include Action(1)
             valid_until: Instant::now() + Duration::from_secs(60),
         };
         assert_eq!(
-            a.decide_with_token(subj(1, 2), obj(1, 1), Action(1), &token),
+            a.decide_with_token(subj(1, high()), obj(1, low()), Action(1), &token),
             Decision::Deny,
             "action not in token op_set must be denied"
         );
@@ -329,12 +349,12 @@ mod tests {
     fn token_gate_permits_when_pdp_and_token_agree() {
         let a = avc();
         let token = TokenScope {
-            label_ceiling: SecurityLabel(3),
+            label_ceiling: high(),
             op_set: Arc::from(vec![Action(1)]),
             valid_until: Instant::now() + Duration::from_secs(60),
         };
         assert_eq!(
-            a.decide_with_token(subj(1, 2), obj(1, 1), Action(1), &token),
+            a.decide_with_token(subj(1, high()), obj(1, low()), Action(1), &token),
             Decision::Permit
         );
     }
@@ -343,12 +363,12 @@ mod tests {
     fn expired_token_fails_closed() {
         let a = avc();
         let token = TokenScope {
-            label_ceiling: SecurityLabel(3),
+            label_ceiling: high(),
             op_set: Arc::from(vec![Action(1)]),
             valid_until: Instant::now() - Duration::from_secs(1), // already expired
         };
         assert_eq!(
-            a.decide_with_token(subj(1, 2), obj(1, 1), Action(1), &token),
+            a.decide_with_token(subj(1, high()), obj(1, low()), Action(1), &token),
             Decision::Deny
         );
     }
@@ -356,7 +376,7 @@ mod tests {
     #[test]
     fn flush_clears_cache() {
         let a = avc();
-        a.decide(subj(1, 2), obj(1, 1), Action(1));
+        a.decide(subj(1, high()), obj(1, low()), Action(1));
         assert_eq!(a.len(), 1);
         a.flush();
         assert!(a.is_empty());

--- a/crates/hyprstream/src/mac/compiled.rs
+++ b/crates/hyprstream/src/mac/compiled.rs
@@ -1,0 +1,424 @@
+//! Compiled-policy distribution + signing (S4 / #570).
+//!
+//! The PolicyService (PDP authority) compiles policy into a [`CompiledPolicy`] (the TE matrix
+//! + the lattice generation it is valid for), serializes it canonically, hashes it, and signs
+//! `(generation, policy_hash)` with the hybrid COSE composite (EdDSA + ML-DSA-65; design §13a,
+//! §14). Nodes (PEPs) load the signed artifact and the [`PolicyLoader`] **rejects any policy
+//! whose signature does not verify** and (per design §14 / S5 containment backstop) whose hash
+//! does not match an approval.
+//!
+//! This module is the *transport/verification* boundary; the per-op hot path (`te` + `avc`)
+//! never touches it. Signature verification happens **once at load**, never per op (design §7,
+//! §13a "never verify-per-op").
+//!
+//! ## What S5 owns vs what this owns
+//! - S5: the UCAN→TE compiler that *produces* the [`TeMatrix`] and the approval signature over
+//!   `(canonical_UCAN_CID, bundle_hash)`.
+//! - S4 (here): wrapping the matrix as a versioned, hashed, signed distributable; and the
+//!   loader that rejects anything unsigned/mismatched before it can feed an evaluator.
+//!
+//! The actual COSE composite sign/verify lives in `hyprstream_rpc::crypto::cose_sign`; this
+//! module abstracts it behind [`PolicySigner`] / [`PolicyVerifier`] so the hot-path crate has
+//! no crypto dependency and so tests can use a trivial signer. The production wiring (using
+//! `MlDsaSigningKeyStore` + Ed25519) is in [`cose`].
+
+use crate::mac::te::TeMatrix;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// A compiled, distributable policy artifact: the TE matrix plus the lattice generation it is
+/// valid against. `generation` ties the matrix to a specific lattice generation (S1) AND is
+/// the AVC's cache-invalidation key — bumping it invalidates every cached decision.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompiledPolicy {
+    /// Monotonic policy generation. Must equal the lattice generation it was compiled
+    /// against (reconciliation point with S1 — see BLOCKER list).
+    pub generation: u64,
+    /// The compiled TE allow/escalate matrix (produced by S5's compiler).
+    pub matrix: TeMatrix,
+}
+
+impl CompiledPolicy {
+    pub fn new(generation: u64, matrix: TeMatrix) -> Self {
+        Self { generation, matrix }
+    }
+
+    /// Canonical bytes for hashing/signing. Deterministic: same policy → identical bytes
+    /// (design §13a determinism). We sort the rule sets into a stable vec form first so the
+    /// `HashSet` iteration order never leaks into the hash.
+    pub fn canonical_bytes(&self) -> Result<Vec<u8>, PolicyDistError> {
+        // Re-serialize via a canonical, order-stable representation.
+        let canonical = CanonicalPolicy::from(self);
+        serde_json::to_vec(&canonical).map_err(|e| PolicyDistError::Encode(e.to_string()))
+    }
+
+    /// BLAKE3 content hash of the canonical bytes — the `policy_hash` the approval binds to.
+    pub fn policy_hash(&self) -> Result<[u8; 32], PolicyDistError> {
+        let bytes = self.canonical_bytes()?;
+        Ok(*blake3::hash(&bytes).as_bytes())
+    }
+}
+
+/// Order-stable view of a [`CompiledPolicy`] for canonical encoding. The `TeMatrix` stores
+/// rules in `HashSet`s (O(1) hot-path lookup); for hashing we project to sorted vecs so the
+/// hash is deterministic regardless of set iteration order.
+#[derive(Serialize, Deserialize)]
+struct CanonicalPolicy {
+    generation: u64,
+    allow: Vec<crate::mac::te::TeRule>,
+    escalate: Vec<crate::mac::te::TeRule>,
+}
+
+impl From<&CompiledPolicy> for CanonicalPolicy {
+    fn from(p: &CompiledPolicy) -> Self {
+        // Reconstruct sorted rule vecs from the matrix. We can't read the private sets
+        // directly, so we expose a sorted projection via TeMatrix below.
+        let (mut allow, mut escalate) = p.matrix.sorted_rules();
+        allow.sort();
+        escalate.sort();
+        Self {
+            generation: p.generation,
+            allow,
+            escalate,
+        }
+    }
+}
+
+/// A signed, distributable policy: the canonical policy bytes + a detached composite
+/// signature over `(generation || policy_hash)`. This is the wire artifact PolicyService
+/// publishes and PEPs fetch.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SignedPolicy {
+    /// Canonical bytes of the [`CompiledPolicy`] (re-hashable at the loader; the loader does
+    /// NOT trust a transmitted hash — it recomputes).
+    pub policy_bytes: Vec<u8>,
+    /// Detached COSE composite signature over the signing input (see [`signing_input`]).
+    pub signature: Vec<u8>,
+    /// Generation, duplicated out-of-band for quick routing; authoritative value is inside
+    /// `policy_bytes` and is what gets signed.
+    pub generation: u64,
+}
+
+/// The exact bytes that get signed: domain-separated `(generation, policy_hash)`. Binding the
+/// generation prevents a rollback/replay of an older signed matrix under a new generation.
+pub fn signing_input(generation: u64, policy_hash: &[u8; 32]) -> Vec<u8> {
+    let mut v = Vec::with_capacity(8 + 8 + 32);
+    v.extend_from_slice(b"hs-mac-te"); // domain separation tag
+    v.extend_from_slice(&generation.to_be_bytes());
+    v.extend_from_slice(policy_hash);
+    v
+}
+
+/// Abstraction over the authority's signing key (production = hybrid EdDSA+ML-DSA-65 COSE
+/// composite). Implemented in [`cose`] over the existing crypto stack.
+pub trait PolicySigner {
+    /// Sign the signing-input bytes, returning a detached signature.
+    fn sign(&self, signing_input: &[u8]) -> Result<Vec<u8>, PolicyDistError>;
+}
+
+/// Abstraction over signature verification at the loader (production = composite verify with
+/// `require_pq = true`, fail-closed).
+pub trait PolicyVerifier {
+    /// Verify `signature` over `signing_input`. Returns `Ok(())` on success, error otherwise.
+    fn verify(&self, signing_input: &[u8], signature: &[u8]) -> Result<(), PolicyDistError>;
+}
+
+/// PolicyService side: compile → hash → sign → distributable artifact.
+pub fn sign_policy<S: PolicySigner>(
+    policy: &CompiledPolicy,
+    signer: &S,
+) -> Result<SignedPolicy, PolicyDistError> {
+    let policy_bytes = policy.canonical_bytes()?;
+    let hash = policy.policy_hash()?;
+    let input = signing_input(policy.generation, &hash);
+    let signature = signer.sign(&input)?;
+    Ok(SignedPolicy {
+        policy_bytes,
+        signature,
+        generation: policy.generation,
+    })
+}
+
+/// An approval record (design §14 containment backstop): the human-approved binding of a
+/// policy generation to its expected hash. The loader accepts ONLY a policy whose recomputed
+/// hash matches an approval for its generation. Even an undetected compiler bug then can't
+/// smuggle authority past review. S5 produces these (signed `(UCAN_CID, bundle_hash)`); here
+/// we model the hash-match the loader enforces.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PolicyApproval {
+    pub generation: u64,
+    pub approved_hash: [u8; 32],
+}
+
+/// PEP side: verify signature + (optionally) match against an approval, then yield the
+/// [`CompiledPolicy`] ready to feed a [`crate::mac::te::LatticeTeEvaluator`]. Fail-closed:
+/// any failure returns an error and NO policy is loaded (the PEP keeps denying).
+pub struct PolicyLoader<V: PolicyVerifier> {
+    verifier: V,
+    /// Approvals indexed by generation. If empty, approval-matching is skipped (sig-only);
+    /// production SHOULD populate this (S5).
+    approvals: Vec<PolicyApproval>,
+}
+
+impl<V: PolicyVerifier> PolicyLoader<V> {
+    pub fn new(verifier: V) -> Self {
+        Self {
+            verifier,
+            approvals: Vec::new(),
+        }
+    }
+
+    /// Register an approval the loader will require a hash-match against.
+    pub fn with_approval(mut self, approval: PolicyApproval) -> Self {
+        self.approvals.push(approval);
+        self
+    }
+
+    /// Verify + load. Steps (all fail-closed):
+    /// 1. Decode the canonical policy bytes.
+    /// 2. Recompute the hash from the bytes (never trust a transmitted hash).
+    /// 3. Verify the composite signature over `(generation, hash)`.
+    /// 4. If approvals are registered, require a matching `(generation, hash)` approval.
+    pub fn load(&self, signed: &SignedPolicy) -> Result<CompiledPolicy, PolicyDistError> {
+        // 1. Decode.
+        let canonical: CanonicalPolicy = serde_json::from_slice(&signed.policy_bytes)
+            .map_err(|e| PolicyDistError::Decode(e.to_string()))?;
+        let matrix = TeMatrix::new(
+            canonical.allow.iter().copied().collect(),
+            canonical.escalate.iter().copied().collect(),
+        );
+        let policy = CompiledPolicy::new(canonical.generation, matrix);
+
+        // The out-of-band generation must match the signed-in generation (no mismatch routing).
+        if policy.generation != signed.generation {
+            return Err(PolicyDistError::GenerationMismatch {
+                outer: signed.generation,
+                inner: policy.generation,
+            });
+        }
+
+        // 2. Recompute hash from the decoded policy's OWN canonical bytes. If the transmitted
+        //    bytes were canonical, this round-trips; if they were tampered into a non-canonical
+        //    form, the recomputed hash diverges and signature/approval checks fail closed.
+        let hash = policy.policy_hash()?;
+        let input = signing_input(policy.generation, &hash);
+
+        // 3. Signature verify (ONCE, at load — never per op).
+        self.verifier.verify(&input, &signed.signature)?;
+
+        // 4. Approval hash-match (containment backstop).
+        if !self.approvals.is_empty() {
+            let matched = self
+                .approvals
+                .iter()
+                .any(|a| a.generation == policy.generation && a.approved_hash == hash);
+            if !matched {
+                return Err(PolicyDistError::NoMatchingApproval {
+                    generation: policy.generation,
+                });
+            }
+        }
+
+        Ok(policy)
+    }
+}
+
+/// Errors in compiled-policy distribution. All are load-time; the hot path never sees them.
+#[derive(Error, Debug)]
+pub enum PolicyDistError {
+    #[error("policy encode failed: {0}")]
+    Encode(String),
+    #[error("policy decode failed: {0}")]
+    Decode(String),
+    #[error("signature verification failed: {0}")]
+    BadSignature(String),
+    #[error("no approval matches policy generation {generation} (hash mismatch — possible compiler tampering)")]
+    NoMatchingApproval { generation: u64 },
+    #[error("generation mismatch: outer={outer} inner={inner}")]
+    GenerationMismatch { outer: u64, inner: u64 },
+}
+
+// ---------------------------------------------------------------------------------------
+// Production crypto wiring over the existing hybrid COSE composite stack.
+// Kept behind these adapters so `te`/`avc` stay crypto-free and tests can use a stub signer.
+// ---------------------------------------------------------------------------------------
+
+/// Production signer/verifier adapters over `hyprstream_rpc::crypto::cose_sign`.
+pub mod cose {
+    use super::{PolicyDistError, PolicySigner, PolicyVerifier};
+    use ed25519_dalek::{SigningKey, VerifyingKey};
+    use hyprstream_rpc::crypto::cose_sign::{sign_composite, verify_composite};
+    use hyprstream_rpc::crypto::pq::{MlDsaSigningKey, MlDsaVerifyingKey};
+
+    /// Domain-separation AAD for compiled-policy signatures (distinct from envelope/token
+    /// AADs so a policy signature can never be confused for another message type).
+    const POLICY_AAD: &[u8] = b"hs-mac-compiled-policy-v1";
+
+    /// Hybrid (EdDSA + ML-DSA-65) signer for compiled policy. `pq` is `None` only when the
+    /// crypto policy is Classical; production MUST be `Some` (design §14: not Ed25519-only).
+    pub struct HybridPolicySigner<'a> {
+        pub ed_sk: &'a SigningKey,
+        pub pq_sk: Option<&'a MlDsaSigningKey>,
+    }
+
+    impl PolicySigner for HybridPolicySigner<'_> {
+        fn sign(&self, signing_input: &[u8]) -> Result<Vec<u8>, PolicyDistError> {
+            sign_composite(self.ed_sk, self.pq_sk, signing_input, POLICY_AAD)
+                .map_err(|e| PolicyDistError::Encode(e.to_string()))
+        }
+    }
+
+    /// Hybrid verifier. `require_pq = true` enforces the ML-DSA outer layer (fail-closed if a
+    /// classical-only signature is presented under a hybrid policy — design §13a).
+    pub struct HybridPolicyVerifier<'a> {
+        pub ed_vk: &'a VerifyingKey,
+        pub pq_vk: Option<&'a MlDsaVerifyingKey>,
+        pub require_pq: bool,
+    }
+
+    impl PolicyVerifier for HybridPolicyVerifier<'_> {
+        fn verify(&self, signing_input: &[u8], signature: &[u8]) -> Result<(), PolicyDistError> {
+            verify_composite(
+                signature,
+                self.ed_vk,
+                self.pq_vk,
+                signing_input,
+                POLICY_AAD,
+                self.require_pq,
+            )
+            .map(|_verified| ())
+            .map_err(|e| PolicyDistError::BadSignature(e.to_string()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mac::te::{Action, ObjectType, SubjectType, TeRule};
+    use std::collections::HashSet;
+
+    fn rule(s: u32, o: u32, a: u32) -> TeRule {
+        TeRule {
+            subject_type: SubjectType(s),
+            object_type: ObjectType(o),
+            action: Action(a),
+        }
+    }
+
+    fn policy(gen: u64) -> CompiledPolicy {
+        let mut allow = HashSet::new();
+        allow.insert(rule(1, 1, 1));
+        allow.insert(rule(1, 2, 1));
+        CompiledPolicy::new(gen, TeMatrix::from_allow(allow))
+    }
+
+    /// A trivial HMAC-free stub signer for unit tests: signature = blake3(key || input).
+    struct StubSigner {
+        key: [u8; 32],
+    }
+    impl PolicySigner for StubSigner {
+        fn sign(&self, input: &[u8]) -> Result<Vec<u8>, PolicyDistError> {
+            let mut h = blake3::Hasher::new();
+            h.update(&self.key);
+            h.update(input);
+            Ok(h.finalize().as_bytes().to_vec())
+        }
+    }
+    struct StubVerifier {
+        key: [u8; 32],
+    }
+    impl PolicyVerifier for StubVerifier {
+        fn verify(&self, input: &[u8], sig: &[u8]) -> Result<(), PolicyDistError> {
+            let mut h = blake3::Hasher::new();
+            h.update(&self.key);
+            h.update(input);
+            if h.finalize().as_bytes().as_slice() == sig {
+                Ok(())
+            } else {
+                Err(PolicyDistError::BadSignature("stub mismatch".into()))
+            }
+        }
+    }
+
+    #[test]
+    fn canonical_hash_is_deterministic_across_set_order() {
+        // Two matrices with the same rules inserted in different order must hash equal.
+        let mut a = HashSet::new();
+        a.insert(rule(1, 1, 1));
+        a.insert(rule(2, 3, 4));
+        let mut b = HashSet::new();
+        b.insert(rule(2, 3, 4));
+        b.insert(rule(1, 1, 1));
+        let pa = CompiledPolicy::new(5, TeMatrix::from_allow(a));
+        let pb = CompiledPolicy::new(5, TeMatrix::from_allow(b));
+        assert_eq!(pa.policy_hash().unwrap(), pb.policy_hash().unwrap());
+    }
+
+    #[test]
+    fn sign_then_load_roundtrips() {
+        let key = [7u8; 32];
+        let signed = sign_policy(&policy(3), &StubSigner { key }).unwrap();
+        let loader = PolicyLoader::new(StubVerifier { key });
+        let loaded = loader.load(&signed).unwrap();
+        assert_eq!(loaded.generation, 3);
+        assert_eq!(loaded.matrix.allow_len(), 2);
+    }
+
+    #[test]
+    fn tampered_policy_bytes_rejected() {
+        let key = [7u8; 32];
+        let mut signed = sign_policy(&policy(3), &StubSigner { key }).unwrap();
+        // Flip a byte in the policy body — recomputed hash diverges → signature fails.
+        signed.policy_bytes[0] ^= 0xFF;
+        let loader = PolicyLoader::new(StubVerifier { key });
+        assert!(loader.load(&signed).is_err(), "tampered policy must be rejected");
+    }
+
+    #[test]
+    fn wrong_key_signature_rejected() {
+        let signed = sign_policy(&policy(3), &StubSigner { key: [1u8; 32] }).unwrap();
+        let loader = PolicyLoader::new(StubVerifier { key: [2u8; 32] });
+        assert!(matches!(
+            loader.load(&signed),
+            Err(PolicyDistError::BadSignature(_))
+        ));
+    }
+
+    #[test]
+    fn approval_hash_match_enforced() {
+        let key = [7u8; 32];
+        let p = policy(9);
+        let hash = p.policy_hash().unwrap();
+        let signed = sign_policy(&p, &StubSigner { key }).unwrap();
+
+        // Loader with the CORRECT approval loads.
+        let good = PolicyLoader::new(StubVerifier { key }).with_approval(PolicyApproval {
+            generation: 9,
+            approved_hash: hash,
+        });
+        assert!(good.load(&signed).is_ok());
+
+        // Loader with a WRONG approval hash rejects, even though the signature verifies.
+        let bad = PolicyLoader::new(StubVerifier { key }).with_approval(PolicyApproval {
+            generation: 9,
+            approved_hash: [0u8; 32],
+        });
+        assert!(matches!(
+            bad.load(&signed),
+            Err(PolicyDistError::NoMatchingApproval { generation: 9 })
+        ));
+    }
+
+    #[test]
+    fn generation_mismatch_rejected() {
+        let key = [7u8; 32];
+        let mut signed = sign_policy(&policy(3), &StubSigner { key }).unwrap();
+        signed.generation = 4; // outer disagrees with the signed-in inner generation
+        let loader = PolicyLoader::new(StubVerifier { key });
+        assert!(matches!(
+            loader.load(&signed),
+            Err(PolicyDistError::GenerationMismatch { outer: 4, inner: 3 })
+        ));
+    }
+}

--- a/crates/hyprstream/src/mac/compiled.rs
+++ b/crates/hyprstream/src/mac/compiled.rs
@@ -22,25 +22,58 @@
 //! no crypto dependency and so tests can use a trivial signer. The production wiring (using
 //! `MlDsaSigningKeyStore` + Ed25519) is in [`cose`].
 
+use crate::mac::lattice::{Lattice, LatticeCodecError};
 use crate::mac::te::TeMatrix;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-/// A compiled, distributable policy artifact: the TE matrix plus the lattice generation it is
-/// valid against. `generation` ties the matrix to a specific lattice generation (S1) AND is
-/// the AVC's cache-invalidation key — bumping it invalidates every cached decision.
+/// A compiled, distributable policy artifact: the TE matrix, **the S1 lattice it was
+/// compiled against (embedded verbatim)**, and the generation that binds them. `generation`
+/// ties the matrix to a specific lattice generation (S1) AND is the AVC's cache-invalidation
+/// key — bumping it invalidates every cached decision.
+///
+/// ## S1 reconciliation (#570): embed the lattice, bind the version (desync-proof)
+///
+/// The signed policy carries the lattice's **canonical CBOR bytes** ([`Lattice::to_bytes`] —
+/// the same codec the COSE signing path uses). Because those bytes are the closed
+/// compartment vocabulary in bit-index order, every process that loads this policy
+/// reconstructs the **identical** name↔bit map: same bytes in → identical bits out, so a
+/// [`SecurityLabel`](crate::mac::lattice::SecurityLabel)'s compartment bits mean the same
+/// thing in the compiler, the PDP, and every distributed AVC. The loader additionally
+/// enforces `lattice.version().generation() == generation` — a compiled matrix is valid
+/// ONLY against the lattice generation that minted its bit assignments.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CompiledPolicy {
-    /// Monotonic policy generation. Must equal the lattice generation it was compiled
-    /// against (reconciliation point with S1 — see BLOCKER list).
+    /// Monotonic policy generation. Equals the embedded lattice's
+    /// [`LatticeVersion::generation`](crate::mac::lattice::LatticeVersion::generation)
+    /// (enforced at construction and re-checked on load).
     pub generation: u64,
     /// The compiled TE allow/escalate matrix (produced by S5's compiler).
     pub matrix: TeMatrix,
+    /// The S1 lattice policy, serialized to its canonical CBOR byte form. Embedded so the
+    /// PDP and every distributed AVC reconstruct an identical name↔bit vocabulary (no
+    /// cross-process compartment-bit desync). Reconstruct via [`CompiledPolicy::lattice`].
+    pub lattice_bytes: Vec<u8>,
 }
 
 impl CompiledPolicy {
-    pub fn new(generation: u64, matrix: TeMatrix) -> Self {
-        Self { generation, matrix }
+    /// Compile a policy against an S1 [`Lattice`]. The generation is taken from the lattice
+    /// version — they are definitionally equal (#570): the lattice that minted the
+    /// compartment bits IS the policy generation. The lattice is embedded verbatim (its
+    /// canonical CBOR bytes) so it travels inside the signature.
+    pub fn new(matrix: TeMatrix, lattice: &Lattice) -> Self {
+        Self {
+            generation: lattice.version().generation(),
+            matrix,
+            lattice_bytes: lattice.to_bytes(),
+        }
+    }
+
+    /// Reconstruct the embedded S1 [`Lattice`] from its canonical bytes. Fail-closed: a
+    /// malformed / tampered vocabulary (duplicate names, over-width) is rejected rather than
+    /// silently yielding a different lattice (the desync-proof property).
+    pub fn lattice(&self) -> Result<Lattice, LatticeCodecError> {
+        Lattice::from_bytes(&self.lattice_bytes)
     }
 
     /// Canonical bytes for hashing/signing. Deterministic: same policy → identical bytes
@@ -61,12 +94,15 @@ impl CompiledPolicy {
 
 /// Order-stable view of a [`CompiledPolicy`] for canonical encoding. The `TeMatrix` stores
 /// rules in `HashSet`s (O(1) hot-path lookup); for hashing we project to sorted vecs so the
-/// hash is deterministic regardless of set iteration order.
+/// hash is deterministic regardless of set iteration order. The embedded `lattice_bytes` are
+/// already canonical (S1's deterministic CBOR), so the policy hash binds the exact lattice
+/// vocabulary too — a tampered compartment map changes the hash and fails the signature.
 #[derive(Serialize, Deserialize)]
 struct CanonicalPolicy {
     generation: u64,
     allow: Vec<crate::mac::te::TeRule>,
     escalate: Vec<crate::mac::te::TeRule>,
+    lattice_bytes: Vec<u8>,
 }
 
 impl From<&CompiledPolicy> for CanonicalPolicy {
@@ -80,6 +116,7 @@ impl From<&CompiledPolicy> for CanonicalPolicy {
             generation: p.generation,
             allow,
             escalate,
+            lattice_bytes: p.lattice_bytes.clone(),
         }
     }
 }
@@ -187,13 +224,34 @@ impl<V: PolicyVerifier> PolicyLoader<V> {
             canonical.allow.iter().copied().collect(),
             canonical.escalate.iter().copied().collect(),
         );
-        let policy = CompiledPolicy::new(canonical.generation, matrix);
+        // Reassemble preserving the embedded lattice bytes verbatim (do NOT re-derive the
+        // generation here — we must round-trip the exact transmitted bytes to recompute the
+        // same hash; the generation/version binding is checked explicitly below).
+        let policy = CompiledPolicy {
+            generation: canonical.generation,
+            matrix,
+            lattice_bytes: canonical.lattice_bytes,
+        };
 
         // The out-of-band generation must match the signed-in generation (no mismatch routing).
         if policy.generation != signed.generation {
             return Err(PolicyDistError::GenerationMismatch {
                 outer: signed.generation,
                 inner: policy.generation,
+            });
+        }
+
+        // S1 reconciliation (#570): the embedded lattice must reconstruct (fail-closed on a
+        // tampered/over-width vocabulary) AND its version must equal the policy generation —
+        // a matrix is only valid against the lattice generation that minted its bits.
+        let lattice = policy
+            .lattice()
+            .map_err(|e| PolicyDistError::Decode(e.to_string()))?;
+        let lattice_gen = lattice.version().generation();
+        if lattice_gen != policy.generation {
+            return Err(PolicyDistError::LatticeGenerationMismatch {
+                policy: policy.generation,
+                lattice: lattice_gen,
             });
         }
 
@@ -236,6 +294,8 @@ pub enum PolicyDistError {
     NoMatchingApproval { generation: u64 },
     #[error("generation mismatch: outer={outer} inner={inner}")]
     GenerationMismatch { outer: u64, inner: u64 },
+    #[error("embedded lattice version {lattice} != policy generation {policy} (S1↔S4 bit-desync guard)")]
+    LatticeGenerationMismatch { policy: u64, lattice: u64 },
 }
 
 // ---------------------------------------------------------------------------------------
@@ -293,8 +353,10 @@ pub mod cose {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use crate::mac::lattice::{Compartment, LatticeVersion};
     use crate::mac::te::{Action, ObjectType, SubjectType, TeRule};
     use std::collections::HashSet;
 
@@ -306,11 +368,20 @@ mod tests {
         }
     }
 
+    /// A lattice at the given generation/version (the bit-vocabulary the policy binds).
+    fn lattice(gen: u32) -> Lattice {
+        Lattice::new(
+            LatticeVersion(gen),
+            [Compartment::new("pii"), Compartment::new("finance")],
+        )
+    }
+
     fn policy(gen: u64) -> CompiledPolicy {
         let mut allow = HashSet::new();
         allow.insert(rule(1, 1, 1));
         allow.insert(rule(1, 2, 1));
-        CompiledPolicy::new(gen, TeMatrix::from_allow(allow))
+        // Generation is taken from the lattice version (they are definitionally equal).
+        CompiledPolicy::new(TeMatrix::from_allow(allow), &lattice(gen as u32))
     }
 
     /// A trivial HMAC-free stub signer for unit tests: signature = blake3(key || input).
@@ -350,9 +421,38 @@ mod tests {
         let mut b = HashSet::new();
         b.insert(rule(2, 3, 4));
         b.insert(rule(1, 1, 1));
-        let pa = CompiledPolicy::new(5, TeMatrix::from_allow(a));
-        let pb = CompiledPolicy::new(5, TeMatrix::from_allow(b));
+        let pa = CompiledPolicy::new(TeMatrix::from_allow(a), &lattice(5));
+        let pb = CompiledPolicy::new(TeMatrix::from_allow(b), &lattice(5));
         assert_eq!(pa.policy_hash().unwrap(), pb.policy_hash().unwrap());
+    }
+
+    #[test]
+    fn embedded_lattice_roundtrips_and_binds_generation() {
+        // #570 desync-proof: the policy carries the lattice; reconstruction yields the same
+        // bit vocabulary, and the version equals the generation.
+        let p = policy(4);
+        assert_eq!(p.generation, 4);
+        let l = p.lattice().unwrap();
+        assert_eq!(l.version().generation(), 4);
+        assert_eq!(l.bit_of(&Compartment::new("finance")), Some(1));
+    }
+
+    #[test]
+    fn loader_rejects_lattice_generation_mismatch() {
+        // Hand-craft a policy whose embedded lattice version disagrees with the generation:
+        // the loader must reject it (bit-desync guard), even with a valid signature.
+        let key = [7u8; 32];
+        let mut allow = HashSet::new();
+        allow.insert(rule(1, 1, 1));
+        let mut p = CompiledPolicy::new(TeMatrix::from_allow(allow), &lattice(2));
+        // Force a mismatch: claim generation 9 but the embedded lattice is version 2.
+        p.generation = 9;
+        let signed = sign_policy(&p, &StubSigner { key }).unwrap();
+        let loader = PolicyLoader::new(StubVerifier { key });
+        assert!(matches!(
+            loader.load(&signed),
+            Err(PolicyDistError::LatticeGenerationMismatch { policy: 9, lattice: 2 })
+        ));
     }
 
     #[test]

--- a/crates/hyprstream/src/mac/lattice.rs
+++ b/crates/hyprstream/src/mac/lattice.rs
@@ -1,184 +1,123 @@
-//! Lattice interface — the **assumed S1 contract** (ticket #567/S1 owns the impl).
+//! Lattice surface for the PDP — **re-export of S1's canonical types** (#567).
 //!
-//! S4 (this ticket, #570) develops the TE evaluator + AVC against this interface so the
-//! two streams can proceed in parallel. EVERYTHING in this file marked `S1-ASSUMPTION`
-//! is a requirement the S1 lattice implementation must satisfy for reconciliation. If S1
-//! lands a different shape, only this file changes — `te.rs` / `avc.rs` depend solely on
-//! the traits/types declared here.
+//! S4 (#570) originally developed the TE evaluator + AVC against a *stub* lattice
+//! (`StubLinearLattice` + a local `SecurityLabel(u32)` + a `Lattice` dominance
+//! trait) so the two streams could proceed in parallel. **S1 has landed**
+//! (`feature/security-mac-ucan` @ `406ff9fdc`) with the real, canonical types in
+//! [`hyprstream_rpc::auth::mac`], and this file is now a thin re-export so the rest
+//! of the PDP (`te.rs`, `avc.rs`, `compiled.rs`) consumes S1 directly. The stub is
+//! deleted.
 //!
-//! ## The contract S1 must satisfy
+//! ## What changed at reconciliation (the S1 contract, as landed)
 //!
-//! 1. A [`SecurityLabel`] is a small, cheap-to-clone, content-bound identifier for a point
-//!    in the lattice. It is `Copy` (a compact id), `Ord`+`Hash` (so it can key the AVC and
-//!    the compiled TE matrix), and totally serializable.
-//! 2. The lattice is a *partial* order with a [`Lattice::dominates`] (`⊒`) test and a
-//!    [`Lattice::join`] (least-upper-bound, for IFC of derived layers). Both are TOTAL —
-//!    defined for every pair of labels the lattice knows — and never panic.
-//! 3. There is a designated **bottom** (public / least-classified) and the lattice can
-//!    report whether a raw label id is *known* ([`Lattice::is_known`]). An unknown label is
-//!    treated as denied by the floor (design §1 invariant 2: unlabeled = denied).
+//! - [`SecurityLabel`] is no longer an opaque `u32` interned id. It is S1's
+//!   **structured value** — a point in the product lattice
+//!   `Level × Assurance × CompartmentSet` — and is `Copy + Ord + Hash`
+//!   (compartments are a packed `u64` bitset), so it still keys the AVC directly
+//!   with no interning indirection. Crucially it has **no `Default`**: an
+//!   unlabeled subject/object is `Option::None` ⇒ deny, never a permissive
+//!   default.
+//! - Dominance (`⊒`) and join (`⊔`) are **intrinsic** to the value
+//!   ([`SecurityLabel::dominates`], [`SecurityLabel::join`] /
+//!   [`SecurityLabel::join_all`]), and re-exposed on
+//!   [`SecurityContext::dominates`] for a verified subject. They are NOT methods
+//!   on a `Lattice` trait — content truth, no policy argument. The old
+//!   `Lattice::dominates`/`join` trait is gone; the PDP floor now calls the
+//!   intrinsic order (see `te.rs`).
+//! - [`Lattice`] is now S1's **policy object** (the closed, versioned compartment
+//!   name↔bit vocabulary). The PDP holds it to (a) align its TE matrix columns to
+//!   the exact bits a label carries via [`Lattice::compartment_names`], (b)
+//!   [`validate`](Lattice::validate) labels at enrollment/seal, and (c) embed it,
+//!   via [`Lattice::to_bytes`], inside the signed `CompiledPolicy` so every
+//!   process reconstructs the **identical** bit map ([`compiled`](crate::mac::compiled)).
+//!   [`LatticeVersion`] is bound to `CompiledPolicy.generation`.
 //!
-//! The MAC floor (per-op `subject.ctx ⊒ object.label` + IFC join) is computed against this
-//! trait and is **independent of any grant/token/UCAN** (design §3, §10).
+//! The MAC floor (per-op `subject.ctx ⊒ object.label` + IFC join) is computed
+//! against the intrinsic order and is **independent of any grant/token/UCAN**
+//! (design §3, §10).
 
-use serde::{Deserialize, Serialize};
-use std::fmt;
+// Re-export S1's canonical MAC types from the RPC crate (the TCB seam). Everything
+// the PDP needs flows through here so a future S1 shape change is a one-file edit.
+pub use hyprstream_rpc::auth::mac::{
+    Assurance, Compartment, CompartmentSet, LabelError, Lattice, LatticeCodecError,
+    LatticeDecodeError, LatticeVersion, Level, SecurityContext, SecurityLabel,
+    SubjectContextClaims, VerifiedKeyMaterial, MAX_COMPARTMENTS,
+};
 
-/// Compact, content-bound identifier for a point in the security lattice.
-///
-/// S1-ASSUMPTION: a label is representable as a `u32` interned id (one per distinct
-/// MLS-level×compartment-set or type-lattice point). The actual semantic content (level +
-/// compartments) lives in the S1 lattice; the evaluator/AVC only ever compare *ids* on the
-/// hot path — comparing structured labels per op would blow the latency budget.
-///
-/// `0` is reserved for [`SecurityLabel::BOTTOM`] (public / least). The interner is owned by
-/// S1; ids are stable for the lifetime of a compiled policy generation (see
-/// `compiled::CompiledPolicy::generation`).
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
-)]
-#[serde(transparent)]
-pub struct SecurityLabel(pub u32);
-
-impl SecurityLabel {
-    /// The bottom of the lattice (public / least-classified). Dominated by everything.
-    pub const BOTTOM: SecurityLabel = SecurityLabel(0);
-
-    /// Raw interned id.
-    #[inline]
-    pub const fn id(self) -> u32 {
-        self.0
-    }
-}
-
-impl fmt::Display for SecurityLabel {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "L{}", self.0)
-    }
-}
-
-/// The lattice engine S1 provides: dominance (`⊒`) + IFC join (least-upper-bound).
-///
-/// S1-ASSUMPTION: implementations are pure, total, deterministic, and `Send + Sync`. No
-/// method allocates on the hot path beyond what's stated, and none panics for any input —
-/// unknown ids fail closed (see [`Lattice::dominates`]).
-pub trait Lattice: Send + Sync {
-    /// `clearance ⊒ label` — does the subject clearance dominate (is at least as high as)
-    /// the object label? This is the MAC floor's core comparison (design §3 per-op
-    /// dominance, §13 "exact lattice comparison").
-    ///
-    /// S1-ASSUMPTION: TOTAL. For two *known* labels returns the exact partial-order
-    /// result. If EITHER label is unknown to this lattice generation, MUST return `false`
-    /// (fail closed — unlabeled = denied, design §1 invariant 2). Never panics.
-    fn dominates(&self, clearance: SecurityLabel, label: SecurityLabel) -> bool;
-
-    /// IFC join — least upper bound of two labels (design §3: a derived layer's label =
-    /// join(inputs); aggregation can't launder classification).
-    ///
-    /// S1-ASSUMPTION: TOTAL and well-defined for every known pair (the lattice has a top,
-    /// or joins are closed). If either input is unknown, MUST return the lattice **top**
-    /// (the most restrictive label) so an unknown input can only *raise* classification,
-    /// never lower it. Returned label is always known.
-    fn join(&self, a: SecurityLabel, b: SecurityLabel) -> SecurityLabel;
-
-    /// Whether `label` is a known point in *this* lattice generation. Used by the floor to
-    /// reject unlabeled subjects/objects before any grant logic runs.
-    ///
-    /// S1-ASSUMPTION: `is_known(SecurityLabel::BOTTOM)` is always `true`.
-    fn is_known(&self, label: SecurityLabel) -> bool;
-
-    /// The lattice top (most restrictive / highest). Used as the fail-closed join result.
-    ///
-    /// S1-ASSUMPTION: dominated-by-nothing-below; `dominates(top, x) == true` for all known
-    /// `x`.
-    fn top(&self) -> SecurityLabel;
-}
-
-/// IFC convenience: join a slice of input labels into the derived label (design §3 — sealed
-/// at rollup). Folds with [`Lattice::join`]; empty input yields BOTTOM. This is the function
-/// S6/seal-time labeling calls; it lives here because it is pure lattice algebra.
-pub fn ifc_join<L: Lattice + ?Sized>(lattice: &L, inputs: &[SecurityLabel]) -> SecurityLabel {
-    inputs
-        .iter()
-        .copied()
-        .fold(SecurityLabel::BOTTOM, |acc, x| lattice.join(acc, x))
-}
-
-// ---------------------------------------------------------------------------------------
-// A minimal in-tree lattice so S4 is testable/runnable BEFORE S1 lands. This is a STUB:
-// a flat MLS chain (BOTTOM=0 ⊑ 1 ⊑ 2 ⊑ ...) with no compartments. S1 replaces it. The TE
-// evaluator and AVC never reference this type — only the `Lattice` trait — so swapping in
-// S1's implementation is a one-line change at construction sites.
-// ---------------------------------------------------------------------------------------
-
-/// Stub linear-order lattice for S4-local testing. **Replace with S1.**
-///
-/// Levels `0..=max` form a total chain; `dominates(a,b) = a >= b`; `join(a,b) = max(a,b)`.
-/// No compartments, no real type lattice. Marked clearly so it is not mistaken for the real
-/// engine.
-#[derive(Debug, Clone)]
-pub struct StubLinearLattice {
-    max_level: u32,
-}
-
-impl StubLinearLattice {
-    /// Levels `0..=max_level` are known.
-    pub fn new(max_level: u32) -> Self {
-        Self { max_level }
-    }
-}
-
-impl Lattice for StubLinearLattice {
-    fn dominates(&self, clearance: SecurityLabel, label: SecurityLabel) -> bool {
-        if !self.is_known(clearance) || !self.is_known(label) {
-            return false; // fail closed
-        }
-        clearance.0 >= label.0
-    }
-
-    fn join(&self, a: SecurityLabel, b: SecurityLabel) -> SecurityLabel {
-        if !self.is_known(a) || !self.is_known(b) {
-            return self.top(); // fail closed — unknown can only raise
-        }
-        SecurityLabel(a.0.max(b.0))
-    }
-
-    fn is_known(&self, label: SecurityLabel) -> bool {
-        label.0 <= self.max_level
-    }
-
-    fn top(&self) -> SecurityLabel {
-        SecurityLabel(self.max_level)
-    }
+/// IFC convenience: join a slice of input labels into the derived label (design
+/// §3 — sealed at rollup). Thin forwarder over S1's intrinsic
+/// [`SecurityLabel::join_all`]; an empty input yields the lattice bottom ⊥ (the
+/// join identity), which the seal/rollup policy (S2) must treat as suspicious. This
+/// is the function S6/seal-time labeling calls; it lives here so PDP callers have a
+/// single entry-point without reaching across crates.
+#[inline]
+#[must_use]
+pub fn ifc_join(inputs: &[SecurityLabel]) -> SecurityLabel {
+    SecurityLabel::join_all(inputs.iter())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn stub_dominance_is_chain() {
-        let l = StubLinearLattice::new(3);
-        assert!(l.dominates(SecurityLabel(2), SecurityLabel(1)));
-        assert!(l.dominates(SecurityLabel(1), SecurityLabel(1)));
-        assert!(!l.dominates(SecurityLabel(1), SecurityLabel(2)));
+    fn lattice() -> Lattice {
+        Lattice::new(
+            LatticeVersion(1),
+            [
+                Compartment::new("pii"),
+                Compartment::new("finance"),
+                Compartment::new("tenant:acme"),
+            ],
+        )
     }
 
     #[test]
-    fn unknown_label_fails_closed() {
-        let l = StubLinearLattice::new(3);
-        // 9 is unknown -> dominates must be false either way (fail closed)
-        assert!(!l.dominates(SecurityLabel(9), SecurityLabel(1)));
-        assert!(!l.dominates(SecurityLabel(3), SecurityLabel(9)));
-        // join with unknown returns top
-        assert_eq!(l.join(SecurityLabel(9), SecurityLabel(1)), l.top());
+    fn intrinsic_dominance_is_product_order() {
+        let l = lattice();
+        let cleared = l
+            .label(
+                Level::Secret,
+                Assurance::PqHybrid,
+                [Compartment::new("pii"), Compartment::new("finance")],
+            )
+            .unwrap();
+        let needs_pii = l
+            .label(Level::Confidential, Assurance::Classical, [Compartment::new("pii")])
+            .unwrap();
+        // dominates on every axis (level ≥, assurance ≥, compartments ⊇).
+        assert!(cleared.dominates(&needs_pii));
+        assert!(!needs_pii.dominates(&cleared));
     }
 
     #[test]
-    fn ifc_join_raises_to_max() {
-        let l = StubLinearLattice::new(3);
-        let labels = [SecurityLabel(1), SecurityLabel(3), SecurityLabel(2)];
-        assert_eq!(ifc_join(&l, &labels), SecurityLabel(3));
-        assert_eq!(ifc_join(&l, &[]), SecurityLabel::BOTTOM);
+    fn ifc_join_raises_to_lub() {
+        let l = lattice();
+        let secret = l
+            .label(Level::Secret, Assurance::PqHybrid, [Compartment::new("pii")])
+            .unwrap();
+        let public = l
+            .label(Level::Public, Assurance::Classical, [])
+            .unwrap();
+        let derived = ifc_join(&[secret, public]);
+        assert_eq!(derived.level, Level::Secret);
+        assert_eq!(derived.assurance, Assurance::PqHybrid);
+        assert!(derived.dominates(&secret));
+        assert!(derived.dominates(&public));
+        // empty input folds to the join identity ⊥.
+        assert!(ifc_join(&[]).is_bottom());
+    }
+
+    #[test]
+    fn lattice_validate_and_bytes_roundtrip() {
+        // The desync-proof property compiled.rs relies on: same bytes → identical
+        // bit assignment in every process.
+        let l = lattice();
+        let restored = Lattice::from_bytes(&l.to_bytes()).unwrap();
+        assert_eq!(restored.compartment_names(), l.compartment_names());
+        let label = l
+            .label(Level::Internal, Assurance::Classical, [Compartment::new("tenant:acme")])
+            .unwrap();
+        assert!(restored.validate(&label).is_ok());
+        assert_eq!(restored.bit_of(&Compartment::new("tenant:acme")), Some(2));
     }
 }

--- a/crates/hyprstream/src/mac/lattice.rs
+++ b/crates/hyprstream/src/mac/lattice.rs
@@ -1,0 +1,184 @@
+//! Lattice interface — the **assumed S1 contract** (ticket #567/S1 owns the impl).
+//!
+//! S4 (this ticket, #570) develops the TE evaluator + AVC against this interface so the
+//! two streams can proceed in parallel. EVERYTHING in this file marked `S1-ASSUMPTION`
+//! is a requirement the S1 lattice implementation must satisfy for reconciliation. If S1
+//! lands a different shape, only this file changes — `te.rs` / `avc.rs` depend solely on
+//! the traits/types declared here.
+//!
+//! ## The contract S1 must satisfy
+//!
+//! 1. A [`SecurityLabel`] is a small, cheap-to-clone, content-bound identifier for a point
+//!    in the lattice. It is `Copy` (a compact id), `Ord`+`Hash` (so it can key the AVC and
+//!    the compiled TE matrix), and totally serializable.
+//! 2. The lattice is a *partial* order with a [`Lattice::dominates`] (`⊒`) test and a
+//!    [`Lattice::join`] (least-upper-bound, for IFC of derived layers). Both are TOTAL —
+//!    defined for every pair of labels the lattice knows — and never panic.
+//! 3. There is a designated **bottom** (public / least-classified) and the lattice can
+//!    report whether a raw label id is *known* ([`Lattice::is_known`]). An unknown label is
+//!    treated as denied by the floor (design §1 invariant 2: unlabeled = denied).
+//!
+//! The MAC floor (per-op `subject.ctx ⊒ object.label` + IFC join) is computed against this
+//! trait and is **independent of any grant/token/UCAN** (design §3, §10).
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Compact, content-bound identifier for a point in the security lattice.
+///
+/// S1-ASSUMPTION: a label is representable as a `u32` interned id (one per distinct
+/// MLS-level×compartment-set or type-lattice point). The actual semantic content (level +
+/// compartments) lives in the S1 lattice; the evaluator/AVC only ever compare *ids* on the
+/// hot path — comparing structured labels per op would blow the latency budget.
+///
+/// `0` is reserved for [`SecurityLabel::BOTTOM`] (public / least). The interner is owned by
+/// S1; ids are stable for the lifetime of a compiled policy generation (see
+/// `compiled::CompiledPolicy::generation`).
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+#[serde(transparent)]
+pub struct SecurityLabel(pub u32);
+
+impl SecurityLabel {
+    /// The bottom of the lattice (public / least-classified). Dominated by everything.
+    pub const BOTTOM: SecurityLabel = SecurityLabel(0);
+
+    /// Raw interned id.
+    #[inline]
+    pub const fn id(self) -> u32 {
+        self.0
+    }
+}
+
+impl fmt::Display for SecurityLabel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "L{}", self.0)
+    }
+}
+
+/// The lattice engine S1 provides: dominance (`⊒`) + IFC join (least-upper-bound).
+///
+/// S1-ASSUMPTION: implementations are pure, total, deterministic, and `Send + Sync`. No
+/// method allocates on the hot path beyond what's stated, and none panics for any input —
+/// unknown ids fail closed (see [`Lattice::dominates`]).
+pub trait Lattice: Send + Sync {
+    /// `clearance ⊒ label` — does the subject clearance dominate (is at least as high as)
+    /// the object label? This is the MAC floor's core comparison (design §3 per-op
+    /// dominance, §13 "exact lattice comparison").
+    ///
+    /// S1-ASSUMPTION: TOTAL. For two *known* labels returns the exact partial-order
+    /// result. If EITHER label is unknown to this lattice generation, MUST return `false`
+    /// (fail closed — unlabeled = denied, design §1 invariant 2). Never panics.
+    fn dominates(&self, clearance: SecurityLabel, label: SecurityLabel) -> bool;
+
+    /// IFC join — least upper bound of two labels (design §3: a derived layer's label =
+    /// join(inputs); aggregation can't launder classification).
+    ///
+    /// S1-ASSUMPTION: TOTAL and well-defined for every known pair (the lattice has a top,
+    /// or joins are closed). If either input is unknown, MUST return the lattice **top**
+    /// (the most restrictive label) so an unknown input can only *raise* classification,
+    /// never lower it. Returned label is always known.
+    fn join(&self, a: SecurityLabel, b: SecurityLabel) -> SecurityLabel;
+
+    /// Whether `label` is a known point in *this* lattice generation. Used by the floor to
+    /// reject unlabeled subjects/objects before any grant logic runs.
+    ///
+    /// S1-ASSUMPTION: `is_known(SecurityLabel::BOTTOM)` is always `true`.
+    fn is_known(&self, label: SecurityLabel) -> bool;
+
+    /// The lattice top (most restrictive / highest). Used as the fail-closed join result.
+    ///
+    /// S1-ASSUMPTION: dominated-by-nothing-below; `dominates(top, x) == true` for all known
+    /// `x`.
+    fn top(&self) -> SecurityLabel;
+}
+
+/// IFC convenience: join a slice of input labels into the derived label (design §3 — sealed
+/// at rollup). Folds with [`Lattice::join`]; empty input yields BOTTOM. This is the function
+/// S6/seal-time labeling calls; it lives here because it is pure lattice algebra.
+pub fn ifc_join<L: Lattice + ?Sized>(lattice: &L, inputs: &[SecurityLabel]) -> SecurityLabel {
+    inputs
+        .iter()
+        .copied()
+        .fold(SecurityLabel::BOTTOM, |acc, x| lattice.join(acc, x))
+}
+
+// ---------------------------------------------------------------------------------------
+// A minimal in-tree lattice so S4 is testable/runnable BEFORE S1 lands. This is a STUB:
+// a flat MLS chain (BOTTOM=0 ⊑ 1 ⊑ 2 ⊑ ...) with no compartments. S1 replaces it. The TE
+// evaluator and AVC never reference this type — only the `Lattice` trait — so swapping in
+// S1's implementation is a one-line change at construction sites.
+// ---------------------------------------------------------------------------------------
+
+/// Stub linear-order lattice for S4-local testing. **Replace with S1.**
+///
+/// Levels `0..=max` form a total chain; `dominates(a,b) = a >= b`; `join(a,b) = max(a,b)`.
+/// No compartments, no real type lattice. Marked clearly so it is not mistaken for the real
+/// engine.
+#[derive(Debug, Clone)]
+pub struct StubLinearLattice {
+    max_level: u32,
+}
+
+impl StubLinearLattice {
+    /// Levels `0..=max_level` are known.
+    pub fn new(max_level: u32) -> Self {
+        Self { max_level }
+    }
+}
+
+impl Lattice for StubLinearLattice {
+    fn dominates(&self, clearance: SecurityLabel, label: SecurityLabel) -> bool {
+        if !self.is_known(clearance) || !self.is_known(label) {
+            return false; // fail closed
+        }
+        clearance.0 >= label.0
+    }
+
+    fn join(&self, a: SecurityLabel, b: SecurityLabel) -> SecurityLabel {
+        if !self.is_known(a) || !self.is_known(b) {
+            return self.top(); // fail closed — unknown can only raise
+        }
+        SecurityLabel(a.0.max(b.0))
+    }
+
+    fn is_known(&self, label: SecurityLabel) -> bool {
+        label.0 <= self.max_level
+    }
+
+    fn top(&self) -> SecurityLabel {
+        SecurityLabel(self.max_level)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stub_dominance_is_chain() {
+        let l = StubLinearLattice::new(3);
+        assert!(l.dominates(SecurityLabel(2), SecurityLabel(1)));
+        assert!(l.dominates(SecurityLabel(1), SecurityLabel(1)));
+        assert!(!l.dominates(SecurityLabel(1), SecurityLabel(2)));
+    }
+
+    #[test]
+    fn unknown_label_fails_closed() {
+        let l = StubLinearLattice::new(3);
+        // 9 is unknown -> dominates must be false either way (fail closed)
+        assert!(!l.dominates(SecurityLabel(9), SecurityLabel(1)));
+        assert!(!l.dominates(SecurityLabel(3), SecurityLabel(9)));
+        // join with unknown returns top
+        assert_eq!(l.join(SecurityLabel(9), SecurityLabel(1)), l.top());
+    }
+
+    #[test]
+    fn ifc_join_raises_to_max() {
+        let l = StubLinearLattice::new(3);
+        let labels = [SecurityLabel(1), SecurityLabel(3), SecurityLabel(2)];
+        assert_eq!(ifc_join(&l, &labels), SecurityLabel(3));
+        assert_eq!(ifc_join(&l, &[]), SecurityLabel::BOTTOM);
+    }
+}

--- a/crates/hyprstream/src/mac/mod.rs
+++ b/crates/hyprstream/src/mac/mod.rs
@@ -3,10 +3,12 @@
 //! This is ticket **S4 (#570)** of the native-MAC security epic (#547): the data-plane
 //! authorization engine. It implements, against an assumed S1 lattice interface:
 //!
-//! - [`lattice`] — the **assumed S1 contract** (`Lattice` trait + `SecurityLabel`). S1 (#567)
-//!   owns the real implementation; everything here is built against the trait so the two
-//!   streams reconcile by S1 satisfying the documented `S1-ASSUMPTION` notes. Ships a clearly
-//!   marked `StubLinearLattice` so S4 is testable before S1 lands.
+//! - [`lattice`] — a thin **re-export of S1's canonical types** (#567): the structured
+//!   `SecurityLabel` (Level × Assurance × CompartmentSet, `Copy + Ord + Hash`, no `Default`),
+//!   the `Lattice` *policy object* (closed compartment name↔bit vocabulary, versioned), and
+//!   `SecurityContext`. Dominance/join are INTRINSIC to the label, not trait methods — the
+//!   PDP floor calls them directly. (The original S4 stub lattice was deleted at
+//!   reconciliation; see the `lattice` module docs.)
 //! - [`te`] — the **type-enforcement evaluator**: a TOTAL, default-deny
 //!   `(subject_ctx, object_label, action) → Decision` over the compiled TE matrix AND the
 //!   independent lattice floor. Small + verifiable. This is the PDP core.
@@ -47,7 +49,8 @@
 //! ## TCB note
 //!
 //! The per-op TCB is intentionally tiny: a hash lookup ([`avc`]), and on a miss a set lookup
-//! plus one lattice `dominates` call ([`te`]). All heavy/bug-prone logic (Casbin matching,
+//! plus one intrinsic `SecurityLabel::dominates` call ([`te`]). All heavy/bug-prone logic
+//! (Casbin matching,
 //! UCAN chain validation, compilation, signature verification) is concentrated off the hot
 //! path — in PolicyService and the [`compiled`] loader, the one audited place (design §2).
 
@@ -62,8 +65,14 @@ pub use compiled::{
     sign_policy, CompiledPolicy, PolicyApproval, PolicyDistError, PolicyLoader, PolicySigner,
     PolicyVerifier, SignedPolicy,
 };
-pub use lattice::{ifc_join, Lattice, SecurityLabel};
+// Lattice surface is now S1's canonical types (#567), re-exported through `lattice` so the
+// PDP has one import path. `ifc_join` is the local forwarder over the intrinsic join.
+pub use lattice::{
+    ifc_join, Assurance, Compartment, CompartmentSet, LabelError, Lattice, LatticeCodecError,
+    LatticeDecodeError, LatticeVersion, Level, SecurityContext, SecurityLabel,
+    SubjectContextClaims, VerifiedKeyMaterial, MAX_COMPARTMENTS,
+};
 pub use te::{
-    Action, Decision, LatticeTeEvaluator, ObjectCtx, ObjectType, SubjectCtx, SubjectType,
-    TeEvaluator, TeMatrix, TeRule,
+    Action, Decision, LatticeTeEvaluator, ObjectCtx, ObjectType, ScopeAction, SubjectCtx,
+    SubjectType, TeEvaluator, TeMatrix, TeRule,
 };

--- a/crates/hyprstream/src/mac/mod.rs
+++ b/crates/hyprstream/src/mac/mod.rs
@@ -1,0 +1,69 @@
+//! Mandatory Access Control — the **Policy Decision Point** (PDP) for the 9P/VFS surface.
+//!
+//! This is ticket **S4 (#570)** of the native-MAC security epic (#547): the data-plane
+//! authorization engine. It implements, against an assumed S1 lattice interface:
+//!
+//! - [`lattice`] — the **assumed S1 contract** (`Lattice` trait + `SecurityLabel`). S1 (#567)
+//!   owns the real implementation; everything here is built against the trait so the two
+//!   streams reconcile by S1 satisfying the documented `S1-ASSUMPTION` notes. Ships a clearly
+//!   marked `StubLinearLattice` so S4 is testable before S1 lands.
+//! - [`te`] — the **type-enforcement evaluator**: a TOTAL, default-deny
+//!   `(subject_ctx, object_label, action) → Decision` over the compiled TE matrix AND the
+//!   independent lattice floor. Small + verifiable. This is the PDP core.
+//! - [`avc`] — the **Access Vector Cache**: the fast local decision cache the PEP (S2) calls
+//!   per op. Sub-µs hits (hash lookup, no Casbin, no signature verify, no lattice walk on a
+//!   hit). Defines how an OAuth access token maps to a cached decision (token = distributed
+//!   AVC entry).
+//! - [`compiled`] — **compiled-policy distribution + signing**: PolicyService hashes + signs
+//!   the TE matrix (hybrid EdDSA + ML-DSA-65 COSE composite); the loader rejects any
+//!   unsigned/mismatched/unapproved policy. Verification happens ONCE at load, never per op.
+//!
+//! ## The control-plane / data-plane split (be explicit)
+//!
+//! ```text
+//! CONTROL PLANE (authoring / compilation store)      DATA PLANE (per-op enforcement)
+//! ─────────────────────────────────────────────      ───────────────────────────────────
+//! UCAN                  the grant/delegation source
+//! Casbin Enforcer       policy STORE + AUTHORING      ── NEVER on the per-op hot path ──
+//!   (auth::policy_manager::PolicyManager)
+//! S5 UCAN→TE compiler   lowers Casbin/UCAN → matrix──► TeMatrix         (compiled object code)
+//! PolicyService         compiles + SIGNS policy ─────► compiled::SignedPolicy
+//!                                                      │ loader verifies ONCE
+//!                                                      ▼
+//!                                                      te::LatticeTeEvaluator  (the PDP)
+//!                                                      avc::CachingAvc          (the cache)
+//!                                                      ▲ PEP (S2) calls per op
+//! ```
+//!
+//! **Casbin stays control-plane.** The existing `casbin::Enforcer` in
+//! [`crate::auth::policy_manager::PolicyManager`] remains the policy store and authoring
+//! surface (RBAC/ABAC string matching, templates, `add_policy`/`apply_template`). Its
+//! `enforce()` string-matcher is **never** invoked per op — that would blow the latency
+//! budget and enlarge the TCB. Instead, S5's compiler lowers the authored policy into the
+//! compact [`te::TeMatrix`] (interned-id allow-set, O(1) lookup), which this PDP evaluates.
+//! The mandatory lattice floor is **independent of Casbin entirely** (design §5a: "the
+//! lattice is NOT encoded in Casbin").
+//!
+//! ## TCB note
+//!
+//! The per-op TCB is intentionally tiny: a hash lookup ([`avc`]), and on a miss a set lookup
+//! plus one lattice `dominates` call ([`te`]). All heavy/bug-prone logic (Casbin matching,
+//! UCAN chain validation, compilation, signature verification) is concentrated off the hot
+//! path — in PolicyService and the [`compiled`] loader, the one audited place (design §2).
+
+pub mod avc;
+pub mod compiled;
+pub mod lattice;
+pub mod te;
+
+// Re-export the per-op contract surface S2 (PEP) and S5/S6 (policy producers) consume.
+pub use avc::{Avc, AvcKey, CachingAvc, TokenScope};
+pub use compiled::{
+    sign_policy, CompiledPolicy, PolicyApproval, PolicyDistError, PolicyLoader, PolicySigner,
+    PolicyVerifier, SignedPolicy,
+};
+pub use lattice::{ifc_join, Lattice, SecurityLabel};
+pub use te::{
+    Action, Decision, LatticeTeEvaluator, ObjectCtx, ObjectType, SubjectCtx, SubjectType,
+    TeEvaluator, TeMatrix, TeRule,
+};

--- a/crates/hyprstream/src/mac/te.rs
+++ b/crates/hyprstream/src/mac/te.rs
@@ -10,22 +10,37 @@
 //! ```text
 //! PERMIT(subject, object, action) ⟺
 //!       te_matrix.permits(subject.type, object.type, action)   ← compiled TE (authority gate)
-//!     ∧ lattice.dominates(subject.clearance, object.label)     ← MAC floor (content-truth, IFC)
+//!     ∧ subject.clearance ⊒ object.label                       ← MAC floor (content-truth, IFC)
 //! ```
 //!
-//! The lattice floor is **independent and uncircumventable** — no TE entry, grant, or token
-//! can relax it (design §1 invariant 3). Default is DENY: an unknown subject type, object
-//! type, action, or unlabeled object → DENY. There is no permissive mode.
+//! The lattice floor is the **intrinsic** dominance on S1's [`SecurityLabel`]
+//! ([`SecurityLabel::dominates`]) — it takes no policy argument and no `Lattice` lookup, so it
+//! is uncircumventable: no TE entry, grant, or token can relax it (design §1 invariant 3).
+//! Default is DENY: an unknown subject type, object type, action, or a non-dominating /
+//! unlabeled clearance → DENY. There is no permissive mode.
+//!
+//! ## S1 reconciliation (#567 landed)
+//!
+//! - The floor is S1's intrinsic [`SecurityLabel::dominates`], not a `Lattice::dominates`
+//!   trait method. The evaluator still holds the S1 [`Lattice`] policy object, but only for
+//!   *well-formedness* concerns (column alignment / validation / version binding), never for
+//!   the per-op order.
+//! - The subject's `clearance` carried in [`SubjectCtx`] is the clearance label the PEP
+//!   already produced from a verified [`SecurityContext`] (assurance clamped to the verified
+//!   key material — #548). The PEP, not this evaluator, applies that clamp.
+//! - "Unlabeled ⇒ deny" lives at the PEP boundary: a subject/object with no S1 label is
+//!   `Option::None` and never reaches `evaluate`. There is deliberately no `Default`
+//!   [`SecurityLabel`].
 //!
 //! ## Relationship to the AVC and to Casbin
 //!
-//! - The [`AvcEvaluator`](crate::mac::avc) caches the *output* of this function so the PEP
-//!   (S2) never re-runs it per op once warm. This evaluator is what fills the cache on a
-//!   miss, and is itself cheap enough to be the miss path.
+//! - The AVC ([`crate::mac::avc`]) caches the *output* of this function so the PEP (S2) never
+//!   re-runs it per op once warm. This evaluator is what fills the cache on a miss, and is
+//!   itself cheap enough to be the miss path.
 //! - Casbin authors the policy; S5's compiler lowers it into the [`TeMatrix`] entries this
 //!   evaluator reads. Casbin's `Enforcer::enforce` is NEVER on this path.
 
-use crate::mac::lattice::{Lattice, SecurityLabel};
+use crate::mac::lattice::{Compartment, Lattice, SecurityLabel};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
@@ -40,11 +55,63 @@ pub struct SubjectType(pub u32);
 #[serde(transparent)]
 pub struct ObjectType(pub u32);
 
-/// Interned id of an *action* / op (9p walk/open/read/write/create/remove + RPC ops).
-/// One per distinct op in the compiled policy. Maps from the UCAN `cmd` at compile time.
+/// Interned id of an *action* / op. One per distinct op in the compiled policy. Maps from
+/// S3's action vocabulary at compile time — see [`Action::from_scope_action`] for the
+/// canonical [`ScopeAction`]→id assignment so a compiled matrix and a PEP agree on ids.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Action(pub u32);
+
+/// S3's canonical action vocabulary (#569), mirrored from the Cap'n Proto `ScopeAction`
+/// enum in `hyprstream-rpc/schema/annotations.capnp` (`$mcpScope(...)`). Keeping the
+/// discriminants 1:1 with that schema enum is what lets S5's UCAN→TE compiler and the PEP
+/// intern the same `cmd`/`$scope` to the same [`Action`] id without a side table.
+///
+/// Note (minimal handling, per #570): `Subscribe`/`Publish` exist in the `ScopeAction`
+/// schema enum but have **no dedicated `auth::Operation` Rust variant** today. They are
+/// represented here so streaming ops are interned to a *stable* id; the
+/// control-plane `Operation` parity for them lands with the streaming-scope work. The
+/// remaining variants line up 1:1 with `auth::Operation` (`Query`/`Write`/`Manage`/
+/// `Infer`/`Train`/`Serve`/`Context`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(u32)]
+pub enum ScopeAction {
+    /// `query @0` ⇄ `Operation::Query`.
+    Query = 0,
+    /// `write @1` ⇄ `Operation::Write`.
+    Write = 1,
+    /// `manage @2` ⇄ `Operation::Manage`.
+    Manage = 2,
+    /// `infer @3` ⇄ `Operation::Infer`.
+    Infer = 3,
+    /// `train @4` ⇄ `Operation::Train`.
+    Train = 4,
+    /// `serve @5` ⇄ `Operation::Serve`.
+    Serve = 5,
+    /// `context @6` ⇄ `Operation::Context`.
+    Context = 6,
+    /// `subscribe @7` — streaming read; no `Operation` parity yet (handled minimally).
+    Subscribe = 7,
+    /// `publish @8` — streaming write; no `Operation` parity yet (handled minimally).
+    Publish = 8,
+}
+
+impl Action {
+    /// Intern a canonical S3 [`ScopeAction`] to its stable [`Action`] id. The id IS the
+    /// schema discriminant, so the assignment is fixed across the compiler and every PEP
+    /// (no per-process numbering drift).
+    #[inline]
+    pub const fn from_scope_action(a: ScopeAction) -> Self {
+        Action(a as u32)
+    }
+}
+
+impl From<ScopeAction> for Action {
+    #[inline]
+    fn from(a: ScopeAction) -> Self {
+        Action::from_scope_action(a)
+    }
+}
 
 /// The decision a PDP returns. Three-valued per design §8 — `Escalate` is a
 /// *deny-on-the-data-plane* that the control plane may turn into a ceiling-amendment flow,
@@ -70,23 +137,28 @@ impl Decision {
 
 /// The subject's security context as the evaluator sees it: a TE type (domain) plus the
 /// lattice clearance. Built by the PEP from the Ed25519-verified token/claims (design §2
-/// "subject ctx from Ed25519 claims"). Both fields are interned ids — cheap to pass per op.
+/// "subject ctx from Ed25519 claims") via S1's [`SecurityContext`] — the clearance carried
+/// here is `SecurityContext::clearance()`, with assurance already clamped to the verified
+/// key material (#548). The TE type is an interned id; the clearance is S1's `Copy`
+/// structured label — both cheap to pass per op.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct SubjectCtx {
     /// TE subject type (SELinux domain).
     pub subject_type: SubjectType,
-    /// Lattice clearance — checked against the object label by the MAC floor.
+    /// Lattice clearance (S1 structured label) — checked against the object label by the
+    /// MAC floor via intrinsic dominance.
     pub clearance: SecurityLabel,
 }
 
 /// The object's security context: a TE object type plus its content-bound label. The label
 /// comes ONLY from the content-addressed manifest (design §3, §14 "labels ONLY from
-/// manifests"), never from a token. The PEP resolves it before calling the evaluator.
+/// manifests"), never from a token. The PEP resolves it (S1 `LabeledObject::security_label`,
+/// `None` ⇒ deny before this point) before calling the evaluator.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ObjectCtx {
     /// TE object type.
     pub object_type: ObjectType,
-    /// Content-bound label from the manifest.
+    /// Content-bound label (S1 structured label) from the manifest.
     pub label: SecurityLabel,
 }
 
@@ -167,21 +239,32 @@ pub trait TeEvaluator: Send + Sync {
 
     /// The policy generation this evaluator answers for. The AVC tags cached entries with
     /// it so a policy reload invalidates stale decisions (no per-op staleness check beyond
-    /// a generation-counter compare).
+    /// a generation-counter compare). Equals the embedded lattice's
+    /// [`LatticeVersion::generation`].
     fn generation(&self) -> u64;
 }
 
-/// Concrete PDP: a compiled [`TeMatrix`] + a [`Lattice`]. Small, total, allocation-free on
-/// the hot path. This is the verifiable TCB core.
-pub struct LatticeTeEvaluator<L: Lattice> {
+/// Concrete PDP: a compiled [`TeMatrix`] + the S1 [`Lattice`] policy object. Small, total,
+/// allocation-free on the hot path. This is the verifiable TCB core.
+///
+/// The [`Lattice`] is held for *well-formedness* and *column alignment*, NOT for the per-op
+/// order: the floor uses S1's intrinsic [`SecurityLabel::dominates`]. The PDP's `generation`
+/// is bound to `lattice.version().generation()` at construction — the desync-proof binding
+/// (#570): the same lattice bytes that minted a label's compartment bits also tag the
+/// compiled policy that evaluates it.
+pub struct LatticeTeEvaluator {
     matrix: TeMatrix,
-    lattice: L,
+    lattice: Lattice,
     generation: u64,
 }
 
-impl<L: Lattice> LatticeTeEvaluator<L> {
-    /// Construct from a compiled matrix, a lattice, and the policy generation id.
-    pub fn new(matrix: TeMatrix, lattice: L, generation: u64) -> Self {
+impl LatticeTeEvaluator {
+    /// Construct from a compiled matrix and the S1 lattice policy. The policy generation is
+    /// taken from the lattice version — they are definitionally equal (#570 reconciliation):
+    /// a compiled TE matrix is only valid against the lattice generation that minted its
+    /// compartment bit assignments.
+    pub fn new(matrix: TeMatrix, lattice: Lattice) -> Self {
+        let generation = lattice.version().generation();
         Self {
             matrix,
             lattice,
@@ -193,15 +276,31 @@ impl<L: Lattice> LatticeTeEvaluator<L> {
     pub fn matrix(&self) -> &TeMatrix {
         &self.matrix
     }
+
+    /// Borrow the lattice policy (column alignment / validation / re-serialization into the
+    /// signed `CompiledPolicy`).
+    pub fn lattice(&self) -> &Lattice {
+        &self.lattice
+    }
+
+    /// The compartment vocabulary in **canonical bit-index order** (`names()[i]` is the
+    /// compartment interned at bit `i`). A TE-matrix builder / compiler aligns its
+    /// compartment columns to label bits by iterating this — NEVER by hardcoding compartment
+    /// names — so a column index always equals the [`CompartmentSet`](crate::mac::lattice::CompartmentSet)
+    /// bit a [`SecurityLabel`] carries.
+    pub fn compartment_columns(&self) -> &[Compartment] {
+        self.lattice.compartment_names()
+    }
 }
 
-impl<L: Lattice> TeEvaluator for LatticeTeEvaluator<L> {
+impl TeEvaluator for LatticeTeEvaluator {
     #[inline]
     fn evaluate(&self, subject: SubjectCtx, object: ObjectCtx, action: Action) -> Decision {
-        // 1. MAC floor FIRST and independently — content-bound, uncircumventable.
-        //    Fail-closed: unknown/unlabeled or non-dominating clearance → DENY, regardless
-        //    of what the TE matrix says (design §1 inv.3, §10).
-        if !self.lattice.dominates(subject.clearance, object.label) {
+        // 1. MAC floor FIRST and independently — S1 intrinsic dominance, content-bound and
+        //    uncircumventable. Fail-closed: a non-dominating clearance → DENY, regardless of
+        //    what the TE matrix says (design §1 inv.3, §10). Unlabeled subject/object never
+        //    reach here (the PEP denies on `None` before constructing the contexts).
+        if !subject.clearance.dominates(&object.label) {
             return Decision::Deny;
         }
         // 2. Compiled TE decision (the authority gate). Default-deny by construction.
@@ -219,9 +318,10 @@ impl<L: Lattice> TeEvaluator for LatticeTeEvaluator<L> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use crate::mac::lattice::StubLinearLattice;
+    use crate::mac::lattice::{Assurance, Compartment, LatticeVersion, Level};
 
     fn rule(s: u32, o: u32, a: u32) -> TeRule {
         TeRule {
@@ -231,70 +331,150 @@ mod tests {
         }
     }
 
-    fn subj(t: u32, clr: u32) -> SubjectCtx {
+    fn lattice() -> Lattice {
+        Lattice::new(
+            LatticeVersion(7),
+            [Compartment::new("pii"), Compartment::new("finance")],
+        )
+    }
+
+    /// A clearance label at (level, assurance, compartment names).
+    fn clearance(level: Level, assurance: Assurance, names: &[&str]) -> SecurityLabel {
+        lattice()
+            .label(level, assurance, names.iter().map(|n| Compartment::new(*n)))
+            .unwrap()
+    }
+
+    fn subj(t: u32, clr: SecurityLabel) -> SubjectCtx {
         SubjectCtx {
             subject_type: SubjectType(t),
-            clearance: SecurityLabel(clr),
+            clearance: clr,
         }
     }
 
-    fn obj(t: u32, lbl: u32) -> ObjectCtx {
+    fn obj(t: u32, lbl: SecurityLabel) -> ObjectCtx {
         ObjectCtx {
             object_type: ObjectType(t),
-            label: SecurityLabel(lbl),
+            label: lbl,
         }
     }
 
-    fn eval() -> LatticeTeEvaluator<StubLinearLattice> {
+    fn eval() -> LatticeTeEvaluator {
         // Allow (subj=1, obj=1, act=1). Escalate (subj=1, obj=1, act=2).
         let mut allow = HashSet::new();
         allow.insert(rule(1, 1, 1));
         let mut escalate = HashSet::new();
         escalate.insert(rule(1, 1, 2));
-        LatticeTeEvaluator::new(
-            TeMatrix::new(allow, escalate),
-            StubLinearLattice::new(3),
-            7,
-        )
+        LatticeTeEvaluator::new(TeMatrix::new(allow, escalate), lattice())
+    }
+
+    #[test]
+    fn generation_bound_to_lattice_version() {
+        // #570 reconciliation: generation == LatticeVersion::generation.
+        assert_eq!(eval().generation(), 7);
     }
 
     #[test]
     fn permit_requires_te_and_floor() {
         let e = eval();
-        // TE allows AND clearance(2) ⊒ label(1): permit.
-        assert_eq!(e.evaluate(subj(1, 2), obj(1, 1), Action(1)), Decision::Permit);
+        let high = clearance(Level::Secret, Assurance::PqHybrid, &["pii"]);
+        let low = clearance(Level::Confidential, Assurance::Classical, &[]);
+        // TE allows AND clearance ⊒ label: permit.
+        assert_eq!(
+            e.evaluate(subj(1, high), obj(1, low), Action(1)),
+            Decision::Permit
+        );
     }
 
     #[test]
     fn floor_denies_even_when_te_allows() {
         let e = eval();
-        // TE allows but clearance(0) does NOT dominate label(1): floor denies.
-        assert_eq!(e.evaluate(subj(1, 0), obj(1, 1), Action(1)), Decision::Deny);
+        // TE allows but a Public clearance does NOT dominate a Secret label: floor denies.
+        let clr = clearance(Level::Public, Assurance::Classical, &[]);
+        let lbl = clearance(Level::Secret, Assurance::Classical, &[]);
+        assert_eq!(
+            e.evaluate(subj(1, clr), obj(1, lbl), Action(1)),
+            Decision::Deny
+        );
+    }
+
+    #[test]
+    fn floor_denies_on_missing_compartment() {
+        let e = eval();
+        // High level/assurance but NOT cleared into the object's "finance" compartment.
+        let clr = clearance(Level::Secret, Assurance::PqHybrid, &["pii"]);
+        let lbl = clearance(Level::Public, Assurance::Unverified, &["finance"]);
+        assert_eq!(
+            e.evaluate(subj(1, clr), obj(1, lbl), Action(1)),
+            Decision::Deny
+        );
+    }
+
+    #[test]
+    fn assurance_floor_denies_classical_on_pqc_object() {
+        // #548 via the SAME dominance check: a classical clearance can't read a pq-hybrid label.
+        let e = eval();
+        let clr = clearance(Level::Secret, Assurance::Classical, &["pii"]);
+        let lbl = clearance(Level::Public, Assurance::PqHybrid, &[]);
+        assert_eq!(
+            e.evaluate(subj(1, clr), obj(1, lbl), Action(1)),
+            Decision::Deny
+        );
     }
 
     #[test]
     fn default_deny_on_te_miss() {
         let e = eval();
-        // Floor holds (2 ⊒ 1) but no TE rule for action 9: deny.
-        assert_eq!(e.evaluate(subj(1, 2), obj(1, 1), Action(9)), Decision::Deny);
+        let high = clearance(Level::Secret, Assurance::PqHybrid, &["pii"]);
+        let low = clearance(Level::Public, Assurance::Classical, &[]);
+        // Floor holds but no TE rule for action 9: deny.
+        assert_eq!(
+            e.evaluate(subj(1, high), obj(1, low), Action(9)),
+            Decision::Deny
+        );
         // Unknown subject type: deny.
-        assert_eq!(e.evaluate(subj(5, 2), obj(1, 1), Action(1)), Decision::Deny);
+        assert_eq!(
+            e.evaluate(subj(5, high), obj(1, low), Action(1)),
+            Decision::Deny
+        );
     }
 
     #[test]
     fn escalate_is_not_a_permit_but_floor_still_first() {
         let e = eval();
+        let high = clearance(Level::Secret, Assurance::PqHybrid, &["pii"]);
+        let low = clearance(Level::Public, Assurance::Classical, &[]);
         // Floor holds, TE says escalate.
-        assert_eq!(e.evaluate(subj(1, 2), obj(1, 1), Action(2)), Decision::Escalate);
+        assert_eq!(
+            e.evaluate(subj(1, high), obj(1, low), Action(2)),
+            Decision::Escalate
+        );
         assert!(!Decision::Escalate.is_permit());
         // But if the floor fails, escalate downgrades to a hard deny (floor is independent).
-        assert_eq!(e.evaluate(subj(1, 0), obj(1, 1), Action(2)), Decision::Deny);
+        let pub_clr = clearance(Level::Public, Assurance::Classical, &[]);
+        let sec_lbl = clearance(Level::Secret, Assurance::Classical, &[]);
+        assert_eq!(
+            e.evaluate(subj(1, pub_clr), obj(1, sec_lbl), Action(2)),
+            Decision::Deny
+        );
     }
 
     #[test]
-    fn unlabeled_object_fails_closed() {
+    fn scope_action_interns_to_schema_discriminant() {
+        // Stable 1:1 with the capnp ScopeAction enum so compiler and PEP agree on ids.
+        assert_eq!(Action::from(ScopeAction::Query), Action(0));
+        assert_eq!(Action::from(ScopeAction::Context), Action(6));
+        assert_eq!(Action::from(ScopeAction::Subscribe), Action(7));
+        assert_eq!(Action::from(ScopeAction::Publish), Action(8));
+    }
+
+    #[test]
+    fn compartment_columns_align_to_bits() {
         let e = eval();
-        // Object label 99 is unknown to the lattice (max 3): floor denies (design §1 inv.2).
-        assert_eq!(e.evaluate(subj(1, 3), obj(1, 99), Action(1)), Decision::Deny);
+        let cols = e.compartment_columns();
+        // Column index == the bit a SecurityLabel carries for that compartment name.
+        assert_eq!(cols[0], Compartment::new("pii"));
+        assert_eq!(cols[1], Compartment::new("finance"));
+        assert_eq!(e.lattice().bit_of(&Compartment::new("finance")), Some(1));
     }
 }

--- a/crates/hyprstream/src/mac/te.rs
+++ b/crates/hyprstream/src/mac/te.rs
@@ -1,0 +1,300 @@
+//! Type-Enforcement evaluator — the **Policy Decision Point** hot-path core (S4 / #570).
+//!
+//! A TOTAL, default-deny function `(subject_ctx, object_label, action) → Decision` over the
+//! compiled TE matrix AND the independent MAC lattice floor. This is intentionally tiny and
+//! verifiable — it is the data-plane evaluator that runs per op. It is **NOT** Casbin's
+//! general string matcher (that stays control-plane; see [`crate::mac`] module docs).
+//!
+//! ## Two independent checks, conjoined (design §3, §10)
+//!
+//! ```text
+//! PERMIT(subject, object, action) ⟺
+//!       te_matrix.permits(subject.type, object.type, action)   ← compiled TE (authority gate)
+//!     ∧ lattice.dominates(subject.clearance, object.label)     ← MAC floor (content-truth, IFC)
+//! ```
+//!
+//! The lattice floor is **independent and uncircumventable** — no TE entry, grant, or token
+//! can relax it (design §1 invariant 3). Default is DENY: an unknown subject type, object
+//! type, action, or unlabeled object → DENY. There is no permissive mode.
+//!
+//! ## Relationship to the AVC and to Casbin
+//!
+//! - The [`AvcEvaluator`](crate::mac::avc) caches the *output* of this function so the PEP
+//!   (S2) never re-runs it per op once warm. This evaluator is what fills the cache on a
+//!   miss, and is itself cheap enough to be the miss path.
+//! - Casbin authors the policy; S5's compiler lowers it into the [`TeMatrix`] entries this
+//!   evaluator reads. Casbin's `Enforcer::enforce` is NEVER on this path.
+
+use crate::mac::lattice::{Lattice, SecurityLabel};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+/// Interned id of a TE *subject type* (SELinux "domain"). One per subject security context
+/// class in the compiled policy. Stable within a policy generation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SubjectType(pub u32);
+
+/// Interned id of a TE *object type*. One per object class in the compiled policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ObjectType(pub u32);
+
+/// Interned id of an *action* / op (9p walk/open/read/write/create/remove + RPC ops).
+/// One per distinct op in the compiled policy. Maps from the UCAN `cmd` at compile time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Action(pub u32);
+
+/// The decision a PDP returns. Three-valued per design §8 — `Escalate` is a
+/// *deny-on-the-data-plane* that the control plane may turn into a ceiling-amendment flow,
+/// but for the per-op monitor it is NOT a permit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Decision {
+    /// Access permitted: TE matrix grants it AND the lattice floor holds.
+    Permit,
+    /// Access denied (default; TE miss, floor failure, or explicit deny).
+    Deny,
+    /// Statically denied here, but eligible for an escalation-tier ceiling amendment
+    /// (design §8). The monitor treats this as DENY for the op; the control plane may act.
+    Escalate,
+}
+
+impl Decision {
+    /// Is this a permit? The only value the PEP may treat as "allow".
+    #[inline]
+    pub fn is_permit(self) -> bool {
+        matches!(self, Decision::Permit)
+    }
+}
+
+/// The subject's security context as the evaluator sees it: a TE type (domain) plus the
+/// lattice clearance. Built by the PEP from the Ed25519-verified token/claims (design §2
+/// "subject ctx from Ed25519 claims"). Both fields are interned ids — cheap to pass per op.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SubjectCtx {
+    /// TE subject type (SELinux domain).
+    pub subject_type: SubjectType,
+    /// Lattice clearance — checked against the object label by the MAC floor.
+    pub clearance: SecurityLabel,
+}
+
+/// The object's security context: a TE object type plus its content-bound label. The label
+/// comes ONLY from the content-addressed manifest (design §3, §14 "labels ONLY from
+/// manifests"), never from a token. The PEP resolves it before calling the evaluator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ObjectCtx {
+    /// TE object type.
+    pub object_type: ObjectType,
+    /// Content-bound label from the manifest.
+    pub label: SecurityLabel,
+}
+
+/// A single permitted TE triple `(subject_type, object_type, action)`. The compiled matrix
+/// is the *allow-set* of these triples (default-deny: absence = deny). Produced by S5's
+/// UCAN→TE compiler.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct TeRule {
+    pub subject_type: SubjectType,
+    pub object_type: ObjectType,
+    pub action: Action,
+}
+
+/// The compiled type-enforcement matrix: a flat allow-set of [`TeRule`]s. Default-deny —
+/// any triple not present is denied. This is the data-plane artifact loaded from signed
+/// compiled policy (see [`crate::mac::compiled`]). Kept as a `HashSet` so the hot-path
+/// lookup is O(1); it is also the unit S5 produces and `compiled` signs.
+///
+/// Optionally carries an *escalation-set*: triples that, while not permitted, are eligible
+/// for a ceiling-amendment (design §8). A triple in neither set is a hard `Deny`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TeMatrix {
+    allow: HashSet<TeRule>,
+    escalate: HashSet<TeRule>,
+}
+
+impl TeMatrix {
+    /// Build from explicit allow/escalate rule sets (the shape S5's compiler emits).
+    pub fn new(allow: HashSet<TeRule>, escalate: HashSet<TeRule>) -> Self {
+        Self { allow, escalate }
+    }
+
+    /// Build an allow-only matrix (no escalation band).
+    pub fn from_allow(allow: impl IntoIterator<Item = TeRule>) -> Self {
+        Self {
+            allow: allow.into_iter().collect(),
+            escalate: HashSet::new(),
+        }
+    }
+
+    /// Number of allow rules (for diagnostics / matrix hashing sanity).
+    pub fn allow_len(&self) -> usize {
+        self.allow.len()
+    }
+
+    /// Sorted-vec projection of the allow/escalate sets, for canonical (order-stable)
+    /// encoding/hashing in [`crate::mac::compiled`]. Returns `(allow, escalate)`; the caller
+    /// sorts. The hot path never calls this.
+    pub fn sorted_rules(&self) -> (Vec<TeRule>, Vec<TeRule>) {
+        (
+            self.allow.iter().copied().collect(),
+            self.escalate.iter().copied().collect(),
+        )
+    }
+
+    /// Raw TE decision for a triple, *without* the lattice floor. Total + default-deny.
+    /// Pure on the matrix contents — this is the part S5 produces policy for.
+    #[inline]
+    pub fn te_decision(&self, rule: TeRule) -> Decision {
+        if self.allow.contains(&rule) {
+            Decision::Permit
+        } else if self.escalate.contains(&rule) {
+            Decision::Escalate
+        } else {
+            Decision::Deny
+        }
+    }
+}
+
+/// The Policy Decision Point evaluator interface — **what S2 (the PEP) calls per op**.
+///
+/// Implementations are TOTAL and default-deny: every well-formed call returns a [`Decision`]
+/// and never panics. This is the clean contract the AVC wraps and S5/S6 produce policy for.
+pub trait TeEvaluator: Send + Sync {
+    /// Evaluate one operation. TOTAL, default-deny. Conjoins the compiled TE decision with
+    /// the independent lattice floor: a `Permit` requires BOTH; the floor can only deny.
+    fn evaluate(&self, subject: SubjectCtx, object: ObjectCtx, action: Action) -> Decision;
+
+    /// The policy generation this evaluator answers for. The AVC tags cached entries with
+    /// it so a policy reload invalidates stale decisions (no per-op staleness check beyond
+    /// a generation-counter compare).
+    fn generation(&self) -> u64;
+}
+
+/// Concrete PDP: a compiled [`TeMatrix`] + a [`Lattice`]. Small, total, allocation-free on
+/// the hot path. This is the verifiable TCB core.
+pub struct LatticeTeEvaluator<L: Lattice> {
+    matrix: TeMatrix,
+    lattice: L,
+    generation: u64,
+}
+
+impl<L: Lattice> LatticeTeEvaluator<L> {
+    /// Construct from a compiled matrix, a lattice, and the policy generation id.
+    pub fn new(matrix: TeMatrix, lattice: L, generation: u64) -> Self {
+        Self {
+            matrix,
+            lattice,
+            generation,
+        }
+    }
+
+    /// Borrow the matrix (diagnostics / re-signing).
+    pub fn matrix(&self) -> &TeMatrix {
+        &self.matrix
+    }
+}
+
+impl<L: Lattice> TeEvaluator for LatticeTeEvaluator<L> {
+    #[inline]
+    fn evaluate(&self, subject: SubjectCtx, object: ObjectCtx, action: Action) -> Decision {
+        // 1. MAC floor FIRST and independently — content-bound, uncircumventable.
+        //    Fail-closed: unknown/unlabeled or non-dominating clearance → DENY, regardless
+        //    of what the TE matrix says (design §1 inv.3, §10).
+        if !self.lattice.dominates(subject.clearance, object.label) {
+            return Decision::Deny;
+        }
+        // 2. Compiled TE decision (the authority gate). Default-deny by construction.
+        self.matrix.te_decision(TeRule {
+            subject_type: subject.subject_type,
+            object_type: object.object_type,
+            action,
+        })
+    }
+
+    #[inline]
+    fn generation(&self) -> u64 {
+        self.generation
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mac::lattice::StubLinearLattice;
+
+    fn rule(s: u32, o: u32, a: u32) -> TeRule {
+        TeRule {
+            subject_type: SubjectType(s),
+            object_type: ObjectType(o),
+            action: Action(a),
+        }
+    }
+
+    fn subj(t: u32, clr: u32) -> SubjectCtx {
+        SubjectCtx {
+            subject_type: SubjectType(t),
+            clearance: SecurityLabel(clr),
+        }
+    }
+
+    fn obj(t: u32, lbl: u32) -> ObjectCtx {
+        ObjectCtx {
+            object_type: ObjectType(t),
+            label: SecurityLabel(lbl),
+        }
+    }
+
+    fn eval() -> LatticeTeEvaluator<StubLinearLattice> {
+        // Allow (subj=1, obj=1, act=1). Escalate (subj=1, obj=1, act=2).
+        let mut allow = HashSet::new();
+        allow.insert(rule(1, 1, 1));
+        let mut escalate = HashSet::new();
+        escalate.insert(rule(1, 1, 2));
+        LatticeTeEvaluator::new(
+            TeMatrix::new(allow, escalate),
+            StubLinearLattice::new(3),
+            7,
+        )
+    }
+
+    #[test]
+    fn permit_requires_te_and_floor() {
+        let e = eval();
+        // TE allows AND clearance(2) ⊒ label(1): permit.
+        assert_eq!(e.evaluate(subj(1, 2), obj(1, 1), Action(1)), Decision::Permit);
+    }
+
+    #[test]
+    fn floor_denies_even_when_te_allows() {
+        let e = eval();
+        // TE allows but clearance(0) does NOT dominate label(1): floor denies.
+        assert_eq!(e.evaluate(subj(1, 0), obj(1, 1), Action(1)), Decision::Deny);
+    }
+
+    #[test]
+    fn default_deny_on_te_miss() {
+        let e = eval();
+        // Floor holds (2 ⊒ 1) but no TE rule for action 9: deny.
+        assert_eq!(e.evaluate(subj(1, 2), obj(1, 1), Action(9)), Decision::Deny);
+        // Unknown subject type: deny.
+        assert_eq!(e.evaluate(subj(5, 2), obj(1, 1), Action(1)), Decision::Deny);
+    }
+
+    #[test]
+    fn escalate_is_not_a_permit_but_floor_still_first() {
+        let e = eval();
+        // Floor holds, TE says escalate.
+        assert_eq!(e.evaluate(subj(1, 2), obj(1, 1), Action(2)), Decision::Escalate);
+        assert!(!Decision::Escalate.is_permit());
+        // But if the floor fails, escalate downgrades to a hard deny (floor is independent).
+        assert_eq!(e.evaluate(subj(1, 0), obj(1, 1), Action(2)), Decision::Deny);
+    }
+
+    #[test]
+    fn unlabeled_object_fails_closed() {
+        let e = eval();
+        // Object label 99 is unknown to the lattice (max 3): floor denies (design §1 inv.2).
+        assert_eq!(e.evaluate(subj(1, 3), obj(1, 99), Action(1)), Decision::Deny);
+    }
+}


### PR DESCRIPTION
Part of epic #547. Rebased clean on S1 (#567) @ `406ff9fdc`.

## Reconciliation (consumes S1's canonical types)
- **lattice.rs**: stub `SecurityLabel(u32)`/local `Lattice` trait/`StubLinearLattice` **deleted**; re-exports S1's `hyprstream_rpc::auth::mac::{SecurityLabel, Lattice, SecurityContext, Level, Assurance, CompartmentSet, LatticeVersion, ...}`.
- **te.rs**: MAC floor uses S1 **intrinsic** `clearance.dominates(&label)`; TE columns aligned to bits via `lattice.compartment_names()` (no hardcoded compartments); `generation` bound to `lattice.version().generation()`.
- **avc.rs**: keys on S1 `SecurityLabel` (Copy+Hash); per-op hit stays a pure hash lookup.
- **compiled.rs**: `CompiledPolicy` embeds the lattice via `to_bytes()` (CBOR, same codec as COSE) folded into the signed canonical bytes; **`LatticeGenerationMismatch` guard** at load → desync-proof across processes.
- Layering preserved (types in hyprstream-rpc, PDP in hyprstream; Casbin control-plane only).

## ⚠️ Merge-gate items (honest)
- **Not compiled here**: `LIBTORCH` unset → `torch-sys` fails before `hyprstream` type-checks. **Must build/test in a LIBTORCH env.** `cargo check -p hyprstream-rpc` passes (S1 types sound, all re-exports exist); stub refs grep-clean; S1 API calls hand-verified.
- **Sequencing**: merge **after #582 (S3)** so it picks up S3's `Operation` vocabulary; S4 currently mirrors the capnp `ScopeAction`. Files disjoint → clean coexistence.
- **Known gap**: `auth::Operation` lacks `Subscribe`/`Publish` variants; S4 mirrors `ScopeAction` minimally — follow-up for S5 / an S3 amendment.