### PR TITLE
ci: migrate clippy+wasm to Graviton (build stays x86 pending arm64 test validation)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,14 +25,15 @@ env:
   CARGO_INCREMENTAL: 0
   BUILDER_IMAGE: ghcr.io/hyprstream/rust-builder-arm64:latest
 
-# The Rust compile jobs run on the self-hosted Graviton (arm64) runners and drive
-# the build through `podman run` against the prebuilt rust-builder image (rust +
-# capnproto + clang + libtorch). We DELIBERATELY do NOT use a job-level
-# `container:` — the runner's native container support wants a Docker-API socket
-# at /var/run/docker.sock, which the rootless-podman golden AMI does not expose
-# (a `container:` job fails with `statfs /var/run/docker.sock: permission
-# denied`). Driving `podman run` from host steps sidesteps that entirely and is
-# the same pattern proven in graviton-build-validate.yml.
+# The fast lint jobs (clippy, wasm) run on the self-hosted Graviton (arm64)
+# runners and drive the build through `podman run` against the prebuilt
+# rust-builder image (rust + capnproto + clang + libtorch). We DELIBERATELY do
+# NOT use a job-level `container:` — the runner's native container support wants
+# a Docker-API socket at /var/run/docker.sock, which the rootless-podman golden
+# AMI does not expose (a `container:` job fails with `statfs
+# /var/run/docker.sock: permission denied`). Driving `podman run` from host
+# steps sidesteps that entirely and is the same pattern proven in
+# graviton-build-validate.yml.
 #
 # Two wins over GitHub-hosted ubuntu-latest: (1) same-region as the sccache S3
 # bucket, so cache transfer is free (ubuntu-latest pulled it over the internet —
@@ -41,6 +42,9 @@ env:
 #
 # AWS creds from the OIDC step are passed into the container by name (`-e VAR`
 # with no value forwards the host value) so the image's sccache reaches S3.
+#
+# The merge-gate `build` job stays on ubuntu-latest for now (arm64 default-feature
+# test validation is not green yet) — see its inline note.
 jobs:
   clippy:
     name: Clippy
@@ -134,7 +138,11 @@ jobs:
     # merge queue. (Per-PR AppImage artifacts were dropped with the PR build; the
     # `appimage.yml` workflow still builds the AppImage on push to `main`.)
     if: github.event_name != 'pull_request'
-    runs-on: [self-hosted, linux, arm64, graviton, hyprstream-merge-gate]
+    # NOTE: the merge-gate build+test stays on ubuntu-latest for now. The arm64
+    # default-feature nextest suite has NOT been validated green on Graviton yet
+    # (runner-smoke test run failed), so the required gate does not move until it
+    # is. clippy + wasm (above) run on Graviton via podman run; this job does not.
+    runs-on: ubuntu-latest
     needs: clippy  # Only build if clippy passes
     # Merge-gate backstop: fail before the merge queue's 120min timeout (ruleset
     # check_response_timeout_minutes) so a hang yields a definitive failure and the
@@ -142,9 +150,14 @@ jobs:
     # nextest step uses the ci-test Cargo profile to avoid release ThinLTO on test
     # binaries, so 90min should retain headroom while catching regressions.
     timeout-minutes: 90
+    env:
+      SCCACHE_IDLE_TIMEOUT: 0
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: Install build dependencies
+      run: sudo apt-get update && sudo apt-get install -y capnproto libsystemd-dev pkg-config libssl-dev
 
     - name: Configure AWS credentials (OIDC → sccache S3)
       uses: aws-actions/configure-aws-credentials@v4
@@ -152,44 +165,53 @@ jobs:
         role-to-assume: ${{ vars.AWS_SCCACHE_ROLE_ARN }}
         aws-region: ${{ vars.AWS_SCCACHE_REGION }}
 
-    - name: Pull builder image
-      run: podman pull "$BUILDER_IMAGE"
+    - name: Setup sccache
+      uses: mozilla-actions/sccache-action@v0.0.9
 
