### PR TITLE
EV5 (#605) part 1: port Model events to EventService + carve WASM primitives

### DIFF
--- a/crates/hyprstream-rpc/src/crypto/broadcast_primitives.rs
+++ b/crates/hyprstream-rpc/src/crypto/broadcast_primitives.rs
@@ -1,0 +1,78 @@
+//! Broadcast crypto primitives preserved from the removed NotificationService.
+//!
+//! These are reused by the WASM client (`wasm_api.rs`) and remain public so the
+//! browser binding is unaffected by the NotificationService removal (EV5/#605).
+//! The blind-relay broadcast service itself is gone; only the reusable crypto
+//! helpers (pubkey fingerprint, length-prefixed AAD, one-shot MAC, attestation
+//! message) remain here.
+
+use subtle::ConstantTimeEq;
+
+use super::backend::keyed_mac;
+use crate::error::{EnvelopeError, EnvelopeResult};
+
+/// 128-bit pubkey fingerprint (Blake3 truncated).
+pub type PubkeyFingerprint = [u8; 16];
+
+/// Compute a 128-bit fingerprint of a public key: `Blake3(pubkey)[..16]`.
+pub fn pubkey_fingerprint(pubkey_bytes: &[u8; 32]) -> PubkeyFingerprint {
+    let hash = blake3::hash(pubkey_bytes);
+    let mut fp = [0u8; 16];
+    fp.copy_from_slice(&hash.as_bytes()[..16]);
+    fp
+}
+
+/// Build length-prefixed AAD for payload encryption.
+///
+/// Format: `u32_le(len(intent_id)) || intent_id || u32_le(len(scope)) || scope`.
+/// Length prefixing prevents ambiguity where different intent_id/scope splits
+/// produce the same concatenated bytes.
+pub fn build_payload_aad(intent_id: &str, scope: &str) -> Vec<u8> {
+    let mut aad = Vec::with_capacity(8 + intent_id.len() + scope.len());
+    aad.extend_from_slice(&(intent_id.len() as u32).to_le_bytes());
+    aad.extend_from_slice(intent_id.as_bytes());
+    aad.extend_from_slice(&(scope.len() as u32).to_le_bytes());
+    aad.extend_from_slice(scope.as_bytes());
+    aad
+}
+
+/// Compute a one-shot MAC: `keyed_mac(mac_key, ciphertext)`.
+pub fn notification_mac(mac_key: &[u8; 32], ciphertext: &[u8]) -> [u8; 32] {
+    keyed_mac(mac_key, ciphertext)
+}
+
+/// Verify a one-shot MAC in constant time.
+pub fn notification_mac_verify(
+    mac_key: &[u8; 32],
+    ciphertext: &[u8],
+    expected_mac: &[u8; 32],
+) -> EnvelopeResult<()> {
+    let computed = keyed_mac(mac_key, ciphertext);
+    if bool::from(computed.ct_eq(expected_mac)) {
+        Ok(())
+    } else {
+        Err(EnvelopeError::MacVerification)
+    }
+}
+
+/// Build the message signed by the publisher's Ed25519 key for attestation.
+///
+/// Format: `ephemeral_pubkey || blinded_sub_pubkey || u32_le(len(scope)) ||
+/// scope || u32_le(len(intent_id)) || intent_id`. Fixed-length pubkeys are not
+/// length-prefixed; variable-length fields are, to prevent concatenation
+/// ambiguity.
+pub fn build_attestation_message(
+    ephemeral_pubkey: &[u8; 32],
+    blinded_sub_pubkey: &[u8; 32],
+    scope: &str,
+    intent_id: &str,
+) -> Vec<u8> {
+    let mut msg = Vec::with_capacity(64 + 8 + scope.len() + intent_id.len());
+    msg.extend_from_slice(ephemeral_pubkey);
+    msg.extend_from_slice(blinded_sub_pubkey);
+    msg.extend_from_slice(&(scope.len() as u32).to_le_bytes());
+    msg.extend_from_slice(scope.as_bytes());
+    msg.extend_from_slice(&(intent_id.len() as u32).to_le_bytes());
+    msg.extend_from_slice(intent_id.as_bytes());
+    msg
+}

--- a/crates/hyprstream-rpc/src/crypto/mod.rs
+++ b/crates/hyprstream-rpc/src/crypto/mod.rs
@@ -35,6 +35,7 @@ pub mod group_key;
 pub mod hmac;
 pub mod key_exchange;
 pub mod notification;
+pub mod broadcast_primitives;
 pub mod pq;
 pub mod signing;
 

--- a/crates/hyprstream-rpc/src/wasm_api.rs
+++ b/crates/hyprstream-rpc/src/wasm_api.rs
@@ -725,7 +725,7 @@ pub fn notification_mac(mac_key: &[u8], data: &[u8]) -> Result<Vec<u8>, JsError>
 
     let mut key = [0u8; 32];
     key.copy_from_slice(mac_key);
-    let mac = crate::crypto::notification::notification_mac(&key, data);
+    let mac = crate::crypto::broadcast_primitives::notification_mac(&key, data);
     Ok(mac.to_vec())
 }
 
