### PR TITLE
feat(9p): H1b — /9p WebTransport plane (QUIC path-mux, Tattach.uname ticket, cert-pinned) (#765)

### DIFF
--- a/crates/hyprstream-9p/src/backend.rs
+++ b/crates/hyprstream-9p/src/backend.rs
@@ -52,6 +52,21 @@ pub struct StatResult {
 /// per walked path.
 #[async_trait]
 pub trait Backend: Send + Sync {
+    /// Establish the session at `Tattach`, given the `uname` the client
+    /// presented. The default is a no-op: backends whose caller identity is
+    /// fixed at construction (the UDS/vsock listeners) ignore `uname`.
+    ///
+    /// A backend that resolves its caller identity from the attach itself
+    /// (the H1b `/9p` WebTransport plane carries a mount ticket in
+    /// `Tattach.uname` — the browser `WebSocket` can't set headers and the
+    /// cert-pinned WT session has no URL query) validates it here and binds
+    /// the session `Subject`. Returning `Err` fails the attach; the translator
+    /// maps it to an `Rlerror` errno (a `hyprstream_vfs::MountError` in the
+    /// cause chain picks the errno — e.g. `PermissionDenied → EACCES`).
+    async fn attach(&self, _uname: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     /// Walk `components` from `fid` (the previously-walked parent, or the
     /// attach root). Allocates internal state for `newfid`.
     async fn walk(

--- a/crates/hyprstream-9p/src/lib.rs
+++ b/crates/hyprstream-9p/src/lib.rs
@@ -65,7 +65,7 @@ pub mod wanix_mount;
 pub use backend::{Backend, OpenResult, StatResult, WalkResult};
 pub use client::{P9Client, P9Transport};
 #[cfg(not(target_arch = "wasm32"))]
-pub use mount_backend::MountBackend;
+pub use mount_backend::{AttachAuthorizer, MountBackend};
 #[cfg(not(target_arch = "wasm32"))]
 pub use remote_mount::Remote9pMount;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/hyprstream-9p/src/mount_backend.rs
+++ b/crates/hyprstream-9p/src/mount_backend.rs
@@ -33,11 +33,31 @@ use anyhow::{anyhow, Context as _, Result};
 use async_trait::async_trait;
 use dashmap::DashMap;
 use hyprstream_rpc::Subject;
-use hyprstream_vfs::{DirEntry, Fid, Mount};
-use tokio::sync::Mutex;
+use hyprstream_vfs::{DirEntry, Fid, Mount, MountError};
+use tokio::sync::{Mutex, OnceCell};
 
 use crate::backend::{Backend, OpenResult, StatResult, WalkResult};
 use crate::msg::{self, Qid, ReaddirEntry};
+
+/// Resolves the mount ticket a client presents in `Tattach.uname` to the
+/// verified session [`Subject`] the export is scoped to.
+///
+/// This is the attach-time credential seam for transports where the caller
+/// identity is not fixed at listener construction: the H1b `/9p` WebTransport
+/// plane serves a cert-pinned mesh session over which many tenants could
+/// attach, so the ticket rides `Tattach.uname` and is validated here — the
+/// per-session analogue of the RPC `EnvelopeContext` (MAC interface policy:
+/// "extend at attach time, never per-op"). The concrete impl lives in the
+/// `hyprstream` crate (it owns the JWT/OAuth verification chain); this trait
+/// keeps `hyprstream-9p` free of that dependency.
+///
+/// On denial, return a [`MountError`] — the translator maps it to an `Rlerror`
+/// errno (e.g. [`MountError::PermissionDenied`] → `EACCES`).
+#[async_trait]
+pub trait AttachAuthorizer: Send + Sync {
+    /// Validate the `uname` ticket and return the narrowed session [`Subject`].
+    async fn authorize(&self, uname: &str) -> Result<Subject, MountError>;
+}
 
 /// Max bytes a single read/write returns. Kept below the translator's `MSG_SIZE`
 /// (8 KiB) so an `Rread` carrying a full iounit plus its 9P header still fits the
@@ -58,16 +78,49 @@ struct MountFidEntry {
 }
 
 /// A [`Backend`] backed by a single Subject-scoped VFS [`Mount`].
+///
+/// The session [`Subject`] is either fixed at construction ([`MountBackend::new`],
+/// the UDS/vsock listeners) or resolved from the client's `Tattach.uname` ticket
+/// at attach time ([`MountBackend::with_authorizer`], the H1b `/9p` WebTransport
+/// plane). It lives behind a [`OnceCell`] so per-op code reads one bound value
+/// either way; ops before a successful attach fail closed.
 pub struct MountBackend {
     mount: Arc<dyn Mount>,
-    subject: Subject,
+    subject: OnceCell<Subject>,
+    /// Present only for the attach-time path; resolves `uname` → `Subject`.
+    authorizer: Option<Arc<dyn AttachAuthorizer>>,
     fids: DashMap<u32, Arc<MountFidEntry>>,
 }
 
 impl MountBackend {
-    /// Wrap `mount` as the 9P export root for `subject`.
+    /// Wrap `mount` as the 9P export root for a `subject` fixed at construction.
     pub fn new(mount: Arc<dyn Mount>, subject: Subject) -> Self {
-        Self { mount, subject, fids: DashMap::new() }
+        let cell = OnceCell::new();
+        // Infallible on a fresh cell.
+        let _ = cell.set(subject);
+        Self { mount, subject: cell, authorizer: None, fids: DashMap::new() }
+    }
+
+    /// Wrap `mount` as the 9P export root whose session [`Subject`] is resolved
+    /// from the `Tattach.uname` ticket by `authorizer` (H1b `/9p` WebTransport).
+    ///
+    /// The `Subject` is unbound until a successful [`Backend::attach`]; any op
+    /// arriving before attach fails closed.
+    pub fn with_authorizer(mount: Arc<dyn Mount>, authorizer: Arc<dyn AttachAuthorizer>) -> Self {
+        Self {
+            mount,
+            subject: OnceCell::new(),
+            authorizer: Some(authorizer),
+            fids: DashMap::new(),
+        }
+    }
+
+    /// The bound session [`Subject`], or an error if no attach has bound it yet
+    /// (fail-closed: a 9P op must never reach the mount without a caller).
+    fn caller(&self) -> Result<&Subject> {
+        self.subject
+            .get()
+            .ok_or_else(|| anyhow!("9P op before Tattach: session Subject not bound"))
     }
 
     /// Clone out the `Arc` for a fid, dropping the `DashMap` guard so the mount
@@ -83,7 +136,7 @@ impl MountBackend {
     async fn qid_of(&self, handle: &Fid) -> Result<Qid> {
         let st = self
             .mount
-            .stat(handle, &self.subject)
+            .stat(handle, self.caller()?)
             .await
             .context("mount stat failed")?;
         Ok(Qid { qtype: st.qtype, version: st.version, path: st.path })
@@ -92,6 +145,25 @@ impl MountBackend {
 
 #[async_trait]
 impl Backend for MountBackend {
+    async fn attach(&self, uname: &str) -> Result<()> {
+        // Fixed-subject listeners have no authorizer; the Subject is already
+        // bound and `uname` is advisory (ignored, as on the UDS/vsock paths).
+        let Some(authorizer) = self.authorizer.as_ref() else {
+            return Ok(());
+        };
+        // Attach-time ticket path (H1b): resolve+narrow. A MountError here maps
+        // to an Rlerror errno (PermissionDenied → EACCES) via the translator.
+        let subject = authorizer.authorize(uname).await.map_err(anyhow::Error::new)?;
+        // First attach wins; a second attach on the same connection must not
+        // silently re-scope the session. Ignore a redundant identical set,
+        // reject a conflicting one.
+        match self.subject.set(subject) {
+            Ok(()) => Ok(()),
+            Err(_) if self.subject.get().is_some() => Ok(()),
+            Err(e) => Err(anyhow!("bind session Subject: {e}")),
+        }
+    }
+
     async fn walk(
         &self,
         fid: u32,
@@ -108,7 +180,7 @@ impl Backend for MountBackend {
         let refs: Vec<&str> = new_path.iter().map(String::as_str).collect();
         let handle = self
             .mount
-            .walk(&refs, &self.subject)
+            .walk(&refs, self.caller()?)
             .await
             .context("mount walk failed")?;
 
@@ -128,7 +200,7 @@ impl Backend for MountBackend {
         let handle = guard.as_mut().ok_or_else(|| anyhow!("open: fid {fid} is clunked"))?;
         let mode = lopen_flags_to_mode(flags);
         self.mount
-            .open(handle, mode, &self.subject)
+            .open(handle, mode, self.caller()?)
             .await
             .context("mount open failed")?;
         let qid = self.qid_of(handle).await?;
@@ -140,7 +212,7 @@ impl Backend for MountBackend {
         let guard = entry.handle.lock().await;
         let handle = guard.as_ref().ok_or_else(|| anyhow!("read: fid {fid} is clunked"))?;
         self.mount
-            .read(handle, offset, count, &self.subject)
+            .read(handle, offset, count, self.caller()?)
             .await
             .context("mount read failed")
     }
@@ -150,7 +222,7 @@ impl Backend for MountBackend {
         let guard = entry.handle.lock().await;
         let handle = guard.as_ref().ok_or_else(|| anyhow!("write: fid {fid} is clunked"))?;
         self.mount
-            .write(handle, offset, data, &self.subject)
+            .write(handle, offset, data, self.caller()?)
             .await
             .context("mount write failed")
     }
@@ -161,7 +233,7 @@ impl Backend for MountBackend {
         let handle = guard.as_ref().ok_or_else(|| anyhow!("stat: fid {fid} is clunked"))?;
         let st = self
             .mount
-            .stat(handle, &self.subject)
+            .stat(handle, self.caller()?)
             .await
             .context("mount stat failed")?;
         let is_dir = st.qtype & QTDIR != 0;
@@ -180,7 +252,7 @@ impl Backend for MountBackend {
             let guard = entry.handle.lock().await;
             let handle = guard.as_ref().ok_or_else(|| anyhow!("readdir: fid {fid} is clunked"))?;
             self.mount
-                .readdir(handle, &self.subject)
+                .readdir(handle, self.caller()?)
                 .await
                 .context("mount readdir failed")?
         };
@@ -192,7 +264,7 @@ impl Backend for MountBackend {
         if let Some((_, entry)) = self.fids.remove(&fid) {
             let handle = entry.handle.lock().await.take();
             if let Some(handle) = handle {
-                self.mount.clunk(handle, &self.subject).await;
+                self.mount.clunk(handle, self.caller()?).await;
             }
         }
         Ok(())

--- a/crates/hyprstream-9p/src/translator.rs
+++ b/crates/hyprstream-9p/src/translator.rs
@@ -132,6 +132,25 @@ impl Translator {
         Self::new(Arc::new(MountBackend::new(mount, subject)))
     }
 
+    /// Build a translator that exports `mount`, resolving the session
+    /// [`Subject`] from the mount ticket the client presents in `Tattach.uname`
+    /// via `authorizer` (H1b `/9p` WebTransport plane, #765).
+    ///
+    /// Unlike [`from_mount`](Self::from_mount) — where the caller identity is
+    /// fixed at construction (a UDS/vsock listener serves exactly one tenant) —
+    /// the WebTransport plane serves a cert-pinned mesh session over which a
+    /// tenant proves identity at attach. The `Subject` is bound once, at the
+    /// first successful `Tattach`, and threaded onto every op by
+    /// [`MountBackend`] thereafter; a denied ticket fails the attach with an
+    /// `Rlerror` (see [`MountBackend::with_authorizer`]). Every other layer —
+    /// the serve loop, fid table, errno mapping — is identical to `from_mount`.
+    pub fn from_mount_authorized(
+        mount: Arc<dyn Mount>,
+        authorizer: Arc<dyn crate::mount_backend::AttachAuthorizer>,
+    ) -> Self {
+        Self::new(Arc::new(MountBackend::with_authorizer(mount, authorizer)))
+    }
+
     /// Run a TCP accept loop until the listener errors or is closed.
     ///
     /// Each connection runs on its own task. Errors on one connection do not
@@ -285,7 +304,7 @@ impl Translator {
         let (tag, req) = parse_request(buf).context("decode 9P T-message")?;
         let resp = match req {
             Request::Version { msize, version } => self.handle_version(msize, version),
-            Request::Attach { fid, .. } => self.handle_attach(fid).await?,
+            Request::Attach { fid, uname, .. } => self.handle_attach(fid, &uname).await?,
             // Flush is intercepted in serve_connection before reaching here;
             // this arm is unreachable but kept exhaustive.
             Request::Flush { .. } => Response::Clunk,
@@ -320,7 +339,12 @@ impl Translator {
         Response::Version { msize, version: "9P2000.L".into() }
     }
 
-    async fn handle_attach(&self, fid: u32) -> Result<Response> {
+    async fn handle_attach(&self, fid: u32, uname: &str) -> Result<Response> {
+        // Establish the session first: on the attach-time ticket path (H1b) this
+        // validates `uname` and binds the session Subject; on the fixed-subject
+        // path it is a no-op. A denied ticket returns here and is mapped to an
+        // Rlerror by the serve loop — before any fid or mount handle exists.
+        self.backend.attach(uname).await?;
         // Attach establishes the root fid. Walk the empty path to materialize
         // a root qid from the backend, then record it.
         let walk = self.backend.walk(fid, fid, &[]).await?;
@@ -1085,5 +1109,93 @@ mod tests {
         drop(good);
         server.abort();
         let _ = std::fs::remove_file(&sock);
+    }
+
+    // ── Attach-time mount ticket (H1b / #765) ───────────────────────────
+
+    /// A fake [`AttachAuthorizer`] mirroring the H1b `Tattach.uname` ticket
+    /// check: one fixed ticket string maps to a narrowed Subject; anything else
+    /// is denied with `PermissionDenied` (→ `EACCES`).
+    struct FakeTicketAuth;
+    #[async_trait::async_trait]
+    impl crate::mount_backend::AttachAuthorizer for FakeTicketAuth {
+        async fn authorize(
+            &self,
+            uname: &str,
+        ) -> std::result::Result<hyprstream_rpc::Subject, hyprstream_vfs::MountError> {
+            if uname == "good-ticket" {
+                Ok(hyprstream_rpc::Subject::new("alice"))
+            } else {
+                Err(hyprstream_vfs::MountError::PermissionDenied("bad ticket".into()))
+            }
+        }
+    }
+
+    fn authorized_translator() -> Arc<Translator> {
+        use hyprstream_vfs::{SyntheticMount, SyntheticNode};
+        let root = SyntheticNode::dir()
+            .with_child("hello.txt", SyntheticNode::file(b"hi alice".to_vec()));
+        let mount: Arc<dyn hyprstream_vfs::Mount> = Arc::new(SyntheticMount::new(root));
+        Arc::new(Translator::from_mount_authorized(mount, Arc::new(FakeTicketAuth)))
+    }
+
+    /// A valid ticket in `Tattach.uname` binds the session Subject and the
+    /// attach + subsequent ops succeed (the H1b happy path over the shared
+    /// `handle_message` core).
+    #[tokio::test]
+    async fn attach_ticket_valid_binds_subject_and_serves() {
+        let t = authorized_translator();
+        let (_, resp) = t
+            .handle_message(&msg::tattach(1, 0, u32::MAX, "good-ticket", ""))
+            .await
+            .unwrap();
+        assert!(matches!(resp, Response::Attach { .. }), "valid ticket must attach: {resp:?}");
+
+        // The bound Subject now threads through walk/open/read.
+        let (_, resp) = t.handle_message(&msg::twalk(2, 0, 1, &["hello.txt"])).await.unwrap();
+        assert!(matches!(resp, Response::Walk { .. }), "got {resp:?}");
+        let (_, resp) = t.handle_message(&msg::tlopen(3, 1, 0)).await.unwrap();
+        assert!(matches!(resp, Response::Lopen { .. }), "got {resp:?}");
+        let (_, resp) = t.handle_message(&msg::tread(4, 1, 0, 64)).await.unwrap();
+        match resp {
+            Response::Read { data } => assert_eq!(&data, b"hi alice"),
+            other => panic!("expected Rread, got {other:?}"),
+        }
+    }
+
+    /// An invalid ticket in `Tattach.uname` fails the attach; the translator
+    /// maps the authorizer's `PermissionDenied` to an `Rlerror` `EACCES` — no
+    /// fid or mount handle is ever created.
+    #[tokio::test]
+    async fn attach_ticket_denied_returns_eacces() {
+        let t = authorized_translator();
+        let err = t
+            .handle_message(&msg::tattach(1, 0, u32::MAX, "forged", ""))
+            .await
+            .unwrap_err();
+        assert_eq!(errno_from_error(&err), EACCES, "denied ticket must be EACCES");
+    }
+
+    /// An empty `uname` (no ticket presented) is likewise denied — the ticket is
+    /// mandatory on the WebTransport plane.
+    #[tokio::test]
+    async fn attach_empty_ticket_denied() {
+        let t = authorized_translator();
+        let err = t
+            .handle_message(&msg::tattach(1, 0, u32::MAX, "", ""))
+            .await
+            .unwrap_err();
+        assert_eq!(errno_from_error(&err), EACCES, "missing ticket must be EACCES");
+    }
+
+    /// Fail-closed: an op arriving before a successful attach binds the Subject
+    /// must not reach the mount (the `OnceCell` is unset).
+    #[tokio::test]
+    async fn op_before_attach_fails_closed() {
+        let t = authorized_translator();
+        // No Tattach: a walk cannot resolve a caller and must error, not serve.
+        let err = t.handle_message(&msg::twalk(1, 0, 1, &["hello.txt"])).await.unwrap_err();
+        // Untyped bookkeeping error (no MountError) → EIO, never a success.
+        assert_eq!(errno_from_error(&err), EIO);
     }
 }

--- a/crates/hyprstream-rpc/src/dial.rs
+++ b/crates/hyprstream-rpc/src/dial.rs
@@ -220,6 +220,14 @@ where
 /// streaming plane (default path → RPC). Both server and client use this.
 pub const MOQ_PATH: &str = "/moq";
 
+/// The URL path the daemon's `web_transport_quinn` server dispatches to the 9P
+/// export plane (H1b / #765): the QUIC path-mux sibling of H1a's `/9p` axum
+/// WebSocket endpoint, for the cert-pinned self-signed mesh. A WebTransport
+/// session whose CONNECT URL path is this is handed to the injected 9P handler
+/// (see [`crate::transport::quinn_transport`]); the mount ticket rides
+/// `Tattach.uname`, not the URL, since the session is already cert-pinned.
+pub const NINEP_PATH: &str = "/9p";
+
 /// A dialed moq streaming session, erased over the concrete transport.
 ///
 /// [`dial_stream`] returns this so a caller can dial the streaming plane over

--- a/crates/hyprstream-rpc/src/transport/quinn_transport.rs
+++ b/crates/hyprstream-rpc/src/transport/quinn_transport.rs
@@ -31,6 +31,56 @@ use crate::transport::rpc_session::{
 };
 use crate::transport_traits::Transport;
 
+/// A WebTransport bidi stream carrying a 9P2000.L session, erased to a byte
+/// stream. The H1b `/9p` arm hands one of these to the injected
+/// [`NinePWtHandler`]; the handler runs the transport-agnostic
+/// `Translator::serve_connection` core over it (the same core H1a's WebSocket
+/// pump feeds). Blanket-implemented for any `AsyncRead + AsyncWrite` byte stream
+/// (a joined WT send/recv pair).
+pub trait NinePWtStream:
+    tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin + 'static
+{
+}
+impl<T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin + 'static> NinePWtStream for T {}
+
+/// Serves one 9P session over a WebTransport bidi stream (H1b / #765).
+///
+/// This is the injection seam that keeps the transport crate free of the 9P
+/// core: the concrete impl lives in the `hyprstream` crate (it owns the 9P
+/// `Translator`, the Subject-scoped export mount, and the mount-ticket
+/// validator), and is registered here via [`QuinnRpcServer::with_ninep_handler`]
+/// or the process-global [`set_global_ninep_handler`] — mirroring how the moq
+/// consumer is threaded onto the same endpoint. The mount ticket is validated
+/// at `Tattach.uname` inside the handler (the cert-pinned session carries no URL
+/// query), so this trait exposes only the raw byte stream.
+#[async_trait]
+pub trait NinePWtHandler: Send + Sync {
+    /// Drive the 9P session on `stream` to completion (returns on EOF, the peer
+    /// resetting the stream, or a fatal 9P framing error). The handler owns
+    /// session teardown.
+    async fn serve(&self, stream: Box<dyn NinePWtStream>);
+}
+
+/// Process-global 9P WebTransport handler, populated by the `hyprstream` crate
+/// at server startup (where `ServerState` — hence the export mount + ticket
+/// validator — is available). The per-service `QuinnRpcServer` build site lives
+/// in `hyprstream-service`, which cannot depend on `hyprstream`; a global here
+/// is the same seam the moq origin uses to cross that boundary. First write
+/// wins; later writes are ignored.
+static GLOBAL_NINEP_HANDLER: std::sync::OnceLock<Arc<dyn NinePWtHandler>> =
+    std::sync::OnceLock::new();
+
+/// Register the process-global 9P WebTransport handler (idempotent, first-wins).
+/// Returns `true` if this call installed it, `false` if one was already set.
+pub fn set_global_ninep_handler(handler: Arc<dyn NinePWtHandler>) -> bool {
+    GLOBAL_NINEP_HANDLER.set(handler).is_ok()
+}
+
+/// The process-global 9P WebTransport handler, if one has been registered.
+pub fn global_ninep_handler() -> Option<Arc<dyn NinePWtHandler>> {
+    GLOBAL_NINEP_HANDLER.get().cloned()
+}
+
 /// A quinn-backed WebTransport server for the RPC plane.
 ///
 /// Accepts WebTransport sessions and spawns [`serve_rpc_connection`] for each.
@@ -69,6 +119,12 @@ pub struct QuinnRpcServer {
     /// #276 subscribe-authz + per-tenant announce-scoping config for the `/moq`
     /// plane. Defaults to "off" (open subscribe preserved).
     moq_authz: crate::transport::iroh_moq::MoqAuthzConfig,
+    /// Optional 9P export handler (H1b / #765). When set, sessions whose
+    /// WebTransport CONNECT URL path is [`crate::dial::NINEP_PATH`] are handed to
+    /// it instead of the RPC core. Defaults to [`global_ninep_handler`] at
+    /// construction; `None` = 9P plane off (unknown-path sessions fall through to
+    /// the RPC core, matching pre-H1b behaviour).
+    ninep_handler: Option<Arc<dyn NinePWtHandler>>,
     shutdown: CancellationToken,
 }
 
@@ -103,6 +159,9 @@ impl QuinnRpcServer {
             moq_consumer: None,
             moq_relay_origin: None,
             moq_authz: crate::transport::iroh_moq::MoqAuthzConfig::default(),
+            // Pick up the process-global 9P handler if the `hyprstream` crate
+            // registered one; a builder call can still override it.
+            ninep_handler: global_ninep_handler(),
             shutdown: CancellationToken::new(),
         }
     }
@@ -154,6 +213,18 @@ impl QuinnRpcServer {
         authz: crate::transport::iroh_moq::MoqAuthzConfig,
     ) -> Self {
         self.moq_authz = authz;
+        self
+    }
+
+    /// Serve the 9P export plane on the same endpoint (H1b / #765).
+    ///
+    /// Sessions whose WebTransport CONNECT URL path is [`crate::dial::NINEP_PATH`]
+    /// are handed to `handler` (which runs the 9P `Translator::serve_connection`
+    /// core over the WT bidi stream); all other paths route to the RPC core (or
+    /// the moq plane for `/moq`). Overrides any process-global handler picked up
+    /// at construction.
+    pub fn with_ninep_handler(mut self, handler: Arc<dyn NinePWtHandler>) -> Self {
+        self.ninep_handler = Some(handler);
         self
     }
 
@@ -284,13 +355,16 @@ impl QuinnRpcServer {
                     let moq_consumer = self.moq_consumer.clone();
                     let moq_relay_origin = self.moq_relay_origin.clone();
                     let moq_authz = self.moq_authz.clone();
+                    let ninep_handler = self.ninep_handler.clone();
                     tokio::spawn(async move {
                         let _conn_permit = conn_permit; // released when this connection ends
-                        // Multiplex by WebTransport CONNECT URL path (#274): read
+                        // Multiplex by WebTransport CONNECT URL path (#274, H1b): read
                         // it BEFORE `request.ok()` consumes the request. `/moq`
-                        // → moq streaming plane; any other path → RPC core.
+                        // → moq streaming plane; `/9p` → 9P export plane (#765);
+                        // any other path → RPC core.
                         // (`Request` Derefs to `ConnectRequest`, exposing `url`.)
                         let is_moq = request.url.path() == crate::dial::MOQ_PATH;
+                        let is_ninep = request.url.path() == crate::dial::NINEP_PATH;
                         // Resolve the handshake INSIDE the task, bounded (#162),
                         // so a slow/stalled CONNECT never blocks the accept loop.
                         let session = match tokio::time::timeout(
@@ -397,6 +471,68 @@ impl QuinnRpcServer {
                                     tracing::warn!(
                                         "quinn-rpc: /moq requested but no moq consumer configured"
                                     );
+                                }
+                            }
+                            return;
+                        }
+
+                        if is_ninep {
+                            // 9P export plane (H1b / #765): the QUIC path-mux
+                            // sibling of H1a's axum `/9p` WebSocket. Serve the
+                            // SAME `Translator::serve_connection` core (via the
+                            // injected handler) over a WT bidi stream.
+                            let Some(handler) = ninep_handler else {
+                                tracing::warn!(
+                                    "quinn-rpc: /9p requested but no 9P handler configured"
+                                );
+                                return;
+                            };
+                            // A stream permit bounds concurrency server-wide and
+                            // lets `shutdown` drain the in-flight session (same
+                            // DoS/drain contract as the RPC streams). If the
+                            // semaphore is closed (shutdown drained it), exit.
+                            let _permit = match Arc::clone(&stream_limit).acquire_owned().await {
+                                Ok(p) => p,
+                                Err(_) => return,
+                            };
+                            // Accept the single client-opened bidi stream (bounded
+                            // so a session that never opens one can't pin the
+                            // permit). `RecvStream`/`SendStream` impl tokio
+                            // `AsyncRead`/`AsyncWrite`, so joining them yields the
+                            // byte stream the 9P core serves directly — the WT
+                            // analogue of H1a's ws↔9p pump, tolerant of arbitrary
+                            // chunking.
+                            let accept = tokio::time::timeout(
+                                super::rpc_session::HANDSHAKE_TIMEOUT,
+                                session.accept_bi(),
+                            )
+                            .await;
+                            let (send, recv) = match accept {
+                                Ok(Ok(pair)) => pair,
+                                Ok(Err(e)) => {
+                                    tracing::debug!(error = ?e, "quinn-9p: accept_bi failed");
+                                    return;
+                                }
+                                Err(_) => {
+                                    tracing::warn!("quinn-9p: client opened no bidi stream in time");
+                                    return;
+                                }
+                            };
+                            let stream: Box<dyn NinePWtStream> =
+                                Box::new(tokio::io::join(recv, send));
+                            // Liveness (H1b, mirrors H1a's server-owned teardown):
+                            // the handler's serve loop returns on stream EOF / a
+                            // fatal 9P error; a dead peer is torn down by the
+                            // cert-pinned QUIC session's idle timeout (transport-
+                            // owned, the WT/reach layer) which resets the stream →
+                            // EOF. We also stop on server shutdown and on the WT
+                            // session closing, whichever comes first.
+                            tokio::select! {
+                                biased;
+                                _ = shutdown.cancelled() => {}
+                                _ = handler.serve(stream) => {}
+                                err = session.closed() => {
+                                    tracing::debug!(?err, "quinn-9p: WT session closed");
                                 }
                             }
                             return;

--- a/crates/hyprstream-rpc/tests/wt_ninep_plane.rs
+++ b/crates/hyprstream-rpc/tests/wt_ninep_plane.rs
@@ -1,0 +1,167 @@
+//! `/9p` WebTransport plane path-mux (H1b / #765).
+//!
+//! Proves the third arm of the QUIC WebTransport path mux
+//! (`quinn_transport.rs`): a WebTransport session whose CONNECT URL path is
+//! [`NINEP_PATH`] is routed to the injected [`NinePWtHandler`] (NOT the RPC core
+//! or the `/moq` plane), the client-opened bidi stream is delivered to the
+//! handler as a working `AsyncRead + AsyncWrite` byte stream (the WT analogue of
+//! H1a's ws↔9p pump), and the session is served over a **cert-pinned** WT client
+//! — exactly the reach layer the self-signed mesh uses.
+//!
+//! The 9P core (`Translator::serve_connection` + attach-time `Tattach.uname`
+//! ticket) lives in `hyprstream-9p` and is covered by its own attach tests; this
+//! test isolates the transport arm with an echo handler so no 9P/torch stack is
+//! pulled into `hyprstream-rpc`.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use ed25519_dalek::SigningKey;
+use rand::RngCore;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use hyprstream_rpc::dial::NINEP_PATH;
+use hyprstream_rpc::transport::quinn_transport::{
+    cert_sha256, connect_pinned_hashes_path, NinePWtHandler, NinePWtStream, QuinnRpcServer,
+};
+
+fn fresh_signing_key() -> SigningKey {
+    let mut k = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut k);
+    SigningKey::from_bytes(&k)
+}
+
+/// Loopback `web_transport_quinn` server with a self-signed cert.
+/// Returns (server, bound_addr, leaf_cert_der).
+fn build_server() -> Result<(web_transport_quinn::Server, std::net::SocketAddr, Vec<u8>)> {
+    let cert_key = rcgen::generate_simple_self_signed(vec!["localhost".to_owned()])?;
+    let cert_der = cert_key.cert.der().to_vec();
+    let key_der = cert_key.key_pair.serialize_der();
+
+    let chain = vec![rustls::pki_types::CertificateDer::from(cert_der.clone())];
+    let key = rustls::pki_types::PrivateKeyDer::Pkcs8(
+        rustls::pki_types::PrivatePkcs8KeyDer::from(key_der),
+    );
+
+    let addr: std::net::SocketAddr = "127.0.0.1:0".parse()?;
+    let server = web_transport_quinn::ServerBuilder::new()
+        .with_addr(addr)
+        .with_certificate(chain, key)
+        .map_err(|e| anyhow!("quinn server build: {e}"))?;
+    let bound = server.local_addr()?;
+    Ok((server, bound, cert_der))
+}
+
+/// Handler standing in for the 9P core: records that it was invoked (proving
+/// `/9p` routing) and echoes bytes back over the joined WT bidi stream (proving
+/// the stream is a working duplex the `Translator` could serve).
+struct EchoNineP {
+    invoked: Arc<tokio::sync::Notify>,
+}
+
+#[async_trait]
+impl NinePWtHandler for EchoNineP {
+    async fn serve(&self, mut stream: Box<dyn NinePWtStream>) {
+        self.invoked.notify_one();
+        let mut buf = [0u8; 4096];
+        loop {
+            match stream.read(&mut buf).await {
+                // EOF (peer half-closed) or a read error: clean teardown.
+                Ok(0) | Err(_) => break,
+                Ok(n) => {
+                    if stream.write_all(&buf[..n]).await.is_err() {
+                        break;
+                    }
+                    let _ = stream.flush().await;
+                }
+            }
+        }
+    }
+}
+
+/// A cert-pinned WT session on `/9p` reaches the injected handler; the bidi
+/// stream round-trips bytes both directions.
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn wt_ninep_path_routes_to_handler_and_streams() -> Result<()> {
+    hyprstream_rpc::transport::install_pq_crypto_provider();
+
+    let (server, addr, cert) = build_server()?;
+    let invoked = Arc::new(tokio::sync::Notify::new());
+    let processor =
+        hyprstream_rpc::transport::rpc_session::from_fn(|req: bytes::Bytes| async move { Ok(req) });
+    let rpc = QuinnRpcServer::with_capacity(
+        server,
+        Arc::new(processor),
+        fresh_signing_key(),
+        hyprstream_rpc::transport::rpc_session::DEFAULT_STREAM_LIMIT,
+    )
+    .with_ninep_handler(Arc::new(EchoNineP { invoked: invoked.clone() }));
+    let shutdown = rpc.shutdown_token();
+    let server_task = tokio::spawn(rpc.run());
+
+    // Cert-pinned client dials the `/9p` path (the self-signed-mesh reach).
+    let pin = cert_sha256(&cert);
+    let session = connect_pinned_hashes_path(addr, &[pin], NINEP_PATH).await?;
+
+    // Open the bidi stream the server's `/9p` arm accepts, and round-trip bytes.
+    let (mut send, mut recv) = session.open_bi().await?;
+    send.write_all(b"hello-9p-over-wt").await?;
+
+    let mut got = vec![0u8; b"hello-9p-over-wt".len()];
+    tokio::time::timeout(Duration::from_secs(5), recv.read_exact(&mut got)).await??;
+    assert_eq!(&got, b"hello-9p-over-wt", "echo must round-trip over the WT bidi stream");
+
+    // The handler was actually reached via the `/9p` path (not RPC/moq).
+    tokio::time::timeout(Duration::from_secs(5), invoked.notified()).await?;
+
+    // Clean teardown: dropping the session closes the WT connection; the
+    // handler's serve loop sees EOF and returns (server-owned liveness).
+    drop(session);
+    shutdown.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(5), server_task).await;
+    Ok(())
+}
+
+/// A `/9p` session with no handler configured is declined cleanly (the server
+/// logs and drops it) without disturbing the accept loop — the plane is simply
+/// off. We assert the server task keeps running afterwards.
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn wt_ninep_without_handler_is_declined() -> Result<()> {
+    hyprstream_rpc::transport::install_pq_crypto_provider();
+
+    let (server, addr, cert) = build_server()?;
+    let processor =
+        hyprstream_rpc::transport::rpc_session::from_fn(|req: bytes::Bytes| async move { Ok(req) });
+    // No `.with_ninep_handler(...)` and no process-global registered.
+    let rpc = QuinnRpcServer::with_capacity(
+        server,
+        Arc::new(processor),
+        fresh_signing_key(),
+        hyprstream_rpc::transport::rpc_session::DEFAULT_STREAM_LIMIT,
+    );
+    let shutdown = rpc.shutdown_token();
+    let server_task = tokio::spawn(rpc.run());
+
+    let pin = cert_sha256(&cert);
+    // The CONNECT succeeds (path mux runs post-handshake); the `/9p` arm finds
+    // no handler and returns, resetting the stream. The client's bidi read then
+    // fails — which is the expected "plane off" outcome, not a hang.
+    let session = connect_pinned_hashes_path(addr, &[pin], NINEP_PATH).await?;
+    let (mut send, mut recv) = session.open_bi().await?;
+    let _ = send.write_all(b"ping").await;
+    let mut got = [0u8; 4];
+    let res = tokio::time::timeout(Duration::from_secs(3), recv.read_exact(&mut got)).await;
+    assert!(
+        matches!(res, Ok(Err(_)) | Err(_)),
+        "no-handler /9p must not deliver an echo (stream declined)"
+    );
+
+    // The accept loop is still alive.
+    assert!(!server_task.is_finished(), "accept loop must survive a declined /9p session");
+    shutdown.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(5), server_task).await;
+    Ok(())
+}

--- a/crates/hyprstream/src/server/mod.rs
+++ b/crates/hyprstream/src/server/mod.rs
@@ -34,6 +34,13 @@ pub fn extract_user(auth_user: Option<&Extension<AuthenticatedUser>>) -> String 
 
 /// Create the main application router
 pub fn create_app(state: ServerState) -> Router {
+    // H1b (#765): register the 9P-over-WebTransport handler for the QUIC
+    // path-mux `/9p` arm, co-located with H1a's axum `/9p` WS route below so
+    // both planes share one `ServerState` (export mount + ticket validator).
+    // Idempotent; the per-service QUIC endpoint (built in `hyprstream-service`,
+    // which can't depend on this crate) picks it up via the process-global.
+    routes::ninep::register_ninep_wt_handler(state.clone());
+
     // Clone config for middleware
     let cors_config = state.config.cors.clone();
     let timeout_duration = Duration::from_secs(state.config.request_timeout_secs);

--- a/crates/hyprstream/src/server/routes/ninep.rs
+++ b/crates/hyprstream/src/server/routes/ninep.rs
@@ -57,10 +57,12 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use async_trait::async_trait;
 use futures::{SinkExt, StreamExt};
-use hyprstream_9p::Translator;
+use hyprstream_9p::{AttachAuthorizer, Translator};
+use hyprstream_rpc::transport::quinn_transport::{NinePWtHandler, NinePWtStream};
 use hyprstream_rpc::Subject;
-use hyprstream_vfs::{Mount, SyntheticMount, SyntheticNode};
+use hyprstream_vfs::{Mount, MountError, SyntheticMount, SyntheticNode};
 use serde::{Deserialize, Serialize};
 use tokio::io::{split, AsyncReadExt, AsyncWriteExt};
 use tracing::{debug, info, warn};
@@ -192,6 +194,19 @@ async fn validate_ticket(
     state: &ServerState,
     ticket: &str,
     _headers: &HeaderMap,
+) -> Result<Subject, &'static str> {
+    verify_mount_ticket(state, ticket).await
+}
+
+/// Transport-agnostic core of mount-ticket validation, shared by H1a's
+/// URL-query path ([`validate_ticket`]) and H1b's `Tattach.uname` path
+/// ([`TicketAttachAuthorizer`]). Both present the same `at+jwt` mount ticket;
+/// only *where* it rides differs (WS query vs 9P attach), so the verification —
+/// signature, audience, expiry, revocation (in `verify_token_claims`), then
+/// subject-name validation — is identical.
+async fn verify_mount_ticket(
+    state: &ServerState,
+    ticket: &str,
 ) -> Result<Subject, &'static str> {
     let claims = crate::server::middleware::verify_token_claims(state, ticket).await?;
     let local_issuers: &[&str] = &[&*state.oauth_issuer_url];
@@ -346,6 +361,91 @@ pub(crate) async fn serve_9p_websocket(
         _ = pump => {}
     }
     frame_reader.abort();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// H1b: /9p over WebTransport (QUIC path-mux plane)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Resolves the mount ticket a client presents in `Tattach.uname` to a narrowed
+/// session [`Subject`], reusing H1a's [`verify_mount_ticket`].
+///
+/// This is the attach-time credential seam for the H1b `/9p` WebTransport plane:
+/// the cert-pinned mesh session carries no URL query (and a browser `WebSocket`
+/// can't set headers), so the ticket rides `Tattach.uname` and is validated once
+/// at attach — the per-session analogue of H1a's pre-upgrade check. On denial we
+/// return [`MountError::PermissionDenied`], which the 9P translator maps to an
+/// `Rlerror` (`EACCES`).
+struct TicketAttachAuthorizer {
+    state: ServerState,
+}
+
+#[async_trait]
+impl AttachAuthorizer for TicketAttachAuthorizer {
+    async fn authorize(&self, uname: &str) -> Result<Subject, MountError> {
+        if uname.is_empty() {
+            return Err(MountError::PermissionDenied("missing mount ticket".to_owned()));
+        }
+        match verify_mount_ticket(&self.state, uname).await {
+            Ok(subject) => Ok(subject),
+            Err(reason) => {
+                warn!(reason, "9P WT attach rejected: invalid mount ticket");
+                Err(MountError::PermissionDenied(reason.to_owned()))
+            }
+        }
+    }
+}
+
+/// The injected 9P-over-WebTransport handler (H1b / #765).
+///
+/// Registered process-globally via [`register_ninep_wt_handler`] so the QUIC
+/// path-mux `/9p` arm (`hyprstream-rpc`) can drive hyprstream's 9P core without
+/// that transport crate depending on `hyprstream`. Each WT bidi stream on the
+/// `/9p` path lands in [`NinePWtHandler::serve`], where it is served by the SAME
+/// [`Translator::serve_connection`] core + [`build_export_mount`] as H1a —
+/// only the ticket now rides `Tattach.uname` (validated by
+/// [`TicketAttachAuthorizer`]) and the transport is a QUIC bidi stream.
+pub struct NinePWtExport {
+    state: ServerState,
+}
+
+impl NinePWtExport {
+    /// Build the handler over the server's [`ServerState`] (the ticket-validation
+    /// chain + export mount source).
+    pub fn new(state: ServerState) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl NinePWtHandler for NinePWtExport {
+    async fn serve(&self, stream: Box<dyn NinePWtStream>) {
+        // The export root is Subject-scoped per op by `MountBackend`; the Subject
+        // is bound at `Tattach` from the validated ticket, so the mount is built
+        // Subject-agnostic here (`build_export_mount` ignores the Subject in the
+        // current placeholder root — see its docs; the real #730 namespace is
+        // scoped by the bound Subject once it lands).
+        let mount = build_export_mount(&self.state, &Subject::anonymous());
+        let authorizer: Arc<dyn AttachAuthorizer> =
+            Arc::new(TicketAttachAuthorizer { state: self.state.clone() });
+        let translator = Arc::new(Translator::from_mount_authorized(mount, authorizer));
+        if let Err(e) = translator.serve_connection(stream).await {
+            debug!(error = %e, "9P WT serve loop ended with error");
+        }
+    }
+}
+
+/// Register the process-global 9P-over-WebTransport handler so the QUIC
+/// path-mux `/9p` arm serves this node's export. Idempotent (first-wins);
+/// call once at server startup where [`ServerState`] exists (see
+/// [`crate::server::create_app`]).
+pub fn register_ninep_wt_handler(state: ServerState) {
+    let installed = hyprstream_rpc::transport::quinn_transport::set_global_ninep_handler(
+        Arc::new(NinePWtExport::new(state)),
+    );
+    if installed {
+        info!("registered 9P-over-WebTransport handler (/9p QUIC path-mux, H1b)");
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## H1b — `/9p` WebTransport plane (#765)

The QUIC path-mux sibling of H1a's `/9p` WebSocket endpoint, for the **self-signed
mesh**: a third arm in the `web_transport_quinn` CONNECT-URL path mux (`/moq` vs
RPC → now also `/9p`). It reuses H1a's **exact** 9P core — the transport-agnostic
`Translator::serve_connection` over `build_export_mount`, the typed-errno mapping,
and the mount-ticket validator — so mesh hosts are mountable where `wss://` can't
cert-pin.

Closes #765. **Stacked on #771 (H1a)** — this branch is based on
`ewindisch/764-h1a-9p-over-ws` and reuses H1a's core; it targets `main` and will
rebase down to just the WebTransport arm once #771 merges.

### What it does
- **`/9p` arm in the QUIC WebTransport path mux** (`quinn_transport.rs`): a WT
  session whose CONNECT path is `/9p` (`dial::NINEP_PATH`) accepts one bidi stream
  and runs the same 9P serve core over it. `web_transport_quinn`'s
  `RecvStream`/`SendStream` already impl tokio `AsyncRead`/`AsyncWrite`, so
  `tokio::io::join(recv, send)` is the byte stream the core serves directly — the
  WT analogue of H1a's ws↔9p pump (tolerant of arbitrary chunking).
- **Ticket in `Tattach.uname`** (not a URL query — the cert-pinned session has no
  query and a browser `WebSocket` can't set headers): validated at attach via the
  reused `verify_mount_ticket` (H1a's validator, factored out of the header-taking
  WS path), which narrows the session `Subject`. Denial → `Rlerror EACCES`. This is
  the MAC "extend at attach time, never per-op" interface move: the credential is
  presented once at session establishment and the derived `Subject` is bound for
  the connection.
- **Cert-pinning** comes from the existing WT/reach layer
  (`connect_pinned_hashes_path` / `certHash`) — not reinvented here.
- **Liveness**: the arm selects the handler's serve loop against the WT session
  closing and server shutdown; the serve loop returns on stream EOF / a fatal 9P
  error. A dead peer is torn down by the cert-pinned QUIC session's idle timeout
  (transport-owned — see the design fork below).
- **Same export mount as H1a**: the placeholder `SyntheticMount` pending the
  export-root decision (#730). Inherited unchanged — this PR does not resolve the
  export root (a separate operator decision).

### Reused vs added
**Reused (from H1a, unchanged):** `Translator::serve_connection`, `MountBackend`,
`build_export_mount`, the ticket-validation chain (`verify_token_claims` →
`verify_mount_ticket`), the typed `MountError → errno` mapping.
**Added:** the `/9p` path-mux arm + injected `NinePWtHandler` seam (a
process-global mirroring the moq-consumer seam, since `hyprstream-service` can't
depend on `hyprstream`); an **attach-time** `AttachAuthorizer` on the 9P core (H1a
bound the `Subject` at construction — the mesh binds it from `Tattach.uname`),
threaded via a new default `Backend::attach(uname)` and
`Translator::from_mount_authorized`; the `hyprstream`-side
`NinePWtExport`/`TicketAttachAuthorizer` + `create_app` registration.

### Tests
- `hyprstream-9p` (attach-time ticket, torch-free): valid ticket binds Subject →
  walk/read succeeds; invalid/empty ticket → `EACCES`; op-before-attach fails
  closed. (4 new; full lib suite 18/18.)
- `hyprstream-rpc` `tests/wt_ninep_plane.rs`: a **cert-pinned** WT client on `/9p`
  reaches the injected handler and round-trips bytes over the bidi stream; a `/9p`
  session with no handler is declined without disturbing the accept loop. (2/2.)
- The 9P core and the WT arm are exercised separately (crate boundary:
  `hyprstream-rpc` can't build a `Translator`); their composition is the
  `create_app` global + `QuinnRpcServer` wiring.

### Design fork needing a decision (flagged, not guessed)
**App-level idle timer vs QUIC transport idle for `/9p` liveness.** H1a runs an
app-level `IDLE_TIMEOUT` on its WS pump because a half-open TCP/WS peer never EOFs.
On QUIC the cert-pinned connection's own idle timeout resets the stream → EOF, so
this arm relies on transport-owned liveness (+ `session.closed()` + shutdown
select) rather than duplicating an app timer. This is arguably stronger and simpler
for QUIC, but if reviewers want symmetry with H1a, wiring an app-level idle timer
into `NinePWtExport::serve` is a small follow-up.

_The shared export-root placeholder (`build_export_mount`) and MAC enforcement
wiring are inherited from H1a / #730 and intentionally unchanged here._
