### PR TITLE
fix(runtime): drop CUDA tensors at shutdown before context teardown

### DIFF
--- a/crates/hyprstream/src/inference/local.rs
+++ b/crates/hyprstream/src/inference/local.rs
@@ -266,6 +266,19 @@ impl LocalInferenceService {
             InferenceRequest::Shutdown { reply } => {
                 info!("Shutdown requested");
                 self.shutdown_requested = true;
+
+                // #429: drop every CUDA tensor the engine owns *now*, on this
+                // service thread, before we acknowledge shutdown. The service
+                // thread is spawned detached, so if we left the RoPE sin/cos
+                // tables (thread-local) and model weights to drop at thread-exit,
+                // their TLS destructors could fire during process-exit cleanup —
+                // after libtorch's atexit handler has torn down the CUDA context
+                // — aborting with `c10::Error: invalid device pointer`. Doing it
+                // here, while the client is still blocked on `reply`, guarantees
+                // the context is alive when these device tensors free. See
+                // `TorchEngine::release_device_resources`.
+                self.engine.release_device_resources();
+
                 let _ = reply.send(Ok(()));
             }
         }

--- a/crates/hyprstream/src/runtime/architectures/llama.rs
+++ b/crates/hyprstream/src/runtime/architectures/llama.rs
@@ -12,6 +12,33 @@ use std::collections::HashMap;
 use std::path::Path;
 use tch::{nn, Device, Kind as DType, Tensor};
 
+// Thread-local cache of RoPE instances (one per layer/head-dim/theta config).
+//
+// Each entry holds sin/cos tables built on the compute device — i.e. real CUDA
+// tensors when the model runs on GPU. The cache is keyed so the tables are
+// reused across decode steps instead of recomputing every token.
+//
+// Teardown (#429): because this is thread-local, these device tensors are *not*
+// dropped when the engine struct drops — they survive until the owning thread
+// exits. The inference service thread is detached, so its TLS destructors can
+// fire during process-exit cleanup, *after* libtorch's atexit handler has torn
+// down the CUDA context — producing the `c10::Error: invalid device pointer`
+// SIGABRT. `clear_rope_cache` drops them explicitly on the service thread,
+// while the context is still alive, at shutdown.
+thread_local! {
+    static ROPE_CACHE: std::cell::RefCell<HashMap<(usize, i64, u32), RoPE>> =
+        std::cell::RefCell::new(HashMap::new());
+}
+
+/// Drop every cached RoPE instance on the *calling* thread.
+///
+/// Must be called on the same thread that ran the forward passes (the
+/// inference service thread) so it clears the entries that matter. Idempotent.
+/// See [`ROPE_CACHE`] for why this exists.
+pub(crate) fn clear_rope_cache() {
+    ROPE_CACHE.with(|cache| cache.borrow_mut().clear());
+}
+
 /// Linear projection layer with optional bias and optional FP8 block scale.
 ///
 /// Weights may be stored as FP8 (E4M3 or E5M2) to save VRAM. When a `scale`
