### PR TITLE
chore(pds): at9p/DAG-CBOR encode-side hardening (#934)

### DIFF
--- a/crates/hyprstream-discovery/src/at9p_alias.rs
+++ b/crates/hyprstream-discovery/src/at9p_alias.rs
@@ -135,7 +135,7 @@ mod tests {
             body.also_known_as = Some(aliases);
         }
         let capsule = sign_capsule(body, &s.ed_sk, &s.pq_sk).unwrap();
-        let bytes = capsule.to_dag_cbor();
+        let bytes = capsule.to_dag_cbor().unwrap();
         let did = format!("did:at9p:{}", capsule.cid512().unwrap());
         (bytes, did)
     }

--- a/crates/hyprstream-discovery/src/at9p_resolver.rs
+++ b/crates/hyprstream-discovery/src/at9p_resolver.rs
@@ -242,7 +242,7 @@ mod tests {
         let s = signer(tag);
         let body = body_with_services(&s, tag);
         let capsule = sign_capsule(body, &s.ed_sk, &s.pq_sk).unwrap();
-        let bytes = capsule.to_dag_cbor();
+        let bytes = capsule.to_dag_cbor().unwrap();
         let cid = capsule.cid512().unwrap();
         let did = format!("{DID_AT9P_PREFIX}{cid}");
         (capsule, bytes, cid, did)

--- a/crates/hyprstream-pds/src/at9p.rs
+++ b/crates/hyprstream-pds/src/at9p.rs
@@ -440,9 +440,12 @@ impl CapsuleBody {
     ///
     /// This is the signed payload for an at9p capsule: the composite signature
     /// (see [`crate::at9p_sign`]) covers exactly these bytes, never the
-    /// enclosing `signatures` field.
-    pub fn to_dag_cbor(&self) -> Vec<u8> {
-        self.to_value().encode()
+    /// enclosing `signatures` field. Validates the body first so a record whose
+    /// pub fields were mutated after construction cannot emit (or get signed
+    /// over) bytes the decode side would reject.
+    pub fn to_dag_cbor(&self) -> Result<Vec<u8>> {
+        self.validate()?;
+        Ok(self.to_value().encode())
     }
 
     pub fn validate(&self) -> Result<()> {
@@ -458,6 +461,12 @@ impl CapsuleBody {
         for key in &self.subject_keys {
             key.validate()?;
         }
+        // next_key_commitments MAY be empty (#879 §5.3: a declared-immutable
+        // identity with rotation frozen forever), but two identical commitments
+        // are meaningless (the same next key pre-committed twice) and would
+        // only waste bytes / invite ambiguity in key selection. Reject
+        // duplicates; each 64B entry is already length-checked on decode.
+        validate_unique_digests(&self.next_key_commitments, "nextKeyCommitments")?;
         ensure!(
             !self.services.is_empty(),
             "capsule services must not be empty"
@@ -617,8 +626,18 @@ impl Capsule {
         Ok(Self { body, signatures })
     }
 
-    pub fn to_dag_cbor(&self) -> Vec<u8> {
-        self.to_value().encode()
+    /// Validate the capsule (body + signature context binding) — the encode/
+    /// decode trust boundary. Public so holders of a `Capsule` built via struct
+    /// literal can check it before emitting bytes.
+    pub fn validate(&self) -> Result<()> {
+        self.body.validate()?;
+        self.signatures.ensure_context(CAPSULE_SIGNATURE_CONTEXT)?;
+        Ok(())
+    }
+
+    pub fn to_dag_cbor(&self) -> Result<Vec<u8>> {
+        self.validate()?;
+        Ok(self.to_value().encode())
     }
 
     pub fn from_dag_cbor(bytes: &[u8]) -> Result<Self> {
@@ -626,7 +645,7 @@ impl Capsule {
     }
 
     pub fn cid512(&self) -> Result<String> {
-        at9p_capsule_cid512(&self.to_dag_cbor())
+        at9p_capsule_cid512(&self.to_dag_cbor()?)
     }
 
     fn to_value(&self) -> DagCbor {
@@ -656,7 +675,39 @@ pub struct UpdateRecord {
 }
 
 impl UpdateRecord {
-    pub fn to_dag_cbor(&self) -> Vec<u8> {
+    /// Validating constructor — the encode/decode trust boundary. Prefer this
+    /// over struct-literal construction so an invalid record is caught at the
+    /// call site rather than at [`Self::to_dag_cbor`] / [`Self::signable_bytes`].
+    pub fn new(
+        subject_cid512: String,
+        epoch: u64,
+        prev_record_digest: [u8; H512_LEN],
+        new_capsule_body: CapsuleBody,
+        expires_at: String,
+        signatures: CoseCompositeSignature,
+    ) -> Result<Self> {
+        let record = Self {
+            subject_cid512,
+            epoch,
+            prev_record_digest,
+            new_capsule_body,
+            expires_at,
+            signatures,
+        };
+        record.validate()?;
+        Ok(record)
+    }
+
+    pub fn to_dag_cbor(&self) -> Result<Vec<u8>> {
+        self.validate()?;
+        Ok(self.to_value().encode())
+    }
+
+    /// Serialize without re-validating. For crate-internal digest/state
+    /// projection (chain watermark, duplicity digest) over records already known
+    /// to be valid — they reached here via [`Self::from_dag_cbor`] (validated)
+    /// or the signing path. External callers must use [`Self::to_dag_cbor`].
+    pub(crate) fn encode_value(&self) -> Vec<u8> {
         self.to_value().encode()
     }
 
@@ -666,9 +717,11 @@ impl UpdateRecord {
 
     /// Canonical DAG-CBOR bytes of the update record *without* its `signatures`
     /// field — the payload the composite signature covers (see
-    /// [`crate::at9p_sign`]).
-    pub fn signable_bytes(&self) -> Vec<u8> {
-        self.signable_value().encode()
+    /// [`crate::at9p_sign`]). Validates the signed content (cid, datetime,
+    /// capsule body); the signature itself is excluded by definition.
+    pub fn signable_bytes(&self) -> Result<Vec<u8>> {
+        self.validate_content()?;
+        Ok(self.signable_value().encode())
     }
 
     fn signable_value(&self) -> DagCbor {
@@ -684,10 +737,19 @@ impl UpdateRecord {
         ])
     }
 
-    fn validate(&self) -> Result<()> {
+    /// Validate the signed content (everything the signature covers) — cid,
+    /// datetime, and the new capsule body. Excludes the signature itself.
+    fn validate_content(&self) -> Result<()> {
         validate_cid512(&self.subject_cid512)?;
         validate_datetime(&self.expires_at)?;
         self.new_capsule_body.validate()?;
+        Ok(())
+    }
+
+    /// Full validation: content plus the signature-context binding. The
+    /// encode/decode trust boundary.
+    pub fn validate(&self) -> Result<()> {
+        self.validate_content()?;
         self.signatures.ensure_context(UPDATE_SIGNATURE_CONTEXT)?;
         Ok(())
     }
@@ -788,15 +850,38 @@ pub struct Manifest {
 }
 
 impl Manifest {
-    pub fn to_dag_cbor(&self) -> Vec<u8> {
-        self.to_value().encode()
+    /// Validating constructor — the encode/decode trust boundary. Prefer this
+    /// over struct-literal construction so an invalid manifest (e.g. mismatched
+    /// `totalLen`, non-contiguous shards, wrong signature context) is caught at
+    /// the call site rather than at [`Self::to_dag_cbor`].
+    pub fn new(
+        subject_cid512: String,
+        codec: String,
+        total_len: u64,
+        shards: Vec<ShardEntry>,
+        signatures: CoseCompositeSignature,
+    ) -> Result<Self> {
+        let manifest = Self {
+            subject_cid512,
+            codec,
+            total_len,
+            shards,
+            signatures,
+        };
+        manifest.validate()?;
+        Ok(manifest)
+    }
+
+    pub fn to_dag_cbor(&self) -> Result<Vec<u8>> {
+        self.validate()?;
+        Ok(self.to_value().encode())
     }
 
     pub fn from_dag_cbor(bytes: &[u8]) -> Result<Self> {
         Self::from_value(&decode_canonical(bytes, "at9p manifest")?)
     }
 
-    fn validate(&self) -> Result<()> {
+    pub fn validate(&self) -> Result<()> {
         validate_cid512(&self.subject_cid512)?;
         validate_nonempty_no_ws(&self.codec, "manifest codec")?;
         ensure!(!self.shards.is_empty(), "manifest shards must not be empty");
@@ -872,13 +957,30 @@ pub struct Shard {
 }
 
 impl Shard {
-    pub fn to_dag_cbor(&self) -> Vec<u8> {
-        DagCbor::str_map([
+    /// Validating constructor — the encode/decode trust boundary.
+    pub fn new(subject_cid512: String, index: u64, shard_bytes: Vec<u8>) -> Result<Self> {
+        let shard = Self {
+            subject_cid512,
+            index,
+            shard_bytes,
+        };
+        shard.validate()?;
+        Ok(shard)
+    }
+
+    /// Validate the shard's `subjectCid512` (the only field-level invariant).
+    pub fn validate(&self) -> Result<()> {
+        validate_cid512(&self.subject_cid512)
+    }
+
+    pub fn to_dag_cbor(&self) -> Result<Vec<u8>> {
+        self.validate()?;
+        Ok(DagCbor::str_map([
             ("index", DagCbor::Unsigned(self.index)),
             ("shardBytes", DagCbor::Bytes(self.shard_bytes.clone())),
             ("subjectCid512", DagCbor::Text(self.subject_cid512.clone())),
         ])
-        .encode()
+        .encode())
     }
 
     pub fn from_dag_cbor(bytes: &[u8]) -> Result<Self> {
@@ -1028,18 +1130,99 @@ fn validate_did_or_endpoint(s: &str, field: &str) -> Result<()> {
     Ok(())
 }
 
+/// Strict ISO-8601 UTC datetime validator for at9p `expires-at` fields.
+///
+/// Accepts exactly `YYYY-MM-DDTHH:MM:SSZ` (20 chars, no fractional seconds,
+/// `Z` zone designator). Unlike a separator-only check, this validates the
+/// calendar fields — month 1..=12, day 1..=days-in-month (leap-aware), hour
+/// 0..=23, minute/second 0..=59 (no leap-second `60`), year 0001..=9999 — so
+/// nonsense like `0000-00-00T00:00:60Z` is rejected instead of passing. This
+/// is the freshness-gate input for rotation records (#883/#879 §7.2); a loose
+/// check would let a nonsensical `expires-at` reach the wire and the rollback
+/// bound.
 fn validate_datetime(s: &str) -> Result<()> {
-    ensure!(s.ends_with('Z'), "datetime must end with 'Z': {s:?}");
-    ensure!(s.len() >= 20, "datetime too short: {s:?}");
+    const EXPECTED_LEN: usize = 20; // YYYY-MM-DDTHH:MM:SSZ
     ensure!(
-        s.as_bytes().get(4) == Some(&b'-')
-            && s.as_bytes().get(7) == Some(&b'-')
-            && s.as_bytes().get(10) == Some(&b'T')
-            && s.as_bytes().get(13) == Some(&b':')
-            && s.as_bytes().get(16) == Some(&b':'),
-        "datetime must be ISO-8601 UTC: {s:?}"
+        s.len() == EXPECTED_LEN,
+        "datetime must be {EXPECTED_LEN} chars (YYYY-MM-DDTHH:MM:SSZ): {s:?}"
+    );
+    let b = s.as_bytes();
+    ensure!(
+        b[4] == b'-'
+            && b[7] == b'-'
+            && b[10] == b'T'
+            && b[13] == b':'
+            && b[16] == b':'
+            && b[19] == b'Z',
+        "datetime must be ISO-8601 UTC (YYYY-MM-DDTHH:MM:SSZ): {s:?}"
+    );
+    let year = four_digit_field(&b[0..4], s, "year")?;
+    let month = two_digit_field(&b[5..7], s, "month")?;
+    let day = two_digit_field(&b[8..10], s, "day")?;
+    let hour = two_digit_field(&b[11..13], s, "hour")?;
+    let minute = two_digit_field(&b[14..16], s, "minute")?;
+    let second = two_digit_field(&b[17..19], s, "second")?;
+    ensure!(
+        (1..=9999).contains(&year),
+        "datetime year out of range 0001..=9999: {s:?}"
+    );
+    ensure!(
+        (1..=12).contains(&month),
+        "datetime month out of range 1..=12: {s:?}"
+    );
+    let max_day = days_in_month(year, month);
+    ensure!(
+        (1..=max_day).contains(&day),
+        "datetime day out of range 1..={max_day} for {year}-{month:02}: {s:?}"
+    );
+    ensure!(hour <= 23, "datetime hour out of range 0..=23: {s:?}");
+    ensure!(minute <= 59, "datetime minute out of range 0..=59: {s:?}");
+    ensure!(
+        second <= 59,
+        "datetime second out of range 0..=59 (no leap seconds): {s:?}"
     );
     Ok(())
+}
+
+/// Parse a fixed 2-digit decimal field, requiring both bytes to be ASCII
+/// digits; returns the value or a datetime-shaped error.
+fn two_digit_field(g: &[u8], s: &str, name: &str) -> Result<u32> {
+    ensure!(
+        g.len() == 2 && g[0].is_ascii_digit() && g[1].is_ascii_digit(),
+        "datetime {name} must be two decimal digits: {s:?}"
+    );
+    Ok((g[0] - b'0') as u32 * 10 + (g[1] - b'0') as u32)
+}
+
+/// Parse a fixed 4-digit decimal field (the year).
+fn four_digit_field(g: &[u8], s: &str, name: &str) -> Result<u32> {
+    ensure!(
+        g.len() == 4 && g.iter().all(u8::is_ascii_digit),
+        "datetime {name} must be four decimal digits: {s:?}"
+    );
+    let mut v = 0u32;
+    for &c in g {
+        v = v * 10 + (c - b'0') as u32;
+    }
+    Ok(v)
+}
+
+/// Proleptic Gregorian leap-year test.
+fn is_leap_year(year: u32) -> bool {
+    year.is_multiple_of(4) && !year.is_multiple_of(100) || year.is_multiple_of(400)
+}
+
+/// Days in a Gregorian month, leap-year aware. `month` is validated 1..=12 by
+/// the caller; any other value is not a real calendar month and yields `0`
+/// (the day-range check in [`validate_datetime`] then rejects it).
+fn days_in_month(year: u32, month: u32) -> u32 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if is_leap_year(year) => 29,
+        2 => 28,
+        _ => 0,
+    }
 }
 
 fn validate_cid512(s: &str) -> Result<()> {
@@ -1091,6 +1274,16 @@ fn validate_classical_did_list(values: &[String], field: &str) -> Result<()> {
             "{field} entry {value:?} must be a classical DID alias \
              (did:web, did:key, or did:plc)"
         );
+    }
+    Ok(())
+}
+
+/// Reject duplicate `H512` digests. The list may be empty (no iteration), but
+/// two equal digests are a meaningless repeat — used for `next_key_commitments`.
+fn validate_unique_digests(digests: &[[u8; H512_LEN]], field: &str) -> Result<()> {
+    let mut seen = BTreeSet::new();
+    for digest in digests {
+        ensure!(seen.insert(digest.as_slice()), "duplicate {field} entry");
     }
     Ok(())
 }
@@ -1177,10 +1370,10 @@ mod tests {
     proptest! {
         #[test]
         fn capsule_round_trip_is_byte_stable(capsule in arb_capsule()) {
-            let bytes = capsule.to_dag_cbor();
+            let bytes = capsule.to_dag_cbor().unwrap();
             let decoded = Capsule::from_dag_cbor(&bytes).unwrap();
             prop_assert_eq!(&decoded, &capsule);
-            prop_assert_eq!(decoded.to_dag_cbor(), bytes);
+            prop_assert_eq!(decoded.to_dag_cbor().unwrap(), bytes);
             prop_assert!(decoded.cid512().unwrap().starts_with('b'));
         }
 
@@ -1195,10 +1388,10 @@ mod tests {
                 expires_at: "2026-07-08T12:00:00Z".to_owned(),
                 signatures: signature(UPDATE_SIGNATURE_CONTEXT, 7),
             };
-            let bytes = record.to_dag_cbor();
+            let bytes = record.to_dag_cbor().unwrap();
             let decoded = UpdateRecord::from_dag_cbor(&bytes).unwrap();
             prop_assert_eq!(&decoded, &record);
-            prop_assert_eq!(decoded.to_dag_cbor(), bytes);
+            prop_assert_eq!(decoded.to_dag_cbor().unwrap(), bytes);
         }
 
         #[test]
@@ -1214,16 +1407,16 @@ mod tests {
                 }],
                 signatures: signature(MANIFEST_SIGNATURE_CONTEXT, 10),
             };
-            let bytes = manifest.to_dag_cbor();
+            let bytes = manifest.to_dag_cbor().unwrap();
             let decoded = Manifest::from_dag_cbor(&bytes).unwrap();
             prop_assert_eq!(&decoded, &manifest);
-            prop_assert_eq!(decoded.to_dag_cbor(), bytes);
+            prop_assert_eq!(decoded.to_dag_cbor().unwrap(), bytes);
         }
     }
 
     #[test]
     fn capsule_rejects_unsorted_map_keys() {
-        let good = sample_capsule(1).to_dag_cbor();
+        let good = sample_capsule(1).to_dag_cbor().unwrap();
         let decoded = DagCbor::decode(&good).unwrap();
         let DagCbor::Map(mut pairs) = decoded else {
             panic!("capsule must encode as map");
@@ -1264,7 +1457,7 @@ mod tests {
             expires_at: "2026-07-08T12:00:00Z".to_owned(),
             signatures: signature(UPDATE_SIGNATURE_CONTEXT, 8),
         };
-        let mut bad = record.to_dag_cbor();
+        let mut bad = record.to_dag_cbor().unwrap();
         let pos = bad
             .windows(5)
             .position(|w| w == b"epoch")
@@ -1297,10 +1490,10 @@ mod tests {
             ]
         );
         // Byte-stable canonical round-trip carries alsoKnownAs.
-        let bytes = capsule.to_dag_cbor();
+        let bytes = capsule.to_dag_cbor().unwrap();
         let decoded = Capsule::from_dag_cbor(&bytes).unwrap();
         assert_eq!(&decoded, &capsule);
-        assert_eq!(decoded.to_dag_cbor(), bytes);
+        assert_eq!(decoded.to_dag_cbor().unwrap(), bytes);
     }
 
     #[test]
@@ -1329,6 +1522,144 @@ mod tests {
         body.also_known_as = Some(vec!["did:web:clean.example".to_owned()]);
         assert!(body.validate().is_ok());
         body.also_known_as = Some(vec!["did:plc:clean".to_owned()]);
+        assert!(body.validate().is_ok());
+    }
+
+    /// Issue #934 (validate-on-encode): pub fields allow post-construction
+    /// mutation, so encode must re-validate and fail closed rather than emit
+    /// (or sign over / cid) bytes the decode side would reject.
+    #[test]
+    fn encode_rejects_post_construction_mutation() {
+        let mut capsule = sample_capsule(1);
+        capsule.body.subject_keys.clear(); // now invalid (empty subject keys)
+        assert!(capsule.body.to_dag_cbor().is_err());
+        assert!(
+            capsule.to_dag_cbor().is_err(),
+            "capsule encode must validate"
+        );
+        assert!(capsule.cid512().is_err(), "cid512 must validate");
+
+        // A record whose signature context was swapped still encodes its bytes
+        // fine for content, but a fully-mutated invalid body fails signable too.
+        let capsule2 = sample_capsule(2);
+        let mut record = UpdateRecord {
+            subject_cid512: capsule2.cid512().unwrap(),
+            epoch: 0,
+            prev_record_digest: digest(1),
+            new_capsule_body: capsule2.body.clone(),
+            expires_at: "2026-07-08T12:00:00Z".to_owned(),
+            signatures: signature(UPDATE_SIGNATURE_CONTEXT, 3),
+        };
+        assert!(record.signable_bytes().is_ok(), "valid content encodes");
+        assert!(record.to_dag_cbor().is_ok(), "valid record encodes");
+        record.new_capsule_body.subject_keys.clear();
+        assert!(record.signable_bytes().is_err(), "invalid content rejected");
+        assert!(record.to_dag_cbor().is_err());
+    }
+
+    /// Issue #934 (validating constructors): the new `new()` constructors close
+    /// the "no validating constructor" gap for UpdateRecord/Manifest/Shard.
+    #[test]
+    fn validating_constructors_reject_invalid() {
+        let capsule = sample_capsule(1);
+        let cid = capsule.cid512().unwrap();
+
+        // UpdateRecord::new rejects a bad datetime.
+        assert!(UpdateRecord::new(
+            cid.clone(),
+            0,
+            digest(1),
+            capsule.body.clone(),
+            "0000-00-00T00:00:60Z".to_owned(),
+            signature(UPDATE_SIGNATURE_CONTEXT, 2),
+        )
+        .is_err());
+
+        // Manifest::new rejects a mismatched totalLen (shard sum is 10, not 999).
+        assert!(Manifest::new(
+            cid.clone(),
+            "dag-cbor".to_owned(),
+            999,
+            vec![ShardEntry {
+                index: 0,
+                shard_len: 10,
+                shard_digest: digest(9),
+            }],
+            signature(MANIFEST_SIGNATURE_CONTEXT, 1),
+        )
+        .is_err());
+
+        // Shard::new rejects a malformed subjectCid512.
+        assert!(Shard::new("not-a-cid".to_owned(), 0, vec![0u8; 4]).is_err());
+        // ... and accepts a valid one.
+        assert!(Shard::new(cid.clone(), 0, vec![0u8; 4]).is_ok());
+    }
+
+    /// Issue #934 (datetime tightening): the old validator only checked
+    /// separator positions, letting nonsense like `0000-00-00T00:00:60Z`
+    /// through. Validate the actual calendar fields.
+    #[test]
+    fn validate_datetime_is_strict_iso8601_utc() {
+        fn check(expires: &str) -> Result<()> {
+            let capsule = sample_capsule(1);
+            UpdateRecord {
+                subject_cid512: capsule.cid512().unwrap(),
+                epoch: 0,
+                prev_record_digest: digest(1),
+                new_capsule_body: capsule.body,
+                expires_at: expires.to_owned(),
+                signatures: signature(UPDATE_SIGNATURE_CONTEXT, 2),
+            }
+            .validate()
+        }
+        // The exact nonsense the old separator-only check let through.
+        assert!(check("0000-00-00T00:00:60Z").is_err());
+        // Leap second 60.
+        assert!(check("2026-07-08T12:00:60Z").is_err());
+        // Month 13 / day 0 / hour 24.
+        assert!(check("2026-13-08T12:00:00Z").is_err());
+        assert!(check("2026-07-00T12:00:00Z").is_err());
+        assert!(check("2026-07-08T24:00:00Z").is_err());
+        // Minute / second 60.
+        assert!(check("2026-07-08T12:60:00Z").is_err());
+        // Fractional seconds (wrong length / not the Z-terminated 20-char form).
+        assert!(check("2026-07-08T12:00:00.5Z").is_err());
+        // Feb 29 in a non-leap year.
+        assert!(check("2023-02-29T00:00:00Z").is_err());
+        // Day 32.
+        assert!(check("2026-07-32T12:00:00Z").is_err());
+        // Wrong length (too short).
+        assert!(check("2026-07-08T12:00Z").is_err());
+        // Non-UTC zone designator.
+        assert!(check("2026-07-08T12:00:00+00:00").is_err());
+
+        // Valid values still pass — including a leap day and far-future dates.
+        assert!(check("2026-07-08T12:00:00Z").is_ok());
+        assert!(check("2024-02-29T00:00:00Z").is_ok()); // 2024 is a leap year
+        assert!(check("2099-01-01T00:00:00Z").is_ok());
+        assert!(check("2023-02-28T23:59:59Z").is_ok());
+    }
+
+    /// Issue #934 (next_key_commitments): MAY be empty (#879 §5.3
+    /// declared-immutable), but duplicate commitments are a meaningless repeat
+    /// and must be rejected.
+    #[test]
+    fn next_key_commitments_empty_ok_duplicates_rejected() {
+        let mut body = CapsuleBody::new(
+            vec![key(1)],
+            vec![service("#ns".to_owned(), ServiceType::NinePExport, 1)],
+        )
+        .unwrap();
+        // Empty is allowed (declared-immutable identity).
+        assert!(body.validate().is_ok());
+        // A single commitment is fine.
+        body.next_key_commitments = vec![digest(5)];
+        assert!(body.validate().is_ok());
+        // Two identical commitments are rejected.
+        body.next_key_commitments = vec![digest(5), digest(5)];
+        assert!(body.validate().is_err());
+        // Two distinct commitments are fine.
+        body.next_key_commitments = vec![digest(5), digest(6)];
         assert!(body.validate().is_ok());
     }
 }

--- a/crates/hyprstream-pds/src/at9p_alias.rs
+++ b/crates/hyprstream-pds/src/at9p_alias.rs
@@ -200,7 +200,7 @@ mod tests {
             body.also_known_as = Some(aliases);
         }
         let capsule = sign_capsule(body, &s.ed_sk, &s.pq_sk).unwrap();
-        let bytes = capsule.to_dag_cbor();
+        let bytes = capsule.to_dag_cbor().unwrap();
         let did = format!("did:at9p:{}", capsule.cid512().unwrap());
         let verified = verify_did_at9p(&did, &bytes).unwrap();
         (verified, did)

--- a/crates/hyprstream-pds/src/at9p_chain.rs
+++ b/crates/hyprstream-pds/src/at9p_chain.rs
@@ -91,7 +91,7 @@ impl ChainState {
         Ok(Self {
             subject_cid512: capsule.cid512()?,
             epoch: 0,
-            record_digest: h512(&capsule.to_dag_cbor()),
+            record_digest: h512(&capsule.to_dag_cbor()?),
             next_key_commitments: capsule.body.next_key_commitments.clone(),
         })
     }
@@ -104,7 +104,10 @@ impl ChainState {
         Self {
             subject_cid512: record.subject_cid512.clone(),
             epoch: record.epoch,
-            record_digest: h512(&record.to_dag_cbor()),
+            // Already validated by contract; use the unchecked serializer so
+            // this infallible projector stays infallible (a record that
+            // reached here came from `from_dag_cbor` or the signing path).
+            record_digest: h512(&record.encode_value()),
             next_key_commitments: record.new_capsule_body.next_key_commitments.clone(),
         }
     }
@@ -480,7 +483,7 @@ mod tests {
         let next_state = validate_successor(&gen_state, &rec, "2026-07-09T00:00:00Z")
             .expect("valid successor must be accepted");
         assert_eq!(next_state.epoch, 1);
-        assert_eq!(next_state.record_digest, h512(&rec.to_dag_cbor()));
+        assert_eq!(next_state.record_digest, h512(&rec.to_dag_cbor().unwrap()));
         assert_eq!(next_state.subject_cid512, gen_state.subject_cid512);
     }
 

--- a/crates/hyprstream-pds/src/at9p_duplicity.rs
+++ b/crates/hyprstream-pds/src/at9p_duplicity.rs
@@ -600,7 +600,9 @@ impl<S: WatermarkStore, A: DuplicityAlarmSink> DuplicityGuard<S, A> {
 /// `record_digest`. Exposed so callers reconstructing a watermark from a
 /// persisted record (e.g. on restart) key it the same way the guard does.
 pub fn record_digest(record: &UpdateRecord) -> [u8; H512_LEN] {
-    h512(&record.to_dag_cbor())
+    // Input is a validated record (decoded or signed); use the unchecked
+    // serializer to keep this infallible — `to_dag_cbor` would re-validate.
+    h512(&record.encode_value())
 }
 
 #[cfg(test)]

--- a/crates/hyprstream-pds/src/at9p_gate.rs
+++ b/crates/hyprstream-pds/src/at9p_gate.rs
@@ -293,7 +293,7 @@ mod tests {
         let s = signer(tag);
         let body = body_for(&s, tag);
         let capsule = sign_capsule(body, &s.ed_sk, &s.pq_sk).unwrap();
-        let bytes = capsule.to_dag_cbor();
+        let bytes = capsule.to_dag_cbor().unwrap();
         let cid = capsule.cid512().unwrap();
         (capsule, bytes, cid)
     }
@@ -391,7 +391,7 @@ mod tests {
         // Corrupt the ed25519 signature but keep it schema-valid (same length).
         let mut broken = capsule.clone();
         broken.signatures.ed25519_signature = vec![0u8; ED25519_SIGNATURE_LEN];
-        let bytes = broken.to_dag_cbor();
+        let bytes = broken.to_dag_cbor().unwrap();
         // The tampered capsule is still canonical & schema-valid.
         let reparsed = Capsule::from_dag_cbor(&bytes).expect("still canonical");
         let cid = reparsed.cid512().unwrap();

--- a/crates/hyprstream-pds/src/at9p_resolver.rs
+++ b/crates/hyprstream-pds/src/at9p_resolver.rs
@@ -132,7 +132,7 @@ mod tests {
         let s = signer(tag);
         let body = body_for(&s, tag);
         let capsule = sign_capsule(body, &s.ed_sk, &s.pq_sk).unwrap();
-        let bytes = capsule.to_dag_cbor();
+        let bytes = capsule.to_dag_cbor().unwrap();
         let did = format!("{DID_AT9P_PREFIX}{}", capsule.cid512().unwrap());
         (capsule, bytes, did)
     }
@@ -162,7 +162,7 @@ mod tests {
         // can reject.
         let (mut capsule, _bytes, _did) = signed(2);
         capsule.signatures.ed25519_signature = vec![0u8; ED25519_SIGNATURE_LEN];
-        let bytes = capsule.to_dag_cbor();
+        let bytes = capsule.to_dag_cbor().unwrap();
         let cid = Capsule::from_dag_cbor(&bytes).unwrap().cid512().unwrap();
         let did = format!("{DID_AT9P_PREFIX}{cid}");
         assert!(At9pGateResolver::new().verify_bytes(&did, &bytes).is_err());
@@ -217,7 +217,7 @@ mod tests {
         // is bound into the trust store.
         let (mut capsule, _bytes, _did) = signed(6);
         capsule.signatures.ed25519_signature = vec![0u8; ED25519_SIGNATURE_LEN];
-        let bytes = capsule.to_dag_cbor();
+        let bytes = capsule.to_dag_cbor().unwrap();
         let cid = Capsule::from_dag_cbor(&bytes).unwrap().cid512().unwrap();
         let did = format!("{DID_AT9P_PREFIX}{cid}");
         let ed: [u8; 32] = capsule.body.subject_keys[0].ed25519_pub.as_slice().try_into().unwrap();

--- a/crates/hyprstream-pds/src/at9p_sign.rs
+++ b/crates/hyprstream-pds/src/at9p_sign.rs
@@ -201,7 +201,7 @@ pub fn sign_capsule(
         "signing ML-DSA-65 key does not match the capsule primary subject key"
     );
 
-    let payload = body.to_dag_cbor();
+    let payload = body.to_dag_cbor()?;
     let signatures = sign_record(&payload, CAPSULE_SIGNATURE_CONTEXT, ed_sk, pq_sk)?;
     Capsule::new(body, signatures)
 }
@@ -216,8 +216,9 @@ pub fn verify_capsule(capsule: &Capsule) -> Result<()> {
         .first()
         .ok_or_else(|| anyhow::anyhow!("capsule has no subject keys"))?;
     let (ed_vk, pq_vk) = verifying_keys(primary)?;
+    let payload = capsule.body.to_dag_cbor()?;
     verify_record(
-        &capsule.body.to_dag_cbor(),
+        &payload,
         &capsule.signatures,
         CAPSULE_SIGNATURE_CONTEXT,
         &ed_vk,
@@ -259,10 +260,10 @@ pub fn sign_update_record(
         expires_at,
         signatures: placeholder,
     };
-    let payload = record.signable_bytes();
+    let payload = record.signable_bytes()?;
     record.signatures = sign_record(&payload, UPDATE_SIGNATURE_CONTEXT, ed_sk, pq_sk)?;
     // Round-trip through the canonical codec to enforce every schema gate.
-    UpdateRecord::from_dag_cbor(&record.to_dag_cbor())
+    UpdateRecord::from_dag_cbor(&record.to_dag_cbor()?)
 }
 
 /// Verify an [`UpdateRecord`] under PINNED Hybrid policy against the authorizing
@@ -270,8 +271,9 @@ pub fn sign_update_record(
 /// key is authorized; this function enforces the crypto + context binding.
 pub fn verify_update_record(record: &UpdateRecord, signer: &HybridKeyPair) -> Result<()> {
     let (ed_vk, pq_vk) = verifying_keys(signer)?;
+    let payload = record.signable_bytes()?;
     verify_record(
-        &record.signable_bytes(),
+        &payload,
         &record.signatures,
         UPDATE_SIGNATURE_CONTEXT,
         &ed_vk,
@@ -330,7 +332,7 @@ mod tests {
             body.clone(),
             // any valid-shaped signature just to derive a cid for the field
             sign_record(
-                &body.to_dag_cbor(),
+                &body.to_dag_cbor().unwrap(),
                 CAPSULE_SIGNATURE_CONTEXT,
                 &s.ed_sk,
                 &s.pq_sk,
@@ -357,7 +359,7 @@ mod tests {
         let (_s, capsule) = signed_capsule();
         verify_capsule(&capsule).expect("capsule must verify");
         // Survives a canonical encode/decode round-trip.
-        let bytes = capsule.to_dag_cbor();
+        let bytes = capsule.to_dag_cbor().unwrap();
         let decoded = Capsule::from_dag_cbor(&bytes).unwrap();
         verify_capsule(&decoded).expect("decoded capsule must verify");
     }
@@ -367,7 +369,7 @@ mod tests {
         let s = signer();
         let record = signed_update(&s);
         verify_update_record(&record, &s.keypair).expect("update must verify");
-        let bytes = record.to_dag_cbor();
+        let bytes = record.to_dag_cbor().unwrap();
         let decoded = UpdateRecord::from_dag_cbor(&bytes).unwrap();
         verify_update_record(&decoded, &s.keypair).expect("decoded update must verify");
     }
@@ -386,18 +388,21 @@ mod tests {
         forged.protected = context_protected_header(UPDATE_SIGNATURE_CONTEXT);
         let (ed_vk, pq_vk) = verifying_keys(&s.keypair).unwrap();
         let res = verify_record(
-            &capsule.body.to_dag_cbor(),
+            &capsule.body.to_dag_cbor().unwrap(),
             &forged,
             UPDATE_SIGNATURE_CONTEXT,
             &ed_vk,
             &pq_vk,
         );
-        assert!(res.is_err(), "cross-context signature reuse must be rejected");
+        assert!(
+            res.is_err(),
+            "cross-context signature reuse must be rejected"
+        );
 
         // And verifying the genuine capsule signature while EXPECTING the update
         // context is rejected too.
         let res2 = verify_record(
-            &capsule.body.to_dag_cbor(),
+            &capsule.body.to_dag_cbor().unwrap(),
             &capsule.signatures,
             UPDATE_SIGNATURE_CONTEXT,
             &ed_vk,
@@ -414,7 +419,7 @@ mod tests {
     fn classical_only_signature_rejected_under_classical_policy() {
         let s = signer();
         let body = capsule_body(s.keypair.clone());
-        let payload = body.to_dag_cbor();
+        let payload = body.to_dag_cbor().unwrap();
         let protected = context_protected_header(CAPSULE_SIGNATURE_CONTEXT);
 
         // Directly emit a CLASSICAL-only composite (pq_sk = None) — the exact
@@ -449,7 +454,7 @@ mod tests {
     fn tampered_payload_rejected() {
         let (s, capsule) = signed_capsule();
         let (ed_vk, pq_vk) = verifying_keys(&s.keypair).unwrap();
-        let mut tampered = capsule.body.to_dag_cbor();
+        let mut tampered = capsule.body.to_dag_cbor().unwrap();
         // Flip a byte in the payload.
         let last = tampered.len() - 1;
         tampered[last] ^= 0x01;

--- a/crates/hyprstream-pds/src/dag_cbor.rs
+++ b/crates/hyprstream-pds/src/dag_cbor.rs
@@ -66,6 +66,13 @@ pub enum DagCbor {
     /// Non-negative integer (CBOR major 0).
     Unsigned(u64),
     /// Negative integer (CBOR major 1); `-1 - n`.
+    ///
+    /// **Invariant:** the wrapped value MUST be `< 0`. The variant encodes as
+    /// CBOR major type 1 (`-1 - n`); a non-negative `n` has no valid encoding
+    /// there and is a programmer error caught (loudly, in release too) at
+    /// [`DagCbor::encode`]. Construct negatives via literal `i128` values
+    /// (`DagCbor::Negative(-1)`) — never compute `Negative(x)` from an
+    /// unbounded `x` without first checking `x < 0`.
     Negative(i128),
     /// Byte string (major 2).
     Bytes(Vec<u8>),
@@ -94,10 +101,12 @@ impl DagCbor {
         let mut v: Vec<(String, DagCbor)> = pairs.into_iter().map(|(k, v)| (k.into(), v)).collect();
         v.sort_by(|a, b| canonical_key_cmp(a.0.as_bytes(), b.0.as_bytes()));
         // Reject duplicate keys — they'd silently collapse in CBOR and produce
-        // a CID-collision risk across implementations.
+        // a CID-collision risk across implementations. This is a programmer
+        // error (the caller fed the same key twice), so it is a hard,
+        // always-on panic rather than a `debug_assert!` that vanishes in
+        // release builds and lets duplicate keys reach the wire.
         if let Some(i) = v.windows(2).position(|w| w[0].0 == w[1].0) {
-            // This is a programmer error; surface it loudly via debug assert.
-            debug_assert!(false, "duplicate DAG-CBOR map key: {:?}", v[i].0);
+            panic!("duplicate DAG-CBOR map key: {:?}", v[i].0);
         }
         let sorted = v
             .into_iter()
@@ -128,7 +137,14 @@ impl DagCbor {
             DagCbor::Unsigned(n) => write_uint(out, MT_UNSIGNED, *n),
             DagCbor::Negative(n) => {
                 // CBOR encodes negatives as -1 - n in major type 1 (uint).
-                // n is < 0 here.
+                // The variant invariant requires n < 0; a non-negative value is
+                // a programmer error (it belongs in `Unsigned`), and computing
+                // `-1 - n` then casting to u64 would silently mis-encode it.
+                // Reject loudly in release as well as debug.
+                assert!(
+                    *n < 0,
+                    "DagCbor::Negative must hold a negative value; got {n} (use Unsigned instead)"
+                );
                 let val = (-1_i128 - n) as u64;
                 write_uint(out, MT_NEGATIVE, val);
             }
@@ -609,5 +625,39 @@ mod tests {
             vec![0x19, 0x01, 0x00],
             "u16 must use head 25"
         );
+    }
+
+    /// Issue #934: duplicate keys fed to `str_map` must be a *hard* error in
+    /// release builds too, not a silent `debug_assert!` that lets two keys
+    /// collapse on the wire (a CID-collision risk across implementations).
+    #[test]
+    #[should_panic(expected = "duplicate DAG-CBOR map key")]
+    fn str_map_rejects_duplicate_keys_in_release() {
+        let _ = DagCbor::str_map([("a", DagCbor::Unsigned(1)), ("a", DagCbor::Unsigned(2))]);
+    }
+
+    /// Issue #934: `Negative(n)` with `n >= 0` has no valid CBOR major-1
+    /// encoding and must be rejected at encode (loudly, in release too) rather
+    /// than silently mis-encoded via the `-1 - n` cast.
+    #[test]
+    #[should_panic(expected = "must hold a negative value")]
+    fn negative_must_be_negative() {
+        // 0 and positive values belong in `Unsigned`; encoding them through
+        // `Negative` would wrap `-1 - n as u64` into a huge bogus major-1 arg.
+        DagCbor::Negative(0).encode();
+    }
+
+    #[test]
+    fn negative_boundary_round_trips() {
+        // The smallest representable negative (-1) and a deep negative both
+        // round-trip correctly through the validated encode path.
+        for n in [
+            DagCbor::Negative(-1),
+            DagCbor::Negative(-24),
+            DagCbor::Negative(-256),
+        ] {
+            let dec = DagCbor::decode(&n.encode()).expect("round-trip");
+            assert_eq!(n, dec);
+        }
     }
 }


### PR DESCRIPTION
Closes #934 — the encode-side / producer-footgun bundle from the #915 review. All programmer-error class; the decode trust boundary was already strict.

## Changes

- **`str_map` duplicate keys (hard error).** `debug_assert!` → always-on `panic!`. Release builds no longer silently emit duplicate map keys (a CID-collision risk across implementations).
- **`DagCbor::Negative(n)` with `n >= 0`.** Rejected at `encode` (loudly, in release) instead of mis-encoding via the wrapping `-1 - n as u64` cast; variant invariant documented.
- **Validate-on-encode.** `Capsule` / `CapsuleBody` / `UpdateRecord` / `Manifest` / `Shard` `to_dag_cbor()` (and `UpdateRecord::signable_bytes` / `Capsule::cid512`) now re-validate before emitting bytes, so post-construction mutation of pub fields cannot produce — or get signed over — bytes the decode side would reject. Added validating `new()` constructors for `UpdateRecord` / `Manifest` / `Shard`; made `validate()` public on `Capsule` / `UpdateRecord` / `Manifest`. A `pub(crate) encode_value` skips re-validation for the two internal digest projectors (chain watermark, duplicity digest) that contractually operate on already-validated records.
- **Strict `validate_datetime`.** Checks the actual calendar fields (year `0001..=9999`, month/day with leap-aware day bounds, hour/min/sec ranges, exact 20-char `YYYY-MM-DDTHH:MM:SSZ`) instead of only separator positions — `0000-00-00T00:00:60Z` is now rejected.
- **`next_key_commitments` dedup.** Per #879 §5.3 the list MAY be empty (declared-immutable identity), but two identical commitments are meaningless and are now rejected; each 64B entry was already length-checked on decode.

## Verification

- `cargo test -p hyprstream-pds` → 164 passed (incl. new tests for each hardening: `str_map_rejects_duplicate_keys_in_release`, `negative_must_be_negative`, `encode_rejects_post_construction_mutation`, `validating_constructors_reject_invalid`, `validate_datetime_is_strict_iso8601_utc`, `next_key_commitments_empty_ok_duplicates_rejected`).
- `cargo clippy -p hyprstream-pds -p hyprstream-discovery --all-targets` clean; pre-commit's full-workspace `--release` clippy (`-D warnings`) passed.