### PR TITLE
ci(arm64): aarch64 rust-builder container + Graviton build validation

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,58 @@
+name: Build arm64 rust-builder image
+
+# Publish the reusable aarch64 rust-builder image (Dockerfile target
+# builder-cpu-arm64) to GHCR so merge-gate/CI jobs PULL a pre-built toolchain
+# image (rust + capnproto + clang + the aarch64 libtorch wheel) instead of
+# rebuilding it per job. sccache-S3 handles the incremental cargo cache on top.
+#
+# The image is built ON a Graviton runner (native arm64 — no qemu) and pushed
+# with both :latest and an immutable content tag (short SHA of the Dockerfile).
+on:
+  workflow_dispatch:
+  push:
+    branches: [main, ewindisch/runner-smoke-test]
+    paths:
+      - 'Dockerfile'
+      - '.github/workflows/build-image.yml'
+  schedule:
+    # Weekly rebuild to pick up base-image/toolchain security updates.
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/hyprstream/rust-builder-arm64
+
+jobs:
+  publish-arm64-builder:
+    runs-on: [self-hosted, linux, arm64, graviton, hyprstream-merge-gate]
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute immutable tag (Dockerfile content hash)
+        id: tag
+        run: |
+          h=$(git hash-object Dockerfile | cut -c1-12)
+          echo "sha=$h" >> "$GITHUB_OUTPUT"
+          echo "date=$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        run: podman login ghcr.io -u "$GITHUB_ACTOR" -p "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Build arm64 builder image
+        run: |
+          podman build \
+            --target builder-cpu-arm64 \
+            --build-arg VARIANT=cpu-arm64 \
+            -t "$IMAGE:latest" \
+            -t "$IMAGE:${{ steps.tag.outputs.date }}-${{ steps.tag.outputs.sha }}" \
+            -f Dockerfile \
+            .
+
+      - name: Push tags
+        run: |
+          podman push "$IMAGE:latest"
+          podman push "$IMAGE:${{ steps.tag.outputs.date }}-${{ steps.tag.outputs.sha }}"

--- a/.github/workflows/graviton-build-validate.yml
+++ b/.github/workflows/graviton-build-validate.yml
@@ -1,0 +1,86 @@
+name: Graviton Build Validation
+
+# Non-required validation (#1011): compile the hyprstream workspace on a
+# self-hosted Graviton (arm64, Rocky 10, podman-only) runner INSIDE the arm64
+# rust-builder container — the same layer the merge-gate `build` job will use.
+#
+# The golden AMI has no toolchain by design; everything (rust, capnproto,
+# libtorch) lives in the container. We therefore:
+#   1. podman build the arm64 builder image (Dockerfile target builder-cpu-arm64),
+#      which installs rust + capnproto + the aarch64 torch wheel's libtorch.
+#   2. podman run the workspace `cargo build` inside it (CI feature set), with the
+#      repo bind-mounted — mirroring how a `container:` merge-gate job would run.
+#
+# Trigger: push to this branch (workflow_dispatch won't work until the workflow
+# reaches the default branch).
+on:
+  workflow_dispatch:
+  # Re-run on changes that can affect the arm64 build — the Dockerfile
+  # (toolchain), workspace source (arch-specific fixes), or this workflow.
+  push:
+    branches: [ewindisch/runner-smoke-test]
+    paths:
+      - '.github/workflows/graviton-build-validate.yml'
+      - 'Dockerfile'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'crates/**'
+
+permissions:
+  contents: read
+
+jobs:
+  build-arm64:
+    runs-on: [self-hosted, linux, arm64, graviton, hyprstream-merge-gate]
+    timeout-minutes: 150
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Arch + OS + podman sanity
+        run: |
+          uname -m
+          . /etc/os-release && echo "$PRETTY_NAME"
+          podman --version
+          nproc
+
+      # Build the toolchain+libtorch image only (not the cargo-build `builder`
+      # stage) so the compile happens in the `podman run` below, where we can see
+      # cargo output live and iterate on the container:-style invocation.
+      - name: Build arm64 builder image
+        run: |
+          podman build \
+            --target builder-cpu-arm64 \
+            --build-arg VARIANT=cpu-arm64 \
+            -t hyprstream-builder-arm64:ci \
+            -f Dockerfile \
+            .
+
+      # Prove libtorch is the aarch64 wheel's and readable inside the container.
+      - name: Verify libtorch (arm64) in image
+        run: |
+          podman run --rm hyprstream-builder-arm64:ci sh -c '
+            set -e
+            echo "arch: $(uname -m)"
+            echo "LIBTORCH=$LIBTORCH"
+            file /opt/libtorch/lib/libtorch_cpu.so | head -1
+            ls /opt/libtorch/include/torch >/dev/null && echo "headers OK"
+            rustc -vV | head -2
+            capnp --version
+          '
+
+      # The actual validation: compile the workspace with the CI feature set
+      # inside the container, repo bind-mounted. sccache runs as a local
+      # in-container disk cache (SCCACHE_DIR=/sccache from the image) — no S3
+      # wiring yet, keeping the first-cut failure surface minimal.
+      - name: Compile workspace in container (release, CI features)
+        run: |
+          podman run --rm \
+            -v "$PWD":/build:Z \
+            -w /build \
+            -e OPENSSL_NO_VENDOR=1 \
+            -e LIBTORCH=/opt/libtorch \
+            -e LD_LIBRARY_PATH=/opt/libtorch/lib \
+            -e LIBTORCH_BYPASS_VERSION_CHECK=1 \
+            -e CARGO_TERM_COLOR=always \
+            hyprstream-builder-arm64:ci \
+            cargo build --release --no-default-features --features otel,gittorrent,xet

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,8 @@ RUN echo "deb http://deb.debian.org/debian bookworm-backports main" >> /etc/apt/
     ca-certificates \
     capnproto \
     cmake \
