### PR TITLE
feat(#524): re-land placement-directory atproto record types (P1 lexicons)

### DIFF
--- a/crates/hyprstream-pds/src/lib.rs
+++ b/crates/hyprstream-pds/src/lib.rs
@@ -54,8 +54,10 @@ pub mod dag_cbor;
 pub mod event_group;
 pub mod list_record;
 pub mod mst;
+pub mod placement;
 pub mod record;
 pub mod tid;
 
 pub use cid::Cid;
+pub use placement::{GroupItemRecord, GroupRecord, NodeRecord, WorkloadRecord};
 pub use record::ModelRecord;

--- a/crates/hyprstream-pds/src/placement/group.rs
+++ b/crates/hyprstream-pds/src/placement/group.rs
@@ -1,0 +1,196 @@
+//! `ai.hyprstream.placement.group` — a consent group (the atproto *list* record).
+//!
+//! ```json
+//! {
+//!   "lexicon": 1,
+//!   "id": "ai.hyprstream.placement.group",
+//!   "defs": { "main": { "type": "record", "key": "tid", "record": {
+//!     "type": "object",
+//!     "required": ["name", "ownerDid", "createdAt"],
+//!     "properties": {
+//!       "name":      { "type": "string" },
+//!       "ownerDid":  { "type": "string" },
+//!       "purpose":   { "type": "string" },
+//!       "createdAt": { "type": "string", "format": "datetime" }
+//!     }
+//! }}}
+//! ```
+//!
+//! Mirrors `app.bsky.graph.list`: this record *names* a group; membership is
+//! carried by `ai.hyprstream.placement.groupItem` (the listitem). `ownerDid` is
+//! the DID that owns the group.
+
+use anyhow::{bail, Result};
+
+use super::{map_get_opt_str, map_get_str, validate_datetime, validate_did, validate_nonempty};
+use crate::cid::Cid;
+use crate::dag_cbor::DagCbor;
+
+/// The NSID of this record type.
+pub const COLLECTION_NSID: &str = "ai.hyprstream.placement.group";
+
+/// An `ai.hyprstream.placement.group` record.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GroupRecord {
+    /// Human-readable group name.
+    pub name: String,
+    /// The DID that owns the group.
+    pub owner_did: String,
+    /// Optional free-form description of the group's purpose.
+    pub purpose: Option<String>,
+    /// ISO-8601 UTC datetime. `format: "datetime"`.
+    pub created_at: String,
+}
+
+impl GroupRecord {
+    /// Validate and construct a record.
+    pub fn new(
+        name: impl Into<String>,
+        owner_did: impl Into<String>,
+        purpose: Option<String>,
+        created_at: impl Into<String>,
+    ) -> Result<Self> {
+        let name = name.into();
+        let owner_did = owner_did.into();
+        let created_at = created_at.into();
+        validate_nonempty(&name, "name")?;
+        validate_did(&owner_did)?;
+        if let Some(p) = &purpose {
+            validate_nonempty(p, "purpose")?;
+        }
+        validate_datetime(&created_at)?;
+        Ok(GroupRecord {
+            name,
+            owner_did,
+            purpose,
+            created_at,
+        })
+    }
+
+    /// Encode to canonical DAG-CBOR bytes (deterministic).
+    pub fn to_dag_cbor(&self) -> Vec<u8> {
+        self.to_value().encode()
+    }
+
+    /// The CID of this record (CIDv1 dag-cbor over its canonical bytes).
+    pub fn cid(&self) -> Cid {
+        Cid::from_dag_cbor(&self.to_dag_cbor())
+    }
+
+    /// Build the typed [`DagCbor`] value form. The optional `purpose` field is
+    /// omitted from the map when absent.
+    pub fn to_value(&self) -> DagCbor {
+        let mut pairs: Vec<(&str, DagCbor)> = vec![
+            ("name", DagCbor::Text(self.name.clone())),
+            ("ownerDid", DagCbor::Text(self.owner_did.clone())),
+            ("createdAt", DagCbor::Text(self.created_at.clone())),
+        ];
+        if let Some(purpose) = &self.purpose {
+            pairs.push(("purpose", DagCbor::Text(purpose.clone())));
+        }
+        DagCbor::str_map(pairs)
+    }
+
+    /// Decode canonical DAG-CBOR bytes into a record, validating all fields.
+    pub fn from_dag_cbor(bytes: &[u8]) -> Result<Self> {
+        let value = DagCbor::decode(bytes)?;
+        Self::from_value(&value)
+    }
+
+    pub fn from_value(value: &DagCbor) -> Result<Self> {
+        let map = value.as_map()?;
+        let name = map_get_str(value, "name", COLLECTION_NSID)?.to_owned();
+        let owner_did = map_get_str(value, "ownerDid", COLLECTION_NSID)?.to_owned();
+        let purpose = map_get_opt_str(value, "purpose")?.map(str::to_owned);
+        let created_at = map_get_str(value, "createdAt", COLLECTION_NSID)?.to_owned();
+        // Reject unknown extra fields (frozen field set: 3 required + 1 optional).
+        for (k, _v) in map {
+            match k.as_str()? {
+                "name" | "ownerDid" | "purpose" | "createdAt" => {}
+                other => {
+                    bail!("{COLLECTION_NSID}: unknown field {other:?} (lexicon is 4 fields)")
+                }
+            }
+        }
+        Self::new(name, owner_did, purpose, created_at)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::panic
+    )]
+    use super::*;
+
+    fn sample() -> GroupRecord {
+        GroupRecord::new(
+            "east-coast-gpus",
+            "did:web:alice.example.com",
+            Some("GPU nodes in us-east".into()),
+            "2026-06-23T12:34:56.789Z",
+        )
+        .expect("valid sample")
+    }
+
+    #[test]
+    fn record_round_trip_same_cid() {
+        let r = sample();
+        let bytes = r.to_dag_cbor();
+        let back = GroupRecord::from_dag_cbor(&bytes).expect("round-trip");
+        assert_eq!(r, back);
+        assert_eq!(r.cid(), back.cid());
+        assert_eq!(r.to_dag_cbor(), back.to_dag_cbor());
+    }
+
+    #[test]
+    fn record_optional_purpose_omitted() {
+        let mut r = sample();
+        r.purpose = None;
+        let v = r.to_value();
+        assert!(v.get("purpose").is_none(), "absent purpose must be omitted");
+        let back = GroupRecord::from_dag_cbor(&r.to_dag_cbor()).expect("round-trip");
+        assert_eq!(r, back);
+    }
+
+    #[test]
+    fn record_fields_canonical_order() {
+        let r = sample();
+        let v = DagCbor::decode(&r.to_dag_cbor()).expect("decode");
+        let map = v.as_map().expect("map");
+        let keys: Vec<&str> = map.iter().map(|(k, _)| k.as_str().expect("str")).collect();
+        // canonical (lexicographic byte) key order.
+        assert_eq!(keys, vec!["createdAt", "name", "ownerDid", "purpose"]);
+    }
+
+    #[test]
+    fn record_rejects_extra_fields() {
+        let mut extra = sample().to_value();
+        if let DagCbor::Map(ref mut v) = extra {
+            v.push((DagCbor::Text("extra".into()), DagCbor::Unsigned(1)));
+            v.sort_by(|a, b| a.0.as_str().unwrap_or("").cmp(b.0.as_str().unwrap_or("")));
+        }
+        assert!(GroupRecord::from_value(&extra).is_err());
+    }
+
+    #[test]
+    fn record_validates_formats() {
+        // Empty name.
+        assert!(GroupRecord::new("", "did:web:x", None, "2026-06-23T12:34:56.789Z").is_err());
+        // Bad owner DID.
+        assert!(GroupRecord::new("g", "not-a-did", None, "2026-06-23T12:34:56.789Z").is_err());
+        // Empty optional purpose.
+        assert!(GroupRecord::new(
+            "g",
+            "did:web:x",
+            Some("".into()),
+            "2026-06-23T12:34:56.789Z"
+        )
+        .is_err());
+        // Bad datetime.
+        assert!(GroupRecord::new("g", "did:web:x", None, "2026").is_err());
+    }
+}

