### PR TITLE
feat(gittorrent): iroh-blobs object store spike behind iroh-blobs feature (F1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,6 +1039,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1274,6 +1283,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bao-tree"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06384416b1825e6e04fde63262fda2dc408f5b64c02d04e0d8b70ae72c17a52b"
+dependencies = [
+ "blake3",
+ "bytes",
+ "futures-lite 2.6.1",
+ "genawaiter",
+ "iroh-io",
+ "positioned-io",
+ "range-collections",
+ "self_cell",
+ "serde",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
 name = "base-x"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1377,6 +1405,12 @@ dependencies = [
  "quote",
  "syn 2.0.111",
 ]
+
+[[package]]
+name = "binary-merge"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597bb81c80a54b6a4381b23faba8d7774b144c94cbd1d6fe3f1329bd776554ab"
 
 [[package]]
 name = "bincode"
@@ -1714,6 +1748,9 @@ name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bytes-utils"
@@ -5728,6 +5765,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "genawaiter"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86bd0361bcbde39b13475e6e36cb24c329964aa2611be285289d1e4b751c1a0"
+dependencies = [
+ "futures-core",
+ "genawaiter-macro",
+ "genawaiter-proc-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "genawaiter-macro"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b32dfe1fdfc0bbde1f22a5da25355514b5e450c33a6af6770884c8750aedfbc"
+
+[[package]]
+name = "genawaiter-proc-macro"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784f84eebc366e15251c4a8c3acee82a6a6f427949776ecb88377362a9621738"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "generator"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5947,6 +6015,7 @@ dependencies = [
  "git2",
  "glob",
  "hex",
+ "iroh-blobs",
  "libp2p",
  "mainline",
  "multihash",
@@ -6208,6 +6277,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6288,6 +6366,20 @@ name = "heapify"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0049b265b7f201ca9ab25475b22b47fe444060126a51abe00f77d986fc5cc52e"
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin 0.9.8",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -7878,6 +7970,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inplace-vec-builder"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf64c2edc8226891a71f127587a2861b132d2b942310843814d5001d99a1d307"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "inquire"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8046,9 +8147,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-base"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af93d67701c00c504982154569192ad384738c0450ba1196930314b955100552"
+checksum = "2160a45265eba3bd290ce698f584c9b088bee47e518e9ec4460d5e5888ef660e"
 dependencies = [
  "curve25519-dalek 5.0.0-pre.6",
  "data-encoding",
@@ -8067,10 +8168,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "iroh-dns"
-version = "1.0.0-rc.1"
+name = "iroh-blobs"
+version = "0.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de4112c91eb64094d77df9d3112606dcf7ff216421afccd2dc762fda5a7b2879"
+checksum = "c6e351f5c1db08dcfb456e6299bda0881e1ba95a360f0913a5e57344c1538fb2"
+dependencies = [
+ "arrayvec",
+ "bao-tree",
+ "bytes",
+ "cfg_aliases",
+ "chrono",
+ "constant_time_eq 0.4.2",
+ "data-encoding",
+ "derive_more",
+ "genawaiter",
+ "getrandom 0.4.2",
+ "hex",
+ "iroh",
+ "iroh-base",
+ "iroh-io",
+ "iroh-metrics",
+ "iroh-tickets",
+ "iroh-util",
+ "irpc",
+ "n0-error",
+ "n0-future",
+ "nested_enum_utils",
+ "postcard",
+ "rand 0.10.1",
+ "range-collections",
+ "redb",
+ "ref-cast",
+ "reflink-copy",
+ "self_cell",
+ "serde",
+ "smallvec",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "iroh-dns"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8b6d2946350d398c9d2d795bb99b04f22e8414c8a8ad9c5c3c0c5b7899af9a4"
 dependencies = [
  "arc-swap",
  "cfg_aliases",
@@ -8088,6 +8229,19 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "iroh-io"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a5feb781017b983ff1b155cd1faf8174da2acafd807aa482876da2d7e6577a"
+dependencies = [
+ "bytes",
+ "futures-lite 2.6.1",
+ "pin-project",
+ "smallvec",
+ "tokio",
 ]
 
 [[package]]
@@ -8161,6 +8315,63 @@ dependencies = [
  "vergen-gitcl",
  "webpki-roots 1.0.7",
  "ws_stream_wasm",
+]
+
+[[package]]
+name = "iroh-tickets"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a4b7fbfa10582f6b4f6b013eef1d21987d3df5fd42c0f7707d5de6abd34f8e9"
+dependencies = [
+ "data-encoding",
+ "derive_more",
+ "iroh-base",
+ "n0-error",
+ "postcard",
+ "serde",
+]
+
+[[package]]
+name = "iroh-util"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7705450a124b2b05f7caad505620ab5ac3bf4eb6b85018e6b9bca36329fd031"
+dependencies = [
+ "derive_more",
+ "iroh",
+ "n0-error",
+ "n0-future",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "irpc"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d38567eed2ed120e1040386930eb3b9ce6ca8a94b13c20a1b3b6535f253b00c"
+dependencies = [
+ "futures-util",
+ "irpc-derive",
+ "n0-error",
+ "n0-future",
+ "postcard",
+ "serde",
+ "smallvec",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "irpc-derive"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d8030c02dce4c9a8aecfb6e0870ee13ba3060096d88f6c1309919af8f197793"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -10209,6 +10420,18 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "nested_enum_utils"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d5475271bdd36a4a2769eac1ef88df0f99428ea43e52dfd8b0ee5cb674695f"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
 
 [[package]]
 name = "netdev"
@@ -12612,6 +12835,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "positioned-io"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ec4b80060f033312b99b6874025d9503d2af87aef2dd4c516e253fbfcdada7"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "postcard"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12620,6 +12853,7 @@ dependencies = [
  "cobs",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
+ "heapless",
  "postcard-derive",
  "serde",
 ]
@@ -12735,6 +12969,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "syn-mid",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12755,6 +13015,12 @@ dependencies = [
  "quote",
  "syn 2.0.111",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -13435,6 +13701,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "range-collections"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "861706ea9c4aded7584c5cd1d241cec2ea7f5f50999f236c22b65409a1f1a0d0"
+dependencies = [
+ "binary-merge",
+ "inplace-vec-builder",
+ "ref-cast",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
 name = "ratatui"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13573,6 +13852,15 @@ checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
 dependencies = [
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "redb"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -14823,6 +15111,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15845,6 +16139,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn-mid"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea305d57546cc8cd04feb14b62ec84bf17f50e3f7b12560d7bfa9265f39d9ed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/crates/gittorrent/Cargo.toml
+++ b/crates/gittorrent/Cargo.toml
@@ -75,6 +75,11 @@ libp2p = { version = "0.56", features = ["kad", "mdns", "noise", "tcp", "tokio",
 # Optional: nothing ships enabled until Track C wiring lands.
 mainline = { version = "7.0", optional = true }
 blake3 = { workspace = true, optional = true }
+
+# iroh-blobs content-addressed byte transport (F1, #899).
+# 0.101.0 pins iroh =1.0.0-rc.0 - the exact version the workspace pins via
+# web-transport-iroh 0.5.x; co-bump all three together (see workspace Cargo.toml).
+iroh-blobs = { version = "=0.101.0", default-features = false, features = ["fs-store"], optional = true }
 multihash = "0.19"
 sha2 = "0.10"
 
@@ -93,6 +98,9 @@ debug = []
 # at9p mainline (BEP5) locator: arbitrary-infohash announce/get_peers, which
 # iroh's internal pkarr cannot do. Off by default (#889 / epic #880 Track C).
 mainline-locator = ["dep:blake3", "dep:mainline"]
+# Experimental iroh-blobs-backed object store (F1, #899). Local store only;
+# networked fetch via the at9p locator is F2 (#900).
+iroh-blobs = ["dep:iroh-blobs"]
 
 [lints]
 workspace = true

--- a/crates/gittorrent/src/blobs.rs
+++ b/crates/gittorrent/src/blobs.rs
@@ -1,0 +1,390 @@
+//! iroh-blobs-backed content-addressed object store (F1, #899).
+//!
+//! Evaluation + first-integration spike for Track F of the gittorrent →
+//! `hyprstream-p2p` convergence (epic #880 §2). Provides a LOCAL (in-process,
+//! no network) put/get pair preserving the consumer contract used by
+//! git-xet-filter and git2db:
+//!
+//! ```text
+//! put_object(Vec<u8>)      -> Sha256Hash
+//! get_object(&Sha256Hash)  -> Option<Vec<u8>>
+//! ```
+//!
+//! # SHA256 ↔ BLAKE3 bridge
+//!
+//! iroh-blobs addresses content by BLAKE3, while the consumer contract is
+//! keyed by SHA256 (XET `MerkleHash` maps 1:1 onto `Sha256Hash`). Rather than
+//! re-keying the consumers, this module keeps the SHA256 facade and maintains
+//! a `sha256 → blake3` index at put time — the facade-preserving shape the
+//! epic ratified. The index is a *locator only*, never a trust root: bytes
+//! fetched through it are BLAKE3-verified by iroh-blobs on read and then
+//! re-verified here against the requested SHA256, so a corrupted or poisoned
+//! index entry can fail a lookup but can never serve wrong bytes.
+//!
+//! For the persistent (`FsStore`) backend the index is an append-only sidecar
+//! file (`sha256-blake3.index`, one `sha256hex blake3hex` line per object)
+//! loaded at open. Malformed or unverifiable lines are skipped with a warning
+//! (the object merely becomes unreachable via SHA256 until re-put).
+//!
+//! # Scope
+//!
+//! Local store only. Networked fetch (provider discovery via the at9p
+//! mainline locator + remote transfer) is F2 (#900). Wiring this store under
+//! `GitTorrentService::{put,get}_object` in place of the libp2p DHT is also
+//! F2; retiring libp2p is F3 (#901).
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use iroh_blobs::store::fs::FsStore;
+use iroh_blobs::store::mem::MemStore;
+use iroh_blobs::Hash as Blake3Hash;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::Mutex;
+
+use crate::crypto::hash::{sha256_git, verify_sha256};
+use crate::{Error, Result, Sha256Hash};
+
+/// Sidecar index file name (relative to the `FsStore` root).
+const INDEX_FILE: &str = "sha256-blake3.index";
+
+enum Backend {
+    Mem(MemStore),
+    Fs(FsStore),
+}
+
+impl Backend {
+    fn store(&self) -> &iroh_blobs::api::Store {
+        match self {
+            Backend::Mem(s) => s,
+            Backend::Fs(s) => s,
+        }
+    }
+}
+
+/// Content-addressed object store backed by iroh-blobs, keyed by SHA256.
+///
+/// See the module docs for the SHA256 ↔ BLAKE3 bridging model.
+pub struct IrohBlobStore {
+    backend: Backend,
+    /// sha256 → blake3 mapping (locator only — reads re-verify SHA256).
+    index: Mutex<HashMap<Sha256Hash, Blake3Hash>>,
+    /// Append-only index persistence (fs backend only).
+    index_path: Option<PathBuf>,
+}
+
+impl IrohBlobStore {
+    /// Create an ephemeral, in-memory store (tests, throwaway caches).
+    pub fn new_memory() -> Self {
+        Self {
+            backend: Backend::Mem(MemStore::new()),
+            index: Mutex::new(HashMap::new()),
+            index_path: None,
+        }
+    }
+
+    /// Open (or create) a persistent store rooted at `root`.
+    ///
+    /// Blob bytes live in the iroh-blobs `FsStore` under `root`; the
+    /// sha256→blake3 index is an append-only sidecar file next to it.
+    pub async fn open_fs(root: impl AsRef<Path>) -> Result<Self> {
+        let root = root.as_ref();
+        tokio::fs::create_dir_all(root).await?;
+        let store = FsStore::load(root)
+            .await
+            .map_err(|e| Error::other(format!("failed to open iroh-blobs store: {e}")))?;
+
+        let index_path = root.join(INDEX_FILE);
+        let index = load_index(&index_path).await?;
+
+        Ok(Self {
+            backend: Backend::Fs(store),
+            index: Mutex::new(index),
+            index_path: Some(index_path),
+        })
+    }
+
+    /// Store an object, returning its SHA256 hash (the consumer-facing key).
+    ///
+    /// The bytes are added to the iroh-blobs store (BLAKE3-addressed, tagged
+    /// so garbage collection cannot reclaim them) and the sha256→blake3
+    /// mapping is recorded.
+    pub async fn put_object(&self, data: Vec<u8>) -> Result<Sha256Hash> {
+        let sha256 = sha256_git(&data)?;
+
+        let tag = self
+            .backend
+            .store()
+            .blobs()
+            .add_bytes(data)
+            .await
+            .map_err(|e| Error::other(format!("iroh-blobs add failed: {e}")))?;
+
+        let mut index = self.index.lock().await;
+        if index.insert(sha256.clone(), tag.hash).is_none() {
+            if let Some(path) = &self.index_path {
+                append_index_entry(path, &sha256, &tag.hash).await?;
+            }
+        }
+        drop(index);
+
+        tracing::debug!("stored object sha256={} blake3={}", sha256, tag.hash);
+        Ok(sha256)
+    }
+
+    /// Fetch an object by its SHA256 hash.
+    ///
+    /// Returns `Ok(None)` when the hash is unknown. Returns an error if the
+    /// index resolves but the retrieved bytes do not hash back to the
+    /// requested SHA256 (poisoned/corrupt mapping — never served).
+    pub async fn get_object(&self, hash: &Sha256Hash) -> Result<Option<Vec<u8>>> {
+        let blake3 = {
+            let index = self.index.lock().await;
+            match index.get(hash) {
+                Some(b3) => *b3,
+                None => return Ok(None),
+            }
+        };
+
+        let bytes = match self.backend.store().blobs().get_bytes(blake3).await {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                // Index entry without a backing blob: unreachable object, not
+                // a hard error for a cache-shaped lookup API.
+                tracing::warn!("indexed blob {blake3} missing from store for sha256 {hash}: {e}");
+                return Ok(None);
+            }
+        };
+
+        let data = bytes.to_vec();
+        if !verify_sha256(&data, hash)? {
+            return Err(Error::other(format!(
+                "sha256 verification failed for object {hash} (index maps to blake3 {blake3})"
+            )));
+        }
+        Ok(Some(data))
+    }
+
+    /// Resolve the BLAKE3 hash backing a SHA256 key, if known.
+    ///
+    /// This is the seam F2 (#900) uses to announce/locate providers: the
+    /// locator plane finds peers, iroh-blobs transfers by BLAKE3.
+    pub async fn blake3_of(&self, hash: &Sha256Hash) -> Option<Blake3Hash> {
+        self.index.lock().await.get(hash).copied()
+    }
+
+    /// Number of SHA256-addressable objects.
+    pub async fn len(&self) -> usize {
+        self.index.lock().await.len()
+    }
+
+    /// Whether the store has no SHA256-addressable objects.
+    pub async fn is_empty(&self) -> bool {
+        self.index.lock().await.is_empty()
+    }
+
+    /// Shut down the underlying iroh-blobs store, flushing pending writes.
+    ///
+    /// Required before the same `FsStore` root can be reopened (the fs
+    /// backend holds a database lock until its actor shuts down); dropping
+    /// the store alone does not release it promptly.
+    pub async fn shutdown(&self) -> Result<()> {
+        self.backend
+            .store()
+            .shutdown()
+            .await
+            .map_err(|e| Error::other(format!("iroh-blobs shutdown failed: {e}")))
+    }
+}
+
+/// Load the sidecar index, skipping (with a warning) any malformed lines.
+async fn load_index(path: &Path) -> Result<HashMap<Sha256Hash, Blake3Hash>> {
+    let mut index = HashMap::new();
+    let contents = match tokio::fs::read_to_string(path).await {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(index),
+        Err(e) => return Err(e.into()),
+    };
+
+    for (lineno, line) in contents.lines().enumerate() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let parsed = line.split_once(' ').and_then(|(sha_hex, b3_hex)| {
+            let sha = Sha256Hash::new(sha_hex).ok()?;
+            let b3 = b3_hex.parse::<Blake3Hash>().ok()?;
+            Some((sha, b3))
+        });
+        match parsed {
+            Some((sha, b3)) => {
+                index.insert(sha, b3);
+            }
+            None => {
+                tracing::warn!(
+                    "skipping malformed index line {} in {}",
+                    lineno + 1,
+                    path.display()
+                );
+            }
+        }
+    }
+    Ok(index)
+}
+
+/// Append one `sha256hex blake3hex` line to the sidecar index.
+async fn append_index_entry(path: &Path, sha256: &Sha256Hash, blake3: &Blake3Hash) -> Result<()> {
+    let mut file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .await?;
+    file.write_all(format!("{sha256} {blake3}\n").as_bytes())
+        .await?;
+    file.flush().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn test_memory_roundtrip() -> Result<()> {
+        let store = IrohBlobStore::new_memory();
+        let data = b"hello iroh-blobs".to_vec();
+
+        let hash = store.put_object(data.clone()).await?;
+        // The consumer-facing key is plain SHA256 of the bytes.
+        assert_eq!(hash, sha256_git(&data)?);
+
+        let fetched = store.get_object(&hash).await?;
+        assert_eq!(fetched.as_deref(), Some(data.as_slice()));
+        assert_eq!(store.len().await, 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_unknown_hash_is_none() -> Result<()> {
+        let store = IrohBlobStore::new_memory();
+        let unknown = sha256_git(b"never stored")?;
+        assert!(store.get_object(&unknown).await?.is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_put_is_idempotent() -> Result<()> {
+        let store = IrohBlobStore::new_memory();
+        let data = b"same bytes twice".to_vec();
+        let h1 = store.put_object(data.clone()).await?;
+        let h2 = store.put_object(data.clone()).await?;
+        assert_eq!(h1, h2);
+        assert_eq!(store.len().await, 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_blake3_mapping_exposed() -> Result<()> {
+        let store = IrohBlobStore::new_memory();
+        let data = b"mapped".to_vec();
+        let sha = store.put_object(data.clone()).await?;
+
+        let b3 = store
+            .blake3_of(&sha)
+            .await
+            .ok_or_else(|| Error::not_found("missing mapping"))?;
+        // Hash::new computes BLAKE3 of the bytes — the mapping must point at
+        // the BLAKE3 of the stored content.
+        assert_eq!(b3, Blake3Hash::new(data.as_slice()));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_fs_persistence_across_reopen() -> Result<()> {
+        let dir = TempDir::new()?;
+        let data = b"persisted across reopen".to_vec();
+
+        let sha = {
+            let store = IrohBlobStore::open_fs(dir.path()).await?;
+            let sha = store.put_object(data.clone()).await?;
+            store.shutdown().await?;
+            sha
+        };
+
+        let store = IrohBlobStore::open_fs(dir.path()).await?;
+        let fetched = store.get_object(&sha).await?;
+        assert_eq!(fetched.as_deref(), Some(data.as_slice()));
+        store.shutdown().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_poisoned_index_never_serves_wrong_bytes() -> Result<()> {
+        let dir = TempDir::new()?;
+        let a = b"object a".to_vec();
+        let b = b"object b".to_vec();
+
+        let (sha_a, sha_b) = {
+            let store = IrohBlobStore::open_fs(dir.path()).await?;
+            let pair = (store.put_object(a.clone()).await?, store.put_object(b.clone()).await?);
+            store.shutdown().await?;
+            pair
+        };
+
+        // Poison the sidecar: cross-wire a's sha256 to b's blake3.
+        let index_path = dir.path().join(INDEX_FILE);
+        let contents = tokio::fs::read_to_string(&index_path).await?;
+        let mut b3 = HashMap::new();
+        for line in contents.lines() {
+            if let Some((sha, blake)) = line.split_once(' ') {
+                b3.insert(sha.to_owned(), blake.to_owned());
+            }
+        }
+        let poisoned = format!(
+            "{} {}\n{} {}\n",
+            sha_a,
+            b3[sha_b.as_str()],
+            sha_b,
+            b3[sha_a.as_str()]
+        );
+        tokio::fs::write(&index_path, poisoned).await?;
+
+        let store = IrohBlobStore::open_fs(dir.path()).await?;
+        // Both lookups resolve to real blobs, but the bytes fail SHA256
+        // re-verification — the store must error, never serve wrong bytes.
+        assert!(store.get_object(&sha_a).await.is_err());
+        assert!(store.get_object(&sha_b).await.is_err());
+        store.shutdown().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_malformed_index_lines_skipped() -> Result<()> {
+        let dir = TempDir::new()?;
+        let data = b"good object".to_vec();
+
+        let sha = {
+            let store = IrohBlobStore::open_fs(dir.path()).await?;
+            let sha = store.put_object(data.clone()).await?;
+            store.shutdown().await?;
+            sha
+        };
+
+        // Prepend garbage lines to the sidecar.
+        let index_path = dir.path().join(INDEX_FILE);
+        let contents = tokio::fs::read_to_string(&index_path).await?;
+        tokio::fs::write(
+            &index_path,
+            format!("not an index line\ndeadbeef tooshort\n{contents}"),
+        )
+        .await?;
+
+        let store = IrohBlobStore::open_fs(dir.path()).await?;
+        let fetched = store.get_object(&sha).await?;
+        assert_eq!(fetched.as_deref(), Some(data.as_slice()));
+        assert_eq!(store.len().await, 1);
+        store.shutdown().await?;
+        Ok(())
+    }
+}

--- a/crates/gittorrent/src/lib.rs
+++ b/crates/gittorrent/src/lib.rs
@@ -3,6 +3,8 @@
 //! This library implements a peer-to-peer network for sharing Git repositories
 //! using libp2p and a Kademlia distributed hash table (DHT).
 
+#[cfg(feature = "iroh-blobs")]
+pub mod blobs;
 pub mod crypto;
 pub mod dht;
 pub mod error;


### PR DESCRIPTION
Part of #899 / #880 Track F.

## Phase 1 — evaluation verdict: SUITABLE

**iroh-blobs 0.101.0** (n0-computer, MIT OR Apache-2.0, active monthly cadence — 0.103.0 shipped 2026-06-15):

- **Version fit**: 0.101.0 pins `iroh =1.0.0-rc.0` — the *exact* version this workspace already pins via `web-transport-iroh 0.5.x`, so **no duplicate iroh tree** enters the graph. 0.102/0.103 track `=1.0.0-rc.1` / `^1.0.0` stable; co-bump iroh-blobs with the iroh/web-transport-iroh pair (comment left in `crates/gittorrent/Cargo.toml`).
- **API stability**: pre-1.0 but the post-0.90 "blobs2" store API (`MemStore`/`FsStore` deref to `api::Store`; `blobs().add_bytes()` / `blobs().get_bytes()`) has been stable across 0.94→0.103. One sharp edge found: `FsStore` holds its db lock until an explicit `Store::shutdown()` — dropping is not enough (surfaced as a test hang; the spike exposes `shutdown()`).
- **SHA256 ↔ BLAKE3** (the critical fit question): iroh-blobs is BLAKE3-addressed, the consumer contract (git-xet-filter `StorageBackend`, git2db) is SHA256-keyed. **Decision: keep the facade, bridge with a sha256→blake3 index maintained at put time** — re-keying consumers would ripple into XET pointer formats (`{"xet":"gittorrent","sha256":...}`) and `MerkleHash` interop for zero benefit. The index is a *locator only, never a trust root*: reads are BLAKE3-verified by iroh-blobs, then re-verified against the requested SHA256, so a poisoned/corrupt index entry can fail a lookup but can never serve wrong bytes (covered by a test).
- **Provider announcement**: iroh-blobs deliberately has no global content discovery — providers serve via `BlobsProtocol` on an iroh Endpoint; discovery is external (tickets or a locator). That is exactly the epic's split: **bytes = iroh-blobs, find = at9p mainline locator (C2/#890)**. `blake3_of()` is the exposed seam for F2.
- **wasm**: explicit `wasm_browser` cfg support upstream (mem store; `fs-store` is native-only) — compatible with the Wanix direction.
- **Dependency weight**: +24 lockfile entries, mostly small (bao-tree, irpc, genawaiter, redb for fs-store), vs the 19 `libp2p*` crates plus their tree that F3 (#901) retires — net reduction once libp2p goes, and the substrate (iroh) is already in-tree.

## Phase 2 — what this adds

- `gittorrent` gains an **off-by-default `iroh-blobs` feature** (optional dep, `default-features = false, features = ["fs-store"]`).
- New `gittorrent::blobs::IrohBlobStore`: local (in-process, **no network**) `put_object(Vec<u8>) -> Sha256Hash` / `get_object(&Sha256Hash) -> Option<Vec<u8>>` against a mem or fs iroh-blobs store, with the sha256→blake3 index (append-only sidecar file for the fs backend) and SHA256 re-verification on every read.
- 7 unit tests, no network: mem/fs round-trips, reopen persistence, idempotent put, unknown-hash → `None`, malformed index lines skipped, and poisoned-index-never-serves-wrong-bytes.

**Not in scope here** (per the story split): networked fetch via the locator and wiring `GitTorrentService::{put,get}_object` onto this store is F2 (#900); retiring libp2p is F3 (#901); the `hyprstream-p2p` rename is F4 (#902, lands with F1–F3).

## Test results

`cargo test -p gittorrent --features iroh-blobs`: 52 lib tests passed (7 new), 0 failed; doctests green; clippy clean; default (no-feature) build unchanged.