### PR TITLE
ci(appimage): strip libtorch, gate GPU variants to tags, local-disk sccache

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -9,8 +9,15 @@ on:
 env:
   CARGO_TERM_COLOR: always
   LIBTORCH_VERSION: "2.10.0"
-  SCCACHE_GHA_ENABLED: "true"
+  # sccache uses its LOCAL-DISK backend here (not the GHA cache). The value of sccache
+  # in this workflow is intra-run: all variants build the identical Rust code (only the
+  # libtorch backend differs), so variants 2..N reuse variant 1's compiled crates from
+  # the runner's local disk. That needs no GHA cache — enabling SCCACHE_GHA_ENABLED just
+  # spammed the 10GB repo cache with tens of thousands of tiny objects and gained nothing
+  # across runs (fresh runner each time). Cross-run Rust caching lives in rust.yml.
   RUSTC_WRAPPER: "sccache"
+  SCCACHE_DIR: "/home/runner/.cache/sccache"
+  SCCACHE_CACHE_SIZE: "20G"
 
 jobs:
   # Build all backend variants sequentially on a single runner
@@ -45,10 +52,9 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      # Installs the sccache binary; local-disk backend is selected via env (no GHA).
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
-        with:
-          key: appimage-sccache
 
       - name: Cache Cargo registry
         uses: actions/cache@v4
