### PR TITLE
ci(rpm): only run RPM build on packaging changes or release tags

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -8,9 +8,6 @@ on:
     paths:
       - 'packaging/rpm/**'
       - '.github/workflows/rpm.yml'
-      - 'crates/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
   workflow_dispatch:
 
 env:
@@ -18,7 +15,7 @@ env:
 
 jobs:
   # Build the RPM and install it inside Fedora and Rocky containers.
-  # Runs on every PR touching packaging/build inputs, and on release tags.
+  # Runs on PRs that touch the RPM packaging, and on release tags.
   build-install:
     name: Build + install (${{ matrix.distro.name }})
     runs-on: ubuntu-latest

--- a/crates/hyprstream-rpc/src/auth/mac/context.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/context.rs
@@ -1,0 +1,262 @@
+//! The **subject security context** — a subject's verified clearance, the
+//! `subject.ctx` side of the per-op dominance check `subject.ctx ⊒ object.label`.
+//!
+//! A subject context is the [`SecurityLabel`] a verified principal is cleared
+//! up to. Where the *object* label is content-bound (in a manifest), the
+//! *subject* context rides the verified claims/envelope (design §3, §11 data
+//! structures: `subject ctx in the verified claims/envelope`).
+//!
+//! ## Where it lives on the wire
+//!
+//! The subject context is **derived**, not self-asserted. Two inputs feed it,
+//! both already verified by the time the monitor runs:
+//! 1. The principal's **clearance** (level + compartments) — assigned by policy
+//!    / enrollment and carried in the verified [`crate::auth::Claims`] (the JWT
+//!    is signed by the issuing node, so the clearance is authority-asserted,
+//!    not subject-asserted). The wire field is added by the
+//!    [`SubjectContextClaims`] seam below; the actual `Claims`/`common.capnp`
+//!    field add is gated on S8/#574 (hybrid envelope) — see BLOCKERS.
+//! 2. The principal's **assurance** (#548) — derived from the *verified key
+//!    material*, never claimed. See [`SecurityContext::derive_assurance`].
+//!
+//! ## Fail-closed
+//!
+//! A subject with no derivable clearance has **no context** (`None`), and the
+//! monitor denies — there is no `Default` clearance. Assurance defaults to
+//! [`Assurance::Unverified`] (the floor) precisely so an un-attested key
+//! dominates nothing above the floor.
+
+use super::label::{Assurance, CompartmentSet, Level, SecurityLabel};
+use serde::{Deserialize, Serialize};
+
+/// How a principal's key material was verified, used to *derive* (never trust) an
+/// [`Assurance`]. Produced by the envelope/claims verification layer — this type
+/// is the seam between "what crypto verified" and "what the lattice sees".
+///
+/// This intentionally mirrors the existing crypto reality (`crypto/pq.rs`,
+/// `register_pq_trust`, [`crate::crypto::CryptoPolicy`]): an Ed25519 identity is
+/// `Classical` until a bound ML-DSA-65 anchor lifts it to `PqHybrid`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum VerifiedKeyMaterial {
+    /// Identity / signature could not be verified at all → floor.
+    Unverified,
+    /// A classical signature verified (Ed25519 / p256 / secp256k1), and no
+    /// bound post-quantum anchor is present. The federation edge.
+    Classical,
+    /// A hybrid composite verified: an Ed25519 identity with a bound ML-DSA-65
+    /// verifying key (the `register_pq_trust` binding) under
+    /// [`crate::crypto::CryptoPolicy::Hybrid`].
+    PqHybrid,
+}
+
+impl VerifiedKeyMaterial {
+    /// Map verified key material → the assurance lattice axis (#548). This is
+    /// the *only* place assurance is assigned to a subject; it is a function of
+    /// verified crypto, so it cannot be spoofed by a claim.
+    pub fn assurance(self) -> Assurance {
+        match self {
+            VerifiedKeyMaterial::Unverified => Assurance::Unverified,
+            VerifiedKeyMaterial::Classical => Assurance::Classical,
+            VerifiedKeyMaterial::PqHybrid => Assurance::PqHybrid,
+        }
+    }
+}
+
+/// A verified subject's security context = the clearance label the monitor
+/// compares against object labels.
+///
+/// Construction is deliberately gated: you build it from a *clearance* (level +
+/// compartments, authority-asserted) and *verified key material* (assurance,
+/// crypto-derived). The assurance axis of the resulting label is ALWAYS the
+/// derived one — a caller cannot pass in a higher assurance than the crypto
+/// supports.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SecurityContext {
+    /// The full clearance label (level + assurance + compartments). The
+    /// assurance component is crypto-derived; see [`SecurityContext::new`].
+    clearance: SecurityLabel,
+}
+
+impl SecurityContext {
+    /// Build a subject context from an authority-asserted clearance
+    /// (`level` + `compartments`) and crypto-derived `key_material`.
+    ///
+    /// The resulting clearance's assurance axis is **clamped to** the derived
+    /// assurance — a classical key can never carry a `PqHybrid` clearance even
+    /// if policy mistakenly assigned one. This is the load-bearing invariant of
+    /// #548: assurance is a property of the verified identity, not a grant.
+    pub fn new(
+        level: Level,
+        compartments: CompartmentSet,
+        key_material: VerifiedKeyMaterial,
+    ) -> Self {
+        SecurityContext {
+            clearance: SecurityLabel::new(level, key_material.assurance(), compartments),
+        }
+    }
+
+    /// Build from a pre-assembled clearance label and verified key material,
+    /// clamping the assurance axis down to what the crypto supports.
+    ///
+    /// `min(clearance.assurance, derived)` — clamp DOWN only, never up. If
+    /// policy assigned `PqHybrid` but the key is `Classical`, the effective
+    /// assurance is `Classical` (fail-closed/least-privilege).
+    pub fn from_clearance(clearance: SecurityLabel, key_material: VerifiedKeyMaterial) -> Self {
+        let derived = key_material.assurance();
+        SecurityContext {
+            clearance: SecurityLabel {
+                assurance: clearance.assurance.min(derived),
+                ..clearance
+            },
+        }
+    }
+
+    /// Derive assurance directly from verified key material (#548).
+    /// Thin forwarder kept as a named entry-point so the enforcement/PDP layers
+    /// (S2/S4) have one obvious call site.
+    pub fn derive_assurance(key_material: VerifiedKeyMaterial) -> Assurance {
+        key_material.assurance()
+    }
+
+    /// The clearance label. This is the `subject.ctx` the monitor feeds into
+    /// `dominates(object_label)`.
+    pub fn clearance(&self) -> &SecurityLabel {
+        &self.clearance
+    }
+
+    /// `self ⊒ object` — does this subject context dominate the object's
+    /// content-bound label? The per-op MAC floor (design §10). Pure forward to
+    /// the intrinsic lattice order.
+    #[must_use]
+    pub fn dominates(&self, object_label: &SecurityLabel) -> bool {
+        self.clearance.dominates(object_label)
+    }
+
+    pub fn level(&self) -> Level {
+        self.clearance.level
+    }
+    pub fn assurance(&self) -> Assurance {
+        self.clearance.assurance
+    }
+    pub fn compartments(&self) -> CompartmentSet {
+        self.clearance.compartments
+    }
+}
+
+/// **Seam** for carrying a subject clearance on the verified claims/envelope.
+///
+/// S1 defines the *shape* of the clearance the claims must carry; the concrete
+/// wire field on [`crate::auth::Claims`] / `common.capnp` is added under S8
+/// (#574, hybrid envelope) so the new authz field ships on the hybrid-signed
+/// envelope rather than the classical one. Until then this trait is the typed
+/// contract S2/S4 program against, and a node assembles a [`SecurityContext`]
+/// by:
+///   1. reading the (future) `clearance` field off verified `Claims`, and
+///   2. deriving assurance from the envelope's verified key material.
+///
+/// Implementing this on `Claims` is a one-liner once the field lands; defining
+/// it now lets S2/S4 compile and test against a stable interface.
+pub trait SubjectContextClaims {
+    /// The authority-asserted clearance carried in the verified claims, if any.
+    /// `None` ⇒ unlabeled subject ⇒ the monitor MUST deny (no default clearance).
+    fn clearance_label(&self) -> Option<SecurityLabel>;
+
+    /// Assemble the full subject context, clamping assurance to the verified
+    /// key material. Returns `None` (→ deny) if the subject carries no
+    /// clearance. Default impl composes the two inputs; implementors normally
+    /// only need to provide [`clearance_label`].
+    ///
+    /// [`clearance_label`]: SubjectContextClaims::clearance_label
+    fn security_context(&self, key_material: VerifiedKeyMaterial) -> Option<SecurityContext> {
+        self.clearance_label()
+            .map(|c| SecurityContext::from_clearance(c, key_material))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    /// A compartment bitset from bit indices (the policy interns names → bits;
+    /// these tests work directly in bits).
+    fn comps(bits: &[u32]) -> CompartmentSet {
+        bits.iter().copied().collect()
+    }
+
+    #[test]
+    fn assurance_derived_from_key_material() {
+        assert_eq!(
+            VerifiedKeyMaterial::Unverified.assurance(),
+            Assurance::Unverified
+        );
+        assert_eq!(
+            VerifiedKeyMaterial::Classical.assurance(),
+            Assurance::Classical
+        );
+        assert_eq!(
+            VerifiedKeyMaterial::PqHybrid.assurance(),
+            Assurance::PqHybrid
+        );
+    }
+
+    #[test]
+    fn new_clamps_assurance_to_key_material() {
+        // Even at Secret level, a classical key yields a classical-assurance ctx.
+        let ctx = SecurityContext::new(Level::Secret, comps(&[0]), VerifiedKeyMaterial::Classical);
+        assert_eq!(ctx.assurance(), Assurance::Classical);
+        assert_eq!(ctx.level(), Level::Secret);
+    }
+
+    #[test]
+    fn from_clearance_clamps_down_never_up() {
+        // policy mistakenly assigned PqHybrid, but key is only Classical.
+        let claimed = SecurityLabel::new(Level::Secret, Assurance::PqHybrid, comps(&[0]));
+        let ctx = SecurityContext::from_clearance(claimed, VerifiedKeyMaterial::Classical);
+        assert_eq!(ctx.assurance(), Assurance::Classical); // clamped down
+    }
+
+    #[test]
+    fn from_clearance_does_not_raise_assurance() {
+        // policy assigned Classical, key is PqHybrid → stays Classical (no raise).
+        let claimed = SecurityLabel::new(Level::Internal, Assurance::Classical, CompartmentSet::EMPTY);
+        let ctx = SecurityContext::from_clearance(claimed, VerifiedKeyMaterial::PqHybrid);
+        assert_eq!(ctx.assurance(), Assurance::Classical);
+    }
+
+    #[test]
+    fn classical_context_cannot_dominate_pqc_object() {
+        let ctx = SecurityContext::new(Level::Secret, comps(&[0]), VerifiedKeyMaterial::Classical);
+        let pqc_object = SecurityLabel::new(Level::Public, Assurance::PqHybrid, CompartmentSet::EMPTY);
+        assert!(!ctx.dominates(&pqc_object));
+    }
+
+    struct FakeClaims(Option<SecurityLabel>);
+    impl SubjectContextClaims for FakeClaims {
+        fn clearance_label(&self) -> Option<SecurityLabel> {
+            self.0
+        }
+    }
+
+    #[test]
+    fn unlabeled_subject_has_no_context() {
+        let claims = FakeClaims(None);
+        assert!(claims
+            .security_context(VerifiedKeyMaterial::PqHybrid)
+            .is_none());
+    }
+
+    #[test]
+    fn labeled_subject_assembles_context_with_clamped_assurance() {
+        let claims = FakeClaims(Some(SecurityLabel::new(
+            Level::Confidential,
+            Assurance::PqHybrid,
+            comps(&[0]),
+        )));
+        let ctx = claims
+            .security_context(VerifiedKeyMaterial::Classical)
+            .unwrap();
+        assert_eq!(ctx.level(), Level::Confidential);
+        assert_eq!(ctx.assurance(), Assurance::Classical); // clamped to verified key
+    }
+}

--- a/crates/hyprstream-rpc/src/auth/mac/genesis.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/genesis.rs
@@ -1,0 +1,211 @@
+//! **Genesis labeling** — the initial-SID / `file_contexts` equivalent.
+//!
+//! Design §1 invariant 2 + the S1 acceptance criteria: *every* existing object
+//! and service must carry a label **before** enforcement turns on. Without
+//! genesis, enabling MAC denies everything (an unlabeled object = deny). With a
+//! *permissive* genesis (label-everything-public), MAC is a no-op. So genesis
+//! is the security-critical bootstrap: it must be **explicit, total, and
+//! audited** — every static node mapped to a declared label, with NO catch-all
+//! that silently lifts coverage.
+//!
+//! This module provides the genesis *mechanism* (a deterministic map from node
+//! path → label, with a completeness check). The genesis *content* (the actual
+//! path→label table) comes from the schema `$scope`/TE annotations (S3, #569)
+//! and site policy; S1 supplies the seam + the fail-closed completeness gate.
+//!
+//! Key property: [`GenesisMap::resolve`] returns `None` for any path not
+//! explicitly assigned. There is deliberately **no default label** — an
+//! unmapped node is unlabeled, hence denied. The operator closes the gap by
+//! adding an explicit assignment, never by widening a default.
+
+use super::label::SecurityLabel;
+use super::lattice::{Lattice, LabelError};
+use super::manifest::StaticNodeLabel;
+use std::collections::BTreeMap;
+
+/// The result of checking genesis completeness over a known set of nodes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenesisReport {
+    /// Nodes that have an explicit, well-formed label assignment.
+    pub labeled: Vec<String>,
+    /// Nodes with NO assignment — these are denied at runtime. Enforcement
+    /// MUST NOT be enabled while this is non-empty (or each entry is an
+    /// intentional, audited deny).
+    pub unlabeled: Vec<String>,
+    /// Assignments whose label is ill-formed under the active lattice (e.g.
+    /// references an unknown compartment). Fail-closed: treated as gaps.
+    pub ill_formed: Vec<(String, LabelError)>,
+}
+
+impl GenesisReport {
+    /// Genesis is **complete** iff every known node is labeled with a
+    /// well-formed label (no gaps, no ill-formed assignments). Enforcement may
+    /// only be enabled when this is true. This is the gate that prevents both
+    /// "deny everything" (gaps) and "trust a typo'd label".
+    pub fn is_complete(&self) -> bool {
+        self.unlabeled.is_empty() && self.ill_formed.is_empty()
+    }
+}
+
+/// A deterministic, explicit map from a static node path to its genesis label.
+///
+/// Built once at startup from the schema annotations + site policy. There is no
+/// wildcard fallthrough to a default label — coverage is by explicit assignment
+/// only. (A site MAY add an explicit `"*"`-style rule in its *source* policy,
+/// but it must materialize to concrete per-node assignments here so the
+/// completeness check sees real coverage, not an implicit catch-all.)
+#[derive(Debug, Clone, Default)]
+pub struct GenesisMap {
+    assignments: BTreeMap<String, SecurityLabel>,
+}
+
+impl GenesisMap {
+    pub fn new() -> Self {
+        GenesisMap::default()
+    }
+
+    /// Assign a genesis label to a node path. Returns `self` for chaining.
+    pub fn assign(mut self, path: impl Into<String>, label: SecurityLabel) -> Self {
+        self.assignments.insert(path.into(), label);
+        self
+    }
+
+    /// The label for a node path, if explicitly assigned. `None` ⇒ unlabeled
+    /// ⇒ deny. **No default.**
+    pub fn resolve(&self, path: &str) -> Option<&SecurityLabel> {
+        self.assignments.get(path)
+    }
+
+    /// Resolve a node path to a [`StaticNodeLabel`], validating it against the
+    /// active lattice. An unassigned path or an ill-formed label both yield an
+    /// *unlabeled* node (fail-closed) — the distinction is surfaced only by
+    /// [`GenesisMap::report`] for operator visibility.
+    pub fn resolve_node(&self, path: &str, lattice: &Lattice) -> StaticNodeLabel {
+        match self.assignments.get(path) {
+            Some(label) if lattice.validate(label).is_ok() => {
+                StaticNodeLabel::labeled(*label)
+            }
+            _ => StaticNodeLabel::unlabeled(),
+        }
+    }
+
+    /// Check genesis completeness over the full set of nodes that *must* be
+    /// labeled (the schema's static-node inventory). Partitions every node into
+    /// labeled / unlabeled / ill-formed. This is the audited bootstrap gate.
+    pub fn report<'a>(
+        &self,
+        all_nodes: impl IntoIterator<Item = &'a str>,
+        lattice: &Lattice,
+    ) -> GenesisReport {
+        let mut labeled = Vec::new();
+        let mut unlabeled = Vec::new();
+        let mut ill_formed = Vec::new();
+
+        for node in all_nodes {
+            match self.assignments.get(node) {
+                None => unlabeled.push(node.to_owned()),
+                Some(label) => match lattice.validate(label) {
+                    Ok(()) => labeled.push(node.to_owned()),
+                    Err(e) => ill_formed.push((node.to_owned(), e)),
+                },
+            }
+        }
+        GenesisReport {
+            labeled,
+            unlabeled,
+            ill_formed,
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::super::label::{Assurance, Compartment, CompartmentSet, Level};
+    use super::super::lattice::LatticeVersion;
+    use super::super::manifest::LabeledObject;
+    use super::*;
+
+    fn comp(s: &str) -> Compartment {
+        Compartment::new(s)
+    }
+
+    fn lattice() -> Lattice {
+        // 2-compartment vocabulary → bits 0 ("pii") and 1 ("health").
+        Lattice::new(LatticeVersion(1), [comp("pii"), comp("health")])
+    }
+
+    fn map() -> GenesisMap {
+        let l = lattice();
+        GenesisMap::new()
+            .assign(
+                "/health",
+                SecurityLabel::new(Level::Public, Assurance::Classical, CompartmentSet::EMPTY),
+            )
+            .assign(
+                "/ctl/policy",
+                l.label(Level::Secret, Assurance::PqHybrid, [comp("pii")]).unwrap(),
+            )
+    }
+
+    #[test]
+    fn resolve_returns_assigned_label_only() {
+        let m = map();
+        assert!(m.resolve("/health").is_some());
+        assert!(m.resolve("/unknown").is_none()); // no default → deny
+    }
+
+    #[test]
+    fn resolve_node_unassigned_is_unlabeled() {
+        let node = map().resolve_node("/nope", &lattice());
+        assert!(node.security_label().is_none());
+    }
+
+    #[test]
+    fn resolve_node_assigned_is_labeled() {
+        let node = map().resolve_node("/health", &lattice());
+        assert!(node.security_label().is_some());
+    }
+
+    #[test]
+    fn report_detects_gaps() {
+        let report = map().report(["/health", "/ctl/policy", "/streams", "/metrics"], &lattice());
+        assert_eq!(report.labeled.len(), 2);
+        // `report` preserves input order of `all_nodes`.
+        assert_eq!(report.unlabeled, vec!["/streams".to_owned(), "/metrics".to_owned()]);
+        assert!(!report.is_complete());
+    }
+
+    #[test]
+    fn report_complete_when_all_labeled() {
+        let report = map().report(["/health", "/ctl/policy"], &lattice());
+        assert!(report.is_complete());
+        assert!(report.unlabeled.is_empty());
+        assert!(report.ill_formed.is_empty());
+    }
+
+    #[test]
+    fn report_flags_ill_formed_label_as_not_complete() {
+        // a label naming an unknown compartment is ill-formed → fail-closed.
+        // Bit 9 is not registered in the 2-compartment vocabulary → ill-formed.
+        let m = GenesisMap::new().assign(
+            "/bad",
+            SecurityLabel::from_bits(Level::Public, Assurance::Classical, [9]),
+        );
+        let report = m.report(["/bad"], &lattice());
+        assert!(report.labeled.is_empty());
+        assert_eq!(report.ill_formed.len(), 1);
+        assert!(!report.is_complete());
+    }
+
+    #[test]
+    fn ill_formed_label_resolves_as_unlabeled() {
+        // Bit 9 is not registered in the 2-compartment vocabulary → ill-formed.
+        let m = GenesisMap::new().assign(
+            "/bad",
+            SecurityLabel::from_bits(Level::Public, Assurance::Classical, [9]),
+        );
+        // resolve_node fails closed: ill-formed → unlabeled → deny.
+        assert!(m.resolve_node("/bad", &lattice()).security_label().is_none());
+    }
+}

--- a/crates/hyprstream-rpc/src/auth/mac/label.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/label.rs
@@ -1,0 +1,564 @@
+//! The security **label** — the content-bound classification carried by every
+//! object, and the verified **clearance** carried by every subject.
+//!
+//! This is S1 (#567), the foundation of the native-MAC authz model (epic #547).
+//! It is **TCB**: keep it small and verifiable. The whole lattice is three
+//! orthogonal axes, each a *small total/partial order*, combined into one
+//! product lattice (see [`super::lattice`]).
+//!
+//! Design invariants (epic #547 §1, design doc §1):
+//! - **No unlabeled state.** There is no `Default` that means "public/allow".
+//!   The absence of a label is represented by `Option::None` at call sites and
+//!   is treated as **denied** by the monitor — never by a permissive default
+//!   here. (We deliberately do NOT derive `Default` for [`SecurityLabel`].)
+//! - **Labels are content-truth.** A label is meant to be bound to content (a
+//!   manifest hash) so it cannot be relabeled without rehashing. This module
+//!   defines the *type*; the binding seam lives in [`super::manifest`].
+//! - **Assurance is a lattice axis, not a flag** (#548). A classical-DID peer
+//!   is bounded LOW; a PQC-bound peer may reach HIGH. The dominance check then
+//!   *automatically* prevents PQC-required data from flowing to a classical
+//!   peer — no separate enforcement path.
+//!
+//! ## Representation (S1↔S4 reconciliation, epic #547)
+//!
+//! [`SecurityLabel`] is a **fixed-size, `Copy + Ord + Hash` value**:
+//! ```text
+//!     level: Level (u8)  ×  assurance: Assurance (u8)  ×  compartments: CompartmentSet (u64 bitset)
+//! ```
+//! Compartments are a **fixed bitset**, not a heap set. Each compartment name
+//! (`"pii"`, `"tenant:acme"`, …) is interned to a bit index by the policy
+//! ([`super::lattice::Lattice`]); the label carries only the bitset. This is what
+//! lets S4's Access Vector Cache (#570) key on a [`SecurityLabel`] *directly* —
+//! no interning layer, no allocation, sub-µs hashing on the hot path. The
+//! string↔bit mapping lives in the `Lattice` policy (the one place the
+//! compartment vocabulary is closed and audited).
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Number of distinct compartments representable in a label.
+///
+/// A fixed bitset width keeps [`SecurityLabel`] `Copy` and pointer-free so it can
+/// be an AVC key (S4, #570). 64 is ample headroom for the closed, audited
+/// compartment vocabulary; widening it is a deliberate (versioned) TCB change,
+/// the same class of change as adding a [`Level`].
+pub const MAX_COMPARTMENTS: u32 = 64;
+
+/// Multi-Level-Security sensitivity level — a **total order** (the MLS axis).
+///
+/// Small and fixed on purpose (TCB). Higher discriminant ⇒ more sensitive.
+/// Ordering is derived from declaration order, so `Public < Internal <
+/// Confidential < Secret`. This is the classic Bell–LaPadula level.
+///
+/// Adding a level is a deliberate policy change (a new lattice version), not a
+/// runtime/config knob.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+#[serde(rename_all = "lowercase")]
+#[repr(u8)]
+pub enum Level {
+    /// World-readable. The *floor* of the level axis. NOTE: floor ≠ unlabeled.
+    /// An object explicitly labeled `Public` is labeled; an object with no
+    /// label at all is denied (see module docs).
+    Public = 0,
+    /// Internal / org-only.
+    Internal = 1,
+    /// Confidential.
+    Confidential = 2,
+    /// Secret — the top of the level axis.
+    Secret = 3,
+}
+
+impl Level {
+    /// The bottom of the level axis (used as the join identity element).
+    pub const BOTTOM: Level = Level::Public;
+    /// The top of the level axis.
+    pub const TOP: Level = Level::Secret;
+}
+
+impl fmt::Display for Level {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Level::Public => "public",
+            Level::Internal => "internal",
+            Level::Confidential => "confidential",
+            Level::Secret => "secret",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Crypto-**assurance** axis (#548) — a **total order** derived from *verified*
+/// key material, never claimed.
+///
+/// This is the dimension that lets a classical (ATProto/p256/secp256k1)
+/// federation perimeter coexist with the mandatory PQC interior without a hole:
+/// PQC-required data is labeled at an assurance only a PQC-bound principal
+/// dominates, and the ordinary dominance check does the rest.
+///
+/// Derivation (a property of the *verified* identity — see
+/// [`super::context::SecurityContext::derive_assurance`]):
+/// - `Unverified` — assurance could not be established (fail-closed; the floor).
+/// - `Classical` — authenticated by a classical DID only (Ed25519/p256/
+///   secp256k1); no bound PQC anchor.
+/// - `PqHybrid`  — has a verified hybrid-PQC anchor (Ed25519 ↔ ML-DSA-65 bound
+///   via `register_pq_trust`), i.e. the [`crate::crypto::CryptoPolicy::Hybrid`]
+///   composite verified.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+#[serde(rename_all = "kebab-case")]
+#[repr(u8)]
+pub enum Assurance {
+    /// Assurance could not be verified. Floor of the axis. A *subject* at
+    /// `Unverified` dominates nothing above it; an *object* requiring more than
+    /// `Unverified` is therefore unreachable by such a subject — fail-closed.
+    Unverified = 0,
+    /// Classical DID, no post-quantum binding (the federation edge).
+    Classical = 1,
+    /// Verified hybrid post-quantum anchor (EdDSA + ML-DSA-65).
+    PqHybrid = 2,
+}
+
+impl Assurance {
+    /// Floor / join identity of the assurance axis.
+    pub const BOTTOM: Assurance = Assurance::Unverified;
+    /// Top of the assurance axis.
+    pub const TOP: Assurance = Assurance::PqHybrid;
+}
+
+impl fmt::Display for Assurance {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Assurance::Unverified => "unverified",
+            Assurance::Classical => "classical",
+            Assurance::PqHybrid => "pq-hybrid",
+        };
+        f.write_str(s)
+    }
+}
+
+/// A need-to-know **compartment** *name* (the categories axis vocabulary).
+///
+/// Compartments form a powerset lattice under ⊆. This type is the *human-facing
+/// name* (e.g. `"tenant:acme"`, `"pii"`, `"model:qwen-7b"`); inside a
+/// [`SecurityLabel`] a compartment is stored as a **bit** in a [`CompartmentSet`]
+/// bitset. The name↔bit mapping is owned by the policy
+/// ([`super::lattice::Lattice`], built from the schema `$scope` annotations —
+/// S3, #569). This type does not constrain the vocabulary.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct Compartment(pub String);
+
+impl Compartment {
+    pub fn new(s: impl Into<String>) -> Self {
+        Compartment(s.into())
+    }
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for Compartment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Compartment({:?})", self.0)
+    }
+}
+
+impl fmt::Display for Compartment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// A **fixed bitset** of compartment bits — the powerset-lattice axis, packed so
+/// [`SecurityLabel`] stays `Copy + Ord + Hash`.
+///
+/// Bit `i` set ⟺ the label is in the compartment interned at index `i` by the
+/// policy. Subset/union are bitwise `AND`/`OR`. The empty set (`0`) is the
+/// compartment-axis bottom. This is the representation that lets S4's AVC (#570)
+/// key on a label with no interning indirection.
+#[derive(
+    Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize,
+)]
+#[serde(transparent)]
+pub struct CompartmentSet(pub u64);
+
+impl CompartmentSet {
+    /// The empty compartment set — the axis bottom.
+    pub const EMPTY: CompartmentSet = CompartmentSet(0);
+
+    /// A set containing exactly the single bit `index` (`0 ≤ index < `
+    /// [`MAX_COMPARTMENTS`]). Out-of-range indices are ignored (empty) —
+    /// fail-closed: an un-representable compartment grants nothing.
+    #[inline]
+    pub const fn single(index: u32) -> Self {
+        if index >= MAX_COMPARTMENTS {
+            CompartmentSet(0)
+        } else {
+            CompartmentSet(1u64 << index)
+        }
+    }
+
+    /// Is this the empty set?
+    #[inline]
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    /// `self ⊆ other` — is every compartment of `self` also in `other`?
+    #[inline]
+    pub const fn is_subset(self, other: CompartmentSet) -> bool {
+        self.0 & other.0 == self.0
+    }
+
+    /// Set **union** (the IFC join on this axis).
+    #[inline]
+    pub const fn union(self, other: CompartmentSet) -> CompartmentSet {
+        CompartmentSet(self.0 | other.0)
+    }
+
+    /// Does this set contain compartment bit `index`?
+    #[inline]
+    pub const fn contains(self, index: u32) -> bool {
+        index < MAX_COMPARTMENTS && (self.0 & (1u64 << index)) != 0
+    }
+
+    /// Iterate the set bit indices, ascending. (Off the hot path: diagnostics /
+    /// rendering / policy validation.)
+    pub fn iter(self) -> impl Iterator<Item = u32> {
+        (0..MAX_COMPARTMENTS).filter(move |&i| self.contains(i))
+    }
+
+    /// Number of compartments in the set.
+    #[inline]
+    pub const fn len(self) -> u32 {
+        self.0.count_ones()
+    }
+}
+
+impl FromIterator<u32> for CompartmentSet {
+    fn from_iter<I: IntoIterator<Item = u32>>(iter: I) -> Self {
+        iter.into_iter().fold(CompartmentSet::EMPTY, |acc, i| {
+            acc.union(CompartmentSet::single(i))
+        })
+    }
+}
+
+impl fmt::Debug for CompartmentSet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "CompartmentSet({:#x})", self.0)
+    }
+}
+
+/// A complete security label: a point in the product lattice
+/// `Level × Assurance × CompartmentSet`.
+///
+/// The same type is used for an **object's** classification and a **subject's**
+/// clearance (a clearance is just a label the subject is allowed to read up
+/// to). Dominance and join are defined on the inherent
+/// [`SecurityLabel::dominates`] / [`SecurityLabel::join`] helpers below — note
+/// those helpers encode the *fixed* product-lattice algebra and are independent
+/// of any site policy (the policy in [`super::lattice::Lattice`] only constrains
+/// which labels are *well-formed/known*, never how they compare).
+///
+/// **`Copy + Ord + Hash`** (compartments are a packed [`CompartmentSet`] bitset,
+/// not a heap set) so S4's AVC (#570) can key on a label directly — and so two
+/// equal labels serialize identically, which content-binding (manifest hash) and
+/// the `(UCAN, bundle_hash)` approval (S5) require.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct SecurityLabel {
+    /// MLS sensitivity level (total order).
+    pub level: Level,
+    /// Crypto-assurance required to handle this label (total order, #548).
+    pub assurance: Assurance,
+    /// Need-to-know compartments as a fixed bitset (powerset lattice under ⊆).
+    #[serde(default)]
+    pub compartments: CompartmentSet,
+}
+
+impl fmt::Debug for SecurityLabel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Render in the SELinux-ish `level:assurance:{bits}` form for logs/audit.
+        write!(f, "{self}")
+    }
+}
+
+impl fmt::Display for SecurityLabel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Note: the label carries compartment *bits*, not names — name resolution
+        // needs the policy. We render bit indices here; a name-aware renderer
+        // lives on `Lattice`.
+        write!(f, "{}:{}", self.level, self.assurance)?;
+        if !self.compartments.is_empty() {
+            let joined = self
+                .compartments
+                .iter()
+                .map(|i| i.to_string())
+                .collect::<Vec<_>>()
+                .join(",");
+            write!(f, ":{{c{joined}}}")?;
+        }
+        Ok(())
+    }
+}
+
+impl SecurityLabel {
+    /// Construct a label from its axes. There is intentionally **no `Default`** —
+    /// every label must be chosen explicitly so "unlabeled" can never silently
+    /// mean "public".
+    pub fn new(level: Level, assurance: Assurance, compartments: CompartmentSet) -> Self {
+        SecurityLabel {
+            level,
+            assurance,
+            compartments,
+        }
+    }
+
+    /// Construct a label from compartment **bit indices** (e.g. resolved from
+    /// names by the policy). Out-of-range indices are dropped (fail-closed).
+    pub fn from_bits(
+        level: Level,
+        assurance: Assurance,
+        bits: impl IntoIterator<Item = u32>,
+    ) -> Self {
+        SecurityLabel {
+            level,
+            assurance,
+            compartments: bits.into_iter().collect(),
+        }
+    }
+
+    /// The lattice **bottom** ⊥ = `(Public, Unverified, {})`.
+    ///
+    /// This is the *join identity*, NOT a default object label. An object is
+    /// only at ⊥ if policy explicitly labels it so. It is mainly useful as the
+    /// seed for folding a join over provenance inputs (IFC).
+    pub const fn bottom() -> Self {
+        SecurityLabel {
+            level: Level::BOTTOM,
+            assurance: Assurance::BOTTOM,
+            compartments: CompartmentSet::EMPTY,
+        }
+    }
+
+    /// Whether this label is the lattice bottom.
+    pub fn is_bottom(&self) -> bool {
+        self.level == Level::BOTTOM
+            && self.assurance == Assurance::BOTTOM
+            && self.compartments.is_empty()
+    }
+
+    /// **Dominance**: does `self` (as a subject clearance) dominate `object`?
+    ///
+    /// `self ⊒ object` ⟺ on *every* axis self is ≥ object:
+    /// - `self.level   >= object.level`            (read-down)
+    /// - `self.assurance >= object.assurance`      (#548)
+    /// - `object.compartments ⊆ self.compartments` (cleared into all required)
+    ///
+    /// This is the per-op MAC floor (design §3, §10). It is the *fixed*
+    /// product-lattice order and takes no policy argument: dominance is content
+    /// truth, never overridable by a token/UCAN/grant.
+    #[inline]
+    #[must_use]
+    pub fn dominates(&self, object: &SecurityLabel) -> bool {
+        self.level >= object.level
+            && self.assurance >= object.assurance
+            && object.compartments.is_subset(self.compartments)
+    }
+
+    /// **Join** (least upper bound) — the IFC combinator (design §3).
+    ///
+    /// `a ⊔ b` = `(max(level), max(assurance), union(compartments))`. A derived
+    /// object's label is the join of its inputs' labels, so a rollup of secret
+    /// inputs is automatically secret and aggregation cannot launder
+    /// classification. Associative, commutative, idempotent; `⊥` is the
+    /// identity — hence [`SecurityLabel::join_all`] can fold from `bottom()`.
+    #[inline]
+    #[must_use]
+    pub fn join(&self, other: &SecurityLabel) -> SecurityLabel {
+        SecurityLabel {
+            level: if self.level >= other.level {
+                self.level
+            } else {
+                other.level
+            },
+            assurance: if self.assurance >= other.assurance {
+                self.assurance
+            } else {
+                other.assurance
+            },
+            compartments: self.compartments.union(other.compartments),
+        }
+    }
+
+    /// Fold the IFC join over a set of input labels (provenance-DAG join).
+    ///
+    /// Returns `⊥` for an empty input set (the identity), which the caller
+    /// MUST treat carefully: a derived object with *no* recorded inputs is
+    /// suspicious and should generally be rejected rather than labeled ⊥. This
+    /// helper computes the algebra only; the seal/rollup policy (when an empty
+    /// provenance is allowed) is S2's (#568).
+    #[must_use]
+    pub fn join_all<'a>(labels: impl IntoIterator<Item = &'a SecurityLabel>) -> SecurityLabel {
+        labels
+            .into_iter()
+            .fold(SecurityLabel::bottom(), |acc, l| acc.join(l))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn label(l: Level, a: Assurance, bits: &[u32]) -> SecurityLabel {
+        SecurityLabel::from_bits(l, a, bits.iter().copied())
+    }
+
+    #[test]
+    fn level_is_totally_ordered() {
+        assert!(Level::Public < Level::Internal);
+        assert!(Level::Internal < Level::Confidential);
+        assert!(Level::Confidential < Level::Secret);
+        assert_eq!(Level::BOTTOM, Level::Public);
+        assert_eq!(Level::TOP, Level::Secret);
+    }
+
+    #[test]
+    fn assurance_is_totally_ordered_unverified_floor() {
+        assert!(Assurance::Unverified < Assurance::Classical);
+        assert!(Assurance::Classical < Assurance::PqHybrid);
+        assert_eq!(Assurance::BOTTOM, Assurance::Unverified);
+    }
+
+    #[test]
+    fn compartment_set_subset_and_union() {
+        let a = CompartmentSet::single(0).union(CompartmentSet::single(2));
+        let b = CompartmentSet::single(0);
+        assert!(b.is_subset(a));
+        assert!(!a.is_subset(b));
+        assert_eq!(a.union(b), a);
+        assert_eq!(a.len(), 2);
+        assert!(a.contains(0));
+        assert!(a.contains(2));
+        assert!(!a.contains(1));
+    }
+
+    #[test]
+    fn label_is_copy_and_hashable() {
+        // The reconciliation requirement: a label is a cheap Copy+Hash+Ord AVC key.
+        fn assert_avc_key<T: Copy + std::hash::Hash + Ord>() {}
+        assert_avc_key::<SecurityLabel>();
+        let x = label(Level::Secret, Assurance::PqHybrid, &[1, 3]);
+        let y = x; // Copy, not move
+        assert_eq!(x, y);
+    }
+
+    #[test]
+    fn dominance_reflexive() {
+        let x = label(Level::Confidential, Assurance::Classical, &[0, 1]);
+        assert!(x.dominates(&x));
+    }
+
+    #[test]
+    fn dominance_level_read_down() {
+        let secret = label(Level::Secret, Assurance::PqHybrid, &[]);
+        let public = label(Level::Public, Assurance::PqHybrid, &[]);
+        assert!(secret.dominates(&public));
+        assert!(!public.dominates(&secret));
+    }
+
+    #[test]
+    fn dominance_requires_compartment_superset() {
+        let cleared = label(Level::Secret, Assurance::PqHybrid, &[0, 1]); // pii, tenant:acme
+        let needs_pii = label(Level::Public, Assurance::Unverified, &[0]);
+        let needs_other = label(Level::Public, Assurance::Unverified, &[5]); // finance
+        assert!(cleared.dominates(&needs_pii));
+        assert!(!cleared.dominates(&needs_other)); // not cleared into "finance"
+    }
+
+    #[test]
+    fn assurance_classical_cannot_dominate_pqc_label() {
+        // #548 acceptance: a classical-DID peer cannot dominate a PQC-required label.
+        let classical_subject = label(Level::Secret, Assurance::Classical, &[0]);
+        let pqc_object = label(Level::Public, Assurance::PqHybrid, &[]);
+        assert!(!classical_subject.dominates(&pqc_object));
+
+        // a PQC-bound peer can (level/compartments permitting).
+        let pqc_subject = label(Level::Secret, Assurance::PqHybrid, &[0]);
+        assert!(pqc_subject.dominates(&pqc_object));
+    }
+
+    #[test]
+    fn unverified_subject_dominates_nothing_above_floor() {
+        let unverified = label(Level::Secret, Assurance::Unverified, &[0]);
+        let needs_classical = label(Level::Public, Assurance::Classical, &[]);
+        assert!(!unverified.dominates(&needs_classical));
+    }
+
+    #[test]
+    fn join_takes_max_and_union() {
+        let a = label(Level::Internal, Assurance::Classical, &[0]); // pii
+        let b = label(Level::Secret, Assurance::PqHybrid, &[5]); // finance
+        let j = a.join(&b);
+        assert_eq!(j.level, Level::Secret);
+        assert_eq!(j.assurance, Assurance::PqHybrid);
+        assert!(j.compartments.contains(0));
+        assert!(j.compartments.contains(5));
+    }
+
+    #[test]
+    fn join_is_least_upper_bound() {
+        let a = label(Level::Internal, Assurance::Classical, &[0]);
+        let b = label(Level::Confidential, Assurance::Unverified, &[5]);
+        let j = a.join(&b);
+        assert!(j.dominates(&a));
+        assert!(j.dominates(&b));
+    }
+
+    #[test]
+    fn join_laws() {
+        let a = label(Level::Internal, Assurance::Classical, &[0]);
+        let b = label(Level::Secret, Assurance::Unverified, &[1]);
+        let c = label(Level::Public, Assurance::PqHybrid, &[2]);
+        // commutative
+        assert_eq!(a.join(&b), b.join(&a));
+        // associative
+        assert_eq!(a.join(&b).join(&c), a.join(&b.join(&c)));
+        // idempotent
+        assert_eq!(a.join(&a), a);
+        // bottom identity
+        assert_eq!(a.join(&SecurityLabel::bottom()), a);
+    }
+
+    #[test]
+    fn join_all_secret_input_propagates() {
+        // IFC: aggregating a secret input yields a secret result.
+        let inputs = vec![
+            label(Level::Public, Assurance::Classical, &[0]),
+            label(Level::Secret, Assurance::PqHybrid, &[1]),
+            label(Level::Internal, Assurance::Classical, &[2]),
+        ];
+        let j = SecurityLabel::join_all(&inputs);
+        assert_eq!(j.level, Level::Secret);
+        assert_eq!(j.assurance, Assurance::PqHybrid);
+        assert_eq!(j.compartments.len(), 3);
+    }
+
+    #[test]
+    fn join_all_empty_is_bottom() {
+        let none: Vec<&SecurityLabel> = vec![];
+        assert!(SecurityLabel::join_all(none).is_bottom());
+    }
+
+    #[test]
+    fn serde_roundtrip_is_canonical() {
+        let l = label(Level::Secret, Assurance::PqHybrid, &[1, 0]);
+        let json = serde_json::to_string(&l).unwrap();
+        let back: SecurityLabel = serde_json::from_str(&json).unwrap();
+        assert_eq!(l, back);
+        // canonical: re-serializing yields identical bytes (content-binding needs this)
+        assert_eq!(json, serde_json::to_string(&back).unwrap());
+    }
+}

