### PR TITLE
feat(#341): rework selection.rs onto #628 scheduling substrate (#629)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7251,6 +7251,7 @@ dependencies = [
  "hex",
  "hypervisor",
  "hyprstream-9p",
+ "hyprstream-discovery",
  "hyprstream-rpc",
  "hyprstream-rpc-build",
  "hyprstream-rpc-derive",

--- a/crates/hyprstream-discovery/schema/discovery.capnp
+++ b/crates/hyprstream-discovery/schema/discovery.capnp
@@ -83,6 +83,12 @@ struct DiscoveryRequest {
     # #431 — fetch a full atproto repo CAR by DID (commit + MST + all records).
     getRepo @16 :Text $scope(query) $mcpDescription("Fetch a full atproto repo CAR by DID")
       $vfsPath("{arg}/repo");
+
+    # #523 P0 / #524 — placement candidate query (the leaf<->federation seam).
+    # Authz-prefiltered per-candidate (fail-closed); bounded result. Selector
+    # matches labels on the durable node records; resources check
+    # (declared - allocatable). (#628 Scheduling Substrate vocabulary.)
+    queryCandidates @17 :QueryCandidatesRequest $scope(query) $mcpDescription("Query placement candidates by label-selector + resource requests");
   }
 }
 
@@ -134,6 +140,9 @@ struct DiscoveryResponse {
     # #431 — record/repo lookup results (paired with the requests above).
     getRecordResult @16 :RecordCar;
     getRepoResult @17 :RecordCar;
+
+    # #523 P0 / #524 — placement candidate query result.
+    queryCandidatesResult @18 :PlacementCandidateSet;
   }
 }
 
@@ -273,4 +282,70 @@ struct GetRecordRequest {
   did @1 :Text;
   collection @2 :Text;   # e.g. "ai.hyprstream.model"
   rkey @3 :Text;         # the TID record key
+}
+
+# ============================================================================
+# #523 P0 / #524 — Scheduling Substrate vocabulary (#628)
+# ============================================================================
+# Shared label/resource/selector vocabulary for every scheduling surface
+# (placement queryCandidates, SandboxPool engine, CellRouter routing, backend
+# selection). One shape — candidates -> filter(predicates) -> rank -> select ->
+# explain — so capability truth is declared once and no surface duplicates
+# filter/rank/explain logic. See the Rust `scheduling` module.
+
+# A named resource amount (k8s-quantity string), e.g. {name: "nvidia.com/gpu",
+# quantity: "8"} or {name: "memory", quantity: "512Gi"}.
+struct Resource {
+  name     @0 :Text;
+  quantity @1 :Text;   # k8s-quantity
+}
+
+# A resource requirement: the candidate must have at least `minQuantity` of
+# `name` allocatable (declared - already-allocated).
+struct ResourceRequest {
+  name        @0 :Text;
+  minQuantity @1 :Text;   # k8s-quantity
+}
+
+# Label-selector match operator (k8s match-expressions).
+enum SelectorOp {
+  in           @0;
+  notIn        @1;
+  exists       @2;
+  doesNotExist @3;
+  gt           @4;
+  lt           @5;
+}
+
+# One label-selector conjunct: `key <op> values`. A query carries a list of
+# these (all must match — AND).
+struct LabelSelector {
+  key    @0 :Text;
+  op     @1 :SelectorOp;
+  values @2 :List(Text);   # for In/NotIn/Gt/Lt (empty for Exists/DoesNotExist)
+}
+
+# A placement candidate returned by queryCandidates. The caller fetches the
+# signed node record via getRecord when it needs the CAR proof.
+struct PlacementCandidate {
+  node          @0 :Text;             # serving node's DID
+  recordUri     @1 :Text;             # at-uri of the node record (for getRecord)
+  loadFraction  @2 :Float32;          # [0,1], live
+  allocatable   @3 :List(Resource);   # capacity free now (live, volatile)
+  lastSeen      @4 :Int64;            # unix millis of last heartbeat
+}
+
+# Bounded result set. `totalMatching` is the full match count before the bound
+# was applied (so callers know if truncation occurred).
+struct PlacementCandidateSet {
+  candidates   @0 :List(PlacementCandidate);
+  totalMatching @1 :UInt32;
+}
+
+# queryCandidates request: all selectors AND, all resources must be satisfiable,
+# bounded to `maxCandidates`.
+struct QueryCandidatesRequest {
+  selectors    @0 :List(LabelSelector);   # ALL must match (AND)
+  resources    @1 :List(ResourceRequest); # ALL must be satisfiable
+  maxCandidates @2 :UInt32;               # bounded set
 }

