### PR TITLE
ci: fast test profile — stop ThinLTO-linking test binaries (fixes ~108min gate)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -120,9 +120,12 @@ jobs:
     needs: clippy  # Only build if clippy passes
     # Merge-gate backstop: fail before the merge queue's 120min timeout (ruleset
     # check_response_timeout_minutes) so a hang yields a definitive failure and the
-    # queue keeps moving instead of timing out and kicking every queued PR. Healthy
-    # build+test is ~90min (Build ~13m / Run tests ~76min), so 115 leaves margin.
-    timeout-minutes: 115
+    # queue keeps moving instead of timing out and kicking every queued PR. The
+    # nextest step uses the ci-test Cargo profile to avoid release ThinLTO on test
+    # binaries, so 90min should retain headroom while catching regressions.
+    timeout-minutes: 90
+    env:
+      SCCACHE_IDLE_TIMEOUT: 0
 
     steps:
     - uses: actions/checkout@v4
@@ -148,10 +151,10 @@ jobs:
     - name: Run tests (nextest, per-test timeout)
       # nextest enforces the per-TEST slow-timeout from .config/nextest.toml
       # ([profile.ci]): a single deadlocked test is SIGKILLed after ~3min and fails
-      # fast, instead of stalling the job until the 115min job / 120min queue
+      # fast, instead of stalling the job until the 90min job / 120min queue
       # timeout. The cap is per-test on purpose — the legit suite is long (~76min),
       # so a per-step timeout could not tell a hang from healthy runtime.
-      run: cargo nextest run --release --profile ci --features download-libtorch
+      run: cargo nextest run --cargo-profile ci-test --profile ci --features download-libtorch
 
     - name: Run doctests
       # nextest does not run doctests; keep them in the merge gate.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -303,6 +303,14 @@ lto = "thin"
 strip = true
 codegen-units = 4 # More threads needed for smaller RAM targets
 
+[profile.ci-test]
+inherits = "dev"
+lto = false
+opt-level = 1
+codegen-units = 16
+debug = 0
+incremental = false
+
 [workspace.lints.rust]
 # unsafe_code = "warn"  # Informational only, many FFI calls are necessary
 # rust_2018_idioms = { level = "warn", priority = -1 }  # Too noisy with lifetime parameters


### PR DESCRIPTION
## Summary

- add a dedicated `ci-test` Cargo profile inheriting from `dev`, with `lto = false`, `opt-level = 1`, `codegen-units = 16`, `debug = 0`, and `incremental = false`
- keep the merge-gate `cargo build --release` release-compilation validation
- switch the merge-gate nextest run from `--release` to `--cargo-profile ci-test`, so test binaries no longer build under release ThinLTO
- set `SCCACHE_IDLE_TIMEOUT=0` on the build job so sccache stats survive the long gate step
- reduce the build job cap from 115min to 90min now that the test-binary build avoids ThinLTO

## CI gate finding

The merge-gate timeout was dominated by compilation, not execution: `cargo nextest run --release` spent about 86 minutes compiling test binaries with release ThinLTO, while actual test execution was under 2 minutes. This should move the gate from roughly 108 minutes toward the expected 50-60 minute range by preserving release build validation while compiling nextest binaries with the lighter CI test profile.

## Verification

- `cargo nextest run --cargo-profile ci-test --no-run -p hyprstream-rpc`
- `OPENSSL_NO_VENDOR=1 LIBTORCH_USE_PYTORCH=1 LIBTORCH_BYPASS_VERSION_CHECK=1 cargo build -p hyprstream`
- pre-commit clippy hook passed during commit

Note: plain local `cargo build -p hyprstream` first hit host environment blockers unrelated to this change: vendored OpenSSL could not find Perl `FindBin.pm`, then libtorch was not configured. The same sanity build passed with this repo's established local OpenSSL/PyTorch environment overrides above.

Board: CI gate unblock.