--- a/crates/hyprstream-rpc/src/auth/mac/lattice.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/lattice.rs
@@ -102,6 +102,49 @@ impl fmt::Display for LabelError {
 
 impl std::error::Error for LabelError {}
 
+/// Reasons a serialized [`Lattice`] is rejected on decode. All fail-closed: a
+/// malformed wire vocabulary never silently becomes a smaller/different lattice.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LatticeDecodeError {
+    /// The wire vocabulary lists the same compartment name twice. Bit
+    /// assignment must be unambiguous, so this is rejected rather than
+    /// silently collapsed (which would shift every later bit).
+    DuplicateCompartment(Compartment),
+    /// The wire vocabulary exceeds the bitset width. Truncating would drop
+    /// compartments and desync bits from the issuer, so reject instead.
+    TooManyCompartments { got: usize, max: u32 },
+}
+
+impl fmt::Display for LatticeDecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LatticeDecodeError::DuplicateCompartment(c) => {
+                write!(f, "duplicate compartment in lattice vocabulary: {c}")
+            }
+            LatticeDecodeError::TooManyCompartments { got, max } => {
+                write!(f, "lattice vocabulary has {got} compartments, max is {max}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for LatticeDecodeError {}
+
+/// Failure decoding a [`Lattice`] from its canonical byte form: either the CBOR
+/// itself was malformed or the decoded vocabulary was rejected (see
+/// [`LatticeDecodeError`]). Carries a rendered message; the distinction is not
+/// load-bearing for callers, which fail closed either way.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LatticeCodecError(String);
+
+impl fmt::Display for LatticeCodecError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "lattice decode failed: {}", self.0)
+    }
+}
+
+impl std::error::Error for LatticeCodecError {}
+
 /// The active lattice policy: the *closed* compartment vocabulary (name↔bit) and
 /// the version. Levels and assurances are fixed by their enums (TCB), so only the
 /// open dimension — compartments — needs a registry.
