### PR TITLE
chore(at9p): D2 hardening nits — VerifiedAt9pKeys witness, prefix-const dedup, did:web assurance doc

### DIFF
--- a/crates/hyprstream-pds/src/at9p_gate.rs
+++ b/crates/hyprstream-pds/src/at9p_gate.rs
@@ -51,7 +51,11 @@ use crate::at9p_sign::verify_capsule;
 
 /// The `did:at9p:` method prefix. A `did:at9p` identifier is exactly this prefix
 /// followed by the base32 CIDv1 (`cid512`) of the genesis capsule.
-pub const DID_AT9P_PREFIX: &str = "did:at9p:";
+///
+/// Re-exported from the single source of truth (`hyprstream_rpc::identity`), shared
+/// with the admission gate and `Did::is_did_at9p`, so the literal cannot drift
+/// across arms (#964). Kept at this path for the existing pds/discovery import sites.
+pub use hyprstream_rpc::identity::DID_AT9P_PREFIX;
 
 /// Which gate of the [`verify_genesis_capsule`] pipeline rejected the input.
 ///

--- a/crates/hyprstream-pds/src/at9p_resolver.rs
+++ b/crates/hyprstream-pds/src/at9p_resolver.rs
@@ -70,7 +70,7 @@ impl At9pCapsuleResolver for At9pGateResolver {
 
         let ml_dsa_65 = ml_dsa_vk_from_bytes(&subject.mldsa65_pub)?;
 
-        Ok(VerifiedAt9pKeys { ed25519, ml_dsa_65 })
+        Ok(VerifiedAt9pKeys::new_gate_verified(ed25519, ml_dsa_65))
     }
 
     fn resolve(&self, did: &str) -> Result<VerifiedAt9pKeys> {
@@ -151,8 +151,8 @@ mod tests {
         let (capsule, bytes, did) = signed(1);
         let primary = capsule.body.subject_keys[0].clone();
         let verified = At9pGateResolver::new().verify_bytes(&did, &bytes).expect("GATE passes");
-        assert_eq!(verified.ed25519.as_slice(), primary.ed25519_pub);
-        assert_eq!(ml_dsa_vk_bytes(&verified.ml_dsa_65), primary.mldsa65_pub);
+        assert_eq!(verified.ed25519().as_slice(), primary.ed25519_pub);
+        assert_eq!(ml_dsa_vk_bytes(verified.ml_dsa_65()), primary.mldsa65_pub);
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/admission.rs
+++ b/crates/hyprstream-rpc/src/admission.rs
@@ -62,13 +62,14 @@ use crate::did_web::{
     DidWebResolver,
 };
 use crate::envelope::KeyedPqTrustStore;
+use crate::identity::DID_AT9P_PREFIX;
 use crate::identity_resolver::At9pCapsuleResolver;
 
-/// The `did:at9p:` method prefix; a `did:at9p` identifier is this prefix followed
-/// by the base32 CIDv1 (`cid512`) of the genesis capsule (#884).
-const DID_AT9P_PREFIX: &str = "did:at9p:";
-
 /// Whether `did` is a `did:at9p` identifier (the self-certifying hybrid-PQC arm).
+///
+/// Delegates to the shared [`DID_AT9P_PREFIX`] literal (the single source of
+/// truth shared with [`crate::identity::Did::is_did_at9p`] and `hyprstream-pds`'s
+/// GATE code) so the prefix cannot drift across arms (#964).
 fn is_did_at9p(did: &str) -> bool {
     did.starts_with(DID_AT9P_PREFIX)
 }
@@ -307,7 +308,7 @@ pub async fn admit_key_against_did<R: DidDocResolve>(
         // The capsule's Ed25519 subject key IS the identity; the peer's
         // authenticated channel key must equal it (one trust root, #185 closed
         // by construction for did:at9p).
-        if !key_eq(&verified.ed25519, peer_key.as_bytes()) {
+        if !key_eq(verified.ed25519(), peer_key.as_bytes()) {
             return Err(admission_reject(
                 origin,
                 peer_key,
@@ -318,7 +319,7 @@ pub async fn admit_key_against_did<R: DidDocResolve>(
         }
         // Atomic hybrid binding from the verified capsule — replaces the
         // out-of-band `mesh_peers` config path for did:at9p peers (#894).
-        ctx.pq_store.bind(verified.ed25519, &verified.ml_dsa_65);
+        ctx.pq_store.bind(*verified.ed25519(), verified.ml_dsa_65());
         return Ok(AdmittedIdentity {
             origin: origin.to_owned(),
             did: Some(did.to_owned()),
@@ -738,7 +739,7 @@ mod tests {
 
     fn verified_subject(ed: [u8; 32]) -> VerifiedAt9pKeys {
         let (_sk, vk) = ml_dsa_generate_keypair();
-        VerifiedAt9pKeys { ed25519: ed, ml_dsa_65: vk }
+        VerifiedAt9pKeys::new_gate_verified(ed, vk)
     }
 
     #[tokio::test]
@@ -771,7 +772,7 @@ mod tests {
         let bound = store
             .ml_dsa_key_for(&ed)
             .expect("ed25519→ml_dsa_65 bound");
-        assert_eq!(ml_dsa_vk_bytes(&bound), ml_dsa_vk_bytes(&keys.ml_dsa_65));
+        assert_eq!(ml_dsa_vk_bytes(&bound), ml_dsa_vk_bytes(keys.ml_dsa_65()));
     }
 
     #[tokio::test]

--- a/crates/hyprstream-rpc/src/identity.rs
+++ b/crates/hyprstream-rpc/src/identity.rs
@@ -41,6 +41,16 @@ use crate::Subject;
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct Did(String);
 
+/// The `did:at9p:` method prefix — the single source of truth for the
+/// self-certifying hybrid-PQC capsule identity (#879/#880). A `did:at9p`
+/// identifier is this prefix followed by the base32 CIDv1 (`cid512`) of the
+/// genesis capsule (#884).
+///
+/// Shared by the admission gate (`crate::admission`), this method check
+/// ([`Did::is_did_at9p`]), and the GATE/capsule code in `hyprstream-pds`
+/// (`at9p_gate`) so the literal cannot drift across the three arms (D2/#964).
+pub const DID_AT9P_PREFIX: &str = "did:at9p:";
+
 impl Did {
     /// Wrap a DID string verbatim. **No validation** — strict checks belong at the
     /// admission gate (see the type docs).
@@ -84,7 +94,7 @@ impl Did {
     /// `PqHybrid` key material is epic #880 (D2); the method-dispatched resolver
     /// reserves the arm but does not yet resolve it (fails closed until #894).
     pub fn is_did_at9p(&self) -> bool {
-        self.0.starts_with("did:at9p:")
+        self.0.starts_with(DID_AT9P_PREFIX)
     }
 
     /// Decode the raw 32-byte Ed25519 public key from a `did:key` identifier.

--- a/crates/hyprstream-rpc/src/identity_resolver.rs
+++ b/crates/hyprstream-rpc/src/identity_resolver.rs
@@ -79,16 +79,52 @@ pub trait DidDocumentProvider: Send + Sync {
 ///
 /// `ed25519` is the capsule's primary subject key — the iroh `NodeId` / channel
 /// identity. `ml_dsa_65` is the PQ half of the hybrid pair. A [`VerifiedAt9pKeys`]
-/// is only constructable by an [`At9pCapsuleResolver`] that ran the A4 GATE
-/// pipeline (canon→hash→sig, #884) to completion, so holding one is proof the
-/// binding came from **content-verified capsule material**, not a config file or a
-/// caller assertion (the D2/#894 provenance boundary).
+/// is only constructable via [`VerifiedAt9pKeys::new_gate_verified`] — the GATE
+/// mint — which only an [`At9pCapsuleResolver`] that ran the A4 GATE pipeline
+/// (canon→hash→sig, #884) to completion reaches. The private fields make the
+/// "only constructable after the GATE ran" provenance a type-level invariant
+/// rather than a bare rustdoc claim: arbitrary code cannot build one with an
+/// unverified `ed25519`↔`ml_dsa_65` pair, so holding one is proof the binding came
+/// from **content-verified capsule material**, not a config file or a caller
+/// assertion (the D2/#894 provenance boundary, hardened in #964).
 #[derive(Clone)]
 pub struct VerifiedAt9pKeys {
     /// The verified Ed25519 subject key (the classical identity / channel key).
-    pub ed25519: [u8; 32],
+    ed25519: [u8; 32],
     /// The verified ML-DSA-65 subject key bound to `ed25519` in the capsule.
-    pub ml_dsa_65: MlDsaVerifyingKey,
+    ml_dsa_65: MlDsaVerifyingKey,
+}
+
+impl VerifiedAt9pKeys {
+    /// The GATE mint — the sole construction path for a [`VerifiedAt9pKeys`].
+    ///
+    /// This is the constructor-witness chokepoint: the fields are private, so the
+    /// *only* way to produce a `VerifiedAt9pKeys` is to call this method, which
+    /// encodes the GATE-ran provenance in its name. Trusted callers are the A4 GATE
+    /// resolver implementations (the real [`At9pCapsuleResolver`] impl in
+    /// `hyprstream-pds::at9p_resolver`, plus in-crate test fixtures). Code that has
+    /// not run the GATE has no business calling this — review a new call site as a
+    /// provenance decision, not a mechanical field set.
+    ///
+    /// (Rust cannot seal this across crates — `hyprstream-pds` is a *dependent* of
+    /// `hyprstream-rpc`, so rpc has no way to grant pds the mint while denying it
+    /// to arbitrary code. The private fields + single named mint convert the
+    /// provenance from "any code can write the struct literal" to "any code must go
+    /// through one review-visible chokepoint", which is the proportionate
+    /// hardening; the trust root remains "whoever injects the gate is trusted".)
+    pub fn new_gate_verified(ed25519: [u8; 32], ml_dsa_65: MlDsaVerifyingKey) -> Self {
+        Self { ed25519, ml_dsa_65 }
+    }
+
+    /// The verified Ed25519 subject key (the classical identity / channel key).
+    pub fn ed25519(&self) -> &[u8; 32] {
+        &self.ed25519
+    }
+
+    /// The verified ML-DSA-65 subject key bound to `ed25519` in the capsule.
+    pub fn ml_dsa_65(&self) -> &MlDsaVerifyingKey {
+        &self.ml_dsa_65
+    }
 }
 
 /// Verifies a `did:at9p` capsule and yields its content-verified subject keys.
@@ -159,6 +195,25 @@ impl<P: DidDocumentProvider> MethodDispatchResolver<P> {
     /// - Ed25519 VM present + ML-DSA-65 VM present ⇒ `PqHybrid`.
     /// - Ed25519 VM present, no ML-DSA-65 VM ⇒ `Classical`.
     /// - No Ed25519 VM ⇒ `Err` (fail-closed: nothing to anchor).
+    ///
+    /// # Assurance quality — the at9p asymmetry
+    ///
+    /// Unlike the `did:at9p` arm, where the `ed25519`↔`ml_dsa_65` pair is
+    /// **content-verified** by the GATE over a self-certifying capsule, the
+    /// `did:web` arm's `PqHybrid` rests on **co-presence in a TLS-fetched
+    /// document**, not on a content-binding between the two keys. Two caveats
+    /// follow, consistent with the ratified #579/D1 "did:web we operate" model:
+    ///
+    /// - **Arbitrary pairing when multiple VMs exist:** the first Ed25519 VM and
+    ///   the first ML-DSA-65 VM in the document are paired. If a document carries
+    ///   several of either, which two get bound is incidental to document order,
+    ///   not cryptographic. (Operated nodes publish one of each, so this is a
+    ///   document-shape concern for third-party docs, not a live risk for nodes we
+    ///   run.)
+    /// - **No content binding:** the document attests both keys, but nothing in the
+    ///   TLS fetch proves the Ed25519 and ML-DSA-65 keys belong to the same
+    ///   principal beyond the document's own say-so. The at9p capsule proves this
+    ///   cryptographically; did:web trusts the (TLS-transported) document.
     fn resolve_did_web(&self, did: &Did) -> Result<IdentityKeys> {
         let doc = self
             .docs
@@ -212,8 +267,8 @@ impl<P: DidDocumentProvider> MethodDispatchResolver<P> {
             .resolve(did.as_str())
             .map_err(|e| anyhow!("did:at9p {did}: capsule GATE failed: {e}"))?;
         Ok(IdentityKeys {
-            ed25519: Some(verified.ed25519),
-            ml_dsa_65: Some(verified.ml_dsa_65),
+            ed25519: Some(*verified.ed25519()),
+            ml_dsa_65: Some(verified.ml_dsa_65().clone()),
             assurance: Assurance::PqHybrid,
         })
     }
@@ -445,7 +500,7 @@ mod tests {
 
     fn verified_keys() -> VerifiedAt9pKeys {
         let (_sk, vk) = ml_dsa_generate_keypair();
-        VerifiedAt9pKeys { ed25519: [9u8; 32], ml_dsa_65: vk }
+        VerifiedAt9pKeys::new_gate_verified([9u8; 32], vk)
     }
 
     #[test]
@@ -460,8 +515,8 @@ mod tests {
             .resolve_identity_keys(&did)
             .expect("verified capsule resolves at PqHybrid");
         assert_eq!(resolved.assurance, Assurance::PqHybrid);
-        assert_eq!(resolved.ed25519, Some(keys.ed25519));
-        assert_eq!(ml_dsa_vk_bytes(&resolved.ml_dsa_65.unwrap()), ml_dsa_vk_bytes(&keys.ml_dsa_65));
+        assert_eq!(resolved.ed25519, Some(*keys.ed25519()));
+        assert_eq!(ml_dsa_vk_bytes(&resolved.ml_dsa_65.unwrap()), ml_dsa_vk_bytes(keys.ml_dsa_65()));
         // The arm routed through the capsule resolver exactly once.
         assert_eq!(fixture.calls.lock().as_slice(), &["did:at9p:cid512abcdef"]);
     }


### PR DESCRIPTION
Closes #964.

Non-blocking hardening from the fable security review of #962 (the D2 admission arm). The trust boundary itself is unchanged — keys still bind only from a GATE-verified capsule, fail-closed throughout.

## 1. `VerifiedAt9pKeys` provenance → type-level

The `ed25519` / `ml_dsa_65` fields are now **private**; the sole construction path is the `new_gate_verified` GATE mint, with `ed25519()` / `ml_dsa_65()` accessors. Code that has not run the GATE can no longer build a `VerifiedAt9pKeys` with an unverified key pair via a struct literal — the rustdoc claim is now enforced at the type level. (Rust can't truly seal this across crates since `hyprstream-pds` is a *dependent* of `hyprstream-rpc`; the private fields + single named mint convert the provenance from "any code can write the literal" to "one review-visible chokepoint", which is the proportionate hardening.)

## 2. `did:at9p:` prefix → single source of truth

The literal was duplicated in three places (admission `is_did_at9p`, `Did::is_did_at9p`, pds `at9p_gate`). Consolidated to one const — `hyprstream_rpc::identity::DID_AT9P_PREFIX` — used by `Did::is_did_at9p` and the admission gate, and re-exported at `hyprstream_pds::at9p_gate::DID_AT9P_PREFIX` so existing import sites are unchanged. Eliminates the drift risk.

## 3. did:web assurance-quality doc note

`resolve_did_web` now documents the asymmetry vs at9p: its `PqHybrid` rests on co-presence in a TLS-fetched document (not the content-binding the at9p capsule proves), and pairs the first Ed25519 VM with the first ML-DSA VM (arbitrary if a doc carries several) — consistent with the ratified #579/D1 "did:web we operate" model.

## Verification

- `cargo test -p hyprstream-rpc -p hyprstream-pds --lib` — rpc 655 passed, pds 156 passed.
- `cargo clippy -p hyprstream-rpc -p hyprstream-pds --all-targets -- -D warnings` — clean (1.97).