### PR TITLE
feat(k8s) K1b: Helm observability — OTel Collector + Prometheus exposition (#784)

### DIFF
--- a/charts/hyprstream/README.md
+++ b/charts/hyprstream/README.md
@@ -79,9 +79,48 @@ Secrets created by the bootstrap/wizard flow or an external-secrets controller.
 `HYPRSTREAM__OAUTH__ISSUER_URL` and must match the issuer stamped into the
 pre-generated service JWTs.
 
-## Extension hooks (separate issues — not implemented here)
+## Observability (K1b, #784)
 
-- `observability.*` → **#784 (K1b)**: OTel Collector → Prometheus exposition.
+`observability.enabled=true` (default off) deploys a standalone **OpenTelemetry
+Collector** (Deployment + ConfigMap + Service) and wires every service to push
+OTLP traces to it (`HYPRSTREAM_OTEL_ENABLE=true`, `OTEL_EXPORTER_OTLP_ENDPOINT`,
+and per-Deployment `OTEL_SERVICE_NAME`).
+
+hyprstream's `otel` feature is OTLP-**push**, **traces only** — it has no native
+`/metrics` surface (an explicit non-goal of #784). The collector closes that gap:
+its `spanmetrics` connector derives RED metrics (request rate / errors / latency)
+from the incoming spans and its `prometheus` exporter exposes them for scraping.
+
+```bash
+helm install hyprstream charts/hyprstream --set observability.enabled=true \
+  --namespace hyprstream --create-namespace
+kubectl -n hyprstream port-forward svc/hyprstream-otel-collector 8889:8889
+curl http://localhost:8889/metrics    # hyprstream_traces_span_metrics_calls_total, ..._duration_milliseconds_*
+```
+
+The `spanmetrics` connector emits `traces.span.metrics.calls` (counter) and
+`..duration` (histogram); the prometheus exporter's `namespace` prefixes them,
+so the scrapeable series are `hyprstream_traces_span_metrics_calls_total` and
+`hyprstream_traces_span_metrics_duration_milliseconds_{bucket,count,sum}`,
+labelled by `service_name` plus the configured `dimensions` (route/method/status).
+
+| Value | Default | Purpose |
+|-------|---------|---------|
+| `observability.enabled` | `false` | Master toggle (env wiring + collector). |
+| `observability.otelExporterOtlpEndpoint` | `""` | Override; empty ⇒ the in-cluster collector Service. |
+| `observability.collector.enabled` | `true` | Deploy the bundled collector (false ⇒ env-only, point at an external one). |
+| `observability.collector.image.*` | contrib `0.128.0` | Contrib distro (needed for `spanmetrics`). |
+| `observability.collector.ports.prometheus` | `8889` | Prometheus exposition port (`/metrics`). |
+| `observability.collector.prometheusNamespace` | `hyprstream` | Metric name prefix. |
+| `observability.collector.dimensions` | route/method/status | Span attrs promoted to metric labels. |
+| `observability.collector.serviceMonitor.enabled` | `false` | Emit a kube-prometheus-stack `ServiceMonitor` (needs the Prometheus Operator CRD). |
+
+**Autoscaling signal (K6a, #792).** The `/metrics` endpoint is the scaling signal
+source: point `prometheus-adapter` or the KEDA prometheus scaler at it to drive an
+HPA on e.g. `hyprstream_traces_span_metrics_calls_total` request rate. Which spans hyprstream emits
+today (and which scaling signals — stream backpressure/queue depth, tokens/s —
+still need instrumentation) are tracked as follow-ups under #792; this chart only
+delivers the exposition surface.
 
 ## Image assumption
 

--- a/charts/hyprstream/templates/NOTES.txt
+++ b/charts/hyprstream/templates/NOTES.txt
@@ -21,4 +21,18 @@ IMPORTANT (Phase 0 substrate):
   * Per-service signing-key Secrets / trust store projection is available with
     keyBootstrap.enabled. Provide pre-generated Secrets; the chart does not mint
     signing keys or service JWTs.
-  * OTel Collector / Prometheus exposition: TODO(#784), gated by observability.enabled.
+{{- if .Values.observability.enabled }}
+
+Observability (K1b, #784) is ENABLED:
+  * Every service pushes OTLP traces to {{ include "hyprstream.otlpEndpoint" . }}.
+{{- if .Values.observability.collector.enabled }}
+  * OTel Collector {{ include "hyprstream.collectorName" . }} derives RED metrics
+    (request rate / errors / latency) from spans and exposes them for scraping:
+      kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "hyprstream.collectorName" . }} {{ .Values.observability.collector.ports.prometheus }}:{{ .Values.observability.collector.ports.prometheus }}
+      curl http://localhost:{{ .Values.observability.collector.ports.prometheus }}/metrics
+    Metrics are prefixed `{{ .Values.observability.collector.prometheusNamespace }}_` (e.g. {{ .Values.observability.collector.prometheusNamespace }}_traces_span_metrics_calls_total).
+    Feed this endpoint to prometheus-adapter/KEDA to drive an HPA (K6a, #792).
+{{- end }}
+{{- else }}
+  * OTel Collector / Prometheus exposition: available via observability.enabled=true (K1b, #784).
+{{- end }}

--- a/charts/hyprstream/templates/_helpers.tpl
+++ b/charts/hyprstream/templates/_helpers.tpl
@@ -65,6 +65,25 @@ Usage: include "hyprstream.svcName" (dict "root" $ "name" $name)
 {{- end }}
 
 {{/*
+OTel Collector object name: <fullname>-otel-collector.
+*/}}
+{{- define "hyprstream.collectorName" -}}
+{{- printf "%s-otel-collector" (include "hyprstream.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+The OTLP endpoint services push traces to. Explicit override wins; otherwise the
+in-cluster collector Service (gRPC/tonic on the OTLP gRPC port).
+*/}}
+{{- define "hyprstream.otlpEndpoint" -}}
+{{- if .Values.observability.otelExporterOtlpEndpoint -}}
+{{- .Values.observability.otelExporterOtlpEndpoint -}}
+{{- else -}}
+{{- printf "http://%s:%v" (include "hyprstream.collectorName" .) .Values.observability.collector.ports.otlpGrpc -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Resolve the container image for a service, applying the per-service variant
 suffix. Usage: include "hyprstream.image" (dict "root" $ "svc" $svc)
 */}}

--- a/charts/hyprstream/templates/configmap.yaml
+++ b/charts/hyprstream/templates/configmap.yaml
@@ -24,8 +24,9 @@ data:
   {{- end }}
   {{- end }}
   {{- if .Values.observability.enabled }}
-  # TODO(#784): observability wiring populates OTEL_EXPORTER_OTLP_ENDPOINT here.
-  {{- with .Values.observability.otelExporterOtlpEndpoint }}
-  OTEL_EXPORTER_OTLP_ENDPOINT: {{ . | quote }}
-  {{- end }}
+  # K1b (#784): turn on the OTLP trace exporter and point it at the collector.
+  # hyprstream only exports OTLP when HYPRSTREAM_OTEL_ENABLE=true (main.rs); the
+  # collector derives Prometheus-scrapeable RED metrics from those spans.
+  HYPRSTREAM_OTEL_ENABLE: "true"
+  OTEL_EXPORTER_OTLP_ENDPOINT: {{ include "hyprstream.otlpEndpoint" . | quote }}
   {{- end }}

--- a/charts/hyprstream/templates/deployments.yaml
+++ b/charts/hyprstream/templates/deployments.yaml
@@ -48,11 +48,15 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "hyprstream.fullname" $root }}-config
-          {{- if or $svc.env (and $root.Values.keyBootstrap.enabled $root.Values.keyBootstrap.issuerUrl) }}
+          {{- if or $svc.env $root.Values.observability.enabled (and $root.Values.keyBootstrap.enabled $root.Values.keyBootstrap.issuerUrl) }}
           env:
             {{- range $k, $v := $svc.env }}
             - name: {{ $k }}
               value: {{ $v | quote }}
+            {{- end }}
+            {{- if $root.Values.observability.enabled }}
+            - name: OTEL_SERVICE_NAME
+              value: {{ include "hyprstream.svcName" $ctx | quote }}
             {{- end }}
             {{- if and $root.Values.keyBootstrap.enabled $root.Values.keyBootstrap.issuerUrl }}
             - name: HYPRSTREAM__OAUTH__ISSUER_URL

--- a/charts/hyprstream/templates/observability.yaml
+++ b/charts/hyprstream/templates/observability.yaml
@@ -1,0 +1,229 @@
+{{- if and .Values.observability.enabled .Values.observability.collector.enabled }}
+{{- $root := . -}}
+{{- $col := .Values.observability.collector -}}
+{{- $name := include "hyprstream.collectorName" . -}}
+# -----------------------------------------------------------------------------
+# K1b (#784) — OpenTelemetry Collector: OTLP trace receiver -> spanmetrics
+# connector (RED metrics) -> Prometheus exposition (autoscaling signal source
+# for HPA/KEDA, #792). Standalone Deployment + ConfigMap + Service (all
+# built-in kinds; the optional ServiceMonitor below needs the Prometheus
+# Operator CRD).
+# -----------------------------------------------------------------------------
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $name }}-config
+  labels:
+    {{- include "hyprstream.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: otel-collector
+data:
+  collector.yaml: |
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:{{ $col.ports.health }}
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:{{ $col.ports.otlpGrpc }}
+          http:
+            endpoint: 0.0.0.0:{{ $col.ports.otlpHttp }}
+    processors:
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+      batch: {}
+    connectors:
+      # Derives request-rate / error / latency (RED) metrics from incoming spans
+      # per service, labelled by the dimensions below. This is the scaling signal.
+      # Emits `traces.span.metrics.calls` (counter) + `..duration` (histogram);
+      # the prometheus exporter `namespace` below prefixes them, giving
+      # {{ $col.prometheusNamespace }}_traces_span_metrics_calls_total etc.
+      spanmetrics:
+        histogram:
+          explicit:
+            buckets: [5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s, 2s, 5s, 10s]
+        {{- with $col.dimensions }}
+        dimensions:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        exemplars:
+          enabled: true
+        metrics_flush_interval: 15s
+    exporters:
+      # Prometheus exposition endpoint scraped by HPA/KEDA/kube-prometheus.
+      prometheus:
+        endpoint: 0.0.0.0:{{ $col.ports.prometheus }}
+        namespace: {{ $col.prometheusNamespace | quote }}
+        resource_to_telemetry_conversion:
+          enabled: true
+        enable_open_metrics: true
+      debug:
+        verbosity: basic
+    service:
+      extensions: [health_check]
+      # Disable the collector's own self-telemetry metrics server to avoid
+      # binding an extra port; the pipeline below is the exposition surface.
+      telemetry:
+        metrics:
+          level: none
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [spanmetrics, debug]
+        metrics:
+          receivers: [spanmetrics]
+          processors: [memory_limiter, batch]
+          exporters: [prometheus]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "hyprstream.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: otel-collector
+spec:
+  replicas: {{ $col.replicas }}
+  selector:
+    matchLabels:
+      {{- include "hyprstream.selectorLabels" $root | nindent 6 }}
+      app.kubernetes.io/component: otel-collector
+  template:
+    metadata:
+      labels:
+        {{- include "hyprstream.selectorLabels" $root | nindent 8 }}
+        app.kubernetes.io/component: otel-collector
+      annotations:
+        # Roll the collector when its rendered config changes.
+        checksum/config: {{ $col | toYaml | sha256sum }}
+        {{- with $col.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "hyprstream.serviceAccountName" $root }}
+      {{- with $root.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+      containers:
+        - name: otel-collector
+          image: "{{ $col.image.repository }}:{{ $col.image.tag }}"
+          imagePullPolicy: {{ $col.image.pullPolicy }}
+          args:
+            - --config=/conf/collector.yaml
+          ports:
+            - name: otlp-grpc
+              containerPort: {{ $col.ports.otlpGrpc }}
+              protocol: TCP
+            - name: otlp-http
+              containerPort: {{ $col.ports.otlpHttp }}
+              protocol: TCP
+            - name: prometheus
+              containerPort: {{ $col.ports.prometheus }}
+              protocol: TCP
+            - name: health
+              containerPort: {{ $col.ports.health }}
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: health
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+          {{- with $col.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /conf
+              readOnly: true
+      {{- with $col.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $col.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $col.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ $name }}-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "hyprstream.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: otel-collector
+  {{- with $col.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ $col.service.type | default "ClusterIP" }}
+  selector:
+    {{- include "hyprstream.selectorLabels" $root | nindent 4 }}
+    app.kubernetes.io/component: otel-collector
+  ports:
+    - name: otlp-grpc
+      port: {{ $col.ports.otlpGrpc }}
+      targetPort: otlp-grpc
+      protocol: TCP
+    - name: otlp-http
+      port: {{ $col.ports.otlpHttp }}
+      targetPort: otlp-http
+      protocol: TCP
+    - name: prometheus
+      port: {{ $col.ports.prometheus }}
+      targetPort: prometheus
+      protocol: TCP
+{{- if $col.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "hyprstream.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: otel-collector
+    {{- with $col.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "hyprstream.selectorLabels" $root | nindent 6 }}
+      app.kubernetes.io/component: otel-collector
+  endpoints:
+    - port: prometheus
+      path: /metrics
+      interval: {{ $col.serviceMonitor.interval }}
+      scrapeTimeout: {{ $col.serviceMonitor.scrapeTimeout }}
+{{- end }}
+{{- end }}

--- a/charts/hyprstream/tests/golden-observability.yaml
+++ b/charts/hyprstream/tests/golden-observability.yaml
@@ -1,0 +1,918 @@
+---
+# Source: hyprstream/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hyprstream
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: hyprstream/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hyprstream-config
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  # Shared HYPRSTREAM__* env for every service. Config crate maps
+  # HYPRSTREAM__<SECTION>__<FIELD> onto HyprConfig.
+  HYPRSTREAM__STORAGE__MODELS_DIR: "/var/lib/hyprstream/models"
+  HYPRSTREAM__STORAGE__LORAS_DIR: "/var/lib/hyprstream/loras"
+  HYPRSTREAM__STORAGE__CACHE_DIR: "/var/lib/hyprstream/cache"
+  HYPRSTREAM__STORAGE__CONFIG_DIR: "/var/lib/hyprstream/config"
+  HYPRSTREAM__TLS__ENABLED: "false"
+  HYPRSTREAM__QUIC__ENABLED: "true"
+  HYPRSTREAM__QUIC__IROH: "true"
+  HYPRSTREAM__QUIC__BIND_ADDR: "0.0.0.0:0"
+  # K1b (#784): turn on the OTLP trace exporter and point it at the collector.
+  # hyprstream only exports OTLP when HYPRSTREAM_OTEL_ENABLE=true (main.rs); the
+  # collector derives Prometheus-scrapeable RED metrics from those spans.
+  HYPRSTREAM_OTEL_ENABLE: "true"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://hyprstream-otel-collector:4317"
+---
+# Source: hyprstream/templates/observability.yaml
+# -----------------------------------------------------------------------------
+# K1b (#784) — OpenTelemetry Collector: OTLP trace receiver -> spanmetrics
+# connector (RED metrics) -> Prometheus exposition (autoscaling signal source
+# for HPA/KEDA, #792). Standalone Deployment + ConfigMap + Service (all
+# built-in kinds; the optional ServiceMonitor below needs the Prometheus
+# Operator CRD).
+# -----------------------------------------------------------------------------
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hyprstream-otel-collector-config
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-collector
+data:
+  collector.yaml: |
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:13133
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+    processors:
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+      batch: {}
+    connectors:
+      # Derives request-rate / error / latency (RED) metrics from incoming spans
+      # per service, labelled by the dimensions below. This is the scaling signal.
+      # Emits `traces.span.metrics.calls` (counter) + `..duration` (histogram);
+      # the prometheus exporter `namespace` below prefixes them, giving
+      # hyprstream_traces_span_metrics_calls_total etc.
+      spanmetrics:
+        histogram:
+          explicit:
+            buckets: [5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s, 2s, 5s, 10s]
+        dimensions:
+          - name: http.method
+          - name: http.route
+          - name: http.status_code
+          - name: rpc.method
+          - name: rpc.service
+        exemplars:
+          enabled: true
+        metrics_flush_interval: 15s
+    exporters:
+      # Prometheus exposition endpoint scraped by HPA/KEDA/kube-prometheus.
+      prometheus:
+        endpoint: 0.0.0.0:8889
+        namespace: "hyprstream"
+        resource_to_telemetry_conversion:
+          enabled: true
+        enable_open_metrics: true
+      debug:
+        verbosity: basic
+    service:
+      extensions: [health_check]
+      # Disable the collector's own self-telemetry metrics server to avoid
+      # binding an extra port; the pipeline below is the exposition surface.
+      telemetry:
+        metrics:
+          level: none
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [spanmetrics, debug]
+        metrics:
+          receivers: [spanmetrics]
+          processors: [memory_limiter, batch]
+          exporters: [prometheus]
+---
+# Source: hyprstream/templates/pvc.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hyprstream-data
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+# Source: hyprstream/templates/observability.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hyprstream-otel-collector
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-collector
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/component: otel-collector
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      targetPort: otlp-grpc
+      protocol: TCP
+    - name: otlp-http
+      port: 4318
+      targetPort: otlp-http
+      protocol: TCP
+    - name: prometheus
+      port: 8889
+      targetPort: prometheus
+      protocol: TCP
+---
+# Source: hyprstream/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hyprstream-discovery
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: discovery
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/component: discovery
+  ports:
+    - name: quic
+      port: 7002
+      targetPort: quic
+      protocol: UDP
+---
+# Source: hyprstream/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hyprstream-event
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: event
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/component: event
+  ports:
+    - name: quic
+      port: 7010
+      targetPort: quic
+      protocol: UDP
+---
+# Source: hyprstream/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hyprstream-model
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: model
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/component: model
+  ports:
+    - name: quic
+      port: 7004
+      targetPort: quic
+      protocol: UDP
+---
+# Source: hyprstream/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hyprstream-oai
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: oai
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/component: oai
+  ports:
+    - name: http
+      port: 6789
+      targetPort: http
+      protocol: TCP
+---
+# Source: hyprstream/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hyprstream-policy
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: policy
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/component: policy
+  ports:
+    - name: quic
+      port: 7001
+      targetPort: quic
+      protocol: UDP
+---
+# Source: hyprstream/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hyprstream-registry
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: registry
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/component: registry
+  ports:
+    - name: quic
+      port: 7003
+      targetPort: quic
+      protocol: UDP
+---
+# Source: hyprstream/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hyprstream-streams
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: streams
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/component: streams
+  ports:
+    - name: quic
+      port: 7011
+      targetPort: quic
+      protocol: UDP
+---
+# Source: hyprstream/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hyprstream-discovery
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: discovery
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hyprstream
+      app.kubernetes.io/instance: hyprstream
+      app.kubernetes.io/component: discovery
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hyprstream
+        app.kubernetes.io/instance: hyprstream
+        app.kubernetes.io/component: discovery
+    spec:
+      serviceAccountName: hyprstream
+      securityContext:
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: discovery
+          image: ghcr.io/hyprstream/hyprstream:0.1.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - service
+            - start
+            - discovery
+            - --foreground
+          envFrom:
+            - configMapRef:
+                name: hyprstream-config
+          env:
+            - name: HYPRSTREAM__DISCOVERY__QUIC_PORT
+              value: "7002"
+            - name: HYPRSTREAM__QUIC__SERVER_NAME
+              value: "hyprstream-discovery"
+            - name: OTEL_SERVICE_NAME
+              value: "hyprstream-discovery"
+          ports:
+            - name: quic
+              containerPort: 7002
+              protocol: UDP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 65532
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/hyprstream
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hyprstream-data
+---
+# Source: hyprstream/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hyprstream-event
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: event
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hyprstream
+      app.kubernetes.io/instance: hyprstream
+      app.kubernetes.io/component: event
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hyprstream
+        app.kubernetes.io/instance: hyprstream
+        app.kubernetes.io/component: event
+    spec:
+      serviceAccountName: hyprstream
+      securityContext:
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: event
+          image: ghcr.io/hyprstream/hyprstream:0.1.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - service
+            - start
+            - event
+            - --foreground
+          envFrom:
+            - configMapRef:
+                name: hyprstream-config
+          env:
+            - name: HYPRSTREAM__EVENT__QUIC_PORT
+              value: "7010"
+            - name: HYPRSTREAM__QUIC__SERVER_NAME
+              value: "hyprstream-event"
+            - name: OTEL_SERVICE_NAME
+              value: "hyprstream-event"
+          ports:
+            - name: quic
+              containerPort: 7010
+              protocol: UDP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 65532
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/hyprstream
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hyprstream-data
+---
+# Source: hyprstream/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hyprstream-model
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: model
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hyprstream
+      app.kubernetes.io/instance: hyprstream
+      app.kubernetes.io/component: model
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hyprstream
+        app.kubernetes.io/instance: hyprstream
+        app.kubernetes.io/component: model
+    spec:
+      serviceAccountName: hyprstream
+      securityContext:
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: model
+          image: ghcr.io/hyprstream/hyprstream:0.1.0-cpu
+          imagePullPolicy: IfNotPresent
+          args:
+            - service
+            - start
+            - model
+            - --foreground
+          envFrom:
+            - configMapRef:
+                name: hyprstream-config
+          env:
+            - name: HYPRSTREAM__MODEL__QUIC_PORT
+              value: "7004"
+            - name: HYPRSTREAM__QUIC__SERVER_NAME
+              value: "hyprstream-model"
+            - name: OTEL_SERVICE_NAME
+              value: "hyprstream-model"
+          ports:
+            - name: quic
+              containerPort: 7004
+              protocol: UDP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 65532
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/hyprstream
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hyprstream-data
+---
+# Source: hyprstream/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hyprstream-oai
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: oai
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hyprstream
+      app.kubernetes.io/instance: hyprstream
+      app.kubernetes.io/component: oai
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hyprstream
+        app.kubernetes.io/instance: hyprstream
+        app.kubernetes.io/component: oai
+    spec:
+      serviceAccountName: hyprstream
+      securityContext:
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: oai
+          image: ghcr.io/hyprstream/hyprstream:0.1.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - service
+            - start
+            - oai
+            - --foreground
+          envFrom:
+            - configMapRef:
+                name: hyprstream-config
+          env:
+            - name: HYPRSTREAM__OAI__HOST
+              value: "0.0.0.0"
+            - name: HYPRSTREAM__OAI__PORT
+              value: "6789"
+            - name: HYPRSTREAM__QUIC__SERVER_NAME
+              value: "hyprstream-oai"
+            - name: OTEL_SERVICE_NAME
+              value: "hyprstream-oai"
+          ports:
+            - name: http
+              containerPort: 6789
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 65532
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/hyprstream
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hyprstream-data
+---
+# Source: hyprstream/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hyprstream-policy
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: policy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hyprstream
+      app.kubernetes.io/instance: hyprstream
+      app.kubernetes.io/component: policy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hyprstream
+        app.kubernetes.io/instance: hyprstream
+        app.kubernetes.io/component: policy
+    spec:
+      serviceAccountName: hyprstream
+      securityContext:
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: policy
+          image: ghcr.io/hyprstream/hyprstream:0.1.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - service
+            - start
+            - policy
+            - --foreground
+          envFrom:
+            - configMapRef:
+                name: hyprstream-config
+          env:
+            - name: HYPRSTREAM__POLICY__QUIC_PORT
+              value: "7001"
+            - name: HYPRSTREAM__QUIC__SERVER_NAME
+              value: "hyprstream-policy"
+            - name: OTEL_SERVICE_NAME
+              value: "hyprstream-policy"
+          ports:
+            - name: quic
+              containerPort: 7001
+              protocol: UDP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 65532
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/hyprstream
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hyprstream-data
+---
+# Source: hyprstream/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hyprstream-registry
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: registry
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hyprstream
+      app.kubernetes.io/instance: hyprstream
+      app.kubernetes.io/component: registry
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hyprstream
+        app.kubernetes.io/instance: hyprstream
+        app.kubernetes.io/component: registry
+    spec:
+      serviceAccountName: hyprstream
+      securityContext:
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: registry
+          image: ghcr.io/hyprstream/hyprstream:0.1.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - service
+            - start
+            - registry
+            - --foreground
+          envFrom:
+            - configMapRef:
+                name: hyprstream-config
+          env:
+            - name: HYPRSTREAM__QUIC__SERVER_NAME
+              value: "hyprstream-registry"
+            - name: HYPRSTREAM__REGISTRY__QUIC_PORT
+              value: "7003"
+            - name: OTEL_SERVICE_NAME
+              value: "hyprstream-registry"
+          ports:
+            - name: quic
+              containerPort: 7003
+              protocol: UDP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 65532
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/hyprstream
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hyprstream-data
+---
+# Source: hyprstream/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hyprstream-streams
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: streams
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hyprstream
+      app.kubernetes.io/instance: hyprstream
+      app.kubernetes.io/component: streams
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hyprstream
+        app.kubernetes.io/instance: hyprstream
+        app.kubernetes.io/component: streams
+    spec:
+      serviceAccountName: hyprstream
+      securityContext:
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: streams
+          image: ghcr.io/hyprstream/hyprstream:0.1.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - service
+            - start
+            - streams
+            - --foreground
+          envFrom:
+            - configMapRef:
+                name: hyprstream-config
+          env:
+            - name: HYPRSTREAM__QUIC__SERVER_NAME
+              value: "hyprstream-streams"
+            - name: OTEL_SERVICE_NAME
+              value: "hyprstream-streams"
+          ports:
+            - name: quic
+              containerPort: 7011
+              protocol: UDP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 65532
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/hyprstream
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hyprstream-data
+---
+# Source: hyprstream/templates/observability.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hyprstream-otel-collector
+  labels:
+    helm.sh/chart: hyprstream-0.1.0
+    app.kubernetes.io/name: hyprstream
+    app.kubernetes.io/instance: hyprstream
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: otel-collector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hyprstream
+      app.kubernetes.io/instance: hyprstream
+      app.kubernetes.io/component: otel-collector
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hyprstream
+        app.kubernetes.io/instance: hyprstream
+        app.kubernetes.io/component: otel-collector
+      annotations:
+        # Roll the collector when its rendered config changes.
+        checksum/config: 909245b4b6619b5dbacb3cebbf79052cd757b686e5372e2fef494d3e61d8ce3d
+    spec:
+      serviceAccountName: hyprstream
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+      containers:
+        - name: otel-collector
+          image: "otel/opentelemetry-collector-contrib:0.128.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config=/conf/collector.yaml
+          ports:
+            - name: otlp-grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+            - name: prometheus
+              containerPort: 8889
+              protocol: TCP
+            - name: health
+              containerPort: 13133
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: health
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: config
+              mountPath: /conf
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: hyprstream-otel-collector-config

--- a/charts/hyprstream/values.yaml
+++ b/charts/hyprstream/values.yaml
@@ -121,14 +121,75 @@ keyBootstrap:
   policyCaSecret: ""
 
 # -----------------------------------------------------------------------------
-# TODO(#784) — K1b observability extension hook.
-# OTel Collector -> Prometheus exposition. NOT implemented here (separate issue).
-# When enabled, #784 will set OTEL_EXPORTER_OTLP_ENDPOINT on every service and
-# deploy/point at a collector. This chart only reserves the shape.
+# K1b observability (#784) — OpenTelemetry Collector -> Prometheus exposition.
+#
+# hyprstream's `otel` feature is OTLP-*push* only and exports **traces** (spans),
+# not metrics (crates/hyprstream/src/bin/main.rs). HPA/KEDA need a scrapeable
+# signal, so the chart deploys a standalone OTel Collector Deployment that:
+#   1. receives OTLP traces from every service (gRPC :4317 / HTTP :4318),
+#   2. derives RED metrics (request rate / errors / latency) from those spans
+#      via the `spanmetrics` connector, and
+#   3. exposes them on a Prometheus exposition endpoint (:8889 /metrics) that
+#      an HPA (prometheus-adapter) or KEDA prometheus scaler can consume (#792).
+#
+# When enabled, every service also gets HYPRSTREAM_OTEL_ENABLE=true and
+# OTEL_EXPORTER_OTLP_ENDPOINT pointed at the collector Service (see configmap).
+# Standalone Deployment (not sidecar/DaemonSet): OTLP is push, so services dial
+# one collector Service by DNS; Prometheus scrapes that one endpoint.
 # -----------------------------------------------------------------------------
 observability:
   enabled: false
-  # otelExporterOtlpEndpoint: ""   # filled by #784
+  # OTLP endpoint every service pushes traces to. Leave empty to default to the
+  # in-cluster collector Service below ("http://<fullname>-otel-collector:4317").
+  # Override to point at an external/existing collector instead.
+  otelExporterOtlpEndpoint: ""
+  collector:
+    # Deploy the bundled collector. Set false to only wire the env above at an
+    # external collector (otelExporterOtlpEndpoint must then be set).
+    enabled: true
+    image:
+      # contrib distro — the `spanmetrics` connector is not in the core distro.
+      repository: otel/opentelemetry-collector-contrib
+      tag: "0.128.0"
+      pullPolicy: IfNotPresent
+    replicas: 1
+    resources: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+    podAnnotations: {}
+    ports:
+      otlpGrpc: 4317
+      otlpHttp: 4318
+      # Prometheus exposition endpoint (scraped by HPA/KEDA/kube-prometheus).
+      prometheus: 8889
+      # Collector health_check extension (used for readiness/liveness).
+      health: 13133
+    # Metric name prefix on the Prometheus exposition
+    # (e.g. hyprstream_traces_span_metrics_calls_total).
+    prometheusNamespace: hyprstream
+    # Span attributes promoted to metric labels (dimensions) so scaling signals
+    # can be sliced per route/method. Attribute must exist on the span or the
+    # dimension is dropped.
+    dimensions:
+      - name: http.method
+      - name: http.route
+      - name: http.status_code
+      - name: rpc.method
+      - name: rpc.service
+    service:
+      type: ClusterIP
+      # Prometheus annotation-based scrape discovery (kube-prometheus ignores
+      # these — use serviceMonitor for that). Handy for prometheus.io/scrape.
+      annotations: {}
+    # Emit a kube-prometheus-stack ServiceMonitor. Requires the Prometheus
+    # Operator CRD (monitoring.coreos.com/v1) to be installed in the cluster.
+    serviceMonitor:
+      enabled: false
+      interval: 30s
+      scrapeTimeout: 10s
+      # Extra labels (e.g. release: kube-prometheus-stack) so the operator selects it.
+      labels: {}
 
 # -----------------------------------------------------------------------------
 # Defaults applied to every service; each services.<name> entry may override.


### PR DESCRIPTION
Implements **K1b (#784)** — Epic **#778** (Phase 0). Based on the base Helm chart branch `ewindisch/779-helm-chart` (#846), using the `observability.*` extension hooks it reserved.

## Problem
hyprstream's `otel` feature is OTLP-**push** and exports **traces only** (`crates/hyprstream/src/bin/main.rs`) — there is no scrapeable/queryable metrics surface. HPA/KEDA (K6a, #792) need one. A native `/metrics` endpoint in hyprstream is an explicit non-goal of this issue.

## What this adds
A standalone **OpenTelemetry Collector** deployed by the chart, gated behind `observability.enabled` (default **off**):

- **Receivers**: OTLP gRPC (`:4317`) + HTTP (`:4318`) — every service pushes traces here.
- **Connector**: `spanmetrics` — derives RED metrics (request rate / errors / latency) from the incoming spans.
- **Exporter**: `prometheus` (`:8889` `/metrics`) — the scrapeable exposition consumed as an autoscaling signal.
- **Pipelines**: `traces: otlp → spanmetrics`, `metrics: spanmetrics → prometheus`; `memory_limiter` + `batch` processors; `health_check` extension for probes.

**Shape**: standalone **Deployment + ConfigMap + Service** (all built-in kinds). Not a sidecar/DaemonSet — OTLP is push, so services dial one collector Service by DNS and Prometheus scrapes that one endpoint. Contrib collector image (`otel/opentelemetry-collector-contrib:0.128.0`) because `spanmetrics` isn't in the core distro. Hardened container securityContext (non-root, read-only rootfs, drop ALL caps).

**Env wiring**: when enabled, the shared ConfigMap sets `HYPRSTREAM_OTEL_ENABLE=true` and `OTEL_EXPORTER_OTLP_ENDPOINT` (defaulting to `http://<fullname>-otel-collector:4317`, overridable via `observability.otelExporterOtlpEndpoint` to point at an external collector).

**Optional**: a kube-prometheus-stack `ServiceMonitor`, gated behind `observability.collector.serviceMonitor.enabled` (requires the Prometheus Operator CRD).

## Metrics exposed
`hyprstream_traces_span_metrics_calls_total` (counter) and `hyprstream_traces_span_metrics_duration_milliseconds_{bucket,count,sum}` (histogram), labelled by `service_name`/`job` plus configurable `dimensions` (`http.route`, `http.method`, `http.status_code`, `rpc.method`, `rpc.service`). Prefix is `observability.collector.prometheusNamespace` (default `hyprstream`).

## Validation
- `helm lint` clean with observability **disabled**, **enabled**, and **enabled+serviceMonitor**.
- `kubeconform -strict` passes on the rendered output (disabled: 17/17, enabled: 20/20 valid; the ServiceMonitor CRD is `-ignore-missing-schemas`-skipped, built-ins strict).
- `helm install --dry-run=server` against the live **kind** API server: OK.
- **E2E on kind** (collector subset installed): collector rolls out healthy; a synthetic OTLP/HTTP span for `service.name=hyprstream-oai` produces `hyprstream_traces_span_metrics_calls_total{http_method="POST",http_route="/v1/chat/completions",http_status_code="200",service_name="hyprstream-oai",...}` on `/metrics`. Health endpoint 200, OTLP ingest 200.
- Default manifest render is byte-for-byte unchanged (observability off by default); added `tests/golden-observability.yaml` for the enabled path.

## Follow-ups (not in scope)
- **K6a (#792)**: wire prometheus-adapter/KEDA to consume `hyprstream_traces_span_metrics_calls_total` and drive a sample HPA end-to-end.
- Which spans hyprstream actually emits today, and instrumentation of scaling signals not yet in traces (stream backpressure / queue depth, tokens/s), are tracked under #792 — this PR delivers only the exposition surface.