### PR TITLE
feat(mac #681): dual-principal audit — record the delegator as on_behalf_of

### DIFF
--- a/crates/hyprstream/src/mac/audit.rs
+++ b/crates/hyprstream/src/mac/audit.rs
@@ -110,6 +110,35 @@ use thiserror::Error;
 // The record
 // ────────────────────────────────────────────────────────────────────────────
 
+/// The delegator principal recorded on a **delegated** (two-principal, #680/#681)
+/// decision — the source of authority on whose behalf the record's `subject_*`
+/// (the effective, met context) was evaluated.
+///
+/// The audit record identifies principals by their **resolved MAC context**
+/// (TE type + S1 clearance), never caller-asserted strings — the same grain as
+/// `AuditRecord`'s `subject_*`. On the S6 grant path both this and the subject
+/// carry the [`crate::mac::te::GRANT_PATH_SUBJECT`] sentinel type, and the
+/// clearance is the distinguishing field.
+///
+/// Why the delegator and not the actor: the record's `subject_clearance` is
+/// already the effective `meet(delegator, actor)` clearance the PDP evaluated —
+/// and its **assurance is the actor's** (the meet clamps assurance to the
+/// signer's verified key material, #548/#681), so the actor's contribution is
+/// auditable directly on `subject_*`. The delegator is the missing half: the
+/// user-attribution (#445) a confused-deputy call would otherwise lose. Both
+/// source principals are therefore recoverable — the actor's clearance
+/// assurance from `subject_clearance`, the delegator here — and the effective
+/// clearance the decision actually rested on is `subject_clearance` itself.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DelegationPrincipal {
+    /// TE subject type of the delegator (SELinux domain); the grant path uses
+    /// the [`crate::mac::te::GRANT_PATH_SUBJECT`] sentinel.
+    pub subject_type: SubjectType,
+    /// The delegator's clearance label (S1). MAC provenance for the authority
+    /// source.
+    pub subject_clearance: SecurityLabel,
+}
+
 /// A single authorization decision, as recorded by the audit store. This is
 /// the unit of tamper-evidence: it is content-addressed (BLAKE3 over canonical
 /// CBOR), signed, and append-logged.
@@ -121,6 +150,8 @@ use thiserror::Error;
 ///   that governed this decision, when known (`None` for ad-hoc evaluators).
 /// - `subject_*` / `object_*` — the resolved security contexts (TE type +
 ///   S1 label) the PDP actually saw, not caller-asserted strings.
+/// - `on_behalf_of` — for a delegated decision, the delegator principal
+///   (#680/#681); `None` for an ordinary single-principal decision.
 /// - `reason` — why the PDP decided as it did (floor failure, TE miss, token
 ///   gate, audit-fail-closed, ...).
 ///
