### PR TITLE
spike(#810): SHA-256 not viable — libgit2 ABI-unsafe, gix has no SHA-256, no hybrid unlock

### DIFF
--- a/crates/git2db/examples/spike_sha256.rs
+++ b/crates/git2db/examples/spike_sha256.rs
@@ -40,6 +40,25 @@
 //! coordinated fork of BOTH `libgit2-sys` (define + rewrite `git_oid` struct + all
 //! sha256-gated extern signatures) AND `git2-rs` (its safe `Oid` hardcodes 20-byte/40-hex
 //! SHA-1), tracking an explicitly-unstable upstream ABI. See PR body for cost/recommendation.
+//!
+//! ## Phase 3 (libgit2 + gix HYBRID) — result: does NOT unlock SHA-256
+//!
+//! Reverse probe (`gix::open` where libgit2 failed). A throwaway `spike_gix.rs` example
+//! with a `gix = "0.70"` dev-dep opened SHA-1 and SHA-256 repos built by system git:
+//!
+//! ```text
+//! gix on SHA-1 repo:   OPEN OK; object_hash=Sha1; commit/tree/revwalk read OK; sees
+//!                      new refs+objects written by git/libgit2 on the same .git (read interop OK)
+//! gix on SHA-256 repo: gix::open ERR "Failed to load the git configuration"
+//!                      caused by: The key "extensions.objectFormat=sha256" was invalid
+//! ```
+//!
+//! Root cause: `gix_hash::Kind` is **SHA-1-only** — `enum Kind { Sha1 = 1 }` with no
+//! `Sha256` variant, in every currently-published gix (checked gix-hash 0.16 / 0.17 / 0.18,
+//! i.e. up through gix ~0.85). `try_into_object_format` hard-rejects `sha256`. So gix cannot
+//! read a SHA-256 repo either; a libgit2+gix hybrid does NOT unlock SHA-256 today — the map
+//! and interop findings are in the PR body. (Reproduce: add `gix = "0.70"` dev-dep + a
+//! `gix::open(path)` probe.)
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::print_stdout)]
 
 fn main() {

--- a/crates/git2db/examples/spike_sha256.rs
+++ b/crates/git2db/examples/spike_sha256.rs
@@ -19,6 +19,27 @@
 //! i.e. NOT CAPABLE — libgit2 rejects the repo at `Repository::open` because it was
 //! not compiled with `GIT_EXPERIMENTAL_SHA256`. A SHA-1 repo opens fine. See the PR
 //! body for the full writeup and the upgrade path that would unblock W1.
+//!
+//! ## Phase 2 (compile-time enable) — result: ABI-UNSAFE, still not viable
+//!
+//! Patching the vendored `libgit2-sys` build to define `GIT_EXPERIMENTAL_SHA256`
+//! (a `cc::Build::define(...)` on the C compile; the crate uses `cc`, not cmake — there
+//! is no `EXPERIMENTAL_SHA256` cmake knob and no feature/env knob exposed) makes the C
+//! library accept sha256 repos, and `Repository::open` then succeeds. BUT the flag is
+//! ABI-breaking: with it, C `struct git_oid` becomes `{ unsigned char type; unsigned char
+//! id[32]; }` (33 bytes), while libgit2-sys's Rust binding still declares `{ id: [u8; 20] }`
+//! and gates nothing on the flag. Result — every OID read is corrupted, for BOTH sha256
+//! AND previously-working sha1 repos:
+//!
+//! ```text
+//! sha256 real HEAD:  eea50b3...0dca157b (64 hex)  → git2-rs read: eea50b34...337692ff  → commit NOT FOUND
+//! sha1   real HEAD:  c162c8f...335c6112d (40 hex)  → git2-rs read: c162c8f...335c611fc  → commit NOT FOUND (REGRESSED)
+//! ```
+//!
+//! So a libgit2-sys-only C define is unsafe and regresses SHA-1. A real enable needs a
+//! coordinated fork of BOTH `libgit2-sys` (define + rewrite `git_oid` struct + all
+//! sha256-gated extern signatures) AND `git2-rs` (its safe `Oid` hardcodes 20-byte/40-hex
+//! SHA-1), tracking an explicitly-unstable upstream ABI. See PR body for cost/recommendation.
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::print_stdout)]
 
 fn main() {

--- a/crates/git2db/examples/spike_sha256.rs
+++ b/crates/git2db/examples/spike_sha256.rs
@@ -1,0 +1,54 @@
+//! SPIKE (#810 / epic #809, W1): can our pinned git2-rs / vendored libgit2 open a
+//! SHA-256 object-format repository at all?
+//!
+//! Reproduction harness. Usage:
+//!
+//! ```sh
+//! git init --object-format=sha256 /tmp/sha256repo
+//! git -C /tmp/sha256repo -c user.email=a@b.c -c user.name=a commit \
+//!     --allow-empty -m init
+//! cargo run -p git2db --example spike_sha256 -- /tmp/sha256repo
+//! ```
+//!
+//! Result on git2 0.20.3 + vendored libgit2-sys 0.18.3 (libgit2 1.9.2):
+//!
+//! ```text
+//! OPEN ERR: class=Repository code=Invalid msg=unknown object format 'sha256'
+//! ```
+//!
+//! i.e. NOT CAPABLE — libgit2 rejects the repo at `Repository::open` because it was
+//! not compiled with `GIT_EXPERIMENTAL_SHA256`. A SHA-1 repo opens fine. See the PR
+//! body for the full writeup and the upgrade path that would unblock W1.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::print_stdout)]
+
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .expect("usage: spike_sha256 <repo-path>");
+    match git2::Repository::open(&path) {
+        Ok(repo) => {
+            println!("OPEN OK");
+            if let Ok(head) = repo.head() {
+                if let Some(oid) = head.target() {
+                    println!("HEAD OID: {} (len={})", oid, oid.to_string().len());
+                    match repo.find_commit(oid) {
+                        Ok(c) => println!("READ COMMIT OK: {:?}", c.summary()),
+                        Err(e) => println!("READ COMMIT ERR: {e}"),
+                    }
+                }
+            }
+            if let Ok(cfg) = repo.config() {
+                match cfg.get_string("extensions.objectformat") {
+                    Ok(v) => println!("extensions.objectFormat = {v}"),
+                    Err(e) => println!("objectFormat read ERR: {e}"),
+                }
+            }
+        }
+        Err(e) => println!(
+            "OPEN ERR: class={:?} code={:?} msg={}",
+            e.class(),
+            e.code(),
+            e.message()
+        ),
+    }
+}