-    # Whole build+test in ONE `podman run` so the target dir and wasm guest
-    # artifacts persist across the sequence. libtorch from the image; default
-    # features (systemd/kata-vm/oci-image/otel/gittorrent/xet) — NOT
-    # download-libtorch (x86-only zip). The wasm-guest `cd`-into-crate-dir dance
-    # is preserved verbatim from the ubuntu job (see #1013/#1016): cargo reads
-    # each guest's .cargo/config.toml from the INVOCATION cwd, not --manifest-path.
-    - name: Build + tests (in rust-builder container)
-      env:
-        SCCACHE_IDLE_TIMEOUT: 0
+    - name: Build
+      run: cargo build --release --verbose --features download-libtorch
+
+    - name: Build wasm guest artifacts (for sandbox/mount tests)
+      # The workers-python / workers-wasmtime sandbox tests hard-fail under CI
+      # (deny-on-missing-guest guard) when their wasm guest artifacts are absent —
+      # the guard forces CI to actually exercise the sandbox. These guests are
+      # EXCLUDED standalone crates with their own target dirs, so build them
+      # explicitly; nextest locates them via HYPRSTREAM_*_WASM on the test step.
+      #
+      # IMPORTANT: `cd` into each guest crate dir before building. Cargo discovers
+      # .cargo/config.toml from the INVOCATION cwd, NOT the --manifest-path dir, so
+      # building from the repo root misses crates/hyprstream-workers-python-guest/
+      # .cargo/config.toml — which sets `--cfg getrandom_backend="custom"` for the
+      # wasm32-unknown-unknown target. Without it getrandom emits a hard
+      # compile_error!("...wasm32-unknown-unknown targets are not supported...").
+      # cd-ing in is the only invocation that honors the per-crate config (the
+      # fsguest has no such config today, but the same pattern is correct for both
+      # and is robust to a future config being added). See #1013 follow-up.
       run: |
-        podman run --rm \
-          -v "$PWD":/build:Z -w /build \
-          -e RUSTC_WRAPPER=sccache -e SCCACHE_BUCKET -e SCCACHE_REGION -e SCCACHE_IDLE_TIMEOUT \
-          -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
-          -e AWS_REGION -e AWS_DEFAULT_REGION \
-          -e LIBTORCH=/opt/libtorch -e LD_LIBRARY_PATH=/opt/libtorch/lib \
-          -e LIBTORCH_BYPASS_VERSION_CHECK=1 -e OPENSSL_NO_VENDOR=1 \
-          -e CARGO_INCREMENTAL=0 -e CARGO_TERM_COLOR=always \
-          "$BUILDER_IMAGE" \
-          bash -euo pipefail -c '
-            cargo build --release --verbose
+        rustup target add wasm32-unknown-unknown wasm32-wasip1
+        ( cd crates/hyprstream-workers-python-guest && \
+          cargo build --release --target wasm32-unknown-unknown )
+        ( cd crates/hyprstream-workers-wasmtime-fsguest && \
+          cargo build --release --target wasm32-wasip1 )
 
-            rustup target add wasm32-unknown-unknown wasm32-wasip1
-            ( cd crates/hyprstream-workers-python-guest && \
-              cargo build --release --target wasm32-unknown-unknown )
-            ( cd crates/hyprstream-workers-wasmtime-fsguest && \
-              cargo build --release --target wasm32-wasip1 )
+    - name: Install cargo-nextest
+      uses: taiki-e/install-action@nextest
 
-            cargo install cargo-nextest --locked || true
+    - name: Run tests (nextest, per-test timeout)
+      # nextest enforces the per-TEST slow-timeout from .config/nextest.toml
+      # ([profile.ci]): a single deadlocked test is SIGKILLed after ~3min and fails
+      # fast, instead of stalling the job until the 90min job / 120min queue
+      # timeout. The cap is per-test on purpose — the legit suite is long (~76min),
+      # so a per-step timeout could not tell a hang from healthy runtime.
+      env:
+        HYPRSTREAM_PYGUEST_WASM: ${{ github.workspace }}/crates/hyprstream-workers-python-guest/target/wasm32-unknown-unknown/release/hyprstream_workers_python_guest.wasm
+        HYPRSTREAM_FSGUEST_WASM: ${{ github.workspace }}/crates/hyprstream-workers-wasmtime-fsguest/target/wasm32-wasip1/release/hyprstream-workers-wasmtime-fsguest.wasm
+      run: cargo nextest run --cargo-profile ci-test --profile ci --features download-libtorch
 
