### PR TITLE
fix(#465): gate tokio net/mio out of the wasm32 build (hyprstream-9p)

### DIFF
--- a/crates/hyprstream-9p/Cargo.toml
+++ b/crates/hyprstream-9p/Cargo.toml
@@ -13,12 +13,20 @@ hyprstream-vfs = { path = "../hyprstream-vfs" }
 hyprstream-rpc = { path = "../hyprstream-rpc" }
 async-trait = { workspace = true }
 anyhow = { workspace = true }
-tokio = { version = "1", features = ["net", "io-util", "rt", "sync", "macros"] }
 tracing = { workspace = true }
 dashmap = { workspace = true }
 parking_lot = { workspace = true }
 
+# Native: full tokio with `net` for the server-side TCP accept loop (translator).
+# `net` pulls `mio`, which has no wasm32-unknown-unknown backend, so it must stay
+# off the wasm target (the browser path uses the DMA/Wanix transport instead).
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1", features = ["net", "io-util", "rt", "sync", "macros"] }
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+# wasm32: tokio without `net` (no `mio`). The translator (TCP server) is
+# cfg-gated out of the wasm build; only the codec + client/DMA paths compile.
+tokio = { version = "1", default-features = false, features = ["sync", "macros"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"

--- a/crates/hyprstream-9p/src/lib.rs
+++ b/crates/hyprstream-9p/src/lib.rs
@@ -22,6 +22,10 @@ pub mod msg;
 pub mod client;
 pub mod backend;
 pub mod memory;
+// The translator is the server-side TCP accept loop (tokio::net). `net` pulls
+// `mio`, which has no wasm32 backend, so the whole module is native-only. The
+// browser/wasm build reaches the backend through the DMA/Wanix client path.
+#[cfg(not(target_arch = "wasm32"))]
 pub mod translator;
 
 #[cfg(target_arch = "wasm32")]
@@ -30,4 +34,5 @@ pub mod dma;
 pub mod wanix_mount;
 
 pub use backend::{Backend, OpenResult, StatResult, WalkResult};
+#[cfg(not(target_arch = "wasm32"))]
 pub use translator::{FidTable, Translator};


### PR DESCRIPTION
Fixes the wasm32 build regression from #558 (commit `696ecdc74`).

## Problem
`hyprstream-9p/Cargo.toml` enabled `tokio` with the `net` feature as an **unconditional**
`[dependencies]` entry. `net` → `mio`, which has **no `wasm32-unknown-unknown` backend**. Since
`hyprstream-rpc-std` depends on `hyprstream-9p` on the wasm32 target, the browser/v2 docker-build wasm
stage and hyprstream's own wasm32 build broke with ~48 `could not compile mio` errors
(`crate::sys::IoSourceState`, missing `Selector`/`Waker`/`Event`, …). #558 introduced both the
unconditional `tokio net` in 9p **and** the std→9p wasm edge.

## Fix (only `crates/hyprstream-9p`; native behavior unchanged)
- `Cargo.toml`: split the `tokio` dep by target —
  - `cfg(not(target_arch = "wasm32"))`: full `["net","io-util","rt","sync","macros"]` (identical to before).
  - `cfg(target_arch = "wasm32")`: `default-features = false, features = ["sync","macros"]` — **no `net`, no `mio`**.
- `src/lib.rs`: gate `pub mod translator;` + its re-exports behind `#[cfg(not(target_arch = "wasm32"))]`.
  `translator.rs` is the **sole** `tokio::net` consumer (server-side TCP accept loop); the wasm path uses
  the DMA/Wanix client (`client`/`dma`/`wanix_mount`), which is what `rpc-std`'s wasm consumer references.
  `rpc-std` itself has no tokio dep — no change there.

## Verification
- **wasm32:** `hyprstream-9p` + `hyprstream-rpc-std` build green; `cargo tree --target wasm32-unknown-unknown -i mio` → empty for both. Repro `cargo build -p hyprstream-rpc-std --lib --release --target wasm32-unknown-unknown` now passes.
- **native:** `cargo build -p hyprstream-9p -p hyprstream-rpc-std` green; `cargo tree -p hyprstream-9p -i mio` still shows `mio ← tokio` (net intact); native clippy clean.
- **repo wasm CI gate** (`cargo check --target wasm32-unknown-unknown -p hyprstream-rpc`, `RUSTFLAGS=--cfg=web_sys_unstable_apis`): passes.

## Unblocks
www v2 docker-build wasm stage (1:6.0 validating end-to-end against a warm podman cache) + hyprstream's own wasm32 build.

## Note (pre-existing, out of scope)
`cargo clippy --target wasm32-unknown-unknown` still fails — but **all** failures are pre-existing
lint-level errors inside `crates/hyprstream-rpc/src` (disallowed `std::sync::RwLock`, `unwrap`/`expect`),
unrelated to this change and in a crate outside this fix's scope. Flagging, not touching it here.

Closes #465.
