### PR TITLE
feat(mac #677): Fu1-Fu6 audit hardening of hybrid-PQ + audit seams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6962,6 +6962,7 @@ dependencies = [
  "cas-serve",
  "casbin",
  "chrono",
+ "ciborium",
  "clap",
  "config 0.13.4",
  "criterion",

--- a/crates/hyprstream-rpc/src/auth/claims.rs
+++ b/crates/hyprstream-rpc/src/auth/claims.rs
@@ -451,6 +451,23 @@ impl Claims {
         is_local_iss(&self.iss, local_issuers)
     }
 
+    /// Strip the authority-asserted MAC `clearance` when this token's issuer is
+    /// NOT a local issuer (Fu5/#677).
+    ///
+    /// `clearance` is authority-asserted: the issuing node signs the JWT, so a
+    /// local issuer (this node, or a configured local cluster issuer) is trusted
+    /// to grant MAC clearance. An external OIDC issuer trusted **for identity**
+    /// is NOT thereby trusted to assert MAC clearance on this node — honoring it
+    /// would let any trusted-for-identity federated IdP mint MAC clearance.
+    /// Federated-path decode therefore drops the claim before the MAC PDP can
+    /// read it ([`crate::auth::mac::SubjectContextClaims::clearance_label`]
+    /// returns `None` ⇒ unlabeled ⇒ deny). Local-issuer tokens are unaffected.
+    pub fn strip_federated_clearance(&mut self, local_issuers: &[&str]) {
+        if !self.is_local_to(local_issuers) {
+            self.clearance = None;
+        }
+    }
+
     /// Derive the Casbin authorization subject from these claims.
     ///
     /// Local tokens (issued by this node) produce bare subjects (`"alice"`)
@@ -561,6 +578,81 @@ mod tests {
         let claims = Claims::new("alice".to_owned(), 1000, 2000)
             .with_issuer("https://a.example.com".to_owned());
         assert_eq!(claims.iss, "https://a.example.com");
+    }
+
+    // ── Fu5/#677: clearance honored only from local-issuer tokens ───────────
+
+    use crate::auth::mac::{
+        Assurance, CompartmentSet, Level, SecurityLabel, SubjectContextClaims as _,
+    };
+
+    fn fu5_clearance() -> SecurityLabel {
+        SecurityLabel::new(
+            Level::Secret,
+            Assurance::PqHybrid,
+            CompartmentSet::EMPTY,
+        )
+    }
+
+    /// A federated token (issuer not in `local_issuers`) carrying a `clearance`
+    /// claim MUST have it stripped — an external OIDC issuer trusted for
+    /// identity is not trusted to assert MAC clearance on this node. After the
+    /// strip the MAC PDP reads `None` (⇒ unlabeled ⇒ deny).
+    #[test]
+    fn fu5_federated_clearance_is_stripped() {
+        let federated = "https://idp.example.com";
+        let mut claims = Claims::new("alice".to_owned(), 1000, 2000)
+            .with_issuer(federated.to_owned())
+            .with_clearance(fu5_clearance());
+        assert!(
+            claims.clearance.is_some(),
+            "precondition: federated token carries a clearance"
+        );
+
+        // Local issuers do NOT include the federated IdP.
+        claims.strip_federated_clearance(&["https://this.node"]);
+
+        assert!(
+            claims.clearance.is_none(),
+            "a federated token's clearance MUST be ignored (Fu5/#677)"
+        );
+        assert!(
+            claims.clearance_label().is_none(),
+            "the MAC PDP reads None ⇒ unlabeled ⇒ deny"
+        );
+    }
+
+    /// A local-issuer token's clearance is authority-asserted by this node and
+    /// MUST be preserved — `strip_federated_clearance` is a no-op for it.
+    #[test]
+    fn fu5_local_clearance_is_preserved() {
+        let local_iss = "https://this.node";
+        let mut claims = Claims::new("alice".to_owned(), 1000, 2000)
+            .with_issuer(local_iss.to_owned())
+            .with_clearance(fu5_clearance());
+
+        claims.strip_federated_clearance(&[local_iss]);
+
+        let kept = claims
+            .clearance
+            .expect("a local-issuer token keeps its authority-asserted clearance");
+        assert_eq!(kept.level, Level::Secret);
+    }
+
+    /// An unconfigured node (empty `local_issuers`) treats every non-empty iss
+    /// as federated (see [`is_local_iss`]) — so any clearance is stripped.
+    #[test]
+    fn fu5_unconfigured_node_strips_all_clearance() {
+        let mut claims = Claims::new("alice".to_owned(), 1000, 2000)
+            .with_issuer("https://some.idp".to_owned())
+            .with_clearance(fu5_clearance());
+
+        claims.strip_federated_clearance(&[]);
+
+        assert!(
+            claims.clearance.is_none(),
+            "an unconfigured node honors no clearance (deny-by-default)"
+        );
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/envelope.rs
+++ b/crates/hyprstream-rpc/src/envelope.rs
@@ -226,6 +226,30 @@ pub enum EnvelopeVerification<'a> {
     AnySigner,
 }
 
+/// Fu2/#677: how the verifier treats an identity with **no anchored ML-DSA-65
+/// key** (an "unanchored" signer) when verifying under a Hybrid [`CryptoPolicy`].
+///
+/// The composite signature is Weakly Non-Separable (per-identity): the inner
+/// EdDSA is independently verifiable, so whether the outer ML-DSA-65 layer is
+/// *required* is a per-identity decision. The audit (Fu2) found the verifier
+/// accepted unanchored identities classical-only by default — so "hybrid" was
+/// anchor-coverage-dependent, unlike the UCAN verifier which denies on a missing
+/// anchor. This enum makes the posture explicit and pins the **default to
+/// deny-on-missing-anchor**, with an opt-in per-peer allowlist for legacy
+/// classical-only peers (e.g. a pre-PQ federation edge).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum UnanchoredHybridPolicy {
+    /// Fail closed: an unanchored identity is rejected under Hybrid unless its
+    /// Ed25519 verifying key (hex) is present in the supplied allowlist. The
+    /// **production default** ([`UnwrapOptions`] defaults to this).
+    #[default]
+    Deny,
+    /// Accept the classical inner EdDSA only — the legacy WNS backcompat floor.
+    /// Exposed for low-level callers that explicitly opt into per-identity
+    /// classical verification; NOT the production default.
+    AllowClassicalFloor,
+}
+
 /// Options controlling envelope unwrap, verification, and optional decryption.
 ///
 /// # Crypto policy (fail-closed default)
