### PR TITLE
deps: crypto/authz bump — casbin 2.20, aws-lc 1.17/0.42

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,9 +1070,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.14.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b8ff6c09cd57b16da53641caa860168b88c172a5ee163b0288d3d6eea12786"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -1080,15 +1080,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.31.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e44d16778acaf6a9ec9899b92cebd65580b83f685446bf2e1f5d3d732f99dcd"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
- "bindgen",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1363,9 +1363,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
- "log",
- "prettyplease",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -1928,9 +1926,9 @@ dependencies = [
 
 [[package]]
 name = "casbin"
-version = "2.17.0"
+version = "2.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2588e0a621ab3f658b445bbe4e4fa05ed2182eb81a6b906c3dcf4d42c9cde5"
+checksum = "c53f7476c2d0d9cd7ccc88c16ffc5c7889a0497b3462b10b12b5329adde69665"
 dependencies = [
  "async-trait",
  "fixedbitset 0.4.2",
@@ -2259,7 +2257,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -17997,7 +17995,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]


### PR DESCRIPTION
**Draft** — isolated security-sensitive dependency bumps, pending e2e validation.

| crate | from | to | role |
|---|---|---|---|
| `casbin` | 2.17.0 | 2.20.0 | MAC/policy authorization engine (the just-merged MAC enforcement depends on it) |
| `aws-lc-rs` | 1.14.0 | 1.17.1 | crypto backend |
| `aws-lc-sys` | 0.31.0 | 0.42.0 | crypto FFI (large jump — new build scripts/FFI) |

Isolated from the bulk registry update (#TBD) so the crypto/authz behavior can be reviewed and test-validated on its own. Lockfile-only, 3 registry bumps, no transitive churn, git deps untouched.

**Validation gate before ready:** full compile (CI Clippy `--all-targets`) + local `cargo nextest` of the authz/MAC/crypto crates (the PR-level CI does not run the test suite — `build`+`nextest` are push/merge_group-only).