+    clang \
+    libclang-dev \
     && apt-get install -y -t bookworm-backports binutils \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
@@ -144,6 +146,45 @@ RUN --mount=type=cache,target=/tmp/libtorch-cache \
         wget -q ${LIBTORCH_CPU_URL} -O "$CACHE_FILE"; \
     fi && \
     unzip -q "$CACHE_FILE" -d /opt
+
+ENV LIBTORCH=/opt/libtorch
+ENV LD_LIBRARY_PATH=/opt/libtorch/lib
+
+#############################################
+# CPU Builder (aarch64 / arm64)
+#############################################
+#
+# There is NO aarch64 libtorch zip at download.pytorch.org/libtorch/cpu — that
+# URL is x86_64-only. The PyTorch aarch64 manylinux_2_28 pip wheel, however,
+# bundles a complete CPU libtorch (torch/lib/*.so + torch/include), so we install
+# torch via pip and point LIBTORCH at the wheel's torch dir. bookworm ships
+# glibc 2.36, satisfying the wheel's manylinux_2_28 (glibc 2.28+) floor.
+#
+# This stage is the toolchain+libtorch image only; the actual cargo build runs
+# either in the `builder` stage below (VARIANT=cpu-arm64) or by mounting the
+# workspace into this image (`container:`-style, as the merge-gate would).
+
+FROM builder-base AS builder-cpu-arm64
+ARG LIBTORCH_VERSION
+
+# tch-rs's fork keys its ABI check to the exact libtorch version string; the pip
+# wheel reports the same 2.10.0 but bypass keeps us resilient to wheel-suffix skew.
+ENV LIBTORCH_BYPASS_VERSION_CHECK=1
+
+# Python + pip to fetch the aarch64 torch wheel (bookworm python3 == 3.11 -> cp311).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 python3-pip \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+# Install the CPU torch wheel (aarch64) and expose its bundled libtorch as
+# /opt/libtorch so the shared `builder` stage's LIBTORCH=/opt/libtorch just works.
+# --break-system-packages: bookworm marks the system python PEP-668 externally-managed.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip3 install --break-system-packages "torch==${LIBTORCH_VERSION}" \
+    && TORCH_DIR="$(python3 -c 'import torch, os; print(os.path.dirname(torch.__file__))')" \
+    && ln -s "$TORCH_DIR" /opt/libtorch \
+    && ls -la /opt/libtorch/lib/libtorch_cpu.so /opt/libtorch/include >/dev/null
 
 ENV LIBTORCH=/opt/libtorch
 ENV LD_LIBRARY_PATH=/opt/libtorch/lib


### PR DESCRIPTION
Enabling step for moving the merge-gate `build` job to arm64 (Graviton). Adds an aarch64 rust-builder container that compiles the workspace, validated green on the live Graviton runners. **Does not touch rust.yml's merge-gate `build` job.**

Depends on #1019 (aarch64 `st_blksize` fix) to compile green.

### Dockerfile
- **New `builder-cpu-arm64` stage.** There is **no aarch64 libtorch zip** at `download.pytorch.org/libtorch/cpu` (x86_64-only). libtorch is instead sourced from the aarch64 PyTorch pip wheel — `torch==2.10.0`, `manylinux_2_28_aarch64` (glibc 2.28+, satisfied by bookworm's 2.36) — which bundles a complete CPU libtorch (`torch/lib/*.so` + `torch/include`), symlinked to `/opt/libtorch` so the shared `builder` stage works unchanged. `LIBTORCH_BYPASS_VERSION_CHECK=1`. The hyprstream/tch-rs fork honors `LIBTORCH` the standard way.
- **Add `clang`/`libclang-dev` to `builder-base`:** `librocksdb-sys` runs bindgen, which needs `libclang.so` at build time (the x86 ubuntu CI image had it preinstalled, so this never surfaced there).

### Workflows
- **`build-image.yml`** — builds `builder-cpu-arm64` natively on a Graviton runner (no qemu) and publishes it to `ghcr.io/hyprstream/rust-builder-arm64` (`:latest` + immutable `date-sha` tag) via the built-in `GITHUB_TOKEN`, so CI jobs **pull** a prebuilt toolchain image rather than rebuilding it per job. Triggers on Dockerfile changes / manual / weekly cron.
- **`graviton-build-validate.yml`** — builds the container on Graviton and compiles the workspace **inside** it (`container:`-style, repo bind-mounted) with the CI feature set (`--no-default-features --features otel,gittorrent,xet`). Non-required validation harness.

### Validation (live Graviton runners)
- Workspace compiled **green in ~21m** inside the container. Verified: `arch: aarch64`, `LIBTORCH=/opt/libtorch`, headers OK, rustc 1.97.0, Cap'n Proto 0.9.2.
- GHCR publish succeeded: pushed `:latest` + `:20260711-fe2980635e21`.

### Remaining before cutting the merge-gate `build` over to `container:` on Graviton
1. Merge #1019 (arch fix) + this PR.
2. Point rust.yml's `build` at `container: ghcr.io/hyprstream/rust-builder-arm64:latest` with `env: OPENSSL_NO_VENDOR=1, LIBTORCH=/opt/libtorch, LIBTORCH_BYPASS_VERSION_CHECK=1`; add GHCR pull auth if the package is private.
3. Wire **sccache-S3** (`id-token: write` + `AWS_SCCACHE_ROLE_ARN`) for cross-runner incremental cache — this validation used a local in-container sccache only.