### PR TITLE
feat(workers): tenant VFS as kata container rootfs over virtio-fs (#721)

### DIFF
--- a/crates/hyprstream-workers/src/runtime/kata_agent.rs
+++ b/crates/hyprstream-workers/src/runtime/kata_agent.rs
@@ -97,6 +97,73 @@ use tokio::net::UnixStream;
 /// `kata-hypervisor`/`protocols` dependencies.
 pub const KATA_AGENT_VSOCK_PORT: u32 = 1024;
 
+/// Guest-side storage `driver` the kata-agent dispatches on to mount a
+/// virtio-fs share. Matches `kata_types::device::DRIVER_VIRTIOFS_TYPE`
+/// (`"virtio-fs"`, tag `3.31.0`), which `agent/src/storage/fs_handler.rs`'s
+/// `VirtioFsHandler` registers.
+const VIRTIOFS_STORAGE_DRIVER: &str = "virtio-fs";
+
+/// Guest-side filesystem type used to mount a virtio-fs share. The kata-agent
+/// `baremount`s the share with this `fstype` (`FS_TYPE_VIRTIO_FS = "virtiofs"`
+/// in upstream `runtime-rs/.../share_virtio_fs.rs`, tag `3.31.0`).
+const VIRTIOFS_FSTYPE: &str = "virtiofs";
+
+/// Base directory the kata-agent uses for per-container bundles inside the
+/// guest (`CONTAINER_BASE = "/run/kata-containers"` in `agent/src/rpc.rs`,
+/// tag `3.31.0`). The container's rootfs lives at `<base>/<cid>/rootfs`.
+const CONTAINER_BASE: &str = "/run/kata-containers";
+
+/// How the container's rootfs is provided to the guest.
+///
+/// hyprstream serves the **entire tenant VFS namespace** (with the rootfs
+/// mounted at `/` — RAFS lower + per-sandbox writable upper + the injected
+/// `/models` / `/deltas` / `/stream` mounts) over a **single** vhost-user-fs
+/// (virtio-fs) device attached to the hypervisor under a mount tag (see
+/// `sandbox_fs.rs` / `kata_backend::attach_share_fs`). This tells
+/// [`KataAgentClient::create_container`] to make the kata-agent mount that
+/// share, by tag, **as the container's rootfs** — so the container's
+/// filesystem *is* the tenant VFS.
+#[derive(Debug, Clone)]
+pub struct ContainerRootfs {
+    /// The virtio-fs mount tag the hypervisor attached the share under — the
+    /// `ShareFsDevice` `mount_tag` passed to
+    /// `kata_backend::KataBackend::attach_share_fs`.
+    pub virtiofs_mount_tag: String,
+}
+
+/// Guest path where the kata-agent expects (and, via `setup_bundle`, pivots
+/// into) a container's rootfs: `<CONTAINER_BASE>/<cid>/rootfs`.
+fn guest_rootfs_path(container_id: &str) -> String {
+    format!("{CONTAINER_BASE}/{container_id}/rootfs")
+}
+
+/// Build the `Storage` entry that makes the kata-agent mount the virtio-fs
+/// share (identified by `rootfs.virtiofs_mount_tag`) directly at the
+/// container's rootfs path inside the guest.
+///
+/// The agent's `VirtioFsHandler` → `common_storage_handler` → `mount_storage`
+/// `baremount`s `source` (the tag) as `fstype` (`virtiofs`) at `mount_point`,
+/// creating the destination directory first. Because we mount it **directly
+/// at `<CONTAINER_BASE>/<cid>/rootfs`**, the agent's `setup_bundle` finds the
+/// rootfs path already present (the virtio-fs mount) and uses it as-is — no
+/// bind-mount indirection, and no separate nested `passthrough/<cid>` layout
+/// (that layout is kata's multi-container *bundle* sharing; hyprstream serves
+/// exactly one rootfs per share). The tenant VFS root thereby becomes the
+/// container root. `Root.Path` in the OCI spec points at the same path (see
+/// [`build_minimal_spec`]).
+fn rootfs_storage(container_id: &str, rootfs: &ContainerRootfs) -> agent::Storage {
+    agent::Storage {
+        driver: VIRTIOFS_STORAGE_DRIVER.to_owned(),
+        source: rootfs.virtiofs_mount_tag.clone(),
+        fstype: VIRTIOFS_FSTYPE.to_owned(),
+        // `nodev`, matching upstream kata's `SHARED_DIR_VIRTIO_FS_OPTIONS`
+        // for the sandbox virtio-fs share.
+        options: vec!["nodev".to_owned()],
+        mount_point: guest_rootfs_path(container_id),
+        ..Default::default()
+    }
+}
+
 /// Default per-dial-attempt timeout.
 const DIAL_TIMEOUT: Duration = Duration::from_millis(500);
 
@@ -267,18 +334,33 @@ impl KataAgentClient {
     }
 
     /// `CreateContainer` — minimal OCI spec wired from `container_id` +
-    /// `argv`. See module docs: this is NOT a full OCI bundle translation
-    /// (no rootfs/mounts/namespaces from `PodSandbox` yet), just enough to
-    /// exercise the real RPC end to end.
+    /// `argv`, plus (when `rootfs` is supplied) a virtio-fs `Storage` entry
+    /// that mounts the tenant VFS share as the container's rootfs (#721).
+    ///
+    /// When `rootfs` is `None` the spec's `Root.Path` still points at
+    /// `<CONTAINER_BASE>/<cid>/rootfs`, but nothing is mounted there — the
+    /// guest must already have a rootfs at that path (the historical bare-VM
+    /// case, which fails `CreateContainer` with `No such file or directory`
+    /// precisely because it does not). Supplying `rootfs` is what makes the
+    /// tenant VFS *be* that rootfs; see [`ContainerRootfs`] / [`rootfs_storage`].
+    ///
+    /// This is still NOT a full OCI bundle translation (no devices/volumes/
+    /// namespaces from `PodSandbox`) — just enough to boot a container whose
+    /// filesystem is the hyprstream tenant VFS.
     pub async fn create_container(
         &self,
         container_id: &str,
         exec_id: &str,
         argv: &[String],
+        rootfs: Option<&ContainerRootfs>,
     ) -> Result<()> {
+        let storages = rootfs
+            .map(|r| vec![rootfs_storage(container_id, r)])
+            .unwrap_or_default();
         let req = agent::CreateContainerRequest {
             container_id: container_id.to_owned(),
             exec_id: exec_id.to_owned(),
+            storages,
             OCI: protobuf::MessageField::some(build_minimal_spec(container_id, argv)),
             ..Default::default()
         };
@@ -310,10 +392,17 @@ impl KataAgentClient {
     ///
     /// `argv` is only used if the container needs to be created (it seeds
     /// the OCI `Process.Args` — see [`build_minimal_spec`]); an already
-    /// existing container's original entrypoint is left untouched.
-    async fn ensure_container(&self, container_id: &str, argv: &[String]) -> Result<()> {
+    /// existing container's original entrypoint is left untouched. `rootfs`
+    /// (the tenant VFS virtio-fs share, #721) is likewise only consumed on
+    /// the create path.
+    async fn ensure_container(
+        &self,
+        container_id: &str,
+        argv: &[String],
+        rootfs: Option<&ContainerRootfs>,
+    ) -> Result<()> {
         let create_exec_id = format!("{container_id}-init");
-        match self.create_container(container_id, &create_exec_id, argv).await {
+        match self.create_container(container_id, &create_exec_id, argv, rootfs).await {
             Ok(()) => {}
             Err(e) if is_already_exists(&e) => {
                 tracing::debug!(container_id, "container already exists, skipping create");
@@ -477,11 +566,12 @@ impl KataAgentClient {
         container_id: &str,
         argv: &[String],
         timeout: Duration,
+        rootfs: Option<&ContainerRootfs>,
     ) -> Result<(i32, Vec<u8>, Vec<u8>)> {
         let exec_id = uuid::Uuid::new_v4().to_string();
 
         tokio::time::timeout(timeout, async {
-            self.ensure_container(container_id, argv).await?;
+            self.ensure_container(container_id, argv, rootfs).await?;
             self.exec_process(container_id, &exec_id, argv).await?;
             let status = self.wait_process(container_id, &exec_id).await?;
             let stdout = self.read_stdout_all(container_id, &exec_id).await.unwrap_or_default();
@@ -525,6 +615,12 @@ fn is_already_exists(err: &anyhow::Error) -> bool {
 
 /// Build a minimal `oci::Spec` sufficient to drive `CreateContainer` against
 /// a kata-agent. NOT a complete OCI bundle translation — see module docs.
+///
+/// `Root.Path` is `<CONTAINER_BASE>/<cid>/rootfs`, the guest path the agent's
+/// `setup_bundle` pivots into. When a [`ContainerRootfs`] is supplied to
+/// [`KataAgentClient::create_container`], the accompanying [`rootfs_storage`]
+/// mounts the tenant VFS virtio-fs share at exactly this path, so the tenant
+/// VFS becomes the container's filesystem (#721).
 fn build_minimal_spec(container_id: &str, argv: &[String]) -> oci::Spec {
     oci::Spec {
         Version: "1.0.2".to_owned(),
@@ -535,7 +631,7 @@ fn build_minimal_spec(container_id: &str, argv: &[String]) -> oci::Spec {
             ..Default::default()
         }),
         Root: protobuf::MessageField::some(oci::Root {
-            Path: format!("/run/kata-containers/{container_id}/rootfs"),
+            Path: guest_rootfs_path(container_id),
             Readonly: false,
             ..Default::default()
         }),
@@ -864,7 +960,7 @@ mod tests {
         let (client, fake, _server, _dir) = spin_up_fake_agent(0).await;
 
         client
-            .create_container("ctr-1", "exec-1", &["echo".into(), "hi".into()])
+            .create_container("ctr-1", "exec-1", &["echo".into(), "hi".into()], None)
             .await
             .unwrap();
 
@@ -873,6 +969,41 @@ mod tests {
         assert_eq!(seen.exec_id, "exec-1");
         assert!(seen.OCI.is_some());
         assert_eq!(seen.OCI.Process.Args, vec!["echo".to_owned(), "hi".to_owned()]);
+        // No rootfs supplied → no virtio-fs Storage entry.
+        assert!(seen.storages.is_empty(), "no rootfs → no storages");
+        assert_eq!(
+            seen.OCI.Root.Path, "/run/kata-containers/ctr-1/rootfs",
+            "Root.Path is the guest container rootfs path"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_container_mounts_tenant_vfs_as_rootfs() {
+        // #721: when a ContainerRootfs (tenant VFS virtio-fs mount tag) is
+        // supplied, CreateContainer carries a Storage entry that mounts that
+        // share, by tag, directly at the container's rootfs path — and
+        // Root.Path points at that same path.
+        let (client, fake, _server, _dir) = spin_up_fake_agent(0).await;
+
+        let rootfs = ContainerRootfs {
+            virtiofs_mount_tag: "hyprstream-vfs".to_owned(),
+        };
+        client
+            .create_container("ctr-1", "exec-1", &["true".into()], Some(&rootfs))
+            .await
+            .unwrap();
+
+        let seen = fake.last_create.lock().clone().unwrap();
+        assert_eq!(seen.storages.len(), 1, "exactly one rootfs Storage entry");
+        let st = &seen.storages[0];
+        assert_eq!(st.driver, "virtio-fs");
+        assert_eq!(st.source, "hyprstream-vfs", "source is the virtio-fs mount tag");
+        assert_eq!(st.fstype, "virtiofs");
+        assert_eq!(st.mount_point, "/run/kata-containers/ctr-1/rootfs");
+        assert_eq!(
+            seen.OCI.Root.Path, st.mount_point,
+            "Root.Path must equal the virtio-fs rootfs mount point"
+        );
     }
 
     #[tokio::test]
@@ -910,7 +1041,7 @@ mod tests {
         let (client, _fake, _server, _dir) = spin_up_fake_agent(42).await;
 
         let (status, stdout, stderr) = client
-            .exec("ctr-1", &["echo".into(), "hi".into()], Duration::from_secs(5))
+            .exec("ctr-1", &["echo".into(), "hi".into()], Duration::from_secs(5), None)
             .await
             .unwrap();
 
@@ -929,7 +1060,7 @@ mod tests {
         let (client, _fake, _server, _dir) = spin_up_fake_agent_with(fake).await;
 
         let result = client
-            .exec("ctr-1", &["echo".into()], Duration::from_millis(50))
+            .exec("ctr-1", &["echo".into()], Duration::from_millis(50), None)
             .await;
         assert!(result.is_err(), "exec must time out when wait_process stalls");
         assert!(result.unwrap_err().to_string().contains("timed out"));
@@ -945,7 +1076,7 @@ mod tests {
         let (client, _fake, _server, _dir) = spin_up_fake_agent_with(fake).await;
 
         let (status, _stdout, _stderr) = client
-            .exec("ctr-1", &["true".into()], Duration::from_secs(5))
+            .exec("ctr-1", &["true".into()], Duration::from_secs(5), None)
             .await
             .expect("exec must succeed despite ALREADY_EXISTS on create/start");
         assert_eq!(status, 5);

--- a/crates/hyprstream-workers/src/runtime/kata_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/kata_backend.rs
@@ -24,10 +24,17 @@ use crate::image::RafsStore;
 
 use super::backend::{SandboxBackend, SandboxHandle};
 use super::client::{CpuUsage, LinuxContainerResources, MemoryUsage, PodSandboxConfig};
-use super::kata_agent::{AgentAddress, KataAgentClient};
+use super::kata_agent::{AgentAddress, ContainerRootfs, KataAgentClient};
 use super::sandbox::PodSandbox;
 use super::sandbox_fs::{SandboxFs, SandboxFsServer, VFS_SOCKET_NAME};
 use hyprstream_vfs::{Subject, SyntheticNode};
+
+/// virtio-fs mount tag under which `start()` attaches the composed per-sandbox
+/// tenant VFS to Cloud Hypervisor. The guest's kata-agent mounts the share by
+/// this tag (see [`kata_agent::ContainerRootfs`](super::kata_agent::ContainerRootfs))
+/// as the container's rootfs (#721). A single, stable tag is used because
+/// exactly one VFS share is attached per sandbox.
+const ROOTFS_MOUNT_TAG: &str = "hyprstream-vfs";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Handle
@@ -47,6 +54,12 @@ pub struct KataHandle {
     /// `hyprstream-vfs-server`. Held for the VM's lifetime so the serving thread
     /// + injected registries outlive the guest; dropped on sandbox teardown.
     pub vfs_server: Option<SandboxFsServer>,
+    /// virtio-fs mount tag of the composed tenant VFS share attached to this
+    /// sandbox's VM, when one was attached (#721). `exec_sync` passes this to
+    /// the kata-agent so `CreateContainer` mounts the share, by tag, as the
+    /// container's rootfs. `None` when the VM booted its own rootfs with no
+    /// tenant VFS (e.g. `sandbox.image_id` unset).
+    pub rootfs_mount_tag: Option<String>,
     /// kata-agent ttrpc/vsock client (#344), connected lazily on first
     /// `exec_sync` call and cached for subsequent calls. `None` until then,
     /// or if the guest agent connection could not be established (e.g. the
@@ -64,6 +77,7 @@ impl std::fmt::Debug for KataHandle {
             .field("api_socket", &self.api_socket)
             .field("virtiofs_socket", &self.virtiofs_socket)
             .field("vfs_socket", &self.vfs_server.as_ref().map(SandboxFsServer::socket_path))
+            .field("rootfs_mount_tag", &self.rootfs_mount_tag)
             .finish_non_exhaustive()
     }
 }
@@ -433,10 +447,15 @@ impl SandboxBackend for KataBackend {
             .map_err(|e| WorkerError::VmStartFailed(format!("failed to prepare VM: {e}")))?;
 
         // Attach the composed VFS socket as a CH ShareFs device, after prepare_vm
-        // and before start_vm so it is folded into the boot VmConfig.
-        if let Some(ref socket) = share_socket {
-            Self::attach_share_fs(&hypervisor, &sandbox.id, socket, "hyprstream-vfs").await?;
-        }
+        // and before start_vm so it is folded into the boot VmConfig. Record the
+        // mount tag so `exec_sync` can tell the kata-agent to mount this share as
+        // the container's rootfs (#721).
+        let rootfs_mount_tag = if let Some(ref socket) = share_socket {
+            Self::attach_share_fs(&hypervisor, &sandbox.id, socket, ROOTFS_MOUNT_TAG).await?;
+            Some(ROOTFS_MOUNT_TAG.to_owned())
+        } else {
+            None
+        };
 
         let timeout_secs = i32::try_from(pool_config.create_timeout_secs).unwrap_or(i32::MAX);
         tracing::debug!(sandbox_id = %sandbox.id, timeout_secs, "Starting VM");
@@ -457,6 +476,7 @@ impl SandboxBackend for KataBackend {
             api_socket,
             virtiofs_socket: virtiofs_sock,
             vfs_server,
+            rootfs_mount_tag,
             agent: tokio::sync::Mutex::new(None),
         });
 
@@ -536,6 +556,9 @@ impl SandboxBackend for KataBackend {
                     // The per-sandbox VFS server is not reusable across resets;
                     // a recycled sandbox composes a fresh one on next start.
                     vfs_server: None,
+                    // Fresh compose+attach on next start re-establishes the tag;
+                    // the old container (and its rootfs mount) is torn down.
+                    rootfs_mount_tag: None,
                     // A reused (warm-pool) sandbox keeps the same VM, but the
                     // container(s) inside it are torn down — drop any cached
                     // agent connection so the next `exec_sync` reconnects
@@ -601,6 +624,13 @@ impl SandboxBackend for KataBackend {
             if let Some(kata) = handle.as_any().downcast_ref::<KataHandle>() {
                 Self::attach_share_fs(&kata.hypervisor, &sandbox.id, server.socket_path(), &mount_tag)
                     .await?;
+                // TODO(#721): a namespace delivered here becomes visible over
+                // virtio-fs but is NOT recorded as the container rootfs tag on
+                // the (already-constructed, shared) `KataHandle`, so a later
+                // `exec_sync` won't mount it as rootfs. The boot-time rootfs
+                // path (`start()` → `rootfs_mount_tag`) is what #721 wires;
+                // making a post-start delivered namespace the container rootfs
+                // needs interior mutability on the handle (or a re-create RPC).
             }
         }
 
@@ -645,8 +675,24 @@ impl SandboxBackend for KataBackend {
         // one Kata VM are a separate concern from #344's vsock/ttrpc client).
         let container_id = sandbox.id.clone();
 
+        // When a tenant VFS was attached at boot (#721), tell the kata-agent to
+        // mount that virtio-fs share, by tag, as the container's rootfs — so
+        // `CreateContainer` finds a real rootfs at `<CONTAINER_BASE>/<cid>/rootfs`
+        // (the tenant VFS) instead of failing `No such file or directory`.
+        let rootfs = kata
+            .rootfs_mount_tag
+            .as_ref()
+            .map(|tag| ContainerRootfs {
+                virtiofs_mount_tag: tag.clone(),
+            });
+
         match client
-            .exec(&container_id, command, std::time::Duration::from_secs(timeout_secs))
+            .exec(
+                &container_id,
+                command,
+                std::time::Duration::from_secs(timeout_secs),
+                rootfs.as_ref(),
+            )
             .await
         {
             Ok(out) => Ok(out),
@@ -974,6 +1020,7 @@ mod tests {
             api_socket: sandbox_path.join("test.sock"),
             virtiofs_socket: Some(sandbox_path.join("virtiofs.sock")),
             vfs_server: None,
+            rootfs_mount_tag: None,
             agent: tokio::sync::Mutex::new(None),
         })
     }

--- a/crates/hyprstream-workers/src/runtime/sandbox.rs
+++ b/crates/hyprstream-workers/src/runtime/sandbox.rs
@@ -134,6 +134,20 @@ impl PodSandbox {
         self.backend_handle = Some(handle);
     }
 
+    /// Set the image id this sandbox's tenant VFS is composed from.
+    ///
+    /// Normally populated by the worker runtime from the `CreateSandbox` RPC.
+    /// Exposed (doc-hidden) as the seam an out-of-crate boot harness (#721)
+    /// needs so that [`KataBackend::start`](super::kata_backend::KataBackend)
+    /// composes + serves + attaches the per-sandbox tenant VFS as the guest's
+    /// virtio-fs rootfs share — instead of booting the bare VM rootfs with no
+    /// container filesystem. When unset, `start()` attaches no share and the
+    /// container has no rootfs (the failure #721 fixes).
+    #[doc(hidden)]
+    pub fn set_image_id(&mut self, image_id: impl Into<String>) {
+        self.image_id = Some(image_id.into());
+    }
+
     /// Mark sandbox as ready
     pub fn mark_ready(&mut self) {
         self.state = PodSandboxState::SandboxReady;

--- a/crates/hyprstream-workers/tests/kata_spawn_e2e.rs
+++ b/crates/hyprstream-workers/tests/kata_spawn_e2e.rs
@@ -206,14 +206,36 @@ async fn kata_spawn_e2e() -> TestResult {
     // so this external harness cannot synthesize a tenant RAFS image itself.
     // Supply `HYPRSTREAM_KATA_RAFS_IMAGE_ID` pointing at an image already
     // present in the store to drive the tenant-VFS-as-rootfs path.
-    let rafs_image_id = std::env::var("HYPRSTREAM_KATA_RAFS_IMAGE_ID").ok();
-    match &rafs_image_id {
-        Some(id) => println!("[kata_spawn_e2e] tenant VFS rootfs from RAFS image {id}"),
-        None => println!(
-            "[kata_spawn_e2e] tenant-VFS rootfs skipped \
-             (set HYPRSTREAM_KATA_RAFS_IMAGE_ID to exercise it)"
-        ),
-    }
+    // Resolve the tenant RAFS image id. Preference order:
+    //   1. HYPRSTREAM_KATA_RAFS_IMAGE_ID — an id already present in a store.
+    //   2. HYPRSTREAM_KATA_PULL_IMAGE — an OCI ref to pull+convert into THIS
+    //      run's store (self-contained: the fresh temp store is otherwise empty).
+    let rafs_image_id = match std::env::var("HYPRSTREAM_KATA_RAFS_IMAGE_ID").ok() {
+        Some(id) => {
+            println!("[kata_spawn_e2e] tenant VFS rootfs from RAFS image {id}");
+            Some(id)
+        }
+        None => match std::env::var("HYPRSTREAM_KATA_PULL_IMAGE").ok() {
+            Some(image_ref) => {
+                println!("[kata_spawn_e2e] pulling+converting {image_ref} into the RAFS store …");
+                // TODO(#737): `RafsStore::ensure`/`pull` drops a nested tokio
+                // runtime inside its own execution → panics from ANY tokio
+                // context (verified: a dedicated-thread `block_on` wrapper does
+                // not help). Until #737 is fixed, prefer HYPRSTREAM_KATA_RAFS_IMAGE_ID
+                // pointing at a store pre-populated by a non-async pull.
+                let id = rafs_store.ensure(&image_ref).await?;
+                println!("[kata_spawn_e2e] tenant VFS rootfs from pulled RAFS image {id}");
+                Some(id)
+            }
+            None => {
+                println!(
+                    "[kata_spawn_e2e] tenant-VFS rootfs skipped (set \
+                     HYPRSTREAM_KATA_RAFS_IMAGE_ID or HYPRSTREAM_KATA_PULL_IMAGE)"
+                );
+                None
+            }
+        },
+    };
 
     // ─────────────────────────────────────────────────────────────────────
     // Boot the microVM via the real backend path.

--- a/crates/hyprstream-workers/tests/kata_spawn_e2e.rs
+++ b/crates/hyprstream-workers/tests/kata_spawn_e2e.rs
@@ -41,17 +41,24 @@
 //! the harness author. Do not remove the self-skip guard to "just verify it
 //! boots".
 //!
-//! ## Known driving-API gaps (see `TODO(#721)` below)
+//! ## Tenant VFS as container rootfs (#721)
 //!
-//! * `PodSandbox::image_id` is `pub(crate)` with no public setter, so an
-//!   external harness cannot instruct `start()` to compose+attach a *tenant*
-//!   VFS as the guest's virtio-fs share. `start()` therefore boots the bare
-//!   guest rootfs; the tenant-file-over-virtio-fs assertion is blocked on
-//!   exposing that seam.
-//! * `image::rafs_builder::build_rafs_bootstrap` is `pub(crate)`, so an
-//!   external harness cannot synthesize a RAFS tenant image; the
-//!   `SandboxFs::compose` + `serve_on` surface is exercised only when a
-//!   pre-built RAFS image id is supplied via `HYPRSTREAM_KATA_RAFS_IMAGE_ID`.
+//! `PodSandbox::set_image_id` (the doc-hidden seam) lets this external harness
+//! instruct `start()` to compose + serve + attach the per-sandbox **tenant
+//! VFS** as the guest's virtio-fs rootfs share. `start()` records the mount
+//! tag; `exec_sync` then tells the kata-agent (`CreateContainer`) to mount
+//! that share, by tag, as the container's rootfs at
+//! `/run/kata-containers/<cid>/rootfs`. So — with `HYPRSTREAM_KATA_RAFS_IMAGE_ID`
+//! set to a pre-built RAFS image in the store — the container's filesystem is
+//! the hyprstream tenant VFS (RAFS rootfs + injected `/models` `/deltas`
+//! `/stream`), which the assertion below verifies.
+//!
+//! ## Remaining gap (see `TODO(#721)`)
+//!
+//! * `image::rafs_builder::build_rafs_bootstrap` is `pub(crate)`, so this
+//!   external harness cannot synthesize a RAFS tenant image itself; the
+//!   tenant-VFS-rootfs path is exercised only when a pre-built RAFS image id
+//!   is supplied via `HYPRSTREAM_KATA_RAFS_IMAGE_ID`.
 
 #![cfg(feature = "kata-vm")]
 // This is an opt-in operator harness: it intentionally prints skip reasons to
@@ -63,12 +70,8 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use hyprstream_workers::runtime::{
-    KataBackend, PodSandbox, PodSandboxConfig, SandboxBackend, SandboxFs, VFS_SOCKET_NAME,
-};
+use hyprstream_workers::runtime::{KataBackend, PodSandbox, PodSandboxConfig, SandboxBackend};
 use hyprstream_workers::{HypervisorType, ImageConfig, PoolConfig, RafsStore};
-
-use hyprstream_vfs::{Subject, SyntheticNode};
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
 
@@ -192,53 +195,24 @@ async fn kata_spawn_e2e() -> TestResult {
 
     let (image_config, rafs_store) = image_store(scratch.path())?;
 
-    // ─────────────────────────────────────────────────────────────────────
-    // (Optional) tenant VFS: compose + serve_on over vhost-user-fs.
-    //
-    // Exercises the public `SandboxFs::compose` → `serve_on` surface that the
-    // backend's own `start()` uses internally. Gated on a pre-built RAFS image
-    // id because:
+    // Optional tenant VFS: when a pre-built RAFS image id is supplied, we tell
+    // `start()` (via `set_image_id` below) to compose + serve + attach that
+    // image's tenant VFS as the guest's virtio-fs rootfs share (#721). When
+    // absent, the VM boots its own `PoolConfig::vm_image` rootfs and the
+    // container has no rootfs (the historical failure #721 targets), so the
+    // exec assertion is relaxed to the bare-guest smoke below.
     //
     // TODO(#721): `image::rafs_builder::build_rafs_bootstrap` is `pub(crate)`,
     // so this external harness cannot synthesize a tenant RAFS image itself.
     // Supply `HYPRSTREAM_KATA_RAFS_IMAGE_ID` pointing at an image already
-    // present in the store to drive this path; otherwise it is skipped.
-    // ─────────────────────────────────────────────────────────────────────
-    if let Ok(image_id) = std::env::var("HYPRSTREAM_KATA_RAFS_IMAGE_ID") {
-        let subject = Subject::new("tenant-721");
-        // A couple of injected files so the guest would see /models/... content.
-        let models = SyntheticNode::dir().with_child(
-            "hello",
-            SyntheticNode::file(b"hello-from-tenant-vfs\n".to_vec()),
-        );
-        let deltas = SyntheticNode::dir();
-        let sandbox_dir = scratch.path().join("tenant-fs");
-        std::fs::create_dir_all(&sandbox_dir)?;
-
-        let fs = SandboxFs::compose(
-            &rafs_store,
-            &image_id,
-            &sandbox_dir,
-            subject,
-            models,
-            deltas,
-        )?;
-        let socket = sandbox_dir.join(VFS_SOCKET_NAME);
-        let server = fs.serve_on(socket.clone(), tokio::runtime::Handle::current())?;
-        assert_eq!(
-            server.socket_path(),
-            socket.as_path(),
-            "serve_on must expose the socket we attach to Cloud Hypervisor"
-        );
-        println!(
-            "[kata_spawn_e2e] tenant VFS served on {}",
-            server.socket_path().display()
-        );
-    } else {
-        println!(
-            "[kata_spawn_e2e] tenant-VFS compose/serve skipped \
+    // present in the store to drive the tenant-VFS-as-rootfs path.
+    let rafs_image_id = std::env::var("HYPRSTREAM_KATA_RAFS_IMAGE_ID").ok();
+    match &rafs_image_id {
+        Some(id) => println!("[kata_spawn_e2e] tenant VFS rootfs from RAFS image {id}"),
+        None => println!(
+            "[kata_spawn_e2e] tenant-VFS rootfs skipped \
              (set HYPRSTREAM_KATA_RAFS_IMAGE_ID to exercise it)"
-        );
+        ),
     }
 
     // ─────────────────────────────────────────────────────────────────────
@@ -259,11 +233,13 @@ async fn kata_spawn_e2e() -> TestResult {
     let sandbox_path = runtime_dir.join(&sandbox_id);
     let mut sandbox = PodSandbox::new(sandbox_id.clone(), &sandbox_config, sandbox_path);
 
-    // TODO(#721): no public setter for `PodSandbox::image_id`, so `start()`
-    // cannot be told to compose+attach the tenant VFS as this guest's
-    // virtio-fs share. The VM boots its own rootfs (`PoolConfig::vm_image`);
-    // wiring the tenant share end-to-end (and asserting a tenant file is
-    // visible over virtio-fs) needs that seam exposed.
+    // #721: hand `start()` the tenant image id so it composes + serves + attaches
+    // the tenant VFS as this guest's virtio-fs rootfs share (and records the
+    // mount tag `exec_sync` uses to mount it as the container's rootfs). Without
+    // this, `start()` attaches no share and the container has no rootfs.
+    if let Some(ref id) = rafs_image_id {
+        sandbox.set_image_id(id.clone());
+    }
     let annotations: HashMap<String, String> = HashMap::new();
 
     // NOTE: this call boots a real Cloud Hypervisor guest. It only runs after
@@ -280,20 +256,34 @@ async fn kata_spawn_e2e() -> TestResult {
     //
     // `exec_sync` lazily dials the guest agent over hybrid-vsock
     // (`guest_agent_client`), then drives CreateContainer → StartContainer →
-    // ExecProcess → WaitProcess. `cat`-ing a file that exists in the kata
-    // guest rootfs confirms the agent is reachable and a container-in-VM ran.
+    // ExecProcess → WaitProcess. When a tenant VFS was attached, `exec_sync`
+    // tells CreateContainer to mount that virtio-fs share as the container's
+    // rootfs, so the exec runs with the tenant VFS as its filesystem.
     //
-    // TODO(#721): once the tenant-VFS seam above is wired, switch this to
-    // `cat /models/hello` and assert `b"hello-from-tenant-vfs\n"` to prove the
-    // tenant share is visible over virtio-fs (the issue's real target).
+    // Proof that the tenant VFS *is* the container rootfs: the injected
+    // hyprstream mounts (`/models`, `/deltas`, `/stream`) live at the tenant
+    // VFS root and therefore at the container's `/`. They do NOT exist in a
+    // bare kata guest rootfs, so listing `/` inside the container and seeing
+    // them is unambiguous evidence the virtio-fs share is the container's
+    // filesystem. (The bare-guest fallback, with no tenant VFS, can only smoke
+    // that the agent + a container ran at all.)
+    //
+    // This is what the OPERATOR BOOT will validate: on a real kata 3.31.0
+    // microVM the `ls /` below must exit 0 and its stdout must contain
+    // `models`, `deltas`, and `stream` — i.e. the tenant VFS mounted over
+    // virtio-fs is the container's root.
+    //
+    // TODO(#721): once `build_rafs_bootstrap` is exposed to this harness (or
+    // an injected-content seam exists), also `cat` a known file the tenant VFS
+    // injects (e.g. `/models/<id>/...`) and assert its bytes.
     // ─────────────────────────────────────────────────────────────────────
-    let exec_result = backend
-        .exec_sync(
-            &sandbox,
-            &["cat".to_owned(), "/etc/hostname".to_owned()],
-            30,
-        )
-        .await;
+    let tenant_vfs = rafs_image_id.is_some();
+    let exec_argv: Vec<String> = if tenant_vfs {
+        vec!["ls".to_owned(), "-1".to_owned(), "/".to_owned()]
+    } else {
+        vec!["cat".to_owned(), "/etc/hostname".to_owned()]
+    };
+    let exec_result = backend.exec_sync(&sandbox, &exec_argv, 30).await;
 
     // Always attempt teardown, even if exec failed, so a booted VM is never
     // left running past the test.
@@ -306,16 +296,27 @@ async fn kata_spawn_e2e() -> TestResult {
         }
     };
 
+    let stdout_str = String::from_utf8_lossy(&stdout);
     println!(
-        "[kata_spawn_e2e] guest exec exit={exit_code} stdout={:?} stderr={:?}",
-        String::from_utf8_lossy(&stdout),
+        "[kata_spawn_e2e] guest exec ({:?}) exit={exit_code} stdout={stdout_str:?} stderr={:?}",
+        exec_argv,
         String::from_utf8_lossy(&stderr)
     );
-    assert_eq!(exit_code, 0, "cat in guest should exit 0");
-    assert!(
-        !stdout.is_empty(),
-        "guest /etc/hostname should be non-empty (proves the container-in-VM ran)"
-    );
+    assert_eq!(exit_code, 0, "guest exec should exit 0");
+    if tenant_vfs {
+        for injected in ["models", "deltas", "stream"] {
+            assert!(
+                stdout_str.lines().any(|l| l.trim() == injected),
+                "container `/` must list injected tenant-VFS mount `/{injected}` \
+                 (proves the virtio-fs tenant VFS is the container rootfs); got: {stdout_str:?}"
+            );
+        }
+    } else {
+        assert!(
+            !stdout.is_empty(),
+            "guest /etc/hostname should be non-empty (proves the container-in-VM ran)"
+        );
+    }
 
     // ─────────────────────────────────────────────────────────────────────
     // Teardown: stop the VM and remove all runtime state.


### PR DESCRIPTION
## What & why

The #721 boot harness boots a real kata 3.31.0 microVM and the kata-agent vsock
handshake works, but `CreateContainer` fails `No such file or directory`: the
guest has **no container rootfs**. `build_minimal_spec` sets
`Root.Path = /run/kata-containers/<cid>/rootfs`, which doesn't exist in-guest
because the bare VM boots with no container image.

This wires the **tenant VFS as the container rootfs over virtio-fs**. The
virtio-fs *share* mechanism already existed (`SandboxFs::compose` → `serve_on`
→ `ShareFsConfig`/`ShareFsDevice` attached to Cloud Hypervisor in
`kata_backend.rs`); what was missing was telling the kata-agent to mount that
share **as the container's rootfs**.

## Mechanism (verified against kata-containers 3.31.0 source)

Kata mounts a container rootfs from a virtio-fs share by passing the agent a
`Storage` entry in `CreateContainerRequest.storages`:

- `agent/src/storage/fs_handler.rs::VirtioFsHandler` registers driver
  `DRIVER_VIRTIOFS_TYPE = "virtio-fs"` (`libs/kata-types/src/device.rs`).
- It calls `common_storage_handler` → `mount_storage` →
  `baremount(source=<mount tag>, mount_point, fstype="virtiofs")`, creating the
  destination dir first.
- In `agent/src/rpc.rs::do_create_container`, `add_storages(req.storages, …)`
  runs **before** `setup_bundle`. `setup_bundle` (`CONTAINER_BASE =
  "/run/kata-containers"`) checks whether `<base>/<cid>/rootfs` already exists;
  if it does (because we mounted the share there), it **skips the bind-mount and
  uses it as-is**, then pivots into it.

Upstream nests each container under `passthrough/<cid>/rootfs` inside a
sandbox-wide share (`share_fs/utils.rs`). hyprstream is simpler: the
`hyprstream-vfs-server` exports the **entire tenant VFS namespace** (rootfs at
`/` + injected `/models` `/deltas` `/stream`) as **one** virtio-fs device per
sandbox — so the whole share root *is* the container rootfs. We therefore mount
the share **directly at `/run/kata-containers/<cid>/rootfs`** (a single
`Storage{driver:"virtio-fs", source:<mount tag>, fstype:"virtiofs",
options:["nodev"], mount_point:<rootfs path>}`), which is also `Root.Path`. No
`passthrough/<cid>` indirection, no bind-mount indirection. The virtio-fs mount
point is itself a mountpoint, so the agent's `pivot_root` is satisfied.

## The seam exposed (smallest correct)

- `PodSandbox::set_image_id` — `#[doc(hidden)]` setter (was `pub(crate)`
  `image_id` with no setter). Lets an out-of-crate harness tell
  `KataBackend::start` to compose + serve + attach the tenant VFS as the guest's
  virtio-fs rootfs share.
- `KataHandle.rootfs_mount_tag: Option<String>` — `start()` records the mount
  tag (`ROOTFS_MOUNT_TAG = "hyprstream-vfs"`) when it attaches a share.
- `kata_agent::ContainerRootfs { virtiofs_mount_tag }` + threading through
  `create_container` / `ensure_container` / `exec` (new `Option<&ContainerRootfs>`
  arg). `exec_sync` builds it from `KataHandle.rootfs_mount_tag`.
- `rootfs_storage()` builds the virtio-fs `Storage` entry; `build_minimal_spec`
  keeps `Root.Path = <base>/<cid>/rootfs` (now backed by the mounted share).

No broad API expansion; the guest-facing constants mirror upstream kata.

## What the operator boot will validate

With `HYPRSTREAM_KATA_KERNEL` / `HYPRSTREAM_KATA_IMAGE` / `/dev/kvm` /
`cloud-hypervisor` **and** `HYPRSTREAM_KATA_RAFS_IMAGE_ID` (a pre-built RAFS
image in the store), `kata_spawn_e2e` boots the microVM, `start()` attaches the
tenant VFS, and `exec_sync(["ls","-1","/"])` inside the container must exit 0
and list `models`, `deltas`, `stream` — the injected hyprstream mounts that live
at the tenant-VFS root and do **not** exist in a bare kata guest rootfs. That is
unambiguous evidence the virtio-fs tenant VFS is the container's filesystem.

## Build gate (compile-only; nothing booted)

- `cargo test -p hyprstream-workers --features kata-vm --no-run` — **passes**
  (both `hyprstream_workers` unittests and `kata_spawn_e2e` link).
- `cargo clippy -p hyprstream-workers --tests --features kata-vm -- -D warnings`
  — **clean**.

Unit coverage added in `kata_agent.rs`:
`test_create_container_mounts_tenant_vfs_as_rootfs` asserts the virtio-fs
`Storage` (driver/source/fstype/mount_point) and `Root.Path == mount_point`;
`test_create_container_round_trip` asserts no storages / correct `Root.Path`
when no rootfs is supplied.

## Remaining `TODO(#721)`

- `image::rafs_builder::build_rafs_bootstrap` is `pub(crate)`, so the external
  harness still can't synthesize a tenant RAFS image itself — the operator must
  supply `HYPRSTREAM_KATA_RAFS_IMAGE_ID`. Once exposed (or an injected-content
  seam exists), also `cat` a known injected file and assert its bytes.
- `deliver_namespace` (#635) attaches a *post-start* namespace over virtio-fs but
  can't record it as the rootfs tag on the already-constructed shared
  `KataHandle`; making a delivered namespace the container rootfs needs interior
  mutability on the handle (or a re-create RPC). The boot-time path
  (`start()` → `rootfs_mount_tag`) is what this PR wires.

**Not booted:** all validation here is `--no-run` compile + clippy. No VM /
cloud-hypervisor / guest was launched.
