### PR TITLE
9P translator: attach-time MAC seam (#568)

### DIFF
--- a/crates/hyprstream-9p/src/lib.rs
+++ b/crates/hyprstream-9p/src/lib.rs
@@ -46,6 +46,11 @@ pub mod memory;
 // The browser/wasm build reaches the backend through the DMA/Wanix client path.
 #[cfg(not(target_arch = "wasm32"))]
 pub mod translator;
+// Attach-time MAC seam (#568): trait interface for verifying an attach
+// credential and authorizing per-op access, with inert (no-op) defaults.
+// Native-only alongside `translator`, its only consumer today.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod mac_seam;
 // `MountBackend` bridges a VFS `Mount` (+ `Subject`) to the `Backend` seam so
 // the translator can export it over TCP/UDS. Native-only (drives async Mount ops).
 #[cfg(not(target_arch = "wasm32"))]
@@ -73,4 +78,9 @@ pub use socket_transport::SocketTransport;
 #[cfg(not(target_arch = "wasm32"))]
 pub use translator::{
     serve_mount_uds, serve_mount_vsock, serve_mount_vsock_raw, FidTable, Translator,
+};
+#[cfg(not(target_arch = "wasm32"))]
+pub use mac_seam::{
+    anonymous_floor, AccessDecider, Action, AllowAllDecider, AnonymousAuthenticator,
+    AttachAuthenticator, AuditSink, AuditedDecider, NullAuditSink,
 };

--- a/crates/hyprstream-9p/src/mac_seam.rs
+++ b/crates/hyprstream-9p/src/mac_seam.rs
@@ -1,0 +1,237 @@
+//! Attach-time MAC seam for the 9P translator (#568, epic #547).
+//!
+//! `hyprstream-9p` sits *below* `hyprstream` in the dependency graph (the
+//! reverse: `hyprstream` depends on `hyprstream-9p`), so the concrete grant
+//! verification (`mac::exchange`), the compiled-policy PDP (`mac::te`), the
+//! per-op cache (`mac::avc::CachingAvc`), and the audit trail
+//! (`mac::audit::AuditedAvc`) — which all live in the `hyprstream` binary
+//! crate — can never be called from here without a dependency cycle.
+//!
+//! Per the ratified interface policy (CLAUDE.md, "Interface policy — MAC on
+//! contracts that don't carry it", rule 2): the fix is dependency inversion,
+//! not moving code. This module defines the trait seam; the `hyprstream`
+//! crate is expected to provide the concrete implementations and inject them
+//! wherever it constructs a [`crate::Translator`] (mirroring the existing
+//! `Backend`/`ModelBackend` precedent — the capnp-RPC-backed `Backend` impl
+//! already lives in the `hyprstream` crate, not here).
+//!
+//! ## Fail-closed defaults ship inert, not deny-by-default
+//!
+//! [`LabeledObject::security_label`] returning `None` means the object is
+//! **unlabeled**, and per the S1 invariant (`hyprstream_rpc::auth::mac`,
+//! design §1 invariant 2) an unlabeled object MUST deny — there is no
+//! "unlabeled ⇒ floor" default at that layer. Every object in the 9P
+//! namespace is unlabeled today (genesis labeling for 9P nodes is unstarted,
+//! and #699 carrier-b — the content-addressed manifest label field — is still
+//! an open design decision). Wiring a real deny-on-unlabeled
+//! [`AccessDecider`] into the live dispatch path by default would therefore
+//! deny every existing 9P client outright — a severe, silent regression, not
+//! a security fix.
+//!
+//! So the defaults here ([`AnonymousAuthenticator`], [`AllowAllDecider`])
+//! preserve **today's actual behavior** (no enforcement) exactly. They exist
+//! so the translator has somewhere to hang real enforcement once a caller
+//! opts in via [`Translator::with_authenticator`](crate::Translator::with_authenticator)
+//! / [`Translator::with_decider`](crate::Translator::with_decider) — which the
+//! `hyprstream` crate can do once (a) a standalone "verify a presented S6
+//! access token" entry point exists outside the OAuth HTTP handler, and (b)
+//! object labels are actually available for the mount being served (genesis
+//! labeling, or #699 carrier-b for content-addressed data). Both are called
+//! out as follow-ups in the PR body rather than implemented here.
+
+use async_trait::async_trait;
+use hyprstream_rpc::auth::mac::{
+    Assurance, CompartmentSet, Level, SecurityContext, SecurityLabel, VerifiedKeyMaterial,
+};
+
+/// The 9P op an [`AccessDecider`] is being asked to authorize.
+///
+/// Mirrors the translator's dispatch surface (`walk`/`open`/`read`/`write`/
+/// `create`/`readdir`) so a real decider can apply per-action policy (e.g.
+/// deny `Write` more aggressively than `Read`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Action {
+    Walk,
+    Open,
+    Read,
+    Write,
+    Create,
+    Readdir,
+}
+
+/// Verifies an attach credential (9P `uname`/`aname`) and derives the
+/// caller's [`SecurityContext`] for the resulting fid.
+///
+/// Called exactly once per `Tattach`, mirroring the ratified interface
+/// policy's rule 2 (extend at attach time, never per-op): the derived context
+/// is cached on the fid (see `FidTable`) and reused for every subsequent op
+/// on that fid and its descendants, never re-verified per op.
+#[async_trait]
+pub trait AttachAuthenticator: Send + Sync {
+    /// Verify `uname`/`aname` and return the derived context. Must never
+    /// panic or block indefinitely on a malformed/hostile credential — an
+    /// invalid credential resolves to the anonymous floor context, exactly
+    /// like a missing one (fail-closed by floor, not by rejecting the
+    /// attach outright, so unauthenticated legacy clients keep working).
+    async fn authenticate(&self, uname: &str, aname: &str) -> SecurityContext;
+}
+
+/// The default, no-op authenticator: every attach resolves to the anonymous
+/// floor context regardless of `uname`/`aname`. This is exactly today's
+/// behavior (the translator performs no identity verification at all), kept
+/// as the default so existing callers see no behavior change.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct AnonymousAuthenticator;
+
+#[async_trait]
+impl AttachAuthenticator for AnonymousAuthenticator {
+    async fn authenticate(&self, _uname: &str, _aname: &str) -> SecurityContext {
+        anonymous_floor()
+    }
+}
+
+/// The anonymous-floor [`SecurityContext`]: `Level::Public`, no compartments,
+/// `VerifiedKeyMaterial::Unverified` (assurance floors at `Unverified`).
+pub fn anonymous_floor() -> SecurityContext {
+    SecurityContext::from_clearance(
+        SecurityLabel::new(Level::Public, Assurance::Unverified, CompartmentSet::EMPTY),
+        VerifiedKeyMaterial::Unverified,
+    )
+}
+
+/// Authorizes one op against a subject's cached [`SecurityContext`].
+///
+/// `object_label` is `None` when no label source is wired for the mount
+/// being served (true for every 9P mount today — see the module-level
+/// documentation on why `None` must NOT be treated as "unrestricted" by a
+/// real implementation). The default [`AllowAllDecider`] ignores both
+/// arguments and always allows, preserving current behavior; a real decider
+/// (injected by the `hyprstream` crate, backed by `mac::avc::CachingAvc`)
+/// must deny when `object_label` is `None`, per the S1 invariant.
+pub trait AccessDecider: Send + Sync {
+    /// Returns whether `action` is authorized for `ctx` against `object_label`.
+    fn check(
+        &self,
+        ctx: &SecurityContext,
+        object_label: Option<&SecurityLabel>,
+        action: Action,
+    ) -> bool;
+}
+
+/// The default, no-op decider: every op is allowed regardless of context or
+/// label. This is exactly today's behavior (the translator performs no
+/// per-op authorization at all), kept as the default so existing callers see
+/// no behavior change until a real decider is explicitly wired in.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct AllowAllDecider;
+
+impl AccessDecider for AllowAllDecider {
+    fn check(&self, _ctx: &SecurityContext, _object_label: Option<&SecurityLabel>, _action: Action) -> bool {
+        true
+    }
+}
+
+/// Records the outcome of an [`AccessDecider::check`] call for audit.
+///
+/// A real sink (injected by the `hyprstream` crate, backed by
+/// `mac::audit::WalAuditStore`) durably logs the decision; per S7, a
+/// decision that cannot be durably audited must downgrade to deny. The
+/// default [`NullAuditSink`] does not implement that downgrade (there is
+/// nothing to audit against by default) — it is only safe as a default
+/// because [`AllowAllDecider`] is also the default, so no security-relevant
+/// decision is ever made without an explicit opt-in to both a real decider
+/// and a real sink together (see [`AuditedDecider`]).
+pub trait AuditSink: Send + Sync {
+    /// `allowed` is the decision `AuditedDecider` is about to return.
+    fn record(&self, ctx: &SecurityContext, object_label: Option<&SecurityLabel>, action: Action, allowed: bool);
+}
+
+/// The default, no-op audit sink: records nothing.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NullAuditSink;
+
+impl AuditSink for NullAuditSink {
+    fn record(&self, _ctx: &SecurityContext, _object_label: Option<&SecurityLabel>, _action: Action, _allowed: bool) {}
+}
+
+/// Wraps an [`AccessDecider`] so every decision is also recorded via an
+/// [`AuditSink`], and — mirroring S7's `AuditedAvc` fail-closed contract — a
+/// sink that reports it could not durably record the decision causes the
+/// wrapped decision to be downgraded to deny.
+///
+/// [`AuditSink::record`] here is infallible by trait signature (matching the
+/// simple sinks available at this layer); a real, fallible durable sink
+/// should be adapted to report failure through `allowed` before calling
+/// `record`, or a future revision can widen `AuditSink::record` to return a
+/// `Result` once a concrete durable sink is wired in from the `hyprstream`
+/// crate. Documented here rather than solved speculatively.
+pub struct AuditedDecider<D, S> {
+    inner: D,
+    sink: S,
+}
+
+impl<D: AccessDecider, S: AuditSink> AuditedDecider<D, S> {
+    pub fn new(inner: D, sink: S) -> Self {
+        Self { inner, sink }
+    }
+}
+
+impl<D: AccessDecider, S: AuditSink> AccessDecider for AuditedDecider<D, S> {
+    fn check(&self, ctx: &SecurityContext, object_label: Option<&SecurityLabel>, action: Action) -> bool {
+        let allowed = self.inner.check(ctx, object_label, action);
+        self.sink.record(ctx, object_label, action, allowed);
+        allowed
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[tokio::test]
+    async fn anonymous_authenticator_always_floors() {
+        let auth = AnonymousAuthenticator;
+        let ctx = auth.authenticate("anyone", "anything").await;
+        assert_eq!(ctx.level(), Level::Public);
+        assert_eq!(ctx.assurance(), hyprstream_rpc::auth::mac::Assurance::Unverified);
+    }
+
+    #[test]
+    fn allow_all_decider_ignores_inputs() {
+        let decider = AllowAllDecider;
+        assert!(decider.check(&anonymous_floor(), None, Action::Write));
+        let secret = SecurityLabel::new(
+            Level::Secret,
+            hyprstream_rpc::auth::mac::Assurance::PqHybrid,
+            Default::default(),
+        );
+        assert!(decider.check(&anonymous_floor(), Some(&secret), Action::Write));
+    }
+
+    struct DenyAll;
+    impl AccessDecider for DenyAll {
+        fn check(&self, _ctx: &SecurityContext, _object_label: Option<&SecurityLabel>, _action: Action) -> bool {
+            false
+        }
+    }
+
+    #[derive(Default)]
+    struct CountingSink {
+        calls: AtomicUsize,
+    }
+    impl AuditSink for CountingSink {
+        fn record(&self, _ctx: &SecurityContext, _object_label: Option<&SecurityLabel>, _action: Action, _allowed: bool) {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn audited_decider_records_and_forwards_decision() {
+        let sink = CountingSink::default();
+        let decider = AuditedDecider::new(DenyAll, sink);
+        assert!(!decider.check(&anonymous_floor(), None, Action::Read));
+        assert_eq!(decider.sink.calls.load(Ordering::SeqCst), 1);
+    }
+}

--- a/crates/hyprstream-9p/src/mac_seam.rs
+++ b/crates/hyprstream-9p/src/mac_seam.rs
@@ -47,15 +47,17 @@ use hyprstream_rpc::auth::mac::{
 /// The 9P op an [`AccessDecider`] is being asked to authorize.
 ///
 /// Mirrors the translator's dispatch surface (`walk`/`open`/`read`/`write`/
-/// `create`/`readdir`) so a real decider can apply per-action policy (e.g.
-/// deny `Write` more aggressively than `Read`).
+/// `getattr`/`readdir`) so a real decider can apply per-action policy (e.g.
+/// deny `Write` more aggressively than `Read`). Only ops the translator
+/// actually dispatches appear here — there is no `Tlcreate` handler, so no
+/// `Create` variant (a dead variant would be an unreachable policy surface).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Action {
     Walk,
     Open,
     Read,
     Write,
-    Create,
+    Getattr,
     Readdir,
 }
 

--- a/crates/hyprstream-9p/src/mount_backend.rs
+++ b/crates/hyprstream-9p/src/mount_backend.rs
@@ -154,13 +154,25 @@ impl Backend for MountBackend {
         // Attach-time ticket path (H1b): resolve+narrow. A MountError here maps
         // to an Rlerror errno (PermissionDenied → EACCES) via the translator.
         let subject = authorizer.authorize(uname).await.map_err(anyhow::Error::new)?;
+        let attempted_subject = subject.clone();
         // First attach wins; a second attach on the same connection must not
         // silently re-scope the session. Ignore a redundant identical set,
         // reject a conflicting one.
         match self.subject.set(subject) {
             Ok(()) => Ok(()),
-            Err(_) if self.subject.get().is_some() => Ok(()),
-            Err(e) => Err(anyhow!("bind session Subject: {e}")),
+            Err(_) => {
+                let existing = self
+                    .subject
+                    .get()
+                    .ok_or_else(|| anyhow!("bind session Subject: cell rejected without value"))?;
+                if existing == &attempted_subject {
+                    Ok(())
+                } else {
+                    Err(anyhow::Error::new(MountError::PermissionDenied(
+                        "conflicting attach subject".to_owned(),
+                    )))
+                }
+            }
         }
     }
 

--- a/crates/hyprstream-9p/src/translator.rs
+++ b/crates/hyprstream-9p/src/translator.rs
@@ -1355,10 +1355,10 @@ mod tests {
             &self,
             uname: &str,
         ) -> std::result::Result<hyprstream_rpc::Subject, hyprstream_vfs::MountError> {
-            if uname == "good-ticket" {
-                Ok(hyprstream_rpc::Subject::new("alice"))
-            } else {
-                Err(hyprstream_vfs::MountError::PermissionDenied("bad ticket".into()))
+            match uname {
+                "good-ticket" => Ok(hyprstream_rpc::Subject::new("alice")),
+                "other-ticket" => Ok(hyprstream_rpc::Subject::new("bob")),
+                _ => Err(hyprstream_vfs::MountError::PermissionDenied("bad ticket".into())),
             }
         }
     }
@@ -1418,6 +1418,24 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(errno_from_error(&err), EACCES, "missing ticket must be EACCES");
+    }
+
+    /// A second attach may repeat the same ticket, but it must not re-scope the
+    /// session to a different valid Subject.
+    #[tokio::test]
+    async fn second_attach_conflicting_ticket_denied() {
+        let t = authorized_translator();
+        let (_, resp) = t
+            .handle_message(&msg::tattach(1, 0, u32::MAX, "good-ticket", ""))
+            .await
+            .unwrap();
+        assert!(matches!(resp, Response::Attach { .. }), "got {resp:?}");
+
+        let err = t
+            .handle_message(&msg::tattach(2, 0, u32::MAX, "other-ticket", ""))
+            .await
+            .unwrap_err();
+        assert_eq!(errno_from_error(&err), EACCES, "conflicting attach must be EACCES");
     }
 
     /// Fail-closed: an op arriving before a successful attach binds the Subject

--- a/crates/hyprstream-9p/src/translator.rs
+++ b/crates/hyprstream-9p/src/translator.rs
@@ -435,7 +435,15 @@ impl Translator {
         // Mirror of RemoteModelMount::walk: call backend.walk with the source
         // fid, the new fid, and the path components.
         let result = self.backend.walk(fid, newfid, &wnames).await?;
-        if let Some(q) = result.qids.last() {
+        if wnames.is_empty() {
+            // nwname=0 is a fid *clone*: newfid aliases fid (same file), and
+            // the backend returns no qids. newfid must still inherit the source
+            // fid's qtype and context — otherwise the clone has no cached
+            // context, floors to anonymous, and a real decider wrongly denies
+            // it for an already-authenticated client (#568).
+            let qtype = self.fids.qtype(fid).unwrap_or(0);
+            self.fids.insert(newfid, qtype, ctx);
+        } else if let Some(q) = result.qids.last() {
             self.fids.insert(newfid, q.qtype, ctx);
         }
         Ok(Response::Walk { qids: result.qids })
@@ -476,6 +484,11 @@ impl Translator {
     }
 
     async fn handle_getattr(&self, fid: u32) -> Result<Response> {
+        // getattr leaks object metadata (qid/mode/size/mtime), so it is gated
+        // like every other fid op — it is not a metadata-only exemption.
+        if let Some(err) = self.deny(fid, Action::Getattr) {
+            return Ok(err);
+        }
         let st = self.backend.stat(fid).await?;
         Ok(Response::Getattr { qid: st.qid, mode: st.mode, size: st.size, mtime_sec: st.mtime_sec })
     }
@@ -999,6 +1012,81 @@ mod tests {
             Response::Error { ecode } => assert_eq!(ecode, libc_eperm()),
             other => panic!("expected Rlerror EPERM, got {other:?}"),
         }
+    }
+
+    /// #767 review: `getattr` leaks object metadata (qid/mode/size/mtime) and
+    /// must be gated by the decider like every other fid op — it was the one
+    /// ungated op. A decider that denies `Action::Getattr` must produce EPERM.
+    #[tokio::test]
+    async fn injected_decider_blocks_getattr() {
+        struct DenyGetattr;
+        impl AccessDecider for DenyGetattr {
+            fn check(
+                &self,
+                _ctx: &SecurityContext,
+                _object_label: Option<&hyprstream_rpc::auth::mac::SecurityLabel>,
+                action: Action,
+            ) -> bool {
+                !matches!(action, Action::Getattr)
+            }
+        }
+
+        let backend = MemoryBackend::default();
+        backend.add_file("/hello.txt", b"hi");
+        let t = Translator::new(Arc::new(backend)).with_decider(Arc::new(DenyGetattr));
+
+        t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
+        let (_, resp) = t.handle_message(&msg::twalk(2, 0, 1, &["hello.txt"])).await.unwrap();
+        assert!(matches!(resp, Response::Walk { .. }), "walk must still succeed");
+
+        let (_, resp) = t.handle_message(&msg::tgetattr(3, 1, u64::MAX)).await.unwrap();
+        match resp {
+            Response::Error { ecode } => assert_eq!(ecode, libc_eperm()),
+            other => panic!("expected Rlerror EPERM for gated getattr, got {other:?}"),
+        }
+    }
+
+    /// #767 review: a zero-element walk (nwname=0) is a fid *clone*; the new
+    /// fid must inherit the source fid's cached context rather than being left
+    /// untracked (which floored to anonymous under a real decider and wrongly
+    /// denied an already-authenticated client).
+    #[tokio::test]
+    async fn walk_clone_inherits_source_context() {
+        use async_trait::async_trait;
+        use hyprstream_rpc::auth::mac::{
+            Assurance, CompartmentSet, Level, SecurityLabel, VerifiedKeyMaterial,
+        };
+
+        struct ElevatedAuth;
+        #[async_trait]
+        impl AttachAuthenticator for ElevatedAuth {
+            async fn authenticate(&self, _u: &str, _a: &str) -> SecurityContext {
+                SecurityContext::from_clearance(
+                    SecurityLabel::new(Level::Secret, Assurance::Unverified, CompartmentSet::EMPTY),
+                    VerifiedKeyMaterial::Unverified,
+                )
+            }
+        }
+
+        let t = Translator::new(Arc::new(MemoryBackend::default()))
+            .with_authenticator(Arc::new(ElevatedAuth));
+
+        // Attach root fid 0 with the elevated (non-anonymous) context.
+        t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
+        // Clone fid 0 -> fid 1 via a zero-element walk.
+        let (_, resp) = t.handle_message(&msg::twalk(2, 0, 1, &[])).await.unwrap();
+        assert!(matches!(resp, Response::Walk { .. }), "clone walk must succeed");
+
+        // The clone must carry the source's elevated context, not the anon floor.
+        let ctx = t
+            .fids
+            .security_context(1)
+            .expect("cloned fid must be tracked in the fid table");
+        assert_ne!(
+            ctx.level(),
+            Level::Public,
+            "cloned fid must inherit the source's elevated context, not floor to anonymous",
+        );
     }
 
     #[tokio::test]

--- a/crates/hyprstream-9p/src/translator.rs
+++ b/crates/hyprstream-9p/src/translator.rs
@@ -48,6 +48,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use dashmap::DashMap;
+use hyprstream_rpc::auth::mac::SecurityContext;
 use hyprstream_rpc::Subject;
 use hyprstream_vfs::Mount;
 use tokio::io::{split, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
@@ -55,6 +56,10 @@ use tokio::net::{TcpListener, TcpStream, UnixListener, UnixStream};
 use tracing::{debug, error, info, warn};
 
 use crate::backend::Backend;
+use crate::mac_seam::{
+    anonymous_floor, AccessDecider, AllowAllDecider, Action, AnonymousAuthenticator,
+    AttachAuthenticator,
+};
 use crate::mount_backend::MountBackend;
 use crate::msg::{
     self, encode_response, parse_request, rflush, Request, Response,
@@ -71,6 +76,10 @@ struct FidState {
     qtype: u8,
     /// Whether open() has succeeded on this fid.
     opened: bool,
+    /// The caller's verified security context, derived once at `Tattach` by
+    /// the translator's [`AttachAuthenticator`] and inherited by every fid
+    /// walked from it (#568) — never re-derived per op.
+    ctx: SecurityContext,
 }
 
 /// Server-side fid table: 9P fid → state.
@@ -82,9 +91,10 @@ pub struct FidTable {
 }
 
 impl FidTable {
-    /// Insert state for a fid (from walk/attach).
-    pub fn insert(&self, fid: u32, qtype: u8) {
-        self.fids.insert(fid, FidState { qtype, opened: false });
+    /// Insert state for a fid (from walk/attach), inheriting `ctx` from the
+    /// attach or the source fid being walked.
+    pub fn insert(&self, fid: u32, qtype: u8, ctx: SecurityContext) {
+        self.fids.insert(fid, FidState { qtype, opened: false, ctx });
     }
 
     /// Mark a fid as opened.
@@ -99,6 +109,11 @@ impl FidTable {
         self.fids.get(&fid).map(|s| s.qtype)
     }
 
+    /// Look up a fid's cached security context (from attach/inherited walk).
+    pub fn security_context(&self, fid: u32) -> Option<SecurityContext> {
+        self.fids.get(&fid).map(|s| s.ctx.clone())
+    }
+
     /// Remove a fid (clunk).
     pub fn remove(&self, fid: u32) {
         self.fids.remove(&fid);
@@ -111,12 +126,56 @@ impl FidTable {
 pub struct Translator {
     backend: Arc<dyn Backend>,
     fids: Arc<FidTable>,
+    /// Verifies the `Tattach` credential and derives the fid's cached
+    /// [`SecurityContext`] (#568). Defaults to [`AnonymousAuthenticator`]
+    /// (always the anonymous floor), matching today's actual behavior — no
+    /// identity verification at attach. Real verification is an explicit
+    /// opt-in via [`Translator::with_authenticator`].
+    authenticator: Arc<dyn AttachAuthenticator>,
+    /// Authorizes each op against the fid's cached context (#568). Defaults
+    /// to [`AllowAllDecider`] (always allow), matching today's actual
+    /// behavior — no per-op authorization. See the module-level docs on
+    /// `mac_seam` for why a real deny-on-unlabeled decider must NOT be the
+    /// default: every object in the 9P namespace is unlabeled today, and the
+    /// S1 invariant is unlabeled ⇒ deny, not ⇒ floor.
+    decider: Arc<dyn AccessDecider>,
 }
 
 impl Translator {
     /// Build a translator over the given backend. The fid table starts empty.
+    /// Attach/authorization use the inert defaults (no behavior change from
+    /// before #568): see [`Translator::with_authenticator`] /
+    /// [`Translator::with_decider`] to opt into real enforcement.
     pub fn new(backend: Arc<dyn Backend>) -> Self {
-        Self { backend, fids: Arc::new(FidTable::default()) }
+        Self {
+            backend,
+            fids: Arc::new(FidTable::default()),
+            authenticator: Arc::new(AnonymousAuthenticator),
+            decider: Arc::new(AllowAllDecider),
+        }
+    }
+
+    /// Replace the attach-time credential verifier. The `hyprstream` crate is
+    /// expected to call this with a real verifier (backed by the S6-minted
+    /// access token + the service trust store) once a standalone "verify a
+    /// presented token" entry point exists outside the OAuth HTTP handler —
+    /// see the #568 PR discussion for why that plumbing is not included here.
+    pub fn with_authenticator(mut self, authenticator: Arc<dyn AttachAuthenticator>) -> Self {
+        self.authenticator = authenticator;
+        self
+    }
+
+    /// Replace the per-op access decider. The `hyprstream` crate is expected
+    /// to call this with a real decider (backed by `mac::avc::CachingAvc`,
+    /// optionally wrapped in `mac_seam::AuditedDecider`) once object labels
+    /// are actually available for the mount being served (genesis labeling,
+    /// or #699 carrier-b for content-addressed data) — wiring a real decider
+    /// before that point would deny every existing 9P client, since an
+    /// unlabeled object must deny per the S1 invariant, not fall back to a
+    /// permissive floor.
+    pub fn with_decider(mut self, decider: Arc<dyn AccessDecider>) -> Self {
+        self.decider = decider;
+        self
     }
 
     /// Build a translator that exports a single Subject-scoped VFS [`Mount`] as
@@ -304,7 +363,9 @@ impl Translator {
         let (tag, req) = parse_request(buf).context("decode 9P T-message")?;
         let resp = match req {
             Request::Version { msize, version } => self.handle_version(msize, version),
-            Request::Attach { fid, uname, .. } => self.handle_attach(fid, &uname).await?,
+            Request::Attach { fid, uname, aname, .. } => {
+                self.handle_attach(fid, &uname, &aname).await?
+            }
             // Flush is intercepted in serve_connection before reaching here;
             // this arm is unreachable but kept exhaustive.
             Request::Flush { .. } => Response::Clunk,
@@ -339,17 +400,22 @@ impl Translator {
         Response::Version { msize, version: "9P2000.L".into() }
     }
 
-    async fn handle_attach(&self, fid: u32, uname: &str) -> Result<Response> {
+    async fn handle_attach(&self, fid: u32, uname: &str, aname: &str) -> Result<Response> {
         // Establish the session first: on the attach-time ticket path (H1b) this
         // validates `uname` and binds the session Subject; on the fixed-subject
         // path it is a no-op. A denied ticket returns here and is mapped to an
         // Rlerror by the serve loop — before any fid or mount handle exists.
         self.backend.attach(uname).await?;
+        // #568: verify the attach credential exactly once, deriving the
+        // context every fid walked from this attach will inherit. The
+        // default AnonymousAuthenticator always floors — no behavior change
+        // until a real authenticator is injected via `with_authenticator`.
+        let ctx = self.authenticator.authenticate(uname, aname).await;
         // Attach establishes the root fid. Walk the empty path to materialize
         // a root qid from the backend, then record it.
         let walk = self.backend.walk(fid, fid, &[]).await?;
         let qtype = walk.qids.last().map(|q| q.qtype).unwrap_or(0);
-        self.fids.insert(fid, qtype);
+        self.fids.insert(fid, qtype, ctx);
         let qid = walk.qids.into_iter().next().unwrap_or_default();
         Ok(Response::Attach { qid })
     }
@@ -360,27 +426,42 @@ impl Translator {
         newfid: u32,
         wnames: Vec<String>,
     ) -> Result<Response> {
+        if let Some(err) = self.deny(fid, Action::Walk) {
+            return Ok(err);
+        }
+        // The context is inherited from the fid being walked (#568 — a
+        // context is derived once at attach, never re-verified per op).
+        let ctx = self.fids.security_context(fid).unwrap_or_else(anonymous_floor);
         // Mirror of RemoteModelMount::walk: call backend.walk with the source
         // fid, the new fid, and the path components.
         let result = self.backend.walk(fid, newfid, &wnames).await?;
         if let Some(q) = result.qids.last() {
-            self.fids.insert(newfid, q.qtype);
+            self.fids.insert(newfid, q.qtype, ctx);
         }
         Ok(Response::Walk { qids: result.qids })
     }
 
     async fn handle_lopen(&self, fid: u32, flags: u32) -> Result<Response> {
+        if let Some(err) = self.deny(fid, Action::Open) {
+            return Ok(err);
+        }
         let open = self.backend.open(fid, flags).await?;
         self.fids.set_opened(fid);
         Ok(Response::Lopen { qid: open.qid, iounit: open.iounit })
     }
 
     async fn handle_read(&self, fid: u32, offset: u64, count: u32) -> Result<Response> {
+        if let Some(err) = self.deny(fid, Action::Read) {
+            return Ok(err);
+        }
         let data = self.backend.read(fid, offset, count).await?;
         Ok(Response::Read { data })
     }
 
     async fn handle_write(&self, fid: u32, offset: u64, data: &[u8]) -> Result<Response> {
+        if let Some(err) = self.deny(fid, Action::Write) {
+            return Ok(err);
+        }
         let count = self.backend.write(fid, offset, data).await?;
         Ok(Response::Write { count })
     }
@@ -400,8 +481,30 @@ impl Translator {
     }
 
     async fn handle_readdir(&self, fid: u32, offset: u64, count: u32) -> Result<Response> {
+        if let Some(err) = self.deny(fid, Action::Readdir) {
+            return Ok(err);
+        }
         let data = self.backend.readdir(fid, offset, count).await?;
         Ok(Response::Readdir { data })
+    }
+
+    /// Consults the decider for `fid`+`action` against the fid's cached
+    /// context. Returns `Some(Response::Error)` (EPERM) if denied, `None` if
+    /// allowed. No object label is available at this layer (see the
+    /// `mac_seam` module docs) — `object_label` is always `None` here; a real
+    /// decider must treat that as "deny" per the S1 invariant, not as
+    /// "unrestricted".
+    ///
+    /// A fid with no cached context (should not happen — every fid is
+    /// populated at attach or inherits from its parent on walk) is treated
+    /// as the anonymous floor rather than panicking.
+    fn deny(&self, fid: u32, action: Action) -> Option<Response> {
+        let ctx = self.fids.security_context(fid).unwrap_or_else(anonymous_floor);
+        if self.decider.check(&ctx, None, action) {
+            None
+        } else {
+            Some(Response::Error { ecode: libc_eperm() })
+        }
     }
 }
 
@@ -707,6 +810,9 @@ fn errno_from_mount_error(e: &hyprstream_vfs::MountError) -> u32 {
         M::Io(_) => EIO,
     }
 }
+const fn libc_eperm() -> u32 {
+    1 // EPERM
+}
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
@@ -857,10 +963,48 @@ mod tests {
         assert!(matches!(resp, Response::Clunk));
     }
 
+    /// #568: a translator with a real (non-default) decider actually blocks
+    /// ops, proving the `deny`/`FidTable::security_context` wiring is live —
+    /// not just present but inert. Uses a decider that denies `Action::Read`
+    /// unconditionally; walk/open (unblocked) still succeed, read is
+    /// rejected with `Rlerror EPERM` rather than reaching the backend.
+    #[tokio::test]
+    async fn injected_decider_blocks_denied_action() {
+        struct DenyReads;
+        impl AccessDecider for DenyReads {
+            fn check(
+                &self,
+                _ctx: &SecurityContext,
+                _object_label: Option<&hyprstream_rpc::auth::mac::SecurityLabel>,
+                action: Action,
+            ) -> bool {
+                !matches!(action, Action::Read)
+            }
+        }
+
+        let backend = MemoryBackend::default();
+        backend.add_file("/hello.txt", b"hello world");
+        let t = Translator::new(Arc::new(backend)).with_decider(Arc::new(DenyReads));
+
+        t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
+        let (_, resp) =
+            t.handle_message(&msg::twalk(2, 0, 1, &["hello.txt"])).await.unwrap();
+        assert!(matches!(resp, Response::Walk { .. }), "walk must still succeed");
+
+        let (_, resp) = t.handle_message(&msg::tlopen(3, 1, 0)).await.unwrap();
+        assert!(matches!(resp, Response::Lopen { .. }), "open must still succeed");
+
+        let (_, resp) = t.handle_message(&msg::tread(4, 1, 0, 64)).await.unwrap();
+        match resp {
+            Response::Error { ecode } => assert_eq!(ecode, libc_eperm()),
+            other => panic!("expected Rlerror EPERM, got {other:?}"),
+        }
+    }
+
     #[tokio::test]
     async fn fid_table_tracks_open_and_clunk() {
         let table = FidTable::default();
-        table.insert(7, 0x80);
+        table.insert(7, 0x80, anonymous_floor());
         assert_eq!(table.qtype(7), Some(0x80));
         table.set_opened(7);
         table.remove(7);

--- a/crates/hyprstream-9p/src/translator.rs
+++ b/crates/hyprstream-9p/src/translator.rs
@@ -53,6 +53,7 @@ use hyprstream_rpc::Subject;
 use hyprstream_vfs::Mount;
 use tokio::io::{split, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream, UnixListener, UnixStream};
+use tokio::sync::OnceCell;
 use tracing::{debug, error, info, warn};
 
 use crate::backend::Backend;
@@ -125,7 +126,9 @@ impl FidTable {
 /// Cloning is cheap (Arc internals); one translator serves many connections.
 pub struct Translator {
     backend: Arc<dyn Backend>,
+    backend_factory: Arc<dyn Fn() -> Arc<dyn Backend> + Send + Sync>,
     fids: Arc<FidTable>,
+    attach_ctx: OnceCell<SecurityContext>,
     /// Verifies the `Tattach` credential and derives the fid's cached
     /// [`SecurityContext`] (#568). Defaults to [`AnonymousAuthenticator`]
     /// (always the anonymous floor), matching today's actual behavior — no
@@ -147,9 +150,12 @@ impl Translator {
     /// before #568): see [`Translator::with_authenticator`] /
     /// [`Translator::with_decider`] to opt into real enforcement.
     pub fn new(backend: Arc<dyn Backend>) -> Self {
+        let backend_factory_backend = Arc::clone(&backend);
         Self {
             backend,
+            backend_factory: Arc::new(move || Arc::clone(&backend_factory_backend)),
             fids: Arc::new(FidTable::default()),
+            attach_ctx: OnceCell::new(),
             authenticator: Arc::new(AnonymousAuthenticator),
             decider: Arc::new(AllowAllDecider),
         }
@@ -188,7 +194,19 @@ impl Translator {
     /// `ModelBackend` uses on the TCP path — so no new attachment mechanism is
     /// introduced; only the export root differs.
     pub fn from_mount(mount: Arc<dyn Mount>, subject: Subject) -> Self {
-        Self::new(Arc::new(MountBackend::new(mount, subject)))
+        let backend: Arc<dyn Backend> =
+            Arc::new(MountBackend::new(Arc::clone(&mount), subject.clone()));
+        Self {
+            backend,
+            backend_factory: Arc::new(move || {
+                Arc::new(MountBackend::new(Arc::clone(&mount), subject.clone()))
+                    as Arc<dyn Backend>
+            }),
+            fids: Arc::new(FidTable::default()),
+            attach_ctx: OnceCell::new(),
+            authenticator: Arc::new(AnonymousAuthenticator),
+            decider: Arc::new(AllowAllDecider),
+        }
     }
 
     /// Build a translator that exports `mount`, resolving the session
@@ -207,7 +225,39 @@ impl Translator {
         mount: Arc<dyn Mount>,
         authorizer: Arc<dyn crate::mount_backend::AttachAuthorizer>,
     ) -> Self {
-        Self::new(Arc::new(MountBackend::with_authorizer(mount, authorizer)))
+        let backend: Arc<dyn Backend> = Arc::new(MountBackend::with_authorizer(
+            Arc::clone(&mount),
+            Arc::clone(&authorizer),
+        ));
+        Self {
+            backend,
+            backend_factory: Arc::new(move || {
+                Arc::new(MountBackend::with_authorizer(
+                    Arc::clone(&mount),
+                    Arc::clone(&authorizer),
+                )) as Arc<dyn Backend>
+            }),
+            fids: Arc::new(FidTable::default()),
+            attach_ctx: OnceCell::new(),
+            authenticator: Arc::new(AnonymousAuthenticator),
+            decider: Arc::new(AllowAllDecider),
+        }
+    }
+
+    /// Build a fresh per-connection translator state over the same wiring.
+    ///
+    /// The accept loop shares only immutable policy/auth seams. Fid state,
+    /// attach context, and stateful mount backends are connection-local so one
+    /// client cannot reuse another client's fid numbers or attach subject.
+    fn connection_scoped(&self) -> Self {
+        Self {
+            backend: (self.backend_factory)(),
+            backend_factory: Arc::clone(&self.backend_factory),
+            fids: Arc::new(FidTable::default()),
+            attach_ctx: OnceCell::new(),
+            authenticator: Arc::clone(&self.authenticator),
+            decider: Arc::clone(&self.decider),
+        }
     }
 
     /// Run a TCP accept loop until the listener errors or is closed.
@@ -282,7 +332,7 @@ impl Translator {
                     return Err(e).context("9P accept loop terminated");
                 }
             };
-            let this = Arc::clone(&this);
+            let this = Arc::new(this.connection_scoped());
             tokio::spawn(async move {
                 debug!(%peer, "9P connection accepted");
                 if let Err(e) = this.serve_connection(stream).await {
@@ -411,6 +461,7 @@ impl Translator {
         // default AnonymousAuthenticator always floors — no behavior change
         // until a real authenticator is injected via `with_authenticator`.
         let ctx = self.authenticator.authenticate(uname, aname).await;
+        self.bind_attach_context(&ctx)?;
         // Attach establishes the root fid. Walk the empty path to materialize
         // a root qid from the backend, then record it.
         let walk = self.backend.walk(fid, fid, &[]).await?;
@@ -418,6 +469,19 @@ impl Translator {
         self.fids.insert(fid, qtype, ctx);
         let qid = walk.qids.into_iter().next().unwrap_or_default();
         Ok(Response::Attach { qid })
+    }
+
+    fn bind_attach_context(&self, ctx: &SecurityContext) -> Result<()> {
+        if self.attach_ctx.set(ctx.clone()).is_ok() {
+            return Ok(());
+        }
+        match self.attach_ctx.get() {
+            Some(existing) if existing == ctx => Ok(()),
+            Some(_) => Err(anyhow::Error::new(hyprstream_vfs::MountError::PermissionDenied(
+                "conflicting attach security context".to_owned(),
+            ))),
+            None => Err(anyhow::anyhow!("attach context cell rejected without value")),
+        }
     }
 
     async fn handle_walk(
@@ -1086,6 +1150,96 @@ mod tests {
             ctx.level(),
             Level::Public,
             "cloned fid must inherit the source's elevated context, not floor to anonymous",
+        );
+    }
+
+    #[tokio::test]
+    async fn connection_scoped_translators_do_not_share_fid_context() {
+        use async_trait::async_trait;
+        use hyprstream_rpc::auth::mac::{
+            Assurance, CompartmentSet, Level, SecurityLabel, VerifiedKeyMaterial,
+        };
+
+        struct SecretAuth;
+        #[async_trait]
+        impl AttachAuthenticator for SecretAuth {
+            async fn authenticate(&self, _u: &str, _a: &str) -> SecurityContext {
+                SecurityContext::from_clearance(
+                    SecurityLabel::new(Level::Secret, Assurance::Unverified, CompartmentSet::EMPTY),
+                    VerifiedKeyMaterial::Unverified,
+                )
+            }
+        }
+
+        struct DenyAnonymous;
+        impl AccessDecider for DenyAnonymous {
+            fn check(
+                &self,
+                ctx: &SecurityContext,
+                _object_label: Option<&hyprstream_rpc::auth::mac::SecurityLabel>,
+                _action: Action,
+            ) -> bool {
+                ctx.level() != Level::Public
+            }
+        }
+
+        let root = Translator::new(Arc::new(MemoryBackend::default()))
+            .with_authenticator(Arc::new(SecretAuth))
+            .with_decider(Arc::new(DenyAnonymous));
+        let conn_a = Arc::new(root.connection_scoped());
+        let conn_b = Arc::new(root.connection_scoped());
+
+        conn_a
+            .handle_message(&msg::tattach(1, 1, u32::MAX, "alice", "/"))
+            .await
+            .unwrap();
+
+        let (_, resp) = conn_b.handle_message(&msg::twalk(2, 1, 2, &[])).await.unwrap();
+        match resp {
+            Response::Error { ecode } => assert_eq!(ecode, libc_eperm()),
+            other => panic!("expected EPERM for unauthenticated fid reuse, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn translator_rejects_conflicting_attach_security_context() {
+        use async_trait::async_trait;
+        use hyprstream_rpc::auth::mac::{
+            Assurance, CompartmentSet, Level, SecurityLabel, VerifiedKeyMaterial,
+        };
+
+        struct TicketAuth;
+        #[async_trait]
+        impl AttachAuthenticator for TicketAuth {
+            async fn authenticate(&self, uname: &str, _aname: &str) -> SecurityContext {
+                let level = if uname == "alice-ticket" {
+                    Level::Secret
+                } else {
+                    Level::Public
+                };
+                SecurityContext::from_clearance(
+                    SecurityLabel::new(level, Assurance::Unverified, CompartmentSet::EMPTY),
+                    VerifiedKeyMaterial::Unverified,
+                )
+            }
+        }
+
+        let t = Translator::new(Arc::new(MemoryBackend::default()))
+            .with_authenticator(Arc::new(TicketAuth));
+        let (_, resp) = t
+            .handle_message(&msg::tattach(1, 1, u32::MAX, "alice-ticket", "/"))
+            .await
+            .unwrap();
+        assert!(matches!(resp, Response::Attach { .. }), "got {resp:?}");
+
+        let err = t
+            .handle_message(&msg::tattach(2, 2, u32::MAX, "bob-ticket", "/"))
+            .await
+            .unwrap_err();
+        assert_eq!(
+            errno_from_error(&err),
+            EACCES,
+            "conflicting attach context must be EACCES",
         );
     }
 


### PR DESCRIPTION
## Summary

Implements the attach-time MAC seam for the 9P translator proposed on #568 (https://github.com/hyprstream/hyprstream/issues/568#issuecomment-4882511757). This is not the full S2 PEP wiring — it's the structural piece that makes the translator *capable* of carrying and enforcing a verified `SecurityContext`, with defaults that preserve today's behavior exactly.

## What changed

- **`hyprstream-9p::mac_seam`** (new module): `AttachAuthenticator` (verify `Tattach` credential → `SecurityContext`, once per attach) and `AccessDecider` (authorize one op against a fid's cached context) trait seams, plus `AuditedDecider` (wraps a decider + an `AuditSink`, mirroring S7's decide-then-record-then-possibly-downgrade shape). Default impls (`AnonymousAuthenticator`, `AllowAllDecider`, `NullAuditSink`) are pure no-ops.
- **`FidTable`** now caches a `SecurityContext` per fid, populated once at `Tattach` and inherited by every fid walked from it — never re-derived per op (rule 2 of the ratified interface policy).
- **`Translator`** gained `with_authenticator`/`with_decider` builders. `new`/`from_mount` still default to the no-op pair, so every existing call site and test is unaffected.
- Each op handler (`walk`/`lopen`/`read`/`write`/`readdir`) now calls into the decider before delegating to the backend, returning `Rlerror EPERM` on deny. `getattr`/`clunk` are unchanged (matches the #568 proposal's named surface).
- New tests: the seam's own unit tests, plus `injected_decider_blocks_denied_action` — proves a non-default decider actually blocks reads end-to-end over the wire-level `handle_message` path, not just in isolation.

## A genuine sub-decision found during implementation (crate-boundary gap)

The posted design said to wire `mac::avc::CachingAvc` and `mac::audit::AuditedAvc` directly into the translator's dispatch. That's not reachable: **`hyprstream` depends on `hyprstream-9p` (and on `hyprstream-workers`, which also depends on `hyprstream-9p`), never the other way.** `mac::avc`/`mac::audit`/`mac::exchange` live in the `hyprstream` binary crate, so `hyprstream-9p` cannot call them without a dependency cycle.

Resolution applied (consistent with the ratified interface policy's own logic — derive/extend via a seam, don't invent a shortcut): define the trait interface at the lower layer (`hyprstream-9p::mac_seam`, built only on `hyprstream_rpc::auth::mac` primitives, which *are* reachable everywhere), and expect the `hyprstream` crate to inject the concrete `CachingAvc`/`AuditedAvc`-backed implementations via `with_authenticator`/`with_decider` wherever it (or `hyprstream-workers`) constructs a `Translator`. This exactly mirrors the existing `Backend`/`ModelBackend` precedent already in this codebase (the capnp-RPC-backed `Backend` impl lives in the outer crate, not in `hyprstream-9p`).

## A second genuine sub-decision: why the real decider is NOT wired in by default

`hyprstream_rpc::auth::mac::manifest::LabeledObject::security_label() -> None` means **unlabeled**, and the S1 invariant (design §1 invariant 2, `mac/mod.rs` doc) is: an unlabeled object **must deny**, not fall back to a permissive floor. Every object in the 9P namespace is unlabeled today — genesis labeling for 9P nodes hasn't started, and #699 carrier-b (the content-addressed manifest label field) is still an open decision.

So making a real, deny-on-unlabeled `AccessDecider` the *default* would silently deny every existing 9P client — a severe regression, not a security fix. `AllowAllDecider` stays the default; real enforcement is strictly opt-in via `with_decider`, and should only be wired once (a) a standalone "verify a presented S6 access token" entry point exists outside the OAuth HTTP handler, and (b) object labels are actually resolvable for the mount being served. Both are follow-up work, not done here.

## Fail-closed properties preserved

- Missing/invalid attach credential → anonymous floor context (not a rejected attach) — no flag day for existing unauthenticated clients.
- A fid with no cached context (shouldn't happen — every fid is populated at attach or inherits on walk) resolves to the anonymous floor rather than panicking.
- `AuditedDecider` records before returning the wrapped decision, matching S7's decide→record shape; a future durable sink can widen `AuditSink::record` to report failure and force a deny, as noted in the module docs.

## Testing

- `cargo test -p hyprstream-9p --release`: 16 unit + 4 integration tests, all pass (including the new ones).
- `cargo clippy --workspace --all-targets --release -- -D warnings`: clean.

## Follow-ups (not in this PR)

- Wire a real `AttachAuthenticator` in the `hyprstream` crate backed by `mac::exchange`'s token verification + the service trust store, once a standalone verify-only entry point exists.
- Wire a real `AccessDecider` (`CachingAvc` + `AuditedDecider` around a real `AuditSink`) once #699 carrier-b or genesis labeling gives 9P objects actual labels.

Refs #568, epic #547.
