### PR TITLE
docs(CLAUDE.md): document native MAC, hybrid PQC, UCAN, 9P crates, commit rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,32 +2,38 @@
 
 **Claude AI Assistant Guide** - Updated Jul 2, 2026
 
+## Big Picture
+
+HyprStream is the runtime for AI that gets smarter the more you use it: a Plan 9-inspired "operating system for agents" where models, inference streams, MCP tools, repositories, and sandboxed apps are all files in one composable, per-process namespace — spanning host, microVM guests, and the browser (Wanix over 9P). Nodes federate by cryptographic identity (atproto `did:web`/`did:key`), not host location, over QUIC/WebTransport or iroh P2P. Self-improvement follows the STEP loop: **Stage → Train → Evaluate → Promote**, every gain a reviewable Git branch of the weights. See `README.md` and https://talks.cyberdione.ai/hyprstream-wanix for the full narrative.
+
 ## Core Philosophy
 
-- **Models are Git repositories** — version-controlled via git2db
+- **Everything is a file** — models, streams, tools, and apps compose in one VFS namespace; capability-scoped by construction
+- **Models are Git repositories** — version-controlled via git2db; promotion = merge, rollback = checkout
 - **Adapters are files** — stored in `model/adapters/` as `.safetensors` (NOT branch-based)
 - **git2db handles all Git operations** — no custom git wrappers, no raw `Repository::open()`
+- **Identity over location** — federation addresses atproto DIDs; transport (QUIC/iroh/UDS/inproc) is pluggable and replaceable
 - **Storage drivers optimize disk** — overlay2 on Linux (~80% savings)
 
 ## Status
 
-**Production**: PyTorch inference (CPU/CUDA/ROCm), git2db model management, file-based LoRA adapters, OpenAI-compatible REST API, UTF-8 streaming
-**Experimental**: XET large file storage (enabled by default), Test-Time Training (TTT) with per-tenant LoRA deltas
+**Production**: PyTorch inference (CPU/CUDA/ROCm), git2db model management, file-based LoRA adapters, OpenAI-compatible REST API, UTF-8 streaming, MoQ streaming/event planes, collaborative TUI
+**Experimental**: XET large file storage (enabled by default), Test-Time Training (TTT) with per-tenant LoRA deltas, federation (off by default; opt in via wizard), Kata microVM workers, atproto PDS
 
 ## Build
 
 ```bash
 export LIBTORCH=/path/to/libtorch
 export LD_LIBRARY_PATH=$LIBTORCH/lib:$LD_LIBRARY_PATH
-cargo build --release                    # Standard (includes xet, gittorrent, systemd, otel)
+cargo build --release                    # Standard (includes xet, gittorrent, systemd, otel, kata-vm)
 cargo build --features cuda --release    # CUDA marker (backend from tch-rs/libtorch)
 cargo build --features bnb --release     # bitsandbytes quantization
 cargo build --features overlayfs --release
-cargo build --no-default-features --features "gittorrent,xet,otel" --release  # No systemd
+cargo build --no-default-features --features "gittorrent,xet,otel" --release  # No systemd/kata
 cargo test --workspace --release
 ```
 
-**Feature flags**: `default = [gittorrent, xet, systemd, otel]`, `cuda` (empty marker), `bnb`, `overlayfs`, `download-libtorch`, `experimental`
+**Feature flags**: `default = [gittorrent, xet, systemd, otel, kata-vm]`, `cuda` (empty marker), `bnb`, `valkey` (Valkey/Redis user+token stores), `overlayfs`, `oci-image` (RAFS ImageFs), `kata-vm` (implies `oci-image`), `download-libtorch`, `experimental`, `pq-hybrid` (NO-OP alias — PQ primitives always compiled, Classical/Hybrid selected at runtime)
 **Backend**: CPU/CUDA/ROCm controlled by tch-rs dependency (fork: github.com/hyprstream/tch-rs branch: hip), NOT cargo features
 
 ## Working Tree & Worktrees (multi-agent safety)
@@ -55,12 +61,12 @@ Multiple agents may share the one checkout at the repo root. That checkout has a
 | `cas-serve` | Content-addressable storage server |
 | `hyprstream-flight` | Arrow Flight SQL server |
 | `hyprstream-metrics` | Metrics (DuckDB/DataFusion) |
-| `hyprstream-rpc` | Cap'n Proto RPC: ZMQ transport, crypto (hybrid PQC, UCAN), signed envelopes, JWT auth |
+| `hyprstream-rpc` | RPC core: Cap'n Proto over pluggable transports (inproc/UDS/QUIC/iroh, ZMTP framing), hybrid-PQC COSE envelopes, JWT/UCAN auth, MoQ streaming |
 | `hyprstream-rpc-derive` | Proc macros: `ToCapnp`, `FromCapnp`, `#[authorize]`, `#[service_factory]`, `generate_rpc_service!` |
 | `hyprstream-rpc-build` | CGR → JSON metadata extraction for macros |
 | `hyprstream-rpc-std` | Standard hyprstream service schemas + generated clients |
 | `hyprstream-util` | Shared generic utility primitives (TTL cache, etc.) |
