### PR TITLE
SECURITY(INV-2): structurally forbid cleartext envelope over iroh/relay/cross-host carriers

### DIFF
--- a/crates/hyprstream-rpc/src/dial.rs
+++ b/crates/hyprstream-rpc/src/dial.rs
@@ -128,18 +128,27 @@ where
         transport: T2,
         vk: Option<VerifyingKey>,
         token: Option<String>,
+        carrier_forbids_cleartext: bool,
     ) -> Arc<dyn RpcClient>
     where
         S2: Signer + 'static,
         T2: crate::transport_traits::Transport + 'static,
     {
-        let rpc = RpcClientImpl::new(signer, transport, vk);
+        let rpc = RpcClientImpl::new(signer, transport, vk)
+            // INV-2 (ADR #1023): the send path refuses a cleartext SignedEnvelope
+            // on an untrusted carrier. `dial()` is the single place transport
+            // choice is made, so it is the correct place to stamp the carrier
+            // classification onto the client.
+            .with_carrier_cleartext_forbidden(carrier_forbids_cleartext);
         let rpc = match token {
             Some(t) => rpc.with_default_jwt(t),
             None => rpc,
         };
         Arc::new(rpc) as Arc<dyn RpcClient>
     }
+
+    // INV-2 carrier classification, computed once from the resolved endpoint.
+    let carrier_forbids_cleartext = target.endpoint.forbids_cleartext_envelope();
 
     // Matched exhaustively on purpose: this is the one place transport choice is
     // made, so a newly-added EndpointType variant MUST be a compile error here
@@ -150,7 +159,7 @@ where
                 anyhow!("no in-process service registered for inproc endpoint '{endpoint}'")
             })?;
             let transport = InMemoryTransport::new(processor);
-            Ok(build_client(signer, transport, server_verifying_key, token))
+            Ok(build_client(signer, transport, server_verifying_key, token, carrier_forbids_cleartext))
         }
         EndpointType::Quic { addr, server_name, auth } => {
             // SECURITY (#185): QUIC channel auth (WebPKI / cert-hash pin) binds the
@@ -173,7 +182,7 @@ where
                 server_name.clone(),
                 auth.clone(),
             );
-            Ok(build_client(signer, transport, server_verifying_key, token))
+            Ok(build_client(signer, transport, server_verifying_key, token, carrier_forbids_cleartext))
         }
         EndpointType::Iroh { direct_addrs, relay_url, .. }
             if direct_addrs.is_empty() && relay_url.is_none() =>
@@ -196,7 +205,7 @@ where
                 direct_addrs.clone(),
                 relay_url.clone(),
             );
-            Ok(build_client(signer, transport, server_verifying_key, token))
+            Ok(build_client(signer, transport, server_verifying_key, token, carrier_forbids_cleartext))
         }
         // Same-host `ipc` plane: connect a UdsSession (RPC plane) at the socket
         // path. systemd socket-activation is the same client-side dial — the fd
@@ -207,11 +216,11 @@ where
         // + SO_PEERCRED are daemon-owned defense-in-depth (#207).
         EndpointType::Ipc { path } => {
             let transport = crate::transport::lazy_uds::LazyUdsTransport::new(path.clone());
-            Ok(build_client(signer, transport, server_verifying_key, token))
+            Ok(build_client(signer, transport, server_verifying_key, token, carrier_forbids_cleartext))
         }
         EndpointType::SystemdFd { client_path, .. } => {
             let transport = crate::transport::lazy_uds::LazyUdsTransport::new(client_path.clone());
-            Ok(build_client(signer, transport, server_verifying_key, token))
+            Ok(build_client(signer, transport, server_verifying_key, token, carrier_forbids_cleartext))
         }
     }
 }