--- a/crates/hyprstream-pds/src/placement/group_item.rs
+++ b/crates/hyprstream-pds/src/placement/group_item.rs
@@ -1,0 +1,173 @@
+//! `ai.hyprstream.placement.groupItem` — a group membership (atproto *listitem*).
+//!
+//! ```json
+//! {
+//!   "lexicon": 1,
+//!   "id": "ai.hyprstream.placement.groupItem",
+//!   "defs": { "main": { "type": "record", "key": "tid", "record": {
+//!     "type": "object",
+//!     "required": ["group", "subject", "createdAt"],
+//!     "properties": {
+//!       "group":     { "type": "string", "format": "at-uri" },
+//!       "subject":   { "type": "string" },
+//!       "createdAt": { "type": "string", "format": "datetime" }
+//!     }
+//! }}}
+//! ```
+//!
+//! Mirrors `app.bsky.graph.listitem`: `group` is the at-uri of the
+//! `ai.hyprstream.placement.group` record, and `subject` is the DID of the node
+//! being added to it.
+
+use anyhow::{bail, Result};
+
+use super::{map_get_str, validate_at_uri, validate_datetime, validate_did};
+use crate::cid::Cid;
+use crate::dag_cbor::DagCbor;
+
+/// The NSID of this record type.
+pub const COLLECTION_NSID: &str = "ai.hyprstream.placement.groupItem";
+
+/// An `ai.hyprstream.placement.groupItem` record.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GroupItemRecord {
+    /// at-uri of the owning group record. `format: "at-uri"`.
+    pub group: String,
+    /// The DID of the node being added to the group.
+    pub subject: String,
+    /// ISO-8601 UTC datetime. `format: "datetime"`.
+    pub created_at: String,
+}
+
+impl GroupItemRecord {
+    /// Validate and construct a record.
+    pub fn new(
+        group: impl Into<String>,
+        subject: impl Into<String>,
+        created_at: impl Into<String>,
+    ) -> Result<Self> {
+        let group = group.into();
+        let subject = subject.into();
+        let created_at = created_at.into();
+        validate_at_uri(&group)?;
+        validate_did(&subject)?;
+        validate_datetime(&created_at)?;
+        Ok(GroupItemRecord {
+            group,
+            subject,
+            created_at,
+        })
+    }
+
+    /// Encode to canonical DAG-CBOR bytes (deterministic).
+    pub fn to_dag_cbor(&self) -> Vec<u8> {
+        self.to_value().encode()
+    }
+
+    /// The CID of this record (CIDv1 dag-cbor over its canonical bytes).
+    pub fn cid(&self) -> Cid {
+        Cid::from_dag_cbor(&self.to_dag_cbor())
+    }
+
+    /// Build the typed [`DagCbor`] value form.
+    pub fn to_value(&self) -> DagCbor {
+        DagCbor::str_map([
+            ("group", DagCbor::Text(self.group.clone())),
+            ("subject", DagCbor::Text(self.subject.clone())),
+            ("createdAt", DagCbor::Text(self.created_at.clone())),
+        ])
+    }
+
+    /// Decode canonical DAG-CBOR bytes into a record, validating all fields.
+    pub fn from_dag_cbor(bytes: &[u8]) -> Result<Self> {
+        let value = DagCbor::decode(bytes)?;
+        Self::from_value(&value)
+    }
+
+    pub fn from_value(value: &DagCbor) -> Result<Self> {
+        let map = value.as_map()?;
+        let group = map_get_str(value, "group", COLLECTION_NSID)?.to_owned();
+        let subject = map_get_str(value, "subject", COLLECTION_NSID)?.to_owned();
+        let created_at = map_get_str(value, "createdAt", COLLECTION_NSID)?.to_owned();
+        // Reject unknown extra fields (the lexicon is frozen at 3 fields).
+        for (k, _v) in map {
+            match k.as_str()? {
+                "group" | "subject" | "createdAt" => {}
+                other => {
+                    bail!("{COLLECTION_NSID}: unknown field {other:?} (lexicon is 3 fields)")
+                }
+            }
+        }
+        Self::new(group, subject, created_at)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::panic
+    )]
+    use super::*;
+
+    fn sample() -> GroupItemRecord {
+        GroupItemRecord::new(
+            "at://did:web:alice.example.com/ai.hyprstream.placement.group/3kxy",
+            "did:web:node1.example.com",
+            "2026-06-23T12:34:56.789Z",
+        )
+        .expect("valid sample")
+    }
+
+    #[test]
+    fn record_round_trip_same_cid() {
+        let r = sample();
+        let bytes = r.to_dag_cbor();
+        let back = GroupItemRecord::from_dag_cbor(&bytes).expect("round-trip");
+        assert_eq!(r, back);
+        assert_eq!(r.cid(), back.cid());
+        assert_eq!(r.to_dag_cbor(), back.to_dag_cbor());
+    }
+
+    #[test]
+    fn record_fields_canonical_order() {
+        let r = sample();
+        let v = DagCbor::decode(&r.to_dag_cbor()).expect("decode");
+        let map = v.as_map().expect("map");
+        let keys: Vec<&str> = map.iter().map(|(k, _)| k.as_str().expect("str")).collect();
+        // canonical (lexicographic byte) key order.
+        assert_eq!(keys, vec!["createdAt", "group", "subject"]);
+    }
+
+    #[test]
+    fn record_rejects_extra_fields() {
+        let mut extra = sample().to_value();
+        if let DagCbor::Map(ref mut v) = extra {
+            v.push((DagCbor::Text("extra".into()), DagCbor::Unsigned(1)));
+            v.sort_by(|a, b| a.0.as_str().unwrap_or("").cmp(b.0.as_str().unwrap_or("")));
+        }
+        assert!(GroupItemRecord::from_value(&extra).is_err());
+    }
+
+    #[test]
+    fn record_validates_formats() {
+        // Bad group at-uri.
+        assert!(GroupItemRecord::new("nope", "did:web:n", "2026-06-23T12:34:56.789Z").is_err());
+        // Bad subject DID.
+        assert!(GroupItemRecord::new(
+            "at://did:web:x/ai.hyprstream.placement.group/3kxy",
+            "not-a-did",
+            "2026-06-23T12:34:56.789Z"
+        )
+        .is_err());
+        // Bad datetime.
+        assert!(GroupItemRecord::new(
+            "at://did:web:x/ai.hyprstream.placement.group/3kxy",
+            "did:web:n",
+            "2026"
+        )
+        .is_err());
+    }
+}

