### PR TITLE
feat(ledger): hyprstream-ledger crate — types, LedgerBackend trait, MemLedger oracle (#923 item 1.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7125,6 +7125,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyprstream-ledger"
+version = "0.1.0"
+dependencies = [
+ "bitflags 2.11.0",
+ "blake3",
+ "ciborium",
+ "ed25519-dalek 2.2.0",
+ "hyprstream-crypto",
+ "proptest",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "hyprstream-metrics"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "crates/hyprstream-workers-wasmtime",
     "crates/hyprstream-workers-python",
     "crates/hyprstream-k8s",
+    "crates/hyprstream-ledger",
 ]
 # bitsandbytes-sys is standalone - only built when bnb feature is enabled.
 # The wasm guests (hyprstream-workers-python-guest = wasm32-unknown-unknown cdylib; the

--- a/crates/hyprstream-ledger/Cargo.toml
+++ b/crates/hyprstream-ledger/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "hyprstream-ledger"
+version = "0.1.0"
+edition.workspace = true
+license = "MIT"
+repository.workspace = true
+description = "Embedded double-entry credit engine (accounting plane): LedgerBackend trait, MemLedger reference/oracle, two-phase transfer state machine (#923)"
+
+# The core crate carries no tokio, no FFI, no RPC/VFS/PDS deps (D3): it must
+# build for wasm32-unknown-unknown so a browser cell / Wanix guest can run a real
+# ledger for local-first quota. `hyprstream-crypto` (#920, WASM-safe) is an
+# UNCONDITIONAL dependency — signed checkpoints are load-bearing, so a build that
+# cannot verify them must not exist (no `cose` feature gate, ratified).
+#
+# The `rocks` (RocksLedger, item 1.2) and `tigerbeetle` (item 2.5) backends land
+# behind their own cargo features in later work items; they are intentionally
+# absent here so the skeleton stays FFI-free and wasm-clean.
+
+[dependencies]
+hyprstream-crypto = { path = "../hyprstream-crypto" }
+
+blake3 = { workspace = true }
+bitflags = { workspace = true, features = ["serde"] }
+ciborium = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+ed25519-dalek = { workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/hyprstream-ledger/src/backend.rs
+++ b/crates/hyprstream-ledger/src/backend.rs
@@ -1,0 +1,80 @@
+//! The `LedgerBackend` trait — the load-bearing accounting-plane surface every
+//! backend (MemLedger now; RocksLedger, TigerBeetleLedger later) implements, and
+//! the enforcer builds on (plan §3.2).
+//!
+//! PLAN DECISION 8: the trait is **synchronous and blocking**. Every backend is
+//! single-writer anyway (plan §2a), so the service layer owns the actor thread
+//! and exposes the async facade (`LedgerHandle::submit → oneshot`). Keeping the
+//! core sync is what keeps it tokio-free (the WASM requirement), matches
+//! RocksDB's sync API, and confines TigerBeetle's async client inside its feature
+//! gate.
+
+use crate::errors::LedgerError;
+use crate::journal::{
+    ChainHead, CheckpointSigner, JournalEntry, OutboxItem, OutboxSeq, SignedCheckpoint, TickReport,
+};
+use crate::types::{
+    Account, AccountId, AccountSpec, BalanceView, IssueTransfer, Outcome, Transfer, TransferId,
+};
+
+/// A single-writer double-entry ledger over one consistency domain (one cell).
+///
+/// # Idempotency contract (plan §2c)
+///
+/// Every mutating method carries a client-supplied [`TransferId`]. Replaying a
+/// `TransferId` returns the **original** [`Outcome`] verbatim — including the
+/// original error. This is a trait contract, property-tested against every
+/// backend against the MemLedger oracle. (Backends may return
+/// [`LedgerError::IdTooOld`] once the outcome row is pruned past the retention
+/// horizon — a later work item; MemLedger keeps everything and never prunes.)
+pub trait LedgerBackend: Send {
+    /// Idempotent. Creates the account iff absent and returns it; if it already
+    /// exists the existing row is returned (its unit must match, else
+    /// [`LedgerError::AccountUnitConflict`]).
+    fn open_account(&mut self, spec: AccountSpec) -> Result<Account, LedgerError>;
+
+    /// Single-phase issuance: issuer liability → destination. INV-1: the only
+    /// entry point that grows a unit's supply; the debit side MUST be the
+    /// issuer's `IssuerLiability` account for the unit (checked).
+    fn credit(&mut self, t: IssueTransfer) -> Outcome;
+
+    /// Single-phase spend. Overdraft-checked on the debit side (plan §2b.1).
+    fn debit(&mut self, t: Transfer) -> Outcome;
+
+    /// Two-phase phase 1: places pending holds on both sides (plan §2b). The
+    /// transfer's `id` is also the reservation id used by `post`/`void`.
+    fn reserve(&mut self, t: Transfer, timeout_s: u32) -> Outcome;
+
+    /// Two-phase phase 2. `amount: None` = full post; `Some(p)` = partial, the
+    /// remainder released. At most one second phase succeeds per reservation.
+    fn post(&mut self, id: TransferId, pending: TransferId, amount: Option<u128>) -> Outcome;
+
+    /// Two-phase phase 2 cancel: releases the pending holds.
+    fn void(&mut self, id: TransferId, pending: TransferId) -> Outcome;
+
+    /// Read-only balance projection (served from a consistent snapshot; safe
+    /// concurrent with the writer).
+    fn balance(&self, account: AccountId) -> Result<BalanceView, LedgerError>;
+
+    /// Force a signed checkpoint now and return it. Periodic checkpoints are the
+    /// backend's own duty (driven from `tick`).
+    fn checkpoint(&mut self, signer: &dyn CheckpointSigner)
+        -> Result<SignedCheckpoint, LedgerError>;
+
+    /// Housekeeping: expiry sweep (plan §2b.4), outcome pruning (plan §2c — later
+    /// item), and scheduled checkpoints. Called by the actor on an interval.
+    fn tick(&mut self, signer: &dyn CheckpointSigner) -> Result<TickReport, LedgerError>;
+
+    /// Ordered peek at committed-but-unemitted proof-plane items (plan §2e).
+    fn outbox_peek(&self, max: usize) -> Result<Vec<OutboxItem>, LedgerError>;
+
+    /// Acknowledge (drop) drained outbox items up to and including `up_to`.
+    fn outbox_ack(&mut self, up_to: OutboxSeq) -> Result<(), LedgerError>;
+
+    /// Replay/inspection window into the journal (for verify tools and
+    /// settlement framing).
+    fn journal_range(&self, from_seq: u64, max: usize) -> Result<Vec<JournalEntry>, LedgerError>;
+
+    /// The current head of the hash chain.
+    fn head(&self) -> ChainHead;
+}

--- a/crates/hyprstream-ledger/src/backend.rs
+++ b/crates/hyprstream-ledger/src/backend.rs
@@ -58,8 +58,10 @@ pub trait LedgerBackend: Send {
 
     /// Force a signed checkpoint now and return it. Periodic checkpoints are the
     /// backend's own duty (driven from `tick`).
-    fn checkpoint(&mut self, signer: &dyn CheckpointSigner)
-        -> Result<SignedCheckpoint, LedgerError>;
+    fn checkpoint(
+        &mut self,
+        signer: &dyn CheckpointSigner,
+    ) -> Result<SignedCheckpoint, LedgerError>;
 
     /// Housekeeping: expiry sweep (plan §2b.4), outcome pruning (plan §2c — later
     /// item), and scheduled checkpoints. Called by the actor on an interval.

--- a/crates/hyprstream-ledger/src/engine.rs
+++ b/crates/hyprstream-ledger/src/engine.rs
@@ -1,0 +1,416 @@
+//! The pure, backend-agnostic transfer state machine (plan §2a step 2, §2b).
+//!
+//! `stage` is a **total, default-deny** function of `(current state, op)` →
+//! `(result, deltas)`. It performs no I/O and no mutation: it reads the current
+//! state through [`StateView`] and returns the deltas a backend must apply
+//! atomically inside its serialized commit. RocksLedger and MemLedger share this
+//! module verbatim, which is what makes "same op sequence ⇒ same outcomes"
+//! true by construction (backend-equivalence).
+//!
+//! There are no TOCTOU races here: within one cell ledger there is a single
+//! writer, so every interleaving question reduces to an *ordering* question, and
+//! the ordering is fixed by the sequence in which ops reach `stage`.
+
+use crate::errors::LedgerError;
+use crate::types::{
+    Account, AccountId, AccountSpec, IssueTransfer, PendingReservation, PendingState, Transfer,
+    TransferId, TransferResult,
+};
+
+/// Minimum reservation timeout (plan §2b.6).
+pub const MIN_TIMEOUT_S: u32 = 1;
+/// Maximum reservation timeout — day-plus holds are tranches, not reservations.
+pub const MAX_TIMEOUT_S: u32 = 24 * 60 * 60;
+
+/// Read-only view of ledger state the engine needs. Backends implement this over
+/// their own storage (a `BTreeMap` for MemLedger, RocksDB point-reads for
+/// RocksLedger).
+pub trait StateView {
+    /// Look up an account by id.
+    fn account(&self, id: AccountId) -> Option<&Account>;
+    /// Look up a pending reservation by its phase-1 transfer id.
+    fn pending(&self, id: TransferId) -> Option<&PendingReservation>;
+    /// The ledger's logical commit clock (seconds). Deadlines are judged against
+    /// this at apply time (plan §2b.5) — never a caller clock.
+    fn now(&self) -> u64;
+}
+
+/// An op the engine can stage. The idempotency key (where present) is the
+/// carried `TransferId`; `stage` never dedups — that is the commit loop's job
+/// (it checks the outcome index before calling `stage`).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum Op {
+    /// Create an account (boxed to keep the enum small). Idempotent by derived
+    /// id; the backend's fast path returns an existing account without a journal
+    /// entry, so this variant is only committed on real creation.
+    OpenAccount(Box<AccountSpec>),
+    /// Single-phase issuance (supply growth).
+    Credit(IssueTransfer),
+    /// Single-phase spend.
+    Debit(Transfer),
+    /// Phase-1 reservation.
+    Reserve {
+        /// The reserve transfer.
+        transfer: Transfer,
+        /// Timeout in seconds (validated against `[MIN,MAX]_TIMEOUT_S`).
+        timeout_s: u32,
+    },
+    /// Phase-2 post. `amount: None` = full; `Some(p)` = partial (remainder released).
+    Post {
+        /// This post's own idempotency id.
+        id: TransferId,
+        /// The phase-1 reservation being resolved.
+        pending: TransferId,
+        /// Optional partial amount.
+        amount: Option<u128>,
+    },
+    /// Phase-2 void (release the hold).
+    Void {
+        /// This void's own idempotency id.
+        id: TransferId,
+        /// The phase-1 reservation being cancelled.
+        pending: TransferId,
+    },
+    /// Sweep-driven expiry of a single reservation (plan §2b.4). Emitted by the
+    /// backend's `tick`, not by callers; it has no external idempotency id.
+    Expire {
+        /// The reservation to expire.
+        pending: TransferId,
+    },
+}
+
+impl Op {
+    /// The idempotency key for this op, if it carries one. `Expire` is
+    /// internally generated and has none.
+    pub fn idempotency_id(&self) -> Option<TransferId> {
+        // `Credit`/`Debit` carry different payload types, so their identical
+        // bodies cannot be merged into one arm.
+        #[allow(clippy::match_same_arms)]
+        match self {
+            Op::OpenAccount(_) | Op::Expire { .. } => None,
+            Op::Credit(t) => Some(t.id),
+            Op::Debit(t) => Some(t.id),
+            Op::Reserve { transfer, .. } => Some(transfer.id),
+            Op::Post { id, .. } | Op::Void { id, .. } => Some(*id),
+        }
+    }
+}
+
+/// A single state mutation the commit loop must apply atomically.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Delta {
+    /// Upsert an account row (keyed by `account.id`).
+    Account(Account),
+    /// Upsert a pending reservation row (keyed by `reservation.transfer.id`).
+    Pending(PendingReservation),
+}
+
+/// The output of [`stage`]: the business result plus the deltas to apply. On an
+/// error result `deltas` is usually empty, but not always — an on-touch expiry
+/// (plan §2b.4) both fails the second phase *and* releases the hold, so a failed
+/// post can carry the expiry delta.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Staged {
+    /// The result recorded under the op's idempotency id.
+    pub result: Result<TransferResult, LedgerError>,
+    /// State mutations to commit atomically with the journal entry.
+    pub deltas: Vec<Delta>,
+}
+
+impl Staged {
+    fn err(e: LedgerError) -> Self {
+        Staged {
+            result: Err(e),
+            deltas: Vec::new(),
+        }
+    }
+}
+
+/// Stage an op against the current state. Pure: no mutation, no I/O.
+pub fn stage(view: &dyn StateView, op: &Op) -> Staged {
+    match op {
+        Op::OpenAccount(spec) => stage_open(view, spec),
+        Op::Credit(t) => stage_credit(view, t),
+        Op::Debit(t) => stage_debit(view, t),
+        Op::Reserve { transfer, timeout_s } => stage_reserve(view, transfer, *timeout_s),
+        Op::Post { pending, amount, .. } => stage_second_phase(view, *pending, Phase::Post(*amount)),
+        Op::Void { pending, .. } => stage_second_phase(view, *pending, Phase::Void),
+        Op::Expire { pending } => stage_second_phase(view, *pending, Phase::Expire),
+    }
+}
+
+fn stage_open(view: &dyn StateView, spec: &AccountSpec) -> Staged {
+    let id = spec.account_id();
+    if let Some(existing) = view.account(id) {
+        if existing.unit != spec.unit {
+            return Staged::err(LedgerError::AccountUnitConflict { id });
+        }
+        // Idempotent no-op (the backend fast-paths this before staging, so this
+        // arm is defensive).
+        return Staged {
+            result: Ok(TransferResult::Opened),
+            deltas: Vec::new(),
+        };
+    }
+    let account = Account::new(id, spec.unit.clone(), spec.flags);
+    Staged {
+        result: Ok(TransferResult::Opened),
+        deltas: vec![Delta::Account(account)],
+    }
+}
+
+fn stage_credit(view: &dyn StateView, t: &IssueTransfer) -> Staged {
+    if t.amount == 0 {
+        return Staged::err(LedgerError::ZeroAmount);
+    }
+    let (liability, dest) =
+        match (view.account(t.issuer_liability), view.account(t.destination)) {
+            (Some(l), Some(d)) => (l, d),
+            (None, _) => return Staged::err(LedgerError::UnknownAccount(t.issuer_liability)),
+            (_, None) => return Staged::err(LedgerError::UnknownAccount(t.destination)),
+        };
+    // The debit side must be an issuer-liability account (INV-1).
+    if t.issuer_liability == t.destination {
+        return Staged::err(LedgerError::AccountsMustDiffer(t.issuer_liability));
+    }
+    if liability.is_debit_constrained() {
+        return Staged::err(LedgerError::NotIssuerLiability(t.issuer_liability));
+    }
+    if let Err(e) = check_unit(liability, &t.unit) {
+        return Staged::err(e);
+    }
+    if let Err(e) = check_unit(dest, &t.unit) {
+        return Staged::err(e);
+    }
+    let mut liability = liability.clone();
+    let mut dest = dest.clone();
+    liability.debits_posted = liability.debits_posted.saturating_add(t.amount);
+    dest.credits_posted = dest.credits_posted.saturating_add(t.amount);
+    Staged {
+        result: Ok(TransferResult::Issued),
+        deltas: vec![Delta::Account(liability), Delta::Account(dest)],
+    }
+}
+
+fn stage_debit(view: &dyn StateView, t: &Transfer) -> Staged {
+    let (debit, credit) = match resolve_pair(view, t.debit_account, t.credit_account, &t.unit) {
+        Ok(p) => p,
+        Err(e) => return Staged::err(e),
+    };
+    if t.amount == 0 {
+        return Staged::err(LedgerError::ZeroAmount);
+    }
+    if debit.is_debit_constrained() && t.amount > debit.available() {
+        return Staged::err(LedgerError::InsufficientBalance {
+            account: debit.id,
+            needed: t.amount,
+            available: debit.available(),
+        });
+    }
+    let mut debit = debit.clone();
+    let mut credit = credit.clone();
+    debit.debits_posted = debit.debits_posted.saturating_add(t.amount);
+    credit.credits_posted = credit.credits_posted.saturating_add(t.amount);
+    Staged {
+        result: Ok(TransferResult::Applied {
+            posted: t.amount,
+            released: 0,
+        }),
+        deltas: vec![Delta::Account(debit), Delta::Account(credit)],
+    }
+}
+
+fn stage_reserve(view: &dyn StateView, t: &Transfer, timeout_s: u32) -> Staged {
+    if !(MIN_TIMEOUT_S..=MAX_TIMEOUT_S).contains(&timeout_s) {
+        return Staged::err(LedgerError::TimeoutOutOfBounds(timeout_s));
+    }
+    let (debit, credit) = match resolve_pair(view, t.debit_account, t.credit_account, &t.unit) {
+        Ok(p) => p,
+        Err(e) => return Staged::err(e),
+    };
+    if t.amount == 0 {
+        return Staged::err(LedgerError::ZeroAmount);
+    }
+    // Overdraft check counts pending (plan §2b.1): `available` already subtracts
+    // `debits_pending`, so back-to-back reserves cannot over-commit.
+    if debit.is_debit_constrained() && t.amount > debit.available() {
+        return Staged::err(LedgerError::InsufficientBalance {
+            account: debit.id,
+            needed: t.amount,
+            available: debit.available(),
+        });
+    }
+    let mut debit = debit.clone();
+    let mut credit = credit.clone();
+    debit.debits_pending = debit.debits_pending.saturating_add(t.amount);
+    credit.credits_pending = credit.credits_pending.saturating_add(t.amount);
+    let reservation = PendingReservation {
+        transfer: t.clone(),
+        deadline: view.now().saturating_add(timeout_s as u64),
+        state: PendingState::Pending,
+    };
+    Staged {
+        result: Ok(TransferResult::Reserved),
+        deltas: vec![
+            Delta::Account(debit),
+            Delta::Account(credit),
+            Delta::Pending(reservation),
+        ],
+    }
+}
+
+/// The three second-phase resolutions, unified because they share the
+/// terminal-state and on-touch-expiry rules.
+enum Phase {
+    Post(Option<u128>),
+    Void,
+    Expire,
+}
+
+fn stage_second_phase(view: &dyn StateView, pending_id: TransferId, phase: Phase) -> Staged {
+    let reservation = match view.pending(pending_id) {
+        Some(r) => r,
+        None => return Staged::err(LedgerError::UnknownPendingTransfer(pending_id)),
+    };
+
+    // Already terminal ⇒ deterministic loser error (plan §2b.5). The first
+    // terminal commit won; this op observes that state.
+    match reservation.state {
+        PendingState::Pending => {}
+        PendingState::Posted => {
+            return Staged::err(LedgerError::PendingTransferAlreadyPosted(pending_id))
+        }
+        PendingState::Voided => {
+            return Staged::err(LedgerError::PendingTransferAlreadyVoided(pending_id))
+        }
+        PendingState::Expired => {
+            return Staged::err(LedgerError::PendingTransferExpired(pending_id))
+        }
+    }
+
+    let t = &reservation.transfer;
+    let debit = match view.account(t.debit_account) {
+        Some(a) => a,
+        None => return Staged::err(LedgerError::UnknownAccount(t.debit_account)),
+    };
+    let credit = match view.account(t.credit_account) {
+        Some(a) => a,
+        None => return Staged::err(LedgerError::UnknownAccount(t.credit_account)),
+    };
+
+    // On-touch expiry (plan §2b.4): if the deadline has passed by the logical
+    // commit clock, expire the reservation *in this same commit* and fail the
+    // second phase (unless the op itself is the expiry). This is what makes the
+    // expiry-vs-post race deterministic: whichever commits first wins.
+    let expired_now = view.now() >= reservation.deadline;
+    if matches!(phase, Phase::Expire) || expired_now {
+        let released = release(debit, credit, t.amount);
+        let mut res = reservation.clone();
+        res.state = PendingState::Expired;
+        let deltas = vec![released.0, released.1, Delta::Pending(res)];
+        // A caller's post/void that lost to expiry gets the deterministic error;
+        // the sweep-driven `Expire` op reports success.
+        let result = if matches!(phase, Phase::Expire) {
+            Ok(TransferResult::Expired)
+        } else {
+            Err(LedgerError::PendingTransferExpired(pending_id))
+        };
+        return Staged { result, deltas };
+    }
+
+    match phase {
+        Phase::Void => {
+            let (d_delta, c_delta) = release(debit, credit, t.amount);
+            let mut res = reservation.clone();
+            res.state = PendingState::Voided;
+            Staged {
+                result: Ok(TransferResult::Voided),
+                deltas: vec![d_delta, c_delta, Delta::Pending(res)],
+            }
+        }
+        Phase::Post(amount) => {
+            let reserved = t.amount;
+            let post_amt = amount.unwrap_or(reserved);
+            if post_amt == 0 {
+                return Staged::err(LedgerError::ZeroAmount);
+            }
+            if post_amt > reserved {
+                return Staged::err(LedgerError::PostExceedsReservation {
+                    requested: post_amt,
+                    reserved,
+                });
+            }
+            let released = reserved - post_amt;
+            let mut debit = debit.clone();
+            let mut credit = credit.clone();
+            // The full reserved amount leaves pending; `post_amt` becomes posted,
+            // the remainder is simply released.
+            debit.debits_pending = debit.debits_pending.saturating_sub(reserved);
+            credit.credits_pending = credit.credits_pending.saturating_sub(reserved);
+            debit.debits_posted = debit.debits_posted.saturating_add(post_amt);
+            credit.credits_posted = credit.credits_posted.saturating_add(post_amt);
+            let mut res = reservation.clone();
+            res.state = PendingState::Posted;
+            Staged {
+                result: Ok(TransferResult::Applied {
+                    posted: post_amt,
+                    released,
+                }),
+                deltas: vec![
+                    Delta::Account(debit),
+                    Delta::Account(credit),
+                    Delta::Pending(res),
+                ],
+            }
+        }
+        Phase::Expire => unreachable_expire(),
+    }
+}
+
+/// Release a full pending hold on both sides (void / expire).
+fn release(debit: &Account, credit: &Account, amount: u128) -> (Delta, Delta) {
+    let mut debit = debit.clone();
+    let mut credit = credit.clone();
+    debit.debits_pending = debit.debits_pending.saturating_sub(amount);
+    credit.credits_pending = credit.credits_pending.saturating_sub(amount);
+    (Delta::Account(debit), Delta::Account(credit))
+}
+
+/// The `Phase::Expire` arm inside the non-expired branch is unreachable: the
+/// expiry path is handled before the `match phase` above. We return a fail-closed
+/// internal error rather than panic (clippy forbids `unreachable!` here anyway).
+fn unreachable_expire() -> Staged {
+    Staged::err(LedgerError::Internal(
+        "expire reached the non-expired second-phase arm".to_owned(),
+    ))
+}
+
+fn resolve_pair<'a>(
+    view: &'a dyn StateView,
+    debit_id: AccountId,
+    credit_id: AccountId,
+    unit: &crate::types::UnitId,
+) -> Result<(&'a Account, &'a Account), LedgerError> {
+    if debit_id == credit_id {
+        return Err(LedgerError::AccountsMustDiffer(debit_id));
+    }
+    let debit = view
+        .account(debit_id)
+        .ok_or(LedgerError::UnknownAccount(debit_id))?;
+    let credit = view
+        .account(credit_id)
+        .ok_or(LedgerError::UnknownAccount(credit_id))?;
+    check_unit(debit, unit)?;
+    check_unit(credit, unit)?;
+    Ok((debit, credit))
+}
+
+fn check_unit(account: &Account, unit: &crate::types::UnitId) -> Result<(), LedgerError> {
+    if &account.unit != unit {
+        return Err(LedgerError::UnitMismatch {
+            transfer: unit.clone(),
+            account: account.unit.clone(),
+        });
+    }
+    Ok(())
+}

