### PR TITLE
feat(rpc): install explicit resolver profiles (#873)

### DIFF
--- a/crates/hyprstream-rpc/src/lib.rs
+++ b/crates/hyprstream-rpc/src/lib.rs
@@ -243,7 +243,7 @@ pub use error::{EnvelopeError, EnvelopeResult, Result, RpcError};
 pub use hyprstream_rpc_derive::{authorize, service_factory, FromCapnp, ToCapnp};
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use resolver::Resolver;
+pub use resolver::{NetworkDiscoveryResolver, Resolver, ResolverProfile};
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use registry::SocketKind;
@@ -289,7 +289,8 @@ pub mod prelude {
     // Registry (with renamed imports for convenience)
     pub use crate::registry::{
         global as registry_global, init as registry_init, try_global as registry_try_global,
-        EndpointMode, EndpointRegistry, ServiceEntry, ServiceRegistration,
+        EndpointMode, EndpointRegistry, IpcResolver, LocalInprocResolver, ServiceEntry,
+        ServiceRegistration,
     };
 
     // Transport

--- a/crates/hyprstream-rpc/src/registry/mod.rs
+++ b/crates/hyprstream-rpc/src/registry/mod.rs
@@ -207,39 +207,74 @@ impl EndpointRegistry {
     /// the historical local fallback (`inproc` or same-host UDS), while missing
     /// QUIC/network endpoints fail closed instead of synthesizing a placeholder.
     pub fn try_endpoint(&self, name: &str, socket_kind: SocketKind) -> anyhow::Result<TransportConfig> {
+        if let Some(endpoint) = self.registered_endpoint(name, socket_kind) {
+            return Ok(endpoint);
+        }
+
+        self.local_default_endpoint(name, socket_kind)
+    }
+
+    /// Get an explicitly registered endpoint without applying any profile
+    /// fallback.
+    pub fn registered_endpoint(
+        &self,
+        name: &str,
+        socket_kind: SocketKind,
+    ) -> Option<TransportConfig> {
         if let Some(entry) = self.services.read().get(name) {
             if let Some(ep) = entry.endpoints.get(&socket_kind) {
-                return Ok(ep.clone());
+                return Some(ep.clone());
             }
         }
-
-        self.default_endpoint(name, socket_kind)
+        None
     }
 
-    /// Generate a default endpoint for a service and socket type.
-    fn default_endpoint(&self, name: &str, socket_kind: SocketKind) -> anyhow::Result<TransportConfig> {
-        if socket_kind == SocketKind::Quic {
-            anyhow::bail!(
-                "no registered QUIC endpoint for service '{name}' — network reach must be announced or explicitly registered"
-            );
+    /// Generate the legacy local default endpoint for a service and socket type.
+    ///
+    /// This remains for direct registry callers. The process-global resolver
+    /// installed by [`init`] uses explicit resolver profile types instead.
+    fn local_default_endpoint(
+        &self,
+        name: &str,
+        socket_kind: SocketKind,
+    ) -> anyhow::Result<TransportConfig> {
+        match self.mode {
+            EndpointMode::Inproc => local_inproc_endpoint(name, socket_kind),
+            EndpointMode::Ipc => same_host_uds_endpoint(name, socket_kind, self.runtime_dir.as_ref()),
         }
-        let suffix = socket_kind.suffix();
-        Ok(match self.mode {
-            EndpointMode::Inproc => {
-                TransportConfig::inproc(format!("hyprstream/{name}{suffix}"))
-            }
-            EndpointMode::Ipc => {
-                // Use normal IPC binding instead of systemd socket activation
-                let path = self
-                    .runtime_dir
-                    .as_ref()
-                    .map(|d| d.join(format!("{name}{suffix}.sock")))
-                    .unwrap_or_else(|| PathBuf::from(format!("/tmp/hyprstream/{name}{suffix}.sock")));
-                TransportConfig::ipc(path)
-            }
-        })
     }
+}
 
+fn local_inproc_endpoint(name: &str, socket_kind: SocketKind) -> anyhow::Result<TransportConfig> {
+    if socket_kind == SocketKind::Quic {
+        anyhow::bail!(
+            "no registered QUIC endpoint for service '{name}' — network reach must be announced or explicitly registered"
+        );
+    }
+    Ok(TransportConfig::inproc(format!(
+        "hyprstream/{name}{}",
+        socket_kind.suffix()
+    )))
+}
+
+fn same_host_uds_endpoint(
+    name: &str,
+    socket_kind: SocketKind,
+    runtime_dir: Option<&PathBuf>,
+) -> anyhow::Result<TransportConfig> {
+    if socket_kind == SocketKind::Quic {
+        anyhow::bail!(
+            "no registered QUIC endpoint for service '{name}' — network reach must be announced or explicitly registered"
+        );
+    }
+    let suffix = socket_kind.suffix();
+    let path = runtime_dir
+        .map(|d| d.join(format!("{name}{suffix}.sock")))
+        .unwrap_or_else(|| PathBuf::from(format!("/tmp/hyprstream/{name}{suffix}.sock")));
+    Ok(TransportConfig::ipc(path))
+}
+
+impl EndpointRegistry {
     // ========================================================================
     // Backward-compatible convenience methods (default to REP socket)
     // ========================================================================
@@ -338,6 +373,49 @@ impl crate::resolver::Resolver for EndpointRegistry {
 // Global registry
 static REGISTRY: RwLock<Option<EndpointRegistry>> = RwLock::new(None);
 
+fn registered_global_endpoint(
+    name: &str,
+    kind: SocketKind,
+) -> anyhow::Result<Option<TransportConfig>> {
+    let registry = try_global()
+        .ok_or_else(|| anyhow::anyhow!("EndpointRegistry not initialized — call init() first"))?;
+    Ok(registry.registered_endpoint(name, kind))
+}
+
+/// Explicit single-process resolver profile.
+pub struct LocalInprocResolver;
+
+#[async_trait::async_trait]
+impl crate::resolver::Resolver for LocalInprocResolver {
+    async fn resolve(&self, name: &str, kind: SocketKind) -> anyhow::Result<TransportConfig> {
+        if let Some(endpoint) = registered_global_endpoint(name, kind)? {
+            return Ok(endpoint);
+        }
+        local_inproc_endpoint(name, kind)
+    }
+}
+
+/// Explicit IPC resolver profile.
+pub struct IpcResolver {
+    runtime_dir: Option<PathBuf>,
+}
+
+impl IpcResolver {
+    pub fn new(runtime_dir: Option<PathBuf>) -> Self {
+        Self { runtime_dir }
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::resolver::Resolver for IpcResolver {
+    async fn resolve(&self, name: &str, kind: SocketKind) -> anyhow::Result<TransportConfig> {
+        if let Some(endpoint) = registered_global_endpoint(name, kind)? {
+            return Ok(endpoint);
+        }
+        same_host_uds_endpoint(name, kind, self.runtime_dir.as_ref())
+    }
+}
+
 /// Initialize the global endpoint registry.
 ///
 /// Idempotent: subsequent calls are no-ops if already initialized.
@@ -349,24 +427,14 @@ static REGISTRY: RwLock<Option<EndpointRegistry>> = RwLock::new(None);
 pub fn init(mode: EndpointMode, runtime_dir: Option<PathBuf>) {
     let mut guard = REGISTRY.write();
     if guard.is_none() {
-        *guard = Some(EndpointRegistry::new(mode, runtime_dir));
-        // Also set the global Resolver so async consumers can use the trait
-        crate::resolver::set_global(Arc::new(GlobalRegistryResolver));
-    }
-}
-
-/// Adapter that delegates `Resolver` calls to the global `EndpointRegistry`.
-///
-/// Installed automatically by `init()`. Allows async callers to resolve
-/// endpoints via the `Resolver` trait without holding a lock guard.
-struct GlobalRegistryResolver;
-
-#[async_trait::async_trait]
-impl crate::resolver::Resolver for GlobalRegistryResolver {
-    async fn resolve(&self, name: &str, kind: SocketKind) -> anyhow::Result<TransportConfig> {
-        let registry = try_global()
-            .ok_or_else(|| anyhow::anyhow!("EndpointRegistry not initialized — call init() first"))?;
-        registry.try_endpoint(name, kind)
+        *guard = Some(EndpointRegistry::new(mode, runtime_dir.clone()));
+        // Also set the global Resolver so async consumers use an explicit
+        // locality profile instead of the registry's legacy direct fallback.
+        let resolver: Arc<dyn crate::resolver::Resolver> = match mode {
+            EndpointMode::Inproc => Arc::new(LocalInprocResolver),
+            EndpointMode::Ipc => Arc::new(IpcResolver::new(runtime_dir)),
+        };
+        crate::resolver::set_global(resolver);
     }
 }
 
@@ -567,6 +635,21 @@ mod tests {
     }
 
     #[test]
+    fn test_global_resolver_installs_local_inproc_profile() {
+        let _lock = TEST_MUTEX.lock();
+        reset_registry();
+        init(EndpointMode::Inproc, None);
+
+        let resolver = match crate::resolver::try_global() {
+            Some(resolver) => resolver,
+            None => panic!("global resolver must be installed"),
+        };
+        let endpoint = futures::executor::block_on(resolver.resolve("policy", SocketKind::Rep))
+            .unwrap_or_else(|err| panic!("local-inproc resolver failed: {err}"));
+        assert_eq!(endpoint.endpoint_string(), "inproc://hyprstream/policy");
+    }
+
+    #[test]
     fn test_ipc_defaults() {
         let _lock = TEST_MUTEX.lock();
         reset_registry();
@@ -579,6 +662,21 @@ mod tests {
         // REQ socket (with suffix)
         let endpoint = global().endpoint("model", SocketKind::Req);
         assert_eq!(endpoint.endpoint_string(), "ipc:///run/hyprstream/model-req.sock");
+    }
+
+    #[test]
+    fn test_global_resolver_installs_ipc_profile() {
+        let _lock = TEST_MUTEX.lock();
+        reset_registry();
+        init(EndpointMode::Ipc, Some(PathBuf::from("/run/hyprstream")));
+
+        let resolver = match crate::resolver::try_global() {
+            Some(resolver) => resolver,
+            None => panic!("global resolver must be installed"),
+        };
+        let endpoint = futures::executor::block_on(resolver.resolve("policy", SocketKind::Rep))
+            .unwrap_or_else(|err| panic!("same-host-uds resolver failed: {err}"));
+        assert_eq!(endpoint.endpoint_string(), "ipc:///run/hyprstream/policy.sock");
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/resolver.rs
+++ b/crates/hyprstream-rpc/src/resolver.rs
@@ -26,10 +26,11 @@
 
 use std::sync::Arc;
 
+use anyhow::anyhow;
 use parking_lot::RwLock;
 
 use crate::registry::SocketKind;
-use crate::transport::TransportConfig;
+use crate::transport::{EndpointType, TransportConfig};
 
 /// Async endpoint resolver.
 ///
@@ -52,6 +53,52 @@ pub trait Resolver: Send + Sync {
     async fn resolve(&self, name: &str, kind: SocketKind) -> anyhow::Result<TransportConfig>;
 }
 
+/// Resolver profile names used at service startup.
+///
+/// Profiles make locality an explicit deployment decision. Generated clients
+/// still ask for `(service_name, socket_kind)`; the installed resolver profile
+/// decides whether that name maps to an in-process handle, a same-host Unix
+/// socket, or a network-discovered peer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolverProfile {
+    /// Single-process / hermetic-test profile.
+    LocalInproc,
+    /// Local IPC profile.
+    Ipc,
+    /// Multi-host production profile backed by DiscoveryService/PDS records.
+    NetworkDiscovery,
+}
+
+/// Network profile wrapper for a DiscoveryService/PDS-backed resolver.
+///
+/// The wrapped resolver owns service discovery. This wrapper enforces the
+/// network-profile invariant: same-host endpoints (`inproc`, `ipc`,
+/// `systemd-fd`) are not valid routable service reach.
+pub struct NetworkDiscoveryResolver {
+    inner: Arc<dyn Resolver>,
+}
+
+impl NetworkDiscoveryResolver {
+    pub fn new(inner: Arc<dyn Resolver>) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait::async_trait]
+impl Resolver for NetworkDiscoveryResolver {
+    async fn resolve(&self, name: &str, kind: SocketKind) -> anyhow::Result<TransportConfig> {
+        let transport = self.inner.resolve(name, kind).await?;
+        match &transport.endpoint {
+            EndpointType::Inproc { .. }
+            | EndpointType::Ipc { .. }
+            | EndpointType::SystemdFd { .. } => Err(anyhow!(
+                "network-discovery resolver returned same-host endpoint for service '{name}' ({kind:?})"
+            )),
+            EndpointType::Quic { .. } | EndpointType::Iroh { .. } => Ok(transport),
+        }
+    }
+}
+
 // ============================================================================
 // Pluggable global resolver (replaceable)
 // ============================================================================
@@ -61,8 +108,9 @@ static GLOBAL_RESOLVER: RwLock<Option<Arc<dyn Resolver>>> = RwLock::new(None);
 /// Set the global resolver.
 ///
 /// Can be called multiple times — each call replaces the previous resolver.
-/// During bootstrap, `registry::init()` installs a `GlobalRegistryResolver`.
-/// Once `DiscoveryService` starts, it replaces this with itself.
+/// During bootstrap, `registry::init()` installs an explicit local resolver
+/// profile. A networked deployment can replace that with a
+/// [`NetworkDiscoveryResolver`] wrapping DiscoveryService or a DiscoveryClient.
 ///
 /// # Example
 ///
@@ -93,4 +141,49 @@ pub fn try_global() -> Option<Arc<dyn Resolver>> {
 pub fn global() -> Arc<dyn Resolver> {
     #[allow(clippy::expect_used)] // Intentional panic for programming error
     GLOBAL_RESOLVER.read().clone().expect("Global resolver not initialized — call resolver::set_global() first")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct StaticResolver(TransportConfig);
+
+    #[async_trait::async_trait]
+    impl Resolver for StaticResolver {
+        async fn resolve(&self, _name: &str, _kind: SocketKind) -> anyhow::Result<TransportConfig> {
+            Ok(self.0.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn network_discovery_resolver_rejects_inproc_reach() {
+        let resolver = NetworkDiscoveryResolver::new(Arc::new(StaticResolver(
+            TransportConfig::inproc("hyprstream/policy"),
+        )));
+
+        let err = match resolver.resolve("policy", SocketKind::Rep).await {
+            Ok(endpoint) => panic!("network resolver accepted local endpoint: {endpoint:?}"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains("same-host endpoint"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn network_discovery_resolver_accepts_quic_reach() {
+        let addr = "127.0.0.1:9443"
+            .parse()
+            .unwrap_or_else(|err| panic!("test socket address must parse: {err}"));
+        let quic = TransportConfig::quic(addr, "policy.local");
+        let resolver = NetworkDiscoveryResolver::new(Arc::new(StaticResolver(quic.clone())));
+
+        let endpoint = resolver
+            .resolve("policy", SocketKind::Rep)
+            .await
+            .unwrap_or_else(|err| panic!("network resolver rejected QUIC endpoint: {err}"));
+        assert_eq!(endpoint.endpoint_string(), quic.endpoint_string());
+    }
 }


### PR DESCRIPTION
Closes #873.

Stacked on #875 / #874.

## Summary
- Adds explicit resolver profile names and concrete resolver types:
  - `LocalInprocResolver`
  - `IpcResolver`
  - `NetworkDiscoveryResolver`
- `registry::init()` now installs a named local resolver profile instead of a generic registry resolver.
- Local profile resolvers first use explicitly registered endpoints, then synthesize only their own local endpoint shape.
- `NetworkDiscoveryResolver` wraps a DiscoveryService/PDS-backed resolver and rejects local-only transports (`inproc`, `ipc`, `systemd-fd`) so network mode cannot silently fall back to local reach.
- Exports the profile types for startup wiring.

## Validation
- `CARGO_TARGET_DIR=/tmp/hyprstream-876-target CARGO_INCREMENTAL=0 cargo test -p hyprstream-rpc registry::tests --lib`
- `CARGO_TARGET_DIR=/tmp/hyprstream-876-target CARGO_INCREMENTAL=0 cargo test -p hyprstream-rpc resolver::tests --lib`
- `CARGO_TARGET_DIR=/tmp/hyprstream-876-target CARGO_INCREMENTAL=0 cargo clippy -p hyprstream-rpc -p hyprstream-rpc-derive -p hyprstream-discovery --all-targets -- -D warnings`
