### PR TITLE
feat(workers): rootless OCI (podman) SandboxBackend (#346)

### DIFF
--- a/crates/hyprstream-workers/Cargo.toml
+++ b/crates/hyprstream-workers/Cargo.toml
@@ -229,6 +229,16 @@ kata-vm = [
 # doesn't vendor wasmtime; stays torch-free either way. When off, `wasm`
 # selection fails closed (the backend simply isn't registered).
 wasm = ["dep:hyprstream-workers-wasmtime"]
+# Rootless OCI container backend (#346, Worker GA epic #341 / taxonomy #508).
+# Compiles in `OciBackend`, a subprocess sibling of nspawn that drives a rootless
+# OCI runtime (podman by default; the runtime binary is configurable) via CLI
+# shell-out — user-namespaced containers from an OCI image, threading the full CRI
+# PodSandboxConfig (name/labels/annotations/resources/security) into the
+# invocation. Torch-free and needs no new dependencies (only the already-present
+# `which`/`nix`/`tokio` process plumbing), so it just gates the module. Opt-in so
+# the lean build doesn't assume a container runtime is installed. When off, `oci`
+# selection fails closed (the backend simply isn't registered).
+oci = []
 # Enable Dragonball built-in VMM support (alternative to cloud-hypervisor).
 # Implies `kata-vm` since it tunes the kata hypervisor abstraction.
 dragonball = ["kata-vm", "kata-hypervisor/dragonball"]

--- a/crates/hyprstream-workers/src/runtime/mod.rs
+++ b/crates/hyprstream-workers/src/runtime/mod.rs
@@ -35,6 +35,12 @@ pub mod kata_backend;
 #[cfg(feature = "kata-vm")]
 pub mod kata_agent;
 pub mod nspawn;
+// Rootless OCI container backend (#346) — gated behind `oci`. Drives a rootless
+// OCI runtime (podman by default) via CLI shell-out; torch-free, no VM toolchain.
+// A subprocess sibling of nspawn under the SandboxBackend seam. Off by default so
+// the lean build doesn't assume a container runtime is installed.
+#[cfg(feature = "oci")]
+pub mod oci_backend;
 mod pool;
 mod sandbox;
 // In-process WebAssembly sandbox backend (#505 P2) — gated behind `wasm`
@@ -97,6 +103,8 @@ pub use exec_mount::ExecMount;
 #[cfg(feature = "kata-vm")]
 pub use kata_backend::{KataBackend, KataHandle};
 pub use nspawn::{NspawnBackend, NspawnConfig, NspawnHandle};
+#[cfg(feature = "oci")]
+pub use oci_backend::{OciBackend, OciConfig, OciHandle};
 #[cfg(feature = "wasm")]
 pub use wasm_backend::{WasmBackend, WasmConfig, WasmHandle};
 // Inventory-based backend registry + fail-closed selection spine (#507)

--- a/crates/hyprstream-workers/src/runtime/oci_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/oci_backend.rs
@@ -1,0 +1,780 @@
+//! OciBackend — rootless OCI container sandbox isolation (#346)
+//!
+//! A subprocess-driving sibling to [`super::nspawn::NspawnBackend`]: instead of
+//! `systemd-nspawn`, it drives a **rootless OCI runtime** (podman by default) to
+//! run each pod sandbox as a real, user-namespaced container from an OCI image.
+//!
+//! Decision D2 of #346 — *"podman/docker shell-out vs embedded youki/crun"* — is
+//! resolved here in favour of the **rootless `podman` CLI shell-out**: it is the
+//! simplest correct path for a casual user (no root, no daemon, seccomp + user
+//! namespaces + a real image rootfs out of the box) and keeps this backend
+//! torch-free with no new heavyweight dependencies. The runtime binary is
+//! configurable ([`OciConfig::runtime_bin`]) so a drop-in replacement (docker,
+//! nerdctl) works without code changes; podman is only the documented default.
+//!
+//! An earlier attempt (#484) shelled out to the podman CLI but was rejected for
+//! *"podman-CLI, drops CRI config, dead code"*. This implementation deliberately
+//! **threads the CRI [`PodSandboxConfig`] through the invocation** rather than
+//! dropping it: pod name/namespace/uid → container name + labels, `labels` →
+//! `--label`, `annotations` → `--annotation` (plus the `hyprstream.io/*`
+//! image/env/mount/gpu keys), `linux.resources` → cgroup flags
+//! (`--cpu-period`/`--cpu-quota`/`--cpu-shares`/`--memory`/`--cpuset-*`), and
+//! `linux.security_context` → `--user`/`--read-only`. Nothing here is dead: every
+//! lifecycle method issues a concrete runtime command.
+//!
+//! ## Lifecycle mapping onto the runtime CLI
+//!
+//! | `SandboxBackend`   | podman realisation                                        |
+//! |--------------------|-----------------------------------------------------------|
+//! | `start`            | `podman run --detach …` from the resolved image; poll `inspect` for `State.Running`; stash container id/name in a downcastable [`OciHandle`] |
+//! | `exec_sync`        | `podman exec <name> -- <cmd…>` (timeout-bounded)          |
+//! | `get_pids`         | `podman inspect --format '{{.State.Pid}}' <name>`        |
+//! | `update_resources` | `podman update <name>` with the new cgroup flags          |
+//! | `stop`             | `podman stop <name>`                                      |
+//! | `destroy`          | `podman rm -f <name>` + sandbox dir cleanup               |
+//! | `reset`            | ephemeral (like nspawn) → `false` (recreate, don't reuse) |
+//!
+//! ## Image sourcing
+//!
+//! The image reference is taken, in order of precedence, from the
+//! `hyprstream.io/oci-image` annotation, then [`OciConfig::default_image`]. The
+//! default is a CRI-style **pause/infra image** so an empty `auto`-selected
+//! sandbox still comes up idle (a pod sandbox *is* the pause container in CRI);
+//! real workloads override it via the annotation.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tracing::{debug, info, warn};
+
+use crate::config::PoolConfig;
+use crate::error::{Result, WorkerError};
+
+use super::backend::{SandboxBackend, SandboxHandle};
+use super::client::{LinuxContainerResources, PodSandboxConfig};
+use super::sandbox::PodSandbox;
+
+/// Annotation key: OCI image reference to run (overrides [`OciConfig::default_image`]).
+const ANN_OCI_IMAGE: &str = "hyprstream.io/oci-image";
+/// Annotation key prefix: per-variable container environment (`hyprstream.io/env.FOO=bar`).
+const ANN_ENV_PREFIX: &str = "hyprstream.io/env.";
+/// Annotation key prefix: bind mount spec (`hyprstream.io/mount.data=/host:/ctr[:ro]`).
+const ANN_MOUNT_PREFIX: &str = "hyprstream.io/mount.";
+/// Annotation key: request GPU device pass-through (`hyprstream.io/gpu=true`).
+const ANN_GPU: &str = "hyprstream.io/gpu";
+
+/// Default OCI runtime binary (rootless podman).
+const DEFAULT_RUNTIME_BIN: &str = "podman";
+/// Default sandbox/infra image (CRI pause semantics): comes up and idles.
+const DEFAULT_PAUSE_IMAGE: &str = "registry.k8s.io/pause:3.10";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Configuration
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Configuration for the rootless OCI backend.
+#[derive(Debug, Clone)]
+pub struct OciConfig {
+    /// OCI runtime binary to shell out to. Default: `podman` (rootless). A
+    /// drop-in CLI-compatible runtime (docker, nerdctl) works by overriding this.
+    pub runtime_bin: PathBuf,
+    /// Image used when no `hyprstream.io/oci-image` annotation is supplied.
+    /// Defaults to a CRI pause/infra image so a bare sandbox still comes up idle.
+    pub default_image: String,
+    /// Run the runtime rootless (podman's default for a non-root user).
+    pub rootless: bool,
+    /// Container network mode passed to `--network` (empty = runtime default,
+    /// which for rootless podman is an isolated slirp4netns/pasta network).
+    pub network_mode: String,
+    /// GPU device nodes to pass through (auto-detected from `/dev/dri`) when a
+    /// sandbox requests `hyprstream.io/gpu=true`.
+    pub gpu_devices: Vec<PathBuf>,
+    /// Readiness poll timeout (waiting for `State.Running`).
+    pub ready_timeout: Duration,
+    /// Readiness poll interval.
+    pub ready_interval: Duration,
+}
+
+impl Default for OciConfig {
+    fn default() -> Self {
+        let runtime_bin = std::env::var("HYPRSTREAM_OCI_RUNTIME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from(DEFAULT_RUNTIME_BIN));
+
+        let default_image = std::env::var("HYPRSTREAM_OCI_IMAGE")
+            .unwrap_or_else(|_| DEFAULT_PAUSE_IMAGE.to_owned());
+
+        Self {
+            runtime_bin,
+            default_image,
+            rootless: !nix::unistd::geteuid().is_root(),
+            network_mode: String::new(),
+            gpu_devices: detect_gpu_devices(),
+            ready_timeout: Duration::from_secs(30),
+            ready_interval: Duration::from_millis(200),
+        }
+    }
+}
+
+/// Auto-detect GPU render/card nodes under `/dev/dri` (shared with nspawn's shape).
+fn detect_gpu_devices() -> Vec<PathBuf> {
+    let dri = Path::new("/dev/dri");
+    if !dri.exists() {
+        return Vec::new();
+    }
+    let mut devices = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(dri) {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if name.starts_with("card") || name.starts_with("renderD") {
+                devices.push(entry.path());
+            }
+        }
+    }
+    devices
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Handle
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Backend-specific state stored on each `PodSandbox`.
+#[derive(Debug, Clone)]
+pub struct OciHandle {
+    /// Sandbox identifier (matches `PodSandbox::id`).
+    pub sandbox_id: String,
+    /// Container name passed to `--name` (`hyprstream-<id>`).
+    pub container_name: String,
+    /// The resolved image reference this sandbox is running.
+    pub image: String,
+    /// Container id reported by the runtime after start (populated on success).
+    pub container_id: Option<String>,
+    /// Host-side sandbox directory for bind-mounts.
+    pub sandbox_path: PathBuf,
+}
+
+impl SandboxHandle for OciHandle {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Backend
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Rootless OCI (podman) sandbox backend.
+pub struct OciBackend {
+    config: OciConfig,
+}
+
+impl OciBackend {
+    pub fn new(config: OciConfig) -> Self {
+        Self { config }
+    }
+
+    /// Stable container name for a sandbox id.
+    fn container_name(sandbox_id: &str) -> String {
+        format!("hyprstream-{sandbox_id}")
+    }
+
+    /// Runtime prerequisite probe for the backend registry: the runtime binary
+    /// must be on PATH, and it must be usable rootless. We approximate the
+    /// rootless-capability check cheaply and synchronously (the registry probe is
+    /// a bare `fn() -> bool`): either we are already root (containers run
+    /// directly), or the `newuidmap`/`newgidmap` helpers that rootless podman
+    /// needs for user-namespace setup are installed. Mirrors the instance-level
+    /// [`SandboxBackend::is_available`]. Fail-closed: any doubt → `false`.
+    fn registry_is_available() -> bool {
+        Self::runtime_available(DEFAULT_RUNTIME_BIN)
+    }
+
+    /// Shared availability logic for a given runtime binary name/path.
+    fn runtime_available(runtime_bin: &str) -> bool {
+        if which::which(runtime_bin).is_err() {
+            return false;
+        }
+        // Root can run containers without the rootless uid-map helpers.
+        if nix::unistd::geteuid().is_root() {
+            return true;
+        }
+        // Rootless podman relies on newuidmap/newgidmap (the `uidmap` package)
+        // to configure the user namespace. Their presence is a good, cheap
+        // signal that rootless containers can actually be created here.
+        which::which("newuidmap").is_ok() && which::which("newgidmap").is_ok()
+    }
+
+    /// Resolve the image reference: annotation override → configured default.
+    fn resolve_image(&self, annotations: &HashMap<String, String>) -> String {
+        annotations
+            .get(ANN_OCI_IMAGE)
+            .cloned()
+            .unwrap_or_else(|| self.config.default_image.clone())
+    }
+
+    /// Build the `podman run` argument list for a sandbox, threading the full CRI
+    /// [`PodSandboxConfig`] (metadata, labels, annotations, resources, security
+    /// context) into the invocation. `annotations` is the canonical annotation
+    /// map supplied by the pool; it also drives image/env/mount/gpu selection.
+    fn build_run_args(
+        &self,
+        sandbox: &PodSandbox,
+        container_name: &str,
+        image: &str,
+        config: &PodSandboxConfig,
+        annotations: &HashMap<String, String>,
+    ) -> Vec<String> {
+        let mut args: Vec<String> = vec!["run".into(), "--detach".into()];
+
+        // Identity: container name + hostname from pod metadata.
+        args.push(format!("--name={container_name}"));
+        let hostname = if config.metadata.name.is_empty() {
+            sandbox.id.clone()
+        } else {
+            config.metadata.name.clone()
+        };
+        args.push(format!("--hostname={hostname}"));
+
+        // CRI identity as labels (so `podman ps --filter label=…` can find pods).
+        args.push(format!("--label=io.hyprstream.sandbox-id={}", sandbox.id));
+        if !config.metadata.name.is_empty() {
+            args.push(format!("--label=io.hyprstream.pod-name={}", config.metadata.name));
+        }
+        if !config.metadata.namespace.is_empty() {
+            args.push(format!("--label=io.hyprstream.namespace={}", config.metadata.namespace));
+        }
+        if !config.metadata.uid.is_empty() {
+            args.push(format!("--label=io.hyprstream.uid={}", config.metadata.uid));
+        }
+        // Pod-supplied labels — threaded verbatim, not dropped.
+        for kv in &config.labels {
+            args.push(format!("--label={}={}", kv.key, kv.value));
+        }
+
+        // Annotations: preserved on the container (CRI parity), and the
+        // `hyprstream.io/*` keys additionally drive env/mount/gpu below.
+        for (k, v) in annotations {
+            args.push(format!("--annotation={k}={v}"));
+        }
+
+        // Environment: always mark the instance; then any `hyprstream.io/env.*`.
+        args.push(format!("--env=HYPRSTREAM_INSTANCE={}", sandbox.id));
+        for (k, v) in annotations {
+            if let Some(name) = k.strip_prefix(ANN_ENV_PREFIX) {
+                if !name.is_empty() {
+                    args.push(format!("--env={name}={v}"));
+                }
+            }
+        }
+
+        // Bind the host-side sandbox runtime directory so state/sockets are
+        // visible on the host (matches nspawn's runtime-dir sharing).
+        args.push(format!(
+            "--volume={}:{}",
+            sandbox.sandbox_path().display(),
+            sandbox.sandbox_path().display()
+        ));
+        // Explicit bind mounts from annotations: `host:container[:ro]`.
+        for (k, v) in annotations {
+            if k.starts_with(ANN_MOUNT_PREFIX) {
+                if let Some(volume) = normalize_mount_spec(v) {
+                    args.push(format!("--volume={volume}"));
+                } else {
+                    warn!(sandbox_id = %sandbox.id, spec = %v, "ignoring malformed mount annotation");
+                }
+            }
+        }
+
+        // GPU pass-through when requested.
+        let wants_gpu = annotations.get(ANN_GPU).is_some_and(|v| v == "true");
+        if wants_gpu {
+            for dev in &self.config.gpu_devices {
+                args.push(format!("--device={}", dev.display()));
+            }
+        }
+
+        // Network isolation mode (runtime default when unset).
+        if !self.config.network_mode.is_empty() {
+            args.push(format!("--network={}", self.config.network_mode));
+        }
+
+        // Resource limits → cgroup flags from `linux.resources`.
+        apply_resource_args(&config.linux.resources, &mut args);
+
+        // Security context → rootless-safe subset (uid + read-only rootfs).
+        let sc = &config.linux.security_context;
+        if sc.run_as_user > 0 {
+            if sc.run_as_group > 0 {
+                args.push(format!("--user={}:{}", sc.run_as_user, sc.run_as_group));
+            } else {
+                args.push(format!("--user={}", sc.run_as_user));
+            }
+        }
+        if sc.readonly_rootfs {
+            args.push("--read-only".into());
+        }
+
+        // Image to run (positional, last before any command).
+        args.push(image.to_owned());
+
+        args
+    }
+
+    /// Inspect a container field via `podman inspect --format`.
+    async fn inspect(&self, container_name: &str, format: &str) -> Option<String> {
+        let output = tokio::process::Command::new(&self.config.runtime_bin)
+            .args(["inspect", "--format", format, container_name])
+            .output()
+            .await
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let s = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+        if s.is_empty() {
+            None
+        } else {
+            Some(s)
+        }
+    }
+
+    /// Poll `inspect` until the container reports `State.Running == true`.
+    async fn wait_for_running(&self, container_name: &str, sandbox_id: &str) -> Result<()> {
+        let deadline = tokio::time::Instant::now() + self.config.ready_timeout;
+        while tokio::time::Instant::now() < deadline {
+            if let Some(state) = self.inspect(container_name, "{{.State.Running}}").await {
+                if state == "true" {
+                    debug!(sandbox_id, container = %container_name, "OCI sandbox running");
+                    return Ok(());
+                }
+            }
+            tokio::time::sleep(self.config.ready_interval).await;
+        }
+        Err(WorkerError::SandboxTimeout {
+            operation: format!("oci readiness ({sandbox_id})"),
+            timeout_secs: self.config.ready_timeout.as_secs(),
+        })
+    }
+}
+
+/// Translate a `host:container[:ro]` annotation spec into a podman `--volume`
+/// value, rejecting empty/incomplete specs. Returns `None` when malformed.
+fn normalize_mount_spec(spec: &str) -> Option<String> {
+    let mut parts = spec.splitn(3, ':');
+    let host = parts.next().filter(|s| !s.is_empty())?;
+    let ctr = parts.next().filter(|s| !s.is_empty())?;
+    match parts.next() {
+        Some(mode) if mode == "ro" || mode == "rw" => Some(format!("{host}:{ctr}:{mode}")),
+        Some(_) => None,
+        None => Some(format!("{host}:{ctr}")),
+    }
+}
+
+/// Append cgroup resource flags derived from CRI [`LinuxContainerResources`].
+fn apply_resource_args(res: &LinuxContainerResources, args: &mut Vec<String>) {
+    if res.cpu_period > 0 {
+        args.push(format!("--cpu-period={}", res.cpu_period));
+    }
+    if res.cpu_quota > 0 {
+        args.push(format!("--cpu-quota={}", res.cpu_quota));
+    }
+    if res.cpu_shares > 0 {
+        args.push(format!("--cpu-shares={}", res.cpu_shares));
+    }
+    if res.memory_limit_in_bytes > 0 {
+        args.push(format!("--memory={}", res.memory_limit_in_bytes));
+    }
+    if !res.cpuset_cpus.is_empty() {
+        args.push(format!("--cpuset-cpus={}", res.cpuset_cpus));
+    }
+    if !res.cpuset_mems.is_empty() {
+        args.push(format!("--cpuset-mems={}", res.cpuset_mems));
+    }
+}
+
+impl std::fmt::Debug for OciBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OciBackend")
+            .field("config", &self.config)
+            .finish()
+    }
+}
+
+#[async_trait]
+impl SandboxBackend for OciBackend {
+    fn backend_type(&self) -> &'static str {
+        "oci"
+    }
+
+    fn is_available(&self) -> bool {
+        Self::runtime_available(&self.config.runtime_bin.to_string_lossy())
+    }
+
+    async fn initialize(&self, _config: &PoolConfig) -> Result<()> {
+        if !self.is_available() {
+            return Err(WorkerError::ConfigError(format!(
+                "OCI runtime '{}' not found on PATH or rootless prerequisites \
+                 (newuidmap/newgidmap) missing",
+                self.config.runtime_bin.display()
+            )));
+        }
+        if !self.config.rootless {
+            warn!(
+                "OCI backend running as root — containers will NOT be user-namespaced \
+                 rootless; prefer running the daemon as a non-root user"
+            );
+        }
+        Ok(())
+    }
+
+    async fn start(
+        &self,
+        sandbox: &mut PodSandbox,
+        config: &PodSandboxConfig,
+        pool_config: &PoolConfig,
+        annotations: &HashMap<String, String>,
+    ) -> Result<Arc<dyn SandboxHandle>> {
+        let container_name = Self::container_name(&sandbox.id);
+        let image = self.resolve_image(annotations);
+
+        // Ensure the sandbox runtime directory exists (bind target).
+        let sandbox_path = pool_config.runtime_dir.join(&sandbox.id);
+        tokio::fs::create_dir_all(&sandbox_path).await?;
+        sandbox.sandbox_path = sandbox_path.clone();
+
+        let run_args =
+            self.build_run_args(sandbox, &container_name, &image, config, annotations);
+
+        info!(
+            sandbox_id = %sandbox.id,
+            container = %container_name,
+            image = %image,
+            runtime = %self.config.runtime_bin.display(),
+            "Starting rootless OCI sandbox"
+        );
+
+        let output = tokio::process::Command::new(&self.config.runtime_bin)
+            .args(&run_args)
+            .output()
+            .await
+            .map_err(|e| {
+                WorkerError::SandboxCreationFailed(format!(
+                    "failed to spawn '{}' run: {e}",
+                    self.config.runtime_bin.display()
+                ))
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(WorkerError::SandboxCreationFailed(format!(
+                "'{} run' failed for sandbox '{}': {}",
+                self.config.runtime_bin.display(),
+                sandbox.id,
+                stderr.trim()
+            )));
+        }
+
+        // Wait for the container to actually be running before reporting ready.
+        self.wait_for_running(&container_name, &sandbox.id).await?;
+
+        let container_id = self.inspect(&container_name, "{{.Id}}").await;
+
+        let handle = Arc::new(OciHandle {
+            sandbox_id: sandbox.id.clone(),
+            container_name: container_name.clone(),
+            image,
+            container_id: container_id.clone(),
+            sandbox_path,
+        });
+
+        sandbox.mark_ready();
+        info!(
+            sandbox_id = %sandbox.id,
+            container = %container_name,
+            container_id = ?container_id,
+            "OCI sandbox started"
+        );
+
+        Ok(handle)
+    }
+
+    async fn stop(&self, sandbox: &PodSandbox) -> Result<()> {
+        let container_name = Self::container_name(&sandbox.id);
+        info!(sandbox_id = %sandbox.id, container = %container_name, "Stopping OCI sandbox");
+
+        let status = tokio::process::Command::new(&self.config.runtime_bin)
+            .args(["stop", &container_name])
+            .status()
+            .await
+            .map_err(|e| WorkerError::VmStopFailed(format!("failed to run stop: {e}")))?;
+
+        if !status.success() {
+            warn!(
+                sandbox_id = %sandbox.id,
+                "container stop returned non-zero (may already be stopped)"
+            );
+        }
+        Ok(())
+    }
+
+    async fn destroy(&self, sandbox: &PodSandbox) -> Result<()> {
+        let container_name = Self::container_name(&sandbox.id);
+        info!(sandbox_id = %sandbox.id, container = %container_name, "Destroying OCI sandbox");
+
+        // Force-remove the container (also stops it).
+        let _ = tokio::process::Command::new(&self.config.runtime_bin)
+            .args(["rm", "-f", &container_name])
+            .status()
+            .await;
+
+        // Clean up the host-side sandbox directory.
+        let sandbox_path = sandbox.sandbox_path();
+        if sandbox_path.exists() {
+            if let Err(e) = tokio::fs::remove_dir_all(sandbox_path).await {
+                warn!(sandbox_id = %sandbox.id, error = %e, "Failed to remove sandbox directory");
+            }
+        }
+        Ok(())
+    }
+
+    async fn reset(&self, _sandbox: &mut PodSandbox) -> Result<bool> {
+        // OCI containers are ephemeral here — recreate rather than reuse in place.
+        Ok(false)
+    }
+
+    async fn get_pids(&self, sandbox: &PodSandbox) -> Result<Vec<u32>> {
+        let container_name = Self::container_name(&sandbox.id);
+        match self.inspect(&container_name, "{{.State.Pid}}").await {
+            Some(pid) => match pid.parse::<u32>() {
+                Ok(0) | Err(_) => Ok(Vec::new()),
+                Ok(p) => Ok(vec![p]),
+            },
+            None => Ok(Vec::new()),
+        }
+    }
+
+    fn supports_exec(&self) -> bool {
+        true
+    }
+
+    async fn exec_sync(
+        &self,
+        sandbox: &PodSandbox,
+        command: &[String],
+        timeout_secs: u64,
+    ) -> Result<(i32, Vec<u8>, Vec<u8>)> {
+        if command.is_empty() {
+            return Err(WorkerError::ExecFailed(
+                "exec_sync: empty command".into(),
+            ));
+        }
+        let container_name = Self::container_name(&sandbox.id);
+
+        let mut args = vec!["exec".to_owned(), container_name, "--".to_owned()];
+        args.extend_from_slice(command);
+
+        let output = tokio::time::timeout(
+            Duration::from_secs(timeout_secs),
+            tokio::process::Command::new(&self.config.runtime_bin)
+                .args(&args)
+                .output(),
+        )
+        .await
+        .map_err(|_| WorkerError::SandboxTimeout {
+            operation: format!("exec_sync in {}", sandbox.id),
+            timeout_secs,
+        })?
+        .map_err(|e| WorkerError::ExecFailed(format!("exec failed: {e}")))?;
+
+        let exit_code = output.status.code().unwrap_or(-1);
+        Ok((exit_code, output.stdout, output.stderr))
+    }
+
+    async fn update_resources(
+        &self,
+        sandbox: &PodSandbox,
+        resources: &LinuxContainerResources,
+    ) -> Result<()> {
+        let container_name = Self::container_name(&sandbox.id);
+
+        // Re-derive the cgroup flags and hand them to `podman update`.
+        let mut update_args: Vec<String> = vec!["update".into()];
+        apply_resource_args(resources, &mut update_args);
+        if update_args.len() == 1 {
+            // Nothing to change.
+            return Ok(());
+        }
+        update_args.push(container_name);
+
+        let _ = tokio::process::Command::new(&self.config.runtime_bin)
+            .args(&update_args)
+            .status()
+            .await;
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Backend registry self-registration (#507 / #518) — gated on the `oci` feature
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Registered only when compiled with `--features oci`. Mirrors how `kata`
+// registers under `kata-vm` and `wasm` under `wasm`: with the feature off the
+// `oci` name simply isn't in the registry, so an explicit request fails closed
+// ("unknown backend") rather than silently downgrading.
+//
+// Unlike the in-process `wasm` tier, a rootless OCI container is a *real*
+// kernel-namespace isolation boundary (user namespaces + seccomp + dedicated
+// image rootfs), so it is `auto_selectable: true`. Its priority sits above
+// `nspawn` (10) — a rootless container with its own image rootfs is a fuller
+// isolation boundary than nspawn sharing the host root — and below the `kata`
+// VM tier, so `"auto"` prefers kata > oci > nspawn when each is available.
+inventory::submit! {
+    crate::runtime::selection::BackendRegistration {
+        name: "oci",
+        priority: 20,
+        auto_selectable: true,
+        is_available: OciBackend::registry_is_available,
+        construct: |_ctx| {
+            Ok(std::sync::Arc::new(OciBackend::new(OciConfig::default()))
+                as std::sync::Arc<dyn crate::runtime::SandboxBackend>)
+        },
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::super::client::{KeyValue, PodSandboxConfig};
+    use super::*;
+    use std::path::PathBuf;
+
+    fn new_pod(id: &str, cfg: &PodSandboxConfig) -> PodSandbox {
+        PodSandbox::new(id.to_owned(), cfg, PathBuf::from("/tmp/oci-test"))
+    }
+
+    #[test]
+    fn backend_type_is_oci() {
+        let backend = OciBackend::new(OciConfig::default());
+        assert_eq!(backend.backend_type(), "oci");
+    }
+
+    #[test]
+    fn default_runtime_is_podman() {
+        // Absent an env override, the documented default runtime is podman.
+        std::env::remove_var("HYPRSTREAM_OCI_RUNTIME");
+        let config = OciConfig::default();
+        assert_eq!(config.runtime_bin, PathBuf::from("podman"));
+    }
+
+    #[test]
+    fn handle_downcasts() {
+        let handle: Arc<dyn SandboxHandle> = Arc::new(OciHandle {
+            sandbox_id: "abc".into(),
+            container_name: "hyprstream-abc".into(),
+            image: "img:latest".into(),
+            container_id: Some("deadbeef".into()),
+            sandbox_path: PathBuf::from("/tmp/x"),
+        });
+        let down = handle.as_any().downcast_ref::<OciHandle>();
+        assert!(down.is_some());
+        assert_eq!(down.unwrap().sandbox_id, "abc");
+        assert_eq!(down.unwrap().container_name, "hyprstream-abc");
+    }
+
+    #[test]
+    fn image_annotation_overrides_default() {
+        let backend = OciBackend::new(OciConfig::default());
+        let mut ann = HashMap::new();
+        assert_eq!(backend.resolve_image(&ann), DEFAULT_PAUSE_IMAGE);
+        ann.insert(ANN_OCI_IMAGE.into(), "alpine:3.20".into());
+        assert_eq!(backend.resolve_image(&ann), "alpine:3.20");
+    }
+
+    #[test]
+    fn mount_spec_normalization() {
+        assert_eq!(
+            normalize_mount_spec("/h:/c"),
+            Some("/h:/c".to_owned())
+        );
+        assert_eq!(
+            normalize_mount_spec("/h:/c:ro"),
+            Some("/h:/c:ro".to_owned())
+        );
+        assert_eq!(
+            normalize_mount_spec("/h:/c:rw"),
+            Some("/h:/c:rw".to_owned())
+        );
+        // Malformed / unsupported mode → rejected.
+        assert_eq!(normalize_mount_spec("/h"), None);
+        assert_eq!(normalize_mount_spec("/h:/c:bogus"), None);
+        assert_eq!(normalize_mount_spec(""), None);
+    }
+
+    #[test]
+    fn resource_args_are_threaded_not_dropped() {
+        let mut res = LinuxContainerResources::default();
+        res.cpu_period = 100_000;
+        res.cpu_quota = 50_000;
+        res.cpu_shares = 512;
+        res.memory_limit_in_bytes = 268_435_456;
+        res.cpuset_cpus = "0-1".into();
+
+        let mut args = Vec::new();
+        apply_resource_args(&res, &mut args);
+
+        assert!(args.contains(&"--cpu-period=100000".to_owned()));
+        assert!(args.contains(&"--cpu-quota=50000".to_owned()));
+        assert!(args.contains(&"--cpu-shares=512".to_owned()));
+        assert!(args.contains(&"--memory=268435456".to_owned()));
+        assert!(args.contains(&"--cpuset-cpus=0-1".to_owned()));
+    }
+
+    #[test]
+    fn run_args_thread_cri_config() {
+        let backend = OciBackend::new(OciConfig::default());
+        let mut cfg = PodSandboxConfig::default();
+        cfg.metadata.name = "my-pod".to_owned();
+        cfg.metadata.namespace = "team-a".to_owned();
+        cfg.metadata.uid = "uid-123".to_owned();
+        cfg.labels = vec![KeyValue {
+            key: "app".into(),
+            value: "demo".into(),
+        }];
+        cfg.linux.resources.memory_limit_in_bytes = 134_217_728;
+
+        let pod = new_pod("sb-1", &cfg);
+        let mut ann = HashMap::new();
+        ann.insert("hyprstream.io/env.FOO".into(), "bar".into());
+        ann.insert("hyprstream.io/mount.data".into(), "/host:/data:ro".into());
+
+        let args = backend.build_run_args(
+            &pod,
+            "hyprstream-sb-1",
+            "alpine:latest",
+            &cfg,
+            &ann,
+        );
+
+        // Identity threaded.
+        assert!(args.contains(&"--name=hyprstream-sb-1".to_owned()));
+        assert!(args.contains(&"--hostname=my-pod".to_owned()));
+        assert!(args.contains(&"--label=io.hyprstream.sandbox-id=sb-1".to_owned()));
+        assert!(args.contains(&"--label=io.hyprstream.namespace=team-a".to_owned()));
+        assert!(args.contains(&"--label=io.hyprstream.uid=uid-123".to_owned()));
+        assert!(args.contains(&"--label=app=demo".to_owned()));
+        // Env + mount threaded (not dropped).
+        assert!(args.contains(&"--env=FOO=bar".to_owned()));
+        assert!(args.contains(&"--volume=/host:/data:ro".to_owned()));
+        assert!(args.contains(&"--env=HYPRSTREAM_INSTANCE=sb-1".to_owned()));
+        // Resources threaded.
+        assert!(args.contains(&"--memory=134217728".to_owned()));
+        // Image is the last positional argument.
+        assert_eq!(args.last().unwrap(), "alpine:latest");
+    }
+}

--- a/crates/hyprstream-workers/src/runtime/selection.rs
+++ b/crates/hyprstream-workers/src/runtime/selection.rs
@@ -374,12 +374,11 @@ mod tests {
         // YAGNI: still-speculative tiers must not be in the registry until built.
         // `wasm` (#505 P2) and `oci` (#346) are now real backends, each handled by
         // its own feature-tracking test below; only `cri` remains speculative.
-        for name in ["cri"] {
-            assert!(
-                !inventory::iter::<BackendRegistration>().any(|r| r.name == name),
-                "speculative backend '{name}' must not be registered (YAGNI)"
-            );
-        }
+        let name = "cri";
+        assert!(
+            !inventory::iter::<BackendRegistration>().any(|r| r.name == name),
+            "speculative backend '{name}' must not be registered (YAGNI)"
+        );
     }
 
     #[test]

--- a/crates/hyprstream-workers/src/runtime/selection.rs
+++ b/crates/hyprstream-workers/src/runtime/selection.rs
@@ -11,10 +11,15 @@
 //!
 //! * `nspawn` — always registered (systemd-nspawn lightweight container).
 //! * `kata`   — registered only under the `kata-vm` feature (full VM isolation).
+//! * `oci`    — registered only under the `oci` feature (rootless OCI/podman
+//!   container, #346).
+//! * `wasm`   — registered only under the `wasm` feature (in-process WebAssembly,
+//!   explicit-name-only).
 //!
-//! YAGNI: speculative tiers (Oci/Cri/Wasm) are intentionally **not** registered.
-//! They gain a `submit!` when their phase actually builds them; until then they
-//! simply do not exist as selectable names (an explicit request errors).
+//! YAGNI: still-speculative tiers (e.g. a raw `cri` shim) are intentionally
+//! **not** registered. They gain a `submit!` when their phase actually builds
+//! them; until then they simply do not exist as selectable names (an explicit
+//! request errors).
 //!
 //! Selection is **config-driven** via `worker.backend` (a string: a registered
 //! backend name, or `"auto"`):
@@ -366,15 +371,47 @@ mod tests {
 
     #[test]
     fn no_speculative_backends_registered() {
-        // YAGNI: still-speculative tiers (Oci/Cri) must not be in the registry
-        // until built. `wasm` is now a real backend (#505 P2) and is handled
-        // separately below — it registers iff the `wasm` feature is on.
-        for name in ["oci", "cri"] {
+        // YAGNI: still-speculative tiers must not be in the registry until built.
+        // `wasm` (#505 P2) and `oci` (#346) are now real backends, each handled by
+        // its own feature-tracking test below; only `cri` remains speculative.
+        for name in ["cri"] {
             assert!(
                 !inventory::iter::<BackendRegistration>().any(|r| r.name == name),
                 "speculative backend '{name}' must not be registered (YAGNI)"
             );
         }
+    }
+
+    #[test]
+    fn registry_contains_oci_only_under_feature() {
+        // The rootless OCI (podman) backend (#346) registers iff built with
+        // `--features oci`. With the feature off it must NOT be a selectable name
+        // (fail-closed), mirroring `wasm`/`kata`.
+        let has_oci = inventory::iter::<BackendRegistration>().any(|r| r.name == "oci");
+        assert_eq!(
+            has_oci,
+            cfg!(feature = "oci"),
+            "oci registration must track the oci feature"
+        );
+    }
+
+    #[cfg(feature = "oci")]
+    #[test]
+    fn oci_is_auto_selectable_and_outranks_nspawn() {
+        // A rootless container (user namespaces + seccomp + its own image rootfs)
+        // is a real isolation tier, so — unlike the in-process `wasm` backend — it
+        // is auto-selectable and outranks nspawn (host-rootfs sharing).
+        let oci = inventory::iter::<BackendRegistration>()
+            .find(|r| r.name == "oci")
+            .expect("oci registered under the oci feature");
+        let nspawn = inventory::iter::<BackendRegistration>()
+            .find(|r| r.name == "nspawn")
+            .expect("nspawn always registered");
+        assert!(oci.auto_selectable, "oci is a real isolation tier → auto-selectable");
+        assert!(
+            oci.priority > nspawn.priority,
+            "rootless OCI must outrank nspawn for auto-selection"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a rootless-container **OCI `SandboxBackend`** to `hyprstream-workers` (#346), a subprocess sibling of the existing `nspawn` backend under the `SandboxBackend` seam. It drives a **rootless OCI runtime — podman by default (runtime binary configurable)** via CLI shell-out to run each pod sandbox as a real, user-namespaced container from an OCI image.

Resolves **decision D2 of #346** ("podman/docker shell-out vs embedded youki/crun") in favour of the rootless `podman` CLI: the simplest correct path for a casual user (no root, no daemon, user namespaces + seccomp + a real image rootfs), torch-free with no new dependencies.

## What it does

- **`runtime/oci_backend.rs`** — `OciBackend` implementing the full `SandboxBackend` lifecycle:
  - `start` → `podman run --detach …`, polls `podman inspect` for `State.Running`, stashes container id/name in a downcastable `OciHandle`
  - `exec_sync` → `podman exec` (timeout-bounded); `get_pids` → `inspect .State.Pid`; `update_resources` → `podman update`; `stop`/`destroy` → `podman stop`/`rm -f` + dir cleanup; `reset` → ephemeral (recreate, like nspawn)
- **Threads the CRI `PodSandboxConfig` through the invocation** (directly addressing the #484 rejection for "drops CRI config, dead code"): pod name/namespace/uid → container name + labels, `labels` → `--label`, `annotations` → `--annotation` (plus `hyprstream.io/{oci-image,env.*,mount.*,gpu}` keys), `linux.resources` → `--cpu-period/--cpu-quota/--cpu-shares/--memory/--cpuset-*`, `linux.security_context` → `--user`/`--read-only`. Every lifecycle method issues a concrete runtime command — nothing dead.
- **Registers via `inventory::submit!`** with `priority: 20` (above `nspawn`'s 10, below the `kata` VM tier) and `auto_selectable: true` — a rootless container is a real kernel-namespace isolation tier (unlike the explicit-only in-process `wasm` backend). Fail-closed `is_available` probes runtime presence + rootless capability (`newuidmap`/`newgidmap`, or root).
- **Feature-gated behind a new `oci` feature** (torch-free, opt-in like `wasm`) in `Cargo.toml` + `mod.rs`. When off, the backend simply isn't registered and `oci` selection fails closed ("unknown backend"). Updated `selection.rs` tests: `no_speculative_backends_registered` (now only `cri`), added `registry_contains_oci_only_under_feature` + `oci_is_auto_selectable_and_outranks_nspawn`.

## Build gate

- `cargo check -p hyprstream-workers --features oci` — **pass**
- `cargo check -p hyprstream-workers` (default, oci absent) — **pass**
- `cargo clippy -p hyprstream-workers --features oci` — clean
- `cargo test -p hyprstream-workers --features oci` — 90 passed, 0 failed (7 new oci_backend unit tests + 2 new selection tests)

Part of Worker GA epic #341 / taxonomy epic #508.

Closes #346
