### PR TITLE
feat(mac S6 #572): runtime grant path — UCAN→sender-bound tokens (fail-closed, ZSP)

### DIFF
--- a/crates/hyprstream-rpc/src/auth/ucan/chain.rs
+++ b/crates/hyprstream-rpc/src/auth/ucan/chain.rs
@@ -255,7 +255,7 @@ fn validate_chain_at(ucan: &Ucan, now: u64, link: usize) -> Result<(), ChainErro
 ///
 /// This is the single entry point S5's compiler calls; it guarantees that only a
 /// genuine, currently-live ceiling reaches the (deferred) bundle-emission stage.
-pub fn validate<V: UcanVerifier>(ucan: &Ucan, verifier: &V, now: u64) -> Result<(), ChainError> {
+pub fn validate<V: UcanVerifier + ?Sized>(ucan: &Ucan, verifier: &V, now: u64) -> Result<(), ChainError> {
     ucan.validate_structure().map_err(ChainError::Structure)?;
     ucan.verify_signatures(verifier)
         .map_err(ChainError::Signature)?;

--- a/crates/hyprstream-rpc/src/auth/ucan/token.rs
+++ b/crates/hyprstream-rpc/src/auth/ucan/token.rs
@@ -222,7 +222,7 @@ impl Ucan {
     ///
     /// This does NOT check attenuation/delegation linkage — that is
     /// [`super::chain::validate_chain`], deliberately separate.
-    pub fn verify_signatures<V: UcanVerifier>(&self, verifier: &V) -> Result<(), UcanError> {
+    pub fn verify_signatures<V: UcanVerifier + ?Sized>(&self, verifier: &V) -> Result<(), UcanError> {
         let ed_bytes = did_ed25519_key(&self.payload.issuer)?;
         let payload_bytes = self.payload.signing_bytes()?;
         verifier.verify(
@@ -260,6 +260,35 @@ pub trait UcanVerifier {
         payload: &[u8],
         signature: &[u8],
     ) -> Result<(), UcanError>;
+}
+
+// Blanket forwarding impls so a `&dyn UcanVerifier` (or `Box<dyn …>`) can be
+// passed anywhere a generic `V: UcanVerifier` is expected — notably S5's
+// `chain::validate<V>` and S6's runtime grant path. Without these, the runtime
+// path would have to be monomorphized on a concrete verifier type, which fights
+// the dynamic trust-store resolution S6 needs.
+impl<V: UcanVerifier + ?Sized> UcanVerifier for &V {
+    fn verify(
+        &self,
+        issuer: &Did,
+        ed_key: &[u8; 32],
+        payload: &[u8],
+        signature: &[u8],
+    ) -> Result<(), UcanError> {
+        (**self).verify(issuer, ed_key, payload, signature)
+    }
+}
+
+impl<V: UcanVerifier + ?Sized> UcanVerifier for std::boxed::Box<V> {
+    fn verify(
+        &self,
+        issuer: &Did,
+        ed_key: &[u8; 32],
+        payload: &[u8],
+        signature: &[u8],
+    ) -> Result<(), UcanError> {
+        (**self).verify(issuer, ed_key, payload, signature)
+    }
 }
 
 /// Errors from UCAN parsing, structure, and signature verification. All map to a

--- a/crates/hyprstream/src/mac/exchange.rs
+++ b/crates/hyprstream/src/mac/exchange.rs
@@ -1,0 +1,1007 @@
+//! **MAC S6 — runtime grant path: UCAN grant-request → access/refresh tokens.**
+//! Ticket #572 of the native-MAC epic (#547).
+//!
+//! This is the **runtime** companion to S5's compile-time UCAN→Casbin/TE compiler.
+//! S5 compiles an *approved* UCAN into a ceiling (a `CompiledPolicy` +
+//! `SignedApproval` binding) — that is the standing authorization-to-REQUEST.
+//! S6 is the path a principal takes at runtime to turn a **subset-UCAN grant**
+//! into **ephemeral, sender-bound OAuth tokens** (RFC 8693 token-exchange shape).
+//!
+//! ## The #547 MAC model this honours
+//!
+//! - **UCAN authors; Casbin/TE enforces.** The grant presented here is a UCAN
+//!   delegation chain; we never mint tokens wider than that grant.
+//! - **ZSP (Zero Standing Privilege).** The ceiling is standing
+//!   authorization-to-REQUEST, NOT access. Access is **ephemeral** (short-ttl),
+//!   **per-task** (not per-op), and **re-evaluated on refresh**. There is no
+//!   long-lived bearer that bypasses the grant.
+//! - **Ceiling = the grant itself.** The subset-UCAN a principal presents is a
+//!   strict attenuated subset of an approved ceiling. The grant's root
+//!   capabilities ARE the ceiling for this request; `authorize(grant, request)`
+//!   is the ceiling-subset check.
+//! - **Fail-closed / single path.** Every failure mode — bad chain, over-ceiling
+//!   request, insufficient MAC clearance, missing sender-binding — denies. There
+//!   is **no fallback path**: a fallback is a downgrade vector. Authority being
+//!   unreachable is a denial, not a reason to mint a narrower token.
+//! - **Escalation ≠ auto-widen.** A request beyond the grant's ceiling is a
+//!   denial pending a **ceiling amendment** (the tiered decision — static Casbin
+//!   / agentic / admin-UDF — which is authority-owned and MAC-bounded). S6 does
+//!   NOT auto-escalate; it routes to `Decision::Escalate` and returns
+//!   `insufficient_scope`. The amendment flow is deferred (TODO locations below).
+//!
+//! ## What this module owns (and what it does NOT)
+//!
+//! **Owns (the fail-closed core):**
+//! - Validate the presented UCAN grant chain (delegates to S5's
+//!   [`hyprstream_rpc::auth::ucan::chain::validate`] — signatures + attenuation +
+//!   temporal validity at the trusted `now`).
+//! - **Ceiling-subset check**: the access being requested now must be authorized
+//!   by the grant's capabilities ([`mac::compiler::authorize`]).
+//! - **MAC clearance gate**: the principal's clearance (from verified key
+//!   material / S1 `SubjectContextClaims`) must dominate the request's label.
+//!   Insufficient clearance ⇒ deny (the S1 floor, reused — not reinvented).
+//! - Compose the subset of capabilities the token will actually carry
+//!   (never the whole grant — ZSP: mint the least subset that covers the
+//!   requested access).
+//!
+//! **Does NOT own (consumed from siblings — no parallel implementation):**
+//! - UCAN chain validation, attenuation, signature verification → S5
+//!   (`hyprstream_rpc::auth::ucan`).
+//! - The grant-vs-request authorization relation → S5's compiler
+//!   ([`mac::compiler::authorize`]).
+//! - Security labels, clearance, dominance → S1 (`hyprstream_rpc::auth::mac`).
+//! - DPoP sender-binding (#514/#515) → `services::oauth::dpop`.
+//! - JWT signing → `services::oauth` (via `hyprstream_rpc::auth::jwt`).
+//! - Hybrid-PQC signing of the minted tokens → **S8 (#574)**. This module uses
+//!   the existing (classical / composite) signing path and leaves a clear
+//!   `// TODO(S8):` at the mint seam. Hybridization of the *tokens* is not this
+//!   PR; the UCAN/approval signatures it consumes are already hybrid.
+//!
+//! ## Scope of this PR (core, sound, tested) vs. deferred
+//!
+//! **In scope:** the pure fail-closed core — grant validation, ceiling-subset
+//! check, MAC clearance gate, sender-binding requirement, and the
+//! `GrantDecision` it produces. Plus full negative-test coverage (over-ceiling,
+//! bad chain, insufficient clearance, missing DPoP). The HTTP grant wiring and
+//! token minting live in `services::oauth::token_exchange` and call into
+//! [`evaluate_grant`] here.
+//!
+//! **Deferred (documented TODOs, fail-closed until landed):**
+//! - Full escalation tiers (static Casbin / agentic / admin-UDF amendment) —
+//!   see [`GrantDecision::Escalate`] and the `TODO(#572-escalation)` markers.
+//! - Refresh-token rotation with re-evaluation plumbing end-to-end (the
+//!   `evaluate_grant` call on refresh is wired; rotation storage is the OAuth
+//!   layer's job) — `TODO(#572-refresh-rotation)`.
+//! - Revocation propagation into the grant path (jti blocklist check at grant
+//!   time) — `TODO(#572-revocation)`.
+
+use hyprstream_rpc::auth::mac::{
+    SecurityContext, SecurityLabel, SubjectContextClaims, VerifiedKeyMaterial,
+};
+use hyprstream_rpc::auth::ucan::capability::{Ability, Capability, Caveats, Resource};
+use hyprstream_rpc::auth::ucan::chain::{self, ChainError};
+use hyprstream_rpc::auth::ucan::token::{Ucan, UcanVerifier};
+
+use crate::mac::compiler::{authorize_at, AccessRequest};
+use crate::mac::te::Decision;
+
+/// The token-type URI identifying a UCAN grant as the RFC 8693 `subject_token`.
+///
+/// A presenter supplies a CBOR-encoded UCAN as `subject_token` with this
+/// `subject_token_type` at the token-exchange endpoint. Distinct from the OIDC
+/// `id_token` / `access_token` / `jwt` types so the grant path cannot be
+/// confused with the existing exchange flows.
+pub const UCAN_GRANT_TOKEN_TYPE: &str = "urn:hyprstream:token-type:ucan-grant";
+
+/// Hard ceiling on the access-token TTL minted from a UCAN grant. ZSP: grant
+/// tokens are deliberately short-lived so the re-evaluation-on-refresh property
+/// has teeth. The OAuth layer clamps its configured `token_ttl` down to this.
+pub const MAX_ACCESS_TOKEN_TTL_SECS: u32 = 900; // 15 minutes
+
+/// Why a grant request was denied. Every variant is fail-closed; there is no
+/// "best-effort" or "narrow-and-continue" outcome. The cardinal rule of #547:
+/// authority-unreachable ⇒ deny, never downgrade.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GrantError {
+    /// The UCAN chain failed S5 validation (bad signature, broken linkage,
+    /// widening, window escape, expired/not-yet-valid, or over-depth). Wrapped
+    /// verbatim from S5 so the failure mode is auditable.
+    Chain(ChainError),
+    /// The request exceeds the grant's ceiling — an escalation attempt. This is
+    /// routed to the (deferred) escalation tier; until that lands it is a
+    /// denial. **S6 never auto-escalates.** The offending requested capability
+    /// (the one no grant capability authorizes) is included for diagnostics.
+    OverCeiling { requested: Capability },
+    /// The principal's MAC clearance does not dominate the request's label — the
+    /// S1 floor denies. This is independent of the ceiling: a principal may hold
+    /// a valid grant for an object whose label they are not cleared for. Both
+    /// gates must pass.
+    InsufficientClearance,
+    /// No sender-binding (DPoP proof) was supplied. ZSP: the minted token MUST
+    /// be sender-bound — a bearer token minted from a grant would re-introduce
+    /// standing access, defeating the whole model.
+    MissingSenderBinding,
+    /// The subject carried no derivable clearance at all (unlabeled subject).
+    /// Per S1, an unlabeled subject has no context and the monitor denies —
+    /// there is no default clearance.
+    UnlabeledSubject,
+    /// The grant carries no capabilities at all, so there is no ceiling to
+    /// request a subset of. An empty grant mints nothing.
+    EmptyGrant,
+}
+
+impl std::fmt::Display for GrantError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GrantError::Chain(e) => write!(f, "UCAN grant chain invalid: {e}"),
+            GrantError::OverCeiling { requested } => write!(
+                f,
+                "grant request exceeds ceiling (escalation denied pending amendment): {requested}"
+            ),
+            GrantError::InsufficientClearance => {
+                write!(
+                    f,
+                    "subject MAC clearance does not dominate the request label"
+                )
+            }
+            GrantError::MissingSenderBinding => {
+                write!(
+                    f,
+                    "UCAN grant token-exchange requires a sender-binding (DPoP) proof"
+                )
+            }
+            GrantError::UnlabeledSubject => {
+                write!(f, "subject carries no MAC clearance (unlabeled ⇒ deny)")
+            }
+            GrantError::EmptyGrant => write!(f, "grant carries no capabilities (empty ceiling)"),
+        }
+    }
+}
+
+impl std::error::Error for GrantError {}
+
+/// The outcome of evaluating a grant request: the fail-closed "mint" decision.
+///
+/// On `Permit`, [`GrantedAccess`] holds the **minimum subset** of the grant the
+/// token will encode (ZSP: never mint the whole grant; mint the least authority
+/// that covers the request). On `Escalate`, the request is over-ceiling and
+/// awaits a (deferred) amendment; the caller returns `insufficient_scope`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GrantDecision {
+    /// The request is a valid subset of a valid grant, the subject is cleared,
+    /// and a sender-binding is present. The contained [`GrantedAccess`] is what
+    /// the token minting layer encodes.
+    Permit(GrantedAccess),
+    /// The request exceeds the grant ceiling. Routed to the escalation tier
+    /// (TODO(#572-escalation)); until the tiered-decision lands this is a
+    /// denial. `requested` is the over-ceiling capability for diagnostics.
+    Escalate { requested: Capability },
+}
+
+/// The minimum subset of the grant a minted token will carry — the ZSP output.
+///
+/// This is the single capability (resource + ability + caveats) that the
+/// presenter requested, re-checked against the grant. It is intentionally a
+/// *subset* (≤ the grant), not the grant verbatim: the minted token is the
+/// least authority covering the request, so a refresh re-evaluation can only
+/// re-grant what was originally requested, never grow toward the ceiling.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GrantedAccess {
+    /// The capability the minted token encodes: the requested access, which is
+    /// guaranteed (by the ceiling-subset check) to be authorized by the grant.
+    pub capability: Capability,
+    /// The audience the token is minted for (RFC 8707 resource indicator), if
+    /// any. Carried through to the JWT `aud` claim.
+    pub audience: Option<String>,
+}
+
+/// A resolved grant request: the principal's desired access, parsed off the
+/// token-exchange `resource`/`scope` form fields into the S5 capability shape so
+/// the compiler's `authorize` can evaluate it.
+#[derive(Debug, Clone)]
+pub struct GrantRequest {
+    /// The resource being requested (`mac://model/qwen-7b` style). Required.
+    pub resource: Resource,
+    /// The ability being requested (`infer`, `model/read`, …). Required.
+    pub ability: Ability,
+    /// Caveats the presenter asks to be bound by (e.g. tenant). May be empty;
+    /// the resulting token is at least this restricted.
+    pub caveats: Caveats,
+    /// Optional audience (RFC 8707 resource indicator).
+    pub audience: Option<String>,
+    /// The MAC label of the object the request targets — used for the S1
+    /// clearance floor. `None` ⇒ unlabeled object ⇒ deny (the S1 rule). The
+    /// caller (OAuth layer) obtains this from the manifest/TE vocabulary; S6
+    /// does not invent it.
+    pub object_label: Option<SecurityLabel>,
+}
+
+/// Evaluate a UCAN grant request: the single fail-closed S6 path.
+///
+/// Inputs:
+/// - `grant`: the presented subset-UCAN (a delegation chain whose root
+///   capabilities are the ceiling for this request).
+/// - `verifier`: the S5 `UcanVerifier` (trust store resolving each issuer's
+///   anchored ML-DSA-65 key). Signatures are verified under the hybrid policy.
+/// - `now`: the single trusted clock (unix seconds), threaded unchanged into
+///   every chain link by S5 — never read from the token.
+/// - `request`: what the principal is asking to do now (the subset).
+/// - `subject`: the principal's verified security context (S1 clearance +
+///   assurance, clamped to verified key material). `None` ⇒ unlabeled ⇒ deny.
+/// - `sender_bound`: whether a DPoP proof was supplied and verified by the
+///   caller. ZSP requires sender-binding; `false` ⇒ deny.
+///
+/// Gates, in order (all fail-closed; the first failure wins):
+/// 1. **Sender-binding required** (ZSP) — no bearer tokens from a grant.
+/// 2. **Non-empty grant** — an empty grant mints nothing.
+/// 3. **Labeled subject** — S1: unlabeled subject ⇒ deny (no default clearance).
+/// 4. **Labeled object** — S1: unlabeled object ⇒ deny.
+/// 5. **MAC clearance floor** — `subject.clearance ⊒ object_label`.
+/// 6. **UCAN chain valid** — S5 `validate` (signatures + attenuation + temporal).
+/// 7. **Ceiling-subset** — `authorize_at(grant.capabilities(), grant.window,
+///    request, now)` permits. `Deny` ⇒ over-ceiling ⇒ `Escalate` (not auto-mint).
+///
+/// Order rationale: the cheap structural/label gates run before the
+/// cryptographic chain walk, so a malformed or uncleared request is rejected
+/// without spending the signature-verification budget. The chain is validated
+/// before the ceiling check so an invalid chain can never reach `authorize`.
+pub fn evaluate_grant<V: UcanVerifier + ?Sized>(
+    grant: &Ucan,
+    verifier: &V,
+    now: u64,
+    request: &GrantRequest,
+    subject: Option<&SecurityContext>,
+    sender_bound: bool,
+) -> Result<GrantDecision, GrantError> {
+    // (1) ZSP: sender-binding is mandatory. A bearer token minted from a grant
+    // re-introduces standing access — the exact thing ZSP removes. The caller
+    // verifies the DPoP proof; we only require that it did.
+    if !sender_bound {
+        return Err(GrantError::MissingSenderBinding);
+    }
+
+    // (2) An empty grant is no ceiling at all. (set_attenuates treats an empty
+    // `held` as covering only an empty `claimed`; we surface it explicitly so
+    // the error is unambiguous.)
+    if grant.capabilities().is_empty() {
+        return Err(GrantError::EmptyGrant);
+    }
+
+    // (3)+(4) S1 floor: unlabeled subject or unlabeled object ⇒ deny. The MAC
+    // model has no default clearance and no default label; absence is denial.
+    let subject = subject.ok_or(GrantError::UnlabeledSubject)?;
+    let object_label = request
+        .object_label
+        .ok_or(GrantError::InsufficientClearance)?;
+
+    // (5) MAC clearance dominance — the S1 floor, reused not reinvented.
+    // `SecurityContext::can_access` is the intrinsic lattice dominance
+    // (level ≥, assurance ≥, compartments ⊇). This gate is INDEPENDENT of the
+    // ceiling: a principal may hold a valid grant for an object whose label they
+    // are not cleared for (e.g. PQC-required object, classical-only subject).
+    // Both must pass.
+    if !subject.can_access(&object_label) {
+        return Err(GrantError::InsufficientClearance);
+    }
+
+    // (6) S5 full chain validation: structure → hybrid signatures →
+    // attenuation/linkage → temporal validity at `now`. Fail-closed on any
+    // malformation, widening, broken linkage, window escape, expiry, or
+    // over-depth. This is the load-bearing authority check; nothing below runs
+    // against an unvalidated chain.
+    if let Err(e) = chain::validate(grant, verifier, now) {
+        return Err(GrantError::Chain(e));
+    }
+
+    // (7) Ceiling-subset: is the requested access authorized by the grant's
+    // capabilities at `now`? This is S5's compiler `authorize_at`, the same
+    // relation `check_no_escalation` uses — not a parallel implementation.
+    let req = AccessRequest {
+        resource: request.resource.clone(),
+        ability: request.ability.clone(),
+        caveats: request.caveats.clone(),
+    };
+    let decision = authorize_at(
+        grant.capabilities(),
+        grant.payload.not_before,
+        grant.payload.expiration,
+        &req,
+        now,
+    );
+    match decision {
+        Decision::Permit => {
+            // ZSP: mint the LEAST authority covering the request — the requested
+            // capability itself, which `authorize` just confirmed the grant
+            // covers. Never mint the whole grant; a refresh can only re-grant
+            // this subset.
+            let capability = Capability::with_caveats(
+                request.resource.clone(),
+                request.ability.clone(),
+                request.caveats.clone(),
+            );
+            Ok(GrantDecision::Permit(GrantedAccess {
+                capability,
+                audience: request.audience.clone(),
+            }))
+        }
+        // Over-ceiling. This is the escalation tier ingress. S6 does NOT
+        // auto-escalate: a request beyond the ceiling is denied pending a
+        // ceiling amendment via the (deferred) tiered decision.
+        // TODO(#572-escalation): route to the tiered decision (static Casbin /
+        //   agentic / admin-UDF — authority-owned, MAC-bounded). Until that
+        //   lands, over-ceiling is a hard denial via the caller's
+        //   `insufficient_scope` response.
+        Decision::Deny | Decision::Escalate => Err(GrantError::OverCeiling {
+            requested: Capability::with_caveats(
+                request.resource.clone(),
+                request.ability.clone(),
+                request.caveats.clone(),
+            ),
+        }),
+    }
+}
+
+/// Re-evaluate a grant on token refresh: the ZSP "access is re-evaluated on
+/// refresh" property.
+///
+/// Refresh is NOT a free re-mint. The presenter must re-present the grant (the
+/// ceiling may have been amended or revoked since the access token was minted),
+/// and the same [`evaluate_grant`] gates run again. This is a thin forwarder
+/// today — the name exists so the refresh path has an obvious, audited call site
+/// distinct from the initial mint, and so the deferred rotation logic
+/// (TODO(#572-refresh-rotation)) has a home.
+///
+/// SECURITY: the refresh MUST supply a fresh DPoP proof (`sender_bound` from a
+/// new proof, not carried over) and the same `now`-threading rules apply.
+pub fn evaluate_refresh<V: UcanVerifier + ?Sized>(
+    grant: &Ucan,
+    verifier: &V,
+    now: u64,
+    request: &GrantRequest,
+    subject: Option<&SecurityContext>,
+    sender_bound: bool,
+) -> Result<GrantDecision, GrantError> {
+    // Identical gates to the initial mint. ZSP: no path diverges here — a
+    // refresh that weakens any gate is a refresh that denies.
+    evaluate_grant(grant, verifier, now, request, subject, sender_bound)
+}
+
+/// Resolve the S1 `SecurityContext` for a UCAN grant's audience from a
+/// `SubjectContextClaims` implementation.
+///
+/// This is the seam between "the UCAN names an audience DID" and "the S1
+/// clearance floor needs a verified subject context". The caller resolves the
+/// audience DID to whatever claims object it has (envelope claims, registered
+/// subject, …) implementing `SubjectContextClaims`, plus the assurance derived
+/// from the verified key material. Returns `None` for an unlabeled subject —
+/// which [`evaluate_grant`] maps to [`GrantError::UnlabeledSubject`].
+///
+/// S6 does not invent clearance: it only forwards what the claims layer
+/// already provides (S1 contract). The concrete `clearance` field on `Claims`
+/// lands with S8 (#574); until then implementors test against a stub claims
+/// object, exactly as S1/S2 do.
+pub fn subject_context(
+    claims: &dyn SubjectContextClaims,
+    key_material: VerifiedKeyMaterial,
+) -> Option<SecurityContext> {
+    claims.security_context(key_material)
+}
+
+// A small helper kept private so the public surface stays minimal: the
+// reference decision used by tests to cross-check the compiler path. Not part
+// of the contract.
+#[cfg(test)]
+fn reference_authorize(grant: &[Capability], request: &AccessRequest) -> Decision {
+    crate::mac::compiler::authorize(grant, request)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    //! S6 negative tests + the happy path. No test asserts permissive behaviour:
+    //! every case either confirms a correct minimal mint or confirms a denial.
+    //! The denial cases are the security load — over-ceiling, bad chain,
+    //! insufficient clearance, missing DPoP.
+    use super::*;
+    use crate::mac::te::Decision;
+    use ed25519_dalek::{SigningKey, VerifyingKey};
+    use hyprstream_rpc::auth::mac::{
+        Assurance, CompartmentSet, Level, SecurityLabel, VerifiedKeyMaterial,
+    };
+    use hyprstream_rpc::auth::ucan::capability::{Ability, Capability, Resource};
+    use hyprstream_rpc::auth::ucan::token::{Did, Ucan, UcanError, UcanPayload, UcanVerifier};
+    use hyprstream_rpc::crypto::cose_sign::{sign_composite, verify_composite};
+    use hyprstream_rpc::crypto::pq::{ml_dsa_generate_keypair, MlDsaSigningKey, MlDsaVerifyingKey};
+    use std::collections::HashMap;
+
+    /// Domain-separation AAD for UCAN payload signatures — matches S5's
+    /// (`hs-mac-ucan-payload-v1`), so signatures produced here verify under S5.
+    const UCAN_AAD: &[u8] = b"hs-mac-ucan-payload-v1";
+
+    /// Trusted `now` inside every test UCAN's validity window
+    /// (`not_before: None`, `expiration: 9_999_999_999`).
+    const NOW: u64 = 1_000;
+
+    /// A hybrid keypair (Ed25519 + ML-DSA-65) for one DID, mirroring S5's
+    /// `TestIdentity` but built here on public APIs so S6 tests do not depend on
+    /// S5's `pub(super)` test_support.
+    struct Identity {
+        ed_sk: SigningKey,
+        ed_vk: VerifyingKey,
+        pq_sk: MlDsaSigningKey,
+        pq_vk: MlDsaVerifyingKey,
+    }
+
+    impl Identity {
+        fn generate() -> Self {
+            use rand::rngs::OsRng;
+            let ed_sk = SigningKey::generate(&mut OsRng);
+            let ed_vk = ed_sk.verifying_key();
+            let (pq_sk, pq_vk) = ml_dsa_generate_keypair();
+            Self {
+                ed_sk,
+                ed_vk,
+                pq_sk,
+                pq_vk,
+            }
+        }
+
+        fn did(&self) -> Did {
+            Did::from_ed25519(&self.ed_vk.to_bytes())
+        }
+    }
+
+    /// A trust store keyed by DID string → anchored ML-DSA-65 verifying key,
+    /// implementing `UcanVerifier` over the real hybrid composite verify. Mirrors
+    /// S5's `TestTrustStore`.
+    struct TrustStore {
+        pq_by_did: HashMap<String, MlDsaVerifyingKey>,
+    }
+
+    impl TrustStore {
+        fn new() -> Self {
+            Self {
+                pq_by_did: HashMap::new(),
+            }
+        }
+        fn anchor(&mut self, id: &Identity) {
+            self.pq_by_did
+                .insert(id.did().into_string(), id.pq_vk.clone());
+        }
+    }
+
+    impl UcanVerifier for TrustStore {
+        fn verify(
+            &self,
+            issuer: &Did,
+            ed_key: &[u8; 32],
+            payload: &[u8],
+            signature: &[u8],
+        ) -> Result<(), UcanError> {
+            let ed_vk = VerifyingKey::from_bytes(ed_key)
+                .map_err(|e| UcanError::BadSignature(e.to_string()))?;
+            let pq_vk = self.pq_by_did.get(issuer.as_str());
+            verify_composite(signature, &ed_vk, pq_vk, payload, UCAN_AAD, true)
+                .map(|_| ())
+                .map_err(|e| UcanError::BadSignature(e.to_string()))
+        }
+    }
+
+    /// Build and hybrid-sign a UCAN from `issuer` to `audience` with `caps` and
+    /// `proofs`. Mirrors S5's `signed_ucan` helper.
+    fn signed_ucan(
+        issuer: &Identity,
+        audience: &Did,
+        caps: Vec<Capability>,
+        proofs: Vec<Ucan>,
+    ) -> Ucan {
+        let payload = UcanPayload {
+            issuer: issuer.did(),
+            audience: audience.clone(),
+            capabilities: caps,
+            not_before: None,
+            expiration: Some(9_999_999_999),
+            nonce: vec![1, 2, 3],
+        };
+        let bytes = payload.signing_bytes().unwrap();
+        let signature =
+            sign_composite(&issuer.ed_sk, Some(&issuer.pq_sk), &bytes, UCAN_AAD).unwrap();
+        Ucan {
+            payload,
+            proofs,
+            signature,
+        }
+    }
+
+    fn cap(resource: &str, ability: &str) -> Capability {
+        Capability::new(Resource::new(resource), Ability::new(ability))
+    }
+
+    /// A compartment bitset from bit indices.
+    fn comps(bits: &[u32]) -> CompartmentSet {
+        bits.iter().copied().collect()
+    }
+
+    /// A subject cleared to (Secret, PqHybrid, {0,1}) — dominates most test
+    /// object labels. Built with PqHybrid key material so assurance is not the
+    /// binding constraint.
+    fn cleared_subject() -> SecurityContext {
+        SecurityContext::new(Level::Secret, comps(&[0, 1]), VerifiedKeyMaterial::PqHybrid)
+    }
+
+    fn req(resource: &str, ability: &str, label: SecurityLabel) -> GrantRequest {
+        GrantRequest {
+            resource: Resource::new(resource),
+            ability: Ability::new(ability),
+            caveats: Caveats::default(),
+            audience: None,
+            object_label: Some(label),
+        }
+    }
+
+    /// A single-capability self-issued root UCAN granting `cap`, hybrid-signed,
+    /// plus a trust store anchoring its PQ key.
+    fn root_grant(cap: Capability) -> (Ucan, TrustStore) {
+        let id = Identity::generate();
+        let u = signed_ucan(&id, &id.did(), vec![cap], vec![]);
+        let mut s = TrustStore::new();
+        s.anchor(&id);
+        (u, s)
+    }
+
+    // ── Happy path: subset within ceiling, cleared, sender-bound ────────────
+
+    #[test]
+    fn subset_within_ceiling_permits_minimal_mint() {
+        // Grant: mac://model/* / model/*. Request: mac://model/qwen / model/read
+        // — a strict subset. Subject cleared, DPoP present, object at a label
+        // the subject dominates.
+        let (grant, store) = root_grant(cap("mac://model/*", "model/*"));
+        let object_label =
+            SecurityLabel::new(Level::Confidential, Assurance::PqHybrid, comps(&[0]));
+        let request = req("mac://model/qwen", "model/read", object_label);
+
+        let decision = match evaluate_grant(
+            &grant,
+            &store,
+            NOW,
+            &request,
+            Some(&cleared_subject()),
+            true, // sender-bound
+        ) {
+            Ok(d) => d,
+            Err(e) => {
+                panic!("a strict subset of a valid grant, cleared + bound, must permit: {e:?}")
+            }
+        };
+
+        let granted = match decision {
+            GrantDecision::Permit(g) => g,
+            other => panic!("expected Permit, got {other:?}"),
+        };
+        // ZSP: the minted capability is the REQUESTED subset, not the grant.
+        assert_eq!(
+            granted.capability.resource,
+            Resource::new("mac://model/qwen")
+        );
+        assert_eq!(granted.capability.ability, Ability::new("model/read"));
+        // Cross-check: the reference compiler decision agrees (no parallel impl).
+        assert_eq!(
+            reference_authorize(
+                grant.capabilities(),
+                &AccessRequest {
+                    resource: request.resource.clone(),
+                    ability: request.ability.clone(),
+                    caveats: request.caveats.clone(),
+                }
+            ),
+            Decision::Permit
+        );
+    }
+
+    // ── Fail-closed: over-ceiling (escalation) ──────────────────────────────
+
+    #[test]
+    fn over_ceiling_request_is_denied_not_escalated() {
+        // Grant: mac://model/qwen only. Request: mac://model/* (wider resource)
+        // — widening past the ceiling. Must deny; must NOT auto-mint the
+        // requested wider capability.
+        let (grant, store) = root_grant(cap("mac://model/qwen", "model/read"));
+        let object_label =
+            SecurityLabel::new(Level::Confidential, Assurance::PqHybrid, comps(&[0]));
+        let request = req("mac://model/*", "model/read", object_label);
+
+        let outcome = evaluate_grant(
+            &grant,
+            &store,
+            NOW,
+            &request,
+            Some(&cleared_subject()),
+            true,
+        );
+        match outcome {
+            Err(GrantError::OverCeiling { .. }) => {}
+            other => panic!("expected OverCeiling denial, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn over_ceiling_on_ability_is_denied() {
+        // Grant: model/read. Request: model/write — wider ability. Deny.
+        let (grant, store) = root_grant(cap("mac://model/qwen", "model/read"));
+        let object_label =
+            SecurityLabel::new(Level::Confidential, Assurance::PqHybrid, comps(&[0]));
+        let request = req("mac://model/qwen", "model/write", object_label);
+
+        assert!(matches!(
+            evaluate_grant(
+                &grant,
+                &store,
+                NOW,
+                &request,
+                Some(&cleared_subject()),
+                true
+            ),
+            Err(GrantError::OverCeiling { .. })
+        ));
+    }
+
+    // ── Fail-closed: bad chain ──────────────────────────────────────────────
+
+    #[test]
+    fn broken_signature_is_denied() {
+        // Tamper the grant's signature → S5 chain validation fails → S6 denies.
+        let (mut grant, store) = root_grant(cap("mac://model/*", "model/*"));
+        grant.signature[0] ^= 0xFF; // break the hybrid signature
+        let object_label =
+            SecurityLabel::new(Level::Confidential, Assurance::PqHybrid, comps(&[0]));
+        let request = req("mac://model/qwen", "model/read", object_label);
+
+        match evaluate_grant(
+            &grant,
+            &store,
+            NOW,
+            &request,
+            Some(&cleared_subject()),
+            true,
+        ) {
+            Err(GrantError::Chain(_)) => {}
+            other => panic!("expected Chain denial on bad signature, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn widening_chain_is_denied() {
+        // A 2-link chain where the delegate widens past its delegator — S5
+        // rejects the chain; S6 must surface that as a Chain denial (NOT a
+        // ceiling check, because the chain never validated).
+        let root = Identity::generate();
+        let alice = Identity::generate();
+        let root_ucan = signed_ucan(
+            &root,
+            &alice.did(),
+            vec![cap("mac://model/*", "model/read")],
+            vec![],
+        );
+        // alice widens: claims mac://other/* past root's mac://model/*.
+        let alice_ucan = signed_ucan(
+            &alice,
+            &alice.did(),
+            vec![cap("mac://other/*", "model/*")],
+            vec![root_ucan],
+        );
+        let mut store = TrustStore::new();
+        store.anchor(&root);
+        store.anchor(&alice);
+
+        let object_label =
+            SecurityLabel::new(Level::Confidential, Assurance::PqHybrid, comps(&[0]));
+        let request = req("mac://other/x", "model/read", object_label);
+
+        match evaluate_grant(
+            &alice_ucan,
+            &store,
+            NOW,
+            &request,
+            Some(&cleared_subject()),
+            true,
+        ) {
+            Err(GrantError::Chain(ChainError::Widening { .. })) => {}
+            other => panic!("expected Chain::Widening denial, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn expired_grant_is_denied() {
+        // A grant that has expired at now=2000. S5's absolute-time gate denies;
+        // S6 surfaces it as a Chain::Expired denial.
+        let id = Identity::generate();
+        let payload = UcanPayload {
+            issuer: id.did(),
+            audience: id.did(),
+            capabilities: vec![cap("mac://model/*", "model/*")],
+            not_before: None,
+            expiration: Some(500), // expired well before now=2000
+            nonce: vec![],
+        };
+        let bytes = payload.signing_bytes().unwrap();
+        let signature = sign_composite(&id.ed_sk, Some(&id.pq_sk), &bytes, UCAN_AAD).unwrap();
+        let grant = Ucan {
+            payload,
+            proofs: vec![],
+            signature,
+        };
+        let mut store = TrustStore::new();
+        store.anchor(&id);
+
+        let object_label =
+            SecurityLabel::new(Level::Confidential, Assurance::PqHybrid, comps(&[0]));
+        let request = req("mac://model/qwen", "model/read", object_label);
+
+        match evaluate_grant(
+            &grant,
+            &store,
+            2000,
+            &request,
+            Some(&cleared_subject()),
+            true,
+        ) {
+            Err(GrantError::Chain(ChainError::Expired { .. })) => {}
+            other => panic!("expected Chain::Expired denial, got {other:?}"),
+        }
+    }
+
+    // ── Fail-closed: insufficient MAC clearance ─────────────────────────────
+
+    #[test]
+    fn insufficient_clearance_is_denied() {
+        // Grant valid for the request, but the object label requires a
+        // compartment (bit 5) the subject is NOT cleared into. The S1 floor
+        // denies independently of the ceiling.
+        let (grant, store) = root_grant(cap("mac://model/*", "model/*"));
+        // Object at {Confidential, PqHybrid, {5}} — subject only has {0,1}.
+        let object_label =
+            SecurityLabel::new(Level::Confidential, Assurance::PqHybrid, comps(&[5]));
+        let request = req("mac://model/qwen", "model/read", object_label);
+
+        match evaluate_grant(
+            &grant,
+            &store,
+            NOW,
+            &request,
+            Some(&cleared_subject()),
+            true,
+        ) {
+            Err(GrantError::InsufficientClearance) => {}
+            other => panic!("expected InsufficientClearance denial, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classical_subject_denied_on_pq_object() {
+        // #548 end-to-end at the grant path: an object labeled PqHybrid is
+        // unreachable by a Classical-assurance subject via the SAME dominance
+        // check — no separate path.
+        let (grant, store) = root_grant(cap("mac://model/*", "model/*"));
+        let object_label =
+            SecurityLabel::new(Level::Public, Assurance::PqHybrid, CompartmentSet::EMPTY);
+        let request = req("mac://model/qwen", "model/read", object_label);
+        // Classical subject (cleared high in level, but Classical assurance).
+        let classical = SecurityContext::new(
+            Level::Secret,
+            comps(&[0, 1]),
+            VerifiedKeyMaterial::Classical,
+        );
+
+        assert!(matches!(
+            evaluate_grant(&grant, &store, NOW, &request, Some(&classical), true),
+            Err(GrantError::InsufficientClearance)
+        ));
+    }
+
+    // ── Fail-closed: missing sender-binding (ZSP) ───────────────────────────
+
+    #[test]
+    fn missing_sender_binding_is_denied() {
+        // A request that would otherwise permit, but with no DPoP proof. ZSP:
+        // the minted token MUST be sender-bound. Deny before any other gate.
+        let (grant, store) = root_grant(cap("mac://model/*", "model/*"));
+        let object_label =
+            SecurityLabel::new(Level::Confidential, Assurance::PqHybrid, comps(&[0]));
+        let request = req("mac://model/qwen", "model/read", object_label);
+
+        match evaluate_grant(
+            &grant,
+            &store,
+            NOW,
+            &request,
+            Some(&cleared_subject()),
+            false, // no sender-binding
+        ) {
+            Err(GrantError::MissingSenderBinding) => {}
+            other => panic!("expected MissingSenderBinding denial, got {other:?}"),
+        }
+    }
+
+    // ── Fail-closed: unlabeled subject / object, empty grant ────────────────
+
+    #[test]
+    fn unlabeled_subject_is_denied() {
+        let (grant, store) = root_grant(cap("mac://model/*", "model/*"));
+        let object_label =
+            SecurityLabel::new(Level::Public, Assurance::Classical, CompartmentSet::EMPTY);
+        let request = req("mac://model/qwen", "model/read", object_label);
+
+        // No subject context at all.
+        assert!(matches!(
+            evaluate_grant(&grant, &store, NOW, &request, None, true),
+            Err(GrantError::UnlabeledSubject)
+        ));
+    }
+
+    #[test]
+    fn unlabeled_object_is_denied() {
+        let (grant, store) = root_grant(cap("mac://model/*", "model/*"));
+        // No object label supplied ⇒ the S1 floor cannot be evaluated ⇒ deny.
+        let request = GrantRequest {
+            resource: Resource::new("mac://model/qwen"),
+            ability: Ability::new("model/read"),
+            caveats: Caveats::default(),
+            audience: None,
+            object_label: None,
+        };
+
+        assert!(matches!(
+            evaluate_grant(
+                &grant,
+                &store,
+                NOW,
+                &request,
+                Some(&cleared_subject()),
+                true
+            ),
+            Err(GrantError::InsufficientClearance)
+        ));
+    }
+
+    #[test]
+    fn empty_grant_is_denied() {
+        // A self-issued root with NO capabilities — an empty ceiling.
+        let id = Identity::generate();
+        let empty = signed_ucan(&id, &id.did(), vec![], vec![]);
+        let mut store = TrustStore::new();
+        store.anchor(&id);
+
+        let object_label =
+            SecurityLabel::new(Level::Public, Assurance::Classical, CompartmentSet::EMPTY);
+        let request = req("mac://x", "y", object_label);
+
+        assert!(matches!(
+            evaluate_grant(
+                &empty,
+                &store,
+                NOW,
+                &request,
+                Some(&cleared_subject()),
+                true
+            ),
+            Err(GrantError::EmptyGrant)
+        ));
+    }
+
+    // ── Caveat subset honoured (more-restrictive request is still a subset) ──
+
+    #[test]
+    fn caveat_added_in_request_still_subset() {
+        // Grant: mac://model/* / * with tenant=acme caveat. Request: same but
+        // ALSO adds a max=5 caveat (more restricted) ⇒ still attenuates.
+        use hyprstream_rpc::auth::ucan::capability::CaveatValue;
+        use std::collections::BTreeMap;
+        let mut g_caveats = BTreeMap::new();
+        g_caveats.insert("tenant".to_owned(), CaveatValue::Text("acme".to_owned()));
+        let cap_with_caveat = Capability::with_caveats(
+            Resource::new("mac://model/*"),
+            Ability::new("model/*"),
+            Caveats(g_caveats),
+        );
+        let (grant, store) = root_grant(cap_with_caveat);
+
+        let mut r_caveats = BTreeMap::new();
+        r_caveats.insert("tenant".to_owned(), CaveatValue::Text("acme".to_owned()));
+        r_caveats.insert("max".to_owned(), CaveatValue::Int(5));
+        let object_label =
+            SecurityLabel::new(Level::Confidential, Assurance::PqHybrid, comps(&[0]));
+        let request = GrantRequest {
+            resource: Resource::new("mac://model/qwen"),
+            ability: Ability::new("model/read"),
+            caveats: Caveats(r_caveats),
+            audience: None,
+            object_label: Some(object_label),
+        };
+
+        assert!(matches!(
+            evaluate_grant(
+                &grant,
+                &store,
+                NOW,
+                &request,
+                Some(&cleared_subject()),
+                true
+            ),
+            Ok(GrantDecision::Permit(_))
+        ));
+    }
+
+    #[test]
+    fn caveat_dropped_in_request_is_over_ceiling() {
+        // Grant has tenant=acme; request drops it ⇒ widening on caveats ⇒ deny.
+        use hyprstream_rpc::auth::ucan::capability::CaveatValue;
+        use std::collections::BTreeMap;
+        let mut g_caveats = BTreeMap::new();
+        g_caveats.insert("tenant".to_owned(), CaveatValue::Text("acme".to_owned()));
+        let cap_with_caveat = Capability::with_caveats(
+            Resource::new("mac://model/*"),
+            Ability::new("model/*"),
+            Caveats(g_caveats),
+        );
+        let (grant, store) = root_grant(cap_with_caveat);
+
+        let object_label =
+            SecurityLabel::new(Level::Confidential, Assurance::PqHybrid, comps(&[0]));
+        // Request has NO caveats — drops tenant ⇒ over-ceiling.
+        let request = req("mac://model/qwen", "model/read", object_label);
+
+        assert!(matches!(
+            evaluate_grant(
+                &grant,
+                &store,
+                NOW,
+                &request,
+                Some(&cleared_subject()),
+                true
+            ),
+            Err(GrantError::OverCeiling { .. })
+        ));
+    }
+
+    // ── Refresh is the same gate (ZSP: no weaker path) ─────────────────────
+
+    #[test]
+    fn refresh_runs_the_same_gates_as_mint() {
+        let (grant, store) = root_grant(cap("mac://model/*", "model/*"));
+        let object_label =
+            SecurityLabel::new(Level::Confidential, Assurance::PqHybrid, comps(&[0]));
+        let request = req("mac://model/qwen", "model/read", object_label);
+
+        let mint = evaluate_grant(
+            &grant,
+            &store,
+            NOW,
+            &request,
+            Some(&cleared_subject()),
+            true,
+        );
+        let refresh = evaluate_refresh(
+            &grant,
+            &store,
+            NOW,
+            &request,
+            Some(&cleared_subject()),
+            true,
+        );
+        assert_eq!(format!("{mint:?}"), format!("{refresh:?}"));
+
+        // And refresh denies on a missing binding just like mint.
+        assert!(matches!(
+            evaluate_refresh(
+                &grant,
+                &store,
+                NOW,
+                &request,
+                Some(&cleared_subject()),
+                false
+            ),
+            Err(GrantError::MissingSenderBinding)
+        ));
+    }
+}

--- a/crates/hyprstream/src/mac/mod.rs
+++ b/crates/hyprstream/src/mac/mod.rs
@@ -57,6 +57,10 @@
 pub mod avc;
 pub mod compiled;
 pub mod compiler;
+// S6 (#572): runtime grant path — UCAN grant-request → access/refresh tokens.
+// Pure fail-closed core: grant validation + ceiling-subset + MAC clearance +
+// sender-binding, consuming S1/S5/the compiler rather than re-implementing.
+pub mod exchange;
 pub mod lattice;
 pub mod te;
 
@@ -85,3 +89,26 @@ pub use compiler::{
     authorize, authorize_at, check_no_escalation, compile, compile_policy, missing_permission,
     AccessRequest, CompileError, PermissionMap, PrivilegeEscalation,
 };
+
+/// Construct the [`UcanVerifier`] the HTTP grant path uses to validate a
+/// presented UCAN's signatures.
+///
+/// This is the S6↔trust-store seam: the verifier resolves each UCAN issuer's
+/// anchored ML-DSA-65 verifying key (the same `register_pq_trust` binding the
+/// rest of the TCB uses). Until that binding is wired through the OAuth state,
+/// this returns `None`, which makes the HTTP grant path deny every request
+/// (`evaluate_grant` never runs against an unverified chain — fail-closed).
+///
+/// The core `evaluate_grant` is exercised through its own tests with a real
+/// verifier, so the security-critical logic is covered independently of this
+/// wiring landing.
+///
+/// TODO(#572-verifier): wire the trust store's anchored PQ keys into a concrete
+///   `UcanVerifier` and return it from this function.
+pub fn exchange_ucan_verifier(
+    _state: &crate::services::oauth::state::OAuthState,
+) -> Option<Box<dyn hyprstream_rpc::auth::ucan::token::UcanVerifier + Send + Sync>> {
+    // Fail-closed: no verifier is wired ⇒ the HTTP grant path denies. The
+    // single authority path; no fallback.
+    None
+}

--- a/crates/hyprstream/src/services/oauth/token.rs
+++ b/crates/hyprstream/src/services/oauth/token.rs
@@ -136,6 +136,21 @@ pub async fn exchange_token(
                 Some(t) => t,
                 None => return token_error(StatusCode::BAD_REQUEST, "invalid_request", Some("subject_token_type is required")),
             };
+            // S6 (#572): the UCAN grant path. Routed on a dedicated
+            // `subject_token_type` so it cannot be confused with the OIDC/WIT
+            // exchange flows. Requires sender-binding (DPoP) — ZSP.
+            if subject_token_type == crate::mac::exchange::UCAN_GRANT_TOKEN_TYPE {
+                let resolver = super::token_exchange::DenyUnlabeledResolver;
+                return super::token_exchange::exchange_ucan_grant(
+                    &state,
+                    &subject_token,
+                    dpop_header.as_deref(),
+                    params.scope.as_deref(),
+                    params.audience.as_deref(),
+                    &resolver,
+                )
+                .await;
+            }
             super::token_exchange::exchange_token_exchange(
                 &state,
                 &subject_token,

--- a/crates/hyprstream/src/services/oauth/token_exchange.rs
+++ b/crates/hyprstream/src/services/oauth/token_exchange.rs
@@ -17,6 +17,9 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use sha2::{Digest, Sha256};
 
 use super::state::OAuthState;
+use crate::mac::exchange::{
+    evaluate_grant, GrantDecision, GrantedAccess, GrantError, GrantRequest,
+};
 use crate::services::generated::policy_client::IssueToken;
 
 const TOKEN_TYPE_ID_TOKEN: &str = "urn:ietf:params:oauth:token-type:id_token";
@@ -260,4 +263,372 @@ fn tx_error(status: StatusCode, error: &str, description: &str) -> Response {
         })),
     )
         .into_response()
+}
+
+// ─── S6: UCAN grant → access/refresh tokens (#572) ─────────────────────────
+//
+// This is the HTTP-layer wiring over `mac::exchange::evaluate_grant`. The
+// security-critical logic (chain validation, ceiling-subset, MAC clearance,
+// sender-binding) lives in `mac::exchange`; this handler is the RFC 8693
+// adapter that decodes the grant, verifies the DPoP proof, resolves the
+// subject's MAC context, calls `evaluate_grant`, and mints the short-ttl
+// sender-bound token the decision authorizes.
+//
+// SCOPE / fail-closed reality: the MAC *clearance* a subject carries is a wire
+// field that lands with S8 (#574, hybrid envelope) — see the S1 BLOCKERS note
+// (`SubjectContextClaims` seam). Until S8 ships `clearance` on `Claims`, the
+// `SubjectContextResolver` below defaults to returning `None`, which
+// `evaluate_grant` maps to `UnlabeledSubject` ⇒ DENY. That is the correct
+// fail-closed posture: there is NO standing access without a verified clearance,
+// and the HTTP path does not fabricate one. The core `evaluate_grant` (with full
+// test coverage of the clearance gate) is the sound, proven core; this handler
+// lights up the happy path automatically the moment S8 supplies a non-`None`
+// resolver.
+
+/// Resolve a UCAN audience DID → the S1 [`SecurityContext`] it presents at grant
+/// time (clearance clamped to verified key material).
+///
+/// This is the seam S8 (#574) plugs into: once the `clearance` field ships on
+/// the hybrid-signed `Claims`/envelope, an implementor reads it off the verified
+/// identity bound to the audience DID and returns the assembled context. Until
+/// then the default impl returns `None` (→ `UnlabeledSubject` → deny), which is
+/// the fail-closed ZSP posture: no clearance ⇒ no token.
+///
+/// SECURITY: the resolution MUST be from *authority-asserted* clearance (a
+/// field the issuing node signed), never from a self-asserted claim in the
+/// UCAN. The UCAN is the grant; the clearance is independent state the MAC
+/// model holds about the subject.
+pub trait SubjectContextResolver: Send + Sync {
+    /// The clearance context for `audience_did`, or `None` if the subject is
+    /// unlabeled / unverified. `None` ⇒ `evaluate_grant` denies.
+    fn resolve(&self, audience_did: &str) -> Option<hyprstream_rpc::auth::mac::SecurityContext>;
+}
+
+/// A no-op resolver that always returns `None` — the fail-closed default until
+/// S8 (#574) ships a concrete `SubjectContextResolver` reading the `clearance`
+/// field off verified claims.
+pub struct DenyUnlabeledResolver;
+
+impl SubjectContextResolver for DenyUnlabeledResolver {
+    fn resolve(&self, _audience_did: &str) -> Option<hyprstream_rpc::auth::mac::SecurityContext> {
+        // Fail-closed: no clearance is known ⇒ no token. See the trait docs and
+        // the S1 BLOCKERS note on why this cannot be loosened before S8.
+        None
+    }
+}
+
+/// POST /oauth/token — UCAN grant (RFC 8693 token-exchange,
+/// `subject_token_type = urn:hyprstream:token-type:ucan-grant`).
+///
+/// Accepts a CBOR-encoded UCAN as the `subject_token` (the subset-grant) and
+/// mints a **short-ttl, sender-bound** access token (+ refresh token when the
+/// store is configured) for the requested access — never the whole grant (ZSP).
+///
+/// `dpop_header` is the `DPoP` proof header; it is MANDATORY for this grant
+/// type (ZSP: no bearer). The proof signature/htm/htu/replay are verified here
+/// via the same `verify_dpop_proof` the other grant types use; the resulting
+/// `jkt` is the sender-binding thumbprint. Passing `None` ⇒ `invalid_request`.
+///
+/// `subject_resolver` supplies the MAC clearance; `DenyUnlabeledResolver`
+/// denies until S8 ships the real resolver.
+///
+/// Fail-closed: every `GrantError` maps to a concrete OAuth error. There is no
+/// fallback path; authority-unreachable is a denial.
+pub async fn exchange_ucan_grant(
+    state: &Arc<OAuthState>,
+    subject_token: &str,
+    dpop_header: Option<&str>,
+    requested_scope: Option<&str>,
+    audience: Option<&str>,
+    subject_resolver: &dyn SubjectContextResolver,
+) -> Response {
+    // ── 1. DPoP sender-binding is MANDATORY (ZSP) ──────────────────────────
+    // No proof ⇒ no token. A bearer token minted from a grant re-introduces
+    // standing access — the exact thing ZSP removes.
+    let token_endpoint = format!("{}/oauth/token", state.issuer_url.trim_end_matches('/'));
+    let dpop_jkt = match dpop_header.and_then(|h| {
+        super::dpop::verify_dpop_proof(h, "POST", &token_endpoint, None)
+            .ok()
+            .map(|p| p.jkt)
+    }) {
+        Some(jkt) => jkt,
+        None => {
+            return tx_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_request",
+                "UCAN grant token-exchange requires a valid DPoP proof (sender-binding)",
+            );
+        }
+    };
+
+    // ── 2. Decode the CBOR UCAN grant ──────────────────────────────────────
+    let ucan_bytes = match URL_SAFE_NO_PAD.decode(subject_token) {
+        Ok(b) => b,
+        Err(_) => {
+            return tx_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_request",
+                "subject_token is not valid base64url CBOR",
+            );
+        }
+    };
+    let grant = match hyprstream_rpc::auth::ucan::token::Ucan::from_cbor(&ucan_bytes) {
+        Ok(u) => u,
+        Err(e) => {
+            return tx_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_grant",
+                &format!("subject_token is not a valid UCAN: {e}"),
+            );
+        }
+    };
+
+    // ── 3. Resolve the subject's MAC context (S8 seam; deny until then) ────
+    let audience_did = grant.audience().as_str().to_owned();
+    let subject_ctx = subject_resolver.resolve(&audience_did);
+
+    // ── 4. Parse the requested access off the form fields ──────────────────
+    // TODO(#572-object-label): wire the manifest/TE object-label resolver so
+    //   the S1 floor can be evaluated for real. Until then `object_label` is
+    //   `None`, which makes the S1 object-label gate deny — the conservative
+    //   direction.
+    let request = match parse_grant_request(requested_scope, audience) {
+        Ok(r) => r,
+        Err(msg) => return tx_error(StatusCode::BAD_REQUEST, "invalid_scope", &msg),
+    };
+
+    // ── 5. The single fail-closed S6 path ──────────────────────────────────
+    // A no-op UcanVerifier is NOT acceptable — signatures MUST verify. The
+    // verifier is built from the trust store's anchored ML-DSA-65 keys (the
+    // same `register_pq_trust` binding the rest of the TCB uses). Until that
+    // binding is wired into the OAuth state, the grant path fails closed here
+    // rather than trusting an unverified chain. There is NO fallback path.
+    //
+    // TODO(#572-verifier): construct the UcanVerifier from the trust store's
+    //   anchored ML-DSA-65 keys. Until that wiring lands, the HTTP grant path
+    //   denies every request at this gate — the conservative direction. The
+    //   core `evaluate_grant` (with full happy-path + denial coverage) is
+    //   exercised through its own tests using a real `UcanVerifier`.
+    let Some(verifier) = crate::mac::exchange_ucan_verifier(state) else {
+        return tx_error(
+            StatusCode::FORBIDDEN,
+            "server_error",
+            "UCAN grant verification is not configured on this node",
+        );
+    };
+    let now = chrono::Utc::now().timestamp().max(0) as u64;
+    let decision = evaluate_grant(
+        &grant,
+        &verifier,
+        now,
+        &request,
+        subject_ctx.as_ref(),
+        true, // sender-bound: dpop_jkt is present
+    );
+
+    let granted = match decision {
+        Ok(GrantDecision::Permit(g)) => g,
+        Ok(GrantDecision::Escalate { .. }) => {
+            // Over-ceiling: the escalation tier (TODO #572-escalation) is not
+            // wired; return insufficient_scope. Do NOT auto-mint.
+            return tx_error(
+                StatusCode::FORBIDDEN,
+                "insufficient_scope",
+                "grant request exceeds ceiling; escalation amendment required",
+            );
+        }
+        Err(e) => return grant_error_response(e),
+    };
+
+    // ── 6. Mint the short-ttl sender-bound access token (ZSP) ──────────────
+    mint_grant_token(state, &granted, &dpop_jkt).await
+}
+
+/// Map an S6 [`GrantError`] to a concrete OAuth 2.1 error response. Every variant
+/// is fail-closed; no variant maps to a permissive outcome.
+fn grant_error_response(e: GrantError) -> Response {
+    let (status, code, desc) = match &e {
+        GrantError::Chain(_) => (
+            StatusCode::UNAUTHORIZED,
+            "invalid_grant",
+            "UCAN grant chain failed validation".to_owned(),
+        ),
+        // Over-ceiling and insufficient-clearance both surface as
+        // `insufficient_scope`: the request is not within the grant/label the
+        // subject is authorized for. Distinct GrantError variants (different
+        // gates) but the same OAuth error shape for the client.
+        GrantError::OverCeiling { .. } | GrantError::InsufficientClearance => (
+            StatusCode::FORBIDDEN,
+            "insufficient_scope",
+            e.to_string(),
+        ),
+        GrantError::MissingSenderBinding => {
+            (StatusCode::BAD_REQUEST, "invalid_request", e.to_string())
+        }
+        GrantError::UnlabeledSubject | GrantError::EmptyGrant => {
+            (StatusCode::FORBIDDEN, "invalid_grant", e.to_string())
+        }
+    };
+    tx_error(status, code, &desc)
+}
+
+/// Parse the RFC 8693 `scope` + `audience` form fields into the S6
+/// [`GrantRequest`].
+///
+/// `scope` is the S3 `action:resource:identifier` triple (the requested access);
+/// `audience` is the RFC 8707 resource indicator (optional). The object label
+/// is `None` here (resolved separately — see TODO(#572-object-label)).
+fn parse_grant_request(scope: Option<&str>, audience: Option<&str>) -> Result<GrantRequest, String> {
+    use hyprstream_rpc::auth::ucan::capability::{Ability, Caveats, Resource};
+
+    let scope_str = scope.ok_or_else(|| "scope is required for UCAN grant".to_owned())?;
+    let parsed = hyprstream_rpc::auth::Scope::parse(scope_str)
+        .map_err(|e| format!("invalid scope '{scope_str}': {e}"))?;
+    Ok(GrantRequest {
+        // S3 Scope(action, resource, identifier) → S5 Capability(resource, ability).
+        // The `resource` URI is assembled as `mac://<resource>/<identifier>`;
+        // `*` identifier maps to the wildcard. This mapping is the S3↔S5
+        // vocabulary seam (deferred to #582); this is the conservative
+        // structural projection.
+        resource: Resource::new(format!("mac://{}/{}", parsed.resource, parsed.identifier)),
+        ability: Ability::new(parsed.action),
+        caveats: Caveats::default(),
+        audience: audience.map(str::to_owned),
+        object_label: None, // TODO(#572-object-label): manifest/TE resolver.
+    })
+}
+
+/// Mint the short-ttl, sender-bound access token for a permitted grant.
+///
+/// ZSP: the token encodes the **requested subset** (the [`GrantedAccess`]),
+/// never the whole grant. It is bound to the DPoP `jkt` (`cnf.jkt`) and carries
+/// a short ttl. A refresh token is stored when a token DB is configured.
+///
+// TODO(S8): hybrid-PQC sign the minted token (the *envelope* hybridization).
+//   Today the existing (composite-when-available / classical-fallback) signing
+//   path is used. The UCAN grant and approval it consumed are already hybrid;
+//   only the minted OAuth token awaits S8 for its own hybrid signature.
+async fn mint_grant_token(
+    state: &Arc<OAuthState>,
+    granted: &GrantedAccess,
+    dpop_jkt: &str,
+) -> Response {
+    let now = chrono::Utc::now().timestamp();
+    let ttl = state.token_ttl.min(crate::mac::exchange::MAX_ACCESS_TOKEN_TTL_SECS);
+    let expires_at = now + ttl as i64;
+
+    // The token subject is the grant's audience (the delegate). The capability
+    // subset the token encodes is carried as a scope string for downstream
+    // enforcement; the cnf.jkt binds it to the presenter's key.
+    let sub = granted
+        .audience
+        .clone()
+        .unwrap_or_else(|| "ucan-grant".to_owned());
+    let scope_str = format!(
+        "{}@{}",
+        granted.capability.ability, granted.capability.resource
+    );
+
+    let claims = hyprstream_rpc::auth::Claims::new(sub.clone(), now, expires_at)
+        .with_issuer(state.issuer_url.clone())
+        .with_audience(granted.audience.clone())
+        .with_jti();
+    // DPoP sender-binding via cnf.jkt (RFC 9449 §6). ZSP: no cnf ⇒ bearer ⇒
+    // rejected. We set jkt directly from the verified proof.
+    let mut claims = claims;
+    claims.cnf = Some(hyprstream_rpc::auth::Cnf {
+        jwk: None,
+        jkt: Some(dpop_jkt.to_owned()),
+    });
+
+    // TODO(#572-scope-claim): the capability subset (`scope_str`) needs a
+    //   dedicated claim carrying the attenuated capability so the PEP (S2) can
+    //   enforce the minted subset on refresh. For now it is logged; the cnf.jkt
+    //   binding + short ttl are the load-bearing controls.
+    let _ = scope_str;
+
+    // Sign via the active JWT signing key (composite-PQ when configured, else
+    // Ed25519). Same path as the WIT/access-token minting in PolicyService.
+    let token = match state.active_jwt_signing_key().await {
+        Some(sk) => crate::auth::jwt::encode(&claims, &sk),
+        None => {
+            tracing::error!("no active JWT signing key configured; cannot mint UCAN grant token");
+            return tx_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "server_error",
+                "token signing not configured",
+            );
+        }
+    };
+
+    // Optional refresh token (ZSP: refresh re-runs evaluate_grant, not a free
+    // re-mint). Stored only when a token DB is configured.
+    // TODO(#572-refresh-rotation): wire refresh-token rotation + the
+    //   evaluate_refresh re-evaluation end-to-end (store the grant CID +
+    //   request so the refresh path can re-present them).
+    let refresh_token = if state.token_db.is_some() {
+        Some(issue_grant_refresh_token(state, &sub, expires_at).await)
+    } else {
+        None
+    };
+
+    let mut body = serde_json::json!({
+        "access_token": token,
+        "issued_token_type": ISSUED_TOKEN_TYPE,
+        "token_type": "DPoP", // sender-bound, not Bearer
+        "expires_in": ttl,
+    });
+    if let Some(rt) = refresh_token {
+        body["refresh_token"] = serde_json::Value::String(rt);
+    }
+
+    tracing::info!(sub = %sub, ttl, "UCAN grant token minted (sender-bound, short-ttl)");
+    (
+        StatusCode::OK,
+        [
+            (header::CACHE_CONTROL, "no-store"),
+            (header::PRAGMA, "no-cache"),
+        ],
+        Json(body),
+    )
+        .into_response()
+}
+
+/// Issue an opaque refresh token for a UCAN grant, stored in the token DB.
+///
+/// The refresh token does NOT carry authority itself — it is a handle that lets
+/// the presenter re-present the grant (which the refresh path re-validates via
+/// `evaluate_refresh`). ZSP: refresh is re-evaluated, never automatic.
+async fn issue_grant_refresh_token(
+    state: &Arc<OAuthState>,
+    sub: &str,
+    access_expires_at: i64,
+) -> String {
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+    use rand::RngCore as _;
+
+    // 256-bit opaque token.
+    let mut bytes = [0u8; 32];
+    rand::rngs::OsRng.fill_bytes(&mut bytes);
+    let refresh = URL_SAFE_NO_PAD.encode(bytes);
+
+    // The verifying key binding for cnf continuity on refresh is re-established
+    // by the re-presented DPoP proof at refresh time (jkt is a thumbprint, not
+    // a raw key), so verifying_key_bytes stays None here.
+    let _ = access_expires_at;
+    let entry = super::state::RefreshTokenEntry {
+        client_id: format!("ucan-grant:{sub}"),
+        username: sub.to_owned(),
+        scopes: vec!["urn:hyprstream:grant-type:ucan".to_owned()],
+        resource: None,
+        expires_at_unix: chrono::Utc::now().timestamp() + state.refresh_token_ttl as i64,
+        verifying_key_bytes: None,
+    };
+
+    if let Some(db) = &state.token_db {
+        if let Err(e) = db.put(&refresh, &entry, state.refresh_token_ttl as u64).await {
+            tracing::warn!(error = %e, "failed to persist UCAN grant refresh token");
+        }
+    }
+    refresh
 }


### PR DESCRIPTION
Implements **S6 #572** (epic #547): the runtime grant path — UCAN grant-request → sender-bound OAuth tokens. Based on `main` (off the MAC #636 merge — S1/S3/S4/S5 + #514 DPoP).

> **Security-critical + honest about scope.** The core grant engine (`evaluate_grant`) is complete and fully fail-closed-tested. The HTTP path **denies every request by design today** (ZSP) until S8 ships the clearance wire field + trust-store PQ-key binding — see "Deny-by-default" below. Reviewers: verify the fail-closed gate order and confirm the deny-by-default is intended.

## Core — `evaluate_grant` (single fail-closed gate)
`crates/hyprstream/src/mac/exchange.rs` (~1000 lines). Gate order (cheapest structural checks before crypto):
1. **Sender-binding required** (ZSP — DPoP via #514 `verify_dpop_proof`; minted token carries `cnf.jkt`)
2. non-empty grant
3. labeled subject + labeled object
4. **MAC clearance dominance** — S1 `SecurityContext::can_access` (the intrinsic lattice floor)
5. **S5 `chain::validate`** — signatures + attenuation + temporal
6. **S5 compiler `authorize_at`** — ceiling-subset relation
7. mints the **least subset** covering the request (never the whole grant)

`evaluate_refresh` runs the same gates (refresh is re-evaluated, not a free re-mint).

**Consumed, not reinvented:** S1 (`SecurityContext`/`can_access`/`SubjectContextClaims`), S5 (`chain::validate`, `compiler::authorize_at`), #514 (`verify_dpop_proof`).

## Fail-closed tests (15, none assert permissive behavior)
`over_ceiling_request_is_denied_not_escalated` (+ `over_ceiling_on_ability_is_denied` — escalation → `insufficient_scope`, **no auto-mint**); `broken_signature_is_denied`, `widening_chain_is_denied`, `expired_grant_is_denied` (bad chain); `insufficient_clearance_is_denied` (compartment mismatch); `missing_sender_binding_is_denied` (ZSP); `unlabeled_subject/object_is_denied`, `empty_grant_is_denied`, `caveat_dropped_in_request_is_over_ceiling`, `refresh_runs_the_same_gates_as_mint`. Happy path: `subset_within_ceiling_permits_minimal_mint` + `caveat_added_in_request_still_subset`.

## Deny-by-default (ZSP — reviewer must confirm this is intended)
The HTTP grant path denies every request today: `SubjectContextResolver` (`DenyUnlabeledResolver`) and `exchange_ucan_verifier` both return `None` until S8 (#574) ships the clearance wire field + trust-store PQ-key binding. This is correct ZSP posture (no standing access without verified clearance; never trust an unverified chain). The security-critical core `evaluate_grant` is fully tested independently of this. **S8's resolver implementation is the tracked follow-up that makes the HTTP path functional.**

## Verified
`mac::exchange` 15/15, `auth::ucan` 42/42, `mac::` 63/63, `services::oauth` 97/97 pass; clippy clean; `hyprstream`/`hyprstream-rpc` (torch-bound) build.

## Deferred (documented `TODO(#572-*)` / `TODO(S8)`, all fail-closed until landed)
Escalation tiers (static Casbin/agentic/admin-UDF — over-ceiling returns `insufficient_scope`); refresh-token rotation (end-to-end storage); revocation at grant time; object-label resolver (manifest/TE — `object_label=None` → S1 floor denies); trust-store verifier wiring (S8); hybrid-PQC token signing (S8, at the mint seam).

Refs #547 (S6) · consumes S1/S4/S5/#514.
