### PR TITLE
refactor(at9p) D3: demote iroh pkarr to liveness-only (#895)

### DIFF
--- a/crates/hyprstream-rpc-std/src/iroh_exports.rs
+++ b/crates/hyprstream-rpc-std/src/iroh_exports.rs
@@ -129,7 +129,9 @@ pub async fn resolve_pkarr_relay_url_js(node_id: &[u8]) -> Result<JsValue, JsErr
         .map_err(|_| JsError::new("node_id must be exactly 32 bytes"))?;
 
     match resolve_pkarr_relay_url(&bytes).await {
-        Ok(Some(url)) => Ok(JsValue::from_str(&url)),
+        // Unwrap the unverified reach hint (D3: pkarr derives zero authority)
+        // to the bare URL string the JS dial path consumes as a relay address.
+        Ok(Some(hint)) => Ok(JsValue::from_str(hint.url())),
         Ok(None) => Ok(JsValue::NULL),
         Err(e) => Err(JsError::new(&e.to_string())),
     }

--- a/crates/hyprstream-rpc/src/iroh_peer.rs
+++ b/crates/hyprstream-rpc/src/iroh_peer.rs
@@ -133,6 +133,38 @@ pub fn node_id_from_did_key(did: &str) -> Result<[u8; 32]> {
 // Pkarr relay lookup (N0 relay — same HTTP endpoint as atproto.ts fallback)
 // ============================================================================
 
+/// A relay URL sourced from a pkarr record — an **unverified reach hint**.
+///
+/// This is the typed output of [`resolve_pkarr_relay_url`]. It exists to make
+/// the D3 liveness-only contract (#895) structural: a pkarr record is signed by
+/// the peer's Ed25519 NodeId, so it is an integrity-protected *reach claim*
+/// ("I am reachable at this relay"), but it carries **zero identity/trust
+/// authority** — it says nothing about which capsule / `did:web` / `did:key`
+/// owns that NodeId or what its PQ key material is.
+///
+/// **Forbidden use:** this value MUST NOT be treated as an identity authority
+/// input. Authority for a `did:at9p` peer comes only from a GATE-verified
+/// capsule (D1 / #893); for a raw `did:key` peer, from the channel-bound
+/// `remote_id()`. The hint is a dial candidate only — feed it to the iroh dial
+/// path as a relay address, never to admission / trust decisions.
+///
+/// The newtype has no conversion to any identity type by design; reach its URL
+/// via [`PkarrReachHint::url`] when constructing a dial target.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PkarrReachHint(String);
+
+impl PkarrReachHint {
+    /// Wrap a relay URL parsed from a pkarr record as an unverified reach hint.
+    pub fn new(relay_url: String) -> Self {
+        Self(relay_url)
+    }
+
+    /// The relay URL, for use as a dial-candidate address only.
+    pub fn url(&self) -> &str {
+        &self.0
+    }
+}
+
 /// Resolve a peer's relay URL from the N0 pkarr relay via iroh's PkarrRelayClient.
 ///
 /// Fetches `https://dns.iroh.link/pkarr/<z32-node-id>` using the iroh
@@ -142,12 +174,17 @@ pub fn node_id_from_did_key(did: &str) -> Result<[u8; 32]> {
 /// This is equivalent to the `atproto.ts` HTTP-fetch workaround but uses
 /// iroh's verified parser instead of manual DNS-wire parsing.
 ///
+/// **D3 (#895): the returned [`PkarrReachHint`] is an unverified reach hint,
+/// not an identity authority source** — see its doc. pkarr rides the same
+/// mainline DHT as the at9p locator, but only at9p (GATE-verified capsule) is
+/// zero-trust.
+///
 /// # Returns
 ///
-/// `Ok(Some(relay_url))` if the peer has published a relay URL.
+/// `Ok(Some(hint))` if the peer has published a relay URL.
 /// `Ok(None)` if the peer has no record or no relay URL in the record.
 /// `Err(_)` if the pkarr relay is unreachable or the response is invalid.
-pub async fn resolve_pkarr_relay_url(node_id_bytes: &[u8; 32]) -> Result<Option<String>> {
+pub async fn resolve_pkarr_relay_url(node_id_bytes: &[u8; 32]) -> Result<Option<PkarrReachHint>> {
     let node_id = EndpointId::from_bytes(node_id_bytes)
         .map_err(|e| anyhow!("invalid node_id bytes: {e:?}"))?;
     let pkarr_relay_url: url::Url = "https://dns.iroh.link/pkarr"
@@ -177,7 +214,10 @@ pub async fn resolve_pkarr_relay_url(node_id_bytes: &[u8; 32]) -> Result<Option<
         .next()
         .map(|url| url.to_string());
 
-    Ok(relay_url)
+    // Wrap as an unverified reach hint so the D3 contract (pkarr derives zero
+    // authority) is enforced at the type — callers get a PkarrReachHint, never a
+    // bare String that could be mistaken for authoritative reach.
+    Ok(relay_url.map(PkarrReachHint::new))
 }
 
 /// Whether a pkarr resolve error is the "no record for this peer" case (HTTP

--- a/crates/hyprstream-rpc/src/transport/iroh_admission.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_admission.rs
@@ -35,6 +35,17 @@
 //! handler MUST drop the connection. When no hook is installed the path is
 //! open (pre-#282 behaviour) so existing single-tenant / loopback deployments
 //! keep working until an operator opts into federation gating.
+//!
+//! # D3 — admission never consults pkarr (#895)
+//!
+//! This gate's only identity input is `Connection::remote_id()` — the
+//! channel-bound Ed25519 pubkey iroh's QUIC TLS already verified — plus, for a
+//! `did:at9p` peer, the GATE-verified capsule keys (D2 / #894, once wired). It
+//! **never** reads a pkarr record: pkarr is a liveness/reach hint on the
+//! mainline DHT and derives zero authority (see
+//! [`crate::transport::iroh_substrate`]'s "D3" note). The reach a pkarr record
+//! advertises may be what lets us *dial* a peer, but it plays no part in the
+//! *admit/deny* decision — that is the liveness-only invariant D3 pins.
 
 use std::sync::Arc;
 

--- a/crates/hyprstream-rpc/src/transport/iroh_substrate.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_substrate.rs
@@ -20,6 +20,51 @@
 //! real `moql` and `hyprstream-rpc/1` handlers are threaded in by the spawner
 //! (#282), and the OAuth/DID-controller identity binds its own canonical
 //! federation substrate (`build_oauth_iroh_substrate`).
+//!
+//! # D3 — iroh pkarr is LIVENESS-ONLY, never an authority source (#895)
+//!
+//! iroh's `presets::N0` discovery publishes classical **pkarr** records —
+//! signed-but-not-encrypted packets — onto the open BitTorrent mainline DHT to
+//! advertise reach (home relay + direct addresses) for a NodeId. As of #895
+//! (epic #880 Track D / D3) this is the contract for pkarr in hyprstream:
+//!
+//! - **Reach hint, not authority.** A pkarr record is an **unverified dial
+//!   candidate**: "NodeId N claims it is reachable at relay R / addr A." It is
+//!   signed by N's Ed25519 key, so it is integrity-protected *as a reach
+//!   claim* — but that says nothing about *which* federated identity (capsule,
+//!   `did:web`, `did:key`) controls N, what its PQ key material is, or whether
+//!   it may be admitted. **No identity / trust / admission decision is ever
+//!   derived from a pkarr record.** Identity is bound by the channel itself
+//!   (`Connection::remote_id()` == the peer's Ed25519 pubkey, verified by iroh's
+//!   QUIC TLS), and for a `did:at9p` peer the *authoritative* identity + PQ
+//!   binding comes only from a **GATE-verified capsule** (D1 / #893, served by
+//!   the at9p mainline locator). pkarr reach must be **confirmed by GATE-verified
+//!   capsule material before any authority is granted** — it is never itself the
+//!   source of that authority.
+//! - **Two riders, one DHT, one trust posture.** Both iroh pkarr and the at9p
+//!   mainline locator (#890 / C2) ride the *same* mainline DHT. Only at9p is
+//!   zero-trust: its records are content-addressed (`did:at9p:<cid512>`) and
+//!   made trustworthy by the GATE pipeline (canon → hash → composite-sig), so
+//!   the DHT is an **untrusted locator** for at9p, never a trust root. pkarr, by
+//!   contrast, is classical-only and trusts the DHT to carry the publisher's
+//!   reach claim verbatim — fine for liveness, fatal as an authority source.
+//! - **Not removed.** pkarr stays — it is genuinely useful for NAT traversal /
+//!   liveness ("is this peer dialable right now?"). D3 only strips (and forbids
+//!   re-deriving) authority from it; it does not disable publication.
+//!
+//! Enforcement seams: the dial path (`crate::dial`) resolves *addresses* from a
+//! NodeId whose identity is already channel-bound, never trusting the pkarr
+//! body; admission (`crate::admission`, `crate::transport::iroh_admission`)
+//! reads only `remote_id()` + (for at9p) GATE-verified capsule keys — never
+//! pkarr. The wasm pkarr output is typed as an unverified reach hint
+//! ([`crate::iroh_peer::PkarrReachHint`]) so it cannot be conflated with
+//! verified reach.
+//!
+//! The #385 metadata-leak side channel (a passive observer can enumerate which
+//! NodeIds are reachable and correlate lookup traffic) is **unaffected** by this
+//! demotion — pkarr is still public. Its mitigation is oblivious-relay (#361);
+//! until then, operators that consider the side channel actionable should run a
+//! self-hosted `iroh-dns-server` via [`IrohSubstrate::from_endpoint`].
 
 use anyhow::Result;
 use iroh::endpoint::{Connection, presets};
@@ -50,18 +95,11 @@ impl IrohSubstrate {
     /// constructor and use [`IrohSubstrate::from_endpoint`] with a
     /// pre-configured `iroh::Endpoint`.
     ///
-    /// #385 threat — discovery metadata leak (S8 close-out):
-    /// pkarr records are *public, signed-but-not-encrypted* packets published on
-    /// the open Mainline DHT. A passive network observer can enumerate which node
-    /// IDs are reachable, observe their home-relay binding, and correlate lookup
-    /// traffic (who is asking for whom) — i.e. discovery is a metadata side
-    /// channel by construction. This is inherent to DHT discovery; the streaming
-    /// plane never claims discovery-metadata privacy. Content confidentiality is
-    /// unaffected (frames are E2E AEAD-sealed at the source; the relay and the
-    /// DHT are blind to plaintext). The mitigation is oblivious-relay (#361):
-    /// hide the lookup pattern itself. Until #361 lands, operators that consider
-    /// the side channel actionable should run a self-hosted `iroh-dns-server`
-    /// via [`Self::from_endpoint`] to keep discovery traffic off the public DHT.
+    /// **pkarr here is liveness-only** — see the module-level "D3" note. The
+    /// published record carries reach hints (relay + direct addrs) for this
+    /// endpoint's NodeId; it derives **zero** identity/trust authority. The
+    /// #385 metadata-leak caveat also applies (mitigated by #361, not by this
+    /// demotion).
     pub async fn new<M, R>(
         secret_key_bytes: [u8; 32],
         moq_handler: M,


### PR DESCRIPTION
Closes #895, part of #880 Track D; **STACKED on #965 (D1)** — do not merge independently.

## What this does

Demotes iroh pkarr (the `presets::N0` mainline-DHT publication path) to **liveness-only**: it is an **unverified reach hint** that derives **zero authority**. The `did:at9p` mainline locator (D1 / #965 capsule resolver) is the **authoritative** capsule/identity source. Both ride the same mainline DHT; only at9p is zero-trust.

A pkarr record is signed by the peer's Ed25519 NodeId, so it is integrity-protected *as a reach claim* ("I am dialable at relay R"), but it says nothing about which capsule / `did:web` / `did:key` owns that NodeId or what its PQ key material is. So **no identity / trust / admission decision may be derived from a pkarr record**. Authority is bound only by the channel itself (`Connection::remote_id()`, verified by iroh's QUIC TLS) and, for a `did:at9p` peer, by a **GATE-verified capsule**. pkarr reach must be confirmed by GATE-verified capsule material before any authority is granted.

pkarr is **not removed** — it is still useful for NAT traversal / liveness ("is this peer dialable right now?"). D3 only strips (and forbids re-deriving) authority from it. The #385 metadata-leak side channel is unaffected (mitigated by #361, not by this demotion).

## Authority stripped

Concretely, this codifies the invariant that **no authority derives from pkarr** and guards it structurally against regression (the dial path was already correct — it resolves addresses from a channel-bound NodeId, never trusting the pkarr body):

- **`transport/iroh_substrate.rs`** (the seam named in #895): authoritative D3 invariant — pkarr is reach-only; identity comes via the channel + GATE capsule. Two-riders-one-DHT framing (pkarr classical + trusts the DHT; at9p content-addressed + GATE-verified, DHT is an untrusted locator).
- **`transport/iroh_admission.rs`**: admission's only identity input is `remote_id()` (+ GATE capsule keys for `did:at9p`); it **never** reads a pkarr record. The reach a pkarr record advertises may be what lets us *dial* a peer, but it plays no part in the *admit/deny* decision.
- **`iroh_peer.rs`** (wasm): the one pkarr output we expose (`resolve_pkarr_relay_url`) now returns a typed **`PkarrReachHint`** newtype — no conversion to any identity type, `url()` accessor for dial candidates only — so it cannot be conflated with verified reach. `iroh_exports.rs` unwraps to the bare URL string the JS dial path consumes.

Nothing behavioral changes for callers; this codifies and type-guards the liveness-only contract.

## Verify

`cargo test -p hyprstream-rpc` (637 lib + suites green) and `cargo clippy -p hyprstream-rpc --all-targets -- -D warnings` clean under 1.97.

> Note: `wt_ninep_plane::wt_ninep_without_handler_is_declined` is a pre-existing flake in the native WebTransport path (a connection-close race) — unrelated to this change (docs + the wasm-gated pkarr output); passes 3/3 in isolation.

## Acceptance (#895)

- ✅ No identity trust derives from a pkarr record — admission reads only the channel-bound key (+ GATE capsule for `did:at9p`); pkarr reach is a typed hint, never an authority input.
- ✅ Capsule is the sole authority source (GATE-verified; D1 / #965).
- ✅ Both pkarr and the at9p locator ride the same mainline DHT; only at9p is zero-trust.