### PR TITLE
Record MAC interface policy in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,12 @@ UCAN (grant/delegation source) → Casbin (policy STORE + authoring, string-matc
 
 **Naming (don't relitigate):** `ceiling`→`grant`, `dominates`→`can_access`, `witness`→`granted_access`, `rules_for`→`permissions_for` — plain MAC/RBAC vocabulary, not academic/poetic terms.
 
+**Interface policy — MAC on contracts that don't carry it (ratified, epic #547):** MAC context is **never a plaintext field of an API contract**. Contracts carry either verified credentials (checked once at session/attach time) or opaque handles to TCB-resolved context. Select the move by what already crosses the interface:
+1. **Derive, don't extend** — a verified identity already crosses (RPC `EnvelopeContext`): compute `SecurityContext` at the boundary from `Claims × VerifiedKeyMaterial` (S1 invariant), cache, enforce via the AVC. No schema change.
+2. **Extend at attach time, never per-op** — a session exists but no identity crosses (9P `Tattach`, #568): present a verified credential **once** at session establishment; cache the derived `SubjectCtx` fid/connection-scoped inside the TCB (the `mac::avc` amortization model); revoke via the AVC generation counter. Per-op params carry at most an opaque, unforgeable handle.
+3. **Fill with deny/clamp** — nothing crosses or the source is outside the TCB: subjects **deny** (`DenyUnlabeledResolver` pattern), object labels **clamp to the importing boundary's floor** (D2 — join, never "unrestricted"), unverifiable key material **floors at Classical** (Decision D, #698).
+4. **Forbidden** — caller-supplied labels/clearance as authoritative PDP inputs (a plain struct param is unauthenticated data: whoever constructs the call constructs the clearance). "Add a `SecurityContext` parameter to every method" is the *wrong* extension even though it looks most explicit. Labels in wire schemas are **hints** (D1 — trusted only from services we operate).
+
 **Current status (check before assuming otherwise):** the MAC library is real and well-tested, but **enforcement is not active in production as of this writing** — the PDP has no wired-in PEP caller, the S6 grant path's HTTP dispatch still fails closed pending resolver/object-label wiring, and the audit store needs explicit startup construction. Everything fails closed (nothing is exploitable), but do not assume MAC is "live" — check the current wiring state (`services::oauth`, service factories) before relying on it protecting anything at runtime.
 
 ## Adding an RPC Method


### PR DESCRIPTION
## Summary

Records the operator-ratified **MAC interface policy** in CLAUDE.md's Native MAC section, so every future session applies the same rule when it hits an interface whose API contract doesn't carry MAC context — instead of re-deriving (or worse, re-deciding) it.

The policy, as ratified on epic #547 (https://github.com/hyprstream/hyprstream/issues/547#issuecomment-4882511734):

> MAC context is never a plaintext field of an API contract. Contracts carry either verified credentials (checked once at session/attach time) or opaque handles to TCB-resolved context; labels appearing in wire schemas are hints (D1); absent subject context denies; absent object labels clamp to the importing boundary's floor (D2); unverifiable key material floors at Classical (Decision D, #698).

The CLAUDE.md addition enumerates the three legitimate moves (derive / extend-at-attach / fill-downward) and the one forbidden move (caller-supplied labels as authoritative PDP inputs), each anchored to the ratified decisions that constrain it.

## Why CLAUDE.md and not just docs/

This is agent-facing operating guidance of the same kind as the existing "Naming (don't relitigate)" and "Current status" blocks in the Native MAC section: it prevents a future session from making the plausible-but-wrong move ("add a `SecurityContext` parameter to every `Mount` method") that the policy exists to forbid. The prose architecture treatment stays in docs/mac-architecture.md.

## Related

- Epic #547 — policy ratification comment
- #568 — concrete `Tattach`-token PEP proposal applying rule 2 (https://github.com/hyprstream/hyprstream/issues/568#issuecomment-4882511757)
- #699 — carrier-b applies rule 3 (D2 floor-join for unlabeled manifests)
- #698 / #718 — Decision D (Classical floor) precedent

Docs-only change; no code touched.
