### PR TITLE
feat(vfs-server): add local fusedev mount serve mode (#653)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7220,6 +7220,7 @@ dependencies = [
  "hyprstream-vfs",
  "libc",
  "parking_lot 0.12.4",
+ "tempfile",
  "tokio",
  "tracing",
  "vhost 0.11.0",

--- a/crates/hyprstream-vfs-server/Cargo.toml
+++ b/crates/hyprstream-vfs-server/Cargo.toml
@@ -3,7 +3,7 @@ name = "hyprstream-vfs-server"
 version = "0.1.0"
 edition.workspace = true
 license.workspace = true
-description = "vhost-user-fs server exposing a hyprstream VFS Namespace to a Cloud Hypervisor guest (FS-A, #362)"
+description = "Serves a hyprstream VFS Namespace over vhost-user-fs to a Cloud Hypervisor guest (FS-A, #362), or as a local /dev/fuse mount for non-VM sandbox backends (#653)"
 
 # Native-only (Linux): vhost-user-fs + fuse-backend-rs virtio transport are not
 # available on wasm, and the crate's purpose is serving a VMM.
@@ -11,10 +11,12 @@ description = "vhost-user-fs server exposing a hyprstream VFS Namespace to a Clo
 hyprstream-vfs = { path = "../hyprstream-vfs" }
 hyprstream-rpc = { path = "../hyprstream-rpc" }
 
-# FUSE protocol engine + virtio transport. `virtiofs` gives the Server, Reader,
-# VirtioFsWriter/Writer; we do not need `fusedev` (kernel /dev/fuse) nor the DAX
-# `vhost-user-fs` feature (no shared-memory window).
-fuse-backend-rs = { version = "0.13", default-features = false, features = ["virtiofs"] }
+# FUSE protocol engine + transports. `virtiofs` gives the Server, Reader,
+# VirtioFsWriter/Writer for the vhost-user-fs (VM) path; `fusedev` additionally
+# gives FuseSession/FuseChannel/FuseDevWriter for a real host `/dev/fuse` mount
+# (#653's `serve_local`, used by non-VM backends like podman/nspawn). We do not
+# need the DAX `vhost-user-fs` feature (no shared-memory window).
+fuse-backend-rs = { version = "0.13", default-features = false, features = ["virtiofs", "fusedev"] }
 
 # vhost-user transport: hosts the FUSE Server over a Unix socket to CH. Versions
 # pinned to match fuse-backend-rs 0.13.1 (vhost 0.11 / vm-memory 0.14.1 /
@@ -35,3 +37,4 @@ tracing = { workspace = true }
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync"] }
 async-trait = "0.1"
+tempfile = "3"

--- a/crates/hyprstream-vfs-server/src/lib.rs
+++ b/crates/hyprstream-vfs-server/src/lib.rs
@@ -19,9 +19,26 @@
 //!         → Namespace mounts    (Mount read/write + FsMount writes, Subject-per-call)
 //! ```
 //!
+//! [`serve_local`] is the non-VM counterpart (#653): the same [`VfsFileSystem`]
+//! down-adapter, mounted at a host directory via `fuse_backend_rs`'s `fusedev`
+//! transport (kernel `/dev/fuse`) instead of vhost-user-fs. This is what lets
+//! non-VM sandbox backends — `podman run --rootfs <dir>` (#617), `systemd-nspawn
+//! --directory=<dir>` — consume the same composed per-sandbox namespace
+//! (`SandboxFs::compose`/`into_filesystem`, #641/#365) the kata/CH path uses,
+//! rather than side-channeling their own image provisioning:
+//!
+//! ```text
+//! podman / systemd-nspawn  (plain POSIX directory)
+//!   → kernel /dev/fuse         (fusedev transport) — server.rs::serve_local
+//!     → fuse_backend_rs::Server (same FUSE protocol engine)
+//!       → VfsFileSystem         (same down-adapter, unmodified)
+//!         → Namespace mounts
+//! ```
+//!
 //! The crate is **native-only** (Linux): vhost-user-fs and `fuse_backend_rs`'s
 //! virtio transport are not available on wasm, and the whole point is serving a
-//! VMM. It is genuinely `Send + Sync` — no wasm `unsafe impl Send`.
+//! VMM (or, for `serve_local`, a real kernel FUSE mount). It is genuinely
+//! `Send + Sync` — no wasm `unsafe impl Send`.
 
 #![cfg(not(target_arch = "wasm32"))]
 
@@ -33,4 +50,4 @@ mod server;
 mod tests;
 
 pub use filesystem::VfsFileSystem;
-pub use server::{serve, VfsBackend};
+pub use server::{serve, serve_local, VfsBackend};

--- a/crates/hyprstream-vfs-server/src/server.rs
+++ b/crates/hyprstream-vfs-server/src/server.rs
@@ -14,6 +14,7 @@
 //! ShareFs attach in `kata_backend.rs`.
 
 use std::io;
+use std::path::Path;
 use std::sync::Arc;
 // `vhost-user-backend` only implements `VhostUserBackend` for the std `Mutex`/
 // `RwLock` (backend.rs:335/415), so we must use the std type here despite the
@@ -23,7 +24,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use fuse_backend_rs::api::server::Server;
-use fuse_backend_rs::transport::{Reader, VirtioFsWriter, Writer};
+use fuse_backend_rs::transport::{FuseChannel, FuseSession, Reader, VirtioFsWriter, Writer};
 use vhost::vhost_user::message::{VhostUserProtocolFeatures, VhostUserVirtioFeatures};
 use vhost::vhost_user::Listener;
 use vhost_user_backend::{VhostUserBackendMut, VhostUserDaemon, VringRwLock, VringT};
@@ -206,4 +207,99 @@ pub fn serve(fs: VfsFileSystem, socket_path: &str) -> io::Result<()> {
         .wait()
         .map_err(|e| io::Error::other(format!("daemon wait: {e}")))?;
     Ok(())
+}
+
+/// Mount `fs` at `mountpoint` as a real host directory via the kernel `fusedev`
+/// transport (`/dev/fuse`), blocking until the mount is torn down (unmounted, or
+/// the kernel closes the FUSE device).
+///
+/// This is the non-VM counterpart to [`serve`]: the same transport-agnostic
+/// [`VfsFileSystem`] down-adapter (`SandboxFs::into_filesystem`), served as a
+/// plain POSIX directory instead of a vhost-user-fs virtio-fs share. It exists
+/// so backends that cannot attach a virtio-fs device — `podman run --rootfs
+/// <dir>` (#617) and `systemd-nspawn --directory=<dir>` — can consume the same
+/// composed per-sandbox namespace the kata/CH path uses, instead of
+/// side-channeling their own image provisioning (spine violation, epic #508).
+///
+/// `mountpoint` must already exist as a directory; this function does not
+/// create it. The mount is torn down when [`FuseSession`] is dropped (which
+/// happens when this function returns, on any exit path) or when the kernel
+/// unmounts it out from under us (e.g. `fusermount3 -u`, or the guest killing
+/// the process).
+///
+/// Open question (tracked by #653, resolution deferred to #617): rootless FUSE
+/// (unprivileged `/dev/fuse` access via `fusermount3`) combined with podman's
+/// `--userns=keep-id` has not been validated here — this function mounts via
+/// the same kernel `/dev/fuse` + `fusermount3` path `fuse-backend-rs` uses for
+/// any fusedev consumer, but whether that composition works unprivileged under
+/// `keep-id` user-namespace remapping is unresolved and out of scope for this
+/// change.
+///
+/// Run this on a dedicated thread; like [`serve`], it blocks until the session
+/// ends.
+pub fn serve_local(fs: VfsFileSystem, mountpoint: &Path) -> io::Result<()> {
+    let server = Arc::new(Server::new(fs));
+
+    let mut session = FuseSession::new(mountpoint, "hyprstream-vfs", "", false)
+        .map_err(|e| io::Error::other(format!("fuse session init {mountpoint:?}: {e}")))?;
+    // `fuse-backend-rs` defaults `allow_other` to true, which requires
+    // `user_allow_other` in `/etc/fuse.conf` (a host-wide opt-in most
+    // deployments won't have set). We only need this mount visible to the
+    // process serving it (and whatever shares its uid/gid — e.g. a podman
+    // `--userns=keep-id` child), so disable it and mount unprivileged.
+    session.set_allow_other(false);
+    session
+        .mount()
+        .map_err(|e| io::Error::other(format!("fuse mount {mountpoint:?}: {e}")))?;
+
+    let mut channel = session
+        .new_channel()
+        .map_err(|e| io::Error::other(format!("fuse channel {mountpoint:?}: {e}")))?;
+
+    let result = drive_channel(&server, &mut channel);
+
+    // Always attempt to tear down the mount, even if the request loop errored,
+    // so a failure mid-mount doesn't leave a dangling `/dev/fuse` connection.
+    if let Err(e) = session.umount() {
+        tracing::warn!(mountpoint = %mountpoint.display(), error = %e, "fuse umount failed");
+    }
+
+    result
+}
+
+/// Drain `channel`, dispatching each request through the FUSE server, until the
+/// kernel closes the session (`get_request` returns `Ok(None)`).
+fn drive_channel(server: &Arc<Server<VfsFileSystem>>, channel: &mut FuseChannel) -> io::Result<()> {
+    loop {
+        let request = match channel.get_request() {
+            Ok(r) => r,
+            Err(e) => {
+                // `FuseChannel::get_request` treats a clean `ENODEV` read as
+                // `Ok(None)` (see its `linux_session.rs` docs), but a
+                // concurrent unmount can also surface as an epoll-error event
+                // on the `/dev/fuse` fd, which it reports as `Err` rather than
+                // `Ok(None)`. Either shape means the same thing here: the
+                // kernel end of the session is gone. Treat any channel error
+                // as ordinary session teardown rather than a hard failure —
+                // there is nothing left to serve once `/dev/fuse` is torn
+                // down, and propagating it would turn a normal `fusermount -u`
+                // into a spurious error from `serve_local`.
+                tracing::debug!(error = %e, "fuse channel closed");
+                return Ok(());
+            }
+        };
+        let Some((reader, writer)) = request else {
+            // Session closed (unmounted or kernel dropped /dev/fuse).
+            return Ok(());
+        };
+        if let Err(e) = server.handle_message(reader, writer.into(), None, None) {
+            // Mirrors fuse-backend-rs's own fusedev example: an encode failure
+            // means the kernel end is gone, so stop; any other per-request
+            // error is logged and the loop continues serving later requests.
+            match e {
+                fuse_backend_rs::Error::EncodeMessage(_) => return Ok(()),
+                _ => tracing::error!(error = %e, "fuse request failed"),
+            }
+        }
+    }
 }

--- a/crates/hyprstream-vfs-server/src/tests.rs
+++ b/crates/hyprstream-vfs-server/src/tests.rs
@@ -561,3 +561,117 @@ fn forget_reclaims_inode() {
     fs.forget(&ctx, f.inode, 1);
     assert!(fs.getattr(&ctx, f.inode, None).is_err());
 }
+
+// ── #653: local `fusedev` mount (real kernel `/dev/fuse`) ──────────────────
+//
+// This is the one test in the suite that leaves the in-process `FileSystem`
+// trait surface and drives a real kernel FUSE mount end to end: `serve_local`
+// mounts the namespace at a host directory, and we exercise it purely through
+// `std::fs` — proving the `VfsFileSystem` down-adapter works unmodified over
+// the `fusedev` transport, not just `virtiofs`.
+//
+// It requires a working, accessible `/dev/fuse` plus an unprivileged-capable
+// `fusermount3` (setuid, or user namespaces configured for unprivileged FUSE
+// mounts). Sandboxed CI/build environments frequently lack this (no `/dev/fuse`
+// device node, or mount(2)/fusermount3 blocked by the container runtime), so
+// the test probes for a working mount up front and skips (rather than fails)
+// when unavailable — the mount attempt itself is the probe; anything short of
+// a running background thread reaching a live directory is treated as
+// "environment can't do this" rather than a code fault. Structural coverage of
+// the same `VfsFileSystem` op surface this exercises (lookup/read/readdir/...)
+// lives in the in-process tests above, which always run.
+#[test]
+fn local_fuse_mount_read_and_readdir() {
+    let dir = match tempfile::tempdir() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("skipping local_fuse_mount_read_and_readdir: no tmp dir: {e}");
+            return;
+        }
+    };
+    let mountpoint = dir.path().to_path_buf();
+
+    let mut ns = Namespace::new();
+    ns.mount(
+        "/data",
+        Arc::new(MemFs::with_files(&[("hello.txt", b"hello from fuse"), ("sub/nested.txt", b"n")])),
+    )
+    .unwrap();
+    let fs = build(ns);
+
+    let mp = mountpoint.clone();
+    let handle = std::thread::Builder::new()
+        .name("fuse-local-test".to_owned())
+        .spawn(move || crate::server::serve_local(fs, &mp))
+        .expect("spawn serve_local thread");
+
+    // Poll for the mount to come up (readdir on an unmounted-but-existing
+    // empty tempdir succeeds trivially, so we look for our known entry
+    // instead of just "the directory is readable").
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let mut mounted = false;
+    while std::time::Instant::now() < deadline {
+        if mountpoint.join("data").join("hello.txt").exists() {
+            mounted = true;
+            break;
+        }
+        if handle.is_finished() {
+            break; // serve_local exited early (mount failed) — stop polling.
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    if !mounted {
+        // Environment can't do a real FUSE mount (no /dev/fuse access,
+        // fusermount3 not usable unprivileged, etc). Best-effort unmount in
+        // case a partial mount happened, then skip.
+        let _ = std::process::Command::new("fusermount3").arg("-u").arg(&mountpoint).status();
+        let _ = std::process::Command::new("fusermount").arg("-u").arg(&mountpoint).status();
+        eprintln!(
+            "skipping local_fuse_mount_read_and_readdir: could not establish a real /dev/fuse \
+             mount in this environment (no access to /dev/fuse or unprivileged fusermount3)"
+        );
+        return;
+    }
+
+    // Read a file through the real kernel mount.
+    let content = std::fs::read_to_string(mountpoint.join("data").join("hello.txt"))
+        .expect("read mounted file");
+    assert_eq!(content, "hello from fuse");
+
+    // List a directory through the real kernel mount.
+    let mut names: Vec<String> = std::fs::read_dir(mountpoint.join("data"))
+        .expect("readdir mounted dir")
+        .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+        .collect();
+    names.sort();
+    assert_eq!(names, vec!["hello.txt".to_owned(), "sub".to_owned()]);
+
+    // Nested read.
+    let nested = std::fs::read_to_string(mountpoint.join("data").join("sub").join("nested.txt"))
+        .expect("read nested mounted file");
+    assert_eq!(nested, "n");
+
+    // Tear down: unmount (fusermount3 -u works unprivileged for a FUSE mount
+    // owned by this uid), then wait for the serving thread to exit.
+    let status = std::process::Command::new("fusermount3")
+        .arg("-u")
+        .arg(&mountpoint)
+        .status();
+    if !matches!(status, Ok(s) if s.success()) {
+        let _ = std::process::Command::new("fusermount").arg("-u").arg(&mountpoint).status();
+    }
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while !handle.is_finished() && std::time::Instant::now() < deadline {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    if handle.is_finished() {
+        handle.join().expect("serve_local thread panicked").expect("serve_local returned an error");
+    } else {
+        // Thread didn't exit in time; nothing more we can do from the test
+        // without risking a hang — leave it be (the process will reap it at
+        // exit) rather than block the suite.
+        eprintln!("serve_local thread did not exit after unmount within timeout");
+    }
+}


### PR DESCRIPTION
## Summary

Closes #653.

`hyprstream-vfs-server` previously could only expose a composed VFS `Namespace` to a Cloud Hypervisor guest over vhost-user-fs/virtiofs — a VM-only transport. Non-VM sandbox backends (podman `--rootfs <dir>` (#617), `systemd-nspawn --directory=<dir>`) need a plain host POSIX directory instead, and currently side-channel their own image provisioning rather than going through the universal image filesystem service (spine violation, epic #508).

This adds `serve_local(fs, mountpoint)`, additive alongside the existing `serve(fs, socket)`:

- Mounts the **same** transport-agnostic `VfsFileSystem` down-adapter (`SandboxFs::into_filesystem`, unmodified) at a host directory via `fuse-backend-rs`'s `fusedev` transport (kernel `/dev/fuse`) instead of vhost-user-fs, using the standard `FuseSession`/`FuseChannel` + `get_request`/`handle_message` loop (mirrors the crate's own `tests/example/passthroughfs.rs` reference pattern).
- Enables `fuse-backend-rs`'s `fusedev` feature additively in `Cargo.toml` — `virtiofs` is kept for the existing VM path, nothing there was touched.
- Disables `allow_other` (defaults to `true` upstream, which requires a host-wide `user_allow_other` opt-in in `/etc/fuse.conf`) since only the serving process's uid needs to see the mount — this also makes an unprivileged mount work out of the box.
- On teardown, treats any `FuseChannel::get_request` error as ordinary session-end (not just the documented clean `ENODEV`/`Ok(None)` case) — a concurrent `fusermount -u` can also surface as an epoll-error event on `/dev/fuse`, and both mean the same thing: the kernel end is gone.

## Testing

Added `local_fuse_mount_read_and_readdir` in `crates/hyprstream-vfs-server/src/tests.rs`: mounts a synthetic in-memory `MemFs`-backed namespace at a real kernel `/dev/fuse` mountpoint via `serve_local` on a background thread, then drives it purely through `std::fs` — reads a file, reads a nested file, lists a directory — then unmounts via `fusermount3 -u` and joins the server thread.

**This was verified as a real, working kernel FUSE mount in this dev environment** (`/dev/fuse` accessible, `fusermount3` setuid-installed) — the test is not a mock. It probes for mount availability with a timeout and skips gracefully (rather than failing) if `/dev/fuse` isn't usable, since sandboxed CI/build environments frequently lack device access or unprivileged-FUSE support; that fallback path was also exercised (before the `allow_other` fix) and confirmed to skip cleanly rather than fail.

Existing in-process `FileSystem`-trait-level tests (lookup/read/write/create/readdir/rename/EROFS/forget) are all still passing and unmodified.

## Verification run in this environment

- `cargo test -p hyprstream-vfs-server --lib`: 10/10 passed (including the real FUSE mount test).
- `cargo clippy --workspace --all-targets --features download-libtorch -- -D warnings`: clean, zero warnings.
- Scoped `cargo clippy -p hyprstream-vfs-server --all-targets -- -D warnings`: clean.

## Open question (per the issue, not resolved here)

Whether rootless FUSE (unprivileged `/dev/fuse` + `fusermount3`) composes correctly with podman's `--userns=keep-id` user-namespace remapping is **unvalidated**. This change mounts via the same kernel `/dev/fuse` + `fusermount3` path any `fusedev` consumer uses, and disables `allow_other` so it works unprivileged for the mounting user — but the specific `keep-id` interaction with podman is out of scope here and deferred to #617, which owns actual podman integration.

## Test plan

- [x] `cargo test -p hyprstream-vfs-server --lib`
- [x] `cargo clippy --workspace --all-targets --features download-libtorch -- -D warnings`
- [ ] Podman `--rootfs` integration against this mount (#617, follow-up)