### PR TITLE
P3 (#526): request routing over the placement directory — HRW/least-loaded + mesh-authz seam

### DIFF
--- a/crates/hyprstream-discovery/Cargo.toml
+++ b/crates/hyprstream-discovery/Cargo.toml
@@ -14,6 +14,9 @@ crate-type = ["rlib"]  # rlib-only: OnceLock singletons must be shared workspace
 hyprstream-rpc = { path = "../hyprstream-rpc" }
 hyprstream-util = { path = "../hyprstream-util" }
 hyprstream-rpc-derive = { path = "../hyprstream-rpc-derive" }
+# #524 P1 — placement directory ingestion: CAR parsing + MST walk + record
+# decoding (ai.hyprstream.placement.* lexicons).
+hyprstream-pds = { path = "../hyprstream-pds" }
 
 # Async runtime
 async-trait = { workspace = true }
@@ -36,8 +39,7 @@ tracing = { workspace = true }
 ed25519-dalek = { workspace = true }
 
 [dev-dependencies]
-# #431 — build/verify real CAR proofs in getRecord handler tests.
-hyprstream-pds = { path = "../hyprstream-pds" }
+# #431 / #524 — build/verify real CAR proofs in getRecord + placement tests.
 p256 = { workspace = true }
 rand = { workspace = true }
 tokio = { workspace = true }

--- a/crates/hyprstream-discovery/schema/discovery.capnp
+++ b/crates/hyprstream-discovery/schema/discovery.capnp
@@ -89,6 +89,13 @@ struct DiscoveryRequest {
     # matches labels on the durable node records; resources check
     # (declared - allocatable). (#628 Scheduling Substrate vocabulary.)
     queryCandidates @17 :QueryCandidatesRequest $scope(query) $mcpDescription("Query placement candidates by label-selector + resource requests");
+
+    # #524 P1 — node liveness heartbeat: live allocatable capacity + load for
+    # one node. Backs the hard-exclusion-on-staleness rule in queryCandidates
+    # (a node with no live/fresh heartbeat is omitted outright, never just
+    # flagged stale). Re-inserting (heartbeating) the same node refreshes its
+    # TTL entry.
+    reportNodeLiveness @18 :NodeLiveness $scope(write) $mcpDescription("Report live node capacity/load for placement candidate liveness");
   }
 }
 
@@ -143,6 +150,9 @@ struct DiscoveryResponse {
 
     # #523 P0 / #524 — placement candidate query result.
     queryCandidatesResult @18 :PlacementCandidateSet;
+
+    # #524 P1 — liveness heartbeat acknowledgement.
+    reportNodeLivenessResult @19 :Void;
   }
 }
 
@@ -348,4 +358,15 @@ struct QueryCandidatesRequest {
   selectors    @0 :List(LabelSelector);   # ALL must match (AND)
   resources    @1 :List(ResourceRequest); # ALL must be satisfiable
   maxCandidates @2 :UInt32;               # bounded set
+}
+
+# #524 P1 — one node's liveness heartbeat: live allocatable capacity + load.
+# Stored in a TTL cache (see the Rust `service` module); a heartbeat for the
+# same node refreshes its expiry. Absence (never reported, or expired) hard-
+# excludes the node from queryCandidates results.
+struct NodeLiveness {
+  node         @0 :Text $domainType("hyprstream_rpc::identity::Did");
+  allocatable  @1 :List(Resource);   # capacity free right now
+  loadFraction @2 :Float32;         # [0,1], live
+  ts           @3 :Int64;           # unix millis this snapshot was taken (0 = use receipt time)
 }

