### PR TITLE
feat(#654): putBlob registry RPC schema (XET authenticated write path)

### DIFF
--- a/crates/hyprstream-rpc-std/schema/registry.capnp
+++ b/crates/hyprstream-rpc-std/schema/registry.capnp
@@ -74,6 +74,22 @@ struct RegistryRequest {
 
     # Fetch content-addressed bytes (git OID or XET merkle root) as a stream.
     getBlob @10 :GetBlobRequest $scope(query) $mcpDescription("Fetch content-addressed bytes (git OID or XET merkle root) as a stream");
+
+    # Ingest content-addressed bytes IN-BAND (the symmetric write half of getBlob).
+    # Epic #654: the missing authenticated upload path. Today writes bypass
+    # hyprstream entirely (cas-serve over SSH, identity-agnostic), so no
+    # merkle→repo provenance can be bound. putBlob brings the upload onto the
+    # same authenticated RPC plane as reads: the server chunks the bytes,
+    # computes the merkle ITSELF (never caller-supplied), and records
+    # (merkle → grantRepo) provenance from the verified identity. This is what
+    # lets #509/#511's fail-closed read-gate flip on without denying legitimate
+    # reads, and closes the OID-field planting class (#436) by construction.
+    #
+    # Authz: coarse $scope(write) auto-gate (registry:PutBlob, "write") PLUS a
+    # fine-grained handler check authorize(ctx, "model:{repo}", "write") that
+    # mirrors authorize_get_blob's per-repo "query" check, one verb up. A read
+    # grant never implies write.
+    putBlob @11 :PutBlobRequest $scope(write) $mcpDescription("Ingest content-addressed bytes; server computes the merkle and binds merkle→repo provenance");
   }
 }
 
@@ -161,6 +177,9 @@ struct RegistryResponse {
     repoResult @10 :RepositoryResponse;
     # Content-addressed blob fetch — rides the moq streaming plane (StreamInfo).
     getBlobResult @11 :StreamInfo;
+    # Content-addressed blob ingest result — the SERVER-COMPUTED merkle (never
+    # caller-supplied) plus the stored xorb set. See PutBlobResult / epic #654.
+    putBlobResult @12 :PutBlobResult;
   }
 }
 
