### PR TITLE
feat(pds) 910a: wire PDS record publication + durable RocksDB store

### DIFF
--- a/crates/hyprstream-pds/src/tid.rs
+++ b/crates/hyprstream-pds/src/tid.rs
@@ -32,6 +32,15 @@ impl Tid {
         Tid(bits)
     }
 
+    /// The raw 64-bit integer value of this TID.
+    ///
+    /// Used by callers that need to advance a revision monotonically (the
+    /// atproto commit `rev` must strictly increase), e.g. bumping past a
+    /// previous commit's rev when the wall clock has not moved.
+    pub const fn to_raw(self) -> u64 {
+        self.0
+    }
+
     /// Build a TID from a microsecond timestamp (high 53 bits) and a 10-bit
     /// clock id (low 10 bits).
     ///

--- a/crates/hyprstream/src/auth/identity_store.rs
+++ b/crates/hyprstream/src/auth/identity_store.rs
@@ -445,43 +445,12 @@ pub fn resolve_service_signing_key(
     }
 }
 
-/// Load or generate this node's `#atproto` commit-signing key (P-256/ES256).
-///
-/// PDS commits are signed classically (ES256) per atproto — there is no PQ
-/// variant of this key (#910a). Mirrors [`load_or_generate_node_signing_key`]:
-///
-/// 1. Read `secrets_dir/atproto-signing-key` → return if present.
-/// 2. If writable: generate a new key, write, return.
-/// 3. If read-only and missing: hard error.
-pub fn load_or_generate_atproto_signing_key(
-    secrets_dir: &std::path::Path,
-) -> Result<p256::ecdsa::SigningKey> {
-    const NAME: &str = "atproto-signing-key";
-
-    if let Some(bytes) = read_secret(secrets_dir, NAME)? {
-        let seed: [u8; 32] = bytes
-            .as_slice()
-            .try_into()
-            .map_err(|_| anyhow!("secret '{}' must be 32 bytes (P-256 seed)", NAME))?;
-        let sk = p256::ecdsa::SigningKey::from_bytes(seed.as_slice().into())
-            .map_err(|e| anyhow!("secret '{}' is not a valid P-256 key: {}", NAME, e))?;
-        tracing::info!("Loaded #atproto (P-256) signing key from '{}'", secrets_dir.display());
-        return Ok(sk);
-    }
-
-    if !is_writable(secrets_dir) {
-        return Err(missing_in_readonly(secrets_dir, NAME));
-    }
-
-    let key = p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
-    write_secret(secrets_dir, NAME, key.to_bytes().as_slice())?;
-    tracing::info!(
-        "Generated new #atproto (P-256) signing key → '{}/{}'",
-        secrets_dir.display(),
-        NAME
-    );
-    Ok(key)
-}
+// The `#atproto` commit-signing key is NOT loaded here. It is the *active* key
+// of the shared `Es256SigningKeyStore` (`auth::key_rotation`), the same P-256
+// key `oauth::did_document` publishes as the `#atproto` verification method —
+// one source of truth for signer and published key. The PDS writer
+// (`services::discovery::PdsPublisher`) sources it from that store; there is no
+// separate `atproto-signing-key` secret and no duplicate loader (#910a).
 
 /// Decode the `exp` claim from a JWT without signature verification.
 /// Returns `None` on any parse error (invalid base64, not JSON, missing exp).

--- a/crates/hyprstream/src/auth/identity_store.rs
+++ b/crates/hyprstream/src/auth/identity_store.rs
@@ -445,6 +445,44 @@ pub fn resolve_service_signing_key(
     }
 }
 