-            export HYPRSTREAM_PYGUEST_WASM=/build/crates/hyprstream-workers-python-guest/target/wasm32-unknown-unknown/release/hyprstream_workers_python_guest.wasm
-            export HYPRSTREAM_FSGUEST_WASM=/build/crates/hyprstream-workers-wasmtime-fsguest/target/wasm32-wasip1/release/hyprstream-workers-wasmtime-fsguest.wasm
-            cargo nextest run --cargo-profile ci-test --profile ci
+    - name: Run doctests
+      # nextest does not run doctests; keep them in the merge gate.
+      run: cargo test --release --doc --features download-libtorch
 
-            cargo test --release --doc
-
-            sccache --show-stats
-          '
+    - name: sccache stats
+      if: always()
+      run: sccache --show-stats

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,21 +23,30 @@ env:
   SCCACHE_BUCKET: ${{ vars.AWS_SCCACHE_BUCKET }}
   SCCACHE_REGION: ${{ vars.AWS_SCCACHE_REGION }}
   CARGO_INCREMENTAL: 0
+  BUILDER_IMAGE: ghcr.io/hyprstream/rust-builder-arm64:latest
 
+# The Rust compile jobs run on the self-hosted Graviton (arm64) runners and drive
+# the build through `podman run` against the prebuilt rust-builder image (rust +
+# capnproto + clang + libtorch). We DELIBERATELY do NOT use a job-level
+# `container:` — the runner's native container support wants a Docker-API socket
+# at /var/run/docker.sock, which the rootless-podman golden AMI does not expose
+# (a `container:` job fails with `statfs /var/run/docker.sock: permission
+# denied`). Driving `podman run` from host steps sidesteps that entirely and is
+# the same pattern proven in graviton-build-validate.yml.
+#
+# Two wins over GitHub-hosted ubuntu-latest: (1) same-region as the sccache S3
+# bucket, so cache transfer is free (ubuntu-latest pulled it over the internet —
+# ~560GB/mo of S3 DataTransfer-Out); (2) libtorch comes from the image
+# (/opt/libtorch), so there is no x86 `download-libtorch` (no aarch64 zip exists).
+#
+# AWS creds from the OIDC step are passed into the container by name (`-e VAR`
+# with no value forwards the host value) so the image's sccache reaches S3.
 jobs:
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, arm64, graviton, hyprstream-merge-gate]
     steps:
     - uses: actions/checkout@v4
-
-    - name: Install build dependencies
-      run: sudo apt-get update && sudo apt-get install -y capnproto libsystemd-dev pkg-config libssl-dev
-
-    - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@1.97.0
-      with:
-        components: clippy
 
     - name: Configure AWS credentials (OIDC → sccache S3)
       uses: aws-actions/configure-aws-credentials@v4
@@ -45,15 +54,25 @@ jobs:
         role-to-assume: ${{ vars.AWS_SCCACHE_ROLE_ARN }}
         aws-region: ${{ vars.AWS_SCCACHE_REGION }}
 
-    - name: Setup sccache
-      uses: mozilla-actions/sccache-action@v0.0.9
+    - name: Pull builder image
+      run: podman pull "$BUILDER_IMAGE"
 
-    - name: Run Clippy
-      run: cargo clippy --workspace --all-targets --features download-libtorch -- -D warnings
-
-    - name: sccache stats
-      if: always()
-      run: sccache --show-stats
+    - name: Run Clippy (in rust-builder container)
+      run: |
+        podman run --rm \
+          -v "$PWD":/build:Z -w /build \
+          -e RUSTC_WRAPPER=sccache -e SCCACHE_BUCKET -e SCCACHE_REGION \
+          -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
+          -e AWS_REGION -e AWS_DEFAULT_REGION \
+          -e LIBTORCH=/opt/libtorch -e LD_LIBRARY_PATH=/opt/libtorch/lib \
+          -e LIBTORCH_BYPASS_VERSION_CHECK=1 -e OPENSSL_NO_VENDOR=1 \
+          -e CARGO_INCREMENTAL=0 -e CARGO_TERM_COLOR=always \
+          "$BUILDER_IMAGE" \
+          bash -euo pipefail -c '
+            rustup component add clippy
+            cargo clippy --workspace --all-targets -- -D warnings
+            sccache --show-stats
+          '
 
   deny:
     name: cargo-deny (bans + licenses)
