### PR TITLE
fix(vfs-server): portable st_blksize cast for aarch64

### DIFF
--- a/crates/hyprstream-vfs-server/src/filesystem.rs
+++ b/crates/hyprstream-vfs-server/src/filesystem.rs
@@ -233,7 +233,9 @@ impl VfsFileSystem {
         let mut attr: libc::stat64 = unsafe { std::mem::zeroed() };
         attr.st_ino = inode;
         attr.st_size = st.size as i64;
-        attr.st_blksize = BLOCK_SIZE as i64;
+        // st_blksize is libc::blksize_t: i64 on x86_64 but i32 on aarch64 —
+        // cast to the field's own type so this compiles on both arches.
+        attr.st_blksize = BLOCK_SIZE as libc::blksize_t;
         attr.st_blocks = st.size.div_ceil(BLOCK_SIZE as u64) as i64;
         attr.st_nlink = 1;
         let (typ, perm) = match kind {


### PR DESCRIPTION
`libc::blksize_t` is **i32 on aarch64** but i64 on x86_64, so `attr.st_blksize = BLOCK_SIZE as i64` in `hyprstream-vfs-server` fails to compile on arm64 with a mismatched-types error. Cast to the field's own type (`libc::blksize_t`) so it builds on both architectures.

Found while validating an aarch64 container build of the full workspace on the Graviton self-hosted runners — this was the one genuine arch bug; everything else was toolchain/CI plumbing (see the companion arm64 builder PR).

- 3-line change, no behavior change on x86_64.
- Prereq for the arm64 workspace build to compile green.