### PR TITLE
feat(at9p) D2: admission did:at9p arm + KeyedPqTrustStore producer (#894)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7272,6 +7272,7 @@ name = "hyprstream-pds"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "blake3",
  "ed25519-dalek 2.2.0",
  "git2",
@@ -7282,6 +7283,7 @@ dependencies = [
  "p256",
  "proptest",
  "rand 0.8.5",
+ "serde_json",
  "sha2 0.10.9",
  "tempfile",
  "tokio",

--- a/crates/hyprstream-pds/Cargo.toml
+++ b/crates/hyprstream-pds/Cargo.toml
@@ -31,6 +31,10 @@ blake3 = { workspace = true }
 # Random signing keys for round-trip / tamper tests.
 rand = { workspace = true }
 proptest = { workspace = true }
+# at9p_resolver tests exercise the admission arm (admit_key_against_did) which is
+# generic over DidDocResolve — an async trait — against a never-call test double.
+async-trait = { workspace = true }
+serde_json = { workspace = true }
 
 # E1 (#421) end-to-end content-addressing + identity test. The dev-deps are the
 # three crates whose composition the test validates: git2db (repo → commit OID),

--- a/crates/hyprstream-pds/src/at9p_resolver.rs
+++ b/crates/hyprstream-pds/src/at9p_resolver.rs
@@ -1,0 +1,247 @@
+//! `hyprstream-pds` implementation of `hyprstream_rpc::identity_resolver::At9pCapsuleResolver`
+//! — the bridge from the A4 GATE pipeline (#884) to the `did:at9p` admission and
+//! resolver arms (D2/#894).
+//!
+//! `hyprstream-rpc` owns the admission gate and the method-dispatched identity
+//! resolver, but the GATE (`canon → hash → sig`) and the capsule schema live here
+//! in `hyprstream-pds` (which depends on rpc, so the dependency does not reverse).
+//! The rpc crate therefore abstracts capsule verification behind the
+//! [`At9pCapsuleResolver`] trait; this module is its real implementation, a thin
+//! wrapper over [`crate::at9p_gate::verify_did_at9p`] that re-expresses the
+//! capsule's content-verified subject keys in the rpc-local key types.
+//!
+//! # Provenance
+//!
+//! A [`VerifiedAt9pKeys`] returned here is only constructable after the full GATE
+//! pipeline passed over canonical bytes whose BLAKE3-512 hash equals the claimed
+//! `cid512` and whose composite signature (pinned Hybrid) verified against the
+//! capsule's own primary subject key. The Ed25519/ML-DSA-65 pair is therefore
+//! **content-verified**, never config-supplied — the D2/#894 provenance boundary.
+
+use anyhow::{anyhow, Result};
+
+use hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes;
+use hyprstream_rpc::identity_resolver::{At9pCapsuleResolver, VerifiedAt9pKeys};
+
+use crate::at9p::ED25519_PUBLIC_KEY_LEN;
+use crate::at9p_gate::verify_did_at9p;
+
+/// The production [`At9pCapsuleResolver`] — the A4 GATE pipeline over a fetched
+/// or peer-presented capsule.
+///
+/// Construct with [`At9pGateResolver::new`]; the locator-backed `resolve` path is
+/// Track C (#890) and returns `Err` until a locator is wired, but
+/// [`verify_bytes`](At9pCapsuleResolver::verify_bytes) — the admission path the
+/// peer presents bytes over — is fully functional today.
+#[derive(Default)]
+pub struct At9pGateResolver;
+
+impl At9pGateResolver {
+    /// Construct the GATE-backed capsule resolver.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl At9pCapsuleResolver for At9pGateResolver {
+    fn verify_bytes(&self, did: &str, capsule_bytes: &[u8]) -> Result<VerifiedAt9pKeys> {
+        // The A4 GATE: canon → hash(H512 == cid512) → sig (pinned Hybrid). Only a
+        // capsule that passes all three gates reaches the Ok, so the keys below
+        // are content-verified binding material.
+        let verified = verify_did_at9p(did, capsule_bytes)
+            .map_err(|e| anyhow!("did:at9p {did} GATE rejected: {e}"))?;
+        let capsule = verified.capsule();
+
+        // The primary subject key (index 0) is the hybrid identity: its Ed25519
+        // half is the iroh NodeId / channel key, its ML-DSA-65 half is the PQ
+        // anchor. `verify_capsule` (sig-gate) already confirmed the capsule's
+        // composite signature verifies against this keypair.
+        let subject = capsule
+            .body
+            .subject_keys
+            .first()
+            .ok_or_else(|| anyhow!("did:at9p {did} capsule carries no subject key"))?;
+
+        let ed25519: [u8; 32] = subject
+            .ed25519_pub
+            .as_slice()
+            .try_into()
+            .map_err(|_| anyhow!("ed25519 subject key is not {ED25519_PUBLIC_KEY_LEN} bytes"))?;
+
+        let ml_dsa_65 = ml_dsa_vk_from_bytes(&subject.mldsa65_pub)?;
+
+        Ok(VerifiedAt9pKeys { ed25519, ml_dsa_65 })
+    }
+
+    fn resolve(&self, did: &str) -> Result<VerifiedAt9pKeys> {
+        // The locator fetch (mainline DHT, Track C / #890) is not wired yet. Until
+        // it is, the resolver path fails closed — admission (verify_bytes, with
+        // peer-presented bytes) is the live D2 path.
+        Err(anyhow!(
+            "did:at9p {did}: mainline locator fetch is not wired (#890) — resolve fails closed"
+        ))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+    use crate::at9p::{
+        Capsule, CapsuleBody, HybridKeyPair, ServiceEndpoint, ServiceEntry, ServiceType, Transport,
+        ED25519_SIGNATURE_LEN,
+    };
+    use crate::at9p_gate::DID_AT9P_PREFIX;
+    use crate::at9p_sign::sign_capsule;
+
+    use ed25519_dalek::SigningKey;
+    use hyprstream_crypto::pq::{ml_dsa_generate_keypair, ml_dsa_vk_bytes, MlDsaSigningKey};
+    use hyprstream_rpc::admission::{admit_key_against_did, At9pAdmission, PeerChannelKey};
+    use hyprstream_rpc::envelope::{KeyedPqTrustStore, PqTrustStore};
+
+    use anyhow::Result as AnyResult;
+    use async_trait::async_trait;
+    use serde_json::Value;
+
+    struct Signer {
+        ed_sk: SigningKey,
+        pq_sk: MlDsaSigningKey,
+        keypair: HybridKeyPair,
+    }
+
+    fn signer(tag: u8) -> Signer {
+        let mut seed = [0u8; 32];
+        seed[0] = tag;
+        seed[31] = tag.wrapping_add(7);
+        let ed_sk = SigningKey::from_bytes(&seed);
+        let (pq_sk, pq_vk) = ml_dsa_generate_keypair();
+        let keypair =
+            HybridKeyPair::new(ed_sk.verifying_key().to_bytes().to_vec(), ml_dsa_vk_bytes(&pq_vk))
+                .unwrap();
+        Signer { ed_sk, pq_sk, keypair }
+    }
+
+    fn body_for(s: &Signer, tag: u8) -> CapsuleBody {
+        let endpoint = ServiceEndpoint::new(Transport::Iroh, format!("iroh://node{tag}")).unwrap();
+        let service = ServiceEntry::new("#ns", ServiceType::NinePExport, endpoint).unwrap();
+        CapsuleBody::new(vec![s.keypair.clone()], vec![service]).unwrap()
+    }
+
+    /// A fully self-signed capsule, its canonical bytes, and its `did:at9p:<cid>`.
+    fn signed(tag: u8) -> (Capsule, Vec<u8>, String) {
+        let s = signer(tag);
+        let body = body_for(&s, tag);
+        let capsule = sign_capsule(body, &s.ed_sk, &s.pq_sk).unwrap();
+        let bytes = capsule.to_dag_cbor();
+        let did = format!("{DID_AT9P_PREFIX}{}", capsule.cid512().unwrap());
+        (capsule, bytes, did)
+    }
+
+    /// A did:web resolver that MUST NOT be called for the did:at9p admission arm.
+    struct NeverResolve;
+    #[async_trait]
+    impl hyprstream_rpc::admission::DidDocResolve for NeverResolve {
+        async fn resolve_doc(&self, did: &str) -> AnyResult<Value> {
+            panic!("did:at9p admission must not resolve a DID document (called for {did})");
+        }
+    }
+
+    #[test]
+    fn gate_resolver_returns_verified_subject_keys() {
+        let (capsule, bytes, did) = signed(1);
+        let primary = capsule.body.subject_keys[0].clone();
+        let verified = At9pGateResolver::new().verify_bytes(&did, &bytes).expect("GATE passes");
+        assert_eq!(verified.ed25519.as_slice(), primary.ed25519_pub);
+        assert_eq!(ml_dsa_vk_bytes(&verified.ml_dsa_65), primary.mldsa65_pub);
+    }
+
+    #[test]
+    fn gate_resolver_rejects_bad_signature() {
+        // Corrupt the Ed25519 signature (keep it schema-valid) and claim the
+        // tampered capsule's own recomputed cid so canon/hash pass — only sig-gate
+        // can reject.
+        let (mut capsule, _bytes, _did) = signed(2);
+        capsule.signatures.ed25519_signature = vec![0u8; ED25519_SIGNATURE_LEN];
+        let bytes = capsule.to_dag_cbor();
+        let cid = Capsule::from_dag_cbor(&bytes).unwrap().cid512().unwrap();
+        let did = format!("{DID_AT9P_PREFIX}{cid}");
+        assert!(At9pGateResolver::new().verify_bytes(&did, &bytes).is_err());
+    }
+
+    #[test]
+    fn gate_resolver_rejects_wrong_cid() {
+        // A genuine capsule claimed under a different (well-formed) cid fails
+        // hash-gate.
+        let (_c1, bytes1, did1) = signed(3);
+        let did_other = signed(4).2;
+        assert_ne!(did1, did_other);
+        assert!(At9pGateResolver::new().verify_bytes(&did_other, &bytes1).is_err());
+    }
+
+    #[tokio::test]
+    async fn admission_binds_hybrid_keys_from_gate_verified_capsule() {
+        // End-to-end D2: a real self-signed capsule → GATE passes → the verified
+        // ed25519→ml_dsa_65 pair is bound into KeyedPqTrustStore. The binding
+        // provably comes from the capsule (the store was empty; the bound PQ key
+        // equals the capsule's), not from any out-of-band config.
+        let (capsule, bytes, did) = signed(5);
+        let ed = capsule.body.subject_keys[0].ed25519_pub.clone();
+        let primary_pq = capsule.body.subject_keys[0].mldsa65_pub.clone();
+        let ed_arr: [u8; 32] = ed.as_slice().try_into().unwrap();
+
+        let gate = At9pGateResolver::new();
+        let mut store = KeyedPqTrustStore::new();
+        assert!(store.is_empty());
+
+        let admitted = admit_key_against_did(
+            &NeverResolve,
+            "https://peer.example",
+            PeerChannelKey(ed_arr),
+            &did,
+            None,
+            Some(At9pAdmission { capsule_bytes: &bytes, gate: &gate, pq_store: &mut store }),
+        )
+        .await
+        .expect("verified capsule admits and binds");
+
+        assert_eq!(admitted.did.as_deref(), Some(did.as_str()));
+        assert_eq!(admitted.key, ed_arr);
+        assert_eq!(store.len(), 1);
+        let bound = store.ml_dsa_key_for(&ed_arr).expect("hybrid binding installed");
+        assert_eq!(ml_dsa_vk_bytes(&bound), primary_pq);
+    }
+
+    #[tokio::test]
+    async fn admission_rejects_gate_failure_and_binds_nothing() {
+        // Tampered signature → GATE rejects → admission fails closed and NOTHING
+        // is bound into the trust store.
+        let (mut capsule, _bytes, _did) = signed(6);
+        capsule.signatures.ed25519_signature = vec![0u8; ED25519_SIGNATURE_LEN];
+        let bytes = capsule.to_dag_cbor();
+        let cid = Capsule::from_dag_cbor(&bytes).unwrap().cid512().unwrap();
+        let did = format!("{DID_AT9P_PREFIX}{cid}");
+        let ed: [u8; 32] = capsule.body.subject_keys[0].ed25519_pub.as_slice().try_into().unwrap();
+
+        let gate = At9pGateResolver::new();
+        let mut store = KeyedPqTrustStore::new();
+        let res = admit_key_against_did(
+            &NeverResolve,
+            "https://peer.example",
+            PeerChannelKey(ed),
+            &did,
+            None,
+            Some(At9pAdmission { capsule_bytes: &bytes, gate: &gate, pq_store: &mut store }),
+        )
+        .await;
+        assert!(res.is_err(), "GATE failure must reject");
+        assert!(store.is_empty(), "a rejected capsule must bind nothing");
+    }
+
+    #[test]
+    fn resolve_fails_closed_until_locator_wired() {
+        // The resolver path (locator fetch, #890) is not wired; it must fail
+        // closed rather than silently degrade.
+        let (_c, _bytes, did) = signed(7);
+        assert!(At9pGateResolver::new().resolve(&did).is_err());
+    }
+}

--- a/crates/hyprstream-pds/src/lib.rs
+++ b/crates/hyprstream-pds/src/lib.rs
@@ -50,6 +50,7 @@
 pub mod at9p;
 pub mod at9p_chain;
 pub mod at9p_gate;
+pub mod at9p_resolver;
 pub mod at9p_sign;
 pub mod car;
 pub mod cid;

--- a/crates/hyprstream-rpc/src/admission.rs
+++ b/crates/hyprstream-rpc/src/admission.rs
@@ -61,6 +61,41 @@ use crate::did_web::{
     did_key_to_ed25519, is_did_key, jwks_ed25519_keys, verification_method_ed25519_keys, DidDocFetcher,
     DidWebResolver,
 };
+use crate::envelope::KeyedPqTrustStore;
+use crate::identity_resolver::At9pCapsuleResolver;
+
+/// The `did:at9p:` method prefix; a `did:at9p` identifier is this prefix followed
+/// by the base32 CIDv1 (`cid512`) of the genesis capsule (#884).
+const DID_AT9P_PREFIX: &str = "did:at9p:";
+
+/// Whether `did` is a `did:at9p` identifier (the self-certifying hybrid-PQC arm).
+fn is_did_at9p(did: &str) -> bool {
+    did.starts_with(DID_AT9P_PREFIX)
+}
+
+/// Inputs for the `did:at9p` admission arm (D2/#894).
+///
+/// Parallel to the `is_did_key` arm, but a `did:at9p` peer upgrades its classical
+/// channel key to a hybrid-PQC anchor, so the arm additionally needs:
+/// - the **capsule bytes** the peer presented over the channel,
+/// - a **GATE verifier** ([`At9pCapsuleResolver`]) that runs the A4
+///   canon→hash→sig pipeline (#884) and returns the content-verified subject keys,
+/// - the **[`KeyedPqTrustStore`]** to bind those verified hybrid keys into — the
+///   atomic `ed25519 → ml_dsa_65` binding that replaces the out-of-band
+///   `mesh_peers` config path for `did:at9p` peers.
+///
+/// The arm is exercised by passing `Some(At9pAdmission { .. })` to
+/// [`admit_key_against_did`]; the live mesh admission flow is not wired beyond
+/// this arm, so [`FederationAdmissionGate::admit`] passes `None` (a `did:at9p`
+/// peer reaching that path fails closed until the accept path feeds capsule bytes).
+pub struct At9pAdmission<'a> {
+    /// The raw genesis capsule bytes the peer presented for `did:at9p:<cid512>`.
+    pub capsule_bytes: &'a [u8],
+    /// The GATE verifier (implemented in `hyprstream-pds` over `verify_did_at9p`).
+    pub gate: &'a dyn At9pCapsuleResolver,
+    /// The native PQ trust store to bind the verified hybrid keys into.
+    pub pq_store: &'a mut KeyedPqTrustStore,
+}
 
 /// The peer's authenticated channel key: the raw 32-byte Ed25519 public key the
 /// connecting peer proved possession of for this session.
@@ -193,7 +228,7 @@ impl<O: OriginAdmission, R: DidDocResolve> FederationAdmissionGate<O, R> {
             .map_err(|e| anyhow!("admission stage 1 (origin {origin}) denied: {e}"))?;
 
         // ── Stage 2: key binding (fail-closed) ────────────────────────────────
-        admit_key_against_did(&self.resolver, origin, peer_key, did, federation_jwks).await
+        admit_key_against_did(&self.resolver, origin, peer_key, did, federation_jwks, None).await
     }
 }
 
@@ -209,6 +244,14 @@ impl<O: OriginAdmission, R: DidDocResolve> FederationAdmissionGate<O, R> {
 ///   resolver call**. We decode the key directly ([`did_key_to_ed25519`]) and
 ///   admit iff `peer_key` equals it. (Reach for such a peer comes from iroh
 ///   discovery #282, not the DID string — out of scope here.)
+/// - **`did:at9p` (self-certifying hybrid-PQC, #894/D2)** — the capsule *is* the
+///   hybrid key commitment: GATE-verify the peer-presented bytes
+///   (canon→hash→sig, #884) via the supplied [`At9pCapsuleResolver`], admit iff
+///   the peer's channel key equals the capsule's Ed25519 subject key, and bind
+///   the verified `ed25519 → ml_dsa_65` pair into the [`KeyedPqTrustStore`].
+///   This is the classical→hybrid trust upgrade, populated from content-verified
+///   material (no config trust). No resolver/fetch: the capsule is
+///   self-certifying. Requires `at9p = Some(_)`; otherwise fail-closed.
 /// - **`did:web` (resolver fetch, #279/#137)** — resolve the peer DID document
 ///   and admit iff `peer_key` matches one of its Ed25519 `verificationMethod`
 ///   keys, falling back to a supplied federation JWKS.
@@ -221,6 +264,7 @@ pub async fn admit_key_against_did<R: DidDocResolve>(
     peer_key: PeerChannelKey,
     did: &str,
     federation_jwks: Option<&Value>,
+    at9p: Option<At9pAdmission<'_>>,
 ) -> Result<AdmittedIdentity> {
     // ── did:key self-certifying arm (#281) ────────────────────────────────────
     // A did:key carries its own Ed25519 key — no DID-doc resolution / network
@@ -241,6 +285,45 @@ pub async fn admit_key_against_did<R: DidDocResolve>(
             peer_key,
             &format!("peer key does not match the self-certifying did:key identity {did}"),
         ));
+    }
+
+    // ── did:at9p self-certifying hybrid arm (#894/D2) ──────────────────────────
+    // The capsule proves the ed25519→ml_dsa_65 binding (GATE pipeline #884), so no
+    // DID-doc fetch and no out-of-band config trust: the binding is installed
+    // straight from content-verified material. A GATE failure rejects and binds
+    // nothing; a missing admission context rejects too (the live accept path does
+    // not yet feed capsule bytes — `FederationAdmissionGate::admit` passes None).
+    if is_did_at9p(did) {
+        let ctx = at9p.ok_or_else(|| {
+            admission_reject(
+                origin,
+                peer_key,
+                &format!("did:at9p {did} presented without a capsule/admission context — fail-closed"),
+            )
+        })?;
+        let verified = ctx.gate.verify_bytes(did, ctx.capsule_bytes).map_err(|e| {
+            admission_reject(origin, peer_key, &format!("did:at9p {did} capsule GATE rejected: {e}"))
+        })?;
+        // The capsule's Ed25519 subject key IS the identity; the peer's
+        // authenticated channel key must equal it (one trust root, #185 closed
+        // by construction for did:at9p).
+        if !key_eq(&verified.ed25519, peer_key.as_bytes()) {
+            return Err(admission_reject(
+                origin,
+                peer_key,
+                &format!(
+                    "peer key does not match the did:at9p capsule Ed25519 subject key {did}"
+                ),
+            ));
+        }
+        // Atomic hybrid binding from the verified capsule — replaces the
+        // out-of-band `mesh_peers` config path for did:at9p peers (#894).
+        ctx.pq_store.bind(verified.ed25519, &verified.ml_dsa_65);
+        return Ok(AdmittedIdentity {
+            origin: origin.to_owned(),
+            did: Some(did.to_owned()),
+            key: *peer_key.as_bytes(),
+        });
     }
 
     // ── did:web resolver arm (#279/#137) ──────────────────────────────────────
@@ -624,5 +707,143 @@ mod tests {
             .await
             .expect_err("invalid did:key must reject (fail-closed)");
         assert!(err.to_string().contains("stage 2"), "{err}");
+    }
+
+    // ── did:at9p self-certifying hybrid arm (D2/#894) ──────────────────────────
+
+    use crate::crypto::pq::{ml_dsa_generate_keypair, ml_dsa_vk_bytes};
+    use crate::envelope::PqTrustStore;
+    use crate::identity_resolver::{At9pCapsuleResolver, VerifiedAt9pKeys};
+
+    const AT9P_DID: &str = "did:at9p:fakecid512";
+
+    /// A capsule gate test double: returns a fixed [`VerifiedAt9pKeys`] on
+    /// `verify_bytes`, or `Err` when `fail` is set (simulating a GATE rejection —
+    /// bad sig / wrong cid). The real GATE lives in `hyprstream-pds`
+    /// (`at9p_resolver::At9pGateResolver`); this fixture keeps the arm testable in
+    /// the lower rpc crate without a pds dependency.
+    struct FixtureGate {
+        keys: VerifiedAt9pKeys,
+        fail: bool,
+    }
+
+    impl At9pCapsuleResolver for FixtureGate {
+        fn verify_bytes(&self, _did: &str, _capsule_bytes: &[u8]) -> Result<VerifiedAt9pKeys> {
+            if self.fail {
+                bail!("simulated GATE failure (bad sig / wrong cid)");
+            }
+            Ok(self.keys.clone())
+        }
+    }
+
+    fn verified_subject(ed: [u8; 32]) -> VerifiedAt9pKeys {
+        let (_sk, vk) = ml_dsa_generate_keypair();
+        VerifiedAt9pKeys { ed25519: ed, ml_dsa_65: vk }
+    }
+
+    #[tokio::test]
+    async fn admits_did_at9p_peer_and_binds_hybrid_keys_from_capsule() {
+        // Valid capsule → GATE passes → the verified ed25519→ml_dsa_65 pair is
+        // bound into KeyedPqTrustStore, atomic hybrid binding from content-verified
+        // material (no config trust).
+        let ed = random_ed25519();
+        let keys = verified_subject(ed);
+        let gate = FixtureGate { keys: keys.clone(), fail: false };
+        let mut store = KeyedPqTrustStore::new();
+        assert!(store.is_empty(), "store starts empty (no config trust)");
+
+        let admitted = admit_key_against_did(
+            &NeverResolve,
+            ORIGIN,
+            PeerChannelKey(ed),
+            AT9P_DID,
+            None,
+            Some(At9pAdmission { capsule_bytes: b"<capsule>", gate: &gate, pq_store: &mut store }),
+        )
+        .await
+        .expect("verified capsule must admit");
+
+        assert_eq!(admitted.did.as_deref(), Some(AT9P_DID));
+        assert_eq!(admitted.key, ed);
+        // The binding is exactly the capsule's verified keys — comes from the
+        // capsule, not config.
+        assert_eq!(store.len(), 1, "exactly one hybrid binding installed");
+        let bound = store
+            .ml_dsa_key_for(&ed)
+            .expect("ed25519→ml_dsa_65 bound");
+        assert_eq!(ml_dsa_vk_bytes(&bound), ml_dsa_vk_bytes(&keys.ml_dsa_65));
+    }
+
+    #[tokio::test]
+    async fn rejects_did_at9p_on_gate_failure_and_binds_nothing() {
+        // A capsule that fails GATE (bad sig / wrong cid) → reject, and crucially
+        // NOTHING is bound into the trust store (no downgrade, no partial trust).
+        let ed = random_ed25519();
+        let gate = FixtureGate { keys: verified_subject(ed), fail: true };
+        let mut store = KeyedPqTrustStore::new();
+
+        let err = admit_key_against_did(
+            &NeverResolve,
+            ORIGIN,
+            PeerChannelKey(ed),
+            AT9P_DID,
+            None,
+            Some(At9pAdmission { capsule_bytes: b"<capsule>", gate: &gate, pq_store: &mut store }),
+        )
+        .await
+        .expect_err("GATE failure must reject (fail-closed)");
+        assert!(err.to_string().contains("stage 2"), "{err}");
+        assert!(err.to_string().contains("GATE"), "{err}");
+        assert!(store.is_empty(), "a rejected capsule must bind nothing");
+    }
+
+    #[tokio::test]
+    async fn rejects_did_at9p_on_channel_key_mismatch_and_binds_nothing() {
+        // The capsule verifies, but the peer's channel key is not the capsule's
+        // Ed25519 subject key → reject (one trust root, #185) and bind nothing.
+        let identity = random_ed25519();
+        let peer = random_ed25519();
+        assert_ne!(identity, peer);
+        let gate = FixtureGate { keys: verified_subject(identity), fail: false };
+        let mut store = KeyedPqTrustStore::new();
+
+        let err = admit_key_against_did(
+            &NeverResolve,
+            ORIGIN,
+            PeerChannelKey(peer),
+            AT9P_DID,
+            None,
+            Some(At9pAdmission { capsule_bytes: b"<capsule>", gate: &gate, pq_store: &mut store }),
+        )
+        .await
+        .expect_err("channel-key mismatch must reject");
+        assert!(err.to_string().contains("stage 2"), "{err}");
+        assert!(store.is_empty(), "a mismatched peer must bind nothing");
+    }
+
+    #[tokio::test]
+    async fn rejects_did_at9p_without_an_admission_context() {
+        // did:at9p presented but no capsule/admission context supplied (the live
+        // accept path does not feed bytes yet) → fail closed.
+        let peer = random_ed25519();
+        let err = admit_key_against_did(&NeverResolve, ORIGIN, PeerChannelKey(peer), AT9P_DID, None, None)
+            .await
+            .expect_err("missing capsule context must reject");
+        assert!(err.to_string().contains("stage 2"), "{err}");
+        assert!(err.to_string().contains("fail-closed"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn did_at9p_still_enforces_stage1_origin() {
+        // Stage 1 (origin) runs first; a denied origin rejects before the at9p arm.
+        let ed = random_ed25519();
+        let gate = FederationAdmissionGate::new(DenyOrigin, NeverResolve);
+        let err = gate
+            .admit(ORIGIN, PeerChannelKey(ed), AT9P_DID, None)
+            .await
+            .expect_err("denied origin must reject a did:at9p peer");
+        // gate.admit passes None for the at9p context, so stage 1's denial is what
+        // surfaces (stage 2 never runs).
+        assert!(err.to_string().contains("stage 1"), "expected stage-1 rejection, got: {err}");
     }
 }

--- a/crates/hyprstream-rpc/src/did_key.rs
+++ b/crates/hyprstream-rpc/src/did_key.rs
@@ -23,30 +23,57 @@ use anyhow::{anyhow, bail, Result};
 /// codepath shares.
 pub(crate) const MULTICODEC_ED25519_PUB: [u8; 2] = [0xed, 0x01];
 
-/// Decode a `Multikey` `publicKeyMultibase` string into raw Ed25519 key bytes.
+/// Multicodec `ml-dsa-65-pub` unsigned-varint prefix (`0x1211` → bytes `0x91 0x24`).
 ///
-/// Verifies the base58btc multibase prefix (`z`) and the `ed25519-pub` multicodec
-/// header, returning the 32-byte payload.
+/// The PQ counterpart to [`MULTICODEC_ED25519_PUB`]: the header the mesh's
+/// `#mesh-pq` ML-DSA-65 verification method carries in its `publicKeyMultibase`.
+/// Mirrors `hyprstream::auth::mesh_trust::MULTICODEC_ML_DSA_65_PUB` (a 2-byte
+/// constant duplicated across the `hyprstream`/`hyprstream-rpc` crate boundary
+/// because `hyprstream-rpc` is the lower crate). Within `hyprstream-rpc` this is
+/// the one definition every codec-agile `Multikey` decode shares.
+pub const MULTICODEC_ML_DSA_65_PUB: [u8; 2] = [0x91, 0x24];
+
+/// Decode a `Multikey` `publicKeyMultibase` string into its raw key bytes,
+/// verifying the base58btc multibase prefix (`z`) and the `expected_codec`
+/// multicodec header, returning the payload with the multicodec prefix stripped.
 ///
-/// Returns `Err` for a wrong multibase, an undecodable base58, a non-Ed25519
-/// codec, or a payload that is not exactly 32 bytes.
-pub fn decode_ed25519_multikey(multibase: &str) -> Result<[u8; 32]> {
+/// This is the **codec-agile** core: it is algorithm-parametric over the
+/// multicodec header, so one implementation covers the `ed25519-pub` (`0xed01`)
+/// and `ml-dsa-65-pub` (`0x1211`) Multikeys the mesh publishes (and any future
+/// codec). [`decode_ed25519_multikey`] is the Ed25519-fixed thin wrapper.
+///
+/// Returns `Err` for a wrong multibase, an undecodable base58, or a multicodec
+/// header that does not match `expected_codec`. Payload *length* validation is
+/// the caller's concern (it is algorithm-specific).
+pub fn decode_multikey(multibase: &str, expected_codec: &[u8; 2]) -> Result<Vec<u8>> {
     let body = multibase
         .strip_prefix('z')
         .ok_or_else(|| anyhow!("Multikey must use base58btc multibase ('z') prefix"))?;
     let decoded = bs58::decode(body)
         .into_vec()
         .map_err(|e| anyhow!("invalid base58btc Multikey: {e}"))?;
-    if decoded.len() < 2 || decoded[..2] != MULTICODEC_ED25519_PUB {
+    if decoded.len() < 2 || &decoded[..2] != expected_codec {
         bail!(
-            "unexpected multicodec prefix (expected ed25519-pub {MULTICODEC_ED25519_PUB:02x?}, got {:02x?})",
+            "unexpected multicodec prefix (expected {expected_codec:02x?}, got {:02x?})",
             decoded.get(..2).unwrap_or(&decoded)
         );
     }
-    let raw: [u8; 32] = decoded[2..]
-        .try_into()
-        .map_err(|_| anyhow!("ed25519 Multikey payload is {} bytes (expected 32)", decoded.len() - 2))?;
-    Ok(raw)
+    Ok(decoded[2..].to_vec())
+}
+
+/// Decode a `Multikey` `publicKeyMultibase` string into raw Ed25519 key bytes.
+///
+/// A thin, length-checked wrapper over the codec-agile [`decode_multikey`]:
+/// verifies the base58btc multibase prefix (`z`) and the `ed25519-pub` multicodec
+/// header, returning the 32-byte payload.
+///
+/// Returns `Err` for a wrong multibase, an undecodable base58, a non-Ed25519
+/// codec, or a payload that is not exactly 32 bytes.
+pub fn decode_ed25519_multikey(multibase: &str) -> Result<[u8; 32]> {
+    let raw = decode_multikey(multibase, &MULTICODEC_ED25519_PUB)?;
+    let len = raw.len();
+    raw.try_into()
+        .map_err(|_| anyhow!("ed25519 Multikey payload is {len} bytes (expected 32)"))
 }
 
 /// Decode a `did:key` (Ed25519) identifier into its raw 32-byte Ed25519 key.

--- a/crates/hyprstream-rpc/src/did_web.rs
+++ b/crates/hyprstream-rpc/src/did_web.rs
@@ -240,7 +240,10 @@ pub fn preferred_transport(doc: &Value, kind: Option<SocketKind>) -> Option<Tran
 // share one implementation and cannot drift. They are re-exported here so
 // existing `crate::did_web::*` callers (admission gate, federation tests) are
 // unaffected.
-pub use crate::did_key::{decode_ed25519_multikey, did_key_to_ed25519, ed25519_to_did_key};
+pub use crate::did_key::{
+    decode_ed25519_multikey, decode_multikey, did_key_to_ed25519, ed25519_to_did_key,
+    MULTICODEC_ML_DSA_65_PUB,
+};
 // Only the test multikey helper references the raw multicodec constant now.
 #[cfg(test)]
 use crate::did_key::MULTICODEC_ED25519_PUB;
@@ -277,6 +280,47 @@ pub fn verification_method_ed25519_keys(doc: &Value) -> Vec<[u8; 32]> {
             Ok(k) => keys.push(k),
             Err(e) => {
                 tracing::debug!(error = %e, "skipping undecodable verificationMethod Multikey");
+            }
+        }
+    }
+    keys
+}
+
+/// Extract every ML-DSA-65 verifying key published in a DID document's
+/// `verificationMethod` array (#579 multi-alg VM extraction).
+///
+/// The PQ counterpart to [`verification_method_ed25519_keys`]: it scans the same
+/// `verificationMethod` array but keeps the `Multikey` entries whose
+/// `publicKeyMultibase` carries the `ml-dsa-65-pub` multicodec (`0x1211`) — the
+/// mesh's `#mesh-pq` verification method. Each candidate is decoded via the
+/// codec-agile [`decode_multikey`] and validated as a real ML-DSA-65 key by
+/// [`crate::crypto::pq::ml_dsa_vk_from_bytes`] (a malformed / wrong-length key is
+/// skipped, never trusted). Ed25519 (`0xed01`) VMs decode to a different codec
+/// and are skipped here, so the two extractors partition the same document by
+/// algorithm without interfering.
+///
+/// A document with no ML-DSA-65 VM yields an **empty** vec (the classical-only
+/// case): the caller treats "no PQ anchor" as `Assurance::Classical`, not an
+/// error.
+pub fn verification_method_ml_dsa_65_keys(doc: &Value) -> Vec<crate::crypto::pq::MlDsaVerifyingKey> {
+    let Some(vms) = doc.get("verificationMethod").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    let mut keys = Vec::new();
+    for vm in vms {
+        let Some(mb) = vm.get("publicKeyMultibase").and_then(Value::as_str) else {
+            continue;
+        };
+        // Only ml-dsa-65-pub Multikeys; an ed25519 (or other) codec is not an
+        // error here — it belongs to the Ed25519 extractor — so skip quietly.
+        let raw = match decode_multikey(mb, &MULTICODEC_ML_DSA_65_PUB) {
+            Ok(raw) => raw,
+            Err(_) => continue,
+        };
+        match crate::crypto::pq::ml_dsa_vk_from_bytes(&raw) {
+            Ok(vk) => keys.push(vk),
+            Err(e) => {
+                tracing::debug!(error = %e, "skipping ml-dsa-65 verificationMethod: not a valid ML-DSA-65 key");
             }
         }
     }

--- a/crates/hyprstream-rpc/src/identity.rs
+++ b/crates/hyprstream-rpc/src/identity.rs
@@ -77,6 +77,16 @@ impl Did {
         self.0.starts_with("did:web:")
     }
 
+    /// Whether this is a `did:at9p` identifier (the self-certifying hybrid-PQC
+    /// capsule identity, #879/#880).
+    ///
+    /// The capsule GATE pipeline that verifies a `did:at9p` and derives its
+    /// `PqHybrid` key material is epic #880 (D2); the method-dispatched resolver
+    /// reserves the arm but does not yet resolve it (fails closed until #894).
+    pub fn is_did_at9p(&self) -> bool {
+        self.0.starts_with("did:at9p:")
+    }
+
     /// Decode the raw 32-byte Ed25519 public key from a `did:key` identifier.
     ///
     /// Returns `Err` for a non-`did:key` DID, a non-Ed25519 multicodec, or a malformed body.

--- a/crates/hyprstream-rpc/src/identity_resolver.rs
+++ b/crates/hyprstream-rpc/src/identity_resolver.rs
@@ -1,0 +1,507 @@
+//! Method-dispatched [`IdentityResolver`] — the real `Did → IdentityKeys` binding (#579).
+//!
+//! This is the single, non-mirror implementation of the canonical
+//! [`crate::identity::IdentityResolver`] contract. It replaces the fixture /
+//! test-double resolvers that stood in for it while the #549 perimeter gateway
+//! and #137 admission gate were built against the interface.
+//!
+//! # Division of labor
+//!
+//! The resolver owns **verification + assurance derivation**; it does *not* own
+//! object labelling, the `KeyedPqTrustStore.bind` mesh anchor (#894), or any
+//! perimeter policy — those consumers are generic over the trait and unchanged.
+//!
+//! # Method dispatch
+//!
+//! [`resolve_identity_keys`](IdentityResolver::resolve_identity_keys) branches on
+//! the DID method:
+//!
+//! - **`did:web`** — resolve the DID document and extract its verification
+//!   methods. An Ed25519 VM (`#mesh` / `#iroh`) is the classical anchor; a
+//!   verified ML-DSA-65 VM (`#mesh-pq`, multicodec `0x1211`) is the PQ anchor.
+//!   Both present ⇒ [`Assurance::PqHybrid`] (a did:web we operate); Ed25519-only ⇒
+//!   [`Assurance::Classical`] (a third-party did:web). No Ed25519 VM ⇒ nothing to
+//!   bind ⇒ `Err` (fail-closed).
+//! - **`did:key`** — a single Ed25519 key decoded from the DID string itself; no
+//!   fetch. A single classical key can never be hybrid, so the honest ceiling is
+//!   [`Assurance::Classical`].
+//! - **`did:at9p`** — the self-certifying hybrid-PQC capsule identity (#879/#880
+//!   D2, #894). The resolver delegates to an injected [`At9pCapsuleResolver`]
+//!   that runs the A4 GATE pipeline (canon→hash→sig, #884) over the capsule and
+//!   returns its content-verified subject keys; a verified capsule yields
+//!   [`Assurance::PqHybrid`]. With no capsule resolver configured the arm fails
+//!   closed (production wiring of the mainline locator is Track C, #890).
+//! - **any other method** — `Err` (fail-closed).
+//!
+//! # Fail-closed
+//!
+//! Per the [`IdentityResolver`] contract, every inability to establish key
+//! material — an unknown method, a fetch failure, a malformed document, a
+//! did:web with no Ed25519 VM — returns `Err`. A resolver **never** returns a
+//! default-`Unverified` `Ok`.
+//!
+//! # Sync trait over an async fetch
+//!
+//! The contract is synchronous and enrollment happens **off the auth path**
+//! (once, at session establishment), so did:web document retrieval is abstracted
+//! behind a synchronous [`DidDocumentProvider`]. This keeps the decode +
+//! assurance-derivation core pure and testable with an injected fixture (no live
+//! network), mirroring the injected-fetcher pattern in [`crate::did_web`]. The
+//! async→sync bridge to the live [`crate::did_web::HttpDidDocFetcher`] is a
+//! wiring concern for the accept-path integration (there is no production
+//! construction site of the perimeter gateway today).
+
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+
+use crate::auth::mac::Assurance;
+use crate::did_web::{
+    did_key_to_ed25519, verification_method_ed25519_keys, verification_method_ml_dsa_65_keys,
+};
+use crate::crypto::pq::MlDsaVerifyingKey;
+use crate::identity::{Did, IdentityKeys, IdentityResolver};
+
+/// A synchronous DID-document provider for the did:web arm.
+///
+/// Abstracted so the resolver's decode/assurance core is testable with an
+/// injected fixture (no network). Enrollment is off the auth path, so a blocking
+/// implementation is acceptable; the trait keeps that policy out of the resolver.
+pub trait DidDocumentProvider: Send + Sync {
+    /// Fetch and parse the DID document for `did` (already known to be `did:web`).
+    fn document(&self, did: &str) -> Result<Value>;
+}
+
+/// The content-verified subject keys of a `did:at9p` capsule, re-expressed in the
+/// rpc-local key types so this crate need not depend on `hyprstream-pds` (pds
+/// depends on rpc; the dependency does not reverse).
+///
+/// `ed25519` is the capsule's primary subject key — the iroh `NodeId` / channel
+/// identity. `ml_dsa_65` is the PQ half of the hybrid pair. A [`VerifiedAt9pKeys`]
+/// is only constructable by an [`At9pCapsuleResolver`] that ran the A4 GATE
+/// pipeline (canon→hash→sig, #884) to completion, so holding one is proof the
+/// binding came from **content-verified capsule material**, not a config file or a
+/// caller assertion (the D2/#894 provenance boundary).
+#[derive(Clone)]
+pub struct VerifiedAt9pKeys {
+    /// The verified Ed25519 subject key (the classical identity / channel key).
+    pub ed25519: [u8; 32],
+    /// The verified ML-DSA-65 subject key bound to `ed25519` in the capsule.
+    pub ml_dsa_65: MlDsaVerifyingKey,
+}
+
+/// Verifies a `did:at9p` capsule and yields its content-verified subject keys.
+///
+/// The A4 GATE pipeline (`canon-gate → hash-gate(H512 == cid512) → sig-gate`,
+/// #884) lives in `hyprstream-pds` beside the capsule schema. The lower
+/// `hyprstream-rpc` crate — which both the admission gate (`crate::admission`) and
+/// this resolver belong to — cannot depend on pds, so the GATE is abstracted
+/// behind this object-safe trait and implemented in pds over
+/// `hyprstream_pds::at9p_gate::verify_did_at9p`.
+///
+/// Two entry points, each fail-closed on any GATE failure (never a default-`Ok`):
+///
+/// - [`verify_bytes`](Self::verify_bytes) — the **admission path**: the peer
+///   presented its capsule bytes over the channel; the GATE decides whether to
+///   accept them. Used by `admit_key_against_did`'s `did:at9p` arm to bind the
+///   verified hybrid keys into the [`crate::envelope::KeyedPqTrustStore`] (#894).
+/// - [`resolve`](Self::resolve) — the **resolver path**: fetch the capsule bytes
+///   for `did` from the (untrusted) mainline locator (#890, Track C) and GATE-verify
+///   them. Used by this module's `did:at9p` arm to derive `PqHybrid` assurance.
+///
+/// The default impls return `Err` so a configuration that supplies only one path
+/// (admission today; the locator is not wired) leaves the other fail-closed rather
+/// than silently degrading.
+pub trait At9pCapsuleResolver: Send + Sync {
+    /// GATE-verify `capsule_bytes` the peer presented for `did:at9p:<cid512>`
+    /// (admission path). Pure over the bytes — no fetch, no I/O.
+    fn verify_bytes(&self, did: &str, capsule_bytes: &[u8]) -> Result<VerifiedAt9pKeys> {
+        let _ = (did, capsule_bytes);
+        Err(anyhow!("at9p capsule-byte verification is not configured (fail-closed)"))
+    }
+
+    /// Fetch the capsule for `did` from the untrusted locator and GATE-verify it
+    /// (resolver path). The locator itself is Track C (#890); until it is wired an
+    /// honest implementation returns `Err`.
+    fn resolve(&self, did: &str) -> Result<VerifiedAt9pKeys> {
+        let _ = did;
+        Err(anyhow!("at9p capsule resolution (locator fetch) is not configured (fail-closed)"))
+    }
+}
+
+/// The real, method-dispatched [`IdentityResolver`] (#579).
+///
+/// Generic over a [`DidDocumentProvider`] so the did:web fetch is injectable
+/// (fixture in tests, blocking HTTPS fetcher in production wiring). The optional
+/// [`At9pCapsuleResolver`] supplies the `did:at9p` arm (D2/#894); when `None` a
+/// `did:at9p` identity fails closed exactly as it did before the arm existed.
+pub struct MethodDispatchResolver<P: DidDocumentProvider> {
+    docs: P,
+    at9p: Option<Arc<dyn At9pCapsuleResolver>>,
+}
+
+impl<P: DidDocumentProvider> MethodDispatchResolver<P> {
+    /// Construct a resolver over a DID-document provider.
+    pub fn new(docs: P) -> Self {
+        Self { docs, at9p: None }
+    }
+
+    /// Attach the `did:at9p` capsule resolver (D2/#894). Without it a `did:at9p`
+    /// identity fails closed; with it, a GATE-verified capsule yields `PqHybrid`.
+    pub fn with_at9p(mut self, at9p: Arc<dyn At9pCapsuleResolver>) -> Self {
+        self.at9p = Some(at9p);
+        self
+    }
+
+    /// The did:web arm: resolve the document and derive key material + assurance.
+    ///
+    /// - Ed25519 VM present + ML-DSA-65 VM present ⇒ `PqHybrid`.
+    /// - Ed25519 VM present, no ML-DSA-65 VM ⇒ `Classical`.
+    /// - No Ed25519 VM ⇒ `Err` (fail-closed: nothing to anchor).
+    fn resolve_did_web(&self, did: &Did) -> Result<IdentityKeys> {
+        let doc = self
+            .docs
+            .document(did.as_str())
+            .map_err(|e| anyhow!("did:web {did} document did not resolve: {e}"))?;
+
+        // First Ed25519 VM is the classical anchor (the `#mesh` / `#iroh` key).
+        // A did:web with no Ed25519 VM cannot be bound (the PQ trust store is
+        // keyed BY the Ed25519 identity), so fail closed.
+        let ed25519 = verification_method_ed25519_keys(&doc).into_iter().next().ok_or_else(|| {
+            anyhow!("did:web {did}: no Ed25519 verificationMethod to anchor — fail-closed")
+        })?;
+
+        // A verified ML-DSA-65 VM (`#mesh-pq`) upgrades the edge to PqHybrid; its
+        // absence is the ordinary classical case, not an error.
+        let ml_dsa_65 = verification_method_ml_dsa_65_keys(&doc).into_iter().next();
+
+        let assurance =
+            if ml_dsa_65.is_some() { Assurance::PqHybrid } else { Assurance::Classical };
+
+        Ok(IdentityKeys { ed25519: Some(ed25519), ml_dsa_65, assurance })
+    }
+
+    /// The did:key arm: a single self-certifying Ed25519 key, no fetch.
+    ///
+    /// A `did:key` encodes exactly one key; a single classical key can never be
+    /// hybrid, so assurance is `Classical` (the honest ceiling).
+    fn resolve_did_key(&self, did: &Did) -> Result<IdentityKeys> {
+        let ed25519 = did_key_to_ed25519(did.as_str())
+            .map_err(|e| anyhow!("did:key {did} is not a valid Ed25519 identity: {e}"))?;
+        Ok(IdentityKeys {
+            ed25519: Some(ed25519),
+            ml_dsa_65: None,
+            assurance: Assurance::Classical,
+        })
+    }
+
+    /// The did:at9p arm (#894, D2): GATE-verify the capsule and derive `PqHybrid`.
+    ///
+    /// Delegates to the configured [`At9pCapsuleResolver`], which runs the A4
+    /// canon→hash→sig pipeline (#884). Only a verified capsule reaches here: both
+    /// the classical Ed25519 and the bound ML-DSA-65 keys come from
+    /// content-verified material, so the honest assurance ceiling is `PqHybrid`
+    /// (the classical→hybrid trust upgrade). Any GATE failure, and a missing
+    /// capsule resolver, fail closed.
+    fn resolve_did_at9p(&self, did: &Did) -> Result<IdentityKeys> {
+        let at9p = self.at9p.as_ref().ok_or_else(|| {
+            anyhow!("did:at9p {did}: no capsule resolver configured — fail-closed")
+        })?;
+        let verified = at9p
+            .resolve(did.as_str())
+            .map_err(|e| anyhow!("did:at9p {did}: capsule GATE failed: {e}"))?;
+        Ok(IdentityKeys {
+            ed25519: Some(verified.ed25519),
+            ml_dsa_65: Some(verified.ml_dsa_65),
+            assurance: Assurance::PqHybrid,
+        })
+    }
+}
+
+impl<P: DidDocumentProvider> IdentityResolver for MethodDispatchResolver<P> {
+    fn resolve_identity_keys(&self, did: &Did) -> Result<IdentityKeys> {
+        if did.is_did_web() {
+            self.resolve_did_web(did)
+        } else if did.is_did_key() {
+            self.resolve_did_key(did)
+        } else if did.is_did_at9p() {
+            self.resolve_did_at9p(did)
+        } else {
+            // Unknown DID method — fail closed (never a default-Unverified Ok).
+            Err(anyhow!("unsupported DID method for {did}: no resolver arm — fail-closed"))
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::crypto::pq::{ml_dsa_sk_to_vk_bytes, ml_dsa_generate_keypair, ml_dsa_vk_bytes};
+    use crate::did_key::{ed25519_to_did_key, MULTICODEC_ED25519_PUB, MULTICODEC_ML_DSA_65_PUB};
+    use ed25519_dalek::SigningKey;
+    use rand::rngs::OsRng;
+    use serde_json::json;
+
+    fn rand_ed25519() -> [u8; 32] {
+        SigningKey::generate(&mut OsRng).verifying_key().to_bytes()
+    }
+
+    fn encode_multikey(raw: &[u8], codec: [u8; 2]) -> String {
+        let mut payload = Vec::with_capacity(2 + raw.len());
+        payload.extend_from_slice(&codec);
+        payload.extend_from_slice(raw);
+        format!("z{}", bs58::encode(payload).into_string())
+    }
+
+    /// A DID document with an Ed25519 `#mesh` VM and, optionally, an ML-DSA-65
+    /// `#mesh-pq` VM.
+    fn did_doc(ed: &[u8; 32], ml_dsa_vk_bytes: Option<&[u8]>) -> Value {
+        let mut vms = vec![json!({
+            "id": "did:web:peer.example#mesh",
+            "type": "Multikey",
+            "controller": "did:web:peer.example",
+            "publicKeyMultibase": encode_multikey(ed, MULTICODEC_ED25519_PUB),
+        })];
+        if let Some(pq) = ml_dsa_vk_bytes {
+            vms.push(json!({
+                "id": "did:web:peer.example#mesh-pq",
+                "type": "Multikey",
+                "controller": "did:web:peer.example",
+                "publicKeyMultibase": encode_multikey(pq, MULTICODEC_ML_DSA_65_PUB),
+            }));
+        }
+        json!({
+            "@context": ["https://www.w3.org/ns/did/v1"],
+            "id": "did:web:peer.example",
+            "verificationMethod": vms,
+            "service": [],
+        })
+    }
+
+    /// Fixture provider returning a fixed document.
+    struct FixtureDocs(Value);
+    impl DidDocumentProvider for FixtureDocs {
+        fn document(&self, _did: &str) -> Result<Value> {
+            Ok(self.0.clone())
+        }
+    }
+
+    /// Provider that always fails — exercises the fail-closed fetch path.
+    struct FailingDocs;
+    impl DidDocumentProvider for FailingDocs {
+        fn document(&self, did: &str) -> Result<Value> {
+            Err(anyhow!("simulated fetch failure for {did}"))
+        }
+    }
+
+    /// A provider that MUST NOT be called (did:key / did:at9p never fetch).
+    struct NeverDocs;
+    impl DidDocumentProvider for NeverDocs {
+        fn document(&self, did: &str) -> Result<Value> {
+            panic!("resolver must not fetch a document for {did}");
+        }
+    }
+
+    const DID_WEB: &str = "did:web:peer.example";
+
+    #[test]
+    fn did_web_ed25519_only_is_classical() {
+        let ed = rand_ed25519();
+        let resolver = MethodDispatchResolver::new(FixtureDocs(did_doc(&ed, None)));
+        let keys = resolver
+            .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
+            .expect("ed25519-only did:web resolves");
+        assert_eq!(keys.assurance, Assurance::Classical);
+        assert_eq!(keys.ed25519, Some(ed));
+        assert!(keys.ml_dsa_65.is_none());
+    }
+
+    #[test]
+    fn did_web_with_ml_dsa_is_pqhybrid() {
+        let ed = rand_ed25519();
+        let (_sk, vk) = ml_dsa_generate_keypair();
+        let pq_bytes = ml_dsa_vk_bytes(&vk);
+        let resolver = MethodDispatchResolver::new(FixtureDocs(did_doc(&ed, Some(&pq_bytes))));
+        let keys = resolver
+            .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
+            .expect("hybrid did:web resolves");
+        assert_eq!(keys.assurance, Assurance::PqHybrid);
+        assert_eq!(keys.ed25519, Some(ed));
+        // The resolved PQ key is exactly the published one.
+        let resolved = keys.ml_dsa_65.expect("PQ anchor present");
+        assert_eq!(ml_dsa_vk_bytes(&resolved), pq_bytes);
+    }
+
+    #[test]
+    fn did_web_derives_pq_key_from_signing_key_roundtrip() {
+        // A mesh-derived ML-DSA key (as node_identity produces) round-trips
+        // through the VM extractor into a usable verifying key.
+        let ed = rand_ed25519();
+        let peer_ed = SigningKey::generate(&mut OsRng);
+        let peer_pq_sk = crate::node_identity::derive_mesh_mldsa_key(&peer_ed);
+        let pq_bytes = ml_dsa_sk_to_vk_bytes(&peer_pq_sk);
+        let resolver = MethodDispatchResolver::new(FixtureDocs(did_doc(&ed, Some(&pq_bytes))));
+        let keys = resolver
+            .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
+            .expect("hybrid did:web resolves");
+        assert_eq!(keys.assurance, Assurance::PqHybrid);
+        assert_eq!(ml_dsa_vk_bytes(&keys.ml_dsa_65.unwrap()), pq_bytes);
+    }
+
+    #[test]
+    fn did_web_no_ed25519_vm_fails_closed() {
+        // A doc with only an ML-DSA VM (no Ed25519 anchor) cannot be bound.
+        let (_sk, vk) = ml_dsa_generate_keypair();
+        let doc = json!({
+            "id": DID_WEB,
+            "verificationMethod": [{
+                "id": "did:web:peer.example#mesh-pq",
+                "publicKeyMultibase": encode_multikey(&ml_dsa_vk_bytes(&vk), MULTICODEC_ML_DSA_65_PUB),
+            }],
+        });
+        let resolver = MethodDispatchResolver::new(FixtureDocs(doc));
+        assert!(resolver.resolve_identity_keys(&Did::new(DID_WEB.to_owned())).is_err());
+    }
+
+    #[test]
+    fn did_web_empty_doc_fails_closed() {
+        let doc = json!({ "id": DID_WEB, "verificationMethod": [] });
+        let resolver = MethodDispatchResolver::new(FixtureDocs(doc));
+        assert!(resolver.resolve_identity_keys(&Did::new(DID_WEB.to_owned())).is_err());
+    }
+
+    #[test]
+    fn did_web_fetch_failure_fails_closed() {
+        let resolver = MethodDispatchResolver::new(FailingDocs);
+        assert!(resolver.resolve_identity_keys(&Did::new(DID_WEB.to_owned())).is_err());
+    }
+
+    #[test]
+    fn did_key_is_classical_without_fetch() {
+        let ed = rand_ed25519();
+        let did = ed25519_to_did_key(&ed);
+        let resolver = MethodDispatchResolver::new(NeverDocs);
+        let keys = resolver
+            .resolve_identity_keys(&Did::new(did))
+            .expect("did:key resolves without fetch");
+        assert_eq!(keys.assurance, Assurance::Classical);
+        assert_eq!(keys.ed25519, Some(ed));
+        assert!(keys.ml_dsa_65.is_none());
+    }
+
+    #[test]
+    fn did_key_malformed_fails_closed() {
+        let resolver = MethodDispatchResolver::new(NeverDocs);
+        let did = Did::new("did:key:zNotAValidEd25519Multikey".to_owned());
+        assert!(resolver.resolve_identity_keys(&did).is_err());
+    }
+
+    #[test]
+    fn did_at9p_arm_fails_closed_without_a_capsule_resolver() {
+        // No At9pCapsuleResolver configured ⇒ did:at9p fails closed (the arm
+        // exists but has nothing to verify against).
+        let resolver = MethodDispatchResolver::new(NeverDocs);
+        let did = Did::new("did:at9p:cid512abcdef".to_owned());
+        // `IdentityKeys` is not `Debug` (the ML-DSA key type isn't), so match on
+        // the result rather than `unwrap_err`.
+        match resolver.resolve_identity_keys(&did) {
+            Ok(_) => panic!("did:at9p must fail closed without a capsule resolver"),
+            Err(err) => {
+                assert!(
+                    err.to_string().contains("fail-closed"),
+                    "missing-resolver arm should fail closed: {err}"
+                );
+            }
+        }
+    }
+
+    // ── did:at9p arm (D2/#894) ───────────────────────────────────────────────
+
+    use super::{At9pCapsuleResolver, VerifiedAt9pKeys};
+    use parking_lot::Mutex;
+    use std::sync::Arc;
+
+    /// A capsule resolver that returns a fixed [`VerifiedAt9pKeys`] (the GATE is
+    /// abstracted in rpc; pds owns the real implementation). Records the calls it
+    /// received so tests can assert the arm routed through it.
+    struct FixtureCapsule {
+        keys: VerifiedAt9pKeys,
+        calls: Mutex<Vec<String>>,
+        fail: bool,
+    }
+
+    impl At9pCapsuleResolver for FixtureCapsule {
+        fn resolve(&self, did: &str) -> Result<VerifiedAt9pKeys> {
+            self.calls.lock().push(did.to_owned());
+            if self.fail {
+                Err(anyhow!("simulated GATE failure"))
+            } else {
+                Ok(self.keys.clone())
+            }
+        }
+    }
+
+    fn verified_keys() -> VerifiedAt9pKeys {
+        let (_sk, vk) = ml_dsa_generate_keypair();
+        VerifiedAt9pKeys { ed25519: [9u8; 32], ml_dsa_65: vk }
+    }
+
+    #[test]
+    fn did_at9p_with_verified_capsule_is_pqhybrid() {
+        // A GATE-verified capsule yields PqHybrid assurance, carrying the
+        // capsule's own Ed25519 + ML-DSA-65 keys (crypto-derived, not asserted).
+        let keys = verified_keys();
+        let fixture = Arc::new(FixtureCapsule { keys: keys.clone(), calls: Mutex::new(vec![]), fail: false });
+        let resolver = MethodDispatchResolver::new(NeverDocs).with_at9p(fixture.clone());
+        let did = Did::new("did:at9p:cid512abcdef".to_owned());
+        let resolved = resolver
+            .resolve_identity_keys(&did)
+            .expect("verified capsule resolves at PqHybrid");
+        assert_eq!(resolved.assurance, Assurance::PqHybrid);
+        assert_eq!(resolved.ed25519, Some(keys.ed25519));
+        assert_eq!(ml_dsa_vk_bytes(&resolved.ml_dsa_65.unwrap()), ml_dsa_vk_bytes(&keys.ml_dsa_65));
+        // The arm routed through the capsule resolver exactly once.
+        assert_eq!(fixture.calls.lock().as_slice(), &["did:at9p:cid512abcdef"]);
+    }
+
+    #[test]
+    fn did_at9p_gate_failure_fails_closed() {
+        // A capsule that fails the GATE (bad sig / wrong cid) is rejected — no
+        // default assurance, no Ok.
+        let fixture = Arc::new(FixtureCapsule {
+            keys: verified_keys(),
+            calls: Mutex::new(vec![]),
+            fail: true,
+        });
+        let resolver = MethodDispatchResolver::new(NeverDocs).with_at9p(fixture);
+        let did = Did::new("did:at9p:cid512abcdef".to_owned());
+        assert!(resolver.resolve_identity_keys(&did).is_err());
+    }
+
+    #[test]
+    fn did_at9p_assurance_is_not_asserted_by_other_arms() {
+        // The did:web and did:key arms must never produce PqHybrid from a path
+        // text or hint — only the verified-capsule arm does. (Provenance: a
+        // did:web with no PQ VM is Classical, regardless of any at9p resolver.)
+        let fixture = Arc::new(FixtureCapsule {
+            keys: verified_keys(),
+            calls: Mutex::new(vec![]),
+            fail: false,
+        });
+        let ed = rand_ed25519();
+        let resolver = MethodDispatchResolver::new(FixtureDocs(did_doc(&ed, None))).with_at9p(fixture);
+        let keys = resolver
+            .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
+            .expect("did:web resolves");
+        assert_eq!(keys.assurance, Assurance::Classical);
+    }
+
+    #[test]
+    fn unknown_method_fails_closed() {
+        let resolver = MethodDispatchResolver::new(NeverDocs);
+        let did = Did::new("did:plc:unsupported".to_owned());
+        assert!(resolver.resolve_identity_keys(&did).is_err());
+    }
+}

--- a/crates/hyprstream-rpc/src/identity_resolver.rs
+++ b/crates/hyprstream-rpc/src/identity_resolver.rs
@@ -1,0 +1,330 @@
+//! Method-dispatched [`IdentityResolver`] — the real `Did → IdentityKeys` binding (#579).
+//!
+//! This is the single, non-mirror implementation of the canonical
+//! [`crate::identity::IdentityResolver`] contract. It replaces the fixture /
+//! test-double resolvers that stood in for it while the #549 perimeter gateway
+//! and #137 admission gate were built against the interface.
+//!
+//! # Division of labor
+//!
+//! The resolver owns **verification + assurance derivation**; it does *not* own
+//! object labelling, the `KeyedPqTrustStore.bind` mesh anchor (#894), or any
+//! perimeter policy — those consumers are generic over the trait and unchanged.
+//!
+//! # Method dispatch
+//!
+//! [`resolve_identity_keys`](IdentityResolver::resolve_identity_keys) branches on
+//! the DID method:
+//!
+//! - **`did:web`** — resolve the DID document and extract its verification
+//!   methods. An Ed25519 VM (`#mesh` / `#iroh`) is the classical anchor; a
+//!   verified ML-DSA-65 VM (`#mesh-pq`, multicodec `0x1211`) is the PQ anchor.
+//!   Both present ⇒ [`Assurance::PqHybrid`] (a did:web we operate); Ed25519-only ⇒
+//!   [`Assurance::Classical`] (a third-party did:web). No Ed25519 VM ⇒ nothing to
+//!   bind ⇒ `Err` (fail-closed).
+//! - **`did:key`** — a single Ed25519 key decoded from the DID string itself; no
+//!   fetch. A single classical key can never be hybrid, so the honest ceiling is
+//!   [`Assurance::Classical`].
+//! - **`did:at9p`** — reserved for the capsule GATE pipeline (#879/#880 D2). This
+//!   resolver does **not** verify capsules; the arm returns `Err` (fail-closed)
+//!   with a clear TODO(#894) marker until that epic fills it.
+//! - **any other method** — `Err` (fail-closed).
+//!
+//! # Fail-closed
+//!
+//! Per the [`IdentityResolver`] contract, every inability to establish key
+//! material — an unknown method, a fetch failure, a malformed document, a
+//! did:web with no Ed25519 VM — returns `Err`. A resolver **never** returns a
+//! default-`Unverified` `Ok`.
+//!
+//! # Sync trait over an async fetch
+//!
+//! The contract is synchronous and enrollment happens **off the auth path**
+//! (once, at session establishment), so did:web document retrieval is abstracted
+//! behind a synchronous [`DidDocumentProvider`]. This keeps the decode +
+//! assurance-derivation core pure and testable with an injected fixture (no live
+//! network), mirroring the injected-fetcher pattern in [`crate::did_web`]. The
+//! async→sync bridge to the live [`crate::did_web::HttpDidDocFetcher`] is a
+//! wiring concern for the accept-path integration (there is no production
+//! construction site of the perimeter gateway today).
+
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+
+use crate::auth::mac::Assurance;
+use crate::did_web::{
+    did_key_to_ed25519, verification_method_ed25519_keys, verification_method_ml_dsa_65_keys,
+};
+use crate::identity::{Did, IdentityKeys, IdentityResolver};
+
+/// A synchronous DID-document provider for the did:web arm.
+///
+/// Abstracted so the resolver's decode/assurance core is testable with an
+/// injected fixture (no network). Enrollment is off the auth path, so a blocking
+/// implementation is acceptable; the trait keeps that policy out of the resolver.
+pub trait DidDocumentProvider: Send + Sync {
+    /// Fetch and parse the DID document for `did` (already known to be `did:web`).
+    fn document(&self, did: &str) -> Result<Value>;
+}
+
+/// The real, method-dispatched [`IdentityResolver`] (#579).
+///
+/// Generic over a [`DidDocumentProvider`] so the did:web fetch is injectable
+/// (fixture in tests, blocking HTTPS fetcher in production wiring).
+pub struct MethodDispatchResolver<P: DidDocumentProvider> {
+    docs: P,
+}
+
+impl<P: DidDocumentProvider> MethodDispatchResolver<P> {
+    /// Construct a resolver over a DID-document provider.
+    pub fn new(docs: P) -> Self {
+        Self { docs }
+    }
+
+    /// The did:web arm: resolve the document and derive key material + assurance.
+    ///
+    /// - Ed25519 VM present + ML-DSA-65 VM present ⇒ `PqHybrid`.
+    /// - Ed25519 VM present, no ML-DSA-65 VM ⇒ `Classical`.
+    /// - No Ed25519 VM ⇒ `Err` (fail-closed: nothing to anchor).
+    fn resolve_did_web(&self, did: &Did) -> Result<IdentityKeys> {
+        let doc = self
+            .docs
+            .document(did.as_str())
+            .map_err(|e| anyhow!("did:web {did} document did not resolve: {e}"))?;
+
+        // First Ed25519 VM is the classical anchor (the `#mesh` / `#iroh` key).
+        // A did:web with no Ed25519 VM cannot be bound (the PQ trust store is
+        // keyed BY the Ed25519 identity), so fail closed.
+        let ed25519 = verification_method_ed25519_keys(&doc).into_iter().next().ok_or_else(|| {
+            anyhow!("did:web {did}: no Ed25519 verificationMethod to anchor — fail-closed")
+        })?;
+
+        // A verified ML-DSA-65 VM (`#mesh-pq`) upgrades the edge to PqHybrid; its
+        // absence is the ordinary classical case, not an error.
+        let ml_dsa_65 = verification_method_ml_dsa_65_keys(&doc).into_iter().next();
+
+        let assurance =
+            if ml_dsa_65.is_some() { Assurance::PqHybrid } else { Assurance::Classical };
+
+        Ok(IdentityKeys { ed25519: Some(ed25519), ml_dsa_65, assurance })
+    }
+
+    /// The did:key arm: a single self-certifying Ed25519 key, no fetch.
+    ///
+    /// A `did:key` encodes exactly one key; a single classical key can never be
+    /// hybrid, so assurance is `Classical` (the honest ceiling).
+    fn resolve_did_key(&self, did: &Did) -> Result<IdentityKeys> {
+        let ed25519 = did_key_to_ed25519(did.as_str())
+            .map_err(|e| anyhow!("did:key {did} is not a valid Ed25519 identity: {e}"))?;
+        Ok(IdentityKeys {
+            ed25519: Some(ed25519),
+            ml_dsa_65: None,
+            assurance: Assurance::Classical,
+        })
+    }
+}
+
+impl<P: DidDocumentProvider> IdentityResolver for MethodDispatchResolver<P> {
+    fn resolve_identity_keys(&self, did: &Did) -> Result<IdentityKeys> {
+        if did.is_did_web() {
+            self.resolve_did_web(did)
+        } else if did.is_did_key() {
+            self.resolve_did_key(did)
+        } else if did.is_did_at9p() {
+            // Reserved for the capsule GATE pipeline (#879/#880 D2). This
+            // resolver does not verify capsules; fail closed until #894 fills it.
+            Err(anyhow!(
+                "did:at9p {did}: capsule verification is not implemented here — reserved for #894 (fail-closed)"
+            ))
+        } else {
+            // Unknown DID method — fail closed (never a default-Unverified Ok).
+            Err(anyhow!("unsupported DID method for {did}: no resolver arm — fail-closed"))
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::crypto::pq::{ml_dsa_sk_to_vk_bytes, ml_dsa_generate_keypair, ml_dsa_vk_bytes};
+    use crate::did_key::{ed25519_to_did_key, MULTICODEC_ED25519_PUB, MULTICODEC_ML_DSA_65_PUB};
+    use ed25519_dalek::SigningKey;
+    use rand::rngs::OsRng;
+    use serde_json::json;
+
+    fn rand_ed25519() -> [u8; 32] {
+        SigningKey::generate(&mut OsRng).verifying_key().to_bytes()
+    }
+
+    fn encode_multikey(raw: &[u8], codec: [u8; 2]) -> String {
+        let mut payload = Vec::with_capacity(2 + raw.len());
+        payload.extend_from_slice(&codec);
+        payload.extend_from_slice(raw);
+        format!("z{}", bs58::encode(payload).into_string())
+    }
+
+    /// A DID document with an Ed25519 `#mesh` VM and, optionally, an ML-DSA-65
+    /// `#mesh-pq` VM.
+    fn did_doc(ed: &[u8; 32], ml_dsa_vk_bytes: Option<&[u8]>) -> Value {
+        let mut vms = vec![json!({
+            "id": "did:web:peer.example#mesh",
+            "type": "Multikey",
+            "controller": "did:web:peer.example",
+            "publicKeyMultibase": encode_multikey(ed, MULTICODEC_ED25519_PUB),
+        })];
+        if let Some(pq) = ml_dsa_vk_bytes {
+            vms.push(json!({
+                "id": "did:web:peer.example#mesh-pq",
+                "type": "Multikey",
+                "controller": "did:web:peer.example",
+                "publicKeyMultibase": encode_multikey(pq, MULTICODEC_ML_DSA_65_PUB),
+            }));
+        }
+        json!({
+            "@context": ["https://www.w3.org/ns/did/v1"],
+            "id": "did:web:peer.example",
+            "verificationMethod": vms,
+            "service": [],
+        })
+    }
+
+    /// Fixture provider returning a fixed document.
+    struct FixtureDocs(Value);
+    impl DidDocumentProvider for FixtureDocs {
+        fn document(&self, _did: &str) -> Result<Value> {
+            Ok(self.0.clone())
+        }
+    }
+
+    /// Provider that always fails — exercises the fail-closed fetch path.
+    struct FailingDocs;
+    impl DidDocumentProvider for FailingDocs {
+        fn document(&self, did: &str) -> Result<Value> {
+            Err(anyhow!("simulated fetch failure for {did}"))
+        }
+    }
+
+    /// A provider that MUST NOT be called (did:key / did:at9p never fetch).
+    struct NeverDocs;
+    impl DidDocumentProvider for NeverDocs {
+        fn document(&self, did: &str) -> Result<Value> {
+            panic!("resolver must not fetch a document for {did}");
+        }
+    }
+
+    const DID_WEB: &str = "did:web:peer.example";
+
+    #[test]
+    fn did_web_ed25519_only_is_classical() {
+        let ed = rand_ed25519();
+        let resolver = MethodDispatchResolver::new(FixtureDocs(did_doc(&ed, None)));
+        let keys = resolver
+            .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
+            .expect("ed25519-only did:web resolves");
+        assert_eq!(keys.assurance, Assurance::Classical);
+        assert_eq!(keys.ed25519, Some(ed));
+        assert!(keys.ml_dsa_65.is_none());
+    }
+
+    #[test]
+    fn did_web_with_ml_dsa_is_pqhybrid() {
+        let ed = rand_ed25519();
+        let (_sk, vk) = ml_dsa_generate_keypair();
+        let pq_bytes = ml_dsa_vk_bytes(&vk);
+        let resolver = MethodDispatchResolver::new(FixtureDocs(did_doc(&ed, Some(&pq_bytes))));
+        let keys = resolver
+            .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
+            .expect("hybrid did:web resolves");
+        assert_eq!(keys.assurance, Assurance::PqHybrid);
+        assert_eq!(keys.ed25519, Some(ed));
+        // The resolved PQ key is exactly the published one.
+        let resolved = keys.ml_dsa_65.expect("PQ anchor present");
+        assert_eq!(ml_dsa_vk_bytes(&resolved), pq_bytes);
+    }
+
+    #[test]
+    fn did_web_derives_pq_key_from_signing_key_roundtrip() {
+        // A mesh-derived ML-DSA key (as node_identity produces) round-trips
+        // through the VM extractor into a usable verifying key.
+        let ed = rand_ed25519();
+        let peer_ed = SigningKey::generate(&mut OsRng);
+        let peer_pq_sk = crate::node_identity::derive_mesh_mldsa_key(&peer_ed);
+        let pq_bytes = ml_dsa_sk_to_vk_bytes(&peer_pq_sk);
+        let resolver = MethodDispatchResolver::new(FixtureDocs(did_doc(&ed, Some(&pq_bytes))));
+        let keys = resolver
+            .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
+            .expect("hybrid did:web resolves");
+        assert_eq!(keys.assurance, Assurance::PqHybrid);
+        assert_eq!(ml_dsa_vk_bytes(&keys.ml_dsa_65.unwrap()), pq_bytes);
+    }
+
+    #[test]
+    fn did_web_no_ed25519_vm_fails_closed() {
+        // A doc with only an ML-DSA VM (no Ed25519 anchor) cannot be bound.
+        let (_sk, vk) = ml_dsa_generate_keypair();
+        let doc = json!({
+            "id": DID_WEB,
+            "verificationMethod": [{
+                "id": "did:web:peer.example#mesh-pq",
+                "publicKeyMultibase": encode_multikey(&ml_dsa_vk_bytes(&vk), MULTICODEC_ML_DSA_65_PUB),
+            }],
+        });
+        let resolver = MethodDispatchResolver::new(FixtureDocs(doc));
+        assert!(resolver.resolve_identity_keys(&Did::new(DID_WEB.to_owned())).is_err());
+    }
+
+    #[test]
+    fn did_web_empty_doc_fails_closed() {
+        let doc = json!({ "id": DID_WEB, "verificationMethod": [] });
+        let resolver = MethodDispatchResolver::new(FixtureDocs(doc));
+        assert!(resolver.resolve_identity_keys(&Did::new(DID_WEB.to_owned())).is_err());
+    }
+
+    #[test]
+    fn did_web_fetch_failure_fails_closed() {
+        let resolver = MethodDispatchResolver::new(FailingDocs);
+        assert!(resolver.resolve_identity_keys(&Did::new(DID_WEB.to_owned())).is_err());
+    }
+
+    #[test]
+    fn did_key_is_classical_without_fetch() {
+        let ed = rand_ed25519();
+        let did = ed25519_to_did_key(&ed);
+        let resolver = MethodDispatchResolver::new(NeverDocs);
+        let keys = resolver
+            .resolve_identity_keys(&Did::new(did))
+            .expect("did:key resolves without fetch");
+        assert_eq!(keys.assurance, Assurance::Classical);
+        assert_eq!(keys.ed25519, Some(ed));
+        assert!(keys.ml_dsa_65.is_none());
+    }
+
+    #[test]
+    fn did_key_malformed_fails_closed() {
+        let resolver = MethodDispatchResolver::new(NeverDocs);
+        let did = Did::new("did:key:zNotAValidEd25519Multikey".to_owned());
+        assert!(resolver.resolve_identity_keys(&did).is_err());
+    }
+
+    #[test]
+    fn did_at9p_arm_is_reserved_and_fails_closed() {
+        let resolver = MethodDispatchResolver::new(NeverDocs);
+        let did = Did::new("did:at9p:cid512abcdef".to_owned());
+        // `IdentityKeys` is not `Debug` (the ML-DSA key type isn't), so match on
+        // the result rather than `unwrap_err`.
+        match resolver.resolve_identity_keys(&did) {
+            Ok(_) => panic!("did:at9p must fail closed (reserved for #894)"),
+            Err(err) => {
+                assert!(err.to_string().contains("#894"), "reserved arm should point at #894: {err}");
+            }
+        }
+    }
+
+    #[test]
+    fn unknown_method_fails_closed() {
+        let resolver = MethodDispatchResolver::new(NeverDocs);
+        let did = Did::new("did:plc:unsupported".to_owned());
+        assert!(resolver.resolve_identity_keys(&did).is_err());
+    }
+}

--- a/crates/hyprstream-rpc/src/lib.rs
+++ b/crates/hyprstream-rpc/src/lib.rs
@@ -180,6 +180,10 @@ pub use hyprstream_crypto::did_key;
 pub mod did_web;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod admission;
+// The real, method-dispatched `IdentityResolver` (#579). Native-only: the
+// did:web arm depends on `did_web`'s DID-document helpers.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod identity_resolver;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod notify;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/hyprstream-rpc/src/lib.rs
+++ b/crates/hyprstream-rpc/src/lib.rs
@@ -178,6 +178,10 @@ pub mod did_key;
 pub mod did_web;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod admission;
+// The real, method-dispatched `IdentityResolver` (#579). Native-only: the
+// did:web arm depends on `did_web`'s DID-document helpers.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod identity_resolver;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod notify;
 #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
Closes #894, part of #880; the classical→hybrid trust upgrade, binds from GATE-verified capsule.

## What

A `did:at9p` peer is self-certifying — the identity *is* the BLAKE3-512 hash of its genesis capsule, and the A4 GATE pipeline (#884, canon→hash→sig) proves the capsule's `ed25519 → ml_dsa_65` binding. So, parallel to the `is_did_key` arm, admitting a `did:at9p` peer needs **no DID-doc fetch and no out-of-band `mesh_peers` config trust**: the verified capsule *is* the binding material. This PR installs that binding straight from the capsule — at9p's role as a **producer** of #579's `ed25519→ml_dsa_65` binding contract, and the provenance boundary where `PqHybrid` assurance is created from verified material (not a caller/path/metadata assertion).

## How

**`admit_key_against_did` did:at9p arm** (`hyprstream-rpc/src/admission.rs`):
1. GATE-verify the peer-presented capsule bytes via `At9pCapsuleResolver::verify_bytes`;
2. admit iff the peer's authenticated channel key equals the capsule's Ed25519 subject key (one trust root — #185 closed by construction);
3. bind the verified `ed25519 → ml_dsa_65` pair into `KeyedPqTrustStore`.

Fail-closed: GATE failure (bad sig / wrong cid), channel-key mismatch, or a missing admission context all reject and **bind nothing** (no classical downgrade). `FederationAdmissionGate::admit` passes `None` for the at9p context (the live mesh accept path is not wired beyond this arm); the public 4-arg `admit` and the `is_did_key`/`did:web` arms are unchanged.

**The seam** (`hyprstream-rpc/src/identity_resolver.rs`): the A4 GATE lives in `hyprstream-pds` (which depends on rpc, so the dependency does not reverse). A new object-safe `At9pCapsuleResolver` trait + `VerifiedAt9pKeys` bridge the GATE into the lower rpc crate, with two entry points — `verify_bytes` (admission: presented bytes) and `resolve` (resolver: locator fetch) — defaulting to `Err` so unwired paths fail closed. `MethodDispatchResolver`'s `did:at9p` arm (previously the reserved `Err` citing #894) now delegates to a configured resolver and yields `PqHybrid` from the verified capsule; without one it still fails closed.

**The producer** (`hyprstream-pds/src/at9p_resolver.rs`): `At9pGateResolver` — the real `At9pCapsuleResolver` impl over `at9p_gate::verify_did_at9p`, re-expressing the verified capsule's primary subject keys in rpc-local types. `resolve()` (mainline locator, Track C / #890) returns `Err` until wired; `verify_bytes()` is live.

## Provenance (MAC review, #894/#877/#834)

Assurance is crypto-derived by the resolver/admission from the verified capsule, never a caller/path/label/metadata assertion (ratified MAC interface policy, D1/R5). did:web and did:key arms never produce `PqHybrid`; only the verified-capsule arm does.

## Building blocks

Brings in the #914 seam (`identity_resolver.rs` / `MethodDispatchResolver` / `Did::is_did_at9p`) by merging `ewindisch/579-resolver-contract`, since this arm integrates with that method-dispatched resolver. The at9p GATE (#951) is already on `main`.

## Tests

- **rpc** (`admission`): valid capsule → GATE passes → `ed25519→ml_dsa_65` bound in the store + admitted; GATE failure / channel-key mismatch / missing context → reject and bind nothing; resolver arm yields `PqHybrid` from a verified capsule and fails closed on GATE error; other arms never assert `PqHybrid`.
- **pds** (`at9p_resolver`): real self-signed capsule → GATE passes → verified subject keys; tampered sig / wrong cid → rejected; end-to-end admission binds the capsule's PQ key into `KeyedPqTrustStore` from an empty store (binding comes from the capsule, not config).

`cargo test -p hyprstream-rpc -p hyprstream-pds` and `cargo clippy --workspace --all-targets --release -- -D warnings` both clean under the pinned 1.97 toolchain.

## Out of scope

Does not wire the full mesh admission flow beyond this arm, and does not remove the `is_did_key`/`did:web` arms. The mainline locator fetch (`resolve`, #890) is left returning `Err`.