@@ -352,6 +371,44 @@ struct GetBlobRequest {
   # → predictable for public-derived content), so the hash alone cannot authorize;
   # entitlement keys on the grant repo.
   grantRepo @2 :Text;   # at-uri of the owning repo (federation-portable)
+}
+
+# Put Blob Request — ingest bytes IN-BAND (the symmetric write half of getBlob).
+#
+# The caller supplies raw bytes; it does NOT supply a merkle. The server chunks
+# (Gearhash CDC, same path cas-serve uses), computes the XET merkle root from the
+# real bytes, stores the xorbs (global content-addressed dedup preserved), and
+# records (merkle → grantRepo) provenance from the authenticated identity. The
+# hash-as-capability attack (planting an OID field to borrow read access) is
+# closed by construction: provenance is bound to WHO uploaded WHAT, THROUGH which
+# repo — not to a caller-committed pointer. See epic #654.
+struct PutBlobRequest {
+  # The content to ingest. v1: inline, hard-capped server-side by
+  # MAX_INLINE_UPLOAD (unbounded Data is a DoS surface; large uploads use the
+  # streaming channel below once it lands). Model-weight-scale blobs are NOT
+  # intended for the inline path.
+  bytes @0 :Data;
+  # Authz GRANT CONTEXT (required) — the repo this content is being ingested
+  # into. The caller MUST hold a WRITE capability on it (Casbin
+  # "model:{repo}", "write"); provenance binds the computed merkle to THIS repo.
+  # A read grant never implies write.
+  grantRepo @1 :Text;   # at-uri of the owning repo (federation-portable)
+  # NOTE (decision 2, folded): a streaming upload channel — symmetric to
+  # getBlob's StreamInfo response — is an ADDITIVE follow-up field here (capnp
+  # additive evolution, NOT an ordinal re-spin), so scaling to GB-class blobs
+  # never requires a second auth-surface schema change.
+}
+
+# Put Blob Result — proof-of-ingest returned to the caller so it can commit the
+# git-xet pointer referencing the (now provenance-bound) merkle.
+struct PutBlobResult {
+  # SERVER-COMPUTED XET merkle root of the ingested bytes. Authoritative — the
+  # caller never asserts this; the server derived it from the actual bytes.
+  merkle @0 :Text;
+  # The xorb hashes written/deduped for this content (reconstruction set).
+  xorbHashes @1 :List(Text);
+  # Bytes actually stored after global dedup (0 if fully deduplicated).
+  bytesStored @2 :UInt64;
 }
 
 # Create Worktree Request (repoId removed — curried into RepositoryClient)

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -33,6 +33,7 @@ use crate::services::generated::registry_client::{
     StreamInfo, ErrorInfo, HealthStatus, DetailedStatusInfo, RemoteInfo,
     CloneRequest, RegisterRequest,
     GetBlobRequest, GetBlobRequestContent,
+    PutBlobRequest,
     CreateWorktreeRequest, RemoveWorktreeRequest,
     BranchRequest, CheckoutRequest, StageFilesRequest,
     CommitRequest, MergeRequest, ContinueMergeRequest,
@@ -1747,6 +1748,39 @@ impl RegistryHandler for RegistryService {
             Ok(status) => Ok(RegistryResponseVariant::HealthCheckResult(status)),
             Err(e) => Ok(reg_error(&e.to_string())),
         }
+    }
+
+    /// STUB (epic #654) — the authenticated XET write path. NOT IMPLEMENTED:
+    /// this returns a fail-closed error so the wire shape lands (unblocking the
+    /// impl PR) without any behavior change. `main` semantics are unchanged: no
+    /// bytes are ever accepted here.
+    ///
+    /// Precondition (already satisfied by dispatch): the coarse `$scope(write)`
+    /// gate runs before this handler, exactly as `$scope(query)` does for
+    /// `handle_get_blob` (neither method carries `#[authorize]`; the coarse gate
+    /// is the schema-declared baseline, the fine-grained check lives in-handler).
+    ///
+    /// The real implementation (separate PR) will then:
+    ///   1. fine-grained `authorize(ctx, "model:{repo}", "write")` on
+    ///      `data.grant_repo`, mirroring `authorize_get_blob`'s per-repo check
+    ///      one verb up (a read grant never implies write);
+    ///   2. cap `data.bytes` at MAX_INLINE_UPLOAD (DoS guard — unbounded `Data`);
+    ///   3. chunk (Gearhash CDC) + store xorbs via an in-process CasStore write
+    ///      API (to add, mirroring `cas-serve::handle_upload_file`);
+    ///   4. compute the merkle SERVER-SIDE from the stored bytes (never
+    ///      caller-supplied — this is what closes the #436 planting vector);
+    ///   5. `xet_provenance.record(merkle, repo_id)` (the #509/#511 hook, today
+    ///      called only in tests — production population starts here);
+    ///   6. return `PutBlobResult { merkle, xorb_hashes, bytes_stored }`.
+    async fn handle_put_blob(&self, _ctx: &EnvelopeContext, _request_id: u64,
+        _data: &PutBlobRequest,
+    ) -> Result<RegistryResponseVariant> {
+        // Fail closed: the write path is not yet wired. Deny rather than
+        // silently accept bytes with no provenance binding.
+        Ok(reg_error(
+            "putBlob not yet implemented (epic #654): authenticated XET upload + \
+             server-side merkle + provenance recording pending",
+        ))
     }
 
 }


### PR DESCRIPTION
## `putBlob` registry RPC schema + fail-closed stub — foundation for epic #654

Adds the **schema** for `putBlob`, the authenticated in-band XET write RPC — the symmetric write half of `getBlob` — plus a **fail-closed stub handler** so the workspace compiles and the exact trait signature the impl must satisfy is visible in-tree.

