### PR TITLE
feat(pds) #924: ai.hyprstream.ledger.* lexicons + holder-controlled write path

### DIFF
--- a/crates/hyprstream-pds/src/ledger/allocation.rs
+++ b/crates/hyprstream-pds/src/ledger/allocation.rs
@@ -1,0 +1,404 @@
+//! `ai.hyprstream.ledger.allocation` — an issuer-signed grant record (the held
+//! entitlement / inventory line).
+//!
+//! ```json
+//! {
+//!   "lexicon": 1,
+//!   "id": "ai.hyprstream.ledger.allocation",
+//!   "defs": { "main": { "type": "record", "key": "tid", "record": {
+//!     "type": "object",
+//!     "required": ["grant", "unit", "amount", "epoch", "issuer", "holder", "class"],
+//!     "properties": {
+//!       "grant":  { "type": "string", "format": "cid" },
+//!       "unit":   { "type": "object",
+//!                   "required": ["code", "issuer"], "properties": {
+//!                     "code":   { "type": "string" },
+//!                     "issuer": { "type": "string", "format": "did" } } },
+//!       "amount": { "type": "integer", "minimum": 0 },
+//!       "epoch":  { "type": "integer", "minimum": 0 },
+//!       "issuer": { "type": "string", "format": "did" },
+//!       "holder": { "type": "string" },
+//!       "class":  { "type": "string", "enum": ["prepaid", "underwritten"] }
+//!     }
+//! }}}
+//! ```
+//!
+//! - `grant` — the CID of the UCAN grant this allocation realizes (`format: "cid"`
+//!   string; the UCAN lives outside this repo's MST).
+//! - `unit` — the credit unit, which **names its issuer** ([`Unit`]): credits are
+//!   issuer *liabilities* (D8-1), never bearer tokens. There is no bare unit.
+//! - `amount` — the granted amount, in the unit's smallest quantum (`u64`).
+//! - `epoch` — the issuance epoch (`u64`).
+//! - `issuer` — the issuing DID. Must equal `unit.issuer` (an allocation is only
+//!   ever the unit-issuer's own liability).
+//! - `holder` — the subject: a pseudonymous `did:key`/`did:at9p` **or** a pairwise
+//!   per-cell identifier (#928 rule 3). Never forced to a root/`did:web` identity.
+//! - `class` — the grant [`GrantClass`]: `prepaid` (bearer-like, lease-mode-only,
+//!   issuable to a bare `did:key`, needs no identity) vs `underwritten`
+//!   (issuer-relationship, the only detect-mode-eligible class). The class↔mode
+//!   coupling is a protocol rule (#928 rule 4).
+
+use anyhow::{bail, Result};
+
+use super::{
+    map_get_str, map_get_uint, reject_unknown_fields, validate_cid_string, validate_did,
+    validate_subject_id,
+};
+use crate::cid::Cid;
+use crate::dag_cbor::DagCbor;
+
+/// The NSID of this record type.
+pub const COLLECTION_NSID: &str = "ai.hyprstream.ledger.allocation";
+
+/// A credit unit that **names its issuer**.
+///
+/// The issuer is baked into the unit itself, so a credit is inseparable from the
+/// party liable for it (D8-1). `code` is the issuer-scoped unit label (e.g.
+/// `"compute-second"`, `"usd-cents"`) — it is only meaningful relative to
+/// `issuer`, never a global bearer denomination.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Unit {
+    /// Issuer-scoped unit label. Non-empty.
+    pub code: String,
+    /// The DID liable for credits denominated in this unit. `format: "did"`.
+    pub issuer: String,
+}
+
+/// The grant class — couples anonymity to spend mode (#928 rule 4).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GrantClass {
+    /// Bearer-like: paid up front, so the issuer bears no credit risk and needs
+    /// no recourse relationship — issuable to a bare `did:key` with no identity.
+    /// **Restricted to lease/prevention mode**: overspend is made impossible, not
+    /// detected after the fact.
+    Prepaid,
+    /// Postpaid: the issuer has a real bilateral relationship (employment,
+    /// contract, billing) and recovers from cheaters itself. The only
+    /// **detect-mode-eligible** class. The issuer's knowledge of its holder is a
+    /// bilateral relationship, never protocol data.
+    Underwritten,
+}
+
+impl GrantClass {
+    /// The lexicon string form.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            GrantClass::Prepaid => "prepaid",
+            GrantClass::Underwritten => "underwritten",
+        }
+    }
+
+    /// Parse the lexicon string form.
+    pub fn parse(s: &str) -> Result<Self> {
+        match s {
+            "prepaid" => Ok(GrantClass::Prepaid),
+            "underwritten" => Ok(GrantClass::Underwritten),
+            other => bail!("{COLLECTION_NSID}: unknown grant class {other:?}"),
+        }
+    }
+
+    /// Whether this class may be spent in **detect mode**.
+    ///
+    /// Detect mode observes overspend after it happens and relies on *recourse*
+    /// to recover — which requires a relationship with the holder. A prepaid
+    /// bearer grant has no such relationship, so detect mode on it is worthless
+    /// (detection without recourse) *and* impossible to act on (recourse without
+    /// identity). The coupling is therefore a protocol rule, not a policy knob:
+    /// only [`GrantClass::Underwritten`] is detect-mode-eligible.
+    pub fn detect_mode_eligible(self) -> bool {
+        matches!(self, GrantClass::Underwritten)
+    }
+}
+
+/// An `ai.hyprstream.ledger.allocation` record.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AllocationRecord {
+    /// CID of the UCAN grant this allocation realizes. `format: "cid"`.
+    pub grant: String,
+    /// The credit unit (names its issuer).
+    pub unit: Unit,
+    /// Granted amount, in the unit's smallest quantum.
+    pub amount: u64,
+    /// Issuance epoch.
+    pub epoch: u64,
+    /// Issuing DID. Must equal `unit.issuer`. `format: "did"`.
+    pub issuer: String,
+    /// Subject: a pseudonymous DID or a pairwise per-cell identifier.
+    pub holder: String,
+    /// The grant class.
+    pub class: GrantClass,
+}
+
+impl AllocationRecord {
+    /// Validate and construct a record.
+    pub fn new(
+        grant: impl Into<String>,
+        unit: Unit,
+        amount: u64,
+        epoch: u64,
+        issuer: impl Into<String>,
+        holder: impl Into<String>,
+        class: GrantClass,
+    ) -> Result<Self> {
+        let grant = grant.into();
+        let issuer = issuer.into();
+        let holder = holder.into();
+        validate_cid_string(&grant, "grant")?;
+        validate_did(&issuer)?;
+        validate_did(&unit.issuer)?;
+        if unit.code.is_empty() {
+            bail!("{COLLECTION_NSID}: unit.code must not be empty");
+        }
+        // D8-1: a credit is the *unit-issuer's* liability, so an allocation can
+        // only be issued by that same issuer. This binds the record to its
+        // liability holder structurally rather than by convention.
+        if issuer != unit.issuer {
+            bail!(
+                "{COLLECTION_NSID}: issuer {issuer:?} must equal unit.issuer {:?} \
+                 (credits are the unit-issuer's liability, D8-1)",
+                unit.issuer
+            );
+        }
+        validate_subject_id(&holder, "holder")?;
+        Ok(AllocationRecord {
+            grant,
+            unit,
+            amount,
+            epoch,
+            issuer,
+            holder,
+            class,
+        })
+    }
+
+    /// Encode to canonical DAG-CBOR bytes (deterministic).
+    pub fn to_dag_cbor(&self) -> Vec<u8> {
+        self.to_value().encode()
+    }
+
+    /// The CID of this record (CIDv1 dag-cbor over its canonical bytes).
+    pub fn cid(&self) -> Cid {
+        Cid::from_dag_cbor(&self.to_dag_cbor())
+    }
+
+    /// Build the typed [`DagCbor`] value form.
+    pub fn to_value(&self) -> DagCbor {
+        let unit = DagCbor::str_map([
+            ("code", DagCbor::Text(self.unit.code.clone())),
+            ("issuer", DagCbor::Text(self.unit.issuer.clone())),
+        ]);
+        DagCbor::str_map([
+            ("grant", DagCbor::Text(self.grant.clone())),
+            ("unit", unit),
+            ("amount", DagCbor::Unsigned(self.amount)),
+            ("epoch", DagCbor::Unsigned(self.epoch)),
+            ("issuer", DagCbor::Text(self.issuer.clone())),
+            ("holder", DagCbor::Text(self.holder.clone())),
+            ("class", DagCbor::Text(self.class.as_str().to_owned())),
+        ])
+    }
+
+    /// Decode canonical DAG-CBOR bytes into a record, validating all fields.
+    pub fn from_dag_cbor(bytes: &[u8]) -> Result<Self> {
+        let value = DagCbor::decode(bytes)?;
+        Self::from_value(&value)
+    }
+
+    pub fn from_value(value: &DagCbor) -> Result<Self> {
+        reject_unknown_fields(
+            value,
+            &["grant", "unit", "amount", "epoch", "issuer", "holder", "class"],
+            COLLECTION_NSID,
+        )?;
+        let grant = map_get_str(value, "grant", COLLECTION_NSID)?.to_owned();
+        let unit = parse_unit(
+            value
+                .get("unit")
+                .ok_or_else(|| anyhow::anyhow!("{COLLECTION_NSID}: missing required field \"unit\""))?,
+        )?;
+        let amount = map_get_uint(value, "amount", COLLECTION_NSID)?;
+        let epoch = map_get_uint(value, "epoch", COLLECTION_NSID)?;
+        let issuer = map_get_str(value, "issuer", COLLECTION_NSID)?.to_owned();
+        let holder = map_get_str(value, "holder", COLLECTION_NSID)?.to_owned();
+        let class = GrantClass::parse(map_get_str(value, "class", COLLECTION_NSID)?)?;
+        Self::new(grant, unit, amount, epoch, issuer, holder, class)
+    }
+}
+
+fn parse_unit(value: &DagCbor) -> Result<Unit> {
+    reject_unknown_fields(value, &["code", "issuer"], COLLECTION_NSID)?;
+    let code = map_get_str(value, "code", COLLECTION_NSID)?.to_owned();
+    let issuer = map_get_str(value, "issuer", COLLECTION_NSID)?.to_owned();
+    Ok(Unit { code, issuer })
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::panic
+    )]
+    use super::*;
+
+    const ISSUER: &str = "did:web:issuer.example.com";
+
+    fn unit() -> Unit {
+        Unit {
+            code: "compute-second".into(),
+            issuer: ISSUER.into(),
+        }
+    }
+
+    fn sample() -> AllocationRecord {
+        AllocationRecord::new(
+            "bafyreiexamplegrantcid1234567890abcdef",
+            unit(),
+            1_000,
+            7,
+            ISSUER,
+            "did:key:zHolderSubject",
+            GrantClass::Underwritten,
+        )
+        .expect("valid sample")
+    }
+
+    #[test]
+    fn record_round_trip_same_cid() {
+        let r = sample();
+        let bytes = r.to_dag_cbor();
+        let back = AllocationRecord::from_dag_cbor(&bytes).expect("round-trip");
+        assert_eq!(r, back);
+        assert_eq!(r.cid(), back.cid());
+        // Canonical: reserialize(decode(bytes)) == bytes.
+        assert_eq!(back.to_dag_cbor(), bytes);
+    }
+
+    #[test]
+    fn record_fields_canonical_order() {
+        let r = sample();
+        let v = DagCbor::decode(&r.to_dag_cbor()).expect("decode");
+        let map = v.as_map().expect("map");
+        let keys: Vec<&str> = map.iter().map(|(k, _)| k.as_str().expect("str")).collect();
+        // pure lexicographic byte order.
+        assert_eq!(
+            keys,
+            vec!["amount", "class", "epoch", "grant", "holder", "issuer", "unit"]
+        );
+    }
+
+    #[test]
+    fn no_legal_identity_field_is_representable() {
+        // A record carrying a legal-identity-looking field must not decode: the
+        // schema has no such field, and unknown fields are rejected (#928 rule 1).
+        let mut v = sample().to_value();
+        if let DagCbor::Map(ref mut pairs) = v {
+            pairs.push((DagCbor::Text("legalName".into()), DagCbor::Text("Jane Doe".into())));
+            pairs.sort_by(|a, b| a.0.as_str().unwrap_or("").cmp(b.0.as_str().unwrap_or("")));
+        }
+        let err = AllocationRecord::from_value(&v).expect_err("legal-identity field must be rejected");
+        assert!(err.to_string().contains("unknown field"), "unexpected: {err:#}");
+    }
+
+    #[test]
+    fn pairwise_holder_accepted() {
+        // A pairwise per-cell identifier (not a DID) is a valid holder (#928 rule 3).
+        let r = AllocationRecord::new(
+            "bafyreiexamplegrantcid1234567890abcdef",
+            unit(),
+            5,
+            1,
+            ISSUER,
+            "pairwise:cell42:8f3ad9c0e1",
+            GrantClass::Prepaid,
+        )
+        .expect("pairwise holder must be accepted");
+        assert_eq!(
+            AllocationRecord::from_dag_cbor(&r.to_dag_cbor()).expect("round-trip"),
+            r
+        );
+    }
+
+    #[test]
+    fn prepaid_issuable_to_bare_did_key() {
+        // Prepaid (bearer-like) is issuable to a bare did:key with no identity.
+        AllocationRecord::new(
+            "bafyreiexamplegrantcid1234567890abcdef",
+            unit(),
+            5,
+            1,
+            ISSUER,
+            "did:key:zBareKeyNoIdentity",
+            GrantClass::Prepaid,
+        )
+        .expect("prepaid to bare did:key must be accepted");
+    }
+
+    #[test]
+    fn class_mode_coupling() {
+        // Only underwritten is detect-mode eligible (#928 rule 4).
+        assert!(!GrantClass::Prepaid.detect_mode_eligible());
+        assert!(GrantClass::Underwritten.detect_mode_eligible());
+    }
+
+    #[test]
+    fn unit_names_its_issuer_and_binds_liability() {
+        // The unit carries its issuer, and the top-level issuer must match it
+        // (D8-1: a credit is the unit-issuer's liability).
+        let mismatched = AllocationRecord::new(
+            "bafyreiexamplegrantcid1234567890abcdef",
+            unit(),
+            5,
+            1,
+            "did:web:other.example.com",
+            "did:key:zHolder",
+            GrantClass::Underwritten,
+        );
+        assert!(mismatched.is_err(), "issuer != unit.issuer must be rejected");
+    }
+
+    #[test]
+    fn record_validates_formats() {
+        // Bad grant cid.
+        assert!(AllocationRecord::new("x", unit(), 1, 1, ISSUER, "did:key:z", GrantClass::Prepaid).is_err());
+        // Bad issuer did.
+        assert!(AllocationRecord::new(
+            "bafyreiexamplegrantcid1234567890abcdef",
+            unit(),
+            1,
+            1,
+            "not-a-did",
+            "did:key:z",
+            GrantClass::Prepaid
+        )
+        .is_err());
+        // Empty holder.
+        assert!(AllocationRecord::new(
+            "bafyreiexamplegrantcid1234567890abcdef",
+            unit(),
+            1,
+            1,
+            ISSUER,
+            "",
+            GrantClass::Prepaid
+        )
+        .is_err());
+        // Unknown class string on decode.
+        let mut v = sample().to_value();
+        if let DagCbor::Map(ref mut pairs) = v {
+            for (k, val) in pairs.iter_mut() {
+                if k.as_str().ok() == Some("class") {
+                    *val = DagCbor::Text("overdraft".into());
+                }
+            }
+        }
+        assert!(AllocationRecord::from_value(&v).is_err());
+    }
+
+    #[test]
+    fn grant_and_cids_are_strings_not_links() {
+        let v = sample().to_value();
+        assert!(matches!(v.get("grant"), Some(DagCbor::Text(_))));
+    }
+}

