### PR TITLE
fix(workers): rootless kata uses XDG_RUNTIME_DIR-based KATA_PATH for sharefs jailer (#743)

### DIFF
--- a/crates/hyprstream-workers/src/runtime/kata_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/kata_backend.rs
@@ -36,6 +36,50 @@ use hyprstream_vfs::{Mount, Subject, SyntheticNode};
 /// exactly one VFS share is attached per sandbox.
 const ROOTFS_MOUNT_TAG: &str = "hyprstream-vfs";
 
+/// Derive the user-writable runtime base directory that rootless Kata must use
+/// for its Cloud Hypervisor virtio-fs (`ShareFs`) jailer root (#743).
+///
+/// **Why this exists / what actually drives the jailer base.** In rootless mode
+/// kata-hypervisor 3.31.0 builds the sharefs jailer root as
+/// `get_rootless_symlink_sandbox_jailer_root(id)` →
+/// `get_rootless_symlink_sandbox_path(id)` → `kata_types::build_path(id)` →
+/// `rootless_dir()`, i.e. its base is **`$XDG_RUNTIME_DIR`**, *not* `KATA_PATH`.
+/// `KATA_PATH` is a compile-time `const` (`"/run/kata"`, root-owned) with **no
+/// env override**, so `std::env::set_var("KATA_PATH", …)` would have zero effect
+/// on the vendored jailer path. The real seam is `XDG_RUNTIME_DIR`, which
+/// `kata_types::rootless::rootless_dir()` reads once via a `lazy_static` and
+/// `.unwrap()`s — so if it is unset the rootless jailer code panics, and if it
+/// points at a non-writable dir (or the caller lacks `mkdir` on it) VM start
+/// fails with `failed to create rootless sharefs symlink jailer root dir:
+/// Permission denied`.
+///
+/// This returns a directory we can `mkdir_all` and own, to be assigned to
+/// `XDG_RUNTIME_DIR` before any VM/hypervisor config is built (`rootless_dir()`
+/// is a one-shot `lazy_static`, so it must be set first).
+///
+/// Pure/deterministic so it can be unit-tested:
+/// - `euid == 0` (rootful) → `None`: behaviour is left unchanged.
+/// - otherwise, prefer `<XDG_RUNTIME_DIR>/kata` (user-owned, e.g.
+///   `/run/user/1000/kata`); if `XDG_RUNTIME_DIR` is unset/empty, fall back to
+///   `<TMPDIR or /tmp>/kata-<uid>`.
+fn rootless_kata_runtime_dir(
+    euid: u32,
+    xdg_runtime_dir: Option<&str>,
+    tmpdir: Option<&str>,
+) -> Option<PathBuf> {
+    if euid == 0 {
+        return None;
+    }
+    let base = match xdg_runtime_dir.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(xdg) => PathBuf::from(xdg).join("kata"),
+        None => {
+            let tmp = tmpdir.map(str::trim).filter(|s| !s.is_empty()).unwrap_or("/tmp");
+            PathBuf::from(tmp).join(format!("kata-{euid}"))
+        }
+    };
+    Some(base)
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Handle
 // ─────────────────────────────────────────────────────────────────────────────
@@ -484,8 +528,36 @@ impl SandboxBackend for KataBackend {
     }
 
     async fn initialize(&self, _config: &PoolConfig) -> Result<()> {
-        let is_root = nix::unistd::geteuid().is_root();
-        if !is_root {
+        let euid = nix::unistd::geteuid();
+        if !euid.is_root() {
+            // Rootless: kata-hypervisor 3.31.0 derives the Cloud Hypervisor
+            // sharefs jailer root from `$XDG_RUNTIME_DIR` (via
+            // `kata_types::build_path` → `rootless_dir()`), NOT from `KATA_PATH`
+            // (a compile-time const "/run/kata" with no env override). A rootless
+            // user cannot `mkdir /run/kata`, and if `XDG_RUNTIME_DIR` is unset
+            // `rootless_dir()` panics on `.unwrap()`. Pin `XDG_RUNTIME_DIR` at a
+            // directory we create and own, before `set_rootless` and before any
+            // VM/hypervisor config is built (`rootless_dir()` is a one-shot
+            // lazy_static, so this must happen first). See #743.
+            let xdg = std::env::var("XDG_RUNTIME_DIR").ok();
+            let tmpdir = std::env::var("TMPDIR").ok();
+            if let Some(kata_runtime_dir) =
+                rootless_kata_runtime_dir(euid.as_raw(), xdg.as_deref(), tmpdir.as_deref())
+            {
+                tokio::fs::create_dir_all(&kata_runtime_dir)
+                    .await
+                    .map_err(|e| {
+                        WorkerError::VmStartFailed(format!(
+                            "failed to create rootless kata runtime dir {}: {e}",
+                            kata_runtime_dir.display()
+                        ))
+                    })?;
+                std::env::set_var("XDG_RUNTIME_DIR", &kata_runtime_dir);
+                tracing::debug!(
+                    dir = %kata_runtime_dir.display(),
+                    "Rootless Kata: pinned XDG_RUNTIME_DIR to a user-writable sharefs jailer base"
+                );
+            }
             rootless::set_rootless(true);
             tracing::debug!("Enabled Kata rootless mode for non-root user");
         }
@@ -1472,6 +1544,51 @@ mod tests {
         if !nix::unistd::geteuid().is_root() {
             assert!(rootless::is_rootless());
         }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // rootless_kata_runtime_dir — pure path derivation (#743)
+    // ─────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_rootless_kata_runtime_dir_root_is_none() {
+        // Rootful (euid 0): behaviour unchanged, no XDG rewrite.
+        assert_eq!(
+            rootless_kata_runtime_dir(0, Some("/run/user/0"), Some("/tmp")),
+            None
+        );
+    }
+
+    #[test]
+    fn test_rootless_kata_runtime_dir_uses_xdg() {
+        // The seam that actually drives kata's rootless jailer base is
+        // XDG_RUNTIME_DIR (not KATA_PATH); nest kata files under it.
+        assert_eq!(
+            rootless_kata_runtime_dir(1000, Some("/run/user/1000"), None),
+            Some(PathBuf::from("/run/user/1000/kata"))
+        );
+    }
+
+    #[test]
+    fn test_rootless_kata_runtime_dir_falls_back_to_tmpdir() {
+        assert_eq!(
+            rootless_kata_runtime_dir(1000, None, Some("/var/tmp")),
+            Some(PathBuf::from("/var/tmp/kata-1000"))
+        );
+    }
+
+    #[test]
+    fn test_rootless_kata_runtime_dir_defaults_to_slash_tmp() {
+        // XDG and TMPDIR both unset/empty → /tmp/kata-<uid> (avoids the
+        // rootless_dir() unwrap panic on a missing XDG_RUNTIME_DIR).
+        assert_eq!(
+            rootless_kata_runtime_dir(1000, None, None),
+            Some(PathBuf::from("/tmp/kata-1000"))
+        );
+        assert_eq!(
+            rootless_kata_runtime_dir(1000, Some("  "), Some("")),
+            Some(PathBuf::from("/tmp/kata-1000"))
+        );
     }
 
     // ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #743.

## Root cause
Rootless kata + virtio-fs `ShareFs` fails at VM start with:
```
failed to create rootless sharefs symlink jailer root dir: Permission denied
```
Traced into vendored kata-hypervisor 3.31.0 (tag `3.31.0`, `cec98e0`). In rootless mode CH's ShareFs attach builds the jailer root via:

`ch::inner_device.rs:362` `get_rootless_symlink_sandbox_jailer_root(id)` → `ch/utils.rs:49` → `get_rootless_symlink_sandbox_path(id)` (`ch/utils.rs:42`) → `kata_types::build_path(id)` (`libs/kata-types/src/lib.rs:111`) → `rootless_dir()` (`libs/kata-types/src/rootless.rs:31`).

`rootless_dir()` returns a `lazy_static` `ROOTLESS_DIR = env::var("XDG_RUNTIME_DIR").unwrap()` (`rootless.rs:15`). So the rootless jailer base is **`$XDG_RUNTIME_DIR`**, then `create_dir_all_with_inherit_owner("<base>/<id>/root")` (`inner_device.rs:364`, const `JAILER_ROOT = "root"`, `lib.rs:89`).

## Does `KATA_PATH` env drive the jailer base? No.
`KATA_PATH` is a compile-time `pub const KATA_PATH: &str = "/run/kata";` (`libs/kata-types/src/config/mod.rs:41`) with **no env override anywhere** in the vendored tree. Setting `std::env::set_var("KATA_PATH", …)` would have **zero** effect on the sharefs jailer path (or on any other kata path). The issue's "base `KATA_PATH=/run/kata`" is a slightly imprecise trace — the actual rootless base is `rootless_dir()` = `$XDG_RUNTIME_DIR`. The real, existing seam is therefore **`XDG_RUNTIME_DIR`**, and two failure modes follow from it:
1. `XDG_RUNTIME_DIR` **unset** → `rootless_dir()` panics on `.unwrap()`.
2. `XDG_RUNTIME_DIR` set to a dir we can't `mkdir` under → `Permission denied` on the jailer root (the reported symptom).

## Fix (hyprstream side, no vendored patch needed)
`KataBackend::initialize` now, when rootless (`geteuid() != 0`), pins `XDG_RUNTIME_DIR` at a directory we create and own, **before** `set_rootless(true)` and before any VM/hypervisor config is built (`ROOTLESS_DIR` is a one-shot `lazy_static`, so ordering matters):

- Pure helper `rootless_kata_runtime_dir(euid, xdg_runtime_dir, tmpdir)`:
  - `euid == 0` → `None` (rootful unchanged).
  - else prefer `<XDG_RUNTIME_DIR>/kata` (user-owned, e.g. `/run/user/1000/kata`); if `XDG_RUNTIME_DIR` unset/empty, fall back to `<TMPDIR or /tmp>/kata-<uid>`.
- `initialize` `mkdir_all`s that dir (under XDG_RUNTIME_DIR / TMPDIR — user-owned; never touches `/run/kata`) and `set_var("XDG_RUNTIME_DIR", …)` so kata's `rootless_dir()` picks it up.

This is the closest correct hyprstream-side mitigation and is **sufficient** — the env override is the actual seam that drives the vendored jailer base; no vendored kata-hypervisor patch is required.

## Rootful behaviour
Unchanged: `euid == 0` short-circuits (`rootless_kata_runtime_dir` returns `None`, no XDG rewrite, `set_rootless` not called).

## Tests / gate (code only — no VM boot)
- `cargo check -p hyprstream-workers --features kata-vm` — clean.
- `cargo clippy -p hyprstream-workers --features kata-vm --all-targets -- -D warnings` — clean.
- 4 new unit tests for the pure path-derivation helper — pass.

**Boot-validation is the operator's follow-up** (#721 / #733) — this PR is code + compile only.

## Overlap note
Touches `kata_backend.rs`, which #741 (`serve_tenant_vfs_9p`) and #742 (`rootfs_mount_tag`/`deliver_namespace`) also touch. Different regions: this change is confined to the `initialize` env setup + a new module-level helper; no overlap with the tenant-VFS 9P / mount-tag code paths.
