### PR TITLE
feat(model): latched load --wait via read_then_subscribe (#649)

### DIFF
--- a/crates/hyprstream-rpc/src/latch.rs
+++ b/crates/hyprstream-rpc/src/latch.rs
@@ -181,6 +181,27 @@ impl<K: ResourceKey> TerminalAuthz<K> for DenyAllTerminalAuthz {
     }
 }
 
+/// Permissive [`TerminalAuthz`] for a Public (plaintext) operational plane.
+///
+/// Counterpart to [`DenyAllTerminalAuthz`] for resources whose terminal value
+/// rides a plaintext EventService source — e.g. the model-lifecycle plane
+/// (`model.lifecycle.{loaded,failed}`), which EV5/#605 deliberately kept
+/// plaintext (the encrypted-default flip is deferred to #555). On such a plane
+/// a late read of the retained terminal releases no plaintext the live edge
+/// would not, so permitting the [`read_then_subscribe`] fast path is consistent
+/// with the plane's current posture.
+///
+/// This is NOT the right authz for a labelled/encrypted plane — there the late
+/// read must enforce MAC (`subject.ctx ⊒ object.label`); that impl lands under
+/// EV4 (#604). Use [`DenyAllTerminalAuthz`] (the default) until the plane has
+/// labels and a real MAC-backed impl exists.
+pub struct AllowAllTerminalAuthz;
+impl<K: ResourceKey> TerminalAuthz<K> for AllowAllTerminalAuthz {
+    fn authorize_read(&self, _key: &K, _watcher: &str) -> bool {
+        true
+    }
+}
+
 /// Latched-completion read: serve the retained terminal for `key` if already
 /// latched (and `authz` permits the late read), else subscribe to the live
 /// EventService edge via `subscriber` and block until an event that `classify`
@@ -296,6 +317,17 @@ mod tests {
         // Reaped keys got the fallback.
         assert_eq!(store.get(&2).unwrap().value.0, 255);
         assert_eq!(store.get(&3).unwrap().latched_by, "reaper@3");
+    }
+
+    #[test]
+    fn allow_all_authz_permits_late_read() {
+        // The plaintext-plane counterpart to deny_all_authz_blocks_late_read:
+        // AllowAllTerminalAuthz (correct for a Public EventService source, e.g.
+        // model lifecycle pre-#555) authorizes a late read of a retained value.
+        let store: TerminalStore<String, ExampleExit> = TerminalStore::new();
+        store.latch("t1".to_owned(), term(0, "owner"));
+        let authz = AllowAllTerminalAuthz;
+        assert!(authz.authorize_read(&"t1".to_owned(), "watcher"));
     }
 
     #[test]

