### PR TITLE
ts_codegen: stop silently degrading unresolved list/struct references

### DIFF
--- a/crates/hyprstream-rpc-build/src/backend.rs
+++ b/crates/hyprstream-rpc-build/src/backend.rs
@@ -43,10 +43,17 @@ pub trait CodegenBackend {
     ///
     /// Returns `None` if this backend does not generate an index file.
     /// TypeScript overrides this to produce `index.ts` with re-exports.
+    ///
+    /// `module_contents` pairs each schema's module name with the full source
+    /// text already written for it, so the barrel generator can detect
+    /// cross-module export name collisions from the single source of truth
+    /// (the actual emitted symbols) instead of re-deriving naming rules
+    /// independently and risking drift.
     fn index_file(
         &self,
         _all_names: &[String],
         _client_names: &[String],
+        _module_contents: &[(String, String)],
     ) -> Option<(String, String)> {
         None
     }

--- a/crates/hyprstream-rpc-build/src/ts_codegen/builders.rs
+++ b/crates/hyprstream-rpc-build/src/ts_codegen/builders.rs
@@ -663,10 +663,26 @@ fn emit_field_setter(
                     field.slot_offset
                 ));
             } else if let Some(inner) = super::extract_list_inner_type(&field.type_name) {
+                if let Some(method) = super::list_setter_method(inner) {
+                    // List(<scalar/Text/Data>) — the runtime has a direct setter
+                    // that takes the whole array (see capnp.ts).
+                    out.push_str(&format!(
+                        "{indent}{builder_var}.{method}({}, {value_expr});\n",
+                        field.slot_offset
+                    ));
+                } else if inner.starts_with("List(") {
+                    panic!(
+                        "ts_codegen: field `{}: {}` is a nested list (List(List(_))) — \
+                         the capnp.ts runtime does not yet support double indirection. \
+                         This must be implemented in message.rs before this field can be \
+                         referenced; a silently-dropped comment is not acceptable (#725).",
+                        field.name, field.type_name
+                    );
+                }
                 // List(Struct) — init struct list and set each element's fields.
                 // Claim a unique ID from the per-function counter so nested lists at
                 // the same capnp pointer slot never shadow each other (TDZ collision).
-                if let Some(sd) = structs.iter().find(|s| s.name == inner) {
+                else if let Some(sd) = structs.iter().find(|s| s.name == inner) {
                     let id = *counter;
                     *counter += 1;
                     let sl = format!("_sl{id}");
@@ -717,11 +733,14 @@ fn emit_field_setter(
                     out.push_str(&format!("{indent}  }});\n"));
                     out.push_str(&format!("{indent}}}\n"));
                 } else {
-                    out.push_str(&format!(
-                        "{indent}// {}: {} — struct definition not found\n",
-                        to_camel_case(&field.name),
-                        field.type_name
-                    ));
+                    panic!(
+                        "ts_codegen: field `{}: {}` references struct `{inner}`, which was \
+                         not found among the parsed schema's structs. This means the \
+                         generator has a dangling struct reference — regenerate the CGR \
+                         input and investigate the parser/resolution logic; this must never \
+                         silently degrade to a comment (#725).",
+                        field.name, field.type_name
+                    );
                 }
             } else if let Some(sd) = structs.iter().find(|s| s.name == field.type_name) {
                 if let Some(inner_name) = sd.option_inner_type() {
@@ -770,12 +789,13 @@ fn emit_field_setter(
                     out.push_str(&format!("{indent}}}\n"));
                 }
             } else {
-                // Unsupported pointer type — skip with comment
-                out.push_str(&format!(
-                    "{indent}// {}: {} — not yet supported by runtime\n",
-                    to_camel_case(&field.name),
-                    field.type_name
-                ));
+                panic!(
+                    "ts_codegen: field `{}: {}` is an unrecognized pointer type — neither a \
+                     primitive, a List(_), nor a known struct (e.g. AnyPointer/Interface are \
+                     not supported). This must be a hard generator error, never a silently \
+                     skipped comment (#725).",
+                    field.name, field.type_name
+                );
             }
         }
         FieldSection::Group => {} // groups are inlined, not handled here
@@ -1031,4 +1051,126 @@ fn emit_union_element_setter(
     }
     out.push_str(&format!("{indent}  default: break;\n"));
     out.push_str(&format!("{indent}}}\n"));
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+
+    use std::path::Path;
+
+    use hyprstream_rpc_build::schema::parse_from_cgr_path;
+    use hyprstream_rpc_build::schema::types::{FieldDef, FieldSection, ParsedSchema, StructDef};
+
+    /// A struct with a `List(Data)` field (mirrors #725's `certHashes: List(Data)`
+    /// repro in `streaming.capnp`'s `QuicReach`) plus a `List(Int64)` field
+    /// (mirrors `worker.capnp`'s `supplementalGroups`), to catch the whole
+    /// "any other currently-unresolved shapes" class the issue calls out, not
+    /// just the one named example.
+    const LIST_SCHEMA: &str = r#"
+@0xd00dfeeda00dfeed;
+
+struct Reach {
+  addr @0 :Text;
+  certHashes @1 :List(Data);
+  supplementalGroups @2 :List(Int64);
+}
+"#;
+
+    /// Compile `schema_src` to a CGR keyed on `name` and parse it. Uses a
+    /// per-(pid, name) temp dir so parallel tests don't collide.
+    fn parse_schema(name: &str, schema_src: &str) -> ParsedSchema {
+        let tmp =
+            std::env::temp_dir().join(format!("hyprstream_ts_bld_{name}_{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+
+        let capnp_path = tmp.join(format!("{name}.capnp"));
+        std::fs::write(&capnp_path, schema_src).expect("write capnp");
+
+        let cgr_path = tmp.join(format!("{name}.cgr"));
+        capnpc::CompilerCommand::new()
+            .src_prefix(&tmp)
+            .file(&capnp_path)
+            .raw_code_generator_request_path(&cgr_path)
+            .run()
+            .expect("compile capnp to CGR");
+
+        let parsed = parse_from_cgr_path(Path::new(&cgr_path), name).expect("parse CGR");
+        let _ = std::fs::remove_dir_all(&tmp);
+        parsed
+    }
+
+    #[test]
+    fn list_data_and_list_scalar_fields_emit_real_setters_not_comments() {
+        let schema = parse_schema("reach", LIST_SCHEMA);
+        let mut out = String::new();
+        super::generate_struct_builders(&mut out, &schema);
+
+        // The #725 regression: these must never degrade to a comment.
+        assert!(
+            !out.contains("struct definition not found"),
+            "must never emit the silent-degrade comment:\n{out}"
+        );
+        assert!(
+            !out.contains("not yet supported by runtime"),
+            "must never emit the silent-degrade comment:\n{out}"
+        );
+
+        // certHashes: List(Data) must use the real runtime setter.
+        assert!(
+            out.contains(".setDataList("),
+            "expected a real setDataList call for List(Data):\n{out}"
+        );
+        // supplementalGroups: List(Int64) must use the real runtime setter too —
+        // this is the "any other currently-unresolved shapes" half of the fix.
+        assert!(
+            out.contains(".setInt64List("),
+            "expected a real setInt64List call for List(Int64):\n{out}"
+        );
+    }
+
+    /// A field whose type references a struct that isn't in the parsed
+    /// schema's `structs` list is a genuine generator bug (a dangling
+    /// reference) — it must be a hard build failure, never a silently
+    /// emitted comment.
+    #[test]
+    #[should_panic(expected = "dangling struct reference")]
+    fn dangling_struct_reference_in_list_field_panics() {
+        let field = FieldDef {
+            name: "ghosts".to_owned(),
+            type_name: "List(GhostStruct)".to_owned(),
+            description: String::new(),
+            fixed_size: None,
+            optional: false,
+            slot_offset: 0,
+            section: FieldSection::Pointer,
+            discriminant_value: 0xFFFF,
+            serde_rename: None,
+            domain_type: None,
+        };
+        let sd = StructDef {
+            name: "Haunted".to_owned(),
+            fields: vec![field],
+            has_union: false,
+            domain_type: None,
+            origin_file: None,
+            data_words: 0,
+            pointer_words: 1,
+            discriminant_count: 0,
+            discriminant_offset: 0,
+            union_arms: vec![],
+        };
+        let schema = ParsedSchema {
+            request_variants: vec![],
+            response_variants: vec![],
+            structs: vec![sd],
+            scoped_clients: vec![],
+            enums: vec![],
+            request_struct: None,
+            response_struct: None,
+        };
+
+        let mut out = String::new();
+        super::generate_struct_builders(&mut out, &schema);
+    }
 }

--- a/crates/hyprstream-rpc-build/src/ts_codegen/message.rs
+++ b/crates/hyprstream-rpc-build/src/ts_codegen/message.rs
@@ -254,6 +254,152 @@ export class CapnpArena {
   }
 
   /**
+   * Set a Data list pointer (List(Data)) at the given pointer index.
+   * Encodes as a composite list of byte-blob pointers (no NUL terminator).
+   */
+  setDataList(ptrIndex: number, values: Uint8Array[]): void {
+    if (values.length === 0) return;
+
+    this.alignAlloc();
+
+    const tagOffset = this.allocOffset;
+    const elementCount = values.length;
+    const elementWords = 1; // 0 data + 1 pointer per element
+    const totalWords = 1 + elementCount * elementWords;
+
+    this.ensureCapacity(totalWords * WORD_SIZE + values.reduce((a, v) => a + v.length + 8, 0));
+
+    const tagLo = ((elementCount << 2) | 0) >>> 0;
+    const tagHi = ((0 << 0) | (1 << 16)) >>> 0;
+    this.buf.setUint32(tagOffset, tagLo, true);
+    this.buf.setUint32(tagOffset + 4, tagHi, true);
+
+    this.allocOffset = tagOffset + WORD_SIZE + elementCount * elementWords * WORD_SIZE;
+
+    const ptrOffset = this.rootPtrOffset + ptrIndex * WORD_SIZE;
+    const offsetWords = (tagOffset - ptrOffset - WORD_SIZE) / WORD_SIZE;
+    const lo = ((offsetWords << 2) | 1) >>> 0;
+    const hi = ((elementCount * elementWords << 3) | 7) >>> 0;
+    this.buf.setUint32(ptrOffset, lo, true);
+    this.buf.setUint32(ptrOffset + 4, hi, true);
+
+    for (let i = 0; i < values.length; i++) {
+      const elementPtrOffset = tagOffset + WORD_SIZE + i * elementWords * WORD_SIZE;
+      const byteLen = values[i].length;
+      const wordLen = Math.ceil(byteLen / WORD_SIZE);
+
+      this.alignAlloc();
+      this.ensureCapacity(wordLen * WORD_SIZE);
+
+      const dataOffset = this.allocOffset;
+      this.raw.set(values[i], dataOffset);
+
+      const dataOffsetWords = (dataOffset - elementPtrOffset - WORD_SIZE) / WORD_SIZE;
+      const dataLo = ((dataOffsetWords << 2) | 1) >>> 0;
+      const dataHi = ((byteLen << 3) | 2) >>> 0;
+      this.buf.setUint32(elementPtrOffset, dataLo, true);
+      this.buf.setUint32(elementPtrOffset + 4, dataHi, true);
+
+      this.allocOffset = dataOffset + wordLen * WORD_SIZE;
+    }
+  }
+
+  /**
+   * Allocate a fixed-width primitive list (List(Bool)/List(UIntN)/List(IntN)/List(FloatN))
+   * pointer at `ptrIndex`. `elemSize` is the capnp list element-size tag
+   * (1=bit, 2=1-byte, 3=2-byte, 4=4-byte, 5=8-byte); `byteWidth` is the
+   * per-element byte width (ignored for bit-packed bool lists).
+   * Returns the byte offset of the first element, or -1 for an empty list.
+   */
+  private allocPrimitiveList(ptrIndex: number, count: number, elemSize: number, byteWidth: number): number {
+    if (count === 0) return -1;
+
+    this.alignAlloc();
+    const totalBytes = elemSize === 1 ? Math.ceil(count / 8) : count * byteWidth;
+    const wordLen = Math.ceil(totalBytes / WORD_SIZE);
+    this.ensureCapacity(wordLen * WORD_SIZE);
+
+    const targetOffset = this.allocOffset;
+    const ptrOffset = this.rootPtrOffset + ptrIndex * WORD_SIZE;
+    const offsetWords = (targetOffset - ptrOffset - WORD_SIZE) / WORD_SIZE;
+    const lo = ((offsetWords << 2) | 1) >>> 0;
+    const hi = ((count << 3) | elemSize) >>> 0;
+    this.buf.setUint32(ptrOffset, lo, true);
+    this.buf.setUint32(ptrOffset + 4, hi, true);
+
+    this.allocOffset = targetOffset + wordLen * WORD_SIZE;
+    return targetOffset;
+  }
+
+  setBoolList(ptrIndex: number, values: boolean[]): void {
+    const base = this.allocPrimitiveList(ptrIndex, values.length, 1, 0);
+    if (base < 0) return;
+    for (let i = 0; i < values.length; i++) {
+      if (values[i]) this.raw[base + (i >> 3)] |= 1 << (i & 7);
+    }
+  }
+
+  setUint8List(ptrIndex: number, values: number[]): void {
+    const base = this.allocPrimitiveList(ptrIndex, values.length, 2, 1);
+    if (base < 0) return;
+    for (let i = 0; i < values.length; i++) this.buf.setUint8(base + i, values[i]);
+  }
+
+  setInt8List(ptrIndex: number, values: number[]): void {
+    const base = this.allocPrimitiveList(ptrIndex, values.length, 2, 1);
+    if (base < 0) return;
+    for (let i = 0; i < values.length; i++) this.buf.setInt8(base + i, values[i]);
+  }
+
+  setUint16List(ptrIndex: number, values: number[]): void {
+    const base = this.allocPrimitiveList(ptrIndex, values.length, 3, 2);
+    if (base < 0) return;
+    for (let i = 0; i < values.length; i++) this.buf.setUint16(base + i * 2, values[i], true);
+  }
+
+  setInt16List(ptrIndex: number, values: number[]): void {
+    const base = this.allocPrimitiveList(ptrIndex, values.length, 3, 2);
+    if (base < 0) return;
+    for (let i = 0; i < values.length; i++) this.buf.setInt16(base + i * 2, values[i], true);
+  }
+
+  setUint32List(ptrIndex: number, values: number[]): void {
+    const base = this.allocPrimitiveList(ptrIndex, values.length, 4, 4);
+    if (base < 0) return;
+    for (let i = 0; i < values.length; i++) this.buf.setUint32(base + i * 4, values[i], true);
+  }
+
+  setInt32List(ptrIndex: number, values: number[]): void {
+    const base = this.allocPrimitiveList(ptrIndex, values.length, 4, 4);
+    if (base < 0) return;
+    for (let i = 0; i < values.length; i++) this.buf.setInt32(base + i * 4, values[i], true);
+  }
+
+  setFloat32List(ptrIndex: number, values: number[]): void {
+    const base = this.allocPrimitiveList(ptrIndex, values.length, 4, 4);
+    if (base < 0) return;
+    for (let i = 0; i < values.length; i++) this.buf.setFloat32(base + i * 4, values[i], true);
+  }
+
+  setUint64List(ptrIndex: number, values: bigint[]): void {
+    const base = this.allocPrimitiveList(ptrIndex, values.length, 5, 8);
+    if (base < 0) return;
+    for (let i = 0; i < values.length; i++) this.buf.setBigUint64(base + i * 8, values[i], true);
+  }
+
+  setInt64List(ptrIndex: number, values: bigint[]): void {
+    const base = this.allocPrimitiveList(ptrIndex, values.length, 5, 8);
+    if (base < 0) return;
+    for (let i = 0; i < values.length; i++) this.buf.setBigInt64(base + i * 8, values[i], true);
+  }
+
+  setFloat64List(ptrIndex: number, values: number[]): void {
+    const base = this.allocPrimitiveList(ptrIndex, values.length, 5, 8);
+    if (base < 0) return;
+    for (let i = 0; i < values.length; i++) this.buf.setFloat64(base + i * 8, values[i], true);
+  }
+
+  /**
    * Initialize a sub-struct at the given pointer index.
    * Returns a StructBuilder for writing fields into the sub-struct.
    */
@@ -458,6 +604,153 @@ export class StructBuilder {
     this.msg._getBuf().setUint32(ptrOffset + 4, hi, true);
 
     this.msg._setAllocOffset(targetOffset + wordLen * WORD_SIZE);
+  }
+
+  /**
+   * Set a Data list pointer (List(Data)) at the given pointer index within this struct.
+   * Encodes as a composite list of byte-blob pointers (no NUL terminator).
+   */
+  setDataList(ptrIndex: number, values: Uint8Array[]): void {
+    if (values.length === 0) return;
+
+    this.msg._alignAlloc();
+
+    const tagOffset = this.msg._getAllocOffset();
+    const elementCount = values.length;
+    const elementWords = 1;
+    const totalWords = 1 + elementCount * elementWords;
+
+    this.msg._ensureCapacity(totalWords * WORD_SIZE + values.reduce((a, v) => a + v.length + 8, 0));
+
+    const tagLo = ((elementCount << 2) | 0) >>> 0;
+    const tagHi = ((0 << 0) | (1 << 16)) >>> 0;
+    this.msg._getBuf().setUint32(tagOffset, tagLo, true);
+    this.msg._getBuf().setUint32(tagOffset + 4, tagHi, true);
+
+    this.msg._setAllocOffset(tagOffset + WORD_SIZE + elementCount * elementWords * WORD_SIZE);
+
+    const ptrOffset = this.ptrOffset + ptrIndex * WORD_SIZE;
+    const offsetWords = (tagOffset - ptrOffset - WORD_SIZE) / WORD_SIZE;
+    const lo = ((offsetWords << 2) | 1) >>> 0;
+    const hi = ((elementCount * elementWords << 3) | 7) >>> 0;
+    this.msg._getBuf().setUint32(ptrOffset, lo, true);
+    this.msg._getBuf().setUint32(ptrOffset + 4, hi, true);
+
+    for (let i = 0; i < values.length; i++) {
+      const elementPtrOffset = tagOffset + WORD_SIZE + i * elementWords * WORD_SIZE;
+      const byteLen = values[i].length;
+      const wordLen = Math.ceil(byteLen / WORD_SIZE);
+
+      this.msg._alignAlloc();
+      this.msg._ensureCapacity(wordLen * WORD_SIZE);
+
+      const dataOffset = this.msg._getAllocOffset();
+      this.msg._getRaw().set(values[i], dataOffset);
+
+      const dataOffsetWords = (dataOffset - elementPtrOffset - WORD_SIZE) / WORD_SIZE;
+      const dataLo = ((dataOffsetWords << 2) | 1) >>> 0;
+      const dataHi = ((byteLen << 3) | 2) >>> 0;
+      this.msg._getBuf().setUint32(elementPtrOffset, dataLo, true);
+      this.msg._getBuf().setUint32(elementPtrOffset + 4, dataHi, true);
+
+      this.msg._setAllocOffset(dataOffset + wordLen * WORD_SIZE);
+    }
+  }
+
+  /**
+   * Allocate a fixed-width primitive list (List(Bool)/List(UIntN)/List(IntN)/List(FloatN))
+   * pointer at `ptrIndex` within this struct. `elemSize` is the capnp list
+   * element-size tag (1=bit, 2=1-byte, 3=2-byte, 4=4-byte, 5=8-byte);
+   * `byteWidth` is the per-element byte width (ignored for bit-packed bool lists).
+   * Returns the byte offset of the first element, or -1 for an empty list.
+   */
+  private allocPrimitiveList(ptrIndex: number, count: number, elemSize: number, byteWidth: number): number {
+    if (count === 0) return -1;
+
+    this.msg._alignAlloc();
+    const totalBytes = elemSize === 1 ? Math.ceil(count / 8) : count * byteWidth;
+    const wordLen = Math.ceil(totalBytes / WORD_SIZE);
+    this.msg._ensureCapacity(wordLen * WORD_SIZE);
+
+    const targetOffset = this.msg._getAllocOffset();
+    const ptrOffset = this.ptrOffset + ptrIndex * WORD_SIZE;
+    const offsetWords = (targetOffset - ptrOffset - WORD_SIZE) / WORD_SIZE;
+    const lo = ((offsetWords << 2) | 1) >>> 0;
+    const hi = ((count << 3) | elemSize) >>> 0;
+    this.msg._getBuf().setUint32(ptrOffset, lo, true);
+    this.msg._getBuf().setUint32(ptrOffset + 4, hi, true);
+
+    this.msg._setAllocOffset(targetOffset + wordLen * WORD_SIZE);
+    return targetOffset;
+  }
+
+  setBoolList(ptrIndex: number, values: boolean[]): void {
+    const base = this.allocPrimitiveList(ptrIndex, values.length, 1, 0);
+    if (base < 0) return;
+    const raw = this.msg._getRaw();
+    for (let i = 0; i < values.length; i++) {
+      if (values[i]) raw[base + (i >> 3)] |= 1 << (i & 7);
+    }
+  }
+
+  setUint8List(ptrIndex: number, values: number[]): void {
+    const base = this.allocPrimitiveList(ptrIndex, values.length, 2, 1);
+    if (base < 0) return;
+    for (let i = 0; i < values.length; i++) this.msg._getBuf().setUint8(base + i, values[i]);
+  }
+
+  setInt8List(ptrIndex: number, values: number[]): void {
+    const base = this.allocPrimitiveList(ptrIndex, values.length, 2, 1);
+    if (base < 0) return;
+    for (let i = 0; i < values.length; i++) this.msg._getBuf().setInt8(base + i, values[i]);
+  }
+
+  setUint16List(ptrIndex: number, values: number[]): void {
+    const base = this.allocPrimitiveList(ptrIndex, values.length, 3, 2);
+    if (base < 0) return;
+    for (let i = 0; i < values.length; i++) this.msg._getBuf().setUint16(base + i * 2, values[i], true);
+  }
+
+  setInt16List(ptrIndex: number, values: number[]): void {
+    const base = this.allocPrimitiveList(ptrIndex, values.length, 3, 2);
+    if (base < 0) return;
+    for (let i = 0; i < values.length; i++) this.msg._getBuf().setInt16(base + i * 2, values[i], true);
+  }
+
+  setUint32List(ptrIndex: number, values: number[]): void {
+    const base = this.allocPrimitiveList(ptrIndex, values.length, 4, 4);
+    if (base < 0) return;
+    for (let i = 0; i < values.length; i++) this.msg._getBuf().setUint32(base + i * 4, values[i], true);
+  }
+
+  setInt32List(ptrIndex: number, values: number[]): void {
+    const base = this.allocPrimitiveList(ptrIndex, values.length, 4, 4);
+    if (base < 0) return;
+    for (let i = 0; i < values.length; i++) this.msg._getBuf().setInt32(base + i * 4, values[i], true);
+  }
+
+  setFloat32List(ptrIndex: number, values: number[]): void {
+    const base = this.allocPrimitiveList(ptrIndex, values.length, 4, 4);
+    if (base < 0) return;
+    for (let i = 0; i < values.length; i++) this.msg._getBuf().setFloat32(base + i * 4, values[i], true);
+  }
+
+  setUint64List(ptrIndex: number, values: bigint[]): void {
+    const base = this.allocPrimitiveList(ptrIndex, values.length, 5, 8);
+    if (base < 0) return;
+    for (let i = 0; i < values.length; i++) this.msg._getBuf().setBigUint64(base + i * 8, values[i], true);
+  }
+
+  setInt64List(ptrIndex: number, values: bigint[]): void {
+    const base = this.allocPrimitiveList(ptrIndex, values.length, 5, 8);
+    if (base < 0) return;
+    for (let i = 0; i < values.length; i++) this.msg._getBuf().setBigInt64(base + i * 8, values[i], true);
+  }
+
+  setFloat64List(ptrIndex: number, values: number[]): void {
+    const base = this.allocPrimitiveList(ptrIndex, values.length, 5, 8);
+    if (base < 0) return;
+    for (let i = 0; i < values.length; i++) this.msg._getBuf().setFloat64(base + i * 8, values[i], true);
   }
 
   /**
@@ -797,7 +1090,7 @@ export class CapnpReader {
     return results;
   }
 
-  /** Read a List(Data) pointer. */
+  /** Read a List(Data) pointer (supports both pointer-list and composite encodings). */
   getDataList(ptrIndex: number): Uint8Array[] {
     const ptrOffset = this.rootPtrOffset + ptrIndex * WORD_SIZE;
     const resolved = this.resolvePtr(ptrOffset);
@@ -809,14 +1102,26 @@ export class CapnpReader {
     const elementSize = hi & 7;
     const targetOffset = offset + WORD_SIZE + offsetWords * WORD_SIZE;
 
-    if (elementSize !== 7) return []; // not composite
-
-    const tagLo = this.buf.getUint32(targetOffset, true);
-    const elementCount = (tagLo >> 2) | 0;
+    // Pointer list (element_size=6, the canonical List(Data) encoding — what
+    // the Rust side emits) or composite list (element_size=7): both carry one
+    // pointer per element, differing only in where the count lives and where
+    // the elements start.
+    let elementCount: number;
+    let elemBase: number;
+    if (elementSize === 6) {
+      elementCount = hi >>> 3;
+      elemBase = targetOffset;
+    } else if (elementSize === 7) {
+      const tagLo = this.buf.getUint32(targetOffset, true);
+      elementCount = (tagLo >> 2) | 0;
+      elemBase = targetOffset + WORD_SIZE;
+    } else {
+      return [];
+    }
 
     const results: Uint8Array[] = [];
     for (let i = 0; i < elementCount; i++) {
-      const elemOffset = targetOffset + WORD_SIZE + i * WORD_SIZE;
+      const elemOffset = elemBase + i * WORD_SIZE;
       const elemLo = this.buf.getUint32(elemOffset, true);
       const elemHi = this.buf.getUint32(elemOffset + 4, true);
 
@@ -832,6 +1137,86 @@ export class CapnpReader {
     }
 
     return results;
+  }
+
+  /**
+   * Read a fixed-width primitive list (List(Bool)/List(UIntN)/List(IntN)/List(FloatN)).
+   * `expectedElemSize` is the capnp list element-size tag this getter accepts
+   * (1=bit, 2=1-byte, 3=2-byte, 4=4-byte, 5=8-byte); `byteWidth` is the
+   * per-element byte width (ignored for bit-packed bool lists). Returns `[]`
+   * if the pointer is null or was encoded with a different element size.
+   */
+  private readPrimitiveList<T>(
+    ptrIndex: number,
+    expectedElemSize: number,
+    byteWidth: number,
+    read: (byteOffset: number, bitIndex: number) => T,
+  ): T[] {
+    const ptrOffset = this.rootPtrOffset + ptrIndex * WORD_SIZE;
+    const resolved = this.resolvePtr(ptrOffset);
+    if (!resolved) return [];
+    const { lo, hi, offset } = resolved;
+    if ((lo & 3) !== 1) return [];
+
+    const offsetWords = (lo >> 2) | 0;
+    const elementSize = hi & 7;
+    if (elementSize !== expectedElemSize) return [];
+    const targetOffset = offset + WORD_SIZE + offsetWords * WORD_SIZE;
+    const count = hi >>> 3;
+
+    const results: T[] = [];
+    for (let i = 0; i < count; i++) {
+      results.push(
+        byteWidth === 0
+          ? read(targetOffset + (i >> 3), i & 7)
+          : read(targetOffset + i * byteWidth, 0),
+      );
+    }
+    return results;
+  }
+
+  getBoolList(ptrIndex: number): boolean[] {
+    return this.readPrimitiveList(ptrIndex, 1, 0, (byteOffset, bitIndex) => (this.raw[byteOffset] & (1 << bitIndex)) !== 0);
+  }
+
+  getUint8List(ptrIndex: number): number[] {
+    return this.readPrimitiveList(ptrIndex, 2, 1, (o) => this.buf.getUint8(o));
+  }
+
+  getInt8List(ptrIndex: number): number[] {
+    return this.readPrimitiveList(ptrIndex, 2, 1, (o) => this.buf.getInt8(o));
+  }
+
+  getUint16List(ptrIndex: number): number[] {
+    return this.readPrimitiveList(ptrIndex, 3, 2, (o) => this.buf.getUint16(o, true));
+  }
+
+  getInt16List(ptrIndex: number): number[] {
+    return this.readPrimitiveList(ptrIndex, 3, 2, (o) => this.buf.getInt16(o, true));
+  }
+
+  getUint32List(ptrIndex: number): number[] {
+    return this.readPrimitiveList(ptrIndex, 4, 4, (o) => this.buf.getUint32(o, true));
+  }
+
+  getInt32List(ptrIndex: number): number[] {
+    return this.readPrimitiveList(ptrIndex, 4, 4, (o) => this.buf.getInt32(o, true));
+  }
+
+  getFloat32List(ptrIndex: number): number[] {
+    return this.readPrimitiveList(ptrIndex, 4, 4, (o) => this.buf.getFloat32(o, true));
+  }
+
+  getUint64List(ptrIndex: number): bigint[] {
+    return this.readPrimitiveList(ptrIndex, 5, 8, (o) => this.buf.getBigUint64(o, true));
+  }
+
+  getInt64List(ptrIndex: number): bigint[] {
+    return this.readPrimitiveList(ptrIndex, 5, 8, (o) => this.buf.getBigInt64(o, true));
+  }
+
+  getFloat64List(ptrIndex: number): number[] {
+    return this.readPrimitiveList(ptrIndex, 5, 8, (o) => this.buf.getFloat64(o, true));
   }
 
   /** Read a List(Struct) composite list pointer. Returns StructReader[] using wire-format shape from tag word. */
@@ -1052,6 +1437,84 @@ export class StructReader {
       results.push(this.raw.subarray(dataOffset, dataOffset + byteCount));
     }
     return results;
+  }
+
+  /**
+   * Read a fixed-width primitive list (List(Bool)/List(UIntN)/List(IntN)/List(FloatN))
+   * within this struct. See `CapnpReader.readPrimitiveList` for the element-size
+   * encoding this mirrors.
+   */
+  private readPrimitiveList<T>(
+    ptrIndex: number,
+    expectedElemSize: number,
+    byteWidth: number,
+    read: (byteOffset: number, bitIndex: number) => T,
+  ): T[] {
+    const ptrOffset = this.dataOffset + this.dataWords * WORD_SIZE + ptrIndex * WORD_SIZE;
+    const resolved = this.resolvePtr(ptrOffset);
+    if (!resolved) return [];
+    const { lo, hi, offset } = resolved;
+    if ((lo & 3) !== 1) return [];
+
+    const offsetWords = (lo >> 2) | 0;
+    const elementSize = hi & 7;
+    if (elementSize !== expectedElemSize) return [];
+    const targetOffset = offset + WORD_SIZE + offsetWords * WORD_SIZE;
+    const count = hi >>> 3;
+
+    const results: T[] = [];
+    for (let i = 0; i < count; i++) {
+      results.push(
+        byteWidth === 0
+          ? read(targetOffset + (i >> 3), i & 7)
+          : read(targetOffset + i * byteWidth, 0),
+      );
+    }
+    return results;
+  }
+
+  getBoolList(ptrIndex: number): boolean[] {
+    return this.readPrimitiveList(ptrIndex, 1, 0, (byteOffset, bitIndex) => (this.raw[byteOffset] & (1 << bitIndex)) !== 0);
+  }
+
+  getUint8List(ptrIndex: number): number[] {
+    return this.readPrimitiveList(ptrIndex, 2, 1, (o) => this.buf.getUint8(o));
+  }
+
+  getInt8List(ptrIndex: number): number[] {
+    return this.readPrimitiveList(ptrIndex, 2, 1, (o) => this.buf.getInt8(o));
+  }
+
+  getUint16List(ptrIndex: number): number[] {
+    return this.readPrimitiveList(ptrIndex, 3, 2, (o) => this.buf.getUint16(o, true));
+  }
+
+  getInt16List(ptrIndex: number): number[] {
+    return this.readPrimitiveList(ptrIndex, 3, 2, (o) => this.buf.getInt16(o, true));
+  }
+
+  getUint32List(ptrIndex: number): number[] {
+    return this.readPrimitiveList(ptrIndex, 4, 4, (o) => this.buf.getUint32(o, true));
+  }
+
+  getInt32List(ptrIndex: number): number[] {
+    return this.readPrimitiveList(ptrIndex, 4, 4, (o) => this.buf.getInt32(o, true));
+  }
+
+  getFloat32List(ptrIndex: number): number[] {
+    return this.readPrimitiveList(ptrIndex, 4, 4, (o) => this.buf.getFloat32(o, true));
+  }
+
+  getUint64List(ptrIndex: number): bigint[] {
+    return this.readPrimitiveList(ptrIndex, 5, 8, (o) => this.buf.getBigUint64(o, true));
+  }
+
+  getInt64List(ptrIndex: number): bigint[] {
+    return this.readPrimitiveList(ptrIndex, 5, 8, (o) => this.buf.getBigInt64(o, true));
+  }
+
+  getFloat64List(ptrIndex: number): number[] {
+    return this.readPrimitiveList(ptrIndex, 5, 8, (o) => this.buf.getFloat64(o, true));
   }
 
   getStructList(ptrIndex: number, _dataWords: number, _ptrWords: number): StructReader[] {

--- a/crates/hyprstream-rpc-build/src/ts_codegen/mod.rs
+++ b/crates/hyprstream-rpc-build/src/ts_codegen/mod.rs
@@ -35,20 +35,24 @@ pub fn generate_all<B: CodegenBackend>(
     // 2. Per-schema service files
     let mut all_names = Vec::new();
     let mut client_names = Vec::new();
+    let mut module_contents = Vec::new();
     for (name, schema) in schemas {
         let content = backend.generate_service_file(name, schema);
         let filename = format!("{name}.{}", backend.file_extension());
         let path = output_dir.join(&filename);
-        std::fs::write(&path, content).expect("Failed to write service file");
+        std::fs::write(&path, &content).expect("Failed to write service file");
         println!("  Generated {filename}");
         all_names.push(name.clone());
         if schema.request_struct.is_some() {
             client_names.push(name.clone());
         }
+        module_contents.push((name.clone(), content));
     }
 
     // 3. Optional index/manifest file
-    if let Some((index_name, index_content)) = backend.index_file(&all_names, &client_names) {
+    if let Some((index_name, index_content)) =
+        backend.index_file(&all_names, &client_names, &module_contents)
+    {
         let index_path = output_dir.join(&index_name);
         std::fs::write(&index_path, index_content).expect("Failed to write index file");
         println!("  Generated {index_name}");
@@ -198,8 +202,55 @@ fn setter_method(type_name: &str) -> Option<&str> {
         "Float64" => "setFloat64",
         "Text" => "setText",
         "Data" => "setData",
-        _ if type_name.starts_with("List(Text") => "setTextList",
-        _ => return None, // struct lists, nested structs, etc. not supported yet
+        _ => return None, // List(_), struct pointers, etc. — handled by list_setter_method / struct codegen
+    })
+}
+
+/// Return the TypeScript setter method name for a `List(<inner>)` field, given
+/// the inner element type name (e.g. `"Int64"`, `"Bool"`, `"Text"`, `"Data"`).
+///
+/// This is the single source of truth for which list element shapes the
+/// `capnp.ts` runtime supports as a flat (non-composite-of-structs) list.
+/// `None` means the caller must fall through to struct-list codegen (if
+/// `inner` names a known struct) — anything else is an unresolved reference
+/// and must be treated as a hard generator error, never a silent comment.
+pub(crate) fn list_setter_method(inner: &str) -> Option<&str> {
+    Some(match inner {
+        "Text" => "setTextList",
+        "Data" => "setDataList",
+        "Bool" => "setBoolList",
+        "UInt8" => "setUint8List",
+        "Int8" => "setInt8List",
+        "UInt16" => "setUint16List",
+        "Int16" => "setInt16List",
+        "UInt32" => "setUint32List",
+        "Int32" => "setInt32List",
+        "UInt64" => "setUint64List",
+        "Int64" => "setInt64List",
+        "Float32" => "setFloat32List",
+        "Float64" => "setFloat64List",
+        _ => return None,
+    })
+}
+
+/// Return the TypeScript getter method name for a `List(<inner>)` field.
+/// Mirrors [`list_setter_method`] — see its docs.
+pub(crate) fn list_getter_method(inner: &str) -> Option<&str> {
+    Some(match inner {
+        "Text" => "getTextList",
+        "Data" => "getDataList",
+        "Bool" => "getBoolList",
+        "UInt8" => "getUint8List",
+        "Int8" => "getInt8List",
+        "UInt16" => "getUint16List",
+        "Int16" => "getInt16List",
+        "UInt32" => "getUint32List",
+        "Int32" => "getInt32List",
+        "UInt64" => "getUint64List",
+        "Int64" => "getInt64List",
+        "Float32" => "getFloat32List",
+        "Float64" => "getFloat64List",
+        _ => return None,
     })
 }
 
@@ -232,9 +283,16 @@ fn getter_method(type_name: &str) -> &str {
         "Float64" => "getFloat64",
         "Text" => "getText",
         "Data" => "getData",
-        _ if type_name.starts_with("List(Text") => "getTextList",
-        _ if type_name.starts_with("List(Data") => "getDataList",
-        _ => "getText",
+        // Callers only ever reach this function for `is_data_scalar`-narrowed
+        // types or a literal Text/Data check — List(_) always resolves through
+        // `list_getter_method` at the call site instead. Anything else getting
+        // here is a generator bug: fail loudly rather than silently guessing
+        // `getText` (the old behavior masked exactly this class of bug — #725).
+        other => panic!(
+            "ts_codegen: getter_method called with unsupported type `{other}` — this \
+             indicates a generator bug in the call site (missing a scalar/Text/Data \
+             guard), never silently degrade to a guessed getter (#725)."
+        ),
     }
 }
 
@@ -451,12 +509,41 @@ impl CodegenBackend for TypeScriptBackend {
         &self,
         all_names: &[String],
         client_names: &[String],
+        module_contents: &[(String, String)],
     ) -> Option<(String, String)> {
         Some((
             "index.ts".to_owned(),
-            generate_index(all_names, client_names),
+            generate_index(all_names, client_names, module_contents),
         ))
     }
+}
+
+/// Scan the literal top-level exported symbol names out of generated TS source.
+///
+/// This is the single source of truth for "what does this module export": it
+/// reads the text that was actually emitted (`export interface X`, `export type
+/// X`, `export function X`) rather than independently re-deriving struct/enum/
+/// function naming rules, so it can never drift from what `interfaces.rs` /
+/// `builders.rs` / `parsers.rs` actually produce.
+fn scan_exported_names(content: &str) -> Vec<String> {
+    const PREFIXES: &[&str] = &["export interface ", "export type ", "export function "];
+    let mut names = Vec::new();
+    for line in content.lines() {
+        let line = line.trim_start();
+        for prefix in PREFIXES {
+            if let Some(rest) = line.strip_prefix(prefix) {
+                let name: String = rest
+                    .chars()
+                    .take_while(|c| c.is_alphanumeric() || *c == '_')
+                    .collect();
+                if !name.is_empty() {
+                    names.push(name);
+                }
+                break;
+            }
+        }
+    }
+    names
 }
 
 /// Generate index.ts with re-exports.
@@ -465,17 +552,171 @@ impl CodegenBackend for TypeScriptBackend {
 /// For data-only schemas: re-exports all exported symbols (standalone builders/parsers).
 /// Does not use `export type *` for service schemas since different services
 /// may share type names (e.g., ErrorInfo, StreamInfo) which causes TS2308 conflicts.
-fn generate_index(all_names: &[String], client_names: &[String]) -> String {
+///
+/// Data-only modules are barrel-exported with a plain `export * from './name'`
+/// UNLESS one of their exported names also appears in another data-only
+/// module — in that case every data-only module sharing the name switches to
+/// an explicit `export { ... }` list with the colliding names aliased as
+/// `{PascalModuleName}{Name}`, so two modules can never silently shadow one
+/// another's export (#725) and a full regen never leaves an ambiguous name
+/// for tsc to reject.
+fn generate_index(
+    all_names: &[String],
+    client_names: &[String],
+    module_contents: &[(String, String)],
+) -> String {
+    // Exported names per data-only module (services only ever barrel-export
+    // their Client class, so they can't collide with each other here).
+    let data_only_exports: Vec<(&String, Vec<String>)> = all_names
+        .iter()
+        .filter(|name| !client_names.contains(name))
+        .map(|name| {
+            let content = module_contents
+                .iter()
+                .find(|(n, _)| n == name)
+                .map(|(_, c)| c.as_str())
+                .unwrap_or_default();
+            (name, scan_exported_names(content))
+        })
+        .collect();
+
+    // name -> number of data-only modules that export it
+    let mut occurrence_count: std::collections::HashMap<&str, usize> =
+        std::collections::HashMap::new();
+    for (_, names) in &data_only_exports {
+        for n in names {
+            *occurrence_count.entry(n.as_str()).or_insert(0) += 1;
+        }
+    }
+
     let mut out = String::from("// Generated by hyprstream-ts-codegen — DO NOT EDIT\n\n");
     out.push_str("export { CapnpArena, CapnpReader } from './capnp';\n");
     for name in all_names {
         if client_names.contains(name) {
             let pascal = to_pascal_case(name);
             out.push_str(&format!("export {{ {pascal}Client }} from './{name}';\n"));
-        } else {
-            // Data-only schema: re-export all standalone builders, parsers, and interfaces
-            out.push_str(&format!("export * from './{name}';\n"));
+            continue;
         }
+
+        let exported = data_only_exports
+            .iter()
+            .find(|(n, _)| *n == name)
+            .map(|(_, names)| names.as_slice())
+            .unwrap_or_default();
+        let has_collision = exported
+            .iter()
+            .any(|n| occurrence_count.get(n.as_str()).copied().unwrap_or(0) > 1);
+
+        if !has_collision {
+            // No cross-module name collision — a plain wildcard re-export is safe.
+            out.push_str(&format!("export * from './{name}';\n"));
+            continue;
+        }
+
+        // At least one export from this module collides with another
+        // data-only module's export — enumerate every export explicitly,
+        // aliasing only the colliding ones, so tsc never sees an ambiguous
+        // wildcard re-export.
+        let module_prefix = to_pascal_case(name);
+        let items: Vec<String> = exported
+            .iter()
+            .map(|n| {
+                if occurrence_count.get(n.as_str()).copied().unwrap_or(0) > 1 {
+                    format!("{n} as {module_prefix}{n}")
+                } else {
+                    n.clone()
+                }
+            })
+            .collect();
+        if items.is_empty() {
+            // Nothing exported from this module (e.g. an empty schema) — no-op.
+            continue;
+        }
+        out.push_str(&format!(
+            "export {{ {} }} from './{name}';\n",
+            items.join(", ")
+        ));
     }
     out
+}
+
+#[cfg(test)]
+mod barrel_tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+
+    use super::generate_index;
+
+    /// Two data-only modules that don't share any exported name keep the
+    /// cheap, plain `export *` re-export.
+    #[test]
+    fn no_collision_uses_plain_wildcard_export() {
+        let all_names = vec!["events".to_owned(), "streaming".to_owned()];
+        let client_names: Vec<String> = vec![];
+        let module_contents = vec![
+            (
+                "events".to_owned(),
+                "export interface EventEnvelope {\n  id: string;\n}\n".to_owned(),
+            ),
+            (
+                "streaming".to_owned(),
+                "export interface StreamInfo {\n  id: string;\n}\n".to_owned(),
+            ),
+        ];
+
+        let out = generate_index(&all_names, &client_names, &module_contents);
+
+        assert!(out.contains("export * from './events';"), "{out}");
+        assert!(out.contains("export * from './streaming';"), "{out}");
+    }
+
+    /// Two data-only modules that both export a struct with the same name (the
+    /// #725 "QoS" scenario) must never both emit a blind `export *` — every
+    /// module owning the colliding name switches to an explicit, aliased
+    /// export so tsc can never see an ambiguous re-export.
+    #[test]
+    fn colliding_export_name_is_aliased_per_module_not_silently_dropped() {
+        let all_names = vec!["events".to_owned(), "streaming".to_owned()];
+        let client_names: Vec<String> = vec![];
+        let module_contents = vec![
+            (
+                "events".to_owned(),
+                "export interface QoS {\n  retries: number;\n}\n\
+                 export interface EventEnvelope {\n  id: string;\n}\n"
+                    .to_owned(),
+            ),
+            (
+                "streaming".to_owned(),
+                "export interface QoS {\n  ackTimeoutMs: number;\n}\n\
+                 export interface StreamInfo {\n  id: string;\n}\n"
+                    .to_owned(),
+            ),
+        ];
+
+        let out = generate_index(&all_names, &client_names, &module_contents);
+
+        // Neither module may fall back to a blind wildcard export — that's
+        // exactly the silent-collision failure mode #725 reported.
+        assert!(!out.contains("export * from './events';"), "{out}");
+        assert!(!out.contains("export * from './streaming';"), "{out}");
+
+        // The colliding name is aliased per-module...
+        assert!(out.contains("QoS as EventsQoS"), "{out}");
+        assert!(out.contains("QoS as StreamingQoS"), "{out}");
+        // ...while the non-colliding names from each module are still
+        // re-exported (nothing gets dropped just because its sibling collided).
+        assert!(out.contains("EventEnvelope"), "{out}");
+        assert!(out.contains("StreamInfo"), "{out}");
+    }
+
+    /// `scan_exported_names` is the single source of truth the barrel
+    /// generator relies on — verify it picks up every emission shape used by
+    /// interfaces.rs / builders.rs / parsers.rs.
+    #[test]
+    fn scan_exported_names_finds_interfaces_types_and_functions() {
+        let content = "export interface Foo {\n  a: number;\n}\n\
+                        export type Bar =\n  | { variant: 'x'; data: undefined };\n\
+                        export function buildFoo(p: Foo): Uint8Array {\n  return new Uint8Array(0);\n}\n";
+        let names = super::scan_exported_names(content);
+        assert_eq!(names, vec!["Foo", "Bar", "buildFoo"]);
+    }
 }

--- a/crates/hyprstream-rpc-build/src/ts_codegen/parsers.rs
+++ b/crates/hyprstream-rpc-build/src/ts_codegen/parsers.rs
@@ -169,19 +169,22 @@ pub fn generate_parsers(out: &mut String, service_name: &str, schema: &ParsedSch
                     &format!("reader.getData({})", vf.slot_offset),
                 );
             }
-        } else if variant.type_name.starts_with("List(Text") {
-            if let Some(vf) = variant_field {
-                emit_return(
-                    out,
-                    &non_union_fields,
-                    &variant.name,
-                    &format!("reader.getTextList({})", vf.slot_offset),
-                );
-            }
         } else if let Some(inner) = super::extract_list_inner_type(&variant.type_name) {
-            // List(Struct) variant
             if let Some(vf) = variant_field {
-                if let Some(sd) = schema.structs.iter().find(|s| s.name == inner) {
+                if let Some(method) = super::list_getter_method(inner) {
+                    emit_return(
+                        out,
+                        &non_union_fields,
+                        &variant.name,
+                        &format!("reader.{method}({})", vf.slot_offset),
+                    );
+                } else if inner.starts_with("List(") {
+                    panic!(
+                        "ts_codegen: response variant `{}: {}` is a nested list \
+                         (List(List(_))) — not yet supported by the capnp.ts runtime (#725).",
+                        variant.name, variant.type_name
+                    );
+                } else if let Some(sd) = schema.structs.iter().find(|s| s.name == inner) {
                     emit_struct_list_read(
                         out,
                         "reader",
@@ -192,7 +195,12 @@ pub fn generate_parsers(out: &mut String, service_name: &str, schema: &ParsedSch
                         schema,
                     );
                 } else {
-                    emit_return(out, &non_union_fields, &variant.name, "[]");
+                    panic!(
+                        "ts_codegen: response variant `{}: {}` references struct `{inner}`, \
+                         which was not found in the parsed schema — dangling reference, must \
+                         not silently degrade (#725).",
+                        variant.name, variant.type_name
+                    );
                 }
             }
         } else {
@@ -363,15 +371,21 @@ pub fn generate_struct_parsers(out: &mut String, schema: &ParsedSchema) {
                     &variant.name,
                     &format!("reader.getData({})", variant.slot_offset),
                 );
-            } else if variant.type_name.starts_with("List(Text") {
-                emit_return(
-                    out,
-                    &non_union_fields,
-                    &variant.name,
-                    &format!("reader.getTextList({})", variant.slot_offset),
-                );
             } else if let Some(inner) = super::extract_list_inner_type(&variant.type_name) {
-                if let Some(isd) = schema.structs.iter().find(|s| s.name == inner) {
+                if let Some(method) = super::list_getter_method(inner) {
+                    emit_return(
+                        out,
+                        &non_union_fields,
+                        &variant.name,
+                        &format!("reader.{method}({})", variant.slot_offset),
+                    );
+                } else if inner.starts_with("List(") {
+                    panic!(
+                        "ts_codegen: union arm `{}: {}` is a nested list (List(List(_))) — \
+                         not yet supported by the capnp.ts runtime (#725).",
+                        variant.name, variant.type_name
+                    );
+                } else if let Some(isd) = schema.structs.iter().find(|s| s.name == inner) {
                     emit_struct_list_read(
                         out,
                         "reader",
@@ -382,7 +396,12 @@ pub fn generate_struct_parsers(out: &mut String, schema: &ParsedSchema) {
                         schema,
                     );
                 } else {
-                    emit_return(out, &non_union_fields, &variant.name, "[]");
+                    panic!(
+                        "ts_codegen: union arm `{}: {}` references struct `{inner}`, which \
+                         was not found in the parsed schema — dangling reference, must not \
+                         silently degrade (#725).",
+                        variant.name, variant.type_name
+                    );
                 }
             } else {
                 // Struct type
@@ -714,16 +733,23 @@ fn emit_inner_variant_read_from(
             let method = super::getter_method(type_name);
             format!("{reader_var}.{method}({byte_off})")
         }
-        t if t.starts_with("List(Text") => {
-            format!("{reader_var}.getTextList({})", f.slot_offset)
-        }
         t if t.starts_with("List(") => {
-            // List(Struct) — read as mapped array
             let inner = super::extract_list_inner_type(t).unwrap_or("");
-            if let Some(sd) = schema.structs.iter().find(|s| s.name == inner) {
+            if let Some(method) = super::list_getter_method(inner) {
+                format!("{reader_var}.{method}({})", f.slot_offset)
+            } else if inner.starts_with("List(") {
+                panic!(
+                    "ts_codegen: inner variant `{type_name}` is a nested list \
+                     (List(List(_))) — not yet supported by the capnp.ts runtime (#725)."
+                );
+            } else if let Some(sd) = schema.structs.iter().find(|s| s.name == inner) {
                 emit_struct_list_field_expr(reader_var, f.slot_offset, sd, schema)
             } else {
-                "[]".into()
+                panic!(
+                    "ts_codegen: inner variant `{type_name}` references struct `{inner}`, \
+                     which was not found in the parsed schema — dangling reference, must \
+                     not silently degrade (#725)."
+                );
             }
         }
         _ => {
@@ -849,21 +875,24 @@ fn emit_pointer_read_expr(
     depth: usize,
 ) -> String {
     match super::extract_list_inner_type(&field.type_name) {
-        Some("Text") => {
-            format!("{reader_var}.getTextList({})", field.slot_offset)
-        }
-        Some("Data") => {
-            format!("{reader_var}.getDataList({})", field.slot_offset)
-        }
         Some(inner) => {
-            // List(Struct) — look up struct def, map elements.
-            // For primitive lists (List(Int64), List(UInt32), etc.) we don't yet have
-            // a runtime getter, so emit a typed empty array to satisfy TypeScript.
-            if let Some(isd) = schema.structs.iter().find(|s| s.name == inner) {
+            if let Some(method) = super::list_getter_method(inner) {
+                format!("{reader_var}.{method}({})", field.slot_offset)
+            } else if inner.starts_with("List(") {
+                panic!(
+                    "ts_codegen: field `{}: {}` is a nested list (List(List(_))) — not yet \
+                     supported by the capnp.ts runtime (#725).",
+                    field.name, field.type_name
+                );
+            } else if let Some(isd) = schema.structs.iter().find(|s| s.name == inner) {
                 emit_struct_list_field_expr(reader_var, field.slot_offset, isd, schema)
             } else {
-                let elem_ts = super::capnp_to_ts_type(inner);
-                format!("([] as {elem_ts}[])")
+                panic!(
+                    "ts_codegen: field `{}: {}` references struct `{inner}`, which was not \
+                     found in the parsed schema — dangling reference, must not silently \
+                     degrade to an empty array (#725).",
+                    field.name, field.type_name
+                );
             }
         }
         None => {
@@ -1462,5 +1491,145 @@ struct Overflow {
             builder.contains("p.highWaterMark"),
             "group arm builder must write the leaf:\n{builder}"
         );
+    }
+
+    /// A struct with a `List(Data)` field (mirrors #725's `certHashes: List(Data)`
+    /// repro) plus a `List(Int64)` field (mirrors `worker.capnp`'s
+    /// `supplementalGroups`) — both must read through a real runtime getter,
+    /// never the old silent `[]` fallback.
+    const LIST_SCHEMA: &str = r#"
+@0xd00dfeeda00dfeef;
+
+struct Reach {
+  addr @0 :Text;
+  certHashes @1 :List(Data);
+  supplementalGroups @2 :List(Int64);
+}
+"#;
+
+    #[test]
+    fn list_data_and_list_scalar_fields_parse_with_real_getters() {
+        let schema = parse_schema("reachparse", LIST_SCHEMA);
+        let mut out = String::new();
+        super::generate_struct_parsers(&mut out, &schema);
+
+        assert!(
+            out.contains(".getDataList("),
+            "expected a real getDataList call for List(Data):\n{out}"
+        );
+        assert!(
+            out.contains(".getInt64List("),
+            "expected a real getInt64List call for List(Int64), not the old \
+             `([] as bigint[])` silent fallback:\n{out}"
+        );
+        assert!(
+            !out.contains("([] as "),
+            "must never silently fall back to a typed empty array:\n{out}"
+        );
+    }
+
+    /// Regression for #725 defect 2 (dropped `EndpointInfo.pubkey`/`selfProof`
+    /// fields): every field declared on a struct — including `Data` fields,
+    /// which is the field type that was dropped — must show up in both the
+    /// generated interface and the parser's return object. No field is ever
+    /// silently narrowed out of a regenerated struct.
+    const ENDPOINT_INFO_SCHEMA: &str = r#"
+@0xd00dfeeda00dfeec;
+
+struct EndpointInfo {
+  socketKind @0 :Text;
+  endpoint @1 :Text;
+  pubkey @2 :Data;
+  selfProof @3 :Data;
+  tlsDomain @4 :Text;
+}
+"#;
+
+    #[test]
+    fn all_struct_fields_are_preserved_none_silently_dropped() {
+        let schema = parse_schema("endpointinfo", ENDPOINT_INFO_SCHEMA);
+
+        let mut ifaces = String::new();
+        super::super::interfaces::generate_interfaces(&mut ifaces, &schema);
+        for field in ["socketKind", "endpoint", "pubkey", "selfProof", "tlsDomain"] {
+            assert!(
+                ifaces.contains(&format!("{field}:")),
+                "interface is missing field `{field}` — a regen must never \
+                 silently drop a schema field:\n{ifaces}"
+            );
+        }
+
+        let mut parser = String::new();
+        super::generate_struct_parsers(&mut parser, &schema);
+        for field in ["socketKind", "endpoint", "pubkey", "selfProof", "tlsDomain"] {
+            assert!(
+                parser.contains(field),
+                "parser is missing field `{field}` — a regen must never \
+                 silently drop a schema field:\n{parser}"
+            );
+        }
+        // The two Data fields specifically must read through the real getter,
+        // not be skipped.
+        assert!(parser.contains(".getData("), "{parser}");
+    }
+
+    /// A field whose type references a struct that isn't in the parsed
+    /// schema's `structs` list is a dangling reference — a genuine generator
+    /// bug — and must be a hard build failure, never a silently emitted
+    /// empty-array fallback.
+    #[test]
+    #[should_panic(expected = "dangling reference")]
+    fn dangling_struct_reference_in_list_response_variant_panics() {
+        use hyprstream_rpc_build::schema::types::{
+            FieldDef, FieldSection, StructDef, UnionVariant,
+        };
+
+        let response_struct = StructDef {
+            name: "GhostResponse".to_owned(),
+            fields: vec![FieldDef {
+                name: "ghosts".to_owned(),
+                type_name: "List(GhostStruct)".to_owned(),
+                description: String::new(),
+                fixed_size: None,
+                optional: false,
+                slot_offset: 0,
+                section: FieldSection::Pointer,
+                discriminant_value: 0,
+                serde_rename: None,
+                domain_type: None,
+            }],
+            has_union: true,
+            domain_type: None,
+            origin_file: None,
+            data_words: 0,
+            pointer_words: 1,
+            discriminant_count: 1,
+            discriminant_offset: 0,
+            union_arms: vec![],
+        };
+        let schema = ParsedSchema {
+            request_variants: vec![],
+            response_variants: vec![UnionVariant {
+                name: "ghosts".to_owned(),
+                type_name: "List(GhostStruct)".to_owned(),
+                description: String::new(),
+                scope: String::new(),
+                scope_exempt: false,
+                cli_hidden: false,
+                doc_example: String::new(),
+                vfs_path: String::new(),
+                vfs_kind: String::new(),
+                vfs_bulk: false,
+                vfs_hidden: false,
+            }],
+            structs: vec![],
+            scoped_clients: vec![],
+            enums: vec![],
+            request_struct: None,
+            response_struct: Some(response_struct),
+        };
+
+        let mut out = String::new();
+        super::generate_parsers(&mut out, "ghost", &schema);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #725.

A fresh TS client regen against current schemas surfaces three related generator defects — all instances of the same root cause: the generator falling back to a silently-degraded output (a comment, an empty array, or a blind `export *`) instead of either doing the right thing or failing loudly.

### 1. Unresolved struct references emitted as comments

`emit_field_setter` (builders.rs) had a working direct setter for `Text`/`Data` scalars and `List(Text)`, but **no builder-side setter for `List(Data)`** (or any other `List(<scalar>)` shape like `List(Int64)`, which is real in `worker.capnp`'s `supplementalGroups`). Missing a match, the code fell into the "look up a struct named `Data`/`Int64`" branch, failed to find one, and emitted `// certHashes: List(Data) — struct definition not found` instead of code — while the *reader* side happened to special-case `List(Data)` directly and worked fine, producing the "same field, different emission context" inconsistency the issue described.

Root cause: list-element-type resolution (Text/Data/scalar vs. struct) was duplicated ad hoc across `builders.rs` and `parsers.rs`, each site handling a different subset.

Fix:
- Added `list_setter_method` / `list_getter_method` in `mod.rs` as the single source of truth for which `List(<inner>)` shapes the runtime supports, and routed every call site (builders.rs, parsers.rs — 5 separate spots) through them.
- Extended `capnp.ts` (the generated runtime) with real `setDataList`/`getBoolList`/`setUint8List`/`getUint8List`/.../`setFloat64List`/`getFloat64List` methods so every primitive list shape (not just Data) has a real accessor.
- Any struct reference that's still not found, or any pointer shape the runtime genuinely doesn't support (nested `List(List(_))`, `AnyPointer`/`Interface`), is now a hard `panic!` at generator time — never a comment or empty-array fallback.

### 2. Dropped fields (`EndpointInfo.pubkey`/`selfProof`)

`EndpointInfo` in the current `discovery.capnp` no longer has `pubkey`/`selfProof` (superseded by `serviceJwt`), so there's nothing to restore in the schema itself — but the underlying generator bug class was real: any `Data`-typed field could hit the same silent-fallback code path as defect 1. Added a regression test (`all_struct_fields_are_preserved_none_silently_dropped`) that checks every field on an `EndpointInfo`-shaped struct (Text + Data fields) shows up in both the generated interface and the parser output, so a future silent drop of any field is caught immediately.

### 3. Barrel collisions between same-named types

`generate_index` re-exported every data-only schema module with a blind `export * from './name'`. Two data-only modules exporting a same-named type (the issue's "QoS" scenario) silently produce an ambiguous re-export that `tsc` rejects.

Fix: the barrel generator now scans the *literal* exported symbol names out of each already-generated module's source text (single source of truth — can't drift from what `interfaces.rs`/`builders.rs`/`parsers.rs` actually emit) and, only for modules that actually share an exported name with another module, switches from `export *` to an explicit `export { ... }` list with the colliding names aliased as `{PascalModuleName}{Name}`. Non-colliding modules keep the cheap `export *`.

Note on #464: the barrel-collision fix here is self-contained and does not depend on #464's broader typed-discriminated-union work — it operates purely on generated-text scanning, independent of how union types are shaped.

## What changed

- `crates/hyprstream-rpc-build/src/ts_codegen/mod.rs` — `list_setter_method`/`list_getter_method`, `scan_exported_names`, rewritten `generate_index` with collision detection/aliasing, `getter_method` now panics on truly unsupported input instead of silently guessing `getText`.
- `crates/hyprstream-rpc-build/src/ts_codegen/builders.rs` — routes list field setters through `list_setter_method`; hard `panic!` on dangling struct refs / unsupported pointer types instead of comments.
- `crates/hyprstream-rpc-build/src/ts_codegen/parsers.rs` — same treatment for all 4 reader-side call sites (top-level response variants, union-struct variants, inner-variant reads, generic pointer reads).
- `crates/hyprstream-rpc-build/src/ts_codegen/message.rs` — new runtime methods (`setDataList`, `setBoolList`, `setUint8List`..`setFloat64List` + matching getters) on both `CapnpArena`/`StructBuilder` and `CapnpReader`/`StructReader`.
- `crates/hyprstream-rpc-build/src/backend.rs` — `index_file` trait method now also receives each module's generated content, so the barrel generator can scan real exports.

## Test plan

- [x] `cargo test -p hyprstream-rpc-build` — all 22 tests pass, including new regression tests:
  - `builders::tests::list_data_and_list_scalar_fields_emit_real_setters_not_comments`
  - `builders::tests::dangling_struct_reference_in_list_field_panics` (should_panic)
  - `parsers::tests::list_data_and_list_scalar_fields_parse_with_real_getters`
  - `parsers::tests::all_struct_fields_are_preserved_none_silently_dropped`
  - `parsers::tests::dangling_struct_reference_in_list_response_variant_panics` (should_panic)
  - `barrel_tests::no_collision_uses_plain_wildcard_export`
  - `barrel_tests::colliding_export_name_is_aliased_per_module_not_silently_dropped`
  - `barrel_tests::scan_exported_names_finds_interfaces_types_and_functions`
- [x] `cargo clippy -p hyprstream-rpc-build --all-targets` — clean
- [x] Full regen against the real schemas (`hyprstream-ts-codegen --input-dir codegen-out`) confirms: zero `struct definition not found` / `not yet supported by runtime` / silent-empty-array occurrences anywhere in output; `certHashes: List(Data)` now emits real `setDataList`/`getDataList` calls in every emission context. Some `.cgr` inputs in the shared `codegen-out/` were stale (predate the mandatory-`$scope` annotation check) and couldn't be parsed at all, independent of this change — a full `cargo build -p hyprstream` to regenerate them hit a fresh-checkout `openssl-sys`/perl `FindBin` build issue plus intermittent host disk pressure, unrelated to the generator itself, so the worker.capnp `List(Int64)` case is verified via the unit test fixture rather than the real worker.cgr.