### PR TITLE
feat(#633): image filesystem service composes into the 9P VFS namespace

### DIFF
--- a/crates/hyprstream-workers/Cargo.toml
+++ b/crates/hyprstream-workers/Cargo.toml
@@ -65,9 +65,11 @@ inventory = { workspace = true }
 # D-Bus integration (optional, for container D-Bus proxy)
 zbus = { version = "4", features = ["tokio"], optional = true }
 
-# Nydus libraries (Dragonfly-native blob fetching) — gated behind `kata-vm`.
-# Only the RAFS image-pull + virtiofs path (consumed by the Kata/CH VM backend)
-# needs these; the lightweight nspawn backend bind-mounts the host root.
+# Nydus libraries (Dragonfly-native blob fetching) — gated behind `oci-image`.
+# These power the universal mountable OCI/RAFS image filesystem service
+# (`ImageFs` = OverlayFs-over-in-process-RAFS, an `FsMount`). Any backend that
+# composes an image filesystem (kata virtio-fs today; podman/nspawn/wasm are
+# follow-ons, see #633) needs these; the lightweight host-root backends do not.
 #
 # Crates.io availability (verified 2026-06-26 against dragonflyoss/nydus v2.4.0):
 #   nydus-api     0.4.1  — ON crates.io, but mixed with git siblings causes type
@@ -117,7 +119,10 @@ blake3 = { workspace = true }
 rand = { workspace = true }
 zeroize = { workspace = true }
 
-# Kata Containers runtime-rs (hypervisor abstraction) — gated behind `kata-vm`.
+# Kata Containers runtime-rs (hypervisor abstraction) — the VM toolchain only.
+# Gated behind `kata-vm` (which implies `oci-image` for the RAFS image service
+# kata serves via virtio-fs). The image filesystem service itself no longer
+# requires these.
 kata-hypervisor = { git = "https://github.com/kata-containers/kata-containers", tag = "3.31.0", package = "hypervisor", features = ["cloud-hypervisor"], optional = true }
 kata-types = { git = "https://github.com/kata-containers/kata-containers", tag = "3.31.0", optional = true }
 kata-sys-util = { git = "https://github.com/kata-containers/kata-containers", tag = "3.31.0", optional = true }
@@ -125,16 +130,14 @@ ch-config = { git = "https://github.com/kata-containers/kata-containers", tag = 
 
 [features]
 default = []
-# Kata/Cloud-Hypervisor VM backend + the RAFS/nydus image-pull + virtiofs
-# toolchain it consumes. Opt-in so casual users who only want the lightweight
-# `systemd-nspawn` backend don't compile the entire VM stack. When this feature
-# is off, `BackendType::Kata` selection and CRI image ops return a clean
-# runtime error rather than failing to compile.
-kata-vm = [
-    "dep:kata-hypervisor",
-    "dep:kata-types",
-    "dep:kata-sys-util",
-    "dep:ch-config",
+# Universal mountable OCI/RAFS image filesystem service (#633, spine of #508).
+# Compiles the `image` module — `RafsStore` (OCI pull + RAFS CAS) and `ImageFs`
+# (an `FsMount` = OverlayFs over an in-process RAFS lower + per-sandbox writable
+# upper) — independent of any VM toolchain. "Root" is a mount position, not a
+# type: an `ImageFs` mounted at `/` is the root purely because the namespace
+# recipe mounted it there. Any backend can compose this; kata does so today via
+# virtio-fs, podman/nspawn/wasm rewiring is a follow-on (TODO, #633).
+oci-image = [
     "dep:nydus-api",
     "dep:nydus-storage",
     "dep:nydus-builder",
@@ -142,6 +145,19 @@ kata-vm = [
     "dep:nydus-utils",
     "dep:nydus-service",
     "dep:fuse-backend-rs",
+]
+# Kata/Cloud-Hypervisor VM backend. Implies `oci-image` (kata serves the
+# universal image filesystem service to its guest via virtio-fs) and adds the
+# VM toolchain (kata hypervisor + the FS-A vhost-user-fs server). Opt-in so
+# casual users who only want the lightweight `systemd-nspawn` backend don't
+# compile the VM stack. When this feature is off, `BackendType::Kata` selection
+# and CRI image ops return a clean runtime error rather than failing to compile.
+kata-vm = [
+    "oci-image",
+    "dep:kata-hypervisor",
+    "dep:kata-types",
+    "dep:kata-sys-util",
+    "dep:ch-config",
     "dep:hyprstream-vfs-server",
 ]
 # In-process WebAssembly sandbox backend (#505 P2). Compiles in `WasmBackend`

--- a/crates/hyprstream-workers/src/image/image_fs.rs
+++ b/crates/hyprstream-workers/src/image/image_fs.rs
@@ -1,7 +1,7 @@
-//! Per-sandbox **RootfsMount** (FS-B, #363).
+//! **ImageFs** — a universal mountable OCI/RAFS image filesystem service (#633,
+//! spine of epic #508).
 //!
-//! Builds the rootfs filesystem for a sandbox as an
-//! [`FsMount`](hyprstream_vfs::FsMount): an `OverlayFs` whose
+//! An `ImageFs` is an [`FsMount`](hyprstream_vfs::FsMount): an `OverlayFs` whose
 //!
 //! - **lower** is the image's RAFS loaded **in-process** as a
 //!   `fuse_backend_rs::FileSystem` (via `nydus-rafs`'s [`Rafs`], which also
@@ -10,6 +10,12 @@
 //!   nothing is materialised on disk up front; and
 //! - **upper** is a per-sandbox writable directory (the copy-up / whiteout
 //!   target), so writes never touch the shared image.
+//!
+//! "Root" is a mount position, not a type: an `ImageFs` mounted at `/` is the
+//! root purely because the namespace recipe mounted it there. Any backend can
+//! compose one — kata serves it to its guest via virtio-fs today, and
+//! podman/nspawn/wasm wiring is a follow-on (TODO, #633). This module compiles
+//! under the `oci-image` feature alone, with no VM toolchain required.
 //!
 //! Composition is delegated to FS-C's
 //! [`rootfs_overlay`](hyprstream_vfs::overlay::rootfs_overlay) — copy-on-write,
@@ -20,7 +26,7 @@
 //! `FsMount` trait with zero churn here.
 //!
 //! ```text
-//!            RootfsMount  (FsMount)
+//!            ImageFs  (FsMount)
 //!                 │
 //!         OverlayFs (FS-C rootfs_overlay)
 //!          ┌──────┴──────┐
@@ -49,6 +55,16 @@ use hyprstream_vfs::overlay::{layer_from_fs, rootfs_overlay};
 use hyprstream_vfs::{FsMount, FuseFileSystemMount, ZeroOpenLayer};
 
 use crate::error::{Result, WorkerError};
+
+/// The concrete type of a mountable OCI/RAFS image filesystem service.
+///
+/// An `OverlayFs` (FS-C's production overlay) over an in-process RAFS lower and
+/// a per-sandbox writable upper. This is what [`image_fs_for`] /
+/// [`RafsStore::image_fs`](crate::image::RafsStore::image_fs) build; it
+/// implements [`FsMount`], so a backend composes it into a namespace at whatever
+/// mount position it chooses (at `/` it is the root purely by virtue of the
+/// mount). "Root" is a mount position, not a type.
+pub type ImageFs = FuseFileSystemMount<OverlayFs>;
 
 /// Subdirectory under a sandbox dir holding the writable rootfs overlay state.
 const ROOTFS_SUBDIR: &str = "rootfs";
@@ -136,30 +152,30 @@ fn prepare_upper(sandbox_dir: &Path) -> Result<(PathBuf, PathBuf)> {
     Ok((upper, work))
 }
 
-/// Build a sandbox **RootfsMount** from an already-loaded RAFS lower and explicit
+/// Build an [`ImageFs`] from an already-loaded RAFS lower and explicit
 /// upper/work directories.
 ///
 /// The lowest-level constructor: callers that hold a [`Rafs`] (e.g. tests, or a
 /// future caller that loaded RAFS itself) compose it here. Wraps the RAFS as the
 /// single read-only overlay lower and `upper` as the writable layer via FS-C's
 /// [`rootfs_overlay`].
-pub fn rootfs_mount_from_rafs(
+pub fn image_fs_from_rafs(
     rafs: Rafs,
     upper: &Path,
     work: &Path,
 ) -> Result<FuseFileSystemMount<OverlayFs>> {
     let upper_layer = hyprstream_vfs::overlay::passthrough_layer(upper)
-        .map_err(|e| WorkerError::RafsError(format!("rootfs upper layer: {e}")))?;
+        .map_err(|e| WorkerError::RafsError(format!("image-fs upper layer: {e}")))?;
     // The RAFS `Rafs` implements `Layer`, but it is *handleless* (`open` yields
     // no handle), which OverlayFs rejects as ENOENT for a lower. Wrap it in
     // `ZeroOpenLayer` so it presents a constant handle; reads still resolve by
     // inode and writes copy-up to the (handle-based) upper.
     let lower_layer = layer_from_fs(ZeroOpenLayer::new(rafs));
     rootfs_overlay(upper_layer, vec![lower_layer], work)
-        .map_err(|e| WorkerError::RafsError(format!("rootfs overlay: {e}")))
+        .map_err(|e| WorkerError::RafsError(format!("image-fs overlay: {e}")))
 }
 
-/// Build a sandbox **RootfsMount** for `image_id`.
+/// Build an [`ImageFs`] for `image_id`.
 ///
 /// * `bootstrap_path` — the image's RAFS bootstrap (`.meta`).
 /// * `blobs_dir` — the image store's blobs directory (RAFS data blobs).
@@ -167,11 +183,12 @@ pub fn rootfs_mount_from_rafs(
 /// * `sandbox_dir` — the per-sandbox directory; the writable upper + work dirs
 ///   are created under `<sandbox_dir>/rootfs/`.
 ///
-/// Returns the rootfs [`FsMount`]: the RAFS image is the read-only lower, a
+/// Returns the image [`FsMount`]: the RAFS image is the read-only lower, a
 /// per-sandbox directory is the writable upper, composed via `OverlayFs`. The
 /// shared image (RAFS bootstrap + blobs) is never written to — copy-ups and
-/// whiteouts land in the upper.
-pub fn rootfs_mount_for(
+/// whiteouts land in the upper. Mount it wherever the namespace recipe chooses;
+/// at `/` it is the root purely by virtue of the mount position.
+pub fn image_fs_for(
     bootstrap_path: &Path,
     blobs_dir: &Path,
     image_id: &str,
@@ -179,18 +196,18 @@ pub fn rootfs_mount_for(
 ) -> Result<impl FsMount> {
     let rafs = load_rafs_lower(bootstrap_path, blobs_dir, image_id)?;
     let (upper, work) = prepare_upper(sandbox_dir)?;
-    rootfs_mount_from_rafs(rafs, &upper, &work)
+    image_fs_from_rafs(rafs, &upper, &work)
 }
 
 impl crate::image::RafsStore {
-    /// Build the rootfs [`FsMount`] for an image into a per-sandbox directory.
+    /// Build the image [`FsMount`] for an image into a per-sandbox directory.
     ///
     /// Resolves the image's RAFS bootstrap and blobs from this store, loads the
     /// RAFS in-process as the read-only lower, and overlays a per-sandbox
-    /// writable upper under `<sandbox_dir>/rootfs/`. See [`rootfs_mount_for`].
-    pub fn rootfs_mount(&self, image_id: &str, sandbox_dir: &Path) -> Result<impl FsMount> {
+    /// writable upper under `<sandbox_dir>/rootfs/`. See [`image_fs_for`].
+    pub fn image_fs(&self, image_id: &str, sandbox_dir: &Path) -> Result<impl FsMount> {
         let bootstrap = self.bootstrap_path(image_id);
-        rootfs_mount_for(&bootstrap, self.blobs_dir(), image_id, sandbox_dir)
+        image_fs_for(&bootstrap, self.blobs_dir(), image_id, sandbox_dir)
     }
 }
 
@@ -286,7 +303,7 @@ mod tests {
         let before = blobs_snapshot(&blobs_dir);
 
         let sandbox = tmp.path().join("sandbox-1");
-        let mount = rootfs_mount_for(&bootstrap, &blobs_dir, "img:test", &sandbox).unwrap();
+        let mount = image_fs_for(&bootstrap, &blobs_dir, "img:test", &sandbox).unwrap();
         let subj = Subject::new("test");
 
         // 1. Read a file present only in the RAFS lower.
@@ -349,7 +366,7 @@ mod tests {
         std::fs::create_dir_all(&blobs).unwrap();
         let bootstrap = tmp.path().join("nope.meta");
         let sandbox = tmp.path().join("sandbox");
-        let err = rootfs_mount_for(&bootstrap, &blobs, "img:missing", &sandbox);
+        let err = image_fs_for(&bootstrap, &blobs, "img:missing", &sandbox);
         assert!(err.is_err(), "missing RAFS bootstrap must hard-error");
     }
 }

--- a/crates/hyprstream-workers/src/image/mod.rs
+++ b/crates/hyprstream-workers/src/image/mod.rs
@@ -35,10 +35,11 @@ mod manifest;
 // `pub(crate)` so sibling-module tests (e.g. runtime::sandbox_fs, FS-D #365)
 // can synthesize RAFS images. The builder fn stays crate-internal.
 pub(crate) mod rafs_builder;
-// FS-B (#363): per-sandbox RootfsMount = OverlayFs(in-process RAFS lower +
+// #633 (spine of #508): the universal mountable OCI/RAFS image filesystem
+// service — `ImageFs`, an `FsMount` = OverlayFs(in-process RAFS lower +
 // writable upper). Native-only (the overlay/RAFS FileSystem stack is Linux).
 #[cfg(not(target_arch = "wasm32"))]
-mod rootfs_mount;
+mod image_fs;
 mod store;
 
 pub use crate::generated::worker_client::{
@@ -47,5 +48,5 @@ pub use crate::generated::worker_client::{
 };
 pub use manifest::{ImageReference, ManifestFetcher, ManifestResult, OciManifest};
 #[cfg(not(target_arch = "wasm32"))]
-pub use rootfs_mount::{rootfs_mount_for, rootfs_mount_from_rafs};
+pub use image_fs::{image_fs_for, image_fs_from_rafs, ImageFs};
 pub use store::{GcStats, ImageMetadata, RafsStore};

--- a/crates/hyprstream-workers/src/lib.rs
+++ b/crates/hyprstream-workers/src/lib.rs
@@ -51,10 +51,11 @@ pub mod error;
 pub use hyprstream_rpc::paths;
 
 pub mod runtime;
-// The `image` module is the RAFS/nydus image store — only the VM path consumes
-// it. Gated behind `kata-vm`; the lightweight nspawn backend bind-mounts the
-// host root and never touches RAFS.
-#[cfg(feature = "kata-vm")]
+// The `image` module is the universal mountable OCI/RAFS image filesystem
+// service (#633): `RafsStore` + `ImageFs` (an `FsMount`). Any backend that
+// composes an image filesystem consumes it; it no longer requires the VM
+// toolchain. Gated behind `oci-image` (which `kata-vm` implies).
+#[cfg(feature = "oci-image")]
 pub mod image;
 pub mod workflow;
 pub mod events;
@@ -72,7 +73,7 @@ pub use runtime::{WorkerService, SandboxBackend, SandboxHandle, NspawnBackend, N
 pub use runtime::{resolve_backend, BackendCtx, BackendRegistration};
 #[cfg(feature = "kata-vm")]
 pub use runtime::KataBackend;
-#[cfg(feature = "kata-vm")]
+#[cfg(feature = "oci-image")]
 pub use image::RafsStore;
 pub use workflow::WorkflowService;
 pub use events::{

--- a/crates/hyprstream-workers/src/runtime/sandbox_fs.rs
+++ b/crates/hyprstream-workers/src/runtime/sandbox_fs.rs
@@ -2,19 +2,19 @@
 //!
 //! This is the end-to-end integration that ties FS-A/FS-B/FS-C together for the
 //! Worker GA filesystem: for **each** sandbox it builds a private VFS
-//! [`Namespace`], composes the rootfs + injected mounts into it, and serves it
-//! over a per-sandbox Unix socket that the Cloud Hypervisor guest attaches as a
-//! virtio-fs ShareFs device.
+//! [`Namespace`], composes the image filesystem + injected mounts into it, and
+//! serves it over a per-sandbox Unix socket that the Cloud Hypervisor guest
+//! attaches as a virtio-fs ShareFs device.
 //!
 //! ```text
 //!   per-sandbox flow (one per sandbox, fully isolated)
 //!
 //!   RafsStore (shared, RO)         injected mounts (per-sandbox)
 //!        │                          /stream  (StreamMount)
-//!   rootfs_mount_for(...)  ──┐      /models  (SyntheticMount)
-//!   (FS-B: RAFS lower +      │      /deltas  (SyntheticMount)
-//!    per-sandbox writable    │          │
-//!    upper, OverlayFs)       ▼          ▼
+//!   image_fs_for(...)      ──┐      /models  (SyntheticMount)
+//!   (ImageFs: RAFS lower +  │      /deltas  (SyntheticMount)
+//!    per-sandbox writable   │          │
+//!    upper, OverlayFs)      ▼          ▼
 //!                       Namespace::fork() + bind_mount  (FS-C)
 //!                              │  bound to this sandbox's Subject
 //!                              ▼
@@ -51,7 +51,7 @@ use hyprstream_vfs::{Mount, Namespace, Subject};
 use hyprstream_vfs_server::{serve, VfsFileSystem};
 
 use crate::error::{Result, WorkerError};
-use crate::image::{rootfs_mount_for, RafsStore};
+use crate::image::{image_fs_for, RafsStore};
 
 /// Default guest mount points for the injected mounts.
 const ROOTFS_PREFIX: &str = "/";
@@ -86,9 +86,10 @@ impl SandboxFs {
     /// Steps (the FS-D core):
     /// 1. Fork an empty base namespace ([`Namespace::fork`] of `new()` — every
     ///    sandbox starts from a clean, private mount table).
-    /// 2. Mount the **rootfs** (FS-B [`rootfs_mount_for`]) at `/`. The RAFS image
+    /// 2. Mount the **image filesystem** ([`image_fs_for`]) at `/`. The RAFS image
     ///    is the shared RO lower; a per-sandbox writable upper under
-    ///    `<sandbox_dir>/rootfs/` is the CoW layer.
+    ///    `<sandbox_dir>/rootfs/` is the CoW layer. It is the root purely because
+    ///    it is mounted at `/` — "root" is a mount position, not a type (#633).
     /// 3. Bind the **injected mounts** — `/stream` (native pipes), `/models`,
     ///    `/deltas` (synthetic, read-only) — into the namespace.
     ///
@@ -106,16 +107,18 @@ impl SandboxFs {
         // 1. Per-sandbox private namespace.
         let mut namespace = Namespace::new().fork();
 
-        // 2. Rootfs at "/" (FS-B: RAFS lower + per-sandbox writable upper).
+        // 2. Image filesystem at "/" (ImageFs: RAFS lower + per-sandbox
+        // writable upper). It is the root purely because the namespace recipe
+        // mounts it here — "root" is a mount position, not a type (#633).
         let bootstrap = rafs_store.bootstrap_path(image_id);
-        let rootfs = rootfs_mount_for(&bootstrap, rafs_store.blobs_dir(), image_id, sandbox_dir)?;
-        // `FsMount: Mount`, so the writable rootfs coerces to the `Arc<dyn Mount>`
+        let image_fs = image_fs_for(&bootstrap, rafs_store.blobs_dir(), image_id, sandbox_dir)?;
+        // `FsMount: Mount`, so the image filesystem coerces to the `Arc<dyn Mount>`
         // the namespace stores; the down-adapter recovers the `FsMount` vtable via
         // `Mount::as_fsmount` for writes/copy-up.
-        let rootfs_mount: Arc<dyn Mount> = Arc::new(rootfs);
+        let root_mount: Arc<dyn Mount> = Arc::new(image_fs);
         namespace
-            .mount(ROOTFS_PREFIX, rootfs_mount)
-            .map_err(|e| WorkerError::SandboxCreationFailed(format!("mount rootfs: {e}")))?;
+            .mount(ROOTFS_PREFIX, root_mount)
+            .map_err(|e| WorkerError::SandboxCreationFailed(format!("mount root: {e}")))?;
 
         // 3. Injected mounts — per-sandbox, never shared with another sandbox.
         let stream_registry = Arc::new(StreamRegistry::new());

--- a/crates/hyprstream-workers/src/runtime/service.rs
+++ b/crates/hyprstream-workers/src/runtime/service.rs
@@ -27,7 +27,7 @@ use crate::events::{
     serialize_container_started, serialize_container_stopped,
     serialize_sandbox_started, serialize_sandbox_stopped,
 };
-#[cfg(feature = "kata-vm")]
+#[cfg(feature = "oci-image")]
 use crate::image::RafsStore;
 // Import generated wire types (canonical OCI-aligned names)
 use crate::generated::worker_client::{
@@ -66,9 +66,9 @@ pub struct WorkerService {
     /// Sandbox pool for VM management
     sandbox_pool: Arc<SandboxPool>,
 
-    /// RAFS store for image management (VM path only). Without `kata-vm`,
-    /// CRI image operations return a clear "built without kata-vm support" error.
-    #[cfg(feature = "kata-vm")]
+    /// RAFS store for image management. Without `oci-image`,
+    /// CRI image operations return a clear "built without oci-image support" error.
+    #[cfg(feature = "oci-image")]
     rafs_store: Arc<RafsStore>,
 
     /// Active containers (container_id -> Container)
@@ -105,9 +105,9 @@ impl WorkerService {
     pub fn new(
         pool_config: PoolConfig,
         backend: Arc<dyn super::backend::SandboxBackend>,
-        // RAFS image store is only meaningful for the VM/CH path; the parameter
-        // is compiled away when `kata-vm` is disabled.
-        #[cfg(feature = "kata-vm")] rafs_store: Arc<RafsStore>,
+        // RAFS image store is the universal image filesystem service; the
+        // parameter is compiled away when `oci-image` is disabled.
+        #[cfg(feature = "oci-image")] rafs_store: Arc<RafsStore>,
         transport: TransportConfig,
         signing_key: SigningKey,
     ) -> AnyhowResult<Self> {
@@ -119,7 +119,7 @@ impl WorkerService {
         let stream_channel = Arc::new(StreamChannel::new(signing_key.clone()));
         Ok(Self {
             sandbox_pool,
-            #[cfg(feature = "kata-vm")]
+            #[cfg(feature = "oci-image")]
             rafs_store,
             containers: RwLock::new(HashMap::new()),
             container_sandbox_map: RwLock::new(HashMap::new()),
@@ -1239,15 +1239,15 @@ impl ContainerHandler for WorkerService {
 
 }
 
-// CRI image operations are backed by the RAFS/nydus store, which only compiles
-// under `kata-vm`. When the feature is off the handlers stay wired (the RPC
-// surface is unchanged) but return a clear "built without kata-vm support" error
-// instead of failing to compile.
-#[cfg(not(feature = "kata-vm"))]
+// CRI image operations are backed by the RAFS/nydus image store, which only
+// compiles under `oci-image`. When the feature is off the handlers stay wired
+// (the RPC surface is unchanged) but return a clear "built without oci-image
+// support" error instead of failing to compile.
+#[cfg(not(feature = "oci-image"))]
 fn image_ops_unsupported<T>() -> AnyhowResult<T> {
     Err(anyhow::anyhow!(
-        "CRI image operations require the `kata-vm` feature (RAFS/nydus image store); \
-         this binary was built without kata-vm support"
+        "CRI image operations require the `oci-image` feature (RAFS/nydus image store); \
+         this binary was built without oci-image support"
     ))
 }
 
@@ -1255,25 +1255,25 @@ fn image_ops_unsupported<T>() -> AnyhowResult<T> {
 impl ImageHandler for WorkerService {
     async fn handle_list(&self, _ctx: &EnvelopeContext, _request_id: u64, filter: &ImageFilter) -> AnyhowResult<Vec<ImageInfo>> {
         let _ = filter; // filter not yet used
-        #[cfg(feature = "kata-vm")]
+        #[cfg(feature = "oci-image")]
         {
             let images = self.rafs_store.list_images().await?;
             Ok(images)
         }
-        #[cfg(not(feature = "kata-vm"))]
+        #[cfg(not(feature = "oci-image"))]
         {
             image_ops_unsupported()
         }
     }
 
     async fn handle_status(&self, _ctx: &EnvelopeContext, _request_id: u64, request: &ImageStatusRequest) -> AnyhowResult<ImageStatusResult> {
-        #[cfg(feature = "kata-vm")]
+        #[cfg(feature = "oci-image")]
         {
             let image_ref = &request.image.image;
             let status = self.rafs_store.image_status(image_ref, request.verbose).await?;
             Ok(status)
         }
-        #[cfg(not(feature = "kata-vm"))]
+        #[cfg(not(feature = "oci-image"))]
         {
             let _ = request;
             image_ops_unsupported()
@@ -1281,7 +1281,7 @@ impl ImageHandler for WorkerService {
     }
 
     async fn handle_pull(&self, _ctx: &EnvelopeContext, _request_id: u64, data: &PullImageRequest) -> AnyhowResult<String> {
-        #[cfg(feature = "kata-vm")]
+        #[cfg(feature = "oci-image")]
         {
             let image_ref = &data.image.image;
             let auth = if !data.auth.username.is_empty() {
@@ -1299,7 +1299,7 @@ impl ImageHandler for WorkerService {
             let image_id = self.rafs_store.pull_with_auth(image_ref, auth.as_ref()).await?;
             Ok(image_id)
         }
-        #[cfg(not(feature = "kata-vm"))]
+        #[cfg(not(feature = "oci-image"))]
         {
             let _ = data;
             image_ops_unsupported()
@@ -1307,13 +1307,13 @@ impl ImageHandler for WorkerService {
     }
 
     async fn handle_remove(&self, _ctx: &EnvelopeContext, _request_id: u64, data: &ImageSpec) -> AnyhowResult<()> {
-        #[cfg(feature = "kata-vm")]
+        #[cfg(feature = "oci-image")]
         {
             let image_ref = &data.image;
             self.rafs_store.remove_image(image_ref).await?;
             Ok(())
         }
-        #[cfg(not(feature = "kata-vm"))]
+        #[cfg(not(feature = "oci-image"))]
         {
             let _ = data;
             image_ops_unsupported()
@@ -1321,12 +1321,12 @@ impl ImageHandler for WorkerService {
     }
 
     async fn handle_fs_info(&self, _ctx: &EnvelopeContext, _request_id: u64) -> AnyhowResult<Vec<FilesystemUsage>> {
-        #[cfg(feature = "kata-vm")]
+        #[cfg(feature = "oci-image")]
         {
             let usage = self.rafs_store.fs_info().await?;
             Ok(usage)
         }
-        #[cfg(not(feature = "kata-vm"))]
+        #[cfg(not(feature = "oci-image"))]
         {
             image_ops_unsupported()
         }

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -201,7 +201,8 @@ gittorrent = ["dep:gittorrent", "git2db/gittorrent-transport"]  # Enable P2P mod
 download-libtorch = ["tch/download-libtorch"]
 overlayfs = ["git2db/overlayfs"]  # Enable overlayfs-backed worktrees (delegated to git2db)
 systemd = ["hyprstream-rpc/systemd", "hyprstream-service/systemd", "hyprstream-workers/systemd", "dep:listenfd"]  # Systemd integration (socket activation, service units)
-kata-vm = ["hyprstream-workers/kata-vm"]  # Kata/Cloud-Hypervisor VM worker backend + RAFS/nydus image stack (in default; drop for an nspawn-only build)
+oci-image = ["hyprstream-workers/oci-image"]  # Universal mountable OCI/RAFS image filesystem service (ImageFs, an FsMount); composable by any backend (#633)
+kata-vm = ["hyprstream-workers/kata-vm", "oci-image"]  # Kata/Cloud-Hypervisor VM worker backend; implies oci-image (kata serves it via virtio-fs). In default; drop for an nspawn-only build
 experimental = ["hyprstream-compositor/experimental"]  # EXPERIMENTAL: Enable service/worker panels, git write operations
 pq-hybrid = []  # NO-OP alias: PQ primitives always compiled; Classical/Hybrid selected at runtime. See M3 #152.
 


### PR DESCRIPTION
Implements **#633** (child of #508, spine step 2): extract OCI/RAFS image provisioning off the kata backend into a universal mountable filesystem service. Stacked on #599.

## What
- **New `oci-image` cargo feature** on `hyprstream-workers` carrying the 7 nydus/RAFS deps (was gated under `kata-vm`). **`kata-vm` now implies `oci-image`** and keeps only the pure-VM toolchain (`kata-hypervisor`/`kata-types`/`ch-config`). So the image machinery compiles **standalone, without any VM toolchain** — `cargo build --features oci-image` succeeds and `cargo tree -i kata-hypervisor` is empty under it.
- **Rename off the Linux-ism** (root = mount position, not a type): `rootfs_mount.rs` → `image_fs.rs`; `RootfsMount` → `ImageFs`; `rootfs_mount_for`/`rootfs_mount_from_rafs` → `image_fs_for`/`image_fs_from_rafs`; `RafsStore::rootfs_mount` → `image_fs`. All call sites updated (`image/mod.rs`, `runtime/sandbox_fs.rs`, `runtime/service.rs`). **Behavior unchanged** — rename + feature re-home.
- The `image` module + CRI image ops re-gated from `kata-vm` → `oci-image` (the image store, not the VM toolchain).

## Why
Under the spine (#508), a filesystem service (OCI/RAFS image) is a peer mountable `FsMount`, composable by mount/bind; "root" is a mount position, not a type. The image→RAFS machinery was kata-private (gated behind `kata-vm`), so every non-kata backend was non-functional or side-channeled its own rootfs. Now any backend can compose an `ImageFs`.

## Verified
`--features oci-image` builds standalone (no VM toolchain in the graph); `--features kata-vm` still builds (kata consumes the now-universal path via `sandbox_fs.rs`, minimal change); no-feature build unchanged; clippy clean; torch-free.

## Deferred (documented TODOs, not implemented)
Wiring podman/nspawn/wasm backends to compose an `ImageFs` — follow-on once the service is universal. (The on-disk `<sandbox>/rootfs/` directory name kept intentionally — renaming it is a sandbox-behavior change, out of scope.)

Refs #508 · #633 · stacked on #599.
