### PR TITLE
feat(#654): authenticated XET write (putBlob) + provenance-gated read — supersedes #511

### DIFF
--- a/crates/cas-serve/src/main.rs
+++ b/crates/cas-serve/src/main.rs
@@ -194,62 +194,27 @@ impl CasServer {
             }
         };
 
-        // Chunk via CDC, then aggregate into xorbs + build the shard.
-        let chunks = chunker::chunk_all(&decoded);
-        let (shard, xorbs) = Shard::from_chunks(&chunks);
-
-        // Ensure storage dirs exist.
-        let xorbs_dir = self.storage_path.join("xorbs");
-        let shards_dir = self.storage_path.join("shards");
-        if let Err(e) = tokio::fs::create_dir_all(&xorbs_dir).await {
-            return Response::error(
-                ErrorCode::IoError,
-                format!("Failed to create xorbs dir: {e}"),
-            );
-        }
-        if let Err(e) = tokio::fs::create_dir_all(&shards_dir).await {
-            return Response::error(
-                ErrorCode::IoError,
-                format!("Failed to create shards dir: {e}"),
-            );
-        }
-
-        // Store each xorb content-addressed. Existing xorbs are not an error
-        // (content-addressed dedup): just overwrite.
-        let mut xorb_hashes = Vec::with_capacity(xorbs.len());
-        for (xorb_hash, bytes) in &xorbs {
-            let hex = xorb_hash.hex();
-            let path = xorbs_dir.join(format!("default.{hex}"));
-            if let Err(e) = tokio::fs::write(&path, bytes).await {
-                return Response::error(
-                    ErrorCode::UploadFailed,
-                    format!("Failed to write xorb {hex}: {e}"),
+        // Chunk + store + server-side merkle go through the shared `CasStore`
+        // write core (`cas_serve::store`), so the binary and in-process embedders
+        // (the registry `putBlob` handler) share one implementation.
+        let store = cas_serve::CasStore::new(&self.storage_path);
+        match store.put_file_bytes(&decoded).await {
+            Ok(put) => {
+                info!(
+                    "UploadFile {}: {} bytes, {} xorb(s), {} new byte(s)",
+                    put.merkle,
+                    decoded.len(),
+                    put.xorb_hashes.len(),
+                    put.bytes_stored
                 );
+                Response::UploadFileSuccess {
+                    file_hash: put.merkle,
+                    // file_len is the original input length (== sum of chunk lens).
+                    file_len: decoded.len() as u64,
+                    xorb_hashes: put.xorb_hashes,
+                }
             }
-            xorb_hashes.push(hex);
-        }
-
-        // Store the reconstruction shard (`.mdb` binary) keyed by the file hash.
-        let shard_path = shards_dir.join(&shard.file_hash);
-        if let Err(e) = tokio::fs::write(&shard_path, shard.to_bytes()).await {
-            return Response::error(
-                ErrorCode::UploadFailed,
-                format!("Failed to write shard: {e}"),
-            );
-        }
-
-        info!(
-            "UploadFile {}: {} bytes, {} chunk(s), {} xorb(s)",
-            shard.file_hash,
-            decoded.len(),
-            chunks.len(),
-            xorbs.len()
-        );
-
-        Response::UploadFileSuccess {
-            file_hash: shard.file_hash,
-            file_len: shard.file_len,
-            xorb_hashes,
+            Err(e) => Response::error(ErrorCode::UploadFailed, format!("Upload failed: {e}")),
         }
     }
 

--- a/crates/cas-serve/src/store.rs
+++ b/crates/cas-serve/src/store.rs
@@ -25,6 +25,19 @@ pub enum StoreError {
     Io(String),
 }
 
+/// Result of ingesting bytes via [`CasStore::put_file_bytes`].
+#[derive(Debug, Clone)]
+pub struct PutResult {
+    /// Server-computed XET merkle root (hex) of the ingested bytes. Authoritative
+    /// — derived from the actual content, never supplied by the caller.
+    pub merkle: String,
+    /// Hex xorb hashes forming the reconstruction set for this content.
+    pub xorb_hashes: Vec<String>,
+    /// Bytes newly written to the store after content-addressed dedup
+    /// (0 if every xorb was already present — fully deduplicated).
+    pub bytes_stored: u64,
+}
+
 /// Storage path resolution order (matches the `cas-serve` binary):
 /// 1. `CAS_STORAGE` environment variable
 /// 2. `XET_CACHE_DIR` environment variable
@@ -106,6 +119,64 @@ impl CasStore {
         }
     }
 
+    /// Ingest raw bytes: chunk (Gearhash CDC), aggregate into xorbs, build the
+    /// reconstruction shard, and store both content-addressed. The XET merkle
+    /// root is computed HERE from the actual bytes and returned in
+    /// [`PutResult::merkle`] — the caller never supplies it. Existing xorbs are
+    /// skipped (global content-addressed dedup), so [`PutResult::bytes_stored`]
+    /// counts only newly-written xorb payload.
+    ///
+    /// This is the in-process, library form of the binary's `UploadFile`
+    /// handler; both go through this single implementation.
+    pub async fn put_file_bytes(&self, data: &[u8]) -> Result<PutResult, StoreError> {
+        use crate::chunker;
+        use crate::shard::Shard;
+
+        // Server-side chunk + merkle: the file_hash is derived from the bytes,
+        // not asserted by the caller (this is what closes the OID-planting vector
+        // for the authenticated write path — see hyprstream registry putBlob).
+        let chunks = chunker::chunk_all(data);
+        let (shard, xorbs) = Shard::from_chunks(&chunks);
+
+        let xorbs_dir = self.storage_path.join("xorbs");
+        let shards_dir = self.storage_path.join("shards");
+        tokio::fs::create_dir_all(&xorbs_dir)
+            .await
+            .map_err(|e| StoreError::Io(format!("create xorbs dir: {e}")))?;
+        tokio::fs::create_dir_all(&shards_dir)
+            .await
+            .map_err(|e| StoreError::Io(format!("create shards dir: {e}")))?;
+
+        // Store each xorb content-addressed. An identical xorb already present is
+        // not an error (dedup): skip the write and don't count it.
+        let mut xorb_hashes = Vec::with_capacity(xorbs.len());
+        let mut bytes_stored: u64 = 0;
+        for (xorb_hash, bytes) in &xorbs {
+            let hex = xorb_hash.hex();
+            let path = self.xorb_path(&hex);
+            if !path.exists() {
+                tokio::fs::write(&path, bytes)
+                    .await
+                    .map_err(|e| StoreError::Io(format!("write xorb {hex}: {e}")))?;
+                bytes_stored += bytes.len() as u64;
+            }
+            xorb_hashes.push(hex);
+        }
+
+        // Reconstruction shard (`.mdb`), keyed by the file merkle. Small metadata,
+        // identical for identical content, so an unconditional (re)write is fine.
+        let shard_path = self.shard_path(&shard.file_hash);
+        tokio::fs::write(&shard_path, shard.to_bytes())
+            .await
+            .map_err(|e| StoreError::Io(format!("write shard {}: {e}", shard.file_hash)))?;
+
+        Ok(PutResult {
+            merkle: shard.file_hash,
+            xorb_hashes,
+            bytes_stored,
+        })
+    }
+
     /// Load the `.mdb` shard, fetch each referenced xorb, and concatenate the
     /// segment bytes to reconstruct the file.
     async fn reassemble_from_shard(
@@ -159,5 +230,58 @@ impl CasStore {
         }
 
         Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A payload large enough to exercise CDC into multiple chunks/xorbs.
+    fn payload(seed: u8, len: usize) -> Vec<u8> {
+        (0..len).map(|i| seed.wrapping_add((i as u8).wrapping_mul(31))).collect()
+    }
+
+    #[tokio::test]
+    async fn put_then_get_round_trips_and_computes_merkle() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        let original = payload(7, 512 * 1024);
+
+        let put = store.put_file_bytes(&original).await.unwrap();
+        // Merkle is server-computed and non-empty; content is content-addressable.
+        assert!(!put.merkle.is_empty(), "server must compute a merkle");
+        assert!(!put.xorb_hashes.is_empty());
+        assert!(put.bytes_stored > 0, "first upload writes new bytes");
+
+        // The store can now reconstruct the exact original bytes by that merkle.
+        let got = store.get_file_bytes(&put.merkle).await.unwrap();
+        assert_eq!(got, original);
+    }
+
+    #[tokio::test]
+    async fn merkle_is_deterministic_and_reupload_dedupes() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+        let original = payload(42, 300 * 1024);
+
+        let first = store.put_file_bytes(&original).await.unwrap();
+        let second = store.put_file_bytes(&original).await.unwrap();
+
+        // Same bytes ⇒ same merkle (content-addressed, caller-independent).
+        assert_eq!(first.merkle, second.merkle);
+        assert_eq!(first.xorb_hashes, second.xorb_hashes);
+        // Re-upload of identical content writes nothing new (global dedup).
+        assert_eq!(second.bytes_stored, 0, "re-upload must fully dedup");
+    }
+
+    #[tokio::test]
+    async fn distinct_content_yields_distinct_merkle() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::new(dir.path());
+
+        let a = store.put_file_bytes(&payload(1, 200 * 1024)).await.unwrap();
+        let b = store.put_file_bytes(&payload(2, 200 * 1024)).await.unwrap();
+        assert_ne!(a.merkle, b.merkle);
     }
 }

