### PR TITLE
refactor(security) S1: rename SecurityLabel::dominates → can_access (Bell–LaPadula) (#567)

### DIFF
--- a/crates/hyprstream-rpc/src/auth/atproto_perimeter.rs
+++ b/crates/hyprstream-rpc/src/auth/atproto_perimeter.rs
@@ -392,7 +392,7 @@ mod tests {
 
         let pq_object =
             SecurityLabel::new(Level::Public, Assurance::PqHybrid, CompartmentSet::EMPTY);
-        assert!(!peer.context.dominates(&pq_object));
+        assert!(!peer.context.can_access(&pq_object));
         assert_eq!(peer.context.assurance(), Assurance::Classical);
     }
 

--- a/crates/hyprstream-rpc/src/auth/mac/context.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/context.rs
@@ -119,7 +119,7 @@ impl SecurityContext {
     }
 
     /// The clearance label. This is the `subject.ctx` the monitor feeds into
-    /// `dominates(object_label)`.
+    /// `can_access(object_label)`.
     pub fn clearance(&self) -> &SecurityLabel {
         &self.clearance
     }
@@ -128,8 +128,8 @@ impl SecurityContext {
     /// content-bound label? The per-op MAC floor (design §10). Pure forward to
     /// the intrinsic lattice order.
     #[must_use]
-    pub fn dominates(&self, object_label: &SecurityLabel) -> bool {
-        self.clearance.dominates(object_label)
+    pub fn can_access(&self, object_label: &SecurityLabel) -> bool {
+        self.clearance.can_access(object_label)
     }
 
     pub fn level(&self) -> Level {
@@ -228,7 +228,7 @@ mod tests {
     fn classical_context_cannot_dominate_pqc_object() {
         let ctx = SecurityContext::new(Level::Secret, comps(&[0]), VerifiedKeyMaterial::Classical);
         let pqc_object = SecurityLabel::new(Level::Public, Assurance::PqHybrid, CompartmentSet::EMPTY);
-        assert!(!ctx.dominates(&pqc_object));
+        assert!(!ctx.can_access(&pqc_object));
     }
 
     struct FakeClaims(Option<SecurityLabel>);

--- a/crates/hyprstream-rpc/src/auth/mac/label.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/label.rs
@@ -257,7 +257,7 @@ impl fmt::Debug for CompartmentSet {
 /// The same type is used for an **object's** classification and a **subject's**
 /// clearance (a clearance is just a label the subject is allowed to read up
 /// to). Dominance and join are defined on the inherent
-/// [`SecurityLabel::dominates`] / [`SecurityLabel::join`] helpers below — note
+/// [`SecurityLabel::can_access`] / [`SecurityLabel::join`] helpers below — note
 /// those helpers encode the *fixed* product-lattice algebra and are independent
 /// of any site policy (the policy in [`super::lattice::Lattice`] only constrains
 /// which labels are *well-formed/known*, never how they compare).
@@ -349,19 +349,20 @@ impl SecurityLabel {
             && self.compartments.is_empty()
     }
 
-    /// **Dominance**: does `self` (as a subject clearance) dominate `object`?
+    /// May a subject with this clearance access an object labelled `object`?
     ///
-    /// `self ⊒ object` ⟺ on *every* axis self is ≥ object:
-    /// - `self.level   >= object.level`            (read-down)
-    /// - `self.assurance >= object.assurance`      (#548)
-    /// - `object.compartments ⊆ self.compartments` (cleared into all required)
+    /// This is the **Bell–LaPadula dominance** relation — clearance `self`
+    /// *dominates* the object label (`self ⊒ object`) iff, on *every* axis, the
+    /// subject is at least the object:
+    /// - `self.level     >= object.level`            (no read-up)
+    /// - `self.assurance >= object.assurance`        (#548 crypto-assurance axis)
+    /// - `object.compartments ⊆ self.compartments`   (cleared into all categories)
     ///
-    /// This is the per-op MAC floor (design §3, §10). It is the *fixed*
-    /// product-lattice order and takes no policy argument: dominance is content
-    /// truth, never overridable by a token/UCAN/grant.
+    /// The per-op MAC floor (design §3, §10): the *fixed* product-lattice order,
+    /// content truth, never overridable by a token/UCAN/grant.
     #[inline]
     #[must_use]
-    pub fn dominates(&self, object: &SecurityLabel) -> bool {
+    pub fn can_access(&self, object: &SecurityLabel) -> bool {
         self.level >= object.level
             && self.assurance >= object.assurance
             && object.compartments.is_subset(self.compartments)
@@ -458,15 +459,15 @@ mod tests {
     #[test]
     fn dominance_reflexive() {
         let x = label(Level::Confidential, Assurance::Classical, &[0, 1]);
-        assert!(x.dominates(&x));
+        assert!(x.can_access(&x));
     }
 
     #[test]
     fn dominance_level_read_down() {
         let secret = label(Level::Secret, Assurance::PqHybrid, &[]);
         let public = label(Level::Public, Assurance::PqHybrid, &[]);
-        assert!(secret.dominates(&public));
-        assert!(!public.dominates(&secret));
+        assert!(secret.can_access(&public));
+        assert!(!public.can_access(&secret));
     }
 
     #[test]
@@ -474,8 +475,8 @@ mod tests {
         let cleared = label(Level::Secret, Assurance::PqHybrid, &[0, 1]); // pii, tenant:acme
         let needs_pii = label(Level::Public, Assurance::Unverified, &[0]);
         let needs_other = label(Level::Public, Assurance::Unverified, &[5]); // finance
-        assert!(cleared.dominates(&needs_pii));
-        assert!(!cleared.dominates(&needs_other)); // not cleared into "finance"
+        assert!(cleared.can_access(&needs_pii));
+        assert!(!cleared.can_access(&needs_other)); // not cleared into "finance"
     }
 
     #[test]
@@ -483,18 +484,18 @@ mod tests {
         // #548 acceptance: a classical-DID peer cannot dominate a PQC-required label.
         let classical_subject = label(Level::Secret, Assurance::Classical, &[0]);
         let pqc_object = label(Level::Public, Assurance::PqHybrid, &[]);
-        assert!(!classical_subject.dominates(&pqc_object));
+        assert!(!classical_subject.can_access(&pqc_object));
 
         // a PQC-bound peer can (level/compartments permitting).
         let pqc_subject = label(Level::Secret, Assurance::PqHybrid, &[0]);
-        assert!(pqc_subject.dominates(&pqc_object));
+        assert!(pqc_subject.can_access(&pqc_object));
     }
 
     #[test]
     fn unverified_subject_dominates_nothing_above_floor() {
         let unverified = label(Level::Secret, Assurance::Unverified, &[0]);
         let needs_classical = label(Level::Public, Assurance::Classical, &[]);
-        assert!(!unverified.dominates(&needs_classical));
+        assert!(!unverified.can_access(&needs_classical));
     }
 
     #[test]
@@ -513,8 +514,8 @@ mod tests {
         let a = label(Level::Internal, Assurance::Classical, &[0]);
         let b = label(Level::Confidential, Assurance::Unverified, &[5]);
         let j = a.join(&b);
-        assert!(j.dominates(&a));
-        assert!(j.dominates(&b));
+        assert!(j.can_access(&a));
+        assert!(j.can_access(&b));
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/auth/mac/lattice.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/lattice.rs
@@ -373,15 +373,15 @@ impl Lattice {
     }
 
     /// Dominance, re-exposed at the policy object for callers that hold a
-    /// `Lattice`. Identical to [`SecurityLabel::dominates`] — the policy does
+    /// `Lattice`. Identical to [`SecurityLabel::can_access`] — the policy does
     /// NOT change the order; this is purely an ergonomic forwarder. Debug
     /// builds assert both labels are well-formed (a mis-labeled object reaching
     /// the monitor is a genesis bug).
     #[must_use]
-    pub fn dominates(&self, subject: &SecurityLabel, object: &SecurityLabel) -> bool {
+    pub fn can_access(&self, subject: &SecurityLabel, object: &SecurityLabel) -> bool {
         debug_assert!(self.validate(subject).is_ok(), "subject label ill-formed");
         debug_assert!(self.validate(object).is_ok(), "object label ill-formed");
-        subject.dominates(object)
+        subject.can_access(object)
     }
 
     /// IFC join, re-exposed at the policy object. Identical algebra to
@@ -467,7 +467,7 @@ mod tests {
                 [comp("pii"), comp("finance"), comp("tenant:acme")],
             )
             .unwrap();
-        assert!(p.dominates(&top, &arbitrary));
+        assert!(p.can_access(&top, &arbitrary));
     }
 
     #[test]
@@ -477,10 +477,10 @@ mod tests {
         let any = p
             .label(Level::Internal, Assurance::Classical, [comp("pii")])
             .unwrap();
-        assert!(any.dominates(&bottom));
+        assert!(any.can_access(&bottom));
         // bottom only dominates bottom.
-        assert!(!bottom.dominates(&any));
-        assert!(bottom.dominates(&bottom));
+        assert!(!bottom.can_access(&any));
+        assert!(bottom.can_access(&bottom));
     }
 
     #[test]
@@ -492,7 +492,7 @@ mod tests {
         let b = p
             .label(Level::Secret, Assurance::PqHybrid, [comp("finance")])
             .unwrap();
-        assert_eq!(p.dominates(&a, &b), a.dominates(&b));
+        assert_eq!(p.can_access(&a, &b), a.can_access(&b));
         assert_eq!(p.join(&a, &b), a.join(&b));
     }
 

--- a/crates/hyprstream-rpc/src/auth/mac/mod.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/mod.rs
@@ -35,8 +35,8 @@
 //!      [`context::SubjectContextClaims::security_context`] (clearance from
 //!      verified claims, assurance derived from verified key material) — `None`
 //!      ⇒ DENY (unlabeled subject);
-//!   3. evaluates the MAC floor [`context::SecurityContext::dominates`]
-//!      (≡ [`SecurityLabel::dominates`]) — `false` ⇒ DENY.
+//!   3. evaluates the MAC floor [`context::SecurityContext::can_access`]
+//!      (≡ [`SecurityLabel::can_access`]) — `false` ⇒ DENY.
 //!   The monitor takes object labels ONLY from `LabeledObject`, never from a
 //!   token/UCAN/caveat (design §3, §14). It needs no `Lattice` on the hot path:
 //!   dominance is intrinsic.
@@ -121,7 +121,7 @@ pub use manifest::{ContentBoundLabel, LabeledObject, StaticNodeLabel};
 mod integration_tests {
     //! End-to-end shape of the per-op check S2 will perform, exercised against
     //! the S1 seams only (object via `LabeledObject`, subject via
-    //! `SubjectContextClaims`, floor via `dominates`).
+    //! `SubjectContextClaims`, floor via `can_access`).
     use super::*;
 
     struct StubClaims(Option<SecurityLabel>);
@@ -145,7 +145,7 @@ mod integration_tests {
         let Some(ctx) = claims.security_context(key_material) else {
             return false; // unlabeled subject → deny
         };
-        ctx.dominates(&object_label)
+        ctx.can_access(&object_label)
     }
 
     /// A compartment bitset from bit indices (bit 0 = "pii", 1 = "finance", … in

--- a/crates/hyprstream/src/mac/lattice.rs
+++ b/crates/hyprstream/src/mac/lattice.rs
@@ -18,11 +18,11 @@
 //!   unlabeled subject/object is `Option::None` ⇒ deny, never a permissive
 //!   default.
 //! - Dominance (`⊒`) and join (`⊔`) are **intrinsic** to the value
-//!   ([`SecurityLabel::dominates`], [`SecurityLabel::join`] /
+//!   ([`SecurityLabel::can_access`], [`SecurityLabel::join`] /
 //!   [`SecurityLabel::join_all`]), and re-exposed on
-//!   [`SecurityContext::dominates`] for a verified subject. They are NOT methods
+//!   [`SecurityContext::can_access`] for a verified subject. They are NOT methods
 //!   on a `Lattice` trait — content truth, no policy argument. The old
-//!   `Lattice::dominates`/`join` trait is gone; the PDP floor now calls the
+//!   `Lattice::can_access`/`join` trait is gone; the PDP floor now calls the
 //!   intrinsic order (see `te.rs`).
 //! - [`Lattice`] is now S1's **policy object** (the closed, versioned compartment
 //!   name↔bit vocabulary). The PDP holds it to (a) align its TE matrix columns to
@@ -86,8 +86,8 @@ mod tests {
             .label(Level::Confidential, Assurance::Classical, [Compartment::new("pii")])
             .unwrap();
         // dominates on every axis (level ≥, assurance ≥, compartments ⊇).
-        assert!(cleared.dominates(&needs_pii));
-        assert!(!needs_pii.dominates(&cleared));
+        assert!(cleared.can_access(&needs_pii));
+        assert!(!needs_pii.can_access(&cleared));
     }
 
     #[test]
@@ -102,8 +102,8 @@ mod tests {
         let derived = ifc_join(&[secret, public]);
         assert_eq!(derived.level, Level::Secret);
         assert_eq!(derived.assurance, Assurance::PqHybrid);
-        assert!(derived.dominates(&secret));
-        assert!(derived.dominates(&public));
+        assert!(derived.can_access(&secret));
+        assert!(derived.can_access(&public));
         // empty input folds to the join identity ⊥.
         assert!(ifc_join(&[]).is_bottom());
     }

--- a/crates/hyprstream/src/mac/mod.rs
+++ b/crates/hyprstream/src/mac/mod.rs
@@ -49,7 +49,7 @@
 //! ## TCB note
 //!
 //! The per-op TCB is intentionally tiny: a hash lookup ([`avc`]), and on a miss a set lookup
-//! plus one intrinsic `SecurityLabel::dominates` call ([`te`]). All heavy/bug-prone logic
+//! plus one intrinsic `SecurityLabel::can_access` call ([`te`]). All heavy/bug-prone logic
 //! (Casbin matching,
 //! UCAN chain validation, compilation, signature verification) is concentrated off the hot
 //! path — in PolicyService and the [`compiled`] loader, the one audited place (design §2).

--- a/crates/hyprstream/src/mac/te.rs
+++ b/crates/hyprstream/src/mac/te.rs
@@ -14,14 +14,14 @@
 //! ```
 //!
 //! The lattice floor is the **intrinsic** dominance on S1's [`SecurityLabel`]
-//! ([`SecurityLabel::dominates`]) — it takes no policy argument and no `Lattice` lookup, so it
+//! ([`SecurityLabel::can_access`]) — it takes no policy argument and no `Lattice` lookup, so it
 //! is uncircumventable: no TE entry, grant, or token can relax it (design §1 invariant 3).
 //! Default is DENY: an unknown subject type, object type, action, or a non-dominating /
 //! unlabeled clearance → DENY. There is no permissive mode.
 //!
 //! ## S1 reconciliation (#567 landed)
 //!
-//! - The floor is S1's intrinsic [`SecurityLabel::dominates`], not a `Lattice::dominates`
+//! - The floor is S1's intrinsic [`SecurityLabel::can_access`], not a `Lattice::can_access`
 //!   trait method. The evaluator still holds the S1 [`Lattice`] policy object, but only for
 //!   *well-formedness* concerns (column alignment / validation / version binding), never for
 //!   the per-op order.
@@ -248,7 +248,7 @@ pub trait TeEvaluator: Send + Sync {
 /// allocation-free on the hot path. This is the verifiable TCB core.
 ///
 /// The [`Lattice`] is held for *well-formedness* and *column alignment*, NOT for the per-op
-/// order: the floor uses S1's intrinsic [`SecurityLabel::dominates`]. The PDP's `generation`
+/// order: the floor uses S1's intrinsic [`SecurityLabel::can_access`]. The PDP's `generation`
 /// is bound to `lattice.version().generation()` at construction — the desync-proof binding
 /// (#570): the same lattice bytes that minted a label's compartment bits also tag the
 /// compiled policy that evaluates it.
@@ -300,7 +300,7 @@ impl TeEvaluator for LatticeTeEvaluator {
         //    uncircumventable. Fail-closed: a non-dominating clearance → DENY, regardless of
         //    what the TE matrix says (design §1 inv.3, §10). Unlabeled subject/object never
         //    reach here (the PEP denies on `None` before constructing the contexts).
-        if !subject.clearance.dominates(&object.label) {
+        if !subject.clearance.can_access(&object.label) {
             return Decision::Deny;
         }
         // 2. Compiled TE decision (the authority gate). Default-deny by construction.


### PR DESCRIPTION
S1 / #567. **Behavior-preserving rename** of the MAC access relation `dominates` → `can_access`, to plainer access-control vocabulary. No logic change.

## Why
`dominates` is the Bell–LaPadula lattice-dominance term — precise, but reads academic. `can_access` states what the relation decides. The **Bell–LaPadula framing is preserved in the rustdoc** (the `can_access` doc names the dominance relation explicitly: `self ⊒ object`, no-read-up on level, assurance, compartment-superset), so the theory isn't lost — just out of the identifier.

## What changed (all three definitions + callers)
- `SecurityLabel::dominates` → `can_access` (`mac/label.rs`) — the core relation; rustdoc updated with the BLP framing.
- `SecurityContext::dominates` → `can_access` (`mac/context.rs`) — verified-subject forwarder.
- `Lattice::dominates` → `can_access` (`mac/lattice.rs`) — lattice forwarder.
- **Runtime call-site:** `hyprstream/src/mac/te.rs` — the TE evaluator's mandatory floor (`subject.clearance.can_access(&object.label)`), the one PEP decision.
- Tests (`label`/`context`/`lattice`, `atproto_perimeter`) and all intra-doc links updated.
- **Unchanged:** `join` (the least-upper-bound / IFC combinator) and conceptual "dominance" prose that explains the BLP model.

## Verification
- `hyprstream-rpc` `auth::mac`: **53 tests pass**; `hyprstream` `mac::`: **48 tests pass**.
- `cargo clippy -p hyprstream -p hyprstream-rpc --all-targets -- -D warnings`: clean.
- Full-workspace release-clippy pre-commit hook passed (no `--no-verify`).
- No method-form `dominates` remains (`fn`/`.call(`/`::path` all renamed); only the intentional BLP prose stays.

Touches merged S1 (#567) + S4 (#570) + #549 code across `hyprstream-rpc` and `hyprstream` — security-TCB (the reference-monitor decision), so it merges on operator review.