--- a/crates/hyprstream-discovery/src/lib.rs
+++ b/crates/hyprstream-discovery/src/lib.rs
@@ -39,6 +39,18 @@ pub mod generated {
 
 mod service;
 
+/// #523 P0 / #524 / #628 — Scheduling Substrate.
+///
+/// The shared `LabelSelector` / `ResourceRequest` / `PlacementCandidate`
+/// vocabulary + a small `filter → rank → select` helper + one `SelectionReport`
+/// explain shape + a `CapabilitySource` contract, so every scheduling surface
+/// (placement `queryCandidates`, the `SandboxPool` engine, `CellRouter` routing,
+/// backend `selection.rs`) composes without duplicating filter/rank/explain
+/// logic or capability truth.
+///
+/// **Not a framework**: free functions + plain types. See the module doc.
+pub mod scheduling;
+
 // Re-export key types
 pub use hyprstream_rpc::resolver::Resolver;
 pub use hyprstream_rpc::registry::SocketKind;

--- a/crates/hyprstream-discovery/src/scheduling.rs
+++ b/crates/hyprstream-discovery/src/scheduling.rs
@@ -1,0 +1,424 @@
+//! Scheduling Substrate — the shared vocabulary + small primitives every
+//! scheduling surface composes on (#523 P0 / #524 / #628).
+//!
+//! Five selection systems grew independently (`selection.rs` backend pick,
+//! `SandboxPool::acquire`, `DevicePool`, `CellRouter`/HRW routing,
+//! `queryCandidates`). They share one shape —
+//! `candidates → filter(predicates) → rank → select → explain` — so this module
+//! is the ONE place that shape lives. Each provider declares capability truth
+//! once (as labels + resources via [`CapabilitySource`]); each consumer filters
+//! and ranks through [`filter`] / [`rank`] / [`select`] and gets a trace
+//! ([`SelectionReport`]) for free, because every [`Predicate`] returns *why* it
+//! rejected.
+//!
+//! ## Guardrail (non-negotiable)
+//! This is small on purpose: plain types + free functions. **No trait towers,
+//! no `Scheduler<T>` abstraction-without-consumers.** If it grows past
+//! "vocabulary + small helpers," it is wrong — extend by adding real consumers,
+//! not by abstracting in a vacuum.
+
+use std::cmp::Ordering;
+
+// ─── Vocabulary (mirrors `discovery.capnp` #523 P0) ─────────────────────────
+
+/// A named resource amount (`{name, quantity}`); `quantity` is a k8s-quantity
+/// string e.g. `"8"`, `"512Gi"`, `"100m"`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Resource {
+    pub name: String,
+    pub quantity: String,
+}
+
+impl Resource {
+    pub fn new(name: impl Into<String>, quantity: impl Into<String>) -> Self {
+        Self { name: name.into(), quantity: quantity.into() }
+    }
+}
+
+/// A resource requirement: a candidate must have at least `min_quantity` of
+/// `name` allocatable (declared − already-allocated).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResourceRequest {
+    pub name: String,
+    pub min_quantity: String,
+}
+
+impl ResourceRequest {
+    pub fn new(name: impl Into<String>, min_quantity: impl Into<String>) -> Self {
+        Self { name: name.into(), min_quantity: min_quantity.into() }
+    }
+
+    /// Satisfied iff `available` parses and is `>= min_quantity`. A missing/
+    /// unparseable available value is *not* satisfiable (fail-closed).
+    pub fn satisfied_by(&self, available: &str) -> bool {
+        match (parse_k8s_quantity(available), parse_k8s_quantity(&self.min_quantity)) {
+            (Some(have), Some(need)) => have >= need,
+            _ => false,
+        }
+    }
+}
+
+/// Label-selector match operator (k8s match-expressions).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelectorOp {
+    In,
+    NotIn,
+    Exists,
+    DoesNotExist,
+    Gt,
+    Lt,
+}
+
+/// One label-selector conjunct: `key <op> values`. A query carries a list of
+/// these (all must match — AND). `values` is ignored for `Exists`/`DoesNotExist`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LabelSelector {
+    pub key: String,
+    pub op: SelectorOp,
+    pub values: Vec<String>,
+}
+
+impl LabelSelector {
+    pub fn new(key: impl Into<String>, op: SelectorOp, values: Vec<String>) -> Self {
+        Self { key: key.into(), op, values }
+    }
+
+    /// Evaluate this selector against a label set `(key, value)`.
+    pub fn matches(&self, labels: &[(String, String)]) -> bool {
+        let entry = labels.iter().find(|(k, _)| k == &self.key);
+        match self.op {
+            SelectorOp::Exists => entry.is_some(),
+            SelectorOp::DoesNotExist => entry.is_none(),
+            SelectorOp::In => entry.is_some_and(|(_, v)| self.values.iter().any(|w| w == v)),
+            SelectorOp::NotIn => entry.is_none_or(|(_, v)| !self.values.iter().any(|w| w == v)),
+            // Gt/Lt compare numerically over the k8s-quantity value (k8s restricts
+            // these to integer resources; we extend to any parseable quantity).
+            SelectorOp::Gt => self.cmp_numeric(entry.map(|(_, v)| v.as_str()), |o| o == Ordering::Greater),
+            SelectorOp::Lt => self.cmp_numeric(entry.map(|(_, v)| v.as_str()), |o| o == Ordering::Less),
+        }
+    }
+
+    fn cmp_numeric(&self, have: Option<&str>, want: impl Fn(Ordering) -> bool) -> bool {
+        let have = match have.and_then(parse_k8s_quantity) {
+            Some(h) => h,
+            None => return false,
+        };
+        // Gt/Lt compare against `values[0]` (k8s: a single value for these ops).
+        let need = match self.values.first().and_then(|v| parse_k8s_quantity(v)) {
+            Some(n) => n,
+            None => return false,
+        };
+        want(have.cmp(&need))
+    }
+}
+
+/// A placement candidate returned by `queryCandidates`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PlacementCandidate {
+    pub node: String,
+    pub record_uri: String,
+    pub load_fraction: f32,
+    pub allocatable: Vec<Resource>,
+    pub last_seen: i64,
+}
+
+/// Bounded result set. `total_matching` is the full match count before the
+/// bound was applied.
+#[derive(Debug, Clone)]
+pub struct PlacementCandidateSet {
+    pub candidates: Vec<PlacementCandidate>,
+    pub total_matching: u32,
+}
+
+// ─── k8s-quantity parsing (minimal, for comparison) ────────────────────────
+
+/// Parse a k8s-quantity string into a canonical comparable value (milli of the
+/// base unit, as `i128`). Handles the common suffixes:
+/// - binary: `Ki`/`Mi`/`Gi`/`Ti`/`Pi`/`Ei` (×1024^n)
+/// - decimal: `k`/`M`/`G`/`T`/`P`/`E` (×1000^n)
+/// - `m` (milli, ÷1000)
+/// - plain decimal number
+///
+/// Returns `None` for unparseable input. This is deliberately **minimal** — it
+/// covers the suffixes in real use here; full k8s quantity semantics (sign,
+/// exponents, the binary/decimal distinction k8s preserves) are deferred to the
+/// scheduler engine that actually does capacity math. Comparison only needs the
+/// same input to canonicalize consistently.
+pub fn parse_k8s_quantity(s: &str) -> Option<i128> {
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+    // Split trailing non-digit suffix from the numeric prefix. k8s quantities are
+    // `<number><suffix>`; a leading sign is allowed.
+    let split = s
+        .find(|c: char| !(c.is_ascii_digit() || c == '.' || c == '-' || c == '+'))
+        .unwrap_or(s.len());
+    let (num, suffix) = s.split_at(split);
+    let v: f64 = num.parse().ok()?;
+    // Canonicalize to milli of the base unit (i128). One multiplier per suffix.
+    // Sub-unit suffixes (`m`, `u`) divide instead of multiply.
+    let milli: i128 = match suffix {
+        "" => (v * 1_000.0) as i128,
+        "m" => v as i128,                       // already milli
+        "u" | "µ" => (v / 1_000.0) as i128,     // micro → milli
+        "k" => (v * 1_000.0 * 1_000.0) as i128,
+        "M" => (v * 1_000_000.0 * 1_000.0) as i128,
+        "G" => (v * 1_000_000_000.0 * 1_000.0) as i128,
+        "T" => (v * 1_000_000_000_000.0 * 1_000.0) as i128,
+        "Ki" => (v * 1_024.0 * 1_000.0) as i128,
+        "Mi" => (v * 1_048_576.0 * 1_000.0) as i128,
+        "Gi" => (v * 1_073_741_824.0 * 1_000.0) as i128,
+        "Ti" => (v * 1_099_511_627_776.0 * 1_000.0) as i128,
+        // P/E and Pi/Ei overflow i128 milli in real magnitudes; fall through to
+        // the catch-all `None` (not in use here).
+        _ => return None,
+    };
+    Some(milli)
+}
+
+// ─── filter → rank → select ────────────────────────────────────────────────
+
+/// Why a predicate rejected a candidate (carried into the explain trace).
+#[derive(Debug, Clone)]
+pub struct RejectionReason(pub String);
+
+/// A predicate over a candidate: returns `None` if it passes, `Some(reason)` if
+/// rejected (and why). Because every predicate returns its reason, a
+/// [`SelectionReport`] trace falls out of [`filter`] / [`select`] for free.
+pub type Predicate<C> = Box<dyn Fn(&C) -> Option<RejectionReason>>;
+
+/// Per-candidate outcome from [`filter`]: the candidate plus its first rejection
+/// (if any). Short-circuits per candidate on the first rejecting predicate.
+#[derive(Debug, Clone)]
+pub struct Outcome<'c, C> {
+    pub candidate: &'c C,
+    pub rejected: Option<RejectionReason>,
+}
+
+impl<'c, C> Outcome<'c, C> {
+    pub fn passed(&self) -> bool {
+        self.rejected.is_none()
+    }
+}
+
+/// Run every candidate through every predicate, recording the first rejection
+/// (if any) per candidate. Predicates are evaluated in order; a candidate
+/// rejected by predicate *i* is not tested against *i+1*.
+#[allow(clippy::needless_lifetimes)] // two input refs; the `'c` ties the borrow unambiguously
+pub fn filter<'c, C>(candidates: &'c [C], predicates: &[Predicate<C>]) -> Vec<Outcome<'c, C>> {
+    candidates
+        .iter()
+        .map(|c| {
+            let rejected = predicates.iter().find_map(|p| p(c));
+            Outcome { candidate: c, rejected }
+        })
+        .collect()
+}
+
+/// Order survivors by `by`. Stable. Consumes the slice of survivor references
+/// (typically `filter(...).iter().filter(|o| o.passed()).map(|o| o.candidate)`).
+pub fn rank<C>(mut survivors: Vec<&C>, by: impl Fn(&C, &C) -> Ordering) -> Vec<&C> {
+    survivors.sort_by(|a, b| by(a, b));
+    survivors
+}
+
+/// One candidate's verdict in a [`SelectionReport`] (generic — consumer-agnostic;
+/// `selection.rs` adds its own backend-specific fields when it adopts this).
+#[derive(Debug, Clone)]
+pub struct CandidateOutcome<C> {
+    pub candidate: C,
+    pub selected: bool,
+    pub rejection_reason: Option<String>,
+}
+
+/// Full trace of a selection decision: every candidate considered + the winner.
+/// The explain shape (generalized from the backend-selection diagnostics).
+#[derive(Debug, Clone)]
+pub struct SelectionReport<C> {
+    pub requested: String,
+    pub candidates: Vec<CandidateOutcome<C>>,
+    pub selected: Option<usize>, // index into `candidates`
+    pub summary: String,
+}
+
+/// The full pipeline: filter → rank → bounded select, returning both the chosen
+/// candidates and the explain trace. `identify` maps a `&C` to the name used in
+/// the report's per-candidate entries (so the report stays generic over `C`).
+///
+/// `selected` in the report marks every returned (post-bound) candidate.
+pub fn select<C>(
+    candidates: &[C],
+    predicates: &[Predicate<C>],
+    rank_by: impl Fn(&C, &C) -> Ordering,
+    max: usize,
+) -> SelectionReport<C>
+where
+    C: Clone,
+{
+    let outcomes = filter(candidates, predicates);
+    let mut survivors: Vec<&C> = outcomes.iter().filter(|o| o.passed()).map(|o| o.candidate).collect();
+    survivors = rank(survivors, rank_by);
+    let bound: Vec<&C> = survivors.into_iter().take(max).collect();
+    let chosen: Vec<&C> = bound.clone();
+    let summary = format!(
+        "{} considered, {} survived filters, {} selected (bound {max})",
+        candidates.len(),
+        outcomes.iter().filter(|o| o.passed()).count(),
+        chosen.len(),
+    );
+    let candidate_reports = candidates
+        .iter()
+        .map(|c| {
+            let is_selected = chosen.iter().any(|s| std::ptr::eq(*s, c));
+            let rejection = outcomes
+                .iter()
+                .find(|o| std::ptr::eq(o.candidate, c))
+                .and_then(|o| o.rejected.as_ref().map(|r| r.0.clone()));
+            CandidateOutcome { candidate: c.clone(), selected: is_selected, rejection_reason: rejection }
+        })
+        .collect();
+    let selected_idx = bound.first().and_then(|b| {
+        candidates.iter().position(|c| std::ptr::eq(c as *const _, *b as *const _))
+    });
+    SelectionReport { requested: String::new(), candidates: candidate_reports, selected: selected_idx, summary }
+}
+
+// ─── Capability-source contract ────────────────────────────────────────────
+
+/// A provider of scheduling capability truth: emits its stable capabilities +
+/// declared capacity in the shared vocabulary so a `PlacementCandidate` / node
+/// record can aggregate them (one source of truth — no hand-declaration, no
+/// drift between e.g. a node record claiming `runtime=kata` and the live
+/// `selection.rs` knowing `cloud-hypervisor` is missing).
+///
+/// Implementors: backend-selection registries, device pools, future NUMA/
+/// topology providers. Aggregators (the node-record publisher) call
+/// [`CapabilitySource::capability_labels`] / [`CapabilitySource::capability_resources`]
+/// and fold the results into the published record.
+pub trait CapabilitySource {
+    /// Stable capability labels — e.g. `("runtime", "kata")`, `("gpu.arch", "hopper")`,
+    /// `("topology.zone", "us-east-1a")`.
+    fn capability_labels(&self) -> Vec<(String, String)>;
+    /// Declared countable capacity — e.g. `Resource("nvidia.com/gpu", "8")`,
+    /// `Resource("memory", "512Gi")`. (Live/allocatable is volatile; the node
+    /// record combines declared capacity with a liveness report.)
+    fn capability_resources(&self) -> Vec<Resource>;
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+
+    fn sel(key: &str, op: SelectorOp, values: &[&str]) -> LabelSelector {
+        LabelSelector::new(key, op, values.iter().map(|&s| s.to_owned()).collect())
+    }
+
+    #[test]
+    fn selector_in_not_in() {
+        let labels = vec![("env".into(), "prod".into()), ("gpu".into(), "h100".into())];
+        assert!(sel("env", SelectorOp::In, &["prod", "staging"]).matches(&labels));
+        assert!(!sel("env", SelectorOp::In, &["dev"]).matches(&labels));
+        assert!(sel("env", SelectorOp::NotIn, &["dev"]).matches(&labels));
+        assert!(!sel("env", SelectorOp::NotIn, &["prod"]).matches(&labels));
+    }
+
+    #[test]
+    fn selector_exists_does_not_exist() {
+        let labels = vec![("env".into(), "prod".into())];
+        assert!(sel("env", SelectorOp::Exists, &[]).matches(&labels));
+        assert!(!sel("missing", SelectorOp::Exists, &[]).matches(&labels));
+        assert!(sel("missing", SelectorOp::DoesNotExist, &[]).matches(&labels));
+        assert!(!sel("env", SelectorOp::DoesNotExist, &[]).matches(&labels));
+    }
+
+    #[test]
+    fn selector_gt_lt_numeric() {
+        let labels = vec![("gpu.count".into(), "8".into())];
+        assert!(sel("gpu.count", SelectorOp::Gt, &["4"]).matches(&labels));
+        assert!(!sel("gpu.count", SelectorOp::Gt, &["8"]).matches(&labels));
+        assert!(sel("gpu.count", SelectorOp::Lt, &["16"]).matches(&labels));
+        assert!(!sel("gpu.count", SelectorOp::Lt, &["8"]).matches(&labels));
+        // missing key → not greater/less (fail-closed)
+        assert!(!sel("absent", SelectorOp::Gt, &["1"]).matches(&labels));
+    }
+
+    #[test]
+    fn k8s_quantity_compares_across_suffixes() {
+        assert!(parse_k8s_quantity("8").unwrap() == parse_k8s_quantity("8000m").unwrap());
+        assert!(parse_k8s_quantity("1Gi").unwrap() > parse_k8s_quantity("512Mi").unwrap());
+        assert!(parse_k8s_quantity("2").unwrap() > parse_k8s_quantity("1").unwrap());
+        assert!(parse_k8s_quantity("100m").unwrap() < parse_k8s_quantity("1").unwrap());
+        assert!(parse_k8s_quantity("garbage").is_none());
+        assert!(parse_k8s_quantity("").is_none());
+    }
+
+    #[test]
+    fn resource_request_satisfied() {
+        let req = ResourceRequest::new("memory", "256Gi");
+        assert!(req.satisfied_by("512Gi"));
+        assert!(req.satisfied_by("256Gi"));
+        assert!(!req.satisfied_by("128Gi"));
+        assert!(!req.satisfied_by("garbage")); // fail-closed
+    }
+
+    #[test]
+    fn filter_rank_select_pipeline() {
+        // candidates: (name, priority). predicate: keep priority >= 2.
+        let cands = vec![("a".to_owned(), 1), ("b".to_owned(), 3), ("c".to_owned(), 2), ("d".to_owned(), 2)];
+        let preds: Vec<Predicate<(String, i32)>> = vec![Box::new(|c| {
+            if c.1 >= 2 { None } else { Some(RejectionReason("priority < 2".into())) }
+        })];
+        let report = select(
+            &cands,
+            &preds,
+            |a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)), // priority desc, name asc
+            2, // bound
+        );
+        // survivors after filter: b(3), c(2), d(2) → ranked b, c, d → bound 2 → [b, c]
+        let selected: Vec<&String> = report
+            .candidates
+            .iter()
+            .filter(|o| o.selected)
+            .map(|o| &o.candidate.0)
+            .collect();
+        assert_eq!(selected, vec![&"b".to_owned(), &"c".to_owned()]);
+        // rejected candidate carries its reason
+        let a = report.candidates.iter().find(|o| o.candidate.0 == "a").unwrap();
+        assert_eq!(a.rejection_reason.as_deref(), Some("priority < 2"));
+        assert!(report.summary.contains("4 considered") && report.summary.contains("3 survived"));
+    }
+
+    #[test]
+    fn filter_records_first_rejection_only() {
+        let cands = vec![1, 2, 3];
+        let preds: Vec<Predicate<i32>> = vec![
+            Box::new(|c| if c % 2 == 0 { Some(RejectionReason("even".into())) } else { None }),
+            Box::new(|c| if *c == 1 { Some(RejectionReason("is-one".into())) } else { None }),
+        ];
+        let out = filter(&cands, &preds);
+        // 1 rejected by FIRST predicate? no — 1 is odd, passes pred 0, rejected by pred 1 ("is-one")
+        assert_eq!(out[0].rejected.as_ref().unwrap().0, "is-one");
+        // 2 rejected by first predicate ("even"), pred 1 not evaluated
+        assert_eq!(out[1].rejected.as_ref().unwrap().0, "even");
+        // 3 passes both
+        assert!(out[2].passed());
+    }
+
+    #[test]
+    fn capability_source_trait() {
+        struct Gpu;
+        impl CapabilitySource for Gpu {
+            fn capability_labels(&self) -> Vec<(String, String)> {
+                vec![("gpu.arch".into(), "hopper".into())]
+            }
+            fn capability_resources(&self) -> Vec<Resource> {
+                vec![Resource::new("nvidia.com/gpu", "8")]
+            }
+        }
+        let g = Gpu;
+        assert_eq!(g.capability_labels(), vec![("gpu.arch".into(), "hopper".into())]);
+        assert_eq!(g.capability_resources().len(), 1);
+    }
+}

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -17,6 +17,7 @@ use crate::generated::discovery_client::{
     RegisterEntityStatementRequest, RegisterEnvelopeKeysetRequest,
     EntityStatement, EnvelopeKeyset, IssuerList,
     GetRecordRequest, RecordCar,
+    QueryCandidatesRequest,
     dispatch_discovery, serialize_response,
 };
 
