### PR TITLE
build(deps): bump tar 0.4.44→0.4.46 and lz4_flex 0.11.5→0.11.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9162,9 +9162,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 dependencies = [
  "twox-hash",
 ]
@@ -15533,9 +15533,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",


### PR DESCRIPTION
Bumps two dependencies via a **minimal lockfile edit** on current `main`, superseding the stale dependabot PRs #127 and #128.

## Why not just merge #127/#128
Both were opened 2026-04-07 against a 3-month-old lock and show `mergeable=UNKNOWN` (stale vs current main). Rebasing them re-resolves the lock the same way a fresh `cargo update` does.

## Why a hand-edit instead of `cargo update -p tar -p lz4_flex`
On current main, `cargo update` (even `--precise`) re-unifies a set of **drifted transitive deps** — downgrading assorted `windows-sys`/`windows-targets` versions (inert on Linux; `cfg(windows)`-gated) and one `syn 2→1` unification. None of that is required by the tar/lz4 bumps. This PR edits only the four version+checksum lines for `tar` and `lz4_flex`; `cargo metadata --locked` passes, confirming the transitive graph is unchanged and the lock is consistent.

## Contents
- `tar` 0.4.44 → 0.4.46 (patch)
- `lz4_flex` 0.11.5 → 0.11.6 (patch)

Full CI (build + test) validates the actual compile.

Closes #127, closes #128.