--- a/crates/hyprstream-pds/src/ledger/checkpoint.rs
+++ b/crates/hyprstream-pds/src/ledger/checkpoint.rs
@@ -1,0 +1,270 @@
+//! `ai.hyprstream.ledger.checkpoint` — a signed ledger head (the anchorable
+//! object).
+//!
+//! ```json
+//! {
+//!   "lexicon": 1,
+//!   "id": "ai.hyprstream.ledger.checkpoint",
+//!   "defs": { "main": { "type": "record", "key": "tid", "record": {
+//!     "type": "object",
+//!     "required": ["seq", "headHash", "stateRoots"],
+//!     "properties": {
+//!       "seq":        { "type": "integer", "minimum": 0 },
+//!       "headHash":   { "type": "string", "format": "cid" },
+//!       "stateRoots": { "type": "array", "items": { "type": "object",
+//!                         "required": ["name", "root"], "properties": {
+//!                           "name": { "type": "string" },
+//!                           "root": { "type": "string", "format": "cid" } } } },
+//!       "anchor":     { "type": "string" }
+//!     }
+//! }}}
+//! ```
+//!
+//! A checkpoint commits the ledger's head at a point in time. It is the object an
+//! external timestamp/anchor (e.g. OpenTimestamps) attests to — so it **carries a
+//! reference to** the anchor, it never *embeds* the anchor proof:
+//!
+//! - `seq` — the monotonically-advancing checkpoint sequence number (`u64`).
+//! - `headHash` — the CID of the ledger head this checkpoint commits (`format:
+//!   "cid"` string).
+//! - `stateRoots` — the named state-tree roots at this head ([`StateRoot`]): each
+//!   a `{name, root-cid}` pair (e.g. `{"accounts", <cid>}`, `{"receipts", <cid>}`).
+//! - `anchor` — *optional* reference to the external anchor for this checkpoint
+//!   (an opaque locator: an OTS receipt id, a txid, a CID …). Omitted until the
+//!   checkpoint is anchored; the anchor proof itself lives outside this record.
+//!   Per #928 rule 8, anchors carry digests only and are submitted on a fixed
+//!   cadence — this record holds only the reference, never activity-correlated
+//!   payload.
+
+use anyhow::{bail, Result};
+
+use super::{
+    map_get_opt_str, map_get_str, map_get_uint, reject_unknown_fields, validate_cid_string,
+    validate_token,
+};
+use crate::cid::Cid;
+use crate::dag_cbor::DagCbor;
+
+/// The NSID of this record type.
+pub const COLLECTION_NSID: &str = "ai.hyprstream.ledger.checkpoint";
+
+/// A named state-tree root at the checkpoint's head.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StateRoot {
+    /// The root's name (e.g. `"accounts"`, `"receipts"`). Non-empty.
+    pub name: String,
+    /// The root CID. `format: "cid"`.
+    pub root: String,
+}
+
+/// An `ai.hyprstream.ledger.checkpoint` record.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CheckpointRecord {
+    /// Monotonic checkpoint sequence number.
+    pub seq: u64,
+    /// CID of the ledger head this checkpoint commits. `format: "cid"`.
+    pub head_hash: String,
+    /// Named state-tree roots at this head.
+    pub state_roots: Vec<StateRoot>,
+    /// Optional reference to the external anchor (never the proof itself).
+    pub anchor: Option<String>,
+}
+
+impl CheckpointRecord {
+    /// Validate and construct a record.
+    pub fn new(
+        seq: u64,
+        head_hash: impl Into<String>,
+        state_roots: Vec<StateRoot>,
+        anchor: Option<String>,
+    ) -> Result<Self> {
+        let head_hash = head_hash.into();
+        validate_cid_string(&head_hash, "headHash")?;
+        for sr in &state_roots {
+            if sr.name.is_empty() {
+                bail!("{COLLECTION_NSID}: stateRoots[].name must not be empty");
+            }
+            validate_cid_string(&sr.root, "stateRoots[].root")?;
+        }
+        if let Some(a) = &anchor {
+            validate_token(a, "anchor")?;
+        }
+        Ok(CheckpointRecord {
+            seq,
+            head_hash,
+            state_roots,
+            anchor,
+        })
+    }
+
+    /// Encode to canonical DAG-CBOR bytes (deterministic).
+    pub fn to_dag_cbor(&self) -> Vec<u8> {
+        self.to_value().encode()
+    }
+
+    /// The CID of this record (CIDv1 dag-cbor over its canonical bytes).
+    pub fn cid(&self) -> Cid {
+        Cid::from_dag_cbor(&self.to_dag_cbor())
+    }
+
+    /// Build the typed [`DagCbor`] value form. The optional `anchor` field is
+    /// omitted from the map when absent.
+    pub fn to_value(&self) -> DagCbor {
+        let state_roots = DagCbor::list(self.state_roots.iter().map(|sr| {
+            DagCbor::str_map([
+                ("name", DagCbor::Text(sr.name.clone())),
+                ("root", DagCbor::Text(sr.root.clone())),
+            ])
+        }));
+        let mut pairs: Vec<(&str, DagCbor)> = vec![
+            ("seq", DagCbor::Unsigned(self.seq)),
+            ("headHash", DagCbor::Text(self.head_hash.clone())),
+            ("stateRoots", state_roots),
+        ];
+        if let Some(anchor) = &self.anchor {
+            pairs.push(("anchor", DagCbor::Text(anchor.clone())));
+        }
+        DagCbor::str_map(pairs)
+    }
+
+    /// Decode canonical DAG-CBOR bytes into a record, validating all fields.
+    pub fn from_dag_cbor(bytes: &[u8]) -> Result<Self> {
+        let value = DagCbor::decode(bytes)?;
+        Self::from_value(&value)
+    }
+
+    pub fn from_value(value: &DagCbor) -> Result<Self> {
+        reject_unknown_fields(
+            value,
+            &["seq", "headHash", "stateRoots", "anchor"],
+            COLLECTION_NSID,
+        )?;
+        let seq = map_get_uint(value, "seq", COLLECTION_NSID)?;
+        let head_hash = map_get_str(value, "headHash", COLLECTION_NSID)?.to_owned();
+        let state_roots = value
+            .get("stateRoots")
+            .ok_or_else(|| anyhow::anyhow!("{COLLECTION_NSID}: missing required field \"stateRoots\""))?
+            .as_list()?
+            .iter()
+            .map(parse_state_root)
+            .collect::<Result<Vec<_>>>()?;
+        let anchor = map_get_opt_str(value, "anchor")?.map(str::to_owned);
+        Self::new(seq, head_hash, state_roots, anchor)
+    }
+}
+
+fn parse_state_root(value: &DagCbor) -> Result<StateRoot> {
+    reject_unknown_fields(value, &["name", "root"], COLLECTION_NSID)?;
+    let name = map_get_str(value, "name", COLLECTION_NSID)?.to_owned();
+    let root = map_get_str(value, "root", COLLECTION_NSID)?.to_owned();
+    Ok(StateRoot { name, root })
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::panic
+    )]
+    use super::*;
+
+    fn roots() -> Vec<StateRoot> {
+        vec![
+            StateRoot {
+                name: "accounts".into(),
+                root: "bafyreiaccountsroot1234567890abcdef".into(),
+            },
+            StateRoot {
+                name: "receipts".into(),
+                root: "bafyreireceiptsroot1234567890abcdef".into(),
+            },
+        ]
+    }
+
+    fn sample() -> CheckpointRecord {
+        CheckpointRecord::new(
+            42,
+            "bafyreiledgerhead1234567890abcdefghij",
+            roots(),
+            Some("ots:abcdef0123456789".into()),
+        )
+        .expect("valid sample")
+    }
+
+    #[test]
+    fn record_round_trip_same_cid() {
+        let r = sample();
+        let bytes = r.to_dag_cbor();
+        let back = CheckpointRecord::from_dag_cbor(&bytes).expect("round-trip");
+        assert_eq!(r, back);
+        assert_eq!(r.cid(), back.cid());
+        assert_eq!(back.to_dag_cbor(), bytes);
+    }
+
+    #[test]
+    fn record_fields_canonical_order() {
+        let r = sample();
+        let v = DagCbor::decode(&r.to_dag_cbor()).expect("decode");
+        let map = v.as_map().expect("map");
+        let keys: Vec<&str> = map.iter().map(|(k, _)| k.as_str().expect("str")).collect();
+        assert_eq!(keys, vec!["anchor", "headHash", "seq", "stateRoots"]);
+    }
+
+    #[test]
+    fn optional_anchor_omitted_when_absent() {
+        let mut r = sample();
+        r.anchor = None;
+        let v = r.to_value();
+        assert!(v.get("anchor").is_none(), "absent anchor must be omitted");
+        let back = CheckpointRecord::from_dag_cbor(&r.to_dag_cbor()).expect("round-trip");
+        assert_eq!(r, back);
+    }
+
+    #[test]
+    fn no_legal_identity_field_is_representable() {
+        let mut v = sample().to_value();
+        if let DagCbor::Map(ref mut pairs) = v {
+            pairs.push((DagCbor::Text("operatorName".into()), DagCbor::Text("Acme LLC".into())));
+            pairs.sort_by(|a, b| a.0.as_str().unwrap_or("").cmp(b.0.as_str().unwrap_or("")));
+        }
+        assert!(CheckpointRecord::from_value(&v).is_err());
+    }
+
+    #[test]
+    fn record_validates_formats() {
+        // Bad head hash cid.
+        assert!(CheckpointRecord::new(1, "x", roots(), None).is_err());
+        // Bad state-root cid.
+        assert!(CheckpointRecord::new(
+            1,
+            "bafyreiledgerhead1234567890abcdefghij",
+            vec![StateRoot {
+                name: "accounts".into(),
+                root: "bad".into()
+            }],
+            None
+        )
+        .is_err());
+        // Empty state-root name.
+        assert!(CheckpointRecord::new(
+            1,
+            "bafyreiledgerhead1234567890abcdefghij",
+            vec![StateRoot {
+                name: "".into(),
+                root: "bafyreiaccountsroot1234567890abcdef".into()
+            }],
+            None
+        )
+        .is_err());
+        // Empty anchor when present.
+        assert!(CheckpointRecord::new(
+            1,
+            "bafyreiledgerhead1234567890abcdefghij",
+            roots(),
+            Some("".into())
+        )
+        .is_err());
+    }
+}