@@ -914,6 +915,23 @@ impl DiscoveryHandler for DiscoveryService {
                 details: String::new(),
             })),
         }
+    }
+
+    /// #523 P0 / #524 — placement candidate query. The vocabulary + filter/rank/
+    /// select helpers landed in `crate::scheduling` (#628); the live
+    /// directory + authz-prefiltered handler is P1's job (#524). Stubbed here
+    /// so the RPC surface compiles; returns UNIMPLEMENTED until P1 wires it.
+    async fn handle_query_candidates(
+        &self,
+        _ctx: &EnvelopeContext,
+        _request_id: u64,
+        _data: &QueryCandidatesRequest,
+    ) -> Result<DiscoveryResponseVariant> {
+        Ok(DiscoveryResponseVariant::Error(ErrorInfo {
+            message: "queryCandidates not yet wired (P1 placement directory; see #524)".to_owned(),
+            code: "UNIMPLEMENTED".to_owned(),
+            details: String::new(),
+        }))
     }
 }
 

--- a/crates/hyprstream-workers/Cargo.toml
+++ b/crates/hyprstream-workers/Cargo.toml
@@ -18,6 +18,10 @@ hyprstream-rpc = { path = "../hyprstream-rpc" }
 hyprstream-workers-wasmtime = { path = "../hyprstream-workers-wasmtime", optional = true }
 hyprstream-rpc-derive = { path = "../hyprstream-rpc-derive" }
 hyprstream-service = { path = "../hyprstream-service" }