--- a/crates/hyprstream/src/services/mod.rs
+++ b/crates/hyprstream/src/services/mod.rs
@@ -79,6 +79,7 @@ pub mod oai;
 pub mod policy;
 pub mod registry;
 pub mod router;
+pub mod xet_provenance;
 pub mod fs;
 pub mod remote_mount;
 pub mod remote_registry_mount;

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -5,6 +5,7 @@
 
 use crate::services::PolicyClient;
 use crate::services::types::{MAX_FDS_GLOBAL, MAX_FDS_PER_CLIENT};
+use crate::services::xet_provenance::XetProvenanceStore;
 use hyprstream_containedfs::{ContainedFs, FsError, FsHandle};
 use crate::services::{EnvelopeContext, RequestService};
 use hyprstream_rpc::transport::TransportConfig;
@@ -327,6 +328,10 @@ pub struct RegistryService {
     expected_audience: Option<String>,
     /// JWT key source for token verification.
     jwt_key_source: Option<std::sync::Arc<dyn hyprstream_rpc::auth::JwtKeySource>>,
+    /// Server-side `(merkle_hex → repo_id)` provenance store backing the
+    /// fail-closed XET `getBlob` gate (#436 / #509). Pointer presence is
+    /// necessary-but-not-sufficient: entitlement requires a provenance record.
+    xet_provenance: Arc<XetProvenanceStore>,
 }
 
 /// Progress reporter that sends updates via a tokio mpsc channel.
