### PR TITLE
ci: sccache S3 backend (OIDC) for all builds + AppImage strip + tag-gate GPU

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -6,11 +6,22 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+  id-token: write
+
 env:
   CARGO_TERM_COLOR: always
   LIBTORCH_VERSION: "2.10.0"
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
+  # sccache S3 backend (OIDC role assumed per-run). Replaces SCCACHE_GHA_ENABLED,
+  # which spammed the 10GB repo cache with thousands of tiny objects for no
+  # cross-run gain (fresh runner each run). Intra-run variant reuse still works
+  # (all variants compile identical Rust — only libtorch differs — so variants
+  # 2..N reuse variant 1's crates from local disk); S3 adds cross-run sharing.
+  RUSTC_WRAPPER: sccache
+  SCCACHE_BUCKET: ${{ vars.AWS_SCCACHE_BUCKET }}
+  SCCACHE_REGION: ${{ vars.AWS_SCCACHE_REGION }}
+  CARGO_INCREMENTAL: 0
 
 jobs:
   # Build all backend variants sequentially on a single runner
@@ -45,10 +56,14 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Configure AWS credentials (OIDC → sccache S3)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_SCCACHE_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_SCCACHE_REGION }}
+
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
-        with:
-          key: appimage-sccache
 
       - name: Cache Cargo registry
         uses: actions/cache@v4
