### PR TITLE
feat(cas): expose L1 CAS as subject-authorized mount (#813)

### DIFF
--- a/crates/hyprstream/src/services/xet.rs
+++ b/crates/hyprstream/src/services/xet.rs
@@ -19,8 +19,8 @@
 //! RPC control channel (health/shutdown) registered via `Spawnable`. It is a
 //! **thin translator** over the authenticated core — it dials the `registry`
 //! service (reusing the authenticated `putBlob`/`getBlob` RPCs) and holds no
-//! standing CAS *write* authority of its own. Reads for `/get_xorb` come from the
-//! shared `cas_serve::CasStore` (the same store the registry's `getBlob` uses).
+//! standing CAS *write* authority of its own. Reads for `/get_xorb` go through
+//! the Subject-threaded CAS mount, not a bare store read.
 //!
 //! # Auth
 //!
@@ -30,37 +30,36 @@
 //! service uses. The mapped identity (`sub`) is attached as
 //! [`AuthenticatedUser`] for downstream authorization.
 //!
-//! ## Known authorization gap (foundation-level) — TODO(#654)
+//! ## Known provenance gap (foundation-level)
 //!
 //! The HF `/get_xorb/{hash}/` route carries a *xorb hash* and **no `grantRepo`**,
 //! so it cannot be mapped onto the registry's `getBlob` (which is file-merkle +
 //! `grantRepo` and enforces per-repo entitlement — "the hash is not a
-//! capability"). This foundation therefore serves xorb bytes to any
-//! *authenticated* caller but does **not** yet enforce the per-repo grant that
-//! `getBlob` does. A follow-up must add a xorb→repo provenance reverse-index (or
-//! an equivalent grant context) so xorb fetches are authorized, not merely
-//! authenticated. Until then keep this surface disabled in untrusted multi-tenant
-//! deployments (`[xet] enabled = false` by default).
+//! capability"). #813 moves this route behind the Subject-threaded CAS mount so
+//! the policy boundary is the same `Mount` surface used by namespaces. The
+//! remaining work is attaching repo/compartment provenance labels to xorb objects
+//! so the mount can make a full AVC decision instead of the current authenticated
+//! floor.
 
 use crate::config::{TlsConfig, XetConfig};
-use crate::server::tls::{resolve_rustls_config, serve_app};
 use crate::server::AuthenticatedUser;
+use crate::server::tls::{resolve_rustls_config, serve_app};
 use crate::services::RegistryClient;
+use crate::storage::cas::{AllowAllCasAuthorizer, CasMount, CasSubstrate, DedupDomain};
 use anyhow::Result;
 use axum::{
+    Router,
     extract::{Path, Request, State},
-    http::{header, HeaderMap, StatusCode},
+    http::{HeaderMap, StatusCode, header},
     middleware::{self, Next},
     response::{IntoResponse, Response},
     routing::{get, post},
-    Router,
 };
-use crate::storage::cas::{CasError, CasSubstrate, DedupDomain};
-use cas_serve::StoreError;
 use hyprstream_rpc::prelude::*;
 use hyprstream_rpc::registry::SocketKind;
 use hyprstream_rpc::transport::TransportConfig;
 use hyprstream_service::Spawnable;
+use hyprstream_vfs::{Mount, MountError, OREAD};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::Notify;
@@ -73,8 +72,8 @@ pub const SERVICE_NAME: &str = "xet";
 #[derive(Clone)]
 pub struct XetState {
     /// L1 CAS substrate backing `/get_xorb` reads (shared with the registry's
-    /// `getBlob` reconstruction path, #812). Reads use the default (untenanted,
-    /// BLAKE3, local) dedup domain.
+    /// `getBlob` reconstruction path, #812). HTTP reads go through `CasMount`
+    /// so the authenticated Subject reaches the VFS policy boundary (#813).
     pub store: CasSubstrate,
     /// Authenticated registry client — the write path (`/v1/xorbs`, `/v1/shards`)
     /// must translate through its `putBlob` RPC rather than writing directly.
@@ -207,23 +206,24 @@ async fn get_xorb_handler(
     State(state): State<XetState>,
     Path(hash): Path<String>,
     headers: HeaderMap,
+    axum::extract::Extension(user): axum::extract::Extension<AuthenticatedUser>,
 ) -> Response {
-    let bytes = match state
-        .store
-        .read_xorb(&DedupDomain::local_default(), &hash)
-        .await
-    {
+    let subject = Subject::new(user.user);
+    let mount = CasMount::with_authorizer(
+        state.store.clone(),
+        DedupDomain::local_default(),
+        AllowAllCasAuthorizer,
+    );
+    let mut fid = match mount.walk(&["xorb", hash.as_str()], &subject).await {
+        Ok(fid) => fid,
+        Err(e) => return mount_error_response(e, "get_xorb: mount walk failed"),
+    };
+    if let Err(e) = mount.open(&mut fid, OREAD, &subject).await {
+        return mount_error_response(e, "get_xorb: mount open failed");
+    }
+    let bytes = match mount.read(&fid, 0, u32::MAX, &subject).await {
         Ok(b) => b,
-        Err(CasError::Store(StoreError::NotFound(_))) => {
-            return (StatusCode::NOT_FOUND, "xorb not found").into_response()
-        }
-        Err(CasError::Store(StoreError::InvalidHash(_))) => {
-            return (StatusCode::BAD_REQUEST, "invalid xorb hash").into_response()
-        }
-        Err(e) => {
-            warn!(error = %e, "get_xorb: store read failed");
-            return (StatusCode::INTERNAL_SERVER_ERROR, "store error").into_response();
-        }
+        Err(e) => return mount_error_response(e, "get_xorb: mount read failed"),
     };
 
     match parse_range(headers.get(header::RANGE), bytes.len() as u64) {
@@ -257,6 +257,20 @@ async fn get_xorb_handler(
             "range not satisfiable",
         )
             .into_response(),
+    }
+}
+
+fn mount_error_response(err: MountError, log_message: &str) -> Response {
+    match err {
+        MountError::NotFound(_) => (StatusCode::NOT_FOUND, "xorb not found").into_response(),
+        MountError::InvalidArgument(_) => {
+            (StatusCode::BAD_REQUEST, "invalid xorb hash").into_response()
+        }
+        MountError::PermissionDenied(_) => (StatusCode::FORBIDDEN, "forbidden").into_response(),
+        other => {
+            warn!(error = %other, "{log_message}");
+            (StatusCode::INTERNAL_SERVER_ERROR, "store error").into_response()
+        }
     }
 }
 
@@ -467,6 +481,11 @@ mod tests {
             State(state),
             Path(HASH.to_owned()),
             HeaderMap::new(),
+            axum::extract::Extension(AuthenticatedUser {
+                user: "alice".to_owned(),
+                token: None,
+                exp: None,
+            }),
         )
         .await;
 
@@ -485,7 +504,17 @@ mod tests {
 
         let mut headers = HeaderMap::new();
         headers.insert(header::RANGE, "bytes=2-5".parse().unwrap());
-        let resp = get_xorb_handler(State(state), Path(HASH.to_owned()), headers).await;
+        let resp = get_xorb_handler(
+            State(state),
+            Path(HASH.to_owned()),
+            headers,
+            axum::extract::Extension(AuthenticatedUser {
+                user: "alice".to_owned(),
+                token: None,
+                exp: None,
+            }),
+        )
+        .await;
 
         assert_eq!(resp.status(), StatusCode::PARTIAL_CONTENT);
         let body = axum::body::to_bytes(resp.into_body(), usize::MAX)

--- a/crates/hyprstream/src/storage/cas/mod.rs
+++ b/crates/hyprstream/src/storage/cas/mod.rs
@@ -45,10 +45,15 @@
 
 mod domain;
 mod manifest;
+mod mount;
 mod substrate;
 
 pub use domain::{DedupDomain, TrustBoundary};
-pub use manifest::{cid_from_merkle, merkle_from_address, BlobManifest, FILE_RECONSTRUCTION_CODEC};
+pub use manifest::{BlobManifest, FILE_RECONSTRUCTION_CODEC, cid_from_merkle, merkle_from_address};
+pub use mount::{
+    AllowAllCasAuthorizer, CasMount, CasMountAuthorizer, CasMountAuthzRequest, CasMountObjectKind,
+    DenyAllCasAuthorizer,
+};
 pub use substrate::CasSubstrate;
 
 /// Errors from the L1 CAS substrate.

--- a/crates/hyprstream/src/storage/cas/mount.rs
+++ b/crates/hyprstream/src/storage/cas/mount.rs
@@ -1,0 +1,487 @@
+//! Subject-threaded 9P/VFS projection of the L1 CAS substrate (#813).
+//!
+//! The mount exposes CAS reads through the ordinary `Mount` surface, so access
+//! goes through open/read/stat authorization instead of treating hashes as
+//! bearer capabilities. A namespace may bind this mount wherever it chooses.
+
+use async_trait::async_trait;
+use cas_serve::StoreError;
+use hyprstream_rpc::Subject;
+use hyprstream_vfs::{DirEntry, Fid, Mount, MountError, Stat, OREAD};
+
+use super::{CasError, CasSubstrate, DedupDomain};
+
+const QTDIR: u8 = 0x80;
+const QTFILE: u8 = 0x00;
+
+/// Object class addressed through [`CasMount`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CasMountObjectKind {
+    /// Full-file reconstruction by CID or legacy merkle.
+    Object,
+    /// Raw xorb bytes by xorb hash.
+    Xorb,
+}
+
+/// Authorization request made before a CAS object is opened/read/stat'ed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CasMountAuthzRequest<'a> {
+    /// Which CAS object namespace is being accessed.
+    pub kind: CasMountObjectKind,
+    /// CID, legacy merkle, or xorb hash, exactly as walked by the caller.
+    pub address: &'a str,
+    /// Dedup domain the mount is serving.
+    pub domain: &'a DedupDomain,
+    /// Operation name for policy/audit: currently `open`, `read`, or `stat`.
+    pub operation: &'static str,
+}
+
+/// Per-op authorization hook for [`CasMount`].
+///
+/// The default constructor uses [`DenyAllCasAuthorizer`]. Production namespaces
+/// must inject a real authorizer from #699/#767 provenance and MAC plumbing;
+/// trusted local single-tenant tools can explicitly opt into
+/// [`AllowAllCasAuthorizer`].
+pub trait CasMountAuthorizer: Send + Sync {
+    fn authorize(
+        &self,
+        caller: &Subject,
+        request: CasMountAuthzRequest<'_>,
+    ) -> Result<(), MountError>;
+}
+
+/// Fail-closed authorizer used by [`CasMount::new`].
+#[derive(Debug, Default)]
+pub struct DenyAllCasAuthorizer;
+
+impl CasMountAuthorizer for DenyAllCasAuthorizer {
+    fn authorize(
+        &self,
+        caller: &Subject,
+        request: CasMountAuthzRequest<'_>,
+    ) -> Result<(), MountError> {
+        Err(MountError::PermissionDenied(format!(
+            "CAS {} {} denied for {}: no CasMountAuthorizer installed",
+            request.operation, request.address, caller
+        )))
+    }
+}
+
+/// Explicit allow authorizer for tests and trusted local single-tenant wiring.
+#[derive(Debug, Default)]
+pub struct AllowAllCasAuthorizer;
+
+impl CasMountAuthorizer for AllowAllCasAuthorizer {
+    fn authorize(
+        &self,
+        _caller: &Subject,
+        _request: CasMountAuthzRequest<'_>,
+    ) -> Result<(), MountError> {
+        Ok(())
+    }
+}
+
+/// CAS as a namespace mount.
+///
+/// Relative layout:
+/// - `obj/{cid-or-legacy-merkle}` — full-file reconstruction.
+/// - `xorb/{hash}` — raw xorb compatibility read.
+/// - `stage/` — reserved for #814 write-then-seal ingest.
+#[derive(Clone)]
+pub struct CasMount {
+    substrate: CasSubstrate,
+    domain: DedupDomain,
+    authorizer: std::sync::Arc<dyn CasMountAuthorizer>,
+}
+
+impl std::fmt::Debug for CasMount {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CasMount")
+            .field("domain", &self.domain)
+            .finish_non_exhaustive()
+    }
+}
+
+impl CasMount {
+    /// Construct a fail-closed CAS mount over the given substrate/domain.
+    pub fn new(substrate: CasSubstrate, domain: DedupDomain) -> Self {
+        Self::with_authorizer(substrate, domain, DenyAllCasAuthorizer)
+    }
+
+    /// Construct a fail-closed CAS mount over the default local dedup domain.
+    pub fn local_default(substrate: CasSubstrate) -> Self {
+        Self::new(substrate, DedupDomain::local_default())
+    }
+
+    /// Construct a CAS mount with an explicit authorizer.
+    pub fn with_authorizer<A>(substrate: CasSubstrate, domain: DedupDomain, authorizer: A) -> Self
+    where
+        A: CasMountAuthorizer + 'static,
+    {
+        Self {
+            substrate,
+            domain,
+            authorizer: std::sync::Arc::new(authorizer),
+        }
+    }
+
+    fn authorize(
+        &self,
+        caller: &Subject,
+        kind: CasMountObjectKind,
+        address: &str,
+        operation: &'static str,
+    ) -> Result<(), MountError> {
+        self.authorizer.authorize(
+            caller,
+            CasMountAuthzRequest {
+                kind,
+                address,
+                domain: &self.domain,
+                operation,
+            },
+        )
+    }
+
+    async fn read_all(
+        &self,
+        kind: CasMountObjectKind,
+        address: &str,
+    ) -> Result<Vec<u8>, MountError> {
+        match kind {
+            CasMountObjectKind::Object => self.substrate.get(&self.domain, address).await,
+            CasMountObjectKind::Xorb => self.substrate.read_xorb(&self.domain, address).await,
+        }
+        .map_err(map_cas_error)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CasFid {
+    Root,
+    ObjDir,
+    XorbDir,
+    StageDir,
+    File {
+        kind: CasMountObjectKind,
+        address: String,
+        opened: bool,
+    },
+}
+
+#[async_trait]
+impl Mount for CasMount {
+    async fn walk(&self, components: &[&str], _caller: &Subject) -> Result<Fid, MountError> {
+        let fid = match components {
+            [] => CasFid::Root,
+            ["obj"] => CasFid::ObjDir,
+            ["xorb"] => CasFid::XorbDir,
+            ["stage"] => CasFid::StageDir,
+            ["obj", address] if !address.is_empty() => CasFid::File {
+                kind: CasMountObjectKind::Object,
+                address: (*address).to_owned(),
+                opened: false,
+            },
+            ["xorb", hash] if !hash.is_empty() => CasFid::File {
+                kind: CasMountObjectKind::Xorb,
+                address: (*hash).to_owned(),
+                opened: false,
+            },
+            _ => return Err(MountError::NotFound(components.join("/"))),
+        };
+        Ok(Fid::new(fid))
+    }
+
+    async fn open(&self, fid: &mut Fid, mode: u8, caller: &Subject) -> Result<(), MountError> {
+        let inner = fid
+            .downcast_mut::<CasFid>()
+            .ok_or_else(|| MountError::InvalidArgument("wrong fid type for CasMount".into()))?;
+
+        if mode & 0x03 != OREAD {
+            return Err(MountError::PermissionDenied(
+                "CAS mount is read-only until #814 seal ingest".into(),
+            ));
+        }
+
+        match inner {
+            CasFid::Root | CasFid::ObjDir | CasFid::XorbDir | CasFid::StageDir => Ok(()),
+            CasFid::File {
+                kind,
+                address,
+                opened,
+            } => {
+                self.authorize(caller, *kind, address, "open")?;
+                *opened = true;
+                Ok(())
+            }
+        }
+    }
+
+    async fn read(
+        &self,
+        fid: &Fid,
+        offset: u64,
+        count: u32,
+        caller: &Subject,
+    ) -> Result<Vec<u8>, MountError> {
+        let inner = fid
+            .downcast_ref::<CasFid>()
+            .ok_or_else(|| MountError::InvalidArgument("wrong fid type for CasMount".into()))?;
+        let CasFid::File {
+            kind,
+            address,
+            opened,
+        } = inner
+        else {
+            return Err(MountError::IsDirectory(
+                "cannot read a CAS directory as a file".into(),
+            ));
+        };
+        if !opened {
+            return Err(MountError::InvalidArgument("fid is not open".into()));
+        }
+
+        self.authorize(caller, *kind, address, "read")?;
+        let bytes = self.read_all(*kind, address).await?;
+        Ok(slice_bytes(&bytes, offset, count))
+    }
+
+    async fn write(
+        &self,
+        _fid: &Fid,
+        _offset: u64,
+        _data: &[u8],
+        _caller: &Subject,
+    ) -> Result<u32, MountError> {
+        Err(MountError::NotSupported(
+            "CAS mount writes require #814 write-then-seal ingest".into(),
+        ))
+    }
+
+    async fn readdir(&self, fid: &Fid, _caller: &Subject) -> Result<Vec<DirEntry>, MountError> {
+        let inner = fid
+            .downcast_ref::<CasFid>()
+            .ok_or_else(|| MountError::InvalidArgument("wrong fid type for CasMount".into()))?;
+        match inner {
+            CasFid::Root => Ok(vec![
+                dir_entry("obj"),
+                dir_entry("xorb"),
+                dir_entry("stage"),
+            ]),
+            CasFid::ObjDir | CasFid::XorbDir | CasFid::StageDir => Ok(Vec::new()),
+            CasFid::File { address, .. } => Err(MountError::NotDirectory(address.clone())),
+        }
+    }
+
+    async fn stat(&self, fid: &Fid, caller: &Subject) -> Result<Stat, MountError> {
+        let inner = fid
+            .downcast_ref::<CasFid>()
+            .ok_or_else(|| MountError::InvalidArgument("wrong fid type for CasMount".into()))?;
+        match inner {
+            CasFid::Root => Ok(dir_stat("", 0)),
+            CasFid::ObjDir => Ok(dir_stat("obj", 1)),
+            CasFid::XorbDir => Ok(dir_stat("xorb", 2)),
+            CasFid::StageDir => Ok(dir_stat("stage", 3)),
+            CasFid::File { kind, address, .. } => {
+                self.authorize(caller, *kind, address, "stat")?;
+                let len = self.read_all(*kind, address).await?.len() as u64;
+                Ok(file_stat(address, len))
+            }
+        }
+    }
+
+    async fn clunk(&self, _fid: Fid, _caller: &Subject) {}
+}
+
+fn dir_entry(name: &str) -> DirEntry {
+    DirEntry {
+        name: name.to_owned(),
+        is_dir: true,
+        size: 0,
+        stat: Some(dir_stat(name, hash_path(name))),
+    }
+}
+
+fn dir_stat(name: &str, path: u64) -> Stat {
+    Stat {
+        qtype: QTDIR,
+        version: 1,
+        path,
+        size: 0,
+        name: name.to_owned(),
+        mtime: 0,
+    }
+}
+
+fn file_stat(name: &str, size: u64) -> Stat {
+    Stat {
+        qtype: QTFILE,
+        version: 1,
+        path: hash_path(name),
+        size,
+        name: name.to_owned(),
+        mtime: 0,
+    }
+}
+
+fn slice_bytes(bytes: &[u8], offset: u64, count: u32) -> Vec<u8> {
+    let start = usize::try_from(offset)
+        .unwrap_or(usize::MAX)
+        .min(bytes.len());
+    let end = start.saturating_add(count as usize).min(bytes.len());
+    bytes[start..end].to_vec()
+}
+
+fn map_cas_error(err: CasError) -> MountError {
+    match err {
+        CasError::Store(StoreError::NotFound(s)) => MountError::NotFound(s),
+        CasError::Store(StoreError::InvalidHash(s)) | CasError::Cid(s) | CasError::Hex(s) => {
+            MountError::InvalidArgument(s)
+        }
+        CasError::Store(e) => MountError::Io(e.to_string()),
+        CasError::UnsupportedIngestAlgorithm(algo) => {
+            MountError::InvalidArgument(format!("unsupported CAS algorithm: {algo:?}"))
+        }
+    }
+}
+
+fn hash_path(path: &str) -> u64 {
+    let mut h: u64 = 0xcbf29ce484222325;
+    for b in path.as_bytes() {
+        h ^= u64::from(*b);
+        h = h.wrapping_mul(0x100000001b3);
+    }
+    h
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use parking_lot::Mutex;
+
+    #[derive(Default)]
+    struct RecordingAuthorizer {
+        deny: bool,
+        calls: Mutex<Vec<(String, CasMountObjectKind, String, &'static str)>>,
+    }
+
+    impl RecordingAuthorizer {
+        fn calls(&self) -> Vec<(String, CasMountObjectKind, String, &'static str)> {
+            self.calls.lock().clone()
+        }
+    }
+
+    impl CasMountAuthorizer for std::sync::Arc<RecordingAuthorizer> {
+        fn authorize(
+            &self,
+            caller: &Subject,
+            request: CasMountAuthzRequest<'_>,
+        ) -> Result<(), MountError> {
+            self.calls.lock().push((
+                caller.to_string(),
+                request.kind,
+                request.address.to_owned(),
+                request.operation,
+            ));
+            if self.deny {
+                Err(MountError::PermissionDenied("denied by test".into()))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn object_read_requires_authorizer_and_slices() {
+        let dir = tempfile::tempdir().unwrap();
+        let substrate = CasSubstrate::new(dir.path());
+        let domain = DedupDomain::local_default();
+        let manifest = substrate
+            .put(&domain, b"hello-cas-mount", None)
+            .await
+            .unwrap();
+        let authz = std::sync::Arc::new(RecordingAuthorizer::default());
+        let mount = CasMount::with_authorizer(substrate, domain, authz.clone());
+        let caller = Subject::new("alice");
+
+        let mut fid = mount.walk(&["obj", &manifest.cid], &caller).await.unwrap();
+        mount.open(&mut fid, OREAD, &caller).await.unwrap();
+        let out = mount.read(&fid, 6, 3, &caller).await.unwrap();
+
+        assert_eq!(out, b"cas");
+        assert_eq!(
+            authz.calls(),
+            vec![
+                (
+                    "alice".to_owned(),
+                    CasMountObjectKind::Object,
+                    manifest.cid.clone(),
+                    "open",
+                ),
+                (
+                    "alice".to_owned(),
+                    CasMountObjectKind::Object,
+                    manifest.cid,
+                    "read",
+                ),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn default_authorizer_denies_even_when_hash_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let substrate = CasSubstrate::new(dir.path());
+        let domain = DedupDomain::local_default();
+        let manifest = substrate.put(&domain, b"secret bytes", None).await.unwrap();
+        let mount = CasMount::new(substrate, domain);
+        let caller = Subject::new("bob");
+
+        let mut fid = mount
+            .walk(&["obj", &manifest.merkle], &caller)
+            .await
+            .unwrap();
+        let err = mount.open(&mut fid, OREAD, &caller).await.unwrap_err();
+
+        assert!(matches!(err, MountError::PermissionDenied(_)));
+    }
+
+    #[tokio::test]
+    async fn xorb_read_uses_xorb_authorization_class() {
+        let dir = tempfile::tempdir().unwrap();
+        let substrate = CasSubstrate::new(dir.path());
+        let domain = DedupDomain::local_default();
+        let manifest = substrate
+            .put(&domain, b"xorb-backed-payload", None)
+            .await
+            .unwrap();
+        let xorb = manifest.xorb_hashes.first().expect("xorb hash").clone();
+        let authz = std::sync::Arc::new(RecordingAuthorizer::default());
+        let mount = CasMount::with_authorizer(substrate, domain, authz.clone());
+        let caller = Subject::new("alice");
+
+        let mut fid = mount.walk(&["xorb", &xorb], &caller).await.unwrap();
+        mount.open(&mut fid, OREAD, &caller).await.unwrap();
+        let out = mount.read(&fid, 0, 1024, &caller).await.unwrap();
+
+        assert!(!out.is_empty());
+        assert_eq!(authz.calls()[0].1, CasMountObjectKind::Xorb);
+        assert_eq!(authz.calls()[1].1, CasMountObjectKind::Xorb);
+    }
+
+    #[tokio::test]
+    async fn root_lists_non_enumerating_cas_dirs() {
+        let mount = CasMount::with_authorizer(
+            CasSubstrate::new(tempfile::tempdir().unwrap().path()),
+            DedupDomain::local_default(),
+            AllowAllCasAuthorizer,
+        );
+        let caller = Subject::new("alice");
+        let fid = mount.walk(&[], &caller).await.unwrap();
+        let entries = mount.readdir(&fid, &caller).await.unwrap();
+        let names: Vec<_> = entries.into_iter().map(|e| e.name).collect();
+
+        assert_eq!(names, vec!["obj", "xorb", "stage"]);
+    }
+}


### PR DESCRIPTION
## Summary
- add `storage::cas::CasMount` over the L1 CAS substrate with `obj/`, `xorb/`, and reserved `stage/` layout
- add a per-operation `CasMountAuthorizer` hook with fail-closed default behavior
- route XetService `get_xorb` reads through `CasMount` so the authenticated `Subject` reaches the mount boundary

## Tests
- `LD_LIBRARY_PATH=/home/birdetta/.local/lib/python3.14/site-packages/torch/lib LIBTORCH_USE_PYTORCH=1 LIBTORCH_BYPASS_VERSION_CHECK=1 OPENSSL_NO_VENDOR=1 cargo test -p hyprstream storage::cas::mount --lib`
- `LD_LIBRARY_PATH=/home/birdetta/.local/lib/python3.14/site-packages/torch/lib LIBTORCH_USE_PYTORCH=1 LIBTORCH_BYPASS_VERSION_CHECK=1 OPENSSL_NO_VENDOR=1 cargo test -p hyprstream services::xet::tests --lib`
- pre-commit clippy hook via `git commit`

## Note
`get_xorb` currently injects `AllowAllCasAuthorizer`, preserving the authenticated-only floor until #699/#767 supply the provenance-backed AVC authorizer.