--- a/crates/hyprstream-ledger/src/engine.rs
+++ b/crates/hyprstream-ledger/src/engine.rs
@@ -13,8 +13,8 @@
 
 use crate::errors::LedgerError;
 use crate::types::{
-    Account, AccountId, AccountSpec, IssueTransfer, PendingReservation, PendingState, Transfer,
-    TransferId, TransferResult,
+    Account, AccountId, AccountSpec, IssueTransfer, PendingReservation, PendingState, Purpose,
+    Transfer, TransferId, TransferResult,
 };
 
 /// Minimum reservation timeout (plan §2b.6).
@@ -132,8 +132,13 @@ pub fn stage(view: &dyn StateView, op: &Op) -> Staged {
         Op::OpenAccount(spec) => stage_open(view, spec),
         Op::Credit(t) => stage_credit(view, t),
         Op::Debit(t) => stage_debit(view, t),
-        Op::Reserve { transfer, timeout_s } => stage_reserve(view, transfer, *timeout_s),
-        Op::Post { pending, amount, .. } => stage_second_phase(view, *pending, Phase::Post(*amount)),
+        Op::Reserve {
+            transfer,
+            timeout_s,
+        } => stage_reserve(view, transfer, *timeout_s),
+        Op::Post {
+            pending, amount, ..
+        } => stage_second_phase(view, *pending, Phase::Post(*amount)),
         Op::Void { pending, .. } => stage_second_phase(view, *pending, Phase::Void),
         Op::Expire { pending } => stage_second_phase(view, *pending, Phase::Expire),
     }
@@ -152,7 +157,7 @@ fn stage_open(view: &dyn StateView, spec: &AccountSpec) -> Staged {
             deltas: Vec::new(),
         };
     }