--- a/crates/hyprstream-pds/src/ledger/mod.rs
+++ b/crates/hyprstream-pds/src/ledger/mod.rs
@@ -1,0 +1,174 @@
+//! `ai.hyprstream.ledger.*` — the cellular-ledger inventory lexicons (#924).
+//!
+//! Three DAG-CBOR record types form the **holder-controlled inventory**: the
+//! signed entitlements, usage receipts, and ledger heads that live in a holder's
+//! own atproto repo (its signed PDS commit is the only signature these records
+//! need — see [`crate::commit`]).
+//!
+//! - [`allocation::AllocationRecord`] (`ai.hyprstream.ledger.allocation`) — an
+//!   issuer-signed grant: the held entitlement. References the UCAN grant CID,
+//!   carries the issuer-named [`allocation::Unit`], amount, epoch, issuer DID,
+//!   holder (subject), and the grant [`allocation::GrantClass`].
+//! - [`receipt::ReceiptRecord`] (`ai.hyprstream.ledger.receipt`) — a dual-signed
+//!   usage record binding **both** principals (spender + host, the #681
+//!   two-principal vocabulary), the referenced allocation CID, the transfer id,
+//!   and the quantum spent.
+//! - [`checkpoint::CheckpointRecord`] (`ai.hyprstream.ledger.checkpoint`) — a
+//!   signed ledger head (seq, head hash, state roots) that **references** — never
+//!   embeds — an external anchor.
+//!
+//! # Pseudonymity constraints (the #928 charter — review-blockers)
+//!
+//! These lexicons are the P0 target of the pseudonymity charter. The rules are
+//! enforced **structurally** — by the shape of the records, not by a runtime
+//! check that could be bypassed:
+//!
+//! 1. **No legal-identity field, anywhere.** Every record has a frozen field set
+//!    and decoding rejects unknown fields, so a `legalName`/`kyc`/… field is not
+//!    representable: it fails to decode. Audit binds pseudonyms only.
+//! 2. **Pairwise per-cell subject identifiers.** The `holder`/`spender`/`host`
+//!    fields are validated by [`validate_subject_id`], which accepts a `did:key`
+//!    / `did:at9p` *or* an opaque pairwise identifier — it never *requires* a
+//!    DID, let alone a `did:web`. A cell-scoped pairwise ID drops straight in.
+//! 3. **The unit names its issuer.** [`allocation::Unit`] bakes the issuer DID
+//!    into the unit itself — there is no bare unit string. Credits are issuer
+//!    *liabilities* (D8-1), never bearer tokens; [`allocation::AllocationRecord`]
+//!    additionally requires the top-level `issuer` to equal `unit.issuer`.
+//! 4. **Grant class couples anonymity to spend mode.**
+//!    [`allocation::GrantClass::Prepaid`] is bearer-like, issuable to a bare
+//!    `did:key`, and lease-mode-only; [`allocation::GrantClass::Underwritten`]
+//!    is the only detect-mode-eligible class (see
+//!    [`allocation::GrantClass::detect_mode_eligible`]).
+//!
+//! # Encoding
+//!
+//! Like the other hyprstream lexicons, every record is **DAG-CBOR** with
+//! canonical (pure-lexicographic) map-key order applied by the encoder, so
+//! callers construct fields in any order. Each record has a frozen field set:
+//! decoding rejects unknown fields. Optional fields are *omitted* from the
+//! encoded map when absent (never encoded as `null`). CID references are carried
+//! as `format: "cid"` **strings** (not DAG-CBOR links): the referenced blocks
+//! (UCAN grants, allocations, external ledger state) live outside this repo's
+//! MST, so a tag-42 link would be a false claim of local containment — the same
+//! reasoning [`crate::record::ModelRecord::current_oid`] documents.
+
+use anyhow::{bail, ensure, Result};
+
+use crate::dag_cbor::DagCbor;
+
+pub mod allocation;
+pub mod checkpoint;
+pub mod receipt;
+
+pub use allocation::{AllocationRecord, GrantClass, Unit};
+pub use checkpoint::{CheckpointRecord, StateRoot};
+pub use receipt::ReceiptRecord;
+
+// ── shared field accessors ──────────────────────────────────────────────────
+
+/// Read a required string field, attributing errors to `nsid`.
+pub(crate) fn map_get_str<'a>(value: &'a DagCbor, key: &str, nsid: &str) -> Result<&'a str> {
+    value
+        .get(key)
+        .ok_or_else(|| anyhow::anyhow!("{nsid}: missing required field {key:?}"))?
+        .as_str()
+}
+
+/// Read a required unsigned-integer field, attributing errors to `nsid`.
+pub(crate) fn map_get_uint(value: &DagCbor, key: &str, nsid: &str) -> Result<u64> {
+    value
+        .get(key)
+        .ok_or_else(|| anyhow::anyhow!("{nsid}: missing required field {key:?}"))?
+        .as_unsigned()
+}
+
+/// Read an optional string field. Returns `None` when omitted; an error if it is
+/// present but not a text string.
+pub(crate) fn map_get_opt_str<'a>(value: &'a DagCbor, key: &str) -> Result<Option<&'a str>> {
+    match value.get(key) {
+        None => Ok(None),
+        Some(v) => Ok(Some(v.as_str()?)),
+    }
+}
+
+// ── field validators (lexicon formats) ──────────────────────────────────────
+
+/// A DID string — must start with `did:` and carry a non-empty, whitespace-free
+/// `method:identifier`. Both `did:web`, `did:key`, and `did:at9p` are accepted.
+/// Used for fields that name a *real, signing* identity (an issuer), never for a
+/// pseudonymous subject (see [`validate_subject_id`]).
+pub(crate) fn validate_did(s: &str) -> Result<()> {
+    ensure!(s.starts_with("did:"), "did must start with \"did:\": {s:?}");
+    let rest = &s[4..];
+    ensure!(!rest.is_empty(), "did must have a method: {s:?}");
+    ensure!(
+        !rest.chars().any(char::is_whitespace),
+        "did must not contain whitespace: {s:?}"
+    );
+    let mut parts = rest.splitn(2, ':');
+    let method = parts.next().unwrap_or("");
+    let id = parts.next().unwrap_or("");
+    ensure!(
+        !method.is_empty() && !id.is_empty(),
+        "did must be \"did:<method>:<id>\": {s:?}"
+    );
+    Ok(())
+}
+
+/// A **pseudonymous subject identifier** (`holder`/`spender`/`host`).
+///
+/// The #928 charter (rule 3) requires these fields to carry either a
+/// pseudonymous DID (`did:key`/`did:at9p`) *or* an opaque **pairwise per-cell
+/// identifier** — an issuer-linkable, cell-unlinkable string the subject
+/// presents differently to each cell. We therefore accept any non-empty,
+/// whitespace-free token and deliberately **do not** require a DID shape: forcing
+/// a DID here would forbid the pairwise-ID presentation the charter mandates and
+/// would push subjects toward a stable global identity. (A `did:web` — an opt-in
+/// linkage to a domain — is likewise never required for participation.)
+pub(crate) fn validate_subject_id(s: &str, field: &str) -> Result<()> {
+    ensure!(!s.is_empty(), "{field} must not be empty");
+    ensure!(
+        !s.chars().any(char::is_whitespace),
+        "{field} must not contain whitespace: {s:?}"
+    );
+    Ok(())
+}
+
+/// `format: "cid"` — a CIDv1 (`b…`/`z…`) or CIDv0 (`Qm…`) string. Mirrors the
+/// `currentOid` validation in [`crate::record`]: we carry external content
+/// addresses as strings and reject the obviously-bogus forms.
+pub(crate) fn validate_cid_string(s: &str, field: &str) -> Result<()> {
+    ensure!(!s.is_empty(), "{field} cid string must be non-empty");
+    let ok = (s.starts_with('b') && s.len() > 8)
+        || (s.starts_with('z') && s.len() > 8)
+        || (s.starts_with("Qm") && s.len() > 8);
+    ensure!(
+        ok,
+        "{field} must be a CIDv1 (b/z…) or CIDv0 (Qm…) string: {s:?}"
+    );
+    Ok(())
+}
+
+/// A required free-form string that must not be empty or contain whitespace
+/// (`field` names it for the error message). Used for opaque locators (transfer
+/// ids, anchor references) that are neither DIDs nor CIDs.
+pub(crate) fn validate_token(s: &str, field: &str) -> Result<()> {
+    ensure!(!s.is_empty(), "{field} must not be empty");
+    ensure!(
+        !s.chars().any(char::is_whitespace),
+        "{field} must not contain whitespace: {s:?}"
+    );
+    Ok(())
+}
+
+/// Reject any map key not in `allowed`, attributing the error to `nsid`.
+pub(crate) fn reject_unknown_fields(value: &DagCbor, allowed: &[&str], nsid: &str) -> Result<()> {
+    let map = value.as_map()?;
+    for (k, _v) in map {
+        let key = k.as_str()?;
+        if !allowed.contains(&key) {
+            bail!("{nsid}: unknown field {key:?} (frozen lexicon fields: {allowed:?})");
+        }
+    }
+    Ok(())
+}