@@ -82,13 +88,18 @@ jobs:
           path: appimage/output/*-cpu-*.AppImage
           retention-days: 5
 
+      # Heavy GPU variants + universal build only on release tags. On push-to-main we
+      # ship just the CPU AppImage — building all 5 every push cost ~70min and produced
+      # ~11GB of artifacts that only matter for releases.
       - name: Build CUDA 12.8 AppImage
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           ./appimage/build-appimage.sh build cuda128 --version ${{ steps.version.outputs.version }}
           ./appimage/build-appimage.sh stage cuda128
           ./appimage/build-appimage.sh clean cuda128
 
       - name: Upload CUDA 12.8 AppImage
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v4
         with:
           name: appimage-cuda128
@@ -96,12 +107,14 @@ jobs:
           retention-days: 5
 
       - name: Build CUDA 13.0 AppImage
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           ./appimage/build-appimage.sh build cuda130 --version ${{ steps.version.outputs.version }}
           ./appimage/build-appimage.sh stage cuda130
           ./appimage/build-appimage.sh clean cuda130
 
       - name: Upload CUDA 13.0 AppImage
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v4
         with:
           name: appimage-cuda130
@@ -109,12 +122,14 @@ jobs:
           retention-days: 5
 
       - name: Build ROCm 7.1 AppImage
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           ./appimage/build-appimage.sh build rocm71 --version ${{ steps.version.outputs.version }}
           ./appimage/build-appimage.sh stage rocm71
           ./appimage/build-appimage.sh clean rocm71
 
       - name: Upload ROCm 7.1 AppImage
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v4
         with:
           name: appimage-rocm71
@@ -122,10 +137,12 @@ jobs:
           retention-days: 5
 
       - name: Build Universal AppImage
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           ./appimage/build-appimage.sh build universal --version ${{ steps.version.outputs.version }}
 
       - name: Upload Universal AppImage
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v4
         with:
           name: appimage-universal

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -137,6 +137,23 @@ build_binary() {
     log_success "Built hyprstream-$variant"
 }
 
+# Strip host symbol tables from bundled libtorch shared objects.
+# libtorch ships its .so files unstripped; --strip-unneeded removes the symbol table
+# while preserving the dynamic symbols needed for loading/relocation, so runtime
+# behavior (including dlopen of backend libs) is unaffected. GPU device fatbinaries are
+# not touched. Best-effort: any file that can't be stripped is left as-is.
+# NOTE: validate a stripped GPU build actually runs inference before cutting a release.
+strip_libtorch_libs() {
+    local lib_dir="$1"
+    command -v strip &>/dev/null || { log_info "strip not found; skipping"; return 0; }
+    local before after
+    before=$(du -sm "$lib_dir" 2>/dev/null | cut -f1)
+    find "$lib_dir" -type f \( -name '*.so' -o -name '*.so.*' \) -print0 \
+        | xargs -0 -r -n1 strip --strip-unneeded 2>/dev/null || true
+    after=$(du -sm "$lib_dir" 2>/dev/null | cut -f1)
+    log_info "Stripped libtorch libs in $lib_dir: ${before}MB -> ${after}MB"
+}
+
 # Create per-backend AppImage
 create_appimage() {
     local variant="$1"
@@ -151,6 +168,7 @@ create_appimage() {
     cp "$BUILD_DIR/bin/hyprstream-$variant" "$appdir/usr/bin/hyprstream"
     # Copy entire lib directory (includes subdirs with Tensile libraries for ROCm)
     cp -r "$LIBTORCH_CACHE_DIR/$variant/libtorch/lib/"* "$appdir/usr/lib/libtorch/lib/"
+    strip_libtorch_libs "$appdir/usr/lib/libtorch/lib"
 
     sed "s/HYPRSTREAM_VARIANT:-cpu/HYPRSTREAM_VARIANT:-$variant/" \
         "$SCRIPT_DIR/AppRun-single" > "$appdir/AppRun"
@@ -187,6 +205,8 @@ create_universal_appimage() {
             cp -r "$LIBTORCH_CACHE_DIR/$variant/libtorch/lib/"* "$appdir/usr/lib/$variant/libtorch/lib/"
         fi
     done
+
+    strip_libtorch_libs "$appdir/usr/lib"
 
     cp "$SCRIPT_DIR/AppRun" "$appdir/"
     chmod +x "$appdir/AppRun"


### PR DESCRIPTION
Follow-up to #625 (cache-hit fix). Independent AppImage/build-size improvements identified from the AppImage build logs.

## Context (from latest build logs)
| Variant | Size | Compression |
|---|---|---|
| CPU | 209 MB | 22% |
| CUDA 12.8 | 3.5 GB | 57% |
| CUDA 13.0 | 1.8 GB | 56% |
| ROCm 7.1 | 4.9 GB | ~50% |
| **Universal** | **~11 GB** | (all four combined) |

The workflow built **all 5 variants on every push to `main`** (~70 min/run) and used the sccache **GHA backend**, which was a primary contributor to the 12k-object / 10 GB cache explosion cleaned up alongside #625.

## Changes

1. **Strip bundled libtorch `.so`** — the packaging script copied them verbatim; libtorch ships unstripped. `strip --strip-unneeded` drops host symbol tables while keeping the dynamic symbols needed for loading (GPU fatbinaries untouched). Logs before/after size per variant.
   - ⚠️ **Needs validation**: confirm a stripped GPU build still runs inference before the next release. If any backend misbehaves, downgrade that path to `--strip-debug`.
2. **Gate heavy variants to release tags** — push-to-`main` now builds only the CPU AppImage; CUDA 12.8/13.0, ROCm 7.1, and the universal image build only on `v*` tags (where the `release` job consumes them). Big CI-time + artifact-storage savings on routine main pushes.
3. **Local-disk sccache** (drop `SCCACHE_GHA_ENABLED`) — the sccache benefit here is *intra-run*: all variants compile identical Rust (only the libtorch backend differs), so variants 2..N reuse variant 1's crates from the runner's local disk. That needs no GHA cache; enabling it just spammed the repo cache for zero cross-run gain (fresh runner each run). Cross-run Rust caching stays in `rust.yml` (#625).

## Not changed
- Local developer sccache is untouched (it's the local-disk backend and genuinely helps across worktrees).
- Whether to ship a "universal" image at all is left as an open question — per-backend images already cover every case.