### PR TITLE
Unify secrets directory resolution

### DIFF
--- a/crates/hyprstream/src/auth/identity_store.rs
+++ b/crates/hyprstream/src/auth/identity_store.rs
@@ -25,21 +25,23 @@ use crate::server::tls::TlsMaterials;
 
 // ─── Low-level primitives ───────────────────────────────────────────────────
 
-/// Resolve the credentials/secrets directory: `HYPRSTREAM__SECRETS__PATH` if set,
-/// else `<config_dir>/credentials`. Fails closed — NEVER falls back to a
-/// world-writable /tmp path for a secret-bearing dir.
+/// Resolve the credentials/secrets directory via the unified config resolver.
+///
+/// Precedence is `HYPRSTREAM__SECRETS__PATH`, config `[secrets].path`, XDG
+/// `<config_dir>/credentials`, then error. Fails closed — NEVER falls back to a
+/// world-writable `/tmp` path or implicit `/etc` path for a secret-bearing dir.
 pub fn credentials_dir() -> anyhow::Result<std::path::PathBuf> {
-    if let Ok(p) = std::env::var("HYPRSTREAM__SECRETS__PATH") {
-        return Ok(std::path::PathBuf::from(p));
-    }
-    if let Ok(c) = crate::config::HyprConfig::load() {
-        return Ok(c.config_dir().join("credentials"));
-    }
-    let base = dirs::config_dir().ok_or_else(|| anyhow!(
-        "cannot resolve a credentials directory: set HYPRSTREAM__SECRETS__PATH \
-         (systemd credentials / k8s secret mount) — refusing to fall back to /tmp"
-    ))?;
-    Ok(base.join("hyprstream").join("credentials"))
+    crate::config::HyprConfig::resolve_secrets_dir()
+}
+
+/// Resolve credentials from an already-loaded config handle.
+///
+/// This is the same resolver family as `credentials_dir()`, but lets CLI paths
+/// that loaded config from `--config` avoid reloading default locations.
+pub fn credentials_dir_for_config(
+    config: Option<&crate::config::HyprConfig>,
+) -> anyhow::Result<std::path::PathBuf> {
+    crate::config::HyprConfig::resolve_secrets_dir_for(config)
 }
 
 /// Read a named secret from `dir`.  Returns `None` if the file does not exist.

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1385,7 +1385,9 @@ fn resolve_service_vk(service_name: &str) -> Option<VerifyingKey> {
         return Some(vk);
     }
     // CLI mode: seed from bootstrap-pubkeys on first use
