### PR TITLE
security(rpc): INV-2 receive-side — reject cleartext envelopes on untrusted carriers (#1042)

### DIFF
--- a/crates/hyprstream-rpc/src/envelope.rs
+++ b/crates/hyprstream-rpc/src/envelope.rs
@@ -398,6 +398,29 @@ pub fn generate_nonce() -> [u8; 16] {
     rand::rngs::OsRng.gen()
 }
 
+/// Bounded wire probe: does this serialized `SignedEnvelope` carry an
+/// encrypted (`#mesh-kem` COSE_Encrypt0) request envelope?
+///
+/// INV-2 receive-side pre-filter (#1042): untrusted carriers must reject a
+/// cleartext envelope **before** signature verification, claims evaluation,
+/// or handler dispatch. This decodes only the Cap'n Proto message root and
+/// reads the `encryptedEnvelope` field length — no signature, replay, or
+/// payload processing — so the rejection point does the minimum work needed
+/// to classify the envelope mode.
+///
+/// Returns `Err` on undecodable bytes; on an untrusted carrier the caller
+/// must treat that exactly like cleartext (reject). Presence is defined as a
+/// non-empty field, matching [`SignedEnvelope::read_from`]'s decoding of the
+/// optional field.
+pub fn wire_signed_envelope_is_encrypted(bytes: &[u8]) -> anyhow::Result<bool> {
+    let reader = capnp::serialize::read_message(
+        &mut std::io::Cursor::new(bytes),
+        capnp::message::ReaderOptions::new(),
+    )?;
+    let sr = reader.get_root::<crate::common_capnp::signed_envelope::Reader>()?;
+    Ok(!sr.get_encrypted_envelope()?.is_empty())
+}
+
 /// Authorization subject for Casbin policy checks and resource isolation.
 ///
 /// A simple newtype over `Option<String>`:

--- a/crates/hyprstream-rpc/src/envelope.rs
+++ b/crates/hyprstream-rpc/src/envelope.rs
@@ -214,6 +214,27 @@ fn envelope_reader_options() -> capnp::message::ReaderOptions {
     opts
 }
 
+/// Parse exactly one bounded Cap'n Proto message from an already-buffered
+/// frame without allocating storage based on its unauthenticated segment
+/// table. The no-allocation reader validates declared segment sizes against
+/// both the traversal limit and the supplied slice before exposing a root.
+fn read_exact_envelope_message(
+    bytes: &[u8],
+) -> Result<capnp::message::Reader<capnp::serialize::NoAllocSliceSegments<'_>>> {
+    let mut remaining = bytes;
+    let reader = capnp::serialize::read_message_from_flat_slice_no_alloc(
+        &mut remaining,
+        envelope_reader_options(),
+    )?;
+    if !remaining.is_empty() {
+        return Err(anyhow!(
+            "trailing bytes after Cap'n Proto envelope: {}",
+            remaining.len()
+        ));
+    }
+    Ok(reader)
+}
+
 // ============================================================================
 // Envelope Unwrap Options
 // ============================================================================
@@ -273,6 +294,10 @@ pub struct UnwrapOptions<'a> {
     /// When present and the envelope has `encrypted_envelope`, the server's
     /// Ed25519 key is converted to X25519 for DH decryption.
     pub decryption_key: Option<&'a crate::crypto::SigningKey>,
+    /// Require the verified wire envelope to carry a non-empty encrypted
+    /// envelope. Enforced after signature/replay verification and before
+    /// decryption or any claims/application processing.
+    pub require_encrypted: bool,
     /// kid-anchored ML-DSA-65 trust store used to resolve the PQ verifying key
     /// for the envelope's EdDSA signer. Required under Hybrid policy.
     pub pq_store: Option<&'a dyn PqTrustStore>,
@@ -296,6 +321,7 @@ impl<'a> UnwrapOptions<'a> {
             verification: EnvelopeVerification::FixedSigner(pubkey),
             nonce_cache,
             decryption_key: None,
+            require_encrypted: false,
             pq_store: None,
             verify_policy: crate::crypto::CryptoPolicy::default(),
             unanchored_policy: UnanchoredHybridPolicy::default(),
@@ -309,6 +335,7 @@ impl<'a> UnwrapOptions<'a> {
             verification: EnvelopeVerification::AnySigner,
             nonce_cache,
             decryption_key: None,
+            require_encrypted: false,
             pq_store: None,
             verify_policy: crate::crypto::CryptoPolicy::default(),
             unanchored_policy: UnanchoredHybridPolicy::default(),
@@ -318,6 +345,12 @@ impl<'a> UnwrapOptions<'a> {
 
     pub fn with_decryption_key(mut self, key: &'a crate::crypto::SigningKey) -> Self {
         self.decryption_key = Some(key);
+        self
+    }
+
+    /// Require request encryption after authenticating the wire envelope.
+    pub fn require_encrypted(mut self, required: bool) -> Self {
+        self.require_encrypted = required;
         self
     }
 
@@ -396,29 +429,6 @@ pub fn generate_nonce() -> [u8; 16] {
     // `crypto::event_crypto::random_nonce` pattern used for AES-GCM nonces.
     use rand::Rng;
     rand::rngs::OsRng.gen()
-}
-
-/// Bounded wire probe: does this serialized `SignedEnvelope` carry an
-/// encrypted (`#mesh-kem` COSE_Encrypt0) request envelope?
-///
-/// INV-2 receive-side pre-filter (#1042): untrusted carriers must reject a
-/// cleartext envelope **before** signature verification, claims evaluation,
-/// or handler dispatch. This decodes only the Cap'n Proto message root and
-/// reads the `encryptedEnvelope` field length — no signature, replay, or
-/// payload processing — so the rejection point does the minimum work needed
-/// to classify the envelope mode.
-///
-/// Returns `Err` on undecodable bytes; on an untrusted carrier the caller
-/// must treat that exactly like cleartext (reject). Presence is defined as a
-/// non-empty field, matching [`SignedEnvelope::read_from`]'s decoding of the
-/// optional field.
-pub fn wire_signed_envelope_is_encrypted(bytes: &[u8]) -> anyhow::Result<bool> {
-    let reader = capnp::serialize::read_message(
-        &mut std::io::Cursor::new(bytes),
-        capnp::message::ReaderOptions::new(),
-    )?;
-    let sr = reader.get_root::<crate::common_capnp::signed_envelope::Reader>()?;
-    Ok(!sr.get_encrypted_envelope()?.is_empty())
 }
 
 /// Authorization subject for Casbin policy checks and resource isolation.
@@ -887,8 +897,7 @@ pub(crate) fn seal_request_envelope(
     {
         let mut message = capnp::message::Builder::new_default();
         {
-            let mut builder =
-                message.init_root::<crate::common_capnp::request_envelope::Builder>();
+            let mut builder = message.init_root::<crate::common_capnp::request_envelope::Builder>();
             envelope.write_to(&mut builder);
         }
         capnp::serialize::write_message(&mut plaintext, &message).map_err(|e| {
@@ -1654,7 +1663,13 @@ impl SignedEnvelope {
             });
         }
         self.check_replay(nonce_cache)?;
-        self.verify_cose_unanchored(expected_pubkey, pq_store, verify_policy, unanchored, allowlist)
+        self.verify_cose_unanchored(
+            expected_pubkey,
+            pq_store,
+            verify_policy,
+            unanchored,
+            allowlist,
+        )
     }
 
     /// Fu2/#677: any-signer variant of [`Self::verify_with_unanchored_policy`].
@@ -1672,7 +1687,13 @@ impl SignedEnvelope {
                 actual: 0,
             })?;
         self.check_replay(nonce_cache)?;
-        self.verify_cose_unanchored(&verifying_key, pq_store, verify_policy, unanchored, allowlist)
+        self.verify_cose_unanchored(
+            &verifying_key,
+            pq_store,
+            verify_policy,
+            unanchored,
+            allowlist,
+        )
     }
 
     /// Timestamp window + nonce replay check.
@@ -1851,11 +1872,8 @@ impl SignedEnvelope {
                     EnvelopeError::Decryption(format!("#mesh-kem envelope open failed: {e}"))
                 })?;
 
-        let reader = capnp::serialize::read_message(
-            &mut std::io::Cursor::new(&plaintext),
-            envelope_reader_options(),
-        )
-        .map_err(|e| EnvelopeError::Decryption(format!("capnp parse after decrypt: {e}")))?;
+        let reader = read_exact_envelope_message(&plaintext)
+            .map_err(|e| EnvelopeError::Decryption(format!("capnp parse after decrypt: {e}")))?;
         let env_reader = reader
             .get_root::<crate::common_capnp::request_envelope::Reader>()
             .map_err(|e| EnvelopeError::Decryption(format!("envelope read after decrypt: {e}")))?;
@@ -2401,12 +2419,7 @@ pub fn unwrap_and_verify(
     request: &[u8],
     opts: &UnwrapOptions<'_>,
 ) -> Result<(SignedEnvelope, Vec<u8>)> {
-    use capnp::serialize;
-
-    let reader = serialize::read_message(
-        &mut std::io::Cursor::new(request),
-        envelope_reader_options(),
-    )?;
+    let reader = read_exact_envelope_message(request)?;
     let signed_reader = reader.get_root::<crate::common_capnp::signed_envelope::Reader>()?;
     let mut signed = SignedEnvelope::read_from(signed_reader)?;
 
@@ -2433,6 +2446,18 @@ pub fn unwrap_and_verify(
                 &opts.unanchored_classical_allowlist,
             )?;
         }
+    }
+
+    // INV-2 receive-side policy (#1042): the carrier requirement is supplied
+    // by the accept boundary, never by request bytes. Check it only after the
+    // signature and replay admission above, so unauthenticated input cannot
+    // select or exercise a signed policy-error path. A non-empty marker alone
+    // is not sufficient: encrypted envelopes continue through canonical KEM
+    // open below before any claims or handler sees their payload.
+    if opts.require_encrypted && !signed.is_encrypted() {
+        return Err(anyhow!(
+            "cleartext request envelope rejected: carrier requires #mesh-kem encryption (INV-2)"
+        ));
     }
 
     if signed.is_encrypted() {
@@ -2525,13 +2550,8 @@ pub fn unwrap_response_with(
     pq_store: Option<&dyn PqTrustStore>,
     verify_policy: crate::crypto::CryptoPolicy,
 ) -> Result<(u64, Vec<u8>)> {
-    use capnp::serialize;
-
     // Deserialize ResponseEnvelope from Cap'n Proto
-    let reader = serialize::read_message(
-        &mut std::io::Cursor::new(response),
-        envelope_reader_options(),
-    )?;
+    let reader = read_exact_envelope_message(response)?;
     let response_reader = reader.get_root::<crate::common_capnp::response_envelope::Reader>()?;
     let envelope = ResponseEnvelope::read_from(response_reader)?;
 
@@ -3451,7 +3471,8 @@ mod tests {
         let ((_sk, vk), wire) = fu2_hybrid_wire_unanchored();
         let cache = TestNonceCache::new();
         // Hybrid + NO pq_store (unanchored) + default Deny posture.
-        let opts = UnwrapOptions::fixed_signer(&vk, &cache).with_verify_policy(CryptoPolicy::Hybrid);
+        let opts =
+            UnwrapOptions::fixed_signer(&vk, &cache).with_verify_policy(CryptoPolicy::Hybrid);
         let res = unwrap_and_verify(&wire, &opts);
         assert!(
             res.is_err(),
@@ -3502,6 +3523,38 @@ mod tests {
         let mut wire = Vec::new();
         capnp::serialize::write_message(&mut wire, &message).expect("serialize response");
         wire
+    }
+
+    #[test]
+    fn exact_flat_parser_rejects_trailing_and_partial_frames() {
+        let (sk, _) = generate_signing_keypair();
+        let wire = response_to_wire(&ResponseEnvelope::new_signed(1, vec![1, 2, 3], &sk));
+
+        let mut trailing = wire.clone();
+        trailing.extend_from_slice(&[0u8; 8]);
+        assert!(
+            read_exact_envelope_message(&trailing).is_err(),
+            "a second/trailing frame must not be ignored"
+        );
+
+        let partial = &wire[..wire.len() - 1];
+        assert!(
+            read_exact_envelope_message(partial).is_err(),
+            "a truncated declared segment must be rejected"
+        );
+    }
+
+    #[test]
+    fn exact_flat_parser_rejects_oversized_and_malformed_segment_tables() {
+        // One segment declaring 131,073 words: one word over the canonical
+        // 1 MiB traversal cap. No body is supplied; rejection must occur from
+        // the bounded table parse without allocating the declared body.
+        let oversized = [0, 0, 0, 0, 1, 0, 2, 0];
+        assert!(read_exact_envelope_message(&oversized).is_err());
+
+        // u32::MAX + 1 wraps to an invalid zero segment count.
+        let malformed_count = [0xff, 0xff, 0xff, 0xff, 0, 0, 0, 0];
+        assert!(read_exact_envelope_message(&malformed_count).is_err());
     }
 
     /// Classical round-trip: sign + verify a response (EdDSA-only COSE).

--- a/crates/hyprstream-rpc/src/service/dispatch.rs
+++ b/crates/hyprstream-rpc/src/service/dispatch.rs
@@ -7,7 +7,7 @@
 //! quinn) — extracted out of `transport/zmtp_quic.rs` so the ZMQ-specific
 //! remainder of that file can be deleted in #138 without touching this.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use capnp::message::Builder;
 use capnp::serialize;
 use tracing::{debug, error, warn};
@@ -90,61 +90,25 @@ where
         )
     };
 
-    // INV-2 receive-side policy (#1042), defense-in-depth behind the serve
-    // loop's own rejection: on a cleartext-forbidding carrier, refuse a
-    // cleartext (or undecodable) envelope BEFORE signature verification,
-    // claims evaluation, or handler dispatch. A valid signature does not make
-    // cleartext acceptable, and nothing in the request bytes can select the
-    // carrier class — `carrier` comes from the accept boundary.
-    if carrier.forbids_cleartext_envelope()
-        && !crate::envelope::wire_signed_envelope_is_encrypted(raw_bytes).unwrap_or(false)
-    {
-        warn!(
-            "{} rejecting cleartext request envelope on untrusted carrier '{}' (INV-2 #1042)",
-            service.name(),
-            carrier
-        );
-        let error_payload = service.build_error_payload(
-            0,
-            &format!(
-                "cleartext request envelope rejected: carrier '{carrier}' forbids \
-                 cleartext (INV-2); seal the request to the server's #mesh-kem recipient"
-            ),
-        );
-        let signed_response = sign_response(0, error_payload);
-        let mut message = Builder::new_default();
-        let mut builder = message.init_root::<crate::common_capnp::response_envelope::Builder>();
-        signed_response.write_to(&mut builder);
-        let mut bytes = Vec::new();
-        serialize::write_message(&mut bytes, &message)?;
-        return Ok(bytes);
-    }
-
     let pq_store_holder = crate::envelope::global_pq_store();
     let base = match verification {
-        EnvelopeVerification::FixedSigner(pubkey) =>
-            crate::envelope::UnwrapOptions::fixed_signer(pubkey, nonce_cache),
-        EnvelopeVerification::AnySigner =>
-            crate::envelope::UnwrapOptions::any_signer(nonce_cache),
-    }.with_decryption_key(signing_key);
-    let opts =
-        crate::envelope::apply_global_verify_config(base, &pq_store_holder);
+        EnvelopeVerification::FixedSigner(pubkey) => {
+            crate::envelope::UnwrapOptions::fixed_signer(pubkey, nonce_cache)
+        }
+        EnvelopeVerification::AnySigner => crate::envelope::UnwrapOptions::any_signer(nonce_cache),
+    }
+    .with_decryption_key(signing_key)
+    .require_encrypted(carrier.forbids_cleartext_envelope());
+    let opts = crate::envelope::apply_global_verify_config(base, &pq_store_holder);
 
     let (mut ctx, payload) = match crate::envelope::unwrap_envelope(raw_bytes, &opts) {
         Ok(result) => result,
         Err(e) => {
             warn!("{} envelope verification failed: {}", service.name(), e);
-            // Build error response with request_id=0 (envelope is invalid)
-            let error_payload = service.build_error_payload(0, &format!("envelope verification failed: {}", e));
-            let signed_response = sign_response(0, error_payload);
-
-            let mut message = Builder::new_default();
-            let mut builder = message.init_root::<crate::common_capnp::response_envelope::Builder>();
-            signed_response.write_to(&mut builder);
-
-            let mut bytes = Vec::new();
-            serialize::write_message(&mut bytes, &message)?;
-            return Ok(bytes);
+            // Never sign a response to unauthenticated input. The transport
+            // boundary treats this error as a silent stream reset/drop on
+            // untrusted carriers, preventing a signing oracle/amplifier.
+            return Err(e).with_context(|| format!("{} envelope admission failed", service.name()));
         }
     };
 
@@ -160,7 +124,10 @@ where
     if let Err(e) = service.verify_claims(&mut ctx).await {
         warn!(
             "{} claims verification failed for {} (id={}): {}",
-            service.name(), ctx.subject(), request_id, e
+            service.name(),
+            ctx.subject(),
+            request_id,
+            e
         );
         let error_payload = service.build_error_payload(request_id, &e.to_string());
         let signed_response = sign_response(request_id, error_payload);
@@ -179,7 +146,10 @@ where
         Ok((resp, cont)) => (resp, cont),
         Err(e) => {
             error!("{} request handling error: {}", service.name(), e);
-            (service.build_error_payload(request_id, &e.to_string()), None)
+            (
+                service.build_error_payload(request_id, &e.to_string()),
+                None,
+            )
         }
     };
 

--- a/crates/hyprstream-rpc/src/service/dispatch.rs
+++ b/crates/hyprstream-rpc/src/service/dispatch.rs
@@ -59,6 +59,7 @@ pub async fn process_request<S>(
     verification: EnvelopeVerification<'_>,
     signing_key: &ed25519_dalek::SigningKey,
     nonce_cache: &crate::envelope::InMemoryNonceCache,
+    carrier: crate::transport::carrier::CarrierContext,
 ) -> Result<Vec<u8>>
 where
     S: crate::service::RequestService,
@@ -88,6 +89,36 @@ where
             response_policy,
         )
     };
