### PR TITLE
fix(vfs): designated Upper must prepend in bind order — stale-read-after-copy-up

### DIFF
--- a/crates/hyprstream-vfs/src/namespace.rs
+++ b/crates/hyprstream-vfs/src/namespace.rs
@@ -125,8 +125,14 @@ impl Namespace {
                 }
             }
             BindFlag::Upper => {
+                // The upper is PREPENDED (Before position): overlay semantics
+                // are upper-wins on the read path, and `cat`/`read_one`/
+                // readdir-dedup are all first-success/first-seen in bind order
+                // — so the upper must be tried before any lower. Appending it
+                // would leave union reads returning stale lower content after
+                // a copy-up.
                 if let Some(entry) = self.mounts.iter_mut().find(|m| m.prefix == prefix) {
-                    entry.targets.push(Arc::clone(&target));
+                    entry.targets.insert(0, Arc::clone(&target));
                     entry.upper = Some(target);
                 } else {
                     self.mounts.push(MountEntry {
@@ -1682,5 +1688,47 @@ mod tests {
         let alice = Subject::new("alice");
         ns.echo("/g/secret", b"ok", &alice).await.unwrap();
         assert_eq!(upper.snapshot().get("secret").unwrap(), b"ok");
+    }
+
+    /// Copy-up works through the `/` catch-all (the FS-D rootfs case): a
+    /// `/`-rooted union of a read-only image lower + a designated writable
+    /// upper copy-ups on write, and the designated-upper routing survives the
+    /// catch-all's full-path remainder (`resolve_entry` returns the owning
+    /// `MountEntry` — including `upper` — for the root mount, not just its
+    /// target list).
+    ///
+    /// NOTE: uses a top-level file because namespace copy-up does not yet
+    /// provision intermediate parent directories in the upper — nested-path
+    /// copy-up (e.g. `etc/hostname`) fails on ANY prefix today (pre-existing,
+    /// not catch-all-specific). Tracked with overlay v2 semantics in #656.
+    #[tokio::test]
+    async fn copy_up_through_root_catch_all() {
+        let mut ns = Namespace::new();
+        let image: MountTarget =
+            Arc::new(ReadOnlyMemMount::new(vec![("hostname", b"worker\n")]));
+        let upper = Arc::new(WritableMemMount::empty());
+
+        ns.bind_mount("/", image, BindFlag::Replace).unwrap();
+        ns.bind_mount("/", Arc::clone(&upper) as MountTarget, BindFlag::Upper).unwrap();
+        assert!(ns.has_designated_upper("/"));
+
+        let caller = test_subject();
+
+        // Read-through to the RO lower via the catch-all.
+        assert_eq!(ns.cat("/hostname", &caller).await.unwrap(), b"worker\n");
+
+        // Write to a lower-only path → copy-up into the designated upper,
+        // routed via the MountEntry the catch-all branch returns.
+        ns.echo("/hostname", b"tenant\n", &caller).await.unwrap();
+        assert_eq!(upper.snapshot().get("hostname").unwrap(), b"tenant\n");
+
+        // The lower is untouched and the union now reads the upper's version.
+        assert_eq!(ns.cat("/hostname", &caller).await.unwrap(), b"tenant\n");
+
+        // A longer prefix still wins over the root union (longest-prefix order
+        // is unaffected by the Upper designation on "/").
+        let stream: MountTarget = Arc::new(MemMount::new(vec![("job", b"chunk")]));
+        ns.mount("/stream", stream).unwrap();
+        assert_eq!(ns.cat("/stream/job", &caller).await.unwrap(), b"chunk");
     }
 }


### PR DESCRIPTION
**Found by the expert-review pass over the #663 merge surface.** Not a merge-resolution bug — a latent behavioral bug in **#657 itself**, confirmed reproducing on pre-#663 main (`be524ee21`).

## The bug
`BindFlag::Upper` **appended** its target to the union's bind order. But every union read path (`cat`, `read_one`, readdir-dedup) is first-success/first-seen **in bind order**. Consequence: after a copy-up, the union kept serving the **stale lower** content — the write "succeeded" into the upper, but readers never saw it.

```
bind: [RO-lower, upper]        // Upper appended
echo /m/f "new"                → copy-up writes upper ✓
cat  /m/f                      → tries RO-lower first → returns OLD bytes ✗
```

That's a silent write-visibility failure on the per-tenant-delta / sandbox-writable-upper use case #370 exists for.

## Why #657's tests missed it
They asserted on `upper.snapshot()` (the mount's internal state) and never **re-read through the namespace** after the copy-up. The write landed; the union just didn't serve it.

## The fix
`Upper` now **prepends** (Before position) — overlay upper-wins semantics on the read path. One-line reorder + doc comment.

## Also pins the #663 merge resolution
Adds `copy_up_through_root_catch_all`: a `/`-rooted RO-image + designated-upper union (the FS-D rootfs case) — read-through, copy-up, upper-wins re-read, and longest-prefix still beating the root union. This is regression coverage for the `resolve_entry`-returns-`MountEntry` catch-all resolution made in #663.

## Known remaining gap (pre-existing, NOT introduced here)
Copy-up does not provision intermediate parent directories in the upper — nested paths (`etc/hostname`) fail `NotFound` on **any** prefix. Confirmed pre-existing on `be524ee21`. Noted in the test; belongs with the overlay-v2 semantics in #656.

## Blast radius / validation
- No production caller uses `BindFlag::Upper` yet (grep-verified) — tests-only blast radius; this corrects the semantic **before** first prod adoption.
- vfs 49+9 pass (incl. all 5 #657 copy-up tests + the new one), vfs-server 9 pass, workers `--features oci-image` 90 pass, clippy `-D warnings` clean.

Refs #370 · #657 · #663 review · gap → #656.