@@ -154,8 +185,21 @@ pub struct AuditRecord {
     pub policy_hash: Option<[u8; 32]>,
     /// TE subject type (SELinux domain).
     pub subject_type: SubjectType,
-    /// The subject's clearance label (S1). MAC provenance for the subject.
+    /// The subject's clearance label (S1). MAC provenance for the subject. On a
+    /// delegated decision this is the **effective** `meet(delegator, actor)`
+    /// clearance the PDP evaluated (assurance clamped to the actor's signer key,
+    /// #548/#681); the delegator half is recorded in [`Self::on_behalf_of`].
     pub subject_clearance: SecurityLabel,
+    /// For a **delegated** decision (#680/#681), the delegator principal — the
+    /// source of authority on whose behalf `subject_*` acted. `None` for an
+    /// ordinary single-principal decision.
+    ///
+    /// **Versioned by omission:** serialized only when `Some`, so a
+    /// single-principal record's canonical bytes (and therefore its content
+    /// hash and its successor's `prev_hash` link) are byte-identical to the
+    /// pre-delegation schema — the hash chain is preserved across the upgrade.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_behalf_of: Option<DelegationPrincipal>,
     /// TE object type.
     pub object_type: ObjectType,
     /// The object's content-bound label (S1). MAC provenance for the object.
@@ -930,9 +974,15 @@ impl<A: Avc, S: AuditSink> AuditedAvc<A, S> {
 
     /// Record a decision through the sink, applying the fail-closed rule.
     /// Returns the decision the PEP should enforce, plus the reason.
+    ///
+    /// `on_behalf_of` carries the delegator principal on a delegated (#680/#681)
+    /// decision — `subject` is the effective, met context the AVC decided on;
+    /// the delegator is recorded but never re-evaluated here (the meet already
+    /// happened upstream in `SecurityContext::delegated`).
     fn audit(
         &self,
         subject: SubjectCtx,
+        on_behalf_of: Option<SubjectCtx>,
         object: ObjectCtx,
         action: Action,
         decision: Decision,
@@ -960,6 +1010,10 @@ impl<A: Avc, S: AuditSink> AuditedAvc<A, S> {
             policy_hash: self.policy_hash,
             subject_type: subject.subject_type,
             subject_clearance: subject.clearance,
+            on_behalf_of: on_behalf_of.map(|d| DelegationPrincipal {
+                subject_type: d.subject_type,
+                subject_clearance: d.clearance,
+            }),
             object_type: object.object_type,
             object_label: object.label,
             action,
@@ -1002,7 +1056,7 @@ impl<A: Avc, S: AuditSink> Avc for AuditedAvc<A, S> {
     fn decide(&self, subject: SubjectCtx, object: ObjectCtx, action: Action) -> Decision {
         let decision = self.inner.decide(subject, object, action);
         let reason = decision_reason_for(decision);
-        self.audit(subject, object, action, decision, reason)
+        self.audit(subject, None, object, action, decision, reason)
     }
 
     #[inline]
@@ -1026,11 +1080,59 @@ impl<A: Avc, S: AuditSink> Avc for AuditedAvc<A, S> {
         } else {
             pre_reason.unwrap_or_else(|| decision_reason_for(decision))
         };
-        self.audit(subject, object, action, decision, reason)
+        self.audit(subject, None, object, action, decision, reason)
     }
 
     fn flush(&self) {
         self.inner.flush();
+    }
+}
+
+impl<A: Avc, S: AuditSink> AuditedAvc<A, S> {
+    /// Delegated (#680/#681) counterpart of [`Avc::decide`]: `subject` is the
+    /// effective, met context the PDP decides on (already `meet(delegator,
+    /// actor)` from [`hyprstream_rpc::auth::mac::SecurityContext::delegated`]);
+    /// `on_behalf_of` is the delegator principal, recorded on the audit record
+    /// but **never re-evaluated** (the decision rests on the met `subject`
+    /// alone — the delegator cannot re-widen it).
+    ///
+    /// The plain [`Avc::decide`] is the single-principal case (`on_behalf_of =
+    /// None`); this is the two-principal case the (future) reference monitor
+    /// calls when a request arrived over a delegation. Kept off the `Avc` trait
+    /// so the hot-path cache key stays `(subject, object, action)` — delegation
+    /// is an audit-attribution concern, not a decision input.
+    #[inline]
+    pub fn decide_delegated(
+        &self,
+        subject: SubjectCtx,
+        on_behalf_of: Option<SubjectCtx>,
+        object: ObjectCtx,
+        action: Action,
+    ) -> Decision {
+        let decision = self.inner.decide(subject, object, action);
+        let reason = decision_reason_for(decision);
+        self.audit(subject, on_behalf_of, object, action, decision, reason)
+    }
+
+    /// Delegated counterpart of [`Avc::decide_with_token`]; see
+    /// [`Self::decide_delegated`] for the two-principal semantics.
+    #[inline]
+    pub fn decide_delegated_with_token(
+        &self,
+        subject: SubjectCtx,
+        on_behalf_of: Option<SubjectCtx>,
+        object: ObjectCtx,
+        action: Action,
+        token: &TokenScope,
+    ) -> Decision {
+        let pre_reason = token_deny_reason(token, action);
+        let decision = self.inner.decide_with_token(subject, object, action, token);
+        let reason = if decision.is_permit() {
+            DecisionReason::Permit
+        } else {
+            pre_reason.unwrap_or_else(|| decision_reason_for(decision))
+        };
+        self.audit(subject, on_behalf_of, object, action, decision, reason)
     }
 }
 
@@ -1423,6 +1525,7 @@ mod tests {
             policy_hash: None,
             subject_type: SubjectType(1),
             subject_clearance: high(),
+            on_behalf_of: None,
             object_type: ObjectType(1),
             object_label: low(),
             action: Action(1),
@@ -1445,6 +1548,97 @@ mod tests {
         assert_ne!(h1, h4, "timestamp drift must change the content hash");
     }
 
+    /// #680/#681 hash-chain back-compat: a single-principal record
+    /// (`on_behalf_of: None`) must serialize byte-identically to the
+    /// pre-delegation schema — the field is skipped entirely, so existing
+    /// content hashes and `prev_hash` links are preserved across the upgrade.
+    /// Setting a delegator changes the hash (it is covered content).
+    #[test]
+    fn on_behalf_of_none_is_omitted_and_some_changes_the_hash() {
+        let mut rec = AuditRecord {
+            seq: 1,
+            prev_hash: [0u8; 32],
+            ts_unix_nanos: 0,
+            decision: Decision::Permit,
+            generation: 7,
+            policy_hash: None,
+            subject_type: SubjectType(1),
+            subject_clearance: high(),
+            on_behalf_of: None,
+            object_type: ObjectType(1),
+            object_label: low(),
+            action: Action(1),
+            reason: DecisionReason::Permit,
+        };
+
+        // `None` is skipped: the field name never appears in the canonical bytes,
+        // so a single-principal record is byte-identical to the pre-delegation
+        // schema (which had no such field at all).
+        let bytes_none = rec.canonical_bytes().unwrap();
+        let text = String::from_utf8(bytes_none.clone()).unwrap();
+        assert!(
+            !text.contains("on_behalf_of"),
+            "a None delegator must be omitted from canonical bytes (hash-chain back-compat)"
+        );
+        let hash_none = rec.content_hash().unwrap();
+
+        // A delegated record IS distinguished: the delegator is covered content,
+        // so the hash moves and the field is now present.
+        rec.on_behalf_of = Some(DelegationPrincipal {
+            subject_type: SubjectType(2),
+            subject_clearance: low(),
+        });
+        let bytes_some = rec.canonical_bytes().unwrap();
+        assert!(
+            String::from_utf8(bytes_some).unwrap().contains("on_behalf_of"),
+            "a Some delegator must appear in the canonical bytes"
+        );
+        assert_ne!(
+            hash_none,
+            rec.content_hash().unwrap(),
+            "recording a delegator must change the content hash — it is tamper-evident content"
+        );
+    }
+
+    /// #680/#681: `AuditedAvc::decide_delegated` decides on the effective (met)
+    /// `subject` alone — the delegator never re-widens the decision — but stamps
+    /// the delegator on the audit record's `on_behalf_of`. The plain `decide`
+    /// path records `None`.
+    #[test]
+    fn decide_delegated_records_delegator_without_affecting_the_decision() {
+        let inner = avc();
+        let sink = Arc::new(CapturingSink::new());
+        let audited = AuditedAvc::new(inner, sink.clone(), 7, None);
+
+        // Met subject clears the op (rule (1,1,1) + floor holds). The delegator
+        // is a DISTINCT principal (different TE type + clearance).
+        let met = subj(1, high());
+        let delegator = subj(2, low());
+        let d = audited.decide_delegated(met, Some(delegator), obj(1, low()), Action(1));
+        assert_eq!(d, Decision::Permit, "decision rests on the met subject alone");
+
+        // A non-delegated decision on the same triple records no delegator.
+        let d2 = audited.decide(subj(1, high()), obj(1, low()), Action(1));
+        assert_eq!(d2, Decision::Permit);
+
+        let recs = sink.records();
+        assert_eq!(recs.len(), 2);
+        let obo = recs[0]
+            .on_behalf_of
+            .expect("the delegated decision records its delegator");
+        assert_eq!(obo.subject_type, SubjectType(2), "delegator's TE type");
+        assert_eq!(obo.subject_clearance, low(), "delegator's own clearance");
+        assert_eq!(
+            recs[0].subject_clearance,
+            high(),
+            "subject_clearance is the met context, not the delegator's"
+        );
+        assert!(
+            recs[1].on_behalf_of.is_none(),
+            "the non-delegated decision records no delegator"
+        );
+    }
+
     // ── Property: append-only / no mutate/delete API ────────────────────────
 
     #[test]
@@ -1463,6 +1657,7 @@ mod tests {
             policy_hash: None,
             subject_type: SubjectType(1),
             subject_clearance: high(),
+            on_behalf_of: None,
             object_type: ObjectType(1),
             object_label: low(),
             action: Action(1),
@@ -1505,6 +1700,7 @@ mod tests {
             policy_hash: Some([0xaa; 32]),
             subject_type: SubjectType(1),
             subject_clearance: high(),
+            on_behalf_of: None,
             object_type: ObjectType(1),
             object_label: low(),
             action: Action(9),
@@ -1555,6 +1751,7 @@ mod tests {
             policy_hash: None,
             subject_type: SubjectType(1),
             subject_clearance: high(),
+            on_behalf_of: None,
             object_type: ObjectType(1),
             object_label: low(),
             action: Action(1),
@@ -1608,6 +1805,7 @@ mod tests {
             policy_hash: None,
             subject_type: SubjectType(1),
             subject_clearance: high(),
+            on_behalf_of: None,
             object_type: ObjectType(1),
             object_label: low(),
             action: Action(1),
@@ -1657,6 +1855,7 @@ mod tests {
             policy_hash: None,
             subject_type: SubjectType(1),
             subject_clearance: high(),
+            on_behalf_of: None,
             object_type: ObjectType(1),
             object_label: low(),
             action: Action(1),

--- a/crates/hyprstream/src/mac/exchange.rs
+++ b/crates/hyprstream/src/mac/exchange.rs
@@ -397,11 +397,12 @@ pub fn audited_evaluate_grant<V: UcanVerifier + ?Sized>(
     now: u64,
     request: &GrantRequest,
     subject: Option<&SecurityContext>,
+    on_behalf_of: Option<&SecurityContext>,
     sender_bound: bool,
     sink: &dyn crate::mac::audit::AuditSink,
 ) -> Result<GrantDecision, GrantError> {
     let result = evaluate_grant(grant, verifier, now, request, subject, sender_bound);
-    audit_grant_outcome(subject, request, &result, sink)
+    audit_grant_outcome(subject, on_behalf_of, request, &result, sink)
 }
 
 /// As [`evaluate_refresh`], with the same audit-then-decide wrapping as
@@ -415,11 +416,12 @@ pub fn audited_evaluate_refresh<V: UcanVerifier + ?Sized>(
     now: u64,
     request: &GrantRequest,
     subject: Option<&SecurityContext>,
+    on_behalf_of: Option<&SecurityContext>,
     sender_bound: bool,
     sink: &dyn crate::mac::audit::AuditSink,
 ) -> Result<GrantDecision, GrantError> {
     let result = evaluate_refresh(grant, verifier, now, request, subject, sender_bound);
-    audit_grant_outcome(subject, request, &result, sink)
+    audit_grant_outcome(subject, on_behalf_of, request, &result, sink)
 }
 
 /// Shared audit-then-decide core for [`audited_evaluate_grant`] /
@@ -430,11 +432,12 @@ pub fn audited_evaluate_refresh<V: UcanVerifier + ?Sized>(
 /// sentinel ids documented on [`crate::mac::te::GRANT_PATH_SUBJECT`]).
 fn audit_grant_outcome(
     subject: Option<&SecurityContext>,
+    on_behalf_of: Option<&SecurityContext>,
     request: &GrantRequest,
     result: &Result<GrantDecision, GrantError>,
     sink: &dyn crate::mac::audit::AuditSink,
 ) -> Result<GrantDecision, GrantError> {
-    use crate::mac::audit::{AuditRecord, DecisionReason};
+    use crate::mac::audit::{AuditRecord, DecisionReason, DelegationPrincipal};
     use crate::mac::te::{Action, ScopeAction, ACTION_UNRECOGNIZED, GRANT_PATH_OBJECT, GRANT_PATH_SUBJECT};
     use hyprstream_rpc::auth::mac::SecurityLabel;
 
@@ -469,6 +472,14 @@ fn audit_grant_outcome(
         policy_hash: None,
         subject_type: GRANT_PATH_SUBJECT,
         subject_clearance: subject.map(|s| *s.clearance()).unwrap_or_else(SecurityLabel::bottom),
+        // #680/#681: on a delegated grant the delegator (authority source) is
+        // recorded here; `subject_clearance` above is the effective met context
+        // the gates evaluated. Same GRANT_PATH_SUBJECT sentinel type — the
+        // clearance is the distinguishing field on the grant path.
+        on_behalf_of: on_behalf_of.map(|d| DelegationPrincipal {
+            subject_type: GRANT_PATH_SUBJECT,
+            subject_clearance: *d.clearance(),
+        }),
         object_type: GRANT_PATH_OBJECT,
         object_label: request.object_label.unwrap_or_else(SecurityLabel::bottom),
         action,
@@ -1191,6 +1202,7 @@ mod tests {
             NOW,
             &request,
             Some(&cleared_subject()),
+            None, // no delegator — single-principal (self-issued) grant
             true,
             &sink,
         );
@@ -1205,6 +1217,56 @@ mod tests {
         assert_eq!(recs[0].reason, crate::mac::audit::DecisionReason::Permit);
         assert_eq!(recs[0].subject_type, crate::mac::te::GRANT_PATH_SUBJECT);
         assert_eq!(recs[0].object_type, crate::mac::te::GRANT_PATH_OBJECT);
+        // Single-principal grant ⇒ no delegator recorded (#680/#681).
+        assert!(
+            recs[0].on_behalf_of.is_none(),
+            "a self-issued grant records no delegator"
+        );
+    }
+
+    /// #680/#681: a delegated grant records the DELEGATOR on the audit record's
+    /// `on_behalf_of`, distinct from the effective (met) `subject_clearance` the
+    /// gates evaluated — so the audit trail names both principals of a delegated
+    /// decision (the user-attribution #445 asks for), not just the actor.
+    #[test]
+    fn delegated_grant_records_delegator_as_on_behalf_of() {
+        let (grant, store) = root_grant(cap("mac://model/*", "model/read"));
+        let object_label =
+            SecurityLabel::new(Level::Confidential, Assurance::PqHybrid, comps(&[0]));
+        let request = req("mac://model/qwen", "model/read", object_label);
+        let sink = SpySink::new();
+
+        // The delegator (authority source): a DISTINCT clearance from the met
+        // subject (`cleared_subject` is Secret/{0,1}), so the record must not
+        // conflate the two.
+        let delegator = SecurityContext::new(Level::Secret, comps(&[0, 1, 2]), VerifiedKeyMaterial::PqHybrid);
+
+        let decision = audited_evaluate_grant(
+            &grant,
+            &store,
+            NOW,
+            &request,
+            Some(&cleared_subject()), // met context the gates evaluate
+            Some(&delegator),         // delegator, for two-principal audit
+            true,
+            &sink,
+        );
+        assert!(matches!(decision, Ok(GrantDecision::Permit(_))));
+
+        let recs = sink.records();
+        assert_eq!(recs.len(), 1);
+        // A delegated grant records its delegator.
+        let obo = recs[0].on_behalf_of.unwrap();
+        assert_eq!(
+            obo.subject_clearance,
+            *delegator.clearance(),
+            "on_behalf_of carries the delegator's own clearance"
+        );
+        assert_ne!(
+            obo.subject_clearance, recs[0].subject_clearance,
+            "delegator (on_behalf_of) is distinct from the met subject clearance"
+        );
+        assert_eq!(obo.subject_type, crate::mac::te::GRANT_PATH_SUBJECT);
     }
 
     /// The core #674 obligation: a would-be Permit that CANNOT be durably
@@ -1226,6 +1288,7 @@ mod tests {
             NOW,
             &request,
             Some(&cleared_subject()),
+            None, // no delegator — single-principal (self-issued) grant
             true,
             &sink,
         );
@@ -1268,6 +1331,7 @@ mod tests {
             NOW,
             &request,
             Some(&cleared_subject()),
+            None, // no delegator — single-principal (self-issued) grant
             true,
             &sink,
         );
@@ -1301,6 +1365,7 @@ mod tests {
             NOW,
             &request,
             Some(&cleared_subject()),
+            None, // no delegator — single-principal (self-issued) grant
             true,
             &sink,
         );
@@ -1326,6 +1391,7 @@ mod tests {
             NOW,
             &request,
             Some(&cleared_subject()),
+            None, // no delegator — single-principal (self-issued) grant
             true,
             &sink,
         );

--- a/crates/hyprstream/src/services/oauth/token_exchange.rs
+++ b/crates/hyprstream/src/services/oauth/token_exchange.rs
@@ -425,22 +425,20 @@ struct TokenPrincipals {
 fn resolve_grant_subject(
     grant: &hyprstream_rpc::auth::ucan::token::Ucan,
     resolver: &dyn SubjectContextResolver,
-) -> (
-    Option<hyprstream_rpc::auth::mac::SecurityContext>,
-    TokenPrincipals,
-) {
+) -> ResolvedGrantSubject {
     let audience = grant.audience().as_str();
     let delegator = grant.root_issuer().as_str();
 
     if delegator == audience {
         // Self-issued root — no delegation. Single principal = the subject.
-        return (
-            resolver.resolve(audience),
-            TokenPrincipals {
+        return ResolvedGrantSubject {
+            subject: resolver.resolve(audience),
+            on_behalf_of: None,
+            principals: TokenPrincipals {
                 sub: audience.to_owned(),
                 act: None,
             },
-        );
+        };
     }
 
     // Delegation: resolve BOTH principals and take the fail-closed meet (#681).
@@ -462,7 +460,30 @@ fn resolve_grant_subject(
             act: None,
         }),
     };
-    (ctx, principals)
+    ResolvedGrantSubject {
+        subject: ctx,
+        // The delegator (authority source), recorded on the grant audit record
+        // as `on_behalf_of` (#680/#681). Carried separately from the met
+        // `subject` so the audit trail names both principals of a delegated
+        // decision. `None` if the delegator is unresolved (the grant already
+        // fails closed via `subject` above).
+        on_behalf_of: delegator_ctx,
+        principals,
+    }
+}
+
+/// Outcome of [`resolve_grant_subject`]: the effective (met) subject context the
+/// grant gates evaluate, the delegator context for two-principal audit
+/// attribution (#680/#681), and the principals the mint stamps on the token.
+struct ResolvedGrantSubject {
+    /// Effective context: `meet(delegator, actor)` for a delegated grant, or the
+    /// sole principal for a self-issued root grant. `None` ⇒ fail closed.
+    subject: Option<hyprstream_rpc::auth::mac::SecurityContext>,
+    /// The delegator principal, for the audit record's `on_behalf_of`. `None`
+    /// for a self-issued root grant (single principal) or an unresolved delegator.
+    on_behalf_of: Option<hyprstream_rpc::auth::mac::SecurityContext>,
+    /// The delegator/actor split the mint stamps on the token.
+    principals: TokenPrincipals,
 }
 
 /// POST /oauth/token — UCAN grant (RFC 8693 token-exchange,
@@ -536,7 +557,11 @@ pub async fn exchange_ucan_grant(
     //    principals and takes the fail-closed meet(delegator, actor); a
     //    self-issued root grant stays single-principal. `principals` carries the
     //    delegator/actor split the mint stamps onto the token.
-    let (subject_ctx, principals) = resolve_grant_subject(&grant, subject_resolver);
+    let ResolvedGrantSubject {
+        subject: subject_ctx,
+        on_behalf_of,
+        principals,
+    } = resolve_grant_subject(&grant, subject_resolver);
 
     // ── 4. Parse the requested access off the form fields ──────────────────
     // TODO(#572-object-label): wire the manifest/TE object-label resolver so
@@ -585,6 +610,7 @@ pub async fn exchange_ucan_grant(
         now,
         &request,
         subject_ctx.as_ref(),
+        on_behalf_of.as_ref(),
         true, // sender-bound: dpop_jkt is present
         sink,
     );
@@ -699,7 +725,11 @@ pub(crate) async fn exchange_ucan_grant_refresh(
     // dispatch's deny-by-default resolver until the S8 concrete resolver is
     // wired (TODO(#572-verifier)/#574) — refresh must not be more permissive
     // than mint.
-    let (subject_ctx, principals) = resolve_grant_subject(&grant, &DenyUnlabeledResolver);
+    let ResolvedGrantSubject {
+        subject: subject_ctx,
+        on_behalf_of,
+        principals,
+    } = resolve_grant_subject(&grant, &DenyUnlabeledResolver);
 
     // The verifier: same trust-store-anchored construction as mint. Absent ⇒
     // fail closed (no unverified chain).
@@ -727,6 +757,7 @@ pub(crate) async fn exchange_ucan_grant_refresh(
         now,
         &request,
         subject_ctx.as_ref(),
+        on_behalf_of.as_ref(),
         true, // sender-bound: a fresh DPoP proof was just verified above
         sink,
     );
@@ -1175,8 +1206,16 @@ mod tests {
             ctx(Level::Secret, &[0], VerifiedKeyMaterial::PqHybrid),
         )]));
 
-        let (context, principals) = resolve_grant_subject(&grant, &resolver);
+        let ResolvedGrantSubject {
+            subject: context,
+            on_behalf_of,
+            principals,
+        } = resolve_grant_subject(&grant, &resolver);
         assert!(principals.act.is_none(), "root grant has no actor");
+        assert!(
+            on_behalf_of.is_none(),
+            "a single-principal grant records no delegator (audit on_behalf_of = None)"
+        );
         assert_eq!(principals.sub, subject_did);
         assert_eq!(context.map(|c| c.level()), Some(Level::Secret));
     }
@@ -1205,7 +1244,11 @@ mod tests {
             ),
         ]));
 
-        let (context, principals) = resolve_grant_subject(&grant, &resolver);
+        let ResolvedGrantSubject {
+            subject: context,
+            on_behalf_of,
+            principals,
+        } = resolve_grant_subject(&grant, &resolver);
         assert_eq!(principals.sub, user_did, "sub is the delegator");
         let act = principals.act.expect("delegation carries an actor");
         assert_eq!(act.sub, mcp_did, "act is the actor");
@@ -1213,6 +1256,17 @@ mod tests {
         let context = context.expect("both principals resolved ⇒ Some");
         assert_eq!(context.level(), Level::Confidential, "min level");
         assert_eq!(context.compartments(), comps(&[1]), "compartment intersection");
+        // The audit `on_behalf_of` carries the DELEGATOR (the user's own
+        // clearance), distinct from the met `subject` context above — this is
+        // the two-principal attribution (#445/#681): the met context is what the
+        // gates saw, the delegator is who the actor acted for.
+        let obo = on_behalf_of.expect("a delegated grant records its delegator");
+        assert_eq!(obo.level(), Level::Secret, "on_behalf_of is the delegator's own level");
+        assert_eq!(
+            obo.compartments(),
+            comps(&[0, 1]),
+            "on_behalf_of is the delegator's own compartments, not the meet"
+        );
     }
 
     /// The delegated derivation fails closed if EITHER principal is unresolved
@@ -1229,7 +1283,11 @@ mod tests {
             ctx(Level::Secret, &[0], VerifiedKeyMaterial::PqHybrid),
         )]));
 
-        let (context, principals) = resolve_grant_subject(&grant, &resolver);
+        let ResolvedGrantSubject {
+            subject: context,
+            on_behalf_of,
+            principals,
+        } = resolve_grant_subject(&grant, &resolver);
         assert!(
             context.is_none(),
             "missing actor clearance ⇒ deny (no default clearance)"
@@ -1237,6 +1295,9 @@ mod tests {
         // The principal split is still reported (the actor clearance is None),
         // but the None context makes evaluate_grant deny before any mint.
         assert!(principals.act.is_some());
+        // The delegator resolved, so it is still available for audit even though
+        // the decision itself fails closed on the unresolved actor.
+        assert!(on_behalf_of.is_some(), "the resolved delegator is still recorded");
     }
 
     /// Multi-hop delegation roots the delegator at the CHAIN ROOT issuer, not
@@ -1251,7 +1312,13 @@ mod tests {
 
         // No clearances resolved — we only assert the principal identities.
         let resolver = MapResolver(HashMap::new());
-        let (_ctx, principals) = resolve_grant_subject(&leaf, &resolver);
+        let ResolvedGrantSubject {
+            on_behalf_of, principals, ..
+        } = resolve_grant_subject(&leaf, &resolver);
+        assert!(
+            on_behalf_of.is_none(),
+            "no clearance resolved ⇒ no delegator context (fails closed on subject anyway)"
+        );
         assert_eq!(
             principals.sub,
             user.as_str(),


### PR DESCRIPTION
## What

Completes the **#681 remainder** on top of the two-principal delegation derivation (#696): a delegated MAC decision now records **both** principals on the tamper-evident audit record.

Closes the #445 attribution gap — a confused-deputy call was previously logged only as the **actor** (`service:mcp`), never the **user** it acted for.

Stacked on `mac/delegation-680-681` (#696). Review that first.

## Schema (`AuditRecord`)

- New `on_behalf_of: Option<DelegationPrincipal>` — the **delegator** (authority source) on a delegated decision; `None` for a single-principal one.
- `DelegationPrincipal` carries `(TE type, clearance)` — the same grain as the record's `subject_*`, never a caller-asserted string.
- **Versioned by omission:** `#[serde(skip_serializing_if = "Option::is_none")]`. A single-principal record's canonical bytes — and therefore its content hash and its successor's `prev_hash` link — are **byte-identical** to the pre-delegation schema. The hash chain is preserved across the upgrade (unit-tested).

## The one reviewable semantics decision

`subject_clearance` stays the **effective `meet(delegator, actor)` clearance the PDP evaluated** — I did *not* change it to the raw actor clearance. Rationale:

- Audit truth: the record must name the clearance the decision actually rested on.
- The meet clamps assurance to the **actor's** verified signer key (#548/#681), so the actor's contribution — including the #548 clamp-down — is auditable **directly** on `subject_*`. (A delegated token asserting `PqHybrid` still records the actor's `Classical` assurance.)
- `on_behalf_of` adds the missing half: the delegator = the user attribution (#445).

Both source principals are recoverable, and the record still names the exact clearance the decision used. If you'd prefer the literal "`subject` = raw actor, `on_behalf_of` = delegator, meet reconstructed" framing, it's a one-field swap — flagging it as the decision to confirm.

## Plumbing (both delegation surfaces)

- **S6 grant path** (`mac::exchange`): `audited_evaluate_grant` / `_refresh` / `audit_grant_outcome` take `on_behalf_of: Option<&SecurityContext>` and stamp it. `token_exchange::resolve_grant_subject` now returns the delegator context (`ResolvedGrantSubject`), so both the **mint** and **refresh** paths record it.
- **Per-op PEP path** (`AuditedAvc`): new `decide_delegated` / `decide_delegated_with_token` inherent methods take the delegator and stamp it. Kept **off** the `Avc` trait so the hot-path cache key stays `(subject, object, action)` — delegation is an audit-attribution concern, not a decision input, and the delegator can never re-widen the met decision.

## Still dormant (unchanged)

Production resolver is still `DenyUnlabeledResolver`, so a delegated grant fails closed before minting; the per-op PEP has no wired caller yet. This PR lands the **schema + both plumbing paths** correctly and observably — what #445 attribution and downstream two-principal enforcement need. Activation stays gated on #698 (clearance provenance) and S2/#568 (PEP).

## Tests

- `on_behalf_of=None` omitted from canonical bytes (hash back-compat); `=Some` moves the hash (tamper-evident).
- delegated grant records the delegator's own clearance, **distinct** from the met subject clearance; single-principal grant records `None`.
- `decide_delegated` decides on the met subject alone yet records the delegator; plain `decide` records `None`.
- `resolve_grant_subject` returns the delegator for a delegated grant, `None` for a self-issued root or an unresolved delegator.

All 99 `mac::` unit tests + 11 `token_exchange` tests pass; `cargo clippy --workspace --all-targets --release -D warnings` clean.

Refs #547, #681, #680, #445