--- a/crates/hyprstream-pds/src/ledger/receipt.rs
+++ b/crates/hyprstream-pds/src/ledger/receipt.rs
@@ -1,0 +1,216 @@
+//! `ai.hyprstream.ledger.receipt` — a dual-signed usage record.
+//!
+//! ```json
+//! {
+//!   "lexicon": 1,
+//!   "id": "ai.hyprstream.ledger.receipt",
+//!   "defs": { "main": { "type": "record", "key": "tid", "record": {
+//!     "type": "object",
+//!     "required": ["allocation", "spender", "host", "transferId", "quantum"],
+//!     "properties": {
+//!       "allocation": { "type": "string", "format": "cid" },
+//!       "spender":    { "type": "string" },
+//!       "host":       { "type": "string" },
+//!       "transferId": { "type": "string" },
+//!       "quantum":    { "type": "integer", "minimum": 0 }
+//!     }
+//! }}}
+//! ```
+//!
+//! A receipt records one spend against a held [`crate::ledger::AllocationRecord`].
+//! It binds **both** principals — the #681 two-principal vocabulary — so the
+//! record attests who spent and who served:
+//!
+//! - `allocation` — CID of the allocation/grant the spend draws down (`format:
+//!   "cid"` string).
+//! - `spender` — the spending principal. For a **pseudonymous-tier** service this
+//!   is the subject's **pairwise per-cell identifier** (#928 rule 7), never a
+//!   root DID — a cell sees only the identifier the subject presents to it.
+//! - `host` — the serving principal (the second of the two principals; the party
+//!   on whose infrastructure the spend occurred).
+//! - `transferId` — the spend's idempotency key. The write path derives the
+//!   receipt's rkey from it, giving at-least-once (idempotent) receipt delivery:
+//!   re-publishing the same `transferId` advances the same record.
+//! - `quantum` — the amount spent, in the allocation unit's smallest quantum.
+
+use anyhow::Result;
+
+use super::{
+    map_get_str, map_get_uint, reject_unknown_fields, validate_cid_string, validate_subject_id,
+    validate_token,
+};
+use crate::cid::Cid;
+use crate::dag_cbor::DagCbor;
+
+/// The NSID of this record type.
+pub const COLLECTION_NSID: &str = "ai.hyprstream.ledger.receipt";
+
+/// An `ai.hyprstream.ledger.receipt` record.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReceiptRecord {
+    /// CID of the allocation/grant this spend draws down. `format: "cid"`.
+    pub allocation: String,
+    /// Spending principal — a pairwise per-cell id for pseudonymous-tier spends.
+    pub spender: String,
+    /// Serving principal (the second of the two #681 principals).
+    pub host: String,
+    /// Idempotency key; the receipt's rkey is derived from it.
+    pub transfer_id: String,
+    /// Amount spent, in the allocation unit's smallest quantum.
+    pub quantum: u64,
+}
+
+impl ReceiptRecord {
+    /// Validate and construct a record.
+    pub fn new(
+        allocation: impl Into<String>,
+        spender: impl Into<String>,
+        host: impl Into<String>,
+        transfer_id: impl Into<String>,
+        quantum: u64,
+    ) -> Result<Self> {
+        let allocation = allocation.into();
+        let spender = spender.into();
+        let host = host.into();
+        let transfer_id = transfer_id.into();
+        validate_cid_string(&allocation, "allocation")?;
+        validate_subject_id(&spender, "spender")?;
+        validate_subject_id(&host, "host")?;
+        validate_token(&transfer_id, "transferId")?;
+        Ok(ReceiptRecord {
+            allocation,
+            spender,
+            host,
+            transfer_id,
+            quantum,
+        })
+    }
+
+    /// Encode to canonical DAG-CBOR bytes (deterministic).
+    pub fn to_dag_cbor(&self) -> Vec<u8> {
+        self.to_value().encode()
+    }
+
+    /// The CID of this record (CIDv1 dag-cbor over its canonical bytes).
+    pub fn cid(&self) -> Cid {
+        Cid::from_dag_cbor(&self.to_dag_cbor())
+    }
+
+    /// Build the typed [`DagCbor`] value form.
+    pub fn to_value(&self) -> DagCbor {
+        DagCbor::str_map([
+            ("allocation", DagCbor::Text(self.allocation.clone())),
+            ("spender", DagCbor::Text(self.spender.clone())),
+            ("host", DagCbor::Text(self.host.clone())),
+            ("transferId", DagCbor::Text(self.transfer_id.clone())),
+            ("quantum", DagCbor::Unsigned(self.quantum)),
+        ])
+    }
+
+    /// Decode canonical DAG-CBOR bytes into a record, validating all fields.
+    pub fn from_dag_cbor(bytes: &[u8]) -> Result<Self> {
+        let value = DagCbor::decode(bytes)?;
+        Self::from_value(&value)
+    }
+
+    pub fn from_value(value: &DagCbor) -> Result<Self> {
+        reject_unknown_fields(
+            value,
+            &["allocation", "spender", "host", "transferId", "quantum"],
+            COLLECTION_NSID,
+        )?;
+        let allocation = map_get_str(value, "allocation", COLLECTION_NSID)?.to_owned();
+        let spender = map_get_str(value, "spender", COLLECTION_NSID)?.to_owned();
+        let host = map_get_str(value, "host", COLLECTION_NSID)?.to_owned();
+        let transfer_id = map_get_str(value, "transferId", COLLECTION_NSID)?.to_owned();
+        let quantum = map_get_uint(value, "quantum", COLLECTION_NSID)?;
+        Self::new(allocation, spender, host, transfer_id, quantum)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::panic
+    )]
+    use super::*;
+
+    fn sample() -> ReceiptRecord {
+        ReceiptRecord::new(
+            "bafyreiexamplealloccid1234567890abcdef",
+            "pairwise:cell42:8f3ad9c0e1",
+            "did:key:zHostNode",
+            "transfer-01HXYZ",
+            25,
+        )
+        .expect("valid sample")
+    }
+
+    #[test]
+    fn record_round_trip_same_cid() {
+        let r = sample();
+        let bytes = r.to_dag_cbor();
+        let back = ReceiptRecord::from_dag_cbor(&bytes).expect("round-trip");
+        assert_eq!(r, back);
+        assert_eq!(r.cid(), back.cid());
+        assert_eq!(back.to_dag_cbor(), bytes);
+    }
+
+    #[test]
+    fn record_fields_canonical_order() {
+        let r = sample();
+        let v = DagCbor::decode(&r.to_dag_cbor()).expect("decode");
+        let map = v.as_map().expect("map");
+        let keys: Vec<&str> = map.iter().map(|(k, _)| k.as_str().expect("str")).collect();
+        assert_eq!(
+            keys,
+            vec!["allocation", "host", "quantum", "spender", "transferId"]
+        );
+    }
+
+    #[test]
+    fn pairwise_spender_accepted() {
+        // Receipts for pseudonymous-tier services bind the pairwise id, not a
+        // root DID (#928 rule 7). A non-DID pairwise spender must be accepted.
+        let r = sample();
+        assert!(!r.spender.starts_with("did:"));
+        assert_eq!(ReceiptRecord::from_dag_cbor(&r.to_dag_cbor()).expect("round-trip"), r);
+    }
+
+    #[test]
+    fn no_legal_identity_field_is_representable() {
+        let mut v = sample().to_value();
+        if let DagCbor::Map(ref mut pairs) = v {
+            pairs.push((DagCbor::Text("payerLegalId".into()), DagCbor::Text("SSN".into())));
+            pairs.sort_by(|a, b| a.0.as_str().unwrap_or("").cmp(b.0.as_str().unwrap_or("")));
+        }
+        assert!(ReceiptRecord::from_value(&v).is_err());
+    }
+
+    #[test]
+    fn record_validates_formats() {
+        // Bad allocation cid.
+        assert!(ReceiptRecord::new("x", "did:key:z", "did:key:h", "t", 1).is_err());
+        // Empty spender.
+        assert!(ReceiptRecord::new(
+            "bafyreiexamplealloccid1234567890abcdef",
+            "",
+            "did:key:h",
+            "t",
+            1
+        )
+        .is_err());
+        // Empty transferId.
+        assert!(ReceiptRecord::new(
+            "bafyreiexamplealloccid1234567890abcdef",
+            "did:key:z",
+            "did:key:h",
+            "",
+            1
+        )
+        .is_err());
+    }
+}