--- a/crates/hyprstream-discovery/src/lib.rs
+++ b/crates/hyprstream-discovery/src/lib.rs
@@ -39,6 +39,15 @@ pub mod generated {
 
 mod service;
 
+/// #524 P1 — placement directory record ingestion + in-process index.
+///
+/// Polls `RecordResolver::resolve_repo` for a bootstrap set of node DIDs,
+/// walks the returned CAR's MST, and decodes `ai.hyprstream.placement.*`
+/// records (node / workload / group / groupItem) into a queryable index:
+/// label-selector evaluation, resource matching, and bidirectional-consent
+/// group membership. Consumed by `handle_query_candidates`.
+pub mod placement_index;
+
 /// #523 P0 / #524 / #628 — Scheduling Substrate.
 ///
 /// The shared `LabelSelector` / `ResourceRequest` / `PlacementCandidate`

--- a/crates/hyprstream-discovery/src/placement_index.rs
+++ b/crates/hyprstream-discovery/src/placement_index.rs
@@ -1,0 +1,567 @@
+//! P1 placement directory — record ingestion + in-process index (#524).
+//!
+//! Day-1 ingestion is **polled `RecordResolver` reads**, not a firehose/moq_event
+//! tail (that's explicitly out of scope — a day-2 ticket). Given a node DID, we
+//! call [`crate::RecordResolver::resolve_repo`], parse the returned CARv1 blob
+//! (`hyprstream_pds::car::parse_car_v1`), walk the repo's MST from the commit's
+//! `data` root, and decode every `ai.hyprstream.placement.{node,workload,group,
+//! groupItem}` record we find into an in-process index.
+//!
+//! # Trust posture
+//!
+//! Unlike `getRecord`/`getRepo` (D5: untrusted relay, caller verifies the CAR
+//! proof offline), this ingestion path does **not** verify the commit
+//! signature. The injected `RecordResolver` is the same trusted, in-process
+//! resolver `handle_get_repo` already serves *from* (see its trait docs: "the
+//! node's local PDS") — there is no untrusted network hop between the index and
+//! its source here. Verifying signatures would need a DID→verifying-key
+//! resolution step this crate doesn't have; that's future federation-hardening
+//! work, not a P1 blocker (the index is best-effort scheduling metadata, not a
+//! security boundary — the *per-candidate authz check* in `queryCandidates` is
+//! the security boundary).
+//!
+//! # Group membership — bidirectional consent
+//!
+//! A node is *effectively* a member of a group only when **both** sides agree:
+//! the group owner published a `GroupItemRecord{group, subject}` naming the
+//! node, **and** the node's own `NodeRecord.groups` lists that group's at-uri
+//! (explicit node-side consent). Neither claim alone is membership — see
+//! [`PlacementIndex::is_member`].
+//!
+//! Group membership is exposed to `queryCandidates`' label-selector matching as
+//! a **synthetic label**, not a schema change: for every group a node is an
+//! effective member of, the index adds a label `("group/<group-at-uri>", "true")`
+//! to that node's effective label set (see [`PlacementIndex::effective_labels`]).
+//! Each group gets its own unique label *key* (rather than several `("group",
+//! X)` pairs under one shared key) because [`crate::scheduling::LabelSelector`]
+//! looks up the *first* entry matching a key (the k8s label model: one value per
+//! key) — multiple same-keyed pairs would only ever let the first one be
+//! evaluated, silently breaking multi-group membership. A caller checks
+//! membership in group `G` with `LabelSelector::new(format!("group/{G}"),
+//! SelectorOp::Exists, vec![])`.
+
+use std::collections::HashMap;
+
+use anyhow::{anyhow, Result};
+use parking_lot::RwLock;
+
+use hyprstream_pds::car::parse_car_v1;
+use hyprstream_pds::cid::Cid;
+use hyprstream_pds::commit::Commit;
+use hyprstream_pds::dag_cbor::DagCbor;
+use hyprstream_pds::mst::NodeData;
+use hyprstream_pds::placement::{group, group_item, node, workload};
+use hyprstream_pds::placement::{GroupItemRecord, GroupRecord, NodeRecord, WorkloadRecord};
+
+use crate::RecordResolver;
+
+/// One node's durable (non-volatile) placement facts, decoded from its
+/// `ai.hyprstream.placement.node` record.
+#[derive(Debug, Clone, Default)]
+pub struct NodeFacts {
+    /// at-uri of the `NodeRecord` itself (`at://<did>/ai.hyprstream.placement.node/<rkey>`).
+    pub record_uri: String,
+    /// Declared `{key, value}` labels.
+    pub labels: Vec<(String, String)>,
+    /// Declared capacity (k8s-quantity strings) — NOT live/allocatable.
+    /// `queryCandidates` uses the *live* liveness report for resource matching,
+    /// never this durable declaration (see the module docs on trust posture).
+    pub declared_resources: Vec<(String, String)>,
+    /// at-uris of groups this node's own record *consents* to.
+    pub consented_groups: Vec<String>,
+}
+
+/// One decoded `ai.hyprstream.placement.group` record's facts.
+#[derive(Debug, Clone)]
+struct GroupFacts {
+    #[allow(dead_code)] // carried for future group-scoped listing; unused by queryCandidates today
+    name: String,
+    #[allow(dead_code)]
+    owner_did: String,
+}
+
+/// Everything ingested from one DID's repo CAR in the most recent poll. Kept
+/// so a re-poll can *replace* (not merge-forever-append) that DID's
+/// contribution to the derived indices — a group/groupItem record deleted
+/// upstream must be able to disappear from the index on the next poll.
+#[derive(Debug, Clone, Default)]
+struct DidSnapshot {
+    node: Option<NodeFacts>,
+    groups: Vec<(String, String, String)>, // (group at-uri, name, owner_did)
+    group_items: Vec<GroupItemRecord>,
+    /// Decoded but not indexed further (day-1 scope; see module docs).
+    workload_count: usize,
+}
+
+/// In-process placement directory index. Rebuilt by polling
+/// [`RecordResolver::resolve_repo`] for a bootstrap set of node DIDs (day-1
+/// ingestion — see the module docs). Read from the `queryCandidates` request
+/// path; written by the poller. `parking_lot::RwLock` mirrors the precedent
+/// already used for `DiscoveryService`'s other in-memory maps.
+#[derive(Default)]
+pub struct PlacementIndex {
+    /// Per-DID last-ingested snapshot (the source of truth for re-poll replace
+    /// semantics).
+    raw: RwLock<HashMap<String, DidSnapshot>>,
+    /// Derived: node DID -> facts. Recomputed after every ingest.
+    nodes: RwLock<HashMap<String, NodeFacts>>,
+    /// Derived: group at-uri -> facts.
+    groups: RwLock<HashMap<String, GroupFacts>>,
+    /// Derived: group at-uri -> DIDs the group OWNER claims as members
+    /// (`GroupItemRecord.subject`). Effective membership additionally requires
+    /// the node's own consent — see [`Self::is_member`].
+    group_claims: RwLock<HashMap<String, Vec<String>>>,
+}
+
+impl PlacementIndex {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Poll `did`'s repo via `resolver` and (re-)ingest its placement records,
+    /// replacing whatever this DID contributed on a previous poll.
+    ///
+    /// `Ok(())` with no visible effect when the DID has no stored repo (nothing
+    /// to ingest) or its repo carries no placement records — this is not an
+    /// error, just an empty directory entry.
+    pub async fn ingest_did(&self, resolver: &dyn RecordResolver, did: &str) -> Result<()> {
+        let repo = resolver
+            .resolve_repo(did)
+            .await
+            .map_err(|e| anyhow!("resolve_repo({did}) failed: {e}"))?;
+        let Some(repo) = repo else {
+            // No repo stored for this DID — clear any stale contribution and stop.
+            self.raw.write().remove(did);
+            self.recompute_derived();
+            return Ok(());
+        };
+        let snapshot = Self::decode_repo_car(did, &repo.car)?;
+        self.raw.write().insert(did.to_owned(), snapshot);
+        self.recompute_derived();
+        Ok(())
+    }
+
+    /// Parse a repo CARv1 blob and decode every `ai.hyprstream.placement.*`
+    /// record reachable from the commit's MST root into a [`DidSnapshot`].
+    fn decode_repo_car(did: &str, car: &[u8]) -> Result<DidSnapshot> {
+        let (roots, blocks) = parse_car_v1(car)?;
+        let root_cid = *roots
+            .first()
+            .ok_or_else(|| anyhow!("repo CAR for {did} has no root"))?;
+        let block_map: HashMap<Cid, Vec<u8>> = blocks.into_iter().collect();
+        let commit_bytes = block_map
+            .get(&root_cid)
+            .ok_or_else(|| anyhow!("repo CAR for {did} missing its commit block"))?;
+        let commit = Commit::from_dag_cbor(commit_bytes)?;
+
+        let mut entries = Vec::new();
+        walk_mst(commit.data, &block_map, &mut entries)?;
+
+        let mut snapshot = DidSnapshot::default();
+        for (key, record_cid) in entries {
+            let Some((collection, _rkey)) = key.split_once('/') else {
+                continue; // malformed key (no collection prefix) — skip, not fatal
+            };
+            let Some(bytes) = block_map.get(&record_cid) else {
+                continue; // entry points at a block the CAR didn't include
+            };
+
+            if collection == node::COLLECTION_NSID {
+                if let Ok(rec) = NodeRecord::from_dag_cbor(bytes) {
+                    snapshot.node = Some(NodeFacts {
+                        record_uri: format!("at://{did}/{key}"),
+                        labels: rec.labels.into_iter().map(|l| (l.key, l.value)).collect(),
+                        declared_resources: rec
+                            .resources
+                            .into_iter()
+                            .map(|r| (r.name, r.capacity))
+                            .collect(),
+                        consented_groups: rec.groups,
+                    });
+                }
+            } else if collection == group::COLLECTION_NSID {
+                if let Ok(rec) = GroupRecord::from_dag_cbor(bytes) {
+                    let uri = format!("at://{did}/{key}");
+                    snapshot.groups.push((uri, rec.name, rec.owner_did));
+                }
+            } else if collection == group_item::COLLECTION_NSID {
+                if let Ok(rec) = GroupItemRecord::from_dag_cbor(bytes) {
+                    snapshot.group_items.push(rec);
+                }
+            } else if collection == workload::COLLECTION_NSID {
+                // Decoded for completeness per #524 P1 scope; workload placement
+                // decisions aren't consumed by queryCandidates (day-1 scope).
+                if WorkloadRecord::from_dag_cbor(bytes).is_ok() {
+                    snapshot.workload_count += 1;
+                }
+            }
+        }
+        Ok(snapshot)
+    }
+
+    /// Rebuild the derived (nodes / groups / group_claims) maps from `raw` in
+    /// full. Simple full-rebuild rather than incremental patching — correct by
+    /// construction (a deleted upstream record can't leak forever) and cheap at
+    /// fleet scale; this is an index refresh, not a hot path.
+    fn recompute_derived(&self) {
+        let raw = self.raw.read();
+        let mut nodes = HashMap::new();
+        let mut groups = HashMap::new();
+        let mut claims: HashMap<String, Vec<String>> = HashMap::new();
+        for (did, snap) in raw.iter() {
+            if let Some(n) = &snap.node {
+                nodes.insert(did.clone(), n.clone());
+            }
+            for (uri, name, owner_did) in &snap.groups {
+                groups.insert(
+                    uri.clone(),
+                    GroupFacts {
+                        name: name.clone(),
+                        owner_did: owner_did.clone(),
+                    },
+                );
+            }
+            for item in &snap.group_items {
+                claims.entry(item.group.clone()).or_default().push(item.subject.clone());
+            }
+        }
+        drop(raw);
+        *self.nodes.write() = nodes;
+        *self.groups.write() = groups;
+        *self.group_claims.write() = claims;
+    }
+
+    /// All node DIDs currently known to the index (have an ingested
+    /// `NodeRecord`).
+    pub fn known_node_dids(&self) -> Vec<String> {
+        self.nodes.read().keys().cloned().collect()
+    }
+
+    /// The at-uri of `did`'s `NodeRecord`, if known.
+    pub fn record_uri(&self, did: &str) -> Option<String> {
+        self.nodes.read().get(did).map(|f| f.record_uri.clone())
+    }
+
+    /// Whether `node_did` is an *effective* (bidirectional-consent) member of
+    /// `group_uri`: the group owner must have published a `GroupItemRecord`
+    /// naming this node, **and** the node's own `NodeRecord.groups` must list
+    /// this group. Either claim alone is not membership.
+    pub fn is_member(&self, node_did: &str, group_uri: &str) -> bool {
+        let node_consents = self
+            .nodes
+            .read()
+            .get(node_did)
+            .is_some_and(|f| f.consented_groups.iter().any(|g| g == group_uri));
+        if !node_consents {
+            return false;
+        }
+        self.group_claims
+            .read()
+            .get(group_uri)
+            .is_some_and(|members| members.iter().any(|m| m == node_did))
+    }
+
+    /// A node's effective label set for selector matching: its declared
+    /// `NodeRecord.labels` plus one synthetic `("group/<uri>", "true")` label
+    /// per group it is an *effective* (bidirectional-consent) member of. See
+    /// the module docs for why group membership uses a per-group label key.
+    pub fn effective_labels(&self, node_did: &str) -> Vec<(String, String)> {
+        let (mut labels, consented_groups) = match self.nodes.read().get(node_did) {
+            Some(f) => (f.labels.clone(), f.consented_groups.clone()),
+            None => return Vec::new(),
+        };
+        for group_uri in &consented_groups {
+            if self.is_member(node_did, group_uri) {
+                labels.push((format!("group/{group_uri}"), "true".to_owned()));
+            }
+        }
+        labels
+    }
+
+    /// A node's declared (durable) capacity — NOT the live/allocatable figure
+    /// `queryCandidates` matches resource requests against. Exposed mainly for
+    /// tests / introspection.
+    pub fn declared_resources(&self, node_did: &str) -> Vec<(String, String)> {
+        self.nodes
+            .read()
+            .get(node_did)
+            .map(|f| f.declared_resources.clone())
+            .unwrap_or_default()
+    }
+}
+
+/// Enumerate every `(full_key, record_cid)` entry reachable from an MST node,
+/// depth-first in key order: left subtree, then each entry (recursing into its
+/// right subtree before the next entry). Mirrors the encode side
+/// (`Node::to_node_data_rec` in `hyprstream_pds::mst`) exactly, including its
+/// prefix-compression convention: `entry.p` compresses against the *previous
+/// entry within this same node* only (resets to 0 at the first entry of every
+/// node) — never against a key from a different node.
+fn walk_mst(node_cid: Cid, blocks: &HashMap<Cid, Vec<u8>>, out: &mut Vec<(String, Cid)>) -> Result<()> {
+    let bytes = blocks
+        .get(&node_cid)
+        .ok_or_else(|| anyhow!("MST node {node_cid} missing from repo CAR blocks"))?;
+    let value = DagCbor::decode(bytes)?;
+    let data = NodeData::from_value(&value)?;
+
+    if let Some(left) = data.l {
+        walk_mst(left, blocks, out)?;
+    }
+    let mut prev_key: Option<String> = None;
+    for entry in &data.e {
+        let key = match &prev_key {
+            Some(prev) => {
+                let prev_bytes = prev.as_bytes();
+                let take = entry.p.min(prev_bytes.len());
+                let mut full = prev_bytes[..take].to_vec();
+                full.extend_from_slice(&entry.k);
+                String::from_utf8(full).map_err(|e| anyhow!("MST entry key is not utf8: {e}"))?
+            }
+            None => String::from_utf8(entry.k.clone())
+                .map_err(|e| anyhow!("MST entry key is not utf8: {e}"))?,
+        };
+        out.push((key.clone(), entry.v));
+        prev_key = Some(key);
+        if let Some(right) = entry.t {
+            walk_mst(right, blocks, out)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    use async_trait::async_trait;
+    use hyprstream_pds::car::build_car_v1;
+    use hyprstream_pds::commit::UnsignedCommit;
+    use hyprstream_pds::mst::Node;
+    use hyprstream_pds::tid::Tid;
+    use p256::ecdsa::SigningKey as P256SigningKey;
+
+    use crate::service::RecordCarData;
+
+    const NODE_DID: &str = "did:web:node1.example.com";
+    const OWNER_DID: &str = "did:web:owner.example.com";
+
+    /// Build a repo CARv1 for `did` from a set of already-encoded `(full_key,
+    /// dag_cbor_bytes)` records (mixed collections OK — the repo MST spans all
+    /// of them, matching real atproto repos).
+    fn repo_car(did: &str, records: &[(String, Vec<u8>)]) -> Vec<u8> {
+        let signing_key = P256SigningKey::random(&mut rand::rngs::OsRng);
+        let mut keyed: BTreeMap<String, Cid> = BTreeMap::new();
+        let mut record_blocks: Vec<(Cid, Vec<u8>)> = Vec::new();
+        for (key, bytes) in records {
+            let cid = Cid::from_dag_cbor(bytes);
+            keyed.insert(key.clone(), cid);
+            record_blocks.push((cid, bytes.clone()));
+        }
+        let tree = Node::from_keyed_records(&keyed);
+        let root = tree.root_cid();
+        let (_root_data, node_blocks) = tree.to_node_data_with_blocks();
+        let unsigned = UnsignedCommit::new(did.to_owned(), root, Tid::now(), None);
+        let commit = hyprstream_pds::commit::Commit::sign(&unsigned, &signing_key);
+
+        let mut blocks: Vec<(Cid, Vec<u8>)> = vec![(commit.cid(), commit.to_dag_cbor())];
+        for (cid, data) in node_blocks {
+            blocks.push((cid, data.encode()));
+        }
+        blocks.extend(record_blocks);
+        build_car_v1(&[commit.cid()], &blocks)
+    }
+
+    fn node_record_key(rkey: &str) -> String {
+        format!("{}/{rkey}", node::COLLECTION_NSID)
+    }
+    fn group_record_key(rkey: &str) -> String {
+        format!("{}/{rkey}", group::COLLECTION_NSID)
+    }
+    fn group_item_record_key(rkey: &str) -> String {
+        format!("{}/{rkey}", group_item::COLLECTION_NSID)
+    }
+
+    /// A resolver serving fixed, per-DID repo CARs (built with real records).
+    struct FixedResolver {
+        repos: HashMap<String, Vec<u8>>,
+    }
+
+    #[async_trait(?Send)]
+    impl RecordResolver for FixedResolver {
+        async fn resolve_record(
+            &self,
+            _did: &str,
+            _collection: &str,
+            _rkey: &str,
+        ) -> Result<Option<RecordCarData>> {
+            Ok(None)
+        }
+        async fn resolve_repo(&self, did: &str) -> Result<Option<RecordCarData>> {
+            Ok(self.repos.get(did).map(|car| RecordCarData {
+                uri: format!("at://{did}"),
+                car: car.clone(),
+            }))
+        }
+    }
+
+    fn sample_node_record(groups: Vec<String>) -> NodeRecord {
+        NodeRecord::new(
+            format!("at://{NODE_DID}"),
+            vec![node::Label {
+                key: "zone".into(),
+                value: "us-east".into(),
+            }],
+            vec![node::Resource {
+                name: "nvidia.com/gpu".into(),
+                capacity: "8".into(),
+            }],
+            groups,
+            "2026-06-23T12:34:56.789Z",
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn ingest_decodes_node_record_labels_and_resources() {
+        let rec = sample_node_record(vec![]);
+        let car = repo_car(NODE_DID, &[(node_record_key("3a"), rec.to_dag_cbor())]);
+        let resolver = FixedResolver {
+            repos: HashMap::from([(NODE_DID.to_owned(), car)]),
+        };
+        let index = PlacementIndex::new();
+        index.ingest_did(&resolver, NODE_DID).await.unwrap();
+
+        assert_eq!(index.known_node_dids(), vec![NODE_DID.to_owned()]);
+        assert_eq!(
+            index.record_uri(NODE_DID).as_deref(),
+            Some(format!("at://{NODE_DID}/{}", node_record_key("3a")).as_str())
+        );
+        let labels = index.effective_labels(NODE_DID);
+        assert!(labels.contains(&("zone".to_owned(), "us-east".to_owned())));
+        assert_eq!(
+            index.declared_resources(NODE_DID),
+            vec![("nvidia.com/gpu".to_owned(), "8".to_owned())]
+        );
+    }
+
+    #[tokio::test]
+    async fn ingest_missing_repo_is_not_an_error_and_yields_no_node() {
+        let resolver = FixedResolver { repos: HashMap::new() };
+        let index = PlacementIndex::new();
+        index.ingest_did(&resolver, NODE_DID).await.unwrap();
+        assert!(index.known_node_dids().is_empty());
+    }
+
+    #[tokio::test]
+    async fn group_membership_requires_both_owner_claim_and_node_consent() {
+        let group_uri_key = group_record_key("3g");
+        let group_rec = GroupRecord::new(
+            "east-coast-gpus",
+            OWNER_DID,
+            None,
+            "2026-06-23T12:34:56.789Z",
+        )
+        .unwrap();
+        let group_uri = format!("at://{OWNER_DID}/{group_uri_key}");
+
+        // Case 1: owner claims the node, but the node's own record does NOT
+        // list the group (no node-side consent) -> not a member.
+        {
+            let owner_car = repo_car(
+                OWNER_DID,
+                &[
+                    (group_uri_key.clone(), group_rec.to_dag_cbor()),
+                    (
+                        group_item_record_key("3i"),
+                        GroupItemRecord::new(group_uri.clone(), NODE_DID, "2026-06-23T12:34:56.789Z")
+                            .unwrap()
+                            .to_dag_cbor(),
+                    ),
+                ],
+            );
+            let node_rec = sample_node_record(vec![]); // no consent
+            let node_car = repo_car(NODE_DID, &[(node_record_key("3a"), node_rec.to_dag_cbor())]);
+            let resolver = FixedResolver {
+                repos: HashMap::from([(OWNER_DID.to_owned(), owner_car), (NODE_DID.to_owned(), node_car)]),
+            };
+            let index = PlacementIndex::new();
+            index.ingest_did(&resolver, OWNER_DID).await.unwrap();
+            index.ingest_did(&resolver, NODE_DID).await.unwrap();
+            assert!(
+                !index.is_member(NODE_DID, &group_uri),
+                "owner-claim without node consent must NOT be membership"
+            );
+            assert!(!index
+                .effective_labels(NODE_DID)
+                .iter()
+                .any(|(k, _)| k == &format!("group/{group_uri}")));
+        }
+
+        // Case 2: node consents (lists the group in its own record), but the
+        // owner never published a GroupItemRecord naming it -> not a member.
+        {
+            let owner_car = repo_car(OWNER_DID, &[(group_uri_key.clone(), group_rec.to_dag_cbor())]);
+            let node_rec = sample_node_record(vec![group_uri.clone()]);
+            let node_car = repo_car(NODE_DID, &[(node_record_key("3a"), node_rec.to_dag_cbor())]);
+            let resolver = FixedResolver {
+                repos: HashMap::from([(OWNER_DID.to_owned(), owner_car), (NODE_DID.to_owned(), node_car)]),
+            };
+            let index = PlacementIndex::new();
+            index.ingest_did(&resolver, OWNER_DID).await.unwrap();
+            index.ingest_did(&resolver, NODE_DID).await.unwrap();
+            assert!(
+                !index.is_member(NODE_DID, &group_uri),
+                "node consent without an owner claim must NOT be membership"
+            );
+        }
+
+        // Case 3: both sides agree -> effective member, surfaced as a synthetic label.
+        {
+            let owner_car = repo_car(
+                OWNER_DID,
+                &[
+                    (group_uri_key.clone(), group_rec.to_dag_cbor()),
+                    (
+                        group_item_record_key("3i"),
+                        GroupItemRecord::new(group_uri.clone(), NODE_DID, "2026-06-23T12:34:56.789Z")
+                            .unwrap()
+                            .to_dag_cbor(),
+                    ),
+                ],
+            );
+            let node_rec = sample_node_record(vec![group_uri.clone()]);
+            let node_car = repo_car(NODE_DID, &[(node_record_key("3a"), node_rec.to_dag_cbor())]);
+            let resolver = FixedResolver {
+                repos: HashMap::from([(OWNER_DID.to_owned(), owner_car), (NODE_DID.to_owned(), node_car)]),
+            };
+            let index = PlacementIndex::new();
+            index.ingest_did(&resolver, OWNER_DID).await.unwrap();
+            index.ingest_did(&resolver, NODE_DID).await.unwrap();
+            assert!(index.is_member(NODE_DID, &group_uri), "both claims present -> member");
+            assert!(index
+                .effective_labels(NODE_DID)
+                .iter()
+                .any(|(k, v)| k == &format!("group/{group_uri}") && v == "true"));
+        }
+    }
+
+    #[tokio::test]
+    async fn reingesting_a_did_replaces_its_prior_contribution() {
+        let rec_a = sample_node_record(vec![]);
+        let car_a = repo_car(NODE_DID, &[(node_record_key("3a"), rec_a.to_dag_cbor())]);
+        let resolver_a = FixedResolver {
+            repos: HashMap::from([(NODE_DID.to_owned(), car_a)]),
+        };
+        let index = PlacementIndex::new();
+        index.ingest_did(&resolver_a, NODE_DID).await.unwrap();
+        assert_eq!(index.declared_resources(NODE_DID).len(), 1);
+
+        // Re-poll with an empty repo (record deleted upstream) — must clear, not
+        // leave the stale entry around forever.
+        let resolver_b = FixedResolver { repos: HashMap::new() };
+        index.ingest_did(&resolver_b, NODE_DID).await.unwrap();
+        assert!(index.known_node_dids().is_empty(), "stale contribution must be cleared on re-poll");
+    }
+}

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -17,16 +17,76 @@ use crate::generated::discovery_client::{
     RegisterEntityStatementRequest, RegisterEnvelopeKeysetRequest,
     EntityStatement, EnvelopeKeyset, IssuerList,
     GetRecordRequest, RecordCar,
-    QueryCandidatesRequest,
+    QueryCandidatesRequest, NodeLiveness, PlacementCandidate, PlacementCandidateSet, Resource,
     dispatch_discovery, serialize_response,
 };
+use crate::placement_index::PlacementIndex;
+use crate::scheduling;
 
 use anyhow::Result;
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use parking_lot::RwLock;
 use tracing::{trace, info};
+use hyprstream_rpc::identity::Did;
+use hyprstream_util::ttl_cache::TtlCache;
+
+/// #524 P1 — liveness heartbeat TTL: a node with no live/fresh
+/// `reportNodeLiveness` entry is hard-excluded from `queryCandidates`
+/// (ratified decision — see the epic's issue comments), never just flagged
+/// stale. 45s sits mid-range of the 30-60s window floated in earlier design
+/// notes; named here so it's easy to retune.
+const LIVENESS_TTL: Duration = Duration::from_secs(45);
+
+/// Liveness cache capacity / inline-reap budget. Generous fleet-scale
+/// headroom; eviction is O(log n) and happens inline on every insert/get, so a
+/// large bound doesn't cost anything until it's actually full.
+const LIVENESS_CACHE_MAX_ENTRIES: usize = 16_384;
+const LIVENESS_CACHE_REAP_BUDGET: usize = 32;
+
+/// Default bound applied to `queryCandidates` when the caller passes
+/// `maxCandidates == 0` (unspecified) — keeps an unscoped query from returning
+/// the entire fleet in one response.
+const DEFAULT_MAX_CANDIDATES: usize = 100;
+
+/// One node's live allocatable capacity + load, as reported via
+/// `reportNodeLiveness`. Stored in a `TtlCache<Did, _>` — absence (never
+/// reported, or expired) hard-excludes the node from `queryCandidates`.
+#[derive(Clone, Debug)]
+struct LiveAllocatable {
+    /// resource name -> k8s-quantity, free right now.
+    allocatable: Vec<(String, String)>,
+    load_fraction: f32,
+    /// unix millis of this snapshot.
+    last_seen: i64,
+}
+
+fn unix_millis_now() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+/// Convert the wire `SelectorOp` (generated from `discovery.capnp`) to the
+/// shared scheduling-substrate `SelectorOp` (`crate::scheduling`, #628).
+/// Deliberately exhaustive (no catch-all) so a future wire variant fails to
+/// compile here instead of silently matching nothing.
+fn to_scheduling_op(
+    op: crate::generated::discovery_client::SelectorOp,
+) -> scheduling::SelectorOp {
+    use crate::generated::discovery_client::SelectorOp as Wire;
+    match op {
+        Wire::In => scheduling::SelectorOp::In,
+        Wire::NotIn => scheduling::SelectorOp::NotIn,
+        Wire::Exists => scheduling::SelectorOp::Exists,
+        Wire::DoesNotExist => scheduling::SelectorOp::DoesNotExist,
+        Wire::Gt => scheduling::SelectorOp::Gt,
+        Wire::Lt => scheduling::SelectorOp::Lt,
+    }
+}
 
 // ============================================================================
 // AuthorizationProvider trait (D5)
@@ -187,6 +247,15 @@ pub struct DiscoveryService {
     tls_endorsement: Vec<u8>,
     /// Domain the TLS endorsement covers (empty when no endorsement).
     tls_domain: String,
+    /// #524 P1 — durable placement directory (labels/declared-resources/group
+    /// consents), refreshed by polling `record_resolver` lazily: the first
+    /// `reportNodeLiveness` heartbeat seen for a DID with no ingested
+    /// `NodeRecord` yet triggers a poll of its repo.
+    placement_index: PlacementIndex,
+    /// #524 P1 — live allocatable capacity + load per node, TTL'd
+    /// (`LIVENESS_TTL`). Backs the hard-exclusion-on-staleness rule in
+    /// `queryCandidates`.
+    liveness: TtlCache<Did, LiveAllocatable>,
     // Infrastructure (for Spawnable)
     transport: TransportConfig,
 }
@@ -216,6 +285,8 @@ impl DiscoveryService {
             envelope_keysets: RwLock::new(HashMap::new()),
             tls_endorsement: Vec::new(),
             tls_domain: String::new(),
+            placement_index: PlacementIndex::new(),
+            liveness: TtlCache::new(LIVENESS_CACHE_MAX_ENTRIES, LIVENESS_CACHE_REAP_BUDGET),
             transport,
         }
     }
@@ -917,21 +988,208 @@ impl DiscoveryHandler for DiscoveryService {
         }
     }
 
-    /// #523 P0 / #524 — placement candidate query. The vocabulary + filter/rank/
-    /// select helpers landed in `crate::scheduling` (#628); the live
-    /// directory + authz-prefiltered handler is P1's job (#524). Stubbed here
-    /// so the RPC surface compiles; returns UNIMPLEMENTED until P1 wires it.
+    /// #523 P0 / #524 — placement candidate query. The auto-generated dispatch
+    /// gate already ran a `discovery:QueryCandidates`/`query` authz check
+    /// before this handler was invoked; that only authorizes "may call
+    /// queryCandidates at all". Each surviving candidate additionally gets its
+    /// own fail-closed `placement:candidate:<did>` check below (a denied node
+    /// is silently omitted, not surfaced as an error) — mirroring why
+    /// `getRecord`/`getRepo` layer a per-target check on top of the generic gate.
+    ///
+    /// Pipeline: known node DIDs (placement directory) → hard-exclude any
+    /// without a live `reportNodeLiveness` entry (decision: absence/expiry is
+    /// exclusion, never a "stale" flag) → sync filter (label selectors AND,
+    /// resource requests AND) via `scheduling::filter` → per-candidate async
+    /// authz → rank (ascending load, DID tiebreak) via `scheduling::rank` →
+    /// bound to `maxCandidates` (or [`DEFAULT_MAX_CANDIDATES`] when 0).
+    /// `totalMatching` is the authorized-survivor count *before* the bound.
     async fn handle_query_candidates(
+        &self,
+        ctx: &EnvelopeContext,
+        _request_id: u64,
+        data: &QueryCandidatesRequest,
+    ) -> Result<DiscoveryResponseVariant> {
+        struct Candidate {
+            did: String,
+            record_uri: String,
+            load_fraction: f32,
+            allocatable: Vec<(String, String)>,
+            last_seen: i64,
+            labels: Vec<(String, String)>,
+        }
+
+        let selectors: Vec<scheduling::LabelSelector> = data
+            .selectors
+            .iter()
+            .map(|s| scheduling::LabelSelector::new(s.key.clone(), to_scheduling_op(s.op), s.values.clone()))
+            .collect();
+        let resources: Vec<scheduling::ResourceRequest> = data
+            .resources
+            .iter()
+            .map(|r| scheduling::ResourceRequest::new(r.name.clone(), r.min_quantity.clone()))
+            .collect();
+
+        // Hard liveness exclusion (decision #1): only nodes with a live,
+        // unexpired `reportNodeLiveness` entry become candidates at all.
+        let candidates: Vec<Candidate> = self
+            .placement_index
+            .known_node_dids()
+            .into_iter()
+            .filter_map(|did| {
+                let live = self.liveness.get(&Did::new(did.clone()))?;
+                let labels = self.placement_index.effective_labels(&did);
+                let record_uri = self.placement_index.record_uri(&did).unwrap_or_default();
+                Some(Candidate {
+                    did,
+                    record_uri,
+                    load_fraction: live.load_fraction,
+                    allocatable: live.allocatable,
+                    last_seen: live.last_seen,
+                    labels,
+                })
+            })
+            .collect();
+
+        let predicates: Vec<scheduling::Predicate<Candidate>> = vec![
+            Box::new({
+                let selectors = selectors.clone();
+                move |c: &Candidate| {
+                    for sel in &selectors {
+                        if !sel.matches(&c.labels) {
+                            return Some(scheduling::RejectionReason(format!(
+                                "label selector on {:?} did not match",
+                                sel.key
+                            )));
+                        }
+                    }
+                    None
+                }
+            }),
+            Box::new({
+                let resources = resources.clone();
+                move |c: &Candidate| {
+                    for req in &resources {
+                        let satisfied = c
+                            .allocatable
+                            .iter()
+                            .find(|(name, _)| name == &req.name)
+                            .is_some_and(|(_, quantity)| req.satisfied_by(quantity));
+                        if !satisfied {
+                            return Some(scheduling::RejectionReason(format!(
+                                "resource {:?} not satisfied",
+                                req.name
+                            )));
+                        }
+                    }
+                    None
+                }
+            }),
+        ];
+
+        let outcomes = scheduling::filter(&candidates, &predicates);
+        let survivors: Vec<&Candidate> = outcomes.iter().filter(|o| o.passed()).map(|o| o.candidate).collect();
+
+        // Per-candidate fail-closed authz — async, so it runs as its own pass
+        // rather than inside a (sync) `scheduling::Predicate` closure. A denied
+        // node is silently dropped, never surfaced as an error.
+        let mut authorized: Vec<&Candidate> = Vec::with_capacity(survivors.len());
+        for c in survivors {
+            let resource = format!("placement:candidate:{}", c.did);
+            if self.authorize(ctx, &resource, "query").await.is_ok() {
+                authorized.push(c);
+            }
+        }
+
+        // Post-filter, post-authz, pre-bound — so callers can tell truncation
+        // apart from "that's really all of them".
+        let total_matching = authorized.len() as u32;
+
+        let ranked = scheduling::rank(authorized, |a, b| {
+            a.load_fraction
+                .partial_cmp(&b.load_fraction)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.did.cmp(&b.did))
+        });
+
+        let max = if data.max_candidates == 0 {
+            DEFAULT_MAX_CANDIDATES
+        } else {
+            data.max_candidates as usize
+        };
+        let candidates_out: Vec<PlacementCandidate> = ranked
+            .into_iter()
+            .take(max)
+            .map(|c| PlacementCandidate {
+                node: c.did.clone(),
+                record_uri: c.record_uri.clone(),
+                load_fraction: c.load_fraction,
+                allocatable: c
+                    .allocatable
+                    .iter()
+                    .map(|(name, quantity)| Resource {
+                        name: name.clone(),
+                        quantity: quantity.clone(),
+                    })
+                    .collect(),
+                last_seen: c.last_seen,
+            })
+            .collect();
+
+        Ok(DiscoveryResponseVariant::QueryCandidatesResult(PlacementCandidateSet {
+            candidates: candidates_out,
+            total_matching,
+        }))
+    }
+
+    /// #524 P1 — node liveness heartbeat. The auto-generated dispatch gate
+    /// already ran a `discovery:ReportNodeLiveness`/`write` authz check before
+    /// this handler was invoked (mirrors `handle_announce`, which needs no
+    /// additional internal check for the same reason).
+    ///
+    /// Re-inserting (heartbeating) the same node refreshes its TTL entry. The
+    /// first heartbeat seen for a DID this directory hasn't ingested a
+    /// `NodeRecord` for yet lazily triggers a one-shot poll of that DID's repo
+    /// (day-1 ingestion cadence — see the `placement_index` module docs); a
+    /// failure there does not fail the heartbeat itself.
+    async fn handle_report_node_liveness(
         &self,
         _ctx: &EnvelopeContext,
         _request_id: u64,
-        _data: &QueryCandidatesRequest,
+        data: &NodeLiveness,
     ) -> Result<DiscoveryResponseVariant> {
-        Ok(DiscoveryResponseVariant::Error(ErrorInfo {
-            message: "queryCandidates not yet wired (P1 placement directory; see #524)".to_owned(),
-            code: "UNIMPLEMENTED".to_owned(),
-            details: String::new(),
-        }))
+        let node_did = data.node.as_str().to_owned();
+        if node_did.is_empty() {
+            return Ok(DiscoveryResponseVariant::Error(ErrorInfo {
+                message: "node is required".to_owned(),
+                code: "INVALID_ARGUMENT".to_owned(),
+                details: String::new(),
+            }));
+        }
+
+        let live = LiveAllocatable {
+            allocatable: data
+                .allocatable
+                .iter()
+                .map(|r| (r.name.clone(), r.quantity.clone()))
+                .collect(),
+            load_fraction: data.load_fraction,
+            last_seen: if data.ts != 0 { data.ts } else { unix_millis_now() },
+        };
+        self.liveness.insert(data.node.clone(), live, LIVENESS_TTL);
+
+        if self.placement_index.record_uri(&node_did).is_none() {
+            if let Some(resolver) = &self.record_resolver {
+                if let Err(e) = self.placement_index.ingest_did(resolver.as_ref(), &node_did).await {
+                    tracing::warn!(
+                        node = %node_did,
+                        error = %e,
+                        "placement directory ingestion failed for heartbeating node (liveness still recorded)"
+                    );
+                }
+            }
+        }
+
+        Ok(DiscoveryResponseVariant::ReportNodeLivenessResult)
     }
 }
 
@@ -1276,5 +1534,273 @@ mod get_record_tests {
         let block_cids: std::collections::BTreeSet<PdsCid> =
             blocks.iter().map(|(c, _)| *c).collect();
         assert!(block_cids.contains(&target_cid));
+    }
+}
+
+// ============================================================================
+// #524 P1 — queryCandidates / reportNodeLiveness handler tests
+// ============================================================================
+
+#[cfg(test)]
+mod query_candidates_tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+    use super::*;
+
+    use std::collections::BTreeMap;
+
+    use hyprstream_pds::car::build_car_v1;
+    use hyprstream_pds::cid::Cid;
+    use hyprstream_pds::commit::{Commit, UnsignedCommit};
+    use hyprstream_pds::mst::Node;
+    use hyprstream_pds::placement::node::{self, NodeRecord};
+    use hyprstream_pds::tid::Tid;
+    use crate::generated::discovery_client::{LabelSelector, SelectorOp, ResourceRequest};
+    use p256::ecdsa::SigningKey as P256SigningKey;
+
+    /// Allows every (resource, operation) pair.
+    struct AllowAll;
+    #[async_trait(?Send)]
+    impl AuthorizationProvider for AllowAll {
+        async fn check(&self, _subject: &str, _domain: &str, _resource: &str, _operation: &str) -> Result<bool> {
+            Ok(true)
+        }
+    }
+
+    /// Denies exactly the `placement:candidate:<did>` resource for one DID;
+    /// allows everything else (including the dispatch-level auto-gate checks).
+    struct DenyNode(String);
+    #[async_trait(?Send)]
+    impl AuthorizationProvider for DenyNode {
+        async fn check(&self, _subject: &str, _domain: &str, resource: &str, _operation: &str) -> Result<bool> {
+            Ok(resource != format!("placement:candidate:{}", self.0))
+        }
+    }
+
+    /// A resolver serving one fixed repo CAR per DID (built with a real
+    /// `NodeRecord` encoding — not hand-hacked bytes).
+    struct FixedRepoResolver {
+        repos: HashMap<String, Vec<u8>>,
+    }
+    #[async_trait(?Send)]
+    impl RecordResolver for FixedRepoResolver {
+        async fn resolve_record(&self, _did: &str, _collection: &str, _rkey: &str) -> Result<Option<RecordCarData>> {
+            Ok(None)
+        }
+        async fn resolve_repo(&self, did: &str) -> Result<Option<RecordCarData>> {
+            Ok(self
+                .repos
+                .get(did)
+                .map(|car| RecordCarData { uri: format!("at://{did}"), car: car.clone() }))
+        }
+    }
+
+    /// Build a one-record repo CAR for `did` carrying `rec` as its
+    /// `ai.hyprstream.placement.node` record.
+    fn node_repo_car(did: &str, rec: &NodeRecord) -> Vec<u8> {
+        let signing_key = P256SigningKey::random(&mut rand::rngs::OsRng);
+        let key = format!("{}/3a", node::COLLECTION_NSID);
+        let record_cid = Cid::from_dag_cbor(&rec.to_dag_cbor());
+        let mut keyed: BTreeMap<String, Cid> = BTreeMap::new();
+        keyed.insert(key, record_cid);
+        let tree = Node::from_keyed_records(&keyed);
+        let root = tree.root_cid();
+        let (_root_data, node_blocks) = tree.to_node_data_with_blocks();
+        let unsigned = UnsignedCommit::new(did.to_owned(), root, Tid::now(), None);
+        let commit = Commit::sign(&unsigned, &signing_key);
+        let mut blocks: Vec<(Cid, Vec<u8>)> = vec![(commit.cid(), commit.to_dag_cbor())];
+        for (cid, data) in node_blocks {
+            blocks.push((cid, data.encode()));
+        }
+        blocks.push((record_cid, rec.to_dag_cbor()));
+        build_car_v1(&[commit.cid()], &blocks)
+    }
+
+    fn sample_node_record(did: &str, labels: Vec<(&str, &str)>) -> NodeRecord {
+        NodeRecord::new(
+            format!("at://{did}"),
+            labels
+                .into_iter()
+                .map(|(k, v)| node::Label { key: k.to_owned(), value: v.to_owned() })
+                .collect(),
+            vec![],
+            vec![],
+            "2026-06-23T12:34:56.789Z",
+        )
+        .unwrap()
+    }
+
+    fn service_with(auth: Box<dyn AuthorizationProvider>, repos: HashMap<String, Vec<u8>>) -> DiscoveryService {
+        let (sk, vk) = hyprstream_rpc::crypto::generate_signing_keypair();
+        DiscoveryService::new(
+            Arc::new(sk),
+            vk,
+            hyprstream_rpc::transport::TransportConfig::inproc("query-candidates-test"),
+        )
+        .with_auth_provider(auth)
+        .with_record_resolver(Box::new(FixedRepoResolver { repos }))
+    }
+
+    fn test_ctx() -> EnvelopeContext {
+        EnvelopeContext::from_callback_service(1, "test-caller")
+    }
+
+    async fn heartbeat(svc: &DiscoveryService, did: &str, allocatable: Vec<(&str, &str)>, load_fraction: f32) {
+        let req = NodeLiveness {
+            node: Did::new(did.to_owned()),
+            allocatable: allocatable
+                .into_iter()
+                .map(|(n, q)| Resource { name: n.to_owned(), quantity: q.to_owned() })
+                .collect(),
+            load_fraction,
+            ts: 0,
+        };
+        let resp = svc.handle_report_node_liveness(&test_ctx(), 1, &req).await.unwrap();
+        assert!(matches!(resp, DiscoveryResponseVariant::ReportNodeLivenessResult));
+    }
+
+    fn empty_query(max_candidates: u32) -> QueryCandidatesRequest {
+        QueryCandidatesRequest { selectors: vec![], resources: vec![], max_candidates }
+    }
+
+    fn as_set(resp: DiscoveryResponseVariant) -> PlacementCandidateSet {
+        match resp {
+            DiscoveryResponseVariant::QueryCandidatesResult(s) => s,
+            other => panic!("expected QueryCandidatesResult, got {other:?}"),
+        }
+    }
+
+    /// A node with an ingested NodeRecord but NO liveness heartbeat must never
+    /// appear — absence is hard exclusion, not a "stale" flag (decision #1).
+    #[tokio::test]
+    async fn liveness_hard_excludes_nodes_never_heartbeated() {
+        let did = "did:web:node1.example.com";
+        let rec = sample_node_record(did, vec![("zone", "us-east")]);
+        let svc = service_with(Box::new(AllowAll), HashMap::from([(did.to_owned(), node_repo_car(did, &rec))]));
+
+        let set = as_set(svc.handle_query_candidates(&test_ctx(), 1, &empty_query(0)).await.unwrap());
+        assert!(set.candidates.is_empty());
+        assert_eq!(set.total_matching, 0);
+    }
+
+    #[tokio::test]
+    async fn label_selector_matches_and_excludes_non_matching_nodes() {
+        let did_a = "did:web:node-a.example.com";
+        let did_b = "did:web:node-b.example.com";
+        let repos = HashMap::from([
+            (did_a.to_owned(), node_repo_car(did_a, &sample_node_record(did_a, vec![("zone", "us-east")]))),
+            (did_b.to_owned(), node_repo_car(did_b, &sample_node_record(did_b, vec![("zone", "us-west")]))),
+        ]);
+        let svc = service_with(Box::new(AllowAll), repos);
+        heartbeat(&svc, did_a, vec![], 0.1).await;
+        heartbeat(&svc, did_b, vec![], 0.1).await;
+
+        let req = QueryCandidatesRequest {
+            selectors: vec![LabelSelector {
+                key: "zone".to_owned(),
+                op: SelectorOp::In,
+                values: vec!["us-east".to_owned()],
+            }],
+            resources: vec![],
+            max_candidates: 0,
+        };
+        let set = as_set(svc.handle_query_candidates(&test_ctx(), 1, &req).await.unwrap());
+        assert_eq!(set.candidates.len(), 1);
+        assert_eq!(set.candidates[0].node, did_a);
+        assert_eq!(set.total_matching, 1);
+    }
+
+    #[tokio::test]
+    async fn resource_request_filters_insufficient_live_capacity() {
+        let did = "did:web:node1.example.com";
+        let rec = sample_node_record(did, vec![]);
+        let svc = service_with(Box::new(AllowAll), HashMap::from([(did.to_owned(), node_repo_car(did, &rec))]));
+        heartbeat(&svc, did, vec![("nvidia.com/gpu", "2")], 0.1).await;
+
+        let req = QueryCandidatesRequest {
+            selectors: vec![],
+            resources: vec![ResourceRequest { name: "nvidia.com/gpu".to_owned(), min_quantity: "4".to_owned() }],
+            max_candidates: 0,
+        };
+        let set = as_set(svc.handle_query_candidates(&test_ctx(), 1, &req).await.unwrap());
+        assert!(set.candidates.is_empty(), "2 GPUs must not satisfy a request for >=4");
+
+        // A satisfiable request against the same live report succeeds.
+        let req_ok = QueryCandidatesRequest {
+            selectors: vec![],
+            resources: vec![ResourceRequest { name: "nvidia.com/gpu".to_owned(), min_quantity: "1".to_owned() }],
+            max_candidates: 0,
+        };
+        let set_ok = as_set(svc.handle_query_candidates(&test_ctx(), 1, &req_ok).await.unwrap());
+        assert_eq!(set_ok.candidates.len(), 1);
+    }
+
+    /// THE LOAD-BEARING TEST: a per-candidate authz denial silently drops that
+    /// node from the result — it is not surfaced as an RPC error.
+    #[tokio::test]
+    async fn per_candidate_authz_denial_is_silent_not_an_error() {
+        let did_a = "did:web:node-a.example.com";
+        let did_b = "did:web:node-b.example.com";
+        let repos = HashMap::from([
+            (did_a.to_owned(), node_repo_car(did_a, &sample_node_record(did_a, vec![]))),
+            (did_b.to_owned(), node_repo_car(did_b, &sample_node_record(did_b, vec![]))),
+        ]);
+        let svc = service_with(Box::new(DenyNode(did_a.to_owned())), repos);
+        heartbeat(&svc, did_a, vec![], 0.1).await;
+        heartbeat(&svc, did_b, vec![], 0.1).await;
+
+        let resp = svc.handle_query_candidates(&test_ctx(), 1, &empty_query(0)).await.unwrap();
+        let set = as_set(resp);
+        assert_eq!(set.candidates.len(), 1);
+        assert_eq!(set.candidates[0].node, did_b);
+        assert_eq!(set.total_matching, 1, "denied candidate must not inflate totalMatching");
+    }
+
+    #[tokio::test]
+    async fn bounding_respects_max_candidates_and_total_matching_is_pre_bound() {
+        let dids: Vec<String> = (0..5).map(|i| format!("did:web:node{i}.example.com")).collect();
+        let mut repos = HashMap::new();
+        for d in &dids {
+            repos.insert(d.clone(), node_repo_car(d, &sample_node_record(d, vec![])));
+        }
+        let svc = service_with(Box::new(AllowAll), repos);
+        for (i, d) in dids.iter().enumerate() {
+            heartbeat(&svc, d, vec![], i as f32 * 0.1).await;
+        }
+
+        let set = as_set(svc.handle_query_candidates(&test_ctx(), 1, &empty_query(2)).await.unwrap());
+        assert_eq!(set.candidates.len(), 2, "bounded to maxCandidates");
+        assert_eq!(set.total_matching, 5, "totalMatching counts all authorized survivors, not just the bound");
+        // Ranked ascending by load_fraction: node0 (0.0) then node1 (0.1).
+        assert_eq!(set.candidates[0].node, dids[0]);
+        assert_eq!(set.candidates[1].node, dids[1]);
+    }
+
+    #[tokio::test]
+    async fn zero_max_candidates_uses_default_bound() {
+        let dids: Vec<String> = (0..3).map(|i| format!("did:web:node{i}.example.com")).collect();
+        let mut repos = HashMap::new();
+        for d in &dids {
+            repos.insert(d.clone(), node_repo_car(d, &sample_node_record(d, vec![])));
+        }
+        let svc = service_with(Box::new(AllowAll), repos);
+        for d in &dids {
+            heartbeat(&svc, d, vec![], 0.0).await;
+        }
+        let set = as_set(svc.handle_query_candidates(&test_ctx(), 1, &empty_query(0)).await.unwrap());
+        assert_eq!(set.candidates.len(), 3, "under the default bound, all 3 come back");
+    }
+
+    #[tokio::test]
+    async fn heartbeat_refreshes_ttl_and_liveness_fields() {
+        let did = "did:web:node1.example.com";
+        let rec = sample_node_record(did, vec![]);
+        let svc = service_with(Box::new(AllowAll), HashMap::from([(did.to_owned(), node_repo_car(did, &rec))]));
+        heartbeat(&svc, did, vec![("cpu", "1")], 0.9).await;
+        heartbeat(&svc, did, vec![("cpu", "8")], 0.1).await;
+
+        let set = as_set(svc.handle_query_candidates(&test_ctx(), 1, &empty_query(0)).await.unwrap());
+        assert_eq!(set.candidates.len(), 1);
+        assert!((set.candidates[0].load_fraction - 0.1).abs() < f32::EPSILON, "second heartbeat must win");
+        assert_eq!(set.candidates[0].allocatable[0].quantity, "8");
     }
 }

