### PR TITLE
test(registry): record XET provenance in merkle entitlement tests (fix red main)

### DIFF
--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -3556,6 +3556,16 @@ mod tests {
         )
         .await;
 
+        // Mirror the authenticated write path (putBlob calls xet_provenance.record):
+        // the repo legitimately contributed MERKLE_A's bytes, so the authoritative
+        // provenance gate is satisfied. Reconstruction/pointer match is the
+        // second gate.
+        service
+            .xet_provenance
+            .record(MERKLE_A, &repo_id.0.to_string())
+            .await
+            .expect("test: record provenance");
+
         let permitted = service
             .repo_contains_xet_merkle(&repo_id, MERKLE_A)
             .await
@@ -3592,6 +3602,16 @@ mod tests {
             &[("model.safetensors", &legit_pointer), ("planted.txt", &planted)],
         )
         .await;
+
+        // Bind only the legitimately-contributed content (MERKLE_A), as the
+        // authenticated putBlob write path would. MERKLE_B was never authentically
+        // written by this repo, so it stays unbound: the authoritative provenance
+        // gate denies it regardless of the planted reference in the tree.
+        service
+            .xet_provenance
+            .record(MERKLE_A, &repo_id.0.to_string())
+            .await
+            .expect("test: record provenance");
 
         let denied = service
             .repo_contains_xet_merkle(&repo_id, MERKLE_B)


### PR DESCRIPTION
Fixes the two failing XET merkle-entitlement tests on `main` (`test_xet_merkle_permitted_when_file_reconstructs_from_it`, `test_xet_merkle_denied_for_planted_reference`). Main's post-merge test CI has been red on these since ~2026-07-04 15:00.

## Root cause — stale test, **not** a security regression
`repo_contains_xet_merkle` has two gates, both required:
1. authoritative provenance — `xet_provenance.is_bound(merkle, repo)`, fail-closed;
2. defense-in-depth — reconstruction/pointer walk.

The tests came from #436 (2026-06-24) and set up only gate 2 (git-lfs pointers). The `is_bound` gate was added ahead of the walk by #654 (`99b003dbf`, 2026-07-02) **without updating these tests**, so gate 1 denied everything (nothing was ever `record()`ed) and both tests failed — including the legitimate MERKLE_A permit case.

**Production is unaffected and correctly fail-closed:** the authenticated `putBlob` write path (`registry.rs:1839`) *does* call `xet_provenance.record(merkle, repo)`, so real content is bound and reads work; planted references are denied at gate 1. The tests just never simulated the write-path binding.

It slipped past PR CI because the test suite runs only on push/merge_group, not on pull_request.

## The fix
Record `MERKLE_A` (mirroring the write path) in both tests. Local `cargo nextest run -p hyprstream`: **904 passed, 0 failed** (was 902/2-fail).

## ⚠️ For reviewer — coverage note (not a correctness issue)
With the provenance gate in front, the deny case is now enforced at gate 1 (MERKLE_B is unbound) *before* the gate-2 reconstruction walk runs. So the **planted-reference / reconstruction defense (#436's gate 2) is no longer exercised by a passing assertion** — it's now untested defense-in-depth. Binding MERKLE_B to force gate 2 would contradict the scenario (a provenance-bound "planted" merkle is a contradiction). Decide whether to add a dedicated gate-2 test (a bound-but-non-reconstructable merkle) or consciously accept gate 2 as defense-in-depth.