### PR TITLE
feat(workers): native Wanix guest — embed Wanix, mount hyprstream 9P as root (#506)

### DIFF
--- a/.github/workflows/wanix-guest.yml
+++ b/.github/workflows/wanix-guest.yml
@@ -1,0 +1,51 @@
+name: wanix guest
+
+# CI-build the native Wanix guest (hyprstream #506, deliverable 2). This is a
+# FOREIGN-toolchain (Go) artifact that lives OUTSIDE the Cargo workspace, so it
+# is not covered by the Rust jobs. This standalone job builds it, vets it, and
+# runs its --self-test (which exercises the real 9P attach/walk/read + Wanix
+# NS().Bind wiring against a throwaway in-process 9P server). Torch-free, no
+# Rust, no cargo.
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'workers/wanix-guest/**'
+      - 'scripts/build-wanix-guest.sh'
+      - '.github/workflows/wanix-guest.yml'
+  pull_request:
+    paths:
+      - 'workers/wanix-guest/**'
+      - 'scripts/build-wanix-guest.sh'
+      - '.github/workflows/wanix-guest.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  wanix-guest:
+    name: build + vet + self-test wanix-guest
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: workers/wanix-guest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go build
+        run: go build ./...
+
+      - name: self-test (mount + bind wiring)
+        run: go run . --self-test
+
+      - name: static build via script
+        working-directory: .
+        run: scripts/build-wanix-guest.sh

--- a/scripts/build-wanix-guest.sh
+++ b/scripts/build-wanix-guest.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Build the native Wanix guest (hyprstream #506, deliverable 2).
+#
+# This is a FOREIGN-toolchain (Go) guest artifact. It is intentionally OUT of
+# the Cargo workspace and is NOT built by `cargo build`; build it with this
+# script (or the standalone CI job). Produces a static (CGO-disabled) binary.
+#
+# Usage:
+#   scripts/build-wanix-guest.sh [output-path]
+#
+# Env:
+#   GOOS, GOARCH  cross-compile targets (default: host)
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pkg_dir="${repo_root}/workers/wanix-guest"
+out="${1:-${repo_root}/target/wanix-guest}"
+
+if ! command -v go >/dev/null 2>&1; then
+  echo "error: go toolchain not found on PATH" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$out")"
+
+echo "building wanix-guest -> ${out}"
+( cd "${pkg_dir}" && CGO_ENABLED=0 go build -o "${out}" . )
+
+echo "built: ${out}"
+file "${out}" 2>/dev/null || true

--- a/workers/wanix-guest/.gitignore
+++ b/workers/wanix-guest/.gitignore
@@ -1,0 +1,1 @@
+/wanix-guest

--- a/workers/wanix-guest/README.md
+++ b/workers/wanix-guest/README.md
@@ -1,0 +1,118 @@
+# wanix-guest
+
+A thin **native Go** guest binary that embeds [Wanix](https://github.com/tractordev/wanix)
+as a *library* and mounts a hyprstream **9P** export as the **root of its Wanix
+namespace** — using Wanix's own mechanisms, with no bespoke verb and no Rust shim.
+
+Part of hyprstream issue **#506** (deliverable 2). It is a foreign-toolchain
+(Go) guest artifact and lives **outside the Cargo workspace** on purpose: it is
+not a crate and is never built by `cargo`.
+
+## What it is
+
+Given a Unix socket where hyprstream exposes a 9P2000.L server, `wanix-guest`:
+
+1. dials the socket → `net.Conn`;
+2. `p9kit.ClientFS(conn, aname)` adapts that connection into a Wanix `fs.FS`;
+3. `wanix.NewRoot()` builds a root `Task` carrying its own namespace (`NS`);
+4. `root.Register("exec", &native.ExecDriver{})` registers the host-process
+   task driver;
+5. `root.NS().Bind(hyprfs, ".", ".", fs.BindReplace)` makes the remote 9P tree
+   the **authoritative root** of the Wanix namespace.
+
+### This uses Wanix's native bind mechanism — not a verb
+
+The mount is performed with Wanix's own `p9kit.ClientFS` + `NS().Bind`. There is
+**no** custom hyprstream verb, no forked Wanix, and no Rust component involved in
+the mount. `wanix-guest` is just a small `main` that wires public Wanix APIs
+together. This was proven end-to-end by a feasibility spike before productionizing.
+
+## Run modes
+
+```
+wanix-guest --sock /run/hyprstream/9p.sock [--aname ""] [--cmd "sh"]
+```
+Connect to a real hyprstream 9P server and bind it as the namespace root, then:
+- with `--cmd`: run the command as a Wanix task (bounded wait for its exit); or
+- without `--cmd`: **serve the namespace** — block until `SIGINT`/`SIGTERM`,
+  periodically probing the remote 9P root and reconnecting+rebinding if the
+  server drops/restarts.
+
+```
+wanix-guest --self-test
+```
+Spin up a throwaway in-process 9P server over a temp socket, bind it as the
+namespace root, and list `/`. Exercises the full 9P attach/walk/read + bind
+wiring with no external server. Used as the build/CI smoke test.
+
+Flags / env:
+
+| flag | env | meaning |
+|------|-----|---------|
+| `--sock` | `HYPRSTREAM_9P_SOCK` | path to hyprstream's 9P Unix socket |
+| `--aname` | | 9P attach name (empty = default tree) |
+| `--cmd` | | command to run as a Wanix task; empty = serve the namespace |
+| `--self-test` | | run against a throwaway in-process 9P server and exit |
+
+Connection lifecycle is handled: the single live `net.Conn` is owned by the
+guest and never leaked; the serve loop health-probes the remote root and
+reconnects with bounded backoff, failing the guest with a clear error only if
+reconnection is exhausted.
+
+## Known semantic gap (be honest)
+
+`native.ExecDriver` runs a task's command as a **host OS process** (`os/exec`).
+That process is **NOT** rooted/chrooted into the mounted 9P namespace — the bound
+tree is the **Wanix-level `fs.FS` view**, reachable through Wanix's namespace API,
+not through the host process's POSIX root. POSIX-rooting host exec into the
+mounted tree is the **sandbox's mount concern**, handled separately in **PR-C /
+`hyprstream-workers`**, not by this binary.
+
+There is a second, related limitation this binary surfaces honestly: in this
+*bare* embed, a host-exec task cannot even fully launch, because `ExecDriver`
+opens the task's stdio at `#task/<id>/fd/N`, which the full Wanix runtime
+provides by binding a console/pipe capability — the minimal embed does not wire
+those caps. So `--cmd` allocates + starts the task via the correct native
+mechanism, but the started process has no stdio and never reports an exit; the
+guest bounds the wait (default 10s) and prints a clear diagnostic pointing at the
+deferred sandbox wiring rather than hanging. **The reliable, fully-working mode
+today is the default "serve the namespace" mode** (and `--self-test` for the
+mount+bind wiring). Wiring task stdio + POSIX-rooting is PR-C's job.
+
+## Building
+
+Not built by cargo. Use the repo script (produces a static, CGO-disabled binary):
+
+```
+scripts/build-wanix-guest.sh [output-path]     # default: target/wanix-guest
+```
+
+or directly:
+
+```
+cd workers/wanix-guest
+CGO_ENABLED=0 go build -o wanix-guest .
+go vet ./...
+go run . --self-test
+```
+
+CI builds/vets/self-tests it via `.github/workflows/wanix-guest.yml` (a
+standalone Go job, independent of the Rust workflows).
+
+## Dependency pinning
+
+- **Wanix** is pinned in `go.mod` to commit
+  `3811507904441f1298ea62df9061083f1d47a799`
+  (`tractor.dev/wanix v0.0.0-20260703022758-381150790444`).
+- **Mandatory `p9` fork replace** — copied verbatim from Wanix's own `go.mod`:
+
+  ```
+  replace github.com/hugelgupf/p9 => github.com/progrium/p9 v0.0.0-20260529042029-b49ec572080f
+  ```
+
+  Wanix's `p9kit` imports the path `github.com/hugelgupf/p9` but requires the
+  **progrium fork**. Go does **not** apply a dependency's `replace` directives
+  transitively, so this line **must** be duplicated in *this* module's `go.mod`
+  or the build fails. (Wanix's other replaces — `golang.org/x/sys` → a wasm fork,
+  `cbor`, `r2fs` — are wasm/build-specific and are *not* needed by this native
+  guest's import subset, so they are intentionally omitted.)

--- a/workers/wanix-guest/go.mod
+++ b/workers/wanix-guest/go.mod
@@ -1,0 +1,20 @@
+module github.com/hyprstream/hyprstream/workers/wanix-guest
+
+go 1.26
+
+require (
+	github.com/hugelgupf/p9 v0.3.1-0.20240118043522-6f4f11e5296e
+	tractor.dev/wanix v0.0.0-20260703022758-381150790444
+)
+
+require (
+	github.com/creack/pty v1.1.24 // indirect
+	github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701 // indirect
+	golang.org/x/sys v0.43.0 // indirect
+	tractor.dev/toolkit-go v0.0.0-20250103001615-9a6753936c19 // indirect
+)
+
+// wanix's p9kit imports the path github.com/hugelgupf/p9 but requires the
+// progrium fork. Go does NOT apply a dependency's replace directives
+// transitively, so this MUST be duplicated here verbatim from wanix's go.mod.
+replace github.com/hugelgupf/p9 => github.com/progrium/p9 v0.0.0-20260529042029-b49ec572080f

--- a/workers/wanix-guest/go.sum
+++ b/workers/wanix-guest/go.sum
@@ -1,0 +1,14 @@
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
+github.com/hugelgupf/socketpair v0.0.0-20230822150718-707395b1939a h1:Nq7wDsqsVBUBfGn8yB1M028ShWTKTtZBcafaTJ35N0s=
+github.com/hugelgupf/socketpair v0.0.0-20230822150718-707395b1939a/go.mod h1:71Bqb5Fh9zPHF8jwdmMEmJObzr25Mx5pWLbDBMMEn6E=
+github.com/progrium/p9 v0.0.0-20260529042029-b49ec572080f h1:ypcwpurBXKbVD8c6flX2dRJCrolHiZwVTsvBryQJOIw=
+github.com/progrium/p9 v0.0.0-20260529042029-b49ec572080f/go.mod h1:LoNwfBWP+QlCkjS1GFNylCthRIk/TkMZd6ICTbC+hrI=
+github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701 h1:pyC9PaHYZFgEKFdlp3G8RaCKgVpHZnecvArXvPXcFkM=
+github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701/go.mod h1:P3a5rG4X7tI17Nn3aOIAYr5HbIMukwXG0urG0WuL8OA=
+golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
+golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+tractor.dev/toolkit-go v0.0.0-20250103001615-9a6753936c19 h1:ODcU8zhYvUtfGJ3KeMhtlA942ScAQMT3KU0O1oBg8Sw=
+tractor.dev/toolkit-go v0.0.0-20250103001615-9a6753936c19/go.mod h1:vI9Jf9tepHLrUqGQf7XZuRcQySNajWRKBjPD4+Ay72I=
+tractor.dev/wanix v0.0.0-20260703022758-381150790444 h1:O1TIufQqOeKyJ+zsJB1bPc8ZviKvpeuMc7yXCr/lvso=
+tractor.dev/wanix v0.0.0-20260703022758-381150790444/go.mod h1:JVBHRRMHsTleaX+UWr8+xRHmEa5CAe9EQs1PvIqUCSk=

--- a/workers/wanix-guest/main.go
+++ b/workers/wanix-guest/main.go
@@ -1,0 +1,375 @@
+// Command wanix-guest is a thin *native* Go guest (hyprstream #506, deliverable 2).
+//
+// It embeds Wanix as a library and mounts a remote hyprstream 9P2000.L export
+// as the ROOT of its Wanix namespace, using Wanix's OWN mechanisms -- no
+// bespoke verb, no Rust shim:
+//
+//   - dial a Unix socket -> net.Conn to a hyprstream 9P server
+//   - p9kit.ClientFS(conn, aname) adapts that conn into a wanix fs.FS
+//   - wanix.NewRoot() builds a Task carrying its own namespace (NS)
+//   - root.Register("exec", &native.ExecDriver{}) enables host-process tasks
+//   - root.NS().Bind(hyprfs, ".", ".", BindReplace) makes the remote tree root
+//
+// Run modes:
+//
+//	wanix-guest --sock /run/hyprstream/9p.sock [--aname ""] [--cmd "sh"]
+//	    Connect to a real hyprstream 9P server, bind it as the namespace root,
+//	    then either run --cmd as a Wanix task (waiting for it to exit) or, when
+//	    no --cmd is given, block serving the namespace until signalled. The
+//	    connection is health-probed; a dropped server triggers reconnect+rebind.
+//
+//	wanix-guest --self-test
+//	    Spin up a throwaway in-process p9kit server over a temp Unix socket,
+//	    bind it as the namespace root, and list "/" -- exercises the full 9P
+//	    attach/walk/read + bind wiring with no external server. Build smoke test.
+//
+// Known semantic gap (see README): native.ExecDriver runs a task's command as a
+// HOST OS process; that process is NOT chrooted/rooted into the mounted 9P tree.
+// The bound tree is the Wanix-level fs.FS view. POSIX-rooting host exec into it
+// is the sandbox's mount concern (PR-C / hyprstream-workers), not this binary.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/hugelgupf/p9/p9"
+
+	"tractor.dev/wanix"
+	wfs "tractor.dev/wanix/fs"
+	"tractor.dev/wanix/fs/fskit"
+	"tractor.dev/wanix/fs/p9kit"
+	"tractor.dev/wanix/native"
+)
+
+const (
+	// probeInterval is how often the serve loop walks the remote 9P root to
+	// detect a dropped/restarted server.
+	probeInterval = 3 * time.Second
+	// reconnectAttempts bounds reconnect tries before the guest gives up.
+	reconnectAttempts = 5
+	// reconnectBackoff is the base delay between reconnect attempts.
+	reconnectBackoff = 500 * time.Millisecond
+	// taskExitTimeout bounds how long runTask waits for a started task to
+	// report its exit code before giving up. In the bare guest a host-exec
+	// task cannot actually run (its stdio caps are not wired -- see README),
+	// so this prevents an indefinite hang.
+	taskExitTimeout = 10 * time.Second
+)
+
+type config struct {
+	sock     string
+	aname    string
+	cmd      string
+	selfTest bool
+}
+
+func main() {
+	log.SetFlags(0)
+	log.SetPrefix("wanix-guest: ")
+
+	cfg := config{}
+	flag.StringVar(&cfg.sock, "sock", os.Getenv("HYPRSTREAM_9P_SOCK"),
+		"path to hyprstream 9P Unix socket (env: HYPRSTREAM_9P_SOCK)")
+	flag.StringVar(&cfg.aname, "aname", "",
+		"9P attach name (empty = default tree)")
+	flag.StringVar(&cfg.cmd, "cmd", "",
+		"command to run as a Wanix task after mounting; empty = serve the namespace")
+	flag.BoolVar(&cfg.selfTest, "self-test", false,
+		"run against a throwaway in-process 9P server and exit")
+	flag.Parse()
+
+	// Ctrl-C / SIGTERM cleanly stops the serve loop and closes the connection.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if cfg.selfTest {
+		if err := runSelfTest(ctx); err != nil {
+			log.Fatalf("self-test: %v", err)
+		}
+		return
+	}
+
+	if cfg.sock == "" {
+		log.Fatal("no 9P socket: pass --sock <path> (or HYPRSTREAM_9P_SOCK), or --self-test")
+	}
+
+	if err := runGuest(ctx, cfg); err != nil {
+		log.Fatalf("%v", err)
+	}
+}
+
+// runSelfTest stands up an in-process p9kit server, binds it as the namespace
+// root, and lists "/" through Wanix's own fs.FS view.
+func runSelfTest(ctx context.Context) error {
+	sock, cleanup, err := startThrowawayServer()
+	if err != nil {
+		return fmt.Errorf("start throwaway 9P server: %w", err)
+	}
+	defer cleanup()
+
+	g, err := newGuest(config{sock: sock})
+	if err != nil {
+		return err
+	}
+	defer g.close()
+
+	if err := g.connectAndBind(); err != nil {
+		return err
+	}
+
+	entries, err := wfs.ReadDir(g.root.NS(), ".")
+	if err != nil {
+		return fmt.Errorf("readdir namespace root: %w", err)
+	}
+	fmt.Printf("self-test OK: mounted throwaway 9P tree as wanix namespace root; %d entries:\n", len(entries))
+	for _, e := range entries {
+		fmt.Printf("  %s\tdir=%v\n", e.Name(), e.IsDir())
+	}
+	_ = ctx
+	return nil
+}
+
+// runGuest connects to a real hyprstream 9P server, binds it as the namespace
+// root, then runs the requested command as a task or serves the namespace.
+func runGuest(ctx context.Context, cfg config) error {
+	g, err := newGuest(cfg)
+	if err != nil {
+		return err
+	}
+	defer g.close()
+
+	if err := g.connectAndBind(); err != nil {
+		return err
+	}
+	log.Printf("mounted hyprstream 9P (%q, aname=%q) as wanix namespace root", cfg.sock, cfg.aname)
+
+	if strings.TrimSpace(cfg.cmd) != "" {
+		return g.runTask(ctx, cfg.cmd)
+	}
+	return g.serve(ctx)
+}
+
+// guest owns the Wanix root Task and the live connection to the remote 9P
+// server. It is responsible for (re)binding the remote tree as the namespace
+// root and for not leaking the underlying net.Conn.
+type guest struct {
+	cfg  config
+	root *wanix.Task
+
+	mu   sync.Mutex
+	conn net.Conn // current live connection; owned by this guest
+}
+
+func newGuest(cfg config) (*guest, error) {
+	root, err := wanix.NewRoot()
+	if err != nil {
+		return nil, fmt.Errorf("wanix.NewRoot: %w", err)
+	}
+	// Native host-process task driver so a command bound at #task/new/exec runs.
+	root.Register("exec", &native.ExecDriver{})
+	return &guest{cfg: cfg, root: root}, nil
+}
+
+// connectAndBind dials the 9P socket, adapts it into a wanix fs.FS, and binds
+// it as the namespace ROOT (BindReplace makes it authoritative at ".").
+func (g *guest) connectAndBind() error {
+	conn, err := net.Dial("unix", g.cfg.sock)
+	if err != nil {
+		return fmt.Errorf("dial 9P socket %q: %w", g.cfg.sock, err)
+	}
+
+	hyprfs, err := p9kit.ClientFS(conn, g.cfg.aname)
+	if err != nil {
+		conn.Close()
+		return fmt.Errorf("p9kit.ClientFS: %w", err)
+	}
+
+	if err := g.root.NS().Bind(hyprfs, ".", ".", wfs.BindReplace); err != nil {
+		conn.Close()
+		return fmt.Errorf("bind remote 9P as namespace root: %w", err)
+	}
+
+	g.mu.Lock()
+	old := g.conn
+	g.conn = conn
+	g.mu.Unlock()
+	if old != nil {
+		old.Close() // drop the previous (dead) connection; rebind replaced it
+	}
+	return nil
+}
+
+// serve blocks after the initial bind, periodically walking the remote 9P root
+// to detect a dropped/restarted server and reconnect+rebind. It returns nil on
+// context cancellation (clean shutdown) and an error only if reconnection is
+// exhausted.
+func (g *guest) serve(ctx context.Context) error {
+	log.Printf("serving namespace; probing every %s (Ctrl-C to stop)", probeInterval)
+	ticker := time.NewTicker(probeInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Print("shutdown requested; unmounting")
+			return nil
+		case <-ticker.C:
+			if _, err := wfs.ReadDir(g.root.NS(), "."); err != nil {
+				log.Printf("9P root probe failed (%v); attempting reconnect", err)
+				if rerr := g.reconnect(ctx); rerr != nil {
+					return fmt.Errorf("lost 9P server and could not reconnect: %w", rerr)
+				}
+				log.Print("reconnected and rebound remote 9P root")
+			}
+		}
+	}
+}
+
+// reconnect retries connectAndBind with bounded backoff, honoring ctx.
+func (g *guest) reconnect(ctx context.Context) error {
+	var lastErr error
+	for attempt := 1; attempt <= reconnectAttempts; attempt++ {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Duration(attempt) * reconnectBackoff):
+		}
+		if err := g.connectAndBind(); err != nil {
+			lastErr = err
+			log.Printf("reconnect attempt %d/%d failed: %v", attempt, reconnectAttempts, err)
+			continue
+		}
+		return nil
+	}
+	return lastErr
+}
+
+// runTask spawns cmd as a Wanix task via Wanix's native task filesystem
+// interface (#task/new/exec -> write cmd -> ctl start), then waits (bounded)
+// for the task's exit file. This is the same mechanism the Wanix shell uses.
+//
+// IMPORTANT: in this *bare* guest the started host-exec process cannot actually
+// run to completion: native.ExecDriver opens the task's stdio at
+// #task/<id>/fd/N, which the full Wanix runtime provides by binding a
+// console/pipe capability but this minimal embed does not. Nor is the host
+// process rooted into the mounted 9P tree. Both are the sandbox's concern,
+// deferred to PR-C (see README). We therefore bound the exit wait and report a
+// clear diagnostic rather than hang forever.
+func (g *guest) runTask(ctx context.Context, cmd string) error {
+	ns := g.root.NS()
+
+	// Allocate an exec task: reading #task/new/exec returns the new task ID.
+	// (Note: id 1 is the root task; the first allocated exec task is id 2+.)
+	idBytes, err := wfs.ReadFile(ns, "#task/new/exec")
+	if err != nil {
+		return fmt.Errorf("alloc exec task (#task/new/exec): %w", err)
+	}
+	id := strings.TrimSpace(string(idBytes))
+	if id == "" {
+		return errors.New("alloc exec task: empty task id")
+	}
+	log.Printf("allocated task %s for cmd %q", id, cmd)
+
+	// Set the command line, then start the task.
+	if err := wfs.WriteFile(ns, fmt.Sprintf("#task/%s/cmd", id), []byte(cmd), 0); err != nil {
+		return fmt.Errorf("set task %s cmd: %w", id, err)
+	}
+	if err := wfs.WriteFile(ns, fmt.Sprintf("#task/%s/ctl", id), []byte("start"), 0); err != nil {
+		return fmt.Errorf("start task %s: %w", id, err)
+	}
+
+	// Poll the task's exit file until it is populated, ctx is cancelled, or the
+	// bounded timeout elapses.
+	exitPath := fmt.Sprintf("#task/%s/exit", id)
+	deadline := time.NewTimer(taskExitTimeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline.C:
+			return fmt.Errorf("task %s did not report exit within %s: the bare guest does not "+
+				"wire host-exec stdio caps (#task/%s/fd/N) or root the process into the mounted "+
+				"9P tree; that is the sandbox's job (deferred to PR-C / hyprstream-workers)",
+				id, taskExitTimeout, id)
+		case <-ticker.C:
+			b, err := wfs.ReadFile(ns, exitPath)
+			if err != nil {
+				// exit not yet available; keep polling.
+				continue
+			}
+			code := strings.TrimSpace(string(b))
+			if code == "" {
+				continue
+			}
+			log.Printf("task %s exited (code %s)", id, code)
+			if code != "0" {
+				return fmt.Errorf("task %s exited with code %s", id, code)
+			}
+			return nil
+		}
+	}
+}
+
+// close releases the live connection. Safe to call multiple times.
+func (g *guest) close() {
+	g.mu.Lock()
+	conn := g.conn
+	g.conn = nil
+	g.mu.Unlock()
+	if conn != nil {
+		conn.Close()
+	}
+}
+
+// startThrowawayServer stands up an in-process p9kit 9P server exporting a
+// small fskit.MapFS over a temp Unix socket. Returns the socket path and a
+// cleanup func. Used only by --self-test; a real deployment replaces it with
+// the hyprstream 9P server.
+func startThrowawayServer() (string, func(), error) {
+	dir, err := os.MkdirTemp("", "wanix-guest-selftest-*")
+	if err != nil {
+		return "", nil, err
+	}
+	sockPath := filepath.Join(dir, "9p.sock")
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		os.RemoveAll(dir)
+		return "", nil, err
+	}
+
+	// Exported tree mimics a hyprstream-ish /ai layout.
+	exported := fskit.MapFS{
+		"models": fskit.MapFS{
+			"llama3": fskit.RawNode([]byte("stub\n"), 0644),
+		},
+		"ctl":     fskit.RawNode([]byte(""), 0644),
+		"version": fskit.RawNode([]byte("selftest\n"), 0644),
+	}
+
+	srv := p9.NewServer(p9kit.Attacher(exported))
+	go func() {
+		_ = srv.Serve(ln) // blocks until the listener closes
+	}()
+
+	cleanup := func() {
+		ln.Close()
+		os.RemoveAll(dir)
+	}
+	return sockPath, cleanup, nil
+}


