### PR TITLE
feat(workers): FUSE POSIX-rooting of the tenant VFS for nspawn — run tasks in the mounted namespace (Model B, #715)

### DIFF
--- a/crates/hyprstream-vfs-server/src/tests.rs
+++ b/crates/hyprstream-vfs-server/src/tests.rs
@@ -675,3 +675,87 @@ fn local_fuse_mount_read_and_readdir() {
         eprintln!("serve_local thread did not exit after unmount within timeout");
     }
 }
+
+/// #720 end-to-end: a rootless `podman run` reads a file through the tenant VFS
+/// FUSE-mounted via `serve_local` — the Model B OCI path exercised against a
+/// real container runtime + kernel `/dev/fuse`. Self-skips when the host lacks
+/// podman or `/dev/fuse` (CI runners), so it is safe in the normal suite.
+#[test]
+fn podman_run_reads_serve_local_vfs() {
+    if !std::path::Path::new("/dev/fuse").exists() {
+        eprintln!("skipping podman_run_reads_serve_local_vfs: no /dev/fuse");
+        return;
+    }
+    if std::process::Command::new("podman").arg("--version").output().is_err() {
+        eprintln!("skipping podman_run_reads_serve_local_vfs: no podman");
+        return;
+    }
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mountpoint = dir.path().to_path_buf();
+
+    let mut ns = Namespace::new();
+    ns.mount(
+        "/data",
+        Arc::new(MemFs::with_files(&[("hello.txt", b"hello from hyprstream vfs")])),
+    )
+    .expect("mount MemFs");
+    let fs = build(ns);
+
+    let mp = mountpoint.clone();
+    let handle = std::thread::Builder::new()
+        .name("fuse-podman-e2e".to_owned())
+        .spawn(move || crate::server::serve_local(fs, &mp))
+        .expect("spawn serve_local");
+
+    // Wait for the mount to come up.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let mut mounted = false;
+    while std::time::Instant::now() < deadline {
+        if mountpoint.join("data").join("hello.txt").exists() {
+            mounted = true;
+            break;
+        }
+        if handle.is_finished() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    let unmount = |mp: &std::path::Path| {
+        if !matches!(std::process::Command::new("fusermount3").arg("-u").arg(mp).status(), Ok(s) if s.success()) {
+            let _ = std::process::Command::new("fusermount").arg("-u").arg(mp).status();
+        }
+    };
+    if !mounted {
+        unmount(&mountpoint);
+        eprintln!("skipping podman_run_reads_serve_local_vfs: serve_local mount did not come up (FUSE unavailable in this env)");
+        return;
+    }
+
+    // Rootless `podman run` reads the file through the FUSE-mounted VFS using
+    // the DEFAULT user namespace. NOTE: do NOT use `--userns=keep-id` here — it
+    // hits a crun+FUSE fd-stat failure ("crun: cannot stat /proc/self/fd/N:
+    // Permission denied") when the bind source is a FUSE mount. Default userns
+    // (and `--userns=host`) work because the container root maps to the mounting
+    // uid and the VFS nodes are world-readable. This is the empirical basis for
+    // the OCI Model B wiring choosing default userns (#720).
+    let vol = format!("{}:/vfs:ro", mountpoint.display());
+    let out = std::process::Command::new("podman")
+        .args([
+            "run", "--rm", "--volume", &vol,
+            "docker.io/library/busybox", "cat", "/vfs/data/hello.txt",
+        ])
+        .output()
+        .expect("podman run");
+
+    unmount(&mountpoint);
+    let _ = handle.join();
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stdout.contains("hello from hyprstream vfs"),
+        "rootless podman did not read the fuse-mounted VFS file.\nstatus={:?}\nstdout={stdout:?}\nstderr={stderr:?}",
+        out.status
+    );
+}

