### PR TITLE
feat(workers): inject-9P-socket capability + Wanix-guest workload wiring (#506)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7252,6 +7252,7 @@ dependencies = [
  "glob",
  "hex",
  "hypervisor",
+ "hyprstream-9p",
  "hyprstream-rpc",
  "hyprstream-rpc-build",
  "hyprstream-rpc-derive",

--- a/crates/hyprstream-workers/Cargo.toml
+++ b/crates/hyprstream-workers/Cargo.toml
@@ -19,6 +19,9 @@ hyprstream-workers-wasmtime = { path = "../hyprstream-workers-wasmtime", optiona
 hyprstream-rpc-derive = { path = "../hyprstream-rpc-derive" }
 hyprstream-service = { path = "../hyprstream-service" }
 hyprstream-vfs = { path = "../hyprstream-vfs" }
+# Wire-faithful 9P2000.L server: serves a Subject-scoped `Arc<dyn Mount>` over a
+# Unix socket for the native Wanix guest to dial (#506, `runtime::wanix_workload`).
+hyprstream-9p = { path = "../hyprstream-9p" }
 # FS-A's vhost-user-fs server (native-only): serves a composed per-sandbox
 # Namespace to a Cloud Hypervisor guest. FS-D wires the compose→serve→attach
 # flow. Native-only (vhost-user-fs/fuse-backend-rs transport are Linux-only).

--- a/crates/hyprstream-workers/src/runtime/kata_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/kata_backend.rs
@@ -853,6 +853,11 @@ inventory::submit! {
         priority: 100,
         // Full VM isolation (strongest tier) → eligible for `"auto"`.
         auto_selectable: true,
+        // A VM does NOT share the host mount namespace, so a host Unix socket
+        // cannot be bind-injected the way oci/nspawn do (#506). The VM path
+        // exposes a tenant namespace over virtio-fs instead (see `sandbox_fs`),
+        // a different mechanism — so kata does not advertise host-UDS injection.
+        injects_9p_socket: false,
         is_available: KataBackend::registry_is_available,
         construct: |ctx| {
             Ok(Arc::new(KataBackend::new(

--- a/crates/hyprstream-workers/src/runtime/mod.rs
+++ b/crates/hyprstream-workers/src/runtime/mod.rs
@@ -58,6 +58,12 @@ pub mod sandbox_fs;
 pub mod selection;
 mod service;
 pub mod spawner;
+// Wanix-guest workload wiring (#506 deliverable 3): allocate a per-workload UDS,
+// serve a tenant's Subject-scoped VFS `Mount` as 9P2000.L over it, and inject the
+// socket + env into a sandbox so the native Wanix guest dials back. Native only
+// (needs tokio `net` for the 9P UDS server).
+#[cfg(not(target_arch = "wasm32"))]
+pub mod wanix_workload;
 
 // Generated wire types — canonical OCI/CRI-aligned names (no Gen*/Wire/Enum aliases)
 pub use client::{
@@ -108,13 +114,21 @@ pub use oci_backend::{OciBackend, OciConfig, OciHandle};
 #[cfg(feature = "wasm")]
 pub use wasm_backend::{WasmBackend, WasmConfig, WasmHandle};
 // Inventory-based backend registry + fail-closed selection spine (#507)
-pub use selection::{resolve_backend, BackendCtx, BackendRegistration};
+pub use selection::{
+    backend_injects_9p_socket, require_9p_socket_capability, resolve_backend,
+    resolve_backend_9p_capable, BackendCtx, BackendRegistration,
+};
 // Domain entities (business logic only)
 pub use container::Container;
 pub use pool::{PoolStats, SandboxPool};
 pub use sandbox::PodSandbox;
 #[cfg(all(not(target_arch = "wasm32"), feature = "oci-image"))]
 pub use sandbox_fs::{InjectedMounts, SandboxFs, SandboxFsServer, VFS_SOCKET_NAME};
+#[cfg(not(target_arch = "wasm32"))]
+pub use wanix_workload::{
+    inject_9p_socket, Injected9pServer, WanixGuestConfig, WanixInjection,
+    ANN_WANIX_COMMAND, ENV_9P_SOCK,
+};
 pub use service::WorkerService;
 // Re-export service infrastructure from hyprstream-rpc for convenience
 pub use hyprstream_rpc::service::{EnvelopeContext, ServiceHandle, RequestService};

--- a/crates/hyprstream-workers/src/runtime/nspawn.rs
+++ b/crates/hyprstream-workers/src/runtime/nspawn.rs
@@ -526,6 +526,12 @@ inventory::submit! {
         priority: 10,
         // Kernel-namespace isolation (real container) → eligible for `"auto"`.
         auto_selectable: true,
+        // systemd-nspawn `--bind`s host paths into the container, so hyprstream
+        // can inject a host 9P Unix socket into the workload's mount namespace
+        // (#506). (Running the Wanix guest *as the boot command* under nspawn is
+        // a separate follow-up — nspawn currently boots the inner hyprstream
+        // service — but the socket-injection capability itself is real.)
+        injects_9p_socket: true,
         is_available: NspawnBackend::registry_is_available,
         construct: |_ctx| {
             Ok(std::sync::Arc::new(NspawnBackend::new(NspawnConfig::default()))

--- a/crates/hyprstream-workers/src/runtime/oci_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/oci_backend.rs
@@ -66,6 +66,12 @@ const ANN_ENV_PREFIX: &str = "hyprstream.io/env.";
 const ANN_MOUNT_PREFIX: &str = "hyprstream.io/mount.";
 /// Annotation key: request GPU device pass-through (`hyprstream.io/gpu=true`).
 const ANN_GPU: &str = "hyprstream.io/gpu";
+/// Annotation key: the workload command to run in the container, appended after
+/// the image (whitespace-separated argv). When absent the image's own entrypoint
+/// runs (CRI pause semantics). Used by the Wanix-guest workload (#506) to run the
+/// injected guest binary; must equal
+/// [`wanix_workload::ANN_WANIX_COMMAND`](super::wanix_workload::ANN_WANIX_COMMAND).
+const ANN_COMMAND: &str = "hyprstream.io/command";
 
 /// Default OCI runtime binary (rootless podman).
 const DEFAULT_RUNTIME_BIN: &str = "podman";
@@ -319,8 +325,17 @@ impl OciBackend {
             args.push("--read-only".into());
         }
 
-        // Image to run (positional, last before any command).
+        // Image to run (positional).
         args.push(image.to_owned());
+
+        // Optional workload command, appended after the image as argv. Absent →
+        // the image entrypoint runs (pause semantics). The Wanix-guest workload
+        // (#506) sets this to the injected guest binary path.
+        if let Some(cmd) = annotations.get(ANN_COMMAND) {
+            for tok in cmd.split_whitespace() {
+                args.push(tok.to_owned());
+            }
+        }
 
         args
     }
@@ -639,6 +654,10 @@ inventory::submit! {
         name: "oci",
         priority: 20,
         auto_selectable: true,
+        // A rootless OCI container bind-mounts host paths (`podman --volume`), so
+        // hyprstream can inject a host 9P Unix socket into the workload's mount
+        // namespace (#506) and set `HYPRSTREAM_9P_SOCK` for the guest to dial.
+        injects_9p_socket: true,
         is_available: OciBackend::registry_is_available,
         construct: |_ctx| {
             Ok(std::sync::Arc::new(OciBackend::new(OciConfig::default()))
@@ -776,5 +795,46 @@ mod tests {
         assert!(args.contains(&"--memory=134217728".to_owned()));
         // Image is the last positional argument.
         assert_eq!(args.last().unwrap(), "alpine:latest");
+    }
+
+    #[test]
+    fn command_annotation_appends_argv_after_image() {
+        // The Wanix-guest workload (#506) injects a `hyprstream.io/command`
+        // annotation; it must be threaded as argv *after* the image, and the
+        // injected 9P socket bind + env must survive too.
+        let backend = OciBackend::new(OciConfig::default());
+        let cfg = PodSandboxConfig::default();
+        let pod = new_pod("sb-9p", &cfg);
+
+        let mut ann = HashMap::new();
+        ann.insert(
+            "hyprstream.io/mount.9p-sock".into(),
+            "/run/hs/sb-9p/9p.sock:/run/hyprstream/9p.sock:rw".into(),
+        );
+        ann.insert(
+            "hyprstream.io/env.HYPRSTREAM_9P_SOCK".into(),
+            "/run/hyprstream/9p.sock".into(),
+        );
+        ann.insert("hyprstream.io/command".into(), "/usr/local/bin/wanix-guest".into());
+
+        let args = backend.build_run_args(&pod, "hyprstream-sb-9p", "alpine:latest", &cfg, &ann);
+
+        // Injected socket bind + env are threaded.
+        assert!(args
+            .contains(&"--volume=/run/hs/sb-9p/9p.sock:/run/hyprstream/9p.sock:rw".to_owned()));
+        assert!(args.contains(&"--env=HYPRSTREAM_9P_SOCK=/run/hyprstream/9p.sock".to_owned()));
+
+        // The command is the LAST arg, appearing AFTER the image.
+        assert_eq!(args.last().unwrap(), "/usr/local/bin/wanix-guest");
+        let img_idx = args.iter().position(|a| a == "alpine:latest").unwrap();
+        let cmd_idx = args.iter().position(|a| a == "/usr/local/bin/wanix-guest").unwrap();
+        assert!(cmd_idx > img_idx, "command must come after the image");
+    }
+
+    #[test]
+    fn command_annotation_key_matches_wanix_contract() {
+        // Single source of truth: the OCI consumer key must equal the wanix
+        // producer key (both are the same wire annotation).
+        assert_eq!(ANN_COMMAND, super::super::wanix_workload::ANN_WANIX_COMMAND);
     }
 }

--- a/crates/hyprstream-workers/src/runtime/selection.rs
+++ b/crates/hyprstream-workers/src/runtime/selection.rs
@@ -99,6 +99,33 @@ pub struct BackendRegistration {
     /// in-process `wasm` sandbox (shared host address space) sets this `false`.
     pub auto_selectable: bool,
 
+    /// Whether this backend can **inject a 9P socket endpoint** — a host Unix
+    /// domain socket — into a workload's mount namespace (#506).
+    ///
+    /// The Wanix-guest workload (`runtime::wanix_workload`) works by having
+    /// hyprstream serve a tenant's Subject-scoped VFS `Mount` as a 9P2000.L
+    /// server on a host UDS, then making that socket reachable *inside* the
+    /// sandbox (bind-mounting the host socket into the container's mount
+    /// namespace and setting `HYPRSTREAM_9P_SOCK`) so the guest dials back. That
+    /// requires the backend to be able to bind-mount an arbitrary host path (the
+    /// socket) into the workload, which the tiers do differently:
+    ///
+    /// * `oci` / `nspawn` → `true`: both bind-mount host paths into the
+    ///   container (`podman --volume` / `nspawn --bind`), so a host UDS injects
+    ///   cleanly.
+    /// * `kata` → `false`: a full VM does not share the host mount namespace, so
+    ///   a host UDS cannot be bind-injected the same way (the VM path uses
+    ///   virtio-fs, a different mechanism — see `sandbox_fs`); it therefore does
+    ///   **not** advertise this capability.
+    /// * `wasm` → `false`: in-process, no separate mount namespace to inject a
+    ///   host socket into.
+    ///
+    /// Selection is **fail-closed** on this flag: a workload that requires 9P
+    /// socket injection ([`resolve_backend_9p_capable`] /
+    /// [`require_9p_socket_capability`]) never resolves to a backend that does
+    /// not advertise it — it errors rather than silently dropping the injection.
+    pub injects_9p_socket: bool,
+
     /// Runtime prerequisite probe (PATH lookups, socket existence, …). Returns
     /// `true` when this backend can actually run on this host *right now*. Used
     /// to inform `"auto"` and to fail-close explicit requests whose prereqs are
@@ -122,10 +149,38 @@ fn registered_names(regs: &[&BackendRegistration]) -> String {
 /// oracle. Factored out of [`resolve_backend`] so the fail-closed / auto-priority
 /// / unknown-name logic is unit-testable without depending on which runtimes
 /// happen to be installed on the test host.
+///
+/// Capability-agnostic; delegates to [`select_registration_with_cap`] with no
+/// required capability.
 fn select_registration<'a>(
     name: &str,
     regs: &[&'a BackendRegistration],
     is_available: impl Fn(&BackendRegistration) -> bool,
+) -> Result<&'a BackendRegistration> {
+    select_registration_with_cap(name, regs, is_available, false)
+}
+
+/// Pure selection with an additional **required-capability** gate for 9P socket
+/// injection (#506), fail-closed.
+///
+/// When `require_9p_socket` is `true`, the chosen registration must advertise
+/// [`BackendRegistration::injects_9p_socket`]:
+///
+/// * `"auto"` → only backends that are *both* `auto_selectable` **and**
+///   `injects_9p_socket` are candidates; the highest-priority available one
+///   wins. If none qualifies, error — never fall back to a backend that cannot
+///   inject the socket (that would silently drop the tenant's namespace export).
+/// * a concrete name → resolves the named backend, then rejects it if it does
+///   not advertise the capability. We never substitute a different (capable)
+///   backend for an explicitly-named incapable one — the explicit request is
+///   authoritative, and the correct answer is a clean error, not a swap.
+///
+/// With `require_9p_socket == false` this is exactly the prior behaviour.
+fn select_registration_with_cap<'a>(
+    name: &str,
+    regs: &[&'a BackendRegistration],
+    is_available: impl Fn(&BackendRegistration) -> bool,
+    require_9p_socket: bool,
 ) -> Result<&'a BackendRegistration> {
     // ── Auto: highest-priority *available* registration wins ──
     //
@@ -134,8 +189,15 @@ fn select_registration<'a>(
     // resort when nothing stronger is available — that would be a silent isolation
     // downgrade (#547 ZSP). Such backends remain reachable by explicit name below.
     if name.eq_ignore_ascii_case("auto") {
-        let mut candidates: Vec<&'a BackendRegistration> =
-            regs.iter().copied().filter(|r| r.auto_selectable).collect();
+        let mut candidates: Vec<&'a BackendRegistration> = regs
+            .iter()
+            .copied()
+            .filter(|r| r.auto_selectable)
+            // Capability gate: when a 9P-socket-injecting workload is being
+            // placed, an incapable backend is not even a candidate — auto must
+            // never downgrade to one that would silently drop the injection.
+            .filter(|r| !require_9p_socket || r.injects_9p_socket)
+            .collect();
         // Highest priority first; ties broken by name for determinism.
         candidates.sort_by(|a, b| b.priority.cmp(&a.priority).then_with(|| a.name.cmp(b.name)));
         for reg in candidates {
@@ -143,8 +205,13 @@ fn select_registration<'a>(
                 return Ok(reg);
             }
         }
+        let cap_note = if require_9p_socket {
+            " that can inject a 9P socket endpoint (host UDS bind-mount)"
+        } else {
+            ""
+        };
         return Err(WorkerError::ConfigError(format!(
-            "auto backend selection found no available sandbox backend among [{}]. \
+            "auto backend selection found no available sandbox backend{cap_note} among [{}]. \
              Install a supported runtime or set `worker.backend` to an explicit \
              backend; refusing to run a workload without isolation (fail-closed).",
             registered_names(regs)
@@ -153,6 +220,18 @@ fn select_registration<'a>(
 
     // ── Explicit request: authoritative, fail-closed ──
     match regs.iter().find(|r| r.name.eq_ignore_ascii_case(name)) {
+        // Named + available, but cannot inject the required 9P socket → reject.
+        // We do NOT substitute a capable backend for an explicitly-named one.
+        Some(reg) if require_9p_socket && !reg.injects_9p_socket => {
+            Err(WorkerError::ConfigError(format!(
+                "sandbox backend '{}' was requested for a workload that requires 9P \
+                 socket injection (a host Unix socket bind-mounted into the sandbox), \
+                 but '{}' cannot inject a host UDS into a workload's mount namespace. \
+                 Choose a backend that can (e.g. oci, nspawn); refusing to silently \
+                 drop the namespace export (fail-closed).",
+                reg.name, reg.name
+            )))
+        }
         Some(reg) if is_available(reg) => Ok(reg),
         Some(reg) => Err(WorkerError::ConfigError(format!(
             "sandbox backend '{}' was requested but its runtime prerequisites are \
@@ -212,6 +291,69 @@ pub fn resolve_backend(name: &str, ctx: &BackendCtx) -> Result<Arc<dyn SandboxBa
     })
 }
 
+/// Resolve `worker.backend` to a [`SandboxBackend`] that is **guaranteed capable
+/// of 9P socket injection** (#506), fail-closed.
+///
+/// Identical to [`resolve_backend`] but with the capability gate engaged: the
+/// resolved backend always advertises
+/// [`injects_9p_socket`](BackendRegistration::injects_9p_socket). Use this when
+/// placing a workload (e.g. the Wanix guest) that needs a host UDS injected into
+/// its mount namespace. `"auto"` picks the highest-priority *capable* backend;
+/// an explicit name that is incapable errors rather than being swapped for a
+/// capable one.
+pub fn resolve_backend_9p_capable(name: &str, ctx: &BackendCtx) -> Result<Arc<dyn SandboxBackend>> {
+    let regs: Vec<&'static BackendRegistration> =
+        inventory::iter::<BackendRegistration>().collect();
+
+    let reg = select_registration_with_cap(name, &regs, |r| (r.is_available)(), true)?;
+
+    tracing::info!(
+        backend = reg.name,
+        requested = name,
+        priority = reg.priority,
+        "sandbox backend selected for 9P-socket-injecting workload (fail-closed)"
+    );
+
+    (reg.construct)(ctx).map_err(|e| {
+        WorkerError::ConfigError(format!(
+            "failed to construct sandbox backend '{}': {e:#}",
+            reg.name
+        ))
+    })
+}
+
+/// Does the registered backend named `backend_type` advertise 9P socket
+/// injection? Returns `false` for an unknown/unregistered name.
+///
+/// This queries the *registry* (not a live backend instance), so a caller
+/// holding an already-constructed `Arc<dyn SandboxBackend>` can check its
+/// capability via [`SandboxBackend::backend_type`](super::SandboxBackend::backend_type).
+pub fn backend_injects_9p_socket(backend_type: &str) -> bool {
+    inventory::iter::<BackendRegistration>()
+        .find(|r| r.name.eq_ignore_ascii_case(backend_type))
+        .is_some_and(|r| r.injects_9p_socket)
+}
+
+/// Fail-closed guard used at the workload seam: error unless `backend_type`
+/// advertises 9P socket injection (#506).
+///
+/// A caller that already holds a constructed backend (e.g. from the pool) uses
+/// this to refuse — cleanly, before spawning any 9P server or building any
+/// injection annotations — to place a socket-injecting workload on a backend
+/// that cannot receive the socket. It never downgrades; it only reports.
+pub fn require_9p_socket_capability(backend_type: &str) -> Result<()> {
+    if backend_injects_9p_socket(backend_type) {
+        Ok(())
+    } else {
+        Err(WorkerError::ConfigError(format!(
+            "sandbox backend '{backend_type}' cannot inject a 9P socket endpoint \
+             (a host Unix socket bind-mounted into the sandbox), which this workload \
+             requires. Select a capable backend (e.g. oci, nspawn); refusing to run \
+             the workload without its namespace export (fail-closed)."
+        )))
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -231,6 +373,7 @@ mod tests {
         name: "high-tier",
         priority: 100,
         auto_selectable: true,
+        injects_9p_socket: false,
         is_available: || true,
         construct: never_available,
     };
@@ -238,6 +381,7 @@ mod tests {
         name: "low-tier",
         priority: 10,
         auto_selectable: true,
+        injects_9p_socket: false,
         is_available: || true,
         construct: never_available,
     };
@@ -249,6 +393,26 @@ mod tests {
         name: "explicit-only",
         priority: 1000,
         auto_selectable: false,
+        injects_9p_socket: false,
+        is_available: || true,
+        construct: never_available,
+    };
+
+    /// A high-priority backend that CAN inject a 9P socket (models `oci`).
+    const NINEP_HIGH: BackendRegistration = BackendRegistration {
+        name: "ninep-high",
+        priority: 100,
+        auto_selectable: true,
+        injects_9p_socket: true,
+        is_available: || true,
+        construct: never_available,
+    };
+    /// A lower-priority backend that CAN inject a 9P socket (models `nspawn`).
+    const NINEP_LOW: BackendRegistration = BackendRegistration {
+        name: "ninep-low",
+        priority: 10,
+        auto_selectable: true,
+        injects_9p_socket: true,
         is_available: || true,
         construct: never_available,
     };
@@ -339,6 +503,137 @@ mod tests {
         assert!(msg.contains("unknown sandbox backend 'bogus'"), "got: {msg}");
         assert!(msg.contains("high-tier"), "should list registered names: {msg}");
         assert!(msg.contains("low-tier"), "should list registered names: {msg}");
+    }
+
+    // ── 9P-socket-injection capability gate (#506), fail-closed ──
+
+    #[test]
+    fn cap_auto_picks_highest_priority_capable_backend() {
+        // Both capable → strongest (highest priority) wins.
+        let regs = vec![&NINEP_HIGH, &NINEP_LOW];
+        let r = select_registration_with_cap("auto", &regs, |_| true, true).unwrap();
+        assert_eq!(r.name, "ninep-high");
+    }
+
+    #[test]
+    fn cap_auto_skips_incapable_backend_even_if_higher_priority() {
+        // HIGH (priority 100) cannot inject; NINEP_LOW (priority 10) can. With
+        // the capability required, auto MUST pick the lower-priority *capable*
+        // backend, never the higher-priority incapable one.
+        let regs = vec![&HIGH, &NINEP_LOW];
+        let r = select_registration_with_cap("auto", &regs, |_| true, true).unwrap();
+        assert_eq!(r.name, "ninep-low", "auto must pick the capable backend");
+    }
+
+    #[test]
+    fn cap_auto_errors_when_no_capable_backend_available() {
+        // Only incapable backends present → auto errors rather than downgrading
+        // to one that would silently drop the 9P injection.
+        let regs = vec![&HIGH, &LOW];
+        let err = select_registration_with_cap("auto", &regs, |_| true, true).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("9P socket endpoint"), "got: {msg}");
+        assert!(msg.contains("fail-closed"), "got: {msg}");
+    }
+
+    #[test]
+    fn cap_auto_errors_when_capable_backend_unavailable() {
+        // The only capable backend is unavailable → auto fails closed (no
+        // fallback to an available-but-incapable backend).
+        let regs = vec![&NINEP_HIGH, &LOW];
+        let err = select_registration_with_cap("auto", &regs, |r| r.name == "low-tier", true)
+            .unwrap_err();
+        assert!(err.to_string().contains("9P socket endpoint"), "got: {err}");
+    }
+
+    #[test]
+    fn cap_explicit_capable_resolves() {
+        let regs = vec![&NINEP_HIGH, &LOW];
+        let r = select_registration_with_cap("ninep-high", &regs, |_| true, true).unwrap();
+        assert_eq!(r.name, "ninep-high");
+    }
+
+    #[test]
+    fn cap_explicit_incapable_errors_no_substitution() {
+        // Explicitly asking for an incapable backend when the capability is
+        // required errors — and must NOT silently swap in a capable one.
+        let regs = vec![&HIGH, &NINEP_LOW];
+        let err =
+            select_registration_with_cap("high-tier", &regs, |_| true, true).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("9P socket injection"), "got: {msg}");
+        assert!(msg.contains("fail-closed"), "got: {msg}");
+        // Must not name the capable backend it could have swapped to.
+        assert!(!msg.contains("ninep-low"), "must not suggest a silent swap: {msg}");
+    }
+
+    #[test]
+    fn cap_off_ignores_incapable_flag() {
+        // With the capability NOT required, an incapable backend resolves fine
+        // (the gate is opt-in; default behaviour is unchanged).
+        let regs = vec![&HIGH, &LOW];
+        let r = select_registration_with_cap("high-tier", &regs, |_| true, false).unwrap();
+        assert_eq!(r.name, "high-tier");
+        let r = select_registration_with_cap("auto", &regs, |_| true, false).unwrap();
+        assert_eq!(r.name, "high-tier");
+    }
+
+    #[test]
+    fn require_capability_helper_is_fail_closed() {
+        // The registry-backed helper the workload seam uses: real registered
+        // backends reflect reality (oci/nspawn capable; kata/wasm not), and an
+        // unknown name is treated as incapable (fail-closed).
+        assert!(!backend_injects_9p_socket("does-not-exist"));
+        assert!(require_9p_socket_capability("does-not-exist").is_err());
+
+        // nspawn is always registered and IS capable (host --bind).
+        assert!(backend_injects_9p_socket("nspawn"), "nspawn can bind a host UDS");
+        assert!(require_9p_socket_capability("nspawn").is_ok());
+        // Case-insensitive, mirroring name matching.
+        assert!(backend_injects_9p_socket("NSPAWN"));
+    }
+
+    #[cfg(feature = "oci")]
+    #[test]
+    fn oci_advertises_9p_socket_injection() {
+        let oci = inventory::iter::<BackendRegistration>()
+            .find(|r| r.name == "oci")
+            .expect("oci registered under the oci feature");
+        assert!(oci.injects_9p_socket, "oci bind-mounts a host UDS → capable");
+    }
+
+    #[cfg(feature = "kata-vm")]
+    #[test]
+    fn kata_does_not_advertise_9p_socket_injection() {
+        // A VM does not share the host mount namespace, so it cannot bind-inject
+        // a host UDS the way oci/nspawn do — it must NOT advertise the capability.
+        let kata = inventory::iter::<BackendRegistration>()
+            .find(|r| r.name == "kata")
+            .expect("kata registered under the kata-vm feature");
+        assert!(
+            !kata.injects_9p_socket,
+            "kata (VM, no shared host mount ns) must not advertise host-UDS injection"
+        );
+    }
+
+    #[cfg(feature = "wasm")]
+    #[test]
+    fn wasm_does_not_advertise_9p_socket_injection() {
+        let wasm = inventory::iter::<BackendRegistration>()
+            .find(|r| r.name == "wasm")
+            .expect("wasm registered under the wasm feature");
+        assert!(
+            !wasm.injects_9p_socket,
+            "in-process wasm has no separate mount ns to inject a host socket into"
+        );
+    }
+
+    #[test]
+    fn nspawn_advertises_9p_socket_injection() {
+        let nspawn = inventory::iter::<BackendRegistration>()
+            .find(|r| r.name == "nspawn")
+            .expect("nspawn always registered");
+        assert!(nspawn.injects_9p_socket, "nspawn --bind can inject a host UDS");
     }
 
     #[test]

--- a/crates/hyprstream-workers/src/runtime/wanix_workload.rs
+++ b/crates/hyprstream-workers/src/runtime/wanix_workload.rs
@@ -1,0 +1,494 @@
+//! Wanix-guest workload wiring (#506, deliverable 3).
+//!
+//! This is the OCI/nspawn analog of the kata/virtio-fs path in
+//! [`super::sandbox_fs`] (FS-D, #365). Where `sandbox_fs` composes a per-sandbox
+//! Subject-scoped VFS [`Namespace`](hyprstream_vfs::Namespace) and serves it over
+//! a **vhost-user-fs** socket that a Cloud-Hypervisor guest attaches as a
+//! virtio-fs device, this module serves a tenant's Subject-scoped [`Mount`] as a
+//! **wire-faithful 9P2000.L server over a plain Unix socket** (PR-A's
+//! [`hyprstream_9p::serve_mount_uds`]) and injects that socket into a
+//! *bind-mount-capable* sandbox (OCI/nspawn) so the native Wanix guest (PR-B's
+//! `workers/wanix-guest`) dials back and binds the export as its namespace root.
+//!
+//! ## The three injection steps (#506 deliverable 3)
+//!
+//! [`inject_9p_socket`] performs, for one workload:
+//!
+//! 1. **(a) allocate a per-workload UDS path** under the workload's runtime dir;
+//! 2. **(b) spawn the 9P server** — [`hyprstream_9p::serve_mount_uds`] serving
+//!    *that tenant's* Subject-scoped [`Mount`] on the socket, as a background
+//!    task (the [`UnixListener`] is bound *synchronously* first, so the socket
+//!    file exists the moment this returns — no race with sandbox start);
+//! 3. **(c) produce the injection annotations** that the sandbox backend already
+//!    consumes at its existing mount/env seam:
+//!    * `hyprstream.io/mount.9p-sock=<host-sock>:<ctr-sock>:rw` — bind the host
+//!      UDS into the container's mount namespace (OCI `--volume`, nspawn
+//!      `--bind`);
+//!    * `hyprstream.io/mount.wanix-guest=<host-bin>:<ctr-bin>:ro` — bind the
+//!      (configurable, [`WanixGuestConfig::guest_bin`]) guest artifact in;
+//!    * `hyprstream.io/env.HYPRSTREAM_9P_SOCK=<ctr-sock>` — tell the guest where
+//!      to dial;
+//!    * `hyprstream.io/command=<ctr-bin>` — run the guest as the workload command
+//!      (consumed by [`OciBackend`](super::oci_backend)'s `build_run_args`).
+//!
+//! The returned [`WanixInjection`] carries both the annotations (a
+//! `HashMap<String, String>`, exactly the shape a
+//! [`SandboxBackend::start`](super::SandboxBackend::start) receives) and an
+//! [`Injected9pServer`] RAII handle that owns the serve task and removes the
+//! socket on drop.
+//!
+//! ## Where the tenant `Mount` + `Subject` come from
+//!
+//! The Subject-scoped [`Mount`] is a tenant's composed VFS namespace root — the
+//! same thing [`SandboxFs::compose`](super::sandbox_fs::SandboxFs) builds for the
+//! kata path (image rootfs + injected `/stream`, `/models`, `/deltas`, bound
+//! under the sandbox's [`Subject`]). Because [`Namespace`](hyprstream_vfs::Namespace)
+//! is not itself an `Arc<dyn Mount>` and the composition source differs per
+//! caller, this module takes the `Mount` + `Subject` as **parameters** rather
+//! than reaching into a specific composition site: the caller (a worker service
+//! placing a tenant workload) passes the tenant's namespace root and principal.
+//! This is the seam #506 leaves explicit — see the deliverable-3 note on the PR.
+//!
+//! ## Fail-closed
+//!
+//! Injection is gated on the **9P-socket-injection capability** (#506,
+//! deliverable 4): [`require_9p_socket_capability`](super::require_9p_socket_capability)
+//! must pass for the target backend before any socket is served. A backend that
+//! cannot receive a host UDS (kata, wasm) is refused cleanly — never a silent
+//! no-op where the guest comes up with no namespace. [`prepare_wanix_workload`]
+//! bundles the gate + injection.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use hyprstream_vfs::{Mount, Subject};
+use tokio::net::UnixListener;
+use tracing::{debug, info, warn};
+
+use crate::error::{Result, WorkerError};
+use crate::runtime::client::KeyValue;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Annotation / env contract (shared with the sandbox backends' existing seam)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Annotation key prefix: per-variable container environment. Matches the OCI
+/// backend's `ANN_ENV_PREFIX` (a wire contract between producer and consumer).
+const ANN_ENV_PREFIX: &str = "hyprstream.io/env.";
+/// Annotation key prefix: bind-mount spec `host:container[:ro|:rw]`. Matches the
+/// OCI backend's `ANN_MOUNT_PREFIX`.
+const ANN_MOUNT_PREFIX: &str = "hyprstream.io/mount.";
+/// Annotation key: the workload command to run in the sandbox. Consumed by
+/// [`OciBackend`](super::oci_backend)'s `build_run_args`. Must equal
+/// `oci_backend::ANN_COMMAND` (asserted by a test under `--features oci`).
+pub const ANN_WANIX_COMMAND: &str = "hyprstream.io/command";
+
+/// Environment variable the Wanix guest reads for the 9P socket path (see
+/// `workers/wanix-guest`). Kept in sync with the guest's `--sock` env fallback.
+pub const ENV_9P_SOCK: &str = "HYPRSTREAM_9P_SOCK";
+
+/// File name of the per-workload 9P socket under the workload runtime dir.
+const NINEP_SOCKET_NAME: &str = "9p.sock";
+/// In-container path the host 9P socket is bind-mounted to.
+const CTR_SOCK_PATH: &str = "/run/hyprstream/9p.sock";
+/// In-container path the host `wanix-guest` binary is bind-mounted to.
+const CTR_GUEST_BIN_PATH: &str = "/usr/local/bin/wanix-guest";
+
+/// Env var overriding the host path to the `wanix-guest` build artifact.
+const ENV_GUEST_BIN: &str = "HYPRSTREAM_WANIX_GUEST_BIN";
+/// Default host path (relative to CWD) of the `wanix-guest` artifact produced by
+/// `scripts/build-wanix-guest.sh`.
+const DEFAULT_GUEST_BIN: &str = "target/wanix-guest";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Configuration
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Configuration for the Wanix-guest workload.
+#[derive(Debug, Clone)]
+pub struct WanixGuestConfig {
+    /// Host path to the `wanix-guest` binary (a foreign-toolchain build artifact
+    /// from `scripts/build-wanix-guest.sh`, *not* a cargo target). Configurable
+    /// via `HYPRSTREAM_WANIX_GUEST_BIN`; **never** hardcoded to an absolute path.
+    pub guest_bin: PathBuf,
+}
+
+impl Default for WanixGuestConfig {
+    fn default() -> Self {
+        let guest_bin = std::env::var(ENV_GUEST_BIN)
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from(DEFAULT_GUEST_BIN));
+        Self { guest_bin }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Running 9P server handle
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// RAII handle for a per-workload 9P server backing an injected socket.
+///
+/// Owns the background serve task (aborted on drop) and removes the socket file
+/// on drop, so tearing a workload down does not leak a listener or a stale
+/// socket. The task also exits on its own if the socket errors/closes.
+pub struct Injected9pServer {
+    /// Host-side path of the 9P Unix socket.
+    socket_path: PathBuf,
+    /// The background serve task ([`hyprstream_9p`]'s accept loop).
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl Injected9pServer {
+    /// Host-side path of the 9P socket (the bind-mount source).
+    pub fn socket_path(&self) -> &Path {
+        &self.socket_path
+    }
+
+    /// Abort the serve task and remove the socket now (idempotent; `Drop` also
+    /// does this).
+    pub fn shutdown(&self) {
+        self.task.abort();
+        if let Err(e) = std::fs::remove_file(&self.socket_path) {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                debug!(socket = %self.socket_path.display(), error = %e, "remove 9P socket");
+            }
+        }
+    }
+}
+
+impl Drop for Injected9pServer {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+impl std::fmt::Debug for Injected9pServer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Injected9pServer")
+            .field("socket_path", &self.socket_path)
+            .finish()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Injection result
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The product of [`inject_9p_socket`]: the annotations to place on the
+/// workload's sandbox config, plus the running 9P server handle.
+#[derive(Debug)]
+pub struct WanixInjection {
+    /// Annotations to merge into the sandbox's config. Shaped as the backend's
+    /// `start` receives them (`HashMap<String, String>`); use
+    /// [`WanixInjection::as_key_values`] to fold them into a
+    /// [`PodSandboxConfig`](super::client::PodSandboxConfig)'s
+    /// `annotations: Vec<KeyValue>` for the pool path.
+    pub annotations: HashMap<String, String>,
+    /// The live 9P server. Keep it alive for the workload's lifetime; drop it to
+    /// tear the export down.
+    pub server: Injected9pServer,
+}
+
+impl WanixInjection {
+    /// The injection annotations as `Vec<KeyValue>` for merging into a
+    /// [`PodSandboxConfig`](super::client::PodSandboxConfig).
+    pub fn as_key_values(&self) -> Vec<KeyValue> {
+        self.annotations
+            .iter()
+            .map(|(k, v)| KeyValue {
+                key: k.clone(),
+                value: v.clone(),
+            })
+            .collect()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Injection
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Allocate a per-workload UDS, serve `mount` (scoped to `subject`) as 9P over
+/// it, and build the sandbox injection annotations (#506 deliverable 3, steps
+/// a/b/c). See the module docs for the full contract.
+///
+/// The [`UnixListener`] is bound synchronously before the serve task is spawned,
+/// so the socket file exists on return — the bind-mount at sandbox start never
+/// races the server coming up.
+///
+/// This is the mechanical injection; the **capability gate** is
+/// [`prepare_wanix_workload`] (or call
+/// [`require_9p_socket_capability`](super::require_9p_socket_capability) first).
+pub async fn inject_9p_socket(
+    mount: Arc<dyn Mount>,
+    subject: Subject,
+    workload_dir: &Path,
+    guest_cfg: &WanixGuestConfig,
+) -> Result<WanixInjection> {
+    // (a) Allocate the per-workload UDS path under the workload runtime dir.
+    tokio::fs::create_dir_all(workload_dir).await.map_err(|e| {
+        WorkerError::SandboxCreationFailed(format!(
+            "create workload dir {}: {e}",
+            workload_dir.display()
+        ))
+    })?;
+    let socket_path = workload_dir.join(NINEP_SOCKET_NAME);
+    // Remove any stale socket from a crashed predecessor (bind would EADDRINUSE).
+    if let Err(e) = tokio::fs::remove_file(&socket_path).await {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            warn!(socket = %socket_path.display(), error = %e, "remove stale 9P socket");
+        }
+    }
+
+    // (b) Bind the listener *now* (socket file exists on return), then spawn the
+    // 9P serve loop in the background over that tenant's Subject-scoped Mount.
+    let listener = UnixListener::bind(&socket_path).map_err(|e| {
+        WorkerError::SandboxCreationFailed(format!(
+            "bind 9P UDS at {}: {e}",
+            socket_path.display()
+        ))
+    })?;
+    let sock_for_log = socket_path.clone();
+    let task = tokio::spawn(async move {
+        // `serve_uds` is PR-A's wire-faithful 9P2000.L server; it runs until the
+        // socket errors/closes (or the task is aborted on teardown).
+        if let Err(e) = hyprstream_9p::Translator::from_mount(mount, subject)
+            .serve_uds(listener)
+            .await
+        {
+            warn!(socket = %sock_for_log.display(), error = %e, "9P workload server exited with error");
+        }
+    });
+
+    // (c) Injection annotations, consumed at the backend's existing mount/env
+    // seam (OCI `--volume`/`--env`/command; nspawn `--bind`/`--setenv`).
+    let host_sock = socket_path.to_string_lossy().into_owned();
+    let host_bin = guest_cfg.guest_bin.to_string_lossy().into_owned();
+
+    let mut annotations = HashMap::new();
+    // Bind the host 9P socket into the container's mount namespace (rw: the guest
+    // connects and does full-duplex 9P over it).
+    annotations.insert(
+        format!("{ANN_MOUNT_PREFIX}9p-sock"),
+        format!("{host_sock}:{CTR_SOCK_PATH}:rw"),
+    );
+    // Bind the configurable guest artifact in read-only.
+    annotations.insert(
+        format!("{ANN_MOUNT_PREFIX}wanix-guest"),
+        format!("{host_bin}:{CTR_GUEST_BIN_PATH}:ro"),
+    );
+    // Point the guest at the in-container socket path.
+    annotations.insert(
+        format!("{ANN_ENV_PREFIX}{ENV_9P_SOCK}"),
+        CTR_SOCK_PATH.to_owned(),
+    );
+    // Run the guest as the workload command (serve-namespace mode: no `--cmd`,
+    // which is the reliable path today — see wanix-guest README's known gap).
+    annotations.insert(ANN_WANIX_COMMAND.to_owned(), CTR_GUEST_BIN_PATH.to_owned());
+
+    info!(
+        socket = %socket_path.display(),
+        guest_bin = %guest_cfg.guest_bin.display(),
+        "prepared Wanix-guest 9P workload injection"
+    );
+
+    Ok(WanixInjection {
+        annotations,
+        server: Injected9pServer { socket_path, task },
+    })
+}
+
+/// Fail-closed convenience: verify `backend_type` can inject a 9P socket, then
+/// perform the injection (#506, deliverables 3 + 4 together).
+///
+/// The capability gate runs **before** any socket is bound or served, so an
+/// incapable backend (kata, wasm) is refused without side effects — never a
+/// silent no-op where the guest boots with no namespace.
+pub async fn prepare_wanix_workload(
+    backend_type: &str,
+    mount: Arc<dyn Mount>,
+    subject: Subject,
+    workload_dir: &Path,
+    guest_cfg: &WanixGuestConfig,
+) -> Result<WanixInjection> {
+    super::require_9p_socket_capability(backend_type)?;
+    inject_9p_socket(mount, subject, workload_dir, guest_cfg).await
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use hyprstream_vfs::injected::{SyntheticMount, SyntheticNode};
+    use std::os::unix::net::UnixStream as StdUnixStream;
+
+    fn tenant_mount() -> Arc<dyn Mount> {
+        // A trivial Subject-scoped tree stands in for a composed tenant namespace.
+        Arc::new(SyntheticMount::new(
+            SyntheticNode::dir().with_child("hello", SyntheticNode::file(b"hi\n".to_vec())),
+        ))
+    }
+
+    #[test]
+    fn guest_bin_is_configurable_not_hardcoded() {
+        // Default is the build-script artifact path (relative), never an absolute
+        // hardcode.
+        std::env::remove_var(ENV_GUEST_BIN);
+        let cfg = WanixGuestConfig::default();
+        assert_eq!(cfg.guest_bin, PathBuf::from(DEFAULT_GUEST_BIN));
+        assert!(cfg.guest_bin.is_relative(), "default must not be an absolute hardcode");
+
+        std::env::set_var(ENV_GUEST_BIN, "/opt/custom/wanix-guest");
+        let cfg = WanixGuestConfig::default();
+        assert_eq!(cfg.guest_bin, PathBuf::from("/opt/custom/wanix-guest"));
+        std::env::remove_var(ENV_GUEST_BIN);
+    }
+
+    #[tokio::test]
+    async fn inject_creates_socket_and_expected_annotations() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = WanixGuestConfig {
+            guest_bin: PathBuf::from("/host/build/wanix-guest"),
+        };
+        let inj = inject_9p_socket(
+            tenant_mount(),
+            Subject::anonymous(),
+            dir.path(),
+            &cfg,
+        )
+        .await
+        .unwrap();
+
+        // (a) socket exists on return (bound synchronously) — the bind-mount
+        // source is ready before any sandbox start.
+        let sock = dir.path().join(NINEP_SOCKET_NAME);
+        assert!(sock.exists(), "9P socket must exist immediately after inject");
+        assert_eq!(inj.server.socket_path(), sock.as_path());
+
+        // (c) env points the guest at the in-container socket.
+        assert_eq!(
+            inj.annotations.get(&format!("{ANN_ENV_PREFIX}{ENV_9P_SOCK}")).map(String::as_str),
+            Some(CTR_SOCK_PATH)
+        );
+        // socket bind: host abs path → container path, rw.
+        let sock_mount = inj
+            .annotations
+            .get(&format!("{ANN_MOUNT_PREFIX}9p-sock"))
+            .expect("9p-sock mount annotation");
+        assert_eq!(
+            sock_mount,
+            &format!("{}:{CTR_SOCK_PATH}:rw", sock.display())
+        );
+        // guest binary bind uses the CONFIGURED host path (read-only).
+        assert_eq!(
+            inj.annotations.get(&format!("{ANN_MOUNT_PREFIX}wanix-guest")).map(String::as_str),
+            Some(format!("/host/build/wanix-guest:{CTR_GUEST_BIN_PATH}:ro").as_str())
+        );
+        // command runs the guest.
+        assert_eq!(
+            inj.annotations.get(ANN_WANIX_COMMAND).map(String::as_str),
+            Some(CTR_GUEST_BIN_PATH)
+        );
+    }
+
+    #[tokio::test]
+    async fn injected_socket_is_a_live_9p_server() {
+        // The spawned task actually serves 9P: a client that connects and sends
+        // a Tversion gets a well-formed Rversion back. Proves (b) wired the real
+        // PR-A server to the tenant Mount, not just created an empty socket.
+        let dir = tempfile::tempdir().unwrap();
+        let inj = inject_9p_socket(
+            tenant_mount(),
+            Subject::anonymous(),
+            dir.path(),
+            &WanixGuestConfig::default(),
+        )
+        .await
+        .unwrap();
+
+        let sock = inj.server.socket_path().to_path_buf();
+        // Connect + do a minimal 9P2000.L version handshake.
+        let reply = tokio::task::spawn_blocking(move || {
+            use std::io::{Read, Write};
+            let mut c = StdUnixStream::connect(&sock).unwrap();
+            // Tversion: size[4] type[1]=100 tag[2]=0xFFFF msize[4] version[s]
+            let version = b"9P2000.L";
+            let mut msg = Vec::new();
+            let body_len = 4 + 1 + 2 + 4 + 2 + version.len();
+            msg.extend_from_slice(&(body_len as u32).to_le_bytes());
+            msg.push(100); // Tversion
+            msg.extend_from_slice(&0xFFFFu16.to_le_bytes());
+            msg.extend_from_slice(&8192u32.to_le_bytes());
+            msg.extend_from_slice(&(version.len() as u16).to_le_bytes());
+            msg.extend_from_slice(version);
+            c.write_all(&msg).unwrap();
+
+            let mut hdr = [0u8; 5];
+            c.read_exact(&mut hdr).unwrap();
+            hdr[4] // message type byte
+        })
+        .await
+        .unwrap();
+
+        // Rversion == 101 (Tversion 100 + 1).
+        assert_eq!(reply, 101, "expected Rversion from the injected 9P server");
+    }
+
+    #[tokio::test]
+    async fn dropping_server_removes_socket() {
+        let dir = tempfile::tempdir().unwrap();
+        let inj = inject_9p_socket(
+            tenant_mount(),
+            Subject::anonymous(),
+            dir.path(),
+            &WanixGuestConfig::default(),
+        )
+        .await
+        .unwrap();
+        let sock = inj.server.socket_path().to_path_buf();
+        assert!(sock.exists());
+        drop(inj);
+        assert!(!sock.exists(), "socket must be removed when the server is dropped");
+    }
+
+    #[tokio::test]
+    async fn prepare_fails_closed_on_incapable_backend() {
+        // kata/wasm/unknown cannot inject a host UDS → refuse before serving.
+        let dir = tempfile::tempdir().unwrap();
+        let err = prepare_wanix_workload(
+            "kata",
+            tenant_mount(),
+            Subject::anonymous(),
+            dir.path(),
+            &WanixGuestConfig::default(),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("cannot inject a 9P socket"), "got: {err}");
+        // And no socket was created (fail-closed BEFORE any side effect).
+        assert!(!dir.path().join(NINEP_SOCKET_NAME).exists());
+    }
+
+    #[tokio::test]
+    async fn prepare_succeeds_on_capable_backend() {
+        // nspawn is always registered and capable → injection proceeds.
+        let dir = tempfile::tempdir().unwrap();
+        let inj = prepare_wanix_workload(
+            "nspawn",
+            tenant_mount(),
+            Subject::anonymous(),
+            dir.path(),
+            &WanixGuestConfig::default(),
+        )
+        .await
+        .unwrap();
+        assert!(inj.server.socket_path().exists());
+        assert!(inj.annotations.contains_key(ANN_WANIX_COMMAND));
+    }
+}

--- a/crates/hyprstream-workers/src/runtime/wasm_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/wasm_backend.rs
@@ -455,6 +455,9 @@ inventory::submit! {
         name: "wasm",
         priority: 5,
         auto_selectable: false,
+        // In-process (shared host address space); there is no separate mount
+        // namespace to bind-inject a host 9P socket into (#506).
+        injects_9p_socket: false,
         is_available: WasmBackend::registry_is_available,
         construct: |_ctx| {
             Ok(std::sync::Arc::new(WasmBackend::new(WasmConfig::default()))


### PR DESCRIPTION
## #506 PR-C — worker wiring (deliverables 3 + 4)

Builds on **PR-A** (`hyprstream-9p` `serve_mount_uds`/`Translator::from_mount`) and **PR-B** (`workers/wanix-guest` native Go binary). Targets the epic branch `feature/wanix-506-workers`.

### Deliverable 4 — selection-taxonomy capability flag
- New `injects_9p_socket: bool` field on `BackendRegistration` (`runtime/selection.rs`), modeled exactly like the existing `auto_selectable` capability flag.
- Reflects reality: **oci → true**, **nspawn → true** (both bind-mount a host path: `podman --volume` / `nspawn --bind`); **kata → false** (a VM has no shared host mount namespace — it uses virtio-fs, see `sandbox_fs`); **wasm → false** (in-process, no separate mount ns).
- **Fail-closed** selection gate: `select_registration_with_cap(...)` + public `resolve_backend_9p_capable()` and `require_9p_socket_capability()`. `"auto"` only considers capable backends (highest-priority capable one wins); an explicitly-named *incapable* backend errors and is **never** silently swapped for a capable one; unknown name → incapable. Existing capability-agnostic `resolve_backend` is unchanged (delegates with the gate off).

### Deliverable 3 — Wanix-guest workload wiring (OCI)
- New `runtime/wanix_workload.rs` — the OCI/nspawn analog of `sandbox_fs.rs`'s kata/virtio-fs path. `inject_9p_socket(mount, subject, workload_dir, guest_cfg)`:
  - **(a)** allocates a per-workload UDS under the workload runtime dir;
  - **(b)** binds the `UnixListener` synchronously (socket exists on return — no race with sandbox start) then spawns PR-A's `Translator::from_mount(mount, subject).serve_uds(listener)` as a background task serving *that tenant's* Subject-scoped `Mount`;
  - **(c)** produces the injection annotations consumed at the backend's existing mount/env seam: `hyprstream.io/mount.9p-sock` (host UDS → container), `hyprstream.io/mount.wanix-guest` (configurable host binary → container, RO), `hyprstream.io/env.HYPRSTREAM_9P_SOCK`, and `hyprstream.io/command` (run the guest).
- `Injected9pServer` is an RAII handle (aborts the serve task + removes the socket on drop).
- Guest binary path is **configurable** via `HYPRSTREAM_WANIX_GUEST_BIN` (default `target/wanix-guest`, the `scripts/build-wanix-guest.sh` artifact) — never a hardcoded absolute path.
- `prepare_wanix_workload(backend_type, ...)` bundles the fail-closed capability gate **before** any socket is served.
- OCI `build_run_args` extended to consume `hyprstream.io/command` (append argv after the image); single-source-of-truth key asserted equal to `wanix_workload::ANN_WANIX_COMMAND` by a test.

### Where the tenant `Mount`/`Subject` come from
`Namespace` is not itself an `Arc<dyn Mount>` and the composition site differs per caller, so the `Mount` + `Subject` are threaded as **parameters** (the same Subject-scoped tree `SandboxFs::compose` builds for the kata path). This is the explicit seam #506 leaves — documented in the module, not faked.

### Out of scope (deferred, per issue)
- nspawn currently boots the inner hyprstream service, so running the guest *as its boot command* is not clean here — nspawn still truthfully advertises the socket-injection **capability** (it can `--bind` a host UDS), but the guest-as-command wiring is OCI-only.
- ExecDriver stdio-rooting / POSIX-rooting host exec into the mounted ns (PR-B's known gap).

### Build / test — runtime-verified vs not
Isolated tmpfs `CARGO_TARGET_DIR`. All green:
- `cargo check -p hyprstream-workers` (default) — ok
- `cargo check -p hyprstream-workers --features oci` — ok
- `cargo clippy -p hyprstream-workers --all-targets -- -D warnings` (default) — clean
- `cargo clippy -p hyprstream-workers --all-targets --features oci -- -D warnings` — clean
- `cargo test -p hyprstream-workers` (default + `--features oci`) — 30 + 18 relevant tests pass, incl. a test that connects to the injected socket and completes a real 9P `Tversion`/`Rversion` handshake against the tenant `Mount`.

**Runtime-verified:** the 9P server injection (socket bound + a live client 9P handshake), the fail-closed capability selection, and the OCI arg-building (socket bind + env + command threaded after the image) are all exercised by unit tests.
**NOT runtime-verified (no podman/isolation runtime in this env):** an actual `podman run` launching the guest binary that dials back end-to-end. The wiring is implemented at the correct existing annotation seam and unit-tested; a full end-to-end launch was not performed.
