### PR TITLE
feat(mac S8 #574): hybrid PQ authz signing + clearance/assurance ctx (activates S6)

### DIFF
--- a/crates/hyprstream-rpc/src/auth/claims.rs
+++ b/crates/hyprstream-rpc/src/auth/claims.rs
@@ -6,10 +6,10 @@
 //! - [`IdTokenClaims`] — OIDC ID Token claims (Section 2 of OpenID Connect
 //!   Core 1.0). Only used by the OAuth token endpoint when `scope=openid`.
 
+use crate::capnp::{FromCapnp, ToCapnp};
 use crate::common_capnp;
-use crate::capnp::{ToCapnp, FromCapnp};
 use anyhow::Result;
-use serde::{Deserialize, Serialize, Serializer, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Compute the RFC 7638 JWK Thumbprint for an Ed25519 key.
 ///
@@ -107,6 +107,26 @@ pub struct Claims {
     /// - Do NOT change to `skip_serializing_if` — that would leak the token in JSON.
     #[serde(skip)]
     pub token: Option<String>,
+
+    /// **MAC clearance (S8/#574, design §3, §11).** The authority-asserted
+    /// clearance the issuing node grants this subject: a `SecurityLabel`
+    /// carrying `level` + `compartments`. This is the **authority-asserted**
+    /// half of the S1 subject context; the issuing node signs the JWT, so the
+    /// clearance cannot be self-asserted by the subject.
+    ///
+    /// **Assurance is NOT carried here.** Per the S1/#548 contract, the
+    /// assurance axis of a subject's context is *derived from the verified key
+    /// material*, never trusted from a claim. The MAC PDP clamps the
+    /// clearance's assurance DOWN to what the verified crypto supports (see
+    /// [`crate::auth::mac::SecurityContext::from_clearance`]). So an Ed25519-only
+    /// identity carrying a `PqHybrid` clearance floors to `Classical` at
+    /// enforcement time — the claim cannot grant assurance the key does not back.
+    ///
+    /// `None` ⇒ unlabeled subject ⇒ the MAC monitor denies (no default
+    /// clearance; the S1 fail-closed rule). Carried on the hybrid-signed
+    /// envelope/JWT so it is itself PQ-forgery-resistant.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub clearance: Option<crate::auth::mac::SecurityLabel>,
 }
 
 // Custom Debug impl — NEVER log the bearer token
@@ -121,6 +141,7 @@ impl std::fmt::Debug for Claims {
             .field("aud", &self.aud)
             .field("cnf", &self.cnf)
             .field("token", &self.token.as_ref().map(|_| "[REDACTED]"))
+            .field("clearance", &self.clearance)
             .finish()
     }
 }
@@ -157,22 +178,30 @@ impl FromCapnp for Claims {
 
     fn read_from(reader: Self::Reader<'_>) -> Result<Self> {
         // Scopes on the wire are ignored - authorization is via Casbin
-        let aud = reader.get_aud().ok()
+        let aud = reader
+            .get_aud()
+            .ok()
             .and_then(|s| s.to_str().ok())
             .map(std::borrow::ToOwned::to_owned)
             .filter(|s| !s.is_empty());
 
-        let token = reader.get_token().ok()
+        let token = reader
+            .get_token()
+            .ok()
             .and_then(|s| s.to_str().ok())
             .map(std::borrow::ToOwned::to_owned)
             .filter(|s| !s.is_empty());
 
-        let iss = reader.get_iss().ok()
+        let iss = reader
+            .get_iss()
+            .ok()
             .and_then(|s| s.to_str().ok())
             .map(std::borrow::ToOwned::to_owned)
             .unwrap_or_default();
 
-        let cnf = reader.get_pub_key().ok()
+        let cnf = reader
+            .get_pub_key()
+            .ok()
             .and_then(|s| s.to_str().ok())
             .filter(|s| !s.is_empty())
             .map(|x| Cnf {
@@ -193,6 +222,11 @@ impl FromCapnp for Claims {
             aud,
             cnf,
             token,
+            // MAC clearance (S8/#574) is not carried on the Cap'n Proto envelope
+            // surface today; it rides the JWT (the hybrid-signed authority token).
+            // The envelope Claims are a distinct carrier from the JWT Claims; the
+            // clearance is read off the verified JWT by the MAC PDP.
+            clearance: None,
         })
     }
 }
@@ -209,6 +243,7 @@ impl Claims {
             aud: None,
             cnf: None,
             token: None,
+            clearance: None,
         }
     }
 
@@ -268,6 +303,16 @@ impl Claims {
             jwk: None,
             jkt: Some(compute_jkt(key_bytes)),
         });
+        self
+    }
+
+    /// Set the MAC clearance claim (S8/#574). The authority-asserted clearance
+    /// the issuing node grants this subject (level + compartments). The
+    /// resulting JWT carries this under its (hybrid) signature, so it is itself
+    /// PQ-forgery-resistant; the assurance axis is NOT carried here — it is
+    /// derived from the verified key material at enforcement time.
+    pub fn with_clearance(mut self, clearance: crate::auth::mac::SecurityLabel) -> Self {
+        self.clearance = Some(clearance);
         self
     }
 
@@ -334,6 +379,27 @@ impl Claims {
     }
 }
 
