### PR TITLE
feat(workers): migrate control-plane RPC transport ZMQ→moq (#350)

### DIFF
--- a/crates/hyprstream-workers/src/config.rs
+++ b/crates/hyprstream-workers/src/config.rs
@@ -235,28 +235,18 @@ impl Default for WorkflowConfig {
     }
 }
 
-/// Configuration for event bus
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Configuration for the worker event bus.
+///
+/// The worker publishes lifecycle events over the moq-lite streaming plane
+/// (#167) via `crate::events::EventPublisher`; there is no ZMQ socket to tune.
+/// The former ZMQ high-water-mark knobs (`publisher_hwm`/`subscriber_hwm`) were
+/// removed with the ZMQ stack (#138/#167) — moq back-pressure/QoS is governed by
+/// `hyprstream_rpc::moq_stream` `StreamOpt`, not per-socket HWMs here.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct EventConfig {
-    /// ZMQ high water mark for publishers
-    pub publisher_hwm: i32,
-
-    /// ZMQ high water mark for subscribers
-    pub subscriber_hwm: i32,
-
     /// Enable event logging for debugging
     pub log_events: bool,
-}
-
-impl Default for EventConfig {
-    fn default() -> Self {
-        Self {
-            publisher_hwm: 1000,
-            subscriber_hwm: 1000,
-            log_events: false,
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/hyprstream-workers/src/runtime/client.rs
+++ b/crates/hyprstream-workers/src/runtime/client.rs
@@ -1,6 +1,8 @@
-//! RuntimeClient trait and ZMQ client
+//! RuntimeClient trait and generated `WorkerClient`.
 //!
-//! Client-side trait for CRI RuntimeService (`runtime.v1`) for future kubelet compatibility.
+//! Client-side trait for CRI RuntimeService (`runtime.v1`) for future kubelet
+//! compatibility. The `WorkerClient` speaks Cap'n Proto over the pluggable RPC
+//! transport (inproc/UDS/QUIC/iroh) — there is no ZMQ client (#138/#167).
 //! Response types use generated types from the Cap'n Proto schema directly.
 
 use std::collections::HashMap; // Only for StatusResponse.info (local-only, not serialized)

--- a/crates/hyprstream-workers/src/runtime/service.rs
+++ b/crates/hyprstream-workers/src/runtime/service.rs
@@ -1,6 +1,26 @@
-//! WorkerService - CRI RuntimeClient + ImageClient via ZMQ
+//! WorkerService — CRI RuntimeClient + ImageClient control plane.
 //!
-//! Implements RequestService trait for handling CRI-aligned requests.
+//! Implements the `RequestService` trait for handling CRI-aligned requests.
+//!
+//! # Transport (#350, epic #341)
+//!
+//! This is the worker **control plane**. It is transport-agnostic: the service
+//! only implements `RequestService` (Cap'n Proto wire format via
+//! `generate_rpc_service!("worker")`) and carries a `TransportConfig`. The
+//! legacy ZMQ ROUTER/DEALER stack was removed workspace-wide (#138/#167 —
+//! ZMQ/ZeroMQ is gone); the blanket `Spawnable` impl bridges this service and
+//! serves it over its *registered* transport (`serve_bridged`: Inproc / IPC-UDS
+//! / systemd-fd, plus the QUIC/Iroh dial plane). No ZMQ socket exists in this
+//! path.
+//!
+//! The **asynchronous** surfaces of the worker already ride the moq-lite
+//! streaming plane, mirroring the event-bus migration (#167): lifecycle events
+//! publish via [`EventPublisher`] (moq-backed — see `crate::events`) and
+//! terminal attach/detach FD data streams via `StreamChannel` /
+//! `AnyStreamPublisher` (moq). moq is a pub/sub fan-out plane, not a
+//! request/response RPC transport, so the synchronous CRI req/rep control plane
+//! stays on the Cap'n Proto bridged transport shared by every peer RPC service
+//! (registry/model/policy/mcp).
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -11,7 +31,9 @@ use anyhow::Result as AnyhowResult;
 use async_trait::async_trait;
 use tracing::{debug, info, warn};
 
-// Import ZMQ service infrastructure from hyprstream-rpc
+// RPC service infrastructure from hyprstream-rpc: the pluggable Cap'n Proto
+// bridged transport (inproc/UDS/QUIC/iroh) + the moq streaming plane. ZMQ is
+// gone (#138/#167) — this is not a ZMQ socket API.
 use hyprstream_rpc::prelude::SigningKey;
 use hyprstream_rpc::service::{AuthorizeFn, EnvelopeContext, RequestService};
 use hyprstream_rpc::moq_stream::AnyStreamPublisher;
@@ -63,7 +85,8 @@ const SERVICE_NAME: &str = "worker";
 
 /// WorkerService handles CRI RuntimeClient and ImageClient requests
 ///
-/// Implements the RequestService trait for integration with hyprstream's ZMQ infrastructure.
+/// Implements the RequestService trait for integration with hyprstream's
+/// Cap'n Proto bridged RPC transport (inproc/UDS/systemd-fd + QUIC/Iroh); ZMQ is gone.
 pub struct WorkerService {
     // Business logic
     /// Sandbox pool for VM management


### PR DESCRIPTION
## Summary

Reconciles the `hyprstream-workers` **control plane** with the already-completed ZMQ→moq / Cap'n-Proto transport migration (issue #350, epic #341 Worker GA).

**Key finding (verified against current code):** the ZMQ/ZeroMQ RPC stack was already removed workspace-wide (#138 / #167). The audit note that framed #350 as a live "transport swap" is based on **stale documentation** in this crate, not on a real ZMQ code path:

- There is **no `zmq` dependency** in `hyprstream-workers/Cargo.toml` and **no ZMQ code** anywhere in the crate.
- `WorkerService` is a transport-agnostic `RequestService` (Cap'n Proto wire format via `generate_rpc_service!("worker")`). The blanket `Spawnable` impl bridges it and serves it over its *registered* transport through `serve_bridged` — Inproc / IPC-UDS / systemd-fd, plus the QUIC/Iroh dial plane. No ZMQ ROUTER.
- The worker's **asynchronous** surfaces already ride moq-lite, exactly like the event-bus reference migration: lifecycle events via `EventPublisher` (moq-backed) and attach/detach FD streams via `StreamChannel` / `AnyStreamPublisher` (moq).

moq is a **pub/sub fan-out plane, not a request/response RPC transport**. No RPC-over-moq path exists for any service (registry/model/policy/worker/mcp all serve req/rep over the bridged Cap'n Proto transport). So the correct, in-scope work is to purge the crate's remaining ZMQ residue and make it truthfully describe the moq/Cap'n-Proto seam — **not** to bolt a parallel RPC-over-moq transport onto one service (which would contradict the "mirror how events did it" instruction, since events are pub/sub).

## Changes

- `runtime/service.rs`, `runtime/client.rs` — replace "via ZMQ" / "ZMQ infrastructure" / "ZMQ client" doc & comment references with an accurate description of the pluggable Cap'n Proto bridged transport + moq streaming plane. Added a `# Transport` module doc explaining the control-plane vs. streaming split.
- `config.rs` — remove the dead ZMQ high-water-mark knobs (`publisher_hwm` / `subscriber_hwm`) from `EventConfig` (unused anywhere since the event bus moved to moq; moq QoS is governed by `StreamOpt`, not per-socket HWMs). Derive `Default` now that only `log_events` remains.

No functional or wire-format change. Security envelope flow (`EnvelopeContext` / signed envelopes / `authorize`) is untouched.

## Complete vs. deferred

- **Complete:** the workers control-plane crate now accurately reflects the finished transport migration; all ZMQ residue in the crate is gone. The transport itself (inproc/UDS/QUIC/iroh + moq for async) was already migrated by #138/#167 and needs no further change here.
- **Not done / not applicable:** no new RPC-over-moq request/response transport was built. There is no such transport in the codebase and it is not how any peer RPC service works; moq is the pub/sub streaming/event plane. Building one would be an out-of-scope, architecture-wide change, not the transport-selection swap #350 anticipated. Flagging honestly rather than claiming a from-scratch moq-RPC implementation.

## Verification

- `cargo check -p hyprstream-workers` (default, torch-free) — pass
- `cargo check -p hyprstream-workers --features wasm` — pass
- `cargo clippy -p hyprstream-workers` — clean
- `cargo test -p hyprstream-workers` — 81 passed, 0 failed
- `--features oci-image` fails only on a pre-existing environment issue (`openssl-sys` vendored build needs the perl/OpenSSL toolchain), unrelated to this change — the edits are feature-invariant.

Closes #350. Part of epic #341.
