### PR TITLE
feat(9p-rpc) T2 (#541): vfs::generate_mount projection + compile-time guards

### DIFF
--- a/crates/hyprstream-rpc-build/src/schema/cgr_reader.rs
+++ b/crates/hyprstream-rpc-build/src/schema/cgr_reader.rs
@@ -551,6 +551,82 @@ fn has_annotation(
     false
 }
 
+/// Resolve the annotation node id whose short name matches `short_name`.
+///
+/// Self-contained lookup used for the VFS projection annotations (epic #539),
+/// mirroring the inline `scopeExempt` id resolution — avoids threading a new id
+/// through every extraction signature for annotations captured in one place.
+fn annotation_id_by_short_name(
+    node_map: &BTreeMap<u64, NodeInfo>,
+    short_name: &str,
+) -> Option<u64> {
+    node_map
+        .values()
+        .find(|info| info.short_name == short_name)
+        .map(|info| info.id)
+}
+
+/// Extract a `VfsKind` enum annotation as its enumerant name (e.g. "ctl").
+///
+/// Resolves the annotation's enum type from the node graph and maps the stored
+/// ordinal back to the enumerant name, mirroring `extract_annotation_enum`.
+/// Empty string when the annotation is absent.
+fn extract_vfs_kind(
+    annotations: capnp::struct_list::Reader<capnp::schema_capnp::annotation::Owned>,
+    target_id: Option<u64>,
+    nodes: &capnp::struct_list::Reader<capnp::schema_capnp::node::Owned>,
+    node_map: &BTreeMap<u64, NodeInfo>,
+) -> String {
+    let target_id = match target_id {
+        Some(id) => id,
+        None => return String::new(),
+    };
+    for i in 0..annotations.len() {
+        let ann = annotations.get(i);
+        if ann.get_id() != target_id {
+            continue;
+        }
+        let Ok(value) = ann.get_value() else { continue };
+        if let Ok(capnp::schema_capnp::value::Enum(ordinal)) = value.which() {
+            let Some(ann_info) = node_map.get(&target_id) else {
+                continue;
+            };
+            let ann_node = nodes.get(ann_info.index);
+            let Ok(capnp::schema_capnp::node::Annotation(ann_reader)) = ann_node.which() else {
+                continue;
+            };
+            let Ok(type_reader) = ann_reader.get_type() else {
+                continue;
+            };
+            let Ok(capnp::schema_capnp::type_::Enum(enum_type)) = type_reader.which() else {
+                continue;
+            };
+            let enum_type_id = enum_type.get_type_id();
+            let Some(enum_info) = node_map.get(&enum_type_id) else {
+                continue;
+            };
+            let enum_node = nodes.get(enum_info.index);
+            let Ok(capnp::schema_capnp::node::Enum(enum_reader)) = enum_node.which() else {
+                continue;
+            };
+            let Ok(enumerants) = enum_reader.get_enumerants() else {
+                continue;
+            };
+            for j in 0..enumerants.len() {
+                let enumerant = enumerants.get(j);
+                if enumerant.get_code_order() == ordinal {
+                    if let Ok(name) = enumerant.get_name() {
+                        if let Ok(s) = name.to_str() {
+                            return s.to_owned();
+                        }
+                    }
+                }
+            }
+        }
+    }
+    String::new()
+}
+
 // ---------------------------------------------------------------------------
 // Union variant extraction
 // ---------------------------------------------------------------------------
@@ -645,6 +721,31 @@ fn extract_union_variants(
             doc_example_id,
         );
 
+        // VFS projection annotations (epic #539, T1). Ids resolved inline by
+        // node short-name — captured only here, so no signature threading.
+        let vfs_path_id = annotation_id_by_short_name(node_map, "vfsPath");
+        let vfs_kind_id = annotation_id_by_short_name(node_map, "vfsKind");
+        let vfs_bulk_id = annotation_id_by_short_name(node_map, "vfsBulk");
+        let vfs_hidden_id = annotation_id_by_short_name(node_map, "vfsHidden");
+        let vfs_path = extract_annotation_text(
+            field.get_annotations().map_err(|e| format!("{e}"))?,
+            vfs_path_id,
+        );
+        let vfs_kind = extract_vfs_kind(
+            field.get_annotations().map_err(|e| format!("{e}"))?,
+            vfs_kind_id,
+            nodes,
+            node_map,
+        );
+        let vfs_bulk = has_annotation(
+            field.get_annotations().map_err(|e| format!("{e}"))?,
+            vfs_bulk_id,
+        );
+        let vfs_hidden = has_annotation(
+            field.get_annotations().map_err(|e| format!("{e}"))?,
+            vfs_hidden_id,
+        );
+
         variants.push(UnionVariant {
             name,
             type_name,
@@ -653,6 +754,10 @@ fn extract_union_variants(
             scope_exempt,
             cli_hidden,
             doc_example,
+            vfs_path,
+            vfs_kind,
+            vfs_bulk,
+            vfs_hidden,
         });
     }
 
@@ -1547,6 +1652,10 @@ mod mandatory_scope_tests {
             scope_exempt: exempt,
             cli_hidden: false,
             doc_example: String::new(),
+            vfs_path: String::new(),
+            vfs_kind: String::new(),
+            vfs_bulk: false,
+            vfs_hidden: false,
         }
     }
 

