### PR TITLE
feat(workers): bidirectional 9P — export guest Wanix namespace, host imports at /workers/<tenant>/wanix (#708 phase 2)

### DIFF
--- a/crates/hyprstream-workers/src/runtime/mod.rs
+++ b/crates/hyprstream-workers/src/runtime/mod.rs
@@ -137,8 +137,8 @@ pub use sandbox_fs::{
 };
 #[cfg(not(target_arch = "wasm32"))]
 pub use wanix_workload::{
-    inject_9p_socket, Injected9pServer, WanixGuestConfig, WanixInjection,
-    ANN_WANIX_COMMAND, ENV_9P_SOCK,
+    import_guest_namespace, inject_9p_socket, ImportedGuestNamespace, Injected9pServer,
+    WanixGuestConfig, WanixInjection, ANN_WANIX_COMMAND, ENV_9P_SOCK, ENV_GUEST_EXPORT_SOCK,
 };
 pub use service::WorkerService;
 // Re-export service infrastructure from hyprstream-rpc for convenience

--- a/crates/hyprstream-workers/src/runtime/wanix_workload.rs
+++ b/crates/hyprstream-workers/src/runtime/wanix_workload.rs
@@ -10,6 +10,33 @@
 //! *bind-mount-capable* sandbox (OCI/nspawn) so the native Wanix guest (PR-B's
 //! `workers/wanix-guest`) dials back and binds the export as its namespace root.
 //!
+//! ## Bidirectional 9P (#708 phase 2)
+//!
+//! The above is **Direction A** — the host exports its namespace, the guest
+//! imports it. This module also wires **Direction B**, the reverse: the native
+//! Wanix guest exports its OWN live namespace over a *second, independent* UDS,
+//! and the host imports it via the phase-1 socket 9P client
+//! [`Remote9pMount`](hyprstream_9p::Remote9pMount) and binds it into the host
+//! VFS [`Namespace`] at `/workers/<tenant>/wanix` — giving the host visibility
+//! into the guest's task tree.
+//!
+//! [`inject_9p_socket`] allocates the export path and injects it (a shared
+//! export *directory* bind-mount + [`ENV_GUEST_EXPORT_SOCK`], mirroring the
+//! Direction-A socket injection). After the sandbox starts,
+//! [`import_guest_namespace`] dials the guest's export socket and binds the
+//! imported tree. The two directions are **independent** — separate sockets,
+//! separate 9P sessions, no shared coupling (#708).
+//!
+//! **Scope + payoff caveat.** This is wired for the shared-FS UDS backends
+//! (OCI/nspawn); a kata guest would export over vsock (follow-up, not here).
+//! And native Wanix currently has only [`native::ExecDriver`] — the exported
+//! `#task` tree is host-exec processes + binds, not a wasi/VM task tree, until a
+//! native wasi driver exists. The *mechanism* (host imports the guest's
+//! namespace bidirectionally, over the phase-1 `Remote9pMount`) is the
+//! deliverable; what is visible through it will grow as the guest gains drivers.
+//!
+//! [`native::ExecDriver`]: https://pkg.go.dev/tractor.dev/wanix/native
+//!
 //! ## The three injection steps (#506 deliverable 3)
 //!
 //! [`inject_9p_socket`] performs, for one workload:
@@ -64,7 +91,8 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use hyprstream_vfs::{Mount, Subject};
+use hyprstream_9p::Remote9pMount;
+use hyprstream_vfs::{BindFlag, Mount, Namespace, Subject};
 use tokio::net::UnixListener;
 use tracing::{debug, info, warn};
 
@@ -90,12 +118,37 @@ pub const ANN_WANIX_COMMAND: &str = "hyprstream.io/command";
 /// `workers/wanix-guest`). Kept in sync with the guest's `--sock` env fallback.
 pub const ENV_9P_SOCK: &str = "HYPRSTREAM_9P_SOCK";
 
+/// Environment variable the Wanix guest reads for the Direction-B **export**
+/// socket path — the in-container UDS on which the guest serves its OWN live
+/// namespace for the host to import (#708 phase 2). Kept in sync with the
+/// guest's `--export-sock` env fallback (`workers/wanix-guest`).
+pub const ENV_GUEST_EXPORT_SOCK: &str = "HYPRSTREAM_GUEST_EXPORT_SOCK";
+
 /// File name of the per-workload 9P socket under the workload runtime dir.
 const NINEP_SOCKET_NAME: &str = "9p.sock";
 /// In-container path the host 9P socket is bind-mounted to.
 const CTR_SOCK_PATH: &str = "/run/hyprstream/9p.sock";
 /// In-container path the host `wanix-guest` binary is bind-mounted to.
 const CTR_GUEST_BIN_PATH: &str = "/usr/local/bin/wanix-guest";
+
+/// Sub-directory under the workload runtime dir shared with the container for
+/// the Direction-B guest export. The guest CREATES its export listener inside
+/// this dir (a bind-mount source must already exist, and the guest's socket
+/// does not yet — so we share the *directory*, not a pre-made socket file, and
+/// the socket the guest binds appears here on the host).
+const GUEST_EXPORT_DIR_NAME: &str = "export";
+/// File name the guest binds its export listener as, inside the shared dir.
+const GUEST_EXPORT_SOCKET_NAME: &str = "wanix.sock";
+/// In-container path the shared export dir is bind-mounted to.
+const CTR_EXPORT_DIR: &str = "/run/hyprstream/export";
+/// In-container path of the guest's export socket (inside [`CTR_EXPORT_DIR`]).
+const CTR_EXPORT_SOCK_PATH: &str = "/run/hyprstream/export/wanix.sock";
+
+/// Bounded attempts to dial the guest export socket after sandbox start (it
+/// appears only once the guest boots and calls `listen(2)`).
+const IMPORT_CONNECT_ATTEMPTS: u32 = 20;
+/// Base backoff between import-connect attempts.
+const IMPORT_CONNECT_BACKOFF: std::time::Duration = std::time::Duration::from_millis(250);
 
 /// Env var overriding the host path to the `wanix-guest` build artifact.
 const ENV_GUEST_BIN: &str = "HYPRSTREAM_WANIX_GUEST_BIN";
@@ -187,9 +240,14 @@ pub struct WanixInjection {
     /// [`PodSandboxConfig`](super::client::PodSandboxConfig)'s
     /// `annotations: Vec<KeyValue>` for the pool path.
     pub annotations: HashMap<String, String>,
-    /// The live 9P server. Keep it alive for the workload's lifetime; drop it to
-    /// tear the export down.
+    /// The live Direction-A 9P server (host exports its namespace to the guest).
+    /// Keep it alive for the workload's lifetime; drop it to tear the export down.
     pub server: Injected9pServer,
+    /// Host-side path where the guest's Direction-B export socket will appear
+    /// once the guest boots and listens (inside the shared export dir bound into
+    /// the container). Pass this to [`import_guest_namespace`] **after** the
+    /// sandbox is started to import the guest's live namespace.
+    pub export_socket_path: PathBuf,
 }
 
 impl WanixInjection {
@@ -203,6 +261,12 @@ impl WanixInjection {
                 value: v.clone(),
             })
             .collect()
+    }
+
+    /// Host-side path of the guest's Direction-B export socket (see
+    /// [`WanixInjection::export_socket_path`]).
+    pub fn export_socket_path(&self) -> &Path {
+        &self.export_socket_path
     }
 }
 