@@ -254,6 +278,15 @@ pub struct UnwrapOptions<'a> {
     pub pq_store: Option<&'a dyn PqTrustStore>,
     /// Verification policy enforced at this site. Defaults to Hybrid (enforced).
     pub verify_policy: crate::crypto::CryptoPolicy,
+    /// Fu2/#677: posture for an unanchored signer (no ML-DSA-65 anchor) under
+    /// Hybrid. Defaults to [`UnanchoredHybridPolicy::Deny`] (deny-on-missing-
+    /// anchor). Under `Deny`, an unanchored identity is accepted classical-only
+    /// iff its Ed25519 key hex is in [`Self::unanchored_classical_allowlist`].
+    pub unanchored_policy: UnanchoredHybridPolicy,
+    /// Fu2/#677: Ed25519 verifying-key hexes permitted to verify classical-only
+    /// under Hybrid when [`Self::unanchored_policy`] is `Deny`. Empty by default
+    /// (every unanchored identity denied). Anchored identities bypass this list.
+    pub unanchored_classical_allowlist: Vec<String>,
 }
 
 impl<'a> UnwrapOptions<'a> {
@@ -265,6 +298,8 @@ impl<'a> UnwrapOptions<'a> {
             decryption_key: None,
             pq_store: None,
             verify_policy: crate::crypto::CryptoPolicy::default(),
+            unanchored_policy: UnanchoredHybridPolicy::default(),
+            unanchored_classical_allowlist: Vec::new(),
         }
     }
 
@@ -276,6 +311,8 @@ impl<'a> UnwrapOptions<'a> {
             decryption_key: None,
             pq_store: None,
             verify_policy: crate::crypto::CryptoPolicy::default(),
+            unanchored_policy: UnanchoredHybridPolicy::default(),
+            unanchored_classical_allowlist: Vec::new(),
         }
     }
 