+# Shared scheduling substrate (#628): filter→rank→select + SelectionReport<C> +
+# RejectionReason. `selection.rs` composes backend selection on these instead of
+# a bespoke explain shape.
+hyprstream-discovery = { path = "../hyprstream-discovery" }
 hyprstream-vfs = { path = "../hyprstream-vfs" }
 # Wire-faithful 9P2000.L server: serves a Subject-scoped `Arc<dyn Mount>` over a
 # Unix socket for the native Wanix guest to dial (#506, `runtime::wanix_workload`).

--- a/crates/hyprstream-workers/src/lib.rs
+++ b/crates/hyprstream-workers/src/lib.rs
@@ -71,6 +71,8 @@ pub use error::WorkerError;
 pub use runtime::{WorkerService, SandboxBackend, SandboxHandle, NspawnBackend, NspawnConfig};
 // Inventory-based backend registry + fail-closed selection spine (#507)
 pub use runtime::{resolve_backend, BackendCtx, BackendRegistration};
+// Scheduling-substrate explain (#628): the shared SelectionReport<C> trace.
+pub use runtime::{explain_selection, BackendCandidate};
 #[cfg(feature = "kata-vm")]
 pub use runtime::KataBackend;
 // The image-store trait seam is always available; only the concrete RAFS impl

