### PR TITLE
fix(pds): use canonical encoding for duplicity digests

### DIFF
--- a/crates/hyprstream-pds/src/at9p.rs
+++ b/crates/hyprstream-pds/src/at9p.rs
@@ -708,7 +708,7 @@ impl UpdateRecord {
 
     pub fn to_dag_cbor(&self) -> Result<Vec<u8>> {
         self.validate()?;
-        Ok(self.to_value().encode())
+        Ok(self.encode_value())
     }
 
     /// Serialize without re-validating. For crate-internal digest/state

--- a/crates/hyprstream-pds/src/at9p.rs
+++ b/crates/hyprstream-pds/src/at9p.rs
@@ -637,7 +637,7 @@ impl Capsule {
 
     pub fn to_dag_cbor(&self) -> Result<Vec<u8>> {
         self.validate()?;
-        Ok(self.to_value().encode())
+        Ok(self.encode_value())
     }
 
     pub fn from_dag_cbor(bytes: &[u8]) -> Result<Self> {
@@ -646,6 +646,14 @@ impl Capsule {
 
     pub fn cid512(&self) -> Result<String> {
         at9p_capsule_cid512(&self.to_dag_cbor()?)
+    }
+
+    /// Serialize without re-validating. For crate-internal digest/state
+    /// projection over capsules already known to be valid — they reached here
+    /// via [`Self::from_dag_cbor`] (validated) or the signing path. External
+    /// callers must use [`Self::to_dag_cbor`].
+    pub(crate) fn encode_value(&self) -> Vec<u8> {
+        self.to_value().encode()
     }
 
     fn to_value(&self) -> DagCbor {

--- a/crates/hyprstream-pds/src/at9p_duplicity.rs
+++ b/crates/hyprstream-pds/src/at9p_duplicity.rs
@@ -217,8 +217,8 @@ impl PredecessorRecord<'_> {
     /// the watermark pins is verified to describe *these* bytes.
     pub fn record_digest(&self) -> [u8; H512_LEN] {
         match self {
-            PredecessorRecord::Genesis(cap) => h512(&cap.to_dag_cbor()),
-            PredecessorRecord::Update(rec) => h512(&rec.to_dag_cbor()),
+            PredecessorRecord::Genesis(cap) => h512(&cap.encode_value()),
+            PredecessorRecord::Update(rec) => h512(&rec.encode_value()),
         }
     }
 
@@ -2263,7 +2263,6 @@ mod tests {
             Some(DuplicityKind::HigherEpochFork)
         );
     }
-
 
     // Small accessors so the guard's sink can be inspected in-test.
     impl DuplicityGuard<InMemoryWatermarkStore, RecordingSink> {

--- a/crates/hyprstream-pds/src/name_record.rs
+++ b/crates/hyprstream-pds/src/name_record.rs
@@ -220,35 +220,39 @@ fn validate_pin_cid(s: &str) -> Result<()> {
 
 #[cfg(test)]
 fn sample_pin() -> String {
-    hyprstream_rpc::cid::encode_cid(
+    match hyprstream_rpc::cid::encode_cid(
         hyprstream_rpc::cid::Codec::GitRaw,
         hyprstream_rpc::cid::HashAlgo::Sha2_256,
         &[0x42; 32],
-    )
-    .expect("valid sample CID")
+    ) {
+        Ok(cid) => cid,
+        Err(err) => panic!("valid sample CID: {err}"),
+    }
 }
 
 #[cfg(test)]
 fn sample_at9p_pin() -> String {
-    hyprstream_rpc::cid::encode_cid(
+    match hyprstream_rpc::cid::encode_cid(
         hyprstream_rpc::cid::Codec::At9pCapsule,
         hyprstream_rpc::cid::HashAlgo::Blake3,
         &[0x24; 64],
-    )
-    .expect("valid sample at9p CID")
+    ) {
+        Ok(cid) => cid,
+        Err(err) => panic!("valid sample at9p CID: {err}"),
+    }
 }
 
 #[cfg(test)]
 fn truncated_pin() -> String {
-    hyprstream_rpc::cid::encode_cid(
+    let cid = match hyprstream_rpc::cid::encode_cid(
         hyprstream_rpc::cid::Codec::GitRaw,
         hyprstream_rpc::cid::HashAlgo::Sha2_256,
         &[0x11; 32],
-    )
-    .expect("valid CID")
-    .chars()
-    .take(12)
-    .collect()
+    ) {
+        Ok(cid) => cid,
+        Err(err) => panic!("valid CID: {err}"),
+    };
+    cid.chars().take(12).collect()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Separates the PDS compile-regression fix from #1022, which is a Graviton CI migration.

The duplicity digest path now uses the crate-internal canonical encoder for already-validated capsule/update records; public DAG-CBOR serialization validates and delegates to that same encoder. Test CID helpers retain their diagnostics.

Validation:
- `rustfmt --check` on the three changed PDS files
- `cargo clippy -p hyprstream-pds --all-targets -- -D warnings`
- `cargo test -p hyprstream-pds`