@@ -758,7 +758,7 @@ pub fn notification_mac_verify(
     let mut mac = [0u8; 32];
     mac.copy_from_slice(expected_mac);
 
-    Ok(crate::crypto::notification::notification_mac_verify(&key, data, &mac).is_ok())
+    Ok(crate::crypto::broadcast_primitives::notification_mac_verify(&key, data, &mac).is_ok())
 }
 
 /// Build length-prefixed AAD for notification payload encryption/decryption.
@@ -777,7 +777,7 @@ pub fn notification_mac_verify(
 /// AAD bytes for use with aes_gcm_encrypt/decrypt
 #[wasm_bindgen]
 pub fn notification_build_payload_aad(intent_id: &str, scope: &str) -> Vec<u8> {
-    crate::crypto::notification::build_payload_aad(intent_id, scope)
+    crate::crypto::broadcast_primitives::build_payload_aad(intent_id, scope)
 }
 
 /// Compute a 128-bit pubkey fingerprint: `Blake3(pubkey)[..16]`.
@@ -798,7 +798,7 @@ pub fn notification_pubkey_fingerprint(pubkey: &[u8]) -> Result<Vec<u8>, JsError
     }
     let mut pk = [0u8; 32];
     pk.copy_from_slice(pubkey);
-    Ok(crate::crypto::notification::pubkey_fingerprint(&pk).to_vec())
+    Ok(crate::crypto::broadcast_primitives::pubkey_fingerprint(&pk).to_vec())
 }
 
 /// Build the Ed25519 attestation message for publisher identity verification.