--- a/crates/hyprstream-pds/src/lib.rs
+++ b/crates/hyprstream-pds/src/lib.rs
@@ -56,6 +56,7 @@ pub mod cid;
 pub mod commit;
 pub mod dag_cbor;
 pub mod event_group;
+pub mod ledger;
 pub mod list_record;
 pub mod mst;
 pub mod placement;
@@ -63,5 +64,6 @@ pub mod record;
 pub mod tid;
 
 pub use cid::Cid;
+pub use ledger::{AllocationRecord, CheckpointRecord, GrantClass, ReceiptRecord, StateRoot, Unit};
 pub use placement::{GroupItemRecord, GroupRecord, NodeRecord, WorkloadRecord};
 pub use record::ModelRecord;

--- a/crates/hyprstream/src/services/discovery.rs
+++ b/crates/hyprstream/src/services/discovery.rs
@@ -17,6 +17,7 @@ use anyhow::{anyhow, bail, Context as _, Result as AnyResult};
 use hyprstream_discovery::{RecordCarData, RecordResolver};
 use hyprstream_pds::car::build_record_proof_car;
 use hyprstream_pds::commit::{Commit, UnsignedCommit};
+use hyprstream_pds::ledger::{AllocationRecord, CheckpointRecord, ReceiptRecord};
 use hyprstream_pds::mst::Node;
 use hyprstream_pds::record::{ModelRecord, COLLECTION_NSID};
 use hyprstream_pds::tid::Tid;
