### PR TITLE
feat(mac #680/#681): delegation foundation — two-principal carriers + shared meet + chain-root (DORMANT)

### DIFF
--- a/crates/hyprstream-rpc/src/auth/claims.rs
+++ b/crates/hyprstream-rpc/src/auth/claims.rs
@@ -67,6 +67,46 @@ pub struct Cnf {
     pub jkt: Option<String>,
 }
 
+/// RFC 8693 §4.1 actor claim — the two-principal carrier for delegated calls
+/// (#680/#681).
+///
+/// A delegated (on-behalf-of) token sets [`Claims::sub`] = the **delegator**
+/// (source of authority, e.g. the user) and [`Claims::act`] = the **actor** that
+/// signs the downstream envelope (e.g. `service:mcp`). This is delegation, not
+/// impersonation: the actor holds no standing access, only the attenuated
+/// authority the delegator granted it.
+///
+/// **Composition (#681):** the effective MAC clearance is `meet(delegator,
+/// actor)` on level/compartments — never either principal alone. The actor's
+/// authority-asserted clearance is carried here so the PDP can take the meet off
+/// the one verified JWT. Like [`Claims::clearance`] it is *authority-asserted*
+/// (the issuing node signs the JWT) and carries **no** assurance: assurance is
+/// derived from the *verified signer* (the actor, who signs the downstream
+/// envelope) and clamped DOWN at enforcement time — never trusted from this claim.
+///
+/// `act` MAY nest (`act.act`) for multi-hop delegation (RFC 8693 §4.1); each hop
+/// composes into the meet. **JWT-carried only** (mirrors [`Claims::clearance`]):
+/// not written to the Cap'n Proto envelope surface — read off the verified JWT by
+/// the MAC PDP.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ActClaim {
+    /// The actor's subject identifier (e.g. `service:mcp`). At enforcement time
+    /// this MUST equal the verified downstream envelope signer (`cnf`): an actor
+    /// cannot claim to act as an identity whose key it does not hold — the
+    /// #680 anti-confused-deputy invariant.
+    pub sub: String,
+    /// The actor's authority-asserted MAC clearance, carried so #681 can take
+    /// `meet(delegator, actor)` without a second lookup. `None` ⇒ the actor is
+    /// unlabeled ⇒ the delegated derivation **fails closed** (no default
+    /// clearance for a missing principal; the S1 rule).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub clearance: Option<crate::auth::mac::SecurityLabel>,
+    /// Nested actor for multi-hop delegation (RFC 8693 §4.1). Boxed to keep
+    /// [`Claims`] sized. Each hop composes into the clearance meet.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub act: Option<Box<ActClaim>>,
+}
+
 /// JWT claims for authentication.
 ///
 /// Note: Authorization is enforced via Casbin policies server-side.
@@ -127,6 +167,15 @@ pub struct Claims {
     /// envelope/JWT so it is itself PQ-forgery-resistant.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub clearance: Option<crate::auth::mac::SecurityLabel>,
+
+    /// **Delegation actor (RFC 8693 §4.1 `act`, #680/#681).** Present iff this is
+    /// a delegated (on-behalf-of) token: [`Self::sub`] is the delegator (source of
+    /// authority), `act` the actor that signs the downstream envelope. Drives the
+    /// two-principal MAC derivation (#681): clearance = `meet(sub, act)`, assurance
+    /// from the verified signer (the actor). See [`ActClaim`]. JWT-carried only
+    /// (mirrors [`Self::clearance`]); reconstructed `None` on the Cap'n Proto path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub act: Option<ActClaim>,
 }
 
 // Custom Debug impl — NEVER log the bearer token
@@ -142,6 +191,7 @@ impl std::fmt::Debug for Claims {
             .field("cnf", &self.cnf)
             .field("token", &self.token.as_ref().map(|_| "[REDACTED]"))
             .field("clearance", &self.clearance)
+            .field("act", &self.act)
             .finish()
     }
 }
