### PR TITLE
feat(p2p): vendor mainline BEP5 client behind mainline-locator feature (#889)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1396,7 +1396,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -5317,6 +5317,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "flurry"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5895,7 +5906,7 @@ dependencies = [
  "hyprstream-containedfs",
  "inventory",
  "libc",
- "lru 0.16.1",
+ "lru 0.16.4",
  "merklehash",
  "nix 0.27.1",
  "once_cell",
@@ -5936,7 +5947,9 @@ dependencies = [
  "glob",
  "hex",
  "libp2p",
+ "mainline",
  "multihash",
+ "parking_lot 0.12.4",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -6642,7 +6655,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -6904,7 +6917,7 @@ dependencies = [
  "libc",
  "listenfd",
  "log",
- "lru 0.16.1",
+ "lru 0.16.4",
  "memmap2",
  "minijinja",
  "ml-dsa",
@@ -7554,7 +7567,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -8919,7 +8932,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if 1.0.3",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -9519,11 +9532,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.1"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe949189f46fabb938b3a9a0be30fdd93fd8a09260da863399a8cf3db756ec8"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -9607,6 +9620,28 @@ name = "macro_rules_attribute-proc_macro"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
+name = "mainline"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dfad9601b9117218868271c05403853593d4817e7abeab5c95e11eee16382bb"
+dependencies = [
+ "crc",
+ "document-features",
+ "dyn-clone",
+ "ed25519-dalek 3.0.0-pre.7",
+ "flume",
+ "futures-lite 2.6.1",
+ "getrandom 0.4.2",
+ "lru 0.16.4",
+ "serde",
+ "serde_bencode",
+ "serde_bytes",
+ "sha1_smol",
+ "thiserror 2.0.18",
+ "tracing",
+]
 
 [[package]]
 name = "match-lookup"
@@ -12881,7 +12916,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -12914,7 +12949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -13420,7 +13455,7 @@ dependencies = [
  "indoc",
  "itertools 0.14.0",
  "kasuari",
- "lru 0.16.1",
+ "lru 0.16.4",
  "strum 0.27.2",
  "thiserror 2.0.18",
  "unicode-segmentation",
@@ -14909,6 +14944,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bencode"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a70dfc7b7438b99896e7f8992363ab8e2c4ba26aa5ec675d32d1c3c2c33d413e"
+dependencies = [
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
 name = "serde_bytes"
 version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15462,6 +15507,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spin"
@@ -18471,7 +18519,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/gittorrent/Cargo.toml
+++ b/crates/gittorrent/Cargo.toml
@@ -70,6 +70,10 @@ async-trait = "0.1"
 
 # libp2p networking
 libp2p = { version = "0.56", features = ["kad", "mdns", "noise", "tcp", "tokio", "yamux", "identify", "request-response", "macros"] }
+
+# Mainline (BEP5) DHT locator for did:at9p (#889, epic #880 Track C).
+# Optional: nothing ships enabled until Track C wiring lands.
+mainline = { version = "7.0", optional = true }
 multihash = "0.19"
 sha2 = "0.10"
 
@@ -79,11 +83,15 @@ bincode = "1.3"
 
 [dev-dependencies]
 tokio-test = "0.4"
+parking_lot.workspace = true
 
 [features]
 default = []
 # Enable additional debug logging
 debug = []
+# at9p mainline (BEP5) locator: arbitrary-infohash announce/get_peers, which
+# iroh's internal pkarr cannot do. Off by default (#889 / epic #880 Track C).
+mainline-locator = ["dep:mainline"]
 
 [lints]
 workspace = true

--- a/crates/gittorrent/src/lib.rs
+++ b/crates/gittorrent/src/lib.rs
@@ -12,6 +12,10 @@ pub mod types;
 pub mod service;
 pub mod daemon;
 
+/// at9p mainline (BEP5) locator — see #889 / epic #880 Track C.
+#[cfg(feature = "mainline-locator")]
+pub mod locator;
+
 // Re-export commonly used types
 pub use error::{Error, Result};
 pub use types::*;

--- a/crates/gittorrent/src/locator.rs
+++ b/crates/gittorrent/src/locator.rs
@@ -1,0 +1,292 @@
+//! Mainline (BEP5) DHT locator — untrusted peer rendezvous for `did:at9p`.
+//!
+//! Track C of the at9p epic (#880, story C1 = #889). This module wraps the
+//! standalone [`mainline`] crate (MIT, pubky/pkarr lineage) to provide
+//! arbitrary-infohash `announce_peer` / `get_peers`, which iroh's internal
+//! pkarr integration cannot do (it is NodeId-lookup only).
+//!
+//! # Trust model
+//!
+//! The DHT is an **untrusted locator**: it only ever yields *candidate* peer
+//! contacts. Zero authority is derived from anything read here — capsules
+//! fetched from returned peers must pass the full GATE pipeline
+//! (canon → H512 == cid512 → composite signature) before use (#879 §5.6).
+//!
+//! # TRUNC20 confinement (review rule R2)
+//!
+//! BEP5 keys are 20-byte infohashes; at9p identities are 64-byte BLAKE3-512
+//! CIDs. The truncation from 64 → 20 bytes happens in exactly one place:
+//! [`rendezvous_infohash`], private to this module. Every public API takes
+//! the full [`Cid512`]; no truncated form escapes this module. Story C2
+//! (#890) will replace the raw prefix with the k-derived rendezvous
+//! (`k-index` + `epoch-be64`, #879 §5.2) — the confinement point stays here.
+//!
+//! # wasm / browser note (documented, not built — C1 acceptance)
+//!
+//! There is **no raw mainline DHT from wasm**: browsers cannot open UDP
+//! sockets, and iroh itself falls back to a pkarr HTTP relay
+//! (`dns.iroh.link`) there. The wasm locator therefore needs either a relay
+//! bridge (an HTTP/WebTransport endpoint on a trusted-for-liveness node that
+//! proxies `get_peers`) or a PDS fallback (capsule fetched via atproto
+//! records, #910). That surface is shared with #470 and is deliberately not
+//! implemented here; this module is native-only.
+
+use std::net::SocketAddrV4;
+
+use async_trait::async_trait;
+use futures::StreamExt;
+
+use crate::error::{Error, Result};
+
+/// Length in bytes of an at9p content identifier (BLAKE3-512 digest).
+pub const CID512_LEN: usize = 64;
+
+/// A full-width at9p content identifier (64-byte BLAKE3-512 CID).
+///
+/// This is the only key type the locator's public API accepts. The 20-byte
+/// BEP5 infohash derived from it never leaves this module (R2).
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Cid512([u8; CID512_LEN]);
+
+impl Cid512 {
+    /// Construct from a full 64-byte digest.
+    pub fn from_bytes(bytes: [u8; CID512_LEN]) -> Self {
+        Self(bytes)
+    }
+
+    /// Construct from a slice, rejecting anything that is not exactly
+    /// 64 bytes. There is deliberately no constructor from shorter input:
+    /// callers must hold the full-width CID.
+    pub fn from_slice(bytes: &[u8]) -> Result<Self> {
+        let arr: [u8; CID512_LEN] = bytes.try_into().map_err(|_| {
+            Error::other(format!(
+                "cid512 must be {CID512_LEN} bytes, got {}",
+                bytes.len()
+            ))
+        })?;
+        Ok(Self(arr))
+    }
+
+    /// The full 64-byte digest.
+    pub fn as_bytes(&self) -> &[u8; CID512_LEN] {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for Cid512 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Cid512({})", hex::encode(self.0))
+    }
+}
+
+/// TRUNC20: derive the 20-byte BEP5 infohash for a full-width CID.
+///
+/// **This is the single truncation site in the codebase** (R2). The result
+/// is passed straight into the BEP5 client and is never returned to callers.
+///
+/// C1 uses the raw 20-byte prefix; C2 (#890) swaps this for the k-derived
+/// rendezvous hash (`k-index` + `epoch-be64`) without widening its scope.
+fn rendezvous_infohash(cid: &Cid512) -> [u8; 20] {
+    let mut infohash = [0u8; 20];
+    infohash.copy_from_slice(&cid.0[..20]);
+    infohash
+}
+
+/// Minimal BEP5 operations the locator needs, abstracted so unit tests never
+/// touch the real DHT (and so C2+ can inject scoring/relay variants).
+#[async_trait]
+pub trait Bep5Client: Send + Sync {
+    /// Announce this process as a provider for `info_hash`.
+    ///
+    /// `port: None` lets remote nodes infer the port (BEP5 implied_port).
+    async fn announce(&self, info_hash: [u8; 20], port: Option<u16>) -> Result<()>;
+
+    /// Collect currently-announced providers for `info_hash`.
+    async fn get_peers(&self, info_hash: [u8; 20]) -> Result<Vec<SocketAddrV4>>;
+}
+
+/// Real BEP5 client backed by [`mainline::async_dht::AsyncDht`].
+///
+/// Runs in client mode (queries + stores, no inbound routing duties). The
+/// underlying crate drives its own UDP socket thread; the async wrapper is
+/// runtime-agnostic and works under tokio.
+pub struct MainlineBep5 {
+    dht: mainline::async_dht::AsyncDht,
+}
+
+impl MainlineBep5 {
+    /// Bootstrap a client-mode node against the default mainline routers.
+    ///
+    /// This *does* touch the network — never call it from unit tests.
+    pub fn new() -> Result<Self> {
+        let dht = mainline::Dht::builder()
+            .build()
+            .map_err(|e| Error::other(format!("mainline DHT bootstrap failed: {e}")))?;
+        Ok(Self {
+            dht: dht.as_async(),
+        })
+    }
+}
+
+#[async_trait]
+impl Bep5Client for MainlineBep5 {
+    async fn announce(&self, info_hash: [u8; 20], port: Option<u16>) -> Result<()> {
+        self.dht
+            .announce_peer(mainline::Id::from(info_hash), port)
+            .await
+            .map_err(|e| Error::other(format!("mainline announce_peer failed: {e}")))?;
+        Ok(())
+    }
+
+    async fn get_peers(&self, info_hash: [u8; 20]) -> Result<Vec<SocketAddrV4>> {
+        let mut stream = self.dht.get_peers(mainline::Id::from(info_hash));
+        let mut peers = Vec::new();
+        while let Some(batch) = stream.next().await {
+            peers.extend(batch);
+        }
+        Ok(peers)
+    }
+}
+
+/// The at9p mainline locator: full-width CID in, candidate peers out.
+///
+/// Thin C1 wrapper — provider scoring, parallel fetch, and size caps are C3
+/// (#891); the k-derived rendezvous is C2 (#890).
+pub struct MainlineLocator {
+    client: Box<dyn Bep5Client>,
+}
+
+impl MainlineLocator {
+    /// Locator over the real mainline DHT (network-touching).
+    pub fn new() -> Result<Self> {
+        Ok(Self::with_client(Box::new(MainlineBep5::new()?)))
+    }
+
+    /// Locator over an injected BEP5 client (tests, relay bridges).
+    pub fn with_client(client: Box<dyn Bep5Client>) -> Self {
+        Self { client }
+    }
+
+    /// Announce this node as a provider for `cid`.
+    pub async fn announce(&self, cid: &Cid512, port: Option<u16>) -> Result<()> {
+        self.client.announce(rendezvous_infohash(cid), port).await
+    }
+
+    /// Look up candidate providers for `cid`.
+    ///
+    /// Returned contacts are **untrusted hints**: anyone can announce on any
+    /// infohash. Callers must verify fetched content against the full
+    /// `cid` via the GATE pipeline before deriving anything from it.
+    pub async fn providers(&self, cid: &Cid512) -> Result<Vec<SocketAddrV4>> {
+        self.client.get_peers(rendezvous_infohash(cid)).await
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use parking_lot::Mutex;
+    use std::collections::HashMap;
+    use std::net::Ipv4Addr;
+
+    use std::sync::Arc;
+
+    /// In-memory BEP5 fake: a HashMap keyed by the 20-byte infohash, exactly
+    /// like the real DHT's keyspace. No sockets, no network. Clone shares
+    /// state so tests can inspect what the locator sent.
+    #[derive(Default, Clone)]
+    struct MockBep5 {
+        table: Arc<Mutex<HashMap<[u8; 20], Vec<SocketAddrV4>>>>,
+        seen_infohashes: Arc<Mutex<Vec<[u8; 20]>>>,
+    }
+
+    #[async_trait]
+    impl Bep5Client for MockBep5 {
+        async fn announce(&self, info_hash: [u8; 20], port: Option<u16>) -> Result<()> {
+            self.seen_infohashes.lock().push(info_hash);
+            let addr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, port.unwrap_or(6881));
+            self.table.lock().entry(info_hash).or_default().push(addr);
+            Ok(())
+        }
+
+        async fn get_peers(&self, info_hash: [u8; 20]) -> Result<Vec<SocketAddrV4>> {
+            self.seen_infohashes.lock().push(info_hash);
+            Ok(self
+                .table
+                .lock()
+                .get(&info_hash)
+                .cloned()
+                .unwrap_or_default())
+        }
+    }
+
+    fn cid(fill: u8) -> Cid512 {
+        Cid512::from_bytes([fill; CID512_LEN])
+    }
+
+    #[tokio::test]
+    async fn announce_then_providers_roundtrip() {
+        let locator = MainlineLocator::with_client(Box::<MockBep5>::default());
+        let id = cid(0xAB);
+
+        locator.announce(&id, Some(4242)).await.unwrap();
+        let peers = locator.providers(&id).await.unwrap();
+
+        assert_eq!(peers, vec![SocketAddrV4::new(Ipv4Addr::LOCALHOST, 4242)]);
+    }
+
+    #[tokio::test]
+    async fn providers_of_unannounced_cid_is_empty() {
+        let locator = MainlineLocator::with_client(Box::<MockBep5>::default());
+        assert!(locator.providers(&cid(0x01)).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn truncation_is_internal_and_prefix_derived() {
+        let mock = MockBep5::default();
+        let locator = MainlineLocator::with_client(Box::new(mock.clone()));
+
+        let mut bytes = [0u8; CID512_LEN];
+        for (i, b) in bytes.iter_mut().enumerate() {
+            *b = i as u8;
+        }
+        let id = Cid512::from_bytes(bytes);
+
+        locator.announce(&id, None).await.unwrap();
+
+        // The infohash the client saw must be exactly the first 20 bytes of
+        // the full-width CID — and nothing wider ever reaches the client.
+        let seen = mock.seen_infohashes.lock().clone();
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0][..], bytes[..20]);
+    }
+
+    #[tokio::test]
+    async fn distinct_cids_sharing_a_20_byte_prefix_collide_on_the_dht() {
+        // Documents the TRUNC20 residual: the DHT rendezvous cannot separate
+        // CIDs that agree on the derived infohash — the full-width GATE
+        // verification after fetch is what restores 512-bit security (#879 §5.2).
+        let locator = MainlineLocator::with_client(Box::<MockBep5>::default());
+
+        let mut a = [0x55u8; CID512_LEN];
+        let mut b = [0x55u8; CID512_LEN];
+        a[63] = 0x00;
+        b[63] = 0xFF;
+        let (a, b) = (Cid512::from_bytes(a), Cid512::from_bytes(b));
+        assert_ne!(a, b);
+
+        locator.announce(&a, Some(1111)).await.unwrap();
+        let peers = locator.providers(&b).await.unwrap();
+        assert_eq!(peers.len(), 1, "same 20-byte prefix rendezvouses together");
+    }
+
+    #[test]
+    fn cid512_rejects_wrong_lengths() {
+        assert!(Cid512::from_slice(&[0u8; 20]).is_err());
+        assert!(Cid512::from_slice(&[0u8; 32]).is_err());
+        assert!(Cid512::from_slice(&[0u8; 63]).is_err());
+        assert!(Cid512::from_slice(&[0u8; 64]).is_ok());
+        assert!(Cid512::from_slice(&[0u8; 65]).is_err());
+    }
+}


### PR DESCRIPTION
Closes #889 (epic #880 Track C, story C1; design #879 §6.1; resolves epic Q8).

## Research verdict: `mainline` crate — suitable

- **Crate:** [`mainline`](https://crates.io/crates/mainline) v7.0.0 (pinned `7.0`), repo `pubky/mainline` — the Nuh/pkarr lineage; the same implementation iroh's pkarr publication rides today.
- **Maintenance:** actively maintained — 7.0.0 released June 9, 2026; ~360k total downloads; runs in production under pkarr/pubky.
- **License:** MIT — compatible with the crate's MIT license.
- **API fit:** exposes exactly what iroh's internal pkarr cannot: `announce_peer(Id, Option<u16>)` / `get_peers(Id)` on **arbitrary 20-byte infohashes** (BEP5), plus BEP44 mutable/immutable put-get if Q3 ever ships the mailbox channel.
- **Async:** `AsyncDht` (default `async` feature) is runtime-agnostic and works under tokio; the crate drives its own UDP actor thread.
- **Dependency weight:** light — 12 small deps (ed25519-dalek, serde_bencode, sha1_smol, lru, flume/futures-lite…); no tokio, no libp2p, no TLS stack.
- **Alternatives (checked honestly):** `rustydht-lib` — abandoned (last release 2022, self-described WIP); `bt-dht`/`dht` — the maintained one on crates.io *is* mainline republished. No credible competitor.
- **wasm (documented, not built — per C1 acceptance):** no raw mainline from browsers (no UDP; iroh itself falls back to the `dns.iroh.link` pkarr HTTP relay). The wasm locator needs a relay bridge or PDS fallback — recorded in the module docs, coordinated with #470.

## What this adds

- `mainline = { version = "7.0", optional = true }` in the `gittorrent` crate (Track C's home; renamed `hyprstream-p2p` in #902), behind a new **`mainline-locator`** feature. **Off by default; no default feature pulls it in** — nothing ships enabled.
- `gittorrent::locator` — a thin wrapper with the TRUNC20-confinement API shape (review rule R2):
  - `Cid512` — the only public key type (full 64-byte BLAKE3-512 CID in; no constructor from shorter input).
  - `rendezvous_infohash()` — the **single, private** 64→20-byte truncation site; C2 (#890) swaps in the k-derived rendezvous here without widening its scope.
  - `MainlineLocator::{announce, providers}` — candidate peers out, documented as untrusted hints (GATE verification downstream).
  - `Bep5Client` trait seam — real `MainlineBep5` (AsyncDht) impl + injectable mock, so C2+ can add scoring/relay variants.
- Unit tests use an in-memory mock only — **no network, no sockets, CI-safe** (roundtrip, empty lookup, truncation-is-prefix, 20-byte-prefix collision documentation, Cid512 length validation).

Deliberately *not* here (later Track C stories): k-derived rendezvous + epoch (C2 #890), provider scoring/parallel fetch/size caps (C3 #891), R1/R7 API enforcement (C4 #892), any wasm relay bridge.
