### PR TITLE
fix(auth): stop deriving service cnf.jwk from the CA root key

### DIFF
--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -356,16 +356,19 @@ impl PolicyHandler for PolicyService {
         let audience = data.audience.as_ref().filter(|s| !s.is_empty()).cloned()
             .or_else(|| self.default_audience.clone());
 
-        // Service tokens: derive the Ed25519 key bytes from the root CA key.
-        // The CA (PolicyService) is authoritative — the pubkey is not caller-provided.
+        // Service tokens: cnf.jwk must be the service's REGISTERED key, never a
+        // CA-derived guess (#441/#806) — bootstrap generates independent random
+        // per-service keys (`load_or_generate_service_signing_key`), so a derived
+        // pubkey here would not match the key the service actually holds. If no
+        // registered key exists yet, error rather than sign a wrong key binding.
         // User tokens: decode the caller-provided pubkey (from OAuth consent page).
         let service_key_bytes: Option<[u8; 32]> = if is_service_token {
             let svc_name = &subject["service:".len()..];
-            let svc_signing_key = hyprstream_rpc::node_identity::derive_purpose_key(
-                &self.signing_key,
-                &format!("service:{svc_name}"),
-            );
-            Some(*svc_signing_key.verifying_key().as_bytes())
+            let trust = hyprstream_service::global_trust_store();
+            let vk = trust.resolve_one(svc_name).ok_or_else(|| {
+                anyhow!("service key '{svc_name}' not registered; refusing to issue a service token with a fabricated cnf.jwk")
+            })?;
+            Some(*vk.as_bytes())
         } else {
             use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
             data.user_pub_key.as_deref().and_then(|s| {
@@ -1368,16 +1371,18 @@ impl PolicyHandler for PolicyService {
         let now = chrono::Utc::now().timestamp();
         let expires_at = now + ttl;
 
-        // Derive the service's pubkey from the root CA key (same as issue_token)
-        let svc_signing_key = hyprstream_rpc::node_identity::derive_purpose_key(
-            &self.signing_key,
-            &format!("service:{svc_name}"),
-        );
+        // cnf.jwk must be the service's REGISTERED key, never a CA-derived guess
+        // (#441/#806) — see handle_issue_token for the rationale. Registered-or-
+        // error: refuse to refresh a service token we can't bind to a real key.
+        let trust = hyprstream_service::global_trust_store();
+        let vk = trust.resolve_one(svc_name).ok_or_else(|| {
+            anyhow!("service key '{svc_name}' not registered; refusing to refresh a service token with a fabricated cnf.jwk")
+        })?;
 
         let issuer = self.default_audience.clone().unwrap_or_default();
         let claims = hyprstream_rpc::auth::Claims::new(subject.clone(), now, expires_at)
             .with_issuer(issuer)
-            .with_cnf_jwk(svc_signing_key.verifying_key().as_bytes());
+            .with_cnf_jwk(vk.as_bytes());
 
         let token = self.sign_token(&claims, true).await;
 


### PR DESCRIPTION
## Summary

Fixes #806, closing out the last living residue of epic #441 on the issuance side.

`crates/hyprstream/src/services/policy.rs` populated `cnf.jwk` on issued and refreshed
service tokens by **deriving** a pubkey from the root/CA signing key
(`derive_purpose_key(&self.signing_key, "service:{name}")`, at what were `policy.rs:364`
and `:1372`). But bootstrap actually generates **independent random** per-service keys
(`load_or_generate_service_signing_key`) — the derived pubkey can never match the key a
service actually holds. #441 already fixed the *verification/resolution* side
(`resolve_service_key`/`handle_resolve_service_key` is registered-or-error, no CA-derivation
fallback); this residue was on the *issuance* side.

## What changed

- `PolicyService::handle_issue_token` (service-token branch): instead of deriving
  `service_key_bytes` via `derive_purpose_key`, it now resolves the service's verifying key
  from the global trust store (`hyprstream_service::global_trust_store().resolve_one(svc_name)`).
  If the service has no registered key yet, `handle_issue_token` now errors instead of
  signing a fabricated key binding — mirroring the exact registered-or-error posture already
  used by `handle_resolve_service_key`.
- `PolicyService::handle_refresh_service_token`: same fix — the refreshed token's `cnf.jwk`
  now comes from the trust store lookup instead of `derive_purpose_key`, with the same
  fail-closed error on an unregistered key.

Both call sites named in the issue are fixed; no new fallback/compat path was introduced.

## registerServiceKey fail-closed (paired #441 decision)

The issue also asked me to check whether the paired #441 decision — "`registerServiceKey`
must be fail-closed (`factories.rs:99`): no JWT / cannot register → the service does not
serve signed responses, don't WARN-and-continue" — had already landed.

It has: `register_service_key()` in `crates/hyprstream/src/services/factories.rs` already
propagates every failure via `?` (all 11 call sites, one per service factory, use
`register_service_key(ctx, "...", &sk)?;`), and `resolve_registration_jwt` bails with a
descriptive error (naming the service and expected credentials path) when no CA-signed JWT
is found on disk or in the trust store — with an existing regression test
(`resolve_registration_jwt_fails_closed_when_missing`) covering exactly this. No
WARN-and-continue path remains, so **no change was needed there**; I left it alone rather
than bundling an unrelated diff into this PR.

## Scope discipline

Per the issue, I did **not** touch:
- #804 (secrets-dir resolution divergence, `policy.rs:1385-1392`) — adjacent hand-rolled
  disk-persist path, explicitly a separate ticket.
- #802/#803/#805/#808 (systemd credential-generation cluster) — separate layer, separate
  tickets.

## Judgment calls

- Used `anyhow!` + `?` (matching `handle_resolve_service_key`'s existing style) rather than
  building a new `PolicyResponseVariant::Error` variant, since the issue explicitly asked to
  mirror the already-fixed handler's error shape, not invent a new one.
- This is a behavior change for any deployment where a service was previously issued a token
  with a CA-derived (and effectively unusable) `cnf.jwk` before ever calling
  `registerServiceKey` — token issuance/refresh for that service will now fail until the
  service registers its real key. That's the intended fail-closed behavior per the issue;
  I did not add a compatibility shim to paper over it.

## Test plan

- [x] `cargo test -p hyprstream --lib` — 885 passed, 0 failed, 1 ignored
- [x] `cargo clippy --workspace --all-targets --features download-libtorch -- -D warnings` — clean, no warnings
- [x] Pre-commit hook (`cargo clippy --workspace --all-targets --release -- -D warnings`) passed