### PR TITLE
XC (#527): jobs as scheduled workloads — wire WorkflowService through the P2 scheduler

### DIFF
--- a/crates/hyprstream-workers/src/runtime/pool.rs
+++ b/crates/hyprstream-workers/src/runtime/pool.rs
@@ -71,9 +71,39 @@ pub struct SandboxPool {
 }
 
 impl SandboxPool {
-    /// Create a new sandbox pool with a backend
+    /// Create a new sandbox pool with a backend.
+    ///
+    /// Uses the fail-closed [`admission::DenyUnknownGroupValidator`] — the
+    /// production default until a membership-backed validator is wired: any
+    /// non-empty `hyprstream.io/group` selector is rejected at admission
+    /// (B′); the no-selector case is unaffected.
     pub fn new(config: PoolConfig, backend: Arc<dyn SandboxBackend>) -> Self {
         let admission = AdmissionTracker::new(config.admission.clone(), config.max_sandboxes);
+        Self::with_admission(config, backend, admission)
+    }
+
+    /// Create a pool with an explicit [`admission::GroupSelectorValidator`]
+    /// (e.g. one backed by a real membership source such as
+    /// `PlacementIndex::is_member`, or a test double). Mirrors
+    /// [`AdmissionTracker::with_group_validator`].
+    pub fn with_group_validator(
+        config: PoolConfig,
+        backend: Arc<dyn SandboxBackend>,
+        group_validator: Arc<dyn admission::GroupSelectorValidator>,
+    ) -> Self {
+        let admission = AdmissionTracker::with_group_validator(
+            config.admission.clone(),
+            config.max_sandboxes,
+            group_validator,
+        );
+        Self::with_admission(config, backend, admission)
+    }
+
+    fn with_admission(
+        config: PoolConfig,
+        backend: Arc<dyn SandboxBackend>,
+        admission: AdmissionTracker,
+    ) -> Self {
         Self {
             warm_pool: Mutex::new(VecDeque::new()),
             active: Mutex::new(HashMap::new()),

--- a/crates/hyprstream-workers/src/workflow/mod.rs
+++ b/crates/hyprstream-workers/src/workflow/mod.rs
@@ -1,7 +1,12 @@
 //! WorkflowService - GitHub Actions compatible workflow orchestration
 //!
-//! Discovers workflows from git repositories, subscribes to events,
-//! and spawns containers via WorkerService.
+//! Discovers workflows from git repositories, subscribes to events, and runs
+//! jobs as scheduled workloads (#527): each job's `runs_on:` + `resources:`
+//! route through the #525 P2 admission engine (`SandboxPool::acquire`) when
+//! the job requests isolation, or stay on the existing in-process VFS/Tcl
+//! execution path otherwise (see `workflow::scheduler` for the mapping).
+//! `WorkflowRunner` talks to `SandboxPool` directly — there is no
+//! `WorkerService` dependency in this crate's workflow engine.
 //!
 //! # Architecture
 //!
@@ -14,8 +19,9 @@
 //!     └── get_run()         → Query run status
 //!     │
 //!     └── WorkflowRunner
-//!           ├── Creates PodSandbox via WorkerService
-//!           └── Executes steps as containers
+//!           ├── JobScheduler → SandboxPool::acquire (isolated jobs) or
+//!           │                  in-proc (`IN_PROC_LABELS`) — #527
+//!           └── Executes steps via VFS `/bin/` ctl calls + TclShell
 //! ```
 
 mod service;
@@ -24,14 +30,16 @@ mod parser;
 mod triggers;
 mod subscription;
 mod runner;
+pub mod scheduler;
 pub mod adapter;
 pub mod gh_adapter;
 
 pub use service::WorkflowService;
-pub use parser::{Workflow, Job, Step};
+pub use parser::{Workflow, Job, JobResources, Step};
 pub use triggers::{EventTrigger, EventHandler, HandlerResult};
 pub use subscription::WorkflowSubscription;
 pub use runner::WorkflowRunner;
+pub use scheduler::{JobScheduler, Placement};
 pub use adapter::SubscriberAdapter;
 pub use gh_adapter::GitHubActionsAdapter;
 

--- a/crates/hyprstream-workers/src/workflow/parser.rs
+++ b/crates/hyprstream-workers/src/workflow/parser.rs
@@ -108,6 +108,14 @@ pub struct Job {
     /// Timeout in minutes
     #[serde(rename = "timeout-minutes", default)]
     pub timeout_minutes: Option<u32>,
+
+    /// Resource hints for scheduling (hyprstream extension, not part of the
+    /// GHA syntax). Consumed by the P2 admission engine (#525) via
+    /// `workflow::scheduler` to derive a `Demand` for the job's sandbox
+    /// reservation. All-zero (the default) means "no resource requirement" —
+    /// existing workflow YAML with no `resources:` key is unaffected.
+    #[serde(default)]
+    pub resources: JobResources,
 }
 
 /// Runner specification
@@ -119,6 +127,24 @@ pub enum RunsOn {
 
     /// Multiple runner labels (AND logic)
     Labels(Vec<String>),
+}
+
+/// Resource hints a job declares for scheduling (hyprstream extension).
+///
+/// GHA has no native `resources:` job key — this is a hyprstream-specific
+/// addition, parsed only when present (`#[serde(default)]` on the `Job`
+/// field), so it never affects existing workflow YAML. See
+/// `workflow::scheduler::job_pod_sandbox_config` for how these map onto the
+/// #525 admission engine's `Demand`.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct JobResources {
+    /// Requested CPU, in millicores (e.g. `500` = half a core).
+    pub cpu_millis: u64,
+    /// Requested memory, in bytes.
+    pub memory_bytes: u64,
+    /// Requested GPU count.
+    pub gpu: usize,
 }
 
 /// Step definition

--- a/crates/hyprstream-workers/src/workflow/runner.rs
+++ b/crates/hyprstream-workers/src/workflow/runner.rs
@@ -88,6 +88,14 @@ pub enum RunnerError {
     #[error("cancelled")]
     Cancelled,
 
+    /// Job placement (scheduler decide + admission) failed. Carries the typed
+    /// [`WorkerError`] so callers/retry-policy can distinguish "retry later,
+    /// queue pressure" (`QueueFull`/`QueueTimeout`) from "terminal, over-quota
+    /// or unauthorized" (`AdmissionDenied`/`Unauthorized`/`AdmissionInfeasible`)
+    /// instead of a flattened string.
+    #[error("job placement failed: {0}")]
+    PlacementFailed(#[from] crate::error::WorkerError),
+
     #[error("vfs error: {0}")]
     VfsError(String),
 
@@ -302,11 +310,22 @@ async fn run_job(
     // #527: decide + (if isolation is requested) acquire a sandbox
     // reservation before running any steps. `None` scheduler ⇒ always
     // in-proc (pre-#527 behavior, unchanged).
+    //
+    // The placement sits outside `job_timeout` and any step-level cancel race,
+    // so it would otherwise wait up to `queue_timeout_secs` in the admission
+    // queue even for an already-cancelled workflow. Race it against the
+    // cancellation token so a cancel aborts the queue wait promptly, and
+    // propagate the typed `WorkerError` (via `PlacementFailed`) instead of
+    // flattening it into a string.
     let placement = match &scheduler {
-        Some(scheduler) => scheduler
-            .place(job_name, &job.runs_on, &job.resources, subject)
-            .await
-            .map_err(|e| RunnerError::VfsError(format!("job placement failed: {e}")))?,
+        Some(scheduler) => {
+            let place_fut = scheduler.place(job_name, &job.runs_on, &job.resources, subject);
+            tokio::select! {
+                biased;
+                _ = cancel.cancelled() => return Err(RunnerError::Cancelled),
+                result = place_fut => result?,
+            }
+        }
         None => Placement::InProc,
     };
 

--- a/crates/hyprstream-workers/src/workflow/runner.rs
+++ b/crates/hyprstream-workers/src/workflow/runner.rs
@@ -6,9 +6,19 @@
 //! - Resolves `uses:` action steps through VFS `/bin/` ctl files
 //! - Evaluates `run:` script steps via TclShell on `spawn_blocking`
 //! - Propagates CancellationToken for cooperative cancellation
+//! - Routes each job through a [`JobScheduler`] (#527) — `runs_on:` +
+//!   `resources:` decide in-proc vs. a real P2-admitted sandbox reservation
+//!   (see `workflow::scheduler`); no scheduler configured (`None`, the
+//!   default) preserves the pre-#527 in-proc-only behavior exactly.
+//! - Honors `WorkflowConfig::max_concurrent_runs` (a run-admission semaphore,
+//!   distinct from `script_semaphore`'s per-job script concurrency) and
+//!   `job_timeout_secs`/`step_timeout_secs` (#521 — wired for real, not
+//!   superseded by P2: admission governs resource capacity/quota, this
+//!   governs wall-clock run/step duration, a different axis)
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
+use std::time::Duration;
 
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
@@ -18,7 +28,10 @@ use hyprstream_workers_tcl::TclShell;
 // VFS proxy no longer needed — TclShell awaits namespace operations directly.
 use hyprstream_vfs::{Namespace, Subject};
 
+use crate::config::WorkflowConfig;
+
 use super::parser::{Job, Step, Workflow};
+use super::scheduler::{JobScheduler, Placement};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Result types (local to runner, not wire-format)
@@ -96,22 +109,63 @@ type RunnerResult<T> = std::result::Result<T, RunnerError>;
 /// Resolves action steps through VFS `/bin/` ctl files and evaluates
 /// script steps via TclShell on `spawn_blocking` threads. Concurrent
 /// script-executing jobs are capped by `script_semaphore`.
+///
+/// # Scheduling (#527)
+///
+/// Each job is routed through an optional [`JobScheduler`]: `runs_on:` +
+/// `resources:` decide in-proc execution (unchanged) vs. a real sandbox
+/// reservation acquired through the #525 P2 admission engine. With no
+/// scheduler configured (the default), every job runs in-proc exactly as
+/// before this change — no regression for existing callers.
+///
+/// # Run-level concurrency + timeouts (#521)
+///
+/// `run_semaphore` bounds concurrent workflow *runs* (`WorkflowConfig::
+/// max_concurrent_runs`) — a different axis from `script_semaphore`, which
+/// bounds concurrent script-executing *jobs* within/across runs.
+/// `job_timeout`/`step_timeout` (`job_timeout_secs`/`step_timeout_secs`) wrap
+/// job and step execution in `tokio::time::timeout`; a job's own
+/// `timeout-minutes:` overrides `job_timeout` when present.
 #[derive(Clone)]
 pub struct WorkflowRunner {
     ns: Arc<Namespace>,
     script_semaphore: Arc<Semaphore>,
+    run_semaphore: Arc<Semaphore>,
+    job_timeout: Duration,
+    step_timeout: Duration,
+    scheduler: Option<Arc<JobScheduler>>,
 }
 
 impl WorkflowRunner {
-    /// Create a new WorkflowRunner.
+    /// Create a new WorkflowRunner with `WorkflowConfig::default()` timeouts/
+    /// concurrency and no job scheduler (every job runs in-proc).
     ///
     /// * `ns` — the root namespace (mounts for `/bin/`, `/env/`, `/srv/`, etc.)
     /// * Default concurrency cap: 64 concurrent script-executing jobs.
     pub fn new(ns: Arc<Namespace>) -> Self {
+        Self::with_config(ns, &WorkflowConfig::default())
+    }
+
+    /// Create a WorkflowRunner honoring `config`'s `max_concurrent_runs` +
+    /// `job_timeout_secs`/`step_timeout_secs` (#521).
+    pub fn with_config(ns: Arc<Namespace>, config: &WorkflowConfig) -> Self {
         Self {
             ns,
             script_semaphore: Arc::new(Semaphore::new(64)),
+            // A zero-permit semaphore would deadlock every run forever;
+            // treat a misconfigured 0 as "at least 1" rather than a silent hang.
+            run_semaphore: Arc::new(Semaphore::new(config.max_concurrent_runs.max(1))),
+            job_timeout: Duration::from_secs(config.job_timeout_secs),
+            step_timeout: Duration::from_secs(config.step_timeout_secs),
+            scheduler: None,
         }
+    }
+
+    /// Attach a [`JobScheduler`] (#527): jobs whose `runs_on:` requests
+    /// isolation are placed onto its sandbox pool instead of running in-proc.
+    pub fn with_scheduler(mut self, scheduler: Arc<JobScheduler>) -> Self {
+        self.scheduler = Some(scheduler);
+        self
     }
 
     /// Run a complete workflow.
@@ -119,6 +173,9 @@ impl WorkflowRunner {
     /// Jobs are topologically sorted by `needs:` into execution waves.
     /// Independent jobs in each wave run concurrently. The `cancel` token
     /// is checked between waves and propagated to individual jobs.
+    ///
+    /// Bounded by `run_semaphore` (#521's `max_concurrent_runs`): a run that
+    /// can't get a permit waits here, honoring `cancel` while waiting.
     pub async fn run(
         &self,
         workflow: &Workflow,
@@ -128,6 +185,14 @@ impl WorkflowRunner {
     ) -> RunnerResult<WorkflowRunResult> {
         // Validate inputs: reject _-prefixed keys (provenance injection prevention).
         validate_inputs(&inputs)?;
+
+        // #521: bound concurrent workflow RUNS. Held for the whole run.
+        let _run_permit = tokio::select! {
+            permit = Arc::clone(&self.run_semaphore).acquire_owned() => {
+                permit.map_err(|_| RunnerError::Cancelled)?
+            }
+            _ = cancel.cancelled() => return Err(RunnerError::Cancelled),
+        };
 
         // Topological sort jobs into execution waves.
         let waves = topological_sort(&workflow.jobs)?;
@@ -150,6 +215,12 @@ impl WorkflowRunner {
                 };
                 let ns = Arc::clone(&self.ns);
                 let sem = Arc::clone(&self.script_semaphore);
+                let scheduler = self.scheduler.clone();
+                let job_timeout = job
+                    .timeout_minutes
+                    .map(|m| Duration::from_secs(u64::from(m) * 60))
+                    .unwrap_or(self.job_timeout);
+                let step_timeout = self.step_timeout;
                 let subject = subject.clone();
                 let cancel = cancel.clone();
                 let env = merge_env(&workflow.env, &job.env);
@@ -157,7 +228,10 @@ impl WorkflowRunner {
                 let name = job_name.clone();
 
                 join_set.spawn(async move {
-                    let result = run_job(ns, sem, &job, &name, env, &inputs, &subject, cancel).await;
+                    let result = run_job(
+                        ns, sem, scheduler, &job, &name, env, &inputs, &subject, cancel,
+                        job_timeout, step_timeout,
+                    ).await;
                     (name, result)
                 });
             }
@@ -209,11 +283,63 @@ impl WorkflowRunner {
 // Job execution
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Run a single job. Steps execute sequentially within a job.
-///
-/// For script steps (`run:`), a single TclShell is reused across all
-/// sequential steps in the same job (constructed inside `spawn_blocking`).
+/// Route `job` through the scheduler (#527), then run its steps within
+/// `job_timeout`, releasing the placement afterward regardless of outcome.
+#[allow(clippy::too_many_arguments)]
 async fn run_job(
+    ns: Arc<Namespace>,
+    semaphore: Arc<Semaphore>,
+    scheduler: Option<Arc<JobScheduler>>,
+    job: &Job,
+    job_name: &str,
+    env: HashMap<String, String>,
+    inputs: &HashMap<String, String>,
+    subject: &Subject,
+    cancel: CancellationToken,
+    job_timeout: Duration,
+    step_timeout: Duration,
+) -> RunnerResult<JobRunResult> {
+    // #527: decide + (if isolation is requested) acquire a sandbox
+    // reservation before running any steps. `None` scheduler ⇒ always
+    // in-proc (pre-#527 behavior, unchanged).
+    let placement = match &scheduler {
+        Some(scheduler) => scheduler
+            .place(job_name, &job.runs_on, &job.resources, subject)
+            .await
+            .map_err(|e| RunnerError::VfsError(format!("job placement failed: {e}")))?,
+        None => Placement::InProc,
+    };
+
+    // #521: bound job execution wall-clock time. A job's own
+    // `timeout-minutes:` already folded into `job_timeout` by the caller.
+    let outcome = tokio::time::timeout(
+        job_timeout,
+        run_job_steps(ns, semaphore, job, job_name, env, inputs, subject, cancel, step_timeout),
+    )
+    .await;
+
+    placement.release().await;
+
+    match outcome {
+        Ok(result) => result,
+        Err(_elapsed) => Ok(JobRunResult {
+            name: job_name.to_owned(),
+            success: false,
+            steps: vec![StepRunResult {
+                name: "<timeout>".to_owned(),
+                success: false,
+                output: format!("job timed out after {}s", job_timeout.as_secs()),
+            }],
+        }),
+    }
+}
+
+/// Execute a single job's steps sequentially. For script steps (`run:`), a
+/// single TclShell is reused across all sequential steps in the same job
+/// (constructed inside `spawn_blocking`). Each step is individually bounded
+/// by `step_timeout` (#521).
+#[allow(clippy::too_many_arguments)]
+async fn run_job_steps(
     ns: Arc<Namespace>,
     semaphore: Arc<Semaphore>,
     job: &Job,
@@ -222,6 +348,7 @@ async fn run_job(
     inputs: &HashMap<String, String>,
     subject: &Subject,
     cancel: CancellationToken,
+    step_timeout: Duration,
 ) -> RunnerResult<JobRunResult> {
     let mut step_results = Vec::new();
     let mut job_success = true;
@@ -304,10 +431,19 @@ async fn run_job(
                 .unwrap_or_else(|| format!("step-{}", i));
 
             if let Some(ref action) = step.uses {
-                // Action step — runs on async runtime.
-                let result =
-                    run_action_step(action, &step.with, &ns_for_actions, &subject_for_actions)
-                        .await;
+                // Action step — runs on async runtime, bounded by step_timeout (#521).
+                let result = match tokio::time::timeout(
+                    step_timeout,
+                    run_action_step(action, &step.with, &ns_for_actions, &subject_for_actions),
+                )
+                .await
+                {
+                    Ok(r) => r,
+                    Err(_elapsed) => Err(RunnerError::StepFailed(format!(
+                        "step timed out after {}s",
+                        step_timeout.as_secs()
+                    ))),
+                };
                 match result {
                     Ok(output) => {
                         step_results.push(StepRunResult {
@@ -347,15 +483,18 @@ async fn run_job(
                     job_success = false;
                     break;
                 }
-                match reply_rx.await {
-                    Ok(Ok(output)) => {
+                // Bounded by step_timeout (#521); on elapsed the reply is simply
+                // dropped — the shell thread will finish the eval on its own time
+                // and move on to the next queued script (or idle if none comes).
+                match tokio::time::timeout(step_timeout, reply_rx).await {
+                    Ok(Ok(Ok(output))) => {
                         step_results.push(StepRunResult {
                             name: step_name,
                             success: true,
                             output,
                         });
                     }
-                    Ok(Err(e)) => {
+                    Ok(Ok(Err(e))) => {
                         let failed = StepRunResult {
                             name: step_name,
                             success: false,
@@ -367,11 +506,20 @@ async fn run_job(
                             break;
                         }
                     }
-                    Err(_) => {
+                    Ok(Err(_)) => {
                         step_results.push(StepRunResult {
                             name: step_name,
                             success: false,
                             output: "TclShell thread panicked".into(),
+                        });
+                        job_success = false;
+                        break;
+                    }
+                    Err(_elapsed) => {
+                        step_results.push(StepRunResult {
+                            name: step_name,
+                            success: false,
+                            output: format!("step timed out after {}s", step_timeout.as_secs()),
                         });
                         job_success = false;
                         break;
@@ -396,7 +544,19 @@ async fn run_job(
                 .unwrap_or_else(|| format!("step-{}", i));
 
             if let Some(ref action) = step.uses {
-                let result = run_action_step(action, &step.with, &ns, subject).await;
+                // Bounded by step_timeout (#521).
+                let result = match tokio::time::timeout(
+                    step_timeout,
+                    run_action_step(action, &step.with, &ns, subject),
+                )
+                .await
+                {
+                    Ok(r) => r,
+                    Err(_elapsed) => Err(RunnerError::StepFailed(format!(
+                        "step timed out after {}s",
+                        step_timeout.as_secs()
+                    ))),
+                };
                 match result {
                     Ok(output) => {
                         step_results.push(StepRunResult {
@@ -883,6 +1043,113 @@ mod tests {
         async fn clunk(&self, _fid: Fid, _caller: &Subject) {}
     }
 
+    /// Ctl-pattern mount whose `write` actually awaits (`tokio::time::sleep`)
+    /// before answering "ok" — used to make `step_timeout`/`job_timeout`
+    /// (#521) deterministically fire in tests: a step routed through this
+    /// mount really pends, so `tokio::time::timeout` races it for real
+    /// instead of the inner future completing synchronously on first poll.
+    struct SlowMount {
+        delay: std::time::Duration,
+    }
+
+    struct SlowFid;
+
+    #[async_trait]
+    impl Mount for SlowMount {
+        async fn walk(&self, _components: &[&str], _caller: &Subject) -> Result<Fid, MountError> {
+            Ok(Fid::new(SlowFid))
+        }
+        async fn open(&self, _fid: &mut Fid, _mode: u8, _caller: &Subject) -> Result<(), MountError> {
+            Ok(())
+        }
+        async fn write(
+            &self,
+            _fid: &Fid,
+            _offset: u64,
+            _data: &[u8],
+            _caller: &Subject,
+        ) -> Result<u32, MountError> {
+            tokio::time::sleep(self.delay).await;
+            Ok(0)
+        }
+        async fn read(
+            &self,
+            _fid: &Fid,
+            offset: u64,
+            _count: u32,
+            _caller: &Subject,
+        ) -> Result<Vec<u8>, MountError> {
+            if offset == 0 {
+                Ok(b"ok".to_vec())
+            } else {
+                Ok(vec![])
+            }
+        }
+        async fn readdir(&self, _fid: &Fid, _caller: &Subject) -> Result<Vec<DirEntry>, MountError> {
+            Ok(vec![])
+        }
+        async fn stat(&self, _fid: &Fid, _caller: &Subject) -> Result<Stat, MountError> {
+            Ok(Stat::unknown_qid(0, 0, String::new(), 0))
+        }
+        async fn clunk(&self, _fid: Fid, _caller: &Subject) {}
+    }
+
+    /// Ctl-pattern mount that tracks concurrently-in-flight `write` calls (for
+    /// the `max_concurrent_runs` / #521 test): bumps a shared counter, records
+    /// the observed peak, sleeps briefly (so overlapping calls actually
+    /// overlap), then decrements.
+    struct TrackingMount {
+        current: Arc<std::sync::atomic::AtomicUsize>,
+        peak: Arc<std::sync::atomic::AtomicUsize>,
+        delay: std::time::Duration,
+    }
+
+    struct TrackingFid;
+
+    #[async_trait]
+    impl Mount for TrackingMount {
+        async fn walk(&self, _components: &[&str], _caller: &Subject) -> Result<Fid, MountError> {
+            Ok(Fid::new(TrackingFid))
+        }
+        async fn open(&self, _fid: &mut Fid, _mode: u8, _caller: &Subject) -> Result<(), MountError> {
+            Ok(())
+        }
+        async fn write(
+            &self,
+            _fid: &Fid,
+            _offset: u64,
+            _data: &[u8],
+            _caller: &Subject,
+        ) -> Result<u32, MountError> {
+            use std::sync::atomic::Ordering;
+            let cur = self.current.fetch_add(1, Ordering::SeqCst) + 1;
+            self.peak.fetch_max(cur, Ordering::SeqCst);
+            tokio::time::sleep(self.delay).await;
+            self.current.fetch_sub(1, Ordering::SeqCst);
+            Ok(0)
+        }
+        async fn read(
+            &self,
+            _fid: &Fid,
+            offset: u64,
+            _count: u32,
+            _caller: &Subject,
+        ) -> Result<Vec<u8>, MountError> {
+            if offset == 0 {
+                Ok(b"ok".to_vec())
+            } else {
+                Ok(vec![])
+            }
+        }
+        async fn readdir(&self, _fid: &Fid, _caller: &Subject) -> Result<Vec<DirEntry>, MountError> {
+            Ok(vec![])
+        }
+        async fn stat(&self, _fid: &Fid, _caller: &Subject) -> Result<Stat, MountError> {
+            Ok(Stat::unknown_qid(0, 0, String::new(), 0))
+        }
+        async fn clunk(&self, _fid: Fid, _caller: &Subject) {}
+    }
+
     fn test_subject() -> Subject {
         Subject::new("test-runner")
     }
@@ -902,6 +1169,51 @@ mod tests {
         ns.mount("/config", config_mount).unwrap();
 
         Arc::new(ns)
+    }
+
+    fn make_namespace_with_slow_action(delay: std::time::Duration) -> Arc<Namespace> {
+        let mut ns = Namespace::new();
+        let bin_mount = Arc::new(SlowMount { delay });
+        ns.mount("/bin", bin_mount).unwrap();
+        Arc::new(ns)
+    }
+
+    fn make_namespace_with_tracking_action(
+        current: Arc<std::sync::atomic::AtomicUsize>,
+        peak: Arc<std::sync::atomic::AtomicUsize>,
+        delay: std::time::Duration,
+    ) -> Arc<Namespace> {
+        let mut ns = Namespace::new();
+        let bin_mount = Arc::new(TrackingMount {
+            current,
+            peak,
+            delay,
+        });
+        ns.mount("/bin", bin_mount).unwrap();
+        Arc::new(ns)
+    }
+
+    fn single_action_job(action: &str) -> Job {
+        Job {
+            runs_on: super::super::parser::RunsOn::Label("ubuntu".into()),
+            needs: None,
+            env: HashMap::new(),
+            steps: vec![Step {
+                name: Some("step".into()),
+                id: None,
+                uses: Some(action.to_owned()),
+                run: None,
+                shell: None,
+                working_directory: None,
+                with: HashMap::new(),
+                env: HashMap::new(),
+                condition: None,
+                continue_on_error: false,
+            }],
+            condition: None,
+            timeout_minutes: None,
+            resources: super::super::parser::JobResources::default(),
+        }
     }
 
     fn make_simple_workflow(jobs: HashMap<String, Job>) -> Workflow {
@@ -927,6 +1239,7 @@ mod tests {
                 steps: vec![],
                 condition: None,
                 timeout_minutes: None,
+                resources: super::super::parser::JobResources::default(),
             },
         );
         jobs.insert(
@@ -938,6 +1251,7 @@ mod tests {
                 steps: vec![],
                 condition: None,
                 timeout_minutes: None,
+                resources: super::super::parser::JobResources::default(),
             },
         );
 
@@ -958,6 +1272,7 @@ mod tests {
                 steps: vec![],
                 condition: None,
                 timeout_minutes: None,
+                resources: super::super::parser::JobResources::default(),
             },
         );
         jobs.insert(
@@ -969,6 +1284,7 @@ mod tests {
                 steps: vec![],
                 condition: None,
                 timeout_minutes: None,
+                resources: super::super::parser::JobResources::default(),
             },
         );
         jobs.insert(
@@ -980,6 +1296,7 @@ mod tests {
                 steps: vec![],
                 condition: None,
                 timeout_minutes: None,
+                resources: super::super::parser::JobResources::default(),
             },
         );
 
@@ -1002,6 +1319,7 @@ mod tests {
                 steps: vec![],
                 condition: None,
                 timeout_minutes: None,
+                resources: super::super::parser::JobResources::default(),
             },
         );
         jobs.insert(
@@ -1013,6 +1331,7 @@ mod tests {
                 steps: vec![],
                 condition: None,
                 timeout_minutes: None,
+                resources: super::super::parser::JobResources::default(),
             },
         );
 
@@ -1091,6 +1410,7 @@ mod tests {
                 }],
                 condition: None,
                 timeout_minutes: None,
+                resources: super::super::parser::JobResources::default(),
             },
         );
         jobs.insert(
@@ -1113,6 +1433,7 @@ mod tests {
                 }],
                 condition: None,
                 timeout_minutes: None,
+                resources: super::super::parser::JobResources::default(),
             },
         );
 
@@ -1161,6 +1482,7 @@ mod tests {
                 }],
                 condition: None,
                 timeout_minutes: None,
+                resources: super::super::parser::JobResources::default(),
             },
         );
 
@@ -1204,6 +1526,7 @@ mod tests {
                 }],
                 condition: None,
                 timeout_minutes: None,
+                resources: super::super::parser::JobResources::default(),
             },
         );
 
@@ -1247,6 +1570,7 @@ mod tests {
                 }],
                 condition: None,
                 timeout_minutes: None,
+                resources: super::super::parser::JobResources::default(),
             },
         );
         jobs.insert(
@@ -1269,6 +1593,7 @@ mod tests {
                 }],
                 condition: None,
                 timeout_minutes: None,
+                resources: super::super::parser::JobResources::default(),
             },
         );
 
@@ -1357,6 +1682,7 @@ mod tests {
                 ],
                 condition: None,
                 timeout_minutes: None,
+                resources: super::super::parser::JobResources::default(),
             },
         );
 
@@ -1415,6 +1741,7 @@ mod tests {
                 ],
                 condition: None,
                 timeout_minutes: None,
+                resources: super::super::parser::JobResources::default(),
             },
         );
 
@@ -1473,6 +1800,7 @@ mod tests {
                 ],
                 condition: None,
                 timeout_minutes: None,
+                resources: super::super::parser::JobResources::default(),
             },
         );
 
@@ -1488,5 +1816,119 @@ mod tests {
         assert_eq!(job.steps.len(), 2);
         // Second step should see the variable set by first step
         assert_eq!(job.steps[1].output, "hello");
+    }
+
+    // ── #521: run-level concurrency + job/step timeouts ──────────────────
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn step_timeout_fails_the_step_and_job() {
+        // The mount actually sleeps 2s; step_timeout of 1s must trip first.
+        let ns = make_namespace_with_slow_action(Duration::from_secs(2));
+        let config = WorkflowConfig {
+            step_timeout_secs: 1,
+            ..Default::default()
+        };
+        let runner = WorkflowRunner::with_config(ns, &config);
+
+        let mut jobs = HashMap::new();
+        jobs.insert("slow-job".to_owned(), single_action_job("slow/step"));
+        let workflow = make_simple_workflow(jobs);
+
+        let result = runner
+            .run(&workflow, HashMap::new(), &test_subject(), CancellationToken::new())
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        let job = &result.jobs["slow-job"];
+        assert!(!job.success);
+        assert!(
+            job.steps[0].output.contains("timed out"),
+            "expected a timeout message, got: {:?}",
+            job.steps[0].output
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn job_timeout_fails_the_whole_job() {
+        // step_timeout is generous; job_timeout (wrapping the whole job) is
+        // the one that must trip.
+        let ns = make_namespace_with_slow_action(Duration::from_secs(2));
+        let config = WorkflowConfig {
+            job_timeout_secs: 1,
+            step_timeout_secs: 600,
+            ..Default::default()
+        };
+        let runner = WorkflowRunner::with_config(ns, &config);
+
+        let mut jobs = HashMap::new();
+        jobs.insert("slow-job".to_owned(), single_action_job("slow/step"));
+        let workflow = make_simple_workflow(jobs);
+
+        let result = runner
+            .run(&workflow, HashMap::new(), &test_subject(), CancellationToken::new())
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        let job = &result.jobs["slow-job"];
+        assert!(!job.success);
+        assert_eq!(job.steps[0].name, "<timeout>");
+        assert!(job.steps[0].output.contains("job timed out"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn max_concurrent_runs_serializes_concurrent_runs() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let current = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let ns = make_namespace_with_tracking_action(
+            current.clone(),
+            peak.clone(),
+            Duration::from_millis(150),
+        );
+        let config = WorkflowConfig {
+            max_concurrent_runs: 1,
+            ..Default::default()
+        };
+        let runner = Arc::new(WorkflowRunner::with_config(ns, &config));
+
+        let make_workflow = || {
+            let mut jobs = HashMap::new();
+            jobs.insert("job".to_owned(), single_action_job("track/step"));
+            make_simple_workflow(jobs)
+        };
+
+        let r1 = {
+            let runner = Arc::clone(&runner);
+            let wf = make_workflow();
+            tokio::spawn(async move {
+                runner
+                    .run(&wf, HashMap::new(), &test_subject(), CancellationToken::new())
+                    .await
+            })
+        };
+        // Give r1 a head start so it acquires the sole run permit first.
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        let r2 = {
+            let runner = Arc::clone(&runner);
+            let wf = make_workflow();
+            tokio::spawn(async move {
+                runner
+                    .run(&wf, HashMap::new(), &test_subject(), CancellationToken::new())
+                    .await
+            })
+        };
+
+        let (res1, res2) = tokio::join!(r1, r2);
+        assert!(res1.unwrap().unwrap().success);
+        assert!(res2.unwrap().unwrap().success);
+        assert_eq!(
+            peak.load(Ordering::SeqCst),
+            1,
+            "max_concurrent_runs=1 should have serialized the two runs, never letting \
+             both execute their job step at once"
+        );
     }
 }

--- a/crates/hyprstream-workers/src/workflow/scheduler.rs
+++ b/crates/hyprstream-workers/src/workflow/scheduler.rs
@@ -6,17 +6,29 @@
 //! (`SandboxPool::acquire`) instead of the pre-#527 fire-and-forget
 //! `tokio::spawn` that ignored both.
 //!
-//! ## 🔒 Mapping convention (NEEDS REVIEWER SIGN-OFF)
+//! ## 🔒 Mapping convention (ratified: B′ group semantics, #921 decision 5)
 //!
 //! `runs_on: <label>` is matched, case-insensitively, against a small
 //! reserved alias set ([`IN_PROC_LABELS`]) meaning "no isolation — run
 //! in-process" (today's VFS/Tcl execution path, unchanged). Any other label
 //! routes the job onto the [`JobScheduler`]'s configured [`SandboxPool`] and
-//! is recorded as the admission `group` (`hyprstream_workers::runtime::ANN_GROUP`)
-//! so operators can give distinct runner labels independent per-group quota
-//! via `AdmissionConfig::max_per_group` — this is "consistent with how #525's
-//! admission engine already consumes that vocabulary", per the issue's own
-//! suggested wording.
+//! is recorded as the `hyprstream_workers::runtime::ANN_GROUP` annotation.
+//!
+//! Under the ratified B′ semantics that annotation is a **capacity-partition
+//! selector, never an authoritative quota/trust/billing key**: admission
+//! (`runtime::admission`) resolves it against the verified Subject's
+//! bidirectional-consent placement-group membership via the pool's
+//! `GroupSelectorValidator` — a workflow naming a group its Subject is not a
+//! member of is **rejected at admission**, not silently accepted. The
+//! production default validator (`DenyUnknownGroupValidator`) fail-closes on
+//! every non-empty selector until a membership source
+//! (`PlacementIndex::is_member`) is wired, so an isolated `runs_on:` label is
+//! deny-by-default today. Validated labels partition node-local capacity via
+//! `AdmissionConfig::max_per_group` (fairness/organization only —
+//! authoritative quota arrives via the ledger path, #922/#925). This module
+//! adds **no group accounting of its own**: the label's only consumer is the
+//! `ANN_GROUP` annotation read back by `admission::derive_group_selector`
+//! inside `SandboxPool::acquire`.
 //!
 //! This is a **label → group** mapping, not a **label → backend** mapping:
 //! one `JobScheduler` wraps exactly one pre-resolved [`SandboxPool`] (bound
@@ -88,7 +100,9 @@ pub fn wants_in_proc(runs_on: &RunsOn) -> bool {
 /// translate to for admission (#525 P2): cpu/memory become
 /// `linux.resources`, `gpu` becomes the `ANN_GPU_REQUEST` annotation (the
 /// same vocabulary `runtime::admission::derive_demand` already reads), and
-/// the `runs_on` label becomes the `ANN_GROUP` annotation (see module docs).
+/// the `runs_on` label becomes the `ANN_GROUP` annotation — a B′ group
+/// *selector*, validated against the verified Subject's membership by the
+/// pool's `GroupSelectorValidator` at admission (see module docs).
 pub fn job_pod_sandbox_config(
     job_name: &str,
     runs_on_label: &str,
@@ -179,6 +193,10 @@ impl JobScheduler {
     /// Decide placement for a job and, if it requests isolation, acquire a
     /// sandbox reservation for it (admitted via `subject`'s identity/quota —
     /// fail-closed if `subject` is anonymous, see `runtime::admission`).
+    ///
+    /// The `runs_on` label rides along as a B′ group selector; admission
+    /// rejects it unless the pool's `GroupSelectorValidator` proves `subject`
+    /// a consented member of that group (deny-unknown by default).
     pub async fn place(
         &self,
         job_name: &str,
@@ -206,6 +224,7 @@ mod tests {
     use crate::config::PoolConfig;
     use crate::runtime::{
         AdmissionConfig, LinuxContainerResources, PodSandbox, SandboxBackend, SandboxHandle,
+        StaticGroupMembership,
     };
     use async_trait::async_trait;
     use std::any::Any;
@@ -330,7 +349,9 @@ mod tests {
             _command: &[String],
             _timeout_secs: u64,
         ) -> Result<(i32, Vec<u8>, Vec<u8>)> {
-            Err(crate::error::WorkerError::ExecFailed("not supported".into()))
+            Err(crate::error::WorkerError::ExecFailed(
+                "not supported".into(),
+            ))
         }
         async fn update_resources(
             &self,
@@ -341,6 +362,8 @@ mod tests {
         }
     }
 
+    /// Scheduler over a pool with the production-default (fail-closed,
+    /// deny-unknown-group) validator — what `SandboxPool::new` gives you.
     fn make_scheduler(admission: AdmissionConfig) -> (Arc<JobScheduler>, Arc<FakeBackend>) {
         let backend = Arc::new(FakeBackend::default());
         let pool_config = PoolConfig {
@@ -348,7 +371,31 @@ mod tests {
             admission,
             ..Default::default()
         };
-        let pool = Arc::new(SandboxPool::new(pool_config, backend.clone() as Arc<dyn SandboxBackend>));
+        let pool = Arc::new(SandboxPool::new(
+            pool_config,
+            backend.clone() as Arc<dyn SandboxBackend>,
+        ));
+        (Arc::new(JobScheduler::new(pool)), backend)
+    }
+
+    /// Scheduler over a pool with a membership-backed validator (B′): the
+    /// runs_on selector is only honored for groups `subject` provably belongs
+    /// to.
+    fn make_scheduler_with_membership(
+        admission: AdmissionConfig,
+        membership: StaticGroupMembership,
+    ) -> (Arc<JobScheduler>, Arc<FakeBackend>) {
+        let backend = Arc::new(FakeBackend::default());
+        let pool_config = PoolConfig {
+            warm_pool_size: 0,
+            admission,
+            ..Default::default()
+        };
+        let pool = Arc::new(SandboxPool::with_group_validator(
+            pool_config,
+            backend.clone() as Arc<dyn SandboxBackend>,
+            Arc::new(membership),
+        ));
         (Arc::new(JobScheduler::new(pool)), backend)
     }
 
@@ -373,7 +420,12 @@ mod tests {
 
     #[tokio::test]
     async fn isolated_runs_on_acquires_a_real_sandbox() {
-        let (scheduler, backend) = make_scheduler(AdmissionConfig::default());
+        // B′: the runs_on label is a group selector, so the Subject must be a
+        // consented member of that group for admission to honor it.
+        let (scheduler, backend) = make_scheduler_with_membership(
+            AdmissionConfig::default(),
+            StaticGroupMembership::new().with_member("kata", "test-user"),
+        );
         let subject = Subject::new("test-user");
 
         let placement = scheduler
@@ -393,32 +445,83 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn unverified_runs_on_group_is_rejected_at_admission() {
+        // B′ fail-closed default: with no membership source wired
+        // (`DenyUnknownGroupValidator`, what `SandboxPool::new` installs), a
+        // runs_on label — an unverifiable group selector — must be REJECTED
+        // at admission, never silently accepted as a fresh quota bucket. The
+        // backend is never touched.
+        let (scheduler, backend) = make_scheduler(AdmissionConfig::default());
+        let subject = Subject::new("test-user");
+
+        let placement = scheduler
+            .place(
+                "job-x",
+                &RunsOn::Label("kata".into()),
+                &JobResources::default(),
+                &subject,
+            )
+            .await;
+
+        assert!(
+            placement.is_err(),
+            "unverifiable group selector must be rejected fail-closed (B′)"
+        );
+        assert_eq!(backend.starts.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
     async fn runs_on_label_influences_admission_via_group_quota() {
         // max_per_group: 1 means a second job under the SAME runs_on label
         // cannot be admitted concurrently, while a job under a DIFFERENT
         // label is unaffected — proving the runs_on value actually reaches
         // and influences the scheduler's placement decision, not just that
-        // *a* sandbox gets created.
-        let (scheduler, _backend) = make_scheduler(AdmissionConfig {
-            max_per_group: 1,
-            ..AdmissionConfig::default()
-        });
+        // *a* sandbox gets created. Both labels are consented memberships of
+        // the Subject (B′) — the quota partition only applies to validated
+        // selectors.
+        let (scheduler, _backend) = make_scheduler_with_membership(
+            AdmissionConfig {
+                max_per_group: Some(1),
+                ..AdmissionConfig::default()
+            },
+            StaticGroupMembership::new()
+                .with_member("gpu-only", "test-user")
+                .with_member("cpu-only", "test-user"),
+        );
         let subject = Subject::new("test-user");
 
         let first = scheduler
-            .place("job-1", &RunsOn::Label("gpu-only".into()), &JobResources::default(), &subject)
+            .place(
+                "job-1",
+                &RunsOn::Label("gpu-only".into()),
+                &JobResources::default(),
+                &subject,
+            )
             .await
             .expect("first gpu-only job admitted");
 
         // Second job, SAME label, same subject: over the per-group quota.
         let second = scheduler
-            .place("job-2", &RunsOn::Label("gpu-only".into()), &JobResources::default(), &subject)
+            .place(
+                "job-2",
+                &RunsOn::Label("gpu-only".into()),
+                &JobResources::default(),
+                &subject,
+            )
             .await;
-        assert!(second.is_err(), "second job under the same maxed-out group should be rejected");
+        assert!(
+            second.is_err(),
+            "second job under the same maxed-out group should be rejected"
+        );
 
         // Third job, DIFFERENT label: its own group quota, unaffected by gpu-only's.
         let third = scheduler
-            .place("job-3", &RunsOn::Label("cpu-only".into()), &JobResources::default(), &subject)
+            .place(
+                "job-3",
+                &RunsOn::Label("cpu-only".into()),
+                &JobResources::default(),
+                &subject,
+            )
             .await
             .expect("different runs_on label has its own group quota");
 

--- a/crates/hyprstream-workers/src/workflow/scheduler.rs
+++ b/crates/hyprstream-workers/src/workflow/scheduler.rs
@@ -1,0 +1,428 @@
+//! Job → scheduled workload placement (#527).
+//!
+//! Maps a job's `runs_on:` label + `resources:` hints onto a placement
+//! decision and, for jobs that request isolation, acquires/releases a real
+//! sandbox reservation through the #525 P2 admission engine
+//! (`SandboxPool::acquire`) instead of the pre-#527 fire-and-forget
+//! `tokio::spawn` that ignored both.
+//!
+//! ## 🔒 Mapping convention (NEEDS REVIEWER SIGN-OFF)
+//!
+//! `runs_on: <label>` is matched, case-insensitively, against a small
+//! reserved alias set ([`IN_PROC_LABELS`]) meaning "no isolation — run
+//! in-process" (today's VFS/Tcl execution path, unchanged). Any other label
+//! routes the job onto the [`JobScheduler`]'s configured [`SandboxPool`] and
+//! is recorded as the admission `group` (`hyprstream_workers::runtime::ANN_GROUP`)
+//! so operators can give distinct runner labels independent per-group quota
+//! via `AdmissionConfig::max_per_group` — this is "consistent with how #525's
+//! admission engine already consumes that vocabulary", per the issue's own
+//! suggested wording.
+//!
+//! This is a **label → group** mapping, not a **label → backend** mapping:
+//! one `JobScheduler` wraps exactly one pre-resolved [`SandboxPool`] (bound
+//! to one [`crate::runtime::SandboxBackend`] at construction — see
+//! `pool.rs`'s own documented invariant that a pool never re-selects its
+//! backend per-request). `runs_on: kata` therefore does NOT pick a different
+//! backend than `runs_on: nspawn` within a single scheduler; both go to
+//! *this scheduler's* one backend, merely tagged with a different admission
+//! group. Routing different labels to genuinely different backends would
+//! mean a router over multiple backend-specific pools — the same
+//! architectural change `pool.rs` already flags as a follow-up, not
+//! something this ticket re-derives. Flagged here explicitly for reviewer
+//! sign-off, per the issue's disclosure ask.
+//!
+//! ## What "runs in a sandbox" means today (also flagged)
+//!
+//! Placement acquires a *real* sandbox reservation — admission is checked,
+//! the backend's `start()` actually runs (a real Kata VM boots when the pool
+//! is Kata-backed) — closing the #520 "no isolation" gap structurally: a
+//! job that requests isolation now really holds a sandbox for its duration.
+//! Step *content* execution (the `uses:`/`run:` bodies) still runs through
+//! the existing VFS `/bin/` ctl + TclShell bridge on the host, not inside the
+//! guest's own namespace — routing individual step exec into the guest (via
+//! `kata_agent::ExecProcess`, `nspawn`, etc.) needs the streaming/fd plane
+//! `exec_mount.rs` itself documents as not yet built. That is a materially
+//! larger follow-up, not attempted here.
+
+use std::sync::Arc;
+
+use hyprstream_vfs::Subject;
+
+use crate::error::Result;
+use crate::runtime::{
+    KeyValue, PodSandboxConfig, PodSandboxMetadata, SandboxPool, ANN_GPU_REQUEST, ANN_GROUP,
+};
+
+use super::parser::{JobResources, RunsOn};
+
+/// `runs_on:` labels (case-insensitive) meaning "no isolation — run
+/// in-process" via the existing VFS/Tcl execution path. Anything else is
+/// treated as a request for this scheduler's sandbox (see module docs).
+pub const IN_PROC_LABELS: &[&str] = &["local", "self-hosted", "in-process", "tcl"];
+
+/// The label that drives a job's placement decision.
+///
+/// GHA's `runs-on: [a, b]` means "match ALL labels" against a runner's
+/// capability set. Hyprstream has no such per-runner capability set to
+/// intersect against (yet) — `runs_on` here selects an admission *group*
+/// (see module docs), a mapping for which multi-label AND-composition has no
+/// defined meaning. Only the first label is consulted; additional labels in
+/// `RunsOn::Labels` are accepted (not a parse error) but otherwise ignored.
+/// This is a documented scope-limit, not a silent drop.
+pub fn primary_label(runs_on: &RunsOn) -> &str {
+    match runs_on {
+        RunsOn::Label(l) => l.as_str(),
+        RunsOn::Labels(v) => v.first().map(String::as_str).unwrap_or(""),
+    }
+}
+
+/// True when `runs_on`'s primary label requests in-process (no sandbox)
+/// execution — either explicitly (an [`IN_PROC_LABELS`] alias) or because no
+/// label was usefully provided (empty string).
+pub fn wants_in_proc(runs_on: &RunsOn) -> bool {
+    let label = primary_label(runs_on);
+    label.is_empty() || IN_PROC_LABELS.iter().any(|l| l.eq_ignore_ascii_case(label))
+}
+
+/// Build the `PodSandboxConfig` a job's `resources:` hints + `runs_on` label
+/// translate to for admission (#525 P2): cpu/memory become
+/// `linux.resources`, `gpu` becomes the `ANN_GPU_REQUEST` annotation (the
+/// same vocabulary `runtime::admission::derive_demand` already reads), and
+/// the `runs_on` label becomes the `ANN_GROUP` annotation (see module docs).
+pub fn job_pod_sandbox_config(
+    job_name: &str,
+    runs_on_label: &str,
+    resources: &JobResources,
+) -> PodSandboxConfig {
+    let mut config = PodSandboxConfig {
+        metadata: PodSandboxMetadata {
+            name: format!("workflow-job-{job_name}"),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    if resources.cpu_millis > 0 {
+        // CRI convention: a 100ms period is the common default; quota scales
+        // with it so `(quota / period) * 1000` round-trips through
+        // `derive_demand` back to `cpu_millis`.
+        config.linux.resources.cpu_period = 100_000;
+        config.linux.resources.cpu_quota = (resources.cpu_millis as i64) * 100;
+    }
+    if resources.memory_bytes > 0 {
+        config.linux.resources.memory_limit_in_bytes = resources.memory_bytes as i64;
+    }
+    if resources.gpu > 0 {
+        config.annotations.push(KeyValue {
+            key: ANN_GPU_REQUEST.to_owned(),
+            value: resources.gpu.to_string(),
+        });
+    }
+    config.annotations.push(KeyValue {
+        key: ANN_GROUP.to_owned(),
+        value: runs_on_label.to_owned(),
+    });
+
+    config
+}
+
+/// A job's resolved placement. `Sandbox` must be released via
+/// [`Placement::release`] once the job finishes (success, failure, timeout,
+/// or cancellation) so the admission reservation and warm-pool slot are
+/// given back — see `SandboxPool::release`'s own reservation-rollback
+/// discipline.
+pub enum Placement {
+    /// No isolation — the job's steps run on the existing host VFS/Tcl path.
+    InProc,
+    /// A live sandbox reservation acquired from `pool`.
+    Sandbox {
+        pool: Arc<SandboxPool>,
+        sandbox_id: String,
+    },
+}
+
+impl Placement {
+    /// Release a `Sandbox` placement back to its pool. A no-op for `InProc`.
+    /// Errors are logged, not propagated: by the time a job finishes, its
+    /// result is already decided, and swallowing a release failure here
+    /// matches `SandboxPool::release`'s own callers elsewhere (best-effort
+    /// cleanup, never fails the job it releases after).
+    pub async fn release(self) {
+        if let Placement::Sandbox { pool, sandbox_id } = self {
+            if let Err(e) = pool.release(&sandbox_id).await {
+                tracing::warn!(
+                    sandbox_id = %sandbox_id,
+                    error = %e,
+                    "failed to release workflow job sandbox"
+                );
+            }
+        }
+    }
+}
+
+/// Routes workflow jobs through the #525 P2 scheduler.
+///
+/// See the module docs for the `runs_on` → group mapping convention and its
+/// documented scope limits.
+pub struct JobScheduler {
+    pool: Arc<SandboxPool>,
+}
+
+impl JobScheduler {
+    /// Wrap an already-constructed [`SandboxPool`] (bound to one backend,
+    /// e.g. via `runtime::resolve_backend` — the same #516 fail-closed
+    /// registry `worker.backend` uses) as the target for isolated jobs.
+    pub fn new(pool: Arc<SandboxPool>) -> Self {
+        Self { pool }
+    }
+
+    /// Decide placement for a job and, if it requests isolation, acquire a
+    /// sandbox reservation for it (admitted via `subject`'s identity/quota —
+    /// fail-closed if `subject` is anonymous, see `runtime::admission`).
+    pub async fn place(
+        &self,
+        job_name: &str,
+        runs_on: &RunsOn,
+        resources: &JobResources,
+        subject: &Subject,
+    ) -> Result<Placement> {
+        if wants_in_proc(runs_on) {
+            return Ok(Placement::InProc);
+        }
+        let label = primary_label(runs_on);
+        let config = job_pod_sandbox_config(job_name, label, resources);
+        let sandbox_id = self.pool.acquire(subject, &config).await?;
+        Ok(Placement::Sandbox {
+            pool: Arc::clone(&self.pool),
+            sandbox_id,
+        })
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::config::PoolConfig;
+    use crate::runtime::{
+        AdmissionConfig, LinuxContainerResources, PodSandbox, SandboxBackend, SandboxHandle,
+    };
+    use async_trait::async_trait;
+    use std::any::Any;
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn primary_label_picks_first_of_list() {
+        assert_eq!(primary_label(&RunsOn::Label("kata".into())), "kata");
+        assert_eq!(
+            primary_label(&RunsOn::Labels(vec!["gpu".into(), "linux".into()])),
+            "gpu"
+        );
+        assert_eq!(primary_label(&RunsOn::Labels(vec![])), "");
+    }
+
+    #[test]
+    fn in_proc_labels_are_case_insensitive() {
+        assert!(wants_in_proc(&RunsOn::Label("LOCAL".into())));
+        assert!(wants_in_proc(&RunsOn::Label("Self-Hosted".into())));
+        assert!(!wants_in_proc(&RunsOn::Label("kata".into())));
+        assert!(!wants_in_proc(&RunsOn::Label("ubuntu-latest".into())));
+    }
+
+    /// Read back an annotation by key (mirrors
+    /// `runtime::admission::annotation`, which is private to that module).
+    fn find_annotation<'a>(config: &'a PodSandboxConfig, key: &str) -> Option<&'a str> {
+        config
+            .annotations
+            .iter()
+            .find(|kv| kv.key == key)
+            .map(|kv| kv.value.as_str())
+    }
+
+    #[test]
+    fn job_pod_sandbox_config_maps_resources_and_group() {
+        let resources = JobResources {
+            cpu_millis: 500,
+            memory_bytes: 1024,
+            gpu: 2,
+        };
+        let config = job_pod_sandbox_config("build", "gpu-workers", &resources);
+
+        // CRI convention: (quota / period) * 1000 == requested cpu_millis
+        // (see `runtime::admission::derive_demand`, which reads it back the
+        // same way from a real acquire() call).
+        assert_eq!(config.linux.resources.cpu_period, 100_000);
+        assert_eq!(config.linux.resources.cpu_quota, 50_000);
+        assert_eq!(config.linux.resources.memory_limit_in_bytes, 1024);
+        assert_eq!(find_annotation(&config, ANN_GPU_REQUEST), Some("2"));
+        assert_eq!(find_annotation(&config, ANN_GROUP), Some("gpu-workers"));
+    }
+
+    #[test]
+    fn job_pod_sandbox_config_no_resources_is_zero_demand() {
+        let config = job_pod_sandbox_config("noop", "kata", &JobResources::default());
+        assert_eq!(config.linux.resources.cpu_period, 0);
+        assert_eq!(config.linux.resources.cpu_quota, 0);
+        assert_eq!(config.linux.resources.memory_limit_in_bytes, 0);
+        assert_eq!(find_annotation(&config, ANN_GPU_REQUEST), None);
+        // Group is still set even with no resource demand — `runs_on`
+        // influences placement (quota) independent of resource requests.
+        assert_eq!(find_annotation(&config, ANN_GROUP), Some("kata"));
+    }
+
+    #[derive(Debug)]
+    struct FakeHandle;
+    impl SandboxHandle for FakeHandle {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    /// Minimal in-memory fake backend so scheduler tests don't need a real
+    /// Kata/nspawn toolchain. Tracks how many times `start()` was actually
+    /// invoked, so tests can prove an isolated job really acquires a sandbox
+    /// (#520) and an in-proc job never touches the backend at all.
+    #[derive(Default)]
+    struct FakeBackend {
+        starts: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl SandboxBackend for FakeBackend {
+        fn backend_type(&self) -> &'static str {
+            "fake"
+        }
+        fn is_available(&self) -> bool {
+            true
+        }
+        async fn initialize(&self, _config: &PoolConfig) -> Result<()> {
+            Ok(())
+        }
+        async fn start(
+            &self,
+            _sandbox: &mut PodSandbox,
+            _config: &PodSandboxConfig,
+            _pool_config: &PoolConfig,
+            _annotations: &HashMap<String, String>,
+        ) -> Result<Arc<dyn SandboxHandle>> {
+            self.starts.fetch_add(1, Ordering::SeqCst);
+            Ok(Arc::new(FakeHandle))
+        }
+        async fn stop(&self, _sandbox: &PodSandbox) -> Result<()> {
+            Ok(())
+        }
+        async fn destroy(&self, _sandbox: &PodSandbox) -> Result<()> {
+            Ok(())
+        }
+        async fn reset(&self, _sandbox: &mut PodSandbox) -> Result<bool> {
+            Ok(true)
+        }
+        async fn get_pids(&self, _sandbox: &PodSandbox) -> Result<Vec<u32>> {
+            Ok(vec![])
+        }
+        fn supports_exec(&self) -> bool {
+            false
+        }
+        async fn exec_sync(
+            &self,
+            _sandbox: &PodSandbox,
+            _command: &[String],
+            _timeout_secs: u64,
+        ) -> Result<(i32, Vec<u8>, Vec<u8>)> {
+            Err(crate::error::WorkerError::ExecFailed("not supported".into()))
+        }
+        async fn update_resources(
+            &self,
+            _sandbox: &PodSandbox,
+            _resources: &LinuxContainerResources,
+        ) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    fn make_scheduler(admission: AdmissionConfig) -> (Arc<JobScheduler>, Arc<FakeBackend>) {
+        let backend = Arc::new(FakeBackend::default());
+        let pool_config = PoolConfig {
+            warm_pool_size: 0,
+            admission,
+            ..Default::default()
+        };
+        let pool = Arc::new(SandboxPool::new(pool_config, backend.clone() as Arc<dyn SandboxBackend>));
+        (Arc::new(JobScheduler::new(pool)), backend)
+    }
+
+    #[tokio::test]
+    async fn in_proc_runs_on_never_touches_the_backend() {
+        let (scheduler, backend) = make_scheduler(AdmissionConfig::default());
+        let subject = Subject::new("test-user");
+
+        let placement = scheduler
+            .place(
+                "job-a",
+                &RunsOn::Label("local".into()),
+                &JobResources::default(),
+                &subject,
+            )
+            .await
+            .expect("in-proc placement never fails");
+
+        assert!(matches!(placement, Placement::InProc));
+        assert_eq!(backend.starts.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn isolated_runs_on_acquires_a_real_sandbox() {
+        let (scheduler, backend) = make_scheduler(AdmissionConfig::default());
+        let subject = Subject::new("test-user");
+
+        let placement = scheduler
+            .place(
+                "job-b",
+                &RunsOn::Label("kata".into()),
+                &JobResources::default(),
+                &subject,
+            )
+            .await
+            .expect("sandbox placement should succeed");
+
+        assert!(matches!(placement, Placement::Sandbox { .. }));
+        assert_eq!(backend.starts.load(Ordering::SeqCst), 1);
+
+        placement.release().await;
+    }
+
+    #[tokio::test]
+    async fn runs_on_label_influences_admission_via_group_quota() {
+        // max_per_group: 1 means a second job under the SAME runs_on label
+        // cannot be admitted concurrently, while a job under a DIFFERENT
+        // label is unaffected — proving the runs_on value actually reaches
+        // and influences the scheduler's placement decision, not just that
+        // *a* sandbox gets created.
+        let (scheduler, _backend) = make_scheduler(AdmissionConfig {
+            max_per_group: 1,
+            ..AdmissionConfig::default()
+        });
+        let subject = Subject::new("test-user");
+
+        let first = scheduler
+            .place("job-1", &RunsOn::Label("gpu-only".into()), &JobResources::default(), &subject)
+            .await
+            .expect("first gpu-only job admitted");
+
+        // Second job, SAME label, same subject: over the per-group quota.
+        let second = scheduler
+            .place("job-2", &RunsOn::Label("gpu-only".into()), &JobResources::default(), &subject)
+            .await;
+        assert!(second.is_err(), "second job under the same maxed-out group should be rejected");
+
+        // Third job, DIFFERENT label: its own group quota, unaffected by gpu-only's.
+        let third = scheduler
+            .place("job-3", &RunsOn::Label("cpu-only".into()), &JobResources::default(), &subject)
+            .await
+            .expect("different runs_on label has its own group quota");
+
+        first.release().await;
+        third.release().await;
+    }
+}

--- a/crates/hyprstream-workers/src/workflow/service.rs
+++ b/crates/hyprstream-workers/src/workflow/service.rs
@@ -718,7 +718,13 @@ impl WorkflowHandler for WorkflowService {
         let inputs_map: HashMap<String, String> = request.inputs.iter()
             .map(|kv| (kv.key.clone(), kv.value.clone()))
             .collect();
-        let subject = hyprstream_vfs::Subject::new(ctx.subject().to_string());
+        // Pass the verified `Subject` through directly — never round-trip it
+        // through `.to_string()` → `Subject::new(...)`. `Subject::anonymous()`
+        // Displays as "anonymous", so that round-trip turns an anonymous caller
+        // into a *named* subject "anonymous" (is_anonymous() == false), which
+        // would then pass the fail-closed admission check this dispatch path
+        // feeds (#527) — defeating per-subject quota + the anonymous deny.
+        let subject = ctx.subject();
         let run_id = self.dispatch(&request.workflow_id.clone(), inputs_map, &subject).await?;
         Ok(WorkflowResponseVariant::DispatchResult(run_id))
     }
@@ -880,4 +886,46 @@ fn extract_triggers(workflow: &Workflow) -> Vec<EventTrigger> {
         "schedule" | "training" => vec![EventTrigger::Custom { topic: format!("training.{event}"), pattern: String::new() }],
         _ => vec![EventTrigger::Custom { topic: format!("repo.{event}"), pattern: String::new() }],
     }).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    // Regression guard for the anonymous-subject fail-closed defeat (#770
+    // review FIX 1). `handle_dispatch` derives the caller subject from
+    // `EnvelopeContext::subject()`, which returns `Subject::anonymous()` for
+    // an unauthenticated caller. That subject must reach `dispatch` (→ runner
+    // → `JobScheduler::place` → `AdmissionTracker::reserve`) *untouched*:
+    // `reserve` is fail-closed on `subject.is_anonymous()`, so a converted
+    // subject would silently pass admission and defeat per-subject quota.
+    //
+    // `EnvelopeContext`'s fields are private to `hyprstream-rpc`, so an
+    // anonymous context can't be built from this crate; this test pins the
+    // invariant the dispatch boundary depends on instead.
+
+    use hyprstream_vfs::Subject;
+
+    #[test]
+    fn anonymous_subject_must_not_round_trip_through_string() {
+        // What `ctx.subject()` yields for an unauthenticated caller.
+        let anon = Subject::anonymous();
+        assert!(anon.is_anonymous());
+
+        // The broken transform `handle_dispatch` used to do:
+        // `Subject::new(ctx.subject().to_string())`. `Subject::anonymous()`
+        // Displays as the literal "anonymous", so re-wrapping it produces a
+        // NAMED subject — fail-closed defeated.
+        let broken = Subject::new(anon.to_string());
+        assert_ne!(anon, broken);
+        assert!(
+            !broken.is_anonymous(),
+            "round-tripping an anonymous subject through Display must stay \
+             forbidden: it turns anonymous into the named subject \"anonymous\" \
+             and bypasses fail-closed admission"
+        );
+
+        // The fixed transform: pass the verified `Subject` through untouched.
+        let fixed: Subject = anon.clone();
+        assert!(fixed.is_anonymous());
+        assert_eq!(anon, fixed);
+    }
 }

--- a/crates/hyprstream-workers/src/workflow/service.rs
+++ b/crates/hyprstream-workers/src/workflow/service.rs
@@ -27,6 +27,7 @@ use crate::generated::workflow_client::{
 };
 
 use super::runner::WorkflowRunner;
+use super::scheduler::JobScheduler;
 use super::subscription::WorkflowSubscription;
 use super::triggers::{EventHandler, EventTrigger, HandlerResult};
 use super::{RunId, WorkflowId, Workflow};
@@ -79,8 +80,12 @@ const SERVICE_NAME: &str = "workflow";
 
 /// WorkflowService handles workflow orchestration
 ///
-/// Discovers workflows from repositories, subscribes to events,
-/// and spawns containers via WorkerService.
+/// Discovers workflows from repositories, subscribes to events, and routes
+/// job execution through [`WorkflowRunner`] (#527): jobs requesting
+/// isolation via `runs_on:` are scheduled onto a sandbox through the #525 P2
+/// admission engine (`SandboxPool::acquire`, see `workflow::scheduler`);
+/// others run in-process over the VFS/Tcl bridge. There is no `WorkerService`
+/// dependency here — `WorkflowRunner` talks to `SandboxPool` directly.
 pub struct WorkflowService {
     /// Registered workflows
     workflows: RwLock<HashMap<WorkflowId, WorkflowDef>>,
@@ -154,9 +159,39 @@ impl WorkflowService {
     /// Set the VFS namespace for workflow execution.
     ///
     /// This creates a WorkflowRunner that resolves actions through `/bin/`
-    /// and evaluates scripts via TclShell.
+    /// and evaluates scripts via TclShell, using default
+    /// [`crate::config::WorkflowConfig`] timeouts/concurrency and no job
+    /// scheduler (every job runs in-proc — see [`Self::set_job_scheduler`]).
     pub fn set_namespace(&mut self, ns: Arc<Namespace>) {
         self.runner = Some(WorkflowRunner::new(ns));
+    }
+
+    /// Like [`Self::set_namespace`], but honors `config`'s
+    /// `max_concurrent_runs` / `job_timeout_secs` / `step_timeout_secs`
+    /// (#521) instead of defaults.
+    pub fn set_namespace_with_config(
+        &mut self,
+        ns: Arc<Namespace>,
+        config: &crate::config::WorkflowConfig,
+    ) {
+        self.runner = Some(WorkflowRunner::with_config(ns, config));
+    }
+
+    /// Attach a [`JobScheduler`] (#527) so jobs whose `runs_on:` requests
+    /// isolation are placed onto a real sandbox through the #525 P2
+    /// admission engine, instead of always running in-proc. Must be called
+    /// after `set_namespace`/`set_namespace_with_config`; a no-op (with a
+    /// warning) if no runner has been configured yet.
+    pub fn set_job_scheduler(&mut self, scheduler: Arc<JobScheduler>) {
+        match self.runner.take() {
+            Some(runner) => self.runner = Some(runner.with_scheduler(scheduler)),
+            None => {
+                tracing::warn!(
+                    "set_job_scheduler called before set_namespace — ignored; \
+                     call set_namespace/set_namespace_with_config first"
+                );
+            }
+        }
     }
 
     /// Set the authorization callback for policy checks.


### PR DESCRIPTION
## Summary

Implements #527 (cross-cutting phase XC of epic #523): workflow jobs become
scheduled workloads instead of a fire-and-forget `tokio::spawn` that ignored
`runs_on:` entirely. Base branch is `ewindisch/525-p2-scheduler-engine`
(PR #761, still open at time of writing) since this ticket wires jobs
through that PR's new admission engine.

Closes #520. Part of epic #523 (cross-cutting phase XC, #527). Resolves #521
(wired for real — see below, not superseded).

## What was built

1. **`workflow/scheduler.rs` (new)** — a `JobScheduler` that maps a job's
   `runs_on:` label onto either:
   - **in-proc** (today's VFS `/bin/` ctl + TclShell path, unchanged) for a
     small reserved alias set (`IN_PROC_LABELS`: `local`, `self-hosted`,
     `in-process`, `tcl`), or
   - a **real sandbox reservation** acquired via `SandboxPool::acquire`
     (#525's P2 admission engine) for any other label, with the label
     recorded as the admission `group` annotation (`ANN_GROUP`) so distinct
     runner labels get independent per-group quota via
     `AdmissionConfig::max_per_group`.

   `WorkflowRunner` now takes an optional `Arc<JobScheduler>`
   (`with_scheduler`); `None` (the default via `WorkflowRunner::new`)
   preserves the exact pre-#527 in-proc-only behavior — no regression.
   `WorkflowService::set_job_scheduler` exposes the same opt-in wiring at
   the service layer.

2. **`resources:` job field (`JobResources`: `cpu_millis`/`memory_bytes`/
   `gpu`)** — a hyprstream extension to the GHA job schema (GHA has no
   native resources key), `#[serde(default)]` so it never affects existing
   workflow YAML. Maps onto `PodSandboxConfig.linux.resources` +
   `ANN_GPU_REQUEST`, the same vocabulary `runtime::admission::derive_demand`
   already reads.

3. **#521 — `max_concurrent_runs`/`job_timeout_secs`/`step_timeout_secs`
   wired for real** (not superseded by P2): `WorkflowRunner::with_config`
   sizes a run-admission semaphore from `max_concurrent_runs` (acquired for
   the whole `run()` call — a different axis from `script_semaphore`, which
   bounds concurrent script-executing *jobs*), and wraps job/step execution
   in `tokio::time::timeout` using `job_timeout_secs`/`step_timeout_secs`. A
   job's own `timeout-minutes:` (parsed since day one, previously never
   read) overrides the default job timeout. I chose to wire this for real
   rather than treat it as superseded, because P2's admission governs
   resource *capacity/quota*, while this governs wall-clock *run/step
   duration* — a genuinely different axis, not a duplicate control.

4. **Doc-comment fix** (`workflow/mod.rs`, `workflow/service.rs`) — both
   claimed the engine "spawns containers via WorkerService"; that
   dependency doesn't exist. Corrected to describe the actual
   `WorkflowRunner` → `JobScheduler` → `SandboxPool` path.

5. **`scan_repo`/`initialize`/`handle_subscribe` stubs (#349/#487)** —
   verified these are **already fully implemented** on this base branch
   (not TODO stubs as the original #520/#527 issue text describes — that
   text appears stale relative to current `main`). No work was needed here;
   I did not expand into #349/#487's broader scope.

## Judgment calls flagged for reviewer sign-off

- **`runs_on` → group, not `runs_on` → backend.** `JobScheduler` wraps
  exactly **one** pre-resolved `SandboxPool` (bound to one `SandboxBackend`
  at construction — this mirrors `pool.rs`'s own documented invariant that a
  pool never re-selects its backend per-request). So `runs_on: kata` and
  `runs_on: nspawn` do **not** pick different backends within one scheduler;
  both go to that scheduler's one backend, tagged with a different admission
  group. Routing different labels to genuinely different backends would mean
  a router over multiple backend-specific pools — the same architectural
  change `pool.rs` already flags as a follow-up, not something this ticket
  re-derives. I picked this mapping because it's directly testable against
  the existing admission engine (quota/fit) without inventing new
  multi-backend plumbing in a crate that currently has zero external
  callers. Full write-up in `scheduler.rs`'s module docs.
- **What "runs in a sandbox" means today.** Placement acquires a *real*
  reservation — admission is checked and the backend's `start()` actually
  runs (a real Kata VM boots when the pool is Kata-backed), closing #520's
  "no isolation" gap structurally. Step *content* execution (`uses:`/`run:`
  bodies) still runs through the existing host-side VFS `/bin/` ctl +
  TclShell bridge, not inside the guest's own namespace — routing individual
  step exec into the guest (via `kata_agent::ExecProcess`, `nspawn`, etc.)
  needs the streaming/fd plane `exec_mount.rs` itself documents as not yet
  built (`/exec/instances/<id>/fd/` — "depends on the streaming plane").
  That's a materially larger follow-up, not attempted here.
- **Subject identity for job placement.** Reused the identity already
  threaded through `WorkflowRunner::run()`/`WorkflowService::dispatch()` —
  the RPC caller's verified `ctx.subject()` for manual dispatch, or the
  pre-existing placeholder `Subject::new("workflow-event-dispatch")` for
  event-triggered auto-dispatch (not new — already present on this base
  branch). I did not invent a new identity. Worth an operator decision on
  whether the event-triggered placeholder should eventually carry a real
  per-repo service identity/DID for quota purposes — flagged, not solved
  here.
- **Only the first `runs_on` label drives placement.** GHA's
  `runs-on: [a, b]` means "match ALL labels" against a runner's capability
  set; hyprstream has no such capability set to intersect against under the
  group mapping above, so multi-label AND-composition has no defined
  meaning yet. Additional labels are accepted (not a parse error) but
  otherwise ignored — documented in `scheduler::primary_label`, not a silent
  drop.
- **No capnp/wire-format changes.** Everything here is internal to
  `hyprstream-workers` (the `resources:` field is parsed YAML, not an RPC
  schema addition), so no reviewer sign-off is needed on that front per the
  issue's own "human sign-off" note.

## Test coverage (acceptance criteria)

- `workflow::scheduler::tests::isolated_runs_on_acquires_a_real_sandbox` /
  `in_proc_runs_on_never_touches_the_backend` — a job's `runs_on` value
  really does decide whether the backend's `start()` is invoked (closes
  #520's "no isolation" gap).
- `workflow::scheduler::tests::runs_on_label_influences_admission_via_group_quota`
  — two jobs with the *same* `runs_on` label hit a per-group quota and the
  second is rejected, while a job with a *different* label is unaffected —
  proving `runs_on`'s value concretely influences the scheduler's placement
  decision.
- `workflow::runner::tests::step_timeout_fails_the_step_and_job` /
  `job_timeout_fails_the_whole_job` — real `tokio::time::timeout` firing
  against a mount that genuinely pends (not a synchronously-ready future),
  so the timeout race is exercised for real.
- `workflow::runner::tests::max_concurrent_runs_serializes_concurrent_runs`
  — two concurrent `run()` calls with `max_concurrent_runs: 1` never
  overlap their job execution (tracked via a shared atomic peak counter).

`cargo build -p hyprstream-workers`: clean.
`cargo test -p hyprstream-workers`: 147/147 passed (144 pre-existing + 3 new
timeout/concurrency tests; scheduler.rs adds 7 of its own within that count).
`cargo clippy -p hyprstream-workers --all-targets`: clean, and also clean
under `--features wasm`, `--features oci`, `--features cri`, and
`--features kata-vm` (the one pre-existing warning under `--features wasm`,
an unused import in `wasm_backend.rs`, predates this change and isn't
touched by it).

## Test plan

- [x] `cargo build -p hyprstream-workers`
- [x] `cargo test -p hyprstream-workers` (147/147)
- [x] `cargo clippy -p hyprstream-workers --all-targets` (clean)
- [x] `cargo clippy -p hyprstream-workers --all-targets --features {wasm,oci,cri,kata-vm}` (clean)

## Rebased onto merged #761 + B′ alignment (2026-07-09)

Rebased onto `main` post-#761 (clean rebase, no textual conflicts) and aligned
with the ratified B′ group semantics (#921 decision 5, merge-path annotation
on this PR):

- `runs_on:` → `hyprstream.io/group` is a **capacity-partition selector**,
  not an authoritative quota key: the scheduler's only consumer of the label
  is the `ANN_GROUP` annotation read back by `admission::derive_group_selector`
  inside `SandboxPool::acquire`, so it flows through #761's
  `GroupSelectorValidator` seam (deny-unknown by default) — no parallel
  counter, no bypass. A new test
  (`unverified_runs_on_group_is_rejected_at_admission`) proves an
  unverifiable `runs_on` selector is rejected at admission under the
  production default, with the backend never touched.
- Added `SandboxPool::with_group_validator` (mirrors
  `AdmissionTracker::with_group_validator`) so a membership-backed validator
  (`PlacementIndex::is_member`, when wired) or a test double can be injected
  at pool construction; `SandboxPool::new` keeps the fail-closed
  `DenyUnknownGroupValidator`. No membership resolution is built here.
- Scheduler tests updated to B′: isolated placement + the group-quota test
  run against a `StaticGroupMembership` the test Subject belongs to;
  `max_per_group` updated for #761's `Option<usize>` quota fields.

`cargo test -p hyprstream-workers`: 160/160; workspace release clippy
(`-D warnings`): clean.
