### PR TITLE
feat(at9p) G3: ai.hyprstream.name NameRecord + did:at9p repo authority (#908)

### DIFF
--- a/crates/hyprstream-pds/src/commit.rs
+++ b/crates/hyprstream-pds/src/commit.rs
@@ -140,6 +140,17 @@ impl Commit {
         ])
     }
 
+    /// Classify this commit's account DID as an accepted repo authority for our
+    /// PDS (`did:web`/`did:plc`/`did:at9p`), or `Err` if the method is not one we
+    /// host a repo for.
+    ///
+    /// This is the method-level acceptance gate (#908); it is independent of and
+    /// additional to the signature check in [`Commit::verify`]. A caller ingesting
+    /// a commit should accept the authority *and* verify the signature.
+    pub fn repo_authority(&self) -> Result<crate::repo_authority::RepoAuthority> {
+        crate::repo_authority::accept_repo_authority(&self.did)
+    }
+
     /// The [`UnsignedCommit`] form of this commit (drops `sig`).
     pub fn unsigned(&self) -> UnsignedCommit {
         UnsignedCommit {

--- a/crates/hyprstream-pds/src/lib.rs
+++ b/crates/hyprstream-pds/src/lib.rs
@@ -62,11 +62,15 @@ pub mod event_group;
 pub mod ledger;
 pub mod list_record;
 pub mod mst;
+pub mod name_record;
 pub mod placement;
 pub mod record;
+pub mod repo_authority;
 pub mod tid;
 
 pub use cid::Cid;
 pub use ledger::{AllocationRecord, CheckpointRecord, GrantClass, ReceiptRecord, StateRoot, Unit};
+pub use name_record::NameRecord;
 pub use placement::{GroupItemRecord, GroupRecord, NodeRecord, WorkloadRecord};
 pub use record::ModelRecord;
+pub use repo_authority::{accept_repo_authority, RepoAuthority};

--- a/crates/hyprstream-pds/src/list_record.rs
+++ b/crates/hyprstream-pds/src/list_record.rs
@@ -81,22 +81,57 @@ pub fn validate_did(s: &str) -> Result<()> {
 }
 
 /// `format: "datetime"` — atproto ISO-8601 UTC, millisecond precision, `Z`.
+///
+/// The canonical shape is exactly `YYYY-MM-DDTHH:MM:SS.mmmZ`, and the fields
+/// are checked semantically (real month/day bounds incl. leap years, 24-hour
+/// clock), not just for separator positions.
 pub fn validate_datetime(s: &str) -> Result<()> {
     ensure!(s.ends_with('Z'), "datetime must end with 'Z' (UTC): {s:?}");
     let pre = &s[..s.len() - 1];
-    ensure!(pre.len() >= 20, "datetime too short: {s:?}");
     let bytes = pre.as_bytes();
+    ensure!(
+        bytes.len() == 23,
+        "datetime must be YYYY-MM-DDTHH:MM:SS.mmm (millisecond precision): {s:?}"
+    );
     ensure!(
         bytes[4] == b'-'
             && bytes[7] == b'-'
             && bytes[10] == b'T'
             && bytes[13] == b':'
-            && bytes[16] == b':',
-        "datetime must be ISO-8601 (YYYY-MM-DDTHH:MM:SS): {s:?}"
+            && bytes[16] == b':'
+            && bytes[19] == b'.',
+        "datetime must be ISO-8601 (YYYY-MM-DDTHH:MM:SS.mmm): {s:?}"
     );
     ensure!(
-        bytes.get(19) == Some(&b'.'),
-        "datetime must have millisecond precision (.mmm): {s:?}"
+        bytes
+            .iter()
+            .enumerate()
+            .all(|(i, b)| matches!(i, 4 | 7 | 10 | 13 | 16 | 19) || b.is_ascii_digit()),
+        "datetime must be all digits outside its separators: {s:?}"
+    );
+    // Every field is all-digit and <= 4 chars, so parse cannot fail — but stay
+    // panic-free anyway (u32::MAX falls out of every range below).
+    let num = |lo: usize, hi: usize| pre[lo..hi].parse::<u32>().unwrap_or(u32::MAX);
+    let (year, month, day) = (num(0, 4), num(5, 7), num(8, 10));
+    let (hour, minute, second) = (num(11, 13), num(14, 16), num(17, 19));
+    ensure!(
+        (1..=12).contains(&month),
+        "datetime month out of range: {s:?}"
+    );
+    let leap = year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+    let days_in_month = match month {
+        4 | 6 | 9 | 11 => 30,
+        2 if leap => 29,
+        2 => 28,
+        _ => 31,
+    };
+    ensure!(
+        (1..=days_in_month).contains(&day),
+        "datetime day out of range: {s:?}"
+    );
+    ensure!(
+        hour <= 23 && minute <= 59 && second <= 59,
+        "datetime time out of range: {s:?}"
     );
     Ok(())
 }
@@ -412,6 +447,35 @@ mod tests {
         )
         .is_err());
         assert!(ListRecord::new("g", "did:web:x", None, "2026", ()).is_err());
+    }
+
+    #[test]
+    fn datetime_is_validated_semantically() {
+        // Valid millisecond-precision UTC datetimes are accepted.
+        for ok in [
+            "2026-06-23T12:34:56.789Z",
+            "2024-02-29T00:00:00.000Z", // leap day in a leap year
+            "2026-12-31T23:59:59.999Z",
+        ] {
+            assert!(validate_datetime(ok).is_ok(), "{ok:?} must be accepted");
+        }
+        for bad in [
+            "2026-99-99T99:99:99.999Z",  // nonsense month/day/time
+            "2026-00-10T12:00:00.000Z",  // month 0
+            "2026-13-10T12:00:00.000Z",  // month 13
+            "2026-04-31T12:00:00.000Z",  // April has 30 days
+            "2026-02-29T12:00:00.000Z",  // not a leap year
+            "2026-06-23T24:00:00.000Z",  // hour 24
+            "2026-06-23T12:60:00.000Z",  // minute 60
+            "2026-06-23T12:34:60.000Z",  // second 60
+            "2026-06-23T12:34:56.Z",     // missing fractional digits
+            "2026-06-23T12:34:56.78Z",   // not millisecond precision
+            "2026-06-23T12:34:56.7890Z", // too many fractional digits
+            "2026-06-23T12:34:56.789",   // missing Z
+            "aaaa-aa-aaTaa:aa:aa.aaaZ",  // separators only, no digits
+        ] {
+            assert!(validate_datetime(bad).is_err(), "{bad:?} must be rejected");
+        }
     }
 
     #[test]

