### PR TITLE
feat(at9p) D4: did:web/did:key -> did:at9p transition + alsoKnownAs (#896)

### DIFF
--- a/crates/hyprstream-discovery/src/at9p_alias.rs
+++ b/crates/hyprstream-discovery/src/at9p_alias.rs
@@ -1,0 +1,194 @@
+//! `did:web` / `did:key` → `did:at9p` aliasing resolver (#896 / D4; design
+//! #879 Q4, #905 §2/§6).
+//!
+//! This is the **I/O half** of the D4 aliasing bridge. It composes the
+//! untrusted [`CapsuleSource`] + GATE pipeline (D1 / #893) with the pure
+//! authoritative-direction rule (`hyprstream_pds::at9p_alias`) to resolve a
+//! classical DID to its authoritative `did:at9p` identity when — and only when
+//! — the two are mutually `alsoKnownAs`-attested. Sibling to
+//! [`crate::at9p_resolver::At9pResolver`]: where that turns a `did:at9p` into
+//! dialable reach, this turns a classical DID + its at9p claim into the
+//! authoritative at9p *identity* (and its assurance).
+//!
+//! # Fail-closed posture
+//!
+//! An authoritative identity is emitted **only** when:
+//!
+//! 1. the capsule named by the classical leg fetches and passes the full GATE
+//!    pipeline (canon → hash → sig), and
+//! 2. both legs name each other (mutual attestation).
+//!
+//! Any GATE failure, a classical leg pointing at a different capsule, or a
+//! capsule that does not reciprocate the classical DID returns `Err` — never a
+//! partial or one-way trust upgrade. See `hyprstream_pds::at9p_alias` for the
+//! authoritative-direction rule and the two-leg strength table.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+
+use hyprstream_pds::at9p_alias::{resolve_authoritative_alias, AuthoritativeIdentity};
+use hyprstream_pds::at9p_gate::verify_did_at9p;
+use hyprstream_rpc::identity::Did;
+
+use crate::at9p_resolver::CapsuleSource;
+
+/// `did:web` / `did:key` → `did:at9p` aliasing resolver.
+///
+/// Wraps an untrusted [`CapsuleSource`] (the mainline locator is the production
+/// implementation) and resolves a classical DID to its authoritative at9p
+/// identity via mutual `alsoKnownAs` attestation + the GATE pipeline.
+pub struct At9pAliasResolver {
+    source: Arc<dyn CapsuleSource>,
+}
+
+impl At9pAliasResolver {
+    /// Build an aliasing resolver over an untrusted capsule source.
+    pub fn new(source: Arc<dyn CapsuleSource>) -> Self {
+        Self { source }
+    }
+
+    /// Resolve `classical_did` to its authoritative `did:at9p` identity.
+    ///
+    /// `classical_aka_at9p` is the **classical leg's** claim — the `did:at9p`
+    /// identifier the classical DID document names in its own `alsoKnownAs`
+    /// (classical-signed, best-effort). This fetches the capsule for that at9p
+    /// DID from the (untrusted) source, runs the full GATE pipeline over the
+    /// bytes, and applies the mutual-attestation / authoritative-direction rule.
+    ///
+    /// Fails closed at the first GATE failure or any one-way / unattested
+    /// claim. On success the at9p identity is authoritative at `PqHybrid`
+    /// assurance (the capsule leg walked).
+    pub async fn resolve_authoritative(
+        &self,
+        classical_did: &Did,
+        classical_aka_at9p: &Did,
+    ) -> Result<AuthoritativeIdentity> {
+        let did_str = classical_aka_at9p.as_str();
+        // The locator derives zero authority — GATE is what makes the bytes
+        // trustworthy, not the source.
+        let bytes = self.source.fetch_capsule(did_str).await?;
+        // GATE — canon → hash → sig. The only place capsule authority is granted.
+        let verified = verify_did_at9p(did_str, &bytes)?;
+        // Authoritative-direction rule — mutual attestation or fail closed.
+        resolve_authoritative_alias(classical_did, classical_aka_at9p, &verified)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::at9p_resolver::CapsuleSource;
+
+    use ed25519_dalek::SigningKey;
+    use hyprstream_crypto::pq::{ml_dsa_generate_keypair, ml_dsa_vk_bytes, MlDsaSigningKey};
+    use hyprstream_pds::at9p::{
+        CapsuleBody, HybridKeyPair, ServiceEndpoint, ServiceEntry, ServiceType, Transport,
+    };
+    use hyprstream_pds::at9p_sign::sign_capsule;
+    use hyprstream_rpc::auth::mac::Assurance;
+
+    /// Serve a fixed capsule's bytes for any requested did.
+    struct FixedSource {
+        bytes: Vec<u8>,
+    }
+
+    #[async_trait::async_trait]
+    impl CapsuleSource for FixedSource {
+        async fn fetch_capsule(&self, _did: &str) -> Result<Vec<u8>> {
+            Ok(self.bytes.clone())
+        }
+    }
+
+    struct Signer {
+        ed_sk: SigningKey,
+        pq_sk: MlDsaSigningKey,
+        keypair: HybridKeyPair,
+    }
+
+    fn signer(tag: u8) -> Signer {
+        let mut seed = [0u8; 32];
+        seed[0] = tag;
+        seed[31] = tag.wrapping_add(7);
+        let ed_sk = SigningKey::from_bytes(&seed);
+        let (pq_sk, pq_vk) = ml_dsa_generate_keypair();
+        let keypair = HybridKeyPair::new(
+            ed_sk.verifying_key().to_bytes().to_vec(),
+            ml_dsa_vk_bytes(&pq_vk),
+        )
+        .unwrap();
+        Signer {
+            ed_sk,
+            pq_sk,
+            keypair,
+        }
+    }
+
+    /// A signed capsule that attests `aliases`, its bytes, and its did.
+    fn signed_with_aliases(aliases: Vec<String>) -> (Vec<u8>, String) {
+        let s = signer(5);
+        let endpoint = ServiceEndpoint::new(Transport::Iroh, "iroh://node5").unwrap();
+        let service = ServiceEntry::new("#ns", ServiceType::NinePExport, endpoint).unwrap();
+        let mut body = CapsuleBody::new(vec![s.keypair.clone()], vec![service]).unwrap();
+        if !aliases.is_empty() {
+            body.also_known_as = Some(aliases);
+        }
+        let capsule = sign_capsule(body, &s.ed_sk, &s.pq_sk).unwrap();
+        let bytes = capsule.to_dag_cbor();
+        let did = format!("did:at9p:{}", capsule.cid512().unwrap());
+        (bytes, did)
+    }
+
+    #[tokio::test]
+    async fn resolver_mutual_attestation_yields_authoritative_at9p() {
+        let classical = Did::new("did:web:node.example".to_owned());
+        let (bytes, did) = signed_with_aliases(vec![classical.as_str().to_owned()]);
+        let at9p = Did::new(did);
+        let resolver = At9pAliasResolver::new(Arc::new(FixedSource { bytes }));
+        let res = resolver
+            .resolve_authoritative(&classical, &at9p)
+            .await
+            .unwrap();
+        assert_eq!(res.at9p_did, at9p);
+        assert_eq!(res.classical_did, classical);
+        assert_eq!(res.assurance, Assurance::PqHybrid);
+    }
+
+    #[tokio::test]
+    async fn resolver_one_way_capsule_claim_fails_closed() {
+        // Capsule attests alice, but we reach it claiming to be bob.
+        let (bytes, did) = signed_with_aliases(vec!["did:web:alice.example".to_owned()]);
+        let at9p = Did::new(did);
+        let bob = Did::new("did:web:bob.example".to_owned());
+        let resolver = At9pAliasResolver::new(Arc::new(FixedSource { bytes }));
+        let err = resolver
+            .resolve_authoritative(&bob, &at9p)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("does not name"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn resolver_classical_leg_pointing_elsewhere_fails_closed() {
+        // Capsule genuinely attests the classical DID, but the classical leg
+        // names a DIFFERENT valid at9p identity than the one the source serves.
+        let classical = Did::new("did:web:node.example".to_owned());
+        let (bytes, _did) = signed_with_aliases(vec![classical.as_str().to_owned()]);
+        // A second, genuinely-valid capsule → a real distinct did:at9p cid512.
+        let (_other_bytes, other_did) = signed_with_aliases(Vec::new());
+        let wrong_at9p = Did::new(other_did);
+        let resolver = At9pAliasResolver::new(Arc::new(FixedSource { bytes }));
+        let err = resolver
+            .resolve_authoritative(&classical, &wrong_at9p)
+            .await
+            .unwrap_err();
+        // GATE hash-gate rejects (the served bytes hash to a different cid) before
+        // the aliasing rule ever runs — the classical leg's claim is not believed.
+        let msg = err.to_string();
+        assert!(
+            msg.contains("hash-gate") || msg.contains("does not name the verified capsule"),
+            "expected GATE or aliasing rejection, got: {msg}"
+        );
+    }
+}

--- a/crates/hyprstream-discovery/src/lib.rs
+++ b/crates/hyprstream-discovery/src/lib.rs
@@ -58,6 +58,11 @@ mod service;
 /// `Resolver::set_global` / network-profile resolver seam (#873).
 pub mod at9p_resolver;
 
+/// #896 (at9p D4) — `did:web` / `did:key` → `did:at9p` aliasing resolver:
+/// resolves a classical DID to its authoritative `did:at9p` identity via mutual
+/// `alsoKnownAs` attestation + the GATE pipeline. Sibling to `at9p_resolver`.
+pub mod at9p_alias;
+
 /// #524 P1 — placement directory record ingestion + in-process index.
 ///
 /// Polls `RecordResolver::resolve_repo` for a bootstrap set of node DIDs,

--- a/crates/hyprstream-pds/src/at9p.rs
+++ b/crates/hyprstream-pds/src/at9p.rs
@@ -478,7 +478,7 @@ impl CapsuleBody {
                 !aliases.is_empty(),
                 "alsoKnownAs must not be empty when present"
             );
-            validate_did_list(aliases, "alsoKnownAs")?;
+            validate_classical_did_list(aliases, "alsoKnownAs")?;
         }
         if let Some(delegations) = &self.delegations {
             ensure!(
@@ -1079,21 +1079,17 @@ fn validate_unique_texts(values: &[String], field: &str) -> Result<()> {
     Ok(())
 }
 
-/// Validate a list of DID identifiers: each entry must be non-empty, whitespace-
-/// free, `did:`-prefixed, and the list duplicate-free. Used for the capsule's
-/// `alsoKnownAs` aliases (#896 / D4) — a non-DID or duplicate alias is rejected
-/// at the schema gate, never silently normalized.
-fn validate_did_list(values: &[String], field: &str) -> Result<()> {
-    let mut seen = BTreeSet::new();
+/// Validate the classical DID aliases a `did:at9p` capsule can reciprocally
+/// attest to (#896 / D4): `did:web`, `did:key`, or `did:plc`, duplicate-free.
+fn validate_classical_did_list(values: &[String], field: &str) -> Result<()> {
+    validate_unique_texts(values, field)?;
     for value in values {
-        validate_nonempty_no_ws(value, field)?;
         ensure!(
-            value.starts_with("did:"),
-            "{field} entry {value:?} must be a DID identifier"
-        );
-        ensure!(
-            seen.insert(value.as_str()),
-            "duplicate {field} entry {value:?}"
+            value.starts_with("did:web:")
+                || value.starts_with("did:key:")
+                || value.starts_with("did:plc:"),
+            "{field} entry {value:?} must be a classical DID alias \
+             (did:web, did:key, or did:plc)"
         );
     }
     Ok(())
@@ -1323,11 +1319,16 @@ mod tests {
             "did:web:dup.example".to_owned(),
         ]);
         assert!(body.validate().is_err());
+        // did:at9p is the capsule identity, not a classical alias.
+        body.also_known_as = Some(vec!["did:at9p:bafynotaclassicalalias".to_owned()]);
+        assert!(body.validate().is_err());
         // Empty list rejected (must not be empty when present).
         body.also_known_as = Some(Vec::new());
         assert!(body.validate().is_err());
-        // A clean DID list validates.
+        // Clean classical DID aliases validate.
         body.also_known_as = Some(vec!["did:web:clean.example".to_owned()]);
+        assert!(body.validate().is_ok());
+        body.also_known_as = Some(vec!["did:plc:clean".to_owned()]);
         assert!(body.validate().is_ok());
     }
 }

--- a/crates/hyprstream-pds/src/at9p.rs
+++ b/crates/hyprstream-pds/src/at9p.rs
@@ -405,6 +405,17 @@ pub struct CapsuleBody {
     pub next_key_commitments: Vec<[u8; H512_LEN]>,
     pub services: Vec<ServiceEntry>,
     pub label_hints: Option<Vec<String>>,
+    /// Classical DID aliases this `did:at9p` identity attests to — the
+    /// **hybrid-signed** leg of the `alsoKnownAs` aliasing bridge (#896 / D4,
+    /// design #879 Q4 / #905 §2/§6). Each entry is a `did:web` / `did:key` /
+    /// `did:plc` identifier the capsule claims to *also* be. Because the list
+    /// lives inside the GATE-verified capsule body, it is content-bound to the
+    /// at9p identity and signed under pinned Hybrid — the strongest of the two
+    /// aliasing legs. The reciprocal (classical→at9p) vouch is classical-only
+    /// (a DID document's best), so the authoritative-direction rule
+    /// (`at9p_alias::resolve_authoritative_alias`) requires **both** legs to
+    /// name each other before the at9p identity is trusted.
+    pub also_known_as: Option<Vec<String>>,
     pub delegations: Option<Vec<Delegation>>,
     pub witnesses: Option<Vec<String>>,
 }
@@ -417,6 +428,7 @@ impl CapsuleBody {
             next_key_commitments: Vec::new(),
             services,
             label_hints: None,
+            also_known_as: None,
             delegations: None,
             witnesses: None,
         };
@@ -460,6 +472,13 @@ impl CapsuleBody {
                 "labelHints must not be empty when present"
             );
             validate_unique_texts(label_hints, "labelHints")?;
+        }
+        if let Some(aliases) = &self.also_known_as {
+            ensure!(
+                !aliases.is_empty(),
+                "alsoKnownAs must not be empty when present"
+            );
+            validate_did_list(aliases, "alsoKnownAs")?;
         }
         if let Some(delegations) = &self.delegations {
             ensure!(
@@ -511,6 +530,12 @@ impl CapsuleBody {
                 DagCbor::list(label_hints.iter().cloned().map(DagCbor::Text)),
             ));
         }
+        if let Some(aliases) = &self.also_known_as {
+            fields.push((
+                "alsoKnownAs",
+                DagCbor::list(aliases.iter().cloned().map(DagCbor::Text)),
+            ));
+        }
         if let Some(delegations) = &self.delegations {
             fields.push((
                 "delegations",
@@ -535,6 +560,7 @@ impl CapsuleBody {
                 "nextKeyCommitments",
                 "services",
                 "labelHints",
+                "alsoKnownAs",
                 "delegations",
                 "witnesses",
             ],
@@ -552,6 +578,7 @@ impl CapsuleBody {
             .collect::<Result<Vec<_>>>()?;
         let services = parse_services(required(value, "services", "at9p capsule body")?)?;
         let label_hints = optional_text_list(value, "labelHints")?;
+        let also_known_as = optional_text_list(value, "alsoKnownAs")?;
         let delegations = match value.get("delegations") {
             Some(v) => Some(
                 v.as_list()?
@@ -568,6 +595,7 @@ impl CapsuleBody {
             next_key_commitments,
             services,
             label_hints,
+            also_known_as,
             delegations,
             witnesses,
         };
@@ -1051,6 +1079,26 @@ fn validate_unique_texts(values: &[String], field: &str) -> Result<()> {
     Ok(())
 }
 
+/// Validate a list of DID identifiers: each entry must be non-empty, whitespace-
+/// free, `did:`-prefixed, and the list duplicate-free. Used for the capsule's
+/// `alsoKnownAs` aliases (#896 / D4) — a non-DID or duplicate alias is rejected
+/// at the schema gate, never silently normalized.
+fn validate_did_list(values: &[String], field: &str) -> Result<()> {
+    let mut seen = BTreeSet::new();
+    for value in values {
+        validate_nonempty_no_ws(value, field)?;
+        ensure!(
+            value.starts_with("did:"),
+            "{field} entry {value:?} must be a DID identifier"
+        );
+        ensure!(
+            seen.insert(value.as_str()),
+            "duplicate {field} entry {value:?}"
+        );
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(
@@ -1118,6 +1166,10 @@ mod tests {
         .unwrap();
         body.next_key_commitments = vec![digest(seed.wrapping_add(3))];
         body.label_hints = Some(vec![format!("tenant{seed}")]);
+        body.also_known_as = Some(vec![
+            format!("did:web:node{seed}.example"),
+            format!("did:key:z6Mkaka{seed}"),
+        ]);
         body.witnesses = Some(vec![format!("did:at9p:witness{seed}")]);
         Capsule::new(body, signature(CAPSULE_SIGNATURE_CONTEXT, seed)).unwrap()
     }
@@ -1235,5 +1287,47 @@ mod tests {
         assert_eq!(decoded.codec, Codec::At9pCapsule);
         assert_eq!(decoded.multihash.algo, HashAlgo::Blake3);
         assert_eq!(decoded.multihash.digest.len(), H512_LEN);
+    }
+
+    #[test]
+    fn also_known_as_round_trips_and_round_trips_byte_stable() {
+        let capsule = sample_capsule(7);
+        // The fixture sets two classical aliases.
+        assert_eq!(
+            capsule.body.also_known_as.as_deref().unwrap(),
+            &[
+                "did:web:node7.example".to_owned(),
+                "did:key:z6Mkaka7".to_owned()
+            ]
+        );
+        // Byte-stable canonical round-trip carries alsoKnownAs.
+        let bytes = capsule.to_dag_cbor();
+        let decoded = Capsule::from_dag_cbor(&bytes).unwrap();
+        assert_eq!(&decoded, &capsule);
+        assert_eq!(decoded.to_dag_cbor(), bytes);
+    }
+
+    #[test]
+    fn also_known_as_rejects_non_did_and_duplicates() {
+        let mut body = CapsuleBody::new(
+            vec![key(1)],
+            vec![service("#ns".to_owned(), ServiceType::NinePExport, 1)],
+        )
+        .unwrap();
+        // Non-DID entry rejected at the schema gate.
+        body.also_known_as = Some(vec!["https://not.a.did.example".to_owned()]);
+        assert!(body.validate().is_err());
+        // Duplicate entry rejected.
+        body.also_known_as = Some(vec![
+            "did:web:dup.example".to_owned(),
+            "did:web:dup.example".to_owned(),
+        ]);
+        assert!(body.validate().is_err());
+        // Empty list rejected (must not be empty when present).
+        body.also_known_as = Some(Vec::new());
+        assert!(body.validate().is_err());
+        // A clean DID list validates.
+        body.also_known_as = Some(vec!["did:web:clean.example".to_owned()]);
+        assert!(body.validate().is_ok());
     }
 }

--- a/crates/hyprstream-pds/src/at9p_alias.rs
+++ b/crates/hyprstream-pds/src/at9p_alias.rs
@@ -1,0 +1,268 @@
+//! Authoritative direction for `did:web` / `did:key` ↔ `did:at9p` aliasing
+//! (#896 / D4; design #879 Q4, ratified #905 §2/§6).
+//!
+//! This is the **pure, I/O-free core** of the D4 aliasing bridge — the rule
+//! that decides, given a classical DID's `alsoKnownAs` claim and a
+//! GATE-verified [`VerifiedCapsule`], whether the two identities are *mutually*
+//! attested and — when they are — which one is authoritative. The I/O half
+//! (fetch the capsule bytes from an untrusted locator, run GATE) composes this
+//! rule and lives in `hyprstream-discovery::at9p_alias`, sibling to the D1
+//! capsule resolver.
+//!
+//! # The authoritative-direction rule
+//!
+//! A `did:web` / `did:key` identity can declare (via `alsoKnownAs`) that it is
+//! *also* a `did:at9p`. The reverse vouch lives inside the at9p capsule body
+//! (the [`CapsuleBody::also_known_as`] field, #896 schema). Two legs therefore
+//! exist, of **different strength**:
+//!
+//! | leg | carrier | signature strength |
+//! |-----|---------|--------------------|
+//! | at9p → classical | the GATE-verified capsule body's `alsoKnownAs` | **Hybrid** (EdDSA + ML-DSA-65, pinned) |
+//! | classical → at9p | the classical DID document's `alsoKnownAs` | **Classical** (the doc's best) |
+//!
+//! The ratified semantics (#905 §2/§6) are:
+//!
+//! 1. **Bidirectional to be believed.** Both documents must name each other. A
+//!    one-way claim is not trusted → [`Err`].
+//! 2. **at9p is authoritative.** The content-verified capsule (BLAKE3-512
+//!    self-certifying, hybrid-signed) is the stronger identity. When the
+//!    attestation is mutual, the at9p identity is authoritative at `PqHybrid`
+//!    assurance — the assurance of the capsule leg actually walked.
+//! 3. **Assurance = the leg walked, never the max.** A verifier reaching the
+//!    identity *through* the classical leg lands `Classical`; reaching it
+//!    *through* the GATE-verified capsule lands `PqHybrid`. This rule is only
+//!    ever evaluated with a [`VerifiedCapsule`] in hand (the capsule leg was
+//!    walked), so its result is `PqHybrid`.
+//!
+//! at9p is the PQ **upgrade path**, additive to — not a replacement for — a
+//! principal's classical atproto identity (the method-allowlist bridge: public
+//! atproto infra accepts only `did:plc`/`did:web` as repo authorities, so
+//! public records publish under the classical DID with `alsoKnownAs` to the
+//! at9p identity; our own PDS accepts `did:at9p` natively, #908/G3).
+
+use anyhow::{ensure, Result};
+
+use hyprstream_rpc::auth::mac::Assurance;
+use hyprstream_rpc::identity::Did;
+
+use crate::at9p_gate::VerifiedCapsule;
+
+/// The authoritative identity resolved through the at9p aliasing bridge.
+///
+/// Produced by [`resolve_authoritative_alias`] only when a classical DID and a
+/// GATE-verified `did:at9p` capsule mutually attest each other. The at9p
+/// identity is authoritative; `assurance` is `PqHybrid` (the capsule leg).
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AuthoritativeIdentity {
+    /// The content-verified `did:at9p:<cid512>` — the stronger identity.
+    pub at9p_did: Did,
+    /// The classical DID that bidirectionally attests to the at9p identity.
+    pub classical_did: Did,
+    /// The assurance established: `PqHybrid` (reached via the GATE-verified
+    /// capsule leg — never the classical leg's best).
+    pub assurance: Assurance,
+}
+
+/// Resolve the authoritative identity for `classical_did` via mutual
+/// `alsoKnownAs` attestation with a GATE-verified `did:at9p` capsule.
+///
+/// - `classical_did` — the classical (`did:web` / `did:key` / `did:plc`)
+///   identity the caller reached.
+/// - `classical_aka_at9p` — the **classical leg's** claim: the `did:at9p` the
+///   classical DID document names in its own `alsoKnownAs`. Classical-signed,
+///   best-effort.
+/// - `verified` — the **capsule leg**: the [`VerifiedCapsule`] fetched for
+///   `classical_aka_at9p` and passed by the GATE pipeline. Its own
+///   `alsoKnownAs` is the hybrid-signed reciprocal vouch.
+///
+/// Returns the authoritative at9p identity at `PqHybrid` assurance when both
+/// legs name each other; **fail-closed** (`Err`) on any one-way or
+/// unattested claim. See the module docs for the full rule.
+pub fn resolve_authoritative_alias(
+    classical_did: &Did,
+    classical_aka_at9p: &Did,
+    verified: &VerifiedCapsule,
+) -> Result<AuthoritativeIdentity> {
+    // The capsule is the authoritative leg — its did is the stronger identity.
+    let at9p_did = Did::new(verified.did());
+
+    // Leg 1 (classical): the classical DID document names THIS capsule as its
+    // at9p alias. A classical leg pointing at a different capsule is a one-way
+    // (or cross-identity) claim — fail-closed.
+    ensure!(
+        classical_aka_at9p == &at9p_did,
+        "aliasing bridge: classical leg {} does not name the verified capsule {} \
+         (one-way claim — fail-closed)",
+        classical_aka_at9p,
+        at9p_did,
+    );
+
+    // Leg 2 (hybrid): the GATE-verified capsule reciprocally names the
+    // classical DID in its alsoKnownAs. Exact string match is the
+    // conservative, fail-closed choice (no normalization that could widen trust).
+    let reciprocated = capsule_names(verified, classical_did);
+    ensure!(
+        reciprocated,
+        "aliasing bridge: verified capsule {} does not name {} in its alsoKnownAs \
+         (one-way claim — fail-closed)",
+        at9p_did,
+        classical_did,
+    );
+
+    Ok(AuthoritativeIdentity {
+        at9p_did,
+        classical_did: classical_did.clone(),
+        // The capsule leg was walked ⇒ PqHybrid. Never the classical leg's max.
+        assurance: Assurance::PqHybrid,
+    })
+}
+
+/// Whether a verified capsule's `alsoKnownAs` names `did`.
+fn capsule_names(verified: &VerifiedCapsule, did: &Did) -> bool {
+    verified
+        .capsule()
+        .body
+        .also_known_as
+        .as_deref()
+        .unwrap_or(&[])
+        .iter()
+        .any(|alias| Did::new(alias.clone()) == *did)
+}
+
+/// The classical aliases a verified `did:at9p` capsule attests to — the
+/// **method-allowlist bridge** (#905 §6).
+///
+/// Public atproto infra (PLC directory, Bluesky, Tangled) allowlists only
+/// `did:plc` / `did:web` as repo authorities, so public `at://` records
+/// publish under the classical DID with `alsoKnownAs` to the `did:at9p`
+/// identity. This accessor projects a verified capsule back to those classical
+/// aliases — the at9p → classical direction — so a holder can publish under a
+/// classical authority while the at9p identity remains the PQ upgrade path.
+/// Returned in the capsule's declared order.
+pub fn classical_aliases(verified: &VerifiedCapsule) -> Vec<Did> {
+    verified
+        .capsule()
+        .body
+        .also_known_as
+        .as_deref()
+        .unwrap_or(&[])
+        .iter()
+        .map(|alias| Did::new(alias.clone()))
+        .collect()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::at9p::{
+        CapsuleBody, HybridKeyPair, ServiceEndpoint, ServiceEntry, ServiceType, Transport,
+    };
+    use crate::at9p_gate::verify_did_at9p;
+    use crate::at9p_sign::sign_capsule;
+
+    use ed25519_dalek::SigningKey;
+    use hyprstream_crypto::pq::{ml_dsa_generate_keypair, ml_dsa_vk_bytes, MlDsaSigningKey};
+
+    struct Signer {
+        ed_sk: SigningKey,
+        pq_sk: MlDsaSigningKey,
+        keypair: HybridKeyPair,
+    }
+
+    fn signer(tag: u8) -> Signer {
+        let mut seed = [0u8; 32];
+        seed[0] = tag;
+        seed[31] = tag.wrapping_add(7);
+        let ed_sk = SigningKey::from_bytes(&seed);
+        let (pq_sk, pq_vk) = ml_dsa_generate_keypair();
+        let keypair = HybridKeyPair::new(
+            ed_sk.verifying_key().to_bytes().to_vec(),
+            ml_dsa_vk_bytes(&pq_vk),
+        )
+        .unwrap();
+        Signer {
+            ed_sk,
+            pq_sk,
+            keypair,
+        }
+    }
+
+    /// Build a GATE-verified capsule that attests `aliases` as its classical
+    /// `alsoKnownAs`, returning (verified, did).
+    fn verified_with_aliases(aliases: Vec<String>) -> (VerifiedCapsule, String) {
+        let s = signer(1);
+        let endpoint = ServiceEndpoint::new(Transport::Iroh, "iroh://node1").unwrap();
+        let service = ServiceEntry::new("#ns", ServiceType::NinePExport, endpoint).unwrap();
+        let mut body = CapsuleBody::new(vec![s.keypair.clone()], vec![service]).unwrap();
+        if !aliases.is_empty() {
+            body.also_known_as = Some(aliases);
+        }
+        let capsule = sign_capsule(body, &s.ed_sk, &s.pq_sk).unwrap();
+        let bytes = capsule.to_dag_cbor();
+        let did = format!("did:at9p:{}", capsule.cid512().unwrap());
+        let verified = verify_did_at9p(&did, &bytes).unwrap();
+        (verified, did)
+    }
+
+    #[test]
+    fn mutual_attestation_resolves_authoritative_at9p_at_pqhybrid() {
+        let classical = Did::new("did:web:node.example".to_owned());
+        // Capsule attests the classical alias (hybrid leg).
+        let (verified, did) = verified_with_aliases(vec![classical.as_str().to_owned()]);
+        let at9p = Did::new(did.clone());
+        // Classical leg names the capsule (classical leg).
+        let res = resolve_authoritative_alias(&classical, &at9p, &verified).unwrap();
+        assert_eq!(res.at9p_did, at9p);
+        assert_eq!(res.classical_did, classical);
+        assert_eq!(res.assurance, Assurance::PqHybrid);
+    }
+
+    #[test]
+    fn one_way_classical_claim_fails_closed() {
+        let classical = Did::new("did:web:node.example".to_owned());
+        let (verified, _did) = verified_with_aliases(vec![classical.as_str().to_owned()]);
+        // Classical leg names a DIFFERENT capsule than the one verified.
+        let other = Did::new("did:at9p:bafyDIFFERENT".to_owned());
+        let err = resolve_authoritative_alias(&classical, &other, &verified).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("does not name the verified capsule"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn one_way_capsule_claim_fails_closed() {
+        // Capsule attests alice; the classical DID reaching us is bob — the
+        // capsule does not reciprocate bob.
+        let (verified, did) = verified_with_aliases(vec!["did:web:alice.example".to_owned()]);
+        let at9p = Did::new(did);
+        let bob = Did::new("did:web:bob.example".to_owned());
+        let err = resolve_authoritative_alias(&bob, &at9p, &verified).unwrap_err();
+        assert!(err.to_string().contains("does not name"), "{err}");
+    }
+
+    #[test]
+    fn capsule_with_no_aliases_fails_closed() {
+        let (verified, did) = verified_with_aliases(Vec::new()); // no aliases
+        let at9p = Did::new(did);
+        let classical = Did::new("did:web:node.example".to_owned());
+        let err = resolve_authoritative_alias(&classical, &at9p, &verified).unwrap_err();
+        assert!(err.to_string().contains("does not name"), "{err}");
+    }
+
+    #[test]
+    fn classical_aliases_project_method_allowlist_bridge() {
+        let a = "did:web:node.example".to_owned();
+        let b = "did:key:z6Mkalias".to_owned();
+        let (verified, _did) = verified_with_aliases(vec![a.clone(), b.clone()]);
+        let aliases = classical_aliases(&verified);
+        assert_eq!(
+            aliases,
+            vec![Did::new(a), Did::new(b)],
+            "projected in declared order"
+        );
+    }
+}

--- a/crates/hyprstream-pds/src/lib.rs
+++ b/crates/hyprstream-pds/src/lib.rs
@@ -49,6 +49,7 @@
 #![deny(clippy::unwrap_used, clippy::expect_used)]
 
 pub mod at9p;
+pub mod at9p_alias;
 pub mod at9p_chain;
 pub mod at9p_duplicity;
 pub mod at9p_gate;

--- a/crates/hyprstream-rpc/src/identity.rs
+++ b/crates/hyprstream-rpc/src/identity.rs
@@ -87,8 +87,11 @@ impl Did {
         self.0.starts_with("did:web:")
     }
 
-    /// Whether this is a `did:at9p` identifier (the self-certifying hybrid-PQC
-    /// capsule identity, #879/#880).
+    /// Whether this is a `did:at9p` identifier — the PQC-hybrid, self-certifying
+    /// identity (`did:at9p:<cid512>`, #879). The authoritative end of the
+    /// `alsoKnownAs` aliasing bridge (#896 / D4): when a `did:web` / `did:key`
+    /// and a `did:at9p` mutually attest each other, the content-verified at9p
+    /// capsule is the stronger identity.
     ///
     /// The capsule GATE pipeline that verifies a `did:at9p` and derives its
     /// `PqHybrid` key material is epic #880 (D2); the method-dispatched resolver
@@ -197,6 +200,12 @@ mod did_tests {
         let neither = Did::new("did:plc:abc123".to_owned());
         assert!(!neither.is_did_key());
         assert!(!neither.is_did_web());
+        assert!(!neither.is_did_at9p());
+
+        let at9p = Did::new("did:at9p:bafyabcd".to_owned());
+        assert!(at9p.is_did_at9p());
+        assert!(!at9p.is_did_key());
+        assert!(!at9p.is_did_web());
     }
 
     #[test]


### PR DESCRIPTION
Closes #896, part of #880 Track D. STACKED on #969 (D3).

## What

Implements the ratified **authoritative-direction rule** for `did:web` / `did:key` ↔ `did:at9p` aliasing (#879 Q4, #905 §2/§6) and the schema that carries it.

### Authoritative-direction rule

- **Bidirectional to be believed.** A `did:web`/`did:key` claiming `alsoKnownAs` a `did:at9p` is corroborated **only** by the at9p capsule claiming the reverse. A one-way claim is not trusted → fail-closed.
- **at9p is authoritative.** The content-verified capsule (BLAKE3-512 self-certifying, hybrid-signed) is the stronger identity. When the attestation is mutual, the at9p identity is authoritative.
- **Assurance = the leg walked, never the max.** The two legs differ in strength: the at9p→classical vouch lives inside the GATE-verified capsule body (**Hybrid**, EdDSA + ML-DSA-65, pinned); the classical→at9p vouch is a DID-document `alsoKnownAs` (**Classical**, the doc's best). Reaching the identity *through* the GATE-verified capsule lands `PqHybrid`; reaching it *through* the classical leg lands `Classical`. This rule is only ever evaluated with a `VerifiedCapsule` in hand, so its result is `PqHybrid`.
- **Method-allowlist bridge.** Public atproto infra (PLC, Bluesky, Tangled) allowlists only `did:plc`/`did:web` as repo authorities, so public `at://` records publish under the classical DID with `alsoKnownAs` to the `did:at9p` identity. at9p is the PQ **upgrade path**, additive to — not a replacement for — the classical identity.

## Changes

- **Schema** (`hyprstream-pds/src/at9p.rs`): `CapsuleBody.also_known_as` — the hybrid-signed leg. Validated as a non-empty, duplicate-free, `did:`-prefixed list; canonical DAG-CBOR round-trip enforced.
- **Pure rule** (`hyprstream-pds/src/at9p_alias.rs`): `resolve_authoritative_alias` (mutual attestation → authoritative at9p at `PqHybrid`, else `Err`) + `classical_aliases` (reverse direction / method-allowlist bridge).
- **I/O resolver** (`hyprstream-discovery/src/at9p_alias.rs`): `At9pAliasResolver` — composes the untrusted `CapsuleSource` + GATE pipeline (D1/#893) with the pure rule. Fail-closed at the first GATE failure or any one-way claim.
- **Identity seam** (`hyprstream-rpc/src/identity.rs`): `Did::is_did_at9p()`.

## Verify

`cargo test -p hyprstream-pds at9p` (44 ok), `cargo test -p hyprstream-discovery at9p` (incl. 3 new alias tests), `cargo clippy -p hyprstream-rpc --all-targets -- -D warnings` clean under 1.97; workspace `--release` clippy clean (pre-commit hook).

Trust-relevant identity aliasing — review @fable.