### PR TITLE
ci: nextest per-test timeout + merge-gate backstop (fail-fast on hangs)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,14 @@
+# cargo-nextest config — consumed by the merge-gate `build` job in
+# .github/workflows/rust.yml (cargo nextest run --profile ci).
+#
+# slow-timeout marks a test "slow" after `period`, then SIGKILLs it after
+# `terminate-after` periods. So a deadlocked test (e.g. a moq relay reconnect
+# that never settles) dies at ~3 x 60s = 3min and fails the run fast, instead of
+# burning the whole job / merge-queue budget (job timeout 115min, queue 120min).
+#
+# This is a per-TEST cap: the legitimate suite is long (~76min on main), so a
+# global/per-step timeout could not distinguish a hang from healthy runtime.
+# If a genuinely-slow-but-correct test trips this, raise `period` (a test is only
+# KILLED after `terminate-after` periods, not merely flagged slow).
+[profile.ci]
+slow-timeout = { period = "60s", terminate-after = 3 }

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -100,6 +100,11 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs: clippy  # Only build if clippy passes
+    # Merge-gate backstop: fail before the merge queue's 120min timeout (ruleset
+    # check_response_timeout_minutes) so a hang yields a definitive failure and the
+    # queue keeps moving instead of timing out and kicking every queued PR. Healthy
+    # build+test is ~90min (Build ~13m / Run tests ~76m), so 115 leaves margin.
+    timeout-minutes: 115
 
     steps:
     - uses: actions/checkout@v4
@@ -120,5 +125,17 @@ jobs:
     - name: Build
       run: cargo build --release --verbose --features download-libtorch
 
-    - name: Run tests
-      run: cargo test --release --verbose --features download-libtorch
+    - name: Install cargo-nextest
+      uses: taiki-e/install-action@nextest
+
+    - name: Run tests (nextest, per-test timeout)
+      # nextest enforces the per-TEST slow-timeout from .config/nextest.toml
+      # ([profile.ci]): a single deadlocked test is SIGKILLed after ~3min and fails
+      # fast, instead of stalling the job until the 115min job / 120min queue
+      # timeout. The cap is per-test on purpose — the legit suite is long (~76min),
+      # so a per-step timeout could not tell a hang from healthy runtime.
+      run: cargo nextest run --release --profile ci --features download-libtorch
+
+    - name: Run doctests
+      # nextest does not run doctests; keep them in the merge gate.
+      run: cargo test --release --doc --features download-libtorch


### PR DESCRIPTION
**Calm CI hardening** (no active incident). Coordinated with 1:3.0 / 1:2.0. The suspected moq #148 "hang" turned out to be the legitimate ~76min test suite, not a deadlock — so **no `#[ignore]`** is bundled here; this is purely a fail-fast backstop for *future* real hangs.

## Problem
The merge-gate `build` job ran `cargo test` with no timeout. A single deadlocked test could stall until the merge queue's **120min** timeout (`protection` ruleset, `check_response_timeout_minutes`) fired — which kicks **every** queued PR. The healthy suite is genuinely long (Run tests ~76min, Build ~13min), so a per-step/global timeout can't distinguish a hang from real runtime.

## Change
- **Per-test timeout via cargo-nextest** — `.config/nextest.toml [profile.ci]`: `slow-timeout { period = 60s, terminate-after = 3 }` → a hung test is SIGKILLed at ~3min and fails fast, while the long legit suite still runs.
- **Separate doctest step** — nextest does not run doctests; `cargo test --doc` keeps them in the gate.
- **Job `timeout-minutes: 115`** — backstop just under the 120min queue timeout, so any hang (even outside the test step) yields a definitive failure and the queue keeps moving instead of timing out.

## ⚠️ Validate before un-drafting
nextest runs **each test in its own process**, so the heavy libtorch suite loads libtorch per process — possible **OOM/slowdown** on the 7GB runner. Need **one green nextest run** (build job is `if: != pull_request`, so it does *not* run on this PR — validate via the merge-queue dry-run, a temporary push to `main`-like branch, or temporarily relaxing the `if:`). If it OOMs/flakes, constrain with `[profile.ci] test-threads` or a serial `test-group` for tch tests.

Owner: CI (1:4.0). Handing to 1:3.0 to drive validation.