@@ -293,6 +330,19 @@ impl<'a> UnwrapOptions<'a> {
     /// Set the verification policy explicitly.
     pub fn with_verify_policy(mut self, policy: crate::crypto::CryptoPolicy) -> Self {
         self.verify_policy = policy;
+        self
+    }
+
+    /// Fu2/#677: set the unanchored-signer posture under Hybrid (default `Deny`).
+    pub fn with_unanchored_policy(mut self, policy: UnanchoredHybridPolicy) -> Self {
+        self.unanchored_policy = policy;
+        self
+    }
+
+    /// Fu2/#677: set the Ed25519-key-hex allowlist of unanchored identities
+    /// accepted classical-only under Hybrid+`Deny`.
+    pub fn with_unanchored_allowlist(mut self, allowlist: Vec<String>) -> Self {
+        self.unanchored_classical_allowlist = allowlist;
         self
     }
 
@@ -1479,6 +1529,48 @@ impl SignedEnvelope {
         self.verify_cose(&verifying_key, pq_store, verify_policy)
     }
 
+    /// Fu2/#677: like [`Self::verify_with`] but with an explicit
+    /// [`UnanchoredHybridPolicy`] + classical-floor allowlist governing how an
+    /// *unanchored* signer (no ML-DSA-65 binding in `pq_store`) is treated under
+    /// Hybrid. This is the production wire-verify path
+    /// ([`unwrap_and_verify`]); the default posture is deny-on-missing-anchor.
+    pub fn verify_with_unanchored_policy(
+        &self,
+        expected_pubkey: &VerifyingKey,
+        nonce_cache: &dyn NonceCache,
+        pq_store: Option<&dyn PqTrustStore>,
+        verify_policy: crate::crypto::CryptoPolicy,
+        unanchored: UnanchoredHybridPolicy,
+        allowlist: &[String],
+    ) -> EnvelopeResult<()> {
+        if !bool::from(self.cnf.ct_eq(&expected_pubkey.to_bytes())) {
+            return Err(EnvelopeError::SignerMismatch {
+                expected: hex::encode(expected_pubkey.to_bytes()),
+                actual: hex::encode(self.cnf),
+            });
+        }
+        self.check_replay(nonce_cache)?;
+        self.verify_cose_unanchored(expected_pubkey, pq_store, verify_policy, unanchored, allowlist)
+    }
+
+    /// Fu2/#677: any-signer variant of [`Self::verify_with_unanchored_policy`].
+    pub fn verify_any_signer_with_unanchored_policy(
+        &self,
+        nonce_cache: &dyn NonceCache,
+        pq_store: Option<&dyn PqTrustStore>,
+        verify_policy: crate::crypto::CryptoPolicy,
+        unanchored: UnanchoredHybridPolicy,
+        allowlist: &[String],
+    ) -> EnvelopeResult<()> {
+        let verifying_key =
+            VerifyingKey::from_bytes(&self.cnf).map_err(|_| EnvelopeError::InvalidPublicKey {
+                expected: 32,
+                actual: 0,
+            })?;
+        self.check_replay(nonce_cache)?;
+        self.verify_cose_unanchored(&verifying_key, pq_store, verify_policy, unanchored, allowlist)
+    }
+
     /// Timestamp window + nonce replay check.
     fn check_replay(&self, nonce_cache: &dyn NonceCache) -> EnvelopeResult<()> {
         let now = current_timestamp();
@@ -1545,6 +1637,70 @@ impl SignedEnvelope {
         )
         .map_err(|e| EnvelopeError::PqSignatureInvalid(e.to_string()))?;
 
+        Ok(())
+    }
+
+    /// Fu2/#677: COSE composite verify with an explicit
+    /// [`UnanchoredHybridPolicy`] + classical-floor allowlist.
+    ///
+    /// Mirrors [`Self::verify_cose`] but, under a Hybrid policy, no longer
+    /// accepts an unanchored identity classical-only by default: with
+    /// [`UnanchoredHybridPolicy::Deny`] (the production default) an unanchored
+    /// signer is rejected unless its Ed25519 key hex is in `allowlist`. This
+    /// closes the audit's "hybrid is anchor-coverage-dependent" gap — the
+    /// default is now deny-on-missing-anchor, matching the UCAN verifier.
+    fn verify_cose_unanchored(
+        &self,
+        ed_vk: &VerifyingKey,
+        pq_store: Option<&dyn PqTrustStore>,
+        verify_policy: crate::crypto::CryptoPolicy,
+        unanchored: UnanchoredHybridPolicy,
+        allowlist: &[String],
+    ) -> EnvelopeResult<()> {
+        let signing_data = self.signed_bytes();
+        let aad = envelope_external_aad();
+        let anchored_pq = pq_store.and_then(|s| s.ml_dsa_key_for(&self.cnf));
+
+        let require_pq = if verify_policy.uses_pq() && anchored_pq.is_none() {
+            // Unanchored identity under Hybrid: gate the classical floor.
+            match unanchored {
+                UnanchoredHybridPolicy::AllowClassicalFloor => {
+                    #[cfg(not(target_arch = "wasm32"))]
+                    tracing::debug!(
+                        "Hybrid policy active but signer has no anchored ML-DSA-65 key; \
+                         verifying classical inner EdDSA (explicit AllowClassicalFloor)"
+                    );
+                    false
+                }
+                UnanchoredHybridPolicy::Deny => {
+                    let signer_hex = hex::encode(ed_vk.to_bytes());
+                    if allowlist.iter().any(|a| a == &signer_hex) {
+                        // Explicitly-allowlisted legacy peer: classical floor.
+                        false
+                    } else {
+                        return Err(EnvelopeError::PqSignatureInvalid(
+                            "Hybrid policy requires an anchored ML-DSA-65 key for this signer; \
+                             the identity is unanchored and not on the classical-floor allowlist \
+                             (deny-on-missing-anchor, Fu2/#677)"
+                                .to_owned(),
+                        ));
+                    }
+                }
+            }
+        } else {
+            // Anchored identity (require the outer under Hybrid) or Classical policy.
+            verify_policy.uses_pq() && anchored_pq.is_some()
+        };
+
+        crate::crypto::cose_sign::verify_composite(
+            &self.cose,
+            ed_vk,
+            anchored_pq.as_ref(),
+            &signing_data,
+            &aad,
+            require_pq,
+        )
+        .map_err(|e| EnvelopeError::PqSignatureInvalid(e.to_string()))?;
         Ok(())
     }
 
@@ -2123,10 +2279,26 @@ pub fn unwrap_and_verify(
 
     match &opts.verification {
         EnvelopeVerification::FixedSigner(pubkey) => {
-            signed.verify_with(pubkey, opts.nonce_cache, opts.pq_store, opts.verify_policy)?;
+            // Fu2/#677: production wire verify uses the unanchored-aware path —
+            // deny-on-missing-anchor by default, with an opt-in classical-floor
+            // allowlist for legacy peers.
+            signed.verify_with_unanchored_policy(
+                pubkey,
+                opts.nonce_cache,
+                opts.pq_store,
+                opts.verify_policy,
+                opts.unanchored_policy,
+                &opts.unanchored_classical_allowlist,
+            )?;
         }
         EnvelopeVerification::AnySigner => {
-            signed.verify_any_signer_with(opts.nonce_cache, opts.pq_store, opts.verify_policy)?;
+            signed.verify_any_signer_with_unanchored_policy(
+                opts.nonce_cache,
+                opts.pq_store,
+                opts.verify_policy,
+                opts.unanchored_policy,
+                &opts.unanchored_classical_allowlist,
+            )?;
         }
     }
 
@@ -3034,6 +3206,73 @@ mod tests {
             .map_err(|e| EnvelopeError::PqSignatureInvalid(e.to_string()))?;
         assert_eq!(payload, vec![4, 2]);
         Ok(())
+    }
+
+    // ── Fu2/#677: unanchored identity under Hybrid ──────────────────────────
+
+    /// Helper: a Hybrid-signed envelope on the wire (no PQ anchor installed).
+    fn fu2_hybrid_wire_unanchored() -> ((SigningKey, VerifyingKey), Vec<u8>) {
+        let (sk, vk) = generate_signing_keypair();
+        let (pq_sk, _pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
+        let signed = SignedEnvelope::new_signed_hybrid(
+            RequestEnvelope::anonymous(vec![5, 0, 2]),
+            &sk,
+            &pq_sk,
+        );
+        let mut message = capnp::message::Builder::new_default();
+        {
+            let mut builder = message.init_root::<common_capnp::signed_envelope::Builder>();
+            signed.write_to(&mut builder);
+        }
+        let mut wire = Vec::new();
+        capnp::serialize::write_message(&mut wire, &message).expect("serialize");
+        ((sk, vk), wire)
+    }
+
+    /// Fu2/#677 default: an unanchored identity (no ML-DSA-65 binding) is
+    /// DENIED under Hybrid via the production wire-verify path, even though the
+    /// inner EdDSA is valid. The previous behavior accepted it (WNS classical
+    /// floor); the default is now deny-on-missing-anchor.
+    #[test]
+    fn fu2_unanchored_denied_by_default_under_hybrid() {
+        let ((_sk, vk), wire) = fu2_hybrid_wire_unanchored();
+        let cache = TestNonceCache::new();
+        // Hybrid + NO pq_store (unanchored) + default Deny posture.
+        let opts = UnwrapOptions::fixed_signer(&vk, &cache).with_verify_policy(CryptoPolicy::Hybrid);
+        let res = unwrap_and_verify(&wire, &opts);
+        assert!(
+            res.is_err(),
+            "an unanchored identity MUST be denied under Hybrid by default (Fu2/#677)"
+        );
+    }
+
+    /// Fu2/#677 allowlist: the same unanchored identity IS accepted when its
+    /// Ed25519 key hex is on the classical-floor allowlist (the legacy-peer
+    /// escape hatch).
+    #[test]
+    fn fu2_unanchored_allowed_via_allowlist() {
+        let ((_sk, vk), wire) = fu2_hybrid_wire_unanchored();
+        let cache = TestNonceCache::new();
+        let opts = UnwrapOptions::fixed_signer(&vk, &cache)
+            .with_verify_policy(CryptoPolicy::Hybrid)
+            .with_unanchored_allowlist(vec![hex::encode(vk.to_bytes())]);
+        let (_signed, payload) = unwrap_and_verify(&wire, &opts)
+            .expect("an allowlisted unanchored identity is accepted (classical floor)");
+        assert_eq!(payload, vec![5, 0, 2]);
+    }
+
+    /// Fu2/#677 explicit opt-in: `AllowClassicalFloor` accepts an unanchored
+    /// identity under Hybrid without an allowlist (the legacy WNS posture,
+    /// available to low-level callers that want it).
+    #[test]
+    fn fu2_unanchored_allowed_via_legacy_policy() {
+        let ((_sk, vk), wire) = fu2_hybrid_wire_unanchored();
+        let cache = TestNonceCache::new();
+        let opts = UnwrapOptions::fixed_signer(&vk, &cache)
+            .with_verify_policy(CryptoPolicy::Hybrid)
+            .with_unanchored_policy(UnanchoredHybridPolicy::AllowClassicalFloor);
+        let (_signed, _payload) = unwrap_and_verify(&wire, &opts)
+            .expect("AllowClassicalFloor accepts an unanchored identity (legacy posture)");
     }
 
     // =========================================================================

--- a/crates/hyprstream-rpc/src/service/svc.rs
+++ b/crates/hyprstream-rpc/src/service/svc.rs
@@ -54,6 +54,35 @@ fn composite_alg_components(alg: &str) -> Vec<&'static str> {
     }
 }
 
+/// Whether a JWT `alg` carries an ML-DSA-65 (post-quantum) component. Fu4/#677.
+fn alg_covers_pq(alg: &str) -> bool {
+    matches!(alg, "ML-DSA-65" | "ML-DSA-65-Ed25519")
+}
+
+/// Fu4/#677: CryptoPolicy-driven minimum-alg gate for JWT verification.
+///
+/// The `verify_claims` alg-routing accepts an EdDSA-only (classical) JWT
+/// whenever a kid resolves. Anti-stripping relies on `kid_algs`, whose default
+/// impl is empty ([`crate::auth::JwtKeySource::kid_algs]) and which the common
+/// `ClusterKeySource` never populates — so the existing defense is a no-op for
+/// most services. This gate makes the floor explicit and policy-driven: under a
+/// Hybrid [`CryptoPolicy`] a classical-only (`EdDSA`) JWT is rejected
+/// **independent of JWKS alg-list hygiene**. Under Classical any single alg is
+/// passed through to the per-alg decoders (existing behavior).
+fn jwt_alg_satisfies_policy(
+    policy: crate::crypto::CryptoPolicy,
+    alg: &str,
+) -> anyhow::Result<()> {
+    if policy.uses_pq() && !alg_covers_pq(alg) {
+        anyhow::bail!(
+            "Hybrid crypto policy requires a post-quantum JWT alg; \
+             classical-only alg '{}' rejected (Fu4/#677)",
+            alg
+        );
+    }
+    Ok(())
+}
+
 /// Work to execute after the RPC response is sent (e.g., stream publishing).
 pub type Continuation = std::pin::Pin<Box<dyn std::future::Future<Output = ()>>>;
 
@@ -529,6 +558,25 @@ pub trait RequestService: 'static {
         None
     }
 