@@ -284,20 +348,180 @@ pub async fn inject_9p_socket(
         format!("{ANN_ENV_PREFIX}{ENV_9P_SOCK}"),
         CTR_SOCK_PATH.to_owned(),
     );
+
+    // ── Direction B (#708 phase 2): guest exports, host imports ──────────────
+    //
+    // Allocate a shared export DIRECTORY (not a pre-made socket file: the guest
+    // is the server here, so it creates the listener — a bind-mount source must
+    // already exist, but the guest's socket does not yet). The guest binds its
+    // export listener inside this dir; because the dir is bind-mounted into the
+    // container, that socket appears on the host at `export_socket_path`, which
+    // the host later dials via [`import_guest_namespace`].
+    let host_export_dir = workload_dir.join(GUEST_EXPORT_DIR_NAME);
+    tokio::fs::create_dir_all(&host_export_dir).await.map_err(|e| {
+        WorkerError::SandboxCreationFailed(format!(
+            "create guest export dir {}: {e}",
+            host_export_dir.display()
+        ))
+    })?;
+    let export_socket_path = host_export_dir.join(GUEST_EXPORT_SOCKET_NAME);
+    // Remove any stale export socket left by a crashed predecessor guest.
+    if let Err(e) = tokio::fs::remove_file(&export_socket_path).await {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            warn!(socket = %export_socket_path.display(), error = %e, "remove stale guest export socket");
+        }
+    }
+    let host_export_dir_str = host_export_dir.to_string_lossy().into_owned();
+    // Bind the shared export dir into the container's mount namespace (rw: the
+    // guest binds its listener inside it, the host reads the resulting socket).
+    annotations.insert(
+        format!("{ANN_MOUNT_PREFIX}wanix-export-dir"),
+        format!("{host_export_dir_str}:{CTR_EXPORT_DIR}:rw"),
+    );
+    // Tell the guest where to export its namespace (in-container socket path).
+    annotations.insert(
+        format!("{ANN_ENV_PREFIX}{ENV_GUEST_EXPORT_SOCK}"),
+        CTR_EXPORT_SOCK_PATH.to_owned(),
+    );
+
     // Run the guest as the workload command (serve-namespace mode: no `--cmd`,
     // which is the reliable path today — see wanix-guest README's known gap).
     annotations.insert(ANN_WANIX_COMMAND.to_owned(), CTR_GUEST_BIN_PATH.to_owned());
 
     info!(
         socket = %socket_path.display(),
+        export_socket = %export_socket_path.display(),
         guest_bin = %guest_cfg.guest_bin.display(),
-        "prepared Wanix-guest 9P workload injection"
+        "prepared bidirectional Wanix-guest 9P workload injection"
     );
 
     Ok(WanixInjection {
         annotations,
         server: Injected9pServer { socket_path, task },
+        export_socket_path,
     })
