### PR TITLE
feat(user): one-command signing-key enrollment (#439)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6855,6 +6855,7 @@ dependencies = [
  "serde_yaml",
  "sha2 0.10.9",
  "shellexpand",
+ "ssh-key",
  "subsecond",
  "subtle",
  "tch",

--- a/crates/hyprstream-rpc-std/schema/oauth.capnp
+++ b/crates/hyprstream-rpc-std/schema/oauth.capnp
@@ -109,10 +109,15 @@ struct PubkeyEntry {
   label @2 :Text;         # user-provided label (e.g., "laptop", "work")
   createdAt @3 :Int64;    # unix timestamp
   lastUsedAt @4 :Int64;   # unix timestamp, 0 if never used
-  # Multicodec algorithm tag (#439/#280): "ed25519" today, "ml-dsa-65"/hybrid
-  # additive later. Defaults to "ed25519" for records written before #439, so
-  # widening the store to PQ is additive rather than a schema migration.
+  # Multicodec algorithm tag (#439/#280): "ed25519" (classical) or
+  # "ed25519+ml-dsa-65" (post-quantum hybrid). Defaults to "ed25519" for records
+  # written before #439, so widening the store to PQ is additive rather than a
+  # schema migration.
   algorithm @5 :Text;
+  # Bound ML-DSA-65 (FIPS 204) verifying key bytes (~1952B) for a hybrid record
+  # (#439). Absent/empty ⇒ classical Ed25519 (None). Kid-anchored to
+  # `fingerprint`; the store enforces algorithm=="ed25519+ml-dsa-65" ⇔ present.
+  pqPubkey @6 :Data;
 }
 
 struct UserListResult {

--- a/crates/hyprstream-rpc-std/schema/oauth.capnp
+++ b/crates/hyprstream-rpc-std/schema/oauth.capnp
@@ -109,6 +109,10 @@ struct PubkeyEntry {
   label @2 :Text;         # user-provided label (e.g., "laptop", "work")
   createdAt @3 :Int64;    # unix timestamp
   lastUsedAt @4 :Int64;   # unix timestamp, 0 if never used
+  # Multicodec algorithm tag (#439/#280): "ed25519" today, "ml-dsa-65"/hybrid
+  # additive later. Defaults to "ed25519" for records written before #439, so
+  # widening the store to PQ is additive rather than a schema migration.
+  algorithm @5 :Text;
 }
 
 struct UserListResult {

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -169,6 +169,7 @@ ciborium.workspace = true                # Canonical CBOR for tamper-evident aud
 tempfile.workspace = true                # Temporary files for model conversion
 base64.workspace = true                  # JWT token encoding
 ed25519-dalek.workspace = true           # JWT Ed25519 signatures
+ssh-key = { version = "0.6", features = ["ed25519", "encryption"] }  # OpenSSH Ed25519 key import (user create --ssh)
 p256.workspace = true                    # ES256 DPoP verification (atproto interop)
 keyring = { version = "3", features = ["linux-native"] }  # OS keyring — Linux keyutils
 curve25519-dalek.workspace = true        # Ristretto255 DH for stream authentication

--- a/crates/hyprstream/src/auth/identity_store.rs
+++ b/crates/hyprstream/src/auth/identity_store.rs
@@ -537,6 +537,54 @@ pub fn load_or_generate_user_signing_key(
     Ok((sk, vk))
 }
 
+/// Install `sk` as the client's user-signing-key (the file
+/// `load_or_generate_user_signing_key` reads), backing up any existing key
+/// first.
+///
+/// Used by `hyprstream user create --ssh`/`--key` (#439) to adopt an external
+/// key as the *actual* signing key the CLI signs with — without this, an
+/// imported-but-not-installed key leaves the client authenticating as
+/// `anonymous`. The previous key, if any, is copied to `user-signing-key.bak`
+/// (mode 0600) so the adopt is reversible; `None` is returned when no prior
+/// key existed.
+pub fn install_user_signing_key(
+    secrets_dir: &std::path::Path,
+    sk: &SigningKey,
+) -> Result<Option<std::path::PathBuf>> {
+    const NAME: &str = "user-signing-key";
+    const BAK: &str = "user-signing-key.bak";
+
+    if !is_writable(secrets_dir) {
+        return Err(missing_in_readonly(secrets_dir, NAME));
+    }
+
+    let path = secrets_dir.join(NAME);
+    let backup = if path.exists() {
+        let bak = secrets_dir.join(BAK);
+        let existing = std::fs::read(&path)
+            .with_context(|| format!("failed to read existing {NAME} for backup"))?;
+        std::fs::write(&bak, &existing)
+            .with_context(|| format!("failed to back up existing {NAME} to '{}'", bak.display()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&bak, std::fs::Permissions::from_mode(0o600))
+                .with_context(|| format!("failed to chmod backup '{}'", bak.display()))?;
+        }
+        tracing::info!("Backed up prior user signing key → '{}'", bak.display());
+        Some(bak)
+    } else {
+        None
+    };
+
+    let mut raw = sk.to_bytes();
+    let result = write_secret(secrets_dir, NAME, &raw);
+    raw.zeroize();
+    result?;
+    tracing::info!("Installed adopted user signing key → '{}/{}'", secrets_dir.display(), NAME);
+    Ok(backup)
+}
+
 /// Load or generate an RSA 2048 keypair for RS256 JWT signing.
 ///
 /// Stored as PKCS#8 DER in `secrets_dir/rsa-key`. If the file doesn't exist

--- a/crates/hyprstream/src/auth/identity_store.rs
+++ b/crates/hyprstream/src/auth/identity_store.rs
@@ -561,16 +561,15 @@ pub fn install_user_signing_key(
     let path = secrets_dir.join(NAME);
     let backup = if path.exists() {
         let bak = secrets_dir.join(BAK);
-        let existing = std::fs::read(&path)
+        // Back up via `write_secret` (atomic temp-file write with mode 0600 set
+        // *before* persist) so the raw seed is never briefly world-readable, and
+        // zeroize the in-memory copy before dropping it.
+        let mut existing = std::fs::read(&path)
             .with_context(|| format!("failed to read existing {NAME} for backup"))?;
-        std::fs::write(&bak, &existing)
+        let result = write_secret(secrets_dir, BAK, &existing);
+        existing.zeroize();
+        result
             .with_context(|| format!("failed to back up existing {NAME} to '{}'", bak.display()))?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&bak, std::fs::Permissions::from_mode(0o600))
-                .with_context(|| format!("failed to chmod backup '{}'", bak.display()))?;
-        }
         tracing::info!("Backed up prior user signing key → '{}'", bak.display());
         Some(bak)
     } else {
@@ -583,6 +582,190 @@ pub fn install_user_signing_key(
     result?;
     tracing::info!("Installed adopted user signing key → '{}/{}'", secrets_dir.display(), NAME);
     Ok(backup)
+}
+
+// ─── Post-quantum hybrid user identity (#439) ────────────────────────────────
+
+/// The on-disk name of the ML-DSA-65 sibling of `user-signing-key`.
+const USER_PQ_NAME: &str = "user-signing-key.mldsa";
+const USER_PQ_BAK: &str = "user-signing-key.mldsa.bak";
+
+/// A user's client identity key material: the Ed25519 anchor plus an optional
+/// bound ML-DSA-65 key (present under [`CryptoPolicy::Hybrid`], absent under
+/// `Classical`). The fingerprint / kid is always the Ed25519 anchor's — the PQ
+/// key is bound *to* it, never fingerprinted itself.
+pub struct UserIdentityKeys {
+    pub ed: SigningKey,
+    pub mldsa: Option<hyprstream_rpc::crypto::pq::MlDsaSigningKey>,
+}
+
+impl UserIdentityKeys {
+    /// The store algorithm tag this key material corresponds to.
+    pub fn algorithm(&self) -> crate::auth::KeyAlgorithm {
+        if self.mldsa.is_some() {
+            crate::auth::KeyAlgorithm::HybridEd25519MlDsa65
+        } else {
+            crate::auth::KeyAlgorithm::Ed25519
+        }
+    }
+
+    /// The bound ML-DSA-65 verifying key bytes (~1952B), if hybrid.
+    pub fn pq_verifying_key_bytes(&self) -> Option<Vec<u8>> {
+        self.mldsa
+            .as_ref()
+            .map(hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes)
+    }
+}
+
+/// Load (or, under `Hybrid`, generate) the user's identity key material for the
+/// given [`CryptoPolicy`].
+///
+/// - The Ed25519 anchor is loaded/generated exactly as before
+///   ([`load_or_generate_user_signing_key`]) — the on-disk `user-signing-key`
+///   file is unchanged, so existing loaders keep working.
+/// - Under [`CryptoPolicy::Hybrid`] an ML-DSA-65 sibling
+///   (`user-signing-key.mldsa`, a 32-byte FIPS 204 seed) is loaded if present,
+///   or generated when absent. This covers the **in-place upgrade** case: a
+///   legacy secrets dir that has only the Ed25519 key gains a bound PQ key for
+///   the *same anchor* (same fingerprint) — no re-enrollment. If the PQ
+///   component is missing and the directory is not writable, or if generating /
+///   persisting it fails, this is a **hard error — never a classical fallback**
+///   (fail closed, matching the node's default Hybrid policy).
+/// - Under [`CryptoPolicy::Classical`] no PQ key is loaded or generated.
+pub fn load_or_generate_user_identity(
+    secrets_dir: &std::path::Path,
+    policy: hyprstream_rpc::crypto::CryptoPolicy,
+) -> Result<UserIdentityKeys> {
+    use hyprstream_rpc::crypto::pq;
+
+    let (ed, _vk) = load_or_generate_user_signing_key(secrets_dir)?;
+
+    if !policy.uses_pq() {
+        return Ok(UserIdentityKeys { ed, mldsa: None });
+    }
+
+    // Hybrid: load the PQ sibling if present, else generate (fail closed).
+    if let Some(mut seed_bytes) = read_secret(secrets_dir, USER_PQ_NAME)? {
+        let mut seed: [u8; 32] = seed_bytes
+            .as_slice()
+            .try_into()
+            .map_err(|_| anyhow!("secret '{}' must be 32 bytes (ML-DSA-65 seed)", USER_PQ_NAME))?;
+        let mldsa = pq::ml_dsa_sk_from_seed(&seed);
+        seed_bytes.zeroize();
+        seed.zeroize();
+        tracing::info!("Loaded hybrid PQ (ML-DSA-65) user key from '{}'", secrets_dir.display());
+        return Ok(UserIdentityKeys { ed, mldsa: Some(mldsa) });
+    }
+
+    // Missing PQ component. Under Hybrid this must be generated; if we cannot
+    // write, fail closed rather than mint a classical-only identity.
+    if !is_writable(secrets_dir) {
+        return Err(anyhow!(
+            "CryptoPolicy is Hybrid but the post-quantum component '{}' is missing \
+             and '{}' is not writable — refusing to fall back to a classical-only \
+             identity (fail closed). Provision the ML-DSA-65 key or set the policy \
+             to Classical explicitly.",
+            USER_PQ_NAME,
+            secrets_dir.display()
+        ));
+    }
+
+    let (mldsa, _mldsa_vk) = pq::ml_dsa_generate_keypair();
+    let mut seed = pq::ml_dsa_sk_to_seed(&mldsa);
+    let result = write_secret(secrets_dir, USER_PQ_NAME, &seed);
+    seed.zeroize();
+    result.with_context(|| {
+        format!(
+            "CryptoPolicy is Hybrid but persisting the ML-DSA-65 component '{}' failed \
+             — refusing a classical-only fallback (fail closed)",
+            USER_PQ_NAME
+        )
+    })?;
+    tracing::info!(
+        "Generated new hybrid PQ (ML-DSA-65) user key → '{}/{}'",
+        secrets_dir.display(),
+        USER_PQ_NAME
+    );
+    Ok(UserIdentityKeys { ed, mldsa: Some(mldsa) })
+}
+
+/// Paths of any prior key files displaced by an adopt, so the caller can report
+/// the backup(s).
+#[derive(Debug, Default)]
+pub struct InstalledIdentityBackup {
+    pub ed: Option<std::path::PathBuf>,
+    pub pq: Option<std::path::PathBuf>,
+}
+
+/// Install adopted identity key material (the `--ssh`/`--key` path), backing up
+/// any displaced key files first.
+///
+/// The adopted Ed25519 key becomes the client's `user-signing-key` (via
+/// [`install_user_signing_key`]). Under `Hybrid`, a **freshly generated**
+/// ML-DSA-65 key is installed as its sibling — an adopted SSH/seed key can never
+/// make the identity hybrid by itself, so a new PQ component is minted and bound
+/// to the same anchor. Under `Classical`, no PQ sibling is written, and any
+/// pre-existing sibling is backed up and removed so the on-disk pair stays
+/// consistent (the file layout never claims hybrid without a matching PQ key).
+pub fn install_user_identity(
+    secrets_dir: &std::path::Path,
+    ed_sk: &SigningKey,
+    mldsa_sk: Option<&hyprstream_rpc::crypto::pq::MlDsaSigningKey>,
+) -> Result<InstalledIdentityBackup> {
+    use hyprstream_rpc::crypto::pq;
+
+    let ed_backup = install_user_signing_key(secrets_dir, ed_sk)?;
+
+    let pq_backup = match mldsa_sk {
+        Some(mldsa) => {
+            // Back up any existing PQ sibling, then install the fresh one.
+            let bak = backup_secret_if_present(secrets_dir, USER_PQ_NAME, USER_PQ_BAK)?;
+            let mut seed = pq::ml_dsa_sk_to_seed(mldsa);
+            let result = write_secret(secrets_dir, USER_PQ_NAME, &seed);
+            seed.zeroize();
+            result?;
+            tracing::info!(
+                "Installed adopted hybrid PQ (ML-DSA-65) user key → '{}/{}'",
+                secrets_dir.display(),
+                USER_PQ_NAME
+            );
+            bak
+        }
+        None => {
+            // Classical adopt: retire any stale PQ sibling so the pair is
+            // consistent (never leave a PQ seed bound to a displaced anchor).
+            let bak = backup_secret_if_present(secrets_dir, USER_PQ_NAME, USER_PQ_BAK)?;
+            if bak.is_some() {
+                let live = secrets_dir.join(USER_PQ_NAME);
+                std::fs::remove_file(&live).with_context(|| {
+                    format!("failed to retire stale PQ key '{}'", live.display())
+                })?;
+                tracing::info!("Retired stale PQ user key (classical adopt) → backup kept");
+            }
+            bak
+        }
+    };
+
+    Ok(InstalledIdentityBackup { ed: ed_backup, pq: pq_backup })
+}
+
+/// Back up `name` → `bak_name` (via [`write_secret`], mode 0600 before persist)
+/// if `name` exists, zeroizing the read buffer. Returns the backup path if made.
+fn backup_secret_if_present(
+    secrets_dir: &std::path::Path,
+    name: &str,
+    bak_name: &str,
+) -> Result<Option<std::path::PathBuf>> {
+    let path = secrets_dir.join(name);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let mut existing = std::fs::read(&path)
+        .with_context(|| format!("failed to read existing {name} for backup"))?;
+    let result = write_secret(secrets_dir, bak_name, &existing);
+    existing.zeroize();
+    result.with_context(|| format!("failed to back up existing {name}"))?;
+    Ok(Some(secrets_dir.join(bak_name)))
 }
 
 /// Load or generate an RSA 2048 keypair for RS256 JWT signing.

--- a/crates/hyprstream/src/auth/mod.rs
+++ b/crates/hyprstream/src/auth/mod.rs
@@ -29,7 +29,7 @@ pub use key_rotation::{MlDsaSigningKeyStore, MlDsaKeySlot};
 pub use policy_manager::{PolicyManager, PolicyError, write_policy_file, global_policy_manager, set_global_policy_manager};
 pub use policy_migration::migrate_policy_csv;
 pub use policy_templates::{PolicyTemplate, ServicePolicyRule, SERVICE_BASE_POLICIES, get_template, get_templates};
-pub use user_store::{DeviceRecord, DeviceStore, UserFilter, UserProfile, UserStore, PubkeyEntry, pubkey_fingerprint, decode_pubkey_base64};
+pub use user_store::{DeviceRecord, DeviceStore, KeyAlgorithm, UserFilter, UserProfile, UserStore, PubkeyEntry, pubkey_fingerprint, decode_pubkey_base64};
 pub use rocksdb_store::RocksDbUserStore;
 #[cfg(feature = "valkey")]
 pub use valkey::ValkeyUserStore;

--- a/crates/hyprstream/src/auth/rocksdb_store.rs
+++ b/crates/hyprstream/src/auth/rocksdb_store.rs
@@ -52,6 +52,9 @@ struct StoredPubkey {
     last_used_at: i64, // 0 means never used
     /// Algorithm tag (#439). Defaults to Ed25519 for pre-#439 records.
     algorithm: KeyAlgorithm,
+    /// Bound ML-DSA-65 verifying key bytes for a hybrid record (#439); `None`
+    /// for classical Ed25519. Invariant: `algorithm.is_hybrid() ⇔ Some`.
+    pq_pubkey: Option<Vec<u8>>,
 }
 
 pub struct RocksDbUserStore {
@@ -140,6 +143,20 @@ impl RocksDbUserStore {
                 entry.set_created_at(pk.created_at);
                 entry.set_last_used_at(pk.last_used_at);
                 entry.set_algorithm(pk.algorithm.as_str());
+                // Enforce the hybrid⇔pq_pubkey invariant on the write path too,
+                // so a malformed StoredPubkey can never be persisted.
+                match (pk.algorithm.is_hybrid(), &pk.pq_pubkey) {
+                    (true, Some(vk)) => entry.set_pq_pubkey(vk),
+                    (false, None) => {}
+                    (true, None) => anyhow::bail!(
+                        "hybrid pubkey {} has no ML-DSA-65 key material (refusing to persist)",
+                        pk.fingerprint
+                    ),
+                    (false, Some(_)) => anyhow::bail!(
+                        "classical pubkey {} carries ML-DSA-65 key material (refusing to persist)",
+                        pk.fingerprint
+                    ),
+                }
             }
         }
         let mut bytes = vec![flags];
@@ -179,16 +196,41 @@ impl RocksDbUserStore {
         let mut pubkeys = Vec::new();
         if ui.has_pubkeys() {
             for pk in ui.get_pubkeys()? {
+                let fingerprint = pk.get_fingerprint()?.to_string()?;
+                // Pre-#439 records have no algorithm tag → default Ed25519.
+                // A present-but-unknown tag must error rather than be misread as
+                // Ed25519 (would silently downgrade a PQ-hybrid key written by a
+                // newer build).
+                let algorithm = match text_or_none(pk.get_algorithm()) {
+                    Some(s) => KeyAlgorithm::parse(&s)?,
+                    None => KeyAlgorithm::default(),
+                };
+                // `pqPubkey` absent/empty ⇒ None. Enforce the hybrid⇔pq_pubkey
+                // invariant: a Hybrid record with no PQ bytes is a fail-closed
+                // read error, never a silent downgrade to Ed25519.
+                let pq_pubkey = match pk.get_pq_pubkey() {
+                    Ok(bytes) if !bytes.is_empty() => Some(bytes.to_vec()),
+                    _ => None,
+                };
+                match (algorithm.is_hybrid(), &pq_pubkey) {
+                    (true, Some(_)) | (false, None) => {}
+                    (true, None) => anyhow::bail!(
+                        "hybrid pubkey record {fingerprint} is missing its ML-DSA-65 \
+                         key material (refusing to read — fail closed)"
+                    ),
+                    (false, Some(_)) => anyhow::bail!(
+                        "classical pubkey record {fingerprint} carries unexpected \
+                         ML-DSA-65 key material (refusing to read)"
+                    ),
+                }
                 pubkeys.push(StoredPubkey {
-                    fingerprint: pk.get_fingerprint()?.to_string()?,
+                    fingerprint,
                     pubkey_base64: pk.get_pubkey_base64()?.to_string()?,
                     label: text_or_none(pk.get_label()),
                     created_at: pk.get_created_at(),
                     last_used_at: pk.get_last_used_at(),
-                    // Pre-#439 records have no algorithm tag → default Ed25519.
-                    algorithm: text_or_none(pk.get_algorithm())
-                        .and_then(|s| KeyAlgorithm::parse(&s).ok())
-                        .unwrap_or_default(),
+                    algorithm,
+                    pq_pubkey,
                 });
             }
         }
@@ -413,6 +455,7 @@ impl UserStore for RocksDbUserStore {
                 created_at: sp.created_at,
                 last_used_at: if sp.last_used_at == 0 { None } else { Some(sp.last_used_at) },
                 algorithm: sp.algorithm,
+                pq_pubkey: sp.pq_pubkey,
             });
         }
         Ok(entries)
@@ -451,10 +494,67 @@ impl UserStore for RocksDbUserStore {
             label,
             created_at: now,
             last_used_at: 0,
-            // Only Ed25519 keys can reach add_pubkey today; the tag is baked in
-            // so widening the trait to PQ later is additive (#439).
+            // Classical binding: no PQ component (#439).
             algorithm: KeyAlgorithm::Ed25519,
+            pq_pubkey: None,
         });
+
+        self.put_user(username, &sub, &profile, &pubkeys)?;
+        self.put_pubkey_index(&fingerprint, username)?;
+
+        Ok(fingerprint)
+    }
+
+    async fn add_pubkey_hybrid(
+        &self,
+        username: &str,
+        pubkey: VerifyingKey,
+        ml_dsa_vk: Vec<u8>,
+        label: Option<String>,
+    ) -> Result<String> {
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        use base64::Engine;
+
+        if ml_dsa_vk.is_empty() {
+            anyhow::bail!("add_pubkey_hybrid: empty ML-DSA-65 verifying key");
+        }
+
+        let (sub, profile, mut pubkeys) = self.get_raw(username)?
+            .ok_or_else(|| anyhow!("User '{}' not found", username))?;
+
+        // Fingerprint is the Ed25519 anchor's (kid) — the PQ vk does not change it.
+        let fingerprint = pubkey_fingerprint(&pubkey);
+
+        // Reject a fingerprint bound to a *different* user.
+        if let Some(existing_user) = self.get_pubkey_index(&fingerprint)? {
+            if existing_user != username {
+                anyhow::bail!("Pubkey already associated with user '{}'", existing_user);
+            }
+        }
+
+        let pubkey_base64 = URL_SAFE_NO_PAD.encode(pubkey.as_bytes());
+        if let Some(existing) = pubkeys.iter_mut().find(|pk| pk.fingerprint == fingerprint) {
+            // In-place upgrade path: an existing record for the same anchor is
+            // lifted Ed25519 → Hybrid. Hybrid → Hybrid is idempotent (re-bind).
+            // There is no Hybrid → Ed25519 transition here (this method only
+            // ever sets Hybrid), so the forbidden downgrade cannot occur.
+            existing.algorithm = KeyAlgorithm::HybridEd25519MlDsa65;
+            existing.pq_pubkey = Some(ml_dsa_vk);
+            if label.is_some() {
+                existing.label = label;
+            }
+        } else {
+            let now = chrono::Utc::now().timestamp();
+            pubkeys.push(StoredPubkey {
+                fingerprint: fingerprint.clone(),
+                pubkey_base64,
+                label,
+                created_at: now,
+                last_used_at: 0,
+                algorithm: KeyAlgorithm::HybridEd25519MlDsa65,
+                pq_pubkey: Some(ml_dsa_vk),
+            });
+        }
 
         self.put_user(username, &sub, &profile, &pubkeys)?;
         self.put_pubkey_index(&fingerprint, username)?;
@@ -1006,5 +1106,113 @@ mod tests {
         // Reverse lookup should also work
         assert_eq!(store2.get_pubkey_user(&fingerprint).await?, Some("alice".to_owned()));
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_hybrid_pubkey_round_trips_pq_material_across_reopen() -> Result<()> {
+        let dir = TempDir::new()?;
+        let key = SigningKey::generate(&mut rand::thread_rng()).verifying_key();
+        // A stand-in ML-DSA-65 vk (bytes are opaque to the store).
+        let pq_vk = vec![0xABu8; 1952];
+        let fingerprint;
+        {
+            let store = make_store(dir.path());
+            store.register("alice").await?;
+            fingerprint = store
+                .add_pubkey_hybrid("alice", key, pq_vk.clone(), Some("laptop".to_owned()))
+                .await?;
+        }
+
+        // Reopen (exercises capnp serialize + deserialize of pqPubkey).
+        let store2 = RocksDbUserStore::open(dir.path())?;
+        let keys = store2.list_pubkeys("alice").await?;
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].fingerprint, fingerprint);
+        assert_eq!(keys[0].algorithm, KeyAlgorithm::HybridEd25519MlDsa65);
+        assert_eq!(keys[0].pq_pubkey.as_ref(), Some(&pq_vk));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_hybrid_upgrade_in_place_preserves_fingerprint() -> Result<()> {
+        let dir = TempDir::new()?;
+        let key = SigningKey::generate(&mut rand::thread_rng()).verifying_key();
+        let store = make_store(dir.path());
+        store.register("alice").await?;
+
+        // Classical first, then upgrade the SAME anchor to hybrid.
+        let fp1 = store.add_pubkey("alice", key, None).await?;
+        let fp2 = store
+            .add_pubkey_hybrid("alice", key, vec![0x11u8; 1952], None)
+            .await?;
+        assert_eq!(fp1, fp2, "hybrid upgrade keeps the Ed25519 anchor fingerprint");
+
+        let keys = store.list_pubkeys("alice").await?;
+        assert_eq!(keys.len(), 1, "in-place upgrade, not a second key");
+        assert_eq!(keys[0].algorithm, KeyAlgorithm::HybridEd25519MlDsa65);
+        assert!(keys[0].pq_pubkey.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn test_serialize_rejects_invariant_violations() {
+        // Hybrid tag with no PQ material must not be persistable.
+        let bad_hybrid = StoredPubkey {
+            fingerprint: "SHA256:x".to_owned(),
+            pubkey_base64: "AAAA".to_owned(),
+            label: None,
+            created_at: 0,
+            last_used_at: 0,
+            algorithm: KeyAlgorithm::HybridEd25519MlDsa65,
+            pq_pubkey: None,
+        };
+        let profile = UserProfile::default();
+        assert!(
+            RocksDbUserStore::serialize_profile("sub", &profile, &[bad_hybrid]).is_err(),
+            "hybrid record with no PQ key must fail to serialize"
+        );
+
+        // Classical tag carrying PQ material is equally invalid.
+        let bad_classical = StoredPubkey {
+            fingerprint: "SHA256:y".to_owned(),
+            pubkey_base64: "AAAA".to_owned(),
+            label: None,
+            created_at: 0,
+            last_used_at: 0,
+            algorithm: KeyAlgorithm::Ed25519,
+            pq_pubkey: Some(vec![1, 2, 3]),
+        };
+        assert!(
+            RocksDbUserStore::serialize_profile("sub", &profile, &[bad_classical]).is_err(),
+            "classical record carrying PQ key material must fail to serialize"
+        );
+    }
+
+    #[test]
+    fn test_deserialize_rejects_unknown_algorithm_tag() {
+        // Hand-build a UserInfo capnp record whose pubkey carries a future,
+        // unknown algorithm tag; the read path must error (never silently
+        // downgrade to Ed25519).
+        let mut message = Builder::new_default();
+        {
+            let mut ui = message.init_root::<crate::oauth_capnp::user_info::Builder>();
+            ui.set_sub("sub");
+            let mut pk_list = ui.init_pubkeys(1);
+            let mut e = pk_list.reborrow().get(0);
+            e.set_fingerprint("SHA256:z");
+            e.set_pubkey_base64("AAAA");
+            e.set_created_at(0);
+            e.set_last_used_at(0);
+            e.set_algorithm("ml-dsa-99-future");
+        }
+        let mut bytes = vec![0u8]; // presence-flags prefix
+        capnp::serialize::write_message(&mut bytes, &message).unwrap();
+
+        let err = RocksDbUserStore::deserialize_profile(&bytes)
+            .expect_err("unknown algorithm tag must fail the read");
+        assert!(
+            err.to_string().to_lowercase().contains("unknown key algorithm"),
+            "error must name the unknown tag: {err}"
+        );
     }
 }

--- a/crates/hyprstream/src/auth/rocksdb_store.rs
+++ b/crates/hyprstream/src/auth/rocksdb_store.rs
@@ -16,7 +16,7 @@ use ed25519_dalek::VerifyingKey;
 use std::io::Cursor;
 use std::path::Path;
 
-use super::user_store::{pubkey_fingerprint, matches_filter, DeviceRecord, DeviceStore, PubkeyEntry, UserFilter, UserProfile, UserStore};
+use super::user_store::{pubkey_fingerprint, matches_filter, DeviceRecord, DeviceStore, KeyAlgorithm, PubkeyEntry, UserFilter, UserProfile, UserStore};
 
 const USER_PREFIX: &[u8] = b"user:";
 const PUBKEY_PREFIX: &[u8] = b"pubkey:";
@@ -50,6 +50,8 @@ struct StoredPubkey {
     label: Option<String>,
     created_at: i64,
     last_used_at: i64, // 0 means never used
+    /// Algorithm tag (#439). Defaults to Ed25519 for pre-#439 records.
+    algorithm: KeyAlgorithm,
 }
 
 pub struct RocksDbUserStore {
@@ -137,6 +139,7 @@ impl RocksDbUserStore {
                 }
                 entry.set_created_at(pk.created_at);
                 entry.set_last_used_at(pk.last_used_at);
+                entry.set_algorithm(pk.algorithm.as_str());
             }
         }
         let mut bytes = vec![flags];
@@ -182,6 +185,10 @@ impl RocksDbUserStore {
                     label: text_or_none(pk.get_label()),
                     created_at: pk.get_created_at(),
                     last_used_at: pk.get_last_used_at(),
+                    // Pre-#439 records have no algorithm tag → default Ed25519.
+                    algorithm: text_or_none(pk.get_algorithm())
+                        .and_then(|s| KeyAlgorithm::parse(&s).ok())
+                        .unwrap_or_default(),
                 });
             }
         }
