### PR TITLE
feat(9p-rpc) T1 (#540): VFS annotation set + rpc-build metadata capture

### DIFF
--- a/crates/hyprstream-rpc-build/src/schema/cgr_reader.rs
+++ b/crates/hyprstream-rpc-build/src/schema/cgr_reader.rs
@@ -551,6 +551,82 @@ fn has_annotation(
     false
 }
 
+/// Resolve the annotation node id whose short name matches `short_name`.
+///
+/// Self-contained lookup used for the VFS projection annotations (epic #539),
+/// mirroring the inline `scopeExempt` id resolution — avoids threading a new id
+/// through every extraction signature for annotations captured in one place.
+fn annotation_id_by_short_name(
+    node_map: &BTreeMap<u64, NodeInfo>,
+    short_name: &str,
+) -> Option<u64> {
+    node_map
+        .values()
+        .find(|info| info.short_name == short_name)
+        .map(|info| info.id)
+}
+
+/// Extract a `VfsKind` enum annotation as its enumerant name (e.g. "ctl").
+///
+/// Resolves the annotation's enum type from the node graph and maps the stored
+/// ordinal back to the enumerant name, mirroring `extract_annotation_enum`.
+/// Empty string when the annotation is absent.
+fn extract_vfs_kind(
+    annotations: capnp::struct_list::Reader<capnp::schema_capnp::annotation::Owned>,
+    target_id: Option<u64>,
+    nodes: &capnp::struct_list::Reader<capnp::schema_capnp::node::Owned>,
+    node_map: &BTreeMap<u64, NodeInfo>,
+) -> String {
+    let target_id = match target_id {
+        Some(id) => id,
+        None => return String::new(),
+    };
+    for i in 0..annotations.len() {
+        let ann = annotations.get(i);
+        if ann.get_id() != target_id {
+            continue;
+        }
+        let Ok(value) = ann.get_value() else { continue };
+        if let Ok(capnp::schema_capnp::value::Enum(ordinal)) = value.which() {
+            let Some(ann_info) = node_map.get(&target_id) else {
+                continue;
+            };
+            let ann_node = nodes.get(ann_info.index);
+            let Ok(capnp::schema_capnp::node::Annotation(ann_reader)) = ann_node.which() else {
+                continue;
+            };
+            let Ok(type_reader) = ann_reader.get_type() else {
+                continue;
+            };
+            let Ok(capnp::schema_capnp::type_::Enum(enum_type)) = type_reader.which() else {
+                continue;
+            };
+            let enum_type_id = enum_type.get_type_id();
+            let Some(enum_info) = node_map.get(&enum_type_id) else {
+                continue;
+            };
+            let enum_node = nodes.get(enum_info.index);
+            let Ok(capnp::schema_capnp::node::Enum(enum_reader)) = enum_node.which() else {
+                continue;
+            };
+            let Ok(enumerants) = enum_reader.get_enumerants() else {
+                continue;
+            };
+            for j in 0..enumerants.len() {
+                let enumerant = enumerants.get(j);
+                if enumerant.get_code_order() == ordinal {
+                    if let Ok(name) = enumerant.get_name() {
+                        if let Ok(s) = name.to_str() {
+                            return s.to_owned();
+                        }
+                    }
+                }
+            }
+        }
+    }
+    String::new()
+}
+
 // ---------------------------------------------------------------------------
 // Union variant extraction
 // ---------------------------------------------------------------------------
@@ -645,6 +721,31 @@ fn extract_union_variants(
             doc_example_id,
         );
 
+        // VFS projection annotations (epic #539, T1). Ids resolved inline by
+        // node short-name — captured only here, so no signature threading.
+        let vfs_path_id = annotation_id_by_short_name(node_map, "vfsPath");
+        let vfs_kind_id = annotation_id_by_short_name(node_map, "vfsKind");
+        let vfs_bulk_id = annotation_id_by_short_name(node_map, "vfsBulk");
+        let vfs_hidden_id = annotation_id_by_short_name(node_map, "vfsHidden");
+        let vfs_path = extract_annotation_text(
+            field.get_annotations().map_err(|e| format!("{e}"))?,
+            vfs_path_id,
+        );
+        let vfs_kind = extract_vfs_kind(
+            field.get_annotations().map_err(|e| format!("{e}"))?,
+            vfs_kind_id,
+            nodes,
+            node_map,
+        );
+        let vfs_bulk = has_annotation(
+            field.get_annotations().map_err(|e| format!("{e}"))?,
+            vfs_bulk_id,
+        );
+        let vfs_hidden = has_annotation(
+            field.get_annotations().map_err(|e| format!("{e}"))?,
+            vfs_hidden_id,
+        );
+
         variants.push(UnionVariant {
             name,
             type_name,
@@ -653,6 +754,10 @@ fn extract_union_variants(
             scope_exempt,
             cli_hidden,
             doc_example,
+            vfs_path,
+            vfs_kind,
+            vfs_bulk,
+            vfs_hidden,
         });
     }
 
@@ -1547,6 +1652,10 @@ mod mandatory_scope_tests {
             scope_exempt: exempt,
             cli_hidden: false,
             doc_example: String::new(),
+            vfs_path: String::new(),
+            vfs_kind: String::new(),
+            vfs_bulk: false,
+            vfs_hidden: false,
         }
     }
 

