### PR TITLE
feat(#778): add SPIFFE/WIT bridge and 9P mount tickets

### DIFF
--- a/crates/hyprstream/src/server/routes/ninep.rs
+++ b/crates/hyprstream/src/server/routes/ninep.rs
@@ -70,6 +70,10 @@ use tracing::{debug, info, warn};
 
 use crate::server::state::ServerState;
 
+const PLANE_WS: &str = "ws";
+const PLANE_WEBTRANSPORT: &str = "webtransport";
+const ROOT_NAMESPACE_PATH: &str = "/";
+
 /// Query-param name carrying the short-lived mount ticket. Kept in sync with
 /// the discovery document and the design doc's `wss://…/9p?ticket=…` example.
 const TICKET_PARAM: &str = "ticket";
@@ -243,8 +247,8 @@ pub async fn wire_planes_metadata() -> impl IntoResponse {
 /// Query params on the `/9p` WebSocket upgrade.
 #[derive(Debug, Deserialize)]
 pub struct NinePQuery {
-    /// Short-lived mount ticket (an `at+jwt`), minted via the existing token
-    /// chain. Required — a missing/invalid ticket is rejected pre-upgrade.
+    /// Short-lived mount ticket, minted by `POST /oauth/mount-ticket`.
+    /// Required — a missing/invalid ticket is rejected pre-upgrade.
     #[serde(default)]
     pub ticket: Option<String>,
 }
@@ -269,13 +273,14 @@ pub async fn ninep_ws(
         }
     };
 
-    let subject = match validate_ticket(&state, ticket, &headers).await {
-        Ok(s) => s,
-        Err(reason) => {
-            warn!(reason, "9P WS upgrade rejected: invalid mount ticket");
-            return (StatusCode::UNAUTHORIZED, "invalid mount ticket").into_response();
-        }
-    };
+    let subject =
+        match validate_ticket(&state, ticket, &headers, PLANE_WS, ROOT_NAMESPACE_PATH).await {
+            Ok(s) => s,
+            Err(reason) => {
+                warn!(reason, "9P WS upgrade rejected: invalid mount ticket");
+                return (StatusCode::UNAUTHORIZED, "invalid mount ticket").into_response();
+            }
+        };
 
     let mount = build_export_mount(&state, &subject);
     // `from_mount` wraps the Subject-scoped mount in a `MountBackend` and threads
@@ -300,27 +305,46 @@ async fn validate_ticket(
     state: &ServerState,
     ticket: &str,
     _headers: &HeaderMap,
+    plane: &str,
+    namespace_path: &str,
 ) -> Result<Subject, &'static str> {
-    verify_mount_ticket(state, ticket).await
+    verify_mount_ticket(state, ticket, plane, namespace_path).await
 }
 
 /// Transport-agnostic core of mount-ticket validation, shared by H1a's
 /// URL-query path ([`validate_ticket`]) and H1b's `Tattach.uname` path
-/// ([`TicketAttachAuthorizer`]). Both present the same `at+jwt` mount ticket;
+/// ([`TicketAttachAuthorizer`]). Both present the same mount-ticket JWT;
 /// only *where* it rides differs (WS query vs 9P attach), so the verification —
-/// signature, audience, expiry, revocation (in `verify_token_claims`), then
-/// subject-name validation — is identical.
+/// signature, expiry, revocation (in `verify_token_claims`), explicit
+/// mount-capability marker, then subject-name validation — is identical.
 async fn verify_mount_ticket(
     state: &ServerState,
     ticket: &str,
+    plane: &str,
+    namespace_path: &str,
 ) -> Result<Subject, &'static str> {
     let claims = crate::server::middleware::verify_token_claims(state, ticket).await?;
+    if !crate::services::oauth::mount_ticket::is_mount_ticket_for(&claims, plane, namespace_path) {
+        return Err("token is not valid for this 9P plane/path");
+    }
     let local_issuers: &[&str] = &[&*state.oauth_issuer_url];
     let subject = claims.subject(local_issuers);
     subject.validate().map_err(|_| "subject validation failed")?;
     match subject.name() {
         Some(n) if !n.is_empty() => {}
         _ => return Err("empty subject"),
+    }
+    let Some(jti) = claims.jti.as_ref() else {
+        return Err("mount ticket missing jti");
+    };
+    let now = chrono::Utc::now().timestamp();
+    let ttl = (claims.exp - now).max(0) as u64;
+    if !state.dpop_jti_seen.insert_if_absent(
+        format!("mount-ticket:{jti}"),
+        (),
+        Duration::from_secs(ttl),
+    ) {
+        return Err("mount ticket already used");
     }
     Ok(subject)
 }