+}
+
+/// A guest namespace imported into the host VFS namespace (#708 phase 2,
+/// Direction B). Holds the [`Remote9pMount`] backing the imported tree so the
+/// remote 9P client connection lives as long as this handle; drop it (and
+/// [`unmount`](ImportedGuestNamespace::unmount) the prefix) at workload teardown.
+pub struct ImportedGuestNamespace {
+    mount: Arc<dyn Mount>,
+    prefix: String,
+}
+
+impl ImportedGuestNamespace {
+    /// The host namespace prefix the guest tree is bound at
+    /// (`/workers/<tenant>/wanix`).
+    pub fn prefix(&self) -> &str {
+        &self.prefix
+    }
+
+    /// The imported guest tree as an `Arc<dyn Mount>` (already bound into the
+    /// host namespace by [`import_guest_namespace`]; exposed for rebind/teardown).
+    pub fn mount(&self) -> Arc<dyn Mount> {
+        Arc::clone(&self.mount)
+    }
+
+    /// Remove the imported tree from `host_ns` (the teardown counterpart of the
+    /// bind [`import_guest_namespace`] performed).
+    pub fn unmount(&self, host_ns: &mut Namespace) {
+        host_ns.unmount(&self.prefix);
+    }
+}
+
+impl std::fmt::Debug for ImportedGuestNamespace {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ImportedGuestNamespace")
+            .field("prefix", &self.prefix)
+            .finish()
+    }
+}
+
+/// Import the guest's live namespace (Direction B, #708 phase 2): dial the
+/// guest's export socket with the phase-1 socket 9P client [`Remote9pMount`],
+/// and bind the resulting [`Mount`] into `host_ns` at `/workers/<tenant>/wanix`,
+/// giving the host visibility into the guest's task tree.
+///
+/// Call this **after** the sandbox has been started: the export socket appears
+/// only once the guest boots and `listen(2)`s, so the dial is retried with
+/// bounded backoff ([`IMPORT_CONNECT_ATTEMPTS`]). `export_sock` is the host-side
+/// [`WanixInjection::export_socket_path`].
+///
+/// This is the reverse, independent 9P session of the Direction-A export the
+/// host serves in [`inject_9p_socket`] — a separate socket, a separate client,
+/// no shared coupling (#708).
+pub async fn import_guest_namespace(
+    host_ns: &mut Namespace,
+    export_sock: &Path,
+    tenant: &str,
+) -> Result<ImportedGuestNamespace> {
+    import_guest_namespace_with(
+        host_ns,
+        export_sock,
+        tenant,
+        IMPORT_CONNECT_ATTEMPTS,
+        IMPORT_CONNECT_BACKOFF,
+    )
+    .await
+}
+
+/// [`import_guest_namespace`] with explicit retry bounds (the public wrapper
+/// uses [`IMPORT_CONNECT_ATTEMPTS`]/[`IMPORT_CONNECT_BACKOFF`]). Kept separate so
+/// tests can drive the retry loop without waiting out the production backoff.
+async fn import_guest_namespace_with(
+    host_ns: &mut Namespace,
+    export_sock: &Path,
+    tenant: &str,
+    attempts: u32,
+    backoff: std::time::Duration,
+) -> Result<ImportedGuestNamespace> {
+    let prefix = format!("/workers/{tenant}/wanix");
+
+    // The guest's listener appears only after it boots — retry with backoff.
+    let mut last_err: Option<anyhow::Error> = None;
+    let mut mount = None;
+    for attempt in 1..=attempts {
+        match Remote9pMount::connect_uds(export_sock, "hyprstream", "").await {
+            Ok(m) => {
+                mount = Some(m);
+                break;
+            }
+            Err(e) => {
+                debug!(
+                    socket = %export_sock.display(),
+                    attempt,
+                    error = %e,
+                    "guest export socket not ready yet; retrying"
+                );
+                last_err = Some(e);
+                tokio::time::sleep(backoff * attempt).await;
+            }
+        }
+    }
+    let mount = mount.ok_or_else(|| {
+        WorkerError::SandboxCreationFailed(format!(
+            "could not import guest namespace from {} after {attempts} attempts: {}",
+            export_sock.display(),
+            last_err
+                .map(|e| e.to_string())
+                .unwrap_or_else(|| "unknown error".into())
+        ))
+    })?;
+
+    let mount: Arc<dyn Mount> = Arc::new(mount);
+    host_ns
+        .bind_mount(&prefix, Arc::clone(&mount), BindFlag::Replace)
+        .map_err(|e| {
+            WorkerError::SandboxCreationFailed(format!(
+                "bind imported guest namespace at {prefix}: {e}"
+            ))
+        })?;
+
+    info!(prefix = %prefix, socket = %export_sock.display(), "imported guest Wanix namespace into host VFS");
+
+    Ok(ImportedGuestNamespace { mount, prefix })
 }
 
 /// Fail-closed convenience: verify `backend_type` can inject a 9P socket, then
