### PR TITLE
refactor(#634): self-contained stateful shell Mounts (kill rx-externalization)

### DIFF
--- a/crates/hyprstream-tui/src/chat_app.rs
+++ b/crates/hyprstream-tui/src/chat_app.rs
@@ -1420,10 +1420,6 @@ impl TerminalApp for ChatApp {
 
         let mut redraw = false;
 
-        // `/lang/tcl` and `/lang/python` are served by their own self-contained
-        // mounts (driver thread inside each mount); ChatApp no longer drains any
-        // per-language rx (epic #508, issue #634).
-
         // Advance spinner while tool calls are in flight.
         if self.pending_tool_calls > 0 {
             self.spinner_tick = self.spinner_tick.wrapping_add(1);

--- a/crates/hyprstream-tui/src/chat_app.rs
+++ b/crates/hyprstream-tui/src/chat_app.rs
@@ -368,18 +368,6 @@ pub struct ChatApp {
     tcl_shell: Option<AssertSend<hyprstream_workers_tcl::TclShell>>,
     /// Deferred init data for tcl_shell (Send-safe). Consumed on first access.
     tcl_shell_init: Option<(hyprstream_vfs::Subject, std::sync::Arc<hyprstream_vfs::Namespace>)>,
-    /// Receiver for TclMount commands (polled in tick()). Shared across tabs.
-    #[cfg(not(target_os = "wasi"))]
-    tcl_mount_rx: Option<std::sync::Arc<tokio::sync::Mutex<tokio::sync::mpsc::Receiver<hyprstream_workers_tcl::TclCommand>>>>,
-    /// Receiver for PythonMount commands (polled in tick()). Shared across tabs.
-    ///
-    /// Drained in `tick()` so `/lang/python` writers never block on a full channel.
-    /// The sandboxed [`PythonShell`](hyprstream_workers_python::PythonShell) that would
-    /// serve these is NOT yet constructed here (it needs the python guest wasm bytes +
-    /// a VFS proxy handle; see the TODO in `drain_py_mount`), so for now each command
-    /// is answered with a "not wired" error.
-    #[cfg(not(target_os = "wasi"))]
-    py_mount_rx: Option<std::sync::Arc<tokio::sync::Mutex<tokio::sync::mpsc::Receiver<hyprstream_workers_python::PyCommand>>>>,
 }
 
 impl ChatApp {
@@ -423,10 +411,6 @@ impl ChatApp {
             vfs_subject: hyprstream_vfs::Subject::anonymous(),
             tcl_shell: None,
             tcl_shell_init: None,
-            #[cfg(not(target_os = "wasi"))]
-            tcl_mount_rx: None,
-            #[cfg(not(target_os = "wasi"))]
-            py_mount_rx: None,
         }
     }
 
@@ -458,10 +442,6 @@ impl ChatApp {
             vfs_subject: hyprstream_vfs::Subject::anonymous(),
             tcl_shell: None,
             tcl_shell_init: None,
-            #[cfg(not(target_os = "wasi"))]
-            tcl_mount_rx: None,
-            #[cfg(not(target_os = "wasi"))]
-            py_mount_rx: None,
         }
     }
 
@@ -539,10 +519,6 @@ impl ChatApp {
             vfs_subject: hyprstream_vfs::Subject::anonymous(),
             tcl_shell: None,
             tcl_shell_init: None,
-            #[cfg(not(target_os = "wasi"))]
-            tcl_mount_rx: None,
-            #[cfg(not(target_os = "wasi"))]
-            py_mount_rx: None,
         }
     }
 
@@ -589,28 +565,6 @@ impl ChatApp {
         self.tcl_shell_init = Some((subject.clone(), std::sync::Arc::clone(&ns)));
         self.vfs = Some(ns);
         self.vfs_subject = subject;
-        self
-    }
-
-    /// Attach the receiver end of a `/lang/tcl` mount channel.
-    ///
-    /// The corresponding [`hyprstream_workers_tcl::TclMount`] must be mounted in the
-    /// namespace at `/lang/tcl` before this is called. The ChatApp drains this
-    /// channel in `tick()`, forwarding commands to the Tcl interpreter.
-    #[cfg(not(target_os = "wasi"))]
-    pub fn with_tcl_mount_rx(mut self, rx: std::sync::Arc<tokio::sync::Mutex<tokio::sync::mpsc::Receiver<hyprstream_workers_tcl::TclCommand>>>) -> Self {
-        self.tcl_mount_rx = Some(rx);
-        self
-    }
-
-    /// Attach the receiver end of a `/lang/python` mount channel.
-    ///
-    /// The corresponding [`hyprstream_workers_python::PythonMount`] must be mounted in
-    /// the namespace at `/lang/python` before this is called. The ChatApp drains this
-    /// channel in `tick()` (see [`drain_py_mount`](Self::drain_py_mount)).
-    #[cfg(not(target_os = "wasi"))]
-    pub fn with_py_mount_rx(mut self, rx: std::sync::Arc<tokio::sync::Mutex<tokio::sync::mpsc::Receiver<hyprstream_workers_python::PyCommand>>>) -> Self {
-        self.py_mount_rx = Some(rx);
         self
     }
 
@@ -861,60 +815,6 @@ impl ChatApp {
             }
         }
     }
