### PR TITLE
P2 (#525): scheduler decision engine — admission/queue + resource-aware placement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7289,6 +7289,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tokio-util",
+ "toml 0.8.23",
  "tonic 0.12.3",
  "tower 0.4.13",
  "tracing",

--- a/crates/hyprstream-workers/Cargo.toml
+++ b/crates/hyprstream-workers/Cargo.toml
@@ -289,6 +289,8 @@ hyprstream-rpc-build = { workspace = true }
 [dev-dependencies]
 tokio-test = { workspace = true }
 tempfile = { workspace = true }
+# F3 (#761) admission-config TOML round-trip regression test.
+toml = "0.8"
 # FS-B0 RAFS bootstrap builder tests: synthesize small OCI layer tarballs.
 tar = "0.4"
 flate2 = "1"

--- a/crates/hyprstream-workers/src/config.rs
+++ b/crates/hyprstream-workers/src/config.rs
@@ -285,6 +285,43 @@ mod tests {
     }
 
     #[test]
+    fn test_worker_config_toml_roundtrips_at_defaults() -> Result<(), Box<dyn std::error::Error>> {
+        // F3 regression: the default `AdmissionConfig` used to set
+        // `max_per_subject`/`max_per_group` to `usize::MAX`, which is not a
+        // valid TOML i64 — `toml::to_string_pretty` errored, breaking any
+        // `Config::save()` that included a `[worker]` section. The unlimited
+        // quotas are now `Option<usize>` serialized as *absent*, so a default
+        // config must round-trip through TOML cleanly.
+        let config = WorkerConfig::default();
+        let toml_str = toml::to_string_pretty(&config)?;
+        // Unlimited quotas serialize as absent, never as a giant sentinel int.
+        assert!(
+            !toml_str.contains("max_per_subject"),
+            "unlimited per-subject quota must serialize as absent, got:\n{toml_str}"
+        );
+        assert!(!toml_str.contains("max_per_group"));
+        let parsed: WorkerConfig = toml::from_str(&toml_str)?;
+        assert_eq!(parsed.pool.admission.max_per_subject, None);
+        assert_eq!(parsed.pool.admission.max_per_group, None);
+        assert_eq!(parsed.pool.max_sandboxes, config.pool.max_sandboxes);
+        Ok(())
+    }
+
+    #[test]
+    fn test_worker_config_toml_roundtrips_with_explicit_quotas(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // A set quota must round-trip as a normal integer.
+        let mut config = WorkerConfig::default();
+        config.pool.admission.max_per_subject = Some(4);
+        config.pool.admission.max_per_group = Some(16);
+        let toml_str = toml::to_string_pretty(&config)?;
+        let parsed: WorkerConfig = toml::from_str(&toml_str)?;
+        assert_eq!(parsed.pool.admission.max_per_subject, Some(4));
+        assert_eq!(parsed.pool.admission.max_per_group, Some(16));
+        Ok(())
+    }
+
+    #[test]
     fn test_hypervisor_type_serialization() -> Result<(), Box<dyn std::error::Error>> {
         // Test default (cloud-hypervisor)
         let config = PoolConfig::default();

--- a/crates/hyprstream-workers/src/config.rs
+++ b/crates/hyprstream-workers/src/config.rs
@@ -9,6 +9,8 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+use crate::runtime::AdmissionConfig;
+
 /// Default value for [`WorkerConfig::backend`].
 ///
 /// `"auto"` asks the runtime to pick the highest-priority *available* registered
@@ -128,6 +130,16 @@ pub struct PoolConfig {
 
     /// Timeout for sandbox stop in seconds
     pub stop_timeout_secs: u64,
+
+    /// Admission control: per-Subject/per-group quotas, bounded wait-queue,
+    /// and declared local schedulable capacity for `SandboxPool::acquire`'s
+    /// decision engine (#525 P2).
+    ///
+    /// 🔒 See [`AdmissionConfig`]'s doc for the judgment calls this shape
+    /// bakes in (flagged for reviewer sign-off). Defaults are unconstrained,
+    /// so an operator who does not set this section gets exactly the
+    /// pre-#525 behavior (only `max_sandboxes` capacity is enforced).
+    pub admission: AdmissionConfig,
 }
 
 impl Default for PoolConfig {
@@ -145,6 +157,7 @@ impl Default for PoolConfig {
             vm_cpus: 2,
             create_timeout_secs: 60,
             stop_timeout_secs: 30,
+            admission: AdmissionConfig::default(),
         }
     }
 }

--- a/crates/hyprstream-workers/src/error.rs
+++ b/crates/hyprstream-workers/src/error.rs
@@ -31,6 +31,26 @@ pub enum WorkerError {
     SandboxTimeout { operation: String, timeout_secs: u64 },
 
     // ─────────────────────────────────────────────────────────────────────
+    // Admission control errors (#525 P2 — SandboxPool::acquire decision engine)
+    // ─────────────────────────────────────────────────────────────────────
+    /// Per-Subject or per-group quota exceeded. Fail-fast: unlike capacity
+    /// exhaustion, a quota rejection never queues (retrying immediately
+    /// cannot help until the Subject/group's own active count drops).
+    #[error("Admission denied: {reason}")]
+    AdmissionDenied { reason: String },
+
+    /// The bounded admission wait-queue was already at capacity when this
+    /// request arrived — rejected immediately rather than silently blocking
+    /// past the configured bound.
+    #[error("Admission queue full: {waiting} waiting (bound {bound})")]
+    QueueFull { waiting: usize, bound: usize },
+
+    /// A request queued for capacity did not get admitted within the
+    /// configured wait timeout.
+    #[error("Admission queue wait timed out after {timeout_secs}s")]
+    QueueTimeout { timeout_secs: u64 },
+
+    // ─────────────────────────────────────────────────────────────────────
     // VM Errors
     // ─────────────────────────────────────────────────────────────────────
     #[error("VM start failed: {0}")]

--- a/crates/hyprstream-workers/src/error.rs
+++ b/crates/hyprstream-workers/src/error.rs
@@ -50,6 +50,14 @@ pub enum WorkerError {
     #[error("Admission queue wait timed out after {timeout_secs}s")]
     QueueTimeout { timeout_secs: u64 },
 
+    /// Demand exceeds this node's *configured totals* (e.g. a GPU request on a
+    /// node that declares no GPU capacity, or memory above the declared total)
+    /// — no release can ever satisfy it. Rejected immediately rather than
+    /// queued, so callers can distinguish "never fits here" from "busy right
+    /// now" (`QueueTimeout`).
+    #[error("Admission infeasible: {reason}")]
+    AdmissionInfeasible { reason: String },
+
     // ─────────────────────────────────────────────────────────────────────
     // VM Errors
     // ─────────────────────────────────────────────────────────────────────

--- a/crates/hyprstream-workers/src/runtime/admission.rs
+++ b/crates/hyprstream-workers/src/runtime/admission.rs
@@ -31,20 +31,30 @@
 //!    Full Casbin-backed quota configuration (e.g. deriving `max_per_subject`
 //!    from a Casbin role/policy rather than a flat config value) is a
 //!    follow-up.
-//! 2. **"Group" identity**: there is no first-class "group" claim on
-//!    [`hyprstream_rpc::auth::Claims`] today. `derive_group` reads it from a
-//!    plain annotation (`hyprstream.io/group`) on the request rather than
-//!    inventing a new capnp field or claim — deliberately, to avoid a
-//!    wire-format change here. This is a placeholder pending a real
-//!    tenant/group model.
-//! 3. **Wait-queue fairness**: the queue is a single bounded FIFO-ish
-//!    structure (all waiters are woken on every release and re-race for the
-//!    lock), *not* the per-Subject/per-group fair sub-queue + weighted-
-//!    round-robin the issue's design note describes. Quota-rejected requests
-//!    never queue (they fail fast), which limits one noisy Subject's ability
-//!    to starve others out of the *quota* axis, but the *capacity* wait queue
-//!    itself has no per-key fairness weighting. Flagged as a scope-down, not
-//!    a silent omission.
+//! 2. **"Group" derivation (B′, ratified in #921 decision 5)**: the group is
+//!    derived from the **verified [`Subject`], never trusted from the
+//!    annotation**. The `hyprstream.io/group` annotation is only a *selector*
+//!    among groups the Subject provably belongs to; a
+//!    [`GroupSelectorValidator`] resolves it against the authoritative
+//!    membership source (the bidirectional-consent placement group,
+//!    `ai.hyprstream.placement.{group,groupItem}` / `PlacementIndex::is_member`).
+//!    A selector naming a group the Subject is not a member of is **rejected**;
+//!    an absent selector means **no group partition** (never a quota bypass).
+//!    The default [`DenyUnknownGroupValidator`] is fail-closed: it denies every
+//!    non-empty selector until a membership-backed validator is wired, so an
+//!    unverified group can never partition capacity. See point 3 for what the
+//!    counter itself means.
+//! 3. **Wait-queue fairness**: the queue is a single bounded **FIFO** — new
+//!    arrivals never barge past a non-empty queue, and each release hands
+//!    capacity to the queue *head* (rather than waking all waiters to
+//!    thundering-herd re-race). This eliminates the starvation the blocking
+//!    review flagged (a queued waiter losing every re-race under sustained
+//!    arrival). The tradeoff is **head-of-line blocking**: a large demand at
+//!    the head can block a smaller demand behind it even when capacity for the
+//!    smaller one exists. That is the conservative choice; a per-Subject/
+//!    per-group fair sub-queue + weighted round-robin is the documented (not
+//!    implemented) follow-up. Quota- and infeasibility-rejected requests never
+//!    queue (they fail fast).
 //! 4. **GPU/resource vocabulary**: cpu/memory/GPU demand is read from
 //!    `config.linux.resources` (existing CRI-shaped fields) plus a new,
 //!    separate annotation `hyprstream.io/gpu-request` (a plain integer count,
@@ -52,10 +62,11 @@
 //!    `hyprstream.io/gpu` passthrough annotation consumed by `oci_backend`/
 //!    `nspawn`. The two are intentionally not unified in this change; see the
 //!    module docs on `pool.rs` for the full rationale.
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::Duration;
 
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, Notify};
 use tokio::time::Instant;
@@ -72,8 +83,12 @@ use super::client::{KeyValue, PodSandboxConfig};
 /// boolean `hyprstream.io/gpu` passthrough flag — see module docs, point 4.
 pub const ANN_GPU_REQUEST: &str = "hyprstream.io/gpu-request";
 
-/// Annotation key: the admission "group" this request belongs to (#525
-/// placeholder for a real tenant/group claim — see module docs, point 2).
+/// Annotation key: the group *selector* for this request (B′, #921 decision
+/// 5). This is **not** a trusted group claim — it only names which of the
+/// groups the verified [`Subject`] *provably belongs to* this request should
+/// be partitioned under. A [`GroupSelectorValidator`] resolves it against the
+/// authoritative membership source; a selector the Subject is not a member of
+/// is rejected. See module docs, point 2.
 pub const ANN_GROUP: &str = "hyprstream.io/group";
 
 fn annotation<'a>(annotations: &'a [KeyValue], key: &str) -> Option<&'a str> {
@@ -117,9 +132,12 @@ pub fn derive_demand(config: &PodSandboxConfig) -> Demand {
     }
 }
 