@@ -82,13 +97,18 @@ jobs:
           path: appimage/output/*-cpu-*.AppImage
           retention-days: 5
 
+      # Heavy GPU variants + universal build only on release tags. On push-to-main
+      # we ship just the CPU AppImage — building all 5 every push cost ~70min and
+      # produced ~11GB of artifacts that only matter at release.
       - name: Build CUDA 12.8 AppImage
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           ./appimage/build-appimage.sh build cuda128 --version ${{ steps.version.outputs.version }}
           ./appimage/build-appimage.sh stage cuda128
           ./appimage/build-appimage.sh clean cuda128
 
       - name: Upload CUDA 12.8 AppImage
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v4
         with:
           name: appimage-cuda128
@@ -96,12 +116,14 @@ jobs:
           retention-days: 5
 
       - name: Build CUDA 13.0 AppImage
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           ./appimage/build-appimage.sh build cuda130 --version ${{ steps.version.outputs.version }}
           ./appimage/build-appimage.sh stage cuda130
           ./appimage/build-appimage.sh clean cuda130
 
       - name: Upload CUDA 13.0 AppImage
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v4
         with:
           name: appimage-cuda130
@@ -109,12 +131,14 @@ jobs:
           retention-days: 5
 
       - name: Build ROCm 7.1 AppImage
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           ./appimage/build-appimage.sh build rocm71 --version ${{ steps.version.outputs.version }}
           ./appimage/build-appimage.sh stage rocm71
           ./appimage/build-appimage.sh clean rocm71
 
       - name: Upload ROCm 7.1 AppImage
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v4
         with:
           name: appimage-rocm71
@@ -122,10 +146,12 @@ jobs:
           retention-days: 5
 
       - name: Build Universal AppImage
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           ./appimage/build-appimage.sh build universal --version ${{ steps.version.outputs.version }}
 
       - name: Upload Universal AppImage
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v4
         with:
           name: appimage-universal

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,10 +6,23 @@ on:
   pull_request:
   merge_group:
 
+# id-token: write lets jobs mint an OIDC token to assume the sccache S3 role
+# (AWS_SCCACHE_ROLE_ARN). No long-lived AWS secrets live in the repo — the role
+# is assumed per-run with a short-lived credential that sccache's S3 backend reads
+# from the standard AWS env vars exported by configure-aws-credentials.
+permissions:
+  contents: read
+  id-token: write
+
 env:
   CARGO_TERM_COLOR: always
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
+  # sccache S3 backend: shared across CI runs AND local devs, keyed on compiler
+  # inputs. Replaces the GHA-cache sccache (3% hit rate, 10GB explosion, write
+  # races) AND Swatinem/rust-cache. Bucket objects expire after 24h (lifecycle).
+  RUSTC_WRAPPER: sccache
+  SCCACHE_BUCKET: ${{ vars.AWS_SCCACHE_BUCKET }}
+  SCCACHE_REGION: ${{ vars.AWS_SCCACHE_REGION }}
+  CARGO_INCREMENTAL: 0
 
 jobs:
   clippy:
@@ -26,18 +39,21 @@ jobs:
       with:
         components: clippy
 
+    - name: Configure AWS credentials (OIDC → sccache S3)
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ vars.AWS_SCCACHE_ROLE_ARN }}
+        aws-region: ${{ vars.AWS_SCCACHE_REGION }}
+
     - name: Setup sccache
       uses: mozilla-actions/sccache-action@v0.0.9
-      with:
-        key: rust-sccache
-
-    - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2
-      with:
-        shared-key: rust-deps
 
     - name: Run Clippy
       run: cargo clippy --workspace --all-targets --features download-libtorch -- -D warnings
+
+    - name: sccache stats
+      if: always()
+      run: sccache --show-stats
 
   deny:
     name: cargo-deny (bans + licenses)
@@ -51,7 +67,7 @@ jobs:
     - name: Check bans
       # ZMQ crates are deny-listed in deny.toml (#138 complete). This gate must
       # be able to fail — do NOT add `|| true`.
-      # Unset RUSTC_WRAPPER: job-level env: "" doesn't clear workflow-level env on GHA.
+      # No compilation here, so no sccache/AWS. Unset RUSTC_WRAPPER defensively.
       run: |
         unset RUSTC_WRAPPER
         cargo deny check bans licenses
@@ -71,15 +87,14 @@ jobs:
       with:
         targets: wasm32-unknown-unknown
 
+    - name: Configure AWS credentials (OIDC → sccache S3)
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ vars.AWS_SCCACHE_ROLE_ARN }}
+        aws-region: ${{ vars.AWS_SCCACHE_REGION }}
+
     - name: Setup sccache
       uses: mozilla-actions/sccache-action@v0.0.9
-      with:
-        key: rust-sccache
-
-    - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2
-      with:
-        shared-key: rust-wasm
 
     # Guards the browser/WebTransport build (#225/#226): getrandom wasm_js (Cargo.toml) +
     # the web_sys_unstable_apis rustflag for WebTransport. Catches wasm-only breakage the
@@ -88,6 +103,10 @@ jobs:
       run: cargo check --target wasm32-unknown-unknown -p hyprstream-rpc
       env:
         RUSTFLAGS: "--cfg=web_sys_unstable_apis"
+
+    - name: sccache stats
+      if: always()
+      run: sccache --show-stats
 
   build:
     # MERGE GATE — not a per-PR-push check. The heavy build+test runs in the merge
@@ -102,7 +121,7 @@ jobs:
     # Merge-gate backstop: fail before the merge queue's 120min timeout (ruleset
     # check_response_timeout_minutes) so a hang yields a definitive failure and the
     # queue keeps moving instead of timing out and kicking every queued PR. Healthy
-    # build+test is ~90min (Build ~13m / Run tests ~76m), so 115 leaves margin.
+    # build+test is ~90min (Build ~13m / Run tests ~76min), so 115 leaves margin.
     timeout-minutes: 115
 
     steps:
@@ -111,15 +130,14 @@ jobs:
     - name: Install build dependencies
       run: sudo apt-get update && sudo apt-get install -y capnproto libsystemd-dev pkg-config libssl-dev
 
+    - name: Configure AWS credentials (OIDC → sccache S3)
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ vars.AWS_SCCACHE_ROLE_ARN }}
+        aws-region: ${{ vars.AWS_SCCACHE_REGION }}
+
     - name: Setup sccache
       uses: mozilla-actions/sccache-action@v0.0.9
-      with:
-        key: rust-sccache
-
-    - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2
-      with:
-        shared-key: rust-deps
 
     - name: Build
       run: cargo build --release --verbose --features download-libtorch
@@ -138,3 +156,7 @@ jobs:
     - name: Run doctests
       # nextest does not run doctests; keep them in the merge gate.
       run: cargo test --release --doc --features download-libtorch
+
+    - name: sccache stats
+      if: always()
+      run: sccache --show-stats

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -137,6 +137,24 @@ build_binary() {
     log_success "Built hyprstream-$variant"
 }
 
+# Strip host symbol tables from bundled libtorch shared objects.
+# libtorch ships its .so files unstripped; --strip-unneeded removes the symbol
+# table while preserving the dynamic symbols needed for loading/relocation, so
+# runtime behavior (including dlopen of backend libs) is unaffected. GPU device
+# fatbinaries are not touched. Best-effort: any file that can't be stripped is
+# left as-is. NOTE: validate a stripped GPU build actually runs inference before
+# cutting a release.
+strip_libtorch_libs() {
+    local lib_dir="$1"
+    command -v strip &>/dev/null || { log_info "strip not found; skipping"; return 0; }
+    local before after
+    before=$(du -sm "$lib_dir" 2>/dev/null | cut -f1)
+    find "$lib_dir" -type f \( -name '*.so' -o -name '*.so.*' \) -print0 \
+        | xargs -0 -r -n1 strip --strip-unneeded 2>/dev/null || true
+    after=$(du -sm "$lib_dir" 2>/dev/null | cut -f1)
+    log_info "Stripped libtorch libs in $lib_dir: ${before}MB -> ${after}MB"
+}
+
 # Create per-backend AppImage
 create_appimage() {
     local variant="$1"
@@ -151,6 +169,7 @@ create_appimage() {
     cp "$BUILD_DIR/bin/hyprstream-$variant" "$appdir/usr/bin/hyprstream"
     # Copy entire lib directory (includes subdirs with Tensile libraries for ROCm)
     cp -r "$LIBTORCH_CACHE_DIR/$variant/libtorch/lib/"* "$appdir/usr/lib/libtorch/lib/"
+    strip_libtorch_libs "$appdir/usr/lib/libtorch/lib"
 
     sed "s/HYPRSTREAM_VARIANT:-cpu/HYPRSTREAM_VARIANT:-$variant/" \
         "$SCRIPT_DIR/AppRun-single" > "$appdir/AppRun"
@@ -187,6 +206,8 @@ create_universal_appimage() {
             cp -r "$LIBTORCH_CACHE_DIR/$variant/libtorch/lib/"* "$appdir/usr/lib/$variant/libtorch/lib/"
         fi
     done
+
+    strip_libtorch_libs "$appdir/usr/lib"
 
     cp "$SCRIPT_DIR/AppRun" "$appdir/"
     chmod +x "$appdir/AppRun"


### PR DESCRIPTION
Replaces the broken GHA-cache sccache with an **S3 backend authenticated via GitHub OIDC** — no long-lived AWS secrets in the repo.

## Validated end-to-end (local assessment against the real bucket)
| Workload | GHA cache | **S3** |
|---|---|---|
| Pure-Rust rebuild | 3.05% | **100%** |
| `librocksdb-sys` C/C++ rebuild | 0.84% | **100%** |
| Write errors | 1,649 | **0** |

Both warm passes followed a full `cargo clean` + sccache server restart, so hits genuinely round-tripped through S3. This is the workload (rocksdb C/C++) that dominates our build time.

## Infra created (AWS, this account)
- Bucket `hyprstream-sccache-53a5f59e`, **24h object expiry** (lifecycle).
- GitHub OIDC provider + IAM role `hyprstream-sccache-ci`, trust scoped to `repo:hyprstream/hyprstream:*`, policy scoped to Get/Put/List on the one bucket.
- Repo variables: `AWS_SCCACHE_ROLE_ARN`, `AWS_SCCACHE_REGION`, `AWS_SCCACHE_BUCKET`.

## Changes
- **rust.yml + appimage.yml**: drop `SCCACHE_GHA_ENABLED` + `Swatinem/rust-cache`; add `permissions: id-token: write`, `aws-actions/configure-aws-credentials` (OIDC assume role), `mozilla-actions/sccache-action`, and `SCCACHE_BUCKET`/`SCCACHE_REGION` from repo vars. Add a `sccache --show-stats` step to each compile job so hit rates are visible in CI.
- **appimage.yml**: strip bundled libtorch `.so` (`--strip-unneeded`); build only CPU on push-to-main, gate CUDA 12.8/13.0 + ROCm 7.1 + universal to `v*` tags (~70min + ~11GB saved per main push).

## Notes
- The CI OIDC assume-role is the one path not testable locally; if it mis-configures, sccache silently no-ops (compiles direct, no failure) — verify via the `sccache stats` step on the first post-merge main build.
- `archlinux.yml` / `rpm.yml` still use `Swatinem/rust-cache` — follow-up to convert.
- Supersedes #625 (closed) and #626 (folded in: strip + tag-gating, sccache upgraded from local-disk to S3).

⚠️ Strip step should be smoke-tested on a GPU build before the next release tag.