### PR TITLE
feat(k8s): project Helm key trust bootstrap (#783)

### DIFF
--- a/charts/hyprstream/README.md
+++ b/charts/hyprstream/README.md
@@ -53,10 +53,32 @@ Values are documented inline in `values.yaml`. Highlights:
   set `accessModes: [ReadWriteMany]` for multi-node).
 - `config.*` — shared `HYPRSTREAM__*` env (rendered into a ConfigMap).
 
+## Key/trust bootstrap
+
+Set `keyBootstrap.enabled=true` to mount the flat credential directory expected
+by `HYPRSTREAM__SECRETS__PATH`. The chart projects externally generated Secrets
+instead of minting identity material in Helm templates.
+
+Required Secret layout:
+
+- Shared trust Secret: `ca-pubkey`, `bootstrap-pubkeys`.
+- Non-policy service credential Secrets: `signing-key`, `service-jwt`.
+- Policy service credential Secret: `signing-key`.
+- Policy CA Secret: `ca-key`.
+
+Omitted per-service Secret names default to
+`<release>-hyprstream-<service>-credentials`. The shared trust Secret defaults to
+`<release>-hyprstream-trust`, and the policy CA Secret defaults to
+`<release>-hyprstream-policy-ca`. Use `keyBootstrap.trust.existingSecret`,
+`keyBootstrap.serviceSecrets`, and `keyBootstrap.policyCaSecret` to bind
+Secrets created by the bootstrap/wizard flow or an external-secrets controller.
+
+`keyBootstrap.issuerUrl`, when set, is exposed to every service as
+`HYPRSTREAM__OAUTH__ISSUER_URL` and must match the issuer stamped into the
+pre-generated service JWTs.
+
 ## Extension hooks (separate issues — not implemented here)
 
-- `keyBootstrap.*` → **#783 (K1a)**: per-service signing-key Secrets, trust store,
-  node DID. This chart only reserves the shape + a stable `HYPRSTREAM__SECRETS__PATH`.
 - `observability.*` → **#784 (K1b)**: OTel Collector → Prometheus exposition.
 
 ## Image assumption
@@ -75,6 +97,5 @@ the RPC resolver / discovery lookup so `for_service("policy")` dials
 multi-process model resolves peers to UDS paths in a shared runtime dir (same-host
 only), and QUIC is a WebTransport/announce plane with no static peer-address
 config. This chart delivers the deployment substrate (Phase 0); a working
-end-to-end install additionally needs that app-side wiring and the #783 key/trust
-bootstrap. The chart itself contains **no shared-volume IPC**, per the #778
-non-goal.
+end-to-end install additionally needs that app-side wiring. The chart itself
+contains **no shared-volume IPC**, per the #778 non-goal.

--- a/charts/hyprstream/templates/NOTES.txt
+++ b/charts/hyprstream/templates/NOTES.txt
@@ -17,7 +17,8 @@ IMPORTANT (Phase 0 substrate):
   * Cross-pod QUIC service-to-service *peer resolution* (feeding K8s DNS names into
     the RPC resolver / discovery lookup) is not yet wired in hyprstream itself.
     This chart provisions the deployment substrate; a working end-to-end install
