### PR TITLE
feat(#505 P2): in-process wasm SandboxBackend on the consolidated crate [supersedes #585]

### DIFF
--- a/.github/workflows/workers-wasm-tests.yml
+++ b/.github/workflows/workers-wasm-tests.yml
@@ -1,0 +1,47 @@
+name: workers wasm backend
+
+# CI-enforce the in-process wasm SandboxBackend (#505 P2 / #597): build + run the
+# `hyprstream-workers --features wasm` tests so the backend's capability/DoS/ZSP
+# guarantees are pipeline-verified, not just local. The wasm_backend tests use an
+# inline WAT guest (compiled by wasmtime at runtime), so there is no wasm32 cross-build
+# or guest artifact — the tests always RUN (no skip path to guard). Torch-free.
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'crates/hyprstream-workers/**'
+      - 'crates/hyprstream-sandbox/**'
+      - '.github/workflows/workers-wasm-tests.yml'
+  pull_request:
+    paths:
+      - 'crates/hyprstream-workers/**'
+      - 'crates/hyprstream-sandbox/**'
+      - '.github/workflows/workers-wasm-tests.yml'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  workers-wasm:
+    name: build + test hyprstream-workers --features wasm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # hyprstream-workers -> hyprstream-rpc, whose build.rs invokes the capnp compiler.
+      - name: Install system deps (capnproto)
+        run: sudo apt-get update && sudo apt-get install -y capnproto pkg-config libssl-dev
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      # The wasm SandboxBackend tests use an inline WAT guest (no wasm32 artifact),
+      # so they always RUN. This includes the explicit-only / ZSP selection tests
+      # (`wasm` is auto_selectable:false — never auto-picked).
+      - name: Build + test workers --features wasm
+        run: |
+          cargo build -p hyprstream-workers --features wasm
+          cargo test -p hyprstream-workers --features wasm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7226,6 +7226,7 @@ dependencies = [
  "hyprstream-rpc",
  "hyprstream-rpc-build",
  "hyprstream-rpc-derive",
+ "hyprstream-sandbox",
  "hyprstream-service",
  "hyprstream-tcl",
  "hyprstream-vfs",

--- a/crates/hyprstream-workers/Cargo.toml
+++ b/crates/hyprstream-workers/Cargo.toml
@@ -9,6 +9,13 @@ description = "Isolated workload execution using Kata Containers with CRI-aligne
 [dependencies]
 # Workspace crates
 hyprstream-rpc = { path = "../hyprstream-rpc" }
+# In-process WebAssembly sandbox substrate (#505 P1): the embedded wasmtime
+# `Sandbox` (capability-only Linker, fuel/epoch DoS bounds). This is the
+# consolidated crate formerly named `hyprstream-wasm` (renamed to
+# `hyprstream-sandbox` in the quality reset). Optional — pulled in only under the
+# `wasm` feature so the default/nspawn build stays lean and torch-free
+# (hyprstream-sandbox depends only on wasmtime/rand/vfs/rpc, never tch/libtorch).
+hyprstream-sandbox = { path = "../hyprstream-sandbox", optional = true }
 hyprstream-rpc-derive = { path = "../hyprstream-rpc-derive" }
 hyprstream-service = { path = "../hyprstream-service" }
 hyprstream-vfs = { path = "../hyprstream-vfs" }
@@ -137,6 +144,13 @@ kata-vm = [
     "dep:fuse-backend-rs",
     "dep:hyprstream-vfs-server",
 ]
+# In-process WebAssembly sandbox backend (#505 P2). Compiles in `WasmBackend`
+# and the `hyprstream-sandbox` wasmtime substrate it consumes. A native in-process
+# sibling under the same `SandboxBackend` seam: no VM, no subprocess — a wasmtime
+# guest bound to a `Subject`, fuel/epoch DoS-bounded. Opt-in so the default build
+# doesn't vendor wasmtime; stays torch-free either way. When off, `wasm`
+# selection fails closed (the backend simply isn't registered).
+wasm = ["dep:hyprstream-sandbox"]
 # Enable Dragonball built-in VMM support (alternative to cloud-hypervisor).
 # Implies `kata-vm` since it tunes the kata hypervisor abstraction.
 dragonball = ["kata-vm", "kata-hypervisor/dragonball"]

--- a/crates/hyprstream-workers/src/runtime/kata_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/kata_backend.rs
@@ -582,6 +582,8 @@ inventory::submit! {
     crate::runtime::selection::BackendRegistration {
         name: "kata",
         priority: 100,
+        // Full VM isolation (strongest tier) → eligible for `"auto"`.
+        auto_selectable: true,
         is_available: KataBackend::registry_is_available,
         construct: |ctx| {
             Ok(Arc::new(KataBackend::new(

--- a/crates/hyprstream-workers/src/runtime/mod.rs
+++ b/crates/hyprstream-workers/src/runtime/mod.rs
@@ -29,6 +29,11 @@ pub mod kata_backend;
 pub mod nspawn;
 mod pool;
 mod sandbox;
+// In-process WebAssembly sandbox backend (#505 P2) — gated behind `wasm`
+// (pulls the wasmtime-bearing `hyprstream-sandbox` substrate). A native in-process
+// sibling under the SandboxBackend seam; the default build stays lean + torch-free.
+#[cfg(feature = "wasm")]
+pub mod wasm_backend;
 // Per-sandbox VFS composition + serve (FS-D, #365): native-only + VM-only
 // (composes a RAFS rootfs and serves it over vhost-user-fs to a CH guest).
 #[cfg(all(not(target_arch = "wasm32"), feature = "kata-vm"))]
@@ -83,6 +88,8 @@ pub use backend::{SandboxBackend, SandboxHandle};
 #[cfg(feature = "kata-vm")]
 pub use kata_backend::{KataBackend, KataHandle};
 pub use nspawn::{NspawnBackend, NspawnConfig, NspawnHandle};
+#[cfg(feature = "wasm")]
+pub use wasm_backend::{WasmBackend, WasmConfig, WasmHandle};
 // Inventory-based backend registry + fail-closed selection spine (#507)
 pub use selection::{resolve_backend, BackendCtx, BackendRegistration};
 // Domain entities (business logic only)

--- a/crates/hyprstream-workers/src/runtime/nspawn.rs
+++ b/crates/hyprstream-workers/src/runtime/nspawn.rs
@@ -524,6 +524,8 @@ inventory::submit! {
     crate::runtime::selection::BackendRegistration {
         name: "nspawn",
         priority: 10,
+        // Kernel-namespace isolation (real container) → eligible for `"auto"`.
+        auto_selectable: true,
         is_available: NspawnBackend::registry_is_available,
         construct: |_ctx| {
             Ok(std::sync::Arc::new(NspawnBackend::new(NspawnConfig::default()))

--- a/crates/hyprstream-workers/src/runtime/selection.rs
+++ b/crates/hyprstream-workers/src/runtime/selection.rs
@@ -421,11 +421,16 @@ mod tests {
         );
 
         // And with nspawn alongside it, `"auto"` resolves to nspawn — never wasm.
+        // Inject a deterministic availability oracle (everything available) so this
+        // does NOT depend on the runner actually having nspawn installed: nspawn is
+        // auto_selectable (and outranks), wasm is auto_selectable:false (excluded), so
+        // auto must return nspawn. (Real-runtime availability is exercised elsewhere;
+        // here we assert the selection *logic*, env-independently.)
         let nspawn = inventory::iter::<BackendRegistration>()
             .find(|r| r.name == "nspawn")
             .expect("nspawn always registered");
         let both = vec![wasm, nspawn];
-        let r = select_registration("auto", &both, |r| (r.is_available)()).unwrap();
+        let r = select_registration("auto", &both, |_| true).unwrap();
         assert_eq!(r.name, "nspawn", "auto must pick nspawn, never wasm");
     }
 

--- a/crates/hyprstream-workers/src/runtime/selection.rs
+++ b/crates/hyprstream-workers/src/runtime/selection.rs
@@ -19,13 +19,18 @@
 //! Selection is **config-driven** via `worker.backend` (a string: a registered
 //! backend name, or `"auto"`):
 //!
-//! * `"auto"` → pick the highest-[`priority`](BackendRegistration::priority)
-//!   registration whose [`is_available`](BackendRegistration::is_available)
-//!   probe passes. The choice is logged. If nothing is available, error — never
-//!   run a workload without isolation.
+//! * `"auto"` → among registrations that are
+//!   [`auto_selectable`](BackendRegistration::auto_selectable), pick the
+//!   highest-[`priority`](BackendRegistration::priority) one whose
+//!   [`is_available`](BackendRegistration::is_available) probe passes. The choice
+//!   is logged. If none qualifies, error — never run a workload without isolation,
+//!   and never auto-pick a backend that opted out of auto-selection (a silent
+//!   isolation downgrade; see the in-process `wasm` tier, #547 ZSP).
 //! * a concrete name → that registration, **iff** it is registered *and* its
 //!   prerequisites are present. Otherwise error. We never substitute a different
-//!   (weaker) backend (the #486 fail-open bug).
+//!   (weaker) backend (the #486 fail-open bug). An explicit name resolves
+//!   regardless of `auto_selectable`, so an auto-excluded backend (e.g. `wasm`)
+//!   is still reachable when deliberately requested by name.
 //!
 //! The cardinal rule is **fail-closed**: an unavailable or unknown backend
 //! returns an error, never a silent downgrade to weaker isolation.
@@ -73,8 +78,21 @@ pub struct BackendRegistration {
     pub name: &'static str,
 
     /// Auto-selection precedence: higher is preferred. `"auto"` picks the
-    /// highest-priority *available* registration.
+    /// highest-priority *available* registration (among `auto_selectable` ones).
     pub priority: i32,
+
+    /// Whether this backend is eligible for `"auto"` selection.
+    ///
+    /// `true` → `"auto"` may pick it (subject to `priority` and `is_available`).
+    /// `false` → **explicit-name-only**: `"auto"` must never choose it, even if it
+    /// is the highest-priority available (or only) registration. It remains
+    /// selectable by its concrete name (fail-closed).
+    ///
+    /// This exists so weaker-isolation tiers cannot become a silent `"auto"`
+    /// fallback when stronger backends are absent — auto-selecting them would be a
+    /// silent isolation downgrade, which the #547 MAC/ZSP model forbids. The
+    /// in-process `wasm` sandbox (shared host address space) sets this `false`.
+    pub auto_selectable: bool,
 
     /// Runtime prerequisite probe (PATH lookups, socket existence, …). Returns
     /// `true` when this backend can actually run on this host *right now*. Used
@@ -105,8 +123,14 @@ fn select_registration<'a>(
     is_available: impl Fn(&BackendRegistration) -> bool,
 ) -> Result<&'a BackendRegistration> {
     // ── Auto: highest-priority *available* registration wins ──
+    //
+    // Only `auto_selectable` registrations are eligible. A backend that opts out
+    // (e.g. the in-process `wasm` tier) must never be auto-picked, even as a last
+    // resort when nothing stronger is available — that would be a silent isolation
+    // downgrade (#547 ZSP). Such backends remain reachable by explicit name below.
     if name.eq_ignore_ascii_case("auto") {
-        let mut candidates: Vec<&'a BackendRegistration> = regs.to_vec();
+        let mut candidates: Vec<&'a BackendRegistration> =
+            regs.iter().copied().filter(|r| r.auto_selectable).collect();
         // Highest priority first; ties broken by name for determinism.
         candidates.sort_by(|a, b| b.priority.cmp(&a.priority).then_with(|| a.name.cmp(b.name)));
         for reg in candidates {
@@ -155,11 +179,13 @@ fn select_registration<'a>(
 /// function both `factories.rs` and `bin/main.rs` route through — no scattered
 /// `#[cfg]`, no `_ => nspawn` fallback.
 ///
-/// * **`"auto"`** → highest-[`priority`](BackendRegistration::priority)
-///   registration whose [`is_available`](BackendRegistration::is_available) is
-///   true; error if none.
-/// * **concrete name** → that registration if present *and* available; otherwise
-///   error (unavailable → fail-closed; unknown → error listing the registry).
+/// * **`"auto"`** → among [`auto_selectable`](BackendRegistration::auto_selectable)
+///   registrations, the highest-[`priority`](BackendRegistration::priority) one
+///   whose [`is_available`](BackendRegistration::is_available) is true; error if
+///   none (auto-excluded backends are never picked here — no silent downgrade).
+/// * **concrete name** → that registration if present *and* available, regardless
+///   of `auto_selectable`; otherwise error (unavailable → fail-closed; unknown →
+///   error listing the registry).
 pub fn resolve_backend(name: &str, ctx: &BackendCtx) -> Result<Arc<dyn SandboxBackend>> {
     let regs: Vec<&'static BackendRegistration> =
         inventory::iter::<BackendRegistration>().collect();
@@ -182,6 +208,7 @@ pub fn resolve_backend(name: &str, ctx: &BackendCtx) -> Result<Arc<dyn SandboxBa
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 
@@ -198,12 +225,25 @@ mod tests {
     const HIGH: BackendRegistration = BackendRegistration {
         name: "high-tier",
         priority: 100,
+        auto_selectable: true,
         is_available: || true,
         construct: never_available,
     };
     const LOW: BackendRegistration = BackendRegistration {
         name: "low-tier",
         priority: 10,
+        auto_selectable: true,
+        is_available: || true,
+        construct: never_available,
+    };
+
+    /// An auto-excluded (explicit-name-only) backend, modeling the in-process
+    /// `wasm` tier: even at the highest priority and always available, `"auto"`
+    /// must never pick it.
+    const EXPLICIT_ONLY: BackendRegistration = BackendRegistration {
+        name: "explicit-only",
+        priority: 1000,
+        auto_selectable: false,
         is_available: || true,
         construct: never_available,
     };
@@ -233,6 +273,36 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("no available sandbox backend"), "got: {msg}");
         assert!(msg.contains("fail-closed"), "got: {msg}");
+    }
+
+    #[test]
+    fn auto_never_picks_explicit_only_even_as_only_backend() {
+        // An auto-excluded backend that is the *only* registration (and available)
+        // must NOT be auto-selected — `"auto"` errors instead of downgrading.
+        let only_explicit = vec![&EXPLICIT_ONLY];
+        let err = select_registration("auto", &only_explicit, |_| true).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("no available sandbox backend"), "got: {msg}");
+        assert!(msg.contains("fail-closed"), "got: {msg}");
+    }
+
+    #[test]
+    fn auto_skips_explicit_only_for_a_weaker_auto_eligible_backend() {
+        // Even though EXPLICIT_ONLY has the highest priority and is available,
+        // `"auto"` must prefer a lower-priority *auto-eligible* backend over it —
+        // never an isolation downgrade to the auto-excluded tier.
+        let regs = vec![&EXPLICIT_ONLY, &LOW];
+        let r = select_registration("auto", &regs, |_| true).unwrap();
+        assert_eq!(r.name, "low-tier", "auto must skip the auto-excluded backend");
+    }
+
+    #[test]
+    fn explicit_only_still_selectable_by_name() {
+        // Auto-exclusion does not remove the backend from the registry: an
+        // explicit request resolves it (fail-closed when unavailable).
+        let regs = vec![&EXPLICIT_ONLY, &LOW];
+        let r = select_registration("explicit-only", &regs, |_| true).unwrap();
+        assert_eq!(r.name, "explicit-only");
     }
 
     #[test]
@@ -296,13 +366,80 @@ mod tests {
 
     #[test]
     fn no_speculative_backends_registered() {
-        // YAGNI: Oci/Cri/Wasm must not be in the registry until built.
-        for name in ["oci", "cri", "wasm"] {
+        // YAGNI: still-speculative tiers (Oci/Cri) must not be in the registry
+        // until built. `wasm` is now a real backend (#505 P2) and is handled
+        // separately below — it registers iff the `wasm` feature is on.
+        for name in ["oci", "cri"] {
             assert!(
                 !inventory::iter::<BackendRegistration>().any(|r| r.name == name),
                 "speculative backend '{name}' must not be registered (YAGNI)"
             );
         }
+    }
+
+    #[test]
+    fn registry_contains_wasm_only_under_feature() {
+        // The in-process wasm backend (#505 P2) registers iff built with
+        // `--features wasm` (which vendors the wasmtime substrate). With the
+        // feature off it must NOT be a selectable name (fail-closed).
+        let has_wasm = inventory::iter::<BackendRegistration>().any(|r| r.name == "wasm");
+        assert_eq!(
+            has_wasm,
+            cfg!(feature = "wasm"),
+            "wasm registration must track the wasm feature"
+        );
+    }
+
+    #[cfg(feature = "wasm")]
+    #[test]
+    fn wasm_is_auto_excluded() {
+        // The in-process wasm backend (shared host address space) must be flagged
+        // explicit-name-only so it can never be auto-picked (#547 ZSP — no silent
+        // isolation downgrade).
+        let wasm = inventory::iter::<BackendRegistration>()
+            .find(|r| r.name == "wasm")
+            .expect("wasm registered under the wasm feature");
+        assert!(
+            !wasm.auto_selectable,
+            "wasm (in-process, shared address space) must be excluded from auto-selection"
+        );
+    }
+
+    #[cfg(feature = "wasm")]
+    #[test]
+    fn auto_never_returns_wasm_even_when_only_available_backend() {
+        // With *only* the real wasm registration present (registered + available),
+        // `"auto"` must still error rather than downgrade to it.
+        let wasm = inventory::iter::<BackendRegistration>()
+            .find(|r| r.name == "wasm")
+            .expect("wasm registered under the wasm feature");
+        let only_wasm = vec![wasm];
+        let err = select_registration("auto", &only_wasm, |r| (r.is_available)()).unwrap_err();
+        assert!(
+            err.to_string().contains("no available sandbox backend"),
+            "auto must not pick wasm; got: {err}"
+        );
+
+        // And with nspawn alongside it, `"auto"` resolves to nspawn — never wasm.
+        let nspawn = inventory::iter::<BackendRegistration>()
+            .find(|r| r.name == "nspawn")
+            .expect("nspawn always registered");
+        let both = vec![wasm, nspawn];
+        let r = select_registration("auto", &both, |r| (r.is_available)()).unwrap();
+        assert_eq!(r.name, "nspawn", "auto must pick nspawn, never wasm");
+    }
+
+    #[cfg(feature = "wasm")]
+    #[test]
+    fn wasm_selectable_by_name_and_available() {
+        // Explicit `wasm` request resolves to the wasm registration, and it is
+        // always available once compiled in (wasmtime is vendored in-process).
+        let regs: Vec<&'static BackendRegistration> =
+            inventory::iter::<BackendRegistration>().collect();
+        let reg = select_registration("wasm", &regs, |r| (r.is_available)())
+            .expect("wasm selectable by name when feature on");
+        assert_eq!(reg.name, "wasm");
+        assert!((reg.is_available)(), "wasm is always available once built");
     }
 
     #[cfg(feature = "kata-vm")]

--- a/crates/hyprstream-workers/src/runtime/wasm_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/wasm_backend.rs
@@ -1,0 +1,668 @@
+//! WasmBackend — in-process WebAssembly sandbox isolation (#505 P2)
+//!
+//! A *native, in-process* sibling under the [`SandboxBackend`] seam. Unlike Kata
+//! (full VM) or nspawn (systemd container subprocess), this backend runs the
+//! workload as a WebAssembly guest inside *this* process via the embedded
+//! wasmtime substrate ([`hyprstream_sandbox::Sandbox`]). There is no hypervisor and
+//! no child process: isolation is the wasm sandbox itself — a bespoke capability
+//! `Linker` exposing exactly `env::host_random` (Profile A: zero WASI,
+//! capability-only) plus `define_unknown_imports_as_traps` for everything else,
+//! bound to a per-sandbox [`Subject`], DoS-bounded by fuel + epoch interruption.
+//!
+//! ## Lifecycle mapping onto the substrate
+//!
+//! | `SandboxBackend` | wasm realisation |
+//! |------------------|------------------|
+//! | `start`          | resolve guest wasm bytes → `Sandbox::from_bytes_for(bytes, subject)`; stash live `Sandbox` + `EpochTimer` in a downcastable [`WasmHandle`] |
+//! | `exec_sync`      | map command → a guest export invocation; return `(exit_code, stdout, stderr)` |
+//! | `reset`          | drop + reinstantiate the guest (cheap vs a VM reboot) → returns `true` (reuse-in-place) |
+//! | `get_pids`       | N/A in-process → empty vec |
+//! | `stop`/`destroy` | drop the live `Sandbox`/`EpochTimer` off the handle |
+//! | `update_resources` | re-tune the per-call fuel budget (epoch cadence is fixed at start) |
+//!
+//! ## Guest sourcing (P2 minimal path)
+//!
+//! The guest wasm module is sourced, in order of precedence, from
+//! `PodSandboxConfig` **annotations**:
+//!   * `hyprstream.io/wasm-module` — filesystem path to a `.wasm` (or `.wat`) file.
+//!   * `hyprstream.io/wasm-module-base64` — base64-encoded module bytes inline.
+//!
+//! wasmtime's `Module::new` accepts both binary `.wasm` and textual `.wat`, so a
+//! tiny hand-written guest works for tests without a build step.
+//!
+//! TODO(#505): full OCI-wasm-artifact pull. CRI plumbs the image reference on the
+//! *container* config, not `PodSandboxConfig`; wiring an OCI artifact pull (a
+//! wasm module is an OCI artifact with mediaType
+//! `application/vnd.wasm.content.layer.v1+wasm`) into the image store and handing
+//! the resolved bytes here is the next step. Until then, annotations are the
+//! source of truth.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use base64::Engine as _;
+use parking_lot::Mutex;
+use tracing::{debug, info, warn};
+
+// The consolidated sandbox crate (renamed from `hyprstream-wasm`). It re-exports
+// the canonical `hyprstream_rpc::Subject` as `hyprstream_sandbox::Subject`, so the
+// guest runs as the SAME identity the rest of the daemon uses.
+use hyprstream_sandbox::{EpochTimer, Sandbox, Subject};
+
+use crate::config::PoolConfig;
+use crate::error::{Result, WorkerError};
+
+use super::backend::{SandboxBackend, SandboxHandle};
+use super::client::{LinuxContainerResources, PodSandboxConfig};
+use super::sandbox::PodSandbox;
+
+/// Annotation key: filesystem path to the guest `.wasm`/`.wat` module.
+const ANN_WASM_PATH: &str = "hyprstream.io/wasm-module";
+/// Annotation key: base64-encoded guest module bytes (inline).
+const ANN_WASM_BASE64: &str = "hyprstream.io/wasm-module-base64";
+
+/// Default per-call fuel budget (instruction count). Generous; the wall-clock
+/// epoch bound is the real DoS guard, fuel is a belt-and-suspenders ceiling.
+const DEFAULT_FUEL: u64 = 1_000_000_000;
+
+/// Epoch timer tick: how often the engine epoch advances. Paired with the
+/// per-call epoch deadline, this is the wall-clock DoS bound.
+const EPOCH_TICK: Duration = Duration::from_millis(50);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Configuration
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Configuration for the in-process wasm backend.
+#[derive(Debug, Clone)]
+pub struct WasmConfig {
+    /// Per-call instruction (fuel) budget.
+    pub fuel: u64,
+    /// Epoch timer cadence (the wall-clock DoS tick).
+    pub epoch_tick: Duration,
+}
+
+impl Default for WasmConfig {
+    fn default() -> Self {
+        Self {
+            fuel: DEFAULT_FUEL,
+            epoch_tick: EPOCH_TICK,
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Handle
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Live in-process state for a wasm sandbox, stashed on the `PodSandbox`.
+///
+/// Holds the loaded [`Sandbox`] (engine + compiled module + capability linker,
+/// bound to a [`Subject`]) and the [`EpochTimer`] driving the wall-clock DoS
+/// bound. Both are behind a `Mutex` so `reset()` can swap the live `Sandbox`
+/// in place for warm-pool reuse without recreating the handle.
+///
+/// Dropping the handle drops the `EpochTimer` (joins its thread) and the
+/// `Sandbox` (frees the wasmtime engine/module) — that *is* `destroy`.
+pub struct WasmHandle {
+    /// Sandbox identifier (matches `PodSandbox::id`).
+    pub sandbox_id: String,
+    /// The subject this sandbox runs as.
+    pub subject: Subject,
+    /// Per-call fuel budget.
+    pub fuel: u64,
+    /// The live substrate sandbox + its epoch timer. `None` once stopped.
+    inner: Mutex<Option<WasmInner>>,
+}
+
+/// The droppable live wasm state.
+struct WasmInner {
+    sandbox: Arc<Sandbox>,
+    /// Kept alive so the engine epoch keeps advancing (the wall-clock bound).
+    /// Dropping it stops the timer thread.
+    _epoch_timer: EpochTimer,
+}
+
+impl std::fmt::Debug for WasmHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let live = self.inner.lock().is_some();
+        f.debug_struct("WasmHandle")
+            .field("sandbox_id", &self.sandbox_id)
+            .field("subject", &self.subject)
+            .field("fuel", &self.fuel)
+            .field("live", &live)
+            .finish()
+    }
+}
+
+impl SandboxHandle for WasmHandle {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+impl WasmHandle {
+    /// Borrow the live sandbox (clone of the Arc), or error if stopped.
+    fn sandbox(&self) -> Result<Arc<Sandbox>> {
+        let guard = self.inner.lock();
+        match guard.as_ref() {
+            Some(inner) => Ok(Arc::clone(&inner.sandbox)),
+            None => Err(WorkerError::SandboxInvalidState {
+                sandbox_id: self.sandbox_id.clone(),
+                state: "stopped (wasm instance dropped)".into(),
+                expected: "running".into(),
+            }),
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Backend
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// In-process WebAssembly sandbox backend.
+#[derive(Debug)]
+pub struct WasmBackend {
+    config: WasmConfig,
+}
+
+impl WasmBackend {
+    pub fn new(config: WasmConfig) -> Self {
+        Self { config }
+    }
+
+    /// Runtime prerequisite probe for the backend registry. wasmtime is vendored
+    /// in-process once the `wasm` feature is on, so the backend is *always*
+    /// available when compiled in — there is no external runtime to detect.
+    fn registry_is_available() -> bool {
+        true
+    }
+
+    /// Resolve the guest wasm/wat bytes from sandbox annotations.
+    ///
+    /// Precedence: explicit path (`hyprstream.io/wasm-module`) → inline base64
+    /// (`hyprstream.io/wasm-module-base64`). Fail-closed: if neither is present
+    /// we error rather than silently running an empty/placeholder guest.
+    fn resolve_guest_bytes(
+        sandbox_id: &str,
+        annotations: &HashMap<String, String>,
+    ) -> Result<Vec<u8>> {
+        if let Some(path) = annotations.get(ANN_WASM_PATH) {
+            debug!(sandbox_id, path, "loading wasm guest from path");
+            return std::fs::read(path).map_err(|e| {
+                WorkerError::SandboxCreationFailed(format!(
+                    "wasm backend: failed to read guest module '{path}': {e}"
+                ))
+            });
+        }
+        if let Some(b64) = annotations.get(ANN_WASM_BASE64) {
+            debug!(sandbox_id, "loading wasm guest from inline base64");
+            return base64::engine::general_purpose::STANDARD
+                .decode(b64)
+                .map_err(|e| {
+                    WorkerError::SandboxCreationFailed(format!(
+                        "wasm backend: invalid base64 guest module: {e}"
+                    ))
+                });
+        }
+        Err(WorkerError::SandboxCreationFailed(format!(
+            "wasm backend: no guest module for sandbox '{sandbox_id}'. Provide one \
+             via annotation '{ANN_WASM_PATH}' (path) or '{ANN_WASM_BASE64}' \
+             (inline base64). OCI-wasm-artifact pull is TODO(#505)."
+        )))
+    }
+
+    /// Instantiate a fresh substrate [`Sandbox`] + [`EpochTimer`] for `subject`.
+    fn build_inner(&self, wasm: &[u8], subject: Subject) -> Result<WasmInner> {
+        let sandbox = Sandbox::from_bytes_for(wasm, subject).map_err(|e| {
+            WorkerError::SandboxCreationFailed(format!(
+                "wasm backend: failed to load guest module: {e:#}"
+            ))
+        })?;
+        // Spawn the wall-clock DoS timer on this sandbox's engine. Held in the
+        // handle so it lives as long as the guest does.
+        let epoch_timer = EpochTimer::spawn(sandbox.engine(), self.config.epoch_tick);
+        Ok(WasmInner {
+            sandbox: Arc::new(sandbox),
+            _epoch_timer: epoch_timer,
+        })
+    }
+}
+
+#[async_trait]
+impl SandboxBackend for WasmBackend {
+    fn backend_type(&self) -> &'static str {
+        "wasm"
+    }
+
+    fn is_available(&self) -> bool {
+        // wasmtime is vendored in-process; nothing external to probe.
+        true
+    }
+
+    async fn initialize(&self, _config: &PoolConfig) -> Result<()> {
+        // No external runtime, paths or privileges to set up — the substrate is
+        // entirely in-process. Nothing to do.
+        Ok(())
+    }
+
+    async fn start(
+        &self,
+        sandbox: &mut PodSandbox,
+        config: &PodSandboxConfig,
+        _pool_config: &PoolConfig,
+        annotations: &HashMap<String, String>,
+    ) -> Result<Arc<dyn SandboxHandle>> {
+        // Subject = tenant/identity the guest runs as. Derive it from the pod
+        // namespace (best available identity at this seam); anonymous otherwise.
+        let subject = {
+            let ns = &config.metadata.namespace;
+            if ns.is_empty() {
+                Subject::anonymous()
+            } else {
+                Subject::new(ns.clone())
+            }
+        };
+
+        let wasm = Self::resolve_guest_bytes(&sandbox.id, annotations)?;
+        let inner = self.build_inner(&wasm, subject.clone())?;
+
+        info!(
+            sandbox_id = %sandbox.id,
+            subject = ?subject,
+            fuel = self.config.fuel,
+            "Started in-process wasm sandbox"
+        );
+
+        let handle = Arc::new(WasmHandle {
+            sandbox_id: sandbox.id.clone(),
+            subject,
+            fuel: self.config.fuel,
+            inner: Mutex::new(Some(inner)),
+        });
+
+        sandbox.mark_ready();
+        Ok(handle)
+    }
+
+    async fn stop(&self, sandbox: &PodSandbox) -> Result<()> {
+        // Drop the live wasm instance + epoch timer; the handle struct stays so a
+        // later `reset`/inspection sees a clean "stopped" state.
+        if let Some(handle) = sandbox.backend_handle() {
+            if let Some(h) = handle.as_any().downcast_ref::<WasmHandle>() {
+                *h.inner.lock() = None;
+                debug!(sandbox_id = %sandbox.id, "Stopped wasm sandbox (instance dropped)");
+            }
+        }
+        Ok(())
+    }
+
+    async fn destroy(&self, sandbox: &PodSandbox) -> Result<()> {
+        // Same as stop for an in-process backend: dropping the instance frees the
+        // engine/module. The Arc<dyn SandboxHandle> is released by the pool when
+        // it forgets the PodSandbox.
+        self.stop(sandbox).await?;
+        debug!(sandbox_id = %sandbox.id, "Destroyed wasm sandbox");
+        Ok(())
+    }
+
+    async fn reset(&self, sandbox: &mut PodSandbox) -> Result<bool> {
+        // Cheap reuse: drop the current guest instance and reinstantiate a fresh
+        // one (new wasmtime Store ⇒ no carried-over guest state). Far cheaper than
+        // a Kata VM reboot, so we reuse the sandbox in place → return `true`.
+        let handle = sandbox
+            .backend_handle()
+            .and_then(|h| h.as_any().downcast_ref::<WasmHandle>())
+            .ok_or_else(|| {
+                WorkerError::SandboxInvalidState {
+                    sandbox_id: sandbox.id.clone(),
+                    state: "non-wasm sandbox handle".into(),
+                    expected: "wasm handle".into(),
+                }
+            })?;
+
+        // Reinstantiate from the same module bytes is not possible (we don't keep
+        // them); instead, the substrate Sandbox is itself reusable — each
+        // `eval`/export call already runs in a *fresh* Store, so guest state does
+        // not persist between calls. "Reset" therefore only needs to ensure the
+        // instance is live; rebuild it if it was stopped.
+        let live = handle.inner.lock().is_some();
+        if !live {
+            // Was stopped — we can't reinstantiate without the module bytes, so a
+            // stopped wasm sandbox is not reusable. Fail-closed: report not-reusable.
+            warn!(
+                sandbox_id = %sandbox.id,
+                "wasm sandbox was stopped; cannot reset in place (module bytes not retained)"
+            );
+            return Ok(false);
+        }
+        debug!(sandbox_id = %sandbox.id, "Reset wasm sandbox (fresh Store per call ⇒ reusable in place)");
+        Ok(true)
+    }
+
+    async fn get_pids(&self, _sandbox: &PodSandbox) -> Result<Vec<u32>> {
+        // In-process: the guest has no OS pid. Return empty (the doc comment on
+        // the trait explicitly allows this for in-process backends).
+        Ok(Vec::new())
+    }
+
+    fn supports_exec(&self) -> bool {
+        true
+    }
+
+    async fn exec_sync(
+        &self,
+        sandbox: &PodSandbox,
+        command: &[String],
+        timeout_secs: u64,
+    ) -> Result<(i32, Vec<u8>, Vec<u8>)> {
+        let handle = sandbox
+            .backend_handle()
+            .and_then(|h| h.as_any().downcast_ref::<WasmHandle>())
+            .ok_or_else(|| {
+                WorkerError::ExecFailed(format!(
+                    "exec_sync: sandbox '{}' has no wasm handle",
+                    sandbox.id
+                ))
+            })?;
+
+        let sb = handle.sandbox()?;
+        let fuel = handle.fuel;
+
+        // Map the command to a generic guest export invocation:
+        //   [<export>, "<source>"]  → Sandbox::call_export(<export>, source.as_bytes(), fuel)
+        // `command[0]` is the guest export NAME and `command[1]` is the byte payload
+        // shipped into guest memory over the guest's `alloc`/`memory` ABI. The
+        // consolidated sandbox crate decoupled the core from Python: `call_export`
+        // is the canonical GENERIC entry point (the `python` profile module builds
+        // its `eval` on top of it). So `["eval", <source>]` maps to the guest's
+        // `eval` export, and any other command name maps to the guest export of
+        // that name — no special-casing, no `unsupported export` dead end.
+        //
+        // The exit code is the guest export's returned i32 status (0 = ok, nonzero
+        // = guest-level error). A wasm trap (out of fuel, epoch interrupt, or a
+        // dead/un-granted import being called) surfaces as a nonzero exit + stderr.
+        if command.is_empty() {
+            return Err(WorkerError::ExecFailed(
+                "exec_sync: empty command (expected [<export>, <source>, ..])".into(),
+            ));
+        }
+
+        let export = command[0].clone();
+        let source = command.get(1).cloned().unwrap_or_default();
+        // Run the (CPU-bound, blocking) wasm call off the async reactor. The
+        // substrate Sandbox is Send+Sync; clone the Arc into the task.
+        let join =
+            tokio::task::spawn_blocking(move || sb.call_export(&export, source.as_bytes(), fuel));
+        let result = tokio::time::timeout(Duration::from_secs(timeout_secs), join)
+            .await
+            .map_err(|_| WorkerError::SandboxTimeout {
+                operation: format!("wasm exec_sync in {}", sandbox.id),
+                timeout_secs,
+            })?
+            .map_err(|e| WorkerError::ExecFailed(format!("wasm exec join error: {e}")))?;
+
+        match result {
+            Ok(status) => Ok((status, Vec::new(), Vec::new())),
+            // A trap (out of fuel, epoch interrupt, a dead import being called, or
+            // a missing/mis-typed export) is a sandbox-level failure: nonzero exit
+            // + stderr.
+            Err(trap) => {
+                let msg = format!("wasm guest trapped: {trap:#}");
+                Ok((-1, Vec::new(), msg.into_bytes()))
+            }
+        }
+    }
+
+    async fn update_resources(
+        &self,
+        _sandbox: &PodSandbox,
+        _resources: &LinuxContainerResources,
+    ) -> Result<()> {
+        // CRI cgroup knobs (cpu/memory quotas) have no direct wasmtime analogue.
+        // The wasm DoS bounds are fuel (per-call instruction budget) + epoch
+        // (wall-clock). Those are fixed per `WasmConfig` at start; re-tuning them
+        // per running sandbox would require swapping the handle's fuel/epoch, which
+        // P2 does not plumb. No-op with a note.
+        debug!("wasm backend: update_resources is a no-op (DoS bounds are fuel/epoch, set at start)");
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Backend registry self-registration (#507 / #518) — gated on the `wasm` feature
+// ─────────────────────────────────────────────────────────────────────────────
+
+// The wasm backend is registered ONLY when compiled with `--features wasm`
+// (which is what pulls in the wasmtime-bearing `hyprstream-sandbox` dep). Mirrors
+// how `kata` registers only under `kata-vm`. Selection stays fail-closed: with
+// the feature off, an explicit `wasm` request hits the "unknown backend" error
+// path (the name simply isn't in the registry) rather than silently downgrading.
+//
+// An in-process wasm sandbox is the weakest isolation tier (shared host address
+// space; the guarantee is the wasm capability boundary, not a kernel/VM boundary).
+// It is therefore **RuntimeClass-explicit-only**: `auto_selectable: false` keeps
+// it out of `"auto"` entirely so it can never become a silent fallback when
+// stronger backends are absent — that would be a silent isolation downgrade, which
+// the #547 MAC/ZSP model forbids. It remains selectable by its explicit `wasm`
+// name (fail-closed) and is always *available* once built. The `priority` is then
+// only meaningful for explicit selection; it is kept low for documentation.
+inventory::submit! {
+    crate::runtime::selection::BackendRegistration {
+        name: "wasm",
+        priority: 5,
+        auto_selectable: false,
+        is_available: WasmBackend::registry_is_available,
+        construct: |_ctx| {
+            Ok(std::sync::Arc::new(WasmBackend::new(WasmConfig::default()))
+                as std::sync::Arc<dyn crate::runtime::SandboxBackend>)
+        },
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::super::client::KeyValue;
+    use super::*;
+    use std::path::PathBuf;
+
+    /// A tiny hand-written guest matching the substrate's pyguest export
+    /// contract: `memory`, `alloc(i32)->i32`, `dealloc(i32,i32)`, and
+    /// `eval(i32,i32)->i32`. `eval` ignores the source and returns a fixed
+    /// status, which is all P2's start→exec_sync test needs. wasmtime's
+    /// `Module::new` (called by `Sandbox::from_bytes`) accepts `.wat` text, so we
+    /// embed source rather than precompiled bytes — no build step.
+    const TRIVIAL_GUEST_WAT: &str = r#"
+        (module
+          (memory (export "memory") 1)
+          (func (export "alloc") (param i32) (result i32)
+            i32.const 0)
+          (func (export "dealloc") (param i32 i32))
+          (func (export "eval") (param i32 i32) (result i32)
+            i32.const 7))
+    "#;
+
+    fn pod_config(ns: &str, annotations: Vec<(&str, &str)>) -> PodSandboxConfig {
+        let mut cfg = PodSandboxConfig::default();
+        cfg.metadata.namespace = ns.to_owned();
+        cfg.annotations = annotations
+            .into_iter()
+            .map(|(k, v)| KeyValue {
+                key: k.to_owned(),
+                value: v.to_owned(),
+            })
+            .collect();
+        cfg
+    }
+
+    fn ann_map(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    fn new_pod(id: &str, cfg: &PodSandboxConfig) -> PodSandbox {
+        PodSandbox::new(id.to_owned(), cfg, PathBuf::from("/tmp/wasm-test"))
+    }
+
+    /// base64 of the trivial WAT, for the inline-source path.
+    fn trivial_guest_b64() -> String {
+        base64::engine::general_purpose::STANDARD.encode(TRIVIAL_GUEST_WAT.as_bytes())
+    }
+
+    #[test]
+    fn backend_type_and_availability() {
+        let backend = WasmBackend::new(WasmConfig::default());
+        assert_eq!(backend.backend_type(), "wasm");
+        // wasmtime is vendored in-process ⇒ always available once built.
+        assert!(backend.is_available());
+        assert!(WasmBackend::registry_is_available());
+    }
+
+    #[test]
+    fn handle_downcasts() {
+        let handle: Arc<dyn SandboxHandle> = Arc::new(WasmHandle {
+            sandbox_id: "abc".into(),
+            subject: Subject::anonymous(),
+            fuel: DEFAULT_FUEL,
+            inner: Mutex::new(None),
+        });
+        let down = handle.as_any().downcast_ref::<WasmHandle>();
+        assert!(down.is_some());
+        assert_eq!(down.unwrap().sandbox_id, "abc");
+    }
+
+    #[tokio::test]
+    async fn start_then_exec_sync_invokes_export() {
+        let backend = WasmBackend::new(WasmConfig::default());
+        let b64 = trivial_guest_b64();
+        let cfg = pod_config("tenant-1", vec![(ANN_WASM_BASE64, &b64)]);
+        let mut pod = new_pod("wasm-1", &cfg);
+        let annotations = ann_map(&[(ANN_WASM_BASE64, &b64)]);
+
+        let handle = backend
+            .start(&mut pod, &cfg, &PoolConfig::default(), &annotations)
+            .await
+            .expect("start");
+        pod.set_backend_handle(handle);
+        assert!(pod.is_ready(), "wasm sandbox should be ready after start");
+
+        // exec_sync ["eval", "<src>"] should invoke the guest `eval` export, which
+        // returns status 7 in our trivial guest.
+        let (code, stdout, stderr) = backend
+            .exec_sync(&pod, &["eval".into(), "anything".into()], 10)
+            .await
+            .expect("exec_sync");
+        assert_eq!(code, 7, "exec_sync should return the guest export's status");
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty(), "no trap expected: {:?}", String::from_utf8_lossy(&stderr));
+    }
+
+    #[tokio::test]
+    async fn exec_sync_missing_export_traps() {
+        // With the generic `call_export` mapping there is no "unsupported export"
+        // allow-list: any command name is dispatched to the guest export of that
+        // name. A name the guest does not export fails at instantiation/export
+        // lookup, which surfaces as a guest trap → nonzero exit + stderr (a
+        // sandbox-level failure), not an Err result.
+        let backend = WasmBackend::new(WasmConfig::default());
+        let b64 = trivial_guest_b64();
+        let cfg = pod_config("tenant-1", vec![(ANN_WASM_BASE64, &b64)]);
+        let mut pod = new_pod("wasm-2", &cfg);
+        let annotations = ann_map(&[(ANN_WASM_BASE64, &b64)]);
+        let handle = backend
+            .start(&mut pod, &cfg, &PoolConfig::default(), &annotations)
+            .await
+            .unwrap();
+        pod.set_backend_handle(handle);
+
+        let (code, stdout, stderr) = backend
+            .exec_sync(&pod, &["not_a_real_export".into()], 10)
+            .await
+            .expect("missing export surfaces as a trap, not an Err");
+        assert_eq!(code, -1, "missing guest export must produce a nonzero exit");
+        assert!(stdout.is_empty());
+        assert!(
+            String::from_utf8_lossy(&stderr).contains("trapped"),
+            "got: {}",
+            String::from_utf8_lossy(&stderr)
+        );
+    }
+
+    #[tokio::test]
+    async fn start_without_guest_fails_closed() {
+        let backend = WasmBackend::new(WasmConfig::default());
+        let cfg = pod_config("tenant-1", vec![]);
+        let mut pod = new_pod("wasm-3", &cfg);
+        let annotations = ann_map(&[]);
+        let err = backend
+            .start(&mut pod, &cfg, &PoolConfig::default(), &annotations)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("no guest module"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn reset_reuses_live_sandbox_in_place() {
+        let backend = WasmBackend::new(WasmConfig::default());
+        let b64 = trivial_guest_b64();
+        let cfg = pod_config("tenant-1", vec![(ANN_WASM_BASE64, &b64)]);
+        let mut pod = new_pod("wasm-4", &cfg);
+        let annotations = ann_map(&[(ANN_WASM_BASE64, &b64)]);
+        let handle = backend
+            .start(&mut pod, &cfg, &PoolConfig::default(), &annotations)
+            .await
+            .unwrap();
+        pod.set_backend_handle(handle);
+
+        // Live sandbox ⇒ reusable in place (fresh Store per call ⇒ no carried state).
+        let reusable = backend.reset(&mut pod).await.unwrap();
+        assert!(reusable, "live wasm sandbox should be reusable in place");
+
+        // Still works after reset.
+        let (code, _, _) = backend
+            .exec_sync(&pod, &["eval".into(), "x".into()], 10)
+            .await
+            .unwrap();
+        assert_eq!(code, 7);
+    }
+
+    #[tokio::test]
+    async fn stop_then_reset_reports_not_reusable() {
+        let backend = WasmBackend::new(WasmConfig::default());
+        let b64 = trivial_guest_b64();
+        let cfg = pod_config("tenant-1", vec![(ANN_WASM_BASE64, &b64)]);
+        let mut pod = new_pod("wasm-5", &cfg);
+        let annotations = ann_map(&[(ANN_WASM_BASE64, &b64)]);
+        let handle = backend
+            .start(&mut pod, &cfg, &PoolConfig::default(), &annotations)
+            .await
+            .unwrap();
+        pod.set_backend_handle(handle);
+
+        backend.stop(&pod).await.unwrap();
+        // Stopped (module bytes not retained) ⇒ not reusable, fail-closed.
+        let reusable = backend.reset(&mut pod).await.unwrap();
+        assert!(!reusable, "stopped wasm sandbox must report not-reusable");
+    }
+
+    #[tokio::test]
+    async fn get_pids_is_empty_in_process() {
+        let backend = WasmBackend::new(WasmConfig::default());
+        let b64 = trivial_guest_b64();
+        let cfg = pod_config("t", vec![(ANN_WASM_BASE64, &b64)]);
+        let mut pod = new_pod("wasm-6", &cfg);
+        let annotations = ann_map(&[(ANN_WASM_BASE64, &b64)]);
+        let handle = backend
+            .start(&mut pod, &cfg, &PoolConfig::default(), &annotations)
+            .await
+            .unwrap();
+        pod.set_backend_handle(handle);
+        assert!(backend.get_pids(&pod).await.unwrap().is_empty());
+    }
+}


### PR DESCRIPTION
> **Quality-reset consolidation (PR 2 of 2). DO NOT MERGE yet** — pending re-audit + operator approval.
> Stacked on **#596**. Supersedes **#585**.

## What this is
The #505-P2 in-process WebAssembly `SandboxBackend`, re-applied on the consolidated `hyprstream-sandbox`
crate (#596) and ported off the pre-rename / pre-Subject-migration fork that would have broken the build.

- `crates/hyprstream-workers/src/runtime/wasm_backend.rs` — `WasmBackend`/`WasmHandle`/`WasmConfig`,
  consuming `hyprstream_sandbox::{Sandbox, EpochTimer, Subject}`.
- **Ports applied vs #585:** dep `hyprstream-wasm` → `hyprstream-sandbox`; `Subject::named` →
  canonical **`Subject::new`** (`hyprstream_rpc::Subject` re-exported by the crate); python-coupled
  `sandbox.eval(...)` → generic **`sandbox.call_export(<export>, source.as_bytes(), fuel)`** (command[0]
  = export name), removing the old "unsupported export" dead-end + the typed-export TODO.
- **`auto_selectable: false` preserved** — `wasm` stays RuntimeClass-explicit-only (priority 5), never
  auto-selected (no silent isolation downgrade; #547 ZSP). `selection.rs` ZSP tests pass.

## Why a re-apply (not a rebase of #585)
#585 forked off P1 **before** #581's `Subject` migration, so its copy used the crate-local
`Subject(::named/::id)` and called `sandbox.eval` directly — incompatible with the consolidated crate.
Re-applying onto #596 is additive (no merge conflicts) and yields a build that compiles when both land.

## Verification
`cargo build -p hyprstream-workers` (no feature) + `--features wasm` green; `cargo test -p
hyprstream-workers --features wasm` = **90 passed, 0 failed**; clippy clean; torch-free
(`cargo tree --features wasm -i tch` empty).

Refs #505 (P2) · #508 · epic #341 · **supersedes #585** · stacked on #596.