--- a/crates/hyprstream-pds/src/placement/mod.rs
+++ b/crates/hyprstream-pds/src/placement/mod.rs
@@ -1,0 +1,127 @@
+//! `ai.hyprstream.placement.*` — the P1 placement-directory lexicons.
+//!
+//! Four DAG-CBOR record types form the consent-scoped placement directory that
+//! sits alongside [`crate::record::ModelRecord`] (`ai.hyprstream.model`):
+//!
+//! - [`node::NodeRecord`] (`ai.hyprstream.placement.node`) — a schedulable node
+//!   advertised by an account: its labels, capacities, and group consents.
+//! - [`workload::WorkloadRecord`] (`ai.hyprstream.placement.workload`) — a
+//!   workload→node placement decision.
+//! - [`group::GroupRecord`] (`ai.hyprstream.placement.group`) — an atproto *list*
+//!   record naming a consent group.
+//! - [`group_item::GroupItemRecord`] (`ai.hyprstream.placement.groupItem`) — an
+//!   atproto *listitem* record adding a node (subject) to a group.
+//!
+//! # Encoding
+//!
+//! Like `ai.hyprstream.model`, every record is **DAG-CBOR** with canonical
+//! (length-first, then lexicographic) map-key order. The encoder applies that
+//! ordering, so callers construct fields in any order. Each record has a frozen
+//! field set: decoding rejects unknown fields. Optional fields are *omitted*
+//! from the encoded map when absent (never encoded as `null`).
+//!
+//! All format-bearing fields are validated at construction time, mirroring
+//! `record.rs`: `at-uri` fields must start with `at://`, `did` fields must start
+//! with `did:` (both `did:web` and `did:key` are accepted), and `datetime`
+//! fields must match the atproto ISO-8601 shape (UTC, milliseconds, trailing
+//! `Z`).
+
+use anyhow::{ensure, Result};
+
+use crate::dag_cbor::DagCbor;
+
+pub mod group;
+pub mod group_item;
+pub mod node;
+pub mod workload;
+
+pub use group::GroupRecord;
+pub use group_item::GroupItemRecord;
+pub use node::NodeRecord;
+pub use workload::WorkloadRecord;
+
+// ── shared field accessors ──────────────────────────────────────────────────
+
+/// Read a required string field, attributing errors to `nsid`.
+pub(crate) fn map_get_str<'a>(value: &'a DagCbor, key: &str, nsid: &str) -> Result<&'a str> {
+    value
+        .get(key)
+        .ok_or_else(|| anyhow::anyhow!("{nsid}: missing required field {key:?}"))?
+        .as_str()
+}
+
+/// Read an optional string field. Returns `None` when the field is omitted; an
+/// error if it is present but not a text string.
+pub(crate) fn map_get_opt_str<'a>(value: &'a DagCbor, key: &str) -> Result<Option<&'a str>> {
+    match value.get(key) {
+        None => Ok(None),
+        Some(v) => Ok(Some(v.as_str()?)),
+    }
+}
+
+// ── field validators (lexicon formats) ──────────────────────────────────────
+
+/// `format: "at-uri"` — must start with `at://` and carry a non-empty,
+/// whitespace-free authority. (DID grammar is enforced by the resolver.)
+pub(crate) fn validate_at_uri(s: &str) -> Result<()> {
+    ensure!(
+        s.starts_with("at://"),
+        "at-uri must start with \"at://\": {s:?}"
+    );
+    let rest = &s[5..];
+    ensure!(!rest.is_empty(), "at-uri must have an authority: {s:?}");
+    ensure!(
+        !rest.chars().any(char::is_whitespace),
+        "at-uri must not contain whitespace: {s:?}"
+    );
+    Ok(())
+}
+
+/// A DID string — must start with `did:` and carry a non-empty, whitespace-free
+/// method-specific identifier. Both `did:web:…` and `did:key:…` are accepted.
+pub(crate) fn validate_did(s: &str) -> Result<()> {
+    ensure!(s.starts_with("did:"), "did must start with \"did:\": {s:?}");
+    let rest = &s[4..];
+    ensure!(!rest.is_empty(), "did must have a method: {s:?}");
+    ensure!(
+        !rest.chars().any(char::is_whitespace),
+        "did must not contain whitespace: {s:?}"
+    );
+    // method:identifier — both segments non-empty.
+    let mut parts = rest.splitn(2, ':');
+    let method = parts.next().unwrap_or("");
+    let id = parts.next().unwrap_or("");
+    ensure!(
+        !method.is_empty() && !id.is_empty(),
+        "did must be \"did:<method>:<id>\": {s:?}"
+    );
+    Ok(())
+}
+
+/// `format: "datetime"` — atproto ISO-8601 UTC, millisecond precision, `Z`.
+pub(crate) fn validate_datetime(s: &str) -> Result<()> {
+    ensure!(s.ends_with('Z'), "datetime must end with 'Z' (UTC): {s:?}");
+    let pre = &s[..s.len() - 1];
+    ensure!(pre.len() >= 20, "datetime too short: {s:?}");
+    let bytes = pre.as_bytes();
+    ensure!(
+        bytes[4] == b'-'
+            && bytes[7] == b'-'
+            && bytes[10] == b'T'
+            && bytes[13] == b':'
+            && bytes[16] == b':',
+        "datetime must be ISO-8601 (YYYY-MM-DDTHH:MM:SS): {s:?}"
+    );
+    ensure!(
+        bytes.get(19) == Some(&b'.'),
+        "datetime must have millisecond precision (.mmm): {s:?}"
+    );
+    Ok(())
+}
+
+/// A required free-form string that must not be empty (`field` names it for the
+/// error message).
+pub(crate) fn validate_nonempty(s: &str, field: &str) -> Result<()> {
+    ensure!(!s.is_empty(), "{field} must not be empty");
+    Ok(())
+}

