### PR TITLE
feat(rpc) 579: method-dispatched resolve_identity_keys (did:web multi-alg VMs + did:key)

### DIFF
--- a/crates/hyprstream-rpc/src/did_key.rs
+++ b/crates/hyprstream-rpc/src/did_key.rs
@@ -23,30 +23,57 @@ use anyhow::{anyhow, bail, Result};
 /// codepath shares.
 pub(crate) const MULTICODEC_ED25519_PUB: [u8; 2] = [0xed, 0x01];
 
-/// Decode a `Multikey` `publicKeyMultibase` string into raw Ed25519 key bytes.
+/// Multicodec `ml-dsa-65-pub` unsigned-varint prefix (`0x1211` → bytes `0x91 0x24`).
 ///
-/// Verifies the base58btc multibase prefix (`z`) and the `ed25519-pub` multicodec
-/// header, returning the 32-byte payload.
+/// The PQ counterpart to [`MULTICODEC_ED25519_PUB`]: the header the mesh's
+/// `#mesh-pq` ML-DSA-65 verification method carries in its `publicKeyMultibase`.
+/// Mirrors `hyprstream::auth::mesh_trust::MULTICODEC_ML_DSA_65_PUB` (a 2-byte
+/// constant duplicated across the `hyprstream`/`hyprstream-rpc` crate boundary
+/// because `hyprstream-rpc` is the lower crate). Within `hyprstream-rpc` this is
+/// the one definition every codec-agile `Multikey` decode shares.
+pub const MULTICODEC_ML_DSA_65_PUB: [u8; 2] = [0x91, 0x24];
+
+/// Decode a `Multikey` `publicKeyMultibase` string into its raw key bytes,
+/// verifying the base58btc multibase prefix (`z`) and the `expected_codec`
+/// multicodec header, returning the payload with the multicodec prefix stripped.
 ///
