### PR TITLE
feat(ts_codegen): typed interfaces + build/parse for inline union group arms

### DIFF
--- a/crates/hyprstream-rpc-build/src/ts_codegen/builders.rs
+++ b/crates/hyprstream-rpc-build/src/ts_codegen/builders.rs
@@ -471,6 +471,7 @@ pub fn generate_struct_builders(out: &mut String, schema: &ParsedSchema) {
             } else {
                 None
             };
+            let group_leaves = super::group_arm_leaves(sd, variant);
 
             let fn_name = format!("build{}_{}", sd.name, variant.name);
 
@@ -488,6 +489,11 @@ pub fn generate_struct_builders(out: &mut String, schema: &ParsedSchema) {
                     params.push(format!("p: {}", ps.name));
                 } else if is_prim {
                     params.push(format!("p: {}", capnp_to_ts_type(&variant.type_name)));
+                } else if group_leaves.is_some() {
+                    params.push(format!(
+                        "p: {}",
+                        super::group_arm_type_name(&sd.name, &variant.name)
+                    ));
                 }
             }
 
@@ -539,6 +545,17 @@ pub fn generate_struct_builders(out: &mut String, schema: &ParsedSchema) {
                 );
             } else if let Some(ps) = payload_struct {
                 emit_struct_init(out, variant, ps, "msg", "p", "  ", schema, &mut counter);
+            } else if let Some(leaves) = group_leaves {
+                emit_group_arm_setter(
+                    out,
+                    "msg",
+                    "p",
+                    leaves,
+                    "  ",
+                    &schema.enums,
+                    &schema.structs,
+                    &mut counter,
+                );
             }
 
             out.push_str("  return msg.finish();\n");
@@ -803,6 +820,38 @@ fn emit_struct_init(
     }
 }
 
+/// Write an inline union `group` arm's leaf fields onto `builder_var`.
+///
+/// The leaves live in the ENCLOSING struct's sections (a group has no own
+/// pointer), so each is set directly on `builder_var` at its own slot offset —
+/// the same per-field setter path a normal field uses. `data_expr` is the
+/// arm's typed group object.
+fn emit_group_arm_setter(
+    out: &mut String,
+    builder_var: &str,
+    data_expr: &str,
+    leaves: &[FieldDef],
+    indent: &str,
+    enums: &[EnumDef],
+    structs: &[StructDef],
+    counter: &mut u32,
+) {
+    for leaf in leaves {
+        let raw = format!("{data_expr}.{}", to_camel_case(&leaf.name));
+        let val = value_expr_for_field(leaf, &raw, enums);
+        emit_field_setter(
+            out,
+            builder_var,
+            leaf,
+            &val,
+            indent,
+            enums,
+            structs,
+            counter,
+        );
+    }
+}
+
 /// Optional fields carry `T | undefined`; coalesce to the capnp default so
 /// TypeScript strict mode doesn't reject passing `T | undefined` to a setter.
 fn value_expr_for_field(field: &FieldDef, raw_expr: &str, enums: &[EnumDef]) -> String {
@@ -909,7 +958,25 @@ fn emit_union_element_setter(
             uf.discriminant_value, uf.name
         ));
 