@@ -834,7 +834,7 @@ pub fn notification_build_attestation_message(
     let mut bp = [0u8; 32];
     bp.copy_from_slice(blinded_sub_pubkey);
 
-    Ok(crate::crypto::notification::build_attestation_message(&ep, &bp, scope, intent_id))
+    Ok(crate::crypto::broadcast_primitives::build_attestation_message(&ep, &bp, scope, intent_id))
 }
 
 /// Sign an Ed25519 attestation for publisher identity binding.

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -661,7 +661,7 @@ impl Spawnable for MoqStreamBarrierService {
 // ═══════════════════════════════════════════════════════════════════════════════
 
 /// Factory for ModelService (model lifecycle management)
-#[service_factory("model", schema = "../../../hyprstream-rpc-std/schema/model.capnp", metadata = crate::services::generated::model_client::schema_metadata, depends_on = ["policy", "registry", "discovery", "notification"])]
+#[service_factory("model", schema = "../../../hyprstream-rpc-std/schema/model.capnp", metadata = crate::services::generated::model_client::schema_metadata, depends_on = ["policy", "registry", "discovery", ])]
 fn create_model_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>> {
     info!("Creating ModelService");
 

--- a/crates/hyprstream/src/services/model.rs
+++ b/crates/hyprstream/src/services/model.rs
@@ -33,7 +33,7 @@ use crate::runtime::KVQuantType;
 use crate::runtime::RuntimeConfig;
 use crate::services::{
     EnvelopeContext,
-    NotificationClient, NotificationPublisher, PolicyClient,
+    PolicyClient,
 };
 use crate::services::generated::inference_client::InferenceClient;
 use crate::services::RegistryClient;
@@ -42,6 +42,7 @@ use crate::services::generated::policy_client::PolicyCheck;
 use crate::storage::ModelRef;
 use anyhow::{anyhow, Result};
 use hyprstream_rpc::prelude::*;
+use hyprstream_rpc::events::EventPublisher;
 use hyprstream_rpc::registry::{global as registry, SocketKind};
 use hyprstream_rpc::transport::TransportConfig;
 use hyprstream_rpc::stream_info::TransportConfig as WireTransportConfig;
@@ -130,8 +131,9 @@ pub struct ModelServiceInner {
     signing_key: SigningKey,
     /// Policy client for authorization checks in InferenceService
     policy_client: PolicyClient,
-    /// Notification publisher for model lifecycle events
-    notification_publisher: NotificationPublisher,
+    /// Event publisher for model lifecycle events (replaces NotificationService, EV5/#605).
+    /// Plaintext (Public) path; the encrypted-default flip is deferred to #555.
+    event_publisher: EventPublisher,
     /// Registry client for resolving model paths
     registry: RegistryClient,
     // Infrastructure (for Spawnable)
@@ -229,21 +231,9 @@ impl ModelService {
         };
         let cache_size = NonZeroUsize::new(config.max_models).unwrap_or(DEFAULT_CACHE_SIZE);
 
-        let key_resp = policy_client.resolve_service_key(
-            &crate::services::generated::policy_client::ResolveServiceKey {
-                service_name: "notification".to_owned(),
-            },
-        ).await?;
-        let notif_vk = hyprstream_rpc::crypto::VerifyingKey::from_bytes(
-            key_resp.verifying_key.as_slice().try_into()
-                .map_err(|_| anyhow!("Invalid verifying key length"))?,
-        ).map_err(|e| anyhow!("Invalid Ed25519 key: {e}"))?;
-        let notif_client = NotificationClient::for_service(
-            signing_key.clone(),
-            notif_vk,
-            None,
-        )?;
-        let notification_publisher = NotificationPublisher::new(notif_client, signing_key.clone());
+        // EV5/#605: model lifecycle events now ride the unified EventService
+        // (plaintext Public path); the parallel NotificationService is removed.
+        let event_publisher = EventPublisher::new("model")?;
 
         Ok(Self { inner: Arc::new(ModelServiceInner {
             loaded_models: RwLock::new(LruCache::new(cache_size)),
@@ -251,7 +241,7 @@ impl ModelService {
             config,
             signing_key,
             policy_client,
-            notification_publisher,
+            event_publisher,
             registry,
             transport,
             expected_audience: None,
@@ -783,7 +773,7 @@ impl ModelService {
                 },
             );
             if let Ok(payload) = serde_json::to_vec(&event) {
-                let _ = self.notification_publisher.publish(&scope, &payload).await;
+                let _ = self.event_publisher.publish("lifecycle", "unloaded", &payload).await;
             }
             Ok(())
         } else {
@@ -1669,9 +1659,8 @@ impl crate::services::RequestService for ModelService {
                             },
                         );
                         if let Ok(payload) = serde_json::to_vec(&event) {
-                            let n = service.notification_publisher.publish(&scope, &payload).await
-                                .unwrap_or(0);
-                            debug!("Published model.loaded to {} subscriber(s)", n);
+                            let _ = service.event_publisher.publish("lifecycle", "loaded", &payload).await;
+                            debug!("Published model.loaded event");
                         }
                     }
                     Err(e) => {
@@ -1685,7 +1674,7 @@ impl crate::services::RequestService for ModelService {
                             },
                         );
                         if let Ok(payload) = serde_json::to_vec(&event) {
-                            let _ = service.notification_publisher.publish(&scope, &payload).await;
+                            let _ = service.event_publisher.publish("lifecycle", "failed", &payload).await;
                         }
                     }
                 }


### PR DESCRIPTION
Part 1 of EV5 (#605). Model lifecycle events → unified EventPublisher; WASM crypto primitives carved to crypto/broadcast_primitives.rs (browser API preserved); model depends_on cut. Encrypted-default flip deferred to #555. Verified: hyprstream builds, 631 rpc tests pass. **Part 2 (follow-up fork)**: port CLI notify/load --wait (blinded-DH NotificationClient → EventSubscriber + read_then_subscribe), then remove the NotificationService (factory/capnp/generated/services+crypto). Coupled to the CLI port — too large/risky for one pass.