### PR TITLE
fix(auth): verify_token_claims validates against published JWKS/rotation keys, not just the CA key (#777)

### DIFF
--- a/crates/hyprstream/src/auth/key_rotation.rs
+++ b/crates/hyprstream/src/auth/key_rotation.rs
@@ -38,6 +38,53 @@ pub fn global_ml_dsa_verifying_keys() -> std::sync::Arc<std::sync::RwLock<Vec<hy
     }).clone()
 }
 
+/// Live, shared handle to the node's published Ed25519 rotation-slot verifying
+/// keys (drain/active/lead). This is the SAME Ed25519 key set the `/oauth/jwks`
+/// endpoint publishes — the keys that sign rotation-issued at+JWTs (WIT, S6
+/// grant / token-exchange, and any issuance path using the active slot). It is
+/// public-key material only; no signing keys are ever exposed through it.
+///
+/// Consumers (e.g. the shared HTTP validator `verify_token_claims`) hold a clone
+/// and verify locally-issued tokens against these keys in addition to the CA key.
+// Cross-service `Arc<std::sync::RwLock<..>>` contract mirroring the ML-DSA
+// verifying-key list above; intentionally `std::sync::RwLock`, not `parking_lot`.
+#[allow(clippy::disallowed_types)]
+pub type PublishedEd25519Keys = std::sync::Arc<std::sync::RwLock<Vec<ed25519_dalek::VerifyingKey>>>;
+
+/// Global shared Ed25519 published verifying keys (rotation slots).
+///
+/// Populated at OAuth service init from the signing-key store's current slots
+/// and refreshed by the rotation task after each promotion/eviction. The CA key
+/// is NOT included here — callers already hold it separately (`verifying_key`).
+static ED25519_VERIFYING_KEYS: std::sync::OnceLock<PublishedEd25519Keys> = std::sync::OnceLock::new();
+
+/// Get or initialize the global published-Ed25519 verifying-key handle.
+///
+/// Returns a live, shared `Arc` — mutations by the rotation task are visible to
+/// every holder. Starts empty until the OAuth service populates it.
+#[allow(clippy::disallowed_types)]
+pub fn global_ed25519_verifying_keys() -> PublishedEd25519Keys {
+    ED25519_VERIFYING_KEYS
+        .get_or_init(|| std::sync::Arc::new(std::sync::RwLock::new(Vec::new())))
+        .clone()
+}
+
+/// Refresh the global published-Ed25519 verifying keys from a signing-key store
+/// snapshot (all current drain/active/lead slots).
+///
+/// Called at OAuth init and after every rotation so the shared HTTP validator
+/// keeps accepting tokens signed by any currently-published slot.
+pub async fn refresh_ed25519_verifying_keys(store: &SigningKeyStore) {
+    let vks: Vec<ed25519_dalek::VerifyingKey> = store
+        .all_slots_snapshot()
+        .await
+        .iter()
+        .map(|slot| slot.key.verifying_key())
+        .collect();
+    let shared = global_ed25519_verifying_keys();
+    let _ = shared.write().map(|mut guard| *guard = vks);
+}
+
 /// Global ML-DSA signing key store singleton.
 ///
 /// Ensures all services (PolicyService, OAuthService, rotation task) share
