### PR TITLE
fix(gittorrent): parse tree-entry hash size from object format, not a hardcoded 20 (#811)

### DIFF
--- a/crates/gittorrent/src/git/objects.rs
+++ b/crates/gittorrent/src/git/objects.rs
@@ -1,6 +1,6 @@
 //! Git object utilities for GitTorrent SHA256 operations
 
-use crate::{types::{GitHash, Sha256Hash, GitRefs}, Result, Error};
+use crate::{types::{GitHash, ObjectFormat, Sha256Hash, GitRefs}, Result, Error};
 use crate::crypto::hash::sha256_git;
 use std::path::Path;
 use std::collections::HashMap;
@@ -263,8 +263,15 @@ pub fn parse_commit_object(data: &[u8]) -> Result<CommitObject> {
     })
 }
 
-/// Parse a tree object from git format
-pub fn parse_tree_object(data: &[u8]) -> Result<TreeObject> {
+/// Parse a tree object from git format.
+///
+/// Tree entries store the referenced OID in **binary** form, which is not
+/// self-describing: a SHA-1 repository uses 20-byte OIDs and a SHA-256
+/// repository uses 32-byte OIDs. The caller must supply the repository's
+/// [`ObjectFormat`] — typically derived from the tree object's own hash
+/// (`GitHash::object_format`) — so the entries are sliced at the correct
+/// width instead of a hardcoded 20.
+pub fn parse_tree_object(data: &[u8], format: ObjectFormat) -> Result<TreeObject> {
     // Parse git object header: "tree <size>\0<content>"
     let null_pos = data.iter().position(|&b| b == 0)
         .ok_or_else(|| Error::other("Invalid git object format"))?;
@@ -301,9 +308,10 @@ pub fn parse_tree_object(data: &[u8]) -> Result<TreeObject> {
             _ => return Err(Error::other(format!("Unknown tree entry mode: {mode_str}"))),
         };
 
-        // Hash is either 20 bytes (SHA1) or 32 bytes (SHA256) after the null terminator
-        // Git currently uses SHA1 (20 bytes), but may switch to SHA256 (32 bytes) in the future
-        let hash_size = 20; // SHA1 for now
+        // Hash is 20 bytes (SHA1) or 32 bytes (SHA256) after the null terminator.
+        // The width is not encoded in the tree object itself, so it comes from the
+        // repository's object format (carried in by the caller).
+        let hash_size = format.hash_len();
         if content.len() < null_pos + 1 + hash_size {
             return Err(Error::other("Tree entry missing hash"));
         }
@@ -342,8 +350,12 @@ pub fn parse_blob_object(data: &[u8]) -> Result<Vec<u8>> {
     Ok(data[null_pos + 1..].to_vec())
 }
 
-/// Parse object references from git object data
-pub fn parse_object_references(object_data: &[u8]) -> Result<Vec<GitHash>> {
+/// Parse object references from git object data.
+///
+/// `format` is the repository's object format, needed to slice binary tree
+/// entries at the correct OID width. Callers derive it from the hash of the
+/// object being parsed (`GitHash::object_format`).
+pub fn parse_object_references(object_data: &[u8], format: ObjectFormat) -> Result<Vec<GitHash>> {
     // Determine object type and parse accordingly
     let null_pos = object_data.iter().position(|&b| b == 0)
         .ok_or_else(|| Error::other("Invalid git object format"))?;
@@ -356,7 +368,7 @@ pub fn parse_object_references(object_data: &[u8]) -> Result<Vec<GitHash>> {
         refs.extend(commit.parent_hashes);
         Ok(refs)
     } else if header.starts_with("tree ") {
-        let tree = parse_tree_object(object_data)?;
+        let tree = parse_tree_object(object_data, format)?;
         Ok(tree.entries.into_iter().map(|e| e.hash).collect())
     } else {
         // Blobs and tags don't reference other objects
@@ -531,7 +543,8 @@ pub fn checkout_tree<'a>(
     let tree_record = dht.get_object(tree_key).await?
         .ok_or_else(|| crate::Error::not_found("Tree not found"))?;
 
-    let tree = parse_tree_object(&tree_record.data)?;
+    // Tree entries use the same object format as the tree's own hash.
+    let tree = parse_tree_object(&tree_record.data, tree_hash.object_format())?;
 
     for entry in tree.entries {
         let entry_path = path.join(&entry.name);
@@ -815,11 +828,79 @@ pub async fn restore_git_refs(repo_path: &Path, refs: &GitRefs) -> Result<()> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use git2::Repository;
     use tempfile::TempDir;
     use std::fs;
+
+    /// Build the raw bytes of a git tree object with a single entry whose OID
+    /// is `oid` bytes wide, e.g. `"tree <size>\0100644 file\0<oid...>"`.
+    fn make_tree_object(name: &str, oid: &[u8]) -> Vec<u8> {
+        let mut content = Vec::new();
+        content.extend_from_slice(b"100644 ");
+        content.extend_from_slice(name.as_bytes());
+        content.push(0);
+        content.extend_from_slice(oid);
+
+        let mut object = format!("tree {}\0", content.len()).into_bytes();
+        object.extend_from_slice(&content);
+        object
+    }
+
+    #[test]
+    fn test_parse_tree_object_sha256_oid() {
+        // A SHA-256 repository stores 32-byte OIDs in tree entries.
+        let oid = [0xABu8; 32];
+        let object = make_tree_object("modern.txt", &oid);
+
+        let tree = parse_tree_object(&object, ObjectFormat::Sha256).unwrap();
+        assert_eq!(tree.entries.len(), 1);
+        let entry = &tree.entries[0];
+        assert_eq!(entry.name, "modern.txt");
+        assert_eq!(entry.hash, GitHash::Sha256(oid));
+        assert_eq!(entry.hash.to_hex(), hex::encode(oid));
+    }
+
+    #[test]
+    fn test_parse_tree_object_sha1_oid() {
+        // A SHA-1 repository stores 20-byte OIDs; the legacy path must still work.
+        let oid = [0x11u8; 20];
+        let object = make_tree_object("legacy.txt", &oid);
+
+        let tree = parse_tree_object(&object, ObjectFormat::Sha1).unwrap();
+        assert_eq!(tree.entries.len(), 1);
+        let entry = &tree.entries[0];
+        assert_eq!(entry.name, "legacy.txt");
+        assert_eq!(entry.hash, GitHash::Sha1(oid));
+    }
+
+    #[test]
+    fn test_parse_tree_object_sha256_with_sha1_width_is_wrong() {
+        // Regression guard for the hardcoded-20 bug: parsing a 32-byte-OID tree
+        // as SHA-1 must NOT silently yield the correct 32-byte hash.
+        let oid = [0xABu8; 32];
+        let object = make_tree_object("modern.txt", &oid);
+
+        // Parsing at the wrong (20-byte) width must not silently recover the
+        // correct 32-byte hash: it either errors or yields a corrupt entry.
+        // Threading the real object format is what avoids this.
+        if let Ok(tree) = parse_tree_object(&object, ObjectFormat::Sha1) {
+            assert_ne!(tree.entries[0].hash, GitHash::Sha256(oid));
+        }
+    }
+
+    #[test]
+    fn test_object_format_hash_len() {
+        assert_eq!(ObjectFormat::Sha1.hash_len(), 20);
+        assert_eq!(ObjectFormat::Sha256.hash_len(), 32);
+        assert_eq!(GitHash::Sha1([0u8; 20]).object_format(), ObjectFormat::Sha1);
+        assert_eq!(
+            GitHash::Sha256([0u8; 32]).object_format(),
+            ObjectFormat::Sha256
+        );
+    }
 
     #[tokio::test]
     async fn test_extract_objects() -> std::result::Result<(), Box<dyn std::error::Error>> {

--- a/crates/gittorrent/src/service.rs
+++ b/crates/gittorrent/src/service.rs
@@ -497,8 +497,10 @@ impl GitTorrentService {
             if let Some(data) = self.get_object(&sha256_hash).await? {
                 objects.push(data.clone());
 
-                // Parse object to find referenced objects (returns GitHash)
-                let referenced = self.parse_object_references(&data)?;
+                // Parse object to find referenced objects (returns GitHash).
+                // The object we just fetched was keyed by `hash`, whose variant
+                // tells us the repository object format for binary tree entries.
+                let referenced = self.parse_object_references(&data, hash.object_format())?;
                 to_fetch.extend(referenced);
             }
         }
@@ -506,10 +508,17 @@ impl GitTorrentService {
         Ok(objects)
     }
 
-    /// Parse an object to find hash references to other objects
-    fn parse_object_references(&self, object_data: &[u8]) -> Result<Vec<crate::types::GitHash>> {
+    /// Parse an object to find hash references to other objects.
+    ///
+    /// `format` is the repository's object format (from the fetched object's
+    /// own hash), used to slice binary tree entries at the correct OID width.
+    fn parse_object_references(
+        &self,
+        object_data: &[u8],
+        format: crate::types::ObjectFormat,
+    ) -> Result<Vec<crate::types::GitHash>> {
         use crate::git::objects::parse_object_references;
-        parse_object_references(object_data)
+        parse_object_references(object_data, format)
     }
 
     /// Clone a repository from a GitTorrent URL

--- a/crates/gittorrent/src/types.rs
+++ b/crates/gittorrent/src/types.rs
@@ -105,6 +105,46 @@ impl GitHash {
     pub fn is_sha1(&self) -> bool {
         matches!(self, GitHash::Sha1(_))
     }
+
+    /// Object format (hash algorithm) this hash belongs to.
+    pub fn object_format(&self) -> ObjectFormat {
+        ObjectFormat::from(self)
+    }
+}
+
+/// Git repository object format (hash algorithm).
+///
+/// Git objects that embed references in **binary** form (notably tree
+/// entries) do not self-describe their hash width, so the width must be
+/// carried from the surrounding context (the object's own hash, or the
+/// repository's `extensions.objectFormat`). This enum makes that context
+/// explicit so a SHA-256 repository is not parsed with a hardcoded 20-byte
+/// (SHA-1) OID width.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ObjectFormat {
+    /// SHA1 object format (20-byte raw OIDs) - legacy git format.
+    Sha1,
+    /// SHA256 object format (32-byte raw OIDs) - modern git format.
+    Sha256,
+}
+
+impl ObjectFormat {
+    /// Raw hash width in bytes for this object format (SHA1 = 20, SHA256 = 32).
+    pub const fn hash_len(self) -> usize {
+        match self {
+            ObjectFormat::Sha1 => 20,
+            ObjectFormat::Sha256 => 32,
+        }
+    }
+}
+
+impl From<&GitHash> for ObjectFormat {
+    fn from(hash: &GitHash) -> Self {
+        match hash {
+            GitHash::Sha1(_) => ObjectFormat::Sha1,
+            GitHash::Sha256(_) => ObjectFormat::Sha256,
+        }
+    }
 }
 
 impl std::fmt::Display for GitHash {

--- a/crates/gittorrent/tests/integration_test.rs
+++ b/crates/gittorrent/tests/integration_test.rs
@@ -125,7 +125,9 @@ mod tests {
         let tree_obj = objects.iter()
             .find(|obj| obj.object_type == GitObjectType::Tree)
             .ok_or("No tree object found")?;
-        let parsed_tree = parse_tree_object(&tree_obj.data)?;
+        // The tree uses the same object format as the commit that references it.
+        let parsed_tree =
+            parse_tree_object(&tree_obj.data, parsed_commit.tree_hash.object_format())?;
 
         assert_eq!(parsed_tree.entries.len(), 1);
         assert_eq!(parsed_tree.entries[0].name, "sample.txt");


### PR DESCRIPTION
## Summary

`parse_tree_object` (`gittorrent/src/git/objects.rs`) sliced tree-entry OIDs at a **hardcoded 20-byte** (SHA-1) width. Tree objects embed their references in binary, which is not self-describing — a SHA-256 object-format repository (32-byte OIDs) parsed **garbage silently**: corruption, not an error.

## Fix

- Add `ObjectFormat` (`Sha1`/`Sha256`) in `types.rs` with `hash_len()` (20/32) and `GitHash::object_format()`.
- Thread the repository object format into `parse_tree_object` and `parse_object_references` instead of the constant `20`.
- Callers derive the format from the hash of the object being parsed (`GitHash::object_format`):
  - `checkout_tree` — from the tree's own hash.
  - the `service.rs` merkle-traversal loop — from the fetched object's DHT key hash.
  - `integration_test.rs` — from the referencing commit's tree hash.
- Unit tests: a 32-byte-OID tree entry parses correctly, a 20-byte one still does, and parsing a SHA-256 tree at the wrong (SHA-1) width does not silently recover the correct hash.

### Design note — how object format reaches the parser
Commit objects reference their tree/parents as **hex text**, so `GitHash::from_hex` already auto-detects the width there. Tree entries are binary and inherit the repo's object format. In this codebase every object is reached via its hash (the DHT/merkle key), and that `GitHash` variant carries the format — so the format is always available at each parse site with no new plumbing beyond passing it down. No new wrong constant (`32`) was introduced; SHA-1 remains fully supported.

## Test
- `cargo check -p gittorrent` — clean
- `cargo clippy -p gittorrent --all-targets -- -D warnings` — clean
- `cargo test -p gittorrent` — 45 lib tests pass (incl. new `test_parse_tree_object_sha256_oid`, `_sha1_oid`, `_sha256_with_sha1_width_is_wrong`, `test_object_format_hash_len`)

Refs #811, epic #809 (W1).