@@ -110,15 +153,71 @@ impl std::error::Error for LabelError {}
 /// (S3, #569) and treated as immutable thereafter (a change is a version bump).
 /// Bit assignments are stable within a version (S4's compiled TE matrix is keyed
 /// to them via the shared generation).
+///
+/// ## Canonical serialization (S1↔S4, #570)
+///
+/// A signed `CompiledPolicy` must carry the lattice so the PDP and every
+/// distributed AVC reconstruct the **identical** name↔bit map — otherwise
+/// [`CompartmentSet`] bits desync from genesis across processes. The wire form
+/// is deliberately minimal: just the [`LatticeVersion`] and the compartment
+/// names **in bit-index order**. Decoding re-interns those names in that exact
+/// order via [`Lattice::new`], so bit assignments are *derived*, never trusted
+/// from the wire — a tampered reverse map cannot exist. Use [`Lattice::to_bytes`]
+/// / [`Lattice::from_bytes`] for the deterministic (CBOR) byte form, or the
+/// `Serialize`/`Deserialize` impls to embed in a larger signed structure.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(into = "LatticeWire", try_from = "LatticeWire")]
 pub struct Lattice {
     version: LatticeVersion,
     /// Compartment name → stable bit index. The bit index is what a
     /// [`SecurityLabel`] actually carries. A label bit with no entry here (or a
     /// name not present) is ill-formed → rejected at creation.
     name_to_bit: BTreeMap<Compartment, u32>,
-    /// Reverse map for rendering / audit. Kept in sync with `name_to_bit`.
-    bit_to_name: BTreeMap<u32, Compartment>,
+    /// Compartments in bit-index order: `by_bit[i]` is the name interned at bit
+    /// `i`. This IS the canonical construction order and the serialized form.
+    by_bit: Vec<Compartment>,
+}
+
+/// The canonical, deterministic wire form of a [`Lattice`]: version + the
+/// compartment vocabulary in bit-index order. The name↔bit map is reconstructed
+/// (not transmitted), making issuer/consumer bit desync structurally impossible.
+#[derive(Serialize, Deserialize)]
+struct LatticeWire {
+    version: LatticeVersion,
+    compartments: Vec<Compartment>,
+}
+
+impl From<Lattice> for LatticeWire {
+    fn from(l: Lattice) -> Self {
+        LatticeWire {
+            version: l.version,
+            compartments: l.by_bit,
+        }
+    }
+}
+
+impl TryFrom<LatticeWire> for Lattice {
+    type Error = LatticeDecodeError;
+
+    /// Reconstruct by interning in wire order. Rejects (fail-closed) a
+    /// vocabulary that [`Lattice::new`] would have silently altered — duplicate
+    /// names or an over-width list — since either would desync bits from the
+    /// issuer rather than reproduce them.
+    fn try_from(w: LatticeWire) -> Result<Self, Self::Error> {
+        if w.compartments.len() > MAX_COMPARTMENTS as usize {
+            return Err(LatticeDecodeError::TooManyCompartments {
+                got: w.compartments.len(),
+                max: MAX_COMPARTMENTS,
+            });
+        }
+        let mut seen = std::collections::BTreeSet::new();
+        for c in &w.compartments {
+            if !seen.insert(c) {
+                return Err(LatticeDecodeError::DuplicateCompartment(c.clone()));
+            }
+        }
+        Ok(Lattice::new(w.version, w.compartments))
+    }
 }
 
 impl Lattice {
@@ -131,26 +230,24 @@ impl Lattice {
         known_compartments: impl IntoIterator<Item = Compartment>,
     ) -> Self {
         let mut name_to_bit = BTreeMap::new();
-        let mut bit_to_name = BTreeMap::new();
-        let mut next: u32 = 0;
+        let mut by_bit: Vec<Compartment> = Vec::new();
         for c in known_compartments {
             if name_to_bit.contains_key(&c) {
                 continue;
             }
-            if next >= MAX_COMPARTMENTS {
+            if by_bit.len() >= MAX_COMPARTMENTS as usize {
                 // Vocabulary exceeds the bitset width: refuse to assign (the
                 // name stays unknown → labels using it fail validation). This is
                 // a policy-authoring error surfaced fail-closed.
                 break;
             }
-            name_to_bit.insert(c.clone(), next);
-            bit_to_name.insert(next, c);
-            next += 1;
+            name_to_bit.insert(c.clone(), by_bit.len() as u32);
+            by_bit.push(c);
         }
         Lattice {
             version,
             name_to_bit,
-            bit_to_name,
+            by_bit,
         }
     }
 
@@ -160,7 +257,39 @@ impl Lattice {
 
     /// Number of compartments in the vocabulary.
     pub fn compartment_count(&self) -> u32 {
-        self.name_to_bit.len() as u32
+        self.by_bit.len() as u32
+    }
+
+    /// The compartment vocabulary in **canonical construction (bit-index)
+    /// order**: `compartment_names()[i]` is the name interned at bit `i`. This
+    /// is the order [`Lattice::new`] assigned and the order the wire form
+    /// preserves — S4's PDP can iterate it to align its TE matrix columns with
+    /// the exact bits a [`SecurityLabel`] carries.
+    pub fn compartment_names(&self) -> &[Compartment] {
+        &self.by_bit
+    }
+
+    /// Canonical, deterministic byte form (CBOR) — the same codec the COSE
+    /// signing path uses — so a signed `CompiledPolicy` can carry the lattice
+    /// verbatim. Round-trips through [`Lattice::from_bytes`] preserving every
+    /// name↔bit assignment exactly. Serialization of an in-memory lattice is
+    /// infallible.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        #[allow(clippy::expect_used)]
+        ciborium::ser::into_writer(self, &mut buf)
+            .expect("Lattice CBOR serialization into a Vec is infallible");
+        buf
+    }
+
+    /// Reconstruct a lattice from its canonical byte form. Fails closed on a
+    /// malformed encoding or a vocabulary [`TryFrom`] would have to alter
+    /// (duplicate names / over-width) — never silently yields a different
+    /// lattice than the issuer signed.
+    ///
+    /// [`TryFrom`]: Lattice::try_from
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, LatticeCodecError> {
+        ciborium::de::from_reader(bytes).map_err(|e| LatticeCodecError(e.to_string()))
     }
 
     /// The bit index assigned to a compartment name, if known.
@@ -170,7 +299,7 @@ impl Lattice {
 
     /// The compartment name for a bit index, if registered.
     pub fn name_of(&self, bit: u32) -> Option<&Compartment> {
-        self.bit_to_name.get(&bit)
+        self.by_bit.get(bit as usize)
     }
 
     /// Is `c` a recognized compartment under this policy?
@@ -217,7 +346,7 @@ impl Lattice {
     /// dominance.
     pub fn validate(&self, label: &SecurityLabel) -> Result<(), LabelError> {
         for bit in label.compartments.iter() {
-            if !self.bit_to_name.contains_key(&bit) {
+            if (bit as usize) >= self.by_bit.len() {
                 return Err(LabelError::UnknownCompartmentBit(bit));
             }
         }
@@ -229,13 +358,9 @@ impl Lattice {
     /// label. (Useful for genesis-labeling the policy authority itself, and for
     /// tests.)
     pub fn top(&self) -> SecurityLabel {
-        let all = self
-            .bit_to_name
-            .keys()
-            .copied()
-            .fold(CompartmentSet::EMPTY, |acc, b| {
-                acc.union(CompartmentSet::single(b))
-            });
+        let all = (0..self.by_bit.len() as u32).fold(CompartmentSet::EMPTY, |acc, b| {
+            acc.union(CompartmentSet::single(b))
+        });
         SecurityLabel::new(Level::TOP, Assurance::TOP, all)
     }
 
@@ -376,5 +501,92 @@ mod tests {
         assert_eq!(LatticeVersion(3).to_string(), "v3");
         // S1↔S4: LatticeVersion ≡ CompiledPolicy.generation.
         assert_eq!(LatticeVersion(3).generation(), 3u64);
+    }
+
+    #[test]
+    fn compartment_names_are_in_construction_order() {
+        let p = policy();
+        let names: Vec<&str> = p.compartment_names().iter().map(Compartment::as_str).collect();
+        // Exactly the order passed to `new`, i.e. bit order 0,1,2.
+        assert_eq!(names, ["pii", "finance", "tenant:acme"]);
+        // And it agrees with the name↔bit map for every entry.
+        for (bit, name) in p.compartment_names().iter().enumerate() {
+            assert_eq!(p.bit_of(name), Some(bit as u32));
+            assert_eq!(p.name_of(bit as u32), Some(name));
+        }
+    }
+
+    #[test]
+    fn to_from_bytes_roundtrips_bits_exactly() {
+        let p = policy();
+        let restored = Lattice::from_bytes(&p.to_bytes()).unwrap();
+        // Same version, same vocabulary, same bit assignment for every name.
+        assert_eq!(restored.version(), p.version());
+        assert_eq!(restored.compartment_names(), p.compartment_names());
+        for name in p.compartment_names() {
+            assert_eq!(restored.bit_of(name), p.bit_of(name));
+        }
+        // A label minted under `p` validates identically under the restored
+        // lattice — the whole point: no cross-process bit desync.
+        let l = p
+            .label(Level::Secret, Assurance::PqHybrid, [comp("tenant:acme")])
+            .unwrap();
+        assert!(restored.validate(&l).is_ok());
+        assert_eq!(restored.bit_of(&comp("tenant:acme")), Some(2));
+    }
+
+    #[test]
+    fn byte_form_is_deterministic() {
+        // Two independently-built identical lattices encode byte-identically —
+        // required so a signature over the bytes is stable across processes.
+        assert_eq!(policy().to_bytes(), policy().to_bytes());
+    }
+
+    #[test]
+    fn serde_roundtrips_through_canonical_wire() {
+        let p = policy();
+        // Exercise the Serialize/Deserialize impls (the embed-in-CompiledPolicy
+        // path) via CBOR, distinct from the to_bytes helper.
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&p, &mut buf).unwrap();
+        let restored: Lattice = ciborium::de::from_reader(&buf[..]).unwrap();
+        assert_eq!(restored.compartment_names(), p.compartment_names());
+        assert_eq!(restored.version(), p.version());
+    }
+
+    #[test]
+    fn decode_rejects_duplicate_compartment() {
+        let wire = LatticeWire {
+            version: LatticeVersion(1),
+            compartments: vec![comp("pii"), comp("finance"), comp("pii")],
+        };
+        assert_eq!(
+            Lattice::try_from(wire).unwrap_err(),
+            LatticeDecodeError::DuplicateCompartment(comp("pii"))
+        );
+    }
+
+    #[test]
+    fn decode_rejects_over_width_vocabulary() {
+        let too_many: Vec<Compartment> = (0..=MAX_COMPARTMENTS)
+            .map(|i| comp(&format!("c{i}")))
+            .collect();
+        let got = too_many.len();
+        let wire = LatticeWire {
+            version: LatticeVersion(1),
+            compartments: too_many,
+        };
+        assert_eq!(
+            Lattice::try_from(wire).unwrap_err(),
+            LatticeDecodeError::TooManyCompartments {
+                got,
+                max: MAX_COMPARTMENTS
+            }
+        );
+    }
+
+    #[test]
+    fn from_bytes_rejects_garbage() {
+        assert!(Lattice::from_bytes(&[0xde, 0xad, 0xbe, 0xef]).is_err());
     }
 }

--- a/crates/hyprstream-rpc/src/auth/mac/lattice.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/lattice.rs
@@ -1,0 +1,380 @@
+//! The MAC **lattice** as policy — defined once, versioned, pinned.
+//!
+//! Two things are deliberately separated here:
+//!
+//! 1. **The order algebra** (dominance ⊒, join ⊔) is *fixed* and lives on
+//!    [`SecurityLabel`] itself. It is the product order of `Level × Assurance ×
+//!    CompartmentSet`. It never depends on site policy, so the per-op monitor
+//!    (S2) can compute dominance with zero policy lookups — content truth only.
+//!
+//! 2. **The well-formedness policy** (which compartments exist + their stable
+//!    bit assignment, the lattice *version*) lives in [`Lattice`]. This is the
+//!    "defined once as policy" object (design §3). It is consulted at
+//!    *label-creation / enrollment / genesis* time to (a) **intern** compartment
+//!    *names* into the bit indices a [`SecurityLabel`] carries, and (b) reject
+//!    typo'd / unknown compartments — NOT on the hot path. Closing the
+//!    compartment vocabulary is what makes labels auditable and keeps the TCB
+//!    small.
+//!
+//! Why split them? Because the dominance check must be uncircumventable and
+//! trivially verifiable. If dominance consulted policy, a policy bug could
+//! grant access. By keeping the order intrinsic and only validating
+//! *membership* against policy, a policy bug can at worst reject a legitimate
+//! label (fail-closed), never widen access.
+//!
+//! ## S1↔S4 reconciliation: the name↔bit interner lives here (#547)
+//!
+//! Because [`SecurityLabel`] carries a packed [`CompartmentSet`] bitset (so S4's
+//! AVC can key on it directly), the *one* place that maps a compartment **name**
+//! (`"pii"`) ↔ a **bit index** is this policy object. Genesis / enrollment
+//! resolve names → bits via [`Lattice::intern`]; nothing on the per-op hot path
+//! ever touches a string.
+
+use super::label::{Assurance, Compartment, CompartmentSet, Level, SecurityLabel, MAX_COMPARTMENTS};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fmt;
+
+/// Monotonic lattice policy version. Crypto-agility / policy-agility rule
+/// (design §14): the suite/lattice is *pinned and versioned*; migration is a
+/// deliberate version bump, never an in-band negotiation. Labels and the
+/// `(UCAN, bundle_hash)` approval (S5) bind this version so a label minted
+/// under v1 can't be silently reinterpreted under v2.
+///
+/// **S1↔S4 reconciliation:** this is the SAME monotonic counter that S4's
+/// `compiled::CompiledPolicy.generation` carries — a compiled TE matrix is valid
+/// only against the lattice generation that minted its bit assignments. See
+/// [`LatticeVersion::generation`].
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+pub struct LatticeVersion(pub u32);
+
+impl LatticeVersion {
+    /// The lattice version as the policy **generation** (S4's `CompiledPolicy`
+    /// and AVC tag this same value). They are definitionally equal: a bump of
+    /// the compartment vocabulary IS a new policy generation.
+    #[inline]
+    pub const fn generation(self) -> u64 {
+        self.0 as u64
+    }
+}
+
+impl fmt::Display for LatticeVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "v{}", self.0)
+    }
+}
+
+/// Reasons a label fails the well-formedness policy. All are fail-closed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LabelError {
+    /// A compartment name in the label is not in the policy's known set.
+    UnknownCompartment(Compartment),
+    /// A compartment *bit* in the label has no registered name under this policy
+    /// (an out-of-vocabulary or stale bit — fail-closed).
+    UnknownCompartmentBit(u32),
+    /// The lattice version on the label does not match the active policy.
+    VersionMismatch {
+        expected: LatticeVersion,
+        found: LatticeVersion,
+    },
+}
+
+impl fmt::Display for LabelError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LabelError::UnknownCompartment(c) => {
+                write!(f, "unknown compartment in label: {c}")
+            }
+            LabelError::UnknownCompartmentBit(b) => {
+                write!(f, "unknown compartment bit in label: c{b}")
+            }
+            LabelError::VersionMismatch { expected, found } => {
+                write!(
+                    f,
+                    "lattice version mismatch: expected {expected}, found {found}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for LabelError {}
+
+/// The active lattice policy: the *closed* compartment vocabulary (name↔bit) and
+/// the version. Levels and assurances are fixed by their enums (TCB), so only the
+/// open dimension — compartments — needs a registry.
+///
+/// Built once at startup from the schema `$scope` annotations + site policy
+/// (S3, #569) and treated as immutable thereafter (a change is a version bump).
+/// Bit assignments are stable within a version (S4's compiled TE matrix is keyed
+/// to them via the shared generation).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Lattice {
+    version: LatticeVersion,
+    /// Compartment name → stable bit index. The bit index is what a
+    /// [`SecurityLabel`] actually carries. A label bit with no entry here (or a
+    /// name not present) is ill-formed → rejected at creation.
+    name_to_bit: BTreeMap<Compartment, u32>,
+    /// Reverse map for rendering / audit. Kept in sync with `name_to_bit`.
+    bit_to_name: BTreeMap<u32, Compartment>,
+}
+
+impl Lattice {
+    /// Construct a lattice policy from a compartment vocabulary, assigning each
+    /// name a stable bit index in iteration order (0, 1, 2, …). Duplicate names
+    /// collapse to the first index. Names beyond [`MAX_COMPARTMENTS`] are
+    /// rejected by truncation (they simply never get a bit — fail-closed).
+    pub fn new(
+        version: LatticeVersion,
+        known_compartments: impl IntoIterator<Item = Compartment>,
+    ) -> Self {
+        let mut name_to_bit = BTreeMap::new();
+        let mut bit_to_name = BTreeMap::new();
+        let mut next: u32 = 0;
+        for c in known_compartments {
+            if name_to_bit.contains_key(&c) {
+                continue;
+            }
+            if next >= MAX_COMPARTMENTS {
+                // Vocabulary exceeds the bitset width: refuse to assign (the
+                // name stays unknown → labels using it fail validation). This is
+                // a policy-authoring error surfaced fail-closed.
+                break;
+            }
+            name_to_bit.insert(c.clone(), next);
+            bit_to_name.insert(next, c);
+            next += 1;
+        }
+        Lattice {
+            version,
+            name_to_bit,
+            bit_to_name,
+        }
+    }
+
+    pub fn version(&self) -> LatticeVersion {
+        self.version
+    }
+
+    /// Number of compartments in the vocabulary.
+    pub fn compartment_count(&self) -> u32 {
+        self.name_to_bit.len() as u32
+    }
+
+    /// The bit index assigned to a compartment name, if known.
+    pub fn bit_of(&self, c: &Compartment) -> Option<u32> {
+        self.name_to_bit.get(c).copied()
+    }
+
+    /// The compartment name for a bit index, if registered.
+    pub fn name_of(&self, bit: u32) -> Option<&Compartment> {
+        self.bit_to_name.get(&bit)
+    }
+
+    /// Is `c` a recognized compartment under this policy?
+    pub fn knows(&self, c: &Compartment) -> bool {
+        self.name_to_bit.contains_key(c)
+    }
+
+    /// **Intern** a set of compartment names into a [`CompartmentSet`] bitset.
+    ///
+    /// This is the genesis/enrollment seam that turns the human-facing vocabulary
+    /// into the packed representation a [`SecurityLabel`] carries. An unknown name
+    /// is an error (fail-closed) — it never silently becomes "no compartment".
+    pub fn intern<'a>(
+        &self,
+        names: impl IntoIterator<Item = &'a Compartment>,
+    ) -> Result<CompartmentSet, LabelError> {
+        let mut set = CompartmentSet::EMPTY;
+        for name in names {
+            match self.name_to_bit.get(name) {
+                Some(&bit) => set = set.union(CompartmentSet::single(bit)),
+                None => return Err(LabelError::UnknownCompartment(name.clone())),
+            }
+        }
+        Ok(set)
+    }
+
+    /// Build a [`SecurityLabel`] from names, interning compartments through this
+    /// policy. The ergonomic genesis constructor: `(level, assurance, names) →
+    /// label`. Fails closed on any unknown compartment name.
+    pub fn label(
+        &self,
+        level: Level,
+        assurance: Assurance,
+        names: impl IntoIterator<Item = Compartment>,
+    ) -> Result<SecurityLabel, LabelError> {
+        let owned: Vec<Compartment> = names.into_iter().collect();
+        let compartments = self.intern(owned.iter())?;
+        Ok(SecurityLabel::new(level, assurance, compartments))
+    }
+
+    /// Validate that a label is **well-formed** under this policy: every
+    /// compartment *bit* it carries maps to a registered name. Use at genesis /
+    /// enrollment / seal time before a label is allowed to exist. Does NOT touch
+    /// dominance.
+    pub fn validate(&self, label: &SecurityLabel) -> Result<(), LabelError> {
+        for bit in label.compartments.iter() {
+            if !self.bit_to_name.contains_key(&bit) {
+                return Err(LabelError::UnknownCompartmentBit(bit));
+            }
+        }
+        Ok(())
+    }
+
+    /// The lattice top ⊤ under this policy = max level, max assurance, *all*
+    /// known compartments. The only clearance that dominates every well-formed
+    /// label. (Useful for genesis-labeling the policy authority itself, and for
+    /// tests.)
+    pub fn top(&self) -> SecurityLabel {
+        let all = self
+            .bit_to_name
+            .keys()
+            .copied()
+            .fold(CompartmentSet::EMPTY, |acc, b| {
+                acc.union(CompartmentSet::single(b))
+            });
+        SecurityLabel::new(Level::TOP, Assurance::TOP, all)
+    }
+
+    /// The lattice bottom ⊥ = `(Public, Unverified, {})`. Same as
+    /// [`SecurityLabel::bottom`]; provided here for symmetry with [`top`].
+    ///
+    /// [`top`]: Lattice::top
+    pub fn bottom(&self) -> SecurityLabel {
+        SecurityLabel::bottom()
+    }
+
+    /// Dominance, re-exposed at the policy object for callers that hold a
+    /// `Lattice`. Identical to [`SecurityLabel::dominates`] — the policy does
+    /// NOT change the order; this is purely an ergonomic forwarder. Debug
+    /// builds assert both labels are well-formed (a mis-labeled object reaching
+    /// the monitor is a genesis bug).
+    #[must_use]
+    pub fn dominates(&self, subject: &SecurityLabel, object: &SecurityLabel) -> bool {
+        debug_assert!(self.validate(subject).is_ok(), "subject label ill-formed");
+        debug_assert!(self.validate(object).is_ok(), "object label ill-formed");
+        subject.dominates(object)
+    }
+
+    /// IFC join, re-exposed at the policy object. Identical algebra to
+    /// [`SecurityLabel::join`]; the result is always well-formed if both inputs
+    /// are (union of known compartments is known).
+    #[must_use]
+    pub fn join(&self, a: &SecurityLabel, b: &SecurityLabel) -> SecurityLabel {
+        a.join(b)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn comp(s: &str) -> Compartment {
+        Compartment::new(s)
+    }
+
+    fn policy() -> Lattice {
+        Lattice::new(
+            LatticeVersion(1),
+            [comp("pii"), comp("finance"), comp("tenant:acme")],
+        )
+    }
+
+    #[test]
+    fn intern_assigns_stable_bits() {
+        let p = policy();
+        assert_eq!(p.bit_of(&comp("pii")), Some(0));
+        assert_eq!(p.bit_of(&comp("finance")), Some(1));
+        assert_eq!(p.bit_of(&comp("tenant:acme")), Some(2));
+        assert_eq!(p.bit_of(&comp("nope")), None);
+    }
+
+    #[test]
+    fn label_via_policy_interns_names() {
+        let p = policy();
+        let l = p
+            .label(
+                Level::Confidential,
+                Assurance::Classical,
+                [comp("pii"), comp("finance")],
+            )
+            .unwrap();
+        assert!(l.compartments.contains(0));
+        assert!(l.compartments.contains(1));
+        assert!(p.validate(&l).is_ok());
+    }
+
+    #[test]
+    fn label_via_policy_rejects_unknown_name() {
+        let p = policy();
+        assert_eq!(
+            p.label(Level::Public, Assurance::Classical, [comp("typo")]),
+            Err(LabelError::UnknownCompartment(comp("typo")))
+        );
+    }
+
+    #[test]
+    fn validate_rejects_unregistered_bit() {
+        let p = policy();
+        // Bit 9 has no registered name in a 3-compartment vocabulary.
+        let l = SecurityLabel::from_bits(Level::Public, Assurance::Classical, [9]);
+        assert_eq!(p.validate(&l), Err(LabelError::UnknownCompartmentBit(9)));
+    }
+
+    #[test]
+    fn empty_compartments_always_wellformed() {
+        let l = SecurityLabel::from_bits(Level::Secret, Assurance::PqHybrid, []);
+        assert!(policy().validate(&l).is_ok());
+    }
+
+    #[test]
+    fn top_dominates_every_wellformed_label() {
+        let p = policy();
+        let top = p.top();
+        let arbitrary = p
+            .label(
+                Level::Secret,
+                Assurance::PqHybrid,
+                [comp("pii"), comp("finance"), comp("tenant:acme")],
+            )
+            .unwrap();
+        assert!(p.dominates(&top, &arbitrary));
+    }
+
+    #[test]
+    fn bottom_dominated_by_everything() {
+        let p = policy();
+        let bottom = p.bottom();
+        let any = p
+            .label(Level::Internal, Assurance::Classical, [comp("pii")])
+            .unwrap();
+        assert!(any.dominates(&bottom));
+        // bottom only dominates bottom.
+        assert!(!bottom.dominates(&any));
+        assert!(bottom.dominates(&bottom));
+    }
+
+    #[test]
+    fn lattice_forwarders_match_intrinsic_algebra() {
+        let p = policy();
+        let a = p
+            .label(Level::Internal, Assurance::Classical, [comp("pii")])
+            .unwrap();
+        let b = p
+            .label(Level::Secret, Assurance::PqHybrid, [comp("finance")])
+            .unwrap();
+        assert_eq!(p.dominates(&a, &b), a.dominates(&b));
+        assert_eq!(p.join(&a, &b), a.join(&b));
+    }
+
+    #[test]
+    fn version_display_and_generation() {
+        assert_eq!(LatticeVersion(3).to_string(), "v3");
+        // S1↔S4: LatticeVersion ≡ CompiledPolicy.generation.
+        assert_eq!(LatticeVersion(3).generation(), 3u64);
+    }
+}

--- a/crates/hyprstream-rpc/src/auth/mac/manifest.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/manifest.rs
@@ -1,0 +1,149 @@
+//! The **object-label seam** — where an object's content-bound label comes from.
+//!
+//! Design §3: "Data layers: `security_label` in the content-addressed manifest —
+//! cryptographically bound; can't be relabeled without changing the hash
+//! (stronger than SELinux xattrs)." The per-op monitor (S2) reads the object's
+//! label from here and feeds it into `subject.ctx ⊒ object.label`.
+//!
+//! ## Why this is a trait, not a struct
+//!
+//! **The content-addressed CAS manifest layer does not exist yet** in this
+//! codebase (the only "manifest" types today are OCI image manifests in
+//! `hyprstream-workers` and release/context manifests — none is the data-plane
+//! CAS manifest with a `security_label`). So S1 cannot fabricate it. Instead S1
+//! defines:
+//!
+//! - [`LabeledObject`] — the seam the monitor (S2) and PDP (S4) program against:
+//!   "give me this object's label." Implemented later by the real manifest type.
+//! - [`ContentBoundLabel`] — the *binding contract* a real manifest must honor:
+//!   the label is covered by the content hash, so relabeling changes the CID.
+//! - [`StaticNodeLabel`] — the satisfiable-today case: static schema nodes
+//!   (status/ctl/health) whose label is declared in the `$scope` annotation, not
+//!   stored in a manifest. These can be labeled and enforced immediately.
+//!
+//! This keeps the interface S2/S4 consume stable while honestly flagging the
+//! data-plane part as blocked (see module-level BLOCKERS in `mod.rs`).
+
+use super::label::SecurityLabel;
+
+/// Anything the reference monitor can ask for a security label.
+///
+/// The monitor never accepts a label from a token/UCAN/caveat (design §3, §14);
+/// it asks the object. For data layers the impl reads the manifest's
+/// content-bound `security_label`; for static nodes it returns the schema-
+/// declared label.
+pub trait LabeledObject {
+    /// This object's security label. `None` ⇒ **unlabeled** ⇒ the monitor MUST
+    /// deny (no unlabeled-default-allow; design §1 invariant 2). Implementors
+    /// must NOT manufacture a permissive default here.
+    fn security_label(&self) -> Option<SecurityLabel>;
+}
+
+/// The binding contract a real CAS manifest must satisfy: the label is bound to
+/// the content hash, so an attacker cannot relabel without producing a new CID
+/// (and thus a new object). This is the property that makes the object label
+/// *content-truth* rather than a mutable xattr.
+///
+/// S1 specifies the contract; the implementation lands with the manifest layer.
+/// A conforming manifest serializes `security_label` *inside* the bytes that the
+/// CID covers — verifying this is the manifest layer's test, asserted here as a
+/// documented invariant.
+pub trait ContentBoundLabel: LabeledObject {
+    /// The content identifier (hash) of the manifest. The label returned by
+    /// [`LabeledObject::security_label`] MUST be part of the preimage of this
+    /// CID.
+    fn content_id(&self) -> &[u8];
+
+    /// Recompute the CID over the manifest bytes (including the label) and check
+    /// it equals [`content_id`]. A real impl uses this to *verify* the binding
+    /// when a manifest is loaded from the store — a mismatch ⇒ tampered ⇒ deny.
+    ///
+    /// Default impl is `false` (fail-closed) so a stub that forgets to implement
+    /// verification denies rather than trusts.
+    ///
+    /// [`content_id`]: ContentBoundLabel::content_id
+    fn verify_binding(&self) -> bool {
+        false
+    }
+}
+
+/// A static schema node's label (status/ctl/health and other declared nodes).
+///
+/// This is the immediately-satisfiable half of object labeling: the label comes
+/// from the `$scope`/TE annotation in the schema (S3, #569), not from a CAS
+/// manifest, so it needs no data-plane store. Genesis labeling (see
+/// [`super::genesis`]) assigns one of these to every static node before
+/// enforcement turns on.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StaticNodeLabel {
+    /// Schema-declared label for this node. Always `Some` once genesis is
+    /// complete — a static node with no declared label is a genesis gap and the
+    /// `Option` surfaces it as "unlabeled → deny".
+    label: Option<SecurityLabel>,
+}
+
+impl StaticNodeLabel {
+    /// A labeled static node.
+    pub fn labeled(label: SecurityLabel) -> Self {
+        StaticNodeLabel { label: Some(label) }
+    }
+
+    /// An explicitly-unlabeled node (genesis gap). Provided so callers can
+    /// represent "no label declared" without reaching for a permissive default.
+    pub fn unlabeled() -> Self {
+        StaticNodeLabel { label: None }
+    }
+}
+
+impl LabeledObject for StaticNodeLabel {
+    fn security_label(&self) -> Option<SecurityLabel> {
+        self.label
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::super::label::{Assurance, CompartmentSet, Level};
+    use super::*;
+
+    #[test]
+    fn static_node_returns_declared_label() {
+        let l = SecurityLabel::new(Level::Internal, Assurance::Classical, CompartmentSet::EMPTY);
+        let node = StaticNodeLabel::labeled(l);
+        assert_eq!(node.security_label(), Some(l));
+    }
+
+    #[test]
+    fn unlabeled_static_node_returns_none() {
+        // → monitor denies. No permissive default.
+        assert!(StaticNodeLabel::unlabeled().security_label().is_none());
+    }
+
+    // A stub manifest demonstrating the seam compiles and fails closed.
+    struct StubManifest {
+        cid: Vec<u8>,
+        label: SecurityLabel,
+    }
+    impl LabeledObject for StubManifest {
+        fn security_label(&self) -> Option<SecurityLabel> {
+            Some(self.label)
+        }
+    }
+    impl ContentBoundLabel for StubManifest {
+        fn content_id(&self) -> &[u8] {
+            &self.cid
+        }
+        // intentionally does NOT override verify_binding → default false.
+    }
+
+    #[test]
+    fn content_bound_default_verify_fails_closed() {
+        let m = StubManifest {
+            cid: vec![1, 2, 3],
+            label: SecurityLabel::new(Level::Secret, Assurance::PqHybrid, CompartmentSet::EMPTY),
+        };
+        assert!(!m.verify_binding(), "unimplemented binding check must fail closed");
+        assert_eq!(m.content_id(), &[1, 2, 3]);
+    }
+}

--- a/crates/hyprstream-rpc/src/auth/mac/mod.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/mod.rs
@@ -113,7 +113,7 @@ pub use genesis::{GenesisMap, GenesisReport};
 pub use label::{
     Assurance, Compartment, CompartmentSet, Level, SecurityLabel, MAX_COMPARTMENTS,
 };
-pub use lattice::{LabelError, Lattice, LatticeVersion};
+pub use lattice::{LabelError, Lattice, LatticeCodecError, LatticeDecodeError, LatticeVersion};
 pub use manifest::{ContentBoundLabel, LabeledObject, StaticNodeLabel};
 
 #[cfg(test)]

--- a/crates/hyprstream-rpc/src/auth/mac/mod.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/mod.rs
@@ -1,0 +1,226 @@
+//! Native MAC — security labels, the lattice, subject contexts, and genesis
+//! labeling. **S1 (#567), the foundation of epic #547.**
+//!
+//! This module is the **TCB seam** the rest of the security epic consumes. It
+//! defines *what a label is*, *how labels compare* (dominance ⊒ and IFC join ⊔),
+//! *where a subject's clearance comes from*, *where an object's label comes
+//! from*, and *how everything gets an initial label* (genesis). It deliberately
+//! contains no enforcement, no policy distribution, and no token logic — those
+//! are S2/S4/S6.
+//!
+//! ## The lattice (small + verifiable, by design)
+//!
+//! A label is a point in the product lattice
+//! ```text
+//!     Level  ×  Assurance  ×  P(Compartment)
+//!     (MLS)     (#548)         (need-to-know)
+//! ```
+//! - **Level** — total order `public < internal < confidential < secret`.
+//! - **Assurance** — total order `unverified < classical < pq-hybrid`, *derived
+//!   from verified key material* (#548), never claimed.
+//! - **Compartments** — powerset lattice under ⊆ (a closed vocabulary, policy).
+//!
+//! Dominance is the product order (≥ on each total axis, ⊇ on the compartment
+//! set); join is component-wise (max / max / ∪). Both are pure functions on
+//! [`SecurityLabel`] with **no policy argument** — content truth, uncircumventable.
+//!
+//! ## Interface contract for S2 (enforcement) and S4 (PDP)
+//!
+//! S1 hands the downstream tickets exactly these stable entry-points:
+//!
+//! - **S2 — reference-monitor per-op check (#568).** For each op the monitor:
+//!   1. obtains the **object label** via [`manifest::LabeledObject::security_label`]
+//!      — `None` ⇒ DENY (unlabeled object);
+//!   2. obtains the **subject context** via
+//!      [`context::SubjectContextClaims::security_context`] (clearance from
+//!      verified claims, assurance derived from verified key material) — `None`
+//!      ⇒ DENY (unlabeled subject);
+//!   3. evaluates the MAC floor [`context::SecurityContext::dominates`]
+//!      (≡ [`SecurityLabel::dominates`]) — `false` ⇒ DENY.
+//!   The monitor takes object labels ONLY from `LabeledObject`, never from a
+//!   token/UCAN/caveat (design §3, §14). It needs no `Lattice` on the hot path:
+//!   dominance is intrinsic.
+//!
+//! - **S2 — IFC at seal/rollup (#568).** A derived object's label =
+//!   [`SecurityLabel::join_all`] over its provenance inputs' labels. Aggregation
+//!   cannot launder classification.
+//!
+//! - **S4 — PDP / lattice engine (#570).** The PDP owns the [`lattice::Lattice`]
+//!   policy object: it [`validate`](lattice::Lattice::validate)s labels at
+//!   enrollment/seal, exposes the pinned [`lattice::LatticeVersion`] for the
+//!   `(UCAN, bundle_hash)` approval binding (S5), and computes the
+//!   **label-ceiling clamp** (§5a) as `min`/dominance over the lattice. The PDP
+//!   never re-implements the order — it reuses the intrinsic [`SecurityLabel`]
+//!   algebra, so the PDP's clamp and the monitor's floor are provably the same
+//!   relation.
+//!
+//! - **Both — derived value:** `effective = approved-ceiling ∩ MAC clearance ∩
+//!   self-attenuation` (design §5). The "∩ MAC clearance" factor is exactly the
+//!   dominance/clamp defined here; S5/S6 compose it, they do not redefine it.
+//!
+//! ## BLOCKERS (what S1 cannot finish, and why)
+//!
+//! S1 ships everything that is genuinely unblocked (the label + lattice + ops +
+//! subject context + genesis mechanism + static-node labels, all tested). The
+//! following are **defined as seams** here but gated on other work:
+//!
+//! 1. **Content-bound manifest labels** ← the data-plane CAS manifest store.
+//!    The content-addressed manifest with a `security_label` field *does not
+//!    exist yet* (today's "manifests" are OCI image / release / context
+//!    manifests, none data-plane CAS). S1 defines the
+//!    [`manifest::ContentBoundLabel`] contract + [`manifest::LabeledObject`]
+//!    seam; the implementation (label-in-CID binding + `verify_binding`) lands
+//!    with the CAS manifest layer. **Static-node labels are NOT blocked** and
+//!    are implemented here.
+//!
+//! 2. **Subject clearance wire field on `Claims`/envelope** ← S8 (#574, hybrid
+//!    envelope). S1 defines the [`context::SubjectContextClaims`] trait that the
+//!    verified claims will implement; the concrete `clearance` field is added to
+//!    `Claims` / `common.capnp` under S8 so the new authz field ships on the
+//!    hybrid-signed (EdDSA + ML-DSA-65) envelope, not the classical one. Until
+//!    then S2/S4 program against the trait and test with a stub.
+//!
+//! 3. **Assurance derivation source** ← #441 / #280 (authoritative key binding)
+//!    + `register_pq_trust`. [`context::VerifiedKeyMaterial`] is the seam; the
+//!    *production* of it (was the ML-DSA-65 anchor actually bound + verified for
+//!    this identity?) is the envelope-verification + key-binding layer's job.
+//!    Until a binding is authoritative, an identity is `Classical` at best and
+//!    `Unverified` if even the classical signature can't be checked — both
+//!    fail-closed.
+//!
+//! 4. **Compartment vocabulary / genesis content** ← S3 (#569, `$scope`/TE
+//!    annotations). S1 defines [`lattice::Lattice`] (the closed vocabulary
+//!    holder) and [`genesis::GenesisMap`] (the path→label mechanism + the
+//!    completeness gate); the *actual* compartment names and the per-node label
+//!    table come from the schema annotations + site policy that S3 produces.
+//!
+//! 5. **PQ-confidentiality labels are unsatisfiable today** ← #153 (streaming
+//!    DH → ML-KEM-768 hybrid KEM). The assurance axis covers *signature*
+//!    assurance, which is shippable. A future *confidentiality* requirement
+//!    (data that must travel a PQ-KEM path) has no satisfying transport until
+//!    #153 wires `pq_kem_ciphertext`; such a label is simply undominated →
+//!    fail-closed, which is correct. No type change needed when #153 lands —
+//!    it's a new compartment/level value, not a new axis.
+
+pub mod context;
+pub mod genesis;
+pub mod label;
+pub mod lattice;
+pub mod manifest;
+
+pub use context::{SecurityContext, SubjectContextClaims, VerifiedKeyMaterial};
+pub use genesis::{GenesisMap, GenesisReport};
+pub use label::{
+    Assurance, Compartment, CompartmentSet, Level, SecurityLabel, MAX_COMPARTMENTS,
+};
+pub use lattice::{LabelError, Lattice, LatticeVersion};
+pub use manifest::{ContentBoundLabel, LabeledObject, StaticNodeLabel};
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod integration_tests {
+    //! End-to-end shape of the per-op check S2 will perform, exercised against
+    //! the S1 seams only (object via `LabeledObject`, subject via
+    //! `SubjectContextClaims`, floor via `dominates`).
+    use super::*;
+
+    struct StubClaims(Option<SecurityLabel>);
+    impl SubjectContextClaims for StubClaims {
+        fn clearance_label(&self) -> Option<SecurityLabel> {
+            self.0
+        }
+    }
+
+    /// The exact ALLOW predicate the monitor (S2) computes for the MAC floor,
+    /// using only S1 seams. Returns true ⇒ floor permits; both unlabeled cases
+    /// return false (deny).
+    fn mac_floor(
+        object: &dyn LabeledObject,
+        claims: &dyn SubjectContextClaims,
+        key_material: VerifiedKeyMaterial,
+    ) -> bool {
+        let Some(object_label) = object.security_label() else {
+            return false; // unlabeled object → deny
+        };
+        let Some(ctx) = claims.security_context(key_material) else {
+            return false; // unlabeled subject → deny
+        };
+        ctx.dominates(&object_label)
+    }
+
+    /// A compartment bitset from bit indices (bit 0 = "pii", 1 = "finance", … in
+    /// these tests). The policy interns names→bits; here we work in bits.
+    fn comps(bits: &[u32]) -> CompartmentSet {
+        bits.iter().copied().collect()
+    }
+
+    #[test]
+    fn allow_when_cleared() {
+        let object = StaticNodeLabel::labeled(SecurityLabel::new(
+            Level::Confidential,
+            Assurance::Classical,
+            comps(&[0]), // pii
+        ));
+        let claims = StubClaims(Some(SecurityLabel::new(
+            Level::Secret,
+            Assurance::PqHybrid,
+            comps(&[0, 1]), // pii, finance
+        )));
+        assert!(mac_floor(&object, &claims, VerifiedKeyMaterial::PqHybrid));
+    }
+
+    #[test]
+    fn deny_unlabeled_object() {
+        let object = StaticNodeLabel::unlabeled();
+        let claims = StubClaims(Some(Lattice::new(LatticeVersion(1), []).top()));
+        assert!(!mac_floor(&object, &claims, VerifiedKeyMaterial::PqHybrid));
+    }
+
+    #[test]
+    fn deny_unlabeled_subject() {
+        let object = StaticNodeLabel::labeled(SecurityLabel::new(
+            Level::Public,
+            Assurance::Classical,
+            CompartmentSet::EMPTY,
+        ));
+        let claims = StubClaims(None);
+        assert!(!mac_floor(&object, &claims, VerifiedKeyMaterial::PqHybrid));
+    }
+
+    #[test]
+    fn deny_classical_subject_on_pqc_object_no_special_path() {
+        // #548 end-to-end: the assurance axis denies via the SAME dominance
+        // check — no separate code path.
+        let object = StaticNodeLabel::labeled(SecurityLabel::new(
+            Level::Public,
+            Assurance::PqHybrid,
+            CompartmentSet::EMPTY,
+        ));
+        let claims = StubClaims(Some(SecurityLabel::new(
+            Level::Secret,
+            Assurance::PqHybrid, // policy assigned high, but...
+            CompartmentSet::EMPTY,
+        )));
+        // ...the verified key material is only Classical → clamped → denied.
+        assert!(!mac_floor(&object, &claims, VerifiedKeyMaterial::Classical));
+        // a PQC-bound key passes.
+        assert!(mac_floor(&object, &claims, VerifiedKeyMaterial::PqHybrid));
+    }
+
+    #[test]
+    fn ifc_join_propagates_to_derived_object() {
+        // A derived object sealed from a secret + a classical input is
+        // secret/pq-hybrid — and a merely-classical subject can't read it.
+        let secret_in = SecurityLabel::new(Level::Secret, Assurance::PqHybrid, comps(&[0]));
+        let public_in = SecurityLabel::new(Level::Public, Assurance::Classical, CompartmentSet::EMPTY);
+        let derived = SecurityLabel::join_all([&secret_in, &public_in]);
+        let object = StaticNodeLabel::labeled(derived);
+
+        let low = StubClaims(Some(SecurityLabel::new(
+            Level::Internal,
+            Assurance::Classical,
+            CompartmentSet::EMPTY,
+        )));
+        assert!(!mac_floor(&object, &low, VerifiedKeyMaterial::Classical));
+    }
+}

--- a/crates/hyprstream-rpc/src/auth/mod.rs
+++ b/crates/hyprstream-rpc/src/auth/mod.rs
@@ -27,8 +27,9 @@ pub use claims::{Claims, Cnf, CnfJwk, IdTokenClaims, OneOrMany, compute_jkt, is_
 pub use jti_blocklist::{InMemoryJtiBlocklist, JtiBlocklist};
 pub use mac::{
     Assurance, Compartment, CompartmentSet, ContentBoundLabel, GenesisMap, GenesisReport,
-    LabelError, LabeledObject, Lattice, LatticeVersion, Level, SecurityContext, SecurityLabel,
-    StaticNodeLabel, SubjectContextClaims, VerifiedKeyMaterial, MAX_COMPARTMENTS,
+    LabelError, LabeledObject, Lattice, LatticeCodecError, LatticeDecodeError, LatticeVersion,
+    Level, SecurityContext, SecurityLabel, StaticNodeLabel, SubjectContextClaims,
+    VerifiedKeyMaterial, MAX_COMPARTMENTS,
 };
 #[cfg(not(target_arch = "wasm32"))]
 pub use federation::FederationKeySource;

--- a/crates/hyprstream-rpc/src/auth/mod.rs
+++ b/crates/hyprstream-rpc/src/auth/mod.rs
@@ -12,6 +12,9 @@ pub mod claims;
 pub mod federation;
 pub mod jti_blocklist;
 pub mod jwt;
+/// Native MAC: security labels, lattice, subject contexts, genesis labeling
+/// (S1, #567). Platform-independent (no std-only deps) so it compiles for wasm.
+pub mod mac;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod key_source;
 #[cfg(not(target_arch = "wasm32"))]
@@ -22,6 +25,11 @@ pub mod scope_registry;
 
 pub use claims::{Claims, Cnf, CnfJwk, IdTokenClaims, OneOrMany, compute_jkt, is_local_iss};
 pub use jti_blocklist::{InMemoryJtiBlocklist, JtiBlocklist};
+pub use mac::{
+    Assurance, Compartment, CompartmentSet, ContentBoundLabel, GenesisMap, GenesisReport,
+    LabelError, LabeledObject, Lattice, LatticeVersion, Level, SecurityContext, SecurityLabel,
+    StaticNodeLabel, SubjectContextClaims, VerifiedKeyMaterial, MAX_COMPARTMENTS,
+};
 #[cfg(not(target_arch = "wasm32"))]
 pub use federation::FederationKeySource;
 pub use jwt::{decode, decode_unverified, decode_with_key, encode, encode_service_jwt, header_alg, header_kid, jwk_thumbprint, JwkThumbprintInput, JwtError};


### PR DESCRIPTION
## Problem

The RPM workflow's `pull_request.paths` filter included `crates/**`, `Cargo.toml`, and `Cargo.lock`, so the two-container (Fedora + Rocky) RPM build+install matrix fired on essentially **every** PR touching Rust source — not just changes to the RPM packaging.

## Change

Narrow the `pull_request.paths` filter to the RPM packaging inputs:

- `packaging/rpm/**`
- `.github/workflows/rpm.yml`

Release behavior is unchanged: `push` tags (`v*`) still build and attach RPMs to releases, and `workflow_dispatch` remains for manual runs.

## Trade-off

A Rust/dependency change that breaks the RPM build (without touching packaging files) will now only surface at release-tag time rather than on the PR. If broader coverage is wanted later, running this on `push` to `main` is a reasonable middle ground.