--- a/crates/hyprstream-workers/src/runtime/mod.rs
+++ b/crates/hyprstream-workers/src/runtime/mod.rs
@@ -118,6 +118,8 @@ pub use selection::{
     backend_injects_9p_socket, require_9p_socket_capability, require_fuse_mount_capability,
     resolve_backend, resolve_backend_9p_capable, BackendCtx, BackendRegistration,
 };
+// Scheduling-substrate explain (#628): the shared SelectionReport<C> trace.
+pub use selection::{explain_selection, BackendCandidate};
 // Domain entities (business logic only)
 pub use container::Container;
 pub use pool::{PoolStats, SandboxPool};

--- a/crates/hyprstream-workers/src/runtime/selection.rs
+++ b/crates/hyprstream-workers/src/runtime/selection.rs
@@ -408,6 +408,36 @@ pub fn require_fuse_mount_capability(backend_type: &str) -> Result<()> {
     check_fuse_mount_capability(backend_type, &regs)
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Selection diagnostics (#348)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// `resolve_backend` answers "which backend do I get"; the function below adds
+// the backend-local "why not" knowledge the #628 scheduling substrate's explain
+// trace needs — a per-backend prerequisite sub-reason. This does not change
+// selection semantics; it is read-only introspection over the same registry.
+
+/// Backend-specific sub-reason for why `is_available()` returned `false`,
+/// e.g. "cloud-hypervisor not on PATH" for `kata`. Falls back to a generic
+/// message for backends this function doesn't have specific knowledge of.
+///
+/// This mirrors the prerequisite probes in each backend's
+/// `registry_is_available()` (see `kata_backend.rs`, `nspawn.rs`,
+/// `wasm_backend.rs`) but is allowed to drift from them in detail since it is
+/// diagnostic-only — it never gates selection itself.
+fn unavailable_reason(name: &str) -> String {
+    match name {
+        "kata" => "runtime prerequisites missing: `cloud-hypervisor` not found on PATH".to_owned(),
+        "nspawn" => {
+            "runtime prerequisites missing: `systemd-nspawn` and/or `machinectl` not found on PATH"
+                .to_owned()
+        }
+        "podman" => "runtime prerequisites missing: `podman` not found on PATH".to_owned(),
+        "wasm" => "wasm runtime prerequisites are not satisfied".to_owned(),
+        other => format!("runtime prerequisites for '{other}' are not satisfied"),
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -912,5 +942,80 @@ mod tests {
             kata.priority > nspawn.priority,
             "kata (VM) must outrank nspawn for auto-selection"
         );
+    }
+
+    // ── N-backend fallback-chain semantics (#348) ──
+    //
+    // Synthetic 3-tier registry modeling a future kata > podman > nspawn world
+    // (podman lands under #346; until then this just proves the *logic*
+    // generalizes past two backends — it does not depend on #346 landing).
+
+    const MID: BackendRegistration = BackendRegistration {
+        name: "mid-tier",
+        priority: 50,
+        auto_selectable: true,
+        injects_9p_socket: false,
+        mounts_fuse_vfs: false,
+        is_available: || true,
+        construct: never_available,
+    };
+
+    fn three_tier_regs() -> Vec<&'static BackendRegistration> {
+        vec![&HIGH, &MID, &LOW]
+    }
+
+    #[test]
+    fn auto_three_tier_all_available_picks_highest() {
+        let r = select_registration("auto", &three_tier_regs(), |_| true).unwrap();
+        assert_eq!(r.name, "high-tier");
+    }
+
+    #[test]
+    fn auto_three_tier_degrades_through_priority_order_one_by_one() {
+        // Simulate backends disappearing one at a time, strongest first —
+        // exactly the "kata missing -> try podman -> try nspawn" chain a
+        // wizard cares about. Each step must fall exactly one tier, never
+        // skip ahead and never error while something remains available.
+        let regs = three_tier_regs();
+
+        let r = select_registration("auto", &regs, |reg| reg.name != "high-tier").unwrap();
+        assert_eq!(r.name, "mid-tier", "first degradation: high unavailable -> mid");
+
+        let r = select_registration("auto", &regs, |reg| reg.name == "low-tier").unwrap();
+        assert_eq!(r.name, "low-tier", "second degradation: only low remains");
+    }
+
+    #[test]
+    fn auto_three_tier_errors_only_when_all_unavailable() {
+        let err = select_registration("auto", &three_tier_regs(), |_| false).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("no available sandbox backend"), "got: {msg}");
+        // Must list all three registered names so the operator knows what to install.
+        assert!(msg.contains("high-tier") && msg.contains("mid-tier") && msg.contains("low-tier"));
+    }
+
+    #[test]
+    fn auto_three_tier_skips_middle_unavailable_tier() {
+        // Mid-tier specifically down (e.g. podman not installed) must not
+        // wrongly fall all the way to low; high still wins if available, and
+        // if high is also down it must land on low (skipping mid), not error.
+        let regs = three_tier_regs();
+        let r = select_registration("auto", &regs, |reg| reg.name != "mid-tier").unwrap();
+        assert_eq!(r.name, "high-tier", "high still available, mid down -> high wins");
+
+        let r =
+            select_registration("auto", &regs, |reg| reg.name == "low-tier").unwrap();
+        assert_eq!(r.name, "low-tier", "high and mid down -> falls through mid to low");
+    }
+
+    // ── unavailable_reason (#348 selection diagnostics) ──
+
+    #[test]
+    fn unavailable_reason_has_per_backend_specifics() {
+        assert!(unavailable_reason("kata").contains("cloud-hypervisor"));
+        assert!(unavailable_reason("nspawn").contains("systemd-nspawn"));
+        assert!(unavailable_reason("podman").contains("podman"));
+        // Unknown backend still gets a non-empty, non-panicking message.
+        assert!(unavailable_reason("future-backend").contains("future-backend"));
     }
 }

