### PR TITLE
mac: wire S4 policy bootload at daemon startup (#570)

### DIFF
--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -2288,10 +2288,18 @@ fn main() -> Result<()> {
                                             &signing_key,
                                             &pq_sk,
                                         ) {
-                                            Ok(policy) => tracing::info!(
+                                            Ok((policy, true)) => tracing::info!(
                                                 "MAC S4: baseline compiled policy installed \
                                                  (generation {}, DORMANT — enforcement not enabled)",
                                                 policy.generation
+                                            ),
+                                            // The seam is write-once: a policy was
+                                            // already installed this process, so the
+                                            // baseline did NOT replace it. Report it
+                                            // honestly rather than claiming an install.
+                                            Ok((_policy, false)) => tracing::warn!(
+                                                "MAC S4: a compiled policy was already installed; \
+                                                 baseline NOT installed (write-once seam unchanged)"
                                             ),
                                             Err(e) => tracing::error!(
                                                 "MAC S4: baseline policy bootload failed \

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -2258,6 +2258,51 @@ fn main() -> Result<()> {
                                     let _ = shared_vks.write().map(|mut guard| *guard = vks);
                                     ctx.set_ml_dsa_verifying_keys(shared_vks);
                                     tracing::info!("PQ-hybrid: ML-DSA-65 verifying keys loaded for JWT verification");
+
+                                    // MAC S4 policy bootload (#570): compile → sign
+                                    // → verify-once-at-load → install the node's
+                                    // baseline CompiledPolicy so the MAC PDP inputs
+                                    // are real. This is the one missing boot step
+                                    // that populates `mac::COMPILED_POLICY`, flipping
+                                    // `exchange_enrollment_resolver` from the deny-all
+                                    // `DenyUnlabeledResolver` to the real (#698)
+                                    // `EnrollmentSubjectContextResolver`.
+                                    //
+                                    // DORMANT: installing a compiled policy does NOT
+                                    // enable enforcement — the per-op deciders stay
+                                    // AllowAll (no PEP consults this PDP yet). It only
+                                    // makes the PDP inputs real.
+                                    //
+                                    // Fail-closed: the baseline is hybrid-signed
+                                    // (EdDSA + ML-DSA-65) and verified with
+                                    // require_pq=true. With no active ML-DSA signing
+                                    // key (Classical mode) nothing is installed —
+                                    // never an Ed25519-only baseline (design §14) —
+                                    // and the resolver keeps denying.
+                                    let active_pq = tokio::task::block_in_place(|| {
+                                        let rt = tokio::runtime::Handle::current();
+                                        rt.block_on(ml_dsa_store.active_key())
+                                    });
+                                    match active_pq {
+                                        Some(pq_sk) => match hyprstream_core::mac::install_baseline_boot_policy(
+                                            &signing_key,
+                                            &pq_sk,
+                                        ) {
+                                            Ok(policy) => tracing::info!(
+                                                "MAC S4: baseline compiled policy installed \
+                                                 (generation {}, DORMANT — enforcement not enabled)",
+                                                policy.generation
+                                            ),
+                                            Err(e) => tracing::error!(
+                                                "MAC S4: baseline policy bootload failed \
+                                                 (grant-path resolver stays fail-closed): {e}"
+                                            ),
+                                        },
+                                        None => tracing::warn!(
+                                            "MAC S4: no active ML-DSA signing key; baseline policy \
+                                             NOT installed (fail-closed — grant-path resolver denies)"
+                                        ),
+                                    }
                                 }
 
                                 // M3 (#152): install the process-global envelope

--- a/crates/hyprstream/src/mac/bootload.rs
+++ b/crates/hyprstream/src/mac/bootload.rs
@@ -1,0 +1,271 @@
+//! S4 policy bootload (#570): the missing daemon-boot step that installs a
+//! **verified** [`CompiledPolicy`] so the MAC PDP inputs are real.
+//!
+//! Everything else in the S4 stack was already built (the
+//! [`LatticeTeEvaluator`](crate::mac::te::LatticeTeEvaluator) PDP, the
+//! [`CachingAvc`](crate::mac::avc::CachingAvc), the [`PolicyLoader`], the
+//! [`SignedPolicy`](crate::mac::compiled::SignedPolicy) sign/verify path), but
+//! **nothing ever ran the compile → sign → verify-load → install chain at
+//! startup**. So [`crate::mac::compiled_policy`] (the process-global `OnceLock`)
+//! stayed `None`, and every downstream seam fell back to deny-all — in
+//! particular [`crate::mac::exchange_enrollment_resolver`] returned the
+//! [`DenyUnlabeledResolver`](crate::services::oauth::token_exchange::DenyUnlabeledResolver),
+//! which is what kept #698's already-merged
+//! [`EnrollmentSubjectContextResolver`](crate::mac::EnrollmentSubjectContextResolver)
+//! inert. This module is the one missing wire.
+//!
+//! ## DORMANT — this does NOT enable enforcement
+//!
+//! Installing a compiled policy only makes the PDP *inputs* real: it flips
+//! [`crate::mac::compiled_policy`] to `Some`, so the enrollment resolver
+//! resolves genuine clearances instead of denying every DID. The per-op
+//! deciders remain AllowAll — no PEP consults this PDP yet (see the "Current
+//! status" note in `CLAUDE.md` / the epic). Turning enforcement *on* is a
+//! separate, deliberate step; this keeps the framework fail-closed and correct
+//! while wiring the last dormant input.
+//!
+//! ## Fail-closed
+//!
+//! The signer is hybrid (EdDSA + ML-DSA-65 COSE composite) and the loader
+//! verifies with `require_pq = true` (design §14 — never Ed25519-only). A node
+//! with no active ML-DSA signing key installs **nothing** (the caller keeps the
+//! resolver denying), never a classical-only baseline.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use ed25519_dalek::SigningKey;
+use hyprstream_rpc::auth::ucan::token::{Did, Ucan, UcanPayload};
+use hyprstream_rpc::crypto::pq::MlDsaSigningKey;
+
+use crate::mac::compiled::cose::{HybridPolicySigner, HybridPolicyVerifier};
+use crate::mac::compiled::{sign_policy, CompiledPolicy, PolicyDistError, PolicyLoader};
+use crate::mac::compiler::{compile, PermissionMap};
+use crate::mac::lattice::{Lattice, LatticeVersion, SecurityLabel};
+use crate::mac::permission_map::ScopePermissionMap;
+use crate::mac::te::SubjectType;
+use crate::mac::install_compiled_policy;
+
+/// Errors from the boot path. All fail-closed: on any error nothing is installed
+/// and [`crate::mac::compiled_policy`] stays `None` (the resolver keeps denying).
+#[derive(Debug, thiserror::Error)]
+pub enum BootPolicyError {
+    /// Signing, hashing, or the verify-once-at-load step failed.
+    #[error("policy bootload failed: {0}")]
+    Policy(#[from] PolicyDistError),
+}
+
+/// Compile a validated grant into a TE policy, hybrid-PQC-sign it, verify it
+/// **once at load**, and install it process-globally. Returns the installed
+/// [`CompiledPolicy`].
+///
+/// The signer and verifier use the **same** node keys: at boot the node is its
+/// own baseline-policy authority, so it self-signs and self-verifies the
+/// artifact through the full [`sign_policy`] → [`PolicyLoader::load`] path
+/// (rather than short-circuiting the crypto). `require_pq = true` — the ML-DSA
+/// outer layer is mandatory; a classical-only signature is rejected.
+///
+/// The caller MUST have already validated `grant`'s UCAN chain — `compile`
+/// reads only its capability set. Enrollment is the authority-owned
+/// DID→clearance table (#698), embedded in and covered by the signature.
+///
+/// Installation is once-per-process (the underlying `OnceLock`): a second call
+/// leaves the first-installed policy in place, but always returns the policy
+/// **this** call compiled+verified (so callers observe their own artifact even
+/// when another already won the global slot).
+pub fn compile_sign_load_install(
+    grant: &Ucan,
+    lattice: &Lattice,
+    permissions: &impl PermissionMap,
+    enrollment: BTreeMap<String, SecurityLabel>,
+    ed_sk: &SigningKey,
+    pq_sk: &MlDsaSigningKey,
+) -> Result<Arc<CompiledPolicy>, BootPolicyError> {
+    // Control plane: lower the grant → TE matrix (S5 compiler) and attach the
+    // authority-owned enrollment. Both travel inside the signature.
+    let policy = compile(grant, lattice, permissions).with_enrollment(enrollment);
+
+    // Sign hybrid (EdDSA + ML-DSA-65 COSE composite; cose_sign::sign_composite
+    // under the HybridPolicySigner adapter).
+    let signer = HybridPolicySigner {
+        ed_sk,
+        pq_sk: Some(pq_sk),
+    };
+    let signed = sign_policy(&policy, &signer)?;
+
+    // Verify ONCE at load (require_pq = true, fail-closed). Same key material —
+    // the node self-signs its baseline; a production distribution flow would
+    // anchor the authority's key instead, but the load/verify contract is
+    // identical.
+    let ed_vk = ed_sk.verifying_key();
+    // `verifying_key` is provided by the `ml_dsa::Keypair` trait; call it
+    // fully-qualified (matching `MlDsaKeySlot::verifying_key`) so this module
+    // needs no extra trait import.
+    let pq_vk = ml_dsa::Keypair::verifying_key(pq_sk).clone();
+    let verifier = HybridPolicyVerifier {
+        ed_vk: &ed_vk,
+        pq_vk: Some(&pq_vk),
+        require_pq: true,
+    };
+    let loaded = PolicyLoader::new(verifier).load(&signed)?;
+
+    let policy = Arc::new(loaded);
+    install_compiled_policy(policy.clone());
+    Ok(policy)
+}
+
+/// Install the node's **dormant baseline** compiled policy at daemon boot.
+///
+/// The baseline is intentionally minimal: a self-issued empty grant over an
+/// empty lattice generation and an empty object registry, so the compiled TE
+/// matrix is empty (grants nothing) and no subject is enrolled. Its only effect
+/// is to make [`crate::mac::compiled_policy`] return `Some`, which switches the
+/// grant path's subject resolver from deny-all to the real
+/// [`EnrollmentSubjectContextResolver`](crate::mac::EnrollmentSubjectContextResolver).
+/// Enforcement stays AllowAll — this is the dormant activation prerequisite, not
+/// the enforcement flip.
+///
+/// A future policy-authoring step (config-driven UCAN grant + enrollment) feeds
+/// a real matrix through the same [`compile_sign_load_install`] path; the empty
+/// baseline is the fail-closed default until then.
+pub fn install_baseline_boot_policy(
+    ed_sk: &SigningKey,
+    pq_sk: &MlDsaSigningKey,
+) -> Result<Arc<CompiledPolicy>, BootPolicyError> {
+    // Self-issued empty grant: the node is its own baseline authority and grants
+    // itself nothing. `compile` reads only the (empty) capability set.
+    let did = Did::from_ed25519(&ed_sk.verifying_key().to_bytes());
+    let grant = Ucan {
+        payload: UcanPayload {
+            issuer: did.clone(),
+            audience: did,
+            capabilities: vec![],
+            not_before: None,
+            expiration: None,
+            nonce: vec![],
+        },
+        proofs: vec![],
+        signature: vec![],
+    };
+
+    // Empty lattice (generation 1) and empty object registry → empty matrix.
+    let lattice = Lattice::new(LatticeVersion(1), []);
+    let permissions = ScopePermissionMap::new(SubjectType(1), Vec::<(String, String)>::new());
+
+    compile_sign_load_install(
+        &grant,
+        &lattice,
+        &permissions,
+        BTreeMap::new(),
+        ed_sk,
+        pq_sk,
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::mac::compiled_policy;
+    use crate::mac::lattice::{Assurance, CompartmentSet, Level};
+    use crate::mac::EnrollmentSubjectContextResolver;
+    use crate::services::oauth::token_exchange::SubjectContextResolver as _;
+    use hyprstream_rpc::auth::ucan::capability::{Ability, Capability, Resource};
+    use hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair;
+    use rand::rngs::OsRng;
+
+    fn cap(res: &str, ab: &str) -> Capability {
+        Capability::new(Resource::new(res), Ability::new(ab))
+    }
+
+    fn grant_with(caps: Vec<Capability>) -> Ucan {
+        let did = Did::from_ed25519(&[0u8; 32]);
+        Ucan {
+            payload: UcanPayload {
+                issuer: did.clone(),
+                audience: did,
+                capabilities: caps,
+                not_before: None,
+                expiration: None,
+                nonce: vec![],
+            },
+            proofs: vec![],
+            signature: vec![],
+        }
+    }
+
+    /// The whole missing boot chain, end to end: compile a real grant, sign it
+    /// hybrid, verify-once-at-load, install it — then the enrollment resolver
+    /// resolves a real clearance for an enrolled DID (instead of the deny-all
+    /// `DenyUnlabeledResolver` that a `None` compiled policy forces), and the
+    /// process-global `compiled_policy()` is `Some`.
+    #[test]
+    fn boot_installs_policy_and_resolver_resolves_real_clearance() {
+        let ed_sk = SigningKey::generate(&mut OsRng);
+        let (pq_sk, _pq_vk) = ml_dsa_generate_keypair();
+
+        // A registry with one model, a grant to read it, and an enrolled subject.
+        let lattice = Lattice::new(LatticeVersion(1), []);
+        let permissions = ScopePermissionMap::new(SubjectType(1), [("model", "llama")]);
+        let grant = grant_with(vec![cap("mac://model/llama", "query")]);
+
+        let did = "did:key:zBootActor";
+        let clearance =
+            SecurityLabel::new(Level::Secret, Assurance::Classical, CompartmentSet::EMPTY);
+        let enrollment = BTreeMap::from([(did.to_owned(), clearance)]);
+
+        let policy = compile_sign_load_install(
+            &grant,
+            &lattice,
+            &permissions,
+            enrollment,
+            &ed_sk,
+            &pq_sk,
+        )
+        .expect("hybrid sign + verify-once-at-load must succeed");
+
+        // The grant lowered to exactly one allow rule (compile ran, and the
+        // signature verified — a bad signature would have failed `load`).
+        assert_eq!(policy.matrix.allow_len(), 1, "one model × one verb");
+
+        // The process-global OnceLock is populated (monotonic across the test
+        // binary; asserting `Some` never races).
+        assert!(
+            compiled_policy().is_some(),
+            "boot must install the process-global compiled policy"
+        );
+
+        // The #698 resolver over THIS verified policy resolves the enrolled DID
+        // to a real clearance — the dormant activation the boot step unblocks.
+        let resolver = EnrollmentSubjectContextResolver::new(policy);
+        let ctx = resolver
+            .resolve(did)
+            .expect("an enrolled DID must resolve to a real clearance, not deny-all");
+        assert_eq!(ctx.clearance().level, Level::Secret);
+        // Decision D: assurance floored at Classical regardless of the table.
+        assert_eq!(ctx.clearance().assurance, Assurance::Classical);
+
+        // An unenrolled DID still denies (fail-closed contract unchanged).
+        assert!(resolver.resolve("did:key:zStranger").is_none());
+    }
+
+    /// The production baseline: a self-issued empty grant compiles to an empty
+    /// matrix and installs cleanly (dormant — grants nothing, enrolls nobody),
+    /// still exercising the full hybrid sign + verify-once-at-load path.
+    #[test]
+    fn baseline_boot_policy_installs_empty_dormant_matrix() {
+        let ed_sk = SigningKey::generate(&mut OsRng);
+        let (pq_sk, _pq_vk) = ml_dsa_generate_keypair();
+
+        let policy = install_baseline_boot_policy(&ed_sk, &pq_sk)
+            .expect("empty baseline must sign + verify-load");
+
+        assert_eq!(policy.generation, 1);
+        assert_eq!(policy.matrix.allow_len(), 0, "empty grant → empty matrix");
+        assert!(
+            policy.clearance_for("did:key:zAnyone").is_none(),
+            "the baseline enrolls nobody (fail-closed default)"
+        );
+        assert!(compiled_policy().is_some());
+    }
+}

--- a/crates/hyprstream/src/mac/bootload.rs
+++ b/crates/hyprstream/src/mac/bootload.rs
@@ -69,10 +69,39 @@ pub enum BootPolicyError {
 /// reads only its capability set. Enrollment is the authority-owned
 /// DID→clearance table (#698), embedded in and covered by the signature.
 ///
-/// Installation is once-per-process (the underlying `OnceLock`): a second call
-/// leaves the first-installed policy in place, but always returns the policy
-/// **this** call compiled+verified (so callers observe their own artifact even
-/// when another already won the global slot).
+/// ## Return: `(policy, installed)` — the write-once truth
+///
+/// Returns the policy **this** call compiled+verified together with an
+/// `installed` flag from [`install_compiled_policy`]: `true` iff this call's
+/// policy actually became the process-global seam, `false` if one was already
+/// installed and the global slot is unchanged. The returned `Arc` is always this
+/// call's own artifact regardless — but when `installed == false`, that artifact
+/// is NOT what [`crate::mac::compiled_policy`] returns.
+///
+/// ## Write-once limitation (do not build a real-policy swap on this yet)
+///
+/// The seam is a `OnceLock`: the **first** installed policy pins it for the
+/// process lifetime. So this API installs a real policy ONLY on a node that has
+/// not already installed the boot baseline — which, at daemon startup, it always
+/// has. A config-driven real policy therefore CANNOT replace the baseline through
+/// this function today: it will compile+verify fine, get `installed == false`,
+/// and silently leave the empty baseline as the live seam. Swapping a
+/// newer verified generation in atomically (e.g. `ArcSwap<CompiledPolicy>` keyed
+/// by `generation`) is the follow-up; until then, treat `installed == false` as
+/// "the earlier policy still governs the seam", never as a successful swap.
+///
+/// ## Key provenance (self-issued smoke test, NOT a distributed trust anchor)
+///
+/// The signer and verifier are the SAME node keys and there are no approvals, so
+/// this is a self-signed, self-verified artifact: the round-trip exercises the
+/// real hybrid `sign_composite` → `verify_composite` path but proves nothing
+/// about an external authority. The node's `ed_sk` (registry identity) and the
+/// `pq_sk` (drawn from the JWT-rotation ML-DSA store) are also a chimera pairing,
+/// not a purpose-built policy-authority key. **Before any *distributed* policy
+/// flow reuses this signer/verifier pairing, key provenance must be settled** —
+/// a dedicated policy-authority keypair whose verifying key is anchored in the
+/// PQ trust store, with `PolicyLoader::with_approval` populated — so the loader
+/// verifies against an anchored authority, not against the same key that signed.
 pub fn compile_sign_load_install(
     grant: &Ucan,
     lattice: &Lattice,
@@ -80,7 +109,7 @@ pub fn compile_sign_load_install(
     enrollment: BTreeMap<String, SecurityLabel>,
     ed_sk: &SigningKey,
     pq_sk: &MlDsaSigningKey,
-) -> Result<Arc<CompiledPolicy>, BootPolicyError> {
+) -> Result<(Arc<CompiledPolicy>, bool), BootPolicyError> {
     // Control plane: lower the grant → TE matrix (S5 compiler) and attach the
     // authority-owned enrollment. Both travel inside the signature.
     let policy = compile(grant, lattice, permissions).with_enrollment(enrollment);
@@ -94,9 +123,9 @@ pub fn compile_sign_load_install(
     let signed = sign_policy(&policy, &signer)?;
 
     // Verify ONCE at load (require_pq = true, fail-closed). Same key material —
-    // the node self-signs its baseline; a production distribution flow would
-    // anchor the authority's key instead, but the load/verify contract is
-    // identical.
+    // the node self-signs its baseline (see the key-provenance note above); a
+    // production distribution flow would anchor a distinct authority key instead,
+    // but the load/verify contract is identical.
     let ed_vk = ed_sk.verifying_key();
     // `verifying_key` is provided by the `ml_dsa::Keypair` trait; call it
     // fully-qualified (matching `MlDsaKeySlot::verifying_key`) so this module
@@ -110,8 +139,8 @@ pub fn compile_sign_load_install(
     let loaded = PolicyLoader::new(verifier).load(&signed)?;
 
     let policy = Arc::new(loaded);
-    install_compiled_policy(policy.clone());
-    Ok(policy)
+    let installed = install_compiled_policy(policy.clone());
+    Ok((policy, installed))
 }
 
 /// Install the node's **dormant baseline** compiled policy at daemon boot.
@@ -125,13 +154,20 @@ pub fn compile_sign_load_install(
 /// Enforcement stays AllowAll — this is the dormant activation prerequisite, not
 /// the enforcement flip.
 ///
-/// A future policy-authoring step (config-driven UCAN grant + enrollment) feeds
-/// a real matrix through the same [`compile_sign_load_install`] path; the empty
-/// baseline is the fail-closed default until then.
+/// Returns `(policy, installed)` from [`compile_sign_load_install`]. At daemon
+/// boot this is the first (and, given the `OnceLock` write-once seam, only)
+/// install, so `installed` is normally `true`; a `false` means a policy was
+/// already installed this process.
+///
+/// A future policy-authoring step (config-driven UCAN grant + enrollment) will
+/// need a **swap-capable** seam to replace this baseline at runtime — it cannot
+/// do so through the current write-once [`install_compiled_policy`] (see that
+/// function's and [`compile_sign_load_install`]'s docs). The empty baseline is
+/// the fail-closed default until that seam lands.
 pub fn install_baseline_boot_policy(
     ed_sk: &SigningKey,
     pq_sk: &MlDsaSigningKey,
-) -> Result<Arc<CompiledPolicy>, BootPolicyError> {
+) -> Result<(Arc<CompiledPolicy>, bool), BootPolicyError> {
     // Self-issued empty grant: the node is its own baseline authority and grants
     // itself nothing. `compile` reads only the (empty) capability set.
     let did = Did::from_ed25519(&ed_sk.verifying_key().to_bytes());
@@ -214,7 +250,7 @@ mod tests {
             SecurityLabel::new(Level::Secret, Assurance::Classical, CompartmentSet::EMPTY);
         let enrollment = BTreeMap::from([(did.to_owned(), clearance)]);
 
-        let policy = compile_sign_load_install(
+        let (policy, _installed) = compile_sign_load_install(
             &grant,
             &lattice,
             &permissions,
@@ -257,7 +293,7 @@ mod tests {
         let ed_sk = SigningKey::generate(&mut OsRng);
         let (pq_sk, _pq_vk) = ml_dsa_generate_keypair();
 
-        let policy = install_baseline_boot_policy(&ed_sk, &pq_sk)
+        let (policy, _installed) = install_baseline_boot_policy(&ed_sk, &pq_sk)
             .expect("empty baseline must sign + verify-load");
 
         assert_eq!(policy.generation, 1);
@@ -267,5 +303,43 @@ mod tests {
             "the baseline enrolls nobody (fail-closed default)"
         );
         assert!(compiled_policy().is_some());
+    }
+
+    /// Seam-level "un-inert but dormant" assertion: after the baseline boot the
+    /// process-global seam is populated, so [`crate::mac::exchange_enrollment_resolver`]
+    /// returns the real [`EnrollmentSubjectContextResolver`] (no longer the
+    /// deny-all `DenyUnlabeledResolver`) — yet, because the baseline enrolls
+    /// nobody, that resolver still denies **every** DID. This is the truest
+    /// statement of what this PR does: it flips the seam on without granting
+    /// anything.
+    ///
+    /// The asserted DID is one no other test in this binary enrolls, so the
+    /// `is_none()` holds regardless of which test's install won the write-once
+    /// global slot.
+    #[test]
+    fn baseline_boot_flips_seam_on_but_still_denies_every_did() {
+        let ed_sk = SigningKey::generate(&mut OsRng);
+        let (pq_sk, _pq_vk) = ml_dsa_generate_keypair();
+
+        let _ = install_baseline_boot_policy(&ed_sk, &pq_sk)
+            .expect("empty baseline must sign + verify-load");
+
+        // The seam flipped on (a compiled policy is installed → the grant path
+        // resolves through EnrollmentSubjectContextResolver, not deny-all).
+        assert!(
+            compiled_policy().is_some(),
+            "the seam must be populated after boot"
+        );
+
+        // …and it still denies every DID (dormant): the enrollment resolver
+        // returns None for an unenrolled subject, exactly like the deny-all
+        // fallback would — un-inert, but grants nothing.
+        let resolver = crate::mac::exchange_enrollment_resolver();
+        assert!(
+            resolver
+                .resolve("did:key:zNobodyEverEnrollsThisSeamTest")
+                .is_none(),
+            "the flipped-on seam must still deny an unenrolled DID"
+        );
     }
 }

--- a/crates/hyprstream/src/mac/mod.rs
+++ b/crates/hyprstream/src/mac/mod.rs
@@ -190,11 +190,24 @@ static COMPILED_POLICY: std::sync::OnceLock<std::sync::Arc<CompiledPolicy>> =
     std::sync::OnceLock::new();
 
 /// Install the node's verified [`CompiledPolicy`] for the
-/// [`exchange_enrollment_resolver`] seam. Once-per-process (a second call is a
-/// no-op, matching `install_verify_config`'s contract). The caller MUST have
+/// [`exchange_enrollment_resolver`] seam. **Write-once per process** (backed by a
+/// `OnceLock`): returns `true` if THIS call installed `policy`, `false` if a
+/// policy was already installed and this call was a no-op. The caller MUST have
 /// already verified the policy via [`PolicyLoader`] — this does not re-verify.
-pub fn install_compiled_policy(policy: std::sync::Arc<CompiledPolicy>) {
-    let _ = COMPILED_POLICY.set(policy);
+///
+/// The `bool` return makes the write-once contract honest: because the slot is a
+/// `OnceLock`, the **first** installed policy pins the seam for the process
+/// lifetime. Today the only caller is the boot baseline
+/// ([`bootload::install_baseline_boot_policy`]), so this is exactly-once; a
+/// future config-driven real policy CANNOT swap the baseline out through this API
+/// (it would get `false` and leave the empty baseline in place). Making the seam
+/// swap-capable — e.g. an `ArcSwap<CompiledPolicy>` keyed by policy generation so
+/// a newer, verified generation replaces an older one atomically — is the
+/// follow-up; until then callers must treat `false` as "the global seam still
+/// holds the earlier policy", never as success.
+#[must_use]
+pub fn install_compiled_policy(policy: std::sync::Arc<CompiledPolicy>) -> bool {
+    COMPILED_POLICY.set(policy).is_ok()
 }
 
 /// The installed [`CompiledPolicy`], if any. `None` on a node that hasn't loaded

--- a/crates/hyprstream/src/mac/mod.rs
+++ b/crates/hyprstream/src/mac/mod.rs
@@ -56,6 +56,9 @@
 
 pub mod audit;
 pub mod avc;
+// S4 (#570): the daemon-boot compile → sign → verify-load → install path that
+// finally populates `COMPILED_POLICY`. Dormant (no enforcement flip).
+pub mod bootload;
 pub mod compiled;
 pub mod compiler;
 // S6 (#572): runtime grant path — UCAN grant-request → access/refresh tokens.
@@ -107,6 +110,9 @@ pub use genesis::{
     floor_label, genesis_lattice, CompositeObjectLabelResolver, GenesisGate, ManifestLabelSource,
     NamespaceEnumerator, NoManifests, SitePolicy,
 };
+// S4 (#570): the boot path that installs the verified `CompiledPolicy` at daemon
+// startup (dormant — makes the PDP inputs real without enabling enforcement).
+pub use bootload::{compile_sign_load_install, install_baseline_boot_policy, BootPolicyError};
 
 /// Construct the [`UcanVerifier`] the HTTP grant path uses to validate a
 /// presented UCAN's signatures.

--- a/crates/hyprstream/src/mac/mod.rs
+++ b/crates/hyprstream/src/mac/mod.rs
@@ -205,8 +205,13 @@ static COMPILED_POLICY: std::sync::OnceLock<std::sync::Arc<CompiledPolicy>> =
 /// a newer, verified generation replaces an older one atomically — is the
 /// follow-up; until then callers must treat `false` as "the global seam still
 /// holds the earlier policy", never as success.
+// `pub(crate)` — this seam installs `policy` WITHOUT re-verifying it (the caller
+// MUST have already run it through `PolicyLoader`). Keeping it crate-private
+// prevents an out-of-crate caller from bypassing the verify-once-at-load path and
+// pinning an unsigned / classical-only policy into the process-global seam. The
+// only caller is `bootload`, which self-verifies through the full sign→load path.
 #[must_use]
-pub fn install_compiled_policy(policy: std::sync::Arc<CompiledPolicy>) -> bool {
+pub(crate) fn install_compiled_policy(policy: std::sync::Arc<CompiledPolicy>) -> bool {
     COMPILED_POLICY.set(policy).is_ok()
 }
 


### PR DESCRIPTION
## S4 policy bootload (#570, MAC epic #547)

The S4 PDP stack was already fully built — `LatticeTeEvaluator`, `CachingAvc`, `AuditedAvc`, the `PolicyLoader` sign/verify path — but **nothing ever ran the `compile → sign → verify-load → install` chain at startup**. So `mac::COMPILED_POLICY` (the process-global `OnceLock`) stayed `None`, and every downstream seam fell back to deny-all. In particular `exchange_enrollment_resolver` returned `DenyUnlabeledResolver`, which is exactly what kept #698's already-merged `EnrollmentSubjectContextResolver` inert.

This PR adds the one missing wire.

### What's added — `crates/hyprstream/src/mac/bootload.rs`

- **`compile_sign_load_install`** — the reusable core: lowers a validated grant to a TE matrix via the existing S5 compiler, attaches the authority-owned enrollment table (#698), hybrid-PQC-signs it (`cose_sign::sign_composite`, EdDSA + ML-DSA-65 composite), and **verifies it once at load** with `require_pq = true` before installing. Returns `(policy, installed)`.
- **`install_baseline_boot_policy`** — the dormant baseline the daemon installs at boot: a self-issued empty grant over an empty lattice/registry, so the matrix grants nothing and enrolls nobody.

Wired into daemon startup (`main.rs`) right after the ML-DSA verifying keys are loaded.

### Dormant — this does NOT enable enforcement

Installing a compiled policy only makes the PDP **inputs** real: it flips `compiled_policy()` to `Some`, switching the grant-path subject resolver from deny-all to the real `EnrollmentSubjectContextResolver`. The per-op deciders stay AllowAll — no PEP consults this PDP yet. Turning enforcement on is a separate, deliberate step.

### Write-once seam (honest contract)

`install_compiled_policy` returns `installed: bool` — the seam is a `OnceLock`, so the **first** installed policy pins the process for its lifetime. At boot that's the baseline. A future config-driven real policy therefore **cannot** replace the baseline through this API (it compiles/verifies fine but gets `installed == false` and leaves the empty baseline live). Making the seam swap-capable — e.g. `ArcSwap<CompiledPolicy>` keyed by policy `generation` — is the follow-up; the daemon logs a warning rather than a false "installed" if the slot was already set.

### Key provenance (self-issued smoke test, not a trust anchor)

At boot the signer and verifier are the **same** node keys with no approvals, and the `ed_sk` (registry identity) / `pq_sk` (JWT-rotation ML-DSA store) pairing is a chimera, not a purpose-built policy-authority key. The round-trip exercises the real hybrid `sign_composite` → `verify_composite` path but proves nothing about an external authority. This is documented in-code: **key provenance must be settled** (dedicated policy-authority keypair anchored in the PQ trust store, `PolicyLoader::with_approval` populated) before any *distributed* policy flow reuses this signer/verifier pairing.

### Fail-closed

The baseline is hybrid-signed and verified with `require_pq = true` (design §14 — never Ed25519-only). The boot path keeps a defensive "no active ML-DSA signing key ⇒ install nothing" branch, but note that in practice `load_or_init_ml_dsa_key_store` **always** provisions an active ML-DSA key, so a node running the daemon path effectively always has one — that branch is a belt-and-suspenders guard, not a "Classical nodes lack a compiled policy" guarantee. Do not rely on Classical mode leaving the seam empty.

### Tests

- `boot_installs_policy_and_resolver_resolves_real_clearance` — the full boot chain end to end: compile a real grant, sign hybrid, verify-once-at-load, install → `compiled_policy().is_some()` and the enrollment resolver resolves a real clearance for an enrolled DID (Classical-floored per #698 Decision D), unenrolled DIDs still deny.
- `baseline_boot_policy_installs_empty_dormant_matrix` — the production empty baseline signs, verify-loads, and installs.
- `baseline_boot_flips_seam_on_but_still_denies_every_did` — seam-level "un-inert but dormant": after the baseline boot, `exchange_enrollment_resolver()` is the real enrollment resolver (seam flipped on) yet returns `None` for every DID (grants nothing).

All `mac::` lib tests pass; workspace clippy (pre-commit, mirrors CI) clean.