### PR TITLE
refactor(rpc) 579: collapse the identity-resolver contract into one canonical definition

### DIFF
--- a/crates/hyprstream-rpc/src/auth/atproto_perimeter.rs
+++ b/crates/hyprstream-rpc/src/auth/atproto_perimeter.rs
@@ -41,51 +41,7 @@ use crate::admission::AdmittedIdentity;
 use crate::auth::mac::{
     Assurance, CompartmentSet, Level, SecurityContext, SecurityLabel, VerifiedKeyMaterial,
 };
-use crate::crypto::pq::MlDsaVerifyingKey;
-use crate::identity::Did;
-
-/// Raw 32-byte Ed25519 verifying key.
-///
-/// Mirror alias for the #579 resolver contract. When #579 lands and exports its
-/// own key type, this alias swaps to it without touching the gateway logic.
-pub type Ed25519Vk = [u8; 32];
-
-/// ML-DSA-65 verifying key (FIPS 204).
-///
-/// Mirror alias for the #579 resolver contract, pinned to the always-compiled PQ
-/// primitive ([`crate::crypto::pq::MlDsaVerifyingKey`]).
-pub type MlDsaVk = MlDsaVerifyingKey;
-
-/// The key material a resolver returns for an external identity.
-///
-/// **Mirror** of the #579 contract; field-for-field what `resolve_identity_keys`
-/// must yield. `ml_dsa_65 == None` ⇒ classical-only edge; `Some` ⇒ a hybrid-PQC
-/// anchor is present. The `assurance` is **crypto-derived by the resolver**, never
-/// self-asserted — the gateway maps it 1:1 into [`VerifiedKeyMaterial`].
-#[derive(Clone)]
-pub struct IdentityKeys {
-    /// The classical Ed25519 verifying key, if the identity published one.
-    pub ed25519: Option<Ed25519Vk>,
-    /// The bound ML-DSA-65 verifying key, if the identity published a PQ anchor.
-    pub ml_dsa_65: Option<MlDsaVk>,
-    /// The assurance the resolver established for this identity (crypto-derived).
-    pub assurance: Assurance,
-}
-
-/// Resolves an external `Did` to its verified key material.
-///
-/// **Mirror** of the #579 resolver trait — its signature matches #579 exactly so a
-/// real `did:plc`/`did:web` resolver (the #579 deliverable) drops in unchanged.
-/// Until #579 lands, the gateway is exercised against fixture implementations (as
-/// `admission.rs` does with its `DidDocResolve` test doubles).
-///
-/// **Fail-closed contract:** an implementation MUST return `Err` on any inability
-/// to establish key material (network failure, unknown DID, malformed document) —
-/// never a default-`Unverified` `Ok`. The gateway treats `Err` as "not enrolled".
-pub trait IdentityResolver: Send + Sync {
-    /// Resolve `did` to its verified key material, or `Err` (fail-closed).
-    fn resolve_identity_keys(&self, did: &Did) -> Result<IdentityKeys>;
-}
+use crate::identity::{Did, IdentityResolver};
 
 /// A pinned, enrolled external peer.
 ///
