### PR TITLE
feat(9p): serve a Subject-scoped Mount over a UDS 9P listener (#506)

### DIFF
--- a/crates/hyprstream-9p/examples/serve_mount_uds.rs
+++ b/crates/hyprstream-9p/examples/serve_mount_uds.rs
@@ -1,0 +1,48 @@
+//! Standalone 9P-over-UDS server used to prove interop with a real 9P2000.L
+//! client (Wanix `p9kit.ClientFS`, i.e. the `progrium/p9` fork).
+//!
+//! Usage: `serve_mount_uds <socket-path>` — binds a `UnixListener` at the given
+//! path and serves a small `SyntheticMount` (two files + a subdir with one file)
+//! as its 9P root, forever. Kill with SIGINT/SIGTERM.
+//!
+//! This is a harness, not shipped functionality — it exercises `from_mount` /
+//! `serve_mount_uds` exactly as #506's supervisor entry point does.
+
+use std::sync::Arc;
+
+use hyprstream_9p::translator::serve_mount_uds;
+use hyprstream_rpc::Subject;
+use hyprstream_vfs::{Mount, SyntheticMount, SyntheticNode};
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    let path = std::env::args()
+        .nth(1)
+        .expect("usage: serve_mount_uds <socket-path>");
+    let _ = std::fs::remove_file(&path);
+
+    // root/
+    //   greeting.txt
+    //   notes.md
+    //   subdir/
+    //     inner.txt
+    let root = SyntheticNode::dir()
+        .with_child(
+            "greeting.txt",
+            SyntheticNode::file(b"hello from hyprstream 9p\n".to_vec()),
+        )
+        .with_child("notes.md", SyntheticNode::file(b"# notes\n".to_vec()))
+        .with_child(
+            "subdir",
+            SyntheticNode::dir().with_child(
+                "inner.txt",
+                SyntheticNode::file(b"inner file contents\n".to_vec()),
+            ),
+        );
+
+    let mount: Arc<dyn Mount> = Arc::new(SyntheticMount::new(root));
+    let subject = Subject::new("tenant-a");
+
+    eprintln!("serving 9P mount at {path}");
+    serve_mount_uds(mount, subject, &path).await
+}

--- a/crates/hyprstream-9p/src/lib.rs
+++ b/crates/hyprstream-9p/src/lib.rs
@@ -22,11 +22,15 @@ pub mod msg;
 pub mod client;
 pub mod backend;
 pub mod memory;
-// The translator is the server-side TCP accept loop (tokio::net). `net` pulls
-// `mio`, which has no wasm32 backend, so the whole module is native-only. The
-// browser/wasm build reaches the backend through the DMA/Wanix client path.
+// The translator is the server-side TCP/UDS accept loop (tokio::net). `net`
+// pulls `mio`, which has no wasm32 backend, so these modules are native-only.
+// The browser/wasm build reaches the backend through the DMA/Wanix client path.
 #[cfg(not(target_arch = "wasm32"))]
 pub mod translator;
+// `MountBackend` bridges a VFS `Mount` (+ `Subject`) to the `Backend` seam so
+// the translator can export it over TCP/UDS. Native-only (drives async Mount ops).
+#[cfg(not(target_arch = "wasm32"))]
+pub mod mount_backend;
 
 #[cfg(target_arch = "wasm32")]
 pub mod dma;
@@ -35,4 +39,6 @@ pub mod wanix_mount;
 
 pub use backend::{Backend, OpenResult, StatResult, WalkResult};
 #[cfg(not(target_arch = "wasm32"))]
-pub use translator::{FidTable, Translator};
+pub use mount_backend::MountBackend;
+#[cfg(not(target_arch = "wasm32"))]
+pub use translator::{serve_mount_uds, FidTable, Translator};