@@ -227,6 +277,9 @@ impl FromCapnp for Claims {
             // The envelope Claims are a distinct carrier from the JWT Claims; the
             // clearance is read off the verified JWT by the MAC PDP.
             clearance: None,
+            // `act` (RFC 8693 delegation) likewise rides the JWT, not this
+            // envelope surface; reconstructed None here (#680/#681).
+            act: None,
         })
     }
 }
@@ -244,6 +297,7 @@ impl Claims {
             cnf: None,
             token: None,
             clearance: None,
+            act: None,
         }
     }
 
@@ -313,6 +367,16 @@ impl Claims {
     /// derived from the verified key material at enforcement time.
     pub fn with_clearance(mut self, clearance: crate::auth::mac::SecurityLabel) -> Self {
         self.clearance = Some(clearance);
+        self
+    }
+
+    /// Set the RFC 8693 delegation actor (`act`, #680/#681). Marks this as a
+    /// delegated (on-behalf-of) token: [`Self::sub`] stays the delegator; `actor`
+    /// is the principal that will sign the downstream envelope. The MAC PDP
+    /// derives clearance as `meet(sub, act)` and assurance from the verified
+    /// signer. See [`ActClaim`].
+    pub fn with_act(mut self, actor: ActClaim) -> Self {
+        self.act = Some(actor);
         self
     }
 
@@ -404,6 +468,49 @@ impl crate::auth::mac::SubjectContextClaims for Claims {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_act_claim_serde_roundtrip_and_default_none() {
+        // Non-delegated token: `act` absent, and (skip_serializing_if) omitted
+        // from the JSON entirely — no empty `act` on the wire.
+        let plain = Claims::new("alice".to_owned(), 1000, 2000);
+        assert!(plain.act.is_none());
+        let json = serde_json::to_string(&plain).unwrap();
+        assert!(!json.contains("\"act\""), "plain token must not carry act: {json}");
+
+        // Delegated token: sub = delegator (user), act = actor (service:mcp),
+        // with a nested hop to exercise RFC 8693 §4.1 multi-hop.
+        let actor = ActClaim {
+            sub: "service:mcp".to_owned(),
+            clearance: None,
+            act: Some(Box::new(ActClaim {
+                sub: "service:gateway".to_owned(),
+                clearance: None,
+                act: None,
+            })),
+        };
+        let delegated = Claims::new("alice".to_owned(), 1000, 2000).with_act(actor.clone());
+        let json = serde_json::to_string(&delegated).unwrap();
+        let back: Claims = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.sub, "alice", "sub stays the delegator");
+        assert_eq!(back.act, Some(actor), "act round-trips including the nested hop");
+        assert_eq!(
+            back.act.as_ref().unwrap().act.as_ref().unwrap().sub,
+            "service:gateway"
+        );
+    }
+
+    #[test]
+    fn test_debug_shows_act_but_redacts_token() {
+        let claims = Claims::new("alice".to_owned(), 1000, 2000).with_act(ActClaim {
+            sub: "service:mcp".to_owned(),
+            clearance: None,
+            act: None,
+        });
+        let dbg = format!("{claims:?}");
+        assert!(dbg.contains("service:mcp"), "act is not secret, must be visible");
+        assert!(dbg.contains("act:"));
+    }
 
     #[test]
     fn test_claims_new() {

--- a/crates/hyprstream-rpc/src/auth/claims.rs
+++ b/crates/hyprstream-rpc/src/auth/claims.rs
@@ -176,6 +176,20 @@ pub struct Claims {
     /// (mirrors [`Self::clearance`]); reconstructed `None` on the Cap'n Proto path.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub act: Option<ActClaim>,
+
+    /// **Attenuated capability subset (ZSP, Fu1/#677, `TODO(#572-scope-claim)`).**
+    /// The least-authority capability the minted token actually encodes, in
+    /// `ability@resource` form. ZSP mints the *subset* that covers the request,
+    /// never the whole grant — this claim puts that subset **on the wire** so the
+    /// downstream PEP (S2) enforces the minted authority (and a refresh can only
+    /// re-grant this subset, never widen). Distinct from Casbin scopes (which are
+    /// NOT in JWTs): this is the MAC/UCAN capability the S6 exchange authorized.
+    ///
+    /// `None` ⇒ not a grant-minted token (ordinary auth token). JWT-carried only
+    /// (mirrors [`Self::clearance`]/[`Self::act`]); reconstructed `None` on the
+    /// Cap'n Proto path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cap: Option<String>,
 }
 
 // Custom Debug impl — NEVER log the bearer token
@@ -192,6 +206,7 @@ impl std::fmt::Debug for Claims {
             .field("token", &self.token.as_ref().map(|_| "[REDACTED]"))
             .field("clearance", &self.clearance)
             .field("act", &self.act)
+            .field("cap", &self.cap)
             .finish()
     }
 }
@@ -280,6 +295,8 @@ impl FromCapnp for Claims {
             // `act` (RFC 8693 delegation) likewise rides the JWT, not this
             // envelope surface; reconstructed None here (#680/#681).
             act: None,
+            // `cap` (attenuated capability subset) is JWT-carried too (Fu1/#677).
+            cap: None,
         })
     }
 }