--- a/crates/hyprstream-rpc-build/src/schema/types.rs
+++ b/crates/hyprstream-rpc-build/src/schema/types.rs
@@ -273,6 +273,7 @@ pub struct ScopedClient {
 
 #[cfg(test)]
 mod vfs_metadata_tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
     use super::*;
 
     /// The VFS projection fields (epic #539, T1) survive a serde round-trip —

--- a/crates/hyprstream-rpc-build/src/schema/types.rs
+++ b/crates/hyprstream-rpc-build/src/schema/types.rs
@@ -39,6 +39,20 @@ pub struct UnionVariant {
     pub cli_hidden: bool,
     /// VFS usage example from `$docExample` annotation. Empty = no example.
     pub doc_example: String,
+    /// Mount-relative VFS path from `$vfsPath` (epic #539, T1). Empty = unset
+    /// (the mount generator, T2, infers a default from scope + arg shape).
+    #[serde(default)]
+    pub vfs_path: String,
+    /// VFS node kind override from `$vfsKind` — the enumerant name
+    /// ("file"/"dir"/"ctl"/"stream"/"query"). Empty = unset (kind is inferred).
+    #[serde(default)]
+    pub vfs_kind: String,
+    /// `$vfsBulk`: read path returns raw mmap bytes, bypassing capnp (DMA path).
+    #[serde(default)]
+    pub vfs_bulk: bool,
+    /// `$vfsHidden`: exclude this method from the generated mount.
+    #[serde(default)]
+    pub vfs_hidden: bool,
 }
 
 /// Payload carried by a tagged-union arm.
@@ -255,4 +269,54 @@ pub struct ScopedClient {
     pub capnp_inner_response: String,
     /// Nested scoped clients detected within this scope (e.g., Fs within Repository)
     pub nested_clients: Vec<ScopedClient>,
+}
+
+#[cfg(test)]
+mod vfs_metadata_tests {
+    use super::*;
+
+    /// The VFS projection fields (epic #539, T1) survive a serde round-trip —
+    /// this is the JSON-metadata contract the mount generator (T2) consumes.
+    #[test]
+    fn vfs_fields_round_trip() {
+        let v = UnionVariant {
+            name: "getByName".into(),
+            type_name: "Text".into(),
+            description: String::new(),
+            scope: "query".into(),
+            scope_exempt: false,
+            cli_hidden: false,
+            doc_example: String::new(),
+            vfs_path: "{name}".into(),
+            vfs_kind: "file".into(),
+            vfs_bulk: false,
+            vfs_hidden: false,
+        };
+        let json = serde_json::to_string(&v).expect("serialize");
+        let back: UnionVariant = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.vfs_path, "{name}");
+        assert_eq!(back.vfs_kind, "file");
+        assert!(!back.vfs_bulk);
+        assert!(!back.vfs_hidden);
+    }
+
+    /// Metadata predating the VFS fields still deserializes — the `#[serde(default)]`
+    /// keeps the capture additive (no forced schema break).
+    #[test]
+    fn legacy_metadata_defaults_vfs_fields() {
+        let legacy = r#"{
+            "name": "list",
+            "type_name": "Void",
+            "description": "",
+            "scope": "query",
+            "scope_exempt": false,
+            "cli_hidden": false,
+            "doc_example": ""
+        }"#;
+        let v: UnionVariant = serde_json::from_str(legacy).expect("deserialize legacy");
+        assert_eq!(v.vfs_path, "");
+        assert_eq!(v.vfs_kind, "");
+        assert!(!v.vfs_bulk);
+        assert!(!v.vfs_hidden);
+    }
 }

--- a/crates/hyprstream-rpc/schema/annotations.capnp
+++ b/crates/hyprstream-rpc/schema/annotations.capnp
@@ -110,3 +110,33 @@ annotation domainType(field, struct) :Text;
 # Serde field rename — generates #[serde(rename = "...")] on the Rust field.
 # Usage: toolType @1 :Text $serdeRename("type");
 annotation serdeRename(field) :Text;
