### PR TITLE
feat(9p): preserve aname at attach (#877)

### DIFF
--- a/crates/hyprstream-9p/README.md
+++ b/crates/hyprstream-9p/README.md
@@ -9,7 +9,7 @@ Implements the subset of the 9P2000.L wire protocol needed for read/write filesy
 | Message pair | Purpose |
 |---|---|
 | `Tversion` / `Rversion` | Protocol negotiation |
-| `Tattach` / `Rattach` | Attach to root fid |
+| `Tattach` / `Rattach` | Attach to root fid; `uname` carries caller credential/ticket when needed, `aname` selects the export root |
 | `Twalk` / `Rwalk` | Path traversal (resolve fid) |
 | `Tlopen` / `Rlopen` | Open file (9P2000.L variant) |
 | `Tread` / `Rread` | Read data |
@@ -22,6 +22,21 @@ Implements the subset of the 9P2000.L wire protocol needed for read/write filesy
 **Wire format**: all messages are 4-byte LE length-prefixed, matching the DMA ring buffer framing used by the Wanix WASM runtime.
 
 **WASM extras** (`target_arch = "wasm32"`): `dma` module (SAB ring-buffer transport) and `wanix_mount` (mount the VFS into the Wanix namespace via DMA).
+
+## Attach contract
+
+`Tattach` preserves both Plan 9 selector fields:
+
+- `uname` is the caller identity material. For authenticated network mounts it
+  may carry a short-lived mount ticket; for fixed-subject local transports it
+  can be ignored.
+- `aname` is the attach name, used by hyprstream as the export selector. Paths
+  walked after attach are paths inside that selected export, not global
+  scheduler or Kubernetes implementation paths.
+
+This keeps Wanix, `hypr9p-guest`, Kubernetes CSI, and future resolver-driven
+mounts on one model: resolve an export profile, attach with its `aname`, then
+walk normal filesystem paths below the attached root.
 
 ## Server-side translator (Kata 9P)
 

--- a/crates/hyprstream-9p/src/backend.rs
+++ b/crates/hyprstream-9p/src/backend.rs
@@ -52,18 +52,22 @@ pub struct StatResult {
 /// per walked path.
 #[async_trait]
 pub trait Backend: Send + Sync {
-    /// Establish the session at `Tattach`, given the `uname` the client
-    /// presented. The default is a no-op: backends whose caller identity is
-    /// fixed at construction (the UDS/vsock listeners) ignore `uname`.
+    /// Establish the session at `Tattach`, given the `uname` and `aname` the
+    /// client presented. The default is a no-op: backends whose caller identity
+    /// and export root are fixed at construction (the UDS/vsock listeners)
+    /// ignore both fields.
     ///
     /// A backend that resolves its caller identity from the attach itself
     /// (the H1b `/9p` WebTransport plane carries a mount ticket in
     /// `Tattach.uname` — the browser `WebSocket` can't set headers and the
     /// cert-pinned WT session has no URL query) validates it here and binds
-    /// the session `Subject`. Returning `Err` fails the attach; the translator
-    /// maps it to an `Rlerror` errno (a `hyprstream_vfs::MountError` in the
-    /// cause chain picks the errno — e.g. `PermissionDenied → EACCES`).
-    async fn attach(&self, _uname: &str) -> anyhow::Result<()> {
+    /// the session `Subject`. `aname` is the 9P attach name/export selector;
+    /// implementations may ignore it for a single-root export, or use it to
+    /// select and authorize a narrower root. Returning `Err` fails the attach;
+    /// the translator maps it to an `Rlerror` errno (a
+    /// `hyprstream_vfs::MountError` in the cause chain picks the errno — e.g.
+    /// `PermissionDenied → EACCES`).
+    async fn attach(&self, _uname: &str, _aname: &str) -> anyhow::Result<()> {
         Ok(())
     }
 

--- a/crates/hyprstream-9p/src/mount_backend.rs
+++ b/crates/hyprstream-9p/src/mount_backend.rs
@@ -55,8 +55,9 @@ use crate::msg::{self, Qid, ReaddirEntry};
 /// errno (e.g. [`MountError::PermissionDenied`] → `EACCES`).
 #[async_trait]
 pub trait AttachAuthorizer: Send + Sync {
-    /// Validate the `uname` ticket and return the narrowed session [`Subject`].
-    async fn authorize(&self, uname: &str) -> Result<Subject, MountError>;
+    /// Validate the `uname` ticket and `aname` export selector, then return the
+    /// narrowed session [`Subject`].
+    async fn authorize(&self, uname: &str, aname: &str) -> Result<Subject, MountError>;
 }
 
 /// Max bytes a single read/write returns. Kept below the translator's `MSG_SIZE`
@@ -145,15 +146,19 @@ impl MountBackend {
 
 #[async_trait]
 impl Backend for MountBackend {
-    async fn attach(&self, uname: &str) -> Result<()> {
+    async fn attach(&self, uname: &str, aname: &str) -> Result<()> {
         // Fixed-subject listeners have no authorizer; the Subject is already
-        // bound and `uname` is advisory (ignored, as on the UDS/vsock paths).
+        // bound and `uname`/`aname` are advisory (ignored, as on the UDS/vsock
+        // paths unless a future fixed-subject export resolver is installed).
         let Some(authorizer) = self.authorizer.as_ref() else {
             return Ok(());
         };
         // Attach-time ticket path (H1b): resolve+narrow. A MountError here maps
         // to an Rlerror errno (PermissionDenied → EACCES) via the translator.
-        let subject = authorizer.authorize(uname).await.map_err(anyhow::Error::new)?;
+        let subject = authorizer
+            .authorize(uname, aname)
+            .await
+            .map_err(anyhow::Error::new)?;
         // First attach wins; a second attach on the same connection must not
         // silently re-scope the session. Ignore a redundant identical set,
         // reject a conflicting one.

--- a/crates/hyprstream-9p/src/translator.rs
+++ b/crates/hyprstream-9p/src/translator.rs
@@ -304,7 +304,9 @@ impl Translator {
         let (tag, req) = parse_request(buf).context("decode 9P T-message")?;
         let resp = match req {
             Request::Version { msize, version } => self.handle_version(msize, version),
-            Request::Attach { fid, uname, .. } => self.handle_attach(fid, &uname).await?,
+            Request::Attach { fid, uname, aname, .. } => {
+                self.handle_attach(fid, &uname, &aname).await?
+            }
             // Flush is intercepted in serve_connection before reaching here;
             // this arm is unreachable but kept exhaustive.
             Request::Flush { .. } => Response::Clunk,
@@ -339,12 +341,14 @@ impl Translator {
         Response::Version { msize, version: "9P2000.L".into() }
     }
 
-    async fn handle_attach(&self, fid: u32, uname: &str) -> Result<Response> {
+    async fn handle_attach(&self, fid: u32, uname: &str, aname: &str) -> Result<Response> {
         // Establish the session first: on the attach-time ticket path (H1b) this
         // validates `uname` and binds the session Subject; on the fixed-subject
-        // path it is a no-op. A denied ticket returns here and is mapped to an
-        // Rlerror by the serve loop — before any fid or mount handle exists.
-        self.backend.attach(uname).await?;
+        // path it is a no-op. `aname` is preserved as the protocol export
+        // selector so backends can authorize/select a root at attach time. A
+        // denied ticket or export returns here and is mapped to an Rlerror by
+        // the serve loop — before any fid or mount handle exists.
+        self.backend.attach(uname, aname).await?;
         // Attach establishes the root fid. Walk the empty path to materialize
         // a root qid from the backend, then record it.
         let walk = self.backend.walk(fid, fid, &[]).await?;
@@ -820,6 +824,77 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn attach_preserves_aname_for_backend() {
+        use parking_lot::Mutex;
+
+        struct RecordingBackend {
+            seen: Mutex<Option<(String, String)>>,
+        }
+
+        #[async_trait::async_trait]
+        impl Backend for RecordingBackend {
+            async fn attach(&self, uname: &str, aname: &str) -> Result<()> {
+                *self.seen.lock() = Some((uname.to_owned(), aname.to_owned()));
+                Ok(())
+            }
+
+            async fn walk(
+                &self,
+                _fid: u32,
+                _newfid: u32,
+                _components: &[String],
+            ) -> Result<crate::backend::WalkResult> {
+                Ok(crate::backend::WalkResult {
+                    qids: vec![sample_qid(0x80, 1)],
+                })
+            }
+
+            async fn open(&self, _fid: u32, _flags: u32) -> Result<crate::backend::OpenResult> {
+                unimplemented!("not used by aname regression test")
+            }
+
+            async fn read(&self, _fid: u32, _offset: u64, _count: u32) -> Result<Vec<u8>> {
+                unimplemented!("not used by aname regression test")
+            }
+
+            async fn write(&self, _fid: u32, _offset: u64, _data: &[u8]) -> Result<u32> {
+                unimplemented!("not used by aname regression test")
+            }
+
+            async fn stat(&self, _fid: u32) -> Result<crate::backend::StatResult> {
+                unimplemented!("not used by aname regression test")
+            }
+
+            async fn readdir(&self, _fid: u32, _offset: u64, _count: u32) -> Result<Vec<u8>> {
+                unimplemented!("not used by aname regression test")
+            }
+
+            async fn clunk(&self, _fid: u32) -> Result<()> {
+                Ok(())
+            }
+        }
+
+        let backend = Arc::new(RecordingBackend { seen: Mutex::new(None) });
+        let t = Translator::new(backend.clone());
+        let (_, resp) = t
+            .handle_message(&msg::tattach(
+                1,
+                0,
+                u32::MAX,
+                "mount-ticket",
+                "export:models/qwen",
+            ))
+            .await
+            .unwrap();
+
+        assert!(matches!(resp, Response::Attach { .. }));
+        assert_eq!(
+            *backend.seen.lock(),
+            Some(("mount-ticket".to_owned(), "export:models/qwen".to_owned()))
+        );
+    }
+
+    #[tokio::test]
     async fn attach_then_walk_open_read_clunk() {
         let backend = MemoryBackend::default();
         backend.add_file("/hello.txt", b"hello world");
@@ -1122,11 +1197,14 @@ mod tests {
         async fn authorize(
             &self,
             uname: &str,
+            aname: &str,
         ) -> std::result::Result<hyprstream_rpc::Subject, hyprstream_vfs::MountError> {
-            if uname == "good-ticket" {
+            if uname == "good-ticket" && (aname.is_empty() || aname == "default") {
                 Ok(hyprstream_rpc::Subject::new("alice"))
             } else {
-                Err(hyprstream_vfs::MountError::PermissionDenied("bad ticket".into()))
+                Err(hyprstream_vfs::MountError::PermissionDenied(
+                    "bad ticket or export".into(),
+                ))
             }
         }
     }
@@ -1186,6 +1264,24 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(errno_from_error(&err), EACCES, "missing ticket must be EACCES");
+    }
+
+    /// The attach-time authorizer receives `aname`, so export selection can
+    /// fail closed before any fid is served.
+    #[tokio::test]
+    async fn attach_aname_denied_returns_eacces() {
+        let t = authorized_translator();
+        let err = t
+            .handle_message(&msg::tattach(
+                1,
+                0,
+                u32::MAX,
+                "good-ticket",
+                "forbidden-export",
+            ))
+            .await
+            .unwrap_err();
+        assert_eq!(errno_from_error(&err), EACCES, "denied aname must be EACCES");
     }
 
     /// Fail-closed: an op arriving before a successful attach binds the Subject

--- a/crates/hyprstream/src/server/routes/ninep.rs
+++ b/crates/hyprstream/src/server/routes/ninep.rs
@@ -488,7 +488,7 @@ struct TicketAttachAuthorizer {
 
 #[async_trait]
 impl AttachAuthorizer for TicketAttachAuthorizer {
-    async fn authorize(&self, uname: &str) -> Result<Subject, MountError> {
+    async fn authorize(&self, uname: &str, _aname: &str) -> Result<Subject, MountError> {
         if uname.is_empty() {
             return Err(MountError::PermissionDenied("missing mount ticket".to_owned()));
         }


### PR DESCRIPTION
Closes #877.

Stacked on #876 / ewindisch/873-service-resolver-profiles.

## Summary
- Preserves `Tattach.aname` through the 9P translator instead of dropping it.
- Extends the 9P backend attach API and attach authorizer to receive both `uname` and `aname`.
- Adds regression coverage for backend `aname` propagation and attach-time export denial.
- Documents the `uname` vs `aname` attach contract for Wanix, hypr9p, CSI, and resolver-driven mounts.

## Validation
- `CARGO_TARGET_DIR=/tmp/hyprstream-877-target CARGO_INCREMENTAL=0 cargo test -p hyprstream-9p`
- Commit hook clippy passed (`git commit`)

## Notes
- `cargo fmt --check --package hyprstream` reports broad pre-existing rustfmt drift outside this change, so I did not mass-format unrelated files.
- `cargo check -p hyprstream --lib` with vendored OpenSSL failed because local Perl cannot load `FindBin.pm`; with `OPENSSL_NO_VENDOR=1` it progressed to missing local libtorch. Neither failure was from this code path.