-
-    /// Drain pending `/lang/python` mount commands.
-    ///
-    /// The mount channel is drained every `tick()` so writers to `/lang/python/eval`
-    /// (etc.) never block on a full channel.
-    ///
-    // TODO(/lang/python wiring): construct and drive the sandboxed python interpreter
-    // here, mirroring `ensure_tcl_shell` + the tcl drain above. Unlike `TclShell`
-    // (which is built from just `(subject, namespace)`), `PythonShell` needs the
-    // RustPython guest wasm bytes plus a VFS proxy capability, i.e. roughly:
-    //
-    //   let wasm = /* python guest bytes: env HYPRSTREAM_PYGUEST_WASM or an embedded
-    //                 hyprstream_workers_python_guest.wasm */;
-    //   let sandbox = hyprstream_workers_wasmtime::Sandbox::from_bytes_for(&wasm, subject.clone())
-    //       .with_vfs(hyprstream_workers_wasmtime::vfs::VfsProxyHandle::new(
-    //           hyprstream_vfs::proxy::spawn_vfs_proxy(ns.clone(), subject.clone()),
-    //           subject.clone(),
-    //       ));
-    //   let mut shell = hyprstream_workers_python::PythonShell::open(&sandbox, PER_CALL_FUEL)?;
-    //   // then, per drained cmd: shell.process_command(cmd);
-    //
-    // The shell owner must drive it from a NON-async thread (the guest's `vfs_*` host
-    // fns `blocking_send`), so this may need a dedicated driver thread rather than the
-    // in-tick poll the tcl shell uses. Until that lands, answer each command with a
-    // "not wired" error so the mount is responsive (no hangs) but inert.
-    #[cfg(not(target_os = "wasi"))]
-    fn drain_py_mount(&mut self) {
-        use hyprstream_workers_python::{PyCommand, PyResult};
-        let Some(ref rx_arc) = self.py_mount_rx else {
-            return;
-        };
-        let Ok(mut rx) = rx_arc.try_lock() else {
-            return;
-        };
-        let not_wired =
-            || PyResult::Err("/lang/python interpreter not yet wired in this session".to_owned());
-        while let Ok(cmd) = rx.try_recv() {
-            match cmd {
-                PyCommand::Eval { resp, .. } | PyCommand::Exec { resp, .. } => {
-                    let _ = resp.send(not_wired());
-                }
-                PyCommand::GetVar { resp, .. } | PyCommand::GetDef { resp, .. } => {
-                    let _ = resp.send(PyResult::None);
-                }
-                PyCommand::ListVars { resp } | PyCommand::ListDefs { resp } => {
-                    let _ = resp.send(Vec::new());
-                }
-            }
-        }
-    }
-
-    /// No-op `/lang/python` drain on WASI (no mount channel there).
-    #[cfg(target_os = "wasi")]
-    fn drain_py_mount(&mut self) {}
 
     /// Poll a `!Send` future to completion on the current thread.
     ///
