### PR TITLE
fix(mac B2 #674): wire the S7 audit store into the S6 grant path

### DIFF
--- a/crates/hyprstream/src/mac/audit.rs
+++ b/crates/hyprstream/src/mac/audit.rs
@@ -183,6 +183,32 @@ pub enum DecisionReason {
     /// **Fail-closed:** the audit write failed, so a Permit was downgraded to
     /// Deny. This is itself auditable (the deny is what the PEP enforced).
     AuditFailClosed,
+
+    // ── B2 (#674): the S6 grant-path decision kind (see [`crate::mac::te::
+    // GRANT_PATH_SUBJECT`]). One variant per `mac::exchange::GrantError`
+    // gate, so a grant denial's cause is as diagnosable as a TE denial's. ──
+    /// No DPoP sender-binding proof was supplied (ZSP gate 1).
+    GrantMissingSenderBinding,
+    /// The presented grant carries no capabilities at all (gate 2).
+    GrantEmptyGrant,
+    /// The subject carried no derivable MAC clearance (gate 3, S1 floor).
+    GrantUnlabeledSubject,
+    /// The MAC clearance floor denied for a grant request (gate 5). Distinct
+    /// from [`DecisionReason::FloorDeny`] (a TE-path floor denial) so a grant
+    /// vs. per-op floor denial is distinguishable in the audit trail. Also
+    /// covers gate 4 (unlabeled object), which `evaluate_grant` maps to the
+    /// same `GrantError::InsufficientClearance`.
+    GrantFloorDeny,
+    /// The UCAN chain failed S5 validation (gate 6: bad signature, broken
+    /// linkage, widening, window escape, expiry, over-depth).
+    GrantChainInvalid,
+    /// The request exceeded the grant's ceiling (gate 7) — an escalation
+    /// attempt, denied pending a ceiling amendment (S6 does not auto-widen).
+    GrantOverCeiling,
+    /// A grant was `Permit`, but the caller's `sink` (or checking `can_sign`
+    /// preflight) could not durably audit it — the permit is downgraded to
+    /// deny, mirroring [`DecisionReason::AuditFailClosed`] for the grant path.
+    GrantAuditFailClosed,
 }
 
 impl DecisionReason {
@@ -195,6 +221,13 @@ impl DecisionReason {
             DecisionReason::Escalate => "escalate",
             DecisionReason::TokenGate => "token_gate",
             DecisionReason::AuditFailClosed => "audit_fail_closed",
+            DecisionReason::GrantMissingSenderBinding => "grant_missing_sender_binding",
+            DecisionReason::GrantEmptyGrant => "grant_empty_grant",
+            DecisionReason::GrantUnlabeledSubject => "grant_unlabeled_subject",
+            DecisionReason::GrantFloorDeny => "grant_floor_deny",
+            DecisionReason::GrantChainInvalid => "grant_chain_invalid",
+            DecisionReason::GrantOverCeiling => "grant_over_ceiling",
+            DecisionReason::GrantAuditFailClosed => "grant_audit_fail_closed",
         }
     }
 }
@@ -325,6 +358,7 @@ pub mod cose {
     use ed25519_dalek::{SigningKey, VerifyingKey};
     use hyprstream_rpc::crypto::cose_sign::{sign_composite, verify_composite};
     use hyprstream_rpc::crypto::pq::{MlDsaSigningKey, MlDsaVerifyingKey};
+    use std::sync::Arc;
 
     /// Domain-separation AAD for audit-record signatures (distinct from
     /// policy/envelope AADs so an audit signature can never be replayed as
@@ -394,6 +428,59 @@ pub mod cose {
                 ));
             }
             sign_composite(self.ed_sk, self.pq_sk, signing_input, AUDIT_AAD)
