### PR TITLE
fix(cli): initialize RPC verification and recover TUI key

### DIFF
--- a/crates/hyprstream-pds/src/at9p.rs
+++ b/crates/hyprstream-pds/src/at9p.rs
@@ -708,7 +708,7 @@ impl UpdateRecord {
 
     pub fn to_dag_cbor(&self) -> Result<Vec<u8>> {
         self.validate()?;
-        Ok(self.to_value().encode())
+        Ok(self.encode_value())
     }
 
     /// Serialize without re-validating. For crate-internal digest/state

--- a/crates/hyprstream-pds/src/at9p.rs
+++ b/crates/hyprstream-pds/src/at9p.rs
@@ -637,7 +637,7 @@ impl Capsule {
 
     pub fn to_dag_cbor(&self) -> Result<Vec<u8>> {
         self.validate()?;
-        Ok(self.to_value().encode())
+        Ok(self.encode_value())
     }
 
     pub fn from_dag_cbor(bytes: &[u8]) -> Result<Self> {
@@ -646,6 +646,14 @@ impl Capsule {
 
     pub fn cid512(&self) -> Result<String> {
         at9p_capsule_cid512(&self.to_dag_cbor()?)
+    }
+
+    /// Serialize without re-validating. For crate-internal digest/state
+    /// projection over capsules already known to be valid — they reached here
+    /// via [`Self::from_dag_cbor`] (validated) or the signing path. External
+    /// callers must use [`Self::to_dag_cbor`].
+    pub(crate) fn encode_value(&self) -> Vec<u8> {
+        self.to_value().encode()
     }
 
     fn to_value(&self) -> DagCbor {

--- a/crates/hyprstream-pds/src/at9p_duplicity.rs
+++ b/crates/hyprstream-pds/src/at9p_duplicity.rs
@@ -217,8 +217,8 @@ impl PredecessorRecord<'_> {
     /// the watermark pins is verified to describe *these* bytes.
     pub fn record_digest(&self) -> [u8; H512_LEN] {
         match self {
-            PredecessorRecord::Genesis(cap) => h512(&cap.to_dag_cbor()),
-            PredecessorRecord::Update(rec) => h512(&rec.to_dag_cbor()),
+            PredecessorRecord::Genesis(cap) => h512(&cap.encode_value()),
+            PredecessorRecord::Update(rec) => h512(&rec.encode_value()),
         }
     }
 
@@ -2263,7 +2263,6 @@ mod tests {
             Some(DuplicityKind::HigherEpochFork)
         );
     }
-
 
     // Small accessors so the guard's sink can be inspected in-test.
     impl DuplicityGuard<InMemoryWatermarkStore, RecordingSink> {

--- a/crates/hyprstream-pds/src/name_record.rs
+++ b/crates/hyprstream-pds/src/name_record.rs
@@ -220,35 +220,39 @@ fn validate_pin_cid(s: &str) -> Result<()> {
 
 #[cfg(test)]
 fn sample_pin() -> String {
-    hyprstream_rpc::cid::encode_cid(
+    match hyprstream_rpc::cid::encode_cid(
         hyprstream_rpc::cid::Codec::GitRaw,
         hyprstream_rpc::cid::HashAlgo::Sha2_256,
         &[0x42; 32],
-    )
-    .expect("valid sample CID")
+    ) {
+        Ok(cid) => cid,
+        Err(err) => panic!("valid sample CID: {err}"),
+    }
 }
 
 #[cfg(test)]
 fn sample_at9p_pin() -> String {
-    hyprstream_rpc::cid::encode_cid(
+    match hyprstream_rpc::cid::encode_cid(
         hyprstream_rpc::cid::Codec::At9pCapsule,
         hyprstream_rpc::cid::HashAlgo::Blake3,
         &[0x24; 64],
-    )
-    .expect("valid sample at9p CID")
+    ) {
+        Ok(cid) => cid,
+        Err(err) => panic!("valid sample at9p CID: {err}"),
+    }
 }
 
 #[cfg(test)]
 fn truncated_pin() -> String {
-    hyprstream_rpc::cid::encode_cid(
+    let cid = match hyprstream_rpc::cid::encode_cid(
         hyprstream_rpc::cid::Codec::GitRaw,
         hyprstream_rpc::cid::HashAlgo::Sha2_256,
         &[0x11; 32],
-    )
-    .expect("valid CID")
-    .chars()
-    .take(12)
-    .collect()
+    ) {
+        Ok(cid) => cid,
+        Err(err) => panic!("valid CID: {err}"),
+    };
+    cid.chars().take(12).collect()
 }
 
 #[cfg(test)]

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1616,6 +1616,13 @@ fn main() -> Result<()> {
         .validate()
         .context("Configuration validation failed")?;
 
+    // RPC clients are used by ordinary CLI commands (`quick`, `tui`, etc.),
+    // not only by service entrypoints. Install both request- and response-side
+    // verification defaults before dispatch so every command uses the
+    // operator-configured mesh trust store (#1018). The installer is
+    // first-write-wins, so the service-specific calls below remain harmless.
+    install_envelope_verify_config(Some(&config.oauth));
+
     // Install the per-service streaming-response concurrency cap from config
     // (#186) before any RPC service starts. First-write-wins; ignore if already
     // installed on this process.

--- a/crates/hyprstream/src/cli/shell_handlers.rs
+++ b/crates/hyprstream/src/cli/shell_handlers.rs
@@ -130,6 +130,9 @@ pub async fn handle_shell_tui(
     use hyprstream_rpc::streaming::StreamPayload;
 
     let client = create_tui_client(signing_key)?;
+    // Resolve the signal-handler client before raw-mode and background-thread
+    // side effects so a failure returns with the terminal untouched.
+    let resize_client = create_tui_client(signing_key)?;
     let (cols, rows) = terminal_size();
     let pane_rows = rows.saturating_sub(4); // status(1) + top border(1) + bottom border(1) + strip(1)
     let pane_cols = cols.saturating_sub(2); // left + right border
@@ -390,9 +393,7 @@ pub async fn handle_shell_tui(
     worker_refresh.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     // SIGWINCH — forward terminal resize to TuiService and compositor.
-    let sigwinch_key = signing_key.clone();
     let resize_tx_sigwinch = resize_tx.clone();
-    let resize_client = create_tui_client(&sigwinch_key)?;
     let _sigwinch_handle = tokio::spawn(async move {
         use tokio::signal::unix::{signal, SignalKind};
         let mut sigwinch = match signal(SignalKind::window_change()) {

--- a/crates/hyprstream/src/cli/shell_handlers.rs
+++ b/crates/hyprstream/src/cli/shell_handlers.rs
@@ -129,7 +129,7 @@ pub async fn handle_shell_tui(
     };
     use hyprstream_rpc::streaming::StreamPayload;
 
-    let client = create_tui_client(signing_key);
+    let client = create_tui_client(signing_key)?;
     let (cols, rows) = terminal_size();
     let pane_rows = rows.saturating_sub(4); // status(1) + top border(1) + bottom border(1) + strip(1)
     let pane_cols = cols.saturating_sub(2); // left + right border
@@ -392,13 +392,13 @@ pub async fn handle_shell_tui(
     // SIGWINCH — forward terminal resize to TuiService and compositor.
     let sigwinch_key = signing_key.clone();
     let resize_tx_sigwinch = resize_tx.clone();
+    let resize_client = create_tui_client(&sigwinch_key)?;
     let _sigwinch_handle = tokio::spawn(async move {
         use tokio::signal::unix::{signal, SignalKind};
         let mut sigwinch = match signal(SignalKind::window_change()) {
             Ok(s) => s,
             Err(_) => return,
         };
-        let resize_client = create_tui_client(&sigwinch_key);
         loop {
             sigwinch.recv().await;
             let (c, r) = terminal_size();
@@ -1564,7 +1564,7 @@ pub async fn handle_tui_shell(
     use crate::cli::tui_handlers::{create_tui_client, terminal_size};
 
     let (cols, rows) = terminal_size();
-    let client = create_tui_client(signing_key);
+    let client = create_tui_client(signing_key)?;
 
     let registry_dir = models_dir.join(".registry").join("models");
     let registry_dir = if registry_dir.exists() { registry_dir } else { models_dir.to_path_buf() };

--- a/crates/hyprstream/src/cli/tui_handlers.rs
+++ b/crates/hyprstream/src/cli/tui_handlers.rs
@@ -51,7 +51,23 @@ pub fn create_tui_client(signing_key: &SigningKey) -> TuiClient {
                 },
                 Err(_) => panic!("Invalid key length from PolicyService"),
             },
-            Err(e) => panic!("Failed to resolve TUI service key: {e}"),
+            Err(e) => {
+                // The bootstrap key set is an operator-authored trust anchor,
+                // not a derived or self-asserted fallback. It is populated in
+                // CLI mode before client construction and lets a client recover
+                // when PolicyService's process-local registration table was
+                // restarted or missed the TUI service registration (#1018).
+                // A subsequently returned response is still pinned to this key.
+                if let Some(vk) = hyprstream_service::global_trust_store().resolve_one("tui") {
+                    tracing::warn!(
+                        error = %e,
+                        "PolicyService did not resolve the TUI key; using provisioned bootstrap key"
+                    );
+                    vk
+                } else {
+                    panic!("Failed to resolve TUI service key: {e}")
+                }
+            }
         }
     };
 

--- a/crates/hyprstream/src/cli/tui_handlers.rs
+++ b/crates/hyprstream/src/cli/tui_handlers.rs
@@ -12,7 +12,7 @@
 // CLI handlers intentionally print to stdout/stderr for user interaction
 #![allow(clippy::print_stdout, clippy::print_stderr, clippy::expect_used)]
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use ed25519_dalek::SigningKey;
 use std::io::Write;
 use tracing::info;
@@ -23,17 +23,14 @@ use crate::services::generated::tui_client::{TuiClient, ConnectRequest, DisplayM
 ///
 /// Resolves the TUI service verifying key via PolicyService, then dials the
 /// TUI service via the registry (inproc or QUIC — transport-agnostic).
-pub fn create_tui_client(signing_key: &SigningKey) -> TuiClient {
+pub fn create_tui_client(signing_key: &SigningKey) -> Result<TuiClient> {
     let sk = signing_key.clone();
 
     // Bootstrap: PolicyService uses the root key in inproc mode
     let policy_vk = signing_key.verifying_key();
-    let policy_client = match crate::services::PolicyClient::for_service(
+    let policy_client = crate::services::PolicyClient::for_service(
         sk.clone(), policy_vk, None,
-    ) {
-        Ok(c) => c,
-        Err(e) => panic!("Failed to create PolicyClient: {e}"),
-    };
+    ).context("Failed to create PolicyClient")?;
     let server_vk = {
         let resp = tokio::task::block_in_place(|| {
             let rt = tokio::runtime::Handle::current();
@@ -43,38 +40,16 @@ pub fn create_tui_client(signing_key: &SigningKey) -> TuiClient {
                 },
             ))
         });
-        match resp {
-            Ok(r) => match <[u8; 32]>::try_from(r.verifying_key.as_slice()) {
-                Ok(bytes) => match hyprstream_rpc::crypto::VerifyingKey::from_bytes(&bytes) {
-                    Ok(vk) => vk,
-                    Err(_) => panic!("Invalid Ed25519 key from PolicyService"),
-                },
-                Err(_) => panic!("Invalid key length from PolicyService"),
-            },
-            Err(e) => {
-                // The bootstrap key set is an operator-authored trust anchor,
-                // not a derived or self-asserted fallback. It is populated in
-                // CLI mode before client construction and lets a client recover
-                // when PolicyService's process-local registration table was
-                // restarted or missed the TUI service registration (#1018).
-                // A subsequently returned response is still pinned to this key.
-                if let Some(vk) = hyprstream_service::global_trust_store().resolve_one("tui") {
-                    tracing::warn!(
-                        error = %e,
-                        "PolicyService did not resolve the TUI key; using provisioned bootstrap key"
-                    );
-                    vk
-                } else {
-                    panic!("Failed to resolve TUI service key: {e}")
-                }
-            }
-        }
+        let response = resp.context(
+            "TUI service is not registered with PolicyService; identity-bound service resolution is required",
+        )?;
+        let bytes: [u8; 32] = response.verifying_key.as_slice().try_into()
+            .map_err(|_| anyhow!("PolicyService returned an invalid TUI verifying-key length"))?;
+        hyprstream_rpc::crypto::VerifyingKey::from_bytes(&bytes)
+            .context("PolicyService returned an invalid TUI Ed25519 key")?
     };
 
-    match TuiClient::for_service(sk, server_vk, None) {
-        Ok(c) => c,
-        Err(e) => panic!("Failed to create TuiClient: {e}"),
-    }
+    TuiClient::for_service(sk, server_vk, None).context("Failed to create TuiClient")
 }
 
 /// Attach to an existing TUI session.
@@ -86,7 +61,7 @@ pub async fn handle_tui_attach(signing_key: &SigningKey, session_id: Option<u32>
     let sid = session_id.unwrap_or(0);
     info!(session_id = sid, "Attaching to TUI session");
 
-    let client = create_tui_client(signing_key);
+    let client = create_tui_client(signing_key)?;
     let (cols, rows) = terminal_size();
 
     // Connect to session via generated TuiClient
@@ -255,7 +230,7 @@ async fn run_attach_loop(
 pub async fn handle_tui_new(signing_key: &SigningKey) -> Result<()> {
     info!("Creating new TUI session");
 
-    let client = create_tui_client(signing_key);
+    let client = create_tui_client(signing_key)?;
     let window_info = client.create_window().await
         .context("Failed to create window. Is the TUI service running?")?;
 
@@ -273,7 +248,7 @@ pub async fn handle_tui_new(signing_key: &SigningKey) -> Result<()> {
 pub async fn handle_tui_list(signing_key: &SigningKey) -> Result<()> {
     info!("Listing TUI sessions");
 
-    let client = create_tui_client(signing_key);
+    let client = create_tui_client(signing_key)?;
 
     let window_list = client.list_windows(0).await
         .context("Failed to list windows. Is the TUI service running?")?;
@@ -407,7 +382,7 @@ pub async fn handle_tui_play(
     app.set_loop(loop_playback);
 
     // Connect to the TUI session to get the active pane ID
-    let client = create_tui_client(signing_key);
+    let client = create_tui_client(signing_key)?;
     let (cols, rows) = terminal_size();
 
     let result = client
@@ -543,7 +518,7 @@ pub async fn forward_process_output(
     };
 
     // Resize polling task — detects when another viewer triggers a pane resize
-    let resize_client = create_tui_client(signing_key);
+    let resize_client = create_tui_client(signing_key)?;
     let resize_handle = tokio::spawn(async move {
         let mut cur = (initial_cols, initial_rows);
         loop {
@@ -565,7 +540,7 @@ pub async fn forward_process_output(
     let stdin_input_tx = process.input_tx.clone();
     let stdin_handle = if let Some(si) = stdin_stream {
         if !si.topic.is_empty() {
-            let poll_client = create_tui_client(signing_key);
+            let poll_client = create_tui_client(signing_key)?;
             let poll_viewer_id = viewer_id;
             let handle = tokio::spawn(async move {
                 use crate::tui::shell_client::poll_stdin_rpc;

--- a/crates/hyprstream/src/cli/tui_handlers.rs
+++ b/crates/hyprstream/src/cli/tui_handlers.rs
@@ -458,6 +458,16 @@ pub async fn forward_process_output(
 
     let resize_tx = process.input_tx.clone();
 
+    // Resolve every auxiliary client before entering raw mode or spawning
+    // background work. A resolution error must leave the terminal and task set
+    // untouched so the CLI can report it cleanly.
+    let resize_client = create_tui_client(signing_key)?;
+    let poll_client = if stdin_stream.is_some_and(|stream| !stream.topic.is_empty()) {
+        Some(create_tui_client(signing_key)?)
+    } else {
+        None
+    };
+
     // Enter raw mode and read stdin if we're on a real terminal.
     // When stdin is not a tty (piped/headless), skip input handling.
     let is_tty = unsafe { libc::isatty(libc::STDIN_FILENO) } == 1;
@@ -518,7 +528,6 @@ pub async fn forward_process_output(
     };
 
     // Resize polling task — detects when another viewer triggers a pane resize
-    let resize_client = create_tui_client(signing_key)?;
     let resize_handle = tokio::spawn(async move {
         let mut cur = (initial_cols, initial_rows);
         loop {
@@ -538,29 +547,24 @@ pub async fn forward_process_output(
     // This avoids creating a second ZMQ context in this process, which triggers a
     // libzmq signaler assertion (dummy == 0) when fork() is involved.
     let stdin_input_tx = process.input_tx.clone();
-    let stdin_handle = if let Some(si) = stdin_stream {
-        if !si.topic.is_empty() {
-            let poll_client = create_tui_client(signing_key)?;
-            let poll_viewer_id = viewer_id;
-            let handle = tokio::spawn(async move {
-                use crate::tui::shell_client::poll_stdin_rpc;
-                loop {
-                    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-                    match poll_stdin_rpc(&poll_client, poll_viewer_id).await {
-                        Ok(data) if !data.is_empty() => {
-                            if stdin_input_tx.send(ProcessInput::Stdin(data)).await.is_err() {
-                                break;
-                            }
+    let stdin_handle = if let Some(poll_client) = poll_client {
+        let poll_viewer_id = viewer_id;
+        let handle = tokio::spawn(async move {
+            use crate::tui::shell_client::poll_stdin_rpc;
+            loop {
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                match poll_stdin_rpc(&poll_client, poll_viewer_id).await {
+                    Ok(data) if !data.is_empty() => {
+                        if stdin_input_tx.send(ProcessInput::Stdin(data)).await.is_err() {
+                            break;
                         }
-                        Err(_) => break,
-                        _ => {}
                     }
+                    Err(_) => break,
+                    _ => {}
                 }
-            });
-            Some(handle)
-        } else {
-            None
-        }
+            }
+        });
+        Some(handle)
     } else {
         None
     };


### PR DESCRIPTION
## Summary

- install process-global request/response envelope verification before dispatching ordinary CLI commands
- remove the ambiguous global-trust-store fallback for the TUI key
- propagate TUI client construction failures as normal CLI errors instead of panicking

This intentionally fixes the response-verification startup half of #1018 while leaving functional TUI recovery fail-closed until identity and transport can be resolved atomically.

Fixes #1018 partially; the resolver migration is tracked under #873.

## Investigation and scope

`install_response_verify_config()` was introduced by `feef937a9` for response-side hybrid enforcement, but its startup call remained confined to service and standalone-worker branches. Ordinary `quick` and `tui` clients could therefore reach response verification without configuration.

Policy-based service-key resolution was introduced by `6de885e1a`. The original revision attempted to recover through `global_trust_store().resolve_one("tui")`, but review confirmed that this can select an arbitrary key within the service scope and still leaves transport selection independent from identity selection. Loading or selecting a bootstrap key more specifically would preserve that split-brain design rather than fix it.

The safe stopping point is therefore:

1. install envelope verification early;
2. return a clear error when PolicyService cannot resolve the TUI identity;
3. implement functional recovery through an identity-bound resolver result under #873, after the resolver-profile work from #876 is restored to main.

PR #1036/#550 is separately hardening HyKEM request envelopes and production network transports; this PR does not duplicate that work.

## Validation

- `git diff --check` passes
- targeted host checking with system PyTorch/OpenSSL reached the known unrelated `hyprstream-pds/src/at9p_duplicity.rs` type errors (`to_dag_cbor()` now returns `Result<Vec<u8>>`)
- the pre-commit workspace Clippy hook failed on the same existing PDS errors before it could complete; the follow-up commit was made with hook bypass only after recording that baseline failure
- prior CI passed CodeQL, cargo-deny, and the WASM browser build; the Claude review action failed internally with `is_error:true` and produced no findings