-    let account = Account::new(id, spec.unit.clone(), spec.flags);
+    let account = Account::new(id, spec.unit.clone(), spec.purpose.clone(), spec.flags);
     Staged {
         result: Ok(TransferResult::Opened),
         deltas: vec![Delta::Account(account)],
@@ -163,17 +168,19 @@ fn stage_credit(view: &dyn StateView, t: &IssueTransfer) -> Staged {
     if t.amount == 0 {
         return Staged::err(LedgerError::ZeroAmount);
     }
-    let (liability, dest) =
-        match (view.account(t.issuer_liability), view.account(t.destination)) {
-            (Some(l), Some(d)) => (l, d),
-            (None, _) => return Staged::err(LedgerError::UnknownAccount(t.issuer_liability)),
-            (_, None) => return Staged::err(LedgerError::UnknownAccount(t.destination)),
-        };
+    let (liability, dest) = match (
+        view.account(t.issuer_liability),
+        view.account(t.destination),
+    ) {
+        (Some(l), Some(d)) => (l, d),
+        (None, _) => return Staged::err(LedgerError::UnknownAccount(t.issuer_liability)),
+        (_, None) => return Staged::err(LedgerError::UnknownAccount(t.destination)),
+    };
     // The debit side must be an issuer-liability account (INV-1).
     if t.issuer_liability == t.destination {
         return Staged::err(LedgerError::AccountsMustDiffer(t.issuer_liability));
     }
-    if liability.is_debit_constrained() {
+    if liability.purpose != Purpose::IssuerLiability {
         return Staged::err(LedgerError::NotIssuerLiability(t.issuer_liability));
     }
     if let Err(e) = check_unit(liability, &t.unit) {

--- a/crates/hyprstream-ledger/src/engine.rs
+++ b/crates/hyprstream-ledger/src/engine.rs
@@ -145,7 +145,10 @@ pub fn stage(view: &dyn StateView, op: &Op) -> Staged {
 }
 
 fn stage_open(view: &dyn StateView, spec: &AccountSpec) -> Staged {
-    let id = spec.account_id();
+    let id = match spec.account_id() {
+        Ok(id) => id,
+        Err(e) => return Staged::err(e),
+    };
     if let Some(existing) = view.account(id) {
         if existing.unit != spec.unit {
             return Staged::err(LedgerError::AccountUnitConflict { id });

--- a/crates/hyprstream-ledger/src/errors.rs
+++ b/crates/hyprstream-ledger/src/errors.rs
@@ -1,0 +1,116 @@
+//! The ledger error vocabulary.
+//!
+//! Errors are **data** (no wrapped source types) so an [`crate::Outcome`] is
+//! `Clone + PartialEq + Eq` and a replay can be asserted byte-identical to the
+//! original — the property the idempotency proptests lean on.
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::types::{AccountId, TransferId, UnitId};
+
+/// Every way a ledger operation can fail. All variants are deterministic
+/// functions of `(current state, op)` so a replay reproduces them exactly.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
+pub enum LedgerError {
+    /// A referenced account does not exist.
+    #[error("unknown account {0:?}")]
+    UnknownAccount(AccountId),
+
+    /// The transfer's unit does not match a touched account's unit (INV-1(b)).
+    #[error("unit mismatch: transfer unit {transfer:?} != account unit {account:?}")]
+    UnitMismatch {
+        /// The unit named on the transfer.
+        transfer: UnitId,
+        /// The unit denormalized on the account.
+        account: UnitId,
+    },
+
+    /// `open_account` was called for an existing id but with a different unit.
+    #[error("account {id:?} already exists with a different unit")]
+    AccountUnitConflict {
+        /// The account id whose unit conflicts.
+        id: AccountId,
+    },
+
+    /// The debit account cannot cover the amount once pending holds are counted
+    /// (overdraft floor, plan §2b.1).
+    #[error("insufficient balance on {account:?}: need {needed}, available {available}")]
+    InsufficientBalance {
+        /// The debit account.
+        account: AccountId,
+        /// Amount requested.
+        needed: u128,
+        /// Amount actually available.
+        available: u128,
+    },
+
+    /// Amount was zero (transfers must move a positive amount).
+    #[error("amount must be greater than zero")]
+    ZeroAmount,
+
+    /// A transfer named the same account on both sides. Double-entry requires two
+    /// distinct accounts (the TigerBeetle `accounts_must_be_different` rule) — a
+    /// self-transfer is meaningless and would collapse two deltas onto one row.
+    #[error("debit and credit accounts must differ ({0:?})")]
+    AccountsMustDiffer(AccountId),
+
+    /// A partial post named an amount larger than the reservation.
+    #[error("post amount {requested} exceeds reserved {reserved}")]
+    PostExceedsReservation {
+        /// Requested post amount.
+        requested: u128,
+        /// The reserved amount.
+        reserved: u128,
+    },
+
+    /// `credit` was called with a debit side that is not an issuer-liability
+    /// account (INV-1: issuance must debit the issuer's own liability).
+    #[error("issuance debit account {0:?} is not an issuer-liability account")]
+    NotIssuerLiability(AccountId),
+
+    /// A second-phase op named a pending id that does not exist.
+    #[error("unknown pending transfer {0:?}")]
+    UnknownPendingTransfer(TransferId),
+
+    /// The reservation's deadline passed before this second phase committed
+    /// (plan §2b.5 — the loser of the expiry-vs-post race).
+    #[error("pending transfer {0:?} expired")]
+    PendingTransferExpired(TransferId),
+
+    /// The reservation was already posted by an earlier second phase.
+    #[error("pending transfer {0:?} already posted")]
+    PendingTransferAlreadyPosted(TransferId),
+
+    /// The reservation was already voided by an earlier second phase.
+    #[error("pending transfer {0:?} already voided")]
+    PendingTransferAlreadyVoided(TransferId),
+
+    /// A reservation timeout was outside the permitted `[1s, 24h]` band.
+    #[error("reservation timeout {0}s out of bounds")]
+    TimeoutOutOfBounds(u32),
+
+    /// A replay arrived for a `TransferId` whose outcome row was already pruned
+    /// past the retention horizon (plan §2c). Distinguishable from "never seen"
+    /// so a caller escalates rather than blindly re-executing. (MemLedger never
+    /// prunes, so it never returns this; retention lands with a later work item.)
+    #[error("transfer id {0:?} is older than the outcome-retention horizon")]
+    IdTooOld(TransferId),
+
+    /// A replay was detected. The reference contract is **transparent replay**
+    /// (the stored [`crate::Outcome`] is returned verbatim), so MemLedger does
+    /// not surface this; it exists for backends that prefer an explicit signal,
+    /// carrying the original outcome.
+    #[error("duplicate transfer id {id:?}")]
+    DuplicateTransferId {
+        /// The replayed id.
+        id: TransferId,
+        /// The original recorded outcome, boxed to keep the enum small.
+        original: Box<crate::types::Outcome>,
+    },
+
+    /// An internal invariant/encoding failure. Fail-closed: the op is rejected
+    /// without mutating state, and is retryable.
+    #[error("internal ledger error: {0}")]
+    Internal(String),
+}

--- a/crates/hyprstream-ledger/src/journal.rs
+++ b/crates/hyprstream-ledger/src/journal.rs
@@ -1,0 +1,314 @@
+//! Journal, checkpoint, and outbox types + the checkpoint signing seam (plan
+//! §2a, §2d, §2e).
+//!
+//! Scope note: the hash-chained journal *data model* and the checkpoint
+//! *commitments* live here so the [`crate::LedgerBackend`] trait is complete and
+//! MemLedger is a true oracle. The RocksDB-persisted journal, group commit, and
+//! the standalone `hyprstream ledger verify` offline tool are later work items
+//! (1.2/1.3/1.10); this module builds only the in-memory reference.
+
+use serde::{Deserialize, Serialize};
+
+use crate::engine::Op;
+use crate::errors::LedgerError;
+use crate::types::{Account, Did, PendingReservation, TransferId, TransferResult};
+
+/// Domain-separation tag for checkpoint signatures (plan §2d).
+pub const CHECKPOINT_DOMAIN: &[u8] = b"hs-ledger-checkpoint-v1";
+
+/// One committed operation in the hash chain. `prev_hash` links it to the prior
+/// entry; the *outcome* is in the chain too (plan §2a step 3), so tampering with
+/// a result breaks the chain.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct JournalEntry {
+    /// Monotonic sequence, starting at 1.
+    pub seq: u64,
+    /// Hash of entry `seq - 1` (`[0u8; 32]` for the genesis entry).
+    pub prev_hash: [u8; 32],
+    /// Logical commit timestamp.
+    pub ts: u64,
+    /// The op that was applied.
+    pub op: Op,
+    /// The recorded result (`Ok` summary or the deterministic error).
+    pub result: Result<TransferResult, LedgerError>,
+}
+
+impl JournalEntry {
+    /// The blake3-256 hash of this entry's canonical encoding. Used as the next
+    /// entry's `prev_hash` and as the checkpoint `head_hash`.
+    pub fn hash(&self) -> Result<[u8; 32], LedgerError> {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"hs-ledger-journal-entry-v1");
+        cbor_into(&mut hasher, self)?;
+        Ok(*hasher.finalize().as_bytes())
+    }
+}
+
+/// The head of the hash chain — the constant-size commitment the backend keeps
+/// in memory and (for RocksLedger) at `CF(meta)/"head"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct ChainHead {
+    /// Sequence of the last committed entry (`0` when empty).
+    pub seq: u64,
+    /// Hash of the last committed entry (`[0u8; 32]` when empty).
+    pub head_hash: [u8; 32],
+}
+
+/// Ordered position of an outbox item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct OutboxSeq(pub u64);
+
+/// What a proof-plane item evidences (plan §2e). The ledger crate only *stages*
+/// these; the service layer drains and emits them to the PDS.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OutboxKind {
+    /// A dual-signed usage receipt for a posted spend/issue.
+    Receipt,
+    /// A signed checkpoint to publish.
+    Checkpoint,
+}
+
+/// A committed-but-unemitted proof-plane item, staged transactionally with the
+/// ledger commit (the outbox pattern) and drained by
+/// [`crate::LedgerBackend::outbox_peek`] / `outbox_ack`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OutboxItem {
+    /// Ordered position.
+    pub seq: OutboxSeq,
+    /// The kind of proof this item carries.
+    pub kind: OutboxKind,
+    /// The transfer this evidences (for receipts).
+    pub transfer_id: Option<TransferId>,
+    /// The journal sequence of the commit that produced it.
+    pub journal_seq: u64,
+}
+
+/// The injection seam for checkpoint signing (mirrors `mac::audit::AuditSigner`).
+///
+/// PLAN DECISION 8: the seam exists for **key/policy injection**, not
+/// optionality. The production impl (service layer) wraps
+/// `hyprstream_crypto::cose_sign::sign_composite` and is policy-aware
+/// (Hybrid/Classical); tests supply a deterministic signer. `hyprstream-crypto`
+/// is an unconditional dependency — a build that cannot sign checkpoints must not
+/// exist.
+pub trait CheckpointSigner {
+    /// Sign the domain-separated signing input (see [`checkpoint_signing_input`]).
+    fn sign(&self, signing_input: &[u8]) -> Result<Vec<u8>, LedgerError>;
+    /// The signing identity (the cell ledger's service DID).
+    fn ledger_id(&self) -> &Did;
+}
+
+/// A periodic, PQC-hybrid-signed commitment to ledger state (plan §2d). It is the
+/// anchorable object and the settlement reference. Per-commit chaining is cheap
+/// and unsigned; only checkpoints carry a signature.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SignedCheckpoint {
+    /// The cell ledger's service identity.
+    pub ledger_id: Did,
+    /// Journal head at checkpoint time.
+    pub seq: u64,
+    /// Hash of journal entry `seq`.
+    pub head_hash: [u8; 32],
+    /// Merkle-style root over all accounts sorted by id (plan §2d).
+    pub balances_root: [u8; 32],
+    /// Root over open reservations sorted by id.
+    pub pending_root: [u8; 32],
+    /// Logical commit time of the checkpoint.
+    pub ts: u64,
+    /// Hash of the previous checkpoint (checkpoints chain too).
+    pub prev_checkpoint_hash: [u8; 32],
+    /// COSE composite signature over [`checkpoint_signing_input`].
+    pub sig: Vec<u8>,
+}
+
+impl SignedCheckpoint {
+    /// A digest over the whole (signed) checkpoint — the value the next
+    /// checkpoint chains to via `prev_checkpoint_hash`, and the object an OTS
+    /// anchor attests (plan §2h).
+    pub fn digest(&self) -> Result<[u8; 32], LedgerError> {
+        let mut h = blake3::Hasher::new();
+        h.update(b"hs-ledger-checkpoint-digest-v1");
+        cbor_into(&mut h, self)?;
+        Ok(*h.finalize().as_bytes())
+    }
+
+    /// The bytes the signature covers (everything except `sig`).
+    pub fn signing_input(&self) -> Result<Vec<u8>, LedgerError> {
+        let content = CheckpointContent {
+            ledger_id: &self.ledger_id,
+            seq: self.seq,
+            head_hash: self.head_hash,
+            balances_root: self.balances_root,
+            pending_root: self.pending_root,
+            ts: self.ts,
+            prev_checkpoint_hash: self.prev_checkpoint_hash,
+        };
+        content.signing_input()
+    }
+}
+
+/// The signable content of a checkpoint (the `sig`-free projection).
+#[derive(Serialize)]
+pub struct CheckpointContent<'a> {
+    /// See [`SignedCheckpoint::ledger_id`].
+    pub ledger_id: &'a Did,
+    /// See [`SignedCheckpoint::seq`].
+    pub seq: u64,
+    /// See [`SignedCheckpoint::head_hash`].
+    pub head_hash: [u8; 32],
+    /// See [`SignedCheckpoint::balances_root`].
+    pub balances_root: [u8; 32],
+    /// See [`SignedCheckpoint::pending_root`].
+    pub pending_root: [u8; 32],
+    /// See [`SignedCheckpoint::ts`].
+    pub ts: u64,
+    /// See [`SignedCheckpoint::prev_checkpoint_hash`].
+    pub prev_checkpoint_hash: [u8; 32],
+}
+
+impl CheckpointContent<'_> {
+    /// Domain-separated signing input: a content hash prefixed by the domain tag
+    /// (the `mac::audit::audit_signing_input` shape — sign the hash, not the raw
+    /// bytes, so the signature is independent of the canonical-bytes choice).
+    pub fn signing_input(&self) -> Result<Vec<u8>, LedgerError> {
+        let mut hasher = blake3::Hasher::new();
+        cbor_into(&mut hasher, self)?;
+        Ok(checkpoint_signing_input(hasher.finalize().as_bytes()))
+    }
+}
+
+/// Assemble the domain-separated signing input from a 32-byte content hash.
+pub fn checkpoint_signing_input(content_hash: &[u8; 32]) -> Vec<u8> {
+    let mut v = Vec::with_capacity(CHECKPOINT_DOMAIN.len() + 32);
+    v.extend_from_slice(CHECKPOINT_DOMAIN);
+    v.extend_from_slice(content_hash);
+    v
+}
+
+/// Verify a checkpoint's composite signature against the ledger DID's key
+/// material, delegating to `hyprstream_crypto::cose_sign::verify_composite`.
+///
+/// This is the load-bearing use of the unconditional `hyprstream-crypto`
+/// dependency: checkpoint signatures gate anchoring, settlement, and dispute
+/// evidence, so the verification primitive belongs in the ledger crate. Full
+/// journal replay + multi-checkpoint verification (`verify.rs` / the CLI) is a
+/// later work item; this verifies a single checkpoint's signature.
+pub fn verify_checkpoint_signature(
+    cp: &SignedCheckpoint,
+    ed_vk: &ed25519_dalek::VerifyingKey,
+    pq_vk: Option<&hyprstream_crypto::pq::MlDsaVerifyingKey>,
+    require_pq: bool,
+) -> Result<(), LedgerError> {
+    let input = cp.signing_input()?;
+    hyprstream_crypto::cose_sign::verify_composite(&cp.sig, ed_vk, pq_vk, &input, &[], require_pq)
+        .map(|_| ())
+        .map_err(|e| LedgerError::Internal(format!("checkpoint signature invalid: {e}")))
+}
+
+/// Root over accounts sorted by id: `blake3(concat(blake3(id || cbor(account))))`.
+/// A deterministic commitment (not a sparse-Merkle proof system — sufficient for
+/// the drift/equivalence properties; a full accumulator can replace it later
+/// without changing the trait).
+pub fn balances_root<'a>(
+    accounts: impl Iterator<Item = &'a Account>,
+) -> Result<[u8; 32], LedgerError> {
+    let mut sorted: Vec<&Account> = accounts.collect();
+    sorted.sort_by_key(|a| a.id.0);
+    let mut root = blake3::Hasher::new();
+    root.update(b"hs-ledger-balances-root-v1");
+    for a in sorted {
+        let mut leaf = blake3::Hasher::new();
+        leaf.update(&a.id.0.to_be_bytes());
+        cbor_into(&mut leaf, a)?;
+        root.update(leaf.finalize().as_bytes());
+    }
+    Ok(*root.finalize().as_bytes())
+}
+
+/// Root over open (`Pending`) reservations sorted by id.
+pub fn pending_root<'a>(
+    reservations: impl Iterator<Item = &'a PendingReservation>,
+) -> Result<[u8; 32], LedgerError> {
+    let mut sorted: Vec<&PendingReservation> = reservations
+        .filter(|r| r.state == crate::types::PendingState::Pending)
+        .collect();
+    sorted.sort_by_key(|r| r.transfer.id.0);
+    let mut root = blake3::Hasher::new();
+    root.update(b"hs-ledger-pending-root-v1");
+    for r in sorted {
+        let mut leaf = blake3::Hasher::new();
+        leaf.update(&r.transfer.id.0.to_be_bytes());
+        cbor_into(&mut leaf, r)?;
+        root.update(leaf.finalize().as_bytes());
+    }
+    Ok(*root.finalize().as_bytes())
+}
+
+/// What one `tick` did (plan §2b.4 sweep + scheduled checkpoint).
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct TickReport {
+    /// How many reservations the sweep expired.
+    pub expired: usize,
+    /// The sequence at which a checkpoint was cut, if any.
+    pub checkpointed: Option<u64>,
+}
+
+/// Serialize `value` as CBOR directly into a `Write` (a blake3 hasher), mapping
+/// the (practically unreachable) serializer error to a fail-closed
+/// [`LedgerError::Internal`] rather than unwrapping.
+fn cbor_into<W: std::io::Write, T: serde::Serialize>(
+    w: &mut W,
+    value: &T,
+) -> Result<(), LedgerError> {
+    ciborium::into_writer(value, w)
+        .map_err(|e| LedgerError::Internal(format!("cbor encoding failed: {e}")))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use hyprstream_crypto::cose_sign::sign_composite;
+    use hyprstream_crypto::pq::{ml_dsa_sk_from_seed, ml_dsa_sk_to_vk_bytes, ml_dsa_vk_from_bytes};
+
+    /// End-to-end proof that the unconditional `hyprstream-crypto` dependency is
+    /// load-bearing: a checkpoint signed with the hybrid composite (EdDSA +
+    /// ML-DSA-65) verifies, and tampering with a committed field breaks it.
+    #[test]
+    fn checkpoint_hybrid_signature_roundtrips_and_detects_tamper() {
+        let ed_sk = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]);
+        let ed_vk = ed_sk.verifying_key();
+        let pq_sk = ml_dsa_sk_from_seed(&[9u8; 32]);
+        let pq_vk = ml_dsa_vk_from_bytes(&ml_dsa_sk_to_vk_bytes(&pq_sk)).unwrap();
+
+        let content = CheckpointContent {
+            ledger_id: &Did("did:web:cell.test".to_owned()),
+            seq: 42,
+            head_hash: [1u8; 32],
+            balances_root: [2u8; 32],
+            pending_root: [3u8; 32],
+            ts: 1000,
+            prev_checkpoint_hash: [0u8; 32],
+        };
+        let input = content.signing_input().unwrap();
+        let sig = sign_composite(&ed_sk, Some(&pq_sk), &input, &[]).unwrap();
+
+        let mut cp = SignedCheckpoint {
+            ledger_id: Did("did:web:cell.test".to_owned()),
+            seq: 42,
+            head_hash: [1u8; 32],
+            balances_root: [2u8; 32],
+            pending_root: [3u8; 32],
+            ts: 1000,
+            prev_checkpoint_hash: [0u8; 32],
+            sig,
+        };
+
+        // Valid signature verifies (fail-closed require_pq = true).
+        verify_checkpoint_signature(&cp, &ed_vk, Some(&pq_vk), true).unwrap();
+
+        // Tampering with a committed field changes the signing input ⇒ rejected.
+        cp.balances_root = [0xFFu8; 32];
+        assert!(verify_checkpoint_signature(&cp, &ed_vk, Some(&pq_vk), true).is_err());
+    }
+}

