### PR TITLE
pds: reconcile DAG-CBOR key-ordering comments to pure-lexicographic

### DIFF
--- a/crates/hyprstream-pds/src/commit.rs
+++ b/crates/hyprstream-pds/src/commit.rs
@@ -39,8 +39,9 @@ pub const COMMIT_VERSION: u64 = 3;
 /// An unsigned commit — the form that gets DAG-CBOR-encoded and signed.
 ///
 /// Field order matches atproto (`did`, `version`, `data`, `rev`, `prev`); the
-/// encoder re-sorts canonically (length-first then lex) so the order here is
-/// only for readability. `version` is always [`COMMIT_VERSION`] = 3.
+/// encoder re-sorts canonically (**pure lexicographic byte order**, RFC 7049
+/// §4.2.1 "core determinism" — not length-first) so the order here is only for
+/// readability. `version` is always [`COMMIT_VERSION`] = 3.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UnsignedCommit {
     pub did: String,

--- a/crates/hyprstream-pds/src/dag_cbor.rs
+++ b/crates/hyprstream-pds/src/dag_cbor.rs
@@ -565,6 +565,36 @@ mod tests {
     }
 
     #[test]
+    fn canonical_key_order_is_pure_lex_not_length_first() {
+        // The placement `node` record's 5 keys. Their pure-lexicographic byte
+        // order (`createdAt, groups, labels, repo, resources`) differs from the
+        // length-first-then-lex order atproto rejects (`repo, groups, labels,
+        // createdAt, resources`), so this fixture is a real discriminator.
+        // Lock the pure-lex bytes: a "fix" toward length-first (the older RFC
+        // 7049 §3.9 "canonical CBOR" form) would silently break CID/CAR interop
+        // against every other atproto implementation.
+        let keys = ["repo", "labels", "resources", "groups", "createdAt"];
+        let map = DagCbor::str_map(keys.into_iter().map(|k| (k, DagCbor::Unsigned(1))));
+        let decoded = DagCbor::decode(&map.encode()).expect("round-trip");
+        let emitted: Vec<&str> = decoded
+            .as_map()
+            .expect("map")
+            .iter()
+            .map(|(k, _)| k.as_str().expect("text key"))
+            .collect();
+        assert_eq!(
+            emitted,
+            vec!["createdAt", "groups", "labels", "repo", "resources"],
+            "DAG-CBOR map keys must be pure-lexicographic byte order"
+        );
+        assert_ne!(
+            emitted,
+            vec!["repo", "groups", "labels", "createdAt", "resources"],
+            "length-first-then-lex order is the rejected RFC 7049 §3.9 form"
+        );
+    }
+
+    #[test]
     fn encode_minimal_widths() {
         // Determinism: minimal-width integer heads.
         assert_eq!(DagCbor::Unsigned(0).encode(), vec![0x00]);

--- a/crates/hyprstream-pds/src/lib.rs
+++ b/crates/hyprstream-pds/src/lib.rs
@@ -7,9 +7,10 @@
 //!
 //! # What this crate provides
 //!
-//! - **DAG-CBOR** deterministic encode/decode ([`dag_cbor`]) — canonical CBOR
-//!   (RFC 7049 §3.9 / §4.2.1): sorted map keys, minimal-length ints, no
-//!   duplicate keys. CID links use CBOR tag 42 per the
+//! - **DAG-CBOR** deterministic encode/decode ([`dag_cbor`]) — canonical CBOR:
+//!   map keys sorted in **pure lexicographic byte order** (RFC 7049 §4.2.1 "core
+//!   determinism", the convention atproto's `@atproto/lex-cbor` uses), minimal-
+//!   length ints, no duplicate keys. CID links use CBOR tag 42 per the
 //!   [DAG-CBOR spec](https://github.com/ipld/specs/blob/master/block-layer/codecs/dag-cbor.md).
 //!   The same record produces identical bytes → same CID every time.
 //! - **`ai.hyprstream.model` record** ([`record`]) — the confirmed 3-field

--- a/crates/hyprstream-pds/src/placement/mod.rs
+++ b/crates/hyprstream-pds/src/placement/mod.rs
@@ -15,8 +15,9 @@
 //! # Encoding
 //!
 //! Like `ai.hyprstream.model`, every record is **DAG-CBOR** with canonical
-//! (length-first, then lexicographic) map-key order. The encoder applies that
-//! ordering, so callers construct fields in any order. Each record has a frozen
+//! map-key order — **pure lexicographic byte order** (RFC 7049 §4.2.1 "core
+//! determinism", not length-first). The encoder applies that ordering, so
+//! callers construct fields in any order. Each record has a frozen
 //! field set: decoding rejects unknown fields. Optional fields are *omitted*
 //! from the encoded map when absent (never encoded as `null`).
 //!

--- a/crates/hyprstream-pds/src/record.rs
+++ b/crates/hyprstream-pds/src/record.rs
@@ -20,9 +20,11 @@
 //! # Encoding
 //!
 //! Records are **DAG-CBOR**. The field order in the encoded map is the canonical
-//! (length-first, then lexicographic) order, which for these three keys is
-//! `createdAt`, `currentOid`, `repo` — the encoder handles this; callers do not
-//! need to care.
+//! order — **pure lexicographic byte order** (RFC 7049 §4.2.1 "core
+//! determinism", matching atproto's `@atproto/lex-cbor`). For these three keys
+//! that is `createdAt`, `currentOid`, `repo`. (NOT length-first-then-lex; that's
+//! the older RFC 7049 §3.9 form, which atproto rejects.) The encoder handles
+//! this; callers do not need to care.
 //!
 //! `currentOid` is a `format: "cid"` **string** — *not* a CID link. It references
 //! external git content by OID, so it is carried as text and validated as a CID
@@ -226,14 +228,14 @@ mod tests {
     fn record_fields_canonical_order() {
         let r = sample();
         let bytes = r.to_dag_cbor();
-        // Decode raw to confirm key order is length-first: createdAt, currentOid, repo.
+        // Decode raw to confirm key order is pure-lexicographic: createdAt, currentOid, repo.
         let v = DagCbor::decode(&bytes).expect("decode");
         let map = v.as_map().expect("map");
         let keys: Vec<&str> = map.iter().map(|(k, _)| k.as_str().expect("str")).collect();
         assert_eq!(
             keys,
             vec!["createdAt", "currentOid", "repo"],
-            "DAG-CBOR map keys must be canonical (length-first, then lex)"
+            "DAG-CBOR map keys must be pure-lexicographic byte order"
         );
     }
 


### PR DESCRIPTION
Closes #566.

## Summary

The DAG-CBOR encoder (`dag_cbor.rs` `canonical_key_cmp = a.cmp(b)`) is and has always been **pure lexicographic byte order** — correct, and matching atproto's `@atproto/lex-cbor` (via `cborg`). But several comments / test messages contradicted it, claiming **"length-first, then lexicographic"** (the older RFC 7049 §3.9 form that atproto rejects):

- `record.rs` module doc + the `record_fields_canonical_order` assertion message
- `commit.rs` `UnsignedCommit` field-order note
- `placement/mod.rs` Encoding section
- `lib.rs` `dag_cbor` bullet (cited §3.9 / §4.2.1 together)

The `record.rs` test even *labeled* the `createdAt, currentOid, repo` order as "length-first" while asserting the pure-lex bytes — true length-first would be `repo, createdAt, currentOid`. The 3-field model record masked the error because it asserted the (correct) pure-lex bytes while mis-describing them.

## Why it matters

Federation interop rests on CIDs, which rest on canonical key order. A well-meaning "fix" toward the *documented* length-first ordering would silently break CID/CAR verification against every other atproto implementation.

## Change

Docs-only reconciliation of all of the above to "pure lexicographic byte order (RFC 7049 §4.2.1 core determinism)"; **no encoder change**. Preserves all existing behavior.

Added a multi-key fixture in `dag_cbor.rs` using the placement `node` record's 5 keys (`createdAt/groups/labels/repo/resources`), whose pure-lex order **differs** from length-first, so the distinction — and CID/CAR interop — is locked by a test.

## Verification

- `cargo test -p hyprstream-pds` — 163 passed (incl. new fixture)
- `cargo clippy -p hyprstream-pds --all-targets -- -D warnings` — clean (1.97)