-    let secrets_dir = HyprConfig::resolve_secrets_dir();
+    let Ok(secrets_dir) = HyprConfig::resolve_secrets_dir() else {
+        return None;
+    };
     if let Ok(pubkeys) = hyprstream_core::auth::identity_store::load_bootstrap_pubkeys(&secrets_dir) {
         for (name, vk) in &pubkeys {
             trust.insert(
@@ -1991,7 +1993,7 @@ fn main() -> Result<()> {
                                     // than this process reads from — the same "consumer silently
                                     // re-derives instead of reading the authoritative record"
                                     // disease #441 targets, just one directory earlier.
-                                    let secrets_dir = hyprstream_core::config::HyprConfig::resolve_secrets_dir();
+                                    let secrets_dir = hyprstream_core::config::HyprConfig::resolve_secrets_dir()?;
 
                                     // Load CA verifying key (trust anchor) for JWT verification only.
                                     // Do NOT insert into the trust store as "policy" scope — the trust
@@ -2063,7 +2065,7 @@ fn main() -> Result<()> {
                                     //
                                     // #759: same authoritative resolver as the `--ipc` branch above —
                                     // see the comment there.
-                                    let secrets_dir = hyprstream_core::config::HyprConfig::resolve_secrets_dir();
+                                    let secrets_dir = hyprstream_core::config::HyprConfig::resolve_secrets_dir()?;
 
                                     // Load CA verifying key (trust anchor)
                                     let ca_vk = hyprstream_core::auth::identity_store::load_ca_verifying_key(&secrets_dir)
@@ -2196,7 +2198,7 @@ fn main() -> Result<()> {
 
                                 // Populate ML-DSA-65 verifying keys for PQ-hybrid JWT verification.
                                 {
-                                    let secrets_dir = hyprstream_core::config::HyprConfig::resolve_secrets_dir();
+                                    let secrets_dir = hyprstream_core::config::HyprConfig::resolve_secrets_dir()?;
                                     let ml_dsa_store = hyprstream_core::auth::key_rotation::global_ml_dsa_key_store(
                                         &secrets_dir,
                                         &config.oauth,
@@ -2393,12 +2395,12 @@ fn main() -> Result<()> {
         Some(("user", sub_m)) => {
             let cmd = UserCommand::from_arg_matches(sub_m)
                 .map_err(|e| anyhow::anyhow!("{}", e))?;
-            // Deliberately NOT the shared `identity_store::credentials_dir()` helper:
-            // that helper re-runs `HyprConfig::load()` against default locations,
-            // while `ctx` honors the `--config <path>` CLI override. The operator's
-            // config must win here, or `--config` invocations would resolve the
-            // user store from XDG defaults and split it.
-            let credentials_dir = ctx.config_dir().join("credentials");
+            // Deliberately resolve from `ctx`: it honors the `--config <path>`
+            // CLI override. The operator's config must win here, or `--config`
+            // invocations would resolve the user store from XDG defaults and
+            // split it.
+            let credentials_dir =
+                hyprstream_core::auth::identity_store::credentials_dir_for_config(Some(ctx.config()))?;
             // User handlers are async, run them in a minimal runtime
             let rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()

--- a/crates/hyprstream/src/cli/bootstrap_manager.rs
+++ b/crates/hyprstream/src/cli/bootstrap_manager.rs
@@ -228,7 +228,16 @@ impl BootstrapManager {
 
         // Load the user-signing-key from the SAME secrets dir the CLI uses, so
         // the bound fingerprint matches the key the CLI signs with.
-        let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir();
+        let secrets_dir = match crate::config::HyprConfig::resolve_secrets_dir() {
+            Ok(path) => path,
+            Err(e) => {
+                tracing::warn!(
+                    username,
+                    "Failed to resolve secrets directory — CLI signing key will not be bound to '{username}': {e}"
+                );
+                return;
+            }
+        };
         let vk = match identity_store::load_or_generate_user_signing_key(&secrets_dir) {
             Ok((_sk, vk)) => vk,
             Err(e) => {

--- a/crates/hyprstream/src/cli/policy_handlers.rs
+++ b/crates/hyprstream/src/cli/policy_handlers.rs
@@ -411,7 +411,7 @@ pub async fn load_or_generate_signing_key(_keys_dir: &Path) -> Result<SigningKey
     if let Some(sk) = crate::config::HyprConfig::node_signing_key_bypass()? {
         return Ok(sk);
     }
-    let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir();
+    let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir()?;
     crate::auth::identity_store::load_or_generate_node_signing_key(&secrets_dir)
 }
 
@@ -456,7 +456,7 @@ pub(crate) fn ensure_user_signing_key() -> Result<(SigningKey, ed25519_dalek::Ve
     if let Some(pair) = crate::config::HyprConfig::user_signing_key_bypass()? {
         return Ok(pair);
     }
-    let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir();
+    let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir()?;
     crate::auth::identity_store::load_or_generate_user_signing_key(&secrets_dir)
 }
 

--- a/crates/hyprstream/src/cli/service_handlers.rs
+++ b/crates/hyprstream/src/cli/service_handlers.rs
@@ -71,8 +71,8 @@ pub async fn handle_service_install(
         #[cfg(feature = "systemd")]
         {
             let secrets_dir = crate::config::HyprConfig::load()
-                .map(|c| c.secrets.resolve_dir(c.config_dir()))
-                .ok();
+                .ok()
+                .and_then(|c| crate::config::HyprConfig::resolve_secrets_dir_for(Some(&c)).ok());
             hyprstream_service::encrypt_credentials_if_available(secrets_dir.as_deref());
         }
 
@@ -572,22 +572,29 @@ pub(crate) async fn run_repair_checks(
     // 4b. TLS materials (HTTP + QUIC) — generate into secrets dir so they are
     //     available for systemd-creds encryption in phase 6.
     {
-        let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir();
-        // HTTP TLS (365-day self-signed)
-        match crate::auth::identity_store::load_or_generate_tls_materials(&secrets_dir, "localhost", 365) {
-            Ok(_) => print_check("TLS key+cert", CheckStatus::Ok, "HTTP (365d)"),
-            Err(e) => {
-                print_check("TLS key+cert", CheckStatus::Fail, &format!("{e}"));
-                all_passed = false;
+        match crate::config::HyprConfig::resolve_secrets_dir() {
+            Ok(secrets_dir) => {
+                // HTTP TLS (365-day self-signed)
+                match crate::auth::identity_store::load_or_generate_tls_materials(&secrets_dir, "localhost", 365) {
+                    Ok(_) => print_check("TLS key+cert", CheckStatus::Ok, "HTTP (365d)"),
+                    Err(e) => {
+                        print_check("TLS key+cert", CheckStatus::Fail, &format!("{e}"));
+                        all_passed = false;
+                    }
+                }
+                // QUIC TLS (14-day per WebTransport spec)
+                match crate::auth::identity_store::load_or_generate_tls_materials_named(
+                    &secrets_dir, "localhost", 14, "quic-key", "quic-cert",
+                ) {
+                    Ok(_) => print_check("QUIC key+cert", CheckStatus::Ok, "WebTransport (14d)"),
+                    Err(e) => {
+                        print_check("QUIC key+cert", CheckStatus::Fail, &format!("{e}"));
+                        all_passed = false;
+                    }
+                }
             }
-        }
-        // QUIC TLS (14-day per WebTransport spec)
-        match crate::auth::identity_store::load_or_generate_tls_materials_named(
-            &secrets_dir, "localhost", 14, "quic-key", "quic-cert",
-        ) {
-            Ok(_) => print_check("QUIC key+cert", CheckStatus::Ok, "WebTransport (14d)"),
             Err(e) => {
-                print_check("QUIC key+cert", CheckStatus::Fail, &format!("{e}"));
+                print_check("Secrets directory", CheckStatus::Fail, &format!("{e}"));
                 all_passed = false;
             }
         }
@@ -595,12 +602,18 @@ pub(crate) async fn run_repair_checks(
 
     // 4c. RSA key for RS256 JWT signing (OIDC interop)
     {
-        let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir();
-        match crate::auth::identity_store::load_or_generate_rsa_key(&secrets_dir) {
-            Ok(_) => print_check("RSA key", CheckStatus::Ok, "RS256 (2048-bit)"),
+        match crate::config::HyprConfig::resolve_secrets_dir() {
+            Ok(secrets_dir) => {
+                match crate::auth::identity_store::load_or_generate_rsa_key(&secrets_dir) {
+                    Ok(_) => print_check("RSA key", CheckStatus::Ok, "RS256 (2048-bit)"),
+                    Err(e) => {
+                        // Non-fatal: EdDSA still works, RS256 is for interop
+                        print_check("RSA key", CheckStatus::Warn, &format!("{e}"));
+                    }
+                }
+            }
             Err(e) => {
-                // Non-fatal: EdDSA still works, RS256 is for interop
-                print_check("RSA key", CheckStatus::Warn, &format!("{e}"));
+                print_check("Secrets directory", CheckStatus::Warn, &format!("{e}"));
             }
         }
     }

--- a/crates/hyprstream/src/cli/sign_challenge.rs
+++ b/crates/hyprstream/src/cli/sign_challenge.rs
@@ -184,7 +184,7 @@ fn load_user_signing_key() -> Result<(ed25519_dalek::SigningKey, String)> {
         return Ok((sk, username));
     }
 
-    let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir();
+    let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir()?;
     let (sk, _vk) = crate::auth::identity_store::load_or_generate_user_signing_key(&secrets_dir)
         .map_err(|e| anyhow::anyhow!(
             "Could not load user signing key: {e}\n\
@@ -203,4 +203,3 @@ fn resolve_server_url(server: Option<String>) -> String {
         .map(|c| c.oauth.issuer_url())
         .unwrap_or_else(|_| "http://localhost:6791".to_owned())
 }
-

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -181,9 +181,11 @@ pub struct SecretsConfig {
 }
 
 impl SecretsConfig {
-    /// Resolve the secrets directory.
+    /// Resolve the secrets directory from this config section only.
     ///
-    /// Returns `path` if set, otherwise `<config_dir>/credentials`.
+    /// Most callers should use `HyprConfig::resolve_secrets_dir()` or
+    /// `HyprConfig::resolve_secrets_dir_for()` so env/config/XDG precedence is
+    /// applied uniformly for all secret material.
     pub fn resolve_dir(&self, config_dir: &Path) -> PathBuf {
         self.path.clone().unwrap_or_else(|| config_dir.join("credentials"))
     }
@@ -191,13 +193,15 @@ impl SecretsConfig {
     /// Return the default secrets directory when no config is available.
     ///
     /// Routes through `StoragePaths` so `XDG_CONFIG_HOME` is respected
-    /// consistently with every other directory in the application.
-    /// Falls back to `/etc/hyprstream/credentials` if XDG resolution fails.
-    pub fn default_dir() -> PathBuf {
-        StoragePaths::new()
-            .and_then(|p| p.config_dir())
-            .map(|d| d.join("credentials"))
-            .unwrap_or_else(|_| PathBuf::from("/etc/hyprstream/credentials"))
+    /// consistently with every other directory in the application. This is
+    /// fail-closed: there is no implicit `/etc` fallback.
+    pub fn default_dir() -> anyhow::Result<PathBuf> {
+        let storage = StoragePaths::new()
+            .map_err(|e| anyhow::anyhow!("failed to initialize XDG storage paths: {e}"))?;
+        let config_dir = storage
+            .config_dir()
+            .map_err(|e| anyhow::anyhow!("failed to resolve XDG config directory: {e}"))?;
+        Ok(config_dir.join("credentials"))
     }
 }
 
@@ -425,7 +429,7 @@ impl QuicConfig {
     /// the leaf + CA cert in a single PEM file.
     pub fn load_tls_materials(&self) -> anyhow::Result<(Vec<Vec<u8>>, Zeroizing<Vec<u8>>)> {
         if self.use_self_signed() {
-            let secrets_dir = HyprConfig::resolve_secrets_dir();
+            let secrets_dir = HyprConfig::resolve_secrets_dir()?;
             // Use quic-specific secret names so QUIC and HTTP certs have different
             // validity windows without stomping each other's files.
             let materials = crate::auth::identity_store::load_or_generate_tls_materials_named(
@@ -2261,14 +2265,36 @@ impl HyprConfig {
 
     // ── Secrets / key bypass helpers ────────────────────────────────────────
 
-    /// Resolve the secrets directory from config, or the platform XDG default.
+    /// Resolve the secrets directory using the unified secret-material resolver.
     ///
-    /// Prefer calling this over inlining the fallback logic everywhere.
-    pub fn resolve_secrets_dir() -> PathBuf {
-        match Self::load() {
-            Ok(cfg) => cfg.secrets.resolve_dir(cfg.config_dir()),
-            Err(_) => SecretsConfig::default_dir(),
+    /// Precedence is:
+    /// 1. `HYPRSTREAM__SECRETS__PATH`
+    /// 2. explicit config, when provided via `resolve_secrets_dir_for`
+    /// 3. loaded config file / env-derived config
+    /// 4. XDG default (`<config_dir>/credentials`)
+    ///
+    /// Resolution is fail-closed: no `/etc` or `/tmp` fallback is chosen
+    /// silently when XDG resolution fails.
+    pub fn resolve_secrets_dir() -> anyhow::Result<PathBuf> {
+        Self::resolve_secrets_dir_for(None)
+    }
+
+    /// Resolve the secrets directory, optionally from an already-loaded config.
+    ///
+    /// The optional config handle lets CLI paths that already honored
+    /// `--config <path>` stay on the same resolver family as daemon/service
+    /// code instead of reloading default config locations.
+    pub fn resolve_secrets_dir_for(config: Option<&HyprConfig>) -> anyhow::Result<PathBuf> {
+        if let Ok(path) = std::env::var("HYPRSTREAM__SECRETS__PATH") {
+            return Ok(PathBuf::from(path));
         }
+        if let Some(config) = config {
+            return Ok(config.secrets.resolve_dir(config.config_dir()));
+        }
+        if let Ok(config) = Self::load() {
+            return Ok(config.secrets.resolve_dir(config.config_dir()));
+        }
+        SecretsConfig::default_dir()
     }
 
     /// Check for the `HYPRSTREAM__SIGNING_KEY` test bypass.
@@ -2571,6 +2597,63 @@ impl From<&crate::config::server::SamplingParamDefaults> for SamplingParams {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Serialize process-env mutations for secrets-dir resolver tests.
+    static SECRETS_DIR_ENV_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn resolve_secrets_dir_env_overrides_config() {
+        let _serial = SECRETS_DIR_ENV_LOCK.lock();
+        let _xdg = EnvVarGuard::set("XDG_CONFIG_HOME", "/tmp/hyprstream-test-config");
+        let _instance = EnvVarGuard::unset("HYPRSTREAM_INSTANCE");
+        let _env = EnvVarGuard::set("HYPRSTREAM__SECRETS__PATH", "/run/hyprstream/secrets");
+
+        let mut cfg = HyprConfig::default();
+        cfg.secrets.path = Some(PathBuf::from("/config/secrets"));
+
+        let dir = HyprConfig::resolve_secrets_dir_for(Some(&cfg)).unwrap();
+        assert_eq!(dir, PathBuf::from("/run/hyprstream/secrets"));
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn resolve_secrets_dir_config_overrides_xdg_default() {
+        let _serial = SECRETS_DIR_ENV_LOCK.lock();
+        let xdg = tempfile::TempDir::new().unwrap();
+        let config_secret = xdg.path().join("from-config");
+        let _xdg = EnvVarGuard::set("XDG_CONFIG_HOME", xdg.path().to_str().unwrap());
+        let _instance = EnvVarGuard::unset("HYPRSTREAM_INSTANCE");
+        let _env = EnvVarGuard::unset("HYPRSTREAM__SECRETS__PATH");
+
+        let mut cfg = HyprConfig::default();
+        cfg.secrets.path = Some(config_secret.clone());
+
+        let dir = HyprConfig::resolve_secrets_dir_for(Some(&cfg)).unwrap();
+        assert_eq!(dir, config_secret);
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn resolve_secrets_dir_uses_xdg_default_without_env_or_config_path() {
+        let _serial = SECRETS_DIR_ENV_LOCK.lock();
+        let xdg = tempfile::TempDir::new().unwrap();
+        let _xdg = EnvVarGuard::set("XDG_CONFIG_HOME", xdg.path().to_str().unwrap());
+        let _instance = EnvVarGuard::unset("HYPRSTREAM_INSTANCE");
+        let _env = EnvVarGuard::unset("HYPRSTREAM__SECRETS__PATH");
+
+        let dir = HyprConfig::resolve_secrets_dir().unwrap();
+        assert_eq!(dir, xdg.path().join("hyprstream").join("credentials"));
+    }
+
+    #[test]
+    fn resolve_secrets_dir_errors_when_xdg_unresolvable() {
+        let _serial = SECRETS_DIR_ENV_LOCK.lock();
+        let _instance = EnvVarGuard::set("HYPRSTREAM_INSTANCE", "../bad");
+        let _env = EnvVarGuard::unset("HYPRSTREAM__SECRETS__PATH");
+
+        assert!(HyprConfig::resolve_secrets_dir().is_err());
+    }
 
     #[test]
     #[allow(clippy::expect_used)]

--- a/crates/hyprstream/src/server/tls.rs
+++ b/crates/hyprstream/src/server/tls.rs
@@ -49,7 +49,7 @@ pub fn get_or_init_tls_materials(config: &TlsConfig) -> anyhow::Result<Arc<TlsMa
     }
 
     let materials = if config.use_self_signed() {
-        let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir();
+        let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir()?;
         let server_name = &config.server_name;
         info!(
             "Loading/generating TLS materials (365-day validity) from '{}'",

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -481,7 +481,7 @@ fn create_policy_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
 
     // Wire ES256 + ML-DSA rotation stores into PolicyService for composite token issuance.
     // Uses global singletons so PolicyService shares the same store the rotation task updates.
-    let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir();
+    let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir()?;
     let es256_store = crate::auth::key_rotation::global_es256_key_store(&secrets_dir, &config.oauth);
     policy_service = policy_service.with_es256_key_store(es256_store);
     {
@@ -540,7 +540,7 @@ fn create_registry_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawn
     // fail closed rather than fall back to /tmp (H2).
     let pds_publisher = (|| -> anyhow::Result<crate::services::discovery::PdsPublisher> {
         let store_dir = pds_store_dir()?;
-        let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir();
+        let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir()?;
         let es256_store =
             crate::auth::key_rotation::global_es256_key_store(&secrets_dir, &config.oauth);
         // `active_key` is async (tokio RwLock); resolve it once here on the

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -520,7 +520,7 @@ impl Spawnable for OAuthService {
 
             // Load the CA JWT signing key for browser WIT issuance (POST /oauth/wit).
             // Also seed the signing key store from the same root key.
-            let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir();
+            let secrets_dir = credentials_dir.clone();
             let oauth_config_arc = Arc::new(self.config.clone());
 
             // Load or initialize ES256 + ML-DSA rotation stores (independent of CA key).


### PR DESCRIPTION
Closes #931

## Summary
- route auth credentials_dir through the HyprConfig secrets resolver
- make secrets resolution fail closed with env > config secrets.path > XDG default > error
- preserve --config-derived user command resolution via an explicit config handle

## Tests
- LIBTORCH=/home/birdetta/Downloads/libtorch LD_LIBRARY_PATH=/home/birdetta/Downloads/libtorch/lib OPENSSL_NO_VENDOR=1 CARGO_TARGET_DIR=/home/birdetta/.cargo-target-931 cargo check -p hyprstream --lib
- LIBTORCH=/home/birdetta/Downloads/libtorch LD_LIBRARY_PATH=/home/birdetta/Downloads/libtorch/lib OPENSSL_NO_VENDOR=1 CARGO_TARGET_DIR=/home/birdetta/.cargo-target-931 cargo test -p hyprstream --lib auth::
- LIBTORCH=/home/birdetta/Downloads/libtorch LD_LIBRARY_PATH=/home/birdetta/Downloads/libtorch/lib OPENSSL_NO_VENDOR=1 CARGO_TARGET_DIR=/home/birdetta/.cargo-target-931 cargo test -p hyprstream --lib config::