--- a/crates/hyprstream/src/cli/git_handlers.rs
+++ b/crates/hyprstream/src/cli/git_handlers.rs
@@ -1540,45 +1540,114 @@ pub async fn handle_load(
     if kv_quant != crate::runtime::KVQuantType::None { println!("  KV quantization: {:?}", kv_quant); }
 
     // If --wait, block on EventService model.lifecycle events until loaded/failed.
-    // EV5/#605: replaced NotificationService blinded-DH path with unified EventService.
-    // Model lifecycle events ride the "model" source in Public/plaintext mode
-    // (encrypted-default flip deferred to #555), so no group-key join is needed.
+    // EV7/#649: latched shape via `read_then_subscribe`. A `load --wait` issued
+    // AFTER the model already loaded would otherwise hang on an event that will
+    // never fire (the load RPC fast-paths and publishes nothing) — so after
+    // subscribing (never before, to avoid missing the live edge) we probe status
+    // and pre-latch the retained `Loaded` terminal; `read_then_subscribe` then
+    // fast-paths the retained value, else blocks on the live `model.lifecycle`
+    // edge until `model.loaded`/`model.failed`.
+    // EV5/#605: model lifecycle events ride the "model" source in Public/plaintext
+    // mode (encrypted-default flip deferred to #555), so the late read uses the
+    // plaintext-plane `AllowAllTerminalAuthz` and no group-key join is needed.
     if let Some(timeout_secs) = wait {
         println!("Waiting for model to load (timeout: {}s)...", timeout_secs);
         ensure_event_client_origin(paths::event_socket());
         let mut subscriber = EventSubscriber::new()?;
         subscriber.subscribe("model")?;
 
-        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
-        let outcome = loop {
-            let remaining = deadline.checked_duration_since(tokio::time::Instant::now()).unwrap_or_default();
-            if remaining.is_zero() {
-                break Err(anyhow::anyhow!("Timeout waiting for model load notification ({}s elapsed)", timeout_secs));
-            }
-            match tokio::time::timeout(remaining, subscriber.recv()).await {
-                Err(_) => break Err(anyhow::anyhow!("Timeout waiting for model load notification ({}s elapsed)", timeout_secs)),
-                Ok(Err(e)) => { debug!("event recv error: {e}"); continue; }
-                Ok(Ok((topic, payload))) => {
-                    let event: EventEnvelope = match serde_json::from_slice(&payload) {
-                        Ok(e) => e, Err(_) => continue,
-                    };
-                    match &event.payload {
-                        EventPayload::ModelLoaded { model_ref: ref mr, endpoint }
-                            if mr.contains(model_ref_str) || model_ref_str.contains(mr.as_str()) =>
-                        {
-                            println!("\u{2713} Model {} loaded", model_ref_str);
-                            println!("  Endpoint: {}", endpoint);
-                            break Ok(());
-                        }
-                        EventPayload::ModelFailed { model_ref: ref mr, error }
-                            if mr.contains(model_ref_str) || model_ref_str.contains(mr.as_str()) =>
-                        {
-                            break Err(anyhow::anyhow!("Model {} failed to load: {}", model_ref_str, error));
-                        }
-                        _ => { debug!("ignoring event: {}", topic); }
-                    }
+        use hyprstream_rpc::latch::{
+            AllowAllTerminalAuthz, Terminal, TerminalStore, read_then_subscribe,
+        };
+        use crate::services::model::ModelLoadTerminal;
+
+        // Local retain-store for this load-wait invocation. Pre-seed from a
+        // status probe so a late arrival (model already loaded) fast-paths.
+        let store: TerminalStore<String, ModelLoadTerminal> = TerminalStore::new();
+        let mut fast_path = false;
+        match model_client
+            .status(&StatusRequest { model_ref: model_ref_str.to_owned() })
+            .await
+        {
+            Ok(entries) => {
+                let already_loaded = entries.iter().any(|e| {
+                    e.status == "loaded"
+                        && (e.model_ref.contains(model_ref_str)
+                            || model_ref_str.contains(e.model_ref.as_str()))
+                });
+                if already_loaded {
+                    // Co-located reach is empty on the wire (#320); the live
+                    // `model.loaded` event's endpoint is unavailable on this
+                    // path, so latch without one (display omits the line).
+                    let _ = store.latch(
+                        model_ref_str.to_owned(),
+                        Terminal {
+                            value: ModelLoadTerminal::Loaded { endpoint: String::new() },
+                            latched_by: "cli-status".to_owned(),
+                        },
+                    );
+                    fast_path = true;
                 }
             }
+            Err(e) => debug!("model status probe failed (will wait on live edge): {e}"),
+        }
+
+        // Classify a `model.lifecycle` event as a terminal value for THIS
+        // model_ref. Non-matching events (other models) yield `None` and
+        // `read_then_subscribe` keeps draining the live edge.
+        let classify_ref = model_ref_str.to_owned();
+        let classify = move |_topic: &str, payload: &[u8]| -> Option<ModelLoadTerminal> {
+            let event: EventEnvelope = match serde_json::from_slice(payload) {
+                Ok(e) => e,
+                Err(_) => return None,
+            };
+            match &event.payload {
+                EventPayload::ModelLoaded { model_ref: mr, endpoint }
+                    if mr.contains(classify_ref.as_str()) || classify_ref.contains(mr.as_str()) =>
+                {
+                    Some(ModelLoadTerminal::Loaded { endpoint: endpoint.clone() })
+                }
+                EventPayload::ModelFailed { model_ref: mr, error }
+                    if mr.contains(classify_ref.as_str()) || classify_ref.contains(mr.as_str()) =>
+                {
+                    Some(ModelLoadTerminal::LoadFailed { error: error.clone() })
+                }
+                _ => None,
+            }
+        };
+
+        let watcher = "cli-load-wait".to_owned();
+        let deadline = std::time::Duration::from_secs(timeout_secs);
+        let outcome = match tokio::time::timeout(
+            deadline,
+            read_then_subscribe(
+                &store,
+                &mut subscriber,
+                &AllowAllTerminalAuthz,
+                &watcher,
+                model_ref_str.to_owned(),
+                classify,
+            ),
+        )
+        .await
+        {
+            Err(_) => Err(anyhow::anyhow!(
+                "Timeout waiting for model load notification ({}s elapsed)",
+                timeout_secs
+            )),
+            Ok(Err(e)) => Err(anyhow::anyhow!("Model load wait failed: {e}")),
+            Ok(Ok(terminal)) => match terminal.value {
+                ModelLoadTerminal::Loaded { endpoint } => {
+                    println!("\u{2713} Model {} loaded{}", model_ref_str, if fast_path { " (already loaded)" } else { "" });
+                    if !endpoint.is_empty() {
+                        println!("  Endpoint: {}", endpoint);
+                    }
+                    Ok(())
+                }
+                ModelLoadTerminal::LoadFailed { error } => {
+                    Err(anyhow::anyhow!("Model {} failed to load: {}", model_ref_str, error))
+                }
+            },
         };
         outcome?;
     }

--- a/crates/hyprstream/src/services/model.rs
+++ b/crates/hyprstream/src/services/model.rs
@@ -41,6 +41,7 @@ use crate::services::generated::registry_client::{StageFilesRequest, CommitWithA
 use crate::services::generated::policy_client::PolicyCheck;
 use crate::storage::ModelRef;
 use anyhow::{anyhow, Result};
+use hyprstream_rpc::latch::{Terminal, TerminalStore};
 use hyprstream_rpc::prelude::*;
 use hyprstream_rpc::events::EventPublisher;
 use hyprstream_rpc::registry::{global as registry, SocketKind};
@@ -49,6 +50,7 @@ use hyprstream_rpc::stream_info::TransportConfig as WireTransportConfig;
 use lru::LruCache;
 use std::collections::HashSet;
 use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::{Mutex, RwLock};
@@ -56,6 +58,42 @@ use tracing::{debug, info, warn};
 
 /// Default endpoint for the model service
 pub const MODEL_ENDPOINT: &str = "inproc://hyprstream/model";
+
+// ============================================================================
+// Latched load terminal (EV7/#649) — host-side retained load outcome
+// ============================================================================
+
+/// Terminal payload for a model load attempt (EV7/#649). Latched host-side by
+/// [`ModelService`] when a load completes — [`Loaded`](Self::Loaded) on success,
+/// [`LoadFailed`](Self::LoadFailed) otherwise — so a late `load --wait` (or a
+/// future P9 `/model/<ref>/loaded` file) is served the retained value instead
+/// of missing the live `model.lifecycle` edge it subscribed to too late.
+///
+/// Rides the same plaintext `model` EventService source as the live edge (EV5
+/// /#605; encrypted-default flip deferred to #555), so retaining it host-side
+/// releases no plaintext the live edge would not.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ModelLoadTerminal {
+    /// Load succeeded; `endpoint` is the inference endpoint string.
+    Loaded { endpoint: String },
+    /// Load failed; `error` is the failure message.
+    LoadFailed { error: String },
+}
+
+/// Per-load-attempt key into the model-service [`TerminalStore`] (EV7/#649).
+///
+/// Combines the model ref with a monotonic per-process epoch (see
+/// [`ModelServiceInner::load_epoch`]) so a reload allocates a fresh key and
+/// latches a NEW terminal — monotonic write-once then holds *per epoch*, the
+/// EV7 "reload = new latch, write-once within an attempt" contract. Without
+/// per-epoch keying the first `Loaded` latch would shadow every reload.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ModelLoadKey {
+    /// The model reference string (e.g. "qwen3-small:main").
+    pub model_ref: String,
+    /// Monotonic load-attempt number for this process.
+    pub epoch: u64,
+}
 
 // ============================================================================
 // ModelService (server-side)
@@ -158,6 +196,17 @@ pub struct ModelServiceInner {
     mesh_identity_roster: Option<Arc<Vec<([u8; 32], hyprstream_rpc::Subject)>>>,
     /// Persistent 9P synthetic tree for the fs scope (lazily initialized).
     fs_tree: std::sync::OnceLock<crate::services::fs::SyntheticTree>,
+    /// Retained terminal for each model load attempt (EV7/#649) — the
+    /// host-side "file holds the truth" retain. A late `load --wait` reads the
+    /// retained [`ModelLoadTerminal`] from here instead of missing the live
+    /// `model.lifecycle` edge. Distinct from the live EventService edge (which
+    /// never holds the retained value) and from the `loaded_models` cache
+    /// (which tracks residency, not the per-attempt terminal outcome).
+    load_terminals: TerminalStore<ModelLoadKey, ModelLoadTerminal>,
+    /// Monotonic per-process epoch counter; each genuine load attempt
+    /// allocates the next value, keying a fresh [`TerminalStore`] entry so a
+    /// reload latches under a new key (reload ⇒ new terminal, EV7/#649).
+    load_epoch: AtomicU64,
 }
 
 /// Model service that manages InferenceService lifecycle.
@@ -279,6 +328,8 @@ impl ModelService {
             discovery_client: None,
             mesh_identity_roster: None,
             fs_tree: std::sync::OnceLock::new(),
+            load_terminals: TerminalStore::new(),
+            load_epoch: AtomicU64::new(0),
         })})
     }
 
