### PR TITLE
ci: advance pinned Rust toolchain 1.96.0 → 1.97.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y capnproto libsystemd-dev pkg-config libssl-dev
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.96.0
       with:
         components: clippy
 
@@ -83,7 +83,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y capnproto pkg-config
 
     - name: Install Rust toolchain (wasm32)
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.96.0
       with:
         targets: wasm32-unknown-unknown
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y capnproto libsystemd-dev pkg-config libssl-dev
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@1.96.0
+      uses: dtolnay/rust-toolchain@1.97.0
       with:
         components: clippy
 
@@ -83,7 +83,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y capnproto pkg-config
 
     - name: Install Rust toolchain (wasm32)
-      uses: dtolnay/rust-toolchain@1.96.0
+      uses: dtolnay/rust-toolchain@1.97.0
       with:
         targets: wasm32-unknown-unknown
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5065,9 +5065,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "event-listener"

--- a/crates/git2db/src/clone_builder.rs
+++ b/crates/git2db/src/clone_builder.rs
@@ -269,7 +269,7 @@ impl CloneBuilder {
         // Build paths
         let repo_dir = hyprstream_containedfs::contained_join(&models_dir, &repo_name)
             .map_err(|e| Git2DBError::configuration(format!("Invalid repository name: {e}")))?;
-        let bare_repo_name = format!("{}.git", &repo_name);
+        let bare_repo_name = format!("{}.git", repo_name);
         let bare_repo_path = repo_dir.join(&bare_repo_name);
         let worktrees_dir = repo_dir.join("worktrees");
 

--- a/crates/hyprstream-flight/src/cli/handlers.rs
+++ b/crates/hyprstream-flight/src/cli/handlers.rs
@@ -80,7 +80,7 @@ pub async fn handle_server(
 
         if let Some(ca) = config.get::<Vec<u8>>("tls.ca_data").ok()
             .or_else(|| config.get_string("tls.ca_path").ok()
-                .and_then(|p| if p.is_empty() { None } else { Some(p) })
+                .filter(|p| !p.is_empty())
                 .and_then(|p| std::fs::read(p).ok())) {
             tls_config = tls_config.client_ca_root(Certificate::from_pem(&ca));
         }

--- a/crates/hyprstream-rpc-derive/src/codegen/client.rs
+++ b/crates/hyprstream-rpc-derive/src/codegen/client.rs
@@ -173,16 +173,13 @@ fn generate_trait_method(
             vec![quote! { value: #ty }]
         }
         struct_name => {
-            if let Some(s) = resolved.find_struct(struct_name) {
-                let nuf: Vec<_> = s.non_union_fields().collect();
-                if nuf.is_empty() || (nuf.len() == 1 && nuf[0].type_name == "Void") {
-                    Vec::new()
-                } else {
-                    let data_name = format_ident!("{}", struct_name);
-                    vec![quote! { request: &#data_name }]
-                }
+            let s = resolved.find_struct(struct_name)?;
+            let nuf: Vec<_> = s.non_union_fields().collect();
+            if nuf.is_empty() || (nuf.len() == 1 && nuf[0].type_name == "Void") {
+                Vec::new()
             } else {
-                return None;
+                let data_name = format_ident!("{}", struct_name);
+                vec![quote! { request: &#data_name }]
             }
         }
     };
@@ -231,15 +228,12 @@ fn determine_return_type(
             quote! { Vec<#data_name> }
         }
         CapnpType::Struct(ref name) => {
-            if let Some(s) = resolved.find_struct(name) {
-                if let Some(ref dt) = s.domain_type {
-                    resolve_domain_type(dt, types_crate)
-                } else {
-                    let data_name = format_ident!("{}", name);
-                    quote! { #data_name }
-                }
+            let s = resolved.find_struct(name)?;
+            if let Some(ref dt) = s.domain_type {
+                resolve_domain_type(dt, types_crate)
             } else {
-                return None;
+                let data_name = format_ident!("{}", name);
+                quote! { #data_name }
             }
         }
         _ => return None,
@@ -421,16 +415,13 @@ fn generate_trait_method_impl(
             (vec![quote! { value: #ty }], vec![quote! { value }])
         }
         struct_name => {
-            if let Some(s) = resolved.find_struct(struct_name) {
-                let nuf: Vec<_> = s.non_union_fields().collect();
-                if nuf.is_empty() || (nuf.len() == 1 && nuf[0].type_name == "Void") {
-                    (Vec::new(), Vec::new())
-                } else {
-                    let data_name = format_ident!("{}", struct_name);
-                    (vec![quote! { request: &#data_name }], vec![quote! { request }])
-                }
+            let s = resolved.find_struct(struct_name)?;
+            let nuf: Vec<_> = s.non_union_fields().collect();
+            if nuf.is_empty() || (nuf.len() == 1 && nuf[0].type_name == "Void") {
+                (Vec::new(), Vec::new())
             } else {
-                return None;
+                let data_name = format_ident!("{}", struct_name);
+                (vec![quote! { request: &#data_name }], vec![quote! { request }])
             }
         }
     };

--- a/crates/hyprstream-service/src/service/spawner/service.rs
+++ b/crates/hyprstream-service/src/service/spawner/service.rs
@@ -526,7 +526,7 @@ impl ServiceSpawner {
 
         // Spawn thread
         let thread_handle = thread::Builder::new()
-            .name(format!("{}-service", &name))
+            .name(format!("{}-service", name))
             .spawn(move || {
                 // Run the service - it will signal ready after socket binds
                 if let Err(e) = Box::new(service).run(shutdown_clone, Some(ready_tx)) {
@@ -841,7 +841,7 @@ impl ServiceManager for InprocManager {
         let name_clone = name.clone(); // Clone for closure use
 
         let thread_handle = thread::Builder::new()
-            .name(format!("{}-service", &name))
+            .name(format!("{}-service", name))
             .spawn(move || {
                 if let Err(e) = service.run(shutdown_clone, Some(ready_tx)) {
                     tracing::error!("Service {} failed: {}", name_clone, e);

--- a/crates/hyprstream/src/cli/git_handlers.rs
+++ b/crates/hyprstream/src/cli/git_handlers.rs
@@ -1038,7 +1038,7 @@ pub async fn handle_info(
 
     // Size calculation - derive bare repo path locally from models_dir
     let bare_repo_path = storage_paths.models_dir().ok()
-        .map(|d| d.join(&model_ref.model).join(format!("{}.git", &model_ref.model)));
+        .map(|d| d.join(&model_ref.model).join(format!("{}.git", model_ref.model)));
 
     if let Some(ref bare_repo_path) = bare_repo_path {
         if bare_repo_path.exists() {

--- a/crates/hyprstream/src/runtime/architectures/qwen3_5.rs
+++ b/crates/hyprstream/src/runtime/architectures/qwen3_5.rs
@@ -2855,7 +2855,7 @@ mod pipeline_tests {
 
         // Build the model in BF16 (cast tiny_weights to bf16 first).
         let mut w = tiny_weights();
-        for (_k, t) in w.iter_mut() {
+        for t in w.values_mut() {
             *t = t.to_kind(dtype);
         }
         let model = Qwen3_5Model::from_weights(

--- a/crates/hyprstream/tests/e2e_inference.rs
+++ b/crates/hyprstream/tests/e2e_inference.rs
@@ -781,7 +781,7 @@ async fn e6_gpu_load_and_stream_tokens() {
 
     eprintln!(
         "[e2e_inference] produced {chunks} chunks, {} tokens, {:.1} tok/s: {:?}",
-        stats.tokens_generated, stats.tokens_per_second, &full
+        stats.tokens_generated, stats.tokens_per_second, full
     );
 
     // The load-bearing assertions: generation actually produced tokens over the
@@ -789,7 +789,7 @@ async fn e6_gpu_load_and_stream_tokens() {
     assert!(
         chunks > 0,
         "stream must deliver >0 text chunks (got 0; full={:?})",
-        &full
+        full
     );
     assert!(
         stats.tokens_generated > 0,
@@ -799,7 +799,7 @@ async fn e6_gpu_load_and_stream_tokens() {
     assert!(
         !full.trim().is_empty(),
         "streamed text must be non-empty (got {:?})",
-        &full
+        full
     );
 
     // A gentle sanity check on content: greedy continuation of
@@ -811,7 +811,7 @@ async fn e6_gpu_load_and_stream_tokens() {
     assert!(
         lower.contains("paris"),
         "greedy continuation should mention Paris; got {:?}",
-        &full
+        full
     );
 
     // Clean shutdown so the GPU memory is released before the next test.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,9 @@
+# Pin the toolchain so CI and local development lint/build against the same
+# compiler. Previously CI used dtolnay/rust-toolchain@stable (floating to the
+# latest stable at run time) while developers ran an older pinned stable, so a
+# newer stable's tightened clippy lints failed CI on code that passed locally
+# — a non-deterministic, cache-dependent merge blocker. Bump this deliberately
+# (and fix any new lints in the same PR) rather than letting it float.
+[toolchain]
+channel = "1.96.0"
+components = ["clippy", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,5 +5,5 @@
 # — a non-deterministic, cache-dependent merge blocker. Bump this deliberately
 # (and fix any new lints in the same PR) rather than letting it float.
 [toolchain]
-channel = "1.96.0"
+channel = "1.97.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Follow-up to #955 (the toolchain pin). Advances the pin to the current stable **1.97.0**.

Stacks on #955 — the substantive work (the 1.97 clippy-lint fixes + the `ethnum 1.5.2→1.5.3` compile fix that 1.97 requires) already lives there and is verified clean under both 1.96.0 and 1.97.0. This PR is just the version flip:
- `rust-toolchain.toml`: `channel = "1.97.0"`
- `rust.yml`: both jobs `@1.97.0`

Merge after #955. Verified locally: `cargo +1.97.0 clippy --workspace --all-targets --features download-libtorch -- -D warnings` → exit 0.

### 1.97 changes that landed on #955 (context)
- clippy: `question_mark` ×3 (rpc-derive codegen), `useless_borrows_in_formatting`, `manual_filter`, `for_kv_map` — all mechanical/behavior-preserving.
- **`ethnum 1.5.2` fails to compile under 1.97** (E0512: 1.97 made `TryFromIntError` non-ZST) — lockfile bump to 1.5.3 (upstream compat fix; reachable only via polars→hyprstream-metrics).