### PR TITLE
feat(9p): H1a — 9P-over-WebSocket export on axum + typed errnos + mount-ticket auth (#764)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,6 +1100,7 @@ dependencies = [
  "async-trait",
  "axum-core 0.4.5",
  "axum-macros",
+ "base64 0.22.1",
  "bytes",
  "futures-util",
  "http 1.3.1",
@@ -1118,8 +1119,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-tungstenite",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
@@ -6809,6 +6812,7 @@ dependencies = [
  "tokenizers",
  "tokio",
  "tokio-stream",
+ "tokio-tungstenite",
  "tokio-util",
  "toml 0.8.23",
  "tonic 0.12.3",
@@ -15926,6 +15930,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-uring"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16440,6 +16456,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.3.1",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
 name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16676,6 +16710,12 @@ dependencies = [
  "libc",
  "log",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8-cstr"

--- a/crates/hyprstream-9p/src/mount_backend.rs
+++ b/crates/hyprstream-9p/src/mount_backend.rs
@@ -29,7 +29,7 @@
 
 use std::sync::Arc;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context as _, Result};
 use async_trait::async_trait;
 use dashmap::DashMap;
 use hyprstream_rpc::Subject;
@@ -85,7 +85,7 @@ impl MountBackend {
             .mount
             .stat(handle, &self.subject)
             .await
-            .map_err(|e| anyhow!("mount stat failed: {e}"))?;
+            .context("mount stat failed")?;
         Ok(Qid { qtype: st.qtype, version: st.version, path: st.path })
     }
 }
@@ -110,7 +110,7 @@ impl Backend for MountBackend {
             .mount
             .walk(&refs, &self.subject)
             .await
-            .map_err(|e| anyhow!("mount walk failed: {e}"))?;
+            .context("mount walk failed")?;
 
         // Mirror `ModelBackend::walk`: return the single leaf qid (the translator
         // records its qtype for the new fid; clients here walk one hop at a time).
@@ -130,7 +130,7 @@ impl Backend for MountBackend {
         self.mount
             .open(handle, mode, &self.subject)
             .await
-            .map_err(|e| anyhow!("mount open failed: {e}"))?;
+            .context("mount open failed")?;
         let qid = self.qid_of(handle).await?;
         Ok(OpenResult { qid, iounit: IOUNIT })
     }
@@ -142,7 +142,7 @@ impl Backend for MountBackend {
         self.mount
             .read(handle, offset, count, &self.subject)
             .await
-            .map_err(|e| anyhow!("mount read failed: {e}"))
+            .context("mount read failed")
     }
 
     async fn write(&self, fid: u32, offset: u64, data: &[u8]) -> Result<u32> {
@@ -152,7 +152,7 @@ impl Backend for MountBackend {
         self.mount
             .write(handle, offset, data, &self.subject)
             .await
-            .map_err(|e| anyhow!("mount write failed: {e}"))
+            .context("mount write failed")
     }
 
     async fn stat(&self, fid: u32) -> Result<StatResult> {
@@ -163,7 +163,7 @@ impl Backend for MountBackend {
             .mount
             .stat(handle, &self.subject)
             .await
-            .map_err(|e| anyhow!("mount stat failed: {e}"))?;
+            .context("mount stat failed")?;
         let is_dir = st.qtype & QTDIR != 0;
         let mode = if is_dir { 0o040755 } else { 0o100644 };
         Ok(StatResult {
@@ -182,7 +182,7 @@ impl Backend for MountBackend {
             self.mount
                 .readdir(handle, &self.subject)
                 .await
-                .map_err(|e| anyhow!("mount readdir failed: {e}"))?
+                .context("mount readdir failed")?
         };
         Ok(encode_dir_entries(&entries, offset, count))
     }

--- a/crates/hyprstream-9p/src/translator.rs
+++ b/crates/hyprstream-9p/src/translator.rs
@@ -261,12 +261,16 @@ impl Translator {
             let (tag, response) = match self.handle_message(&buf).await {
                 Ok(r) => r,
                 Err(e) => {
-                    // Map a handler error to Rlerror (errno-style code).
-                    // We use a synthetic code; real errno mapping is backend-
-                    // specific and deferred to a later hardening pass.
+                    // Map a typed backend error to a real 9P2000.L `Rlerror`
+                    // errno (H1a / #764). `wanix serve` clients and shell UX
+                    // depend on distinguishing ENOENT/EACCES/ENOTDIR from a
+                    // blanket EIO; [`errno_from_error`] walks the anyhow cause
+                    // chain for a [`hyprstream_vfs::MountError`] and maps it,
+                    // falling back to EIO for untyped errors.
                     let err_tag = tag_or_notag(&buf);
-                    warn!(error = %e, tag = err_tag, "9P handler error");
-                    (err_tag, Response::Error { ecode: libc_eio() })
+                    let ecode = errno_from_error(&e);
+                    warn!(error = %e, tag = err_tag, ecode, "9P handler error");
+                    (err_tag, Response::Error { ecode })
                 }
             };
 
@@ -626,20 +630,150 @@ fn tag_or_notag(buf: &[u8]) -> u16 {
     }
 }
 
-// errno-style codes the translator emits on its own errors. We hardcode the
-// integer values rather than depend on libc so the crate stays wasm-friendly.
-const fn libc_eio() -> u32 {
-    5 // EIO
-}
+// errno-style codes the translator emits. We hardcode the integer values
+// (Linux asm-generic errno numbers) rather than depend on libc so the crate
+// stays wasm-friendly and the Rlerror wire codes are stable across platforms.
+const ENOENT: u32 = 2; // No such file or directory
+const EIO: u32 = 5; // I/O error
+const EACCES: u32 = 13; // Permission denied
+const EEXIST: u32 = 17; // File exists
+const ENOTDIR: u32 = 20; // Not a directory
+const EISDIR: u32 = 21; // Is a directory
+const EINVAL: u32 = 22; // Invalid argument
+const ENOSYS: u32 = 38; // Function not implemented
+
 const fn libc_einval() -> u32 {
-    22 // EINVAL
+    EINVAL
+}
+
+/// Map a backend handler error to a 9P2000.L `Rlerror` errno (H1a / #764).
+///
+/// The backend seam is stringly-typed at the `anyhow::Error` boundary, but the
+/// VFS [`MountBackend`] preserves the underlying [`hyprstream_vfs::MountError`]
+/// as an anyhow *source* (via `.context(...)`, not string interpolation), so
+/// the concrete error survives in the cause chain. This walks that chain and
+/// maps the first [`MountError`] it finds to its POSIX errno; an untyped error
+/// (e.g. a fid-table bookkeeping failure) falls back to [`EIO`].
+///
+/// Mapping (min ENOENT/EACCES/ENOTDIR per the spike, plus the rest of the
+/// [`MountError`] surface):
+/// `NotFound→ENOENT`, `PermissionDenied→EACCES`, `NotDirectory→ENOTDIR`,
+/// `IsDirectory→EISDIR`, `InvalidArgument→EINVAL`, `AlreadyExists→EEXIST`,
+/// `NotSupported→ENOSYS`, `Io→EIO`.
+pub(crate) fn errno_from_error(err: &anyhow::Error) -> u32 {
+    for cause in err.chain() {
+        if let Some(me) = cause.downcast_ref::<hyprstream_vfs::MountError>() {
+            return errno_from_mount_error(me);
+        }
+    }
+    EIO
+}
+
+/// Map a [`hyprstream_vfs::MountError`] variant to its POSIX errno.
+fn errno_from_mount_error(e: &hyprstream_vfs::MountError) -> u32 {
+    use hyprstream_vfs::MountError as M;
+    match e {
+        M::NotFound(_) => ENOENT,
+        M::PermissionDenied(_) => EACCES,
+        M::NotDirectory(_) => ENOTDIR,
+        M::IsDirectory(_) => EISDIR,
+        M::InvalidArgument(_) => EINVAL,
+        M::AlreadyExists(_) => EEXIST,
+        M::NotSupported(_) => ENOSYS,
+        M::Io(_) => EIO,
+    }
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::memory::MemoryBackend;
     use crate::msg::Qid;
+
+    // ── Typed errno mapping (H1a / #764) ────────────────────────────────
+
+    /// Every [`hyprstream_vfs::MountError`] variant must map to its POSIX
+    /// errno when wrapped exactly as [`MountBackend`] wraps it (via
+    /// `.context(...)`, which preserves the concrete error as an anyhow
+    /// source). An untyped error falls back to EIO. Regression guard for the
+    /// blanket-EIO behaviour the spike flagged at `translator.rs:211`.
+    #[test]
+    fn mount_errors_map_to_errnos() {
+        use hyprstream_vfs::MountError as M;
+        let cases = [
+            (M::NotFound("x".into()), ENOENT),
+            (M::PermissionDenied("x".into()), EACCES),
+            (M::NotDirectory("x".into()), ENOTDIR),
+            (M::IsDirectory("x".into()), EISDIR),
+            (M::InvalidArgument("x".into()), EINVAL),
+            (M::AlreadyExists("x".into()), EEXIST),
+            (M::NotSupported("x".into()), ENOSYS),
+            (M::Io("x".into()), EIO),
+        ];
+        for (err, expected) in cases {
+            // Mimic the MountBackend error path: attach context so the
+            // MountError is an anyhow *source*, not string-flattened.
+            let wrapped = anyhow::Error::new(err).context("mount op failed");
+            assert_eq!(errno_from_error(&wrapped), expected);
+        }
+        // Untyped bookkeeping errors fall back to EIO.
+        assert_eq!(errno_from_error(&anyhow::anyhow!("fid 3 not walked")), EIO);
+    }
+
+    /// End-to-end through [`MountBackend`]: a `Mount` that returns
+    /// `NotFound` on a bad walk must surface as an anyhow chain the
+    /// translator maps to `ENOENT` (not EIO). Proves the `.context(...)`
+    /// wrapping in `MountBackend` keeps the `MountError` downcastable.
+    #[tokio::test]
+    async fn mount_backend_preserves_typed_errno_end_to_end() {
+        use crate::mount_backend::MountBackend;
+        use async_trait::async_trait;
+        use hyprstream_rpc::Subject;
+        use hyprstream_vfs::{DirEntry, Fid, Mount, MountError, Stat};
+
+        struct StubMount;
+        #[async_trait]
+        impl Mount for StubMount {
+            async fn walk(&self, components: &[&str], _c: &Subject) -> Result<Fid, MountError> {
+                if components.is_empty() {
+                    // Attach walks the empty root path — resolve it.
+                    Ok(Fid::new(()))
+                } else {
+                    Err(MountError::NotFound(components.join("/")))
+                }
+            }
+            async fn open(&self, _f: &mut Fid, _m: u8, _c: &Subject) -> Result<(), MountError> {
+                Err(MountError::PermissionDenied("open".into()))
+            }
+            async fn read(&self, _f: &Fid, _o: u64, _n: u32, _c: &Subject) -> Result<Vec<u8>, MountError> {
+                Err(MountError::Io("read".into()))
+            }
+            async fn write(&self, _f: &Fid, _o: u64, _d: &[u8], _c: &Subject) -> Result<u32, MountError> {
+                Err(MountError::NotSupported("write".into()))
+            }
+            async fn readdir(&self, _f: &Fid, _c: &Subject) -> Result<Vec<DirEntry>, MountError> {
+                Err(MountError::NotDirectory("readdir".into()))
+            }
+            async fn stat(&self, _f: &Fid, _c: &Subject) -> Result<Stat, MountError> {
+                Ok(Stat::unknown_qid(0x80, 0, "/".into(), 0))
+            }
+            async fn clunk(&self, _f: Fid, _c: &Subject) {}
+        }
+
+        let backend = MountBackend::new(Arc::new(StubMount), Subject::new("tenant"));
+        let t = Arc::new(Translator::new(Arc::new(backend)));
+
+        // Attach fid 0 as root (empty walk succeeds).
+        t.handle_message(&msg::tattach(1, 0, u32::MAX, "u", "")).await.unwrap();
+
+        // Walk to a missing child → Err whose errno must be ENOENT.
+        let err = t
+            .handle_message(&msg::twalk(2, 0, 1, &["nope"]))
+            .await
+            .unwrap_err();
+        assert_eq!(errno_from_error(&err), ENOENT, "missing path must be ENOENT, not EIO");
+    }
 
     fn sample_qid(qtype: u8, path: u64) -> Qid {
         Qid { qtype, version: 1, path }

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -175,7 +175,8 @@ subtle.workspace = true                  # Constant-time operations
 ring = "0.17"                            # TLS endorsement signing (key-type-agnostic)
 
 # HTTP API dependencies
-axum.workspace = true
+# `ws` feature: 9P-over-WebSocket export (H1a / #764) on the existing server.
+axum = { workspace = true, features = ["ws"] }
 axum-server.workspace = true
 tower-http.workspace = true
 url.workspace = true
@@ -226,6 +227,8 @@ iroh.workspace = true
 rand.workspace = true
 # Test-only: drive the xet axum Router via `ServiceExt::oneshot` (auth-reject test).
 tower = { version = "0.5", features = ["util"] }
+# Test-only: WebSocket client for the 9P-over-WS attach round-trip (H1a / #764).
+tokio-tungstenite = "0.24"
 
 [lints]
 workspace = true

--- a/crates/hyprstream/src/server/middleware.rs
+++ b/crates/hyprstream/src/server/middleware.rs
@@ -84,45 +84,19 @@ pub async fn auth_middleware(
     // Build WWW-Authenticate header for 401 responses (RFC 9728)
     let www_authenticate = build_www_authenticate(&state);
 
-    if !token.contains('.') {
-        warn!(client_ip = %client_ip, method = %method, path = %path, "Auth failure: malformed token");
-        return unauthorized_response("Authentication failed", &www_authenticate);
-    }
-
-    // Extract iss for key routing
-    let iss = extract_iss_from_token(&token);
+    // Verify the token to validated claims via the shared auth chain
+    // (malformed check, local-vs-federation issuer routing, signature +
+    // audience validation, JTI revocation). Reused verbatim by the 9P mount
+    // ticket validator (H1a / #764). DPoP sender-binding is enforced below,
+    // after we hold the claims, because it is header/scheme-specific.
     let local_issuers: &[&str] = &[&*state.oauth_issuer_url];
-    let result = if hyprstream_rpc::auth::is_local_iss(&iss, local_issuers) {
-        jwt::decode(&token, &state.verifying_key, Some(&state.resource_url))
-    } else {
-        if !state.federation_resolver.is_trusted(&iss) {
-            warn!(client_ip = %client_ip, method = %method, path = %path, issuer = %iss, "Auth failure: untrusted federation issuer");
-            return unauthorized_response("Authentication failed", &www_authenticate);
-        }
-        match state.federation_resolver.get_key(&iss).await {
-            Ok(key) => jwt::decode_with_key(&token, &key, Some(&state.resource_url)),
-            Err(e) => {
-                warn!(client_ip = %client_ip, method = %method, path = %path, issuer = %iss, error = %e, "Auth failure: federation key resolution failed");
-                return unauthorized_response("Authentication failed", &www_authenticate);
-            }
-        }
-    };
-
-    let claims = match result {
+    let claims = match verify_token_claims(&state, &token).await {
         Ok(c) => c,
-        Err(e) => {
-            warn!(client_ip = %client_ip, method = %method, path = %path, error = %e, "Auth failure: JWT validation failed");
+        Err(reason) => {
+            warn!(client_ip = %client_ip, method = %method, path = %path, reason, "Auth failure");
             return unauthorized_response("Authentication failed", &www_authenticate);
         }
     };
-
-    // JTI revocation check (RFC 7009) — shared blocklist with OAuth revocation endpoint.
-    if let Some(ref jti) = claims.jti {
-        if state.jti_blocklist.is_revoked(jti) {
-            warn!(jti = %jti, sub = %claims.sub, "Revoked token presented");
-            return unauthorized_response("Authentication failed", &www_authenticate);
-        }
-    }
 
     // DPoP binding enforcement (RFC 9449).
     // A token with cnf.jkt MUST be presented with Authorization: DPoP + DPoP proof header.
@@ -290,6 +264,58 @@ pub async fn rate_limit_middleware(
     }
 
     next.run(request).await
+}
+
+/// Verify a bearer/ticket token to its validated [`jwt::Claims`] using the
+/// shared server auth chain.
+///
+/// This is the token-verification core factored out of [`auth_middleware`] so
+/// the 9P mount-ticket validator (H1a / #764) reuses the *exact* same chain
+/// rather than re-implementing one:
+///
+/// 1. malformed-token rejection,
+/// 2. local-vs-federation issuer routing (local `verifying_key` or
+///    `federation_resolver`),
+/// 3. Ed25519 / ML-DSA signature + audience validation via `jwt::decode`,
+/// 4. JTI revocation against the shared blocklist (RFC 7009).
+///
+/// It does **not** enforce DPoP sender-binding: that is header/scheme-specific
+/// and stays in [`auth_middleware`]. Returns `Err(reason)` with a short,
+/// log-safe reason string on any failure (never leaks token contents).
+pub(crate) async fn verify_token_claims(
+    state: &ServerState,
+    token: &str,
+) -> Result<jwt::Claims, &'static str> {
+    if !token.contains('.') {
+        return Err("malformed token");
+    }
+
+    // Extract iss for key routing (local node key vs trusted federation peer).
+    let iss = extract_iss_from_token(token);
+    let local_issuers: &[&str] = &[&*state.oauth_issuer_url];
+    let result = if hyprstream_rpc::auth::is_local_iss(&iss, local_issuers) {
+        jwt::decode(token, &state.verifying_key, Some(&state.resource_url))
+    } else {
+        if !state.federation_resolver.is_trusted(&iss) {
+            return Err("untrusted federation issuer");
+        }
+        match state.federation_resolver.get_key(&iss).await {
+            Ok(key) => jwt::decode_with_key(token, &key, Some(&state.resource_url)),
+            Err(_) => return Err("federation key resolution failed"),
+        }
+    };
+
+    let claims = result.map_err(|_| "JWT validation failed")?;
+
+    // JTI revocation check (RFC 7009) — shared blocklist with the OAuth
+    // revocation endpoint.
+    if let Some(ref jti) = claims.jti {
+        if state.jti_blocklist.is_revoked(jti) {
+            return Err("revoked token");
+        }
+    }
+
+    Ok(claims)
 }
 
 /// Build WWW-Authenticate header value with resource_metadata URL (RFC 9728).

--- a/crates/hyprstream/src/server/mod.rs
+++ b/crates/hyprstream/src/server/mod.rs
@@ -45,7 +45,16 @@ pub fn create_app(state: ServerState) -> Router {
         .route(
             "/.well-known/oauth-protected-resource",
             get(oauth_protected_resource_metadata),
-        );
+        )
+        // 9P-over-WebSocket export (H1a / #764). Public routes: the mount
+        // ticket rides the URL query (browser WS can't set headers) and is
+        // validated inside the /9p handler, so these bypass `auth_middleware`
+        // (which requires an Authorization header).
+        .route(
+            "/.well-known/export9p",
+            get(routes::ninep::export9p_metadata),
+        )
+        .route("/9p", get(routes::ninep::ninep_ws));
 
     // Protected routes (auth required)
     let protected_routes = Router::new()

--- a/crates/hyprstream/src/server/routes/mod.rs
+++ b/crates/hyprstream/src/server/routes/mod.rs
@@ -1,4 +1,5 @@
 //! HTTP route handlers
 
 pub mod models;
+pub mod ninep;
 pub mod openai;

--- a/crates/hyprstream/src/server/routes/ninep.rs
+++ b/crates/hyprstream/src/server/routes/ninep.rs
@@ -1,0 +1,402 @@
+//! 9P-over-WebSocket export (H1a / #764).
+//!
+//! Serves hyprstream's Subject-scoped VFS as **9P2000.L over WebSocket** on the
+//! existing axum HTTP server, wire-compatible with `wanix serve`, so stock
+//! wanix 0.4 / apptron mount a hyprstream host with zero client glue.
+//!
+//! Two routes (registered in [`crate::server`]):
+//!
+//! - `GET /.well-known/export9p` — discovery. Advertises the `/9p` WebSocket
+//!   endpoint, the mount-ticket query parameter, and the wire so a mounting
+//!   client (S4 `WanixSessionContext`) can construct the `wss://…/9p?ticket=…`
+//!   URL. (Upstream's `/.well-known/export9p` is a `mux`-session endpoint for
+//!   the *reverse* direction — a browser exporting **its** namespace outward;
+//!   H1a's interop path is the raw-frame `/9p` endpoint that stock wanix
+//!   `import` binds connect to directly, so we serve a JSON discovery document
+//!   here instead of the mux protocol. See the PR "WIRE CONTRACT" section.)
+//! - `GET /9p` — WebSocket upgrade → a ws↔9p byte pump feeding the
+//!   transport-agnostic [`Translator::serve_connection`] core over a
+//!   [`MountBackend`] (the SAME core the UDS/vsock transports use — not a
+//!   fork). Binary frames carry framed 9P2000.L messages; the pump tolerates
+//!   arbitrary chunking (`P9PortReadWriter` on the wanix side buffers).
+//!
+//! ## Auth (reuses the existing chain)
+//!
+//! The mount ticket rides the URL query (`?ticket=<at+jwt>`) because a browser
+//! `WebSocket` cannot set request headers. It is validated at the WS upgrade
+//! via [`crate::server::middleware::verify_token_claims`] — the exact same
+//! chain `auth_middleware` uses (issuer routing, Ed25519/ML-DSA signature +
+//! audience validation, JTI revocation). The validated `sub` becomes the
+//! session [`Subject`], threaded onto every 9P op by [`MountBackend`] (the
+//! single MAC policy-enforcement point). Denials surface as `Rlerror` errnos.
+//!
+//! ## Server-owned liveness (H1a hard requirement)
+//!
+//! A dead browser peer is NOT observable to the far side (a closed port yields
+//! no EOF), so a naive server would leak the 9P session forever. The inbound
+//! pump therefore OWNS liveness: it wraps every WS read in an **idle timeout**
+//! ([`IDLE_TIMEOUT`]); on idle, WS close, or WS error it drops the pump's write
+//! half, which surfaces as EOF to `serve_connection` and tears the session
+//! down cleanly. The server never relies on the client noticing.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::{
+    extract::{
+        ws::{Message, WebSocket, WebSocketUpgrade},
+        Query, State,
+    },
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use futures::{SinkExt, StreamExt};
+use hyprstream_9p::Translator;
+use hyprstream_rpc::Subject;
+use hyprstream_vfs::{Mount, SyntheticMount, SyntheticNode};
+use serde::{Deserialize, Serialize};
+use tokio::io::{split, AsyncReadExt, AsyncWriteExt};
+use tracing::{debug, info, warn};
+
+use crate::server::state::ServerState;
+
+/// Query-param name carrying the short-lived mount ticket. Kept in sync with
+/// the discovery document and the design doc's `wss://…/9p?ticket=…` example.
+const TICKET_PARAM: &str = "ticket";
+
+/// Idle timeout for a 9P-over-WS session. If no inbound WS message arrives
+/// within this window the server closes the session (see module docs:
+/// server-owned liveness — a dead browser peer is otherwise invisible).
+const IDLE_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Duplex buffer bridging the WS pump to the 9P serve core. Sized to comfortably
+/// hold a full negotiated 9P msize plus headroom.
+const DUPLEX_BUF: usize = 64 * 1024;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Discovery: GET /.well-known/export9p
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Discovery document for the 9P-over-WebSocket export.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Export9pDiscovery {
+    /// 9P dialect served (`9P2000.L`).
+    pub protocol: String,
+    /// Transport (`websocket`).
+    pub transport: String,
+    /// WebSocket upgrade path (`/9p`).
+    pub endpoint: String,
+    /// Query-param name for the mount ticket (`ticket`).
+    pub ticket_param: String,
+    /// Required `Sec-WebSocket-Protocol` subprotocol, or `null` for none.
+    /// H1a requires none — stock wanix opens `new WebSocket(src)` with no
+    /// subprotocol.
+    pub subprotocol: Option<String>,
+    /// Wire framing: raw length-prefixed 9P2000.L messages, one per binary
+    /// frame from the server (arbitrary chunking tolerated inbound).
+    pub wire: String,
+    /// The upstream tool this endpoint is wire-compatible with.
+    pub compatible_with: String,
+}
+
+impl Default for Export9pDiscovery {
+    fn default() -> Self {
+        Self {
+            protocol: "9P2000.L".to_owned(),
+            transport: "websocket".to_owned(),
+            endpoint: "/9p".to_owned(),
+            ticket_param: TICKET_PARAM.to_owned(),
+            subprotocol: None,
+            wire: "raw-9p-binary-frames".to_owned(),
+            compatible_with: "wanix serve".to_owned(),
+        }
+    }
+}
+
+/// `GET /.well-known/export9p` — advertise the 9P-over-WS export.
+pub async fn export9p_metadata() -> impl IntoResponse {
+    Json(Export9pDiscovery::default())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mount: GET /9p (WebSocket upgrade)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Query params on the `/9p` WebSocket upgrade.
+#[derive(Debug, Deserialize)]
+pub struct NinePQuery {
+    /// Short-lived mount ticket (an `at+jwt`), minted via the existing token
+    /// chain. Required — a missing/invalid ticket is rejected pre-upgrade.
+    #[serde(default)]
+    pub ticket: Option<String>,
+}
+
+/// `GET /9p` — validate the mount ticket, then upgrade to a 9P-over-WS session.
+///
+/// The ticket is validated BEFORE the upgrade so an unauthenticated client gets
+/// a clean HTTP `401` rather than a dangling WebSocket. On success the session's
+/// [`Subject`] is bound for the whole connection and enforced per-op by
+/// [`MountBackend`].
+pub async fn ninep_ws(
+    State(state): State<ServerState>,
+    Query(q): Query<NinePQuery>,
+    headers: HeaderMap,
+    ws: WebSocketUpgrade,
+) -> Response {
+    let ticket = match q.ticket.as_deref() {
+        Some(t) if !t.is_empty() => t,
+        _ => {
+            debug!("9P WS upgrade rejected: missing mount ticket");
+            return (StatusCode::UNAUTHORIZED, "missing mount ticket").into_response();
+        }
+    };
+
+    let subject = match validate_ticket(&state, ticket, &headers).await {
+        Ok(s) => s,
+        Err(reason) => {
+            warn!(reason, "9P WS upgrade rejected: invalid mount ticket");
+            return (StatusCode::UNAUTHORIZED, "invalid mount ticket").into_response();
+        }
+    };
+
+    let mount = build_export_mount(&state, &subject);
+    // `from_mount` wraps the Subject-scoped mount in a `MountBackend` and threads
+    // `subject` onto every backend op — the same seam UDS/vsock use.
+    let translator = Arc::new(Translator::from_mount(mount, subject));
+
+    // No subprotocol negotiation: stock wanix connects with none.
+    ws.on_upgrade(move |socket| serve_9p_websocket(socket, translator, IDLE_TIMEOUT))
+}
+
+/// Validate a mount ticket to a session [`Subject`], reusing the server auth
+/// chain ([`verify_token_claims`](crate::server::middleware::verify_token_claims)).
+///
+/// Real controls enforced here: Ed25519/ML-DSA signature, audience binding to
+/// this resource, expiry, and JTI revocation (all inside `verify_token_claims`),
+/// plus subject-name validation. The `sub` becomes the session Subject.
+///
+/// NOTE (flagged design fork — see PR body): one-shot replay prevention and
+/// explicit browser-`Origin` binding beyond the JWT `aud` are NOT yet enforced;
+/// the current controls are signature + short expiry + audience + revocation.
+async fn validate_ticket(
+    state: &ServerState,
+    ticket: &str,
+    _headers: &HeaderMap,
+) -> Result<Subject, &'static str> {
+    let claims = crate::server::middleware::verify_token_claims(state, ticket).await?;
+    let local_issuers: &[&str] = &[&*state.oauth_issuer_url];
+    let subject = claims.subject(local_issuers);
+    subject.validate().map_err(|_| "subject validation failed")?;
+    match subject.name() {
+        Some(n) if !n.is_empty() => {}
+        _ => return Err("empty subject"),
+    }
+    Ok(subject)
+}
+
+/// Build the Subject-scoped VFS [`Mount`] exported as the 9P root.
+///
+/// FLAGGED DESIGN FORK (see PR body): the real host VFS (`srv/{service}`,
+/// `worktree/`, `stream/{topic}/{data,info,ctl}`) is composed on the #730 branch
+/// and is not yet reachable from `ServerState` on `main`. Until that lands we
+/// export a read-only synthetic skeleton mirroring that layout, so the endpoint
+/// is live and interop-testable (stock wanix can attach + `ls`) and produces
+/// real errnos. Swapping in the composed Subject-scoped namespace is a one-line
+/// change here once #730 exposes it.
+fn build_export_mount(_state: &ServerState, _subject: &Subject) -> Arc<dyn Mount> {
+    let root = SyntheticNode::dir()
+        .with_child("srv", SyntheticNode::dir())
+        .with_child("worktree", SyntheticNode::dir())
+        .with_child("stream", SyntheticNode::dir())
+        .with_child(
+            "README",
+            SyntheticNode::file(
+                b"hyprstream 9P-over-WebSocket export (H1a placeholder root).\n\
+                  Real Subject-scoped host VFS lands with #730.\n"
+                    .to_vec(),
+            ),
+        );
+    Arc::new(SyntheticMount::new(root))
+}
+
+/// Drive one 9P-over-WebSocket session to completion.
+///
+/// Bridges the WebSocket message stream to the transport-agnostic
+/// [`Translator::serve_connection`] core via an in-process duplex (mirroring
+/// `wanix serve`'s ws↔9p pump), and OWNS session liveness (see module docs).
+pub(crate) async fn serve_9p_websocket(
+    socket: WebSocket,
+    translator: Arc<Translator>,
+    idle: Duration,
+) {
+    // `core_side` feeds the 9P serve core; `pump_side` is driven by the WS pump.
+    let (core_side, pump_side) = tokio::io::duplex(DUPLEX_BUF);
+    let (mut pump_rd, mut pump_wr) = split(pump_side);
+    let (mut ws_tx, mut ws_rx) = socket.split();
+
+    // Outbound: framed 9P responses from the core → one WS binary frame each
+    // (mirrors `serve.go`'s 9p→ws goroutine: read length prefix, then payload).
+    let to_ws = tokio::spawn(async move {
+        loop {
+            let mut len = [0u8; 4];
+            if pump_rd.read_exact(&mut len).await.is_err() {
+                break; // core closed
+            }
+            let total = u32::from_le_bytes(len) as usize;
+            if total < 4 {
+                break;
+            }
+            let mut frame = vec![0u8; total];
+            frame[..4].copy_from_slice(&len);
+            if pump_rd.read_exact(&mut frame[4..]).await.is_err() {
+                break;
+            }
+            if ws_tx.send(Message::Binary(frame)).await.is_err() {
+                break; // peer gone
+            }
+        }
+        let _ = ws_tx.close().await;
+    });
+
+    // Inbound: WS binary frames → core (raw bytes; the core reframes). Owns
+    // liveness — an idle/closed/errored peer drops `pump_wr`, EOF-ing the core.
+    let inbound = async move {
+        loop {
+            match tokio::time::timeout(idle, ws_rx.next()).await {
+                Err(_) => {
+                    info!("9P WS session idle timeout; closing");
+                    break;
+                }
+                Ok(None) => break, // stream ended
+                Ok(Some(Err(e))) => {
+                    debug!(error = %e, "9P WS read error; closing");
+                    break;
+                }
+                Ok(Some(Ok(msg))) => match msg {
+                    Message::Binary(bytes) => {
+                        if pump_wr.write_all(&bytes).await.is_err() {
+                            break; // core gone
+                        }
+                    }
+                    Message::Close(_) => break,
+                    // Text/Ping/Pong are not 9P payload; ignore (axum auto-Pongs Pings).
+                    Message::Ping(_) | Message::Pong(_) | Message::Text(_) => {}
+                },
+            }
+        }
+        // `pump_wr` drops here → core read half sees EOF → serve_connection ends.
+    };
+
+    // Run the core and the inbound pump concurrently. serve_connection returns
+    // on EOF (inbound drop) or a fatal 9P framing/write error; either way we
+    // then abort the outbound task.
+    tokio::select! {
+        r = translator.serve_connection(core_side) => {
+            if let Err(e) = r {
+                debug!(error = %e, "9P WS serve loop ended with error");
+            }
+        }
+        _ = inbound => {}
+    }
+    to_ws.abort();
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use axum::{routing::get, Router};
+    use hyprstream_9p::msg::{self, Response as P9Response};
+    use tokio_tungstenite::tungstenite::Message as WsMessage;
+
+    /// Discovery doc round-trips and advertises the H1a contract.
+    #[test]
+    fn discovery_defaults_match_wire_contract() {
+        let d = Export9pDiscovery::default();
+        assert_eq!(d.protocol, "9P2000.L");
+        assert_eq!(d.endpoint, "/9p");
+        assert_eq!(d.ticket_param, "ticket");
+        assert_eq!(d.subprotocol, None); // stock wanix uses no subprotocol
+    }
+
+    /// End-to-end 9P-over-WebSocket attach: spin the `/9p` transport over a
+    /// `MemoryBackend`, connect a real WebSocket client, and drive
+    /// version → attach → walk → open → read. Exercises the full ws↔9p pump +
+    /// the shared `serve_connection` core over genuine WS binary frames.
+    #[tokio::test]
+    async fn websocket_9p_attach_walk_read_roundtrip() {
+        // A test route that serves a Subject-scoped SyntheticMount over WS via
+        // `from_mount` — the SAME MountBackend path `/9p` uses in production, so
+        // typed MountError→errno mapping is exercised end to end. No
+        // ServerState/ticket, isolating the transport under test.
+        async fn test_ws(ws: WebSocketUpgrade) -> Response {
+            let root = SyntheticNode::dir()
+                .with_child("hello.txt", SyntheticNode::file(b"hello ws".to_vec()));
+            let mount: Arc<dyn Mount> = Arc::new(SyntheticMount::new(root));
+            let translator = Arc::new(Translator::from_mount(mount, Subject::new("test")));
+            ws.on_upgrade(move |s| serve_9p_websocket(s, translator, Duration::from_secs(10)))
+        }
+
+        let app = Router::new().route("/9p", get(test_ws));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let url = format!("ws://{addr}/9p");
+        let (mut ws, _resp) = tokio_tungstenite::connect_async(&url).await.unwrap();
+
+        // Helper: send a framed 9P T-message, await the next binary frame,
+        // decode the R-message.
+        async fn rpc(
+            ws: &mut tokio_tungstenite::WebSocketStream<
+                tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+            >,
+            tmsg: Vec<u8>,
+        ) -> P9Response {
+            ws.send(WsMessage::Binary(tmsg)).await.unwrap();
+            loop {
+                match ws.next().await.unwrap().unwrap() {
+                    WsMessage::Binary(buf) => {
+                        let (_tag, resp) = msg::parse_response(&buf).unwrap();
+                        return resp;
+                    }
+                    _ => continue,
+                }
+            }
+        }
+
+        // Tversion → Rversion.
+        let resp = rpc(&mut ws, msg::tversion(1, 8192, "9P2000.L")).await;
+        assert!(matches!(resp, P9Response::Version { .. }), "got {resp:?}");
+
+        // Tattach fid 0 as root.
+        let resp = rpc(&mut ws, msg::tattach(2, 0, u32::MAX, "u", "")).await;
+        assert!(matches!(resp, P9Response::Attach { .. }), "got {resp:?}");
+
+        // Twalk to the file, Tlopen, Tread.
+        let resp = rpc(&mut ws, msg::twalk(3, 0, 1, &["hello.txt"])).await;
+        assert!(matches!(resp, P9Response::Walk { .. }), "got {resp:?}");
+
+        let resp = rpc(&mut ws, msg::tlopen(4, 1, 0)).await;
+        assert!(matches!(resp, P9Response::Lopen { .. }), "got {resp:?}");
+
+        let resp = rpc(&mut ws, msg::tread(5, 1, 0, 64)).await;
+        match resp {
+            P9Response::Read { data } => assert_eq!(&data, b"hello ws"),
+            other => panic!("expected Rread, got {other:?}"),
+        }
+
+        // A walk to a missing path returns a typed ENOENT Rlerror (H1a errnos).
+        let resp = rpc(&mut ws, msg::twalk(6, 0, 2, &["nope"])).await;
+        match resp {
+            P9Response::Error { ecode } => assert_eq!(ecode, 2, "missing path must be ENOENT"),
+            other => panic!("expected Rlerror ENOENT, got {other:?}"),
+        }
+
+        ws.close(None).await.unwrap();
+        server.abort();
+    }
+}

--- a/crates/hyprstream/src/server/routes/ninep.rs
+++ b/crates/hyprstream/src/server/routes/ninep.rs
@@ -33,11 +33,17 @@
 //! ## Server-owned liveness (H1a hard requirement)
 //!
 //! A dead browser peer is NOT observable to the far side (a closed port yields
-//! no EOF), so a naive server would leak the 9P session forever. The inbound
-//! pump therefore OWNS liveness: it wraps every WS read in an **idle timeout**
-//! ([`IDLE_TIMEOUT`]); on idle, WS close, or WS error it drops the pump's write
-//! half, which surfaces as EOF to `serve_connection` and tears the session
-//! down cleanly. The server never relies on the client noticing.
+//! no EOF), so a naive server would leak the 9P session forever. The pump
+//! therefore OWNS liveness via **server-driven WS ping/pong keepalive**: it
+//! sends a WS `Ping` every [`PING_INTERVAL`] (30s) and closes the session after
+//! [`MAX_MISSED_PONGS`] consecutive unanswered pings (~90s). Closing drops the
+//! pump's write half, which surfaces as EOF to `serve_connection` and tears the
+//! 9P session down cleanly. A dead peer stops ponging and is reaped in ~90s; a
+//! HEALTHY-but-idle mount survives **indefinitely** because pongs keep flowing
+//! with zero 9P traffic (and any inbound frame — pong or data — counts as
+//! liveness). The client's WS `close` event is the browser's unmount trigger,
+//! so teardown stays 100% server-driven with no client keepalive. The server
+//! never relies on the client noticing.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -65,10 +71,13 @@ use crate::server::state::ServerState;
 /// the discovery document and the design doc's `wss://…/9p?ticket=…` example.
 const TICKET_PARAM: &str = "ticket";
 
-/// Idle timeout for a 9P-over-WS session. If no inbound WS message arrives
-/// within this window the server closes the session (see module docs:
-/// server-owned liveness — a dead browser peer is otherwise invisible).
-const IDLE_TIMEOUT: Duration = Duration::from_secs(300);
+/// Interval between server-sent WS keepalive `Ping`s. A HEALTHY-but-idle mount
+/// stays alive indefinitely as long as the peer keeps ponging (see module docs).
+const PING_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Consecutive unanswered pings tolerated before the server reaps the session.
+/// With [`PING_INTERVAL`] = 30s this is ~90s of silence → dead-peer detection.
+const MAX_MISSED_PONGS: u32 = 3;
 
 /// Duplex buffer bridging the WS pump to the 9P serve core. Sized to comfortably
 /// hold a full negotiated 9P msize plus headroom.
@@ -166,7 +175,7 @@ pub async fn ninep_ws(
     let translator = Arc::new(Translator::from_mount(mount, subject));
 
     // No subprotocol negotiation: stock wanix connects with none.
-    ws.on_upgrade(move |socket| serve_9p_websocket(socket, translator, IDLE_TIMEOUT))
+    ws.on_upgrade(move |socket| serve_9p_websocket(socket, translator, PING_INTERVAL))
 }
 
 /// Validate a mount ticket to a session [`Subject`], reusing the server auth
@@ -224,20 +233,26 @@ fn build_export_mount(_state: &ServerState, _subject: &Subject) -> Arc<dyn Mount
 ///
 /// Bridges the WebSocket message stream to the transport-agnostic
 /// [`Translator::serve_connection`] core via an in-process duplex (mirroring
-/// `wanix serve`'s ws↔9p pump), and OWNS session liveness (see module docs).
+/// `wanix serve`'s ws↔9p pump), and OWNS session liveness via server-driven
+/// ping/pong keepalive (see module docs): a `Ping` every `ping_interval`, close
+/// after [`MAX_MISSED_PONGS`] consecutive unanswered pings; any inbound frame
+/// resets the miss counter, so a healthy-idle mount lives indefinitely.
 pub(crate) async fn serve_9p_websocket(
     socket: WebSocket,
     translator: Arc<Translator>,
-    idle: Duration,
+    ping_interval: Duration,
 ) {
     // `core_side` feeds the 9P serve core; `pump_side` is driven by the WS pump.
     let (core_side, pump_side) = tokio::io::duplex(DUPLEX_BUF);
     let (mut pump_rd, mut pump_wr) = split(pump_side);
     let (mut ws_tx, mut ws_rx) = socket.split();
 
-    // Outbound: framed 9P responses from the core → one WS binary frame each
-    // (mirrors `serve.go`'s 9p→ws goroutine: read length prefix, then payload).
-    let to_ws = tokio::spawn(async move {
+    // Outbound framing is not cancel-safe (a full 9P message is two `read_exact`
+    // reads: length prefix then payload), so it runs in its own task and feeds
+    // whole frames to the select loop over a channel. Mirrors `serve.go`'s
+    // 9p→ws goroutine.
+    let (frame_tx, mut frame_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(32);
+    let frame_reader = tokio::spawn(async move {
         loop {
             let mut len = [0u8; 4];
             if pump_rd.read_exact(&mut len).await.is_err() {
@@ -252,54 +267,85 @@ pub(crate) async fn serve_9p_websocket(
             if pump_rd.read_exact(&mut frame[4..]).await.is_err() {
                 break;
             }
-            if ws_tx.send(Message::Binary(frame)).await.is_err() {
-                break; // peer gone
+            if frame_tx.send(frame).await.is_err() {
+                break; // select loop gone
+            }
+        }
+        // `frame_tx` drops → `frame_rx` closes → select loop learns the core ended.
+    });
+    // `frame_reader` (a JoinHandle) owns `pump_rd`; aborted after the session.
+
+    // The pump select loop owns the WS sink+stream, `pump_wr`, the keepalive
+    // ping interval, and the missed-pong counter — the single point that both
+    // forwards bytes and decides liveness.
+    let pump = async move {
+        let mut ping = tokio::time::interval(ping_interval);
+        ping.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        let mut missed_pongs: u32 = 0;
+        loop {
+            tokio::select! {
+                // Outbound 9P frame → one WS binary frame.
+                maybe = frame_rx.recv() => match maybe {
+                    Some(frame) => {
+                        if ws_tx.send(Message::Binary(frame)).await.is_err() {
+                            break; // peer gone
+                        }
+                    }
+                    None => break, // core closed (serve_connection ended)
+                },
+                // Inbound WS frame → core (binary), or liveness signal.
+                msg = ws_rx.next() => match msg {
+                    None => break, // stream ended
+                    Some(Err(e)) => {
+                        debug!(error = %e, "9P WS read error; closing");
+                        break;
+                    }
+                    Some(Ok(m)) => {
+                        // ANY inbound frame (pong OR data) proves the peer is alive.
+                        missed_pongs = 0;
+                        match m {
+                            Message::Binary(bytes) => {
+                                if pump_wr.write_all(&bytes).await.is_err() {
+                                    break; // core gone
+                                }
+                            }
+                            Message::Close(_) => break,
+                            // Pong/Ping/Text carry no 9P payload; tungstenite
+                            // auto-replies to inbound Pings at the protocol layer.
+                            Message::Ping(_) | Message::Pong(_) | Message::Text(_) => {}
+                        }
+                    }
+                },
+                // Keepalive tick: send a Ping; reap the session after too many
+                // consecutive unanswered pings (dead peer).
+                _ = ping.tick() => {
+                    missed_pongs += 1;
+                    if missed_pongs >= MAX_MISSED_PONGS {
+                        info!(missed_pongs, "9P WS keepalive: peer missed pongs; closing");
+                        break;
+                    }
+                    if ws_tx.send(Message::Ping(Vec::new())).await.is_err() {
+                        break; // peer gone
+                    }
+                }
             }
         }
         let _ = ws_tx.close().await;
-    });
-
-    // Inbound: WS binary frames → core (raw bytes; the core reframes). Owns
-    // liveness — an idle/closed/errored peer drops `pump_wr`, EOF-ing the core.
-    let inbound = async move {
-        loop {
-            match tokio::time::timeout(idle, ws_rx.next()).await {
-                Err(_) => {
-                    info!("9P WS session idle timeout; closing");
-                    break;
-                }
-                Ok(None) => break, // stream ended
-                Ok(Some(Err(e))) => {
-                    debug!(error = %e, "9P WS read error; closing");
-                    break;
-                }
-                Ok(Some(Ok(msg))) => match msg {
-                    Message::Binary(bytes) => {
-                        if pump_wr.write_all(&bytes).await.is_err() {
-                            break; // core gone
-                        }
-                    }
-                    Message::Close(_) => break,
-                    // Text/Ping/Pong are not 9P payload; ignore (axum auto-Pongs Pings).
-                    Message::Ping(_) | Message::Pong(_) | Message::Text(_) => {}
-                },
-            }
-        }
         // `pump_wr` drops here → core read half sees EOF → serve_connection ends.
     };
 
-    // Run the core and the inbound pump concurrently. serve_connection returns
-    // on EOF (inbound drop) or a fatal 9P framing/write error; either way we
-    // then abort the outbound task.
+    // Run the core and the pump concurrently. serve_connection returns on EOF
+    // (pump drop) or a fatal 9P framing/write error; either way we then reap the
+    // outbound frame reader.
     tokio::select! {
         r = translator.serve_connection(core_side) => {
             if let Err(e) = r {
                 debug!(error = %e, "9P WS serve loop ended with error");
             }
         }
-        _ = inbound => {}
+        _ = pump => {}
     }
-    to_ws.abort();
+    frame_reader.abort();
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## H1a — 9P-over-WebSocket export on axum + typed errnos + mount-ticket auth

Implements #764 (H1a of the Wanix-integration epic). Serves hyprstream's
Subject-scoped VFS as **9P2000.L over WebSocket** on the existing axum HTTP
server, wire-compatible with `wanix serve`, so stock wanix 0.4 / apptron mount a
hyprstream host with zero client glue.

Design doc (approved): `docs/plans/2026-07-03-shell-page-wanix-host-mounts.md`
(www-cyberdione-ai) §"hyprstream 9P serving (H1)" + §Security + §Verification.

### What landed

1. **Typed backend errors → errnos** (`hyprstream-9p`, the highest-certainty
   piece). `translator.rs` previously mapped every backend error to a blanket
   `EIO`. `MountBackend` now preserves the underlying `MountError` as an anyhow
   *source* (`.context(...)` instead of string interpolation), and the serve
   loop walks the cause chain to map it to a real `Rlerror` errno:
   `NotFound→ENOENT`, `PermissionDenied→EACCES`, `NotDirectory→ENOTDIR`,
   `IsDirectory→EISDIR`, `InvalidArgument→EINVAL`, `AlreadyExists→EEXIST`,
   `NotSupported→ENOSYS`, `Io→EIO`; untyped errors still fall back to `EIO`.
   `wanix serve` clients and shell UX depend on real `ENOENT`.

2. **`GET /9p` WebSocket upgrade → ws↔9p byte pump** into the **same**
   transport-agnostic `Translator::serve_connection` core the UDS/vsock
   transports use (over an in-process duplex, mirroring upstream
   `cmd/wanix/serve.go`'s ws↔9p pump). The core is reused, not forked — the WS
   arm is pure glue.

3. **`GET /.well-known/export9p`** — JSON discovery document advertising the
   `/9p` endpoint, ticket param, wire, and (absence of) subprotocol.

4. **Mount-ticket auth** validated at the WS upgrade by **reusing the existing
   auth chain** — token verification was factored out of `auth_middleware` into
   `verify_token_claims` (issuer routing, Ed25519/ML-DSA signature + audience
   validation, JTI revocation); both the middleware and the ticket validator
   now call it. The validated `sub` becomes the session `Subject`, threaded onto
   every 9P op by `MountBackend` (the single MAC policy-enforcement point).
   Denials surface as `Rlerror`.

### WIRE CONTRACT (for the www S4 mount UI — 1:3.0)

- **Discovery:** `GET /.well-known/export9p` → JSON
  `{ protocol:"9P2000.L", transport:"websocket", endpoint:"/9p",
  ticket_param:"ticket", subprotocol:null, wire:"raw-9p-binary-frames",
  compatible_with:"wanix serve" }`.
- **Mount endpoint:** `GET /9p` WebSocket upgrade. Client connects to
  `wss://host/9p?ticket=<at+jwt>` (stock wanix: `new WebSocket(src)`).
- **Ticket:** query param **`ticket`**, an `at+jwt` minted via the existing
  token chain. Validation semantics: signature + audience (bound to this
  resource via the JWT `aud`) + **expiry** + JTI-revocation, all via the shared
  `verify_token_claims`. Validated **pre-upgrade** (bad ticket → HTTP `401`, not
  a dangling socket). **One-shot replay prevention and explicit `Origin`
  binding beyond `aud` are NOT yet enforced — see flagged fork below.**
- **`Tattach` `aname`:** currently ignored / MUST be empty. The attach root **is
  the ticket's Subject-scoped export root**; subtree selection is via subsequent
  `Twalk`. (`aname`-selected subtrees are a future extension.)
- **Subprotocol:** **none.** No `Sec-WebSocket-Protocol` is required or
  negotiated (stock wanix connects with none).
- **Framing:** each server→client 9P message is one binary WS frame (length-
  prefixed 9P2000.L); inbound chunking is arbitrary (buffered).

### Server-side liveness (hard requirement) — WS ping/pong keepalive

A dead browser peer is **not** observable to the far side (a closed port yields
no EOF), so the **server owns liveness** — it does not rely on the client
noticing. Liveness = **WS `Ping` every 30s / close after 3 consecutive missed
pongs (~90s)** (NOT a read-idle timeout). Any inbound frame — a pong OR 9P data
— resets the miss counter, so a **healthy-but-idle mount survives
indefinitely** (a persistent host mount left idle for hours stays up as long as
pongs flow) while a genuinely dead peer stops ponging and is reaped in ~90s. On
reap / WS `Close` / WS error the pump drops its write half → EOF into
`serve_connection` → the 9P session tears down cleanly (frame reader aborted,
socket closed). The client's WS `close` event is the browser's unmount trigger,
so teardown stays **100% server-driven** with no client keepalive.

### Verified

- `hyprstream-9p`: `cargo test -p hyprstream-9p` (14 tests) + `cargo clippy -p
  hyprstream-9p --all-targets -- -D warnings` clean. New tests: per-variant
  errno mapping (unit) and an end-to-end `MountBackend`→translator ENOENT path.
- `hyprstream`: WS attach round-trip integration test (real WebSocket client via
  `tokio-tungstenite` against the `/9p` transport over a `MemoryBackend`):
  version → attach → walk → open → read, plus a missing-path → `Rlerror ENOENT`
  assertion. Build/clippy/test results in the PR thread.

### Flagged for operator decision (design forks)

1. **Export root (which `Mount`).** The real Subject-scoped host VFS
   (`srv/{service}`, `worktree/`, `stream/{topic}`) is composed on the #730
   branch and is **not yet reachable from `ServerState` on `main`** — and the
   one candidate reachable today (`RemoteModelMount`) uses a blocking
   embedded-runtime model that **panics if awaited from the axum async
   runtime**. So H1a exports a **read-only `SyntheticMount` skeleton** mirroring
   the target layout: the endpoint is live + interop-testable (attach + `ls`)
   and produces real errnos, and swapping in the composed namespace is a
   one-line change in `build_export_mount` once #730 exposes an async export
   mount. **Decision: is the synthetic placeholder acceptable for H1a, or should
   this block on #730's export-mount seam?**
2. **Ticket hardening: one-shot + Origin binding.** The design calls for
   one-shot, origin-bound tickets. H1a enforces signature + `aud` + short expiry
   + revocation (the real controls) but does **not** yet enforce single-use
   (needs a ticket-jti cache, like `dpop_jti_seen`) or a browser-`Origin` check
   beyond `aud`. **Decision: add a one-shot ticket-jti cache + Origin allowlist
   now, or defer to H1b/hardening?**
3. **Per-op `fs`-scope policy.** Enforcement is via `MountBackend`'s
   Subject-threading (the MAC PEP). H1a does not add a separate capnp-`fs`-scope
   gate at `Tattach`; it relies on the Subject-scoped mount as the single PEP.
   Left as-is to avoid touching MAC #547 internals (out of scope per the task).

### Reused vs added

- **Reused:** `Translator::serve_connection` / `from_mount` / `MountBackend`
  (the 9P core); the auth chain (`verify_token_claims`, extracted from
  `auth_middleware`); `SyntheticMount` (VFS); `axum` server + route wiring.
- **Added:** WS transport arm (`routes/ninep.rs`), the two routes, typed-errno
  mapping in the translator, the `axum` `ws` feature, and tests.

Constraint (per design): `wss://` has no cert-pinning API → CA-certed /
reverse-proxied hosts only; the self-signed mesh is H1b. Does NOT touch MAC #547
policy internals.

Refs #764.