@@ -347,6 +398,35 @@ impl ModelService {
     /// Resolved via the registry (the local [`hyprstream_rpc::Resolver`] backend):
     /// the `Inproc` arm for a co-located service. The spawner registers it in the
     /// in-process dial registry and the router dials it via `dial()`.
+    /// Allocate the next monotonic load epoch (EV7/#649). Each genuine load
+    /// attempt (one that proceeds past the already-loaded / already-pending
+    /// fast paths) draws a fresh epoch so its terminal latches under a new
+    /// [`ModelLoadKey`] — reload ⇒ new terminal, monotonic write-once per epoch.
+    fn allocate_load_epoch(&self) -> u64 {
+        self.load_epoch.fetch_add(1, Ordering::Relaxed) + 1
+    }
+
+    /// Latch the retained terminal for a completed load attempt (EV7/#649) —
+    /// the host-side retain a late `load --wait` reads from. Monotonic
+    /// write-once per (`model_ref`, `epoch`): the first terminal for an attempt
+    /// wins; a real attempt always latches under a fresh epoch, so the guard is
+    /// belt-and-suspenders. Split out so the latch decision is unit-testable
+    /// independent of the full load path.
+    fn latch_load_terminal(&self, model_ref: &str, epoch: u64, result: &Result<String>) {
+        let terminal = match result {
+            Ok(endpoint) => Terminal {
+                value: ModelLoadTerminal::Loaded { endpoint: endpoint.clone() },
+                latched_by: "model-service".to_owned(),
+            },
+            Err(e) => Terminal {
+                value: ModelLoadTerminal::LoadFailed { error: e.to_string() },
+                latched_by: "model-service".to_owned(),
+            },
+        };
+        let key = ModelLoadKey { model_ref: model_ref.to_owned(), epoch };
+        let _ = self.load_terminals.latch(key, terminal);
+    }
+
     fn inference_transport(model_ref_str: &str) -> TransportConfig {
         let safe_name = model_ref_str.replace([':', '/', '\\'], "-");
         let service_name = format!("inference-{safe_name}");
@@ -744,10 +824,19 @@ impl ModelService {
             }
         }
 
+        // EV7/#649: this is a genuine new load attempt (past the already-loaded
+        // and already-pending fast paths) — allocate a fresh epoch so its
+        // terminal latches under a new key (reload ⇒ new terminal).
+        let epoch = self.allocate_load_epoch();
+
         let result = self.load_model_inner(model_ref_str, max_context, kv_quant).await;
 
         // Always remove from pending, whether load succeeded or failed
         self.pending_loads.lock().await.remove(model_ref_str);
+
+        // EV7/#649: latch the retained terminal (Loaded / LoadFailed) for this
+        // load attempt — the host-side retain a late `load --wait` reads.
+        self.latch_load_terminal(model_ref_str, epoch, &result);
 
         if result.is_ok() {
             info!("Model {} loaded successfully", model_ref_str);
@@ -1888,6 +1977,94 @@ mod tests {
         assert_eq!(config.max_models, 5);
         assert_eq!(config.max_context, None);
         assert_eq!(config.kv_quant, KVQuantType::None);
+    }
+
+    // ========================================================================
+    // #649 — latched load terminal (EV7 host-side retain)
+    //
+    // `ModelLoadTerminal` + `ModelLoadKey` latch directly into a
+    // `TerminalStore`; these tests prove the per-load-attempt / monotonic-
+    // write-once contract without constructing a full `ModelService` (which
+    // needs a registry + transport). The wiring (`allocate_load_epoch` +
+    // `latch_load_terminal` called from `load_model`) is thin glue over these
+    // primitives.
+    // ========================================================================
+
+    fn loaded_term(endpoint: &str) -> Terminal<ModelLoadTerminal> {
+        Terminal {
+            value: ModelLoadTerminal::Loaded { endpoint: endpoint.to_owned() },
+            latched_by: "model-service".to_owned(),
+        }
+    }
+
+    fn failed_term(err: &str) -> Terminal<ModelLoadTerminal> {
+        Terminal {
+            value: ModelLoadTerminal::LoadFailed { error: err.to_owned() },
+            latched_by: "model-service".to_owned(),
+        }
+    }
+
+    // Read back a latched terminal without `.unwrap()` (clippy denies it here).
+    fn latched_value(
+        store: &TerminalStore<ModelLoadKey, ModelLoadTerminal>,
+        key: &ModelLoadKey,
+    ) -> ModelLoadTerminal {
+        match store.get(key) {
+            Some(t) => t.value,
+            None => panic!("expected a terminal latched for {key:?}"),
+        }
+    }
+
+    /// Monotonic write-once within a single load attempt (single epoch): a
+    /// second latch on the same key is rejected and the first terminal wins.
+    #[test]
+    fn load_terminal_is_monotonic_write_once_per_epoch() {
+        let store: TerminalStore<ModelLoadKey, ModelLoadTerminal> = TerminalStore::new();
+        let key = ModelLoadKey { model_ref: "qwen3:main".to_owned(), epoch: 1 };
+        assert!(store.latch(key.clone(), loaded_term("ep1")));
+        // A late failure for the SAME attempt cannot overwrite the real Loaded.
+        assert!(!store.latch(key.clone(), failed_term("race")));
+        assert_eq!(
+            latched_value(&store, &key),
+            ModelLoadTerminal::Loaded { endpoint: "ep1".to_owned() }
+        );
+    }
+
+    /// Per-load-attempt keying: a reload allocates a fresh epoch and latches a
+    /// NEW terminal — the EV7 "reload = new latch" contract. Without per-epoch
+    /// keying the first Loaded would shadow every subsequent reload.
+    #[test]
+    fn reload_latches_new_terminal_under_new_epoch() {
+        let store: TerminalStore<ModelLoadKey, ModelLoadTerminal> = TerminalStore::new();
+        // First load attempt (epoch 1): Loaded.
+        let k1 = ModelLoadKey { model_ref: "qwen3:main".to_owned(), epoch: 1 };
+        assert!(store.latch(k1.clone(), loaded_term("ep1")));
+        // Reload (epoch 2): a distinct key, so it latches a fresh terminal.
+        let k2 = ModelLoadKey { model_ref: "qwen3:main".to_owned(), epoch: 2 };
+        assert!(store.latch(k2.clone(), loaded_term("ep2")));
+        // Both attempts' terminals are retained (monotonic per-epoch).
+        assert_eq!(
+            latched_value(&store, &k1),
+            ModelLoadTerminal::Loaded { endpoint: "ep1".to_owned() }
+        );
+        assert_eq!(
+            latched_value(&store, &k2),
+            ModelLoadTerminal::Loaded { endpoint: "ep2".to_owned() }
+        );
+    }
+
+    /// A failed attempt latches `LoadFailed` under its epoch; a later
+    /// successful reload (new epoch) latches `Loaded`. The failure is retained,
+    /// not overwritten — each attempt has its own authoritative terminal.
+    #[test]
+    fn failed_then_reload_latches_distinct_terminals() {
+        let store: TerminalStore<ModelLoadKey, ModelLoadTerminal> = TerminalStore::new();
+        let kf = ModelLoadKey { model_ref: "qwen3:main".to_owned(), epoch: 1 };
+        assert!(store.latch(kf.clone(), failed_term("oom")));
+        let ks = ModelLoadKey { model_ref: "qwen3:main".to_owned(), epoch: 2 };
+        assert!(store.latch(ks.clone(), loaded_term("ep2")));
+        assert!(matches!(latched_value(&store, &kf), ModelLoadTerminal::LoadFailed { .. }));
+        assert!(matches!(latched_value(&store, &ks), ModelLoadTerminal::Loaded { .. }));
     }
 
     /// #320: the co-located InferenceService resolves (via the local Resolver


### PR DESCRIPTION
Closes #649.

## Summary

Adopts the EV7 `read_then_subscribe` primitive on the `model load --wait` path so a wait issued **after** the model already loaded returns the retained terminal instead of hanging on a live `model.lifecycle` edge that will never fire (late-arrival correctness — the canonical EV7 consumer).

EV5 (#648) routed `load --wait` to the live-only `EventSubscriber::recv()`, matching the old NotificationService snapshot-at-publish parity. EV7 (#642) shipped `read_then_subscribe` + `TerminalStore` precisely to close the late-arrival gap; this PR is the model-service adoption.

## Changes

- **Model service (`services/model.rs`)** — latches `Loaded{endpoint}` / `LoadFailed{error}` into a host-side `TerminalStore<ModelLoadKey, ModelLoadTerminal>` on each load completion (the EV7 "file holds the authoritative retained terminal value"). Keyed by `(model_ref, epoch)`: a monotonic per-process epoch allocates a fresh key per genuine load attempt, so a reload latches a **new** terminal (monotonic write-once holds per epoch — the "reload = new latch" contract). The already-loaded / already-pending fast paths do not latch (no new load attempt).
- **CLI `load --wait` (`cli/git_handlers.rs`)** — replaces the bare `subscriber.recv()` loop with `read_then_subscribe` over a local retain-store. Subscribes **first** (never misses the live edge), then probes status and pre-latches the retained `Loaded` terminal if the model is already loaded — the late-arrival fast path; otherwise blocks on the live `model.lifecycle` edge until `model.loaded`/`model.failed`.
- **`hyprstream-rpc::latch`** — adds `AllowAllTerminalAuthz`, the plaintext-plane counterpart to `DenyAllTerminalAuthz`. Model lifecycle rides a Public EventService source (EV5/#605; encrypted-default flip deferred to #555), so a late read of the retained terminal releases no plaintext the live edge would not. MAC-backed replacement lands under EV4 (#604); `DenyAll` remains the default for labelled/encrypted planes.

## Acceptance

- ✅ `load --wait` issued after a model already loaded returns the retained `Loaded` terminal immediately (status-probe pre-latch → `read_then_subscribe` fast path) instead of hanging until timeout.
- ✅ Per-load-attempt/epoch latching; reload produces a new terminal (monotonic write-once per epoch).
- ✅ Behavior preserved for the live-edge (early-watcher) and `LoadFailed` paths.

## Tests

`hyprstream-rpc` latch + `hyprstream` model unit tests; `cargo clippy --workspace --all-targets --release -- -D warnings` clean (pre-commit hook, 1.97).

- `allow_all_authz_permits_late_read`
- `load_terminal_is_monotonic_write_once_per_epoch`
- `reload_latches_new_terminal_under_new_epoch`
- `failed_then_reload_latches_distinct_terminals`

A full `read_then_subscribe` end-to-end test needs a running moq EventBus + tokio runtime (noted as out-of-scope for a lib unit test in `latch.rs`); the unit-testable invariants (authz, monotonic-latch, per-epoch reload) are covered.