--- a/crates/hyprstream-pds/src/mst.rs
+++ b/crates/hyprstream-pds/src/mst.rs
@@ -225,10 +225,25 @@ impl Node {
     pub fn from_records(collection: &str, records: &BTreeMap<Tid, Cid>) -> Self {
         // Sorted keys (BTreeMap over Tid already gives ascending rkey order; we
         // form the full `<collection>/<rkey>` strings and build from there).
-        let keys: Vec<(String, Cid)> = records
+        let keyed: BTreeMap<String, Cid> = records
             .iter()
             .map(|(tid, cid)| (record_key(collection, *tid), *cid))
             .collect();
+        Self::from_keyed_records(&keyed)
+    }
+
+    /// Build an MST from already-formed full record keys (`"<collection>/<rkey>"`)
+    /// to record CID.
+    ///
+    /// Unlike [`Self::from_records`] (single collection, keyed by [`Tid`]), this
+    /// accepts keys spanning *multiple* collections in one tree — the real
+    /// atproto shape (one MST per account repo, not per collection; a repo's
+    /// records live at keys like `ai.hyprstream.model/<rkey>` and
+    /// `ai.hyprstream.placement.node/<rkey>` side by side in the same tree).
+    /// A directory walker enumerates a collection's records by filtering
+    /// entries whose key starts with `"<collection>/"`.
+    pub fn from_keyed_records(records: &BTreeMap<String, Cid>) -> Self {
+        let keys: Vec<(String, Cid)> = records.iter().map(|(k, v)| (k.clone(), *v)).collect();
         if keys.is_empty() {
             return Node::empty();
         }
@@ -625,6 +640,59 @@ mod tests {
             proof.verify(&root, &wrong).is_err(),
             "proof must reject a wrong record"
         );
+    }
+
+    #[test]
+    fn mst_from_keyed_records_mixes_collections() {
+        // A repo's MST spans multiple collections side by side — build one
+        // directly from full keys (no single `collection` argument) and confirm
+        // every entry's key + value round-trips through the node blocks.
+        let mut keyed: BTreeMap<String, Cid> = BTreeMap::new();
+        for i in 0..4u64 {
+            let (tid, rec) = make_record(i);
+            keyed.insert(
+                format!("{}/{}", crate::record::COLLECTION_NSID, tid.encode()),
+                rec.cid(),
+            );
+        }
+        for i in 0..3u64 {
+            let cid = Cid::from_dag_cbor(format!("placement-node-{i}").as_bytes());
+            keyed.insert(format!("ai.hyprstream.placement.node/synthetic-{i}"), cid);
+        }
+        let tree = Node::from_keyed_records(&keyed);
+        let (root_data, blocks) = tree.to_node_data_with_blocks();
+        assert_eq!(root_data.cid(), tree.root_cid());
+
+        // Walk all node blocks and collect every entry's (key, value) — cross
+        // check against the input map by reconstructing keys the same way the
+        // directory walker will (see hyprstream-discovery's placement_index).
+        let block_map: BTreeMap<Cid, NodeData> = blocks.into_iter().collect();
+        let mut found: BTreeMap<String, Cid> = BTreeMap::new();
+        fn walk(cid: Cid, blocks: &BTreeMap<Cid, NodeData>, out: &mut BTreeMap<String, Cid>) {
+            let data = blocks.get(&cid).expect("block present");
+            if let Some(l) = data.l {
+                walk(l, blocks, out);
+            }
+            let mut prev: Option<String> = None;
+            for entry in &data.e {
+                let key = match &prev {
+                    Some(p) => {
+                        let take = entry.p.min(p.len());
+                        let mut full = p.as_bytes()[..take].to_vec();
+                        full.extend_from_slice(&entry.k);
+                        String::from_utf8(full).expect("utf8 key")
+                    }
+                    None => String::from_utf8(entry.k.clone()).expect("utf8 key"),
+                };
+                out.insert(key.clone(), entry.v);
+                prev = Some(key);
+                if let Some(t) = entry.t {
+                    walk(t, blocks, out);
+                }
+            }
+        }
+        walk(tree.root_cid(), &block_map, &mut found);
+        assert_eq!(found, keyed, "walked entries must match the input key set exactly");
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/identity.rs
+++ b/crates/hyprstream-rpc/src/identity.rs
@@ -31,10 +31,11 @@ use crate::Subject;
 /// live as DID-document verification methods.
 ///
 /// Wire representation is `Text`; serde (de)serializes transparently as the inner string.
-/// Cloneable, hashable, and usable as a map key.
+/// Cloneable, hashable, orderable (lexicographic on the inner string), and usable as a map
+/// key — including ordered maps / `TtlCache<Did, _>` (#524 placement liveness directory).
 /// `Default` yields an empty DID (`Did("")`) — the generated capnp data structs that carry a
 /// `Did` field derive `Default`, and an absent `Text` field reads back as the empty string.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct Did(String);
 
 impl Did {

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -728,6 +728,15 @@ fn create_model_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnabl
         }
     }
 
+    // #523 P3 mesh-authz gate: the enrolled mesh_peers roster maps a routed
+    // NodeId to its per-host subject (`service:inference:host-<label>`).
+    // Empty `mesh_peers` (mesh/federation not configured) yields an empty
+    // roster — every non-co-located candidate then fails closed (denied),
+    // never silently skipped. See `select_inference_server` / `mesh_authz_gate`.
+    model_service = model_service.with_mesh_identity_roster(std::sync::Arc::new(
+        crate::auth::mesh_trust::build_mesh_identity_roster(&config.oauth),
+    ));
+
     Ok(ctx.into_spawnable_quic(model_service, config.model.quic_port))
 }
 