--- a/crates/hyprstream-ledger/src/lib.rs
+++ b/crates/hyprstream-ledger/src/lib.rs
@@ -48,7 +48,8 @@ pub use backend::LedgerBackend;
 pub use errors::LedgerError;
 pub use journal::{
     balances_root, checkpoint_signing_input, pending_root, verify_checkpoint_signature, ChainHead,
-    CheckpointSigner, JournalEntry, OutboxItem, OutboxKind, OutboxSeq, SignedCheckpoint, TickReport,
+    CheckpointSigner, JournalEntry, OutboxItem, OutboxKind, OutboxSeq, SignedCheckpoint,
+    TickReport,
 };
 pub use mem::MemLedger;
 pub use types::{

--- a/crates/hyprstream-ledger/src/lib.rs
+++ b/crates/hyprstream-ledger/src/lib.rs
@@ -1,0 +1,57 @@
+//! # hyprstream-ledger
+//!
+//! The **accounting plane** of the cellular-ledger stack (epic #922, plan item
+//! 1.1): an embedded, single-writer, double-entry credit engine that
+//! deliberately mirrors TigerBeetle's data model.
+//!
+//! ## The two invariants (D8)
+//!
+//! - **INV-1 — credits are issuer liabilities, not bearer tokens.** Every unit
+//!   [`UnitId`] names its issuer; every account id bakes that unit in; issuance is
+//!   the only supply-growing entry point and it debits the issuer's own liability.
+//!   There is no representation of value that omits the issuer.
+//! - **INV-2 — no ledger tier on the inference hot path.** This crate is
+//!   synchronous and knows nothing of admission; the enforcer's `CreditGate`
+//!   (a later item) depends on the *types* here, never on a backend, and talks to
+//!   the ledger only through an async actor facade in the service layer.
+//!
+//! ## What is in this crate (item 1.1)
+//!
+//! - [`types`] — the account model, units, transfers, outcomes (plan §2.0).
+//! - [`errors`] — the deterministic error vocabulary.
+//! - [`engine`] — the pure, backend-agnostic transfer state machine (plan §2b),
+//!   shared verbatim by every backend so "same ops ⇒ same outcomes" holds by
+//!   construction.
+//! - [`journal`] — journal / checkpoint / outbox types and the
+//!   [`CheckpointSigner`](journal::CheckpointSigner) injection seam.
+//! - [`backend::LedgerBackend`] — the load-bearing trait.
+//! - [`mem::MemLedger`] — the complete in-memory reference implementation and
+//!   proptest oracle; WASM-friendly (no tokio, no I/O, logical clock only).
+//!
+//! RocksLedger, the persisted hash-chained journal + offline verify tool, the
+//! transactional-outbox emitter, and TigerBeetleLedger are later work items.
+//!
+//! ## Crate boundaries (D3)
+//!
+//! No RPC / VFS / PDS / tokio dependencies. `hyprstream-crypto` (#920, WASM-safe)
+//! is an **unconditional** dependency — signed checkpoints are load-bearing, so a
+//! build that cannot verify them must not exist (no feature gate, ratified).
+
+pub mod backend;
+pub mod engine;
+pub mod errors;
+pub mod journal;
+pub mod mem;
+pub mod types;
+
+pub use backend::LedgerBackend;
+pub use errors::LedgerError;
+pub use journal::{
+    balances_root, checkpoint_signing_input, pending_root, verify_checkpoint_signature, ChainHead,
+    CheckpointSigner, JournalEntry, OutboxItem, OutboxKind, OutboxSeq, SignedCheckpoint, TickReport,
+};
+pub use mem::MemLedger;
+pub use types::{
+    Account, AccountFlags, AccountId, AccountSpec, BalanceView, Cid, Did, IssueTransfer, Outcome,
+    PendingReservation, PendingState, Purpose, Transfer, TransferId, TransferResult, UnitId,
+};

--- a/crates/hyprstream-ledger/src/mem.rs
+++ b/crates/hyprstream-ledger/src/mem.rs
@@ -198,7 +198,7 @@ impl engine::StateView for MemLedger {
 
 impl LedgerBackend for MemLedger {
     fn open_account(&mut self, spec: AccountSpec) -> Result<Account, LedgerError> {
-        let id = spec.account_id();
+        let id = spec.account_id()?;
         // Fast path: idempotent return of an existing account, with NO journal
         // growth (the property the idempotency proptest checks for opens).
         if let Some(existing) = self.accounts.get(&id) {

--- a/crates/hyprstream-ledger/src/mem.rs
+++ b/crates/hyprstream-ledger/src/mem.rs
@@ -1,0 +1,331 @@
+//! `MemLedger` — the in-memory reference implementation.
+//!
+//! Two jobs (plan §3.3):
+//! 1. The **WASM-capable** backend: a browser cell / Wanix guest can run a real
+//!    ledger for local-first quota. It uses no tokio, no I/O, and no wall clock —
+//!    the logical clock is driven explicitly via [`MemLedger::advance_clock`], so
+//!    behaviour is fully deterministic and reproducible.
+//! 2. The **proptest oracle**: every other backend is equivalence-tested against
+//!    it, so its commit loop is the canonical interpretation of `engine::stage`.
+//!
+//! It keeps *everything* — journal, outcomes, terminal reservations, outbox — in
+//! memory forever (outcome-retention pruning is a later work item). The commit
+//! loop mirrors the RocksLedger one (idempotency-check → stage → single atomic
+//! apply → advance head), so the two stay observably identical.
+
+use std::collections::BTreeMap;
+
+use crate::backend::LedgerBackend;
+use crate::engine::{self, Op};
+use crate::errors::LedgerError;
+use crate::journal::{
+    balances_root, pending_root, ChainHead, CheckpointContent, CheckpointSigner, JournalEntry,
+    OutboxItem, OutboxKind, OutboxSeq, SignedCheckpoint, TickReport,
+};
+use crate::types::{
+    Account, AccountId, AccountSpec, BalanceView, Did, IssueTransfer, Outcome, PendingReservation,
+    PendingState, Transfer, TransferId, TransferResult,
+};
+
+/// An in-memory single-writer double-entry ledger.
+#[derive(Debug)]
+pub struct MemLedger {
+    ledger_id: Did,
+    accounts: BTreeMap<AccountId, Account>,
+    pending: BTreeMap<TransferId, PendingReservation>,
+    outcomes: BTreeMap<TransferId, Outcome>,
+    journal: Vec<JournalEntry>,
+    outbox: BTreeMap<u64, OutboxItem>,
+    outbox_next: u64,
+    head: ChainHead,
+    clock: u64,
+    last_checkpoint: Option<SignedCheckpoint>,
+}
+
+impl MemLedger {
+    /// Create an empty ledger for the given cell identity, logical clock at 0.
+    pub fn new(ledger_id: Did) -> Self {
+        MemLedger {
+            ledger_id,
+            accounts: BTreeMap::new(),
+            pending: BTreeMap::new(),
+            outcomes: BTreeMap::new(),
+            journal: Vec::new(),
+            outbox: BTreeMap::new(),
+            outbox_next: 0,
+            head: ChainHead::default(),
+            clock: 0,
+            last_checkpoint: None,
+        }
+    }
+
+    /// The cell identity.
+    pub fn ledger_id(&self) -> &Did {
+        &self.ledger_id
+    }
+
+    /// Advance the logical commit clock to at least `to` (monotone — the clock
+    /// never regresses). This is the WASM-safe substitute for a wall clock:
+    /// tests and the actor drive time explicitly, which is what makes the
+    /// expiry-vs-post race deterministic.
+    pub fn advance_clock(&mut self, to: u64) {
+        self.clock = self.clock.max(to);
+    }
+
+    /// The current logical clock.
+    pub fn clock(&self) -> u64 {
+        self.clock
+    }
+
+    /// The full journal (reference/oracle inspection).
+    pub fn journal(&self) -> &[JournalEntry] {
+        &self.journal
+    }
+
+    /// Iterator over all accounts (for conservation checks in tests).
+    pub fn accounts(&self) -> impl Iterator<Item = &Account> {
+        self.accounts.values()
+    }
+
+    /// The last signed checkpoint, if any.
+    pub fn last_checkpoint(&self) -> Option<&SignedCheckpoint> {
+        self.last_checkpoint.as_ref()
+    }
+
+    // --- the serialized commit loop (plan §2a, in-memory) ---
+
+    /// Apply one op atomically: idempotency-check → stage → apply deltas + append
+    /// journal + record outcome + stage outbox, all as one logical commit.
+    fn commit(&mut self, op: Op) -> Outcome {
+        // 1. Idempotency FIRST (plan §2c): a replay returns the ORIGINAL outcome,
+        //    including original errors, without a new journal entry.
+        if let Some(id) = op.idempotency_id() {
+            if let Some(prior) = self.outcomes.get(&id) {
+                return prior.clone();
+            }
+        }
+
+        // 2. Stage against current state (pure).
+        let staged = engine::stage(self, &op);
+
+        // 3. Build the journal entry and its hash BEFORE mutating, so an
+        //    (unreachable) encoding failure aborts cleanly with no state change.
+        let seq = self.head.seq + 1;
+        let entry = JournalEntry {
+            seq,
+            prev_hash: self.head.head_hash,
+            ts: self.clock,
+            op: op.clone(),
+            result: staged.result.clone(),
+        };
+        let head_hash = match entry.hash() {
+            Ok(h) => h,
+            Err(e) => {
+                return Outcome {
+                    result: Err(e),
+                    seq: self.head.seq,
+                }
+            }
+        };
+
+        // 4. Apply deltas + advance the chain (the atomicity unit).
+        for delta in staged.deltas {
+            match delta {
+                engine::Delta::Account(a) => {
+                    self.accounts.insert(a.id, a);
+                }
+                engine::Delta::Pending(r) => {
+                    self.pending.insert(r.transfer.id, r);
+                }
+            }
+        }
+        self.journal.push(entry);
+        self.head = ChainHead { seq, head_hash };
+
+        let outcome = Outcome {
+            result: staged.result,
+            seq,
+        };
+
+        // 5. Record the outcome (successes AND rejections — plan §2c) and stage a
+        //    receipt for settled value (posted spends / issuance, plan §2e).
+        if let Some(id) = op.idempotency_id() {
+            self.outcomes.insert(id, outcome.clone());
+        }
+        if matches!(
+            outcome.result,
+            Ok(TransferResult::Issued) | Ok(TransferResult::Applied { .. })
+        ) {
+            self.enqueue_outbox(OutboxKind::Receipt, op.idempotency_id(), seq);
+        }
+
+        outcome
+    }
+
+    fn enqueue_outbox(&mut self, kind: OutboxKind, transfer_id: Option<TransferId>, journal_seq: u64) {
+        let seq = OutboxSeq(self.outbox_next);
+        self.outbox_next += 1;
+        self.outbox.insert(
+            seq.0,
+            OutboxItem {
+                seq,
+                kind,
+                transfer_id,
+                journal_seq,
+            },
+        );
+    }
+}
+
+impl engine::StateView for MemLedger {
+    fn account(&self, id: AccountId) -> Option<&Account> {
+        self.accounts.get(&id)
+    }
+
+    fn pending(&self, id: TransferId) -> Option<&PendingReservation> {
+        self.pending.get(&id)
+    }
+
+    fn now(&self) -> u64 {
+        self.clock
+    }
+}
+
+impl LedgerBackend for MemLedger {
+    fn open_account(&mut self, spec: AccountSpec) -> Result<Account, LedgerError> {
+        let id = spec.account_id();
+        // Fast path: idempotent return of an existing account, with NO journal
+        // growth (the property the idempotency proptest checks for opens).
+        if let Some(existing) = self.accounts.get(&id) {
+            if existing.unit != spec.unit {
+                return Err(LedgerError::AccountUnitConflict { id });
+            }
+            return Ok(existing.clone());
+        }
+        let outcome = self.commit(Op::OpenAccount(Box::new(spec)));
+        match outcome.result {
+            Ok(_) => self
+                .accounts
+                .get(&id)
+                .cloned()
+                .ok_or_else(|| LedgerError::Internal("account absent after open".to_owned())),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn credit(&mut self, t: IssueTransfer) -> Outcome {
+        self.commit(Op::Credit(t))
+    }
+
+    fn debit(&mut self, t: Transfer) -> Outcome {
+        self.commit(Op::Debit(t))
+    }
+
+    fn reserve(&mut self, t: Transfer, timeout_s: u32) -> Outcome {
+        self.commit(Op::Reserve {
+            transfer: t,
+            timeout_s,
+        })
+    }
+
+    fn post(&mut self, id: TransferId, pending: TransferId, amount: Option<u128>) -> Outcome {
+        self.commit(Op::Post {
+            id,
+            pending,
+            amount,
+        })
+    }
+
+    fn void(&mut self, id: TransferId, pending: TransferId) -> Outcome {
+        self.commit(Op::Void { id, pending })
+    }
+
+    fn balance(&self, account: AccountId) -> Result<BalanceView, LedgerError> {
+        self.accounts
+            .get(&account)
+            .map(|a| a.view(self.head.seq))
+            .ok_or(LedgerError::UnknownAccount(account))
+    }
+
+    fn checkpoint(
+        &mut self,
+        signer: &dyn CheckpointSigner,
+    ) -> Result<SignedCheckpoint, LedgerError> {
+        let balances = balances_root(self.accounts.values())?;
+        let pending = pending_root(self.pending.values())?;
+        let prev_checkpoint_hash = match &self.last_checkpoint {
+            Some(cp) => cp.digest()?,
+            None => [0u8; 32],
+        };
+        let content = CheckpointContent {
+            ledger_id: signer.ledger_id(),
+            seq: self.head.seq,
+            head_hash: self.head.head_hash,
+            balances_root: balances,
+            pending_root: pending,
+            ts: self.clock,
+            prev_checkpoint_hash,
+        };
+        let sig = signer.sign(&content.signing_input()?)?;
+        let cp = SignedCheckpoint {
+            ledger_id: signer.ledger_id().clone(),
+            seq: self.head.seq,
+            head_hash: self.head.head_hash,
+            balances_root: balances,
+            pending_root: pending,
+            ts: self.clock,
+            prev_checkpoint_hash,
+            sig,
+        };
+        self.last_checkpoint = Some(cp.clone());
+        self.enqueue_outbox(OutboxKind::Checkpoint, None, self.head.seq);
+        Ok(cp)
+    }
+
+    fn tick(&mut self, _signer: &dyn CheckpointSigner) -> Result<TickReport, LedgerError> {
+        // Expiry sweep (plan §2b.4): every open reservation whose deadline the
+        // logical clock has reached is expired, one journal entry each. (Scheduled
+        // checkpoint cadence is a later work item; explicit `checkpoint` covers
+        // the skeleton.)
+        let now = self.clock;
+        let due: Vec<TransferId> = self
+            .pending
+            .iter()
+            .filter(|(_, r)| r.state == PendingState::Pending && now >= r.deadline)
+            .map(|(id, _)| *id)
+            .collect();
+        let mut expired = 0usize;
+        for id in due {
+            if self.commit(Op::Expire { pending: id }).is_ok() {
+                expired += 1;
+            }
+        }
+        Ok(TickReport {
+            expired,
+            checkpointed: None,
+        })
+    }
+
+    fn outbox_peek(&self, max: usize) -> Result<Vec<OutboxItem>, LedgerError> {
+        Ok(self.outbox.values().take(max).cloned().collect())
+    }
+
+    fn outbox_ack(&mut self, up_to: OutboxSeq) -> Result<(), LedgerError> {
+        self.outbox.retain(|&seq, _| seq > up_to.0);
+        Ok(())
+    }
+
+    fn journal_range(&self, from_seq: u64, max: usize) -> Result<Vec<JournalEntry>, LedgerError> {
+        Ok(self
+            .journal
+            .iter()
+            .filter(|e| e.seq >= from_seq)
+            .take(max)
+            .cloned()
+            .collect())
+    }
+
+    fn head(&self) -> ChainHead {
+        self.head
+    }
+}

--- a/crates/hyprstream-ledger/src/mem.rs
+++ b/crates/hyprstream-ledger/src/mem.rs
@@ -162,7 +162,12 @@ impl MemLedger {
         outcome
     }
 
-    fn enqueue_outbox(&mut self, kind: OutboxKind, transfer_id: Option<TransferId>, journal_seq: u64) {
+    fn enqueue_outbox(
+        &mut self,
+        kind: OutboxKind,
+        transfer_id: Option<TransferId>,
+        journal_seq: u64,
+    ) {
         let seq = OutboxSeq(self.outbox_next);
         self.outbox_next += 1;
         self.outbox.insert(

--- a/crates/hyprstream-ledger/src/types.rs
+++ b/crates/hyprstream-ledger/src/types.rs
@@ -6,7 +6,10 @@
 //! benches).
 
 use bitflags::bitflags;
+use ciborium::value::Value;
 use serde::{Deserialize, Serialize};
+
+use crate::errors::LedgerError;
 
 /// A decentralized identifier, carried opaquely (`did:web` / `did:key` /
 /// `did:at9p`). The ledger crate treats DIDs as pseudonymous strings and never
@@ -74,60 +77,100 @@ pub enum Purpose {
 /// no allocation-time coordination, and it is TigerBeetle-compatible (TB account
 /// ids are `u128`).
 ///
-/// PLAN DECISION 1: `AccountId = blake3_128(encode(ledger_id, owner, unit,
-/// purpose))`. The unit already names its issuer (INV-1), so the issuer is baked
-/// into the id transitively.
+/// PLAN DECISION 1: `AccountId = blake3_128(canonical_dag_cbor(ledger_id,
+/// owner, unit, purpose))`. The unit already names its issuer (INV-1), so the
+/// issuer is baked into the id transitively.
+///
+/// # Interop contract — normative account-id encoding
+///
+/// The hashed body is **canonical DAG-CBOR** (the same wire format
+/// `hyprstream-pds::dag_cbor` emits: sorted map keys, minimal-width integers,
+/// definite lengths). Account ids are a contract other implementations
+/// re-derive, so the byte layout below is normative — it supersedes the earlier
+/// bespoke length-prefixed encoding.
+///
+/// The body is a single definite-length DAG-CBOR **array** in this fixed order
+/// (no maps, so canonicality needs no key-sorting):
+///
+/// ```text
+/// [
+///   "hs-ledger-account-id-v1",   // domain-separation tag
+///   <ledger_id  : tstr>,
+///   <owner      : tstr>,
+///   <unit_issuer: tstr>,          // unit.issuer
+///   <unit_code  : tstr>,          // unit.resource_class
+///   <purpose    : purpose-encoding>
+/// ]
+/// ```
+///
+/// where `purpose-encoding` is itself canonical DAG-CBOR:
+///
+/// | `Purpose` | encoding |
+/// |---|---|
+/// | `Available` | unsigned `0` |
+/// | `Escrow { peer_cell }` | `[1, <peer_cell:tstr>]` |
+/// | `IssuerLiability` | unsigned `2` |
+/// | `Remote { home_cell }` | `[3, <home_cell:tstr>]` |
+/// | `Bond` | unsigned `4` |
+///
+/// The id is the 128-bit blake3 XOF (`blake3::Hasher::finalize_xof`, 16 bytes,
+/// read big-endian into a `u128`) of those bytes. Two implementations that agree
+/// on this layout derive byte-identical ids.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct AccountId(pub u128);
 
 impl AccountId {
-    /// Derive the canonical account id.
+    /// Derive the canonical account id over the normative DAG-CBOR encoding
+    /// (see the [`AccountId`] rustdoc for the interop wire format).
     ///
-    /// The hash input is a domain-separated, length-prefixed encoding of the
-    /// tuple rather than raw DAG-CBOR. This keeps `derive` **infallible** (no
-    /// serializer `Result` to unwrap) while remaining canonical: it is the single
-    /// source function every backend calls, so RocksLedger / TigerBeetleLedger
-    /// derive byte-identical ids. (Trait-surface decision — see PR notes.)
-    pub fn derive(ledger_id: &Did, owner: &Did, unit: &UnitId, purpose: &Purpose) -> Self {
+    /// Returns `Result` because the CBOR serializer is fallible at the API
+    /// level (`ciborium::into_writer`). Over this fixed set of small types
+    /// (text strings, small unsigned ints, definite-length arrays) an encode
+    /// error is unreachable in practice; rather than `unwrap` (lint-denied) we
+    /// map the impossible failure to [`LedgerError::Internal`], which is
+    /// fail-closed and retryable. Call sites propagate it.
+    pub fn derive(
+        ledger_id: &Did,
+        owner: &Did,
+        unit: &UnitId,
+        purpose: &Purpose,
+    ) -> Result<Self, LedgerError> {
+        let value = Value::Array(vec![
+            // Domain-separation tag, carried inside the canonical body so the
+            // entire hashed input is canonical DAG-CBOR.
+            Value::Text("hs-ledger-account-id-v1".to_owned()),
+            Value::Text(ledger_id.0.clone()),
+            Value::Text(owner.0.clone()),
+            Value::Text(unit.issuer.0.clone()),
+            Value::Text(unit.resource_class.clone()),
+            canonical_purpose(purpose),
+        ]);
         let mut h = blake3::Hasher::new();
-        h.update(b"hs-ledger-account-id-v1");
-        write_field(&mut h, ledger_id.0.as_bytes());
-        write_field(&mut h, owner.0.as_bytes());
-        write_field(&mut h, unit.issuer.0.as_bytes());
-        write_field(&mut h, unit.resource_class.as_bytes());
-        write_purpose(&mut h, purpose);
+        ciborium::into_writer(&value, &mut h)
+            .map_err(|e| LedgerError::Internal(format!("account-id DAG-CBOR encode failed: {e}")))?;
         let mut out = [0u8; 16];
         h.finalize_xof().fill(&mut out);
-        AccountId(u128::from_be_bytes(out))
+        Ok(AccountId(u128::from_be_bytes(out)))
     }
 }
 
-/// Length-prefixed field write (8-byte BE length + bytes) — unambiguous framing
-/// so no two distinct tuples can collide by concatenation boundary shifting.
-fn write_field(h: &mut blake3::Hasher, bytes: &[u8]) {
-    h.update(&(bytes.len() as u64).to_be_bytes());
-    h.update(bytes);
-}
-
-fn write_purpose(h: &mut blake3::Hasher, purpose: &Purpose) {
+/// Canonical DAG-CBOR encoding of [`Purpose`] (see the [`AccountId`] interop
+/// table). Fixed-shape: a bare unsigned int for the leaf purposes, a
+/// `[tag, did]` array for the carried-DID purposes — definite-length and
+/// minimal-width, so ciborium emits canonical bytes with no map sorting needed.
+fn canonical_purpose(purpose: &Purpose) -> Value {
     match purpose {
-        Purpose::Available => {
-            h.update(&[0u8]);
-        }
-        Purpose::Escrow { peer_cell } => {
-            h.update(&[1u8]);
-            write_field(h, peer_cell.0.as_bytes());
-        }
-        Purpose::IssuerLiability => {
-            h.update(&[2u8]);
-        }
-        Purpose::Remote { home_cell } => {
-            h.update(&[3u8]);
-            write_field(h, home_cell.0.as_bytes());
-        }
-        Purpose::Bond => {
-            h.update(&[4u8]);
-        }
+        Purpose::Available => Value::Integer(0u64.into()),
+        Purpose::Escrow { peer_cell } => Value::Array(vec![
+            Value::Integer(1u64.into()),
+            Value::Text(peer_cell.0.clone()),
+        ]),
+        Purpose::IssuerLiability => Value::Integer(2u64.into()),
+        Purpose::Remote { home_cell } => Value::Array(vec![
+            Value::Integer(3u64.into()),
+            Value::Text(home_cell.0.clone()),
+        ]),
+        Purpose::Bond => Value::Integer(4u64.into()),
     }
 }
 
@@ -249,8 +292,8 @@ impl AccountSpec {
         }
     }
 
-    /// The derived id for this spec.
-    pub fn account_id(&self) -> AccountId {
+    /// The derived id for this spec (see [`AccountId::derive`]).
+    pub fn account_id(&self) -> Result<AccountId, LedgerError> {
         AccountId::derive(&self.ledger_id, &self.owner, &self.unit, &self.purpose)
     }
 }

--- a/crates/hyprstream-ledger/src/types.rs
+++ b/crates/hyprstream-ledger/src/types.rs
@@ -1,0 +1,388 @@
+//! Core data model for the accounting plane (plan §2.0).
+//!
+//! Everything here is `no_std`-friendly in spirit (no I/O, no clock, no tokio) so
+//! the whole crate builds for `wasm32-unknown-unknown`. Amounts are `u128` minor
+//! units; **no floats anywhere** (INV grep-gate: `f32|f64` forbidden outside
+//! benches).
+
+use bitflags::bitflags;
+use serde::{Deserialize, Serialize};
+
+/// A decentralized identifier, carried opaquely (`did:web` / `did:key` /
+/// `did:at9p`). The ledger crate treats DIDs as pseudonymous strings and never
+/// resolves or interprets them — per the #924 P0 constraint, **no legal-identity
+/// fields** live in this model; a DID is the only principal handle.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct Did(pub String);
+
+impl Did {
+    /// Borrow the DID string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for Did {
+    fn from(s: &str) -> Self {
+        Did(s.to_owned())
+    }
+}
+
+/// Opaque content identifier for a UCAN allocation grant. Kept as raw bytes so
+/// this crate carries **no `hyprstream-pds` dependency** (D3 crate boundary): the
+/// ledger only correlates a spend to its grant, it never parses the CID.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct Cid(pub Vec<u8>);
+
+/// A resource unit. INV-1(a): **the unit names its issuer.** Two units with
+/// different issuers are different units, full stop — there is no bearer-token
+/// representation of value that omits the issuer.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct UnitId {
+    /// The resource authority — the liability holder for this unit.
+    pub issuer: Did,
+    /// e.g. `"gpu.h100.seconds"`.
+    pub resource_class: String,
+}
+
+/// What an account is *for*. The purpose participates in the account id, so two
+/// accounts of the same owner/unit but different purpose are distinct rows.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum Purpose {
+    /// Spendable balance held by an owner.
+    Available,
+    /// Funds escrowed toward a peer cell (home side of a tranche, §2f).
+    Escrow {
+        /// The peer cell the escrow is pledged to.
+        peer_cell: Did,
+    },
+    /// The issuer's own liability account — issuance debits this (INV-1). Grows
+    /// as supply is issued; the "money supply" per unit *is* this balance.
+    IssuerLiability,
+    /// Remotely-funded spendable balance (remote side of a tranche, §2f).
+    Remote {
+        /// The home cell that pre-funded this balance.
+        home_cell: Did,
+    },
+    /// A posted bond (Phase 3 slashing collateral); modelled as a ledger account
+    /// so a slash is just a transfer to the injured party.
+    Bond,
+}
+
+/// 128-bit account identity. Deterministic function of the canonical tuple, so
+/// any party that knows `(ledger_id, owner, unit, purpose)` can derive it with
+/// no allocation-time coordination, and it is TigerBeetle-compatible (TB account
+/// ids are `u128`).
+///
+/// PLAN DECISION 1: `AccountId = blake3_128(encode(ledger_id, owner, unit,
+/// purpose))`. The unit already names its issuer (INV-1), so the issuer is baked
+/// into the id transitively.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct AccountId(pub u128);
+
+impl AccountId {
+    /// Derive the canonical account id.
+    ///
+    /// The hash input is a domain-separated, length-prefixed encoding of the
+    /// tuple rather than raw DAG-CBOR. This keeps `derive` **infallible** (no
+    /// serializer `Result` to unwrap) while remaining canonical: it is the single
+    /// source function every backend calls, so RocksLedger / TigerBeetleLedger
+    /// derive byte-identical ids. (Trait-surface decision — see PR notes.)
+    pub fn derive(ledger_id: &Did, owner: &Did, unit: &UnitId, purpose: &Purpose) -> Self {
+        let mut h = blake3::Hasher::new();
+        h.update(b"hs-ledger-account-id-v1");
+        write_field(&mut h, ledger_id.0.as_bytes());
+        write_field(&mut h, owner.0.as_bytes());
+        write_field(&mut h, unit.issuer.0.as_bytes());
+        write_field(&mut h, unit.resource_class.as_bytes());
+        write_purpose(&mut h, purpose);
+        let mut out = [0u8; 16];
+        h.finalize_xof().fill(&mut out);
+        AccountId(u128::from_be_bytes(out))
+    }
+}
+
+/// Length-prefixed field write (8-byte BE length + bytes) — unambiguous framing
+/// so no two distinct tuples can collide by concatenation boundary shifting.
+fn write_field(h: &mut blake3::Hasher, bytes: &[u8]) {
+    h.update(&(bytes.len() as u64).to_be_bytes());
+    h.update(bytes);
+}
+
+fn write_purpose(h: &mut blake3::Hasher, purpose: &Purpose) {
+    match purpose {
+        Purpose::Available => {
+            h.update(&[0u8]);
+        }
+        Purpose::Escrow { peer_cell } => {
+            h.update(&[1u8]);
+            write_field(h, peer_cell.0.as_bytes());
+        }
+        Purpose::IssuerLiability => {
+            h.update(&[2u8]);
+        }
+        Purpose::Remote { home_cell } => {
+            h.update(&[3u8]);
+            write_field(h, home_cell.0.as_bytes());
+        }
+        Purpose::Bond => {
+            h.update(&[4u8]);
+        }
+    }
+}
+
+bitflags! {
+    /// TigerBeetle-compatible account flags.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct AccountFlags: u32 {
+        /// The normal case: a debit-constrained account may never let
+        /// `debits_posted + debits_pending` exceed `credits_posted`. Issuer
+        /// liability accounts clear this flag (they are the source of supply).
+        const DEBITS_MUST_NOT_EXCEED_CREDITS = 0b0000_0001;
+    }
+}
+
+impl AccountFlags {
+    /// The default flags for a purpose: everything is debit-constrained except an
+    /// issuer's own liability account.
+    pub fn for_purpose(purpose: &Purpose) -> Self {
+        match purpose {
+            Purpose::IssuerLiability => AccountFlags::empty(),
+            _ => AccountFlags::DEBITS_MUST_NOT_EXCEED_CREDITS,
+        }
+    }
+}
+
+/// TigerBeetle-compatible account state (plan §2.0). The four counters are `u128`
+/// minor units. `*_posted` only ever grow; `*_pending` rise on reserve and fall
+/// on post/void/expire. Balances are differences of counters, never stored.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Account {
+    /// Derived identity (see [`AccountId::derive`]).
+    pub id: AccountId,
+    /// Denormalized unit; checked to match on every transfer touching this account.
+    pub unit: UnitId,
+    /// Held-but-not-settled debits (outstanding reservations on the debit side).
+    pub debits_pending: u128,
+    /// Settled debits — monotonically increasing.
+    pub debits_posted: u128,
+    /// Held-but-not-settled credits.
+    pub credits_pending: u128,
+    /// Settled credits — monotonically increasing.
+    pub credits_posted: u128,
+    /// Behavioural flags (overdraft constraint, …).
+    pub flags: AccountFlags,
+}
+
+impl Account {
+    /// A freshly opened account with zeroed counters.
+    pub fn new(id: AccountId, unit: UnitId, flags: AccountFlags) -> Self {
+        Account {
+            id,
+            unit,
+            debits_pending: 0,
+            debits_posted: 0,
+            credits_pending: 0,
+            credits_posted: 0,
+            flags,
+        }
+    }
+
+    /// Amount available to spend for a debit-constrained account: settled net
+    /// credit minus everything already promised. Pending **credits** do NOT count
+    /// (they may still void) — the TigerBeetle rule. Saturating so it can never
+    /// underflow into a huge number.
+    pub fn available(&self) -> u128 {
+        self.credits_posted
+            .saturating_sub(self.debits_posted)
+            .saturating_sub(self.debits_pending)
+    }
+
+    /// Whether this account enforces the overdraft floor.
+    pub fn is_debit_constrained(&self) -> bool {
+        self.flags
+            .contains(AccountFlags::DEBITS_MUST_NOT_EXCEED_CREDITS)
+    }
+
+    /// A read-only projection of balances at a given journal sequence.
+    pub fn view(&self, as_of_seq: u64) -> BalanceView {
+        BalanceView {
+            debits_pending: self.debits_pending,
+            debits_posted: self.debits_posted,
+            credits_pending: self.credits_pending,
+            credits_posted: self.credits_posted,
+            available: self.available(),
+            as_of_seq,
+        }
+    }
+}
+
+/// Everything needed to open (or idempotently re-open) an account.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AccountSpec {
+    /// The cell ledger this account lives in.
+    pub ledger_id: Did,
+    /// The owning principal (a pseudonymous DID; may be a group owner DID).
+    pub owner: Did,
+    /// The unit (names its issuer).
+    pub unit: UnitId,
+    /// What the account is for.
+    pub purpose: Purpose,
+    /// Flags; use [`AccountFlags::for_purpose`] for the sensible default.
+    pub flags: AccountFlags,
+}
+
+impl AccountSpec {
+    /// Convenience constructor deriving default flags from the purpose.
+    pub fn new(ledger_id: Did, owner: Did, unit: UnitId, purpose: Purpose) -> Self {
+        let flags = AccountFlags::for_purpose(&purpose);
+        AccountSpec {
+            ledger_id,
+            owner,
+            unit,
+            purpose,
+            flags,
+        }
+    }
+
+    /// The derived id for this spec.
+    pub fn account_id(&self) -> AccountId {
+        AccountId::derive(&self.ledger_id, &self.owner, &self.unit, &self.purpose)
+    }
+}
+
+/// Client-supplied 128-bit transfer id (plan §2c). **The id IS the idempotency
+/// key**: replaying it returns the original outcome (including original errors).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct TransferId(pub u128);
+
+/// Single-phase issuance (INV-1): the only entry point that grows a unit's
+/// supply. The debit side MUST be the issuer's `IssuerLiability` account for the
+/// unit; the credit side is the destination.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IssueTransfer {
+    /// Idempotency key.
+    pub id: TransferId,
+    /// The issuer's liability account (debit side; must be `Purpose::IssuerLiability`).
+    pub issuer_liability: AccountId,
+    /// Where the freshly-issued credit lands.
+    pub destination: AccountId,
+    /// The unit being issued (issuer must match the liability account owner).
+    pub unit: UnitId,
+    /// Amount in minor units; must be `> 0`.
+    pub amount: u128,
+    /// The grant this issuance backs, if any.
+    pub grant_cid: Option<Cid>,
+    /// Opaque correlation (e.g. request hash).
+    pub user_data: [u8; 32],
+}
+
+/// A value movement between two accounts of the **same unit** (INV-1(b): one
+/// `unit` field, never two — cross-issuer movement is two linked transfers).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Transfer {
+    /// Idempotency key (for `reserve` this is also the pending reservation id).
+    pub id: TransferId,
+    /// Account debited.
+    pub debit_account: AccountId,
+    /// Account credited.
+    pub credit_account: AccountId,
+    /// The unit; must equal both accounts' unit.
+    pub unit: UnitId,
+    /// Amount in minor units; must be `> 0`.
+    pub amount: u128,
+    /// The UCAN allocation this spend draws on.
+    pub grant_cid: Option<Cid>,
+    /// Opaque correlation.
+    pub user_data: [u8; 32],
+}
+
+/// The lifecycle state of a two-phase reservation (plan §2b).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PendingState {
+    /// Held, not yet resolved.
+    Pending,
+    /// Second phase committed as a post (full or partial).
+    Posted,
+    /// Second phase committed as a void.
+    Voided,
+    /// Deadline passed before a second phase committed.
+    Expired,
+}
+
+impl PendingState {
+    /// Whether the reservation has reached a terminal state.
+    pub fn is_terminal(self) -> bool {
+        !matches!(self, PendingState::Pending)
+    }
+}
+
+/// A tracked phase-1 reservation. Held in `CF(pending)` in RocksLedger; a
+/// `BTreeMap` entry in MemLedger.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingReservation {
+    /// The reserve transfer (its `id` is the pending id).
+    pub transfer: Transfer,
+    /// Logical deadline (ledger clock seconds) after which the hold expires.
+    pub deadline: u64,
+    /// Current lifecycle state.
+    pub state: PendingState,
+}
+
+/// What a successful op did — the positive half of an [`Outcome`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TransferResult {
+    /// Supply issued (`credit`).
+    Issued,
+    /// A single-phase or posted two-phase settlement.
+    Applied {
+        /// Amount moved to posted.
+        posted: u128,
+        /// Amount released back from pending (partial-post remainder; `0` for
+        /// single-phase and full posts).
+        released: u128,
+    },
+    /// A phase-1 hold was placed (`reserve`).
+    Reserved,
+    /// A reservation was cancelled (`void`).
+    Voided,
+    /// A reservation expired (produced by the sweep or on-touch).
+    Expired,
+    /// An account was created (`open_account` via the journal).
+    Opened,
+}
+
+/// The recorded result of an operation. Stored under the op's `TransferId`; a
+/// replay returns this **verbatim** (PLAN DECISION 3 — original result, including
+/// original errors).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Outcome {
+    /// The business result: `Ok` with what happened, or the deterministic error.
+    pub result: Result<TransferResult, crate::errors::LedgerError>,
+    /// The journal sequence that recorded this outcome.
+    pub seq: u64,
+}
+
+impl Outcome {
+    /// Whether the op succeeded.
+    pub fn is_ok(&self) -> bool {
+        self.result.is_ok()
+    }
+}
+
+/// Read-only balance projection returned by [`crate::LedgerBackend::balance`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BalanceView {
+    /// Outstanding debit holds.
+    pub debits_pending: u128,
+    /// Settled debits.
+    pub debits_posted: u128,
+    /// Outstanding credit holds.
+    pub credits_pending: u128,
+    /// Settled credits.
+    pub credits_posted: u128,
+    /// Spendable amount (see [`Account::available`]).
+    pub available: u128,
+    /// The journal sequence this view reflects.
+    pub as_of_seq: u64,
+}