--- a/crates/hyprstream-workers/src/runtime/selection.rs
+++ b/crates/hyprstream-workers/src/runtime/selection.rs
@@ -42,6 +42,10 @@
 
 use std::sync::Arc;
 
+use hyprstream_discovery::scheduling::{
+    self, CapabilitySource, Predicate, RejectionReason, Resource, SelectionReport,
+};
+
 use crate::config::PoolConfig;
 use crate::error::{Result, WorkerError};
 
@@ -416,6 +420,11 @@ pub fn require_fuse_mount_capability(backend_type: &str) -> Result<()> {
 // the backend-local "why not" knowledge the #628 scheduling substrate's explain
 // trace needs — a per-backend prerequisite sub-reason. This does not change
 // selection semantics; it is read-only introspection over the same registry.
+//
+// The generic filter→rank→select explain trace (`SelectionReport<C>`) is owned
+// by the #628 scheduling substrate (`hyprstream-discovery::scheduling`);
+// `explain_selection` below composes on it (see the "Scheduling-substrate
+// adoption" section) rather than carrying a second, backend-specific copy.
 
 /// Backend-specific sub-reason for why `is_available()` returned `false`,
 /// e.g. "cloud-hypervisor not on PATH" for `kata`. Falls back to a generic
@@ -436,6 +445,135 @@ fn unavailable_reason(name: &str) -> String {
         "wasm" => "wasm runtime prerequisites are not satisfied".to_owned(),
         other => format!("runtime prerequisites for '{other}' are not satisfied"),
     }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scheduling-substrate adoption (#628)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// The explain surface #348 needs is the #628 substrate's generic
+// `filter → rank → select → SelectionReport<C>`. Backend selection is one
+// consumer of that shape: candidates are the compiled-in registrations,
+// availability is a `Predicate` whose `RejectionReason` is sourced from
+// `unavailable_reason`, and rank is by descending priority. `explain_selection`
+// runs the substrate pipeline and returns its `SelectionReport`, so the trace
+// falls out of `select` for free — no bespoke report type here.
+//
+// `resolve_backend`/`select_registration` above remain the authoritative
+// construction path (they encode explicit-name and unknown-name semantics that
+// are not a single generic `select` call); the substrate governs the "auto"
+// explain trace, keeping one explain shape across every scheduling surface.
+//
+// Full resource-aware ranking (GPU/memory/NUMA via `ResourceRequest`) plugs in
+// here as additional predicates + a resource-aware `rank_by`; that is downstream
+// consumer work (#341/#525). This adoption wires availability-as-predicate +
+// explain + the capability-source seam.
+
+/// A cloneable projection of a [`BackendRegistration`] for the substrate's
+/// generic pipeline (`SelectionReport<C>` requires `C: Clone`; a registration
+/// holds `fn` pointers and is not cloneable). Carries exactly what selection
+/// filtering, ranking, and the explain trace need.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackendCandidate {
+    /// Registered backend name (`"kata"`, `"nspawn"`, …).
+    pub name: &'static str,
+    /// Auto-selection precedence (higher preferred).
+    pub priority: i32,
+    /// Whether `"auto"` may pick this backend.
+    pub auto_selectable: bool,
+    /// Live availability probe result at the time the candidate was captured.
+    pub available: bool,
+}
+
+impl BackendCandidate {
+    fn from_registration(reg: &BackendRegistration) -> Self {
+        Self {
+            name: reg.name,
+            priority: reg.priority,
+            auto_selectable: reg.auto_selectable,
+            available: (reg.is_available)(),
+        }
+    }
+}
+
+/// Runtime availability + capability truth a backend contributes to the shared
+/// scheduling vocabulary. A node-record publisher aggregates these across every
+/// registered backend so a placement record's `runtime=<name>` labels reflect
+/// what is actually available here (no hand-declaration, no drift — #628).
+impl CapabilitySource for BackendCandidate {
+    fn capability_labels(&self) -> Vec<(String, String)> {
+        vec![
+            ("runtime".to_owned(), self.name.to_owned()),
+            (
+                format!("runtime.{}.available", self.name),
+                self.available.to_string(),
+            ),
+        ]
+    }
+
+    fn capability_resources(&self) -> Vec<Resource> {
+        // Backend selection contributes runtime-availability labels, not
+        // countable capacity; GPU/memory/NUMA capacity comes from other sources
+        // (DevicePool, node liveness). See the module note on resource-aware rank.
+        Vec::new()
+    }
+}
+
+/// Availability predicate: rejects a candidate whose runtime prerequisites are
+/// missing, carrying the backend-specific [`unavailable_reason`] as the
+/// [`RejectionReason`] so it lands in the [`SelectionReport`] trace.
+fn availability_predicate() -> Predicate<BackendCandidate> {
+    Box::new(|c: &BackendCandidate| {
+        if c.available {
+            None
+        } else {
+            Some(RejectionReason(unavailable_reason(c.name)))
+        }
+    })
+}
+
+/// Auto-eligibility predicate: rejects backends excluded from `"auto"` (the
+/// isolation-downgrade guard, #547 ZSP), with the reason recorded in the trace.
+fn auto_eligibility_predicate() -> Predicate<BackendCandidate> {
+    Box::new(|c: &BackendCandidate| {
+        if c.auto_selectable {
+            None
+        } else {
+            Some(RejectionReason(format!(
+                "backend '{}' is explicit-name-only (excluded from auto-selection; \
+                 no silent isolation downgrade)",
+                c.name
+            )))
+        }
+    })
+}
+
+/// Explain what `"auto"` selection would decide over the compiled-in registry,
+/// as the shared [`SelectionReport`]. The winning candidate is the highest-
+/// priority backend that is both auto-eligible and available; every other
+/// candidate carries the [`RejectionReason`] that excluded it.
+///
+/// This is diagnostics only (a wizard/CLI "why this backend?" trace); the
+/// authoritative construction path is [`resolve_backend`]. Both agree on the
+/// same winner for `"auto"` because both rank by descending priority over the
+/// auto-eligible, available set.
+pub fn explain_selection() -> SelectionReport<BackendCandidate> {
+    let candidates: Vec<BackendCandidate> = inventory::iter::<BackendRegistration>()
+        .map(BackendCandidate::from_registration)
+        .collect();
+
+    let predicates = vec![auto_eligibility_predicate(), availability_predicate()];
+
+    let mut report = scheduling::select(
+        &candidates,
+        &predicates,
+        // Highest priority first; name ascending as a deterministic tiebreak —
+        // matching `select_registration`'s "auto" ordering exactly.
+        |a, b| b.priority.cmp(&a.priority).then_with(|| a.name.cmp(b.name)),
+        1, // "auto" selects a single backend
+    );
+    report.requested = "auto".to_owned();
+    report
 }
 
 #[cfg(test)]
@@ -1017,5 +1155,119 @@ mod tests {
         assert!(unavailable_reason("podman").contains("podman"));
         // Unknown backend still gets a non-empty, non-panicking message.
         assert!(unavailable_reason("future-backend").contains("future-backend"));
+    }
+
+    // ── Scheduling-substrate explain adoption (#628) ──
+    //
+    // These exercise the substrate pipeline over `BackendCandidate` directly (a
+    // deterministic candidate set), proving the migrated explain produces the
+    // shared `SelectionReport<C>` and that `unavailable_reason` flows through as
+    // the `RejectionReason`. `explain_selection()` itself is a thin wrapper that
+    // feeds the real inventory into this same pipeline.
+
+    fn candidate(name: &'static str, priority: i32, auto: bool, avail: bool) -> BackendCandidate {
+        BackendCandidate { name, priority, auto_selectable: auto, available: avail }
+    }
+
+    /// Reusable copy of `explain_selection`'s pipeline over an explicit candidate
+    /// set (so tests don't depend on the host's installed runtimes).
+    fn explain_over(candidates: &[BackendCandidate]) -> SelectionReport<BackendCandidate> {
+        let predicates = vec![auto_eligibility_predicate(), availability_predicate()];
+        let mut report = scheduling::select(
+            candidates,
+            &predicates,
+            |a, b| b.priority.cmp(&a.priority).then_with(|| a.name.cmp(b.name)),
+            1,
+        );
+        report.requested = "auto".to_owned();
+        report
+    }
+
+    #[test]
+    fn explain_selects_highest_priority_available_auto_eligible() {
+        let cands = vec![
+            candidate("kata", 100, true, true),
+            candidate("nspawn", 10, true, true),
+        ];
+        let report = explain_over(&cands);
+        let selected: Vec<&str> =
+            report.candidates.iter().filter(|o| o.selected).map(|o| o.candidate.name).collect();
+        assert_eq!(selected, vec!["kata"], "highest-priority available wins");
+        assert_eq!(report.requested, "auto");
+    }
+
+    #[test]
+    fn explain_reports_unavailable_reason_as_rejection() {
+        // kata unavailable → excluded, and its RejectionReason must be the
+        // backend-specific `unavailable_reason` (the #628 integration point).
+        let cands = vec![
+            candidate("kata", 100, true, false),
+            candidate("nspawn", 10, true, true),
+        ];
+        let report = explain_over(&cands);
+        let kata = report.candidates.iter().find(|o| o.candidate.name == "kata").unwrap();
+        assert!(!kata.selected);
+        assert_eq!(kata.rejection_reason.as_deref(), Some(unavailable_reason("kata").as_str()));
+        assert!(kata.rejection_reason.as_deref().unwrap().contains("cloud-hypervisor"));
+        // nspawn (available, auto-eligible) is the winner.
+        let nspawn = report.candidates.iter().find(|o| o.candidate.name == "nspawn").unwrap();
+        assert!(nspawn.selected);
+    }
+
+    #[test]
+    fn explain_excludes_auto_ineligible_with_reason() {
+        // An explicit-name-only backend (e.g. wasm) at the highest priority and
+        // available must be rejected in the trace, and a weaker auto-eligible
+        // backend selected — matching `select_registration`'s auto semantics.
+        let cands = vec![
+            candidate("wasm", 1000, false, true),
+            candidate("nspawn", 10, true, true),
+        ];
+        let report = explain_over(&cands);
+        let wasm = report.candidates.iter().find(|o| o.candidate.name == "wasm").unwrap();
+        assert!(!wasm.selected);
+        assert!(wasm.rejection_reason.as_deref().unwrap().contains("explicit-name-only"));
+        let nspawn = report.candidates.iter().find(|o| o.candidate.name == "nspawn").unwrap();
+        assert!(nspawn.selected, "auto must pick the auto-eligible backend, never the excluded one");
+    }
+
+    #[test]
+    fn explain_agrees_with_select_registration_on_the_winner() {
+        // The explain trace and the authoritative `select_registration` path must
+        // agree on which backend `"auto"` yields, over the same candidate set.
+        const A: BackendRegistration = BackendRegistration {
+            name: "high-tier", priority: 100, auto_selectable: true,
+            injects_9p_socket: false, mounts_fuse_vfs: false,
+            is_available: || true, construct: never_available,
+        };
+        const B: BackendRegistration = BackendRegistration {
+            name: "low-tier", priority: 10, auto_selectable: true,
+            injects_9p_socket: false, mounts_fuse_vfs: false,
+            is_available: || true, construct: never_available,
+        };
+        let regs = vec![&A, &B];
+        let winner = select_registration("auto", &regs, |_| true).unwrap();
+
+        let cands: Vec<BackendCandidate> =
+            regs.iter().map(|r| BackendCandidate::from_registration(r)).collect();
+        let report = explain_over(&cands);
+        let explained = report
+            .candidates
+            .iter()
+            .find(|o| o.selected)
+            .map(|o| o.candidate.name)
+            .unwrap();
+        assert_eq!(explained, winner.name, "explain winner must match select_registration");
+    }
+
+    #[test]
+    fn backend_candidate_capability_labels_emit_runtime_truth() {
+        // The capability-source seam: a backend contributes `runtime=<name>` +
+        // availability so a node record can aggregate it (#628, no drift).
+        let c = candidate("kata", 100, true, false);
+        let labels = c.capability_labels();
+        assert!(labels.contains(&("runtime".to_owned(), "kata".to_owned())));
+        assert!(labels.contains(&("runtime.kata.available".to_owned(), "false".to_owned())));
+        assert!(c.capability_resources().is_empty());
     }
 }


