### PR TITLE
feat(k8s) K1: Helm chart — service-per-Deployment over QUIC/iroh (#779)

### DIFF
--- a/charts/hyprstream/.helmignore
+++ b/charts/hyprstream/.helmignore
@@ -1,0 +1,8 @@
+.DS_Store
+.git/
+.gitignore
+*.tmp
+*.bak
+*.swp
+# tests/ holds golden renders used by CI, not chart runtime assets.
+tests/

--- a/charts/hyprstream/Chart.yaml
+++ b/charts/hyprstream/Chart.yaml
@@ -1,0 +1,28 @@
+apiVersion: v2
+name: hyprstream
+description: |
+  HyprStream on Kubernetes — one Deployment per service, communicating over the
+  networked transport (QUIC/iroh), never over shared-volume UDS. This is the K1
+  deployment substrate (epic #778, issue #779): the base every other K8s axis
+  (identity, CSI, operator, serving) is layered on top of.
+type: application
+
+# Chart version — bump on chart changes.
+version: 0.1.0
+
+# The hyprstream image tag this chart targets by default (see values.yaml image.tag).
+# Overridable per-install; this is only the default when image.tag is empty.
+appVersion: "0.1.0"
+
+keywords:
+  - hyprstream
+  - inference
+  - plan9
+  - quic
+  - iroh
+home: https://github.com/hyprstream/hyprstream
+sources:
+  - https://github.com/hyprstream/hyprstream
+maintainers:
+  - name: hyprstream
+    url: https://github.com/hyprstream/hyprstream

--- a/charts/hyprstream/README.md
+++ b/charts/hyprstream/README.md
@@ -79,9 +79,48 @@ Secrets created by the bootstrap/wizard flow or an external-secrets controller.
 `HYPRSTREAM__OAUTH__ISSUER_URL` and must match the issuer stamped into the
 pre-generated service JWTs.
 
-## Extension hooks (separate issues — not implemented here)
+## Observability (K1b, #784)
 
-- `observability.*` → **#784 (K1b)**: OTel Collector → Prometheus exposition.
+`observability.enabled=true` (default off) deploys a standalone **OpenTelemetry
+Collector** (Deployment + ConfigMap + Service) and wires every service to push
+OTLP traces to it (`HYPRSTREAM_OTEL_ENABLE=true`, `OTEL_EXPORTER_OTLP_ENDPOINT`,
+and per-Deployment `OTEL_SERVICE_NAME`).
+
+hyprstream's `otel` feature is OTLP-**push**, **traces only** — it has no native
+`/metrics` surface (an explicit non-goal of #784). The collector closes that gap:
+its `spanmetrics` connector derives RED metrics (request rate / errors / latency)
+from the incoming spans and its `prometheus` exporter exposes them for scraping.
+
+```bash
+helm install hyprstream charts/hyprstream --set observability.enabled=true \
+  --namespace hyprstream --create-namespace
+kubectl -n hyprstream port-forward svc/hyprstream-otel-collector 8889:8889
+curl http://localhost:8889/metrics    # hyprstream_traces_span_metrics_calls_total, ..._duration_milliseconds_*
+```
+
+The `spanmetrics` connector emits `traces.span.metrics.calls` (counter) and
+`..duration` (histogram); the prometheus exporter's `namespace` prefixes them,
+so the scrapeable series are `hyprstream_traces_span_metrics_calls_total` and
+`hyprstream_traces_span_metrics_duration_milliseconds_{bucket,count,sum}`,
+labelled by `service_name` plus the configured `dimensions` (route/method/status).
+
+| Value | Default | Purpose |
+|-------|---------|---------|
+| `observability.enabled` | `false` | Master toggle (env wiring + collector). |
+| `observability.otelExporterOtlpEndpoint` | `""` | Override; empty ⇒ the in-cluster collector Service. |
+| `observability.collector.enabled` | `true` | Deploy the bundled collector (false ⇒ env-only, point at an external one). |
+| `observability.collector.image.*` | contrib `0.128.0` | Contrib distro (needed for `spanmetrics`). |
+| `observability.collector.ports.prometheus` | `8889` | Prometheus exposition port (`/metrics`). |
+| `observability.collector.prometheusNamespace` | `hyprstream` | Metric name prefix. |
+| `observability.collector.dimensions` | route/method/status | Span attrs promoted to metric labels. |
+| `observability.collector.serviceMonitor.enabled` | `false` | Emit a kube-prometheus-stack `ServiceMonitor` (needs the Prometheus Operator CRD). |
+
+**Autoscaling signal (K6a, #792).** The `/metrics` endpoint is the scaling signal
+source: point `prometheus-adapter` or the KEDA prometheus scaler at it to drive an
+HPA on e.g. `hyprstream_traces_span_metrics_calls_total` request rate. Which spans hyprstream emits
+today (and which scaling signals — stream backpressure/queue depth, tokens/s —
+still need instrumentation) are tracked as follow-ups under #792; this chart only
+delivers the exposition surface.
 
 ## Image assumption
 

--- a/charts/hyprstream/README.md
+++ b/charts/hyprstream/README.md
@@ -53,10 +53,32 @@ Values are documented inline in `values.yaml`. Highlights:
   set `accessModes: [ReadWriteMany]` for multi-node).
 - `config.*` — shared `HYPRSTREAM__*` env (rendered into a ConfigMap).
 
+## Key/trust bootstrap
+
+Set `keyBootstrap.enabled=true` to mount the flat credential directory expected
+by `HYPRSTREAM__SECRETS__PATH`. The chart projects externally generated Secrets
+instead of minting identity material in Helm templates.
+
+Required Secret layout:
+
+- Shared trust Secret: `ca-pubkey`, `bootstrap-pubkeys`.
+- Non-policy service credential Secrets: `signing-key`, `service-jwt`.
+- Policy service credential Secret: `signing-key`.
+- Policy CA Secret: `ca-key`.
+
+Omitted per-service Secret names default to
+`<release>-hyprstream-<service>-credentials`. The shared trust Secret defaults to
+`<release>-hyprstream-trust`, and the policy CA Secret defaults to
+`<release>-hyprstream-policy-ca`. Use `keyBootstrap.trust.existingSecret`,
+`keyBootstrap.serviceSecrets`, and `keyBootstrap.policyCaSecret` to bind
+Secrets created by the bootstrap/wizard flow or an external-secrets controller.
+
+`keyBootstrap.issuerUrl`, when set, is exposed to every service as
+`HYPRSTREAM__OAUTH__ISSUER_URL` and must match the issuer stamped into the
+pre-generated service JWTs.
+
 ## Extension hooks (separate issues — not implemented here)
 
-- `keyBootstrap.*` → **#783 (K1a)**: per-service signing-key Secrets, trust store,
-  node DID. This chart only reserves the shape + a stable `HYPRSTREAM__SECRETS__PATH`.
 - `observability.*` → **#784 (K1b)**: OTel Collector → Prometheus exposition.
 
 ## Image assumption
@@ -75,6 +97,5 @@ the RPC resolver / discovery lookup so `for_service("policy")` dials
 multi-process model resolves peers to UDS paths in a shared runtime dir (same-host
 only), and QUIC is a WebTransport/announce plane with no static peer-address
 config. This chart delivers the deployment substrate (Phase 0); a working
-end-to-end install additionally needs that app-side wiring and the #783 key/trust
-bootstrap. The chart itself contains **no shared-volume IPC**, per the #778
-non-goal.
+end-to-end install additionally needs that app-side wiring. The chart itself
+contains **no shared-volume IPC**, per the #778 non-goal.

--- a/charts/hyprstream/README.md
+++ b/charts/hyprstream/README.md
@@ -1,0 +1,80 @@
+# hyprstream Helm chart
+
+Deploys hyprstream to Kubernetes as **one Deployment + one ClusterIP Service per
+service** ("service-per-Deployment"). Services address each other by Kubernetes
+DNS Service name over the networked transport (QUIC over UDP / iroh) — never over
+shared-volume Unix-domain sockets. This is the K1 deployment substrate (epic
+#778, issue #779).
+
+## Quick start
+
+```bash
+helm install hyprstream charts/hyprstream --namespace hyprstream --create-namespace
+kubectl -n hyprstream port-forward svc/hyprstream-oai 6789:6789
+curl http://localhost:6789/v1/models
+```
+
+## Service set
+
+The chart models the real inventory-registered factories
+(`crates/hyprstream/src/services/factories.rs`). Map keys are the exact service
+names passed to `hyprstream service start <name> --foreground`.
+
+| Service | Kind | Default | Notes |
+|---------|------|---------|-------|
+| policy | rpc (QUIC/UDP) | on | Casbin policy + CA |
+| discovery | rpc | on | endpoint resolution |
+| registry | rpc | on | git2db model registry |
+| model | rpc | on | inference; `variant: cpu\|cuda\|rocm` |
+| event | moq | on | group-keyed event bus |
+| streams | moq | on | token stream origin |
+| oai | http (TCP) | on | OpenAI-compat API, `/health` probe |
+| oauth | http+quic | off | OAuth 2.1 |
+| mcp | http+quic | off | Model Context Protocol |
+| xet | http | off | HF-XET CAS face |
+| flight | grpc | off | Arrow Flight SQL |
+| metrics | rpc | off | DuckDB metrics |
+| tui | rpc | off | TUI display server |
+| worker | rpc | off | sandbox backends — **needs elevated privilege** |
+
+Default-enabled set matches the #779 acceptance path plus transitive
+dependencies (discovery).
+
+## Configuration
+
+Values are documented inline in `values.yaml`. Highlights:
+
+- `image.repository` / `image.tag` — container image (see assumption below).
+- `services.<name>.enabled` — per-service toggle.
+- `services.model.variant` — `cpu` (default) / `cuda` / `rocm`; appends the image
+  suffix and is where you add `resources.limits.nvidia.com/gpu` +
+  `nodeSelector` for GPU nodes.
+- `persistence.*` — the shared `/var/lib/hyprstream` data volume (RWO by default;
+  set `accessModes: [ReadWriteMany]` for multi-node).
+- `config.*` — shared `HYPRSTREAM__*` env (rendered into a ConfigMap).
+
+## Extension hooks (separate issues — not implemented here)
+
+- `keyBootstrap.*` → **#783 (K1a)**: per-service signing-key Secrets, trust store,
+  node DID. This chart only reserves the shape + a stable `HYPRSTREAM__SECRETS__PATH`.
+- `observability.*` → **#784 (K1b)**: OTel Collector → Prometheus exposition.
+
+## Image assumption
+
+No published image reference exists in-repo yet — only a local multi-variant
+`Dockerfile` (distroless CPU/CUDA/ROCm stages) that tags nothing. `image.repository`
+defaults to a **placeholder** (`ghcr.io/hyprstream/hyprstream`) and `image.tag`
+defaults to `Chart.appVersion`. Override for your registry, or wire CI to publish
+there.
+
+## Known gap (Phase 0)
+
+Cross-pod QUIC service-to-service **peer resolution** — feeding K8s DNS names into
+the RPC resolver / discovery lookup so `for_service("policy")` dials
+`hyprstream-policy` — is not yet wired in hyprstream itself: the current
+multi-process model resolves peers to UDS paths in a shared runtime dir (same-host
+only), and QUIC is a WebTransport/announce plane with no static peer-address
+config. This chart delivers the deployment substrate (Phase 0); a working
+end-to-end install additionally needs that app-side wiring and the #783 key/trust
+bootstrap. The chart itself contains **no shared-volume IPC**, per the #778
+non-goal.

--- a/charts/hyprstream/README.md
+++ b/charts/hyprstream/README.md
@@ -52,6 +52,8 @@ Values are documented inline in `values.yaml`. Highlights:
 - `persistence.*` — the shared `/var/lib/hyprstream` data volume (RWO by default;
   set `accessModes: [ReadWriteMany]` for multi-node).
 - `config.*` — shared `HYPRSTREAM__*` env (rendered into a ConfigMap).
+- `config.tls.enabled` — false by default so in-cluster HTTP probes and the
+  port-forward quick start use plain HTTP on the oai Service port.
 
 ## Key/trust bootstrap
 

--- a/charts/hyprstream/templates/NOTES.txt
+++ b/charts/hyprstream/templates/NOTES.txt
@@ -21,4 +21,18 @@ IMPORTANT (Phase 0 substrate):
   * Per-service signing-key Secrets / trust store projection is available with
     keyBootstrap.enabled. Provide pre-generated Secrets; the chart does not mint
     signing keys or service JWTs.
-  * OTel Collector / Prometheus exposition: TODO(#784), gated by observability.enabled.
+{{- if .Values.observability.enabled }}
+
+Observability (K1b, #784) is ENABLED:
+  * Every service pushes OTLP traces to {{ include "hyprstream.otlpEndpoint" . }}.
+{{- if .Values.observability.collector.enabled }}
+  * OTel Collector {{ include "hyprstream.collectorName" . }} derives RED metrics
+    (request rate / errors / latency) from spans and exposes them for scraping:
+      kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "hyprstream.collectorName" . }} {{ .Values.observability.collector.ports.prometheus }}:{{ .Values.observability.collector.ports.prometheus }}
+      curl http://localhost:{{ .Values.observability.collector.ports.prometheus }}/metrics
+    Metrics are prefixed `{{ .Values.observability.collector.prometheusNamespace }}_` (e.g. {{ .Values.observability.collector.prometheusNamespace }}_traces_span_metrics_calls_total).
+    Feed this endpoint to prometheus-adapter/KEDA to drive an HPA (K6a, #792).
+{{- end }}
+{{- else }}
+  * OTel Collector / Prometheus exposition: available via observability.enabled=true (K1b, #784).
+{{- end }}

--- a/charts/hyprstream/templates/NOTES.txt
+++ b/charts/hyprstream/templates/NOTES.txt
@@ -17,7 +17,8 @@ IMPORTANT (Phase 0 substrate):
   * Cross-pod QUIC service-to-service *peer resolution* (feeding K8s DNS names into
     the RPC resolver / discovery lookup) is not yet wired in hyprstream itself.
     This chart provisions the deployment substrate; a working end-to-end install
-    also needs that app-side wiring plus the key/trust bootstrap from #783 (K1a).
-  * Per-service signing-key Secrets / trust store / node DID: TODO(#783), gated by
-    keyBootstrap.enabled.
+    also needs that app-side wiring.
+  * Per-service signing-key Secrets / trust store projection is available with
+    keyBootstrap.enabled. Provide pre-generated Secrets; the chart does not mint
+    signing keys or service JWTs.
   * OTel Collector / Prometheus exposition: TODO(#784), gated by observability.enabled.

--- a/charts/hyprstream/templates/NOTES.txt
+++ b/charts/hyprstream/templates/NOTES.txt
@@ -1,0 +1,23 @@
+HyprStream deployed as {{ include "hyprstream.fullname" . }} in namespace {{ .Release.Namespace }}.
+
+Enabled services (one Deployment + ClusterIP Service each):
+{{- range $name, $svc := .Values.services }}
+{{- if $svc.enabled }}
+  - {{ printf "%s-%s" (include "hyprstream.fullname" $) $name }}  ({{ $svc.kind }})
+{{- end }}
+{{- end }}
+
+Services address each other by DNS Service name over QUIC/iroh (no shared-volume UDS).
+
+Reach the OpenAI-compatible API (if oai is enabled):
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "hyprstream.fullname" . }}-oai 6789:6789
+  curl http://localhost:6789/v1/models
+
+IMPORTANT (Phase 0 substrate):
+  * Cross-pod QUIC service-to-service *peer resolution* (feeding K8s DNS names into
+    the RPC resolver / discovery lookup) is not yet wired in hyprstream itself.
+    This chart provisions the deployment substrate; a working end-to-end install
+    also needs that app-side wiring plus the key/trust bootstrap from #783 (K1a).
+  * Per-service signing-key Secrets / trust store / node DID: TODO(#783), gated by
+    keyBootstrap.enabled.
+  * OTel Collector / Prometheus exposition: TODO(#784), gated by observability.enabled.

--- a/charts/hyprstream/templates/_helpers.tpl
+++ b/charts/hyprstream/templates/_helpers.tpl
@@ -78,3 +78,26 @@ suffix. Usage: include "hyprstream.image" (dict "root" $ "svc" $svc)
 {{- end -}}
 {{- printf "%s:%s%s" $img.repository $tag $suffix -}}
 {{- end }}
+
+{{/*
+Shared trust Secret name.
+*/}}
+{{- define "hyprstream.trustSecretName" -}}
+{{- default (printf "%s-trust" (include "hyprstream.fullname" .)) .Values.keyBootstrap.trust.existingSecret -}}
+{{- end }}
+
+{{/*
+Per-service credential Secret name.
+Usage: include "hyprstream.serviceCredentialSecretName" (dict "root" $ "name" $name)
+*/}}
+{{- define "hyprstream.serviceCredentialSecretName" -}}
+{{- $default := printf "%s-%s-credentials" (include "hyprstream.fullname" .root) .name -}}
+{{- default $default (index .root.Values.keyBootstrap.serviceSecrets .name) -}}
+{{- end }}
+
+{{/*
+Policy CA Secret name.
+*/}}
+{{- define "hyprstream.policyCaSecretName" -}}
+{{- default (printf "%s-policy-ca" (include "hyprstream.fullname" .)) .Values.keyBootstrap.policyCaSecret -}}
+{{- end }}

--- a/charts/hyprstream/templates/_helpers.tpl
+++ b/charts/hyprstream/templates/_helpers.tpl
@@ -1,0 +1,80 @@
+{{/*
+Chart name (overridable).
+*/}}
+{{- define "hyprstream.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Fully qualified app name.
+*/}}
+{{- define "hyprstream.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "hyprstream.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "hyprstream.labels" -}}
+helm.sh/chart: {{ include "hyprstream.chart" . }}
+{{ include "hyprstream.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels (chart-wide).
+*/}}
+{{- define "hyprstream.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "hyprstream.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "hyprstream.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "hyprstream.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Per-service object name: <fullname>-<serviceName>.
+Usage: include "hyprstream.svcName" (dict "root" $ "name" $name)
+*/}}
+{{- define "hyprstream.svcName" -}}
+{{- printf "%s-%s" (include "hyprstream.fullname" .root) .name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Resolve the container image for a service, applying the per-service variant
+suffix. Usage: include "hyprstream.image" (dict "root" $ "svc" $svc)
+*/}}
+{{- define "hyprstream.image" -}}
+{{- $img := .root.Values.image -}}
+{{- $tag := default .root.Chart.AppVersion $img.tag -}}
+{{- $variant := .svc.variant | default "" -}}
+{{- $suffix := "" -}}
+{{- if $variant -}}
+{{- $suffix = index $img.variants $variant | default "" -}}
+{{- end -}}
+{{- printf "%s:%s%s" $img.repository $tag $suffix -}}
+{{- end }}

--- a/charts/hyprstream/templates/_helpers.tpl
+++ b/charts/hyprstream/templates/_helpers.tpl
@@ -65,6 +65,25 @@ Usage: include "hyprstream.svcName" (dict "root" $ "name" $name)
 {{- end }}
 
 {{/*
+OTel Collector object name: <fullname>-otel-collector.
+*/}}
+{{- define "hyprstream.collectorName" -}}
+{{- printf "%s-otel-collector" (include "hyprstream.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+The OTLP endpoint services push traces to. Explicit override wins; otherwise the
+in-cluster collector Service (gRPC/tonic on the OTLP gRPC port).
+*/}}
+{{- define "hyprstream.otlpEndpoint" -}}
+{{- if .Values.observability.otelExporterOtlpEndpoint -}}
+{{- .Values.observability.otelExporterOtlpEndpoint -}}
+{{- else -}}
+{{- printf "http://%s:%v" (include "hyprstream.collectorName" .) .Values.observability.collector.ports.otlpGrpc -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Resolve the container image for a service, applying the per-service variant
 suffix. Usage: include "hyprstream.image" (dict "root" $ "svc" $svc)
 */}}

--- a/charts/hyprstream/templates/configmap.yaml
+++ b/charts/hyprstream/templates/configmap.yaml
@@ -24,8 +24,9 @@ data:
   {{- end }}
   {{- end }}
   {{- if .Values.observability.enabled }}
-  # TODO(#784): observability wiring populates OTEL_EXPORTER_OTLP_ENDPOINT here.
-  {{- with .Values.observability.otelExporterOtlpEndpoint }}
-  OTEL_EXPORTER_OTLP_ENDPOINT: {{ . | quote }}
-  {{- end }}
+  # K1b (#784): turn on the OTLP trace exporter and point it at the collector.
+  # hyprstream only exports OTLP when HYPRSTREAM_OTEL_ENABLE=true (main.rs); the
+  # collector derives Prometheus-scrapeable RED metrics from those spans.
+  HYPRSTREAM_OTEL_ENABLE: "true"
+  OTEL_EXPORTER_OTLP_ENDPOINT: {{ include "hyprstream.otlpEndpoint" . | quote }}
   {{- end }}

--- a/charts/hyprstream/templates/configmap.yaml
+++ b/charts/hyprstream/templates/configmap.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "hyprstream.fullname" . }}-config
+  labels:
+    {{- include "hyprstream.labels" . | nindent 4 }}
+data:
+  # Shared HYPRSTREAM__* env for every service. Config crate maps
+  # HYPRSTREAM__<SECTION>__<FIELD> onto HyprConfig.
+  HYPRSTREAM__STORAGE__MODELS_DIR: {{ printf "%s/models" .Values.config.dataDir | quote }}
+  HYPRSTREAM__STORAGE__LORAS_DIR: {{ printf "%s/loras" .Values.config.dataDir | quote }}
+  HYPRSTREAM__STORAGE__CACHE_DIR: {{ printf "%s/cache" .Values.config.dataDir | quote }}
+  HYPRSTREAM__STORAGE__CONFIG_DIR: {{ printf "%s/config" .Values.config.dataDir | quote }}
+  HYPRSTREAM__SECRETS__PATH: {{ .Values.keyBootstrap.secretsPath | quote }}
+  HYPRSTREAM__QUIC__ENABLED: {{ .Values.config.quic.enabled | quote }}
+  HYPRSTREAM__QUIC__IROH: {{ .Values.config.quic.iroh | quote }}
+  HYPRSTREAM__QUIC__BIND_ADDR: {{ .Values.config.quic.bindAddr | quote }}
+  {{- with .Values.config.extraEnv }}
+  {{- range $k, $v := . }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.observability.enabled }}
+  # TODO(#784): observability wiring populates OTEL_EXPORTER_OTLP_ENDPOINT here.
+  {{- with .Values.observability.otelExporterOtlpEndpoint }}
+  OTEL_EXPORTER_OTLP_ENDPOINT: {{ . | quote }}
+  {{- end }}
+  {{- end }}

--- a/charts/hyprstream/templates/configmap.yaml
+++ b/charts/hyprstream/templates/configmap.yaml
@@ -11,7 +11,10 @@ data:
   HYPRSTREAM__STORAGE__LORAS_DIR: {{ printf "%s/loras" .Values.config.dataDir | quote }}
   HYPRSTREAM__STORAGE__CACHE_DIR: {{ printf "%s/cache" .Values.config.dataDir | quote }}
   HYPRSTREAM__STORAGE__CONFIG_DIR: {{ printf "%s/config" .Values.config.dataDir | quote }}
+  HYPRSTREAM__TLS__ENABLED: {{ .Values.config.tls.enabled | quote }}
+  {{- if .Values.keyBootstrap.enabled }}
   HYPRSTREAM__SECRETS__PATH: {{ .Values.keyBootstrap.secretsPath | quote }}
+  {{- end }}
   HYPRSTREAM__QUIC__ENABLED: {{ .Values.config.quic.enabled | quote }}
   HYPRSTREAM__QUIC__IROH: {{ .Values.config.quic.iroh | quote }}
   HYPRSTREAM__QUIC__BIND_ADDR: {{ .Values.config.quic.bindAddr | quote }}

--- a/charts/hyprstream/templates/deployments.yaml
+++ b/charts/hyprstream/templates/deployments.yaml
@@ -48,11 +48,15 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "hyprstream.fullname" $root }}-config
-          {{- with $svc.env }}
+          {{- if or $svc.env (and $root.Values.keyBootstrap.enabled $root.Values.keyBootstrap.issuerUrl) }}
           env:
-            {{- range $k, $v := . }}
+            {{- range $k, $v := $svc.env }}
             - name: {{ $k }}
               value: {{ $v | quote }}
+            {{- end }}
+            {{- if and $root.Values.keyBootstrap.enabled $root.Values.keyBootstrap.issuerUrl }}
+            - name: HYPRSTREAM__OAUTH__ISSUER_URL
+              value: {{ $root.Values.keyBootstrap.issuerUrl | quote }}
             {{- end }}
           {{- end }}
           {{- with $svc.ports }}
@@ -83,7 +87,9 @@ spec:
             - name: data
               mountPath: {{ $root.Values.config.dataDir }}
             {{- if $root.Values.keyBootstrap.enabled }}
-            # TODO(#783): mount per-service signing-key Secret at secretsPath.
+            - name: credentials
+              mountPath: {{ $root.Values.keyBootstrap.secretsPath }}
+              readOnly: true
             {{- end }}
       {{- with (default $defaults.nodeSelector $svc.nodeSelector) }}
       nodeSelector:
@@ -105,5 +111,34 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- if $root.Values.keyBootstrap.enabled }}
+        - name: credentials
+          projected:
+            defaultMode: 0400
+            sources:
+              - secret:
+                  name: {{ include "hyprstream.trustSecretName" $root }}
+                  items:
+                    - key: ca-pubkey
+                      path: ca-pubkey
+                    - key: bootstrap-pubkeys
+                      path: bootstrap-pubkeys
+              - secret:
+                  name: {{ include "hyprstream.serviceCredentialSecretName" $ctx }}
+                  items:
+                    - key: signing-key
+                      path: signing-key
+                    {{- if ne $name "policy" }}
+                    - key: service-jwt
+                      path: service-jwt
+                    {{- end }}
+              {{- if eq $name "policy" }}
+              - secret:
+                  name: {{ include "hyprstream.policyCaSecretName" $root }}
+                  items:
+                    - key: ca-key
+                      path: ca-key
+              {{- end }}
+        {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/hyprstream/templates/deployments.yaml
+++ b/charts/hyprstream/templates/deployments.yaml
@@ -48,11 +48,15 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "hyprstream.fullname" $root }}-config
-          {{- if or $svc.env (and $root.Values.keyBootstrap.enabled $root.Values.keyBootstrap.issuerUrl) }}
+          {{- if or $svc.env $root.Values.observability.enabled (and $root.Values.keyBootstrap.enabled $root.Values.keyBootstrap.issuerUrl) }}
           env:
             {{- range $k, $v := $svc.env }}
             - name: {{ $k }}
               value: {{ $v | quote }}
+            {{- end }}
+            {{- if $root.Values.observability.enabled }}
+            - name: OTEL_SERVICE_NAME
+              value: {{ include "hyprstream.svcName" $ctx | quote }}
             {{- end }}
             {{- if and $root.Values.keyBootstrap.enabled $root.Values.keyBootstrap.issuerUrl }}
             - name: HYPRSTREAM__OAUTH__ISSUER_URL

--- a/charts/hyprstream/templates/deployments.yaml
+++ b/charts/hyprstream/templates/deployments.yaml
@@ -114,7 +114,7 @@ spec:
         {{- if $root.Values.keyBootstrap.enabled }}
         - name: credentials
           projected:
-            defaultMode: 0400
+            defaultMode: 0440
             sources:
               - secret:
                   name: {{ include "hyprstream.trustSecretName" $root }}

--- a/charts/hyprstream/templates/deployments.yaml
+++ b/charts/hyprstream/templates/deployments.yaml
@@ -1,0 +1,109 @@
+{{- $root := . -}}
+{{- $defaults := .Values.defaults -}}
+{{- range $name, $svc := .Values.services }}
+{{- if $svc.enabled }}
+{{- $ctx := dict "root" $root "name" $name }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "hyprstream.svcName" $ctx }}
+  labels:
+    {{- include "hyprstream.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: {{ $name }}
+spec:
+  replicas: {{ $svc.replicas | default $defaults.replicas }}
+  selector:
+    matchLabels:
+      {{- include "hyprstream.selectorLabels" $root | nindent 6 }}
+      app.kubernetes.io/component: {{ $name }}
+  template:
+    metadata:
+      labels:
+        {{- include "hyprstream.selectorLabels" $root | nindent 8 }}
+        app.kubernetes.io/component: {{ $name }}
+      {{- with (mergeOverwrite (deepCopy $defaults.podAnnotations) ($svc.podAnnotations | default dict)) }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "hyprstream.serviceAccountName" $root }}
+      {{- with $root.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (default $defaults.podSecurityContext $svc.podSecurityContext) }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ $name }}
+          image: {{ include "hyprstream.image" (dict "root" $root "svc" $svc) }}
+          imagePullPolicy: {{ $root.Values.image.pullPolicy }}
+          args:
+            - service
+            - start
+            - {{ $name }}
+            - --foreground
+          envFrom:
+            - configMapRef:
+                name: {{ include "hyprstream.fullname" $root }}-config
+          {{- with $svc.env }}
+          env:
+            {{- range $k, $v := . }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+          {{- end }}
+          {{- with $svc.ports }}
+          ports:
+            {{- range . }}
+            - name: {{ .name }}
+              containerPort: {{ .port }}
+              protocol: {{ .protocol | default "TCP" }}
+            {{- end }}
+          {{- end }}
+          {{- with (default $defaults.readinessProbe $svc.readinessProbe) }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with (default $defaults.livenessProbe $svc.livenessProbe) }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with (default $defaults.securityContext $svc.securityContext) }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with (default $defaults.resources $svc.resources) }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ $root.Values.config.dataDir }}
+            {{- if $root.Values.keyBootstrap.enabled }}
+            # TODO(#783): mount per-service signing-key Secret at secretsPath.
+            {{- end }}
+      {{- with (default $defaults.nodeSelector $svc.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (default $defaults.tolerations $svc.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (default $defaults.affinity $svc.affinity) }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: data
+          {{- if $root.Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ $root.Values.persistence.existingClaim | default (printf "%s-data" (include "hyprstream.fullname" $root)) }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/hyprstream/templates/keybootstrap.yaml
+++ b/charts/hyprstream/templates/keybootstrap.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.keyBootstrap.enabled }}
+{{- if not .Values.keyBootstrap.trust.existingSecret }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "hyprstream.trustSecretName" . }}
+  labels:
+    {{- include "hyprstream.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  ca-pubkey: {{ required "keyBootstrap.trust.caPubkey is required when keyBootstrap.enabled=true and keyBootstrap.trust.existingSecret is empty" .Values.keyBootstrap.trust.caPubkey | quote }}
+  bootstrap-pubkeys: {{ required "keyBootstrap.trust.bootstrapPubkeys is required when keyBootstrap.enabled=true and keyBootstrap.trust.existingSecret is empty" .Values.keyBootstrap.trust.bootstrapPubkeys | quote }}
+{{- end }}
+{{- end }}

--- a/charts/hyprstream/templates/observability.yaml
+++ b/charts/hyprstream/templates/observability.yaml
@@ -1,0 +1,229 @@
+{{- if and .Values.observability.enabled .Values.observability.collector.enabled }}
+{{- $root := . -}}
+{{- $col := .Values.observability.collector -}}
+{{- $name := include "hyprstream.collectorName" . -}}
+# -----------------------------------------------------------------------------
+# K1b (#784) — OpenTelemetry Collector: OTLP trace receiver -> spanmetrics
+# connector (RED metrics) -> Prometheus exposition (autoscaling signal source
+# for HPA/KEDA, #792). Standalone Deployment + ConfigMap + Service (all
+# built-in kinds; the optional ServiceMonitor below needs the Prometheus
+# Operator CRD).
+# -----------------------------------------------------------------------------
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $name }}-config
+  labels:
+    {{- include "hyprstream.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: otel-collector
+data:
+  collector.yaml: |
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:{{ $col.ports.health }}
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:{{ $col.ports.otlpGrpc }}
+          http:
+            endpoint: 0.0.0.0:{{ $col.ports.otlpHttp }}
+    processors:
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+      batch: {}
+    connectors:
+      # Derives request-rate / error / latency (RED) metrics from incoming spans
+      # per service, labelled by the dimensions below. This is the scaling signal.
+      # Emits `traces.span.metrics.calls` (counter) + `..duration` (histogram);
+      # the prometheus exporter `namespace` below prefixes them, giving
+      # {{ $col.prometheusNamespace }}_traces_span_metrics_calls_total etc.
+      spanmetrics:
+        histogram:
+          explicit:
+            buckets: [5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s, 2s, 5s, 10s]
+        {{- with $col.dimensions }}
+        dimensions:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        exemplars:
+          enabled: true
+        metrics_flush_interval: 15s
+    exporters:
+      # Prometheus exposition endpoint scraped by HPA/KEDA/kube-prometheus.
+      prometheus:
+        endpoint: 0.0.0.0:{{ $col.ports.prometheus }}
+        namespace: {{ $col.prometheusNamespace | quote }}
+        resource_to_telemetry_conversion:
+          enabled: true
+        enable_open_metrics: true
+      debug:
+        verbosity: basic
+    service:
+      extensions: [health_check]
+      # Disable the collector's own self-telemetry metrics server to avoid
+      # binding an extra port; the pipeline below is the exposition surface.
+      telemetry:
+        metrics:
+          level: none
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [spanmetrics, debug]
+        metrics:
+          receivers: [spanmetrics]
+          processors: [memory_limiter, batch]
+          exporters: [prometheus]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "hyprstream.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: otel-collector
+spec:
+  replicas: {{ $col.replicas }}
+  selector:
+    matchLabels:
+      {{- include "hyprstream.selectorLabels" $root | nindent 6 }}
+      app.kubernetes.io/component: otel-collector
+  template:
+    metadata:
+      labels:
+        {{- include "hyprstream.selectorLabels" $root | nindent 8 }}
+        app.kubernetes.io/component: otel-collector
+      annotations:
+        # Roll the collector when its rendered config changes.
+        checksum/config: {{ $col | toYaml | sha256sum }}
+        {{- with $col.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "hyprstream.serviceAccountName" $root }}
+      {{- with $root.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+      containers:
+        - name: otel-collector
+          image: "{{ $col.image.repository }}:{{ $col.image.tag }}"
+          imagePullPolicy: {{ $col.image.pullPolicy }}
+          args:
+            - --config=/conf/collector.yaml
+          ports:
+            - name: otlp-grpc
+              containerPort: {{ $col.ports.otlpGrpc }}
+              protocol: TCP
+            - name: otlp-http
+              containerPort: {{ $col.ports.otlpHttp }}
+              protocol: TCP
+            - name: prometheus
+              containerPort: {{ $col.ports.prometheus }}
+              protocol: TCP
+            - name: health
+              containerPort: {{ $col.ports.health }}
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: health
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+          {{- with $col.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /conf
+              readOnly: true
+      {{- with $col.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $col.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $col.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ $name }}-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "hyprstream.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: otel-collector
+  {{- with $col.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ $col.service.type | default "ClusterIP" }}
+  selector:
+    {{- include "hyprstream.selectorLabels" $root | nindent 4 }}
+    app.kubernetes.io/component: otel-collector
+  ports:
+    - name: otlp-grpc
+      port: {{ $col.ports.otlpGrpc }}
+      targetPort: otlp-grpc
+      protocol: TCP
+    - name: otlp-http
+      port: {{ $col.ports.otlpHttp }}
+      targetPort: otlp-http
+      protocol: TCP
+    - name: prometheus
+      port: {{ $col.ports.prometheus }}
+      targetPort: prometheus
+      protocol: TCP
+{{- if $col.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "hyprstream.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: otel-collector
+    {{- with $col.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "hyprstream.selectorLabels" $root | nindent 6 }}
+      app.kubernetes.io/component: otel-collector
+  endpoints:
+    - port: prometheus
+      path: /metrics
+      interval: {{ $col.serviceMonitor.interval }}
+      scrapeTimeout: {{ $col.serviceMonitor.scrapeTimeout }}
+{{- end }}
+{{- end }}

--- a/charts/hyprstream/templates/pvc.yaml
+++ b/charts/hyprstream/templates/pvc.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "hyprstream.fullname" . }}-data
+  labels:
+    {{- include "hyprstream.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+{{- end }}
+{{/*
+  NOTE: this is a single shared claim across all service Deployments. accessModes
+  defaults to ReadWriteOnce, which binds to pods on ONE node — fine for a
+  single-node cluster (kind) and for validation. On a multi-node cluster set
+  persistence.accessModes to [ReadWriteMany] with an RWX-capable StorageClass, or
+  supply model data out-of-band via XET/CAS. Cross-service state sharing (models,
+  CAS) is the reason for a shared volume.
+*/}}

--- a/charts/hyprstream/templates/serviceaccount.yaml
+++ b/charts/hyprstream/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "hyprstream.serviceAccountName" . }}
+  labels:
+    {{- include "hyprstream.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/hyprstream/templates/services.yaml
+++ b/charts/hyprstream/templates/services.yaml
@@ -1,0 +1,32 @@
+{{- $root := . -}}
+{{- $defaults := .Values.defaults -}}
+{{- range $name, $svc := .Values.services }}
+{{- if $svc.enabled }}
+{{- $ctx := dict "root" $root "name" $name }}
+{{- $svcCfg := $svc.service | default $defaults.service }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "hyprstream.svcName" $ctx }}
+  labels:
+    {{- include "hyprstream.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: {{ $name }}
+  {{- with (default $defaults.service.annotations $svcCfg.annotations) }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ $svcCfg.type | default "ClusterIP" }}
+  selector:
+    {{- include "hyprstream.selectorLabels" $root | nindent 4 }}
+    app.kubernetes.io/component: {{ $name }}
+  ports:
+    {{- range $svc.ports }}
+    - name: {{ .name }}
+      port: {{ .port }}
+      targetPort: {{ .name }}
+      protocol: {{ .protocol | default "TCP" }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/hyprstream/tests/golden-default.yaml
+++ b/charts/hyprstream/tests/golden-default.yaml
@@ -30,7 +30,7 @@ data:
   HYPRSTREAM__STORAGE__LORAS_DIR: "/var/lib/hyprstream/loras"
   HYPRSTREAM__STORAGE__CACHE_DIR: "/var/lib/hyprstream/cache"
   HYPRSTREAM__STORAGE__CONFIG_DIR: "/var/lib/hyprstream/config"
-  HYPRSTREAM__SECRETS__PATH: "/var/lib/hyprstream/credentials"
+  HYPRSTREAM__TLS__ENABLED: "false"
   HYPRSTREAM__QUIC__ENABLED: "true"
   HYPRSTREAM__QUIC__IROH: "true"
   HYPRSTREAM__QUIC__BIND_ADDR: "0.0.0.0:0"
@@ -248,6 +248,9 @@ spec:
         app.kubernetes.io/component: discovery
     spec:
       serviceAccountName: hyprstream
+      securityContext:
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: discovery
           image: ghcr.io/hyprstream/hyprstream:0.1.0
@@ -312,6 +315,9 @@ spec:
         app.kubernetes.io/component: event
     spec:
       serviceAccountName: hyprstream
+      securityContext:
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: event
           image: ghcr.io/hyprstream/hyprstream:0.1.0
@@ -376,6 +382,9 @@ spec:
         app.kubernetes.io/component: model
     spec:
       serviceAccountName: hyprstream
+      securityContext:
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: model
           image: ghcr.io/hyprstream/hyprstream:0.1.0-cpu
@@ -440,6 +449,9 @@ spec:
         app.kubernetes.io/component: oai
     spec:
       serviceAccountName: hyprstream
+      securityContext:
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: oai
           image: ghcr.io/hyprstream/hyprstream:0.1.0
@@ -519,6 +531,9 @@ spec:
         app.kubernetes.io/component: policy
     spec:
       serviceAccountName: hyprstream
+      securityContext:
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: policy
           image: ghcr.io/hyprstream/hyprstream:0.1.0
@@ -583,6 +598,9 @@ spec:
         app.kubernetes.io/component: registry
     spec:
       serviceAccountName: hyprstream
+      securityContext:
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: registry
           image: ghcr.io/hyprstream/hyprstream:0.1.0
@@ -647,6 +665,9 @@ spec:
         app.kubernetes.io/component: streams
     spec:
       serviceAccountName: hyprstream
+      securityContext:
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: streams
           image: ghcr.io/hyprstream/hyprstream:0.1.0

--- a/charts/hyprstream/tests/golden-default.yaml
+++ b/charts/hyprstream/tests/golden-default.yaml
@@ -1,0 +1,683 @@
+---
+# Source: hyprstream/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hyprstream
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: hyprstream/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hyprstream-config
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  # Shared HYPRSTREAM__* env for every service. Config crate maps
+  # HYPRSTREAM__<SECTION>__<FIELD> onto HyprConfig.
+  HYPRSTREAM__STORAGE__MODELS_DIR: "/var/lib/hyprstream/models"
+  HYPRSTREAM__STORAGE__LORAS_DIR: "/var/lib/hyprstream/loras"
+  HYPRSTREAM__STORAGE__CACHE_DIR: "/var/lib/hyprstream/cache"
+  HYPRSTREAM__STORAGE__CONFIG_DIR: "/var/lib/hyprstream/config"
+  HYPRSTREAM__SECRETS__PATH: "/var/lib/hyprstream/credentials"
+  HYPRSTREAM__QUIC__ENABLED: "true"
+  HYPRSTREAM__QUIC__IROH: "true"
+  HYPRSTREAM__QUIC__BIND_ADDR: "0.0.0.0:0"
+---
+# Source: hyprstream/templates/pvc.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hyprstream-data
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+# Source: hyprstream/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hyprstream-discovery
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: discovery
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/component: discovery
+  ports:
+    - name: quic
+      port: 7002
+      targetPort: quic
+      protocol: UDP
+---
+# Source: hyprstream/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hyprstream-event
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: event
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/component: event
+  ports:
+    - name: quic
+      port: 7010
+      targetPort: quic
+      protocol: UDP
+---
+# Source: hyprstream/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hyprstream-model
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: model
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/component: model
+  ports:
+    - name: quic
+      port: 7004
+      targetPort: quic
+      protocol: UDP
+---
+# Source: hyprstream/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hyprstream-oai
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: oai
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/component: oai
+  ports:
+    - name: http
+      port: 6789
+      targetPort: http
+      protocol: TCP
+---
+# Source: hyprstream/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hyprstream-policy
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: policy
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/component: policy
+  ports:
+    - name: quic
+      port: 7001
+      targetPort: quic
+      protocol: UDP
+---
+# Source: hyprstream/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hyprstream-registry
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: registry
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/component: registry
+  ports:
+    - name: quic
+      port: 7003
+      targetPort: quic
+      protocol: UDP
+---
+# Source: hyprstream/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hyprstream-streams
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: streams
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/component: streams
+  ports:
+    - name: quic
+      port: 7011
+      targetPort: quic
+      protocol: UDP
+---
+# Source: hyprstream/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hyprstream-discovery
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: discovery
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hyprstream
+      app.kubernetes.io/instance: hyprstream
+      app.kubernetes.io/component: discovery
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hyprstream
+        app.kubernetes.io/instance: hyprstream
+        app.kubernetes.io/component: discovery
+    spec:
+      serviceAccountName: hyprstream
+      containers:
+        - name: discovery
+          image: ghcr.io/hyprstream/hyprstream:0.1.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - service
+            - start
+            - discovery
+            - --foreground
+          envFrom:
+            - configMapRef:
+                name: hyprstream-config
+          env:
+            - name: HYPRSTREAM__DISCOVERY__QUIC_PORT
+              value: "7002"
+            - name: HYPRSTREAM__QUIC__SERVER_NAME
+              value: "hyprstream-discovery"
+          ports:
+            - name: quic
+              containerPort: 7002
+              protocol: UDP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 65532
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/hyprstream
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hyprstream-data
+---
+# Source: hyprstream/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hyprstream-event
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: event
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hyprstream
+      app.kubernetes.io/instance: hyprstream
+      app.kubernetes.io/component: event
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hyprstream
+        app.kubernetes.io/instance: hyprstream
+        app.kubernetes.io/component: event
+    spec:
+      serviceAccountName: hyprstream
+      containers:
+        - name: event
+          image: ghcr.io/hyprstream/hyprstream:0.1.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - service
+            - start
+            - event
+            - --foreground
+          envFrom:
+            - configMapRef:
+                name: hyprstream-config
+          env:
+            - name: HYPRSTREAM__EVENT__QUIC_PORT
+              value: "7010"
+            - name: HYPRSTREAM__QUIC__SERVER_NAME
+              value: "hyprstream-event"
+          ports:
+            - name: quic
+              containerPort: 7010
+              protocol: UDP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 65532
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/hyprstream
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hyprstream-data
+---
+# Source: hyprstream/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hyprstream-model
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: model
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hyprstream
+      app.kubernetes.io/instance: hyprstream
+      app.kubernetes.io/component: model
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hyprstream
+        app.kubernetes.io/instance: hyprstream
+        app.kubernetes.io/component: model
+    spec:
+      serviceAccountName: hyprstream
+      containers:
+        - name: model
+          image: ghcr.io/hyprstream/hyprstream:0.1.0-cpu
+          imagePullPolicy: IfNotPresent
+          args:
+            - service
+            - start
+            - model
+            - --foreground
+          envFrom:
+            - configMapRef:
+                name: hyprstream-config
+          env:
+            - name: HYPRSTREAM__MODEL__QUIC_PORT
+              value: "7004"
+            - name: HYPRSTREAM__QUIC__SERVER_NAME
+              value: "hyprstream-model"
+          ports:
+            - name: quic
+              containerPort: 7004
+              protocol: UDP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 65532
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/hyprstream
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hyprstream-data
+---
+# Source: hyprstream/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hyprstream-oai
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: oai
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hyprstream
+      app.kubernetes.io/instance: hyprstream
+      app.kubernetes.io/component: oai
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hyprstream
+        app.kubernetes.io/instance: hyprstream
+        app.kubernetes.io/component: oai
+    spec:
+      serviceAccountName: hyprstream
+      containers:
+        - name: oai
+          image: ghcr.io/hyprstream/hyprstream:0.1.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - service
+            - start
+            - oai
+            - --foreground
+          envFrom:
+            - configMapRef:
+                name: hyprstream-config
+          env:
+            - name: HYPRSTREAM__OAI__HOST
+              value: "0.0.0.0"
+            - name: HYPRSTREAM__OAI__PORT
+              value: "6789"
+            - name: HYPRSTREAM__QUIC__SERVER_NAME
+              value: "hyprstream-oai"
+          ports:
+            - name: http
+              containerPort: 6789
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 65532
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/hyprstream
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hyprstream-data
+---
+# Source: hyprstream/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hyprstream-policy
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: policy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hyprstream
+      app.kubernetes.io/instance: hyprstream
+      app.kubernetes.io/component: policy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hyprstream
+        app.kubernetes.io/instance: hyprstream
+        app.kubernetes.io/component: policy
+    spec:
+      serviceAccountName: hyprstream
+      containers:
+        - name: policy
+          image: ghcr.io/hyprstream/hyprstream:0.1.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - service
+            - start
+            - policy
+            - --foreground
+          envFrom:
+            - configMapRef:
+                name: hyprstream-config
+          env:
+            - name: HYPRSTREAM__POLICY__QUIC_PORT
+              value: "7001"
+            - name: HYPRSTREAM__QUIC__SERVER_NAME
+              value: "hyprstream-policy"
+          ports:
+            - name: quic
+              containerPort: 7001
+              protocol: UDP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 65532
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/hyprstream
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hyprstream-data
+---
+# Source: hyprstream/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hyprstream-registry
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: registry
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hyprstream
+      app.kubernetes.io/instance: hyprstream
+      app.kubernetes.io/component: registry
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hyprstream
+        app.kubernetes.io/instance: hyprstream
+        app.kubernetes.io/component: registry
+    spec:
+      serviceAccountName: hyprstream
+      containers:
+        - name: registry
+          image: ghcr.io/hyprstream/hyprstream:0.1.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - service
+            - start
+            - registry
+            - --foreground
+          envFrom:
+            - configMapRef:
+                name: hyprstream-config
+          env:
+            - name: HYPRSTREAM__QUIC__SERVER_NAME
+              value: "hyprstream-registry"
+            - name: HYPRSTREAM__REGISTRY__QUIC_PORT
+              value: "7003"
+          ports:
+            - name: quic
+              containerPort: 7003
+              protocol: UDP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 65532
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/hyprstream
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hyprstream-data
+---
+# Source: hyprstream/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hyprstream-streams
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: streams
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hyprstream
+      app.kubernetes.io/instance: hyprstream
+      app.kubernetes.io/component: streams
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hyprstream
+        app.kubernetes.io/instance: hyprstream
+        app.kubernetes.io/component: streams
+    spec:
+      serviceAccountName: hyprstream
+      containers:
+        - name: streams
+          image: ghcr.io/hyprstream/hyprstream:0.1.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - service
+            - start
+            - streams
+            - --foreground
+          envFrom:
+            - configMapRef:
+                name: hyprstream-config
+          env:
+            - name: HYPRSTREAM__QUIC__SERVER_NAME
+              value: "hyprstream-streams"
+          ports:
+            - name: quic
+              containerPort: 7011
+              protocol: UDP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 65532
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/hyprstream
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hyprstream-data

--- a/charts/hyprstream/tests/golden-observability.yaml
+++ b/charts/hyprstream/tests/golden-observability.yaml
@@ -1,0 +1,918 @@
+---
+# Source: hyprstream/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hyprstream
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: hyprstream/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hyprstream-config
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  # Shared HYPRSTREAM__* env for every service. Config crate maps
+  # HYPRSTREAM__<SECTION>__<FIELD> onto HyprConfig.
+  HYPRSTREAM__STORAGE__MODELS_DIR: "/var/lib/hyprstream/models"
+  HYPRSTREAM__STORAGE__LORAS_DIR: "/var/lib/hyprstream/loras"
+  HYPRSTREAM__STORAGE__CACHE_DIR: "/var/lib/hyprstream/cache"
+  HYPRSTREAM__STORAGE__CONFIG_DIR: "/var/lib/hyprstream/config"
+  HYPRSTREAM__TLS__ENABLED: "false"
+  HYPRSTREAM__QUIC__ENABLED: "true"
+  HYPRSTREAM__QUIC__IROH: "true"
+  HYPRSTREAM__QUIC__BIND_ADDR: "0.0.0.0:0"
+  # K1b (#784): turn on the OTLP trace exporter and point it at the collector.
+  # hyprstream only exports OTLP when HYPRSTREAM_OTEL_ENABLE=true (main.rs); the
+  # collector derives Prometheus-scrapeable RED metrics from those spans.
+  HYPRSTREAM_OTEL_ENABLE: "true"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://hyprstream-otel-collector:4317"
+---
+# Source: hyprstream/templates/observability.yaml
+# -----------------------------------------------------------------------------
+# K1b (#784) — OpenTelemetry Collector: OTLP trace receiver -> spanmetrics
+# connector (RED metrics) -> Prometheus exposition (autoscaling signal source
+# for HPA/KEDA, #792). Standalone Deployment + ConfigMap + Service (all
+# built-in kinds; the optional ServiceMonitor below needs the Prometheus
+# Operator CRD).
+# -----------------------------------------------------------------------------
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hyprstream-otel-collector-config
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-collector
+data:
+  collector.yaml: |
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:13133
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+    processors:
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+      batch: {}
+    connectors:
+      # Derives request-rate / error / latency (RED) metrics from incoming spans
+      # per service, labelled by the dimensions below. This is the scaling signal.
+      # Emits `traces.span.metrics.calls` (counter) + `..duration` (histogram);
+      # the prometheus exporter `namespace` below prefixes them, giving
+      # hyprstream_traces_span_metrics_calls_total etc.
+      spanmetrics:
+        histogram:
+          explicit:
+            buckets: [5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s, 2s, 5s, 10s]
+        dimensions:
+          - name: http.method
+          - name: http.route
+          - name: http.status_code
+          - name: rpc.method
+          - name: rpc.service
+        exemplars:
+          enabled: true
+        metrics_flush_interval: 15s
+    exporters:
+      # Prometheus exposition endpoint scraped by HPA/KEDA/kube-prometheus.
+      prometheus:
+        endpoint: 0.0.0.0:8889
+        namespace: "hyprstream"
+        resource_to_telemetry_conversion:
+          enabled: true
+        enable_open_metrics: true
+      debug:
+        verbosity: basic
+    service:
+      extensions: [health_check]
+      # Disable the collector's own self-telemetry metrics server to avoid
+      # binding an extra port; the pipeline below is the exposition surface.
+      telemetry:
+        metrics:
+          level: none
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [spanmetrics, debug]
+        metrics:
+          receivers: [spanmetrics]
+          processors: [memory_limiter, batch]
+          exporters: [prometheus]
+---
+# Source: hyprstream/templates/pvc.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hyprstream-data
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+# Source: hyprstream/templates/observability.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hyprstream-otel-collector
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-collector
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/component: otel-collector
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      targetPort: otlp-grpc
+      protocol: TCP
+    - name: otlp-http
+      port: 4318
+      targetPort: otlp-http
+      protocol: TCP
+    - name: prometheus
+      port: 8889
+      targetPort: prometheus
+      protocol: TCP
+---
+# Source: hyprstream/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hyprstream-discovery
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: discovery
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/component: discovery
+  ports:
+    - name: quic
+      port: 7002
+      targetPort: quic
+      protocol: UDP
+---
+# Source: hyprstream/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hyprstream-event
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: event
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/component: event
+  ports:
+    - name: quic
+      port: 7010
+      targetPort: quic
+      protocol: UDP
+---
+# Source: hyprstream/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hyprstream-model
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: model
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/component: model
+  ports:
+    - name: quic
+      port: 7004
+      targetPort: quic
+      protocol: UDP
+---
+# Source: hyprstream/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hyprstream-oai
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: oai
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/component: oai
+  ports:
+    - name: http
+      port: 6789
+      targetPort: http
+      protocol: TCP
+---
+# Source: hyprstream/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hyprstream-policy
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: policy
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/component: policy
+  ports:
+    - name: quic
+      port: 7001
+      targetPort: quic
+      protocol: UDP
+---
+# Source: hyprstream/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hyprstream-registry
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: registry
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/component: registry
+  ports:
+    - name: quic
+      port: 7003
+      targetPort: quic
+      protocol: UDP
+---
+# Source: hyprstream/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hyprstream-streams
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: streams
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/component: streams
+  ports:
+    - name: quic
+      port: 7011
+      targetPort: quic
+      protocol: UDP
+---
+# Source: hyprstream/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hyprstream-discovery
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: discovery
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hyprstream
+      app.kubernetes.io/instance: hyprstream
+      app.kubernetes.io/component: discovery
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hyprstream
+        app.kubernetes.io/instance: hyprstream
+        app.kubernetes.io/component: discovery
+    spec:
+      serviceAccountName: hyprstream
+      securityContext:
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: discovery
+          image: ghcr.io/hyprstream/hyprstream:0.1.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - service
+            - start
+            - discovery
+            - --foreground
+          envFrom:
+            - configMapRef:
+                name: hyprstream-config
+          env:
+            - name: HYPRSTREAM__DISCOVERY__QUIC_PORT
+              value: "7002"
+            - name: HYPRSTREAM__QUIC__SERVER_NAME
+              value: "hyprstream-discovery"
+            - name: OTEL_SERVICE_NAME
+              value: "hyprstream-discovery"
+          ports:
+            - name: quic
+              containerPort: 7002
+              protocol: UDP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 65532
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/hyprstream
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hyprstream-data
+---
+# Source: hyprstream/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hyprstream-event
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: event
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hyprstream
+      app.kubernetes.io/instance: hyprstream
+      app.kubernetes.io/component: event
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hyprstream
+        app.kubernetes.io/instance: hyprstream
+        app.kubernetes.io/component: event
+    spec:
+      serviceAccountName: hyprstream
+      securityContext:
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: event
+          image: ghcr.io/hyprstream/hyprstream:0.1.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - service
+            - start
+            - event
+            - --foreground
+          envFrom:
+            - configMapRef:
+                name: hyprstream-config
+          env:
+            - name: HYPRSTREAM__EVENT__QUIC_PORT
+              value: "7010"
+            - name: HYPRSTREAM__QUIC__SERVER_NAME
+              value: "hyprstream-event"
+            - name: OTEL_SERVICE_NAME
+              value: "hyprstream-event"
+          ports:
+            - name: quic
+              containerPort: 7010
+              protocol: UDP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 65532
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/hyprstream
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hyprstream-data
+---
+# Source: hyprstream/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hyprstream-model
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: model
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hyprstream
+      app.kubernetes.io/instance: hyprstream
+      app.kubernetes.io/component: model
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hyprstream
+        app.kubernetes.io/instance: hyprstream
+        app.kubernetes.io/component: model
+    spec:
+      serviceAccountName: hyprstream
+      securityContext:
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: model
+          image: ghcr.io/hyprstream/hyprstream:0.1.0-cpu
+          imagePullPolicy: IfNotPresent
+          args:
+            - service
+            - start
+            - model
+            - --foreground
+          envFrom:
+            - configMapRef:
+                name: hyprstream-config
+          env:
+            - name: HYPRSTREAM__MODEL__QUIC_PORT
+              value: "7004"
+            - name: HYPRSTREAM__QUIC__SERVER_NAME
+              value: "hyprstream-model"
+            - name: OTEL_SERVICE_NAME
+              value: "hyprstream-model"
+          ports:
+            - name: quic
+              containerPort: 7004
+              protocol: UDP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 65532
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/hyprstream
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hyprstream-data
+---
+# Source: hyprstream/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hyprstream-oai
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: oai
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hyprstream
+      app.kubernetes.io/instance: hyprstream
+      app.kubernetes.io/component: oai
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hyprstream
+        app.kubernetes.io/instance: hyprstream
+        app.kubernetes.io/component: oai
+    spec:
+      serviceAccountName: hyprstream
+      securityContext:
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: oai
+          image: ghcr.io/hyprstream/hyprstream:0.1.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - service
+            - start
+            - oai
+            - --foreground
+          envFrom:
+            - configMapRef:
+                name: hyprstream-config
+          env:
+            - name: HYPRSTREAM__OAI__HOST
+              value: "0.0.0.0"
+            - name: HYPRSTREAM__OAI__PORT
+              value: "6789"
+            - name: HYPRSTREAM__QUIC__SERVER_NAME
+              value: "hyprstream-oai"
+            - name: OTEL_SERVICE_NAME
+              value: "hyprstream-oai"
+          ports:
+            - name: http
+              containerPort: 6789
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 65532
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/hyprstream
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hyprstream-data
+---
+# Source: hyprstream/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hyprstream-policy
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: policy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hyprstream
+      app.kubernetes.io/instance: hyprstream
+      app.kubernetes.io/component: policy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hyprstream
+        app.kubernetes.io/instance: hyprstream
+        app.kubernetes.io/component: policy
+    spec:
+      serviceAccountName: hyprstream
+      securityContext:
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: policy
+          image: ghcr.io/hyprstream/hyprstream:0.1.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - service
+            - start
+            - policy
+            - --foreground
+          envFrom:
+            - configMapRef:
+                name: hyprstream-config
+          env:
+            - name: HYPRSTREAM__POLICY__QUIC_PORT
+              value: "7001"
+            - name: HYPRSTREAM__QUIC__SERVER_NAME
+              value: "hyprstream-policy"
+            - name: OTEL_SERVICE_NAME
+              value: "hyprstream-policy"
+          ports:
+            - name: quic
+              containerPort: 7001
+              protocol: UDP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 65532
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/hyprstream
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hyprstream-data
+---
+# Source: hyprstream/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hyprstream-registry
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: registry
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hyprstream
+      app.kubernetes.io/instance: hyprstream
+      app.kubernetes.io/component: registry
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hyprstream
+        app.kubernetes.io/instance: hyprstream
+        app.kubernetes.io/component: registry
+    spec:
+      serviceAccountName: hyprstream
+      securityContext:
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: registry
+          image: ghcr.io/hyprstream/hyprstream:0.1.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - service
+            - start
+            - registry
+            - --foreground
+          envFrom:
+            - configMapRef:
+                name: hyprstream-config
+          env:
+            - name: HYPRSTREAM__QUIC__SERVER_NAME
+              value: "hyprstream-registry"
+            - name: HYPRSTREAM__REGISTRY__QUIC_PORT
+              value: "7003"
+            - name: OTEL_SERVICE_NAME
+              value: "hyprstream-registry"
+          ports:
+            - name: quic
+              containerPort: 7003
+              protocol: UDP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 65532
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/hyprstream
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hyprstream-data
+---
+# Source: hyprstream/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hyprstream-streams
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: streams
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hyprstream
+      app.kubernetes.io/instance: hyprstream
+      app.kubernetes.io/component: streams
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hyprstream
+        app.kubernetes.io/instance: hyprstream
+        app.kubernetes.io/component: streams
+    spec:
+      serviceAccountName: hyprstream
+      securityContext:
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: streams
+          image: ghcr.io/hyprstream/hyprstream:0.1.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - service
+            - start
+            - streams
+            - --foreground
+          envFrom:
+            - configMapRef:
+                name: hyprstream-config
+          env:
+            - name: HYPRSTREAM__QUIC__SERVER_NAME
+              value: "hyprstream-streams"
+            - name: OTEL_SERVICE_NAME
+              value: "hyprstream-streams"
+          ports:
+            - name: quic
+              containerPort: 7011
+              protocol: UDP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 65532
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/hyprstream
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hyprstream-data
+---
+# Source: hyprstream/templates/observability.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hyprstream-otel-collector
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-collector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hyprstream
+      app.kubernetes.io/instance: hyprstream
+      app.kubernetes.io/component: otel-collector
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hyprstream
+        app.kubernetes.io/instance: hyprstream
+        app.kubernetes.io/component: otel-collector
+      annotations:
+        # Roll the collector when its rendered config changes.
+        checksum/config: 909245b4b6619b5dbacb3cebbf79052cd757b686e5372e2fef494d3e61d8ce3d
+    spec:
+      serviceAccountName: hyprstream
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+      containers:
+        - name: otel-collector
+          image: "otel/opentelemetry-collector-contrib:0.128.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config=/conf/collector.yaml
+          ports:
+            - name: otlp-grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+            - name: prometheus
+              containerPort: 8889
+              protocol: TCP
+            - name: health
+              containerPort: 13133
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: health
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: config
+              mountPath: /conf
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: hyprstream-otel-collector-config

--- a/charts/hyprstream/values.yaml
+++ b/charts/hyprstream/values.yaml
@@ -55,6 +55,12 @@ config:
     # Base bind address; the per-service QUIC listen port comes from each
     # service's HYPRSTREAM__<SVC>__QUIC_PORT (see services.<name>.env).
     bindAddr: "0.0.0.0:0"
+  # In-cluster HTTP surfaces are fronted by Kubernetes Services and probes.
+  # Leave app TLS off by default so the oai readiness/liveness HTTP probes and
+  # README port-forward curl hit the protocol actually served on 6789. Operators
+  # that terminate TLS in-process can set this true and update probes to HTTPS.
+  tls:
+    enabled: false
   # Extra raw HYPRSTREAM__* env applied to every service (escape hatch).
   extraEnv: {}
 
@@ -134,7 +140,9 @@ defaults:
   tolerations: []
   affinity: {}
   podAnnotations: {}
-  podSecurityContext: {}
+  podSecurityContext:
+    fsGroup: 65532
+    fsGroupChangePolicy: OnRootMismatch
   securityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: false

--- a/charts/hyprstream/values.yaml
+++ b/charts/hyprstream/values.yaml
@@ -121,14 +121,75 @@ keyBootstrap:
   policyCaSecret: ""
 
 # -----------------------------------------------------------------------------
-# TODO(#784) — K1b observability extension hook.
-# OTel Collector -> Prometheus exposition. NOT implemented here (separate issue).
-# When enabled, #784 will set OTEL_EXPORTER_OTLP_ENDPOINT on every service and
-# deploy/point at a collector. This chart only reserves the shape.
+# K1b observability (#784) — OpenTelemetry Collector -> Prometheus exposition.
+#
+# hyprstream's `otel` feature is OTLP-*push* only and exports **traces** (spans),
+# not metrics (crates/hyprstream/src/bin/main.rs). HPA/KEDA need a scrapeable
+# signal, so the chart deploys a standalone OTel Collector Deployment that:
+#   1. receives OTLP traces from every service (gRPC :4317 / HTTP :4318),
+#   2. derives RED metrics (request rate / errors / latency) from those spans
+#      via the `spanmetrics` connector, and
+#   3. exposes them on a Prometheus exposition endpoint (:8889 /metrics) that
+#      an HPA (prometheus-adapter) or KEDA prometheus scaler can consume (#792).
+#
+# When enabled, every service also gets HYPRSTREAM_OTEL_ENABLE=true and
+# OTEL_EXPORTER_OTLP_ENDPOINT pointed at the collector Service (see configmap).
+# Standalone Deployment (not sidecar/DaemonSet): OTLP is push, so services dial
+# one collector Service by DNS; Prometheus scrapes that one endpoint.
 # -----------------------------------------------------------------------------
 observability:
   enabled: false
-  # otelExporterOtlpEndpoint: ""   # filled by #784
+  # OTLP endpoint every service pushes traces to. Leave empty to default to the
+  # in-cluster collector Service below ("http://<fullname>-otel-collector:4317").
+  # Override to point at an external/existing collector instead.
+  otelExporterOtlpEndpoint: ""
+  collector:
+    # Deploy the bundled collector. Set false to only wire the env above at an
+    # external collector (otelExporterOtlpEndpoint must then be set).
+    enabled: true
+    image:
+      # contrib distro — the `spanmetrics` connector is not in the core distro.
+      repository: otel/opentelemetry-collector-contrib
+      tag: "0.128.0"
+      pullPolicy: IfNotPresent
+    replicas: 1
+    resources: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+    podAnnotations: {}
+    ports:
+      otlpGrpc: 4317
+      otlpHttp: 4318
+      # Prometheus exposition endpoint (scraped by HPA/KEDA/kube-prometheus).
+      prometheus: 8889
+      # Collector health_check extension (used for readiness/liveness).
+      health: 13133
+    # Metric name prefix on the Prometheus exposition
+    # (e.g. hyprstream_traces_span_metrics_calls_total).
+    prometheusNamespace: hyprstream
+    # Span attributes promoted to metric labels (dimensions) so scaling signals
+    # can be sliced per route/method. Attribute must exist on the span or the
+    # dimension is dropped.
+    dimensions:
+      - name: http.method
+      - name: http.route
+      - name: http.status_code
+      - name: rpc.method
+      - name: rpc.service
+    service:
+      type: ClusterIP
+      # Prometheus annotation-based scrape discovery (kube-prometheus ignores
+      # these — use serviceMonitor for that). Handy for prometheus.io/scrape.
+      annotations: {}
+    # Emit a kube-prometheus-stack ServiceMonitor. Requires the Prometheus
+    # Operator CRD (monitoring.coreos.com/v1) to be installed in the cluster.
+    serviceMonitor:
+      enabled: false
+      interval: 30s
+      scrapeTimeout: 10s
+      # Extra labels (e.g. release: kube-prometheus-stack) so the operator selects it.
+      labels: {}
 
 # -----------------------------------------------------------------------------
 # Defaults applied to every service; each services.<name> entry may override.

--- a/charts/hyprstream/values.yaml
+++ b/charts/hyprstream/values.yaml
@@ -72,19 +72,47 @@ persistence:
   annotations: {}
 
 # -----------------------------------------------------------------------------
-# TODO(#783) — K1a key/trust bootstrap extension hook.
-# Per-service signing-key Secrets, CA/trust store, node DID. Intentionally NOT
-# implemented here (separate issue). When keyBootstrap.enabled is true, #783
-# will project per-service Secret volumes into HYPRSTREAM__SECRETS__PATH and set
-# the node DID. This chart only reserves the shape + a stable secrets mount path.
+# K1a key/trust bootstrap (#783).
+#
+# hyprstream reads a flat credential directory when HYPRSTREAM__SECRETS__PATH is
+# set. In Kubernetes each pod gets that flat directory by projecting:
+#   - shared trust: ca-pubkey + bootstrap-pubkeys
+#   - service credential Secret: signing-key + service-jwt
+#   - policy-only CA Secret: ca-key (policy signs/renews service JWTs)
+#
+# Generate these files with the normal hyprstream bootstrap/wizard flow, or an
+# external-secrets controller. The chart deliberately does not mint keys in
+# templates: Helm has no secure RNG/signing primitive, and missing credentials
+# should fail closed rather than silently deriving identity in-cluster.
 # -----------------------------------------------------------------------------
 keyBootstrap:
   enabled: false
-  # Directory each service reads signing keys / bootstrap pubkeys / JWTs from
-  # (HYPRSTREAM__SECRETS__PATH). #783 owns populating it from Secrets.
+  # Directory each service reads signing keys / bootstrap pubkeys / JWTs from.
   secretsPath: /var/lib/hyprstream/credentials
-  # nodeDid: ""              # filled by #783
-  # secretNameTemplate: ""   # filled by #783
+  # OAuth issuer / local trust-domain URL stamped into service JWTs by the
+  # bootstrap tool and used as the node's did:web authority when OAuth is on.
+  # If set, it is exposed as HYPRSTREAM__OAUTH__ISSUER_URL.
+  issuerUrl: ""
+  # Shared public trust material. Existing Secret must contain:
+  #   ca-pubkey
+  #   bootstrap-pubkeys
+  trust:
+    existingSecret: ""
+    # Inline public trust data for dev/test installs. Values are rendered into a
+    # Secret only when existingSecret is empty. Do not put private keys here.
+    caPubkey: ""
+    bootstrapPubkeys: ""
+  # Per-service credential Secrets. Each non-policy service Secret must contain:
+  #   signing-key
+  #   service-jwt
+  # The policy service Secret must contain:
+  #   signing-key
+  # and may contain service-jwt for symmetry.
+  # Omitted entries default to "<fullname>-<service>-credentials".
+  serviceSecrets: {}
+  # Policy-only CA Secret. Must contain ca-key. Omitted default:
+  # "<fullname>-policy-ca".
+  policyCaSecret: ""
 
 # -----------------------------------------------------------------------------
 # TODO(#784) — K1b observability extension hook.

--- a/charts/hyprstream/values.yaml
+++ b/charts/hyprstream/values.yaml
@@ -1,0 +1,338 @@
+# Default values for the hyprstream chart.
+#
+# Topology: one Deployment + one ClusterIP Service per hyprstream service
+# ("service-per-Deployment"). Services communicate over the networked transport
+# (QUIC over UDP / iroh), addressed by Kubernetes DNS Service names — never over
+# shared-volume Unix-domain sockets (UDS is explicitly not a deployment topology
+# requirement; ratified in epic #778 non-goals).
+#
+# The service set here mirrors the real inventory-registered factories in
+# crates/hyprstream/src/services/factories.rs. QUIC/RPC services expose a UDP
+# port; HTTP surfaces (oai/xet/flight) expose a TCP port.
+
+# -----------------------------------------------------------------------------
+# Image
+# -----------------------------------------------------------------------------
+# ASSUMPTION: no published image reference exists in-repo yet (only a local
+# multi-variant Dockerfile that builds distroless CPU/CUDA/ROCm images and tags
+# nothing). This is a placeholder registry/repo; override for your registry, or
+# have CI publish to it. Variant suffixes match the Dockerfile VARIANT stages.
+image:
+  repository: ghcr.io/hyprstream/hyprstream
+  # Empty tag => Chart.appVersion. A per-service `variant` appends a suffix below.
+  tag: ""
+  pullPolicy: IfNotPresent
+  # Suffix appended to the tag per service `variant` (see services.<name>.variant).
+  # e.g. tag "0.1.0" + variant "cuda" => "0.1.0-cuda128".
+  variants:
+    cpu: "-cpu"
+    cuda: "-cuda128"
+    rocm: "-rocm71"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+  automountServiceAccountToken: true
+
+# -----------------------------------------------------------------------------
+# Shared config -> rendered into a ConfigMap and mounted as HYPRSTREAM__* env on
+# every service. Config crate maps HYPRSTREAM__<SECTION>__<FIELD> (double
+# underscore) onto HyprConfig (crates/hyprstream/src/config/mod.rs).
+# -----------------------------------------------------------------------------
+config:
+  # Root data/state directory (models, loras, cache, config). Backed by the PVC
+  # below when persistence.enabled=true.
+  dataDir: /var/lib/hyprstream
+  # QUIC + iroh are on by default in QuicConfig; kept explicit here.
+  quic:
+    enabled: true
+    iroh: true
+    # Base bind address; the per-service QUIC listen port comes from each
+    # service's HYPRSTREAM__<SVC>__QUIC_PORT (see services.<name>.env).
+    bindAddr: "0.0.0.0:0"
+  # Extra raw HYPRSTREAM__* env applied to every service (escape hatch).
+  extraEnv: {}
+
+# -----------------------------------------------------------------------------
+# Persistence for the data dir (models via XET/CAS or PVC). Set enabled=false to
+# use an emptyDir (ephemeral) instead — useful for smoke tests.
+# -----------------------------------------------------------------------------
+persistence:
+  enabled: true
+  # existingClaim: ""
+  storageClass: ""
+  accessModes:
+    - ReadWriteOnce
+  size: 20Gi
+  annotations: {}
+
+# -----------------------------------------------------------------------------
+# TODO(#783) — K1a key/trust bootstrap extension hook.
+# Per-service signing-key Secrets, CA/trust store, node DID. Intentionally NOT
+# implemented here (separate issue). When keyBootstrap.enabled is true, #783
+# will project per-service Secret volumes into HYPRSTREAM__SECRETS__PATH and set
+# the node DID. This chart only reserves the shape + a stable secrets mount path.
+# -----------------------------------------------------------------------------
+keyBootstrap:
+  enabled: false
+  # Directory each service reads signing keys / bootstrap pubkeys / JWTs from
+  # (HYPRSTREAM__SECRETS__PATH). #783 owns populating it from Secrets.
+  secretsPath: /var/lib/hyprstream/credentials
+  # nodeDid: ""              # filled by #783
+  # secretNameTemplate: ""   # filled by #783
+
+# -----------------------------------------------------------------------------
+# TODO(#784) — K1b observability extension hook.
+# OTel Collector -> Prometheus exposition. NOT implemented here (separate issue).
+# When enabled, #784 will set OTEL_EXPORTER_OTLP_ENDPOINT on every service and
+# deploy/point at a collector. This chart only reserves the shape.
+# -----------------------------------------------------------------------------
+observability:
+  enabled: false
+  # otelExporterOtlpEndpoint: ""   # filled by #784
+
+# -----------------------------------------------------------------------------
+# Defaults applied to every service; each services.<name> entry may override.
+# -----------------------------------------------------------------------------
+defaults:
+  replicas: 1
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: false
+    runAsNonRoot: true
+    runAsUser: 65532        # distroless "nonroot"
+    capabilities:
+      drop:
+        - ALL
+  # Probes are per-service; QUIC (UDP) services have no TCP/HTTP health surface,
+  # so ordering across Deployments relies on hyprstream's fail-closed connect
+  # retry rather than initContainer wait-hacks. Services with an HTTP surface
+  # (oai) set a real readiness probe below.
+  readinessProbe: {}
+  livenessProbe: {}
+  service:
+    type: ClusterIP
+    annotations: {}
+
+# -----------------------------------------------------------------------------
+# Services (mirrors #[service_factory] registrations). The map key IS the
+# hyprstream service name passed to `service start <name> --foreground`.
+#
+# Default-enabled set satisfies the #779 acceptance path
+# (event/registry/policy/streams/model(cpu)/oai) plus its transitive
+# dependencies (discovery; registry/model/oai depend_on it). Everything else is
+# a toggle (enabled:false) so operators opt in.
+# -----------------------------------------------------------------------------
+services:
+
+  # --- Control plane -------------------------------------------------------
+  policy:
+    enabled: true
+    kind: rpc              # QUIC/RPC (informational)
+    ports:
+      - name: quic
+        port: 7001
+        protocol: UDP
+    env:
+      HYPRSTREAM__POLICY__QUIC_PORT: "7001"
+      HYPRSTREAM__QUIC__SERVER_NAME: "hyprstream-policy"
+
+  discovery:
+    enabled: true
+    kind: rpc
+    ports:
+      - name: quic
+        port: 7002
+        protocol: UDP
+    env:
+      HYPRSTREAM__DISCOVERY__QUIC_PORT: "7002"
+      HYPRSTREAM__QUIC__SERVER_NAME: "hyprstream-discovery"
+
+  registry:
+    enabled: true
+    kind: rpc
+    ports:
+      - name: quic
+        port: 7003
+        protocol: UDP
+    env:
+      HYPRSTREAM__REGISTRY__QUIC_PORT: "7003"
+      HYPRSTREAM__QUIC__SERVER_NAME: "hyprstream-registry"
+
+  model:
+    enabled: true
+    kind: rpc
+    # Inference image variant: cpu | cuda | rocm. GPU variants also need the
+    # matching resources/nodeSelector below (device plugins).
+    variant: cpu
+    ports:
+      - name: quic
+        port: 7004
+        protocol: UDP
+    env:
+      HYPRSTREAM__MODEL__QUIC_PORT: "7004"
+      HYPRSTREAM__QUIC__SERVER_NAME: "hyprstream-model"
+    # GPU example (uncomment + set variant: cuda):
+    # resources:
+    #   limits:
+    #     nvidia.com/gpu: 1
+    # nodeSelector:
+    #   nvidia.com/gpu.present: "true"
+
+  # --- MoQ planes (process-global origins; barrier services) ---------------
+  event:
+    enabled: true
+    kind: moq
+    ports:
+      - name: quic
+        port: 7010
+        protocol: UDP
+    env:
+      HYPRSTREAM__EVENT__QUIC_PORT: "7010"
+      HYPRSTREAM__QUIC__SERVER_NAME: "hyprstream-event"
+
+  streams:
+    enabled: true
+    kind: moq
+    # The streams barrier service serves a process-global MoQ origin. It has no
+    # RPC QUIC listener of its own; a nominal port keeps the Service valid and
+    # reserves the MoQ/WebTransport reach for cross-pod wiring.
+    ports:
+      - name: quic
+        port: 7011
+        protocol: UDP
+    env:
+      HYPRSTREAM__QUIC__SERVER_NAME: "hyprstream-streams"
+
+  # --- HTTP surface --------------------------------------------------------
+  oai:
+    enabled: true
+    kind: http
+    ports:
+      - name: http
+        port: 6789
+        protocol: TCP
+    env:
+      HYPRSTREAM__OAI__PORT: "6789"
+      HYPRSTREAM__OAI__HOST: "0.0.0.0"
+      HYPRSTREAM__QUIC__SERVER_NAME: "hyprstream-oai"
+    # oai serves an Axum /health route (crates/hyprstream/src/server/mod.rs).
+    readinessProbe:
+      httpGet:
+        path: /health
+        port: http
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      failureThreshold: 6
+    livenessProbe:
+      httpGet:
+        path: /health
+        port: http
+      initialDelaySeconds: 30
+      periodSeconds: 20
+
+  # --- Optional services (opt in) -----------------------------------------
+  oauth:
+    enabled: false
+    kind: http
+    ports:
+      - name: http
+        port: 6791
+        protocol: TCP
+      - name: quic
+        port: 7007
+        protocol: UDP
+    env:
+      HYPRSTREAM__OAUTH__PORT: "6791"
+      HYPRSTREAM__OAUTH__QUIC_PORT: "7007"
+      HYPRSTREAM__QUIC__SERVER_NAME: "hyprstream-oauth"
+
+  mcp:
+    enabled: false
+    kind: http
+    ports:
+      - name: http
+        port: 6790
+        protocol: TCP
+      - name: quic
+        port: 7006
+        protocol: UDP
+    env:
+      HYPRSTREAM__MCP__HTTP_PORT: "6790"
+      HYPRSTREAM__MCP__QUIC_PORT: "7006"
+      HYPRSTREAM__QUIC__SERVER_NAME: "hyprstream-mcp"
+
+  xet:
+    enabled: false
+    kind: http
+    ports:
+      - name: http
+        port: 6792
+        protocol: TCP
+    env:
+      HYPRSTREAM__XET__PORT: "6792"
+      HYPRSTREAM__QUIC__SERVER_NAME: "hyprstream-xet"
+
+  flight:
+    enabled: false
+    kind: http
+    ports:
+      - name: grpc
+        port: 50051
+        protocol: TCP
+    env:
+      HYPRSTREAM__FLIGHT__PORT: "50051"
+      HYPRSTREAM__QUIC__SERVER_NAME: "hyprstream-flight"
+
+  metrics:
+    enabled: false
+    kind: rpc
+    ports:
+      - name: quic
+        port: 7009
+        protocol: UDP
+    env:
+      HYPRSTREAM__METRICS__QUIC_PORT: "7009"
+      HYPRSTREAM__QUIC__SERVER_NAME: "hyprstream-metrics"
+
+  tui:
+    enabled: false
+    kind: rpc
+    ports:
+      - name: quic
+        port: 7008
+        protocol: UDP
+    env:
+      HYPRSTREAM__TUI__QUIC_PORT: "7008"
+      HYPRSTREAM__QUIC__SERVER_NAME: "hyprstream-tui"
+
+  worker:
+    # The worker service manages sandbox backends (Kata microVM / rootless OCI /
+    # nspawn). PRIVILEGE NOTE: real sandbox backends need elevated privileges
+    # (device access, user namespaces, /dev/kvm for microVMs) that are NOT
+    # granted by this chart's default hardened securityContext. Enable only with
+    # a securityContext override appropriate to your backend + node policy.
+    enabled: false
+    kind: rpc
+    ports:
+      - name: quic
+        port: 7005
+        protocol: UDP
+    env:
+      HYPRSTREAM__WORKER__QUIC_PORT: "7005"
+      HYPRSTREAM__QUIC__SERVER_NAME: "hyprstream-worker"
+    # Example privileged override (backend-dependent — review before use):
+    # securityContext:
+    #   runAsNonRoot: false
+    #   privileged: true


### PR DESCRIPTION
Implements **K1 (#779)** under **Epic #778, Phase 0**: a Helm chart at `charts/hyprstream/` deploying hyprstream to Kubernetes as **one Deployment + one ClusterIP Service per service** ("service-per-Deployment"), addressing each other by Kubernetes DNS Service name over the networked transport (**QUIC over UDP / iroh**) — **no shared-volume UDS anywhere in the chart** (per the #778 non-goal; UDS stays an incidental same-host optimization only).

### Service set modeled (source of truth)
Mirrors the real inventory-registered `#[service_factory(...)]` set in `crates/hyprstream/src/services/factories.rs`. Map keys are the exact names passed to `hyprstream service start <name> --foreground`:

- **Default-enabled** (matches the #779 acceptance path + transitive `depends_on`): `policy`, `discovery`, `registry`, `model` (cpu), `event`, `streams`, `oai`. (`discovery` is on because `registry`/`model`/`oai` depend on it.)
- **Opt-in toggles** (`enabled: false`): `oauth`, `mcp`, `xet`, `flight`, `metrics`, `tui`, `worker`. `worker` documents its elevated-privilege needs (device access / userns / `/dev/kvm`) which the default hardened `securityContext` deliberately does not grant.

QUIC/RPC services expose a **UDP** port; HTTP surfaces (`oai`/`xet`/`flight`) expose **TCP**. `oai` gets a real readiness/liveness probe (`httpGet /health`, from `crates/hyprstream/src/server/mod.rs`).

### What's in the chart
- `Chart.yaml`, `values.yaml` (fully commented), `_helpers.tpl`, `serviceaccount.yaml`, `configmap.yaml` (shared `HYPRSTREAM__*` env), `pvc.yaml` (shared `/var/lib/hyprstream` data dir), and **DRY** `deployments.yaml` / `services.yaml` that `range` over `.Values.services` merging `.Values.defaults`.
- **GPU variants**: `services.model.variant: cpu|cuda|rocm` appends the image suffix (matching the Dockerfile VARIANT stages) and is the anchor for `resources.limits.nvidia.com/gpu` + `nodeSelector` (nvidia/ROCm device plugins).
- **Env scheme**: `HYPRSTREAM__<SECTION>__<FIELD>` (config crate, double-underscore) — e.g. `HYPRSTREAM__POLICY__QUIC_PORT`, `HYPRSTREAM__OAI__PORT`, `HYPRSTREAM__STORAGE__MODELS_DIR`.
- **Golden render** committed at `charts/hyprstream/tests/golden-default.yaml`.

### Extension hooks left (NOT implemented here — separate issues)
- `keyBootstrap.*` → **#783 (K1a)**: per-service signing-key Secrets, trust store, node DID. Chart reserves the shape + a stable `HYPRSTREAM__SECRETS__PATH`; a `volumeMounts` TODO marker sits in `deployments.yaml`.
- `observability.*` → **#784 (K1b)**: OTel Collector → Prometheus exposition. Chart reserves the shape + a ConfigMap TODO for `OTEL_EXPORTER_OTLP_ENDPOINT`.

### Image assumption
No published image reference exists in-repo yet — only a local multi-variant distroless `Dockerfile` that tags nothing. `image.repository` defaults to a **placeholder** `ghcr.io/hyprstream/hyprstream`; `image.tag` defaults to `Chart.appVersion`; variant suffixes (`-cpu`/`-cuda128`/`-rocm71`) match the Dockerfile. Override for your registry or wire CI to publish there.

### Known gap (flagged, not a chart defect)
Cross-pod QUIC service-to-service **peer resolution** — feeding K8s DNS names into the RPC resolver so `for_service("policy")` dials `hyprstream-policy` — is **not yet wired in hyprstream itself**. Today the multi-process model resolves peers to UDS paths in a shared runtime dir (same-host only; `EndpointRegistry::default_endpoint`, `crates/hyprstream-rpc/src/registry/mod.rs`), and QUIC is a WebTransport/announce plane with no static peer-address config. This chart delivers the **Phase-0 deployment substrate**; a working end-to-end install additionally needs that app-side resolver wiring plus the #783 key/trust bootstrap (consistent with #779 being "soft-gated by #759/#774"). Documented in the chart README + `NOTES.txt`.

### Validation performed
- `helm lint charts/hyprstream` — clean.
- `helm template` — renders (17 objects default; 31 with all services enabled + `model.variant=cuda`, image resolves to `...:0.1.0-cuda128`).
- `kubeconform -strict` (built-in kinds, k8s 1.31) — 17/17 and 31/31 valid.
- `helm install --dry-run=server` against a live **kind** cluster (`kind-hyprstream`) — renders against the API server without error.

Part of #779. Epic #778.