### PR TITLE
feat(workers): real Kata update_resources + container_stats (T1-D #345)

### DIFF
--- a/crates/hyprstream-workers/src/runtime/backend.rs
+++ b/crates/hyprstream-workers/src/runtime/backend.rs
@@ -13,7 +13,7 @@ use crate::config::PoolConfig;
 use crate::error::Result;
 
 use super::sandbox::PodSandbox;
-use super::client::{LinuxContainerResources, PodSandboxConfig};
+use super::client::{CpuUsage, LinuxContainerResources, MemoryUsage, PodSandboxConfig};
 
 /// Opaque handle stored on each `PodSandbox`.
 ///
@@ -83,5 +83,19 @@ pub trait SandboxBackend: Send + Sync {
         _resources: &LinuxContainerResources,
     ) -> Result<()> {
         Ok(()) // default: no-op
+    }
+
+    /// Fetch live per-container resource usage from the sandbox's guest.
+    ///
+    /// Returns `Some((cpu, memory))` sourced from inside the sandbox (e.g.
+    /// the kata-agent stats RPC / guest cgroups), or `None` when the backend
+    /// cannot observe the guest (default). Callers fall back to
+    /// placeholder/zeroed usage when this is `None`, so a backend that has no
+    /// in-guest visibility does not have to synthesise fake numbers.
+    async fn container_stats(
+        &self,
+        _sandbox: &PodSandbox,
+    ) -> Result<Option<(CpuUsage, MemoryUsage)>> {
+        Ok(None) // default: no guest-level stats available
     }
 }

--- a/crates/hyprstream-workers/src/runtime/kata_agent.rs
+++ b/crates/hyprstream-workers/src/runtime/kata_agent.rs
@@ -368,6 +368,55 @@ impl KataAgentClient {
         Ok(resp.status)
     }
 
+    /// `UpdateContainer` — apply new cgroup resource limits to a running
+    /// container inside the guest.
+    ///
+    /// This is the RPC a CRI `UpdateContainerResources` maps onto: the
+    /// kata-agent rewrites the container's in-guest cgroups (CPU shares/quota/
+    /// period, memory limit, cpuset, …). It updates the container's slice of
+    /// the *existing* VM; growing the VM itself past its boot size (vCPU /
+    /// memory hotplug) is a separate hypervisor concern and not attempted
+    /// here — matching upstream kata, whose `update_container` handler drives
+    /// the guest cgroup layer, with VM resize handled independently by the
+    /// runtime's resource manager.
+    pub async fn update_container(
+        &self,
+        container_id: &str,
+        resources: oci::LinuxResources,
+    ) -> Result<()> {
+        let req = agent::UpdateContainerRequest {
+            container_id: container_id.to_owned(),
+            resources: protobuf::MessageField::some(resources),
+            ..Default::default()
+        };
+        self.client
+            .update_container(self.ctx(), &req)
+            .await
+            .context("UpdateContainer ttrpc call")?;
+        Ok(())
+    }
+
+    /// `StatsContainer` — fetch the guest cgroup (+ network) stats for a
+    /// container. The returned [`agent::StatsContainerResponse`] carries the
+    /// real in-guest cgroup counters (`cgroup_stats.cpu_stats` /
+    /// `memory_stats`); mapping them into the CRI `ContainerStats` shape is
+    /// the caller's job (see `KataBackend::container_stats`).
+    pub async fn stats_container(
+        &self,
+        container_id: &str,
+    ) -> Result<agent::StatsContainerResponse> {
+        let req = agent::StatsContainerRequest {
+            container_id: container_id.to_owned(),
+            ..Default::default()
+        };
+        let resp = self
+            .client
+            .stats_container(self.ctx(), &req)
+            .await
+            .context("StatsContainer ttrpc call")?;
+        Ok(resp)
+    }
+
     /// Drain available stdout via repeated `ReadStdout` calls until the
     /// agent reports no more data (empty response).
     pub async fn read_stdout_all(&self, container_id: &str, exec_id: &str) -> Result<Vec<u8>> {

--- a/crates/hyprstream-workers/src/runtime/kata_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/kata_backend.rs
@@ -16,13 +16,14 @@ use kata_hypervisor::dragonball::Dragonball;
 use kata_hypervisor::{Hypervisor, ShareFsConfig, ShareFsDevice};
 use kata_types::config::hypervisor::{Hypervisor as HypervisorConfig, RootlessUser};
 use kata_types::rootless;
+use protocols::{agent, oci};
 
 use crate::config::{HypervisorType, ImageConfig, PoolConfig};
 use crate::error::{Result, WorkerError};
 use crate::image::RafsStore;
 
 use super::backend::{SandboxBackend, SandboxHandle};
-use super::client::PodSandboxConfig;
+use super::client::{CpuUsage, LinuxContainerResources, MemoryUsage, PodSandboxConfig};
 use super::kata_agent::{AgentAddress, KataAgentClient};
 use super::sandbox::PodSandbox;
 use super::sandbox_fs::{SandboxFs, SandboxFsServer, VFS_SOCKET_NAME};
@@ -633,9 +634,175 @@ impl SandboxBackend for KataBackend {
             }
         }
     }