### PR DESCRIPTION
Deliverable 2 of #506. Targets the epic branch `feature/wanix-506-workers`.

## What it is
`workers/wanix-guest/` — a thin **native Go** binary (its own Go module, **outside the Cargo workspace**) that embeds [Wanix](https://github.com/tractordev/wanix) as a *library* and mounts a hyprstream **9P** export as the **root of its Wanix namespace**. No bespoke verb, no forked Wanix, no Rust shim.

## Native-mechanism design
The mount is Wanix's own machinery — nothing custom:
```
net.Dial(unix, sock)                         -> net.Conn
p9kit.ClientFS(conn, aname)                  -> wanix fs.FS
wanix.NewRoot()                              -> root Task + namespace (NS)
root.Register("exec", &native.ExecDriver{})  -> host-process task driver
root.NS().Bind(hyprfs, ".", ".", BindReplace)-> remote 9P tree IS the ns root
```
Productionized from a feasibility spike that proved this compiles + works end-to-end:
- flags/env: `--sock`/`HYPRSTREAM_9P_SOCK`, `--aname`, `--cmd`, `--self-test`
- real conn lifecycle: single owned `net.Conn` (never leaked); serve loop health-probes the remote 9P root and reconnects+rebinds with bounded backoff, failing with a clear error only if reconnection is exhausted
- run loop: with `--cmd`, run it as a Wanix task (bounded wait); without, **serve the namespace** (block until SIGINT/SIGTERM); `--self-test` runs a throwaway in-process 9P server end-to-end

## Wanix pin + mandatory `progrium/p9` replace
- `tractor.dev/wanix` pinned to commit `3811507` (`v0.0.0-20260703022758-381150790444`).
- **Mandatory** replace copied verbatim from Wanix's own go.mod (Go does NOT apply a dependency's replaces transitively; the build fails without it):
  ```
  replace github.com/hugelgupf/p9 => github.com/progrium/p9 v0.0.0-20260529042029-b49ec572080f
  ```
  Wanix's other replaces (`x/sys` wasm fork, `cbor`, `r2fs`) are wasm/build-specific and not needed by this native guest's import subset, so they are intentionally omitted.

