### PR TITLE
fix(#654): clippy-clean cas-serve on main — unblock team CI (URGENT)

### DIFF
--- a/crates/cas-serve/src/main.rs
+++ b/crates/cas-serve/src/main.rs
@@ -41,9 +41,8 @@
 
 // The binary reuses the library's modules to avoid drift between the server
 // and any client/embedder of `cas_serve`.
-use cas_serve::{chunker, protocol, shard};
+use cas_serve::protocol;
 use protocol::{ErrorCode, Request, Response};
-use shard::Shard;
 use std::io::{BufRead, Write};
 use std::path::PathBuf;
 use tracing::{debug, error, info};
@@ -326,6 +325,10 @@ fn main() -> anyhow::Result<()> {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    // `chunker` and `Shard` are used only by these tests (the non-test binary
+    // routes chunk/store through `CasStore::put_file_bytes`), so import them
+    // here rather than at module scope to keep the non-test build warning-clean.
+    use cas_serve::{chunker, shard::Shard};
     use tempfile::tempdir;
 
     #[tokio::test]

--- a/crates/cas-serve/src/store.rs
+++ b/crates/cas-serve/src/store.rs
@@ -234,6 +234,7 @@ impl CasStore {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)] // panicking is correct in unit tests
 mod tests {
     use super::*;
 


### PR DESCRIPTION
## URGENT — main CI is red for the whole team; this unblocks it

Two Clippy regressions from the #691 putBlob merge (`99b003dbf`) turned `main` red. They landed because **Clippy is not a required merge check** (only `build` is, and it's merge_group-only), so #691 merged with a red Clippy — and now every PR inherits it (e.g. #696 can't go green despite its own crates being clean).

### The two failures (both in `cas-serve`, both reproduced locally)
1. **`main.rs:44/46` — unused `chunker` / `shard::Shard`.** The `UploadFile` handler was refactored onto `CasStore::put_file_bytes` in #691, making these imports test-only, but they stayed at module scope → unused in the non-`--all-targets` build (`cargo clippy --workspace`) → `-D warnings`. **Fix:** moved both into the test module.
2. **`store.rs` test module — `.unwrap()` under `unwrap_used = deny`** → fails `--all-targets` clippy. **Fix:** added the conventional `#[allow(clippy::unwrap_used, expect_used)]` (matches e.g. `te.rs`).

### Verified
- `cargo clippy -p cas-serve -- -D warnings` (main's plain config) — **clean** (was 2 errors).
- `cargo clippy -p cas-serve --all-targets -- -D warnings` — **clean** (was 9 errors).
- `cargo test -p cas-serve` — green.

Tiny (6 insertions, 2 deletions), surgical, safe to fast-track. Note: #692 (retire the cas-serve binary) will later delete `main.rs` and supersede change (1); it'll rebase cleanly on this.

### Process follow-up
Please make **Clippy a required status check** — this class of regression reaching `main` is only possible because it isn't one.