@@ -395,6 +619,81 @@ mod tests {
             inj.annotations.get(ANN_WANIX_COMMAND).map(String::as_str),
             Some(CTR_GUEST_BIN_PATH)
         );
+
+        // Direction B (#708 phase 2): shared export dir bound rw, export env set,
+        // and the host-side export socket path exposed under the shared dir.
+        let export_dir = dir.path().join(GUEST_EXPORT_DIR_NAME);
+        assert!(export_dir.is_dir(), "shared export dir must be created on inject");
+        assert_eq!(
+            inj.annotations.get(&format!("{ANN_MOUNT_PREFIX}wanix-export-dir")),
+            Some(&format!("{}:{CTR_EXPORT_DIR}:rw", export_dir.display()))
+        );
+        assert_eq!(
+            inj.annotations
+                .get(&format!("{ANN_ENV_PREFIX}{ENV_GUEST_EXPORT_SOCK}"))
+                .map(String::as_str),
+            Some(CTR_EXPORT_SOCK_PATH)
+        );
+        assert_eq!(
+            inj.export_socket_path(),
+            export_dir.join(GUEST_EXPORT_SOCKET_NAME).as_path()
+        );
+    }
+
+    #[tokio::test]
+    async fn import_guest_namespace_binds_and_reads() {
+        // Stand up a local wire-faithful 9P server over a Mount — this stands in
+        // for the guest's Direction-B export — then import it into a host
+        // namespace and read a file back through the bound prefix. Exercises the
+        // full host-import mechanism (phase-1 Remote9pMount → bind_mount) in
+        // process, no sandbox boot.
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("guest-export.sock");
+        let listener = UnixListener::bind(&sock).unwrap();
+        let server = tokio::spawn(async move {
+            let _ = hyprstream_9p::Translator::from_mount(tenant_mount(), Subject::anonymous())
+                .serve_uds(listener)
+                .await;
+        });
+
+        let mut host_ns = Namespace::new();
+        let imported = import_guest_namespace(&mut host_ns, &sock, "t1")
+            .await
+            .unwrap();
+        assert_eq!(imported.prefix(), "/workers/t1/wanix");
+
+        let data = host_ns
+            .cat("/workers/t1/wanix/hello", &Subject::anonymous())
+            .await
+            .unwrap();
+        assert_eq!(data, b"hi\n", "host must read the guest's file over the imported 9P mount");
+
+        imported.unmount(&mut host_ns);
+        assert!(
+            !host_ns.mount_prefixes().contains(&"/workers/t1/wanix"),
+            "unmount must remove the imported prefix"
+        );
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn import_fails_when_no_guest_export() {
+        // No server ever listens on the socket → bounded retries exhaust and the
+        // import fails closed (never binds a dead mount).
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("never-appears.sock");
+        let mut host_ns = Namespace::new();
+        let err = import_guest_namespace_with(
+            &mut host_ns,
+            &sock,
+            "t1",
+            3,
+            std::time::Duration::from_millis(1),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("could not import guest namespace"), "got: {err}");
+        assert!(host_ns.mount_prefixes().is_empty(), "nothing must be bound on failure");
     }
 
     #[tokio::test]

--- a/workers/wanix-guest/main.go
+++ b/workers/wanix-guest/main.go
@@ -10,18 +10,37 @@
 //   - root.Register("exec", &native.ExecDriver{}) enables host-process tasks
 //   - root.NS().Bind(hyprfs, ".", ".", BindReplace) makes the remote tree root
 //
+// Bidirectional 9P (#708 phase 2). The above is Direction A: the guest IMPORTS
+// hyprstream's namespace. This binary also serves Direction B, the reverse --
+// the guest EXPORTS its OWN live namespace so the host can import it and bind it
+// into the host VFS namespace (giving the host visibility into the guest's task
+// tree). When HYPRSTREAM_GUEST_EXPORT_SOCK (or --export-sock) is set, after the
+// root is built the guest stands up a second, INDEPENDENT 9P2000.L server --
+//
+//	p9.NewServer(p9kit.Attacher(root.NS()))   served on that Unix socket
+//
+// in its own goroutine, using Wanix's OWN embed (root.NS() is the live vfs.NS,
+// which is an fs.FS) -- no upstream `wanix serve` patch, no bespoke verb. Import
+// and export are two independent 9P sessions over two sockets that share no
+// state beyond the namespace itself (#708).
+//
 // Run modes:
 //
-//	wanix-guest --sock /run/hyprstream/9p.sock [--aname ""] [--cmd "sh"]
+//	wanix-guest --sock /run/hyprstream/9p.sock [--aname ""] [--cmd "sh"] \
+//	            [--export-sock /run/hyprstream/wanix-export.sock]
 //	    Connect to a real hyprstream 9P server, bind it as the namespace root,
 //	    then either run --cmd as a Wanix task (waiting for it to exit) or, when
 //	    no --cmd is given, block serving the namespace until signalled. The
 //	    connection is health-probed; a dropped server triggers reconnect+rebind.
+//	    When --export-sock is given the guest namespace is also served over that
+//	    socket for the host to import (Direction B).
 //
 //	wanix-guest --self-test
 //	    Spin up a throwaway in-process p9kit server over a temp Unix socket,
-//	    bind it as the namespace root, and list "/" -- exercises the full 9P
-//	    attach/walk/read + bind wiring with no external server. Build smoke test.
+//	    bind it as the namespace root, list "/", THEN stand up the Direction-B
+//	    export server on a throwaway socket and read the same namespace back
+//	    through a p9 client -- exercises the full import AND export 9P wiring
+//	    with no external server. Build smoke test.
 //
 // Known semantic gap (see README): native.ExecDriver runs a task's command as a
 // HOST OS process; that process is NOT chrooted/rooted into the mounted 9P tree.
@@ -69,10 +88,11 @@ const (
 )
 
 type config struct {
-	sock     string
-	aname    string
-	cmd      string
-	selfTest bool
+	sock       string
+	aname      string
+	cmd        string
+	exportSock string
+	selfTest   bool
 }
 
 func main() {
@@ -86,6 +106,9 @@ func main() {
 		"9P attach name (empty = default tree)")
 	flag.StringVar(&cfg.cmd, "cmd", "",
 		"command to run as a Wanix task after mounting; empty = serve the namespace")
+	flag.StringVar(&cfg.exportSock, "export-sock", os.Getenv("HYPRSTREAM_GUEST_EXPORT_SOCK"),
+		"path to a Unix socket on which to EXPORT this guest's namespace over 9P for the host to import "+
+			"(Direction B; env: HYPRSTREAM_GUEST_EXPORT_SOCK); empty = no export")
 	flag.BoolVar(&cfg.selfTest, "self-test", false,
 		"run against a throwaway in-process 9P server and exit")
 	flag.Parse()
@@ -137,7 +160,56 @@ func runSelfTest(ctx context.Context) error {
 	for _, e := range entries {
 		fmt.Printf("  %s\tdir=%v\n", e.Name(), e.IsDir())
 	}
+
+	// Direction B (#708 phase 2): stand up the export server on a throwaway
+	// socket and read the SAME namespace back through a p9 client -- exercising
+	// the full serve -> attach -> walk -> readdir path the host uses to import.
+	if err := exportSelfTest(g.root.NS(), entries); err != nil {
+		return err
+	}
+
 	_ = ctx
+	return nil
+}
+
+// exportSelfTest serves ns over a throwaway export socket, dials it with a p9
+// client, and verifies the client sees the same root entries -- the Direction-B
+// (guest exports, host imports) build smoke test.
+func exportSelfTest(ns wfs.FS, want []wfs.DirEntry) error {
+	dir, err := os.MkdirTemp("", "wanix-guest-export-*")
+	if err != nil {
+		return fmt.Errorf("mktemp export dir: %w", err)
+	}
+	defer os.RemoveAll(dir)
+	sockPath := filepath.Join(dir, "export.sock")
+
+	stop, err := serveExport(ns, sockPath)
+	if err != nil {
+		return fmt.Errorf("serve export: %w", err)
+	}
+	defer stop()
+
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		return fmt.Errorf("dial export socket %q: %w", sockPath, err)
+	}
+	defer conn.Close()
+
+	exported, err := p9kit.ClientFS(conn, "")
+	if err != nil {
+		return fmt.Errorf("p9kit.ClientFS(export): %w", err)
+	}
+	got, err := wfs.ReadDir(exported, ".")
+	if err != nil {
+		return fmt.Errorf("readdir exported namespace over 9P client: %w", err)
+	}
+	if len(got) != len(want) {
+		return fmt.Errorf("exported namespace entry count mismatch: got %d, want %d", len(got), len(want))
+	}
+	fmt.Printf("self-test OK: exported guest namespace over 9P; p9 client read %d entries:\n", len(got))
+	for _, e := range got {
+		fmt.Printf("  %s\tdir=%v\n", e.Name(), e.IsDir())
+	}
 	return nil
 }
 
@@ -155,10 +227,62 @@ func runGuest(ctx context.Context, cfg config) error {
 	}
 	log.Printf("mounted hyprstream 9P (%q, aname=%q) as wanix namespace root", cfg.sock, cfg.aname)
 
+	// Direction B (#708 phase 2): if an export socket is configured, serve THIS
+	// guest's own live namespace over it so the host can import + bind it into
+	// the host VFS namespace. This is a SECOND, independent 9P session -- its own
+	// listener and server, sharing no state with the Direction-A import above
+	// beyond the namespace it reads.
+	if s := strings.TrimSpace(cfg.exportSock); s != "" {
+		stop, err := serveExport(g.root.NS(), s)
+		if err != nil {
+			return fmt.Errorf("start guest namespace export: %w", err)
+		}
+		defer stop()
+		log.Printf("exporting guest namespace over 9P at %q (host imports this)", s)
+	}
+
 	if strings.TrimSpace(cfg.cmd) != "" {
 		return g.runTask(ctx, cfg.cmd)
 	}
 	return g.serve(ctx)
+}
+
+// serveExport stands up a 9P2000.L server (progrium/p9) exporting ns on a Unix
+// socket at sockPath -- Direction B of the bidirectional 9P (#708 phase 2): the
+// guest serves its OWN live namespace so hyprstream (the host) can import it via
+// its socket 9P client Mount (phase 1) and bind it into the host VFS namespace.
+//
+// This is INDEPENDENT of the Direction-A import session: a separate listener, a
+// separate 9P session, no shared state beyond the namespace it reads. The
+// listener is bound synchronously (so the socket file exists on return -- the
+// host's import dial never races the server coming up); the accept loop runs in
+// a goroutine until the returned stop func closes the listener.
+func serveExport(ns wfs.FS, sockPath string) (func(), error) {
+	// Remove any stale socket from a crashed predecessor (Listen would EADDRINUSE).
+	if err := os.Remove(sockPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("remove stale export socket %q: %w", sockPath, err)
+	}
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		return nil, fmt.Errorf("listen export socket %q: %w", sockPath, err)
+	}
+
+	srv := p9.NewServer(p9kit.Attacher(ns))
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// Serve blocks until the listener is closed (stop), at which point Accept
+		// fails with a closing error and Serve returns nil.
+		if err := srv.Serve(ln); err != nil {
+			log.Printf("export 9P server exited with error: %v", err)
+		}
+	}()
+
+	stop := func() {
+		ln.Close()
+		<-done
+	}
+	return stop, nil
 }
 
 // guest owns the Wanix root Task and the live connection to the remote 9P


