### PR TITLE
feat(9p-rpc) T3 (#542): native Send+Sync ServiceMount port

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6741,6 +6741,7 @@ dependencies = [
  "hyprstream-tcl",
  "hyprstream-vfs",
  "js-sys",
+ "parking_lot 0.12.4",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",

--- a/crates/hyprstream-rpc-std/Cargo.toml
+++ b/crates/hyprstream-rpc-std/Cargo.toml
@@ -18,6 +18,7 @@ anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 async-trait = { workspace = true }
+parking_lot = { workspace = true }
 base64 = { workspace = true }
 subsecond = { workspace = true }
 hyprstream-vfs = { path = "../hyprstream-vfs" }

--- a/crates/hyprstream-rpc-std/src/lib.rs
+++ b/crates/hyprstream-rpc-std/src/lib.rs
@@ -149,9 +149,10 @@ pub mod oauth_client {
 // WASM exports (browser only)
 // ============================================================================
 
-#[cfg(target_arch = "wasm32")]
+// Generic codegen-driven service→9p projection (`ServiceMount`) + stream pipes.
+// Native and wasm both: the same generated dispatch drives the file surface on
+// either target. (#539 T3)
 pub mod vfs_mount;
-#[cfg(target_arch = "wasm32")]
 pub mod stream_mount;
 #[cfg(target_arch = "wasm32")]
 pub mod wasm_exports;

--- a/crates/hyprstream-rpc-std/src/stream_mount.rs
+++ b/crates/hyprstream-rpc-std/src/stream_mount.rs
@@ -8,35 +8,14 @@
 //! dispatching streaming RPC methods via `RpcClient::open_stream()` and
 //! registered in the StreamRegistry.
 
-#![cfg(target_arch = "wasm32")]
-
 use std::collections::HashMap;
+
+use parking_lot::Mutex;
 
 use async_trait::async_trait;
 use hyprstream_vfs::{DirEntry, Fid, Mount, MountError, Stat};
 use hyprstream_rpc::Subject;
 use hyprstream_rpc::stream_consumer::{StreamHandle, StreamPayload};
-
-// ============================================================================
-// Send+Sync wrappers for wasm32
-// ============================================================================
-
-/// RefCell wrapper that is Send+Sync on wasm32 (single-threaded).
-struct SyncRefCell<T>(std::cell::RefCell<T>);
-unsafe impl<T> Send for SyncRefCell<T> {}
-unsafe impl<T> Sync for SyncRefCell<T> {}
-
-impl<T> SyncRefCell<T> {
-    fn new(val: T) -> Self {
-        Self(std::cell::RefCell::new(val))
-    }
-    fn borrow(&self) -> std::cell::Ref<'_, T> {
-        self.0.borrow()
-    }
-    fn borrow_mut(&self) -> std::cell::RefMut<'_, T> {
-        self.0.borrow_mut()
-    }
-}
 
 // ============================================================================
 // Stream Registry — tracks active streams
@@ -56,34 +35,29 @@ pub struct StreamEntry {
 
 /// Registry of active streams, keyed by topic.
 pub struct StreamRegistry {
-    streams: SyncRefCell<HashMap<String, StreamEntry>>,
+    streams: Mutex<HashMap<String, StreamEntry>>,
 }
-
-// SAFETY: wasm32 is single-threaded
-unsafe impl Send for StreamRegistry {}
-unsafe impl Sync for StreamRegistry {}
 
 impl StreamRegistry {
     pub fn new() -> Self {
         Self {
-            streams: SyncRefCell::new(HashMap::new()),
+            streams: Mutex::new(HashMap::new()),
         }
     }
 
     /// Register a new stream.
     pub fn register(&self, topic: String, entry: StreamEntry) {
-        self.streams.borrow_mut().insert(topic, entry);
+        self.lock().insert(topic, entry);
     }
 
     /// Check if a topic exists.
     pub fn exists(&self, topic: &str) -> bool {
-        self.streams.borrow().contains_key(topic)
+        self.lock().contains_key(topic)
     }
 
     /// List active topic names (optionally filtered by owner).
     pub fn list_topics(&self, owner_filter: Option<&str>) -> Vec<String> {
-        self.streams
-            .borrow()
+        self.lock()
             .iter()
             .filter(|(_, e)| owner_filter.is_none() || owner_filter == Some(e.owner.as_str()))
             .map(|(k, _)| k.clone())
@@ -92,7 +66,18 @@ impl StreamRegistry {
 
     /// Remove a stream and return it for cleanup.
     pub fn remove(&self, topic: &str) -> Option<StreamEntry> {
-        self.streams.borrow_mut().remove(topic)
+        self.lock().remove(topic)
+    }
+
+    /// Lock the stream map (`parking_lot` — no poison).
+    fn lock(&self) -> parking_lot::MutexGuard<'_, HashMap<String, StreamEntry>> {
+        self.streams.lock()
+    }
+}
+
+impl Default for StreamRegistry {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -123,16 +108,26 @@ enum StreamFidState {
 /// Streams appear as directories under `/stream/{topic}/` with `data`, `info`,
 /// and `ctl` pseudo-files. Reading from `data` blocks until the next verified
 /// payload arrives via the StreamHandle.
+///
+/// Wasm-only: the `Mount` `read`/`write` path awaits [`StreamHandle`] methods,
+/// which return `!Send` futures (`#[async_trait(?Send)]` on the trait). Making
+/// this mount a native (`Send`) `Mount` requires `StreamHandle`'s futures to be
+/// `Send` — a separate change in `hyprstream-rpc`'s stream transport, tracked
+/// outside T3. `StreamRegistry`/`StreamEntry` above are target-agnostic so the
+/// generic service mount can register streams on any target.
+#[cfg(target_arch = "wasm32")]
 pub struct StreamMount {
     registry: std::sync::Arc<StreamRegistry>,
 }
 
+#[cfg(target_arch = "wasm32")]
 impl StreamMount {
     pub fn new(registry: std::sync::Arc<StreamRegistry>) -> Self {
         Self { registry }
     }
 }
 
+#[cfg(target_arch = "wasm32")]
 #[async_trait(?Send)]
 impl Mount for StreamMount {
     async fn walk(&self, components: &[&str], _caller: &Subject) -> Result<Fid, MountError> {
@@ -187,7 +182,7 @@ impl Mount for StreamMount {
             StreamFidState::Data { topic } => {
                 // Check completion WITHOUT holding borrow across await
                 let is_completed = {
-                    let streams = self.registry.streams.borrow();
+                    let streams = self.registry.lock();
                     let entry = streams
                         .get(topic.as_str())
                         .ok_or_else(|| MountError::NotFound(topic.clone()))?;
@@ -200,7 +195,7 @@ impl Mount for StreamMount {
 
                 // Take handle out temporarily (avoids holding RefCell borrow across await)
                 let mut handle = {
-                    let mut streams = self.registry.streams.borrow_mut();
+                    let mut streams = self.registry.lock();
                     let entry = streams
                         .get_mut(topic.as_str())
                         .ok_or_else(|| MountError::NotFound(topic.clone()))?;
@@ -214,7 +209,7 @@ impl Mount for StreamMount {
                 // Put handle back
                 let is_completed = handle.is_completed();
                 {
-                    let mut streams = self.registry.streams.borrow_mut();
+                    let mut streams = self.registry.lock();
                     if let Some(entry) = streams.get_mut(topic.as_str()) {
                         entry.handle = Some(handle);
                     }
@@ -222,7 +217,7 @@ impl Mount for StreamMount {
 
                 match result {
                     Ok(Some(StreamPayload::Data(data))) => {
-                        let mut streams = self.registry.streams.borrow_mut();
+                        let mut streams = self.registry.lock();
                         if let Some(entry) = streams.get_mut(topic.as_str()) {
                             entry.bytes_received += data.len() as u64;
                             entry.blocks_received += 1;
@@ -230,7 +225,7 @@ impl Mount for StreamMount {
                         Ok(data)
                     }
                     Ok(Some(StreamPayload::Complete(meta))) => {
-                        let mut streams = self.registry.streams.borrow_mut();
+                        let mut streams = self.registry.lock();
                         if let Some(entry) = streams.get_mut(topic.as_str()) {
                             entry.blocks_received += 1;
                         }
@@ -240,7 +235,7 @@ impl Mount for StreamMount {
                         Err(MountError::Io(format!("stream error: {msg}")))
                     }
                     Ok(Some(StreamPayload::Tagged { payload, .. })) => {
-                        let mut streams = self.registry.streams.borrow_mut();
+                        let mut streams = self.registry.lock();
                         if let Some(entry) = streams.get_mut(topic.as_str()) {
                             entry.bytes_received += payload.len() as u64;
                             entry.blocks_received += 1;
@@ -252,7 +247,7 @@ impl Mount for StreamMount {
                 }
             }
             StreamFidState::Info { topic } => {
-                let streams = self.registry.streams.borrow();
+                let streams = self.registry.lock();
                 let entry = streams
                     .get(topic.as_str())
                     .ok_or_else(|| MountError::NotFound(topic.clone()))?;

--- a/crates/hyprstream-rpc-std/src/vfs_mount.rs
+++ b/crates/hyprstream-rpc-std/src/vfs_mount.rs
@@ -11,9 +11,10 @@
 //!                        optional — mounted only when running under Wanix,
 //!                        see [`mount_wanix`]). #409/#391.
 
-#![cfg(target_arch = "wasm32")]
-
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+
+use parking_lot::Mutex;
 
 use async_trait::async_trait;
 use hyprstream_vfs::{DirEntry, Fid, Mount, MountError, Stat};
@@ -41,38 +42,48 @@ fn slice_read(data: Vec<u8>, offset: u64, count: u32) -> Vec<u8> {
     data[start..end].to_vec()
 }
 
+/// Generate an ephemeral ECDH keypair as 64 bytes: `[secret_scalar(32) | pubkey(32)]`.
+///
+/// Same layout the streaming handshake expects (secret first, pubkey at `[32..64]`),
+/// built directly from `DefaultKeyExchange` so it works on native and wasm alike.
+fn ephemeral_keypair_64() -> Result<Vec<u8>, String> {
+    use hyprstream_rpc::crypto::key_exchange::DefaultKeyExchange;
+    use hyprstream_rpc::crypto::KeyExchange;
+
+    let (secret, public) = DefaultKeyExchange::generate_keypair();
+    let mut out = Vec::with_capacity(64);
+    out.extend_from_slice(secret.scalar().as_bytes());
+    out.extend_from_slice(&DefaultKeyExchange::pubkey_to_bytes(&public));
+    if out.len() != 64 {
+        return Err(format!("ephemeral keypair wrong length: {}", out.len()));
+    }
+    Ok(out)
+}
+
 // ============================================================================
 // CtlResponseCache — stores write→read response for ctl pattern
 // ============================================================================
 
-struct CtlResponseCache(std::cell::RefCell<Option<Vec<u8>>>);
-
-// SAFETY: wasm32 is single-threaded.
-unsafe impl Send for CtlResponseCache {}
-unsafe impl Sync for CtlResponseCache {}
+struct CtlResponseCache(Mutex<Option<Vec<u8>>>);
 
 impl CtlResponseCache {
     fn new() -> Self {
-        Self(std::cell::RefCell::new(None))
+        Self(Mutex::new(None))
     }
     fn take(&self) -> Option<Vec<u8>> {
-        self.0.borrow_mut().take()
+        self.0.lock().take()
     }
     fn set(&self, data: Vec<u8>) {
-        *self.0.borrow_mut() = Some(data);
+        *self.0.lock() = Some(data);
     }
 }
 
-/// Atomic-like counter for request IDs, Send+Sync on wasm32.
-struct IdCounter(std::cell::Cell<u64>);
-unsafe impl Send for IdCounter {}
-unsafe impl Sync for IdCounter {}
+/// Monotonic counter for request IDs.
+struct IdCounter(AtomicU64);
 impl IdCounter {
-    fn new() -> Self { Self(std::cell::Cell::new(1)) }
+    fn new() -> Self { Self(AtomicU64::new(1)) }
     fn next(&self) -> u64 {
-        let id = self.0.get();
-        self.0.set(id + 1);
-        id
+        self.0.fetch_add(1, Ordering::Relaxed)
     }
 }
 
@@ -95,8 +106,9 @@ pub enum ServiceDispatchResult {
 }
 
 /// Trait for service-specific dispatch. Implemented via macro from generated code.
-#[async_trait(?Send)]
-trait ServiceDispatch: Send + Sync {
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+pub trait ServiceDispatch: Send + Sync {
     async fn dispatch(&self, method: &str, args_json: &str, client: &dyn RpcClient) -> Result<ServiceDispatchResult, String>;
     fn metadata(&self) -> (&'static str, &'static [hyprstream_rpc::metadata::MethodMeta]);
 }
@@ -130,7 +142,8 @@ impl GenericServiceMount {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl Mount for GenericServiceMount {
     async fn walk(&self, components: &[&str], _caller: &Subject) -> Result<Fid, MountError> {
         Ok(Fid::new(VfsFidState {
@@ -164,7 +177,7 @@ impl Mount for GenericServiceMount {
         // cat /srv/{service}/{method} → dispatch query method with empty args
         let method = &state.path[0];
         match self.service.dispatch(method, "{}", self.client.as_ref()).await
-            .map_err(|e| MountError::Io(e))? {
+            .map_err(MountError::Io)? {
             ServiceDispatchResult::Response(json) => {
                 Ok(slice_read(json.into_bytes(), offset, count))
             }
@@ -215,7 +228,7 @@ impl Mount for GenericServiceMount {
         let args_str = args_owned.as_str();
 
         let dispatch_result = self.service.dispatch(cmd, args_str, self.client.as_ref()).await
-            .map_err(|e| MountError::Io(e))?;
+            .map_err(MountError::Io)?;
 
         let resp = match dispatch_result {
             ServiceDispatchResult::Response(json) => json.into_bytes(),
@@ -317,7 +330,8 @@ impl DocMount {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl Mount for DocMount {
     async fn walk(&self, components: &[&str], _caller: &Subject) -> Result<Fid, MountError> {
         Ok(Fid::new(VfsFidState {
@@ -395,15 +409,16 @@ macro_rules! impl_service_dispatch {
     ($name:ident, $mod:path) => {
         struct $name;
 
-        #[async_trait(?Send)]
+        #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
         impl ServiceDispatch for $name {
             async fn dispatch(&self, method: &str, args_json: &str, client: &dyn RpcClient) -> Result<ServiceDispatchResult, String> {
                 use $mod as svc;
 
                 // Generate ephemeral keypair upfront — used by streaming methods,
                 // ignored by non-streaming (the send closure decides which transport to use).
-                let keypair = hyprstream_rpc::wasm_api::generate_ephemeral_keypair()
-                    .map_err(|e| format!("keypair: {e:?}"))?;
+                let keypair = crate::vfs_mount::ephemeral_keypair_64()
+                    .map_err(|e| format!("keypair: {e}"))?;
                 let ephemeral_pubkey = keypair[32..64].to_vec();
 
                 let result = svc::dispatch(method, args_json, 0, |payload: Vec<u8>| async move {
@@ -461,6 +476,12 @@ impl_service_dispatch!(InferenceDispatch, crate::inference_client);
 /// in the native namespace the same path exposes the worktree filesystem
 /// (`RemoteRegistryMount`, real qids). The convergence is at the path +
 /// backing-service level; the access style differs by transport capability.
+///
+/// Browser-only: it wires the wasm transport clients into the browser namespace.
+/// The `GenericServiceMount`/`DocMount`/`StreamMount` building blocks it uses are
+/// target-agnostic; native callers compose them through the standard namespace
+/// builder + `#[service_factory]` auto-mount (#543) instead.
+#[cfg(target_arch = "wasm32")]
 pub fn build_browser_namespace(
     registry_client: Arc<dyn RpcClient>,
     model_client: Arc<dyn RpcClient>,
@@ -541,6 +562,10 @@ pub fn build_browser_namespace(
 /// sites: `mount_wanix(ns, &sab, uname, aname).await?` →
 /// `let client = P9Client::connect(DmaTransport::new(&sab, true), uname, aname).await?;
 /// mount_wanix(ns, client)?;`.
+///
+/// Wasm-only: `WanixMount`/`P9Client`/`DmaTransport` are SharedArrayBuffer-DMA
+/// types compiled only for the browser target.
+#[cfg(target_arch = "wasm32")]
 pub fn mount_wanix<T>(
     ns: &mut hyprstream_vfs::Namespace,
     client: hyprstream_9p::client::P9Client<T>,
@@ -553,3 +578,24 @@ where
         Arc::new(hyprstream_9p::wanix_mount::WanixMount::new(client)),
     )
 }
+
+// ============================================================================
+// Compile-time Send + Sync guarantees (#539 T3)
+// ============================================================================
+
+/// The generic service→9p mounts must be `Send + Sync` to serve behind the
+/// native (multi-threaded) `Mount` trait. These are compiler-enforced, not
+/// assumed — the whole point of the native port.
+#[cfg(not(target_arch = "wasm32"))]
+const _: () = {
+    fn assert_send_sync<T: Send + Sync>() {}
+    fn assertions() {
+        assert_send_sync::<GenericServiceMount>();
+        assert_send_sync::<DocMount>();
+        // The registry is the shared state behind the native mount; it must be
+        // Send + Sync even though a `StreamEntry`'s `Box<dyn StreamHandle>` is
+        // only `Send` (guarded by the registry's `Mutex`).
+        assert_send_sync::<crate::stream_mount::StreamRegistry>();
+    }
+    let _ = assertions;
+};


### PR DESCRIPTION
Implements **T3 of epic #539** (#542): port the generic codegen-driven capnp→9p adapter (`ServiceMount`/`DocMount`) from wasm-only to a native `Send + Sync` `Mount`. Per the epic, this is a **port, not a build** — the generic adapter already existed, gated `#![cfg(target_arch = "wasm32")]`. Now every service gets a synthetic 9p file face on native too.

## !Sync → Sync conversions (the port)
Followed `RemoteModelMount`'s native discipline (lock, extract, drop guard before await):
- `CtlResponseCache`: `std::cell::RefCell<Option<Vec<u8>>>` + `unsafe impl Send/Sync` → `parking_lot::Mutex<Option<Vec<u8>>>`.
- `IdCounter`: `std::cell::Cell<u64>` + `unsafe impl Send/Sync` → `AtomicU64` (`fetch_add`).
- `StreamRegistry`: `SyncRefCell<HashMap<..>>` + `unsafe impl Send/Sync` → `parking_lot::Mutex<HashMap<..>>`.
- `async_trait(?Send)` → `#[cfg_attr(wasm32, async_trait(?Send))] #[cfg_attr(not, async_trait)]` on all 4 sites (trait + both `Mount` impls + the dispatch macro), matching the `Mount` trait's own cfg_attr.
- Ephemeral keypair: `wasm_api::generate_ephemeral_keypair` (wasm-only) → a target-agnostic `ephemeral_keypair_64()` over `DefaultKeyExchange` (identical 64-byte `[secret|pubkey]` layout).

All `unsafe impl Send/Sync` "wasm is single-threaded" hacks are **gone**, replaced by genuinely-Send+Sync types.

## What stays wasm-gated (honest scope boundary)
- **`StreamMount`** (the `/stream/{topic}` pipe reader): its `read`/`write` await `StreamHandle::next_payload`/`cancel`, which return **`!Send` futures** (`#[async_trait(?Send)]` on the `StreamHandle` trait in `hyprstream-rpc`). Making this mount native requires `StreamHandle`'s futures to be `Send` — a separate transport-layer change, **outside T3**. `StreamRegistry`/`StreamEntry` are target-agnostic, so `GenericServiceMount` registers streams on any target; only the pipe *reader* is deferred.
- **`build_browser_namespace`** + **`mount_wanix`**: browser DMA/SharedArrayBuffer + `WanixMount`/`P9Client` are `wasm32`-only. T3 delivers the reusable `Mount` building blocks; native wiring is T4 (#543, `#[service_factory]` auto-mount).

## Send + Sync proof (compiler-enforced)
`const _: () = { fn assert_send_sync<T: Send+Sync>(); ... }` over `GenericServiceMount`, `DocMount`, `StreamRegistry` — not assumed.

## Verified
- `cargo build -p hyprstream-rpc-std` (native): clean.
- `cargo test -p hyprstream-rpc-std`: 1/1 (the Send+Sync assertion compiles = passes).
- `cargo clippy -p hyprstream-rpc-std`: clean (switched to `parking_lot::Mutex` per the workspace's disallowed-`std::sync::Mutex` lint).
- wasm path preserved by construction (additive cfg_attr; `?Send` retained on wasm). Note: a full `--target wasm32-unknown-unknown` build hits a **pre-existing** `web_sys::WebTransport` error in `hyprstream-rpc/web_transport.rs` (needs `--cfg=web_sys_unstable_apis`), which reproduces without this PR — unrelated to T3.

## Not in scope
- `RemoteModelMount` deletion → **T6 (#545)**.
- Auto-mount wiring → **T4 (#543)**.
- Consuming new `$vfs*` annotations → **T2 (#541)**.

Refs #539 · closes #542 · stacked on `feature/9p-rpc-epic`.