-    also needs that app-side wiring plus the key/trust bootstrap from #783 (K1a).
-  * Per-service signing-key Secrets / trust store / node DID: TODO(#783), gated by
-    keyBootstrap.enabled.
+    also needs that app-side wiring.
+  * Per-service signing-key Secrets / trust store projection is available with
+    keyBootstrap.enabled. Provide pre-generated Secrets; the chart does not mint
+    signing keys or service JWTs.
   * OTel Collector / Prometheus exposition: TODO(#784), gated by observability.enabled.

--- a/charts/hyprstream/templates/_helpers.tpl
+++ b/charts/hyprstream/templates/_helpers.tpl
@@ -78,3 +78,26 @@ suffix. Usage: include "hyprstream.image" (dict "root" $ "svc" $svc)
 {{- end -}}
 {{- printf "%s:%s%s" $img.repository $tag $suffix -}}
 {{- end }}
+
+{{/*
+Shared trust Secret name.
+*/}}
+{{- define "hyprstream.trustSecretName" -}}
+{{- default (printf "%s-trust" (include "hyprstream.fullname" .)) .Values.keyBootstrap.trust.existingSecret -}}
+{{- end }}
+
+{{/*
+Per-service credential Secret name.
+Usage: include "hyprstream.serviceCredentialSecretName" (dict "root" $ "name" $name)
+*/}}
+{{- define "hyprstream.serviceCredentialSecretName" -}}
+{{- $default := printf "%s-%s-credentials" (include "hyprstream.fullname" .root) .name -}}
+{{- default $default (index .root.Values.keyBootstrap.serviceSecrets .name) -}}
+{{- end }}
+
+{{/*
+Policy CA Secret name.
+*/}}
+{{- define "hyprstream.policyCaSecretName" -}}
+{{- default (printf "%s-policy-ca" (include "hyprstream.fullname" .)) .Values.keyBootstrap.policyCaSecret -}}
+{{- end }}

--- a/charts/hyprstream/templates/deployments.yaml
+++ b/charts/hyprstream/templates/deployments.yaml
@@ -48,11 +48,15 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "hyprstream.fullname" $root }}-config
-          {{- with $svc.env }}
+          {{- if or $svc.env (and $root.Values.keyBootstrap.enabled $root.Values.keyBootstrap.issuerUrl) }}
           env:
-            {{- range $k, $v := . }}
+            {{- range $k, $v := $svc.env }}
             - name: {{ $k }}
               value: {{ $v | quote }}
+            {{- end }}
+            {{- if and $root.Values.keyBootstrap.enabled $root.Values.keyBootstrap.issuerUrl }}
+            - name: HYPRSTREAM__OAUTH__ISSUER_URL
+              value: {{ $root.Values.keyBootstrap.issuerUrl | quote }}
             {{- end }}
           {{- end }}
           {{- with $svc.ports }}
@@ -83,7 +87,9 @@ spec:
             - name: data
               mountPath: {{ $root.Values.config.dataDir }}
             {{- if $root.Values.keyBootstrap.enabled }}
-            # TODO(#783): mount per-service signing-key Secret at secretsPath.
+            - name: credentials
+              mountPath: {{ $root.Values.keyBootstrap.secretsPath }}
+              readOnly: true
             {{- end }}
       {{- with (default $defaults.nodeSelector $svc.nodeSelector) }}
       nodeSelector:
