### PR TITLE
feat(cas) L1: unified CAS substrate — multihash + dedup domains (#812)

### DIFF
--- a/crates/hyprstream/src/storage/cas/domain.rs
+++ b/crates/hyprstream/src/storage/cas/domain.rs
@@ -43,11 +43,23 @@ impl TrustBoundary {
 ///   or enforces MAC policy from it.
 /// - `algorithm` — the multihash algorithm; SHA-1 content is never deduplicated
 ///   against SHA-256 (the pair would lean on the weaker collision resistance).
+/// - `digest_length` — the multihash digest length in bytes. **Length is part of
+///   CID identity** (the multihash carries `uvarint(len)`), so it is part of the
+///   dedup key too: BLAKE3 is an XOF and `BLAKE3-512(x)[0:32] == BLAKE3-256(x)`,
+///   so a 256-bit and a 512-bit domain over the *same* content would alias if the
+///   length were dropped from the key. Two widths get distinct storage roots
+///   (#812/#881 joint decision).
 /// - `trust_boundary` — see [`TrustBoundary`].
+///
+/// The `(algorithm, digest_length)` pair is validated against
+/// [`HashAlgo::validate_digest_len`] by [`DedupDomain::new`]; the fields stay
+/// `pub` so struct-literal construction with `..DedupDomain::local_default()`
+/// remains ergonomic, but callers that vary the algorithm/length should go through
+/// [`DedupDomain::new`] to keep the pair well-formed.
 ///
 /// # On-disk mapping
 ///
-/// The **default** domain `(None, Blake3, Local)` maps to the substrate root
+/// The **default** domain `(None, Blake3, 32, Local)` maps to the substrate root
 /// itself (no sub-directory), so the legacy `cas_serve::CasStore` layout and every
 /// existing caller keep working byte-for-byte. Every other domain maps to a
 /// deterministic, injective sub-path so distinct domains never collide.
@@ -57,6 +69,9 @@ pub struct DedupDomain {
     pub compartment: Option<Compartment>,
     /// Multihash algorithm partition.
     pub algorithm: HashAlgo,
+    /// Multihash digest length in bytes (part of the CID identity). Must be a
+    /// length the `algorithm` accepts (see [`HashAlgo::validate_digest_len`]).
+    pub digest_length: u16,
     /// Storage layer / trust boundary partition.
     pub trust_boundary: TrustBoundary,
 }
@@ -69,6 +84,7 @@ impl DedupDomain {
         Self {
             compartment: None,
             algorithm: HashAlgo::Blake3,
+            digest_length: 32,
             trust_boundary: TrustBoundary::Local,
         }
     }
@@ -78,14 +94,43 @@ impl DedupDomain {
         Self {
             compartment: Some(compartment),
             algorithm: HashAlgo::Blake3,
+            digest_length: 32,
             trust_boundary: TrustBoundary::Local,
         }
+    }
+
+    /// Construct a domain, validating that `(algorithm, digest_length)` is a
+    /// well-formed multihash pair (the length is one the algorithm accepts).
+    ///
+    /// This is the constructor to use when varying the algorithm or width; the
+    /// compartment/trust-boundary default to untenanted/local. Prefer
+    /// [`local_default`](Self::local_default) /
+    /// [`local_tenant`](Self::local_tenant) for the common BLAKE3-256 cases.
+    pub fn new(
+        algorithm: HashAlgo,
+        digest_length: u16,
+        compartment: Option<Compartment>,
+        trust_boundary: TrustBoundary,
+    ) -> Result<Self, InvalidDedupDomain> {
+        if algorithm.validate_digest_len(digest_length as usize).is_err() {
+            return Err(InvalidDedupDomain {
+                algorithm,
+                digest_length,
+            });
+        }
+        Ok(Self {
+            compartment,
+            algorithm,
+            digest_length,
+            trust_boundary,
+        })
     }
 
     /// True for the default domain (root-mapped, legacy-compatible).
     pub fn is_default(&self) -> bool {
         self.compartment.is_none()
             && self.algorithm == HashAlgo::Blake3
+            && self.digest_length == 32
             && self.trust_boundary == TrustBoundary::Local
     }
 
@@ -93,11 +138,14 @@ impl DedupDomain {
     ///
     /// - Default domain → empty (the root itself), preserving the legacy layout.
     /// - Otherwise →
-    ///   `domains/<boundary>/algo-<code>/c-<hex(compartment)|none>/`.
+    ///   `domains/<boundary>/algo-<code>-len<N>/c-<hex(compartment)|none>/`.
     ///
-    /// The compartment name is hex-encoded so the mapping is injective and
-    /// path-safe regardless of the characters a compartment name contains (e.g.
-    /// the `:` in `"tenant:acme"`), and can never traverse out of the root.
+    /// The `algo-<code>-len<N>` segment encodes **both** the algorithm code and
+    /// the digest length, so two widths of the same algorithm (BLAKE3-256 vs
+    /// BLAKE3-512) map to distinct sub-roots and cannot share xorbs. The
+    /// compartment name is hex-encoded so the mapping is injective and path-safe
+    /// regardless of the characters a compartment name contains (e.g. the `:` in
+    /// `"tenant:acme"`), and can never traverse out of the root.
     pub fn relative_path(&self) -> PathBuf {
         if self.is_default() {
             return PathBuf::new();
@@ -108,9 +156,21 @@ impl DedupDomain {
         };
         PathBuf::from("domains")
             .join(self.trust_boundary.token())
-            .join(format!("algo-{:#x}", self.algorithm as u64))
+            .join(format!(
+                "algo-{:#x}-len{}",
+                self.algorithm as u64, self.digest_length
+            ))
             .join(compartment)
     }
+}
+
+/// Error returned by [`DedupDomain::new`] when the `(algorithm, digest_length)`
+/// pair is not a well-formed multihash pair (e.g. sha1/32, blake3/48).
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("invalid dedup domain: algorithm {algorithm:?} does not accept digest length {digest_length}")]
+pub struct InvalidDedupDomain {
+    pub algorithm: HashAlgo,
+    pub digest_length: u16,
 }
 
 #[cfg(test)]
@@ -132,6 +192,7 @@ mod tests {
         let base = DedupDomain::local_default();
         let other_algo = DedupDomain {
             algorithm: HashAlgo::Sha2_256,
+            digest_length: 32,
             ..DedupDomain::local_default()
         };
         let other_boundary = DedupDomain {
@@ -154,6 +215,50 @@ mod tests {
                 assert_ne!(paths[i], paths[j], "domains {i} and {j} collide on disk");
             }
         }
+    }
+
+    #[test]
+    fn blake3_256_and_512_widths_do_not_alias() {
+        // The #812/#881 joint-decision guarantee: BLAKE3 is an XOF and
+        // BLAKE3-512(x)[0:32] == BLAKE3-256(x), so the two widths MUST get
+        // distinct storage roots or a 512-bit address would dedup against — and
+        // leak the existence of — its 256-bit prefix domain.
+        //
+        // Use a tenant compartment so *neither* domain collapses to the default
+        // root (Blake3/32/None/Local); we want to compare two real sub-paths and
+        // see the length encoded in each.
+        let tenant = Some(Compartment::new("tenant:acme"));
+        let w256 = DedupDomain::new(HashAlgo::Blake3, 32, tenant.clone(), TrustBoundary::Local)
+            .unwrap();
+        let w512 = DedupDomain::new(HashAlgo::Blake3, 64, tenant, TrustBoundary::Local).unwrap();
+        let p256 = w256.relative_path();
+        let p512 = w512.relative_path();
+        assert_ne!(
+            p256, p512,
+            "BLAKE3-256 and BLAKE3-512 domains must not share a storage root"
+        );
+        // The path must encode the length so the distinction is self-describing.
+        assert!(
+            p256.to_string_lossy().contains("len32"),
+            "256-bit domain path must carry len32: {p256:?}"
+        );
+        assert!(
+            p512.to_string_lossy().contains("len64"),
+            "512-bit domain path must carry len64: {p512:?}"
+        );
+    }
+
+    #[test]
+    fn new_rejects_malformed_algo_length_pair() {
+        // sha1 only accepts 20 bytes; 32 is not a valid sha1 multihash.
+        let err = DedupDomain::new(HashAlgo::Sha1, 32, None, TrustBoundary::Local).unwrap_err();
+        assert_eq!(err.algorithm, HashAlgo::Sha1);
+        assert_eq!(err.digest_length, 32);
+        // blake3 accepts 32 or 64, not 48.
+        assert!(DedupDomain::new(HashAlgo::Blake3, 48, None, TrustBoundary::Local).is_err());
+        // Valid pairs construct fine.
+        assert!(DedupDomain::new(HashAlgo::Blake3, 64, None, TrustBoundary::Local).is_ok());
+        assert!(DedupDomain::new(HashAlgo::Sha2_256, 32, None, TrustBoundary::Local).is_ok());
     }
 
     #[test]

--- a/crates/hyprstream/src/storage/cas/mod.rs
+++ b/crates/hyprstream/src/storage/cas/mod.rs
@@ -3,8 +3,8 @@
 //! One content-addressed store under everything. Every artifact is addressed by a
 //! self-describing **multihash** ([`hyprstream_rpc::cid`]), and every ingest is
 //! partitioned into a **dedup domain** keyed `(compartment, algorithm,
-//! trust_boundary)` so content is only ever deduplicated against other content in
-//! the *same* domain.
+//! digest_length, trust_boundary)` so content is only ever deduplicated against
+//! other content in the *same* domain.
 //!
 //! ## What this layer is
 //!
@@ -32,6 +32,10 @@
 //!   (READ-only here — the substrate never authors or enforces MAC policy).
 //! - **algorithm** — SHA-1 content is never deduplicated against SHA-256; the pair
 //!   would lean on the weaker collision resistance.
+//! - **digest_length** — length is part of multihash/CID identity, so it is part of
+//!   the dedup key: BLAKE3 is an XOF and `BLAKE3-512(x)[0:32] == BLAKE3-256(x)`,
+//!   so the two widths must not share a storage root (#812/#881 joint decision).
+//!   Ingest is BLAKE3-256 today; a 512-bit width lands as its own root in #881.
 //! - **trust_boundary** — node-local content is never deduplicated against
 //!   shared-remote content (an existence/content oracle across the boundary, U5).
 //!
@@ -48,7 +52,7 @@ mod manifest;
 mod mount;
 mod substrate;
 
-pub use domain::{DedupDomain, TrustBoundary};
+pub use domain::{DedupDomain, InvalidDedupDomain, TrustBoundary};
 pub use manifest::{BlobManifest, FILE_RECONSTRUCTION_CODEC, cid_from_merkle, merkle_from_address};
 pub use mount::{
     AllowAllCasAuthorizer, CasMount, CasMountAuthorizer, CasMountAuthzRequest, CasMountObjectKind,

--- a/crates/hyprstream/src/storage/cas/substrate.rs
+++ b/crates/hyprstream/src/storage/cas/substrate.rs
@@ -16,6 +16,11 @@ use super::domain::DedupDomain;
 use super::manifest::{cid_from_merkle, merkle_from_address, BlobManifest};
 use super::CasError;
 
+/// Hex-character length of a `digest_length`-byte digest (2 hex chars per byte).
+const fn hex_digest_len(digest_length: u16) -> usize {
+    digest_length as usize * 2
+}
+
 /// The L1 unified content-addressed store.
 ///
 /// A thin, domain-partitioning facade over `cas_serve::CasStore`. Construct once
@@ -52,21 +57,33 @@ impl CasSubstrate {
     /// boundaries stay identical to xet-core. The substrate adds the canonical
     /// multihash CID and attaches the `security_label` carrier (plumb-through only).
     ///
-    /// Only BLAKE3-256 ingest is implemented today (the merkle the store computes
-    /// is BLAKE3-based); a non-BLAKE3 domain is rejected rather than mislabeled
-    /// with a CID that claims the wrong algorithm. The domain still *keys* every
-    /// algorithm so future non-BLAKE3 content never dedups against BLAKE3 content.
+    /// Only **BLAKE3-256** ingest is implemented today: the merkle the store
+    /// computes is the 32-byte BLAKE3 reconstruction hash, so the domain must
+    /// declare `(Blake3, digest_length = 32)`. Any other `(algorithm, length)`
+    /// pair is rejected rather than mislabeled with a CID that claims the wrong
+    /// algorithm/width. The domain vocabulary still *keys* every algorithm and
+    /// width (see [`DedupDomain`]) so future non-BLAKE3 / wider ingest (e.g. the
+    /// BLAKE3-512 at9p capsule path, #881) never dedups against BLAKE3-256 content
+    /// — it lands as a distinct, length-partitioned storage root.
     pub async fn put(
         &self,
         domain: &DedupDomain,
         data: &[u8],
         security_label: Option<SecurityLabel>,
     ) -> Result<BlobManifest, CasError> {
-        if domain.algorithm != HashAlgo::Blake3 {
+        if domain.algorithm != HashAlgo::Blake3 || domain.digest_length != 32 {
             return Err(CasError::UnsupportedIngestAlgorithm(domain.algorithm));
         }
         let store = self.store_for(domain);
         let put = store.put_file_bytes(data).await?;
+        // The store's merkle is the 32-byte BLAKE3 digest the domain declared;
+        // assert the contract rather than silently emitting a CID of the wrong width.
+        debug_assert_eq!(
+            put.merkle.len(),
+            hex_digest_len(domain.digest_length),
+            "store merkle must be the declared {}-byte digest",
+            domain.digest_length
+        );
         let cid = cid_from_merkle(domain.algorithm, &put.merkle)?;
         Ok(BlobManifest {
             cid,
@@ -202,10 +219,30 @@ mod tests {
         let sub = CasSubstrate::new(dir.path());
         let domain = DedupDomain {
             algorithm: HashAlgo::Sha2_256,
+            digest_length: 32,
             ..DedupDomain::local_default()
         };
         let err = sub.put(&domain, b"hello", None).await.unwrap_err();
         assert!(matches!(err, CasError::UnsupportedIngestAlgorithm(_)));
+    }
+
+    #[tokio::test]
+    async fn blake3_512_ingest_not_yet_supported() {
+        // The domain vocabulary admits a BLAKE3-512 width (length-partitioned
+        // storage root), but ingest of it is #881's job; the substrate must
+        // reject a 512-bit ingest domain rather than silently addressing the
+        // 32-byte merkle as if it were 64 bytes.
+        let dir = tempfile::tempdir().unwrap();
+        let sub = CasSubstrate::new(dir.path());
+        let domain = DedupDomain {
+            digest_length: 64,
+            ..DedupDomain::local_default()
+        };
+        let err = sub.put(&domain, b"hello", None).await.unwrap_err();
+        assert!(
+            matches!(err, CasError::UnsupportedIngestAlgorithm(_)),
+            "BLAKE3-512 ingest must be rejected until #881 lands"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Part of #809/#632. Closes #812 (L1).

## What this lands

A code audit (posted on #812, 07-08) found the L1 CAS substrate was **largely built**, not a green gap: multihash addressing via `cid.rs` / `HashAlgo`, the `(compartment, algorithm, trust_boundary)` dedup-domain partition, `cas_serve::CasStore` absorbed behind the `CasSubstrate` facade, registry/XET re-pointed through it, and the `BlobManifest.security_label` carrier field (#699 carrier-(b)) were all already in place.

This PR narrows #812 to its **remaining true gap**: the dedup-domain key did not include digest length.

### Length-aware dedup domains (the #812/#881 joint decision)

BLAKE3 is an XOF, so `BLAKE3-512(x)[0:32] == BLAKE3-256(x)`. Keying dedup domains on `(compartment, algorithm, trust_boundary)` alone would let a 256-bit and a 512-bit domain over the same content **alias** — a 512-bit address would dedup against (and leak the existence of) its 256-bit prefix domain. Length is part of multihash/CID identity, so it is now part of the dedup key:

- `DedupDomain` gains a `digest_length: u16` field. The key is now `(compartment, algorithm, digest_length, trust_boundary)`.
- `local_default()` / `local_tenant()` stay BLAKE3-256 (32-byte). `is_default()` requires `digest_length == 32`, so the legacy root-mapped layout (default domain → substrate root) is preserved **byte-for-byte** — existing stores and callers are unaffected.
- `DedupDomain::new()` validates the `(algorithm, digest_length)` pair against `HashAlgo::validate_digest_len`, returning a new `InvalidDedupDomain` error for malformed pairs (e.g. `sha1/32`, `blake3/48`).
- `relative_path()` encodes length in the sub-root segment (`algo-<code>-len<N>`), so two widths of the same algorithm map to distinct, self-describing storage roots and cannot share xorbs.
- `CasSubstrate::put()` now requires `(Blake3, 32)` and asserts the store's merkle matches the declared width; a 512-bit ingest domain is **rejected** rather than silently addressed as the wrong width.

## Deferred

- **Multi-width ingest (BLAKE3-512).** The underlying `cas_serve::CasStore` computes a 32-byte BLAKE3 reconstruction merkle; BLAKE3-512 ingest cannot be cleanly bolted on (the store keys on the 32-byte merkle, not a 64-byte digest). This is #881's job (at9p capsule commitments) and now lands on a **length-partitioned root** thanks to this change — the dependency #881 had on #812 is satisfied.
- `cid.rs` variable-length digests (the other half of the joint ask) were already landed: `HashAlgo::validate_digest_len` accepts BLAKE3 `32 | 64`, with a round-trip test pinning that the two widths do not alias.

## Verify

`cargo test -p hyprstream --lib storage::cas::` → 23 passed (incl. new `blake3_256_and_512_widths_do_not_alias`, `new_rejects_malformed_algo_length_pair`, `blake3_512_ingest_not_yet_supported`). `cargo test -p hyprstream-rpc --lib cid::` → 24 passed. Pre-commit workspace `cargo clippy --workspace --all-targets --release -- -D warnings` clean under 1.97.0.