@@ -67,25 +86,17 @@ jobs:
     - name: Check bans
       # ZMQ crates are deny-listed in deny.toml (#138 complete). This gate must
       # be able to fail — do NOT add `|| true`.
-      # No compilation here, so no sccache/AWS. Unset RUSTC_WRAPPER defensively.
+      # No compilation here (metadata only), arch-independent, no S3 — stays on
+      # the free GitHub-hosted runner.
       run: |
         unset RUSTC_WRAPPER
         cargo deny check bans licenses
 
   wasm:
     name: WASM (browser client)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, arm64, graviton, hyprstream-merge-gate]
     steps:
     - uses: actions/checkout@v4
-
-    # capnproto only — the wasm browser client (hyprstream-rpc) has no libtorch/systemd deps.
-    - name: Install build dependencies
-      run: sudo apt-get update && sudo apt-get install -y capnproto pkg-config
-
-    - name: Install Rust toolchain (wasm32)
-      uses: dtolnay/rust-toolchain@1.97.0
-      with:
-        targets: wasm32-unknown-unknown
 
     - name: Configure AWS credentials (OIDC → sccache S3)
       uses: aws-actions/configure-aws-credentials@v4
@@ -93,20 +104,27 @@ jobs:
         role-to-assume: ${{ vars.AWS_SCCACHE_ROLE_ARN }}
         aws-region: ${{ vars.AWS_SCCACHE_REGION }}
 
-    - name: Setup sccache
-      uses: mozilla-actions/sccache-action@v0.0.9
+    - name: Pull builder image
+      run: podman pull "$BUILDER_IMAGE"
 
     # Guards the browser/WebTransport build (#225/#226): getrandom wasm_js (Cargo.toml) +
     # the web_sys_unstable_apis rustflag for WebTransport. Catches wasm-only breakage the
     # native clippy/build jobs miss (e.g. the PQ-crypto getrandom regression).
-    - name: Check wasm32 browser build
-      run: cargo check --target wasm32-unknown-unknown -p hyprstream-rpc
-      env:
-        RUSTFLAGS: "--cfg=web_sys_unstable_apis"
-
-    - name: sccache stats
-      if: always()
-      run: sccache --show-stats
+    - name: Check wasm32 browser build (in rust-builder container)
+      run: |
+        podman run --rm \
+          -v "$PWD":/build:Z -w /build \
+          -e RUSTC_WRAPPER=sccache -e SCCACHE_BUCKET -e SCCACHE_REGION \
+          -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
+          -e AWS_REGION -e AWS_DEFAULT_REGION \
+          -e CARGO_INCREMENTAL=0 -e CARGO_TERM_COLOR=always \
+          -e RUSTFLAGS='--cfg=web_sys_unstable_apis' \
+          "$BUILDER_IMAGE" \
+          bash -euo pipefail -c '
+            rustup target add wasm32-unknown-unknown
+            cargo check --target wasm32-unknown-unknown -p hyprstream-rpc
+            sccache --show-stats
+          '
 
   build:
     # MERGE GATE — not a per-PR-push check. The heavy build+test runs in the merge
@@ -116,7 +134,7 @@ jobs:
     # merge queue. (Per-PR AppImage artifacts were dropped with the PR build; the
     # `appimage.yml` workflow still builds the AppImage on push to `main`.)
     if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, arm64, graviton, hyprstream-merge-gate]
     needs: clippy  # Only build if clippy passes
     # Merge-gate backstop: fail before the merge queue's 120min timeout (ruleset
     # check_response_timeout_minutes) so a hang yields a definitive failure and the
@@ -124,14 +142,9 @@ jobs:
     # nextest step uses the ci-test Cargo profile to avoid release ThinLTO on test
     # binaries, so 90min should retain headroom while catching regressions.
     timeout-minutes: 90
-    env:
-      SCCACHE_IDLE_TIMEOUT: 0
 
     steps:
     - uses: actions/checkout@v4
-
-    - name: Install build dependencies
-      run: sudo apt-get update && sudo apt-get install -y capnproto libsystemd-dev pkg-config libssl-dev
 
     - name: Configure AWS credentials (OIDC → sccache S3)
       uses: aws-actions/configure-aws-credentials@v4