+                .map_err(|e| AuditError::Sign(e.to_string()))
+        }
+    }
+
+    /// Owned-key variant of [`CoseAuditSigner`] (B2, #674): production wiring
+    /// stores this on `OAuthState`/`AuditedAvc`, both of which must be
+    /// `'static` — a borrowed signer cannot live there. Holds `Arc`s to the
+    /// same key material a borrowed [`CoseAuditSigner`] would reference (a
+    /// startup-time snapshot of the node's active EdDSA + ML-DSA-65 keys), and
+    /// signs with the IDENTICAL fail-closed logic: under Hybrid, a missing PQ
+    /// key fails every `sign` call rather than downgrading.
+    pub struct OwnedCoseAuditSigner {
+        ed_sk: Arc<SigningKey>,
+        pq_sk: Option<Arc<MlDsaSigningKey>>,
+        require_pq: bool,
+    }
+
+    impl OwnedCoseAuditSigner {
+        /// Construct from owned key material + the node's enforced
+        /// [`CryptoPolicy`](hyprstream_rpc::crypto::CryptoPolicy). See
+        /// [`CoseAuditSigner::new`] for the exact Hybrid/Classical semantics —
+        /// identical here.
+        pub fn new(
+            ed_sk: Arc<SigningKey>,
+            pq_sk: Option<Arc<MlDsaSigningKey>>,
+            policy: hyprstream_rpc::crypto::CryptoPolicy,
+        ) -> Self {
+            Self {
+                ed_sk,
+                pq_sk: if policy.uses_pq() { pq_sk } else { None },
+                require_pq: policy.uses_pq(),
+            }
+        }
+
+        /// As [`CoseAuditSigner::can_sign`]: whether this signer can produce a
+        /// signature under its policy. Production wiring MUST check this at
+        /// startup and refuse to boot the audited grant path if false under
+        /// Hybrid (no audit signer ⇒ no Permit, per the S7 fail-closed
+        /// contract) — see `OAuthState::with_audit_sink`.
+        #[must_use]
+        pub fn can_sign(&self) -> bool {
+            !self.require_pq || self.pq_sk.is_some()
+        }
+    }
+
+    impl AuditSigner for OwnedCoseAuditSigner {
+        fn sign(&self, signing_input: &[u8]) -> Result<Vec<u8>, AuditError> {
+            if self.require_pq && self.pq_sk.is_none() {
+                return Err(AuditError::Sign(
+                    "Hybrid crypto policy requires an ML-DSA-65 audit signing key, none provisioned (fail-closed)".to_owned(),
+                ));
+            }
+            sign_composite(&self.ed_sk, self.pq_sk.as_deref(), signing_input, AUDIT_AAD)
                 .map_err(|e| AuditError::Sign(e.to_string()))
         }
     }

--- a/crates/hyprstream/src/mac/exchange.rs
+++ b/crates/hyprstream/src/mac/exchange.rs
@@ -129,6 +129,12 @@ pub enum GrantError {
     /// The grant carries no capabilities at all, so there is no ceiling to
     /// request a subset of. An empty grant mints nothing.
     EmptyGrant,
+    /// **B2 (#674):** the request would otherwise `Permit`, but the decision
+    /// could not be durably audited (the audit sink's `record` failed, or its
+    /// signer cannot sign under the enforced crypto policy). Mirrors S7's
+    /// `AuditedAvc` fail-closed rule at the grant path: a decision that cannot
+    /// be audited is never allowed through. See [`audited_evaluate_grant`].
+    AuditUnavailable,
 }
 
 impl std::fmt::Display for GrantError {
@@ -155,6 +161,10 @@ impl std::fmt::Display for GrantError {
                 write!(f, "subject carries no MAC clearance (unlabeled ⇒ deny)")
             }
             GrantError::EmptyGrant => write!(f, "grant carries no capabilities (empty ceiling)"),
+            GrantError::AuditUnavailable => write!(
+                f,
+                "grant decision could not be durably audited (fail-closed)"
+            ),
         }
     }
 }
