### PR TITLE
fix(mac B2 #674): don't install an audit sink that can't sign

### DIFF
--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -543,30 +543,41 @@ impl Spawnable for OAuthService {
                     audit_pq_key,
                     crypto_policy,
                 );
+                // Fail-closed the SAME way as "store failed to open": a signer
+                // that can't sign under the enforced policy is not a usable
+                // audit sink. Do NOT install it — installing it anyway would
+                // let every real request silently fail two audit-write
+                // attempts deep (mint's Permit downgrade, then the best-effort
+                // fallback deny record, both via this same broken signer) with
+                // only this one startup log line as any indication, instead of
+                // the immediate, obvious "audit trail is not configured" error
+                // the grant path already gives when `audit_sink` is `None`.
                 if !signer.can_sign() {
                     tracing::error!(
                         "MAC audit signer cannot sign under the enforced Hybrid crypto \
                          policy (no ML-DSA-65 key provisioned) — the S6 grant path will \
                          fail closed (deny) on every request until a key is provisioned"
                     );
-                }
-                match crate::mac::audit::WalAuditStore::open(
-                    credentials_dir.join("mac-audit"),
-                    signer,
-                ) {
-                    Ok(store) => {
-                        info!("MAC grant-path audit store opened (WAL, hash-chained, checkpointed)");
-                        Some(Arc::new(store) as Arc<dyn crate::mac::audit::AuditSink>)
-                    }
-                    Err(e) => {
-                        // Fail-closed by omission: `audit_sink` stays `None`, and
-                        // the grant path denies every request rather than mint
-                        // unaudited tokens (see `exchange_ucan_grant`).
-                        tracing::error!(
-                            "MAC grant-path audit store failed to open — the S6 grant \
-                             path will fail closed (deny) on every request: {e:?}"
-                        );
-                        None
+                    None
+                } else {
+                    match crate::mac::audit::WalAuditStore::open(
+                        credentials_dir.join("mac-audit"),
+                        signer,
+                    ) {
+                        Ok(store) => {
+                            info!("MAC grant-path audit store opened (WAL, hash-chained, checkpointed)");
+                            Some(Arc::new(store) as Arc<dyn crate::mac::audit::AuditSink>)
+                        }
+                        Err(e) => {
+                            // Fail-closed by omission: `audit_sink` stays `None`, and
+                            // the grant path denies every request rather than mint
+                            // unaudited tokens (see `exchange_ucan_grant`).
+                            tracing::error!(
+                                "MAC grant-path audit store failed to open — the S6 grant \
+                                 path will fail closed (deny) on every request: {e:?}"
+                            );
+                            None
+                        }
                     }
                 }
             };


### PR DESCRIPTION
Small standalone follow-up to #686 (B2/#674, merged) — the fix was originally pushed to #686's branch but raced with the manual merge (landed right around/after `28c76ad7f` was merged as `8f3925472`), so it never made it into main. Opening it separately rather than touching an already-merged PR.

## The gap
In the `oauth` service factory, constructing the S6 grant-path audit sink: under a Hybrid crypto policy with no ML-DSA-65 key provisioned, `OwnedCoseAuditSigner::can_sign()` correctly reports `false` — but the factory logged one startup error and **installed the non-signing signer into the audit store anyway**.

Every real grant decision would then silently fail two audit-write attempts deep (the mint path's Permit-downgrade write, then the best-effort fallback deny-record write — both via the same signer that can never sign), with only that one easy-to-miss startup log line as any indication, instead of the immediate, obvious "audit trail is not configured" 500 the grant path already gives when `audit_sink` is `None`.

**Not a security issue** — fail-closed held throughout either way (`GrantError::AuditUnavailable` denies every request in this state) — but a real correctness/observability gap in the factory wiring: the degrade path was inconsistent and harder to diagnose than it needed to be.

## The fix
Treat "signer can't sign" exactly like "store failed to open": don't install it. `audit_sink` stays `None`, so the grant path gives the same clean, immediate error message in both misconfiguration states.

## Verification
- `mac::` 96/96 pass · `cargo check -p hyprstream` clean · `cargo clippy -p hyprstream --all-targets` clean.

Single-commit, single-file (`services/oauth/mod.rs`) change.