## Known semantic gap (deferred to PR-C)
`native.ExecDriver` runs a task's command as a **host OS process** that is **NOT** rooted into the mounted 9P namespace — the bound tree is the Wanix-level `fs.FS` view. POSIX-rooting host exec into it is the **sandbox's mount concern** (PR-C / `hyprstream-workers`), not this binary's job.

Additionally surfaced honestly: in this *bare* embed a host-exec task can't even fully launch, because `ExecDriver` opens task stdio at `#task/<id>/fd/N`, which the full Wanix runtime provides by binding a console/pipe cap and this minimal embed does not. So `--cmd` allocates+starts the task via the correct native mechanism, but the process has no stdio and never reports exit; the guest **bounds** the wait (10s) and prints a clear diagnostic instead of hanging. The reliable, fully-working modes today are the default **serve-the-namespace** mode and `--self-test`. Task-stdio wiring + POSIX rooting = PR-C.

## Build (foreign toolchain — not cargo)
- `scripts/build-wanix-guest.sh` → static `CGO_ENABLED=0 go build` (default out `target/wanix-guest`); not wired into cargo.
- Standalone CI job `.github/workflows/wanix-guest.yml` (Go only; independent of Rust workflows) builds + vets + self-tests.

## Build results (verified locally, against the committed remote-pin go.mod)
```
go build ./...        OK
go vet ./...          OK
go run . --self-test  OK  (mounted throwaway 9P tree as ns root; 3 entries)
CGO_ENABLED=0 build   OK  (static ELF)
--cmd (real p9 server) fails fast in 10s with the documented stdio-cap diagnostic
```
The committed go.mod (remote wanix pin + progrium/p9 replace) fetched and built successfully in this environment — verified as committed, not via a local replace.

Do not merge; draft.