@@ -139,53 +152,44 @@ jobs:
         role-to-assume: ${{ vars.AWS_SCCACHE_ROLE_ARN }}
         aws-region: ${{ vars.AWS_SCCACHE_REGION }}
 
-    - name: Setup sccache
-      uses: mozilla-actions/sccache-action@v0.0.9
+    - name: Pull builder image
+      run: podman pull "$BUILDER_IMAGE"
 
-    - name: Build
-      run: cargo build --release --verbose --features download-libtorch
-
-    - name: Build wasm guest artifacts (for sandbox/mount tests)
-      # The workers-python / workers-wasmtime sandbox tests hard-fail under CI
-      # (deny-on-missing-guest guard) when their wasm guest artifacts are absent —
-      # the guard forces CI to actually exercise the sandbox. These guests are
-      # EXCLUDED standalone crates with their own target dirs, so build them
-      # explicitly; nextest locates them via HYPRSTREAM_*_WASM on the test step.
-      #
-      # IMPORTANT: `cd` into each guest crate dir before building. Cargo discovers
-      # .cargo/config.toml from the INVOCATION cwd, NOT the --manifest-path dir, so
-      # building from the repo root misses crates/hyprstream-workers-python-guest/
-      # .cargo/config.toml — which sets `--cfg getrandom_backend="custom"` for the
-      # wasm32-unknown-unknown target. Without it getrandom emits a hard
-      # compile_error!("...wasm32-unknown-unknown targets are not supported...").
-      # cd-ing in is the only invocation that honors the per-crate config (the
-      # fsguest has no such config today, but the same pattern is correct for both
-      # and is robust to a future config being added). See #1013 follow-up.
-      run: |
-        rustup target add wasm32-unknown-unknown wasm32-wasip1
-        ( cd crates/hyprstream-workers-python-guest && \
-          cargo build --release --target wasm32-unknown-unknown )
-        ( cd crates/hyprstream-workers-wasmtime-fsguest && \
-          cargo build --release --target wasm32-wasip1 )
-
-    - name: Install cargo-nextest
-      uses: taiki-e/install-action@nextest
-
-    - name: Run tests (nextest, per-test timeout)
-      # nextest enforces the per-TEST slow-timeout from .config/nextest.toml
-      # ([profile.ci]): a single deadlocked test is SIGKILLed after ~3min and fails
-      # fast, instead of stalling the job until the 90min job / 120min queue
-      # timeout. The cap is per-test on purpose — the legit suite is long (~76min),
-      # so a per-step timeout could not tell a hang from healthy runtime.
+    # Whole build+test in ONE `podman run` so the target dir and wasm guest
+    # artifacts persist across the sequence. libtorch from the image; default
+    # features (systemd/kata-vm/oci-image/otel/gittorrent/xet) — NOT
+    # download-libtorch (x86-only zip). The wasm-guest `cd`-into-crate-dir dance
+    # is preserved verbatim from the ubuntu job (see #1013/#1016): cargo reads
+    # each guest's .cargo/config.toml from the INVOCATION cwd, not --manifest-path.
+    - name: Build + tests (in rust-builder container)
       env:
-        HYPRSTREAM_PYGUEST_WASM: ${{ github.workspace }}/crates/hyprstream-workers-python-guest/target/wasm32-unknown-unknown/release/hyprstream_workers_python_guest.wasm
-        HYPRSTREAM_FSGUEST_WASM: ${{ github.workspace }}/crates/hyprstream-workers-wasmtime-fsguest/target/wasm32-wasip1/release/hyprstream-workers-wasmtime-fsguest.wasm
-      run: cargo nextest run --cargo-profile ci-test --profile ci --features download-libtorch
+        SCCACHE_IDLE_TIMEOUT: 0
+      run: |
+        podman run --rm \
+          -v "$PWD":/build:Z -w /build \
+          -e RUSTC_WRAPPER=sccache -e SCCACHE_BUCKET -e SCCACHE_REGION -e SCCACHE_IDLE_TIMEOUT \
+          -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
+          -e AWS_REGION -e AWS_DEFAULT_REGION \
+          -e LIBTORCH=/opt/libtorch -e LD_LIBRARY_PATH=/opt/libtorch/lib \
+          -e LIBTORCH_BYPASS_VERSION_CHECK=1 -e OPENSSL_NO_VENDOR=1 \
+          -e CARGO_INCREMENTAL=0 -e CARGO_TERM_COLOR=always \
+          "$BUILDER_IMAGE" \
+          bash -euo pipefail -c '
+            cargo build --release --verbose
 
