### PR TITLE
feat(#669): T2 codegen — disambiguate multiple Void-arg dir listings + collision guard

### DIFF
--- a/crates/hyprstream-discovery/schema/discovery.capnp
+++ b/crates/hyprstream-discovery/schema/discovery.capnp
@@ -12,6 +12,7 @@ using import "/annotations.capnp".scope;
 using import "/annotations.capnp".mcpDescription;
 using import "/annotations.capnp".optional;
 using import "/annotations.capnp".domainType;
+using import "/annotations.capnp".vfsPath;
 
 # Unified discovery request with union discriminator
 struct DiscoveryRequest {
@@ -24,17 +25,20 @@ struct DiscoveryRequest {
     listServices @1 :Void $scope(query) $mcpDescription("List all registered services with descriptions");
 
     # Get all endpoints for a named service
-    getEndpoints @2 :Text $scope(query) $mcpDescription("Get all endpoints for a named service");
+    getEndpoints @2 :Text $scope(query) $mcpDescription("Get all endpoints for a named service")
+      $vfsPath("{arg}/endpoints");
 
     # Get schema bytes for a service
-    getSchema @3 :Text $scope(query) $mcpDescription("Get schema bytes for a service");
+    getSchema @3 :Text $scope(query) $mcpDescription("Get schema bytes for a service")
+      $vfsPath("{arg}/schema");
 
     # Health check
     ping @4 :Void $scope(query) $mcpDescription("Health check");
 
     # Get OAuth protected resource metadata (RFC 9728) for services
     # Text parameter filters by service name (empty = all services)
-    getAuthMetadata @5 :Text $scope(query) $mcpDescription("Get OAuth protected resource metadata for services");
+    getAuthMetadata @5 :Text $scope(query) $mcpDescription("Get OAuth protected resource metadata for services")
+      $vfsPath("{arg}/auth-metadata");
 
     # Removed: prepareStream (was insecure — bypassed DH key exchange).
     # Use StreamChannel::prepare_stream for authenticated streaming.
@@ -56,13 +60,15 @@ struct DiscoveryRequest {
     registerEntityStatement @10 :RegisterEntityStatementRequest $scope(write) $mcpDescription("Register a signed OIDF entity statement for an issuer");
 
     # Fetch a cached signed entity statement for an issuer (used by FederationKeyResolver before HTTPS fallback)
-    getEntityStatement @11 :Text $scope(query) $mcpDescription("Fetch cached signed entity statement for issuer URL");
+    getEntityStatement @11 :Text $scope(query) $mcpDescription("Fetch cached signed entity statement for issuer URL")
+      $vfsPath("{arg}/entity-statement");
 
     # Push a COSE_KeySet (CBOR) for a service's envelope-signing keys (called by each service at startup + rotation)
     registerEnvelopeKeyset @12 :RegisterEnvelopeKeysetRequest $scope(write) $mcpDescription("Register envelope COSE_KeySet for a service");
 
     # Fetch a cached COSE_KeySet for a service's envelope keys
-    getEnvelopeKeyset @13 :Text $scope(query) $mcpDescription("Fetch cached envelope COSE_KeySet for service DID");
+    getEnvelopeKeyset @13 :Text $scope(query) $mcpDescription("Fetch cached envelope COSE_KeySet for service DID")
+      $vfsPath("{arg}/envelope-keyset");
 
     # List all known issuer URLs whose entity statements are cached (authenticated)
     listKnownIssuers @14 :Void $scope(query) $mcpDescription("List issuers with cached entity statements");
@@ -75,7 +81,8 @@ struct DiscoveryRequest {
     getRecord @15 :GetRecordRequest $scope(query) $mcpDescription("Fetch an atproto record (ai.hyprstream.model) as a verifiable CAR proof");
 
     # #431 — fetch a full atproto repo CAR by DID (commit + MST + all records).
-    getRepo @16 :Text $scope(query) $mcpDescription("Fetch a full atproto repo CAR by DID");
+    getRepo @16 :Text $scope(query) $mcpDescription("Fetch a full atproto repo CAR by DID")
+      $vfsPath("{arg}/repo");
   }
 }
 

--- a/crates/hyprstream-rpc-derive/src/codegen/vfs.rs
+++ b/crates/hyprstream-rpc-derive/src/codegen/vfs.rs
@@ -177,10 +177,24 @@ pub fn validate_node(method_snake: &str, scope: &str, kind: NodeKind) -> Result<
 }
 
 /// Infer the default mount-relative path for a node when `$vfsPath` is unset.
-fn infer_path(kind: NodeKind, method_snake: &str, arg: &CapnpType) -> String {
+///
+/// `dir_is_sole_listing` distinguishes the common single-listing case (the
+/// listing IS the directory root, path `.`) from a struct with several `Dir`
+/// listings (e.g. registry's `repo/{repoId}` scope: `listBranches`/`listTags`/
+/// `listRemotes`/`listWorktrees` are all `query`+`Void` `list*` methods). In
+/// the latter case `.` would silently collide across every listing, so each
+/// gets a name-derived path instead: strip a leading `list_` from the method's
+/// snake-case name if present, else use the name as-is.
+fn infer_path(kind: NodeKind, method_snake: &str, arg: &CapnpType, dir_is_sole_listing: bool) -> String {
     match kind {
-        // A directory listing is the mount root by convention.
-        NodeKind::Dir => ".".to_owned(),
+        // The lone directory listing in this scope is the mount root by
+        // convention. When there's more than one, each needs its own name so
+        // they don't all collide at ".".
+        NodeKind::Dir if dir_is_sole_listing => ".".to_owned(),
+        NodeKind::Dir => method_snake
+            .strip_prefix("list_")
+            .unwrap_or(method_snake)
+            .to_owned(),
         // A scalar-arg file binds the arg from the path segment.
         NodeKind::File if !matches!(arg, CapnpType::Void) => "{arg}".to_owned(),
         // A control file lands at the conventional `ctl` node.
@@ -194,15 +208,28 @@ fn infer_path(kind: NodeKind, method_snake: &str, arg: &CapnpType) -> String {
 /// Build the `VfsNode` entry token stream for one set of request variants.
 ///
 /// Shared by the top-level table and each scoped-client subdir table. Returns
-/// `Err(compile_error_tokens)` on a bad `$vfsKind` or a scope/kind contradiction.
+/// `Err(compile_error_tokens)` on a bad `$vfsKind`, a scope/kind contradiction,
+/// or two methods landing on the same path.
+///
+/// Two passes: the first resolves each method's kind (needed to count how
+/// many un-annotated `Dir` listings this scope has, which decides whether the
+/// lone-listing "." default applies — see [`infer_path`]); the second
+/// resolves paths with that count in hand, then builds the entries and checks
+/// for any same-path collision across the whole scope.
 fn build_node_entries(
     variants: &[UnionVariant],
     scoped_names: &[&str],
     response_variants: &[UnionVariant],
     resolved: &ResolvedSchema,
 ) -> Result<Vec<TokenStream>, TokenStream> {
-    let mut node_entries: Vec<TokenStream> = Vec::new();
+    struct Resolved<'a> {
+        variant: &'a UnionVariant,
+        method_snake: String,
+        arg: CapnpType,
+        kind: NodeKind,
+    }
 
+    let mut resolved_variants: Vec<Resolved> = Vec::new();
     for v in variants {
         // Scoped clients project as subdirectories with their own tables; skip
         // them in the flat node list. `$vfsHidden` excludes a method entirely.
@@ -222,13 +249,47 @@ fn build_node_entries(
             return Err(compile_error(&msg));
         }
 
+        resolved_variants.push(Resolved { variant: v, method_snake, arg, kind });
+    }
+
+    // How many un-annotated methods in this scope infer to `Dir` — decides
+    // whether the sole one gets "." or each gets a name-derived path.
+    let unannotated_dir_count = resolved_variants
+        .iter()
+        .filter(|r| r.kind == NodeKind::Dir && r.variant.vfs_path.is_empty())
+        .count();
+    let dir_is_sole_listing = unannotated_dir_count <= 1;
+
+    let mut node_entries: Vec<TokenStream> = Vec::new();
+    // (path, method_snake) — `Ctl` entries are intentionally excluded: several
+    // write/manage methods sharing one `ctl` file, dispatched by the verb text
+    // written to it, is the designed multiplexing convention (see the module
+    // doc's mapping table), not a collision.
+    let mut seen_paths: Vec<(String, String)> = Vec::new();
+
+    for r in &resolved_variants {
+        let v = r.variant;
         let path = if v.vfs_path.is_empty() {
-            infer_path(kind, &method_snake, &arg)
+            infer_path(r.kind, &r.method_snake, &r.arg, dir_is_sole_listing)
         } else {
             v.vfs_path.clone()
         };
 
-        let kind_tokens = kind.to_tokens();
+        // The guard: two non-`Ctl` methods must not project to the same path
+        // — a 9P read node can only be served by one method. Fires regardless
+        // of whether the collision came from inference or explicit `$vfsPath`.
+        if r.kind != NodeKind::Ctl {
+            if let Some((_, other)) = seen_paths.iter().find(|(p, _)| *p == path) {
+                return Err(compile_error(&format!(
+                    "method `{}` and method `{other}` both project to VFS path `{path}` — set an explicit `$vfsPath` on at least one to disambiguate",
+                    r.method_snake
+                )));
+            }
+            seen_paths.push((path.clone(), r.method_snake.clone()));
+        }
+
+        let kind_tokens = r.kind.to_tokens();
+        let method_snake = r.method_snake.as_str();
         let scope = v.scope.as_str();
         let bulk = v.vfs_bulk;
 
@@ -377,7 +438,7 @@ mod tests {
     fn infers_parameterized_file_for_text_query() {
         let k = infer_kind("query", &CapnpType::Text, "getByName", false);
         assert_eq!(k, NodeKind::File);
-        assert_eq!(infer_path(k, "get_by_name", &CapnpType::Text), "{arg}");
+        assert_eq!(infer_path(k, "get_by_name", &CapnpType::Text, true), "{arg}");
     }
 
     #[test]
@@ -390,7 +451,7 @@ mod tests {
     fn infers_ctl_for_write() {
         let k = infer_kind("write", &CapnpType::Struct("CloneRequest".into()), "clone", false);
         assert_eq!(k, NodeKind::Ctl);
-        assert_eq!(infer_path(k, "clone", &CapnpType::Struct("CloneRequest".into())), "ctl");
+        assert_eq!(infer_path(k, "clone", &CapnpType::Struct("CloneRequest".into()), true), "ctl");
     }
 
     #[test]
@@ -576,5 +637,83 @@ mod tests {
         let resolved = ResolvedSchema::from(&schema);
         let out = generate_mount("dataonly", &resolved).to_string();
         assert!(out.is_empty(), "data-only schema has no mount: {out}");
+    }
+
+    // ── #669: multiple Void-arg listings in one struct must not collide ──────
+
+    #[test]
+    fn multiple_listings_get_distinct_name_derived_paths() {
+        // Mirrors registry's `repo/{repoId}` scope: four query+Void `list*`
+        // methods, none annotated — all would infer to "." without the fix.
+        let schema = schema_with(
+            vec![
+                variant("listBranches", "Void", "query"),
+                variant("listTags", "Void", "query"),
+                variant("listRemotes", "Void", "query"),
+                variant("listWorktrees", "Void", "query"),
+            ],
+            vec![],
+        );
+        let resolved = ResolvedSchema::from(&schema);
+        let out = generate_mount("repo", &resolved).to_string();
+
+        assert!(!out.contains("compile_error"), "no collision guard error: {out}");
+        assert!(out.contains("\"branches\""), "list_ prefix stripped: {out}");
+        assert!(out.contains("\"tags\""), "list_ prefix stripped: {out}");
+        assert!(out.contains("\"remotes\""), "list_ prefix stripped: {out}");
+        assert!(out.contains("\"worktrees\""), "list_ prefix stripped: {out}");
+        // None of the four should still be the bare "." (the pre-fix collision).
+        assert!(!out.contains("path : \".\""), "no method landed on the bare root: {out}");
+    }
+
+    #[test]
+    fn single_listing_still_defaults_to_dot() {
+        // The common case (one Dir-kind listing in the scope) is unaffected.
+        let schema = schema_with(vec![variant("list", "Void", "query")], vec![]);
+        let resolved = ResolvedSchema::from(&schema);
+        let out = generate_mount("registry", &resolved).to_string();
+
+        assert!(!out.contains("compile_error"), "no guard error: {out}");
+        assert!(out.contains("path : \".\""), "sole listing is still the scope root: {out}");
+    }
+
+    #[test]
+    fn explicit_vfs_path_overrides_even_with_multiple_listings() {
+        // Three listings: two explicitly annotated (never collide, whatever
+        // they're set to), one bare. Only the un-annotated ones count toward
+        // "how many listings default in this scope" — with just one bare
+        // listing left, it still gets the sole-listing "." default, and the
+        // explicit paths win over inference for the other two.
+        let mut branches = variant("listBranches", "Void", "query");
+        branches.vfs_path = "custom-branches".into();
+        let mut remotes = variant("listRemotes", "Void", "query");
+        remotes.vfs_path = "custom-remotes".into();
+        let schema = schema_with(
+            vec![branches, remotes, variant("listTags", "Void", "query")],
+            vec![],
+        );
+        let resolved = ResolvedSchema::from(&schema);
+        let out = generate_mount("repo", &resolved).to_string();
+
+        assert!(!out.contains("compile_error"), "no guard error: {out}");
+        assert!(out.contains("\"custom-branches\""), "explicit path wins: {out}");
+        assert!(out.contains("\"custom-remotes\""), "explicit path wins: {out}");
+        assert!(out.contains("path : \".\""), "the sole un-annotated listing still gets the root: {out}");
+    }
+
+    #[test]
+    fn collision_guard_fires_on_same_path() {
+        // Two distinct methods that would both resolve to the same explicit path.
+        let mut a = variant("getByName", "Text", "query");
+        a.vfs_path = "dup".into();
+        let mut b = variant("getById", "Text", "query");
+        b.vfs_path = "dup".into();
+        let schema = schema_with(vec![a, b], vec![]);
+        let resolved = ResolvedSchema::from(&schema);
+        let out = generate_mount("registry", &resolved).to_string();
+
+        assert!(out.contains("compile_error"), "collision is a build error: {out}");
+        assert!(out.contains("get_by_name") && out.contains("get_by_id"), "names both methods: {out}");
+        assert!(out.contains("dup"), "names the colliding path: {out}");
     }
 }

--- a/crates/hyprstream-rpc-std/schema/oauth.capnp
+++ b/crates/hyprstream-rpc-std/schema/oauth.capnp
@@ -9,6 +9,7 @@ using import "/common.capnp".ErrorInfo;
 using import "/annotations.capnp".scope;
 using import "/annotations.capnp".mcpDescription;
 using import "/annotations.capnp".optional;
+using import "/annotations.capnp".vfsPath;
 
 struct OauthRequest {
   id @0 :UInt64;
@@ -33,7 +34,8 @@ struct OauthRequest {
     removePubkey @9 :RemovePubkey
       $scope(manage) $mcpDescription("Remove a public key by fingerprint");
     listPubkeys @10 :Text
-      $scope(query) $mcpDescription("List all public keys for a user");
+      $scope(query) $mcpDescription("List all public keys for a user")
+      $vfsPath("{arg}/pubkeys");
   }
 }
 

--- a/crates/hyprstream-workers/schema/workflow.capnp
+++ b/crates/hyprstream-workers/schema/workflow.capnp
@@ -4,6 +4,7 @@ using import "/common.capnp".ErrorInfo;
 using import "/annotations.capnp".mcpDescription;
 using import "/annotations.capnp".paramDescription;
 using import "/annotations.capnp".scope;
+using import "/annotations.capnp".vfsPath;
 
 # Cap'n Proto schema for workflow service (independent service)
 #
@@ -19,7 +20,8 @@ struct WorkflowRequest {
   union {
     scanRepo @1 :Text
       $mcpDescription("Scan a repository for workflow definitions")
-      $scope(query);
+      $scope(query)
+      $vfsPath("{arg}/scan");
     register @2 :WorkflowDef
       $mcpDescription("Register a workflow definition")
       $scope(write);
@@ -37,10 +39,12 @@ struct WorkflowRequest {
       $scope(write);
     getRun @7 :Text
       $mcpDescription("Get status of a workflow run")
-      $scope(query);
+      $scope(query)
+      $vfsPath("{arg}/run");
     listRuns @8 :Text
       $mcpDescription("List runs for a workflow")
-      $scope(query);
+      $scope(query)
+      $vfsPath("{arg}/runs");
   }
 }
 

--- a/crates/hyprstream/schema/tui.capnp
+++ b/crates/hyprstream/schema/tui.capnp
@@ -10,6 +10,7 @@
 using import "/common.capnp".ErrorInfo;
 using import "/annotations.capnp".scope;
 using import "/annotations.capnp".mcpDescription;
+using import "/annotations.capnp".vfsPath;
 # #275: the moq reach model (network-routable dial parameters) so a cross-process
 # TUI viewer can dial the producer's networked moq plane instead of its own local
 # UDS plane. Shared 1:1 with the inference StreamInfo's reach (streaming.capnp).
@@ -136,7 +137,8 @@ struct TuiRequest {
 
     # List all windows in a session
     listWindows @5 :UInt32  # session_id
-      $scope(query) $mcpDescription("List all windows in a session");
+      $scope(query) $mcpDescription("List all windows in a session")
+      $vfsPath("{arg}/windows");
 
     # Focus a window
     focusWindow @6 :UInt32  # window_id
@@ -156,7 +158,8 @@ struct TuiRequest {
 
     # Get a snapshot of the current display state
     snapshot @10 :UInt32  # session_id (0 = current)
-      $scope(query) $mcpDescription("Get snapshot of current display");
+      $scope(query) $mcpDescription("Get snapshot of current display")
+      $vfsPath("{arg}/snapshot");
 
     # Resize the terminal
     resize @11 :ResizeRequest


### PR DESCRIPTION
Fixes #669. Reviewed as READY-TO-EXECUTE by 2:0.0's audit pass (see #669 comments).

## The bug
`infer_path`'s `NodeKind::Dir => ".".to_owned()` was unconditional. A scope with more than one un-annotated `Dir`-kind listing (e.g. registry's `repo/{repoId}` scope: `listBranches`/`listTags`/`listRemotes`/`listWorktrees`, all `query`+`Void`) silently collided — every listing landed on the scope root, last-processed wins.

## The fix
- **Name-derived paths for multi-listing scopes.** `build_node_entries` now resolves kinds in a first pass to count un-annotated `Dir` listings per scope. Exactly one → the existing `.` default holds (the listing IS the scope root — the common case, unaffected). More than one → each gets a name-derived path (`list_` prefix stripped, e.g. `list_branches` → `branches`). Explicit `$vfsPath` always overrides.
- **General same-path collision guard.** Not limited to the Dir-listing case — fires on ANY two non-`Ctl` methods landing on the same path (`Ctl` is excluded by design: multiple write/manage methods sharing one verb-dispatched `ctl` file is the intended multiplexing convention, not a bug).

## The guard found a real bug
`oauth.capnp`'s `listPubkeys` (`Text` arg) and `getUser` (`Text` arg) both infer to `{arg}` — a genuine pre-existing collision in production schema. Fixed with an explicit `$vfsPath("{arg}/pubkeys")`. Verified: reverting that one-line schema fix reproduces the `compile_error!` against current main — the guard is load-bearing, not theoretical.

## Tests (4 new)
- Multiple listings get distinct name-derived paths (registry `repo` shape).
- Single listing still defaults to `.` (regression guard on the common case).
- Explicit `$vfsPath` overrides even with sibling listings present.
- Collision guard fires with a message naming both methods + the path.

## Verified
- `rpc-derive`: 30/30 (26 existing + 4 new).
- `rpc-std`: builds clean (oauth.capnp collision fixed).
- T5 `registry_vfs_parity`: unregressed, 5/5.
- `clippy -D warnings` clean on both crates.