@@ -365,6 +375,127 @@ pub fn evaluate_refresh<V: UcanVerifier + ?Sized>(
     // Identical gates to the initial mint. ZSP: no path diverges here — a
     // refresh that weakens any gate is a refresh that denies.
     evaluate_grant(grant, verifier, now, request, subject, sender_bound)
+}
+
+/// As [`evaluate_grant`], but records a tamper-evident [`AuditRecord`] of the
+/// outcome through `sink` before returning — S7's complete-mediation guarantee
+/// extended to the grant path (B2, #674). This is the mint-path entry point
+/// production code should call; the plain [`evaluate_grant`] is the
+/// unaudited core the gate tests exercise directly.
+///
+/// Every gate outcome is audited, permit and deny alike (`DecisionReason`'s
+/// `Grant*` variants — see [`crate::mac::audit::DecisionReason`]). On a would-be
+/// `Permit`, the audit write happens **before** the token layer is told to
+/// mint: if it fails, the permit is downgraded to
+/// [`GrantError::AuditUnavailable`] rather than handed back — mirroring
+/// [`crate::mac::audit::AuditedAvc`]'s fail-closed rule that a decision which
+/// cannot be audited is never allowed through.
+#[allow(clippy::too_many_arguments)]
+pub fn audited_evaluate_grant<V: UcanVerifier + ?Sized>(
+    grant: &Ucan,
+    verifier: &V,
+    now: u64,
+    request: &GrantRequest,
+    subject: Option<&SecurityContext>,
+    sender_bound: bool,
+    sink: &dyn crate::mac::audit::AuditSink,
+) -> Result<GrantDecision, GrantError> {
+    let result = evaluate_grant(grant, verifier, now, request, subject, sender_bound);
+    audit_grant_outcome(subject, request, &result, sink)
+}
+
+/// As [`evaluate_refresh`], with the same audit-then-decide wrapping as
+/// [`audited_evaluate_grant`]. The refresh path's audit records are
+/// indistinguishable in shape from the mint path's (both are grant-path
+/// decisions); the caller distinguishes them by context if needed.
+#[allow(clippy::too_many_arguments)]
+pub fn audited_evaluate_refresh<V: UcanVerifier + ?Sized>(
+    grant: &Ucan,
+    verifier: &V,
+    now: u64,
+    request: &GrantRequest,
+    subject: Option<&SecurityContext>,
+    sender_bound: bool,
+    sink: &dyn crate::mac::audit::AuditSink,
+) -> Result<GrantDecision, GrantError> {
+    let result = evaluate_refresh(grant, verifier, now, request, subject, sender_bound);
+    audit_grant_outcome(subject, request, &result, sink)
+}
+
+/// Shared audit-then-decide core for [`audited_evaluate_grant`] /
+/// [`audited_evaluate_refresh`]. Builds the [`AuditRecord`] from whatever
+/// context is available (subject may be `None` on an unlabeled-subject
+/// denial; the request's ability may not parse as a canonical
+/// [`crate::mac::te::ScopeAction`] — both are still recorded, using the
+/// sentinel ids documented on [`crate::mac::te::GRANT_PATH_SUBJECT`]).
+fn audit_grant_outcome(
+    subject: Option<&SecurityContext>,
+    request: &GrantRequest,
+    result: &Result<GrantDecision, GrantError>,
+    sink: &dyn crate::mac::audit::AuditSink,
+) -> Result<GrantDecision, GrantError> {
+    use crate::mac::audit::{AuditRecord, DecisionReason};
+    use crate::mac::te::{Action, ScopeAction, ACTION_UNRECOGNIZED, GRANT_PATH_OBJECT, GRANT_PATH_SUBJECT};
+    use hyprstream_rpc::auth::mac::SecurityLabel;
+
+    let (decision, reason) = match result {
+        Ok(GrantDecision::Permit(_)) => (Decision::Permit, DecisionReason::Permit),
+        Ok(GrantDecision::Escalate { .. }) => (Decision::Escalate, DecisionReason::GrantOverCeiling),
+        Err(GrantError::Chain(_)) => (Decision::Deny, DecisionReason::GrantChainInvalid),
+        Err(GrantError::OverCeiling { .. }) => (Decision::Deny, DecisionReason::GrantOverCeiling),
+        Err(GrantError::InsufficientClearance) => (Decision::Deny, DecisionReason::GrantFloorDeny),
+        Err(GrantError::MissingSenderBinding) => {
+            (Decision::Deny, DecisionReason::GrantMissingSenderBinding)
+        }
+        Err(GrantError::UnlabeledSubject) => (Decision::Deny, DecisionReason::GrantUnlabeledSubject),
+        Err(GrantError::EmptyGrant) => (Decision::Deny, DecisionReason::GrantEmptyGrant),
+        // Constructed below, never as the pre-audit decision — but exhaustive
+        // match requires a reachable-if-mis-called arm. Records as a deny.
+        Err(GrantError::AuditUnavailable) => (Decision::Deny, DecisionReason::GrantAuditFailClosed),
+    };
+
+    let action = ScopeAction::parse(request.ability.as_str())
+        .map(Action::from)
+        .unwrap_or(ACTION_UNRECOGNIZED);
+    let record = AuditRecord {
+        seq: 0,          // the sink (WalAuditStore) assigns the real seq.
+        prev_hash: [0u8; 32], // the sink assigns the real chain link.
+        ts_unix_nanos: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0),
+        decision,
+        generation: 0, // grant decisions are not TE-matrix-generation-versioned.
+        policy_hash: None,
+        subject_type: GRANT_PATH_SUBJECT,
+        subject_clearance: subject.map(|s| *s.clearance()).unwrap_or_else(SecurityLabel::bottom),
+        object_type: GRANT_PATH_OBJECT,
+        object_label: request.object_label.unwrap_or_else(SecurityLabel::bottom),
+        action,
+        reason,
+    };
+
+    match sink.record(&record) {
+        Ok(()) => result.clone(),
+        Err(_) => {
+            // Fail-closed: a would-be Permit that cannot be durably audited is
+            // downgraded. A deny that cannot be audited is still enforced as
+            // decided (the deny is not weakened by a broken audit sink) but the
+            // failure is surfaced so it is observable.
+            if matches!(result, Ok(GrantDecision::Permit(_))) {
+                let deny_record = AuditRecord {
+                    reason: DecisionReason::GrantAuditFailClosed,
+                    decision: Decision::Deny,
+                    ..record
+                };
+                let _ = sink.record(&deny_record);
+                Err(GrantError::AuditUnavailable)
+            } else {
+                tracing::error!("MAC grant-path audit write failed on a Deny decision (deny still enforced)");
+                result.clone()
+            }
+        }
+    }
 }
 
 /// Resolve the S1 `SecurityContext` for a UCAN grant's audience from a
