### PR TITLE
feat(security) S5: UCAN→Casbin/TE compiler core — milestone 1 (#571)

### DIFF
--- a/crates/hyprstream-rpc/src/auth/mod.rs
+++ b/crates/hyprstream-rpc/src/auth/mod.rs
@@ -22,6 +22,10 @@ pub mod key_subject_resolver;
 pub mod scope;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod scope_registry;
+/// UCAN → Casbin/TE compiler foundation (S5, #571): the UCAN token model,
+/// delegation-chain + ceiling/attenuation validation, and the signed
+/// `(UCAN, bundle_hash)` approval binding (hybrid EdDSA + ML-DSA-65 COSE).
+pub mod ucan;
 
 pub use claims::{Claims, Cnf, CnfJwk, IdTokenClaims, OneOrMany, compute_jkt, is_local_iss};
 pub use jti_blocklist::{InMemoryJtiBlocklist, JtiBlocklist};
@@ -41,3 +45,7 @@ pub use key_subject_resolver::{KeySubjectResolver, set_global as set_global_key_
 pub use scope::Scope;
 #[cfg(not(target_arch = "wasm32"))]
 pub use scope_registry::ScopeDefinition;
+pub use ucan::{
+    set_attenuates, Ability, ApprovalBinding, ApprovalError, Capability, CaveatValue, Caveats,
+    ChainError, Did, Resource, SignedApproval, Ucan, UcanError, UcanPayload, UcanVerifier,
+};

--- a/crates/hyprstream-rpc/src/auth/ucan/approval.rs
+++ b/crates/hyprstream-rpc/src/auth/ucan/approval.rs
@@ -1,0 +1,362 @@
+//! The signed **`(UCAN, bundle_hash)` approval binding** (S5 / #571).
+//!
+//! This is the containment backstop of the whole compiler design (#547, design
+//! §14): an approved UCAN is cryptographically tied to the **hash of the bundle
+//! it compiles to**, so a compiler bug can never produce a bundle that exceeds
+//! what was reviewed. The reviewer approves a specific `(UCAN, lattice
+//! generation, bundle_hash)` triple; the policy loader (S4
+//! `compiled::PolicyLoader`) then accepts ONLY a compiled policy whose recomputed
+//! hash matches an approval for its generation.
+//!
+//! ## What this binds, and why those three things
+//!
+//! - **`ucan_cid`** — the content hash (BLAKE3 of canonical CBOR) of the
+//!   approved UCAN. Ties the approval to the *exact* delegation that was
+//!   reviewed; re-issuing or mutating the UCAN changes the CID.
+//! - **`generation`** — the [`LatticeVersion`] generation the bundle is valid
+//!   for. Binding it prevents replaying an approval under a different lattice
+//!   version whose compartment bits mean something else (the same desync guard
+//!   S4 enforces; design §14 crypto/policy-agility).
+//! - **`bundle_hash`** — the `[u8; 32]` BLAKE3 hash of the compiled bundle. This
+//!   is **exactly** the value S4's `CompiledPolicy::policy_hash()` produces and
+//!   `compiled::PolicyApproval::approved_hash` consumes, so an
+//!   [`ApprovalBinding`] minted here drops straight into the S4 loader once
+//!   bundle emission (milestone 2) is wired.
+//!
+//! ## Signing: hybrid COSE, NEVER Ed25519-only
+//!
+//! The binding is signed with the project's hybrid post-quantum COSE composite
+//! (EdDSA + ML-DSA-65) via [`crate::crypto::cose_sign::sign_composite`] and
+//! verified with `require_pq = true`. A classical-only signature is rejected
+//! (fail-closed) — an approval is a long-lived authority artifact and is exactly
+//! the kind of confidentiality/integrity-critical object the hybrid-PQC plan
+//! requires to resist harvest-now-decrypt-later forgery.
+
+use crate::crypto::cose_sign::{sign_composite, verify_composite};
+use crate::crypto::pq::{MlDsaSigningKey, MlDsaVerifyingKey};
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+use super::token::Ucan;
+
+/// Domain-separation AAD for approval-binding signatures. Distinct from the UCAN
+/// payload AAD (`hs-mac-ucan-payload-v1`), the compiled-policy AAD
+/// (`hs-mac-compiled-policy-v1`), and envelope AADs, so an approval signature can
+/// never be confused with — or replayed as — any other signed object.
+pub const APPROVAL_AAD: &[u8] = b"hs-mac-ucan-approval-v1";
+
+/// BLAKE3 content id of a UCAN: hash of its canonical CBOR encoding. The same
+/// codec the rest of the MAC stack uses, so the CID is stable across processes.
+pub fn ucan_cid(ucan: &Ucan) -> Result<[u8; 32], ApprovalError> {
+    let bytes = ucan
+        .to_cbor()
+        .map_err(|e| ApprovalError::Encode(e.to_string()))?;
+    Ok(*blake3::hash(&bytes).as_bytes())
+}
+
+/// The reviewed binding: the approved UCAN's CID, the lattice generation it is
+/// valid for, and the hash of the bundle it compiles to. These are the bytes the
+/// hybrid-COSE signature covers (see [`ApprovalBinding::signing_payload`]).
+///
+/// `bundle_hash` is intentionally a raw `[u8; 32]` — the exact type S4's
+/// `CompiledPolicy::policy_hash()` returns — so milestone-2 bundle emission feeds
+/// its output straight in with no conversion, and a verified binding yields an
+/// S4 `compiled::PolicyApproval { generation, approved_hash: bundle_hash }`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ApprovalBinding {
+    /// BLAKE3 CID of the approved UCAN ([`ucan_cid`]).
+    pub ucan_cid: [u8; 32],
+    /// The lattice/policy generation this bundle is valid for
+    /// ([`LatticeVersion::generation`]). Bound so the approval cannot be replayed
+    /// under a different compartment vocabulary.
+    pub generation: u64,
+    /// BLAKE3 hash of the compiled bundle (== S4 `CompiledPolicy::policy_hash()`).
+    pub bundle_hash: [u8; 32],
+}
+
+impl ApprovalBinding {
+    /// Construct a binding from an approved UCAN, the generation it targets, and
+    /// the hash of the bundle it compiled to.
+    pub fn new(ucan: &Ucan, generation: u64, bundle_hash: [u8; 32]) -> Result<Self, ApprovalError> {
+        Ok(Self {
+            ucan_cid: ucan_cid(ucan)?,
+            generation,
+            bundle_hash,
+        })
+    }
+
+    /// The exact, domain-separated bytes the signature covers:
+    /// `b"hs-mac-ucan-approval" || ucan_cid || generation_be || bundle_hash`.
+    /// Deterministic and length-prefixed by fixed field widths, so the layout is
+    /// unambiguous.
+    pub fn signing_payload(&self) -> Vec<u8> {
+        let mut v = Vec::with_capacity(19 + 32 + 8 + 32);
+        v.extend_from_slice(b"hs-mac-ucan-approval"); // intra-payload tag (belt-and-braces with AAD)
+        v.extend_from_slice(&self.ucan_cid);
+        v.extend_from_slice(&self.generation.to_be_bytes());
+        v.extend_from_slice(&self.bundle_hash);
+        v
+    }
+}
+
+/// A signed approval: the binding plus a detached hybrid-COSE composite
+/// signature over its [`ApprovalBinding::signing_payload`]. This is the artifact
+/// a reviewer/authority emits and the policy loader consumes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SignedApproval {
+    /// The reviewed binding (re-derivable + re-hashable at the verifier).
+    pub binding: ApprovalBinding,
+    /// Detached hybrid-COSE composite signature (EdDSA + ML-DSA-65).
+    pub signature: Vec<u8>,
+}
+
+impl SignedApproval {
+    /// Sign an approval binding with the authority's HYBRID keypair. `pq_sk`
+    /// MUST be `Some` — an approval is never Ed25519-only (design §14). Passing
+    /// the classical key without a PQ key is rejected fail-closed so a misuse
+    /// can't silently downgrade the suite.
+    pub fn sign(
+        binding: ApprovalBinding,
+        ed_sk: &SigningKey,
+        pq_sk: &MlDsaSigningKey,
+    ) -> Result<Self, ApprovalError> {
+        let payload = binding.signing_payload();
+        let signature = sign_composite(ed_sk, Some(pq_sk), &payload, APPROVAL_AAD)
+            .map_err(|e| ApprovalError::Sign(e.to_string()))?;
+        Ok(Self { binding, signature })
+    }
+
+    /// Verify the approval under the HYBRID policy (`require_pq = true`): both the
+    /// EdDSA and the anchored ML-DSA-65 layers must verify against the authority's
+    /// keys, over the binding's signing payload. Fail-closed: a stripped PQ layer,
+    /// a wrong key, or a tampered binding all reject.
+    ///
+    /// On success returns the verified [`ApprovalBinding`] (so the caller does not
+    /// re-trust `self.binding` without having checked the signature).
+    pub fn verify(
+        &self,
+        ed_vk: &VerifyingKey,
+        pq_vk: &MlDsaVerifyingKey,
+    ) -> Result<&ApprovalBinding, ApprovalError> {
+        let payload = self.binding.signing_payload();
+        verify_composite(
+            &self.signature,
+            ed_vk,
+            Some(pq_vk),
+            &payload,
+            APPROVAL_AAD,
+            true,
+        )
+        .map_err(|e| ApprovalError::Verify(e.to_string()))?;
+        Ok(&self.binding)
+    }
+
+    /// Verify the approval AND confirm it binds the given UCAN, generation, and
+    /// bundle hash. This is the check the policy loader runs: it has the compiled
+    /// bundle's `(generation, bundle_hash)` and the approved UCAN in hand and must
+    /// confirm the signed approval covers exactly them. Fail-closed on any
+    /// mismatch.
+    pub fn verify_binds(
+        &self,
+        ed_vk: &VerifyingKey,
+        pq_vk: &MlDsaVerifyingKey,
+        ucan: &Ucan,
+        generation: u64,
+        bundle_hash: &[u8; 32],
+    ) -> Result<(), ApprovalError> {
+        let binding = self.verify(ed_vk, pq_vk)?;
+        let cid = ucan_cid(ucan)?;
+        if binding.ucan_cid != cid {
+            return Err(ApprovalError::UcanMismatch);
+        }
+        if binding.generation != generation {
+            return Err(ApprovalError::GenerationMismatch {
+                approved: binding.generation,
+                bundle: generation,
+            });
+        }
+        if &binding.bundle_hash != bundle_hash {
+            return Err(ApprovalError::BundleHashMismatch);
+        }
+        Ok(())
+    }
+}
+
+/// Errors from approval construction / signing / verification. All fail-closed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ApprovalError {
+    /// UCAN encode failure while computing the CID.
+    Encode(String),
+    /// Hybrid-COSE signing failed.
+    Sign(String),
+    /// Hybrid-COSE verification failed (bad signature, stripped PQ layer, etc.).
+    Verify(String),
+    /// The signed approval does not bind the presented UCAN.
+    UcanMismatch,
+    /// The approval's generation does not match the bundle's generation.
+    GenerationMismatch { approved: u64, bundle: u64 },
+    /// The approval's bundle hash does not match the presented bundle.
+    BundleHashMismatch,
+}
+
+impl fmt::Display for ApprovalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ApprovalError::Encode(e) => write!(f, "approval UCAN encode failed: {e}"),
+            ApprovalError::Sign(e) => write!(f, "approval signing failed: {e}"),
+            ApprovalError::Verify(e) => write!(f, "approval verification failed: {e}"),
+            ApprovalError::UcanMismatch => {
+                write!(f, "signed approval does not bind the presented UCAN")
+            }
+            ApprovalError::GenerationMismatch { approved, bundle } => write!(
+                f,
+                "approval generation {approved} != bundle generation {bundle}"
+            ),
+            ApprovalError::BundleHashMismatch => {
+                write!(
+                    f,
+                    "approval bundle hash does not match the presented bundle"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ApprovalError {}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::super::token::test_support::*;
+    use super::*;
+
+    /// A fresh authority hybrid keypair + a sample approved UCAN.
+    fn setup() -> (TestIdentity, Ucan, u64, [u8; 32]) {
+        let authority = TestIdentity::generate();
+        let issuer = TestIdentity::generate();
+        let ucan = signed_ucan(
+            &issuer,
+            &issuer.did(),
+            vec![cap("mac://model/*", "infer")],
+            vec![],
+        );
+        let generation = 7u64;
+        // Stand-in bundle hash (milestone 2 supplies the real CompiledPolicy::policy_hash()).
+        let bundle_hash = *blake3::hash(b"compiled-bundle-bytes").as_bytes();
+        (authority, ucan, generation, bundle_hash)
+    }
+
+    #[test]
+    fn ucan_cid_is_stable_and_content_sensitive() {
+        let issuer = TestIdentity::generate();
+        let a = signed_ucan(&issuer, &issuer.did(), vec![cap("mac://x", "y")], vec![]);
+        assert_eq!(ucan_cid(&a).unwrap(), ucan_cid(&a).unwrap());
+        let b = signed_ucan(&issuer, &issuer.did(), vec![cap("mac://x", "z")], vec![]);
+        assert_ne!(ucan_cid(&a).unwrap(), ucan_cid(&b).unwrap());
+    }
+
+    #[test]
+    fn sign_then_verify_roundtrips() {
+        let (auth, ucan, generation, bundle_hash) = setup();
+        let binding = ApprovalBinding::new(&ucan, generation, bundle_hash).unwrap();
+        let signed = SignedApproval::sign(binding.clone(), &auth.ed_sk, &auth.pq_sk).unwrap();
+        let verified = signed.verify(&auth.ed_vk, &auth.pq_vk).unwrap();
+        assert_eq!(verified, &binding);
+    }
+
+    #[test]
+    fn verify_rejects_wrong_authority_key() {
+        let (auth, ucan, generation, bundle_hash) = setup();
+        let other = TestIdentity::generate();
+        let binding = ApprovalBinding::new(&ucan, generation, bundle_hash).unwrap();
+        let signed = SignedApproval::sign(binding, &auth.ed_sk, &auth.pq_sk).unwrap();
+        // Wrong PQ key.
+        assert!(matches!(
+            signed.verify(&auth.ed_vk, &other.pq_vk),
+            Err(ApprovalError::Verify(_))
+        ));
+        // Wrong Ed key.
+        assert!(matches!(
+            signed.verify(&other.ed_vk, &auth.pq_vk),
+            Err(ApprovalError::Verify(_))
+        ));
+    }
+
+    #[test]
+    fn verify_rejects_tampered_binding() {
+        let (auth, ucan, generation, bundle_hash) = setup();
+        let binding = ApprovalBinding::new(&ucan, generation, bundle_hash).unwrap();
+        let mut signed = SignedApproval::sign(binding, &auth.ed_sk, &auth.pq_sk).unwrap();
+        // Flip the bundle hash after signing.
+        signed.binding.bundle_hash[0] ^= 0xFF;
+        assert!(matches!(
+            signed.verify(&auth.ed_vk, &auth.pq_vk),
+            Err(ApprovalError::Verify(_))
+        ));
+    }
+
+    #[test]
+    fn verify_binds_confirms_exact_triple() {
+        let (auth, ucan, generation, bundle_hash) = setup();
+        let binding = ApprovalBinding::new(&ucan, generation, bundle_hash).unwrap();
+        let signed = SignedApproval::sign(binding, &auth.ed_sk, &auth.pq_sk).unwrap();
+
+        // Correct triple binds.
+        assert!(signed
+            .verify_binds(&auth.ed_vk, &auth.pq_vk, &ucan, generation, &bundle_hash)
+            .is_ok());
+
+        // Wrong generation.
+        assert!(matches!(
+            signed.verify_binds(
+                &auth.ed_vk,
+                &auth.pq_vk,
+                &ucan,
+                generation + 1,
+                &bundle_hash
+            ),
+            Err(ApprovalError::GenerationMismatch { .. })
+        ));
+
+        // Wrong bundle hash.
+        let wrong = *blake3::hash(b"different-bundle").as_bytes();
+        assert!(matches!(
+            signed.verify_binds(&auth.ed_vk, &auth.pq_vk, &ucan, generation, &wrong),
+            Err(ApprovalError::BundleHashMismatch)
+        ));
+
+        // Wrong UCAN.
+        let other_issuer = TestIdentity::generate();
+        let other_ucan = signed_ucan(
+            &other_issuer,
+            &other_issuer.did(),
+            vec![cap("mac://q", "r")],
+            vec![],
+        );
+        assert!(matches!(
+            signed.verify_binds(
+                &auth.ed_vk,
+                &auth.pq_vk,
+                &other_ucan,
+                generation,
+                &bundle_hash
+            ),
+            Err(ApprovalError::UcanMismatch)
+        ));
+    }
+
+    #[test]
+    fn signing_payload_binds_all_three_fields() {
+        // Distinct (cid, generation, bundle_hash) → distinct signing payloads.
+        let issuer = TestIdentity::generate();
+        let ucan = signed_ucan(&issuer, &issuer.did(), vec![cap("mac://x", "y")], vec![]);
+        let b1 = ApprovalBinding::new(&ucan, 1, [0u8; 32]).unwrap();
+        let mut b2 = b1.clone();
+        b2.generation = 2;
+        let mut b3 = b1.clone();
+        b3.bundle_hash = [9u8; 32];
+        assert_ne!(b1.signing_payload(), b2.signing_payload());
+        assert_ne!(b1.signing_payload(), b3.signing_payload());
+    }
+}

--- a/crates/hyprstream-rpc/src/auth/ucan/capability.rs
+++ b/crates/hyprstream-rpc/src/auth/ucan/capability.rs
@@ -1,0 +1,409 @@
+//! The typed **capability** — a single `(resource, ability)` grant — and the
+//! **attenuation** (⊆) relation that is the core ceiling invariant of S5 (#571).
+//!
+//! A UCAN delegates *authority* as a set of capabilities. The cardinal rule of
+//! the whole epic (#547, design "ceiling/attenuation") is that **a delegation
+//! can only ever narrow, never widen**: every capability a child UCAN claims
+//! must be *covered by* (⊆) some capability its delegator held. If it is not,
+//! the chain is rejected — fail-closed. The compiler then lowers the *root* of a
+//! validated chain into a TE ceiling that is guaranteed to be no wider than what
+//! was reviewed.
+//!
+//! ## What lives here vs. what is deferred
+//!
+//! This module is deliberately **vocabulary-independent** (S5 milestone 1). A
+//! [`Capability`] is `(Resource, Ability, Caveats)` where:
+//! - [`Resource`] is a hierarchical URI-like string (`mac://model/qwen-7b`); the
+//!   subset relation on resources is *prefix/`*` containment* — structural, not
+//!   tied to any concrete app vocabulary.
+//! - [`Ability`] is the action verb (`infer`, `model/*`, `*`); subset is
+//!   namespace containment (`a/b` ⊆ `a/*` ⊆ `*`).
+//! - [`Caveats`] is an opaque CBOR map of restrictions; for milestone 1 the
+//!   subset rule is the conservative "more caveats = more restricted, and a
+//!   child may only *add* caveats or keep them equal" — the safe default. The
+//!   value-aware caveat algebra (e.g. numeric ranges) is a milestone-2 seam.
+//!
+//! The mapping from an [`Ability`]/[`Resource`] to S3's concrete
+//! `ScopeAction`/`Operation` + object types — i.e. *what the verbs mean to the
+//! enforcement layer* — is the [`super::seam`] that lands after S3 (#582). This
+//! module never needs it: attenuation is purely structural.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fmt;
+
+/// A hierarchical resource identifier a capability applies to.
+///
+/// Treated as a `/`-delimited path with an optional trailing `*` wildcard
+/// segment (UCAN-style "resource pointer"). The string is the source of truth;
+/// the [`Resource::covers`] relation is the structural subset used by
+/// attenuation. We do **not** interpret the scheme/authority semantically here —
+/// that interpretation is the deferred vocabulary seam.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Resource(pub String);
+
+impl Resource {
+    pub fn new(s: impl Into<String>) -> Self {
+        Resource(s.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Does `self` **cover** `other` — i.e. is `other` within the authority of
+    /// `self`? This is the resource half of attenuation: a child resource is
+    /// valid only if its delegator's resource covers it.
+    ///
+    /// Rules (fail-closed; when in doubt, do NOT cover):
+    /// - `*` (or empty) covers everything.
+    /// - An exact string match covers itself.
+    /// - A trailing `/*` (or bare `*` suffix on a segment boundary) covers any
+    ///   resource sharing the prefix up to that boundary.
+    ///
+    /// A child resource that is *broader* than the parent (e.g. parent
+    /// `mac://m/a`, child `mac://m/*`) is NOT covered → rejected.
+    #[must_use]
+    pub fn covers(&self, other: &Resource) -> bool {
+        let parent = self.0.as_str();
+        let child = other.0.as_str();
+
+        // Top wildcard covers all.
+        if parent == "*" || parent.is_empty() {
+            return true;
+        }
+        if parent == child {
+            return true;
+        }
+        // Prefix wildcard: `prefix/*` covers `prefix/...` (at a segment
+        // boundary, so `a/b/*` does not cover `a/bc`).
+        if let Some(prefix) = parent.strip_suffix("/*") {
+            // `prefix/*` covers `prefix` itself and anything under `prefix/`.
+            return child == prefix || child.starts_with(&format!("{prefix}/"));
+        }
+        if let Some(prefix) = parent.strip_suffix('*') {
+            // Bare-`*` suffix (no slash): textual prefix containment. Narrower
+            // form, kept conservative — only used when an author writes `a*`.
+            return child.starts_with(prefix);
+        }
+        false
+    }
+}
+
+impl fmt::Display for Resource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// An action/verb a capability authorizes, e.g. `infer`, `model/read`, `*`.
+///
+/// Subset is namespace containment over `/`-delimited verb segments: `a/b` ⊆
+/// `a/*` ⊆ `*`. This mirrors the UCAN ability convention and is intentionally
+/// independent of S3's `ScopeAction` enum — the verb→`ScopeAction` mapping is the
+/// deferred [`super::seam`].
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Ability(pub String);
+
+impl Ability {
+    pub fn new(s: impl Into<String>) -> Self {
+        Ability(s.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Does `self` **cover** `other`? `*` covers all; `a/*` covers `a` and any
+    /// `a/...`; otherwise exact match. Fail-closed: a broader child verb is not
+    /// covered.
+    #[must_use]
+    pub fn covers(&self, other: &Ability) -> bool {
+        let parent = self.0.as_str();
+        let child = other.0.as_str();
+        if parent == "*" {
+            return true;
+        }
+        if parent == child {
+            return true;
+        }
+        if let Some(prefix) = parent.strip_suffix("/*") {
+            return child == prefix || child.starts_with(&format!("{prefix}/"));
+        }
+        false
+    }
+}
+
+impl fmt::Display for Ability {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Opaque restriction map attached to a capability (UCAN "caveats").
+///
+/// Milestone-1 semantics are deliberately conservative and value-blind: a child
+/// capability's caveats must be a **superset** (more restrictive) of — or equal
+/// to — the parent's. I.e. a child may *add* restrictions or repeat the
+/// parent's, but may never *drop* or *loosen* one. Concretely [`Caveats::covers`]
+/// requires every parent key to be present in the child with a byte-identical
+/// value; the child may carry extra keys (extra restrictions).
+///
+/// The value-aware algebra (a child `{"max": 5}` being covered by a parent
+/// `{"max": 10}`) is a milestone-2 seam — see the module docs and
+/// [`super::seam`]. Until then we never *widen* on caveats, which is the
+/// fail-closed direction.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Caveats(pub BTreeMap<String, CaveatValue>);
+
+/// A single caveat value. Kept as a small, comparable, deterministically
+/// serializable shape so caveat maps hash/compare stably. Rich/value-range
+/// caveats are milestone 2.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum CaveatValue {
+    /// A textual restriction (the common UCAN case).
+    Text(String),
+    /// An integer restriction.
+    Int(i64),
+    /// A boolean restriction.
+    Bool(bool),
+}
+
+impl Caveats {
+    /// The empty (unrestricted) caveat set.
+    pub fn empty() -> Self {
+        Caveats(BTreeMap::new())
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Does `self` (the **parent's** caveats) permit a child carrying
+    /// `child` caveats? True iff every restriction the parent imposes is also
+    /// imposed, identically, by the child — the child may add more but never
+    /// drop or change one. Fail-closed (value-blind in milestone 1).
+    #[must_use]
+    pub fn covers(&self, child: &Caveats) -> bool {
+        self.0.iter().all(|(k, v)| child.0.get(k) == Some(v))
+    }
+}
+
+/// A single capability: authority to perform [`Ability`] on [`Resource`] subject
+/// to [`Caveats`]. The atom of UCAN delegation and the unit attenuation operates
+/// on.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Capability {
+    /// The resource (`with` in UCAN parlance).
+    pub resource: Resource,
+    /// The ability/action (`can` in UCAN parlance).
+    pub ability: Ability,
+    /// Restrictions (UCAN `nb`/caveats). Empty = unrestricted.
+    #[serde(default)]
+    pub caveats: Caveats,
+}
+
+impl Capability {
+    /// Construct a capability with no caveats.
+    pub fn new(resource: Resource, ability: Ability) -> Self {
+        Self {
+            resource,
+            ability,
+            caveats: Caveats::empty(),
+        }
+    }
+
+    /// Construct with explicit caveats.
+    pub fn with_caveats(resource: Resource, ability: Ability, caveats: Caveats) -> Self {
+        Self {
+            resource,
+            ability,
+            caveats,
+        }
+    }
+
+    /// **Attenuation predicate**: does `self` (held by a delegator) *authorize*
+    /// `other` (claimed by a delegate)? This is the load-bearing ⊆ relation. A
+    /// delegate capability is valid iff its delegator covers it on **all three**
+    /// axes:
+    ///
+    /// 1. resource: `self.resource.covers(other.resource)`
+    /// 2. ability:  `self.ability.covers(other.ability)`
+    /// 3. caveats:  `self.caveats.covers(other.caveats)` (child at least as
+    ///    restricted)
+    ///
+    /// Conjunction of all three; any axis failing ⇒ NOT authorized (fail-closed).
+    /// A delegate that widens on *any* axis is rejected.
+    #[must_use]
+    pub fn authorizes(&self, other: &Capability) -> bool {
+        self.resource.covers(&other.resource)
+            && self.ability.covers(&other.ability)
+            && self.caveats.covers(&other.caveats)
+    }
+}
+
+impl fmt::Display for Capability {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}@{}", self.ability, self.resource)?;
+        if !self.caveats.is_empty() {
+            write!(f, " {:?}", self.caveats.0)?;
+        }
+        Ok(())
+    }
+}
+
+/// Is the capability set `claimed` **entirely covered** by the capability set
+/// `held`? True iff *every* claimed capability is authorized by *at least one*
+/// held capability. This is the set-level attenuation used between adjacent
+/// links of a delegation chain.
+///
+/// Fail-closed: an empty `held` covers only an empty `claimed`; any claimed
+/// capability with no covering held capability rejects the whole set.
+#[must_use]
+pub fn set_attenuates(held: &[Capability], claimed: &[Capability]) -> bool {
+    claimed.iter().all(|c| held.iter().any(|h| h.authorizes(c)))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn res(s: &str) -> Resource {
+        Resource::new(s)
+    }
+    fn ab(s: &str) -> Ability {
+        Ability::new(s)
+    }
+    fn cap(r: &str, a: &str) -> Capability {
+        Capability::new(res(r), ab(a))
+    }
+
+    // ---- Resource::covers ------------------------------------------------
+
+    #[test]
+    fn resource_exact_match_covers() {
+        assert!(res("mac://model/qwen").covers(&res("mac://model/qwen")));
+        assert!(!res("mac://model/qwen").covers(&res("mac://model/llama")));
+    }
+
+    #[test]
+    fn resource_top_wildcard_covers_all() {
+        assert!(res("*").covers(&res("mac://anything/at/all")));
+        assert!(res("").covers(&res("mac://anything")));
+    }
+
+    #[test]
+    fn resource_prefix_wildcard_covers_subtree_at_boundary() {
+        let parent = res("mac://model/*");
+        assert!(parent.covers(&res("mac://model")));
+        assert!(parent.covers(&res("mac://model/qwen")));
+        assert!(parent.covers(&res("mac://model/qwen/v2")));
+        // Must respect the segment boundary: `model/*` does NOT cover `modelX`.
+        assert!(!parent.covers(&res("mac://modelX")));
+    }
+
+    #[test]
+    fn resource_child_cannot_widen() {
+        // parent narrow, child broad → NOT covered (the anti-widening invariant).
+        assert!(!res("mac://model/qwen").covers(&res("mac://model/*")));
+        assert!(!res("mac://model/qwen").covers(&res("*")));
+    }
+
+    // ---- Ability::covers -------------------------------------------------
+
+    #[test]
+    fn ability_wildcard_and_namespace() {
+        assert!(ab("*").covers(&ab("infer")));
+        assert!(ab("model/*").covers(&ab("model/read")));
+        assert!(ab("model/*").covers(&ab("model")));
+        assert!(!ab("model/read").covers(&ab("model/write")));
+        // child cannot widen.
+        assert!(!ab("model/read").covers(&ab("model/*")));
+        assert!(!ab("infer").covers(&ab("*")));
+    }
+
+    // ---- Caveats::covers -------------------------------------------------
+
+    #[test]
+    fn caveats_empty_parent_covers_anything() {
+        let parent = Caveats::empty();
+        let mut child = BTreeMap::new();
+        child.insert("tenant".to_owned(), CaveatValue::Text("acme".to_owned()));
+        assert!(parent.covers(&Caveats(child)));
+    }
+
+    #[test]
+    fn caveats_child_may_add_but_not_drop() {
+        let mut p = BTreeMap::new();
+        p.insert("tenant".to_owned(), CaveatValue::Text("acme".to_owned()));
+        let parent = Caveats(p);
+
+        // Child keeps the restriction AND adds one: covered (more restricted).
+        let mut c = BTreeMap::new();
+        c.insert("tenant".to_owned(), CaveatValue::Text("acme".to_owned()));
+        c.insert("max".to_owned(), CaveatValue::Int(5));
+        assert!(parent.covers(&Caveats(c)));
+
+        // Child drops the parent's restriction: NOT covered (would widen).
+        assert!(!parent.covers(&Caveats::empty()));
+
+        // Child changes the restriction's value: NOT covered (value-blind, M1).
+        let mut c2 = BTreeMap::new();
+        c2.insert("tenant".to_owned(), CaveatValue::Text("other".to_owned()));
+        assert!(!parent.covers(&Caveats(c2)));
+    }
+
+    // ---- Capability::authorizes (the 3-axis conjunction) -----------------
+
+    #[test]
+    fn capability_authorizes_requires_all_three_axes() {
+        let held = cap("mac://model/*", "model/*");
+        assert!(held.authorizes(&cap("mac://model/qwen", "model/read")));
+        // widen resource → reject
+        assert!(!held.authorizes(&cap("mac://other/qwen", "model/read")));
+        // widen ability → reject
+        assert!(!held.authorizes(&cap("mac://model/qwen", "admin/*")));
+    }
+
+    #[test]
+    fn capability_authorizes_rejects_caveat_drop() {
+        let mut p = BTreeMap::new();
+        p.insert("tenant".to_owned(), CaveatValue::Text("acme".to_owned()));
+        let held = Capability::with_caveats(res("mac://model/*"), ab("*"), Caveats(p));
+        // identical resource/ability but child drops the caveat → reject.
+        assert!(!held.authorizes(&cap("mac://model/qwen", "infer")));
+    }
+
+    // ---- set_attenuates --------------------------------------------------
+
+    #[test]
+    fn set_attenuates_every_claimed_must_be_covered() {
+        let held = vec![
+            cap("mac://model/*", "model/*"),
+            cap("mac://stream/*", "subscribe"),
+        ];
+        let claimed = vec![
+            cap("mac://model/qwen", "model/read"),
+            cap("mac://stream/abc", "subscribe"),
+        ];
+        assert!(set_attenuates(&held, &claimed));
+
+        // one claimed cap escapes the held set → whole set rejected.
+        let escapes = vec![
+            cap("mac://model/qwen", "model/read"),
+            cap("mac://admin/x", "manage"),
+        ];
+        assert!(!set_attenuates(&held, &escapes));
+    }
+
+    #[test]
+    fn set_attenuates_empty_held_covers_only_empty() {
+        assert!(set_attenuates(&[], &[]));
+        assert!(!set_attenuates(&[], &[cap("mac://x", "y")]));
+    }
+}

--- a/crates/hyprstream-rpc/src/auth/ucan/chain.rs
+++ b/crates/hyprstream-rpc/src/auth/ucan/chain.rs
@@ -1,0 +1,457 @@
+//! **Delegation-chain + ceiling/attenuation validation** — the core correctness
+//! component of S5 (#571).
+//!
+//! Per the epic (#547, design "ceiling/attenuation"): *every* delegation in a
+//! UCAN chain must be a SUBSET (attenuation) of its delegator's authority — a
+//! child can never widen. This module walks the proof chain of a UCAN and
+//! enforces, at each link, the two structural invariants that make the chain a
+//! genuine ceiling:
+//!
+//! 1. **Linkage:** the delegate UCAN's *issuer* must equal the delegator
+//!    (proof) UCAN's *audience*. Authority flows `proof.audience → ucan.issuer`;
+//!    a chain where the issuer was not the party the proof delegated to is
+//!    forged.
+//! 2. **Attenuation (⊆):** every capability the delegate UCAN claims must be
+//!    authorized by the delegator's capability set
+//!    ([`super::capability::set_attenuates`]). A delegate that widens on
+//!    resource, ability, or caveats is rejected.
+//!
+//! Plus the obvious gates: temporal validity (a child cannot outlive its parent
+//! — its validity window must be within the parent's), and recursion to the
+//! root (a root has no proofs and grants whatever it self-asserts).
+//!
+//! **Fail-closed everywhere.** Any malformation, missing link, widening, or
+//! out-of-window condition rejects the entire chain. This is intentionally
+//! conservative TCB code: a false reject is a denied request; a false accept is
+//! a privilege escalation, so the asymmetry is always resolved toward rejection.
+//!
+//! ## Scope (milestone 1)
+//!
+//! Signature verification is assumed already done by
+//! [`super::token::Ucan::verify_signatures`] — `validate_chain` is *structural*
+//! (linkage + attenuation + time). Callers run signatures first, then this. The
+//! combined entry point [`validate`] does both in the correct order. Revocation
+//! lists and a richer multi-proof "any-path" model are milestone-2 seams; M1
+//! validates the single-delegator-per-link chain (each UCAN's `proofs[i]` is *a*
+//! delegator that must independently cover the claims).
+
+use super::capability::set_attenuates;
+use super::token::{Ucan, UcanError, UcanVerifier};
+use std::fmt;
+
+/// Why a delegation chain was rejected. Every variant is a fail-closed denial.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChainError {
+    /// A signature failed to verify (wraps [`UcanError`]).
+    Signature(UcanError),
+    /// Structural malformation (wraps [`UcanError`]).
+    Structure(UcanError),
+    /// The delegate's issuer is not the delegator's audience — broken linkage.
+    BrokenLinkage {
+        /// The delegate UCAN's issuer (who claims to wield the authority).
+        delegate_issuer: String,
+        /// The delegator (proof) UCAN's audience (who the authority was given to).
+        delegator_audience: String,
+    },
+    /// The delegate claims a capability its delegator does not authorize — an
+    /// attempt to WIDEN authority across a delegation. The cardinal violation.
+    Widening {
+        /// 0-based index of the offending link from the leaf (0 = leaf→its proof).
+        link: usize,
+    },
+    /// The child's validity window is not contained within its delegator's
+    /// (a child cannot be valid when its parent is not).
+    WindowEscape {
+        /// 0-based link index.
+        link: usize,
+    },
+    /// A non-root UCAN carried no proofs (cannot be authorized) — only a root
+    /// may have an empty proof set, and a root is the *top* of the chain.
+    MissingProof,
+}
+
+impl fmt::Display for ChainError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ChainError::Signature(e) => write!(f, "chain signature invalid: {e}"),
+            ChainError::Structure(e) => write!(f, "chain structurally invalid: {e}"),
+            ChainError::BrokenLinkage { delegate_issuer, delegator_audience } => write!(
+                f,
+                "broken delegation linkage: delegate issuer {delegate_issuer} != delegator audience {delegator_audience}"
+            ),
+            ChainError::Widening { link } => {
+                write!(f, "attenuation violation (widening) at chain link {link}")
+            }
+            ChainError::WindowEscape { link } => {
+                write!(f, "validity window escapes delegator at chain link {link}")
+            }
+            ChainError::MissingProof => {
+                write!(f, "non-root UCAN has no delegating proof (cannot authorize)")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ChainError {}
+
+/// Is the child's validity window contained within the parent's? A child may not
+/// start before the parent or end after it. `None` bounds are treated as the
+/// widest possible on that side, so:
+/// - child unbounded-below + parent bounded-below ⇒ escape.
+/// - child unbounded-above + parent bounded-above ⇒ escape.
+fn window_within(child: &Ucan, parent: &Ucan) -> bool {
+    // not_before: child must not begin earlier than parent.
+    let nbf_ok = match (child.payload.not_before, parent.payload.not_before) {
+        (_, None) => true,        // parent unbounded below
+        (None, Some(_)) => false, // child unbounded below, parent not
+        (Some(c), Some(p)) => c >= p,
+    };
+    // expiration: child must not end later than parent.
+    let exp_ok = match (child.payload.expiration, parent.payload.expiration) {
+        (_, None) => true,        // parent unbounded above
+        (None, Some(_)) => false, // child unbounded above, parent not
+        (Some(c), Some(p)) => c <= p,
+    };
+    nbf_ok && exp_ok
+}
+
+/// Validate ONE delegation edge: `delegate` is authorized by `delegator`
+/// (`delegate`'s proof). Enforces linkage, attenuation, and window containment.
+/// `link` is the index used in error reporting.
+fn validate_edge(delegate: &Ucan, delegator: &Ucan, link: usize) -> Result<(), ChainError> {
+    // 1. Linkage: authority flows delegator.audience → delegate.issuer.
+    if delegate.issuer() != delegator.audience() {
+        return Err(ChainError::BrokenLinkage {
+            delegate_issuer: delegate.issuer().0.clone(),
+            delegator_audience: delegator.audience().0.clone(),
+        });
+    }
+    // 2. Attenuation: the delegator's capabilities must cover the delegate's.
+    if !set_attenuates(delegator.capabilities(), delegate.capabilities()) {
+        return Err(ChainError::Widening { link });
+    }
+    // 3. Window containment: child cannot outlive its parent.
+    if !window_within(delegate, delegator) {
+        return Err(ChainError::WindowEscape { link });
+    }
+    Ok(())
+}
+
+/// Recursively validate the delegation chain rooted at `ucan` (structural only —
+/// run signatures separately, or use [`validate`]).
+///
+/// Walks every proof: for each `proof` in `ucan.proofs`, validates the edge
+/// `ucan ⟶ proof` (linkage + attenuation + window), then recurses into the
+/// proof's own chain. A UCAN with no proofs is treated as a **root** and
+/// authorizes whatever it self-asserts (its capabilities become the ceiling).
+///
+/// `link` is the depth from the original leaf, threaded for diagnostics.
+pub fn validate_chain(ucan: &Ucan) -> Result<(), ChainError> {
+    validate_chain_at(ucan, 0)
+}
+
+fn validate_chain_at(ucan: &Ucan, link: usize) -> Result<(), ChainError> {
+    if ucan.proofs.is_empty() {
+        // Root: self-asserted authority is the top of the ceiling. Nothing above
+        // to attenuate against. (Whether a given root DID is *trusted* to assert
+        // is the verifier/trust-anchor concern, handled at signature time and by
+        // the approval binding — not structural attenuation.)
+        return Ok(());
+    }
+    for proof in &ucan.proofs {
+        validate_edge(ucan, proof, link)?;
+        validate_chain_at(proof, link + 1)?;
+    }
+    Ok(())
+}
+
+/// The full fail-closed validation a compiler front-end runs before lowering a
+/// UCAN into a ceiling: **(1) structure, (2) signatures, (3) delegation chain +
+/// attenuation**, in that order. Returns `Ok(())` only if every link is
+/// structurally sound, correctly signed under the hybrid policy, properly
+/// linked, and strictly attenuating.
+///
+/// This is the single entry point S5's compiler calls; it guarantees that only a
+/// genuine ceiling reaches the (deferred) bundle-emission stage.
+pub fn validate<V: UcanVerifier>(ucan: &Ucan, verifier: &V) -> Result<(), ChainError> {
+    ucan.validate_structure().map_err(ChainError::Structure)?;
+    ucan.verify_signatures(verifier)
+        .map_err(ChainError::Signature)?;
+    validate_chain(ucan)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::super::token::test_support::*;
+    use super::*;
+    use crate::auth::ucan::capability::{Ability, Capability, CaveatValue, Caveats, Resource};
+    use crate::auth::ucan::token::{Did, Ucan, UcanPayload};
+    use crate::crypto::cose_sign::sign_composite;
+    use std::collections::BTreeMap;
+
+    /// Re-sign a (possibly mutated) payload so we can test *structural* chain
+    /// rejections without the signature failing first.
+    fn resign(issuer: &TestIdentity, payload: UcanPayload, proofs: Vec<Ucan>) -> Ucan {
+        let bytes = payload.signing_bytes().unwrap();
+        let signature =
+            sign_composite(&issuer.ed_sk, Some(&issuer.pq_sk), &bytes, UCAN_AAD).unwrap();
+        Ucan {
+            payload,
+            proofs,
+            signature,
+        }
+    }
+
+    fn store(ids: &[&TestIdentity]) -> TestTrustStore {
+        let mut s = TestTrustStore::new();
+        for id in ids {
+            s.anchor(id);
+        }
+        s
+    }
+
+    // ---- Happy path: a properly attenuating chain ------------------------
+
+    #[test]
+    fn valid_attenuating_chain_accepted() {
+        // root: mac://* / *   →  alice: mac://model/* / model/*  →  bob: mac://model/qwen / model/read
+        let root = TestIdentity::generate();
+        let alice = TestIdentity::generate();
+        let bob = TestIdentity::generate();
+
+        let root_ucan = signed_ucan(&root, &alice.did(), vec![cap("mac://*", "*")], vec![]);
+        let alice_ucan = signed_ucan(
+            &alice,
+            &bob.did(),
+            vec![cap("mac://model/*", "model/*")],
+            vec![root_ucan],
+        );
+        let bob_ucan = signed_ucan(
+            &bob,
+            &bob.did(),
+            vec![cap("mac://model/qwen", "model/read")],
+            vec![alice_ucan],
+        );
+
+        let s = store(&[&root, &alice, &bob]);
+        assert!(
+            validate(&bob_ucan, &s).is_ok(),
+            "a strictly-attenuating chain must validate"
+        );
+    }
+
+    #[test]
+    fn root_with_no_proofs_is_self_authorizing() {
+        let root = TestIdentity::generate();
+        let u = signed_ucan(&root, &root.did(), vec![cap("mac://anything", "*")], vec![]);
+        let s = store(&[&root]);
+        assert!(validate(&u, &s).is_ok());
+    }
+
+    // ---- Widening: the cardinal rejection --------------------------------
+
+    #[test]
+    fn widening_resource_rejected() {
+        // alice was delegated mac://model/* but bob claims mac://other/x.
+        let root = TestIdentity::generate();
+        let alice = TestIdentity::generate();
+        let bob = TestIdentity::generate();
+        let root_ucan = signed_ucan(&root, &alice.did(), vec![cap("mac://model/*", "*")], vec![]);
+        let alice_ucan = signed_ucan(
+            &alice,
+            &bob.did(),
+            vec![cap("mac://other/x", "model/read")],
+            vec![root_ucan],
+        );
+        let s = store(&[&root, &alice]);
+        match validate(&alice_ucan, &s) {
+            Err(ChainError::Widening { link: 0 }) => {}
+            other => panic!("expected Widening at link 0, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn widening_ability_rejected() {
+        let root = TestIdentity::generate();
+        let alice = TestIdentity::generate();
+        let bob = TestIdentity::generate();
+        let root_ucan = signed_ucan(
+            &root,
+            &alice.did(),
+            vec![cap("mac://*", "model/read")],
+            vec![],
+        );
+        // bob tries to gain model/* from a model/read delegation.
+        let alice_ucan = signed_ucan(
+            &alice,
+            &bob.did(),
+            vec![cap("mac://model/qwen", "model/*")],
+            vec![root_ucan],
+        );
+        let s = store(&[&root, &alice]);
+        assert!(matches!(
+            validate(&alice_ucan, &s),
+            Err(ChainError::Widening { .. })
+        ));
+    }
+
+    #[test]
+    fn widening_deep_in_chain_rejected() {
+        // root→alice valid, alice→bob widens. Reject at link 1 (the alice→its-proof edge
+        // is fine; the bob→alice edge — link 0 here — is the widening one).
+        let root = TestIdentity::generate();
+        let alice = TestIdentity::generate();
+        let bob = TestIdentity::generate();
+        let root_ucan = signed_ucan(
+            &root,
+            &alice.did(),
+            vec![cap("mac://model/*", "model/*")],
+            vec![],
+        );
+        let alice_ucan = signed_ucan(
+            &alice,
+            &bob.did(),
+            vec![cap("mac://model/qwen", "model/read")],
+            vec![root_ucan],
+        );
+        // bob legitimately attenuates from alice, but we then tamper alice's claim to widen
+        // beyond root and re-sign so signatures still pass.
+        let mut alice_payload = alice_ucan.payload.clone();
+        alice_payload.capabilities = vec![cap("mac://admin/*", "admin/*")]; // widens past root
+        let widened_alice = resign(&alice, alice_payload, alice_ucan.proofs.clone());
+        let bob_ucan = signed_ucan(
+            &bob,
+            &bob.did(),
+            vec![cap("mac://admin/x", "admin/*")],
+            vec![widened_alice],
+        );
+        let s = store(&[&root, &alice, &bob]);
+        // The bob→alice edge passes (bob ⊆ widened alice), but alice→root widens at link 1.
+        assert!(matches!(
+            validate(&bob_ucan, &s),
+            Err(ChainError::Widening { link: 1 })
+        ));
+    }
+
+    #[test]
+    fn caveat_drop_is_widening() {
+        // root delegates with a tenant caveat; alice drops it.
+        let root = TestIdentity::generate();
+        let alice = TestIdentity::generate();
+        let mut cv = BTreeMap::new();
+        cv.insert("tenant".to_owned(), CaveatValue::Text("acme".to_owned()));
+        let restricted = Capability::with_caveats(
+            Resource::new("mac://model/*"),
+            Ability::new("*"),
+            Caveats(cv),
+        );
+        let root_ucan = signed_ucan(&root, &alice.did(), vec![restricted], vec![]);
+        // alice claims the same resource/ability but WITHOUT the tenant caveat → widening.
+        let alice_ucan = signed_ucan(
+            &alice,
+            &alice.did(),
+            vec![cap("mac://model/qwen", "infer")],
+            vec![root_ucan],
+        );
+        let s = store(&[&root, &alice]);
+        assert!(matches!(
+            validate(&alice_ucan, &s),
+            Err(ChainError::Widening { .. })
+        ));
+    }
+
+    // ---- Linkage ---------------------------------------------------------
+
+    #[test]
+    fn broken_linkage_rejected() {
+        // root delegates to alice, but bob (not alice) presents root as its proof.
+        let root = TestIdentity::generate();
+        let alice = TestIdentity::generate();
+        let bob = TestIdentity::generate();
+        let root_to_alice = signed_ucan(&root, &alice.did(), vec![cap("mac://*", "*")], vec![]);
+        // bob issues a UCAN citing root_to_alice as proof — but bob != alice.
+        let bob_ucan = signed_ucan(
+            &bob,
+            &bob.did(),
+            vec![cap("mac://model/x", "infer")],
+            vec![root_to_alice],
+        );
+        let s = store(&[&root, &bob]);
+        assert!(matches!(
+            validate(&bob_ucan, &s),
+            Err(ChainError::BrokenLinkage { .. })
+        ));
+    }
+
+    // ---- Temporal window -------------------------------------------------
+
+    #[test]
+    fn child_outliving_parent_rejected() {
+        let root = TestIdentity::generate();
+        let alice = TestIdentity::generate();
+        // root expires at 1000.
+        let mut root_payload = UcanPayload {
+            issuer: root.did(),
+            audience: alice.did(),
+            capabilities: vec![cap("mac://*", "*")],
+            not_before: None,
+            expiration: Some(1000),
+            nonce: vec![],
+        };
+        let root_ucan = resign(&root, root_payload.clone(), vec![]);
+        // alice expires at 2000 — outlives root → window escape.
+        let alice_payload = UcanPayload {
+            issuer: alice.did(),
+            audience: alice.did(),
+            capabilities: vec![cap("mac://model/x", "infer")],
+            not_before: None,
+            expiration: Some(2000),
+            nonce: vec![],
+        };
+        let alice_ucan = resign(&alice, alice_payload, vec![root_ucan]);
+        let s = store(&[&root, &alice]);
+        assert!(matches!(
+            validate(&alice_ucan, &s),
+            Err(ChainError::WindowEscape { .. })
+        ));
+
+        // Same window (alice within root) is fine.
+        root_payload.expiration = Some(2000);
+        let root_ok = resign(&root, root_payload, vec![]);
+        let alice_ok_payload = UcanPayload {
+            issuer: alice.did(),
+            audience: alice.did(),
+            capabilities: vec![cap("mac://model/x", "infer")],
+            not_before: None,
+            expiration: Some(2000),
+            nonce: vec![],
+        };
+        let alice_ok = resign(&alice, alice_ok_payload, vec![root_ok]);
+        let _ = Did::new("did:key:placeholder"); // keep Did import used
+        assert!(validate(&alice_ok, &store(&[&root, &alice])).is_ok());
+    }
+
+    // ---- Signature ordering ----------------------------------------------
+
+    #[test]
+    fn validate_runs_signatures_before_chain() {
+        // A widening chain whose signatures are ALSO invalid should report a
+        // signature error (signatures gate first).
+        let root = TestIdentity::generate();
+        let alice = TestIdentity::generate();
+        let root_ucan = signed_ucan(&root, &alice.did(), vec![cap("mac://model/*", "*")], vec![]);
+        let mut alice_ucan = signed_ucan(
+            &alice,
+            &alice.did(),
+            vec![cap("mac://other/x", "*")],
+            vec![root_ucan],
+        );
+        alice_ucan.signature[0] ^= 0xFF; // break alice's signature
+        let s = store(&[&root, &alice]);
+        assert!(matches!(
+            validate(&alice_ucan, &s),
+            Err(ChainError::Signature(_))
+        ));
+    }
+}

--- a/crates/hyprstream-rpc/src/auth/ucan/chain.rs
+++ b/crates/hyprstream-rpc/src/auth/ucan/chain.rs
@@ -16,24 +16,41 @@
 //!    ([`super::capability::set_attenuates`]). A delegate that widens on
 //!    resource, ability, or caveats is rejected.
 //!
-//! Plus the obvious gates: temporal validity (a child cannot outlive its parent
-//! — its validity window must be within the parent's), and recursion to the
-//! root (a root has no proofs and grants whatever it self-asserts).
+//! Plus the temporal and structural gates, which are TWO independent checks:
 //!
-//! **Fail-closed everywhere.** Any malformation, missing link, widening, or
-//! out-of-window condition rejects the entire chain. This is intentionally
-//! conservative TCB code: a false reject is a denied request; a false accept is
-//! a privilege escalation, so the asymmetry is always resolved toward rejection.
+//! - **Relative window containment** ([`window_within`]): a child cannot outlive
+//!   its parent — its `[not_before, expiration]` window must be within the
+//!   delegator's. This bounds the chain *shape* but says nothing about the
+//!   wall-clock.
+//! - **Absolute validity at `now`** ([`super::token::Ucan::is_valid_at`]): EVERY
+//!   link must be live at the validation instant — not expired and not
+//!   future-dated (`not_before <= now <= expiration`). Relative containment alone
+//!   is NOT sufficient: a fully-attenuating, correctly-linked chain in which
+//!   every link has already EXPIRED still satisfies window containment, so
+//!   without the absolute check it would validate and could be replayed/compiled
+//!   into a ceiling. Both gates are therefore enforced, per link.
+//!
+//! And recursion to the root (a root has no proofs and grants whatever it
+//! self-asserts), with a bounded proof depth ([`MAX_PROOF_DEPTH`]) so a
+//! maliciously deep nested-proof chain cannot exhaust the stack (a DoS guard, not
+//! an authority concern).
+//!
+//! **Fail-closed everywhere.** Any malformation, missing link, widening,
+//! out-of-window, expired/not-yet-valid, or over-depth condition rejects the
+//! entire chain. This is intentionally conservative TCB code: a false reject is a
+//! denied request; a false accept is a privilege escalation, so the asymmetry is
+//! always resolved toward rejection.
 //!
 //! ## Scope (milestone 1)
 //!
 //! Signature verification is assumed already done by
-//! [`super::token::Ucan::verify_signatures`] — `validate_chain` is *structural*
-//! (linkage + attenuation + time). Callers run signatures first, then this. The
-//! combined entry point [`validate`] does both in the correct order. Revocation
-//! lists and a richer multi-proof "any-path" model are milestone-2 seams; M1
-//! validates the single-delegator-per-link chain (each UCAN's `proofs[i]` is *a*
-//! delegator that must independently cover the claims).
+//! [`super::token::Ucan::verify_signatures`] — `validate_chain` covers linkage,
+//! attenuation, relative window containment, absolute validity at `now`, and the
+//! depth bound. Callers run signatures first, then this; the combined entry point
+//! [`validate`] does both in the correct order. Revocation lists and a richer
+//! multi-proof "any-path" model are milestone-2 seams; M1 validates the
+//! single-delegator-per-link chain (each UCAN's `proofs[i]` is *a* delegator that
+//! must independently cover the claims).
 
 use super::capability::set_attenuates;
 use super::token::{Ucan, UcanError, UcanVerifier};
@@ -65,10 +82,35 @@ pub enum ChainError {
         /// 0-based link index.
         link: usize,
     },
+    /// A link is not live at the validation instant `now`: it has expired
+    /// (`now > expiration`) or is not yet valid (`now < not_before`). Absolute
+    /// time check — independent of relative window containment. Fail-closed: an
+    /// expired chain MUST deny.
+    Expired {
+        /// 0-based link index (0 = leaf).
+        link: usize,
+    },
+    /// The proof chain is nested deeper than [`MAX_PROOF_DEPTH`]. A DoS guard
+    /// against stack exhaustion from a maliciously deep chain — not an
+    /// authority-widening concern, but rejected fail-closed all the same.
+    DepthExceeded {
+        /// The depth at which the bound was exceeded.
+        depth: usize,
+    },
     /// A non-root UCAN carried no proofs (cannot be authorized) — only a root
     /// may have an empty proof set, and a root is the *top* of the chain.
     MissingProof,
 }
+
+/// Maximum delegation-chain (nested-proof) depth this validator will walk. A
+/// chain deeper than this is rejected fail-closed ([`ChainError::DepthExceeded`])
+/// before recursion can exhaust the stack. UCAN delegation chains are short by
+/// construction (a handful of hops); this bound is generous for legitimate use
+/// while capping a hostile `proofs`-within-`proofs` nesting (a DoS vector at both
+/// parse time and walk time). The same bound is enforced at CBOR decode in
+/// [`super::token::Ucan::from_cbor`] so an over-deep token is refused before it
+/// is ever walked.
+pub const MAX_PROOF_DEPTH: usize = 32;
 
 impl fmt::Display for ChainError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -84,6 +126,18 @@ impl fmt::Display for ChainError {
             }
             ChainError::WindowEscape { link } => {
                 write!(f, "validity window escapes delegator at chain link {link}")
+            }
+            ChainError::Expired { link } => {
+                write!(
+                    f,
+                    "chain link {link} is not live at the validation instant (expired or not yet valid)"
+                )
+            }
+            ChainError::DepthExceeded { depth } => {
+                write!(
+                    f,
+                    "delegation chain exceeds maximum proof depth {MAX_PROOF_DEPTH} (at depth {depth})"
+                )
             }
             ChainError::MissingProof => {
                 write!(f, "non-root UCAN has no delegating proof (cannot authorize)")
@@ -137,47 +191,75 @@ fn validate_edge(delegate: &Ucan, delegator: &Ucan, link: usize) -> Result<(), C
     Ok(())
 }
 
-/// Recursively validate the delegation chain rooted at `ucan` (structural only —
-/// run signatures separately, or use [`validate`]).
+/// Recursively validate the delegation chain rooted at `ucan` (structural +
+/// temporal — run signatures separately, or use [`validate`]).
 ///
-/// Walks every proof: for each `proof` in `ucan.proofs`, validates the edge
-/// `ucan ⟶ proof` (linkage + attenuation + window), then recurses into the
-/// proof's own chain. A UCAN with no proofs is treated as a **root** and
-/// authorizes whatever it self-asserts (its capabilities become the ceiling).
+/// Checks, on EVERY node (the leaf, every intermediate, and the root):
+/// - **absolute validity at `now`** via [`Ucan::is_valid_at`] — the link must be
+///   live (not expired, not future-dated) at the single caller-supplied instant;
+/// - for each `proof` in `ucan.proofs`, the edge `ucan ⟶ proof` (linkage +
+///   attenuation + relative window containment), then recurses into the proof.
 ///
-/// `link` is the depth from the original leaf, threaded for diagnostics.
-pub fn validate_chain(ucan: &Ucan) -> Result<(), ChainError> {
-    validate_chain_at(ucan, 0)
+/// A UCAN with no proofs is a **root** and authorizes whatever it self-asserts
+/// (its capabilities become the ceiling) — but it is STILL clock-checked.
+///
+/// `now` is a **single trusted clock value supplied by the caller**, threaded
+/// down UNCHANGED to every link. It is never taken from a token's own fields, so
+/// a forged `not_before`/`expiration` cannot self-certify validity — it can only
+/// narrow (the relative-window check) or fail the absolute check against the one
+/// authoritative `now`.
+///
+/// `link` is the depth from the original leaf, used both for diagnostics and as
+/// the [`MAX_PROOF_DEPTH`] DoS bound.
+pub fn validate_chain(ucan: &Ucan, now: u64) -> Result<(), ChainError> {
+    validate_chain_at(ucan, now, 0)
 }
 
-fn validate_chain_at(ucan: &Ucan, link: usize) -> Result<(), ChainError> {
+fn validate_chain_at(ucan: &Ucan, now: u64, link: usize) -> Result<(), ChainError> {
+    // Depth bound FIRST — cap recursion before doing any work at this level so a
+    // hostile deep chain cannot exhaust the stack (DoS guard, fail-closed).
+    if link >= MAX_PROOF_DEPTH {
+        return Err(ChainError::DepthExceeded { depth: link });
+    }
+    // Absolute time on THIS node (covers leaf, intermediates, and the root). The
+    // same `now` is used at every level — never derived from the token.
+    if !ucan.is_valid_at(now) {
+        return Err(ChainError::Expired { link });
+    }
     if ucan.proofs.is_empty() {
         // Root: self-asserted authority is the top of the ceiling. Nothing above
         // to attenuate against. (Whether a given root DID is *trusted* to assert
         // is the verifier/trust-anchor concern, handled at signature time and by
-        // the approval binding — not structural attenuation.)
+        // the approval binding — not structural attenuation.) Still clock-checked
+        // above.
         return Ok(());
     }
     for proof in &ucan.proofs {
         validate_edge(ucan, proof, link)?;
-        validate_chain_at(proof, link + 1)?;
+        validate_chain_at(proof, now, link + 1)?;
     }
     Ok(())
 }
 
 /// The full fail-closed validation a compiler front-end runs before lowering a
 /// UCAN into a ceiling: **(1) structure, (2) signatures, (3) delegation chain +
-/// attenuation**, in that order. Returns `Ok(())` only if every link is
-/// structurally sound, correctly signed under the hybrid policy, properly
-/// linked, and strictly attenuating.
+/// attenuation + temporal validity at `now`**, in that order. Returns `Ok(())`
+/// only if every link is structurally sound, correctly signed under the hybrid
+/// policy, properly linked, strictly attenuating, within its delegator's window,
+/// AND live at `now` (not expired, not future-dated), with the chain no deeper
+/// than [`MAX_PROOF_DEPTH`].
+///
+/// `now` is the single trusted current time (unix seconds) the caller supplies;
+/// it is threaded unchanged to every link. The caller is responsible for sourcing
+/// a trustworthy clock — the validator never reads "now" from the token.
 ///
 /// This is the single entry point S5's compiler calls; it guarantees that only a
-/// genuine ceiling reaches the (deferred) bundle-emission stage.
-pub fn validate<V: UcanVerifier>(ucan: &Ucan, verifier: &V) -> Result<(), ChainError> {
+/// genuine, currently-live ceiling reaches the (deferred) bundle-emission stage.
+pub fn validate<V: UcanVerifier>(ucan: &Ucan, verifier: &V, now: u64) -> Result<(), ChainError> {
     ucan.validate_structure().map_err(ChainError::Structure)?;
     ucan.verify_signatures(verifier)
         .map_err(ChainError::Signature)?;
-    validate_chain(ucan)
+    validate_chain(ucan, now)
 }
 
 #[cfg(test)]
@@ -211,6 +293,12 @@ mod tests {
         s
     }
 
+    /// A wall-clock instant that is within the validity window of every UCAN the
+    /// `signed_ucan` helper mints (`not_before: None`, `expiration:
+    /// 9_999_999_999`) and within the explicit windows used by the temporal
+    /// tests. Passed as the trusted `now` to `validate`/`validate_chain`.
+    const NOW: u64 = 1_000;
+
     // ---- Happy path: a properly attenuating chain ------------------------
 
     #[test]
@@ -236,7 +324,7 @@ mod tests {
 
         let s = store(&[&root, &alice, &bob]);
         assert!(
-            validate(&bob_ucan, &s).is_ok(),
+            validate(&bob_ucan, &s, NOW).is_ok(),
             "a strictly-attenuating chain must validate"
         );
     }
@@ -246,7 +334,7 @@ mod tests {
         let root = TestIdentity::generate();
         let u = signed_ucan(&root, &root.did(), vec![cap("mac://anything", "*")], vec![]);
         let s = store(&[&root]);
-        assert!(validate(&u, &s).is_ok());
+        assert!(validate(&u, &s, NOW).is_ok());
     }
 
     // ---- Widening: the cardinal rejection --------------------------------
@@ -265,7 +353,7 @@ mod tests {
             vec![root_ucan],
         );
         let s = store(&[&root, &alice]);
-        match validate(&alice_ucan, &s) {
+        match validate(&alice_ucan, &s, NOW) {
             Err(ChainError::Widening { link: 0 }) => {}
             other => panic!("expected Widening at link 0, got {other:?}"),
         }
@@ -291,7 +379,7 @@ mod tests {
         );
         let s = store(&[&root, &alice]);
         assert!(matches!(
-            validate(&alice_ucan, &s),
+            validate(&alice_ucan, &s, NOW),
             Err(ChainError::Widening { .. })
         ));
     }
@@ -329,7 +417,7 @@ mod tests {
         let s = store(&[&root, &alice, &bob]);
         // The bob→alice edge passes (bob ⊆ widened alice), but alice→root widens at link 1.
         assert!(matches!(
-            validate(&bob_ucan, &s),
+            validate(&bob_ucan, &s, NOW),
             Err(ChainError::Widening { link: 1 })
         ));
     }
@@ -356,7 +444,7 @@ mod tests {
         );
         let s = store(&[&root, &alice]);
         assert!(matches!(
-            validate(&alice_ucan, &s),
+            validate(&alice_ucan, &s, NOW),
             Err(ChainError::Widening { .. })
         ));
     }
@@ -379,7 +467,7 @@ mod tests {
         );
         let s = store(&[&root, &bob]);
         assert!(matches!(
-            validate(&bob_ucan, &s),
+            validate(&bob_ucan, &s, NOW),
             Err(ChainError::BrokenLinkage { .. })
         ));
     }
@@ -412,7 +500,7 @@ mod tests {
         let alice_ucan = resign(&alice, alice_payload, vec![root_ucan]);
         let s = store(&[&root, &alice]);
         assert!(matches!(
-            validate(&alice_ucan, &s),
+            validate(&alice_ucan, &s, NOW),
             Err(ChainError::WindowEscape { .. })
         ));
 
@@ -429,7 +517,7 @@ mod tests {
         };
         let alice_ok = resign(&alice, alice_ok_payload, vec![root_ok]);
         let _ = Did::new("did:key:placeholder"); // keep Did import used
-        assert!(validate(&alice_ok, &store(&[&root, &alice])).is_ok());
+        assert!(validate(&alice_ok, &store(&[&root, &alice]), NOW).is_ok());
     }
 
     // ---- Signature ordering ----------------------------------------------
@@ -450,8 +538,157 @@ mod tests {
         alice_ucan.signature[0] ^= 0xFF; // break alice's signature
         let s = store(&[&root, &alice]);
         assert!(matches!(
-            validate(&alice_ucan, &s),
+            validate(&alice_ucan, &s, NOW),
             Err(ChainError::Signature(_))
         ));
+    }
+
+    // ---- Absolute time at `now` (the fail-open fix, #590) ----------------
+
+    /// Mint a self-issued (root) UCAN with an explicit validity window, properly
+    /// hybrid-signed, plus its trust store.
+    fn windowed_root(nbf: Option<u64>, exp: Option<u64>) -> (Ucan, TestTrustStore) {
+        let id = TestIdentity::generate();
+        let payload = UcanPayload {
+            issuer: id.did(),
+            audience: id.did(),
+            capabilities: vec![cap("mac://model/*", "infer")],
+            not_before: nbf,
+            expiration: exp,
+            nonce: vec![],
+        };
+        let u = resign(&id, payload, vec![]);
+        (u, store(&[&id]))
+    }
+
+    #[test]
+    fn expired_chain_denied() {
+        // A perfectly signed, linked, self-asserting chain that EXPIRED at 500.
+        // Relative window containment is satisfied (root has no parent), so before
+        // the absolute check this validated — the fail-open. Now: deny at now=1000.
+        let (u, s) = windowed_root(None, Some(500));
+        assert!(matches!(
+            validate(&u, &s, 1000),
+            Err(ChainError::Expired { link: 0 })
+        ));
+    }
+
+    #[test]
+    fn future_nbf_denied() {
+        // Not-yet-valid: not_before is in the future relative to `now`.
+        let (u, s) = windowed_root(Some(5000), Some(9000));
+        assert!(matches!(
+            validate(&u, &s, 1000),
+            Err(ChainError::Expired { link: 0 })
+        ));
+    }
+
+    #[test]
+    fn valid_at_now_accepted() {
+        // Live window straddling `now` validates.
+        let (u, s) = windowed_root(Some(500), Some(2000));
+        assert!(validate(&u, &s, 1000).is_ok());
+        // Boundary instants are inclusive (now == nbf and now == exp).
+        assert!(validate(&u, &s, 500).is_ok());
+        assert!(validate(&u, &s, 2000).is_ok());
+    }
+
+    #[test]
+    fn expiry_checked_across_a_multi_link_chain() {
+        // A 2-link root → leaf chain that is fully within-window (containment OK).
+        // It validates while live and is denied once expired — exercising the
+        // per-link absolute check through the recursion (not just a 1-node chain).
+        //
+        // Note on why "leaf live but a deeper proof expired" is NOT testable here:
+        // window containment forces leaf.window ⊆ proof.window, so the leaf can
+        // never outlive its proof. The per-link check on deeper nodes is therefore
+        // exercised by (a) `expired_chain_denied` — a root (the *bottom* link) is
+        // clock-checked — and (b) this multi-link chain denying when expired.
+        let root = TestIdentity::generate();
+        let leaf = TestIdentity::generate();
+        let root_payload = UcanPayload {
+            issuer: root.did(),
+            audience: leaf.did(),
+            capabilities: vec![cap("mac://*", "*")],
+            not_before: Some(100),
+            expiration: Some(2000),
+            nonce: vec![],
+        };
+        let root_ucan = resign(&root, root_payload, vec![]);
+        let leaf_payload = UcanPayload {
+            issuer: leaf.did(),
+            audience: leaf.did(),
+            capabilities: vec![cap("mac://model/x", "infer")],
+            not_before: Some(100),
+            expiration: Some(2000),
+            nonce: vec![],
+        };
+        let leaf_ucan = resign(&leaf, leaf_payload, vec![root_ucan]);
+        let s = store(&[&root, &leaf]);
+        // Live: validates.
+        assert!(validate(&leaf_ucan, &s, 1000).is_ok());
+        // Expired: denied on the clock.
+        assert!(matches!(
+            validate(&leaf_ucan, &s, 3000),
+            Err(ChainError::Expired { .. })
+        ));
+        // Not yet valid: denied.
+        assert!(matches!(
+            validate(&leaf_ucan, &s, 50),
+            Err(ChainError::Expired { .. })
+        ));
+    }
+
+    // ---- Proof-depth DoS bound ------------------------------------------
+
+    /// Build a linear self-delegating chain of `n` links (leaf has `n-1` nested
+    /// proofs), all hybrid-signed and live at `NOW`. Returns (leaf, store).
+    fn linear_chain(n: usize) -> (Ucan, TestTrustStore) {
+        let id = TestIdentity::generate();
+        let mk = |proofs: Vec<Ucan>| {
+            let payload = UcanPayload {
+                issuer: id.did(),
+                audience: id.did(),
+                capabilities: vec![cap("mac://model/*", "infer")],
+                not_before: None,
+                expiration: Some(9_999_999_999),
+                nonce: vec![],
+            };
+            resign(&id, payload, proofs)
+        };
+        let mut u = mk(vec![]);
+        for _ in 1..n {
+            u = mk(vec![u]);
+        }
+        (u, store(&[&id]))
+    }
+
+    #[test]
+    fn max_depth_chain_accepted_one_over_rejected() {
+        // A chain exactly at the bound walks fine.
+        let (ok, s) = linear_chain(MAX_PROOF_DEPTH);
+        assert!(validate(&ok, &s, NOW).is_ok());
+        // One link deeper than the bound is rejected fail-closed.
+        let (deep, s2) = linear_chain(MAX_PROOF_DEPTH + 1);
+        assert!(matches!(
+            validate(&deep, &s2, NOW),
+            Err(ChainError::DepthExceeded { .. })
+        ));
+    }
+
+    #[test]
+    fn over_deep_chain_rejected_at_cbor_decode() {
+        // The DoS bound is also enforced at parse time: an over-deep token is
+        // refused by `from_cbor` before it can ever be walked.
+        let (deep, _) = linear_chain(MAX_PROOF_DEPTH + 1);
+        let bytes = deep.to_cbor().unwrap();
+        assert!(matches!(
+            Ucan::from_cbor(&bytes),
+            Err(crate::auth::ucan::token::UcanError::Malformed(_))
+        ));
+        // A chain within the bound round-trips through from_cbor fine.
+        let (ok, _) = linear_chain(MAX_PROOF_DEPTH);
+        let ok_bytes = ok.to_cbor().unwrap();
+        assert!(Ucan::from_cbor(&ok_bytes).is_ok());
     }
 }

--- a/crates/hyprstream-rpc/src/auth/ucan/mod.rs
+++ b/crates/hyprstream-rpc/src/auth/ucan/mod.rs
@@ -1,0 +1,68 @@
+//! **UCAN → Casbin/TE compiler foundation** — S5 / #571 of the native-MAC epic
+//! (#547), milestone 1: the vocabulary-INDEPENDENT core.
+//!
+//! ## The design (epic #547, decided)
+//!
+//! UCAN is the **authoring / delegation source language**; Casbin/TE is the
+//! **compiled enforcement**. An approved UCAN compiles *deterministically and
+//! faithfully* into a Casbin/TE bundle that is a **ceiling**. A signed
+//! `(UCAN, bundle_hash)` binding ([`approval`]) cryptographically ties the bundle
+//! to the reviewed UCAN, so a compiler bug can never produce a bundle that
+//! exceeds what was reviewed (design §14 containment backstop). Object labels and
+//! the MAC floor come from manifests (S1), **never** from the UCAN — the compiler
+//! produces the *grant ceiling*, not object labels.
+//!
+//! ```text
+//!  authoring (control plane)                       enforcement (S4 data plane)
+//!  ─────────────────────────                       ───────────────────────────
+//!  UCAN delegation chain                            CompiledPolicy { TeMatrix, lattice, generation }
+//!     │  verify_signatures (hybrid COSE)               ▲
+//!     │  validate_chain (linkage + ATTENUATION ⊆)      │ PolicyLoader verifies ONCE
+//!     ▼                                                │ + approval hash-match
+//!  validated ceiling ──[emit, M2 seam]──► bundle ──► policy_hash (BLAKE3)
+//!     │                                                ▲
+//!     └──► SignedApproval{ ucan_cid, generation, ─────┘
+//!          bundle_hash }   (hybrid EdDSA+ML-DSA-65)
+//! ```
+//!
+//! ## Module layout
+//!
+//! - [`capability`] — the typed [`Capability`] `(resource, ability, caveats)` and
+//!   the **attenuation (⊆)** relation. Vocabulary-independent; structural.
+//! - [`token`] — the typed [`Ucan`] model, CBOR parse, structural validation, and
+//!   **hybrid-COSE signature verification** (EdDSA + ML-DSA-65). Minimal model
+//!   (we control both ends), aligned with the project crypto — NOT a JWT `ucan`
+//!   crate.
+//! - [`chain`] — **delegation-chain + ceiling/attenuation validation**. The most
+//!   security-critical component: walks the proof chain and rejects any widening,
+//!   broken linkage, or window escape. Fail-closed.
+//! - [`approval`] — the signed `(UCAN, bundle_hash)` [`approval::ApprovalBinding`],
+//!   binding the [`SecurityLabel`](crate::auth::mac) lattice generation too,
+//!   signed with hybrid COSE. Its `bundle_hash` is exactly S4's
+//!   `CompiledPolicy::policy_hash()` so it drops into the S4 loader's
+//!   `PolicyApproval`.
+//! - [`seam`] — milestone-2 interfaces left unimplemented: the action-vocabulary
+//!   mapping (gated on S3/#582), Casbin/TE bundle emission, and the faithfulness
+//!   framework. Scaffolded only.
+//!
+//! ## Relationship to S4 (#570/#583)
+//!
+//! S4's PDP (in the `hyprstream` crate, `mac::compiled::CompiledPolicy`) is the
+//! consumer of this compiler's output. The emitted bundle is a
+//! `hyprstream::mac::TeMatrix` wrapped in a `CompiledPolicy` whose
+//! `generation == LatticeVersion::generation()` and whose `policy_hash()` is the
+//! `bundle_hash` this module's approval binds. Bundle emission needs the
+//! `hyprstream`-crate TE types, so it is a [`seam`] (milestone 2); the
+//! milestone-1 core lives here in `hyprstream-rpc` and needs only S1 + crypto.
+
+pub mod approval;
+pub mod capability;
+pub mod chain;
+pub mod seam;
+pub mod token;
+
+pub use approval::{ucan_cid, ApprovalBinding, ApprovalError, SignedApproval, APPROVAL_AAD};
+pub use capability::{set_attenuates, Ability, Capability, CaveatValue, Caveats, Resource};
+pub use chain::{validate, validate_chain, ChainError};
+pub use seam::{ActionVocabulary, BundleEmitter, FaithfulnessCheck};
+pub use token::{Did, Ucan, UcanError, UcanPayload, UcanVerifier};

--- a/crates/hyprstream-rpc/src/auth/ucan/seam.rs
+++ b/crates/hyprstream-rpc/src/auth/ucan/seam.rs
@@ -1,0 +1,121 @@
+//! **Milestone-2 seams** — clean interfaces deliberately left unimplemented in
+//! S5 milestone 1 (#571). Each is gated on other work; defining the trait now
+//! lets the milestone-1 core (token / chain / approval) compile, test, and ship
+//! independently, and pins the contract so the deferred pieces wire in last with
+//! no churn to the validated attenuation/approval logic.
+//!
+//! Nothing here is on any hot path. These are control-plane, compile-time
+//! interfaces.
+
+use super::capability::{Ability, Resource};
+
+// ---------------------------------------------------------------------------
+// SEAM 1 — action-vocabulary mapping (UCAN cmd ↔ ScopeAction / Operation)
+// TODO(#571 milestone 2 / post-#582): wire in last, once S3 (#582) merges.
+// ---------------------------------------------------------------------------
+
+/// Maps the UCAN vocabulary (a structural [`Ability`] verb + [`Resource`]) onto
+/// S3's concrete enforcement vocabulary — the `ScopeAction` / `Operation` action
+/// ids and TE object types the compiled `TeMatrix` keys on.
+///
+/// **DEFERRED — do NOT implement in milestone 1.** S3 (#582) is mid-fix on the
+/// `$scope` / `annotations.capnp` work that owns the canonical `ScopeAction`
+/// enum (and will add `Operation::Subscribe` / `Operation::Publish`). The
+/// milestone-1 attenuation core is intentionally vocabulary-independent so it
+/// never depends on this; the mapping is the *last* thing to wire so it can pull
+/// the final, merged `ScopeAction` discriminants without colliding with #582.
+///
+/// When implemented (milestone 2), the concrete `Action`/`ObjectType` ids it
+/// returns MUST match `hyprstream::mac::te::Action::from_scope_action` /
+/// `ScopeAction` so the compiler and every PEP intern the same verb to the same
+/// id with no side table. The associated types are left abstract here so this
+/// crate (the lower one) does not yet need to name the `hyprstream`-crate TE
+/// types.
+pub trait ActionVocabulary {
+    /// The interned action-id type (milestone 2 = `hyprstream::mac::te::Action`).
+    type Action;
+    /// The interned object-type id type (milestone 2 = `hyprstream::mac::te::ObjectType`).
+    type ObjectType;
+
+    /// Map a UCAN ability verb to its enforcement action id, if the verb is in
+    /// the closed vocabulary. `None` ⇒ unknown verb ⇒ the compiler MUST reject
+    /// (fail-closed — never default to a permissive action).
+    fn action_of(&self, ability: &Ability) -> Option<Self::Action>;
+
+    /// Map a UCAN resource pointer to its TE object type, if recognized. `None`
+    /// ⇒ unknown resource class ⇒ reject.
+    fn object_type_of(&self, resource: &Resource) -> Option<Self::ObjectType>;
+}
+
+// ---------------------------------------------------------------------------
+// SEAM 2 — Casbin/TE bundle emission
+// TODO(#571 milestone 2): scaffold only; produces the hyprstream::mac TeMatrix.
+// ---------------------------------------------------------------------------
+
+/// Lowers a validated UCAN ceiling into the compiled enforcement bundle (the
+/// Casbin/TE artifact S4 distributes). This is what actually *produces* the
+/// `bundle_hash` the [`super::approval::ApprovalBinding`] signs.
+///
+/// **SCAFFOLD ONLY in milestone 1.** The concrete emitter lives in milestone 2
+/// because it depends on (a) the action vocabulary ([`ActionVocabulary`], gated
+/// on #582) and (b) the `hyprstream`-crate `TeMatrix` / `CompiledPolicy` types
+/// (S4, `crates/hyprstream/src/mac/compiled.rs`). Crate layering note: the
+/// emitter most likely lives in the `hyprstream` crate (which already depends on
+/// this one and owns `TeMatrix`), consuming the milestone-1 validated `Ucan` +
+/// `ActionVocabulary` from here. The contract is fixed now:
+///
+/// 1. input: a UCAN whose chain ALREADY passed [`super::chain::validate`];
+/// 2. output: a compiled bundle whose authority is provably ⊆ the UCAN's
+///    capabilities (the faithfulness obligation — see [`FaithfulnessCheck`]);
+/// 3. the caller hashes the bundle (BLAKE3, == `CompiledPolicy::policy_hash()`)
+///    and binds it via [`super::approval::SignedApproval::sign`].
+pub trait BundleEmitter {
+    /// The compiled bundle type (milestone 2 = a `hyprstream::mac::CompiledPolicy`
+    /// or its `TeMatrix` + lattice generation).
+    type Bundle;
+    /// Emission error type.
+    type Error;
+
+    /// Compile a validated UCAN ceiling into a bundle. Implementors MUST be
+    /// deterministic (same UCAN + same lattice generation ⇒ byte-identical
+    /// bundle ⇒ identical hash) so the approval binding is reproducible.
+    fn emit(&self, validated_ucan: &super::token::Ucan) -> Result<Self::Bundle, Self::Error>;
+}
+
+// ---------------------------------------------------------------------------
+// SEAM 3 — faithfulness framework
+// TODO(#571 milestone 2): reference interpreter + differential property tests
+//                         + SMT equivalence for the structural fragment.
+// ---------------------------------------------------------------------------
+
+/// The faithfulness obligation: the emitted bundle grants *exactly* the
+/// authority the approved UCAN does — no more (soundness: the bundle is a
+/// ceiling) and, for the auditable fragment, no less (completeness).
+///
+/// **SCAFFOLD ONLY in milestone 1.** Milestone 2 implements this as three
+/// mutually-reinforcing checks, all off the hot path:
+/// 1. a **reference interpreter** that decides `(subject, object, action)`
+///    directly from the UCAN capability set (the spec of intent);
+/// 2. **differential property tests** comparing the reference interpreter to the
+///    emitted bundle's `TeEvaluator` over randomized requests (must agree on
+///    every input);
+/// 3. an **SMT equivalence proof** for the structural (vocabulary-closed)
+///    fragment, discharging the "for all requests" quantifier the property
+///    tests only sample.
+///
+/// The contract: `check` returns `Ok(())` iff the bundle is faithful to the
+/// UCAN, else a counterexample. A compiler that cannot discharge this MUST NOT
+/// emit an approval (fail-closed: an unfaithful bundle is never signed).
+pub trait FaithfulnessCheck {
+    /// The bundle type under check (milestone 2 = the emitted TE bundle).
+    type Bundle;
+    /// A counterexample / failure describing where bundle and UCAN disagree.
+    type Counterexample;
+
+    /// Verify the emitted `bundle` faithfully realizes `ucan`'s ceiling.
+    fn check(
+        &self,
+        ucan: &super::token::Ucan,
+        bundle: &Self::Bundle,
+    ) -> Result<(), Self::Counterexample>;
+}

--- a/crates/hyprstream-rpc/src/auth/ucan/token.rs
+++ b/crates/hyprstream-rpc/src/auth/ucan/token.rs
@@ -131,8 +131,40 @@ impl Ucan {
     /// Decode a UCAN from canonical CBOR. Pure structural decode — does NOT
     /// verify signatures or attenuation (call [`Ucan::verify_signatures`] then
     /// [`super::chain::validate_chain`]).
+    ///
+    /// Fail-closed DoS guard: a decoded chain whose nesting meets or exceeds
+    /// [`super::chain::MAX_PROOF_DEPTH`] is rejected here, before it is ever
+    /// walked, so a maliciously deep `proofs`-within-`proofs` token cannot reach
+    /// (or exhaust the stack in) the validator. (The validator independently
+    /// re-enforces the same bound during the walk.)
     pub fn from_cbor(bytes: &[u8]) -> Result<Self, UcanError> {
-        ciborium::de::from_reader(bytes).map_err(|e| UcanError::Decode(e.to_string()))
+        let ucan: Ucan =
+            ciborium::de::from_reader(bytes).map_err(|e| UcanError::Decode(e.to_string()))?;
+        // Match the validator's bound exactly: the walk rejects once a link index
+        // reaches `MAX_PROOF_DEPTH` (links `0..MAX_PROOF_DEPTH` are allowed), so a
+        // `proof_depth` of `MAX_PROOF_DEPTH` or more is over-deep.
+        let depth = ucan.proof_depth();
+        if depth >= super::chain::MAX_PROOF_DEPTH {
+            return Err(UcanError::Malformed(format!(
+                "delegation chain nested {depth} deep meets/exceeds maximum proof depth {}",
+                super::chain::MAX_PROOF_DEPTH
+            )));
+        }
+        Ok(ucan)
+    }
+
+    /// The maximum nesting depth of this UCAN's proof chain: `0` for a root (no
+    /// proofs), otherwise `1 + max(proof.proof_depth())`. Used by [`from_cbor`]
+    /// as a parse-time DoS bound. Walks the in-memory tree iteratively-bounded by
+    /// the already-decoded structure (the decode itself is what we cap).
+    ///
+    /// [`from_cbor`]: Ucan::from_cbor
+    pub fn proof_depth(&self) -> usize {
+        self.proofs
+            .iter()
+            .map(|p| 1 + p.proof_depth())
+            .max()
+            .unwrap_or(0)
     }
 
     /// Encode this UCAN to canonical CBOR.

--- a/crates/hyprstream-rpc/src/auth/ucan/token.rs
+++ b/crates/hyprstream-rpc/src/auth/ucan/token.rs
@@ -1,0 +1,539 @@
+//! The typed **UCAN token** model + structural validation + hybrid-COSE
+//! signature verification (S5 / #571, milestone 1).
+//!
+//! We control both ends of this UCAN — issuance and consumption are internal to
+//! the MAC epic — so this is a **minimal, typed** model rather than a full
+//! JOSE/JWT UCAN. Crucially, UCAN signing is aligned with the project's hybrid
+//! post-quantum COSE composite (EdDSA + ML-DSA-65), **not** a JWT `ucan` crate:
+//! a UCAN is a CBOR payload signed with [`crate::crypto::cose_sign::sign_composite`]
+//! and verified with [`crate::crypto::cose_sign::verify_composite`]
+//! (`require_pq = true`). This keeps the whole authority chain on the same
+//! HNDL-resistant signature suite the rest of the TCB uses.
+//!
+//! ## Shape
+//!
+//! ```text
+//! Ucan {
+//!   payload: UcanPayload {        // the signed bytes (canonical CBOR)
+//!     issuer:   Did,              // did:key of the signer
+//!     audience: Did,              // did:key of the delegate
+//!     capabilities: [Capability], // the granted authority
+//!     not_before / expiration: Option<u64> (unix seconds),
+//!     nonce: ...,
+//!   },
+//!   proofs: [Ucan],               // the delegation chain (delegator UCANs)
+//!   signature: Vec<u8>,           // detached hybrid-COSE composite over payload
+//! }
+//! ```
+//!
+//! Signature *verification* lives here. Delegation-chain + attenuation
+//! validation lives in [`super::chain`] (it is the most security-critical piece
+//! and is isolated for that reason).
+
+use super::capability::Capability;
+use crate::did_key::did_key_to_ed25519;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// A decentralized identifier. Milestone 1 supports `did:key` (Ed25519)
+/// exclusively — the self-contained form the rest of `hyprstream-rpc` already
+/// uses (`crate::did_key`). The string is the canonical identity; the resolved
+/// Ed25519 key is derived on demand for signature verification.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Did(pub String);
+
+impl Did {
+    pub fn new(s: impl Into<String>) -> Self {
+        Did(s.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Resolve the Ed25519 verifying key bytes this `did:key` encodes. The
+    /// classical half of the hybrid identity; the ML-DSA-65 anchor is resolved
+    /// separately by the verifier's trust store (see [`UcanVerifier`]). Errors
+    /// (fail-closed) if this is not a well-formed `did:key` Ed25519 identifier.
+    pub fn ed25519_key(&self) -> Result<[u8; 32], UcanError> {
+        did_key_to_ed25519(&self.0).map_err(|e| UcanError::BadDid {
+            did: self.0.clone(),
+            reason: e.to_string(),
+        })
+    }
+}
+
+impl fmt::Display for Did {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// The signed body of a UCAN: everything an issuer commits to with their
+/// signature. Serialized to canonical CBOR ([`UcanPayload::signing_bytes`]) to
+/// produce the exact bytes the hybrid-COSE composite signs/verifies.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UcanPayload {
+    /// The issuer (signer) DID.
+    pub issuer: Did,
+    /// The audience (delegate) DID — who this UCAN grants authority to.
+    pub audience: Did,
+    /// The capabilities granted by this UCAN.
+    pub capabilities: Vec<Capability>,
+    /// `not before` — earliest unix second at which this UCAN is valid.
+    #[serde(default)]
+    pub not_before: Option<u64>,
+    /// `expiration` — unix second after which this UCAN is invalid. `None` =
+    /// non-expiring (discouraged but representable).
+    #[serde(default)]
+    pub expiration: Option<u64>,
+    /// Replay-uniqueness nonce.
+    #[serde(default)]
+    pub nonce: Vec<u8>,
+}
+
+impl UcanPayload {
+    /// Canonical CBOR bytes of the payload — the exact bytes that are signed and
+    /// verified. Deterministic for a given payload (ciborium emits map keys in
+    /// struct-field order; the same payload always yields identical bytes), so a
+    /// signature over these bytes is stable across processes.
+    ///
+    /// Serializing an in-memory payload into a `Vec` is infallible for this
+    /// shape; we still avoid `unwrap`/`expect` in non-test code and surface any
+    /// (unreachable) encoder error as a fail-closed [`UcanError`].
+    pub fn signing_bytes(&self) -> Result<Vec<u8>, UcanError> {
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(self, &mut buf).map_err(|e| UcanError::Encode(e.to_string()))?;
+        Ok(buf)
+    }
+}
+
+/// A UCAN: a signed payload plus the proof chain of delegator UCANs.
+///
+/// The chain is the `proofs` vector — each entry is the *delegator's* UCAN whose
+/// audience is this UCAN's issuer and whose capabilities must cover this UCAN's
+/// (validated in [`super::chain`]). A root UCAN (self-issued authority) has an
+/// empty `proofs` vector.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Ucan {
+    /// The signed claims.
+    pub payload: UcanPayload,
+    /// The delegation chain: delegator UCANs that authorize this one. Empty for
+    /// a root.
+    #[serde(default)]
+    pub proofs: Vec<Ucan>,
+    /// Detached hybrid-COSE composite signature over [`UcanPayload::signing_bytes`].
+    pub signature: Vec<u8>,
+}
+
+impl Ucan {
+    /// Decode a UCAN from canonical CBOR. Pure structural decode — does NOT
+    /// verify signatures or attenuation (call [`Ucan::verify_signatures`] then
+    /// [`super::chain::validate_chain`]).
+    pub fn from_cbor(bytes: &[u8]) -> Result<Self, UcanError> {
+        ciborium::de::from_reader(bytes).map_err(|e| UcanError::Decode(e.to_string()))
+    }
+
+    /// Encode this UCAN to canonical CBOR.
+    pub fn to_cbor(&self) -> Result<Vec<u8>, UcanError> {
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(self, &mut buf).map_err(|e| UcanError::Encode(e.to_string()))?;
+        Ok(buf)
+    }
+
+    /// The issuer DID of this UCAN.
+    pub fn issuer(&self) -> &Did {
+        &self.payload.issuer
+    }
+
+    /// The audience DID of this UCAN.
+    pub fn audience(&self) -> &Did {
+        &self.payload.audience
+    }
+
+    /// The capabilities this UCAN grants.
+    pub fn capabilities(&self) -> &[Capability] {
+        &self.payload.capabilities
+    }
+
+    /// **Structural** validation independent of crypto/attenuation: a UCAN is
+    /// structurally well-formed iff both its DIDs resolve to valid `did:key`
+    /// Ed25519 identities and (if present) `not_before <= expiration`. Each
+    /// proof is recursively checked. Fail-closed on any malformation.
+    pub fn validate_structure(&self) -> Result<(), UcanError> {
+        // DIDs must be resolvable did:key identifiers.
+        let _ = self.payload.issuer.ed25519_key()?;
+        let _ = self.payload.audience.ed25519_key()?;
+        if let (Some(nbf), Some(exp)) = (self.payload.not_before, self.payload.expiration) {
+            if nbf > exp {
+                return Err(UcanError::Malformed(format!(
+                    "not_before ({nbf}) is after expiration ({exp})"
+                )));
+            }
+        }
+        for proof in &self.proofs {
+            proof.validate_structure()?;
+        }
+        Ok(())
+    }
+
+    /// Is this UCAN temporally valid at `now` (unix seconds)? `not_before`
+    /// inclusive, `expiration` inclusive of `now <= exp`. A `None` bound is
+    /// unbounded on that side.
+    #[must_use]
+    pub fn is_valid_at(&self, now: u64) -> bool {
+        if let Some(nbf) = self.payload.not_before {
+            if now < nbf {
+                return false;
+            }
+        }
+        if let Some(exp) = self.payload.expiration {
+            if now > exp {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Verify the hybrid-COSE composite signature on THIS UCAN's payload, AND
+    /// recursively on every proof in the chain. The issuer's classical key is
+    /// taken from its `did:key`; the matching ML-DSA-65 anchor is resolved
+    /// through `verifier` (the trust store / key-binding layer — the same
+    /// `register_pq_trust` reality `crypto::pq` models). Fail-closed: any link
+    /// whose signature does not verify (or whose PQ anchor is missing under the
+    /// hybrid policy) rejects the whole UCAN.
+    ///
+    /// This does NOT check attenuation/delegation linkage — that is
+    /// [`super::chain::validate_chain`], deliberately separate.
+    pub fn verify_signatures<V: UcanVerifier>(&self, verifier: &V) -> Result<(), UcanError> {
+        let ed_bytes = self.payload.issuer.ed25519_key()?;
+        let payload_bytes = self.payload.signing_bytes()?;
+        verifier.verify(
+            &self.payload.issuer,
+            &ed_bytes,
+            &payload_bytes,
+            &self.signature,
+        )?;
+        for proof in &self.proofs {
+            proof.verify_signatures(verifier)?;
+        }
+        Ok(())
+    }
+}
+
+/// Resolves a UCAN issuer's verified key material and checks a detached
+/// hybrid-COSE signature over the payload bytes.
+///
+/// This is the seam between "what DID/key-binding layer says is anchored" and
+/// "what the UCAN verifier trusts". The production implementor resolves the
+/// issuer's anchored ML-DSA-65 verifying key (via the `register_pq_trust` /
+/// `PqTrustStore` binding referenced in `crypto::cose_sign`) keyed by the
+/// issuer's Ed25519 identity and calls
+/// [`crate::crypto::cose_sign::verify_composite`] with `require_pq = true`. The
+/// classical Ed25519 key is supplied (already decoded from the `did:key`).
+pub trait UcanVerifier {
+    /// Verify `signature` (a hybrid-COSE composite) over `payload` for the given
+    /// `issuer`, whose decoded Ed25519 verifying key bytes are `ed_key`. Returns
+    /// `Ok(())` iff the composite verifies under the project's hybrid policy
+    /// (both EdDSA and the anchored ML-DSA-65 layer). Fail-closed otherwise.
+    fn verify(
+        &self,
+        issuer: &Did,
+        ed_key: &[u8; 32],
+        payload: &[u8],
+        signature: &[u8],
+    ) -> Result<(), UcanError>;
+}
+
+/// Errors from UCAN parsing, structure, and signature verification. All map to a
+/// fail-closed rejection at the call site.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UcanError {
+    /// CBOR decode failure.
+    Decode(String),
+    /// CBOR encode failure (effectively unreachable for in-memory shapes).
+    Encode(String),
+    /// A DID was not a well-formed `did:key` Ed25519 identifier.
+    BadDid { did: String, reason: String },
+    /// Structurally malformed (e.g. inverted validity window).
+    Malformed(String),
+    /// A signature did not verify under the hybrid policy.
+    BadSignature(String),
+}
+
+impl fmt::Display for UcanError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            UcanError::Decode(e) => write!(f, "UCAN decode failed: {e}"),
+            UcanError::Encode(e) => write!(f, "UCAN encode failed: {e}"),
+            UcanError::BadDid { did, reason } => write!(f, "invalid did:key {did}: {reason}"),
+            UcanError::Malformed(e) => write!(f, "malformed UCAN: {e}"),
+            UcanError::BadSignature(e) => write!(f, "UCAN signature verification failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for UcanError {}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+pub(super) mod test_support {
+    //! Shared test helpers for building and signing UCANs with the real hybrid
+    //! COSE path. Visible to sibling test modules (`chain`, `approval`).
+    use super::*;
+    use crate::auth::ucan::capability::{Ability, Capability, Resource};
+    use crate::crypto::cose_sign::{sign_composite, verify_composite};
+    use crate::crypto::pq::{ml_dsa_generate_keypair, MlDsaSigningKey, MlDsaVerifyingKey};
+    use crate::did_key::ed25519_to_did_key;
+    use ed25519_dalek::{SigningKey, VerifyingKey};
+    use std::collections::HashMap;
+
+    /// Domain-separation AAD for UCAN payload signatures (distinct from the
+    /// compiled-policy and envelope AADs so a UCAN signature can never be
+    /// replayed as another message type).
+    pub const UCAN_AAD: &[u8] = b"hs-mac-ucan-payload-v1";
+
+    /// A hybrid keypair (Ed25519 + ML-DSA-65) bound to one DID identity.
+    pub struct TestIdentity {
+        pub ed_sk: SigningKey,
+        pub ed_vk: VerifyingKey,
+        pub pq_sk: MlDsaSigningKey,
+        pub pq_vk: MlDsaVerifyingKey,
+    }
+
+    impl TestIdentity {
+        pub fn generate() -> Self {
+            use rand::rngs::OsRng;
+            let ed_sk = SigningKey::generate(&mut OsRng);
+            let ed_vk = ed_sk.verifying_key();
+            let (pq_sk, pq_vk) = ml_dsa_generate_keypair();
+            Self {
+                ed_sk,
+                ed_vk,
+                pq_sk,
+                pq_vk,
+            }
+        }
+
+        pub fn did(&self) -> Did {
+            Did::new(ed25519_to_did_key(&self.ed_vk.to_bytes()))
+        }
+    }
+
+    pub fn cap(resource: &str, ability: &str) -> Capability {
+        Capability::new(Resource::new(resource), Ability::new(ability))
+    }
+
+    /// Build and hybrid-sign a UCAN from `issuer` to `audience` with `caps` and
+    /// the given `proofs`.
+    pub fn signed_ucan(
+        issuer: &TestIdentity,
+        audience: &Did,
+        caps: Vec<Capability>,
+        proofs: Vec<Ucan>,
+    ) -> Ucan {
+        let payload = UcanPayload {
+            issuer: issuer.did(),
+            audience: audience.clone(),
+            capabilities: caps,
+            not_before: None,
+            expiration: Some(9_999_999_999),
+            nonce: vec![1, 2, 3],
+        };
+        let bytes = payload.signing_bytes().unwrap();
+        let signature =
+            sign_composite(&issuer.ed_sk, Some(&issuer.pq_sk), &bytes, UCAN_AAD).unwrap();
+        Ucan {
+            payload,
+            proofs,
+            signature,
+        }
+    }
+
+    /// A trust store keyed by DID string → anchored ML-DSA-65 verifying key,
+    /// implementing [`UcanVerifier`] over the real hybrid composite verify.
+    pub struct TestTrustStore {
+        pub pq_by_did: HashMap<String, MlDsaVerifyingKey>,
+    }
+
+    impl TestTrustStore {
+        pub fn new() -> Self {
+            Self {
+                pq_by_did: HashMap::new(),
+            }
+        }
+        pub fn anchor(&mut self, id: &TestIdentity) {
+            self.pq_by_did.insert(id.did().0, id.pq_vk.clone());
+        }
+    }
+
+    impl UcanVerifier for TestTrustStore {
+        fn verify(
+            &self,
+            issuer: &Did,
+            ed_key: &[u8; 32],
+            payload: &[u8],
+            signature: &[u8],
+        ) -> Result<(), UcanError> {
+            let ed_vk = VerifyingKey::from_bytes(ed_key)
+                .map_err(|e| UcanError::BadSignature(e.to_string()))?;
+            let pq_vk = self.pq_by_did.get(&issuer.0);
+            verify_composite(signature, &ed_vk, pq_vk, payload, UCAN_AAD, true)
+                .map(|_| ())
+                .map_err(|e| UcanError::BadSignature(e.to_string()))
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::test_support::*;
+    use super::*;
+
+    #[test]
+    fn cbor_roundtrip_preserves_ucan() {
+        let alice = TestIdentity::generate();
+        let bob = TestIdentity::generate();
+        let u = signed_ucan(
+            &alice,
+            &bob.did(),
+            vec![cap("mac://model/*", "infer")],
+            vec![],
+        );
+        let bytes = u.to_cbor().unwrap();
+        let back = Ucan::from_cbor(&bytes).unwrap();
+        assert_eq!(u, back);
+    }
+
+    #[test]
+    fn signing_bytes_are_deterministic() {
+        let alice = TestIdentity::generate();
+        let bob = TestIdentity::generate();
+        let u = signed_ucan(&alice, &bob.did(), vec![cap("mac://x", "y")], vec![]);
+        assert_eq!(
+            u.payload.signing_bytes().unwrap(),
+            u.payload.signing_bytes().unwrap()
+        );
+    }
+
+    #[test]
+    fn validate_structure_accepts_well_formed() {
+        let alice = TestIdentity::generate();
+        let bob = TestIdentity::generate();
+        let u = signed_ucan(&alice, &bob.did(), vec![cap("mac://x", "y")], vec![]);
+        assert!(u.validate_structure().is_ok());
+    }
+
+    #[test]
+    fn validate_structure_rejects_bad_did() {
+        let alice = TestIdentity::generate();
+        let mut u = signed_ucan(&alice, &alice.did(), vec![], vec![]);
+        u.payload.audience = Did::new("did:web:example.com");
+        assert!(matches!(
+            u.validate_structure(),
+            Err(UcanError::BadDid { .. })
+        ));
+    }
+
+    #[test]
+    fn validate_structure_rejects_inverted_window() {
+        let alice = TestIdentity::generate();
+        let mut u = signed_ucan(&alice, &alice.did(), vec![], vec![]);
+        u.payload.not_before = Some(100);
+        u.payload.expiration = Some(50);
+        assert!(matches!(
+            u.validate_structure(),
+            Err(UcanError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn is_valid_at_respects_window() {
+        let alice = TestIdentity::generate();
+        let mut u = signed_ucan(&alice, &alice.did(), vec![], vec![]);
+        u.payload.not_before = Some(100);
+        u.payload.expiration = Some(200);
+        assert!(!u.is_valid_at(99));
+        assert!(u.is_valid_at(100));
+        assert!(u.is_valid_at(200));
+        assert!(!u.is_valid_at(201));
+    }
+
+    #[test]
+    fn verify_signatures_accepts_valid_hybrid_signature() {
+        let alice = TestIdentity::generate();
+        let bob = TestIdentity::generate();
+        let u = signed_ucan(
+            &alice,
+            &bob.did(),
+            vec![cap("mac://model/*", "infer")],
+            vec![],
+        );
+
+        let mut store = TestTrustStore::new();
+        store.anchor(&alice);
+        assert!(u.verify_signatures(&store).is_ok());
+    }
+
+    #[test]
+    fn verify_signatures_rejects_missing_pq_anchor() {
+        // No anchored ML-DSA key → require_pq=true must fail closed.
+        let alice = TestIdentity::generate();
+        let bob = TestIdentity::generate();
+        let u = signed_ucan(&alice, &bob.did(), vec![cap("mac://x", "y")], vec![]);
+        let store = TestTrustStore::new(); // empty: no anchor
+        assert!(matches!(
+            u.verify_signatures(&store),
+            Err(UcanError::BadSignature(_))
+        ));
+    }
+
+    #[test]
+    fn verify_signatures_rejects_tampered_payload() {
+        let alice = TestIdentity::generate();
+        let bob = TestIdentity::generate();
+        let mut u = signed_ucan(
+            &alice,
+            &bob.did(),
+            vec![cap("mac://model/qwen", "infer")],
+            vec![],
+        );
+        // Widen the capability AFTER signing — signature must no longer verify.
+        u.payload.capabilities = vec![cap("mac://*", "*")];
+        let mut store = TestTrustStore::new();
+        store.anchor(&alice);
+        assert!(matches!(
+            u.verify_signatures(&store),
+            Err(UcanError::BadSignature(_))
+        ));
+    }
+
+    #[test]
+    fn verify_signatures_recurses_into_proofs() {
+        // root → alice → bob; tamper the embedded root proof, expect rejection.
+        let root = TestIdentity::generate();
+        let alice = TestIdentity::generate();
+        let bob = TestIdentity::generate();
+        let root_ucan = signed_ucan(&root, &alice.did(), vec![cap("mac://*", "*")], vec![]);
+        let mut alice_ucan = signed_ucan(
+            &alice,
+            &bob.did(),
+            vec![cap("mac://model/qwen", "infer")],
+            vec![root_ucan],
+        );
+
+        let mut store = TestTrustStore::new();
+        store.anchor(&root);
+        store.anchor(&alice);
+        assert!(alice_ucan.verify_signatures(&store).is_ok());
+
+        // Corrupt the proof's signature.
+        alice_ucan.proofs[0].signature[0] ^= 0xFF;
+        assert!(matches!(
+            alice_ucan.verify_signatures(&store),
+            Err(UcanError::BadSignature(_))
+        ));
+    }
+}


### PR DESCRIPTION
Part of epic #547 (native MAC authz), issue #571 (S5 — UCAN→Casbin/TE compiler). Based on `feature/security-mac-ucan` (S1 #567 + S4 #570). **Milestone 1 of 2: the vocabulary-independent compiler core + approval binding.** The action-vocabulary mapping, Casbin/TE bundle emission, and the faithfulness framework land in milestone 2 (seams in place; vocab mapping gated on S3/#582 merging so it targets the final `ScopeAction`/`Operation` set, which now includes `Subscribe`/`Publish`).

## Design
UCAN is the **authoring/delegation source language**; Casbin/TE is the compiled **enforcement**. An approved UCAN compiles deterministically and faithfully to a Casbin/TE bundle that is a **ceiling**, and a signed `(UCAN, bundle_hash)` binding ties the compiled artifact to exactly what was reviewed so a compiler bug can never exceed the approved authority. Labels/MAC-floor come from manifests, never from the UCAN.

## What milestone 1 delivers (`crates/hyprstream-rpc/src/auth/ucan/`)
- **`capability.rs`** — `Capability { resource, ability, caveats }`; `Resource`/`Ability` with `/`+`*` containment; value-blind `Caveats` (child may add, not drop). `authorizes` = 3-axis conjunction; `set_attenuates` for set-level ⊆.
- **`token.rs`** — typed `Ucan` / `UcanPayload` / `Did`; CBOR (de)serialize, `validate_structure`, `is_valid_at`, recursive `verify_signatures` via the project's **hybrid EdDSA + ML-DSA-65 COSE** (`sign_composite`/`verify_composite`, `require_pq`) through a `UcanVerifier` trust-store seam. No JOSE/JWT UCAN crate — aligned with the project crypto floor.
- **`chain.rs`** — the core: `validate_chain` enforces **linkage** (`delegate.issuer == delegator.audience`), **attenuation** (no widening on any axis), and **time-window containment** (child can't outlive parent). Fail-closed throughout.
- **`approval.rs`** — `ApprovalBinding { ucan_cid, generation, bundle_hash }` + `SignedApproval` (hybrid COSE). `bundle_hash` is the BLAKE3 `[u8;32]` that S4's `compiled::policy_hash()` yields, so it drops straight into S4's `compiled::PolicyApproval`; `generation` binds the `LatticeVersion`.
- **`seam.rs`** — milestone-2 interfaces (scaffold only): `ActionVocabulary` (UCAN ↔ `ScopeAction`/`Operation`, deferred to post-#582), `BundleEmitter` (lower a validated ceiling into S4's `TeMatrix`/`CompiledPolicy`), `FaithfulnessCheck` (reference interpreter + differential property tests + SMT equivalence for the structural fragment).

## Verification
- `cargo build -p hyprstream-rpc`: clean.
- `cargo test -p hyprstream-rpc --lib auth::ucan`: **36 passed / 0 failed** (capability covers/authorizes/attenuation; token CBOR-roundtrip/deterministic-signing/structure/verify incl. missing-PQ-anchor + tampered + recurse-into-proofs; chain valid + widening-rejected on every axis + broken-linkage + window + ordering; approval cid-stability + sign/verify + tamper-reject + exact-triple binding).
- `cargo clippy -p hyprstream-rpc --all-targets -- -D warnings`: clean. Full-workspace pre-commit hook passed.

## Not in scope (milestone 2)
Action-vocab mapping (post-#582), bundle emission into S4's `TeMatrix`, faithfulness framework. Seams are defined so they wire in without reshaping the core.