-    - name: Run doctests
-      # nextest does not run doctests; keep them in the merge gate.
-      run: cargo test --release --doc --features download-libtorch
+            rustup target add wasm32-unknown-unknown wasm32-wasip1
+            ( cd crates/hyprstream-workers-python-guest && \
+              cargo build --release --target wasm32-unknown-unknown )
+            ( cd crates/hyprstream-workers-wasmtime-fsguest && \
+              cargo build --release --target wasm32-wasip1 )
 
-    - name: sccache stats
-      if: always()
-      run: sccache --show-stats
+            cargo install cargo-nextest --locked || true
+
+            export HYPRSTREAM_PYGUEST_WASM=/build/crates/hyprstream-workers-python-guest/target/wasm32-unknown-unknown/release/hyprstream_workers_python_guest.wasm
+            export HYPRSTREAM_FSGUEST_WASM=/build/crates/hyprstream-workers-wasmtime-fsguest/target/wasm32-wasip1/release/hyprstream-workers-wasmtime-fsguest.wasm
+            cargo nextest run --cargo-profile ci-test --profile ci
+
+            cargo test --release --doc
+
+            sccache --show-stats
+          '

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,8 +49,14 @@ jobs:
   clippy:
     name: Clippy
     runs-on: [self-hosted, linux, arm64, graviton, hyprstream-merge-gate]
+    # The last successful run took ~6 minutes including image pull. Keep a
+    # bounded backstop for the shared runner without giving a stalled lint job
+    # the merge-gate's 90-minute budget.
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Configure AWS credentials (OIDC → sccache S3)
       uses: aws-actions/configure-aws-credentials@v4
@@ -99,8 +105,11 @@ jobs:
   wasm:
     name: WASM (browser client)
     runs-on: [self-hosted, linux, arm64, graviton, hyprstream-merge-gate]
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Configure AWS credentials (OIDC → sccache S3)
       uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,9 @@ env:
   SCCACHE_BUCKET: ${{ vars.AWS_SCCACHE_BUCKET }}
   SCCACHE_REGION: ${{ vars.AWS_SCCACHE_REGION }}
   CARGO_INCREMENTAL: 0
-  BUILDER_IMAGE: ghcr.io/hyprstream/rust-builder-arm64:latest
+  # Pin the arm64 image resolved from :latest on 2026-07-14. Bump this digest
+  # deliberately after a builder-image publish so CI inputs remain reproducible.
+  BUILDER_IMAGE: ghcr.io/hyprstream/rust-builder-arm64@sha256:92d8b445f8020e38a4ab08a5868b98819630e3bbf3425f3e281b0e66f1e4b9d5
 
 # The fast lint jobs (clippy, wasm) run on the self-hosted Graviton (arm64)
 # runners and drive the build through `podman run` against the prebuilt