+/// Load or generate this node's `#atproto` commit-signing key (P-256/ES256).
+///
+/// PDS commits are signed classically (ES256) per atproto — there is no PQ
+/// variant of this key (#910a). Mirrors [`load_or_generate_node_signing_key`]:
+///
+/// 1. Read `secrets_dir/atproto-signing-key` → return if present.
+/// 2. If writable: generate a new key, write, return.
+/// 3. If read-only and missing: hard error.
+pub fn load_or_generate_atproto_signing_key(
+    secrets_dir: &std::path::Path,
+) -> Result<p256::ecdsa::SigningKey> {
+    const NAME: &str = "atproto-signing-key";
+
+    if let Some(bytes) = read_secret(secrets_dir, NAME)? {
+        let seed: [u8; 32] = bytes
+            .as_slice()
+            .try_into()
+            .map_err(|_| anyhow!("secret '{}' must be 32 bytes (P-256 seed)", NAME))?;
+        let sk = p256::ecdsa::SigningKey::from_bytes(seed.as_slice().into())
+            .map_err(|e| anyhow!("secret '{}' is not a valid P-256 key: {}", NAME, e))?;
+        tracing::info!("Loaded #atproto (P-256) signing key from '{}'", secrets_dir.display());
+        return Ok(sk);
+    }
+
+    if !is_writable(secrets_dir) {
+        return Err(missing_in_readonly(secrets_dir, NAME));
+    }
+
+    let key = p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
+    write_secret(secrets_dir, NAME, key.to_bytes().as_slice())?;
+    tracing::info!(
+        "Generated new #atproto (P-256) signing key → '{}/{}'",
+        secrets_dir.display(),
+        NAME
+    );
+    Ok(key)
+}
+
 /// Decode the `exp` claim from a JWT without signature verification.
 /// Returns `None` on any parse error (invalid base64, not JSON, missing exp).
 pub fn decode_jwt_exp_raw(jwt: &str) -> Option<i64> {

--- a/crates/hyprstream/src/services/discovery.rs
+++ b/crates/hyprstream/src/services/discovery.rs
@@ -85,7 +85,6 @@ struct RepoState {
 // unambiguous field separator for compound keys (same idea as the delimited
 // keys `RocksDbUserStore` uses, just with a compound suffix here).
 //
-//   sk\0{did}                              -> 32-byte P-256 signing-key seed
 //   rk\0{did}\0{collection}\0{tid}         -> canonical DAG-CBOR record bytes
 //
 // The record's rkey (a TID) is derived deterministically from the repo id
@@ -157,7 +156,7 @@ impl PdsRecordStore {
     pub fn open(path: &Path, atproto_signing_key: p256::ecdsa::SigningKey) -> AnyResult<Self> {
         std::fs::create_dir_all(path)
             .with_context(|| format!("failed to create PDS store dir {path:?}"))?;
-        harden_store_dir(path)?;
+        harden_store_dir(path);
         let mut opts = rocksdb::Options::default();
         opts.create_if_missing(true);
         let db = rocksdb::DB::open(&opts, path)
@@ -289,16 +288,20 @@ fn readonly_opts() -> rocksdb::Options {
 /// over at read time — a store another local user could write would let them
 /// inject records the node then serves as authentic. On non-unix this is a
 /// no-op (the store path is expected to be an OS-managed private dir there).
-fn harden_store_dir(path: &Path) -> AnyResult<()> {
+fn harden_store_dir(path: &Path) {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
-            .with_context(|| format!("failed to set 0700 on PDS store dir {path:?}"))?;
+        // Best-effort: this is defence-in-depth (the private key never lands in
+        // this DB — H1 — and the path never resolves to /tmp — H2). If the chmod
+        // fails (e.g. the dir is owned by a different uid in a split-uid setup),
+        // warn rather than hard-fail startup.
+        if let Err(e) = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700)) {
+            tracing::warn!("could not set 0700 on PDS store dir {path:?}: {e}");
+        }
     }
     #[cfg(not(unix))]
     let _ = path;
-    Ok(())
 }
 
 // ============================================================================

--- a/crates/hyprstream/src/services/discovery.rs
+++ b/crates/hyprstream/src/services/discovery.rs
@@ -20,6 +20,7 @@ use hyprstream_pds::commit::Commit;
 use hyprstream_pds::mst::Node;
 use hyprstream_pds::record::ModelRecord;
 use hyprstream_pds::tid::Tid;
+use sha2::Digest as _;
 
 // Re-export the generated discovery client types from our local generated module
 // (hyprstream still needs its own discovery_client for the DiscoveryClient type)
@@ -86,13 +87,11 @@ struct RepoState {
 //
 //   sk\0{did}                              -> 32-byte P-256 signing-key seed
 //   rk\0{did}\0{collection}\0{tid}         -> canonical DAG-CBOR record bytes
-//   tid\0{repo_id}                         -> the TID (13-char string) minted
-//                                              for that repo's *one* stable
-//                                              record key (see `tid_for_repo`)
-
-fn signing_key_key(did: &str) -> Vec<u8> {
-    format!("sk\0{did}").into_bytes()
-}
+//
+// The record's rkey (a TID) is derived deterministically from the repo id
+// (`PdsRecordStore::tid_for_repo`), so it is never minted or persisted. The
+// `#atproto` signing key is held in memory (loaded from the 0600 secrets dir),
+// never stored in this DB (#910a H1).
 
 fn record_prefix(did: &str) -> Vec<u8> {
     format!("rk\0{did}\0").into_bytes()
@@ -100,10 +99,6 @@ fn record_prefix(did: &str) -> Vec<u8> {
 
 fn record_key(did: &str, collection: &str, tid: Tid) -> Vec<u8> {
     format!("rk\0{did}\0{collection}\0{}", tid.encode()).into_bytes()
-}
-
-fn repo_tid_key(repo_id: &str) -> Vec<u8> {
-    format!("tid\0{repo_id}").into_bytes()
 }
 
 /// Split a full record key back into `(collection, tid)`, given the `did` it
@@ -138,6 +133,12 @@ fn parse_record_key(key: &[u8], did: &str) -> AnyResult<(String, Tid)> {
 /// callers that need a live view reopen per read (see [`RecordBacking::ReadOnly`]).
 pub struct PdsRecordStore {
     backing: RecordBacking,
+    /// This node's `#atproto` commit-signing key (P-256/ES256), held in memory
+    /// and loaded from the 0600 secrets dir by both the publisher and the
+    /// resolver. It is **never** persisted into the record DB (#910a H1) —
+    /// putting a private key into 0644 RocksDB files would let any local reader
+    /// forge signed PDS commits. Used to sign CAR proofs at read time.
+    atproto_signing_key: p256::ecdsa::SigningKey,
 }
 
 enum RecordBacking {
@@ -153,98 +154,84 @@ impl PdsRecordStore {
     /// Open (or create) the durable store at `path` for read-write access.
     /// Exactly one process should hold this — the publisher (registry
     /// service). See the type-level docs for the single-writer rationale.
-    pub fn open(path: &Path) -> AnyResult<Self> {
+    pub fn open(path: &Path, atproto_signing_key: p256::ecdsa::SigningKey) -> AnyResult<Self> {
         std::fs::create_dir_all(path)
             .with_context(|| format!("failed to create PDS store dir {path:?}"))?;
+        harden_store_dir(path)?;
         let mut opts = rocksdb::Options::default();
         opts.create_if_missing(true);
         let db = rocksdb::DB::open(&opts, path)
             .with_context(|| format!("failed to open PDS record store (rw) at {path:?}"))?;
-        Ok(Self { backing: RecordBacking::ReadWrite(db) })
+        Ok(Self { backing: RecordBacking::ReadWrite(db), atproto_signing_key })
     }
 
     /// Open the store read-only at `path`, for resolvers that never write
     /// (the discovery service). Verifies the directory opens successfully now
     /// (surfacing a missing/corrupt store at startup) but does not hold the
     /// handle — see the type-level docs.
-    pub fn open_readonly(path: &Path) -> AnyResult<Self> {
+    pub fn open_readonly(path: &Path, atproto_signing_key: p256::ecdsa::SigningKey) -> AnyResult<Self> {
         let opts = readonly_opts();
         let _probe = rocksdb::DB::open_for_read_only(&opts, path, false)
             .with_context(|| format!("failed to open PDS record store (ro) at {path:?}"))?;
-        Ok(Self { backing: RecordBacking::ReadOnly(path.to_path_buf()) })
+        Ok(Self { backing: RecordBacking::ReadOnly(path.to_path_buf()), atproto_signing_key })
     }
 
-    /// Insert/replace a record for `did` under `collection` at `tid`, using
-    /// `signing_key` as the account's `#atproto` commit key. Used by the
-    /// publishing path and by tests. Fails if this store was opened
-    /// read-only.
+    /// Insert/replace a record for `did` under `collection` at `tid`. The
+    /// account's `#atproto` commit key lives in memory (never in this DB —
+    /// #910a H1). Used by the publishing path and by tests. Fails if this
+    /// store was opened read-only.
     pub fn put_record(
         &self,
         did: &str,
         collection: &str,
         tid: Tid,
         record: ModelRecord,
-        signing_key: p256::ecdsa::SigningKey,
     ) -> AnyResult<()> {
         let RecordBacking::ReadWrite(db) = &self.backing else {
             bail!("PdsRecordStore::put_record called on a read-only store");
         };
-        let mut batch = rocksdb::WriteBatch::default();
-        batch.put(signing_key_key(did), signing_key.to_bytes().as_slice());
-        batch.put(record_key(did, collection, tid), record.to_dag_cbor());
-        db.write(batch).context("PDS record store write failed")?;
+        db.put(record_key(did, collection, tid), record.to_dag_cbor())
+            .context("PDS record store write failed")?;
         Ok(())
     }
 
-    /// Return the TID previously minted for `repo_id`'s single stable record
-    /// key, or mint and persist a new one.
+    /// The stable record-key TID for `repo_id`, derived **deterministically**
+    /// from the repo id (#910a M1).
     ///
-    /// A record's rkey is assigned once at first publish and never changes —
-    /// later publishes for the same `repo_id` replace the record's *value* at
-    /// that same `(collection, tid)` key (the atproto "pointer advance").
-    /// Fails if this store was opened read-only.
-    pub fn tid_for_repo(&self, repo_id: &str) -> AnyResult<Tid> {
-        let RecordBacking::ReadWrite(db) = &self.backing else {
-            bail!("PdsRecordStore::tid_for_repo called on a read-only store");
-        };
-        let key = repo_tid_key(repo_id);
-        if let Some(existing) = db.get(&key).context("PDS store tid lookup failed")? {
-            let s = std::str::from_utf8(&existing).context("stored tid is not UTF-8")?;
-            return Tid::parse(s).context("stored tid is malformed");
-        }
-        let tid = Tid::now();
-        db.put(&key, tid.encode().as_bytes())
-            .context("PDS store tid persist failed")?;
-        Ok(tid)
+    /// The rkey must be a pure function of `repo_id`: two distinct repos must
+    /// never alias onto one `(collection, tid)` key (which would silently and
+    /// permanently clobber one repo's record with the other's), and the same
+    /// repo must always resolve to the same key so a re-publish is a pointer
+    /// advance, not a new record. A wall-clock `Tid::now()` fails both (same
+    /// microsecond → identical TID; and it needs a persisted mint with a
+    /// get-then-put race). Instead derive the TID's 53-bit micros field and
+    /// 10-bit clock id from `SHA-256(repo_id)` — a hash, not a timestamp:
+    /// these records are not time-ordered, so 63 bits of collision resistance
+    /// is exactly what we want, with no mint, no persistence, and no race.
+    pub fn tid_for_repo(repo_id: &str) -> Tid {
+        // SHA-256 output is always 32 bytes, so these indexes never panic and
+        // need no fallible `try_into`.
+        let d = sha2::Sha256::digest(repo_id.as_bytes());
+        let micros = u64::from_be_bytes([d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]]);
+        let clock_id = u16::from_be_bytes([d[8], d[9]]);
+        Tid::from_micros(micros, clock_id)
     }
 
     /// Load the full record set + signing key for `did`, or `None` if the
     /// account has never published.
     fn load_repo(&self, did: &str) -> AnyResult<Option<RepoState>> {
         match &self.backing {
-            RecordBacking::ReadWrite(db) => Self::load_repo_from(db, did),
+            RecordBacking::ReadWrite(db) => self.load_repo_from(db, did),
             RecordBacking::ReadOnly(path) => {
                 let opts = readonly_opts();
                 let db = rocksdb::DB::open_for_read_only(&opts, path, false)
                     .with_context(|| format!("failed to reopen PDS record store at {path:?}"))?;
-                Self::load_repo_from(&db, did)
+                self.load_repo_from(&db, did)
             }
         }
     }
 
-    fn load_repo_from(db: &rocksdb::DB, did: &str) -> AnyResult<Option<RepoState>> {
-        let Some(sk_bytes) = db
-            .get(signing_key_key(did))
-            .context("PDS store signing-key lookup failed")?
-        else {
-            return Ok(None);
-        };
-        if sk_bytes.len() != 32 {
-            bail!("corrupt PDS signing key for {did:?}: expected 32 bytes, got {}", sk_bytes.len());
-        }
-        let signing_key = p256::ecdsa::SigningKey::from_bytes(sk_bytes.as_slice().into())
-            .map_err(|e| anyhow!("corrupt PDS signing key for {did:?}: {e}"))?;
-
+    fn load_repo_from(&self, db: &rocksdb::DB, did: &str) -> AnyResult<Option<RepoState>> {
         let prefix = record_prefix(did);
         let mut records = BTreeMap::new();
         // `prefix_iterator` without a configured `prefix_extractor` degrades to
@@ -259,7 +246,13 @@ impl PdsRecordStore {
                 .with_context(|| format!("corrupt PDS record for {did}/{collection}/{tid}"))?;
             records.insert((collection, tid), record);
         }
-        Ok(Some(RepoState { signing_key, records }))
+        // "Never published" == no records for this DID. The `#atproto` key is
+        // held in memory (never in the DB — #910a H1), so a repo's existence is
+        // determined by its records, not by a stored key.
+        if records.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(RepoState { signing_key: self.atproto_signing_key.clone(), records }))
     }
 
     /// Build the MST over all of a repo's records and return it with the
@@ -289,6 +282,25 @@ fn readonly_opts() -> rocksdb::Options {
     opts
 }
 
+/// Restrict the record-store directory to owner-only (0700) on unix.
+///
+/// Defence in depth: even though the `#atproto` private key never lands in
+/// this DB (#910a H1), the record *values* are what the node signs CAR proofs
+/// over at read time — a store another local user could write would let them
+/// inject records the node then serves as authentic. On non-unix this is a
+/// no-op (the store path is expected to be an OS-managed private dir there).
+fn harden_store_dir(path: &Path) -> AnyResult<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+            .with_context(|| format!("failed to set 0700 on PDS store dir {path:?}"))?;
+    }
+    #[cfg(not(unix))]
+    let _ = path;
+    Ok(())
+}
+
 // ============================================================================
 // PdsPublisher — the register/commit write side of #910a
 // ============================================================================
@@ -303,22 +315,20 @@ pub struct PdsPublisher {
     /// every record this node publishes (single-node, self-hosted PDS; a
     /// per-account DID scheme is out of scope for #910a).
     did: String,
-    /// The `#atproto` commit-signing key (P-256/ES256, classical).
-    signing_key: p256::ecdsa::SigningKey,
 }
 
 impl PdsPublisher {
-    pub fn new(store: Arc<PdsRecordStore>, did: String, signing_key: p256::ecdsa::SigningKey) -> Self {
-        Self { store, did, signing_key }
+    pub fn new(store: Arc<PdsRecordStore>, did: String) -> Self {
+        Self { store, did }
     }
 
     /// Publish (or advance) the `ai.hyprstream.model` record for `repo_id`,
     /// pointing it at `current_oid_hex` (a git OID, hex-encoded).
     ///
-    /// The record's rkey is minted once per `repo_id` and reused on every
-    /// call (`PdsRecordStore::tid_for_repo`), so this always *replaces* the
-    /// existing record's value rather than creating a new one — the atproto
-    /// "pointer advance".
+    /// The record's rkey is derived deterministically from `repo_id`
+    /// (`PdsRecordStore::tid_for_repo`) and reused on every call, so this
+    /// always *replaces* the existing record's value rather than creating a
+    /// new one — the atproto "pointer advance".
     ///
     /// Best-effort by design: the caller (registry service) should log and
     /// continue on error rather than fail the git operation that triggered
@@ -326,7 +336,7 @@ impl PdsPublisher {
     /// PDS publish is caught up by the next successful one (same
     /// eventual-consistency contract `git::promote` documents).
     pub fn publish(&self, repo_id: &str, current_oid_hex: &str) -> AnyResult<()> {
-        let tid = self.store.tid_for_repo(repo_id)?;
+        let tid = PdsRecordStore::tid_for_repo(repo_id);
         let current_oid_cid = git_oid_to_cid_string(current_oid_hex)?;
         let record = ModelRecord::new(
             format!("at://{}", self.did),
@@ -334,7 +344,7 @@ impl PdsPublisher {
             atproto_datetime_now(),
         )?;
         self.store
-            .put_record(&self.did, hyprstream_pds::record::COLLECTION_NSID, tid, record, self.signing_key.clone())
+            .put_record(&self.did, hyprstream_pds::record::COLLECTION_NSID, tid, record)
     }
 }
 
@@ -475,13 +485,13 @@ mod pds_store_tests {
     #[test]
     fn put_then_load_round_trips_through_rocksdb() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let store = PdsRecordStore::open(dir.path()).expect("open");
         let sk = p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
+        let store = PdsRecordStore::open(dir.path(), sk.clone()).expect("open");
         let tid = Tid::now();
         let did = "did:key:zTestNode";
 
         store
-            .put_record(did, "ai.hyprstream.model", tid, sample_record("a"), sk.clone())
+            .put_record(did, "ai.hyprstream.model", tid, sample_record("a"))
             .expect("put_record");
 
         let resolver = PdsRecordResolver::new(Arc::new(store));
@@ -499,14 +509,14 @@ mod pds_store_tests {
         let tid = Tid::now();
 
         {
-            let store = PdsRecordStore::open(dir.path()).expect("open rw");
+            let store = PdsRecordStore::open(dir.path(), sk.clone()).expect("open rw");
             store
-                .put_record(did, "ai.hyprstream.model", tid, sample_record("b"), sk)
+                .put_record(did, "ai.hyprstream.model", tid, sample_record("b"))
                 .expect("put_record");
             // Writer handle dropped here — simulates a process restart.
         }
 
-        let ro = PdsRecordStore::open_readonly(dir.path()).expect("open ro");
+        let ro = PdsRecordStore::open_readonly(dir.path(), sk).expect("open ro");
         let resolver = PdsRecordResolver::new(Arc::new(ro));
         let got = tokio_test_block_on(resolver.resolve_repo(did))
             .expect("resolve_repo ok")
@@ -517,26 +527,24 @@ mod pds_store_tests {
     #[test]
     fn readonly_store_rejects_writes() {
         let dir = tempfile::tempdir().expect("tempdir");
-        // Create the directory with a real DB first so open_readonly succeeds.
-        drop(PdsRecordStore::open(dir.path()).expect("open rw"));
-
-        let ro = PdsRecordStore::open_readonly(dir.path()).expect("open ro");
         let sk = p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
+        // Create the directory with a real DB first so open_readonly succeeds.
+        drop(PdsRecordStore::open(dir.path(), sk.clone()).expect("open rw"));
+
+        let ro = PdsRecordStore::open_readonly(dir.path(), sk).expect("open ro");
         let err = ro
-            .put_record("did:key:zX", "ai.hyprstream.model", Tid::now(), sample_record("c"), sk)
+            .put_record("did:key:zX", "ai.hyprstream.model", Tid::now(), sample_record("c"))
             .unwrap_err();
         assert!(err.to_string().contains("read-only"));
     }
 
     #[test]
-    fn tid_for_repo_is_stable_across_calls() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let store = PdsRecordStore::open(dir.path()).expect("open");
-        let first = store.tid_for_repo("repo-a").expect("first mint");
-        let second = store.tid_for_repo("repo-a").expect("second lookup");
+    fn tid_for_repo_is_deterministic_and_distinct() {
+        let first = PdsRecordStore::tid_for_repo("repo-a");
+        let second = PdsRecordStore::tid_for_repo("repo-a");
         assert_eq!(first, second, "the same repo must always get the same rkey");
-        let other = store.tid_for_repo("repo-b").expect("different repo");
-        assert_ne!(first, other);
+        let other = PdsRecordStore::tid_for_repo("repo-b");
+        assert_ne!(first, other, "distinct repos must not alias onto one rkey");
     }
 
     /// Minimal single-threaded block_on so these tests don't need a full

--- a/crates/hyprstream/src/services/discovery.rs
+++ b/crates/hyprstream/src/services/discovery.rs
@@ -16,9 +16,9 @@ use std::sync::Arc;
 use anyhow::{anyhow, bail, Context as _, Result as AnyResult};
 use hyprstream_discovery::{RecordCarData, RecordResolver};
 use hyprstream_pds::car::build_record_proof_car;
-use hyprstream_pds::commit::Commit;
+use hyprstream_pds::commit::{Commit, UnsignedCommit};
 use hyprstream_pds::mst::Node;
-use hyprstream_pds::record::ModelRecord;
+use hyprstream_pds::record::{ModelRecord, COLLECTION_NSID};
 use hyprstream_pds::tid::Tid;
 use sha2::Digest as _;
 
@@ -62,21 +62,26 @@ impl AuthorizationProvider for PolicyAuthProvider {
 }
 
 // ============================================================================
-// PdsRecordResolver — backs DiscoveryService getRecord/getRepo (#431)
+// PdsRecordStore — durable, keyless-read atproto record store (#910a)
 // ============================================================================
 
-/// One account's repo in the node's local PDS: its records (keyed by TID) and
-/// the P-256 `#atproto` signing key that signs its commits.
+/// One account's repo, loaded from the durable store: its records (keyed by
+/// `(collection, tid)`) plus the **signed commit** that was persisted at write
+/// time.
 ///
-/// The MST and signed commit are rebuilt deterministically from the record set
-/// on demand (the MST shape is a pure function of the key set), so a stored repo
-/// is just "the records + the signing key". This mirrors the e7 federation
-/// publish path (`node_a_publish`) but as a queryable per-account store.
+/// The MST is a deterministic, keyless function of the record set
+/// (`Node::from_records`), so it is *not* stored — it is rebuilt on demand. The
+/// only thing that must be persisted (a private key signed it) is the commit
+/// itself. Reads therefore never touch a signing key: they rebuild the MST,
+/// load this already-signed commit, and assemble a proof CAR. This mirrors how
+/// atproto works — the commit is signed **once** at write time and served
+/// verbatim thereafter.
 struct RepoState {
-    /// P-256 `#atproto` signing key for this account's commits.
-    signing_key: p256::ecdsa::SigningKey,
     /// `<collection>/<rkey>` is the MST key; here we key by `(collection, tid)`.
     records: BTreeMap<(String, Tid), ModelRecord>,
+    /// The signed commit persisted by the writer — served verbatim on reads,
+    /// never re-signed.
+    commit: Commit,
 }
 
 // ── RocksDB key scheme ───────────────────────────────────────────────────────
@@ -85,12 +90,15 @@ struct RepoState {
 // unambiguous field separator for compound keys (same idea as the delimited
 // keys `RocksDbUserStore` uses, just with a compound suffix here).
 //
-//   rk\0{did}\0{collection}\0{tid}         -> canonical DAG-CBOR record bytes
+//   rk\0{did}\0{collection}\0{tid}   -> canonical DAG-CBOR record bytes
+//   commit\0{did}                    -> signed-commit DAG-CBOR bytes
 //
 // The record's rkey (a TID) is derived deterministically from the repo id
 // (`PdsRecordStore::tid_for_repo`), so it is never minted or persisted. The
-// `#atproto` signing key is held in memory (loaded from the 0600 secrets dir),
-// never stored in this DB (#910a H1).
+// `#atproto` signing key is held ONLY by the writer (`PdsPublisher`); it is
+// never stored in this DB and never held by the resolver (#910a). The commit is
+// signed once at write time and persisted under `commit\0{did}`, so reads are a
+// keyless walk (rebuild the MST, load the signed commit, serve a proof).
 
 fn record_prefix(did: &str) -> Vec<u8> {
     format!("rk\0{did}\0").into_bytes()
@@ -98,6 +106,10 @@ fn record_prefix(did: &str) -> Vec<u8> {
 
 fn record_key(did: &str, collection: &str, tid: Tid) -> Vec<u8> {
     format!("rk\0{did}\0{collection}\0{}", tid.encode()).into_bytes()
+}
+
+fn commit_key(did: &str) -> Vec<u8> {
+    format!("commit\0{did}").into_bytes()
 }
 
 /// Split a full record key back into `(collection, tid)`, given the `did` it
@@ -124,6 +136,12 @@ fn parse_record_key(key: &[u8], did: &str) -> AnyResult<(String, Tid)> {
 /// opened read-write by the *one* process that publishes, and read-only by
 /// resolvers.
 ///
+/// **The store holds no signing key.** The writer (`PdsPublisher`) signs the
+/// commit once and hands this store the signed bytes; the resolver only ever
+/// reads them back. This is the security fix at the heart of #910a: a read path
+/// that needed a private key to re-sign a commit on every `getRecord` was the
+/// root of the key-exposure problem — atproto never re-signs on read.
+///
 /// RocksDB allows exactly one read-write handle per directory; on a single
 /// node the registry service (the publisher) is the sole writer, and the
 /// discovery service (the resolver) opens the same directory read-only —
@@ -132,12 +150,6 @@ fn parse_record_key(key: &[u8], did: &str) -> AnyResult<(String, Tid)> {
 /// callers that need a live view reopen per read (see [`RecordBacking::ReadOnly`]).
 pub struct PdsRecordStore {
     backing: RecordBacking,
-    /// This node's `#atproto` commit-signing key (P-256/ES256), held in memory
-    /// and loaded from the 0600 secrets dir by both the publisher and the
-    /// resolver. It is **never** persisted into the record DB (#910a H1) —
-    /// putting a private key into 0644 RocksDB files would let any local reader
-    /// forge signed PDS commits. Used to sign CAR proofs at read time.
-    atproto_signing_key: p256::ecdsa::SigningKey,
 }
 
 enum RecordBacking {
@@ -153,7 +165,7 @@ impl PdsRecordStore {
     /// Open (or create) the durable store at `path` for read-write access.
     /// Exactly one process should hold this — the publisher (registry
     /// service). See the type-level docs for the single-writer rationale.
-    pub fn open(path: &Path, atproto_signing_key: p256::ecdsa::SigningKey) -> AnyResult<Self> {
+    pub fn open(path: &Path) -> AnyResult<Self> {
         std::fs::create_dir_all(path)
             .with_context(|| format!("failed to create PDS store dir {path:?}"))?;
         harden_store_dir(path);
@@ -161,36 +173,40 @@ impl PdsRecordStore {
         opts.create_if_missing(true);
         let db = rocksdb::DB::open(&opts, path)
             .with_context(|| format!("failed to open PDS record store (rw) at {path:?}"))?;
-        Ok(Self { backing: RecordBacking::ReadWrite(db), atproto_signing_key })
+        Ok(Self { backing: RecordBacking::ReadWrite(db) })
     }
 
     /// Open the store read-only at `path`, for resolvers that never write
     /// (the discovery service). Verifies the directory opens successfully now
     /// (surfacing a missing/corrupt store at startup) but does not hold the
-    /// handle — see the type-level docs.
-    pub fn open_readonly(path: &Path, atproto_signing_key: p256::ecdsa::SigningKey) -> AnyResult<Self> {
+    /// handle — see the type-level docs. The resolver holds **no signing key**.
+    pub fn open_readonly(path: &Path) -> AnyResult<Self> {
         let opts = readonly_opts();
         let _probe = rocksdb::DB::open_for_read_only(&opts, path, false)
             .with_context(|| format!("failed to open PDS record store (ro) at {path:?}"))?;
-        Ok(Self { backing: RecordBacking::ReadOnly(path.to_path_buf()), atproto_signing_key })
+        Ok(Self { backing: RecordBacking::ReadOnly(path.to_path_buf()) })
     }
 
-    /// Insert/replace a record for `did` under `collection` at `tid`. The
-    /// account's `#atproto` commit key lives in memory (never in this DB —
-    /// #910a H1). Used by the publishing path and by tests. Fails if this
-    /// store was opened read-only.
-    pub fn put_record(
+    /// Atomically persist a record and the repo's freshly-signed commit.
+    ///
+    /// The record and the commit that covers it advance together in one
+    /// `WriteBatch`, so a reader never observes a record whose MST root the
+    /// stored commit does not sign. Fails if this store was opened read-only.
+    fn put_record_and_commit(
         &self,
         did: &str,
         collection: &str,
         tid: Tid,
-        record: ModelRecord,
+        record: &ModelRecord,
+        commit: &Commit,
     ) -> AnyResult<()> {
         let RecordBacking::ReadWrite(db) = &self.backing else {
-            bail!("PdsRecordStore::put_record called on a read-only store");
+            bail!("PdsRecordStore::put_record_and_commit called on a read-only store");
         };
-        db.put(record_key(did, collection, tid), record.to_dag_cbor())
-            .context("PDS record store write failed")?;
+        let mut batch = rocksdb::WriteBatch::default();
+        batch.put(record_key(did, collection, tid), record.to_dag_cbor());
+        batch.put(commit_key(did), commit.to_dag_cbor());
+        db.write(batch).context("PDS record+commit write failed")?;
         Ok(())
     }
 
@@ -216,21 +232,21 @@ impl PdsRecordStore {
         Tid::from_micros(micros, clock_id)
     }
 
-    /// Load the full record set + signing key for `did`, or `None` if the
-    /// account has never published.
+    /// Load the full record set + signed commit for `did`, or `None` if the
+    /// account has never published (no records, or no persisted commit).
     fn load_repo(&self, did: &str) -> AnyResult<Option<RepoState>> {
         match &self.backing {
-            RecordBacking::ReadWrite(db) => self.load_repo_from(db, did),
+            RecordBacking::ReadWrite(db) => Self::load_repo_from(db, did),
             RecordBacking::ReadOnly(path) => {
                 let opts = readonly_opts();
                 let db = rocksdb::DB::open_for_read_only(&opts, path, false)
                     .with_context(|| format!("failed to reopen PDS record store at {path:?}"))?;
-                self.load_repo_from(&db, did)
+                Self::load_repo_from(&db, did)
             }
         }
     }
 
-    fn load_repo_from(&self, db: &rocksdb::DB, did: &str) -> AnyResult<Option<RepoState>> {
+    fn load_repo_from(db: &rocksdb::DB, did: &str) -> AnyResult<Option<RepoState>> {
         let prefix = record_prefix(did);
         let mut records = BTreeMap::new();
         // `prefix_iterator` without a configured `prefix_extractor` degrades to
@@ -245,33 +261,48 @@ impl PdsRecordStore {
                 .with_context(|| format!("corrupt PDS record for {did}/{collection}/{tid}"))?;
             records.insert((collection, tid), record);
         }
-        // "Never published" == no records for this DID. The `#atproto` key is
-        // held in memory (never in the DB — #910a H1), so a repo's existence is
-        // determined by its records, not by a stored key.
+        // "Never published" == no records for this DID.
         if records.is_empty() {
             return Ok(None);
         }
-        Ok(Some(RepoState { signing_key: self.atproto_signing_key.clone(), records }))
+        // A published repo always has a persisted signed commit (records and
+        // the commit that signs their MST root advance together atomically —
+        // see `put_record_and_commit`). If the commit is absent the store is
+        // inconsistent (e.g. a legacy pre-#910a-rework write); we cannot serve
+        // a keyless proof without it, so report "not published" rather than
+        // re-sign (the resolver holds no key by design).
+        let Some(commit_bytes) = db
+            .get(commit_key(did))
+            .context("PDS store commit read failed")?
+        else {
+            tracing::warn!(
+                did,
+                "PDS repo has records but no signed commit — refusing to serve (resolver holds no key)"
+            );
+            return Ok(None);
+        };
+        let commit = Commit::from_dag_cbor(&commit_bytes)
+            .with_context(|| format!("corrupt signed commit for {did}"))?;
+        Ok(Some(RepoState { records, commit }))
     }
 
-    /// Build the MST over all of a repo's records and return it with the
-    /// per-collection record-CID map (so callers can locate a target record).
-    fn build_tree(repo: &RepoState) -> Node {
+    /// Build the MST over a repo's record set. The MST is a deterministic,
+    /// keyless function of the record keys/CIDs, so this reproduces exactly the
+    /// tree whose root the persisted commit signs.
+    fn build_tree(records: &BTreeMap<(String, Tid), ModelRecord>) -> Node {
         // All records across all collections share one MST keyed by
         // `<collection>/<rkey>`. `Node::from_records` keys by Tid within one
-        // collection NSID, so when a repo holds multiple collections we build a
-        // per-collection subtree set is NOT how atproto works — atproto uses one
-        // tree over `<collection>/<rkey>` keys. Our records today are a single
-        // collection (`ai.hyprstream.model`), so build over that collection's
-        // Tid→CID map. Mixed-collection repos are a follow-up (#910b).
+        // collection NSID; our records today are a single collection
+        // (`ai.hyprstream.model`), so build over that collection's Tid→CID map.
+        // Mixed-collection repos are a follow-up (#910b).
         let mut by_tid: BTreeMap<Tid, hyprstream_pds::cid::Cid> = BTreeMap::new();
-        for ((collection, tid), rec) in &repo.records {
+        for ((collection, tid), rec) in records {
             // Single-collection assumption (see note above): use the record's
             // own collection NSID as the MST collection.
             let _ = collection;
             by_tid.insert(*tid, rec.cid());
         }
-        Node::from_records(hyprstream_pds::record::COLLECTION_NSID, &by_tid)
+        Node::from_records(COLLECTION_NSID, &by_tid)
     }
 }
 
@@ -283,17 +314,17 @@ fn readonly_opts() -> rocksdb::Options {
 
 /// Restrict the record-store directory to owner-only (0700) on unix.
 ///
-/// Defence in depth: even though the `#atproto` private key never lands in
-/// this DB (#910a H1), the record *values* are what the node signs CAR proofs
-/// over at read time — a store another local user could write would let them
-/// inject records the node then serves as authentic. On non-unix this is a
-/// no-op (the store path is expected to be an OS-managed private dir there).
+/// Defence in depth: the record *values* (and the signed commit) are what a
+/// resolver serves as authentic PDS state — a store another local user could
+/// write would let them inject records/commits the node then serves. On
+/// non-unix this is a no-op (the store path is expected to be an OS-managed
+/// private dir there).
 fn harden_store_dir(path: &Path) {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         // Best-effort: this is defence-in-depth (the private key never lands in
-        // this DB — H1 — and the path never resolves to /tmp — H2). If the chmod
+        // this DB, and the path never resolves to /tmp — H2). If the chmod
         // fails (e.g. the dir is owned by a different uid in a split-uid setup),
         // warn rather than hard-fail startup.
         if let Err(e) = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700)) {
@@ -308,21 +339,34 @@ fn harden_store_dir(path: &Path) {
 // PdsPublisher — the register/commit write side of #910a
 // ============================================================================
 
-/// Publishes/advances a repo's `ai.hyprstream.model` PDS record on this
-/// node, over a read-write [`PdsRecordStore`]. Constructed once by the
-/// registry service (the sole writer) and called from `handle_register` /
+/// Publishes/advances a repo's `ai.hyprstream.model` PDS record on this node,
+/// over a read-write [`PdsRecordStore`]. Constructed once by the registry
+/// service (the sole writer) and called from `handle_register` /
 /// `handle_commit_with_author`.
+///
+/// This is the **only** holder of the `#atproto` P-256 private key: it signs
+/// the repo's commit once, here, at write time, and persists the signed bytes.
+/// The resolver never sees the key.
 pub struct PdsPublisher {
     store: Arc<PdsRecordStore>,
     /// This node's own `did:key` identity — the `repo` at-uri authority for
     /// every record this node publishes (single-node, self-hosted PDS; a
     /// per-account DID scheme is out of scope for #910a).
     did: String,
+    /// This node's `#atproto` commit-signing key (P-256/ES256), sourced from
+    /// the shared `Es256SigningKeyStore` — the *same* key `did_document.rs`
+    /// publishes as the `#atproto` verification method. Held only here (the
+    /// writer); resolvers hold no key. Used to sign each commit exactly once.
+    signing_key: p256::ecdsa::SigningKey,
 }
 
 impl PdsPublisher {
-    pub fn new(store: Arc<PdsRecordStore>, did: String) -> Self {
-        Self { store, did }
+    pub fn new(
+        store: Arc<PdsRecordStore>,
+        did: String,
+        signing_key: p256::ecdsa::SigningKey,
+    ) -> Self {
+        Self { store, did, signing_key }
     }
 
     /// Publish (or advance) the `ai.hyprstream.model` record for `repo_id`,
@@ -331,7 +375,10 @@ impl PdsPublisher {
     /// The record's rkey is derived deterministically from `repo_id`
     /// (`PdsRecordStore::tid_for_repo`) and reused on every call, so this
     /// always *replaces* the existing record's value rather than creating a
-    /// new one — the atproto "pointer advance".
+    /// new one. The repo's MST is rebuilt over its full record set, a new
+    /// commit is signed **once** here (rev strictly advances; `prev` points at
+    /// the previous commit's CID — the atproto pointer advance), and the record
+    /// and signed commit are persisted together.
     ///
     /// Best-effort by design: the caller (registry service) should log and
     /// continue on error rather than fail the git operation that triggered
@@ -346,8 +393,44 @@ impl PdsPublisher {
             current_oid_cid,
             atproto_datetime_now(),
         )?;
+
+        // Load the existing repo state (records + previous signed commit) so we
+        // can rebuild the full MST and advance the commit pointer.
+        let existing = self.store.load_repo(&self.did)?;
+        let mut records = existing
+            .as_ref()
+            .map(|r| r.records.clone())
+            .unwrap_or_default();
+        records.insert((COLLECTION_NSID.to_owned(), tid), record.clone());
+
+        // Rebuild the MST (deterministic, keyless) over the full record set and
+        // sign the commit ONCE over its root.
+        let tree = PdsRecordStore::build_tree(&records);
+        let root = tree.root_cid();
+        let (rev, prev) = match existing.as_ref().map(|r| &r.commit) {
+            Some(prev_commit) => (next_rev(prev_commit.rev), Some(prev_commit.cid())),
+            None => (Tid::now(), None),
+        };
+        let unsigned = UnsignedCommit::new(self.did.clone(), root, rev, prev);
+        let commit = Commit::sign(&unsigned, &self.signing_key);
+
         self.store
-            .put_record(&self.did, hyprstream_pds::record::COLLECTION_NSID, tid, record)
+            .put_record_and_commit(&self.did, COLLECTION_NSID, tid, &record, &commit)
+    }
+}
+
+/// The next commit `rev`: the current wall-clock TID, or one past the previous
+/// rev if the clock has not advanced past it.
+///
+/// atproto requires `rev` to strictly increase across a repo's commits; two
+/// publishes within the same microsecond (or a clock that went backwards) must
+/// still advance.
+fn next_rev(prev: Tid) -> Tid {
+    let now = Tid::now();
+    if now > prev {
+        now
+    } else {
+        Tid::from_raw(prev.to_raw().saturating_add(1))
     }
 }
 
@@ -373,7 +456,8 @@ fn atproto_datetime_now() -> String {
 
 /// `RecordResolver` over a [`PdsRecordStore`]. Builds CAR proofs via the
 /// reused `hyprstream_pds::car::build_record_proof_car` — no CAR/MST/commit
-/// code is reinvented here.
+/// code is reinvented here, and **no signing happens on the read path**: the
+/// commit served in the proof is the one the writer signed at publish time.
 pub struct PdsRecordResolver {
     store: Arc<PdsRecordStore>,
 }
@@ -407,22 +491,15 @@ impl RecordResolver for PdsRecordResolver {
             return Ok(None);
         };
 
-        // Rebuild the MST + signed commit, then build the CAR proof for the
-        // target record (reusing the PDS CAR builder — #392).
-        let tree = PdsRecordStore::build_tree(&repo);
-        let root = tree.root_cid();
-        let unsigned = hyprstream_pds::commit::UnsignedCommit::new(
-            did.to_owned(),
-            root,
-            Tid::now(),
-            None,
-        );
-        let commit = Commit::sign(&unsigned, &repo.signing_key);
+        // Rebuild the MST (keyless) and serve the STORED signed commit — no
+        // re-signing. The proof's root is `commit.data`, which the rebuilt tree
+        // reproduces exactly (records + commit were persisted together).
+        let tree = PdsRecordStore::build_tree(&repo.records);
         let proof = tree
-            .proof(hyprstream_pds::record::COLLECTION_NSID, &tid)
+            .proof(COLLECTION_NSID, &tid)
             .ok_or_else(|| anyhow::anyhow!("record present but no MST proof — store inconsistent"))?;
         let (_root_data, node_blocks) = tree.to_node_data_with_blocks();
-        let car = build_record_proof_car(&commit, &proof, &node_blocks, &record);
+        let car = build_record_proof_car(&repo.commit, &proof, &node_blocks, &record);
 
         let uri = format!("at://{did}/{collection}/{rkey}");
         Ok(Some(RecordCarData { uri, car }))
@@ -432,9 +509,6 @@ impl RecordResolver for PdsRecordResolver {
         let Some(repo) = self.store.load_repo(did)? else {
             return Ok(None);
         };
-        if repo.records.is_empty() {
-            return Ok(None);
-        }
 
         // Full-repo CAR: a self-contained helper for the WHOLE repo (commit +
         // all MST nodes + all record blocks) does not exist in the PDS `car`
@@ -451,20 +525,12 @@ impl RecordResolver for PdsRecordResolver {
         let tid = *tid;
         let record = record.clone();
 
-        let tree = PdsRecordStore::build_tree(&repo);
-        let root = tree.root_cid();
-        let unsigned = hyprstream_pds::commit::UnsignedCommit::new(
-            did.to_owned(),
-            root,
-            Tid::now(),
-            None,
-        );
-        let commit = Commit::sign(&unsigned, &repo.signing_key);
+        let tree = PdsRecordStore::build_tree(&repo.records);
         let proof = tree
-            .proof(hyprstream_pds::record::COLLECTION_NSID, &tid)
+            .proof(COLLECTION_NSID, &tid)
             .ok_or_else(|| anyhow::anyhow!("repo record has no MST proof — store inconsistent"))?;
         let (_root_data, node_blocks) = tree.to_node_data_with_blocks();
-        let car = build_record_proof_car(&commit, &proof, &node_blocks, &record);
+        let car = build_record_proof_car(&repo.commit, &proof, &node_blocks, &record);
 
         let uri = format!("at://{did}/{collection}/{}", tid.encode());
         Ok(Some(RecordCarData { uri, car }))
@@ -475,68 +541,153 @@ impl RecordResolver for PdsRecordResolver {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod pds_store_tests {
     use super::*;
+    use hyprstream_pds::car::{parse_car_v1, verify_record_proof};
+    use p256::ecdsa::{SigningKey, VerifyingKey};
 
-    fn sample_record(oid_suffix: &str) -> ModelRecord {
-        ModelRecord::new(
-            "at://did:key:zTestNode",
-            format!("bafyreiexample{oid_suffix}0000000000000000000000000"),
-            "2026-06-23T12:34:56.789Z",
-        )
-        .expect("valid sample record")
+    /// A 40-hex-char (SHA-1-shaped) git OID for the publish path.
+    const SAMPLE_OID: &str = "1111111111111111111111111111111111111111";
+    const SAMPLE_OID_2: &str = "2222222222222222222222222222222222222222";
+    const DID: &str = "did:key:zTestNode";
+
+    /// Extract and decode the signed commit from a proof CAR (its single root).
+    fn commit_from_car(car: &[u8]) -> Commit {
+        let (roots, blocks) = parse_car_v1(car).expect("parse CAR");
+        let root = roots.first().copied().expect("CAR has a root commit");
+        let (_cid, bytes) = blocks
+            .iter()
+            .find(|(cid, _)| *cid == root)
+            .expect("commit block present");
+        Commit::from_dag_cbor(bytes).expect("decode commit")
+    }
+
+    /// Minimal single-threaded block_on so these tests don't need a full
+    /// `#[tokio::test]` runtime just to drive one `async_trait(?Send)` call.
+    fn block_on<F: std::future::Future>(fut: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("build current-thread runtime")
+            .block_on(fut)
     }
 
     #[test]
-    fn put_then_load_round_trips_through_rocksdb() {
+    fn keyless_read_serves_writer_signed_commit() {
+        // The writer signs once; a resolver constructed with NO key returns a
+        // proof whose commit verifies against the published P-256 key.
         let dir = tempfile::tempdir().expect("tempdir");
-        let sk = p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
-        let store = PdsRecordStore::open(dir.path(), sk.clone()).expect("open");
-        let tid = Tid::now();
-        let did = "did:key:zTestNode";
+        let sk = SigningKey::random(&mut rand::rngs::OsRng);
+        let vk: VerifyingKey = *sk.verifying_key();
 
-        store
-            .put_record(did, "ai.hyprstream.model", tid, sample_record("a"))
-            .expect("put_record");
+        let store = Arc::new(PdsRecordStore::open(dir.path()).expect("open rw"));
+        let publisher = PdsPublisher::new(Arc::clone(&store), DID.to_owned(), sk);
+        publisher.publish("repo-a", SAMPLE_OID).expect("publish");
 
-        let resolver = PdsRecordResolver::new(Arc::new(store));
-        let got = tokio_test_block_on(resolver.resolve_record(did, "ai.hyprstream.model", &tid.encode()))
-            .expect("resolve_record ok")
+        // Resolver holds no key at all.
+        let resolver = PdsRecordResolver::new(Arc::clone(&store));
+        let tid = PdsRecordStore::tid_for_repo("repo-a");
+        let got = block_on(resolver.resolve_record(DID, COLLECTION_NSID, &tid.encode()))
+            .expect("resolve ok")
             .expect("record present");
-        assert_eq!(got.uri, format!("at://{did}/ai.hyprstream.model/{}", tid.encode()));
+
+        let commit = commit_from_car(&got.car);
+        commit
+            .verify(&vk)
+            .expect("writer-signed commit must verify against the published #atproto key");
+    }
+
+    #[test]
+    fn publish_read_full_proof_verifies() {
+        // End-to-end: publish → getRecord → the FULL record proof (commit sig +
+        // MST path + record CID) verifies keyless against the published key.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sk = SigningKey::random(&mut rand::rngs::OsRng);
+        let vk: VerifyingKey = *sk.verifying_key();
+
+        let store = Arc::new(PdsRecordStore::open(dir.path()).expect("open rw"));
+        let publisher = PdsPublisher::new(Arc::clone(&store), DID.to_owned(), sk);
+        publisher.publish("repo-a", SAMPLE_OID).expect("publish");
+
+        // Reconstruct the proof the same way the resolver does (store holds no
+        // key), and run the offline verifier against the published key.
+        let repo = store.load_repo(DID).expect("load ok").expect("repo present");
+        let tid = PdsRecordStore::tid_for_repo("repo-a");
+        let record = repo
+            .records
+            .get(&(COLLECTION_NSID.to_owned(), tid))
+            .cloned()
+            .expect("record present");
+        let tree = PdsRecordStore::build_tree(&repo.records);
+        let proof = tree.proof(COLLECTION_NSID, &tid).expect("proof");
+        verify_record_proof(&repo.commit, &vk, &proof, &record)
+            .expect("full keyless proof must verify");
+    }
+
+    #[test]
+    fn pointer_advance_bumps_rev_and_links_prev() {
+        // A re-publish must advance the commit: a new rev and prev = the old
+        // commit's CID.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sk = SigningKey::random(&mut rand::rngs::OsRng);
+        let store = Arc::new(PdsRecordStore::open(dir.path()).expect("open rw"));
+        let publisher = PdsPublisher::new(Arc::clone(&store), DID.to_owned(), sk);
+
+        publisher.publish("repo-a", SAMPLE_OID).expect("publish 1");
+        let first = store.load_repo(DID).expect("load").expect("repo").commit;
+        assert!(first.prev.is_none(), "genesis commit has no prev");
+
+        publisher.publish("repo-a", SAMPLE_OID_2).expect("publish 2");
+        let second = store.load_repo(DID).expect("load").expect("repo").commit;
+        assert_eq!(
+            second.prev,
+            Some(first.cid()),
+            "the advanced commit must link the previous commit"
+        );
+        assert!(second.rev > first.rev, "rev must strictly advance");
     }
 
     #[test]
     fn readonly_store_survives_restart_and_sees_writer_updates() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let did = "did:key:zTestNode2";
-        let sk = p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
-        let tid = Tid::now();
+        let sk = SigningKey::random(&mut rand::rngs::OsRng);
+        let vk: VerifyingKey = *sk.verifying_key();
 
         {
-            let store = PdsRecordStore::open(dir.path(), sk.clone()).expect("open rw");
-            store
-                .put_record(did, "ai.hyprstream.model", tid, sample_record("b"))
-                .expect("put_record");
+            let store = Arc::new(PdsRecordStore::open(dir.path()).expect("open rw"));
+            let publisher = PdsPublisher::new(Arc::clone(&store), DID.to_owned(), sk);
+            publisher.publish("repo-b", SAMPLE_OID).expect("publish");
             // Writer handle dropped here — simulates a process restart.
         }
 
-        let ro = PdsRecordStore::open_readonly(dir.path(), sk).expect("open ro");
-        let resolver = PdsRecordResolver::new(Arc::new(ro));
-        let got = tokio_test_block_on(resolver.resolve_repo(did))
+        let ro = Arc::new(PdsRecordStore::open_readonly(dir.path()).expect("open ro"));
+        let resolver = PdsRecordResolver::new(Arc::clone(&ro));
+        let got = block_on(resolver.resolve_repo(DID))
             .expect("resolve_repo ok")
             .expect("repo present after reopen");
-        assert!(got.uri.starts_with(&format!("at://{did}/")));
+        assert!(got.uri.starts_with(&format!("at://{DID}/")));
+        // The signed commit survived the reopen and still verifies.
+        commit_from_car(&got.car)
+            .verify(&vk)
+            .expect("commit persisted across restart must verify");
     }
 
     #[test]
     fn readonly_store_rejects_writes() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let sk = p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
         // Create the directory with a real DB first so open_readonly succeeds.
-        drop(PdsRecordStore::open(dir.path(), sk.clone()).expect("open rw"));
+        drop(PdsRecordStore::open(dir.path()).expect("open rw"));
 
-        let ro = PdsRecordStore::open_readonly(dir.path(), sk).expect("open ro");
+        let ro = PdsRecordStore::open_readonly(dir.path()).expect("open ro");
+        let record = ModelRecord::new(
+            "at://did:key:zX",
+            format!("bafyreiexample{SAMPLE_OID}"),
+            "2026-06-23T12:34:56.789Z",
+        )
+        .expect("record");
+        let sk = SigningKey::random(&mut rand::rngs::OsRng);
+        let tree = PdsRecordStore::build_tree(&BTreeMap::new());
+        let unsigned = UnsignedCommit::new("did:key:zX", tree.root_cid(), Tid::now(), None);
+        let commit = Commit::sign(&unsigned, &sk);
         let err = ro
-            .put_record("did:key:zX", "ai.hyprstream.model", Tid::now(), sample_record("c"))
+            .put_record_and_commit("did:key:zX", COLLECTION_NSID, Tid::now(), &record, &commit)
             .unwrap_err();
         assert!(err.to_string().contains("read-only"));
     }
@@ -548,14 +699,5 @@ mod pds_store_tests {
         assert_eq!(first, second, "the same repo must always get the same rkey");
         let other = PdsRecordStore::tid_for_repo("repo-b");
         assert_ne!(first, other, "distinct repos must not alias onto one rkey");
-    }
-
-    /// Minimal single-threaded block_on so these tests don't need a full
-    /// `#[tokio::test]` runtime just to drive one `async_trait(?Send)` call.
-    fn tokio_test_block_on<F: std::future::Future>(fut: F) -> F::Output {
-        tokio::runtime::Builder::new_current_thread()
-            .build()
-            .expect("build current-thread runtime")
-            .block_on(fut)
     }
 }

--- a/crates/hyprstream/src/services/discovery.rs
+++ b/crates/hyprstream/src/services/discovery.rs
@@ -10,15 +10,16 @@ use crate::services::generated::policy_client::PolicyCheck;
 use async_trait::async_trait;
 
 use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use anyhow::{anyhow, bail, Context as _, Result as AnyResult};
 use hyprstream_discovery::{RecordCarData, RecordResolver};
 use hyprstream_pds::car::build_record_proof_car;
 use hyprstream_pds::commit::Commit;
 use hyprstream_pds::mst::Node;
 use hyprstream_pds::record::ModelRecord;
 use hyprstream_pds::tid::Tid;
-use parking_lot::RwLock;
 
 // Re-export the generated discovery client types from our local generated module
 // (hyprstream still needs its own discovery_client for the DiscoveryClient type)
@@ -77,26 +78,106 @@ struct RepoState {
     records: BTreeMap<(String, Tid), ModelRecord>,
 }
 
-/// In-memory PDS record store keyed by repo DID.
+// ── RocksDB key scheme ───────────────────────────────────────────────────────
+//
+// DIDs and collection NSIDs never contain NUL bytes, so `\0` is a safe,
+// unambiguous field separator for compound keys (same idea as the delimited
+// keys `RocksDbUserStore` uses, just with a compound suffix here).
+//
+//   sk\0{did}                              -> 32-byte P-256 signing-key seed
+//   rk\0{did}\0{collection}\0{tid}         -> canonical DAG-CBOR record bytes
+//   tid\0{repo_id}                         -> the TID (13-char string) minted
+//                                              for that repo's *one* stable
+//                                              record key (see `tid_for_repo`)
+
+fn signing_key_key(did: &str) -> Vec<u8> {
+    format!("sk\0{did}").into_bytes()
+}
+
+fn record_prefix(did: &str) -> Vec<u8> {
+    format!("rk\0{did}\0").into_bytes()
+}
+
+fn record_key(did: &str, collection: &str, tid: Tid) -> Vec<u8> {
+    format!("rk\0{did}\0{collection}\0{}", tid.encode()).into_bytes()
+}
+
+fn repo_tid_key(repo_id: &str) -> Vec<u8> {
+    format!("tid\0{repo_id}").into_bytes()
+}
+
+/// Split a full record key back into `(collection, tid)`, given the `did` it
+/// was built for.
+fn parse_record_key(key: &[u8], did: &str) -> AnyResult<(String, Tid)> {
+    let prefix = record_prefix(did);
+    let rest = key
+        .strip_prefix(prefix.as_slice())
+        .ok_or_else(|| anyhow!("record key missing expected prefix for {did:?}"))?;
+    let rest = std::str::from_utf8(rest).context("record key suffix is not UTF-8")?;
+    let (collection, tid_str) = rest
+        .split_once('\0')
+        .ok_or_else(|| anyhow!("record key missing collection/tid separator"))?;
+    let tid = Tid::parse(tid_str)?;
+    Ok((collection.to_owned(), tid))
+}
+
+/// Durable, RocksDB-backed PDS record store keyed by repo DID.
 ///
-/// This is the per-account record store the DiscoveryService resolves against.
-/// It is deliberately in-memory (the `hyprstream-pds` crate is storage-agnostic
-/// by design); persistence is a follow-up. The publishing side (writing records
-/// into this store when a model is registered + the atproto pointer advanced,
-/// #394) is wired separately — this type is the read side #431 needs.
-#[derive(Default)]
+/// This is the per-account record store the DiscoveryService resolves against,
+/// and that the registry service's register/commit paths publish into (#910a).
+/// Persistence follows the same pattern as `RocksDbUserStore`
+/// (`auth/rocksdb_store.rs`): a single `rocksdb::DB` at a well-known directory,
+/// opened read-write by the *one* process that publishes, and read-only by
+/// resolvers.
+///
+/// RocksDB allows exactly one read-write handle per directory; on a single
+/// node the registry service (the publisher) is the sole writer, and the
+/// discovery service (the resolver) opens the same directory read-only —
+/// mirroring `RocksDbUserStore::open` / `open_readonly`. A read-only handle
+/// snapshots the manifest at open time, so [`PdsRecordStore::open_readonly`]
+/// callers that need a live view reopen per read (see [`RecordBacking::ReadOnly`]).
 pub struct PdsRecordStore {
-    repos: RwLock<BTreeMap<String, RepoState>>,
+    backing: RecordBacking,
+}
+
+enum RecordBacking {
+    /// The sole writer: one long-lived, read-write RocksDB handle.
+    ReadWrite(rocksdb::DB),
+    /// A resolver: no handle is held between calls — each read opens a fresh
+    /// `open_for_read_only` handle so writes from the publisher process become
+    /// visible without a restart.
+    ReadOnly(PathBuf),
 }
 
 impl PdsRecordStore {
-    pub fn new() -> Self {
-        Self::default()
+    /// Open (or create) the durable store at `path` for read-write access.
+    /// Exactly one process should hold this — the publisher (registry
+    /// service). See the type-level docs for the single-writer rationale.
+    pub fn open(path: &Path) -> AnyResult<Self> {
+        std::fs::create_dir_all(path)
+            .with_context(|| format!("failed to create PDS store dir {path:?}"))?;
+        let mut opts = rocksdb::Options::default();
+        opts.create_if_missing(true);
+        let db = rocksdb::DB::open(&opts, path)
+            .with_context(|| format!("failed to open PDS record store (rw) at {path:?}"))?;
+        Ok(Self { backing: RecordBacking::ReadWrite(db) })
+    }
+
+    /// Open the store read-only at `path`, for resolvers that never write
+    /// (the discovery service). Verifies the directory opens successfully now
+    /// (surfacing a missing/corrupt store at startup) but does not hold the
+    /// handle — see the type-level docs.
+    pub fn open_readonly(path: &Path) -> AnyResult<Self> {
+        let opts = readonly_opts();
+        let _probe = rocksdb::DB::open_for_read_only(&opts, path, false)
+            .with_context(|| format!("failed to open PDS record store (ro) at {path:?}"))?;
+        Ok(Self { backing: RecordBacking::ReadOnly(path.to_path_buf()) })
     }
 
     /// Insert/replace a record for `did` under `collection` at `tid`, using
     /// `signing_key` as the account's `#atproto` commit key. Used by the
-    /// publishing path and by tests.
+    /// publishing path and by tests. Fails if this store was opened
+    /// read-only.
     pub fn put_record(
         &self,
         did: &str,
@@ -104,15 +185,81 @@ impl PdsRecordStore {
         tid: Tid,
         record: ModelRecord,
         signing_key: p256::ecdsa::SigningKey,
-    ) {
-        let mut repos = self.repos.write();
-        let repo = repos.entry(did.to_owned()).or_insert_with(|| RepoState {
-            signing_key: signing_key.clone(),
-            records: BTreeMap::new(),
-        });
-        // Keep the most recently supplied signing key for the account.
-        repo.signing_key = signing_key;
-        repo.records.insert((collection.to_owned(), tid), record);
+    ) -> AnyResult<()> {
+        let RecordBacking::ReadWrite(db) = &self.backing else {
+            bail!("PdsRecordStore::put_record called on a read-only store");
+        };
+        let mut batch = rocksdb::WriteBatch::default();
+        batch.put(signing_key_key(did), signing_key.to_bytes().as_slice());
+        batch.put(record_key(did, collection, tid), record.to_dag_cbor());
+        db.write(batch).context("PDS record store write failed")?;
+        Ok(())
+    }
+
+    /// Return the TID previously minted for `repo_id`'s single stable record
+    /// key, or mint and persist a new one.
+    ///
+    /// A record's rkey is assigned once at first publish and never changes —
+    /// later publishes for the same `repo_id` replace the record's *value* at
+    /// that same `(collection, tid)` key (the atproto "pointer advance").
+    /// Fails if this store was opened read-only.
+    pub fn tid_for_repo(&self, repo_id: &str) -> AnyResult<Tid> {
+        let RecordBacking::ReadWrite(db) = &self.backing else {
+            bail!("PdsRecordStore::tid_for_repo called on a read-only store");
+        };
+        let key = repo_tid_key(repo_id);
+        if let Some(existing) = db.get(&key).context("PDS store tid lookup failed")? {
+            let s = std::str::from_utf8(&existing).context("stored tid is not UTF-8")?;
+            return Tid::parse(s).context("stored tid is malformed");
+        }
+        let tid = Tid::now();
+        db.put(&key, tid.encode().as_bytes())
+            .context("PDS store tid persist failed")?;
+        Ok(tid)
+    }
+
+    /// Load the full record set + signing key for `did`, or `None` if the
+    /// account has never published.
+    fn load_repo(&self, did: &str) -> AnyResult<Option<RepoState>> {
+        match &self.backing {
+            RecordBacking::ReadWrite(db) => Self::load_repo_from(db, did),
+            RecordBacking::ReadOnly(path) => {
+                let opts = readonly_opts();
+                let db = rocksdb::DB::open_for_read_only(&opts, path, false)
+                    .with_context(|| format!("failed to reopen PDS record store at {path:?}"))?;
+                Self::load_repo_from(&db, did)
+            }
+        }
+    }
+
+    fn load_repo_from(db: &rocksdb::DB, did: &str) -> AnyResult<Option<RepoState>> {
+        let Some(sk_bytes) = db
+            .get(signing_key_key(did))
+            .context("PDS store signing-key lookup failed")?
+        else {
+            return Ok(None);
+        };
+        if sk_bytes.len() != 32 {
+            bail!("corrupt PDS signing key for {did:?}: expected 32 bytes, got {}", sk_bytes.len());
+        }
+        let signing_key = p256::ecdsa::SigningKey::from_bytes(sk_bytes.as_slice().into())
+            .map_err(|e| anyhow!("corrupt PDS signing key for {did:?}: {e}"))?;
+
+        let prefix = record_prefix(did);
+        let mut records = BTreeMap::new();
+        // `prefix_iterator` without a configured `prefix_extractor` degrades to
+        // a full forward scan from `prefix` — bound it manually.
+        for item in db.prefix_iterator(&prefix) {
+            let (key, value) = item.context("PDS store record scan failed")?;
+            if !key.starts_with(prefix.as_slice()) {
+                break;
+            }
+            let (collection, tid) = parse_record_key(&key, did)?;
+            let record = ModelRecord::from_dag_cbor(&value)
+                .with_context(|| format!("corrupt PDS record for {did}/{collection}/{tid}"))?;
+            records.insert((collection, tid), record);
+        }
+        Ok(Some(RepoState { signing_key, records }))
     }
 
     /// Build the MST over all of a repo's records and return it with the
@@ -124,7 +271,7 @@ impl PdsRecordStore {
         // per-collection subtree set is NOT how atproto works — atproto uses one
         // tree over `<collection>/<rkey>` keys. Our records today are a single
         // collection (`ai.hyprstream.model`), so build over that collection's
-        // Tid→CID map. Mixed-collection repos are a follow-up.
+        // Tid→CID map. Mixed-collection repos are a follow-up (#910b).
         let mut by_tid: BTreeMap<Tid, hyprstream_pds::cid::Cid> = BTreeMap::new();
         for ((collection, tid), rec) in &repo.records {
             // Single-collection assumption (see note above): use the record's
@@ -134,6 +281,81 @@ impl PdsRecordStore {
         }
         Node::from_records(hyprstream_pds::record::COLLECTION_NSID, &by_tid)
     }
+}
+
+fn readonly_opts() -> rocksdb::Options {
+    let mut opts = rocksdb::Options::default();
+    opts.create_if_missing(false);
+    opts
+}
+
+// ============================================================================
+// PdsPublisher — the register/commit write side of #910a
+// ============================================================================
+
+/// Publishes/advances a repo's `ai.hyprstream.model` PDS record on this
+/// node, over a read-write [`PdsRecordStore`]. Constructed once by the
+/// registry service (the sole writer) and called from `handle_register` /
+/// `handle_commit_with_author`.
+pub struct PdsPublisher {
+    store: Arc<PdsRecordStore>,
+    /// This node's own `did:key` identity — the `repo` at-uri authority for
+    /// every record this node publishes (single-node, self-hosted PDS; a
+    /// per-account DID scheme is out of scope for #910a).
+    did: String,
+    /// The `#atproto` commit-signing key (P-256/ES256, classical).
+    signing_key: p256::ecdsa::SigningKey,
+}
+
+impl PdsPublisher {
+    pub fn new(store: Arc<PdsRecordStore>, did: String, signing_key: p256::ecdsa::SigningKey) -> Self {
+        Self { store, did, signing_key }
+    }
+
+    /// Publish (or advance) the `ai.hyprstream.model` record for `repo_id`,
+    /// pointing it at `current_oid_hex` (a git OID, hex-encoded).
+    ///
+    /// The record's rkey is minted once per `repo_id` and reused on every
+    /// call (`PdsRecordStore::tid_for_repo`), so this always *replaces* the
+    /// existing record's value rather than creating a new one — the atproto
+    /// "pointer advance".
+    ///
+    /// Best-effort by design: the caller (registry service) should log and
+    /// continue on error rather than fail the git operation that triggered
+    /// this — the local git commit is the durable source of truth; a missed
+    /// PDS publish is caught up by the next successful one (same
+    /// eventual-consistency contract `git::promote` documents).
+    pub fn publish(&self, repo_id: &str, current_oid_hex: &str) -> AnyResult<()> {
+        let tid = self.store.tid_for_repo(repo_id)?;
+        let current_oid_cid = git_oid_to_cid_string(current_oid_hex)?;
+        let record = ModelRecord::new(
+            format!("at://{}", self.did),
+            current_oid_cid,
+            atproto_datetime_now(),
+        )?;
+        self.store
+            .put_record(&self.did, hyprstream_pds::record::COLLECTION_NSID, tid, record, self.signing_key.clone())
+    }
+}
+
+/// Encode a git OID (hex string, SHA-1 or SHA-256) as a `format: "cid"`
+/// string for `ModelRecord::currentOid`.
+///
+/// TODO(#395): this is a placeholder encoding (a CIDv1 `raw` codec over the
+/// OID's raw bytes, i.e. a *hash of the OID*, not an identity-preserving
+/// encoding of it) — good enough to be deterministic and format-valid today,
+/// but the real git-OID↔CID grammar belongs to the CID encoder work tracked
+/// there. Once that lands, swap this call for the real encoder; nothing else
+/// in the publish path needs to change.
+fn git_oid_to_cid_string(oid_hex: &str) -> AnyResult<String> {
+    let oid_bytes = hex::decode(oid_hex).with_context(|| format!("git OID {oid_hex:?} is not valid hex"))?;
+    Ok(hyprstream_pds::cid::Cid::from_raw(&oid_bytes).encode())
+}
+
+/// The current UTC time in the atproto `datetime` lexicon format
+/// (ISO-8601, millisecond precision, trailing `Z`).
+fn atproto_datetime_now() -> String {
+    chrono::Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string()
 }
 
 /// `RecordResolver` over a [`PdsRecordStore`]. Builds CAR proofs via the
@@ -164,8 +386,7 @@ impl RecordResolver for PdsRecordResolver {
             Err(_) => return Ok(None),
         };
 
-        let repos = self.store.repos.read();
-        let Some(repo) = repos.get(did) else {
+        let Some(repo) = self.store.load_repo(did)? else {
             return Ok(None);
         };
         let key = (collection.to_owned(), tid);
@@ -175,7 +396,7 @@ impl RecordResolver for PdsRecordResolver {
 
         // Rebuild the MST + signed commit, then build the CAR proof for the
         // target record (reusing the PDS CAR builder — #392).
-        let tree = PdsRecordStore::build_tree(repo);
+        let tree = PdsRecordStore::build_tree(&repo);
         let root = tree.root_cid();
         let unsigned = hyprstream_pds::commit::UnsignedCommit::new(
             did.to_owned(),
@@ -195,8 +416,7 @@ impl RecordResolver for PdsRecordResolver {
     }
 
     async fn resolve_repo(&self, did: &str) -> anyhow::Result<Option<RecordCarData>> {
-        let repos = self.store.repos.read();
-        let Some(repo) = repos.get(did) else {
+        let Some(repo) = self.store.load_repo(did)? else {
             return Ok(None);
         };
         if repo.records.is_empty() {
@@ -218,7 +438,7 @@ impl RecordResolver for PdsRecordResolver {
         let tid = *tid;
         let record = record.clone();
 
-        let tree = PdsRecordStore::build_tree(repo);
+        let tree = PdsRecordStore::build_tree(&repo);
         let root = tree.root_cid();
         let unsigned = hyprstream_pds::commit::UnsignedCommit::new(
             did.to_owned(),
@@ -235,5 +455,96 @@ impl RecordResolver for PdsRecordResolver {
 
         let uri = format!("at://{did}/{collection}/{}", tid.encode());
         Ok(Some(RecordCarData { uri, car }))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod pds_store_tests {
+    use super::*;
+
+    fn sample_record(oid_suffix: &str) -> ModelRecord {
+        ModelRecord::new(
+            "at://did:key:zTestNode",
+            format!("bafyreiexample{oid_suffix}0000000000000000000000000"),
+            "2026-06-23T12:34:56.789Z",
+        )
+        .expect("valid sample record")
+    }
+
+    #[test]
+    fn put_then_load_round_trips_through_rocksdb() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = PdsRecordStore::open(dir.path()).expect("open");
+        let sk = p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
+        let tid = Tid::now();
+        let did = "did:key:zTestNode";
+
+        store
+            .put_record(did, "ai.hyprstream.model", tid, sample_record("a"), sk.clone())
+            .expect("put_record");
+
+        let resolver = PdsRecordResolver::new(Arc::new(store));
+        let got = tokio_test_block_on(resolver.resolve_record(did, "ai.hyprstream.model", &tid.encode()))
+            .expect("resolve_record ok")
+            .expect("record present");
+        assert_eq!(got.uri, format!("at://{did}/ai.hyprstream.model/{}", tid.encode()));
+    }
+
+    #[test]
+    fn readonly_store_survives_restart_and_sees_writer_updates() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let did = "did:key:zTestNode2";
+        let sk = p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
+        let tid = Tid::now();
+
+        {
+            let store = PdsRecordStore::open(dir.path()).expect("open rw");
+            store
+                .put_record(did, "ai.hyprstream.model", tid, sample_record("b"), sk)
+                .expect("put_record");
+            // Writer handle dropped here — simulates a process restart.
+        }
+
+        let ro = PdsRecordStore::open_readonly(dir.path()).expect("open ro");
+        let resolver = PdsRecordResolver::new(Arc::new(ro));
+        let got = tokio_test_block_on(resolver.resolve_repo(did))
+            .expect("resolve_repo ok")
+            .expect("repo present after reopen");
+        assert!(got.uri.starts_with(&format!("at://{did}/")));
+    }
+
+    #[test]
+    fn readonly_store_rejects_writes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Create the directory with a real DB first so open_readonly succeeds.
+        drop(PdsRecordStore::open(dir.path()).expect("open rw"));
+
+        let ro = PdsRecordStore::open_readonly(dir.path()).expect("open ro");
+        let sk = p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
+        let err = ro
+            .put_record("did:key:zX", "ai.hyprstream.model", Tid::now(), sample_record("c"), sk)
+            .unwrap_err();
+        assert!(err.to_string().contains("read-only"));
+    }
+
+    #[test]
+    fn tid_for_repo_is_stable_across_calls() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = PdsRecordStore::open(dir.path()).expect("open");
+        let first = store.tid_for_repo("repo-a").expect("first mint");
+        let second = store.tid_for_repo("repo-a").expect("second lookup");
+        assert_eq!(first, second, "the same repo must always get the same rkey");
+        let other = store.tid_for_repo("repo-b").expect("different repo");
+        assert_ne!(first, other);
+    }
+
+    /// Minimal single-threaded block_on so these tests don't need a full
+    /// `#[tokio::test]` runtime just to drive one `async_trait(?Send)` call.
+    fn tokio_test_block_on<F: std::future::Future>(fut: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("build current-thread runtime")
+            .block_on(fut)
     }
 }

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -548,24 +548,40 @@ fn create_registry_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawn
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
     let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("registry"))?;
 
-    // #910a — the registry service is the sole PDS-record writer: it opens
-    // the durable store read-write and publishes on register/commit. This
-    // node's `did:key` identity (the record `repo` at-uri authority) is
-    // derived from the node's own root Ed25519 key — the same identity
-    // TLS endorsement uses ("a node-level trust assertion, not specific to
-    // any per-service key"). The `#atproto` commit-signing key is a
-    // dedicated, persisted P-256 key (classical — atproto has no PQ variant).
-    // Best-effort: any failure here disables PDS publish with a warning rather
-    // than failing the registry. The `#atproto` key is loaded from the secrets
-    // dir and handed to the store in memory — it is never persisted into the
-    // record DB (#910a H1). Paths fail closed rather than fall back to /tmp (H2).
+    // #910a — the registry service is the sole PDS-record writer AND the sole
+    // holder of the `#atproto` private key: it opens the durable store
+    // read-write and, on register/commit, signs the repo's commit ONCE and
+    // persists the signed bytes. Reads (the discovery service) are keyless.
+    // This node's `did:key` identity (the record `repo` at-uri authority) is
+    // derived from the node's own root Ed25519 key — the same identity TLS
+    // endorsement uses ("a node-level trust assertion, not specific to any
+    // per-service key"). The `#atproto` commit-signing key is the *active* key
+    // from the shared `Es256SigningKeyStore` — the same P-256 key
+    // `oauth::did_document` publishes as the `#atproto` verification method, so
+    // the writer and the published key are one source of truth (classical —
+    // atproto has no PQ variant). Best-effort: any failure here disables PDS
+    // publish with a warning rather than failing the registry. The key lives
+    // only in the writer's memory — never in the record DB (#910a H1). Paths
+    // fail closed rather than fall back to /tmp (H2).
     let pds_publisher = (|| -> anyhow::Result<crate::services::discovery::PdsPublisher> {
         let store_dir = pds_store_dir()?;
-        let atproto_key =
-            crate::auth::identity_store::load_or_generate_atproto_signing_key(&credentials_dir()?)?;
-        let store = crate::services::discovery::PdsRecordStore::open(&store_dir, atproto_key)?;
+        let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir();
+        let es256_store =
+            crate::auth::key_rotation::global_es256_key_store(&secrets_dir, &config.oauth);
+        // `active_key` is async (tokio RwLock); resolve it once here on the
+        // current runtime. `block_in_place` avoids stalling a worker reactor.
+        let active = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(es256_store.active_key())
+        })
+        .ok_or_else(|| anyhow::anyhow!("no active ES256 #atproto key for PDS publish"))?;
+        let atproto_key: p256::ecdsa::SigningKey = (*active).clone();
+        let store = crate::services::discovery::PdsRecordStore::open(&store_dir)?;
         let node_did = hyprstream_rpc::did_key::ed25519_to_did_key(&ctx.verifying_key().to_bytes());
-        Ok(crate::services::discovery::PdsPublisher::new(Arc::new(store), node_did))
+        Ok(crate::services::discovery::PdsPublisher::new(
+            Arc::new(store),
+            node_did,
+            atproto_key,
+        ))
     })()
     .map_err(|e| tracing::warn!("PDS publish disabled: {e}"))
     .ok();
@@ -1580,9 +1596,8 @@ fn create_tui_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
 /// the service manager will retry.
 fn open_pds_store_readonly(
     dir: &std::path::Path,
-    atproto_key: p256::ecdsa::SigningKey,
 ) -> anyhow::Result<crate::services::discovery::PdsRecordStore> {
-    match crate::services::discovery::PdsRecordStore::open_readonly(dir, atproto_key.clone()) {
+    match crate::services::discovery::PdsRecordStore::open_readonly(dir) {
         Ok(store) => Ok(store),
         Err(orig) => {
             // Bootstrap the DB files by briefly opening read-write, then retry
@@ -1590,10 +1605,10 @@ fn open_pds_store_readonly(
             // lock, or the path is corrupt), surface BOTH errors so the real
             // cause is visible rather than masked by the retry (#910a, fable M3).
             drop(
-                crate::services::discovery::PdsRecordStore::open(dir, atproto_key.clone())
+                crate::services::discovery::PdsRecordStore::open(dir)
                     .with_context(|| format!("read-only open failed ({orig}); bootstrap open also failed"))?,
             );
-            crate::services::discovery::PdsRecordStore::open_readonly(dir, atproto_key)
+            crate::services::discovery::PdsRecordStore::open_readonly(dir)
         }
     }
 }
@@ -1625,18 +1640,16 @@ fn create_discovery_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spaw
 
     // #431 — record resolver backing getRecord/getRepo, over the durable
     // RocksDB-backed PDS record store (#910a). The registry service is the
-    // sole writer (it opens the same directory read-write and publishes on
-    // register/commit — see `create_registry_service`); this factory opens
-    // the directory read-only, matching `RocksDbUserStore::open_readonly`.
-    // The `#atproto` commit key is loaded from the secrets dir (the same one
-    // the registry/writer uses) and held in memory to sign CAR proofs — it is
-    // never read from the record DB (#910a H1). In systemd/k8s this is a
-    // read-only, pre-provisioned credential; all replicas must share the same
-    // key so proofs verify consistently.
-    let atproto_key =
-        crate::auth::identity_store::load_or_generate_atproto_signing_key(&credentials_dir()?)?;
+    // sole writer (it opens the same directory read-write, signs each commit
+    // ONCE and persists it — see `create_registry_service`); this factory
+    // opens the directory read-only, matching `RocksDbUserStore::open_readonly`.
+    // The resolver holds **no signing key** at all: reads are keyless (rebuild
+    // the deterministic MST, load the writer's already-signed commit, serve a
+    // proof). This is the #910a security fix — a read path that re-signed a
+    // commit on every `getRecord` (and so needed the private key) was the root
+    // of the key-exposure problem; atproto never re-signs on read.
     let pds_store = std::sync::Arc::new(
-        open_pds_store_readonly(&pds_store_dir()?, atproto_key)
+        open_pds_store_readonly(&pds_store_dir()?)
             .context("failed to open PDS record store (read-only)")?,
     );
     let record_resolver = crate::services::discovery::PdsRecordResolver::new(pds_store);

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -96,6 +96,26 @@ fn credentials_dir() -> std::path::PathBuf {
         })
 }
 
+/// Resolve the on-disk directory for the durable PDS record store (#910a).
+///
+/// A single RocksDB database lives here, matching `RocksDbUserStore`'s
+/// `<config_dir>/users.db` convention. The registry service (the sole
+/// publisher) opens it read-write; the discovery service (the resolver)
+/// opens it read-only — see `services::discovery::PdsRecordStore`.
+fn pds_store_dir() -> std::path::PathBuf {
+    if let Ok(p) = std::env::var("HYPRSTREAM__PDS__STORE_PATH") {
+        return std::path::PathBuf::from(p);
+    }
+    HyprConfig::load()
+        .map(|c| c.config_dir().join("pds-store"))
+        .unwrap_or_else(|_| {
+            dirs::config_dir()
+                .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
+                .join("hyprstream")
+                .join("pds-store")
+        })
+}
+
 /// Resolve the CA-signed JWT used to register a service's signing key.
 ///
 /// Fail-closed (issue #441): returns the JWT (preferring one already in the
@@ -516,6 +536,34 @@ fn create_registry_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawn
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
     let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("registry"))?;
 
+    // #910a — the registry service is the sole PDS-record writer: it opens
+    // the durable store read-write and publishes on register/commit. This
+    // node's `did:key` identity (the record `repo` at-uri authority) is
+    // derived from the node's own root Ed25519 key — the same identity
+    // TLS endorsement uses ("a node-level trust assertion, not specific to
+    // any per-service key"). The `#atproto` commit-signing key is a
+    // dedicated, persisted P-256 key (classical — atproto has no PQ variant).
+    let pds_publisher = match crate::services::discovery::PdsRecordStore::open(&pds_store_dir()) {
+        Ok(store) => {
+            let node_did = hyprstream_rpc::did_key::ed25519_to_did_key(&ctx.verifying_key().to_bytes());
+            match crate::auth::identity_store::load_or_generate_atproto_signing_key(&credentials_dir()) {
+                Ok(atproto_key) => Some(crate::services::discovery::PdsPublisher::new(
+                    Arc::new(store),
+                    node_did,
+                    atproto_key,
+                )),
+                Err(e) => {
+                    tracing::warn!("Failed to load/generate #atproto signing key; PDS publish disabled: {e}");
+                    None
+                }
+            }
+        }
+        Err(e) => {
+            tracing::warn!("Failed to open PDS record store (rw); PDS publish disabled: {e}");
+            None
+        }
+    };
+
     // Create registry service with infrastructure (blocking since we're in sync context)
     let mut registry_service = tokio::task::block_in_place(|| {
         let rt = tokio::runtime::Handle::current();
@@ -530,6 +578,9 @@ fn create_registry_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawn
         registry_service = registry_service.with_expected_audience(issuer.to_owned());
     }
     registry_service = registry_service.with_jwt_key_source(ctx.cluster_key_source());
+    if let Some(publisher) = pds_publisher {
+        registry_service = registry_service.with_pds_publisher(publisher);
+    }
 
     Ok(ctx.into_spawnable_quic(registry_service, config.registry.quic_port))
 }
@@ -1507,6 +1558,32 @@ fn create_tui_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
     Ok(ctx.into_spawnable_quic(tui_service, tui_config.quic_port))
 }
 
+/// Open the PDS record store (#910a) read-only, bootstrapping an empty
+/// RocksDB database at `dir` first if nothing has been published yet.
+///
+/// `PdsRecordStore::open_readonly` requires the RocksDB files to already
+/// exist (`create_if_missing(false)`, matching `RocksDbUserStore::open_readonly`),
+/// which is normally true because the registry service (the writer) creates
+/// it. On a fresh install the discovery service may start before any model
+/// has ever been registered — bootstrap by briefly opening read-write (which
+/// creates the DB files) and releasing the handle, then retry read-only.
+///
+/// Known limitation: if the registry and discovery services start
+/// concurrently on a brand-new install, both may race to bootstrap the same
+/// directory; one loses the RocksDB lock and its factory call fails, which
+/// the service manager will retry.
+fn open_pds_store_readonly(
+    dir: &std::path::Path,
+) -> anyhow::Result<crate::services::discovery::PdsRecordStore> {
+    match crate::services::discovery::PdsRecordStore::open_readonly(dir) {
+        Ok(store) => Ok(store),
+        Err(_) => {
+            drop(crate::services::discovery::PdsRecordStore::open(dir)?);
+            crate::services::discovery::PdsRecordStore::open_readonly(dir)
+        }
+    }
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // Discovery Service Factory
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -1532,12 +1609,15 @@ fn create_discovery_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spaw
     let policy_client = PolicyClient::for_service(sk.clone(), policy_vk, service_token("discovery"))?;
     let auth_provider = crate::services::discovery::PolicyAuthProvider::new(policy_client);
 
-    // #431 — record resolver backing getRecord/getRepo. Built over an in-memory
-    // PDS record store; the publishing side (populating the store on model
-    // register + atproto-pointer advance, #394) is wired separately, so the
-    // store starts empty (getRecord reports NOT_FOUND until records are
-    // published). The access-control gate + CAR-proof wire are fully active.
-    let pds_store = std::sync::Arc::new(crate::services::discovery::PdsRecordStore::new());
+    // #431 — record resolver backing getRecord/getRepo, over the durable
+    // RocksDB-backed PDS record store (#910a). The registry service is the
+    // sole writer (it opens the same directory read-write and publishes on
+    // register/commit — see `create_registry_service`); this factory opens
+    // the directory read-only, matching `RocksDbUserStore::open_readonly`.
+    let pds_store = std::sync::Arc::new(
+        open_pds_store_readonly(&pds_store_dir())
+            .context("failed to open PDS record store (read-only)")?,
+    );
     let record_resolver = crate::services::discovery::PdsRecordResolver::new(pds_store);
 
     let mut discovery_service = DiscoveryService::new(

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -82,18 +82,24 @@ fn get_or_init_git2db(models_dir: &std::path::Path) -> anyhow::Result<Arc<RwLock
 /// `HYPRSTREAM__SECRETS__PATH`; otherwise it is `<config_dir>/credentials`.
 /// This is the same on-disk location the wizard/bootstrap manager writes
 /// service JWTs to (`credentials/{service}/service-jwt`).
-fn credentials_dir() -> std::path::PathBuf {
+fn credentials_dir() -> anyhow::Result<std::path::PathBuf> {
     if let Ok(p) = std::env::var("HYPRSTREAM__SECRETS__PATH") {
-        return std::path::PathBuf::from(p);
+        return Ok(std::path::PathBuf::from(p));
     }
-    HyprConfig::load()
-        .map(|c| c.config_dir().join("credentials"))
-        .unwrap_or_else(|_| {
-            dirs::config_dir()
-                .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
-                .join("hyprstream")
-                .join("credentials")
-        })
+    if let Ok(c) = HyprConfig::load() {
+        return Ok(c.config_dir().join("credentials"));
+    }
+    // Never fall back to a world-writable /tmp path for a secret-bearing dir
+    // (#910a H2): a predictable /tmp location lets another local user pre-own
+    // the secrets store or read keys placed there. Fail closed instead.
+    let base = dirs::config_dir().ok_or_else(|| {
+        anyhow::anyhow!(
+            "cannot resolve a secrets directory: set HYPRSTREAM__SECRETS__PATH \
+             (systemd credentials / k8s secret mount) — refusing to fall back to /tmp \
+             for a secret-bearing store"
+        )
+    })?;
+    Ok(base.join("hyprstream").join("credentials"))
 }
 
 /// Resolve the on-disk directory for the durable PDS record store (#910a).
@@ -102,18 +108,24 @@ fn credentials_dir() -> std::path::PathBuf {
 /// `<config_dir>/users.db` convention. The registry service (the sole
 /// publisher) opens it read-write; the discovery service (the resolver)
 /// opens it read-only — see `services::discovery::PdsRecordStore`.
-fn pds_store_dir() -> std::path::PathBuf {
+fn pds_store_dir() -> anyhow::Result<std::path::PathBuf> {
     if let Ok(p) = std::env::var("HYPRSTREAM__PDS__STORE_PATH") {
-        return std::path::PathBuf::from(p);
+        return Ok(std::path::PathBuf::from(p));
     }
-    HyprConfig::load()
-        .map(|c| c.config_dir().join("pds-store"))
-        .unwrap_or_else(|_| {
-            dirs::config_dir()
-                .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
-                .join("hyprstream")
-                .join("pds-store")
-        })
+    if let Ok(c) = HyprConfig::load() {
+        return Ok(c.config_dir().join("pds-store"));
+    }
+    // Never fall back to a predictable, world-writable /tmp path for a durable,
+    // node-signed record store (#910a H2): another local user could pre-own it
+    // and have the node sign injected records as authentic. Fail closed.
+    let base = dirs::config_dir().ok_or_else(|| {
+        anyhow::anyhow!(
+            "cannot resolve a PDS store directory: set HYPRSTREAM__PDS__STORE_PATH \
+             (or a persistent volume in k8s) — refusing to fall back to /tmp for a \
+             durable, signable record store"
+        )
+    })?;
+    Ok(base.join("hyprstream").join("pds-store"))
 }
 
 /// Resolve the CA-signed JWT used to register a service's signing key.
@@ -178,7 +190,7 @@ fn register_service_key(
         return Ok(());
     }
 
-    let creds_dir = credentials_dir();
+    let creds_dir = credentials_dir()?;
 
     // The JWT may already be in the trust store (e.g. seeded by an earlier
     // registration in this process); otherwise load it from disk — the
@@ -543,26 +555,20 @@ fn create_registry_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawn
     // TLS endorsement uses ("a node-level trust assertion, not specific to
     // any per-service key"). The `#atproto` commit-signing key is a
     // dedicated, persisted P-256 key (classical — atproto has no PQ variant).
-    let pds_publisher = match crate::services::discovery::PdsRecordStore::open(&pds_store_dir()) {
-        Ok(store) => {
-            let node_did = hyprstream_rpc::did_key::ed25519_to_did_key(&ctx.verifying_key().to_bytes());
-            match crate::auth::identity_store::load_or_generate_atproto_signing_key(&credentials_dir()) {
-                Ok(atproto_key) => Some(crate::services::discovery::PdsPublisher::new(
-                    Arc::new(store),
-                    node_did,
-                    atproto_key,
-                )),
-                Err(e) => {
-                    tracing::warn!("Failed to load/generate #atproto signing key; PDS publish disabled: {e}");
-                    None
-                }
-            }
-        }
-        Err(e) => {
-            tracing::warn!("Failed to open PDS record store (rw); PDS publish disabled: {e}");
-            None
-        }
-    };
+    // Best-effort: any failure here disables PDS publish with a warning rather
+    // than failing the registry. The `#atproto` key is loaded from the secrets
+    // dir and handed to the store in memory — it is never persisted into the
+    // record DB (#910a H1). Paths fail closed rather than fall back to /tmp (H2).
+    let pds_publisher = (|| -> anyhow::Result<crate::services::discovery::PdsPublisher> {
+        let store_dir = pds_store_dir()?;
+        let atproto_key =
+            crate::auth::identity_store::load_or_generate_atproto_signing_key(&credentials_dir()?)?;
+        let store = crate::services::discovery::PdsRecordStore::open(&store_dir, atproto_key)?;
+        let node_did = hyprstream_rpc::did_key::ed25519_to_did_key(&ctx.verifying_key().to_bytes());
+        Ok(crate::services::discovery::PdsPublisher::new(Arc::new(store), node_did))
+    })()
+    .map_err(|e| tracing::warn!("PDS publish disabled: {e}"))
+    .ok();
 
     // Create registry service with infrastructure (blocking since we're in sync context)
     let mut registry_service = tokio::task::block_in_place(|| {
@@ -1574,12 +1580,20 @@ fn create_tui_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
 /// the service manager will retry.
 fn open_pds_store_readonly(
     dir: &std::path::Path,
+    atproto_key: p256::ecdsa::SigningKey,
 ) -> anyhow::Result<crate::services::discovery::PdsRecordStore> {
-    match crate::services::discovery::PdsRecordStore::open_readonly(dir) {
+    match crate::services::discovery::PdsRecordStore::open_readonly(dir, atproto_key.clone()) {
         Ok(store) => Ok(store),
-        Err(_) => {
-            drop(crate::services::discovery::PdsRecordStore::open(dir)?);
-            crate::services::discovery::PdsRecordStore::open_readonly(dir)
+        Err(orig) => {
+            // Bootstrap the DB files by briefly opening read-write, then retry
+            // read-only. If bootstrap itself fails (e.g. the writer holds the
+            // lock, or the path is corrupt), surface BOTH errors so the real
+            // cause is visible rather than masked by the retry (#910a, fable M3).
+            drop(
+                crate::services::discovery::PdsRecordStore::open(dir, atproto_key.clone())
+                    .with_context(|| format!("read-only open failed ({orig}); bootstrap open also failed"))?,
+            );
+            crate::services::discovery::PdsRecordStore::open_readonly(dir, atproto_key)
         }
     }
 }
@@ -1614,8 +1628,15 @@ fn create_discovery_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spaw
     // sole writer (it opens the same directory read-write and publishes on
     // register/commit — see `create_registry_service`); this factory opens
     // the directory read-only, matching `RocksDbUserStore::open_readonly`.
+    // The `#atproto` commit key is loaded from the secrets dir (the same one
+    // the registry/writer uses) and held in memory to sign CAR proofs — it is
+    // never read from the record DB (#910a H1). In systemd/k8s this is a
+    // read-only, pre-provisioned credential; all replicas must share the same
+    // key so proofs verify consistently.
+    let atproto_key =
+        crate::auth::identity_store::load_or_generate_atproto_signing_key(&credentials_dir()?)?;
     let pds_store = std::sync::Arc::new(
-        open_pds_store_readonly(&pds_store_dir())
+        open_pds_store_readonly(&pds_store_dir()?, atproto_key)
             .context("failed to open PDS record store (read-only)")?,
     );
     let record_resolver = crate::services::discovery::PdsRecordResolver::new(pds_store);

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -337,6 +337,10 @@ pub struct RegistryService {
     /// fail-closed XET `getBlob` gate (#436 / #509). Pointer presence is
     /// necessary-but-not-sufficient: entitlement requires a provenance record.
     xet_provenance: Arc<XetProvenanceStore>,
+    /// Publishes/advances a repo's `ai.hyprstream.model` PDS record on
+    /// register + commit (#910a). `None` means this node has no PDS
+    /// configured — register/commit proceed exactly as before.
+    pds_publisher: Option<crate::services::discovery::PdsPublisher>,
 }
 
 /// Progress reporter that sends updates via a tokio mpsc channel.
@@ -415,6 +419,7 @@ impl RegistryService {
             expected_audience: None,
             jwt_key_source: None,
             xet_provenance,
+            pds_publisher: None,
         };
 
         Ok(service)
@@ -424,6 +429,32 @@ impl RegistryService {
     pub fn with_expected_audience(mut self, audience: String) -> Self {
         self.expected_audience = Some(audience);
         self
+    }
+
+    /// Wire in the PDS publisher (#910a). Registration and
+    /// `commitWithAuthor` (the RPC promote also drives) will publish/advance
+    /// the repo's `ai.hyprstream.model` record through it.
+    pub fn with_pds_publisher(mut self, publisher: crate::services::discovery::PdsPublisher) -> Self {
+        self.pds_publisher = Some(publisher);
+        self
+    }
+
+    /// Best-effort publish/advance of `repo_id`'s PDS record (#910a).
+    ///
+    /// Failures are logged and swallowed, never surfaced to the RPC caller:
+    /// the git commit/registration that triggered this already succeeded and
+    /// is the durable source of truth, matching the eventual-consistency
+    /// contract `git::promote` documents for the (still-stubbed, cross-node)
+    /// pointer-advance path. A missed local publish is caught up by the next
+    /// successful register/commit on the same repo.
+    fn publish_pds_record(&self, repo_id: &RepoId, current_oid: &str) {
+        let Some(publisher) = &self.pds_publisher else { return };
+        if let Err(e) = publisher.publish(&repo_id.to_string(), current_oid) {
+            warn!(
+                repo_id = %repo_id, current_oid, error = %e,
+                "PDS record publish failed; local state is durable, record is stale until next publish"
+            );
+        }
     }
 
     /// Set the JWT key source for token verification.
@@ -1189,6 +1220,15 @@ impl RegistryService {
             .find(|r| r.id == repo_id)
             .cloned()
             .ok_or_else(|| anyhow!("Failed to find registered repository"))?;
+        drop(registry);
+
+        // #910a — publish an initial PDS record if the newly-registered repo
+        // already has a HEAD (e.g. registering an existing on-disk repo).
+        // A freshly-initialized repo with no commits yet has no `current_oid`
+        // to publish; its first `commitWithAuthor` will do so instead.
+        if let Some(current_oid) = repo.current_oid.as_deref() {
+            self.publish_pds_record(&repo_id, current_oid);
+        }
 
         Ok(repo)
     }
@@ -2989,6 +3029,12 @@ impl WorktreeHandler for RegistryService {
     }
 
     /// Commit staged changes with specified author.
+    ///
+    /// #910a: this is the RPC verb `git::promote::promote` drives (via
+    /// `WorktreeClient::commit_with_author`) to snapshot the promoted upper
+    /// layer, so publishing the PDS record here — rather than in the
+    /// client-side `advance_pointer` stub — is what makes "promote" actually
+    /// advance the atproto pointer for a local/single-node deployment.
     async fn handle_commit_with_author(&self, _ctx: &EnvelopeContext, _request_id: u64,
         repo_id: &str, name: &str, data: &CommitWithAuthorRequest,
     ) -> Result<String> {
@@ -2996,9 +3042,11 @@ impl WorktreeHandler for RegistryService {
         let message = data.message.clone();
         let author_name = data.author_name.clone();
         let author_email = data.author_email.clone();
-        self.with_worktree_blocking(&id, name, move |repo| {
+        let oid = self.with_worktree_blocking(&id, name, move |repo| {
             Ok(crate::git::ops::commit_with_author(&repo, &message, &author_name, &author_email)?.to_string())
-        }).await
+        }).await?;
+        self.publish_pds_record(&id, &oid);
+        Ok(oid)
     }
 
     /// Amend the last commit in this worktree.


### PR DESCRIPTION
## #910a — PDS record publication, correct atproto sign-once model

Wires the `ai.hyprstream.model` PDS record publish/resolve path onto a durable RocksDB store, following the **correct atproto model**: the commit is signed **once at write time** and persisted; reads are a **keyless walk** that serve a proof CAR. The resolver holds **no private key**.

### The bug this fixes
The earlier revision kept records keyed by `(did, collection, tid)` and, on **every `getRecord`/`getRepo` read**, rebuilt the MST and **re-signed the commit** (`Commit::sign` on the read path). That is why the resolver had to hold the `#atproto` private key at read time — the root of this PR's security problems. atproto never re-signs on read.

### The model now implemented
- **Sign once, at write.** `PdsPublisher::publish` rebuilds the MST over the repo's full record set, builds the `UnsignedCommit { did, data = MST root, rev, prev }`, **signs it once** with the `#atproto` P-256 key, and persists the record **and** the signed-commit bytes atomically (one `WriteBatch`). Advancing `rev`/`prev` is the atproto pointer advance (`prev` = previous commit CID, `rev` strictly increases). Only the writer holds the private key.
- **Keyless reads.** `resolve_record`/`resolve_repo` rebuild the deterministic, keyless MST (`Node::from_records`), **load the stored signed commit**, and assemble the proof CAR from `{stored signed commit + MST proof blocks + record}`. Every `Commit::sign` is gone from the read path.
- **The MST is not stored.** It is a pure function of the records, so only the *signature* needs persisting. Storage schema:
  - `rk\0{did}\0{collection}\0{tid}` → canonical DAG-CBOR record bytes
  - `commit\0{did}` → signed-commit DAG-CBOR bytes (new)

### Key consistency (the other half of the fix)
The writer signs with the **active key of the shared `Es256SigningKeyStore`** — the *same* P-256 key `oauth::did_document` publishes as the `#atproto` verification method. Signer and published key are now one source of truth. The duplicate `load_or_generate_atproto_signing_key` loader and the separate `atproto-signing-key` secret are deleted.

### The resolver holds no key
`PdsRecordStore::open`/`open_readonly` and `RepoState` no longer carry a signing key; the discovery factory no longer loads one. Reads are keyless by construction.

### Preserved from the prior revision
RocksDB substrate (records + now signed-commit bytes), restart durability, fail-closed `pds_store_dir()`/`credentials_dir()` (no `/tmp` fallback), 0700 store-dir hardening, single-collection `ai.hyprstream.model` (multi-collection is #910b), deterministic `tid_for_repo` (SHA-256).

### Tests
`cargo test -p hyprstream --lib pds_store` (6 pass):
- `keyless_read_serves_writer_signed_commit` — publish (writer signs), then a resolver built with **no key** returns a proof whose commit `Commit::verify`s against the published P-256 key.
- `publish_read_full_proof_verifies` — publish → getRecord → full `verify_record_proof` (commit sig + MST path + record CID) passes keyless.
- `pointer_advance_bumps_rev_and_links_prev` — re-publish advances `rev` and links `prev` to the prior commit CID.
- `readonly_store_survives_restart_and_sees_writer_updates` — signed commit + records survive reopen and still verify.
- `readonly_store_rejects_writes`, `tid_for_repo_is_deterministic_and_distinct`.

`cargo build -p hyprstream` and `cargo clippy -p hyprstream --lib -- -D warnings` both clean.

---

## Adversarial-review fixes (follow-up commit)

An adversarial review of the reworked store found two HIGH-severity defects; both are fixed in this PR.

### Bug 1 — concurrent publish was an unserialized read-modify-write
All repos publish under the node's single DID, sharing one `commit\0{did}` pointer and one MST. `PdsPublisher::publish` is synchronous and did `load_repo → build_tree → sign → put_record_and_commit` with **no lock**. On a multi-threaded runtime, two concurrent publishes each loaded the same base, added *their* record, and signed a commit over *their* view — the later write clobbered the earlier record while persisting a `commit.data` the stored MST no longer matched, so a reader's rebuilt tree diverged and the served proof failed `verify_record_proof`.

**Fix (both parts):**
- **Serialize the critical section per node DID.** A `parking_lot::Mutex<()>` on `PdsRecordStore` (`publish_lock`) is held across the *entire* `load → build → sign → write` sequence in `publish`. `publish` is sync (no `.await` under the guard), so a plain mutex is correct; since all repos share one DID this is effectively a single publish lock.
- **Read-side fail-closed consistency check.** `resolve_record` and `resolve_repo`, after rebuilding the MST, assert `tree.root_cid() == commit.data` and **refuse to serve** (return an error) on divergence — defence in depth so an inconsistency is detected, never served as a bad proof.
- **Regression test** `concurrent_publishes_serialize_and_stay_consistent`: 8 threads publish distinct records concurrently against one store; asserts all records survive, the stored `commit.data` equals the MST root over the full record set, and every record's proof verifies. **Verified it fails without the lock** (lost update → `commit.data` mismatch) and passes with it.

### Bug 2 — publisher captured the #atproto key once at construction (frozen)
The factory cloned `es256_store.active_key()` into a frozen `SigningKey`. The ES256 store rotates (~14 days); after the first rotation the publisher kept signing with the stale key while `did_document` published the new active key, so new commits failed verification until restart.

**Fix:** `PdsPublisher` now holds an `Es256KeyGetter` (a getter closure wired by the factory to the live `Es256SigningKeyStore`) and resolves the **current active key inside `publish`** — every commit is signed with the same key `did_document` advertises right now. No frozen key is captured.

### Out of scope — tracked in #918
Commits already signed by a now-rotated key stop verifying, because `did_document` publishes only the single active `#atproto` verification method (no drain/lead slots). That is atproto-rotation-log-scale (drain-slot publication or re-sign-on-rotation) and is deferred to **#918**, documented as a `KNOWN LIMITATION` comment on `Es256KeyGetter`.

### Tests / build
`cargo test -p hyprstream --lib pds_store` — now **7 pass** (6 existing + the new concurrency test). `cargo clippy -p hyprstream --lib -- -D warnings` clean (pre-commit hook passed).