--- a/crates/hyprstream-ledger/src/types.rs
+++ b/crates/hyprstream-ledger/src/types.rs
@@ -162,6 +162,9 @@ pub struct Account {
     pub id: AccountId,
     /// Denormalized unit; checked to match on every transfer touching this account.
     pub unit: UnitId,
+    /// Denormalized purpose; issuance checks this directly instead of inferring
+    /// authority from flags.
+    pub purpose: Purpose,
     /// Held-but-not-settled debits (outstanding reservations on the debit side).
     pub debits_pending: u128,
     /// Settled debits — monotonically increasing.
@@ -176,10 +179,11 @@ pub struct Account {
 
 impl Account {
     /// A freshly opened account with zeroed counters.
-    pub fn new(id: AccountId, unit: UnitId, flags: AccountFlags) -> Self {
+    pub fn new(id: AccountId, unit: UnitId, purpose: Purpose, flags: AccountFlags) -> Self {
         Account {
             id,
             unit,
+            purpose,
             debits_pending: 0,
             debits_posted: 0,
             credits_pending: 0,

--- a/crates/hyprstream-ledger/tests/proptests.rs
+++ b/crates/hyprstream-ledger/tests/proptests.rs
@@ -8,8 +8,8 @@
 
 use hyprstream_ledger::engine::{MAX_TIMEOUT_S, MIN_TIMEOUT_S};
 use hyprstream_ledger::{
-    Account, AccountSpec, Did, IssueTransfer, LedgerBackend, MemLedger, Purpose, TransferId,
-    TransferResult, UnitId,
+    Account, AccountFlags, AccountSpec, Did, IssueTransfer, LedgerBackend, LedgerError, MemLedger,
+    Purpose, TransferId, TransferResult, UnitId,
 };
 use proptest::prelude::*;
 
@@ -90,13 +90,32 @@ fn assert_no_overdraft(l: &MemLedger) {
 /// One generated action over the fixed account set.
 #[derive(Debug, Clone)]
 enum Action {
-    Credit { dest: usize, amount: u64 },
-    Debit { from: usize, to: usize, amount: u64 },
-    Reserve { from: usize, to: usize, amount: u64, timeout: u32 },
-    Post { which: usize, partial: Option<u64> },
-    Void { which: usize },
+    Credit {
+        dest: usize,
+        amount: u64,
+    },
+    Debit {
+        from: usize,
+        to: usize,
+        amount: u64,
+    },
+    Reserve {
+        from: usize,
+        to: usize,
+        amount: u64,
+        timeout: u32,
+    },
+    Post {
+        which: usize,
+        partial: Option<u64>,
+    },
+    Void {
+        which: usize,
+    },
     Tick,
-    Advance { secs: u64 },
+    Advance {
+        secs: u64,
+    },
 }
 
 fn action_strategy() -> impl Strategy<Value = Action> {
@@ -104,10 +123,19 @@ fn action_strategy() -> impl Strategy<Value = Action> {
     let idx = 1usize..=K_SPENDABLE;
     prop_oneof![
         (idx.clone(), 1u64..1000).prop_map(|(dest, amount)| Action::Credit { dest, amount }),
-        (idx.clone(), idx.clone(), 1u64..1000)
-            .prop_map(|(from, to, amount)| Action::Debit { from, to, amount }),
-        (idx.clone(), idx.clone(), 1u64..1000, MIN_TIMEOUT_S..50u32)
-            .prop_map(|(from, to, amount, timeout)| Action::Reserve { from, to, amount, timeout }),
+        (idx.clone(), idx.clone(), 1u64..1000).prop_map(|(from, to, amount)| Action::Debit {
+            from,
+            to,
+            amount
+        }),
+        (idx.clone(), idx.clone(), 1u64..1000, MIN_TIMEOUT_S..50u32).prop_map(
+            |(from, to, amount, timeout)| Action::Reserve {
+                from,
+                to,
+                amount,
+                timeout
+            }
+        ),
         (0usize..8, proptest::option::of(1u64..1000))
             .prop_map(|(which, partial)| Action::Post { which, partial }),
         (0usize..8).prop_map(|which| Action::Void { which }),
@@ -299,10 +327,17 @@ fn mk_transfer(
     }
 }
 
-/// A stable snapshot of every account's balance view, for idempotency
-/// no-state-change assertions.
-fn snapshot(l: &MemLedger) -> Vec<(u128, u128, u128, u128)> {
-    let mut v: Vec<_> = l
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LedgerSnapshot {
+    head_seq: u64,
+    journal_len: usize,
+    accounts: Vec<(u128, u128, u128, u128)>,
+}
+
+/// A stable snapshot of every account's balance view and journal position, for
+/// idempotency no-state-change/no-journal-growth assertions.
+fn snapshot(l: &MemLedger) -> LedgerSnapshot {
+    let mut accounts: Vec<_> = l
         .accounts()
         .map(|a: &Account| {
             (
@@ -313,8 +348,12 @@ fn snapshot(l: &MemLedger) -> Vec<(u128, u128, u128, u128)> {
             )
         })
         .collect();
-    v.sort_by_key(|t| t.0);
-    v
+    accounts.sort_by_key(|t| t.0);
+    LedgerSnapshot {
+        head_seq: l.head().seq,
+        journal_len: l.journal().len(),
+        accounts,
+    }
 }
 
 /// A no-op checkpoint signer for tick (which never actually checkpoints in the
@@ -335,4 +374,38 @@ impl hyprstream_ledger::CheckpointSigner for NoopSigner {
 fn timeout_bounds_are_plan_values() {
     assert_eq!(MIN_TIMEOUT_S, 1);
     assert_eq!(MAX_TIMEOUT_S, 24 * 60 * 60);
+}
+
+#[test]
+fn issuance_rejects_available_account_even_with_empty_flags() {
+    let mut l = MemLedger::new(ledger_id());
+    let source = l
+        .open_account(AccountSpec {
+            ledger_id: ledger_id(),
+            owner: Did("did:key:not-issuer-liability".to_owned()),
+            unit: unit(),
+            purpose: Purpose::Available,
+            flags: AccountFlags::empty(),
+        })
+        .unwrap();
+    let dest = l
+        .open_account(AccountSpec::new(
+            ledger_id(),
+            Did("did:key:dest".to_owned()),
+            unit(),
+            Purpose::Available,
+        ))
+        .unwrap();
+
+    let out = l.credit(IssueTransfer {
+        id: TransferId(1),
+        issuer_liability: source.id,
+        destination: dest.id,
+        unit: unit(),
+        amount: 10,
+        grant_cid: None,
+        user_data: ud(),
+    });
+
+    assert_eq!(out.result, Err(LedgerError::NotIssuerLiability(source.id)));
 }

--- a/crates/hyprstream-ledger/tests/proptests.rs
+++ b/crates/hyprstream-ledger/tests/proptests.rs
@@ -1,0 +1,338 @@
+//! Property, idempotency, two-phase-safety and expiry-race tests against the
+//! `MemLedger` oracle (plan §6.1). RocksLedger equivalence is a later work item;
+//! MemLedger is exercised here as both SUT and reference.
+
+// The workspace denies unwrap/expect even in tests; a test harness legitimately
+// unwraps known-good values.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use hyprstream_ledger::engine::{MAX_TIMEOUT_S, MIN_TIMEOUT_S};
+use hyprstream_ledger::{
+    Account, AccountSpec, Did, IssueTransfer, LedgerBackend, MemLedger, Purpose, TransferId,
+    TransferResult, UnitId,
+};
+use proptest::prelude::*;
+
+const K_SPENDABLE: usize = 3;
+
+fn ledger_id() -> Did {
+    Did("did:web:cell.test".to_owned())
+}
+
+fn unit() -> UnitId {
+    UnitId {
+        issuer: Did("did:web:issuer.test".to_owned()),
+        resource_class: "gpu.h100.seconds".to_owned(),
+    }
+}
+
+/// Build a ledger with an issuer-liability account (index 0) and `K_SPENDABLE`
+/// spendable accounts. Returns their account ids indexed 0..=K.
+fn fresh() -> (MemLedger, Vec<hyprstream_ledger::AccountId>) {
+    let mut l = MemLedger::new(ledger_id());
+    let mut ids = Vec::new();
+    let liability = l
+        .open_account(AccountSpec::new(
+            ledger_id(),
+            unit().issuer.clone(),
+            unit(),
+            Purpose::IssuerLiability,
+        ))
+        .unwrap();
+    ids.push(liability.id);
+    for i in 0..K_SPENDABLE {
+        let a = l
+            .open_account(AccountSpec::new(
+                ledger_id(),
+                Did(format!("did:key:owner{i}")),
+                unit(),
+                Purpose::Available,
+            ))
+            .unwrap();
+        ids.push(a.id);
+    }
+    (l, ids)
+}
+
+/// Conservation (INV-1(c) / plan §6.1): across ALL accounts, per unit,
+/// Σdebits_posted == Σcredits_posted AND Σdebits_pending == Σcredits_pending.
+fn assert_conservation(l: &MemLedger) {
+    let (mut dp, mut cp, mut dpend, mut cpend) = (0u128, 0u128, 0u128, 0u128);
+    for a in l.accounts() {
+        dp += a.debits_posted;
+        cp += a.credits_posted;
+        dpend += a.debits_pending;
+        cpend += a.credits_pending;
+    }
+    assert_eq!(dp, cp, "posted debits != posted credits");
+    assert_eq!(dpend, cpend, "pending debits != pending credits");
+}
+
+/// Two-phase safety (plan §6.1): no debit-constrained account ever lets
+/// `debits_posted + debits_pending` exceed `credits_posted` — the overdraft floor
+/// holds across every reserve→post/void/expire interleaving.
+fn assert_no_overdraft(l: &MemLedger) {
+    for a in l.accounts() {
+        if a.is_debit_constrained() {
+            let committed = a.debits_posted.saturating_add(a.debits_pending);
+            assert!(
+                committed <= a.credits_posted,
+                "overdraft on {:?}: {}+{} > {}",
+                a.id,
+                a.debits_posted,
+                a.debits_pending,
+                a.credits_posted
+            );
+        }
+    }
+}
+
+/// One generated action over the fixed account set.
+#[derive(Debug, Clone)]
+enum Action {
+    Credit { dest: usize, amount: u64 },
+    Debit { from: usize, to: usize, amount: u64 },
+    Reserve { from: usize, to: usize, amount: u64, timeout: u32 },
+    Post { which: usize, partial: Option<u64> },
+    Void { which: usize },
+    Tick,
+    Advance { secs: u64 },
+}
+
+fn action_strategy() -> impl Strategy<Value = Action> {
+    // Indices 1..=K_SPENDABLE are spendable accounts; 0 is the liability.
+    let idx = 1usize..=K_SPENDABLE;
+    prop_oneof![
+        (idx.clone(), 1u64..1000).prop_map(|(dest, amount)| Action::Credit { dest, amount }),
+        (idx.clone(), idx.clone(), 1u64..1000)
+            .prop_map(|(from, to, amount)| Action::Debit { from, to, amount }),
+        (idx.clone(), idx.clone(), 1u64..1000, MIN_TIMEOUT_S..50u32)
+            .prop_map(|(from, to, amount, timeout)| Action::Reserve { from, to, amount, timeout }),
+        (0usize..8, proptest::option::of(1u64..1000))
+            .prop_map(|(which, partial)| Action::Post { which, partial }),
+        (0usize..8).prop_map(|which| Action::Void { which }),
+        Just(Action::Tick),
+        (1u64..60).prop_map(|secs| Action::Advance { secs }),
+    ]
+}
+
+fn next_id(counter: &mut u128) -> TransferId {
+    *counter += 1;
+    TransferId(*counter)
+}
+
+fn ud() -> [u8; 32] {
+    [0u8; 32]
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(400))]
+
+    /// Conservation + two-phase overdraft safety + inline idempotency over an
+    /// arbitrary interleaving of every op kind.
+    #[test]
+    fn sequence_invariants(actions in proptest::collection::vec(action_strategy(), 0..60)) {
+        let (mut l, ids) = fresh();
+        let mut counter: u128 = 0;
+        // Reservation ids in creation order, for Post/Void to reference.
+        let mut reserves: Vec<TransferId> = Vec::new();
+
+        assert_conservation(&l);
+        assert_no_overdraft(&l);
+
+        for action in actions {
+            match action {
+                Action::Credit { dest, amount } => {
+                    let id = next_id(&mut counter);
+                    let t = IssueTransfer {
+                        id,
+                        issuer_liability: ids[0],
+                        destination: ids[dest],
+                        unit: unit(),
+                        amount: amount as u128,
+                        grant_cid: None,
+                        user_data: ud(),
+                    };
+                    let out1 = l.credit(t.clone());
+                    // Inline idempotency: replay is transparent, no state change.
+                    let before = snapshot(&l);
+                    let out2 = l.credit(t);
+                    prop_assert_eq!(&out1, &out2);
+                    prop_assert_eq!(before, snapshot(&l));
+                }
+                Action::Debit { from, to, amount } => {
+                    let id = next_id(&mut counter);
+                    let t = mk_transfer(id, ids[from], ids[to], amount);
+                    let out1 = l.debit(t.clone());
+                    let before = snapshot(&l);
+                    let out2 = l.debit(t);
+                    prop_assert_eq!(&out1, &out2);
+                    prop_assert_eq!(before, snapshot(&l));
+                }
+                Action::Reserve { from, to, amount, timeout } => {
+                    let id = next_id(&mut counter);
+                    let t = mk_transfer(id, ids[from], ids[to], amount);
+                    let out1 = l.reserve(t.clone(), timeout);
+                    reserves.push(id);
+                    let before = snapshot(&l);
+                    let out2 = l.reserve(t, timeout);
+                    prop_assert_eq!(&out1, &out2);
+                    prop_assert_eq!(before, snapshot(&l));
+                }
+                Action::Post { which, partial } => {
+                    if reserves.is_empty() { continue; }
+                    let pending = reserves[which % reserves.len()];
+                    let id = next_id(&mut counter);
+                    let out1 = l.post(id, pending, partial.map(|p| p as u128));
+                    let before = snapshot(&l);
+                    let out2 = l.post(id, pending, partial.map(|p| p as u128));
+                    prop_assert_eq!(&out1, &out2);
+                    prop_assert_eq!(before, snapshot(&l));
+                }
+                Action::Void { which } => {
+                    if reserves.is_empty() { continue; }
+                    let pending = reserves[which % reserves.len()];
+                    let id = next_id(&mut counter);
+                    let out1 = l.void(id, pending);
+                    let before = snapshot(&l);
+                    let out2 = l.void(id, pending);
+                    prop_assert_eq!(&out1, &out2);
+                    prop_assert_eq!(before, snapshot(&l));
+                }
+                Action::Tick => {
+                    l.tick(&NoopSigner).unwrap();
+                }
+                Action::Advance { secs } => {
+                    l.advance_clock(l.clock() + secs);
+                }
+            }
+            assert_conservation(&l);
+            assert_no_overdraft(&l);
+        }
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(500))]
+
+    /// Expiry-vs-post race determinism (plan §2b.5, §6.1): whatever the ordering
+    /// of {advance, post, void, tick} after a reserve, you can NEVER post once the
+    /// logical clock reached the deadline (no late post), the second phase
+    /// succeeds at most once, and conservation/overdraft hold throughout.
+    #[test]
+    fn expiry_post_race(
+        amount in 1u64..500,
+        timeout in MIN_TIMEOUT_S..20u32,
+        steps in proptest::collection::vec(0u8..4, 1..12),
+    ) {
+        let (mut l, ids) = fresh();
+        let mut counter: u128 = 0;
+
+        // Fund the debit account generously so the reserve always succeeds.
+        let fund = next_id(&mut counter);
+        l.credit(IssueTransfer {
+            id: fund,
+            issuer_liability: ids[0],
+            destination: ids[1],
+            unit: unit(),
+            amount: (amount as u128) * 4,
+            grant_cid: None,
+            user_data: ud(),
+        });
+
+        // The reservation under test.
+        let rid = next_id(&mut counter);
+        let reserved_at = l.clock();
+        let deadline = reserved_at + timeout as u64;
+        let r = l.reserve(mk_transfer(rid, ids[1], ids[2], amount), timeout);
+        prop_assert!(r.is_ok());
+
+        let mut applied_count = 0usize;
+        let mut voided_count = 0usize;
+
+        for s in steps {
+            match s {
+                0 => l.advance_clock(l.clock() + 1),
+                1 => {
+                    let now = l.clock();
+                    let out = l.post(next_id(&mut counter), rid, None);
+                    if let Ok(TransferResult::Applied { .. }) = out.result {
+                        // No late post: an Applied post is impossible at/after the deadline.
+                        prop_assert!(now < deadline, "posted at now={} >= deadline={}", now, deadline);
+                        applied_count += 1;
+                    }
+                }
+                2 => {
+                    let out = l.void(next_id(&mut counter), rid);
+                    if let Ok(TransferResult::Voided) = out.result {
+                        voided_count += 1;
+                    }
+                }
+                _ => { l.tick(&NoopSigner).unwrap(); }
+            }
+            assert_conservation(&l);
+            assert_no_overdraft(&l);
+        }
+
+        // Exactly-once second phase: at most one post AND at most one void, and
+        // never both.
+        prop_assert!(applied_count <= 1);
+        prop_assert!(voided_count <= 1);
+        prop_assert!(applied_count + voided_count <= 1);
+    }
+}
+
+fn mk_transfer(
+    id: TransferId,
+    from: hyprstream_ledger::AccountId,
+    to: hyprstream_ledger::AccountId,
+    amount: u64,
+) -> hyprstream_ledger::Transfer {
+    hyprstream_ledger::Transfer {
+        id,
+        debit_account: from,
+        credit_account: to,
+        unit: unit(),
+        amount: amount as u128,
+        grant_cid: None,
+        user_data: ud(),
+    }
+}
+
+/// A stable snapshot of every account's balance view, for idempotency
+/// no-state-change assertions.
+fn snapshot(l: &MemLedger) -> Vec<(u128, u128, u128, u128)> {
+    let mut v: Vec<_> = l
+        .accounts()
+        .map(|a: &Account| {
+            (
+                a.id.0,
+                a.debits_posted,
+                a.credits_posted,
+                a.debits_pending + a.credits_pending,
+            )
+        })
+        .collect();
+    v.sort_by_key(|t| t.0);
+    v
+}
+
+/// A no-op checkpoint signer for tick (which never actually checkpoints in the
+/// skeleton).
+struct NoopSigner;
+impl hyprstream_ledger::CheckpointSigner for NoopSigner {
+    fn sign(&self, _input: &[u8]) -> Result<Vec<u8>, hyprstream_ledger::LedgerError> {
+        Ok(Vec::new())
+    }
+    fn ledger_id(&self) -> &Did {
+        static ID: std::sync::OnceLock<Did> = std::sync::OnceLock::new();
+        ID.get_or_init(|| Did("did:web:cell.test".to_owned()))
+    }
+}
+
+/// Bounds sanity: the timeout band is what the plan specifies.
+#[test]
+fn timeout_bounds_are_plan_values() {
+    assert_eq!(MIN_TIMEOUT_S, 1);
+    assert_eq!(MAX_TIMEOUT_S, 24 * 60 * 60);
+}


### PR DESCRIPTION
Part of #923 (epic #922, plan on the epic comments). Item **1.1** — the
accounting-plane skeleton the whole cellular-ledger stack builds on. The trait
surface is load-bearing (every backend and the enforcer depend on it), so this
is the judgment-tier slice; RocksLedger / journal persistence / outbox emitter /
TigerBeetle are later items and are intentionally **not** built here.

## What's in it

New crate `crates/hyprstream-ledger` (MIT), added to the workspace:

- **`types.rs`** — `AccountId` = blake3-128 over `(ledger_id, owner, unit,
  purpose)` (PLAN DECISION 1; issuer baked into the unit per INV-1 and the #924
  P0 pseudonymity rule — no legal-identity fields, DID-only principals),
  `UnitId` (names its issuer), `TransferId` (client-supplied u128), the
  four-counter `Account` quadruple, `Purpose` (incl. `Bond`), `IssueTransfer` /
  `Transfer`, `Outcome`, `BalanceView`.
- **`errors.rs`** — the deterministic error vocabulary. Data-only (no wrapped
  sources) so `Outcome` is `Clone + Eq` and a replay is asserted byte-identical.
- **`engine.rs`** — the pure, backend-agnostic `stage` state machine (plan §2b):
  two-phase reserve/post(full|partial)/void/expire, overdraft check counts
  pending inside the commit, on-touch + sweep expiry judged by the ledger's
  logical commit clock, first-terminal-commit-wins race resolution (PLAN
  DECISION 2), transparent idempotent replay (PLAN DECISION 3).
- **`journal.rs`** — journal / checkpoint / outbox types, the `CheckpointSigner`
  injection seam, and hybrid-composite (`EdDSA + ML-DSA-65`) checkpoint
  verification via `hyprstream-crypto` — an **unconditional** dependency, no
  `cose` feature gate (PLAN DECISION 8, ratified).
- **`backend.rs`** — the synchronous `LedgerBackend` trait (PLAN DECISION 8:
  sync + actor facade owned by the service layer, keeps the core tokio-free).
- **`mem.rs`** — `MemLedger`: the complete in-memory reference implementation
  **and** the proptest oracle. WASM-friendly — no tokio, no I/O, no wall clock;
  the logical clock is advanced explicitly via `advance_clock`, which is what
  makes the expiry-vs-post race deterministic and reproducible.

## Trait-surface decisions (these gate downstream items)

- **Sync `LedgerBackend`** with a `&mut self` single-writer contract; the full
  §3.2 surface (open/credit/debit/reserve/post/void/balance/checkpoint/tick/
  outbox_peek/outbox_ack/journal_range/head) so 1.2/1.3/1.4 just implement it.
- **`AccountId::derive` is the one canonical id function** every backend calls,
  using a domain-separated length-prefixed encoding (not raw DAG-CBOR) so the
  derive stays infallible while remaining canonical across backends.
- **Transparent idempotent replay** is the contract (stored `Outcome` returned
  verbatim, including original errors); `DuplicateTransferId` / `IdTooOld` exist
  in the vocabulary for backends/retention that surface replays explicitly.
- **Same-account transfers are rejected** (`AccountsMustDiffer`, the TigerBeetle
  `accounts_must_be_different` rule) — found via a conservation proptest failure
  where a self-transfer collapsed two deltas onto one row.
- **`Op::Expire`** is an internal, non-idempotency-keyed op emitted by `tick`, so
  the hash chain records every expiry as a real journal entry.

## Tests

`cargo test -p hyprstream-ledger` green: proptests for **conservation** (Σposted
and Σpending debits == credits after every op), **inline idempotency** (replay
yields identical `Outcome`, zero state change), **two-phase overdraft safety**
(no debit-constrained account ever exceeds its credits across
reserve→post/void/expire interleavings), and **expiry-vs-post race determinism**
(never an `Applied` post at/after the deadline; second phase succeeds at most
once). Plus an end-to-end hybrid-composite checkpoint sign/verify roundtrip
proving the `hyprstream-crypto` dependency is load-bearing.

Verified: `cargo build -p hyprstream-ledger --target wasm32-unknown-unknown`
passes; `cargo clippy -p hyprstream-ledger --all-targets` clean; full-workspace
clippy pre-commit hook passed.