### PR DESCRIPTION
## Phase 2 of #708 — Direction B: host imports the guest namespace

Phase 1 (the socket 9P client `Mount`, `Remote9pMount`) is on `main`. This completes the bidirectional 9P: the native Wanix guest **exports its own live namespace** over a second socket, and hyprstream **imports it** and binds it into the host VFS namespace at `/workers/<tenant>/wanix` — giving the host visibility into the guest's task tree.

### Guest export — no upstream Wanix patch needed
`workers/wanix-guest/main.go` (from #506) already **embeds Wanix as a Go library** (`wanix.NewRoot()`, `root.NS()`). So the guest exports its OWN live namespace directly, in our code:

```go
p9.NewServer(p9kit.Attacher(root.NS()))   // served on a UDS in a goroutine
```

`p9kit.Attacher` takes any `tractor.dev/wanix/fs.FS`, and `*vfs.NS` (from `root.NS()`) is one — so no bespoke verb and no fork of upstream `wanix serve`. A new `HYPRSTREAM_GUEST_EXPORT_SOCK` / `--export-sock` triggers it. The export runs alongside the existing Direction-A import as **two independent 9P sessions** (import = guest mounts host; export = host mounts guest), sharing no state beyond the namespace itself.

### Host import — via the phase-1 `Remote9pMount`
In `wanix_workload.rs` the injection now also allocates a **shared export directory** bind (the guest is the *server* here — its socket doesn't exist yet, so we share the directory, not a pre-made file) plus the `HYPRSTREAM_GUEST_EXPORT_SOCK` env, mirroring the Direction-A socket injection. After the sandbox starts, `import_guest_namespace()` dials the guest's export socket with the phase-1 `Remote9pMount::connect_uds` (bounded retry, since the listener appears only after boot) and `Namespace::bind_mount`s the imported tree at `/workers/<tenant>/wanix`. The returned `ImportedGuestNamespace` holds the mount/connection for teardown (`unmount`).

### Two independent directions
Separate sockets, separate 9P sessions, no shared coupling — as #708 specifies. Direction A (host→guest) is unchanged; Direction B (guest→host) is purely additive.

### Honesty / caveat — thin payoff
Native Wanix currently has only `ExecDriver` — the exported `#task` tree is host-exec processes + binds (no wasi/VM task tree) until a native wasi driver exists. **The mechanism** (host imports the guest's namespace bidirectionally, over the phase-1 `Remote9pMount`) **is the deliverable**; what's visible through it grows as the guest gains drivers.

### Scope
Wired for the shared-FS UDS backends (**OCI/nspawn**); the capability gate (`require_9p_socket_capability`) already refuses kata/wasm. A kata guest would export over **vsock** — follow-up, not here.

### What the operator boot validates
This PR is **code + compile only** (no VM/container was booted). A real boot validates: (1) the guest binds its export socket inside the shared dir and it appears host-side; (2) `import_guest_namespace` connects and binds; (3) the host can `ls`/read `/workers/<tenant>/wanix` and see the guest's namespace incl. the `#task` tree. Not wired to a production caller yet (the tenant `Mount` + host `Namespace` are the explicit seam #506/#708 leave to the worker-placement site).

### Gates (all clean)
- `cargo check -p hyprstream-workers --features oci,oci-image` — ok
- `cargo check -p hyprstream-workers` (default) — ok
- `cargo clippy -p hyprstream-workers --all-targets --features oci,oci-image -- -D warnings` — ok
- `cargo test -p hyprstream-workers --features oci,oci-image wanix_workload` — 8 passed (incl. new in-process import round-trip + fail-closed)
- `cd workers/wanix-guest && go build ./... && go vet ./...` — ok; `go run . --self-test` exercises export→p9-client read; `gofmt` clean

Closes #708