--- a/crates/hyprstream/src/services/model.rs
+++ b/crates/hyprstream/src/services/model.rs
@@ -146,6 +146,16 @@ pub struct ModelServiceInner {
     /// federation; `resolve_model_ref`'s at:// branch then falls through to
     /// local resolution.
     discovery_client: Option<Arc<hyprstream_discovery::DiscoveryClient>>,
+    /// Mesh peer identity roster (#328): enrolled Ed25519 node id → per-host
+    /// mesh-authz `Subject` (`service:inference:host-<label>`), built from
+    /// operator-configured `mesh_peers` via
+    /// [`crate::auth::mesh_trust::build_mesh_identity_roster`]. Consumed by
+    /// [`ModelService::mesh_authz_gate`] (#523 P3) to resolve a routed
+    /// [`crate::services::router::NodeId`] before the fail-closed #319/#328
+    /// policy check. `None` = no roster configured (e.g. federation/mesh not
+    /// enabled) — every non-co-located candidate is then denied by
+    /// [`ModelService::resolve_mesh_subject`], never silently skipped.
+    mesh_identity_roster: Option<Arc<Vec<([u8; 32], hyprstream_rpc::Subject)>>>,
     /// Persistent 9P synthetic tree for the fs scope (lazily initialized).
     fs_tree: std::sync::OnceLock<crate::services::fs::SyntheticTree>,
 }