@@ -405,6 +412,7 @@ impl UserStore for RocksDbUserStore {
                 label: sp.label,
                 created_at: sp.created_at,
                 last_used_at: if sp.last_used_at == 0 { None } else { Some(sp.last_used_at) },
+                algorithm: sp.algorithm,
             });
         }
         Ok(entries)
@@ -443,6 +451,9 @@ impl UserStore for RocksDbUserStore {
             label,
             created_at: now,
             last_used_at: 0,
+            // Only Ed25519 keys can reach add_pubkey today; the tag is baked in
+            // so widening the trait to PQ later is additive (#439).
+            algorithm: KeyAlgorithm::Ed25519,
         });
 
         self.put_user(username, &sub, &profile, &pubkeys)?;
@@ -815,6 +826,32 @@ mod tests {
         assert_eq!(keys[0].label.as_deref(), Some("laptop"));
         assert_eq!(keys[0].pubkey.as_bytes(), pubkey.as_bytes());
         assert!(keys[0].last_used_at.is_none());
+        // #439: every stored pubkey carries an algorithm tag (Ed25519 today).
+        assert_eq!(keys[0].algorithm, KeyAlgorithm::Ed25519);
+        Ok(())
+    }
+
+    /// #439: the algorithm tag survives a RocksDB roundtrip (serialize →
+    /// close → reopen → deserialize), so widening the store to PQ later is
+    /// additive rather than a re-migration of existing records.
+    #[tokio::test]
+    async fn test_pubkey_algorithm_tag_persists_across_reopen() -> Result<()> {
+        let dir = TempDir::new()?;
+        {
+            let store = make_store(dir.path());
+            store.register("alice").await?;
+            let pubkey = SigningKey::generate(&mut rand::thread_rng()).verifying_key();
+            store.add_pubkey("alice", pubkey, None).await?;
+            // `store` is dropped here, releasing the RocksDB write lock so the
+            // reopen below succeeds in the same process.
+        }
+
+        // Reopen the same store (exercises capnp serialize + deserialize path).
+        let store2 = RocksDbUserStore::open(dir.path())?;
+        let keys = store2.list_pubkeys("alice").await?;
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].algorithm, KeyAlgorithm::Ed25519);
+        assert_eq!(keys[0].algorithm.as_str(), "ed25519");
         Ok(())
     }
 