@@ -422,6 +423,69 @@ impl PdsPublisher {
         record_id: &str,
         current_oid_hex: &str,
     ) -> AnyResult<()> {
+        let current_oid_cid = git_oid_to_cid_string(current_oid_hex)?;
+        self.publish_pointer(collection, record_id, current_oid_cid)
+    }
+
+    /// Publish (or advance) a holder-controlled `ai.hyprstream.ledger.allocation`
+    /// record — the held entitlement (#924).
+    ///
+    /// The allocation's canonical DAG-CBOR bytes are content-addressed and the
+    /// resulting CID becomes the pointer this repo's MST carries under the
+    /// `ai.hyprstream.ledger.allocation` collection; the holder's signed PDS
+    /// commit is the only signature the record needs (it lives in the holder's
+    /// own repo). The rkey is derived deterministically from the record's grant
+    /// CID, so re-publishing the same grant advances the same record.
+    pub fn publish_ledger_allocation(&self, rec: &AllocationRecord) -> AnyResult<()> {
+        self.publish_pointer(
+            hyprstream_pds::ledger::allocation::COLLECTION_NSID,
+            &rec.grant,
+            hyprstream_pds::cid::Cid::from_dag_cbor(&rec.to_dag_cbor()).encode(),
+        )
+    }
+
+    /// Publish (or advance) a holder-controlled `ai.hyprstream.ledger.receipt`
+    /// record — a dual-signed usage record (#924).
+    ///
+    /// The rkey is derived from the receipt's `transferId`, giving at-least-once
+    /// (idempotent) receipt delivery: re-publishing the same transfer advances
+    /// the same record rather than creating a duplicate.
+    pub fn publish_ledger_receipt(&self, rec: &ReceiptRecord) -> AnyResult<()> {
+        self.publish_pointer(
+            hyprstream_pds::ledger::receipt::COLLECTION_NSID,
+            &rec.transfer_id,
+            hyprstream_pds::cid::Cid::from_dag_cbor(&rec.to_dag_cbor()).encode(),
+        )
+    }
+
+    /// Publish (or advance) a holder-controlled `ai.hyprstream.ledger.checkpoint`
+    /// record — a signed ledger head (#924).
+    ///
+    /// `ledger_id` is the stable key of the ledger whose head this checkpoint
+    /// commits, so successive checkpoints advance the one head pointer.
+    pub fn publish_ledger_checkpoint(
+        &self,
+        ledger_id: &str,
+        rec: &CheckpointRecord,
+    ) -> AnyResult<()> {
+        self.publish_pointer(
+            hyprstream_pds::ledger::checkpoint::COLLECTION_NSID,
+            ledger_id,
+            hyprstream_pds::cid::Cid::from_dag_cbor(&rec.to_dag_cbor()).encode(),
+        )
+    }
+
+    /// The shared publish critical section: write (or advance) the pointer record
+    /// in `collection` for `record_id`, pointing it at the already-formed
+    /// `current_oid_cid` (`format: "cid"` string). Every collection — the git
+    /// model pointer and the ledger records alike — shares the repo's ONE MST and
+    /// the ONE commit signed here (#910b).
+    fn publish_pointer(
+        &self,
+        collection: &str,
+        record_id: &str,
+        current_oid_cid: String,
+    ) -> AnyResult<()> {
         // The collection NSID becomes both a `\0`-delimited RocksDB key field
         // and the `<collection>/<rkey>` MST key prefix — reject anything that
         // would be ambiguous in either encoding.
@@ -429,7 +493,6 @@ impl PdsPublisher {
             bail!("invalid collection NSID {collection:?}");
         }
         let tid = PdsRecordStore::tid_for_repo(record_id);
-        let current_oid_cid = git_oid_to_cid_string(current_oid_hex)?;
         let record = ModelRecord::new(
             format!("at://{}", self.did),
             current_oid_cid,
@@ -824,6 +887,76 @@ mod pds_store_tests {
 
         resolve_and_verify(&store, &vk, COLLECTION_NSID, "repo-a");
         resolve_and_verify(&store, &vk, NAME_COLLECTION, "name-a");
+    }
+
+    #[test]
+    fn ledger_multi_collection_publish_resolves() {
+        // #924: an allocation + a receipt written under ONE holder DID as two new
+        // ledger collections, covered by ONE signed commit and each independently
+        // resolvable via the #910b path. The receipt binds a *pairwise* spender
+        // id (not a root DID), exercising the pseudonymity constraint end-to-end.
+        use hyprstream_pds::ledger::{
+            allocation as alloc_ns, receipt as receipt_ns, AllocationRecord, GrantClass,
+            ReceiptRecord, Unit,
+        };
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sk = SigningKey::random(&mut rand::rngs::OsRng);
+        let vk: VerifyingKey = *sk.verifying_key();
+
+        let store = Arc::new(PdsRecordStore::open(dir.path()).expect("open rw"));
+        let publisher = PdsPublisher::new(Arc::clone(&store), DID.to_owned(), sk);
+
+        let alloc = AllocationRecord::new(
+            "bafyreiexamplegrantcid1234567890abcdef",
+            Unit {
+                code: "compute-second".into(),
+                issuer: "did:web:issuer.example.com".into(),
+            },
+            1_000,
+            7,
+            "did:web:issuer.example.com",
+            "did:key:zHolderSubject",
+            GrantClass::Prepaid,
+        )
+        .expect("valid allocation");
+        let receipt = ReceiptRecord::new(
+            alloc.cid().encode(),
+            "pairwise:cell42:8f3ad9c0e1",
+            "did:key:zHostNode",
+            "transfer-01HXYZ",
+            25,
+        )
+        .expect("valid receipt");
+
+        publisher
+            .publish_ledger_allocation(&alloc)
+            .expect("publish allocation");
+        publisher
+            .publish_ledger_receipt(&receipt)
+            .expect("publish receipt");
+
+        // One repo, one signed commit, two ledger collections.
+        let repo = store.load_repo(DID).expect("load").expect("repo");
+        assert_eq!(repo.records.len(), 2, "allocation + receipt in one repo");
+
+        // Each ledger collection resolves with a valid keyless proof.
+        resolve_and_verify(&store, &vk, alloc_ns::COLLECTION_NSID, &alloc.grant);
+        resolve_and_verify(&store, &vk, receipt_ns::COLLECTION_NSID, &receipt.transfer_id);
+
+        // The published pointer's currentOid is the ledger record's content CID —
+        // the record is content-addressed, so its bytes are recoverable/verifiable.
+        let alloc_tid = PdsRecordStore::tid_for_repo(&alloc.grant);
+        let ptr = repo
+            .records
+            .get(&(alloc_ns::COLLECTION_NSID.to_owned(), alloc_tid))
+            .cloned()
+            .expect("allocation pointer present");
+        assert_eq!(
+            ptr.current_oid,
+            alloc.cid().encode(),
+            "pointer must address the allocation record's content CID"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #924, part of #922; honors the #928 pseudonymity P0 constraints