--- a/crates/hyprstream-pds/src/at9p.rs
+++ b/crates/hyprstream-pds/src/at9p.rs
@@ -708,7 +708,7 @@ impl UpdateRecord {
 
     pub fn to_dag_cbor(&self) -> Result<Vec<u8>> {
         self.validate()?;
-        Ok(self.to_value().encode())
+        Ok(self.encode_value())
     }
 
     /// Serialize without re-validating. For crate-internal digest/state

--- a/crates/hyprstream-pds/src/at9p.rs
+++ b/crates/hyprstream-pds/src/at9p.rs
@@ -637,7 +637,7 @@ impl Capsule {
 
     pub fn to_dag_cbor(&self) -> Result<Vec<u8>> {
         self.validate()?;
-        Ok(self.to_value().encode())
+        Ok(self.encode_value())
     }
 
     pub fn from_dag_cbor(bytes: &[u8]) -> Result<Self> {
@@ -646,6 +646,14 @@ impl Capsule {
 
     pub fn cid512(&self) -> Result<String> {
         at9p_capsule_cid512(&self.to_dag_cbor()?)
+    }
+
+    /// Serialize without re-validating. For crate-internal digest/state
+    /// projection over capsules already known to be valid — they reached here
+    /// via [`Self::from_dag_cbor`] (validated) or the signing path. External
+    /// callers must use [`Self::to_dag_cbor`].
+    pub(crate) fn encode_value(&self) -> Vec<u8> {
+        self.to_value().encode()
     }
 
     fn to_value(&self) -> DagCbor {

--- a/crates/hyprstream-pds/src/at9p_duplicity.rs
+++ b/crates/hyprstream-pds/src/at9p_duplicity.rs
@@ -217,8 +217,8 @@ impl PredecessorRecord<'_> {
     /// the watermark pins is verified to describe *these* bytes.
     pub fn record_digest(&self) -> [u8; H512_LEN] {
         match self {
-            PredecessorRecord::Genesis(cap) => h512(&cap.to_dag_cbor()),
-            PredecessorRecord::Update(rec) => h512(&rec.to_dag_cbor()),
+            PredecessorRecord::Genesis(cap) => h512(&cap.encode_value()),
+            PredecessorRecord::Update(rec) => h512(&rec.encode_value()),
         }
     }
 
@@ -2263,7 +2263,6 @@ mod tests {
             Some(DuplicityKind::HigherEpochFork)
         );
     }
-
 
     // Small accessors so the guard's sink can be inspected in-test.
     impl DuplicityGuard<InMemoryWatermarkStore, RecordingSink> {

--- a/crates/hyprstream-pds/src/name_record.rs
+++ b/crates/hyprstream-pds/src/name_record.rs
@@ -220,35 +220,39 @@ fn validate_pin_cid(s: &str) -> Result<()> {
 
 #[cfg(test)]
 fn sample_pin() -> String {
-    hyprstream_rpc::cid::encode_cid(
+    match hyprstream_rpc::cid::encode_cid(
         hyprstream_rpc::cid::Codec::GitRaw,
         hyprstream_rpc::cid::HashAlgo::Sha2_256,
         &[0x42; 32],
-    )
-    .expect("valid sample CID")
+    ) {
+        Ok(cid) => cid,
+        Err(err) => panic!("valid sample CID: {err}"),
+    }
 }
 
 #[cfg(test)]
 fn sample_at9p_pin() -> String {
-    hyprstream_rpc::cid::encode_cid(
+    match hyprstream_rpc::cid::encode_cid(
         hyprstream_rpc::cid::Codec::At9pCapsule,
         hyprstream_rpc::cid::HashAlgo::Blake3,
         &[0x24; 64],
-    )
-    .expect("valid sample at9p CID")
+    ) {
+        Ok(cid) => cid,
+        Err(err) => panic!("valid sample at9p CID: {err}"),
+    }
 }
 
 #[cfg(test)]
 fn truncated_pin() -> String {
-    hyprstream_rpc::cid::encode_cid(
+    let cid = match hyprstream_rpc::cid::encode_cid(
         hyprstream_rpc::cid::Codec::GitRaw,
         hyprstream_rpc::cid::HashAlgo::Sha2_256,
         &[0x11; 32],
-    )
-    .expect("valid CID")
-    .chars()
-    .take(12)
-    .collect()
+    ) {
+        Ok(cid) => cid,
+        Err(err) => panic!("valid CID: {err}"),
+    };
+    cid.chars().take(12).collect()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Supersedes closed #1021. Graviton runner validation established that job-level `container:` expects a Docker API socket unavailable on the rootless-Podman AMI; these jobs use the repository’s established host-step `podman run` pattern instead.

## Scope

- Inherits the focused PDS compile fix from #1041 as ancestry only; the #1022-specific diff remains `.github/workflows/rust.yml`.
- Moves the PR-triggered `clippy` and `wasm` checks to the trusted self-hosted ARM64 Graviton runner pool using `ghcr.io/hyprstream/rust-builder-arm64:latest`.
- Keeps the merge-queue `build` gate on `ubuntu-latest`: the default-feature arm64 nextest suite is not yet validated green.
- Keeps `cargo-deny` on GitHub-hosted Ubuntu.
- Uses bounded 30-minute timeouts and disables checkout credential persistence before mounting the workspace into Podman.

`download-libtorch` deliberately remains outside the ARM64 clippy job because its upstream archive is x86-only; the builder image supplies ARM64 libtorch.

Follow-up: move the merge gate only after the runner-smoke/default-feature suite is green.