--- a/crates/hyprstream-pds/src/placement/node.rs
+++ b/crates/hyprstream-pds/src/placement/node.rs
@@ -1,0 +1,360 @@
+//! `ai.hyprstream.placement.node` — a schedulable node advertised by an account.
+//!
+//! ```json
+//! {
+//!   "lexicon": 1,
+//!   "id": "ai.hyprstream.placement.node",
+//!   "defs": { "main": { "type": "record", "key": "tid", "record": {
+//!     "type": "object",
+//!     "required": ["repo", "labels", "resources", "groups", "createdAt"],
+//!     "properties": {
+//!       "repo":      { "type": "string", "format": "at-uri" },
+//!       "labels":    { "type": "array", "items": { "type": "object",
+//!                        "required": ["key", "value"], "properties": {
+//!                          "key":   { "type": "string" },
+//!                          "value": { "type": "string" } } } },
+//!       "resources": { "type": "array", "items": { "type": "object",
+//!                        "required": ["name", "capacity"], "properties": {
+//!                          "name":     { "type": "string" },
+//!                          "capacity": { "type": "string" } } } },
+//!       "groups":    { "type": "array", "items": { "type": "string", "format": "at-uri" } },
+//!       "createdAt": { "type": "string", "format": "datetime" }
+//!     }
+//! }}}
+//! ```
+//!
+//! `groups` are at-uris of `ai.hyprstream.placement.group` records the node has
+//! consented to be placed within. `resources[].capacity` carries a Kubernetes
+//! quantity string (e.g. `"16"`, `"100m"`, `"8Gi"`).
+
+use anyhow::{bail, ensure, Result};
+
+use super::{map_get_str, validate_at_uri, validate_datetime};
+use crate::cid::Cid;
+use crate::dag_cbor::DagCbor;
+
+/// The NSID of this record type.
+pub const COLLECTION_NSID: &str = "ai.hyprstream.placement.node";
+
+/// A `{key, value}` label pair.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Label {
+    pub key: String,
+    pub value: String,
+}
+
+/// A `{name, capacity}` resource advertisement. `capacity` is a k8s-quantity.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Resource {
+    pub name: String,
+    pub capacity: String,
+}
+
+/// An `ai.hyprstream.placement.node` record.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NodeRecord {
+    /// at-uri of the owning repo. `format: "at-uri"`.
+    pub repo: String,
+    /// Free-form `{key, value}` labels.
+    pub labels: Vec<Label>,
+    /// Advertised `{name, capacity}` resources (capacity is a k8s-quantity).
+    pub resources: Vec<Resource>,
+    /// at-uris of consented placement groups. Each is `format: "at-uri"`.
+    pub groups: Vec<String>,
+    /// ISO-8601 UTC datetime. `format: "datetime"`.
+    pub created_at: String,
+}
+
+impl NodeRecord {
+    /// Validate and construct a record.
+    pub fn new(
+        repo: impl Into<String>,
+        labels: Vec<Label>,
+        resources: Vec<Resource>,
+        groups: Vec<String>,
+        created_at: impl Into<String>,
+    ) -> Result<Self> {
+        let repo = repo.into();
+        let created_at = created_at.into();
+        validate_at_uri(&repo)?;
+        for l in &labels {
+            validate_label(l)?;
+        }
+        for r in &resources {
+            validate_resource(r)?;
+        }
+        for g in &groups {
+            validate_at_uri(g)?;
+        }
+        validate_datetime(&created_at)?;
+        Ok(NodeRecord {
+            repo,
+            labels,
+            resources,
+            groups,
+            created_at,
+        })
+    }
+
+    /// Encode to canonical DAG-CBOR bytes (deterministic).
+    pub fn to_dag_cbor(&self) -> Vec<u8> {
+        self.to_value().encode()
+    }
+
+    /// The CID of this record (CIDv1 dag-cbor over its canonical bytes).
+    pub fn cid(&self) -> Cid {
+        Cid::from_dag_cbor(&self.to_dag_cbor())
+    }
+
+    /// Build the typed [`DagCbor`] value form.
+    pub fn to_value(&self) -> DagCbor {
+        let labels = DagCbor::list(self.labels.iter().map(|l| {
+            DagCbor::str_map([
+                ("key", DagCbor::Text(l.key.clone())),
+                ("value", DagCbor::Text(l.value.clone())),
+            ])
+        }));
+        let resources = DagCbor::list(self.resources.iter().map(|r| {
+            DagCbor::str_map([
+                ("name", DagCbor::Text(r.name.clone())),
+                ("capacity", DagCbor::Text(r.capacity.clone())),
+            ])
+        }));
+        let groups = DagCbor::list(self.groups.iter().map(|g| DagCbor::Text(g.clone())));
+        DagCbor::str_map([
+            ("repo", DagCbor::Text(self.repo.clone())),
+            ("labels", labels),
+            ("resources", resources),
+            ("groups", groups),
+            ("createdAt", DagCbor::Text(self.created_at.clone())),
+        ])
+    }
+
+    /// Decode canonical DAG-CBOR bytes into a record, validating all fields.
+    pub fn from_dag_cbor(bytes: &[u8]) -> Result<Self> {
+        let value = DagCbor::decode(bytes)?;
+        Self::from_value(&value)
+    }
+
+    pub fn from_value(value: &DagCbor) -> Result<Self> {
+        let map = value.as_map()?;
+        let repo = map_get_str(value, "repo", COLLECTION_NSID)?.to_owned();
+        let labels = value
+            .get("labels")
+            .ok_or_else(|| anyhow::anyhow!("{COLLECTION_NSID}: missing required field \"labels\""))?
+            .as_list()?
+            .iter()
+            .map(parse_label)
+            .collect::<Result<Vec<_>>>()?;
+        let resources = value
+            .get("resources")
+            .ok_or_else(|| {
+                anyhow::anyhow!("{COLLECTION_NSID}: missing required field \"resources\"")
+            })?
+            .as_list()?
+            .iter()
+            .map(parse_resource)
+            .collect::<Result<Vec<_>>>()?;
+        let groups = value
+            .get("groups")
+            .ok_or_else(|| anyhow::anyhow!("{COLLECTION_NSID}: missing required field \"groups\""))?
+            .as_list()?
+            .iter()
+            .map(|g| Ok(g.as_str()?.to_owned()))
+            .collect::<Result<Vec<_>>>()?;
+        let created_at = map_get_str(value, "createdAt", COLLECTION_NSID)?.to_owned();
+        // Reject unknown extra fields (the lexicon is frozen at 5 fields).
+        for (k, _v) in map {
+            match k.as_str()? {
+                "repo" | "labels" | "resources" | "groups" | "createdAt" => {}
+                other => {
+                    bail!("{COLLECTION_NSID}: unknown field {other:?} (lexicon is 5 fields)")
+                }
+            }
+        }
+        Self::new(repo, labels, resources, groups, created_at)
+    }
+}
+
+fn parse_label(value: &DagCbor) -> Result<Label> {
+    let map = value.as_map()?;
+    let key = map_get_str(value, "key", COLLECTION_NSID)?.to_owned();
+    let val = map_get_str(value, "value", COLLECTION_NSID)?.to_owned();
+    for (k, _v) in map {
+        match k.as_str()? {
+            "key" | "value" => {}
+            other => {
+                bail!("{COLLECTION_NSID}: unknown label field {other:?} (lexicon is 2 fields)")
+            }
+        }
+    }
+    Ok(Label { key, value: val })
+}
+
+fn parse_resource(value: &DagCbor) -> Result<Resource> {
+    let map = value.as_map()?;
+    let name = map_get_str(value, "name", COLLECTION_NSID)?.to_owned();
+    let capacity = map_get_str(value, "capacity", COLLECTION_NSID)?.to_owned();
+    for (k, _v) in map {
+        match k.as_str()? {
+            "name" | "capacity" => {}
+            other => {
+                bail!("{COLLECTION_NSID}: unknown resource field {other:?} (lexicon is 2 fields)")
+            }
+        }
+    }
+    Ok(Resource { name, capacity })
+}
+
+// ── nested-object validators ────────────────────────────────────────────────
+
+fn validate_label(l: &Label) -> Result<()> {
+    ensure!(!l.key.is_empty(), "label key must not be empty");
+    Ok(())
+}
+
+fn validate_resource(r: &Resource) -> Result<()> {
+    ensure!(!r.name.is_empty(), "resource name must not be empty");
+    validate_k8s_quantity(&r.capacity)?;
+    Ok(())
+}
+
+/// A Kubernetes quantity string (e.g. `"16"`, `"100m"`, `"8Gi"`, `"2.5"`). We
+/// do not fully parse the suffix grammar here; we reject the obviously-invalid
+/// forms (empty, whitespace, or a non-numeric leading character).
+fn validate_k8s_quantity(s: &str) -> Result<()> {
+    ensure!(!s.is_empty(), "k8s quantity must not be empty: {s:?}");
+    ensure!(
+        !s.chars().any(char::is_whitespace),
+        "k8s quantity must not contain whitespace: {s:?}"
+    );
+    let first = s.chars().next().unwrap_or(' ');
+    ensure!(
+        first.is_ascii_digit() || first == '.' || first == '+' || first == '-',
+        "k8s quantity must start with a digit/sign/dot: {s:?}"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::panic
+    )]
+    use super::*;
+
+    fn sample() -> NodeRecord {
+        NodeRecord::new(
+            "at://did:web:alice.example.com",
+            vec![Label {
+                key: "zone".into(),
+                value: "us-east".into(),
+            }],
+            vec![Resource {
+                name: "nvidia.com/gpu".into(),
+                capacity: "8".into(),
+            }],
+            vec!["at://did:web:alice.example.com/ai.hyprstream.placement.group/3kxy".into()],
+            "2026-06-23T12:34:56.789Z",
+        )
+        .expect("valid sample")
+    }
+
+    #[test]
+    fn record_round_trip_same_cid() {
+        let r = sample();
+        let bytes = r.to_dag_cbor();
+        let back = NodeRecord::from_dag_cbor(&bytes).expect("round-trip");
+        assert_eq!(r, back);
+        assert_eq!(r.cid(), back.cid());
+        assert_eq!(r.to_dag_cbor(), back.to_dag_cbor());
+    }
+
+    #[test]
+    fn record_fields_canonical_order() {
+        let r = sample();
+        let bytes = r.to_dag_cbor();
+        let v = DagCbor::decode(&bytes).expect("decode");
+        let map = v.as_map().expect("map");
+        let keys: Vec<&str> = map.iter().map(|(k, _)| k.as_str().expect("str")).collect();
+        // canonical (lexicographic byte) key order.
+        assert_eq!(
+            keys,
+            vec!["createdAt", "groups", "labels", "repo", "resources"]
+        );
+    }
+
+    #[test]
+    fn record_rejects_extra_fields() {
+        let mut extra = sample().to_value();
+        if let DagCbor::Map(ref mut v) = extra {
+            v.push((DagCbor::Text("extra".into()), DagCbor::Unsigned(1)));
+            v.sort_by(|a, b| a.0.as_str().unwrap_or("").cmp(b.0.as_str().unwrap_or("")));
+        }
+        assert!(NodeRecord::from_value(&extra).is_err());
+    }
+
+    #[test]
+    fn record_rejects_unknown_nested_label_field() {
+        let r = sample();
+        let mut v = r.to_value();
+        if let DagCbor::Map(ref mut pairs) = v {
+            for (k, val) in pairs.iter_mut() {
+                if k.as_str().ok() == Some("labels") {
+                    if let DagCbor::List(items) = val {
+                        if let Some(DagCbor::Map(obj)) = items.first_mut() {
+                            obj.push((DagCbor::Text("zzz".into()), DagCbor::Text("x".into())));
+                        }
+                    }
+                }
+            }
+        }
+        assert!(NodeRecord::from_value(&v).is_err());
+    }
+
+    #[test]
+    fn record_validates_formats() {
+        // Bad repo at-uri.
+        assert!(
+            NodeRecord::new("nope", vec![], vec![], vec![], "2026-06-23T12:34:56.789Z").is_err()
+        );
+        // Bad group at-uri.
+        assert!(NodeRecord::new(
+            "at://did:web:x",
+            vec![],
+            vec![],
+            vec!["not-an-at-uri".into()],
+            "2026-06-23T12:34:56.789Z"
+        )
+        .is_err());
+        // Bad datetime.
+        assert!(NodeRecord::new("at://did:web:x", vec![], vec![], vec![], "2026-06-23").is_err());
+        // Empty label key.
+        assert!(NodeRecord::new(
+            "at://did:web:x",
+            vec![Label {
+                key: "".into(),
+                value: "v".into()
+            }],
+            vec![],
+            vec![],
+            "2026-06-23T12:34:56.789Z"
+        )
+        .is_err());
+        // Bad k8s quantity.
+        assert!(NodeRecord::new(
+            "at://did:web:x",
+            vec![],
+            vec![Resource {
+                name: "cpu".into(),
+                capacity: "lots".into()
+            }],
+            vec![],
+            "2026-06-23T12:34:56.789Z"
+        )
+        .is_err());
+    }
+}

