### PR TITLE
fix(rpc-build): unblock main Clippy (approx_constant on wire_roundtrip e-fixture)

### DIFF
--- a/crates/hyprstream-rpc-build/tests/wire_roundtrip.rs
+++ b/crates/hyprstream-rpc-build/tests/wire_roundtrip.rs
@@ -300,6 +300,10 @@ impl Drop for Workdir {
 /// The TS→Rust leg must compare against this oracle, not only TS self-parse vs
 /// Rust parse, otherwise a TS builder/parser pair that agrees on the wrong shape
 /// could pass.
+// The f64 fixture below intentionally uses the decimal expansion of e as a
+// non-trivial full-precision value; it is a cross-runtime golden, so keep the
+// literal byte-identical rather than swapping in std::f64::consts::E.
+#[allow(clippy::approx_constant)]
 fn expected_ts_roundtrip_json() -> Value {
     let big_f32s: Vec<Value> = (0..2048).map(|i| json!((i * 2) as f64)).collect();
     let big_embeds: Vec<Value> = (0..4)


### PR DESCRIPTION
Main's Clippy is **red** — `crates/hyprstream-rpc-build/tests/wire_roundtrip.rs:325` has the f64 golden `2.718281828459045`, which trips `clippy::approx_constant` (deny-level correctness). It landed via #978 and now **fails Clippy on every rebased PR** (observed on #977, #1015, and pending on #1003/#1014), blocking the whole fleet.

It's a deliberate full-precision cross-runtime golden compared on both the Rust and TS sides, so the fix keeps the literal byte-identical and `#[allow(clippy::approx_constant)]` on the fixture fn (rather than `std::f64::consts::E`, to avoid any risk to the golden). Test-only, one attribute + comment.