+
+    // INV-2 receive-side policy (#1042), defense-in-depth behind the serve
+    // loop's own rejection: on a cleartext-forbidding carrier, refuse a
+    // cleartext (or undecodable) envelope BEFORE signature verification,
+    // claims evaluation, or handler dispatch. A valid signature does not make
+    // cleartext acceptable, and nothing in the request bytes can select the
+    // carrier class — `carrier` comes from the accept boundary.
+    if carrier.forbids_cleartext_envelope()
+        && !crate::envelope::wire_signed_envelope_is_encrypted(raw_bytes).unwrap_or(false)
+    {
+        warn!(
+            "{} rejecting cleartext request envelope on untrusted carrier '{}' (INV-2 #1042)",
+            service.name(),
+            carrier
+        );
+        let error_payload = service.build_error_payload(
+            0,
+            &format!(
+                "cleartext request envelope rejected: carrier '{carrier}' forbids \
+                 cleartext (INV-2); seal the request to the server's #mesh-kem recipient"
+            ),
+        );
+        let signed_response = sign_response(0, error_payload);
+        let mut message = Builder::new_default();
+        let mut builder = message.init_root::<crate::common_capnp::response_envelope::Builder>();
+        signed_response.write_to(&mut builder);
+        let mut bytes = Vec::new();
+        serialize::write_message(&mut bytes, &message)?;
+        return Ok(bytes);
+    }
 
     let pq_store_holder = crate::envelope::global_pq_store();
     let base = match verification {

--- a/crates/hyprstream-rpc/src/transport/carrier.rs
+++ b/crates/hyprstream-rpc/src/transport/carrier.rs
@@ -1,0 +1,167 @@
+//! Receive-side carrier classification (INV-2, #1042; ADR #1023).
+//!
+//! A [`CarrierContext`] states, for one accepted connection/request, which
+//! class of carrier the bytes arrived on. It is constructed **only at the
+//! server's real accept boundary** (the listener/session code in this crate)
+//! and threaded through [`super::rpc_session::serve_rpc_connection`] and
+//! [`crate::service::dispatch::process_request`] to the envelope-policy
+//! chokepoints. It is never derived from request bytes, headers, JWT claims,
+//! remote addresses, or caller assertions — whoever constructs a request must
+//! not be able to construct its trust class.
+//!
+//! The context answers exactly one policy question on the receive path: may a
+//! cleartext (`encrypted_envelope == None`) request envelope be processed?
+//! Untrusted carriers (iroh direct/relay, QUIC including loopback,
+//! WebTransport, unknown) must reject cleartext before claims evaluation or
+//! handler dispatch; only explicitly trusted same-host carriers (inproc, UDS,
+//! systemd-activated UDS) retain their documented cleartext behavior.
+//!
+//! This mirrors the send side's [`Transport::forbids_cleartext_envelope`]
+//! (#1036) so the two halves of INV-2 (#1028) classify identically. The
+//! carrier context is **not** an identity: remote NodeId, TLS identity,
+//! relay/direct state, and signer equality remain diagnostics — live identity
+//! admission is #1027's separate evidence.
+//!
+//! [`Transport::forbids_cleartext_envelope`]: crate::transport_traits::Transport::forbids_cleartext_envelope
+
+/// Carrier class of an accepted RPC connection, as attested by the accept
+/// boundary that constructed it.
+///
+/// Trusted-local constructors are `pub(crate)`: only this crate's transport
+/// accept boundaries (in-memory inproc, UDS/systemd listeners) can mint a
+/// trusted context. Out-of-crate hosts that terminate their own genuinely
+/// same-host channel must use the loudly-named
+/// [`CarrierContext::explicit_trusted_local`] so every such grant is
+/// greppable. Untrusted constructors are freely public — classifying a
+/// carrier as untrusted is always safe.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CarrierContext {
+    class: CarrierClass,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CarrierClass {
+    /// Same-process in-memory channel: bytes never leave the address space.
+    Inproc,
+    /// Same-host Unix domain socket accepted by this crate's UDS listener
+    /// (including systemd socket activation) — peer-credential authenticated.
+    TrustedUds,
+    /// An out-of-crate host explicitly attested its channel as same-host
+    /// trusted via [`CarrierContext::explicit_trusted_local`].
+    ExplicitTrustedLocal,
+    /// iroh connection, direct or relay-carried.
+    Iroh,
+    /// QUIC session — cross-host or loopback. A loopback address is not
+    /// evidence the bytes stay inside the trust boundary (it can terminate at
+    /// a proxy/tunnel), so it earns no exemption.
+    Quic,
+    /// WebTransport session (browser or native `web_transport_quinn`).
+    WebTransport,
+    /// Unknown or ambiguous origin. Fail-closed: treated as untrusted.
+    Unknown,
+}
+
+impl CarrierContext {
+    /// Same-process in-memory carrier (trusted local). Accept-boundary only.
+    pub(crate) fn inproc() -> Self {
+        Self { class: CarrierClass::Inproc }
+    }
+
+    /// Same-host UDS carrier accepted by this crate's listener, including
+    /// systemd socket activation (trusted local). Accept-boundary only.
+    pub(crate) fn trusted_uds() -> Self {
+        Self { class: CarrierClass::TrustedUds }
+    }
+
+    /// An iroh carrier (direct or relay-carried). Untrusted.
+    pub fn iroh() -> Self {
+        Self { class: CarrierClass::Iroh }
+    }
+
+    /// A QUIC carrier — cross-host **or loopback**. Untrusted.
+    pub fn quic() -> Self {
+        Self { class: CarrierClass::Quic }
+    }
+
+    /// A WebTransport carrier. Untrusted.
+    pub fn web_transport() -> Self {
+        Self { class: CarrierClass::WebTransport }
+    }
+
+    /// Unknown/ambiguous carrier. Untrusted (the fail-closed default any new
+    /// accept path should start from until it is deliberately classified).
+    pub fn untrusted_unknown() -> Self {
+        Self { class: CarrierClass::Unknown }
+    }
+
+    /// Explicit trusted-local attestation for an out-of-crate host that
+    /// terminates its own genuinely same-host channel (or a test driving the
+    /// dispatch API directly).
+    ///
+    /// **This is a security assertion.** Calling it declares that the bytes
+    /// handed to the processor never crossed a network carrier. It must never
+    /// be reachable from request data, and a code-review grep for this name
+    /// must account for every call site. When in doubt, use
+    /// [`CarrierContext::untrusted_unknown`] — cleartext will then be refused,
+    /// which is the safe failure.
+    pub fn explicit_trusted_local() -> Self {
+        Self { class: CarrierClass::ExplicitTrustedLocal }
+    }
+
+    /// Whether this carrier forbids cleartext request envelopes (INV-2).
+    ///
+    /// `true` for every network/unknown carrier; `false` only for the
+    /// explicitly trusted same-host classes.
+    pub fn forbids_cleartext_envelope(&self) -> bool {
+        match self.class {
+            CarrierClass::Inproc
+            | CarrierClass::TrustedUds
+            | CarrierClass::ExplicitTrustedLocal => false,
+            CarrierClass::Iroh
+            | CarrierClass::Quic
+            | CarrierClass::WebTransport
+            | CarrierClass::Unknown => true,
+        }
+    }
+
+    /// Short static label for logs/errors. Never used for policy.
+    pub fn label(&self) -> &'static str {
+        match self.class {
+            CarrierClass::Inproc => "inproc",
+            CarrierClass::TrustedUds => "uds",
+            CarrierClass::ExplicitTrustedLocal => "explicit-trusted-local",
+            CarrierClass::Iroh => "iroh",
+            CarrierClass::Quic => "quic",
+            CarrierClass::WebTransport => "webtransport",
+            CarrierClass::Unknown => "unknown",
+        }
+    }
+}
+
+impl std::fmt::Display for CarrierContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// INV-2 receive-side classification matrix (#1042): every network or
+    /// unknown carrier forbids cleartext; only the explicit same-host classes
+    /// permit it.
+    #[test]
+    fn inv2_receive_carrier_matrix() {
+        assert!(CarrierContext::iroh().forbids_cleartext_envelope());
+        assert!(CarrierContext::quic().forbids_cleartext_envelope(),);
+        assert!(CarrierContext::web_transport().forbids_cleartext_envelope());
+        assert!(
+            CarrierContext::untrusted_unknown().forbids_cleartext_envelope(),
+            "missing/ambiguous context must follow the untrusted branch"
+        );
+        assert!(!CarrierContext::inproc().forbids_cleartext_envelope());
+        assert!(!CarrierContext::trusted_uds().forbids_cleartext_envelope());
+        assert!(!CarrierContext::explicit_trusted_local().forbids_cleartext_envelope());
+    }
+}

--- a/crates/hyprstream-rpc/src/transport/carrier.rs
+++ b/crates/hyprstream-rpc/src/transport/carrier.rs
@@ -29,10 +29,7 @@
 ///
 /// Trusted-local constructors are `pub(crate)`: only this crate's transport
 /// accept boundaries (in-memory inproc, UDS/systemd listeners) can mint a
-/// trusted context. Out-of-crate hosts that terminate their own genuinely
-/// same-host channel must use the loudly-named
-/// [`CarrierContext::explicit_trusted_local`] so every such grant is
-/// greppable. Untrusted constructors are freely public — classifying a
+/// trusted context. Untrusted constructors are freely public — classifying a
 /// carrier as untrusted is always safe.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CarrierContext {