@@ -298,6 +315,7 @@ impl Claims {
             token: None,
             clearance: None,
             act: None,
+            cap: None,
         }
     }
 
@@ -377,6 +395,13 @@ impl Claims {
     /// signer. See [`ActClaim`].
     pub fn with_act(mut self, actor: ActClaim) -> Self {
         self.act = Some(actor);
+        self
+    }
+
+    /// Set the attenuated capability subset (`cap`, ZSP Fu1/#677) the minted
+    /// token encodes, in `ability@resource` form. See [`Self::cap`].
+    pub fn with_cap(mut self, cap: String) -> Self {
+        self.cap = Some(cap);
         self
     }
 
@@ -489,11 +514,19 @@ mod tests {
                 act: None,
             })),
         };
-        let delegated = Claims::new("alice".to_owned(), 1000, 2000).with_act(actor.clone());
+        let delegated = Claims::new("alice".to_owned(), 1000, 2000)
+            .with_act(actor.clone())
+            .with_cap("infer@mac://model/qwen-7b".to_owned());
         let json = serde_json::to_string(&delegated).unwrap();
         let back: Claims = serde_json::from_str(&json).unwrap();
         assert_eq!(back.sub, "alice", "sub stays the delegator");
         assert_eq!(back.act, Some(actor), "act round-trips including the nested hop");
