### PR TITLE
fix(test): anchor ML-DSA-65 signer in policy_over_iroh (fixes deny-on-missing-anchor gate failure, #677 Fu2)

### DIFF
--- a/crates/hyprstream/tests/policy_over_iroh.rs
+++ b/crates/hyprstream/tests/policy_over_iroh.rs
@@ -28,27 +28,60 @@ use hyprstream_core::config::TokenConfig;
 use hyprstream_core::services::PolicyService;
 use hyprstream_core::services::generated::policy_client::{PolicyCheck, PolicyClient};
 
-use hyprstream_rpc::envelope::{install_verify_config, EnvelopeVerifyConfig, InMemoryNonceCache};
 use hyprstream_rpc::crypto::CryptoPolicy;
+use hyprstream_rpc::envelope::{
+    EnvelopeVerifyConfig, InMemoryNonceCache, KeyedPqTrustStore, PqTrustStore,
+    install_verify_config,
+};
+use hyprstream_rpc::node_identity::derive_mesh_mldsa_key;
 use hyprstream_rpc::rpc_client::RpcClientImpl;
 use hyprstream_rpc::signer::LocalSigner;
 use hyprstream_rpc::transport::TransportConfig;
 use hyprstream_rpc::transport::iroh_rpc::{IrohRpcProtocolHandler, LocalServiceBridge};
-use hyprstream_rpc::transport::iroh_substrate::{
-    ALPN_HYPRSTREAM_RPC, IrohSubstrate, NoopHandler,
-};
+use hyprstream_rpc::transport::iroh_substrate::{ALPN_HYPRSTREAM_RPC, IrohSubstrate, NoopHandler};
 use hyprstream_rpc::transport::iroh_transport::IrohTransport;
 
 use iroh::{EndpointAddr, TransportAddr};
+
+const SERVICE_SIGNING_SEED: [u8; 32] = [0x51; 32];
+const CLIENT_SIGNING_SEED: [u8; 32] = [0xC1; 32];
+
+fn policy_service_signing_key() -> SigningKey {
+    SigningKey::from_bytes(&SERVICE_SIGNING_SEED)
+}
+
+fn policy_client_signing_key() -> SigningKey {
+    SigningKey::from_bytes(&CLIENT_SIGNING_SEED)
+}
+
+fn bind_mesh_anchor(store: &mut KeyedPqTrustStore, signing_key: &SigningKey) {
+    let pq_signing_key = derive_mesh_mldsa_key(signing_key);
+    store.bind(
+        signing_key.verifying_key().to_bytes(),
+        &ml_dsa::Keypair::verifying_key(&pq_signing_key),
+    );
+}
+
+fn policy_pq_trust_store() -> Arc<dyn PqTrustStore> {
+    let mut store = KeyedPqTrustStore::new();
+    bind_mesh_anchor(&mut store, &policy_service_signing_key());
+    bind_mesh_anchor(&mut store, &policy_client_signing_key());
+    Arc::new(store)
+}
+
+fn install_hybrid_verify_config() -> Arc<dyn PqTrustStore> {
+    let pq_store = policy_pq_trust_store();
+    let _ = install_verify_config(EnvelopeVerifyConfig {
+        policy: CryptoPolicy::Hybrid,
+        pq_store: Some(Arc::clone(&pq_store)),
+    });
+    pq_store
+}
 
 fn fresh_node_key() -> [u8; 32] {
     let mut k = [0u8; 32];
     rand::thread_rng().fill_bytes(&mut k);
     k
-}
-
-fn fresh_signing_key() -> SigningKey {
-    SigningKey::from_bytes(&fresh_node_key())
 }
 
 fn direct_addr(substrate: &IrohSubstrate) -> EndpointAddr {
@@ -77,7 +110,7 @@ async fn make_policy_service() -> Result<(PolicyService, SigningKey, TempDir)> {
     // Git2DB::open initializes .registry as a git repo at this path.
     let git2db = Arc::new(RwLock::new(Git2DB::open(&models_dir).await?));
 
-    let signing_key = fresh_signing_key();
+    let signing_key = policy_service_signing_key();
     let service = PolicyService::new(
         policy_manager,
         Arc::new(signing_key.clone()),
@@ -113,6 +146,7 @@ async fn serve_over_iroh(
 async fn client_for(
     server_addr: EndpointAddr,
     server_vk: ed25519_dalek::VerifyingKey,
+    response_pq_store: Arc<dyn PqTrustStore>,
 ) -> Result<(IrohSubstrate, PolicyClient)> {
     let client_substrate = IrohSubstrate::new(
         fresh_node_key(),
@@ -125,7 +159,12 @@ async fn client_for(
         .connect(server_addr, ALPN_HYPRSTREAM_RPC)
         .await?;
     let transport = IrohTransport::new(conn);
-    let rpc = RpcClientImpl::new(LocalSigner::new(fresh_signing_key()), transport, Some(server_vk));
+    let rpc = RpcClientImpl::new(
+        LocalSigner::new(policy_client_signing_key()),
+        transport,
+        Some(server_vk),
+    )
+    .with_response_pq_store(response_pq_store);
     let policy_client = PolicyClient::new(Arc::new(rpc));
     Ok((client_substrate, policy_client))
 }
@@ -135,18 +174,13 @@ async fn client_for(
 /// produced by the bootstrap `SERVICE_BASE_POLICIES`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn policy_check_allow_and_deny_over_iroh() -> Result<()> {
-    // Opt in to Classical so the test is order-independent w.r.t. process-global
-    // verify config; fail-close default is Hybrid which requires PQ keys.
-    let _ = install_verify_config(EnvelopeVerifyConfig {
-        policy: CryptoPolicy::Classical,
-        pq_store: None,
-    });
+    let pq_store = install_hybrid_verify_config();
 
     let (service, server_signing, _temp) = make_policy_service().await?;
     let server_vk = server_signing.verifying_key();
 
     let (server, server_addr) = serve_over_iroh(service, server_signing).await?;
-    let (client_substrate, policy) = client_for(server_addr, server_vk).await?;
+    let (client_substrate, policy) = client_for(server_addr, server_vk, pq_store).await?;
 
     // ALLOW: service:oauth → policy:ResolveServiceKey:query (from
     // SERVICE_BASE_POLICIES, asserted in policy_manager.rs base-rules test).
@@ -181,11 +215,13 @@ async fn policy_check_allow_and_deny_over_iroh() -> Result<()> {
 /// holds under a real service's response shape.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn policy_concurrent_checks_over_iroh() -> Result<()> {
+    let pq_store = install_hybrid_verify_config();
+
     let (service, server_signing, _temp) = make_policy_service().await?;
     let server_vk = server_signing.verifying_key();
 
     let (server, server_addr) = serve_over_iroh(service, server_signing).await?;
-    let (client_substrate, policy) = client_for(server_addr, server_vk).await?;
+    let (client_substrate, policy) = client_for(server_addr, server_vk, pq_store).await?;
     let policy = Arc::new(policy);
 
     // Cases chosen so wildcard base rules don't interfere:


### PR DESCRIPTION
## Summary
- replace the Classical policy dodge in `policy_over_iroh` with fixed test service/client Ed25519 identities anchored to their derived mesh ML-DSA-65 keys
- install a Hybrid request verifier store containing both anchors and pass the same store to client-side Hybrid response verification
- keep the iroh dial path direct; this fixes the deterministic #677 Fu2 deny-on-missing-anchor failure rather than masking it as a timing issue

## Validation
- `OPENSSL_NO_VENDOR=1 LIBTORCH_USE_PYTORCH=1 LIBTORCH_BYPASS_VERSION_CHECK=1 LD_LIBRARY_PATH=/home/birdetta/.local/lib/python3.14/site-packages/torch/lib:${LD_LIBRARY_PATH:-} cargo nextest run -p hyprstream policy_concurrent_checks_over_iroh`
- repeated `policy_concurrent_checks_over_iroh` 5x, all passed
- `OPENSSL_NO_VENDOR=1 LIBTORCH_USE_PYTORCH=1 LIBTORCH_BYPASS_VERSION_CHECK=1 LD_LIBRARY_PATH=/home/birdetta/.local/lib/python3.14/site-packages/torch/lib:${LD_LIBRARY_PATH:-} cargo nextest run -p hyprstream policy_` (41 passed)
- foreground commit hook clippy passed

Review: fable (crypto-policy path)