### PR TITLE
feat(9p): raw (no-handshake) vsock mode for guest-initiated 9P connections (#741)

### DIFF
--- a/crates/hyprstream-9p/src/lib.rs
+++ b/crates/hyprstream-9p/src/lib.rs
@@ -41,4 +41,6 @@ pub use backend::{Backend, OpenResult, StatResult, WalkResult};
 #[cfg(not(target_arch = "wasm32"))]
 pub use mount_backend::MountBackend;
 #[cfg(not(target_arch = "wasm32"))]
-pub use translator::{serve_mount_uds, serve_mount_vsock, FidTable, Translator};
+pub use translator::{
+    serve_mount_uds, serve_mount_vsock, serve_mount_vsock_raw, FidTable, Translator,
+};

--- a/crates/hyprstream-9p/src/translator.rs
+++ b/crates/hyprstream-9p/src/translator.rs
@@ -166,6 +166,29 @@ impl Translator {
         self.serve_listener(HybridVsockListener { inner: listener }).await
     }
 
+    /// Run the accept loop over a **raw** (no-handshake) hybrid-vsock host
+    /// socket: a per-port host UDS the **guest dials**.
+    ///
+    /// The raw sibling of [`serve_vsock`](Self::serve_vsock). Where
+    /// [`serve_vsock`] plays the CH host-multiplexer role for connections
+    /// *hyprstream* initiates — and therefore strips a `connect <port>\n` text
+    /// preamble off each accepted stream — this entry point serves a **per-port
+    /// host listener** (`<vsock-base>_<port>`, e.g. `VFS_9P_VSOCK_PORT=564`) that
+    /// the guest connects to. Per the Firecracker/CH hybrid-vsock spec,
+    /// guest-initiated connections to a per-port host UDS arrive **raw**: there is
+    /// no `connect <port>\n` preamble (the port is already encoded in the socket
+    /// path, not in an in-band handshake). Stripping a preamble here would eat the
+    /// guest's first 9P `Tversion` bytes and break the handshake (#741).
+    ///
+    /// So this hands each accepted [`UnixStream`] straight to the shared
+    /// [`serve_connection`](Self::serve_connection) core with **no** preamble
+    /// strip. The `Subject`-per-op enforcement and wire-faithful 9P2000.L framing
+    /// are byte-identical to every other transport; only the accept surface
+    /// differs (raw, via [`RawVsockListener`]).
+    pub async fn serve_vsock_raw(self, listener: UnixListener) -> Result<()> {
+        self.serve_listener(RawVsockListener { inner: listener }).await
+    }
+
     /// Transport-agnostic accept loop shared by [`serve`](Self::serve) and
     /// [`serve_uds`](Self::serve_uds). Each accepted connection is served on its
     /// own task via [`serve_connection`](Self::serve_connection); errors on one
@@ -390,6 +413,30 @@ pub async fn serve_mount_vsock(
     Translator::from_mount(mount, subject).serve_vsock(listener).await
 }
 
+/// Bind a **raw** (no-handshake) hybrid-vsock **per-port** host socket at `path`
+/// and serve `mount` (scoped to `subject`) as its 9P2000.L root until the socket
+/// errors or is closed.
+///
+/// The raw sibling of [`serve_mount_vsock`], for the **guest-initiated**
+/// direction (#741). `path` is a per-port host UDS (`<vsock-base>_<port>`) the
+/// **guest dials**; per the Firecracker/CH hybrid-vsock spec such connections
+/// arrive **raw** (no `connect <port>\n` preamble — the port is encoded in the
+/// socket path). Accepted streams go straight to the shared 9P core via
+/// [`Translator::serve_vsock_raw`] with no preamble strip, so the guest's first
+/// `Tversion` bytes are treated as 9P and not consumed. This is the entry a kata
+/// supervisor uses to expose a tenant's Subject-scoped export on
+/// `VFS_9P_VSOCK_PORT`.
+pub async fn serve_mount_vsock_raw(
+    mount: Arc<dyn Mount>,
+    subject: Subject,
+    path: impl AsRef<Path>,
+) -> Result<()> {
+    let listener = UnixListener::bind(path.as_ref()).with_context(|| {
+        format!("bind 9P raw hybrid-vsock per-port listener at {:?}", path.as_ref())
+    })?;
+    Translator::from_mount(mount, subject).serve_vsock_raw(listener).await
+}
+
 /// Transport-agnostic accept surface, implemented for [`TcpListener`] and
 /// [`UnixListener`] so both share one accept loop (`serve_listener`).
 ///
@@ -483,6 +530,42 @@ impl Listen for HybridVsockListener {
             .local_addr()
             .map(|a| format!("hvsock:{a:?}"))
             .unwrap_or_else(|_| "hvsock:?".to_owned())
+    }
+}
+
+/// A **raw** (no-handshake) hybrid-vsock **per-port** host listener: a
+/// [`UnixListener`] bound at a per-port host UDS (`<vsock-base>_<port>`) that the
+/// **guest dials**. Unlike [`HybridVsockListener`], accepted connections carry
+/// **no** `connect <port>\n` preamble — per the Firecracker/CH hybrid-vsock spec
+/// the port is encoded in the socket path, and guest-initiated connections to a
+/// per-port host UDS arrive raw (#741). So [`accept_conn`](Listen::accept_conn)
+/// yields the accepted [`UnixStream`] verbatim to the shared 9P serve path; the
+/// guest's first bytes are the 9P `Tversion`, never a preamble.
+///
+/// This is a thin, self-documenting wrapper (rather than serving the bare
+/// [`UnixListener`]) so the "listening" log line and peer strings identify the
+/// channel as raw hybrid-vsock; the byte handling is identical to the plain UDS
+/// impl.
+struct RawVsockListener {
+    inner: UnixListener,
+}
+
+#[async_trait]
+impl Listen for RawVsockListener {
+    type Conn = UnixStream;
+
+    async fn accept_conn(&self) -> std::io::Result<(UnixStream, String)> {
+        // No preamble: hand the stream straight through. The first bytes the
+        // guest sends are the 9P Tversion.
+        let (stream, peer) = self.inner.accept().await?;
+        Ok((stream, format!("rawvsock:{peer:?}")))
+    }
+
+    fn describe(&self) -> String {
+        self.inner
+            .local_addr()
+            .map(|a| format!("rawvsock:{a:?}"))
+            .unwrap_or_else(|_| "rawvsock:?".to_owned())
     }
 }
 