--- a/crates/hyprstream-workers/src/runtime/kata_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/kata_backend.rs
@@ -906,6 +906,10 @@ inventory::submit! {
         // exposes a tenant namespace over virtio-fs instead (see `sandbox_fs`),
         // a different mechanism — so kata does not advertise host-UDS injection.
         injects_9p_socket: false,
+        // kata already shares the composed per-sandbox VFS with its guest as a
+        // virtio-fs (vhost-user-fs) device, NOT a host FUSE mount, so it does not
+        // advertise the Model B (#715) host-FUSE-mount capability.
+        mounts_fuse_vfs: false,
         is_available: KataBackend::registry_is_available,
         construct: |ctx| {
             Ok(Arc::new(KataBackend::new(

--- a/crates/hyprstream-workers/src/runtime/mod.rs
+++ b/crates/hyprstream-workers/src/runtime/mod.rs
@@ -115,15 +115,17 @@ pub use oci_backend::{OciBackend, OciConfig, OciHandle};
 pub use wasm_backend::{WasmBackend, WasmConfig, WasmHandle};
 // Inventory-based backend registry + fail-closed selection spine (#507)
 pub use selection::{
-    backend_injects_9p_socket, require_9p_socket_capability, resolve_backend,
-    resolve_backend_9p_capable, BackendCtx, BackendRegistration,
+    backend_injects_9p_socket, require_9p_socket_capability, require_fuse_mount_capability,
+    resolve_backend, resolve_backend_9p_capable, BackendCtx, BackendRegistration,
 };
 // Domain entities (business logic only)
 pub use container::Container;
 pub use pool::{PoolStats, SandboxPool};
 pub use sandbox::PodSandbox;
 #[cfg(all(not(target_arch = "wasm32"), feature = "oci-image"))]
-pub use sandbox_fs::{InjectedMounts, SandboxFs, SandboxFsServer, VFS_SOCKET_NAME};
+pub use sandbox_fs::{
+    InjectedMounts, SandboxFs, SandboxFsLocalMount, SandboxFsServer, VFS_SOCKET_NAME,
+};
 #[cfg(not(target_arch = "wasm32"))]
 pub use wanix_workload::{
     inject_9p_socket, Injected9pServer, WanixGuestConfig, WanixInjection,

--- a/crates/hyprstream-workers/src/runtime/nspawn.rs
+++ b/crates/hyprstream-workers/src/runtime/nspawn.rs
@@ -24,6 +24,13 @@ use crate::error::{Result, WorkerError};
 use super::backend::{SandboxBackend, SandboxHandle};
 use super::client::{LinuxContainerResources, PodSandboxConfig};
 use super::sandbox::PodSandbox;
+#[cfg(feature = "oci-image")]
+use crate::image::RafsStore;
+
+/// Sub-directory of the per-sandbox runtime dir where the tenant VFS is
+/// FUSE-mounted for Model B (#715) POSIX-rooting.
+#[cfg(feature = "oci-image")]
+const VFS_ROOT_DIR: &str = "vfs-root";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Configuration
@@ -103,6 +110,14 @@ pub struct NspawnHandle {
     pub leader_pid: Option<u32>,
     /// Host-side sandbox directory for bind-mounts.
     pub sandbox_path: PathBuf,
+    /// Per-sandbox tenant-VFS FUSE mount (Model B, #715). When set, the
+    /// container is `--directory`-rooted at this mount's host directory. Held
+    /// here (behind `Arc`) for the sandbox's lifetime so the mount — and its
+    /// serving thread + injected registries — outlive container start; it is
+    /// unmounted when the last handle clone drops (RAII), i.e. on sandbox
+    /// stop/destroy.
+    #[cfg(feature = "oci-image")]
+    pub vfs_root_mount: Option<Arc<super::sandbox_fs::SandboxFsLocalMount>>,
 }
 
 impl SandboxHandle for NspawnHandle {
@@ -118,11 +133,34 @@ impl SandboxHandle for NspawnHandle {
 /// systemd-nspawn sandbox backend.
 pub struct NspawnBackend {
     config: NspawnConfig,
+    /// RAFS image store for composing the per-sandbox tenant VFS that Model B
+    /// (#715) FUSE-mounts as the container root. `None` when no store was
+    /// provided; the field exists only when the image service (`oci-image`) is
+    /// compiled in.
+    #[cfg(feature = "oci-image")]
+    rafs_store: Option<Arc<RafsStore>>,
 }
 
 impl NspawnBackend {
     pub fn new(config: NspawnConfig) -> Self {
-        Self { config }
+        Self {
+            config,
+            #[cfg(feature = "oci-image")]
+            rafs_store: None,
+        }
+    }
+
+    /// Attach the RAFS image store used to compose the per-sandbox tenant VFS
+    /// for Model B (#715) FUSE-rooting. Threaded in from [`BackendCtx`] at
+    /// selection time (see the inventory registration below). Without a store,
+    /// nspawn behaves exactly as before — a host-root (`--directory=/`)
+    /// container, no tenant-VFS root.
+    ///
+    /// [`BackendCtx`]: super::selection::BackendCtx
+    #[cfg(feature = "oci-image")]
+    pub fn with_rafs_store(mut self, rafs_store: Option<Arc<RafsStore>>) -> Self {
+        self.rafs_store = rafs_store;
+        self
     }
 
     /// Runtime prerequisite probe for the backend registry: both
@@ -133,18 +171,28 @@ impl NspawnBackend {
     }
 
     /// Build the `systemd-nspawn` argument list for a sandbox.
+    ///
+    /// `vfs_root` is the host directory the tenant VFS was FUSE-mounted at
+    /// (Model B, #715). When `Some`, the container is rooted there — its
+    /// workload sees the tenant VFS as its filesystem — instead of sharing the
+    /// host root (`--directory=/`).
     fn build_nspawn_args(
         &self,
         sandbox: &PodSandbox,
         machine_name: &str,
         annotations: &HashMap<String, String>,
         resources: Option<&LinuxContainerResources>,
+        vfs_root: Option<&Path>,
     ) -> Vec<String> {
         let mut args = Vec::new();
 
-        // Core flags
+        // Core flags. Root at the tenant-VFS FUSE mount when Model B (#715) has
+        // composed one for this sandbox; otherwise share the host root as before.
         args.push(format!("--machine={machine_name}"));
-        args.push("--directory=/".into());
+        match vfs_root {
+            Some(root) => args.push(format!("--directory={}", root.display())),
+            None => args.push("--directory=/".into()),
+        }
         args.push("--tmpfs=/tmp".into());
         args.push("--tmpfs=/run".into());
 
@@ -217,6 +265,86 @@ impl NspawnBackend {
         args.push("--foreground".into());
 
         args
+    }
+
+    /// Annotation key carrying the sandbox's policy principal (the [`Subject`]
+    /// at the VFS Mount boundary, #353/#319/#328) — same key the kata backend
+    /// reads. When absent, the sandbox id is used as a stable per-sandbox
+    /// principal so isolation still holds.
+    ///
+    /// [`Subject`]: hyprstream_vfs::Subject
+    #[cfg(feature = "oci-image")]
+    const SUBJECT_ANNOTATION: &'static str = "hyprstream.io/subject";
+
+    /// Resolve the [`Subject`](hyprstream_vfs::Subject) this sandbox's tenant
+    /// VFS is served under (mirrors `KataBackend::sandbox_subject`).
+    #[cfg(feature = "oci-image")]
+    fn sandbox_subject(
+        sandbox: &PodSandbox,
+        annotations: &HashMap<String, String>,
+    ) -> hyprstream_vfs::Subject {
+        annotations
+            .get(Self::SUBJECT_ANNOTATION)
+            .filter(|s| !s.is_empty())
+            .map(hyprstream_vfs::Subject::new)
+            .unwrap_or_else(|| hyprstream_vfs::Subject::new(sandbox.id.clone()))
+    }
+
+    /// Compose the per-sandbox tenant VFS (image rootfs + injected mounts) and
+    /// FUSE-mount it at a per-sandbox host directory (Model B, #715) — the
+    /// non-VM sibling of `KataBackend::compose_and_serve_vfs`.
+    ///
+    /// Returns the RAII [`SandboxFsLocalMount`](super::sandbox_fs::SandboxFsLocalMount);
+    /// the container is then `--directory`-rooted at its `mountpoint()`. Compose
+    /// is CPU/IO-bound (RAFS load), so it runs on a blocking thread; the mount's
+    /// own serving thread is spawned inside `serve_local_at`. The
+    /// [`require_fuse_mount_capability`](super::selection::require_fuse_mount_capability)
+    /// gate asserts nspawn is declared able to FUSE-root before we mount
+    /// (fail-closed).
+    #[cfg(feature = "oci-image")]
+    async fn compose_and_mount_vfs_root(
+        &self,
+        sandbox: &PodSandbox,
+        image_id: &str,
+        subject: hyprstream_vfs::Subject,
+    ) -> Result<super::sandbox_fs::SandboxFsLocalMount> {
+        use super::sandbox_fs::SandboxFs;
+        use hyprstream_vfs::injected::SyntheticNode;
+
+        let rafs_store = self.rafs_store.clone().ok_or_else(|| {
+            WorkerError::SandboxCreationFailed(
+                "nspawn tenant-VFS root requested but no RAFS image store is configured".into(),
+            )
+        })?;
+
+        // Fail-closed capability gate (#715): only POSIX-root the composed VFS
+        // for a backend that declares it can FUSE-mount it. nspawn does.
+        super::selection::require_fuse_mount_capability(self.backend_type())?;
+
+        let mountpoint = sandbox.sandbox_path().join(VFS_ROOT_DIR);
+        let rt = tokio::runtime::Handle::current();
+        let image_id = image_id.to_owned();
+        let sandbox_dir = sandbox.sandbox_path().clone();
+        let mp = mountpoint.clone();
+
+        // RAFS load + overlay setup is blocking; do it off the async executor.
+        tokio::task::spawn_blocking(move || {
+            let fs = SandboxFs::compose(
+                &rafs_store,
+                &image_id,
+                &sandbox_dir,
+                subject,
+                // Models / deltas injected listings: empty mount points for now
+                // (the worker runtime populates them per tenant), mirroring kata.
+                SyntheticNode::dir(),
+                SyntheticNode::dir(),
+            )?;
+            fs.serve_local_at(rt, mp)
+        })
+        .await
+        .map_err(|e| {
+            WorkerError::SandboxCreationFailed(format!("VFS compose/mount task join: {e}"))
+        })?
     }
 
     /// Discover leader PID via `machinectl show`.
@@ -315,12 +443,46 @@ impl SandboxBackend for NspawnBackend {
         tokio::fs::create_dir_all(&sandbox_path).await?;
         sandbox.sandbox_path = sandbox_path.clone();
 
+        // Model B (#715): when an image store is configured and the sandbox
+        // names an image, compose the per-sandbox tenant VFS and FUSE-mount it as
+        // the container root, so the workload POSIX-roots in the tenant's VFS —
+        // the non-VM sibling of kata's virtio-fs path. Held on the handle so it
+        // outlives start and unmounts on teardown (RAII). Without a store (or
+        // image), nspawn stays a host-root container exactly as before.
+        #[cfg(feature = "oci-image")]
+        let vfs_root_mount: Option<Arc<super::sandbox_fs::SandboxFsLocalMount>> =
+            if self.rafs_store.is_some() {
+                if let Some(image_id) = sandbox.image_id.clone() {
+                    let subject = Self::sandbox_subject(sandbox, annotations);
+                    let mount = self
+                        .compose_and_mount_vfs_root(sandbox, &image_id, subject)
+                        .await?;
+                    info!(
+                        sandbox_id = %sandbox.id,
+                        mountpoint = %mount.mountpoint().display(),
+                        "Mounted tenant VFS as nspawn container root (Model B, #715)"
+                    );
+                    Some(Arc::new(mount))
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+
+        #[cfg(feature = "oci-image")]
+        let vfs_root_mountpoint: Option<PathBuf> =
+            vfs_root_mount.as_ref().map(|m| m.mountpoint().to_path_buf());
+        #[cfg(not(feature = "oci-image"))]
+        let vfs_root_mountpoint: Option<PathBuf> = None;
+
         // Build argument list
         let nspawn_args = self.build_nspawn_args(
             sandbox,
             &machine_name,
             annotations,
             Some(&config.linux.resources),
+            vfs_root_mountpoint.as_deref(),
         );
 
         info!(
@@ -354,6 +516,8 @@ impl SandboxBackend for NspawnBackend {
             machine_name: machine_name.clone(),
             leader_pid,
             sandbox_path,
+            #[cfg(feature = "oci-image")]
+            vfs_root_mount,
         });
 
         info!(
@@ -588,10 +752,20 @@ inventory::submit! {
         // a separate follow-up — nspawn currently boots the inner hyprstream
         // service — but the socket-injection capability itself is real.)
         injects_9p_socket: true,
+        // Model B (#715): nspawn POSIX-roots the workload in the tenant VFS by
+        // FUSE-mounting the composed per-sandbox namespace at a host directory
+        // and handing it to the container — the non-VM sibling of kata's
+        // virtio-fs path. It advertises the capability so the fail-closed gate
+        // ([`require_fuse_mount_capability`]) permits the mount.
+        mounts_fuse_vfs: true,
         is_available: NspawnBackend::registry_is_available,
         construct: |_ctx| {
-            Ok(std::sync::Arc::new(NspawnBackend::new(NspawnConfig::default()))
-                as std::sync::Arc<dyn crate::runtime::SandboxBackend>)
+            #[cfg(feature = "oci-image")]
+            let backend = NspawnBackend::new(NspawnConfig::default())
+                .with_rafs_store(Some(std::sync::Arc::clone(&_ctx.rafs_store)));
+            #[cfg(not(feature = "oci-image"))]
+            let backend = NspawnBackend::new(NspawnConfig::default());
+            Ok(std::sync::Arc::new(backend) as std::sync::Arc<dyn crate::runtime::SandboxBackend>)
         },
     }
 }
@@ -616,6 +790,8 @@ mod tests {
             machine_name: "hyprstream-test-123".into(),
             leader_pid: Some(42),
             sandbox_path: PathBuf::from("/tmp/test"),
+            #[cfg(feature = "oci-image")]
+            vfs_root_mount: None,
         };
 
         let handle: Arc<dyn SandboxHandle> = Arc::new(handle);

--- a/crates/hyprstream-workers/src/runtime/oci_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/oci_backend.rs
@@ -1031,7 +1031,7 @@ mod tests {
         );
         ann.insert("hyprstream.io/command".into(), "/usr/local/bin/wanix-guest".into());
 
-        let args = backend.build_run_args(&pod, "hyprstream-sb-9p", "alpine:latest", &cfg, &ann);
+        let args = backend.build_run_args(&pod, "hyprstream-sb-9p", "alpine:latest", &cfg, &ann, None);
 
         // Injected socket bind + env are threaded.
         assert!(args

--- a/crates/hyprstream-workers/src/runtime/oci_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/oci_backend.rs
@@ -57,6 +57,25 @@ use crate::error::{Result, WorkerError};
 use super::backend::{SandboxBackend, SandboxHandle};
 use super::client::{LinuxContainerResources, PodSandboxConfig};
 use super::sandbox::PodSandbox;
+#[cfg(feature = "oci-image")]
+use crate::image::RafsStore;
+
+/// Sub-directory of the per-sandbox runtime dir where the tenant VFS is
+/// FUSE-mounted for Model B (#715) POSIX-rooting. Mirrors nspawn's `VFS_ROOT_DIR`.
+#[cfg(feature = "oci-image")]
+const VFS_ROOT_DIR: &str = "vfs-root";
+
+/// Container path the tenant VFS FUSE mount is bind-mounted to (Model B, #715).
+///
+/// Unlike nspawn — which POSIX-roots the whole container at the FUSE mount via
+/// `--directory=<mountpoint>` — a rootless podman container keeps its own OCI
+/// image rootfs, so the composed tenant VFS (image rootfs CoW upper + injected
+/// `/models`, `/deltas`, `/stream`) is instead bind-mounted **into** the
+/// container at this well-known path via the same `--volume` seam podman already
+/// uses for `hyprstream.io/mount.*` annotations. The workload reads its tenant
+/// namespace here.
+#[cfg(feature = "oci-image")]
+const VFS_ROOT_CTR_PATH: &str = "/hyprstream";
 
 /// Annotation key: OCI image reference to run (overrides [`OciConfig::default_image`]).
 const ANN_OCI_IMAGE: &str = "hyprstream.io/oci-image";
@@ -162,6 +181,14 @@ pub struct OciHandle {
     pub container_id: Option<String>,
     /// Host-side sandbox directory for bind-mounts.
     pub sandbox_path: PathBuf,
+    /// Per-sandbox tenant-VFS FUSE mount (Model B, #715). When set, the composed
+    /// namespace is FUSE-mounted at this handle's host directory and
+    /// bind-mounted into the container at [`VFS_ROOT_CTR_PATH`]. Held here
+    /// (behind `Arc`) for the sandbox's lifetime so the mount — and its serving
+    /// thread + injected registries — outlive container start; it is unmounted
+    /// when the last handle clone drops (RAII), i.e. on sandbox stop/destroy.
+    #[cfg(feature = "oci-image")]
+    pub vfs_root_mount: Option<Arc<super::sandbox_fs::SandboxFsLocalMount>>,
 }
 
 impl SandboxHandle for OciHandle {
@@ -177,11 +204,34 @@ impl SandboxHandle for OciHandle {
 /// Rootless OCI (podman) sandbox backend.
 pub struct OciBackend {
     config: OciConfig,
+    /// RAFS image store for composing the per-sandbox tenant VFS that Model B
+    /// (#715) FUSE-mounts and bind-mounts into the container. `None` when no
+    /// store was provided; the field exists only when the image service
+    /// (`oci-image`) is compiled in. Without a store, oci behaves exactly as
+    /// before — a plain image-rooted container, no tenant-VFS bind.
+    #[cfg(feature = "oci-image")]
+    rafs_store: Option<Arc<RafsStore>>,
 }
 
 impl OciBackend {
     pub fn new(config: OciConfig) -> Self {
-        Self { config }
+        Self {
+            config,
+            #[cfg(feature = "oci-image")]
+            rafs_store: None,
+        }
+    }
+
+    /// Attach the RAFS image store used to compose the per-sandbox tenant VFS
+    /// for Model B (#715) FUSE-rooting. Threaded in from [`BackendCtx`] at
+    /// selection time (see the inventory registration below), exactly as the
+    /// nspawn backend does. Without a store, oci behaves exactly as before.
+    ///
+    /// [`BackendCtx`]: super::selection::BackendCtx
+    #[cfg(feature = "oci-image")]
+    pub fn with_rafs_store(mut self, rafs_store: Option<Arc<RafsStore>>) -> Self {
+        self.rafs_store = rafs_store;
+        self
     }
 
     /// Stable container name for a sandbox id.
@@ -223,10 +273,104 @@ impl OciBackend {
             .unwrap_or_else(|| self.config.default_image.clone())
     }
 
+    /// Annotation key carrying the sandbox's policy principal (the [`Subject`]
+    /// at the VFS Mount boundary, #353/#319/#328) — the same key the kata and
+    /// nspawn backends read. When absent, the sandbox id is used as a stable
+    /// per-sandbox principal so isolation still holds. MAC-conservative: one
+    /// single-`Subject` `VfsFileSystem` per sandbox, no uid→Subject mapping.
+    ///
+    /// [`Subject`]: hyprstream_vfs::Subject
+    #[cfg(feature = "oci-image")]
+    const SUBJECT_ANNOTATION: &'static str = "hyprstream.io/subject";
+
+    /// Resolve the [`Subject`](hyprstream_vfs::Subject) this sandbox's tenant
+    /// VFS is served under (mirrors `NspawnBackend::sandbox_subject` and
+    /// `KataBackend::sandbox_subject` — same key, same fallback).
+    #[cfg(feature = "oci-image")]
+    fn sandbox_subject(
+        sandbox: &PodSandbox,
+        annotations: &HashMap<String, String>,
+    ) -> hyprstream_vfs::Subject {
+        annotations
+            .get(Self::SUBJECT_ANNOTATION)
+            .filter(|s| !s.is_empty())
+            .map(hyprstream_vfs::Subject::new)
+            .unwrap_or_else(|| hyprstream_vfs::Subject::new(sandbox.id.clone()))
+    }
+
+    /// Compose the per-sandbox tenant VFS (image rootfs + injected mounts) and
+    /// FUSE-mount it at a per-sandbox host directory (Model B, #715) — the
+    /// rootless-OCI sibling of nspawn's `compose_and_mount_vfs_root`.
+    ///
+    /// Returns the RAII [`SandboxFsLocalMount`](super::sandbox_fs::SandboxFsLocalMount);
+    /// the container then bind-mounts its `mountpoint()` at [`VFS_ROOT_CTR_PATH`]
+    /// (unlike nspawn, podman keeps its own image rootfs, so the tenant VFS is a
+    /// volume rather than the container root). Compose is CPU/IO-bound (RAFS
+    /// load), so it runs on a blocking thread; the mount's own serving thread is
+    /// spawned inside `serve_local_at`. The
+    /// [`require_fuse_mount_capability`](super::selection::require_fuse_mount_capability)
+    /// gate asserts oci is declared able to FUSE-mount before we mount
+    /// (fail-closed).
+    #[cfg(feature = "oci-image")]
+    async fn compose_and_mount_vfs_root(
+        &self,
+        sandbox: &PodSandbox,
+        image_id: &str,
+        subject: hyprstream_vfs::Subject,
+    ) -> Result<super::sandbox_fs::SandboxFsLocalMount> {
+        use super::sandbox_fs::SandboxFs;
+        use hyprstream_vfs::injected::SyntheticNode;
+
+        let rafs_store = self.rafs_store.clone().ok_or_else(|| {
+            WorkerError::SandboxCreationFailed(
+                "oci tenant-VFS mount requested but no RAFS image store is configured".into(),
+            )
+        })?;
+
+        // Fail-closed capability gate (#715): only POSIX-root the composed VFS
+        // for a backend that declares it can FUSE-mount it. oci does (rootless
+        // `/dev/fuse` feasibility measured positive on the target host).
+        super::selection::require_fuse_mount_capability(self.backend_type())?;
+
+        let mountpoint = sandbox.sandbox_path().join(VFS_ROOT_DIR);
+        let rt = tokio::runtime::Handle::current();
+        let image_id = image_id.to_owned();
+        let sandbox_dir = sandbox.sandbox_path().clone();
+        let mp = mountpoint.clone();
+
+        // RAFS load + overlay setup is blocking; do it off the async executor.
+        tokio::task::spawn_blocking(move || {
+            let fs = SandboxFs::compose(
+                &rafs_store,
+                &image_id,
+                &sandbox_dir,
+                subject,
+                // Models / deltas injected listings: empty mount points for now
+                // (the worker runtime populates them per tenant), mirroring
+                // nspawn and kata.
+                SyntheticNode::dir(),
+                SyntheticNode::dir(),
+            )?;
+            fs.serve_local_at(rt, mp)
+        })
+        .await
+        .map_err(|e| {
+            WorkerError::SandboxCreationFailed(format!("VFS compose/mount task join: {e}"))
+        })?
+    }
+
     /// Build the `podman run` argument list for a sandbox, threading the full CRI
     /// [`PodSandboxConfig`] (metadata, labels, annotations, resources, security
     /// context) into the invocation. `annotations` is the canonical annotation
     /// map supplied by the pool; it also drives image/env/mount/gpu selection.
+    ///
+    /// `vfs_root` is the host directory the tenant VFS was FUSE-mounted at (Model
+    /// B, #715). When `Some`, it is bind-mounted into the container at
+    /// [`VFS_ROOT_CTR_PATH`] via the same `--volume` seam podman already uses for
+    /// `hyprstream.io/mount.*` annotations; podman keeps its own OCI image
+    /// rootfs, so the tenant VFS is a mount *into* the container rather than its
+    /// root (the difference from nspawn's `--directory` rooting).
+    #[cfg_attr(not(feature = "oci-image"), allow(unused_variables))]
     fn build_run_args(
         &self,
         sandbox: &PodSandbox,
@@ -234,6 +378,7 @@ impl OciBackend {
         image: &str,
         config: &PodSandboxConfig,
         annotations: &HashMap<String, String>,
+        vfs_root: Option<&Path>,
     ) -> Vec<String> {
         let mut args: Vec<String> = vec!["run".into(), "--detach".into()];
 
@@ -294,6 +439,15 @@ impl OciBackend {
                     warn!(sandbox_id = %sandbox.id, spec = %v, "ignoring malformed mount annotation");
                 }
             }
+        }
+
+        // Model B (#715): bind the composed tenant-VFS FUSE mount into the
+        // container at a well-known path (reusing the same `--volume` seam as the
+        // annotation mounts above). Rootless podman keeps its own image rootfs,
+        // so the tenant VFS is a volume rather than the container root.
+        #[cfg(feature = "oci-image")]
+        if let Some(root) = vfs_root {
+            args.push(format!("--volume={}:{}", root.display(), VFS_ROOT_CTR_PATH));
         }
 
         // GPU pass-through when requested.
@@ -462,8 +616,49 @@ impl SandboxBackend for OciBackend {
         tokio::fs::create_dir_all(&sandbox_path).await?;
         sandbox.sandbox_path = sandbox_path.clone();
 
-        let run_args =
-            self.build_run_args(sandbox, &container_name, &image, config, annotations);
+        // Model B (#715): when an image store is configured and the sandbox
+        // names an image, compose the per-sandbox tenant VFS and FUSE-mount it,
+        // then bind that host directory into the container so the workload sees
+        // the tenant VFS — the rootless-OCI sibling of nspawn's `--directory`
+        // rooting and kata's virtio-fs path. Held on the handle so it outlives
+        // start and unmounts on teardown (RAII). Without a store (or image), oci
+        // stays a plain image-rooted container exactly as before.
+        #[cfg(feature = "oci-image")]
+        let vfs_root_mount: Option<Arc<super::sandbox_fs::SandboxFsLocalMount>> =
+            if self.rafs_store.is_some() {
+                if let Some(image_id) = sandbox.image_id.clone() {
+                    let subject = Self::sandbox_subject(sandbox, annotations);
+                    let mount = self
+                        .compose_and_mount_vfs_root(sandbox, &image_id, subject)
+                        .await?;
+                    info!(
+                        sandbox_id = %sandbox.id,
+                        mountpoint = %mount.mountpoint().display(),
+                        ctr_path = %VFS_ROOT_CTR_PATH,
+                        "Mounted tenant VFS into OCI container (Model B, #715)"
+                    );
+                    Some(Arc::new(mount))
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+
+        #[cfg(feature = "oci-image")]
+        let vfs_root_mountpoint: Option<PathBuf> =
+            vfs_root_mount.as_ref().map(|m| m.mountpoint().to_path_buf());
+        #[cfg(not(feature = "oci-image"))]
+        let vfs_root_mountpoint: Option<PathBuf> = None;
+
+        let run_args = self.build_run_args(
+            sandbox,
+            &container_name,
+            &image,
+            config,
+            annotations,
+            vfs_root_mountpoint.as_deref(),
+        );
 
         info!(
             sandbox_id = %sandbox.id,
@@ -505,6 +700,8 @@ impl SandboxBackend for OciBackend {
             image,
             container_id: container_id.clone(),
             sandbox_path,
+            #[cfg(feature = "oci-image")]
+            vfs_root_mount,
         });
 
         sandbox.mark_ready();
@@ -658,17 +855,22 @@ inventory::submit! {
         // hyprstream can inject a host 9P Unix socket into the workload's mount
         // namespace (#506) and set `HYPRSTREAM_9P_SOCK` for the guest to dial.
         injects_9p_socket: true,
-        // TODO(#715): rootless-userns /dev/fuse feasibility spike before enabling
-        // OCI. Model B FUSE-rooting of the tenant VFS is deferred for the rootless
-        // OCI (podman) backend: whether an unprivileged `/dev/fuse` mount composes
-        // with podman `--userns=keep-id` uid remapping is unresolved (#653/#617),
-        // so oci does not advertise the capability yet (fail-closed — an explicit
-        // FUSE-root request against oci is refused until this is validated).
-        mounts_fuse_vfs: false,
+        // Model B (#715): the rootless-userns `/dev/fuse` feasibility spike is
+        // resolved — measured positive on the target host (`/dev/fuse` opens in a
+        // rootless userns; rootless podman already runs on fuse-overlayfs). So oci
+        // composes the per-sandbox tenant VFS, FUSE-mounts it, and bind-mounts it
+        // into the container (the sibling of nspawn's `--directory` rooting and
+        // kata's virtio-fs path). It advertises the capability so the fail-closed
+        // gate ([`require_fuse_mount_capability`]) permits the mount.
+        mounts_fuse_vfs: true,
         is_available: OciBackend::registry_is_available,
         construct: |_ctx| {
-            Ok(std::sync::Arc::new(OciBackend::new(OciConfig::default()))
-                as std::sync::Arc<dyn crate::runtime::SandboxBackend>)
+            #[cfg(feature = "oci-image")]
+            let backend = OciBackend::new(OciConfig::default())
+                .with_rafs_store(Some(std::sync::Arc::clone(&_ctx.rafs_store)));
+            #[cfg(not(feature = "oci-image"))]
+            let backend = OciBackend::new(OciConfig::default());
+            Ok(std::sync::Arc::new(backend) as std::sync::Arc<dyn crate::runtime::SandboxBackend>)
         },
     }
 }
@@ -706,6 +908,8 @@ mod tests {
             image: "img:latest".into(),
             container_id: Some("deadbeef".into()),
             sandbox_path: PathBuf::from("/tmp/x"),
+            #[cfg(feature = "oci-image")]
+            vfs_root_mount: None,
         });
         let down = handle.as_any().downcast_ref::<OciHandle>();
         assert!(down.is_some());
@@ -785,6 +989,7 @@ mod tests {
             "alpine:latest",
             &cfg,
             &ann,
+            None,
         );
 
         // Identity threaded.
@@ -800,6 +1005,8 @@ mod tests {
         assert!(args.contains(&"--env=HYPRSTREAM_INSTANCE=sb-1".to_owned()));
         // Resources threaded.
         assert!(args.contains(&"--memory=134217728".to_owned()));
+        // No tenant-VFS bind when no FUSE mount was composed.
+        assert!(!args.iter().any(|a| a.contains(":/hyprstream")));
         // Image is the last positional argument.
         assert_eq!(args.last().unwrap(), "alpine:latest");
     }
@@ -843,5 +1050,45 @@ mod tests {
         // Single source of truth: the OCI consumer key must equal the wanix
         // producer key (both are the same wire annotation).
         assert_eq!(ANN_COMMAND, super::super::wanix_workload::ANN_WANIX_COMMAND);
+    }
+
+    /// Model B (#715): the OCI backend must advertise the FUSE tenant-VFS mount
+    /// capability in the real inventory now that rootless `/dev/fuse`
+    /// feasibility is confirmed, so the fail-closed gate resolves it Ok. This is
+    /// the sibling assertion to `nspawn_advertises_fuse_mount_capability_*`.
+    #[test]
+    fn oci_advertises_fuse_mount_capability_in_real_inventory() {
+        assert!(
+            crate::runtime::selection::require_fuse_mount_capability("oci").is_ok(),
+            "oci must advertise mounts_fuse_vfs (Model B #715)"
+        );
+    }
+
+    /// Model B (#715): when a tenant VFS was FUSE-mounted, its host directory is
+    /// bind-mounted into the container at the well-known path via the same
+    /// `--volume` seam as annotation mounts. Only meaningful when the image
+    /// service is compiled in (the mount path is `oci-image`-gated).
+    #[cfg(feature = "oci-image")]
+    #[test]
+    fn run_args_bind_tenant_vfs_when_present() {
+        let backend = OciBackend::new(OciConfig::default());
+        let cfg = PodSandboxConfig::default();
+        let pod = new_pod("sb-vfs", &cfg);
+        let ann = HashMap::new();
+
+        let mount = PathBuf::from("/run/hyprstream/sb-vfs/vfs-root");
+        let args = backend.build_run_args(
+            &pod,
+            "hyprstream-sb-vfs",
+            "alpine:latest",
+            &cfg,
+            &ann,
+            Some(mount.as_path()),
+        );
+
+        assert!(
+            args.contains(&format!("--volume={}:{}", mount.display(), VFS_ROOT_CTR_PATH)),
+            "tenant VFS must be bind-mounted at {VFS_ROOT_CTR_PATH}; got: {args:?}"
+        );
     }
 }

--- a/crates/hyprstream-workers/src/runtime/oci_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/oci_backend.rs
@@ -658,6 +658,13 @@ inventory::submit! {
         // hyprstream can inject a host 9P Unix socket into the workload's mount
         // namespace (#506) and set `HYPRSTREAM_9P_SOCK` for the guest to dial.
         injects_9p_socket: true,
+        // TODO(#715): rootless-userns /dev/fuse feasibility spike before enabling
+        // OCI. Model B FUSE-rooting of the tenant VFS is deferred for the rootless
+        // OCI (podman) backend: whether an unprivileged `/dev/fuse` mount composes
+        // with podman `--userns=keep-id` uid remapping is unresolved (#653/#617),
+        // so oci does not advertise the capability yet (fail-closed — an explicit
+        // FUSE-root request against oci is refused until this is validated).
+        mounts_fuse_vfs: false,
         is_available: OciBackend::registry_is_available,
         construct: |_ctx| {
             Ok(std::sync::Arc::new(OciBackend::new(OciConfig::default()))

--- a/crates/hyprstream-workers/src/runtime/sandbox_fs.rs
+++ b/crates/hyprstream-workers/src/runtime/sandbox_fs.rs
@@ -372,27 +372,46 @@ impl std::fmt::Debug for SandboxFsLocalMount {
 impl Drop for SandboxFsLocalMount {
     fn drop(&mut self) {
         // `serve_local` blocks until the FUSE session ends; unmount to make it
-        // return. `fusermount3 -u` tears down the kernel mount unprivileged (for
-        // a mount owned by this uid), which the serving thread observes as the
-        // session closing and exits its loop. Best-effort: if the mount never
-        // came up (e.g. no `/dev/fuse`), the unmount is a harmless no-op and the
-        // thread has already exited.
-        let unmounted = std::process::Command::new("fusermount3")
-            .arg("-u")
-            .arg(&self.mountpoint)
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false);
-        if !unmounted {
-            let _ = std::process::Command::new("fusermount")
-                .arg("-u")
-                .arg(&self.mountpoint)
-                .status();
+        // return. A non-lazy `fusermount3 -u` tears down the kernel mount
+        // unprivileged (for a mount owned by this uid), which the serving thread
+        // observes as the session closing and exits its loop. Best-effort: if
+        // the mount never came up (e.g. no `/dev/fuse`), the unmount is a
+        // harmless no-op and the thread has already exited.
+        //
+        // If the clean unmount fails because the mount is still busy (a workload
+        // process still has it open), fall back to a LAZY unmount (`-uz`): the
+        // kernel detaches the mount as soon as it stops being referenced, which
+        // still closes the FUSE session so the serving thread exits. Without this
+        // fallback a busy mount would leave the session open and the
+        // `thread.join()` below would block forever, hanging the runtime thread
+        // that dropped this handle.
+        if !fusermount_unmount(&self.mountpoint, false) {
+            let _ = fusermount_unmount(&self.mountpoint, true);
         }
         if let Some(thread) = self.thread.take() {
             let _ = thread.join();
         }
     }
+}
+
+/// Unmount the FUSE mount at `mountpoint`, trying `fusermount3` then the older
+/// `fusermount`. With `lazy = true` uses `-uz` (detach-when-idle), which
+/// succeeds even when the mount is busy; with `lazy = false` uses a clean `-u`.
+/// Returns whether either tool reported success.
+fn fusermount_unmount(mountpoint: &Path, lazy: bool) -> bool {
+    let flag = if lazy { "-uz" } else { "-u" };
+    for tool in ["fusermount3", "fusermount"] {
+        let ok = std::process::Command::new(tool)
+            .arg(flag)
+            .arg(mountpoint)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if ok {
+            return true;
+        }
+    }
+    false
 }
 
 fn socket_filename(path: &Path) -> String {

--- a/crates/hyprstream-workers/src/runtime/sandbox_fs.rs
+++ b/crates/hyprstream-workers/src/runtime/sandbox_fs.rs
@@ -48,7 +48,7 @@ use std::sync::Arc;
 
 use hyprstream_vfs::injected::{StreamMount, StreamRegistry, SyntheticMount, SyntheticNode};
 use hyprstream_vfs::{Mount, Namespace, Subject};
-use hyprstream_vfs_server::{serve, VfsFileSystem};
+use hyprstream_vfs_server::{serve, serve_local, VfsFileSystem};
 
 use crate::error::{Result, WorkerError};
 use crate::image::{image_fs_for, RafsStore};
@@ -234,6 +234,81 @@ impl SandboxFs {
             _thread: thread,
         })
     }
+
+    /// FUSE-mount this composed namespace at `mountpoint` as a real host
+    /// directory — the **non-VM sibling of [`serve_on`]** (Model B, #715).
+    ///
+    /// Where [`serve_on`] serves the [`VfsFileSystem`] to a **VM** guest over
+    /// vhost-user-fs (virtio-fs), this serves the *same* down-adapter to the
+    /// **host kernel** over `/dev/fuse` via
+    /// [`hyprstream_vfs_server::serve_local`], so a non-VM sandbox (e.g.
+    /// `systemd-nspawn --directory=<mountpoint>`) can POSIX-root its workload
+    /// directly in the tenant's composed VFS. Any host process that enters the
+    /// sandbox — the inference workload, a shell — then sees the tenant VFS as
+    /// its filesystem, closing the "run a task" gap (#506) for the POSIX case.
+    ///
+    /// ## Subject preservation (MAC-conservative)
+    ///
+    /// The [`Subject`] is preserved **automatically**: [`into_filesystem`] bakes
+    /// it into the [`VfsFileSystem`], so every VFS op driven over the FUSE
+    /// channel is attributed to this sandbox's single Subject at the Mount
+    /// boundary (Subject-per-call). Because the mount is **per-sandbox** and
+    /// served under **one** Subject, there is no uid→Subject mapping to invent
+    /// (and none is invented): every operation over this mount is correctly
+    /// attributed to the sandbox principal, exactly as the virtio-fs path is.
+    ///
+    /// Rootless-userns uid-mapping / `allow_other` nuances (e.g. an unprivileged
+    /// `/dev/fuse` under a podman `--userns=keep-id` remapping) are **out of
+    /// scope** for the nspawn target, which runs closer to the host; they are
+    /// deferred to the OCI/rootless-FUSE feasibility spike (#715 / #617).
+    ///
+    /// [`serve_local`] **blocks** until the mount is torn down, so it runs on a
+    /// dedicated OS thread; the returned [`SandboxFsLocalMount`] unmounts and
+    /// joins that thread on drop (RAII), mirroring [`SandboxFsServer`].
+    ///
+    /// `mountpoint` is created (`create_dir_all`) if absent. `rt` is captured for
+    /// the down-adapter's async→sync bridge.
+    ///
+    /// [`into_filesystem`]: SandboxFs::into_filesystem
+    pub fn serve_local_at(
+        self,
+        rt: tokio::runtime::Handle,
+        mountpoint: PathBuf,
+    ) -> Result<SandboxFsLocalMount> {
+        std::fs::create_dir_all(&mountpoint).map_err(|e| {
+            WorkerError::SandboxCreationFailed(format!(
+                "create FUSE mountpoint {}: {e}",
+                mountpoint.display()
+            ))
+        })?;
+
+        let (fs, injected) = self.into_filesystem(rt);
+
+        let mp = mountpoint.clone();
+        // `serve_local` blocks until the FUSE session ends; run it on a dedicated
+        // OS thread (the down-adapter's `block_on` uses the captured runtime
+        // handle, not this thread's executor).
+        let thread = std::thread::Builder::new()
+            .name(format!("vfs-fuse-{}", socket_filename(&mountpoint)))
+            .spawn(move || {
+                if let Err(e) = serve_local(fs, &mp) {
+                    tracing::error!(
+                        mountpoint = %mp.display(),
+                        error = %e,
+                        "FUSE VFS mount exited with error"
+                    );
+                }
+            })
+            .map_err(|e| {
+                WorkerError::SandboxCreationFailed(format!("spawn FUSE VFS mount thread: {e}"))
+            })?;
+
+        Ok(SandboxFsLocalMount {
+            mountpoint,
+            injected,
+            thread: Some(thread),
+        })
+    }
 }
 
 /// A running per-sandbox VFS server: owns the socket path and injected handles.
@@ -255,6 +330,68 @@ impl SandboxFsServer {
     /// Runtime handles for the injected mounts (feed `/stream` here).
     pub fn injected(&self) -> &InjectedMounts {
         &self.injected
+    }
+}
+
+/// A running per-sandbox VFS **FUSE mount** at a host directory: the non-VM
+/// sibling of [`SandboxFsServer`] (Model B, #715).
+///
+/// Owns the mountpoint, the injected-mount handles, and the OS thread running
+/// the blocking [`hyprstream_vfs_server::serve_local`] session loop. Dropping it
+/// unmounts the FUSE mount (`fusermount3 -u`, which is unprivileged for a mount
+/// owned by this uid) — which makes the kernel close the `/dev/fuse` session so
+/// the serving thread's loop returns — then joins the thread. This is what makes
+/// the tenant VFS disappear from the host when the sandbox is stopped/destroyed.
+pub struct SandboxFsLocalMount {
+    mountpoint: PathBuf,
+    injected: InjectedMounts,
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl SandboxFsLocalMount {
+    /// The host directory the tenant VFS is FUSE-mounted at (give this to the
+    /// container as its root, or as a bind-mount source).
+    pub fn mountpoint(&self) -> &Path {
+        &self.mountpoint
+    }
+
+    /// Runtime handles for the injected mounts (feed `/stream` here).
+    pub fn injected(&self) -> &InjectedMounts {
+        &self.injected
+    }
+}
+
+impl std::fmt::Debug for SandboxFsLocalMount {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SandboxFsLocalMount")
+            .field("mountpoint", &self.mountpoint)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for SandboxFsLocalMount {
+    fn drop(&mut self) {
+        // `serve_local` blocks until the FUSE session ends; unmount to make it
+        // return. `fusermount3 -u` tears down the kernel mount unprivileged (for
+        // a mount owned by this uid), which the serving thread observes as the
+        // session closing and exits its loop. Best-effort: if the mount never
+        // came up (e.g. no `/dev/fuse`), the unmount is a harmless no-op and the
+        // thread has already exited.
+        let unmounted = std::process::Command::new("fusermount3")
+            .arg("-u")
+            .arg(&self.mountpoint)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !unmounted {
+            let _ = std::process::Command::new("fusermount")
+                .arg("-u")
+                .arg(&self.mountpoint)
+                .status();
+        }
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
     }
 }
 
@@ -468,6 +605,54 @@ mod tests {
         // Injected handles survive the move into the adapter.
         injected.stream_registry.register("x", None);
         assert!(injected.stream_registry.exists("x"));
+    }
+
+    /// Model B (#715): `serve_local_at` is the FUSE sibling of `serve_on`. It
+    /// returns an RAII [`SandboxFsLocalMount`] carrying the mountpoint + injected
+    /// handles, and dropping it tears the mount down. A real `/dev/fuse` mount
+    /// can't be exercised in most CI/build sandboxes (no device node or usable
+    /// `fusermount3`), so this asserts the handle *shape* only — the serving
+    /// thread may fail to mount and exit immediately, which drop tolerates. The
+    /// live end-to-end mount is validated on a real host (mirroring the
+    /// `hyprstream-vfs-server` `local_fuse_mount_read_and_readdir` test, which
+    /// self-skips when the environment can't do a real FUSE mount).
+    #[test]
+    fn serve_local_at_returns_raii_mount_handle() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = store_with_image(tmp.path(), "img:l", &[("etc/hostname", b"h\n")]);
+        let fs = SandboxFs::compose(
+            &store,
+            "img:l",
+            &tmp.path().join("sandbox"),
+            Subject::new("tenant"),
+            SyntheticNode::dir(),
+            SyntheticNode::dir(),
+        )
+        .unwrap();
+
+        // The down-adapter's `block_on` must run on a runtime distinct from the
+        // calling thread, so a multi-thread handle held for the whole test.
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let mountpoint = tmp.path().join("vfs-root");
+        let mount = fs
+            .serve_local_at(rt.handle().clone(), mountpoint.clone())
+            .expect("serve_local_at returns a mount handle even if the mount can't come up");
+
+        // `serve_local_at` created the mountpoint dir and reports it back.
+        assert!(mountpoint.is_dir(), "mountpoint should be created");
+        assert_eq!(mount.mountpoint(), mountpoint);
+
+        // Injected handles survive into the RAII mount handle.
+        mount.injected().stream_registry.register("x", None);
+        assert!(mount.injected().stream_registry.exists("x"));
+
+        // Drop unmounts + joins; tolerates a mount that never came up.
+        drop(mount);
     }
 
     /// The FS-A down-adapter serves the composed namespace: driving the

--- a/crates/hyprstream-workers/src/runtime/selection.rs
+++ b/crates/hyprstream-workers/src/runtime/selection.rs
@@ -45,9 +45,9 @@ use std::sync::Arc;
 use crate::config::PoolConfig;
 use crate::error::{Result, WorkerError};
 
-#[cfg(feature = "kata-vm")]
+#[cfg(feature = "oci-image")]
 use crate::config::ImageConfig;
-#[cfg(feature = "kata-vm")]
+#[cfg(feature = "oci-image")]
 use crate::image::RafsStore;
 
 use super::SandboxBackend;
@@ -61,13 +61,18 @@ pub struct BackendCtx {
     /// Sandbox pool configuration (paths, hypervisor, limits).
     pub pool_config: PoolConfig,
 
-    /// Image storage configuration. Only the VM (`kata-vm`) path consumes the
-    /// RAFS/nydus image store, so this field only exists on that build.
-    #[cfg(feature = "kata-vm")]
+    /// Image storage configuration. Any backend that composes the RAFS image
+    /// filesystem (kata over virtio-fs, or nspawn over FUSE — Model B #715)
+    /// consumes it, so it exists on the `oci-image` build, not just `kata-vm`.
+    /// The Cargo manifest is explicit that the RAFS image service "lives on
+    /// oci-image, not kata-vm".
+    #[cfg(feature = "oci-image")]
     pub image_config: ImageConfig,
 
-    /// RAFS/nydus image store — VM-only (`kata-vm`).
-    #[cfg(feature = "kata-vm")]
+    /// RAFS/nydus image store — available whenever the image filesystem service
+    /// is compiled in (`oci-image`), so both the kata (virtio-fs) and nspawn
+    /// (FUSE, #715) backends can compose a per-sandbox VFS from it.
+    #[cfg(feature = "oci-image")]
     pub rafs_store: Arc<RafsStore>,
 }
 
@@ -125,6 +130,21 @@ pub struct BackendRegistration {
     /// [`require_9p_socket_capability`]) never resolves to a backend that does
     /// not advertise it — it errors rather than silently dropping the injection.
     pub injects_9p_socket: bool,
+    /// Whether this backend **FUSE-mounts the composed per-sandbox tenant VFS**
+    /// as a real host directory and POSIX-roots its workload there (Model B,
+    /// #715 — the non-VM sibling of the kata virtio-fs path).
+    ///
+    /// `true` → the backend consumes `SandboxFs::serve_local_at` to serve the
+    /// composed namespace over `/dev/fuse` and give that host directory to the
+    /// container. `nspawn` sets this. `kata` does **not** — it already shares the
+    /// composed VFS as a virtio-fs device, not a host FUSE mount. In-process
+    /// `wasm` has no host filesystem to mount into. `oci` is deferred pending a
+    /// rootless `/dev/fuse` feasibility spike and advertises `false` for now.
+    ///
+    /// [`require_fuse_mount_capability`] gates the mount fail-closed: a backend
+    /// that does not advertise this capability is never handed a FUSE-rooted
+    /// namespace (no silent POSIX-rooting in a namespace a backend can't mount).
+    pub mounts_fuse_vfs: bool,
 
     /// Runtime prerequisite probe (PATH lookups, socket existence, …). Returns
     /// `true` when this backend can actually run on this host *right now*. Used
@@ -354,6 +374,40 @@ pub fn require_9p_socket_capability(backend_type: &str) -> Result<()> {
     }
 }
 
+/// Pure capability check over a registration set, with the same fail-closed
+/// contract as [`select_registration`]. Factored out so the Model B (#715)
+/// FUSE-mount gate is unit-testable without depending on which backends the
+/// build's inventory happens to contain.
+fn check_fuse_mount_capability(name: &str, regs: &[&BackendRegistration]) -> Result<()> {
+    match regs.iter().find(|r| r.name.eq_ignore_ascii_case(name)) {
+        Some(reg) if reg.mounts_fuse_vfs => Ok(()),
+        Some(reg) => Err(WorkerError::ConfigError(format!(
+            "sandbox backend '{}' does not advertise the FUSE tenant-VFS mount \
+             capability (mounts_fuse_vfs); refusing to POSIX-root a workload in a \
+             namespace this backend was not declared able to mount (fail-closed).",
+            reg.name
+        ))),
+        None => Err(WorkerError::ConfigError(format!(
+            "unknown sandbox backend '{name}'; cannot check FUSE tenant-VFS mount \
+             capability"
+        ))),
+    }
+}
+
+/// Fail-closed gate for Model B (#715): assert `backend_type` advertises the
+/// [`mounts_fuse_vfs`](BackendRegistration::mounts_fuse_vfs) capability before a
+/// caller FUSE-mounts the composed tenant VFS as that backend's root.
+///
+/// Parallels [`resolve_backend`]'s fail-closed contract: an unknown backend, or
+/// a registered one that does not advertise the capability, errors rather than
+/// proceeding — we never POSIX-root a workload in a namespace a backend was not
+/// declared able to mount, and never silently substitute a different transport.
+pub fn require_fuse_mount_capability(backend_type: &str) -> Result<()> {
+    let regs: Vec<&'static BackendRegistration> =
+        inventory::iter::<BackendRegistration>().collect();
+    check_fuse_mount_capability(backend_type, &regs)
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -374,6 +428,7 @@ mod tests {
         priority: 100,
         auto_selectable: true,
         injects_9p_socket: false,
+        mounts_fuse_vfs: false,
         is_available: || true,
         construct: never_available,
     };
@@ -382,6 +437,19 @@ mod tests {
         priority: 10,
         auto_selectable: true,
         injects_9p_socket: false,
+        mounts_fuse_vfs: false,
+        is_available: || true,
+        construct: never_available,
+    };
+
+    /// A FUSE-mount-capable backend, modeling the Model B (#715) nspawn target:
+    /// it advertises `mounts_fuse_vfs: true`.
+    const FUSE_CAP: BackendRegistration = BackendRegistration {
+        name: "fuse-tier",
+        priority: 50,
+        auto_selectable: true,
+        injects_9p_socket: false,
+        mounts_fuse_vfs: true,
         is_available: || true,
         construct: never_available,
     };
@@ -394,6 +462,7 @@ mod tests {
         priority: 1000,
         auto_selectable: false,
         injects_9p_socket: false,
+        mounts_fuse_vfs: false,
         is_available: || true,
         construct: never_available,
     };
@@ -404,6 +473,7 @@ mod tests {
         priority: 100,
         auto_selectable: true,
         injects_9p_socket: true,
+        mounts_fuse_vfs: false,
         is_available: || true,
         construct: never_available,
     };
@@ -413,6 +483,7 @@ mod tests {
         priority: 10,
         auto_selectable: true,
         injects_9p_socket: true,
+        mounts_fuse_vfs: false,
         is_available: || true,
         construct: never_available,
     };
@@ -645,6 +716,56 @@ mod tests {
     }
 
     // ── The real inventory must reflect the build's feature set ──
+
+    // ── Model B (#715): FUSE tenant-VFS mount capability gate ──
+
+    #[test]
+    fn fuse_capability_gate_allows_advertised_backend() {
+        let regs = vec![&FUSE_CAP, &LOW];
+        assert!(check_fuse_mount_capability("fuse-tier", &regs).is_ok());
+        // Case-insensitive, mirroring backend selection.
+        assert!(check_fuse_mount_capability("FUSE-TIER", &regs).is_ok());
+    }
+
+    #[test]
+    fn fuse_capability_gate_fails_closed_for_non_advertising_backend() {
+        // A registered backend that does NOT advertise the capability must be
+        // refused — no silent POSIX-rooting in a namespace it can't mount.
+        let regs = vec![&FUSE_CAP, &LOW];
+        let err = check_fuse_mount_capability("low-tier", &regs).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("does not advertise"), "got: {msg}");
+        assert!(msg.contains("fail-closed"), "got: {msg}");
+    }
+
+    #[test]
+    fn fuse_capability_gate_unknown_backend_errors() {
+        let regs = vec![&FUSE_CAP];
+        let err = check_fuse_mount_capability("bogus", &regs).unwrap_err();
+        assert!(
+            err.to_string().contains("unknown sandbox backend"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn nspawn_advertises_fuse_mount_capability_in_real_inventory() {
+        // The real inventory: nspawn is the Model B FUSE-root target (#715), so
+        // the public gate resolves it Ok. nspawn is always registered.
+        assert!(
+            require_fuse_mount_capability("nspawn").is_ok(),
+            "nspawn must advertise mounts_fuse_vfs"
+        );
+    }
+
+    #[cfg(feature = "kata-vm")]
+    #[test]
+    fn kata_does_not_advertise_fuse_mount_capability() {
+        // kata already shares the composed VFS via virtio-fs, not a host FUSE
+        // mount, so it must NOT advertise the capability (fail-closed).
+        let err = require_fuse_mount_capability("kata").unwrap_err();
+        assert!(err.to_string().contains("does not advertise"), "got: {err}");
+    }
 
     #[test]
     fn registry_contains_nspawn_always() {

--- a/crates/hyprstream-workers/src/runtime/wasm_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/wasm_backend.rs
@@ -486,6 +486,9 @@ inventory::submit! {
         // In-process (shared host address space); there is no separate mount
         // namespace to bind-inject a host 9P socket into (#506).
         injects_9p_socket: false,
+        // In-process wasm has no host filesystem to POSIX-root into, so it does
+        // not advertise the Model B (#715) host-FUSE-mount capability.
+        mounts_fuse_vfs: false,
         is_available: WasmBackend::registry_is_available,
         construct: |_ctx| {
             Ok(std::sync::Arc::new(WasmBackend::new(WasmConfig::default()))

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1087,7 +1087,7 @@ fn handle_quick_command(
                         cloud_init_dir: data_dir.join("cloud-init"),
                         ..PoolConfig::default()
                     };
-                    #[cfg(feature = "kata-vm")]
+                    #[cfg(feature = "oci-image")]
                     let image_config = ImageConfig {
                         blobs_dir: data_dir.join("images/blobs"),
                         bootstrap_dir: data_dir.join("images/bootstrap"),
@@ -1102,8 +1102,11 @@ fn handle_quick_command(
                             resolve_backend, BackendCtx, SandboxBackend,
                         };
 
-                        // RAFS image store is only built on the VM path (kata-vm).
-                        #[cfg(feature = "kata-vm")]
+                        // RAFS image store is built whenever the image filesystem
+                        // service is compiled in (`oci-image`), so both kata
+                        // (virtio-fs) and nspawn (FUSE tenant-VFS root, Model B
+                        // #715) can compose a per-sandbox VFS from it.
+                        #[cfg(feature = "oci-image")]
                         let rafs_store = {
                             use hyprstream_workers::image::RafsStore;
                             Arc::new(RafsStore::new(image_config.clone())?)
@@ -1121,9 +1124,9 @@ fn handle_quick_command(
                             .unwrap_or_else(|| "auto".to_owned());
                         let backend_ctx = BackendCtx {
                             pool_config: pool_config.clone(),
-                            #[cfg(feature = "kata-vm")]
+                            #[cfg(feature = "oci-image")]
                             image_config,
-                            #[cfg(feature = "kata-vm")]
+                            #[cfg(feature = "oci-image")]
                             rafs_store: Arc::clone(&rafs_store),
                         };
                         let backend: Arc<dyn SandboxBackend> =

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -49,7 +49,7 @@ use hyprstream_core::storage::{GitRef, ModelRef};
 use hyprstream_core::services::{PolicyClient, RegistryClient};
 // Worker service for Kata-based workload execution
 use hyprstream_workers::runtime::WorkerService;
-#[cfg(feature = "kata-vm")]
+#[cfg(feature = "oci-image")]
 use hyprstream_workers::ImageConfig;
 use hyprstream_workers::PoolConfig;
 use std::sync::Arc;

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -744,9 +744,9 @@ fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
     info!("Creating WorkerService");
 
     use hyprstream_workers::config::PoolConfig;
-    #[cfg(feature = "kata-vm")]
+    #[cfg(feature = "oci-image")]
     use hyprstream_workers::config::ImageConfig;
-    #[cfg(feature = "kata-vm")]
+    #[cfg(feature = "oci-image")]
     use hyprstream_workers::image::RafsStore;
     use hyprstream_workers::{resolve_backend, BackendCtx, SandboxBackend, WorkerService};
 
@@ -783,8 +783,10 @@ fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
         ..PoolConfig::default()
     };
 
-    // RAFS/nydus image store is only built for the VM path (kata-vm feature).
-    #[cfg(feature = "kata-vm")]
+    // RAFS/nydus image store is built whenever the image filesystem service is
+    // compiled in (`oci-image`), so both kata (virtio-fs) and nspawn (FUSE
+    // tenant-VFS root, Model B #715) can compose a per-sandbox VFS from it.
+    #[cfg(feature = "oci-image")]
     let image_config = ImageConfig {
         blobs_dir: data_dir.join("images/blobs"),
         bootstrap_dir: data_dir.join("images/bootstrap"),
@@ -794,7 +796,7 @@ fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
         ..ImageConfig::default()
     };
 
-    #[cfg(feature = "kata-vm")]
+    #[cfg(feature = "oci-image")]
     let rafs_store = Arc::new(RafsStore::new(image_config.clone())?);
 
     // Resolve + construct the backend fail-closed against the inventory registry
@@ -804,9 +806,9 @@ fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
     // `_ => nspawn` fallback (#507 / #518).
     let backend_ctx = BackendCtx {
         pool_config: pool_config.clone(),
-        #[cfg(feature = "kata-vm")]
+        #[cfg(feature = "oci-image")]
         image_config,
-        #[cfg(feature = "kata-vm")]
+        #[cfg(feature = "oci-image")]
         rafs_store: Arc::clone(&rafs_store),
     };
     let backend: Arc<dyn SandboxBackend> = resolve_backend(&backend_name, &backend_ctx)?;


### PR DESCRIPTION
Closes #715. Follow-on to #506 (Worker GA #341 / taxonomy #508).

Lets a **non-VM (systemd-nspawn) sandbox POSIX-root its workload in the tenant VFS** by FUSE-mounting the composed per-sandbox `Namespace` at a host directory — the non-VM sibling of kata's virtio-fs path. This resolves the "run a task in the mounted namespace" gap #506 left open: any host process in the sandbox (inference workload, shell) now sees the tenant VFS as its filesystem.

## Design (Model B, per the #715 spike)
Model A (Wanix-native task through NS) was rejected — Wanix's NS-routing task drivers are browser-only (`js && wasm`); the native driver runs host `os/exec` which bypasses NS. Model B uses the host kernel's own mount namespace instead — the POSIX analog of "the namespace *is* the filesystem".

- **`SandboxFs::serve_local_at(self, rt, mountpoint) -> SandboxFsLocalMount`** — the FUSE sibling of the existing `serve_on` (kata vhost-user-fs). Serves the *same* `VfsFileSystem` (from `into_filesystem`) over `/dev/fuse` via `hyprstream_vfs_server::serve_local` (#653) on a dedicated thread; RAII handle unmounts + joins on drop.
- **Subject preserved automatically, MAC-conservative:** the mount is per-sandbox under the single `Subject` baked into `VfsFileSystem`, so every op over it is correctly attributed — **no uid→Subject mapping is invented**. (ADR-651's "fuse boundary loses Subject" concern is sidestepped: one Subject per mount, not a multi-principal boundary.)
- **`mounts_fuse_vfs` capability + fail-closed `require_fuse_mount_capability`** (parallels #506's `injects_9p_socket`): nspawn=true, kata=false (already has virtio-fs), oci=false-for-now, wasm=false.
- **nspawn wiring:** compose → gate → `serve_local_at` → root the container (`--directory=<mountpoint>`); the mount handle lives on `NspawnHandle` and unmounts on stop/destroy.

## Explicitly deferred
- **OCI / rootless-userns FUSE** is NOT wired here (`// TODO(#715)`): whether `/dev/fuse` works inside rootless podman userns (uid mapping, `allow_other`, `/dev/fuse` access) needs its own feasibility spike. nspawn (closer to host) is the correct lower-risk first target.

## Structural change worth review
`BackendCtx`'s `rafs_store`/`image_config` were widened from `kata-vm` to `oci-image` gating (the Cargo manifest already declares the RAFS image service lives on `oci-image`, not `kata-vm`), so nspawn and kata compose from the same store. This touched `crates/hyprstream/src/bin/main.rs` + `src/services/factories.rs`. This introduces a **new build combo (oci-image without kata-vm)** — CI's full feature matrix is the gate for it.

## Verified vs. not (honest)
**Verified:** `cargo check`/`clippy -D warnings` clean for `hyprstream-workers` (default + `oci-image`) and `hyprstream-vfs-server`; `cargo test -p hyprstream-workers --features oci-image` = 107 passed (incl. new RAII-mount + capability-gate tests); selection tests 19 passed.
**NOT verified in-env:**
- Live `/dev/fuse` mount — no accessible `/dev/fuse`/`fusermount3` in the build sandbox (RAII test confirms drop tolerates a never-mounted handle, mirroring vfs-server's self-skipping FUSE test). **Needs a real systemd-nspawn host for end-to-end.**
- Full `-p hyprstream` build (libtorch-heavy) for the `main.rs`/`factories.rs` cfg swaps — mechanical `kata-vm`→`oci-image` edits; **CI is the gate** (a local libtorch check was run alongside this PR).

## Follow-ups
- OCI/rootless-FUSE feasibility spike + wiring (#715 TODO).
- End-to-end validation on a real nspawn host.