@@ -1005,5 +1136,200 @@ mod tests {
             ),
             Err(GrantError::MissingSenderBinding)
         ));
+    }
+
+    // ── B2 (#674): the audited grant path ───────────────────────────────────
+
+    /// An in-memory sink that records every [`crate::mac::audit::AuditRecord`]
+    /// it's given, or can be told to fail the next `record` call (to exercise
+    /// the fail-closed-on-audit-failure path without a real `WalAuditStore`).
+    struct SpySink {
+        records: parking_lot::Mutex<Vec<crate::mac::audit::AuditRecord>>,
+        fail_next: std::sync::atomic::AtomicBool,
+    }
+    impl SpySink {
+        fn new() -> Self {
+            Self {
+                records: parking_lot::Mutex::new(Vec::new()),
+                fail_next: std::sync::atomic::AtomicBool::new(false),
+            }
+        }
+        fn fail_next_write(&self) {
+            self.fail_next.store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+        fn records(&self) -> Vec<crate::mac::audit::AuditRecord> {
+            self.records.lock().clone()
+        }
+    }
+    impl crate::mac::audit::AuditSink for SpySink {
+        fn record(
+            &self,
+            record: &crate::mac::audit::AuditRecord,
+        ) -> Result<(), crate::mac::audit::AuditError> {
+            if self.fail_next.swap(false, std::sync::atomic::Ordering::SeqCst) {
+                return Err(crate::mac::audit::AuditError::Io("injected failure".into()));
+            }
+            self.records.lock().push(record.clone());
+            Ok(())
+        }
+    }
+
+    /// A permit is audited (exactly one `Permit` record, with the grant-path
+    /// sentinel ids) and the token still mints — auditing must not itself
+    /// deny a decision the gates approved.
+    #[test]
+    fn audited_permit_is_recorded_and_still_mints() {
+        let (grant, store) = root_grant(cap("mac://model/*", "model/read"));
+        let object_label =
+            SecurityLabel::new(Level::Confidential, Assurance::PqHybrid, comps(&[0]));
+        let request = req("mac://model/qwen", "model/read", object_label);
+        let sink = SpySink::new();
+
+        let decision = audited_evaluate_grant(
+            &grant,
+            &store,
+            NOW,
+            &request,
+            Some(&cleared_subject()),
+            true,
+            &sink,
+        );
+        assert!(
+            matches!(decision, Ok(GrantDecision::Permit(_))),
+            "an honest permit must still mint under audit: {decision:?}"
+        );
+
+        let recs = sink.records();
+        assert_eq!(recs.len(), 1, "exactly one record per decision");
+        assert_eq!(recs[0].decision, crate::mac::te::Decision::Permit);
+        assert_eq!(recs[0].reason, crate::mac::audit::DecisionReason::Permit);
+        assert_eq!(recs[0].subject_type, crate::mac::te::GRANT_PATH_SUBJECT);
+        assert_eq!(recs[0].object_type, crate::mac::te::GRANT_PATH_OBJECT);
+    }
+
+    /// The core #674 obligation: a would-be Permit that CANNOT be durably
+    /// audited must be downgraded to a deny (`AuditUnavailable`), never handed
+    /// back as a Permit — mirroring `AuditedAvc`'s fail-closed rule at the TE
+    /// path. Also asserts the resulting deny record IS still attempted/audited.
+    #[test]
+    fn permit_downgrades_to_deny_when_audit_write_fails() {
+        let (grant, store) = root_grant(cap("mac://model/*", "model/read"));
+        let object_label =
+            SecurityLabel::new(Level::Confidential, Assurance::PqHybrid, comps(&[0]));
+        let request = req("mac://model/qwen", "model/read", object_label);
+        let sink = SpySink::new();
+        sink.fail_next_write(); // the Permit's own audit write will fail
+
+        let decision = audited_evaluate_grant(
+            &grant,
+            &store,
+            NOW,
+            &request,
+            Some(&cleared_subject()),
+            true,
+            &sink,
+        );
+        assert!(
+            matches!(decision, Err(GrantError::AuditUnavailable)),
+            "an unauditable permit must be downgraded, got {decision:?}"
+        );
+        // The fallback deny record was itself recorded (best-effort, per the
+        // AuditedAvc precedent) — the second `record` call, which SpySink
+        // allows since only the first was told to fail.
+        let recs = sink.records();
+        assert_eq!(recs.len(), 1, "the downgraded deny is recorded");
+        assert_eq!(recs[0].decision, crate::mac::te::Decision::Deny);
+        assert_eq!(
+            recs[0].reason,
+            crate::mac::audit::DecisionReason::GrantAuditFailClosed
+        );
+    }
+
+    /// A denial that cannot be audited is still enforced as a deny (auditing
+    /// failure never WEAKENS a decision — only a would-be Permit is affected).
+    #[test]
+    fn deny_stays_deny_when_audit_write_fails() {
+        let (grant, store) = root_grant(cap("mac://model/*", "model/read"));
+        // Missing object label ⇒ InsufficientClearance (gate 4), independent of
+        // the audit sink.
+        let request = GrantRequest {
+            resource: Resource::new("mac://model/qwen"),
+            ability: Ability::new("model/read"),
+            caveats: Caveats::default(),
+            audience: None,
+            object_label: None,
+        };
+        let sink = SpySink::new();
+        sink.fail_next_write();
+
+        let decision = audited_evaluate_grant(
+            &grant,
+            &store,
+            NOW,
+            &request,
+            Some(&cleared_subject()),
+            true,
+            &sink,
+        );
+        assert!(
+            matches!(decision, Err(GrantError::InsufficientClearance)),
+            "a deny must be enforced as decided even if its audit write fails: {decision:?}"
+        );
+        // The (failed) attempt leaves no record — asserting we don't silently
+        // fabricate one; the failure was logged instead (see tracing::error!).
+        assert!(sink.records().is_empty());
+    }
+
+    /// An unrecognized ability (doesn't parse as a canonical `ScopeAction`)
+    /// still produces a well-formed audit record — using the sentinel
+    /// `ACTION_UNRECOGNIZED` id rather than dropping the record. Diagnosable,
+    /// not silently lost.
+    #[test]
+    fn unparseable_ability_still_produces_a_diagnosable_record() {
+        let (grant, store) = root_grant(cap("mac://model/*", "totally-not-a-verb"));
+        let object_label =
+            SecurityLabel::new(Level::Confidential, Assurance::PqHybrid, comps(&[0]));
+        let request = req("mac://model/qwen", "totally-not-a-verb", object_label);
+        let sink = SpySink::new();
+
+        // The grant will actually Permit (the capability's ability string
+        // matches verbatim), but the ability is not a canonical ScopeAction —
+        // exercising the ACTION_UNRECOGNIZED fallback on a real decision.
+        let _ = audited_evaluate_grant(
+            &grant,
+            &store,
+            NOW,
+            &request,
+            Some(&cleared_subject()),
+            true,
+            &sink,
+        );
+        let recs = sink.records();
+        assert_eq!(recs.len(), 1);
+        assert_eq!(recs[0].action, crate::mac::te::ACTION_UNRECOGNIZED);
+    }
+
+    /// `audited_evaluate_refresh` audits identically to
+    /// `audited_evaluate_grant` (same gate chain, same record shape) — the
+    /// refresh path is not a quieter/less-audited sibling.
+    #[test]
+    fn audited_refresh_is_recorded_the_same_way() {
+        let (grant, store) = root_grant(cap("mac://model/*", "model/read"));
+        let object_label =
+            SecurityLabel::new(Level::Confidential, Assurance::PqHybrid, comps(&[0]));
+        let request = req("mac://model/qwen", "model/read", object_label);
+        let sink = SpySink::new();
+
+        let decision = audited_evaluate_refresh(
+            &grant,
+            &store,
+            NOW,
+            &request,
+            Some(&cleared_subject()),
+            true,
+            &sink,
+        );
+        assert!(matches!(decision, Ok(GrantDecision::Permit(_))));
+        assert_eq!(sink.records().len(), 1);
     }
 }