@@ -744,6 +827,76 @@ mod tests {
         let (_, resp) = msg::parse_response(&read_frame(&mut client).await).unwrap();
         match resp {
             Response::Read { data } => assert_eq!(&data, b"hello vsock"),
+            other => panic!("expected Rread with payload, got {other:?}"),
+        }
+
+        drop(client);
+        server.abort();
+        let _ = std::fs::remove_file(&sock);
+    }
+
+    /// RAW (no-handshake) vsock: a guest-initiated client that connects to a
+    /// per-port host UDS and sends its 9P `Tversion` **immediately** — with NO
+    /// `connect <port>\n` preamble — must drive a byte-identical 9P2000.L session.
+    /// This is the #741 guest→host direction: the raw serve path must treat the
+    /// very first bytes as 9P and never consume a preamble. Exercises
+    /// [`Translator::serve_vsock_raw`] / [`RawVsockListener`].
+    #[tokio::test]
+    async fn raw_vsock_no_preamble_9p_session() {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        use tokio::net::UnixStream;
+
+        let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+        let sock = std::env::temp_dir()
+            .join(format!("hs9p-rawvsock-{}-{nanos}.sock", std::process::id()));
+        let _ = std::fs::remove_file(&sock);
+
+        let backend = MemoryBackend::default();
+        backend.add_file("/hello.txt", b"hello raw");
+        let listener = UnixListener::bind(&sock).expect("bind raw vsock per-port host UDS");
+        let translator = Translator::new(Arc::new(backend));
+        let server = tokio::spawn(translator.serve_vsock_raw(listener));
+
+        // ── Client (guest) side ─────────────────────────────────────────
+        let mut client = UnixStream::connect(&sock).await.expect("dial per-port host UDS");
+
+        async fn read_frame(s: &mut UnixStream) -> Vec<u8> {
+            let mut len = [0u8; 4];
+            s.read_exact(&mut len).await.unwrap();
+            let total = u32::from_le_bytes(len) as usize;
+            let mut buf = vec![0u8; total];
+            buf[..4].copy_from_slice(&len);
+            s.read_exact(&mut buf[4..]).await.unwrap();
+            buf
+        }
+
+        // FIRST bytes on the wire are 9P Tversion — NO `connect <port>\n`
+        // preamble. If the raw path erroneously stripped a preamble it would
+        // swallow these bytes and the session would hang / fail here.
+        client.write_all(&msg::tversion(1, MSG_SIZE, "9P2000.L")).await.unwrap();
+        let (_, resp) = msg::parse_response(&read_frame(&mut client).await).unwrap();
+        assert!(
+            matches!(resp, Response::Version { .. }),
+            "raw path must treat the first bytes as 9P Tversion, got {resp:?}"
+        );
+
+        // Rest of the session proves the stream was never desynchronized.
+        client.write_all(&msg::tattach(2, 0, u32::MAX, "u", "/")).await.unwrap();
+        let (_, resp) = msg::parse_response(&read_frame(&mut client).await).unwrap();
+        assert!(matches!(resp, Response::Attach { .. }), "expected Rattach, got {resp:?}");
+
+        client.write_all(&msg::twalk(3, 0, 1, &["hello.txt"])).await.unwrap();
+        let (_, resp) = msg::parse_response(&read_frame(&mut client).await).unwrap();
+        assert!(matches!(resp, Response::Walk { .. }), "expected Rwalk, got {resp:?}");
+
+        client.write_all(&msg::tlopen(4, 1, 0)).await.unwrap();
+        let (_, resp) = msg::parse_response(&read_frame(&mut client).await).unwrap();
+        assert!(matches!(resp, Response::Lopen { .. }), "expected Rlopen, got {resp:?}");
+
+        client.write_all(&msg::tread(5, 1, 0, 64)).await.unwrap();
+        let (_, resp) = msg::parse_response(&read_frame(&mut client).await).unwrap();
+        match resp {
+            Response::Read { data } => assert_eq!(&data, b"hello raw"),
             other => panic!("expected Rread with payload, got {other:?}"),
         }
 

--- a/crates/hyprstream-workers/src/runtime/kata_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/kata_backend.rs
@@ -132,7 +132,7 @@ fn vfs_9p_vsock_uds(vsock_base: &str, port: u32) -> PathBuf {
 pub struct Vfs9pVsockServer {
     /// Host-side UDS the guest's vsock port maps to (`<vsock-uds>_<port>`).
     socket_path: PathBuf,
-    /// The background 9P serve task ([`hyprstream_9p::serve_mount_vsock`]).
+    /// The background 9P serve task ([`hyprstream_9p::serve_mount_vsock_raw`]).
     task: tokio::task::JoinHandle<()>,
 }
 
@@ -1104,12 +1104,22 @@ impl KataBackend {
 
         let sock_for_task = socket_path.clone();
         let sandbox_id = sandbox_id.to_owned();
-        // `serve_mount_vsock` binds the host UDS and runs the 9P accept loop until
-        // the socket errors/closes (or the task is aborted on teardown). It serves
-        // the same Subject-scoped Mount as native 9P; only the transport differs.
+        // `serve_mount_vsock_raw` binds the per-port host UDS and runs the 9P
+        // accept loop until the socket errors/closes (or the task is aborted on
+        // teardown). It serves the same Subject-scoped Mount as native 9P; only
+        // the transport differs.
+        //
+        // RAW (no-handshake) mode is required here (#741): this is a **per-port**
+        // host listener (`<vsock-base>_<VFS_9P_VSOCK_PORT>`) that the **guest
+        // dials**. Per the Firecracker/CH hybrid-vsock spec, guest-initiated
+        // connections to a per-port host UDS arrive **raw** — the port is encoded
+        // in the socket path, not in an in-band `connect <port>\n` preamble. The
+        // preamble-stripping `serve_mount_vsock` is for the opposite (host-
+        // initiated, CH-multiplexer) direction; using it here would consume the
+        // guest's first 9P `Tversion` bytes and break the handshake.
         let task = tokio::spawn(async move {
             if let Err(e) =
-                hyprstream_9p::serve_mount_vsock(mount, subject, &sock_for_task).await
+                hyprstream_9p::serve_mount_vsock_raw(mount, subject, &sock_for_task).await
             {
                 tracing::warn!(
                     sandbox_id = %sandbox_id,


### PR DESCRIPTION
Closes #741. Part of epic #729 (V1 #730/#734 → V2 #731/#736).

## Problem
`HybridVsockListener` (`crates/hyprstream-9p/src/translator.rs`) strips a `connect <port>\n` text preamble on **every** accepted connection. That is correct only for the direction where hyprstream plays the CH host-multiplexer for connections it *initiates*. But `KataBackend` (V2) stands up a **per-port host listener** `<vsock-base>_<VFS_9P_VSOCK_PORT=564>` that the **guest dials**. Per the Firecracker/CH hybrid-vsock spec, guest-initiated connections to a per-port host UDS arrive **raw** — the port is encoded in the socket path, not in an in-band handshake. The unconditional strip would consume the guest's first 9P `Tversion` bytes and break the handshake.

## Design: a raw (no-handshake) mode
Mirrors how `serve_uds`/`serve_vsock` already share the transport-agnostic `serve_listener` accept loop + the generic `serve_connection` 9P core — no duplication of message handling:

- **`RawVsockListener`** — a new `Listen` impl wrapping `UnixListener`. `accept_conn` hands the accepted `UnixStream` straight through (no preamble read/strip); the guest's first bytes are the 9P `Tversion`. Kept as a thin, self-documenting wrapper (not the bare `UnixListener`) so the "listening" log line and peer strings identify the channel as `rawvsock:`.
- **`Translator::serve_vsock_raw`** — raw sibling of `serve_vsock`; selects `RawVsockListener`.
- **`serve_mount_vsock_raw(mount, subject, path)`** — one-call entry (exported from `lib.rs`), the raw sibling of `serve_mount_vsock`.

The preamble-stripping `serve_vsock` / `serve_mount_vsock` path is left **fully intact** for the host-initiated (CH-multiplexer) direction. `Subject`-per-op enforcement and wire-faithful 9P2000.L framing are byte-identical across all transports; only the accept surface differs.

## KataBackend wiring
`KataBackend::serve_tenant_vfs_9p` (the tenant-VFS 9P-over-vsock channel, V2 #731) now uses `serve_mount_vsock_raw` instead of `serve_mount_vsock`, with a comment citing #741 and the Firecracker/CH raw-per-port-listener semantics. This is the guest→host direction, so raw is required.

## Tests
Added `raw_vsock_no_preamble_9p_session`: a client connects to a per-port host UDS and sends its 9P `Tversion` **immediately with no preamble**, then drives a full version→attach→walk→open→read session. It asserts the first bytes are treated as 9P (a `Response::Version`), proving no preamble was consumed and the stream never desynchronized. The existing preamble-stripping tests (`hybrid_vsock_handshake_then_9p_session`, `hybrid_vsock_bad_preamble_does_not_kill_listener`) still pass, confirming the host-initiated path is unchanged.

## Verified vs not verified
- **Verified (code):** `cargo check`/`clippy -D warnings` clean on both crates; the new unit test + all existing translator tests pass; the raw path is byte-identical to UDS handling minus the preamble.
- **NOT yet verified (needs a real boot):** the exact guest **wire behavior** — that a booted kata guest's in-guest 9P client dialing `VFS_9P_VSOCK_PORT` actually sends a raw (preamble-free) stream. This is confirmed at first kata boot (V3 #732 / V4 #733). Until then this remains the most likely blocker for the guest mount, and this PR is the fix predicated on the documented Firecracker/CH per-port-listener semantics.

## Build gate
- `cargo check -p hyprstream-9p` — OK
- `cargo check -p hyprstream-workers --features kata-vm` — OK
- `cargo clippy -p hyprstream-9p --all-targets -- -D warnings` — clean
- `cargo clippy -p hyprstream-workers --features kata-vm -- -D warnings` — clean
- `cargo test -p hyprstream-9p translator::` — 8 passed, 0 failed (incl. `raw_vsock_no_preamble_9p_session`)