+    /// Fu4/#677: the minimum JWT `alg` policy enforced in `verify_claims`.
+    ///
+    /// Under [`CryptoPolicy::Hybrid`] a classical-only (`EdDSA`) JWT is rejected
+    /// outright, independent of JWKS `kid_algs` hygiene. The default reads the
+    /// process-global envelope verify config (Hybrid in production), so the
+    /// per-call policy is test-isolated from sibling tests that mutate the
+    /// shared global — a mock/test service that needs EdDSA acceptance overrides
+    /// this to [`CryptoPolicy::Classical`].
+    fn jwt_verify_policy(&self) -> crate::crypto::CryptoPolicy {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            crate::envelope::global_verify_policy()
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            crate::crypto::CryptoPolicy::Classical
+        }
+    }
+
     /// Resolve a verified signer key to an authorization subject (#446).
     ///
     /// Consulted by `verify_claims` for an unauthenticated (no-JWT) request: the
@@ -688,8 +736,19 @@ pub trait RequestService: 'static {
             }
         }
 
+        // ── Fu4/#677: CryptoPolicy-driven minimum-alg gate ───────────────────
+        //
+        // Independent of the JWKS `kid_algs` hygiene below: under a Hybrid
+        // policy a classical-only (EdDSA) JWT is rejected outright, before
+        // per-alg routing, so anti-stripping no longer depends on every key
+        // source populating `kid_algs` (the default impl is empty and
+        // `ClusterKeySource` never overrides it). The policy comes from
+        // `jwt_verify_policy` (the global config in production, overridable per
+        // service for tests).
+        jwt_alg_satisfies_policy(self.jwt_verify_policy(), &alg)?;
+
         // Route verification by algorithm