--- a/crates/hyprstream-9p/src/memory.rs
+++ b/crates/hyprstream-9p/src/memory.rs
@@ -106,21 +106,20 @@ impl Backend for MemoryBackend {
             .get(&fid)
             .ok_or_else(|| anyhow::anyhow!("unknown fid {fid}"))?;
         if link.is_dir {
-            // Directory read: synthesize a 9P readdir record per top-level file.
+            // Directory read: emit standard 9P2000.L Rreaddir dirent records
+            // (`qid[13] offset[8] type[1] name[s]`) — the same wire format the
+            // Mount export path and any standard client (incl. this crate's own
+            // `client.rs`, which parses via `parse_readdir_entries`) expect.
             let files = self.files.lock();
-            let mut out = Vec::new();
-            for (name, entry) in files.iter() {
-                out.extend_from_slice(&(name.len() as u32).to_le_bytes());
-                out.extend_from_slice(name.as_bytes());
-                out.push(0); // not dir
-                out.extend_from_slice(&(entry.bytes.len() as u64).to_le_bytes());
-            }
-            let off = offset as usize;
-            if off >= out.len() {
-                return Ok(Vec::new());
-            }
-            let end = (off + count as usize).min(out.len());
-            return Ok(out[off..end].to_vec());
+            let records: Vec<crate::msg::ReaddirEntry> = files
+                .iter()
+                .map(|(name, entry)| crate::msg::ReaddirEntry {
+                    qid: entry.qid.clone(),
+                    name: name.clone(),
+                })
+                .collect();
+            drop(files);
+            return Ok(crate::msg::encode_readdir_page(&records, offset, count));
         }
         let path = link.path.clone().unwrap_or_default();
         let files = self.files.lock();

--- a/crates/hyprstream-9p/src/mount_backend.rs
+++ b/crates/hyprstream-9p/src/mount_backend.rs
@@ -1,0 +1,266 @@
+//! `MountBackend` — a [`Backend`] that exports an in-process VFS [`Mount`].
+//!
+//! This is the server-side adapter used by the UDS 9P listener (#506). It is
+//! the local-mount counterpart to the `hyprstream` crate's capnp-RPC
+//! `ModelBackend`: both implement the same [`Backend`] seam the [`Translator`]
+//! dispatches to, so the accept/serve/fid-table machinery is shared verbatim —
+//! only the object behind the `Backend` differs.
+//!
+//! ```text
+//!   Wanix (p9kit.ClientFS) ──► UnixListener ──► Translator ──► MountBackend ──► dyn Mount
+//!         9P2000.L wire            UDS            fid table      Subject-scoped     policy PEP
+//! ```
+//!
+//! ## Subject threading (MAC-load-bearing)
+//!
+//! Every [`Mount`] method takes the verified caller [`Subject`]. The listener
+//! serves exactly one tenant's export, so the `Subject` is fixed at construction
+//! and threaded onto every op; the served mount remains the single policy
+//! enforcement point. There is no path by which a 9P op reaches the mount without
+//! the tenant's `Subject`.
+//!
+//! ## Fid mapping
+//!
+//! The translator allocates opaque `u32` 9P fids; a [`Mount`] hands back opaque
+//! [`Fid`] handles from `walk`. `MountBackend` owns the `u32 → (path, Fid)`
+//! mapping. Because a [`Mount::walk`] resolves a path from the mount root (not
+//! relative to a source fid), each fid also remembers its absolute path so a
+//! subsequent relative walk can re-resolve `parent_path + components`.
+
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use dashmap::DashMap;
+use hyprstream_rpc::Subject;
+use hyprstream_vfs::{DirEntry, Fid, Mount};
+use tokio::sync::Mutex;
+
+use crate::backend::{Backend, OpenResult, StatResult, WalkResult};
+use crate::msg::Qid;
+
+/// Max bytes a single read/write returns. Kept below the translator's `MSG_SIZE`
+/// (8 KiB) so an `Rread` carrying a full iounit plus its 9P header still fits the
+/// negotiated msize.
+const IOUNIT: u32 = 8 * 1024 - 64;
+
+/// 9P qtype bit for a directory (`QTDIR`).
+const QTDIR: u8 = 0x80;
+
+/// Per-fid state: the absolute path it resolves to plus the live mount handle.
+///
+/// The handle lives behind an async `Mutex` so a mount op can be awaited without
+/// holding a `DashMap` shard guard. `Option` because `clunk` takes ownership of
+/// the [`Fid`] to hand back to the mount.
+struct MountFidEntry {
+    path: Vec<String>,
+    handle: Mutex<Option<Fid>>,
+}
+
+/// A [`Backend`] backed by a single Subject-scoped VFS [`Mount`].
+pub struct MountBackend {
+    mount: Arc<dyn Mount>,
+    subject: Subject,
+    fids: DashMap<u32, Arc<MountFidEntry>>,
+}
+
+impl MountBackend {
+    /// Wrap `mount` as the 9P export root for `subject`.
+    pub fn new(mount: Arc<dyn Mount>, subject: Subject) -> Self {
+        Self { mount, subject, fids: DashMap::new() }
+    }
+
+    /// Clone out the `Arc` for a fid, dropping the `DashMap` guard so the mount
+    /// call can await without holding a shard lock.
+    fn entry(&self, fid: u32) -> Result<Arc<MountFidEntry>> {
+        self.fids
+            .get(&fid)
+            .map(|e| Arc::clone(&e))
+            .ok_or_else(|| anyhow!("fid {fid} not walked"))
+    }
+
+    /// Build the leaf [`Qid`] for a mount handle by stat-ing it.
+    async fn qid_of(&self, handle: &Fid) -> Result<Qid> {
+        let st = self
+            .mount
+            .stat(handle, &self.subject)
+            .await
+            .map_err(|e| anyhow!("mount stat failed: {e}"))?;
+        Ok(Qid { qtype: st.qtype, version: st.version, path: st.path })
+    }
+}
+
+#[async_trait]
+impl Backend for MountBackend {
+    async fn walk(
+        &self,
+        fid: u32,
+        newfid: u32,
+        components: &[String],
+    ) -> Result<WalkResult> {
+        // A Mount walk resolves from the root, so build the target's absolute
+        // path as parent_path + components. An empty-components walk (attach /
+        // clone) re-resolves the source fid's own path.
+        let parent_path = self.fids.get(&fid).map(|e| e.path.clone()).unwrap_or_default();
+        let mut new_path = parent_path;
+        new_path.extend(components.iter().cloned());
+
+        let refs: Vec<&str> = new_path.iter().map(String::as_str).collect();
+        let handle = self
+            .mount
+            .walk(&refs, &self.subject)
+            .await
+            .map_err(|e| anyhow!("mount walk failed: {e}"))?;
+
+        // Mirror `ModelBackend::walk`: return the single leaf qid (the translator
+        // records its qtype for the new fid; clients here walk one hop at a time).
+        let qid = self.qid_of(&handle).await?;
+        self.fids.insert(
+            newfid,
+            Arc::new(MountFidEntry { path: new_path, handle: Mutex::new(Some(handle)) }),
+        );
+        Ok(WalkResult { qids: vec![qid] })
+    }
+
+    async fn open(&self, fid: u32, flags: u32) -> Result<OpenResult> {
+        let entry = self.entry(fid)?;
+        let mut guard = entry.handle.lock().await;
+        let handle = guard.as_mut().ok_or_else(|| anyhow!("open: fid {fid} is clunked"))?;
+        let mode = lopen_flags_to_mode(flags);
+        self.mount
+            .open(handle, mode, &self.subject)
+            .await
+            .map_err(|e| anyhow!("mount open failed: {e}"))?;
+        let qid = self.qid_of(handle).await?;
+        Ok(OpenResult { qid, iounit: IOUNIT })
+    }
+
+    async fn read(&self, fid: u32, offset: u64, count: u32) -> Result<Vec<u8>> {
+        let entry = self.entry(fid)?;
+        let guard = entry.handle.lock().await;
+        let handle = guard.as_ref().ok_or_else(|| anyhow!("read: fid {fid} is clunked"))?;
+        self.mount
+            .read(handle, offset, count, &self.subject)
+            .await
+            .map_err(|e| anyhow!("mount read failed: {e}"))
+    }
+
+    async fn write(&self, fid: u32, offset: u64, data: &[u8]) -> Result<u32> {
+        let entry = self.entry(fid)?;
+        let guard = entry.handle.lock().await;
+        let handle = guard.as_ref().ok_or_else(|| anyhow!("write: fid {fid} is clunked"))?;
+        self.mount
+            .write(handle, offset, data, &self.subject)
+            .await
+            .map_err(|e| anyhow!("mount write failed: {e}"))
+    }
+
+    async fn stat(&self, fid: u32) -> Result<StatResult> {
+        let entry = self.entry(fid)?;
+        let guard = entry.handle.lock().await;
+        let handle = guard.as_ref().ok_or_else(|| anyhow!("stat: fid {fid} is clunked"))?;
+        let st = self
+            .mount
+            .stat(handle, &self.subject)
+            .await
+            .map_err(|e| anyhow!("mount stat failed: {e}"))?;
+        let is_dir = st.qtype & QTDIR != 0;
+        let mode = if is_dir { 0o040755 } else { 0o100644 };
+        Ok(StatResult {
+            qid: Qid { qtype: st.qtype, version: st.version, path: st.path },
+            mode,
+            size: st.size,
+            mtime_sec: st.mtime,
+        })
+    }
+
+    async fn readdir(&self, fid: u32, offset: u64, count: u32) -> Result<Vec<u8>> {
+        let entry = self.entry(fid)?;
+        let entries = {
+            let guard = entry.handle.lock().await;
+            let handle = guard.as_ref().ok_or_else(|| anyhow!("readdir: fid {fid} is clunked"))?;
+            self.mount
+                .readdir(handle, &self.subject)
+                .await
+                .map_err(|e| anyhow!("mount readdir failed: {e}"))?
+        };
+        Ok(encode_dir_entries(&entries, offset, count))
+    }
+
+    async fn clunk(&self, fid: u32) -> Result<()> {
+        // Drop local state and hand the mount handle back for release.
+        if let Some((_, entry)) = self.fids.remove(&fid) {
+            let handle = entry.handle.lock().await.take();
+            if let Some(handle) = handle {
+                self.mount.clunk(handle, &self.subject).await;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Encode directory entries in the length-prefixed wire format the translator
+/// passes through verbatim (matching `MemoryBackend`/the model service):
+/// `name_len: u32` · `name` · `is_dir: u8` · `size: u64`, all little-endian.
+///
+/// `offset`/`count` slice the encoded buffer so a client can page through a
+/// large directory across multiple reads.
+fn encode_dir_entries(entries: &[DirEntry], offset: u64, count: u32) -> Vec<u8> {
+    let mut buf = Vec::new();
+    for e in entries {
+        let name = e.name.as_bytes();
+        buf.extend_from_slice(&(name.len() as u32).to_le_bytes());
+        buf.extend_from_slice(name);
+        buf.push(u8::from(e.is_dir));
+        buf.extend_from_slice(&e.size.to_le_bytes());
+    }
+    let off = offset as usize;
+    if off >= buf.len() {
+        return Vec::new();
+    }
+    let end = (off + count as usize).min(buf.len());
+    buf[off..end].to_vec()
+}
+
+/// Map 9P2000.L `Tlopen` flags (Linux `O_*` bits) to a 9P open-mode byte
+/// (`OREAD=0` / `OWRITE=1` / `ORDWR=2`). Only read/write intent is preserved;
+/// `O_CREAT`/`O_TRUNC`/`O_APPEND` are advisory here. Mirrors the equivalent
+/// mapping in the capnp-RPC `ModelBackend`.
+fn lopen_flags_to_mode(flags: u32) -> u8 {
+    const O_WRONLY: u32 = 0o1;
+    const O_RDWR: u32 = 0o2;
+    match flags & 0o3 {
+        O_WRONLY => 1, // OWRITE
+        O_RDWR => 2,   // ORDWR
+        _ => 0,        // OREAD
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lopen_flags_mapping() {
+        assert_eq!(lopen_flags_to_mode(0), 0);
+        assert_eq!(lopen_flags_to_mode(0o1), 1);
+        assert_eq!(lopen_flags_to_mode(0o2), 2);
+        assert_eq!(lopen_flags_to_mode(0o101), 1);
+    }
+
+    #[test]
+    fn encode_dir_entries_slices_by_offset() {
+        let entries = vec![
+            DirEntry { name: "a".into(), is_dir: true, size: 0, stat: None },
+            DirEntry { name: "bb".into(), is_dir: false, size: 7, stat: None },
+        ];
+        let full = encode_dir_entries(&entries, 0, u32::MAX);
+        assert!(!full.is_empty());
+        // First entry: len(4) + "a"(1) + is_dir(1) + size(8) = 14 bytes.
+        assert_eq!(&full[0..4], &1u32.to_le_bytes());
+        assert_eq!(full[4], b'a');
+        assert_eq!(full[5], 1); // is_dir
+        // Paging: an offset past the end yields nothing.
+        assert!(encode_dir_entries(&entries, full.len() as u64, 16).is_empty());
+    }
+}

--- a/crates/hyprstream-9p/src/mount_backend.rs
+++ b/crates/hyprstream-9p/src/mount_backend.rs
@@ -37,7 +37,7 @@ use hyprstream_vfs::{DirEntry, Fid, Mount};
 use tokio::sync::Mutex;
 
 use crate::backend::{Backend, OpenResult, StatResult, WalkResult};
-use crate::msg::Qid;
+use crate::msg::{self, Qid, ReaddirEntry};
 
 /// Max bytes a single read/write returns. Kept below the translator's `MSG_SIZE`
 /// (8 KiB) so an `Rread` carrying a full iounit plus its 9P header still fits the
@@ -199,27 +199,31 @@ impl Backend for MountBackend {
     }
 }
 
-/// Encode directory entries in the length-prefixed wire format the translator
-/// passes through verbatim (matching `MemoryBackend`/the model service):
-/// `name_len: u32` · `name` · `is_dir: u8` · `size: u64`, all little-endian.
+/// Encode directory entries as a page of **standard 9P2000.L Rreaddir dirent
+/// records** (`qid[13] · offset[8] · type[1] · name[s]`) via
+/// [`msg::encode_readdir_page`].
 ///
-/// `offset`/`count` slice the encoded buffer so a client can page through a
-/// large directory across multiple reads.
+/// This is the wire-faithful format a standard 9P client (Wanix `p9kit` over
+/// `progrium/p9`) requires — not the hyprstream-internal
+/// `name_len/name/is_dir/size` dialect. `offset` is a dirent cookie and `count`
+/// a byte budget; records are packed whole (see `encode_readdir_page`).
+///
+/// Per-entry qid: a `DirEntry` may carry a `stat` with a real qid; when it does
+/// we use it, otherwise we synthesize the qtype from `is_dir` with an unknown
+/// (`version=0, path=0`) identity — sound per `Stat`'s qid invariant, and
+/// sufficient because standard clients re-walk each name to stat it.
 fn encode_dir_entries(entries: &[DirEntry], offset: u64, count: u32) -> Vec<u8> {
-    let mut buf = Vec::new();
-    for e in entries {
-        let name = e.name.as_bytes();
-        buf.extend_from_slice(&(name.len() as u32).to_le_bytes());
-        buf.extend_from_slice(name);
-        buf.push(u8::from(e.is_dir));
-        buf.extend_from_slice(&e.size.to_le_bytes());
-    }
-    let off = offset as usize;
-    if off >= buf.len() {
-        return Vec::new();
-    }
-    let end = (off + count as usize).min(buf.len());
-    buf[off..end].to_vec()
+    let records: Vec<ReaddirEntry> = entries
+        .iter()
+        .map(|e| {
+            let qid = match &e.stat {
+                Some(st) => Qid { qtype: st.qtype, version: st.version, path: st.path },
+                None => Qid { qtype: if e.is_dir { QTDIR } else { 0 }, version: 0, path: 0 },
+            };
+            ReaddirEntry { qid, name: e.name.clone() }
+        })
+        .collect();
+    msg::encode_readdir_page(&records, offset, count)
 }
 
 /// Map 9P2000.L `Tlopen` flags (Linux `O_*` bits) to a 9P open-mode byte
@@ -249,18 +253,40 @@ mod tests {
     }
 
     #[test]
-    fn encode_dir_entries_slices_by_offset() {
+    fn encode_dir_entries_emits_standard_rreaddir_records() {
+        use crate::msg::parse_readdir_entries;
+
         let entries = vec![
             DirEntry { name: "a".into(), is_dir: true, size: 0, stat: None },
             DirEntry { name: "bb".into(), is_dir: false, size: 7, stat: None },
         ];
         let full = encode_dir_entries(&entries, 0, u32::MAX);
         assert!(!full.is_empty());
-        // First entry: len(4) + "a"(1) + is_dir(1) + size(8) = 14 bytes.
-        assert_eq!(&full[0..4], &1u32.to_le_bytes());
-        assert_eq!(full[4], b'a');
-        assert_eq!(full[5], 1); // is_dir
-        // Paging: an offset past the end yields nothing.
-        assert!(encode_dir_entries(&entries, full.len() as u64, 16).is_empty());
+
+        // Standard record layout: qid[13] · offset[8] · type[1] · name[2+len].
+        // First entry "a" (a dir): qid.qtype = QTDIR at byte 0, dirent type at
+        // byte 21 also QTDIR, name length u16=1 at bytes 22..24, 'a' at 24.
+        assert_eq!(full[0], QTDIR); // qid.qtype
+        assert_eq!(&full[13..21], &1u64.to_le_bytes()); // offset cookie = 1
+        assert_eq!(full[21], QTDIR); // dirent type = dir
+        assert_eq!(&full[22..24], &1u16.to_le_bytes()); // name len
+        assert_eq!(full[24], b'a');
+
+        // Round-trips through the standard client-side parser.
+        let parsed = parse_readdir_entries(&full).unwrap();
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].name, "a");
+        assert!(parsed[0].qid.is_dir());
+        assert_eq!(parsed[0].offset, 1);
+        assert_eq!(parsed[1].name, "bb");
+        assert!(!parsed[1].qid.is_dir());
+        assert_eq!(parsed[1].offset, 2);
+
+        // Cookie paging: offset past the last cookie yields nothing.
+        assert!(encode_dir_entries(&entries, 2, u32::MAX).is_empty());
+        // Resuming after cookie 1 yields only the second entry.
+        let rest = parse_readdir_entries(&encode_dir_entries(&entries, 1, u32::MAX)).unwrap();
+        assert_eq!(rest.len(), 1);
+        assert_eq!(rest[0].name, "bb");
     }
 }

--- a/crates/hyprstream-9p/src/msg.rs
+++ b/crates/hyprstream-9p/src/msg.rs
@@ -338,7 +338,12 @@ pub fn encode_response(tag: u16, response: &Response) -> Vec<u8> {
         Response::Getattr { qid, mode, size, mtime_sec } => {
             rgetattr(tag, qid, *mode, *size, *mtime_sec)
         }
-        Response::Readdir { data } => rread(tag, data), // same wire shape as Rread
+        // Rreaddir shares Rread's `count[4] · data[count]` body shape but MUST
+        // carry the RREADDIR (41) message type — a standard 9P2000.L client
+        // (e.g. Wanix `p9kit.ClientFS` over `progrium/p9`) rejects an Rread (117)
+        // reply to a Treaddir. `data` is already a run of standard dirent records
+        // (`qid[13] offset[8] type[1] name[s]`); see [`encode_readdir_page`].
+        Response::Readdir { data } => rreaddir(tag, data),
     }
 }
 
@@ -385,6 +390,16 @@ pub fn rread(tag: u16, data: &[u8]) -> Vec<u8> {
     body.extend_from_slice(&(data.len() as u32).to_le_bytes());
     body.extend_from_slice(data);
     encode_rmessage(tag, RREAD, &body)
+}
+
+/// Encode an Rreaddir. Body is `count[4] · data[count]` (identical framing to
+/// [`rread`]) but the message type is RREADDIR (41). `data` must already be a
+/// packed run of standard dirent records — build it with [`encode_readdir_page`].
+pub fn rreaddir(tag: u16, data: &[u8]) -> Vec<u8> {
+    let mut body = Vec::new();
+    body.extend_from_slice(&(data.len() as u32).to_le_bytes());
+    body.extend_from_slice(data);
+    encode_rmessage(tag, RREADDIR, &body)
 }
 
 pub fn rwrite(tag: u16, count: u32) -> Vec<u8> {
@@ -541,6 +556,57 @@ pub struct DirEntryP9 {
     pub offset: u64,
     pub dtype: u8,
     pub name: String,
+}
+
+/// One directory entry to encode into an Rreaddir payload.
+///
+/// The inverse of [`DirEntryP9`]: the server builds these, the client parses
+/// the resulting bytes back into `DirEntryP9`s. `qid` carries the entry's
+/// identity (its `qtype` also supplies the dirent type byte); `name` is the
+/// single path component.
+#[derive(Debug, Clone)]
+pub struct ReaddirEntry {
+    pub qid: Qid,
+    pub name: String,
+}
+
+/// Encode a directory listing as a page of **standard 9P2000.L Rreaddir dirent
+/// records** with cookie-based paging.
+///
+/// Each record is `qid[13] · offset[8] · type[1] · name[s]` — the exact shape
+/// [`parse_readdir_entries`] (and any standard client such as `progrium/p9`)
+/// decodes. `entries` is the *full* listing in a stable order; the record's
+/// `offset` is a resumption cookie equal to the entry's 1-based index.
+///
+/// Paging contract (as required by 9P2000.L, distinct from a byte-offset read):
+/// - `offset` is a dirent cookie — only entries whose cookie is `> offset` are
+///   emitted (so a client resumes by passing back the last cookie it saw).
+/// - `count` is a byte budget — records are packed **whole** (never split) until
+///   the next record would exceed it. A single record larger than `count` is
+///   still emitted alone so the client can always make progress.
+///
+/// The dirent `type` byte is the entry's qid type (`QTDIR`=0x80 / `QTFILE`=0x00);
+/// `progrium/p9` reads it as a `QIDType`, and Wanix's `p9kit` re-walks each name
+/// anyway, so this is the interoperable choice.
+pub fn encode_readdir_page(entries: &[ReaddirEntry], offset: u64, count: u32) -> Vec<u8> {
+    let budget = count as usize;
+    let mut out = Vec::new();
+    for (i, e) in entries.iter().enumerate() {
+        let cookie = i as u64 + 1;
+        if cookie <= offset {
+            continue;
+        }
+        let mut rec = Vec::new();
+        e.qid.write_to(&mut rec); // qid[13]
+        rec.extend_from_slice(&cookie.to_le_bytes()); // offset[8]
+        rec.push(e.qid.qtype); // type[1] — dirent type = qid type
+        write_string(&mut rec, &e.name); // name[2+len]
+        if !out.is_empty() && out.len() + rec.len() > budget {
+            break;
+        }
+        out.extend_from_slice(&rec);
+    }
+    out
 }
 
 /// Parse Rreaddir data into directory entries.

--- a/crates/hyprstream-9p/src/translator.rs
+++ b/crates/hyprstream-9p/src/translator.rs
@@ -14,20 +14,30 @@
 //!
 //! ## Transport
 //!
-//! [`Translator::serve`] runs a TCP accept loop. Each connection is served on
-//! its own tokio task via [`serve_connection`]. virtio-9P will plug in here
-//! later with a different transport that shares the same per-connection
-//! `handle_message` core.
+//! [`Translator::serve`] runs a TCP accept loop; [`Translator::serve_uds`] runs
+//! the same loop over a Unix domain socket ([`tokio::net::UnixListener`]). Both
+//! delegate to one transport-agnostic accept loop (`serve_listener`) and the
+//! same per-connection [`Translator::serve_connection`] core, which operates on
+//! any `AsyncRead + AsyncWrite` stream. The UDS entry point is how a native
+//! Wanix workload consumes a Subject-scoped export via its `p9kit.ClientFS` 9P
+//! client (#506); [`Translator::from_mount`] / [`serve_mount_uds`] build the
+//! translator directly from an `Arc<dyn Mount>` + `Subject`. virtio-9P will plug
+//! in the same way with a third transport.
 
+use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
+use async_trait::async_trait;
 use dashmap::DashMap;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::{TcpListener, TcpStream};
+use hyprstream_rpc::Subject;
+use hyprstream_vfs::Mount;
+use tokio::io::{split, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream, UnixListener, UnixStream};
 use tracing::{debug, error, info, warn};
 
 use crate::backend::Backend;
+use crate::mount_backend::MountBackend;
 use crate::msg::{
     self, encode_response, parse_request, rflush, Request, Response,
 };
@@ -91,15 +101,45 @@ impl Translator {
         Self { backend, fids: Arc::new(FidTable::default()) }
     }
 
+    /// Build a translator that exports a single Subject-scoped VFS [`Mount`] as
+    /// its 9P root.
+    ///
+    /// This is the entry point for #506: `mount` is the tenant's export root
+    /// (already the single MAC policy-enforcement point) and `subject` is the
+    /// verified caller identity threaded onto every backend op. It wraps the
+    /// mount in a [`MountBackend`] — the same [`Backend`] seam the capnp-RPC
+    /// `ModelBackend` uses on the TCP path — so no new attachment mechanism is
+    /// introduced; only the export root differs.
+    pub fn from_mount(mount: Arc<dyn Mount>, subject: Subject) -> Self {
+        Self::new(Arc::new(MountBackend::new(mount, subject)))
+    }
+
     /// Run a TCP accept loop until the listener errors or is closed.
     ///
     /// Each connection runs on its own task. Errors on one connection do not
     /// affect siblings.
     pub async fn serve(self, listener: TcpListener) -> Result<()> {
+        self.serve_listener(listener).await
+    }
+
+    /// Run the accept loop over a Unix domain socket.
+    ///
+    /// Identical per-connection handling to [`Translator::serve`]; only the
+    /// transport differs. This is how a native Wanix workload attaches to a
+    /// Subject-scoped export over a UDS via its `p9kit.ClientFS` 9P client.
+    pub async fn serve_uds(self, listener: UnixListener) -> Result<()> {
+        self.serve_listener(listener).await
+    }
+
+    /// Transport-agnostic accept loop shared by [`serve`](Self::serve) and
+    /// [`serve_uds`](Self::serve_uds). Each accepted connection is served on its
+    /// own task via [`serve_connection`](Self::serve_connection); errors on one
+    /// connection do not affect siblings.
+    async fn serve_listener<L: Listen>(self, listener: L) -> Result<()> {
         let this = Arc::new(self);
-        info!(addr = ?listener.local_addr(), "9P translator: listening");
+        info!(endpoint = %listener.describe(), "9P translator: listening");
         loop {
-            let (stream, peer) = match listener.accept().await {
+            let (stream, peer) = match listener.accept_conn().await {
                 Ok(v) => v,
                 Err(e) => {
                     error!(error = %e, "9P translator: accept failed, shutting down");
@@ -118,8 +158,14 @@ impl Translator {
 
     /// Serve a single connection to completion (until EOF, parse error, or
     /// the peer resets).
-    pub async fn serve_connection(self: &Arc<Self>, stream: TcpStream) -> Result<()> {
-        let (mut rx, mut tx) = stream.into_split();
+    ///
+    /// Generic over the byte stream so the same core serves TCP, UDS, and any
+    /// future `AsyncRead + AsyncWrite` transport.
+    pub async fn serve_connection<S>(self: &Arc<Self>, stream: S) -> Result<()>
+    where
+        S: AsyncRead + AsyncWrite + Send + 'static,
+    {
+        let (mut rx, mut tx) = split(stream);
         // Reusable growable read buffer; capped per-message by msize.
         let mut len_buf = [0u8; 4];
 
@@ -270,6 +316,73 @@ impl Translator {
     async fn handle_readdir(&self, fid: u32, offset: u64, count: u32) -> Result<Response> {
         let data = self.backend.readdir(fid, offset, count).await?;
         Ok(Response::Readdir { data })
+    }
+}
+
+/// Bind a Unix domain socket at `path` and serve `mount` (scoped to `subject`)
+/// as its 9P2000.L root until the socket errors or is closed.
+///
+/// Convenience wrapper over [`Translator::from_mount`] + [`Translator::serve_uds`]
+/// — the #506 one-call entry point a supervisor uses to expose a tenant's
+/// Subject-scoped export to a native Wanix `p9kit.ClientFS` client.
+pub async fn serve_mount_uds(
+    mount: Arc<dyn Mount>,
+    subject: Subject,
+    path: impl AsRef<Path>,
+) -> Result<()> {
+    let listener = UnixListener::bind(path.as_ref())
+        .with_context(|| format!("bind 9P UDS listener at {:?}", path.as_ref()))?;
+    Translator::from_mount(mount, subject).serve_uds(listener).await
+}
+
+/// Transport-agnostic accept surface, implemented for [`TcpListener`] and
+/// [`UnixListener`] so both share one accept loop (`serve_listener`).
+///
+/// Keeping this private and trait-bounded (rather than duplicating the loop)
+/// means TCP and UDS run byte-identical connection handling; a new transport
+/// only implements `accept_conn` + `describe`.
+#[async_trait]
+trait Listen: Send + Sync + 'static {
+    /// The per-connection byte stream this listener produces.
+    type Conn: AsyncRead + AsyncWrite + Send + 'static;
+
+    /// Accept one connection, returning the stream and a display string for the
+    /// peer (used only for tracing).
+    async fn accept_conn(&self) -> std::io::Result<(Self::Conn, String)>;
+
+    /// Human-readable endpoint description for the "listening" log line.
+    fn describe(&self) -> String;
+}
+
+#[async_trait]
+impl Listen for TcpListener {
+    type Conn = TcpStream;
+
+    async fn accept_conn(&self) -> std::io::Result<(TcpStream, String)> {
+        let (stream, peer) = self.accept().await?;
+        Ok((stream, peer.to_string()))
+    }
+
+    fn describe(&self) -> String {
+        self.local_addr()
+            .map(|a| a.to_string())
+            .unwrap_or_else(|_| "tcp:?".to_owned())
+    }
+}
+
+#[async_trait]
+impl Listen for UnixListener {
+    type Conn = UnixStream;
+
+    async fn accept_conn(&self) -> std::io::Result<(UnixStream, String)> {
+        let (stream, peer) = self.accept().await?;
+        Ok((stream, format!("unix:{peer:?}")))
+    }
+
+    fn describe(&self) -> String {
+        self.local_addr()
+            .map(|a| format!("unix:{a:?}"))
+            .unwrap_or_else(|_| "unix:?".to_owned())
     }
 }
 

--- a/crates/hyprstream-9p/src/translator.rs
+++ b/crates/hyprstream-9p/src/translator.rs
@@ -483,4 +483,39 @@ mod tests {
         let q = sample_qid(0x80, 42);
         assert!(q.is_dir());
     }
+
+    /// A Treaddir over the translator must produce a wire message typed RREADDIR
+    /// (41), whose payload decodes as standard 9P2000.L dirent records — the
+    /// exact contract a standard client (Wanix `p9kit`) enforces. Regression
+    /// guard for the interop fix (previously framed as RREAD=117).
+    #[tokio::test]
+    async fn readdir_emits_standard_rreaddir_wire() {
+        let backend = MemoryBackend::default();
+        backend.add_file("/one.txt", b"111");
+        backend.add_file("/two.txt", b"22");
+        let t = Arc::new(Translator::new(Arc::new(backend)));
+
+        // Attach fid 0 as the (directory) root, then open + readdir it.
+        t.handle_message(&msg::tattach(1, 0, u32::MAX, "u", "/")).await.unwrap();
+        t.handle_message(&msg::tlopen(2, 0, 0)).await.unwrap();
+        let (tag, resp) = t.handle_message(&msg::treaddir(3, 0, 0, 8192)).await.unwrap();
+
+        // Encode to the wire exactly as serve_connection does, and check the
+        // message-type byte is RREADDIR, not RREAD.
+        let wire = msg::encode_response(tag, &resp);
+        assert_eq!(wire[4], msg::RREADDIR, "readdir must be framed as RREADDIR (41)");
+        assert_ne!(wire[4], msg::RREAD, "readdir must NOT be framed as RREAD (117)");
+
+        // The payload must decode as standard dirent records.
+        let data = match resp {
+            Response::Readdir { data } => data,
+            other => panic!("expected Readdir, got {other:?}"),
+        };
+        let entries = msg::parse_readdir_entries(&data).unwrap();
+        let mut names: Vec<_> = entries.iter().map(|e| e.name.clone()).collect();
+        names.sort();
+        assert_eq!(names, vec!["one.txt".to_string(), "two.txt".to_string()]);
+        // Cookies are 1-based and monotonic.
+        assert!(entries.iter().all(|e| e.offset >= 1));
+    }
 }

--- a/crates/hyprstream-9p/tests/uds_translator.rs
+++ b/crates/hyprstream-9p/tests/uds_translator.rs
@@ -1,0 +1,183 @@
+//! End-to-end integration test: the translator serving a Subject-scoped VFS
+//! `Mount` as a 9P2000.L server over a Unix domain socket (#506).
+//!
+//! Binds a `UnixListener` on a temp path, exports a tiny in-test `Mount` via
+//! `Translator::from_mount(mount, subject)`, then drives it from a raw
+//! `UnixStream` using the 9P codec (version → attach → walk → lopen → read →
+//! getattr → clunk). This proves the UDS accept loop, the transport-generic
+//! `serve_connection`, and the `MountBackend` → `Mount` (Subject-threaded)
+//! bridge all work together — the path a native Wanix `p9kit.ClientFS` uses.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use hyprstream_9p::msg::{self, Response};
+use hyprstream_9p::Translator;
+use hyprstream_rpc::Subject;
+use hyprstream_vfs::{DirEntry, Fid, Mount, MountError, Stat};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{UnixListener, UnixStream};
+
+/// Opaque per-fid state for `TestMount`: the absolute path it resolves to.
+struct TestFid {
+    path: Vec<String>,
+}
+
+/// Minimal read-only `Mount` exposing a flat set of top-level files, so the
+/// test has no dependency on the binary crate's synthetic tree.
+struct TestMount {
+    files: HashMap<String, Vec<u8>>,
+}
+
+#[async_trait]
+impl Mount for TestMount {
+    async fn walk(&self, components: &[&str], _caller: &Subject) -> Result<Fid, MountError> {
+        let path: Vec<String> = components.iter().map(|s| (*s).to_owned()).collect();
+        if path.is_empty() {
+            return Ok(Fid::new(TestFid { path })); // root
+        }
+        let joined = path.join("/");
+        if self.files.contains_key(&joined) {
+            Ok(Fid::new(TestFid { path }))
+        } else {
+            Err(MountError::NotFound(joined))
+        }
+    }
+
+    async fn open(&self, _fid: &mut Fid, _mode: u8, _caller: &Subject) -> Result<(), MountError> {
+        Ok(())
+    }
+
+    async fn read(&self, fid: &Fid, offset: u64, count: u32, _caller: &Subject) -> Result<Vec<u8>, MountError> {
+        let state = fid.downcast_ref::<TestFid>().ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
+        let joined = state.path.join("/");
+        let data = self.files.get(&joined).ok_or_else(|| MountError::NotFound(joined))?;
+        let off = offset as usize;
+        if off >= data.len() {
+            return Ok(vec![]);
+        }
+        let end = (off + count as usize).min(data.len());
+        Ok(data[off..end].to_vec())
+    }
+
+    async fn write(&self, _fid: &Fid, _offset: u64, _data: &[u8], _caller: &Subject) -> Result<u32, MountError> {
+        Err(MountError::NotSupported("read-only test mount".into()))
+    }
+
+    async fn readdir(&self, _fid: &Fid, _caller: &Subject) -> Result<Vec<DirEntry>, MountError> {
+        Ok(self
+            .files
+            .keys()
+            .map(|k| DirEntry { name: k.clone(), is_dir: false, size: 0, stat: None })
+            .collect())
+    }
+
+    async fn stat(&self, fid: &Fid, _caller: &Subject) -> Result<Stat, MountError> {
+        let state = fid.downcast_ref::<TestFid>().ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
+        if state.path.is_empty() {
+            return Ok(Stat { qtype: 0x80, version: 1, path: 0, size: 0, name: String::new(), mtime: 0 });
+        }
+        let joined = state.path.join("/");
+        let size = self.files.get(&joined).map(|d| d.len() as u64).unwrap_or(0);
+        Ok(Stat { qtype: 0, version: 1, path: 1, size, name: joined, mtime: 0 })
+    }
+
+    async fn clunk(&self, _fid: Fid, _caller: &Subject) {}
+}
+
+/// Read one complete 9P message (length-prefixed) from `stream`.
+async fn recv_message(stream: &mut UnixStream) -> Vec<u8> {
+    let mut len = [0u8; 4];
+    stream.read_exact(&mut len).await.unwrap();
+    let total = u32::from_le_bytes(len) as usize;
+    let mut buf = vec![0u8; total];
+    buf[..4].copy_from_slice(&len);
+    stream.read_exact(&mut buf[4..]).await.unwrap();
+    buf
+}
+
+async fn rpc(stream: &mut UnixStream, req: Vec<u8>) -> Response {
+    stream.write_all(&req).await.unwrap();
+    let resp = recv_message(stream).await;
+    let (_, parsed) = msg::parse_response(&resp).unwrap();
+    parsed
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn uds_full_session() {
+    let mut files = HashMap::new();
+    files.insert("hello.txt".to_owned(), b"hello over uds".to_vec());
+    let mount: Arc<dyn Mount> = Arc::new(TestMount { files });
+
+    // Unique per-run socket path in the OS temp dir.
+    let sock = std::env::temp_dir().join(format!(
+        "hyprstream-9p-uds-{}-{}.sock",
+        std::process::id(),
+        std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos(),
+    ));
+    let _ = std::fs::remove_file(&sock);
+    let listener = UnixListener::bind(&sock).unwrap();
+
+    let subject = Subject::new("tenant-a");
+    let translator = Translator::from_mount(mount, subject);
+    let server = tokio::spawn(async move {
+        let _ = translator.serve_uds(listener).await;
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let mut client = UnixStream::connect(&sock).await.unwrap();
+
+    // Version negotiation.
+    match rpc(&mut client, msg::tversion(1, 4096, "9P2000.L")).await {
+        Response::Version { version, .. } => assert_eq!(version, "9P2000.L"),
+        other => panic!("expected Rversion, got {other:?}"),
+    }
+
+    // Attach: fid 0 = root (a directory).
+    match rpc(&mut client, msg::tattach(2, 0, u32::MAX, "tenant-a", "/")).await {
+        Response::Attach { qid } => assert!(qid.is_dir(), "root qid should be a dir"),
+        other => panic!("expected Rattach, got {other:?}"),
+    }
+
+    // Walk root → fid 1 (the file).
+    match rpc(&mut client, msg::twalk(3, 0, 1, &["hello.txt"])).await {
+        Response::Walk { qids } => assert_eq!(qids.len(), 1),
+        other => panic!("expected Rwalk, got {other:?}"),
+    }
+
+    // Open fid 1 for reading.
+    match rpc(&mut client, msg::tlopen(4, 1, 0)).await {
+        Response::Lopen { iounit, .. } => assert!(iounit > 0),
+        other => panic!("expected Rlopen, got {other:?}"),
+    }
+
+    // Read the file content back.
+    match rpc(&mut client, msg::tread(5, 1, 0, 256)).await {
+        Response::Read { data } => assert_eq!(&data, b"hello over uds"),
+        other => panic!("expected Rread, got {other:?}"),
+    }
+
+    // Stat (getattr): size matches.
+    match rpc(&mut client, msg::tgetattr(6, 1, 0x7ff)).await {
+        Response::Getattr { size, .. } => assert_eq!(size, b"hello over uds".len() as u64),
+        other => panic!("expected Rgetattr, got {other:?}"),
+    }
+
+    // Clunk.
+    match rpc(&mut client, msg::tclunk(7, 1)).await {
+        Response::Clunk => {}
+        other => panic!("expected Rclunk, got {other:?}"),
+    }
+
+    // Walking a missing file surfaces an Rlerror.
+    match rpc(&mut client, msg::twalk(8, 0, 2, &["nope"])).await {
+        Response::Error { .. } => {}
+        other => panic!("expected Rlerror for missing file, got {other:?}"),
+    }
+
+    server.abort();
+    let _ = std::fs::remove_file(&sock);
+}


### PR DESCRIPTION
## #506 deliverable 1 — 9P server over a Unix domain socket

Serves a Subject-scoped VFS `Mount` as a 9P2000.L **server** over a Unix domain socket, so a native Wanix workload can attach to a tenant's export via its own `p9kit.ClientFS` 9P client. hyprstream is the server; Wanix is the client.

### What this adds
- **UDS transport, no duplicated accept/serve logic.** `Translator::serve_connection` is now generic over any `AsyncRead + AsyncWrite` stream (`tokio::io::split` in place of `TcpStream::into_split`). `serve` (TCP) and the new `serve_uds` (`tokio::net::UnixListener`) both delegate to a single transport-agnostic `serve_listener` loop via a small private `Listen` trait implemented for `TcpListener` and `UnixListener`. Per-connection handling (framing, fid table, dispatch, Tflush/Rlerror) is byte-identical across transports; a future virtio-9P transport plugs in the same way.
- **`MountBackend`** — adapts an `Arc<dyn hyprstream_vfs::Mount>` + `Subject` to the existing `Backend` trait, the *same* seam the capnp-RPC `ModelBackend` uses on the TCP path. No new attachment mechanism: only the object behind `Backend` differs. It owns the `u32` 9P fid → (absolute path, opaque mount `Fid`) mapping and re-resolves relative walks as `parent_path + components` (a `Mount::walk` resolves from the mount root). readdir is re-encoded into the same length-prefixed wire format `MemoryBackend`/the model service already emit.
- **Subject threading (MAC-load-bearing).** The listener serves exactly one tenant's export, so the verified `Subject` is fixed at construction and threaded onto every `Mount` op. There is no path by which a 9P op reaches the mount without the tenant's `Subject`; the served mount remains the single policy-enforcement point.
- **Entry points:** `Translator::from_mount(mount, subject)` and the `serve_mount_uds(mount, subject, path)` one-call convenience wrapper (bind UDS + serve).

### How it reuses the existing translator
Nothing in the message core changed — `handle_message`, the fid table, Tflush handling, and Rlerror mapping are untouched. The only structural change is making the stream/listener types generic so TCP and UDS share one code path, plus a `Backend` impl for the mount case (mirroring `ModelBackend`).

### Build / test
- `cargo check -p hyprstream-9p` — passes.
- `cargo clippy -p hyprstream-9p --all-targets -- -D warnings` — clean (matches CI's `-D warnings`).
- `cargo test -p hyprstream-9p` — 11 pass: existing TCP integration tests (no regression from the generic `serve_connection`), unit tests, and a new `tests/uds_translator.rs` that binds a temp UDS, exports a tiny in-test `Mount` via `from_mount`, and drives version → attach → walk → lopen → read → getattr → clunk from a raw `UnixStream`, asserting content round-trips and a missing walk returns `Rlerror`.

The crate is torch-free, so checks are scoped to `-p hyprstream-9p` and fast.

Draft; targets `feature/wanix-506-workers` (epic integration branch). Scope stays within the 9p/vfs crates — no `mac/` / `oauth/` / #547 code touched.
---

### Interop fix — verified wire-faithful against a real p9kit client (added after review)

The first cut of the UDS export was **not** actually interoperable with a standard 9P2000.L client. The internal tests passed only because none of them exercised `readdir` over the wire, and the crate's own `client.rs` had *also* silently expected the standard format — so the internal dialect was latently broken on both ends. Empirically dialing the server with the exact client Wanix uses (`fs/p9kit.ClientFS` → the `progrium/p9` fork) failed immediately after attach:

```
FAIL [readdir subdir]: wait: unexpected message type: got 117, want 41
```

Two wire faults, both on the `readdir` path:
1. **Framing** — `Response::Readdir` was encoded as `Rread` (msg type **117**); 9P2000.L requires `Rreaddir` (type **41**). A standard client rejects an `Rread` reply to a `Treaddir`.
2. **Record format** — the backends emitted an hyprstream-internal dirent dialect (`name_len/name/is_dir/size`) instead of standard records (`qid[13] · offset[8] · type[1] · name[s]`).

Fix (scoped to the readdir path; nothing else in the message core changed):
- `msg.rs`: add `rreaddir()` framing and `encode_readdir_page()` — a standard dirent-record encoder with proper 9P **cookie-based paging** (`offset` = dirent cookie, `count` = byte budget, records packed whole and never split). `Response::Readdir` now routes through `rreaddir`.
- `MountBackend` (the UDS/#506 export path) and `MemoryBackend` now emit standard records; each entry's qid comes from its `Stat` when present, else a qtype synthesized from `is_dir` with an unknown (`version=0, path=0`) identity (sound per `Stat`'s qid invariant — standard clients re-walk each name to stat it anyway). This also makes the crate's own `client.rs` round-trip, since it already parsed the standard format.
- No change needed to `walk`: p9kit is satisfied with the leaf qid (multi-component `subdir/inner.txt` reads verified below).

**Empirical proof — same server, after the fix, driven by `p9kit.ClientFS`:**
```
OK   [attach]: p9kit.ClientFS attached (version+attach negotiated)
OK   [readdir subdir]: [inner.txt(dir=false)]
OK   [readdir root]: [greeting.txt(dir=false) notes.md(dir=false) subdir(dir=true)] (dirs=1 files=2)
OK   [read]: greeting.txt = "hello from hyprstream 9p\n"
OK   [read nested]: subdir/inner.txt = "inner file contents\n"
OK   [getattr]: greeting.txt size=25 mode=-rw-r--r-- isdir=false
OK   [raw readdir]: [greeting.txt(qidType=0x00) notes.md(qidType=0x00) subdir(qidType=0x80)]
ALL PASS: attach + walk + readdir + read + getattr all interoperate with p9kit
```

Tests now 12 (`cargo test -p hyprstream-9p`): the existing 11 plus assertions that the Mount encoder and the translator wire path both produce `RREADDIR`-framed, standard-record bytes. `cargo clippy -p hyprstream-9p --all-targets -- -D warnings` clean. A standalone `examples/serve_mount_uds.rs` harness serves a sample `SyntheticMount` for the round-trip.