--- a/crates/hyprstream/src/auth/user_store.rs
+++ b/crates/hyprstream/src/auth/user_store.rs
@@ -31,6 +31,49 @@ pub struct UserProfile {
     pub external_id: Option<String>,
 }
 
+/// The public-key algorithm of a stored [`PubkeyEntry`].
+///
+/// Ed25519 is the only implemented variant today; the tag exists from day one
+/// (#439) so that adding ML-DSA-65 / hybrid user keys later (mirroring the
+/// #280 Multikey path) is *additive* — every record already carries its
+/// algorithm, so widening `UserStore::add_pubkey` past Ed25519 will not be a
+/// store-schema migration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum KeyAlgorithm {
+    Ed25519,
+}
+
+impl Default for KeyAlgorithm {
+    /// Ed25519 is the classical floor for local human identity keys (the same
+    /// call already made for the iroh NodeId); PQ user keys are deferred.
+    fn default() -> Self {
+        Self::Ed25519
+    }
+}
+
+impl KeyAlgorithm {
+    /// Multicodec-style lowercase algorithm name written into stored records.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Ed25519 => "ed25519",
+        }
+    }
+
+    /// Parse an algorithm tag read back from a stored record.
+    ///
+    /// Unknown tags error rather than silently falling back, so a future PQ
+    /// tag written by a newer build is never misread as Ed25519 by this one.
+    pub fn parse(s: &str) -> anyhow::Result<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "ed25519" => Ok(Self::Ed25519),
+            other => anyhow::bail!(
+                "Unknown key algorithm tag '{other}'; only 'ed25519' is implemented in this build"
+            ),
+        }
+    }
+}
+
 /// A pubkey entry associated with a user (like GitHub SSH keys).
 #[derive(Debug, Clone)]
 pub struct PubkeyEntry {
@@ -44,6 +87,9 @@ pub struct PubkeyEntry {
     pub created_at: i64,
     /// Unix timestamp when the key was last used for auth, or None if never.
     pub last_used_at: Option<i64>,
+    /// Algorithm tag (#439). Defaults to [`KeyAlgorithm::Ed25519`] for records
+    /// written before the tag existed.
+    pub algorithm: KeyAlgorithm,
 }
 
 /// Filter parameters for user search (SCIM-aligned).
@@ -325,6 +371,7 @@ pub trait DeviceStore: Send + Sync {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 
@@ -346,5 +393,17 @@ mod tests {
         assert!(matches_filter("userName pr", "alice", &None, &None, None));
         assert!(matches_filter("id pr", "alice", &sub, &None, None));
         assert!(!matches_filter("active pr", "alice", &None, &None, None));
+    }
+
+    #[test]
+    fn test_key_algorithm_parse_and_roundtrip() {
+        assert_eq!(KeyAlgorithm::Ed25519.as_str(), "ed25519");
+        assert_eq!(KeyAlgorithm::default(), KeyAlgorithm::Ed25519);
+        // Accepts case/whitespace variants.
+        assert_eq!(KeyAlgorithm::parse("ed25519").unwrap(), KeyAlgorithm::Ed25519);
+        assert_eq!(KeyAlgorithm::parse("  Ed25519 ").unwrap(), KeyAlgorithm::Ed25519);
+        // Unknown tags error (never silently fall back to Ed25519).
+        assert!(KeyAlgorithm::parse("ml-dsa-65").is_err());
+        assert!(KeyAlgorithm::parse("").is_err());
     }
 }

--- a/crates/hyprstream/src/auth/user_store.rs
+++ b/crates/hyprstream/src/auth/user_store.rs
@@ -33,31 +33,46 @@ pub struct UserProfile {
 
 /// The public-key algorithm of a stored [`PubkeyEntry`].
 ///
-/// Ed25519 is the only implemented variant today; the tag exists from day one
-/// (#439) so that adding ML-DSA-65 / hybrid user keys later (mirroring the
-/// #280 Multikey path) is *additive* — every record already carries its
-/// algorithm, so widening `UserStore::add_pubkey` past Ed25519 will not be a
-/// store-schema migration.
+/// - [`Ed25519`](Self::Ed25519) — classical anchor only (the pre-#439 default,
+///   and what SSH/raw-seed adopt still contributes as its classical component).
+/// - [`HybridEd25519MlDsa65`](Self::HybridEd25519MlDsa65) — the Ed25519 anchor
+///   with a **bound ML-DSA-65 verifying key** (#439 PQ enrollment). This mirrors
+///   the `register_pq_trust` / `KeyedPqTrustStore` envelope model and the
+///   did:at9p ed25519→ml_dsa binding: the fingerprint stays the Ed25519 anchor's
+///   SHA256, and the ML-DSA-65 vk is carried alongside in `pq_pubkey`.
+///
+/// Invariant enforced by the stores: `HybridEd25519MlDsa65 ⇔ pq_pubkey.is_some()`.
+/// A hybrid record with missing PQ bytes is a **read error** (fail closed),
+/// never a silent downgrade to Ed25519.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum KeyAlgorithm {
     Ed25519,
+    /// EdDSA (Ed25519) anchor + bound ML-DSA-65 (FIPS 204) — post-quantum hybrid.
+    #[serde(rename = "ed25519+ml-dsa-65")]
+    HybridEd25519MlDsa65,
 }
 
 impl Default for KeyAlgorithm {
-    /// Ed25519 is the classical floor for local human identity keys (the same
-    /// call already made for the iroh NodeId); PQ user keys are deferred.
+    /// Ed25519 is the classical floor for records with no algorithm tag
+    /// (pre-#439) and for the SSH/raw-seed adopt paths' classical component.
     fn default() -> Self {
         Self::Ed25519
     }
 }
 
 impl KeyAlgorithm {
-    /// Multicodec-style lowercase algorithm name written into stored records.
+    /// Canonical lowercase algorithm tag written into stored records.
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Ed25519 => "ed25519",
+            Self::HybridEd25519MlDsa65 => "ed25519+ml-dsa-65",
         }
+    }
+
+    /// Whether this algorithm carries a post-quantum (ML-DSA-65) component.
+    pub fn is_hybrid(&self) -> bool {
+        matches!(self, Self::HybridEd25519MlDsa65)
     }
 
     /// Parse an algorithm tag read back from a stored record.
