### PR TITLE
fix(bootstrap): issue policy service JWT symmetric with peers

### DIFF
--- a/crates/hyprstream/src/auth/service_jwt.rs
+++ b/crates/hyprstream/src/auth/service_jwt.rs
@@ -112,6 +112,75 @@ mod tests {
         assert_eq!(decode_jwt_iss(&jwt).as_deref(), Some(issuer));
     }
 
+    /// PolicyService gets a `service:policy` JWT just like every other service
+    /// (#448). Bootstrap no longer skips it: it mints a CA-signed JWT whose
+    /// `cnf` binds the root/CA verifying key — the same key recorded in
+    /// `bootstrap_pubkeys["policy"]` and the key PolicyService actually signs
+    /// RPC responses with. This test encodes that invariant directly so the
+    /// "skip policy" regression cannot silently return: trust-store key ==
+    /// JWT `cnf` == actual signer, all three equal to `root_key`'s verifying
+    /// key.
+    #[test]
+    fn policy_service_jwt_is_symmetric_and_binds_root_key() {
+        let dir = tempfile::tempdir().unwrap();
+        // The CA: PolicyService's identity IS the root/CA key.
+        let root_key = SigningKey::from_bytes(&[7u8; 32]);
+        // The CA JWT signing key is purpose-derived from the root key, exactly
+        // as `do_bootstrap` derives it before signing any service JWT.
+        let ca_jwt_key =
+            hyprstream_rpc::node_identity::derive_purpose_key(&root_key, "hyprstream-jwt-v1");
+        let issuer = "http://localhost:6791";
+
+        // Reproduce the policy branch of the bootstrap loop: service_key ==
+        // root_key (NOT an independent per-service key), then issue + persist.
+        let policy_key = root_key.clone();
+        let policy_vk = policy_key.verifying_key();
+        let jwt = issue_or_load_service_jwt(
+            dir.path(),
+            "policy",
+            &ca_jwt_key,
+            &policy_vk,
+            issuer,
+            1_000_000,
+        )
+        .unwrap();
+        super::super::identity_store::write_service_jwt(dir.path(), "policy", &jwt).unwrap();
+
+        // The JWT is persisted at policy/service-jwt (not skipped).
+        let loaded =
+            super::super::identity_store::load_service_jwt(dir.path(), "policy").unwrap();
+        assert_eq!(loaded.as_deref(), Some(jwt.as_str()));
+
+        // Subject is service:policy.
+        let payload_b64 = jwt.split('.').nth(1).unwrap();
+        let payload = URL_SAFE_NO_PAD.decode(payload_b64).unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(value.get("sub").and_then(|v| v.as_str()), Some("service:policy"));
+
+        // cnf.jwk binds the root verifying key — what the trust store records
+        // for "policy" and what PolicyService signs with.
+        let cnf = value.get("cnf").and_then(|v| v.get("jwk"));
+        assert!(cnf.is_some(), "policy service JWT must carry a cnf.jwk");
+        // The JWK thumbprint representation here is the raw 32-byte verifying
+        // key (x); compare against root_key.verifying_key() bytes.
+        let x = cnf
+            .and_then(|v| v.get("x"))
+            .and_then(|v| v.as_str())
+            .unwrap();
+        let x_bytes = URL_SAFE_NO_PAD.decode(x).unwrap();
+        assert_eq!(
+            x_bytes.as_slice(),
+            root_key.verifying_key().as_bytes(),
+            "cnf.jwk must bind root_key.verifying_key(), the key bootstrap registers for policy"
+        );
+
+        // And that equals what bootstrap would register in bootstrap_pubkeys.
+        assert_eq!(
+            root_key.verifying_key().as_bytes(),
+            policy_vk.as_bytes()
+        );
+    }
+
     /// A persisted legacy empty-issuer token is re-minted with the issuer set,
     /// rather than being returned as-is — so an upgrade heals the #328 mismatch
     /// on the next wizard/bootstrap run without manual intervention.

