### PR TITLE
fix(git-xet-filter): portable pointer casts for aarch64

### DIFF
--- a/crates/git-xet-filter/src/callbacks.rs
+++ b/crates/git-xet-filter/src/callbacks.rs
@@ -154,7 +154,7 @@ extern "C" fn xet_stream_write(
             return -1;
         }
 
-        let data = std::slice::from_raw_parts(buffer as *const u8, len);
+        let data = std::slice::from_raw_parts(buffer.cast::<u8>(), len);
         (*xet_stream).buffer.extend_from_slice(data);
     }
     0
@@ -285,7 +285,7 @@ fn write_to_next(next: *mut OpaqueGitWriteStream, data: &[u8]) -> Result<(), Xet
     unsafe {
         let ws = next as *mut GitWriteStreamBase;
         let write_fn = (*ws).write;
-        let result = write_fn(ws, data.as_ptr() as *const c_char, data.len());
+        let result = write_fn(ws, data.as_ptr().cast::<c_char>(), data.len());
         if result < 0 {
             return Err(XetError::new(XetErrorKind::IoError, "Write to next stream failed"));
         }


### PR DESCRIPTION
`libc::c_char` is `i8` on x86_64 but `u8` on aarch64, so `buffer as *const u8` and `data.as_ptr() as *const c_char` in `callbacks.rs` become **same-type casts on aarch64**, which clippy's `unnecessary_cast` rejects under `-D warnings`. This is the one arch-specific lint that blocked the arm64 Clippy job in the Graviton CI cutover (surfaced by #1022; the full default-feature dep tree otherwise compiles fine on arm64).

Fix: use `.cast::<T>()`, portable across both arches and not flagged by the lint. No behavior change; `cargo check -p git-xet-filter` clean. Same flavor as the earlier `st_blksize` aarch64 fix (#1019).