@@ -326,6 +373,9 @@ pub fn spawn_rotation_task(
             interval.tick().await;
             let now = chrono::Utc::now().timestamp();
             rotate_jwt_keys(&config, &secrets_dir, &store, now).await;
+            // Keep the shared HTTP validator's published Ed25519 key set current
+            // after every rotation (drain evicted / lead promoted → active).
+            refresh_ed25519_verifying_keys(&store).await;
             if let Some(ref es256) = extra.es256 {
                 rotate_es256_keys(&config, &secrets_dir, es256, now).await;
             }

--- a/crates/hyprstream/src/server/middleware.rs
+++ b/crates/hyprstream/src/server/middleware.rs
@@ -282,6 +282,53 @@ pub async fn rate_limit_middleware(
 /// It does **not** enforce DPoP sender-binding: that is header/scheme-specific
 /// and stays in [`auth_middleware`]. Returns `Err(reason)` with a short,
 /// log-safe reason string on any failure (never leaks token contents).
+/// RFC 7638 JWK thumbprint (the JWKS `kid`) for an Ed25519 verifying key.
+fn ed25519_kid(key: &ed25519_dalek::VerifyingKey) -> String {
+    hyprstream_rpc::auth::jwk_thumbprint(&hyprstream_rpc::auth::JwkThumbprintInput::Ed25519 {
+        x: key.as_bytes(),
+    })
+}
+
+/// Verify a locally-issued JWT against the node's full published key set: the
+/// cluster CA key plus every currently-published Ed25519 rotation slot (the same
+/// key set `/oauth/jwks` publishes). Accepts the token if ANY of these trusted,
+/// node-published keys verifies it — standard JWKS/`kid`-rotation semantics.
+///
+/// Security invariant: only keys the node itself publishes are ever tried. A
+/// token-supplied (`jwk`/embedded) key is NEVER admitted; the `kid` header is
+/// used only as an ordering *hint* to try the matching published key first, and
+/// falls through to the other trusted keys. Audience validation is unchanged —
+/// `jwt::decode` still enforces strict local-issuer audience matching.
+fn decode_local_multi_key(
+    token: &str,
+    ca_key: &ed25519_dalek::VerifyingKey,
+    published_keys: &[ed25519_dalek::VerifyingKey],
+    expected_aud: Option<&str>,
+) -> Result<jwt::Claims, &'static str> {
+    // Candidate set: CA key first, then all published rotation slots. This is the
+    // exact set the JWKS endpoint publishes; nothing else is trusted.
+    let mut candidates: Vec<&ed25519_dalek::VerifyingKey> =
+        Vec::with_capacity(1 + published_keys.len());
+    candidates.push(ca_key);
+    candidates.extend(published_keys.iter());
+
+    // If the JOSE header carries a kid, try the matching published key first
+    // (fast path for the common rotation case). This is a stable reordering
+    // only — every trusted candidate is still attempted, so a token whose kid
+    // is absent/mismatched but which is validly signed by a published key still
+    // verifies. The kid is the RFC 7638 JWK thumbprint the JWKS `kid` uses.
+    if let Some(token_kid) = extract_kid_from_token(token) {
+        candidates.sort_by_key(|k| u8::from(ed25519_kid(k) != token_kid));
+    }
+
+    for key in candidates {
+        if let Ok(claims) = jwt::decode(token, key, expected_aud) {
+            return Ok(claims);
+        }
+    }
+    Err("JWT validation failed")
+}
+
 pub(crate) async fn verify_token_claims(
     state: &ServerState,
     token: &str,
@@ -293,19 +340,35 @@ pub(crate) async fn verify_token_claims(
     // Extract iss for key routing (local node key vs trusted federation peer).
     let iss = extract_iss_from_token(token);
     let local_issuers: &[&str] = &[&*state.oauth_issuer_url];
-    let result = if hyprstream_rpc::auth::is_local_iss(&iss, local_issuers) {
-        jwt::decode(token, &state.verifying_key, Some(&state.resource_url))
+    let claims = if hyprstream_rpc::auth::is_local_iss(&iss, local_issuers) {
+        // Local-issuer tokens may be signed by EITHER the cluster CA key OR any
+        // currently-published rotation slot (the OAuth token endpoint signs with
+        // `active_jwt_signing_key()` → the rotation active slot). Validate against
+        // the same key set the /oauth/jwks endpoint publishes (CA + rotation
+        // slots), accepting if ANY trusted, published key verifies (#777).
+        let published = {
+            let guard = state
+                .published_jwt_verifying_keys
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            guard.clone()
+        };
+        decode_local_multi_key(
+            token,
+            &state.verifying_key,
+            &published,
+            Some(&state.resource_url),
+        )?
     } else {
         if !state.federation_resolver.is_trusted(&iss) {
             return Err("untrusted federation issuer");
         }
         match state.federation_resolver.get_key(&iss).await {
-            Ok(key) => jwt::decode_with_key(token, &key, Some(&state.resource_url)),
+            Ok(key) => jwt::decode_with_key(token, &key, Some(&state.resource_url))
+                .map_err(|_| "JWT validation failed")?,
             Err(_) => return Err("federation key resolution failed"),
         }
     };
-
-    let claims = result.map_err(|_| "JWT validation failed")?;
 
     // JTI revocation check (RFC 7009) — shared blocklist with the OAuth
     // revocation endpoint.
@@ -520,5 +583,134 @@ mod tests {
 
         // Garbage input
         assert_eq!(extract_iss_from_token("notavalidtoken"), "");
+    }
+}
+
+/// Rotation/JWKS-aware local-token validation (#777).
+///
+/// Proves `decode_local_multi_key` accepts a token signed by ANY currently
+/// published key (CA or rotation slot) and rejects unpublished keys / wrong
+/// audience, and that the shared jti-revocation check still rejects a
+/// validly-decoded token.
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod rotation_aware_tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+
+    const AUD: &str = "https://node-a/resource";
+
+    fn now() -> i64 {
+        chrono::Utc::now().timestamp()
+    }
+
+    fn new_key() -> SigningKey {
+        SigningKey::generate(&mut rand::rngs::OsRng)
+    }
+
+    /// Build a locally-issued at+JWT signed by `key`, with the given audience and
+    /// optional explicit jti (`jwt::encode` auto-assigns a random jti otherwise).
+    fn signed_token(key: &SigningKey, aud: &str, jti: Option<&str>) -> String {
+        let n = now();
+        let mut claims = jwt::Claims::new("alice".to_owned(), n, n + 3600)
+            .with_audience(Some(aud.to_owned()));
+        if let Some(j) = jti {
+            claims.jti = Some(j.to_owned());
+        }
+        jwt::encode(&claims, key)
+    }
+
+    #[test]
+    fn rotation_active_slot_verifies() {
+        // Token signed by a rotation slot that is NOT the CA key — this is the
+        // exact case that 401'd before #777.
+        let ca = new_key();
+        let rotation = new_key();
+        let token = signed_token(&rotation, AUD, None);
+        let published = vec![rotation.verifying_key()];
+
+        let claims =
+            decode_local_multi_key(&token, &ca.verifying_key(), &published, Some(AUD)).unwrap();
+        assert_eq!(claims.sub, "alice");
+    }
+
+    #[test]
+    fn ca_key_signed_token_still_verifies() {
+        // CA-signed token must still verify — even with no rotation slots published.
+        let ca = new_key();
+        let token = signed_token(&ca, AUD, None);
+
+        let claims = decode_local_multi_key(&token, &ca.verifying_key(), &[], Some(AUD)).unwrap();
+        assert_eq!(claims.sub, "alice");
+    }
+
+    #[test]
+    fn unpublished_random_key_rejected() {
+        // A token signed by a key the node never published must be rejected — the
+        // core security invariant (only trusted, published keys are ever tried).
+        let ca = new_key();
+        let rotation = new_key();
+        let attacker = new_key();
+        let token = signed_token(&attacker, AUD, None);
+        let published = vec![rotation.verifying_key()];
+
+        let err = decode_local_multi_key(&token, &ca.verifying_key(), &published, Some(AUD))
+            .unwrap_err();
+        assert_eq!(err, "JWT validation failed");
+    }
+
+    #[test]
+    fn wrong_audience_rejected() {
+        // Correct (published) key but wrong audience → still rejected. Strict
+        // local-issuer audience validation is unchanged.
+        let ca = new_key();
+        let rotation = new_key();
+        let token = signed_token(&rotation, "https://evil/other", None);
+        let published = vec![rotation.verifying_key()];
+
+        let err = decode_local_multi_key(&token, &ca.verifying_key(), &published, Some(AUD))
+            .unwrap_err();
+        assert_eq!(err, "JWT validation failed");
+    }
+
+    #[test]
+    fn revoked_jti_still_rejected() {
+        // A rotation-signed token decodes cleanly, but the shared jti-blocklist
+        // check `verify_token_claims` performs after decode still rejects it.
+        use hyprstream_rpc::auth::{InMemoryJtiBlocklist, JtiBlocklist as _};
+
+        let ca = new_key();
+        let rotation = new_key();
+        let token = signed_token(&rotation, AUD, Some("jti-777"));
+        let published = vec![rotation.verifying_key()];
+
+        let claims =
+            decode_local_multi_key(&token, &ca.verifying_key(), &published, Some(AUD)).unwrap();
+        assert_eq!(claims.jti.as_deref(), Some("jti-777"));
+
+        let blocklist = InMemoryJtiBlocklist::new();
+        blocklist.revoke("jti-777".to_owned(), now() + 3600);
+        // This mirrors the exact post-decode check in `verify_token_claims`.
+        assert!(blocklist.is_revoked(claims.jti.as_deref().unwrap()));
+    }
+
+    #[test]
+    fn kid_hint_finds_rotation_slot_behind_ca() {
+        // The rotation slot is listed after the CA candidate; the kid-preference
+        // reorder must still locate and verify against it (it also verifies
+        // without any kid, since every candidate is tried).
+        let ca = new_key();
+        let rotation = new_key();
+        let token = signed_token(&rotation, AUD, None);
+        // Token header carries the rotation key's RFC 7638 thumbprint as kid.
+        assert_eq!(
+            extract_kid_from_token(&token).as_deref(),
+            Some(ed25519_kid(&rotation.verifying_key()).as_str()),
+        );
+        let published = vec![rotation.verifying_key()];
+
+        let claims =
+            decode_local_multi_key(&token, &ca.verifying_key(), &published, Some(AUD)).unwrap();
+        assert_eq!(claims.sub, "alice");
     }
 }

--- a/crates/hyprstream/src/server/state.rs
+++ b/crates/hyprstream/src/server/state.rs
@@ -35,8 +35,20 @@ pub struct ServerState {
     /// Ed25519 signing key for creating JWT tokens
     pub signing_key: Arc<SigningKey>,
 
-    /// Ed25519 verifying key for validating JWT tokens (derived from signing_key)
+    /// Ed25519 verifying key for validating JWT tokens (derived from signing_key).
+    ///
+    /// This is the cluster CA key. Locally-issued at+JWTs may instead be signed by
+    /// a rotation slot (see `published_jwt_verifying_keys`), so token validation
+    /// tries this key AND the published rotation keys.
     pub verifying_key: Arc<VerifyingKey>,
+
+    /// Live, shared handle to the node's published Ed25519 rotation-slot verifying
+    /// keys — the SAME set the `/oauth/jwks` endpoint publishes. Locally-issued
+    /// tokens signed by the OAuth rotation active/lead/drain slots (WIT, S6 grant /
+    /// token-exchange, WITs) verify against these in addition to `verifying_key`.
+    /// Only node-published public keys are ever admitted here (never token-supplied
+    /// keys). Populated + kept current by the key-rotation task.
+    pub published_jwt_verifying_keys: crate::auth::key_rotation::PublishedEd25519Keys,
 
     /// Context store for RAG/CAG (optional)
     pub context_store: Option<Arc<ContextStore<hyprstream_metrics::storage::duckdb::DuckDbBackend>>>,
@@ -113,6 +125,12 @@ impl ServerState {
         // issued by PolicyService can be verified correctly.
         let verifying_key = Arc::new(jwt_verifying_key);
 
+        // Live handle to the node's published Ed25519 rotation-slot verifying keys.
+        // Shared with the OAuth key-rotation task so tokens signed by the active
+        // rotation slot (not the CA key) still validate here.
+        let published_jwt_verifying_keys =
+            crate::auth::key_rotation::global_ed25519_verifying_keys();
+
         // Preload models for faster first request
         if !config.preload_models.is_empty() {
             tracing::info!("Preloading {} models", config.preload_models.len());
@@ -148,6 +166,7 @@ impl ServerState {
             metrics,
             signing_key,
             verifying_key,
+            published_jwt_verifying_keys,
             context_store: None, // Initialize via enable_context_store() if needed
             resource_url,
             oauth_issuer_url,

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -594,6 +594,12 @@ impl Spawnable for OAuthService {
                     );
                     let store_arc = Arc::new(store);
 
+                    // Publish the current Ed25519 rotation-slot verifying keys to the
+                    // process-shared handle so the OAI/HTTP validator (`verify_token_claims`)
+                    // accepts tokens signed by any active/lead/drain slot from startup —
+                    // before the first rotation tick. Mirrors the /oauth/jwks key set.
+                    crate::auth::key_rotation::refresh_ed25519_verifying_keys(&store_arc).await;
+
                     // Spawn the background rotation task (rotates all algorithm stores).
                     crate::auth::key_rotation::spawn_rotation_task(
                         Arc::clone(&oauth_config_arc),


### PR DESCRIPTION
## Summary

Fixes #777. The shared HTTP token validator `verify_token_claims`
(`server/middleware.rs`) decoded local-issuer tokens against **only**
`state.verifying_key` — the single cluster CA key. But the OAuth issuance paths
that use `OAuthState::active_jwt_signing_key()` sign with the rotation store's
**active slot**, not the CA key. Any rotation-slot-signed token therefore failed
the signature check → `"JWT validation failed"` → 401, on `/9p` and every
endpoint sharing this validator.

Surfaced by the www S6 wire-scope e2e against PR #771 — see
#764 comment https://github.com/hyprstream/hyprstream/issues/764#issuecomment-4883770697
(a valid, resource-bound PKCE at+JWT 401'd at the `/9p` upgrade; audience matched,
purely the key).

## Fix

The local-issuer branch now validates against the **same key set the
`/oauth/jwks` endpoint publishes** — the cluster CA key **plus** every current
Ed25519 rotation slot (drain/active/lead) — accepting the token if ANY published
key verifies it (standard JWKS/`kid`-rotation semantics).

- New `decode_local_multi_key` helper: tries the CA key + published rotation
  keys; if the JOSE header carries a `kid` it tries the matching published key
  first (ordering *hint* only — every trusted candidate is still attempted).
  Only node-published keys are ever admitted; a token-supplied `jwk`/embedded
  key is NEVER trusted.
- `ServerState` gains `published_jwt_verifying_keys`: a live, shared handle
  (`Arc<RwLock<Vec<VerifyingKey>>>`, public keys only) mirroring the existing
  `global_ml_dsa_verifying_keys` pattern. Populated at OAuth init from the
  signing-key store's slots and refreshed by the key-rotation task after every
  promotion/eviction, so it stays current across rotations. No private/signing
  key material is placed in `ServerState`.

**Unchanged (verified by tests + preserved code):** strict local-issuer audience
validation (`Some(&state.resource_url)`), the JTI-revocation blocklist check,
malformed-token rejection, and the entire federation-issuer branch
(`federation_resolver`). DPoP untouched.

## Tests

`server::middleware::rotation_aware_tests` (all green):
- rotation active-slot-signed token verifies (the case that 401'd)
- CA-key-signed token still verifies
- token signed by an unpublished/random key rejected
- wrong-audience rejected (strict aud unchanged)
- revoked-JTI still rejected
- kid hint locates a rotation slot listed behind the CA candidate

## Build gate
- `cargo check -p hyprstream --lib` — clean
- `cargo test -p hyprstream --lib server::middleware` — 7 passed
- `cargo clippy -p hyprstream --all-targets -- -D warnings` — clean

## Stacking
PR base is `main` but this is **stacked on #771** (and #764 / the H1a
`ewindisch/764-h1a-9p-over-ws` branch where `verify_token_claims` was factored,
not yet on main). Rebase onto main after #771 merges. Not blocking the #771
wire/discovery/errno work.