+
+    /// Apply new CPU/memory limits to the sandbox's running container by
+    /// driving the kata-agent `UpdateContainer` RPC (the CRI
+    /// `UpdateContainerResources` path). The CRI-shaped
+    /// [`LinuxContainerResources`] is mapped to the guest's
+    /// [`oci::LinuxResources`] and the agent rewrites the in-guest cgroups.
+    ///
+    /// Uses `sandbox.id` as the guest container id — the same single-workload
+    /// convention `exec_sync` uses (see there). Requires a started sandbox
+    /// with a live agent connection; without a backend handle this fails
+    /// rather than silently no-op'ing (unlike the trait default), because a
+    /// caller asking to resize an unstarted sandbox has made a mistake.
+    async fn update_resources(
+        &self,
+        sandbox: &PodSandbox,
+        resources: &LinuxContainerResources,
+    ) -> Result<()> {
+        let handle = sandbox.backend_handle.as_ref().ok_or_else(|| {
+            WorkerError::Internal("update_resources: sandbox has no backend handle".into())
+        })?;
+        let kata = handle.as_any().downcast_ref::<KataHandle>().ok_or_else(|| {
+            WorkerError::Internal("update_resources: backend handle is not a KataHandle".into())
+        })?;
+
+        let client = self.guest_agent_client(kata).await?;
+        let container_id = sandbox.id.clone();
+        let oci_resources = Self::map_linux_resources(resources);
+
+        client
+            .update_container(&container_id, oci_resources)
+            .await
+            .map_err(|e| {
+                WorkerError::Internal(format!("kata-agent update_container failed: {e:#}"))
+            })?;
+
+        tracing::info!(
+            sandbox_id = %sandbox.id,
+            cpu_shares = resources.cpu_shares,
+            cpu_quota = resources.cpu_quota,
+            cpu_period = resources.cpu_period,
+            memory_limit_in_bytes = resources.memory_limit_in_bytes,
+            "Updated container resources via kata-agent UpdateContainer"
+        );
+        Ok(())
+    }
+
+    /// Fetch live CPU/memory usage for the sandbox's container from the guest
+    /// via the kata-agent `StatsContainer` RPC, mapped into the CRI
+    /// [`CpuUsage`]/[`MemoryUsage`] shape.
+    ///
+    /// Returns `Ok(None)` when the sandbox has no backend handle yet (never
+    /// started) so the caller can fall back to placeholder stats rather than
+    /// erroring on a not-yet-running sandbox. A live agent that then fails the
+    /// RPC surfaces as `Err`.
+    async fn container_stats(
+        &self,
+        sandbox: &PodSandbox,
+    ) -> Result<Option<(CpuUsage, MemoryUsage)>> {
+        let Some(handle) = sandbox.backend_handle.as_ref() else {
+            return Ok(None);
+        };
+        let Some(kata) = handle.as_any().downcast_ref::<KataHandle>() else {
+            return Ok(None);
+        };
+
+        let client = self.guest_agent_client(kata).await?;
+        let container_id = sandbox.id.clone();
+
+        let resp = client.stats_container(&container_id).await.map_err(|e| {
+            WorkerError::Internal(format!("kata-agent stats_container failed: {e:#}"))
+        })?;
+
+        Ok(Some(Self::map_container_stats(&resp)))
+    }
 }
 
 impl KataBackend {
+    /// Map the CRI [`LinuxContainerResources`] to the guest
+    /// [`oci::LinuxResources`] the kata-agent's `UpdateContainer` expects.
+    ///
+    /// Only the fields with a meaningful CRI→OCI correspondence are set; the
+    /// rest are left at their protobuf defaults so the agent treats them as
+    /// "unchanged". `memory_swap_limit_in_bytes` maps to OCI `Swap`, and the
+    /// cpuset strings to `Cpus`/`Mems`.
+    fn map_linux_resources(resources: &LinuxContainerResources) -> oci::LinuxResources {
+        let cpu = oci::LinuxCPU {
+            // CRI cpu_shares is i64; OCI Shares is u64. Clamp negatives to 0.
+            Shares: u64::try_from(resources.cpu_shares).unwrap_or(0),
+            Quota: resources.cpu_quota,
+            Period: u64::try_from(resources.cpu_period).unwrap_or(0),
+            Cpus: resources.cpuset_cpus.clone(),
+            Mems: resources.cpuset_mems.clone(),
+            ..Default::default()
+        };
+        let memory = oci::LinuxMemory {
+            Limit: resources.memory_limit_in_bytes,
+            Swap: resources.memory_swap_limit_in_bytes,
+            ..Default::default()
+        };
+        oci::LinuxResources {
+            CPU: protobuf::MessageField::some(cpu),
+            Memory: protobuf::MessageField::some(memory),
+            ..Default::default()
+        }
+    }
+
+    /// Map a kata-agent [`agent::StatsContainerResponse`] (guest cgroup
+    /// counters) into the CRI [`CpuUsage`]/[`MemoryUsage`] shape.
+    ///
+    /// `usage_nano_cores` is left 0: it is a *rate* that requires two samples
+    /// (a delta of `usage_core_nano_seconds` over wall-clock) which a single
+    /// stats call cannot compute — kubelet's own CRI stats provider derives
+    /// it host-side from successive samples, so emitting a fabricated value
+    /// here would be wrong. `working_set_bytes` follows the CRI definition
+    /// (`usage − total_inactive_file`); other fields come straight from the
+    /// cgroup memory counters, reading `rss`/`pgfault`/`pgmajfault` from the
+    /// per-cgroup `stats` map (falling back to 0 when a controller does not
+    /// export them).
+    fn map_container_stats(resp: &agent::StatsContainerResponse) -> (CpuUsage, MemoryUsage) {
+        let now_ns = chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0);
+        let cgroup = &resp.cgroup_stats;
+
+        let cpu = CpuUsage {
+            timestamp: now_ns,
+            usage_core_nano_seconds: cgroup.cpu_stats.cpu_usage.total_usage,
+            usage_nano_cores: 0,
+        };
+
+        let mem = &cgroup.memory_stats;
+        let usage_bytes = mem.usage.usage;
+        let inactive_file = mem
+            .stats
+            .get("total_inactive_file")
+            .or_else(|| mem.stats.get("inactive_file"))
+            .copied()
+            .unwrap_or(0);
+        let rss_bytes = mem
+            .stats
+            .get("total_rss")
+            .or_else(|| mem.stats.get("rss"))
+            .copied()
+            .unwrap_or(0);
+        let page_faults = mem
+            .stats
+            .get("total_pgfault")
+            .or_else(|| mem.stats.get("pgfault"))
+            .copied()
+            .unwrap_or(0);
+        let major_page_faults = mem
+            .stats
+            .get("total_pgmajfault")
+            .or_else(|| mem.stats.get("pgmajfault"))
+            .copied()
+            .unwrap_or(0);
+        let limit = mem.usage.limit;
+
+        let memory = MemoryUsage {
+            timestamp: now_ns,
+            working_set_bytes: usage_bytes.saturating_sub(inactive_file),
+            available_bytes: limit.saturating_sub(usage_bytes),
+            usage_bytes,
+            rss_bytes,
+            page_faults,
+            major_page_faults,
+        };
+
+        (cpu, memory)
+    }
+
     /// Get (lazily connecting if needed) the cached kata-agent ttrpc client
     /// for this sandbox's VM.
     ///