@@ -492,7 +516,8 @@ impl AttachAuthorizer for TicketAttachAuthorizer {
         if uname.is_empty() {
             return Err(MountError::PermissionDenied("missing mount ticket".to_owned()));
         }
-        match verify_mount_ticket(&self.state, uname).await {
+        match verify_mount_ticket(&self.state, uname, PLANE_WEBTRANSPORT, ROOT_NAMESPACE_PATH).await
+        {
             Ok(subject) => Ok(subject),
             Err(reason) => {
                 warn!(reason, "9P WT attach rejected: invalid mount ticket");

--- a/crates/hyprstream/src/services/oauth/jwks.rs
+++ b/crates/hyprstream/src/services/oauth/jwks.rs
@@ -28,6 +28,12 @@ pub fn compute_rsa_kid(n: &str, e: &str) -> String {
 
 /// GET /oauth/jwks
 pub async fn jwks(State(state): State<Arc<OAuthState>>) -> impl IntoResponse {
+    Json(serde_json::json!({ "keys": jwks_json(&state).await }))
+}
+
+/// Build the public JWKS key array shared by `/oauth/jwks` and the SPIFFE
+/// bundle endpoint.
+pub async fn jwks_json(state: &OAuthState) -> Vec<serde_json::Value> {
     let mut keys: Vec<serde_json::Value> = Vec::new();
 
     // Serve all rotation slots (drain + active + lead) when the store is present.
@@ -118,7 +124,7 @@ pub async fn jwks(State(state): State<Arc<OAuthState>>) -> impl IntoResponse {
         keys.push(rsa_jwk.clone());
     }
 
-    Json(serde_json::json!({ "keys": keys }))
+    keys
 }
 
 #[cfg(test)]

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -40,6 +40,7 @@ pub mod jwks;
 pub mod jwt_bearer;
 pub mod login_page;
 pub mod metadata;
+pub mod mount_ticket;
 pub mod oauth2_userinfo;
 pub mod oidc_callback;
 pub mod oidc_discovery;
@@ -49,6 +50,7 @@ pub mod revocation;
 pub mod scim;
 pub mod scim_types;
 pub mod session;
+pub mod spiffe;
 pub mod state;
 pub mod token;
 pub mod token_exchange;
@@ -104,6 +106,7 @@ pub fn create_app(state: Arc<OAuthState>, cors_config: &crate::config::CorsConfi
             "/.well-known/openid-configuration",
             get(metadata::openid_configuration),
         )
+        .route("/.well-known/spiffe/bundle", get(spiffe::spiffe_bundle))
         .route(
             "/.well-known/openid-federation",
             get(federation_entity::entity_configuration),
@@ -115,6 +118,7 @@ pub fn create_app(state: Arc<OAuthState>, cors_config: &crate::config::CorsConfi
         )
         .route("/oauth/par", post(par::push_authorization_request))
         .route("/oauth/token", post(token::exchange_token))
+        .route("/oauth/spiffe/wit", post(spiffe::exchange_workload_wit))
         .route("/oauth/jwks", get(jwks::jwks))
         .route("/oauth/device", post(device::device_authorize))
         .route(
@@ -148,6 +152,14 @@ pub fn create_app(state: Arc<OAuthState>, cors_config: &crate::config::CorsConfi
     let protected_router = Router::new()
         .route("/oauth/introspect", post(introspection::introspect_token))
         .route("/oauth/wit", post(wit_bootstrap::issue_browser_wit))
+        .route(
+            "/oauth/mount-ticket",
+            post(mount_ticket::issue_mount_ticket),
+        )
+        .route(
+            "/oauth/spiffe/service-svid",
+            post(spiffe::issue_service_svid),
+        )
         .route(
             "/oauth/userinfo",
             get(userinfo::userinfo).post(userinfo::userinfo),

--- a/crates/hyprstream/src/services/oauth/mount_ticket.rs
+++ b/crates/hyprstream/src/services/oauth/mount_ticket.rs
@@ -1,0 +1,233 @@
+//! 9P mount-ticket minting for K3a.
+//!
+//! A mount ticket is a short-lived JWT derived from an already verified
+//! OAuth/WIT caller. It is bound to a specific 9P plane and namespace path,
+//! then consumed exactly once at 9P attach by the route layer.
+
+use std::sync::Arc;
+
+use axum::{
+    Extension, Json,
+    extract::State,
+    http::{HeaderMap, StatusCode, header},
+    response::{IntoResponse, Response},
+};
+use serde::{Deserialize, Serialize};
+
+use super::state::OAuthState;
+use crate::server::middleware::AuthenticatedUser;
+
+pub const MOUNT_TICKET_TTL: i64 = 5 * 60;
+pub const MOUNT_CAP_PREFIX: &str = "mount@9p://";
+
+#[derive(Debug, Deserialize)]
+pub struct MountTicketRequest {
+    /// 9P plane name, normally `ws` or `webtransport`.
+    pub plane: String,
+    /// Namespace path being mounted. The minted token is not valid for broader
+    /// paths; callers should request the narrowest path they need.
+    pub namespace_path: String,
+    /// Reserved for future sender-bound mount tickets. Rejected until the 9P
+    /// attach path verifies proof-of-possession for this key.
+    #[serde(default)]
+    pub pubkey: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MountTicketResponse {
+    pub ticket: String,
+    pub token_type: &'static str,
+    pub expires_in: i64,
+    pub audience: String,
+    pub capability: String,
+}
+
+/// `POST /oauth/mount-ticket` — mint a 9P attach credential.
+pub async fn issue_mount_ticket(
+    State(state): State<Arc<OAuthState>>,
+    Extension(user): Extension<AuthenticatedUser>,
+    headers: HeaderMap,
+    Json(body): Json<MountTicketRequest>,
+) -> Response {
+    if !valid_plane(&body.plane) {
+        return oauth_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            Some("plane must contain only [A-Za-z0-9._-]"),
+        );
+    }
+    if body.pubkey.is_some() || headers.contains_key("DPoP") {
+        return oauth_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            Some(
+                "sender-bound mount tickets are not supported until 9P attach verifies proof-of-possession",
+            ),
+        );
+    }
+    let normalized_path = match normalize_namespace_path(&body.namespace_path) {
+        Some(path) => path,
+        None => {
+            return oauth_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_request",
+                Some("namespace_path must be absolute and must not contain '..'"),
+            );
+        }
+    };
+    if normalized_path != "/" {
+        return oauth_error(
+            StatusCode::FORBIDDEN,
+            "insufficient_scope",
+            Some(
+                "non-root namespace_path tickets require namespace authorization and are not enabled yet",
+            ),
+        );
+    }
+
+    let key = match state.active_jwt_signing_key().await {
+        Some(k) => k,
+        None => {
+            return oauth_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "temporarily_unavailable",
+                Some("mount-ticket issuance not available"),
+            );
+        }
+    };
+
+    let now = chrono::Utc::now().timestamp();
+    let exp = now + MOUNT_TICKET_TTL;
+    let audience = state.issuer_url.clone();
+    let capability = ticket_capability(&body.plane, &normalized_path);
+    let claims = hyprstream_rpc::auth::Claims::new(user.user.clone(), now, exp)
+        .with_issuer(state.issuer_url.clone())
+        .with_audience(Some(audience.clone()))
+        .with_cap(capability.clone());
+    let ticket = hyprstream_rpc::auth::jwt::encode(&claims, &key);
+
+    tracing::info!(
+        sub = %user.user,
+        plane = %body.plane,
+        namespace_path = %normalized_path,
+        "9P mount ticket issued"
+    );
+
+    (
+        StatusCode::OK,
+        [
+            (header::CACHE_CONTROL, "no-store"),
+            (header::PRAGMA, "no-cache"),
+        ],
+        Json(MountTicketResponse {
+            ticket,
+            token_type: "mount-ticket+jwt",
+            expires_in: MOUNT_TICKET_TTL,
+            audience,
+            capability,
+        }),
+    )
+        .into_response()
+}
+
+pub fn ticket_capability(plane: &str, namespace_path: &str) -> String {
+    format!("{MOUNT_CAP_PREFIX}{plane}{namespace_path}")
+}
+
+pub fn is_mount_ticket_claims(claims: &hyprstream_rpc::auth::Claims) -> bool {
+    claims
+        .cap
+        .as_deref()
+        .is_some_and(|cap| cap.starts_with(MOUNT_CAP_PREFIX))
+}
+
+pub fn is_mount_ticket_for(
+    claims: &hyprstream_rpc::auth::Claims,
+    plane: &str,
+    namespace_path: &str,
+) -> bool {
+    claims
+        .cap
+        .as_deref()
+        .is_some_and(|cap| cap == ticket_capability(plane, namespace_path))
+}
+
+fn valid_plane(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+}
+
+fn normalize_namespace_path(value: &str) -> Option<String> {
+    if !value.starts_with('/') {
+        return None;
+    }
+    let mut out = Vec::new();
+    for component in value.split('/') {
+        if component.is_empty() || component == "." {
+            continue;
+        }
+        if component == ".." {
+            return None;
+        }
+        out.push(component);
+    }
+    Some(format!("/{}", out.join("/")))
+}
+
+fn oauth_error(status: StatusCode, error: &str, description: Option<&str>) -> Response {
+    let mut body = serde_json::Map::new();
+    body.insert(
+        "error".to_owned(),
+        serde_json::Value::String(error.to_owned()),
+    );
+    if let Some(description) = description {
+        body.insert(
+            "error_description".to_owned(),
+            serde_json::Value::String(description.to_owned()),
+        );
+    }
+    (
+        status,
+        [
+            (header::CACHE_CONTROL, "no-store"),
+            (header::PRAGMA, "no-cache"),
+        ],
+        Json(serde_json::Value::Object(body)),
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn namespace_path_must_be_absolute_and_contained() {
+        assert_eq!(
+            normalize_namespace_path("/tenant/./data"),
+            Some("/tenant/data".to_owned())
+        );
+        assert_eq!(normalize_namespace_path("/"), Some("/".to_owned()));
+        assert_eq!(normalize_namespace_path("tenant/data"), None);
+        assert_eq!(normalize_namespace_path("/tenant/../root"), None);
+    }
+
+    #[test]
+    fn mount_capability_is_plane_and_path_bound() {
+        assert_eq!(
+            ticket_capability("webtransport", "/tenant/a"),
+            "mount@9p://webtransport/tenant/a"
+        );
+    }
+
+    #[test]
+    fn mount_capability_match_is_exact() {
+        let claims = hyprstream_rpc::auth::Claims::new("alice".to_owned(), 1, 2)
+            .with_cap(ticket_capability("webtransport", "/"));
+        assert!(is_mount_ticket_for(&claims, "webtransport", "/"));
+        assert!(!is_mount_ticket_for(&claims, "ws", "/"));
+        assert!(!is_mount_ticket_for(&claims, "webtransport", "/tenant/a"));
+    }
+}

--- a/crates/hyprstream/src/services/oauth/spiffe.rs
+++ b/crates/hyprstream/src/services/oauth/spiffe.rs
@@ -1,0 +1,503 @@
+//! SPIFFE/JWT-SVID compatibility surface for the Kubernetes security spine.
+//!
+//! This module deliberately reuses the existing OAuth trust machinery:
+//! external cluster/SPIRE issuers must already be present in
+//! `OAuthState::trusted_issuers`, which is populated only after the normal
+//! `federation:register` admission path. Accepted workload JWTs are re-issued
+//! as local WITs; hyprstream-provided JWT-SVIDs are signed by the same active
+//! JWT signing key published by the bundle endpoint.
+
+use std::sync::Arc;
+
+use axum::{
+    Extension, Json,
+    extract::State,
+    http::{HeaderMap, StatusCode, header},
+    response::{IntoResponse, Response},
+};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use ed25519_dalek::{Signature, Signer as _, Verifier as _};
+use serde::{Deserialize, Serialize};
+
+use super::state::OAuthState;
+use crate::server::middleware::AuthenticatedUser;
+
+const K8S_WIT_TTL: i64 = 10 * 60;
+const JWT_SVID_TTL: i64 = 10 * 60;
+
+#[derive(Debug, Deserialize)]
+pub struct WorkloadWitRequest {
+    /// Projected Kubernetes ServiceAccount token or SPIRE JWT-SVID.
+    pub subject_token: String,
+    /// Expected audience of the presented token. Kubernetes projected tokens
+    /// should request this audience explicitly; absent/wrong aud fails closed.
+    pub audience: String,
+    /// Optional base64url Ed25519 key to carry as `cnf.jwk` in the issued WIT.
+    /// If omitted and a valid DPoP proof is supplied, the DPoP public key binds
+    /// the WIT instead.
+    #[serde(default)]
+    pub pubkey: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct WorkloadWitResponse {
+    pub wit: String,
+    pub token_type: &'static str,
+    pub expires_in: i64,
+    pub subject: String,
+    pub source_issuer: String,
+    pub source_subject: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ServiceSvidRequest {
+    /// Service name in `spiffe://<trust-domain>/service/<name>`.
+    pub service: String,
+    /// JWT-SVID audiences. At least one is required by SPIFFE JWT-SVID.
+    pub audience: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ServiceSvidResponse {
+    pub token: String,
+    pub token_type: &'static str,
+    pub expires_in: i64,
+    pub spiffe_id: String,
+    pub bundle_endpoint: String,
+}
+
+#[derive(Debug, Serialize)]
+struct JwtSvidClaims {
+    iss: String,
+    sub: String,
+    aud: Vec<String>,
+    iat: i64,
+    exp: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExternalWorkloadClaims {
+    iss: String,
+    sub: String,
+    exp: i64,
+    #[serde(default)]
+    nbf: Option<i64>,
+    #[serde(default)]
+    aud: serde_json::Value,
+}
+
+/// `POST /oauth/spiffe/wit` — exchange a cluster/SPIRE JWT for a local WIT.
+pub async fn exchange_workload_wit(
+    State(state): State<Arc<OAuthState>>,
+    headers: HeaderMap,
+    Json(body): Json<WorkloadWitRequest>,
+) -> Response {
+    if body.audience.trim().is_empty() {
+        return oauth_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            Some("audience is required"),
+        );
+    }
+
+    let source =
+        match verify_external_workload_jwt(&state, &body.subject_token, &body.audience).await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(error = %e, "SPIFFE/WIT exchange rejected");
+                return oauth_error(StatusCode::UNAUTHORIZED, "invalid_grant", None);
+            }
+        };
+
+    let endpoint = format!(
+        "{}/oauth/spiffe/wit",
+        state.issuer_url.trim_end_matches('/')
+    );
+    let bind_key = match binding_key(&headers, body.pubkey.as_deref(), &endpoint) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(error = %e, "SPIFFE/WIT exchange rejected: invalid sender binding");
+            return oauth_error(StatusCode::BAD_REQUEST, "invalid_request", Some(e));
+        }
+    };
+
+    let ca_key = match state.active_jwt_signing_key().await {
+        Some(k) => k,
+        None => {
+            return oauth_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "temporarily_unavailable",
+                Some("WIT issuance not available"),
+            );
+        }
+    };
+
+    let now = chrono::Utc::now().timestamp();
+    let exp = now + K8S_WIT_TTL;
+    let subject = map_workload_subject(&source.iss, &source.sub);
+    let mut claims = hyprstream_rpc::auth::Claims::new(subject.clone(), now, exp)
+        .with_issuer(state.issuer_url.clone())
+        .with_audience(Some(body.audience));
+    if let Some(key) = bind_key {
+        claims = claims.with_cnf_jwk(&key);
+    }
+    let wit = hyprstream_rpc::auth::jwt::encode_service_jwt(&claims, &ca_key);
+
+    tracing::info!(
+        source_issuer = %source.iss,
+        source_subject = %source.sub,
+        subject = %subject,
+        "SPIFFE/Kubernetes workload token exchanged for WIT"
+    );
+
+    (
+        StatusCode::OK,
+        [
+            (header::CACHE_CONTROL, "no-store"),
+            (header::PRAGMA, "no-cache"),
+        ],
+        Json(WorkloadWitResponse {
+            wit,
+            token_type: "wit+jwt",
+            expires_in: K8S_WIT_TTL,
+            subject,
+            source_issuer: source.iss,
+            source_subject: source.sub,
+        }),
+    )
+        .into_response()
+}
+
+/// `POST /oauth/spiffe/service-svid` — issue a JWT-SVID for a hyprstream service.
+///
+/// Protected by normal OAuth bearer auth. PolicyService remains the authority
+/// behind issuance; this HTTP surface only shapes the token as JWT-SVID.
+pub async fn issue_service_svid(
+    State(state): State<Arc<OAuthState>>,
+    Extension(user): Extension<AuthenticatedUser>,
+    Json(body): Json<ServiceSvidRequest>,
+) -> Response {
+    if !valid_service_name(&body.service) {
+        return oauth_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            Some("service must contain only [A-Za-z0-9._-]"),
+        );
+    }
+    if body.audience.is_empty() || body.audience.iter().any(|a| a.trim().is_empty()) {
+        return oauth_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            Some("audience must contain at least one non-empty value"),
+        );
+    }
+
+    let signing_key = match state.active_jwt_signing_key().await {
+        Some(k) => k,
+        None => {
+            return oauth_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "temporarily_unavailable",
+                Some("JWT-SVID issuance not available"),
+            );
+        }
+    };
+
+    let now = chrono::Utc::now().timestamp();
+    let exp = now + JWT_SVID_TTL;
+    let spiffe_id = service_spiffe_id(&state.issuer_url, &body.service);
+    let claims = JwtSvidClaims {
+        iss: state.issuer_url.clone(),
+        sub: spiffe_id.clone(),
+        aud: body.audience,
+        iat: now,
+        exp,
+    };
+    let token = encode_jwt_svid(&claims, &signing_key);
+
+    tracing::info!(
+        requester = %user.user,
+        spiffe_id = %spiffe_id,
+        "SPIFFE JWT-SVID issued for hyprstream service"
+    );
+
+    (
+        StatusCode::OK,
+        [
+            (header::CACHE_CONTROL, "no-store"),
+            (header::PRAGMA, "no-cache"),
+        ],
+        Json(ServiceSvidResponse {
+            token,
+            token_type: "jwt-svid",
+            expires_in: JWT_SVID_TTL,
+            spiffe_id,
+            bundle_endpoint: format!(
+                "{}/.well-known/spiffe/bundle",
+                state.issuer_url.trim_end_matches('/')
+            ),
+        }),
+    )
+        .into_response()
+}
+
+/// `GET /.well-known/spiffe/bundle` — SPIFFE trust-domain bundle.
+pub async fn spiffe_bundle(State(state): State<Arc<OAuthState>>) -> Response {
+    let keys = super::jwks::jwks_json(&state).await;
+    Json(serde_json::json!({
+        "spiffe_sequence": 1,
+        "keys": keys,
+    }))
+    .into_response()
+}
+
+async fn verify_external_workload_jwt(
+    state: &Arc<OAuthState>,
+    token: &str,
+    expected_audience: &str,
+) -> Result<ExternalWorkloadClaims, String> {
+    let unverified = decode_external_claims_unverified(token)
+        .map_err(|e| format!("cannot parse workload jwt: {e}"))?;
+    if unverified.iss.is_empty() {
+        return Err("workload jwt missing iss".to_owned());
+    }
+    if unverified.sub.is_empty() {
+        return Err("workload jwt missing sub".to_owned());
+    }
+
+    let cfg = state
+        .trusted_issuers
+        .get(&unverified.iss)
+        .ok_or_else(|| format!("issuer is not registered/trusted: {}", unverified.iss))?
+        .clone();
+    let vk =
+        super::jwt_bearer::resolve_federated_key(state, &unverified.iss, token, cfg.allow_http)
+            .await?;
+    verify_external_eddsa_jwt(token, &vk)?;
+    let claims = decode_external_claims_unverified(token)?;
+    validate_external_claims(&claims, expected_audience)?;
+    Ok(claims)
+}
+
+fn decode_external_claims_unverified(token: &str) -> Result<ExternalWorkloadClaims, String> {
+    let payload_b64 = token
+        .split('.')
+        .nth(1)
+        .ok_or_else(|| "invalid jwt format".to_owned())?;
+    let payload = URL_SAFE_NO_PAD
+        .decode(payload_b64)
+        .map_err(|_| "invalid jwt payload base64".to_owned())?;
+    serde_json::from_slice(&payload).map_err(|e| format!("invalid jwt claims: {e}"))
+}
+
+fn verify_external_eddsa_jwt(token: &str, key: &ed25519_dalek::VerifyingKey) -> Result<(), String> {
+    let parts: Vec<&str> = token.split('.').collect();
+    if parts.len() != 3 {
+        return Err("invalid jwt format".to_owned());
+    }
+    let header = URL_SAFE_NO_PAD
+        .decode(parts[0])
+        .map_err(|_| "invalid jwt header base64".to_owned())?;
+    let header: serde_json::Value =
+        serde_json::from_slice(&header).map_err(|e| format!("invalid jwt header: {e}"))?;
+    if header.get("alg").and_then(|v| v.as_str()) != Some("EdDSA") {
+        return Err("only EdDSA workload JWTs are supported".to_owned());
+    }
+    let sig_bytes = URL_SAFE_NO_PAD
+        .decode(parts[2])
+        .map_err(|_| "invalid jwt signature base64".to_owned())?;
+    let sig_bytes: [u8; 64] = sig_bytes
+        .try_into()
+        .map_err(|_| "invalid Ed25519 signature length".to_owned())?;
+    let signing_input = format!("{}.{}", parts[0], parts[1]);
+    key.verify(signing_input.as_bytes(), &Signature::from_bytes(&sig_bytes))
+        .map_err(|_| "workload jwt signature verification failed".to_owned())
+}
+
+fn validate_external_claims(
+    claims: &ExternalWorkloadClaims,
+    expected_audience: &str,
+) -> Result<(), String> {
+    let now = chrono::Utc::now().timestamp();
+    if claims.exp <= now {
+        return Err("workload jwt expired".to_owned());
+    }
+    if claims.nbf.is_some_and(|nbf| nbf > now + 5) {
+        return Err("workload jwt not yet valid".to_owned());
+    }
+    let audience_ok = match &claims.aud {
+        serde_json::Value::String(aud) => aud == expected_audience,
+        serde_json::Value::Array(auds) => auds
+            .iter()
+            .any(|aud| aud.as_str() == Some(expected_audience)),
+        _ => false,
+    };
+    if !audience_ok {
+        return Err("workload jwt audience mismatch".to_owned());
+    }
+    Ok(())
+}
+
+fn binding_key(
+    headers: &HeaderMap,
+    explicit_pubkey: Option<&str>,
+    endpoint: &str,
+) -> Result<Option<[u8; 32]>, &'static str> {
+    if let Some(pubkey) = explicit_pubkey {
+        return decode_ed25519_pubkey(pubkey).map(Some);
+    }
+
+    let Some(dpop) = headers.get("DPoP").and_then(|v| v.to_str().ok()) else {
+        return Ok(None);
+    };
+    let proof = super::dpop::verify_dpop_proof(dpop, "POST", endpoint, None)
+        .map_err(|_| "invalid DPoP proof")?;
+    match proof.key {
+        super::dpop::DpopKey::Ed25519 { bytes } => Ok(Some(bytes)),
+        _ => Err("DPoP proof key must be Ed25519 for WIT cnf.jwk binding"),
+    }
+}
+
+fn decode_ed25519_pubkey(value: &str) -> Result<[u8; 32], &'static str> {
+    let bytes: [u8; 32] = URL_SAFE_NO_PAD
+        .decode(value)
+        .ok()
+        .and_then(|b| b.try_into().ok())
+        .ok_or("pubkey must be base64url-encoded 32-byte Ed25519 public key")?;
+    ed25519_dalek::VerifyingKey::from_bytes(&bytes)
+        .map_err(|_| "pubkey is not a valid Ed25519 public key")?;
+    Ok(bytes)
+}
+
+fn map_workload_subject(issuer: &str, sub: &str) -> String {
+    if let Some(rest) = sub.strip_prefix("system:serviceaccount:") {
+        let mut parts = rest.splitn(2, ':');
+        if let (Some(ns), Some(sa)) = (parts.next(), parts.next()) {
+            return format!("k8s:{}:{}:{}", trust_domain_from_issuer(issuer), ns, sa);
+        }
+    }
+    if let Some(rest) = sub.strip_prefix("spiffe://") {
+        return format!("spiffe:{rest}");
+    }
+    format!("federated:{}:{}", trust_domain_from_issuer(issuer), sub)
+}
+
+fn service_spiffe_id(issuer_url: &str, service: &str) -> String {
+    format!(
+        "spiffe://{}/service/{service}",
+        trust_domain_from_issuer(issuer_url)
+    )
+}
+
+fn trust_domain_from_issuer(issuer_url: &str) -> String {
+    issuer_url
+        .trim_start_matches("https://")
+        .trim_start_matches("http://")
+        .trim_end_matches('/')
+        .split('/')
+        .next()
+        .unwrap_or(issuer_url)
+        .to_owned()
+}
+
+fn valid_service_name(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+}
+
+fn encode_jwt_svid(claims: &JwtSvidClaims, signing_key: &ed25519_dalek::SigningKey) -> String {
+    let kid = hyprstream_rpc::auth::jwt::kid_for_key(signing_key);
+    let header = serde_json::json!({
+        "alg": "EdDSA",
+        "typ": "JWT",
+        "kid": kid,
+    });
+    let header_b64 = URL_SAFE_NO_PAD.encode(header.to_string());
+    let payload = serde_json::to_vec(claims).unwrap_or_default();
+    let payload_b64 = URL_SAFE_NO_PAD.encode(payload);
+    let signing_input = format!("{header_b64}.{payload_b64}");
+    let sig = signing_key.sign(signing_input.as_bytes());
+    format!(
+        "{}.{}",
+        signing_input,
+        URL_SAFE_NO_PAD.encode(sig.to_bytes())
+    )
+}
+
+fn oauth_error(status: StatusCode, error: &str, description: Option<&str>) -> Response {
+    let mut body = serde_json::Map::new();
+    body.insert(
+        "error".to_owned(),
+        serde_json::Value::String(error.to_owned()),
+    );
+    if let Some(description) = description {
+        body.insert(
+            "error_description".to_owned(),
+            serde_json::Value::String(description.to_owned()),
+        );
+    }
+    (
+        status,
+        [
+            (header::CACHE_CONTROL, "no-store"),
+            (header::PRAGMA, "no-cache"),
+        ],
+        Json(serde_json::Value::Object(body)),
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::rngs::OsRng;
+
+    #[test]
+    fn k8s_service_account_subject_maps_without_collision() {
+        assert_eq!(
+            map_workload_subject(
+                "https://issuer.example.test",
+                "system:serviceaccount:training:runner"
+            ),
+            "k8s:issuer.example.test:training:runner"
+        );
+    }
+
+    #[test]
+    fn service_spiffe_id_uses_issuer_host_as_trust_domain() {
+        assert_eq!(
+            service_spiffe_id("https://hypr.example.test/oauth", "model"),
+            "spiffe://hypr.example.test/service/model"
+        );
+    }
+
+    #[test]
+    fn jwt_svid_uses_audience_array() {
+        let key = ed25519_dalek::SigningKey::generate(&mut OsRng);
+        let token = encode_jwt_svid(
+            &JwtSvidClaims {
+                iss: "https://hypr.example.test".to_owned(),
+                sub: "spiffe://hypr.example.test/service/model".to_owned(),
+                aud: vec!["9p".to_owned(), "rpc".to_owned()],
+                iat: 1,
+                exp: 2,
+            },
+            &key,
+        );
+        let Some(payload_b64) = token.split('.').nth(1) else {
+            panic!("payload part");
+        };
+        let payload = match URL_SAFE_NO_PAD.decode(payload_b64) {
+            Ok(payload) => payload,
+            Err(e) => panic!("payload decodes: {e}"),
+        };
+        let value: serde_json::Value = match serde_json::from_slice(&payload) {
+            Ok(value) => value,
+            Err(e) => panic!("json payload: {e}"),
+        };
+        assert_eq!(value["aud"], serde_json::json!(["9p", "rpc"]));
+        assert_eq!(value["sub"], "spiffe://hypr.example.test/service/model");
+    }
+}

--- a/docs/spiffe.md
+++ b/docs/spiffe.md
@@ -1,16 +1,16 @@
 # SPIFFE in hyprstream
 
-> **Status: design direction — SPIFFE proper is NOT implemented.** hyprstream issues no SPIFFE IDs, serves no SPIFFE bundle endpoint, and has no `[spiffe]` config section. What *does* ship today is the SVID **concept** under different standards: workload identity is a WIMSE Workload Identity Token (`typ: "wit+jwt"`, minted by `encode_service_jwt` in `crates/hyprstream-rpc/src/auth/jwt.rs`; browser WITs via `POST /oauth/wit`, `crates/hyprstream/src/services/oauth/wit_bootstrap.rs`), node identity is did:web/did:key, and envelope signing is hybrid-PQC COSE. This page describes how a SPIFFE-compatible surface *would* layer over that reality if a SPIFFE-consumer integration ever needs it. Nothing below is a configuration you can turn on today except where explicitly noted.
+> **Status: partial HTTP compatibility surface.** hyprstream still does not run a SPIRE server, issue X.509-SVIDs, or expose a `[spiffe]` config section. It now exposes the JWT-SVID-compatible pieces needed by the Kubernetes security spine: `POST /oauth/spiffe/wit` consumes a registered cluster/SPIRE issuer token and re-issues a local WIT, `POST /oauth/spiffe/service-svid` issues a service JWT-SVID, and `GET /.well-known/spiffe/bundle` publishes the same signing keys as OAuth JWKS in SPIFFE bundle shape. The underlying identity system remains WIT/did:web plus hybrid-PQC COSE.
 
 The intended model: hyprstream acts as a **SPIFFE trust-domain authority** — issuing SPIFFE-compatible identities for its own workloads and publishing a trust bundle that other SPIFFE consumers can verify against, with no SPIRE installation required on the hyprstream host.
 
 This page is for operators considering integrating hyprstream with a SPIFFE-aware environment. If you don't run any SPIFFE consumers, you can skip it entirely — the WIT/did:web identity system works without any of this.
 
-## The short version (proposed model)
+## The short version
 
 - **Trust domain** = hyprstream instance FQDN (e.g. `hyprstream.acme.com`)
-- **SPIFFE IDs** would look like `spiffe://hyprstream.acme.com/service/model`
-- **Trust bundle** would be served at `https://hyprstream.acme.com/.well-known/spiffe/bundle`
+- **SPIFFE IDs** look like `spiffe://hyprstream.acme.com/service/model`
+- **Trust bundle** is served at `https://hyprstream.acme.com/.well-known/spiffe/bundle`
 - **Federation** with other trust domains would be gated by the same `federation:register` policy that already controls OAuth/CIMD federation — one trust decision, multiple protocols
 
 ## Why FQDN-aligned
@@ -37,7 +37,47 @@ The SVID role is filled by WIMSE Workload Identity Tokens:
 - **Browser WITs** — `POST /oauth/wit` (`crates/hyprstream/src/services/oauth/wit_bootstrap.rs`) exchanges a PKCE-issued `at+jwt` for a short-lived `wit+jwt` bound to the caller's Ed25519 pubkey.
 - **Node identity** — did:web documents at the FQDN; envelope signatures use hybrid-PQC COSE (EdDSA + ML-DSA-65).
 
-A future SPIFFE surface would be a re-encoding of these primitives (WIT ≈ JWT-SVID, did:web JWKS ≈ trust bundle), not a parallel identity system.
+The SPIFFE surface is a re-encoding of these primitives (WIT ≈ JWT-SVID, did:web/OAuth JWKS ≈ trust bundle), not a parallel identity system.
+
+## HTTP surface
+
+### Consume: cluster/SPIRE token to WIT
+
+`POST /oauth/spiffe/wit` accepts JSON:
+
+```json
+{
+  "subject_token": "<projected ServiceAccount token or JWT-SVID>",
+  "audience": "hyprstream",
+  "pubkey": "<optional base64url Ed25519 public key>"
+}
+```
+
+The token issuer must already be registered in `oauth.trusted_issuers` through the normal federation path. The endpoint verifies issuer, signature, expiry/not-before, and audience. Kubernetes ServiceAccount subjects are mapped as `k8s:<issuer-host>:<namespace>:<serviceaccount>`; SPIFFE subjects are mapped as `spiffe:<trust-domain>/<path>`. The issued credential is a short-lived `wit+jwt`, optionally bound with `cnf.jwk` from `pubkey` or an Ed25519 DPoP proof.
+
+### Provide: service JWT-SVID
+
+`POST /oauth/spiffe/service-svid` is protected by normal OAuth bearer auth and accepts:
+
+```json
+{
+  "service": "model",
+  "audience": ["consumer-a"]
+}
+```
+
+It returns a short-lived JWT-SVID whose `sub` is `spiffe://<issuer-host>/service/<service>`, with an audience array for SPIFFE validators.
+
+### Bundle
+
+`GET /.well-known/spiffe/bundle` returns:
+
+```json
+{
+  "spiffe_sequence": 1,
+  "keys": [/* same active signing keys as /oauth/jwks */]
+}
+```
 
 ## Proposed SPIFFE ID scheme
 
@@ -64,7 +104,7 @@ hyprstream quick policy apply
 
 Apply the `federation-open` template (or run `hyprstream wizard --enable-federation`) to enable open federation; allowlist specific origins for stricter posture. A SPIFFE integration would sit behind this same gate.
 
-## Scope limits (would apply even if implemented)
+## Scope limits
 
 - **JWT-SVID only.** No X.509-SVID issuance is planned. If you need mTLS with X.509-SVIDs (e.g., service mesh sidecars), run SPIRE alongside hyprstream and federate the trust domains.
 - **No upstream-authority mode.** hyprstream would not be a SPIRE upstream CA; other SPIRE deployments would federate with it as peers.
@@ -78,7 +118,7 @@ Apply the `federation-open` template (or run `hyprstream wizard --enable-federat
 | OAuth client (with FQDN) | `https://app.example.com/client.json` | CIMD | shipped |
 | OAuth client (no FQDN) | UUID issued by hyprstream | DCR (RFC 7591) | shipped |
 | hyprstream workload | WIMSE WIT (`wit+jwt`) | EdDSA JWT + COSE envelopes | shipped |
-| hyprstream workload (SPIFFE view) | `spiffe://hyprstream.acme.com/service/model` | SPIFFE JWT-SVID | **design only** |
+| hyprstream workload (SPIFFE view) | `spiffe://hyprstream.acme.com/service/model` | SPIFFE JWT-SVID | partial HTTP surface |
 | Peer hyprstream | `https://hyprstream.partner.org` | OAuth/OIDC issuer + did:web | shipped (gated by `federation:register`) |
 
 ## References


### PR DESCRIPTION
## Summary

Implements the first ready slice of the #778 security spine across #780, #785, and #786:

- Adds `POST /oauth/spiffe/wit` to consume a registered external Kubernetes/SPIRE workload JWT and re-issue a local short-lived `wit+jwt`.
- Adds `POST /oauth/spiffe/service-svid` to issue hyprstream service JWT-SVIDs with `spiffe://<issuer-host>/service/<name>` subjects.
- Adds `GET /.well-known/spiffe/bundle`, sharing the same signing keys as `/oauth/jwks` in SPIFFE bundle shape.
- Adds `POST /oauth/mount-ticket` to mint short-lived 9P mount tickets from an already authenticated caller.
- Tightens 9P WS/WT ticket validation so attach now requires an explicit mount-ticket capability (`cap=mount@9p://...`); plain bearer/access tokens are rejected.
- Updates `docs/spiffe.md` from design-only to the partial HTTP compatibility surface now present.

## CSI #790 interface

CSI can request a mount ticket with:

```json
POST /oauth/mount-ticket
{
  "plane": "webtransport",
  "namespace_path": "/tenant/a",
  "pubkey": "<optional base64url Ed25519 public key>"
}
```

Response includes:

```json
{
  "ticket": "<jwt>",
  "token_type": "mount-ticket+jwt",
  "expires_in": 300,
  "audience": "<issuer-url>",
  "capability": "mount@9p://webtransport/tenant/a"
}
```

Presentation contract:

- WebTransport 9P: send the returned ticket in `Tattach.uname`.
- WebSocket 9P: send the returned ticket as `?ticket=` on `/9p`.

## Design notes / blockers

- Existing server token verification requires JWT `aud` to match the protected resource URL, so plane/path binding is currently encoded in `cap=mount@9p://<plane><namespace_path>` rather than using JWT `aud` as the plane/path authority. If #790 or policy wants strict JWT `aud=9p-plane`, the next step is a mount-ticket-specific verifier or a resource override in `verify_token_claims`.
- External workload token verification reuses the existing federated JWKS resolver. That resolver is Ed25519/EdDSA-oriented today, so Kubernetes issuers using RSA/ES256 service-account tokens will need resolver expansion before they can pass #780.
- #785 authority placement choice in this slice: OAuth HTTP surface is the public issuer/bundle endpoint; PolicyService remains the signing/trust-policy authority behind issuance.

## Verification

- Pre-commit clippy hook passed on commit.
- `TMPDIR=/home/birdetta/projects/cyberdione/hyprstream/.tmp-build CARGO_TARGET_DIR=/home/birdetta/projects/cyberdione/hyprstream/target LIBTORCH=/home/birdetta/Downloads/libtorch LD_LIBRARY_PATH=/home/birdetta/Downloads/libtorch/lib cargo test -p hyprstream --lib oauth:: --no-default-features` — 114 passed, 0 failed.

Closes #780.
Closes #785.
Closes #786.