--- a/crates/hyprstream/src/mac/te.rs
+++ b/crates/hyprstream/src/mac/te.rs
@@ -231,6 +231,21 @@ pub struct TeRule {
     pub action: Action,
 }
 
+/// Sentinel ids (B2, #674) for auditing a decision that is NOT a per-op TE
+/// evaluation — today, the S6 grant path (`mac::exchange::evaluate_grant`),
+/// which decides against a UCAN grant's capabilities, not a compiled TE
+/// matrix. `AuditRecord` has one shape (it predates the grant path); rather
+/// than fork the schema, a grant record uses these reserved ids so it is
+/// self-describing and can never collide with a real interned TE id (which
+/// starts from 0 and is bounded by the compiled registry). `subject_type`/
+/// `object_type` reuse `u32::MAX`; `action` uses `ScopeAction`'s id space
+/// directly when the requested ability parses, or `ACTION_UNRECOGNIZED`
+/// otherwise (still recorded — an audit record for an unparseable ability is
+/// exactly the diagnosable case, not a reason to drop the record).
+pub const GRANT_PATH_SUBJECT: SubjectType = SubjectType(u32::MAX);
+pub const GRANT_PATH_OBJECT: ObjectType = ObjectType(u32::MAX);
+pub const ACTION_UNRECOGNIZED: Action = Action(u32::MAX);
+
 /// The compiled type-enforcement matrix: a flat allow-set of [`TeRule`]s. Default-deny —
 /// any triple not present is denied. This is the data-plane artifact loaded from signed
 /// compiled policy (see [`crate::mac::compiled`]). Kept as a `HashSet` so the hot-path

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -528,6 +528,49 @@ impl Spawnable for OAuthService {
             );
             info!("ML-DSA-65 signing key rotation store loaded");
 