--- a/crates/hyprstream-rpc-build/src/schema/types.rs
+++ b/crates/hyprstream-rpc-build/src/schema/types.rs
@@ -273,6 +273,7 @@ pub struct ScopedClient {
 
 #[cfg(test)]
 mod vfs_metadata_tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
     use super::*;
 
     /// The VFS projection fields (epic #539, T1) survive a serde round-trip —

--- a/crates/hyprstream-rpc-build/src/schema/types.rs
+++ b/crates/hyprstream-rpc-build/src/schema/types.rs
@@ -39,6 +39,20 @@ pub struct UnionVariant {
     pub cli_hidden: bool,
     /// VFS usage example from `$docExample` annotation. Empty = no example.
     pub doc_example: String,
+    /// Mount-relative VFS path from `$vfsPath` (epic #539, T1). Empty = unset
+    /// (the mount generator, T2, infers a default from scope + arg shape).
+    #[serde(default)]
+    pub vfs_path: String,
+    /// VFS node kind override from `$vfsKind` — the enumerant name
+    /// ("file"/"dir"/"ctl"/"stream"/"query"). Empty = unset (kind is inferred).
+    #[serde(default)]
+    pub vfs_kind: String,
+    /// `$vfsBulk`: read path returns raw mmap bytes, bypassing capnp (DMA path).
+    #[serde(default)]
+    pub vfs_bulk: bool,
+    /// `$vfsHidden`: exclude this method from the generated mount.
+    #[serde(default)]
+    pub vfs_hidden: bool,
 }
 
 /// Payload carried by a tagged-union arm.
@@ -255,4 +269,54 @@ pub struct ScopedClient {
     pub capnp_inner_response: String,
     /// Nested scoped clients detected within this scope (e.g., Fs within Repository)
     pub nested_clients: Vec<ScopedClient>,
+}
+
+#[cfg(test)]
+mod vfs_metadata_tests {
+    use super::*;
+
+    /// The VFS projection fields (epic #539, T1) survive a serde round-trip —
+    /// this is the JSON-metadata contract the mount generator (T2) consumes.
+    #[test]
+    fn vfs_fields_round_trip() {
+        let v = UnionVariant {
+            name: "getByName".into(),
+            type_name: "Text".into(),
+            description: String::new(),
+            scope: "query".into(),
+            scope_exempt: false,
+            cli_hidden: false,
+            doc_example: String::new(),
+            vfs_path: "{name}".into(),
+            vfs_kind: "file".into(),
+            vfs_bulk: false,
+            vfs_hidden: false,
+        };
+        let json = serde_json::to_string(&v).expect("serialize");
+        let back: UnionVariant = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.vfs_path, "{name}");
+        assert_eq!(back.vfs_kind, "file");
+        assert!(!back.vfs_bulk);
+        assert!(!back.vfs_hidden);
+    }
+
+    /// Metadata predating the VFS fields still deserializes — the `#[serde(default)]`
+    /// keeps the capture additive (no forced schema break).
+    #[test]
+    fn legacy_metadata_defaults_vfs_fields() {
+        let legacy = r#"{
+            "name": "list",
+            "type_name": "Void",
+            "description": "",
+            "scope": "query",
+            "scope_exempt": false,
+            "cli_hidden": false,
+            "doc_example": ""
+        }"#;
+        let v: UnionVariant = serde_json::from_str(legacy).expect("deserialize legacy");
+        assert_eq!(v.vfs_path, "");
+        assert_eq!(v.vfs_kind, "");
+        assert!(!v.vfs_bulk);
+        assert!(!v.vfs_hidden);
+    }
 }

--- a/crates/hyprstream-rpc-derive/src/codegen/mod.rs
+++ b/crates/hyprstream-rpc-derive/src/codegen/mod.rs
@@ -6,6 +6,7 @@ pub mod dispatch;
 pub mod handler;
 pub mod metadata;
 pub mod scoped;
+pub mod vfs;
 
 use crate::resolve::ResolvedSchema;
 use crate::schema::types::ParsedSchema;