@@ -846,12 +873,6 @@ impl LlamaAttention {
 
     /// Apply Rotary Position Embeddings with optional scaling
     fn apply_rope(&self, tensor: &Tensor, position_ids: &Tensor) -> Result<Tensor> {
-        // Use a thread-local RoPE instance cache for efficiency
-        thread_local! {
-            static ROPE_CACHE: std::cell::RefCell<std::collections::HashMap<(usize, i64, u32), RoPE>> =
-                std::cell::RefCell::new(std::collections::HashMap::new());
-        }
-
         ROPE_CACHE.with(|cache| {
             let mut cache = cache.borrow_mut();
 

--- a/crates/hyprstream/src/runtime/architectures/qwen3_5.rs
+++ b/crates/hyprstream/src/runtime/architectures/qwen3_5.rs
@@ -21,6 +21,26 @@ use std::sync::Arc;
 use tch::{Device, Kind, Tensor};
 use tracing::info;
 
+// Thread-local cache of RoPE instances (sin/cos tables on the compute device),
+// keyed by (layer_idx, rope_theta bits, device ordinal). See the equivalent
+// `llama::ROPE_CACHE` for the full rationale.
+//
+// Teardown (#429): entries hold real CUDA tensors on GPU runs and survive the
+// engine's `Drop` (they are thread-local). `clear_rope_cache` drops them on the
+// service thread at shutdown, before libtorch's atexit handler tears down the
+// CUDA context — otherwise the TLS destructor frees them during process-exit
+// cleanup and aborts with `c10::Error: invalid device pointer`.
+thread_local! {
+    static ROPE_CACHE: std::cell::RefCell<HashMap<(usize, u32, i64), RoPE>> =
+        std::cell::RefCell::new(HashMap::new());
+}
+
+/// Drop every cached RoPE instance on the *calling* thread. Idempotent; call on
+/// the inference service thread at shutdown. See [`ROPE_CACHE`].
+pub(crate) fn clear_rope_cache() {
+    ROPE_CACHE.with(|cache| cache.borrow_mut().clear());
+}
+
 // ============================================================================
 // Config
 // ============================================================================
@@ -1074,18 +1094,8 @@ impl Qwen3_5FullAttention {
     ) -> Result<Tensor> {
         // Thread-local RoPE cache: reuses sin/cos tables across decode steps.
         // Saves ~9 GPU kernels per call (generate_embeddings) after the first token.
-        // Same pattern as LlamaModel::apply_rope.
-        use std::cell::RefCell;
-        // Cache key includes the DEVICE: the cached RoPE holds sin/cos tables on
-        // a specific device. Under a pipeline split (#314) the same `layer_idx`
-        // could legitimately run on different devices on one thread, so omitting
-        // device would hand back tables on the wrong device. We encode the device
-        // as an i64 (`-1` = CPU, otherwise the CUDA ordinal) since tch::Device is
-        // not Hash. On the single-device path this just adds one constant key dim.
-        thread_local! {
-            static ROPE_CACHE: RefCell<HashMap<(usize, u32, i64), RoPE>> =
-                RefCell::new(HashMap::new());
-        }
+        // Same pattern as LlamaModel::apply_rope. (The static lives at module scope;
+        // see [`clear_rope_cache`] for the teardown story.)
         let device_key: i64 = match device {
             Device::Cuda(i) => i as i64,
             _ => -1,

--- a/crates/hyprstream/src/runtime/torch_engine.rs
+++ b/crates/hyprstream/src/runtime/torch_engine.rs
@@ -2091,6 +2091,83 @@ impl TorchEngine {
 
         Ok(hidden_states)
     }
+
+    /// Explicitly drop every CUDA/device tensor the engine owns or has cached
+    /// on this thread, **now** — while the CUDA context is still alive.
+    ///
+    /// # Why this exists (#429)
+    ///
+    /// `tch`/libtorch defers CUDA context teardown to an `atexit` handler that
+    /// runs during *process* exit. But two classes of device tensor outlive the
+    /// engine struct and only drop later:
+    ///
+    /// 1. **Thread-local RoPE caches** (`llama::ROPE_CACHE`, `qwen3_5::ROPE_CACHE`)
+    ///    — sin/cos tables cached on the compute device. They are TLS, so they
+    ///    are not touched by `Drop` and survive until the owning thread exits.
+    /// 2. **The inference service thread itself** — it is spawned detached in
+    ///    `LocalInferenceService::start`, so its TLS destructors (and thus the
+    ///    RoPE cache drop) can fire during process-exit cleanup, *after* the
+    ///    CUDA context is gone → `c10::Error: invalid device pointer` (SIGABRT).
+    ///
+    /// The engine-only GPU smoke (`e6_gpu_engine_is_single_device_on_one_gpu_host`)
+    /// never loads weights nor runs a forward pass, so it populates no RoPE
+    /// cache and exits cleanly; the streaming test does, which is why only it
+    /// aborts.
+    ///
+    /// Calling this on the service thread at `Shutdown` receipt — *before*
+    /// replying to the client — drops the RoPE tables and the model weights
+    /// synchronously while the caller is still blocked on the reply (process
+    /// indubitably alive, context valid). After it returns only empty shells
+    /// remain for any late TLS/static destruction, so there is nothing left to
+    /// free against a dead context.
+    ///
+    /// # Contract
+    ///
+    /// This is a **terminal** teardown: the engine is unusable afterward
+    /// (`model_info` reports unloaded, generation will error). It must only be
+    /// called once, at shutdown. Unlike [`Drop`], it deliberately *does* clear
+    /// shared `Arc<Mutex<Option<T>>>` contents — that is safe precisely because
+    /// the engine is being retired, not because the contents are unused. (The
+    /// production inference path holds a single engine instance per service; a
+    /// cached clone would see `None` and fail closed with "No model loaded",
+    /// which is the correct behavior for a retired engine.)
+    pub fn release_device_resources(&mut self) {
+        // 1. Clear the model's own KV cache while the model still exists (the
+        //    cache tensors live inside the architecture model's KVCacheManager).
+        self.clear_kv_cache();
+
+        // 2. Drop the architecture model (all decoder-layer weights, embeddings,
+        //    lm_head) — the bulk of the device memory.
+        self.persistent_model = None;
+
+        // 3. Drop the (dummy) VarStore and clear the session KV registry so any
+        //    device tensors held there release before context teardown too.
+        {
+            let mut vs_guard = self.var_store.lock();
+            *vs_guard = None;
+        }
+        if let Some(registry) = self.kv_cache_registry.clone() {
+            registry.clear_all();
+        }
+
+        // 4. Drop the thread-local RoPE sin/cos tables on *this* thread. This is
+        //    the load-bearing step for #429: without it these CUDA tensors would
+        //    only free in the detached service thread's TLS destructor.
+        crate::runtime::architectures::llama::clear_rope_cache();
+        crate::runtime::architectures::qwen3_5::clear_rope_cache();
+
+        // 5. Drain any in-flight CUDA kernels (frees completed, makes the above
+        //    drops effective on the device) before we hand control back. CPU is
+        //    a no-op. Best-effort: a failure to synchronize is logged, not fatal
+        //    — the tensors are already dropped on the Rust side.
+        if let Device::Cuda(idx) = self.device {
+            // atc_synchronize panics on internal error; never propagate.
+            let res = std::panic::catch_unwind(|| tch::Cuda::synchronize(idx as i64));
+            if res.is_err() {
+                warn!("CUDA synchronize during teardown returned an error (ignored)");
+            }
+        }
+    }
 }
 
 impl Drop for TorchEngine {
@@ -2156,6 +2233,70 @@ mod tests {
         assert!(engine.device_pool().is_none());
         assert_eq!(engine.device(), Device::Cpu);
     }
+
+    /// #429: `release_device_resources` is the terminal teardown that drops
+    /// CUDA tensors (weights, KV cache, thread-local RoPE tables) on the
+    /// service thread at shutdown. It must:
+    /// - be safe on an engine that never loaded a model (no-op for the
+    ///   weight/KV paths, but must still clear RoPE TLS),
+    /// - be idempotent (double-call must not panic / double-free),
+    /// - leave the engine visibly unloaded afterward.
+    ///
+    /// This runs on CPU (no CUDA context), so it can't reproduce the SIGABRT
+    /// itself; it pins the *ordering contract* the GPU fix relies on. The
+    /// thread-local RoPE caches are populated on whichever thread runs the
+    /// forward pass — this test clears the test thread's own TLS, which is
+    /// exactly what the production Shutdown handler does on the service thread.
+    #[test]
+    fn release_device_resources_is_safe_and_idempotent() {
+        let mut engine =
+            super::TorchEngine::with_device(RuntimeConfig::default(), Device::Cpu, None).unwrap();
+
+        // Never loaded a model — these start empty.
+        assert!(!engine.has_varstore());
+
+        // First call: no model weights, no KV registry, no RoPE entries on this
+        // thread — must still succeed and clear the (empty) RoPE TLS.
+        engine.release_device_resources();
+        assert!(
+            !engine.has_varstore(),
+            "an unloaded engine stays unloaded after teardown"
+        );
+
+        // Second call: idempotent — must not panic or double-free.
+        engine.release_device_resources();
+        engine.release_device_resources();
+
+        // Dropping the engine afterward must also be clean (no double-drop of
+        // the already-None persistent_model / var_store).
+        drop(engine);
+    }
+
+    /// #429: a loaded-model teardown must actually drop the VarStore contents.
+    /// We can't load a real model without weights/libtorch-on-this-host, but we
+    /// can set the dummy VarStore (the same step `load_model_file` performs) and
+    /// confirm `release_device_resources` clears it — the contract the GPU path
+    /// relies on to free weight tensors before CUDA context teardown.
+    #[test]
+    fn release_device_resources_clears_loaded_varstore() {
+        let mut engine =
+            super::TorchEngine::with_device(RuntimeConfig::default(), Device::Cpu, None).unwrap();
+        // Mimic the load path: install a dummy VarStore on the engine's device.
+        {
+            let vs = VarStore::new(Device::Cpu);
+            let mut guard = engine.var_store.lock();
+            *guard = Some(vs);
+        }
+        assert!(engine.has_varstore());
+
+        engine.release_device_resources();
+
+        assert!(
+            !engine.has_varstore(),
+            "release_device_resources must drop the VarStore"
+        );
+    }
+
 
     /// `with_device(.., Some(multi_pool))` must mark the engine multi-device and
     /// expose the pool with the right primary. We build the pool from explicit

--- a/crates/hyprstream/tests/e2e_inference.rs
+++ b/crates/hyprstream/tests/e2e_inference.rs
@@ -34,18 +34,23 @@
 //!   cargo test -p hyprstream --release --test e2e_inference -- --ignored
 //! ```
 //!
-//! ## Known teardown artifact (GPU streaming test only)
+//! ## Teardown ordering (#429)
 //!
-//! `e6_gpu_load_and_stream_tokens` loads real model weights onto CUDA. After the
-//! test's assertions pass and the `ok` result line is printed, libtorch may abort
-//! the *test binary* during static/TLS-destructor cleanup with
-//! `c10::Error: invalid device pointer` (SIGABRT) — the CUDA caching allocator
-//! frees a tensor after the CUDA context has already been torn down at process
-//! exit. This is a known `tch`/libtorch process-teardown interaction, not a test
-//! failure: the load + streaming assertions have all passed by the time it fires,
-//! and it does not affect the default (CPU-only) `cargo test` run, which never
-//! touches CUDA. Run the streaming test in isolation (or read the `ok` line
-//! before the abort) to confirm the inference path itself is green.
+//! `e6_gpu_load_and_stream_tokens` loads real model weights onto CUDA. Two
+//! classes of device tensor used to outlive the engine struct: the
+//! thread-local RoPE sin/cos tables (`llama::ROPE_CACHE` / `qwen3_5::ROPE_CACHE`)
+//! and the model weights. Because the inference service thread is spawned
+//! *detached*, their TLS destructors could fire during process-exit cleanup —
+//! after libtorch's `atexit` handler had torn down the CUDA context — aborting
+//! the test binary with `c10::Error: invalid device pointer` (SIGABRT), *after*
+//! the assertions had already passed.
+//!
+//! The fix is an explicit, ordered teardown: `client.shutdown()` now drops every
+//! device tensor the engine owns **on the service thread, before replying** —
+//! while the caller is still blocked on the reply, so the process and the CUDA
+//! context are indubitably still alive. See `TorchEngine::release_device_resources`
+//! and the `Shutdown` arm of `LocalInferenceService`. After it returns only
+//! empty shells remain for any late static/TLS destruction.
 //!
 //! The router/placement tests (sections 3 & 4) are CPU-only and always run.
 //!


### PR DESCRIPTION
Closes #429.

## Problem

The `#[ignore]`d GPU streaming test `e6_gpu_load_and_stream_tokens` (#421-E6) passed every assertion and printed `ok`, then libtorch aborted the *test binary* during process-exit cleanup:

```
c10::Error: invalid device pointer   (SIGABRT)
```

This is a teardown-ordering artifact, not a test-logic failure. The engine-only GPU smoke (`e6_gpu_engine_is_single_device_on_one_gpu_host`) exits cleanly (EXIT=0); the default CPU run never touches CUDA so is unaffected.

## Root cause

Two classes of device tensor outlive the `TorchEngine` struct:

1. **Thread-local RoPE caches** (`llama::ROPE_CACHE`, `qwen3_5::ROPE_CACHE`) hold sin/cos tables built on the compute device. They are TLS, so `Drop` never touches them — they survive until the owning thread exits.
2. The **inference service thread is spawned detached** in `LocalInferenceService::start`. Its TLS destructors (and thus the RoPE-table drops) can therefore fire *during process-exit cleanup* — after libtorch's `atexit` handler has already torn down the CUDA context — freeing a device pointer against a dead context.

The engine-only smoke never loads weights nor runs a forward pass, so it populates no RoPE cache and exits cleanly; only the streaming test (which loads weights + runs forward passes) aborted.

## Fix

Add `TorchEngine::release_device_resources` — an explicit, ordered teardown that, on the calling thread:
1. clears the model's KV cache (while the model still exists),
2. drops the persistent model (all decoder-layer weights, embeddings, lm_head),
3. drops the dummy VarStore + clears the session KV registry,
4. drops the thread-local RoPE sin/cos tables (`llama::clear_rope_cache()` / `qwen3_5::clear_rope_cache()`),
5. synchronizes the CUDA device so in-flight frees complete.

Call it from the `Shutdown` arm of `LocalInferenceService`, on the service thread, **before** replying to the client. Because the caller is still blocked on the reply at that point, the process and the CUDA context are indubitably alive when these tensors free. After it returns, only empty shells remain for any late static/TLS destruction — nothing left to free against a dead context.

The RoPE `thread_local!` decls are hoisted from inside `apply_rope` to module scope and gain `pub(crate) fn clear_rope_cache()` clearers so the engine can drop them deterministically.

## Tests

- `release_device_resources_is_safe_and_idempotent` — safe on an unloaded engine (no weights/KV/RoPE), idempotent (triple-call, no panic/double-free), engine visibly unloaded afterward.
- `release_device_resources_clears_loaded_varstore` — installs the dummy VarStore (the load path's step) and confirms teardown clears it.

Both run on CPU — they pin the *ordering contract* the GPU fix relies on (the SIGABRT itself needs a CUDA context + real weights and can't reproduce in CI). The ignored GPU streaming test is unchanged; its module docs now describe the fix rather than the known artifact.

## Verification

`cargo clippy -p hyprstream --all-targets -- -D warnings` clean (1.97); the workspace `--release` clippy gate ran via the pre-commit hook. New unit tests pass.