-| `hyprstream-service` | Pluggable service orchestration (spawner, factory, manager) |
+| `hyprstream-service` | Pluggable service orchestration (spawner, factory, manager, trust store) |
 | `hyprstream-discovery` | Service discovery and endpoint resolution |
 | `hyprstream-workers` | Kata-based worker isolation |
 | `hyprstream-workers-wasmtime` | Embedded wasmtime host — sandboxes untrusted wasm guests behind capability profiles |
@@ -77,7 +83,7 @@ Multiple agents may share the one checkout at the repo root. That checkout has a
 | `chat-core` | Chat orchestration state machine — token parsing, tool call detection, agentic loop |
 | `bitsandbytes-sys` | bitsandbytes FFI bindings |
 
-`hyprstream-tcl` above was renamed **`hyprstream-workers-tcl`**; worker-engine crates are always `hyprstream-workers-{engine}`, never `hyprstream-<lang>` (decided, don't relitigate).
+Worker-engine crates are always `hyprstream-workers-{engine}`, never `hyprstream-<lang>` (decided, don't relitigate; `hyprstream-tcl` was renamed `hyprstream-workers-tcl` under this rule).
 
 ## Key Source Layout (`crates/hyprstream/src/`)
 
@@ -88,17 +94,20 @@ Multiple agents may share the one checkout at the repo root. That checkout has a
 - `api/` — OpenAI compat types, tool calling
 - `server/` — Axum routes (`/v1/models` lists worktrees as `model:branch`), state management
 - `services/` — RPC service implementations + `factories.rs` (inventory-based auto-discovery)
-- `schema/` — Cap'n Proto schemas: `registry.capnp`, `inference.capnp`, `model.capnp`, `policy.capnp`, `worker.capnp`, `mcp.capnp`
+- `mac/` — Native MAC data-plane: TE evaluator, AVC, UCAN→TE compiler, grant exchange, audit (see Native MAC below)
+- `events/` — group-keyed EventService integration (epic #600)
+- `auth/`, `inference/`, `tui/`, `cli/`, `config/`, `archetypes/` — supporting modules
+- `schema/` — app-local Cap'n Proto schemas: `tui.capnp`, `compositor_ipc.capnp` (service schemas live in `hyprstream-rpc-std/schema/`)
 
 ## Services (13 total, registered via `#[service_factory]` in `services/factories.rs`)
 
-**ZMQ RPC** (Cap'n Proto over ZMQ, REQ/REP): registry, model, policy, worker, mcp, discovery, metrics, tui
-**HTTP** (Axum): oai (OpenAI-compat), oauth (OAuth 2.1), flight (Arrow Flight SQL)
-**Proxies** (ZMQ): streams (PULL→XPUB), event (XSUB→XPUB)
+**RPC** (Cap'n Proto request/reply over the pluggable transport layer): registry, model, policy, worker, mcp, discovery, metrics, tui, oauth
+**HTTP surfaces** (Axum, spawned by their factories): oai (OpenAI-compat), oauth (OAuth 2.1 endpoints alongside its RPC schema), mcp (HTTP/SSE for external MCP clients), flight (Arrow Flight SQL)
+**MoQ planes** (process-global origins + a UDS moq server for cross-process; NO proxy threads): streams (`MoqStreamOrigin`, #138), event (`MoqEventOrigin`, #167 — replaced the old ZMQ XPUB/XSUB proxies)
 
-**Security**: CURVE transport encryption → Ed25519 signed envelopes → Casbin + JWT authorization
-**Spawner modes**: Tokio (async), Thread (!Send types like tch-rs), Subprocess (systemd/standalone)
-**Endpoints**: Inproc (daemon, zero-copy) or IPC (systemd socket activation)
+**Security**: transport channel auth (TLS 1.3 on QUIC, UDS peer credentials) → hybrid-PQC COSE signed envelopes → Casbin + JWT/UCAN authorization
+**Spawner modes** (`hyprstream-service`): Tokio (async), Thread (!Send types like tch-rs), Subprocess (systemd/standalone)
+**Endpoints**: Inproc (daemon, zero-copy), IPC/UDS (incl. systemd socket activation via SystemdFd), QUIC (cross-host), Iroh (P2P/federation)
 
 ## Key Patterns
 
@@ -108,6 +117,7 @@ Multiple agents may share the one checkout at the repo root. That checkout has a
 **Generation** — `engine.generate(req)?` returns `TextStream` (futures::Stream), handles UTF-8 internally via `DecodeStream`
 **TTT** — `TestTimeTrainer::adapt_tenant()` for inference-time adaptation, `DeltaPool` for per-tenant LRU management
 **XET/LFS** — Filter initialized in main.rs via `git2db::xet_filter::initialize()`, auto-smudges on git ops; fallback: `git2db::LfsStorage`
+**Streaming & events** — MoQ (moq-lite) everywhere: token streams via `moq_stream.rs` (`StreamPublisher`, QoS via `StreamOpt`), events via `moq_event.rs` (group-keyed EventService, epic #600). There is no ZMQ pub/sub anywhere.
 **Hybrid PQC signing** — security-critical artifacts (UCAN grants/approvals, compiled MAC policy, audit records, minted tokens) sign via `hyprstream_rpc::crypto::cose_sign::{sign_composite, verify_composite}` (EdDSA + ML-DSA-65 nested COSE). Never Ed25519-only for these paths. `CryptoPolicy::{Hybrid, Classical}` picks the enforced suite; under `Hybrid`, a missing PQ key **fails closed** at sign time — it never silently downgrades to classical.
 **UCAN capability delegation** — `hyprstream_rpc::auth::ucan` (`token.rs`/`chain.rs`/`capability.rs`/`approval.rs`) is the delegation-chain primitive underlying the MAC grant path: a `Ucan` carries `Capability` triples (resource/ability/caveats), `chain::validate` walks/attenuates a delegation chain, `Capability::authorizes`/`covers` do directional wildcard matching. UCAN *authors* capability; it never enforces on its own — see Native MAC below.
 **9P/VFS surface — three distinct crates, don't conflate**: `hyprstream-vfs` (the Plan 9-inspired in-process namespace multiplexer — mounts, binds, the `Mount` trait), `hyprstream-9p` (the 9P2000.L wire-protocol codec + translator bridging 9P ⇄ hyprstream RPC), `hyprstream-vfs-server` (vhost-user-fs server exposing a VFS `Namespace` to a Cloud Hypervisor guest, #362).
@@ -122,13 +132,24 @@ Multiple agents may share the one checkout at the repo root. That checkout has a
                                           generate_rpc_service! macro → typed clients + handlers + dispatch
 ```
 
+### Transport Layer (`hyprstream-rpc/src/transport/`)
+
+ZMQ/ZeroMQ is **gone**. RPC uses ZMTP 3.1 *framing* (the wire serialization only — no libzmq) over pluggable transport backends behind `TransportConfig`:
+
+- **Inproc** — in-process channels (fastest, zero-copy)
+- **IPC/UDS** — Unix domain sockets (same-host, peer-credential auth), incl. **SystemdFd** socket activation
+- **QUIC** — quinn, TLS 1.3 (`QuicServerAuth`: `web_pki()` / `pinned(hashes)` / both)
+- **Iroh** — P2P with Ed25519 endpoint binding (NAT traversal, federation)
+
+`dial.rs` lazy-loads the backend chain (inproc → quinn → iroh); `resolver.rs` + `hyprstream-discovery` resolve federated peers via atproto DIDs. Transport auth is channel-level only — identity and trust live in the signed envelope, which survives forwarding across any transport.
+
 ### Security Model (3 layers)
 
-1. **Transport**: CURVE encryption (Curve25519) on TCP sockets via `CurveConfig`
-2. **Application**: Ed25519 signed `SignedEnvelope` — survives message forwarding
-3. **Authorization**: Casbin policy + JWT scopes (`action:resource:identifier`)
+1. **Transport**: TLS 1.3 (QUIC) or UDS peer credentials — confidentiality + anti-MITM, NOT the trust root
+2. **Application**: `SignedEnvelope` with COSE composite signature (EdDSA + ML-DSA-65, detached); optional ML-KEM-768 hybrid encryption; verified against the peer's key material
+3. **Authorization**: Casbin policy + JWT scopes (`action:resource:identifier`) + UCAN delegation chains; native MAC as the mandatory floor (below)
 
-**Envelope flow**: Client builds `RequestEnvelope` → signs with Ed25519 → `SignedEnvelope` → server verifies → extracts `EnvelopeContext` with verified identity → handler checks authorization
+**Envelope flow**: Client builds `RequestEnvelope` → signs (COSE composite per `CryptoPolicy`) → `SignedEnvelope` → server verifies → extracts `EnvelopeContext` with verified identity → handler checks authorization
 
 ### Derive Macros (`hyprstream-rpc-derive`)
 
@@ -142,23 +163,26 @@ Multiple agents may share the one checkout at the repo root. That checkout has a
 
 ### Schema Locations
 
-- `crates/hyprstream-rpc/schema/` — `common.capnp` (envelopes, identity, claims), `streaming.capnp`, `events.capnp`, `annotations.capnp`
-- `crates/hyprstream/schema/` — `registry.capnp`, `inference.capnp`, `model.capnp`, `policy.capnp`, `worker.capnp`, `mcp.capnp`
+- `crates/hyprstream-rpc/schema/` — `common.capnp` (envelopes, identity, claims), `streaming.capnp`, `events.capnp`, `annotations.capnp`, `nine.capnp` (9P bridge), `optional.capnp`
+- `crates/hyprstream-rpc-std/schema/` — `registry.capnp`, `model.capnp`, `policy.capnp`, `mcp.capnp`, `oauth.capnp`, `inference.capnp`, `metrics.capnp`, `chat_core.capnp`, `service_events.capnp`
+- `crates/hyprstream/schema/` — `tui.capnp`, `compositor_ipc.capnp`
+- `crates/hyprstream-workers/schema/` — `worker.capnp`
 
 ### Key RPC Types (`crates/hyprstream-rpc/src/`)
 
-- `service/zmq.rs` — `ZmqService` trait, `RequestLoop`, `EnvelopeContext`
-- `envelope.rs` — `SignedEnvelope`, `RequestIdentity` (Local/ApiToken/Peer/Anonymous)
-- `crypto/mod.rs` — Ed25519 signing, Ristretto255 ECDH, `ChainedStreamHmac`
-- `streaming.rs` — `StreamPublisher`, `ResponseStream` (PUSH/PULL→XPUB, prevents message loss)
-- `auth/` — JWT `Claims`, `Scope`, `ScopeRegistry`
+- `service/svc.rs` — `RequestService` trait (the service abstraction; `ZmqService` is long gone), `EnvelopeContext`
+- `service/spawnable.rs` — `Spawnable` (blanket impl for `RequestService + Send + Sync`; `!Send` types implement directly)
+- `envelope.rs` — `SignedEnvelope` (COSE composite + optional ML-KEM ciphertext), `RequestIdentity` (Local/ApiToken/Peer/Anonymous)
+- `crypto/` — `cose_sign.rs` (composite sign/verify), `pq.rs` (ML-DSA-65, ML-KEM-768), `signing.rs`, `key_exchange.rs`, `group_key.rs`/`event_crypto.rs` (group-keyed event confidentiality)
+- `moq_stream.rs` / `moq_event.rs` / `streaming.rs` — MoQ streaming + event planes, `StreamPublisher`, QoS/relay options
+- `auth/` — JWT `Claims`, `Scope`, `ScopeRegistry`, `ucan/` (delegation), `mac/` (labels/lattice/context), `federation.rs`, `atproto_perimeter.rs`
 
-### Spawner Details
+### Spawner Details (`hyprstream-service`)
 
-- **Tokio mode**: `tokio::task::spawn_blocking()` — async-safe services
+- **Tokio mode**: `tokio::spawn` — async-safe services
 - **Thread mode**: `std::thread` + single-threaded tokio runtime — required for `!Send` types (tch-rs tensors)
-- **Subprocess mode**: `ProcessSpawner` — auto-detects systemd (`systemd-run`) or standalone (PID file tracking)
-- **`Spawnable` trait**: blanket impl for all `ZmqService + Send + Sync`; `!Send` types (e.g., inference) implement directly
+- **Subprocess mode**: `ProcessSpawner` — Standalone or Systemd backends (auto-detected; `systemd-run` or PID-file tracking)
+- Service lifecycle, dependency ordering (`depends_on`), and the per-service signing-key **trust store** live in `hyprstream-service::service::{spawner, manager, ordering, trust_store}`
 
 ## Native MAC — Mandatory Access Control (epic #547)
 
@@ -186,15 +210,15 @@ UCAN (grant/delegation source) → Casbin (policy STORE + authoring, string-matc
 
 ## Adding an RPC Method
 
-1. Define in `.capnp` schema (request/response structs + method variant)
+1. Define in the `.capnp` schema (request/response structs + method variant) — service schemas live in `crates/hyprstream-rpc-std/schema/`
 2. `cargo build -p hyprstream` (regenerates CGR metadata)
 3. Implement handler with `#[authorize(action = "...", resource = "...")]`
 4. Client code auto-generated by `generate_rpc_service!`
 
 ## Adding a New Service
 
-1. Implement `ZmqService` (or `Spawnable` for !Send types)
-2. Add `#[service_factory("name", schema = "...")]` fn in `factories.rs`
+1. Implement `RequestService` (or `Spawnable` directly for !Send types)
+2. Add `#[service_factory("name", schema = "...", depends_on = [...])]` fn in `factories.rs`
 3. Auto-discoverable via inventory — `hyprstream service start name --foreground` works
 4. `hyprstream service install` generates systemd units
 
@@ -217,6 +241,7 @@ cargo test -p hyprstream storage::adapter_manager
 
 ## Removed Code (don't recreate)
 
+- **The entire ZMQ/ZeroMQ stack** — libzmq sockets, CURVE transport encryption, `CurveConfig`, `ZmqService`, the XPUB/XSUB stream/event proxies, the ZMQ `StreamService` (#138 N4, #167). Replaced by ZMTP *framing* over pluggable transports (inproc/UDS/QUIC/iroh) + MoQ streaming/event planes. Do not reintroduce a zmq dependency or describe the RPC layer as "ZMQ".
 - `api/adapter_storage.rs` — branch-based adapters (Oct 2025)
 - `git/branch_manager.rs` — custom git wrapper (Oct 2025)
 - `storage/sharing.rs` — ModelSharing (P2P belongs at transport layer)
@@ -238,7 +263,7 @@ cargo clippy --all-targets --all-features
 
 ## Docs
 
-See: `README.md`, `DEVELOP.md`, `CONTRIBUTING.md`, `crates/git2db/CLAUDE.md`, `docs/` (quickstart, tool calling, KV cache, RPC, workers, streaming, events, cryptography)
+See: `README.md`, `DEVELOP.md`, `CONTRIBUTING.md`, `crates/git2db/CLAUDE.md`, `docs/` (quickstart, vfs, workers-architecture, rpc-architecture, cryptography-architecture, eventservice-architecture, service-runtime-architecture, streaming-service-architecture, tool calling, KV cache), and the architecture talk: https://talks.cyberdione.ai/hyprstream-wanix
 
 ## Licensing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # hyprstream Development Guide
 
-**Claude AI Assistant Guide** - Updated Feb 22, 2026
+**Claude AI Assistant Guide** - Updated Jul 2, 2026
 
 ## Core Philosophy
 
@@ -40,25 +40,44 @@ Multiple agents may share the one checkout at the repo root. That checkout has a
 - **Shared checkout stays neutral:** leave the root checkout on `main`; use it only for read-only ops (`fetch`, `log`, `show`, `ls-tree`) and `git worktree add`/`gh` — never for active branch work.
 - **Clean up:** `git worktree remove <path>` when done; `git worktree prune` for stale entries.
 
+### Commit authorship (GitHub ruleset, enforced on `main`)
+
+**Never add a `Co-authored-by: Claude <noreply@anthropic.com>` trailer, or any AI-attribution marker, to a commit message.** A repo ruleset on the default branch rejects commits whose message matches that pattern. Commit as whatever git identity is already configured for the session (do not fabricate or override author identity to route around this or any other rule) and write a plain, human-style commit message — the ruleset is about the trailer text, not about disguising who/what made the change.
+
 ## Crate Map
 
 | Crate | Purpose |
 |-------|---------|
-| `hyprstream` | Main app: runtime, storage, git, training, API, services, CLI (MIT OR AGPL-3.0) |
+| `hyprstream` | Main app: runtime, storage, git, training, API, services, CLI, native MAC (MIT OR AGPL-3.0) |
 | `git2db` | Git repository management library (has own CLAUDE.md) |
 | `git-xet-filter` | XET/LFS large file storage (libgit2 filter) |
 | `gittorrent` | P2P model distribution |
 | `cas-serve` | Content-addressable storage server |
 | `hyprstream-flight` | Arrow Flight SQL server |
 | `hyprstream-metrics` | Metrics (DuckDB/DataFusion) |
-| `hyprstream-rpc` | Cap'n Proto RPC: ZMQ transport, crypto, signed envelopes, JWT auth |
+| `hyprstream-rpc` | Cap'n Proto RPC: ZMQ transport, crypto (hybrid PQC, UCAN), signed envelopes, JWT auth |
 | `hyprstream-rpc-derive` | Proc macros: `ToCapnp`, `FromCapnp`, `#[authorize]`, `#[service_factory]`, `generate_rpc_service!` |
 | `hyprstream-rpc-build` | CGR → JSON metadata extraction for macros |
+| `hyprstream-rpc-std` | Standard hyprstream service schemas + generated clients |
+| `hyprstream-util` | Shared generic utility primitives (TTL cache, etc.) |
+| `hyprstream-service` | Pluggable service orchestration (spawner, factory, manager) |
+| `hyprstream-discovery` | Service discovery and endpoint resolution |
 | `hyprstream-workers` | Kata-based worker isolation |
+| `hyprstream-workers-wasmtime` | Embedded wasmtime host — sandboxes untrusted wasm guests behind capability profiles |
+| `hyprstream-workers-tcl` | Tcl (molt) shell for the hyprstream VFS namespace |
+| `hyprstream-workers-python` | RustPython engine + `/lang/python` 9P shell over the wasmtime sandbox |
 | `hyprstream-containedfs` | Contained filesystem ops |
 | `hyprstream-vfs` | Plan 9-inspired VFS namespace multiplexer |
-| `hyprstream-tcl` | Tcl (molt) shell for VFS namespace |
+| `hyprstream-vfs-server` | vhost-user-fs server exposing a VFS Namespace to a Cloud Hypervisor guest (#362) |
+| `hyprstream-9p` | 9P2000.L codec + server-side translator bridging 9P to hyprstream RPC (Cap'n Proto) |
+| `hyprstream-pds` | atproto PDS record store — DAG-CBOR records, MST, signed commits, CAR proofs (#392) |
+| `hyprstream-tui` | Terminal UI — wizard, dashboards, status |
+| `hyprstream-compositor` | Pure Rust TUI compositor — WASM-compatible chrome state machine |
+| `waxterm` | Run ratatui apps natively and in the browser via WASI |
+| `chat-core` | Chat orchestration state machine — token parsing, tool call detection, agentic loop |
 | `bitsandbytes-sys` | bitsandbytes FFI bindings |
+
+`hyprstream-tcl` above was renamed **`hyprstream-workers-tcl`**; worker-engine crates are always `hyprstream-workers-{engine}`, never `hyprstream-<lang>` (decided, don't relitigate).
 
 ## Key Source Layout (`crates/hyprstream/src/`)
 
@@ -71,9 +90,9 @@ Multiple agents may share the one checkout at the repo root. That checkout has a
 - `services/` — RPC service implementations + `factories.rs` (inventory-based auto-discovery)
 - `schema/` — Cap'n Proto schemas: `registry.capnp`, `inference.capnp`, `model.capnp`, `policy.capnp`, `worker.capnp`, `mcp.capnp`
 
-## Services (10 total, registered via `#[service_factory]` in `services/factories.rs`)
+## Services (13 total, registered via `#[service_factory]` in `services/factories.rs`)
 
-**ZMQ RPC** (Cap'n Proto over ZMQ, REQ/REP): registry, model, policy, worker, mcp
+**ZMQ RPC** (Cap'n Proto over ZMQ, REQ/REP): registry, model, policy, worker, mcp, discovery, metrics, tui
 **HTTP** (Axum): oai (OpenAI-compat), oauth (OAuth 2.1), flight (Arrow Flight SQL)
 **Proxies** (ZMQ): streams (PULL→XPUB), event (XSUB→XPUB)
 
@@ -89,6 +108,9 @@ Multiple agents may share the one checkout at the repo root. That checkout has a
 **Generation** — `engine.generate(req)?` returns `TextStream` (futures::Stream), handles UTF-8 internally via `DecodeStream`
 **TTT** — `TestTimeTrainer::adapt_tenant()` for inference-time adaptation, `DeltaPool` for per-tenant LRU management
 **XET/LFS** — Filter initialized in main.rs via `git2db::xet_filter::initialize()`, auto-smudges on git ops; fallback: `git2db::LfsStorage`
+**Hybrid PQC signing** — security-critical artifacts (UCAN grants/approvals, compiled MAC policy, audit records, minted tokens) sign via `hyprstream_rpc::crypto::cose_sign::{sign_composite, verify_composite}` (EdDSA + ML-DSA-65 nested COSE). Never Ed25519-only for these paths. `CryptoPolicy::{Hybrid, Classical}` picks the enforced suite; under `Hybrid`, a missing PQ key **fails closed** at sign time — it never silently downgrades to classical.
+**UCAN capability delegation** — `hyprstream_rpc::auth::ucan` (`token.rs`/`chain.rs`/`capability.rs`/`approval.rs`) is the delegation-chain primitive underlying the MAC grant path: a `Ucan` carries `Capability` triples (resource/ability/caveats), `chain::validate` walks/attenuates a delegation chain, `Capability::authorizes`/`covers` do directional wildcard matching. UCAN *authors* capability; it never enforces on its own — see Native MAC below.
+**9P/VFS surface — three distinct crates, don't conflate**: `hyprstream-vfs` (the Plan 9-inspired in-process namespace multiplexer — mounts, binds, the `Mount` trait), `hyprstream-9p` (the 9P2000.L wire-protocol codec + translator bridging 9P ⇄ hyprstream RPC), `hyprstream-vfs-server` (vhost-user-fs server exposing a VFS `Namespace` to a Cloud Hypervisor guest, #362).
 
 ## RPC & Security
 
@@ -138,6 +160,30 @@ Multiple agents may share the one checkout at the repo root. That checkout has a
 - **Subprocess mode**: `ProcessSpawner` — auto-detects systemd (`systemd-run`) or standalone (PID file tracking)
 - **`Spawnable` trait**: blanket impl for all `ZmqService + Send + Sync`; `!Send` types (e.g., inference) implement directly
 
+## Native MAC — Mandatory Access Control (epic #547)
+
+`crates/hyprstream/src/mac/` (`label`/`lattice`/`context` live in `hyprstream-rpc/src/auth/mac/`) is a from-scratch **Bell–LaPadula-style MAC layer** for the 9P/VFS data plane — distinct from, and layered underneath, the RPC authorization model above (Casbin/JWT scopes are the **control plane**; MAC is the **mandatory floor** no control-plane grant can bypass).
+
+**Control-plane / data-plane split** (be precise about this when touching MAC code):
+```
+UCAN (grant/delegation source) → Casbin (policy STORE + authoring, string-matcher NEVER on the per-op hot path)
+  → S5 compiler lowers UCAN/Casbin → compiled::SignedPolicy (hybrid-PQC-signed TeMatrix)
+    → loader verifies ONCE at load → te::LatticeTeEvaluator (the PDP) + avc::CachingAvc (the per-op cache, PEP calls this)
+```
+
+**Key modules:**
+- `hyprstream_rpc::auth::mac` — `SecurityLabel` (Level × Assurance × CompartmentSet, `Copy+Ord+Hash`), `Lattice` (versioned compartment vocabulary), `SecurityContext` (clearance derived from verified `Claims` × `VerifiedKeyMaterial` — **never Claims alone**). Dominance is the `can_access` method (Bell–LaPadula framing kept in its rustdoc), not a free trait method.
+- `mac::te` — the type-enforcement PDP: total, default-deny `(subject_ctx, object_label, action) → Decision` over the compiled matrix AND the independent lattice floor.
+- `mac::avc` — the Access Vector Cache the PEP calls per op (sub-µs hits, no Casbin/signature/lattice walk on a hit).
+- `mac::compiler` + `mac::permission_map` — the UCAN→TE compiler. `PermissionMap` is the S3-scope↔TE-rule vocabulary seam; `ScopePermissionMap` (`permission_map.rs`) is the production impl, made **injective + exact by construction** (wildcards expand at compile time over a closed/sorted registry) so `granted_access` is trivially the most-permissive access — no join/LUB logic that could mask an escalation. `check_no_escalation` verifies the emitted matrix against the independent grant, never by re-running the forward map.
+- `mac::exchange` — S6 runtime grant path (ZSP: zero standing privilege): a presented UCAN subset-grant → short-ttl, sender-bound (DPoP) OAuth token, re-evaluated on every refresh, never minting more than the requested subset.
+- `mac::audit` — S7 tamper-evident audit: `WalAuditStore` is an append-only, hash-chained (`prev_hash`), signed-checkpoint-anchored journal; `AuditedAvc` wraps any AVC so a decision that cannot be durably audited is downgraded to Deny (fail-closed), never silently permitted.
+- `mac::compiled` — signed policy distribution (hybrid-PQC COSE), verified once at load.
+
+**Naming (don't relitigate):** `ceiling`→`grant`, `dominates`→`can_access`, `witness`→`granted_access`, `rules_for`→`permissions_for` — plain MAC/RBAC vocabulary, not academic/poetic terms.
+
+**Current status (check before assuming otherwise):** the MAC library is real and well-tested, but **enforcement is not active in production as of this writing** — the PDP has no wired-in PEP caller, the S6 grant path's HTTP dispatch still fails closed pending resolver/object-label wiring, and the audit store needs explicit startup construction. Everything fails closed (nothing is exploitable), but do not assume MAC is "live" — check the current wiring state (`services::oauth`, service factories) before relying on it protecting anything at runtime.
+
 ## Adding an RPC Method
 
 1. Define in `.capnp` schema (request/response structs + method variant)
@@ -176,6 +222,7 @@ cargo test -p hyprstream storage::adapter_manager
 - `storage/sharing.rs` — ModelSharing (P2P belongs at transport layer)
 - `storage/xet_native.rs` — consolidated into git2db/git-xet-filter
 - `training/lora_trainer.rs` — replaced by TTT system
+- `mac/compiler.rs`'s `seam.rs` (`BundleEmitter`/`FaithfulnessCheck`/`ActionVocabulary` traits) and its `smt` no-op module — deleted in the S5 simplification (June 2026): over-engineered/academic naming collapsed to plain free functions (`compile`/`check_no_escalation`/`authorize`). Don't recreate trait-heavy ceremony here; the deferred SMT proof is a `// TODO(#571)` marker, not a stub module.
 
 ## Quick Commands
 


### PR DESCRIPTION
CLAUDE.md hasn't been updated since Feb 22, while the repo went through significant rearchitecting: the native MAC epic (#547 — S1 through S8, plus the B1/B2/B3 + #676 fail-closed hardening merged today), hybrid-PQC signing conventions, the UCAN capability-delegation layer, and 14 new/renamed workspace crates — none of it reflected in the guide.

## What changed

- **Crate map** — added all missing workspace members (`hyprstream-9p`, `hyprstream-pds`, `hyprstream-tui`, `hyprstream-workers-{wasmtime,tcl,python}`, `hyprstream-vfs-server`, `hyprstream-rpc-std`, `hyprstream-util`/`-service`/`-discovery`, `hyprstream-compositor`, `waxterm`, `chat-core`) with descriptions; noted the `hyprstream-tcl` → `hyprstream-workers-tcl` rename and the settled worker-engine naming convention.
- **Services count** corrected 10 → 13 (discovery/metrics/tui `service_factory` registrations existed but weren't reflected).
- **New "Native MAC" section** — the control-plane/data-plane split, the module map (`label`/`lattice`/`context`, `te`, `avc`, `compiler`/`permission_map`, `exchange`, `audit`, `compiled`), the settled naming (`ceiling`→`grant`, `dominates`→`can_access`, `witness`→`granted_access`), and an explicit **"enforcement is not active in production"** status note — this is a real mistake I made and had corrected by an independent audit earlier today; documenting it now so a future session doesn't repeat it.
- **Key Patterns** — hybrid PQC signing convention (`sign_composite`/`verify_composite`, `CryptoPolicy` fail-closed under Hybrid), UCAN capability delegation, and a note distinguishing the three 9P/VFS crates (easy to conflate: `hyprstream-vfs` the namespace multiplexer, `hyprstream-9p` the wire codec, `hyprstream-vfs-server` the vhost-user-fs bridge).
- **Removed Code** — the S5 simplification's deleted `seam.rs`/`smt` scaffolding, so it isn't recreated.
- **New "Commit authorship" subsection** — the repo's GitHub ruleset blocks any commit containing a Claude co-authorship trailer; documented plainly rather than left as something learned only by hitting the rule.

Docs-only change; no code touched.


---

## Second commit: purge the stale ZMQ-era architecture (major-issue fixup)

Review flagged that the first commit updated the guide *around* a description of the RPC layer that is no longer true at all — the doc still said "Cap'n Proto over ZMQ, REQ/REP", "CURVE transport encryption", "PULL→XPUB / XSUB→XPUB proxies", and `ZmqService`. Verified against the code and corrected:

- **Transport** — new section: ZMTP 3.1 *framing* (no libzmq) over pluggable backends behind `TransportConfig` — inproc, UDS/IPC (+ SystemdFd socket activation), QUIC (quinn, TLS 1.3, `QuicServerAuth`), iroh P2P; `dial.rs` lazy backend chain, DID-based resolution via `hyprstream-discovery`.
- **Streaming/events** — the `streams`/`event` services are MoQ (moq-lite) process-global origins (`MoqStreamOrigin` #138, `MoqEventOrigin` #167), not ZMQ proxies; group-keyed EventService (epic #600) noted.
- **Security model** — layer 1 is TLS 1.3 / UDS peer creds (CURVE is gone); layer 2 is the COSE composite hybrid envelope (EdDSA + ML-DSA-65, optional ML-KEM-768), matching the README's PQ claims; layer 3 adds UCAN + the MAC floor.
- **Key RPC types** — `service/svc.rs` `RequestService` (ZmqService no longer exists), `spawnable.rs`, corrected crypto/auth/moq module paths; spawner/manager/trust-store moved to `hyprstream-service`.
- **Schema locations** — service schemas now in `hyprstream-rpc-std/schema/` (incl. oauth/inference/metrics/chat_core), `worker.capnp` in `hyprstream-workers/schema/`, app-local `tui`/`compositor_ipc`.
- **Alignment with README + the [hyprstream-wanix talk](https://talks.cyberdione.ai/hyprstream-wanix)** — new "Big Picture" intro (everything-is-a-file namespace, Wanix over 9P, STEP loop, identity-over-location federation), refreshed Core Philosophy/Status, current feature flags (`kata-vm` in default, `valkey`, `oci-image`, `pq-hybrid` no-op alias).
- **Removed Code** — the entire ZMQ/ZeroMQ stack recorded so it isn't reintroduced or re-documented.

Still docs-only; every claim checked against the current source (factories.rs, transport/, envelope.rs, Cargo.toml features).
