### PR TITLE
feat(ts_codegen): support List(List(T)) nested-list fields (#758)

### DIFF
--- a/crates/hyprstream-rpc-build/src/ts_codegen/builders.rs
+++ b/crates/hyprstream-rpc-build/src/ts_codegen/builders.rs
@@ -670,14 +670,25 @@ fn emit_field_setter(
                         "{indent}{builder_var}.{method}({}, {value_expr});\n",
                         field.slot_offset
                     ));
-                } else if inner.starts_with("List(") {
-                    panic!(
-                        "ts_codegen: field `{}: {}` is a nested list (List(List(_))) — \
-                         the capnp.ts runtime does not yet support double indirection. \
-                         This must be implemented in message.rs before this field can be \
-                         referenced; a silently-dropped comment is not acceptable (#725).",
-                        field.name, field.type_name
-                    );
+                } else if let Some(nested_inner) = super::extract_list_inner_type(inner) {
+                    // List(List(<nested_inner>)) — a doubly-nested primitive list
+                    // (e.g. `embeddings: List(List(Float32))`). The runtime has a
+                    // direct setter that takes the whole nested array.
+                    if let Some(method) = super::nested_list_setter_method(nested_inner) {
+                        out.push_str(&format!(
+                            "{indent}{builder_var}.{method}({}, {value_expr});\n",
+                            field.slot_offset
+                        ));
+                    } else {
+                        panic!(
+                            "ts_codegen: field `{}: {}` is a nested list of `{nested_inner}` \
+                             — the capnp.ts runtime does not yet support this inner element \
+                             type for List(List(_)). This must be implemented in message.rs \
+                             before this field can be referenced; a silently-dropped comment \
+                             is not acceptable (#758).",
+                            field.name, field.type_name
+                        );
+                    }
                 }
                 // List(Struct) — init struct list and set each element's fields.
                 // Claim a unique ID from the per-function counter so nested lists at
@@ -1127,6 +1138,39 @@ struct Reach {
             out.contains(".setInt64List("),
             "expected a real setInt64List call for List(Int64):\n{out}"
         );
+    }
+
+    /// A nested-list (`List(List(Float32))`) field, mirroring the
+    /// `embeddings` field of `EmbedImagesResponse` in `inference.capnp` (the
+    /// #758 repro — see the matching parser-side test in `parsers.rs`).
+    const NESTED_LIST_SCHEMA: &str = r#"
+@0xd00dfeeda00dfeec;
+
+struct EmbedImagesResponse {
+  embeddings @0 :List(List(Float32));
+  dimensions @1 :UInt32;
+}
+"#;
+
+    #[test]
+    fn nested_list_field_builds_with_real_setter() {
+        let schema = parse_schema("embedbuild", NESTED_LIST_SCHEMA);
+        let mut out = String::new();
+        super::generate_struct_builders(&mut out, &schema);
+
+        // Must write through the real nested-list runtime setter, never the
+        // old #725 hard-panic ("nested list ... does not yet support double
+        // indirection") and never a silently dropped comment.
+        assert!(
+            out.contains(".setFloat32ListList(0,"),
+            "expected a real setFloat32ListList call for List(List(Float32)):\n{out}"
+        );
+        assert!(
+            !out.contains("does not yet support double indirection"),
+            "must never emit the old #725 nested-list panic path:\n{out}"
+        );
+        // The sibling scalar field must still build correctly alongside it.
+        assert!(out.contains(".setUint32(0,"), "{out}");
     }
 
     /// A field whose type references a struct that isn't in the parsed

