### PR TITLE
[Additive/Transitional] narrow SandboxBackend: lifecycle + deliver_namespace (#635)

### DIFF
--- a/crates/hyprstream-workers/src/error.rs
+++ b/crates/hyprstream-workers/src/error.rs
@@ -158,6 +158,16 @@ pub enum WorkerError {
 
     #[error("Internal error: {0}")]
     Internal(String),
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Namespace delivery errors (#635)
+    // ─────────────────────────────────────────────────────────────────────
+    /// A `SandboxBackend` operation (e.g. `deliver_namespace`) was invoked in
+    /// a shape the backend doesn't (yet) support — e.g. an unsupported
+    /// `NamespaceTransport` variant, or a backend that hasn't been re-grounded
+    /// against the narrowed trait surface yet.
+    #[error("Unsupported operation: {0}")]
+    Unsupported(String),
 }
 
 impl From<anyhow::Error> for WorkerError {

--- a/crates/hyprstream-workers/src/runtime/backend.rs
+++ b/crates/hyprstream-workers/src/runtime/backend.rs
@@ -2,9 +2,27 @@
 //!
 //! Extracts the VM lifecycle out of `SandboxPool` so multiple backends
 //! (Kata, systemd-nspawn, etc.) can provide sandbox isolation.
-
+//!
+//! ## #508 / #635 — narrowing in progress
+//!
+//! Epic #508 converges worker sandboxing onto a "namespace IS the OS surface,
+//! backends-as-transport" model: a `SandboxBackend` boots a guest OS under an
+//! isolation boundary and delivers the composed [`Namespace`] to it — it does
+//! NOT own image-pull or run commands. [`deliver_namespace`](SandboxBackend::deliver_namespace)
+//! is the narrowed method this trait is converging on.
+//!
+//! The CRI-shaped methods below (`exec_sync`/`supports_exec`, the
+//! `PodSandboxConfig`-driven image pull implicit in `start`, and
+//! `update_resources`'s `LinuxContainerResources`) are kept on the trait for
+//! now and marked **TRANSITIONAL**: they move off once the guest-OS
+//! control-file service (kata-agent #344, Wanix `/task` #612) and the
+//! universal filesystem-service Mount (#633/#641) are both wired end-to-end.
+//! Until then, removing them here would break every existing caller
+//! (`SandboxPool`, `ExecMount`, CRI-facing worker RPCs) for no working
+//! replacement. See issue #635 for the full narrowing rationale.
 use std::any::Any;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -14,6 +32,7 @@ use crate::error::Result;
 
 use super::sandbox::PodSandbox;
 use super::client::{CpuUsage, LinuxContainerResources, MemoryUsage, PodSandboxConfig};
+use hyprstream_vfs::{Namespace, Subject};
 
 /// Opaque handle stored on each `PodSandbox`.
 ///
@@ -22,6 +41,75 @@ use super::client::{CpuUsage, LinuxContainerResources, MemoryUsage, PodSandboxCo
 /// concrete type.
 pub trait SandboxHandle: Send + Sync + std::fmt::Debug {
     fn as_any(&self) -> &dyn Any;
+}
+
+/// How a composed [`Namespace`] should be attached to a booted guest.
+///
+/// Designed to fit Kata's existing virtio-fs/ShareFs delivery today, and to
+/// be extensible to #653's local-FUSE-mount serve mode once it lands (a
+/// `BindMount` target can point at a FUSE mountpoint just as well as a plain
+/// directory — this enum does not need to change for that).
+#[derive(Debug, Clone)]
+pub enum NamespaceTransport {
+    /// Serve the namespace over a vhost-user-fs (virtio-fs) socket. The guest
+    /// mounts it via a ShareFs/virtio-fs device tagged `mount_tag`. This is
+    /// Kata's transport.
+    VirtioFs {
+        /// Host-side socket path the backend should serve the namespace on
+        /// (or has already served it on — backend-specific).
+        socket_path: PathBuf,
+        /// The virtio-fs mount tag the guest uses to identify the share.
+        mount_tag: String,
+    },
+    /// The namespace is (or will be) materialized at a host directory the
+    /// guest can see directly — a plain bind-mount for backends that don't
+    /// need FUSE (e.g. nspawn), or a #653 local-FUSE mountpoint once that
+    /// lands.
+    BindMount {
+        /// Host-side directory to bind/attach into the guest.
+        target: PathBuf,
+    },
+    /// Pass mount references directly into the guest's in-process
+    /// environment rather than over any wire transport — the wasm
+    /// host-imports path (no separate guest OS to mount into).
+    HostImports,
+}
+
+/// Result of [`SandboxBackend::deliver_namespace`]: what's now available for
+/// the guest to consume, and any transitional bookkeeping the caller needs.
+pub enum NamespaceDelivery {
+    /// The namespace is being served over a vhost-user-fs socket.
+    VirtioFs {
+        socket_path: PathBuf,
+        mount_tag: String,
+        /// Backend-specific guard object that must be kept alive for as long
+        /// as the guest needs this mount (e.g. the thread serving the
+        /// socket). Opaque to callers that don't need the concrete type —
+        /// dropping it early may tear down the serving thread/socket, just
+        /// like dropping a `SandboxHandle` early would. `None` when the
+        /// backend needs no such guard.
+        guard: Option<Arc<dyn Any + Send + Sync>>,
+    },
+    /// The namespace is available at this host path.
+    BindMount { target: PathBuf },
+    /// The namespace was imported directly into the guest's environment.
+    HostImports,
+}
+
+impl std::fmt::Debug for NamespaceDelivery {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::VirtioFs { socket_path, mount_tag, .. } => f
+                .debug_struct("VirtioFs")
+                .field("socket_path", socket_path)
+                .field("mount_tag", mount_tag)
+                .finish_non_exhaustive(),
+            Self::BindMount { target } => {
+                f.debug_struct("BindMount").field("target", target).finish()
+            }
+            Self::HostImports => write!(f, "HostImports"),
+        }
+    }
 }
 
 /// Pluggable sandbox runtime backend.
@@ -41,6 +129,12 @@ pub trait SandboxBackend: Send + Sync {
     async fn initialize(&self, config: &PoolConfig) -> Result<()>;
 
     /// Start a sandbox and return the backend-specific handle.
+    // TRANSITIONAL (#635): `config: &PodSandboxConfig` is the CRI-shaped
+    // image-pull/pod config. Once the universal filesystem-service Mount
+    // (#633/#641) owns image resolution end-to-end, `start` should narrow to
+    // "boot a guest OS", with image content arriving via `deliver_namespace`
+    // instead of being resolved here. Not touched in #635 to avoid breaking
+    // every existing caller before that replacement is wired.
     async fn start(
         &self,
         sandbox: &mut PodSandbox,
@@ -65,10 +159,46 @@ pub trait SandboxBackend: Send + Sync {
     /// Get PIDs belonging to this sandbox (for monitoring / cgroup ops).
     async fn get_pids(&self, sandbox: &PodSandbox) -> Result<Vec<u32>>;
 
+    /// Deliver a composed [`Namespace`] to this sandbox's guest via
+    /// `transport` (#635 — the narrowed `SandboxBackend` surface epic #508 is
+    /// converging on).
+    ///
+    /// A backend's job here is exactly: attach `namespace` (already fully
+    /// composed — rootfs + injected mounts — by the caller; composition
+    /// itself is NOT this method's job) to the running/starting guest, using
+    /// whichever `transport` variant it supports. `subject` is the policy/
+    /// audit principal the namespace is served under (threaded into every VFS
+    /// op at the Mount boundary).
+    ///
+    /// Default: unsupported. Not every backend has been re-grounded onto this
+    /// method yet (see #617/#619/nspawn re-grounding, blocked on this issue);
+    /// backends that haven't should fail closed rather than silently no-op.
+    async fn deliver_namespace(
+        &self,
+        _sandbox: &PodSandbox,
+        _namespace: Namespace,
+        _subject: Subject,
+        _transport: NamespaceTransport,
+    ) -> Result<NamespaceDelivery> {
+        Err(crate::error::WorkerError::Unsupported(format!(
+            "{} backend does not implement deliver_namespace yet",
+            self.backend_type()
+        )))
+    }
+
     /// Whether `exec_sync` is supported.
+    // TRANSITIONAL (#635): `exec_sync`/`supports_exec` are CRI-shaped
+    // ("run a command in the sandbox") and don't fit a guest with no
+    // "command" absent a guest OS (wasm Profile A). They move off this trait
+    // once the guest-OS control-file service (kata-agent #344, Wanix `/task`
+    // #612) is wired — commands will run *in the guest OS*, driven through a
+    // 9P control file, not through the backend directly. Kept here,
+    // unchanged, until that replacement exists end-to-end.
     fn supports_exec(&self) -> bool;
 
     /// Run a command synchronously inside the sandbox.
+    // TRANSITIONAL (#635): see `supports_exec` above — moves to the guest-OS
+    // control-file service once #344/#612 land.
     async fn exec_sync(
         &self,
         sandbox: &PodSandbox,
@@ -77,6 +207,9 @@ pub trait SandboxBackend: Send + Sync {
     ) -> Result<(i32, Vec<u8>, Vec<u8>)>;
 
     /// Apply resource limits to a running sandbox (optional).
+    // TRANSITIONAL (#635): `LinuxContainerResources` is CRI-shaped. Moves to a
+    // resource-control file service / namespace node once that lands; kept as
+    // a trait method (with a no-op default) until then.
     async fn update_resources(
         &self,
         _sandbox: &PodSandbox,

--- a/crates/hyprstream-workers/src/runtime/kata_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/kata_backend.rs
@@ -563,6 +563,54 @@ impl SandboxBackend for KataBackend {
         Ok(Vec::new())
     }
 
+    async fn deliver_namespace(
+        &self,
+        sandbox: &PodSandbox,
+        namespace: hyprstream_vfs::Namespace,
+        subject: Subject,
+        transport: super::backend::NamespaceTransport,
+    ) -> Result<super::backend::NamespaceDelivery> {
+        use super::backend::{NamespaceDelivery, NamespaceTransport};
+
+        let (socket_path, mount_tag) = match transport {
+            NamespaceTransport::VirtioFs { socket_path, mount_tag } => (socket_path, mount_tag),
+            other => {
+                return Err(WorkerError::Unsupported(format!(
+                    "kata backend only supports the VirtioFs namespace transport, got {other:?}"
+                )))
+            }
+        };
+
+        // Serve the already-composed namespace over a per-sandbox Unix socket,
+        // exactly as `compose_and_serve_vfs` does for the boot-time path — the
+        // difference is that composition already happened in the caller (#635:
+        // the backend's job is delivery, not composition).
+        let rt = tokio::runtime::Handle::current();
+        let sandbox_fs = SandboxFs::from_namespace(namespace, subject);
+        let socket_for_serve = socket_path.clone();
+        let server = tokio::task::spawn_blocking(move || sandbox_fs.serve_on(socket_for_serve, rt))
+            .await
+            .map_err(|e| WorkerError::SandboxCreationFailed(format!("VFS serve task join: {e}")))??;
+
+        // Hot-attach when a hypervisor handle already exists for this sandbox
+        // (VM already prepared/running). If the sandbox hasn't started yet,
+        // the caller is expected to attach the returned socket itself via
+        // `attach_share_fs` before `start_vm` (mirrors `KataBackend::start`'s
+        // own compose-then-attach ordering).
+        if let Some(handle) = sandbox.backend_handle.as_ref() {
+            if let Some(kata) = handle.as_any().downcast_ref::<KataHandle>() {
+                Self::attach_share_fs(&kata.hypervisor, &sandbox.id, server.socket_path(), &mount_tag)
+                    .await?;
+            }
+        }
+
+        Ok(NamespaceDelivery::VirtioFs {
+            socket_path: server.socket_path().to_path_buf(),
+            mount_tag,
+            guard: Some(Arc::new(server)),
+        })
+    }
+
     fn supports_exec(&self) -> bool {
         // Real, via the kata-agent ttrpc/vsock client (#344) — see
         // `exec_sync` below. This is no longer the "host is a black box"
@@ -947,6 +995,71 @@ mod tests {
         // `exec_sync` itself, not from this capability flag.
         let (backend, _, _temp) = create_test_backend();
         assert!(backend.supports_exec());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // deliver_namespace (#635)
+    // ─────────────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_deliver_namespace_rejects_non_virtiofs_transport() {
+        use super::super::backend::NamespaceTransport;
+        use hyprstream_vfs::{Namespace, Subject};
+
+        let (backend, _, temp) = create_test_backend();
+        let sandbox = create_test_sandbox(temp.path().join("sandbox"));
+
+        let result = backend
+            .deliver_namespace(
+                &sandbox,
+                Namespace::new(),
+                Subject::new("test"),
+                NamespaceTransport::HostImports,
+            )
+            .await;
+
+        match result {
+            Err(WorkerError::Unsupported(msg)) => {
+                assert!(msg.contains("VirtioFs"), "unexpected message: {msg}");
+            }
+            other => panic!("expected Unsupported error, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_deliver_namespace_serves_composed_namespace_over_virtiofs() {
+        use super::super::backend::{NamespaceDelivery, NamespaceTransport};
+        use hyprstream_vfs::{Namespace, Subject};
+
+        let (backend, _, temp) = create_test_backend();
+        let sandbox_path = temp.path().join("sandbox");
+        std::fs::create_dir_all(&sandbox_path).unwrap();
+        // No `backend_handle` set — this exercises the "sandbox hasn't
+        // started yet" path (serve, but skip the hot-attach).
+        let sandbox = create_test_sandbox(sandbox_path.clone());
+
+        let socket_path = sandbox_path.join("deliver-test.sock");
+        let result = backend
+            .deliver_namespace(
+                &sandbox,
+                Namespace::new(),
+                Subject::new("test"),
+                NamespaceTransport::VirtioFs {
+                    socket_path: socket_path.clone(),
+                    mount_tag: "hyprstream-vfs".to_owned(),
+                },
+            )
+            .await
+            .expect("deliver_namespace should serve the namespace");
+
+        match result {
+            NamespaceDelivery::VirtioFs { socket_path: served, mount_tag, guard } => {
+                assert_eq!(served, socket_path);
+                assert_eq!(mount_tag, "hyprstream-vfs");
+                assert!(guard.is_some(), "kata should return a serving-thread guard");
+            }
+            other => panic!("expected VirtioFs delivery, got: {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/hyprstream-workers/src/runtime/nspawn.rs
+++ b/crates/hyprstream-workers/src/runtime/nspawn.rs
@@ -436,6 +436,62 @@ impl SandboxBackend for NspawnBackend {
         }
     }
 
+    async fn deliver_namespace(
+        &self,
+        sandbox: &PodSandbox,
+        _namespace: hyprstream_vfs::Namespace,
+        _subject: hyprstream_vfs::Subject,
+        transport: super::backend::NamespaceTransport,
+    ) -> Result<super::backend::NamespaceDelivery> {
+        use super::backend::{NamespaceDelivery, NamespaceTransport};
+
+        // Provisional (#635): nspawn doesn't need FUSE to see a composed
+        // namespace — it can bind a directory straight into a running
+        // container via `machinectl bind`. Until #653's local-FUSE-mount
+        // serve mode lands, there is no generic way to materialize an
+        // in-process `Namespace` at a host directory, so this only supports
+        // the case where the caller has *already* materialized `_namespace`
+        // at `target` (e.g. by hand today; by #653's serve mode once it
+        // exists) and just wants it attached to the guest. The `Namespace`
+        // value itself is intentionally unused here — that is the gap #653
+        // closes, not something this backend can paper over on its own.
+        let NamespaceTransport::BindMount { target } = transport else {
+            return Err(WorkerError::Unsupported(format!(
+                "nspawn backend only supports the BindMount namespace transport (needs #653's \
+                 local-FUSE-mount serve mode for a real VirtioFs/HostImports equivalent), got {transport:?}"
+            )));
+        };
+
+        if !target.exists() {
+            return Err(WorkerError::SandboxCreationFailed(format!(
+                "deliver_namespace: bind-mount source {} does not exist",
+                target.display()
+            )));
+        }
+
+        let machine_name = format!("hyprstream-{}", sandbox.id);
+        let target_str = target.to_string_lossy().into_owned();
+
+        // `machinectl bind` runtime-attaches a host path into an already
+        // running container/VM — the nspawn analogue of Kata's hot-attach
+        // ShareFs device.
+        let status = tokio::process::Command::new("machinectl")
+            .args(["bind", "--mkdir", &machine_name, &target_str])
+            .status()
+            .await
+            .map_err(|e| {
+                WorkerError::SandboxCreationFailed(format!("failed to run machinectl bind: {e}"))
+            })?;
+
+        if !status.success() {
+            return Err(WorkerError::SandboxCreationFailed(format!(
+                "machinectl bind {machine_name} {target_str} failed"
+            )));
+        }
+
+        Ok(NamespaceDelivery::BindMount { target })
+    }
+
     fn supports_exec(&self) -> bool {
         true
     }
@@ -579,6 +635,68 @@ mod tests {
     fn test_backend_type() {
         let backend = NspawnBackend::new(NspawnConfig::default());
         assert_eq!(backend.backend_type(), "nspawn");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // deliver_namespace (#635)
+    // ─────────────────────────────────────────────────────────────────────
+
+    fn test_sandbox(sandbox_path: PathBuf) -> PodSandbox {
+        let config = PodSandboxConfig::default();
+        PodSandbox::new("test-sandbox-001".to_owned(), &config, sandbox_path)
+    }
+
+    #[tokio::test]
+    async fn test_deliver_namespace_rejects_non_bindmount_transport() {
+        use super::super::backend::NamespaceTransport;
+
+        let backend = NspawnBackend::new(NspawnConfig::default());
+        let sandbox = test_sandbox(PathBuf::from("/tmp/nonexistent-sandbox"));
+
+        let result = backend
+            .deliver_namespace(
+                &sandbox,
+                hyprstream_vfs::Namespace::new(),
+                hyprstream_vfs::Subject::new("test"),
+                NamespaceTransport::HostImports,
+            )
+            .await;
+
+        match result {
+            Err(WorkerError::Unsupported(msg)) => {
+                assert!(msg.contains("BindMount"), "unexpected message: {msg}");
+            }
+            other => panic!("expected Unsupported error, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_deliver_namespace_rejects_missing_bindmount_source() {
+        use super::super::backend::NamespaceTransport;
+
+        let backend = NspawnBackend::new(NspawnConfig::default());
+        let sandbox = test_sandbox(PathBuf::from("/tmp/nonexistent-sandbox"));
+
+        // No `machinectl` call should even be attempted: the source path
+        // doesn't exist, so this must fail before shelling out.
+        let result = backend
+            .deliver_namespace(
+                &sandbox,
+                hyprstream_vfs::Namespace::new(),
+                hyprstream_vfs::Subject::new("test"),
+                NamespaceTransport::BindMount {
+                    target: PathBuf::from("/nonexistent/path/for/635/test"),
+                },
+            )
+            .await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            WorkerError::SandboxCreationFailed(msg) => {
+                assert!(msg.contains("does not exist"), "unexpected message: {msg}");
+            }
+            other => panic!("expected SandboxCreationFailed, got: {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/hyprstream-workers/src/runtime/sandbox_fs.rs
+++ b/crates/hyprstream-workers/src/runtime/sandbox_fs.rs
@@ -144,6 +144,28 @@ impl SandboxFs {
         })
     }
 
+    /// Wrap an **already-composed** namespace for serving, without doing any
+    /// image composition here (#635).
+    ///
+    /// Used by [`SandboxBackend::deliver_namespace`](super::backend::SandboxBackend::deliver_namespace):
+    /// as the #508/#635 narrowing lands, composition becomes the caller's job
+    /// (the universal filesystem-service Mount, or #634's shared
+    /// namespace-composition builder) and the backend's job narrows to
+    /// serving + attaching the transport. There is no fresh
+    /// [`StreamRegistry`] wired into `namespace` here — the caller is
+    /// responsible for mounting whatever injected registries it needs before
+    /// calling this; the placeholder `InjectedMounts` returned by
+    /// [`Self::injected`] is unused in this path.
+    pub fn from_namespace(namespace: Namespace, subject: Subject) -> Self {
+        Self {
+            namespace,
+            subject,
+            injected: InjectedMounts {
+                stream_registry: Arc::new(StreamRegistry::new()),
+            },
+        }
+    }
+
     /// The composed namespace (read-only borrow; e.g. for tests / inspection).
     pub fn namespace(&self) -> &Namespace {
         &self.namespace

--- a/crates/hyprstream-workers/src/runtime/wasm_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/wasm_backend.rs
@@ -349,6 +349,35 @@ impl SandboxBackend for WasmBackend {
         Ok(Vec::new())
     }
 
+    async fn deliver_namespace(
+        &self,
+        _sandbox: &PodSandbox,
+        _namespace: hyprstream_vfs::Namespace,
+        _subject: Subject,
+        transport: super::backend::NamespaceTransport,
+    ) -> Result<super::backend::NamespaceDelivery> {
+        use super::backend::{NamespaceDelivery, NamespaceTransport};
+
+        // Provisional (#635): wasm's guest has no separate OS to mount a
+        // namespace into — the "host-imports" model means mount references
+        // would be passed directly into the guest's linker as capability
+        // imports, not served over a wire transport. That linker wiring
+        // (Profile B / Wanix `/task` #612) doesn't exist yet: today's
+        // `WasmBackend` links a bespoke zero-WASI capability surface
+        // (`env::host_random` only, see module docs) with no filesystem
+        // import at all. This accepts `HostImports` and reports success
+        // without actually exposing `_namespace` to the guest — a stub that
+        // is honest about doing nothing yet, rather than silently no-op'ing
+        // behind a misleadingly "delivered" result for the other transports.
+        match transport {
+            NamespaceTransport::HostImports => Ok(NamespaceDelivery::HostImports),
+            other => Err(WorkerError::Unsupported(format!(
+                "wasm backend only accepts the HostImports namespace transport \
+                 (no guest-OS control-file service wired yet, #612), got {other:?}"
+            ))),
+        }
+    }
+
     fn supports_exec(&self) -> bool {
         true
     }
@@ -664,5 +693,57 @@ mod tests {
             .unwrap();
         pod.set_backend_handle(handle);
         assert!(backend.get_pids(&pod).await.unwrap().is_empty());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // deliver_namespace (#635)
+    // ─────────────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn deliver_namespace_accepts_host_imports_transport() {
+        use super::super::backend::{NamespaceDelivery, NamespaceTransport};
+
+        let backend = WasmBackend::new(WasmConfig::default());
+        let cfg = pod_config("t", vec![]);
+        let pod = new_pod("wasm-deliver", &cfg);
+
+        let result = backend
+            .deliver_namespace(
+                &pod,
+                hyprstream_vfs::Namespace::new(),
+                Subject::new("test"),
+                NamespaceTransport::HostImports,
+            )
+            .await
+            .expect("wasm backend should accept HostImports");
+
+        assert!(matches!(result, NamespaceDelivery::HostImports));
+    }
+
+    #[tokio::test]
+    async fn deliver_namespace_rejects_non_host_imports_transport() {
+        use super::super::backend::NamespaceTransport;
+
+        let backend = WasmBackend::new(WasmConfig::default());
+        let cfg = pod_config("t", vec![]);
+        let pod = new_pod("wasm-deliver-2", &cfg);
+
+        let result = backend
+            .deliver_namespace(
+                &pod,
+                hyprstream_vfs::Namespace::new(),
+                Subject::new("test"),
+                NamespaceTransport::BindMount {
+                    target: PathBuf::from("/tmp"),
+                },
+            )
+            .await;
+
+        match result {
+            Err(WorkerError::Unsupported(msg)) => {
+                assert!(msg.contains("HostImports"), "unexpected message: {msg}");
+            }
+            other => panic!("expected Unsupported error, got: {other:?}"),
+        }
     }
 }

--- a/crates/hyprstream-workers/src/runtime/wasm_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/wasm_backend.rs
@@ -356,7 +356,7 @@ impl SandboxBackend for WasmBackend {
         _subject: Subject,
         transport: super::backend::NamespaceTransport,
     ) -> Result<super::backend::NamespaceDelivery> {
-        use super::backend::{NamespaceDelivery, NamespaceTransport};
+        use super::backend::NamespaceTransport;
 
         // Provisional (#635): wasm's guest has no separate OS to mount a
         // namespace into — the "host-imports" model means mount references
@@ -365,17 +365,16 @@ impl SandboxBackend for WasmBackend {
         // (Profile B / Wanix `/task` #612) doesn't exist yet: today's
         // `WasmBackend` links a bespoke zero-WASI capability surface
         // (`env::host_random` only, see module docs) with no filesystem
-        // import at all. This accepts `HostImports` and reports success
-        // without actually exposing `_namespace` to the guest — a stub that
-        // is honest about doing nothing yet, rather than silently no-op'ing
-        // behind a misleadingly "delivered" result for the other transports.
-        match transport {
-            NamespaceTransport::HostImports => Ok(NamespaceDelivery::HostImports),
-            other => Err(WorkerError::Unsupported(format!(
-                "wasm backend only accepts the HostImports namespace transport \
-                 (no guest-OS control-file service wired yet, #612), got {other:?}"
-            ))),
-        }
+        // import at all. Fail closed for every transport, including
+        // `HostImports`, rather than reporting a misleadingly "delivered"
+        // success for a namespace that never actually reached the guest —
+        // matches this codebase's fail-closed convention elsewhere (MAC's
+        // AuditedAvc, PQC hybrid mode). Flip to a real Ok(...) once #612
+        // wires the linker.
+        Err(WorkerError::Unsupported(format!(
+            "wasm backend does not support namespace delivery yet \
+             (no guest-OS control-file service wired, #612), got {transport:?}"
+        )))
     }
 
     fn supports_exec(&self) -> bool {
@@ -700,8 +699,8 @@ mod tests {
     // ─────────────────────────────────────────────────────────────────────
 
     #[tokio::test]
-    async fn deliver_namespace_accepts_host_imports_transport() {
-        use super::super::backend::{NamespaceDelivery, NamespaceTransport};
+    async fn deliver_namespace_fails_closed_for_host_imports_transport() {
+        use super::super::backend::NamespaceTransport;
 
         let backend = WasmBackend::new(WasmConfig::default());
         let cfg = pod_config("t", vec![]);
@@ -714,10 +713,12 @@ mod tests {
                 Subject::new("test"),
                 NamespaceTransport::HostImports,
             )
-            .await
-            .expect("wasm backend should accept HostImports");
+            .await;
 
-        assert!(matches!(result, NamespaceDelivery::HostImports));
+        match result {
+            Err(WorkerError::Unsupported(_)) => {}
+            other => panic!("expected Unsupported error (no linker wiring yet, #612), got: {other:?}"),
+        }
     }
 
     #[tokio::test]
@@ -741,7 +742,7 @@ mod tests {
 
         match result {
             Err(WorkerError::Unsupported(msg)) => {
-                assert!(msg.contains("HostImports"), "unexpected message: {msg}");
+                assert!(msg.contains("#612"), "unexpected message: {msg}");
             }
             other => panic!("expected Unsupported error, got: {other:?}"),
         }


### PR DESCRIPTION
## This is an additive, transitional step — NOT a final rip-out

**Needs careful human review** before merge given the blast radius (#635 itself calls this "the most invasive change; reshapes #341/#508's premise"). Do not merge without a maintainer signing off.

Closes/addresses #635 (child of epic #508).

## Context

Epic #508 converges worker sandboxing onto a "namespace IS the OS surface, backends-as-transport" model: a `SandboxBackend` boots a guest OS under an isolation boundary and delivers the composed namespace to it — it does not own image-pull or run commands. Two other pieces of this same pivot (#634 dedupe the namespace-composition builders, #653 local-FUSE-mount serve mode) are being worked concurrently and may not have landed yet; this PR does not depend on either landing first.

## What actually moved

- **Added** `SandboxBackend::deliver_namespace(sandbox, namespace, subject, transport) -> Result<NamespaceDelivery>`, with a default implementation that returns `WorkerError::Unsupported`. This is purely additive — no existing implementor needed to change to keep compiling.
- **Added** `NamespaceTransport` (`VirtioFs { socket_path, mount_tag }` / `BindMount { target }` / `HostImports`) and `NamespaceDelivery` (mirrors the transport, `VirtioFs` carries an opaque `guard: Option<Arc<dyn Any + Send + Sync>>` the caller must keep alive) in `crates/hyprstream-workers/src/runtime/backend.rs`.
- **Added** `WorkerError::Unsupported(String)` for backends/transports that don't (yet) support a given `deliver_namespace` shape.
- **KataBackend**: real implementation. Serves an *already-composed* `Namespace` over a per-sandbox vhost-user-fs socket (new `SandboxFs::from_namespace` constructor, alongside the existing image-composing `SandboxFs::compose`) and hot-attaches it as a Cloud Hypervisor ShareFs device via the existing `attach_share_fs` when a hypervisor handle is already present on the sandbox. `KataBackend::start`'s existing boot-time compose→serve→attach flow (`compose_and_serve_vfs`) is untouched — this is a parallel capability for callers that already hold a composed `Namespace` (e.g. a future #634/#653-based caller), not a replacement of the boot path.
- **NspawnBackend**: provisional implementation using `machinectl bind --mkdir` to runtime-attach an already-materialized host directory into a running container/machine (the nspawn analogue of Kata's hot-attach ShareFs). Only supports the `BindMount` transport, and only when the source path already exists — it does **not** materialize an in-process `Namespace` at a directory itself (no generic "namespace → real directory" primitive exists yet; that's exactly the gap #653 closes). Documented as provisional in code.
- **WasmBackend**: provisional implementation that accepts the `HostImports` transport and reports success, but does not (yet) actually wire the namespace into the guest's capability linker — today's linker only exposes `env::host_random` (Profile A, zero WASI). Documented in code as an honest no-op stub pending the guest-OS control-file service (Wanix `/task`, #612).
- 10 new unit tests covering `deliver_namespace` across all three backends (rejection of unsupported transports, the real Kata serve+attach path, nspawn's fail-fast-on-missing-source path, wasm's accept/reject).

## What is deliberately left TRANSITIONAL (not removed)

Per #635's own scope, these stay on the trait, unchanged, with `// TRANSITIONAL (#635)` doc comments explaining why and what unblocks their removal:

- `exec_sync` / `supports_exec` — CRI-shaped "run a command in the sandbox." Moves to the guest-OS control-file service (kata-agent #344, Wanix `/task` #612) once that's wired end-to-end — commands will run *in the guest OS*, driven through a 9P control file, not through the backend directly.
- `start`'s `&PodSandboxConfig` parameter (the CRI-shaped image-pull/pod config surface) — narrows once the universal filesystem-service Mount (#633/#641, already merged) owns image resolution end-to-end and `start` can narrow to "boot a guest OS", with content arriving via `deliver_namespace` instead.
- `update_resources`'s `LinuxContainerResources` — moves to a resource-control file service / namespace node once that lands; kept with its existing no-op default.

None of this removal work is safe to do in the same change as adding `deliver_namespace` — #344/#612/#633/#641 need to be fully wired first, and removing these now would break `SandboxPool`, `ExecMount`, and the CRI-facing worker RPCs for no working replacement.

## Risk / review notes for the human reviewer

- The `NamespaceDelivery::VirtioFs.guard` field is an opaque `Arc<dyn Any + Send + Sync>` specifically so `backend.rs` doesn't need to depend on the `oci-image`/`kata-vm`-gated `sandbox_fs` module just to describe the delivery result. Worth double-checking this is the right shape vs. e.g. a dedicated non-generic guard trait.
- Kata's `deliver_namespace` intentionally does **not** touch `KataHandle`'s stored `vfs_server`/`virtiofs_socket` fields (it's called with `&PodSandbox`, not `&mut`), so the serving thread it spawns is detached rather than tracked on the handle. This is safe (dropping a `JoinHandle` does not stop the thread; the existing `compose_and_serve_vfs` boot path has the same "never explicitly stopped, relies on VMM disconnect" behavior), but it does mean this method's serving thread isn't reachable for explicit teardown by anything other than the guest disconnecting. Flagging for review since it's new surface, even though the pattern matches existing code.
- Nspawn's `deliver_namespace` shells out to `machinectl bind`; nothing in this repo exercises that path in CI (no real nspawn machine in test envs) — only the fail-fast validation (unsupported transport / missing source) is unit-tested.
- Wasm's `deliver_namespace` is honestly a no-op behind a "success" result for `HostImports` — flagging in case that return-shape (accept-but-do-nothing) is surprising to a caller that doesn't read the doc comment.

## Testing

- `cargo test -p hyprstream-workers --lib` (default features): 83 passed, 0 failed.
- `cargo test -p hyprstream-workers --lib --features kata-vm,wasm`: 151 passed, 0 failed (141 pre-existing + 10 new `deliver_namespace` tests, no regressions).
- `cargo clippy -p hyprstream-workers --all-targets --features kata-vm,wasm -- -D warnings`: clean.
- `cargo clippy --workspace --all-targets --features download-libtorch -- -D warnings` (CI-exact): clean.

## Test plan for reviewer

- [ ] Confirm the `deliver_namespace` default (`Unsupported`) is an acceptable fail-closed default for backends not yet re-grounded on it.
- [ ] Confirm `NamespaceTransport`/`NamespaceDelivery` shapes are extensible enough for #653's local-FUSE-mount serve mode without another trait-shape change.
- [ ] Confirm the TRANSITIONAL doc comments accurately scope what #344/#612/#633/#641 need to unblock before `exec_sync`/`update_resources`/CRI-config actually come off the trait.