### PR TITLE
feat(rpc): re-land explicit resolver profiles (#873)

### DIFF
--- a/crates/hyprstream-pds/src/at9p.rs
+++ b/crates/hyprstream-pds/src/at9p.rs
@@ -708,7 +708,7 @@ impl UpdateRecord {
 
     pub fn to_dag_cbor(&self) -> Result<Vec<u8>> {
         self.validate()?;
-        Ok(self.to_value().encode())
+        Ok(self.encode_value())
     }
 
     /// Serialize without re-validating. For crate-internal digest/state

--- a/crates/hyprstream-pds/src/at9p.rs
+++ b/crates/hyprstream-pds/src/at9p.rs
@@ -637,7 +637,7 @@ impl Capsule {
 
     pub fn to_dag_cbor(&self) -> Result<Vec<u8>> {
         self.validate()?;
-        Ok(self.to_value().encode())
+        Ok(self.encode_value())
     }
 
     pub fn from_dag_cbor(bytes: &[u8]) -> Result<Self> {
@@ -646,6 +646,14 @@ impl Capsule {
 
     pub fn cid512(&self) -> Result<String> {
         at9p_capsule_cid512(&self.to_dag_cbor()?)
+    }
+
+    /// Serialize without re-validating. For crate-internal digest/state
+    /// projection over capsules already known to be valid — they reached here
+    /// via [`Self::from_dag_cbor`] (validated) or the signing path. External
+    /// callers must use [`Self::to_dag_cbor`].
+    pub(crate) fn encode_value(&self) -> Vec<u8> {
+        self.to_value().encode()
     }
 
     fn to_value(&self) -> DagCbor {

--- a/crates/hyprstream-pds/src/at9p_duplicity.rs
+++ b/crates/hyprstream-pds/src/at9p_duplicity.rs
@@ -217,8 +217,8 @@ impl PredecessorRecord<'_> {
     /// the watermark pins is verified to describe *these* bytes.
     pub fn record_digest(&self) -> [u8; H512_LEN] {
         match self {
-            PredecessorRecord::Genesis(cap) => h512(&cap.to_dag_cbor()),
-            PredecessorRecord::Update(rec) => h512(&rec.to_dag_cbor()),
+            PredecessorRecord::Genesis(cap) => h512(&cap.encode_value()),
+            PredecessorRecord::Update(rec) => h512(&rec.encode_value()),
         }
     }
 
@@ -2263,7 +2263,6 @@ mod tests {
             Some(DuplicityKind::HigherEpochFork)
         );
     }
-
 
     // Small accessors so the guard's sink can be inspected in-test.
     impl DuplicityGuard<InMemoryWatermarkStore, RecordingSink> {

--- a/crates/hyprstream-pds/src/name_record.rs
+++ b/crates/hyprstream-pds/src/name_record.rs
@@ -220,35 +220,39 @@ fn validate_pin_cid(s: &str) -> Result<()> {
 
 #[cfg(test)]
 fn sample_pin() -> String {
-    hyprstream_rpc::cid::encode_cid(
+    match hyprstream_rpc::cid::encode_cid(
         hyprstream_rpc::cid::Codec::GitRaw,
         hyprstream_rpc::cid::HashAlgo::Sha2_256,
         &[0x42; 32],
-    )
-    .expect("valid sample CID")
+    ) {
+        Ok(cid) => cid,
+        Err(err) => panic!("valid sample CID: {err}"),
+    }
 }
 
 #[cfg(test)]
 fn sample_at9p_pin() -> String {
-    hyprstream_rpc::cid::encode_cid(
+    match hyprstream_rpc::cid::encode_cid(
         hyprstream_rpc::cid::Codec::At9pCapsule,
         hyprstream_rpc::cid::HashAlgo::Blake3,
         &[0x24; 64],
-    )
-    .expect("valid sample at9p CID")
+    ) {
+        Ok(cid) => cid,
+        Err(err) => panic!("valid sample at9p CID: {err}"),
+    }
 }
 
 #[cfg(test)]
 fn truncated_pin() -> String {
-    hyprstream_rpc::cid::encode_cid(
+    let cid = match hyprstream_rpc::cid::encode_cid(
         hyprstream_rpc::cid::Codec::GitRaw,
         hyprstream_rpc::cid::HashAlgo::Sha2_256,
         &[0x11; 32],
-    )
-    .expect("valid CID")
-    .chars()
-    .take(12)
-    .collect()
+    ) {
+        Ok(cid) => cid,
+        Err(err) => panic!("valid CID: {err}"),
+    };
+    cid.chars().take(12).collect()
 }
 
 #[cfg(test)]

--- a/crates/hyprstream-rpc/src/lib.rs
+++ b/crates/hyprstream-rpc/src/lib.rs
@@ -249,7 +249,7 @@ pub use error::{EnvelopeError, EnvelopeResult, Result, RpcError};
 pub use hyprstream_rpc_derive::{authorize, service_factory, FromCapnp, ToCapnp};
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use resolver::Resolver;
+pub use resolver::{NetworkDiscoveryResolver, Resolver, ResolverProfile};
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use registry::SocketKind;
@@ -295,7 +295,8 @@ pub mod prelude {
     // Registry (with renamed imports for convenience)
     pub use crate::registry::{
         global as registry_global, init as registry_init, try_global as registry_try_global,
-        EndpointMode, EndpointRegistry, ServiceEntry, ServiceRegistration,
+        EndpointMode, EndpointRegistry, IpcResolver, LocalInprocResolver, ServiceEntry,
+        ServiceRegistration,
     };
 
     // Transport

--- a/crates/hyprstream-rpc/src/registry/mod.rs
+++ b/crates/hyprstream-rpc/src/registry/mod.rs
@@ -207,39 +207,74 @@ impl EndpointRegistry {
     /// the historical local fallback (`inproc` or same-host UDS), while missing
     /// QUIC/network endpoints fail closed instead of synthesizing a placeholder.
     pub fn try_endpoint(&self, name: &str, socket_kind: SocketKind) -> anyhow::Result<TransportConfig> {
+        if let Some(endpoint) = self.registered_endpoint(name, socket_kind) {
+            return Ok(endpoint);
+        }
+
+        self.local_default_endpoint(name, socket_kind)
+    }
+
+    /// Get an explicitly registered endpoint without applying any profile
+    /// fallback.
+    pub fn registered_endpoint(
+        &self,
+        name: &str,
+        socket_kind: SocketKind,
+    ) -> Option<TransportConfig> {
         if let Some(entry) = self.services.read().get(name) {
             if let Some(ep) = entry.endpoints.get(&socket_kind) {
-                return Ok(ep.clone());
+                return Some(ep.clone());
             }
         }
-
-        self.default_endpoint(name, socket_kind)
+        None
     }
 
-    /// Generate a default endpoint for a service and socket type.
-    fn default_endpoint(&self, name: &str, socket_kind: SocketKind) -> anyhow::Result<TransportConfig> {
-        if socket_kind == SocketKind::Quic {
-            anyhow::bail!(
-                "no registered QUIC endpoint for service '{name}' — network reach must be announced or explicitly registered"
-            );
+    /// Generate the legacy local default endpoint for a service and socket type.
+    ///
+    /// This remains for direct registry callers. The process-global resolver
+    /// installed by [`init`] uses explicit resolver profile types instead.
+    fn local_default_endpoint(
+        &self,
+        name: &str,
+        socket_kind: SocketKind,
+    ) -> anyhow::Result<TransportConfig> {
+        match self.mode {
+            EndpointMode::Inproc => local_inproc_endpoint(name, socket_kind),
+            EndpointMode::Ipc => same_host_uds_endpoint(name, socket_kind, self.runtime_dir.as_ref()),
         }
-        let suffix = socket_kind.suffix();
-        Ok(match self.mode {
-            EndpointMode::Inproc => {
-                TransportConfig::inproc(format!("hyprstream/{name}{suffix}"))
-            }
-            EndpointMode::Ipc => {
-                // Use normal IPC binding instead of systemd socket activation
-                let path = self
-                    .runtime_dir
-                    .as_ref()
-                    .map(|d| d.join(format!("{name}{suffix}.sock")))
-                    .unwrap_or_else(|| PathBuf::from(format!("/tmp/hyprstream/{name}{suffix}.sock")));
-                TransportConfig::ipc(path)
-            }
-        })
     }
+}
 
+fn local_inproc_endpoint(name: &str, socket_kind: SocketKind) -> anyhow::Result<TransportConfig> {
+    if socket_kind == SocketKind::Quic {
+        anyhow::bail!(
+            "no registered QUIC endpoint for service '{name}' — network reach must be announced or explicitly registered"
+        );
+    }
+    Ok(TransportConfig::inproc(format!(
+        "hyprstream/{name}{}",
+        socket_kind.suffix()
+    )))
+}
+
+fn same_host_uds_endpoint(
+    name: &str,
+    socket_kind: SocketKind,
+    runtime_dir: Option<&PathBuf>,
+) -> anyhow::Result<TransportConfig> {
+    if socket_kind == SocketKind::Quic {
+        anyhow::bail!(
+            "no registered QUIC endpoint for service '{name}' — network reach must be announced or explicitly registered"
+        );
+    }
+    let suffix = socket_kind.suffix();
+    let path = runtime_dir
+        .map(|d| d.join(format!("{name}{suffix}.sock")))
+        .unwrap_or_else(|| PathBuf::from(format!("/tmp/hyprstream/{name}{suffix}.sock")));
+    Ok(TransportConfig::ipc(path))
+}
+
+impl EndpointRegistry {
     // ========================================================================
     // Backward-compatible convenience methods (default to REP socket)
     // ========================================================================
@@ -338,6 +373,49 @@ impl crate::resolver::Resolver for EndpointRegistry {
 // Global registry
 static REGISTRY: RwLock<Option<EndpointRegistry>> = RwLock::new(None);
 
+fn registered_global_endpoint(
+    name: &str,
+    kind: SocketKind,
+) -> anyhow::Result<Option<TransportConfig>> {
+    let registry = try_global()
+        .ok_or_else(|| anyhow::anyhow!("EndpointRegistry not initialized — call init() first"))?;
+    Ok(registry.registered_endpoint(name, kind))
+}
+
+/// Explicit single-process resolver profile.
+pub struct LocalInprocResolver;
+
+#[async_trait::async_trait]
+impl crate::resolver::Resolver for LocalInprocResolver {
+    async fn resolve(&self, name: &str, kind: SocketKind) -> anyhow::Result<TransportConfig> {
+        if let Some(endpoint) = registered_global_endpoint(name, kind)? {
+            return Ok(endpoint);
+        }
+        local_inproc_endpoint(name, kind)
+    }
+}
+
+/// Explicit IPC resolver profile.
+pub struct IpcResolver {
+    runtime_dir: Option<PathBuf>,
+}
+
+impl IpcResolver {
+    pub fn new(runtime_dir: Option<PathBuf>) -> Self {
+        Self { runtime_dir }
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::resolver::Resolver for IpcResolver {
+    async fn resolve(&self, name: &str, kind: SocketKind) -> anyhow::Result<TransportConfig> {
+        if let Some(endpoint) = registered_global_endpoint(name, kind)? {
+            return Ok(endpoint);
+        }
+        same_host_uds_endpoint(name, kind, self.runtime_dir.as_ref())
+    }
+}
+
 /// Initialize the global endpoint registry.
 ///
 /// Idempotent: subsequent calls are no-ops if already initialized.
@@ -349,24 +427,14 @@ static REGISTRY: RwLock<Option<EndpointRegistry>> = RwLock::new(None);
 pub fn init(mode: EndpointMode, runtime_dir: Option<PathBuf>) {
     let mut guard = REGISTRY.write();
     if guard.is_none() {
-        *guard = Some(EndpointRegistry::new(mode, runtime_dir));
-        // Also set the global Resolver so async consumers can use the trait
-        crate::resolver::set_global(Arc::new(GlobalRegistryResolver));
-    }
-}
-
-/// Adapter that delegates `Resolver` calls to the global `EndpointRegistry`.
-///
-/// Installed automatically by `init()`. Allows async callers to resolve
-/// endpoints via the `Resolver` trait without holding a lock guard.
-struct GlobalRegistryResolver;
-
-#[async_trait::async_trait]
-impl crate::resolver::Resolver for GlobalRegistryResolver {
-    async fn resolve(&self, name: &str, kind: SocketKind) -> anyhow::Result<TransportConfig> {
-        let registry = try_global()
-            .ok_or_else(|| anyhow::anyhow!("EndpointRegistry not initialized — call init() first"))?;
-        registry.try_endpoint(name, kind)
+        *guard = Some(EndpointRegistry::new(mode, runtime_dir.clone()));
+        // Also set the global Resolver so async consumers use an explicit
+        // locality profile instead of the registry's legacy direct fallback.
+        let resolver: Arc<dyn crate::resolver::Resolver> = match mode {
+            EndpointMode::Inproc => Arc::new(LocalInprocResolver),
+            EndpointMode::Ipc => Arc::new(IpcResolver::new(runtime_dir)),
+        };
+        crate::resolver::set_global(resolver);
     }
 }
 
@@ -567,6 +635,21 @@ mod tests {
     }
 
     #[test]
+    fn test_global_resolver_installs_local_inproc_profile() {
+        let _lock = TEST_MUTEX.lock();
+        reset_registry();
+        init(EndpointMode::Inproc, None);
+
+        let resolver = match crate::resolver::try_global() {
+            Some(resolver) => resolver,
+            None => panic!("global resolver must be installed"),
+        };
+        let endpoint = futures::executor::block_on(resolver.resolve("policy", SocketKind::Rep))
+            .unwrap_or_else(|err| panic!("local-inproc resolver failed: {err}"));
+        assert_eq!(endpoint.endpoint_string(), "inproc://hyprstream/policy");
+    }
+
+    #[test]
     fn test_ipc_defaults() {
         let _lock = TEST_MUTEX.lock();
         reset_registry();
@@ -579,6 +662,21 @@ mod tests {
         // REQ socket (with suffix)
         let endpoint = global().endpoint("model", SocketKind::Req);
         assert_eq!(endpoint.endpoint_string(), "ipc:///run/hyprstream/model-req.sock");
+    }
+
+    #[test]
+    fn test_global_resolver_installs_ipc_profile() {
+        let _lock = TEST_MUTEX.lock();
+        reset_registry();
+        init(EndpointMode::Ipc, Some(PathBuf::from("/run/hyprstream")));
+
+        let resolver = match crate::resolver::try_global() {
+            Some(resolver) => resolver,
+            None => panic!("global resolver must be installed"),
+        };
+        let endpoint = futures::executor::block_on(resolver.resolve("policy", SocketKind::Rep))
+            .unwrap_or_else(|err| panic!("same-host-uds resolver failed: {err}"));
+        assert_eq!(endpoint.endpoint_string(), "ipc:///run/hyprstream/policy.sock");
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/resolver.rs
+++ b/crates/hyprstream-rpc/src/resolver.rs
@@ -26,10 +26,11 @@
 
 use std::sync::Arc;
 
+use anyhow::anyhow;
 use parking_lot::RwLock;
 
 use crate::registry::SocketKind;
-use crate::transport::TransportConfig;
+use crate::transport::{EndpointType, TransportConfig};
 
 /// Async endpoint resolver.
 ///
@@ -52,6 +53,52 @@ pub trait Resolver: Send + Sync {
     async fn resolve(&self, name: &str, kind: SocketKind) -> anyhow::Result<TransportConfig>;
 }
 
+/// Resolver profile names used at service startup.
+///
+/// Profiles make locality an explicit deployment decision. Generated clients
+/// still ask for `(service_name, socket_kind)`; the installed resolver profile
+/// decides whether that name maps to an in-process handle, a same-host Unix
+/// socket, or a network-discovered peer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolverProfile {
+    /// Single-process / hermetic-test profile.
+    LocalInproc,
+    /// Local IPC profile.
+    Ipc,
+    /// Multi-host production profile backed by DiscoveryService/PDS records.
+    NetworkDiscovery,
+}
+
+/// Network profile wrapper for a DiscoveryService/PDS-backed resolver.
+///
+/// The wrapped resolver owns service discovery. This wrapper enforces the
+/// network-profile invariant: same-host endpoints (`inproc`, `ipc`,
+/// `systemd-fd`) are not valid routable service reach.
+pub struct NetworkDiscoveryResolver {
+    inner: Arc<dyn Resolver>,
+}
+
+impl NetworkDiscoveryResolver {
+    pub fn new(inner: Arc<dyn Resolver>) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait::async_trait]
+impl Resolver for NetworkDiscoveryResolver {
+    async fn resolve(&self, name: &str, kind: SocketKind) -> anyhow::Result<TransportConfig> {
+        let transport = self.inner.resolve(name, kind).await?;
+        match &transport.endpoint {
+            EndpointType::Inproc { .. }
+            | EndpointType::Ipc { .. }
+            | EndpointType::SystemdFd { .. } => Err(anyhow!(
+                "network-discovery resolver returned same-host endpoint for service '{name}' ({kind:?})"
+            )),
+            EndpointType::Quic { .. } | EndpointType::Iroh { .. } => Ok(transport),
+        }
+    }
+}
+
 // ============================================================================
 // Pluggable global resolver (replaceable)
 // ============================================================================
@@ -61,8 +108,9 @@ static GLOBAL_RESOLVER: RwLock<Option<Arc<dyn Resolver>>> = RwLock::new(None);
 /// Set the global resolver.
 ///
 /// Can be called multiple times — each call replaces the previous resolver.
-/// During bootstrap, `registry::init()` installs a `GlobalRegistryResolver`.
-/// Once `DiscoveryService` starts, it replaces this with itself.
+/// During bootstrap, `registry::init()` installs an explicit local resolver
+/// profile. A networked deployment can replace that with a
+/// [`NetworkDiscoveryResolver`] wrapping DiscoveryService or a DiscoveryClient.
 ///
 /// # Example
 ///
@@ -92,5 +140,85 @@ pub fn try_global() -> Option<Arc<dyn Resolver>> {
 #[deprecated(note = "use try_global() instead for graceful degradation (D9)")]
 pub fn global() -> Arc<dyn Resolver> {
     #[allow(clippy::expect_used)] // Intentional panic for programming error
-    GLOBAL_RESOLVER.read().clone().expect("Global resolver not initialized — call resolver::set_global() first")
+    GLOBAL_RESOLVER
+        .read()
+        .clone()
+        .expect("Global resolver not initialized — call resolver::set_global() first")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct StaticResolver(TransportConfig);
+
+    #[async_trait::async_trait]
+    impl Resolver for StaticResolver {
+        async fn resolve(&self, _name: &str, _kind: SocketKind) -> anyhow::Result<TransportConfig> {
+            Ok(self.0.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn network_discovery_resolver_rejects_inproc_reach() {
+        let resolver = NetworkDiscoveryResolver::new(Arc::new(StaticResolver(
+            TransportConfig::inproc("hyprstream/policy"),
+        )));
+
+        let err = match resolver.resolve("policy", SocketKind::Rep).await {
+            Ok(endpoint) => panic!("network resolver accepted local endpoint: {endpoint:?}"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains("same-host endpoint"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn network_discovery_resolver_rejects_same_host_reach() {
+        for local in [
+            TransportConfig::ipc("/run/hyprstream/policy.sock"),
+            TransportConfig::systemd_fd(3, "/run/hyprstream/policy.sock"),
+        ] {
+            let resolver = NetworkDiscoveryResolver::new(Arc::new(StaticResolver(local)));
+            let err = match resolver.resolve("policy", SocketKind::Rep).await {
+                Ok(endpoint) => {
+                    panic!("network resolver accepted same-host endpoint: {endpoint:?}")
+                }
+                Err(err) => err,
+            };
+            assert!(
+                err.to_string().contains("same-host endpoint"),
+                "unexpected error: {err}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn network_discovery_resolver_accepts_quic_reach() {
+        let addr = "127.0.0.1:9443"
+            .parse()
+            .unwrap_or_else(|err| panic!("test socket address must parse: {err}"));
+        let quic = TransportConfig::quic(addr, "policy.local");
+        let resolver = NetworkDiscoveryResolver::new(Arc::new(StaticResolver(quic.clone())));
+
+        let endpoint = resolver
+            .resolve("policy", SocketKind::Rep)
+            .await
+            .unwrap_or_else(|err| panic!("network resolver rejected QUIC endpoint: {err}"));
+        assert_eq!(endpoint.endpoint_string(), quic.endpoint_string());
+    }
+
+    #[tokio::test]
+    async fn network_discovery_resolver_accepts_iroh_reach() {
+        let iroh = TransportConfig::iroh([7; 32], Vec::new(), None);
+        let resolver = NetworkDiscoveryResolver::new(Arc::new(StaticResolver(iroh.clone())));
+
+        let endpoint = resolver
+            .resolve("policy", SocketKind::Rep)
+            .await
+            .unwrap_or_else(|err| panic!("network resolver rejected iroh endpoint: {err}"));
+        assert_eq!(endpoint, iroh);
+    }
 }


### PR DESCRIPTION
Refs #873.

## Why this re-land is needed

PR #876 merged into `ewindisch/874-fail-close-quic-default`, not `main`. Its implementation commit (`b9c7996`) is therefore absent from current `main`, while #873 remains open. This reapplies that smallest coherent resolver-profile change against current main rather than cherry-picking the stacked merge.

## What

- Adds explicit resolver profiles and concrete local resolver types:
  - `LocalInprocResolver` for single-process/local tests
  - `IpcResolver` for same-host UDS test/systemd-dev use
  - `NetworkDiscoveryResolver` for DiscoveryService/PDS-backed network reach
- Makes `registry::init()` install the matching explicit local profile.
- Preserves explicitly registered endpoints and the current fail-closed behavior for missing QUIC reach.
- Makes network-discovery reject `inproc`, `ipc`, and `systemd-fd` endpoints while accepting current production network transports (QUIC and iroh).

UDS remains limited same-host testing/dev plumbing; this does not make it a production topology default. Production resolution remains Discovery/PDS-backed QUIC/iroh (and the broader MoQ/WebTransport topology).

## Scope coordination

PR #1036 changes request-envelope encryption, cleartext carrier policy, dial/WASM paths, and transport traits. It does not currently touch the three files changed here. This PR intentionally does not absorb identity-bound `ResolvedService`, generated-client adoption, or browser KEM provisioning; those remain separate audits/changes under #873 and #550.

## Validation

- `cargo test -p hyprstream-rpc registry::tests --lib` — 10 passed
- `cargo test -p hyprstream-rpc resolver::tests --lib` — 17 passed (includes unrelated identity-resolver tests matched by the filter)
- `cargo clippy -p hyprstream-rpc -p hyprstream-rpc-derive --all-targets -- -D warnings` — clean
- `cargo clippy -p hyprstream-rpc -p hyprstream-rpc-derive -p hyprstream-discovery --all-targets -- -D warnings` — affected crates are clean, but the command is blocked by the pre-existing main regression in `hyprstream-pds/src/at9p_duplicity.rs:220-221`: `to_dag_cbor()` returns `Result<Vec<u8>, _>` where `h512()` expects `&[u8]`.

The nested worktree required a temporary local `[workspace]` boundary in the excluded `bitsandbytes-sys` manifest for Cargo invocation; it was restored and is not part of this PR.