+// ── MAC subject-context seam (S8/#574, S1/#548) ─────────────────────────────
+//
+// `Claims` is the authority-asserted carrier for a subject's clearance. The S1
+// `SubjectContextClaims` trait is the typed contract the MAC PDP / S6 grant path
+// program against; this impl lights it up for real verified JWT claims. The
+// two-input `security_context(key_material)` combines:
+//   1. the authority-asserted clearance (this `clearance` field — the JWT is
+//      signed by the issuing node, so this is authority-asserted, not self-
+//      asserted), and
+//   2. the assurance derived from the *verified key material* (threaded in from
+//      the envelope signature-verification layer — NEVER trusted from a claim).
+// `SecurityContext::from_clearance` clamps the assurance axis DOWN to what the
+// crypto supports, so a classical key carrying a PqHybrid clearance floors to
+// Classical — the load-bearing #548 invariant: assurance is a property of the
+// verified identity, not a grant.
+impl crate::auth::mac::SubjectContextClaims for Claims {
+    fn clearance_label(&self) -> Option<crate::auth::mac::SecurityLabel> {
+        self.clearance
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -366,15 +432,15 @@ mod tests {
 
     #[test]
     fn test_claims_with_token() {
-        let claims = Claims::new("alice".to_owned(), 1000, 2000)
-            .with_token("eyJ.test.token".to_owned());
+        let claims =
+            Claims::new("alice".to_owned(), 1000, 2000).with_token("eyJ.test.token".to_owned());
         assert_eq!(claims.token, Some("eyJ.test.token".to_owned()));
     }
 
     #[test]
     fn test_claims_token_not_in_json() {
-        let claims = Claims::new("alice".to_owned(), 1000, 2000)
-            .with_token("eyJ.secret.token".to_owned());
+        let claims =
+            Claims::new("alice".to_owned(), 1000, 2000).with_token("eyJ.secret.token".to_owned());
         let json = serde_json::to_string(&claims).unwrap();
         assert!(!json.contains("secret"));
         assert!(!json.contains("token"));
@@ -382,8 +448,8 @@ mod tests {
 
     #[test]
     fn test_claims_debug_redacts_token() {
-        let claims = Claims::new("alice".to_owned(), 1000, 2000)
-            .with_token("eyJ.secret.token".to_owned());
+        let claims =
+            Claims::new("alice".to_owned(), 1000, 2000).with_token("eyJ.secret.token".to_owned());
         let debug = format!("{:?}", claims);
         assert!(debug.contains("[REDACTED]"));
         assert!(!debug.contains("secret"));
@@ -422,8 +488,14 @@ mod tests {
             .with_issuer("https://other.example.com".to_owned());
         let no_sub = Claims::new(String::new(), 0, 9999);
 
-        assert_eq!(local.subject(&["https://node.example.com"]), Subject::new("alice"));
-        assert_eq!(federated.subject(&["https://node.example.com"]), Subject::federated("https://other.example.com", "bob"));
+        assert_eq!(
+            local.subject(&["https://node.example.com"]),
+            Subject::new("alice")
+        );
+        assert_eq!(
+            federated.subject(&["https://node.example.com"]),
+            Subject::federated("https://other.example.com", "bob")
+        );
         assert_eq!(no_sub.subject(&[]), Subject::anonymous());
     }
 
@@ -526,9 +598,9 @@ impl<'de> Deserialize<'de> for OneOrMany {
                 let strings: std::result::Result<Vec<String>, _> = arr
                     .into_iter()
                     .map(|v| {
-                        v.as_str()
-                            .map(String::from)
-                            .ok_or_else(|| serde::de::Error::custom("aud array must contain strings"))
+                        v.as_str().map(String::from).ok_or_else(|| {
+                            serde::de::Error::custom("aud array must contain strings")
+                        })
                     })
                     .collect();
                 Ok(Self::from_vec(strings?))

--- a/crates/hyprstream-rpc/src/auth/ucan/chain.rs
+++ b/crates/hyprstream-rpc/src/auth/ucan/chain.rs
@@ -255,7 +255,11 @@ fn validate_chain_at(ucan: &Ucan, now: u64, link: usize) -> Result<(), ChainErro
 ///
 /// This is the single entry point S5's compiler calls; it guarantees that only a
 /// genuine, currently-live ceiling reaches the (deferred) bundle-emission stage.
-pub fn validate<V: UcanVerifier + ?Sized>(ucan: &Ucan, verifier: &V, now: u64) -> Result<(), ChainError> {
+pub fn validate<V: UcanVerifier + ?Sized>(
+    ucan: &Ucan,
+    verifier: &V,
+    now: u64,
+) -> Result<(), ChainError> {
     ucan.validate_structure().map_err(ChainError::Structure)?;
     ucan.verify_signatures(verifier)
         .map_err(ChainError::Signature)?;
@@ -268,7 +272,7 @@ mod tests {
     use super::super::token::test_support::*;
     use super::*;
     use crate::auth::ucan::capability::{Ability, Capability, CaveatValue, Caveats, Resource};
-    use crate::auth::ucan::token::{Did, Ucan, UcanPayload};
+    use crate::auth::ucan::token::{Did, Ucan, UcanPayload, UCAN_AAD};
     use crate::crypto::cose_sign::sign_composite;
     use std::collections::BTreeMap;
 

--- a/crates/hyprstream-rpc/src/auth/ucan/token.rs
+++ b/crates/hyprstream-rpc/src/auth/ucan/token.rs
@@ -43,6 +43,16 @@ use std::fmt;
 /// the SAME `crate::did_key` parser the rest of `hyprstream-rpc` uses).
 pub use crate::identity::Did;
 
+/// Domain-separation AAD for UCAN payload signatures (distinct from the
+/// compiled-policy, approval, audit, and envelope AADs so a UCAN signature can
+/// never be replayed as another message type). Signed and verified by every
+/// producer/consumer of UCANs — the test helpers, the chain validator, the
+/// production `UcanVerifier` (the HTTP grant path's trust-store-backed
+/// verifier), and cross-process consumers. Promoted to a public non-test
+/// constant by S8 (#574) so the production verifier shares the exact AAD the
+/// signers use (a mismatch silently fails signature verification).
+pub const UCAN_AAD: &[u8] = b"hs-mac-ucan-payload-v1";
+
 /// Resolve the Ed25519 verifying-key bytes a UCAN `did:key` issuer/audience
 /// encodes, mapped to a fail-closed [`UcanError`]. Thin adapter over the canonical
 /// [`Did::to_ed25519`] so the UCAN signature/structure paths keep their typed
@@ -222,7 +232,10 @@ impl Ucan {
     ///
     /// This does NOT check attenuation/delegation linkage — that is
     /// [`super::chain::validate_chain`], deliberately separate.
-    pub fn verify_signatures<V: UcanVerifier + ?Sized>(&self, verifier: &V) -> Result<(), UcanError> {
+    pub fn verify_signatures<V: UcanVerifier + ?Sized>(
+        &self,
+        verifier: &V,
+    ) -> Result<(), UcanError> {
         let ed_bytes = did_ed25519_key(&self.payload.issuer)?;
         let payload_bytes = self.payload.signing_bytes()?;
         verifier.verify(
@@ -333,10 +346,8 @@ pub(super) mod test_support {
     use ed25519_dalek::{SigningKey, VerifyingKey};
     use std::collections::HashMap;
 
-    /// Domain-separation AAD for UCAN payload signatures (distinct from the
-    /// compiled-policy and envelope AADs so a UCAN signature can never be
-    /// replayed as another message type).
-    pub const UCAN_AAD: &[u8] = b"hs-mac-ucan-payload-v1";
+    // The UCAN payload-signature AAD is the public `super::UCAN_AAD` constant
+    // (promoted out of `test_support` by S8 so production verifiers share it).
 
     /// A hybrid keypair (Ed25519 + ML-DSA-65) bound to one DID identity.
     pub struct TestIdentity {

--- a/crates/hyprstream-rpc/src/service/svc.rs
+++ b/crates/hyprstream-rpc/src/service/svc.rs
@@ -12,8 +12,8 @@
 use crate::prelude::*;
 use crate::transport::TransportConfig;
 use anyhow::Result;
-use zeroize::Zeroizing;
 use async_trait::async_trait;
+use zeroize::Zeroizing;
 // AtomicU64 and Ordering removed — were unused
 use std::sync::Arc;
 use tokio::sync::Notify;
@@ -26,7 +26,15 @@ use tracing::warn;
 /// The concrete implementation typically wraps `PolicyClient::check_policy()`.
 ///
 /// Returns a boxed future to support async policy checks on single-threaded runtimes.
-pub type AuthorizeFn = Arc<dyn Fn(String, String, String) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<bool>> + Send>> + Send + Sync>;
+pub type AuthorizeFn = Arc<
+    dyn Fn(
+            String,
+            String,
+            String,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<bool>> + Send>>
+        + Send
+        + Sync,
+>;
 
 /// Decompose a composite JWT alg into its underlying component algs.
 ///
@@ -231,6 +239,82 @@ impl EnvelopeContext {
         self.claims.as_ref()
     }
 
+    /// **Derive the verified key material (S8/#574, S1/#548).** This is the
+    /// accessor that threads crypto-derived assurance from the envelope's
+    /// verified signature into MAC context assembly.
+    ///
+    /// Returns the [`VerifiedKeyMaterial`] assurance axis for THIS verified
+    /// envelope, derived (never trusted) from what the signature layer actually
+    /// verified:
+    ///
+    /// - **`PqHybrid`** — the envelope's `cnf` Ed25519 signer key is
+    ///   cryptographically verified (it is `self.cnf`, set during
+    ///   [`Self::from_verified`] from the signature check) AND a bound ML-DSA-65
+    ///   anchor for that identity is present in the global `PqTrustStore`
+    ///   (`register_pq_trust` binding) under the enforced Hybrid policy. This is
+    ///   the kid-anchored binding the rest of the TCB uses — the PQ key is
+    ///   resolved from the trust store keyed by the EdDSA identity, never
+    ///   self-asserted.
+    /// - **`Classical`** — the `cnf` Ed25519 signer key is verified but NO bound
+    ///   ML-DSA-65 anchor is present (the federation edge, or a pre-PQ identity).
+    /// - **`Unverified`** — the `cnf` key is zeroed (a callback-service context
+    ///   with no real envelope; assurance floors to the S1 `Unverified` floor
+    ///   so it dominates nothing above it).
+    ///
+    /// **Re-derive per verified envelope; never cache across identities.** Each
+    /// envelope has its own signer; caching would conflate assurances.
+    ///
+    /// This is the load-bearing S8 input: without it every subject floors to
+    /// `Unverified` and dominates nothing (S6 would deny everything). The MAC
+    /// PDP combines this with the clearance off `Claims` via
+    /// [`crate::auth::mac::SubjectContextClaims::security_context`].
+    #[must_use]
+    pub fn verified_key_material(&self) -> crate::auth::mac::VerifiedKeyMaterial {
+        // The callback-service path mints a context with a zeroed cnf and no
+        // real envelope — there is no signature to derive assurance from. Floor
+        // to Unverified so the S1 dominance check denies anything above the
+        // floor (this is the correct posture for an un-attested service self-
+        // call that crosses into MAC-enforced territory).
+        if self.cnf == [0u8; 32] {
+            return crate::auth::mac::VerifiedKeyMaterial::Unverified;
+        }
+        // cnf is the cryptographically-verified Ed25519 signer key (set during
+        // from_verified* from the envelope signature check). It is verified by
+        // construction — the only question is whether a PQ anchor is bound.
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            if let Some(store) = crate::envelope::global_pq_store() {
+                if store.ml_dsa_key_for(&self.cnf).is_some() {
+                    return crate::auth::mac::VerifiedKeyMaterial::PqHybrid;
+                }
+            }
+        }
+        // Verified Ed25519, no bound PQ anchor ⇒ Classical (the federation edge
+        // / pre-PQ identity). NOT PqHybrid — no silent upgrade.
+        crate::auth::mac::VerifiedKeyMaterial::Classical
+    }
+
+    /// Derive the full MAC [`SecurityContext`] for this verified envelope: the
+    /// **two-input** S1 derivation (clearance from `Claims` + assurance from
+    /// [`Self::verified_key_material`]). This is the convenience entry-point the
+    /// MAC PDP / S6 grant path call; it composes the authority-asserted
+    /// clearance with the crypto-derived assurance, clamping the assurance axis
+    /// DOWN to what the verified key supports.
+    ///
+    /// Returns `None` (→ S1 deny) when the subject carries no clearance
+    /// (unlabeled subject) — there is no default clearance. The resulting
+    /// context is a SIBLING to [`Subject`]: identity and clearance are
+    /// independent dimensions of the same verified principal.
+    ///
+    /// **Re-derive per verified envelope; never cache across identities.**
+    #[must_use]
+    pub fn security_context(&self) -> Option<crate::auth::mac::SecurityContext> {
+        use crate::auth::mac::SubjectContextClaims as _;
+        let claims = self.claims.as_ref()?;
+        let key_material = self.verified_key_material();
+        claims.security_context(key_material)
+    }
+
     /// Get the raw JWT token from the envelope (if present).
     pub fn jwt_token(&self) -> Option<&str> {
         self.jwt_token.as_deref()
@@ -337,7 +421,6 @@ impl EnvelopeContext {
             );
         }
     }
-
 }
 
 /// Trait for RPC services.
@@ -360,7 +443,11 @@ pub trait RequestService: 'static {
     ///   (used for streaming: ensures client has stream_id before data flows)
     ///
     /// Non-streaming services always return `None` for the continuation.
-    async fn handle_request(&self, ctx: &EnvelopeContext, payload: &[u8]) -> Result<(Vec<u8>, Option<Continuation>)>;
+    async fn handle_request(
+        &self,
+        ctx: &EnvelopeContext,
+        payload: &[u8],
+    ) -> Result<(Vec<u8>, Option<Continuation>)>;
 
     /// Service name (for logging and registry).
     fn name(&self) -> &str;
@@ -391,7 +478,9 @@ pub trait RequestService: 'static {
     /// inner EdDSA (skip-unknown interop). Override to return `None` to force
     /// Classical-only responses.
     fn pq_signing_key(&self) -> Option<crate::crypto::pq::MlDsaSigningKey> {
-        Some(crate::node_identity::derive_mesh_mldsa_key(&self.signing_key()))
+        Some(crate::node_identity::derive_mesh_mldsa_key(
+            &self.signing_key(),
+        ))
     }
 
     /// Ed25519 verifying key for envelope signature verification.
@@ -495,7 +584,9 @@ pub trait RequestService: 'static {
     /// The legacy `claims` path is kept for backwards compat with older clients.
     async fn verify_claims(&self, ctx: &mut EnvelopeContext) -> anyhow::Result<()> {
         // Prefer jwt_token (new path) over legacy claims
-        let token = ctx.jwt_token.clone()
+        let token = ctx
+            .jwt_token
+            .clone()
             .or_else(|| ctx.claims().and_then(|c| c.token.clone()));
 
         let Some(token) = token else {
@@ -581,13 +672,17 @@ pub trait RequestService: 'static {
                 // covered components include every listed alg.
                 if listed_algs.len() > 1 {
                     let covered = composite_alg_components(&alg);
-                    let all_covered = listed_algs.iter().all(|need| covered.iter().any(|c| c == need) || need == &alg);
+                    let all_covered = listed_algs
+                        .iter()
+                        .all(|need| covered.iter().any(|c| c == need) || need == &alg);
                     if !all_covered {
                         tracing::warn!(
                             "JWT alg={} does not cover all JWKS-listed algs {:?} for kid={} — stripping rejected",
                             alg, listed_algs, kid_str
                         );
-                        anyhow::bail!("JWT alg does not cover all JWKS-listed algs (stripping defense)");
+                        anyhow::bail!(
+                            "JWT alg does not cover all JWKS-listed algs (stripping defense)"
+                        );
                     }
                 }
             }
@@ -605,14 +700,23 @@ pub trait RequestService: 'static {
                 let mut result = None;
                 for vk in &vks {
                     match crate::auth::jwt::decode_ml_dsa_65(&token, vk, aud) {
-                        Ok(claims) => { result = Some(claims); break; }
-                        Err(e) => { last_err = Some(e); }
+                        Ok(claims) => {
+                            result = Some(claims);
+                            break;
+                        }
+                        Err(e) => {
+                            last_err = Some(e);
+                        }
                     }
                 }
                 match result {
                     Some(claims) => claims,
                     None => {
-                        tracing::warn!("ML-DSA-65 JWT verification failed (tried {} keys): {:?}", vks.len(), last_err);
+                        tracing::warn!(
+                            "ML-DSA-65 JWT verification failed (tried {} keys): {:?}",
+                            vks.len(),
+                            last_err
+                        );
                         anyhow::bail!("JWT verification failed");
                     }
                 }
@@ -622,17 +726,29 @@ pub trait RequestService: 'static {
                 if vks.is_empty() {
                     anyhow::bail!("Composite JWT received but no PQ verifying keys available");
                 }
-                let verifying_key = key_source.get_key(&unverified.iss, kid.as_deref()).await.map_err(|e| {
-                    tracing::warn!("JWT key resolution failed for iss={}: {}", unverified.iss, e);
-                    anyhow::anyhow!("JWT key resolution failed")
-                })?;
+                let verifying_key = key_source
+                    .get_key(&unverified.iss, kid.as_deref())
+                    .await
+                    .map_err(|e| {
+                        tracing::warn!(
+                            "JWT key resolution failed for iss={}: {}",
+                            unverified.iss,
+                            e
+                        );
+                        anyhow::anyhow!("JWT key resolution failed")
+                    })?;
                 let aud = self.expected_audience();
                 let mut last_err = None;
                 let mut result = None;
                 for vk in &vks {
                     match crate::auth::jwt::decode_composite(&token, vk, &verifying_key, aud) {
-                        Ok(claims) => { result = Some(claims); break; }
-                        Err(e) => { last_err = Some(e); }
+                        Ok(claims) => {
+                            result = Some(claims);
+                            break;
+                        }
+                        Err(e) => {
+                            last_err = Some(e);
+                        }
                     }
                 }
                 match result {
@@ -645,10 +761,17 @@ pub trait RequestService: 'static {
             }
             _ => {
                 // EdDSA (default path)
-                let verifying_key = key_source.get_key(&unverified.iss, kid.as_deref()).await.map_err(|e| {
-                    tracing::warn!("JWT key resolution failed for iss={}: {}", unverified.iss, e);
-                    anyhow::anyhow!("JWT key resolution failed")
-                })?;
+                let verifying_key = key_source
+                    .get_key(&unverified.iss, kid.as_deref())
+                    .await
+                    .map_err(|e| {
+                        tracing::warn!(
+                            "JWT key resolution failed for iss={}: {}",
+                            unverified.iss,
+                            e
+                        );
+                        anyhow::anyhow!("JWT key resolution failed")
+                    })?;
                 crate::auth::decode_with_key(&token, &verifying_key, self.expected_audience())
                     .map_err(|e| {
                         tracing::warn!("JWT verification failed: {}", e);
@@ -705,9 +828,10 @@ pub trait RequestService: 'static {
                 // R2b: DPoP path — JWT has cnf.jkt (thumbprint) instead of cnf.jwk.
                 // Compute the JWK thumbprint of the envelope signer and compare.
                 use subtle::ConstantTimeEq as _;
-                let envelope_jkt = crate::auth::jwk_thumbprint(
-                    &crate::auth::JwkThumbprintInput::Ed25519 { x: &ctx.cnf },
-                );
+                let envelope_jkt =
+                    crate::auth::jwk_thumbprint(&crate::auth::JwkThumbprintInput::Ed25519 {
+                        x: &ctx.cnf,
+                    });
                 if envelope_jkt.as_bytes().ct_ne(jkt.as_bytes()).into() {
                     tracing::warn!("JWT cnf.jkt mismatch: sub={}", claims.sub);
                     anyhow::bail!("JWT cnf.jkt does not match envelope signer");
@@ -727,7 +851,9 @@ pub trait RequestService: 'static {
                 }
             } else if self.require_cnf_binding() {
                 tracing::warn!("JWT missing cnf binding (jwk or jkt): sub={}", claims.sub);
-                anyhow::bail!("JWT must include cnf binding for key binding (required by this service)");
+                anyhow::bail!(
+                    "JWT must include cnf binding for key binding (required by this service)"
+                );
             }
         }
 
@@ -754,9 +880,7 @@ pub trait RequestService: 'static {
     fn build_error_payload(&self, request_id: u64, error: &str) -> Vec<u8> {
         warn!(
             service = self.name(),
-            request_id,
-            error,
-            "build_error_payload not overridden — sending empty error response"
+            request_id, error, "build_error_payload not overridden — sending empty error response"
         );
         vec![]
     }
@@ -806,8 +930,7 @@ pub struct QuicLoopConfig {
     /// path (origin + key-binding against `remote_id()`). `None` = open (the
     /// pre-#282 accept-open behaviour). Native-only.
     #[cfg(not(target_arch = "wasm32"))]
-    pub iroh_admission:
-        Option<crate::transport::iroh_admission::SharedIrohAdmission>,
+    pub iroh_admission: Option<crate::transport::iroh_admission::SharedIrohAdmission>,
     /// #282: callback invoked after the iroh substrate binds, with
     /// (service_name, node_id) where `node_id` is the endpoint's 32-byte Ed25519
     /// public key. Used to advertise the `#iroh` VM + `IrohTransport` service
@@ -900,17 +1023,31 @@ mod empty_iss_gate_tests {
 
     #[async_trait(?Send)]
     impl RequestService for MockService {
-        async fn handle_request(&self, _ctx: &EnvelopeContext, _payload: &[u8]) -> Result<(Vec<u8>, Option<Continuation>)> {
+        async fn handle_request(
+            &self,
+            _ctx: &EnvelopeContext,
+            _payload: &[u8],
+        ) -> Result<(Vec<u8>, Option<Continuation>)> {
             Ok((vec![], None))
         }
-        fn name(&self) -> &str { "mock" }
-        fn transport(&self) -> &TransportConfig { &self.transport }
-        fn signing_key(&self) -> SigningKey { self.signing_key.clone() }
+        fn name(&self) -> &str {
+            "mock"
+        }
+        fn transport(&self) -> &TransportConfig {
+            &self.transport
+        }
+        fn signing_key(&self) -> SigningKey {
+            self.signing_key.clone()
+        }
         fn jwt_key_source(&self) -> Option<std::sync::Arc<dyn crate::auth::JwtKeySource>> {
             Some(self.key_source.clone())
         }
-        fn require_cnf_binding(&self) -> bool { false }
-        fn pq_signing_key(&self) -> Option<crate::crypto::pq::MlDsaSigningKey> { None }
+        fn require_cnf_binding(&self) -> bool {
+            false
+        }
+        fn pq_signing_key(&self) -> Option<crate::crypto::pq::MlDsaSigningKey> {
+            None
+        }
     }
 
     /// Build an `EnvelopeContext` carrying `jwt_token`, with the chosen
@@ -934,10 +1071,8 @@ mod empty_iss_gate_tests {
         // anchors that same CA key with an empty local issuer URL (so empty iss
         // is "local").
         let ca = SigningKey::from_bytes(&[7u8; 32]);
-        let key_source = std::sync::Arc::new(ClusterKeySource::new(
-            ca.verifying_key(),
-            String::new(),
-        ));
+        let key_source =
+            std::sync::Arc::new(ClusterKeySource::new(ca.verifying_key(), String::new()));
         let svc = MockService {
             signing_key: SigningKey::from_bytes(&[8u8; 32]),
             transport: TransportConfig::inproc("mock"),
@@ -961,7 +1096,10 @@ mod empty_iss_gate_tests {
         let mut ctx = ctx_with_token(token, /* is_local_caller */ false);
 
         let result = svc.verify_claims(&mut ctx).await;
-        assert!(result.is_err(), "networked empty-iss token must be rejected");
+        assert!(
+            result.is_err(),
+            "networked empty-iss token must be rejected"
+        );
         let msg = result.err().map(|e| e.to_string()).unwrap_or_default();
         assert!(
             msg.contains("empty JWT issuer is only accepted from in-process callers"),
@@ -976,7 +1114,10 @@ mod empty_iss_gate_tests {
         let mut ctx = ctx_with_token(token, /* is_local_caller */ true);
 
         let result = svc.verify_claims(&mut ctx).await;
-        assert!(result.is_ok(), "in-process empty-iss token must pass the gate: {result:?}");
+        assert!(
+            result.is_ok(),
+            "in-process empty-iss token must pass the gate: {result:?}"
+        );
         // And the local bare-sub subject is resolved.
         assert_eq!(ctx.subject().name(), Some("alice"));
     }
@@ -1024,13 +1165,25 @@ mod ipc_key_identity_tests {
 
     #[async_trait(?Send)]
     impl RequestService for PlainService {
-        async fn handle_request(&self, _ctx: &EnvelopeContext, _payload: &[u8]) -> Result<(Vec<u8>, Option<Continuation>)> {
+        async fn handle_request(
+            &self,
+            _ctx: &EnvelopeContext,
+            _payload: &[u8],
+        ) -> Result<(Vec<u8>, Option<Continuation>)> {
             Ok((vec![], None))
         }
-        fn name(&self) -> &str { "discovery" }
-        fn transport(&self) -> &TransportConfig { &self.transport }
-        fn signing_key(&self) -> SigningKey { self.signing_key.clone() }
-        fn pq_signing_key(&self) -> Option<crate::crypto::pq::MlDsaSigningKey> { None }
+        fn name(&self) -> &str {
+            "discovery"
+        }
+        fn transport(&self) -> &TransportConfig {
+            &self.transport
+        }
+        fn signing_key(&self) -> SigningKey {
+            self.signing_key.clone()
+        }
+        fn pq_signing_key(&self) -> Option<crate::crypto::pq::MlDsaSigningKey> {
+            None
+        }
     }
 
     /// Test resolver mapping a fixed set of pubkeys → subjects (the trust store
@@ -1041,7 +1194,9 @@ mod ipc_key_identity_tests {
 
     impl KeySubjectResolver for MapResolver {
         fn resolve_subject(&self, signer_pubkey: &[u8; 32]) -> Option<Subject> {
-            self.bindings.get(signer_pubkey).map(|s| Subject::new(s.clone()))
+            self.bindings
+                .get(signer_pubkey)
+                .map(|s| Subject::new(s.clone()))
         }
     }
 
@@ -1093,7 +1248,9 @@ mod ipc_key_identity_tests {
         let _guard = RESOLVER_LOCK.lock().await;
 
         // Resolver knows ONLY about some other (registered) key.
-        let registered = SigningKey::from_bytes(&[33u8; 32]).verifying_key().to_bytes();
+        let registered = SigningKey::from_bytes(&[33u8; 32])
+            .verifying_key()
+            .to_bytes();
         let mut bindings = HashMap::new();
         bindings.insert(registered, "service:discovery".to_owned());
         set_key_resolver(std::sync::Arc::new(MapResolver { bindings }));
@@ -1104,7 +1261,9 @@ mod ipc_key_identity_tests {
         };
 
         // A genuinely anonymous caller signs with an UNREGISTERED key.
-        let anon_pub = SigningKey::from_bytes(&[44u8; 32]).verifying_key().to_bytes();
+        let anon_pub = SigningKey::from_bytes(&[44u8; 32])
+            .verifying_key()
+            .to_bytes();
         let mut ctx = ctx_for_signer(anon_pub);
         svc.verify_claims(&mut ctx).await.expect("verify_claims ok");
 
@@ -1241,7 +1400,9 @@ mod accounting_audit_tests {
 
     fn capture<F: FnOnce()>(f: F) -> Vec<AuditRecord> {
         let records = Arc::new(Mutex::new(Vec::new()));
-        let layer = CaptureLayer { records: records.clone() };
+        let layer = CaptureLayer {
+            records: records.clone(),
+        };
         let subscriber = Registry::default().with(layer);
         with_default(subscriber, f);
         let out = records.lock().clone();
@@ -1256,9 +1417,16 @@ mod accounting_audit_tests {
         });
 
         let audit: Vec<_> = records.iter().filter(|r| r.target == "audit").collect();
-        assert_eq!(audit.len(), 1, "exactly one audit record expected: {records:?}");
+        assert_eq!(
+            audit.len(),
+            1,
+            "exactly one audit record expected: {records:?}"
+        );
         let r = audit[0];
-        assert_eq!(r.subject, "testuser", "subject must be the verified subject");
+        assert_eq!(
+            r.subject, "testuser",
+            "subject must be the verified subject"
+        );
         assert_eq!(r.resource, "registry:*");
         assert_eq!(r.action, "write");
         assert_eq!(r.decision, "allow");
@@ -1283,9 +1451,16 @@ mod accounting_audit_tests {
         });
 
         let audit: Vec<_> = records.iter().filter(|r| r.target == "audit").collect();
-        assert_eq!(audit.len(), 1, "exactly one audit record expected: {records:?}");
+        assert_eq!(
+            audit.len(),
+            1,
+            "exactly one audit record expected: {records:?}"
+        );
         let r = audit[0];
-        assert_eq!(r.subject, "anonymous", "anonymous deny must be attributed as 'anonymous'");
+        assert_eq!(
+            r.subject, "anonymous",
+            "anonymous deny must be attributed as 'anonymous'"
+        );
         assert_eq!(r.resource, "registry:*");
         assert_eq!(r.action, "write");
         assert_eq!(r.decision, "deny");
@@ -1299,8 +1474,193 @@ mod accounting_audit_tests {
         let records = capture(|| {
             ctx.audit_authz("registry:*", "write", /* allowed */ false);
         });
-        let r = records.iter().find(|r| r.target == "audit").expect("audit record");
+        let r = records
+            .iter()
+            .find(|r| r.target == "audit")
+            .expect("audit record");
         assert_eq!(r.subject, "viewer-probe");
         assert_eq!(r.decision, "deny");
+    }
+
+    // ── S8 (#574): verified_key_material() + two-input security_context() ──
+
+    use crate::auth::mac::{Assurance, CompartmentSet, Level, SecurityLabel, VerifiedKeyMaterial};
+    use crate::crypto::pq::ml_dsa_generate_keypair;
+    use crate::envelope::{install_verify_config, KeyedPqTrustStore};
+    use ed25519_dalek::SigningKey;
+    use rand::rngs::OsRng;
+
+    /// Build a context with a specific `cnf` (the cryptographically-verified
+    /// Ed25519 signer key) and optional clearance claims.
+    fn ctx_with_cnf(cnf: [u8; 32], clearance: Option<SecurityLabel>) -> EnvelopeContext {
+        let claims =
+            clearance.map(|c| crate::auth::Claims::new("sub".to_owned(), 1, 2).with_clearance(c));
+        EnvelopeContext {
+            request_id: 1,
+            claims,
+            jwt_token: None,
+            key_derived_subject: Subject::anonymous(),
+            jwt_subject: None,
+            cnf,
+            envelope_wit_hash: None,
+            client_dh_public: None,
+            is_local_caller: false,
+        }
+    }
+
+    /// A zeroed cnf (the callback-service shape) ⇒ Unverified assurance.
+    #[test]
+    fn verified_key_material_zeroed_cnf_is_unverified() {
+        let ctx = ctx_with_cnf([0u8; 32], None);
+        assert_eq!(ctx.verified_key_material(), VerifiedKeyMaterial::Unverified);
+    }
+
+    /// A non-zero cnf with NO bound PQ anchor ⇒ Classical (the federation edge).
+    /// NOT PqHybrid — no silent upgrade.
+    #[test]
+    fn verified_key_material_verified_cnf_no_anchor_is_classical() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let cnf = ed.verifying_key().to_bytes();
+        // No global PQ store installed in this test process (or none binding
+        // this key) ⇒ Classical.
+        let ctx = ctx_with_cnf(cnf, None);
+        // The global store may or may not be installed by another test; the
+        // invariant we assert is that it is NOT PqHybrid (no anchor for a
+        // random key).
+        let km = ctx.verified_key_material();
+        assert_ne!(
+            km,
+            VerifiedKeyMaterial::PqHybrid,
+            "a key with no bound PQ anchor must never derive PqHybrid"
+        );
+        let _ = ed; // suppress unused warning when the assertion path differs
+    }
+
+    /// A non-zero cnf WITH a bound PQ anchor (under Hybrid) ⇒ PqHybrid. This is
+    /// the activation: the assurance derived from the kid-anchored PQ binding.
+    #[test]
+    fn verified_key_material_bound_pq_anchor_is_pqhybrid() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let cnf = ed.verifying_key().to_bytes();
+        let (_pq_sk, pq_vk) = ml_dsa_generate_keypair();
+
+        // Install a global verify config with a PQ store binding this key.
+        // `install_verify_config` is first-write-wins; if another test already
+        // installed one this is a no-op and we verify against whatever store is
+        // present. To make this test hermetic we use a dedicated store and rely
+        // on the global accessor. If a store is already installed we cannot
+        // rebind, so we assert the weaker but still-load-bearing property:
+        // the accessor returns Classical OR PqHybrid (never Unverified for a
+        // verified cnf), and is deterministic.
+        let mut store = KeyedPqTrustStore::new();
+        store.bind(cnf, &pq_vk);
+        let _ = install_verify_config(crate::envelope::EnvelopeVerifyConfig {
+            policy: crate::crypto::CryptoPolicy::Hybrid,
+            pq_store: Some(std::sync::Arc::new(store)),
+        });
+        let ctx = ctx_with_cnf(cnf, None);
+        let km = ctx.verified_key_material();
+        // The verified cnf is never Unverified. If our install won (no prior
+        // config) it is PqHybrid; if a prior test's config is in force it is at
+        // worst Classical. Either way: NOT Unverified.
+        assert_ne!(
+            km,
+            VerifiedKeyMaterial::Unverified,
+            "a verified cnf must never derive Unverified"
+        );
+    }
+
+    /// Two-input ctx: clearance from Claims + assurance derived from the
+    /// verified cnf. The global `PqTrustStore` is process-global (first-write-
+    /// wins via `OnceLock`), so concurrent tests may own it; this test asserts
+    /// the load-bearing invariants that hold regardless of which store won:
+    /// (1) a verified cnf NEVER derives Unverified, and (2) the derived
+    /// context's assurance is whatever the verified crypto supports (Classical
+    /// if no anchor bound this key, PqHybrid if one did), NEVER higher than the
+    /// clearance. The dedicated `classical_key_subject_clamped_and_denied_on_pq_object`
+    /// test below pins the fail-closed direction hermetically.
+    #[test]
+    fn security_context_verified_cnf_never_unverified_never_exceeds_clearance() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let cnf = ed.verifying_key().to_bytes();
+        let (_pq_sk, pq_vk) = ml_dsa_generate_keypair();
+        // Attempt to install a store binding this key. If another test already
+        // installed one, this is a no-op and the lookup returns no anchor.
+        let mut store = KeyedPqTrustStore::new();
+        store.bind(cnf, &pq_vk);
+        let _ = install_verify_config(crate::envelope::EnvelopeVerifyConfig {
+            policy: crate::crypto::CryptoPolicy::Hybrid,
+            pq_store: Some(std::sync::Arc::new(store)),
+        });
+
+        let clearance =
+            SecurityLabel::new(Level::Secret, Assurance::PqHybrid, CompartmentSet::EMPTY);
+        let ctx = ctx_with_cnf(cnf, Some(clearance));
+        let sc = ctx
+            .security_context()
+            .expect("labeled subject has a context");
+        assert_ne!(
+            ctx.verified_key_material(),
+            VerifiedKeyMaterial::Unverified,
+            "a verified cnf must never derive Unverified"
+        );
+        assert!(
+            sc.assurance() <= Assurance::PqHybrid,
+            "assurance must never exceed the clearance"
+        );
+        assert_eq!(sc.level(), Level::Secret);
+    }
+
+    /// **Fail-closed (the load-bearing #548 invariant):** a Classical-key
+    /// subject (verified Ed25519, no bound PQ anchor) carrying a PqHybrid
+    /// clearance MUST clamp to Classical assurance, and therefore MUST be
+    /// DENIED on a PqHybrid-required object. No silent upgrade.
+    #[test]
+    fn classical_key_subject_clamped_and_denied_on_pq_object() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let cnf = ed.verifying_key().to_bytes();
+        // No PQ binding for this key in any store we install here. If a global
+        // store happens to bind a random key that is astronomically improbable;
+        // to be hermetic we install a store that does NOT bind this key.
+        let store = KeyedPqTrustStore::new(); // empty
+        let _ = install_verify_config(crate::envelope::EnvelopeVerifyConfig {
+            policy: crate::crypto::CryptoPolicy::Hybrid,
+            pq_store: Some(std::sync::Arc::new(store)),
+        });
+
+        // Policy mistakenly assigned a PqHybrid clearance...
+        let claimed_clearance =
+            SecurityLabel::new(Level::Secret, Assurance::PqHybrid, CompartmentSet::EMPTY);
+        let ctx = ctx_with_cnf(cnf, Some(claimed_clearance));
+        let sc = ctx
+            .security_context()
+            .expect("labeled subject has a context");
+        // ...but the verified key is Classical, so assurance CLAMPS DOWN.
+        assert_eq!(
+            sc.assurance(),
+            Assurance::Classical,
+            "a Classical key must clamp a PqHybrid clearance down to Classical (no silent upgrade)"
+        );
+        // Consequently the MAC floor DENIES access to a PqHybrid object even
+        // though the level (Secret) dominates.
+        let pq_object =
+            SecurityLabel::new(Level::Public, Assurance::PqHybrid, CompartmentSet::EMPTY);
+        assert!(
+            !sc.can_access(&pq_object),
+            "Classical-assurance subject MUST be denied on a PqHybrid object (fail-closed)"
+        );
+    }
+
+    /// Unlabeled subject (no clearance claim) ⇒ `security_context()` returns
+    /// None ⇒ the S1 monitor denies (no default clearance).
+    #[test]
+    fn unlabeled_subject_has_no_security_context() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let cnf = ed.verifying_key().to_bytes();
+        let ctx = ctx_with_cnf(cnf, None); // no clearance
+        assert!(
+            ctx.security_context().is_none(),
+            "unlabeled subject must have no security context (S1 deny)"
+        );
     }
 }

--- a/crates/hyprstream/src/mac/audit.rs
+++ b/crates/hyprstream/src/mac/audit.rs
@@ -66,10 +66,12 @@
 //!   archival is `TODO(S7-followup):` below.
 //! - **Policy-evolution feedback** — denials feeding back into PolicyService is
 //!   `TODO(S7-followup):` — the records are here, the consumer is not.
-//! - **Hybrid (EdDSA + ML-DSA-65) signing of audit records** — the signer
-//!   trait is hybrid-capable today, but production key management for the
-//!   audit signing identity (the ML-DSA-65 half) lands with S8 (#574);
-//!   `TODO(S8):` markers are at every sign/verify call.
+//! - **Hybrid (EdDSA + ML-DSA-65) signing of audit records** — S8 (#574) made
+//!   the [`cose::CoseAuditSigner`] policy-aware: under a Hybrid crypto policy it
+//!   fails closed if no ML-DSA-65 key is provisioned (no silent downgrade of a
+//!   security-critical accounting artifact). Production wiring of the audited
+//!   AVC (constructing a `WalAuditStore` with the node's PQ audit key and
+//!   installing it in the PEP) is `TODO(S7-followup):`.
 
 use crate::mac::avc::{Avc, TokenScope};
 use crate::mac::lattice::SecurityLabel;
@@ -221,13 +223,15 @@ impl From<std::io::Error> for AuditError {
 /// the hybrid COSE composite (EdDSA + ML-DSA-65) via
 /// [`crate::mac::compiled::cose`]; tests use a trivial stub.
 //
-// TODO(S8 #574): the production audit signer MUST sign with the hybrid
-// composite (EdDSA + ML-DSA-65), the same construction `mac::compiled::cose`
-// already uses. Today `CoseAuditSigner` is hybrid-capable but the ML-DSA-65
-// audit signing key is not provisioned; S8 wires the key store for it. Until
-// then a node running under a Hybrid crypto policy SHOULD pass `Some(pq_sk)`;
-// a Classical-only deployment passes `None` and gets classical EdDSA-only
-// audit signatures (still tamper-evident, not PQ-forgery-resistant).
+// S8 (#574): the production audit signer signs with the hybrid composite
+// (EdDSA + ML-DSA-65), the same construction `mac::compiled::cose` uses. The
+// `CoseAuditSigner` is policy-aware: under a Hybrid policy with `require_pq`
+// it FAILS CLOSED if no ML-DSA-65 key is provisioned, rather than silently
+// emitting a classical-only signature (which would be a downgrade of a
+// security-critical accounting artifact). A Classical-only deployment passes
+// `require_pq = false` and gets classical EdDSA-only audit signatures (still
+// tamper-evident, not PQ-forgery-resistant) — the explicit, policy-selected
+// pinned suite, never an in-band downgrade.
 pub trait AuditSigner: Send + Sync {
     /// Sign the record's signing input (see [`audit_signing_input`]).
     fn sign(&self, signing_input: &[u8]) -> Result<Vec<u8>, AuditError>;
@@ -251,11 +255,16 @@ pub fn audit_signing_input(content_hash: &[u8; 32]) -> Vec<u8> {
 
 /// Production signer/verifier adapters over `hyprstream_rpc::crypto::cose_sign`,
 /// mirroring [`crate::mac::compiled::cose`].
-//
-// TODO(S8 #574): provision the ML-DSA-65 audit signing key (the `pq_sk` half)
-// from the node key store and pass `require_pq = true` at verify under a Hybrid
-// crypto policy. The construction here is already the hybrid nested composite;
-// only the key management is S8's job.
+///
+/// S8 (#574): the signer is policy-aware. Construct it via
+/// [`CoseAuditSigner::new`] with the node's enforced
+/// [`CryptoPolicy`](hyprstream_rpc::crypto::CryptoPolicy). Under a Hybrid policy
+/// it FAILS CLOSED at sign time if no ML-DSA-65 key is provisioned — an audit
+/// record is a security-critical accounting artifact and silently emitting an
+/// Ed25519-only signature under a Hybrid policy would be an in-band downgrade.
+/// The construction is the hybrid nested COSE composite; the key management is
+/// the caller's job (the node provisions the PQ audit key from the same
+/// `MlDsaSigningKeyStore` the token mint uses).
 pub mod cose {
     use super::{AuditError, AuditSigner, AuditVerifier};
     use ed25519_dalek::{SigningKey, VerifyingKey};
@@ -267,17 +276,68 @@ pub mod cose {
     /// another message type).
     pub const AUDIT_AAD: &[u8] = b"hs-mac-audit-v1";
 
-    /// Hybrid (EdDSA + ML-DSA-65) signer for audit records. `pq_sk = None`
-    /// yields a classical-only signature (still tamper-evident).
+    /// Hybrid (EdDSA + ML-DSA-65) signer for audit records, policy-aware.
+    ///
+    /// Construct with [`CoseAuditSigner::new`], passing the node's enforced
+    /// [`CryptoPolicy`](hyprstream_rpc::crypto::CryptoPolicy). Under `Hybrid` the
+    /// ML-DSA-65 key is REQUIRED (fail-closed at sign time if absent); under
+    /// `Classical` it is OPTIONAL and a classical EdDSA-only signature is
+    /// emitted (the explicit, policy-selected pinned suite).
     pub struct CoseAuditSigner<'a> {
-        pub ed_sk: &'a SigningKey,
-        pub pq_sk: Option<&'a MlDsaSigningKey>,
+        ed_sk: &'a SigningKey,
+        pq_sk: Option<&'a MlDsaSigningKey>,
+        require_pq: bool,
+    }
+
+    impl<'a> CoseAuditSigner<'a> {
+        /// Construct a policy-aware audit signer.
+        ///
+        /// `policy` is the node's enforced crypto policy. `pq_sk` is the
+        /// provisioned ML-DSA-65 audit signing key (from the node's
+        /// `MlDsaSigningKeyStore`). Under `Hybrid`: `pq_sk = Some` produces a
+        /// hybrid composite (EdDSA + ML-DSA-65); `pq_sk = None` makes
+        /// construction succeed but every [`AuditSigner::sign`] FAILS CLOSED
+        /// (an audit record cannot be downgraded to classical under a Hybrid
+        /// policy — use [`Self::can_sign`] to check ahead of a hot path;
+        /// production MUST provision the PQ key under Hybrid). Under
+        /// `Classical`: `pq_sk` is ignored and EdDSA-only signatures are
+        /// emitted (the policy-selected suite).
+        pub fn new(
+            ed_sk: &'a SigningKey,
+            pq_sk: Option<&'a MlDsaSigningKey>,
+            policy: hyprstream_rpc::crypto::CryptoPolicy,
+        ) -> Self {
+            Self {
+                ed_sk,
+                // Under Classical the PQ key is ignored; coerce to None so the
+                // sign path unambiguously emits EdDSA-only (no silent hybrid).
+                pq_sk: if policy.uses_pq() { pq_sk } else { None },
+                require_pq: policy.uses_pq(),
+            }
+        }
+
+        /// Whether this signer can produce a signature under its policy: under
+        /// Hybrid this requires the PQ key; under Classical it always can.
+        /// Production wiring SHOULD check this at startup and fail to boot if
+        /// false under Hybrid (no audit signer ⇒ no Permit, per the S7
+        /// fail-closed contract).
+        #[must_use]
+        pub fn can_sign(&self) -> bool {
+            !self.require_pq || self.pq_sk.is_some()
+        }
     }
 
     impl AuditSigner for CoseAuditSigner<'_> {
         fn sign(&self, signing_input: &[u8]) -> Result<Vec<u8>, AuditError> {
-            // TODO(S8): once ML-DSA-65 audit key is provisioned, this is always
-            // hybrid under a Hybrid crypto policy. The call already supports it.
+            // Fail-closed: a Hybrid policy requires the ML-DSA-65 audit key. A
+            // missing key here is a provisioning bug; we refuse to emit a
+            // classical-only audit signature under Hybrid rather than silently
+            // downgrading a security-critical accounting artifact.
+            if self.require_pq && self.pq_sk.is_none() {
+                return Err(AuditError::Sign(
+                    "Hybrid crypto policy requires an ML-DSA-65 audit signing key, none provisioned (fail-closed)".to_owned(),
+                ));
+            }
             sign_composite(self.ed_sk, self.pq_sk, signing_input, AUDIT_AAD)
                 .map_err(|e| AuditError::Sign(e.to_string()))
         }
@@ -428,10 +488,10 @@ impl<S: AuditSigner> WalAuditStore<S> {
         let bytes = stored.canonical_bytes()?;
         let hash = *blake3::hash(&bytes).as_bytes();
 
-        // 2. Sign the domain-separated signing input.
-        // TODO(S8): hybrid (EdDSA + ML-DSA-65) signing is already wired via the
-        // CoseAuditSigner; S8 provisions the PQ audit key. The signer trait
-        // abstracts which mode is in use.
+        // 2. Sign the domain-separated signing input. S8 (#574): the
+        // CoseAuditSigner is policy-aware — under Hybrid it fails closed here
+        // if no ML-DSA-65 key is provisioned (no silent downgrade). The signer
+        // trait abstracts which mode is in use.
         let signing_input = audit_signing_input(&hash);
         let signature = self.signer.sign(&signing_input)?;
 
@@ -1364,5 +1424,97 @@ mod tests {
             let dec = base64_decode(&s).unwrap();
             assert_eq!(dec, case, "roundtrip failed for {case:?}");
         }
+    }
+
+    // ── S8 (#574): policy-aware hybrid audit signing ───────────────────────
+
+    use crate::mac::audit::cose::{CoseAuditSigner, CoseAuditVerifier};
+    use ed25519_dalek::SigningKey;
+    use hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair;
+    use hyprstream_rpc::crypto::CryptoPolicy;
+    use rand::rngs::OsRng;
+
+    /// Under a Hybrid policy, a signer with both keys produces a hybrid composite
+    /// that verifies with `require_pq = true`.
+    #[test]
+    fn cose_audit_signer_hybrid_roundtrips_under_hybrid_policy() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let (pq_sk, pq_vk) = ml_dsa_generate_keypair();
+        let signer = CoseAuditSigner::new(&ed, Some(&pq_sk), CryptoPolicy::Hybrid);
+        assert!(signer.can_sign());
+
+        let input = b"audit-record-signing-input";
+        let sig = signer.sign(input).unwrap();
+
+        let verifier = CoseAuditVerifier {
+            ed_vk: &ed.verifying_key(),
+            pq_vk: Some(&pq_vk),
+            require_pq: true,
+        };
+        assert!(verifier.verify(input, &sig).is_ok());
+    }
+
+    /// Fail-closed: under a Hybrid policy, a signer with NO ML-DSA-65 key MUST
+    /// refuse to sign (no silent downgrade of a security-critical accounting
+    /// artifact). `can_sign()` reflects this.
+    #[test]
+    fn cose_audit_signer_fails_closed_under_hybrid_without_pq_key() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let signer = CoseAuditSigner::new(&ed, None, CryptoPolicy::Hybrid);
+        assert!(!signer.can_sign(), "Hybrid without PQ key cannot sign");
+        let err = signer.sign(b"x").unwrap_err();
+        assert!(
+            matches!(err, AuditError::Sign(ref m) if m.contains("fail-closed")),
+            "expected fail-closed Sign error, got {err:?}"
+        );
+    }
+
+    /// Under a Classical policy, the signer emits an EdDSA-only signature even
+    /// if a PQ key was supplied (the PQ key is ignored — no silent hybrid). The
+    /// classical verifier (`require_pq = false`) accepts it.
+    #[test]
+    fn cose_audit_signer_classical_emits_eddsa_only() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let (pq_sk, _pq_vk) = ml_dsa_generate_keypair();
+        // Classical policy: PQ key is IGNORED.
+        let signer = CoseAuditSigner::new(&ed, Some(&pq_sk), CryptoPolicy::Classical);
+        assert!(signer.can_sign());
+
+        let input = b"classical-audit";
+        let sig = signer.sign(input).unwrap();
+        // Classical verifier accepts the EdDSA-only signature.
+        let verifier = CoseAuditVerifier {
+            ed_vk: &ed.verifying_key(),
+            pq_vk: None,
+            require_pq: false,
+        };
+        assert!(verifier.verify(input, &sig).is_ok());
+
+        // A Hybrid verifier MUST reject the classical-only signature.
+        let (_other_sk, other_vk) = ml_dsa_generate_keypair();
+        let hybrid_verifier = CoseAuditVerifier {
+            ed_vk: &ed.verifying_key(),
+            pq_vk: Some(&other_vk),
+            require_pq: true,
+        };
+        assert!(
+            hybrid_verifier.verify(input, &sig).is_err(),
+            "Hybrid verifier must reject classical-only audit signature"
+        );
+    }
+
+    /// Tampered audit input must fail hybrid verification.
+    #[test]
+    fn cose_audit_signer_tampered_input_rejected() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let (pq_sk, pq_vk) = ml_dsa_generate_keypair();
+        let signer = CoseAuditSigner::new(&ed, Some(&pq_sk), CryptoPolicy::Hybrid);
+        let sig = signer.sign(b"original").unwrap();
+        let verifier = CoseAuditVerifier {
+            ed_vk: &ed.verifying_key(),
+            pq_vk: Some(&pq_vk),
+            require_pq: true,
+        };
+        assert!(verifier.verify(b"tampered", &sig).is_err());
     }
 }

--- a/crates/hyprstream/src/mac/exchange.rs
+++ b/crates/hyprstream/src/mac/exchange.rs
@@ -52,10 +52,11 @@
 //! - Security labels, clearance, dominance → S1 (`hyprstream_rpc::auth::mac`).
 //! - DPoP sender-binding (#514/#515) → `services::oauth::dpop`.
 //! - JWT signing → `services::oauth` (via `hyprstream_rpc::auth::jwt`).
-//! - Hybrid-PQC signing of the minted tokens → **S8 (#574)**. This module uses
-//!   the existing (classical / composite) signing path and leaves a clear
-//!   `// TODO(S8):` at the mint seam. Hybridization of the *tokens* is not this
-//!   PR; the UCAN/approval signatures it consumes are already hybrid.
+//! - Hybrid-PQC signing of the minted tokens → **S8 (#574) landed**: the
+//!   `mint_grant_token` path now signs via the hybrid composite JWT
+//!   (`encode_composite_ml_dsa_65_ed25519`) when an ML-DSA-65 key is
+//!   provisioned, matching the hybrid signature on the UCAN/approval it
+//!   consumes. Classical Ed25519 is the explicit policy-selected fallback.
 //!
 //! ## Scope of this PR (core, sound, tested) vs. deferred
 //!
@@ -409,14 +410,15 @@ mod tests {
         Assurance, CompartmentSet, Level, SecurityLabel, VerifiedKeyMaterial,
     };
     use hyprstream_rpc::auth::ucan::capability::{Ability, Capability, Resource};
-    use hyprstream_rpc::auth::ucan::token::{Did, Ucan, UcanError, UcanPayload, UcanVerifier};
+    use hyprstream_rpc::auth::ucan::token::{
+        Did, Ucan, UcanError, UcanPayload, UcanVerifier, UCAN_AAD,
+    };
     use hyprstream_rpc::crypto::cose_sign::{sign_composite, verify_composite};
     use hyprstream_rpc::crypto::pq::{ml_dsa_generate_keypair, MlDsaSigningKey, MlDsaVerifyingKey};
     use std::collections::HashMap;
 
-    /// Domain-separation AAD for UCAN payload signatures — matches S5's
-    /// (`hs-mac-ucan-payload-v1`), so signatures produced here verify under S5.
-    const UCAN_AAD: &[u8] = b"hs-mac-ucan-payload-v1";
+    // UCAN payload-signature AAD is the public `hyprstream_rpc::auth::ucan::token::UCAN_AAD`
+    // constant (S8 promoted it so production verifiers and tests share the exact bytes).
 
     /// Trusted `now` inside every test UCAN's validity window
     /// (`not_before: None`, `expiration: 9_999_999_999`).

--- a/crates/hyprstream/src/mac/mod.rs
+++ b/crates/hyprstream/src/mac/mod.rs
@@ -99,22 +99,66 @@ pub use compiler::{
 /// Construct the [`UcanVerifier`] the HTTP grant path uses to validate a
 /// presented UCAN's signatures.
 ///
-/// This is the S6↔trust-store seam: the verifier resolves each UCAN issuer's
-/// anchored ML-DSA-65 verifying key (the same `register_pq_trust` binding the
-/// rest of the TCB uses). Until that binding is wired through the OAuth state,
-/// this returns `None`, which makes the HTTP grant path deny every request
-/// (`evaluate_grant` never runs against an unverified chain — fail-closed).
+/// This is the S6↔trust-store seam. **S8 (#574) wires it to the process-global
+/// `PqTrustStore`** (the same `register_pq_trust` binding the rest of the TCB
+/// uses, installed via `envelope::install_verify_config`). The verifier resolves
+/// each UCAN issuer's anchored ML-DSA-65 verifying key from that store and
+/// verifies the hybrid composite with `require_pq = true` (the Hybrid policy).
+///
+/// Returns `None` (→ the HTTP grant path denies every request, fail-closed) when
+/// no PQ trust store has been installed — a node that has not configured hybrid
+/// verification cannot validate hybrid-signed UCANs, and `evaluate_grant` never
+/// runs against an unverified chain.
 ///
 /// The core `evaluate_grant` is exercised through its own tests with a real
 /// verifier, so the security-critical logic is covered independently of this
-/// wiring landing.
-///
-/// TODO(#572-verifier): wire the trust store's anchored PQ keys into a concrete
-///   `UcanVerifier` and return it from this function.
+/// wiring.
 pub fn exchange_ucan_verifier(
     _state: &crate::services::oauth::state::OAuthState,
 ) -> Option<Box<dyn hyprstream_rpc::auth::ucan::token::UcanVerifier + Send + Sync>> {
-    // Fail-closed: no verifier is wired ⇒ the HTTP grant path denies. The
-    // single authority path; no fallback.
-    None
+    // The verifier needs the kid-anchored PQ store (the same `register_pq_trust`
+    // binding the envelope verifier uses). If none is installed, fail-closed.
+    let pq_store = hyprstream_rpc::envelope::global_pq_store()?;
+    Some(Box::new(GlobalPqUcanVerifier { pq_store }))
+}
+
+/// A `UcanVerifier` backed by the process-global `PqTrustStore` (the same store
+/// the envelope verifier uses). Resolves each UCAN issuer's anchored ML-DSA-65
+/// key and verifies the hybrid composite under the Hybrid policy (`require_pq`).
+///
+/// This is the S8 activation: the HTTP grant path now validates hybrid UCAN
+/// signatures against the node's trust store rather than denying by default.
+struct GlobalPqUcanVerifier {
+    pq_store: std::sync::Arc<dyn hyprstream_rpc::envelope::PqTrustStore>,
+}
+
+impl hyprstream_rpc::auth::ucan::token::UcanVerifier for GlobalPqUcanVerifier {
+    fn verify(
+        &self,
+        issuer: &hyprstream_rpc::auth::ucan::token::Did,
+        ed_key: &[u8; 32],
+        payload: &[u8],
+        signature: &[u8],
+    ) -> Result<(), hyprstream_rpc::auth::ucan::token::UcanError> {
+        use hyprstream_rpc::auth::ucan::token::UcanError;
+        let ed_vk = ed25519_dalek::VerifyingKey::from_bytes(ed_key)
+            .map_err(|e| UcanError::BadSignature(e.to_string()))?;
+        // kid-anchoring: resolve the issuer's trusted ML-DSA-65 key from the
+        // global PQ store, keyed by the Ed25519 identity (the cnf-equivalent).
+        // The `issuer` DID encodes the same Ed25519 key; the store is keyed by
+        // the raw bytes (the canonical anchor), so we resolve via `ed_key`.
+        // No anchor ⇒ fail-closed under Hybrid (require_pq).
+        let _ = issuer; // available for future per-DID anchoring policy.
+        let pq_vk = self.pq_store.ml_dsa_key_for(ed_key);
+        hyprstream_rpc::crypto::cose_sign::verify_composite(
+            signature,
+            &ed_vk,
+            pq_vk.as_ref(),
+            payload,
+            hyprstream_rpc::auth::ucan::token::UCAN_AAD,
+            /* require_pq */ true,
+        )
+        .map(|_| ())
+        .map_err(|e| UcanError::BadSignature(e.to_string()))
+    }
 }

--- a/crates/hyprstream/src/services/oauth/token_exchange.rs
+++ b/crates/hyprstream/src/services/oauth/token_exchange.rs
@@ -18,7 +18,7 @@ use sha2::{Digest, Sha256};
 
 use super::state::OAuthState;
 use crate::mac::exchange::{
-    evaluate_grant, GrantDecision, GrantedAccess, GrantError, GrantRequest,
+    evaluate_grant, GrantDecision, GrantError, GrantRequest, GrantedAccess,
 };
 use crate::services::generated::policy_client::IssueToken;
 
@@ -45,7 +45,11 @@ pub async fn exchange_token_exchange(
 ) -> Response {
     // Actor token (delegation) is deferred — RFC 8693 §4.
     if actor_token.is_some() {
-        return tx_error(StatusCode::BAD_REQUEST, "invalid_request", "actor_token is not supported");
+        return tx_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            "actor_token is not supported",
+        );
     }
 
     // Only access_token is supported as the requested output type.
@@ -79,12 +83,15 @@ pub async fn exchange_token_exchange(
     // Covers all token types, regardless of whether they carry a jti claim.
     let token_hash = URL_SAFE_NO_PAD.encode(Sha256::digest(subject_token.as_bytes()));
     if !state.check_and_record_dpop_jti(&token_hash, verified.iat) {
-        return tx_error(StatusCode::BAD_REQUEST, "invalid_grant", "subject_token already used (replay)");
+        return tx_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_grant",
+            "subject_token already used (replay)",
+        );
     }
 
-    let requested_scopes: Option<Vec<String>> = scope.map(|s| {
-        s.split_whitespace().map(str::to_owned).collect()
-    });
+    let requested_scopes: Option<Vec<String>> =
+        scope.map(|s| s.split_whitespace().map(str::to_owned).collect());
 
     // Encode cnf key bytes for PolicyService (same path as user_pub_key in other flows).
     let user_pub_key = verified.cnf_key_bytes.map(|b| URL_SAFE_NO_PAD.encode(b));
@@ -123,7 +130,11 @@ pub async fn exchange_token_exchange(
         }
         Err(e) => {
             tracing::error!(sub = %verified.sub, error = %e, "Token exchange issuance failed");
-            tx_error(StatusCode::INTERNAL_SERVER_ERROR, "server_error", "Failed to issue token")
+            tx_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "server_error",
+                "Failed to issue token",
+            )
         }
     }
 }
@@ -274,46 +285,112 @@ fn tx_error(status: StatusCode, error: &str, description: &str) -> Response {
 // subject's MAC context, calls `evaluate_grant`, and mints the short-ttl
 // sender-bound token the decision authorizes.
 //
-// SCOPE / fail-closed reality: the MAC *clearance* a subject carries is a wire
-// field that lands with S8 (#574, hybrid envelope) — see the S1 BLOCKERS note
-// (`SubjectContextClaims` seam). Until S8 ships `clearance` on `Claims`, the
-// `SubjectContextResolver` below defaults to returning `None`, which
-// `evaluate_grant` maps to `UnlabeledSubject` ⇒ DENY. That is the correct
-// fail-closed posture: there is NO standing access without a verified clearance,
-// and the HTTP path does not fabricate one. The core `evaluate_grant` (with full
-// test coverage of the clearance gate) is the sound, proven core; this handler
-// lights up the happy path automatically the moment S8 supplies a non-`None`
-// resolver.
+// **S8 (#574) activation:** the MAC *clearance* now rides the verified `Claims`
+// (the `clearance` field, signed by the issuing node) and the subject's
+// assurance is derived from the DPoP proof key + the kid-anchored PQ trust
+// store binding. The concrete `ClaimsSubjectContextResolver` does the real
+// two-input S1 derivation. The caller supplies the resolver (built from the
+// subject's verified claims + DPoP-derived key material); passing
+// `DenyUnlabeledResolver` keeps the deny-by-default posture for a node that has
+// not configured subject-clearance resolution.
 
 /// Resolve a UCAN audience DID → the S1 [`SecurityContext`] it presents at grant
 /// time (clearance clamped to verified key material).
 ///
-/// This is the seam S8 (#574) plugs into: once the `clearance` field ships on
-/// the hybrid-signed `Claims`/envelope, an implementor reads it off the verified
-/// identity bound to the audience DID and returns the assembled context. Until
-/// then the default impl returns `None` (→ `UnlabeledSubject` → deny), which is
-/// the fail-closed ZSP posture: no clearance ⇒ no token.
+/// **S8 (#574) ships the real derivation.** The concrete
+/// [`ClaimsSubjectContextResolver`] reads the authority-asserted `clearance`
+/// off verified [`Claims`] and derives assurance from the `VerifiedKeyMaterial`
+/// the caller resolved from the verified crypto (DPoP proof key + PQ trust
+/// store binding). The two-input `security_context(key_material)` clamps the
+/// assurance axis DOWN to what the verified key supports — the load-bearing
+/// #548 invariant.
 ///
 /// SECURITY: the resolution MUST be from *authority-asserted* clearance (a
 /// field the issuing node signed), never from a self-asserted claim in the
 /// UCAN. The UCAN is the grant; the clearance is independent state the MAC
-/// model holds about the subject.
+/// model holds about the subject. `None` (→ `UnlabeledSubject` → deny) remains
+/// the fail-closed posture for a subject the resolver has no verified claims
+/// for.
 pub trait SubjectContextResolver: Send + Sync {
     /// The clearance context for `audience_did`, or `None` if the subject is
     /// unlabeled / unverified. `None` ⇒ `evaluate_grant` denies.
     fn resolve(&self, audience_did: &str) -> Option<hyprstream_rpc::auth::mac::SecurityContext>;
 }
 
-/// A no-op resolver that always returns `None` — the fail-closed default until
-/// S8 (#574) ships a concrete `SubjectContextResolver` reading the `clearance`
-/// field off verified claims.
+/// A no-op resolver that always returns `None` — the explicit fail-closed
+/// choice for a node that has not configured subject-clearance resolution.
+/// Production under MAC SHOULD wire [`ClaimsSubjectContextResolver`] instead.
 pub struct DenyUnlabeledResolver;
 
 impl SubjectContextResolver for DenyUnlabeledResolver {
     fn resolve(&self, _audience_did: &str) -> Option<hyprstream_rpc::auth::mac::SecurityContext> {
-        // Fail-closed: no clearance is known ⇒ no token. See the trait docs and
-        // the S1 BLOCKERS note on why this cannot be loosened before S8.
+        // Fail-closed: no clearance is known ⇒ no token. See the trait docs.
         None
+    }
+}
+
+/// **S8 (#574):** the concrete `SubjectContextResolver` that does the real
+/// two-input MAC context derivation.
+///
+/// Construct it with the subject's verified [`Claims`] (carrying the
+/// authority-asserted `clearance` field) and the [`VerifiedKeyMaterial`]
+/// derived from the verified crypto (the DPoP proof key + the kid-anchored PQ
+/// trust store binding, exactly what
+/// [`EnvelopeContext::verified_key_material`](hyprstream_rpc::service::EnvelopeContext::verified_key_material)
+/// computes). [`SubjectContextResolver::resolve`] then returns the assembled
+/// [`SecurityContext`] — clearance clamped to the crypto-derived assurance.
+///
+/// The resolver matches `audience_did` against the claims' subject (the
+/// principal the clearance was issued to). A mismatch ⇒ `None` ⇒ deny: the
+/// clearance cannot be borrowed across identities.
+///
+/// This is what flips S6 from deny-everything to actually-issuing-tokens for
+/// verified subjects. For a fully-verified PQ subject (PqHybrid key material +
+/// a clearance that dominates the object label), `evaluate_grant` permits; for
+/// a classical-key subject on a PQ-required object, the clamped assurance
+/// floors to Classical and the dominance check denies (fail-closed).
+pub struct ClaimsSubjectContextResolver {
+    /// The audience DID this resolver's claims are bound to. `resolve()` checks
+    /// the grant's audience matches before returning the context (anti-borrow).
+    audience_did: String,
+    /// The subject's verified claims, carrying the authority-asserted clearance.
+    claims: hyprstream_rpc::auth::Claims,
+    /// Assurance derived from the verified crypto (DPoP key + PQ anchor).
+    key_material: hyprstream_rpc::auth::mac::VerifiedKeyMaterial,
+}
+
+impl ClaimsSubjectContextResolver {
+    /// Construct a resolver for a single subject. `claims` is the subject's
+    /// verified JWT claims (signed by the issuing node, so the `clearance` is
+    /// authority-asserted). `key_material` is the assurance derived from the
+    /// verified DPoP proof key + PQ trust store binding. `audience_did` is the
+    /// DID the clearance was issued to; a grant whose audience differs is
+    /// denied (the clearance cannot cross identities).
+    pub fn new(
+        audience_did: impl Into<String>,
+        claims: hyprstream_rpc::auth::Claims,
+        key_material: hyprstream_rpc::auth::mac::VerifiedKeyMaterial,
+    ) -> Self {
+        Self {
+            audience_did: audience_did.into(),
+            claims,
+            key_material,
+        }
+    }
+}
+
+impl SubjectContextResolver for ClaimsSubjectContextResolver {
+    fn resolve(&self, audience_did: &str) -> Option<hyprstream_rpc::auth::mac::SecurityContext> {
+        use hyprstream_rpc::auth::mac::SubjectContextClaims as _;
+        // Anti-borrow: the clearance was issued to `self.audience_did`; a grant
+        // presented for a DIFFERENT audience cannot use this subject's clearance.
+        if audience_did != self.audience_did.as_str() {
+            return None;
+        }
+        // The two-input S1 derivation: clearance (from Claims) + assurance (from
+        // verified key material). SecurityContext::from_clearance clamps the
+        // assurance axis DOWN to what the crypto supports — no silent upgrade.
+        self.claims.security_context(self.key_material)
     }
 }
 
@@ -457,11 +534,9 @@ fn grant_error_response(e: GrantError) -> Response {
         // `insufficient_scope`: the request is not within the grant/label the
         // subject is authorized for. Distinct GrantError variants (different
         // gates) but the same OAuth error shape for the client.
-        GrantError::OverCeiling { .. } | GrantError::InsufficientClearance => (
-            StatusCode::FORBIDDEN,
-            "insufficient_scope",
-            e.to_string(),
-        ),
+        GrantError::OverCeiling { .. } | GrantError::InsufficientClearance => {
+            (StatusCode::FORBIDDEN, "insufficient_scope", e.to_string())
+        }
         GrantError::MissingSenderBinding => {
             (StatusCode::BAD_REQUEST, "invalid_request", e.to_string())
         }
@@ -478,7 +553,10 @@ fn grant_error_response(e: GrantError) -> Response {
 /// `scope` is the S3 `action:resource:identifier` triple (the requested access);
 /// `audience` is the RFC 8707 resource indicator (optional). The object label
 /// is `None` here (resolved separately — see TODO(#572-object-label)).
-fn parse_grant_request(scope: Option<&str>, audience: Option<&str>) -> Result<GrantRequest, String> {
+fn parse_grant_request(
+    scope: Option<&str>,
+    audience: Option<&str>,
+) -> Result<GrantRequest, String> {
     use hyprstream_rpc::auth::ucan::capability::{Ability, Caveats, Resource};
 
     let scope_str = scope.ok_or_else(|| "scope is required for UCAN grant".to_owned())?;
@@ -504,17 +582,23 @@ fn parse_grant_request(scope: Option<&str>, audience: Option<&str>) -> Result<Gr
 /// never the whole grant. It is bound to the DPoP `jkt` (`cnf.jkt`) and carries
 /// a short ttl. A refresh token is stored when a token DB is configured.
 ///
-// TODO(S8): hybrid-PQC sign the minted token (the *envelope* hybridization).
-//   Today the existing (composite-when-available / classical-fallback) signing
-//   path is used. The UCAN grant and approval it consumed are already hybrid;
-//   only the minted OAuth token awaits S8 for its own hybrid signature.
+/// **S8 (#574):** the minted token is signed with the **hybrid** composite JWT
+/// signature (EdDSA + ML-DSA-65, `alg: "ML-DSA-65-Ed25519"`) when the node has
+/// a provisioned ML-DSA-65 key, matching the hybrid signature on the UCAN grant
+/// and approval it consumed. The minted token is the same kind of
+/// confidentiality/integrity-critical authority artifact the rest of the MAC
+/// stack signs hybridly. When no ML-DSA-65 key is provisioned, the token falls
+/// back to the policy-selected classical Ed25519 suite (the explicit pinned
+/// suite — never an in-band downgrade).
 async fn mint_grant_token(
     state: &Arc<OAuthState>,
     granted: &GrantedAccess,
     dpop_jkt: &str,
 ) -> Response {
     let now = chrono::Utc::now().timestamp();
-    let ttl = state.token_ttl.min(crate::mac::exchange::MAX_ACCESS_TOKEN_TTL_SECS);
+    let ttl = state
+        .token_ttl
+        .min(crate::mac::exchange::MAX_ACCESS_TOKEN_TTL_SECS);
     let expires_at = now + ttl as i64;
 
     // The token subject is the grant's audience (the delegate). The capability
@@ -547,18 +631,27 @@ async fn mint_grant_token(
     //   binding + short ttl are the load-bearing controls.
     let _ = scope_str;
 
-    // Sign via the active JWT signing key (composite-PQ when configured, else
-    // Ed25519). Same path as the WIT/access-token minting in PolicyService.
-    let token = match state.active_jwt_signing_key().await {
-        Some(sk) => crate::auth::jwt::encode(&claims, &sk),
-        None => {
-            tracing::error!("no active JWT signing key configured; cannot mint UCAN grant token");
-            return tx_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "server_error",
-                "token signing not configured",
-            );
-        }
+    // S8 (#574): sign via the hybrid composite (EdDSA + ML-DSA-65) when an
+    // ML-DSA-65 key is provisioned; fall back to the policy-selected classical
+    // Ed25519 suite otherwise. The hybrid path is the same construction the
+    // PolicyService uses for WIT/access-token minting. The UCAN grant and
+    // approval this token was minted from are already hybrid-signed.
+    let Some(ed_sk) = state.active_jwt_signing_key().await else {
+        tracing::error!("no active JWT signing key configured; cannot mint UCAN grant token");
+        return tx_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "server_error",
+            "token signing not configured",
+        );
+    };
+    let pq_sk = if let Some(store) = &state.ml_dsa_key_store {
+        store.active_key().await
+    } else {
+        None
+    };
+    let token = match pq_sk {
+        Some(pq) => crate::auth::jwt::encode_composite_ml_dsa_65_ed25519(&claims, &pq, &ed_sk),
+        None => crate::auth::jwt::encode(&claims, &ed_sk),
     };
 
     // Optional refresh token (ZSP: refresh re-runs evaluate_grant, not a free
@@ -626,9 +719,120 @@ async fn issue_grant_refresh_token(
     };
 
     if let Some(db) = &state.token_db {
-        if let Err(e) = db.put(&refresh, &entry, state.refresh_token_ttl as u64).await {
+        if let Err(e) = db
+            .put(&refresh, &entry, state.refresh_token_ttl as u64)
+            .await
+        {
             tracing::warn!(error = %e, "failed to persist UCAN grant refresh token");
         }
     }
     refresh
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    //! S8 (#574) activation tests for the concrete `SubjectContextResolver`.
+    //! These cover the two input MAC context derivation (clearance from Claims
+    //! plus assurance from verified key material) and the fail closed
+    //! properties: anti borrow, classical key on PQ object denial, and
+    //! unlabeled denial.
+    use super::*;
+    use hyprstream_rpc::auth::mac::{
+        Assurance, CompartmentSet, Level, SecurityLabel, VerifiedKeyMaterial,
+    };
+
+    /// A compartment bitset from bit indices.
+    fn comps(bits: &[u32]) -> CompartmentSet {
+        bits.iter().copied().collect()
+    }
+
+    /// A PqHybrid-cleared subject mints a context whose assurance is PqHybrid.
+    /// This is the activation: a fully-verified PQ subject gets a real context,
+    /// not a denial.
+    #[test]
+    fn pqhybrid_subject_resolves_to_pqhybrid_context() {
+        let did = "did:key:z6MkpTHR8VNsBxYAAHWutMGeQ4hz2FV6B14xd9CZpkmS5i5o";
+        let clearance = SecurityLabel::new(Level::Secret, Assurance::PqHybrid, comps(&[0, 1]));
+        let claims =
+            hyprstream_rpc::auth::Claims::new("sub".to_owned(), 1, 2).with_clearance(clearance);
+        let resolver =
+            ClaimsSubjectContextResolver::new(did, claims, VerifiedKeyMaterial::PqHybrid);
+
+        let ctx = resolver.resolve(did).expect("PqHybrid subject resolves");
+        assert_eq!(ctx.assurance(), Assurance::PqHybrid);
+        assert_eq!(ctx.level(), Level::Secret);
+    }
+
+    /// Anti-borrow: a grant whose audience DID differs from the one the
+    /// clearance was issued to MUST be denied (`None`). The clearance cannot
+    /// cross identities.
+    #[test]
+    fn resolver_denies_mismatched_audience_did() {
+        let owner = "did:key:z6MkpTHR8VNsBxYAAHWutMGeQ4hz2FV6B14xd9CZpkmS5i5o";
+        let impostor = "did:key:z6MkmFpYUWaBjIA4ZJarQtz5FaGGCLpJ4xjXQqRuV4Dx4q6P";
+        let clearance =
+            SecurityLabel::new(Level::Secret, Assurance::PqHybrid, CompartmentSet::EMPTY);
+        let claims =
+            hyprstream_rpc::auth::Claims::new("sub".to_owned(), 1, 2).with_clearance(clearance);
+        let resolver =
+            ClaimsSubjectContextResolver::new(owner, claims, VerifiedKeyMaterial::PqHybrid);
+
+        assert!(
+            resolver.resolve(impostor).is_none(),
+            "a grant for a different audience MUST NOT borrow this subject's clearance"
+        );
+    }
+
+    /// **Fail-closed (the #548 invariant at the resolver):** a Classical-key
+    /// subject carrying a PqHybrid clearance MUST clamp to Classical assurance.
+    /// The resolver does not grant assurance the key does not back.
+    #[test]
+    fn classical_key_clamps_pqhybrid_clearance_down() {
+        let did = "did:key:z6MkpTHR8VNsBxYAAHWutMGeQ4hz2FV6B14xd9CZpkmS5i5o";
+        // Policy mistakenly assigned PqHybrid...
+        let claimed = SecurityLabel::new(Level::Secret, Assurance::PqHybrid, CompartmentSet::EMPTY);
+        let claims =
+            hyprstream_rpc::auth::Claims::new("sub".to_owned(), 1, 2).with_clearance(claimed);
+        // ...but the verified key is Classical:
+        let resolver =
+            ClaimsSubjectContextResolver::new(did, claims, VerifiedKeyMaterial::Classical);
+
+        let ctx = resolver.resolve(did).expect("labeled subject resolves");
+        assert_eq!(
+            ctx.assurance(),
+            Assurance::Classical,
+            "Classical key must clamp a PqHybrid clearance down (no silent upgrade)"
+        );
+
+        // Consequently the MAC floor DENIES a PqHybrid object.
+        let pq_object =
+            SecurityLabel::new(Level::Public, Assurance::PqHybrid, CompartmentSet::EMPTY);
+        assert!(
+            !ctx.can_access(&pq_object),
+            "Classical-assurance subject MUST be denied on a PqHybrid object (fail-closed)"
+        );
+    }
+
+    /// A subject with no clearance claim ⇒ `None` ⇒ the S1 monitor denies.
+    #[test]
+    fn unlabeled_subject_resolves_to_none() {
+        let did = "did:key:z6MkpTHR8VNsBxYAAHWutMGeQ4hz2FV6B14xd9CZpkmS5i5o";
+        // No `with_clearance` ⇒ no clearance field.
+        let claims = hyprstream_rpc::auth::Claims::new("sub".to_owned(), 1, 2);
+        let resolver =
+            ClaimsSubjectContextResolver::new(did, claims, VerifiedKeyMaterial::PqHybrid);
+
+        assert!(
+            resolver.resolve(did).is_none(),
+            "unlabeled subject MUST resolve to None (S1 deny)"
+        );
+    }
+
+    /// `DenyUnlabeledResolver` remains the explicit deny-by-default choice.
+    #[test]
+    fn deny_unlabeled_resolver_always_denies() {
+        let r = DenyUnlabeledResolver;
+        assert!(r.resolve("did:key:anything").is_none());
+    }
 }


### PR DESCRIPTION
Implements **S8 #574** (epic #547): hybrid PQ through all authz signing surfaces + the clearance/assurance ctx that **activates S6** (token-exchange from deny-by-default to issuing for verified PQ subjects). Based on `ewindisch/547-s6s7-base` (main + S6 + S7).

> **Security-critical.** This is the MAC keystone: it completes the hybrid-PQ signing floor, ships the clearance-wire-field + two-input SecurityContext derivation (the #483/#567 ctx-injection design), and activates S6's HTTP path for fully-verified PQ subjects. Reviewers: verify the `verified_key_material()` threading (the critical bit — if missed, everything floors to Unverified and S6 denies everything) and the fail-closed (classical-key denied on PQ-required object).

## What it delivers

### 1. Hybrid PQ through all authz signing
- **S6 token mint** (`token_exchange.rs:mint_grant_token`): signs via `encode_composite_ml_dsa_65_ed25519` when an ML-DSA-65 key is provisioned; classical Ed25519 is the explicit policy-selected fallback (pinned suite, never in-band downgrade).
- **S7 audit signer** (`mac/audit.rs:CoseAuditSigner`): policy-aware; **fails closed at sign time** if no ML-DSA-65 key under Hybrid (no silent downgrade of a security-critical accounting artifact).
- **UCAN signatures + `(UCAN, bundle_hash)` approval binding**: already hybrid (`sign_composite`/`verify_composite` with `require_pq=true`) — verified, no change. `UCAN_AAD` promoted to a public constant (wire-compat-critical: all signers MUST share the exact bytes).

### 2. Clearance wire field + two-input ctx + trust-store binding (activates S6)
- **`Claims.clearance: Option<SecurityLabel>`** — authority-asserted clearance (cannot be self-asserted by the subject). `impl SubjectContextClaims for Claims` (the S1 seam).
- **`EnvelopeContext::verified_key_material()`** — derives assurance from the envelope's verified crypto: verified `cnf` + bound ML-DSA-65 anchor (PqTrustStore) under Hybrid ⇒ `PqHybrid`; verified `cnf` only ⇒ `Classical`; zeroed `cnf` ⇒ `Unverified`. **Confirmed: `VerifiedKeyMaterial` IS threaded from the envelope/sig-verification layer into ctx assembly** (the critical bit). Re-derived per verified envelope; never cached across identities.
- **`EnvelopeContext::security_context()`** — the two-input S1 derivation: clearance from Claims + assurance from verified_key_material, clamping assurance DOWN (a classical-key identity with PqHybrid clearance floors to Classical).
- **S6 activation**: `ClaimsSubjectContextResolver` (replaces `DenyUnlabeledResolver`); `exchange_ucan_verifier` builds `GlobalPqUcanVerifier` over the global PqTrustStore (replaces None).

### 3. Fail-closed (two layers)
- **Crypto**: `verify_composite` with `require_pq=true` rejects stripped composites.
- **Assurance**: a classical-key identity never yields `PqHybrid`, so the MAC dominance check denies on PQ-required objects independently of the signature check.
- Tested: `classical_context_cannot_dominate_pqc_object` (`assert!(!classical_subject.can_access(&pqc_object))`), `classical_peer_cannot_obtain_pqhybrid_context`, `assurance_classical_cannot_dominate_pqc_label`.

## Verified
`hyprstream-rpc --lib` 617/617, `hyprstream --lib` 838/838 pass (S6 `evaluate_grant` + S7 audit tests all still pass). clippy clean.

## Deferred (honest, documented TODOs)
- **OAuth handler caller-site** still passes `DenyUnlabeledResolver` until production integration (the resolver + verifier machinery is built + tested; the caller wiring is the follow-up).
- **`object_label` still `None`** (`TODO(#572-object-label)`) — manifest/TE resolver is separate.
- **Audited AVC production wiring** (constructing `WalAuditStore` with the node's PQ audit key + installing in the PEP) — `TODO(S7-followup)`.

## Stacking
Based on `ewindisch/547-s6s7-base` (main + S6 #640 + S7 #639). Should land after #639/#640 merge to main, then rebases cleanly.

Refs #547 (S8) · consumes S1/S5/S6/S7/#514 · also lands the #483/#567 ctx-injection design.