@@ -215,6 +225,26 @@ pub fn model_ref_dispatch(s: &str) -> ModelRefDispatch<'_> {
     }
 }
 
+/// Outcome of [`ModelService::route_decision`] — which arm of the replica
+/// set HRW/least-loaded selected, kept separate from `InferenceClient`
+/// construction so the pure ranking decision is unit-testable without a
+/// live [`LoadedModel`] (no `InferenceClient`/`SpawnedService` required).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RouteDecision {
+    /// The router selected the co-located replica (`load_state`'s
+    /// co-located entry) — the in-process fast path, no dial, no mesh
+    /// policy fires (same trust domain).
+    CoLocated,
+    /// The router selected a DIFFERENT (non-co-located) replica from the
+    /// resolved candidate set. #282 has not wired a cross-host dial yet,
+    /// so callers still fall back to the co-located client — but only
+    /// AFTER running the #319/#328 mesh-authz gate against this node.
+    Remote(crate::services::router::NodeId),
+    /// No healthy candidate at all (every entry excluded as down/stalled,
+    /// or the replica set is empty).
+    NoHealthyCandidate,
+}
+
 impl ModelService {
     /// Create a new model service with infrastructure
     pub async fn new(
@@ -247,6 +277,7 @@ impl ModelService {
             expected_audience: None,
             jwt_key_source: None,
             discovery_client: None,
+            mesh_identity_roster: None,
             fs_tree: std::sync::OnceLock::new(),
         })})
     }