@@ -67,8 +82,10 @@ impl KeyAlgorithm {
     pub fn parse(s: &str) -> anyhow::Result<Self> {
         match s.trim().to_ascii_lowercase().as_str() {
             "ed25519" => Ok(Self::Ed25519),
+            "ed25519+ml-dsa-65" => Ok(Self::HybridEd25519MlDsa65),
             other => anyhow::bail!(
-                "Unknown key algorithm tag '{other}'; only 'ed25519' is implemented in this build"
+                "Unknown key algorithm tag '{other}'; this build implements \
+                 'ed25519' and 'ed25519+ml-dsa-65'"
             ),
         }
     }
@@ -90,6 +107,13 @@ pub struct PubkeyEntry {
     /// Algorithm tag (#439). Defaults to [`KeyAlgorithm::Ed25519`] for records
     /// written before the tag existed.
     pub algorithm: KeyAlgorithm,
+    /// Bound ML-DSA-65 verifying key bytes (~1952B) for a
+    /// [`KeyAlgorithm::HybridEd25519MlDsa65`] record; `None` for classical
+    /// Ed25519. Kid-anchored to `fingerprint` (the Ed25519 anchor); resolved
+    /// by the challenge verifier, never carried in a login request. The
+    /// `algorithm.is_hybrid() ⇔ pq_pubkey.is_some()` invariant is enforced at
+    /// store read/write.
+    pub pq_pubkey: Option<Vec<u8>>,
 }
 
 /// Filter parameters for user search (SCIM-aligned).
@@ -143,11 +167,34 @@ pub trait UserStore: Send + Sync {
     /// List all pubkeys for a user.
     async fn list_pubkeys(&self, username: &str) -> Result<Vec<PubkeyEntry>>;
 
-    /// Add a pubkey to a user. Returns the fingerprint.
+    /// Add a classical Ed25519 pubkey to a user. Returns the fingerprint.
+    ///
+    /// Records `KeyAlgorithm::Ed25519` with no PQ component. For post-quantum
+    /// hybrid enrollment use [`add_pubkey_hybrid`](Self::add_pubkey_hybrid).
     async fn add_pubkey(
         &self,
         username: &str,
         pubkey: VerifyingKey,
+        label: Option<String>,
+    ) -> Result<String>;
+
+    /// Add a post-quantum **hybrid** identity key: the Ed25519 anchor plus its
+    /// bound ML-DSA-65 verifying key (#439). Returns the fingerprint (of the
+    /// Ed25519 anchor — the PQ vk does not change the kid).
+    ///
+    /// Records `KeyAlgorithm::HybridEd25519MlDsa65` with `pq_pubkey = Some(..)`.
+    /// If a classical Ed25519 record for the same anchor already exists, this is
+    /// the in-place upgrade path (Ed25519 → Hybrid for the same fingerprint);
+    /// the reverse transition is rejected.
+    ///
+    /// `ml_dsa_vk` must be the ~1952-byte ML-DSA-65 verifying key encoding
+    /// (`pq::ml_dsa_vk_bytes`). Required of every backend — no fail-open default
+    /// that could silently drop the PQ binding.
+    async fn add_pubkey_hybrid(
+        &self,
+        username: &str,
+        pubkey: VerifyingKey,
+        ml_dsa_vk: Vec<u8>,
         label: Option<String>,
     ) -> Result<String>;
 

--- a/crates/hyprstream/src/auth/valkey.rs
+++ b/crates/hyprstream/src/auth/valkey.rs
@@ -32,6 +32,10 @@ struct StoredKey {
     /// Algorithm tag (#439). Defaults to Ed25519 for pre-#439 records.
     #[serde(default)]
     algorithm: crate::auth::KeyAlgorithm,
+    /// Standard-base64 ML-DSA-65 verifying key for a hybrid record (#439);
+    /// `None`/absent for classical Ed25519. Invariant: present ⇔ hybrid tag.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pq_pubkey_base64: Option<String>,
 }
 
 pub struct ValkeyUserStore {
@@ -248,6 +252,28 @@ impl UserStore for ValkeyUserStore {
                 let raw = base64::engine::general_purpose::STANDARD.decode(&stored.pubkey_base64)?;
                 let key_bytes: [u8; 32] = raw.try_into().map_err(|_| anyhow!("bad key length"))?;
                 let pubkey = VerifyingKey::from_bytes(&key_bytes)?;
+                // Decode + invariant-check the PQ component (fail closed on a
+                // Hybrid record with no/empty PQ bytes — never a silent
+                // downgrade to Ed25519).
+                let pq_pubkey = match stored.pq_pubkey_base64.as_deref() {
+                    Some(b64) if !b64.is_empty() => Some(
+                        base64::engine::general_purpose::STANDARD
+                            .decode(b64)
+                            .with_context(|| format!("invalid base64 ML-DSA-65 key for {fp}"))?,
+                    ),
+                    _ => None,
+                };
+                match (stored.algorithm.is_hybrid(), &pq_pubkey) {
+                    (true, Some(_)) | (false, None) => {}
+                    (true, None) => anyhow::bail!(
+                        "hybrid pubkey record {fp} is missing its ML-DSA-65 key \
+                         material (refusing to read — fail closed)"
+                    ),
+                    (false, Some(_)) => anyhow::bail!(
+                        "classical pubkey record {fp} carries unexpected ML-DSA-65 \
+                         key material (refusing to read)"
+                    ),
+                }
                 entries.push(PubkeyEntry {
                     fingerprint: fp,
                     pubkey,
@@ -255,6 +281,7 @@ impl UserStore for ValkeyUserStore {
                     created_at: stored.created_at,
                     last_used_at: stored.last_used_at,
                     algorithm: stored.algorithm,
+                    pq_pubkey,
                 });
             }
         }
@@ -266,7 +293,57 @@ impl UserStore for ValkeyUserStore {
         let fp = pubkey_fingerprint(&pubkey);
         let pubkey_base64 = base64::engine::general_purpose::STANDARD.encode(pubkey.as_bytes());
         let now = chrono::Utc::now().timestamp();
-        let stored = StoredKey { pubkey_base64, label, created_at: now, last_used_at: None, algorithm: crate::auth::KeyAlgorithm::Ed25519 };
+        let stored = StoredKey {
+            pubkey_base64,
+            label,
+            created_at: now,
+            last_used_at: None,
+            algorithm: crate::auth::KeyAlgorithm::Ed25519,
+            pq_pubkey_base64: None,
+        };
+        let json = serde_json::to_string(&stored)?;
+        self.pool.set::<(), _, _>(format!("hs:key:{fp}"), json, None, None, false).await?;
+        self.pool.sadd::<i64, _, _>(format!("hs:user:{username}:keys"), &fp).await?;
+        self.pool.set::<(), _, _>(format!("hs:keyowner:{fp}"), username, None, None, false).await?;
+        Ok(fp)
+    }
+
+    async fn add_pubkey_hybrid(
+        &self,
+        username: &str,
+        pubkey: VerifyingKey,
+        ml_dsa_vk: Vec<u8>,
+        label: Option<String>,
+    ) -> Result<String> {
+        use base64::Engine;
+        if ml_dsa_vk.is_empty() {
+            anyhow::bail!("add_pubkey_hybrid: empty ML-DSA-65 verifying key");
+        }
+        // Fingerprint is the Ed25519 anchor's (kid) — the PQ vk does not change it.
+        let fp = pubkey_fingerprint(&pubkey);
+        let pubkey_base64 = base64::engine::general_purpose::STANDARD.encode(pubkey.as_bytes());
+        let pq_pubkey_base64 =
+            Some(base64::engine::general_purpose::STANDARD.encode(&ml_dsa_vk));
+
+        // In-place upgrade (Ed25519 → Hybrid) or idempotent re-bind: preserve
+        // the original created_at/last_used_at if a record already exists.
+        let (created_at, last_used_at, existing_label) =
+            match self.pool.get::<Option<String>, _>(format!("hs:key:{fp}")).await? {
+                Some(s) => {
+                    let prev: StoredKey = serde_json::from_str(&s)?;
+                    (prev.created_at, prev.last_used_at, prev.label)
+                }
+                None => (chrono::Utc::now().timestamp(), None, None),
+            };
+
+        let stored = StoredKey {
+            pubkey_base64,
+            label: label.or(existing_label),
+            created_at,
+            last_used_at,
+            algorithm: crate::auth::KeyAlgorithm::HybridEd25519MlDsa65,
+            pq_pubkey_base64,
+        };
         let json = serde_json::to_string(&stored)?;
         self.pool.set::<(), _, _>(format!("hs:key:{fp}"), json, None, None, false).await?;
         self.pool.sadd::<i64, _, _>(format!("hs:user:{username}:keys"), &fp).await?;

--- a/crates/hyprstream/src/auth/valkey.rs
+++ b/crates/hyprstream/src/auth/valkey.rs
@@ -321,6 +321,14 @@ impl UserStore for ValkeyUserStore {
         }
         // Fingerprint is the Ed25519 anchor's (kid) — the PQ vk does not change it.
         let fp = pubkey_fingerprint(&pubkey);
+        // Reject a fingerprint already owned by a *different* user (matches the
+        // RocksDB backend): without this, a cross-user re-bind would overwrite
+        // hs:keyowner and leave the key in both users' sets.
+        if let Some(existing_user) = self.get_pubkey_user(&fp).await? {
+            if existing_user != username {
+                anyhow::bail!("Pubkey already associated with user '{existing_user}'");
+            }
+        }
         let pubkey_base64 = base64::engine::general_purpose::STANDARD.encode(pubkey.as_bytes());
         let pq_pubkey_base64 =
             Some(base64::engine::general_purpose::STANDARD.encode(&ml_dsa_vk));

--- a/crates/hyprstream/src/auth/valkey.rs
+++ b/crates/hyprstream/src/auth/valkey.rs
@@ -29,6 +29,9 @@ struct StoredKey {
     label: Option<String>,
     created_at: i64,
     last_used_at: Option<i64>,
+    /// Algorithm tag (#439). Defaults to Ed25519 for pre-#439 records.
+    #[serde(default)]
+    algorithm: crate::auth::KeyAlgorithm,
 }
 
 pub struct ValkeyUserStore {
@@ -251,6 +254,7 @@ impl UserStore for ValkeyUserStore {
                     label: stored.label,
                     created_at: stored.created_at,
                     last_used_at: stored.last_used_at,
+                    algorithm: stored.algorithm,
                 });
             }
         }
@@ -262,7 +266,7 @@ impl UserStore for ValkeyUserStore {
         let fp = pubkey_fingerprint(&pubkey);
         let pubkey_base64 = base64::engine::general_purpose::STANDARD.encode(pubkey.as_bytes());
         let now = chrono::Utc::now().timestamp();
-        let stored = StoredKey { pubkey_base64, label, created_at: now, last_used_at: None };
+        let stored = StoredKey { pubkey_base64, label, created_at: now, last_used_at: None, algorithm: crate::auth::KeyAlgorithm::Ed25519 };
         let json = serde_json::to_string(&stored)?;
         self.pool.set::<(), _, _>(format!("hs:key:{fp}"), json, None, None, false).await?;
         self.pool.sadd::<i64, _, _>(format!("hs:user:{username}:keys"), &fp).await?;

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -25,7 +25,7 @@ use hyprstream_core::cli::{
     handle_sign_challenge, handle_status, handle_token_create, handle_unload, handle_training_batch,
     handle_training_checkpoint, handle_training_infer, handle_training_init, handle_worktree_add,
     handle_worktree_info, handle_worktree_list, handle_worktree_remove,
-    handle_user_list, handle_user_register, handle_user_remove,
+    handle_user_create, handle_user_list, handle_user_register, handle_user_remove,
     handle_user_keys_list, handle_user_keys_import, handle_user_keys_remove,
     load_or_generate_signing_key, AppContext, DeviceConfig, DevicePreference, RuntimeConfig,
     // Worker handlers
@@ -2408,6 +2408,18 @@ fn main() -> Result<()> {
                 .context("Failed to create runtime for user command")?;
             rt.block_on(async {
                 match cmd {
+                    UserCommand::Create { username, role, generate, key, ssh, no_role } => {
+                        handle_user_create(
+                            &credentials_dir,
+                            &username,
+                            &role,
+                            no_role,
+                            generate,
+                            key.as_deref(),
+                            ssh.as_deref(),
+                        )
+                        .await?;
+                    }
                     UserCommand::Register { username } => {
                         handle_user_register(&credentials_dir, &username).await?;
                     }

--- a/crates/hyprstream/src/cli/bootstrap_manager.rs
+++ b/crates/hyprstream/src/cli/bootstrap_manager.rs
@@ -192,8 +192,11 @@ impl BootstrapManager {
             }
         };
 
+        // Root-of-trust enrollment follows node crypto policy (Hybrid default,
+        // fail-closed) — the same selector as envelope traffic.
+        let policy = hyprstream_rpc::envelope::envelope_policy_from_env();
         if let Err(e) = self.rt.block_on(
-            enroll_user(&store, &secrets_dir, username, EnrollKeySource::Generate),
+            enroll_user(&store, &secrets_dir, username, EnrollKeySource::Generate, policy),
         ) {
             tracing::warn!(
                 username,

--- a/crates/hyprstream/src/cli/bootstrap_manager.rs
+++ b/crates/hyprstream/src/cli/bootstrap_manager.rs
@@ -195,13 +195,20 @@ impl BootstrapManager {
         // Root-of-trust enrollment follows node crypto policy (Hybrid default,
         // fail-closed) — the same selector as envelope traffic.
         let policy = hyprstream_rpc::envelope::envelope_policy_from_env();
-        if let Err(e) = self.rt.block_on(
+        match self.rt.block_on(
             enroll_user(&store, &secrets_dir, username, EnrollKeySource::Generate, policy),
         ) {
-            tracing::warn!(
+            Ok(outcome) => {
+                // Surface enrollment notices (e.g. the classical-downgrade
+                // warning) — `enroll_user` is fail-loud, not fail-silent.
+                for notice in &outcome.notices {
+                    tracing::warn!(username, "{notice}");
+                }
+            }
+            Err(e) => tracing::warn!(
                 username,
                 "Failed to enroll user identity (register + bind signing key): {e}"
-            );
+            ),
         }
     }
 

--- a/crates/hyprstream/src/cli/bootstrap_manager.rs
+++ b/crates/hyprstream/src/cli/bootstrap_manager.rs
@@ -17,7 +17,7 @@ use hyprstream_tui::wizard::backend::*;
 
 use crate::auth::identity_store;
 use crate::auth::policy_templates::{get_template, get_templates};
-use crate::auth::{RocksDbUserStore, PolicyManager, UserStore};
+use crate::auth::{RocksDbUserStore, PolicyManager};
 use crate::cli::gpu_detect;
 use crate::cli::policy_handlers::{
     load_or_generate_signing_key, mint_local_token, parse_duration,
@@ -88,44 +88,10 @@ fn os_username() -> String {
         .unwrap_or_else(|_| "anonymous".to_owned())
 }
 
-/// Bind a user-signing-key public key to `username`, idempotently and
-/// collision-safely.
-///
-/// `add_pubkey` rejects a fingerprint that is already bound (to the same or a
-/// different user), so we resolve the current binding first:
-/// - already bound to `username` → no-op (the key is already recognized),
-/// - bound to a *different* user (e.g. an `anonymous` record left by a prior
-///   partial run) → re-point it: remove from the old user, add to `username`,
-/// - unbound → add it.
-///
-/// Re-pointing is the least-surprising behavior: there is exactly one local
-/// user-signing-key, so it should map to exactly one identity — the one the
-/// operator is setting up.
-async fn bind_user_signing_key(
-    store: &RocksDbUserStore,
-    username: &str,
-    vk: ed25519_dalek::VerifyingKey,
-) -> anyhow::Result<()> {
-    let fingerprint = crate::auth::user_store::pubkey_fingerprint(&vk);
-
-    match store.get_pubkey_user(&fingerprint).await? {
-        Some(existing) if existing == username => {
-            // Already bound to this user — nothing to do.
-            return Ok(());
-        }
-        Some(existing) => {
-            // Bound to a different (likely stale `anonymous`) user — re-point.
-            tracing::info!("Re-pointing user-signing-key from '{existing}' to '{username}'");
-            store.remove_pubkey(&existing, &fingerprint).await?;
-        }
-        None => {}
-    }
-
-    store
-        .add_pubkey(username, vk, Some("wizard".to_owned()))
-        .await?;
-    Ok(())
-}
+// The shared enroll routine (#438 wizard + #439 `user create`) lives in
+// `cli::enroll`; the wizard uses it directly. `bind_user_signing_key` is still
+// unit-tested here (see `tests`).
+use crate::cli::enroll::{enroll_user, EnrollKeySource};
 
 /// Returns true if this is the first run (no bootstrap completed yet).
 ///
@@ -185,13 +151,12 @@ impl BootstrapManager {
     /// Register a user identity in UserStore and bind the CLI's user-signing-key
     /// public key to it.
     ///
-    /// The wizard has the local user-signing-key (the credential the CLI signs
-    /// auth challenges with), so any username it is asked to register — the OS
-    /// user (non-interactive) or an operator-entered name (interactive) — can be
-    /// bound to that key. Without the binding the server can never resolve the
-    /// CLI's signature back to a subject and falls back to `anonymous` (#438).
-    ///
-    /// Idempotent and collision-safe (see `bind_user_signing_key`).
+    /// Delegates to the shared [`enroll_user`] routine (#438 wizard + #439
+    /// `user create`) so the register→store→bind sequence cannot drift. The
+    /// wizard uses the `Generate` source: it adopts the existing/on-disk
+    /// user-signing-key the CLI signs with. Without the binding the server can
+    /// never resolve the CLI's signature back to a subject and falls back to
+    /// `anonymous` (#438).
     fn register_local_identity(&mut self, username: &str) {
         let credentials_dir = match identity_store::credentials_dir() {
             Ok(path) => path,
@@ -214,18 +179,6 @@ impl BootstrapManager {
             }
         };
 
-        // Register the user record if it doesn't already exist. `register`
-        // overwrites pubkeys on an existing record, so only call it when absent.
-        if self.rt.block_on(store.get_profile(username)).ok().flatten().is_none() {
-            if let Err(e) = self.rt.block_on(store.register(username)) {
-                tracing::warn!(
-                    username,
-                    "Failed to register user identity in UserStore — user identity will not be registered: {e}"
-                );
-                return;
-            }
-        }
-
         // Load the user-signing-key from the SAME secrets dir the CLI uses, so
         // the bound fingerprint matches the key the CLI signs with.
         let secrets_dir = match crate::config::HyprConfig::resolve_secrets_dir() {
@@ -238,36 +191,15 @@ impl BootstrapManager {
                 return;
             }
         };
-        let vk = match identity_store::load_or_generate_user_signing_key(&secrets_dir) {
-            Ok((_sk, vk)) => vk,
-            Err(e) => {
-                tracing::warn!(
-                    username, ?secrets_dir,
-                    "Failed to load user-signing-key — CLI signing key will not be bound to '{username}': {e}"
-                );
-                return;
-            }
-        };
 
-        if let Err(e) = self.bind_user_signing_key(&store, username, vk) {
+        if let Err(e) = self.rt.block_on(
+            enroll_user(&store, &secrets_dir, username, EnrollKeySource::Generate),
+        ) {
             tracing::warn!(
                 username,
-                "Failed to bind user-signing-key pubkey to '{username}': {e}"
+                "Failed to enroll user identity (register + bind signing key): {e}"
             );
         }
-    }
-
-    /// Bind the user-signing-key public key to `username`.
-    ///
-    /// Blocking wrapper over [`bind_user_signing_key`] (the free async fn holds
-    /// the idempotency/collision logic and is unit-tested directly).
-    fn bind_user_signing_key(
-        &self,
-        store: &RocksDbUserStore,
-        username: &str,
-        vk: ed25519_dalek::VerifyingKey,
-    ) -> anyhow::Result<()> {
-        self.rt.block_on(bind_user_signing_key(store, username, vk))
     }
 
     /// Ensure the signing key is loaded.
@@ -826,6 +758,7 @@ async fn do_bootstrap(
 mod tests {
     use super::*;
     use crate::auth::{RocksDbUserStore, UserStore};
+    use crate::cli::enroll::bind_user_signing_key;
     use tempfile::TempDir;
 
     /// Replicates the register + bind sequence performed by

--- a/crates/hyprstream/src/cli/commands/user.rs
+++ b/crates/hyprstream/src/cli/commands/user.rs
@@ -4,6 +4,33 @@ use clap::Subcommand;
 
 #[derive(Debug, Subcommand)]
 pub enum UserCommand {
+    /// Create a user AND enroll a signing key in one step
+    ///
+    /// Generates (default) or adopts a signing key, installs it as the client's
+    /// actual signing key, registers the user record, binds the derived public
+    /// key, and grants a role — collapsing the multi-step enrollment that,
+    /// done wrong, silently authenticates as `anonymous` (#439).
+    Create {
+        /// Username to enroll (defaults to the OS user, matching the CLI's `sub`)
+        #[arg(default_value_t = os_user_string())]
+        username: String,
+        /// Role to grant (default `operator`; use `admin` for full access)
+        #[arg(long, default_value = "operator")]
+        role: String,
+        /// Generate a fresh Ed25519 signing key (default)
+        #[arg(long, conflicts_with_all = ["key", "ssh"])]
+        generate: bool,
+        /// Adopt a raw 32-byte Ed25519 seed file as the signing key
+        #[arg(long, value_name = "PATH", conflicts_with_all = ["generate", "ssh"])]
+        key: Option<String>,
+        /// Adopt an OpenSSH Ed25519 private key as the signing key
+        /// (passphrase-prompted if encrypted)
+        #[arg(long, value_name = "PATH", conflicts_with_all = ["generate", "key"])]
+        ssh: Option<String>,
+        /// Skip granting the role even if services are running
+        #[arg(long)]
+        no_role: bool,
+    },
     /// Create a user account (no key required at registration)
     Register {
         /// Username
@@ -24,6 +51,16 @@ pub enum UserCommand {
         #[command(subcommand)]
         command: UserKeysCommand,
     },
+}
+
+/// Resolve the OS username exactly as the CLI presents it in `sub`
+/// (`$USER` → `$LOGNAME` → `"anonymous"`), so `user create`'s default matches
+/// the subject the CLI authenticates as. Kept in lockstep with
+/// `sign_challenge.rs::load_user_signing_key`.
+fn os_user_string() -> String {
+    std::env::var("USER")
+        .or_else(|_| std::env::var("LOGNAME"))
+        .unwrap_or_else(|_| "anonymous".to_owned())
 }
 
 #[derive(Debug, Subcommand)]

--- a/crates/hyprstream/src/cli/enroll.rs
+++ b/crates/hyprstream/src/cli/enroll.rs
@@ -1,0 +1,272 @@
+//! Shared user-signing-key enrollment routine (#438 wizard + #439 `user create`).
+//!
+//! Enrolling a usable client identity is a register → store → bind sequence
+//! whose silent partial failure leaves the CLI authenticating as `anonymous`
+//! (#438/#439). This module is the single place that sequence lives, so the
+//! bootstrap wizard and the `hyprstream user create` command cannot drift.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use ed25519_dalek::{SigningKey, VerifyingKey};
+
+use crate::auth::identity_store;
+use crate::auth::{KeyAlgorithm, RocksDbUserStore, UserStore, pubkey_fingerprint};
+
+/// Where the client signing key comes from during enrollment.
+#[derive(Debug, Clone)]
+pub enum EnrollKeySource {
+    /// Generate a fresh Ed25519 key, or reuse the existing on-disk
+    /// `user-signing-key` if one is already present (the wizard path).
+    Generate,
+    /// Adopt a raw 32-byte Ed25519 seed, installing it as the client signing key.
+    RawSeed([u8; 32]),
+    /// Adopt an already-decoded Ed25519 signing key, installing it as the
+    /// client signing key (e.g. parsed from an OpenSSH private key).
+    SigningKey(SigningKey),
+}
+
+/// Result of enrolling a user identity.
+#[derive(Debug, Clone)]
+pub struct EnrollOutcome {
+    pub username: String,
+    /// SSH-style `SHA256:` fingerprint of the bound verifying key.
+    pub fingerprint: String,
+    /// Algorithm tag of the enrolled key (Ed25519 today).
+    pub algorithm: KeyAlgorithm,
+    /// Path of the prior `user-signing-key` backup, if an existing key was
+    /// displaced by an adopt (`--ssh`/`--key`). `None` for `Generate`.
+    pub key_backed_up: Option<PathBuf>,
+}
+
+/// The one shared enrollment routine.
+///
+/// 1. **Register** the user record if it does not already exist (`register`
+///    overwrites pubkeys on an existing record, so it is only called when the
+///    profile is absent).
+/// 2. **Store** the resolved signing key as the client's actual
+///    `credentials/user-signing-key` (backing up any prior key on the adopt
+///    paths), so the CLI signs with *this* key.
+/// 3. **Bind** the derived public key to the user, idempotently and
+///    collision-safely (see [`bind_user_signing_key`]).
+///
+/// Returns the bound fingerprint and algorithm so callers can verify + print
+/// enrollment actually took (`user create` shows it equals
+/// `ssh-keygen -l -E sha256` of the key).
+pub async fn enroll_user(
+    store: &RocksDbUserStore,
+    secrets_dir: &Path,
+    username: &str,
+    source: EnrollKeySource,
+) -> Result<EnrollOutcome> {
+    // 1. Register the user record if absent.
+    if store.get_profile(username).await.ok().flatten().is_none() {
+        store
+            .register(username)
+            .await
+            .with_context(|| format!("Failed to register user identity '{username}'"))?;
+    }
+
+    // 2. Resolve the signing key and ensure it is installed as the client key.
+    let (vk, backed_up) = resolve_and_store_signing_key(secrets_dir, source)?;
+
+    // 3. Bind the derived public key to the user.
+    bind_user_signing_key(store, username, vk).await?;
+
+    Ok(EnrollOutcome {
+        username: username.to_owned(),
+        fingerprint: pubkey_fingerprint(&vk),
+        algorithm: KeyAlgorithm::Ed25519,
+        key_backed_up: backed_up,
+    })
+}
+
+/// Resolve `source` to a verifying key, installing adopt-path keys as the
+/// client signing key (with backup). Returns `(verifying_key, backup_path)`.
+fn resolve_and_store_signing_key(
+    secrets_dir: &Path,
+    source: EnrollKeySource,
+) -> Result<(VerifyingKey, Option<PathBuf>)> {
+    match source {
+        EnrollKeySource::Generate => {
+            // load_or_generate already persists (or reuses) the on-disk key —
+            // no adopt, no backup.
+            let (_sk, vk) = identity_store::load_or_generate_user_signing_key(secrets_dir)?;
+            Ok((vk, None))
+        }
+        EnrollKeySource::RawSeed(seed) => {
+            let sk = SigningKey::from_bytes(&seed);
+            let backup = identity_store::install_user_signing_key(secrets_dir, &sk)?;
+            Ok((sk.verifying_key(), backup))
+        }
+        EnrollKeySource::SigningKey(sk) => {
+            let vk = sk.verifying_key();
+            let backup = identity_store::install_user_signing_key(secrets_dir, &sk)?;
+            Ok((vk, backup))
+        }
+    }
+}
+
+/// Bind a user-signing-key public key to `username`, idempotently and
+/// collision-safely.
+///
+/// `add_pubkey` rejects a fingerprint that is already bound (to the same or a
+/// different user), so the current binding is resolved first:
+/// - already bound to `username` → no-op (the key is already recognized),
+/// - bound to a *different* user (e.g. an `anonymous` record left by a prior
+///   partial run) → re-point it: remove from the old user, add to `username`,
+/// - unbound → add it.
+///
+/// Re-pointing is the least-surprising behavior: there is exactly one local
+/// user-signing-key, so it should map to exactly one identity — the one the
+/// operator is enrolling.
+pub(crate) async fn bind_user_signing_key(
+    store: &RocksDbUserStore,
+    username: &str,
+    vk: VerifyingKey,
+) -> Result<()> {
+    let fingerprint = pubkey_fingerprint(&vk);
+
+    match store.get_pubkey_user(&fingerprint).await? {
+        Some(existing) if existing == username => {
+            // Already bound to this user — nothing to do.
+            return Ok(());
+        }
+        Some(existing) => {
+            // Bound to a different (likely stale `anonymous`) user — re-point.
+            tracing::info!("Re-pointing user-signing-key from '{existing}' to '{username}'");
+            store.remove_pubkey(&existing, &fingerprint).await?;
+        }
+        None => {}
+    }
+
+    store
+        .add_pubkey(username, vk, Some("enroll".to_owned()))
+        .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn open(creds: &TempDir) -> RocksDbUserStore {
+        RocksDbUserStore::open(creds.path()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn enroll_generate_registers_binds_and_tags_ed25519() {
+        let creds = TempDir::new().unwrap();
+        let secrets = TempDir::new().unwrap();
+        let store = open(&creds);
+
+        let outcome = enroll_user(&store, secrets.path(), "alice", EnrollKeySource::Generate)
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.username, "alice");
+        assert_eq!(outcome.algorithm, KeyAlgorithm::Ed25519);
+        assert!(outcome.fingerprint.starts_with("SHA256:"));
+        assert!(outcome.key_backed_up.is_none(), "generate must not back up");
+
+        // Profile exists and the fingerprint reverse-maps to the user.
+        assert!(store.get_profile("alice").await.unwrap().is_some());
+        assert_eq!(
+            store.get_pubkey_user(&outcome.fingerprint).await.unwrap(),
+            Some("alice".to_owned())
+        );
+
+        // The bound key equals the on-disk user-signing-key the CLI signs with.
+        let (_sk, vk) = identity_store::load_or_generate_user_signing_key(secrets.path()).unwrap();
+        assert_eq!(
+            crate::auth::pubkey_fingerprint(&vk),
+            outcome.fingerprint,
+            "enrolled fingerprint must match the client signing key"
+        );
+    }
+
+    #[tokio::test]
+    async fn enroll_adopt_signing_key_installs_and_backs_up_existing() {
+        let creds = TempDir::new().unwrap();
+        let secrets = TempDir::new().unwrap();
+        let store = open(&creds);
+
+        // Seed the on-disk key first (simulate a prior key), then adopt a new one.
+        let (_prior, _) =
+            identity_store::load_or_generate_user_signing_key(secrets.path()).unwrap();
+        let adopted = SigningKey::generate(&mut rand::rngs::OsRng);
+        let outcome = enroll_user(
+            &store,
+            secrets.path(),
+            "bob",
+            EnrollKeySource::SigningKey(adopted),
+        )
+        .await
+        .unwrap();
+
+        // A backup of the prior key must exist, and the installed key must be the adopted one.
+        assert!(outcome.key_backed_up.as_ref().unwrap().exists());
+        let (_sk, vk) = identity_store::load_or_generate_user_signing_key(secrets.path()).unwrap();
+        assert_eq!(
+            crate::auth::pubkey_fingerprint(&vk),
+            outcome.fingerprint,
+            "installed signing key must be the adopted key"
+        );
+
+        // Re-running enroll for bob is idempotent.
+        enroll_user(&store, secrets.path(), "bob", EnrollKeySource::Generate)
+            .await
+            .unwrap();
+        assert_eq!(store.list_pubkeys("bob").await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn enroll_repoints_from_stale_anonymous_binding() {
+        let creds = TempDir::new().unwrap();
+        let secrets = TempDir::new().unwrap();
+        let store = open(&creds);
+
+        // Generate the on-disk key and bind it to a stale "anonymous" first.
+        let (_sk, vk) =
+            identity_store::load_or_generate_user_signing_key(secrets.path()).unwrap();
+        store.register("anonymous").await.unwrap();
+        bind_user_signing_key(&store, "anonymous", vk).await.unwrap();
+        let fp = crate::auth::pubkey_fingerprint(&vk);
+        assert_eq!(
+            store.get_pubkey_user(&fp).await.unwrap(),
+            Some("anonymous".to_owned())
+        );
+
+        // Enrolling the real user must re-point the key away from anonymous.
+        let outcome = enroll_user(&store, secrets.path(), "carol", EnrollKeySource::Generate)
+            .await
+            .unwrap();
+        assert_eq!(
+            store.get_pubkey_user(&outcome.fingerprint).await.unwrap(),
+            Some("carol".to_owned())
+        );
+    }
+
+    #[tokio::test]
+    async fn enroll_raw_seed_round_trips() {
+        let creds = TempDir::new().unwrap();
+        let secrets = TempDir::new().unwrap();
+        let store = open(&creds);
+
+        let sk = SigningKey::generate(&mut rand::rngs::OsRng);
+        let seed = sk.to_bytes();
+
+        let outcome =
+            enroll_user(&store, secrets.path(), "dan", EnrollKeySource::RawSeed(seed))
+                .await
+                .unwrap();
+        assert_eq!(
+            outcome.fingerprint,
+            crate::auth::pubkey_fingerprint(&sk.verifying_key())
+        );
+        // No prior key → no backup.
+        assert!(outcome.key_backed_up.is_none());
+    }
+}

--- a/crates/hyprstream/src/cli/enroll.rs
+++ b/crates/hyprstream/src/cli/enroll.rs
@@ -9,8 +9,9 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use ed25519_dalek::{SigningKey, VerifyingKey};
+use hyprstream_rpc::crypto::CryptoPolicy;
 
-use crate::auth::identity_store;
+use crate::auth::identity_store::{self, UserIdentityKeys};
 use crate::auth::{KeyAlgorithm, RocksDbUserStore, UserStore, pubkey_fingerprint};
 
 /// Where the client signing key comes from during enrollment.
@@ -30,13 +31,24 @@ pub enum EnrollKeySource {
 #[derive(Debug, Clone)]
 pub struct EnrollOutcome {
     pub username: String,
-    /// SSH-style `SHA256:` fingerprint of the bound verifying key.
+    /// SSH-style `SHA256:` fingerprint of the bound verifying key. Always the
+    /// **Ed25519 anchor's** fingerprint (the kid) — a bound ML-DSA-65 key does
+    /// not change it.
     pub fingerprint: String,
-    /// Algorithm tag of the enrolled key (Ed25519 today).
+    /// Algorithm actually enrolled — [`KeyAlgorithm::HybridEd25519MlDsa65`]
+    /// under a Hybrid policy, [`KeyAlgorithm::Ed25519`] under Classical. Never
+    /// hardcoded; reflects what was really written.
     pub algorithm: KeyAlgorithm,
     /// Path of the prior `user-signing-key` backup, if an existing key was
     /// displaced by an adopt (`--ssh`/`--key`). `None` for `Generate`.
     pub key_backed_up: Option<PathBuf>,
+    /// Path of the prior `user-signing-key.mldsa` backup, if a PQ sibling was
+    /// displaced by an adopt. `None` otherwise.
+    pub pq_key_backed_up: Option<PathBuf>,
+    /// Human-facing notices the caller should print verbatim (e.g. a classical
+    /// downgrade warning, or that a PQ component was generated for an adopted
+    /// SSH/seed key). Never silent.
+    pub notices: Vec<String>,
 }
 
 /// The one shared enrollment routine.
@@ -47,64 +59,148 @@ pub struct EnrollOutcome {
 /// 2. **Store** the resolved signing key as the client's actual
 ///    `credentials/user-signing-key` (backing up any prior key on the adopt
 ///    paths), so the CLI signs with *this* key.
-/// 3. **Bind** the derived public key to the user, idempotently and
-///    collision-safely (see [`bind_user_signing_key`]).
+/// 3. **Bind** the derived public key(s) to the user, idempotently and
+///    collision-safely (see [`bind_user_signing_key_material`]).
 ///
 /// Returns the bound fingerprint and algorithm so callers can verify + print
 /// enrollment actually took (`user create` shows it equals
 /// `ssh-keygen -l -E sha256` of the key).
+///
+/// `policy` selects the crypto suite (see [`resolve_and_store_identity`]). Under
+/// [`CryptoPolicy::Hybrid`] (the node default) enrollment mints an Ed25519
+/// anchor **plus** a bound ML-DSA-65 key and writes a hybrid store record; a
+/// missing/unpersistable PQ component is a hard error (fail closed). Under
+/// [`CryptoPolicy::Classical`] a classical-only identity is written with a loud
+/// notice — never a silent downgrade.
 pub async fn enroll_user(
     store: &RocksDbUserStore,
     secrets_dir: &Path,
     username: &str,
     source: EnrollKeySource,
+    policy: CryptoPolicy,
 ) -> Result<EnrollOutcome> {
-    // 1. Register the user record if absent.
-    if store.get_profile(username).await.ok().flatten().is_none() {
+    // 1. Register the user record if absent. Propagate a lookup *failure*
+    //    rather than treating it as "absent" — `register` overwrites an
+    //    existing record's bound pubkeys, so a swallowed error could drop a
+    //    real user's keys.
+    let existing = store
+        .get_profile(username)
+        .await
+        .with_context(|| format!("Failed to look up user identity '{username}'"))?;
+    if existing.is_none() {
         store
             .register(username)
             .await
             .with_context(|| format!("Failed to register user identity '{username}'"))?;
     }
 
-    // 2. Resolve the signing key and ensure it is installed as the client key.
-    let (vk, backed_up) = resolve_and_store_signing_key(secrets_dir, source)?;
+    // 2. Resolve the identity key material (per source × policy) and install it
+    //    as the client key(s).
+    let resolved = resolve_and_store_identity(secrets_dir, source, policy)?;
 
-    // 3. Bind the derived public key to the user.
-    bind_user_signing_key(store, username, vk).await?;
+    // 3. Bind the derived public key(s) to the user (hybrid record when a PQ
+    //    component is present).
+    let vk = resolved.keys.ed.verifying_key();
+    let pq_vk = resolved.keys.pq_verifying_key_bytes();
+    bind_user_signing_key_material(store, username, vk, pq_vk).await?;
 
     Ok(EnrollOutcome {
         username: username.to_owned(),
         fingerprint: pubkey_fingerprint(&vk),
-        algorithm: KeyAlgorithm::Ed25519,
-        key_backed_up: backed_up,
+        algorithm: resolved.keys.algorithm(),
+        key_backed_up: resolved.ed_backup,
+        pq_key_backed_up: resolved.pq_backup,
+        notices: resolved.notices,
     })
 }
 
-/// Resolve `source` to a verifying key, installing adopt-path keys as the
-/// client signing key (with backup). Returns `(verifying_key, backup_path)`.
-fn resolve_and_store_signing_key(
+/// Identity key material resolved from a source × policy, already installed on
+/// disk as the client key(s).
+struct ResolvedIdentity {
+    keys: UserIdentityKeys,
+    ed_backup: Option<PathBuf>,
+    pq_backup: Option<PathBuf>,
+    notices: Vec<String>,
+}
+
+/// The classical-downgrade notice printed whenever a Classical-policy identity
+/// is enrolled (never silent — CLAUDE.md's fail-loud requirement).
+fn classical_notice() -> String {
+    "classical-only (policy=Classical): this identity is capped at Classical MAC \
+     assurance. Set CryptoPolicy to Hybrid (unset HYPRSTREAM_ENVELOPE_POLICY or \
+     set it to 'hybrid') to enroll a post-quantum identity."
+        .to_owned()
+}
+
+/// Resolve `source` × `policy` into installed identity key material.
+///
+/// - [`EnrollKeySource::Generate`]: load/generate the Ed25519 anchor and (under
+///   Hybrid) the ML-DSA-65 sibling via
+///   [`identity_store::load_or_generate_user_identity`] — this also covers the
+///   in-place upgrade of a legacy Ed25519-only secrets dir.
+/// - [`EnrollKeySource::RawSeed`] / [`EnrollKeySource::SigningKey`] (adopt): the
+///   adopted key is the **classical component only**. Under Hybrid a fresh
+///   ML-DSA-65 key is generated and bound to the same anchor (an SSH/seed key
+///   can never make the identity hybrid by itself); a notice says so.
+fn resolve_and_store_identity(
     secrets_dir: &Path,
     source: EnrollKeySource,
-) -> Result<(VerifyingKey, Option<PathBuf>)> {
+    policy: CryptoPolicy,
+) -> Result<ResolvedIdentity> {
     match source {
         EnrollKeySource::Generate => {
-            // load_or_generate already persists (or reuses) the on-disk key —
-            // no adopt, no backup.
-            let (_sk, vk) = identity_store::load_or_generate_user_signing_key(secrets_dir)?;
-            Ok((vk, None))
+            // load_or_generate persists (or reuses) the on-disk key(s) — no
+            // adopt, no backup. Fails closed under Hybrid if the PQ component
+            // cannot be provisioned.
+            let keys = identity_store::load_or_generate_user_identity(secrets_dir, policy)?;
+            let mut notices = Vec::new();
+            if keys.mldsa.is_none() {
+                notices.push(classical_notice());
+            }
+            Ok(ResolvedIdentity { keys, ed_backup: None, pq_backup: None, notices })
         }
         EnrollKeySource::RawSeed(seed) => {
-            let sk = SigningKey::from_bytes(&seed);
-            let backup = identity_store::install_user_signing_key(secrets_dir, &sk)?;
-            Ok((sk.verifying_key(), backup))
+            adopt_identity(secrets_dir, SigningKey::from_bytes(&seed), policy, &pq_generate)
         }
-        EnrollKeySource::SigningKey(sk) => {
-            let vk = sk.verifying_key();
-            let backup = identity_store::install_user_signing_key(secrets_dir, &sk)?;
-            Ok((vk, backup))
-        }
+        EnrollKeySource::SigningKey(sk) => adopt_identity(secrets_dir, sk, policy, &pq_generate),
     }
+}
+
+/// Generate a fresh ML-DSA-65 signing key (indirection kept small so the adopt
+/// path reads clearly).
+fn pq_generate() -> hyprstream_rpc::crypto::pq::MlDsaSigningKey {
+    hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair().0
+}
+
+/// Install an adopted Ed25519 key as the client anchor, minting + binding a
+/// fresh ML-DSA-65 component under Hybrid.
+fn adopt_identity(
+    secrets_dir: &Path,
+    ed_sk: SigningKey,
+    policy: CryptoPolicy,
+    pq_gen: &dyn Fn() -> hyprstream_rpc::crypto::pq::MlDsaSigningKey,
+) -> Result<ResolvedIdentity> {
+    let mut notices = Vec::new();
+    let mldsa = if policy.uses_pq() {
+        notices.push(
+            "adopted SSH/seed key is classical; a post-quantum ML-DSA-65 component \
+             was generated and bound to the same anchor."
+                .to_owned(),
+        );
+        Some(pq_gen())
+    } else {
+        notices.push(classical_notice());
+        None
+    };
+
+    let backup = identity_store::install_user_identity(secrets_dir, &ed_sk, mldsa.as_ref())?;
+    let keys = UserIdentityKeys { ed: ed_sk, mldsa };
+    Ok(ResolvedIdentity {
+        keys,
+        ed_backup: backup.ed,
+        pq_backup: backup.pq,
+        notices,
+    })
 }
 
 /// Bind a user-signing-key public key to `username`, idempotently and
@@ -120,16 +216,47 @@ fn resolve_and_store_signing_key(
 /// Re-pointing is the least-surprising behavior: there is exactly one local
 /// user-signing-key, so it should map to exactly one identity — the one the
 /// operator is enrolling.
+///
+/// Thin classical (no-PQ) wrapper over [`bind_user_signing_key_material`], used
+/// by the wizard/enroll tests to bind a pre-existing on-disk key; production
+/// enrollment goes through [`bind_user_signing_key_material`] directly.
+#[cfg(test)]
 pub(crate) async fn bind_user_signing_key(
     store: &RocksDbUserStore,
     username: &str,
     vk: VerifyingKey,
 ) -> Result<()> {
+    bind_user_signing_key_material(store, username, vk, None).await
+}
+
+/// Bind a user-signing-key to `username`, carrying an optional bound ML-DSA-65
+/// verifying key (a hybrid record when `pq_vk` is `Some`).
+///
+/// Collision handling is keyed by the **Ed25519 anchor fingerprint** (the PQ vk
+/// never changes the kid), identical to the classical path:
+/// - already bound to `username`: no-op for classical; for hybrid, perform the
+///   in-place Ed25519 → Hybrid upgrade (idempotent) so a legacy classical record
+///   for the same anchor gains its PQ binding;
+/// - bound to a different (stale `anonymous`) user: re-point;
+/// - unbound: add.
+pub(crate) async fn bind_user_signing_key_material(
+    store: &RocksDbUserStore,
+    username: &str,
+    vk: VerifyingKey,
+    pq_vk: Option<Vec<u8>>,
+) -> Result<()> {
     let fingerprint = pubkey_fingerprint(&vk);
 
     match store.get_pubkey_user(&fingerprint).await? {
         Some(existing) if existing == username => {
-            // Already bound to this user — nothing to do.
+            // Already bound to this user. Classical → nothing to do. Hybrid →
+            // upgrade in place (add_pubkey_hybrid is idempotent and lifts an
+            // existing Ed25519 record to Hybrid for the same anchor).
+            if let Some(pq) = pq_vk {
+                store
+                    .add_pubkey_hybrid(username, vk, pq, Some("enroll".to_owned()))
+                    .await?;
+            }
             return Ok(());
         }
         Some(existing) => {
@@ -140,9 +267,18 @@ pub(crate) async fn bind_user_signing_key(
         None => {}
     }
 
-    store
-        .add_pubkey(username, vk, Some("enroll".to_owned()))
-        .await?;
+    match pq_vk {
+        Some(pq) => {
+            store
+                .add_pubkey_hybrid(username, vk, pq, Some("enroll".to_owned()))
+                .await?;
+        }
+        None => {
+            store
+                .add_pubkey(username, vk, Some("enroll".to_owned()))
+                .await?;
+        }
+    }
     Ok(())
 }
 
@@ -162,9 +298,15 @@ mod tests {
         let secrets = TempDir::new().unwrap();
         let store = open(&creds);
 
-        let outcome = enroll_user(&store, secrets.path(), "alice", EnrollKeySource::Generate)
-            .await
-            .unwrap();
+        let outcome = enroll_user(
+            &store,
+            secrets.path(),
+            "alice",
+            EnrollKeySource::Generate,
+            CryptoPolicy::Classical,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(outcome.username, "alice");
         assert_eq!(outcome.algorithm, KeyAlgorithm::Ed25519);
@@ -202,6 +344,7 @@ mod tests {
             secrets.path(),
             "bob",
             EnrollKeySource::SigningKey(adopted),
+            CryptoPolicy::Classical,
         )
         .await
         .unwrap();
@@ -216,9 +359,15 @@ mod tests {
         );
 
         // Re-running enroll for bob is idempotent.
-        enroll_user(&store, secrets.path(), "bob", EnrollKeySource::Generate)
-            .await
-            .unwrap();
+        enroll_user(
+            &store,
+            secrets.path(),
+            "bob",
+            EnrollKeySource::Generate,
+            CryptoPolicy::Classical,
+        )
+        .await
+        .unwrap();
         assert_eq!(store.list_pubkeys("bob").await.unwrap().len(), 1);
     }
 
@@ -240,9 +389,15 @@ mod tests {
         );
 
         // Enrolling the real user must re-point the key away from anonymous.
-        let outcome = enroll_user(&store, secrets.path(), "carol", EnrollKeySource::Generate)
-            .await
-            .unwrap();
+        let outcome = enroll_user(
+            &store,
+            secrets.path(),
+            "carol",
+            EnrollKeySource::Generate,
+            CryptoPolicy::Classical,
+        )
+        .await
+        .unwrap();
         assert_eq!(
             store.get_pubkey_user(&outcome.fingerprint).await.unwrap(),
             Some("carol".to_owned())
@@ -258,15 +413,186 @@ mod tests {
         let sk = SigningKey::generate(&mut rand::rngs::OsRng);
         let seed = sk.to_bytes();
 
-        let outcome =
-            enroll_user(&store, secrets.path(), "dan", EnrollKeySource::RawSeed(seed))
-                .await
-                .unwrap();
+        let outcome = enroll_user(
+            &store,
+            secrets.path(),
+            "dan",
+            EnrollKeySource::RawSeed(seed),
+            CryptoPolicy::Classical,
+        )
+        .await
+        .unwrap();
         assert_eq!(
             outcome.fingerprint,
             crate::auth::pubkey_fingerprint(&sk.verifying_key())
         );
         // No prior key → no backup.
         assert!(outcome.key_backed_up.is_none());
+    }
+
+    // ─── Hybrid (post-quantum) enrollment (#439) ─────────────────────────────
+
+    #[tokio::test]
+    async fn enroll_generate_hybrid_writes_pq_record_and_sibling_file() {
+        let creds = TempDir::new().unwrap();
+        let secrets = TempDir::new().unwrap();
+        let store = open(&creds);
+
+        let outcome = enroll_user(
+            &store,
+            secrets.path(),
+            "alice",
+            EnrollKeySource::Generate,
+            CryptoPolicy::Hybrid,
+        )
+        .await
+        .unwrap();
+
+        // The enrolled algorithm reflects reality: hybrid, not a hardcoded tag.
+        assert_eq!(outcome.algorithm, KeyAlgorithm::HybridEd25519MlDsa65);
+        assert!(outcome.notices.is_empty(), "hybrid generate has no downgrade notice");
+
+        // Both on-disk key files exist, each mode 0600.
+        let ed = secrets.path().join("user-signing-key");
+        let pq = secrets.path().join("user-signing-key.mldsa");
+        assert!(ed.exists() && pq.exists(), "both key files must be written");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            for p in [&ed, &pq] {
+                let mode = std::fs::metadata(p).unwrap().permissions().mode() & 0o777;
+                assert_eq!(mode, 0o600, "{} must be 0600", p.display());
+            }
+        }
+
+        // The store record is hybrid and carries the bound ML-DSA-65 vk.
+        let keys = store.list_pubkeys("alice").await.unwrap();
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].algorithm, KeyAlgorithm::HybridEd25519MlDsa65);
+        let pq_bytes = keys[0].pq_pubkey.as_ref().expect("hybrid record has pq_pubkey");
+        // Matches the ML-DSA vk derived from the on-disk PQ seed.
+        let loaded = identity_store::load_or_generate_user_identity(
+            secrets.path(),
+            CryptoPolicy::Hybrid,
+        )
+        .unwrap();
+        assert_eq!(&loaded.pq_verifying_key_bytes().unwrap(), pq_bytes);
+        // Fingerprint is the Ed25519 anchor's (kid), unchanged by the PQ key.
+        assert_eq!(
+            outcome.fingerprint,
+            crate::auth::pubkey_fingerprint(&loaded.ed.verifying_key())
+        );
+    }
+
+    #[tokio::test]
+    async fn enroll_adopt_ssh_under_hybrid_generates_pq_and_notices() {
+        let creds = TempDir::new().unwrap();
+        let secrets = TempDir::new().unwrap();
+        let store = open(&creds);
+
+        // An adopted (SSH-style) key is the classical component; under Hybrid a
+        // fresh PQ component is generated + bound, with a notice saying so.
+        let adopted = SigningKey::generate(&mut rand::rngs::OsRng);
+        let vk = adopted.verifying_key();
+        let outcome = enroll_user(
+            &store,
+            secrets.path(),
+            "erin",
+            EnrollKeySource::SigningKey(adopted),
+            CryptoPolicy::Hybrid,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome.algorithm, KeyAlgorithm::HybridEd25519MlDsa65);
+        assert_eq!(
+            outcome.fingerprint,
+            crate::auth::pubkey_fingerprint(&vk),
+            "anchor fingerprint is the adopted Ed25519 key's"
+        );
+        assert!(
+            outcome.notices.iter().any(|n| n.contains("post-quantum")),
+            "must notify that a PQ component was generated for the adopted key"
+        );
+        assert!(secrets.path().join("user-signing-key.mldsa").exists());
+        let keys = store.list_pubkeys("erin").await.unwrap();
+        assert!(keys[0].pq_pubkey.is_some());
+    }
+
+    #[tokio::test]
+    async fn enroll_hybrid_readonly_secrets_fails_closed() {
+        let creds = TempDir::new().unwrap();
+        let secrets = TempDir::new().unwrap();
+        let store = open(&creds);
+
+        // Pre-seed a classical Ed25519 key, then make the dir read-only so the
+        // PQ sibling cannot be generated. Under Hybrid this MUST fail closed —
+        // never mint a classical-only identity.
+        let _ = identity_store::load_or_generate_user_signing_key(secrets.path()).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(secrets.path(), std::fs::Permissions::from_mode(0o500))
+                .unwrap();
+
+            let err = enroll_user(
+                &store,
+                secrets.path(),
+                "frank",
+                EnrollKeySource::Generate,
+                CryptoPolicy::Hybrid,
+            )
+            .await
+            .expect_err("hybrid enrollment must fail closed on a read-only secrets dir");
+            assert!(
+                err.to_string().contains("fail closed")
+                    || err.to_string().to_lowercase().contains("hybrid"),
+                "error must name the fail-closed reason: {err}"
+            );
+
+            // Restore perms so TempDir cleanup works.
+            std::fs::set_permissions(secrets.path(), std::fs::Permissions::from_mode(0o700))
+                .unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn enroll_legacy_ed25519_dir_upgrades_in_place_same_fingerprint() {
+        let creds = TempDir::new().unwrap();
+        let secrets = TempDir::new().unwrap();
+        let store = open(&creds);
+
+        // Legacy: classical enrollment first (Ed25519 file only, classical record).
+        let classical = enroll_user(
+            &store,
+            secrets.path(),
+            "grace",
+            EnrollKeySource::Generate,
+            CryptoPolicy::Classical,
+        )
+        .await
+        .unwrap();
+        assert_eq!(classical.algorithm, KeyAlgorithm::Ed25519);
+        assert!(!secrets.path().join("user-signing-key.mldsa").exists());
+
+        // Re-enroll under Hybrid: same anchor gains a PQ binding in place; the
+        // fingerprint (kid) is unchanged, and the record becomes hybrid.
+        let hybrid = enroll_user(
+            &store,
+            secrets.path(),
+            "grace",
+            EnrollKeySource::Generate,
+            CryptoPolicy::Hybrid,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            hybrid.fingerprint, classical.fingerprint,
+            "in-place upgrade must preserve the anchor fingerprint"
+        );
+        assert_eq!(hybrid.algorithm, KeyAlgorithm::HybridEd25519MlDsa65);
+        let keys = store.list_pubkeys("grace").await.unwrap();
+        assert_eq!(keys.len(), 1, "upgrade is in place, not a second key");
+        assert!(keys[0].pq_pubkey.is_some());
     }
 }

--- a/crates/hyprstream/src/cli/mod.rs
+++ b/crates/hyprstream/src/cli/mod.rs
@@ -9,6 +9,7 @@
 pub mod commands;
 pub mod context;
 pub mod daemon;
+pub mod enroll;
 pub mod git_handlers;
 pub mod gpu_detect;
 pub mod handlers;
@@ -53,7 +54,7 @@ pub use policy_handlers::{
     load_or_generate_signing_key,
 };
 pub use user_handlers::{
-    handle_user_list, handle_user_register, handle_user_remove,
+    handle_user_create, handle_user_list, handle_user_register, handle_user_remove,
     handle_user_keys_list, handle_user_keys_import, handle_user_keys_remove,
 };
 pub use crate::auth::policy_templates::{PolicyTemplate, get_template, get_templates};

--- a/crates/hyprstream/src/cli/user_handlers.rs
+++ b/crates/hyprstream/src/cli/user_handlers.rs
@@ -4,12 +4,13 @@
 
 use anyhow::{Context, Result};
 use base64::{engine::general_purpose::STANDARD, Engine};
-use ed25519_dalek::VerifyingKey;
+use ed25519_dalek::{SigningKey, VerifyingKey};
 use std::io::{Read, Write};
 use std::path::Path;
 
 use crate::auth::{RocksDbUserStore, UserStore};
 use crate::cli::commands::UserKeysImportFormat;
+use crate::cli::enroll::{enroll_user, EnrollKeySource};
 
 fn open_store(credentials_dir: &Path) -> Result<RocksDbUserStore> {
     RocksDbUserStore::open(credentials_dir).context("Failed to open credential store")
@@ -129,7 +130,7 @@ pub async fn handle_user_keys_list(credentials_dir: &Path, username: &str) -> Re
         for pk in &pubkeys {
             let label = pk.label.as_deref().unwrap_or("(no label)");
             let ts = pk.created_at;
-            println!("{}  {}  (added {})", pk.fingerprint, label, ts);
+            println!("{}  {}  algorithm={}  (added {})", pk.fingerprint, label, pk.algorithm.as_str(), ts);
         }
     }
     Ok(())
@@ -167,6 +168,151 @@ pub async fn handle_user_keys_import(
         .context("Failed to add key")?;
     println!("Added key {fingerprint}");
     Ok(())
+}
+
+/// Handle `user create <username> [--role] [--generate|--key|--ssh] [--no-role]`.
+///
+/// One-command enrollment (#439): generates (default) or adopts a signing key,
+/// installs it as the client's actual signing key, registers the user record,
+/// binds the derived public key, and grants a role — collapsing the multi-step
+/// dance whose partial failure silently authenticates as `anonymous`.
+pub async fn handle_user_create(
+    credentials_dir: &Path,
+    username: &str,
+    role: &str,
+    no_role: bool,
+    generate: bool,
+    key: Option<&str>,
+    ssh: Option<&str>,
+) -> Result<()> {
+    let store = open_store(credentials_dir)?;
+    let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir()
+        .context("Failed to resolve secrets directory")?;
+
+    let source = resolve_create_key_source(generate, key, ssh)?;
+
+    let outcome = enroll_user(&store, &secrets_dir, username, source)
+        .await
+        .context("Failed to enroll user")?;
+
+    println!("✓ Enrolled user '{}'", outcome.username);
+    if let Some(bak) = &outcome.key_backed_up {
+        println!("  Backed up prior signing key to {}", bak.display());
+    }
+    println!("  Signing key installed as the client key — the CLI now signs with this key.");
+    println!(
+        "  Fingerprint: {}  (algorithm={})",
+        outcome.fingerprint,
+        outcome.algorithm.as_str()
+    );
+    println!(
+        "  Verify: `ssh-keygen -l -E sha256` of the key prints {}",
+        outcome.fingerprint
+    );
+
+    if !no_role {
+        // Best-effort role grant via the running PolicyService. Enrollment
+        // already succeeded; a down service (or first-run setup) must not undo
+        // it — point the operator at the manual command instead.
+        match grant_role(username, role).await {
+            Ok(()) => {}
+            Err(e) => {
+                println!(
+                    "  ⚠ Could not grant role '{role}' automatically ({e}).\n    \
+                     Run `hyprstream policy role add {username} {role}` once services are up."
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Resolve the `user create` key source from the `--generate`/`--key`/`--ssh`
+/// flags. `--generate` (or no key flag) → [`EnrollKeySource::Generate`].
+fn resolve_create_key_source(
+    _generate: bool,
+    key: Option<&str>,
+    ssh: Option<&str>,
+) -> Result<EnrollKeySource> {
+    if let Some(path) = ssh {
+        let sk = parse_openssh_ed25519(path)?;
+        return Ok(EnrollKeySource::SigningKey(sk));
+    }
+    if let Some(path) = key {
+        let seed = read_seed_file(path)?;
+        return Ok(EnrollKeySource::RawSeed(seed));
+    }
+    Ok(EnrollKeySource::Generate)
+}
+
+/// Read a raw 32-byte Ed25519 seed from a file (or `-` stdin). Accepts either
+/// raw 32 bytes or standard base64 of 32 bytes.
+fn read_seed_file(path: &str) -> Result<[u8; 32]> {
+    let raw = if path == "-" {
+        let mut buf = Vec::new();
+        std::io::stdin().read_to_end(&mut buf)?;
+        buf
+    } else {
+        std::fs::read(path).with_context(|| format!("Failed to read seed file: {path}"))?
+    };
+
+    let seed: [u8; 32] = if raw.len() == 32 {
+        raw.try_into()
+            .map_err(|_| anyhow::anyhow!("Seed file is not 32 bytes (Ed25519)"))?
+    } else {
+        // Try base64 of 32 bytes.
+        let s = std::str::from_utf8(&raw)
+            .map_err(|_| anyhow::anyhow!("Seed file is neither 32 raw bytes nor base64 of 32 bytes"))?;
+        let decoded = STANDARD.decode(s.trim())
+            .map_err(|_| anyhow::anyhow!("Seed file is neither 32 raw bytes nor base64 of 32 bytes"))?;
+        decoded
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("Decoded seed is not 32 bytes (Ed25519)"))?
+    };
+    Ok(seed)
+}
+
+/// Parse an OpenSSH Ed25519 private key from `path`, prompting for a passphrase
+/// if the key is encrypted.
+fn parse_openssh_ed25519(path: &str) -> Result<SigningKey> {
+    let pem = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read OpenSSH key: {path}"))?;
+    let key = ssh_key::PrivateKey::from_openssh(&pem)
+        .with_context(|| format!("Failed to parse OpenSSH private key: {path}"))?;
+    let key = if key.is_encrypted() {
+        let passphrase = prompt_passphrase()?;
+        key.decrypt(&passphrase)
+            .context("Failed to decrypt OpenSSH key (wrong passphrase?)")?
+    } else {
+        key
+    };
+    match key.key_data() {
+        ssh_key::private::KeypairData::Ed25519(ed) => {
+            Ok(SigningKey::from(&ed.private))
+        }
+        _ => anyhow::bail!(
+            "{path} is not an Ed25519 key ({}); only ssh-ed25519 is supported. \
+             Generate one with: ssh-keygen -t ed25519",
+            key.algorithm().as_str()
+        ),
+    }
+}
+
+/// Prompt the terminal for an OpenSSH passphrase without echoing it.
+fn prompt_passphrase() -> Result<String> {
+    inquire::Password::new("Passphrase (OpenSSH key is encrypted): ")
+        .with_display_mode(inquire::PasswordDisplayMode::Hidden)
+        .without_confirmation()
+        .prompt()
+        .map_err(|e| anyhow::anyhow!("failed to read passphrase: {e}"))
+}
+
+/// Grant a role to `username` via the running PolicyService.
+async fn grant_role(username: &str, role: &str) -> Result<()> {
+    let keys_dir = std::path::PathBuf::from("."); // load_or_generate_signing_key resolves via config
+    let signing_key = crate::cli::load_or_generate_signing_key(&keys_dir).await?;
+    crate::cli::handle_policy_role_add(&signing_key, username, role, false).await
 }
 
 /// Handle `user keys remove <username> <fingerprint>`

--- a/crates/hyprstream/src/cli/user_handlers.rs
+++ b/crates/hyprstream/src/cli/user_handlers.rs
@@ -191,7 +191,13 @@ pub async fn handle_user_create(
 
     let source = resolve_create_key_source(generate, key, ssh)?;
 
-    let outcome = enroll_user(&store, &secrets_dir, username, source)
+    // Post-quantum policy is node policy: Hybrid by default (fail-closed), only
+    // an explicit HYPRSTREAM_ENVELOPE_POLICY=classical downgrades. Enrollment is
+    // a root-of-trust path, so it follows the same selector as envelope traffic
+    // rather than silently minting classical-only identity material.
+    let policy = hyprstream_rpc::envelope::envelope_policy_from_env();
+
+    let outcome = enroll_user(&store, &secrets_dir, username, source, policy)
         .await
         .context("Failed to enroll user")?;
 
@@ -199,12 +205,18 @@ pub async fn handle_user_create(
     if let Some(bak) = &outcome.key_backed_up {
         println!("  Backed up prior signing key to {}", bak.display());
     }
+    if let Some(bak) = &outcome.pq_key_backed_up {
+        println!("  Backed up prior post-quantum key to {}", bak.display());
+    }
     println!("  Signing key installed as the client key — the CLI now signs with this key.");
     println!(
         "  Fingerprint: {}  (algorithm={})",
         outcome.fingerprint,
         outcome.algorithm.as_str()
     );
+    for notice in &outcome.notices {
+        println!("  ⚠ {notice}");
+    }
     println!(
         "  Verify: `ssh-keygen -l -E sha256` of the key prints {}",
         outcome.fingerprint

--- a/crates/hyprstream/src/services/oauth/rpc_handler.rs
+++ b/crates/hyprstream/src/services/oauth/rpc_handler.rs
@@ -69,6 +69,7 @@ impl OAuthRpcHandler {
                 created_at: pk.created_at,
                 last_used_at: pk.last_used_at.unwrap_or(0),
                 algorithm: pk.algorithm.as_str().to_owned(),
+                pq_pubkey: pk.pq_pubkey.clone().unwrap_or_default(),
             }).collect(),
         }
     }
@@ -226,6 +227,7 @@ impl OauthHandler for OAuthRpcHandler {
             created_at: entry.created_at,
             last_used_at: entry.last_used_at.unwrap_or(0),
             algorithm: entry.algorithm.as_str().to_owned(),
+            pq_pubkey: entry.pq_pubkey.clone().unwrap_or_default(),
         }))
     }
 
@@ -258,6 +260,7 @@ impl OauthHandler for OAuthRpcHandler {
                     created_at: e.created_at,
                     last_used_at: e.last_used_at.unwrap_or(0),
                     algorithm: e.algorithm.as_str().to_owned(),
+                    pq_pubkey: e.pq_pubkey.clone().unwrap_or_default(),
                 })
                 .collect(),
         ))

--- a/crates/hyprstream/src/services/oauth/rpc_handler.rs
+++ b/crates/hyprstream/src/services/oauth/rpc_handler.rs
@@ -68,6 +68,7 @@ impl OAuthRpcHandler {
                 label: pk.label.clone().unwrap_or_default(),
                 created_at: pk.created_at,
                 last_used_at: pk.last_used_at.unwrap_or(0),
+                algorithm: pk.algorithm.as_str().to_owned(),
             }).collect(),
         }
     }
@@ -224,6 +225,7 @@ impl OauthHandler for OAuthRpcHandler {
             label: entry.label.unwrap_or_default(),
             created_at: entry.created_at,
             last_used_at: entry.last_used_at.unwrap_or(0),
+            algorithm: entry.algorithm.as_str().to_owned(),
         }))
     }
 
@@ -255,6 +257,7 @@ impl OauthHandler for OAuthRpcHandler {
                     label: e.label.unwrap_or_default(),
                     created_at: e.created_at,
                     last_used_at: e.last_used_at.unwrap_or(0),
+                    algorithm: e.algorithm.as_str().to_owned(),
                 })
                 .collect(),
         ))

--- a/crates/hyprstream/src/services/oauth/user_service.rs
+++ b/crates/hyprstream/src/services/oauth/user_service.rs
@@ -33,6 +33,9 @@ pub struct PubkeyInfo {
     pub created_at: i64,
     pub last_used_at: Option<i64>,
     pub algorithm: crate::auth::KeyAlgorithm,
+    /// Bound ML-DSA-65 verifying key bytes for a hybrid record (#439); `None`
+    /// for classical Ed25519.
+    pub pq_pubkey: Option<Vec<u8>>,
 }
 
 impl From<&PubkeyEntry> for PubkeyInfo {
@@ -44,6 +47,7 @@ impl From<&PubkeyEntry> for PubkeyInfo {
             created_at: entry.created_at,
             last_used_at: entry.last_used_at,
             algorithm: entry.algorithm,
+            pq_pubkey: entry.pq_pubkey.clone(),
         }
     }
 }

--- a/crates/hyprstream/src/services/oauth/user_service.rs
+++ b/crates/hyprstream/src/services/oauth/user_service.rs
@@ -32,6 +32,7 @@ pub struct PubkeyInfo {
     pub label: Option<String>,
     pub created_at: i64,
     pub last_used_at: Option<i64>,
+    pub algorithm: crate::auth::KeyAlgorithm,
 }
 
 impl From<&PubkeyEntry> for PubkeyInfo {
@@ -42,6 +43,7 @@ impl From<&PubkeyEntry> for PubkeyInfo {
             label: entry.label.clone(),
             created_at: entry.created_at,
             last_used_at: entry.last_used_at,
+            algorithm: entry.algorithm,
         }
     }
 }


### PR DESCRIPTION
Closes #439.

## What

`hyprstream user create <username> [--role] [--generate|--key|--ssh] [--no-role]` — one command that generates (default) or adopts a signing key, installs it as the client's actual signing key, registers the user record, binds the derived public key, and grants a role. Collapses the multi-step enrollment whose silent partial failure authenticates as `anonymous` (#438).

## Changes

- **Shared enroll routine** (`cli::enroll::enroll_user`): register-if-absent → resolve/store signing key → bind pubkey. Both the bootstrap wizard (#438) and `user create` now call it so the two paths cannot drift (DRY). The wizard's `register_local_identity` now delegates to it.
- **`user create` flags**: `--generate` (default), `--key <seed-file>` (raw 32-byte Ed25519 seed), `--ssh <key>` (OpenSSH Ed25519 private key, passphrase-prompted via `ssh-key` + `inquire`), `--role` (default `operator`; `admin` opt-in), `--no-role`. Username defaults to the OS user, matching the CLI's `sub`.
- **Algorithm-tagged key records** (#439 PQ-readiness hook, mirroring #280): new `KeyAlgorithm` enum (Ed25519 today), an `algorithm` field on `PubkeyEntry` / `StoredPubkey` / `StoredKey` / `PubkeyInfo`, and a new `algorithm` capnp field on `oauth.capnp:PubkeyEntry` (defaults to `ed25519` for pre-#439 records). `user keys list` now shows the algorithm. Widening the store to PQ later is **additive, not a store-schema migration**.
- `identity_store::install_user_signing_key` installs an adopted key at `credentials/user-signing-key` with a reversible `.bak` backup of the prior key.
- Role grant is best-effort via the running PolicyService (mirrors `policy role add`); if services are down it prints the manual command without failing the enrollment.

PQ is intentionally **not** implemented here — classical Ed25519 is the correct floor for a local human identity key (no HNDL exposure on signatures). The algorithm tag is the only PQ-forward choice baked in now.

## Verification

- `cargo clippy -p hyprstream --all-targets -- -D warnings` clean; pre-commit hook (workspace `--release` clippy) green.
- New/updated tests: `cli::enroll::*` (generate / adopt+backup / raw seed / re-point-from-anonymous), `auth::user_store::test_key_algorithm_parse_and_roundtrip`, `auth::rocksdb_store::test_pubkey_algorithm_tag_persists_across_reopen`, algorithm assertion in `test_add_and_list_pubkeys`, and the wizard's `register_local_identity` now exercises the shared routine via its existing tests.