### PR DESCRIPTION
## Summary

This recovers and rebases the real payload of issue #629 from the stranded
`ewindisch/624-C-selection-substrate` branch, which never merged because #624
was superseded/redirected mid-flight.

Two commits are cherry-picked and adapted onto a current base:

- `cdc790c5d` — adds `unavailable_reason(name)`, the per-backend "why not
  available" sub-reason `selection.rs` didn't previously expose.
- `d8c56cb23` — wires `selection.rs` onto the `hyprstream-discovery::scheduling`
  substrate (#628): a `BackendCandidate` projection of `BackendRegistration`,
  availability-as-`Predicate`, `explain_selection()` returning the substrate's
  generic `SelectionReport<C>`, and a `CapabilitySource` impl emitting
  `runtime=<name>`/`available` truth (the no-drift seam #628 designed for).

Per #659's own draft note, the real change here is ~264 lines across a handful
of files in `selection.rs` (plus the `Cargo.toml`/`Cargo.lock` dependency edge
to `hyprstream-discovery`) — everything else in the old branch/PR was noise
from a stale, 260+-commit-diverged base.

**Wizard data API intentionally dropped.** The original T2-C commit also added
`list_backends_for_wizard()` / `BackendStatus`. Per the #624 operator closing
comment (2026-07-02), that API had zero consumers and is not carried forward —
this PR ships only `unavailable_reason`, which the substrate's explain path
actually needs.

**Behavior preserved.** `resolve_backend`/`select_registration` remain the
authoritative construction path; explicit-name and unknown-name semantics are
unchanged (verified by the full existing `selection.rs` test suite, all
passing). Only the "auto" diagnostics/explain trace is new — it now composes
on the shared substrate's `filter -> rank -> select -> SelectionReport<C>`
pipeline instead of a bespoke shape.

**Base.** #628's substrate landed on `main` via commit `d396223c2`
(`ewindisch/628-substrate-reland`), but PR #752 (which reconciles that branch
with `main`) was still open at the time this branch was cut, so this PR is
stacked on `ewindisch/628-substrate-reland` rather than `main` directly. It
will need a rebase once #752 merges — that's expected.

## Test plan

- [x] `cargo build -p hyprstream-workers`
- [x] `cargo test -p hyprstream-workers` (113 passed, incl. all `selection.rs`
      tests — explicit-name, unknown-name, auto-priority, and the new explain
      tests)
- [x] `cargo clippy -p hyprstream-workers --all-targets` (clean)
- [x] `grep -rn "list_backends_for_wizard\|BackendStatus" crates/` returns
      nothing

Closes #629. Refs #624 (superseded design), #628 (substrate), #659 (earlier
blocked attempt — superseded by this PR).