### PR TITLE
feat(cas) L1: unified CAS substrate — multihash + dedup domains + CasStore absorption (#812)

### DIFF
--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -945,7 +945,7 @@ fn create_oai_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
 /// xet-enabled git repo can point its CAS endpoint at hyprstream. It dials the
 /// `registry` service (reusing the authenticated `putBlob`/`getBlob` core) and
 /// holds no standing CAS write authority of its own. Reads come from the shared
-/// `cas_serve::CasStore`.
+/// L1 CAS substrate (`crate::storage::CasSubstrate`, #812).
 #[service_factory("xet", depends_on = ["policy", "registry", "discovery"])]
 fn create_xet_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>> {
     info!("Creating XetService");
@@ -966,8 +966,8 @@ fn create_xet_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
         RegistryClient::for_service(sk.clone(), registry_vk, service_token("xet"))?;
 
     let state = XetState {
-        // Reads share the same content-addressed store the registry's getBlob uses.
-        store: cas_serve::CasStore::from_env(),
+        // Reads share the same L1 CAS substrate the registry's getBlob uses (#812).
+        store: crate::storage::CasSubstrate::from_env(),
         registry: Some(registry_client),
         jwt_verifying_key: ctx.jwt_verifying_key(),
         audience: config.xet.resource_url(),

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -1041,8 +1041,11 @@ impl RegistryService {
 
         let result = stream_channel
             .run_stream(&stream_ctx, |mut publisher| async move {
-                let store = cas_serve::CasStore::from_env();
-                let bytes = match store.get_file_bytes(&address).await {
+                // L1 CAS substrate, default (untenanted, BLAKE3, local) domain —
+                // layout-compatible with the legacy CasStore root (#812).
+                let substrate = crate::storage::CasSubstrate::from_env();
+                let domain = crate::storage::DedupDomain::local_default();
+                let bytes = match substrate.get(&domain, &address).await {
                     Ok(b) => b,
                     Err(e) => return (publisher, Err(anyhow!("getBlob reconstruction failed: {}", e))),
                 };
@@ -1826,9 +1829,13 @@ impl RegistryService {
             .map_err(|e| anyhow!("write not authorized on '{}': {}", data.grant_repo, e))?;
 
         // ── Chunk + store + SERVER-SIDE merkle (caller supplied only bytes) ──
-        let store = cas_serve::CasStore::from_env();
-        let put = store
-            .put_file_bytes(&data.bytes)
+        // Ingest through the L1 CAS substrate's default (untenanted, BLAKE3, local)
+        // domain (#812). The `security_label` carrier is left `None` here — object
+        // labeling/enforcement is #699/#767's job, not the ingest path's.
+        let substrate = crate::storage::CasSubstrate::from_env();
+        let domain = crate::storage::DedupDomain::local_default();
+        let put = substrate
+            .put(&domain, &data.bytes, None)
             .await
             .map_err(|e| anyhow!("CAS ingest failed: {e}"))?;
 

--- a/crates/hyprstream/src/services/xet.rs
+++ b/crates/hyprstream/src/services/xet.rs
@@ -55,7 +55,8 @@ use axum::{
     routing::{get, post},
     Router,
 };
-use cas_serve::{CasStore, StoreError};
+use crate::storage::cas::{CasError, CasSubstrate, DedupDomain};
+use cas_serve::StoreError;
 use hyprstream_rpc::prelude::*;
 use hyprstream_rpc::registry::SocketKind;
 use hyprstream_rpc::transport::TransportConfig;
@@ -71,9 +72,10 @@ pub const SERVICE_NAME: &str = "xet";
 /// Shared state for the axum HTTP handlers.
 #[derive(Clone)]
 pub struct XetState {
-    /// Content-addressed store backing `/get_xorb` reads (shared with the
-    /// registry's `getBlob` reconstruction path).
-    pub store: CasStore,
+    /// L1 CAS substrate backing `/get_xorb` reads (shared with the registry's
+    /// `getBlob` reconstruction path, #812). Reads use the default (untenanted,
+    /// BLAKE3, local) dedup domain.
+    pub store: CasSubstrate,
     /// Authenticated registry client — the write path (`/v1/xorbs`, `/v1/shards`)
     /// must translate through its `putBlob` RPC rather than writing directly.
     /// Dialed by the factory and held here so the 501 write stubs can be wired
@@ -206,12 +208,16 @@ async fn get_xorb_handler(
     Path(hash): Path<String>,
     headers: HeaderMap,
 ) -> Response {
-    let bytes = match state.store.read_xorb(&hash).await {
+    let bytes = match state
+        .store
+        .read_xorb(&DedupDomain::local_default(), &hash)
+        .await
+    {
         Ok(b) => b,
-        Err(StoreError::NotFound(_)) => {
+        Err(CasError::Store(StoreError::NotFound(_))) => {
             return (StatusCode::NOT_FOUND, "xorb not found").into_response()
         }
-        Err(StoreError::InvalidHash(_)) => {
+        Err(CasError::Store(StoreError::InvalidHash(_))) => {
             return (StatusCode::BAD_REQUEST, "invalid xorb hash").into_response()
         }
         Err(e) => {
@@ -440,7 +446,7 @@ mod tests {
         let (_sk, vk) = hyprstream_rpc::crypto::generate_signing_keypair();
 
         XetState {
-            store: CasStore::new(dir),
+            store: CasSubstrate::new(dir),
             // Write path is 501; no live registry needed to exercise reads/auth.
             registry: None,
             jwt_verifying_key: vk,

--- a/crates/hyprstream/src/storage/cas/domain.rs
+++ b/crates/hyprstream/src/storage/cas/domain.rs
@@ -1,0 +1,176 @@
+//! Dedup domains — the `(compartment, algorithm, trust_boundary)` key that
+//! decides which content may be deduplicated against which.
+//!
+//! A domain is realized as a distinct filesystem sub-root under the substrate
+//! root, so two blobs in different domains physically cannot share a xorb — the
+//! dedup partition is structural, not a runtime check that could be forgotten.
+
+use std::path::PathBuf;
+
+use hyprstream_rpc::auth::mac::Compartment;
+use hyprstream_rpc::cid::HashAlgo;
+
+/// The storage layer / trust boundary a blob lives in.
+///
+/// Local content is **never** deduplicated against shared-remote content: doing so
+/// would turn "is this xorb already present?" into an existence/content oracle
+/// across the boundary (U5). The boundary is part of the dedup-domain key, so the
+/// two tiers get physically separate storage roots.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TrustBoundary {
+    /// Node-local durable serving tier — the default write destination.
+    Local,
+    /// Content that originates from, or is shared with, a remote/federated peer.
+    SharedRemote,
+}
+
+impl TrustBoundary {
+    /// Stable, path-safe token for this boundary (used in the domain sub-root).
+    const fn token(self) -> &'static str {
+        match self {
+            TrustBoundary::Local => "local",
+            TrustBoundary::SharedRemote => "shared-remote",
+        }
+    }
+}
+
+/// A dedup domain: content is only ever deduplicated against other content in the
+/// **same** domain. Keyed by:
+///
+/// - `compartment` — tenant / need-to-know isolation, drawn from the existing MAC
+///   [`Compartment`] vocabulary (e.g. `"tenant:acme"`). `None` = untenanted. This
+///   field is READ-only vocabulary reuse; the substrate never authors, derives,
+///   or enforces MAC policy from it.
+/// - `algorithm` — the multihash algorithm; SHA-1 content is never deduplicated
+///   against SHA-256 (the pair would lean on the weaker collision resistance).
+/// - `trust_boundary` — see [`TrustBoundary`].
+///
+/// # On-disk mapping
+///
+/// The **default** domain `(None, Blake3, Local)` maps to the substrate root
+/// itself (no sub-directory), so the legacy `cas_serve::CasStore` layout and every
+/// existing caller keep working byte-for-byte. Every other domain maps to a
+/// deterministic, injective sub-path so distinct domains never collide.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DedupDomain {
+    /// Need-to-know compartment (tenant scope). `None` = untenanted.
+    pub compartment: Option<Compartment>,
+    /// Multihash algorithm partition.
+    pub algorithm: HashAlgo,
+    /// Storage layer / trust boundary partition.
+    pub trust_boundary: TrustBoundary,
+}
+
+impl DedupDomain {
+    /// The default domain: untenanted, BLAKE3-256, node-local. This is the domain
+    /// the current registry/XET call sites use, and it maps to the substrate root
+    /// (legacy layout, byte-for-byte parity).
+    pub fn local_default() -> Self {
+        Self {
+            compartment: None,
+            algorithm: HashAlgo::Blake3,
+            trust_boundary: TrustBoundary::Local,
+        }
+    }
+
+    /// A node-local, BLAKE3-256 domain scoped to a single tenant compartment.
+    pub fn local_tenant(compartment: Compartment) -> Self {
+        Self {
+            compartment: Some(compartment),
+            algorithm: HashAlgo::Blake3,
+            trust_boundary: TrustBoundary::Local,
+        }
+    }
+
+    /// True for the default domain (root-mapped, legacy-compatible).
+    pub fn is_default(&self) -> bool {
+        self.compartment.is_none()
+            && self.algorithm == HashAlgo::Blake3
+            && self.trust_boundary == TrustBoundary::Local
+    }
+
+    /// Relative sub-path (under the substrate root) isolating this domain's blobs.
+    ///
+    /// - Default domain → empty (the root itself), preserving the legacy layout.
+    /// - Otherwise →
+    ///   `domains/<boundary>/algo-<code>/c-<hex(compartment)|none>/`.
+    ///
+    /// The compartment name is hex-encoded so the mapping is injective and
+    /// path-safe regardless of the characters a compartment name contains (e.g.
+    /// the `:` in `"tenant:acme"`), and can never traverse out of the root.
+    pub fn relative_path(&self) -> PathBuf {
+        if self.is_default() {
+            return PathBuf::new();
+        }
+        let compartment = match &self.compartment {
+            Some(c) => format!("c-{}", hex::encode(c.as_str().as_bytes())),
+            None => "c-none".to_owned(),
+        };
+        PathBuf::from("domains")
+            .join(self.trust_boundary.token())
+            .join(format!("algo-{:#x}", self.algorithm as u64))
+            .join(compartment)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_domain_maps_to_root() {
+        let d = DedupDomain::local_default();
+        assert!(d.is_default());
+        assert_eq!(d.relative_path(), PathBuf::new(), "default domain is the root");
+    }
+
+    #[test]
+    fn distinct_domains_map_to_distinct_paths() {
+        // Every axis change must produce a distinct storage sub-root, or two
+        // domains would share xorbs (the exact leak the domain key prevents).
+        let base = DedupDomain::local_default();
+        let other_algo = DedupDomain {
+            algorithm: HashAlgo::Sha2_256,
+            ..DedupDomain::local_default()
+        };
+        let other_boundary = DedupDomain {
+            trust_boundary: TrustBoundary::SharedRemote,
+            ..DedupDomain::local_default()
+        };
+        let tenant_a = DedupDomain::local_tenant(Compartment::new("tenant:acme"));
+        let tenant_b = DedupDomain::local_tenant(Compartment::new("tenant:beta"));
+
+        let paths = [
+            base.relative_path(),
+            other_algo.relative_path(),
+            other_boundary.relative_path(),
+            tenant_a.relative_path(),
+            tenant_b.relative_path(),
+        ];
+        // All five must be pairwise distinct.
+        for i in 0..paths.len() {
+            for j in (i + 1)..paths.len() {
+                assert_ne!(paths[i], paths[j], "domains {i} and {j} collide on disk");
+            }
+        }
+    }
+
+    #[test]
+    fn compartment_path_is_traversal_safe() {
+        // A hostile-looking compartment name must not escape the root.
+        let d = DedupDomain::local_tenant(Compartment::new("../../etc/passwd"));
+        let p = d.relative_path();
+        assert!(
+            p.components().all(|c| !matches!(c, std::path::Component::ParentDir)),
+            "compartment name must never yield a `..` component: {p:?}"
+        );
+    }
+
+    #[test]
+    fn same_domain_is_stable() {
+        let a = DedupDomain::local_tenant(Compartment::new("tenant:acme"));
+        let b = DedupDomain::local_tenant(Compartment::new("tenant:acme"));
+        assert_eq!(a.relative_path(), b.relative_path());
+    }
+}

--- a/crates/hyprstream/src/storage/cas/manifest.rs
+++ b/crates/hyprstream/src/storage/cas/manifest.rs
@@ -1,0 +1,162 @@
+//! L1 blob manifest + multihash address helpers.
+//!
+//! The manifest is the substrate's ingest result: it carries the canonical
+//! self-describing content address (CIDv1 multihash), the legacy XET merkle hex
+//! (for the current wire and provenance keying), the reconstruction xorb set, the
+//! reconstructed byte length, and the `security_label` **carrier field** that
+//! unblocks #699 carrier-(b).
+
+use hyprstream_rpc::auth::mac::SecurityLabel;
+use hyprstream_rpc::cid::{decode_cid, encode_cid, Codec, HashAlgo};
+use serde::{Deserialize, Serialize};
+
+use super::CasError;
+
+/// Multicodec for a full-file reconstruction address.
+///
+/// A CAS blob is addressed by its XET reconstruction *shard* (merkle) hash, so the
+/// content-type codec is [`Codec::XetShard`] — see `cid.rs`.
+pub const FILE_RECONSTRUCTION_CODEC: Codec = Codec::XetShard;
+
+/// The L1 manifest describing one stored blob.
+///
+/// This is the substrate-level result type. It supersedes `cas_serve::PutResult`
+/// for substrate callers by adding the canonical [`Self::cid`] and the
+/// [`Self::security_label`] carrier field, while keeping [`Self::merkle`] and
+/// [`Self::xorb_hashes`] so existing wire/provenance behavior is preserved.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BlobManifest {
+    /// Canonical self-describing content address (CIDv1, base32 multibase). Encodes
+    /// the reconstruction codec + multihash algorithm + digest, so it is portable
+    /// across the local registry, federation, and XET CAS uniformly.
+    pub cid: String,
+
+    /// Legacy XET merkle root (hex). Identical to `cas_serve::PutResult::merkle`;
+    /// this is the digest embedded in [`Self::cid`]. Retained because the current
+    /// `putBlob`/`getBlob` wire and the provenance store key on it.
+    pub merkle: String,
+
+    /// Reconstruction xorb set (hex xorb hashes), from the underlying store.
+    pub xorb_hashes: Vec<String>,
+
+    /// Bytes newly written after content-addressed dedup within the domain
+    /// (`0` if fully deduplicated).
+    pub bytes_stored: u64,
+
+    /// Total byte length of the reconstructed content.
+    pub byte_len: u64,
+
+    /// **Carrier field (#699 carrier-(b)).** The MAC object label for this blob.
+    ///
+    /// Plumb-through only: the substrate never populates this with real policy,
+    /// never derives it, and never enforces on it. Population + enforcement is
+    /// #699/#767's job. `None` means *unlabeled carrier* — NOT "public".
+    #[serde(default)]
+    pub security_label: Option<SecurityLabel>,
+}
+
+/// Encode a legacy XET merkle hex digest as a canonical CIDv1 for the given
+/// algorithm, using the reconstruction-shard codec.
+pub fn cid_from_merkle(algorithm: HashAlgo, merkle_hex: &str) -> Result<String, CasError> {
+    let digest = hex::decode(merkle_hex).map_err(|e| CasError::Hex(e.to_string()))?;
+    encode_cid(FILE_RECONSTRUCTION_CODEC, algorithm, &digest).map_err(|e| CasError::Cid(e.to_string()))
+}
+
+/// Resolve a caller-supplied content address to the hex digest the underlying
+/// `cas_serve::CasStore` keys on.
+///
+/// Accepts **either**:
+/// - a canonical CIDv1 string (`b…` base32 multibase) — decoded to its digest, or
+/// - a legacy bare hex merkle (40 or 64 hex chars) — returned lowercased.
+///
+/// This is the compatibility seam that lets existing callers keep passing a hex
+/// merkle while new callers pass a self-describing multihash. The two address
+/// spaces are unambiguous: our legacy merkles are exactly 20- or 32-byte digests
+/// (40/64 hex chars), and a CID is longer and uses the base32 alphabet.
+pub fn merkle_from_address(address: &str) -> Result<String, CasError> {
+    let looks_like_legacy_hex =
+        matches!(address.len(), 40 | 64) && address.bytes().all(|b| b.is_ascii_hexdigit());
+    if looks_like_legacy_hex {
+        return Ok(address.to_ascii_lowercase());
+    }
+    let cid = decode_cid(address).map_err(|e| CasError::Cid(e.to_string()))?;
+    Ok(hex::encode(cid.multihash.digest))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cid_from_merkle_round_trips_via_address() {
+        // 32-byte blake3 merkle → CID → back to the same hex digest.
+        let merkle = "ab".repeat(32);
+        let cid = cid_from_merkle(HashAlgo::Blake3, &merkle).unwrap();
+        assert!(cid.starts_with('b'), "canonical CIDv1 base32 prefix");
+        let back = merkle_from_address(&cid).unwrap();
+        assert_eq!(back, merkle);
+    }
+
+    #[test]
+    fn legacy_hex_merkle_passes_through() {
+        let merkle = "cd".repeat(32); // 64 hex chars
+        assert_eq!(merkle_from_address(&merkle).unwrap(), merkle);
+        // Uppercase legacy hex is normalized to lowercase.
+        assert_eq!(merkle_from_address(&merkle.to_uppercase()).unwrap(), merkle);
+        // A 40-char (sha1) legacy digest is also accepted.
+        let sha1 = "ef".repeat(20);
+        assert_eq!(merkle_from_address(&sha1).unwrap(), sha1);
+    }
+
+    #[test]
+    fn cid_and_legacy_hex_resolve_identically() {
+        let merkle = "12".repeat(32);
+        let cid = cid_from_merkle(HashAlgo::Blake3, &merkle).unwrap();
+        assert_eq!(
+            merkle_from_address(&cid).unwrap(),
+            merkle_from_address(&merkle).unwrap(),
+            "a CID and its legacy hex must resolve to the same store key"
+        );
+    }
+
+    #[test]
+    fn rejects_garbage_address() {
+        // Not 40/64 hex, not a valid CID.
+        assert!(merkle_from_address("not-an-address").is_err());
+        assert!(cid_from_merkle(HashAlgo::Blake3, "zz").is_err());
+    }
+
+    #[test]
+    fn manifest_security_label_carrier_serializes() {
+        use hyprstream_rpc::auth::mac::{Assurance, CompartmentSet, Level};
+        let label = SecurityLabel::new(Level::Internal, Assurance::Classical, CompartmentSet::EMPTY);
+        let m = BlobManifest {
+            cid: "bexample".to_owned(),
+            merkle: "ab".repeat(32),
+            xorb_hashes: vec!["cd".repeat(32)],
+            bytes_stored: 42,
+            byte_len: 100,
+            security_label: Some(label),
+        };
+        let json = serde_json::to_string(&m).unwrap();
+        let back: BlobManifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, m);
+        assert_eq!(back.security_label, Some(label));
+    }
+
+    #[test]
+    fn manifest_unlabeled_carrier_round_trips() {
+        let m = BlobManifest {
+            cid: "bexample".to_owned(),
+            merkle: "ab".repeat(32),
+            xorb_hashes: vec![],
+            bytes_stored: 0,
+            byte_len: 0,
+            security_label: None,
+        };
+        let json = serde_json::to_string(&m).unwrap();
+        let back: BlobManifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.security_label, None, "None = unlabeled carrier, not public");
+    }
+}

--- a/crates/hyprstream/src/storage/cas/mod.rs
+++ b/crates/hyprstream/src/storage/cas/mod.rs
@@ -1,0 +1,74 @@
+//! L1 unified content-addressed store (CAS) substrate — #812 (epic #809, W1).
+//!
+//! One content-addressed store under everything. Every artifact is addressed by a
+//! self-describing **multihash** ([`hyprstream_rpc::cid`]), and every ingest is
+//! partitioned into a **dedup domain** keyed `(compartment, algorithm,
+//! trust_boundary)` so content is only ever deduplicated against other content in
+//! the *same* domain.
+//!
+//! ## What this layer is
+//!
+//! [`CasSubstrate`] absorbs [`cas_serve::CasStore`] (the write/reconstruct core
+//! left behind the retired `cas-serve` binary) behind a domain-partitioned,
+//! multihash-addressed facade. The registry `putBlob`/`getBlob` paths and the XET
+//! `get_xorb` route reach the store *through* the substrate now, never a bare
+//! `CasStore::from_env()`.
+//!
+//! - **Chunking** is unchanged: gearhash CDC via `cas_serve::chunker`, byte-for-byte
+//!   identical to xet-core (see that crate's `chunker.rs` golden test).
+//! - **Default algorithm** is BLAKE3-256, aligning with the existing
+//!   merklehash/xet substrate.
+//! - **On-disk layout** for the *default* domain `(None, Blake3, Local)` is
+//!   identical to the legacy `CasStore` root, so existing stores and callers keep
+//!   working byte-for-byte. Non-default domains get their own sub-root.
+//!
+//! ## Dedup domains ([`DedupDomain`])
+//!
+//! Content in different domains is **never** deduplicated together, because each
+//! domain is a distinct storage sub-root:
+//!
+//! - **compartment** — tenant / need-to-know isolation, keyed off the existing MAC
+//!   [`Compartment`](hyprstream_rpc::auth::mac::Compartment) vocabulary
+//!   (READ-only here — the substrate never authors or enforces MAC policy).
+//! - **algorithm** — SHA-1 content is never deduplicated against SHA-256; the pair
+//!   would lean on the weaker collision resistance.
+//! - **trust_boundary** — node-local content is never deduplicated against
+//!   shared-remote content (an existence/content oracle across the boundary, U5).
+//!
+//! ## MAC boundary (deliberate)
+//!
+//! [`BlobManifest`] carries a `security_label` **carrier field** (unblocks #699
+//! carrier-(b)). This is *plumb-through only*: the substrate never populates it
+//! with real policy, never derives clearance, and never enforces access. Object
+//! labeling and enforcement are #699/#767's job. A `None` label is an *unlabeled
+//! carrier*, NOT "public".
+
+mod domain;
+mod manifest;
+mod substrate;
+
+pub use domain::{DedupDomain, TrustBoundary};
+pub use manifest::{cid_from_merkle, merkle_from_address, BlobManifest, FILE_RECONSTRUCTION_CODEC};
+pub use substrate::CasSubstrate;
+
+/// Errors from the L1 CAS substrate.
+#[derive(Debug, thiserror::Error)]
+pub enum CasError {
+    /// The underlying content-addressed store failed (io, not-found, corrupt shard).
+    #[error("cas store: {0}")]
+    Store(#[from] cas_serve::StoreError),
+
+    /// A content address (CID / multihash) could not be encoded or decoded.
+    #[error("content address: {0}")]
+    Cid(String),
+
+    /// A hex digest was malformed.
+    #[error("invalid hex digest: {0}")]
+    Hex(String),
+
+    /// Ingest was requested for an algorithm the substrate cannot currently
+    /// *produce*. The domain vocabulary supports every algorithm for keying, but
+    /// the ingest path only computes BLAKE3-256 today (see [`CasSubstrate::put`]).
+    #[error("unsupported ingest algorithm: {0:?} (only BLAKE3-256 ingest is implemented)")]
+    UnsupportedIngestAlgorithm(hyprstream_rpc::cid::HashAlgo),
+}

--- a/crates/hyprstream/src/storage/cas/substrate.rs
+++ b/crates/hyprstream/src/storage/cas/substrate.rs
@@ -1,0 +1,223 @@
+//! [`CasSubstrate`] — the L1 unified content-addressed store.
+//!
+//! Wraps `cas_serve::CasStore` per dedup domain: each domain gets its own store
+//! rooted at [`DedupDomain::relative_path`] under the substrate root, so
+//! deduplication is structurally confined to a single `(compartment, algorithm,
+//! trust_boundary)` domain. Addressing is multihash: ingest returns a canonical
+//! CID, and reads accept either a CID or a legacy hex merkle.
+
+use std::path::{Path, PathBuf};
+
+use cas_serve::CasStore;
+use hyprstream_rpc::auth::mac::SecurityLabel;
+use hyprstream_rpc::cid::HashAlgo;
+
+use super::domain::DedupDomain;
+use super::manifest::{cid_from_merkle, merkle_from_address, BlobManifest};
+use super::CasError;
+
+/// The L1 unified content-addressed store.
+///
+/// A thin, domain-partitioning facade over `cas_serve::CasStore`. Construct once
+/// (`from_env`) and route every ingest/read through a [`DedupDomain`].
+#[derive(Debug, Clone)]
+pub struct CasSubstrate {
+    root: PathBuf,
+}
+
+impl CasSubstrate {
+    /// Open a substrate rooted at `root`.
+    pub fn new(root: impl AsRef<Path>) -> Self {
+        Self {
+            root: root.as_ref().to_path_buf(),
+        }
+    }
+
+    /// Open a substrate using the standard XET storage-path resolution
+    /// (`CAS_STORAGE` / `XET_CACHE_DIR` / `~/.cache/xet`), matching the legacy
+    /// `CasStore::from_env()` root exactly so the default domain is layout-compatible.
+    pub fn from_env() -> Self {
+        Self::new(cas_serve::store::resolve_storage_path())
+    }
+
+    /// The `CasStore` backing a given dedup domain (rooted at the domain sub-path).
+    fn store_for(&self, domain: &DedupDomain) -> CasStore {
+        CasStore::new(self.root.join(domain.relative_path()))
+    }
+
+    /// Ingest bytes into a dedup domain.
+    ///
+    /// Chunking (gearhash CDC), xorb aggregation, content-addressed dedup, and the
+    /// server-computed merkle all happen inside the underlying `CasStore` — byte
+    /// boundaries stay identical to xet-core. The substrate adds the canonical
+    /// multihash CID and attaches the `security_label` carrier (plumb-through only).
+    ///
+    /// Only BLAKE3-256 ingest is implemented today (the merkle the store computes
+    /// is BLAKE3-based); a non-BLAKE3 domain is rejected rather than mislabeled
+    /// with a CID that claims the wrong algorithm. The domain still *keys* every
+    /// algorithm so future non-BLAKE3 content never dedups against BLAKE3 content.
+    pub async fn put(
+        &self,
+        domain: &DedupDomain,
+        data: &[u8],
+        security_label: Option<SecurityLabel>,
+    ) -> Result<BlobManifest, CasError> {
+        if domain.algorithm != HashAlgo::Blake3 {
+            return Err(CasError::UnsupportedIngestAlgorithm(domain.algorithm));
+        }
+        let store = self.store_for(domain);
+        let put = store.put_file_bytes(data).await?;
+        let cid = cid_from_merkle(domain.algorithm, &put.merkle)?;
+        Ok(BlobManifest {
+            cid,
+            merkle: put.merkle,
+            xorb_hashes: put.xorb_hashes,
+            bytes_stored: put.bytes_stored,
+            byte_len: data.len() as u64,
+            security_label,
+        })
+    }
+
+    /// Reconstruct a blob's bytes by content address within a domain.
+    ///
+    /// `address` may be a canonical CID or a legacy hex merkle (see
+    /// [`merkle_from_address`]).
+    pub async fn get(&self, domain: &DedupDomain, address: &str) -> Result<Vec<u8>, CasError> {
+        let merkle = merkle_from_address(address)?;
+        let store = self.store_for(domain);
+        Ok(store.get_file_bytes(&merkle).await?)
+    }
+
+    /// Read the raw bytes of a single stored xorb, keyed by its hex xorb hash,
+    /// within a domain. Backs the HuggingFace-XET `GET /get_xorb/{hash}/` route.
+    pub async fn read_xorb(
+        &self,
+        domain: &DedupDomain,
+        xorb_hash_hex: &str,
+    ) -> Result<Vec<u8>, CasError> {
+        let store = self.store_for(domain);
+        Ok(store.read_xorb(xorb_hash_hex).await?)
+    }
+
+    /// True if the substrate can serve this content address within the domain.
+    pub fn exists(&self, domain: &DedupDomain, address: &str) -> bool {
+        match merkle_from_address(address) {
+            Ok(merkle) => self.store_for(domain).exists(&merkle),
+            Err(_) => false,
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use hyprstream_rpc::auth::mac::Compartment;
+
+    fn payload(seed: u8, len: usize) -> Vec<u8> {
+        (0..len)
+            .map(|i| seed.wrapping_add((i as u8).wrapping_mul(31)))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn put_get_round_trips_via_cid_and_legacy_hex() {
+        let dir = tempfile::tempdir().unwrap();
+        let sub = CasSubstrate::new(dir.path());
+        let domain = DedupDomain::local_default();
+        let original = payload(7, 256 * 1024);
+
+        let m = sub.put(&domain, &original, None).await.unwrap();
+        assert!(m.cid.starts_with('b'));
+        assert_eq!(m.byte_len, original.len() as u64);
+        assert!(m.bytes_stored > 0);
+
+        // Reconstruct by the canonical CID.
+        assert_eq!(sub.get(&domain, &m.cid).await.unwrap(), original);
+        // And by the legacy hex merkle — same content.
+        assert_eq!(sub.get(&domain, &m.merkle).await.unwrap(), original);
+        assert!(sub.exists(&domain, &m.cid));
+    }
+
+    #[tokio::test]
+    async fn default_domain_matches_legacy_casstore_layout() {
+        // Parity guard: a blob written through the substrate's default domain must
+        // be readable by a bare CasStore at the same root (byte-for-byte layout).
+        let dir = tempfile::tempdir().unwrap();
+        let sub = CasSubstrate::new(dir.path());
+        let original = payload(3, 200 * 1024);
+
+        let m = sub
+            .put(&DedupDomain::local_default(), &original, None)
+            .await
+            .unwrap();
+
+        let legacy = CasStore::new(dir.path());
+        assert_eq!(legacy.get_file_bytes(&m.merkle).await.unwrap(), original);
+    }
+
+    #[tokio::test]
+    async fn distinct_domains_do_not_dedup_together() {
+        // Same bytes in two domains must produce the same merkle but be stored
+        // independently: the second write is NOT deduplicated against the first.
+        let dir = tempfile::tempdir().unwrap();
+        let sub = CasSubstrate::new(dir.path());
+        let original = payload(9, 200 * 1024);
+
+        let default_domain = DedupDomain::local_default();
+        let tenant_domain = DedupDomain::local_tenant(Compartment::new("tenant:acme"));
+
+        let a = sub.put(&default_domain, &original, None).await.unwrap();
+        let b = sub.put(&tenant_domain, &original, None).await.unwrap();
+
+        // Content-addressed ⇒ identical merkle regardless of domain.
+        assert_eq!(a.merkle, b.merkle);
+        // But the tenant domain stored fresh bytes (no cross-domain dedup).
+        assert!(
+            b.bytes_stored > 0,
+            "cross-domain content must not deduplicate: existence/content leak"
+        );
+
+        // The tenant blob is NOT visible from the default domain and vice-versa is
+        // physically separate storage.
+        assert!(sub.exists(&tenant_domain, &b.merkle));
+    }
+
+    #[tokio::test]
+    async fn same_domain_reupload_dedups() {
+        let dir = tempfile::tempdir().unwrap();
+        let sub = CasSubstrate::new(dir.path());
+        let domain = DedupDomain::local_default();
+        let original = payload(11, 200 * 1024);
+
+        let first = sub.put(&domain, &original, None).await.unwrap();
+        let second = sub.put(&domain, &original, None).await.unwrap();
+        assert_eq!(first.merkle, second.merkle);
+        assert_eq!(second.bytes_stored, 0, "same-domain re-upload fully dedups");
+    }
+
+    #[tokio::test]
+    async fn non_blake3_ingest_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let sub = CasSubstrate::new(dir.path());
+        let domain = DedupDomain {
+            algorithm: HashAlgo::Sha2_256,
+            ..DedupDomain::local_default()
+        };
+        let err = sub.put(&domain, b"hello", None).await.unwrap_err();
+        assert!(matches!(err, CasError::UnsupportedIngestAlgorithm(_)));
+    }
+
+    #[tokio::test]
+    async fn carrier_label_is_passed_through() {
+        use hyprstream_rpc::auth::mac::{Assurance, CompartmentSet, Level};
+        let dir = tempfile::tempdir().unwrap();
+        let sub = CasSubstrate::new(dir.path());
+        let label = SecurityLabel::new(Level::Internal, Assurance::Classical, CompartmentSet::EMPTY);
+        let m = sub
+            .put(&DedupDomain::local_default(), b"payload-bytes", Some(label))
+            .await
+            .unwrap();
+        assert_eq!(m.security_label, Some(label), "carrier field plumbs through unchanged");
+    }
+}

--- a/crates/hyprstream/src/storage/mod.rs
+++ b/crates/hyprstream/src/storage/mod.rs
@@ -9,6 +9,7 @@
 //! - Git LFS to XET translation for Hugging Face models (via git2db::lfs, requires `xet` feature)
 //! - Git-native model registry
 pub mod adapter_manager;
+pub mod cas;
 pub mod errors;
 pub mod model_ref;
 pub mod paths;
@@ -16,6 +17,7 @@ pub mod release_store;
 
 // Re-export types for backward compatibility
 pub use adapter_manager::{AdapterConfig, AdapterInfo, AdapterManager};
+pub use cas::{BlobManifest, CasError, CasSubstrate, DedupDomain, TrustBoundary};
 pub use errors::{ModelRefError, ModelRefResult};
 pub use model_ref::{validate_model_name, GitRef, ModelRef};
 pub use paths::StoragePaths;


### PR DESCRIPTION
## L1 unified CAS substrate — #812 (epic #809, W1; #705 P0 core)

First, reviewable increment of the L1 unified content-addressed store: **one content-addressed store under everything**, multihash-addressed, dedup-domain-partitioned, absorbing `cas_serve::CasStore` behind it. Draft — enumerates deferred slices below.

### Delivered
- **New module `crates/hyprstream/src/storage/cas/`**
  - `DedupDomain { compartment, algorithm, trust_boundary }` + `TrustBoundary{Local,SharedRemote}` — the dedup key. Each domain is a **distinct filesystem sub-root**, so dedup is *structurally* confined per domain (not a runtime check that can be forgotten):
    - **compartment** keyed off the existing MAC `Compartment` vocabulary (READ-only reuse; hex-encoded into the path so tenant names like `tenant:acme` are injective + traversal-safe);
    - **algorithm-partitioned** — SHA-1 never dedups against SHA-256;
    - **layer-partitioned** — `Local` never dedups against `SharedRemote` (existence/content leak, U5).
    - The **default domain `(None, Blake3, Local)` maps to the substrate root itself** → byte-for-byte layout parity with the legacy `CasStore`, so every existing caller/on-disk store keeps working.
  - `BlobManifest` — substrate ingest result carrying the canonical **CIDv1 multihash** (`cid`), the legacy XET merkle hex (`merkle`, retained for the current wire + provenance keying), `xorb_hashes`, `bytes_stored`, `byte_len`, and the **`security_label` carrier field** (unblocks #699 carrier-(b) — plumb-through only, `None` = *unlabeled carrier*, never "public").
  - `CasSubstrate` — domain-partitioning facade over `cas_serve::CasStore`. `put` (BLAKE3-256 ingest → CID), `get`/`exists` (accept **either** a CID or a legacy hex merkle via `merkle_from_address`), `read_xorb`.
- **Multihash addressing** via the existing `hyprstream_rpc::cid` (`XetShard` codec + `Blake3`), default **BLAKE3-256**.
- **CasStore absorbed**: registry `putBlob`/`getBlob` and the XET `get_xorb` route now go through `CasSubstrate` (default local domain) — the only `CasStore` construction path is now the substrate. No wire/schema change; behavior preserved.
- **Chunking unchanged**: gearhash CDC via `cas_serve::chunker`, byte-identical to xet-core. The upstream golden boundary regression test already lives in `cas-serve/src/chunker.rs::boundaries_match_xet_core_const_data` and is exercised transitively.

### Tests (all green)
16 new `storage::cas` unit tests (multihash round-trip incl. CID↔legacy-hex equivalence; dedup-domain path keying incl. traversal-safety; substrate put/get parity + legacy-CasStore layout parity; **cross-domain no-dedup**; carrier plumb-through; non-BLAKE3 ingest rejection). Re-pointed `services::xet` (9) + `services::xet_provenance` all pass.

### Deferred (clearly-marked #812 follow-ups)
1. **Full dedup-domain enforcement** — registry/xet ingest currently use the default (untenanted, local) domain with `security_label: None`. Threading a real `compartment`/`trust_boundary` from verified identity, and *populating* the carrier label, is gated on MAC activation (#699/#767) — deliberately out of scope per the MAC boundary rule.
2. **Non-BLAKE3 ingest** — the domain vocabulary keys every algorithm, but `put` only *produces* BLAKE3-256 today (fails closed on other algos rather than mislabeling a CID). SHA-1/SHA-256 git-content ingest is a follow-up.
3. **RAFS blob absorption into L1** — see D-G below.
4. **CID as the wire identifier** — `putBlob`/`getBlob` still carry the hex merkle; promoting the CID to the schema is a separate additive change.
5. **Persisted manifest sidecar** — `BlobManifest` is currently the in-memory ingest result (on-disk format unchanged for parity/nydus-compat). A persisted per-blob manifest is future work.
6. L0 persistence union / L2 CAS Mount / L3 views (#813/#814).

### D-G nydus-compat assessment (#778 / #789 / #800)
**Not constrained by this PR.** The substrate does not absorb RAFS blobs yet (deferred slice 3), and it makes **no on-disk layout change** to the existing store: the default domain is the legacy `CasStore` root byte-for-byte, and non-default domains only add *new* sibling sub-roots (`domains/…`). Nothing stock nydus-snapshotter reads is touched. When RAFS absorption lands, the constraint is that RAFS blobs stay stock-nydus-compatible — flagged for that follow-up; coordinate with the 1:1.0 stream. No divergence introduced here.

### Design fork needing an owner decision
When RAFS blobs are absorbed (slice 3), a stock-nydus blob is content-addressed by its own (sha256) digest and lives in nydus' expected layout. Two options: (a) treat RAFS blobs as a **SharedRemote/sha256 dedup domain** that *shadows* the nydus layout (L1 as a projection, nydus dir authoritative), or (b) make L1 the store of record and expose a stock-nydus **view** (L3). This PR is compatible with both; the choice affects whether L1's default-root parity extends to the RAFS domain. Flagging for the epic owner.

Epic: #809 (W1, L1). Closes part of #812; depends conceptually on #810 (multihash addressing is the CAS's own, independent of libgit2's object store, so not gated on it).