@@ -60,6 +61,9 @@ pub fn generate_client_only(service_name: &str, schema: &ParsedSchema, types_cra
     // Scoped client structs (same cfg-gated pattern)
     let scoped_clients = scoped::generate_portable_scoped_clients(service_name, &resolved, types_crate);
 
+    // Generated 9P/VFS node table (#539 T2) — must compile to wasm32 too.
+    let vfs_mount = vfs::generate_mount(service_name, &resolved);
+
     quote::quote! {
         #data_structs
         #response_enum
@@ -73,6 +77,7 @@ pub fn generate_client_only(service_name: &str, schema: &ParsedSchema, types_cra
         #scoped_clients
         #metadata_code
         #portable_dispatch
+        #vfs_mount
     }
 }
 
@@ -110,6 +115,9 @@ pub fn generate_service(service_name: &str, schema: &ParsedSchema, types_crate: 
         proc_macro2::TokenStream::new()
     };
 
+    // Generated 9P/VFS node table (#539 T2).
+    let vfs_mount = vfs::generate_mount(service_name, &resolved);
+
     quote::quote! {
         #data_structs
         #response_enum
@@ -121,5 +129,6 @@ pub fn generate_service(service_name: &str, schema: &ParsedSchema, types_crate: 
         #constructors
         #handler
         #metadata_code
+        #vfs_mount
     }
 }

--- a/crates/hyprstream-rpc-derive/src/codegen/vfs.rs
+++ b/crates/hyprstream-rpc-derive/src/codegen/vfs.rs
@@ -1,0 +1,507 @@
+//! VFS/9P projection generation (epic #539, T2).
+//!
+//! Emits a `vfs_nodes() -> (&str, &[VfsNode])` table per service — the 4th
+//! codegen projection alongside client/handler/dispatch/metadata. Each node is
+//! derived from a method's [`UnionVariant`] (the SAME data the MCP/metadata
+//! surface reads) plus the `$vfs*` annotations captured in T1.
+//!
+//! The runtime mount engine (T3) consumes the table to serve `/srv/{service}`.
+//! This module only emits the table + the read/write-vs-scope guard; it wires
+//! no behavior.
+//!
+//! ## Mapping rules (method shape → node kind; `$vfsKind` overrides)
+//!
+//! | shape                          | default kind |
+//! |--------------------------------|--------------|
+//! | query, Void, name "list*"      | `Dir`        |
+//! | query, Text/scalar arg         | `File` @ `{arg}` |
+//! | query, Void                    | `File`       |
+//! | query, struct (rich args)      | `Query`      |
+//! | write / manage                 | `Ctl`        |
+//! | streaming (any)                | `Stream`     |
+//!
+//! ## Guard (compile-time)
+//!
+//! A read-only kind (`File`/`Dir`/`Query`) on a write/manage scope, or a `Ctl`
+//! on a query scope, is a contradiction — a 9P read must be side-effect-free.
+//! [`validate_node`] returns the error; [`generate_mount`] turns it into a
+//! `compile_error!`.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+
+use crate::resolve::ResolvedSchema;
+use crate::schema::types::UnionVariant;
+use crate::util::{to_snake_case, CapnpType};
+
+/// The VFS node kind, mirrored from the runtime `hyprstream_rpc::metadata::VfsNodeKind`.
+/// Kept as a plain derive-crate enum so inference/guard logic is unit-testable
+/// without depending on the runtime crate.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum NodeKind {
+    File,
+    Dir,
+    Ctl,
+    Stream,
+    Query,
+}
+
+impl NodeKind {
+    /// Parse the `$vfsKind` enumerant name (as captured in `UnionVariant::vfs_kind`).
+    fn parse(s: &str) -> Option<Self> {
+        match s {
+            "file" => Some(Self::File),
+            "dir" => Some(Self::Dir),
+            "ctl" => Some(Self::Ctl),
+            "stream" => Some(Self::Stream),
+            "query" => Some(Self::Query),
+            _ => None,
+        }
+    }
+
+    /// A read of this node must be side-effect-free (9P read invariant).
+    fn is_read_only(self) -> bool {
+        matches!(self, Self::File | Self::Dir | Self::Query)
+    }
+
+    /// The runtime-crate variant tokens for this kind.
+    fn to_tokens(self) -> TokenStream {
+        match self {
+            Self::File => quote! { hyprstream_rpc::metadata::VfsNodeKind::File },
+            Self::Dir => quote! { hyprstream_rpc::metadata::VfsNodeKind::Dir },
+            Self::Ctl => quote! { hyprstream_rpc::metadata::VfsNodeKind::Ctl },
+            Self::Stream => quote! { hyprstream_rpc::metadata::VfsNodeKind::Stream },
+            Self::Query => quote! { hyprstream_rpc::metadata::VfsNodeKind::Query },
+        }
+    }
+}
+
+/// Whether the method's scope action denotes a mutation (write/manage) vs a read (query).
+///
+/// Scopes come from `$scope`/`$capability` (S3, #547). A `query` (or read-shaped)
+/// scope must project to a read-only node; anything else is treated as a mutation.
+/// Empty scope (a `$scopeExempt` method) is treated as read (least authority).
+fn scope_is_mutation(scope: &str) -> bool {
+    !matches!(scope, "" | "query" | "read")
+}
+
+/// Whether a method name denotes a listing (projects to a directory by default).
+fn is_list_name(name: &str) -> bool {
+    let snake = to_snake_case(name);
+    snake == "list" || snake.starts_with("list_")
+}
+
+/// Infer the default node kind from a method's scope + argument shape + streaming.
+///
+/// `$vfsKind` (when present) overrides this — see [`resolve_kind`].
+pub fn infer_kind(scope: &str, arg: &CapnpType, name: &str, is_streaming: bool) -> NodeKind {
+    if is_streaming {
+        return NodeKind::Stream;
+    }
+    if scope_is_mutation(scope) {
+        return NodeKind::Ctl;
+    }
+    // Read-shaped (query/exempt): pick by argument shape.
+    match arg {
+        // A `list*` method with no args reads as a directory.
+        CapnpType::Void if is_list_name(name) => NodeKind::Dir,
+        // A struct / rich args → a synthetic query file (write spec, read result).
+        // Void and single-scalar args both read as a file (the `{arg}` binding is
+        // decided from arg shape in `infer_path`, not the kind).
+        arg if is_query_file_arg(arg) => NodeKind::Query,
+        _ => NodeKind::File,
+    }
+}
+
+/// Whether a read-shaped method's argument is "rich" (a struct/list needing a
+/// written query spec) rather than Void or a single bindable scalar.
+fn is_query_file_arg(arg: &CapnpType) -> bool {
+    matches!(
+        arg,
+        CapnpType::Struct(_)
+            | CapnpType::Unknown(_)
+            | CapnpType::ListText
+            | CapnpType::ListData
+            | CapnpType::ListPrimitive(_)
+            | CapnpType::ListStruct(_)
+            | CapnpType::Data
+    )
+}
+
+/// Resolve the effective node kind: `$vfsKind` override, else inference.
+///
+/// Returns an `Err(message)` if `$vfsKind` names an unknown enumerant.
+pub fn resolve_kind(
+    v: &UnionVariant,
+    arg: &CapnpType,
+    is_streaming: bool,
+) -> Result<NodeKind, String> {
+    if v.vfs_kind.is_empty() {
+        Ok(infer_kind(&v.scope, arg, &v.name, is_streaming))
+    } else {
+        NodeKind::parse(&v.vfs_kind).ok_or_else(|| {
+            format!(
+                "method `{}`: `$vfsKind(\"{}\")` is not a valid VFS node kind \
+                 (expected one of file/dir/ctl/stream/query)",
+                to_snake_case(&v.name),
+                v.vfs_kind
+            )
+        })
+    }
+}
+
+/// The compile-time guard: a node's kind must not contradict its scope.
+///
+/// - A write/manage scope must NOT project to a read-only node
+///   (`file`/`dir`/`query`) — a mutation behind a side-effect-free 9P read.
+/// - A query/read scope must NOT project to a `ctl` — a read that invokes a verb.
+///
+/// Returns `Err(message)` on contradiction, naming the offending method.
+pub fn validate_node(method_snake: &str, scope: &str, kind: NodeKind) -> Result<(), String> {
+    let mutation = scope_is_mutation(scope);
+    if mutation && kind.is_read_only() {
+        return Err(format!(
+            "method `{method_snake}`: write/manage scope `{scope}` cannot project to a \
+             read-only VFS node (`{kind:?}`) — a 9P read must be side-effect-free; \
+             use `$vfsKind(ctl)` or `$vfsKind(stream)`"
+        ));
+    }
+    if !mutation && matches!(kind, NodeKind::Ctl) {
+        return Err(format!(
+            "method `{method_snake}`: query scope `{scope}` cannot project to a `ctl` node \
+             — a control-file write invokes the method; use a read kind \
+             (`$vfsKind(file|dir|query)`) or give the method a write scope"
+        ));
+    }
+    Ok(())
+}
+
+/// Infer the default mount-relative path for a node when `$vfsPath` is unset.
+fn infer_path(kind: NodeKind, method_snake: &str, arg: &CapnpType) -> String {
+    match kind {
+        // A directory listing is the mount root by convention.
+        NodeKind::Dir => ".".to_owned(),
+        // A scalar-arg file binds the arg from the path segment.
+        NodeKind::File if !matches!(arg, CapnpType::Void) => "{arg}".to_owned(),
+        // A control file lands at the conventional `ctl` node.
+        NodeKind::Ctl => "ctl".to_owned(),
+        // Everything else (a Void read file like `health`, a stream, or a query
+        // file) is served under the method's own name.
+        NodeKind::Stream | NodeKind::Query | NodeKind::File => method_snake.to_owned(),
+    }
+}
+
+/// Generate the per-service `vfs_nodes()` table.
+///
+/// Emits `pub fn vfs_nodes() -> (&'static str, &'static [VfsNode])`. On a
+/// scope/kind contradiction (or bad `$vfsKind`), emits a `compile_error!`
+/// naming the offending method instead.
+pub fn generate_mount(service_name: &str, resolved: &ResolvedSchema) -> TokenStream {
+    // Data-only schemas (no request variants) get no mount.
+    if resolved.raw.request_variants.is_empty() {
+        return TokenStream::new();
+    }
+
+    let scoped_names: Vec<&str> = resolved
+        .raw
+        .scoped_clients
+        .iter()
+        .map(|sc| sc.factory_name.as_str())
+        .collect();
+
+    let mut node_entries: Vec<TokenStream> = Vec::new();
+
+    for v in &resolved.raw.request_variants {
+        // Scoped clients project as subdirectories — deferred to the nested pass
+        // (their own node tables); skip here. `$vfsHidden` excludes a method.
+        if scoped_names.contains(&v.name.as_str()) || v.vfs_hidden {
+            continue;
+        }
+
+        let method_snake = to_snake_case(&v.name);
+        let arg = resolved.resolve_type(&v.type_name).capnp_type.clone();
+        let is_streaming = is_streaming_variant(&v.name, &resolved.raw.response_variants);
+
+        // Resolve kind ($vfsKind override or inference) — bad annotation ⇒ compile_error.
+        let kind = match resolve_kind(v, &arg, is_streaming) {
+            Ok(k) => k,
+            Err(msg) => return compile_error(&msg),
+        };
+
+        // The guard: kind must not contradict scope.
+        if let Err(msg) = validate_node(&method_snake, &v.scope, kind) {
+            return compile_error(&msg);
+        }
+
+        let path = if v.vfs_path.is_empty() {
+            infer_path(kind, &method_snake, &arg)
+        } else {
+            v.vfs_path.clone()
+        };
+
+        let kind_tokens = kind.to_tokens();
+        let scope = v.scope.as_str();
+        let bulk = v.vfs_bulk;
+
+        node_entries.push(quote! {
+            hyprstream_rpc::metadata::VfsNode {
+                method: #method_snake,
+                path: #path,
+                kind: #kind_tokens,
+                scope: #scope,
+                bulk: #bulk,
+            }
+        });
+    }
+
+    let doc = format!("Generated 9P/VFS node table for the {service_name} service (epic #539).");
+
+    quote! {
+        #[doc = #doc]
+        pub fn vfs_nodes() -> (&'static str, &'static [hyprstream_rpc::metadata::VfsNode]) {
+            static NODES: &[hyprstream_rpc::metadata::VfsNode] = &[
+                #(#node_entries,)*
+            ];
+            (#service_name, NODES)
+        }
+    }
+}
+
+/// Emit a `compile_error!` carrying `msg`.
+fn compile_error(msg: &str) -> TokenStream {
+    quote! { ::core::compile_error!(#msg); }
+}
+
+/// Whether a request variant's response is a `StreamInfo` (a streaming method).
+/// Mirrors `metadata::is_streaming_variant` for the non-scoped case.
+fn is_streaming_variant(variant_name: &str, response_variants: &[UnionVariant]) -> bool {
+    let expected = format!("{variant_name}Result");
+    response_variants
+        .iter()
+        .find(|v| v.name == expected)
+        .map(|v| v.type_name == "StreamInfo")
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn infers_dir_for_void_list_query() {
+        let k = infer_kind("query", &CapnpType::Void, "list", false);
+        assert_eq!(k, NodeKind::Dir);
+    }
+
+    #[test]
+    fn infers_file_for_void_query() {
+        let k = infer_kind("query", &CapnpType::Void, "healthCheck", false);
+        assert_eq!(k, NodeKind::File);
+    }
+
+    #[test]
+    fn infers_parameterized_file_for_text_query() {
+        let k = infer_kind("query", &CapnpType::Text, "getByName", false);
+        assert_eq!(k, NodeKind::File);
+        assert_eq!(infer_path(k, "get_by_name", &CapnpType::Text), "{arg}");
+    }
+
+    #[test]
+    fn infers_query_for_struct_query() {
+        let k = infer_kind("query", &CapnpType::Struct("SearchRequest".into()), "search", false);
+        assert_eq!(k, NodeKind::Query);
+    }
+
+    #[test]
+    fn infers_ctl_for_write() {
+        let k = infer_kind("write", &CapnpType::Struct("CloneRequest".into()), "clone", false);
+        assert_eq!(k, NodeKind::Ctl);
+        assert_eq!(infer_path(k, "clone", &CapnpType::Struct("CloneRequest".into())), "ctl");
+    }
+
+    #[test]
+    fn infers_stream_for_streaming() {
+        let k = infer_kind("write", &CapnpType::Struct("CloneRequest".into()), "cloneStream", true);
+        assert_eq!(k, NodeKind::Stream);
+    }
+
+    #[test]
+    fn guard_rejects_write_scope_on_read_only_node() {
+        // A write method forced to a read-only `file` must be rejected.
+        let err = validate_node("clone", "write", NodeKind::File).unwrap_err();
+        assert!(err.contains("clone"), "error names the method: {err}");
+        assert!(err.contains("side-effect-free"), "error explains why: {err}");
+    }
+
+    #[test]
+    fn guard_rejects_query_scope_on_ctl_node() {
+        let err = validate_node("get_by_name", "query", NodeKind::Ctl).unwrap_err();
+        assert!(err.contains("get_by_name"));
+        assert!(err.contains("ctl"));
+    }
+
+    #[test]
+    fn guard_permits_consistent_pairings() {
+        assert!(validate_node("clone", "write", NodeKind::Ctl).is_ok());
+        assert!(validate_node("list", "query", NodeKind::Dir).is_ok());
+        assert!(validate_node("get", "query", NodeKind::File).is_ok());
+        assert!(validate_node("search", "query", NodeKind::Query).is_ok());
+        // A scope-exempt method (empty scope) is treated as read — ctl still rejected.
+        assert!(validate_node("ping", "", NodeKind::File).is_ok());
+        assert!(validate_node("ping", "", NodeKind::Ctl).is_err());
+    }
+
+    #[test]
+    fn bad_vfs_kind_annotation_is_reported() {
+        let v = UnionVariant {
+            name: "clone".into(),
+            type_name: "CloneRequest".into(),
+            description: String::new(),
+            scope: "write".into(),
+            scope_exempt: false,
+            cli_hidden: false,
+            doc_example: String::new(),
+            vfs_path: String::new(),
+            vfs_kind: "bogus".into(),
+            vfs_bulk: false,
+            vfs_hidden: false,
+        };
+        let err = resolve_kind(&v, &CapnpType::Struct("CloneRequest".into()), false).unwrap_err();
+        assert!(err.contains("bogus"));
+        assert!(err.contains("clone"));
+    }
+
+    #[test]
+    fn vfs_kind_override_wins_over_inference() {
+        // A query method explicitly annotated as a query file (rich-args override).
+        let v = UnionVariant {
+            name: "getByName".into(),
+            type_name: "Text".into(),
+            description: String::new(),
+            scope: "query".into(),
+            scope_exempt: false,
+            cli_hidden: false,
+            doc_example: String::new(),
+            vfs_path: String::new(),
+            vfs_kind: "query".into(),
+            vfs_bulk: false,
+            vfs_hidden: false,
+        };
+        let k = resolve_kind(&v, &CapnpType::Text, false).expect("valid kind");
+        assert_eq!(k, NodeKind::Query);
+    }
+
+    // ── End-to-end token generation over a fixture service ───────────────────
+
+    use crate::schema::types::{ParsedSchema, StructDef};
+
+    fn variant(name: &str, type_name: &str, scope: &str) -> UnionVariant {
+        UnionVariant {
+            name: name.into(),
+            type_name: type_name.into(),
+            description: String::new(),
+            scope: scope.into(),
+            scope_exempt: false,
+            cli_hidden: false,
+            doc_example: String::new(),
+            vfs_path: String::new(),
+            vfs_kind: String::new(),
+            vfs_bulk: false,
+            vfs_hidden: false,
+        }
+    }
+
+    fn empty_struct(name: &str) -> StructDef {
+        StructDef {
+            name: name.into(),
+            fields: vec![],
+            has_union: false,
+            domain_type: None,
+            origin_file: None,
+            data_words: 0,
+            pointer_words: 0,
+            discriminant_count: 0,
+            discriminant_offset: 0,
+            union_arms: vec![],
+        }
+    }
+
+    fn schema_with(request_variants: Vec<UnionVariant>, structs: Vec<StructDef>) -> ParsedSchema {
+        ParsedSchema {
+            request_variants,
+            response_variants: vec![],
+            structs,
+            scoped_clients: vec![],
+            enums: vec![],
+            request_struct: None,
+            response_struct: None,
+        }
+    }
+
+    #[test]
+    fn generates_a_sensible_node_table() {
+        // A registry-like service: list (dir), getByName (param file), health
+        // (void read file), clone (ctl).
+        let schema = schema_with(
+            vec![
+                variant("list", "Void", "query"),
+                variant("getByName", "Text", "query"),
+                variant("healthCheck", "Void", "query"),
+                variant("clone", "CloneRequest", "write"),
+            ],
+            vec![empty_struct("CloneRequest")],
+        );
+        let resolved = ResolvedSchema::from(&schema);
+        let out = generate_mount("registry", &resolved).to_string();
+
+        assert!(out.contains("fn vfs_nodes"), "emits vfs_nodes(): {out}");
+        // list → Dir at "."
+        assert!(out.contains("VfsNodeKind :: Dir"), "list is a Dir: {out}");
+        // getByName → File at "{arg}"
+        assert!(out.contains("\"{arg}\""), "param file binds {{arg}}: {out}");
+        // clone → Ctl at "ctl"
+        assert!(out.contains("VfsNodeKind :: Ctl"), "clone is a Ctl: {out}");
+        assert!(out.contains("\"ctl\""), "ctl node path: {out}");
+        // health → File node present
+        assert!(out.contains("\"health_check\""), "health file path: {out}");
+        // No compile_error emitted for a consistent schema.
+        assert!(!out.contains("compile_error"), "no guard error: {out}");
+    }
+
+    #[test]
+    fn contradiction_emits_compile_error() {
+        // A write method forced to a read-only `file` via $vfsKind must fail the build.
+        let mut bad = variant("clone", "CloneRequest", "write");
+        bad.vfs_kind = "file".into();
+        let schema = schema_with(vec![bad], vec![empty_struct("CloneRequest")]);
+        let resolved = ResolvedSchema::from(&schema);
+        let out = generate_mount("registry", &resolved).to_string();
+
+        assert!(out.contains("compile_error"), "emits compile_error: {out}");
+        assert!(out.contains("clone"), "names the offending method: {out}");
+    }
+
+    #[test]
+    fn vfs_hidden_excludes_a_method() {
+        let mut hidden = variant("internalPing", "Void", "query");
+        hidden.vfs_hidden = true;
+        let schema = schema_with(
+            vec![variant("list", "Void", "query"), hidden],
+            vec![],
+        );
+        let resolved = ResolvedSchema::from(&schema);
+        let out = generate_mount("registry", &resolved).to_string();
+
+        assert!(out.contains("\"list\"") || out.contains("VfsNodeKind :: Dir"));
+        assert!(!out.contains("internal_ping"), "hidden method excluded: {out}");
+    }
+
+    #[test]
+    fn data_only_schema_emits_no_mount() {
+        let schema = schema_with(vec![], vec![empty_struct("SomeData")]);
+        let resolved = ResolvedSchema::from(&schema);
+        let out = generate_mount("dataonly", &resolved).to_string();
+        assert!(out.is_empty(), "data-only schema has no mount: {out}");
+    }
+}

--- a/crates/hyprstream-rpc/schema/annotations.capnp
+++ b/crates/hyprstream-rpc/schema/annotations.capnp
@@ -110,3 +110,33 @@ annotation domainType(field, struct) :Text;
 # Serde field rename — generates #[serde(rename = "...")] on the Rust field.
 # Usage: toolType @1 :Text $serdeRename("type");
 annotation serdeRename(field) :Text;
+
+# ── VFS / 9p projection (epic #539) ───────────────────────────────────────
+# The generated 9p/VFS file surface projected from each service's method
+# structure. Captured at build time (T1, #540); consumed by the mount
+# generator (T2, #541). These are metadata only — declaring them does not
+# emit a mount by itself.
+
+# Node kind a method projects to in the generated mount.
+enum VfsNodeKind {
+  file   @0;   # readable (maybe writable) leaf
+  dir    @1;   # directory (readdir)
+  ctl    @2;   # write-a-verb control file
+  stream @3;   # /stream-style pipe (data/info/ctl)
+  query  @4;   # synthetic clone/query file
+}
+
+# Mount-relative path a method binds to (fid-0 rooted, NEVER absolute).
+# `{braces}` mark param segments that bind method args.
+# Usage: getByName @3 :Text $vfsPath("{name}");
+annotation vfsPath(field, struct) :Text;
+
+# Override the inferred VFS node kind for a method.
+# Usage: clone @4 :CloneRequest $vfsKind(ctl);
+annotation vfsKind(field) :VfsNodeKind;
+
+# Read path returns raw mmap bytes, bypassing capnp (DMA hot path).
+annotation vfsBulk(field) :Void;
+
+# Exclude a method from the generated mount.
+annotation vfsHidden(field) :Void;

--- a/crates/hyprstream-rpc/src/_metadata.rs
+++ b/crates/hyprstream-rpc/src/_metadata.rs
@@ -40,6 +40,58 @@ pub struct MethodMeta {
     pub doc_example: &'static str,
 }
 
+/// The 9P/VFS node kind a generated method projects to (epic #539).
+///
+/// Mirrors the `VfsNodeKind` capnp enum. `File`/`Dir`/`Query` are read-only
+/// (side-effect-free 9P reads); `Ctl` is a write-a-verb control file; `Stream`
+/// is a `/stream`-style pipe.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum VfsNodeKind {
+    /// Readable (maybe writable) leaf; `read` renders the method's response.
+    File,
+    /// Directory; `readdir` lists child entries (e.g. a `list` method).
+    Dir,
+    /// Write-a-verb control file; a `write` invokes the method.
+    Ctl,
+    /// `/stream`-style pipe (data/info/ctl) for a streaming method.
+    Stream,
+    /// Synthetic query file: write a spec, read the result.
+    Query,
+}
+
+impl VfsNodeKind {
+    /// Whether a `read` of this node must be side-effect-free (9P read invariant).
+    /// `File`/`Dir`/`Query` are read surfaces; `Ctl`/`Stream` mutate/produce.
+    pub fn is_read_only(self) -> bool {
+        matches!(self, Self::File | Self::Dir | Self::Query)
+    }
+}
+
+/// A single node in a service's generated 9P/VFS projection (epic #539, T2).
+///
+/// Built by codegen from each method's `MethodMeta` + `$vfs*` annotations. The
+/// runtime mount engine (T3) consumes these to serve `/srv/{service}` — `path`
+/// is mount-relative (fid-0 rooted, never absolute); `{braces}` in `path` are
+/// segments that bind the method's scalar argument.
+#[derive(Copy, Clone, Debug)]
+pub struct VfsNode {
+    /// The method this node projects (snake_case), used to dispatch on access.
+    pub method: &'static str,
+    /// Mount-relative path; `{name}` segments bind a scalar arg from the walk.
+    pub path: &'static str,
+    /// The projected node kind (inferred from scope+shape, or `$vfsKind`).
+    pub kind: VfsNodeKind,
+    /// Authorization scope action (from `MethodMeta::scope`).
+    pub scope: &'static str,
+    /// `$vfsBulk`: `read` returns raw mmap bytes, bypassing capnp (DMA path).
+    pub bulk: bool,
+}
+
+/// Function type for a service's VFS node table.
+///
+/// Returns `(service_name, nodes)`.
+pub type VfsNodesFn = fn() -> (&'static str, &'static [VfsNode]);
+
 /// Function type for service schema metadata.
 ///
 /// Returns `(service_name, methods)`.


### PR DESCRIPTION
Implements **T2 (#541)** of the 9P-RPC generated-projection epic (#539). Adds `vfs::generate_mount` as the 4th codegen projection (alongside client/handler/dispatch/metadata): each service emits a `vfs_nodes()` table — the machine-readable 9P/VFS node projection the runtime mount engine (T3) consumes.

## Base
**Stacked on `ewindisch/540-vfs-annotations` (T1's PR #661), NOT the epic branch** — T1 has not merged into `feature/9p-rpc-epic` yet, so this branch carries T1's commit too. Rebase onto the epic branch once T1 lands (should be conflict-free — disjoint files). Targets `feature/9p-rpc-epic`.

## What's added (+568, 3 files)
- **`codegen/vfs.rs`** (NEW) — `generate_mount(service, resolved)` builds a `VfsNode` per method from its `UnionVariant` + the T1 `$vfs*` fields.
- **`codegen/mod.rs`** — composes `vfs_mount` into both `generate_service` and `generate_client_only` (VFS must compile to wasm32).
- **`hyprstream-rpc/_metadata.rs`** — runtime `VfsNode` / `VfsNodeKind` types (mirror the `MethodMeta`/`ScopedClientTreeNode` pattern; pure `&'static str`/`bool`/enum, wasm-safe).

## Mapping rules (method shape → node kind; `$vfsKind` overrides)
| shape | kind | default path |
|-------|------|--------------|
| query, Void, `list*` | `Dir` | `.` |
| query, scalar arg (Text/int/enum) | `File` | `{arg}` (binds the segment) |
| query, Void | `File` | method name (e.g. `health`) |
| query, struct / rich args | `Query` | method name |
| write \| manage | `Ctl` | `ctl` |
| streaming | `Stream` | method name |

`$vfsHidden` excludes a method; `$vfsBulk` marks the node for raw-byte reads (DMA path, engine honors in T3). Paths are mount-relative (fid-0 rooted).

## Compile-time guard
A read-only kind (`file`/`dir`/`query`) on a write/manage scope, or a `ctl` on a query scope, is a contradiction — a 9P read must be side-effect-free. `generate_mount` emits a `compile_error!` naming the offending method. Exact messages:

> `method \`clone\`: write/manage scope \`write\` cannot project to a read-only VFS node (\`File\`) — a 9P read must be side-effect-free; use \`$vfsKind(ctl)\` or \`$vfsKind(stream)\``

> `method \`get_by_name\`: query scope \`query\` cannot project to a \`ctl\` node — a control-file write invokes the method; use a read kind (\`$vfsKind(file|dir|query)\`) or give the method a write scope`

An unknown `$vfsKind("bogus")` is also a `compile_error!`.

## Verified
- `cargo build -p hyprstream-rpc-derive` — clean
- `cargo build -p hyprstream-rpc` — clean (**end-to-end: the macro runs `generate_mount` over every real service schema via build.rs**)
- `cargo test -p hyprstream-rpc-derive` — **26 passed** (15 new vfs: inference, both guard directions, bad-annotation, token generation, `$vfsHidden` exclusion, data-only-no-mount; 11 pre-existing, no regressions)
- `cargo clippy` — clean on both crates
- **wasm32:** the generated `vfs_nodes()` is pure/wasm-safe; a full `wasm32-unknown-unknown` build hits a **pre-existing** `web_sys::WebTransport` error (needs `--cfg=web_sys_unstable_apis`) — confirmed it reproduces on the base branch with my changes stashed, so not a T2 regression, and no wasm error touches the vfs/metadata code.

## Deferred (correctly, per epic sequencing)
- Real-schema annotation (registry.capnp `$vfsPath`/`$vfsKind`) = **T5** (#544)
- Runtime mount-engine consumption of `vfs_nodes()` = **T3** (#542)
- Nested request structs as subdirectories: scoped clients are skipped in the top-level table (they get their own tables); the recursive subdir pass is a small follow-on within T3/T5's wiring.
- `$mcpScope`-mandatory (D2) — out of scope, stayed additive.

## Ambiguities resolved
- **Scope→mutation classification**: treated `query`/`read`/empty(`$scopeExempt`) as read; everything else as mutation. Empty scope is least-authority (read), so a `ctl` on an exempt method is still rejected.
- **`{arg}` binding**: only single-scalar read args get `{arg}`; struct args become a `Query` file (write-spec-then-read) rather than a path param.

Refs #539 · #541 · consumes T1 (#540).