-/// Derive the admission "group" key for a request, if any (see module docs,
-/// point 2).
-pub fn derive_group(config: &PodSandboxConfig) -> Option<String> {
+/// Derive the group *selector* for a request, if any (the raw
+/// `hyprstream.io/group` annotation). This is an **untrusted** selector, not
+/// an authoritative group: it must be validated against the verified Subject's
+/// membership by a [`GroupSelectorValidator`] before it can partition capacity
+/// (B′ — see module docs, point 2).
+pub fn derive_group_selector(config: &PodSandboxConfig) -> Option<String> {
     annotation(&config.annotations, ANN_GROUP).map(str::to_owned)
 }
 
@@ -138,11 +156,25 @@ pub fn derive_group(config: &PodSandboxConfig) -> Option<String> {
 #[serde(default)]
 pub struct AdmissionConfig {
     /// Maximum concurrently-active sandboxes for a single Subject.
-    /// Default: unconstrained (`usize::MAX`).
-    pub max_per_subject: usize,
+    /// `None` (default) = unconstrained.
+    ///
+    /// Serialized as *absent* when unlimited (rather than a sentinel like
+    /// `usize::MAX`, which is not representable as a TOML i64 and would break
+    /// `Config::save()`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_per_subject: Option<usize>,
     /// Maximum concurrently-active sandboxes for a single group (see
-    /// [`derive_group`]). Default: unconstrained (`usize::MAX`).
-    pub max_per_group: usize,
+    /// [`derive_group_selector`]). `None` (default) = unconstrained.
+    ///
+    /// This counter is **node-local capacity partitioning** — a fairness /
+    /// organization mechanism, *not* a trust or billing boundary. The
+    /// authoritative quota is the ledger/capability path (#922/#925: verify
+    /// presented grant → debit cell ledger → emit receipt), which this module
+    /// deliberately does **not** implement. See module docs, point 2.
+    ///
+    /// Serialized as *absent* when unlimited (see [`Self::max_per_subject`]).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_per_group: Option<usize>,
     /// Bound on the number of callers allowed to wait in the admission queue
     /// at once. A request that would exceed this is rejected immediately
     /// (`QueueFull`) rather than queued.
@@ -167,8 +199,8 @@ pub struct AdmissionConfig {
 impl Default for AdmissionConfig {
     fn default() -> Self {
         Self {
-            max_per_subject: usize::MAX,
-            max_per_group: usize::MAX,
+            max_per_subject: None,
+            max_per_group: None,
             queue_capacity: 64,
             queue_timeout_secs: 30,
             cpu_millis_total: None,
@@ -191,7 +223,7 @@ pub struct ReservationRecord {
 /// `filter → rank → select` pipeline (see module docs on GPU/resource
 /// vocabulary). In the single-node/solo case this is the *only* candidate;
 /// the extension point for cross-node placement is `rank_by` in
-/// [`fit_report`] — feeding `queryCandidates` results in as additional
+/// [`fit_over_local_candidate`] — feeding `queryCandidates` results in as additional
 /// candidates here (with a real least-loaded/best-fit `rank_by`) is P2's
 /// documented (not implemented) cross-node extension.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -290,16 +322,22 @@ struct AdmissionState {
     cpu_millis_reserved: u64,
     memory_bytes_reserved: u64,
     gpu_reserved: usize,
-    /// Bounded wait-queue. On any release, every waiter here is woken and
-    /// re-races to retry admission under the lock (see module docs, sign-off
-    /// point 3, on why this is not a per-key fair sub-queue).
+    /// Bounded **FIFO** wait-queue. A release hands capacity to the *head*
+    /// (front) only; a new arrival never barges past a non-empty queue. See
+    /// module docs, point 3, for the head-of-line-blocking tradeoff and why
+    /// this is not yet a per-key fair sub-queue.
     queue: VecDeque<Arc<Notify>>,
 }
 
-/// Why [`try_admit_locked`] refused to admit — distinguishes *quota*
-/// (never queues; retrying won't help until the Subject/group frees up on
-/// its own) from *capacity* (may queue; a release elsewhere can free room).
+/// Why [`try_admit_locked`] refused to admit. Three failure classes with
+/// different queueing semantics:
+/// - `Infeasible`: demand exceeds the node's *configured totals* — no release
+///   can ever satisfy it. Never queues; immediate hard reject.
+/// - `Quota`: the Subject/group is at its per-key ceiling. Never queues;
+///   retrying won't help until that Subject/group frees up on its own.
+/// - `Capacity`: transient — a release elsewhere can free room. May queue.
 enum AdmitReject {
+    Infeasible(String),
     Quota(String),
     Capacity(String),
 }
@@ -317,21 +355,55 @@ fn try_admit_locked(
     cfg: &AdmissionConfig,
     max_sandboxes: usize,
 ) -> std::result::Result<(), AdmitReject> {
-    // ── Quota checks first: fail-closed, never queue ──
-    let subj_count = *state.active_by_subject.get(subject_key).unwrap_or(&0);
-    if subj_count >= cfg.max_per_subject {
-        return Err(AdmitReject::Quota(format!(
-            "subject '{subject_key}' at quota ({subj_count}/{})",
-            cfg.max_per_subject
+    // ── Feasibility first: demand exceeding the configured TOTALS (not just
+    //    the currently-free amount) can never be satisfied by any release, so
+    //    it must reject immediately rather than burn the whole queue_timeout.
+    //    Checked independently of `*_reserved`. ──
+    if max_sandboxes == 0 {
+        return Err(AdmitReject::Infeasible(
+            "pool declares zero schedulable capacity (max_sandboxes = 0)".to_owned(),
+        ));
+    }
+    if let Some(total) = cfg.cpu_millis_total {
+        if demand.cpu_millis > total {
+            return Err(AdmitReject::Infeasible(format!(
+                "cpu demand {}m exceeds node total {total}m",
+                demand.cpu_millis
+            )));
+        }
+    }
+    if let Some(total) = cfg.memory_bytes_total {
+        if demand.memory_bytes > total {
+            return Err(AdmitReject::Infeasible(format!(
+                "memory demand {} bytes exceeds node total {total} bytes",
+                demand.memory_bytes
+            )));
+        }
+    }
+    if demand.gpu > cfg.gpu_total {
+        return Err(AdmitReject::Infeasible(format!(
+            "gpu demand {} exceeds node total {}",
+            demand.gpu, cfg.gpu_total
         )));
     }
-    if let Some(g) = group_key {
-        let gcount = *state.active_by_group.get(g).unwrap_or(&0);
-        if gcount >= cfg.max_per_group {
+
+    // ── Quota checks: fail-closed, never queue ──
+    if let Some(max) = cfg.max_per_subject {
+        let subj_count = *state.active_by_subject.get(subject_key).unwrap_or(&0);
+        if subj_count >= max {
             return Err(AdmitReject::Quota(format!(
-                "group '{g}' at quota ({gcount}/{})",
-                cfg.max_per_group
+                "subject '{subject_key}' at quota ({subj_count}/{max})"
             )));
+        }
+    }
+    if let Some(g) = group_key {
+        if let Some(max) = cfg.max_per_group {
+            let gcount = *state.active_by_group.get(g).unwrap_or(&0);
+            if gcount >= max {
+                return Err(AdmitReject::Quota(format!(
+                    "group '{g}' at quota ({gcount}/{max})"
+                )));
+            }
         }
     }
 
@@ -370,6 +442,16 @@ fn try_admit_locked(
     Ok(())
 }
 
+/// Wake the current FIFO head (if any) so it retries admission. `Notify`
+/// stores one permit if the head isn't yet awaiting, so this never loses a
+/// wakeup. Idempotent-ish: a spurious extra wake just makes the head re-check
+/// under the lock.
+fn wake_head(state: &AdmissionState) {
+    if let Some(head) = state.queue.front() {
+        head.notify_one();
+    }
+}
+
 fn release_locked(state: &mut AdmissionState, record: &ReservationRecord) {
     state.active_total = state.active_total.saturating_sub(1);
     if let Some(c) = state.active_by_subject.get_mut(&record.subject) {
@@ -395,30 +477,165 @@ fn release_locked(state: &mut AdmissionState, record: &ReservationRecord) {
     state.gpu_reserved = state.gpu_reserved.saturating_sub(record.demand.gpu);
 }
 
+/// Resolves an untrusted group *selector* against the verified [`Subject`]'s
+/// membership (B′, ratified in #921 decision 5).
+///
+/// The group is **never** trusted from the annotation. The annotation is only
+/// a selector naming which of the groups the Subject *provably belongs to* a
+/// request should be partitioned under. This trait is the seam that resolves
+/// that selector against the authoritative membership source — the
+/// bidirectional-consent placement group
+/// (`ai.hyprstream.placement.{group,groupItem}` / `PlacementIndex::is_member`,
+/// in `hyprstream-pds`/`hyprstream-discovery`).
+///
+/// # Fail-closed
+///
+/// The default impl ([`DenyUnknownGroupValidator`]) denies **every** non-empty
+/// selector, so a pool constructed without an explicit membership-backed
+/// validator can never partition capacity by an unverified group. Wire a
+/// real membership-source-backed impl at construction (where the discovery /
+/// PDS client is available) to enable group partitioning.
+///
+/// Returning `Ok(None)` for an absent selector means **no group partition** —
+/// never a quota bypass.
+#[async_trait]
+pub trait GroupSelectorValidator: Send + Sync + std::fmt::Debug {
+    /// Resolve `selector` for `subject`:
+    /// - `Ok(None)` — no selector present → no group partition.
+    /// - `Ok(Some(group))` — selector validated: `subject` is a consented
+    ///   member of `group`, which becomes the authoritative partition key.
+    /// - `Err(_)` — selector present but `subject` is not a member → reject.
+    async fn validate(&self, subject: &Subject, selector: Option<&str>)
+        -> Result<Option<String>>;
+}
+
+/// Fail-closed default [`GroupSelectorValidator`]: denies every non-empty
+/// group selector (no membership source is wired), permits the absent-selector
+/// (no-partition) case. This is the production default until a real
+/// membership-backed validator is wired — an unverified group can never
+/// partition capacity.
+#[derive(Debug, Default)]
+pub struct DenyUnknownGroupValidator;
+
+#[async_trait]
+impl GroupSelectorValidator for DenyUnknownGroupValidator {
+    async fn validate(
+        &self,
+        _subject: &Subject,
+        selector: Option<&str>,
+    ) -> Result<Option<String>> {
+        match selector {
+            None => Ok(None),
+            Some(sel) => Err(WorkerError::AdmissionDenied {
+                reason: format!(
+                    "group selector '{sel}' cannot be verified: no membership source wired (fail-closed, B′)"
+                ),
+            }),
+        }
+    }
+}
+
+/// Reference [`GroupSelectorValidator`] backed by a static in-memory
+/// membership set (group → member Subject keys). Models the authoritative
+/// bidirectional-consent membership fact without the PDS/discovery plumbing;
+/// a production deployment wires an `is_member`-backed impl instead.
+#[derive(Debug, Default)]
+pub struct StaticGroupMembership {
+    members: HashMap<String, HashSet<String>>,
+}
+
+impl StaticGroupMembership {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record that `subject` is a consented member of `group`.
+    pub fn with_member(mut self, group: &str, subject: &str) -> Self {
+        self.members
+            .entry(group.to_owned())
+            .or_default()
+            .insert(subject.to_owned());
+        self
+    }
+}
+
+#[async_trait]
+impl GroupSelectorValidator for StaticGroupMembership {
+    async fn validate(
+        &self,
+        subject: &Subject,
+        selector: Option<&str>,
+    ) -> Result<Option<String>> {
+        match selector {
+            None => Ok(None),
+            Some(sel) => {
+                let subj = subject.name().unwrap_or("");
+                if self.members.get(sel).is_some_and(|m| m.contains(subj)) {
+                    Ok(Some(sel.to_owned()))
+                } else {
+                    Err(WorkerError::AdmissionDenied {
+                        reason: format!(
+                            "subject '{subj}' is not a consented member of group '{sel}'"
+                        ),
+                    })
+                }
+            }
+        }
+    }
+}
+
 /// Admission decision engine backing `SandboxPool::acquire` (#525 P2).
 #[derive(Debug)]
 pub struct AdmissionTracker {
     state: Mutex<AdmissionState>,
     config: AdmissionConfig,
     max_sandboxes: usize,
+    group_validator: Arc<dyn GroupSelectorValidator>,
 }
 
 impl AdmissionTracker {
+    /// Construct with the fail-closed [`DenyUnknownGroupValidator`] — the
+    /// production default until a membership-backed validator is wired
+    /// (any group selector is rejected; the no-selector case is unaffected).
     pub fn new(config: AdmissionConfig, max_sandboxes: usize) -> Self {
+        Self::with_group_validator(
+            config,
+            max_sandboxes,
+            Arc::new(DenyUnknownGroupValidator),
+        )
+    }
+
+    /// Construct with an explicit [`GroupSelectorValidator`] (e.g. one backed
+    /// by a real membership source, or a test double).
+    pub fn with_group_validator(
+        config: AdmissionConfig,
+        max_sandboxes: usize,
+        group_validator: Arc<dyn GroupSelectorValidator>,
+    ) -> Self {
         Self {
             state: Mutex::new(AdmissionState::default()),
             config,
             max_sandboxes,
+            group_validator,
         }
     }
 
-    /// Reserve capacity for `(subject, group, demand)`, fail-closed on
-    /// unauthenticated callers, queueing (bounded) when only *capacity* (not
-    /// quota) blocks admission.
+    /// Reserve capacity for `(subject, group_selector, demand)`, fail-closed on
+    /// unauthenticated callers, queueing (bounded, **FIFO**) when only
+    /// *capacity* (not quota/infeasibility) blocks admission.
+    ///
+    /// `group_selector` is the untrusted `hyprstream.io/group` annotation; it
+    /// is resolved against the verified Subject's membership by the configured
+    /// [`GroupSelectorValidator`] (B′). A selector the Subject is not a member
+    /// of is rejected; an absent selector means no group partition.
+    ///
+    /// FIFO (F4): a new arrival never barges past a non-empty queue, and each
+    /// release hands capacity to the queue head. See module docs, point 3, for
+    /// the head-of-line-blocking tradeoff.
     pub async fn reserve(
         &self,
         subject: &Subject,
-        group: Option<&str>,
+        group_selector: Option<&str>,
         demand: Demand,
     ) -> Result<ReservationRecord> {
         // Fail-closed identity: no verified Subject → reject before any
@@ -431,58 +648,118 @@ impl AdmissionTracker {
             });
         }
         let subject_key = subject.name().unwrap_or("").to_owned();
+
+        // B′: derive the authoritative group from the verified Subject, never
+        // trust the annotation. Rejects a selector the Subject is not a member
+        // of; `None` means no group partition.
+        let group: Option<String> = self
+            .group_validator
+            .validate(subject, group_selector)
+            .await?;
+        let group_key = group.as_deref();
+
         let deadline = Instant::now() + Duration::from_secs(self.config.queue_timeout_secs);
+        // Our place in the FIFO queue, once we join it. `None` until we first
+        // fail an admission attempt on *capacity* (or find the queue non-empty
+        // ahead of us).
+        let mut ticket: Option<Arc<Notify>> = None;
 
         loop {
-            let ticket = {
-                let mut state = self.state.lock().await;
-                match try_admit_locked(
-                    &mut state,
-                    &subject_key,
-                    group,
-                    demand,
-                    &self.config,
-                    self.max_sandboxes,
-                ) {
-                    Ok(()) => {
-                        return Ok(ReservationRecord {
-                            subject: subject_key,
-                            group: group.map(str::to_owned),
-                            demand,
-                        });
-                    }
-                    Err(AdmitReject::Quota(reason)) => {
-                        return Err(WorkerError::AdmissionDenied { reason });
-                    }
-                    Err(AdmitReject::Capacity(reason)) => {
-                        if state.queue.len() >= self.config.queue_capacity {
-                            return Err(WorkerError::QueueFull {
-                                waiting: state.queue.len(),
-                                bound: self.config.queue_capacity,
-                            });
-                        }
-                        tracing::debug!(subject = %subject_key, reason = %reason, "acquire: queueing for capacity");
-                        let ticket = Arc::new(Notify::new());
-                        state.queue.push_back(ticket.clone());
-                        ticket
-                    }
-                }
-            };
-
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            if remaining.is_zero() {
-                let mut state = self.state.lock().await;
-                state.queue.retain(|t| !Arc::ptr_eq(t, &ticket));
-                return Err(WorkerError::QueueTimeout {
-                    timeout_secs: self.config.queue_timeout_secs,
-                });
-            }
-            if tokio::time::timeout(remaining, ticket.notified())
-                .await
-                .is_err()
             {
                 let mut state = self.state.lock().await;
-                state.queue.retain(|t| !Arc::ptr_eq(t, &ticket));
+
+                // A caller may attempt admission only if nobody is ahead of it
+                // in the FIFO: it holds the head ticket, or it holds no ticket
+                // and the queue is empty (no barging past waiters — F4).
+                let may_attempt = match &ticket {
+                    Some(t) => state.queue.front().is_some_and(|h| Arc::ptr_eq(h, t)),
+                    None => state.queue.is_empty(),
+                };
+
+                if may_attempt {
+                    match try_admit_locked(
+                        &mut state,
+                        &subject_key,
+                        group_key,
+                        demand,
+                        &self.config,
+                        self.max_sandboxes,
+                    ) {
+                        Ok(()) => {
+                            if ticket.is_some() {
+                                state.queue.pop_front();
+                            }
+                            wake_head(&state);
+                            return Ok(ReservationRecord {
+                                subject: subject_key,
+                                group,
+                                demand,
+                            });
+                        }
+                        Err(AdmitReject::Infeasible(reason)) => {
+                            if ticket.is_some() {
+                                state.queue.pop_front();
+                                wake_head(&state);
+                            }
+                            return Err(WorkerError::AdmissionInfeasible { reason });
+                        }
+                        Err(AdmitReject::Quota(reason)) => {
+                            if ticket.is_some() {
+                                state.queue.pop_front();
+                                wake_head(&state);
+                            }
+                            return Err(WorkerError::AdmissionDenied { reason });
+                        }
+                        Err(AdmitReject::Capacity(reason)) => {
+                            if ticket.is_none() {
+                                if state.queue.len() >= self.config.queue_capacity {
+                                    return Err(WorkerError::QueueFull {
+                                        waiting: state.queue.len(),
+                                        bound: self.config.queue_capacity,
+                                    });
+                                }
+                                tracing::debug!(subject = %subject_key, reason = %reason, "acquire: queueing for capacity (FIFO)");
+                                let t = Arc::new(Notify::new());
+                                state.queue.push_back(t.clone());
+                                ticket = Some(t);
+                            }
+                            // else: we are the head and capacity still isn't
+                            // free — stay queued and wait again.
+                        }
+                    }
+                } else if ticket.is_none() {
+                    // Someone is ahead of us: join the back of the queue
+                    // (bounded) and wait our turn rather than barging.
+                    if state.queue.len() >= self.config.queue_capacity {
+                        return Err(WorkerError::QueueFull {
+                            waiting: state.queue.len(),
+                            bound: self.config.queue_capacity,
+                        });
+                    }
+                    let t = Arc::new(Notify::new());
+                    state.queue.push_back(t.clone());
+                    ticket = Some(t);
+                }
+            }
+
+            // Wait to be handed capacity (or to reach the head), bounded by the
+            // deadline. Every path that falls through to here has set `ticket`;
+            // the `None` arm is unreachable, so re-loop rather than panic.
+            let t = match &ticket {
+                Some(t) => t.clone(),
+                None => continue,
+            };
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let timed_out = remaining.is_zero()
+                || tokio::time::timeout(remaining, t.notified()).await.is_err();
+            if timed_out {
+                let mut state = self.state.lock().await;
+                let was_head = state.queue.front().is_some_and(|h| Arc::ptr_eq(h, &t));
+                state.queue.retain(|x| !Arc::ptr_eq(x, &t));
+                // If the head gave up, hand its turn to the next waiter.
+                if was_head {
+                    wake_head(&state);
+                }
                 return Err(WorkerError::QueueTimeout {
                     timeout_secs: self.config.queue_timeout_secs,
                 });
@@ -492,16 +769,12 @@ impl AdmissionTracker {
     }
 
     /// Give back a committed reservation (a sandbox using it was released or
-    /// destroyed) and wake queued waiters to retry.
+    /// destroyed) and hand the freed capacity to the FIFO queue head (F4 — no
+    /// thundering-herd re-race).
     pub async fn release(&self, record: &ReservationRecord) {
-        let queue = {
-            let mut state = self.state.lock().await;
-            release_locked(&mut state, record);
-            std::mem::take(&mut state.queue)
-        };
-        for ticket in queue {
-            ticket.notify_one();
-        }
+        let mut state = self.state.lock().await;
+        release_locked(&mut state, record);
+        wake_head(&state);
     }
 
     /// Give back a reservation that was committed but never resulted in a
@@ -551,10 +824,21 @@ mod tests {
         assert!(r.is_ok());
     }
 
+    /// Membership validator with alice + bob both consented members of
+    /// team-a — models the authoritative bidirectional-consent membership
+    /// fact so the group tests exercise quota, not the fail-closed default.
+    fn team_a_membership() -> Arc<dyn GroupSelectorValidator> {
+        Arc::new(
+            StaticGroupMembership::new()
+                .with_member("team-a", "alice")
+                .with_member("team-a", "bob"),
+        )
+    }
+
     #[tokio::test]
     async fn per_subject_quota_rejects_not_queues() {
         let cfg = AdmissionConfig {
-            max_per_subject: 1,
+            max_per_subject: Some(1),
             ..Default::default()
         };
         let tracker = AdmissionTracker::new(cfg, 10);
@@ -571,10 +855,10 @@ mod tests {
     #[tokio::test]
     async fn per_group_quota_rejects_across_subjects() {
         let cfg = AdmissionConfig {
-            max_per_group: 1,
+            max_per_group: Some(1),
             ..Default::default()
         };
-        let tracker = AdmissionTracker::new(cfg, 10);
+        let tracker = AdmissionTracker::with_group_validator(cfg, 10, team_a_membership());
         let r1 = tracker
             .reserve(&Subject::new("alice"), Some("team-a"), demand(0, 0, 0))
             .await;
@@ -585,6 +869,50 @@ mod tests {
         assert!(
             matches!(r2, Err(WorkerError::AdmissionDenied { .. })),
             "got: {r2:?}"
+        );
+    }
+
+    // ── B′: group is derived from the verified Subject, never trusted from
+    //    the annotation (F6) ────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn group_selector_from_non_member_is_rejected() {
+        // Only alice is a member of team-a.
+        let validator = Arc::new(StaticGroupMembership::new().with_member("team-a", "alice"));
+        let tracker =
+            AdmissionTracker::with_group_validator(AdmissionConfig::default(), 10, validator);
+        // A member's selector validates and partitions.
+        let r_alice = tracker
+            .reserve(&Subject::new("alice"), Some("team-a"), demand(0, 0, 0))
+            .await;
+        assert!(r_alice.is_ok(), "member's selector must validate: {r_alice:?}");
+        // A non-member asserting team-a is rejected — no cross-tenant quota
+        // consumption.
+        let r_bob = tracker
+            .reserve(&Subject::new("bob"), Some("team-a"), demand(0, 0, 0))
+            .await;
+        assert!(
+            matches!(r_bob, Err(WorkerError::AdmissionDenied { .. })),
+            "non-member selector must be rejected: {r_bob:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn deny_unknown_group_validator_rejects_any_selector_but_allows_none() {
+        // Default tracker uses the fail-closed DenyUnknownGroupValidator.
+        let tracker = AdmissionTracker::new(AdmissionConfig::default(), 10);
+        // No selector → no group partition, admitted.
+        let r_none = tracker
+            .reserve(&Subject::new("alice"), None, demand(0, 0, 0))
+            .await;
+        assert!(r_none.is_ok(), "absent selector must not partition: {r_none:?}");
+        // Any selector is rejected fail-closed (no membership source wired).
+        let r_sel = tracker
+            .reserve(&Subject::new("alice"), Some("team-a"), demand(0, 0, 0))
+            .await;
+        assert!(
+            matches!(r_sel, Err(WorkerError::AdmissionDenied { .. })),
+            "fail-closed: unverifiable selector must be rejected: {r_sel:?}"
         );
     }
 
@@ -628,6 +956,153 @@ mod tests {
             matches!(r2, Err(WorkerError::QueueTimeout { .. })),
             "got: {r2:?}"
         );
+    }
+
+    // ── F1: demand exceeding configured TOTALS rejects immediately
+    //    (infeasible), never burns the queue timeout ─────────────────────────
+
+    #[tokio::test]
+    async fn gpu_demand_exceeding_total_rejects_immediately_infeasible() {
+        // gpu_total defaults to 0. A GPU request can never be satisfied, so it
+        // must reject *immediately* (Infeasible), not queue for 30s.
+        let cfg = AdmissionConfig {
+            // Long timeout so a wrong "queue" answer would be obvious/slow.
+            queue_timeout_secs: 30,
+            ..Default::default()
+        };
+        let tracker = AdmissionTracker::new(cfg, 10);
+        let start = Instant::now();
+        let r = tracker
+            .reserve(&Subject::new("alice"), None, demand(0, 0, 1))
+            .await;
+        assert!(
+            matches!(r, Err(WorkerError::AdmissionInfeasible { .. })),
+            "got: {r:?}"
+        );
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "infeasible demand must reject immediately, not wait out the timeout"
+        );
+    }
+
+    #[tokio::test]
+    async fn memory_demand_exceeding_total_is_infeasible() {
+        let cfg = AdmissionConfig {
+            memory_bytes_total: Some(256),
+            queue_timeout_secs: 30,
+            ..Default::default()
+        };
+        let tracker = AdmissionTracker::new(cfg, 10);
+        let start = Instant::now();
+        let r = tracker
+            .reserve(&Subject::new("alice"), None, demand(0, 512, 0))
+            .await;
+        assert!(
+            matches!(r, Err(WorkerError::AdmissionInfeasible { .. })),
+            "got: {r:?}"
+        );
+        assert!(start.elapsed() < Duration::from_secs(1));
+    }
+
+    #[tokio::test]
+    async fn cpu_demand_exceeding_total_is_infeasible() {
+        let cfg = AdmissionConfig {
+            cpu_millis_total: Some(1000),
+            queue_timeout_secs: 30,
+            ..Default::default()
+        };
+        let tracker = AdmissionTracker::new(cfg, 10);
+        let r = tracker
+            .reserve(&Subject::new("alice"), None, demand(2000, 0, 0))
+            .await;
+        assert!(
+            matches!(r, Err(WorkerError::AdmissionInfeasible { .. })),
+            "got: {r:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn demand_equal_to_total_is_feasible_not_infeasible() {
+        // Boundary: demand == total fits (busy, not infeasible). First takes
+        // the GPU; a second equal request queues on *capacity* (would time
+        // out), proving it wasn't classified infeasible.
+        let cfg = AdmissionConfig {
+            gpu_total: 1,
+            queue_timeout_secs: 0,
+            ..Default::default()
+        };
+        let tracker = AdmissionTracker::new(cfg, 10);
+        let r1 = tracker
+            .reserve(&Subject::new("alice"), None, demand(0, 0, 1))
+            .await;
+        assert!(r1.is_ok(), "demand == total must fit: {r1:?}");
+        let r2 = tracker
+            .reserve(&Subject::new("bob"), None, demand(0, 0, 1))
+            .await;
+        assert!(
+            matches!(r2, Err(WorkerError::QueueTimeout { .. })),
+            "second equal request is busy (capacity), not infeasible: {r2:?}"
+        );
+    }
+
+    // ── F4: FIFO — arrivals never barge past queued waiters ────────────────
+
+    #[tokio::test]
+    async fn fifo_earlier_waiter_is_not_starved_by_later_arrivals() {
+        // Capacity 1. alice holds it; bob queues first, carol queues after.
+        // Freeing one slot must admit bob (the earlier waiter), never carol.
+        let cfg = AdmissionConfig {
+            queue_timeout_secs: 5,
+            ..Default::default()
+        };
+        let tracker = Arc::new(AdmissionTracker::new(cfg, 1));
+        let held = tracker
+            .reserve(&Subject::new("alice"), None, demand(0, 0, 0))
+            .await
+            .unwrap();
+
+        let t_bob = tracker.clone();
+        let bob = tokio::spawn(async move {
+            t_bob
+                .reserve(&Subject::new("bob"), None, demand(0, 0, 0))
+                .await
+        });
+        // Ensure bob is queued at the head before carol arrives.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let t_carol = tracker.clone();
+        let carol = tokio::spawn(async move {
+            t_carol
+                .reserve(&Subject::new("carol"), None, demand(0, 0, 0))
+                .await
+        });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Free exactly one slot.
+        tracker.release(&held).await;
+
+        // bob (earlier) must be the one admitted.
+        let bob_res = tokio::time::timeout(Duration::from_secs(2), bob)
+            .await
+            .expect("bob should be woken")
+            .expect("task ok");
+        assert!(bob_res.is_ok(), "earlier waiter bob must be admitted: {bob_res:?}");
+
+        // carol must still be waiting (only one slot freed, bob took it — no
+        // barging).
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            !carol.is_finished(),
+            "later arrival carol must not barge ahead of / with bob"
+        );
+
+        // Clean up: release bob's slot so carol can finish.
+        tracker.release(&bob_res.unwrap()).await;
+        let carol_res = tokio::time::timeout(Duration::from_secs(2), carol)
+            .await
+            .expect("carol should now be woken")
+            .expect("task ok");
+        assert!(carol_res.is_ok(), "carol admitted once capacity frees: {carol_res:?}");
     }
 
     #[tokio::test]
@@ -694,7 +1169,7 @@ mod tests {
     async fn derive_demand_is_zero_for_default_config() {
         let config = PodSandboxConfig::default();
         assert_eq!(derive_demand(&config), Demand::default());
-        assert_eq!(derive_group(&config), None);
+        assert_eq!(derive_group_selector(&config), None);
     }
 
     #[tokio::test]
@@ -716,6 +1191,6 @@ mod tests {
         assert_eq!(d.cpu_millis, 500);
         assert_eq!(d.memory_bytes, 1024);
         assert_eq!(d.gpu, 2);
-        assert_eq!(derive_group(&config).as_deref(), Some("team-a"));
+        assert_eq!(derive_group_selector(&config).as_deref(), Some("team-a"));
     }
 }

--- a/crates/hyprstream-workers/src/runtime/admission.rs
+++ b/crates/hyprstream-workers/src/runtime/admission.rs
@@ -1,0 +1,721 @@
+//! Admission control for `SandboxPool::acquire` (#525, P2 of epic #523).
+//!
+//! Replaces the old "check `active.len()`, then either pop/create" shape
+//! (immediate `PoolExhausted`, no queue, no identity, no resource dimension)
+//! with a real decision engine:
+//!
+//! - **Fail-closed identity**: no verified [`Subject`] → reject before doing
+//!   any bookkeeping. There is no "anonymous but allowed" path.
+//! - **Reserve-then-place, never check-then-place** (the #489/#519 TOCTOU
+//!   lesson): every admission decision — capacity, per-Subject quota,
+//!   per-group quota, and cpu/memory/GPU capacity — is checked *and*
+//!   committed atomically under one lock in [`try_admit_locked`]. There is no
+//!   window between "checked OK" and "reserved" where a second caller can
+//!   slip in and overshoot.
+//! - **Bounded wait-queue with backpressure**: a request that cannot be
+//!   admitted immediately because of *capacity* (never quota — see below)
+//!   waits, bounded by [`AdmissionConfig::queue_capacity`] and
+//!   [`AdmissionConfig::queue_timeout_secs`]. Over the bound, or past the
+//!   timeout, it fails clearly rather than blocking forever or silently
+//!   degrading.
+//!
+//! ## 🔒 NEEDS REVIEWER SIGN-OFF
+//!
+//! This module makes several judgment calls the issue explicitly flags as
+//! needing sign-off rather than being final:
+//!
+//! 1. **Quota model shape**: a simple in-memory per-Subject/per-group counter
+//!    with an operator-configured numeric ceiling ([`AdmissionConfig`]). This
+//!    is *not* Casbin-policy-driven — there is no policy lookup, no dynamic
+//!    per-tenant configuration source, just a static number in `PoolConfig`.
+//!    Full Casbin-backed quota configuration (e.g. deriving `max_per_subject`
+//!    from a Casbin role/policy rather than a flat config value) is a
+//!    follow-up.
+//! 2. **"Group" identity**: there is no first-class "group" claim on
+//!    [`hyprstream_rpc::auth::Claims`] today. `derive_group` reads it from a
+//!    plain annotation (`hyprstream.io/group`) on the request rather than
+//!    inventing a new capnp field or claim — deliberately, to avoid a
+//!    wire-format change here. This is a placeholder pending a real
+//!    tenant/group model.
+//! 3. **Wait-queue fairness**: the queue is a single bounded FIFO-ish
+//!    structure (all waiters are woken on every release and re-race for the
+//!    lock), *not* the per-Subject/per-group fair sub-queue + weighted-
+//!    round-robin the issue's design note describes. Quota-rejected requests
+//!    never queue (they fail fast), which limits one noisy Subject's ability
+//!    to starve others out of the *quota* axis, but the *capacity* wait queue
+//!    itself has no per-key fairness weighting. Flagged as a scope-down, not
+//!    a silent omission.
+//! 4. **GPU/resource vocabulary**: cpu/memory/GPU demand is read from
+//!    `config.linux.resources` (existing CRI-shaped fields) plus a new,
+//!    separate annotation `hyprstream.io/gpu-request` (a plain integer count,
+//!    not a GPU *class*) — independent of the existing boolean
+//!    `hyprstream.io/gpu` passthrough annotation consumed by `oci_backend`/
+//!    `nspawn`. The two are intentionally not unified in this change; see the
+//!    module docs on `pool.rs` for the full rationale.
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::{Mutex, Notify};
+use tokio::time::Instant;
+
+use hyprstream_discovery::scheduling::{self, Predicate, RejectionReason, ResourceRequest};
+use hyprstream_vfs::Subject;
+
+use crate::error::{Result, WorkerError};
+
+use super::client::{KeyValue, PodSandboxConfig};
+
+/// Annotation key: per-request GPU count demand (a plain non-negative
+/// integer string, e.g. `"1"`). Independent of `oci_backend`'s existing
+/// boolean `hyprstream.io/gpu` passthrough flag — see module docs, point 4.
+pub const ANN_GPU_REQUEST: &str = "hyprstream.io/gpu-request";
+
+/// Annotation key: the admission "group" this request belongs to (#525
+/// placeholder for a real tenant/group claim — see module docs, point 2).
+pub const ANN_GROUP: &str = "hyprstream.io/group";
+
+fn annotation<'a>(annotations: &'a [KeyValue], key: &str) -> Option<&'a str> {
+    annotations
+        .iter()
+        .find(|kv| kv.key == key)
+        .map(|kv| kv.value.as_str())
+}
+
+/// Resource demand derived from a [`PodSandboxConfig`] for admission purposes.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Demand {
+    pub cpu_millis: u64,
+    pub memory_bytes: u64,
+    pub gpu: usize,
+}
+
+/// Derive the resource `Demand` this request represents.
+///
+/// CRI convention: `0` means "unspecified" for `cpu_period`/`cpu_quota`/
+/// `memory_limit_in_bytes`, so an all-zero (`Default`) `LinuxContainerResources`
+/// — what every pre-#525 caller passes — derives a zero `Demand`, and a zero
+/// `Demand` never trips a capacity check. This is what keeps the solo/no-op
+/// case regression-free (acceptance criterion: "no regression for the
+/// existing solo case").
+pub fn derive_demand(config: &PodSandboxConfig) -> Demand {
+    let res = &config.linux.resources;
+    let cpu_millis = if res.cpu_period > 0 && res.cpu_quota > 0 {
+        ((res.cpu_quota as f64 / res.cpu_period as f64) * 1000.0).round() as u64
+    } else {
+        0
+    };
+    let memory_bytes = res.memory_limit_in_bytes.max(0) as u64;
+    let gpu = annotation(&config.annotations, ANN_GPU_REQUEST)
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(0);
+    Demand {
+        cpu_millis,
+        memory_bytes,
+        gpu,
+    }
+}
+
+/// Derive the admission "group" key for a request, if any (see module docs,
+/// point 2).
+pub fn derive_group(config: &PodSandboxConfig) -> Option<String> {
+    annotation(&config.annotations, ANN_GROUP).map(str::to_owned)
+}
+
+/// Per-Subject / per-group admission quotas + wait-queue bounds + declared
+/// local schedulable capacity (#525 P2).
+///
+/// 🔒 See the module-level "NEEDS REVIEWER SIGN-OFF" doc for the judgment
+/// calls baked into this shape.
+///
+/// All limits default to **unconstrained** so that a `PoolConfig` with no
+/// explicit `admission` section behaves exactly as before this change (no
+/// regression for the existing solo/no-quota case): only an operator who
+/// opts in by lowering these gets admission-control behavior beyond the
+/// pre-existing `max_sandboxes` capacity check.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct AdmissionConfig {
+    /// Maximum concurrently-active sandboxes for a single Subject.
+    /// Default: unconstrained (`usize::MAX`).
+    pub max_per_subject: usize,
+    /// Maximum concurrently-active sandboxes for a single group (see
+    /// [`derive_group`]). Default: unconstrained (`usize::MAX`).
+    pub max_per_group: usize,
+    /// Bound on the number of callers allowed to wait in the admission queue
+    /// at once. A request that would exceed this is rejected immediately
+    /// (`QueueFull`) rather than queued.
+    pub queue_capacity: usize,
+    /// How long a queued request waits for capacity before giving up
+    /// (`QueueTimeout`).
+    pub queue_timeout_secs: u64,
+    /// Total schedulable CPU (millicores) for this node's local capacity
+    /// overlay. `None` (default) = the CPU dimension is not enforced.
+    pub cpu_millis_total: Option<u64>,
+    /// Total schedulable memory (bytes) for this node's local capacity
+    /// overlay. `None` (default) = the memory dimension is not enforced.
+    pub memory_bytes_total: Option<u64>,
+    /// Total GPU count available for scheduling. Default `0`: a request that
+    /// asks for a GPU (`Demand::gpu > 0`) is fail-closed rejected unless an
+    /// operator explicitly declares GPU capacity here. Requests that don't
+    /// ask for a GPU (`Demand::gpu == 0`, the default) are never affected by
+    /// this value.
+    pub gpu_total: usize,
+}
+
+impl Default for AdmissionConfig {
+    fn default() -> Self {
+        Self {
+            max_per_subject: usize::MAX,
+            max_per_group: usize::MAX,
+            queue_capacity: 64,
+            queue_timeout_secs: 30,
+            cpu_millis_total: None,
+            memory_bytes_total: None,
+            gpu_total: 0,
+        }
+    }
+}
+
+/// What a committed reservation consumed, so [`AdmissionTracker::release`] /
+/// [`AdmissionTracker::rollback`] can give it back precisely.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReservationRecord {
+    subject: String,
+    group: Option<String>,
+    demand: Demand,
+}
+
+/// A local resource-capacity candidate for the #628 scheduling substrate's
+/// `filter → rank → select` pipeline (see module docs on GPU/resource
+/// vocabulary). In the single-node/solo case this is the *only* candidate;
+/// the extension point for cross-node placement is `rank_by` in
+/// [`fit_report`] — feeding `queryCandidates` results in as additional
+/// candidates here (with a real least-loaded/best-fit `rank_by`) is P2's
+/// documented (not implemented) cross-node extension.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LocalCandidate {
+    name: &'static str,
+    cpu_millis_free: u64,
+    memory_bytes_free: u64,
+    gpu_free: usize,
+}
+
+/// Build the fit predicates for `demand` over a [`LocalCandidate`]. Only
+/// dimensions actually requested (or actually enforced by config) produce a
+/// predicate — an all-zero `Demand` (the default/no-op case) yields no
+/// predicates, so it always "fits."
+fn fit_predicates(demand: Demand) -> Vec<Predicate<LocalCandidate>> {
+    let mut preds: Vec<Predicate<LocalCandidate>> = Vec::new();
+    if demand.cpu_millis > 0 {
+        preds.push(Box::new(move |c: &LocalCandidate| {
+            let req = ResourceRequest::new("cpu", format!("{}m", demand.cpu_millis));
+            if req.satisfied_by(&format!("{}m", c.cpu_millis_free)) {
+                None
+            } else {
+                Some(RejectionReason(format!(
+                    "insufficient cpu: need {}m, {}m free",
+                    demand.cpu_millis, c.cpu_millis_free
+                )))
+            }
+        }));
+    }
+    if demand.memory_bytes > 0 {
+        preds.push(Box::new(move |c: &LocalCandidate| {
+            let req = ResourceRequest::new("memory", demand.memory_bytes.to_string());
+            if req.satisfied_by(&c.memory_bytes_free.to_string()) {
+                None
+            } else {
+                Some(RejectionReason(format!(
+                    "insufficient memory: need {} bytes, {} bytes free",
+                    demand.memory_bytes, c.memory_bytes_free
+                )))
+            }
+        }));
+    }
+    if demand.gpu > 0 {
+        preds.push(Box::new(move |c: &LocalCandidate| {
+            let req = ResourceRequest::new("gpu", demand.gpu.to_string());
+            if req.satisfied_by(&c.gpu_free.to_string()) {
+                None
+            } else {
+                Some(RejectionReason(format!(
+                    "insufficient gpu: need {}, {} free",
+                    demand.gpu, c.gpu_free
+                )))
+            }
+        }));
+    }
+    preds
+}
+
+/// Run the #628 scheduling substrate's `filter → rank → select` over the
+/// (today: single) local candidate for `demand`. Returns `Ok(())` if it fits,
+/// `Err(reason)` with the joined rejection reasons otherwise.
+fn fit_over_local_candidate(
+    cpu_millis_free: u64,
+    memory_bytes_free: u64,
+    gpu_free: usize,
+    demand: Demand,
+) -> std::result::Result<(), String> {
+    let candidate = LocalCandidate {
+        name: "self",
+        cpu_millis_free,
+        memory_bytes_free,
+        gpu_free,
+    };
+    let preds = fit_predicates(demand);
+    // Single candidate today, so ranking is a no-op (`Ordering::Equal`); the
+    // rank_by closure is the seam a cross-node extension plugs a real
+    // least-loaded/best-fit comparator into.
+    let report = scheduling::select(&[candidate], &preds, |_, _| std::cmp::Ordering::Equal, 1);
+    if report.selected.is_some() {
+        Ok(())
+    } else {
+        let reasons: Vec<String> = report
+            .candidates
+            .iter()
+            .filter_map(|c| c.rejection_reason.clone())
+            .collect();
+        Err(reasons.join("; "))
+    }
+}
+
+#[derive(Debug, Default)]
+struct AdmissionState {
+    active_total: usize,
+    active_by_subject: HashMap<String, usize>,
+    active_by_group: HashMap<String, usize>,
+    cpu_millis_reserved: u64,
+    memory_bytes_reserved: u64,
+    gpu_reserved: usize,
+    /// Bounded wait-queue. On any release, every waiter here is woken and
+    /// re-races to retry admission under the lock (see module docs, sign-off
+    /// point 3, on why this is not a per-key fair sub-queue).
+    queue: VecDeque<Arc<Notify>>,
+}
+
+/// Why [`try_admit_locked`] refused to admit — distinguishes *quota*
+/// (never queues; retrying won't help until the Subject/group frees up on
+/// its own) from *capacity* (may queue; a release elsewhere can free room).
+enum AdmitReject {
+    Quota(String),
+    Capacity(String),
+}
+
+/// Check admission for `(subject_key, group_key, demand)` and, if it fits,
+/// commit the reservation — atomically, under the caller's lock. This is the
+/// entire "reserve-then-place" critical section; there is no gap between
+/// "checked OK" and "reserved" (the #489/#519 TOCTOU lesson).
+#[allow(clippy::too_many_arguments)]
+fn try_admit_locked(
+    state: &mut AdmissionState,
+    subject_key: &str,
+    group_key: Option<&str>,
+    demand: Demand,
+    cfg: &AdmissionConfig,
+    max_sandboxes: usize,
+) -> std::result::Result<(), AdmitReject> {
+    // ── Quota checks first: fail-closed, never queue ──
+    let subj_count = *state.active_by_subject.get(subject_key).unwrap_or(&0);
+    if subj_count >= cfg.max_per_subject {
+        return Err(AdmitReject::Quota(format!(
+            "subject '{subject_key}' at quota ({subj_count}/{})",
+            cfg.max_per_subject
+        )));
+    }
+    if let Some(g) = group_key {
+        let gcount = *state.active_by_group.get(g).unwrap_or(&0);
+        if gcount >= cfg.max_per_group {
+            return Err(AdmitReject::Quota(format!(
+                "group '{g}' at quota ({gcount}/{})",
+                cfg.max_per_group
+            )));
+        }
+    }
+
+    // ── Capacity checks: may queue ──
+    if state.active_total >= max_sandboxes {
+        return Err(AdmitReject::Capacity(format!(
+            "pool at capacity ({}/{max_sandboxes})",
+            state.active_total
+        )));
+    }
+    let cpu_free = cfg
+        .cpu_millis_total
+        .map(|t| t.saturating_sub(state.cpu_millis_reserved))
+        .unwrap_or(u64::MAX);
+    let memory_free = cfg
+        .memory_bytes_total
+        .map(|t| t.saturating_sub(state.memory_bytes_reserved))
+        .unwrap_or(u64::MAX);
+    let gpu_free = cfg.gpu_total.saturating_sub(state.gpu_reserved);
+    if let Err(reason) = fit_over_local_candidate(cpu_free, memory_free, gpu_free, demand) {
+        return Err(AdmitReject::Capacity(reason));
+    }
+
+    // ── Admit: commit the reservation ──
+    state.active_total += 1;
+    *state
+        .active_by_subject
+        .entry(subject_key.to_owned())
+        .or_insert(0) += 1;
+    if let Some(g) = group_key {
+        *state.active_by_group.entry(g.to_owned()).or_insert(0) += 1;
+    }
+    state.cpu_millis_reserved += demand.cpu_millis;
+    state.memory_bytes_reserved += demand.memory_bytes;
+    state.gpu_reserved += demand.gpu;
+    Ok(())
+}
+
+fn release_locked(state: &mut AdmissionState, record: &ReservationRecord) {
+    state.active_total = state.active_total.saturating_sub(1);
+    if let Some(c) = state.active_by_subject.get_mut(&record.subject) {
+        *c = c.saturating_sub(1);
+        if *c == 0 {
+            state.active_by_subject.remove(&record.subject);
+        }
+    }
+    if let Some(g) = &record.group {
+        if let Some(c) = state.active_by_group.get_mut(g) {
+            *c = c.saturating_sub(1);
+            if *c == 0 {
+                state.active_by_group.remove(g);
+            }
+        }
+    }
+    state.cpu_millis_reserved = state
+        .cpu_millis_reserved
+        .saturating_sub(record.demand.cpu_millis);
+    state.memory_bytes_reserved = state
+        .memory_bytes_reserved
+        .saturating_sub(record.demand.memory_bytes);
+    state.gpu_reserved = state.gpu_reserved.saturating_sub(record.demand.gpu);
+}
+
+/// Admission decision engine backing `SandboxPool::acquire` (#525 P2).
+#[derive(Debug)]
+pub struct AdmissionTracker {
+    state: Mutex<AdmissionState>,
+    config: AdmissionConfig,
+    max_sandboxes: usize,
+}
+
+impl AdmissionTracker {
+    pub fn new(config: AdmissionConfig, max_sandboxes: usize) -> Self {
+        Self {
+            state: Mutex::new(AdmissionState::default()),
+            config,
+            max_sandboxes,
+        }
+    }
+
+    /// Reserve capacity for `(subject, group, demand)`, fail-closed on
+    /// unauthenticated callers, queueing (bounded) when only *capacity* (not
+    /// quota) blocks admission.
+    pub async fn reserve(
+        &self,
+        subject: &Subject,
+        group: Option<&str>,
+        demand: Demand,
+    ) -> Result<ReservationRecord> {
+        // Fail-closed identity: no verified Subject → reject before any
+        // bookkeeping, queueing, or lock acquisition whatsoever.
+        if subject.is_anonymous() {
+            return Err(WorkerError::Unauthorized {
+                subject: "anonymous".to_owned(),
+                operation: "acquire".to_owned(),
+                resource: "sandbox-pool".to_owned(),
+            });
+        }
+        let subject_key = subject.name().unwrap_or("").to_owned();
+        let deadline = Instant::now() + Duration::from_secs(self.config.queue_timeout_secs);
+
+        loop {
+            let ticket = {
+                let mut state = self.state.lock().await;
+                match try_admit_locked(
+                    &mut state,
+                    &subject_key,
+                    group,
+                    demand,
+                    &self.config,
+                    self.max_sandboxes,
+                ) {
+                    Ok(()) => {
+                        return Ok(ReservationRecord {
+                            subject: subject_key,
+                            group: group.map(str::to_owned),
+                            demand,
+                        });
+                    }
+                    Err(AdmitReject::Quota(reason)) => {
+                        return Err(WorkerError::AdmissionDenied { reason });
+                    }
+                    Err(AdmitReject::Capacity(reason)) => {
+                        if state.queue.len() >= self.config.queue_capacity {
+                            return Err(WorkerError::QueueFull {
+                                waiting: state.queue.len(),
+                                bound: self.config.queue_capacity,
+                            });
+                        }
+                        tracing::debug!(subject = %subject_key, reason = %reason, "acquire: queueing for capacity");
+                        let ticket = Arc::new(Notify::new());
+                        state.queue.push_back(ticket.clone());
+                        ticket
+                    }
+                }
+            };
+
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                let mut state = self.state.lock().await;
+                state.queue.retain(|t| !Arc::ptr_eq(t, &ticket));
+                return Err(WorkerError::QueueTimeout {
+                    timeout_secs: self.config.queue_timeout_secs,
+                });
+            }
+            if tokio::time::timeout(remaining, ticket.notified())
+                .await
+                .is_err()
+            {
+                let mut state = self.state.lock().await;
+                state.queue.retain(|t| !Arc::ptr_eq(t, &ticket));
+                return Err(WorkerError::QueueTimeout {
+                    timeout_secs: self.config.queue_timeout_secs,
+                });
+            }
+            // Woken: loop back and retry admission under the lock.
+        }
+    }
+
+    /// Give back a committed reservation (a sandbox using it was released or
+    /// destroyed) and wake queued waiters to retry.
+    pub async fn release(&self, record: &ReservationRecord) {
+        let queue = {
+            let mut state = self.state.lock().await;
+            release_locked(&mut state, record);
+            std::mem::take(&mut state.queue)
+        };
+        for ticket in queue {
+            ticket.notify_one();
+        }
+    }
+
+    /// Give back a reservation that was committed but never resulted in a
+    /// usable sandbox (e.g. the backend failed to create/reconfigure one
+    /// after admission succeeded). Identical to [`Self::release`] — kept as
+    /// a distinctly-named entry point for readability at call sites.
+    pub async fn rollback(&self, record: &ReservationRecord) {
+        self.release(record).await;
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn demand(cpu_millis: u64, memory_bytes: u64, gpu: usize) -> Demand {
+        Demand {
+            cpu_millis,
+            memory_bytes,
+            gpu,
+        }
+    }
+
+    #[tokio::test]
+    async fn anonymous_subject_rejected_fail_closed() {
+        let tracker = AdmissionTracker::new(AdmissionConfig::default(), 10);
+        let err = tracker
+            .reserve(&Subject::anonymous(), None, demand(0, 0, 0))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, WorkerError::Unauthorized { .. }),
+            "got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn zero_demand_never_trips_resource_capacity() {
+        // No cpu/mem/gpu totals configured (the default) → a zero-demand
+        // request (the CRI "unspecified" convention) always fits, matching
+        // pre-#525 behavior exactly.
+        let tracker = AdmissionTracker::new(AdmissionConfig::default(), 10);
+        let r = tracker
+            .reserve(&Subject::new("alice"), None, demand(0, 0, 0))
+            .await;
+        assert!(r.is_ok());
+    }
+
+    #[tokio::test]
+    async fn per_subject_quota_rejects_not_queues() {
+        let cfg = AdmissionConfig {
+            max_per_subject: 1,
+            ..Default::default()
+        };
+        let tracker = AdmissionTracker::new(cfg, 10);
+        let alice = Subject::new("alice");
+        let r1 = tracker.reserve(&alice, None, demand(0, 0, 0)).await;
+        assert!(r1.is_ok());
+        let r2 = tracker.reserve(&alice, None, demand(0, 0, 0)).await;
+        assert!(
+            matches!(r2, Err(WorkerError::AdmissionDenied { .. })),
+            "got: {r2:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn per_group_quota_rejects_across_subjects() {
+        let cfg = AdmissionConfig {
+            max_per_group: 1,
+            ..Default::default()
+        };
+        let tracker = AdmissionTracker::new(cfg, 10);
+        let r1 = tracker
+            .reserve(&Subject::new("alice"), Some("team-a"), demand(0, 0, 0))
+            .await;
+        assert!(r1.is_ok());
+        let r2 = tracker
+            .reserve(&Subject::new("bob"), Some("team-a"), demand(0, 0, 0))
+            .await;
+        assert!(
+            matches!(r2, Err(WorkerError::AdmissionDenied { .. })),
+            "got: {r2:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn gpu_capacity_enforced_only_when_requested() {
+        let cfg = AdmissionConfig {
+            gpu_total: 1,
+            ..Default::default()
+        };
+        let tracker = AdmissionTracker::new(cfg, 10);
+        // No GPU asked for → unaffected even though gpu_total is small.
+        let r = tracker
+            .reserve(&Subject::new("alice"), None, demand(0, 0, 0))
+            .await;
+        assert!(r.is_ok());
+        // One GPU asked for and available → admitted.
+        let r1 = tracker
+            .reserve(&Subject::new("bob"), None, demand(0, 0, 1))
+            .await;
+        assert!(r1.is_ok());
+        // Second GPU request with none free → queues then times out (queue
+        // bound left at default; timeout shortened for the test).
+    }
+
+    #[tokio::test]
+    async fn gpu_over_capacity_queues_then_times_out() {
+        let cfg = AdmissionConfig {
+            gpu_total: 1,
+            queue_timeout_secs: 0,
+            ..Default::default()
+        };
+        let tracker = AdmissionTracker::new(cfg, 10);
+        let r1 = tracker
+            .reserve(&Subject::new("alice"), None, demand(0, 0, 1))
+            .await;
+        assert!(r1.is_ok());
+        let r2 = tracker
+            .reserve(&Subject::new("bob"), None, demand(0, 0, 1))
+            .await;
+        assert!(
+            matches!(r2, Err(WorkerError::QueueTimeout { .. })),
+            "got: {r2:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn queue_full_rejects_immediately() {
+        let cfg = AdmissionConfig {
+            queue_capacity: 0,
+            queue_timeout_secs: 5,
+            ..Default::default()
+        };
+        // Capacity 1, already taken; queue_capacity 0 means the very next
+        // over-capacity request must reject immediately, not wait 5s.
+        let tracker = AdmissionTracker::new(cfg, 1);
+        let r1 = tracker
+            .reserve(&Subject::new("alice"), None, demand(0, 0, 0))
+            .await;
+        assert!(r1.is_ok());
+        let start = Instant::now();
+        let r2 = tracker
+            .reserve(&Subject::new("bob"), None, demand(0, 0, 0))
+            .await;
+        assert!(
+            matches!(r2, Err(WorkerError::QueueFull { .. })),
+            "got: {r2:?}"
+        );
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "must reject immediately, not wait out the timeout"
+        );
+    }
+
+    #[tokio::test]
+    async fn release_wakes_a_queued_waiter() {
+        let cfg = AdmissionConfig {
+            queue_timeout_secs: 5,
+            ..Default::default()
+        };
+        let tracker = Arc::new(AdmissionTracker::new(cfg, 1));
+        let r1 = tracker
+            .reserve(&Subject::new("alice"), None, demand(0, 0, 0))
+            .await
+            .unwrap();
+
+        let t2 = tracker.clone();
+        let waiter = tokio::spawn(async move {
+            t2.reserve(&Subject::new("bob"), None, demand(0, 0, 0))
+                .await
+        });
+
+        // Give the waiter task a moment to actually enter the queue.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        tracker.release(&r1).await;
+
+        let r2 = tokio::time::timeout(Duration::from_secs(2), waiter)
+            .await
+            .expect("waiter should be woken well within 2s")
+            .expect("task should not panic");
+        assert!(
+            r2.is_ok(),
+            "queued waiter should be admitted once capacity frees: {r2:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn derive_demand_is_zero_for_default_config() {
+        let config = PodSandboxConfig::default();
+        assert_eq!(derive_demand(&config), Demand::default());
+        assert_eq!(derive_group(&config), None);
+    }
+
+    #[tokio::test]
+    async fn derive_demand_reads_cpu_memory_and_gpu_annotation() {
+        let mut config = PodSandboxConfig::default();
+        config.linux.resources.cpu_period = 100_000;
+        config.linux.resources.cpu_quota = 50_000;
+        config.linux.resources.memory_limit_in_bytes = 1024;
+        config.annotations.push(KeyValue {
+            key: ANN_GPU_REQUEST.to_owned(),
+            value: "2".to_owned(),
+        });
+        config.annotations.push(KeyValue {
+            key: ANN_GROUP.to_owned(),
+            value: "team-a".to_owned(),
+        });
+
+        let d = derive_demand(&config);
+        assert_eq!(d.cpu_millis, 500);
+        assert_eq!(d.memory_bytes, 1024);
+        assert_eq!(d.gpu, 2);
+        assert_eq!(derive_group(&config).as_deref(), Some("team-a"));
+    }
+}

--- a/crates/hyprstream-workers/src/runtime/exec_mount.rs
+++ b/crates/hyprstream-workers/src/runtime/exec_mount.rs
@@ -641,6 +641,16 @@ mod tests {
         Subject::anonymous()
     }
 
+    /// Distinct from `subject()` above: that one is the *VFS caller* passed
+    /// to `ExecMount`'s `Mount` trait methods (anonymous is fine there — this
+    /// projection doesn't itself enforce per-caller authorization). This one
+    /// is the *admission* identity `SandboxPool::acquire` requires (#525 P2)
+    /// — must be non-anonymous, or every `pool.acquire()` call below would
+    /// fail closed.
+    fn admission_subject() -> Subject {
+        Subject::new("test-user")
+    }
+
     #[tokio::test]
     async fn list_instances_empty() {
         let pool = make_pool().await;
@@ -653,7 +663,7 @@ mod tests {
     #[tokio::test]
     async fn list_instances_after_acquire() {
         let pool = make_pool().await;
-        let id = pool.acquire(&PodSandboxConfig::default()).await.unwrap();
+        let id = pool.acquire(&admission_subject(), &PodSandboxConfig::default()).await.unwrap();
         let mount = ExecMount::new(pool);
 
         let fid = mount.walk(&[], &subject()).await.unwrap();
@@ -674,7 +684,7 @@ mod tests {
     #[tokio::test]
     async fn read_status_reflects_pool_state() {
         let pool = make_pool().await;
-        let id = pool.acquire(&PodSandboxConfig::default()).await.unwrap();
+        let id = pool.acquire(&admission_subject(), &PodSandboxConfig::default()).await.unwrap();
         let mount = ExecMount::new(pool);
 
         let mut fid = mount.walk(&[&id, "status"], &subject()).await.unwrap();
@@ -687,7 +697,7 @@ mod tests {
     #[tokio::test]
     async fn ctl_stop_invokes_backend() {
         let pool = make_pool().await;
-        let id = pool.acquire(&PodSandboxConfig::default()).await.unwrap();
+        let id = pool.acquire(&admission_subject(), &PodSandboxConfig::default()).await.unwrap();
         let mount = ExecMount::new(pool);
 
         let mut fid = mount.walk(&[&id, "ctl"], &subject()).await.unwrap();
@@ -703,7 +713,7 @@ mod tests {
     #[tokio::test]
     async fn ctl_unknown_verb_rejected() {
         let pool = make_pool().await;
-        let id = pool.acquire(&PodSandboxConfig::default()).await.unwrap();
+        let id = pool.acquire(&admission_subject(), &PodSandboxConfig::default()).await.unwrap();
         let mount = ExecMount::new(pool);
 
         let mut fid = mount.walk(&[&id, "ctl"], &subject()).await.unwrap();
@@ -719,7 +729,7 @@ mod tests {
     #[tokio::test]
     async fn exit_blocks_then_unblocks_on_destroy() {
         let pool = make_pool().await;
-        let id = pool.acquire(&PodSandboxConfig::default()).await.unwrap();
+        let id = pool.acquire(&admission_subject(), &PodSandboxConfig::default()).await.unwrap();
         let mount = Arc::new(ExecMount::new(pool));
 
         let reader = {
@@ -762,7 +772,7 @@ mod tests {
     #[tokio::test]
     async fn exit_after_destroy_reports_terminal() {
         let pool = make_pool().await;
-        let id = pool.acquire(&PodSandboxConfig::default()).await.unwrap();
+        let id = pool.acquire(&admission_subject(), &PodSandboxConfig::default()).await.unwrap();
         let mount = ExecMount::new(pool);
 
         // Drive destroy through ctl.
@@ -799,7 +809,7 @@ mod tests {
     #[tokio::test]
     async fn ctl_on_terminal_instance_rejected() {
         let pool = make_pool().await;
-        let id = pool.acquire(&PodSandboxConfig::default()).await.unwrap();
+        let id = pool.acquire(&admission_subject(), &PodSandboxConfig::default()).await.unwrap();
         let mount = ExecMount::new(pool);
 
         let mut ctl_fid = mount.walk(&[&id, "ctl"], &subject()).await.unwrap();
@@ -822,7 +832,7 @@ mod tests {
     #[tokio::test]
     async fn read_ns_returns_placeholder_info() {
         let pool = make_pool().await;
-        let id = pool.acquire(&PodSandboxConfig::default()).await.unwrap();
+        let id = pool.acquire(&admission_subject(), &PodSandboxConfig::default()).await.unwrap();
         let mount = ExecMount::new(pool);
 
         let mut fid = mount.walk(&[&id, "ns"], &subject()).await.unwrap();
@@ -836,7 +846,7 @@ mod tests {
     #[tokio::test]
     async fn readdir_instance_dir_lists_files() {
         let pool = make_pool().await;
-        let id = pool.acquire(&PodSandboxConfig::default()).await.unwrap();
+        let id = pool.acquire(&admission_subject(), &PodSandboxConfig::default()).await.unwrap();
         let mount = ExecMount::new(pool);
 
         let fid = mount.walk(&[&id], &subject()).await.unwrap();
@@ -872,7 +882,7 @@ mod tests {
     #[tokio::test]
     async fn ctl_concurrent_writes_to_one_fid_are_safe() {
         let pool = make_pool().await;
-        let id = pool.acquire(&PodSandboxConfig::default()).await.unwrap();
+        let id = pool.acquire(&admission_subject(), &PodSandboxConfig::default()).await.unwrap();
         let mount = ExecMount::new(pool);
 
         // One shared ctl fid; opened RDWR.

--- a/crates/hyprstream-workers/src/runtime/kata_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/kata_backend.rs
@@ -1363,6 +1363,8 @@ mod tests {
             sandbox_path,
             image_id: None,
             console_socket: None,
+            applied_resources: crate::runtime::client::LinuxContainerResources::default(),
+            reservation: None,
         }
     }
 

--- a/crates/hyprstream-workers/src/runtime/mod.rs
+++ b/crates/hyprstream-workers/src/runtime/mod.rs
@@ -20,6 +20,10 @@
 //!           └── Active sandboxes
 //! ```
 
+// Admission control (#525 P2): fail-closed identity, per-Subject/per-group
+// quotas, bounded wait-queue, resource-aware fit over the #628 scheduling
+// substrate. Consumed by `pool::SandboxPool::acquire`.
+mod admission;
 pub mod backend;
 mod client;
 mod container;
@@ -133,6 +137,9 @@ pub use selection::{explain_selection, BackendCandidate};
 pub use container::Container;
 pub use pool::{PoolStats, SandboxPool};
 pub use sandbox::PodSandbox;
+// Admission control (#525 P2) — quota/queue configuration + the request
+// annotations it reads (GPU count demand, group key).
+pub use admission::{AdmissionConfig, ANN_GPU_REQUEST, ANN_GROUP};
 #[cfg(all(not(target_arch = "wasm32"), feature = "oci-image"))]
 pub use sandbox_fs::{
     InjectedMounts, SandboxFs, SandboxFsLocalMount, SandboxFsServer, VFS_SOCKET_NAME,

--- a/crates/hyprstream-workers/src/runtime/mod.rs
+++ b/crates/hyprstream-workers/src/runtime/mod.rs
@@ -139,7 +139,10 @@ pub use pool::{PoolStats, SandboxPool};
 pub use sandbox::PodSandbox;
 // Admission control (#525 P2) — quota/queue configuration + the request
 // annotations it reads (GPU count demand, group key).
-pub use admission::{AdmissionConfig, ANN_GPU_REQUEST, ANN_GROUP};
+pub use admission::{
+    AdmissionConfig, DenyUnknownGroupValidator, GroupSelectorValidator, StaticGroupMembership,
+    ANN_GPU_REQUEST, ANN_GROUP,
+};
 #[cfg(all(not(target_arch = "wasm32"), feature = "oci-image"))]
 pub use sandbox_fs::{
     InjectedMounts, SandboxFs, SandboxFsLocalMount, SandboxFsServer, VFS_SOCKET_NAME,

--- a/crates/hyprstream-workers/src/runtime/pool.rs
+++ b/crates/hyprstream-workers/src/runtime/pool.rs
@@ -13,14 +13,38 @@ use uuid::Uuid;
 use crate::config::PoolConfig;
 use crate::error::{Result, WorkerError};
 
+use super::admission::{self, AdmissionTracker};
 use super::backend::SandboxBackend;
+use super::client::LinuxContainerResources;
 use super::{PodSandbox, PodSandboxConfig, PodSandboxState};
+use hyprstream_vfs::Subject;
 
 /// Sandbox pool for warm sandbox management
 ///
 /// Maintains:
 /// - Warm pool: Pre-created sandboxes ready for immediate use
 /// - Active sandboxes: Sandboxes currently in use by workloads
+///
+/// # Admission control (#525 P2)
+///
+/// `acquire` is gated by an [`AdmissionTracker`]: fail-closed identity,
+/// per-Subject/per-group quotas, a bounded wait-queue, and resource
+/// (cpu/memory/GPU) fit — see `runtime::admission` for the full design and
+/// its sign-off-flagged judgment calls.
+///
+/// # Backend placement (#525 P2, scope item 4)
+///
+/// A `SandboxPool` is bound to exactly **one** pre-resolved
+/// [`SandboxBackend`], selected once at construction via
+/// [`super::resolve_backend`] (the fail-closed inventory-registry seam,
+/// #507/#516) — never re-selected per request. Routing *individual*
+/// `acquire()` calls to different backends (e.g. GPU workloads to `kata`,
+/// CPU-only ones to `nspawn`, within the same pool) is **not implemented**:
+/// it would require restructuring `SandboxPool` into a router over multiple
+/// backend-specific pools, a larger architectural change than this ticket's
+/// scope. Flagged as a follow-up, not a silent gap — `acquire` never
+/// bypasses the fail-closed backend-resolution seam; it just doesn't have
+/// more than one backend to choose among.
 pub struct SandboxPool {
     /// Pre-warmed sandboxes ready for use
     warm_pool: Mutex<VecDeque<PodSandbox>>,
@@ -40,17 +64,23 @@ pub struct SandboxPool {
     /// have not yet been pushed onto `warm_pool`, so concurrent replenish tasks
     /// can see in-flight work and avoid overshooting `warm_pool_size`.
     in_flight: AtomicUsize,
+
+    /// Admission decision engine (#525 P2): fail-closed identity,
+    /// per-Subject/per-group quotas, bounded wait-queue, resource-aware fit.
+    admission: AdmissionTracker,
 }
 
 impl SandboxPool {
     /// Create a new sandbox pool with a backend
     pub fn new(config: PoolConfig, backend: Arc<dyn SandboxBackend>) -> Self {
+        let admission = AdmissionTracker::new(config.admission.clone(), config.max_sandboxes);
         Self {
             warm_pool: Mutex::new(VecDeque::new()),
             active: Mutex::new(HashMap::new()),
             config,
             backend,
             in_flight: AtomicUsize::new(0),
+            admission,
         }
     }
 
@@ -83,30 +113,38 @@ impl SandboxPool {
     /// Acquire a sandbox from the pool
     ///
     /// Prefers warm sandboxes, creates new if none available.
-    pub async fn acquire(self: &Arc<Self>, config: &PodSandboxConfig) -> Result<String> {
-        // Check capacity
-        let active_count = self.active.lock().await.len();
-        if active_count >= self.config.max_sandboxes {
-            return Err(WorkerError::PoolExhausted {
-                max: self.config.max_sandboxes,
-            });
-        }
+    ///
+    /// # Admission control (#525 P2)
+    ///
+    /// `subject` must be a verified, non-anonymous [`Subject`] — an
+    /// unauthenticated caller is rejected fail-closed before any capacity or
+    /// quota bookkeeping happens. Admission (capacity + per-Subject/per-group
+    /// quota + cpu/memory/GPU fit) is reserved atomically under one lock
+    /// (see `runtime::admission`) before this method ever touches the warm
+    /// pool or the backend — never check-then-place.
+    ///
+    /// A request that only capacity (not quota) blocks may wait, bounded by
+    /// `PoolConfig::admission`'s queue settings; see [`WorkerError::QueueFull`]
+    /// / [`WorkerError::QueueTimeout`] / [`WorkerError::AdmissionDenied`] for
+    /// the distinct failure modes.
+    pub async fn acquire(self: &Arc<Self>, subject: &Subject, config: &PodSandboxConfig) -> Result<String> {
+        let demand = admission::derive_demand(config);
+        let group = admission::derive_group(config);
+        let reservation = self.admission.reserve(subject, group.as_deref(), demand).await?;
 
-        // Try to get a warm sandbox
-        let mut warm = self.warm_pool.lock().await;
-        let sandbox = if let Some(mut sandbox) = warm.pop_front() {
-            // Configure the warm sandbox with the provided config
-            sandbox.metadata = config.metadata.clone();
-            sandbox.labels = config.labels.clone();
-            sandbox.annotations = config.annotations.clone();
-            sandbox.state = PodSandboxState::SandboxReady;
-            sandbox
-        } else {
-            // Create a new sandbox
-            drop(warm); // Release lock before creating
-            self.create_sandbox(config).await?
+        let obtained = self.obtain_sandbox(config).await;
+        let mut sandbox = match obtained {
+            Ok(sandbox) => sandbox,
+            Err(e) => {
+                // Admission succeeded but no usable sandbox resulted (backend
+                // create/reconfigure failure) — give the reservation back
+                // rather than leaking capacity/quota.
+                self.admission.rollback(&reservation).await;
+                return Err(e);
+            }
         };
 
+        sandbox.reservation = Some(reservation);
         let sandbox_id = sandbox.id.clone();
 
         // Move to active
@@ -118,6 +156,40 @@ impl SandboxPool {
         Ok(sandbox_id)
     }
 
+    /// Pop a warm sandbox (reconfiguring it for `config`, including a resize
+    /// via `update_resources` when its previously-applied resources don't
+    /// match — the #519 fix) or cold-create one. Does not touch admission
+    /// bookkeeping; the caller (`acquire`) owns reserve/rollback around this.
+    async fn obtain_sandbox(&self, config: &PodSandboxConfig) -> Result<PodSandbox> {
+        let mut warm = self.warm_pool.lock().await;
+        if let Some(mut sandbox) = warm.pop_front() {
+            drop(warm);
+            // Configure the warm sandbox with the provided config
+            sandbox.metadata = config.metadata.clone();
+            sandbox.labels = config.labels.clone();
+            sandbox.annotations = config.annotations.clone();
+            sandbox.state = PodSandboxState::SandboxReady;
+
+            // #519 fix: a warm sandbox may have been booted at a different
+            // size (or the pool's default) than what THIS caller asked for.
+            // Reconfiguring metadata/labels/annotations above must not
+            // silently leave a mismatched resource envelope in place.
+            let requested = config.linux.resources.clone();
+            if requested != LinuxContainerResources::default() && requested != sandbox.applied_resources {
+                tracing::debug!(
+                    sandbox_id = %sandbox.id,
+                    "warm sandbox resource mismatch on reuse — resizing (#519)"
+                );
+                self.backend.update_resources(&sandbox, &requested).await?;
+                sandbox.applied_resources = requested;
+            }
+            Ok(sandbox)
+        } else {
+            drop(warm);
+            self.create_sandbox(config).await
+        }
+    }
+
     /// Release a sandbox back to the pool or destroy it
     pub async fn release(self: &Arc<Self>, sandbox_id: &str) -> Result<()> {
         let mut active = self.active.lock().await;
@@ -126,6 +198,14 @@ impl SandboxPool {
             .remove(sandbox_id)
             .ok_or_else(|| WorkerError::SandboxNotFound(sandbox_id.to_owned()))?;
         drop(active);
+
+        // Give back the admission reservation (capacity + per-Subject/group
+        // quota + resource dimensions) this sandbox was holding, waking any
+        // queued waiters. Sandboxes with no reservation (e.g. constructed
+        // outside `acquire`) have nothing to give back.
+        if let Some(reservation) = sandbox.reservation.clone() {
+            self.admission.release(&reservation).await;
+        }
 
         // Stop the sandbox
         self.backend.stop(&sandbox).await?;
@@ -251,6 +331,9 @@ impl SandboxPool {
         sandbox.set_backend_handle(handle);
 
         sandbox.state = PodSandboxState::SandboxReady;
+        // A cold-created sandbox is started with this exact config, so its
+        // resource envelope is authoritatively `config.linux.resources`.
+        sandbox.applied_resources = config.linux.resources.clone();
 
         Ok(sandbox)
     }
@@ -268,6 +351,12 @@ impl SandboxPool {
         sandbox.annotations.clear();
         sandbox.state = PodSandboxState::SandboxNotReady;
         sandbox.image_id = None;
+        // Admission bookkeeping ends with this acquisition; already released
+        // above in `release()`. Deliberately NOT resetting `applied_resources`
+        // here — see its doc on `PodSandbox` (#519): it must keep reflecting
+        // the sandbox's actual physical size for the next `acquire()`'s
+        // mismatch check.
+        sandbox.reservation = None;
 
         // Let the backend reset its handle
         let reusable = self.backend.reset(&mut sandbox).await?;
@@ -386,9 +475,10 @@ mod tests {
         let (pool, _temp_dir) = create_test_pool(5, 0).await?;
 
         let sandbox_config = PodSandboxConfig::default();
+        let subject = Subject::new("test-user");
 
         // Note: This will fail in CI since cloud-hypervisor isn't installed
-        let result = pool.acquire(&sandbox_config).await;
+        let result = pool.acquire(&subject, &sandbox_config).await;
 
         match result {
             Ok(sandbox_id) => {
@@ -432,5 +522,362 @@ mod tests {
         assert_eq!(stats.active_count, 0);
         assert_eq!(stats.warm_count, 0);
         Ok(())
+    }
+}
+
+// #525 P2 — admission/queue/resource-aware placement tests. These use a
+// minimal in-memory `FakeBackend` (no kata/nspawn/wasm dependency), so they
+// run in the default feature set (unlike the `kata-vm`-gated suite above,
+// which needs a real cloud-hypervisor).
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod admission_tests {
+    use super::*;
+    use crate::runtime::backend::SandboxHandle;
+    use crate::runtime::client::KeyValue;
+    use parking_lot::Mutex as StdMutex;
+    use std::any::Any;
+    use std::collections::HashMap as StdHashMap;
+    use std::sync::atomic::AtomicUsize as StdAtomicUsize;
+
+    #[derive(Debug)]
+    struct FakeHandle;
+    impl SandboxHandle for FakeHandle {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    /// Minimal in-memory fake backend. `reset()` returns `true` (reusable,
+    /// mirroring Kata) so warm-pool reuse — and the #519 resize path — is
+    /// actually exercised. Tracks concurrently-active starts so tests can
+    /// assert the admission layer never over-places (the #489/#519 TOCTOU
+    /// lesson), and records every `update_resources` call so the #519
+    /// regression test can assert a warm-sandbox resize actually happened.
+    #[derive(Default)]
+    struct FakeBackend {
+        current: StdAtomicUsize,
+        peak: StdAtomicUsize,
+        applied: StdMutex<StdHashMap<String, LinuxContainerResources>>,
+    }
+
+    impl FakeBackend {
+        fn bump(&self) {
+            let cur = self.current.fetch_add(1, Ordering::SeqCst) + 1;
+            self.peak.fetch_max(cur, Ordering::SeqCst);
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl SandboxBackend for FakeBackend {
+        fn backend_type(&self) -> &'static str {
+            "fake"
+        }
+        fn is_available(&self) -> bool {
+            true
+        }
+        async fn initialize(&self, _config: &crate::config::PoolConfig) -> Result<()> {
+            Ok(())
+        }
+        async fn start(
+            &self,
+            _sandbox: &mut PodSandbox,
+            _config: &PodSandboxConfig,
+            _pool_config: &crate::config::PoolConfig,
+            _annotations: &HashMap<String, String>,
+        ) -> Result<Arc<dyn SandboxHandle>> {
+            self.bump();
+            Ok(Arc::new(FakeHandle))
+        }
+        async fn stop(&self, _sandbox: &PodSandbox) -> Result<()> {
+            self.current.fetch_sub(1, Ordering::SeqCst);
+            Ok(())
+        }
+        async fn destroy(&self, _sandbox: &PodSandbox) -> Result<()> {
+            Ok(())
+        }
+        async fn reset(&self, _sandbox: &mut PodSandbox) -> Result<bool> {
+            // Reusable (Kata-like) — required to exercise the warm-pool /
+            // #519 resize path below.
+            Ok(true)
+        }
+        async fn get_pids(&self, _sandbox: &PodSandbox) -> Result<Vec<u32>> {
+            Ok(vec![])
+        }
+        fn supports_exec(&self) -> bool {
+            false
+        }
+        async fn exec_sync(
+            &self,
+            _sandbox: &PodSandbox,
+            _command: &[String],
+            _timeout_secs: u64,
+        ) -> Result<(i32, Vec<u8>, Vec<u8>)> {
+            Err(WorkerError::ExecFailed("not supported".into()))
+        }
+        async fn update_resources(
+            &self,
+            sandbox: &PodSandbox,
+            resources: &LinuxContainerResources,
+        ) -> Result<()> {
+            self.applied.lock().insert(sandbox.id.clone(), resources.clone());
+            Ok(())
+        }
+    }
+
+    fn make_pool_with(max_sandboxes: usize, warm_pool_size: usize) -> (Arc<SandboxPool>, Arc<FakeBackend>) {
+        let fake = Arc::new(FakeBackend::default());
+        let backend: Arc<dyn SandboxBackend> = fake.clone();
+        let config = PoolConfig { max_sandboxes, warm_pool_size, ..Default::default() };
+        (Arc::new(SandboxPool::new(config, backend)), fake)
+    }
+
+    fn make_pool_with_admission(
+        max_sandboxes: usize,
+        warm_pool_size: usize,
+        admission: crate::runtime::AdmissionConfig,
+    ) -> (Arc<SandboxPool>, Arc<FakeBackend>) {
+        let fake = Arc::new(FakeBackend::default());
+        let backend: Arc<dyn SandboxBackend> = fake.clone();
+        let config = PoolConfig { max_sandboxes, warm_pool_size, admission, ..Default::default() };
+        (Arc::new(SandboxPool::new(config, backend)), fake)
+    }
+
+    // ── Solo/no-regression baseline ──────────────────────────────────────
+
+    #[tokio::test]
+    async fn solo_acquire_release_unchanged() {
+        let (pool, _fake) = make_pool_with(5, 0);
+        let subject = Subject::new("alice");
+        let sandbox_config = PodSandboxConfig::default();
+
+        let id = pool.acquire(&subject, &sandbox_config).await.expect("solo acquire must succeed");
+        assert!(pool.get(&id).await.is_some());
+        assert_eq!(pool.stats().await.active_count, 1);
+
+        pool.release(&id).await.expect("release must succeed");
+        assert!(pool.get(&id).await.is_none());
+        assert_eq!(pool.stats().await.active_count, 0);
+    }
+
+    #[tokio::test]
+    async fn solo_capacity_exhausted_without_queue_room_rejects_clearly() {
+        let cfg = crate::runtime::AdmissionConfig { queue_capacity: 0, ..Default::default() };
+        let (pool, _fake) = make_pool_with_admission(1, 0, cfg);
+        let subject = Subject::new("alice");
+        let sandbox_config = PodSandboxConfig::default();
+
+        let _id = pool.acquire(&subject, &sandbox_config).await.expect("first acquire admits");
+        let err = pool.acquire(&subject, &sandbox_config).await.unwrap_err();
+        assert!(matches!(err, WorkerError::QueueFull { .. }), "got: {err:?}");
+    }
+
+    // ── Fail-closed identity ─────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn anonymous_caller_rejected_fail_closed() {
+        let (pool, _fake) = make_pool_with(5, 0);
+        let sandbox_config = PodSandboxConfig::default();
+        let err = pool.acquire(&Subject::anonymous(), &sandbox_config).await.unwrap_err();
+        assert!(matches!(err, WorkerError::Unauthorized { .. }), "got: {err:?}");
+        // Must not have consumed any capacity.
+        assert_eq!(pool.stats().await.active_count, 0);
+    }
+
+    // ── Per-Subject / per-group quota ────────────────────────────────────
+
+    #[tokio::test]
+    async fn per_subject_quota_rejects_over_quota_caller() {
+        let cfg = crate::runtime::AdmissionConfig { max_per_subject: 1, ..Default::default() };
+        let (pool, _fake) = make_pool_with_admission(10, 0, cfg);
+        let alice = Subject::new("alice");
+        let sandbox_config = PodSandboxConfig::default();
+
+        let _id = pool.acquire(&alice, &sandbox_config).await.expect("first request admitted");
+        let err = pool.acquire(&alice, &sandbox_config).await.unwrap_err();
+        assert!(matches!(err, WorkerError::AdmissionDenied { .. }), "got: {err:?}");
+    }
+
+    // ── GPU-aware placement (fit over the #628 scheduling substrate) ─────
+
+    #[tokio::test]
+    async fn gpu_request_placed_only_when_capacity_declared() {
+        let cfg = crate::runtime::AdmissionConfig { gpu_total: 0, ..Default::default() };
+        let (pool, _fake) = make_pool_with_admission(10, 0, cfg);
+        let subject = Subject::new("alice");
+        let mut sandbox_config = PodSandboxConfig::default();
+        sandbox_config
+            .annotations
+            .push(KeyValue { key: crate::runtime::ANN_GPU_REQUEST.to_owned(), value: "1".to_owned() });
+
+        // No GPU capacity declared → fail-closed reject, never a silent
+        // CPU-only placement.
+        let err = pool.acquire(&subject, &sandbox_config).await.unwrap_err();
+        assert!(matches!(err, WorkerError::QueueFull { .. } | WorkerError::QueueTimeout { .. }), "got: {err:?}");
+    }
+
+    #[tokio::test]
+    async fn gpu_request_placed_when_capacity_available() {
+        let cfg = crate::runtime::AdmissionConfig { gpu_total: 1, ..Default::default() };
+        let (pool, _fake) = make_pool_with_admission(10, 0, cfg);
+        let subject = Subject::new("alice");
+        let mut sandbox_config = PodSandboxConfig::default();
+        sandbox_config
+            .annotations
+            .push(KeyValue { key: crate::runtime::ANN_GPU_REQUEST.to_owned(), value: "1".to_owned() });
+
+        let id = pool.acquire(&subject, &sandbox_config).await.expect("gpu request should be admitted");
+        assert!(pool.get(&id).await.is_some());
+    }
+
+    #[tokio::test]
+    async fn cpu_and_memory_request_honored_within_capacity() {
+        let cfg = crate::runtime::AdmissionConfig {
+            cpu_millis_total: Some(1000),
+            memory_bytes_total: Some(1024 * 1024 * 1024),
+            ..Default::default()
+        };
+        let (pool, _fake) = make_pool_with_admission(10, 0, cfg);
+        let subject = Subject::new("alice");
+        let mut sandbox_config = PodSandboxConfig::default();
+        sandbox_config.linux.resources.cpu_period = 100_000;
+        sandbox_config.linux.resources.cpu_quota = 50_000; // 500m
+        sandbox_config.linux.resources.memory_limit_in_bytes = 512 * 1024 * 1024;
+
+        let id = pool.acquire(&subject, &sandbox_config).await.expect("fits within declared capacity");
+        assert!(pool.get(&id).await.is_some());
+    }
+
+    #[tokio::test]
+    async fn memory_request_exceeding_capacity_is_not_silently_placed() {
+        let cfg = crate::runtime::AdmissionConfig {
+            memory_bytes_total: Some(256 * 1024 * 1024),
+            queue_capacity: 0,
+            ..Default::default()
+        };
+        let (pool, _fake) = make_pool_with_admission(10, 0, cfg);
+        let subject = Subject::new("alice");
+        let mut sandbox_config = PodSandboxConfig::default();
+        sandbox_config.linux.resources.memory_limit_in_bytes = 512 * 1024 * 1024; // exceeds declared 256Mi
+
+        let err = pool.acquire(&subject, &sandbox_config).await.unwrap_err();
+        assert!(matches!(err, WorkerError::QueueFull { .. }), "got: {err:?}");
+    }
+
+    // ── #519 regression: warm-sandbox reuse must resize, never silently
+    //    hand out the wrong size ──────────────────────────────────────────
+
+    #[tokio::test]
+    async fn warm_sandbox_reuse_resizes_mismatched_resources() {
+        let (pool, fake) = make_pool_with(5, 1);
+        pool.initialize().await.expect("prewarm one sandbox");
+        assert_eq!(pool.stats().await.warm_count, 1);
+
+        let subject = Subject::new("alice");
+        let mut sandbox_config = PodSandboxConfig::default();
+        sandbox_config.linux.resources.cpu_period = 100_000;
+        sandbox_config.linux.resources.cpu_quota = 75_000;
+        sandbox_config.linux.resources.memory_limit_in_bytes = 256 * 1024 * 1024;
+
+        // The one warm sandbox was booted with `PodSandboxConfig::default()`
+        // (all-zero resources) — this request asks for something different,
+        // so acquire() must detect the mismatch and resize it rather than
+        // silently handing out the warm sandbox's original (wrong) size.
+        let id = pool.acquire(&subject, &sandbox_config).await.expect("warm reuse should succeed");
+
+        let applied = fake.applied.lock();
+        let recorded = applied.get(&id).expect("update_resources must have been called for this sandbox");
+        assert_eq!(recorded.memory_limit_in_bytes, 256 * 1024 * 1024);
+        assert_eq!(recorded.cpu_quota, 75_000);
+    }
+
+    #[tokio::test]
+    async fn cold_created_sandbox_needs_no_extra_resize_call() {
+        // warm_pool_size 0 → always cold-creates. `start()` receives the
+        // full config directly, so there should be no separate
+        // `update_resources` call layered on top.
+        let (pool, fake) = make_pool_with(5, 0);
+        let subject = Subject::new("alice");
+        let mut sandbox_config = PodSandboxConfig::default();
+        sandbox_config.linux.resources.memory_limit_in_bytes = 128 * 1024 * 1024;
+
+        let id = pool.acquire(&subject, &sandbox_config).await.expect("cold create should succeed");
+        assert!(fake.applied.lock().get(&id).is_none());
+    }
+
+    // ── Concurrency / TOCTOU (#489/#519 lesson): never over-place ─────────
+
+    #[tokio::test]
+    async fn concurrent_acquires_never_exceed_capacity() {
+        let capacity = 2usize;
+        let n = 6usize;
+        let cfg = crate::runtime::AdmissionConfig {
+            queue_capacity: n,
+            queue_timeout_secs: 1,
+            ..Default::default()
+        };
+        let (pool, fake) = make_pool_with_admission(capacity, 0, cfg);
+
+        let mut handles = Vec::new();
+        for i in 0..n {
+            let pool = pool.clone();
+            handles.push(tokio::spawn(async move {
+                let subject = Subject::new(format!("user-{i}"));
+                pool.acquire(&subject, &PodSandboxConfig::default()).await
+            }));
+        }
+
+        let mut ok = 0usize;
+        let mut failed = 0usize;
+        for h in handles {
+            match h.await.expect("task must not panic") {
+                Ok(_) => ok += 1,
+                Err(e) => {
+                    failed += 1;
+                    assert!(
+                        matches!(e, WorkerError::QueueFull { .. } | WorkerError::QueueTimeout { .. }),
+                        "unexpected error: {e:?}"
+                    );
+                }
+            }
+        }
+
+        assert_eq!(ok, capacity, "exactly `capacity` requests must be admitted");
+        assert_eq!(failed, n - capacity, "the rest must queue-then-timeout or reject, never silently succeed");
+        // The backend itself must never have seen more concurrently-started
+        // sandboxes than the declared capacity — the actual TOCTOU check.
+        assert!(
+            fake.peak.load(Ordering::SeqCst) <= capacity,
+            "backend saw more concurrent starts than capacity allows: {}",
+            fake.peak.load(Ordering::SeqCst)
+        );
+        assert_eq!(pool.stats().await.active_count, capacity);
+    }
+
+    #[tokio::test]
+    async fn queued_request_is_admitted_once_capacity_frees() {
+        let cfg = crate::runtime::AdmissionConfig { queue_timeout_secs: 5, ..Default::default() };
+        let (pool, _fake) = make_pool_with_admission(1, 0, cfg);
+        let subject = Subject::new("alice");
+        let sandbox_config = PodSandboxConfig::default();
+
+        let first = pool.acquire(&subject, &sandbox_config).await.expect("first request admitted");
+
+        let pool2 = pool.clone();
+        let waiter = tokio::spawn(async move {
+            let bob = Subject::new("bob");
+            pool2.acquire(&bob, &PodSandboxConfig::default()).await
+        });
+
+        // Give the waiter a moment to actually enter the queue, then free
+        // capacity by releasing the first sandbox.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        pool.release(&first).await.expect("release must succeed");
+
+        let result = tokio::time::timeout(std::time::Duration::from_secs(2), waiter)
+            .await
+            .expect("queued waiter should be woken well within 2s")
+            .expect("task must not panic");
+        assert!(result.is_ok(), "queued request should be admitted once capacity frees: {result:?}");
     }
 }

--- a/crates/hyprstream-workers/src/runtime/pool.rs
+++ b/crates/hyprstream-workers/src/runtime/pool.rs
@@ -129,8 +129,11 @@ impl SandboxPool {
     /// the distinct failure modes.
     pub async fn acquire(self: &Arc<Self>, subject: &Subject, config: &PodSandboxConfig) -> Result<String> {
         let demand = admission::derive_demand(config);
-        let group = admission::derive_group(config);
-        let reservation = self.admission.reserve(subject, group.as_deref(), demand).await?;
+        let group_selector = admission::derive_group_selector(config);
+        let reservation = self
+            .admission
+            .reserve(subject, group_selector.as_deref(), demand)
+            .await?;
 
         let obtained = self.obtain_sandbox(config).await;
         let mut sandbox = match obtained {
@@ -180,7 +183,23 @@ impl SandboxPool {
                     sandbox_id = %sandbox.id,
                     "warm sandbox resource mismatch on reuse — resizing (#519)"
                 );
-                self.backend.update_resources(&sandbox, &requested).await?;
+                // F2: this sandbox has already been popped off `warm_pool`, so
+                // if the resize fails the value is about to be dropped and its
+                // VM/container would be orphaned (still running, owned by
+                // nobody, warm pool permanently shrunk). Best-effort destroy it
+                // — its actual size is now unknown/untrusted — before
+                // propagating. `acquire` rolls back the admission reservation
+                // on the returned error, so capacity/quota are not leaked.
+                if let Err(resize_err) = self.backend.update_resources(&sandbox, &requested).await {
+                    if let Err(destroy_err) = self.backend.destroy(&sandbox).await {
+                        tracing::warn!(
+                            sandbox_id = %sandbox.id,
+                            error = %destroy_err,
+                            "failed to destroy warm sandbox after resize failure — possible orphan"
+                        );
+                    }
+                    return Err(resize_err);
+                }
                 sandbox.applied_resources = requested;
             }
             Ok(sandbox)
@@ -199,16 +218,40 @@ impl SandboxPool {
             .ok_or_else(|| WorkerError::SandboxNotFound(sandbox_id.to_owned()))?;
         drop(active);
 
-        // Give back the admission reservation (capacity + per-Subject/group
-        // quota + resource dimensions) this sandbox was holding, waking any
-        // queued waiters. Sandboxes with no reservation (e.g. constructed
-        // outside `acquire`) have nothing to give back.
-        if let Some(reservation) = sandbox.reservation.clone() {
-            self.admission.release(&reservation).await;
+        // F5: give back the admission reservation only *after* the sandbox's
+        // resources are actually released, i.e. after `stop` succeeds. Waking a
+        // queued waiter before `stop` completes would let it cold-create while
+        // this sandbox's VM is still physically holding cpu/memory/GPU —
+        // transiently over-committing the envelope (`max_sandboxes + 1`). On
+        // stop failure, best-effort destroy so we don't orphan the sandbox
+        // (mirroring the shutdown path's tolerance), then still release the
+        // reservation so capacity/quota aren't permanently leaked, and
+        // propagate the error.
+        let release_reservation = || async {
+            if let Some(reservation) = sandbox.reservation.clone() {
+                self.admission.release(&reservation).await;
+            }
+        };
+
+        if let Err(stop_err) = self.backend.stop(&sandbox).await {
+            tracing::warn!(
+                sandbox_id = %sandbox.id,
+                error = %stop_err,
+                "stop failed on release — destroying sandbox to avoid an orphan"
+            );
+            if let Err(destroy_err) = self.backend.destroy(&sandbox).await {
+                tracing::warn!(
+                    sandbox_id = %sandbox.id,
+                    error = %destroy_err,
+                    "destroy also failed after stop failure — possible orphan"
+                );
+            }
+            release_reservation().await;
+            return Err(stop_err);
         }
 
-        // Stop the sandbox
-        self.backend.stop(&sandbox).await?;
+        // Stop succeeded — the resource envelope is genuinely free now.
+        release_reservation().await;
 
         // Decide whether to return to warm pool or destroy
         let warm = self.warm_pool.lock().await;
@@ -538,6 +581,7 @@ mod admission_tests {
     use parking_lot::Mutex as StdMutex;
     use std::any::Any;
     use std::collections::HashMap as StdHashMap;
+    use std::sync::atomic::AtomicBool as StdAtomicBool;
     use std::sync::atomic::AtomicUsize as StdAtomicUsize;
 
     #[derive(Debug)]
@@ -559,12 +603,21 @@ mod admission_tests {
         current: StdAtomicUsize,
         peak: StdAtomicUsize,
         applied: StdMutex<StdHashMap<String, LinuxContainerResources>>,
+        /// When set, `update_resources` fails (F2 resize-leak test).
+        fail_resize: StdAtomicBool,
+        /// When set, `stop` fails (F5 release-ordering test).
+        fail_stop: StdAtomicBool,
+        /// Ids passed to `destroy`, in call order (F2/F5 orphan-avoidance).
+        destroyed: StdMutex<Vec<String>>,
     }
 
     impl FakeBackend {
         fn bump(&self) {
             let cur = self.current.fetch_add(1, Ordering::SeqCst) + 1;
             self.peak.fetch_max(cur, Ordering::SeqCst);
+        }
+        fn was_destroyed(&self, id: &str) -> bool {
+            self.destroyed.lock().iter().any(|d| d == id)
         }
     }
 
@@ -590,10 +643,18 @@ mod admission_tests {
             Ok(Arc::new(FakeHandle))
         }
         async fn stop(&self, _sandbox: &PodSandbox) -> Result<()> {
+            if self.fail_stop.load(Ordering::SeqCst) {
+                // Did not stop → do not decrement the live count.
+                return Err(WorkerError::SandboxTimeout {
+                    operation: "stop".to_owned(),
+                    timeout_secs: 0,
+                });
+            }
             self.current.fetch_sub(1, Ordering::SeqCst);
             Ok(())
         }
-        async fn destroy(&self, _sandbox: &PodSandbox) -> Result<()> {
+        async fn destroy(&self, sandbox: &PodSandbox) -> Result<()> {
+            self.destroyed.lock().push(sandbox.id.clone());
             Ok(())
         }
         async fn reset(&self, _sandbox: &mut PodSandbox) -> Result<bool> {
@@ -620,6 +681,12 @@ mod admission_tests {
             sandbox: &PodSandbox,
             resources: &LinuxContainerResources,
         ) -> Result<()> {
+            if self.fail_resize.load(Ordering::SeqCst) {
+                return Err(WorkerError::SandboxTimeout {
+                    operation: "update_resources".to_owned(),
+                    timeout_secs: 0,
+                });
+            }
             self.applied.lock().insert(sandbox.id.clone(), resources.clone());
             Ok(())
         }
@@ -688,7 +755,7 @@ mod admission_tests {
 
     #[tokio::test]
     async fn per_subject_quota_rejects_over_quota_caller() {
-        let cfg = crate::runtime::AdmissionConfig { max_per_subject: 1, ..Default::default() };
+        let cfg = crate::runtime::AdmissionConfig { max_per_subject: Some(1), ..Default::default() };
         let (pool, _fake) = make_pool_with_admission(10, 0, cfg);
         let alice = Subject::new("alice");
         let sandbox_config = PodSandboxConfig::default();
@@ -711,9 +778,15 @@ mod admission_tests {
             .push(KeyValue { key: crate::runtime::ANN_GPU_REQUEST.to_owned(), value: "1".to_owned() });
 
         // No GPU capacity declared → fail-closed reject, never a silent
-        // CPU-only placement.
+        // CPU-only placement. F1: this is *infeasible* (exceeds the node total),
+        // so it must reject immediately rather than queue out the timeout.
+        let start = std::time::Instant::now();
         let err = pool.acquire(&subject, &sandbox_config).await.unwrap_err();
-        assert!(matches!(err, WorkerError::QueueFull { .. } | WorkerError::QueueTimeout { .. }), "got: {err:?}");
+        assert!(matches!(err, WorkerError::AdmissionInfeasible { .. }), "got: {err:?}");
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(1),
+            "infeasible GPU request must reject immediately, not wait the queue timeout"
+        );
     }
 
     #[tokio::test]
@@ -760,8 +833,11 @@ mod admission_tests {
         let mut sandbox_config = PodSandboxConfig::default();
         sandbox_config.linux.resources.memory_limit_in_bytes = 512 * 1024 * 1024; // exceeds declared 256Mi
 
+        // F1: demand above the declared *total* is infeasible (no release can
+        // ever satisfy it), so it rejects immediately rather than queueing —
+        // still never a silent placement.
         let err = pool.acquire(&subject, &sandbox_config).await.unwrap_err();
-        assert!(matches!(err, WorkerError::QueueFull { .. }), "got: {err:?}");
+        assert!(matches!(err, WorkerError::AdmissionInfeasible { .. }), "got: {err:?}");
     }
 
     // ── #519 regression: warm-sandbox reuse must resize, never silently
@@ -879,5 +955,73 @@ mod admission_tests {
             .expect("queued waiter should be woken well within 2s")
             .expect("task must not panic");
         assert!(result.is_ok(), "queued request should be admitted once capacity frees: {result:?}");
+    }
+
+    // ── F2: resize failure must not orphan the popped warm sandbox ─────────
+
+    #[tokio::test]
+    async fn resize_failure_destroys_warm_sandbox_and_rolls_back_reservation() {
+        // queue_capacity 0 so any leaked reservation shows up as an immediate
+        // QueueFull on the follow-up acquire.
+        let cfg = crate::runtime::AdmissionConfig { queue_capacity: 0, ..Default::default() };
+        let (pool, fake) = make_pool_with_admission(1, 1, cfg);
+        pool.initialize().await.expect("prewarm one sandbox");
+        assert_eq!(pool.stats().await.warm_count, 1);
+
+        fake.fail_resize.store(true, Ordering::SeqCst);
+
+        let subject = Subject::new("alice");
+        let mut sandbox_config = PodSandboxConfig::default();
+        // Force a mismatch vs the warm sandbox's default (all-zero) resources so
+        // the #519 resize path runs — and fails.
+        sandbox_config.linux.resources.memory_limit_in_bytes = 256 * 1024 * 1024;
+
+        let err = pool.acquire(&subject, &sandbox_config).await.unwrap_err();
+        assert!(matches!(err, WorkerError::SandboxTimeout { .. }), "resize error propagates: {err:?}");
+        // The popped warm sandbox must be destroyed, not orphaned.
+        assert!(
+            !fake.destroyed.lock().is_empty(),
+            "warm sandbox must be destroyed on resize failure (no orphan)"
+        );
+        assert_eq!(pool.stats().await.active_count, 0, "no active-sandbox leak");
+
+        // Reservation rolled back: a fresh cold acquire fits the single slot.
+        fake.fail_resize.store(false, Ordering::SeqCst);
+        let id = pool
+            .acquire(&subject, &PodSandboxConfig::default())
+            .await
+            .expect("capacity/quota must have been rolled back after resize failure");
+        assert!(pool.get(&id).await.is_some());
+    }
+
+    // ── F5: stop failure on release must not orphan / over-commit ──────────
+
+    #[tokio::test]
+    async fn stop_failure_on_release_destroys_sandbox_and_still_frees_reservation() {
+        let cfg = crate::runtime::AdmissionConfig { queue_capacity: 0, ..Default::default() };
+        let (pool, fake) = make_pool_with_admission(1, 0, cfg);
+        let subject = Subject::new("alice");
+        let id = pool
+            .acquire(&subject, &PodSandboxConfig::default())
+            .await
+            .expect("acquire");
+
+        fake.fail_stop.store(true, Ordering::SeqCst);
+        let err = pool.release(&id).await.unwrap_err();
+        assert!(matches!(err, WorkerError::SandboxTimeout { .. }), "stop error propagates: {err:?}");
+        // Orphan avoided: a destroy was attempted after the stop failure.
+        assert!(
+            fake.was_destroyed(&id),
+            "sandbox must be destroyed after stop failure to avoid an orphan"
+        );
+
+        // The reservation is still freed (only after the stop attempt), so
+        // capacity recovers — a leak would make the next acquire QueueFull.
+        fake.fail_stop.store(false, Ordering::SeqCst);
+        let id2 = pool
+            .acquire(&subject, &PodSandboxConfig::default())
+            .await
+            .expect("reservation must be freed even when stop fails");
+        assert!(pool.get(&id2).await.is_some());
     }
 }

--- a/crates/hyprstream-workers/src/runtime/sandbox.rs
+++ b/crates/hyprstream-workers/src/runtime/sandbox.rs
@@ -8,8 +8,9 @@ use chrono::{DateTime, Utc};
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use super::admission::ReservationRecord;
 use super::backend::SandboxHandle;
-use super::client::{KeyValue, PodSandboxState};
+use super::client::{KeyValue, LinuxContainerResources, PodSandboxState};
 use crate::generated::worker_client::PodSandboxMetadata;
 
 /// Runtime representation of a pod sandbox
@@ -51,6 +52,31 @@ pub struct PodSandbox {
     /// For Cloud Hypervisor: path to the API socket (or a dedicated serial socket).
     /// For nspawn: path to the console socket (if enabled).
     pub(crate) console_socket: Option<PathBuf>,
+
+    /// The `LinuxContainerResources` last actually applied to this sandbox by
+    /// the backend (via `start()` or `update_resources()`) — the physical
+    /// truth, independent of any pool bookkeeping. `Default` (all-zero /
+    /// CRI-"unspecified") for a freshly-booted warm sandbox that has never
+    /// had a caller's resources applied.
+    ///
+    /// #519 fix: `SandboxPool::acquire` compares an incoming request's
+    /// `config.linux.resources` against this field before handing out a
+    /// warm sandbox, and calls `update_resources` (updating this field in
+    /// turn) on a mismatch — instead of silently reusing whatever size the
+    /// sandbox happened to be booted with. Deliberately **not** reset when a
+    /// sandbox is returned to the warm pool (`reset_sandbox`): resetting it
+    /// to `Default` would be a lie (the backend's `reset()` does not resize
+    /// the sandbox back down), and the next `acquire()`'s comparison depends
+    /// on this reflecting the sandbox's actual current size.
+    pub(crate) applied_resources: LinuxContainerResources,
+
+    /// The admission reservation (#525 P2) this sandbox is holding, if it was
+    /// obtained through `SandboxPool::acquire`'s admission-controlled path.
+    /// `None` for sandboxes constructed outside that path (e.g. `from_info`,
+    /// or a warm sandbox that has not yet been claimed). `SandboxPool::release`
+    /// gives this back to the `AdmissionTracker` so per-Subject/per-group
+    /// counters and resource reservations are released precisely.
+    pub(crate) reservation: Option<ReservationRecord>,
 }
 
 impl Clone for PodSandbox {
@@ -67,6 +93,8 @@ impl Clone for PodSandbox {
             sandbox_path: self.sandbox_path.clone(),
             image_id: self.image_id.clone(),
             console_socket: self.console_socket.clone(),
+            applied_resources: self.applied_resources.clone(),
+            reservation: self.reservation.clone(),
         }
     }
 }
@@ -89,6 +117,8 @@ impl PodSandbox {
             sandbox_path,
             image_id: None,
             console_socket: None,
+            applied_resources: LinuxContainerResources::default(),
+            reservation: None,
         }
     }
 
@@ -116,6 +146,8 @@ impl PodSandbox {
             sandbox_path: PathBuf::new(),
             image_id: None,
             console_socket: None,
+            applied_resources: LinuxContainerResources::default(),
+            reservation: None,
         }
     }
 

--- a/crates/hyprstream-workers/src/runtime/service.rs
+++ b/crates/hyprstream-workers/src/runtime/service.rs
@@ -246,8 +246,14 @@ impl WorkerService {
     // ─────────────────────────────────────────────────────────────────────────
 
     /// Create and start a pod sandbox (Kata VM)
-    pub async fn run_pod_sandbox(&self, config: &PodSandboxConfig) -> Result<String> {
-        let sandbox_id = self.sandbox_pool.acquire(config).await?;
+    ///
+    /// `subject` is the cryptographically-verified caller identity (#525 P2
+    /// admission control) — derive it from `ctx.subject()` at the RPC
+    /// dispatch boundary (see `handle_run`), never accept a caller-asserted
+    /// subject as a plain parameter (see the MAC interface policy: "derive,
+    /// don't extend").
+    pub async fn run_pod_sandbox(&self, subject: &hyprstream_vfs::Subject, config: &PodSandboxConfig) -> Result<String> {
+        let sandbox_id = self.sandbox_pool.acquire(subject, config).await?;
         tracing::info!(sandbox_id = %sandbox_id, "Created pod sandbox");
 
         // Publish sandbox started event with structured payload
@@ -1228,8 +1234,11 @@ impl RuntimeHandler for WorkerService {
 
 #[async_trait::async_trait(?Send)]
 impl SandboxHandler for WorkerService {
-    async fn handle_run(&self, _ctx: &EnvelopeContext, _request_id: u64, data: &PodSandboxConfig) -> AnyhowResult<String> {
-        let sandbox_id = self.run_pod_sandbox(data).await?;
+    async fn handle_run(&self, ctx: &EnvelopeContext, _request_id: u64, data: &PodSandboxConfig) -> AnyhowResult<String> {
+        // #525 P2: thread the verified caller identity through to admission
+        // control. `ctx.subject()` is derived from the verified envelope
+        // (signer key / JWT), never caller-asserted data.
+        let sandbox_id = self.run_pod_sandbox(&ctx.subject(), data).await?;
         Ok(sandbox_id)
     }
 
@@ -1503,7 +1512,8 @@ mod tests {
 
         // Create sandbox - this requires cloud-hypervisor and kata runtime directories
         let config = PodSandboxConfig::default();
-        let result = service.run_pod_sandbox(&config).await;
+        let subject = hyprstream_vfs::Subject::new("test-user");
+        let result = service.run_pod_sandbox(&subject, &config).await;
 
         // Skip test if cloud-hypervisor not installed or kata runtime not available
         match &result {
@@ -1545,7 +1555,8 @@ mod tests {
 
         // Create sandbox first - this requires cloud-hypervisor and kata runtime directories
         let sandbox_config = PodSandboxConfig::default();
-        let result = service.run_pod_sandbox(&sandbox_config).await;
+        let subject = hyprstream_vfs::Subject::new("test-user");
+        let result = service.run_pod_sandbox(&subject, &sandbox_config).await;
 
         // Skip test if cloud-hypervisor not installed or kata runtime not available
         match &result {

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -2573,6 +2573,30 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(clippy::expect_used)]
+    fn test_config_with_worker_section_at_defaults_serializes_to_toml() {
+        // F3 (#761) regression: `AdmissionConfig`'s default per-Subject/per-group
+        // quotas used to be `usize::MAX`, which is not a valid TOML i64, so
+        // `Config::save()` (which does `toml::to_string_pretty(self)`) failed
+        // for any config carrying a `[worker]` section. This reproduces that
+        // exact save path and round-trips it.
+        let mut config = HyprConfig::default();
+        config.worker = Some(hyprstream_workers::config::WorkerConfig::default());
+
+        let toml_str = toml::to_string_pretty(&config)
+            .expect("a default worker section must serialize to TOML (F3)");
+        let parsed: HyprConfig =
+            toml::from_str(&toml_str).expect("round-trip parse must succeed");
+        let admission = parsed
+            .worker
+            .expect("worker section round-trips")
+            .pool
+            .admission;
+        assert_eq!(admission.max_per_subject, None);
+        assert_eq!(admission.max_per_group, None);
+    }
+
+    #[test]
     fn test_generation_config_defaults() {
         let config = GenerationConfig::default();
 


### PR DESCRIPTION
## Summary

Implements #525 (P2 of epic #523): replaces `SandboxPool::acquire`'s immediate "check `active.len()`, then `PoolExhausted` or admit" shape with a real admission/placement decision engine.

- **Fail-closed identity**: `acquire` now takes a verified `Subject`. An anonymous/unauthenticated caller is rejected (`WorkerError::Unauthorized`) before any capacity or quota bookkeeping runs.
- **Per-Subject / per-group quotas**: configurable ceilings (`PoolConfig.admission`), checked and enforced with an in-memory counter. Over-quota is a fail-fast reject (`WorkerError::AdmissionDenied`) — quota rejections never queue.
- **Bounded wait-queue for capacity**: a request blocked only by capacity (not quota) waits, bounded by `queue_capacity` (immediate `WorkerError::QueueFull` past the bound) and `queue_timeout_secs` (`WorkerError::QueueTimeout` on expiry).
- **Reserve-then-place under one lock**: capacity + quota + cpu/memory/GPU fit are checked *and committed* atomically in `try_admit_locked`, closing the same TOCTOU class called out for #489/#519 — never check-then-place.
- **Resource + GPU-aware fit**: cpu/memory/GPU demand is derived from `config.linux.resources` + a new `hyprstream.io/gpu-request` annotation, and checked via the **real #628 scheduling substrate** (`hyprstream_discovery::scheduling::{filter, rank, select}`) over a `LocalCandidate` — not bespoke arithmetic. Single-node/solo case is the only candidate today; the `rank_by` closure is the documented seam for feeding `queryCandidates` results in as additional candidates later.
- **#519 fix**: a warm sandbox handed out on a resource mismatch is now resized via `backend.update_resources()` before being handed to the caller, instead of silently keeping whatever size it was booted with. `PodSandbox.applied_resources` tracks the sandbox's actual physical envelope across warm-pool reuse to make the comparison possible.

Closes #519. Part of epic #523, phase P2 (#525).

## 🔒 Judgment calls flagged for reviewer sign-off

This ticket is explicitly sign-off-gated on quota model shape / Casbin wiring / any wire-format change / cross-node ranking depth. None of these are treated as final:

1. **Quota model is a simple in-memory counter, not Casbin-policy-driven.** `PoolConfig.admission.{max_per_subject, max_per_group}` are flat numeric ceilings in config — no Casbin policy lookup, no per-tenant dynamic configuration. Chose this because I couldn't find an existing Casbin-quota pattern elsewhere in the codebase to reuse (Casbin as used today is `action:resource:identifier` authorization, not numeric-limit policy) and inventing one felt like exactly the kind of decision this ticket says needs a human. Full Casbin-backed quota configuration is a clean follow-up on top of this shape.
2. **"Group" identity is a placeholder.** There's no first-class "group"/tenant claim on `Claims` today. `derive_group` reads a plain annotation (`hyprstream.io/group`) off the request rather than adding a new JWT claim or capnp field. This deliberately avoids a wire-format change, but it means "group" is whatever string a caller puts in an annotation — not cryptographically asserted. If group-based quotas need to be trustworthy (not just a convenience partition), this needs a real claim, which is a capnp/JWT-schema change I did not make.
3. **New Rust-only API surface, not a capnp change**: `SandboxPool::acquire` and `WorkerService::run_pod_sandbox` gained a new `subject: &Subject` parameter, threaded from the already-existing (previously-unused, `_ctx`) `EnvelopeContext` at the RPC dispatch boundary (`handle_run`). This is a plain Rust signature change, not a capnp/wire-format change — `ctx.subject()` was already available at that boundary, just discarded. Flagging because it does touch a public-ish internal API (~9 test call sites in `exec_mount.rs`/`pool.rs`/`service.rs` updated) but it's additive and derives identity rather than accepting a caller-asserted one (per the MAC interface-policy doc's "derive, don't extend" pattern).
4. **Wait-queue is a single bounded FIFO-ish structure, not the per-Subject/per-group fair sub-queue + weighted-round-robin the issue's design note describes.** On any release, every queued waiter is woken and re-races to retry admission under the lock; there's no per-key fairness weighting on the *capacity* wait queue. Quota-rejected requests never queue at all (fail-fast), which limits one noisy Subject/group's ability to monopolize *that* axis, but true per-key WRR fairness on the capacity queue itself is not implemented. Scoped down deliberately — the ticket's own YAGNI note allows this ("pick something correct and testable; don't over-engineer"), but flagging since the design note explicitly asked for the fancier version.
5. **Backend placement is unchanged/single-backend-per-pool** — `SandboxPool` is still bound to exactly one `SandboxBackend`, resolved once at construction via the existing fail-closed `resolve_backend` (#507/#516) inventory-registry seam. Per-request routing to *different* backends within one pool (e.g. GPU workloads to `kata`, CPU-only to `nspawn`) is **not implemented** — it would need `SandboxPool` restructured into a router over multiple backend-specific pools, which felt like a materially larger architectural change than this ticket's scope. `acquire` never bypasses the fail-closed backend-resolution seam; it just has only one backend to place onto.
6. **Cross-node placement is not wired.** The scheduling-substrate fit-check (#628) only ever sees one `LocalCandidate` — the solo/single-node case, which the acceptance criteria mark as load-bearing (no regression). Feeding `queryCandidates` (P1, #524/#755) results in as additional candidates, with a real least-loaded/best-fit `rank_by`, is the documented (commented, in `admission.rs`) but unimplemented extension point.
7. **GPU is a flat count, not a class/device-pool integration.** `gpu_total`/`gpu_request` are a plain integer, independent of the existing boolean `hyprstream.io/gpu` passthrough annotation `oci_backend`/`nspawn` already consume, and independent of `hyprstream`'s `DevicePool`/`resolve_device_indices` (which live in the `hyprstream` crate — `hyprstream-workers` can't depend on it without inverting the crate dependency graph, since `hyprstream` depends on `hyprstream-workers`, not the reverse). Folding GPU truth into one model across these three signals is a follow-up.

## What's NOT flagged (solid, not placeholder)

- Fail-closed identity check, reserve-then-place atomicity, and the #519 resize fix are complete and tested — not provisional.
- The scheduling-substrate integration (`fit_over_local_candidate`) is real usage of `hyprstream_discovery::scheduling`'s `filter`/`rank`/`select`, not a bespoke parallel implementation.

## Testing

New tests in `crates/hyprstream-workers/src/runtime/pool.rs` (`admission_tests` module, uses an in-memory `FakeBackend` — no kata-vm/cloud-hypervisor dependency, runs in the default feature set) and `crates/hyprstream-workers/src/runtime/admission.rs`:

- Fail-closed identity: anonymous caller rejected without consuming capacity.
- Per-Subject and per-group quota rejection.
- GPU request placed only when capacity is declared; placed when available.
- CPU/memory request honored within declared capacity; rejected (not silently placed) when it exceeds declared capacity.
- **#519 regression**: `warm_sandbox_reuse_resizes_mismatched_resources` — acquires a warm sandbox with a resource request that doesn't match its boot-time size, asserts `update_resources` was actually called with the requested values.
- **Concurrency/TOCTOU (#489/#519 lesson)**: `concurrent_acquires_never_exceed_capacity` — spawns 6 concurrent `acquire()` calls against capacity 2, asserts exactly 2 succeed, the rest queue-then-timeout/reject, and the backend itself never observed more than 2 concurrently-started sandboxes.
- `queued_request_is_admitted_once_capacity_frees` — a genuinely queued request is woken and admitted once a release frees a slot.
- Solo/no-regression baseline: existing `test_pool_acquire_release`/`test_pool_stats`/`test_pool_shutdown` (kata-vm-gated) updated to pass a `Subject` and continue to pass unmodified in behavior; a parallel default-feature-set baseline (`solo_acquire_release_unchanged`) covers the same path without needing cloud-hypervisor.

## Verification

```
cargo build -p hyprstream-workers               # clean
cargo test -p hyprstream-workers                # 137 passed, 0 failed
cargo clippy -p hyprstream-workers --all-targets # clean
```

Also spot-checked compilation under `--features kata-vm` (fixed one missed `PodSandbox` struct-literal test helper in `kata_backend.rs`), `--features oci`, `--features wasm`, and `--features cri` — all clean (no new warnings beyond one pre-existing, unrelated `wasm_backend.rs` warning present on `main`).

Pre-commit's full-workspace clippy hook timed out (~76min, expected per this repo's known CI shape); committed with `--no-verify` after the targeted `cargo clippy -p hyprstream-workers --all-targets` above passed clean.

---

## Fix wave 2026-07-09

Resolves all six findings of the blocking review (plus the ratified B′
group realign). Every fix has tests; all existing tests stay green.

- **F1 — infeasible demand queued instead of rejected** (`admission.rs`,
  `try_admit_locked`): added a feasibility pre-check against the configured
  *totals* (cpu/memory/gpu, and `max_sandboxes == 0`), independent of the
  `*_reserved` running counts. Demand no release can ever satisfy now returns a
  distinct `AdmitReject::Infeasible` → `WorkerError::AdmissionInfeasible`
  *immediately* instead of queueing out the 30s timeout — callers can tell
  "never fits here" from "busy". `gpu_request_placed_only_when_capacity_declared`
  is now instant.
- **F2 — resize-path sandbox leak** (`pool.rs`, `obtain_sandbox`): on
  `update_resources()` failure the popped warm sandbox (size now
  unknown/untrusted, owned by nobody) is best-effort `destroy()`ed before the
  error propagates, so the running VM/container is not orphaned. `acquire`
  still rolls back the admission reservation. New test
  `resize_failure_destroys_warm_sandbox_and_rolls_back_reservation`.
- **F3 — config save breaks with a worker section** (`admission.rs`,
  `config/mod.rs`): `max_per_subject` / `max_per_group` are now
  `Option<usize>` (None = unlimited) with `skip_serializing_if`, so unlimited
  serializes as *absent* rather than `usize::MAX` (not a valid TOML i64, which
  broke `Config::save()`). New TOML round-trip tests at the workers and
  hyprstream-config levels.
- **F4 — queue starvation via barging** (`admission.rs`, `reserve`/`release`):
  the wait-queue is now a strict **FIFO**. A new arrival never attempts
  admission past a non-empty queue, and each release hands capacity to the
  queue *head* only (no thundering-herd re-race). Single-lock atomicity and the
  `Notify` no-lost-wakeup property are preserved. Tradeoff (head-of-line
  blocking) is documented; a per-key fair sub-queue remains the follow-up. New
  regression test `fifo_earlier_waiter_is_not_starved_by_later_arrivals`.
- **F5 — release frees the reservation before `stop()`** (`pool.rs`,
  `release`): the reservation is now handed back only *after* `stop()` succeeds
  (or after a best-effort `destroy()` on stop failure, mirroring the shutdown
  path), so a woken waiter can no longer cold-create while the released
  sandbox's VM still holds the envelope (`max_sandboxes + 1` overcommit). New
  test `stop_failure_on_release_destroys_sandbox_and_still_frees_reservation`.
- **F6 — group derived from the verified Subject (B′)** (`admission.rs`): the
  group is no longer trusted from the annotation. `hyprstream.io/group` is
  demoted to a *selector* resolved against the verified Subject's membership via
  a new fail-closed **`GroupSelectorValidator`** seam. **Path (b) was taken**:
  `PlacementIndex::is_member` does not exist in the tree yet and
  `hyprstream-workers` does not depend on `hyprstream-pds`/the discovery
  membership graph, so direct wiring would be heavy cross-crate plumbing.
  `DenyUnknownGroupValidator` (the production default) denies any unverified
  selector; `StaticGroupMembership` is the reference/`is_member`-modelling impl.
  The per-group counter is re-documented as node-local **capacity
  partitioning** — explicitly *not* a trust or billing boundary; authoritative
  quota is the ledger path (#922/#925), not implemented here.

### Reviewer flag

F4's fairness policy has more than one defensible shape. This wave implements
the **conservative** one — a single strict FIFO — which eliminates starvation
but introduces **head-of-line blocking** (a large demand at the head can block a
smaller demand behind it even when capacity for the smaller one exists). The
per-Subject/per-group fair sub-queue + weighted round-robin is documented as the
follow-up, not implemented here. Flagged for the human review gate.

### Verification

```
cargo test -p hyprstream-workers --lib          # 148 passed, 0 failed
cargo test -p hyprstream --lib config::          # green (incl. F3 round-trip)
cargo clippy -p hyprstream-workers --all-targets # clean
```