@@ -378,6 +383,10 @@ impl RegistryService {
         let base_dir = base_dir.as_ref().to_path_buf();
         let registry = Git2DB::open(&base_dir).await?;
 
+        // Load the XET provenance store (lives alongside registry metadata).
+        // Missing file → empty store → fail-closed XET getBlob (secure default).
+        let xet_provenance = Arc::new(XetProvenanceStore::load(&base_dir).await?);
+
         let worker_registry = Arc::new(RwLock::new(registry));
 
         // Create fid table and editing table, spawn reaper
@@ -400,6 +409,7 @@ impl RegistryService {
             editing_table,
             expected_audience: None,
             jwt_key_source: None,
+            xet_provenance,
         };
 
         Ok(service)
@@ -907,47 +917,40 @@ impl RegistryService {
 
     // (helper `xet_pointer_references_merkle` defined at module scope below)
 
-    /// Condition-(b) check for a XET merkle root, HuggingFace-Xet-compatible:
-    /// entitlement is by *reconstruction*, not by mere reference. grantRepo
-    /// satisfies (b) iff it tracks a git-xet / git-lfs file whose **content-OID
-    /// field equals the requested merkle** — i.e. a file in this repo genuinely
-    /// reconstructs *from* this address. The merkle being the file's OID is what
-    /// makes the caller entitled to the bytes; a blob that merely names the hex
-    /// (planted reference) does NOT qualify, since that file does not reconstruct
-    /// from it.
+    /// Condition-(b) check for a XET merkle root — **provenance-gated and
+    /// fail-closed** (the #436 / #509 fix).
     ///
-    /// This matches HF Xet's model: the CAS stays GLOBAL and content-addressed
-    /// (cross-repo dedup is preserved — the storage win), and isolation is
-    /// enforced at the READ-AUTHORIZATION layer: "you can only read chunks
-    /// required to reproduce files you have access to, and no more." Possessing a
-    /// content hash is never a capability; access keys on repo permission
-    /// (condition (a)) AND the content being a reconstruction target in that repo.
+    /// Entitlement requires BOTH:
+    ///   1. a **server-side provenance record** binding this merkle to
+    ///      `repo_id` (i.e. this repo actually *uploaded* the bytes); AND
+    ///   2. (defense-in-depth) the repo's current HEAD tree still **references**
+    ///      the merkle via a checked-in git-xet / git-lfs pointer whose merkle
+    ///      field EXACTLY equals the requested hash.
     ///
-    /// Granularity (#436): the binding here is FILE-LEVEL — the requested merkle
-    /// must equal a tracked file's xet/lfs content-OID. Chunk-range-level
-    /// entitlement (verifying a requested chunk address is in a file's mdb_shard
-    /// reconstruction manifest) is sound but heavier and is DEFERRED; getBlob's
-    /// content union addresses whole files by their OID, so file-level binding is
-    /// the correct grain for the current wire.
-    ///
-    /// LIMITATION — STILL GATED for PRIVATE multitenant XET (#436 NOT fully
-    /// closed). This check trusts a CALLER-COMMITTED pointer file as evidence of
-    /// entitlement. The pointer is entirely caller-controlled: a writer with
-    /// access to their own repo can commit a well-formed pointer whose
-    /// `oid sha256:` field is a target private merkle (publicly computable for
-    /// public-derived content) and pass condition (b). Closing this requires a
-    /// SERVER-AUTHORITATIVE provenance record — the bytes for this merkle were
-    /// uploaded *through this repo* (the mdb_shard reconstruction manifest the
-    /// repo owns at upload time), not a client-supplied pointer. Until that lands,
-    /// the XET path is sound for PUBLIC / same-trust-domain content only; private
-    /// cross-tenant XET fetch must stay disabled. (The exact-OID-field parse below
-    /// is still an improvement — it closes the comment/size/substring sub-vector —
-    /// but it is NOT the isolation boundary.)
+    /// The provenance record is the authoritative gate. Pointer presence is
+    /// **necessary-but-not-sufficient**: because the CAS is global and
+    /// non-namespaced, a pointer blob is caller-committed and therefore
+    /// *forgeable* — Tenant B can plant `oid sha256:<Tenant A's private merkle>`
+    /// in their own repo. We therefore **deny when no provenance record exists**
+    /// and NEVER fall back to the pointer-only check. See
+    /// [`crate::services::xet_provenance`] for the trust boundary and #509 for
+    /// the authenticated upload-binding that populates provenance.
     async fn repo_contains_xet_merkle(
         &self,
         repo_id: &git2db::RepoId,
         merkle_hex: &str,
     ) -> Result<bool> {
+        // ── Authoritative gate: fail-closed provenance check. ──
+        // No record binding (merkle → repo) ⇒ deny, regardless of any pointer.
+        if !self
+            .xet_provenance
+            .is_bound(merkle_hex, &repo_id.0.to_string())
+            .await
+        {
+            return Ok(false);
+        }
+
+        // ── Defense-in-depth: the repo must still reference the merkle. ──
         let merkle_hex = merkle_hex.to_owned();
         self.with_repo_blocking(repo_id, move |repo| {
             let head = match repo.head().ok().and_then(|h| h.peel_to_tree().ok()) {

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -34,7 +34,7 @@ use crate::services::generated::registry_client::{
     StreamInfo, ErrorInfo, HealthStatus, DetailedStatusInfo, RemoteInfo,
     CloneRequest, RegisterRequest,
     GetBlobRequest, GetBlobRequestContent,
-    PutBlobRequest,
+    PutBlobRequest, PutBlobResult,
     CreateWorktreeRequest, RemoveWorktreeRequest,
     BranchRequest, CheckoutRequest, StageFilesRequest,
     CommitRequest, MergeRequest, ContinueMergeRequest,
@@ -154,6 +154,11 @@ struct FidTable {
 
 /// Idle timeout for fids (5 minutes).
 const FID_IDLE_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Hard cap on the inline `putBlob` upload path (DoS guard for unbounded `Data`).
+/// Model-weight-scale blobs are NOT intended for the inline path; a streaming
+/// upload channel (additive schema follow-up) will carry those. 64 MiB.
+const MAX_INLINE_UPLOAD: u64 = 64 * 1024 * 1024;
 
 fn now_epoch_secs() -> u64 {
     SystemTime::now()
@@ -1753,39 +1758,94 @@ impl RegistryHandler for RegistryService {
         }
     }
 
-    /// STUB (epic #654) — the authenticated XET write path. NOT IMPLEMENTED:
-    /// this returns a fail-closed error so the wire shape lands (unblocking the
-    /// impl PR) without any behavior change. `main` semantics are unchanged: no
-    /// bytes are ever accepted here.
+    /// Authenticated in-band XET write (epic #654) — the symmetric write half of
+    /// `getBlob` and what populates the provenance store the `#509` read-gate
+    /// consults. The caller supplies bytes only; the server computes the merkle
+    /// from those bytes (never caller-supplied — this is what closes the #436
+    /// OID-planting vector by construction) and binds `(merkle → grantRepo)`
+    /// provenance from the verified identity.
     ///
-    /// Precondition (already satisfied by dispatch): the coarse `$scope(write)`
-    /// gate runs before this handler, exactly as `$scope(query)` does for
-    /// `handle_get_blob` (neither method carries `#[authorize]`; the coarse gate
-    /// is the schema-declared baseline, the fine-grained check lives in-handler).
-    ///
-    /// The real implementation (separate PR) will then:
-    ///   1. fine-grained `authorize(ctx, "model:{repo}", "write")` on
-    ///      `data.grant_repo`, mirroring `authorize_get_blob`'s per-repo check
-    ///      one verb up (a read grant never implies write);
-    ///   2. cap `data.bytes` at MAX_INLINE_UPLOAD (DoS guard — unbounded `Data`);
-    ///   3. chunk (Gearhash CDC) + store xorbs via an in-process CasStore write
-    ///      API (to add, mirroring `cas-serve::handle_upload_file`);
-    ///   4. compute the merkle SERVER-SIDE from the stored bytes (never
-    ///      caller-supplied — this is what closes the #436 planting vector);
-    ///   5. `xet_provenance.record(merkle, repo_id)` (the #509/#511 hook, today
-    ///      called only in tests — production population starts here);
-    ///   6. return `PutBlobResult { merkle, xorb_hashes, bytes_stored }`.
-    async fn handle_put_blob(&self, _ctx: &EnvelopeContext, _request_id: u64,
-        _data: &PutBlobRequest,
+    /// The coarse `$scope(write)` gate runs in dispatch before this handler (as
+    /// `$scope(query)` does for `handle_get_blob`; neither carries `#[authorize]`).
+    /// A failure returns a fail-closed error response — no bytes are persisted and
+    /// no provenance is recorded unless the caller is authorized.
+    async fn handle_put_blob(&self, ctx: &EnvelopeContext, _request_id: u64,
+        data: &PutBlobRequest,
     ) -> Result<RegistryResponseVariant> {
-        // Fail closed: the write path is not yet wired. Deny rather than
-        // silently accept bytes with no provenance binding.
-        Ok(reg_error(
-            "putBlob not yet implemented (epic #654): authenticated XET upload + \
-             server-side merkle + provenance recording pending",
-        ))
+        match self.put_blob_inner(ctx, data).await {
+            Ok(variant) => Ok(variant),
+            // Fail-closed: any deny/error → error response, nothing stored.
+            Err(e) => Ok(reg_error(&format!("putBlob denied: {e}"))),
+        }
     }
 
+}
+
+impl RegistryService {
+    /// Core of [`RegistryHandler::handle_put_blob`], split out for `?` ergonomics.
+    /// Every early return here is a hard deny (no bytes stored, no provenance
+    /// recorded); the caller maps `Err` → a fail-closed error response.
+    async fn put_blob_inner(
+        &self,
+        ctx: &EnvelopeContext,
+        data: &PutBlobRequest,
+    ) -> Result<RegistryResponseVariant> {
+        // ── Input validation ──
+        if data.grant_repo.trim().is_empty() {
+            anyhow::bail!("grantRepo is required (provenance binds the bytes to a repo)");
+        }
+        if data.bytes.is_empty() {
+            anyhow::bail!("empty upload");
+        }
+        // DoS guard: the inline path is hard-capped. Larger blobs will use the
+        // streaming upload channel (additive schema follow-up field).
+        if data.bytes.len() as u64 > MAX_INLINE_UPLOAD {
+            anyhow::bail!(
+                "upload exceeds inline cap ({} > {MAX_INLINE_UPLOAD} bytes); \
+                 streaming upload not yet available",
+                data.bytes.len()
+            );
+        }
+
+        // ── Resolve grantRepo → tracked repo (unknown repo = deny) ──
+        let repo = self
+            .resolve_grant_repo(&data.grant_repo)
+            .await
+            .ok_or_else(|| anyhow!("grantRepo '{}' not found", data.grant_repo))?;
+        let repo_name = repo.name.clone().unwrap_or_default();
+        if repo_name.is_empty() {
+            anyhow::bail!("grantRepo has no name for authz");
+        }
+
+        // ── Authorize WRITE on grantRepo. Mirrors `authorize_get_blob`'s per-repo
+        //    Casbin check, one verb up: a read (`query`) grant never implies
+        //    `write`. There is no condition-(b) "reconstruction target" check on
+        //    the write side — the upload is precisely what CREATES the binding. ──
+        RegistryHandler::authorize(self, ctx, &format!("model:{}", repo_name), "write")
+            .await
+            .map_err(|e| anyhow!("write not authorized on '{}': {}", data.grant_repo, e))?;
+
+        // ── Chunk + store + SERVER-SIDE merkle (caller supplied only bytes) ──
+        let store = cas_serve::CasStore::from_env();
+        let put = store
+            .put_file_bytes(&data.bytes)
+            .await
+            .map_err(|e| anyhow!("CAS ingest failed: {e}"))?;
+
+        // ── Bind provenance: THIS repo uploaded THIS merkle. Key on the SAME
+        //    `repo_id.0.to_string()` form the read-gate's `is_bound` uses, or the
+        //    later read would never match this binding. ──
+        self.xet_provenance
+            .record(&put.merkle, &repo.id.0.to_string())
+            .await
+            .map_err(|e| anyhow!("provenance record failed: {e}"))?;
+
+        Ok(RegistryResponseVariant::PutBlobResult(PutBlobResult {
+            merkle: put.merkle,
+            xorb_hashes: put.xorb_hashes,
+            bytes_stored: put.bytes_stored,
+        }))
+    }
 }
 
 // ============================================================================

--- a/crates/hyprstream/src/services/xet_provenance.rs
+++ b/crates/hyprstream/src/services/xet_provenance.rs
@@ -1,0 +1,258 @@
+//! XET content provenance store (the #436 / #509 fix).
+//!
+//! # Why this exists
+//!
+//! The XET CAS is **global and content-addressed**: bytes are deduplicated by
+//! their computed merkle root with no per-tenant namespacing. The pre-existing
+//! `getBlob` authorization (condition (b)) decided entitlement from a git-xet /
+//! git-lfs **pointer blob committed into the grant repo's HEAD tree**. That
+//! pointer is **caller-committed and therefore forgeable**: Tenant B can commit
+//! `oid sha256:<Tenant A's private merkle>` into their own repo and read A's
+//! private bytes back over the shared CAS. The pointer-only check structurally
+//! cannot tell a *planted* reference from a *genuine* one.
+//!
+//! # What this provides
+//!
+//! A persisted, **server-side-only** mapping `merkle_hex → {repo_id, …}` recording
+//! which repositories actually *contributed* (uploaded) the bytes behind a merkle.
+//! The bytes themselves remain globally deduplicated in the CAS — only this
+//! provenance mapping is per-repo. The read gate consults this store and **fails
+//! closed**: if no provenance record binds the merkle to the grant repo, the
+//! request is denied. A forgeable pointer can never, on its own, grant access.
+//!
+//! # Trust boundary (load-bearing)
+//!
+//! `record()` is the *only* mutating entry point and MUST be called exclusively
+//! from a **server-authenticated** code path that has already established the
+//! pushing repo's identity (NOT from caller-supplied identity such as `$USER` or
+//! a request field). See the module-level note in `registry.rs` for the wiring
+//! status of the authenticated upload binding (issue #509, part 2).
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+use tracing::{debug, warn};
+
+/// On-disk representation. Versioned so the format can evolve.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+struct ProvenanceFile {
+    #[serde(default = "default_version")]
+    version: String,
+    /// merkle_hex → set of repo_id (UUID strings) that uploaded these bytes.
+    #[serde(default)]
+    bindings: HashMap<String, HashSet<String>>,
+}
+
+fn default_version() -> String {
+    "1.0.0".to_owned()
+}
+
+/// Persisted `(merkle_hex → {repo_id})` provenance mapping for XET CAS content.
+///
+/// Lives alongside the registry metadata (`<base_dir>/.registry/`) so it shares
+/// the registry's durability and 0600 permission posture.
+pub struct XetProvenanceStore {
+    path: PathBuf,
+    inner: RwLock<HashMap<String, HashSet<String>>>,
+}
+
+impl XetProvenanceStore {
+    /// File name within the `.registry` directory.
+    const FILE_NAME: &'static str = "xet_provenance.json";
+
+    /// Load the provenance store from `<base_dir>/.registry/xet_provenance.json`,
+    /// creating an empty in-memory store if the file does not yet exist.
+    ///
+    /// A missing file is the expected first-run state and yields an **empty**
+    /// store — which, combined with the fail-closed read gate, denies all
+    /// XetMerkle `getBlob` requests until provenance is recorded. That is the
+    /// intended secure default.
+    pub async fn load(base_dir: &Path) -> Result<Self> {
+        let path = base_dir.join(".registry").join(Self::FILE_NAME);
+        let bindings = match tokio::fs::read(&path).await {
+            Ok(bytes) => {
+                let parsed: ProvenanceFile = serde_json::from_slice(&bytes).with_context(|| {
+                    format!("failed to parse XET provenance store at {}", path.display())
+                })?;
+                debug!(
+                    entries = parsed.bindings.len(),
+                    path = %path.display(),
+                    "loaded XET provenance store"
+                );
+                parsed.bindings
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                debug!(path = %path.display(), "no XET provenance store yet; starting empty (fail-closed)");
+                HashMap::new()
+            }
+            Err(e) => {
+                return Err(e).with_context(|| {
+                    format!("failed to read XET provenance store at {}", path.display())
+                });
+            }
+        };
+        Ok(Self {
+            path,
+            inner: RwLock::new(bindings),
+        })
+    }
+
+    /// Record that `repo_id` legitimately contributed the bytes behind
+    /// `merkle_hex`, persisting the mapping.
+    ///
+    /// SECURITY: callers MUST have authenticated the pushing repo's identity
+    /// server-side before invoking this. Never pass caller-supplied identity.
+    /// The mapping is additive (global dedup means the same bytes may be
+    /// uploaded by multiple repos; each legitimately gets a binding).
+    pub async fn record(&self, merkle_hex: &str, repo_id: &str) -> Result<()> {
+        let merkle_hex = merkle_hex.trim().to_ascii_lowercase();
+        let repo_id = repo_id.trim().to_owned();
+        if merkle_hex.is_empty() || repo_id.is_empty() {
+            anyhow::bail!("record provenance denied: empty merkle or repo_id");
+        }
+        {
+            let mut guard = self.inner.write().await;
+            let entry = guard.entry(merkle_hex.clone()).or_default();
+            if !entry.insert(repo_id.clone()) {
+                // Already recorded; nothing to persist.
+                return Ok(());
+            }
+        }
+        self.persist().await.with_context(|| {
+            format!("failed to persist XET provenance for merkle {merkle_hex}")
+        })?;
+        debug!(merkle = %merkle_hex, repo = %repo_id, "recorded XET provenance");
+        Ok(())
+    }
+
+    /// Fail-closed gate check: is `merkle_hex` bound to `repo_id` by a recorded
+    /// provenance entry? Returns `false` (deny) when no record exists.
+    pub async fn is_bound(&self, merkle_hex: &str, repo_id: &str) -> bool {
+        let merkle_hex = merkle_hex.trim().to_ascii_lowercase();
+        let repo_id = repo_id.trim();
+        if merkle_hex.is_empty() || repo_id.is_empty() {
+            return false;
+        }
+        let guard = self.inner.read().await;
+        guard
+            .get(&merkle_hex)
+            .map(|repos| repos.contains(repo_id))
+            .unwrap_or(false)
+    }
+
+    /// Atomically persist the in-memory mapping to disk (tmp file + rename),
+    /// with 0600 permissions (matches the registry metadata posture).
+    async fn persist(&self) -> Result<()> {
+        let snapshot = {
+            let guard = self.inner.read().await;
+            ProvenanceFile {
+                version: default_version(),
+                bindings: guard.clone(),
+            }
+        };
+        let json = serde_json::to_vec_pretty(&snapshot)
+            .context("failed to serialize XET provenance store")?;
+
+        if let Some(parent) = self.path.parent() {
+            if let Err(e) = tokio::fs::create_dir_all(parent).await {
+                warn!(error = %e, dir = %parent.display(), "failed to ensure provenance dir");
+            }
+        }
+
+        let tmp = self.path.with_extension("json.tmp");
+        tokio::fs::write(&tmp, &json)
+            .await
+            .with_context(|| format!("failed to write provenance tmp {}", tmp.display()))?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = tokio::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600)).await;
+        }
+
+        tokio::fs::rename(&tmp, &self.path)
+            .await
+            .with_context(|| format!("failed to rename provenance into place {}", self.path.display()))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    // A 64-hex-char merkle stand-in for "Tenant A's private content".
+    const MERKLE_A: &str = "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1";
+    const REPO_A: &str = "11111111-1111-1111-1111-111111111111";
+    const REPO_B: &str = "22222222-2222-2222-2222-222222222222";
+
+    async fn store_in(dir: &Path) -> XetProvenanceStore {
+        tokio::fs::create_dir_all(dir.join(".registry")).await.unwrap();
+        XetProvenanceStore::load(dir).await.unwrap()
+    }
+
+    /// The core #436 / #509 invariant at the gate layer: a planted pointer with
+    /// NO provenance record must be denied (fail-closed). This is the
+    /// substantive content behind `oid_field_planted_pointer_must_be_denied`.
+    #[tokio::test]
+    async fn oid_field_planted_pointer_must_be_denied() {
+        let dir = tempdir().unwrap();
+        let store = store_in(dir.path()).await;
+
+        // Tenant A genuinely uploaded the bytes → provenance bound to repo A.
+        store.record(MERKLE_A, REPO_A).await.unwrap();
+
+        // Tenant B planted a pointer referencing A's merkle but never uploaded
+        // the bytes → NO provenance binding for repo B → MUST be denied.
+        assert!(
+            !store.is_bound(MERKLE_A, REPO_B).await,
+            "planted-pointer repo B must NOT be entitled to A's merkle"
+        );
+
+        // The legitimate owner (repo A) still resolves.
+        assert!(
+            store.is_bound(MERKLE_A, REPO_A).await,
+            "the repo that genuinely uploaded the merkle must still resolve it"
+        );
+    }
+
+    /// Fail-closed default: an unknown merkle (no record at all) is denied for
+    /// everyone — never falls back to the forgeable pointer check.
+    #[tokio::test]
+    async fn unknown_merkle_denied_fail_closed() {
+        let dir = tempdir().unwrap();
+        let store = store_in(dir.path()).await;
+        assert!(!store.is_bound(MERKLE_A, REPO_A).await);
+        assert!(!store.is_bound(MERKLE_A, REPO_B).await);
+    }
+
+    /// Records survive a reload (persistence), and case/whitespace are normalized.
+    #[tokio::test]
+    async fn provenance_persists_across_reload() {
+        let dir = tempdir().unwrap();
+        {
+            let store = store_in(dir.path()).await;
+            store.record(&MERKLE_A.to_ascii_uppercase(), REPO_A).await.unwrap();
+        }
+        let reloaded = XetProvenanceStore::load(dir.path()).await.unwrap();
+        assert!(reloaded.is_bound(MERKLE_A, REPO_A).await);
+        assert!(!reloaded.is_bound(MERKLE_A, REPO_B).await);
+    }
+
+    /// Global dedup: the same bytes uploaded by two repos bind to both, and each
+    /// is entitled independently.
+    #[tokio::test]
+    async fn shared_bytes_bind_per_repo() {
+        let dir = tempdir().unwrap();
+        let store = store_in(dir.path()).await;
+        store.record(MERKLE_A, REPO_A).await.unwrap();
+        store.record(MERKLE_A, REPO_B).await.unwrap();
+        assert!(store.is_bound(MERKLE_A, REPO_A).await);
+        assert!(store.is_bound(MERKLE_A, REPO_B).await);
+    }
+}


### PR DESCRIPTION
## Authenticated XET write path + provenance-gated read — multitenant XET, functional *and* secure (epic #654)

Lands the **write half** of authenticated XET as one atomic change together with the server-side provenance store and the fail-closed read-gate, so the gate and the writer that populates it go live in the **same commit range** — never a window where the gate denies reads against an empty store.

**Supersedes #511** (its two commits — the provenance store and the read-gate — are included here, authored by @ewindisch). Closing #511 in favour of this.

### Why atomic

- **Read-gate** (`repo_contains_xet_merkle`) denies a `XetMerkle` `getBlob` unless a **server-side provenance record** binds `(merkle → repo)`. Pointer presence is necessary-but-not-sufficient (a checked-in pointer is caller-forgeable — the #436 OID-planting vector).
- **Writer** (`putBlob`) is the *only* thing that records provenance. `XetProvenanceStore::record()` had no production caller — so the gate alone would deny every legitimate read. They must land together. This PR does that.

### What's here (3 commits)

1. **`security(#509): server-side XET provenance store`** (@ewindisch) — `xet_provenance.rs`: persisted `(merkle_hex → {repo_id})` map, 0600, atomic tmp+rename; `record()` / `is_bound()`; wired onto `RegistryService`.
2. **`security(#509): provenance-gate XET getBlob, fail-closed`** (@ewindisch) — `repo_contains_xet_merkle` consults the store **first**; no record ⇒ **deny**, never falls back to the forgeable pointer-only check.
3. **`feat(#654): authenticated putBlob write path`** (this) — the real `handle_put_blob` + the in-process CAS write core:
   - **`cas-serve` lib**: new `CasStore::put_file_bytes(bytes) -> PutResult { merkle, xorb_hashes, bytes_stored }` — chunks (Gearhash CDC), computes the XET merkle **server-side from the bytes**, stores xorbs+shard content-addressed, skips already-present xorbs (global dedup; `bytes_stored` counts only new payload). The binary's `UploadFile` handler now routes through this same method (single implementation).
   - **hyprstream `handle_put_blob`**: validate → resolve `grantRepo` (unknown ⇒ deny) → **authorize `write`** on `model:{repo}` (mirrors `authorize_get_blob`'s `query` check one verb up — a read grant never implies write) → cap at `MAX_INLINE_UPLOAD` (64 MiB DoS guard) → `put_file_bytes` → `record(merkle, repo.id.0.to_string())` (keyed **identically** to the read-gate's `is_bound`). Fail-closed: any error ⇒ error response, nothing stored or recorded.

### The security property

The merkle is **computed by the server from the actual bytes**, never supplied by the caller, and provenance is bound to *who uploaded what through which repo*. So the OID-field-planting class (#436) is closed **by construction**: a tenant can't borrow read access by committing a pointer to someone else's private merkle, because they never uploaded those bytes through their repo — no provenance record, gate denies.

### Not here (tracked follow-ups, #654)

- Streaming upload channel (additive schema field) for GB-class blobs — inline path is capped at 64 MiB.
- Retiring the identity-agnostic `cas-serve` **binary** ingress (the `cas_serve` **library** — CDC/merkle math — stays; it's the interop contract). Task #4.
- Dual-stack HF-XET-wire HTTP face (drop-in "alternative XET backend to HuggingFace"). Separate change (A).

### Verified

- `cargo test -p cas-serve --lib` — **15/15 pass**, incl. 3 new `put_file_bytes` tests: round-trip reconstruction, deterministic server-computed merkle, and full dedup on re-upload (`bytes_stored == 0`).
- `cargo check -p hyprstream --lib` — clean.
- The 4 existing `xet_provenance` unit tests (from #509) still pass; read-gate deny-path unchanged.

Supersedes #511 · closes #509 · closes #436 · advances epic #654.