@@ -294,6 +325,23 @@ impl ModelService {
         self
     }
 
+    /// Set the mesh peer identity roster for the #319/#328 mesh-authz gate
+    /// (#523 P3), typically built via
+    /// [`crate::auth::mesh_trust::build_mesh_identity_roster`].
+    ///
+    /// # Panics
+    /// Panics if called after the service has been cloned (Arc refcount > 1).
+    #[allow(clippy::expect_used)]
+    pub fn with_mesh_identity_roster(
+        mut self,
+        roster: Arc<Vec<([u8; 32], hyprstream_rpc::Subject)>>,
+    ) -> Self {
+        Arc::get_mut(&mut self.inner)
+            .expect("with_mesh_identity_roster must be called before service is shared")
+            .mesh_identity_roster = Some(roster);
+        self
+    }
+
     /// Derive the deterministic InferenceService transport for a model ref (#320).
     ///
     /// Resolved via the registry (the local [`hyprstream_rpc::Resolver`] backend):
@@ -326,57 +374,157 @@ impl ModelService {
             .collect()
     }
 
-    /// Router seam (#322 leaf cell-router over the #320 single-select base):
-    /// pick ONE InferenceService for a request from a loaded model's replica
-    /// set, applying capacity-weighted HRW + session affinity.
+    /// Pure HRW/least-loaded + session-affinity ranking decision (#523 P3):
+    /// which candidate in `load_state` the router picked for `session_id`,
+    /// classified against the co-located node. Contains no I/O and no
+    /// `InferenceClient` — reused directly by unit tests that construct a
+    /// synthetic multi-entry `load_state` without needing a live model.
+    fn route_decision(
+        router: &mut crate::services::router::CellRouter,
+        load_state: &[crate::services::router::InferenceServerInfo],
+        co_located: crate::services::router::NodeId,
+        session_id: &str,
+        now: Instant,
+    ) -> RouteDecision {
+        match router.place(session_id, load_state, now) {
+            Some(placement) if placement.node_id == co_located => RouteDecision::CoLocated,
+            Some(placement) => RouteDecision::Remote(placement.node_id),
+            None => RouteDecision::NoHealthyCandidate,
+        }
+    }
+
+    /// Router seam (#322 leaf cell-router over the #320 single-select base,
+    /// unified with #523 P3): pick ONE InferenceService for a request from a
+    /// loaded model's replica set, applying capacity-weighted HRW +
+    /// least-loaded + session affinity (via [`Self::route_decision`] /
+    /// `CellRouter::place`) over the P1 candidate set resolved into
+    /// `load_state`.
     ///
