### PR TITLE
ci: build wasm guests from their crate dirs (fix getrandom config, #1013 follow-up)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -151,12 +151,22 @@ jobs:
       # the guard forces CI to actually exercise the sandbox. These guests are
       # EXCLUDED standalone crates with their own target dirs, so build them
       # explicitly; nextest locates them via HYPRSTREAM_*_WASM on the test step.
+      #
+      # IMPORTANT: `cd` into each guest crate dir before building. Cargo discovers
+      # .cargo/config.toml from the INVOCATION cwd, NOT the --manifest-path dir, so
+      # building from the repo root misses crates/hyprstream-workers-python-guest/
+      # .cargo/config.toml — which sets `--cfg getrandom_backend="custom"` for the
+      # wasm32-unknown-unknown target. Without it getrandom emits a hard
+      # compile_error!("...wasm32-unknown-unknown targets are not supported...").
+      # cd-ing in is the only invocation that honors the per-crate config (the
+      # fsguest has no such config today, but the same pattern is correct for both
+      # and is robust to a future config being added). See #1013 follow-up.
       run: |
         rustup target add wasm32-unknown-unknown wasm32-wasip1
-        cargo build --release --target wasm32-unknown-unknown \
-          --manifest-path crates/hyprstream-workers-python-guest/Cargo.toml
-        cargo build --release --target wasm32-wasip1 \
-          --manifest-path crates/hyprstream-workers-wasmtime-fsguest/Cargo.toml
+        ( cd crates/hyprstream-workers-python-guest && \
+          cargo build --release --target wasm32-unknown-unknown )
+        ( cd crates/hyprstream-workers-wasmtime-fsguest && \
+          cargo build --release --target wasm32-wasip1 )
 
     - name: Install cargo-nextest
       uses: taiki-e/install-action@nextest


### PR DESCRIPTION
## Root cause

#1013 added a "Build wasm guest artifacts" step that builds the guests with `cargo build --manifest-path crates/<guest>/Cargo.toml` **from the repo root**. Cargo discovers `.cargo/config.toml` from the **invocation cwd**, not the `--manifest-path` dir — so that invocation never reads `crates/hyprstream-workers-python-guest/.cargo/config.toml`, which sets `--cfg getrandom_backend="custom"` for `wasm32-unknown-unknown`. Without that cfg, getrandom 0.3 emits a hard `compile_error!("...wasm32-unknown-unknown targets are not supported...")`, the merge-gate build step fails red, and the guest artifacts never land for the deny-on-missing-guest sandbox tests.

## Fix

`cd` into each guest crate dir before building, so the per-crate `.cargo/config.toml` applies. This is the only invocation that honors the config; it is also correct for the fsguest (`wasm32-wasip1`, no config today) and robust to one being added later. The `wasm32-wasip1` target install and the `HYPRSTREAM_*_WASM` env on the nextest step are unchanged.

## Local verification (rigorous)

- **Reproduced** the failure: `cargo build --manifest-path crates/hyprstream-workers-python-guest/Cargo.toml --target wasm32-unknown-unknown` from root → getrandom `compile_error!` (build step red).
- **Guard intact**: with the pyguest artifact hidden and `CI=1`, the deny-on-missing-guest guard panics (`pyguest wasm not built but running under CI`) — the gate's secondary safety net fires.
- **Fix**: `cd` into each guest + `cargo build` → both `.wasm` artifacts land at the exact crate target paths the workflow's `HYPRSTREAM_*_WASM` env references.
- **All green**: `CI=1 HYPRSTREAM_PYGUEST_WASM=… HYPRSTREAM_FSGUEST_WASM=… cargo nextest run -p hyprstream-workers-python -p hyprstream-workers-wasmtime` → **15 tests, 15 passed, 0 skipped**.

This is the merge-gate unblock.

---
Board: merge-gate RED→GREEN. #1013 follow-up — wasm-guest build honors per-crate `.cargo/config.toml` (getrandom custom-backend cfg).