@@ -46,9 +43,6 @@ enum CarrierClass {
     /// Same-host Unix domain socket accepted by this crate's UDS listener
     /// (including systemd socket activation) — peer-credential authenticated.
     TrustedUds,
-    /// An out-of-crate host explicitly attested its channel as same-host
-    /// trusted via [`CarrierContext::explicit_trusted_local`].
-    ExplicitTrustedLocal,
     /// iroh connection, direct or relay-carried.
     Iroh,
     /// QUIC session — cross-host or loopback. A loopback address is not
@@ -64,48 +58,46 @@ enum CarrierClass {
 impl CarrierContext {
     /// Same-process in-memory carrier (trusted local). Accept-boundary only.
     pub(crate) fn inproc() -> Self {
-        Self { class: CarrierClass::Inproc }
+        Self {
+            class: CarrierClass::Inproc,
+        }
     }
 
     /// Same-host UDS carrier accepted by this crate's listener, including
     /// systemd socket activation (trusted local). Accept-boundary only.
     pub(crate) fn trusted_uds() -> Self {
-        Self { class: CarrierClass::TrustedUds }
+        Self {
+            class: CarrierClass::TrustedUds,
+        }
     }
 
     /// An iroh carrier (direct or relay-carried). Untrusted.
     pub fn iroh() -> Self {
-        Self { class: CarrierClass::Iroh }
+        Self {
+            class: CarrierClass::Iroh,
+        }
     }
 
     /// A QUIC carrier — cross-host **or loopback**. Untrusted.
     pub fn quic() -> Self {
-        Self { class: CarrierClass::Quic }
+        Self {
+            class: CarrierClass::Quic,
+        }
     }
 
     /// A WebTransport carrier. Untrusted.
     pub fn web_transport() -> Self {
-        Self { class: CarrierClass::WebTransport }
+        Self {
+            class: CarrierClass::WebTransport,
+        }
     }
 
     /// Unknown/ambiguous carrier. Untrusted (the fail-closed default any new
     /// accept path should start from until it is deliberately classified).
     pub fn untrusted_unknown() -> Self {
-        Self { class: CarrierClass::Unknown }
-    }
-
-    /// Explicit trusted-local attestation for an out-of-crate host that
-    /// terminates its own genuinely same-host channel (or a test driving the
-    /// dispatch API directly).
-    ///
-    /// **This is a security assertion.** Calling it declares that the bytes
-    /// handed to the processor never crossed a network carrier. It must never
-    /// be reachable from request data, and a code-review grep for this name
-    /// must account for every call site. When in doubt, use
-    /// [`CarrierContext::untrusted_unknown`] — cleartext will then be refused,
-    /// which is the safe failure.
-    pub fn explicit_trusted_local() -> Self {
-        Self { class: CarrierClass::ExplicitTrustedLocal }
+        Self {
+            class: CarrierClass::Unknown,
+        }
     }
 
     /// Whether this carrier forbids cleartext request envelopes (INV-2).
@@ -114,9 +106,7 @@ impl CarrierContext {
     /// explicitly trusted same-host classes.
     pub fn forbids_cleartext_envelope(&self) -> bool {
         match self.class {
-            CarrierClass::Inproc
-            | CarrierClass::TrustedUds
-            | CarrierClass::ExplicitTrustedLocal => false,
+            CarrierClass::Inproc | CarrierClass::TrustedUds => false,
             CarrierClass::Iroh
             | CarrierClass::Quic
             | CarrierClass::WebTransport
@@ -129,7 +119,6 @@ impl CarrierContext {
         match self.class {
             CarrierClass::Inproc => "inproc",
             CarrierClass::TrustedUds => "uds",
-            CarrierClass::ExplicitTrustedLocal => "explicit-trusted-local",
             CarrierClass::Iroh => "iroh",
             CarrierClass::Quic => "quic",
             CarrierClass::WebTransport => "webtransport",
@@ -162,6 +151,5 @@ mod tests {
         );
         assert!(!CarrierContext::inproc().forbids_cleartext_envelope());
         assert!(!CarrierContext::trusted_uds().forbids_cleartext_envelope());
-        assert!(!CarrierContext::explicit_trusted_local().forbids_cleartext_envelope());
     }
 }

--- a/crates/hyprstream-rpc/src/transport/in_memory.rs
+++ b/crates/hyprstream-rpc/src/transport/in_memory.rs
@@ -83,7 +83,16 @@ impl Transport for InMemoryTransport {
             .map(|ms| Duration::from_millis(ms.max(0) as u64))
             .unwrap_or(DEFAULT_TIMEOUT);
         let processor = Arc::clone(&self.processor);
-        let fut = async move { processor.process(Bytes::from(payload)).await };
+        // INV-2 (#1042): the request never leaves this address space — the
+        // one carrier class that is inproc by construction.
+        let fut = async move {
+            processor
+                .process(
+                    Bytes::from(payload),
+                    crate::transport::carrier::CarrierContext::inproc(),
+                )
+                .await
+        };
         let resp = tokio::time::timeout(timeout, fut)
             .await
             .map_err(|_| anyhow!("in-process RPC timeout after {timeout:?}"))??;

--- a/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
@@ -177,6 +177,8 @@ impl ProtocolHandler for IrohRpcProtocolHandler {
         // abstraction and delegate to the shared accept loop. Drain semantics
         // (`shutdown` below draining the same `Semaphore`) are unchanged.
         let session = web_transport_iroh::Session::raw(conn);
+        // INV-2 (#1042): this accept boundary terminates an iroh connection —
+        // an untrusted carrier regardless of direct/relay path or NodeId.
         serve_rpc_connection(
             session,
             Arc::clone(&self.inner.processor),
@@ -184,6 +186,7 @@ impl ProtocolHandler for IrohRpcProtocolHandler {
             Arc::clone(&self.inner.stream_limit),
             self.inner.read_timeout,
             self.inner.shutdown.clone(),
+            crate::transport::carrier::CarrierContext::iroh(),
         )
         .await
         .map_err(|e| AcceptError::from_err(std::io::Error::other(e.to_string())))
@@ -251,6 +254,9 @@ pub async fn client_request(conn: &Connection, request: &[u8]) -> Result<Bytes> 
 /// Per-request payload + response slot exchanged with the bridge thread.
 struct BridgeMessage {
     request: Bytes,
+    /// Accept-boundary carrier classification (INV-2 #1042), forwarded
+    /// verbatim to the dispatch pipeline's cleartext policy.
+    carrier: crate::transport::carrier::CarrierContext,
     respond: tokio::sync::oneshot::Sender<Result<Bytes>>,
 }
 
@@ -275,6 +281,7 @@ async fn run_bridge_dispatch_loop<S>(
                 crate::envelope::EnvelopeVerification::AnySigner,
                 &signing_key,
                 &nonce_cache,
+                msg.carrier,
             )
             .await
             .map(Bytes::from);
@@ -415,12 +422,14 @@ impl IrohRequestProcessor for LocalServiceBridge {
     fn process(
         &self,
         request: Bytes,
+        carrier: crate::transport::carrier::CarrierContext,
     ) -> std::pin::Pin<Box<dyn Future<Output = Result<Bytes>> + Send + '_>> {
         let tx = self.tx.clone();
         Box::pin(async move {
             let (respond_tx, respond_rx) = tokio::sync::oneshot::channel();
             tx.send(BridgeMessage {
                 request,
+                carrier,
                 respond: respond_tx,
             })
             .await

--- a/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
@@ -6,8 +6,8 @@
 //!   [`crate::transport::iroh_substrate`] under the `hyprstream-rpc/1` ALPN.
 //!   Enforces a server-wide cap on concurrent streams (DoS bound) and
 //!   drains in-flight requests on `ProtocolHandler::shutdown`.
-//! - [`IrohRequestProcessor`] — trait callers implement to wire actual
-//!   request processing (envelope verification + service dispatch).
+//! - [`IrohRequestProcessor`] — sealed request processing trait; production
+//!   network sessions admit only the canonical envelope/service bridge.
 //! - [`LocalServiceBridge`] — adapts a [`crate::service::RequestService`]
 //!   (potentially `!Send`) to the Send-bounded [`IrohRequestProcessor`].
 //!
@@ -16,10 +16,9 @@
 //! verification, JWT/DPoP, and `authorize_signer` enforcement happen inside
 //! the processor (which is `LocalServiceBridge` in production, delegating
 //! to [`crate::service::dispatch::process_request`]). The handler does
-//! hold a signing key, but uses it only to produce signed error envelopes
-//! when the processor itself returns `Err` (a wire-level failure), so the
-//! client always sees a parseable `ResponseEnvelope` rather than an opaque
-//! EOF + Cap'n Proto parse error.
+//! hold a signing key for trusted-local transport-only processor failures.
+//! Admission failures on the untrusted iroh carrier are reset/dropped without
+//! a signed response, preventing an unauthenticated signing oracle.
 //!
 //! **Wire framing**: each request is the opaque bytes of a Cap'n Proto-encoded
 //! [`crate::envelope::SignedEnvelope`] written to a freshly-opened iroh bidi
@@ -41,8 +40,8 @@ use tokio_util::sync::CancellationToken;
 // Transport-generic core lives in `super::rpc_session`. Re-export the shared
 // surface from here so existing `iroh_rpc::{...}` imports keep working.
 pub use super::rpc_session::{
-    DEFAULT_STREAM_LIMIT, IrohRequestProcessor, MAX_FRAME_BYTES, build_error_envelope, from_fn,
-    read_to_cap, serve_rpc_connection,
+    build_error_envelope, from_fn, read_to_cap, serve_rpc_connection, IrohRequestProcessor,
+    DEFAULT_STREAM_LIMIT, MAX_FRAME_BYTES,
 };
 
 // ============================================================================
@@ -62,9 +61,10 @@ pub struct IrohRpcProtocolHandler {
 #[derive(Clone)]
 struct HandlerInner {
     processor: Arc<dyn IrohRequestProcessor>,
-    /// Used to produce signed error envelopes when the processor itself
-    /// returns `Err` (wire-level fatal). Application errors come back from
-    /// the processor pre-wrapped as signed `ResponseEnvelope` bytes.
+    /// Used for signed stub errors only below a trusted-local transport test
+    /// boundary. Production iroh admission failures are silently dropped.
+    /// Authenticated application errors come back from the processor already
+    /// wrapped as signed `ResponseEnvelope` bytes.
     signing_key: SigningKey,
     /// Caps concurrent bidi streams in flight. Hold one permit per stream.
     stream_limit: Arc<Semaphore>,
@@ -76,6 +76,10 @@ struct HandlerInner {
     connection_limit: Arc<Semaphore>,
     /// Per-stream request-read timeout (#159 slowloris bound).
     read_timeout: std::time::Duration,
+    /// Accept-boundary carrier classification. Production is always iroh;
+    /// unit tests may substitute inproc to exercise raw transport mechanics
+    /// below the network envelope-policy boundary.
+    carrier: crate::transport::carrier::CarrierContext,
     /// Level-triggered shutdown signal: once `cancel()` is called, every
     /// future and current `cancelled().await` resolves immediately. Used
     /// instead of `tokio::sync::Notify` because `Notify::notify_waiters`
@@ -116,6 +120,7 @@ impl IrohRpcProtocolHandler {
                     super::rpc_session::DEFAULT_CONNECTION_LIMIT,
                 )),
                 read_timeout: super::rpc_session::REQUEST_READ_TIMEOUT,
+                carrier: crate::transport::carrier::CarrierContext::iroh(),
                 shutdown: CancellationToken::new(),
             }),
         }
@@ -126,6 +131,12 @@ impl IrohRpcProtocolHandler {
     /// [`super::rpc_session::REQUEST_READ_TIMEOUT`].
     pub fn with_read_timeout(mut self, read_timeout: std::time::Duration) -> Self {
         self.mutate_inner(|i| i.read_timeout = read_timeout);
+        self
+    }
+
+    #[cfg(test)]
+    fn with_test_trusted_carrier(mut self) -> Self {
+        self.mutate_inner(|i| i.carrier = crate::transport::carrier::CarrierContext::inproc());
         self
     }
 
@@ -186,7 +197,7 @@ impl ProtocolHandler for IrohRpcProtocolHandler {
             Arc::clone(&self.inner.stream_limit),
             self.inner.read_timeout,
             self.inner.shutdown.clone(),
-            crate::transport::carrier::CarrierContext::iroh(),
+            self.inner.carrier,
         )
         .await
         .map_err(|e| AcceptError::from_err(std::io::Error::other(e.to_string())))
@@ -308,6 +319,12 @@ pub struct LocalServiceBridge {
     tx: tokio::sync::mpsc::Sender<BridgeMessage>,
 }
 
+impl crate::transport::rpc_session::sealed::Sealed for LocalServiceBridge {
+    fn admits_untrusted_carrier(&self) -> bool {
+        true
+    }
+}
+
 impl LocalServiceBridge {
     /// Spawn a dedicated bridge thread that owns `service` and forwards
     /// requests through [`crate::service::dispatch::process_request`].
@@ -386,7 +403,10 @@ impl LocalServiceBridge {
         std::thread::Builder::new()
             .name(format!("rpc-bridge:{thread_name}"))
             .spawn(move || {
-                let rt = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
+                let rt = match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
                     Ok(rt) => rt,
                     Err(e) => {
                         let _ = ready_tx.send(Err(anyhow::anyhow!("bridge runtime: {e}")));
@@ -445,7 +465,7 @@ impl IrohRequestProcessor for LocalServiceBridge {
 mod tests {
     use super::*;
     use crate::transport::iroh_substrate::{
-        ALPN_HYPRSTREAM_RPC, ALPN_MOQ_LITE, IrohSubstrate, NoopHandler,
+        IrohSubstrate, NoopHandler, ALPN_HYPRSTREAM_RPC, ALPN_MOQ_LITE,
     };
     use iroh::{EndpointAddr, TransportAddr};
     use rand::RngCore;
@@ -521,7 +541,9 @@ mod tests {
             Arc::clone(&nonce),
             0,
         )?;
-        ready.await.map_err(|_| anyhow::anyhow!("readiness dropped"))??;
+        ready
+            .await
+            .map_err(|_| anyhow::anyhow!("readiness dropped"))??;
 
         // Builder fails (e.g. GPU init error) → the error surfaces on readiness,
         // not silently as a later channel-closed.
@@ -531,7 +553,9 @@ mod tests {
             nonce,
             0,
         )?;
-        let build_result = ready2.await.map_err(|_| anyhow::anyhow!("readiness dropped"))?;
+        let build_result = ready2
+            .await
+            .map_err(|_| anyhow::anyhow!("readiness dropped"))?;
         assert!(
             build_result.is_err(),
             "a build failure must surface on the readiness channel"
@@ -547,10 +571,12 @@ mod tests {
             out.extend_from_slice(&req);
             Ok(Bytes::from(out))
         });
-        let rpc_handler = IrohRpcProtocolHandler::new(processor, fresh_signing_key());
+        let rpc_handler =
+            IrohRpcProtocolHandler::new(processor, fresh_signing_key()).with_test_trusted_carrier();
 
         let server =
-            IrohSubstrate::new_test(fresh_key(), NoopHandler::new("moq-not-wired"), rpc_handler).await?;
+            IrohSubstrate::new_test(fresh_key(), NoopHandler::new("moq-not-wired"), rpc_handler)
+                .await?;
         let server_addr = direct_addr(&server);
 
         let client = IrohSubstrate::new_test(
@@ -582,7 +608,7 @@ mod tests {
         let server = IrohSubstrate::new_test(
             fresh_key(),
             NoopHandler::new("moq"),
-            IrohRpcProtocolHandler::new(processor, fresh_signing_key()),
+            IrohRpcProtocolHandler::new(processor, fresh_signing_key()).with_test_trusted_carrier(),
         )
         .await?;
         let server_addr = direct_addr(&server);
@@ -623,7 +649,8 @@ mod tests {
 
         let processor =
             from_fn(|_req: Bytes| async move { Err(anyhow::anyhow!("boom from processor")) });
-        let handler = IrohRpcProtocolHandler::new(processor, server_signing);
+        let handler =
+            IrohRpcProtocolHandler::new(processor, server_signing).with_test_trusted_carrier();
 
         let server = IrohSubstrate::new_test(fresh_key(), NoopHandler::new("moq"), handler).await?;
         let server_addr = direct_addr(&server);
@@ -639,7 +666,8 @@ mod tests {
         // Send any bytes; the processor will Err regardless. The interesting
         // assertion is what comes back: a verifiable ResponseEnvelope.
         let resp_bytes = client_request(&conn, b"anything").await?;
-        let (request_id, payload) = crate::envelope::unwrap_response(&resp_bytes, Some(&server_vk))?;
+        let (request_id, payload) =
+            crate::envelope::unwrap_response(&resp_bytes, Some(&server_vk))?;
         assert_eq!(request_id, 0, "error envelope uses request_id=0");
         let body = std::str::from_utf8(&payload)?;
         assert!(body.contains("boom from processor"), "got: {body}");
@@ -678,11 +706,9 @@ mod tests {
                 Ok(Bytes::from_static(b"ok"))
             }
         });
-        let handler = IrohRpcProtocolHandler::with_stream_limit(
-            Arc::new(processor),
-            fresh_signing_key(),
-            2,
-        );
+        let handler =
+            IrohRpcProtocolHandler::with_stream_limit(Arc::new(processor), fresh_signing_key(), 2)
+                .with_test_trusted_carrier();
 
         let server = IrohSubstrate::new_test(fresh_key(), NoopHandler::new("moq"), handler).await?;
         let server_addr = direct_addr(&server);
@@ -726,12 +752,10 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn rpc_slowloris_stream_is_timed_out_and_permit_released() -> Result<()> {
         let processor = from_fn(move |_req: Bytes| async move { Ok(Bytes::from_static(b"ok")) });
-        let handler = IrohRpcProtocolHandler::with_stream_limit(
-            Arc::new(processor),
-            fresh_signing_key(),
-            1,
-        )
-        .with_read_timeout(Duration::from_millis(300));
+        let handler =
+            IrohRpcProtocolHandler::with_stream_limit(Arc::new(processor), fresh_signing_key(), 1)
+                .with_test_trusted_carrier()
+                .with_read_timeout(Duration::from_millis(300));
 
         let server = IrohSubstrate::new_test(fresh_key(), NoopHandler::new("moq"), handler).await?;
         let server_addr = direct_addr(&server);
@@ -746,7 +770,10 @@ mod tests {
 
         // Slowloris: open a bidi stream, dribble one byte, never finish.
         let (mut stall_send, _stall_recv) = conn.open_bi().await.context("open_bi stall")?;
-        stall_send.write_all(b"x").await.context("write stall byte")?;
+        stall_send
+            .write_all(b"x")
+            .await
+            .context("write stall byte")?;
         // Deliberately DO NOT call finish(); keep the stream (and its server-side
         // permit) alive. Hold the handle so it isn't dropped/reset early.
 
@@ -783,7 +810,8 @@ mod tests {
                 Ok(Bytes::from_static(b"drained-ok"))
             }
         });
-        let handler = IrohRpcProtocolHandler::new(processor, fresh_signing_key());
+        let handler =
+            IrohRpcProtocolHandler::new(processor, fresh_signing_key()).with_test_trusted_carrier();
 
         let server = IrohSubstrate::new_test(fresh_key(), NoopHandler::new("moq"), handler).await?;
         let server_addr = direct_addr(&server);
@@ -803,7 +831,9 @@ mod tests {
 
         // Synchronise: wait until the processor signals it has entered the
         // sleep, *then* shut down. No wall-clock guesses.
-        entered.notified().await;
+        tokio::time::timeout(Duration::from_secs(5), entered.notified())
+            .await
+            .context("processor was never entered before shutdown")?;
         server.shutdown().await?;
 
         let resp = req_task.await??;
@@ -812,5 +842,4 @@ mod tests {
         client.shutdown().await?;
         Ok(())
     }
-
 }

--- a/crates/hyprstream-rpc/src/transport/lazy_quinn.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_quinn.rs
@@ -140,12 +140,10 @@ impl Transport for LazyQuinnTransport {
         let deadline = timeout_ms
             .map(|ms| Duration::from_millis(ms.max(0) as u64))
             .unwrap_or(DEFAULT_TIMEOUT);
-        let inner_ceiling_ms = deadline
-            .as_millis()
-            .saturating_mul(2)
-            .min(i32::MAX as u128) as i32;
+        let inner_ceiling_ms = deadline.as_millis().saturating_mul(2).min(i32::MAX as u128) as i32;
 
-        match tokio::time::timeout(deadline, transport.send(payload, Some(inner_ceiling_ms))).await {
+        match tokio::time::timeout(deadline, transport.send(payload, Some(inner_ceiling_ms))).await
+        {
             // Our deadline fired: a slow/stalled request, not necessarily a dead
             // connection. Keep the cached session — re-dialing on every timeout
             // would thrash a merely-busy peer. (#156 owns liveness-based re-dial.)
@@ -209,8 +207,7 @@ mod tests {
     fn spawn_echo_server() -> (SocketAddr, [u8; 32], CancellationToken) {
         crate::transport::pq_provider::install_pq_crypto_provider();
 
-        let cert_key =
-            rcgen::generate_simple_self_signed(vec!["localhost".to_owned()]).unwrap();
+        let cert_key = rcgen::generate_simple_self_signed(vec!["localhost".to_owned()]).unwrap();
         let cert_der = cert_key.cert.der().to_vec();
         let key_der = cert_key.key_pair.serialize_der();
         let chain = vec![rustls::pki_types::CertificateDer::from(cert_der.clone())];
@@ -224,9 +221,9 @@ mod tests {
             .unwrap();
         let bound = server.local_addr().unwrap();
 
-        let processor =
-            crate::transport::rpc_session::from_fn(|req: Bytes| async move { Ok(req) });
-        let rpc_server = QuinnRpcServer::new(server, processor, fresh_signing_key());
+        let processor = crate::transport::rpc_session::from_fn(|req: Bytes| async move { Ok(req) });
+        let rpc_server =
+            QuinnRpcServer::new(server, processor, fresh_signing_key()).with_test_trusted_carrier();
         let shutdown = rpc_server.shutdown_token();
         tokio::spawn(rpc_server.run());
 
@@ -236,13 +233,23 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn lazy_connects_on_first_send_and_caches() {
         let (addr, pin, shutdown) = spawn_echo_server();
-        let t = LazyQuinnTransport::new(addr, "localhost", QuicServerAuth::pinned(vec![pin]).unwrap());
+        let t = LazyQuinnTransport::new(
+            addr,
+            "localhost",
+            QuicServerAuth::pinned(vec![pin]).unwrap(),
+        );
 
-        assert!(t.state.lock().await.cached.is_none(), "no connection before first send");
+        assert!(
+            t.state.lock().await.cached.is_none(),
+            "no connection before first send"
+        );
 
         let resp = t.send(b"hello".to_vec(), Some(5_000)).await.unwrap();
         assert_eq!(resp, b"hello");
-        assert!(t.state.lock().await.cached.is_some(), "session cached after first send");
+        assert!(
+            t.state.lock().await.cached.is_some(),
+            "session cached after first send"
+        );
 
         let resp2 = t.send(b"again".to_vec(), Some(5_000)).await.unwrap();
         assert_eq!(resp2, b"again");
@@ -253,15 +260,22 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn wrong_cert_pin_does_not_connect() {
         let (addr, _pin, shutdown) = spawn_echo_server();
-        let t = LazyQuinnTransport::new(addr, "localhost", QuicServerAuth::pinned(vec![[0u8; 32]]).unwrap()); // wrong fingerprint
-        // The TLS handshake must *promptly reject* a wrong pin: the send must
-        // COMPLETE with an error well within the hang-guard. If the guard fires
-        // (i.e. send hung), the test fails — so a hang can't masquerade as a pass.
+        let t = LazyQuinnTransport::new(
+            addr,
+            "localhost",
+            QuicServerAuth::pinned(vec![[0u8; 32]]).unwrap(),
+        ); // wrong fingerprint
+           // The TLS handshake must *promptly reject* a wrong pin: the send must
+           // COMPLETE with an error well within the hang-guard. If the guard fires
+           // (i.e. send hung), the test fails — so a hang can't masquerade as a pass.
         let res = tokio::time::timeout(Duration::from_secs(8), t.send(b"x".to_vec(), Some(3_000)))
             .await
             .expect("send must complete (with an error) — a wrong pin should reject, not hang");
         assert!(res.is_err(), "a wrong cert pin must make send fail");
-        assert!(t.state.lock().await.cached.is_none(), "failed dial leaves nothing cached");
+        assert!(
+            t.state.lock().await.cached.is_none(),
+            "failed dial leaves nothing cached"
+        );
         shutdown.cancel();
     }
 
@@ -278,8 +292,14 @@ mod tests {
         let res = tokio::time::timeout(Duration::from_secs(13), t.send(b"x".to_vec(), Some(2_000)))
             .await
             .expect("send must complete (with an error) within the connect timeout, not hang");
-        assert!(res.is_err(), "a dead address must yield an error, not a connection");
-        assert!(t.state.lock().await.cached.is_none(), "a failed connect caches nothing");
+        assert!(
+            res.is_err(),
+            "a dead address must yield an error, not a connection"
+        );
+        assert!(
+            t.state.lock().await.cached.is_none(),
+            "a failed connect caches nothing"
+        );
     }
 
     #[tokio::test]

--- a/crates/hyprstream-rpc/src/transport/lazy_uds.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_uds.rs
@@ -191,6 +191,7 @@ mod tests {
                         tokio::spawn(async move {
                             let _ = serve_rpc_connection(
                                 session, p, sk, l, REQUEST_READ_TIMEOUT, sd,
+                                crate::transport::carrier::CarrierContext::explicit_trusted_local(),
                             )
                             .await;
                         });

--- a/crates/hyprstream-rpc/src/transport/lazy_uds.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_uds.rs
@@ -130,7 +130,8 @@ impl Transport for LazyUdsTransport {
             .unwrap_or(DEFAULT_TIMEOUT);
         let inner_ceiling_ms = deadline.as_millis().saturating_mul(2).min(i32::MAX as u128) as i32;
 
-        match tokio::time::timeout(deadline, transport.send(payload, Some(inner_ceiling_ms))).await {
+        match tokio::time::timeout(deadline, transport.send(payload, Some(inner_ceiling_ms))).await
+        {
             Err(_elapsed) => Err(anyhow!("uds RPC timeout after {deadline:?}")),
             Ok(Ok(resp)) => Ok(resp),
             Ok(Err(e)) => {
@@ -191,7 +192,7 @@ mod tests {
                         tokio::spawn(async move {
                             let _ = serve_rpc_connection(
                                 session, p, sk, l, REQUEST_READ_TIMEOUT, sd,
-                                crate::transport::carrier::CarrierContext::explicit_trusted_local(),
+                                crate::transport::carrier::CarrierContext::trusted_uds(),
                             )
                             .await;
                         });
@@ -201,10 +202,16 @@ mod tests {
         });
 
         let t = LazyUdsTransport::new(path.clone());
-        assert!(t.state.lock().await.cached.is_none(), "no connection before first send");
+        assert!(
+            t.state.lock().await.cached.is_none(),
+            "no connection before first send"
+        );
         let resp = t.send(b"ping".to_vec(), Some(4_000)).await.unwrap();
         assert_eq!(resp, b"ping");
-        assert!(t.state.lock().await.cached.is_some(), "session cached after first send");
+        assert!(
+            t.state.lock().await.cached.is_some(),
+            "session cached after first send"
+        );
         // Second call reuses the cached session (multiplexed stream).
         let resp2 = t.send(b"pong".to_vec(), Some(4_000)).await.unwrap();
         assert_eq!(resp2, b"pong");
@@ -217,14 +224,18 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn lazy_uds_missing_socket_errors_without_hang() {
-        let path = std::env::temp_dir().join(format!("lazy-uds-absent-{}.sock", std::process::id()));
+        let path =
+            std::env::temp_dir().join(format!("lazy-uds-absent-{}.sock", std::process::id()));
         let _ = std::fs::remove_file(&path);
         let t = LazyUdsTransport::new(path);
         let res = tokio::time::timeout(Duration::from_secs(5), t.send(b"x".to_vec(), Some(2_000)))
             .await
             .expect("send must complete (with an error), not hang");
         assert!(res.is_err(), "dialing an absent socket must fail");
-        assert!(t.state.lock().await.cached.is_none(), "a failed connect caches nothing");
+        assert!(
+            t.state.lock().await.cached.is_none(),
+            "a failed connect caches nothing"
+        );
     }
 
     #[tokio::test]

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -8,6 +8,7 @@
 //! - Raw socket options via `sockopt` submodule
 
 mod traits;
+pub mod carrier;
 pub mod zmtp_quic;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod pq_provider;

--- a/crates/hyprstream-rpc/src/transport/quinn_transport.rs
+++ b/crates/hyprstream-rpc/src/transport/quinn_transport.rs
@@ -19,15 +19,17 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{Result, anyhow, bail};
+#[cfg(test)]
+use anyhow::Context;
+use anyhow::{anyhow, bail, Result};
 use async_trait::async_trait;
 use ed25519_dalek::SigningKey;
 use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 
 use crate::transport::rpc_session::{
-    DEFAULT_STREAM_LIMIT, IrohRequestProcessor, RpcPendingStream, RpcPublishStub,
-    SessionRpcTransport, serve_rpc_connection,
+    serve_rpc_connection, IrohRequestProcessor, RpcPendingStream, RpcPublishStub,
+    SessionRpcTransport, DEFAULT_STREAM_LIMIT,
 };
 use crate::transport_traits::Transport;
 
@@ -104,6 +106,9 @@ pub struct QuinnRpcServer {
     connection_limit: Arc<Semaphore>,
     /// Per-stream request-read timeout (#159 slowloris bound).
     read_timeout: Duration,
+    /// Accept-boundary carrier classification. Production is always
+    /// WebTransport; unit tests may use inproc for raw transport-only probes.
+    carrier: crate::transport::carrier::CarrierContext,
     /// Optional moq streaming-plane consumer (#274). When set, sessions whose
     /// WebTransport CONNECT URL path is [`crate::dial::MOQ_PATH`] are handed to
     /// `moq_net::Server::accept` instead of the RPC core. `None` = RPC only.
@@ -136,7 +141,12 @@ impl QuinnRpcServer {
         processor: P,
         signing_key: SigningKey,
     ) -> Self {
-        Self::with_capacity(server, Arc::new(processor), signing_key, DEFAULT_STREAM_LIMIT)
+        Self::with_capacity(
+            server,
+            Arc::new(processor),
+            signing_key,
+            DEFAULT_STREAM_LIMIT,
+        )
     }
 
     /// Build a server with an explicit server-wide concurrent-stream cap.
@@ -156,6 +166,7 @@ impl QuinnRpcServer {
                 super::rpc_session::DEFAULT_CONNECTION_LIMIT,
             )),
             read_timeout: super::rpc_session::REQUEST_READ_TIMEOUT,
+            carrier: crate::transport::carrier::CarrierContext::web_transport(),
             moq_consumer: None,
             moq_relay_origin: None,
             moq_authz: crate::transport::iroh_moq::MoqAuthzConfig::default(),
@@ -175,6 +186,12 @@ impl QuinnRpcServer {
     /// over a per-connection iroh ALPN — here the multiplex is by URL path.
     pub fn with_moq_consumer(mut self, consumer: moq_net::OriginConsumer) -> Self {
         self.moq_consumer = Some(consumer);
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_test_trusted_carrier(mut self) -> Self {
+        self.carrier = crate::transport::carrier::CarrierContext::inproc();
         self
     }
 
@@ -208,10 +225,7 @@ impl QuinnRpcServer {
     /// authorizer will deny *private* subscribes here (fail-closed) while public
     /// broadcasts stay open. Cross-tenant enumeration defense for authenticated
     /// peers lives on the iroh `moql` path.
-    pub fn with_moq_authz(
-        mut self,
-        authz: crate::transport::iroh_moq::MoqAuthzConfig,
-    ) -> Self {
+    pub fn with_moq_authz(mut self, authz: crate::transport::iroh_moq::MoqAuthzConfig) -> Self {
         self.moq_authz = authz;
         self
     }
@@ -356,6 +370,7 @@ impl QuinnRpcServer {
                     let moq_relay_origin = self.moq_relay_origin.clone();
                     let moq_authz = self.moq_authz.clone();
                     let ninep_handler = self.ninep_handler.clone();
+                    let carrier = self.carrier;
                     tokio::spawn(async move {
                         let _conn_permit = conn_permit; // released when this connection ends
                         // Multiplex by WebTransport CONNECT URL path (#274, H1b): read
@@ -548,7 +563,7 @@ impl QuinnRpcServer {
                             stream_limit,
                             read_timeout,
                             shutdown,
-                            crate::transport::carrier::CarrierContext::web_transport(),
+                            carrier,
                         )
                         .await
                         {
@@ -606,10 +621,7 @@ impl Transport for QuinnTransport {
 /// Build a quinn WebTransport client session against a server with a CA-issued
 /// certificate, validated via the system root store and the DNS `server_name`
 /// (`QuicServerAuth::web_pki`). Dials `https://{server_name}:{port}/`.
-pub async fn connect_webpki(
-    server_name: &str,
-    port: u16,
-) -> Result<web_transport_quinn::Session> {
+pub async fn connect_webpki(server_name: &str, port: u16) -> Result<web_transport_quinn::Session> {
     let client = web_transport_quinn::ClientBuilder::new()
         .with_system_roots()
         .map_err(|e| anyhow!("quinn client (system roots): {e}"))?;
@@ -634,8 +646,8 @@ pub async fn connect_pinned_hashes(
     let client = web_transport_quinn::ClientBuilder::new()
         .with_server_certificate_hashes(hashes)
         .map_err(|e| anyhow!("quinn client build: {e}"))?;
-    let url = url::Url::parse(&format!("https://{addr}/"))
-        .map_err(|e| anyhow!("quinn url: {e}"))?;
+    let url =
+        url::Url::parse(&format!("https://{addr}/")).map_err(|e| anyhow!("quinn url: {e}"))?;
     client
         .connect(url)
         .await
@@ -684,8 +696,8 @@ pub async fn connect_pinned_hashes_path(
     let client = web_transport_quinn::ClientBuilder::new()
         .with_server_certificate_hashes(hashes)
         .map_err(|e| anyhow!("quinn client build: {e}"))?;
-    let url = url::Url::parse(&format!("https://{addr}{path}"))
-        .map_err(|e| anyhow!("quinn url: {e}"))?;
+    let url =
+        url::Url::parse(&format!("https://{addr}{path}")).map_err(|e| anyhow!("quinn url: {e}"))?;
     client
         .connect(url)
         .await
@@ -783,7 +795,8 @@ mod tests {
         });
 
         let (server, addr, cert_der) = build_server()?;
-        let rpc_server = QuinnRpcServer::new(server, processor, fresh_signing_key());
+        let rpc_server =
+            QuinnRpcServer::new(server, processor, fresh_signing_key()).with_test_trusted_carrier();
         let shutdown = rpc_server.shutdown_token();
         let server_task = tokio::spawn(rpc_server.run());
 
@@ -804,10 +817,10 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn verify_peer_cert_pinned_accepts_right_rejects_wrong() -> Result<()> {
         crate::transport::pq_provider::install_pq_crypto_provider();
-        let processor =
-            crate::transport::rpc_session::from_fn(|req: Bytes| async move { Ok(req) });
+        let processor = crate::transport::rpc_session::from_fn(|req: Bytes| async move { Ok(req) });
         let (server, addr, cert_der) = build_server()?;
-        let rpc_server = QuinnRpcServer::new(server, processor, fresh_signing_key());
+        let rpc_server =
+            QuinnRpcServer::new(server, processor, fresh_signing_key()).with_test_trusted_carrier();
         let shutdown = rpc_server.shutdown_token();
         let server_task = tokio::spawn(rpc_server.run());
 
@@ -815,9 +828,18 @@ mod tests {
         let mut right = [0u8; 32];
         right.copy_from_slice(&sha256(&cert_der));
 
-        assert!(verify_peer_cert_pinned(&session, &[right]).is_ok(), "matching leaf hash must pass");
-        assert!(verify_peer_cert_pinned(&session, &[[0u8; 32]]).is_err(), "wrong hash must reject");
-        assert!(verify_peer_cert_pinned(&session, &[]).is_err(), "empty pin set must reject (fail-closed)");
+        assert!(
+            verify_peer_cert_pinned(&session, &[right]).is_ok(),
+            "matching leaf hash must pass"
+        );
+        assert!(
+            verify_peer_cert_pinned(&session, &[[0u8; 32]]).is_err(),
+            "wrong hash must reject"
+        );
+        assert!(
+            verify_peer_cert_pinned(&session, &[]).is_err(),
+            "empty pin set must reject (fail-closed)"
+        );
 
         shutdown.cancel();
         let _ = server_task.await;
@@ -830,12 +852,12 @@ mod tests {
     async fn quinn_connection_cap_rejects_excess() -> Result<()> {
         crate::transport::pq_provider::install_pq_crypto_provider();
 
-        let processor =
-            crate::transport::rpc_session::from_fn(|req: Bytes| async move { Ok(req) });
+        let processor = crate::transport::rpc_session::from_fn(|req: Bytes| async move { Ok(req) });
 
         let (server, addr, cert_der) = build_server()?;
-        let rpc_server =
-            QuinnRpcServer::new(server, processor, fresh_signing_key()).with_connection_limit(1);
+        let rpc_server = QuinnRpcServer::new(server, processor, fresh_signing_key())
+            .with_test_trusted_carrier()
+            .with_connection_limit(1);
         let shutdown = rpc_server.shutdown_token();
         let server_task = tokio::spawn(rpc_server.run());
 
@@ -891,7 +913,8 @@ mod tests {
         });
 
         let (server, addr, cert_der) = build_server()?;
-        let rpc_server = QuinnRpcServer::new(server, processor, fresh_signing_key());
+        let rpc_server =
+            QuinnRpcServer::new(server, processor, fresh_signing_key()).with_test_trusted_carrier();
         // Grab the shared drain handles before `run()` consumes the server.
         let stream_limit = rpc_server.stream_limit();
         let capacity = rpc_server.capacity();
@@ -909,7 +932,9 @@ mod tests {
 
         // Synchronise: wait until the processor has entered the sleep, then
         // drain-shutdown. No wall-clock guesses.
-        entered.notified().await;
+        tokio::time::timeout(Duration::from_secs(5), entered.notified())
+            .await
+            .context("processor was never entered before shutdown")?;
         QuinnRpcServer::shutdown(&stream_limit, capacity, &token).await;
 
         // The in-flight request must still complete with its real response.

--- a/crates/hyprstream-rpc/src/transport/quinn_transport.rs
+++ b/crates/hyprstream-rpc/src/transport/quinn_transport.rs
@@ -538,6 +538,9 @@ impl QuinnRpcServer {
                             return;
                         }
 
+                        // INV-2 (#1042): this accept boundary terminates a
+                        // WebTransport-over-QUIC session — an untrusted
+                        // carrier even on a loopback address.
                         if let Err(e) = serve_rpc_connection(
                             session,
                             processor,
@@ -545,6 +548,7 @@ impl QuinnRpcServer {
                             stream_limit,
                             read_timeout,
                             shutdown,
+                            crate::transport::carrier::CarrierContext::web_transport(),
                         )
                         .await
                         {

--- a/crates/hyprstream-rpc/src/transport/rpc_session.rs
+++ b/crates/hyprstream-rpc/src/transport/rpc_session.rs
@@ -28,7 +28,7 @@ use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{Result, anyhow, bail};
+use anyhow::{anyhow, bail, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
 use ed25519_dalek::SigningKey;
@@ -137,10 +137,17 @@ impl Default for RpcConfig {
 }
 
 // ============================================================================
-// IrohRequestProcessor — pluggable request handling trait
+// IrohRequestProcessor — sealed request handling trait
 // ============================================================================
 
-/// Trait implemented by callers to wire actual request processing.
+pub(crate) mod sealed {
+    pub trait Sealed {
+        /// True only for the crate-owned canonical envelope pipeline.
+        fn admits_untrusted_carrier(&self) -> bool;
+    }
+}
+
+/// Sealed trait used to wire actual request processing.
 ///
 /// The processor receives the raw request bytes (a Cap'n Proto-encoded
 /// `SignedEnvelope`) and returns the raw response bytes.
@@ -151,28 +158,26 @@ impl Default for RpcConfig {
 ///   Application-layer errors (verification failure, handler error, etc.)
 ///   MUST be returned this way as signed error envelopes — the server
 ///   forwards them unchanged.
-/// - **`Err(_)`** — wire-level fatal: the processor cannot produce *any*
-///   response. The server responds with its own signed error envelope
-///   (`request_id = 0`) so the client sees a parseable error rather than a
-///   Cap'n Proto parse failure.
+/// - **`Err(_)`** — admission or wire-level fatal. Untrusted network carriers
+///   silently reset/drop the stream so unauthenticated input cannot trigger a
+///   signed response. Trusted local carriers retain the legacy signed stub
+///   error for transport-only callers.
 ///
-/// Implementations MUST be `Send + Sync + 'static` because accept loops run on
-/// a multi-threaded tokio runtime. For services that are `!Send` (e.g. those
-/// holding `tch-rs` tensors), use [`super::iroh_rpc::LocalServiceBridge`].
+/// Implementations are crate-owned so arbitrary raw-byte callbacks cannot
+/// become an application-facing network boundary. Services use
+/// [`super::iroh_rpc::LocalServiceBridge`], including `!Send` services.
 ///
 /// The `carrier` argument is the accept boundary's attestation of which
 /// carrier class the request arrived on (INV-2 receive side, #1042). It is a
 /// **required** parameter — a processor cannot be invoked without a carrier
 /// classification, so a forgotten context is a compile error, not a silent
-/// fail-open. Processors that verify envelopes (the [`dispatch`] pipeline)
-/// re-enforce the cleartext policy against it; the generic serve loop has
-/// already rejected cleartext on forbidding carriers before invoking the
-/// processor, so for most implementations it is defense-in-depth.
+/// fail-open. On an untrusted carrier, the serve loop invokes only the
+/// crate-owned canonical [`dispatch`] processor.
 ///
 /// [`dispatch`]: crate::service::dispatch::process_request
 ///
 /// (Name retained from the iroh-only era to avoid churn in callers.)
-pub trait IrohRequestProcessor: Send + Sync + 'static {
+pub trait IrohRequestProcessor: sealed::Sealed + Send + Sync + 'static {
     fn process(
         &self,
         request: Bytes,
@@ -182,15 +187,19 @@ pub trait IrohRequestProcessor: Send + Sync + 'static {
 
 /// Convenience: build an [`IrohRequestProcessor`] from a `Send + Sync`
 /// async closure. Useful for tests.
-/// The closure is carrier-agnostic: the INV-2 cleartext rejection has already
-/// run in the serve loop before the processor is invoked, and test closures
-/// have no envelope policy of their own.
+/// The closure is carrier-agnostic and is therefore restricted to trusted
+/// inproc/UDS carriers. It cannot receive bytes from an untrusted carrier.
 pub fn from_fn<F, Fut>(f: F) -> impl IrohRequestProcessor
 where
     F: Fn(Bytes) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Result<Bytes>> + Send + 'static,
 {
     struct FnProcessor<F>(F);
+    impl<F> sealed::Sealed for FnProcessor<F> {
+        fn admits_untrusted_carrier(&self) -> bool {
+            false
+        }
+    }
     impl<F, Fut> IrohRequestProcessor for FnProcessor<F>
     where
         F: Fn(Bytes) -> Fut + Send + Sync + 'static,
@@ -281,10 +290,9 @@ pub async fn read_to_cap<R: RecvStream>(recv: &mut R, cap: usize) -> Result<Byte
 /// one per-stream permit per accepted bidi stream.
 ///
 /// `carrier` is the accept boundary's classification of this session's
-/// carrier (INV-2 receive side, #1042). On a carrier that forbids cleartext,
-/// every stream's request is probed for an encrypted envelope **before** the
-/// processor is invoked; a cleartext (or undecodable) request is answered
-/// with a signed error envelope and never reaches request processing.
+/// carrier (INV-2 receive side, #1042). Untrusted carriers may invoke only the
+/// crate-owned canonical envelope processor; raw closure processors are
+/// silently refused before their callback can observe request bytes.
 pub async fn serve_rpc_connection<S>(
     session: S,
     processor: Arc<dyn IrohRequestProcessor>,
@@ -339,8 +347,9 @@ where
     }
 }
 
-/// Handle one bidi stream end-to-end: read request, dispatch to processor,
-/// write response (or signed error envelope on processor failure).
+/// Handle one bidi stream end-to-end: read request, dispatch to the admitted
+/// processor, and write its response. Admission failures on untrusted carriers
+/// are silently dropped; trusted-local processor failures get a signed stub.
 async fn handle_stream<S>(
     mut send: S::SendStream,
     mut recv: S::RecvStream,
@@ -355,52 +364,50 @@ async fn handle_stream<S>(
     // we return, dropping `recv`/`send` (which resets the stream) and releasing
     // the semaphore permit held by the caller — so a stalled/trickling peer
     // cannot pin a server-wide permit indefinitely.
-    let request = match tokio::time::timeout(read_timeout, read_to_cap(&mut recv, MAX_FRAME_BYTES)).await {
-        Ok(Ok(buf)) => buf,
-        Ok(Err(e)) => {
-            tracing::warn!(error = ?e, "rpc-session: failed reading request");
-            return;
-        }
-        Err(_) => {
+    let request =
+        match tokio::time::timeout(read_timeout, read_to_cap(&mut recv, MAX_FRAME_BYTES)).await {
+            Ok(Ok(buf)) => buf,
+            Ok(Err(e)) => {
+                tracing::warn!(error = ?e, "rpc-session: failed reading request");
+                return;
+            }
+            Err(_) => {
+                tracing::warn!(
+                    timeout = ?read_timeout,
+                    "rpc-session: request read timed out, abandoning stream"
+                );
+                return;
+            }
+        };
+
+    // A raw/custom callback must never become the application boundary for a
+    // network carrier. Only the sealed canonical bridge is allowed to receive
+    // such bytes; it performs bounded parsing, authentication, replay checks,
+    // INV-2 enforcement, and KEM open before handler dispatch.
+    if carrier.forbids_cleartext_envelope() && !processor.admits_untrusted_carrier() {
+        tracing::warn!(
+            carrier = %carrier,
+            "rpc-session: refusing non-canonical raw processor on untrusted carrier"
+        );
+        return;
+    }
+
+    let response = match processor.process(request, carrier).await {
+        Ok(bytes) => bytes,
+        Err(e) if carrier.forbids_cleartext_envelope() => {
+            // Do not sign responses to input that failed canonical network
+            // admission: malformed, unauthenticated, replayed, cleartext, and
+            // undecryptable requests all reset/drop silently.
             tracing::warn!(
-                timeout = ?read_timeout,
-                "rpc-session: request read timed out, abandoning stream"
+                error = ?e,
+                carrier = %carrier,
+                "rpc-session: silently dropping request that failed canonical admission"
             );
             return;
         }
-    };
-
-    // INV-2 receive-side chokepoint (#1042): on a cleartext-forbidding
-    // carrier, probe the envelope mode before ANY request processing. A
-    // cleartext envelope is rejected even if it is validly signed by an
-    // authorized signer; undecodable bytes are treated exactly like cleartext
-    // (fail-closed). Only the message root and the `encryptedEnvelope` field
-    // length are read here — no signature, claims, or payload work happens
-    // for a rejected request.
-    let response = if carrier.forbids_cleartext_envelope()
-        && !crate::envelope::wire_signed_envelope_is_encrypted(&request).unwrap_or(false)
-    {
-        tracing::warn!(
-            carrier = %carrier,
-            "rpc-session: rejecting cleartext request envelope on untrusted carrier (INV-2 #1042)"
-        );
-        build_error_envelope(
-            &signing_key,
-            None,
-            &format!(
-                "cleartext request envelope rejected: carrier '{carrier}' forbids \
-                 cleartext (INV-2); seal the request to the server's #mesh-kem recipient"
-            ),
-        )
-    } else {
-        match processor.process(request, carrier).await {
-            Ok(bytes) => bytes,
-            Err(e) => {
-                tracing::warn!(error = ?e, "rpc-session: processor error, sending stub error envelope");
-                // No PQ key flows through the generic processor path; the error
-                // envelope is Classical (a Classical client verifies it via EdDSA).
-                build_error_envelope(&signing_key, None, &format!("processor error: {e}"))
-            }
+        Err(e) => {
+            tracing::warn!(error = ?e, "rpc-session: trusted-carrier processor error, sending stub error envelope");
+            build_error_envelope(&signing_key, None, &format!("processor error: {e}"))
         }
     };
 

--- a/crates/hyprstream-rpc/src/transport/rpc_session.rs
+++ b/crates/hyprstream-rpc/src/transport/rpc_session.rs
@@ -36,6 +36,7 @@ use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 use web_transport_trait::{RecvStream, SendStream, Session};
 
+use crate::transport::carrier::CarrierContext;
 use crate::transport_traits::{PublishSink, Transport};
 
 /// Hard cap on per-frame size (request or response) for the RPC control plane.
@@ -159,16 +160,31 @@ impl Default for RpcConfig {
 /// a multi-threaded tokio runtime. For services that are `!Send` (e.g. those
 /// holding `tch-rs` tensors), use [`super::iroh_rpc::LocalServiceBridge`].
 ///
+/// The `carrier` argument is the accept boundary's attestation of which
+/// carrier class the request arrived on (INV-2 receive side, #1042). It is a
+/// **required** parameter — a processor cannot be invoked without a carrier
+/// classification, so a forgotten context is a compile error, not a silent
+/// fail-open. Processors that verify envelopes (the [`dispatch`] pipeline)
+/// re-enforce the cleartext policy against it; the generic serve loop has
+/// already rejected cleartext on forbidding carriers before invoking the
+/// processor, so for most implementations it is defense-in-depth.
+///
+/// [`dispatch`]: crate::service::dispatch::process_request
+///
 /// (Name retained from the iroh-only era to avoid churn in callers.)
 pub trait IrohRequestProcessor: Send + Sync + 'static {
     fn process(
         &self,
         request: Bytes,
+        carrier: CarrierContext,
     ) -> std::pin::Pin<Box<dyn Future<Output = Result<Bytes>> + Send + '_>>;
 }
 
 /// Convenience: build an [`IrohRequestProcessor`] from a `Send + Sync`
 /// async closure. Useful for tests.
+/// The closure is carrier-agnostic: the INV-2 cleartext rejection has already
+/// run in the serve loop before the processor is invoked, and test closures
+/// have no envelope policy of their own.
 pub fn from_fn<F, Fut>(f: F) -> impl IrohRequestProcessor
 where
     F: Fn(Bytes) -> Fut + Send + Sync + 'static,
@@ -183,6 +199,7 @@ where
         fn process(
             &self,
             request: Bytes,
+            _carrier: CarrierContext,
         ) -> std::pin::Pin<Box<dyn Future<Output = Result<Bytes>> + Send + '_>> {
             Box::pin((self.0)(request))
         }
@@ -262,6 +279,12 @@ pub async fn read_to_cap<R: RecvStream>(recv: &mut R, cap: usize) -> Result<Byte
 /// shutdown, cancels `shutdown` then `acquire_many(capacity)`s every permit so
 /// detached `handle_stream` tasks finish before teardown. This fn only acquires
 /// one per-stream permit per accepted bidi stream.
+///
+/// `carrier` is the accept boundary's classification of this session's
+/// carrier (INV-2 receive side, #1042). On a carrier that forbids cleartext,
+/// every stream's request is probed for an encrypted envelope **before** the
+/// processor is invoked; a cleartext (or undecodable) request is answered
+/// with a signed error envelope and never reaches request processing.
 pub async fn serve_rpc_connection<S>(
     session: S,
     processor: Arc<dyn IrohRequestProcessor>,
@@ -269,6 +292,7 @@ pub async fn serve_rpc_connection<S>(
     stream_limit: Arc<Semaphore>,
     read_timeout: Duration,
     shutdown: CancellationToken,
+    carrier: CarrierContext,
 ) -> Result<()>
 where
     S: Session,
@@ -307,7 +331,8 @@ where
                 tokio::spawn(async move {
                     let _permit = permit; // released on task end
                     let _keepalive = session_keepalive;
-                    handle_stream::<S>(send, recv, processor, signing_key, read_timeout).await;
+                    handle_stream::<S>(send, recv, processor, signing_key, read_timeout, carrier)
+                        .await;
                 });
             }
         }
@@ -322,6 +347,7 @@ async fn handle_stream<S>(
     processor: Arc<dyn IrohRequestProcessor>,
     signing_key: SigningKey,
     read_timeout: Duration,
+    carrier: CarrierContext,
 ) where
     S: Session,
 {
@@ -344,13 +370,37 @@ async fn handle_stream<S>(
         }
     };
 
-    let response = match processor.process(request).await {
-        Ok(bytes) => bytes,
-        Err(e) => {
-            tracing::warn!(error = ?e, "rpc-session: processor error, sending stub error envelope");
-            // No PQ key flows through the generic processor path; the error
-            // envelope is Classical (a Classical client verifies it via EdDSA).
-            build_error_envelope(&signing_key, None, &format!("processor error: {e}"))
+    // INV-2 receive-side chokepoint (#1042): on a cleartext-forbidding
+    // carrier, probe the envelope mode before ANY request processing. A
+    // cleartext envelope is rejected even if it is validly signed by an
+    // authorized signer; undecodable bytes are treated exactly like cleartext
+    // (fail-closed). Only the message root and the `encryptedEnvelope` field
+    // length are read here — no signature, claims, or payload work happens
+    // for a rejected request.
+    let response = if carrier.forbids_cleartext_envelope()
+        && !crate::envelope::wire_signed_envelope_is_encrypted(&request).unwrap_or(false)
+    {
+        tracing::warn!(
+            carrier = %carrier,
+            "rpc-session: rejecting cleartext request envelope on untrusted carrier (INV-2 #1042)"
+        );
+        build_error_envelope(
+            &signing_key,
+            None,
+            &format!(
+                "cleartext request envelope rejected: carrier '{carrier}' forbids \
+                 cleartext (INV-2); seal the request to the server's #mesh-kem recipient"
+            ),
+        )
+    } else {
+        match processor.process(request, carrier).await {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                tracing::warn!(error = ?e, "rpc-session: processor error, sending stub error envelope");
+                // No PQ key flows through the generic processor path; the error
+                // envelope is Classical (a Classical client verifies it via EdDSA).
+                build_error_envelope(&signing_key, None, &format!("processor error: {e}"))
+            }
         }
     };
 

--- a/crates/hyprstream-rpc/src/transport/uds_server.rs
+++ b/crates/hyprstream-rpc/src/transport/uds_server.rs
@@ -229,8 +229,12 @@ impl UdsRpcServer {
 
                         match plane {
                             PLANE_RPC => {
+                                // INV-2 (#1042): this accept boundary terminates a
+                                // same-host UDS connection (incl. systemd socket
+                                // activation) — the explicitly trusted local class.
                                 if let Err(e) = serve_rpc_connection(
                                     session, processor, signing_key, stream_limit, read_timeout, shutdown,
+                                    crate::transport::carrier::CarrierContext::trusted_uds(),
                                 )
                                 .await
                                 {

--- a/crates/hyprstream-rpc/src/transport/uds_session.rs
+++ b/crates/hyprstream-rpc/src/transport/uds_session.rs
@@ -684,6 +684,7 @@ mod tests {
             limit,
             REQUEST_READ_TIMEOUT,
             shutdown.clone(),
+            crate::transport::carrier::CarrierContext::explicit_trusted_local(),
         ));
 
         // Two sequential calls prove the session multiplexes fresh bidi streams.

--- a/crates/hyprstream-rpc/src/transport/uds_session.rs
+++ b/crates/hyprstream-rpc/src/transport/uds_session.rs
@@ -263,7 +263,9 @@ async fn classify_inbound(
     match tag[0] {
         TAG_BIDI => {
             let (rh, wh) = stream.split();
-            let _ = bi_tx.send((UdsSendStream::new(wh), UdsRecvStream::new(rh))).await;
+            let _ = bi_tx
+                .send((UdsSendStream::new(wh), UdsRecvStream::new(rh)))
+                .await;
         }
         TAG_UNI => {
             let (rh, _wh) = stream.split();
@@ -427,7 +429,9 @@ impl UdsSession {
             .send(DriverCmd::OpenOutbound(tx))
             .await
             .map_err(|_| UdsError::closed())?;
-        rx.await.map_err(|_| UdsError::closed())?.map_err(UdsError::conn)
+        rx.await
+            .map_err(|_| UdsError::closed())?
+            .map_err(UdsError::conn)
     }
 }
 
@@ -527,7 +531,10 @@ pub async fn accept_uds(mut stream: tokio::net::UnixStream) -> Result<(u8, UdsSe
     if !matches!(plane[0], PLANE_RPC | PLANE_MOQ) {
         anyhow::bail!("uds: unknown plane selector byte 0x{:02x}", plane[0]);
     }
-    Ok((plane[0], UdsSession::spawn(stream.compat(), yamux::Mode::Server)))
+    Ok((
+        plane[0],
+        UdsSession::spawn(stream.compat(), yamux::Mode::Server),
+    ))
 }
 
 // Compile-time assertion that our types satisfy the native `MaybeSend` bound
@@ -684,7 +691,7 @@ mod tests {
             limit,
             REQUEST_READ_TIMEOUT,
             shutdown.clone(),
-            crate::transport::carrier::CarrierContext::explicit_trusted_local(),
+            crate::transport::carrier::CarrierContext::trusted_uds(),
         ));
 
         // Two sequential calls prove the session multiplexes fresh bidi streams.
@@ -714,7 +721,9 @@ mod tests {
         let mut broadcast = producer.create_broadcast("alice/run-1").unwrap();
         let mut track = broadcast.create_track(Track::new("tokens")).unwrap();
         let mut group = track.create_group(Group::from(0u64)).unwrap();
-        group.write_frame(Bytes::from_static(b"hello-uds-moq")).unwrap();
+        group
+            .write_frame(Bytes::from_static(b"hello-uds-moq"))
+            .unwrap();
         drop(group);
 
         // The moq handshake is bidirectional (client opens the SETUP stream, the
@@ -728,10 +737,11 @@ mod tests {
         let client_origin = Origin::random().produce();
         let client_consumer = client_origin.consume();
         let moq_client = Client::new().with_consume(client_origin);
-        let _moq_session = tokio::time::timeout(Duration::from_secs(8), moq_client.connect(client_session))
-            .await
-            .expect("client.connect hung")
-            .unwrap();
+        let _moq_session =
+            tokio::time::timeout(Duration::from_secs(8), moq_client.connect(client_session))
+                .await
+                .expect("client.connect hung")
+                .unwrap();
         let _moq_server = tokio::time::timeout(Duration::from_secs(8), server_task)
             .await
             .expect("server.accept hung")
@@ -803,7 +813,9 @@ mod tests {
         // Client writes a bogus plane selector.
         let cli = tokio::spawn(async move {
             let mut a = a;
-            tokio::io::AsyncWriteExt::write_all(&mut a, &[0xFF]).await.unwrap();
+            tokio::io::AsyncWriteExt::write_all(&mut a, &[0xFF])
+                .await
+                .unwrap();
             // Hold the socket open so the server's read sees the byte, not EOF.
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         });

--- a/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
+++ b/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
@@ -529,12 +529,15 @@ impl QuicRep {
         // just don't pin it to the server's own key. JWT claims + Casbin handle
         // authorization.
         // subsecond::call wraps dispatch for hot-patching during dev
+        // INV-2 (#1042): this legacy ZMTP entry point terminates a QUIC
+        // stream — an untrusted carrier even on a loopback address.
         let response_bytes = subsecond::call(|| crate::service::dispatch::process_request(
             raw_bytes,
             &*service,
             EnvelopeVerification::AnySigner,
             &signing_key,
             &nonce_cache,
+            crate::transport::carrier::CarrierContext::quic(),
         )).await?;
 
         // Send response

--- a/crates/hyprstream-rpc/tests/inv2_receive_dispatch.rs
+++ b/crates/hyprstream-rpc/tests/inv2_receive_dispatch.rs
@@ -3,13 +3,14 @@
 //! Proves `service::dispatch::process_request` — the shared envelope-verify →
 //! claims → handler pipeline — refuses a cleartext request envelope on an
 //! untrusted carrier **before** the application handler runs, while an
-//! encrypted (`#mesh-kem`) request on the same carrier and a cleartext request
-//! on an explicitly trusted local carrier both dispatch normally.
+//! encrypted (`#mesh-kem`) request on the same carrier dispatches normally.
+//! Trusted-local cleartext is covered through the actual inproc/UDS transport
+//! tests because trusted contexts are intentionally not publicly mintable.
 //!
 //! The carrier context is a required parameter supplied by the accept
 //! boundary; nothing inside the request bytes participates in the decision,
-//! which these tests demonstrate by sending byte-identical envelopes under
-//! different carrier classifications.
+//! which these tests demonstrate across all publicly constructible untrusted
+//! carrier classifications.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -60,7 +61,11 @@ fn keys() -> &'static Keys {
             pq_store: Some(Arc::new(store)),
         });
 
-        Keys { client_sk, client_pq, server_sk }
+        Keys {
+            client_sk,
+            client_pq,
+            server_sk,
+        }
     })
 }
 
@@ -163,20 +168,19 @@ async fn cleartext_on_untrusted_carrier_rejected_before_handler() {
     let (service, invoked) = SentinelService::new(k.server_sk.clone());
     let nonce_cache = envelope::InMemoryNonceCache::new();
 
-    let signed = SignedEnvelope::new_signed_hybrid(
-        request_envelope(b"sensitive-cleartext"),
-        &k.client_sk,
-        &k.client_pq,
-    );
-    let wire = to_wire(&signed);
-
     for carrier in [
         CarrierContext::iroh(),
         CarrierContext::quic(),
         CarrierContext::web_transport(),
         CarrierContext::untrusted_unknown(),
     ] {
-        let response_bytes = process_request(
+        let signed = SignedEnvelope::new_signed_hybrid(
+            request_envelope(b"sensitive-cleartext"),
+            &k.client_sk,
+            &k.client_pq,
+        );
+        let wire = to_wire(&signed);
+        let result = process_request(
             &wire,
             &service,
             EnvelopeVerification::AnySigner,
@@ -184,53 +188,14 @@ async fn cleartext_on_untrusted_carrier_rejected_before_handler() {
             &nonce_cache,
             carrier,
         )
-        .await
-        .expect("rejection is a signed error response, not a wire error");
+        .await;
 
-        let response = decode_response(&response_bytes);
-        assert_eq!(response.request_id, 0, "rejected before envelope processing");
-        let text = String::from_utf8_lossy(&response.payload);
-        assert!(
-            text.contains("cleartext"),
-            "error must state the cleartext rejection, got: {text}"
-        );
+        assert!(result.is_err(), "cleartext must be silently rejected");
         assert!(
             !invoked.load(Ordering::SeqCst),
             "handler must never run for cleartext on carrier '{carrier}'"
         );
     }
-}
-
-/// The same bytes that every untrusted carrier rejects dispatch normally on
-/// an explicitly trusted local carrier — proving the decision comes from the
-/// accept boundary's context, not from anything in the request.
-#[tokio::test]
-async fn cleartext_on_trusted_local_carrier_dispatches() {
-    let k = keys();
-    let (service, invoked) = SentinelService::new(k.server_sk.clone());
-    let nonce_cache = envelope::InMemoryNonceCache::new();
-
-    let signed = SignedEnvelope::new_signed_hybrid(
-        request_envelope(b"local-cleartext"),
-        &k.client_sk,
-        &k.client_pq,
-    );
-
-    let response_bytes = process_request(
-        &to_wire(&signed),
-        &service,
-        EnvelopeVerification::AnySigner,
-        &k.server_sk,
-        &nonce_cache,
-        CarrierContext::explicit_trusted_local(),
-    )
-    .await
-    .unwrap();
-
-    let response = decode_response(&response_bytes);
-    assert!(invoked.load(Ordering::SeqCst), "trusted-local cleartext must dispatch");
-    assert_eq!(response.request_id, 7);
-    assert_eq!(response.payload, b"local-cleartext");
 }
 
 /// An encrypted (`#mesh-kem`) hybrid-signed request on an untrusted carrier
@@ -263,7 +228,10 @@ async fn encrypted_on_untrusted_carrier_dispatches() {
     .unwrap();
 
     let response = decode_response(&response_bytes);
-    assert!(invoked.load(Ordering::SeqCst), "encrypted request must dispatch");
+    assert!(
+        invoked.load(Ordering::SeqCst),
+        "encrypted request must dispatch"
+    );
     assert_eq!(response.request_id, 7);
     assert_eq!(response.payload, b"sealed-payload");
 }
@@ -276,7 +244,7 @@ async fn garbage_on_untrusted_carrier_rejected_before_handler() {
     let (service, invoked) = SentinelService::new(k.server_sk.clone());
     let nonce_cache = envelope::InMemoryNonceCache::new();
 
-    let response_bytes = process_request(
+    let result = process_request(
         b"not-a-capnp-message",
         &service,
         EnvelopeVerification::AnySigner,
@@ -284,10 +252,14 @@ async fn garbage_on_untrusted_carrier_rejected_before_handler() {
         &nonce_cache,
         CarrierContext::iroh(),
     )
-    .await
-    .unwrap();
+    .await;
 
-    let response = decode_response(&response_bytes);
-    assert_eq!(response.request_id, 0);
-    assert!(!invoked.load(Ordering::SeqCst), "garbage must never dispatch");
+    assert!(
+        result.is_err(),
+        "garbage must be dropped without a signed response"
+    );
+    assert!(
+        !invoked.load(Ordering::SeqCst),
+        "garbage must never dispatch"
+    );
 }

--- a/crates/hyprstream-rpc/tests/inv2_receive_dispatch.rs
+++ b/crates/hyprstream-rpc/tests/inv2_receive_dispatch.rs
@@ -1,0 +1,293 @@
+//! INV-2 receive-side dispatch enforcement (#1042).
+//!
+//! Proves `service::dispatch::process_request` — the shared envelope-verify →
+//! claims → handler pipeline — refuses a cleartext request envelope on an
+//! untrusted carrier **before** the application handler runs, while an
+//! encrypted (`#mesh-kem`) request on the same carrier and a cleartext request
+//! on an explicitly trusted local carrier both dispatch normally.
+//!
+//! The carrier context is a required parameter supplied by the accept
+//! boundary; nothing inside the request bytes participates in the decision,
+//! which these tests demonstrate by sending byte-identical envelopes under
+//! different carrier classifications.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, OnceLock};
+
+use anyhow::Result;
+use async_trait::async_trait;
+use ed25519_dalek::SigningKey;
+
+use hyprstream_rpc::crypto::pq::MlDsaSigningKey;
+use hyprstream_rpc::crypto::signing::generate_signing_keypair;
+use hyprstream_rpc::envelope::{
+    self, Authorization, EnvelopeVerification, RequestEnvelope, ResponseEnvelope, SignedEnvelope,
+};
+use hyprstream_rpc::node_identity::{derive_mesh_kem_recipient, derive_mesh_mldsa_key};
+use hyprstream_rpc::service::dispatch::process_request;
+use hyprstream_rpc::service::{Continuation, EnvelopeContext, RequestService};
+use hyprstream_rpc::transport::carrier::CarrierContext;
+use hyprstream_rpc::transport::TransportConfig;
+use hyprstream_rpc::{FromCapnp, ToCapnp};
+
+/// Process-wide fixed keys so every test in this binary shares one global
+/// verify config / PQ trust store (installation is first-wins).
+struct Keys {
+    client_sk: SigningKey,
+    client_pq: MlDsaSigningKey,
+    server_sk: SigningKey,
+}
+
+fn keys() -> &'static Keys {
+    static KEYS: OnceLock<Keys> = OnceLock::new();
+    KEYS.get_or_init(|| {
+        let (client_sk, client_vk) = generate_signing_keypair();
+        let (server_sk, _server_vk) = generate_signing_keypair();
+        let client_pq = derive_mesh_mldsa_key(&client_sk);
+
+        // Hybrid verify config anchoring the client's ML-DSA key by its
+        // Ed25519 kid — same shape the daemon installs at startup.
+        let client_pq_vk = hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(
+            &hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(&client_pq),
+        )
+        .unwrap();
+        let mut store = hyprstream_rpc::envelope::KeyedPqTrustStore::new();
+        store.bind(client_vk.to_bytes(), &client_pq_vk);
+        let _ = envelope::install_verify_config(envelope::EnvelopeVerifyConfig {
+            policy: hyprstream_rpc::crypto::CryptoPolicy::Hybrid,
+            pq_store: Some(Arc::new(store)),
+        });
+
+        Keys { client_sk, client_pq, server_sk }
+    })
+}
+
+/// Minimal service whose only job is to record whether the application
+/// handler was ever reached.
+struct SentinelService {
+    transport: TransportConfig,
+    signing_key: SigningKey,
+    invoked: Arc<AtomicBool>,
+}
+
+impl SentinelService {
+    fn new(signing_key: SigningKey) -> (Self, Arc<AtomicBool>) {
+        let invoked = Arc::new(AtomicBool::new(false));
+        (
+            Self {
+                transport: TransportConfig::inproc("inv2-sentinel"),
+                signing_key,
+                invoked: Arc::clone(&invoked),
+            },
+            invoked,
+        )
+    }
+}
+
+#[async_trait(?Send)]
+impl RequestService for SentinelService {
+    async fn handle_request(
+        &self,
+        _ctx: &EnvelopeContext,
+        payload: &[u8],
+    ) -> Result<(Vec<u8>, Option<Continuation>)> {
+        self.invoked.store(true, Ordering::SeqCst);
+        Ok((payload.to_vec(), None))
+    }
+
+    fn name(&self) -> &str {
+        "inv2-sentinel"
+    }
+
+    fn transport(&self) -> &TransportConfig {
+        &self.transport
+    }
+
+    fn signing_key(&self) -> SigningKey {
+        self.signing_key.clone()
+    }
+
+    /// Surface the raw error text (the default returns an empty vec) so the
+    /// test can assert *which* rejection path produced the response.
+    fn build_error_payload(&self, _request_id: u64, error: &str) -> Vec<u8> {
+        error.as_bytes().to_vec()
+    }
+}
+
+fn request_envelope(payload: &[u8]) -> RequestEnvelope {
+    RequestEnvelope {
+        request_id: 7,
+        payload: payload.to_vec(),
+        iat: envelope::current_timestamp(),
+        nonce: envelope::generate_nonce(),
+        authorization: Authorization::None,
+        delegation_token: None,
+        wth: None,
+        client_dh_public: None,
+    }
+}
+
+fn to_wire(signed: &SignedEnvelope) -> Vec<u8> {
+    let mut message = capnp::message::Builder::new_default();
+    {
+        let mut builder =
+            message.init_root::<hyprstream_rpc::common_capnp::signed_envelope::Builder>();
+        signed.write_to(&mut builder);
+    }
+    let mut bytes = Vec::new();
+    capnp::serialize::write_message(&mut bytes, &message).unwrap();
+    bytes
+}
+
+fn decode_response(bytes: &[u8]) -> ResponseEnvelope {
+    let reader = capnp::serialize::read_message(
+        &mut std::io::Cursor::new(bytes),
+        capnp::message::ReaderOptions::new(),
+    )
+    .unwrap();
+    let rr = reader
+        .get_root::<hyprstream_rpc::common_capnp::response_envelope::Reader>()
+        .unwrap();
+    ResponseEnvelope::read_from(rr).unwrap()
+}
+
+/// A validly hybrid-signed **cleartext** envelope from an authorized signer is
+/// rejected on an untrusted carrier before the handler runs. The signature
+/// being good is exactly the point: INV-2 is a carrier policy, not a
+/// signature check.
+#[tokio::test]
+async fn cleartext_on_untrusted_carrier_rejected_before_handler() {
+    let k = keys();
+    let (service, invoked) = SentinelService::new(k.server_sk.clone());
+    let nonce_cache = envelope::InMemoryNonceCache::new();
+
+    let signed = SignedEnvelope::new_signed_hybrid(
+        request_envelope(b"sensitive-cleartext"),
+        &k.client_sk,
+        &k.client_pq,
+    );
+    let wire = to_wire(&signed);
+
+    for carrier in [
+        CarrierContext::iroh(),
+        CarrierContext::quic(),
+        CarrierContext::web_transport(),
+        CarrierContext::untrusted_unknown(),
+    ] {
+        let response_bytes = process_request(
+            &wire,
+            &service,
+            EnvelopeVerification::AnySigner,
+            &k.server_sk,
+            &nonce_cache,
+            carrier,
+        )
+        .await
+        .expect("rejection is a signed error response, not a wire error");
+
+        let response = decode_response(&response_bytes);
+        assert_eq!(response.request_id, 0, "rejected before envelope processing");
+        let text = String::from_utf8_lossy(&response.payload);
+        assert!(
+            text.contains("cleartext"),
+            "error must state the cleartext rejection, got: {text}"
+        );
+        assert!(
+            !invoked.load(Ordering::SeqCst),
+            "handler must never run for cleartext on carrier '{carrier}'"
+        );
+    }
+}
+
+/// The same bytes that every untrusted carrier rejects dispatch normally on
+/// an explicitly trusted local carrier — proving the decision comes from the
+/// accept boundary's context, not from anything in the request.
+#[tokio::test]
+async fn cleartext_on_trusted_local_carrier_dispatches() {
+    let k = keys();
+    let (service, invoked) = SentinelService::new(k.server_sk.clone());
+    let nonce_cache = envelope::InMemoryNonceCache::new();
+
+    let signed = SignedEnvelope::new_signed_hybrid(
+        request_envelope(b"local-cleartext"),
+        &k.client_sk,
+        &k.client_pq,
+    );
+
+    let response_bytes = process_request(
+        &to_wire(&signed),
+        &service,
+        EnvelopeVerification::AnySigner,
+        &k.server_sk,
+        &nonce_cache,
+        CarrierContext::explicit_trusted_local(),
+    )
+    .await
+    .unwrap();
+
+    let response = decode_response(&response_bytes);
+    assert!(invoked.load(Ordering::SeqCst), "trusted-local cleartext must dispatch");
+    assert_eq!(response.request_id, 7);
+    assert_eq!(response.payload, b"local-cleartext");
+}
+
+/// An encrypted (`#mesh-kem`) hybrid-signed request on an untrusted carrier
+/// passes the INV-2 gate and reaches the handler — the ban is on cleartext,
+/// not on the carrier.
+#[tokio::test]
+async fn encrypted_on_untrusted_carrier_dispatches() {
+    let k = keys();
+    let (service, invoked) = SentinelService::new(k.server_sk.clone());
+    let nonce_cache = envelope::InMemoryNonceCache::new();
+
+    let recipient = derive_mesh_kem_recipient(&k.server_sk).unwrap();
+    let signed = SignedEnvelope::new_signed_encrypted_mesh_kem(
+        request_envelope(b"sealed-payload"),
+        &k.client_sk,
+        &k.client_pq,
+        &recipient.public(),
+    )
+    .unwrap();
+
+    let response_bytes = process_request(
+        &to_wire(&signed),
+        &service,
+        EnvelopeVerification::AnySigner,
+        &k.server_sk,
+        &nonce_cache,
+        CarrierContext::iroh(),
+    )
+    .await
+    .unwrap();
+
+    let response = decode_response(&response_bytes);
+    assert!(invoked.load(Ordering::SeqCst), "encrypted request must dispatch");
+    assert_eq!(response.request_id, 7);
+    assert_eq!(response.payload, b"sealed-payload");
+}
+
+/// Undecodable bytes on an untrusted carrier follow the cleartext branch
+/// (fail-closed) and never reach the handler.
+#[tokio::test]
+async fn garbage_on_untrusted_carrier_rejected_before_handler() {
+    let k = keys();
+    let (service, invoked) = SentinelService::new(k.server_sk.clone());
+    let nonce_cache = envelope::InMemoryNonceCache::new();
+
+    let response_bytes = process_request(
+        b"not-a-capnp-message",
+        &service,
+        EnvelopeVerification::AnySigner,
+        &k.server_sk,
+        &nonce_cache,
+        CarrierContext::iroh(),
+    )
+    .await
+    .unwrap();
+
+    let response = decode_response(&response_bytes);
+    assert_eq!(response.request_id, 0);
+    assert!(!invoked.load(Ordering::SeqCst), "garbage must never dispatch");
+}

--- a/crates/hyprstream-rpc/tests/iroh_rpc_e2e.rs
+++ b/crates/hyprstream-rpc/tests/iroh_rpc_e2e.rs
@@ -16,8 +16,10 @@
 //! suite over iroh) requires `services/factories.rs` wiring — tracked as
 //! Phase 2 part 3 of #133.
 
+use std::future::Future;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -122,10 +124,51 @@ fn direct_addr(substrate: &IrohSubstrate) -> EndpointAddr {
     )
 }
 
-fn assert_silent_drop(result: Result<Vec<u8>>, message: &str) {
-    if let Ok(bytes) = result {
-        assert!(bytes.is_empty(), "{message}: unexpected response bytes");
+const SILENT_DROP_DEADLINE: Duration = Duration::from_secs(1);
+
+/// Assert that a network admission drop completes promptly with an empty FIN.
+///
+/// Real iroh reproduction of every intended drop in this suite yields
+/// `Ok(empty)`. No reset/closed error is allowlisted because none is produced
+/// by this path. In particular, the transport's own timeout and every unrelated
+/// error are failures rather than alternate evidence of a silent drop.
+async fn assert_silent_drop<F>(operation: F, message: &str)
+where
+    F: Future<Output = Result<Vec<u8>>>,
+{
+    match tokio::time::timeout(SILENT_DROP_DEADLINE, operation).await {
+        Err(_) => panic!(
+            "{message}: outer deadline elapsed after {SILENT_DROP_DEADLINE:?}; \
+             timeout is not evidence of peer close"
+        ),
+        Ok(Ok(bytes)) => assert!(
+            bytes.is_empty(),
+            "{message}: unexpected response bytes: {}",
+            bytes.len()
+        ),
+        Ok(Err(error)) => panic!(
+            "{message}: unexpected transport error (only prompt Ok(empty) is accepted): {error:#}"
+        ),
     }
+}
+
+#[tokio::test]
+async fn silent_drop_oracle_rejects_nonresponsive_peer_control() {
+    let started = Instant::now();
+    let assertion = tokio::spawn(assert_silent_drop(
+        std::future::pending::<Result<Vec<u8>>>(),
+        "nonresponsive peer control",
+    ));
+
+    match tokio::time::timeout(SILENT_DROP_DEADLINE * 2, assertion).await {
+        Err(_) => panic!("oracle control itself hung"),
+        Ok(Ok(())) => panic!("a nonresponsive peer passed the silent-drop assertion"),
+        Ok(Err(join_error)) => assert!(join_error.is_panic()),
+    }
+    assert!(
+        started.elapsed() < SILENT_DROP_DEADLINE * 2,
+        "timeout control must fail promptly"
+    );
 }
 
 struct RecordingTransport<T> {
@@ -365,8 +408,11 @@ async fn cleartext_envelope_rejected_on_iroh_receive() -> Result<()> {
 
     // Raw send bypasses RpcClientImpl's send-side guard — this exercises the
     // *receive* side directly, the scenario a hostile/downgrading peer creates.
-    let result = transport.send(wire, Some(8_000)).await;
-    assert_silent_drop(result, "cleartext must be reset/dropped without a response");
+    assert_silent_drop(
+        transport.send(wire, Some(8_000)),
+        "cleartext must be reset/dropped without a response",
+    )
+    .await;
     assert_eq!(
         invocations.load(Ordering::SeqCst),
         0,
@@ -445,8 +491,11 @@ async fn false_encrypted_marker_never_reaches_custom_processor_over_iroh() -> Re
         "adversarial frame must actually contain the clear outer payload"
     );
 
-    let result = transport.send(wire, Some(5_000)).await;
-    assert_silent_drop(result, "false marker must be silently reset/dropped");
+    assert_silent_drop(
+        transport.send(wire, Some(5_000)),
+        "false marker must be silently reset/dropped",
+    )
+    .await;
     assert_eq!(invocations.load(Ordering::SeqCst), 0);
 
     client.shutdown().await?;
@@ -483,10 +532,11 @@ async fn repeated_garbage_is_silently_dropped_without_handler_work() -> Result<(
     let transport = IrohTransport::new(conn);
 
     for _ in 0..3 {
-        let result = transport
-            .send(b"not-a-capnp-message".to_vec(), Some(5_000))
-            .await;
-        assert_silent_drop(result, "garbage must not receive a signed response");
+        assert_silent_drop(
+            transport.send(b"not-a-capnp-message".to_vec(), Some(5_000)),
+            "garbage must not receive a signed response",
+        )
+        .await;
     }
     assert_eq!(invocations.load(Ordering::SeqCst), 0);
 

--- a/crates/hyprstream-rpc/tests/iroh_rpc_e2e.rs
+++ b/crates/hyprstream-rpc/tests/iroh_rpc_e2e.rs
@@ -16,7 +16,8 @@
 //! suite over iroh) requires `services/factories.rs` wiring — tracked as
 //! Phase 2 part 3 of #133.
 
-use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, OnceLock};
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -24,7 +25,6 @@ use ed25519_dalek::{SigningKey, VerifyingKey};
 use tokio::sync::Mutex;
 
 use hyprstream_rpc::capnp::FromCapnp;
-use hyprstream_rpc::ToCapnp;
 use hyprstream_rpc::crypto::hybrid_kem::KeyedKemTrustStore;
 use hyprstream_rpc::envelope::{InMemoryNonceCache, KeyedPqTrustStore, SignedEnvelope};
 use hyprstream_rpc::node_identity::{derive_mesh_kem_recipient, derive_mesh_mldsa_key};
@@ -36,6 +36,7 @@ use hyprstream_rpc::transport::iroh_substrate::{IrohSubstrate, NoopHandler, ALPN
 use hyprstream_rpc::transport::iroh_transport::IrohTransport;
 use hyprstream_rpc::transport::TransportConfig;
 use hyprstream_rpc::transport_traits::Transport;
+use hyprstream_rpc::ToCapnp;
 use iroh::{EndpointAddr, TransportAddr};
 use rand::RngCore;
 
@@ -45,6 +46,7 @@ struct EchoService {
     name: String,
     transport: TransportConfig,
     signing_key: SigningKey,
+    invocations: Option<Arc<AtomicUsize>>,
 }
 
 impl EchoService {
@@ -53,7 +55,13 @@ impl EchoService {
             name: "iroh-echo".to_owned(),
             transport: TransportConfig::inproc("iroh-echo-unused"),
             signing_key,
+            invocations: None,
         }
+    }
+
+    fn with_invocations(mut self, invocations: Arc<AtomicUsize>) -> Self {
+        self.invocations = Some(invocations);
+        self
     }
 }
 
@@ -64,6 +72,9 @@ impl RequestService for EchoService {
         _ctx: &EnvelopeContext,
         payload: &[u8],
     ) -> Result<(Vec<u8>, Option<Continuation>)> {
+        if let Some(invocations) = &self.invocations {
+            invocations.fetch_add(1, Ordering::SeqCst);
+        }
         let mut out = Vec::with_capacity(1 + payload.len());
         out.push(0xEC);
         out.extend_from_slice(payload);
@@ -89,6 +100,11 @@ fn fresh_signing_key() -> SigningKey {
     SigningKey::from_bytes(&bytes)
 }
 
+fn request_client_signing_key() -> &'static SigningKey {
+    static KEY: OnceLock<SigningKey> = OnceLock::new();
+    KEY.get_or_init(fresh_signing_key)
+}
+
 fn fresh_node_key() -> [u8; 32] {
     let mut k = [0u8; 32];
     rand::thread_rng().fill_bytes(&mut k);
@@ -104,6 +120,12 @@ fn direct_addr(substrate: &IrohSubstrate) -> EndpointAddr {
             .into_iter()
             .map(TransportAddr::Ip),
     )
+}
+
+fn assert_silent_drop(result: Result<Vec<u8>>, message: &str) {
+    if let Ok(bytes) = result {
+        assert!(bytes.is_empty(), "{message}: unexpected response bytes");
+    }
 }
 
 struct RecordingTransport<T> {
@@ -174,7 +196,7 @@ async fn hykem_encrypted_envelope_round_trip_over_iroh() -> Result<()> {
     let server_addr = direct_addr(&server);
 
     // ─── Client side ──────────────────────────────────────────────────────
-    let client_signing = fresh_signing_key();
+    let client_signing = request_client_signing_key().clone();
     let client_verifying = client_signing.verifying_key();
     let client = IrohSubstrate::new(
         fresh_node_key(),
@@ -264,20 +286,20 @@ async fn hykem_encrypted_envelope_round_trip_over_iroh() -> Result<()> {
 
 /// INV-2 receive-side (#1042) over a real iroh carrier: a validly hybrid-signed
 /// **cleartext** envelope, sent raw over the wire (bypassing the client's
-/// send-side guard), is rejected by the server before the echo handler runs.
-/// The reply is a signed error envelope naming the cleartext rejection, and it
-/// never carries the echo handler's `0xEC` prefix.
+/// send-side guard), is authenticated/replay-checked and then silently dropped
+/// before the echo handler runs. No attacker-triggered signed error is emitted.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn cleartext_envelope_rejected_on_iroh_receive() -> Result<()> {
     use hyprstream_rpc::envelope::{
-        current_timestamp, generate_nonce, Authorization, RequestEnvelope, ResponseEnvelope,
+        current_timestamp, generate_nonce, Authorization, RequestEnvelope,
     };
 
     // ─── Server side ──────────────────────────────────────────────────────
     let server_signing = fresh_signing_key();
     let server_nonce_cache = Arc::new(InMemoryNonceCache::new());
+    let invocations = Arc::new(AtomicUsize::new(0));
     let bridge = LocalServiceBridge::spawn(
-        EchoService::new(server_signing.clone()),
+        EchoService::new(server_signing.clone()).with_invocations(Arc::clone(&invocations)),
         server_nonce_cache,
         0,
     )?;
@@ -290,7 +312,7 @@ async fn cleartext_envelope_rejected_on_iroh_receive() -> Result<()> {
     let server_addr = direct_addr(&server);
 
     // ─── Client side: send a CLEARTEXT signed envelope raw ────────────────
-    let client_signing = fresh_signing_key();
+    let client_signing = request_client_signing_key().clone();
     let client = IrohSubstrate::new(
         fresh_node_key(),
         NoopHandler::new("client-moq"),
@@ -336,31 +358,137 @@ async fn cleartext_envelope_rejected_on_iroh_receive() -> Result<()> {
         }
         capnp::serialize::write_message(&mut wire, &message)?;
     }
-    assert!(!signed.is_encrypted(), "test must send a cleartext envelope");
+    assert!(
+        !signed.is_encrypted(),
+        "test must send a cleartext envelope"
+    );
 
     // Raw send bypasses RpcClientImpl's send-side guard — this exercises the
     // *receive* side directly, the scenario a hostile/downgrading peer creates.
-    let response_bytes = transport.send(wire, Some(8_000)).await?;
+    let result = transport.send(wire, Some(8_000)).await;
+    assert_silent_drop(result, "cleartext must be reset/dropped without a response");
+    assert_eq!(
+        invocations.load(Ordering::SeqCst),
+        0,
+        "cleartext must never reach the application handler"
+    );
 
-    let reader = capnp::serialize::read_message(
-        &mut std::io::Cursor::new(&response_bytes),
-        capnp::message::ReaderOptions::new(),
-    )?;
-    let response = ResponseEnvelope::read_from(
-        reader.get_root::<hyprstream_rpc::common_capnp::response_envelope::Reader>()?,
-    )?;
+    client.shutdown().await?;
+    server.shutdown().await?;
+    Ok(())
+}
 
-    assert_eq!(response.request_id, 0, "rejected before request processing (id=0)");
-    let text = String::from_utf8_lossy(&response.payload);
+/// A non-empty `encryptedEnvelope` marker is not proof of encryption. Even
+/// when the same wire message contains a clear outer payload, the sealed raw
+/// processor extension point must be refused on a real iroh carrier.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn false_encrypted_marker_never_reaches_custom_processor_over_iroh() -> Result<()> {
+    use bytes::Bytes;
+    use hyprstream_rpc::envelope::{
+        current_timestamp, generate_nonce, Authorization, RequestEnvelope,
+    };
+
+    let invocations = Arc::new(AtomicUsize::new(0));
+    let invoked = Arc::clone(&invocations);
+    let processor = hyprstream_rpc::transport::rpc_session::from_fn(move |_request: Bytes| {
+        let invoked = Arc::clone(&invoked);
+        async move {
+            invoked.fetch_add(1, Ordering::SeqCst);
+            Ok(Bytes::from_static(b"must-not-run"))
+        }
+    });
+    let server = IrohSubstrate::new(
+        fresh_node_key(),
+        NoopHandler::new("moq-not-wired"),
+        IrohRpcProtocolHandler::new(processor, fresh_signing_key()),
+    )
+    .await?;
+    let client = IrohSubstrate::new(
+        fresh_node_key(),
+        NoopHandler::new("client-moq"),
+        NoopHandler::new("client-rpc"),
+    )
+    .await?;
+    let conn = client
+        .connect(direct_addr(&server), ALPN_HYPRSTREAM_RPC)
+        .await?;
+    let transport = IrohTransport::new(conn);
+
+    let signer = fresh_signing_key();
+    let signed = SignedEnvelope::new_signed(
+        RequestEnvelope {
+            request_id: 31337,
+            payload: b"visible-cleartext-sentinel".to_vec(),
+            iat: current_timestamp(),
+            nonce: generate_nonce(),
+            authorization: Authorization::None,
+            delegation_token: None,
+            wth: None,
+            client_dh_public: None,
+        },
+        &signer,
+    );
+    let mut wire = Vec::new();
+    {
+        let mut message = capnp::message::Builder::new_default();
+        {
+            let mut builder =
+                message.init_root::<hyprstream_rpc::common_capnp::signed_envelope::Builder>();
+            signed.write_to(&mut builder);
+            builder.set_encrypted_envelope(&[0xA5]);
+        }
+        capnp::serialize::write_message(&mut wire, &message)?;
+    }
     assert!(
-        text.contains("cleartext"),
-        "server must report the INV-2 cleartext rejection, got: {text}"
+        wire.windows(b"visible-cleartext-sentinel".len())
+            .any(|w| w == b"visible-cleartext-sentinel"),
+        "adversarial frame must actually contain the clear outer payload"
     );
-    assert_ne!(
-        response.payload.first().copied(),
-        Some(0xEC),
-        "echo handler must not have run — no 0xEC prefix"
-    );
+
+    let result = transport.send(wire, Some(5_000)).await;
+    assert_silent_drop(result, "false marker must be silently reset/dropped");
+    assert_eq!(invocations.load(Ordering::SeqCst), 0);
+
+    client.shutdown().await?;
+    server.shutdown().await?;
+    Ok(())
+}
+
+/// Repeated undecodable unauthenticated requests produce no signed response
+/// and never invoke the application handler.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn repeated_garbage_is_silently_dropped_without_handler_work() -> Result<()> {
+    let server_signing = fresh_signing_key();
+    let invocations = Arc::new(AtomicUsize::new(0));
+    let bridge = LocalServiceBridge::spawn(
+        EchoService::new(server_signing.clone()).with_invocations(Arc::clone(&invocations)),
+        Arc::new(InMemoryNonceCache::new()),
+        0,
+    )?;
+    let server = IrohSubstrate::new(
+        fresh_node_key(),
+        NoopHandler::new("moq-not-wired"),
+        IrohRpcProtocolHandler::new(bridge, server_signing),
+    )
+    .await?;
+    let client = IrohSubstrate::new(
+        fresh_node_key(),
+        NoopHandler::new("client-moq"),
+        NoopHandler::new("client-rpc"),
+    )
+    .await?;
+    let conn = client
+        .connect(direct_addr(&server), ALPN_HYPRSTREAM_RPC)
+        .await?;
+    let transport = IrohTransport::new(conn);
+
+    for _ in 0..3 {
+        let result = transport
+            .send(b"not-a-capnp-message".to_vec(), Some(5_000))
+            .await;
+        assert_silent_drop(result, "garbage must not receive a signed response");
+    }
+    assert_eq!(invocations.load(Ordering::SeqCst), 0);
 
     client.shutdown().await?;
     server.shutdown().await?;

--- a/crates/hyprstream-rpc/tests/iroh_rpc_e2e.rs
+++ b/crates/hyprstream-rpc/tests/iroh_rpc_e2e.rs
@@ -24,6 +24,7 @@ use ed25519_dalek::{SigningKey, VerifyingKey};
 use tokio::sync::Mutex;
 
 use hyprstream_rpc::capnp::FromCapnp;
+use hyprstream_rpc::ToCapnp;
 use hyprstream_rpc::crypto::hybrid_kem::KeyedKemTrustStore;
 use hyprstream_rpc::envelope::{InMemoryNonceCache, KeyedPqTrustStore, SignedEnvelope};
 use hyprstream_rpc::node_identity::{derive_mesh_kem_recipient, derive_mesh_mldsa_key};
@@ -255,6 +256,111 @@ async fn hykem_encrypted_envelope_round_trip_over_iroh() -> Result<()> {
     // Second call on the same connection to exercise multiple bidi streams.
     let response2 = rpc.call(b"second".to_vec()).await?;
     assert_eq!(&response2[..], b"\xECsecond");
+
+    client.shutdown().await?;
+    server.shutdown().await?;
+    Ok(())
+}
+
+/// INV-2 receive-side (#1042) over a real iroh carrier: a validly hybrid-signed
+/// **cleartext** envelope, sent raw over the wire (bypassing the client's
+/// send-side guard), is rejected by the server before the echo handler runs.
+/// The reply is a signed error envelope naming the cleartext rejection, and it
+/// never carries the echo handler's `0xEC` prefix.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cleartext_envelope_rejected_on_iroh_receive() -> Result<()> {
+    use hyprstream_rpc::envelope::{
+        current_timestamp, generate_nonce, Authorization, RequestEnvelope, ResponseEnvelope,
+    };
+
+    // ─── Server side ──────────────────────────────────────────────────────
+    let server_signing = fresh_signing_key();
+    let server_nonce_cache = Arc::new(InMemoryNonceCache::new());
+    let bridge = LocalServiceBridge::spawn(
+        EchoService::new(server_signing.clone()),
+        server_nonce_cache,
+        0,
+    )?;
+    let server = IrohSubstrate::new(
+        fresh_node_key(),
+        NoopHandler::new("moq-not-wired"),
+        IrohRpcProtocolHandler::new(bridge, server_signing.clone()),
+    )
+    .await?;
+    let server_addr = direct_addr(&server);
+
+    // ─── Client side: send a CLEARTEXT signed envelope raw ────────────────
+    let client_signing = fresh_signing_key();
+    let client = IrohSubstrate::new(
+        fresh_node_key(),
+        NoopHandler::new("client-moq"),
+        NoopHandler::new("client-rpc"),
+    )
+    .await?;
+    let conn = client.connect(server_addr, ALPN_HYPRSTREAM_RPC).await?;
+    let transport = IrohTransport::new(conn);
+
+    // Anchor the client's ML-DSA key so the envelope is a *validly* hybrid-signed
+    // cleartext one — the rejection must be about the carrier, not the signature.
+    let client_pq_sk = derive_mesh_mldsa_key(&client_signing);
+    let client_pq_vk = hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(
+        &hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(&client_pq_sk),
+    )?;
+    let mut request_pq_store = KeyedPqTrustStore::new();
+    request_pq_store.bind(client_signing.verifying_key().to_bytes(), &client_pq_vk);
+    let _ = hyprstream_rpc::envelope::install_verify_config(
+        hyprstream_rpc::envelope::EnvelopeVerifyConfig {
+            policy: hyprstream_rpc::crypto::CryptoPolicy::Hybrid,
+            pq_store: Some(Arc::new(request_pq_store)),
+        },
+    );
+
+    let envelope = RequestEnvelope {
+        request_id: 99,
+        payload: b"ping-payload".to_vec(),
+        iat: current_timestamp(),
+        nonce: generate_nonce(),
+        authorization: Authorization::None,
+        delegation_token: None,
+        wth: None,
+        client_dh_public: None,
+    };
+    let signed = SignedEnvelope::new_signed_hybrid(envelope, &client_signing, &client_pq_sk);
+    let mut wire = Vec::new();
+    {
+        let mut message = capnp::message::Builder::new_default();
+        {
+            let mut builder =
+                message.init_root::<hyprstream_rpc::common_capnp::signed_envelope::Builder>();
+            signed.write_to(&mut builder);
+        }
+        capnp::serialize::write_message(&mut wire, &message)?;
+    }
+    assert!(!signed.is_encrypted(), "test must send a cleartext envelope");
+
+    // Raw send bypasses RpcClientImpl's send-side guard — this exercises the
+    // *receive* side directly, the scenario a hostile/downgrading peer creates.
+    let response_bytes = transport.send(wire, Some(8_000)).await?;
+
+    let reader = capnp::serialize::read_message(
+        &mut std::io::Cursor::new(&response_bytes),
+        capnp::message::ReaderOptions::new(),
+    )?;
+    let response = ResponseEnvelope::read_from(
+        reader.get_root::<hyprstream_rpc::common_capnp::response_envelope::Reader>()?,
+    )?;
+
+    assert_eq!(response.request_id, 0, "rejected before request processing (id=0)");
+    let text = String::from_utf8_lossy(&response.payload);
+    assert!(
+        text.contains("cleartext"),
+        "server must report the INV-2 cleartext rejection, got: {text}"
+    );
+    assert_ne!(
+        response.payload.first().copied(),
+        Some(0xEC),
+        "echo handler must not have run — no 0xEC prefix"
+    );
 
     client.shutdown().await?;
     server.shutdown().await?;


### PR DESCRIPTION
## What

Completes the **request receive half** of INV-2 (ADR #1023 / epic #1026 / parent #1028), stacked on the send-side foundation in #1036. A peer must not be able to deliver a cleartext request envelope—or bytes merely claiming to be encrypted—to an application handler over iroh, QUIC (including loopback), or WebTransport.

This revision incorporates the independent security review on the original #1043 head. Network request bytes now have one unavoidable canonical admission path: exact bounded Cap'n Proto parsing, signature/replay admission, carrier encryption policy, and `#mesh-kem` open all complete before claims or application dispatch. Malformed, unauthenticated, replayed, cleartext, and undecryptable network inputs are silently dropped/reset without producing an attacker-triggered signed response.

The final-review follow-up also makes the real-carrier silent-drop oracle mutation-effective: only a prompt empty FIN is accepted. A one-second outer deadline, any transport error, or any response bytes fail the assertion, and a deliberately nonresponsive control proves the timeout path fails without hanging the suite.

> **Stacked on #1036** (`ewindisch/hykem-wiring`). Merge #1036 first, then rebase/retarget this PR and obtain substantive final review. Do not merge this PR while its stacked base remains outstanding.

## Security design

- **Exact, bounded, allocation-safe framing.** Envelope parsing uses Cap'n Proto's flat-slice no-allocation reader over the already-buffered frame, with the existing 1 MiB traversal and 64-level nesting bounds. It rejects trailing, partial, malformed, and oversized framing. The old unauthenticated encrypted-field probe is removed.
- **Canonical admission is unavoidable.** `IrohRequestProcessor` is sealed. The crate-owned `LocalServiceBridge` is the only processor admitted on untrusted carriers; public raw closures are limited to trusted local paths. A nonempty `encryptedEnvelope` field cannot authorize raw bytes to reach a custom callback.
- **Carrier trust is accept-boundary-owned.** Only crate-private inproc and UDS constructors can mint trusted contexts. Public constructors create iroh/QUIC/WebTransport/unknown contexts, all of which forbid cleartext. Loopback QUIC remains untrusted.
- **No pre-auth signing oracle.** Dispatch applies the untrusted-carrier encryption requirement only inside canonical unwrap, after signature/replay admission and before claims/handler dispatch. Admission failures propagate to the network serve loop, which silently resets/drops them; it does not sign an error. Authenticated claims or application errors retain the normal signed response behavior.
- **Raw transport tests stay below the policy boundary.** Crate-only test carrier injection keeps framing, timeout, admission, and drain tests focused on transport behavior. Production handlers retain their real untrusted carrier classification. Shutdown synchronization is time-bounded so regressions fail instead of wedging the suite.

## Tests added or strengthened

- Exact parser adversarial cases: trailing bytes, truncated frames, oversized segment declarations, and malformed segment counts.
- Dispatch coverage: valid encrypted request succeeds; signed cleartext and undecodable input are rejected before handler work.
- Real iroh coverage:
  - encrypted `#mesh-kem` round trip succeeds;
  - validly signed cleartext is silently dropped and handler count remains zero;
  - a false one-byte encrypted marker plus visible clear outer payload never reaches a custom raw processor;
  - repeated undecodable unauthenticated requests yield no response and no handler invocation.
- Silent-drop assertions accept only `Ok(empty)` within a one-second outer deadline. The real iroh path demonstrably produces that outcome; no arbitrary error/reset allowlist is used. A pending-peer control verifies deadline expiry panics promptly.
- Existing iroh/quinn/lazy transport tests are migrated below the application security boundary, with bounded shutdown waits.

## Local verification

All commands used an isolated `CARGO_TARGET_DIR` and ran serially:

- focused exact-parser unit tests — pass
- `cargo test -p hyprstream-rpc --test inv2_receive_dispatch` — 3/3 pass
- `cargo test -p hyprstream-rpc --test iroh_rpc_e2e` — 5/5 pass, including the nonresponsive-peer oracle control
- `cargo test -p hyprstream-rpc --lib --quiet` — 680/680 pass; completes in about 10 seconds
- all 11 RPC integration targets — 39/39 pass in one clean sweep
- `cargo clippy -p hyprstream-rpc --lib --tests -- -D warnings` — pass
- `RUSTFLAGS='--cfg=web_sys_unstable_apis' cargo check --target wasm32-unknown-unknown -p hyprstream-rpc` — pass
- `cargo deny check bans licenses` — pass
- downstream `cargo build -p hyprstream -p hyprstream-service` — pass with the repository's documented system OpenSSL / Python libtorch environment

## Scope

This PR covers request-envelope receive enforcement only. Response direction, streaming, MoQ, and 9P remain under #1028 and related work. This PR tracks #1042 but intentionally does not close it before review and merge.

Related: #1042, #1028, #1026, #1023.