@@ -105,5 +111,34 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- if $root.Values.keyBootstrap.enabled }}
+        - name: credentials
+          projected:
+            defaultMode: 0400
+            sources:
+              - secret:
+                  name: {{ include "hyprstream.trustSecretName" $root }}
+                  items:
+                    - key: ca-pubkey
+                      path: ca-pubkey
+                    - key: bootstrap-pubkeys
+                      path: bootstrap-pubkeys
+              - secret:
+                  name: {{ include "hyprstream.serviceCredentialSecretName" $ctx }}
+                  items:
+                    - key: signing-key
+                      path: signing-key
+                    {{- if ne $name "policy" }}
+                    - key: service-jwt
+                      path: service-jwt
+                    {{- end }}
+              {{- if eq $name "policy" }}
+              - secret:
+                  name: {{ include "hyprstream.policyCaSecretName" $root }}
+                  items:
+                    - key: ca-key
+                      path: ca-key
+              {{- end }}
+        {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/hyprstream/templates/keybootstrap.yaml
+++ b/charts/hyprstream/templates/keybootstrap.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.keyBootstrap.enabled }}
+{{- if not .Values.keyBootstrap.trust.existingSecret }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "hyprstream.trustSecretName" . }}
+  labels:
+    {{- include "hyprstream.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  ca-pubkey: {{ required "keyBootstrap.trust.caPubkey is required when keyBootstrap.enabled=true and keyBootstrap.trust.existingSecret is empty" .Values.keyBootstrap.trust.caPubkey | quote }}
+  bootstrap-pubkeys: {{ required "keyBootstrap.trust.bootstrapPubkeys is required when keyBootstrap.enabled=true and keyBootstrap.trust.existingSecret is empty" .Values.keyBootstrap.trust.bootstrapPubkeys | quote }}
+{{- end }}
+{{- end }}

--- a/charts/hyprstream/values.yaml
+++ b/charts/hyprstream/values.yaml
@@ -72,19 +72,47 @@ persistence:
   annotations: {}
 
 # -----------------------------------------------------------------------------
-# TODO(#783) — K1a key/trust bootstrap extension hook.
-# Per-service signing-key Secrets, CA/trust store, node DID. Intentionally NOT
-# implemented here (separate issue). When keyBootstrap.enabled is true, #783
-# will project per-service Secret volumes into HYPRSTREAM__SECRETS__PATH and set
-# the node DID. This chart only reserves the shape + a stable secrets mount path.
+# K1a key/trust bootstrap (#783).
+#
+# hyprstream reads a flat credential directory when HYPRSTREAM__SECRETS__PATH is
+# set. In Kubernetes each pod gets that flat directory by projecting:
+#   - shared trust: ca-pubkey + bootstrap-pubkeys
+#   - service credential Secret: signing-key + service-jwt
+#   - policy-only CA Secret: ca-key (policy signs/renews service JWTs)
+#
+# Generate these files with the normal hyprstream bootstrap/wizard flow, or an
+# external-secrets controller. The chart deliberately does not mint keys in
+# templates: Helm has no secure RNG/signing primitive, and missing credentials
+# should fail closed rather than silently deriving identity in-cluster.
 # -----------------------------------------------------------------------------
 keyBootstrap:
   enabled: false
-  # Directory each service reads signing keys / bootstrap pubkeys / JWTs from
-  # (HYPRSTREAM__SECRETS__PATH). #783 owns populating it from Secrets.
+  # Directory each service reads signing keys / bootstrap pubkeys / JWTs from.
   secretsPath: /var/lib/hyprstream/credentials
-  # nodeDid: ""              # filled by #783
-  # secretNameTemplate: ""   # filled by #783
+  # OAuth issuer / local trust-domain URL stamped into service JWTs by the
+  # bootstrap tool and used as the node's did:web authority when OAuth is on.
+  # If set, it is exposed as HYPRSTREAM__OAUTH__ISSUER_URL.
+  issuerUrl: ""
+  # Shared public trust material. Existing Secret must contain:
+  #   ca-pubkey
+  #   bootstrap-pubkeys
+  trust:
+    existingSecret: ""
+    # Inline public trust data for dev/test installs. Values are rendered into a
+    # Secret only when existingSecret is empty. Do not put private keys here.
+    caPubkey: ""
+    bootstrapPubkeys: ""
+  # Per-service credential Secrets. Each non-policy service Secret must contain:
+  #   signing-key
+  #   service-jwt
+  # The policy service Secret must contain:
+  #   signing-key
+  # and may contain service-jwt for symmetry.
+  # Omitted entries default to "<fullname>-<service>-credentials".
+  serviceSecrets: {}
+  # Policy-only CA Secret. Must contain ca-key. Omitted default:
+  # "<fullname>-policy-ca".
+  policyCaSecret: ""
 
 # -----------------------------------------------------------------------------
 # TODO(#784) — K1b observability extension hook.


### PR DESCRIPTION
## Summary
- add keyBootstrap chart values for shared trust, per-service credential Secrets, policy CA Secret, and issuer URL
- project the flat HYPRSTREAM__SECRETS__PATH credential directory into each service pod when keyBootstrap.enabled=true
- document the external Secret contract and keep Helm from minting private keys or service JWTs

## Validation
- helm lint charts/hyprstream
- helm template hyprstream charts/hyprstream
- diff -u charts/hyprstream/tests/golden-default.yaml /tmp/hyprstream-783-default.yaml
- helm template hyprstream charts/hyprstream --set keyBootstrap.enabled=true --set keyBootstrap.issuerUrl=https://hypr.example.test --set keyBootstrap.trust.caPubkey=test-ca-pubkey --set keyBootstrap.trust.bootstrapPubkeys='{"policy":"test-bootstrap"}'
- kubectl apply --dry-run=server -f /tmp/hyprstream-783-keybootstrap.yaml
- helm template hyprstream charts/hyprstream --set keyBootstrap.enabled=true fails closed when no trust Secret or inline trust material is provided

Note: the pre-commit full-workspace release clippy hook was started and then stopped because this Helm-only change triggered DuckDB/RocksDB C++ builds while /home was at 99% disk usage. Chart validation above is complete.