-        if uf.type_name == "Void" {
+        if let Some(leaves) = super::group_arm_leaves(sd, uf) {
+            // Inline group arm — write its leaves directly on this struct.
+            out.push_str(&format!("{bi}{{\n"));
+            out.push_str(&format!(
+                "{bi}  const _ugd = {value_var}.data as {};\n",
+                super::group_arm_type_name(&sd.name, &uf.name)
+            ));
+            emit_group_arm_setter(
+                out,
+                builder_var,
+                "_ugd",
+                leaves,
+                &format!("{bi}  "),
+                enums,
+                structs,
+                counter,
+            );
+            out.push_str(&format!("{bi}}}\n"));
+        } else if uf.type_name == "Void" {
             // Nothing to set
         } else if uf.section == FieldSection::Data && is_data_scalar(&uf.type_name) {
             let byte_off = data_byte_offset(uf);

--- a/crates/hyprstream-rpc-build/src/ts_codegen/interfaces.rs
+++ b/crates/hyprstream-rpc-build/src/ts_codegen/interfaces.rs
@@ -1,6 +1,8 @@
 //! Generate TypeScript interfaces from Cap'n Proto struct and enum definitions.
 
-use hyprstream_rpc_build::schema::types::{EnumDef, FieldSection, ParsedSchema, StructDef};
+use hyprstream_rpc_build::schema::types::{
+    EnumDef, FieldDef, FieldSection, ParsedSchema, StructDef,
+};
 use hyprstream_rpc_build::util::to_camel_case;
 
 use super::capnp_to_ts_type;
@@ -31,6 +33,33 @@ fn emit_enum(out: &mut String, e: &EnumDef) {
     out.push('\n');
 }
 
+/// Emit a TypeScript interface for an inline union `group` arm's leaf fields.
+///
+/// Mirrors the non-union-field emission in [`emit_struct_interface`]: struct
+/// pointers are nullable, Option*/Text/Data/List are not.
+fn emit_group_interface(out: &mut String, name: &str, leaves: &[FieldDef]) {
+    out.push_str(&format!("export interface {name} {{\n"));
+    for leaf in leaves {
+        let ts = capnp_to_ts_type(&leaf.type_name);
+        let nullable = if matches!(leaf.section, FieldSection::Pointer)
+            && !matches!(leaf.type_name.as_str(), "Text" | "Data")
+            && !leaf.type_name.starts_with("List(")
+            && !leaf.type_name.starts_with("Option")
+        {
+            " | null"
+        } else {
+            ""
+        };
+        out.push_str(&format!(
+            "  {}: {}{};\n",
+            to_camel_case(&leaf.name),
+            ts,
+            nullable
+        ));
+    }
+    out.push_str("}\n\n");
+}
+
 /// Emit a TypeScript interface from a struct definition.
 ///
 /// Only non-union fields are included. Structs that are pure union envelopes
@@ -48,6 +77,19 @@ fn emit_struct_interface(out: &mut String, s: &StructDef) {
     if non_union_fields.is_empty() && s.has_union {
         let union_fields: Vec<_> = s.union_fields().collect();
         if !union_fields.is_empty() {
+            // Synthesize a named interface for each inline `group` arm. Its leaf
+            // fields live in this struct's own sections, so the arm's `data` is
+            // that leaf shape (see `group_arm_leaves`). Emit before the union
+            // type so the alias can reference it.
+            for f in &union_fields {
+                if let Some(leaves) = super::group_arm_leaves(s, f) {
+                    emit_group_interface(
+                        out,
+                        &super::group_arm_type_name(&s.name, &f.name),
+                        leaves,
+                    );
+                }
+            }
             out.push_str(&format!("export type {} =\n", s.name));
             for f in &union_fields {
                 // Use the raw field name to match the generated parser/builder,
@@ -55,7 +97,7 @@ fn emit_struct_interface(out: &mut String, s: &StructDef) {
                 out.push_str(&format!(
                     "  | {{ variant: '{}'; data: {} }}\n",
                     f.name,
-                    super::union_variant_data_type(f)
+                    super::union_arm_data_type(s, f)
                 ));
             }
             // Fallback arm matching the parser's `default` case.

--- a/crates/hyprstream-rpc-build/src/ts_codegen/mod.rs
+++ b/crates/hyprstream-rpc-build/src/ts_codegen/mod.rs
@@ -14,7 +14,9 @@ mod parsers;
 use std::path::Path;
 
 use hyprstream_rpc_build::backend::CodegenBackend;
-use hyprstream_rpc_build::schema::types::{EnumDef, FieldDef, FieldSection, ParsedSchema};
+use hyprstream_rpc_build::schema::types::{
+    ArmPayload, EnumDef, FieldDef, FieldSection, ParsedSchema, StructDef,
+};
 use hyprstream_rpc_build::util::{to_camel_case, to_pascal_case};
 
 /// Generate all output files from parsed schemas using the given backend.
@@ -313,6 +315,49 @@ pub(crate) fn union_variant_data_type(f: &FieldDef) -> String {
         format!("{} | null", capnp_to_ts_type(tn))
     } else {
         capnp_to_ts_type(tn)
+    }
+}
+
+/// If union field `uf` of struct `sd` is an inline `group` arm, return its leaf
+/// fields (from the structured `union_arms` view). `None` for Void/single-type
+/// arms.
+///
+/// A capnp `group` arm carries an inlined anonymous struct whose leaf fields are
+/// allocated their own slots in the ENCLOSING struct's data/pointer sections;
+/// each leaf `FieldDef` therefore already carries a correct `slot_offset` +
+/// `section` (extracted by the same `field_def_from_slot` path as a normal
+/// field), so build/parse can read/write them directly on the enclosing
+/// reader/builder.
+pub(crate) fn group_arm_leaves<'a>(sd: &'a StructDef, uf: &FieldDef) -> Option<&'a [FieldDef]> {
+    if uf.section != FieldSection::Group {
+        return None;
+    }
+    sd.union_arms
+        .iter()
+        .find(|a| a.name == uf.name)
+        .and_then(|a| match &a.payload {
+            ArmPayload::Group(leaves) => Some(leaves.as_slice()),
+            _ => None,
+        })
+}
+
+/// Name of the synthesized TypeScript interface for a group arm, e.g. the
+/// `dropOldest` arm of `OverflowPolicy` → `OverflowPolicyDropOldest`.
+pub(crate) fn group_arm_type_name(struct_name: &str, arm_name: &str) -> String {
+    format!("{struct_name}{}", to_pascal_case(arm_name))
+}
+
+/// The `data:` TypeScript type for one arm of struct `sd`'s discriminated union.
+///
+/// Same as [`union_variant_data_type`] for Void/scalar/struct arms, but a group
+/// arm resolves to its synthesized interface (`{Struct}{Arm}` | null) instead of
+/// the bare, undefined `Group`. Shared by the interface emitter and the parser
+/// result-type aliases so type/build/parse agree.
+pub(crate) fn union_arm_data_type(sd: &StructDef, f: &FieldDef) -> String {
+    if group_arm_leaves(sd, f).is_some() {
+        format!("{} | null", group_arm_type_name(&sd.name, &f.name))
+    } else {
+        union_variant_data_type(f)
     }
 }
 

--- a/crates/hyprstream-rpc-build/src/ts_codegen/parsers.rs
+++ b/crates/hyprstream-rpc-build/src/ts_codegen/parsers.rs
@@ -39,7 +39,13 @@ pub fn generate_parsers(out: &mut String, service_name: &str, schema: &ParsedSch
     if resp_struct.has_union {
         let shared_fields: Vec<String> = non_union_fields
             .iter()
-            .map(|f| format!("{}: {}", to_camel_case(&f.name), capnp_to_ts_type(&f.type_name)))
+            .map(|f| {
+                format!(
+                    "{}: {}",
+                    to_camel_case(&f.name),
+                    capnp_to_ts_type(&f.type_name)
+                )
+            })
             .collect();
         let arms: Vec<(String, String)> = schema
             .response_variants
@@ -54,7 +60,12 @@ pub fn generate_parsers(out: &mut String, service_name: &str, schema: &ParsedSch
                 (v.name.clone(), data_ty)
             })
             .collect();
-        emit_result_union_alias(out, &format!("{pascal}ResponseResult"), &shared_fields, &arms);
+        emit_result_union_alias(
+            out,
+            &format!("{pascal}ResponseResult"),
+            &shared_fields,
+            &arms,
+        );
     } else {
         // Data-only response (no union) — plain interface, unchanged shape.
         out.push_str(&format!("export interface {pascal}ResponseResult {{\n"));
@@ -284,7 +295,7 @@ pub fn generate_struct_parsers(out: &mut String, schema: &ParsedSchema) {
             .collect();
         let arms: Vec<(String, String)> = union_fields
             .iter()
-            .map(|f| (f.name.clone(), super::union_variant_data_type(f)))
+            .map(|f| (f.name.clone(), super::union_arm_data_type(sd, f)))
             .collect();
         emit_result_union_alias(out, &format!("{}Result", sd.name), &shared_fields, &arms);
 
@@ -315,7 +326,10 @@ pub fn generate_struct_parsers(out: &mut String, schema: &ParsedSchema) {
                 variant.discriminant_value, variant.name
             ));
 
-            if variant.type_name == "Void" {
+            if let Some(leaves) = super::group_arm_leaves(sd, variant) {
+                let data = emit_group_arm_read("reader", leaves, schema);
+                emit_return(out, &non_union_fields, &variant.name, &data);
+            } else if variant.type_name == "Void" {
                 emit_return(out, &non_union_fields, &variant.name, "undefined");
             } else if variant.type_name == "Bool" {
                 let byte_off = data_byte_offset(variant);
@@ -782,8 +796,11 @@ fn emit_struct_pointer_expr(
 
         for uf in &union_fields {
             s.push_str(&format!("    case {}: {{\n", uf.discriminant_value));
-            let data_expr =
-                emit_inner_variant_read_from(&var_name, Some(uf), &uf.type_name, schema, depth + 1);
+            let data_expr = if let Some(leaves) = super::group_arm_leaves(sd, uf) {
+                emit_group_arm_read(&var_name, leaves, schema)
+            } else {
+                emit_inner_variant_read_from(&var_name, Some(uf), &uf.type_name, schema, depth + 1)
+            };
             s.push_str(&format!(
                 "      return {{ {nuf_str}{nuf_comma}variant: '{}' as const, data: {data_expr} }};\n",
                 uf.name
@@ -902,6 +919,23 @@ fn emit_struct_element_field_read_inner(
     }
 }
 
+/// Read an inline union `group` arm's leaf fields into an object literal
+/// matching its synthesized interface: `{ leaf1: <read>, leaf2: <read> }`.
+///
+/// The leaves live in the ENCLOSING struct's sections, so they read from the
+/// same `reader_var` at their own slot offsets (a group has no own pointer).
+fn emit_group_arm_read(reader_var: &str, leaves: &[FieldDef], schema: &ParsedSchema) -> String {
+    let parts: Vec<String> = leaves
+        .iter()
+        .map(|leaf| {
+            let camel = to_camel_case(&leaf.name);
+            let read = emit_struct_element_field_read_inner(reader_var, leaf, schema, 0);
+            format!("{camel}: {read}")
+        })
+        .collect();
+    format!("{{ {} }}", parts.join(", "))
+}
+
 /// Generate an inline expression that reads a List(Struct) and maps elements to objects.
 ///
 /// For non-union structs: maps to `{ field1, field2, ... }`.
@@ -975,7 +1009,11 @@ fn emit_union_struct_list_field_expr(
             "      case {}: // {}\n",
             uf.discriminant_value, uf.name
         ));
-        let data_expr = emit_inner_variant_read_from("_el", Some(uf), &uf.type_name, schema, 0);
+        let data_expr = if let Some(leaves) = super::group_arm_leaves(sd, uf) {
+            emit_group_arm_read("_el", leaves, schema)
+        } else {
+            emit_inner_variant_read_from("_el", Some(uf), &uf.type_name, schema, 0)
+        };
         // `as const` narrows the literal so the mapped array types as the typed
         // discriminated union (e.g. StreamPayload[]) rather than widening to
         // `{ variant: string; ... }[]`.
@@ -1254,10 +1292,7 @@ struct PayloadResponse {
     /// Compile `schema_src` to a CGR keyed on `name` and parse it. Uses a
     /// per-(pid, name) temp dir so parallel tests don't collide.
     fn parse_schema(name: &str, schema_src: &str) -> ParsedSchema {
-        let tmp = std::env::temp_dir().join(format!(
-            "hyprstream_ts_{name}_{}",
-            std::process::id()
-        ));
+        let tmp = std::env::temp_dir().join(format!("hyprstream_ts_{name}_{}", std::process::id()));
         std::fs::create_dir_all(&tmp).expect("create temp dir");
 
         let capnp_path = tmp.join(format!("{name}.capnp"));
@@ -1363,6 +1398,69 @@ struct PayloadResponse {
         assert!(
             out.contains("variant: 'ok' as const"),
             "variant return missing `as const`:\n{out}"
+        );
+    }
+
+    /// A pure-union struct with an inline `group` arm carrying leaf fields —
+    /// mirrors streaming.capnp's OverflowPolicy.dropOldest.
+    const GROUP_SCHEMA: &str = r#"
+@0x9009900990099009;
+
+struct Overflow {
+  union {
+    block @0 :Void;
+    dropOldest :group {
+      highWaterMark @1 :UInt32;
+    }
+  }
+}
+"#;
+
+    #[test]
+    fn inline_union_group_arm_emits_interface_type_and_build_parse() {
+        let schema = parse_schema("groupfix", GROUP_SCHEMA);
+
+        // 1. Interface: a synthesized `{Struct}{Arm}` interface + a typed arm
+        //    referencing it (NOT the undefined bare `Group`).
+        let mut ifaces = String::new();
+        super::super::interfaces::generate_interfaces(&mut ifaces, &schema);
+        assert!(
+            ifaces.contains("export interface OverflowDropOldest {"),
+            "missing synthesized group interface:\n{ifaces}"
+        );
+        assert!(
+            ifaces.contains("highWaterMark: number;"),
+            "group leaf field missing from interface:\n{ifaces}"
+        );
+        assert!(
+            ifaces.contains("| { variant: 'dropOldest'; data: OverflowDropOldest | null }"),
+            "group arm not typed to its interface:\n{ifaces}"
+        );
+        assert!(
+            !ifaces.contains("data: Group"),
+            "must not emit the undefined bare `Group` type:\n{ifaces}"
+        );
+
+        // 2. Parser: the group arm reads its leaf into an object literal, not
+        //    `undefined`/`null`.
+        let mut parser = String::new();
+        super::generate_struct_parsers(&mut parser, &schema);
+        assert!(
+            parser.contains("variant: 'dropOldest' as const, data: { highWaterMark:"),
+            "group arm parse must read leaves into an object:\n{parser}"
+        );
+
+        // 3. Builder: the per-arm builder takes the group interface and writes
+        //    the leaf.
+        let mut builder = String::new();
+        super::super::builders::generate_struct_builders(&mut builder, &schema);
+        assert!(
+            builder.contains("buildOverflow_dropOldest(p: OverflowDropOldest)"),
+            "group arm builder must take the group interface:\n{builder}"
+        );
+        assert!(
+            builder.contains("p.highWaterMark"),
+            "group arm builder must write the leaf:\n{builder}"
         );
     }
 }


### PR DESCRIPTION
Completes the inline-`group` sub-case of #464 (typed discriminated unions).

## Problem
The typed-union emitter handled Void/scalar/struct arms, but **inline `group` arms were unhandled**: they emitted `data: Group` (an undefined TS type) and the builder/parser skipped their fields. Any schema with a non-empty union group produces uncompilable TS — e.g. `streaming.capnp`'s `StreamOpt` QoS unions (`Ordering.unordered`, `Delivery.atLeastOnce`, `OverflowPolicy.dropOldest`), which blocked regenerating the frontend's `streaming.ts` for the moq reach model.

## Fix
Synthesize a named interface per group arm (`{Struct}{ArmPascalCase}`, e.g. `OverflowPolicyDropOldest`) from the arm's leaf fields, reference it in the union arm type, and emit real build/parse for each leaf.

**No new offset logic.** Group leaves already carry correct `slot_offset`/`section` — they're built via the same `field_def_from_slot` as normal struct fields (a group's leaves live in the enclosing struct's data/pointer sections). So build/parse reuse the existing per-field emitters, and the offsets stay symmetric with the Rust enum codegen.

### Touchpoints (`crates/hyprstream-rpc-build/src/ts_codegen/`)
- **mod.rs** — `group_arm_leaves` (correlate a union `FieldDef` to its `ArmPayload::Group(leaves)`), `group_arm_type_name`, `union_arm_data_type` (group→interface, else existing logic). Shared so type/build/parse agree by construction.
- **interfaces.rs** — synthesize one interface per group arm; type the arm via `union_arm_data_type`.
- **builders.rs** — write each leaf on the enclosing builder at its offset (was `FieldSection::Group => {}`).
- **parsers.rs** — read each leaf into `{ leaf: <read> }` at its offset (was `undefined`), across all three union-read paths + result-type aliases.

### Generated output (before → after)
```ts
// before:  | { variant: 'dropOldest'; data: Group }          // TS2304
// after:
export interface OverflowPolicyDropOldest { highWaterMark: number; }
export type OverflowPolicy =
  | { variant: 'block'; data: undefined }
  | { variant: 'dropOldest'; data: OverflowPolicyDropOldest | null }
  | { variant: 'unknown'; data: null };
```
Build: `setUint32(4, p.highWaterMark)` · Parse: `getUint32(4)` — symmetric.

## Verification
- New test `inline_union_group_arm_emits_interface_type_and_build_parse`; all `hyprstream-rpc-build` tests green; targeted clippy clean.
- Consumer proof: regenerated `www-cyberdione-ai` `src/rpc/generated/streaming.ts` → `tsc` 0 errors (the 6 `Cannot find name 'Group'` gone) and a browser build→parse round-trip preserves a `dropOldest.highWaterMark` group leaf.

Touches the RPC TS surface (generated wire codec) — capnp/RPC-adjacent, flagging for review per the codegen gate.