### PR TITLE
feat(workers): WorkflowService scan_repo + YAML round-trip + event routing (#349)

### DIFF
--- a/crates/hyprstream-workers/src/workflow/service.rs
+++ b/crates/hyprstream-workers/src/workflow/service.rs
@@ -1,6 +1,7 @@
 //! WorkflowService - RequestService implementation for workflow orchestration
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
@@ -90,6 +91,12 @@ pub struct WorkflowService {
     /// Per-repo workflow subscriptions (O(1) lookup)
     repo_workflows: RwLock<HashMap<String, Vec<WorkflowSubscription>>>,
 
+    /// Registered repo paths (repo_id → filesystem root)
+    repo_paths: RwLock<HashMap<String, PathBuf>>,
+
+    /// Active subscriptions (sub_id → WorkflowSubscription)
+    subscriptions: RwLock<HashMap<String, WorkflowSubscription>>,
+
     /// Event handlers for different event types
     handlers: RwLock<Vec<Box<dyn EventHandler>>>,
 
@@ -124,6 +131,8 @@ impl WorkflowService {
             workflows: RwLock::new(HashMap::new()),
             runs: Arc::new(RwLock::new(HashMap::new())),
             repo_workflows: RwLock::new(HashMap::new()),
+            repo_paths: RwLock::new(HashMap::new()),
+            subscriptions: RwLock::new(HashMap::new()),
             handlers: RwLock::new(Vec::new()),
             event_loop_handle: tokio::sync::Mutex::new(None),
             transport,
@@ -131,6 +140,15 @@ impl WorkflowService {
             authorize_fn: None,
             runner: None,
         }
+    }
+
+    /// Register the filesystem root for a repo_id.
+    ///
+    /// Once registered, `scan_repo(repo_id)` will glob
+    /// `<root>/.github/workflows/*.yml` to discover workflows.
+    pub async fn register_repo_path(&self, repo_id: impl Into<String>, path: PathBuf) {
+        let mut repo_paths = self.repo_paths.write().await;
+        repo_paths.insert(repo_id.into(), path);
     }
 
     /// Set the VFS namespace for workflow execution.
@@ -146,10 +164,22 @@ impl WorkflowService {
         self.authorize_fn = Some(authorize_fn);
     }
 
-    /// Initialize the service
+    /// Initialize the service: scan all registered repos and register their workflows.
     pub async fn initialize(&self) -> Result<()> {
-        // TODO: Scan all registered repos for workflows
-        // TODO: Create handlers for each workflow trigger
+        let repo_ids: Vec<String> = {
+            let repo_paths = self.repo_paths.read().await;
+            repo_paths.keys().cloned().collect()
+        };
+
+        for repo_id in repo_ids {
+            match self.rescan_repo(&repo_id).await {
+                Ok(()) => {}
+                Err(e) => {
+                    tracing::warn!(repo_id = %repo_id, error = %e, "Failed to scan repo during init");
+                }
+            }
+        }
+
         tracing::info!("WorkflowService initialized");
         Ok(())
     }
@@ -161,10 +191,12 @@ impl WorkflowService {
     pub async fn start(self: Arc<Self>) -> Result<()> {
         let mut subscriber = EventSubscriber::new()?;
 
-        // Subscribe to worker events (sandbox/container lifecycle)
-        subscriber.subscribe("worker.")?;
+        // Subscribe to all event categories that can trigger or affect workflows.
+        for prefix in &["worker.", "repo.", "training.", "metrics."] {
+            subscriber.subscribe(prefix)?;
+        }
 
-        tracing::info!("WorkflowService subscribed to worker.* events");
+        tracing::info!("WorkflowService subscribed to worker/repo/training/metrics events");
 
         let service = self.clone();
         let handle = tokio::spawn(async move {
@@ -262,13 +294,95 @@ impl WorkflowService {
         handlers.push(handler);
     }
 
-    /// Scan a repository for workflows
+    /// Scan a repository for `.github/workflows/*.yml` files.
+    ///
+    /// Uses the path registered via `register_repo_path`. Returns an empty
+    /// Vec (not an error) if no path is registered for the repo or if the
+    /// workflows directory does not exist.
     pub(crate) async fn scan_repo(&self, repo_id: &str) -> Result<Vec<WorkflowDef>> {
-        // TODO: Read .github/workflows/*.yml from repo
-        // TODO: Parse each workflow file
-        // TODO: Return list of workflow definitions
         tracing::info!(repo_id = %repo_id, "Scanning repository for workflows");
-        Ok(Vec::new())
+
+        let root = {
+            let repo_paths = self.repo_paths.read().await;
+            match repo_paths.get(repo_id) {
+                Some(p) => p.clone(),
+                None => {
+                    tracing::debug!(repo_id = %repo_id, "No path registered for repo — skipping scan");
+                    return Ok(Vec::new());
+                }
+            }
+        };
+
+        // The directory walk + file reads + YAML parsing are all blocking I/O.
+        // Run them on the blocking thread pool so we don't stall the async
+        // worker (and starve other tasks sharing this runtime).
+        let repo_id_owned = repo_id.to_owned();
+        let defs = tokio::task::spawn_blocking(move || -> Result<Vec<WorkflowDef>> {
+            let workflow_dir = root.join(".github").join("workflows");
+            if !workflow_dir.is_dir() {
+                tracing::debug!(
+                    repo_id = %repo_id_owned,
+                    dir = %workflow_dir.display(),
+                    "No .github/workflows dir found"
+                );
+                return Ok(Vec::new());
+            }
+
+            let mut defs = Vec::new();
+            let read_dir = std::fs::read_dir(&workflow_dir).map_err(|e| {
+                crate::error::WorkerError::WorkflowParseError(format!(
+                    "Failed to read workflows dir {}: {e}",
+                    workflow_dir.display()
+                ))
+            })?;
+
+            for entry in read_dir.flatten() {
+                let path = entry.path();
+                let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+                if ext != "yml" && ext != "yaml" {
+                    continue;
+                }
+
+                let yaml = match std::fs::read_to_string(&path) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        tracing::warn!(path = %path.display(), error = %e, "Failed to read workflow file");
+                        continue;
+                    }
+                };
+
+                let workflow = match Workflow::parse(&yaml) {
+                    Ok(w) => w,
+                    Err(e) => {
+                        tracing::warn!(path = %path.display(), error = %e, "Failed to parse workflow");
+                        continue;
+                    }
+                };
+
+                let rel_path = path
+                    .strip_prefix(&root)
+                    .map(|p| p.to_string_lossy().into_owned())
+                    .unwrap_or_else(|_| path.to_string_lossy().into_owned());
+
+                let triggers = extract_triggers(&workflow);
+
+                defs.push(WorkflowDef {
+                    path: rel_path,
+                    repo_id: repo_id_owned.clone(),
+                    workflow,
+                    triggers,
+                });
+            }
+
+            Ok(defs)
+        })
+        .await
+        .map_err(|e| {
+            crate::error::WorkerError::WorkflowParseError(format!("scan_repo blocking task failed: {e}"))
+        })??;
+
+        tracing::info!(repo_id = %repo_id, count = defs.len(), "Scan complete");
+        Ok(defs)
     }
 
     /// Register a workflow
@@ -503,15 +617,24 @@ impl WorkflowHandler for WorkflowService {
         repo_id: &str,
     ) -> AnyhowResult<WorkflowResponseVariant> {
         let workflows = self.scan_repo(repo_id).await?;
-        Ok(WorkflowResponseVariant::ScanRepoResult(
-            workflows.iter().map(|wf| WorkflowDefWire {
-                path: wf.path.clone(),
-                repo_id: wf.repo_id.clone(),
-                name: wf.workflow.name.clone(),
-                triggers: Vec::new(), // EventTrigger is empty struct for now
-                yaml: String::new(),  // TODO: serialize workflow back to YAML
-            }).collect()
-        ))
+        let defs = workflows
+            .iter()
+            .map(|wf| {
+                // Propagate serialization failures instead of defaulting to an
+                // empty yaml string (which would register a broken stub).
+                let yaml = serde_yaml::to_string(&wf.workflow).map_err(|e| {
+                    anyhow::anyhow!("failed to serialize workflow '{}' to YAML: {e}", wf.path)
+                })?;
+                Ok::<_, anyhow::Error>(WorkflowDefWire {
+                    path: wf.path.clone(),
+                    repo_id: wf.repo_id.clone(),
+                    name: wf.workflow.name.clone(),
+                    triggers: Vec::new(),
+                    yaml,
+                })
+            })
+            .collect::<AnyhowResult<Vec<_>>>()?;
+        Ok(WorkflowResponseVariant::ScanRepoResult(defs))
     }
 
     async fn handle_register(
@@ -520,16 +643,23 @@ impl WorkflowHandler for WorkflowService {
         _request_id: u64,
         data: &WorkflowDefWire,
     ) -> AnyhowResult<WorkflowResponseVariant> {
-        let workflow_def = WorkflowDef {
-            path: data.path.clone(),
-            repo_id: data.repo_id.clone(),
-            workflow: Workflow {
+        let workflow = if data.yaml.is_empty() {
+            // Build a minimal Workflow from wire fields when no YAML is provided.
+            Workflow {
                 name: data.name.clone(),
                 on: super::parser::WorkflowTrigger::List(Vec::new()),
                 env: HashMap::new(),
                 jobs: HashMap::new(),
-            },
-            triggers: Vec::new(), // TODO: convert EventTrigger to EventTrigger
+            }
+        } else {
+            Workflow::parse(&data.yaml)?
+        };
+        let triggers = extract_triggers(&workflow);
+        let workflow_def = WorkflowDef {
+            path: data.path.clone(),
+            repo_id: data.repo_id.clone(),
+            workflow,
+            triggers,
         };
         let workflow_id = self.register_workflow(workflow_def).await?;
         Ok(WorkflowResponseVariant::RegisterResult(workflow_id))
@@ -564,11 +694,36 @@ impl WorkflowHandler for WorkflowService {
         _request_id: u64,
         request: &SubscribeRequest,
     ) -> AnyhowResult<WorkflowResponseVariant> {
-        // TODO: implement subscription via event handler registration
-        tracing::info!(workflow_id = %request.workflow_id, "Subscribe request (not yet implemented)");
-        Ok(WorkflowResponseVariant::SubscribeResult(
-            format!("sub-{}", request.workflow_id)
-        ))
+        // Validate the "repo_id:path" workflow_id convention up-front. An id
+        // without ':' would otherwise be used wholesale as the repo_id, routing
+        // the subscription into the wrong repo bucket.
+        let repo_id = repo_id_from_workflow_id(&request.workflow_id)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "invalid workflow_id '{}': expected 'repo_id:path' convention",
+                    request.workflow_id
+                )
+            })?
+            .to_owned();
+
+        let sub_id = format!("sub-{}-{}", request.workflow_id, uuid::Uuid::new_v4());
+        let trigger = EventTrigger::Custom {
+            topic: format!("workflow.{}", request.workflow_id),
+            pattern: String::new(),
+        };
+        let subscription = WorkflowSubscription::new(request.workflow_id.clone(), trigger);
+
+        {
+            let mut subs = self.subscriptions.write().await;
+            subs.insert(sub_id.clone(), subscription.clone());
+        }
+        {
+            let mut repo_workflows = self.repo_workflows.write().await;
+            repo_workflows.entry(repo_id).or_default().push(subscription);
+        }
+
+        tracing::info!(workflow_id = %request.workflow_id, sub_id = %sub_id, "Subscribed");
+        Ok(WorkflowResponseVariant::SubscribeResult(sub_id))
     }
 
     async fn handle_unsubscribe(
@@ -577,8 +732,29 @@ impl WorkflowHandler for WorkflowService {
         _request_id: u64,
         sub_id: &str,
     ) -> AnyhowResult<WorkflowResponseVariant> {
-        // TODO: implement unsubscription
-        tracing::info!(sub_id = %sub_id, "Unsubscribe request (not yet implemented)");
+        let removed_sub = {
+            let mut subs = self.subscriptions.write().await;
+            subs.remove(sub_id)
+        };
+        if let Some(sub) = removed_sub {
+            // Keep repo_workflows in sync: handle_subscribe pushes the same
+            // subscription into the repo bucket, so unsubscribe must remove it
+            // there too (otherwise a dead entry leaks).
+            if let Some(repo_id) = repo_id_from_workflow_id(&sub.workflow_id) {
+                let mut repo_workflows = self.repo_workflows.write().await;
+                if let Some(list) = repo_workflows.get_mut(repo_id) {
+                    if let Some(pos) = list.iter().position(|s| s.workflow_id == sub.workflow_id) {
+                        list.remove(pos);
+                    }
+                    if list.is_empty() {
+                        repo_workflows.remove(repo_id);
+                    }
+                }
+            }
+            tracing::info!(sub_id = %sub_id, "Unsubscribed");
+        } else {
+            tracing::debug!(sub_id = %sub_id, "Unsubscribe: subscription not found");
+        }
         Ok(WorkflowResponseVariant::UnsubscribeResult)
     }
 
@@ -632,4 +808,41 @@ impl RequestService for WorkflowService {
     fn signing_key(&self) -> SigningKey {
         self.signing_key.clone()
     }
+}
+
+/// Extract the `repo_id` from a `workflow_id` following the `repo_id:path`
+/// convention. Returns `None` when the id does not contain a `':'` separator.
+fn repo_id_from_workflow_id(workflow_id: &str) -> Option<&str> {
+    workflow_id.split_once(':').map(|(repo_id, _)| repo_id)
+}
+
+/// Build `EventTrigger`s from a parsed `Workflow`'s `on:` field.
+///
+/// Maps GitHub Actions event names to the closest `EventTrigger` variant.
+fn extract_triggers(workflow: &Workflow) -> Vec<EventTrigger> {
+    use super::parser::WorkflowTrigger;
+    use super::triggers::RepoEventType;
+
+    let event_names: Vec<String> = match &workflow.on {
+        WorkflowTrigger::Simple(event) => vec![event.clone()],
+        WorkflowTrigger::List(events) => events.clone(),
+        WorkflowTrigger::Complex(map) => map.keys().cloned().collect(),
+    };
+
+    event_names.iter().flat_map(|event| match event.as_str() {
+        "push" => vec![EventTrigger::RepositoryEvent { event_type: RepoEventType::Push, pattern: None }],
+        "pull_request" => vec![EventTrigger::RepositoryEvent { event_type: RepoEventType::PullRequest, pattern: None }],
+        // GitHub's `create` event fires for BOTH branch and tag creation. There
+        // is no dedicated branch-create variant in RepoEventType, so emit a Tag
+        // trigger plus a Push trigger (the closest branch-ref match) to avoid
+        // silently dropping branch-creation events.
+        "create" => vec![
+            EventTrigger::RepositoryEvent { event_type: RepoEventType::Tag, pattern: None },
+            EventTrigger::RepositoryEvent { event_type: RepoEventType::Push, pattern: None },
+        ],
+        "tag" => vec![EventTrigger::RepositoryEvent { event_type: RepoEventType::Tag, pattern: None }],
+        "workflow_dispatch" => vec![EventTrigger::WorkflowDispatch { inputs: std::collections::HashMap::new() }],
+        "schedule" | "training" => vec![EventTrigger::Custom { topic: format!("training.{event}"), pattern: String::new() }],
+        _ => vec![EventTrigger::Custom { topic: format!("repo.{event}"), pattern: String::new() }],
+    }).collect()
 }


### PR DESCRIPTION
## Summary

Extraction of #349's actual content from PR #487, which bundled it with now-dead/superseded podman+autoselect work on a stale base (`ewindisch/348-backend-autoselect`, from closed PR #486/#348). This PR carries **only** the WorkflowService changes — verified zero references to podman/BackendRegistration/selection/autoselect in the diff.

### `scan_repo()`
- Reads `.github/workflows/*.yml` from the path registered via `register_repo_path(repo_id, path)`
- Parses each file using the existing `Workflow::parse()`
- Calls `extract_triggers()` to map `on:` event names → `EventTrigger` variants
- Returns `Vec<WorkflowDef>`; empty Vec (not error) if path unregistered or dir absent

### YAML round-trip
- `handle_scan_repo` now serializes `wf.workflow` back via `serde_yaml::to_string()` into `WorkflowDefWire.yaml`

### subscribe/unsubscribe
- `subscriptions: RwLock<HashMap<String, WorkflowSubscription>>` tracks active subs
- `handle_subscribe` generates a `sub-<workflow_id>-<ts-tid>` ID, inserts into both maps
- `handle_unsubscribe` removes by sub_id

### Event routing
- `start()` now subscribes to `worker.`, `repo.`, `training.`, `metrics.` prefixes (was only `worker.`)

### initialize()
- Now calls `rescan_repo()` for all registered repos on startup

## Provenance

- Original work: #487 (stacked on closed #486/#348)
- Rebased onto `ewindisch/workers-engines-recut` (#599) per 1:1.0 — confirmed this content has no coupling to the backend-selection/podman work that lives on separate stacked branches (#617, in-flight #348-v2)
- Patch applied cleanly (no conflicts) against current `workers-engines-recut`

## Test plan
- [x] `cargo build -p hyprstream-workers` clean
- [x] `cargo test -p hyprstream-workers --lib workflow::` — 22/22 passed
- [x] `cargo clippy -p hyprstream-workers --all-targets` clean

Closes #349. Part of epic #341.