### PR DESCRIPTION
# SPIKE #810 (epic #809, W1) — SHA-256 object-format feasibility

Three phases, each gating the next. **Bottom line: there is no low-cost path to SHA-256 in git2db today. libgit2 can't (default), enabling it natively is ABI-unsafe, and gix can't read SHA-256 at all — so a libgit2+gix hybrid does not unlock it either.** This is a human re-plan decision for #809.

| Phase | Question | Verdict |
|-------|----------|---------|
| 1 | Does the default vendored libgit2 open a sha256 repo? | ❌ NOT CAPABLE (`unknown object format 'sha256'` at `Repository::open`) |
| 2 | Can we enable it at compile time? | ⚠️ Compiles, but ABI-UNSAFE — corrupts every OID incl. SHA-1 (regression). Needs a dual libgit2-sys + git2-rs fork of an unstable upstream ABI |
| 3 | Does a libgit2+gix **hybrid** unlock it? | ❌ NO — gix (all published versions) is SHA-1-only; it cannot read a sha256 repo, so there is nothing to divide labor with |

---

## Phase 3 — libgit2 + gix hybrid map

**Premise tested:** gix owns SHA-256-aware read/plumbing (the #810 driver), libgit2 keeps worktree/checkout + the XET filter, both on the same `.git`. **The premise fails at step one:** gix has no SHA-256 support.

### Empirical gix probe (reverse of phase 1)
`gix = "0.70"` dev-dep + a `gix::open` probe, on repos built by system git 2.54.0:

```
gix on SHA-1 repo:    OPEN OK; object_hash=Sha1; commit + tree + revwalk read OK
gix on SHA-256 repo:  gix::open ERR "Failed to load the git configuration"
                      caused by: The key "extensions.objectFormat=sha256" was invalid
```

Root cause is structural, not a feature flag: `gix_hash::Kind` is **SHA-1 only** —
```rust
pub enum Kind { Sha1 = 1 }   // no Sha256 variant
```
and `extensions::ObjectFormat::try_into_object_format` returns `Err` for anything but `"sha1"`. Verified across **gix-hash 0.16, 0.17, and 0.18** (i.e. up through gix ~0.85, the newest available). gitoxide has SHA-256 as a long-standing *tracked-but-unimplemented* item; the whole `gix-hash`/`gix-object`/`gix-odb` type stack is `Sha1`-fixed today.

### On-disk interop (the one thing that DID hold — for SHA-1)
Both gix and libgit2 use the standard on-disk format, so **reads interoperate on SHA-1**: gix opened repos written by `git`/libgit2 and, after a new commit was written on the same `.git`, gix re-read the updated HEAD/refs/objects and revwalk correctly. This confirms the general mechanism — but it is moot for #810 because neither tool speaks SHA-256.

### git2db operation map (op → who can do it)
Grouped as plumbing vs porcelain/integration; "gix SHA-256" is the column that matters for #810.

| Surface | Call sites (git2db) | libgit2 today | gix today | gix **SHA-256** |
|---|---|---|---|---|
| **Plumbing** ||||
| object read (commit/tree/blob) | `repository_handle.rs`, `storage/driver.rs` `find_commit/find_tree` | ✅ | ✅ mature (SHA-1) | ❌ no Sha256 Kind |
| revwalk / graph | `branch.rs`, driver | ✅ | ✅ mature (SHA-1) | ❌ |
| refs read/write | `references.rs`, `branch.rs` | ✅ | ✅ read; write ok | ❌ (oid is SHA-1) |
| index (add/write-tree) | `driver.rs`/`repository_handle.rs` `.index()` → `find_tree` → `commit` | ✅ | ⚠️ partial/less mature | ❌ |
| object **write** / commit | `.commit(...)` (driver, handle) | ✅ | ⚠️ improving, less battle-tested | ❌ |
| **Porcelain / integration** ||||
| worktree add + checkout | `manager.rs` `create_git_worktree`, `WorktreeAddOptions`, `CheckoutBuilder` | ✅ | ⚠️ `gix-worktree` checkout is newer/narrower | ❌ |
| **clean/smudge filter pipeline (XET)** | `git-xet-filter` FFI `git_filter_register`, `git_filter_source_*`, streaming write API | ✅ **libgit2-only** | ❌ **no equivalent global filter-registration hook** | ❌ |
| storage drivers (overlay2/vfs/reflink) | `storage/overlay2.rs`, `vfs.rs` | FS + libgit2 worktree | n/a (FS layer) | n/a |
| remote fetch/push, transport | `remote.rs`, `git2::transport` (custom gittorrent transport) | ✅ | ⚠️ has own transport stack | ❌ |

### The XET filter is the hard libgit2 anchor
`git-xet-filter` is **literally a libgit2 filter**: it calls `git_filter_register` and implements libgit2's `git_filter` vtable (`check`/`stream`, `git_filter_source_mode/_flags/_repo/_path`, libgit2 write-stream). This is the mechanism that auto-smudges model weights during checkout. **gix exposes no equivalent global clean/smudge filter-registration surface** that XET could hang on — this pipeline is libgit2-only and would have to stay there in any hybrid, regardless of hash.

### Verdict on the hybrid
**A libgit2+gix hybrid does not cleanly unlock SHA-256 — it does not unlock it at all.** The only unique value gix could add (SHA-256-aware object-format read/plumbing — the entire reason to bring it in for #810) does not exist in any shipped gix. What gix *can* do (SHA-1 plumbing) is already covered by libgit2, so adding gix for #810 would be a second backend with **zero** SHA-256 benefit — exactly the multi-backend outcome the operator ruled out. libgit2 must stay for worktree/checkout/XET-filter/storage; gix has nothing to divide.

### Recommended architecture
**Do not adopt gix for #810.** Neither native-libgit2-enable (phase 2, ABI-unsafe) nor a gix hybrid (phase 3, no SHA-256) works today. Options for #809 to weigh, in order:
1. **Defer SHA-256 in git2db** and keep the phase-1 posture: detect `extensions.objectFormat`, and where a repo is sha256, **label it** (the ticket's MAC-assurance-hint intent) and refuse the *git2 read path* gracefully rather than corrupt — do **not** claim read support. (This is a small, safe increment that does not require any SHA-256 engine.)
2. **Shell out to system `git`** (2.54.0 handles sha256 fully) for the narrow sha256 read/interop paths, if/when needed — process boundary, no ABI/type-system risk.
3. **Track gitoxide SHA-256 upstream** and revisit a gix-owns-sha256-plumbing / libgit2-owns-checkout+XET hybrid **once `gix_hash::Kind` actually gains `Sha256`** end-to-end (open + odb read + refs). The hybrid seam is sound *in principle* (on-disk read interop works); it is blocked purely on gix capability.
4. A coordinated libgit2-sys + git2-rs experimental-ABI fork (phase 2) remains the only "native in-process" route and carries whole-workspace ABI + maintenance risk — not recommended.

### Risks
- **gix write/index/checkout maturity** is behind libgit2 even for SHA-1; a hybrid that let gix write shared index/refs while libgit2 holds a live worktree would risk index/ref races — the boundary must be **gix read-only on quiescent state**, never concurrent writers on a live index/worktree.
- The XET filter's libgit2 dependency is non-negotiable in any hybrid; SHA-256 support would still have to reach the *filter/checkout* path, which is the least-supported area in gix.

---

<details><summary>Phase 2 — compile-time enable (ABI-unsafe), full evidence</summary>

`libgit2-sys 0.18.3` builds libgit2 with **`cc::Build`, not cmake** (no `EXPERIMENTAL_SHA256` cmake var, no feature/env knob). Minimal enable = `cfg.define("GIT_EXPERIMENTAL_SHA256", "1")` in its `build.rs` via `[patch.crates-io] libgit2-sys = { path = ... }`. C compiles clean; git2 0.20.3 builds unchanged. But the flag changes C `struct git_oid` from `{id[20]}` to `{unsigned char type; unsigned char id[32]}` (33 bytes) while libgit2-sys's Rust binding still declares `{id:[u8;20]}` and gates nothing — silent ABI mismatch:

```
sha256 real HEAD: eea50b3...0dca157b (64hex) → git2-rs: eea50b34...337692ff → commit NOT FOUND
sha1   real HEAD: c162c8f...335c6112d (40hex) → git2-rs: c162c8f...335c611fc → commit NOT FOUND (REGRESSED)
```
A libgit2-sys-only define corrupts data and regresses SHA-1; real enable needs a coordinated libgit2-sys + git2-rs fork of an explicitly-unstable upstream ABI, with whole-workspace blast radius.
</details>

<details><summary>Phase 1 — default build NOT CAPABLE, full evidence</summary>

`git2 0.20.3` / `libgit2-sys 0.18.3+1.9.2` (libgit2 1.9.2), `vendored-libgit2`. `build.rs` defines only the SHA-256 *hash backend* (`GIT_SHA256_OPENSSL`/`_BUILTIN`), never `GIT_EXPERIMENTAL_SHA256`. `git2` crate exposes no object-format API (only SSH cert hashes). Empirical: `Repository::open` on a `git init --object-format=sha256` repo → `class=Repository code=Invalid msg=unknown object format 'sha256'`; SHA-1 control opens/reads fine. libgit2 rejects the repo *at open*, before any object read.
</details>

### Deliverable in this PR
Reproduction harness `crates/git2db/examples/spike_sha256.rs` (all three phases documented in its module doc; re-runnable). The phase-2 `spike-vendor` fork and phase-3 `gix` dev-dep + `spike_gix.rs` probe were throwaway and are **not** committed (reproduction steps are in the doc comment). No API changes; `git2db::Oid` still re-exports `git2::Oid` (SHA-1).

Refs #810, #809.
