### PR TITLE
feat(#552): wire #mesh-kem keyAgreement into the DID document

### DIFF
--- a/crates/hyprstream/src/services/oauth/did_document.rs
+++ b/crates/hyprstream/src/services/oauth/did_document.rs
@@ -255,9 +255,9 @@ fn mesh_kem_key_agreement_methods(did: &str, x25519_ek: &[u8], mlkem768_ek: &[u8
 /// Validates the suite shape defensively (exactly the 2 components of
 /// `SuiteId::HyKemX25519MlKem768`, X25519 then ML-KEM-768) before emitting —
 /// `recipient_public` only ever comes from this node's own
-/// `derive_mesh_kem_recipient`, but a shape mismatch must fail closed (omit
-/// `keyAgreement`) rather than publish a malformed or misordered key that a
-/// peer would silently mis-anchor.
+/// `derive_mesh_kem_recipient`, but a shape mismatch must fail closed (publish
+/// an empty `keyAgreement` relationship) rather than publish a malformed or
+/// misordered key that a peer would silently mis-anchor.
 fn mesh_kem_key_agreement(
     did: &str,
     recipient_public: Option<&hyprstream_rpc::crypto::hybrid_kem::RecipientPublic>,

--- a/crates/hyprstream/src/services/oauth/did_document.rs
+++ b/crates/hyprstream/src/services/oauth/did_document.rs
@@ -186,30 +186,23 @@ fn mldsa65_verification_method(did: &str, key_id: &str, vk_bytes: &[u8]) -> Valu
 
 // ============================================================================
 // #mesh-kem hybrid keyAgreement identity (S1 / #552, epic #550)
-//
-// NOTE: this crate requires libtorch to compile, which was unavailable in the
-// implementing fork — the helpers below are faithful mirrors of the working
-// `#mesh-pq` / p256 multibase helpers above but are NOT compile-verified here.
-// Integration into `build_did_document` (push these into a `keyAgreement` array)
-// is a deliberate follow-up: it touches the builder signature + every caller, so
-// it is left to a pass that can compile the `hyprstream` crate.
 // ============================================================================
 
 /// multicodec `x25519-pub` unsigned-varint prefix (`0xec` → bytes `0xec 0x01`).
 const MULTICODEC_X25519_PUB: [u8; 2] = [0xec, 0x01];
 
-/// multicodec `ml-kem-768-pub` unsigned-varint prefix.
+/// multicodec `mlkem-768-pub` unsigned-varint prefix.
 ///
-/// PROVISIONAL: code point `0x120b` (ML-KEM-768 / FIPS 203 encapsulation key) as
-/// an unsigned varint → bytes `0x8b 0x24` (same shape as `ml-dsa-65-pub`
-/// `0x1211` → `0x91 0x24`). **Confirm against the multiformats multicodec
-/// registry / draft-ietf-cose-mlkem before production** — the exact ML-KEM code
-/// point must match what peers decode.
-const MULTICODEC_ML_KEM_768_PUB: [u8; 2] = [0x8b, 0x24];
+/// Code point `0x120c` (ML-KEM-768 / FIPS 203 encapsulation key) from the
+/// multiformats multicodec registry (`table.csv`, status: draft) — confirmed
+/// against the upstream registry (NOT `0x120b`, which is `mlkem-512-pub`; a
+/// one-code-point mixup there would silently anchor peers to the wrong key
+/// size). As an unsigned varint, `0x120c` encodes to the two bytes `0x8c 0x24`
+/// (same shape as `ml-dsa-65-pub` `0x1211` → `0x91 0x24`).
+const MULTICODEC_ML_KEM_768_PUB: [u8; 2] = [0x8c, 0x24];
 
 /// Multibase z-encode (base58btc, multicodec-prefixed) a raw X25519 encapsulation
 /// key (32 bytes) as a `Multikey` `publicKeyMultibase`.
-#[allow(dead_code)] // wired into build_did_document's keyAgreement set by the #552 follow-up
 fn x25519_to_multibase(ek_bytes: &[u8]) -> String {
     let mut payload = Vec::with_capacity(MULTICODEC_X25519_PUB.len() + ek_bytes.len());
     payload.extend_from_slice(&MULTICODEC_X25519_PUB);
@@ -219,7 +212,6 @@ fn x25519_to_multibase(ek_bytes: &[u8]) -> String {
 
 /// Multibase z-encode a raw ML-KEM-768 encapsulation key (1184 bytes) as a
 /// `Multikey` `publicKeyMultibase`.
-#[allow(dead_code)]
 fn mlkem768_to_multibase(ek_bytes: &[u8]) -> String {
     let mut payload = Vec::with_capacity(MULTICODEC_ML_KEM_768_PUB.len() + ek_bytes.len());
     payload.extend_from_slice(&MULTICODEC_ML_KEM_768_PUB);
@@ -238,7 +230,6 @@ fn mlkem768_to_multibase(ek_bytes: &[u8]) -> String {
 /// `x25519_ek` / `mlkem768_ek` are the raw encapsulation keys in suite-component
 /// order, from `hyprstream_rpc::node_identity::derive_mesh_kem_recipient(..)
 /// .public().eks`.
-#[allow(dead_code)] // build_did_document integration is the #552 follow-up (needs libtorch to verify)
 fn mesh_kem_key_agreement_methods(did: &str, x25519_ek: &[u8], mlkem768_ek: &[u8]) -> Vec<Value> {
     vec![
         json!({
@@ -254,6 +245,37 @@ fn mesh_kem_key_agreement_methods(did: &str, x25519_ek: &[u8], mlkem768_ek: &[u8
             "publicKeyMultibase": mlkem768_to_multibase(mlkem768_ek),
         }),
     ]
+}
+
+/// Build the `keyAgreement` entries for a node's `#mesh-kem` recipient public
+/// material, embedding the VMs directly in the `keyAgreement` relationship
+/// array (did:key convention — not cross-referenced via `verificationMethod`,
+/// since these are key-agreement-only keys, never used for signing).
+///
+/// Validates the suite shape defensively (exactly the 2 components of
+/// `SuiteId::HyKemX25519MlKem768`, X25519 then ML-KEM-768) before emitting —
+/// `recipient_public` only ever comes from this node's own
+/// `derive_mesh_kem_recipient`, but a shape mismatch must fail closed (omit
+/// `keyAgreement`) rather than publish a malformed or misordered key that a
+/// peer would silently mis-anchor.
+fn mesh_kem_key_agreement(
+    did: &str,
+    recipient_public: Option<&hyprstream_rpc::crypto::hybrid_kem::RecipientPublic>,
+) -> Vec<Value> {
+    use hyprstream_rpc::crypto::hybrid_kem::SuiteId;
+    let Some(pub_material) = recipient_public else {
+        return Vec::new();
+    };
+    // `SuiteId::HyKemX25519MlKem768.components()` is `[X25519, MlKem768]` by
+    // construction, so pinning the suite id here also pins the component
+    // order below.
+    if pub_material.suite_id != SuiteId::HyKemX25519MlKem768 {
+        return Vec::new();
+    }
+    let [x25519_ek, mlkem768_ek] = &pub_material.eks[..] else {
+        return Vec::new();
+    };
+    mesh_kem_key_agreement_methods(did, x25519_ek, mlkem768_ek)
 }
 
 #[cfg(test)]
@@ -312,6 +334,11 @@ fn ed25519_verification_method_jwk(did: &str, key_id: &str, vk: &VerifyingKey) -
 /// `at://{handle}`. The Ed25519 `keys` remain as additional (mesh) verification
 /// methods, and `transports` are additional typed `service` entries — both are
 /// ignored by atproto resolvers (which match by id/type) but used by our mesh.
+///
+/// `mesh_kem_public` (S1 / #552), when present, publishes the node's
+/// `#mesh-kem` hybrid keyAgreement recipient (X25519 + ML-KEM-768) as
+/// `keyAgreement` entries — additive and, like `mesh_pq_vk`, ignored by
+/// atproto resolvers.
 fn build_did_document(
     did: &str,
     issuer_url: &str,
@@ -319,6 +346,7 @@ fn build_did_document(
     atproto: Option<&AtprotoIdentity<'_>>,
     transports: &[TransportEndpoint],
     mesh_pq_vk: Option<&[u8]>,
+    mesh_kem_public: Option<&hyprstream_rpc::crypto::hybrid_kem::RecipientPublic>,
 ) -> Value {
     let mut verification_methods = Vec::with_capacity(keys.len() * 2 + 2);
     let mut authentication_refs = Vec::with_capacity(keys.len() * 2 + 2);
@@ -379,6 +407,12 @@ fn build_did_document(
         }));
     }
 
+    // `#mesh-kem` hybrid keyAgreement (S1 / #552): embedded directly in the
+    // `keyAgreement` relationship (did:key convention) — these are
+    // key-agreement-only keys, never cross-referenced from
+    // `verificationMethod`/`authentication`/`assertionMethod`.
+    let key_agreement = mesh_kem_key_agreement(did, mesh_kem_public);
+
     let mut doc = json!({
         "@context": [
             "https://www.w3.org/ns/did/v1",
@@ -389,6 +423,7 @@ fn build_did_document(
         "verificationMethod": verification_methods,
         "authentication": authentication_refs,
         "assertionMethod": assertion_refs,
+        "keyAgreement": key_agreement,
         "service": services,
     });
 
@@ -501,6 +536,7 @@ pub async fn root_did_document(
         atproto.as_ref(),
         &transports,
         state.mesh_pq_verifying_key.as_deref(),
+        state.mesh_kem_public.as_ref(),
     );
     (
         StatusCode::OK,
@@ -582,7 +618,7 @@ pub async fn user_did_document(
         None => Vec::new(),
     };
 
-    let doc = build_did_document(&did, &state.issuer_url, &keys, None, &[], None);
+    let doc = build_did_document(&did, &state.issuer_url, &keys, None, &[], None, None);
     (
         StatusCode::OK,
         [(header::CONTENT_TYPE, "application/did+json")],
@@ -621,7 +657,7 @@ pub async fn client_did_document(
     // lookup + extract_ed25519_keys_from_jwks call.
     let keys: Vec<(String, VerifyingKey)> = Vec::new();
 
-    let doc = build_did_document(&did, &state.issuer_url, &keys, None, &[], None);
+    let doc = build_did_document(&did, &state.issuer_url, &keys, None, &[], None, None);
     (
         StatusCode::OK,
         [(header::CONTENT_TYPE, "application/did+json")],
@@ -724,6 +760,7 @@ mod tests {
             None,
             &[],
             None,
+            None,
         );
         assert_eq!(doc["id"].as_str().unwrap(), did);
         assert!(doc["@context"].is_array());
@@ -744,7 +781,7 @@ mod tests {
     #[test]
     fn build_did_doc_empty_keys_is_valid() {
         let did = "did:web:example.com:users:alice";
-        let doc = build_did_document(did, "https://example.com", &[], None, &[], None);
+        let doc = build_did_document(did, "https://example.com", &[], None, &[], None, None);
         assert_eq!(doc["id"].as_str().unwrap(), did);
         assert_eq!(doc["verificationMethod"].as_array().unwrap().len(), 0);
         assert_eq!(doc["authentication"].as_array().unwrap().len(), 0);
@@ -783,6 +820,7 @@ mod tests {
             &[("key-1".to_owned(), ed.verifying_key())],
             Some(&atproto),
             &transports,
+            None,
             None,
         );
 
@@ -878,6 +916,7 @@ mod tests {
             None,
             &[],
             Some(&vk_bytes),
+            None,
         );
         let vms = doc["verificationMethod"].as_array().unwrap();
         // key-1 multibase + key-1 jwk + mesh-pq = 3.
@@ -911,6 +950,7 @@ mod tests {
             None,
             &[],
             Some(&pq_vk_bytes),
+            None,
         );
         let vms = doc["verificationMethod"].as_array().unwrap();
         let pq = vms.iter().find(|v| v["id"] == format!("{did}#mesh-pq")).unwrap();
@@ -952,6 +992,7 @@ mod tests {
             None,
             &transports,
             None,
+            None,
         );
 
         // The `#iroh` VM is present and carries the node_id as a Multikey.
@@ -991,6 +1032,7 @@ mod tests {
             None,
             &[],
             None,
+            None,
         );
         let vms = doc["verificationMethod"].as_array().unwrap();
         assert!(
@@ -1002,6 +1044,80 @@ mod tests {
             !svcs.iter().any(|s| s["type"] == "IrohTransport"),
             "no IrohTransport entry when iroh is not bound"
         );
+    }
+
+    #[test]
+    fn build_did_doc_omits_key_agreement_when_mesh_kem_absent() {
+        // No `#mesh-kem` public material provided → `keyAgreement` is present
+        // but empty (a valid, empty DID-document relationship), never omitted
+        // outright (omitting the key entirely would be a different, also-valid
+        // shape, but an empty array is simpler for consumers to handle uniformly).
+        let sk = SigningKey::generate(&mut OsRng);
+        let did = "did:web:hyprstream.example.com";
+        let doc = build_did_document(
+            did,
+            "https://hyprstream.example.com",
+            &[("key-1".to_owned(), sk.verifying_key())],
+            None,
+            &[],
+            None,
+            None,
+        );
+        assert_eq!(doc["keyAgreement"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn build_did_doc_publishes_mesh_kem_key_agreement() {
+        // S1 / #552: when a `#mesh-kem` recipient public is provided,
+        // build_did_document emits both suite-component `keyAgreement` VMs
+        // (X25519 + ML-KEM-768), embedded directly (not cross-referenced from
+        // verificationMethod/authentication/assertionMethod — these are
+        // key-agreement-only keys).
+        let node_sk = SigningKey::generate(&mut OsRng);
+        let kem_kp = hyprstream_rpc::node_identity::derive_mesh_kem_recipient(&node_sk)
+            .expect("derive #mesh-kem recipient");
+        let kem_pub = kem_kp.public();
+
+        let did = "did:web:hyprstream.example.com";
+        let doc = build_did_document(
+            did,
+            "https://hyprstream.example.com",
+            &[("key-1".to_owned(), node_sk.verifying_key())],
+            None,
+            &[],
+            None,
+            Some(&kem_pub),
+        );
+
+        // keyAgreement carries exactly the two suite-component VMs, and they
+        // are NOT duplicated into verificationMethod/authentication/assertionMethod.
+        let kas = doc["keyAgreement"].as_array().unwrap();
+        assert_eq!(kas.len(), 2);
+        assert_eq!(kas[0]["id"].as_str().unwrap(), format!("{did}#mesh-kem-x25519"));
+        assert_eq!(kas[0]["type"].as_str().unwrap(), "Multikey");
+        assert_eq!(kas[1]["id"].as_str().unwrap(), format!("{did}#mesh-kem-mlkem768"));
+        assert_eq!(kas[1]["type"].as_str().unwrap(), "Multikey");
+
+        let vms = doc["verificationMethod"].as_array().unwrap();
+        assert!(!vms.iter().any(|v| v["id"] == format!("{did}#mesh-kem-x25519")));
+        assert!(!vms.iter().any(|v| v["id"] == format!("{did}#mesh-kem-mlkem768")));
+        assert!(!doc["authentication"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|v| v.as_str().map(|s| s.contains("mesh-kem")).unwrap_or(false)));
+
+        // The published X25519 leg round-trips to the exact bytes derived —
+        // consistency between the DID doc and the key the node actually holds.
+        let mb = kas[0]["publicKeyMultibase"].as_str().unwrap();
+        let decoded = bs58::decode(&mb[1..]).into_vec().unwrap();
+        assert_eq!(&decoded[..2], &MULTICODEC_X25519_PUB);
+        assert_eq!(&decoded[2..], kem_pub.eks[0].as_slice());
+
+        let mb2 = kas[1]["publicKeyMultibase"].as_str().unwrap();
+        let decoded2 = bs58::decode(&mb2[1..]).into_vec().unwrap();
+        assert_eq!(&decoded2[..2], &MULTICODEC_ML_KEM_768_PUB);
+        assert_eq!(&decoded2[2..], kem_pub.eks[1].as_slice());
     }
 
     #[test]

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -527,6 +527,7 @@ impl Spawnable for OAuthService {
                 &self.config,
             );
             info!("ML-DSA-65 signing key rotation store loaded");
+            let crypto_policy = hyprstream_rpc::envelope::envelope_policy_from_env();
 
             // MAC #547 / B2 (#674): construct the S6 grant-path audit sink. A
             // startup-time snapshot of the active ML-DSA-65 key (rotation
@@ -536,7 +537,6 @@ impl Spawnable for OAuthService {
             // decides whether the PQ layer is REQUIRED (fail-closed if the key
             // snapshot comes back empty) or ignored (Classical).
             let audit_sink: Option<Arc<dyn crate::mac::audit::AuditSink>> = {
-                let crypto_policy = hyprstream_rpc::envelope::envelope_policy_from_env();
                 let audit_pq_key = ml_dsa_store.active_key().await;
                 let signer = crate::mac::audit::cose::OwnedCoseAuditSigner::new(
                     Arc::new(self.signing_key.clone()),
@@ -632,7 +632,9 @@ impl Spawnable for OAuthService {
             if let Some(ds) = device_store_opt {
                 oauth_state = oauth_state.with_device_store(ds);
             }
-            oauth_state = oauth_state.with_signing_key(self.signing_key.clone());
+            oauth_state = oauth_state
+                .with_signing_key(self.signing_key.clone(), crypto_policy)
+                .map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(format!("{e:#}")))?;
             if let Some(key) = ca_jwt_key {
                 oauth_state = oauth_state.with_ca_jwt_key(key);
             }

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -6,6 +6,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use anyhow::Context as _;
 use base64::Engine as _;
 use tokio::sync::RwLock;
 use serde::{Deserialize, Serialize};
@@ -143,6 +144,39 @@ pub struct PushedAuthRequest {
 impl PushedAuthRequest {
     pub fn is_expired(&self) -> bool {
         Instant::now() > self.expires_at
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use hyprstream_rpc::crypto::CryptoPolicy;
+    use rand::rngs::OsRng;
+
+    #[test]
+    fn mesh_kem_derivation_failure_fails_closed_under_hybrid() {
+        let key = ed25519_dalek::SigningKey::generate(&mut OsRng);
+        let err = mesh_kem_public_for_policy(&key, CryptoPolicy::Hybrid, |_| {
+            Err(anyhow::anyhow!("synthetic derivation failure"))
+        })
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("Hybrid policy"),
+            "unexpected error: {err:?}",
+        );
+    }
+
+    #[test]
+    fn mesh_kem_derivation_failure_is_empty_under_classical() {
+        let key = ed25519_dalek::SigningKey::generate(&mut OsRng);
+        let public = mesh_kem_public_for_policy(&key, CryptoPolicy::Classical, |_| {
+            Err(anyhow::anyhow!("synthetic derivation failure"))
+        })
+        .unwrap();
+
+        assert!(public.is_none());
     }
 }
 
@@ -434,8 +468,9 @@ pub struct OAuthState {
     /// verification methods in the root DID document. Derived from the same
     /// Ed25519 key as [`Self::signing_key`] (via `derive_mesh_kem_recipient`),
     /// so the published keys equal what the node decapsulates `#mesh-kem`
-    /// envelopes with. `None` when the entity signing key is not configured
-    /// (or derivation failed — see `with_signing_key`).
+    /// envelopes with. `None` when the entity signing key is not configured,
+    /// or when derivation failed under Classical policy (Hybrid fails closed
+    /// during `with_signing_key`).
     pub mesh_kem_public: Option<hyprstream_rpc::crypto::hybrid_kem::RecipientPublic>,
     /// #282: the node's iroh endpoint id (its Ed25519 `node_id`, 32 bytes),
     /// published as the `#iroh` verification method + an `IrohTransport` service
@@ -446,6 +481,29 @@ pub struct OAuthState {
     /// `relays`. Empty = rely on pkarr/DNS discovery for reachability (the
     /// peer resolves direct paths by node_id alone).
     pub iroh_relays: Vec<String>,
+}
+
+fn mesh_kem_public_for_policy(
+    key: &ed25519_dalek::SigningKey,
+    policy: hyprstream_rpc::crypto::CryptoPolicy,
+    derive: impl FnOnce(
+        &ed25519_dalek::SigningKey,
+    ) -> anyhow::Result<hyprstream_rpc::crypto::hybrid_kem::RecipientKeypair>,
+) -> anyhow::Result<Option<hyprstream_rpc::crypto::hybrid_kem::RecipientPublic>> {
+    match derive(key) {
+        Ok(kem_kp) => Ok(Some(kem_kp.public())),
+        Err(e) if policy.uses_pq() => Err(e).context(
+            "failed to derive #mesh-kem hybrid keyAgreement identity under Hybrid policy",
+        ),
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "failed to derive #mesh-kem hybrid keyAgreement identity under Classical policy; \
+                 root DID document will publish an empty keyAgreement relationship",
+            );
+            Ok(None)
+        }
+    }
 }
 
 impl OAuthState {
@@ -651,25 +709,22 @@ impl OAuthState {
     /// with (`derive_mesh_mldsa_key`), and the node's `#mesh-kem` hybrid
     /// keyAgreement public material (S1 / #552, `derive_mesh_kem_recipient`) so
     /// peers can anchor a recipient key that matches what this node decapsulates
-    /// with. A `#mesh-kem` derivation failure is logged and leaves
-    /// `mesh_kem_public` unset — the DID document then omits `keyAgreement`
-    /// rather than publishing a key the node cannot actually use (fail-closed:
-    /// no unanchorable/unusable key is ever advertised).
-    pub fn with_signing_key(mut self, key: ed25519_dalek::SigningKey) -> Self {
+    /// with. A `#mesh-kem` derivation failure is fail-closed under Hybrid
+    /// policy: startup returns an error rather than publishing a root DID
+    /// document with an empty `keyAgreement` relationship. Under Classical
+    /// policy, the failure is logged and `mesh_kem_public` stays unset.
+    pub fn with_signing_key(
+        mut self,
+        key: ed25519_dalek::SigningKey,
+        policy: hyprstream_rpc::crypto::CryptoPolicy,
+    ) -> anyhow::Result<Self> {
         let pq_sk = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&key);
         self.mesh_pq_verifying_key = Some(hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(&pq_sk));
-        match hyprstream_rpc::node_identity::derive_mesh_kem_recipient(&key) {
-            Ok(kem_kp) => self.mesh_kem_public = Some(kem_kp.public()),
-            Err(e) => {
-                tracing::error!(
-                    error = %e,
-                    "failed to derive #mesh-kem hybrid keyAgreement identity; \
-                     root DID document will omit keyAgreement",
-                );
-            }
-        }
+        self.mesh_kem_public = mesh_kem_public_for_policy(&key, policy, |key| {
+            hyprstream_rpc::node_identity::derive_mesh_kem_recipient(key)
+        })?;
         self.signing_key = Some(key);
-        self
+        Ok(self)
     }
 
     /// Inject a pre-built token store implementation.

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -428,6 +428,15 @@ pub struct OAuthState {
     /// the published VM equals the key the node signs mesh responses with.
     /// `None` when the entity signing key is not configured.
     pub mesh_pq_verifying_key: Option<Vec<u8>>,
+    /// The node's `#mesh-kem` hybrid keyAgreement public material (S1 / #552):
+    /// one ML-KEM-768-hybrid recipient public (X25519 + ML-KEM-768 encapsulation
+    /// keys, suite `HyKemX25519MlKem768`). Published as the `keyAgreement`
+    /// verification methods in the root DID document. Derived from the same
+    /// Ed25519 key as [`Self::signing_key`] (via `derive_mesh_kem_recipient`),
+    /// so the published keys equal what the node decapsulates `#mesh-kem`
+    /// envelopes with. `None` when the entity signing key is not configured
+    /// (or derivation failed — see `with_signing_key`).
+    pub mesh_kem_public: Option<hyprstream_rpc::crypto::hybrid_kem::RecipientPublic>,
     /// #282: the node's iroh endpoint id (its Ed25519 `node_id`, 32 bytes),
     /// published as the `#iroh` verification method + an `IrohTransport` service
     /// entry in the root DID document — **only** when the iroh substrate is
@@ -497,6 +506,7 @@ impl OAuthState {
             quic_cert_hashes: Vec::new(),
             quic_public_uri: None,
             mesh_pq_verifying_key: None,
+            mesh_kem_public: None,
             iroh_node_id: None,
             iroh_relays: Vec::new(),
         }
@@ -638,10 +648,26 @@ impl OAuthState {
     /// Also derives and stores the node's mesh ML-DSA-65 verifying key (#157)
     /// from this same Ed25519 key, so the root DID document's `#mesh-pq`
     /// Multikey verification method matches the post-quantum key the mesh signs
-    /// with (`derive_mesh_mldsa_key`).
+    /// with (`derive_mesh_mldsa_key`), and the node's `#mesh-kem` hybrid
+    /// keyAgreement public material (S1 / #552, `derive_mesh_kem_recipient`) so
+    /// peers can anchor a recipient key that matches what this node decapsulates
+    /// with. A `#mesh-kem` derivation failure is logged and leaves
+    /// `mesh_kem_public` unset — the DID document then omits `keyAgreement`
+    /// rather than publishing a key the node cannot actually use (fail-closed:
+    /// no unanchorable/unusable key is ever advertised).
     pub fn with_signing_key(mut self, key: ed25519_dalek::SigningKey) -> Self {
         let pq_sk = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&key);
         self.mesh_pq_verifying_key = Some(hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(&pq_sk));
+        match hyprstream_rpc::node_identity::derive_mesh_kem_recipient(&key) {
+            Ok(kem_kp) => self.mesh_kem_public = Some(kem_kp.public()),
+            Err(e) => {
+                tracing::error!(
+                    error = %e,
+                    "failed to derive #mesh-kem hybrid keyAgreement identity; \
+                     root DID document will omit keyAgreement",
+                );
+            }
+        }
         self.signing_key = Some(key);
         self
     }


### PR DESCRIPTION
Closes #552, part of epic #550.

## Context

S1 (#552) landed earlier as PR #562 (`derive_mesh_kem_recipient`, the `KemTrustStore` trust store, `KemPrekey` rotation seam, and `did_document.rs` Multikey helpers for `#mesh-kem`), but that PR explicitly deferred three items pending a libtorch-capable build environment (see its body / the code comments it left behind):

1. Wire the `#mesh-kem` helpers into `build_did_document`'s `keyAgreement` set (cross-cutting — touches the signature and every caller).
2. A libtorch compile pass to confirm the wiring actually builds.
3. Confirm the **provisional** ML-KEM-768 multicodec code point against the multiformats registry.

This PR does all three, closing out #552.

## What's implemented

- `build_did_document` (`crates/hyprstream/src/services/oauth/did_document.rs`) now takes `mesh_kem_public: Option<&hyprstream_rpc::crypto::hybrid_kem::RecipientPublic>` and emits a `keyAgreement` array with `#mesh-kem-x25519` / `#mesh-kem-mlkem768` Multikey verification methods. These are embedded directly in `keyAgreement` (did:key convention), not cross-referenced from `verificationMethod`/`authentication`/`assertionMethod` — they're key-agreement-only, never used for signing.
- `OAuthState` (`state.rs`) grows a `mesh_kem_public` field, derived in `with_signing_key` alongside the existing `mesh_pq_verifying_key` derivation, via `hyprstream_rpc::node_identity::derive_mesh_kem_recipient`. A derivation failure is logged and leaves the field unset — the DID document then simply omits `keyAgreement` rather than publish a key that doesn't actually work (fail-closed, consistent with epic #550's "no in-band downgrade / never publish something unusable" posture).
- `root_did_document` passes `state.mesh_kem_public.as_ref()` through; the per-user/per-client DID document endpoints pass `None` (no mesh identity there).

## Judgment call flagged: the multicodec bug

The prior pass's `MULTICODEC_ML_KEM_768_PUB` constant was `0x120b` → bytes `[0x8b, 0x24]`, marked `PROVISIONAL... confirm before production`. I checked the upstream multiformats `multicodec/table.csv`:

```
mlkem-512-pub,  key, 0x120b, draft
mlkem-768-pub,  key, 0x120c, draft
mlkem-1024-pub, key, 0x120d, draft
```

`0x120b` is actually **`mlkem-512-pub`**, not 768. I fixed the constant to the correct `0x120c` → `[0x8c, 0x24]` and updated the doc comment to state this as confirmed (not provisional) against the registry, with a note on what the mixup would have caused (peers silently anchoring the wrong key-size code point). `x25519-pub` (`0xec` → `[0xec, 0x01]`) and the already-shipped `ml-dsa-65-pub` (`0x1211` → `[0x91, 0x24]`) both checked out correct against the same table.

## Deferred (later stages, not this PR)

Per scope discipline in #552/#550: no `cose_encrypt.rs` (S2/#553), no stream hybrid wiring (S3/#554), no envelope/notification hybrid-by-default (S4/#555 — actually already merged separately as #577/`3172d4faf`), no fail-closed posture changes (S5/#556), no transport PQ (S6/#557 — already merged as `eb1a231b5`). This PR is purely: derive → publish → (trust anchoring/rotation already existed in `hybrid_kem.rs` from the earlier S1 pass, untouched here).

## Testing

- `cargo test -p hyprstream --lib services::oauth::did_document`: **20 passed, 0 failed** (18 existing + 2 new: `build_did_doc_omits_key_agreement_when_mesh_kem_absent`, `build_did_doc_publishes_mesh_kem_key_agreement`).
- `cargo test -p hyprstream-rpc --lib node_identity`: **18 passed, 0 failed**.
- `cargo test -p hyprstream-rpc --lib hybrid_kem`: **20 passed, 0 failed**.
- `cargo test -p hyprstream-rpc --lib mesh_kem`: **4 passed, 0 failed** (includes the existing envelope hybrid-encrypt/decrypt roundtrip, unaffected by this change).
- `cargo clippy --workspace --all-targets --features download-libtorch -- -D warnings`: clean, 0 warnings.

## Test plan

- [x] `derive_mesh_kem_recipient` deterministic + key-separated (pre-existing, still green)
- [x] `build_did_document` emits `keyAgreement` with correct shape when a `#mesh-kem` key is present
- [x] `build_did_document` emits an empty `keyAgreement` array (not an omitted field) when absent
- [x] Published multibase bytes round-trip to the exact `RecipientPublic.eks` bytes, with the corrected multicodec prefix
- [x] Full workspace clippy clean