+            // MAC #547 / B2 (#674): construct the S6 grant-path audit sink. A
+            // startup-time snapshot of the active ML-DSA-65 key (rotation
+            // during the process lifetime is a follow-up — S7's audit key
+            // provisioning is otherwise the same "load once at boot" shape as
+            // the rest of this factory). The node's enforced crypto policy
+            // decides whether the PQ layer is REQUIRED (fail-closed if the key
+            // snapshot comes back empty) or ignored (Classical).
+            let audit_sink: Option<Arc<dyn crate::mac::audit::AuditSink>> = {
+                let crypto_policy = hyprstream_rpc::envelope::envelope_policy_from_env();
+                let audit_pq_key = ml_dsa_store.active_key().await;
+                let signer = crate::mac::audit::cose::OwnedCoseAuditSigner::new(
+                    Arc::new(self.signing_key.clone()),
+                    audit_pq_key,
+                    crypto_policy,
+                );
+                if !signer.can_sign() {
+                    tracing::error!(
+                        "MAC audit signer cannot sign under the enforced Hybrid crypto \
+                         policy (no ML-DSA-65 key provisioned) — the S6 grant path will \
+                         fail closed (deny) on every request until a key is provisioned"
+                    );
+                }
+                match crate::mac::audit::WalAuditStore::open(
+                    credentials_dir.join("mac-audit"),
+                    signer,
+                ) {
+                    Ok(store) => {
+                        info!("MAC grant-path audit store opened (WAL, hash-chained, checkpointed)");
+                        Some(Arc::new(store) as Arc<dyn crate::mac::audit::AuditSink>)
+                    }
+                    Err(e) => {
+                        // Fail-closed by omission: `audit_sink` stays `None`, and
+                        // the grant path denies every request rather than mint
+                        // unaudited tokens (see `exchange_ucan_grant`).
+                        tracing::error!(
+                            "MAC grant-path audit store failed to open — the S6 grant \
+                             path will fail closed (deny) on every request: {e:?}"
+                        );
+                        None
+                    }
+                }
+            };
+
             let (ca_jwt_key, signing_key_store) = match crate::auth::identity_store::load_ca_signing_key(&credentials_dir) {
                 Ok(root_key) => {
                     let key = hyprstream_rpc::node_identity::derive_purpose_key(&root_key, "hyprstream-jwt-v1");
@@ -588,6 +631,9 @@ impl Spawnable for OAuthService {
             oauth_state = oauth_state.with_es256_key_store(Arc::clone(&es256_store));
             {
                 oauth_state = oauth_state.with_ml_dsa_key_store(Arc::clone(&ml_dsa_store));
+            }
+            if let Some(sink) = audit_sink {
+                oauth_state = oauth_state.with_audit_sink(sink);
             }
             if let Some(bl) = self.jti_blocklist {
                 oauth_state = oauth_state.with_jti_blocklist(bl);

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -405,6 +405,15 @@ pub struct OAuthState {
     pub es256_key_store: Option<Arc<crate::auth::Es256SigningKeyStore>>,
     /// ML-DSA-65 signing key rotation store for PQ-hybrid JWT issuance.
     pub ml_dsa_key_store: Option<Arc<crate::auth::MlDsaSigningKeyStore>>,
+    /// MAC #547 / B2 (#674): the tamper-evident audit sink the S6 grant path
+    /// (`mac::exchange::audited_evaluate_grant`/`audited_evaluate_refresh`)
+    /// records every decision through. `None` means the grant-path audit
+    /// trail is not configured — the grant path treats that as fail-closed
+    /// (deny, not "audit best-effort") rather than minting unaudited tokens.
+    /// Production wiring is [`crate::mac::audit::WalAuditStore`] + an
+    /// [`crate::mac::audit::cose::OwnedCoseAuditSigner`] (see the `oauth`
+    /// service factory).
+    pub audit_sink: Option<Arc<dyn crate::mac::audit::AuditSink>>,
     /// QUIC/WebTransport cert hashes (SHA-256 of leaf DER, `sha2-256` multihash encoding).
     /// Published in the DID-doc `#quic` service entry so peers can pin the cert (#185).
     /// A set so cert rotation can publish old + new simultaneously.
@@ -484,6 +493,7 @@ impl OAuthState {
             jti_blocklist: None,
             es256_key_store: None,
             ml_dsa_key_store: None,
+            audit_sink: None,
             quic_cert_hashes: Vec::new(),
             quic_public_uri: None,
             mesh_pq_verifying_key: None,
@@ -528,6 +538,14 @@ impl OAuthState {
     /// Attach the ML-DSA-65 key rotation store.
     pub fn with_ml_dsa_key_store(mut self, store: Arc<crate::auth::MlDsaSigningKeyStore>) -> Self {
         self.ml_dsa_key_store = Some(store);
+        self
+    }
+
+    /// Attach the S6 grant-path audit sink (B2, #674). Without this, the
+    /// grant path fails closed on every request rather than minting tokens
+    /// with no audit trail.
+    pub fn with_audit_sink(mut self, sink: Arc<dyn crate::mac::audit::AuditSink>) -> Self {
+        self.audit_sink = Some(sink);
         self
     }
 

--- a/crates/hyprstream/src/services/oauth/token_exchange.rs
+++ b/crates/hyprstream/src/services/oauth/token_exchange.rs
@@ -17,9 +17,7 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use sha2::{Digest, Sha256};
 
 use super::state::OAuthState;
-use crate::mac::exchange::{
-    evaluate_grant, evaluate_refresh, GrantDecision, GrantError, GrantRequest, GrantedAccess,
-};
+use crate::mac::exchange::{GrantDecision, GrantError, GrantRequest, GrantedAccess};
 use crate::services::generated::policy_client::IssueToken;
 
 const TOKEN_TYPE_ID_TOKEN: &str = "urn:ietf:params:oauth:token-type:id_token";
@@ -493,14 +491,26 @@ pub async fn exchange_ucan_grant(
             "UCAN grant verification is not configured on this node",
         );
     };
+    // MAC #547 / B2 (#674): the grant path is a security decision, and S7's
+    // complete-mediation guarantee is only real if every decision is on the
+    // audit trail. No sink configured ⇒ fail closed (deny) rather than mint
+    // an unaudited token — mirroring `AuditedAvc`'s rule at the TE path.
+    let Some(sink) = state.audit_sink.as_deref() else {
+        return tx_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "server_error",
+            "MAC grant-path audit trail is not configured on this node",
+        );
+    };
     let now = chrono::Utc::now().timestamp().max(0) as u64;
-    let decision = evaluate_grant(
+    let decision = crate::mac::exchange::audited_evaluate_grant(
         &grant,
         &verifier,
         now,
         &request,
         subject_ctx.as_ref(),
         true, // sender-bound: dpop_jkt is present
+        sink,
     );
 
     let granted = match decision {
@@ -538,7 +548,7 @@ pub async fn exchange_ucan_grant(
 ///
 /// 1. requires a **fresh** DPoP proof (mandatory sender-binding — matching the
 ///    initial mint), and
-/// 2. re-presents the persisted grant to [`evaluate_refresh`], which runs the
+/// 2. re-presents the persisted grant to [`crate::mac::exchange::audited_evaluate_refresh`], which runs the
 ///    same gate chain as mint against the *current* `now` and verifier state —
 ///    so a ceiling that has since been amended/revoked, or a grant that has
 ///    since expired, now denies.
@@ -623,14 +633,25 @@ pub(crate) async fn exchange_ucan_grant_refresh(
             "UCAN grant verification is not configured on this node",
         );
     };
+    // MAC #547 / B2 (#674): refresh is a grant-path decision exactly like mint
+    // — it must be on the audit trail too, with the same fail-closed rule (no
+    // sink configured ⇒ deny rather than re-mint unaudited).
+    let Some(sink) = state.audit_sink.as_deref() else {
+        return tx_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "server_error",
+            "MAC grant-path audit trail is not configured on this node",
+        );
+    };
     let now = chrono::Utc::now().timestamp().max(0) as u64;
-    let decision = evaluate_refresh(
+    let decision = crate::mac::exchange::audited_evaluate_refresh(
         &grant,
         &verifier,
         now,
         &request,
         subject_ctx.as_ref(),
         true, // sender-bound: a fresh DPoP proof was just verified above
+        sink,
     );
 
     let granted = match decision {
@@ -670,6 +691,12 @@ fn grant_error_response(e: GrantError) -> Response {
         }
         GrantError::UnlabeledSubject | GrantError::EmptyGrant => {
             (StatusCode::FORBIDDEN, "invalid_grant", e.to_string())
+        }
+        // B2 (#674): a would-be Permit that could not be durably audited.
+        // Fail-closed, not the client's fault — surfaced as server_error
+        // (matches the "audit trail not configured" preflight response).
+        GrantError::AuditUnavailable => {
+            (StatusCode::INTERNAL_SERVER_ERROR, "server_error", e.to_string())
         }
     };
     tx_error(status, code, &desc)


### PR DESCRIPTION
Closes #674 · Blocker-before-activation for MAC epic #547.

**Stacks on #679 (B3) + #684 (#676)** — both are still open; this PR's diff will shrink to just the B2 delta once they merge (same pattern as S6/S7/S8 earlier in the epic). Individually reviewable now; the branch already contains both dependencies' commits so it builds/tests green standalone.

## The gap (from the independent post-S8 enforcement audit)
Every S6 grant-path decision (`evaluate_grant`/`evaluate_refresh`) is the **one live MAC decision point today**, and it emitted **no audit record at all**. S7's whole premise is complete mediation with a tamper-evident, signed audit trail that fails closed — without production wiring that guarantee was untested in the path that will actually gate real grants.

## The fix
- **`OwnedCoseAuditSigner`** (`mac/audit.rs::cose`) — an owned-key `AuditSigner` alongside the existing borrowed `CoseAuditSigner`. `OAuthState`/the audited AVC must be `'static`, so a borrowed signer can't live there; this holds `Arc<SigningKey>`/`Option<Arc<MlDsaSigningKey>>` with **identical** fail-closed sign logic (Hybrid + no PQ key ⇒ every `sign()` fails, never downgrades).
- **New `DecisionReason::Grant*` variants** mirroring every `GrantError` gate — a grant denial's cause is as diagnosable in the audit trail as a TE denial's.
- **`GRANT_PATH_SUBJECT`/`GRANT_PATH_OBJECT`/`ACTION_UNRECOGNIZED` sentinels** (`te.rs`) — `AuditRecord` predates the grant path and is shaped around a per-op TE triple; rather than fork the schema, a grant record uses reserved ids (`u32::MAX`) so it self-describes as a distinct decision kind and can never collide with a real interned TE id.
- **`audited_evaluate_grant` / `audited_evaluate_refresh`** (`mac/exchange.rs`) — audit-then-decide wrappers around the pure `evaluate_grant`/`evaluate_refresh`. Every gate outcome is audited, permit **and** deny. On a would-be `Permit`, the audit write happens **before** the caller mints: if it fails, the permit is downgraded to a new `GrantError::AuditUnavailable` — the same fail-closed rule `AuditedAvc` enforces at the TE path. A deny that can't be audited is still enforced as decided (auditing failure never weakens a decision, only a would-be permit).
- **`OAuthState`** gains `audit_sink: Option<Arc<dyn AuditSink>>` + `with_audit_sink`. The `oauth` service factory constructs a `WalAuditStore` + `OwnedCoseAuditSigner` at startup (node's active Ed25519 + a startup-time ML-DSA-65 key snapshot, gated by the node's enforced `CryptoPolicy`). The mint call site now **requires** the sink — no sink configured ⇒ fail closed (deny every request), never mint unaudited tokens.

## Verification
- 5 new tests (`mac::exchange`): permit recorded + still mints; permit downgraded to `AuditUnavailable` when the write fails (and the resulting deny **is** recorded); a deny stays a deny when its audit write fails; an unparseable ability still produces a diagnosable record via the sentinel; `audited_evaluate_refresh` audits identically to mint.
- `mac::` **96/96 pass** · `cargo check -p hyprstream` clean · `cargo clippy -p hyprstream --all-targets` clean.

🤖 Claude-authored (security-TCB) — requires human review before merge.
