### PR TITLE
feat(#608 P3): TUI — replace poll_local spin loop with dedicated-thread async drivers

### DIFF
--- a/crates/hyprstream-tui/Cargo.toml
+++ b/crates/hyprstream-tui/Cargo.toml
@@ -30,7 +30,7 @@ parking_lot = "0.12"
 rand = "0.8"
 uuid = { version = "1.0", features = ["v4", "v5", "serde"] }
 zeroize = { version = "1", features = ["derive"] }
-tokio = { version = "1", features = ["sync"] }
+tokio = { version = "1", features = ["sync", "rt", "macros"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 landlock = "0.4"

--- a/crates/hyprstream-tui/src/chat_app.rs
+++ b/crates/hyprstream-tui/src/chat_app.rs
@@ -225,47 +225,6 @@ pub enum ChatMode {
 // ChatApp
 // ============================================================================
 
-/// Create a no-op waker for polling futures that don't need wake notifications.
-///
-/// Safe for TclShell/VFS futures which are purely computational (no IO reactor,
-/// no timers) — they always make progress on each poll without needing external
-/// wake-ups.
-fn noop_waker() -> std::task::Waker {
-    fn noop(_: *const ()) {}
-    fn clone(p: *const ()) -> std::task::RawWaker {
-        std::task::RawWaker::new(p, &VTABLE)
-    }
-    static VTABLE: std::task::RawWakerVTable =
-        std::task::RawWakerVTable::new(clone, noop, noop, noop);
-    // SAFETY: The vtable functions are valid no-ops. The data pointer is never dereferenced.
-    unsafe { std::task::Waker::from_raw(std::task::RawWaker::new(std::ptr::null(), &VTABLE)) }
-}
-
-/// Wrapper that asserts `Send` for a `!Send` value.
-///
-/// **Not thread-local storage** — this is a Send bypass for values that are
-/// constructed and accessed on a single thread but must transit a thread boundary
-/// wrapped in `Option<AssertSend<T>>` where the Option is `None` during the move.
-///
-/// SAFETY: This is used exclusively for `TclShell` which uses `Rc` internally
-/// (making it `!Send`). The wrapper is safe because:
-/// - The value is always wrapped in `Option` that is `None` during cross-thread moves
-/// - It is only populated via `ensure_tcl_shell()` on the app thread
-/// - It is only accessed from that same thread thereafter
-/// - `UnsafeCell` ensures `AssertSend<T>` is `!Sync` (cannot be shared across threads)
-struct AssertSend<T>(std::cell::UnsafeCell<T>);
-
-// SAFETY: See struct-level documentation.
-unsafe impl<T> Send for AssertSend<T> {}
-
-impl<T> std::ops::Deref for AssertSend<T> {
-    type Target = T;
-    fn deref(&self) -> &T { unsafe { &*self.0.get() } }
-}
-impl<T> std::ops::DerefMut for AssertSend<T> {
-    fn deref_mut(&mut self) -> &mut T { unsafe { &mut *self.0.get() } }
-}
-
 /// Double-Esc close window: two Esc presses within this interval close the app.
 #[cfg(not(target_os = "wasi"))]
 const DOUBLE_ESC_MS: u128 = 1500;
@@ -357,17 +316,106 @@ pub struct ChatApp {
     vfs: Option<std::sync::Arc<hyprstream_vfs::Namespace>>,
     /// Caller identity for VFS operations.
     vfs_subject: hyprstream_vfs::Subject,
-    /// Tcl shell for / command evaluation. Created lazily on first use because
-    /// TclShell is !Send (molt Value uses Rc) and ChatApp is moved across threads
-    /// in spawn_app_process. The init data (vfs_tx + subject) IS Send.
+    /// Tcl shell owner for `/` command evaluation. Created lazily on first use
+    /// (see [`ensure_tcl_shell`](Self::ensure_tcl_shell)) because `TclShell` is
+    /// `!Send` (molt `Value` uses `Rc`) and ChatApp is moved across threads in
+    /// `spawn_app_process` — so the shell cannot be constructed until ChatApp has
+    /// settled on its final thread. The init data (subject + namespace) IS Send
+    /// and crosses the thread boundary fine; only the live shell cannot.
     ///
-    /// SAFETY: TclShell is wrapped in `AssertSend` (unsafe Send impl) because:
-    /// 1. It is always `None` when ChatApp crosses a thread boundary
-    /// 2. It is only constructed inside `ensure_tcl_shell()` on the app thread
-    /// 3. It is only accessed from that same thread thereafter
-    tcl_shell: Option<AssertSend<hyprstream_workers_tcl::TclShell>>,
-    /// Deferred init data for tcl_shell (Send-safe). Consumed on first access.
+    /// The `TclShell` is never touched outside the dedicated owner thread that
+    /// [`shell_driver::ShellOwner`] spawns for it — there is no unsafe Send bypass
+    /// because the shell never crosses a thread boundary at all.
+    #[cfg(not(target_os = "wasi"))]
+    tcl_owner: Option<crate::shell_driver::ShellOwner>,
+    /// Deferred init data for the Tcl shell owner (Send-safe). Consumed on first
+    /// access by [`ensure_tcl_shell`](Self::ensure_tcl_shell).
     tcl_shell_init: Option<(hyprstream_vfs::Subject, std::sync::Arc<hyprstream_vfs::Namespace>)>,
+    /// Dedicated-thread driver for direct `Namespace` access (`cat`/`ls`), used
+    /// by bare-path slash commands that don't need a Tcl interpreter at all. See
+    /// [`ensure_ns_driver`](Self::ensure_ns_driver) and the routing split in
+    /// [`handle_vfs_command`](Self::handle_vfs_command).
+    #[cfg(not(target_os = "wasi"))]
+    ns_driver: Option<crate::shell_driver::NamespaceDriver>,
+}
+
+// ============================================================================
+// Slash-command routing: decouple simple VFS access from Tcl
+// ============================================================================
+
+/// Classification of a `/`-prefixed command, used to decide whether it can be
+/// served directly from the `Namespace` (no Tcl interpreter involved) or needs
+/// genuine Tcl script evaluation.
+///
+/// This is the decoupling #611 asks for: slash-command routing no longer
+/// assumes Tcl is the only way to reach the VFS. Only commands that are
+/// literally "read a file" or "list a directory" — the two cases the old
+/// bare-path heuristic already special-cased — bypass Tcl; anything with
+/// Tcl-shaped syntax (multiple words, braces, `$vars`, `[brackets]`, other
+/// builtins like `write`/`ctl`/`mount`/`help`, or unrecognized commands) still
+/// goes through the interpreter exactly as before.
+#[cfg(not(target_os = "wasi"))]
+#[derive(Debug)]
+enum VfsCommandClass {
+    /// Bare path (`/srv/model/status`) or explicit `cat <path>` with exactly one
+    /// argument and no Tcl metacharacters in it.
+    Cat(String),
+    /// `ls` or `ls <path>` with at most one argument and no Tcl metacharacters.
+    Ls(Option<String>),
+    /// Anything else — evaluate as Tcl.
+    Eval(String),
+}
+
+/// True if `s` contains characters that would change meaning under Tcl
+/// evaluation (substitution, grouping, command nesting) or any whitespace.
+///
+/// Direct-path arguments containing any of these fall through to `eval` so they
+/// get exactly the semantics they had before this routing split. The Tcl
+/// metacharacters (`$ [ ] { } " ; \`) cover substitution/grouping/command-
+/// nesting. The whitespace check keeps a bare-path fast-path argument
+/// byte-faithful to "literally `cat <this exact string>`": the old bare-path
+/// heuristic built `cat {input}` and let the molt tokenizer split it, so a path
+/// containing e.g. a newline would have been command-split by the interpreter
+/// rather than read as one opaque filename — routing such inputs through Tcl
+/// preserves that. (The VFS resolver returns `NotFound` for whitespace-bearing
+/// paths regardless; all path-safety/authorization lives inside
+/// `Namespace::cat`/`ls`, which the Tcl `cmd_cat`/`cmd_ls` builtins call
+/// unchanged — so this is a faithfulness guard, not a security fix.)
+#[cfg(not(target_os = "wasi"))]
+fn has_tcl_metachars(s: &str) -> bool {
+    s.contains(['$', '[', ']', '{', '}', '"', ';', '\\']) || s.contains(char::is_whitespace)
+}
+
+/// Classify a stripped (no leading `/`) slash-command body for direct-VFS vs.
+/// Tcl-eval routing. `leading_slash_path` mirrors the original bare-path
+/// heuristic in `handle_vfs_command`: a single word containing `/` with no
+/// space (e.g. `srv/model/status`, from input `/srv/model/status`).
+#[cfg(not(target_os = "wasi"))]
+fn classify_vfs_command(stripped: &str, leading_slash_path: bool) -> VfsCommandClass {
+    if leading_slash_path {
+        return if has_tcl_metachars(stripped) {
+            VfsCommandClass::Eval(stripped.to_owned())
+        } else {
+            VfsCommandClass::Cat(format!("/{stripped}"))
+        };
+    }
+
+    let mut parts = stripped.split_whitespace();
+    let Some(cmd) = parts.next() else {
+        return VfsCommandClass::Eval(stripped.to_owned());
+    };
+    let rest: Vec<&str> = parts.collect();
+
+    match cmd {
+        "cat" if rest.len() == 1 && !has_tcl_metachars(rest[0]) => {
+            VfsCommandClass::Cat(rest[0].to_owned())
+        }
+        "ls" if rest.is_empty() => VfsCommandClass::Ls(None),
+        "ls" if rest.len() == 1 && !has_tcl_metachars(rest[0]) => {
+            VfsCommandClass::Ls(Some(rest[0].to_owned()))
+        }
+        _ => VfsCommandClass::Eval(stripped.to_owned()),
+    }
 }
 
 impl ChatApp {
@@ -409,8 +457,9 @@ impl ChatApp {
             spinner_tick: 0,
             vfs: None,
             vfs_subject: hyprstream_vfs::Subject::anonymous(),
-            tcl_shell: None,
+            tcl_owner: None,
             tcl_shell_init: None,
+            ns_driver: None,
         }
     }
 
@@ -440,7 +489,6 @@ impl ChatApp {
             spinner_tick: 0,
             vfs: None,
             vfs_subject: hyprstream_vfs::Subject::anonymous(),
-            tcl_shell: None,
             tcl_shell_init: None,
         }
     }
@@ -517,8 +565,9 @@ impl ChatApp {
             spinner_tick: 0,
             vfs: None,
             vfs_subject: hyprstream_vfs::Subject::anonymous(),
-            tcl_shell: None,
+            tcl_owner: None,
             tcl_shell_init: None,
+            ns_driver: None,
         }
     }
 
@@ -541,9 +590,11 @@ impl ChatApp {
 
     /// Attach a VFS namespace for `/path` command routing.
     ///
-    /// The TclShell is created lazily on first use (inside the app thread)
-    /// because it is `!Send` and ChatApp must cross a thread boundary in
-    /// `spawn_app_process`.
+    /// The Tcl shell owner thread and the direct-`Namespace` driver thread (see
+    /// `crate::shell_driver`) are both created lazily on first use, because
+    /// `TclShell` is `!Send` and ChatApp must cross a thread boundary in
+    /// `spawn_app_process` before it can settle on the thread its owner will
+    /// spawn from.
     pub fn with_vfs(mut self, ns: std::sync::Arc<hyprstream_vfs::Namespace>, subject: hyprstream_vfs::Subject) -> Self {
         self.tcl_shell_init = Some((subject.clone(), std::sync::Arc::clone(&ns)));
         self.vfs = Some(ns);
@@ -804,46 +855,61 @@ impl ChatApp {
         self.scroll_offset = 0;
     }
 
-    /// Lazily initialize the TclShell. Must be called from the app thread
-    /// (after the ChatApp has been moved into spawn_app_process).
+    /// Lazily spawn the Tcl shell owner thread. Must be called from the app
+    /// thread (after the ChatApp has been moved into `spawn_app_process`) so
+    /// `tcl_shell_init`'s `Subject`/`Arc<Namespace>` (both `Send`) can cross into
+    /// the dedicated owner thread that [`shell_driver::ShellOwner::spawn`]
+    /// creates — the live `TclShell` itself never crosses any thread boundary.
+    ///
+    /// The owner services the synchronous slash-command `eval()` path only;
+    /// `/lang/tcl` VFS traffic is served by the self-contained `TclMount` in the
+    /// namespace, not by ChatApp.
+    #[cfg(not(target_os = "wasi"))]
     fn ensure_tcl_shell(&mut self) {
-        if self.tcl_shell.is_none() {
+        if self.tcl_owner.is_none() {
             if let Some((subject, namespace)) = self.tcl_shell_init.take() {
-                self.tcl_shell = Some(AssertSend(std::cell::UnsafeCell::new(
-                    hyprstream_workers_tcl::TclShell::new(subject, namespace),
-                )));
+                self.tcl_owner = Some(crate::shell_driver::ShellOwner::spawn(
+                    subject, namespace,
+                ));
             }
         }
     }
 
-    /// Poll a `!Send` future to completion on the current thread.
-    ///
-    /// Works in both contexts: inside an existing tokio runtime (shell_handlers
-    /// compositor loop) and on a bare OS thread (spawn_app_process). Uses a
-    /// noop-waker poll loop — safe because TclShell/VFS futures are pure async
-    /// (no IO reactor, no timers — just trait method dispatch).
-    fn poll_local<F: std::future::Future>(fut: F) -> F::Output {
-        let mut fut = std::pin::pin!(fut);
-        let waker = noop_waker();
-        let mut cx = std::task::Context::from_waker(&waker);
-        loop {
-            match fut.as_mut().poll(&mut cx) {
-                std::task::Poll::Ready(val) => return val,
-                std::task::Poll::Pending => std::thread::yield_now(),
+    /// No-op on WASI: there is no dedicated-thread shell owner there (no VFS,
+    /// no `/`-command routing — see `new_wasm`, which never calls `with_vfs`).
+    #[cfg(target_os = "wasi")]
+    fn ensure_tcl_shell(&mut self) {}
+
+    /// Lazily spawn the direct-`Namespace` driver thread used for bare
+    /// cat/ls-shaped `/`-commands that don't need a Tcl interpreter at all.
+    #[cfg(not(target_os = "wasi"))]
+    fn ensure_ns_driver(&mut self) {
+        if self.ns_driver.is_none() {
+            if let Some(ns) = &self.vfs {
+                self.ns_driver = Some(crate::shell_driver::NamespaceDriver::spawn(
+                    self.vfs_subject.clone(),
+                    std::sync::Arc::clone(ns),
+                ));
             }
         }
     }
 
-    /// Handle a `/`-prefixed command by evaluating it as Tcl against the VFS.
+    /// Handle a `/`-prefixed command.
     ///
-    /// Bare paths (e.g. `/srv/model/status`) are treated as `cat /srv/model/status`.
-    /// Commands (e.g. `/ls /srv/model`) are evaluated directly.
+    /// Bare paths (e.g. `/srv/model/status`) and simple `cat`/`ls` invocations
+    /// are served directly from the `Namespace` via
+    /// [`NamespaceDriver`](crate::shell_driver::NamespaceDriver) — no Tcl
+    /// interpreter is constructed or consulted for these. Anything else (e.g.
+    /// `/write`, `/ctl`, `/mount`, `/help`, or genuine Tcl syntax with
+    /// `$vars`/`[brackets]`/etc.) still evaluates through `TclShell` via
+    /// [`ShellOwner`](crate::shell_driver::ShellOwner), exactly as before — this
+    /// is a routing refactor, not a behavior change for those paths.
+    #[cfg(not(target_os = "wasi"))]
     fn handle_vfs_command(&mut self, input: &str) {
-        self.ensure_tcl_shell();
-        let Some(shell) = &mut self.tcl_shell else {
+        if self.vfs.is_none() {
             self.push_system_message("VFS not available");
             return;
-        };
+        }
 
         // Show the command in history.
         self.history.push(ChatHistoryEntry {
@@ -854,17 +920,38 @@ impl ChatApp {
             tool_call_id: None,
         });
 
-        // Strip leading '/' and decide: bare path vs command.
+        // Strip leading '/' and decide: bare path vs command, mirroring the
+        // original heuristic exactly (single word containing '/' with no space
+        // = bare path), before sub-classifying for direct-vs-Tcl routing.
         let stripped = input.trim_start_matches('/');
-        let script = if !stripped.contains(' ') && stripped.contains('/') {
-            // Bare path like /srv/model/status → cat it.
-            format!("cat {input}")
-        } else {
-            // Command like /ls /srv or /help → eval as-is.
-            stripped.to_owned()
+        let leading_slash_path = !stripped.contains(' ') && stripped.contains('/');
+
+        let class = classify_vfs_command(stripped, leading_slash_path);
+
+        let result = match class {
+            VfsCommandClass::Cat(path) => {
+                self.ensure_ns_driver();
+                match &self.ns_driver {
+                    Some(driver) => driver.cat(&path),
+                    None => Err("VFS not available".to_owned()),
+                }
+            }
+            VfsCommandClass::Ls(path) => {
+                self.ensure_ns_driver();
+                match &self.ns_driver {
+                    Some(driver) => driver.ls(path.as_deref().unwrap_or("/")),
+                    None => Err("VFS not available".to_owned()),
+                }
+            }
+            VfsCommandClass::Eval(script) => {
+                self.ensure_tcl_shell();
+                match &self.tcl_owner {
+                    Some(owner) => owner.eval(&script),
+                    None => Err("VFS not available".to_owned()),
+                }
+            }
         };
 
-        let result = Self::poll_local(shell.eval(&script));
         match result {
             Ok(output) if !output.is_empty() => {
                 self.push_system_message(&output);
@@ -874,6 +961,13 @@ impl ChatApp {
                 self.push_system_message(&format!("error: {e}"));
             }
         }
+    }
+
+    /// No-op on WASI: `/`-command routing requires a VFS namespace, which is
+    /// never attached there (see `new_wasm`).
+    #[cfg(target_os = "wasi")]
+    fn handle_vfs_command(&mut self, _input: &str) {
+        self.push_system_message("VFS not available");
     }
 
     // ── Submit helpers ────────────────────────────────────────────────────────
@@ -1571,5 +1665,109 @@ impl TerminalApp for ChatApp {
 
     fn should_quit(&self) -> bool {
         self.quit
+    }
+}
+
+#[cfg(all(test, not(target_os = "wasi")))]
+mod tests {
+    use super::{classify_vfs_command, has_tcl_metachars, VfsCommandClass};
+
+    /// A bare path (single word containing `/`) with no metacharacters routes to
+    /// a direct `Namespace::cat` of the leading-`/`-prefixed path — matching the
+    /// old `format!("cat {input}")` behavior exactly.
+    #[test]
+    fn bare_path_routes_to_direct_cat() {
+        let class = classify_vfs_command("srv/model/status", true);
+        assert!(matches!(class, VfsCommandClass::Cat(p) if p == "/srv/model/status"));
+    }
+
+    /// A bare path containing any Tcl metacharacter falls through to Tcl `eval`
+    /// so the interpreter's substitution/grouping semantics are preserved.
+    #[test]
+    fn bare_path_with_metachar_routes_to_eval() {
+        for bad in ["srv/$x", "srv/[a]", "srv/{b}", "srv/\"q\"", "srv;c", "srv\\d"] {
+            let class = classify_vfs_command(bad, true);
+            assert!(
+                matches!(class, VfsCommandClass::Eval(ref s) if s == bad),
+                "bare path {bad:?} should fall through to Eval, got {class:?}"
+            );
+        }
+    }
+
+    /// A bare path containing whitespace (space/tab/newline) also falls through
+    /// to Tcl: the old heuristic built `cat {input}` and let molt tokenize it, so
+    /// e.g. a newline would have been command-split. See `has_tcl_metachars`.
+    #[test]
+    fn bare_path_with_whitespace_routes_to_eval() {
+        for bad in ["srv/x\t", "srv\ny/z", "srv\r/z"] {
+            // `leading_slash_path` is computed by the caller from "no space AND
+            // contains '/'"; a tab/newline is not a space so the caller would
+            // still set it true — the classifier must then reject via the
+            // whitespace arm of has_tcl_metachars.
+            let class = classify_vfs_command(bad, true);
+            assert!(
+                matches!(class, VfsCommandClass::Eval(ref s) if s == bad),
+                "bare path {bad:?} should fall through to Eval, got {class:?}"
+            );
+        }
+    }
+
+    /// `cat <path>` with exactly one metachar-free argument routes to direct cat.
+    #[test]
+    fn explicit_cat_routes_to_direct_cat() {
+        let class = classify_vfs_command("cat /srv/model/status", false);
+        assert!(matches!(class, VfsCommandClass::Cat(p) if p == "/srv/model/status"));
+    }
+
+    /// `cat` with zero, two, or metachar-bearing arguments falls through to Tcl.
+    #[test]
+    fn cat_wrong_arity_or_meta_routes_to_eval() {
+        assert!(matches!(
+            classify_vfs_command("cat", false),
+            VfsCommandClass::Eval(_)
+        ));
+        assert!(matches!(
+            classify_vfs_command("cat a b", false),
+            VfsCommandClass::Eval(_)
+        ));
+        assert!(matches!(
+            classify_vfs_command("cat $x", false),
+            VfsCommandClass::Eval(_)
+        ));
+    }
+
+    /// `ls` and `ls <path>` route to direct ls.
+    #[test]
+    fn ls_routes_to_direct_ls() {
+        assert!(matches!(classify_vfs_command("ls", false), VfsCommandClass::Ls(None)));
+        assert!(matches!(
+            classify_vfs_command("ls /srv", false),
+            VfsCommandClass::Ls(Some(p)) if p == "/srv"
+        ));
+    }
+
+    /// Everything that isn't a bare path or simple cat/ls — write/ctl/mount/help,
+    /// unknown commands, empty input — falls through to Tcl `eval` unchanged.
+    #[test]
+    fn non_direct_commands_route_to_eval() {
+        for input in ["write /x y", "ctl /svc start", "mount foo", "help", "frobnicate", ""] {
+            assert!(
+                matches!(classify_vfs_command(input, false), VfsCommandClass::Eval(s) if s == input),
+                "input {input:?} should Eval unchanged"
+            );
+        }
+    }
+
+    /// `has_tcl_metachars` is the security-relevant gate: it must reject every
+    /// character that would change meaning under Tcl evaluation, plus whitespace.
+    #[test]
+    fn metachar_detection_is_complete() {
+        // Each Tcl-significant character, in an otherwise-inert string.
+        for c in ['$', '[', ']', '{', '}', '"', ';', '\\', ' ', '\t', '\n', '\r'] {
+            assert!(has_tcl_metachars(&format!("x{c}y")), "failed to flag {c:?}");
+        }
+        // A plain path is clean.
+        assert!(!has_tcl_metachars("/srv/model/status"));
+        assert!(!has_tcl_metachars("bin/foo-bar_2.txt"));
     }
 }

--- a/crates/hyprstream-tui/src/lib.rs
+++ b/crates/hyprstream-tui/src/lib.rs
@@ -14,6 +14,9 @@ pub mod private_store;
 
 pub mod chat_app;
 
+#[cfg(not(target_os = "wasi"))]
+pub mod shell_driver;
+
 #[cfg(target_os = "wasi")]
 pub mod chat_ui_wasm;
 

--- a/crates/hyprstream-tui/src/shell_driver.rs
+++ b/crates/hyprstream-tui/src/shell_driver.rs
@@ -1,0 +1,267 @@
+//! Dedicated-thread async drivers for `!Send` language-shell interpreters (and,
+//! via [`NamespaceDriver`], for direct `Namespace` access that doesn't need an
+//! interpreter at all).
+//!
+//! The synchronous slash-command path (`ChatApp::handle_vfs_command`) needs to run
+//! async VFS futures to completion from a key-event handler that must not spin. A
+//! `Poll::Pending` on a VFS read that legitimately blocks on an external event
+//! (e.g. an `/exec/instances/<id>/exit` read awaiting a worker-completion signal)
+//! must park the caller, not hot-spin a core — which a noop-waker poll loop cannot
+//! do, because a noop waker never delivers the wake-up.
+//!
+//! ## The driver
+//!
+//! [`ShellOwner`] spawns one dedicated OS thread per shell. That thread runs a
+//! single-threaded `tokio::runtime::Runtime` (`Builder::new_current_thread()`)
+//! driving a `tokio::task::LocalSet`, the same pattern used by
+//! `hyprstream-workers::workflow::runner`'s per-job `TclShell` owner
+//! (`crates/hyprstream-workers/src/workflow/runner.rs`, `run_job`). Because the
+//! shell never leaves that thread, a `Pending` future registers a *real* waker
+//! tied to the runtime's reactor/timer/notify machinery — the executor parks the
+//! thread (zero CPU) until something actually wakes it, instead of spinning.
+//!
+//! `TclShell`'s `!Send` constraint (it wraps a molt `Interp`, which is `Rc`-based)
+//! is load-bearing here: the shell is constructed on, and never leaves, its owner
+//! thread — the whole point of a single-threaded `LocalSet` owner.
+//!
+//! ## The blocking `eval()` leg
+//!
+//! [`ShellOwner::eval`] round-trips a request to the owner thread and waits for the
+//! reply over a plain `std::sync::mpsc` channel — deliberately NOT
+//! `tokio::sync::oneshot::Receiver::blocking_recv()`, because `handle_input` runs
+//! in two different contexts depending on how the TUI is hosted:
+//!
+//!   - a bare OS thread with no tokio runtime at all (`spawn_app_process` /
+//!     `run_app_loop`, the TuiService-hosted path), and
+//!   - directly inside an active tokio runtime (the CLI shell's event loop in
+//!     `crates/hyprstream/src/cli/shell_handlers.rs`, which calls
+//!     `app.handle_input()` from within a `tokio::select!` arm).
+//!
+//! `tokio::sync::oneshot::Receiver::blocking_recv()` panics ("Cannot block the
+//! current thread from within a runtime") in the second context. `std::sync::mpsc`
+//! has no opinion about tokio and parks the calling OS thread via a condvar in
+//! both contexts, so it is safe everywhere `handle_vfs_command` is called from.
+//! This blocks the calling (input-handling) thread for the duration of one `eval`
+//! — a parked wait, not a spinning one. Making `handle_vfs_command` fully
+//! non-blocking would mean enqueue-and-poll against `ShellOwner` rather than
+//! waiting inline.
+
+use std::sync::mpsc as std_mpsc;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TclShell owner
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// One ad-hoc `eval()` request sent to a [`ShellOwner`]'s dedicated thread.
+///
+/// The job runs `shell.eval(&script)` and sends the result back over `reply` —
+/// encapsulating the reply send keeps the channel a plain `FnOnce(&mut TclShell)`
+/// regardless of the job's result type.
+struct TclEvalJob {
+    script: String,
+    reply: std_mpsc::Sender<Result<String, String>>,
+}
+
+/// Dedicated-thread owner for a `TclShell`.
+///
+/// Spawns one OS thread that builds a current-thread tokio runtime + `LocalSet`,
+/// constructs the `TclShell` on that thread (preserving its `!Send` requirement),
+/// and services ad-hoc `eval()` calls (from slash-command routing) via
+/// [`Self::eval`], which blocks the *calling* thread (parked, not spinning) until
+/// the owner thread replies.
+///
+/// Dropping the `ShellOwner` drops `job_tx`, which ends the owner thread's job
+/// loop.
+pub struct ShellOwner {
+    job_tx: std_mpsc::Sender<TclEvalJob>,
+    _handle: std::thread::JoinHandle<()>,
+}
+
+impl ShellOwner {
+    /// Spawn the owner thread, constructing a `TclShell` from `subject`/`namespace`.
+    pub fn spawn(
+        subject: hyprstream_vfs::Subject,
+        namespace: std::sync::Arc<hyprstream_vfs::Namespace>,
+    ) -> Self {
+        let (job_tx, job_rx) = std_mpsc::channel::<TclEvalJob>();
+
+        #[allow(clippy::expect_used)] // thread spawn failure is unrecoverable here
+        let handle = std::thread::Builder::new()
+            .name("tcl-shell-owner".into())
+            .spawn(move || {
+                // Single-threaded runtime + LocalSet: the same pattern used by
+                // hyprstream-workers::workflow::runner's per-job TclShell owner
+                // (crates/hyprstream-workers/src/workflow/runner.rs, run_job).
+                // A Pending future here registers a real waker tied to this
+                // runtime's reactor — `.await` parks the thread; it does not spin.
+                #[allow(clippy::expect_used)] // runtime creation failure is unrecoverable
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("tcl-shell-owner runtime");
+                let local = tokio::task::LocalSet::new();
+
+                local.block_on(&rt, async move {
+                    let mut shell = hyprstream_workers_tcl::TclShell::new(subject, namespace);
+
+                    // Bridge the plain std::sync::mpsc job queue into this
+                    // LocalSet without ever blocking the runtime thread itself:
+                    // a tiny forwarder thread does the (parked, not spun)
+                    // std::sync::mpsc::Receiver::recv(), then hands jobs off
+                    // through a tokio channel this task can `.await` on.
+                    let (bridge_tx, mut bridge_rx) =
+                        tokio::sync::mpsc::unbounded_channel::<TclEvalJob>();
+                    std::thread::spawn(move || {
+                        while let Ok(job) = job_rx.recv() {
+                            if bridge_tx.send(job).is_err() {
+                                break;
+                            }
+                        }
+                    });
+
+                    // job_tx (held by ShellOwner) dropped — owner is torn down.
+                    while let Some(TclEvalJob { script, reply }) = bridge_rx.recv().await {
+                        let result = shell.eval(&script).await;
+                        let _ = reply.send(result);
+                    }
+                });
+            })
+            .expect("spawn tcl-shell-owner thread");
+
+        Self { job_tx, _handle: handle }
+    }
+
+    /// Evaluate a Tcl script on the owner thread and block (parked, not spun)
+    /// until the result is ready.
+    ///
+    /// Safe to call from any thread context, including from inside an active
+    /// tokio runtime — uses `std::sync::mpsc`, not `tokio::sync::oneshot`, for
+    /// the reply leg specifically so it never hits tokio's "cannot block the
+    /// current thread from within a runtime" panic (see module docs).
+    pub fn eval(&self, script: &str) -> Result<String, String> {
+        let (reply_tx, reply_rx) = std_mpsc::channel();
+        let sent = self.job_tx.send(TclEvalJob {
+            script: script.to_owned(),
+            reply: reply_tx,
+        });
+        if sent.is_err() {
+            return Err("tcl shell owner thread is gone".to_owned());
+        }
+        reply_rx
+            .recv()
+            .unwrap_or_else(|_| Err("tcl shell owner thread is gone".to_owned()))
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Direct Namespace driver (Tcl-independent VFS access for bare cat/ls routing)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// One direct `Namespace` request — `cat` or `ls` — dispatched without going
+/// through a `TclShell` at all.
+enum NsOp {
+    Cat(String),
+    Ls(String),
+}
+
+struct NsJob {
+    op: NsOp,
+    reply: std_mpsc::Sender<Result<String, String>>,
+}
+
+/// Dedicated-thread driver for direct `Namespace` access (`cat`/`ls`), with no
+/// Tcl interpreter involved at all.
+///
+/// This is what lets `ChatApp::handle_vfs_command` decouple simple path reads
+/// from `TclShell`: a bare path like `/srv/model/status` no longer needs an
+/// interpreter to exist, let alone to `eval("cat ...")` through one. Unlike
+/// [`ShellOwner`], `Namespace::cat`/`Namespace::ls` futures are plain `Send`
+/// (no `Rc`, no `!Send` constraint) — so this driver doesn't need a `LocalSet`,
+/// just a parked single-threaded runtime to give synchronous callers (which may
+/// or may not already be inside a tokio runtime — see module docs) a non-spinning
+/// way to wait on an async VFS call.
+pub struct NamespaceDriver {
+    job_tx: std_mpsc::Sender<NsJob>,
+    _handle: std::thread::JoinHandle<()>,
+}
+
+impl NamespaceDriver {
+    /// Spawn the driver thread bound to `namespace`/`subject`.
+    pub fn spawn(
+        subject: hyprstream_vfs::Subject,
+        namespace: std::sync::Arc<hyprstream_vfs::Namespace>,
+    ) -> Self {
+        let (job_tx, job_rx) = std_mpsc::channel::<NsJob>();
+
+        #[allow(clippy::expect_used)] // thread spawn failure is unrecoverable here
+        let handle = std::thread::Builder::new()
+            .name("vfs-namespace-driver".into())
+            .spawn(move || {
+                #[allow(clippy::expect_used)] // runtime creation failure is unrecoverable
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("vfs-namespace-driver runtime");
+
+                // job_rx.recv() blocks this dedicated OS thread (parked via
+                // condvar, not spun) between requests. Each request is then
+                // driven to completion with its own `rt.block_on(..)` — this
+                // thread has no other work, so there is nothing to interleave
+                // with and no benefit to keeping a task alive across requests.
+                while let Ok(NsJob { op, reply }) = job_rx.recv() {
+                    let result = rt.block_on(async {
+                        match op {
+                            NsOp::Cat(path) => namespace
+                                .cat(&path, &subject)
+                                .await
+                                .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+                                .map_err(|e| e.to_string()),
+                            NsOp::Ls(path) => namespace
+                                .ls(&path, &subject)
+                                .await
+                                .map(|entries| {
+                                    entries
+                                        .iter()
+                                        .map(|e| {
+                                            if e.is_dir {
+                                                format!("{}/", e.name)
+                                            } else {
+                                                e.name.clone()
+                                            }
+                                        })
+                                        .collect::<Vec<_>>()
+                                        .join("\n")
+                                })
+                                .map_err(|e| e.to_string()),
+                        }
+                    });
+                    let _ = reply.send(result);
+                }
+            })
+            .expect("spawn vfs-namespace-driver thread");
+
+        Self { job_tx, _handle: handle }
+    }
+
+    /// Read a file's contents as a UTF-8 (lossy) string. Blocks the calling
+    /// thread (parked, not spun) until the result is ready; safe to call from
+    /// any thread context, including from inside an active tokio runtime.
+    pub fn cat(&self, path: &str) -> Result<String, String> {
+        self.request(NsOp::Cat(path.to_owned()))
+    }
+
+    /// List a directory's entries (directories suffixed with `/`), newline-joined.
+    pub fn ls(&self, path: &str) -> Result<String, String> {
+        self.request(NsOp::Ls(path.to_owned()))
+    }
+
+    fn request(&self, op: NsOp) -> Result<String, String> {
+        let (reply_tx, reply_rx) = std_mpsc::channel();
+        if self.job_tx.send(NsJob { op, reply: reply_tx }).is_err() {
+            return Err("vfs namespace driver thread is gone".to_owned());
+        }
+        reply_rx
+            .recv()
+            .unwrap_or_else(|_| Err("vfs namespace driver thread is gone".to_owned()))
+    }
+}


### PR DESCRIPTION
**Descoped** (#611, P3 of #608): replace the `poll_local` noop-waker spin loop with dedicated-thread async drivers, and decouple bare-path VFS routing from Tcl.

## Why descoped
This PR branched before #638 (self-contained shell Mounts) merged. #638 made `/lang/tcl` + `/lang/python` self-serving (their driver threads live inside the Mounts; `create_mount_channel` is now `#[cfg(test)]`-only, no non-test caller hands a mount-rx to `ChatApp`). So the entire mount-rx-servicing surface this PR originally carried is now dead. Rebased onto the post-#638 base with that surface removed.

## What lands (the still-needed fix)
The `poll_local` spin loop still exists in the base and is still called from `handle_vfs_command`. It drives `!Send` shell futures with a **noop waker** — safe only while every VFS future is purely computational. The moment a VFS read legitimately blocks on an external event (e.g. `/exec/instances/<id>/exit` awaiting worker completion, #607/#623), that loop **hot-spins a CPU core forever** (a noop waker can't deliver the wake-up). This replaces it with:
- **`ShellOwner`** — Tcl `eval()` on a dedicated current-thread-runtime + `LocalSet` thread (preserves `TclShell`'s `!Send` invariant; parks, never spins).
- **`NamespaceDriver`** — direct `cat`/`ls` on a parked thread, no Tcl interpreter needed.
- **`classify_vfs_command`** — bare paths route straight to `NamespaceDriver` (no `eval("cat …")` round-trip through Tcl).
- Blocking eval leg uses `std::sync::mpsc` (not `tokio::oneshot`) so it's safe both inside and outside a tokio runtime.

## Dropped (dead post-#638)
`PyShellOwner`, `tcl_mount_rx`/`py_mount_rx`, `with_tcl_mount_rx`/`with_py_mount_rx`, `drain_py_mount`, and `ShellOwner::spawn`'s mount-select arm.

## Verified
`cargo check -p hyprstream-tui` + `-p hyprstream` clean; `cargo test -p hyprstream-tui` 35/35 (incl. 8 routing tests); clippy clean; dead-surface grep clean.

## Follow-up (non-blocking)
`hyprstream-workers-python` is now an unused dep of `hyprstream-tui` (inherited from base) — worth a trim.

Refs #611 · #608 P3.