+        assert_eq!(
+            back.cap.as_deref(),
+            Some("infer@mac://model/qwen-7b"),
+            "attenuated capability subset rides the token (Fu1/#677)"
+        );
+        assert!(plain.cap.is_none(), "plain token carries no cap");
         assert_eq!(
             back.act.as_ref().unwrap().act.as_ref().unwrap().sub,
             "service:gateway"

--- a/crates/hyprstream-rpc/src/auth/mac/context.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/context.rs
@@ -141,6 +141,51 @@ impl SecurityContext {
     pub fn compartments(&self) -> CompartmentSet {
         self.clearance.compartments
     }
+
+    /// **#681 two-principal composition for a delegated call.** THE single shared
+    /// derivation — both the S6 token-exchange gate (#680) and the downstream PDP
+    /// call this; it is never re-implemented (a parallel impl would drift into
+    /// the exact escalation hole this closes).
+    ///
+    /// - **Level + compartments = meet(delegator, actor)** (`min` level,
+    ///   compartment intersection). The effective clearance dominates an object
+    ///   only if *both* the authority source (`delegator` = UCAN chain root) and
+    ///   the acting receiver (`actor` = the presenter/MCP that signs the
+    ///   downstream envelope and receives the bytes) dominate it. Never either
+    ///   alone.
+    /// - **Assurance = the actor's** (the *signer's* verified key material,
+    ///   already clamped into `actor`'s context per #548). The actor signs the
+    ///   downstream envelope and receives the object bytes, so the crypto floor
+    ///   that governs the read is the actor's — not the delegator's (who
+    ///   authorizes but never receives). A `Classical` actor thus cannot reach a
+    ///   `PqHybrid`-labeled object even if the delegated clearance claims
+    ///   `PqHybrid`.
+    ///
+    /// meet(root, actor) is *sufficient*: intermediate delegation hops carry
+    /// authority, not data (bounded by UCAN capability attenuation), and never
+    /// receive the object bytes — so their clearances do not enter the read floor.
+    #[must_use]
+    pub fn delegated_meet(delegator: &SecurityContext, actor: &SecurityContext) -> SecurityContext {
+        SecurityContext {
+            clearance: SecurityLabel::new(
+                delegator.level().min(actor.level()),
+                actor.assurance(), // signer-derived; NOT met with the delegator
+                delegator.compartments().intersect(actor.compartments()),
+            ),
+        }
+    }
+
+    /// Fail-closed wrapper over [`Self::delegated_meet`]: `None` (→ deny) if
+    /// *either* principal's clearance is unresolved (#681 AC — no default
+    /// clearance for a missing principal). This is the entry point the exchange
+    /// gate and the PDP both call.
+    #[must_use]
+    pub fn delegated(
+        delegator: Option<&SecurityContext>,
+        actor: Option<&SecurityContext>,
+    ) -> Option<SecurityContext> {
+        Some(Self::delegated_meet(delegator?, actor?))
+    }
 }
 
 /// **Seam** for carrying a subject clearance on the verified claims/envelope.
@@ -182,6 +227,52 @@ mod tests {
     /// these tests work directly in bits).
     fn comps(bits: &[u32]) -> CompartmentSet {
         bits.iter().copied().collect()
+    }
+
+    // ── #681 two-principal delegated meet ──────────────────────────────────
+
+    #[test]
+    fn delegated_meet_is_min_level_and_compartment_intersection_neither_alone() {
+        // delegator: Secret / {0,1} ; actor: Confidential / {1,2}. Both PqHybrid.
+        let delegator =
+            SecurityContext::new(Level::Secret, comps(&[0, 1]), VerifiedKeyMaterial::PqHybrid);
+        let actor =
+            SecurityContext::new(Level::Confidential, comps(&[1, 2]), VerifiedKeyMaterial::PqHybrid);
+        let meet = SecurityContext::delegated_meet(&delegator, &actor);
+
+        assert_eq!(meet.level(), Level::Confidential, "min level");
+        assert_eq!(meet.compartments(), comps(&[1]), "compartment intersection");
+        // Neither principal alone equals the meet — the composition is strictly
+        // bounded by both (this is the escalation the single-principal path had).
+        assert_ne!(meet.level(), delegator.level());
+        assert_ne!(meet.compartments(), actor.compartments());
+    }
+
+    #[test]
+    fn delegated_assurance_is_the_signer_actor_classical_actor_cannot_reach_pqhybrid() {
+        // Delegated clearance would like PqHybrid (delegator is PqHybrid), but the
+        // ACTOR signs the downstream envelope with a Classical key. Assurance must
+        // follow the actor → the delegated context cannot reach a PqHybrid object.
+        let delegator =
+            SecurityContext::new(Level::Secret, comps(&[]), VerifiedKeyMaterial::PqHybrid);
+        let actor = SecurityContext::new(Level::Secret, comps(&[]), VerifiedKeyMaterial::Classical);
+        let meet = SecurityContext::delegated_meet(&delegator, &actor);
+
+        assert_eq!(meet.assurance(), Assurance::Classical, "assurance is the actor's (signer)");
+        let pqhybrid_object = SecurityLabel::new(Level::Secret, Assurance::PqHybrid, comps(&[]));
+        assert!(
+            !meet.can_access(&pqhybrid_object),
+            "Classical actor must NOT reach a PqHybrid object even with a PqHybrid delegator"
+        );
+    }
+
+    #[test]
+    fn delegated_fails_closed_if_either_principal_unresolved() {
+        let ctx = SecurityContext::new(Level::Secret, comps(&[0]), VerifiedKeyMaterial::PqHybrid);
+        assert!(SecurityContext::delegated(None, Some(&ctx)).is_none(), "missing delegator ⇒ deny");
+        assert!(SecurityContext::delegated(Some(&ctx), None).is_none(), "missing actor ⇒ deny");
+        assert!(SecurityContext::delegated(None, None).is_none());
+        assert!(SecurityContext::delegated(Some(&ctx), Some(&ctx)).is_some());
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/auth/mac/label.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/label.rs
@@ -218,6 +218,16 @@ impl CompartmentSet {
         CompartmentSet(self.0 | other.0)
     }
 
+    /// Set **intersection** (the lattice *meet* on this axis) — the dual of
+    /// [`Self::union`]. Used to compose the need-to-know of two principals
+    /// (#681 delegated meet): the result is cleared into a compartment only if
+    /// *both* inputs are, so a delegated call never widens need-to-know past
+    /// either principal.
+    #[inline]
+    pub const fn intersect(self, other: CompartmentSet) -> CompartmentSet {
+        CompartmentSet(self.0 & other.0)
+    }
+
     /// Does this set contain compartment bit `index`?
     #[inline]
     pub const fn contains(self, index: u32) -> bool {

--- a/crates/hyprstream-rpc/src/auth/ucan/token.rs
+++ b/crates/hyprstream-rpc/src/auth/ucan/token.rs
@@ -183,6 +183,35 @@ impl Ucan {
         &self.payload.capabilities
     }
 
+    /// The **root** of this delegation chain — the self-issued authority at the
+    /// top, the entry with an empty `proofs` vector. For a delegated grant this
+    /// is the resource-owning delegator; its [`issuer`] is the source of
+    /// authority (#680/#681: the `sub`/delegator principal, distinct from the
+    /// leaf [`audience`] = the actor/presenter).
+    ///
+    /// M1 walks the single-delegator-per-link chain via `proofs[0]` (the
+    /// linkage `super::chain::validate` also enforces). Depth is bounded by
+    /// [`super::chain::MAX_PROOF_DEPTH`] at decode, so this cannot runaway.
+    ///
+    /// [`issuer`]: Self::issuer
+    /// [`audience`]: Self::audience
+    #[must_use]
+    pub fn root(&self) -> &Ucan {
+        let mut cur = self;
+        while let Some(delegator) = cur.proofs.first() {
+            cur = delegator;
+        }
+        cur
+    }
+
+    /// The DID of the delegation-chain root's issuer — the ultimate source of
+    /// authority (the resource-owning delegator). Convenience over
+    /// [`Self::root`]`().issuer()`. See [`Self::root`].
+    #[must_use]
+    pub fn root_issuer(&self) -> &Did {
+        self.root().issuer()
+    }
+
     /// **Structural** validation independent of crypto/attenuation: a UCAN is
     /// structurally well-formed iff both its DIDs resolve to valid `did:key`
     /// Ed25519 identities and (if present) `not_before <= expiration`. Each
@@ -544,6 +573,34 @@ mod tests {
             u.verify_signatures(&store),
             Err(UcanError::BadSignature(_))
         ));
+    }
+
+    #[test]
+    fn root_walks_to_the_self_issued_delegator() {
+        // user (root) ⟶ gateway ⟶ mcp. The delegator (source of authority) is
+        // the root's issuer (user); the actor/presenter is the leaf audience (mcp).
+        let user = TestIdentity::generate();
+        let gateway = TestIdentity::generate();
+        let mcp = TestIdentity::generate();
+
+        let root = signed_ucan(&user, &gateway.did(), vec![cap("mac://model/x", "infer")], vec![]);
+        let leaf = signed_ucan(
+            &gateway,
+            &mcp.did(),
+            vec![cap("mac://model/x", "infer")],
+            vec![root.clone()],
+        );
+
+        assert_eq!(leaf.audience(), &mcp.did(), "leaf audience = actor/presenter");
+        assert_eq!(leaf.issuer(), &gateway.did(), "leaf issuer = immediate (intermediate) issuer");
+        assert_eq!(
+            leaf.root_issuer(),
+            &user.did(),
+            "root_issuer = ultimate delegator, NOT the immediate issuer"
+        );
+        assert!(leaf.root().proofs.is_empty(), "root has empty proofs");
+        // A root UCAN is its own root.
+        assert_eq!(root.root_issuer(), &user.did());
     }
 
     #[test]

--- a/crates/hyprstream/src/services/oauth/token_exchange.rs
+++ b/crates/hyprstream/src/services/oauth/token_exchange.rs
@@ -742,9 +742,14 @@ async fn mint_grant_token(
         granted.capability.ability, granted.capability.resource
     );
 
+    // Fu1/#677 (was TODO(#572-scope-claim)): carry the attenuated capability
+    // subset in the `cap` claim so the downstream PEP (S2) enforces the minted
+    // least-authority on the wire, and a refresh can only re-grant this subset
+    // — not just log it. The cnf.jkt binding + short ttl remain load-bearing.
     let claims = hyprstream_rpc::auth::Claims::new(sub.clone(), now, expires_at)
         .with_issuer(state.issuer_url.clone())
         .with_audience(granted.audience.clone())
+        .with_cap(scope_str)
         .with_jti();
     // DPoP sender-binding via cnf.jkt (RFC 9449 §6). ZSP: no cnf ⇒ bearer ⇒
     // rejected. We set jkt directly from the verified proof.
@@ -753,12 +758,6 @@ async fn mint_grant_token(
         jwk: None,
         jkt: Some(dpop_jkt.to_owned()),
     });
-
-    // TODO(#572-scope-claim): the capability subset (`scope_str`) needs a
-    //   dedicated claim carrying the attenuated capability so the PEP (S2) can
-    //   enforce the minted subset on refresh. For now it is logged; the cnf.jkt
-    //   binding + short ttl are the load-bearing controls.
-    let _ = scope_str;
 
     // S8 (#574): sign via the hybrid composite (EdDSA + ML-DSA-65) when an
     // ML-DSA-65 key is provisioned; fall back to the policy-selected classical


### PR DESCRIPTION
## Summary
Foundation for the MAC delegation follow-ons **#680** (confused-deputy / RFC 8693 actor_token entry) and **#681** (two-principal SecurityContext). All additive, all unit-tested, and **DORMANT — no behavior change**: nothing calls these yet. The S6 exchange wiring that consumes them lands in a stacked follow-up PR.

Stacked on **#678** (B1/#673) — base retargets to `main` once #678 merges. Do not merge ahead of #678 (#680's exchange re-runs `evaluate_grant`).

## What's here (4 commits)
1. **`act` two-principal carrier** — RFC 8693 `act` claim on `Claims`; `sub`=delegator, `act`=actor that signs the downstream envelope. JWT-only (mirrors `clearance`).
2. **`cap` attenuated subset (Fu1/#677)** — `mint_grant_token` now carries the least-authority capability on the wire instead of discarding `scope_str` (resolves `TODO(#572-scope-claim)`). Promoted to a #680 prerequisite by security review.
3. **`SecurityContext::delegated_meet` (#681, the linchpin)** — THE single shared two-principal derivation both the exchange gate and the PDP call: `meet(delegator, actor)` on level+compartments, assurance from the **signer** (actor). Fail-closed if either principal is unresolved. + `CompartmentSet::intersect`.
4. **UCAN chain-root walk** — `Ucan::root()`/`root_issuer()`: the delegator is the chain root's issuer, not the immediate `grant.issuer()`.

## Security posture (per `2:0.0` ruling)
- Option A (approval-time UCAN ceiling) ratified; the meet is computed **once** and reused (no parallel impl → no drift).
- Assurance follows the signer: a Classical actor can't reach a PqHybrid object even with a PqHybrid delegator (tested).
- Whole path ships **dormant until `#572-object-label`**; direct unit tests are the verification surface (HTTP path denies until object-label, matching the rest of the dormant MAC stack).

## Tests
Carrier round-trips (incl. nested `act`, `cap`); `delegated_meet` — neither principal alone governs, Classical-actor/PqHybrid-object denial, fail-closed on either missing; chain-root walk (user→gateway→mcp). Full `--workspace --all-targets --release -D warnings` clippy gate passes on every commit.

## Follow-up (stacked PR)
Slice B (actor_token entry + delegated mint + WIT verify + anti-borrow) · C (live revocation) · D (per-session grant store) · E (MCP dial-site swaps) · F-rest (PDP wiring + dual-principal audit).

Refs #680 #681 #677 #572. /cc security review (`2:0.0` requested diff review before merge).