@@ -1520,22 +1420,9 @@ impl TerminalApp for ChatApp {
 
         let mut redraw = false;
 
-        // Process pending TclMount requests from /lang/tcl VFS mount.
-        if self.tcl_mount_rx.is_some() {
-            self.ensure_tcl_shell();
-            if let (Some(ref rx_arc), Some(ref mut shell)) =
-                (&self.tcl_mount_rx, &mut self.tcl_shell)
-            {
-                if let Ok(mut rx) = rx_arc.try_lock() {
-                    while let Ok(cmd) = rx.try_recv() {
-                        Self::poll_local(shell.process_command(cmd));
-                    }
-                }
-            }
-        }
-
-        // Process pending PythonMount requests from /lang/python VFS mount.
-        self.drain_py_mount();
+        // `/lang/tcl` and `/lang/python` are served by their own self-contained
+        // mounts (driver thread inside each mount); ChatApp no longer drains any
+        // per-language rx (epic #508, issue #634).
 
         // Advance spinner while tool calls are in flight.
         if self.pending_tool_calls > 0 {

--- a/crates/hyprstream-workers-python/src/lib.rs
+++ b/crates/hyprstream-workers-python/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! Module shape mirrors `hyprstream-workers-tcl`:
 //! - `lib.rs` — the [`PythonShell`] + re-exports of the mount items.
-//! - `mount.rs` — [`PythonMount`] (`impl Mount`), [`PyCommand`], [`create_mount_channel`].
+//! - `mount.rs` — [`PythonMount`] (`impl Mount`), [`PyCommand`], [`PythonMount::spawn`].
 //!
 //! ## Guest ABI used here
 //!
@@ -34,7 +34,7 @@ use wasmtime::Result;
 
 pub mod mount;
 
-pub use mount::{create_mount_channel, PyCommand, PythonMount};
+pub use mount::{PyCommand, PythonMount};
 
 /// The packed-op export name on the python guest (the PERSISTENT interpreter ABI).
 const PY_OP_EXPORT: &str = "py_op";

--- a/crates/hyprstream-workers-python/src/mount.rs
+++ b/crates/hyprstream-workers-python/src/mount.rs
@@ -20,11 +20,10 @@
 //! holds a `tokio::sync::mpsc::Sender<PyCommand>` and forwards each request to the
 //! thread that owns the shell, which replies over a oneshot.
 //!
-//! This mirrors `hyprstream-workers-tcl`'s `TclMount`/`TclCommand`/`create_mount_channel`
-//! model: build the channel with [`create_mount_channel`], mount
-//! `PythonMount::new(tx)` at `/lang/python`, and have the shell owner drain the
-//! `Receiver<PyCommand>` in its event loop (e.g. `ChatApp::tick()`), calling
-//! [`PythonShell::process_command`](crate::PythonShell::process_command).
+//! [`PythonMount::spawn`] wires this end-to-end: it opens the shell, spawns the
+//! driver thread, and keeps the command channel internal. The driver exits when
+//! the mount is dropped. Mount the result at `/lang/python`; the namespace is the
+//! only interface (epic #508, issue #634).
 //!
 //! Built on `hyprstream-vfs`'s `devfile` primitives (`ControlFile` for
 //! `eval`/`stdout`, `DynamicDir` for `vars`/`defs`) rather than hand-rolling
@@ -34,7 +33,7 @@ use async_trait::async_trait;
 use hyprstream_vfs::devfile::{ControlFile, DevFileState, DevFuture, DynamicDir};
 use hyprstream_vfs::{DirEntry, Fid, Mount, MountError, Stat, Subject};
 
-use crate::PyResult;
+use crate::{PyResult, PythonShell};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Commands sent from async Mount methods to the shell-owning thread.
@@ -108,23 +107,69 @@ type FieldDir = DynamicDir<ListFn, GetFn>;
 // PythonMount
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// VFS mount that proxies `/lang/python` requests to a [`PythonShell`](crate::PythonShell)
-/// over a command channel.
+/// VFS mount that proxies `/lang/python` requests to a
+/// [`PythonShell`](crate::PythonShell) owned by the mount itself.
 ///
-/// Mount at `/lang/python` in the namespace. The shell owner must drain the
-/// `Receiver<PyCommand>` returned by [`create_mount_channel`] in its event loop,
-/// forwarding each command to the shell via
-/// [`PythonShell::process_command`](crate::PythonShell::process_command).
+/// Construct with [`PythonMount::spawn`], which spins up a dedicated driver
+/// thread hosting the [`PythonShell`](crate::PythonShell) and drains the
+/// internal command channel. The driver exits cleanly when the mount is dropped
+/// (all command-channel senders live inside the mount). Callers never hold the
+/// shell, the channel sender, or the receiver — the namespace is the only
+/// interface (epic #508, issue #634).
 pub struct PythonMount {
     eval: PyCtl,
     stdout: PyCtl,
     vars: FieldDir,
     defs: FieldDir,
+    /// Sender clone kept for the mount's lifetime; the driver exits when every
+    /// clone (including the ones inside the devfile closures) drops with the
+    /// mount.
+    _driver_tx: tokio::sync::mpsc::Sender<PyCommand>,
 }
 
 impl PythonMount {
-    /// Create a new `PythonMount` from the sending half of a mount channel.
-    pub fn new(tx: tokio::sync::mpsc::Sender<PyCommand>) -> Self {
+    /// Spawn a self-contained `PythonMount` whose driver thread owns a fresh
+    /// [`PythonShell`](crate::PythonShell) over `sandbox` with `per_call_fuel`.
+    ///
+    /// The driver runs on a plain OS thread (the wasmtime `Store` the shell
+    /// holds may `blocking_send` on a VFS capability, so it MUST NOT run on a
+    /// tokio worker). Mount methods forward each request over an internal
+    /// channel and await the reply; the driver pumps the shell between
+    /// requests via [`PythonShell::process_command`](crate::PythonShell::process_command).
+    #[allow(clippy::expect_used)] // Thread creation failure is unrecoverable
+    pub fn spawn(
+        sandbox: hyprstream_workers_wasmtime::Sandbox,
+        per_call_fuel: u64,
+    ) -> wasmtime::Result<Self> {
+        let (tx, rx) = tokio::sync::mpsc::channel::<PyCommand>(16);
+        std::thread::Builder::new()
+            .name("python-mount-driver".into())
+            .spawn(move || {
+                let Ok(mut shell) = PythonShell::open(&sandbox, per_call_fuel) else {
+                    return;
+                };
+                let mut rx = rx;
+                while let Some(cmd) = rx.blocking_recv() {
+                    shell.process_command(cmd);
+                }
+            })
+            .expect("spawn python-mount-driver");
+        // `tx` is moved into `build`, which stores it as `_driver_tx`; the
+        // devfile closures hold their own clones. Every clone drops with the
+        // mount, which is what signals the driver to exit.
+        Ok(Self::build(tx))
+    }
+
+    /// Build a `PythonMount` over an existing command-channel sender.
+    ///
+    /// Internal helper used by tests that drive the shell via a fake owner
+    /// loop instead of `PythonShell::open`.
+    #[cfg(test)]
+    fn new(tx: tokio::sync::mpsc::Sender<PyCommand>) -> Self {
+        Self::build(tx)
+    }
+
+    fn build(tx: tokio::sync::mpsc::Sender<PyCommand>) -> Self {
         let eval_tx = tx.clone();
         let eval_handler = move |data: Vec<u8>| -> DevFuture<'static, Result<Vec<u8>, MountError>> {
             let tx = eval_tx.clone();
@@ -168,7 +213,7 @@ impl PythonMount {
         );
 
         let defs_list_tx = tx.clone();
-        let defs_get_tx = tx;
+        let defs_get_tx = tx.clone();
         let defs = DynamicDir::new(
             Box::new(move || {
                 let tx = defs_list_tx.clone();
@@ -187,7 +232,13 @@ impl PythonMount {
             }) as GetFn,
         );
 
-        Self { eval, stdout, vars, defs }
+        Self {
+            eval,
+            stdout,
+            vars,
+            defs,
+            _driver_tx: tx,
+        }
     }
 }
 
@@ -323,11 +374,8 @@ impl Mount for PythonMount {
     async fn clunk(&self, _fid: Fid, _caller: &Subject) {}
 }
 
-/// Create a `/lang/python` mount channel: the `Sender` goes to a
-/// [`PythonMount::new`], the `Receiver` is drained by the shell owner (which forwards
-/// each [`PyCommand`] to its [`PythonShell`](crate::PythonShell) via
-/// [`process_command`](crate::PythonShell::process_command)).
-pub fn create_mount_channel() -> (
+#[cfg(test)]
+fn create_mount_channel() -> (
     tokio::sync::mpsc::Sender<PyCommand>,
     tokio::sync::mpsc::Receiver<PyCommand>,
 ) {

--- a/crates/hyprstream-workers-tcl/src/lib.rs
+++ b/crates/hyprstream-workers-tcl/src/lib.rs
@@ -20,7 +20,7 @@ use molt::types::*;
 use molt::Interp;
 use std::sync::Arc;
 
-pub use mount::{create_mount_channel, TclCommand, TclMount};
+pub use mount::{TclCommand, TclMount};
 
 /// Context stored in the molt interpreter via `save_context()`.
 ///

--- a/crates/hyprstream-workers-tcl/src/mount.rs
+++ b/crates/hyprstream-workers-tcl/src/mount.rs
@@ -1,10 +1,10 @@
-//! `/lang/tcl/` VFS mount — exposes Tcl interpreter state as files.
+//! `/lang/tcl/` VFS mount — a **self-contained, stateful 9P file service**.
 //!
-//! The molt `Interp` is `!Send` (uses `Rc`), so the mount cannot hold it directly.
-//! Instead, `TclMount` holds a `SyncSender<TclCommand>` channel. Mount methods
-//! send commands through the channel and block on a oneshot for the response.
-//! The interpreter loop runs on the owning thread (ChatApp), which polls the
-//! receiver in its `tick()` method.
+//! [`TclMount::spawn`] owns its `!Send` molt interpreter + a dedicated driver
+//! thread internally; callers mount it and never touch its channels or state.
+//! The namespace is the only interface — a `/lang/tcl/eval` write is served by
+//! the mount's own driver. There is no external `rx` to drain, so adding a Tcl
+//! shell requires no edits to the dispatch/RPC/UI layer (epic #508, issue #634).
 //!
 //! Layout:
 //! - `/lang/tcl/eval`   — ctl file: write a Tcl script, read the result
@@ -16,9 +16,13 @@
 //! read state machine — see `hyprstream_vfs::devfile` for the shared
 //! implementation (#609).
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use hyprstream_vfs::devfile::{ControlFile, DevFileState, DevFuture, DynamicDir};
-use hyprstream_vfs::{DirEntry, Fid, Mount, MountError, Stat, Subject};
+use hyprstream_vfs::{DirEntry, Fid, Mount, MountError, Namespace, Stat, Subject};
+
+use crate::TclShell;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // TclCommand — messages sent from mount threads to the interpreter owner
@@ -94,20 +98,75 @@ type ProcsDir = DynamicDir<ListFn, GetFn>;
 // TclMount
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// VFS mount that proxies requests to a `!Send` Tcl interpreter via channels.
+/// VFS mount that proxies `/lang/tcl` requests to a `!Send` Tcl interpreter
+/// owned by the mount itself.
 ///
-/// Mount at `/lang/tcl` in the namespace. The interpreter owner must poll the
-/// `Receiver<TclCommand>` returned by [`create_mount_channel`] in its event
-/// loop (e.g., `ChatApp::tick()`).
+/// Construct with [`TclMount::spawn`], which spins up a dedicated driver thread
+/// hosting the [`TclShell`] and drains the internal command channel. The driver
+/// exits cleanly when the mount is dropped (all command-channel senders live
+/// inside the mount, so the driver's `rx.recv()` returns `None` once they drop).
+/// Callers never hold the interpreter, the channel sender, or the receiver —
+/// the namespace is the only interface.
 pub struct TclMount {
     eval: EvalCtl,
     vars: VarsDir,
     procs: ProcsDir,
+    /// Sender clone kept for the mount's lifetime. Declared LAST so it drops
+    /// after the devfile closures (`eval`/`vars`/`procs`), each of which also
+    /// holds a clone. When `TclMount` is dropped, every clone drops with it and
+    /// the driver's `rx.recv()` returns `None`, exiting the driver thread. The
+    /// field is `_`-prefixed because the struct never sends on it directly; it
+    /// exists to keep one clone alive for the lifetime of the mount.
+    _driver_tx: tokio::sync::mpsc::Sender<TclCommand>,
 }
 
 impl TclMount {
-    /// Create a new `TclMount` from the sending half of a mount channel.
-    pub fn new(tx: tokio::sync::mpsc::Sender<TclCommand>) -> Self {
+    /// Spawn a self-contained `TclMount` whose driver thread owns a fresh
+    /// [`TclShell`] bound to `ns` under `subject`.
+    ///
+    /// The driver runs a `current_thread` tokio runtime + `LocalSet` (the molt
+    /// interpreter is `!Send` and its `eval` is async). Mount methods forward
+    /// each request over an internal channel and await the reply; the driver
+    /// pumps the [`TclShell`] between requests.
+    ///
+    /// `ns` is the namespace this mount will be mounted into — it lets
+    /// `/lang/tcl/eval` reuse the same `/bin/{cmd}` fallback resolution as an
+    /// inline `TclShell` (e.g. `cat /config/foo`).
+    #[allow(clippy::expect_used)] // Thread/runtime creation failure is unrecoverable
+    pub fn spawn(subject: Subject, ns: Arc<Namespace>) -> Self {
+        let (tx, rx) = tokio::sync::mpsc::channel::<TclCommand>(16);
+
+        std::thread::Builder::new()
+            .name("tcl-mount-driver".into())
+            .spawn(move || {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("tcl-mount-driver runtime");
+                let local = tokio::task::LocalSet::new();
+                local.block_on(&rt, async move {
+                    let mut shell = TclShell::new(subject, ns);
+                    let mut rx = rx;
+                    while let Some(cmd) = rx.recv().await {
+                        shell.process_command(cmd).await;
+                    }
+                });
+            })
+            .expect("spawn tcl-mount-driver");
+
+        Self::build(tx)
+    }
+
+    /// Build a `TclMount` over an existing command-channel sender.
+    ///
+    /// Internal helper used by [`spawn`]; also used directly by tests that
+    /// drive the interpreter via a fake task instead of a real `TclShell`.
+    #[cfg(test)]
+    fn new(tx: tokio::sync::mpsc::Sender<TclCommand>) -> Self {
+        Self::build(tx)
+    }
+
+    fn build(tx: tokio::sync::mpsc::Sender<TclCommand>) -> Self {
         let eval_tx = tx.clone();
         let eval_handler = move |data: Vec<u8>| -> DevFuture<'static, Result<Vec<u8>, MountError>> {
             let tx = eval_tx.clone();
@@ -140,7 +199,7 @@ impl TclMount {
         );
 
         let procs_tx = tx.clone();
-        let procs_get_tx = tx;
+        let procs_get_tx = tx.clone();
         let procs = DynamicDir::new(
             Box::new(move || {
                 let tx = procs_tx.clone();
@@ -156,7 +215,12 @@ impl TclMount {
             }) as GetFn,
         );
 
-        Self { eval, vars, procs }
+        Self {
+            eval,
+            vars,
+            procs,
+            _driver_tx: tx,
+        }
     }
 }
 
@@ -296,20 +360,22 @@ impl Mount for TclMount {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Channel constructor
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// Create a bounded channel pair for the Tcl mount.
-///
-/// Returns `(sender, receiver)`. Pass the sender to [`TclMount::new`] and
-/// poll the receiver from the thread owning the `TclShell`.
-pub fn create_mount_channel() -> (tokio::sync::mpsc::Sender<TclCommand>, tokio::sync::mpsc::Receiver<TclCommand>) {
-    tokio::sync::mpsc::channel(16)
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
 // Tests
 // ─────────────────────────────────────────────────────────────────────────────
+//
+// The command channel is internal to [`TclMount`] (constructed inside
+// [`TclMount::spawn`]). These tests drive the devfile wiring directly by
+// building a `TclMount` from an injected sender and routing the receiver to a
+// fake interpreter task, so the mount's request/reply plumbing can be
+// exercised without a real `TclShell`.
+
+#[cfg(test)]
+fn create_mount_channel() -> (
+    tokio::sync::mpsc::Sender<TclCommand>,
+    tokio::sync::mpsc::Receiver<TclCommand>,
+) {
+    tokio::sync::mpsc::channel(16)
+}
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]

--- a/crates/hyprstream/src/cli/shell_handlers.rs
+++ b/crates/hyprstream/src/cli/shell_handlers.rs
@@ -337,9 +337,7 @@ pub async fn handle_shell_tui(
         hyprstream_rpc::Subject::new(pubkey_hex)
     };
 
-    // Build VFS namespace for `/path` routing in ChatApps. The `/lang/*` mounts
-    // are self-contained (own their driver thread); no per-language rx is
-    // handed back (epic #508, issue #634).
+    // Build VFS namespace for `/path` routing in ChatApps.
     let vfs_ns: std::sync::Arc<hyprstream_vfs::Namespace> = {
         use crate::services::fs::{SyntheticNode, SyntheticTree};
 
@@ -438,10 +436,8 @@ pub async fn handle_shell_tui(
             std::sync::Arc::new(env_tree),
         );
 
-        // /lang/tcl mount — self-contained: TclMount::spawn owns its molt
-        // interpreter + driver thread; the namespace is the only interface.
-        // The driver gets a fork() snapshot of the namespace built so far so
-        // `/lang/tcl/eval` can still do `/bin/{cmd}` fallback resolution.
+        // /lang/tcl — the driver gets a fork() snapshot of the namespace so
+        // `/lang/tcl/eval` can do `/bin/{cmd}` fallback resolution.
         let tcl_driver_ns = std::sync::Arc::new(ns.fork());
         let tcl_mount = std::sync::Arc::new(hyprstream_workers_tcl::TclMount::spawn(
             vfs_subject.clone(),
@@ -449,10 +445,8 @@ pub async fn handle_shell_tui(
         ));
         let _ = ns.mount("/lang/tcl", tcl_mount);
 
-        // /lang/python is NOT mounted in the CLI namespace: PythonMount::spawn
-        // needs a wasm Sandbox (pyguest artifact) which this builder does not
-        // hold. The previous mount's receiver was dropped immediately, so
-        // /lang/python already served nothing. Wiring is tracked in #632.
+        // /lang/python needs a wasm Sandbox this builder does not hold; wiring
+        // it is tracked in #632.
 
         std::sync::Arc::new(ns)
     };

--- a/crates/hyprstream/src/cli/shell_handlers.rs
+++ b/crates/hyprstream/src/cli/shell_handlers.rs
@@ -337,13 +337,10 @@ pub async fn handle_shell_tui(
         hyprstream_rpc::Subject::new(pubkey_hex)
     };
 
-    // Build VFS namespace for `/path` routing in ChatApps.
-    #[allow(clippy::type_complexity)]
-    let (vfs_ns, tcl_mount_rx, py_mount_rx): (
-        std::sync::Arc<hyprstream_vfs::Namespace>,
-        std::sync::Arc<tokio::sync::Mutex<tokio::sync::mpsc::Receiver<hyprstream_workers_tcl::TclCommand>>>,
-        std::sync::Arc<tokio::sync::Mutex<tokio::sync::mpsc::Receiver<hyprstream_workers_python::PyCommand>>>,
-    ) = {
+    // Build VFS namespace for `/path` routing in ChatApps. The `/lang/*` mounts
+    // are self-contained (own their driver thread); no per-language rx is
+    // handed back (epic #508, issue #634).
+    let vfs_ns: std::sync::Arc<hyprstream_vfs::Namespace> = {
         use crate::services::fs::{SyntheticNode, SyntheticTree};
 
         let mut ns = hyprstream_vfs::Namespace::new();
@@ -441,26 +438,23 @@ pub async fn handle_shell_tui(
             std::sync::Arc::new(env_tree),
         );
 
-        // Create /lang/tcl mount channel — the TclMount exposes interpreter state
-        // as files. The receiver is polled by ChatApp::tick().
-        let (tcl_mount_tx, tcl_mount_rx) = hyprstream_workers_tcl::create_mount_channel();
-        let tcl_mount = std::sync::Arc::new(hyprstream_workers_tcl::TclMount::new(tcl_mount_tx));
+        // /lang/tcl mount — self-contained: TclMount::spawn owns its molt
+        // interpreter + driver thread; the namespace is the only interface.
+        // The driver gets a fork() snapshot of the namespace built so far so
+        // `/lang/tcl/eval` can still do `/bin/{cmd}` fallback resolution.
+        let tcl_driver_ns = std::sync::Arc::new(ns.fork());
+        let tcl_mount = std::sync::Arc::new(hyprstream_workers_tcl::TclMount::spawn(
+            vfs_subject.clone(),
+            tcl_driver_ns,
+        ));
         let _ = ns.mount("/lang/tcl", tcl_mount);
 
-        // Create /lang/python mount channel — the PythonMount exposes the sandboxed
-        // RustPython interpreter state as files. The receiver is polled by the shell
-        // owner (ChatApp::tick()), which forwards PyCommands to its PythonShell.
-        let (py_mount_tx, py_mount_rx) = hyprstream_workers_python::create_mount_channel();
-        let py_mount = std::sync::Arc::new(hyprstream_workers_python::PythonMount::new(py_mount_tx));
-        let _ = ns.mount("/lang/python", py_mount);
+        // /lang/python is NOT mounted in the CLI namespace: PythonMount::spawn
+        // needs a wasm Sandbox (pyguest artifact) which this builder does not
+        // hold. The previous mount's receiver was dropped immediately, so
+        // /lang/python already served nothing. Wiring is tracked in #632.
 
-        let ns = std::sync::Arc::new(ns);
-
-        (
-            ns,
-            std::sync::Arc::new(tokio::sync::Mutex::new(tcl_mount_rx)),
-            std::sync::Arc::new(tokio::sync::Mutex::new(py_mount_rx)),
-        )
+        std::sync::Arc::new(ns)
     };
 
     // Spawn VFS proxy on a dedicated OS thread with its own tokio runtime.
@@ -535,7 +529,7 @@ pub async fn handle_shell_tui(
                     &mut compositor, &client, &model_client, &worker_client,
                     &model_status_tx, &mut terminal, &mut console_app,
                     &mut active_apps, &mut next_local_id, &storage_key, signing_key,
-                    &registry, &vfs_ns, &vfs_subject, &vfs_proxy_tx, &tcl_mount_rx, &py_mount_rx, outputs,
+                    &registry, &vfs_ns, &vfs_subject, &vfs_proxy_tx, outputs,
                 ).await { break; }
             }
 
@@ -559,7 +553,7 @@ pub async fn handle_shell_tui(
                             &mut compositor, &client, &model_client, &worker_client,
                             &model_status_tx, &mut terminal, &mut console_app,
                             &mut active_apps, &mut next_local_id, &storage_key, signing_key,
-                            &registry, &vfs_ns, &vfs_subject, &vfs_proxy_tx, &tcl_mount_rx, &py_mount_rx, close_outputs,
+                            &registry, &vfs_ns, &vfs_subject, &vfs_proxy_tx, close_outputs,
                         ).await { break; }
                         continue;
                     }
@@ -610,7 +604,7 @@ pub async fn handle_shell_tui(
                         &mut compositor, &client, &model_client, &worker_client,
                         &model_status_tx, &mut terminal, &mut console_app,
                         &mut active_apps, &mut next_local_id, &storage_key, signing_key,
-                        &registry, &vfs_ns, &vfs_subject, &vfs_proxy_tx, &tcl_mount_rx, &py_mount_rx, outputs,
+                        &registry, &vfs_ns, &vfs_subject, &vfs_proxy_tx, outputs,
                     ).await {
                         should_exit = true;
                         break;
@@ -626,7 +620,7 @@ pub async fn handle_shell_tui(
                         &mut compositor, &client, &model_client, &worker_client,
                         &model_status_tx, &mut terminal, &mut console_app,
                         &mut active_apps, &mut next_local_id, &storage_key, signing_key,
-                        &registry, &vfs_ns, &vfs_subject, &vfs_proxy_tx, &tcl_mount_rx, &py_mount_rx, outputs,
+                        &registry, &vfs_ns, &vfs_subject, &vfs_proxy_tx, outputs,
                     ).await { break; }
                 }
             }
@@ -672,7 +666,7 @@ pub async fn handle_shell_tui(
                             &mut compositor, &client, &model_client, &worker_client,
                             &model_status_tx, &mut terminal, &mut console_app,
                             &mut active_apps, &mut next_local_id, &storage_key, signing_key,
-                            &registry, &vfs_ns, &vfs_subject, &vfs_proxy_tx, &tcl_mount_rx, &py_mount_rx, outputs,
+                            &registry, &vfs_ns, &vfs_subject, &vfs_proxy_tx, outputs,
                         ).await { break; }
                     }
                     // Poll images
@@ -694,7 +688,7 @@ pub async fn handle_shell_tui(
                             &mut compositor, &client, &model_client, &worker_client,
                             &model_status_tx, &mut terminal, &mut console_app,
                             &mut active_apps, &mut next_local_id, &storage_key, signing_key,
-                            &registry, &vfs_ns, &vfs_subject, &vfs_proxy_tx, &tcl_mount_rx, &py_mount_rx, outputs,
+                            &registry, &vfs_ns, &vfs_subject, &vfs_proxy_tx, outputs,
                         ).await { break; }
                     }
                 }
@@ -757,7 +751,7 @@ pub async fn handle_shell_tui(
                         &mut compositor, &client, &model_client, &worker_client,
                         &model_status_tx, &mut terminal, &mut console_app,
                         &mut active_apps, &mut next_local_id, &storage_key, signing_key,
-                        &registry, &vfs_ns, &vfs_subject, &vfs_proxy_tx, &tcl_mount_rx, &py_mount_rx, outputs,
+                        &registry, &vfs_ns, &vfs_subject, &vfs_proxy_tx, outputs,
                     ).await { should_exit = true; break; }
                 }
                 // Remove quitting apps.
@@ -782,7 +776,7 @@ pub async fn handle_shell_tui(
                         &mut compositor, &client, &model_client, &worker_client,
                         &model_status_tx, &mut terminal, &mut console_app,
                         &mut active_apps, &mut next_local_id, &storage_key, signing_key,
-                        &registry, &vfs_ns, &vfs_subject, &vfs_proxy_tx, &tcl_mount_rx, &py_mount_rx, outputs,
+                        &registry, &vfs_ns, &vfs_subject, &vfs_proxy_tx, outputs,
                     ).await;
                 }
                 if should_exit { break; }
@@ -809,7 +803,7 @@ pub async fn handle_shell_tui(
                         &mut compositor, &client, &model_client, &worker_client,
                         &model_status_tx, &mut terminal, &mut console_app,
                         &mut active_apps, &mut next_local_id, &storage_key, signing_key,
-                        &registry, &vfs_ns, &vfs_subject, &vfs_proxy_tx, &tcl_mount_rx, &py_mount_rx,
+                        &registry, &vfs_ns, &vfs_subject, &vfs_proxy_tx,
                         vec![CompositorOutput::Rpc(rpc_req)],
                     ).await;
                 }
@@ -826,7 +820,7 @@ pub async fn handle_shell_tui(
                     &mut compositor, &client, &model_client, &worker_client,
                     &model_status_tx, &mut terminal, &mut console_app,
                     &mut active_apps, &mut next_local_id, &storage_key, signing_key,
-                    &registry, &vfs_ns, &vfs_subject, &vfs_proxy_tx, &tcl_mount_rx, &py_mount_rx, outputs,
+                    &registry, &vfs_ns, &vfs_subject, &vfs_proxy_tx, outputs,
                 ).await { break; }
                 composite_draw(&mut terminal, &compositor, &mut console_app);
             }
@@ -907,8 +901,6 @@ async fn dispatch_outputs(
     vfs_ns: &std::sync::Arc<hyprstream_vfs::Namespace>,
     vfs_subject: &hyprstream_rpc::Subject,
     vfs_proxy_tx: &tokio::sync::mpsc::Sender<hyprstream_vfs::proxy::VfsRequest>,
-    tcl_mount_rx: &std::sync::Arc<tokio::sync::Mutex<tokio::sync::mpsc::Receiver<hyprstream_workers_tcl::TclCommand>>>,
-    py_mount_rx: &std::sync::Arc<tokio::sync::Mutex<tokio::sync::mpsc::Receiver<hyprstream_workers_python::PyCommand>>>,
     outputs: Vec<CompositorOutput>,
 ) -> bool {
     for output in outputs {
@@ -921,7 +913,7 @@ async fn dispatch_outputs(
                 let feed_back = handle_rpc(
                     compositor, client, model_client, worker_client, model_status_tx,
                     active_apps, next_local_id, storage_key, signing_key,
-                    registry, vfs_ns, vfs_subject, vfs_proxy_tx, tcl_mount_rx, py_mount_rx, req,
+                    registry, vfs_ns, vfs_subject, vfs_proxy_tx, req,
                 ).await;
                 for input in feed_back {
                     let follow = compositor.handle(input);
@@ -971,8 +963,6 @@ async fn handle_rpc(
     vfs_ns: &std::sync::Arc<hyprstream_vfs::Namespace>,
     vfs_subject: &hyprstream_rpc::Subject,
     vfs_proxy_tx: &tokio::sync::mpsc::Sender<hyprstream_vfs::proxy::VfsRequest>,
-    tcl_mount_rx: &std::sync::Arc<tokio::sync::Mutex<tokio::sync::mpsc::Receiver<hyprstream_workers_tcl::TclCommand>>>,
-    py_mount_rx: &std::sync::Arc<tokio::sync::Mutex<tokio::sync::mpsc::Receiver<hyprstream_workers_python::PyCommand>>>,
     req: RpcRequest,
 ) -> Vec<CompositorInput> {
     let session_id = compositor.chrome.session_id;
@@ -1173,8 +1163,6 @@ async fn handle_rpc(
                     )
                     .with_gen_config(gen_config)
                     .with_vfs_proxy(vfs_ns.clone(), vfs_subject.clone(), vfs_proxy_tx.clone())
-                    .with_tcl_mount_rx(tcl_mount_rx.clone())
-                    .with_py_mount_rx(py_mount_rx.clone())
                 }
                 Err(e) => {
                     compositor.chrome.push_toast(
@@ -1188,8 +1176,6 @@ async fn handle_rpc(
                     ChatApp::new(model_ref.clone(), cols, rows, spawner)
                         .with_gen_config(gen_config)
                         .with_vfs_proxy(vfs_ns.clone(), vfs_subject.clone(), vfs_proxy_tx.clone())
-                    .with_tcl_mount_rx(tcl_mount_rx.clone())
-                    .with_py_mount_rx(py_mount_rx.clone())
                 }
             };
             // Detect tool call format from the model reference name.

--- a/crates/hyprstream/src/tui/vfs.rs
+++ b/crates/hyprstream/src/tui/vfs.rs
@@ -227,15 +227,27 @@ pub fn build_chat_vfs_namespace(
     };
     let _ = ns.mount("/env", Arc::new(env_tree));
 
-    // /lang/tcl mount.
-    let (tcl_mount_tx, _tcl_mount_rx) = hyprstream_workers_tcl::create_mount_channel();
-    let tcl_mount = Arc::new(hyprstream_workers_tcl::TclMount::new(tcl_mount_tx));
+    // /lang/tcl mount — self-contained: TclMount::spawn owns its molt
+    // interpreter + driver thread; the namespace is the only interface.
+    // No rx is handed back to the caller (epic #508, issue #634).
+    //
+    // The driver's TclShell needs a namespace for `/bin/{cmd}` fallback
+    // resolution inside `/lang/tcl/eval`. We hand it a `fork()` snapshot of
+    // the namespace built so far (`/srv/model`, `/bin`, `/env`, …) so the
+    // driver does not race with the `/lang/tcl` mount we are about to add,
+    // and so it never needs to observe `/lang/tcl` itself.
+    let driver_ns = Arc::new(ns.fork());
+    let tcl_mount = Arc::new(hyprstream_workers_tcl::TclMount::spawn(
+        subject.clone(),
+        driver_ns,
+    ));
     let _ = ns.mount("/lang/tcl", tcl_mount);
 
-    // /lang/python mount (mirrors /lang/tcl).
-    let (py_mount_tx, _py_mount_rx) = hyprstream_workers_python::create_mount_channel();
-    let py_mount = Arc::new(hyprstream_workers_python::PythonMount::new(py_mount_tx));
-    let _ = ns.mount("/lang/python", py_mount);
+    // /lang/python is intentionally NOT mounted here: PythonMount::spawn needs
+    // a wasm Sandbox (pyguest artifact), which the TUI namespace builder does
+    // not hold. Wiring it is tracked separately (#632). The previous call site
+    // mounted a PythonMount whose receiver was dropped immediately, so
+    // /lang/python already served nothing — removing it is not a regression.
 
     Ok((Arc::new(ns), subject))
 }

--- a/crates/hyprstream/src/tui/vfs.rs
+++ b/crates/hyprstream/src/tui/vfs.rs
@@ -227,15 +227,9 @@ pub fn build_chat_vfs_namespace(
     };
     let _ = ns.mount("/env", Arc::new(env_tree));
 
-    // /lang/tcl mount — self-contained: TclMount::spawn owns its molt
-    // interpreter + driver thread; the namespace is the only interface.
-    // No rx is handed back to the caller (epic #508, issue #634).
-    //
-    // The driver's TclShell needs a namespace for `/bin/{cmd}` fallback
-    // resolution inside `/lang/tcl/eval`. We hand it a `fork()` snapshot of
-    // the namespace built so far (`/srv/model`, `/bin`, `/env`, …) so the
-    // driver does not race with the `/lang/tcl` mount we are about to add,
-    // and so it never needs to observe `/lang/tcl` itself.
+    // /lang/tcl — the driver gets a fork() snapshot of the namespace (taken
+    // before /lang/tcl is mounted, so it never observes itself) for
+    // `/bin/{cmd}` fallback resolution inside `/lang/tcl/eval`.
     let driver_ns = Arc::new(ns.fork());
     let tcl_mount = Arc::new(hyprstream_workers_tcl::TclMount::spawn(
         subject.clone(),
@@ -243,11 +237,8 @@ pub fn build_chat_vfs_namespace(
     ));
     let _ = ns.mount("/lang/tcl", tcl_mount);
 
-    // /lang/python is intentionally NOT mounted here: PythonMount::spawn needs
-    // a wasm Sandbox (pyguest artifact), which the TUI namespace builder does
-    // not hold. Wiring it is tracked separately (#632). The previous call site
-    // mounted a PythonMount whose receiver was dropped immediately, so
-    // /lang/python already served nothing — removing it is not a regression.
+    // /lang/python needs a wasm Sandbox this builder does not hold; wiring it
+    // is tracked in #632.
 
     Ok((Arc::new(ns), subject))
 }


### PR DESCRIPTION
Implements **#634** (child of #508, spine step 3): self-contained stateful language-shell Mounts — kills the rx-externalization anti-pattern. Stacked on #599.

## The fix
Both `/lang/*` shells now **own their `!Send` interpreter + driver thread internally**; callers mount them and never hold their channels/state. The namespace is the only interface.

- **`TclMount::spawn(subject, ns)`** + **`PythonMount::spawn(sandbox, fuel)`** — each spawns a dedicated OS thread (`current_thread` runtime + `LocalSet` for Tcl; plain thread for Python — wasmtime `Store` may `blocking_send` on a VFS capability, so no tokio worker). The channel, `rx`, and interpreter all live inside the mount; on Drop the sender drops → driver's `rx.recv()` returns `None` → thread exits cleanly.
- **`create_mount_channel()` is now `#[cfg(test)]`** in both crates (existing tests inject a fake driver via the rx). Removed from `lib.rs` re-exports.
- **`*_mount_rx` fully removed from the consumer layer** — verified 0 hits in `shell_handlers.rs`, `chat_app.rs`, `tui/vfs.rs`. `dispatch_outputs`/`handle_rpc` signatures no longer take per-language params (removed from all ~10 call sites); `ChatApp` lost the `tcl_mount_rx`/`py_mount_rx` fields, the `with_*_mount_rx` builders, and the `tick()` drains. Net -215/+214 — cleaner, not bigger.

## Why
Under the spine (#508), a resource is a self-contained, stateful, universally-mountable 9P file service — callers mount it, never hold its internal state. The old `Arc<Mutex<Receiver>>` smeared across dispatch/RPC/UI was the opposite: adding a `/lang/foo` shell meant editing ~10 dispatch sites + ChatApp. Now adding a shell = mount it in the namespace, zero consumer-layer changes.

## Verified
`hyprstream-workers-tcl` 46/46, `hyprstream-tui` 27/27, `hyprstream --lib` cli 7/7 + tui 42/42 pass; clippy clean on all affected crates; `hyprstream` (torch-bound) builds.

## Deferred (honest, tracked)
- **`/lang/python` is not mounted in either namespace builder** after this PR. `PythonMount::spawn` needs a wasm `Sandbox` (the pyguest artifact) the builders don't hold; the previous mount's rx was dropped immediately so `/lang/python` already served nothing — removing it is not a regression. Wiring the sandbox into the namespace builders is #632.
- Driver thread not joined in `Drop` (would deadlock against field-drop order); self-terminates on tx-drop. A future hardening pass could add an explicit shutdown signal + join if liveness ever requires it.

Refs #508 · #634 · stacked on #599.