-    /// Today a model still maps 1:1 to one co-located InferenceService, so the
-    /// router's `load_state` has a single entry and HRW trivially picks it; the
-    /// fast path returns the in-process `model.client` directly (no dial). When
-    /// the replica set grows (cross-host reaches resolved via the Resolver per
-    /// the federated-model-addressing spike), this is where HRW single-selects a
-    /// networked (Iroh) reach and dials it. The router body operates on the
-    /// resolved replica set; OID/reach resolution is the entry's job.
+    /// Today a model still maps 1:1 to one co-located InferenceService in the
+    /// common case, so `load_state` has a single entry and HRW trivially picks
+    /// it; the fast path returns the in-process `model.client` directly (no
+    /// dial). `load_state` grows to multiple entries once cross-host replicas
+    /// are resolved into it (tracked separately — see the module-level P3 PR
+    /// notes); when HRW picks a non-co-located entry, the #319/#328 mesh-authz
+    /// gate below runs BEFORE any (still not-yet-wired, #282) dial would
+    /// happen, so enforcement is already fail-closed the moment #282 adds the
+    /// dial. The router body operates on the resolved replica set; OID/reach
+    /// resolution is the entry's job.
     ///
     /// `session_id` is the placement key (defaults to "default" when the caller
     /// has no session — keeps HRW stable for non-session-scoped requests like
     /// `apply_chat_template`).
