### PR TITLE
feat(k8s): add operator controller runtime (#791)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7097,7 +7097,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "thiserror 1.0.69",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/hyprstream-k8s/Cargo.toml
+++ b/crates/hyprstream-k8s/Cargo.toml
@@ -19,6 +19,9 @@ default = []
 # `ws` adds the websocket upgrade path kube uses for pod `exec`/`attach`
 # (`AttachedProcess`), consumed by the workers `k8s` sandbox backend.
 k8s = [
+    "dep:futures",
+    "dep:tokio",
+    "dep:tracing",
     "kube/client",
     "kube/runtime",
     "kube/rustls-tls",
@@ -26,9 +29,7 @@ k8s = [
     "dep:hyprstream-vfs",
     "dep:hyprstream-rpc",
     "dep:async-trait",
-    "dep:tokio",
     "dep:parking_lot",
-    "dep:futures",
 ]
 
 [dependencies]
@@ -41,14 +42,16 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 schemars = "1"
+futures = { workspace = true, optional = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
 
 # `/k8s` VFS projection (K7, #782) — all optional, pulled in by the `k8s` feature.
 hyprstream-vfs = { path = "../hyprstream-vfs", optional = true }
 hyprstream-rpc = { path = "../hyprstream-rpc", optional = true }
 async-trait = { version = "0.1", optional = true }
-tokio = { version = "1", features = ["sync", "rt"], optional = true }
 parking_lot = { workspace = true, optional = true }
-futures = { version = "0.3", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "sync"] }

--- a/crates/hyprstream-k8s/src/lib.rs
+++ b/crates/hyprstream-k8s/src/lib.rs
@@ -49,6 +49,8 @@ pub mod training;
 
 #[cfg(feature = "k8s")]
 pub mod install;
+#[cfg(feature = "k8s")]
+pub mod operator;
 
 // Re-export the underlying `kube`/`k8s-openapi` crates so downstream crates
 // (e.g. `hyprstream-workers`' `k8s` sandbox backend) consume the *same*

--- a/crates/hyprstream-k8s/src/operator.rs
+++ b/crates/hyprstream-k8s/src/operator.rs
@@ -1,0 +1,541 @@
+//! kube-rs operator runtime for hyprstream CRDs.
+//!
+//! This is K5b (#791): reconcilers translate Kubernetes intent into
+//! hyprstream RPC calls, then reflect observed git/runtime truth back into
+//! status. They are deliberately not a second writer of model weights.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::future::BoxFuture;
+use futures::StreamExt;
+use kube::api::{Patch, PatchParams};
+use kube::core::NamespaceResourceScope;
+use kube::runtime::controller::Action;
+use kube::runtime::{watcher, Controller};
+use kube::{Api, Client, Resource, ResourceExt};
+use serde::Serialize;
+use serde_json::json;
+use thiserror::Error;
+
+use crate::{
+    Adapter, AdapterStatus, Model, ModelStatus, TenantBinding, API_VERSION, MANAGED_BY_LABEL,
+    MANAGED_BY_VALUE,
+};
+
+/// Field manager used by the operator when writing status.
+pub const OPERATOR_FIELD_MANAGER: &str = "hyprstream-operator";
+
+const MODEL_KIND: &str = "Model";
+const ADAPTER_KIND: &str = "Adapter";
+
+/// Runtime configuration shared by every reconciler.
+#[derive(Clone, Debug)]
+pub struct OperatorConfig {
+    /// Requeue interval after a successful reconcile.
+    pub requeue: Duration,
+}
+
+impl Default for OperatorConfig {
+    fn default() -> Self {
+        Self {
+            requeue: Duration::from_secs(300),
+        }
+    }
+}
+
+/// Result observed after a model reconcile through RegistryService/ModelService.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ModelObservation {
+    pub observed_ref: String,
+    pub message: Option<String>,
+}
+
+/// Result observed after an adapter reconcile through RegistryService.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AdapterObservation {
+    pub observed_file: String,
+    pub message: Option<String>,
+}
+
+/// Thin abstraction over the hyprstream RPC clients used by K5b.
+///
+/// The production implementation is expected to wrap generated
+/// RegistryService/ModelService clients. #848 is the remaining cluster-topology
+/// dependency for constructing those clients over cross-pod QUIC/iroh.
+pub trait HyprstreamOperatorRpc: Send + Sync + 'static {
+    fn reconcile_model<'a>(
+        &'a self,
+        tenant: &'a str,
+        model: &'a Model,
+    ) -> BoxFuture<'a, Result<ModelObservation, OperatorError>>;
+
+    fn reconcile_adapter<'a>(
+        &'a self,
+        tenant: &'a str,
+        adapter: &'a Adapter,
+    ) -> BoxFuture<'a, Result<AdapterObservation, OperatorError>>;
+}
+
+/// Shared controller state.
+#[derive(Clone)]
+pub struct OperatorState<R> {
+    client: Client,
+    rpc: Arc<R>,
+    config: OperatorConfig,
+}
+
+impl<R> OperatorState<R>
+where
+    R: HyprstreamOperatorRpc,
+{
+    pub fn new(client: Client, rpc: Arc<R>, config: OperatorConfig) -> Self {
+        Self {
+            client,
+            rpc,
+            config,
+        }
+    }
+}
+
+/// Operator runtime errors surfaced into status conditions and logs.
+#[derive(Debug, Error)]
+pub enum OperatorError {
+    #[error("resource {kind}/{name} is missing metadata.namespace")]
+    MissingNamespace { kind: &'static str, name: String },
+
+    #[error("namespace {namespace} is not bound to a hyprstream tenant")]
+    TenantBindingMissing { namespace: String },
+
+    #[error("kubernetes API error: {0}")]
+    Kube(#[from] kube::Error),
+
+    #[error("hyprstream RPC error: {0}")]
+    Rpc(String),
+}
+
+/// Run Model and Adapter controllers until the process receives Ctrl-C.
+pub async fn run_model_adapter_operator<R>(
+    client: Client,
+    rpc: Arc<R>,
+    config: OperatorConfig,
+) -> Result<(), OperatorError>
+where
+    R: HyprstreamOperatorRpc,
+{
+    let state = Arc::new(OperatorState::new(client.clone(), rpc, config));
+    let models = run_model_controller(client.clone(), Arc::clone(&state));
+    let adapters = run_adapter_controller(client, state);
+    tokio::select! {
+        result = models => result,
+        result = adapters => result,
+        _ = tokio::signal::ctrl_c() => Ok(()),
+    }
+}
+
+/// Run the Model controller stream.
+pub async fn run_model_controller<R>(
+    client: Client,
+    state: Arc<OperatorState<R>>,
+) -> Result<(), OperatorError>
+where
+    R: HyprstreamOperatorRpc,
+{
+    Controller::new(Api::<Model>::all(client), watcher::Config::default())
+        .run(reconcile_model, model_error_policy::<R>, state)
+        .for_each(|result| async move {
+            if let Err(error) = result {
+                tracing::warn!(%error, "model reconcile failed");
+            }
+        })
+        .await;
+    Ok(())
+}
+
+/// Run the Adapter controller stream.
+pub async fn run_adapter_controller<R>(
+    client: Client,
+    state: Arc<OperatorState<R>>,
+) -> Result<(), OperatorError>
+where
+    R: HyprstreamOperatorRpc,
+{
+    Controller::new(Api::<Adapter>::all(client), watcher::Config::default())
+        .run(reconcile_adapter, adapter_error_policy::<R>, state)
+        .for_each(|result| async move {
+            if let Err(error) = result {
+                tracing::warn!(%error, "adapter reconcile failed");
+            }
+        })
+        .await;
+    Ok(())
+}
+
+async fn reconcile_model<R>(
+    model: Arc<Model>,
+    state: Arc<OperatorState<R>>,
+) -> Result<Action, OperatorError>
+where
+    R: HyprstreamOperatorRpc,
+{
+    ensure_operator_label(&state.client, model.as_ref(), MODEL_KIND).await?;
+    let outcome = evaluate_model(model.as_ref(), state.as_ref()).await;
+    patch_model_status(
+        &state.client,
+        model.as_ref(),
+        status_for_model_outcome(model.as_ref(), &outcome),
+    )
+    .await?;
+    outcome.map(|_| Action::requeue(state.config.requeue))
+}
+
+async fn reconcile_adapter<R>(
+    adapter: Arc<Adapter>,
+    state: Arc<OperatorState<R>>,
+) -> Result<Action, OperatorError>
+where
+    R: HyprstreamOperatorRpc,
+{
+    ensure_operator_label(&state.client, adapter.as_ref(), ADAPTER_KIND).await?;
+    let outcome = evaluate_adapter(adapter.as_ref(), state.as_ref()).await;
+    patch_adapter_status(
+        &state.client,
+        adapter.as_ref(),
+        status_for_adapter_outcome(adapter.as_ref(), &outcome),
+    )
+    .await?;
+    outcome.map(|_| Action::requeue(state.config.requeue))
+}
+
+fn model_error_policy<R>(
+    _model: Arc<Model>,
+    _error: &OperatorError,
+    state: Arc<OperatorState<R>>,
+) -> Action
+where
+    R: HyprstreamOperatorRpc,
+{
+    Action::requeue(state.config.requeue)
+}
+
+fn adapter_error_policy<R>(
+    _adapter: Arc<Adapter>,
+    _error: &OperatorError,
+    state: Arc<OperatorState<R>>,
+) -> Action
+where
+    R: HyprstreamOperatorRpc,
+{
+    Action::requeue(state.config.requeue)
+}
+
+async fn evaluate_model<R>(
+    model: &Model,
+    state: &OperatorState<R>,
+) -> Result<ModelObservation, OperatorError>
+where
+    R: HyprstreamOperatorRpc,
+{
+    let tenant = tenant_for_resource(&state.client, MODEL_KIND, model).await?;
+    state.rpc.reconcile_model(&tenant, model).await
+}
+
+async fn evaluate_adapter<R>(
+    adapter: &Adapter,
+    state: &OperatorState<R>,
+) -> Result<AdapterObservation, OperatorError>
+where
+    R: HyprstreamOperatorRpc,
+{
+    let tenant = tenant_for_resource(&state.client, ADAPTER_KIND, adapter).await?;
+    state.rpc.reconcile_adapter(&tenant, adapter).await
+}
+
+async fn tenant_for_resource<K>(
+    client: &Client,
+    kind: &'static str,
+    resource: &K,
+) -> Result<String, OperatorError>
+where
+    K: Resource + ResourceExt,
+{
+    let name = resource.name_any();
+    let namespace = resource
+        .namespace()
+        .ok_or_else(|| OperatorError::MissingNamespace { kind, name })?;
+    tenant_for_namespace(client, &namespace).await
+}
+
+async fn tenant_for_namespace(client: &Client, namespace: &str) -> Result<String, OperatorError> {
+    let bindings: Api<TenantBinding> = Api::all(client.clone());
+    let list = bindings.list(&Default::default()).await?;
+    list.into_iter()
+        .find(|binding| binding.spec.namespace == namespace)
+        .map(|binding| binding.spec.tenant)
+        .ok_or_else(|| OperatorError::TenantBindingMissing {
+            namespace: namespace.to_owned(),
+        })
+}
+
+fn status_for_model_outcome(
+    model: &Model,
+    outcome: &Result<ModelObservation, OperatorError>,
+) -> ModelStatus {
+    match outcome {
+        Ok(observed) => ModelStatus {
+            observed_ref: Some(observed.observed_ref.clone()),
+            phase: Some("Ready".to_owned()),
+            message: observed.message.clone(),
+            observed_generation: model.meta().generation,
+        },
+        Err(error) => ModelStatus {
+            observed_ref: None,
+            phase: Some("Rejected".to_owned()),
+            message: Some(error.to_string()),
+            observed_generation: model.meta().generation,
+        },
+    }
+}
+
+fn status_for_adapter_outcome(
+    adapter: &Adapter,
+    outcome: &Result<AdapterObservation, OperatorError>,
+) -> AdapterStatus {
+    match outcome {
+        Ok(observed) => AdapterStatus {
+            observed_file: Some(observed.observed_file.clone()),
+            phase: Some("Ready".to_owned()),
+            observed_generation: adapter.meta().generation,
+        },
+        Err(_error) => AdapterStatus {
+            observed_file: None,
+            phase: Some("Rejected".to_owned()),
+            observed_generation: adapter.meta().generation,
+        },
+    }
+}
+
+async fn ensure_operator_label<K>(
+    client: &Client,
+    resource: &K,
+    kind: &'static str,
+) -> Result<K, kube::Error>
+where
+    K: Clone
+        + std::fmt::Debug
+        + Resource<Scope = NamespaceResourceScope>
+        + ResourceExt
+        + serde::de::DeserializeOwned,
+    <K as Resource>::DynamicType: Default,
+{
+    let namespace = resource.namespace().unwrap_or_default();
+    let api: Api<K> = Api::namespaced(client.clone(), &namespace);
+    api.patch(
+        &resource.name_any(),
+        &PatchParams::apply(OPERATOR_FIELD_MANAGER).force(),
+        &Patch::Apply(&metadata_patch(resource, kind)),
+    )
+    .await
+}
+
+async fn patch_model_status(
+    client: &Client,
+    model: &Model,
+    status: ModelStatus,
+) -> Result<Model, kube::Error> {
+    patch_namespaced_status(client, model, MODEL_KIND, status).await
+}
+
+async fn patch_adapter_status(
+    client: &Client,
+    adapter: &Adapter,
+    status: AdapterStatus,
+) -> Result<Adapter, kube::Error> {
+    patch_namespaced_status(client, adapter, ADAPTER_KIND, status).await
+}
+
+async fn patch_namespaced_status<K, S>(
+    client: &Client,
+    resource: &K,
+    kind: &'static str,
+    status: S,
+) -> Result<K, kube::Error>
+where
+    K: Clone + Resource<Scope = NamespaceResourceScope> + ResourceExt + serde::de::DeserializeOwned,
+    <K as Resource>::DynamicType: Default,
+    S: Serialize,
+{
+    let namespace = resource.namespace().unwrap_or_default();
+    let api: Api<K> = Api::namespaced(client.clone(), &namespace);
+    let patch = status_patch(resource, kind, status);
+    api.patch_status(
+        &resource.name_any(),
+        &PatchParams::apply(OPERATOR_FIELD_MANAGER).force(),
+        &Patch::Apply(&patch),
+    )
+    .await
+}
+
+fn status_patch<K, S>(resource: &K, kind: &'static str, status: S) -> serde_json::Value
+where
+    K: ResourceExt,
+    S: Serialize,
+{
+    json!({
+        "apiVersion": format!("{}.hyprstream.io/{API_VERSION}", group_for_kind(kind)),
+        "kind": kind,
+        "metadata": {
+            "name": resource.name_any(),
+            "namespace": resource.namespace(),
+        },
+        "status": status,
+    })
+}
+
+fn metadata_patch<K>(resource: &K, kind: &'static str) -> serde_json::Value
+where
+    K: ResourceExt,
+{
+    json!({
+        "apiVersion": format!("{}.hyprstream.io/{API_VERSION}", group_for_kind(kind)),
+        "kind": kind,
+        "metadata": {
+            "name": resource.name_any(),
+            "namespace": resource.namespace(),
+            "labels": {
+                MANAGED_BY_LABEL: MANAGED_BY_VALUE,
+            },
+        },
+    })
+}
+
+fn group_for_kind(kind: &str) -> &'static str {
+    match kind {
+        MODEL_KIND | ADAPTER_KIND => "models",
+        _ => "mesh",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{AdapterSpec, ModelSpec, ModelStage};
+
+    #[test]
+    fn model_success_status_reports_observed_ref() {
+        let model = Model::new(
+            "qwen",
+            ModelSpec {
+                repo: "hf://org/qwen".to_owned(),
+                git_ref: Some("main".to_owned()),
+                stage: ModelStage::Promoted,
+            },
+        );
+        let status = status_for_model_outcome(
+            &model,
+            &Ok(ModelObservation {
+                observed_ref: "refs/heads/main".to_owned(),
+                message: Some("checked out".to_owned()),
+            }),
+        );
+
+        assert_eq!(status.phase.as_deref(), Some("Ready"));
+        assert_eq!(status.observed_ref.as_deref(), Some("refs/heads/main"));
+        assert_eq!(status.message.as_deref(), Some("checked out"));
+    }
+
+    #[test]
+    fn model_binding_failure_is_rejected_status() {
+        let model = Model::new(
+            "qwen",
+            ModelSpec {
+                repo: "hf://org/qwen".to_owned(),
+                git_ref: Some("main".to_owned()),
+                stage: ModelStage::Promoted,
+            },
+        );
+        let status = status_for_model_outcome(
+            &model,
+            &Err(OperatorError::TenantBindingMissing {
+                namespace: "tenant-a".to_owned(),
+            }),
+        );
+
+        assert_eq!(status.phase.as_deref(), Some("Rejected"));
+        assert!(status
+            .message
+            .as_deref()
+            .unwrap_or_default()
+            .contains("tenant-a"));
+    }
+
+    #[test]
+    fn adapter_success_status_reports_file() {
+        let adapter = Adapter::new(
+            "style",
+            AdapterSpec {
+                model_ref: "qwen".to_owned(),
+                file: "00_style.safetensors".to_owned(),
+                base_ref: None,
+            },
+        );
+        let status = status_for_adapter_outcome(
+            &adapter,
+            &Ok(AdapterObservation {
+                observed_file: "00_style.safetensors".to_owned(),
+                message: None,
+            }),
+        );
+
+        assert_eq!(status.phase.as_deref(), Some("Ready"));
+        assert_eq!(
+            status.observed_file.as_deref(),
+            Some("00_style.safetensors")
+        );
+    }
+
+    #[test]
+    fn model_metadata_patch_marks_operator_ownership() {
+        let model = Model::new(
+            "qwen",
+            ModelSpec {
+                repo: "hf://org/qwen".to_owned(),
+                git_ref: Some("main".to_owned()),
+                stage: ModelStage::Promoted,
+            },
+        );
+        let patch = metadata_patch(&model, MODEL_KIND);
+
+        assert_eq!(patch["apiVersion"], "models.hyprstream.io/v1alpha1");
+        assert_eq!(patch["kind"], "Model");
+        assert_eq!(
+            patch["metadata"]["labels"][MANAGED_BY_LABEL],
+            MANAGED_BY_VALUE
+        );
+    }
+
+    #[test]
+    fn adapter_status_patch_uses_models_group() {
+        let adapter = Adapter::new(
+            "style",
+            AdapterSpec {
+                model_ref: "qwen".to_owned(),
+                file: "00_style.safetensors".to_owned(),
+                base_ref: None,
+            },
+        );
+        let patch = status_patch(
+            &adapter,
+            ADAPTER_KIND,
+            AdapterStatus {
+                observed_file: Some("00_style.safetensors".to_owned()),
+                phase: Some("Ready".to_owned()),
+                observed_generation: None,
+            },
+        );
+
+        assert_eq!(patch["apiVersion"], "models.hyprstream.io/v1alpha1");
+        assert_eq!(patch["kind"], "Adapter");
+        assert_eq!(patch["status"]["observedFile"], "00_style.safetensors");
+    }
+}

--- a/crates/hyprstream-k8s/src/operator.rs
+++ b/crates/hyprstream-k8s/src/operator.rs
@@ -4,12 +4,13 @@
 //! hyprstream RPC calls, then reflect observed git/runtime truth back into
 //! status. They are deliberately not a second writer of model weights.
 
+use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use futures::future::BoxFuture;
 use futures::StreamExt;
-use kube::api::{Patch, PatchParams};
+use kube::api::{ListParams, Patch, PatchParams};
 use kube::core::NamespaceResourceScope;
 use kube::runtime::controller::Action;
 use kube::runtime::{watcher, Controller};
@@ -34,12 +35,15 @@ const ADAPTER_KIND: &str = "Adapter";
 pub struct OperatorConfig {
     /// Requeue interval after a successful reconcile.
     pub requeue: Duration,
+    /// Maximum age of the namespace -> tenant cache.
+    pub tenant_binding_cache_ttl: Duration,
 }
 
 impl Default for OperatorConfig {
     fn default() -> Self {
         Self {
             requeue: Duration::from_secs(300),
+            tenant_binding_cache_ttl: Duration::from_secs(60),
         }
     }
 }
@@ -83,6 +87,7 @@ pub struct OperatorState<R> {
     client: Client,
     rpc: Arc<R>,
     config: OperatorConfig,
+    tenant_bindings: TenantBindingCache,
 }
 
 impl<R> OperatorState<R>
@@ -94,8 +99,20 @@ where
             client,
             rpc,
             config,
+            tenant_bindings: TenantBindingCache::default(),
         }
     }
+}
+
+#[derive(Clone, Default)]
+struct TenantBindingCache {
+    inner: Arc<tokio::sync::RwLock<CachedTenantBindings>>,
+}
+
+#[derive(Default)]
+struct CachedTenantBindings {
+    refreshed_at: Option<Instant>,
+    tenants_by_namespace: HashMap<String, String>,
 }
 
 /// Operator runtime errors surfaced into status conditions and logs.
@@ -106,6 +123,9 @@ pub enum OperatorError {
 
     #[error("namespace {namespace} is not bound to a hyprstream tenant")]
     TenantBindingMissing { namespace: String },
+
+    #[error("namespace {namespace} has multiple TenantBindings: {bindings}")]
+    TenantBindingDuplicate { namespace: String, bindings: String },
 
     #[error("kubernetes API error: {0}")]
     Kube(#[from] kube::Error),
@@ -178,6 +198,9 @@ async fn reconcile_model<R>(
 where
     R: HyprstreamOperatorRpc,
 {
+    if model_status_observed_current(model.as_ref()) {
+        return Ok(Action::requeue(state.config.requeue));
+    }
     ensure_operator_label(&state.client, model.as_ref(), MODEL_KIND).await?;
     let outcome = evaluate_model(model.as_ref(), state.as_ref()).await;
     patch_model_status(
@@ -196,6 +219,9 @@ async fn reconcile_adapter<R>(
 where
     R: HyprstreamOperatorRpc,
 {
+    if adapter_status_observed_current(adapter.as_ref()) {
+        return Ok(Action::requeue(state.config.requeue));
+    }
     ensure_operator_label(&state.client, adapter.as_ref(), ADAPTER_KIND).await?;
     let outcome = evaluate_adapter(adapter.as_ref(), state.as_ref()).await;
     patch_adapter_status(
@@ -236,7 +262,7 @@ async fn evaluate_model<R>(
 where
     R: HyprstreamOperatorRpc,
 {
-    let tenant = tenant_for_resource(&state.client, MODEL_KIND, model).await?;
+    let tenant = tenant_for_resource(state, MODEL_KIND, model).await?;
     state.rpc.reconcile_model(&tenant, model).await
 }
 
@@ -247,34 +273,129 @@ async fn evaluate_adapter<R>(
 where
     R: HyprstreamOperatorRpc,
 {
-    let tenant = tenant_for_resource(&state.client, ADAPTER_KIND, adapter).await?;
+    let tenant = tenant_for_resource(state, ADAPTER_KIND, adapter).await?;
     state.rpc.reconcile_adapter(&tenant, adapter).await
 }
 
-async fn tenant_for_resource<K>(
-    client: &Client,
+async fn tenant_for_resource<R, K>(
+    state: &OperatorState<R>,
     kind: &'static str,
     resource: &K,
 ) -> Result<String, OperatorError>
 where
+    R: HyprstreamOperatorRpc,
     K: Resource + ResourceExt,
 {
     let name = resource.name_any();
     let namespace = resource
         .namespace()
         .ok_or_else(|| OperatorError::MissingNamespace { kind, name })?;
-    tenant_for_namespace(client, &namespace).await
+    state.tenant_for_namespace(&namespace).await
 }
 
-async fn tenant_for_namespace(client: &Client, namespace: &str) -> Result<String, OperatorError> {
-    let bindings: Api<TenantBinding> = Api::all(client.clone());
-    let list = bindings.list(&Default::default()).await?;
-    list.into_iter()
-        .find(|binding| binding.spec.namespace == namespace)
-        .map(|binding| binding.spec.tenant)
-        .ok_or_else(|| OperatorError::TenantBindingMissing {
-            namespace: namespace.to_owned(),
-        })
+impl<R> OperatorState<R>
+where
+    R: HyprstreamOperatorRpc,
+{
+    async fn tenant_for_namespace(&self, namespace: &str) -> Result<String, OperatorError> {
+        if let Some(tenant) = self
+            .tenant_bindings
+            .get_fresh(namespace, self.config.tenant_binding_cache_ttl)
+            .await
+        {
+            return Ok(tenant);
+        }
+
+        let bindings: Api<TenantBinding> = Api::all(self.client.clone());
+        let list = bindings.list(&ListParams::default()).await?;
+        let tenants_by_namespace = tenant_map(list)?;
+        self.tenant_bindings
+            .replace(tenants_by_namespace, Instant::now())
+            .await;
+        self.tenant_bindings
+            .get_any(namespace)
+            .await
+            .ok_or_else(|| OperatorError::TenantBindingMissing {
+                namespace: namespace.to_owned(),
+            })
+    }
+}
+
+impl TenantBindingCache {
+    async fn get_fresh(&self, namespace: &str, ttl: Duration) -> Option<String> {
+        let cache = self.inner.read().await;
+        let fresh = cache
+            .refreshed_at
+            .is_some_and(|refreshed_at| refreshed_at.elapsed() <= ttl);
+        if fresh {
+            cache.tenants_by_namespace.get(namespace).cloned()
+        } else {
+            None
+        }
+    }
+
+    async fn get_any(&self, namespace: &str) -> Option<String> {
+        self.inner
+            .read()
+            .await
+            .tenants_by_namespace
+            .get(namespace)
+            .cloned()
+    }
+
+    async fn replace(&self, tenants_by_namespace: HashMap<String, String>, refreshed_at: Instant) {
+        let mut cache = self.inner.write().await;
+        cache.refreshed_at = Some(refreshed_at);
+        cache.tenants_by_namespace = tenants_by_namespace;
+    }
+}
+
+fn tenant_map(
+    bindings: impl IntoIterator<Item = TenantBinding>,
+) -> Result<HashMap<String, String>, OperatorError> {
+    let mut tenants = HashMap::new();
+    let mut owners: HashMap<String, Vec<String>> = HashMap::new();
+
+    for binding in bindings {
+        let namespace = binding.spec.namespace.clone();
+        owners
+            .entry(namespace.clone())
+            .or_default()
+            .push(binding.name_any());
+        tenants
+            .entry(namespace)
+            .or_insert_with(|| binding.spec.tenant.clone());
+    }
+
+    if let Some((namespace, bindings)) = owners
+        .into_iter()
+        .find(|(_namespace, bindings)| bindings.len() > 1)
+    {
+        let mut bindings = bindings;
+        bindings.sort();
+        return Err(OperatorError::TenantBindingDuplicate {
+            namespace,
+            bindings: bindings.join(","),
+        });
+    }
+
+    Ok(tenants)
+}
+
+fn model_status_observed_current(model: &Model) -> bool {
+    model
+        .status
+        .as_ref()
+        .and_then(|status| status.observed_generation)
+        == model.meta().generation
+}
+
+fn adapter_status_observed_current(adapter: &Adapter) -> bool {
+    adapter
+        .status
+        .as_ref()
+        .and_then(|status| status.observed_generation)
+        == adapter.meta().generation
 }
 
 fn status_for_model_outcome(
@@ -419,7 +540,7 @@ fn group_for_kind(kind: &str) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{AdapterSpec, ModelSpec, ModelStage};
+    use crate::{AdapterSpec, ModelSpec, ModelStage, TenantBindingSpec};
 
     #[test]
     fn model_success_status_reports_observed_ref() {
@@ -537,5 +658,76 @@ mod tests {
         assert_eq!(patch["apiVersion"], "models.hyprstream.io/v1alpha1");
         assert_eq!(patch["kind"], "Adapter");
         assert_eq!(patch["status"]["observedFile"], "00_style.safetensors");
+    }
+
+    #[test]
+    fn current_generation_status_short_circuits_reconcile() {
+        let mut model = Model::new(
+            "qwen",
+            ModelSpec {
+                repo: "hf://org/qwen".to_owned(),
+                git_ref: Some("main".to_owned()),
+                stage: ModelStage::Promoted,
+            },
+        );
+        model.metadata.generation = Some(7);
+        model.status = Some(ModelStatus {
+            observed_generation: Some(7),
+            ..Default::default()
+        });
+
+        assert!(model_status_observed_current(&model));
+
+        model.status = Some(ModelStatus {
+            observed_generation: Some(6),
+            ..Default::default()
+        });
+        assert!(!model_status_observed_current(&model));
+    }
+
+    #[test]
+    fn tenant_map_rejects_duplicate_namespace_bindings() {
+        let first = TenantBinding::new(
+            "tenant-a",
+            TenantBindingSpec {
+                namespace: "team-a".to_owned(),
+                tenant: "did:web:tenant-a".to_owned(),
+            },
+        );
+        let second = TenantBinding::new(
+            "tenant-b",
+            TenantBindingSpec {
+                namespace: "team-a".to_owned(),
+                tenant: "did:web:tenant-b".to_owned(),
+            },
+        );
+
+        let error = match tenant_map([first, second]) {
+            Ok(_) => panic!("duplicate must fail"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            error,
+            OperatorError::TenantBindingDuplicate { namespace, .. } if namespace == "team-a"
+        ));
+    }
+
+    #[test]
+    fn tenant_map_is_namespace_keyed() {
+        let binding = TenantBinding::new(
+            "tenant-a",
+            TenantBindingSpec {
+                namespace: "team-a".to_owned(),
+                tenant: "did:web:tenant-a".to_owned(),
+            },
+        );
+
+        match tenant_map([binding]) {
+            Ok(tenants) => assert_eq!(
+                tenants.get("team-a").map(String::as_str),
+                Some("did:web:tenant-a")
+            ),
+            Err(error) => panic!("valid binding failed: {error}"),
+        }
     }
 }

--- a/crates/hyprstream-workers/src/runtime/backend.rs
+++ b/crates/hyprstream-workers/src/runtime/backend.rs
@@ -30,8 +30,8 @@ use async_trait::async_trait;
 use crate::config::PoolConfig;
 use crate::error::Result;
 
-use super::sandbox::PodSandbox;
 use super::client::{CpuUsage, LinuxContainerResources, MemoryUsage, PodSandboxConfig};
+use super::sandbox::PodSandbox;
 use hyprstream_vfs::{Namespace, Subject};
 
 /// Opaque handle stored on each `PodSandbox`.
@@ -73,6 +73,22 @@ pub enum NamespaceTransport {
     /// environment rather than over any wire transport — the wasm
     /// host-imports path (no separate guest OS to mount into).
     HostImports,
+    /// Deliver the composed namespace over authenticated network 9P and mount it
+    /// in a scheduler-placed Kubernetes pod through `csi.hyprstream.io` (#793).
+    ///
+    /// `endpoint` is the dial-time carrier endpoint selected by the operator
+    /// (normally iroh/QUIC-WebTransport cross-node, vsock for Kata, UDS only
+    /// co-located). `ticket` is a #862 mount ticket scoped to `namespace_path`.
+    /// The CSI node plugin chooses `mounter` (`kernel` or `fuse`) per
+    /// StorageClass/node policy.
+    NineP {
+        endpoint: String,
+        ticket: String,
+        namespace_path: String,
+        plane: String,
+        mounter: String,
+        mount_path: PathBuf,
+    },
 }
 
 /// Result of [`SandboxBackend::deliver_namespace`]: what's now available for
@@ -94,12 +110,25 @@ pub enum NamespaceDelivery {
     BindMount { target: PathBuf },
     /// The namespace was imported directly into the guest's environment.
     HostImports,
+    /// The namespace is represented as a `csi.hyprstream.io` pod volume.
+    NineP {
+        endpoint: String,
+        ticket: String,
+        namespace_path: String,
+        plane: String,
+        mounter: String,
+        mount_path: PathBuf,
+    },
 }
 
 impl std::fmt::Debug for NamespaceDelivery {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::VirtioFs { socket_path, mount_tag, .. } => f
+            Self::VirtioFs {
+                socket_path,
+                mount_tag,
+                ..
+            } => f
                 .debug_struct("VirtioFs")
                 .field("socket_path", socket_path)
                 .field("mount_tag", mount_tag)
@@ -108,6 +137,21 @@ impl std::fmt::Debug for NamespaceDelivery {
                 f.debug_struct("BindMount").field("target", target).finish()
             }
             Self::HostImports => write!(f, "HostImports"),
+            Self::NineP {
+                endpoint,
+                namespace_path,
+                plane,
+                mounter,
+                mount_path,
+                ..
+            } => f
+                .debug_struct("NineP")
+                .field("endpoint", endpoint)
+                .field("namespace_path", namespace_path)
+                .field("plane", plane)
+                .field("mounter", mounter)
+                .field("mount_path", mount_path)
+                .finish_non_exhaustive(),
         }
     }
 }

--- a/crates/hyprstream-workers/src/runtime/backend.rs
+++ b/crates/hyprstream-workers/src/runtime/backend.rs
@@ -78,12 +78,11 @@ pub enum NamespaceTransport {
     ///
     /// `endpoint` is the dial-time carrier endpoint selected by the operator
     /// (normally iroh/QUIC-WebTransport cross-node, vsock for Kata, UDS only
-    /// co-located). `ticket` is a #862 mount ticket scoped to `namespace_path`.
-    /// The CSI node plugin chooses `mounter` (`kernel` or `fuse`) per
-    /// StorageClass/node policy.
+    /// co-located). The CSI node plugin mints the scoped #862 mount ticket at
+    /// `NodePublishVolume` via Kubernetes CSI `tokenRequests`, so no bearer
+    /// ticket is persisted in the PodSpec.
     NineP {
         endpoint: String,
-        ticket: String,
         namespace_path: String,
         plane: String,
         mounter: String,
@@ -113,7 +112,6 @@ pub enum NamespaceDelivery {
     /// The namespace is represented as a `csi.hyprstream.io` pod volume.
     NineP {
         endpoint: String,
-        ticket: String,
         namespace_path: String,
         plane: String,
         mounter: String,

--- a/crates/hyprstream-workers/src/runtime/backend.rs
+++ b/crates/hyprstream-workers/src/runtime/backend.rs
@@ -80,10 +80,12 @@ pub enum NamespaceTransport {
     /// (normally iroh/QUIC-WebTransport cross-node, vsock for Kata, UDS only
     /// co-located). The CSI node plugin mints the scoped #862 mount ticket at
     /// `NodePublishVolume` via Kubernetes CSI `tokenRequests`, so no bearer
-    /// ticket is persisted in the PodSpec.
+    /// ticket is persisted in the PodSpec. `aname` is the Plan 9 attach name
+    /// selecting the authorized export root; filesystem paths are walked after
+    /// attach inside that root.
     NineP {
         endpoint: String,
-        namespace_path: String,
+        aname: String,
         plane: String,
         mounter: String,
         mount_path: PathBuf,
@@ -112,7 +114,7 @@ pub enum NamespaceDelivery {
     /// The namespace is represented as a `csi.hyprstream.io` pod volume.
     NineP {
         endpoint: String,
-        namespace_path: String,
+        aname: String,
         plane: String,
         mounter: String,
         mount_path: PathBuf,
@@ -137,7 +139,7 @@ impl std::fmt::Debug for NamespaceDelivery {
             Self::HostImports => write!(f, "HostImports"),
             Self::NineP {
                 endpoint,
-                namespace_path,
+                aname,
                 plane,
                 mounter,
                 mount_path,
@@ -145,7 +147,7 @@ impl std::fmt::Debug for NamespaceDelivery {
             } => f
                 .debug_struct("NineP")
                 .field("endpoint", endpoint)
-                .field("namespace_path", namespace_path)
+                .field("aname", aname)
                 .field("plane", plane)
                 .field("mounter", mounter)
                 .field("mount_path", mount_path)

--- a/crates/hyprstream-workers/src/runtime/k8s_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/k8s_backend.rs
@@ -41,7 +41,7 @@
 //! ## Namespace delivery (#793)
 //!
 //! Scheduler-placed pods receive composed hyprstream namespaces through
-//! `csi.hyprstream.io` volumes. The endpoint/namespace path/mounter reference
+//! `csi.hyprstream.io` volumes. The endpoint/aname/mounter reference
 //! is injected into the PodSpec at create time; the CSI node plugin mints the
 //! scoped mount ticket at `NodePublishVolume` via Kubernetes CSI tokenRequests
 //! so bearer tickets are never persisted in etcd. Late mutation of a running
@@ -100,8 +100,8 @@ const ANN_WORKLOAD_KIND: &str = "hyprstream.io/k8s-workload-kind";
 /// Annotation key: absolute path inside the workload container where the
 /// composed hyprstream namespace is mounted through `csi.hyprstream.io`.
 const ANN_NINEP_MOUNT_PATH: &str = "hyprstream.io/9p-mount-path";
-/// Annotation key: mount-ticket scoped namespace path.
-const ANN_NINEP_NAMESPACE_PATH: &str = "hyprstream.io/9p-namespace-path";
+/// Annotation key: Plan 9 attach name selecting the exported namespace root.
+const ANN_NINEP_ANAME: &str = "hyprstream.io/9p-aname";
 /// Annotation key: dial-time carrier endpoint for the CSI node plugin.
 const ANN_NINEP_ENDPOINT: &str = "hyprstream.io/9p-endpoint";
 /// Annotation key: mount ticket plane (`webtransport`, `ws`, `vsock`, ...).
@@ -462,7 +462,7 @@ fn to_k8s_env(sandbox_id: &str, annotations: &HashMap<String, String>) -> Vec<En
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct NinePVolumeSpec {
     mount_path: String,
-    namespace_path: String,
+    aname: String,
     endpoint: String,
     plane: String,
     mounter: String,
@@ -477,7 +477,7 @@ fn ninep_volume_from_annotations(
     else {
         return Ok(None);
     };
-    let namespace_path = required_annotation(annotations, ANN_NINEP_NAMESPACE_PATH)?;
+    let aname = required_annotation(annotations, ANN_NINEP_ANAME)?;
     let endpoint = required_annotation(annotations, ANN_NINEP_ENDPOINT)?;
     let plane = annotations
         .get(ANN_NINEP_PLANE)
@@ -494,11 +494,6 @@ fn ninep_volume_from_annotations(
             "{ANN_NINEP_MOUNT_PATH} must be absolute, got {mount_path:?}"
         )));
     }
-    if !namespace_path.starts_with('/') {
-        return Err(WorkerError::ConfigError(format!(
-            "{ANN_NINEP_NAMESPACE_PATH} must be absolute, got {namespace_path:?}"
-        )));
-    }
     if mounter != "kernel" && mounter != "fuse" {
         return Err(WorkerError::ConfigError(format!(
             "{ANN_NINEP_MOUNTER} must be kernel or fuse, got {mounter:?}"
@@ -506,7 +501,7 @@ fn ninep_volume_from_annotations(
     }
     Ok(Some(NinePVolumeSpec {
         mount_path: mount_path.clone(),
-        namespace_path,
+        aname,
         endpoint,
         plane,
         mounter,
@@ -523,7 +518,7 @@ fn required_annotation(annotations: &HashMap<String, String>, key: &str) -> Resu
 
 fn ninep_volume(spec: &NinePVolumeSpec) -> Volume {
     let mut attrs = BTreeMap::new();
-    attrs.insert("namespacePath".to_owned(), spec.namespace_path.clone());
+    attrs.insert("aname".to_owned(), spec.aname.clone());
     attrs.insert("plane".to_owned(), spec.plane.clone());
     attrs.insert("mounter".to_owned(), spec.mounter.clone());
     attrs.insert("endpoint".to_owned(), spec.endpoint.clone());
@@ -591,7 +586,6 @@ pub fn to_k8s_podspec(
         ..Default::default()
     };
     if let Some(spec) = ninep.as_ref() {
-        validate_ninep_scope(sandbox_id, &spec.namespace_path)?;
         container.volume_mounts = Some(vec![ninep_volume_mount(spec)]);
     }
 
@@ -619,16 +613,6 @@ fn object_labels(
     labels.insert(INSTANCE_LABEL.to_owned(), instance_id.to_owned());
     labels.insert(SANDBOX_LABEL.to_owned(), sandbox_id.to_owned());
     labels
-}
-
-fn validate_ninep_scope(sandbox_id: &str, namespace_path: &str) -> Result<()> {
-    let expected = format!("/sandboxes/{sandbox_id}");
-    if namespace_path != expected && !namespace_path.starts_with(&format!("{expected}/")) {
-        return Err(WorkerError::ConfigError(format!(
-            "{ANN_NINEP_NAMESPACE_PATH} must be scoped under {expected:?}, got {namespace_path:?}"
-        )));
-    }
-    Ok(())
 }
 
 fn object_meta(
@@ -857,7 +841,7 @@ impl SandboxBackend for K8sBackend {
     ) -> Result<NamespaceDelivery> {
         let NamespaceTransport::NineP {
             endpoint,
-            namespace_path,
+            aname,
             plane,
             mounter,
             mount_path,
@@ -869,12 +853,6 @@ impl SandboxBackend for K8sBackend {
                     .to_owned(),
             ));
         };
-        if !namespace_path.starts_with('/') {
-            return Err(WorkerError::ConfigError(format!(
-                "NineP namespace_path must be absolute, got {namespace_path:?}"
-            )));
-        }
-        validate_ninep_scope(&_sandbox.id, &namespace_path)?;
         if !mount_path.is_absolute() {
             return Err(WorkerError::ConfigError(format!(
                 "NineP mount_path must be absolute, got {}",
@@ -888,7 +866,7 @@ impl SandboxBackend for K8sBackend {
         }
         Ok(NamespaceDelivery::NineP {
             endpoint,
-            namespace_path,
+            aname,
             plane,
             mounter,
             mount_path,
@@ -1215,7 +1193,7 @@ mod tests {
     fn podspec_injects_ninep_csi_volume() {
         let mut ann = HashMap::new();
         ann.insert(ANN_NINEP_MOUNT_PATH.into(), "/mnt/hyprstream".into());
-        ann.insert(ANN_NINEP_NAMESPACE_PATH.into(), "/sandboxes/sb-10".into());
+        ann.insert(ANN_NINEP_ANAME.into(), "export:sandbox:sb-10".into());
         ann.insert(ANN_NINEP_ENDPOINT.into(), "https://node.example/9p".into());
         ann.insert(ANN_NINEP_PLANE.into(), "webtransport".into());
         ann.insert(ANN_NINEP_MOUNTER.into(), "kernel".into());
@@ -1231,8 +1209,8 @@ mod tests {
         assert_eq!(csi.driver, CSI_DRIVER);
         let attrs = csi.volume_attributes.as_ref().unwrap();
         assert_eq!(
-            attrs.get("namespacePath").map(String::as_str),
-            Some("/sandboxes/sb-10")
+            attrs.get("aname").map(String::as_str),
+            Some("export:sandbox:sb-10")
         );
         assert!(!attrs.contains_key("ticket"));
         assert_eq!(
@@ -1245,23 +1223,22 @@ mod tests {
     #[test]
     fn podspec_rejects_relative_ninep_scope() {
         let mut ann = HashMap::new();
-        ann.insert(ANN_NINEP_MOUNT_PATH.into(), "/mnt/hyprstream".into());
-        ann.insert(ANN_NINEP_NAMESPACE_PATH.into(), "sandboxes/sb-11".into());
+        ann.insert(ANN_NINEP_MOUNT_PATH.into(), "mnt/hyprstream".into());
+        ann.insert(ANN_NINEP_ANAME.into(), "export:sandbox:sb-11".into());
         ann.insert(ANN_NINEP_ENDPOINT.into(), "https://node.example/9p".into());
 
         let err = to_k8s_podspec(&cfg(), "sb-11", &ann, DEFAULT_IMAGE).unwrap_err();
-        assert!(err.to_string().contains(ANN_NINEP_NAMESPACE_PATH));
+        assert!(err.to_string().contains(ANN_NINEP_MOUNT_PATH));
     }
 
     #[test]
-    fn podspec_rejects_cross_sandbox_ninep_scope() {
+    fn podspec_requires_ninep_aname() {
         let mut ann = HashMap::new();
         ann.insert(ANN_NINEP_MOUNT_PATH.into(), "/mnt/hyprstream".into());
-        ann.insert(ANN_NINEP_NAMESPACE_PATH.into(), "/sandboxes/other".into());
         ann.insert(ANN_NINEP_ENDPOINT.into(), "https://node.example/9p".into());
 
         let err = to_k8s_podspec(&cfg(), "sb-11", &ann, DEFAULT_IMAGE).unwrap_err();
-        assert!(err.to_string().contains("/sandboxes/sb-11"));
+        assert!(err.to_string().contains(ANN_NINEP_ANAME));
     }
 
     #[tokio::test]
@@ -1279,7 +1256,7 @@ mod tests {
                 hyprstream_vfs::Subject::anonymous(),
                 NamespaceTransport::NineP {
                     endpoint: "https://node.example/9p".to_owned(),
-                    namespace_path: "/sandboxes/sb-12".to_owned(),
+                    aname: "export:sandbox:sb-12".to_owned(),
                     plane: "webtransport".to_owned(),
                     mounter: "fuse".to_owned(),
                     mount_path: PathBuf::from("/mnt/hyprstream"),
@@ -1290,10 +1267,10 @@ mod tests {
         assert!(matches!(
             delivery,
             NamespaceDelivery::NineP {
-                ref namespace_path,
+                ref aname,
                 ref mounter,
                 ..
-            } if namespace_path == "/sandboxes/sb-12" && mounter == "fuse"
+            } if aname == "export:sandbox:sb-12" && mounter == "fuse"
         ));
     }
 
@@ -1312,7 +1289,7 @@ mod tests {
                 hyprstream_vfs::Subject::anonymous(),
                 NamespaceTransport::NineP {
                     endpoint: "https://node.example/9p".to_owned(),
-                    namespace_path: "/sandboxes/sb-13".to_owned(),
+                    aname: "export:sandbox:sb-13".to_owned(),
                     plane: "webtransport".to_owned(),
                     mounter: "raw".to_owned(),
                     mount_path: PathBuf::from("/mnt/hyprstream"),

--- a/crates/hyprstream-workers/src/runtime/k8s_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/k8s_backend.rs
@@ -41,10 +41,13 @@
 //! ## Namespace delivery (#793)
 //!
 //! Scheduler-placed pods receive composed hyprstream namespaces through
-//! `csi.hyprstream.io` volumes. The ticket/endpoint/namespace path are injected
-//! into the PodSpec at create time; late mutation of a running Pod's volumes is
-//! impossible by Kubernetes design, so `deliver_namespace(NineP)` returns the
-//! same delivery descriptor the start path must have injected.
+//! `csi.hyprstream.io` volumes. The endpoint/namespace path/mounter reference
+//! is injected into the PodSpec at create time; the CSI node plugin mints the
+//! scoped mount ticket at `NodePublishVolume` via Kubernetes CSI tokenRequests
+//! so bearer tickets are never persisted in etcd. Late mutation of a running
+//! Pod's volumes is impossible by Kubernetes design, so
+//! `deliver_namespace(NineP)` returns the same delivery descriptor the start
+//! path must have injected.
 
 use std::any::Any;
 use std::collections::{BTreeMap, HashMap};
@@ -99,8 +102,6 @@ const ANN_WORKLOAD_KIND: &str = "hyprstream.io/k8s-workload-kind";
 const ANN_NINEP_MOUNT_PATH: &str = "hyprstream.io/9p-mount-path";
 /// Annotation key: mount-ticket scoped namespace path.
 const ANN_NINEP_NAMESPACE_PATH: &str = "hyprstream.io/9p-namespace-path";
-/// Annotation key: #862 mount ticket presented as Tattach.uname by CSI.
-const ANN_NINEP_TICKET: &str = "hyprstream.io/9p-ticket";
 /// Annotation key: dial-time carrier endpoint for the CSI node plugin.
 const ANN_NINEP_ENDPOINT: &str = "hyprstream.io/9p-endpoint";
 /// Annotation key: mount ticket plane (`webtransport`, `ws`, `vsock`, ...).
@@ -462,7 +463,6 @@ fn to_k8s_env(sandbox_id: &str, annotations: &HashMap<String, String>) -> Vec<En
 struct NinePVolumeSpec {
     mount_path: String,
     namespace_path: String,
-    ticket: String,
     endpoint: String,
     plane: String,
     mounter: String,
@@ -478,7 +478,6 @@ fn ninep_volume_from_annotations(
         return Ok(None);
     };
     let namespace_path = required_annotation(annotations, ANN_NINEP_NAMESPACE_PATH)?;
-    let ticket = required_annotation(annotations, ANN_NINEP_TICKET)?;
     let endpoint = required_annotation(annotations, ANN_NINEP_ENDPOINT)?;
     let plane = annotations
         .get(ANN_NINEP_PLANE)
@@ -508,7 +507,6 @@ fn ninep_volume_from_annotations(
     Ok(Some(NinePVolumeSpec {
         mount_path: mount_path.clone(),
         namespace_path,
-        ticket,
         endpoint,
         plane,
         mounter,
@@ -529,10 +527,6 @@ fn ninep_volume(spec: &NinePVolumeSpec) -> Volume {
     attrs.insert("plane".to_owned(), spec.plane.clone());
     attrs.insert("mounter".to_owned(), spec.mounter.clone());
     attrs.insert("endpoint".to_owned(), spec.endpoint.clone());
-    // The node plugin uses this pre-minted per-sandbox ticket as Tattach.uname.
-    // A follow-up can switch to CSI tokenRequests -> /oauth/mount-ticket in the
-    // node plugin when the worker has a live issuer client in-process.
-    attrs.insert("ticket".to_owned(), spec.ticket.clone());
     Volume {
         name: NINEP_VOLUME_NAME.to_owned(),
         csi: Some(CSIVolumeSource {
@@ -597,6 +591,7 @@ pub fn to_k8s_podspec(
         ..Default::default()
     };
     if let Some(spec) = ninep.as_ref() {
+        validate_ninep_scope(sandbox_id, &spec.namespace_path)?;
         container.volume_mounts = Some(vec![ninep_volume_mount(spec)]);
     }
 
@@ -624,6 +619,16 @@ fn object_labels(
     labels.insert(INSTANCE_LABEL.to_owned(), instance_id.to_owned());
     labels.insert(SANDBOX_LABEL.to_owned(), sandbox_id.to_owned());
     labels
+}
+
+fn validate_ninep_scope(sandbox_id: &str, namespace_path: &str) -> Result<()> {
+    let expected = format!("/sandboxes/{sandbox_id}");
+    if namespace_path != expected && !namespace_path.starts_with(&format!("{expected}/")) {
+        return Err(WorkerError::ConfigError(format!(
+            "{ANN_NINEP_NAMESPACE_PATH} must be scoped under {expected:?}, got {namespace_path:?}"
+        )));
+    }
+    Ok(())
 }
 
 fn object_meta(
@@ -852,7 +857,6 @@ impl SandboxBackend for K8sBackend {
     ) -> Result<NamespaceDelivery> {
         let NamespaceTransport::NineP {
             endpoint,
-            ticket,
             namespace_path,
             plane,
             mounter,
@@ -870,20 +874,20 @@ impl SandboxBackend for K8sBackend {
                 "NineP namespace_path must be absolute, got {namespace_path:?}"
             )));
         }
+        validate_ninep_scope(&_sandbox.id, &namespace_path)?;
         if !mount_path.is_absolute() {
             return Err(WorkerError::ConfigError(format!(
                 "NineP mount_path must be absolute, got {}",
                 mount_path.display()
             )));
         }
-        if ticket.is_empty() {
-            return Err(WorkerError::ConfigError(
-                "NineP delivery requires a scoped mount ticket".to_owned(),
-            ));
+        if mounter != "kernel" && mounter != "fuse" {
+            return Err(WorkerError::ConfigError(format!(
+                "NineP mounter must be kernel or fuse, got {mounter:?}"
+            )));
         }
         Ok(NamespaceDelivery::NineP {
             endpoint,
-            ticket,
             namespace_path,
             plane,
             mounter,
@@ -1212,7 +1216,6 @@ mod tests {
         let mut ann = HashMap::new();
         ann.insert(ANN_NINEP_MOUNT_PATH.into(), "/mnt/hyprstream".into());
         ann.insert(ANN_NINEP_NAMESPACE_PATH.into(), "/sandboxes/sb-10".into());
-        ann.insert(ANN_NINEP_TICKET.into(), "ticket-sb-10".into());
         ann.insert(ANN_NINEP_ENDPOINT.into(), "https://node.example/9p".into());
         ann.insert(ANN_NINEP_PLANE.into(), "webtransport".into());
         ann.insert(ANN_NINEP_MOUNTER.into(), "kernel".into());
@@ -1231,10 +1234,7 @@ mod tests {
             attrs.get("namespacePath").map(String::as_str),
             Some("/sandboxes/sb-10")
         );
-        assert_eq!(
-            attrs.get("ticket").map(String::as_str),
-            Some("ticket-sb-10")
-        );
+        assert!(!attrs.contains_key("ticket"));
         assert_eq!(
             attrs.get("endpoint").map(String::as_str),
             Some("https://node.example/9p")
@@ -1247,11 +1247,21 @@ mod tests {
         let mut ann = HashMap::new();
         ann.insert(ANN_NINEP_MOUNT_PATH.into(), "/mnt/hyprstream".into());
         ann.insert(ANN_NINEP_NAMESPACE_PATH.into(), "sandboxes/sb-11".into());
-        ann.insert(ANN_NINEP_TICKET.into(), "ticket".into());
         ann.insert(ANN_NINEP_ENDPOINT.into(), "https://node.example/9p".into());
 
         let err = to_k8s_podspec(&cfg(), "sb-11", &ann, DEFAULT_IMAGE).unwrap_err();
         assert!(err.to_string().contains(ANN_NINEP_NAMESPACE_PATH));
+    }
+
+    #[test]
+    fn podspec_rejects_cross_sandbox_ninep_scope() {
+        let mut ann = HashMap::new();
+        ann.insert(ANN_NINEP_MOUNT_PATH.into(), "/mnt/hyprstream".into());
+        ann.insert(ANN_NINEP_NAMESPACE_PATH.into(), "/sandboxes/other".into());
+        ann.insert(ANN_NINEP_ENDPOINT.into(), "https://node.example/9p".into());
+
+        let err = to_k8s_podspec(&cfg(), "sb-11", &ann, DEFAULT_IMAGE).unwrap_err();
+        assert!(err.to_string().contains("/sandboxes/sb-11"));
     }
 
     #[tokio::test]
@@ -1269,7 +1279,6 @@ mod tests {
                 hyprstream_vfs::Subject::anonymous(),
                 NamespaceTransport::NineP {
                     endpoint: "https://node.example/9p".to_owned(),
-                    ticket: "ticket".to_owned(),
                     namespace_path: "/sandboxes/sb-12".to_owned(),
                     plane: "webtransport".to_owned(),
                     mounter: "fuse".to_owned(),
@@ -1286,6 +1295,32 @@ mod tests {
                 ..
             } if namespace_path == "/sandboxes/sb-12" && mounter == "fuse"
         ));
+    }
+
+    #[tokio::test]
+    async fn deliver_namespace_rejects_unknown_mounter() {
+        let backend = K8sBackend::new(K8sConfig::default());
+        let sandbox = PodSandbox::new(
+            "sb-13".to_owned(),
+            &cfg(),
+            PathBuf::from("/tmp/hyprstream-k8s-test"),
+        );
+        let err = backend
+            .deliver_namespace(
+                &sandbox,
+                hyprstream_vfs::Namespace::new(),
+                hyprstream_vfs::Subject::anonymous(),
+                NamespaceTransport::NineP {
+                    endpoint: "https://node.example/9p".to_owned(),
+                    namespace_path: "/sandboxes/sb-13".to_owned(),
+                    plane: "webtransport".to_owned(),
+                    mounter: "raw".to_owned(),
+                    mount_path: PathBuf::from("/mnt/hyprstream"),
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("mounter"));
     }
 
     #[test]

--- a/crates/hyprstream-workers/src/runtime/k8s_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/k8s_backend.rs
@@ -38,14 +38,13 @@
 //! so a restarted backend can reap its own sandbox workload without adopting a
 //! different sandbox's objects.
 //!
-//! ## Out of scope here
+//! ## Namespace delivery (#793)
 //!
-//! - **Namespace delivery** (`deliver_namespace`) is K4b (#793, needs K3): the
-//!   trait default (fail-closed "not implemented") is deliberately left in
-//!   place.
-//! - **Placement mapping** (node affinity / GPU / topology) is K4c.
-//! - The "runs on a kind cluster" e2e acceptance is a follow-up; this change is
-//!   the backend core + the offline-testable `to_k8s_podspec` mapping.
+//! Scheduler-placed pods receive composed hyprstream namespaces through
+//! `csi.hyprstream.io` volumes. The ticket/endpoint/namespace path are injected
+//! into the PodSpec at create time; late mutation of a running Pod's volumes is
+//! impossible by Kubernetes design, so `deliver_namespace(NineP)` returns the
+//! same delivery descriptor the start path must have injected.
 
 use std::any::Any;
 use std::collections::{BTreeMap, HashMap};
@@ -58,7 +57,8 @@ use tracing::{debug, info, warn};
 
 use hyprstream_k8s::k8s_openapi::api::batch::v1::{Job, JobSpec};
 use hyprstream_k8s::k8s_openapi::api::core::v1::{
-    Container, EnvVar, Pod, PodSpec, PodTemplateSpec, ResourceRequirements, SecurityContext,
+    CSIVolumeSource, Container, EnvVar, Pod, PodSpec, PodTemplateSpec, ResourceRequirements,
+    SecurityContext, Volume, VolumeMount,
 };
 use hyprstream_k8s::k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use hyprstream_k8s::k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -70,7 +70,7 @@ use hyprstream_k8s::MANAGED_BY_LABEL;
 use crate::config::PoolConfig;
 use crate::error::{Result, WorkerError};
 
-use super::backend::{SandboxBackend, SandboxHandle};
+use super::backend::{NamespaceDelivery, NamespaceTransport, SandboxBackend, SandboxHandle};
 use super::client::{KeyValue, PodSandboxConfig};
 use super::sandbox::PodSandbox;
 
@@ -94,6 +94,21 @@ const ANN_NAMESPACE: &str = "hyprstream.io/k8s-namespace";
 /// the default). A `Job` gets retry/backoff + completion tracking from the Job
 /// controller; a bare `Pod` is the minimal, watch-until-`Running` shape.
 const ANN_WORKLOAD_KIND: &str = "hyprstream.io/k8s-workload-kind";
+/// Annotation key: absolute path inside the workload container where the
+/// composed hyprstream namespace is mounted through `csi.hyprstream.io`.
+const ANN_NINEP_MOUNT_PATH: &str = "hyprstream.io/9p-mount-path";
+/// Annotation key: mount-ticket scoped namespace path.
+const ANN_NINEP_NAMESPACE_PATH: &str = "hyprstream.io/9p-namespace-path";
+/// Annotation key: #862 mount ticket presented as Tattach.uname by CSI.
+const ANN_NINEP_TICKET: &str = "hyprstream.io/9p-ticket";
+/// Annotation key: dial-time carrier endpoint for the CSI node plugin.
+const ANN_NINEP_ENDPOINT: &str = "hyprstream.io/9p-endpoint";
+/// Annotation key: mount ticket plane (`webtransport`, `ws`, `vsock`, ...).
+const ANN_NINEP_PLANE: &str = "hyprstream.io/9p-plane";
+/// Annotation key: CSI mounter (`kernel` or `fuse`).
+const ANN_NINEP_MOUNTER: &str = "hyprstream.io/9p-mounter";
+const CSI_DRIVER: &str = "csi.hyprstream.io";
+const NINEP_VOLUME_NAME: &str = "hyprstream-9p";
 
 /// Label value for [`MANAGED_BY_LABEL`] on objects this backend emits.
 ///
@@ -443,6 +458,102 @@ fn to_k8s_env(sandbox_id: &str, annotations: &HashMap<String, String>) -> Vec<En
     env
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NinePVolumeSpec {
+    mount_path: String,
+    namespace_path: String,
+    ticket: String,
+    endpoint: String,
+    plane: String,
+    mounter: String,
+}
+
+fn ninep_volume_from_annotations(
+    annotations: &HashMap<String, String>,
+) -> Result<Option<NinePVolumeSpec>> {
+    let Some(mount_path) = annotations
+        .get(ANN_NINEP_MOUNT_PATH)
+        .filter(|s| !s.is_empty())
+    else {
+        return Ok(None);
+    };
+    let namespace_path = required_annotation(annotations, ANN_NINEP_NAMESPACE_PATH)?;
+    let ticket = required_annotation(annotations, ANN_NINEP_TICKET)?;
+    let endpoint = required_annotation(annotations, ANN_NINEP_ENDPOINT)?;
+    let plane = annotations
+        .get(ANN_NINEP_PLANE)
+        .filter(|s| !s.is_empty())
+        .cloned()
+        .unwrap_or_else(|| "webtransport".to_owned());
+    let mounter = annotations
+        .get(ANN_NINEP_MOUNTER)
+        .filter(|s| !s.is_empty())
+        .cloned()
+        .unwrap_or_else(|| "fuse".to_owned());
+    if !mount_path.starts_with('/') {
+        return Err(WorkerError::ConfigError(format!(
+            "{ANN_NINEP_MOUNT_PATH} must be absolute, got {mount_path:?}"
+        )));
+    }
+    if !namespace_path.starts_with('/') {
+        return Err(WorkerError::ConfigError(format!(
+            "{ANN_NINEP_NAMESPACE_PATH} must be absolute, got {namespace_path:?}"
+        )));
+    }
+    if mounter != "kernel" && mounter != "fuse" {
+        return Err(WorkerError::ConfigError(format!(
+            "{ANN_NINEP_MOUNTER} must be kernel or fuse, got {mounter:?}"
+        )));
+    }
+    Ok(Some(NinePVolumeSpec {
+        mount_path: mount_path.clone(),
+        namespace_path,
+        ticket,
+        endpoint,
+        plane,
+        mounter,
+    }))
+}
+
+fn required_annotation(annotations: &HashMap<String, String>, key: &str) -> Result<String> {
+    annotations
+        .get(key)
+        .filter(|s| !s.is_empty())
+        .cloned()
+        .ok_or_else(|| WorkerError::ConfigError(format!("{key} is required for 9P CSI delivery")))
+}
+
+fn ninep_volume(spec: &NinePVolumeSpec) -> Volume {
+    let mut attrs = BTreeMap::new();
+    attrs.insert("namespacePath".to_owned(), spec.namespace_path.clone());
+    attrs.insert("plane".to_owned(), spec.plane.clone());
+    attrs.insert("mounter".to_owned(), spec.mounter.clone());
+    attrs.insert("endpoint".to_owned(), spec.endpoint.clone());
+    // The node plugin uses this pre-minted per-sandbox ticket as Tattach.uname.
+    // A follow-up can switch to CSI tokenRequests -> /oauth/mount-ticket in the
+    // node plugin when the worker has a live issuer client in-process.
+    attrs.insert("ticket".to_owned(), spec.ticket.clone());
+    Volume {
+        name: NINEP_VOLUME_NAME.to_owned(),
+        csi: Some(CSIVolumeSource {
+            driver: CSI_DRIVER.to_owned(),
+            read_only: Some(false),
+            volume_attributes: Some(attrs),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+fn ninep_volume_mount(spec: &NinePVolumeSpec) -> VolumeMount {
+    VolumeMount {
+        name: NINEP_VOLUME_NAME.to_owned(),
+        mount_path: spec.mount_path.clone(),
+        read_only: Some(false),
+        ..Default::default()
+    }
+}
+
 /// Translate the capnp [`PodSandboxConfig`] + resolved annotations into a
 /// Kubernetes [`PodSpec`] with a single `workload` container.
 ///
@@ -456,7 +567,7 @@ pub fn to_k8s_podspec(
     sandbox_id: &str,
     annotations: &HashMap<String, String>,
     default_image: &str,
-) -> PodSpec {
+) -> Result<PodSpec> {
     let image = annotations
         .get(ANN_IMAGE)
         .filter(|s| !s.is_empty())
@@ -474,7 +585,9 @@ pub fn to_k8s_podspec(
         .cloned()
         .and_then(NonEmptyOption::into_option_nonempty);
 
-    let container = Container {
+    let ninep = ninep_volume_from_annotations(annotations)?;
+
+    let mut container = Container {
         name: "workload".to_owned(),
         image: Some(image),
         command,
@@ -483,13 +596,20 @@ pub fn to_k8s_podspec(
         security_context: to_k8s_security_context(config),
         ..Default::default()
     };
+    if let Some(spec) = ninep.as_ref() {
+        container.volume_mounts = Some(vec![ninep_volume_mount(spec)]);
+    }
 
-    PodSpec {
+    let mut pod_spec = PodSpec {
         containers: vec![container],
         restart_policy: Some("Never".to_owned()),
         runtime_class_name,
         ..Default::default()
+    };
+    if let Some(spec) = ninep.as_ref() {
+        pod_spec.volumes = Some(vec![ninep_volume(spec)]);
     }
+    Ok(pod_spec)
 }
 
 /// Origin-marker labels stamped on every emitted object: the config labels plus
@@ -527,17 +647,17 @@ fn build_pod(
     instance_id: &str,
     default_image: &str,
     annotations: &HashMap<String, String>,
-) -> Pod {
-    Pod {
+) -> Result<Pod> {
+    Ok(Pod {
         metadata: object_meta(config, sandbox_id, namespace, instance_id),
         spec: Some(to_k8s_podspec(
             config,
             sandbox_id,
             annotations,
             default_image,
-        )),
+        )?),
         ..Default::default()
-    }
+    })
 }
 
 fn build_job(
@@ -547,9 +667,9 @@ fn build_job(
     instance_id: &str,
     default_image: &str,
     annotations: &HashMap<String, String>,
-) -> Job {
+) -> Result<Job> {
     let labels = object_labels(config, sandbox_id, instance_id);
-    Job {
+    Ok(Job {
         metadata: object_meta(config, sandbox_id, namespace, instance_id),
         spec: Some(JobSpec {
             // Do not let the Job controller retry indefinitely; the sandbox
@@ -565,12 +685,12 @@ fn build_job(
                     sandbox_id,
                     annotations,
                     default_image,
-                )),
+                )?),
             },
             ..Default::default()
         }),
         ..Default::default()
-    }
+    })
 }
 
 #[async_trait]
@@ -648,7 +768,7 @@ impl SandboxBackend for K8sBackend {
                     &self.instance_id,
                     &image,
                     annotations,
-                );
+                )?;
                 let pods: Api<Pod> = Api::namespaced(client, &namespace);
                 pods.create(&PostParams::default(), &pod)
                     .await
@@ -679,7 +799,7 @@ impl SandboxBackend for K8sBackend {
                     &self.instance_id,
                     &image,
                     annotations,
-                );
+                )?;
                 let jobs: Api<Job> = Api::namespaced(client, &namespace);
                 jobs.create(&PostParams::default(), &job)
                     .await
@@ -721,6 +841,54 @@ impl SandboxBackend for K8sBackend {
         // Host PIDs are a node-local concept the API server does not expose;
         // fail-safe empty result rather than fabricating one (same as `cri`).
         Ok(Vec::new())
+    }
+
+    async fn deliver_namespace(
+        &self,
+        _sandbox: &PodSandbox,
+        _namespace: hyprstream_vfs::Namespace,
+        _subject: hyprstream_vfs::Subject,
+        transport: NamespaceTransport,
+    ) -> Result<NamespaceDelivery> {
+        let NamespaceTransport::NineP {
+            endpoint,
+            ticket,
+            namespace_path,
+            plane,
+            mounter,
+            mount_path,
+        } = transport
+        else {
+            return Err(WorkerError::Unsupported(
+                "k8s backend only supports NamespaceTransport::NineP; host bind mounts \
+                 and Kata/virtiofs transports are not meaningful for API-server pods"
+                    .to_owned(),
+            ));
+        };
+        if !namespace_path.starts_with('/') {
+            return Err(WorkerError::ConfigError(format!(
+                "NineP namespace_path must be absolute, got {namespace_path:?}"
+            )));
+        }
+        if !mount_path.is_absolute() {
+            return Err(WorkerError::ConfigError(format!(
+                "NineP mount_path must be absolute, got {}",
+                mount_path.display()
+            )));
+        }
+        if ticket.is_empty() {
+            return Err(WorkerError::ConfigError(
+                "NineP delivery requires a scoped mount ticket".to_owned(),
+            ));
+        }
+        Ok(NamespaceDelivery::NineP {
+            endpoint,
+            ticket,
+            namespace_path,
+            plane,
+            mounter,
+            mount_path,
+        })
     }
 
     fn supports_exec(&self) -> bool {
@@ -955,7 +1123,7 @@ mod tests {
         ann.insert(ANN_COMMAND.into(), "/bin/sh -c echo".into());
         ann.insert("hyprstream.io/env.FOO".into(), "bar".into());
 
-        let spec = to_k8s_podspec(&cfg(), "sb-1", &ann, DEFAULT_IMAGE);
+        let spec = to_k8s_podspec(&cfg(), "sb-1", &ann, DEFAULT_IMAGE).expect("podspec");
         assert_eq!(spec.restart_policy.as_deref(), Some("Never"));
         let c = &spec.containers[0];
         assert_eq!(c.name, "workload");
@@ -975,7 +1143,7 @@ mod tests {
 
     #[test]
     fn podspec_defaults_image_when_no_annotation() {
-        let spec = to_k8s_podspec(&cfg(), "sb-2", &HashMap::new(), DEFAULT_IMAGE);
+        let spec = to_k8s_podspec(&cfg(), "sb-2", &HashMap::new(), DEFAULT_IMAGE).expect("podspec");
         assert_eq!(spec.containers[0].image.as_deref(), Some(DEFAULT_IMAGE));
         // No command annotation ⇒ image entrypoint (None), not an empty argv.
         assert!(spec.containers[0].command.is_none());
@@ -985,13 +1153,13 @@ mod tests {
     fn podspec_passes_runtime_class_through() {
         let mut ann = HashMap::new();
         ann.insert(ANN_RUNTIME_CLASS.into(), "kata".into());
-        let spec = to_k8s_podspec(&cfg(), "sb-3", &ann, DEFAULT_IMAGE);
+        let spec = to_k8s_podspec(&cfg(), "sb-3", &ann, DEFAULT_IMAGE).expect("podspec");
         assert_eq!(spec.runtime_class_name.as_deref(), Some("kata"));
 
         // Empty runtime-class ⇒ cluster default (no runtimeClassName).
         let mut ann2 = HashMap::new();
         ann2.insert(ANN_RUNTIME_CLASS.into(), "".into());
-        let spec2 = to_k8s_podspec(&cfg(), "sb-3b", &ann2, DEFAULT_IMAGE);
+        let spec2 = to_k8s_podspec(&cfg(), "sb-3b", &ann2, DEFAULT_IMAGE).expect("podspec");
         assert!(spec2.runtime_class_name.is_none());
     }
 
@@ -1002,7 +1170,7 @@ mod tests {
         c.linux.resources.cpu_quota = 50_000; // 0.5 core → 500m
         c.linux.resources.memory_limit_in_bytes = 268_435_456; // 256Mi bytes
 
-        let spec = to_k8s_podspec(&c, "sb-4", &HashMap::new(), DEFAULT_IMAGE);
+        let spec = to_k8s_podspec(&c, "sb-4", &HashMap::new(), DEFAULT_IMAGE).expect("podspec");
         let res = spec.containers[0].resources.as_ref().unwrap();
         let limits = res.limits.as_ref().unwrap();
         assert_eq!(limits.get("cpu").unwrap().0, "500m");
@@ -1013,7 +1181,7 @@ mod tests {
 
     #[test]
     fn no_resources_when_unspecified() {
-        let spec = to_k8s_podspec(&cfg(), "sb-5", &HashMap::new(), DEFAULT_IMAGE);
+        let spec = to_k8s_podspec(&cfg(), "sb-5", &HashMap::new(), DEFAULT_IMAGE).expect("podspec");
         assert!(spec.containers[0].resources.is_none());
     }
 
@@ -1023,7 +1191,7 @@ mod tests {
         c.linux.security_context.run_as_user = 1000;
         c.linux.security_context.readonly_rootfs = true;
 
-        let spec = to_k8s_podspec(&c, "sb-6", &HashMap::new(), DEFAULT_IMAGE);
+        let spec = to_k8s_podspec(&c, "sb-6", &HashMap::new(), DEFAULT_IMAGE).expect("podspec");
         let sc = spec.containers[0].security_context.as_ref().unwrap();
         assert_eq!(sc.run_as_user, Some(1000));
         assert_eq!(sc.read_only_root_filesystem, Some(true));
@@ -1035,8 +1203,89 @@ mod tests {
     #[test]
     fn security_context_none_when_nothing_asserted() {
         // run_as_user == 0 is treated as unset (never force root).
-        let spec = to_k8s_podspec(&cfg(), "sb-7", &HashMap::new(), DEFAULT_IMAGE);
+        let spec = to_k8s_podspec(&cfg(), "sb-7", &HashMap::new(), DEFAULT_IMAGE).expect("podspec");
         assert!(spec.containers[0].security_context.is_none());
+    }
+
+    #[test]
+    fn podspec_injects_ninep_csi_volume() {
+        let mut ann = HashMap::new();
+        ann.insert(ANN_NINEP_MOUNT_PATH.into(), "/mnt/hyprstream".into());
+        ann.insert(ANN_NINEP_NAMESPACE_PATH.into(), "/sandboxes/sb-10".into());
+        ann.insert(ANN_NINEP_TICKET.into(), "ticket-sb-10".into());
+        ann.insert(ANN_NINEP_ENDPOINT.into(), "https://node.example/9p".into());
+        ann.insert(ANN_NINEP_PLANE.into(), "webtransport".into());
+        ann.insert(ANN_NINEP_MOUNTER.into(), "kernel".into());
+
+        let spec = to_k8s_podspec(&cfg(), "sb-10", &ann, DEFAULT_IMAGE).expect("podspec");
+        let mounts = spec.containers[0].volume_mounts.as_ref().unwrap();
+        assert_eq!(mounts[0].name, NINEP_VOLUME_NAME);
+        assert_eq!(mounts[0].mount_path, "/mnt/hyprstream");
+
+        let volume = &spec.volumes.as_ref().unwrap()[0];
+        assert_eq!(volume.name, NINEP_VOLUME_NAME);
+        let csi = volume.csi.as_ref().unwrap();
+        assert_eq!(csi.driver, CSI_DRIVER);
+        let attrs = csi.volume_attributes.as_ref().unwrap();
+        assert_eq!(
+            attrs.get("namespacePath").map(String::as_str),
+            Some("/sandboxes/sb-10")
+        );
+        assert_eq!(
+            attrs.get("ticket").map(String::as_str),
+            Some("ticket-sb-10")
+        );
+        assert_eq!(
+            attrs.get("endpoint").map(String::as_str),
+            Some("https://node.example/9p")
+        );
+        assert_eq!(attrs.get("mounter").map(String::as_str), Some("kernel"));
+    }
+
+    #[test]
+    fn podspec_rejects_relative_ninep_scope() {
+        let mut ann = HashMap::new();
+        ann.insert(ANN_NINEP_MOUNT_PATH.into(), "/mnt/hyprstream".into());
+        ann.insert(ANN_NINEP_NAMESPACE_PATH.into(), "sandboxes/sb-11".into());
+        ann.insert(ANN_NINEP_TICKET.into(), "ticket".into());
+        ann.insert(ANN_NINEP_ENDPOINT.into(), "https://node.example/9p".into());
+
+        let err = to_k8s_podspec(&cfg(), "sb-11", &ann, DEFAULT_IMAGE).unwrap_err();
+        assert!(err.to_string().contains(ANN_NINEP_NAMESPACE_PATH));
+    }
+
+    #[tokio::test]
+    async fn deliver_namespace_accepts_ninep_transport() {
+        let backend = K8sBackend::new(K8sConfig::default());
+        let sandbox = PodSandbox::new(
+            "sb-12".to_owned(),
+            &cfg(),
+            PathBuf::from("/tmp/hyprstream-k8s-test"),
+        );
+        let delivery = backend
+            .deliver_namespace(
+                &sandbox,
+                hyprstream_vfs::Namespace::new(),
+                hyprstream_vfs::Subject::anonymous(),
+                NamespaceTransport::NineP {
+                    endpoint: "https://node.example/9p".to_owned(),
+                    ticket: "ticket".to_owned(),
+                    namespace_path: "/sandboxes/sb-12".to_owned(),
+                    plane: "webtransport".to_owned(),
+                    mounter: "fuse".to_owned(),
+                    mount_path: PathBuf::from("/mnt/hyprstream"),
+                },
+            )
+            .await
+            .expect("ninep delivery");
+        assert!(matches!(
+            delivery,
+            NamespaceDelivery::NineP {
+                ref namespace_path,
+                ref mounter,
+                ..
+            } if namespace_path == "/sandboxes/sb-12" && mounter == "fuse"
+        ));
     }
 
     #[test]
@@ -1053,7 +1302,8 @@ mod tests {
             "inst-xyz",
             DEFAULT_IMAGE,
             &HashMap::new(),
-        );
+        )
+        .expect("pod");
         assert_eq!(pod.metadata.name.as_deref(), Some("sb-8"));
         assert_eq!(pod.metadata.namespace.as_deref(), Some("team-a"));
         let labels = pod.metadata.labels.as_ref().unwrap();
@@ -1078,7 +1328,8 @@ mod tests {
             "inst-1",
             DEFAULT_IMAGE,
             &HashMap::new(),
-        );
+        )
+        .expect("job");
         let spec = job.spec.as_ref().unwrap();
         assert_eq!(spec.backoff_limit, Some(0));
         let tmpl = &spec.template;


### PR DESCRIPTION
## Summary
- add the K5b kube-rs operator runtime scaffold for Model and Adapter CRDs
- enforce TenantBinding before RPC reconciliation and surface rejected/ready phases in status
- apply managed-by metadata via the main resource API and write generation-aware status through the status subresource
- define an RPC abstraction for the future in-cluster Registry/Model clients without binding this PR to transport construction

## Validation
- OPENSSL_NO_VENDOR=1 cargo test -p hyprstream-k8s --features k8s
- OPENSSL_NO_VENDOR=1 cargo clippy -p hyprstream-k8s --features k8s --all-targets -- -D warnings

## Notes
- Stacked on #847 / ewindisch/788-crd-schemas.
- Functional in-cluster RPC e2e still depends on #859/#848 landing or stabilizing; this PR keeps the transport behind HyprstreamOperatorRpc so unit coverage remains offline and deterministic.