--- a/crates/hyprstream-rpc-build/src/ts_codegen/message.rs
+++ b/crates/hyprstream-rpc-build/src/ts_codegen/message.rs
@@ -311,7 +311,15 @@ export class CapnpArena {
    * per-element byte width (ignored for bit-packed bool lists).
    * Returns the byte offset of the first element, or -1 for an empty list.
    */
-  private allocPrimitiveList(ptrIndex: number, count: number, elemSize: number, byteWidth: number): number {
+  /**
+   * Same as `allocPrimitiveList`, but takes the absolute byte offset of the
+   * pointer word to write (rather than deriving it from `ptrIndex` against
+   * the root pointer section). Shared by the root-level list setters and by
+   * `List(List(_))` nested-list setters, whose inner-list pointer lives at a
+   * computed offset inside the allocated outer pointer list, not at a
+   * `ptrIndex` slot.
+   */
+  private allocPrimitiveListAt(ptrOffset: number, count: number, elemSize: number, byteWidth: number): number {
     if (count === 0) return -1;
 
     this.alignAlloc();
@@ -320,7 +328,6 @@ export class CapnpArena {
     this.ensureCapacity(wordLen * WORD_SIZE);
 
     const targetOffset = this.allocOffset;
-    const ptrOffset = this.rootPtrOffset + ptrIndex * WORD_SIZE;
     const offsetWords = (targetOffset - ptrOffset - WORD_SIZE) / WORD_SIZE;
     const lo = ((offsetWords << 2) | 1) >>> 0;
     const hi = ((count << 3) | elemSize) >>> 0;
@@ -329,6 +336,37 @@ export class CapnpArena {
 
     this.allocOffset = targetOffset + wordLen * WORD_SIZE;
     return targetOffset;
+  }
+
+  private allocPrimitiveList(ptrIndex: number, count: number, elemSize: number, byteWidth: number): number {
+    return this.allocPrimitiveListAt(this.rootPtrOffset + ptrIndex * WORD_SIZE, count, elemSize, byteWidth);
+  }
+
+  /**
+   * Allocate the outer pointer-list structure for a `List(List(<inner>))`
+   * field at `ptrIndex`: a plain pointer list (element_size=6) with one
+   * pointer-word slot reserved per outer element. Each slot is later filled
+   * in by `allocPrimitiveListAt` when the corresponding inner list is
+   * written. Returns the byte offset of the first outer-element pointer
+   * slot, or -1 for an empty outer list (leaving the field's pointer null).
+   */
+  private allocNestedListOuter(ptrIndex: number, outerCount: number): number {
+    if (outerCount === 0) return -1;
+
+    this.alignAlloc();
+    this.ensureCapacity(outerCount * WORD_SIZE);
+
+    const outerBase = this.allocOffset;
+    this.allocOffset = outerBase + outerCount * WORD_SIZE;
+
+    const ptrOffset = this.rootPtrOffset + ptrIndex * WORD_SIZE;
+    const offsetWords = (outerBase - ptrOffset - WORD_SIZE) / WORD_SIZE;
+    const lo = ((offsetWords << 2) | 1) >>> 0;
+    const hi = ((outerCount << 3) | 6) >>> 0; // element_size=6: pointer list
+    this.buf.setUint32(ptrOffset, lo, true);
+    this.buf.setUint32(ptrOffset + 4, hi, true);
+
+    return outerBase;
   }
 
   setBoolList(ptrIndex: number, values: boolean[]): void {
@@ -397,6 +435,135 @@ export class CapnpArena {
     const base = this.allocPrimitiveList(ptrIndex, values.length, 5, 8);
     if (base < 0) return;
     for (let i = 0; i < values.length; i++) this.buf.setFloat64(base + i * 8, values[i], true);
+  }
+
+  // --- Nested List(List(<primitive>)) setters ---
+  //
+  // Each outer element is a pointer to an inner primitive list, allocated via
+  // `allocNestedListOuter` (outer pointer-list shell) + `allocPrimitiveListAt`
+  // (each inner list, written at the outer element's reserved pointer slot).
+
+  setBoolListList(ptrIndex: number, values: boolean[][]): void {
+    const outerBase = this.allocNestedListOuter(ptrIndex, values.length);
+    if (outerBase < 0) return;
+    for (let i = 0; i < values.length; i++) {
+      const inner = values[i];
+      if (inner.length === 0) continue;
+      const base = this.allocPrimitiveListAt(outerBase + i * WORD_SIZE, inner.length, 1, 0);
+      for (let j = 0; j < inner.length; j++) {
+        if (inner[j]) this.raw[base + (j >> 3)] |= 1 << (j & 7);
+      }
+    }
+  }
+
+  setUint8ListList(ptrIndex: number, values: number[][]): void {
+    const outerBase = this.allocNestedListOuter(ptrIndex, values.length);
+    if (outerBase < 0) return;
+    for (let i = 0; i < values.length; i++) {
+      const inner = values[i];
+      if (inner.length === 0) continue;
+      const base = this.allocPrimitiveListAt(outerBase + i * WORD_SIZE, inner.length, 2, 1);
+      for (let j = 0; j < inner.length; j++) this.buf.setUint8(base + j, inner[j]);
+    }
+  }
+
+  setInt8ListList(ptrIndex: number, values: number[][]): void {
+    const outerBase = this.allocNestedListOuter(ptrIndex, values.length);
+    if (outerBase < 0) return;
+    for (let i = 0; i < values.length; i++) {
+      const inner = values[i];
+      if (inner.length === 0) continue;
+      const base = this.allocPrimitiveListAt(outerBase + i * WORD_SIZE, inner.length, 2, 1);
+      for (let j = 0; j < inner.length; j++) this.buf.setInt8(base + j, inner[j]);
+    }
+  }
+
+  setUint16ListList(ptrIndex: number, values: number[][]): void {
+    const outerBase = this.allocNestedListOuter(ptrIndex, values.length);
+    if (outerBase < 0) return;
+    for (let i = 0; i < values.length; i++) {
+      const inner = values[i];
+      if (inner.length === 0) continue;
+      const base = this.allocPrimitiveListAt(outerBase + i * WORD_SIZE, inner.length, 3, 2);
+      for (let j = 0; j < inner.length; j++) this.buf.setUint16(base + j * 2, inner[j], true);
+    }
+  }
+
+  setInt16ListList(ptrIndex: number, values: number[][]): void {
+    const outerBase = this.allocNestedListOuter(ptrIndex, values.length);
+    if (outerBase < 0) return;
+    for (let i = 0; i < values.length; i++) {
+      const inner = values[i];
+      if (inner.length === 0) continue;
+      const base = this.allocPrimitiveListAt(outerBase + i * WORD_SIZE, inner.length, 3, 2);
+      for (let j = 0; j < inner.length; j++) this.buf.setInt16(base + j * 2, inner[j], true);
+    }
+  }
+
+  setUint32ListList(ptrIndex: number, values: number[][]): void {
+    const outerBase = this.allocNestedListOuter(ptrIndex, values.length);
+    if (outerBase < 0) return;
+    for (let i = 0; i < values.length; i++) {
+      const inner = values[i];
+      if (inner.length === 0) continue;
+      const base = this.allocPrimitiveListAt(outerBase + i * WORD_SIZE, inner.length, 4, 4);
+      for (let j = 0; j < inner.length; j++) this.buf.setUint32(base + j * 4, inner[j], true);
+    }
+  }
+
+  setInt32ListList(ptrIndex: number, values: number[][]): void {
+    const outerBase = this.allocNestedListOuter(ptrIndex, values.length);
+    if (outerBase < 0) return;
+    for (let i = 0; i < values.length; i++) {
+      const inner = values[i];
+      if (inner.length === 0) continue;
+      const base = this.allocPrimitiveListAt(outerBase + i * WORD_SIZE, inner.length, 4, 4);
+      for (let j = 0; j < inner.length; j++) this.buf.setInt32(base + j * 4, inner[j], true);
+    }
+  }
+
+  setFloat32ListList(ptrIndex: number, values: number[][]): void {
+    const outerBase = this.allocNestedListOuter(ptrIndex, values.length);
+    if (outerBase < 0) return;
+    for (let i = 0; i < values.length; i++) {
+      const inner = values[i];
+      if (inner.length === 0) continue;
+      const base = this.allocPrimitiveListAt(outerBase + i * WORD_SIZE, inner.length, 4, 4);
+      for (let j = 0; j < inner.length; j++) this.buf.setFloat32(base + j * 4, inner[j], true);
+    }
+  }
+
+  setUint64ListList(ptrIndex: number, values: bigint[][]): void {
+    const outerBase = this.allocNestedListOuter(ptrIndex, values.length);
+    if (outerBase < 0) return;
+    for (let i = 0; i < values.length; i++) {
+      const inner = values[i];
+      if (inner.length === 0) continue;
+      const base = this.allocPrimitiveListAt(outerBase + i * WORD_SIZE, inner.length, 5, 8);
+      for (let j = 0; j < inner.length; j++) this.buf.setBigUint64(base + j * 8, inner[j], true);
+    }
+  }
+
+  setInt64ListList(ptrIndex: number, values: bigint[][]): void {
+    const outerBase = this.allocNestedListOuter(ptrIndex, values.length);
+    if (outerBase < 0) return;
+    for (let i = 0; i < values.length; i++) {
+      const inner = values[i];
+      if (inner.length === 0) continue;
+      const base = this.allocPrimitiveListAt(outerBase + i * WORD_SIZE, inner.length, 5, 8);
+      for (let j = 0; j < inner.length; j++) this.buf.setBigInt64(base + j * 8, inner[j], true);
+    }
+  }
+
+  setFloat64ListList(ptrIndex: number, values: number[][]): void {
+    const outerBase = this.allocNestedListOuter(ptrIndex, values.length);
+    if (outerBase < 0) return;
+    for (let i = 0; i < values.length; i++) {
+      const inner = values[i];
+      if (inner.length === 0) continue;
+      const base = this.allocPrimitiveListAt(outerBase + i * WORD_SIZE, inner.length, 5, 8);
+      for (let j = 0; j < inner.length; j++) this.buf.setFloat64(base + j * 8, inner[j], true);
+    }
   }
 
   /**
@@ -664,7 +831,7 @@ export class StructBuilder {
    * `byteWidth` is the per-element byte width (ignored for bit-packed bool lists).
    * Returns the byte offset of the first element, or -1 for an empty list.
    */
-  private allocPrimitiveList(ptrIndex: number, count: number, elemSize: number, byteWidth: number): number {
+  private allocPrimitiveListAt(ptrOffset: number, count: number, elemSize: number, byteWidth: number): number {
     if (count === 0) return -1;
 
     this.msg._alignAlloc();
@@ -673,7 +840,6 @@ export class StructBuilder {
     this.msg._ensureCapacity(wordLen * WORD_SIZE);
 
     const targetOffset = this.msg._getAllocOffset();
-    const ptrOffset = this.ptrOffset + ptrIndex * WORD_SIZE;
     const offsetWords = (targetOffset - ptrOffset - WORD_SIZE) / WORD_SIZE;
     const lo = ((offsetWords << 2) | 1) >>> 0;
     const hi = ((count << 3) | elemSize) >>> 0;
@@ -682,6 +848,34 @@ export class StructBuilder {
 
     this.msg._setAllocOffset(targetOffset + wordLen * WORD_SIZE);
     return targetOffset;
+  }
+
+  private allocPrimitiveList(ptrIndex: number, count: number, elemSize: number, byteWidth: number): number {
+    return this.allocPrimitiveListAt(this.ptrOffset + ptrIndex * WORD_SIZE, count, elemSize, byteWidth);
+  }
+
+  /**
+   * Allocate the outer pointer-list structure for a `List(List(<inner>))`
+   * field at `ptrIndex` within this struct. See `CapnpArena.allocNestedListOuter`
+   * for the encoding this mirrors.
+   */
+  private allocNestedListOuter(ptrIndex: number, outerCount: number): number {
+    if (outerCount === 0) return -1;
+
+    this.msg._alignAlloc();
+    this.msg._ensureCapacity(outerCount * WORD_SIZE);
+
+    const outerBase = this.msg._getAllocOffset();
+    this.msg._setAllocOffset(outerBase + outerCount * WORD_SIZE);
+
+    const ptrOffset = this.ptrOffset + ptrIndex * WORD_SIZE;
+    const offsetWords = (outerBase - ptrOffset - WORD_SIZE) / WORD_SIZE;
+    const lo = ((offsetWords << 2) | 1) >>> 0;
+    const hi = ((outerCount << 3) | 6) >>> 0; // element_size=6: pointer list
+    this.msg._getBuf().setUint32(ptrOffset, lo, true);
+    this.msg._getBuf().setUint32(ptrOffset + 4, hi, true);
+
+    return outerBase;
   }
 
   setBoolList(ptrIndex: number, values: boolean[]): void {
@@ -751,6 +945,132 @@ export class StructBuilder {
     const base = this.allocPrimitiveList(ptrIndex, values.length, 5, 8);
     if (base < 0) return;
     for (let i = 0; i < values.length; i++) this.msg._getBuf().setFloat64(base + i * 8, values[i], true);
+  }
+
+  // --- Nested List(List(<primitive>)) setters (see CapnpArena's for docs) ---
+
+  setBoolListList(ptrIndex: number, values: boolean[][]): void {
+    const outerBase = this.allocNestedListOuter(ptrIndex, values.length);
+    if (outerBase < 0) return;
+    const raw = this.msg._getRaw();
+    for (let i = 0; i < values.length; i++) {
+      const inner = values[i];
+      if (inner.length === 0) continue;
+      const base = this.allocPrimitiveListAt(outerBase + i * WORD_SIZE, inner.length, 1, 0);
+      for (let j = 0; j < inner.length; j++) {
+        if (inner[j]) raw[base + (j >> 3)] |= 1 << (j & 7);
+      }
+    }
+  }
+
+  setUint8ListList(ptrIndex: number, values: number[][]): void {
+    const outerBase = this.allocNestedListOuter(ptrIndex, values.length);
+    if (outerBase < 0) return;
+    for (let i = 0; i < values.length; i++) {
+      const inner = values[i];
+      if (inner.length === 0) continue;
+      const base = this.allocPrimitiveListAt(outerBase + i * WORD_SIZE, inner.length, 2, 1);
+      for (let j = 0; j < inner.length; j++) this.msg._getBuf().setUint8(base + j, inner[j]);
+    }
+  }
+
+  setInt8ListList(ptrIndex: number, values: number[][]): void {
+    const outerBase = this.allocNestedListOuter(ptrIndex, values.length);
+    if (outerBase < 0) return;
+    for (let i = 0; i < values.length; i++) {
+      const inner = values[i];
+      if (inner.length === 0) continue;
+      const base = this.allocPrimitiveListAt(outerBase + i * WORD_SIZE, inner.length, 2, 1);
+      for (let j = 0; j < inner.length; j++) this.msg._getBuf().setInt8(base + j, inner[j]);
+    }
+  }
+
+  setUint16ListList(ptrIndex: number, values: number[][]): void {
+    const outerBase = this.allocNestedListOuter(ptrIndex, values.length);
+    if (outerBase < 0) return;
+    for (let i = 0; i < values.length; i++) {
+      const inner = values[i];
+      if (inner.length === 0) continue;
+      const base = this.allocPrimitiveListAt(outerBase + i * WORD_SIZE, inner.length, 3, 2);
+      for (let j = 0; j < inner.length; j++) this.msg._getBuf().setUint16(base + j * 2, inner[j], true);
+    }
+  }
+
+  setInt16ListList(ptrIndex: number, values: number[][]): void {
+    const outerBase = this.allocNestedListOuter(ptrIndex, values.length);
+    if (outerBase < 0) return;
+    for (let i = 0; i < values.length; i++) {
+      const inner = values[i];
+      if (inner.length === 0) continue;
+      const base = this.allocPrimitiveListAt(outerBase + i * WORD_SIZE, inner.length, 3, 2);
+      for (let j = 0; j < inner.length; j++) this.msg._getBuf().setInt16(base + j * 2, inner[j], true);
+    }
+  }
+
+  setUint32ListList(ptrIndex: number, values: number[][]): void {
+    const outerBase = this.allocNestedListOuter(ptrIndex, values.length);
+    if (outerBase < 0) return;
+    for (let i = 0; i < values.length; i++) {
+      const inner = values[i];
+      if (inner.length === 0) continue;
+      const base = this.allocPrimitiveListAt(outerBase + i * WORD_SIZE, inner.length, 4, 4);
+      for (let j = 0; j < inner.length; j++) this.msg._getBuf().setUint32(base + j * 4, inner[j], true);
+    }
+  }
+
+  setInt32ListList(ptrIndex: number, values: number[][]): void {
+    const outerBase = this.allocNestedListOuter(ptrIndex, values.length);
+    if (outerBase < 0) return;
+    for (let i = 0; i < values.length; i++) {
+      const inner = values[i];
+      if (inner.length === 0) continue;
+      const base = this.allocPrimitiveListAt(outerBase + i * WORD_SIZE, inner.length, 4, 4);
+      for (let j = 0; j < inner.length; j++) this.msg._getBuf().setInt32(base + j * 4, inner[j], true);
+    }
+  }
+
+  setFloat32ListList(ptrIndex: number, values: number[][]): void {
+    const outerBase = this.allocNestedListOuter(ptrIndex, values.length);
+    if (outerBase < 0) return;
+    for (let i = 0; i < values.length; i++) {
+      const inner = values[i];
+      if (inner.length === 0) continue;
+      const base = this.allocPrimitiveListAt(outerBase + i * WORD_SIZE, inner.length, 4, 4);
+      for (let j = 0; j < inner.length; j++) this.msg._getBuf().setFloat32(base + j * 4, inner[j], true);
+    }
+  }
+
+  setUint64ListList(ptrIndex: number, values: bigint[][]): void {
+    const outerBase = this.allocNestedListOuter(ptrIndex, values.length);
+    if (outerBase < 0) return;
+    for (let i = 0; i < values.length; i++) {
+      const inner = values[i];
+      if (inner.length === 0) continue;
+      const base = this.allocPrimitiveListAt(outerBase + i * WORD_SIZE, inner.length, 5, 8);
+      for (let j = 0; j < inner.length; j++) this.msg._getBuf().setBigUint64(base + j * 8, inner[j], true);
+    }
+  }
+
+  setInt64ListList(ptrIndex: number, values: bigint[][]): void {
+    const outerBase = this.allocNestedListOuter(ptrIndex, values.length);
+    if (outerBase < 0) return;
+    for (let i = 0; i < values.length; i++) {
+      const inner = values[i];
+      if (inner.length === 0) continue;
+      const base = this.allocPrimitiveListAt(outerBase + i * WORD_SIZE, inner.length, 5, 8);
+      for (let j = 0; j < inner.length; j++) this.msg._getBuf().setBigInt64(base + j * 8, inner[j], true);
+    }
+  }
+
+  setFloat64ListList(ptrIndex: number, values: number[][]): void {
+    const outerBase = this.allocNestedListOuter(ptrIndex, values.length);
+    if (outerBase < 0) return;
+    for (let i = 0; i < values.length; i++) {
+      const inner = values[i];
+      if (inner.length === 0) continue;
+      const base = this.allocPrimitiveListAt(outerBase + i * WORD_SIZE, inner.length, 5, 8);
+      for (let j = 0; j < inner.length; j++) this.msg._getBuf().setFloat64(base + j * 8, inner[j], true);
+    }
   }
 
   /**
@@ -1219,6 +1539,112 @@ export class CapnpReader {
     return this.readPrimitiveList(ptrIndex, 5, 8, (o) => this.buf.getFloat64(o, true));
   }
 
+  /**
+   * Read a `List(List(<inner>))` field: a pointer list whose elements are
+   * themselves primitive lists (List(Bool)/List(UIntN)/List(IntN)/List(FloatN)).
+   * Mirrors `readPrimitiveList`, resolving one extra level of pointer
+   * indirection per outer element. Supports both the canonical pointer-list
+   * outer encoding (element_size=6) and composite (element_size=7, used when
+   * the outer list happens to be optimized as a single-pointer struct list).
+   * An outer element whose inner pointer is null, or whose encoded element
+   * size doesn't match `innerElemSize`, reads as `[]` for that element.
+   */
+  private readNestedPrimitiveList<T>(
+    ptrIndex: number,
+    innerElemSize: number,
+    innerByteWidth: number,
+    readInner: (byteOffset: number, bitIndex: number) => T,
+  ): T[][] {
+    const ptrOffset = this.rootPtrOffset + ptrIndex * WORD_SIZE;
+    const resolved = this.resolvePtr(ptrOffset);
+    if (!resolved) return [];
+    const { lo, hi, offset } = resolved;
+    if ((lo & 3) !== 1) return [];
+
+    const offsetWords = (lo >> 2) | 0;
+    const outerElementSize = hi & 7;
+    const targetOffset = offset + WORD_SIZE + offsetWords * WORD_SIZE;
+
+    let outerCount: number;
+    let outerBase: number;
+    if (outerElementSize === 6) {
+      outerCount = hi >>> 3;
+      outerBase = targetOffset;
+    } else if (outerElementSize === 7) {
+      const tagLo = this.buf.getUint32(targetOffset, true);
+      outerCount = (tagLo >> 2) | 0;
+      outerBase = targetOffset + WORD_SIZE;
+    } else {
+      return [];
+    }
+
+    const results: T[][] = [];
+    for (let i = 0; i < outerCount; i++) {
+      const elemPtrOffset = outerBase + i * WORD_SIZE;
+      const elemResolved = this.resolvePtr(elemPtrOffset);
+      if (!elemResolved) { results.push([]); continue; }
+      const { lo: iLo, hi: iHi, offset: iOffset } = elemResolved;
+      if ((iLo & 3) !== 1 || (iHi & 7) !== innerElemSize) { results.push([]); continue; }
+      const iOffsetWords = (iLo >> 2) | 0;
+      const innerTarget = iOffset + WORD_SIZE + iOffsetWords * WORD_SIZE;
+      const innerCount = iHi >>> 3;
+      const inner: T[] = [];
+      for (let j = 0; j < innerCount; j++) {
+        inner.push(
+          innerByteWidth === 0
+            ? readInner(innerTarget + (j >> 3), j & 7)
+            : readInner(innerTarget + j * innerByteWidth, 0),
+        );
+      }
+      results.push(inner);
+    }
+    return results;
+  }
+
+  getBoolListList(ptrIndex: number): boolean[][] {
+    return this.readNestedPrimitiveList(ptrIndex, 1, 0, (byteOffset, bitIndex) => (this.raw[byteOffset] & (1 << bitIndex)) !== 0);
+  }
+
+  getUint8ListList(ptrIndex: number): number[][] {
+    return this.readNestedPrimitiveList(ptrIndex, 2, 1, (o) => this.buf.getUint8(o));
+  }
+
+  getInt8ListList(ptrIndex: number): number[][] {
+    return this.readNestedPrimitiveList(ptrIndex, 2, 1, (o) => this.buf.getInt8(o));
+  }
+
+  getUint16ListList(ptrIndex: number): number[][] {
+    return this.readNestedPrimitiveList(ptrIndex, 3, 2, (o) => this.buf.getUint16(o, true));
+  }
+
+  getInt16ListList(ptrIndex: number): number[][] {
+    return this.readNestedPrimitiveList(ptrIndex, 3, 2, (o) => this.buf.getInt16(o, true));
+  }
+
+  getUint32ListList(ptrIndex: number): number[][] {
+    return this.readNestedPrimitiveList(ptrIndex, 4, 4, (o) => this.buf.getUint32(o, true));
+  }
+
+  getInt32ListList(ptrIndex: number): number[][] {
+    return this.readNestedPrimitiveList(ptrIndex, 4, 4, (o) => this.buf.getInt32(o, true));
+  }
+
+  getFloat32ListList(ptrIndex: number): number[][] {
+    return this.readNestedPrimitiveList(ptrIndex, 4, 4, (o) => this.buf.getFloat32(o, true));
+  }
+
+  getUint64ListList(ptrIndex: number): bigint[][] {
+    return this.readNestedPrimitiveList(ptrIndex, 5, 8, (o) => this.buf.getBigUint64(o, true));
+  }
+
+  getInt64ListList(ptrIndex: number): bigint[][] {
+    return this.readNestedPrimitiveList(ptrIndex, 5, 8, (o) => this.buf.getBigInt64(o, true));
+  }
+
+  getFloat64ListList(ptrIndex: number): number[][] {
+    return this.readNestedPrimitiveList(ptrIndex, 5, 8, (o) => this.buf.getFloat64(o, true));
+  }
+
   /** Read a List(Struct) composite list pointer. Returns StructReader[] using wire-format shape from tag word. */
   getStructList(ptrIndex: number, _dataWords: number, _ptrWords: number): StructReader[] {
     const ptrOffset = this.rootPtrOffset + ptrIndex * WORD_SIZE;
@@ -1515,6 +1941,106 @@ export class StructReader {
 
   getFloat64List(ptrIndex: number): number[] {
     return this.readPrimitiveList(ptrIndex, 5, 8, (o) => this.buf.getFloat64(o, true));
+  }
+
+  /**
+   * Read a `List(List(<inner>))` field within this struct. See
+   * `CapnpReader.readNestedPrimitiveList` for the encoding this mirrors.
+   */
+  private readNestedPrimitiveList<T>(
+    ptrIndex: number,
+    innerElemSize: number,
+    innerByteWidth: number,
+    readInner: (byteOffset: number, bitIndex: number) => T,
+  ): T[][] {
+    const ptrOffset = this.dataOffset + this.dataWords * WORD_SIZE + ptrIndex * WORD_SIZE;
+    const resolved = this.resolvePtr(ptrOffset);
+    if (!resolved) return [];
+    const { lo, hi, offset } = resolved;
+    if ((lo & 3) !== 1) return [];
+
+    const offsetWords = (lo >> 2) | 0;
+    const outerElementSize = hi & 7;
+    const targetOffset = offset + WORD_SIZE + offsetWords * WORD_SIZE;
+
+    let outerCount: number;
+    let outerBase: number;
+    if (outerElementSize === 6) {
+      outerCount = hi >>> 3;
+      outerBase = targetOffset;
+    } else if (outerElementSize === 7) {
+      const tagLo = this.buf.getUint32(targetOffset, true);
+      outerCount = (tagLo >> 2) | 0;
+      outerBase = targetOffset + WORD_SIZE;
+    } else {
+      return [];
+    }
+
+    const results: T[][] = [];
+    for (let i = 0; i < outerCount; i++) {
+      const elemPtrOffset = outerBase + i * WORD_SIZE;
+      const elemResolved = this.resolvePtr(elemPtrOffset);
+      if (!elemResolved) { results.push([]); continue; }
+      const { lo: iLo, hi: iHi, offset: iOffset } = elemResolved;
+      if ((iLo & 3) !== 1 || (iHi & 7) !== innerElemSize) { results.push([]); continue; }
+      const iOffsetWords = (iLo >> 2) | 0;
+      const innerTarget = iOffset + WORD_SIZE + iOffsetWords * WORD_SIZE;
+      const innerCount = iHi >>> 3;
+      const inner: T[] = [];
+      for (let j = 0; j < innerCount; j++) {
+        inner.push(
+          innerByteWidth === 0
+            ? readInner(innerTarget + (j >> 3), j & 7)
+            : readInner(innerTarget + j * innerByteWidth, 0),
+        );
+      }
+      results.push(inner);
+    }
+    return results;
+  }
+
+  getBoolListList(ptrIndex: number): boolean[][] {
+    return this.readNestedPrimitiveList(ptrIndex, 1, 0, (byteOffset, bitIndex) => (this.raw[byteOffset] & (1 << bitIndex)) !== 0);
+  }
+
+  getUint8ListList(ptrIndex: number): number[][] {
+    return this.readNestedPrimitiveList(ptrIndex, 2, 1, (o) => this.buf.getUint8(o));
+  }
+
+  getInt8ListList(ptrIndex: number): number[][] {
+    return this.readNestedPrimitiveList(ptrIndex, 2, 1, (o) => this.buf.getInt8(o));
+  }
+
+  getUint16ListList(ptrIndex: number): number[][] {
+    return this.readNestedPrimitiveList(ptrIndex, 3, 2, (o) => this.buf.getUint16(o, true));
+  }
+
+  getInt16ListList(ptrIndex: number): number[][] {
+    return this.readNestedPrimitiveList(ptrIndex, 3, 2, (o) => this.buf.getInt16(o, true));
+  }
+
+  getUint32ListList(ptrIndex: number): number[][] {
+    return this.readNestedPrimitiveList(ptrIndex, 4, 4, (o) => this.buf.getUint32(o, true));
+  }
+
+  getInt32ListList(ptrIndex: number): number[][] {
+    return this.readNestedPrimitiveList(ptrIndex, 4, 4, (o) => this.buf.getInt32(o, true));
+  }
+
+  getFloat32ListList(ptrIndex: number): number[][] {
+    return this.readNestedPrimitiveList(ptrIndex, 4, 4, (o) => this.buf.getFloat32(o, true));
+  }
+
+  getUint64ListList(ptrIndex: number): bigint[][] {
+    return this.readNestedPrimitiveList(ptrIndex, 5, 8, (o) => this.buf.getBigUint64(o, true));
+  }
+
+  getInt64ListList(ptrIndex: number): bigint[][] {
+    return this.readNestedPrimitiveList(ptrIndex, 5, 8, (o) => this.buf.getBigInt64(o, true));
+  }
+
+  getFloat64ListList(ptrIndex: number): number[][] {
+    return this.readNestedPrimitiveList(ptrIndex, 5, 8, (o) => this.buf.getFloat64(o, true));
   }
 
   getStructList(ptrIndex: number, _dataWords: number, _ptrWords: number): StructReader[] {

--- a/crates/hyprstream-rpc-build/src/ts_codegen/message.rs
+++ b/crates/hyprstream-rpc-build/src/ts_codegen/message.rs
@@ -952,11 +952,13 @@ export class StructBuilder {
   setBoolListList(ptrIndex: number, values: boolean[][]): void {
     const outerBase = this.allocNestedListOuter(ptrIndex, values.length);
     if (outerBase < 0) return;
-    const raw = this.msg._getRaw();
     for (let i = 0; i < values.length; i++) {
       const inner = values[i];
       if (inner.length === 0) continue;
       const base = this.allocPrimitiveListAt(outerBase + i * WORD_SIZE, inner.length, 1, 0);
+      // Re-fetch after alloc: allocPrimitiveListAt can grow the arena,
+      // detaching any previously captured raw buffer.
+      const raw = this.msg._getRaw();
       for (let j = 0; j < inner.length; j++) {
         if (inner[j]) raw[base + (j >> 3)] |= 1 << (j & 7);
       }

--- a/crates/hyprstream-rpc-build/src/ts_codegen/mod.rs
+++ b/crates/hyprstream-rpc-build/src/ts_codegen/mod.rs
@@ -254,6 +254,54 @@ pub(crate) fn list_getter_method(inner: &str) -> Option<&str> {
     })
 }
 
+/// Return the TypeScript setter method name for a `List(List(<inner>))` field,
+/// given the doubly-nested (innermost) element type name — e.g. `"Float32"`
+/// for the `embeddings: List(List(Float32))` shape used by
+/// `inference.capnp`/`model.capnp`.
+///
+/// Mirrors [`list_setter_method`] one level deeper: the runtime encodes the
+/// outer list as a plain pointer list (each element itself a `List(<inner>)`
+/// pointer), so only inner element types the flat list runtime already
+/// supports as a *primitive* list are covered here — `None` for `Text`/`Data`
+/// (nested `List(List(Text))`/`List(List(Data))`) and struct/list inner types,
+/// which are not yet implemented and must remain a hard generator error
+/// rather than silently degrading (#758).
+pub(crate) fn nested_list_setter_method(inner: &str) -> Option<&str> {
+    Some(match inner {
+        "Bool" => "setBoolListList",
+        "UInt8" => "setUint8ListList",
+        "Int8" => "setInt8ListList",
+        "UInt16" => "setUint16ListList",
+        "Int16" => "setInt16ListList",
+        "UInt32" => "setUint32ListList",
+        "Int32" => "setInt32ListList",
+        "UInt64" => "setUint64ListList",
+        "Int64" => "setInt64ListList",
+        "Float32" => "setFloat32ListList",
+        "Float64" => "setFloat64ListList",
+        _ => return None,
+    })
+}
+
+/// Return the TypeScript getter method name for a `List(List(<inner>))`
+/// field. Mirrors [`nested_list_setter_method`] — see its docs.
+pub(crate) fn nested_list_getter_method(inner: &str) -> Option<&str> {
+    Some(match inner {
+        "Bool" => "getBoolListList",
+        "UInt8" => "getUint8ListList",
+        "Int8" => "getInt8ListList",
+        "UInt16" => "getUint16ListList",
+        "Int16" => "getInt16ListList",
+        "UInt32" => "getUint32ListList",
+        "Int32" => "getInt32ListList",
+        "UInt64" => "getUint64ListList",
+        "Int64" => "getInt64ListList",
+        "Float32" => "getFloat32ListList",
+        "Float64" => "getFloat64ListList",
+        _ => return None,
+    })
+}
+
 /// Return the default TS expression for a Cap'n Proto type (used for optional field coalescing).
 fn default_value_expr(type_name: &str) -> &str {
     match type_name {

--- a/crates/hyprstream-rpc-build/src/ts_codegen/parsers.rs
+++ b/crates/hyprstream-rpc-build/src/ts_codegen/parsers.rs
@@ -178,12 +178,23 @@ pub fn generate_parsers(out: &mut String, service_name: &str, schema: &ParsedSch
                         &variant.name,
                         &format!("reader.{method}({})", vf.slot_offset),
                     );
-                } else if inner.starts_with("List(") {
-                    panic!(
-                        "ts_codegen: response variant `{}: {}` is a nested list \
-                         (List(List(_))) — not yet supported by the capnp.ts runtime (#725).",
-                        variant.name, variant.type_name
-                    );
+                } else if let Some(nested_inner) = super::extract_list_inner_type(inner) {
+                    if let Some(method) = super::nested_list_getter_method(nested_inner) {
+                        emit_return(
+                            out,
+                            &non_union_fields,
+                            &variant.name,
+                            &format!("reader.{method}({})", vf.slot_offset),
+                        );
+                    } else {
+                        panic!(
+                            "ts_codegen: response variant `{}: {}` is a nested list of \
+                             `{nested_inner}` — not yet supported by the capnp.ts runtime \
+                             (only primitive-scalar List(List(_)) shapes are implemented) \
+                             (#758).",
+                            variant.name, variant.type_name
+                        );
+                    }
                 } else if let Some(sd) = schema.structs.iter().find(|s| s.name == inner) {
                     emit_struct_list_read(
                         out,
@@ -379,12 +390,22 @@ pub fn generate_struct_parsers(out: &mut String, schema: &ParsedSchema) {
                         &variant.name,
                         &format!("reader.{method}({})", variant.slot_offset),
                     );
-                } else if inner.starts_with("List(") {
-                    panic!(
-                        "ts_codegen: union arm `{}: {}` is a nested list (List(List(_))) — \
-                         not yet supported by the capnp.ts runtime (#725).",
-                        variant.name, variant.type_name
-                    );
+                } else if let Some(nested_inner) = super::extract_list_inner_type(inner) {
+                    if let Some(method) = super::nested_list_getter_method(nested_inner) {
+                        emit_return(
+                            out,
+                            &non_union_fields,
+                            &variant.name,
+                            &format!("reader.{method}({})", variant.slot_offset),
+                        );
+                    } else {
+                        panic!(
+                            "ts_codegen: union arm `{}: {}` is a nested list of `{nested_inner}` \
+                             — not yet supported by the capnp.ts runtime (only \
+                             primitive-scalar List(List(_)) shapes are implemented) (#758).",
+                            variant.name, variant.type_name
+                        );
+                    }
                 } else if let Some(isd) = schema.structs.iter().find(|s| s.name == inner) {
                     emit_struct_list_read(
                         out,
@@ -737,11 +758,16 @@ fn emit_inner_variant_read_from(
             let inner = super::extract_list_inner_type(t).unwrap_or("");
             if let Some(method) = super::list_getter_method(inner) {
                 format!("{reader_var}.{method}({})", f.slot_offset)
-            } else if inner.starts_with("List(") {
-                panic!(
-                    "ts_codegen: inner variant `{type_name}` is a nested list \
-                     (List(List(_))) — not yet supported by the capnp.ts runtime (#725)."
-                );
+            } else if let Some(nested_inner) = super::extract_list_inner_type(inner) {
+                if let Some(method) = super::nested_list_getter_method(nested_inner) {
+                    format!("{reader_var}.{method}({})", f.slot_offset)
+                } else {
+                    panic!(
+                        "ts_codegen: inner variant `{type_name}` is a nested list of \
+                         `{nested_inner}` — not yet supported by the capnp.ts runtime \
+                         (only primitive-scalar List(List(_)) shapes are implemented) (#758)."
+                    );
+                }
             } else if let Some(sd) = schema.structs.iter().find(|s| s.name == inner) {
                 emit_struct_list_field_expr(reader_var, f.slot_offset, sd, schema)
             } else {
@@ -878,12 +904,17 @@ fn emit_pointer_read_expr(
         Some(inner) => {
             if let Some(method) = super::list_getter_method(inner) {
                 format!("{reader_var}.{method}({})", field.slot_offset)
-            } else if inner.starts_with("List(") {
-                panic!(
-                    "ts_codegen: field `{}: {}` is a nested list (List(List(_))) — not yet \
-                     supported by the capnp.ts runtime (#725).",
-                    field.name, field.type_name
-                );
+            } else if let Some(nested_inner) = super::extract_list_inner_type(inner) {
+                if let Some(method) = super::nested_list_getter_method(nested_inner) {
+                    format!("{reader_var}.{method}({})", field.slot_offset)
+                } else {
+                    panic!(
+                        "ts_codegen: field `{}: {}` is a nested list of `{nested_inner}` — \
+                         not yet supported by the capnp.ts runtime (only primitive-scalar \
+                         List(List(_)) shapes are implemented) (#758).",
+                        field.name, field.type_name
+                    );
+                }
             } else if let Some(isd) = schema.structs.iter().find(|s| s.name == inner) {
                 emit_struct_list_field_expr(reader_var, field.slot_offset, isd, schema)
             } else {
@@ -1571,6 +1602,40 @@ struct EndpointInfo {
         // The two Data fields specifically must read through the real getter,
         // not be skipped.
         assert!(parser.contains(".getData("), "{parser}");
+    }
+
+    /// A nested-list (`List(List(Float32))`) field, mirroring the
+    /// `embeddings` field of `EmbedImagesResponse` in `inference.capnp` (the
+    /// #758 repro: a full regen of `inference.ts`/`model.ts` aborted on
+    /// exactly this shape because nested lists had no codegen support).
+    const NESTED_LIST_SCHEMA: &str = r#"
+@0xd00dfeeda00dfeee;
+
+struct EmbedImagesResponse {
+  embeddings @0 :List(List(Float32));
+  dimensions @1 :UInt32;
+}
+"#;
+
+    #[test]
+    fn nested_list_field_parses_with_real_getter() {
+        let schema = parse_schema("embedparse", NESTED_LIST_SCHEMA);
+        let mut out = String::new();
+        super::generate_struct_parsers(&mut out, &schema);
+
+        // Must read through the real nested-list runtime getter, never the
+        // old #725 hard-panic ("nested list ... not yet supported") and
+        // never a silent `[]` fallback.
+        assert!(
+            out.contains("reader.getFloat32ListList(0)"),
+            "expected a real getFloat32ListList call for List(List(Float32)):\n{out}"
+        );
+        assert!(
+            !out.contains("not yet supported"),
+            "must never emit the old #725 nested-list panic path:\n{out}"
+        );
+        // The sibling scalar field must still parse correctly alongside it.
+        assert!(out.contains("reader.getUint32(0)"), "{out}");
     }
 
     /// A field whose type references a struct that isn't in the parsed


### PR DESCRIPTION
## Summary

Follow-up to #725/PR #728. `ts_codegen` now hard-fails on unresolved list/struct references instead of silently degrading, which surfaced a real gap: `List(List(T))` (used by the `embeddings` field of `EmbedImagesResponse` in `inference.capnp`/`model.capnp`) had no codegen support at all, so a full regen of `inference.ts`/`model.ts` aborted.

This extends `ts_codegen` to emit real `List(List(T))` getters/setters for primitive-scalar inner types (`Bool`/`UIntN`/`IntN`/`FloatN`), and flips the previous hard-panic back into working codegen for this shape.

## What changed

- **`crates/hyprstream-rpc-build/src/ts_codegen/message.rs`** (the generated `capnp.ts` runtime): added `get{Bool,Uint8,Int8,Uint16,Int16,Uint32,Int32,Uint64,Int64,Float32,Float64}ListList` to `CapnpReader`/`StructReader`, and matching `set*ListList` to `CapnpArena`/`StructBuilder`. The outer list is encoded as a plain pointer list (`element_size=6`) whose elements are themselves primitive lists — both the canonical pointer-list and inline-composite outer encodings are handled, mirroring the existing `List(Text)`/`List(Data)` support. `allocPrimitiveList` was refactored into an offset-based `allocPrimitiveListAt` so nested-list setters can write inner lists at a computed pointer slot instead of a fixed `ptrIndex`.
- **`crates/hyprstream-rpc-build/src/ts_codegen/mod.rs`**: added `nested_list_getter_method`/`nested_list_setter_method`, mapping a doubly-nested inner type name to its runtime method (mirrors `list_getter_method`/`list_setter_method`).
- **`crates/hyprstream-rpc-build/src/ts_codegen/parsers.rs`** and **`builders.rs`**: every place that previously matched `inner.starts_with("List(")` and hard-panicked now recognizes `List(List(<inner>))` and dispatches to the new runtime methods for primitive inner types, still hard-failing (never silently degrading) for inner shapes the runtime doesn't support yet (`Text`/`Data`/struct/triple-nested).

## Golden test

Added a test to both `parsers.rs` and `builders.rs` using an embeddings-shaped schema (`embeddings @0 :List(List(Float32)); dimensions @1 :UInt32;`, mirroring `EmbedImagesResponse`) asserting the generated TS uses the real `getFloat32ListList`/`setFloat32ListList` calls and never falls back to the old panic path.

## Verification

- `cargo test -p hyprstream-rpc-build` — 13/13 pass (including the two new golden tests).
- `cargo clippy -p hyprstream-rpc-build --all-targets` — clean.
- **End-to-end regen**: built `hyprstream-rpc-std` to produce live CGR files, then ran `cargo run -p hyprstream-rpc-build --bin hyprstream-ts-codegen -- --input-dir <hyprstream-rpc-std OUT_DIR> --output-dir <tmp>` against them directly. All 9 service files generated successfully with no panic, including `inference.ts` and `model.ts`. Confirmed the generated output uses the new runtime calls at every `embeddings` call site (standalone parser/builder, and the nested scoped-response read path for `model.ts`'s `infer.embed` variant):
  - `inference.ts`: `embeddings: number[][]`, `_s.getFloat32ListList(0)`, `msg.setFloat32ListList(0, p.embeddings)`, `reader.getFloat32ListList(0)`
  - `model.ts`: same shape plus the nested scoped-response read `_p0.getFloat32ListList(0)` inside the `infer.embed` variant parse.

Closes #758.