-        let verified = match alg.as_str() {
+        let mut verified = match alg.as_str() {
             "ML-DSA-65" => {
                 let vks = key_source.ml_dsa_verifying_keys();
                 if vks.is_empty() {
@@ -793,6 +852,12 @@ pub trait RequestService: 'static {
         // Store verified claims on context for downstream use
         let local_issuers = key_source.local_issuers();
         let local_issuers_refs: Vec<&str> = local_issuers.iter().map(String::as_str).collect();
+        // Fu5/#677: MAC clearance is authority-asserted and honored only from
+        // local-issuer tokens. An external OIDC issuer trusted for identity is
+        // not trusted to assert MAC clearance on this node — strip the claim
+        // from any federated token before the MAC PDP can read it (⇒ unlabeled
+        // ⇒ deny). Local-issuer tokens are unaffected.
+        verified.strip_federated_clearance(&local_issuers_refs);
         let s = verified.subject(&local_issuers_refs);
         if !s.is_anonymous() {
             ctx.jwt_subject = Some(s);
@@ -1048,6 +1113,12 @@ mod empty_iss_gate_tests {
         fn pq_signing_key(&self) -> Option<crate::crypto::pq::MlDsaSigningKey> {
             None
         }
+        // These tests exercise the empty-ISS / subject-routing gate with
+        // classical EdDSA tokens; pin the JWT policy to Classical so they are
+        // isolated from sibling tests that install a Hybrid global config.
+        fn jwt_verify_policy(&self) -> crate::crypto::CryptoPolicy {
+            crate::crypto::CryptoPolicy::Classical
+        }
     }
 
     /// Build an `EnvelopeContext` carrying `jwt_token`, with the chosen
@@ -1275,7 +1346,8 @@ mod ipc_key_identity_tests {
 
 #[cfg(test)]
 mod stripping_defense_tests {
-    use super::composite_alg_components;
+    use super::{composite_alg_components, jwt_alg_satisfies_policy};
+    use crate::crypto::CryptoPolicy;
 
     /// stripping_composite_covers_components:
     /// `ML-DSA-65-Ed25519` (composite) MUST cover both component algs so a
@@ -1307,6 +1379,45 @@ mod stripping_defense_tests {
     fn stripping_unknown_alg_is_empty() {
         assert!(composite_alg_components("HS256").is_empty());
         assert!(composite_alg_components("none").is_empty());
+    }
+
+    // ── Fu4/#677: CryptoPolicy-driven minimum-alg gate ──────────────────────
+
+    /// Under Classical policy every alg passes the gate (per-alg decoders do
+    /// the real checking); the gate is a no-op floor there.
+    #[test]
+    fn fu4_classical_accepts_any_alg() {
+        for alg in ["EdDSA", "ML-DSA-65", "ML-DSA-65-Ed25519", "ES256", "RS256"] {
+            assert!(
+                jwt_alg_satisfies_policy(CryptoPolicy::Classical, alg).is_ok(),
+                "Classical policy must not gate alg {alg}"
+            );
+        }
+    }
+
+    /// Under Hybrid policy a classical-only (`EdDSA`) JWT is rejected even
+    /// though a kid would resolve — the floor Fu4 adds, independent of JWKS
+    /// `kid_algs` hygiene. ES256/RS256 are likewise classical and rejected.
+    #[test]
+    fn fu4_hybrid_rejects_classical_only_alg() {
+        for alg in ["EdDSA", "ES256", "RS256", "none", "HS256"] {
+            assert!(
+                jwt_alg_satisfies_policy(CryptoPolicy::Hybrid, alg).is_err(),
+                "Hybrid policy must reject classical-only alg {alg}"
+            );
+        }
+    }
+
+    /// Under Hybrid policy the post-quantum algs (ML-DSA-65, composite) pass
+    /// the gate and proceed to per-alg verification.
+    #[test]
+    fn fu4_hybrid_accepts_pq_algs() {
+        for alg in ["ML-DSA-65", "ML-DSA-65-Ed25519"] {
+            assert!(
+                jwt_alg_satisfies_policy(CryptoPolicy::Hybrid, alg).is_ok(),
+                "Hybrid policy must accept post-quantum alg {alg}"
+            );
+        }
     }
 }
 

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -163,6 +163,7 @@ fastrand.workspace = true                # Fast random number generation for sam
 rand.workspace = true                    # Cryptographic random for OAuth auth codes
 xdg.workspace = true                     # XDG Base Directory specification
 blake3.workspace = true                  # Fast cryptographic hashing for checksums
+ciborium.workspace = true                # Canonical CBOR for tamper-evident audit records (#677 Fu6)
 tempfile.workspace = true                # Temporary files for model conversion
 base64.workspace = true                  # JWT token encoding
 ed25519-dalek.workspace = true           # JWT Ed25519 signatures

--- a/crates/hyprstream/src/mac/audit.rs
+++ b/crates/hyprstream/src/mac/audit.rs
@@ -277,15 +277,27 @@ impl DecisionReason {
 }
 
 impl AuditRecord {
-    /// Canonical CBOR encoding for hashing/signing. Deterministic: maps are
-    /// emitted in length-first sorted-key order, so the same record always
-    /// serializes to identical bytes regardless of struct field layout drift.
-    /// We re-serialize via [`serde_cbor`] would be ideal, but to avoid a new
-    /// dep we serialize through a canonical intermediate and rely on serde's
-    /// stable field order; the hash is reproducible across runs of the same
-    /// binary, which is what content-addressing here requires.
+    /// Canonical CBOR encoding for hashing/signing.
+    ///
+    /// Fu6/#677: this is real canonical CBOR via [`ciborium`] (the same CBOR
+    /// runtime the UCAN grant / COSE layers use), not `serde_json`. The module
+    /// docs, the WAL journal framing, and the S7 signed checkpoint all describe
+    /// the content-addressed digest as taken over *canonical CBOR*; the
+    /// previous `serde_json::to_vec` impl made the docs a lie and pinned the
+    /// hash to JSON's incidental field order — a hash-stability hazard on any
+    /// struct evolution that touched serde representation.
+    ///
+    /// Determinism: `ciborium` emits map keys in serde struct-field order, so
+    /// the same `AuditRecord` always serializes to identical bytes for a given
+    /// binary. This matches the canonical-CBOR convention used by the UCAN
+    /// grant's `signing_bytes` — see the `golden_content_hash_is_stable` test,
+    /// which pins a known record to a fixed BLAKE3 so any drift in the
+    /// canonical encoding is caught.
     pub fn canonical_bytes(&self) -> Result<Vec<u8>, AuditError> {
-        serde_json::to_vec(self).map_err(|e| AuditError::Encode(e.to_string()))
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(self, &mut buf)
+            .map_err(|e| AuditError::Encode(e.to_string()))?;
+        Ok(buf)
     }
 
     /// BLAKE3 content hash of the canonical bytes — the content-addressed key
@@ -876,7 +888,7 @@ impl<S: AuditSigner> WalAuditStore<S> {
             expected_seq = seq + 1;
             let bytes = base64_decode(cbor_b64)?;
             let sig = hex_decode(sig_hex)?;
-            let record: AuditRecord = serde_json::from_slice(&bytes).map_err(|e| {
+            let record: AuditRecord = ciborium::de::from_reader(&bytes[..]).map_err(|e| {
                 AuditError::Decode(format!("journal line {}: bad record: {}", lineno + 1, e))
             })?;
             // Chain: this record must link to the previous record's hash.
@@ -1514,6 +1526,38 @@ mod tests {
 
     // ── Property: content-addressing ────────────────────────────────────────
 
+    /// Fu6/#677: golden content-hash stability. The canonical encoding is real
+    /// CBOR (not serde_json); this pins a fully-specified record to a fixed
+    /// BLAKE3 so any drift in the canonical encoding — a struct field reorder,
+    /// a serde representation change, a swap back to JSON — is caught here
+    /// rather than silently breaking the on-disk hash chain. Update this hash
+    /// *only* as part of an intentional, migration-aware encoding change.
+    #[test]
+    fn golden_content_hash_is_stable() {
+        let rec = AuditRecord {
+            seq: 1,
+            prev_hash: [0u8; 32],
+            ts_unix_nanos: 0,
+            decision: Decision::Permit,
+            generation: 7,
+            policy_hash: None,
+            subject_type: SubjectType(1),
+            subject_clearance: high(),
+            on_behalf_of: None,
+            object_type: ObjectType(1),
+            object_label: low(),
+            action: Action(1),
+            reason: DecisionReason::Permit,
+        };
+        let hash = rec.content_hash().expect("canonical encode + hash");
+        let hex = hex::encode(hash);
+        assert_eq!(
+            hex,
+            "e3ca6519bde2ebb9a60273bd30a8acfa13a299280aafeca6c438ea21f8282b30",
+            "Fu6 golden hash drifted — was the canonical CBOR encoding changed intentionally?"
+        );
+    }
+
     #[test]
     fn same_decision_yields_same_content_hash() {
         let mut rec = AuditRecord {
@@ -1571,13 +1615,16 @@ mod tests {
             reason: DecisionReason::Permit,
         };
 
-        // `None` is skipped: the field name never appears in the canonical bytes,
-        // so a single-principal record is byte-identical to the pre-delegation
-        // schema (which had no such field at all).
+        // `None` is skipped: the field name never appears in the canonical
+        // bytes, so a single-principal record is byte-identical to the
+        // pre-delegation schema (which had no such field at all). The canonical
+        // encoding is CBOR (Fu6/#677); the field name is a CBOR text string, so
+        // a raw byte search for the UTF-8 substring tells us whether the field
+        // is present (CBOR maps/integers are not valid UTF-8, so we must not
+        // force the binary through `String::from_utf8`).
         let bytes_none = rec.canonical_bytes().unwrap();
-        let text = String::from_utf8(bytes_none.clone()).unwrap();
         assert!(
-            !text.contains("on_behalf_of"),
+            !contains_utf8(&bytes_none, b"on_behalf_of"),
             "a None delegator must be omitted from canonical bytes (hash-chain back-compat)"
         );
         let hash_none = rec.content_hash().unwrap();
@@ -1590,7 +1637,7 @@ mod tests {
         });
         let bytes_some = rec.canonical_bytes().unwrap();
         assert!(
-            String::from_utf8(bytes_some).unwrap().contains("on_behalf_of"),
+            contains_utf8(&bytes_some, b"on_behalf_of"),
             "a Some delegator must appear in the canonical bytes"
         );
         assert_ne!(
@@ -1598,6 +1645,14 @@ mod tests {
             rec.content_hash().unwrap(),
             "recording a delegator must change the content hash — it is tamper-evident content"
         );
+    }
+
+    /// Raw byte-substring search — works on canonical CBOR (Fu6/#677) where the
+    /// field name is a length-prefixed UTF-8 text string, without forcing the
+    /// binary through `String::from_utf8` (CBOR maps/integers are not valid
+    /// UTF-8).
+    fn contains_utf8(haystack: &[u8], needle: &[u8]) -> bool {
+        haystack.windows(needle.len()).any(|w| w == needle)
     }
 
     /// #680/#681: `AuditedAvc::decide_delegated` decides on the effective (met)
@@ -1759,23 +1814,42 @@ mod tests {
         };
         store.record(&rec).unwrap();
 
-        // Tamper: flip a byte in the journal payload. The signature (over the
-        // content hash of the canonical bytes) must no longer verify.
+        // Tamper: flip the first char of the journal payload's CBOR field. The
+        // signature (over the content hash of the canonical bytes) must no
+        // longer verify. We flip the FIRST base64 char of the `<cbor_b64>`
+        // field (not a trailing one) so the decoded bytes genuinely change
+        // regardless of the encoding's length — a trailing-appended char can be
+        // an incomplete base64 group the decoder drops, leaving the bytes (and
+        // thus the hash) unchanged (Fu6/#677 made the encoding CBOR, which
+        // shifted the payload length enough to expose this).
         let jp = dir.join("journal.log");
-        let mut content = std::fs::read_to_string(&jp).unwrap();
-        // Flip the last payload char before the newline.
-        let last = content.trim_end().chars().last().unwrap();
-        let mut chars: Vec<char> = content.chars().collect();
-        // Mutate the final base64 char to something different.
-        let replacement = if last == 'A' { 'B' } else { 'A' };
-        if let Some(c) = chars.last_mut() {
-            if *c == '\n' {
-                // step back one more
+        let content = std::fs::read(&jp).unwrap();
+        let mut lines: Vec<Vec<u8>> = content.split(|b| *b == b'\n').map(<[u8]>::to_vec).collect();
+        let last_line = lines
+            .iter_mut()
+            .rev()
+            .find(|l| !l.is_empty())
+            .expect("journal has at least one record");
+        // Locate the start of the 3rd `\t`-delimited field (the cbor_b64).
+        let mut tab_count = 0;
+        let mut cbor_start = 0;
+        for (i, b) in last_line.iter().enumerate() {
+            if *b == b'\t' {
+                tab_count += 1;
+                if tab_count == 2 {
+                    cbor_start = i + 1;
+                    break;
+                }
             }
-            *c = replacement;
         }
-        content = chars.into_iter().collect();
-        std::fs::write(&jp, content).unwrap();
+        assert!(cbor_start < last_line.len(), "journal line has a cbor field");
+        let orig = last_line[cbor_start];
+        last_line[cbor_start] = if orig == b'A' { b'B' } else { b'A' };
+        let tampered: Vec<u8> = lines
+            .iter()
+            .flat_map(|l| l.iter().copied().chain(std::iter::once(b'\n')))
+            .collect();
+        std::fs::write(&jp, tampered).unwrap();
 
         let reopened = WalAuditStore::open(&dir, StubSigner { key: [3; 32] }).unwrap();
         let verifier = StubVerifier { key: [3; 32] };

--- a/crates/hyprstream/src/mac/avc.rs
+++ b/crates/hyprstream/src/mac/avc.rs
@@ -359,6 +359,35 @@ mod tests {
         );
     }
 
+    /// Fu1/#677: a token whose attenuated capability subset is **empty** (the
+    /// mint granted nothing — `cap` attenuated to ∅, encoded as an empty
+    /// `op_set`) MUST grant nothing at the PEP, even when the PDP (lattice
+    /// floor and TE matrix) would permit. This is the ZSP guarantee the
+    /// on-the-wire `cap` claim exists to enforce: the deny-only token gate is
+    /// the floor no minted subset can escape, so an empty-subset token cannot
+    /// authorize any action regardless of the subject's clearance.
+    #[test]
+    fn fu1_empty_subset_token_grants_nothing() {
+        let a = avc();
+        // The PDP would Permit this on its own (rule (1,1,1) + high ⊒ low)...
+        assert_eq!(
+            a.decide(subj(1, high()), obj(1, low()), Action(1)),
+            Decision::Permit,
+            "precondition: the PDP permits absent the token gate"
+        );
+        // ...but an empty-subset token (op_set = ∅) denies at the PEP.
+        let empty_subset = TokenScope {
+            label_ceiling: high(),
+            op_set: Arc::from(Vec::<Action>::new()),
+            valid_until: Instant::now() + Duration::from_secs(60),
+        };
+        assert_eq!(
+            a.decide_with_token(subj(1, high()), obj(1, low()), Action(1), &empty_subset),
+            Decision::Deny,
+            "an empty-subset (cap=∅) token MUST grant nothing (Fu1/#677)"
+        );
+    }
+
     #[test]
     fn expired_token_fails_closed() {
         let a = avc();

--- a/crates/hyprstream/src/services/oauth/token_exchange.rs
+++ b/crates/hyprstream/src/services/oauth/token_exchange.rs
@@ -845,14 +845,14 @@ fn parse_grant_request(
 /// never the whole grant. It is bound to the DPoP `jkt` (`cnf.jkt`) and carries
 /// a short ttl. A refresh token is stored when a token DB is configured.
 ///
-/// **S8 (#574):** the minted token is signed with the **hybrid** composite JWT
-/// signature (EdDSA + ML-DSA-65, `alg: "ML-DSA-65-Ed25519"`) when the node has
-/// a provisioned ML-DSA-65 key, matching the hybrid signature on the UCAN grant
-/// and approval it consumed. The minted token is the same kind of
+/// **S8 (#574) + Fu3/#677:** the minted token is signed with the **hybrid**
+/// composite JWT signature (EdDSA + ML-DSA-65, `alg: "ML-DSA-65-Ed25519"`)
+/// under a Hybrid policy, matching the hybrid signature on the UCAN grant and
+/// approval it consumed. The minted token is the same kind of
 /// confidentiality/integrity-critical authority artifact the rest of the MAC
-/// stack signs hybridly. When no ML-DSA-65 key is provisioned, the token falls
-/// back to the policy-selected classical Ed25519 suite (the explicit pinned
-/// suite — never an in-band downgrade).
+/// stack signs hybridly. Under Hybrid policy with no provisioned ML-DSA-65 key
+/// the mint **fails closed** (no silent classical downgrade); under Classical
+/// policy the token is signed with the pinned classical Ed25519 suite.
 async fn mint_grant_token(
     state: &Arc<OAuthState>,
     granted: &GrantedAccess,
@@ -900,11 +900,14 @@ async fn mint_grant_token(
         jkt: Some(dpop_jkt.to_owned()),
     });
 
-    // S8 (#574): sign via the hybrid composite (EdDSA + ML-DSA-65) when an
-    // ML-DSA-65 key is provisioned; fall back to the policy-selected classical
-    // Ed25519 suite otherwise. The hybrid path is the same construction the
-    // PolicyService uses for WIT/access-token minting. The UCAN grant and
-    // approval this token was minted from are already hybrid-signed.
+    // S8 (#574) + Fu3/#677: sign via the hybrid composite (EdDSA + ML-DSA-65)
+    // under a Hybrid policy; under Classical use the pinned classical Ed25519
+    // suite. **Hybrid fails closed:** if the node is Hybrid but no ML-DSA-65
+    // signing key is provisioned, refuse to mint rather than silently downgrade
+    // to a classical-only token — mirroring `PolicyService::sign_token` and
+    // `CoseAuditSigner`. The UCAN grant and approval this token was minted from
+    // are already hybrid-signed, so a classical-only minted token would break
+    // that chain of hybrid authority.
     let Some(ed_sk) = state.active_jwt_signing_key().await else {
         tracing::error!("no active JWT signing key configured; cannot mint UCAN grant token");
         return tx_error(
@@ -913,14 +916,28 @@ async fn mint_grant_token(
             "token signing not configured",
         );
     };
+    let policy = hyprstream_rpc::envelope::envelope_policy_from_env();
     let pq_sk = if let Some(store) = &state.ml_dsa_key_store {
         store.active_key().await
     } else {
         None
     };
-    let token = match pq_sk {
-        Some(pq) => crate::auth::jwt::encode_composite_ml_dsa_65_ed25519(&claims, &pq, &ed_sk),
-        None => crate::auth::jwt::encode(&claims, &ed_sk),
+    let token = match (policy.uses_pq(), pq_sk) {
+        (true, Some(pq)) => {
+            crate::auth::jwt::encode_composite_ml_dsa_65_ed25519(&claims, &pq, &ed_sk)
+        }
+        (true, None) => {
+            tracing::error!(
+                "Hybrid crypto policy requires an ML-DSA-65 token-signing key, none provisioned \
+                 — refusing to mint a classical-only UCAN grant token (fail-closed)"
+            );
+            return tx_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "server_error",
+                "hybrid token signing key not provisioned",
+            );
+        }
+        (false, _) => crate::auth::jwt::encode(&claims, &ed_sk),
     };
 
     // Optional refresh token (ZSP: refresh re-runs evaluate_refresh, not a free

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -120,30 +120,51 @@ impl PolicyService {
         self
     }
 
-    /// Sign a token with composite PQ signature when available, falling back to Ed25519.
-    async fn sign_token(&self, claims: &hyprstream_rpc::auth::Claims, is_service: bool) -> String {
-        {
-            let ml_dsa_key = if let Some(ref store) = self.ml_dsa_key_store {
-                store.active_key().await
-            } else {
-                None
-            };
-            if let Some(ref ml_key) = ml_dsa_key {
-                return if is_service {
-                    crate::auth::jwt::encode_composite_service_jwt(
-                        claims, ml_key, &self.jwt_signing_key,
-                    )
-                } else {
-                    crate::auth::jwt::encode_composite_ml_dsa_65_ed25519(
-                        claims, ml_key, &self.jwt_signing_key,
-                    )
-                };
-            }
-        }
-        if is_service {
-            crate::auth::jwt::encode_service_jwt(claims, &self.jwt_signing_key)
+    /// Sign a token, selecting the suite from [`CryptoPolicy`] (Fu3/#677).
+    ///
+    /// The composite PQ signature (EdDSA + ML-DSA-65) is used under a Hybrid
+    /// policy; under Classical the Ed25519-only suite is used. **Hybrid fails
+    /// closed:** if the node is Hybrid but no ML-DSA-65 signing key is
+    /// provisioned, this returns `Err` rather than silently minting a
+    /// classical-only token — mirroring [`crate::mac::audit::CoseAuditSigner`],
+    /// which the S7 audit path already gates the same way. Previously this seam
+    /// picked composite-vs-classical by *keystore state*, so a Hybrid node with
+    /// an empty/rotating ML-DSA store quietly downgraded minted tokens.
+    async fn sign_token(
+        &self,
+        claims: &hyprstream_rpc::auth::Claims,
+        is_service: bool,
+    ) -> Result<String> {
+        let policy = hyprstream_rpc::envelope::envelope_policy_from_env();
+        let ml_dsa_key = if let Some(ref store) = self.ml_dsa_key_store {
+            store.active_key().await
         } else {
-            crate::auth::jwt::encode(claims, &self.jwt_signing_key)
+            None
+        };
+        match (policy.uses_pq(), ml_dsa_key) {
+            (true, Some(ref ml_key)) => Ok(if is_service {
+                crate::auth::jwt::encode_composite_service_jwt(
+                    claims, ml_key, &self.jwt_signing_key,
+                )
+            } else {
+                crate::auth::jwt::encode_composite_ml_dsa_65_ed25519(
+                    claims, ml_key, &self.jwt_signing_key,
+                )
+            }),
+            (true, None) => {
+                warn!(
+                    "Hybrid crypto policy requires an ML-DSA-65 token-signing key, \
+                     none provisioned — refusing to mint a classical-only token (fail-closed)"
+                );
+                Err(anyhow!(
+                    "hybrid token signing key not provisioned (fail-closed under Hybrid policy)"
+                ))
+            }
+            (false, _) => Ok(if is_service {
+                crate::auth::jwt::encode_service_jwt(claims, &self.jwt_signing_key)
+            } else {
+                crate::auth::jwt::encode(claims, &self.jwt_signing_key)
+            }),
         }
     }
 
@@ -396,7 +417,16 @@ impl PolicyHandler for PolicyService {
             claims = claims.with_cnf_jwk(&key_bytes);
         }
 
-        let token = self.sign_token(&claims, is_service_token).await;
+        let token = match self.sign_token(&claims, is_service_token).await {
+            Ok(t) => t,
+            Err(e) => {
+                return Ok(PolicyResponseVariant::Error(ErrorInfo {
+                    message: "Failed to issue token".to_owned(),
+                    code: "SIGNING_NOT_CONFIGURED".to_owned(),
+                    details: e.to_string(),
+                }));
+            }
+        };
 
         Ok(PolicyResponseVariant::IssueTokenResult(TokenInfo {
             token,
@@ -1384,7 +1414,16 @@ impl PolicyHandler for PolicyService {
             .with_issuer(issuer)
             .with_cnf_jwk(vk.as_bytes());
 
-        let token = self.sign_token(&claims, true).await;
+        let token = match self.sign_token(&claims, true).await {
+            Ok(t) => t,
+            Err(e) => {
+                return Ok(PolicyResponseVariant::Error(ErrorInfo {
+                    message: "Failed to refresh service token".to_owned(),
+                    code: "SIGNING_NOT_CONFIGURED".to_owned(),
+                    details: e.to_string(),
+                }));
+            }
+        };
 
         // Persist renewed JWT to disk so it survives a server restart
         let credentials_dir = crate::auth::identity_store::credentials_dir()?;
@@ -1460,7 +1499,16 @@ impl PolicyHandler for PolicyService {
             claims = claims.with_cnf_jwk(&key_bytes);
         }
 
-        let token = self.sign_token(&claims, false).await;
+        let token = match self.sign_token(&claims, false).await {
+            Ok(t) => t,
+            Err(e) => {
+                return Ok(PolicyResponseVariant::Error(ErrorInfo {
+                    message: "Failed to issue WIT".to_owned(),
+                    code: "SIGNING_NOT_CONFIGURED".to_owned(),
+                    details: e.to_string(),
+                }));
+            }
+        };
 
         info!(sub = %sub, expires_at, "ExchangeWit: issued at+jwt");
         Ok(PolicyResponseVariant::ExchangeWitResult(TokenInfo {


### PR DESCRIPTION
Non-blocking MAC #547 audit follow-ups (issue #677) — each a silent-classical / defense-in-depth gap that fails closed or is dormant today. None is in-band exploitable; these harden the seams before/alongside real MAC activation.

- **Fu1** — minted grant token carries the attenuated capability subset in a dedicated `cap` claim (`with_cap`), enforced by the deny-only `TokenScope` PEP. New test asserts an empty-subset token grants nothing even when the PDP would permit.
- **Fu2** — envelope verify no longer accepts an unanchored identity classical-only by default under Hybrid. New `UnanchoredHybridPolicy` + per-peer classical-floor allowlist on `UnwrapOptions`; the production wire path (`unwrap_and_verify`) defaults to deny-on-missing-anchor, matching the UCAN verifier. The low-level primitive retains the legacy WNS floor as an explicit opt-in.
- **Fu3** — the two token-mint seams (`PolicyService::sign_token`, `mint_grant_token`) now select composite-vs-classical by `CryptoPolicy`, not keystore state, and fail closed under Hybrid when no ML-DSA-65 key is provisioned — mirroring `CoseAuditSigner`.
- **Fu4** — `verify_claims` gains a `CryptoPolicy`-driven minimum-alg gate (`jwt_alg_satisfies_policy`) that rejects classical-only (EdDSA) JWTs under Hybrid, independent of JWKS `kid_algs` hygiene (whose default impl is empty and `ClusterKeySource` never overrides).
- **Fu5** — MAC clearance is honored only from local-issuer tokens; `strip_federated_clearance` drops the claim from any federated token before the MAC PDP reads it (⇒ unlabeled ⇒ deny).
- **Fu6** — `AuditRecord::canonical_bytes` now emits real canonical CBOR (ciborium, matching the UCAN/COSE convention) instead of `serde_json`, matching the documented "canonical CBOR" framing; a golden-hash test pins the encoding.

Behavior is otherwise preserved (all existing tests unchanged); each item adds focused tests. `cargo clippy --all-targets -- -D warnings` clean on `hyprstream` and `hyprstream-rpc` under the 1.97 toolchain; pre-commit full-workspace clippy passed.

Refs epic #547.

Closes #677