+
+# ── VFS / 9p projection (epic #539) ───────────────────────────────────────
+# The generated 9p/VFS file surface projected from each service's method
+# structure. Captured at build time (T1, #540); consumed by the mount
+# generator (T2, #541). These are metadata only — declaring them does not
+# emit a mount by itself.
+
+# Node kind a method projects to in the generated mount.
+enum VfsNodeKind {
+  file   @0;   # readable (maybe writable) leaf
+  dir    @1;   # directory (readdir)
+  ctl    @2;   # write-a-verb control file
+  stream @3;   # /stream-style pipe (data/info/ctl)
+  query  @4;   # synthetic clone/query file
+}
+
+# Mount-relative path a method binds to (fid-0 rooted, NEVER absolute).
+# `{braces}` mark param segments that bind method args.
+# Usage: getByName @3 :Text $vfsPath("{name}");
+annotation vfsPath(field, struct) :Text;
+
+# Override the inferred VFS node kind for a method.
+# Usage: clone @4 :CloneRequest $vfsKind(ctl);
+annotation vfsKind(field) :VfsNodeKind;
+
+# Read path returns raw mmap bytes, bypassing capnp (DMA hot path).
+annotation vfsBulk(field) :Void;
+
+# Exclude a method from the generated mount.
+annotation vfsHidden(field) :Void;


### PR DESCRIPTION
Implements **T1 of epic #539** (root track): the VFS/9p projection annotation set + build-time metadata capture. Metadata capture only — no mount is emitted (that's T2 #541).

## What's added
**`annotations.capnp`** — the projection annotation set:
- `enum VfsNodeKind { file, dir, ctl, stream, query }` (named `VfsNodeKind`, not `VfsKind`, to avoid a capnp-codegen module-name clash with the `vfsKind` annotation — both would lower to a `vfs_kind` module otherwise).
- `annotation vfsPath(field, struct) :Text` — mount-relative path (fid-0 rooted; `{braces}` = param segs binding args).
- `annotation vfsKind(field) :VfsNodeKind` — override the inferred node kind.
- `annotation vfsBulk(field) :Void` — raw mmap bytes, bypass capnp (DMA path).
- `annotation vfsHidden(field) :Void` — exclude from the generated mount.

**`rpc-build/schema/types.rs`** — `UnionVariant` gains `vfs_path` / `vfs_kind` (enumerant name) / `vfs_bulk` / `vfs_hidden`, all `#[serde(default)]`. Additive: legacy JSON metadata still deserializes (test proves it).

**`rpc-build/schema/cgr_reader.rs`** — capture in `extract_union_variants`, resolving annotation ids **inline via node short-name** (`annotation_id_by_short_name`) rather than threading four new ids through ~10 extraction signatures. This mirrors the existing `scopeExempt` inline-resolution pattern, not the `doc_example_id` threaded pattern — same result, far smaller blast radius. `vfsKind` enum→enumerant-name resolution mirrors `extract_annotation_enum` (`extract_vfs_kind`).

## Mirrors the existing pattern
`vfs_path`/`vfs_kind` capture is `extract_annotation_text`/enum exactly as `doc_example`/`scope` do; `vfs_bulk`/`vfs_hidden` use `has_annotation` exactly as `cli_hidden`/`scope_exempt` do.

## Deferred to T2 (#541)
- The mount generator (`codegen/vfs.rs`) — not created here.
- The compile-time guard ("write|manage MUST NOT map to read-only `file`; query MUST NOT map to `ctl`") — it needs the projection to have something to check, so it lands with T2.
- `$mcpScope`-mandatory (D2) — a separate, deliberately-sequenced schema break; capturing vfs_* does not require it, so this stays additive.
- No real service schema annotated yet (registry.capnp etc. = the T5 pilot #544).

## Verified
- `cargo build -p hyprstream-rpc-build` — clean.
- `cargo build -p hyprstream-rpc` — clean (annotations.capnp parses through build.rs end-to-end).
- `cargo test -p hyprstream-rpc-build` — 10/10 (incl. new `vfs_fields_round_trip` + `legacy_metadata_defaults_vfs_fields`).
- clippy clean on both crates.

## Note on epic line-numbers
The epic body's file-map line numbers were approximate; the real capture site is `extract_union_variants` (~line 648) and I used the inline-id pattern rather than the threaded-id pattern the body sketched — cleaner for annotations captured in one place. Anchors (`UnionVariant`, `extract_annotation_text`, `has_annotation`, `scope_exempt` resolution) all matched.

Refs #539 · closes #540.