@@ -1090,6 +1257,98 @@ mod tests {
     // ─────────────────────────────────────────────────────────────────────
     // Cloud-init ISO generation (requires genisoimage)
     // ─────────────────────────────────────────────────────────────────────
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Resource / stats mapping (T1-D #345) — pure functions, no VM needed
+    // ─────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_map_linux_resources_maps_cpu_and_memory() {
+        let resources = LinuxContainerResources {
+            cpu_shares: 512,
+            cpu_quota: 50_000,
+            cpu_period: 100_000,
+            memory_limit_in_bytes: 256 * 1024 * 1024,
+            memory_swap_limit_in_bytes: 512 * 1024 * 1024,
+            cpuset_cpus: "0-1".to_owned(),
+            cpuset_mems: "0".to_owned(),
+            ..Default::default()
+        };
+
+        let oci = KataBackend::map_linux_resources(&resources);
+
+        assert_eq!(oci.CPU.Shares, 512);
+        assert_eq!(oci.CPU.Quota, 50_000);
+        assert_eq!(oci.CPU.Period, 100_000);
+        assert_eq!(oci.CPU.Cpus, "0-1");
+        assert_eq!(oci.CPU.Mems, "0");
+        assert_eq!(oci.Memory.Limit, 256 * 1024 * 1024);
+        assert_eq!(oci.Memory.Swap, 512 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_map_linux_resources_clamps_negative_cpu_to_zero() {
+        // CRI cpu_shares/cpu_period are i64; OCI Shares/Period are u64. A
+        // negative "unset" sentinel must not wrap around to a huge u64.
+        let resources = LinuxContainerResources {
+            cpu_shares: -1,
+            cpu_period: -1,
+            ..Default::default()
+        };
+
+        let oci = KataBackend::map_linux_resources(&resources);
+        assert_eq!(oci.CPU.Shares, 0);
+        assert_eq!(oci.CPU.Period, 0);
+    }
+
+    #[test]
+    fn test_map_container_stats_maps_cgroup_counters() {
+        let mut cpu_usage = agent::CpuUsage::new();
+        cpu_usage.total_usage = 123_456;
+        let mut cpu_stats = agent::CpuStats::new();
+        cpu_stats.cpu_usage = protobuf::MessageField::some(cpu_usage);
+
+        let mut mem_data = agent::MemoryData::new();
+        mem_data.usage = 1000;
+        mem_data.limit = 4000;
+        let mut mem_stats = agent::MemoryStats::new();
+        mem_stats.usage = protobuf::MessageField::some(mem_data);
+        mem_stats.stats.insert("total_inactive_file".to_owned(), 200);
+        mem_stats.stats.insert("total_rss".to_owned(), 700);
+        mem_stats.stats.insert("total_pgfault".to_owned(), 42);
+        mem_stats.stats.insert("total_pgmajfault".to_owned(), 7);
+
+        let mut cgroup = agent::CgroupStats::new();
+        cgroup.cpu_stats = protobuf::MessageField::some(cpu_stats);
+        cgroup.memory_stats = protobuf::MessageField::some(mem_stats);
+
+        let mut resp = agent::StatsContainerResponse::new();
+        resp.cgroup_stats = protobuf::MessageField::some(cgroup);
+
+        let (cpu, mem) = KataBackend::map_container_stats(&resp);
+
+        assert_eq!(cpu.usage_core_nano_seconds, 123_456);
+        // usage_nano_cores is a rate needing two samples; single-sample = 0.
+        assert_eq!(cpu.usage_nano_cores, 0);
+        assert_eq!(mem.usage_bytes, 1000);
+        assert_eq!(mem.working_set_bytes, 800, "usage - total_inactive_file");
+        assert_eq!(mem.available_bytes, 3000, "limit - usage");
+        assert_eq!(mem.rss_bytes, 700);
+        assert_eq!(mem.page_faults, 42);
+        assert_eq!(mem.major_page_faults, 7);
+    }
+
+    #[test]
+    fn test_map_container_stats_empty_response_is_zeroed() {
+        // A response with no cgroup_stats (default instances) must not panic
+        // and must yield all-zero counters.
+        let resp = agent::StatsContainerResponse::new();
+        let (cpu, mem) = KataBackend::map_container_stats(&resp);
+        assert_eq!(cpu.usage_core_nano_seconds, 0);
+        assert_eq!(mem.usage_bytes, 0);
+        assert_eq!(mem.working_set_bytes, 0);
+        assert_eq!(mem.available_bytes, 0);
+    }
 
     #[tokio::test]
     #[ignore] // requires genisoimage binary

--- a/crates/hyprstream-workers/src/runtime/service.rs
+++ b/crates/hyprstream-workers/src/runtime/service.rs
@@ -772,14 +772,51 @@ impl WorkerService {
 
     /// Get container stats
     pub async fn container_stats(&self, container_id: &str) -> Result<ContainerStats> {
-        let containers = self.containers.read().await;
+        // Snapshot the container and release the lock before any backend RPC:
+        // the guest stats call awaits, and holding the `containers` read lock
+        // across it would needlessly serialise all container mutations.
+        let (mut stats, pod_sandbox_id) = {
+            let containers = self.containers.read().await;
+            let container = containers
+                .get(container_id)
+                .ok_or_else(|| WorkerError::ContainerNotFound(container_id.to_owned()))?;
+            (ContainerStats::from(container), container.pod_sandbox_id.clone())
+        };
 
-        let container = containers
-            .get(container_id)
-            .ok_or_else(|| WorkerError::ContainerNotFound(container_id.to_owned()))?;
+        self.enrich_container_stats(container_id, &pod_sandbox_id, &mut stats)
+            .await;
+        Ok(stats)
+    }
 
-        // TODO: Get actual stats from container
-        Ok(ContainerStats::from(container))
+    /// Overlay real guest-sourced CPU/memory usage onto placeholder
+    /// [`ContainerStats`] when the sandbox backend can observe the guest
+    /// (e.g. Kata via the kata-agent `StatsContainer` RPC). Backends without
+    /// in-guest visibility return `None` and the placeholder values stand.
+    /// A backend error degrades to the placeholder (logged) rather than
+    /// failing the stats call.
+    async fn enrich_container_stats(
+        &self,
+        container_id: &str,
+        pod_sandbox_id: &str,
+        stats: &mut ContainerStats,
+    ) {
+        let Some(sandbox) = self.sandbox_pool.get(pod_sandbox_id).await else {
+            return;
+        };
+        match self.sandbox_pool.backend().container_stats(&sandbox).await {
+            Ok(Some((cpu, memory))) => {
+                stats.cpu = cpu;
+                stats.memory = memory;
+            }
+            Ok(None) => {}
+            Err(e) => {
+                tracing::warn!(
+                    container_id = %container_id,
+                    error = %e,
+                    "Failed to fetch guest container stats; returning placeholder stats"
+                );
+            }
+        }
     }
 
     /// List container stats matching the given filter.
@@ -787,27 +824,45 @@ impl WorkerService {
         &self,
         filter: &ContainerStatsFilter,
     ) -> Result<Vec<ContainerStats>> {
-        let containers = self.containers.read().await;
-        let mut results = Vec::new();
+        // Collect matching (placeholder stats, container id, sandbox id)
+        // snapshots under the lock, then release it before enriching each with
+        // guest-sourced usage (the backend RPCs await and must not run under
+        // the `containers` read lock).
+        let snapshots: Vec<(ContainerStats, String, String)> = {
+            let containers = self.containers.read().await;
+            containers
+                .values()
+                .filter(|container| {
+                    if !filter.id.is_empty() && container.id != filter.id {
+                        return false;
+                    }
+                    if !filter.pod_sandbox_id.is_empty()
+                        && container.pod_sandbox_id != filter.pod_sandbox_id
+                    {
+                        return false;
+                    }
+                    filter.label_selector.iter().all(|kv| {
+                        container
+                            .labels
+                            .iter()
+                            .any(|l| l.key == kv.key && l.value == kv.value)
+                    })
+                })
+                .map(|container| {
+                    (
+                        ContainerStats::from(container),
+                        container.id.clone(),
+                        container.pod_sandbox_id.clone(),
+                    )
+                })
+                .collect()
+        };
 
-        for container in containers.values() {
-            if !filter.id.is_empty() && container.id != filter.id {
-                continue;
-            }
-            if !filter.pod_sandbox_id.is_empty() && container.pod_sandbox_id != filter.pod_sandbox_id {
-                continue;
-            }
-            let mut matches_labels = true;
-            for kv in &filter.label_selector {
-                if !container.labels.iter().any(|l| l.key == kv.key && l.value == kv.value) {
-                    matches_labels = false;
-                    break;
-                }
-            }
-            if !matches_labels {
-                continue;
-            }
-            results.push(ContainerStats::from(container));
+        let mut results = Vec::with_capacity(snapshots.len());
+        for (mut stats, container_id, pod_sandbox_id) in snapshots {
+            self.enrich_container_stats(&container_id, &pod_sandbox_id, &mut stats)
+                .await;
+            results.push(stats);
         }
 
         Ok(results)


### PR DESCRIPTION
## T1-D: real Kata VM lifecycle ops — `update_resources` + `container_stats`

Part of the Worker GA epic **#341**. Closes **#345**.

Finishes the two concrete gaps the T1-D audit flagged in the Kata backend, both routed through the existing kata-agent ttrpc/vsock client (`runtime/kata_agent.rs`, #344). `get_pids` was already real and is untouched.

### `update_resources` (was: trait default no-op)
`KataBackend::update_resources` now drives the kata-agent **`UpdateContainer`** RPC — the CRI `UpdateContainerResources` path. The CRI-shaped `LinuxContainerResources` is mapped to the guest `oci::LinuxResources` (`map_linux_resources`): cpu shares/quota/period + cpuset → `LinuxCPU`, memory limit + swap → `LinuxMemory`. The agent rewrites the container's in-guest cgroups. Uses `sandbox.id` as the guest container id (same single-workload convention as `exec_sync`); fails (rather than silently no-op'ing like the trait default) when the sandbox has no backend handle. Negative CRI "unset" sentinels are clamped so an i64→u64 conversion can't wrap.

### `container_stats` (was: `// TODO: Get actual stats`, placeholder)
New `SandboxBackend::container_stats` trait method (default `Ok(None)`), implemented for Kata via the kata-agent **`StatsContainer`** RPC. Guest cgroup counters are mapped (`map_container_stats`) into CRI `CpuUsage`/`MemoryUsage`:
- `usage_core_nano_seconds` ← `cpu_stats.cpu_usage.total_usage`
- `working_set_bytes` ← `usage − total_inactive_file` (CRI definition), plus `usage_bytes`/`available_bytes`/`rss_bytes`/`page_faults`/`major_page_faults` from the memory cgroup.
- `usage_nano_cores` is left `0` — it is a rate needing two samples over wall-clock; kubelet derives it host-side, so fabricating a value here would be wrong (documented inline).

`service.rs::container_stats` (and `list_container_stats`, same pattern) now snapshot the container under the lock, drop it, then overlay real guest usage via `sandbox_pool.backend().container_stats(&sandbox)`. Backends with no in-guest visibility return `None` and the prior placeholder stands; a backend error degrades to the placeholder (logged), so the stats endpoint never hard-fails.

### Deferred: `console`
Left **out of scope** for this PR. The Kata side only exposes an accessor (`sandbox.console_socket()` / `KataHandle`) with no `SandboxBackend`/service trait method to hang a console attach off — wiring one is a new surface (trait method + CRI `Attach`-style streaming), not a fill-in of an existing partial op. The two audited gaps above are the concrete "partial → real" items; console is tracked separately under the epic.

### Tests
Four pure-function unit tests added (no VM needed): resource mapping (incl. negative-clamp) and stats mapping (populated + empty response). All pass under `--features kata-vm`.

### Build / verification
- `cargo check -p hyprstream-workers` (default, torch-free) — **passes**.
- `OPENSSL_NO_VENDOR=1 cargo check -p hyprstream-workers --features kata-vm` — **passes** (full kata hypervisor + CH + ttrpc + protocols stack compiles). `OPENSSL_NO_VENDOR=1` was needed only to link the system OpenSSL 3.5.7 instead of the vendored build, which fails in this environment on a missing Perl `FindBin.pm` — unrelated to this change.
- `OPENSSL_NO_VENDOR=1 cargo test -p hyprstream-workers --features kata-vm map_` — 4/4 pass.
- `cargo clippy -p hyprstream-workers` and `... --features kata-vm` — clean.

Scope: only `crates/hyprstream-workers/` (`runtime/{backend,kata_agent,kata_backend,service}.rs`). No other epic touched.