--- a/crates/hyprstream-pds/src/placement/workload.rs
+++ b/crates/hyprstream-pds/src/placement/workload.rs
@@ -1,0 +1,229 @@
+//! `ai.hyprstream.placement.workload` — a workload→node placement decision.
+//!
+//! ```json
+//! {
+//!   "lexicon": 1,
+//!   "id": "ai.hyprstream.placement.workload",
+//!   "defs": { "main": { "type": "record", "key": "tid", "record": {
+//!     "type": "object",
+//!     "required": ["repo", "workload", "node", "createdAt"],
+//!     "properties": {
+//!       "repo":      { "type": "string", "format": "at-uri" },
+//!       "workload":  { "type": "string" },
+//!       "node":      { "type": "string" },
+//!       "group":     { "type": "string" },
+//!       "createdAt": { "type": "string", "format": "datetime" }
+//!     }
+//! }}}
+//! ```
+//!
+//! `workload` is a model at-uri or shard id (free-form string). `node` is the
+//! DID of the placed node. `group` is the optional consent group the placement
+//! was made under.
+
+use anyhow::{bail, Result};
+
+use super::{
+    map_get_opt_str, map_get_str, validate_at_uri, validate_datetime, validate_did,
+    validate_nonempty,
+};
+use crate::cid::Cid;
+use crate::dag_cbor::DagCbor;
+
+/// The NSID of this record type.
+pub const COLLECTION_NSID: &str = "ai.hyprstream.placement.workload";
+
+/// An `ai.hyprstream.placement.workload` record.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WorkloadRecord {
+    /// at-uri of the owning repo. `format: "at-uri"`.
+    pub repo: String,
+    /// The workload identifier: a model at-uri or a shard id.
+    pub workload: String,
+    /// The DID of the node the workload is placed on.
+    pub node: String,
+    /// Optional consent group the placement was made under.
+    pub group: Option<String>,
+    /// ISO-8601 UTC datetime. `format: "datetime"`.
+    pub created_at: String,
+}
+
+impl WorkloadRecord {
+    /// Validate and construct a record.
+    pub fn new(
+        repo: impl Into<String>,
+        workload: impl Into<String>,
+        node: impl Into<String>,
+        group: Option<String>,
+        created_at: impl Into<String>,
+    ) -> Result<Self> {
+        let repo = repo.into();
+        let workload = workload.into();
+        let node = node.into();
+        let created_at = created_at.into();
+        validate_at_uri(&repo)?;
+        validate_nonempty(&workload, "workload")?;
+        validate_did(&node)?;
+        if let Some(g) = &group {
+            validate_nonempty(g, "group")?;
+        }
+        validate_datetime(&created_at)?;
+        Ok(WorkloadRecord {
+            repo,
+            workload,
+            node,
+            group,
+            created_at,
+        })
+    }
+
+    /// Encode to canonical DAG-CBOR bytes (deterministic).
+    pub fn to_dag_cbor(&self) -> Vec<u8> {
+        self.to_value().encode()
+    }
+
+    /// The CID of this record (CIDv1 dag-cbor over its canonical bytes).
+    pub fn cid(&self) -> Cid {
+        Cid::from_dag_cbor(&self.to_dag_cbor())
+    }
+
+    /// Build the typed [`DagCbor`] value form. The optional `group` field is
+    /// omitted from the map when absent.
+    pub fn to_value(&self) -> DagCbor {
+        let mut pairs: Vec<(&str, DagCbor)> = vec![
+            ("repo", DagCbor::Text(self.repo.clone())),
+            ("workload", DagCbor::Text(self.workload.clone())),
+            ("node", DagCbor::Text(self.node.clone())),
+            ("createdAt", DagCbor::Text(self.created_at.clone())),
+        ];
+        if let Some(group) = &self.group {
+            pairs.push(("group", DagCbor::Text(group.clone())));
+        }
+        DagCbor::str_map(pairs)
+    }
+
+    /// Decode canonical DAG-CBOR bytes into a record, validating all fields.
+    pub fn from_dag_cbor(bytes: &[u8]) -> Result<Self> {
+        let value = DagCbor::decode(bytes)?;
+        Self::from_value(&value)
+    }
+
+    pub fn from_value(value: &DagCbor) -> Result<Self> {
+        let map = value.as_map()?;
+        let repo = map_get_str(value, "repo", COLLECTION_NSID)?.to_owned();
+        let workload = map_get_str(value, "workload", COLLECTION_NSID)?.to_owned();
+        let node = map_get_str(value, "node", COLLECTION_NSID)?.to_owned();
+        let group = map_get_opt_str(value, "group")?.map(str::to_owned);
+        let created_at = map_get_str(value, "createdAt", COLLECTION_NSID)?.to_owned();
+        // Reject unknown extra fields (frozen field set: 4 required + 1 optional).
+        for (k, _v) in map {
+            match k.as_str()? {
+                "repo" | "workload" | "node" | "group" | "createdAt" => {}
+                other => {
+                    bail!("{COLLECTION_NSID}: unknown field {other:?} (lexicon is 5 fields)")
+                }
+            }
+        }
+        Self::new(repo, workload, node, group, created_at)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::panic
+    )]
+    use super::*;
+
+    fn sample() -> WorkloadRecord {
+        WorkloadRecord::new(
+            "at://did:web:alice.example.com",
+            "at://did:web:alice.example.com/ai.hyprstream.model/3kxy",
+            "did:web:node1.example.com",
+            Some("at://did:web:alice.example.com/ai.hyprstream.placement.group/3kxz".into()),
+            "2026-06-23T12:34:56.789Z",
+        )
+        .expect("valid sample")
+    }
+
+    #[test]
+    fn record_round_trip_same_cid() {
+        let r = sample();
+        let bytes = r.to_dag_cbor();
+        let back = WorkloadRecord::from_dag_cbor(&bytes).expect("round-trip");
+        assert_eq!(r, back);
+        assert_eq!(r.cid(), back.cid());
+        assert_eq!(r.to_dag_cbor(), back.to_dag_cbor());
+    }
+
+    #[test]
+    fn record_optional_group_omitted() {
+        let mut r = sample();
+        r.group = None;
+        let v = r.to_value();
+        assert!(v.get("group").is_none(), "absent group must be omitted");
+        let back = WorkloadRecord::from_dag_cbor(&r.to_dag_cbor()).expect("round-trip");
+        assert_eq!(r, back);
+    }
+
+    #[test]
+    fn record_fields_canonical_order() {
+        let r = sample();
+        let v = DagCbor::decode(&r.to_dag_cbor()).expect("decode");
+        let map = v.as_map().expect("map");
+        let keys: Vec<&str> = map.iter().map(|(k, _)| k.as_str().expect("str")).collect();
+        // canonical (lexicographic byte) key order.
+        assert_eq!(keys, vec!["createdAt", "group", "node", "repo", "workload"]);
+    }
+
+    #[test]
+    fn record_rejects_extra_fields() {
+        let mut extra = sample().to_value();
+        if let DagCbor::Map(ref mut v) = extra {
+            v.push((DagCbor::Text("extra".into()), DagCbor::Unsigned(1)));
+            v.sort_by(|a, b| a.0.as_str().unwrap_or("").cmp(b.0.as_str().unwrap_or("")));
+        }
+        assert!(WorkloadRecord::from_value(&extra).is_err());
+    }
+
+    #[test]
+    fn record_validates_formats() {
+        // Bad repo at-uri.
+        assert!(
+            WorkloadRecord::new("nope", "w", "did:web:n", None, "2026-06-23T12:34:56.789Z")
+                .is_err()
+        );
+        // Empty workload.
+        assert!(WorkloadRecord::new(
+            "at://did:web:x",
+            "",
+            "did:web:n",
+            None,
+            "2026-06-23T12:34:56.789Z"
+        )
+        .is_err());
+        // Bad node DID.
+        assert!(WorkloadRecord::new(
+            "at://did:web:x",
+            "w",
+            "not-a-did",
+            None,
+            "2026-06-23T12:34:56.789Z"
+        )
+        .is_err());
+        // Empty optional group.
+        assert!(WorkloadRecord::new(
+            "at://did:web:x",
+            "w",
+            "did:web:n",
+            Some("".into()),
+            "2026-06-23T12:34:56.789Z"
+        )
+        .is_err());
+        // Bad datetime.
+        assert!(WorkloadRecord::new("at://did:web:x", "w", "did:web:n", None, "2026").is_err());
+    }
+}


