### PR TITLE
ci: run PR checks on any base branch, not just main

### DIFF
--- a/.github/workflows/archlinux.yml
+++ b/.github/workflows/archlinux.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - 'archlinux/**'
   pull_request:
-    branches: [ "main" ]
     paths:
       - 'archlinux/**'
   release:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -9,7 +9,6 @@ on:
       - 'flake.lock'
       - 'nix/**'
   pull_request:
-    branches: [ "main" ]
     paths:
       - 'flake.nix'
       - 'flake.lock'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
   merge_group:
 
 env:


### PR DESCRIPTION
## Problem

`rust.yml`, `archlinux.yml`, and `nix.yml` gated their `pull_request` trigger on `branches: [ "main" ]`. PRs targeting epic/feature base branches (not `main`) therefore got **zero** per-PR CI — e.g. #547's stacked PRs #582/#583, where a build panic slipped through with no per-PR signal.

## Change

Drop the `pull_request` branch filter in all three workflows so a PR to **any** base branch triggers checks.

Everything else is unchanged:
- `paths:` filters on archlinux.yml / nix.yml — kept
- `push: branches: [ "main" ]` — kept
- `merge_group` — kept

`claude-code-review.yml` and `rpm.yml` already lack a PR branch filter and are left untouched.

## Note

In `rust.yml`, the heavy `build` job still carries its existing `if: github.event_name != 'pull_request'` guard, so per-PR push runs the fast jobs (clippy / cargo-deny / wasm) — the full build+test continues to run in the merge queue and on push to `main`, by existing design. This PR only broadens *which base branches* get PR signal; it does not change *which jobs* run per-PR. clippy compiles `--workspace --all-targets`, so build-time breakage on epic-branch PRs will now surface.

Requested by OPERATOR via multi-pane coordination; owner: GitHub Actions.