--- a/crates/hyprstream/src/cli/bootstrap_manager.rs
+++ b/crates/hyprstream/src/cli/bootstrap_manager.rs
@@ -772,19 +772,28 @@ async fn do_bootstrap(
         for factory in list_factories() {
             let service_name = factory.name;
 
-            if service_name == "policy" {
-                // PolicyService uses the root/CA key directly — no independent key needed.
-                bootstrap_pubkeys.insert(
-                    service_name.to_owned(),
-                    root_key.verifying_key(),
-                );
-                continue;
-            }
-
-            // Load or generate independent Ed25519 keypair
-            let service_key = identity_store::load_or_generate_service_signing_key(
-                &credentials_dir, service_name,
-            )?;
+            // PolicyService's identity IS the root/CA key: unlike every other
+            // service it has no independent per-service keypair, so it resolves
+            // to `root_key` rather than `load_or_generate_service_signing_key`
+            // (which would read/generate a divergent `policy/signing-key`).
+            //
+            // But it is NOT skipped: we still mint a CA-signed `service:policy`
+            // JWT — self-signed in the sense that the CA JWT key signs it, with
+            // `cnf` binding the root verifying key — and persist it to
+            // `policy/service-jwt`. That makes PolicyService symmetric with
+            // every other service and keeps the trust store (which records
+            // `root_key.verifying_key()` for "policy") in lockstep with the
+            // on-disk JWT, so a later `service repair`/reinstall can no longer
+            // leave a stale `policy` key/JWT pair that disagrees with the
+            // current CA key (#448). It also enables future per-service
+            // rotation of the policy credential.
+            let service_key = if service_name == "policy" {
+                root_key.clone()
+            } else {
+                identity_store::load_or_generate_service_signing_key(
+                    &credentials_dir, service_name,
+                )?
+            };
             let service_vk = service_key.verifying_key();
 
             let jwt = crate::auth::service_jwt::issue_or_load_service_jwt(
@@ -799,7 +808,7 @@ async fn do_bootstrap(
         identity_store::write_bootstrap_pubkeys(&credentials_dir, &bootstrap_pubkeys)?;
 
         tracing::info!(
-            "Generated {} independent service keypairs + JWTs",
+            "Generated service keypairs + JWTs for {} services",
             bootstrap_pubkeys.len(),
         );
     }


### PR DESCRIPTION
Closes #448.

## Problem

`do_bootstrap` explicitly skipped PolicyService in the per-service JWT issuance loop — it only registered `root_key.verifying_key()` into `bootstrap-pubkeys["policy"]` and `continue`d, never minting a JWT. A stale `policy/signing-key` left by a prior wizard/`service repair` run could then diverge from the current `ca-key`, so the trust store's recorded "policy" pubkey disagreed with the key PolicyService actually loads — a silent trust-store inconsistency.

## Fix (issue option 1)

Stop skipping PolicyService. Mint a CA-signed `service:policy` JWT — signed by the CA JWT key (`derive_purpose_key(root_key, "hyprstream-jwt-v1")`), `cnf` binding `root_key.verifying_key()` — and persist it to `policy/service-jwt`, making PolicyService symmetric with every other service.

PolicyService's signing key still resolves to `root_key` (no independent `policy/signing-key` is ever created), so:

```
trust-store key  ==  JWT cnf  ==  actual signer  ==  root_key.verifying_key()
```

This keeps the on-disk credential in lockstep with what the trust store records, so a later repair/reinstall can no longer leave a stale `policy` pair that disagrees with the current CA key. It also enables future per-service rotation of the policy credential.

## Verification

- `cargo test -p hyprstream --lib auth::service_jwt` — passes (incl. new `policy_service_jwt_is_symmetric_and_binds_root_key`)
- `cargo test -p hyprstream --lib cli::bootstrap_manager` — passes
- `cargo clippy -p hyprstream --all-targets -- -D warnings` — clean
- Pre-commit full-workspace release clippy (`--workspace --all-targets --release -- -D warnings`) — passed