### PR DESCRIPTION
Re-lands the placement-directory lexicons that were stranded on `feature/placement-scheduling-p1-lexicons` (orphaned +1/−278 vs main, never merged). Clean cherry-pick of `33761f1d3` onto current main.

## What this adds
`crates/hyprstream-pds/src/placement/` — atproto DAG-CBOR record types for the cellular placement directory:
- `node.rs`, `workload.rs`, `group.rs`, `group_item.rs`, `mod.rs` (+ `lib.rs` re-exports)

## Why it's not a duplicate of the scheduling substrate (#628/PR #630)
Different layer. PR #630 landed the **runtime scheduler** (label/resource vocab + filter→rank→select). These are the **persistence/advertisement record types** for the placement directory (DiscoveryService). Complementary — the scheduler needs something to read; these are the records it reads.

## Scope / caveat
This delivers **only the lexicons**, so it *partial-completes* #524. Still open under #524 after this: `queryCandidates` + TTL'd resource ads + dynamic groups in DiscoveryService.

## Verification
- `cargo build -p hyprstream-pds` ✅ (no `dag_cbor` drift)
- `cargo test -p hyprstream-pds placement` ✅ **19/19 pass**
- Self-contained: depends only on `dag_cbor::DagCbor` + `anyhow`; does not import the EV2 List/ListItem primitives, so none of the churned event work touches it.

Refs #524