### PR TITLE
feat(workers): per-BackendType feature flags — nspawn gate + kata alias (#518)

### DIFF
--- a/crates/hyprstream-workers/Cargo.toml
+++ b/crates/hyprstream-workers/Cargo.toml
@@ -234,14 +234,16 @@ oci-image = [
     # it lives on `oci-image`, not `kata-vm`.
     "dep:hyprstream-vfs-server",
 ]
-# Kata/Cloud-Hypervisor VM backend. Implies `oci-image` (kata composes the
-# image filesystem service into a namespace and serves it to its guest via
-# virtio-fs) and adds the VM toolchain plus the kata-agent vsock/ttrpc client
-# (kata hypervisor + CH config + agent RPC). Opt-in so casual users who only
-# want the lightweight `systemd-nspawn` backend don't compile the VM stack.
-# When this feature is off, `BackendType::Kata` selection and CRI image ops
-# return a clean runtime error rather than failing to compile.
-kata-vm = [
+# Kata/Cloud-Hypervisor VM backend (#518: the granular per-`BackendType`
+# feature). Implies `oci-image` (kata composes the image filesystem service
+# into a namespace and serves it to its guest via virtio-fs) and adds the VM
+# toolchain plus the kata-agent vsock/ttrpc client (kata hypervisor + CH
+# config + agent RPC). Opt-in so casual users who only want the lightweight
+# `systemd-nspawn` backend don't compile the VM stack. When this feature is
+# off, `BackendType::Kata` selection and CRI image ops return a clean runtime
+# error rather than failing to compile. `kata-vm` (below) is the backward-
+# compat convenience alias for this feature.
+kata = [
     "oci-image",
     "dep:kata-hypervisor",
     "dep:kata-types",
@@ -252,6 +254,20 @@ kata-vm = [
     "dep:protobuf",
     "dep:vsock",
 ]
+# Backward-compat convenience alias (#518): the coarse `kata-vm` bundle (#347)
+# becomes a thin alias for the granular `kata` feature. Existing
+# `--features kata-vm` invocations keep working unchanged; `kata` is the
+# canonical per-`BackendType` name going forward.
+kata-vm = ["kata"]
+# systemd-nspawn lightweight-container backend (#518: the granular per-
+# `BackendType` feature). Compiles in `NspawnBackend` and registers it as the
+# lowest-isolation auto-selectable tier (priority 10). Torch-free and needs no
+# new dependencies (only the already-present `which`/`nix`/`tokio` process
+# plumbing), so it just gates the module. Opt-in like every other backend so a
+# build can pick exactly its backend set (casual = `wasm`+`nspawn`; server =
+# `kata`+`oci`+`cri`). When off, `nspawn` selection fails closed (the backend
+# simply isn't registered).
+nspawn = []
 # In-process WebAssembly sandbox backend (#505 P2). Compiles in `WasmBackend`
 # and the `hyprstream-workers-wasmtime` wasmtime substrate it consumes. A native in-process
 # sibling under the same `SandboxBackend` seam: no VM, no subprocess — a wasmtime
@@ -291,7 +307,8 @@ cri = ["dep:k8s-cri", "dep:tonic", "dep:tower", "dep:hyper-util"]
 # selection fails closed (the backend simply isn't registered).
 k8s = ["dep:hyprstream-k8s", "hyprstream-k8s/k8s"]
 # Enable Dragonball built-in VMM support (alternative to cloud-hypervisor).
-# Implies `kata-vm` since it tunes the kata hypervisor abstraction.
+# Implies `kata` (via the `kata-vm` alias) since it tunes the kata hypervisor
+# abstraction.
 dragonball = ["kata-vm", "kata-hypervisor/dragonball"]
 # Enable D-Bus bridge for container access to host D-Bus services
 dbus = ["dep:zbus"]

--- a/crates/hyprstream-workers/src/lib.rs
+++ b/crates/hyprstream-workers/src/lib.rs
@@ -68,12 +68,14 @@ pub use config::{HypervisorType, ImageConfig, PoolConfig, WorkerConfig, Workflow
 pub use error::WorkerError;
 
 // Re-export service types
-pub use runtime::{WorkerService, SandboxBackend, SandboxHandle, NspawnBackend, NspawnConfig};
+pub use runtime::{WorkerService, SandboxBackend, SandboxHandle};
+#[cfg(feature = "nspawn")]
+pub use runtime::{NspawnBackend, NspawnConfig};
 // Inventory-based backend registry + fail-closed selection spine (#507)
 pub use runtime::{resolve_backend, BackendCtx, BackendRegistration};
 // Scheduling-substrate explain (#628): the shared SelectionReport<C> trace.
 pub use runtime::{explain_selection, BackendCandidate};
-#[cfg(feature = "kata-vm")]
+#[cfg(feature = "kata")]
 pub use runtime::KataBackend;
 // The image-store trait seam is always available; only the concrete RAFS impl
 // (`RafsStore`) requires `oci-image`.

--- a/crates/hyprstream-workers/src/runtime/kata_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/kata_backend.rs
@@ -1253,8 +1253,9 @@ impl KataBackend {
 
 // This whole file only compiles under `kata-vm` (see runtime/mod.rs), so this
 // `submit!` is feature-gated by construction: the `kata` backend is a selectable
-// name *only* in builds that include the VM toolchain. In a non-`kata-vm` binary
-// there is no registration, and selecting `kata` fails closed with a build hint.
+// name *only* in builds that include the VM toolchain. In a non-`kata` binary
+// (the `kata-vm` alias is off too) there is no registration, and selecting
+// `kata` fails closed with a build hint.
 //
 // Highest priority → preferred by `auto` (strongest isolation). Construction
 // pulls the RAFS image store from the per-call BackendCtx.

--- a/crates/hyprstream-workers/src/runtime/mod.rs
+++ b/crates/hyprstream-workers/src/runtime/mod.rs
@@ -45,14 +45,18 @@ pub mod k8s_backend;
 // `/exec/instances/` VFS projection of `SandboxPool` (#608 P2 / #610) — a
 // `hyprstream_vfs::Mount` impl, so it has no `kata-vm`/`wasm` dependency.
 pub mod exec_mount;
-// Kata/CH VM backend — gated behind `kata-vm` (pulls the kata/nydus toolchain).
-#[cfg(feature = "kata-vm")]
+// Kata/CH VM backend — gated behind `kata` (pulls the kata/nydus toolchain).
+// `kata-vm` is a backward-compat alias for `kata` (#518).
+#[cfg(feature = "kata")]
 pub mod kata_backend;
 // kata-agent ttrpc/vsock client (#344): CreateContainer/StartContainer/
 // ExecProcess/WaitProcess against the guest's kata-agent. Used by
 // `kata_backend::KataBackend::exec_sync`.
-#[cfg(feature = "kata-vm")]
+#[cfg(feature = "kata")]
 pub mod kata_agent;
+// systemd-nspawn lightweight-container backend (#518: per-BackendType feature).
+// The lowest-isolation auto-selectable tier; torch-free, no heavy deps.
+#[cfg(feature = "nspawn")]
 pub mod nspawn;
 // Rootless OCI container backend (#346) — gated behind `oci`. Drives a rootless
 // OCI runtime (podman by default) via CLI shell-out; torch-free, no VM toolchain.
@@ -127,8 +131,9 @@ pub use backend::{SandboxBackend, SandboxHandle};
 pub use cri_backend::{CriBackend, CriConfig, CriHandle};
 // `/exec/instances/` Plan9 projection of the pool (#608 P2 / #610)
 pub use exec_mount::ExecMount;
-#[cfg(feature = "kata-vm")]
+#[cfg(feature = "kata")]
 pub use kata_backend::{KataBackend, KataHandle};
+#[cfg(feature = "nspawn")]
 pub use nspawn::{NspawnBackend, NspawnConfig, NspawnHandle};
 #[cfg(feature = "oci")]
 pub use oci_backend::{OciBackend, OciConfig, OciHandle};

--- a/crates/hyprstream-workers/src/runtime/pool.rs
+++ b/crates/hyprstream-workers/src/runtime/pool.rs
@@ -512,8 +512,8 @@ pub struct PoolStats {
     pub warm_pool_target: usize,
 }
 
-// The pool tests build a KataBackend + RafsStore, so they only run under `kata-vm`.
-#[cfg(all(test, feature = "kata-vm"))]
+// The pool tests build a KataBackend + RafsStore, so they only run under `kata`.
+#[cfg(all(test, feature = "kata"))]
 mod tests {
     use super::*;
     use crate::config::{ImageConfig, PoolConfig};

--- a/crates/hyprstream-workers/src/runtime/selection.rs
+++ b/crates/hyprstream-workers/src/runtime/selection.rs
@@ -9,8 +9,10 @@
 //! feature-gated by the `#[cfg]` that compiles that backend in (#518). The
 //! registry is therefore *exactly* the set of backends built into this binary:
 //!
-//! * `nspawn` — always registered (systemd-nspawn lightweight container).
-//! * `kata`   — registered only under the `kata-vm` feature (full VM isolation).
+//! * `nspawn` — registered only under the `nspawn` feature (systemd-nspawn
+//!   lightweight container).
+//! * `kata`   — registered only under the `kata` feature (full VM isolation;
+//!   `kata-vm` is a backward-compat alias for `kata`).
 //! * `oci`    — registered only under the `oci` feature (rootless OCI/podman
 //!   container, #346).
 //! * `wasm`   — registered only under the `wasm` feature (in-process WebAssembly,
@@ -277,7 +279,7 @@ fn select_registration_with_cap<'a>(
             if name.eq_ignore_ascii_case("kata") {
                 msg.push_str(
                     ". The `kata` backend is only present when built with \
-                     `--features kata-vm`",
+                     `--features kata` (or the `kata-vm` alias)",
                 );
             }
             Err(WorkerError::ConfigError(msg))
@@ -829,11 +831,14 @@ mod tests {
         assert!(!backend_injects_9p_socket("does-not-exist"));
         assert!(require_9p_socket_capability("does-not-exist").is_err());
 
-        // nspawn is always registered and IS capable (host --bind).
-        assert!(backend_injects_9p_socket("nspawn"), "nspawn can bind a host UDS");
-        assert!(require_9p_socket_capability("nspawn").is_ok());
-        // Case-insensitive, mirroring name matching.
-        assert!(backend_injects_9p_socket("NSPAWN"));
+        // nspawn is registered under the `nspawn` feature and IS capable (host --bind).
+        #[cfg(feature = "nspawn")]
+        {
+            assert!(backend_injects_9p_socket("nspawn"), "nspawn can bind a host UDS");
+            assert!(require_9p_socket_capability("nspawn").is_ok());
+            // Case-insensitive, mirroring name matching.
+            assert!(backend_injects_9p_socket("NSPAWN"));
+        }
     }
 
     #[cfg(feature = "oci")]
@@ -845,14 +850,23 @@ mod tests {
         assert!(oci.injects_9p_socket, "oci bind-mounts a host UDS → capable");
     }
 
-    #[cfg(feature = "kata-vm")]
+    #[cfg(feature = "nspawn")]
+    #[test]
+    fn nspawn_advertises_9p_socket_injection() {
+        let nspawn = inventory::iter::<BackendRegistration>()
+            .find(|r| r.name == "nspawn")
+            .expect("nspawn registered under the nspawn feature");
+        assert!(nspawn.injects_9p_socket, "nspawn --bind can inject a host UDS");
+    }
+
+    #[cfg(feature = "kata")]
     #[test]
     fn kata_does_not_advertise_9p_socket_injection() {
         // A VM does not share the host mount namespace, so it cannot bind-inject
         // a host UDS the way oci/nspawn do — it must NOT advertise the capability.
         let kata = inventory::iter::<BackendRegistration>()
             .find(|r| r.name == "kata")
-            .expect("kata registered under the kata-vm feature");
+            .expect("kata registered under the kata feature");
         assert!(
             !kata.injects_9p_socket,
             "kata (VM, no shared host mount ns) must not advertise host-UDS injection"
@@ -872,18 +886,11 @@ mod tests {
     }
 
     #[test]
-    fn nspawn_advertises_9p_socket_injection() {
-        let nspawn = inventory::iter::<BackendRegistration>()
-            .find(|r| r.name == "nspawn")
-            .expect("nspawn always registered");
-        assert!(nspawn.injects_9p_socket, "nspawn --bind can inject a host UDS");
-    }
-
-    #[test]
     fn unknown_kata_hints_about_feature() {
-        // Asking for kata when it isn't registered (e.g. kata-vm off) gives a
+        // Asking for kata when it isn't registered (e.g. kata off) gives a
         // build-feature hint rather than a bare unknown error.
         let err = select_registration("kata", &regs(), |_| true).unwrap_err();
+        assert!(err.to_string().contains("kata"), "got: {err}");
         assert!(err.to_string().contains("kata-vm"), "got: {err}");
     }
 
@@ -920,17 +927,18 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "nspawn")]
     #[test]
     fn nspawn_advertises_fuse_mount_capability_in_real_inventory() {
         // The real inventory: nspawn is the Model B FUSE-root target (#715), so
-        // the public gate resolves it Ok. nspawn is always registered.
+        // the public gate resolves it Ok. nspawn registers under its feature.
         assert!(
             require_fuse_mount_capability("nspawn").is_ok(),
             "nspawn must advertise mounts_fuse_vfs"
         );
     }
 
-    #[cfg(feature = "kata-vm")]
+    #[cfg(feature = "kata")]
     #[test]
     fn kata_does_not_advertise_fuse_mount_capability() {
         // kata already shares the composed VFS via virtio-fs, not a host FUSE
@@ -940,11 +948,16 @@ mod tests {
     }
 
     #[test]
-    fn registry_contains_nspawn_always() {
-        let names: Vec<&str> = inventory::iter::<BackendRegistration>()
-            .map(|r| r.name)
-            .collect();
-        assert!(names.contains(&"nspawn"), "nspawn must always register; got {names:?}");
+    fn registry_contains_nspawn_only_under_feature() {
+        // nspawn registers iff built with `--features nspawn` (#518: per-
+        // BackendType feature, mirroring kata/oci/cri/wasm). With the feature off
+        // it must NOT be a selectable name (fail-closed).
+        let has_nspawn = inventory::iter::<BackendRegistration>().any(|r| r.name == "nspawn");
+        assert_eq!(
+            has_nspawn,
+            cfg!(feature = "nspawn"),
+            "nspawn registration must track the nspawn feature"
+        );
     }
 
     #[test]
@@ -952,8 +965,8 @@ mod tests {
         let has_kata = inventory::iter::<BackendRegistration>().any(|r| r.name == "kata");
         assert_eq!(
             has_kata,
-            cfg!(feature = "kata-vm"),
-            "kata registration must track the kata-vm feature"
+            cfg!(feature = "kata"),
+            "kata registration must track the kata feature (kata-vm is its alias)"
         );
     }
 
@@ -1025,7 +1038,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "oci")]
+    #[cfg(all(feature = "oci", feature = "nspawn"))]
     #[test]
     fn oci_is_auto_selectable_and_outranks_nspawn() {
         // A rootless container (user namespaces + seccomp + its own image rootfs)
@@ -1036,7 +1049,7 @@ mod tests {
             .expect("oci registered under the oci feature");
         let nspawn = inventory::iter::<BackendRegistration>()
             .find(|r| r.name == "nspawn")
-            .expect("nspawn always registered");
+            .expect("nspawn registered under the nspawn feature");
         assert!(oci.auto_selectable, "oci is a real isolation tier → auto-selectable");
         assert!(
             oci.priority > nspawn.priority,
@@ -1086,16 +1099,25 @@ mod tests {
             err.to_string().contains("no available sandbox backend"),
             "auto must not pick wasm; got: {err}"
         );
+    }
 
-        // And with nspawn alongside it, `"auto"` resolves to nspawn — never wasm.
+    // The wasm-vs-nspawn comparison needs both backends compiled in: wasm (the
+    // auto-excluded tier) and nspawn (the auto-eligible tier that must win).
+    #[cfg(all(feature = "wasm", feature = "nspawn"))]
+    #[test]
+    fn auto_prefers_nspawn_over_auto_excluded_wasm() {
+        // With nspawn alongside wasm, `"auto"` resolves to nspawn — never wasm.
         // Inject a deterministic availability oracle (everything available) so this
         // does NOT depend on the runner actually having nspawn installed: nspawn is
         // auto_selectable (and outranks), wasm is auto_selectable:false (excluded), so
         // auto must return nspawn. (Real-runtime availability is exercised elsewhere;
         // here we assert the selection *logic*, env-independently.)
+        let wasm = inventory::iter::<BackendRegistration>()
+            .find(|r| r.name == "wasm")
+            .expect("wasm registered under the wasm feature");
         let nspawn = inventory::iter::<BackendRegistration>()
             .find(|r| r.name == "nspawn")
-            .expect("nspawn always registered");
+            .expect("nspawn registered under the nspawn feature");
         let both = vec![wasm, nspawn];
         let r = select_registration("auto", &both, |_| true).unwrap();
         assert_eq!(r.name, "nspawn", "auto must pick nspawn, never wasm");
@@ -1114,7 +1136,7 @@ mod tests {
         assert!((reg.is_available)(), "wasm is always available once built");
     }
 
-    #[cfg(feature = "kata-vm")]
+    #[cfg(all(feature = "kata", feature = "nspawn"))]
     #[test]
     fn kata_outranks_nspawn_in_priority() {
         let kata = inventory::iter::<BackendRegistration>()

--- a/crates/hyprstream-workers/src/runtime/service.rs
+++ b/crates/hyprstream-workers/src/runtime/service.rs
@@ -1448,8 +1448,8 @@ impl RequestService for WorkerService {
 }
 
 // These tests exercise the VM lifecycle (RafsStore + KataBackend), so they only
-// build/run under `kata-vm`.
-#[cfg(all(test, feature = "kata-vm"))]
+// build/run under `kata`.
+#[cfg(all(test, feature = "kata"))]
 #[allow(clippy::print_stderr)]
 mod tests {
     use super::*;

--- a/crates/hyprstream-workers/src/runtime/wanix_workload.rs
+++ b/crates/hyprstream-workers/src/runtime/wanix_workload.rs
@@ -774,9 +774,10 @@ mod tests {
         assert!(!dir.path().join(NINEP_SOCKET_NAME).exists());
     }
 
+    #[cfg(feature = "nspawn")]
     #[tokio::test]
     async fn prepare_succeeds_on_capable_backend() {
-        // nspawn is always registered and capable → injection proceeds.
+        // nspawn is registered (under the `nspawn` feature) and capable → injection proceeds.
         let dir = tempfile::tempdir().unwrap();
         let inj = prepare_wanix_workload(
             "nspawn",

--- a/crates/hyprstream-workers/src/runtime/wasm_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/wasm_backend.rs
@@ -356,8 +356,6 @@ impl SandboxBackend for WasmBackend {
         _subject: Subject,
         transport: super::backend::NamespaceTransport,
     ) -> Result<super::backend::NamespaceDelivery> {
-        use super::backend::NamespaceTransport;
-
         // Provisional (#635): wasm's guest has no separate OS to mount a
         // namespace into — the "host-imports" model means mount references
         // would be passed directly into the guest's linker as capability

--- a/crates/hyprstream-workers/tests/kata_9p_vsock_e2e.rs
+++ b/crates/hyprstream-workers/tests/kata_9p_vsock_e2e.rs
@@ -57,7 +57,7 @@
 //! 3. The kata guest kernel's lack of a 9P `trans=fd` transport is irrelevant
 //!    because the mount is userspace — confirming the V3 design choice.
 
-#![cfg(feature = "kata-vm")]
+#![cfg(feature = "kata")]
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 // Operator harness: assert with test-friendly macros.
 #![allow(clippy::unwrap_used, clippy::expect_used)]

--- a/crates/hyprstream-workers/tests/kata_spawn_e2e.rs
+++ b/crates/hyprstream-workers/tests/kata_spawn_e2e.rs
@@ -60,7 +60,7 @@
 //!   tenant-VFS-rootfs path is exercised only when a pre-built RAFS image id
 //!   is supplied via `HYPRSTREAM_KATA_RAFS_IMAGE_ID`.
 
-#![cfg(feature = "kata-vm")]
+#![cfg(feature = "kata")]
 // This is an opt-in operator harness: it intentionally prints skip reasons to
 // stdout and asserts with the test-friendly macros. Allow the workspace
 // restriction lints that would otherwise fire on that harness style.

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -199,7 +199,7 @@ keyring = { version = "3", features = ["windows-native"] }
 keyring = { version = "3", features = ["sync-secret-service", "crypto-rust"] }
 
 [features]
-default = ["gittorrent", "xet", "systemd", "otel", "kata-vm"]
+default = ["gittorrent", "xet", "systemd", "otel", "kata-vm", "nspawn"]
 cuda = []
 valkey = ["dep:fred"]  # Enable Valkey/Redis-backed user and token stores
 bnb = ["dep:bitsandbytes-sys"]  # Enable bitsandbytes KV cache quantization (requires compatible ROCm/CUDA)
@@ -210,7 +210,17 @@ download-libtorch = ["tch/download-libtorch"]
 overlayfs = ["git2db/overlayfs"]  # Enable overlayfs-backed worktrees (delegated to git2db)
 systemd = ["hyprstream-rpc/systemd", "hyprstream-service/systemd", "hyprstream-workers/systemd", "dep:listenfd"]  # Systemd integration (socket activation, service units)
 oci-image = ["hyprstream-workers/oci-image"]  # Universal mountable OCI/RAFS image filesystem service (ImageFs, an FsMount); composable by any backend (#633)
-kata-vm = ["hyprstream-workers/kata-vm", "oci-image"]  # Kata/Cloud-Hypervisor VM worker backend; implies oci-image (kata serves it via virtio-fs). In default; drop for an nspawn-only build
+# Kata/Cloud-Hypervisor VM worker backend (#518: granular per-BackendType feature).
+# Implies oci-image (kata serves it via virtio-fs). `kata-vm` (below) is the
+# backward-compat alias that forwards to this.
+kata = ["hyprstream-workers/kata", "oci-image"]
+# Backward-compat convenience alias (#518): `kata-vm` now forwards to the
+# granular `kata` feature. Existing `--features kata-vm` keeps working.
+kata-vm = ["kata"]
+# systemd-nspawn lightweight-container worker backend (#518: per-BackendType
+# feature). In default so the app keeps the nspawn auto-fallback tier; drop it
+# (and kata-vm) for a wasm/oci/cri-only build.
+nspawn = ["hyprstream-workers/nspawn"]
 experimental = ["hyprstream-compositor/experimental"]  # EXPERIMENTAL: Enable service/worker panels, git write operations
 pq-hybrid = []  # NO-OP alias: PQ primitives always compiled; Classical/Hybrid selected at runtime. See M3 #152.
 # Phase-1 cellular-ledger local-enforcer (epic #922, #925): the `ledger` service

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1137,9 +1137,13 @@ fn handle_quick_command(
                         let mut worker_service = WorkerService::new(
                             pool_config,
                             backend,
-                            #[cfg(feature = "kata-vm")]
+                            // Wire rafs_store for the canonical `kata` feature as
+                            // well as its `kata-vm` compat alias — `kata-vm = ["kata"]`
+                            // is one-way, so a `--features kata` build must not fall
+                            // through to the `None` arm (#518).
+                            #[cfg(any(feature = "kata", feature = "kata-vm"))]
                             Some(rafs_store),
-                            #[cfg(not(feature = "kata-vm"))]
+                            #[cfg(not(any(feature = "kata", feature = "kata-vm")))]
                             None,
                             worker_transport,
                             signing_key.clone(),

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -962,9 +962,12 @@ fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
     let mut worker_service = WorkerService::new(
         pool_config,
         backend,
-        #[cfg(feature = "kata-vm")]
+        // `kata-vm = ["kata"]` is one-way: a `--features kata` build must still
+        // wire rafs_store, so gate on either the canonical feature or its alias
+        // rather than `kata-vm` alone (#518).
+        #[cfg(any(feature = "kata", feature = "kata-vm"))]
         Some(rafs_store),
-        #[cfg(not(feature = "kata-vm"))]
+        #[cfg(not(any(feature = "kata", feature = "kata-vm")))]
         None,
         ctx.transport("worker", SocketKind::Rep),
         sk.clone(),


### PR DESCRIPTION
## Summary

Closes #518. Completes the granular per-`BackendType` feature gating on top of #516's inventory registry: **one cargo feature per backend**, so a build selects exactly its backend set (casual = `wasm`+`nspawn`; server = `kata`+`oci`+`cri`).

#516 folded in per-backend gating for `kata`/`oci`/`cri`/`wasm` and made `nspawn` always-compiled as the baseline. #518's literal spec asks for one feature per `BackendType` **including `nspawn`**, with `kata-vm` becoming a granular alias. This PR lands that remaining delta without re-litigating #516's fail-closed inventory selection (which stays exactly as-is).

## Changes

- **`nspawn` feature (workers)** — gates the `NspawnBackend` module, its `inventory::submit!` registration, and its re-exports (`mod.rs`, `lib.rs`). Previously always compiled; now opt-in like every other backend. When off, `nspawn` selection fails closed (the backend simply isn't registered) — same fail-closed contract as `kata`/`oci`/`cri`/`wasm`.
- **`kata` granular feature (workers)** — the heavy kata/nydus/agent toolchain deps move under `kata`. `kata-vm` becomes a thin backward-compat alias (`kata-vm = ["kata"]`); existing `--features kata-vm` keeps working unchanged. The workers-internal `#[cfg(feature = "kata-vm")]` gates (`mod.rs` / `pool.rs` / `service.rs` test blocks, the two kata e2e test harnesses) are repointed to `kata`.
- **Main `hyprstream` crate** — adds matching `kata` / `nspawn` passthroughs; `kata-vm` aliases `kata` there too. `nspawn` is added to the main crate's `default` so the application keeps the nspawn auto-fallback tier (no behavior change for `cargo build -p hyprstream`).
- **Tests** — the registry/selection tests now treat `nspawn` as feature-gated (mirroring `kata`/`oci`/`cri`/`wasm`); the `kata-vm` cfgs become `kata`; the cross-backend comparison tests (`oci` outranks `nspawn`, `kata` outranks `nspawn`, `auto` prefers `nspawn` over auto-excluded `wasm`) gate on both participating features. One `wanix_workload` test that assumed nspawn-always-registered is gated behind `nspawn`.
- **Drive-by** — drop a dead function-local `use NamespaceTransport;` in `wasm_backend.rs` (the parameter is already path-typed; the body only uses the value) that tripped `-D warnings` under `--features wasm`. Pre-existing, unrelated to #518, but blocking `--all-features` clippy.

## Behavior preserved

- #516's fail-closed `resolve_backend` / inventory selection is untouched.
- `--features kata-vm` still works (alias). `cargo build -p hyprstream` (default) still produces kata + nspawn + oci-image.
- New capability: `cargo build -p hyprstream-workers --no-default-features --features wasm,nspawn` (tiny casual build) or `--features kata,oci,cri` (server build).

## Verification

- `cargo test -p hyprstream-workers --lib` — default (153), `--features nspawn` (163), `--features nspawn,kata` (246), `--all-features` (328) — all green.
- `cargo clippy -p hyprstream-workers --all-targets -- -D warnings` — clean (default **and** `--all-features`).
- `cargo check -p hyprstream` (default `kata-vm`+`nspawn`) — clean.
- Pre-commit hook (`cargo clippy --workspace --all-targets --release -- -D warnings`) — passed.

Toolchain 1.97. Under epic #508 / Worker GA #341.