@@ -267,6 +223,7 @@ impl EnrollmentStore {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use crate::identity::{IdentityKeys, MlDsaVk};
     use crate::crypto::pq::ml_dsa_generate_keypair;
 
     const DID_WEB: &str = "did:web:peer.example";

--- a/crates/hyprstream-rpc/src/auth/mod.rs
+++ b/crates/hyprstream-rpc/src/auth/mod.rs
@@ -32,7 +32,10 @@ pub mod scope_registry;
 pub mod ucan;
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use atproto_perimeter::{AtprotoPerimeterGateway, Ed25519Vk, EnrolledPeer, EnrollmentStore, IdentityKeys, IdentityResolver, MlDsaVk};
+pub use atproto_perimeter::{AtprotoPerimeterGateway, EnrolledPeer, EnrollmentStore};
+// The identity-resolution contract (#579) lives canonically in `crate::identity`;
+// re-exported here so existing `crate::auth::{IdentityResolver, ...}` paths keep working.
+pub use crate::identity::{Ed25519Vk, IdentityKeys, IdentityResolver, MlDsaVk};
 pub use claims::{ActClaim, Claims, Cnf, CnfJwk, IdTokenClaims, OneOrMany, compute_jkt, is_local_iss};
 pub use jti_blocklist::{InMemoryJtiBlocklist, JtiBlocklist};
 pub use mac::{

--- a/crates/hyprstream-rpc/src/identity.rs
+++ b/crates/hyprstream-rpc/src/identity.rs
@@ -13,6 +13,9 @@ use std::str::FromStr;
 
 use anyhow::Result;
 use async_trait::async_trait;
+
+use crate::auth::mac::Assurance;
+use crate::crypto::pq::MlDsaVerifyingKey;
 use serde::{Deserialize, Serialize};
 
 use crate::Subject;
@@ -211,4 +214,47 @@ mod did_tests {
         let back: Did = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back, did);
     }
+}
+
+// ============================================================================
+// Identity-resolution contract (#579)
+//
+// The canonical `Did -> verified key material` contract. A method-dispatched
+// resolver (did:web VM extractor / did:key single-Ed25519 / did:at9p capsule
+// arm, #894) implements `IdentityResolver`; consumers — the ATProto perimeter
+// gateway (`auth::atproto_perimeter`) and mesh admission (`admission`) — are
+// generic over it and never see key bytes directly. One definition lives here;
+// do not re-declare it elsewhere.
+// ============================================================================
+
+/// Raw 32-byte Ed25519 verifying key.
+pub type Ed25519Vk = [u8; 32];
+
+/// ML-DSA-65 verifying key (FIPS 204), pinned to the always-compiled PQ
+/// primitive ([`crate::crypto::pq::MlDsaVerifyingKey`]).
+pub type MlDsaVk = MlDsaVerifyingKey;
+
+/// The key material a resolver returns for an identity.
+///
+/// `ml_dsa_65 == None` ⇒ classical-only edge; `Some` ⇒ a hybrid-PQC anchor is
+/// present. `assurance` is **crypto-derived by the resolver**, never
+/// self-asserted — consumers map it 1:1 into their MAC key material.
+#[derive(Clone)]
+pub struct IdentityKeys {
+    /// The classical Ed25519 verifying key, if the identity published one.
+    pub ed25519: Option<Ed25519Vk>,
+    /// The bound ML-DSA-65 verifying key, if the identity published a PQ anchor.
+    pub ml_dsa_65: Option<MlDsaVk>,
+    /// The assurance the resolver established for this identity (crypto-derived).
+    pub assurance: Assurance,
+}
+
+/// Resolves a `Did` to its verified key material.
+///
+/// **Fail-closed contract:** an implementation MUST return `Err` on any inability
+/// to establish key material (network failure, unknown DID, malformed document) —
+/// never a default-`Unverified` `Ok`. Consumers treat `Err` as "not enrolled".
+pub trait IdentityResolver: Send + Sync {
+    /// Resolve `did` to its verified key material, or `Err` (fail-closed).
+    fn resolve_identity_keys(&self, did: &Did) -> Result<IdentityKeys>;
 }


### PR DESCRIPTION
Part of #579. Collapses the forward-declared "Mirror" duplication.

**What:** moves `IdentityKeys`, `IdentityResolver`, `Ed25519Vk`, `MlDsaVk` from `auth::atproto_perimeter` (where they were a placeholder labeled "Mirror of the #579 contract") into `crate::identity` as the single canonical contract. Re-exported from `auth::mod` so existing `crate::auth::{...}` paths are unchanged.

**Why:** the #549 perimeter gateway is generic over `IdentityResolver` and was built/tested against the placeholder. Left as-is, #579's real dispatcher would define a second copy and the gateway would drift against a stale one. One definition removes that hazard.

**Behavior:** zero logic change. Perimeter enrollment tests + identity tests pass; `cargo clippy -D warnings` clean.

Follow-up (still #579): implement the real method-dispatched `resolve_identity_keys` (did:web VM extractor + did:key arms) implementing this canonical trait, replacing the FixtureResolver. did:at9p arm is #894.