-/// Returns `Err` for a wrong multibase, an undecodable base58, a non-Ed25519
-/// codec, or a payload that is not exactly 32 bytes.
-pub fn decode_ed25519_multikey(multibase: &str) -> Result<[u8; 32]> {
+/// This is the **codec-agile** core: it is algorithm-parametric over the
+/// multicodec header, so one implementation covers the `ed25519-pub` (`0xed01`)
+/// and `ml-dsa-65-pub` (`0x1211`) Multikeys the mesh publishes (and any future
+/// codec). [`decode_ed25519_multikey`] is the Ed25519-fixed thin wrapper.
+///
+/// Returns `Err` for a wrong multibase, an undecodable base58, or a multicodec
+/// header that does not match `expected_codec`. Payload *length* validation is
+/// the caller's concern (it is algorithm-specific).
+pub fn decode_multikey(multibase: &str, expected_codec: &[u8; 2]) -> Result<Vec<u8>> {
     let body = multibase
         .strip_prefix('z')
         .ok_or_else(|| anyhow!("Multikey must use base58btc multibase ('z') prefix"))?;
     let decoded = bs58::decode(body)
         .into_vec()
         .map_err(|e| anyhow!("invalid base58btc Multikey: {e}"))?;
-    if decoded.len() < 2 || decoded[..2] != MULTICODEC_ED25519_PUB {
+    if decoded.len() < 2 || &decoded[..2] != expected_codec {
         bail!(
-            "unexpected multicodec prefix (expected ed25519-pub {MULTICODEC_ED25519_PUB:02x?}, got {:02x?})",
+            "unexpected multicodec prefix (expected {expected_codec:02x?}, got {:02x?})",
             decoded.get(..2).unwrap_or(&decoded)
         );
     }
-    let raw: [u8; 32] = decoded[2..]
-        .try_into()
-        .map_err(|_| anyhow!("ed25519 Multikey payload is {} bytes (expected 32)", decoded.len() - 2))?;
-    Ok(raw)
+    Ok(decoded[2..].to_vec())
+}
+
+/// Decode a `Multikey` `publicKeyMultibase` string into raw Ed25519 key bytes.
+///
+/// A thin, length-checked wrapper over the codec-agile [`decode_multikey`]:
+/// verifies the base58btc multibase prefix (`z`) and the `ed25519-pub` multicodec
+/// header, returning the 32-byte payload.
+///
+/// Returns `Err` for a wrong multibase, an undecodable base58, a non-Ed25519
+/// codec, or a payload that is not exactly 32 bytes.
+pub fn decode_ed25519_multikey(multibase: &str) -> Result<[u8; 32]> {
+    let raw = decode_multikey(multibase, &MULTICODEC_ED25519_PUB)?;
+    let len = raw.len();
+    raw.try_into()
+        .map_err(|_| anyhow!("ed25519 Multikey payload is {len} bytes (expected 32)"))
 }
 
 /// Decode a `did:key` (Ed25519) identifier into its raw 32-byte Ed25519 key.

--- a/crates/hyprstream-rpc/src/did_web.rs
+++ b/crates/hyprstream-rpc/src/did_web.rs
@@ -240,7 +240,10 @@ pub fn preferred_transport(doc: &Value, kind: Option<SocketKind>) -> Option<Tran
 // share one implementation and cannot drift. They are re-exported here so
 // existing `crate::did_web::*` callers (admission gate, federation tests) are
 // unaffected.
-pub use crate::did_key::{decode_ed25519_multikey, did_key_to_ed25519, ed25519_to_did_key};
+pub use crate::did_key::{
+    decode_ed25519_multikey, decode_multikey, did_key_to_ed25519, ed25519_to_did_key,
+    MULTICODEC_ML_DSA_65_PUB,
+};
 // Only the test multikey helper references the raw multicodec constant now.
 #[cfg(test)]
 use crate::did_key::MULTICODEC_ED25519_PUB;
@@ -277,6 +280,47 @@ pub fn verification_method_ed25519_keys(doc: &Value) -> Vec<[u8; 32]> {
             Ok(k) => keys.push(k),
             Err(e) => {
                 tracing::debug!(error = %e, "skipping undecodable verificationMethod Multikey");
+            }
+        }
+    }
+    keys
+}
+
+/// Extract every ML-DSA-65 verifying key published in a DID document's
+/// `verificationMethod` array (#579 multi-alg VM extraction).
+///
+/// The PQ counterpart to [`verification_method_ed25519_keys`]: it scans the same
+/// `verificationMethod` array but keeps the `Multikey` entries whose
+/// `publicKeyMultibase` carries the `ml-dsa-65-pub` multicodec (`0x1211`) — the
+/// mesh's `#mesh-pq` verification method. Each candidate is decoded via the
+/// codec-agile [`decode_multikey`] and validated as a real ML-DSA-65 key by
+/// [`crate::crypto::pq::ml_dsa_vk_from_bytes`] (a malformed / wrong-length key is
+/// skipped, never trusted). Ed25519 (`0xed01`) VMs decode to a different codec
+/// and are skipped here, so the two extractors partition the same document by
+/// algorithm without interfering.
+///
+/// A document with no ML-DSA-65 VM yields an **empty** vec (the classical-only
+/// case): the caller treats "no PQ anchor" as `Assurance::Classical`, not an
+/// error.
+pub fn verification_method_ml_dsa_65_keys(doc: &Value) -> Vec<crate::crypto::pq::MlDsaVerifyingKey> {
+    let Some(vms) = doc.get("verificationMethod").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    let mut keys = Vec::new();
+    for vm in vms {
+        let Some(mb) = vm.get("publicKeyMultibase").and_then(Value::as_str) else {
+            continue;
+        };
+        // Only ml-dsa-65-pub Multikeys; an ed25519 (or other) codec is not an
+        // error here — it belongs to the Ed25519 extractor — so skip quietly.
+        let raw = match decode_multikey(mb, &MULTICODEC_ML_DSA_65_PUB) {
+            Ok(raw) => raw,
+            Err(_) => continue,
+        };
+        match crate::crypto::pq::ml_dsa_vk_from_bytes(&raw) {
+            Ok(vk) => keys.push(vk),
+            Err(e) => {
+                tracing::debug!(error = %e, "skipping ml-dsa-65 verificationMethod: not a valid ML-DSA-65 key");
             }
         }
     }

--- a/crates/hyprstream-rpc/src/identity.rs
+++ b/crates/hyprstream-rpc/src/identity.rs
@@ -77,6 +77,16 @@ impl Did {
         self.0.starts_with("did:web:")
     }
 
+    /// Whether this is a `did:at9p` identifier (the self-certifying hybrid-PQC
+    /// capsule identity, #879/#880).
+    ///
+    /// The capsule GATE pipeline that verifies a `did:at9p` and derives its
+    /// `PqHybrid` key material is epic #880 (D2); the method-dispatched resolver
+    /// reserves the arm but does not yet resolve it (fails closed until #894).
+    pub fn is_did_at9p(&self) -> bool {
+        self.0.starts_with("did:at9p:")
+    }
+
     /// Decode the raw 32-byte Ed25519 public key from a `did:key` identifier.
     ///
     /// Returns `Err` for a non-`did:key` DID, a non-Ed25519 multicodec, or a malformed body.

--- a/crates/hyprstream-rpc/src/identity_resolver.rs
+++ b/crates/hyprstream-rpc/src/identity_resolver.rs
@@ -1,0 +1,330 @@
+//! Method-dispatched [`IdentityResolver`] — the real `Did → IdentityKeys` binding (#579).
+//!
+//! This is the single, non-mirror implementation of the canonical
+//! [`crate::identity::IdentityResolver`] contract. It replaces the fixture /
+//! test-double resolvers that stood in for it while the #549 perimeter gateway
+//! and #137 admission gate were built against the interface.
+//!
+//! # Division of labor
+//!
+//! The resolver owns **verification + assurance derivation**; it does *not* own
+//! object labelling, the `KeyedPqTrustStore.bind` mesh anchor (#894), or any
+//! perimeter policy — those consumers are generic over the trait and unchanged.
+//!
+//! # Method dispatch
+//!
+//! [`resolve_identity_keys`](IdentityResolver::resolve_identity_keys) branches on
+//! the DID method:
+//!
+//! - **`did:web`** — resolve the DID document and extract its verification
+//!   methods. An Ed25519 VM (`#mesh` / `#iroh`) is the classical anchor; a
+//!   verified ML-DSA-65 VM (`#mesh-pq`, multicodec `0x1211`) is the PQ anchor.
+//!   Both present ⇒ [`Assurance::PqHybrid`] (a did:web we operate); Ed25519-only ⇒
+//!   [`Assurance::Classical`] (a third-party did:web). No Ed25519 VM ⇒ nothing to
+//!   bind ⇒ `Err` (fail-closed).
+//! - **`did:key`** — a single Ed25519 key decoded from the DID string itself; no
+//!   fetch. A single classical key can never be hybrid, so the honest ceiling is
+//!   [`Assurance::Classical`].
+//! - **`did:at9p`** — reserved for the capsule GATE pipeline (#879/#880 D2). This
+//!   resolver does **not** verify capsules; the arm returns `Err` (fail-closed)
+//!   with a clear TODO(#894) marker until that epic fills it.
+//! - **any other method** — `Err` (fail-closed).
+//!
+//! # Fail-closed
+//!
+//! Per the [`IdentityResolver`] contract, every inability to establish key
+//! material — an unknown method, a fetch failure, a malformed document, a
+//! did:web with no Ed25519 VM — returns `Err`. A resolver **never** returns a
+//! default-`Unverified` `Ok`.
+//!
+//! # Sync trait over an async fetch
+//!
+//! The contract is synchronous and enrollment happens **off the auth path**
+//! (once, at session establishment), so did:web document retrieval is abstracted
+//! behind a synchronous [`DidDocumentProvider`]. This keeps the decode +
+//! assurance-derivation core pure and testable with an injected fixture (no live
+//! network), mirroring the injected-fetcher pattern in [`crate::did_web`]. The
+//! async→sync bridge to the live [`crate::did_web::HttpDidDocFetcher`] is a
+//! wiring concern for the accept-path integration (there is no production
+//! construction site of the perimeter gateway today).
+
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+
+use crate::auth::mac::Assurance;
+use crate::did_web::{
+    did_key_to_ed25519, verification_method_ed25519_keys, verification_method_ml_dsa_65_keys,
+};
+use crate::identity::{Did, IdentityKeys, IdentityResolver};
+
+/// A synchronous DID-document provider for the did:web arm.
+///
+/// Abstracted so the resolver's decode/assurance core is testable with an
+/// injected fixture (no network). Enrollment is off the auth path, so a blocking
+/// implementation is acceptable; the trait keeps that policy out of the resolver.
+pub trait DidDocumentProvider: Send + Sync {
+    /// Fetch and parse the DID document for `did` (already known to be `did:web`).
+    fn document(&self, did: &str) -> Result<Value>;
+}
+
+/// The real, method-dispatched [`IdentityResolver`] (#579).
+///
+/// Generic over a [`DidDocumentProvider`] so the did:web fetch is injectable
+/// (fixture in tests, blocking HTTPS fetcher in production wiring).
+pub struct MethodDispatchResolver<P: DidDocumentProvider> {
+    docs: P,
+}
+
+impl<P: DidDocumentProvider> MethodDispatchResolver<P> {
+    /// Construct a resolver over a DID-document provider.
+    pub fn new(docs: P) -> Self {
+        Self { docs }
+    }
+
+    /// The did:web arm: resolve the document and derive key material + assurance.
+    ///
+    /// - Ed25519 VM present + ML-DSA-65 VM present ⇒ `PqHybrid`.
+    /// - Ed25519 VM present, no ML-DSA-65 VM ⇒ `Classical`.
+    /// - No Ed25519 VM ⇒ `Err` (fail-closed: nothing to anchor).
+    fn resolve_did_web(&self, did: &Did) -> Result<IdentityKeys> {
+        let doc = self
+            .docs
+            .document(did.as_str())
+            .map_err(|e| anyhow!("did:web {did} document did not resolve: {e}"))?;
+
+        // First Ed25519 VM is the classical anchor (the `#mesh` / `#iroh` key).
+        // A did:web with no Ed25519 VM cannot be bound (the PQ trust store is
+        // keyed BY the Ed25519 identity), so fail closed.
+        let ed25519 = verification_method_ed25519_keys(&doc).into_iter().next().ok_or_else(|| {
+            anyhow!("did:web {did}: no Ed25519 verificationMethod to anchor — fail-closed")
+        })?;
+
+        // A verified ML-DSA-65 VM (`#mesh-pq`) upgrades the edge to PqHybrid; its
+        // absence is the ordinary classical case, not an error.
+        let ml_dsa_65 = verification_method_ml_dsa_65_keys(&doc).into_iter().next();
+
+        let assurance =
+            if ml_dsa_65.is_some() { Assurance::PqHybrid } else { Assurance::Classical };
+
+        Ok(IdentityKeys { ed25519: Some(ed25519), ml_dsa_65, assurance })
+    }
+
+    /// The did:key arm: a single self-certifying Ed25519 key, no fetch.
+    ///
+    /// A `did:key` encodes exactly one key; a single classical key can never be
+    /// hybrid, so assurance is `Classical` (the honest ceiling).
+    fn resolve_did_key(&self, did: &Did) -> Result<IdentityKeys> {
+        let ed25519 = did_key_to_ed25519(did.as_str())
+            .map_err(|e| anyhow!("did:key {did} is not a valid Ed25519 identity: {e}"))?;
+        Ok(IdentityKeys {
+            ed25519: Some(ed25519),
+            ml_dsa_65: None,
+            assurance: Assurance::Classical,
+        })
+    }
+}
+
+impl<P: DidDocumentProvider> IdentityResolver for MethodDispatchResolver<P> {
+    fn resolve_identity_keys(&self, did: &Did) -> Result<IdentityKeys> {
+        if did.is_did_web() {
+            self.resolve_did_web(did)
+        } else if did.is_did_key() {
+            self.resolve_did_key(did)
+        } else if did.is_did_at9p() {
+            // Reserved for the capsule GATE pipeline (#879/#880 D2). This
+            // resolver does not verify capsules; fail closed until #894 fills it.
+            Err(anyhow!(
+                "did:at9p {did}: capsule verification is not implemented here — reserved for #894 (fail-closed)"
+            ))
+        } else {
+            // Unknown DID method — fail closed (never a default-Unverified Ok).
+            Err(anyhow!("unsupported DID method for {did}: no resolver arm — fail-closed"))
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::crypto::pq::{ml_dsa_sk_to_vk_bytes, ml_dsa_generate_keypair, ml_dsa_vk_bytes};
+    use crate::did_key::{ed25519_to_did_key, MULTICODEC_ED25519_PUB, MULTICODEC_ML_DSA_65_PUB};
+    use ed25519_dalek::SigningKey;
+    use rand::rngs::OsRng;
+    use serde_json::json;
+
+    fn rand_ed25519() -> [u8; 32] {
+        SigningKey::generate(&mut OsRng).verifying_key().to_bytes()
+    }
+
+    fn encode_multikey(raw: &[u8], codec: [u8; 2]) -> String {
+        let mut payload = Vec::with_capacity(2 + raw.len());
+        payload.extend_from_slice(&codec);
+        payload.extend_from_slice(raw);
+        format!("z{}", bs58::encode(payload).into_string())
+    }
+
+    /// A DID document with an Ed25519 `#mesh` VM and, optionally, an ML-DSA-65
+    /// `#mesh-pq` VM.
+    fn did_doc(ed: &[u8; 32], ml_dsa_vk_bytes: Option<&[u8]>) -> Value {
+        let mut vms = vec![json!({
+            "id": "did:web:peer.example#mesh",
+            "type": "Multikey",
+            "controller": "did:web:peer.example",
+            "publicKeyMultibase": encode_multikey(ed, MULTICODEC_ED25519_PUB),
+        })];
+        if let Some(pq) = ml_dsa_vk_bytes {
+            vms.push(json!({
+                "id": "did:web:peer.example#mesh-pq",
+                "type": "Multikey",
+                "controller": "did:web:peer.example",
+                "publicKeyMultibase": encode_multikey(pq, MULTICODEC_ML_DSA_65_PUB),
+            }));
+        }
+        json!({
+            "@context": ["https://www.w3.org/ns/did/v1"],
+            "id": "did:web:peer.example",
+            "verificationMethod": vms,
+            "service": [],
+        })
+    }
+
+    /// Fixture provider returning a fixed document.
+    struct FixtureDocs(Value);
+    impl DidDocumentProvider for FixtureDocs {
+        fn document(&self, _did: &str) -> Result<Value> {
+            Ok(self.0.clone())
+        }
+    }
+
+    /// Provider that always fails — exercises the fail-closed fetch path.
+    struct FailingDocs;
+    impl DidDocumentProvider for FailingDocs {
+        fn document(&self, did: &str) -> Result<Value> {
+            Err(anyhow!("simulated fetch failure for {did}"))
+        }
+    }
+
+    /// A provider that MUST NOT be called (did:key / did:at9p never fetch).
+    struct NeverDocs;
+    impl DidDocumentProvider for NeverDocs {
+        fn document(&self, did: &str) -> Result<Value> {
+            panic!("resolver must not fetch a document for {did}");
+        }
+    }
+
+    const DID_WEB: &str = "did:web:peer.example";
+
+    #[test]
+    fn did_web_ed25519_only_is_classical() {
+        let ed = rand_ed25519();
+        let resolver = MethodDispatchResolver::new(FixtureDocs(did_doc(&ed, None)));
+        let keys = resolver
+            .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
+            .expect("ed25519-only did:web resolves");
+        assert_eq!(keys.assurance, Assurance::Classical);
+        assert_eq!(keys.ed25519, Some(ed));
+        assert!(keys.ml_dsa_65.is_none());
+    }
+
+    #[test]
+    fn did_web_with_ml_dsa_is_pqhybrid() {
+        let ed = rand_ed25519();
+        let (_sk, vk) = ml_dsa_generate_keypair();
+        let pq_bytes = ml_dsa_vk_bytes(&vk);
+        let resolver = MethodDispatchResolver::new(FixtureDocs(did_doc(&ed, Some(&pq_bytes))));
+        let keys = resolver
+            .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
+            .expect("hybrid did:web resolves");
+        assert_eq!(keys.assurance, Assurance::PqHybrid);
+        assert_eq!(keys.ed25519, Some(ed));
+        // The resolved PQ key is exactly the published one.
+        let resolved = keys.ml_dsa_65.expect("PQ anchor present");
+        assert_eq!(ml_dsa_vk_bytes(&resolved), pq_bytes);
+    }
+
+    #[test]
+    fn did_web_derives_pq_key_from_signing_key_roundtrip() {
+        // A mesh-derived ML-DSA key (as node_identity produces) round-trips
+        // through the VM extractor into a usable verifying key.
+        let ed = rand_ed25519();
+        let peer_ed = SigningKey::generate(&mut OsRng);
+        let peer_pq_sk = crate::node_identity::derive_mesh_mldsa_key(&peer_ed);
+        let pq_bytes = ml_dsa_sk_to_vk_bytes(&peer_pq_sk);
+        let resolver = MethodDispatchResolver::new(FixtureDocs(did_doc(&ed, Some(&pq_bytes))));
+        let keys = resolver
+            .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
+            .expect("hybrid did:web resolves");
+        assert_eq!(keys.assurance, Assurance::PqHybrid);
+        assert_eq!(ml_dsa_vk_bytes(&keys.ml_dsa_65.unwrap()), pq_bytes);
+    }
+
+    #[test]
+    fn did_web_no_ed25519_vm_fails_closed() {
+        // A doc with only an ML-DSA VM (no Ed25519 anchor) cannot be bound.
+        let (_sk, vk) = ml_dsa_generate_keypair();
+        let doc = json!({
+            "id": DID_WEB,
+            "verificationMethod": [{
+                "id": "did:web:peer.example#mesh-pq",
+                "publicKeyMultibase": encode_multikey(&ml_dsa_vk_bytes(&vk), MULTICODEC_ML_DSA_65_PUB),
+            }],
+        });
+        let resolver = MethodDispatchResolver::new(FixtureDocs(doc));
+        assert!(resolver.resolve_identity_keys(&Did::new(DID_WEB.to_owned())).is_err());
+    }
+
+    #[test]
+    fn did_web_empty_doc_fails_closed() {
+        let doc = json!({ "id": DID_WEB, "verificationMethod": [] });
+        let resolver = MethodDispatchResolver::new(FixtureDocs(doc));
+        assert!(resolver.resolve_identity_keys(&Did::new(DID_WEB.to_owned())).is_err());
+    }
+
+    #[test]
+    fn did_web_fetch_failure_fails_closed() {
+        let resolver = MethodDispatchResolver::new(FailingDocs);
+        assert!(resolver.resolve_identity_keys(&Did::new(DID_WEB.to_owned())).is_err());
+    }
+
+    #[test]
+    fn did_key_is_classical_without_fetch() {
+        let ed = rand_ed25519();
+        let did = ed25519_to_did_key(&ed);
+        let resolver = MethodDispatchResolver::new(NeverDocs);
+        let keys = resolver
+            .resolve_identity_keys(&Did::new(did))
+            .expect("did:key resolves without fetch");
+        assert_eq!(keys.assurance, Assurance::Classical);
+        assert_eq!(keys.ed25519, Some(ed));
+        assert!(keys.ml_dsa_65.is_none());
+    }
+
+    #[test]
+    fn did_key_malformed_fails_closed() {
+        let resolver = MethodDispatchResolver::new(NeverDocs);
+        let did = Did::new("did:key:zNotAValidEd25519Multikey".to_owned());
+        assert!(resolver.resolve_identity_keys(&did).is_err());
+    }
+
+    #[test]
+    fn did_at9p_arm_is_reserved_and_fails_closed() {
+        let resolver = MethodDispatchResolver::new(NeverDocs);
+        let did = Did::new("did:at9p:cid512abcdef".to_owned());
+        // `IdentityKeys` is not `Debug` (the ML-DSA key type isn't), so match on
+        // the result rather than `unwrap_err`.
+        match resolver.resolve_identity_keys(&did) {
+            Ok(_) => panic!("did:at9p must fail closed (reserved for #894)"),
+            Err(err) => {
+                assert!(err.to_string().contains("#894"), "reserved arm should point at #894: {err}");
+            }
+        }
+    }
+
+    #[test]
+    fn unknown_method_fails_closed() {
+        let resolver = MethodDispatchResolver::new(NeverDocs);
+        let did = Did::new("did:plc:unsupported".to_owned());
+        assert!(resolver.resolve_identity_keys(&did).is_err());
+    }
+}

--- a/crates/hyprstream-rpc/src/lib.rs
+++ b/crates/hyprstream-rpc/src/lib.rs
@@ -178,6 +178,10 @@ pub mod did_key;
 pub mod did_web;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod admission;
+// The real, method-dispatched `IdentityResolver` (#579). Native-only: the
+// did:web arm depends on `did_web`'s DID-document helpers.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod identity_resolver;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod notify;
 #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
Closes the DID→key binding gap for #579: implements the real, **method-dispatched** `resolve_identity_keys` behind the canonical `IdentityResolver` contract.

> Stacks on **#911** (`ewindisch/579-resolver-contract`), which collapsed the "Mirror" contract into one canonical definition in `crate::identity`. This PR adds the real, non-mirror implementation of that trait. Please merge #911 first (base is set to its branch).

## What this delivers

A single `MethodDispatchResolver` that branches on the DID method and derives `Assurance` from **verified key material** — fail-closed on any failure (never a default-`Unverified` `Ok`):

| Method | Behavior | Assurance |
|--------|----------|-----------|
| `did:web` | Resolve the DID document; extract verification methods | `PqHybrid` if both an Ed25519 VM (`#mesh`/`#iroh`) **and** a verified ML-DSA-65 VM (`#mesh-pq`, `0x1211`) are present (a did:web we operate); `Classical` if Ed25519-only (third-party); **`Err`** if no Ed25519 VM (nothing to anchor — the PQ trust store is keyed *by* the Ed25519 identity) |
| `did:key` | Single Ed25519 key decoded from the DID string, **no fetch** | `Classical` (a single classical key can never be hybrid) |
| `did:at9p` | **Arm reserved** — capsule verification is #894/#880-D2; returns `Err` with a TODO pointing at #894 | — |
| any other | `Err` | — |

## Supporting changes (all in `hyprstream-rpc`)

- **`did_key`**: added the codec-agile `decode_multikey(multibase, expected_codec)` plus the `ml-dsa-65-pub` (`0x1211`) multicodec constant. `decode_ed25519_multikey` is now a thin, length-checked wrapper over it — the decoder consolidation called for in #579 (in-scope item 2), done within `hyprstream-rpc` (`mesh_trust::decode_multikey` lives in the higher `hyprstream` crate and can't be depended on from here).
- **`did_web`**: added `verification_method_ml_dsa_65_keys` — the PQ counterpart to `verification_method_ed25519_keys`, partitioning the same `verificationMethod` array by multicodec and validating each candidate via `crypto::pq::ml_dsa_vk_from_bytes` (a malformed/wrong-length key is skipped, never trusted). This closes the gap where the ML-DSA binding was sourced from `mesh_peers` **config** rather than the resolved document (#579 in-scope item 1).
- **`identity`**: added `Did::is_did_at9p` so method dispatch is one place.

## Division of labor (kept clean)

- The **resolver** owns verification + assurance derivation only.
- `AtprotoPerimeterGateway` (#549) and mesh `admission` (#137) stay **zero-logic-change** consumers of the trait — untouched here.
- `KeyedPqTrustStore.bind` and object-label wiring are **not** in scope (#894).

## Sync trait over an async fetch

The `IdentityResolver` contract is synchronous and enrollment happens off the auth path (once, at session establishment), so the did:web document fetch is abstracted behind a synchronous `DidDocumentProvider`. This keeps the decode + assurance-derivation core pure and unit-testable with an injected fixture (no live network), mirroring `did_web`'s injected-fetcher pattern. The async→sync bridge to the live `HttpDidDocFetcher` is a wiring concern for the accept-path integration; there is no production construction site of the perimeter gateway today, so no Fixture swap in non-test code is required yet.

## Tests

9 new `identity_resolver` unit tests (Classical/PqHybrid did:web, no-Ed25519 fail-closed, empty doc, fetch failure, did:key classical no-fetch, malformed did:key, reserved did:at9p arm, unknown method) plus the mesh-derived ML-DSA key round-trip. `cargo test -p hyprstream-rpc --lib` green; `cargo clippy -p hyprstream-rpc -- -D warnings` clean.
