### PR TITLE
feat(9p): socket-transport 9P client Mount — import a remote 9P namespace over UDS/TCP (#708 phase 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6842,6 +6842,7 @@ dependencies = [
  "hyprstream-vfs",
  "js-sys",
  "parking_lot 0.12.4",
+ "tempfile",
  "tokio",
  "tracing",
  "wasm-bindgen",

--- a/crates/hyprstream-9p/Cargo.toml
+++ b/crates/hyprstream-9p/Cargo.toml
@@ -32,7 +32,8 @@ wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
 
 [dev-dependencies]
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
+tempfile = { workspace = true }
 
 [features]
 default = []

--- a/crates/hyprstream-9p/src/client.rs
+++ b/crates/hyprstream-9p/src/client.rs
@@ -4,15 +4,21 @@
 //! On wasm32, these would be backed by DMA ring buffers (SharedArrayBuffer).
 //! On native, these could be backed by pipes, TCP, or QUIC streams.
 
-use std::cell::Cell;
+use std::sync::atomic::{AtomicU16, AtomicU32, Ordering};
 
 use crate::msg::{self, Qid, Response};
 
 /// Transport trait for sending/receiving 9P messages.
 ///
-/// Implementations provide the actual byte transport (DMA ring, pipe, etc.).
+/// Implementations provide the actual byte transport (DMA ring, socket, etc.).
 /// Messages are already length-prefixed by the 9P serializer.
-#[async_trait::async_trait(?Send)]
+///
+/// The trait is `Send` on native targets — so a socket-backed transport can back
+/// a `Send + Sync` [`Mount`](hyprstream_vfs::Mount) — and `?Send` on wasm32,
+/// where the DMA transport is single-threaded. This mirrors the `Mount` trait's
+/// own `cfg_attr` split.
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 pub trait P9Transport {
     /// Send a complete 9P message (including length prefix).
     async fn send(&self, data: &[u8]) -> anyhow::Result<()>;
@@ -25,10 +31,14 @@ pub trait P9Transport {
 ///
 /// Manages fid allocation, tag sequencing, and protocol handshake.
 /// All operations are async — the transport determines the actual I/O.
+/// The client uses atomic fid/tag counters (rather than `Cell`) so that
+/// `P9Client<T>` is `Send + Sync` whenever the transport is. That lets a native,
+/// socket-backed client back a `Send + Sync` VFS `Mount` served on real OS
+/// threads; on single-threaded wasm the atomics are equally correct.
 pub struct P9Client<T: P9Transport> {
     transport: T,
-    next_fid: Cell<u32>,
-    next_tag: Cell<u16>,
+    next_fid: AtomicU32,
+    next_tag: AtomicU16,
     root_fid: u32,
     #[allow(dead_code)]
     msize: u32,
@@ -39,8 +49,8 @@ impl<T: P9Transport> P9Client<T> {
     pub async fn connect(transport: T, uname: &str, aname: &str) -> anyhow::Result<Self> {
         let client = Self {
             transport,
-            next_fid: Cell::new(1), // 0 reserved for root
-            next_tag: Cell::new(1), // 0 is NOTAG
+            next_fid: AtomicU32::new(1), // 0 reserved for root
+            next_tag: AtomicU16::new(1), // 0 is NOTAG
             root_fid: 0,
             msize: 8192,
         };
@@ -79,16 +89,19 @@ impl<T: P9Transport> P9Client<T> {
     }
 
     fn alloc_fid(&self) -> u32 {
-        let fid = self.next_fid.get();
-        self.next_fid.set(fid.wrapping_add(1));
-        fid
+        // Returns the current value and post-increments; wraps like the prior
+        // `Cell` version (fid 0 is the root and only recurs after 2^32 walks).
+        self.next_fid.fetch_add(1, Ordering::Relaxed)
     }
 
     fn alloc_tag(&self) -> u16 {
-        let tag = self.next_tag.get();
-        self.next_tag.set(tag.wrapping_add(1));
-        if self.next_tag.get() == 0 { self.next_tag.set(1); } // skip NOTAG
-        tag
+        // Post-increment; skip NOTAG (0) if we wrap onto it.
+        let tag = self.next_tag.fetch_add(1, Ordering::Relaxed);
+        if tag == 0 {
+            self.next_tag.fetch_add(1, Ordering::Relaxed)
+        } else {
+            tag
+        }
     }
 
     /// Send a T-message and receive the R-message, checking for errors.

--- a/crates/hyprstream-9p/src/lib.rs
+++ b/crates/hyprstream-9p/src/lib.rs
@@ -15,8 +15,27 @@
 //!   the model service's `fs` scope — the inverse of `RemoteModelMount`
 //!   (VFS → RPC).
 //!
-//! The client side ([`client`], [`dma`], [`wanix_mount`]) bridges hyprstream's
-//! VFS to Wanix via DMA and is unchanged.
+//! ## Client side
+//!
+//! [`client`] is the transport-agnostic 9P2000.L client ([`client::P9Client`]),
+//! driven by a [`client::P9Transport`]. Two transports back it:
+//!
+//! - **wasm** ([`dma`], [`wanix_mount`]) — SharedArrayBuffer DMA ring to a
+//!   browser Wanix server; single-threaded, so [`wanix_mount::WanixMount`] uses
+//!   `unsafe impl Send/Sync`.
+//! - **native** ([`socket_transport`], [`remote_mount`]) — a real Unix/TCP
+//!   socket ([`socket_transport::SocketTransport`]) exposed as a genuinely
+//!   `Send + Sync` VFS [`Mount`](hyprstream_vfs::Mount)
+//!   ([`remote_mount::Remote9pMount`]). This is the client half of #708: dial a
+//!   remote 9P server and import its tree into the host namespace. It is the
+//!   exact inverse of [`mount_backend::MountBackend`] (Mount → 9P server) and
+//!   shares the same [`client::P9Transport`] / [`msg`] wire core, so a future
+//!   9P-over-WebSocket server reuses the same seam.
+//!
+//! The wasm `WanixMount` and native `Remote9pMount` are deliberately *separate*
+//! types rather than one renamed generic: they have incompatible `Send`/`Sync`
+//! stories (wasm's `unsafe impl` is only sound single-threaded, native is
+//! genuinely thread-safe) and are gated to disjoint targets.
 
 pub mod msg;
 pub mod client;
@@ -31,6 +50,12 @@ pub mod translator;
 // the translator can export it over TCP/UDS. Native-only (drives async Mount ops).
 #[cfg(not(target_arch = "wasm32"))]
 pub mod mount_backend;
+// The socket 9P *client* Mount (import a remote 9P namespace over UDS/TCP). Uses
+// `tokio::net`, so native-only — the wasm build imports via the DMA/Wanix path.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod socket_transport;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod remote_mount;
 
 #[cfg(target_arch = "wasm32")]
 pub mod dma;
@@ -38,8 +63,13 @@ pub mod dma;
 pub mod wanix_mount;
 
 pub use backend::{Backend, OpenResult, StatResult, WalkResult};
+pub use client::{P9Client, P9Transport};
 #[cfg(not(target_arch = "wasm32"))]
 pub use mount_backend::MountBackend;
+#[cfg(not(target_arch = "wasm32"))]
+pub use remote_mount::Remote9pMount;
+#[cfg(not(target_arch = "wasm32"))]
+pub use socket_transport::SocketTransport;
 #[cfg(not(target_arch = "wasm32"))]
 pub use translator::{
     serve_mount_uds, serve_mount_vsock, serve_mount_vsock_raw, FidTable, Translator,

--- a/crates/hyprstream-9p/src/remote_mount.rs
+++ b/crates/hyprstream-9p/src/remote_mount.rs
@@ -1,0 +1,206 @@
+//! `Remote9pMount` — a native VFS [`Mount`] backed by a socket 9P client.
+//!
+//! This is the **client half** of the bidirectional 9P story (#708): where
+//! [`MountBackend`](crate::mount_backend::MountBackend) exports a local VFS
+//! [`Mount`] *as* a 9P server, `Remote9pMount` *imports* a remote 9P2000.L server
+//! and presents it back as a [`Mount`] the host can
+//! [`bind_mount`](hyprstream_vfs::Namespace) into its own namespace. Together
+//! they let hyprstream both serve its namespace to a guest and consume the
+//! guest's namespace — two independent 9P sessions over two sockets.
+//!
+//! It is the native, socket-transport analogue of the wasm-only
+//! [`WanixMount`](crate::wanix_mount::WanixMount): the same `P9Client`-backed
+//! `Mount` shape, but generic over a genuinely `Send + Sync`
+//! [`SocketTransport`] rather than the browser DMA transport, and with no
+//! `unsafe impl Send/Sync` (the wasm `WanixMount` needs one because its DMA
+//! transport is only sound single-threaded). See the crate docs for why the two
+//! are separate types rather than one renamed generic.
+//!
+//! ## Subject / fid semantics
+//!
+//! Every op threads the caller [`Subject`], exactly like every other VFS
+//! [`Mount`]. Each `walk` returns an opaque [`Fid`] wrapping the remote 9P fid
+//! number; `open`/`read`/`write`/`readdir`/`stat`/`clunk` forward to that fid.
+//! The wrapped [`P9Client`] is held behind a single async `Mutex` so each
+//! Mount op is one atomic T→R exchange on the connection — requests never
+//! interleave on the wire.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use std::path::Path;
+use tokio::net::{TcpStream, UnixStream};
+use tokio::sync::Mutex;
+
+use hyprstream_rpc::Subject;
+use hyprstream_vfs::{DirEntry, Fid, Mount, MountError, Stat};
+
+use crate::client::{P9Client, P9Transport};
+use crate::socket_transport::SocketTransport;
+
+/// Fid state for a [`Remote9pMount`] — the remote 9P fid number.
+struct P9FidState {
+    fid: u32,
+}
+
+/// A VFS [`Mount`] that forwards every operation to a remote 9P2000.L server
+/// over a socket [`P9Transport`].
+///
+/// Build one with [`connect_uds`](Remote9pMount::connect_uds) /
+/// [`connect_tcp`](Remote9pMount::connect_tcp), or [`from_client`] with a
+/// pre-connected [`P9Client`] over any transport.
+///
+/// [`from_client`]: Remote9pMount::from_client
+pub struct Remote9pMount<T: P9Transport> {
+    client: Mutex<P9Client<T>>,
+}
+
+impl<T: P9Transport> Remote9pMount<T> {
+    /// Wrap an already-connected [`P9Client`] (version + attach handshake done).
+    pub fn from_client(client: P9Client<T>) -> Self {
+        Self {
+            client: Mutex::new(client),
+        }
+    }
+}
+
+impl Remote9pMount<SocketTransport<UnixStream>> {
+    /// Dial a remote 9P server on a Unix domain socket and attach its root.
+    ///
+    /// `uname`/`aname` are the 9P attach identity and export name (the server's
+    /// [`Translator`](crate::translator::Translator) ignores them and serves its
+    /// single Subject-scoped root, but they are sent for protocol conformance).
+    pub async fn connect_uds(
+        path: impl AsRef<Path>,
+        uname: &str,
+        aname: &str,
+    ) -> Result<Self> {
+        let transport = SocketTransport::connect_uds(path).await?;
+        let client = P9Client::connect(transport, uname, aname).await?;
+        Ok(Self::from_client(client))
+    }
+}
+
+impl Remote9pMount<SocketTransport<TcpStream>> {
+    /// Dial a remote 9P server over TCP and attach its root.
+    pub async fn connect_tcp(
+        addr: impl tokio::net::ToSocketAddrs,
+        uname: &str,
+        aname: &str,
+    ) -> Result<Self> {
+        let transport = SocketTransport::connect_tcp(addr).await?;
+        let client = P9Client::connect(transport, uname, aname).await?;
+        Ok(Self::from_client(client))
+    }
+}
+
+#[async_trait]
+impl<T> Mount for Remote9pMount<T>
+where
+    T: P9Transport + Send + Sync + 'static,
+{
+    async fn walk(&self, components: &[&str], _caller: &Subject) -> Result<Fid, MountError> {
+        let client = self.client.lock().await;
+        let (fid, _qids) = client
+            .walk(components)
+            .await
+            .map_err(|e| MountError::NotFound(e.to_string()))?;
+        Ok(Fid::new(P9FidState { fid }))
+    }
+
+    async fn open(&self, fid: &mut Fid, mode: u8, _caller: &Subject) -> Result<(), MountError> {
+        let f = fid
+            .downcast_ref::<P9FidState>()
+            .ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?
+            .fid;
+        let client = self.client.lock().await;
+        client
+            .open(f, mode as u32)
+            .await
+            .map_err(|e| MountError::Io(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn read(
+        &self,
+        fid: &Fid,
+        offset: u64,
+        count: u32,
+        _caller: &Subject,
+    ) -> Result<Vec<u8>, MountError> {
+        let f = fid
+            .downcast_ref::<P9FidState>()
+            .ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?
+            .fid;
+        let client = self.client.lock().await;
+        client
+            .read(f, offset, count)
+            .await
+            .map_err(|e| MountError::Io(e.to_string()))
+    }
+
+    async fn write(
+        &self,
+        fid: &Fid,
+        offset: u64,
+        data: &[u8],
+        _caller: &Subject,
+    ) -> Result<u32, MountError> {
+        let f = fid
+            .downcast_ref::<P9FidState>()
+            .ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?
+            .fid;
+        let client = self.client.lock().await;
+        client
+            .write(f, offset, data)
+            .await
+            .map_err(|e| MountError::Io(e.to_string()))
+    }
+
+    async fn readdir(&self, fid: &Fid, _caller: &Subject) -> Result<Vec<DirEntry>, MountError> {
+        let f = fid
+            .downcast_ref::<P9FidState>()
+            .ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?
+            .fid;
+        let client = self.client.lock().await;
+        let entries = client
+            .readdir(f, 0, 65536)
+            .await
+            .map_err(|e| MountError::Io(e.to_string()))?;
+        Ok(entries
+            .into_iter()
+            .map(|e| DirEntry {
+                name: e.name,
+                is_dir: e.qid.is_dir(),
+                size: 0,
+                stat: None,
+            })
+            .collect())
+    }
+
+    async fn stat(&self, fid: &Fid, _caller: &Subject) -> Result<Stat, MountError> {
+        let f = fid
+            .downcast_ref::<P9FidState>()
+            .ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?
+            .fid;
+        let client = self.client.lock().await;
+        let (qid, _mode, size, mtime) = client
+            .getattr(f)
+            .await
+            .map_err(|e| MountError::Io(e.to_string()))?;
+        Ok(Stat {
+            qtype: qid.qtype,
+            version: qid.version,
+            path: qid.path,
+            size,
+            name: String::new(), // name comes from walk, not stat
+            mtime,
+        })
+    }
+
+    async fn clunk(&self, fid: Fid, _caller: &Subject) {
+        if let Some(f) = fid.downcast_ref::<P9FidState>().map(|s| s.fid) {
+            let client = self.client.lock().await;
+            let _ = client.clunk(f).await;
+        }
+    }
+}

--- a/crates/hyprstream-9p/src/socket_transport.rs
+++ b/crates/hyprstream-9p/src/socket_transport.rs
@@ -1,0 +1,127 @@
+//! Socket-backed [`P9Transport`] — a native 9P transport over a byte stream.
+//!
+//! This is the **client-side** counterpart to the server-side [`Translator`]
+//! accept loop: where the translator *reads* length-prefixed 9P frames off a
+//! `tokio::net` stream and *dispatches* them to a [`Backend`], `SocketTransport`
+//! *carries* complete 9P frames between a [`P9Client`] and a remote 9P2000.L
+//! server over the same wire (a Unix domain socket or TCP). It is the inverse of
+//! the DMA transport ([`crate::dma`]): identical [`P9Transport`] contract, but a
+//! real OS socket instead of a SharedArrayBuffer ring, so it carries across
+//! process (and host) boundaries.
+//!
+//! ## Framing contract
+//!
+//! [`P9Client`] hands `send` a complete 9P message whose first four bytes are the
+//! self-counting `size[4]` field, and expects `recv` to return exactly one such
+//! complete frame. `recv` therefore reads the 4-byte length prefix first, then
+//! the `size - 4` remaining body bytes, handling partial reads via
+//! [`read_exact`](tokio::io::AsyncReadExt::read_exact) — matching the framing the
+//! [`Translator`] itself uses on the server side.
+//!
+//! ## Concurrency
+//!
+//! The read and write halves each sit behind their own async `Mutex`, so the
+//! transport is `Send + Sync`. Whole request/response pairs are serialized one
+//! level up (in [`Remote9pMount`](crate::remote_mount::Remote9pMount), which
+//! holds the [`P9Client`] behind a single mutex), which is what keeps
+//! interleaved T-messages from racing on one connection.
+//!
+//! [`Translator`]: crate::translator::Translator
+//! [`Backend`]: crate::backend::Backend
+//! [`P9Client`]: crate::client::P9Client
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use tokio::io::{split, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadHalf, WriteHalf};
+use tokio::net::{TcpStream, UnixStream};
+use tokio::sync::Mutex;
+
+use crate::client::P9Transport;
+
+/// A [`P9Transport`] backed by an `AsyncRead + AsyncWrite` byte stream.
+///
+/// Construct it directly from any stream via [`SocketTransport::new`], or use the
+/// [`connect_uds`](SocketTransport::connect_uds) /
+/// [`connect_tcp`](SocketTransport::connect_tcp) helpers for the common Unix and
+/// TCP cases.
+pub struct SocketTransport<S> {
+    rx: Mutex<ReadHalf<S>>,
+    tx: Mutex<WriteHalf<S>>,
+}
+
+impl<S> SocketTransport<S>
+where
+    S: AsyncRead + AsyncWrite + Send + 'static,
+{
+    /// Wrap an already-connected byte stream as a 9P transport.
+    pub fn new(stream: S) -> Self {
+        let (rx, tx) = split(stream);
+        Self {
+            rx: Mutex::new(rx),
+            tx: Mutex::new(tx),
+        }
+    }
+}
+
+impl SocketTransport<UnixStream> {
+    /// Dial a 9P server listening on a Unix domain socket at `path`.
+    pub async fn connect_uds(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+        let stream = UnixStream::connect(path)
+            .await
+            .with_context(|| format!("connect 9P UDS at {path:?}"))?;
+        Ok(Self::new(stream))
+    }
+}
+
+impl SocketTransport<TcpStream> {
+    /// Dial a 9P server listening on a TCP `addr`.
+    pub async fn connect_tcp(addr: impl tokio::net::ToSocketAddrs) -> Result<Self> {
+        let stream = TcpStream::connect(addr)
+            .await
+            .context("connect 9P TCP endpoint")?;
+        // 9P is request/response with small messages; disable Nagle to avoid
+        // coalescing latency. Best-effort — failure here is non-fatal.
+        let _ = stream.set_nodelay(true);
+        Ok(Self::new(stream))
+    }
+}
+
+#[async_trait::async_trait]
+impl<S> P9Transport for SocketTransport<S>
+where
+    S: AsyncRead + AsyncWrite + Send + 'static,
+{
+    async fn send(&self, data: &[u8]) -> Result<()> {
+        let mut tx = self.tx.lock().await;
+        tx.write_all(data).await.context("9P socket send")?;
+        tx.flush().await.context("9P socket flush")?;
+        Ok(())
+    }
+
+    async fn recv(&self) -> Result<Vec<u8>> {
+        let mut rx = self.rx.lock().await;
+
+        // Read the 4-byte self-counting size prefix first...
+        let mut len_buf = [0u8; 4];
+        rx.read_exact(&mut len_buf)
+            .await
+            .context("9P socket recv: size prefix")?;
+        let total = u32::from_le_bytes(len_buf) as usize;
+
+        // A valid 9P2000.L message is at least size[4] + type[1] + tag[2].
+        if total < 7 {
+            anyhow::bail!("invalid 9P frame size: {total}");
+        }
+
+        // ...then the remaining `total - 4` body bytes. `read_exact` loops over
+        // partial reads until the full frame has arrived.
+        let mut buf = vec![0u8; total];
+        buf[..4].copy_from_slice(&len_buf);
+        rx.read_exact(&mut buf[4..])
+            .await
+            .context("9P socket recv: message body")?;
+        Ok(buf)
+    }
+}

--- a/crates/hyprstream-9p/tests/socket_roundtrip.rs
+++ b/crates/hyprstream-9p/tests/socket_roundtrip.rs
@@ -1,0 +1,123 @@
+//! Round-trip integration test: the socket 9P **client** `Mount`
+//! ([`Remote9pMount`]) against hyprstream's own server-side [`Translator`]
+//! (`serve_mount_uds`), over a real Unix domain socket.
+//!
+//! This is the reusable-infra proof for #708 phase 1: it needs no Wanix. We
+//! serve a small in-process [`SyntheticMount`] over a temp UDS, dial it with the
+//! socket client Mount, and drive attach → walk → readdir → read (including a
+//! nested walk and a stat) end-to-end, asserting the bytes round-trip through the
+//! full 9P2000.L wire path (client codec ⇄ socket ⇄ translator ⇄ MountBackend).
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use hyprstream_9p::{serve_mount_uds, Remote9pMount};
+use hyprstream_rpc::Subject;
+use hyprstream_vfs::{Mount, SyntheticMount, SyntheticNode};
+
+#[tokio::test]
+async fn socket_client_mount_round_trips_against_translator() {
+    // ── Build a small synthetic tree to export ──────────────────────────────
+    let root = SyntheticNode::dir()
+        .with_child("hello.txt", SyntheticNode::file(b"hello world".to_vec()))
+        .with_child(
+            "dir",
+            SyntheticNode::dir().with_child("nested.txt", SyntheticNode::file(b"deep".to_vec())),
+        );
+    let mount: Arc<dyn Mount> = Arc::new(SyntheticMount::new(root));
+    let subject = Subject::new("tester");
+
+    // Temp UDS path (unique dir, auto-cleaned on drop).
+    let dir = tempfile::tempdir().unwrap();
+    let sock = dir.path().join("9p.sock");
+
+    // ── Serve it over a UDS in the background via the hyprstream translator ──
+    let server = tokio::spawn({
+        let mount = Arc::clone(&mount);
+        let subject = subject.clone();
+        let sock = sock.clone();
+        async move {
+            // Returns only on listener error / shutdown; we abort it at the end.
+            let _ = serve_mount_uds(mount, subject, sock).await;
+        }
+    });
+
+    // Wait for the listener socket to appear.
+    let mut ready = false;
+    for _ in 0..200 {
+        if sock.exists() {
+            ready = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(ready, "translator did not bind the UDS in time");
+
+    // ── Dial it with the socket 9P *client* Mount (version + attach) ─────────
+    let client_mount = Remote9pMount::connect_uds(&sock, "tester", "/")
+        .await
+        .expect("connect socket client mount");
+    let caller = Subject::new("tester");
+
+    // Walk the root, open it, readdir.
+    let mut root_fid = client_mount.walk(&[], &caller).await.expect("walk root");
+    client_mount
+        .open(&mut root_fid, 0, &caller)
+        .await
+        .expect("open root dir");
+    let entries = client_mount
+        .readdir(&root_fid, &caller)
+        .await
+        .expect("readdir root");
+    let mut names: Vec<String> = entries.iter().map(|e| e.name.clone()).collect();
+    names.sort();
+    assert_eq!(names, vec!["dir".to_string(), "hello.txt".to_string()]);
+    // The directory child must be reported as a directory (qid qtype carried
+    // through the wire-faithful Rreaddir records).
+    let dir_entry = entries.iter().find(|e| e.name == "dir").unwrap();
+    assert!(dir_entry.is_dir, "`dir` should be reported as a directory");
+
+    // Walk to the top-level file, open, read the full contents.
+    let mut file_fid = client_mount
+        .walk(&["hello.txt"], &caller)
+        .await
+        .expect("walk hello.txt");
+    client_mount
+        .open(&mut file_fid, 0, &caller)
+        .await
+        .expect("open hello.txt");
+    let data = client_mount
+        .read(&file_fid, 0, 1024, &caller)
+        .await
+        .expect("read hello.txt");
+    assert_eq!(&data, b"hello world");
+
+    // stat the file: size must match.
+    let st = client_mount.stat(&file_fid, &caller).await.expect("stat");
+    assert_eq!(st.size, 11);
+
+    // Multi-component walk into the nested dir, open, read.
+    let mut nested_fid = client_mount
+        .walk(&["dir", "nested.txt"], &caller)
+        .await
+        .expect("walk dir/nested.txt");
+    client_mount
+        .open(&mut nested_fid, 0, &caller)
+        .await
+        .expect("open nested.txt");
+    let nested = client_mount
+        .read(&nested_fid, 0, 1024, &caller)
+        .await
+        .expect("read nested.txt");
+    assert_eq!(&nested, b"deep");
+
+    // Clunk everything we opened (best-effort; drives the clunk path).
+    client_mount.clunk(root_fid, &caller).await;
+    client_mount.clunk(file_fid, &caller).await;
+    client_mount.clunk(nested_fid, &caller).await;
+
+    server.abort();
+    let _ = server.await;
+}


### PR DESCRIPTION
## #708 phase 1 — reusable infra (no Wanix)

Gives hyprstream a **socket-based 9P2000.L client `Mount`**: dial a remote 9P server over a Unix (or TCP) socket and present the remote tree as an `hyprstream_vfs::Mount` that can be `bind_mount`-ed into the host namespace. This is the **inverse** of `MountBackend` (Mount → 9P server) and the client half of #708 (hyprstream imports a remote 9P namespace).

Phase 2 (wanix `serve` export of `NewRoot().NS()` + wiring the workload's second socket into `/workers/<tenant>/wanix`) is **separate and NOT in scope here** — see the issue. This lands only the reusable Rust plumbing and proves it against our own server.

### What's here

- **`socket_transport.rs` — `SocketTransport<S>`**: a native `P9Transport` over any `AsyncRead + AsyncWrite` stream (helpers `connect_uds` / `connect_tcp`). `recv()` reads the 4-byte self-counting `size[4]` prefix, then the `size-4` body via `read_exact` (partial-read-safe); `send()` writes the full framed message. Read/write halves each sit behind an async `Mutex`, so it is `Send + Sync`. This mirrors `DmaTransport`'s contract exactly (send = one complete frame, recv = one complete frame) — the same framing the server-side `Translator` uses.
- **`remote_mount.rs` — `Remote9pMount<T>`**: a native VFS `Mount` backed by a `P9Client<T>`. Constructors `Remote9pMount::connect_uds(path, uname, aname)` / `connect_tcp(addr, …)` (and `from_client` for any transport). Every op threads the caller `Subject` and forwards to the remote fid; the `P9Client` is held behind a single async `Mutex` so each Mount op is one atomic T→R exchange (requests never interleave on the wire).
- **`client.rs` — `P9Client` fid/tag counters `Cell` → `AtomicU32/U16`**, and `P9Transport` made `Send` on native / `?Send` on wasm via `cfg_attr` (mirroring the `Mount` trait's own split). This is what lets a socket client back a genuinely `Send + Sync` `Mount` served on real OS threads. Equally correct on single-threaded wasm; the DMA/`WanixMount` path is unchanged.
- **`tests/socket_roundtrip.rs`**: the key proof — serves an in-test `SyntheticMount` over a temp **UDS** via `serve_mount_uds`/`Translator`, dials it with `Remote9pMount::connect_uds`, and drives attach → walk → readdir → nested walk → read → stat → clunk end-to-end, asserting the bytes round-trip through the full wire path (client codec ⇄ socket ⇄ translator ⇄ `MountBackend`). No Wanix needed.

### Naming decision (`WanixMount` vs `Remote9pMount`)

`WanixMount` is `#[cfg(target_arch = "wasm32")]`-only and relies on `unsafe impl Send/Sync` that is sound **only** because the browser DMA transport is single-threaded. The native socket Mount is genuinely thread-safe (no `unsafe impl`). Because the two have incompatible `Send`/`Sync` stories and are gated to disjoint targets, I **added a separate native `Remote9pMount`** rather than rename/generalize the wasm `WanixMount` — a rename would have forced one type to carry both an `unsafe` and a safe Send story. Both share the same `P9Client` / `P9Transport` / `msg` wire core (the `Cell`→atomic change makes `P9Client` reusable across both). Existing DMA/browser `WanixMount` users are untouched.

### Shared seam

`SocketTransport` and `Remote9pMount` sit on the same `P9Transport` + `msg` (9P2000.L codec) core as the server-side `Translator`, so a future **9P-over-WebSocket server (H1a)** reuses the exact same seam — one transport abstraction, both directions.

### Checks (native, tmpfs target)

- `cargo check -p hyprstream-9p` — clean
- `cargo clippy -p hyprstream-9p --all-targets -- -D warnings` — clean
- `cargo test -p hyprstream-9p` — 13 lib + all integration tests pass (incl. the new `socket_client_mount_round_trips_against_translator` and the existing Rreaddir wire regression guards)
- `cargo check -p hyprstream-9p --target wasm32-unknown-unknown` (`--cfg=web_sys_unstable_apis`) — compiles; the DMA/`WanixMount` path is unaffected by the trait/atomics change.

Does not touch `mac/`, `oauth/`, or MAC #547.