-    fn select_inference_server(
+    async fn select_inference_server(
+        &self,
         model: &mut LoadedModel,
         session_id: &str,
     ) -> InferenceClient {
         let now = Instant::now();
-        if let Some(placement) = model.router.place(session_id, &model.load_state, now) {
-            // In v1 the co-located node is always in the replica set (seeded at
-            // load). If HRW picks it, use the in-process fast path — no dial.
-            if placement.node_id == Self::co_located_node_id(model) {
-                return model.client.clone();
+        let co_located = Self::co_located_node_id(model);
+        match Self::route_decision(&mut model.router, &model.load_state, co_located, session_id, now) {
+            RouteDecision::CoLocated => model.client.clone(),
+            RouteDecision::Remote(node_id) => {
+                // AUTHZ SEAM (#319/#328 mesh policy): a co-located `Inproc`
+                // selection never reaches here (handled above) — it's an
+                // in-process call within the same trust domain, so no mesh
+                // policy fires there. A non-co-located selection DOES reach
+                // here; gate it fail-closed against the target host identity
+                // BEFORE any dial (the dial itself stays a documented no-op —
+                // cross-host inference spawn/discovery is deferred to #282).
+                self.mesh_authz_gate(&model.model_ref, node_id, session_id).await;
+                debug!(
+                    "router placed session {session_id} on remote node {:?} but no \
+                     networked dial path is wired yet (#282) — using co-located fallback",
+                    node_id
+                );
+                model.client.clone()
             }
-            // Networked selection: a future branch dials the chosen Iroh reach
-            // (after the #319/#328 mesh-authz gate). Not wired in v1 — fall back
-            // to the co-located client so requests still succeed while the
-            // federation entry is being built. See the AUTHZ SEAM note below.
+            RouteDecision::NoHealthyCandidate => {
+                warn!(
+                    "router found no healthy placement for session {session_id} \
+                     (replica set empty or every entry excluded) — using co-located fallback"
+                );
+                model.client.clone()
+            }
+        }
+    }
+
+    /// #319/#328 mesh-authz gate: fail-closed check that a routed
+    /// non-co-located node's host identity is authorized for `mesh.rpc`
+    /// (the inference peer-call umbrella right) before any networked dial
+    /// would occur. Resolves `node_id` to its per-host subject
+    /// (`service:inference:host-<label>`) via the enrolled `mesh_peers`
+    /// roster (#328) — an un-enrolled node (or no roster configured at all)
+    /// resolves to `None`, which is treated as denied, never as "skip the
+    /// check". The Casbin decision itself is evaluated by `PolicyService`
+    /// against the `mesh-host` template (deny-by-default, never wildcard).
+    ///
+    /// No cross-host dial exists yet (#282), so this call's outcome does not
+    /// change today's fallback-to-co-located behavior — it only logs the
+    /// decision. Wiring it now means the gate is fail-closed and already in
+    /// place the instant #282 adds the dial, rather than a TODO discovered
+    /// under time pressure later.
+    async fn mesh_authz_gate(
+        &self,
+        model_ref: &str,
+        node_id: crate::services::router::NodeId,
+        session_id: &str,
+    ) {
+        let subject = Self::resolve_mesh_subject(
+            self.mesh_identity_roster.as_deref().map(Vec::as_slice),
+            node_id,
+        );
+        let Some(subject) = subject else {
+            warn!(
+                "mesh-authz: node {node_id:?} is not an enrolled mesh_peers host — \
+                 denying mesh.rpc for session {session_id} on model {model_ref} \
+                 (fail closed, #319/#328)"
+            );
+            return;
+        };
+        let resource = format!("mesh://inference/{model_ref}");
+        let allowed = self
+            .policy_client
+            .check(&PolicyCheck {
+                subject: subject.to_string(),
+                domain: "*".to_owned(),
+                resource,
+                operation: "mesh.rpc".to_owned(),
+            })
+            .await
+            .unwrap_or_else(|e| {
+                warn!(
+                    "mesh-authz: policy check failed for {subject} on model {model_ref}: \
+                     {e} — denying (fail closed)"
+                );
+                false
+            });
+        if allowed {
             debug!(
-                "router placed session {session_id} on remote node {:?} but no \
-                 networked dial path is wired yet — using co-located fallback",
-                placement.node_id
+                "mesh-authz: {subject} authorized for mesh.rpc on model {model_ref} \
+                 (dial not wired yet, #282)"
+            );
+        } else {
+            warn!(
+                "mesh-authz: denied mesh.rpc for {subject} on model {model_ref} \
+                 (session {session_id})"
             );
         }
-        model.client.clone()
+    }
 
-        // AUTHZ SEAM (#319/#328 mesh policy) — GAP, intentionally not wired here:
-        // a co-located `Inproc` selection is an in-process call within the same
-        // trust domain, so no mesh policy fires. When this seam grows a branch
-        // that DIALS a networked (Iroh) reach to a remote InferenceService, that
-        // dial MUST first be gated by the #319 mesh check on the target host
-        // identity — `mesh.rpc` / `infer.stage` for the `service:inference:host-<id>`
-        // subject in the tenant domain (the `mesh-host` policy template in
-        // `auth::policy_templates`, deny-by-default, never wildcard). The vocab +
-        // per-host identity (`node_identity::inference_host_subject`) exist; the
-        // enforcement call belongs on that future networked branch, not on the
-        // co-located fast path. (Per-host identity:
-        // `hyprstream_rpc::node_identity::mesh_host_subject`.) Cross-host
-        // inference spawn/discovery is deferred to #282.
+    /// Resolve a routed [`NodeId`](crate::services::router::NodeId) to its
+    /// per-host mesh-authz [`Subject`] via the enrolled `mesh_peers` roster
+    /// (#328). Pure/no I/O — split out so the fail-closed resolution rule
+    /// (`None` roster or unmatched node ⇒ `None` ⇒ deny) is directly
+    /// unit-testable.
+    fn resolve_mesh_subject(
+        roster: Option<&[([u8; 32], hyprstream_rpc::Subject)]>,
+        node_id: crate::services::router::NodeId,
+    ) -> Option<hyprstream_rpc::Subject> {
+        roster?
+            .iter()
+            .find(|(id, _)| *id == node_id)
+            .map(|(_, s)| s.clone())
     }
 
     /// Identity of the co-located InferenceService = our own Ed25519 verifying
@@ -903,7 +1051,7 @@ impl ModelService {
         // swap it in here — the router body is session_id-keyed, not
         // subject-keyed, by design.
         let placement_key = ctx.subject().to_string();
-        let client = Self::select_inference_server(model, &placement_key);
+        let client = self.select_inference_server(model, &placement_key).await;
         // TODO: Forward user JWT to worker via per-call builder (delegated_bearer or
         // request().jwt(token).call(payload)) once inference methods support CallOptions.
         // The previous with_jwt() call was mutating shared state — unsafe with pooling.
@@ -1862,5 +2010,179 @@ mod tests {
                 "local ModelRef '{s}' must still parse after #395"
             );
         }
+    }
+
+    // ========================================================================
+    // #523 P3 — route_decision (HRW/least-loaded + session affinity ranking)
+    //
+    // `route_decision` is pure (no `InferenceClient`/`SpawnedService`), so
+    // these tests build a `CellRouter` + synthetic `load_state` directly,
+    // proving the ranking substrate without needing a live `LoadedModel`.
+    // The `CellRouter`/`InferenceServerInfo` ranking machinery itself is
+    // already exhaustively covered in `services::router::tests`; these tests
+    // cover `route_decision`'s CoLocated/Remote/NoHealthyCandidate
+    // classification specifically, which is new in this PR.
+    // ========================================================================
+
+    use crate::services::router::{CellRouter, InferenceServerInfo};
+
+    fn server(id: u8, mem_free: u64, active: u64) -> InferenceServerInfo {
+        InferenceServerInfo {
+            node_id: [id; 32],
+            transport: TransportConfig::inproc("test"),
+            gpu_memory_free: mem_free,
+            active_sessions: active,
+            last_heartbeat: Instant::now(),
+        }
+    }
+
+    /// Degenerate/solo case (acceptance criterion): a single-entry replica set
+    /// (today's actual `load_state` shape at load time) always classifies as
+    /// `CoLocated` — no regression from pre-P3 behavior.
+    #[test]
+    fn route_decision_single_replica_is_co_located() {
+        let co_located = [0x10; 32];
+        let load_state = vec![server(0x10, 1024, 0)];
+        let mut router = CellRouter::default();
+        let decision = ModelService::route_decision(
+            &mut router,
+            &load_state,
+            co_located,
+            "sess-A",
+            Instant::now(),
+        );
+        assert_eq!(decision, RouteDecision::CoLocated);
+    }
+
+    /// Multi-replica (synthetic `load_state`, per the PR notes on the P1
+    /// candidate-population gap): HRW must be able to select a NON-co-located
+    /// entry, classified as `Remote`, distributing distinct sessions across
+    /// more than one node — the acceptance criterion's "requests distribute
+    /// by HRW/least-loaded over live candidates" proven at this layer.
+    #[test]
+    fn route_decision_multi_replica_distributes_and_detects_remote() {
+        let co_located = [0x10; 32];
+        let load_state = vec![
+            server(0x10, 16 * 1024 * 1024 * 1024, 0), // co-located
+            server(0x20, 16 * 1024 * 1024 * 1024, 0), // remote
+            server(0x30, 16 * 1024 * 1024 * 1024, 0), // remote
+        ];
+        let mut saw_co_located = false;
+        let mut saw_remote = false;
+        for i in 0..150u32 {
+            // Fresh router per session avoids affinity stickiness masking the
+            // underlying HRW spread this test wants to observe.
+            let mut router = CellRouter::default();
+            match ModelService::route_decision(
+                &mut router,
+                &load_state,
+                co_located,
+                &format!("sess-{i}"),
+                Instant::now(),
+            ) {
+                RouteDecision::CoLocated => saw_co_located = true,
+                RouteDecision::Remote(_) => saw_remote = true,
+                RouteDecision::NoHealthyCandidate => panic!("healthy replica set must place"),
+            }
+        }
+        assert!(saw_co_located, "some sessions must land on the co-located replica");
+        assert!(saw_remote, "some sessions must land on a remote replica (not always co-located)");
+    }
+
+    /// Session affinity holds: the same session_id must classify identically
+    /// across repeated calls on the SAME router instance (KV-cache stickiness),
+    /// whether it lands co-located or remote.
+    #[test]
+    fn route_decision_session_affinity_holds() {
+        let co_located = [0x10; 32];
+        let load_state = vec![
+            server(0x10, 16 * 1024 * 1024 * 1024, 0),
+            server(0x20, 16 * 1024 * 1024 * 1024, 0),
+            server(0x30, 16 * 1024 * 1024 * 1024, 0),
+        ];
+        let mut router = CellRouter::default();
+        let now = Instant::now();
+        let first = ModelService::route_decision(&mut router, &load_state, co_located, "sess-sticky", now);
+        for _ in 0..5 {
+            let again = ModelService::route_decision(&mut router, &load_state, co_located, "sess-sticky", now);
+            assert_eq!(first, again, "same session must stick to the same replica within its lease");
+        }
+    }
+
+    /// Fail-over on replica loss: once the affinity-bound node is marked down
+    /// (dial-fail), the NEXT `route_decision` for the same session must
+    /// reassign to a different node rather than returning the excluded one.
+    #[test]
+    fn route_decision_fails_over_on_replica_loss() {
+        let co_located = [0x10; 32];
+        let load_state = vec![
+            server(0x10, 16 * 1024 * 1024 * 1024, 0),
+            server(0x20, 16 * 1024 * 1024 * 1024, 0),
+            server(0x30, 16 * 1024 * 1024 * 1024, 0),
+        ];
+        let mut router = CellRouter::default();
+        let now = Instant::now();
+        let first = ModelService::route_decision(&mut router, &load_state, co_located, "sess-B", now);
+        let first_node = match first {
+            RouteDecision::CoLocated => co_located,
+            RouteDecision::Remote(n) => n,
+            RouteDecision::NoHealthyCandidate => panic!("healthy replica set must place"),
+        };
+        router.report_dial_fail(first_node, now);
+        let second = ModelService::route_decision(&mut router, &load_state, co_located, "sess-B", now);
+        let second_node = match second {
+            RouteDecision::CoLocated => co_located,
+            RouteDecision::Remote(n) => n,
+            RouteDecision::NoHealthyCandidate => panic!("two healthy replicas remain after one failure"),
+        };
+        assert_ne!(second_node, first_node, "must fail over off the down replica");
+    }
+
+    /// Empty/all-excluded replica set classifies as `NoHealthyCandidate` (the
+    /// caller's fallback-to-co-located-client path), never a panic.
+    #[test]
+    fn route_decision_empty_replica_set_is_no_healthy_candidate() {
+        let co_located = [0x10; 32];
+        let load_state: Vec<InferenceServerInfo> = vec![];
+        let mut router = CellRouter::default();
+        let decision = ModelService::route_decision(
+            &mut router,
+            &load_state,
+            co_located,
+            "sess-A",
+            Instant::now(),
+        );
+        assert_eq!(decision, RouteDecision::NoHealthyCandidate);
+    }
+
+    // ========================================================================
+    // #523 P3 / #319 / #328 — resolve_mesh_subject (mesh-authz gate resolution)
+    // ========================================================================
+
+    #[test]
+    fn resolve_mesh_subject_none_roster_denies() {
+        // No roster configured (mesh/federation not enabled) must resolve to
+        // `None` — the caller treats this as deny, never as "skip the check".
+        assert_eq!(ModelService::resolve_mesh_subject(None, [0x10; 32]), None);
+    }
+
+    #[test]
+    fn resolve_mesh_subject_unenrolled_node_denies() {
+        let roster = vec![([0x20u8; 32], hyprstream_rpc::Subject::new("service:inference:host-known"))];
+        assert_eq!(
+            ModelService::resolve_mesh_subject(Some(&roster), [0x99; 32]),
+            None,
+            "a node absent from the roster must resolve to None (fail closed)"
+        );
+    }
+
+    #[test]
+    fn resolve_mesh_subject_enrolled_node_resolves() {
+        let subject = hyprstream_rpc::Subject::new("service:inference:host-gpu-3");
+        let roster = vec![([0x20u8; 32], subject.clone())];
+        assert_eq!(
+            ModelService::resolve_mesh_subject(Some(&roster), [0x20; 32]),
+            Some(subject)
+        );
     }
 }


### PR DESCRIPTION
## Summary

Implements P3 of epic #523: replaces `select_inference_server`'s trivial single-entry pick with real HRW/least-loaded + session-affinity ranking over a model's replica set, and wires the previously-documented `#319`/`#328` mesh-authz gap at the routing seam.

- **`route_decision`** — a new pure classification (`CoLocated` / `Remote(NodeId)` / `NoHealthyCandidate`) factored out of `select_inference_server`, reusing `CellRouter::place` (capacity-weighted HRW + least-loaded + session affinity) rather than reimplementing selection. Pure/no I/O, so it's directly unit-testable against a synthetic multi-entry `load_state` without a live `LoadedModel`.
- **Mesh-authz gate (`mesh_authz_gate`/`resolve_mesh_subject`)** — when routing selects a non-co-located candidate, it now resolves that node to its per-host `Subject` (`service:inference:host-<label>`) via an enrolled `mesh_peers` roster and runs the existing `mesh.rpc` Casbin check *before* any dial would happen. No roster configured, or the node absent from it, resolves to `None` and is treated as **denied** — never silently skipped. This closes the gap the code's own prior comment flagged as intentionally unwired.
- **`factories.rs`** — builds the roster from operator-configured `mesh_peers` via `auth::mesh_trust::build_mesh_identity_roster` (already existing, with its own tests) and wires it into `ModelService` at construction.

## Explicitly deferred (not this PR)

**Actual cross-host dialing is #282's job, not this one's.** When `route_decision` returns `Remote`, this PR still falls back to the co-located client (today's existing, documented behavior) — it does *not* fabricate a working networked dial. The point of wiring the mesh-authz gate now is so enforcement is already fail-closed and in place the moment #282 adds a real dial, rather than a TODO discovered later under time pressure.

**Multi-replica `load_state` population itself is a separate concern.** `load_state` is still seeded with a single co-located entry at model load in the common case; this PR proves the ranking/gating logic is correct via synthetic multi-entry `load_state` in tests, but the "how does a second replica's entry actually get into `load_state`" plumbing is not part of this change.

## Judgment calls flagging for reviewer sign-off (per this ticket's own 🔒 gates)

- **🔒 Mesh-authz sign-off**: the `mesh_identity_roster`'s shape (`Vec<([u8; 32], Subject)>`, built once at service construction from `mesh_peers` config) and the `mesh.rpc` resource string (`mesh://inference/{model_ref}`) are new surface — please confirm this matches the intended `#319`/`#328` policy shape before merge.
- **🔒 No capnp change** — this PR is pure Rust-side routing/authz logic; no wire-format changes were needed for this scope.
- The roster is rebuilt once at `create_model_service` time from static config (no live re-enrollment/rotation path) — reasonable for a first cut, flagged in case operators expect dynamic mesh_peers changes to take effect without a restart.

## Tests

- `route_decision`: solo/degenerate case (no regression), multi-replica distribution (proves non-co-located candidates are reachable), session-affinity stickiness, fail-over on replica loss, empty replica set.
- `resolve_mesh_subject`: no roster (deny), node absent from roster (deny), enrolled node (resolves).
- All 17 `services::model` tests + all 22 `services::router` tests pass; existing router/affinity test suite untouched and still green (no regression to session affinity or HRW itself, since this PR reuses `CellRouter::place` rather than reimplementing it).

`cargo build -p hyprstream`, `cargo test -p hyprstream --lib services::model:: / services::router::`, and targeted `cargo clippy -p hyprstream --lib --all-targets` are all clean (verified after rebasing onto current `main`, since #755/#754 merged during this work).

Part of epic #523, phase P3 (#526). Relates: #319/#328 (mesh-authz), #322 (closed router lineage this unifies with), #282 (deferred cross-host dial), #383/#329 (orthogonal placement dimensions, untouched).