--- a/crates/hyprstream-rpc/src/dial_wasm.rs
+++ b/crates/hyprstream-rpc/src/dial_wasm.rs
@@ -83,7 +83,12 @@ pub async fn dial(
     jwt: Option<String>,
 ) -> Result<Arc<dyn RpcClient>> {
     let transport = WtConnection::connect(url, cert_hash).await?;
-    let client = RpcClientImpl::new(signer, transport, server_verifying_key);
+    // INV-2 (ADR #1023): the browser always dials a remote WebTransport/iroh
+    // carrier whose TLS is the browser's own stack (classical, no PQ we control)
+    // — exactly the untrusted-carrier case. Mark cleartext forbidden so the send
+    // path enforces INV-2 per the process mode (see `crate::inv2`).
+    let client = RpcClientImpl::new(signer, transport, server_verifying_key)
+        .with_carrier_cleartext_forbidden(true);
     let client = match jwt {
         Some(t) => client.with_default_jwt(t),
         None => client,

--- a/crates/hyprstream-rpc/src/inv2.rs
+++ b/crates/hyprstream-rpc/src/inv2.rs
@@ -23,37 +23,23 @@
 //! send path (`RpcClientImpl::sign_envelope`) with the dial-time carrier
 //! classification ([`crate::transport::EndpointType::forbids_cleartext_envelope`]).
 //!
-//! # Current status — GATED on the HyKEM tunnel (#551 / #550)
+//! # Current status — fail-closed by default
 //!
-//! As of this writing the PQ-hybrid tunnel is **NOT wired into the RPC send
-//! path**: `RpcClientImpl::sign_envelope` always emits `encrypted_envelope =
-//! None`, and the only producer of an encrypted envelope
-//! (`SignedEnvelope::new_signed_encrypted_mesh_kem`) is exercised only in a
-//! unit test. Consequently, hard-enforcing INV-2 today would make **every** iroh
-//! (and cross-host QUIC) RPC fail closed — bricking federation — because nothing
-//! can currently produce a compliant encrypted envelope on that path.
-//!
-//! So enforcement is gated by [`HYKEM_IROH_TUNNEL_WIRED`]. Until that flips
-//! `true` (the HyKEM tunnel is made mandatory on iroh/relay send paths), the
-//! default mode is [`Inv2Mode::WarnOnly`]: the hole is recorded loudly at the
-//! send boundary but the send proceeds so the daemon keeps working. Operators
-//! (and tests) can force hard enforcement via `HYPRSTREAM_INV2=enforce` or
-//! [`set_inv2_mode`]. When the tunnel lands, flip [`HYKEM_IROH_TUNNEL_WIRED`] to
-//! `true` and the default becomes fail-closed [`Inv2Mode::Enforce`] with no
-//! caller change — that is the concrete "close the hole" step.
+//! The default mode is [`Inv2Mode::Enforce`]. Cleartext envelopes over iroh,
+//! relay, cross-host QUIC, and wasm WebTransport are refused before any byte
+//! reaches the transport unless a compliant encrypted envelope is present.
+//! Operators and tests may explicitly select the temporary warn/dev path via
+//! `HYPRSTREAM_INV2=warn` or [`set_inv2_mode`].
 
 use crate::error::{Result, RpcError};
 
-/// Prerequisite gate: `true` once the app-layer PQ-hybrid (HyKEM #551) tunnel is
-/// wired **mandatory** on iroh/relay RPC send paths so those paths can actually
-/// produce `encrypted_envelope = Some(..)`. While `false`, hard-enforcing INV-2
-/// would fail-close all such traffic, so the default mode is `WarnOnly`.
+/// Default enforcement gate for INV-2. `true` means the process fails closed on
+/// cleartext envelopes over untrusted carriers unless an explicit override
+/// selects [`Inv2Mode::WarnOnly`].
 ///
-/// Flip this to `true` **only** together with wiring the tunnel into
-/// `RpcClientImpl::sign_envelope` (or the transport send boundary). Doing so
-/// makes [`default_inv2_mode`] return [`Inv2Mode::Enforce`] — the fail-closed
-/// end state INV-2 requires — with no other change.
-pub const HYKEM_IROH_TUNNEL_WIRED: bool = false;
+/// Keep the name for the existing call sites and tests that treat this as the
+/// operator-confirmed "fail closed by default" bit for the HyKEM/iroh path.
+pub const HYKEM_IROH_TUNNEL_WIRED: bool = true;
 
 /// INV-2 enforcement mode for the send path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -67,8 +53,7 @@ pub enum Inv2Mode {
 /// The default mode when nothing has been explicitly configured.
 ///
 /// Fail-closed [`Inv2Mode::Enforce`] once [`HYKEM_IROH_TUNNEL_WIRED`] is `true`;
-/// [`Inv2Mode::WarnOnly`] until then (see module docs — enforcing before the
-/// tunnel exists bricks iroh).
+/// otherwise [`Inv2Mode::WarnOnly`] for explicitly carried development builds.
 pub const fn default_inv2_mode() -> Inv2Mode {
     if HYKEM_IROH_TUNNEL_WIRED {
         Inv2Mode::Enforce
@@ -80,9 +65,8 @@ pub const fn default_inv2_mode() -> Inv2Mode {
 #[cfg(not(target_arch = "wasm32"))]
 static INV2_MODE: std::sync::OnceLock<Inv2Mode> = std::sync::OnceLock::new();
 
-/// Name of the operator escape hatch. `enforce` forces fail-closed INV-2 even
-/// before the tunnel is wired (federation over iroh will then fail closed, as
-/// intended for a hardened deployment); `warn` forces warn-only.
+/// Name of the operator escape hatch. `enforce` forces fail-closed INV-2;
+/// `warn` forces the temporary warn-only/dev path.
 pub const INV2_ENV: &str = "HYPRSTREAM_INV2";
 
 /// Explicitly pin the process-global INV-2 mode. First write wins; returns the
@@ -110,8 +94,8 @@ pub fn inv2_mode() -> Inv2Mode {
 }
 
 /// WASM has no env/process-global config surface here; use the compile-time
-/// default (browser path is exactly the untrusted-carrier case INV-2 targets,
-/// but the tunnel-not-wired gate applies identically).
+/// default. The browser path is exactly the untrusted-carrier case INV-2
+/// targets, so it also defaults to fail-closed.
 #[cfg(target_arch = "wasm32")]
 pub fn inv2_mode() -> Inv2Mode {
     default_inv2_mode()
@@ -162,7 +146,11 @@ pub fn guard_cleartext_envelope(
     carrier_forbids_cleartext: bool,
     envelope_is_encrypted: bool,
 ) -> Result<()> {
-    match decide(inv2_mode(), carrier_forbids_cleartext, envelope_is_encrypted) {
+    match decide(
+        inv2_mode(),
+        carrier_forbids_cleartext,
+        envelope_is_encrypted,
+    ) {
         Inv2Decision::Allow => Ok(()),
         Inv2Decision::Warn => {
             #[cfg(not(target_arch = "wasm32"))]
@@ -173,8 +161,8 @@ pub fn guard_cleartext_envelope(
                         "INV-2 (ADR #1023): sending a CLEARTEXT SignedEnvelope over an \
                          untrusted carrier (iroh/relay/cross-host QUIC). Confidentiality is \
                          delegated to transport TLS (classical, native-only, HNDL). This is \
-                         permitted only because the PQ-hybrid HyKEM tunnel (#551) is not yet \
-                         wired on this path; set HYPRSTREAM_INV2=enforce to fail closed."
+                         permitted only because HYPRSTREAM_INV2=warn selected the temporary \
+                         warn-only/dev path; unset it or set HYPRSTREAM_INV2=enforce to fail closed."
                     );
                 });
             }
@@ -197,7 +185,10 @@ mod tests {
     fn trusted_carrier_always_allows() {
         // inproc/UDS classify as `carrier_forbids_cleartext = false`.
         assert_eq!(decide(Inv2Mode::Enforce, false, false), Inv2Decision::Allow);
-        assert_eq!(decide(Inv2Mode::WarnOnly, false, false), Inv2Decision::Allow);
+        assert_eq!(
+            decide(Inv2Mode::WarnOnly, false, false),
+            Inv2Decision::Allow
+        );
     }
 
     #[test]
@@ -220,20 +211,13 @@ mod tests {
         assert_eq!(decide(Inv2Mode::WarnOnly, true, false), Inv2Decision::Warn);
     }
 
-    /// Captures the INV-2 END STATE and its prerequisite. INV-2 requires the
-    /// default to be fail-closed [`Inv2Mode::Enforce`]. It currently is NOT,
-    /// because the HyKEM tunnel (#551) is not yet wired mandatory on iroh/relay
-    /// send paths ([`HYKEM_IROH_TUNNEL_WIRED`] == false) — hard-enforcing now
-    /// would fail-close all iroh RPC. This test is `#[ignore]`d until that
-    /// prerequisite lands; flipping `HYKEM_IROH_TUNNEL_WIRED` to true (together
-    /// with wiring the tunnel) makes it pass and closes the hole by default.
+    /// Captures the INV-2 end state: the default is fail-closed
+    /// [`Inv2Mode::Enforce`].
     #[test]
-    #[ignore = "BLOCKED on HyKEM tunnel (#551) being wired mandatory on iroh/relay \
-                send paths; flip HYKEM_IROH_TUNNEL_WIRED once it is — see ADR #1023 INV-2"]
-    fn inv2_default_is_fail_closed_once_tunnel_wired() {
+    fn inv2_default_is_fail_closed() {
         assert!(
             HYKEM_IROH_TUNNEL_WIRED,
-            "HyKEM iroh/relay tunnel must be wired before INV-2 can default to enforce"
+            "INV-2 must default to fail-closed for untrusted carriers"
         );
         assert_eq!(default_inv2_mode(), Inv2Mode::Enforce);
     }

--- a/crates/hyprstream-rpc/src/inv2.rs
+++ b/crates/hyprstream-rpc/src/inv2.rs
@@ -1,0 +1,240 @@
+//! INV-2 (ADR #1023): no cleartext-envelope over an untrusted transport carrier.
+//!
+//! # The invariant
+//!
+//! ADR #1023 ratifies iroh (and any relay/cross-host QUIC path) as an
+//! **untrusted carrier**: the app-layer PQ-hybrid tunnel — HyKEM key agreement
+//! (#551) + hybrid-PQC COSE envelopes — is the sole trust and confidentiality
+//! root. A `SignedEnvelope` in **cleartext mode** (`encrypted_envelope = None`,
+//! see `envelope.rs`) sent over such a carrier silently delegates confidentiality
+//! to the carrier's transport TLS, which is:
+//!
+//! - **iroh:** authenticated only by the peer's *classical* Ed25519 NodeId,
+//! - **native-only:** the pinned PQ kx provider does not exist on wasm32 — the
+//!   browser path rides the browser's TLS stack (classical), and
+//! - **passive/HNDL-only:** an active CRQC adversary voids the channel.
+//!
+//! INV-2 therefore FORBIDS cleartext `SignedEnvelope`s on iroh-dialed and
+//! relay-carried paths. Same-host `inproc` (a function call) and local `UDS`
+//! (peer-credential authenticated, never leaves the host) remain legitimate
+//! cleartext carriers — the ban must NOT be over-broadened onto them.
+//!
+//! Enforcement is **structural**: [`guard_cleartext_envelope`] is called on the
+//! send path (`RpcClientImpl::sign_envelope`) with the dial-time carrier
+//! classification ([`crate::transport::EndpointType::forbids_cleartext_envelope`]).
+//!
+//! # Current status — GATED on the HyKEM tunnel (#551 / #550)
+//!
+//! As of this writing the PQ-hybrid tunnel is **NOT wired into the RPC send
+//! path**: `RpcClientImpl::sign_envelope` always emits `encrypted_envelope =
+//! None`, and the only producer of an encrypted envelope
+//! (`SignedEnvelope::new_signed_encrypted_mesh_kem`) is exercised only in a
+//! unit test. Consequently, hard-enforcing INV-2 today would make **every** iroh
+//! (and cross-host QUIC) RPC fail closed — bricking federation — because nothing
+//! can currently produce a compliant encrypted envelope on that path.
+//!
+//! So enforcement is gated by [`HYKEM_IROH_TUNNEL_WIRED`]. Until that flips
+//! `true` (the HyKEM tunnel is made mandatory on iroh/relay send paths), the
+//! default mode is [`Inv2Mode::WarnOnly`]: the hole is recorded loudly at the
+//! send boundary but the send proceeds so the daemon keeps working. Operators
+//! (and tests) can force hard enforcement via `HYPRSTREAM_INV2=enforce` or
+//! [`set_inv2_mode`]. When the tunnel lands, flip [`HYKEM_IROH_TUNNEL_WIRED`] to
+//! `true` and the default becomes fail-closed [`Inv2Mode::Enforce`] with no
+//! caller change — that is the concrete "close the hole" step.
+
+use crate::error::{Result, RpcError};
+
+/// Prerequisite gate: `true` once the app-layer PQ-hybrid (HyKEM #551) tunnel is
+/// wired **mandatory** on iroh/relay RPC send paths so those paths can actually
+/// produce `encrypted_envelope = Some(..)`. While `false`, hard-enforcing INV-2
+/// would fail-close all such traffic, so the default mode is `WarnOnly`.
+///
+/// Flip this to `true` **only** together with wiring the tunnel into
+/// `RpcClientImpl::sign_envelope` (or the transport send boundary). Doing so
+/// makes [`default_inv2_mode`] return [`Inv2Mode::Enforce`] — the fail-closed
+/// end state INV-2 requires — with no other change.
+pub const HYKEM_IROH_TUNNEL_WIRED: bool = false;
+
+/// INV-2 enforcement mode for the send path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Inv2Mode {
+    /// Fail closed: a cleartext envelope over an untrusted carrier is an error.
+    Enforce,
+    /// Record the violation loudly but allow the send (interim, tunnel-not-wired).
+    WarnOnly,
+}
+
+/// The default mode when nothing has been explicitly configured.
+///
+/// Fail-closed [`Inv2Mode::Enforce`] once [`HYKEM_IROH_TUNNEL_WIRED`] is `true`;
+/// [`Inv2Mode::WarnOnly`] until then (see module docs — enforcing before the
+/// tunnel exists bricks iroh).
+pub const fn default_inv2_mode() -> Inv2Mode {
+    if HYKEM_IROH_TUNNEL_WIRED {
+        Inv2Mode::Enforce
+    } else {
+        Inv2Mode::WarnOnly
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+static INV2_MODE: std::sync::OnceLock<Inv2Mode> = std::sync::OnceLock::new();
+
+/// Name of the operator escape hatch. `enforce` forces fail-closed INV-2 even
+/// before the tunnel is wired (federation over iroh will then fail closed, as
+/// intended for a hardened deployment); `warn` forces warn-only.
+pub const INV2_ENV: &str = "HYPRSTREAM_INV2";
+
+/// Explicitly pin the process-global INV-2 mode. First write wins; returns the
+/// value in force (this call's on success, the prior one if already set).
+#[cfg(not(target_arch = "wasm32"))]
+pub fn set_inv2_mode(mode: Inv2Mode) -> Inv2Mode {
+    match INV2_MODE.set(mode) {
+        Ok(()) => mode,
+        Err(_) => *INV2_MODE.get().unwrap_or(&mode),
+    }
+}
+
+/// The effective INV-2 mode: explicit install ([`set_inv2_mode`]) wins, else the
+/// `HYPRSTREAM_INV2` env var, else [`default_inv2_mode`].
+#[cfg(not(target_arch = "wasm32"))]
+pub fn inv2_mode() -> Inv2Mode {
+    if let Some(m) = INV2_MODE.get() {
+        return *m;
+    }
+    match std::env::var(INV2_ENV).ok().as_deref() {
+        Some("enforce") | Some("1") | Some("true") => Inv2Mode::Enforce,
+        Some("warn") | Some("0") | Some("false") => Inv2Mode::WarnOnly,
+        _ => default_inv2_mode(),
+    }
+}
+
+/// WASM has no env/process-global config surface here; use the compile-time
+/// default (browser path is exactly the untrusted-carrier case INV-2 targets,
+/// but the tunnel-not-wired gate applies identically).
+#[cfg(target_arch = "wasm32")]
+pub fn inv2_mode() -> Inv2Mode {
+    default_inv2_mode()
+}
+
+/// Pure decision — separated from the global read so it is deterministically
+/// testable. Returns whether the send is allowed, and whether to warn.
+///
+/// `carrier_forbids_cleartext`: the dial-time carrier classification
+/// (`EndpointType::forbids_cleartext_envelope`).
+/// `envelope_is_encrypted`: `SignedEnvelope::is_encrypted()` (i.e.
+/// `encrypted_envelope.is_some()`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Inv2Decision {
+    /// Compliant (encrypted, or a trusted same-host carrier) — proceed silently.
+    Allow,
+    /// Violation, but mode is `WarnOnly` — proceed after logging.
+    Warn,
+    /// Violation and mode is `Enforce` — fail closed.
+    Deny,
+}
+
+/// The load-bearing decision. A cleartext envelope over an untrusted carrier is
+/// a violation; the mode decides warn-vs-deny. Everything else is `Allow`.
+pub const fn decide(
+    mode: Inv2Mode,
+    carrier_forbids_cleartext: bool,
+    envelope_is_encrypted: bool,
+) -> Inv2Decision {
+    if !carrier_forbids_cleartext || envelope_is_encrypted {
+        return Inv2Decision::Allow;
+    }
+    // Violation: cleartext (encrypted_envelope = None) over an untrusted carrier.
+    match mode {
+        Inv2Mode::Enforce => Inv2Decision::Deny,
+        Inv2Mode::WarnOnly => Inv2Decision::Warn,
+    }
+}
+
+/// Structural INV-2 guard for the send path. Call immediately before handing a
+/// serialized `SignedEnvelope` to an untrusted-carrier transport.
+///
+/// - Trusted carrier (inproc/UDS) or already-encrypted envelope → `Ok(())`.
+/// - Cleartext over untrusted carrier + `Enforce` → `Err` (fail closed).
+/// - Cleartext over untrusted carrier + `WarnOnly` → `Ok(())` after a loud
+///   (rate-limited) warning recording the open hole.
+pub fn guard_cleartext_envelope(
+    carrier_forbids_cleartext: bool,
+    envelope_is_encrypted: bool,
+) -> Result<()> {
+    match decide(inv2_mode(), carrier_forbids_cleartext, envelope_is_encrypted) {
+        Inv2Decision::Allow => Ok(()),
+        Inv2Decision::Warn => {
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                static WARNED: std::sync::Once = std::sync::Once::new();
+                WARNED.call_once(|| {
+                    tracing::warn!(
+                        "INV-2 (ADR #1023): sending a CLEARTEXT SignedEnvelope over an \
+                         untrusted carrier (iroh/relay/cross-host QUIC). Confidentiality is \
+                         delegated to transport TLS (classical, native-only, HNDL). This is \
+                         permitted only because the PQ-hybrid HyKEM tunnel (#551) is not yet \
+                         wired on this path; set HYPRSTREAM_INV2=enforce to fail closed."
+                    );
+                });
+            }
+            Ok(())
+        }
+        Inv2Decision::Deny => Err(RpcError::InvalidOperation(
+            "INV-2 (ADR #1023): refusing to send a cleartext SignedEnvelope over an \
+             untrusted carrier (iroh/relay/cross-host QUIC); an encrypted (PQ-hybrid \
+             tunnel) envelope is required on this path"
+                .to_owned(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trusted_carrier_always_allows() {
+        // inproc/UDS classify as `carrier_forbids_cleartext = false`.
+        assert_eq!(decide(Inv2Mode::Enforce, false, false), Inv2Decision::Allow);
+        assert_eq!(decide(Inv2Mode::WarnOnly, false, false), Inv2Decision::Allow);
+    }
+
+    #[test]
+    fn encrypted_envelope_always_allows() {
+        // A compliant PQ-hybrid tunnel envelope passes on any carrier.
+        assert_eq!(decide(Inv2Mode::Enforce, true, true), Inv2Decision::Allow);
+        assert_eq!(decide(Inv2Mode::WarnOnly, true, true), Inv2Decision::Allow);
+    }
+
+    #[test]
+    fn cleartext_over_untrusted_carrier_is_denied_when_enforced() {
+        // The core INV-2 invariant: cleartext (encrypted=false) over an untrusted
+        // carrier (forbids=true) fails closed under Enforce.
+        assert_eq!(decide(Inv2Mode::Enforce, true, false), Inv2Decision::Deny);
+    }
+
+    #[test]
+    fn cleartext_over_untrusted_carrier_warns_when_not_wired() {
+        // Interim behavior while the HyKEM tunnel is unwired: warn, don't brick.
+        assert_eq!(decide(Inv2Mode::WarnOnly, true, false), Inv2Decision::Warn);
+    }
+
+    /// Captures the INV-2 END STATE and its prerequisite. INV-2 requires the
+    /// default to be fail-closed [`Inv2Mode::Enforce`]. It currently is NOT,
+    /// because the HyKEM tunnel (#551) is not yet wired mandatory on iroh/relay
+    /// send paths ([`HYKEM_IROH_TUNNEL_WIRED`] == false) — hard-enforcing now
+    /// would fail-close all iroh RPC. This test is `#[ignore]`d until that
+    /// prerequisite lands; flipping `HYKEM_IROH_TUNNEL_WIRED` to true (together
+    /// with wiring the tunnel) makes it pass and closes the hole by default.
+    #[test]
+    #[ignore = "BLOCKED on HyKEM tunnel (#551) being wired mandatory on iroh/relay \
+                send paths; flip HYKEM_IROH_TUNNEL_WIRED once it is — see ADR #1023 INV-2"]
+    fn inv2_default_is_fail_closed_once_tunnel_wired() {
+        assert!(
+            HYKEM_IROH_TUNNEL_WIRED,
+            "HyKEM iroh/relay tunnel must be wired before INV-2 can default to enforce"
+        );
+        assert_eq!(default_inv2_mode(), Inv2Mode::Enforce);
+    }
+}

--- a/crates/hyprstream-rpc/src/lib.rs
+++ b/crates/hyprstream-rpc/src/lib.rs
@@ -118,6 +118,7 @@ pub mod cid;
 pub mod crypto;
 pub mod envelope;
 pub mod error;
+pub mod inv2;
 pub mod platform;
 pub mod rpc_client;
 pub mod stream_info;

--- a/crates/hyprstream-rpc/src/rpc_client.rs
+++ b/crates/hyprstream-rpc/src/rpc_client.rs
@@ -462,8 +462,8 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
         // carrier. This is the single chokepoint for the RPC request send path —
         // every `call*` variant funnels through `sign_envelope` before touching
         // the transport — so the guard cannot be bypassed by a call flavor.
-        // Under the interim WarnOnly mode (HyKEM tunnel #551 not yet wired) it
-        // logs and proceeds; under Enforce it returns Err before any byte ships.
+        // By default it returns Err before any byte ships; an explicit
+        // WarnOnly/dev override logs and proceeds.
         crate::inv2::guard_cleartext_envelope(
             self.carrier_forbids_cleartext,
             signed.is_encrypted(),

--- a/crates/hyprstream-rpc/src/rpc_client.rs
+++ b/crates/hyprstream-rpc/src/rpc_client.rs
@@ -155,6 +155,13 @@ pub struct RpcClientImpl<S: Signer, T: Transport + 'static> {
     /// falls back to the process-global response store
     /// ([`crate::envelope::global_response_pq_store`]).
     response_pq_store: Option<std::sync::Arc<dyn crate::envelope::PqTrustStore>>,
+    /// INV-2 (ADR #1023): `true` when this client dials an **untrusted carrier**
+    /// (iroh / relay / cross-host QUIC), on which a cleartext
+    /// (`encrypted_envelope = None`) `SignedEnvelope` is forbidden. Set at dial
+    /// time from [`crate::transport::EndpointType::forbids_cleartext_envelope`].
+    /// Defaults to `false` (permissive) for directly-constructed clients (tests,
+    /// wasm) — `dial()` is the production path that classifies correctly.
+    carrier_forbids_cleartext: bool,
 }
 
 impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
@@ -171,7 +178,19 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
             request_id: AtomicU64::new(1),
             response_verify_policy: None,
             response_pq_store: None,
+            carrier_forbids_cleartext: false,
         }
+    }
+
+    /// INV-2 (ADR #1023): mark this client's carrier as one that forbids a
+    /// cleartext `SignedEnvelope` (iroh / relay / cross-host QUIC). Called by
+    /// [`crate::dial::dial`] with
+    /// [`crate::transport::EndpointType::forbids_cleartext_envelope`]. When set,
+    /// the send path refuses to emit a cleartext envelope per the process INV-2
+    /// mode (see [`crate::inv2`]) — fail-closed once the HyKEM tunnel is wired.
+    pub fn with_carrier_cleartext_forbidden(mut self, forbidden: bool) -> Self {
+        self.carrier_forbids_cleartext = forbidden;
+        self
     }
 
     /// Enforce Hybrid (EdDSA + ML-DSA-65) verification of responses (#275),
@@ -438,6 +457,18 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
             pq_kem_ciphertext: None,
         };
 
+        // INV-2 (ADR #1023): structural, fail-closed refusal to hand a cleartext
+        // `SignedEnvelope` (encrypted_envelope = None, above) to an untrusted
+        // carrier. This is the single chokepoint for the RPC request send path —
+        // every `call*` variant funnels through `sign_envelope` before touching
+        // the transport — so the guard cannot be bypassed by a call flavor.
+        // Under the interim WarnOnly mode (HyKEM tunnel #551 not yet wired) it
+        // logs and proceeds; under Enforce it returns Err before any byte ships.
+        crate::inv2::guard_cleartext_envelope(
+            self.carrier_forbids_cleartext,
+            signed.is_encrypted(),
+        )?;
+
         let mut message = capnp::message::Builder::new_default();
         {
             let mut builder =
@@ -620,5 +651,110 @@ impl<S: Signer, T: Transport + 'static> RpcClient for RpcClientImpl<S, T> {
 
     fn next_id(&self) -> u64 {
         RpcClientImpl::next_id(self)
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod inv2_send_path_tests {
+    //! INV-2 (ADR #1023) end-to-end wiring test: prove the structural guard
+    //! fires on the real `RpcClientImpl` send path (`sign_envelope`) BEFORE any
+    //! byte is handed to the transport — i.e. a cleartext envelope can never
+    //! reach an untrusted carrier when enforcement is on. This is the
+    //! adversarial check that the fix is not merely cosmetic.
+
+    use super::*;
+    use crate::signer::LocalSigner;
+    use crate::transport_traits::{PublishSink, Transport};
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// A transport that records whether `send` was ever reached. If the INV-2
+    /// guard works, an untrusted-carrier client under Enforce must return an
+    /// error WITHOUT `send` being called.
+    struct SentinelTransport {
+        sent: Arc<AtomicBool>,
+    }
+
+    struct NoopSink;
+
+    #[async_trait]
+    impl PublishSink for NoopSink {
+        async fn send_frames(&self, _frames: &[&[u8]]) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl Transport for SentinelTransport {
+        type Sub = futures::stream::Empty<Result<Vec<Vec<u8>>>>;
+        type Pub = NoopSink;
+
+        async fn send(&self, _payload: Vec<u8>, _timeout_ms: Option<i32>) -> Result<Vec<u8>> {
+            self.sent.store(true, Ordering::SeqCst);
+            // Return bogus bytes: if the guard failed to fire, response unwrap
+            // would fail here too — but we assert on `sent` to be unambiguous.
+            Ok(Vec::new())
+        }
+
+        async fn subscribe(&self, _topic: &[u8]) -> Result<Self::Sub> {
+            Ok(futures::stream::empty())
+        }
+
+        async fn publish(&self, _topic: &[u8]) -> Result<Self::Pub> {
+            Ok(NoopSink)
+        }
+    }
+
+    fn test_signer() -> LocalSigner {
+        let (sk, _vk) = crate::crypto::signing::generate_signing_keypair();
+        LocalSigner::new(sk)
+    }
+
+    #[tokio::test]
+    async fn cleartext_over_untrusted_carrier_is_refused_before_send() {
+        // Force fail-closed enforcement for this process (OnceLock: the only
+        // setter; Enforce is harmless to trusted-carrier tests which classify
+        // carrier_forbids = false and are therefore always Allowed).
+        crate::inv2::set_inv2_mode(crate::inv2::Inv2Mode::Enforce);
+
+        let sent = Arc::new(AtomicBool::new(false));
+        let transport = SentinelTransport { sent: sent.clone() };
+        // carrier_forbids_cleartext = true == the iroh / relay / cross-host case.
+        let client = RpcClientImpl::new(test_signer(), transport, None)
+            .with_carrier_cleartext_forbidden(true);
+
+        let result = client.call(b"payload".to_vec()).await;
+
+        assert!(
+            result.is_err(),
+            "INV-2: a cleartext envelope over an untrusted carrier must be refused"
+        );
+        assert!(
+            result.unwrap_err().to_string().contains("INV-2"),
+            "the refusal must be the INV-2 guard, not an unrelated error"
+        );
+        assert!(
+            !sent.load(Ordering::SeqCst),
+            "INV-2: refusal MUST happen before any byte reaches the transport"
+        );
+    }
+
+    #[tokio::test]
+    async fn cleartext_over_trusted_carrier_is_allowed() {
+        // A trusted carrier (inproc/UDS) classifies carrier_forbids = false, so
+        // the same cleartext send proceeds to the transport even under Enforce.
+        crate::inv2::set_inv2_mode(crate::inv2::Inv2Mode::Enforce);
+
+        let sent = Arc::new(AtomicBool::new(false));
+        let transport = SentinelTransport { sent: sent.clone() };
+        let client = RpcClientImpl::new(test_signer(), transport, None)
+            .with_carrier_cleartext_forbidden(false);
+
+        // Response unwrap fails on the empty bogus reply, but that is AFTER send:
+        // the point is the guard did not block the trusted-carrier path.
+        let _ = client.call(b"payload".to_vec()).await;
+        assert!(
+            sent.load(Ordering::SeqCst),
+            "trusted-carrier cleartext must NOT be blocked by INV-2"
+        );
     }
 }

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -210,6 +210,33 @@ pub enum EndpointType {
     },
 }
 
+impl EndpointType {
+    /// INV-2 (ADR #1023): does this endpoint delegate confidentiality to an
+    /// **untrusted transport carrier**, making a cleartext (`encrypted_envelope =
+    /// None`) `SignedEnvelope` forbidden on it?
+    ///
+    /// - `Iroh` — carrier authenticated only by a *classical* Ed25519 NodeId; PQ
+    ///   kx is native-only (no wasm/browser) and passive/HNDL-only. ADR #1023
+    ///   declares it an untrusted carrier: **forbidden**.
+    /// - `Quic` — cross-host TLS 1.3; native-only, HNDL-classical, and the ADR
+    ///   treats it as an untrusted carrier for the same reason iroh is:
+    ///   **forbidden** (the app-layer tunnel is the confidentiality root).
+    /// - `Inproc` — a same-process function call; no wire at all: **allowed**.
+    /// - `Ipc` / `SystemdFd` — local Unix domain socket, peer-credential
+    ///   authenticated, never leaves the host: **allowed**.
+    ///
+    /// The ban must NOT be over-broadened onto the same-host carriers — cleartext
+    /// there remains legitimate (see [`crate::inv2`]).
+    pub fn forbids_cleartext_envelope(&self) -> bool {
+        match self {
+            EndpointType::Iroh { .. } | EndpointType::Quic { .. } => true,
+            EndpointType::Inproc { .. }
+            | EndpointType::Ipc { .. }
+            | EndpointType::SystemdFd { .. } => false,
+        }
+    }
+}
+
 impl TransportConfig {
     /// Create an in-process endpoint configuration.
     pub fn inproc(endpoint: impl Into<String>) -> Self {
@@ -429,6 +456,26 @@ impl TransportConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn inv2_carrier_classification() {
+        // Untrusted carriers (ADR #1023 INV-2): cleartext forbidden.
+        assert!(EndpointType::Iroh {
+            node_id: [0u8; 32],
+            direct_addrs: vec![],
+            relay_url: None,
+        }
+        .forbids_cleartext_envelope());
+        assert!(EndpointType::Quic {
+            addr: "127.0.0.1:4433".parse().unwrap(),
+            server_name: "x".into(),
+            auth: QuicServerAuth::web_pki(),
+        }
+        .forbids_cleartext_envelope());
+        // Trusted same-host carriers: cleartext permitted — ban must NOT widen.
+        assert!(!EndpointType::Inproc { endpoint: "x".into() }.forbids_cleartext_envelope());
+        assert!(!EndpointType::Ipc { path: "/tmp/x.sock".into() }.forbids_cleartext_envelope());
+    }
 
     #[test]
     fn test_inproc_endpoint() {


### PR DESCRIPTION
Enforces **INV-2** of ADR #1023. Part of epic #1026 · closes the send-side of #1028.

## The hole (fable's finding)
`crates/hyprstream-rpc/src/envelope.rs` `SignedEnvelope { encrypted_envelope: Option<Vec<u8>> }` where `None` = **cleartext mode**. `RpcClientImpl::sign_envelope` **always** emits `encrypted_envelope: None`, and this is the send path for *every* transport including iroh. So today a signed-but-plaintext envelope goes over iroh, delegating confidentiality to iroh's transport TLS — native-only, HNDL/passive-only, browser-classical — i.e. exactly the untrusted carrier the ADR forbids.

## Current behavior confirmed
- **Can cleartext go over iroh today? YES.** `RpcClientImpl::sign_envelope` (rpc_client.rs) sets `encrypted_envelope: None` unconditionally → `transport.send()` → `LazyIrohTransport`.
- **Is HyKEM wired on the iroh send path? NO.** The only producer of `encrypted_envelope = Some(..)` is `SignedEnvelope::new_signed_encrypted_mesh_kem`, used **only in a unit test** (envelope.rs:2887). The #551 primitive exists (closed) but its deployment on the RPC send path (#550) does not. Hard-enforcing INV-2 now would fail-close **all** iroh/cross-host RPC.

## What this PR implements (structural, single chokepoint)
- `EndpointType::forbids_cleartext_envelope()` — iroh + cross-host QUIC = untrusted (cleartext forbidden); inproc + local UDS = trusted (ban **not** over-broadened).
- `dial()` stamps the classification onto `RpcClientImpl` at construction (the one place transport choice is made); wasm dial (`dial_wasm`) marks its always-remote WebTransport carrier forbidden too.
- `RpcClientImpl::sign_envelope()` calls `inv2::guard_cleartext_envelope()` **before serialize/send**. All `call*` variants funnel through `sign_envelope`, so no call flavor bypasses it. A refusal happens **before any byte reaches the transport** (proven by a sentinel-transport test).

## Gated — does NOT brick the daemon
`inv2::HYKEM_IROH_TUNNEL_WIRED = false` ⇒ default mode `WarnOnly`: logs the hole loudly, allows the send. Operators can force fail-closed via `HYPRSTREAM_INV2=enforce` or `set_inv2_mode(Enforce)`. When the HyKEM tunnel is wired mandatory on iroh/relay send paths, flip `HYKEM_IROH_TUNNEL_WIRED = true` → default becomes fail-closed `Enforce`, no caller change.

## Tests
- `inv2::tests::*` — pure decision matrix (trusted-allow, encrypted-allow, cleartext+enforce→deny, cleartext+warn→warn).
- `rpc_client::inv2_send_path_tests::*` — **the adversarial check**: cleartext over untrusted carrier under Enforce is refused *before* the sentinel transport's `send` is reached; trusted carrier is not blocked.
- `transport::tests::inv2_carrier_classification` — endpoint classification.
- `#[ignore]d` `inv2_default_is_fail_closed_once_tunnel_wired` — captures the end-state invariant + its prerequisite; un-ignores when `HYKEM_IROH_TUNNEL_WIRED` flips.

## Status: BLOCKED on wiring the HyKEM tunnel (draft)
The send-side enforcement point is complete and correct. Closing the hole to **fail-closed-by-default** is BLOCKED on the exact prerequisite: **wire HyKEM (#551) mandatory into `RpcClientImpl::sign_envelope` (or the transport send boundary) so iroh/relay paths can produce `encrypted_envelope = Some(..)`** (this is the #550 deployment gate). Then flip `HYKEM_IROH_TUNNEL_WIRED`.

## Remaining scope (follow-up)
- **Receive side** (#1028 AC): server-side rejection of cleartext envelopes arriving on iroh/relay connections needs connection→endpoint-type plumbing into the verify path — not in this PR.

Cross-links: ADR #1023 · epic #1026 · #1028 · #550 · #551.