This is the keystone of epic #654 (Authenticated XET Read+Write). It is **safe to land as a foundation**: the schema is purely additive (new union ordinals `@11`/`@12`), and the handler is **inert and fail-closed** — it accepts no bytes and returns an error. `main` behavior is unchanged; nothing new is reachable that does anything.

### Why this exists

Reads are in-band + authenticated (`getBlob`); **writes bypass hyprstream entirely** — `cas-serve` over SSH, identity-agnostic — so no `merkle → repo` provenance can be bound. That's the structural reason #436 couldn't be fully closed: **there was no write path inside hyprstream to bind provenance in.** `putBlob` brings the upload onto the authenticated RPC plane. The server chunks the bytes, computes the merkle **itself** (never caller-supplied), and records `(merkle → grantRepo)` provenance from the verified identity — closing the OID-field-planting class (#436) *by construction*.

**Sequencing (why this lands first):** `XetProvenanceStore::record()` (from #509/#511) is currently called **only in tests**. #511's fail-closed read-gate therefore cannot merge alone — against an empty provenance store it would deny every legitimate read. `putBlob`'s impl is what *populates* that store. Order is: **this schema → `handle_put_blob` impl (populates provenance) → #511 read-gate flips on.** See #654 for the full never-break sequencing.

### What's in this PR

- `crates/hyprstream-rpc-std/schema/registry.capnp`:
  - `putBlob @11 :PutBlobRequest $scope(write)` on `RegistryRequest`
  - `putBlobResult @12 :PutBlobResult` on `RegistryResponse`
  - `struct PutBlobRequest { bytes @0 :Data; grantRepo @1 :Text; }`
  - `struct PutBlobResult { merkle @0 :Text; xorbHashes @1 :List(Text); bytesStored @2 :UInt64; }`
- `crates/hyprstream/src/services/registry.rs`: fail-closed `handle_put_blob` stub that documents the 6-step real impl and denies until it lands.

### Authz shape (mirrors `getBlob` exactly, one verb up)

- **Coarse**: `$scope(write)` auto-gate → Casbin `("registry:PutBlob", "write")`. `$scope` is a closed enum (missing it is a build error); `write` is the correct existing verb. This runs in dispatch before the handler, exactly as `$scope(query)` does for `getBlob` (neither handler carries `#[authorize]`).
- **Fine**: the impl calls `authorize(ctx, "model:{repo}", "write")` on `grantRepo` — same per-repo pattern as `authorize_get_blob`'s `"query"` check. A read grant never implies write. `"write"` is distinct from `"query"` (read) and `"ttt.writeback"` (TTT) → **no privilege conflation**.

### Decisions folded in (from #654)

1. **Verb**: reuse `$scope(write)` + fine `("model:{repo}","write")`.
2. **Transport**: v1 inline `Data`, server-capped by `MAX_INLINE_UPLOAD`. A streaming upload channel (symmetric to `getBlob`'s `StreamInfo`) is an **additive follow-up field** — capnp additive evolution, not an ordinal re-spin — so scaling to GB-class blobs never needs a second auth-surface schema change.
3. **Ownership**: Casbin `write` grant now; DID→repo proof deferred to UCAN.
4. **#511**: rebases onto this; its read-gate is step 3 of the sequence and lands after the impl populates provenance.

### Not in this PR (follow-ups under #654)

- Real `handle_put_blob` (chunk + store + server-side merkle + `record()`).
- In-process `CasStore` write API (mirroring `cas-serve::handle_upload_file`) + retiring the identity-agnostic `cas-serve` **binary** ingress (the `cas_serve` **library** — CDC/merkle math — is kept; it's the interop contract).
- The dual-stack HF-XET-wire HTTP face (drop-in "alternative XET backend to HuggingFace"), a separate change.

### Verified

- `cargo check -p hyprstream --lib` — clean (rebased on current `main`).
- Additive schema only; existing `getBlob` deny-path behavior unaffected.
- Handler is fail-closed: no reachable path accepts bytes or writes provenance.

Refs epic #654 · read-gate #509/#511 · origin #436.