--- a/crates/hyprstream-pds/src/name_record.rs
+++ b/crates/hyprstream-pds/src/name_record.rs
@@ -1,0 +1,323 @@
+//! `ai.hyprstream.name` — the NameRecord: the trusted, PQ-signed **name → DID
+//! URL** layer (#908, design #905 §1/§3/§6; #879 §Name-resolution).
+//!
+//! This is the thin naming layer that sits *on top of* `ai.hyprstream.model`
+//! (#387 D1). A NameRecord binds a human-chosen `label` to a `subject` **DID
+//! URL** and a content `pin`. It is the trusted complement the DHT must never
+//! answer: the DHT is an untrusted *locator*; the authoritative name → DID-URL
+//! mapping lives here, in a PQ-signed atproto record served from a PDS.
+//!
+//! The confirmed 4-field lexicon:
+//!
+//! ```json
+//! {
+//!   "lexicon": 1,
+//!   "id": "ai.hyprstream.name",
+//!   "defs": { "main": { "type": "record", "key": "tid", "record": {
+//!     "type": "object",
+//!     "required": ["subject", "pin", "label", "createdAt"],
+//!     "properties": {
+//!       "subject":   { "type": "string" },               // a DID URL, opaque
+//!       "pin":       { "type": "string", "format": "cid" },
+//!       "label":     { "type": "string" },               // human label
+//!       "createdAt": { "type": "string", "format": "datetime" }
+//!     }
+//! }}}
+//! ```
+//!
+//! # `subject` carries a DID URL, not an at-uri, and never a 9P path
+//!
+//! The `subject` field is a **DID URL** carried as an opaque string (a standard
+//! lexicon extension: unmodified Bluesky/Tangled can store, sync, and serve
+//! these records without understanding the field). The acceptance contract is
+//! that this DID URL *dereferences* via the G1 (#906) resolution path.
+//!
+//! Crucially, the value is a `did:`-scheme DID URL — **never** a raw 9P path and
+//! **never** an `at://` URI. `at://` addresses this record; the record's body
+//! resolves onward to a DID URL. Keeping 9P paths out of the at:// / record
+//! layer is the #879 name-resolution non-goal made structural: paths live below
+//! the DID, reached only after the DID URL dereferences.
+//!
+//! # Encoding
+//!
+//! Records are canonical **DAG-CBOR**: map keys in pure lexicographic byte order
+//! (RFC 7049 §4.2.1 "core determinism"), matching the rest of this crate. For
+//! these four keys that order is `createdAt`, `label`, `pin`, `subject`. Same
+//! record → same bytes → same CID.
+//!
+//! `pin` is a `format: "cid"` **string** (not a DAG-CBOR link): it references
+//! external content addressed outside this repo's MST, so it is carried as text
+//! and validated as a CID string — the same treatment `currentOid` gets in
+//! [`crate::record`].
+
+use anyhow::{ensure, Result};
+
+use crate::cid::Cid;
+use crate::dag_cbor::DagCbor;
+use crate::ledger::validate_cid_string;
+use crate::list_record::{map_get_str, validate_datetime, validate_nonempty};
+
+/// The NSID of this record type — the collection portion of an at-uri that
+/// addresses a NameRecord (`at://<repo>/ai.hyprstream.name/<rkey>`).
+pub const COLLECTION_NSID: &str = "ai.hyprstream.name";
+
+/// An `ai.hyprstream.name` record: the trusted name → DID-URL binding.
+///
+/// Construct with [`NameRecord::new`]; encode/decode via the DAG-CBOR
+/// conversion methods.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NameRecord {
+    /// The **DID URL** this name resolves to, carried opaquely. Must be a
+    /// `did:`-scheme DID URL (it may carry a path/query/fragment); it dereferences
+    /// via G1. Never an `at://` URI and never a 9P path.
+    pub subject: String,
+    /// The content pin — a `format: "cid"` string addressing the pinned content.
+    pub pin: String,
+    /// A human-readable label for this name.
+    pub label: String,
+    /// ISO-8601 UTC datetime (`format: "datetime"`), millisecond precision, `Z`.
+    pub created_at: String,
+}
+
+impl NameRecord {
+    /// Validate and construct a NameRecord.
+    ///
+    /// `subject` must be a `did:`-scheme DID URL (a DID, optionally with a
+    /// path/query/fragment), `pin` a parseable CID string, `label` non-empty, and
+    /// `created_at` the atproto `datetime` shape (UTC, milliseconds, trailing `Z`).
+    pub fn new(
+        subject: impl Into<String>,
+        pin: impl Into<String>,
+        label: impl Into<String>,
+        created_at: impl Into<String>,
+    ) -> Result<Self> {
+        let subject = subject.into();
+        let pin = pin.into();
+        let label = label.into();
+        let created_at = created_at.into();
+        validate_did_url(&subject)?;
+        validate_cid_string(&pin, "pin")?;
+        validate_nonempty(&label, "label")?;
+        validate_datetime(&created_at)?;
+        Ok(Self {
+            subject,
+            pin,
+            label,
+            created_at,
+        })
+    }
+
+    /// Encode to canonical DAG-CBOR bytes (deterministic).
+    pub fn to_dag_cbor(&self) -> Vec<u8> {
+        self.to_value().encode()
+    }
+
+    /// The CID of this record (CIDv1 dag-cbor over its canonical bytes).
+    pub fn cid(&self) -> Cid {
+        Cid::from_dag_cbor(&self.to_dag_cbor())
+    }
+
+    /// Build the typed [`DagCbor`] value form (fields in canonical order).
+    pub fn to_value(&self) -> DagCbor {
+        DagCbor::str_map([
+            ("createdAt", DagCbor::Text(self.created_at.clone())),
+            ("label", DagCbor::Text(self.label.clone())),
+            ("pin", DagCbor::Text(self.pin.clone())),
+            ("subject", DagCbor::Text(self.subject.clone())),
+        ])
+    }
+
+    /// Decode canonical DAG-CBOR bytes into a NameRecord, validating all fields.
+    pub fn from_dag_cbor(bytes: &[u8]) -> Result<Self> {
+        Self::from_value(&DagCbor::decode(bytes)?)
+    }
+
+    pub fn from_value(value: &DagCbor) -> Result<Self> {
+        let map = value.as_map()?;
+        let subject = map_get_str(value, "subject", COLLECTION_NSID)?.to_owned();
+        let pin = map_get_str(value, "pin", COLLECTION_NSID)?.to_owned();
+        let label = map_get_str(value, "label", COLLECTION_NSID)?.to_owned();
+        let created_at = map_get_str(value, "createdAt", COLLECTION_NSID)?.to_owned();
+        // The lexicon is frozen at 4 fields — reject anything else.
+        for (k, _v) in map {
+            match k.as_str()? {
+                "subject" | "pin" | "label" | "createdAt" => {}
+                other => anyhow::bail!(
+                    "{COLLECTION_NSID}: unknown field {other:?} (lexicon is 4 fields)"
+                ),
+            }
+        }
+        Self::new(subject, pin, label, created_at)
+    }
+}
+
+/// A **DID URL** carried as an opaque string: it must be a `did:`-scheme URL
+/// with a non-empty `method` and `method-specific-id` (the id may carry a
+/// `/path`, `?query`, or `#fragment`). Deliberately lenient — full DID grammar
+/// and actual dereferencing are the resolver's job (G1) — but it firmly rejects
+/// the two things a NameRecord subject must never be: an `at://` URI and a bare
+/// 9P path.
+fn validate_did_url(s: &str) -> Result<()> {
+    ensure!(
+        s.starts_with("did:"),
+        "subject must be a did: DID URL (not an at-uri or 9P path): {s:?}"
+    );
+    let rest = &s[4..];
+    ensure!(!rest.is_empty(), "subject DID URL must have a method: {s:?}");
+    ensure!(
+        !rest.chars().any(char::is_whitespace),
+        "subject DID URL must not contain whitespace: {s:?}"
+    );
+    let mut parts = rest.splitn(2, ':');
+    let method = parts.next().unwrap_or("");
+    let id = parts.next().unwrap_or("");
+    ensure!(
+        !method.is_empty() && !id.is_empty(),
+        "subject must be \"did:<method>:<id>[/path][?query][#fragment]\": {s:?}"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::panic
+    )]
+    use super::*;
+
+    fn sample() -> NameRecord {
+        NameRecord::new(
+            "did:web:alice.example.com/models/qwen3",
+            "bafyreiexamplepin1234567890abcdefghij",
+            "qwen3-serving",
+            "2026-06-23T12:34:56.789Z",
+        )
+        .expect("valid sample")
+    }
+
+    #[test]
+    fn round_trip_same_cid() {
+        let r = sample();
+        let bytes = r.to_dag_cbor();
+        let back = NameRecord::from_dag_cbor(&bytes).expect("round-trip");
+        assert_eq!(r, back);
+        assert_eq!(r.cid(), back.cid());
+        assert_eq!(r.to_dag_cbor(), back.to_dag_cbor());
+    }
+
+    #[test]
+    fn fields_canonical_order() {
+        let r = sample();
+        let v = DagCbor::decode(&r.to_dag_cbor()).expect("decode");
+        let map = v.as_map().expect("map");
+        let keys: Vec<&str> = map.iter().map(|(k, _)| k.as_str().expect("str")).collect();
+        assert_eq!(
+            keys,
+            vec!["createdAt", "label", "pin", "subject"],
+            "DAG-CBOR map keys must be pure-lexicographic byte order"
+        );
+    }
+
+    #[test]
+    fn subject_is_a_did_url_not_a_link() {
+        let r = sample();
+        let v = r.to_value();
+        // subject is carried as an opaque Text string, not a DAG-CBOR link.
+        assert!(matches!(v.get("subject"), Some(DagCbor::Text(_))));
+        // pin likewise is a cid-string, not a tag-42 link.
+        assert!(matches!(v.get("pin"), Some(DagCbor::Text(_))));
+    }
+
+    #[test]
+    fn accepts_did_at9p_subject() {
+        // The acceptance case: a did:at9p DID URL as subject.
+        let r = NameRecord::new(
+            "did:at9p:bafkrei1234567890abcdefghijklmnop#service",
+            "bafyreiexamplepin1234567890abcdefghij",
+            "my-node",
+            "2026-06-23T12:34:56.789Z",
+        )
+        .expect("did:at9p subject must be accepted");
+        assert!(r.subject.starts_with("did:at9p:"));
+    }
+
+    #[test]
+    fn rejects_at_uri_subject() {
+        // A NameRecord subject must never be an at:// URI — at:// addresses the
+        // record; the body resolves onward to a DID URL.
+        assert!(NameRecord::new(
+            "at://did:web:alice.example.com/ai.hyprstream.model/3kxy",
+            "bafyreiexamplepin1234567890abcdefghij",
+            "bad",
+            "2026-06-23T12:34:56.789Z",
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn rejects_9p_path_subject() {
+        // A raw 9P path must never leak into the at:// / record layer (#879).
+        assert!(NameRecord::new(
+            "/models/qwen3/adapters",
+            "bafyreiexamplepin1234567890abcdefghij",
+            "bad",
+            "2026-06-23T12:34:56.789Z",
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn validates_formats() {
+        // Bad pin (not a cid).
+        assert!(NameRecord::new(
+            "did:web:x",
+            "x",
+            "l",
+            "2026-06-23T12:34:56.789Z"
+        )
+        .is_err());
+        // Empty label.
+        assert!(NameRecord::new(
+            "did:web:x",
+            "bafyreiexamplepin1234567890abcdefghij",
+            "",
+            "2026-06-23T12:34:56.789Z"
+        )
+        .is_err());
+        // Bad datetime.
+        assert!(NameRecord::new(
+            "did:web:x",
+            "bafyreiexamplepin1234567890abcdefghij",
+            "l",
+            "2026-06-23T12:34:56.789"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn rejects_extra_fields() {
+        let mut extra = sample().to_value();
+        if let DagCbor::Map(ref mut v) = extra {
+            v.push((DagCbor::Text("bogus".into()), DagCbor::Unsigned(1)));
+            v.sort_by(|a, b| a.0.as_str().unwrap_or("").cmp(b.0.as_str().unwrap_or("")));
+        }
+        assert!(NameRecord::from_value(&extra).is_err());
+    }
+
+    #[test]
+    fn deterministic_across_rebuild() {
+        let r1 = sample();
+        let r2 = NameRecord::new(
+            r1.subject.clone(),
+            r1.pin.clone(),
+            r1.label.clone(),
+            r1.created_at.clone(),
+        )
+        .expect("rebuild");
+        assert_eq!(r1.to_dag_cbor(), r2.to_dag_cbor());
+        assert_eq!(r1.cid(), r2.cid());
+    }
+}

--- a/crates/hyprstream-pds/src/name_record.rs
+++ b/crates/hyprstream-pds/src/name_record.rs
@@ -54,7 +54,6 @@ use anyhow::{ensure, Result};
 
 use crate::cid::Cid;
 use crate::dag_cbor::DagCbor;
-use crate::ledger::validate_cid_string;
 use crate::list_record::{map_get_str, validate_datetime, validate_nonempty};
 
 /// The NSID of this record type — the collection portion of an at-uri that
@@ -70,13 +69,13 @@ pub struct NameRecord {
     /// The **DID URL** this name resolves to, carried opaquely. Must be a
     /// `did:`-scheme DID URL (it may carry a path/query/fragment); it dereferences
     /// via G1. Never an `at://` URI and never a 9P path.
-    pub subject: String,
+    subject: String,
     /// The content pin — a `format: "cid"` string addressing the pinned content.
-    pub pin: String,
+    pin: String,
     /// A human-readable label for this name.
-    pub label: String,
+    label: String,
     /// ISO-8601 UTC datetime (`format: "datetime"`), millisecond precision, `Z`.
-    pub created_at: String,
+    created_at: String,
 }
 
 impl NameRecord {
@@ -96,7 +95,7 @@ impl NameRecord {
         let label = label.into();
         let created_at = created_at.into();
         validate_did_url(&subject)?;
-        validate_cid_string(&pin, "pin")?;
+        validate_pin_cid(&pin)?;
         validate_nonempty(&label, "label")?;
         validate_datetime(&created_at)?;
         Ok(Self {
@@ -105,6 +104,26 @@ impl NameRecord {
             label,
             created_at,
         })
+    }
+
+    /// The DID URL this name resolves to.
+    pub fn subject(&self) -> &str {
+        &self.subject
+    }
+
+    /// The content CID string pinned by this name.
+    pub fn pin(&self) -> &str {
+        &self.pin
+    }
+
+    /// Human-readable label for this name.
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+
+    /// Creation timestamp in canonical atproto datetime shape.
+    pub fn created_at(&self) -> &str {
+        &self.created_at
     }
 
     /// Encode to canonical DAG-CBOR bytes (deterministic).
@@ -163,7 +182,10 @@ fn validate_did_url(s: &str) -> Result<()> {
         "subject must be a did: DID URL (not an at-uri or 9P path): {s:?}"
     );
     let rest = &s[4..];
-    ensure!(!rest.is_empty(), "subject DID URL must have a method: {s:?}");
+    ensure!(
+        !rest.is_empty(),
+        "subject DID URL must have a method: {s:?}"
+    );
     ensure!(
         !rest.chars().any(char::is_whitespace),
         "subject DID URL must not contain whitespace: {s:?}"
@@ -175,7 +197,50 @@ fn validate_did_url(s: &str) -> Result<()> {
         !method.is_empty() && !id.is_empty(),
         "subject must be \"did:<method>:<id>[/path][?query][#fragment]\": {s:?}"
     );
+    ensure!(
+        !matches!(id.as_bytes().first(), Some(b'/' | b'?' | b'#')),
+        "subject DID URL must include a method-specific id before any path/query/fragment: {s:?}"
+    );
     Ok(())
+}
+
+fn validate_pin_cid(s: &str) -> Result<()> {
+    hyprstream_rpc::cid::decode_cid(s)
+        .map(|_| ())
+        .map_err(|err| anyhow::anyhow!("pin must be a parseable CIDv1 base32 string: {s:?}: {err}"))
+}
+
+#[cfg(test)]
+fn sample_pin() -> String {
+    hyprstream_rpc::cid::encode_cid(
+        hyprstream_rpc::cid::Codec::GitRaw,
+        hyprstream_rpc::cid::HashAlgo::Sha2_256,
+        &[0x42; 32],
+    )
+    .expect("valid sample CID")
+}
+
+#[cfg(test)]
+fn sample_at9p_pin() -> String {
+    hyprstream_rpc::cid::encode_cid(
+        hyprstream_rpc::cid::Codec::At9pCapsule,
+        hyprstream_rpc::cid::HashAlgo::Blake3,
+        &[0x24; 64],
+    )
+    .expect("valid sample at9p CID")
+}
+
+#[cfg(test)]
+fn truncated_pin() -> String {
+    hyprstream_rpc::cid::encode_cid(
+        hyprstream_rpc::cid::Codec::GitRaw,
+        hyprstream_rpc::cid::HashAlgo::Sha2_256,
+        &[0x11; 32],
+    )
+    .expect("valid CID")
+    .chars()
+    .take(12)
+    .collect()
 }
 
 #[cfg(test)]
@@ -191,7 +256,7 @@ mod tests {
     fn sample() -> NameRecord {
         NameRecord::new(
             "did:web:alice.example.com/models/qwen3",
-            "bafyreiexamplepin1234567890abcdefghij",
+            sample_pin(),
             "qwen3-serving",
             "2026-06-23T12:34:56.789Z",
         )
@@ -236,12 +301,12 @@ mod tests {
         // The acceptance case: a did:at9p DID URL as subject.
         let r = NameRecord::new(
             "did:at9p:bafkrei1234567890abcdefghijklmnop#service",
-            "bafyreiexamplepin1234567890abcdefghij",
+            sample_at9p_pin(),
             "my-node",
             "2026-06-23T12:34:56.789Z",
         )
         .expect("did:at9p subject must be accepted");
-        assert!(r.subject.starts_with("did:at9p:"));
+        assert!(r.subject().starts_with("did:at9p:"));
     }
 
     #[test]
@@ -250,7 +315,7 @@ mod tests {
         // record; the body resolves onward to a DID URL.
         assert!(NameRecord::new(
             "at://did:web:alice.example.com/ai.hyprstream.model/3kxy",
-            "bafyreiexamplepin1234567890abcdefghij",
+            sample_pin(),
             "bad",
             "2026-06-23T12:34:56.789Z",
         )
@@ -262,7 +327,7 @@ mod tests {
         // A raw 9P path must never leak into the at:// / record layer (#879).
         assert!(NameRecord::new(
             "/models/qwen3/adapters",
-            "bafyreiexamplepin1234567890abcdefghij",
+            sample_pin(),
             "bad",
             "2026-06-23T12:34:56.789Z",
         )
@@ -270,31 +335,47 @@ mod tests {
     }
 
     #[test]
+    fn rejects_did_url_without_method_specific_id_before_suffix() {
+        for subject in ["did:web:/models/qwen3", "did:web:?q", "did:web:#f"] {
+            assert!(
+                NameRecord::new(subject, sample_pin(), "bad", "2026-06-23T12:34:56.789Z",).is_err(),
+                "{subject:?} must not treat a URL suffix delimiter as the DID id"
+            );
+        }
+
+        NameRecord::new(
+            "did:web:alice.example.com/models/qwen3?version=1#svc",
+            sample_pin(),
+            "ok",
+            "2026-06-23T12:34:56.789Z",
+        )
+        .expect("valid DID URL suffix after method-specific id");
+    }
+
+    #[test]
     fn validates_formats() {
         // Bad pin (not a cid).
+        assert!(NameRecord::new("did:web:x", "x", "l", "2026-06-23T12:34:56.789Z").is_err());
+        // Bad pin (malformed base32 CID body).
+        assert!(
+            NameRecord::new("did:web:x", "b!!!!!!!!", "l", "2026-06-23T12:34:56.789Z").is_err()
+        );
+        // Bad pin (valid base32 prefix but truncated multihash/CID body).
         assert!(NameRecord::new(
             "did:web:x",
-            "x",
+            truncated_pin(),
             "l",
             "2026-06-23T12:34:56.789Z"
         )
         .is_err());
         // Empty label.
-        assert!(NameRecord::new(
-            "did:web:x",
-            "bafyreiexamplepin1234567890abcdefghij",
-            "",
-            "2026-06-23T12:34:56.789Z"
-        )
-        .is_err());
+        assert!(
+            NameRecord::new("did:web:x", sample_pin(), "", "2026-06-23T12:34:56.789Z").is_err()
+        );
         // Bad datetime.
-        assert!(NameRecord::new(
-            "did:web:x",
-            "bafyreiexamplepin1234567890abcdefghij",
-            "l",
-            "2026-06-23T12:34:56.789"
-        )
-        .is_err());
+        assert!(
+            NameRecord::new("did:web:x", sample_pin(), "l", "2026-06-23T12:34:56.789").is_err()
+        );
     }
 
     #[test]
@@ -310,13 +391,8 @@ mod tests {
     #[test]
     fn deterministic_across_rebuild() {
         let r1 = sample();
-        let r2 = NameRecord::new(
-            r1.subject.clone(),
-            r1.pin.clone(),
-            r1.label.clone(),
-            r1.created_at.clone(),
-        )
-        .expect("rebuild");
+        let r2 =
+            NameRecord::new(r1.subject(), r1.pin(), r1.label(), r1.created_at()).expect("rebuild");
         assert_eq!(r1.to_dag_cbor(), r2.to_dag_cbor());
         assert_eq!(r1.cid(), r2.cid());
     }

--- a/crates/hyprstream-pds/src/name_record.rs
+++ b/crates/hyprstream-pds/src/name_record.rs
@@ -166,6 +166,14 @@ impl NameRecord {
                 ),
             }
         }
+        // `DagCbor::decode` already rejects duplicate map keys on the wire path,
+        // but `from_value` is public: reject hand-built values where a recognized
+        // key appears twice (which would make `map_get_str` pick one of two
+        // conflicting values).
+        ensure!(
+            map.len() == 4,
+            "{COLLECTION_NSID}: duplicate field (lexicon is exactly 4 fields)"
+        );
         Self::new(subject, pin, label, created_at)
     }
 }
@@ -386,6 +394,21 @@ mod tests {
             v.sort_by(|a, b| a.0.as_str().unwrap_or("").cmp(b.0.as_str().unwrap_or("")));
         }
         assert!(NameRecord::from_value(&extra).is_err());
+    }
+
+    #[test]
+    fn rejects_duplicate_recognized_field() {
+        // A hand-built value with a second `subject` must not parse: the wire
+        // decoder rejects duplicate keys, and the value-level path must too.
+        let mut dup = sample().to_value();
+        if let DagCbor::Map(ref mut v) = dup {
+            v.push((
+                DagCbor::Text("subject".into()),
+                DagCbor::Text("did:web:evil.example.com".into()),
+            ));
+            v.sort_by(|a, b| a.0.as_str().unwrap_or("").cmp(b.0.as_str().unwrap_or("")));
+        }
+        assert!(NameRecord::from_value(&dup).is_err());
     }
 
     #[test]

--- a/crates/hyprstream-pds/src/record.rs
+++ b/crates/hyprstream-pds/src/record.rs
@@ -36,6 +36,7 @@ use anyhow::{bail, ensure, Result};
 
 use crate::cid::Cid;
 use crate::dag_cbor::DagCbor;
+use crate::list_record::validate_datetime;
 
 /// The NSID of this record type. The collection portion of an at-uri that
 /// addresses a record (`at://<repo>/<collection>/<rkey>`).
@@ -167,29 +168,6 @@ fn validate_cid_string(s: &str) -> Result<()> {
     ensure!(
         ok,
         "cid string must be a CIDv1 (b/z…) or CIDv0 (Qm…): {s:?}"
-    );
-    Ok(())
-}
-
-fn validate_datetime(s: &str) -> Result<()> {
-    // atproto `datetime`: ISO-8601 UTC, millisecond precision, trailing Z.
-    // Canonical example: "2026-06-23T12:34:56.789Z".
-    ensure!(s.ends_with('Z'), "datetime must end with 'Z' (UTC): {s:?}");
-    let pre = &s[..s.len() - 1];
-    ensure!(pre.len() >= 20, "datetime too short: {s:?}");
-    let bytes = pre.as_bytes();
-    ensure!(
-        bytes[4] == b'-'
-            && bytes[7] == b'-'
-            && bytes[10] == b'T'
-            && bytes[13] == b':'
-            && bytes[16] == b':',
-        "datetime must be ISO-8601 (YYYY-MM-DDTHH:MM:SS): {s:?}"
-    );
-    // Expect ".mmm" milliseconds between seconds and the trailing Z.
-    ensure!(
-        bytes.get(19) == Some(&b'.'),
-        "datetime must have millisecond precision (.mmm): {s:?}"
     );
     Ok(())
 }

--- a/crates/hyprstream-pds/src/repo_authority.rs
+++ b/crates/hyprstream-pds/src/repo_authority.rs
@@ -1,0 +1,96 @@
+//! Which DID methods *our* PDS accepts as a **repo authority** — the account DID
+//! that owns a repository and signs its commits (#908, design #905 §6).
+//!
+//! Public atproto infrastructure allowlists only `did:plc` and `did:web` as repo
+//! authorities. hyprstream additionally accepts **`did:at9p`** (the
+//! self-certifying hybrid-PQC capsule identity, #879/#880) on *our own* side: a
+//! did:at9p account can own and sign a repo hosted by our PDS. Public publication
+//! of such a repo goes through the #896 `alsoKnownAs` bridge, which republishes
+//! under a classical `did:web`/`did:plc` authority that public infra will accept —
+//! so accepting did:at9p here never implies public infra must.
+//!
+//! This is a pure classification of the DID *method*; it is not a signature check
+//! (that is [`crate::commit::Commit::verify`]) and not a full DID-grammar
+//! validation (the resolver owns that). It answers exactly one question: *is this
+//! DID method one our PDS will host a repo for?*
+
+use anyhow::{bail, Result};
+
+use hyprstream_rpc::identity::Did;
+
+/// A DID method our PDS accepts as a repo authority.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RepoAuthority {
+    /// `did:web` — an operated node whose keys live as DID-document verification
+    /// methods. Accepted by public atproto infra.
+    Web,
+    /// `did:plc` — the atproto placeholder DID method. Accepted by public atproto
+    /// infra.
+    Plc,
+    /// `did:at9p` — the self-certifying hybrid-PQC capsule identity (#879/#880).
+    /// Accepted by our PDS; **not** by public atproto infra (bridged via #896).
+    At9p,
+}
+
+impl RepoAuthority {
+    /// Whether public atproto infrastructure will itself accept this authority as
+    /// a repo owner.
+    ///
+    /// `true` for `did:web`/`did:plc`; `false` for `did:at9p`. A did:at9p repo is
+    /// published to public infra only via the #896 `alsoKnownAs` bridge under a
+    /// classical DID.
+    pub fn is_publicly_publishable(self) -> bool {
+        matches!(self, RepoAuthority::Web | RepoAuthority::Plc)
+    }
+}
+
+/// Classify `did` as an accepted repo authority for our PDS, or reject it.
+///
+/// Accepts `did:web`, `did:plc`, and `did:at9p`; every other DID method is
+/// rejected. The `did:at9p` arm is what this issue (#908) adds — the classical
+/// methods were already implicitly accepted by the commit layer, which never
+/// method-checked its `did`.
+pub fn accept_repo_authority(did: &str) -> Result<RepoAuthority> {
+    let d = Did::new(did.to_owned());
+    if d.is_did_web() {
+        Ok(RepoAuthority::Web)
+    } else if did.starts_with("did:plc:") {
+        Ok(RepoAuthority::Plc)
+    } else if d.is_did_at9p() {
+        Ok(RepoAuthority::At9p)
+    } else {
+        bail!("did {did:?} is not an accepted repo authority (want did:web, did:plc, or did:at9p)")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+    use super::*;
+
+    #[test]
+    fn accepts_did_at9p() {
+        let a = accept_repo_authority("did:at9p:bafkrei1234567890abcdefghijklmnop").unwrap();
+        assert_eq!(a, RepoAuthority::At9p);
+        assert!(!a.is_publicly_publishable(), "did:at9p is bridged, not public");
+    }
+
+    #[test]
+    fn accepts_classical_methods() {
+        let web = accept_repo_authority("did:web:alice.example.com").unwrap();
+        assert_eq!(web, RepoAuthority::Web);
+        assert!(web.is_publicly_publishable());
+
+        let plc = accept_repo_authority("did:plc:abc123").unwrap();
+        assert_eq!(plc, RepoAuthority::Plc);
+        assert!(plc.is_publicly_publishable());
+    }
+
+    #[test]
+    fn rejects_unknown_methods() {
+        assert!(accept_repo_authority("did:key:z6Mkxyz").is_err());
+        assert!(accept_repo_authority("did:example:123").is_err());
+        assert!(accept_repo_authority("not-a-did").is_err());
+        assert!(accept_repo_authority("").is_err());
+    }
+}


### PR DESCRIPTION
Implements #908 (G3 — the at:// **records** layer of epic #880 / design #905 §1/§3/§6).

## What

- **`ai.hyprstream.name` NameRecord** (`crates/hyprstream-pds/src/name_record.rs`) — the thin, trusted **name → DID-URL** layer on top of `ai.hyprstream.model` (#387 D1). A 4-field frozen lexicon: `subject` (an opaque **DID URL**), `pin` (`format: cid`), `label` (human), `createdAt`. Canonical DAG-CBOR (pure-lexicographic key order), same treatment as the other records in this crate.
  - `subject` must be a `did:`-scheme DID URL that dereferences via G1 (#906). It **rejects** an `at://` URI or a bare 9P path — `at://` addresses the record; the body resolves onward to a DID URL. This keeps 9P paths out of the at:// / record layer, the #879 name-resolution non-goal made structural.
  - The record body carries the DID URL as an opaque string field (standard lexicon extension — unmodified Bluesky/Tangled can store/sync/serve it).

- **did:at9p repo authority** (`crates/hyprstream-pds/src/repo_authority.rs`) — `accept_repo_authority` classifies the account DID that owns a repo and signs its commits. Our PDS accepts `did:web`/`did:plc`/`did:at9p`; public atproto infra allowlists only the classical methods, so `RepoAuthority::is_publicly_publishable()` reports `did:at9p` as bridge-only (public publication under a classical DID via the #896 `alsoKnownAs` bridge). `Commit::repo_authority()` exposes the gate at the commit-ingest point, independent of and additional to `Commit::verify`.

## Acceptance

- `at://<did>/ai.hyprstream.name/<rkey>` decodes to a body whose `subject` DID URL is a valid `did:` DID URL (dereference is the G1 path).
- did:at9p accepted as a repo authority by our PDS; at:// never carries a 9P path (enforced + tested).

## Scope / gating

The **publication leg** (name → discovery) stays gated on **#910** per the issue — this PR is the records + authority layer only. No publication stub is wired here.

## Tests

12 new unit tests (round-trip/CID determinism, canonical field order, DID-URL vs at-uri vs 9P-path rejection, did:at9p subject + authority acceptance, unknown-field rejection). Full `cargo test -p hyprstream-pds` green (169 lib + 6 integration); clippy clean.