### PR TITLE
security(rpc): seal transcript-bound responses

### DIFF
--- a/crates/hyprstream-rpc-derive/src/codegen/client.rs
+++ b/crates/hyprstream-rpc-derive/src/codegen/client.rs
@@ -25,7 +25,11 @@ fn is_rpc_stream_info(type_name: &str, resolved: &ResolvedSchema) -> bool {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Generate the top-level service trait and all scope traits.
-pub fn generate_service_traits(service_name: &str, resolved: &ResolvedSchema, types_crate: Option<&syn::Path>) -> TokenStream {
+pub fn generate_service_traits(
+    service_name: &str,
+    resolved: &ResolvedSchema,
+    types_crate: Option<&syn::Path>,
+) -> TokenStream {
     let mut tokens = TokenStream::new();
 
     // Generate scope traits first (bottom-up: nested → parent → top-level)
@@ -34,18 +38,30 @@ pub fn generate_service_traits(service_name: &str, resolved: &ResolvedSchema, ty
     }
 
     // Generate top-level service trait
-    tokens.extend(generate_top_level_trait(service_name, resolved, types_crate));
+    tokens.extend(generate_top_level_trait(
+        service_name,
+        resolved,
+        types_crate,
+    ));
 
     tokens
 }
 
 /// Generate a scope trait (e.g., RuntimeRpc, ContainerRpc) and recurse into nested scopes.
-fn generate_scope_trait_recursive(sc: &ScopedClient, resolved: &ResolvedSchema, types_crate: Option<&syn::Path>) -> TokenStream {
+fn generate_scope_trait_recursive(
+    sc: &ScopedClient,
+    resolved: &ResolvedSchema,
+    types_crate: Option<&syn::Path>,
+) -> TokenStream {
     let mut tokens = TokenStream::new();
 
     // Generate nested scope traits first
     for nested in &sc.nested_clients {
-        tokens.extend(generate_scope_trait_recursive(nested, resolved, types_crate));
+        tokens.extend(generate_scope_trait_recursive(
+            nested,
+            resolved,
+            types_crate,
+        ));
     }
 
     let trait_name = scope_trait_name(&sc.client_name);
@@ -53,23 +69,35 @@ fn generate_scope_trait_recursive(sc: &ScopedClient, resolved: &ResolvedSchema, 
     let doc = format!("Generated RPC trait for {} scope.", sc.factory_name);
 
     // Nested scope associated types + factory methods
-    let nested_assoc_types: Vec<TokenStream> = sc.nested_clients.iter().map(|nested| {
-        let assoc_name = format_ident!("{}", to_pascal_case(&nested.factory_name));
-        let nested_trait = format_ident!("{}", scope_trait_name(&nested.client_name));
-        quote! { type #assoc_name: #nested_trait; }
-    }).collect();
+    let nested_assoc_types: Vec<TokenStream> = sc
+        .nested_clients
+        .iter()
+        .map(|nested| {
+            let assoc_name = format_ident!("{}", to_pascal_case(&nested.factory_name));
+            let nested_trait = format_ident!("{}", scope_trait_name(&nested.client_name));
+            quote! { type #assoc_name: #nested_trait; }
+        })
+        .collect();
 
-    let nested_factory_methods: Vec<TokenStream> = sc.nested_clients.iter().map(|nested| {
-        let method = format_ident!("{}", to_snake_case(&nested.factory_name));
-        let assoc_name = format_ident!("{}", to_pascal_case(&nested.factory_name));
-        let params = scope_factory_params(&nested.scope_fields, resolved);
-        quote! { fn #method(&self #(, #params)*) -> Self::#assoc_name; }
-    }).collect();
+    let nested_factory_methods: Vec<TokenStream> = sc
+        .nested_clients
+        .iter()
+        .map(|nested| {
+            let method = format_ident!("{}", to_snake_case(&nested.factory_name));
+            let assoc_name = format_ident!("{}", to_pascal_case(&nested.factory_name));
+            let params = scope_factory_params(&nested.scope_fields, resolved);
+            quote! { fn #method(&self #(, #params)*) -> Self::#assoc_name; }
+        })
+        .collect();
 
     // Trait methods from inner_request_variants
-    let trait_methods: Vec<TokenStream> = sc.inner_request_variants.iter().filter_map(|v| {
-        generate_trait_method(v, &sc.inner_response_variants, resolved, types_crate, true)
-    }).collect();
+    let trait_methods: Vec<TokenStream> = sc
+        .inner_request_variants
+        .iter()
+        .filter_map(|v| {
+            generate_trait_method(v, &sc.inner_response_variants, resolved, types_crate, true)
+        })
+        .collect();
 
     tokens.extend(quote! {
         #[doc = #doc]
@@ -86,37 +114,61 @@ fn generate_scope_trait_recursive(sc: &ScopedClient, resolved: &ResolvedSchema, 
 }
 
 /// Generate the top-level service trait (e.g., WorkerRpc, ModelRpc).
-fn generate_top_level_trait(service_name: &str, resolved: &ResolvedSchema, types_crate: Option<&syn::Path>) -> TokenStream {
+fn generate_top_level_trait(
+    service_name: &str,
+    resolved: &ResolvedSchema,
+    types_crate: Option<&syn::Path>,
+) -> TokenStream {
     let pascal = to_pascal_case(service_name);
     let trait_name = format_ident!("{}Rpc", pascal);
     let doc = format!("Generated RPC trait for the {pascal} service.");
 
-    let scoped_variant_names: Vec<&str> = resolved.raw
+    let scoped_variant_names: Vec<&str> = resolved
+        .raw
         .scoped_clients
         .iter()
         .map(|sc| sc.factory_name.as_str())
         .collect();
 
     // Associated types for scoped clients
-    let assoc_types: Vec<TokenStream> = resolved.raw.scoped_clients.iter().map(|sc| {
-        let assoc_name = format_ident!("{}", to_pascal_case(&sc.factory_name));
-        let scope_trait = format_ident!("{}", scope_trait_name(&sc.client_name));
-        quote! { type #assoc_name: #scope_trait; }
-    }).collect();
+    let assoc_types: Vec<TokenStream> = resolved
+        .raw
+        .scoped_clients
+        .iter()
+        .map(|sc| {
+            let assoc_name = format_ident!("{}", to_pascal_case(&sc.factory_name));
+            let scope_trait = format_ident!("{}", scope_trait_name(&sc.client_name));
+            quote! { type #assoc_name: #scope_trait; }
+        })
+        .collect();
 
     // Factory methods for scoped clients
-    let factory_methods: Vec<TokenStream> = resolved.raw.scoped_clients.iter().map(|sc| {
-        let method = format_ident!("{}", to_snake_case(&sc.factory_name));
-        let assoc_name = format_ident!("{}", to_pascal_case(&sc.factory_name));
-        let params = scope_factory_params(&sc.scope_fields, resolved);
-        quote! { fn #method(&self #(, #params)*) -> Self::#assoc_name; }
-    }).collect();
+    let factory_methods: Vec<TokenStream> = resolved
+        .raw
+        .scoped_clients
+        .iter()
+        .map(|sc| {
+            let method = format_ident!("{}", to_snake_case(&sc.factory_name));
+            let assoc_name = format_ident!("{}", to_pascal_case(&sc.factory_name));
+            let params = scope_factory_params(&sc.scope_fields, resolved);
+            quote! { fn #method(&self #(, #params)*) -> Self::#assoc_name; }
+        })
+        .collect();
 
     // Non-scoped methods
-    let trait_methods: Vec<TokenStream> = resolved.raw.request_variants.iter()
+    let trait_methods: Vec<TokenStream> = resolved
+        .raw
+        .request_variants
+        .iter()
         .filter(|v| !scoped_variant_names.contains(&v.name.as_str()))
         .filter_map(|v| {
-            generate_trait_method(v, &resolved.raw.response_variants, resolved, types_crate, false)
+            generate_trait_method(
+                v,
+                &resolved.raw.response_variants,
+                resolved,
+                types_crate,
+                false,
+            )
         })
         .collect();
 
@@ -143,13 +195,23 @@ fn generate_trait_method(
     let method_name = format_ident!("{}", to_snake_case(&variant.name));
 
     // Determine return type
-    let return_type = determine_return_type(&variant.name, response_variants, resolved, is_scoped, types_crate)?;
+    let return_type = determine_return_type(
+        &variant.name,
+        response_variants,
+        resolved,
+        is_scoped,
+        types_crate,
+    )?;
 
     // Detect streaming — trait methods return StreamHandle directly (no ephemeral_pubkey param)
     let is_streaming = response_variants
         .iter()
         .find(|v| {
-            let expected = if is_scoped { variant.name.clone() } else { format!("{}Result", variant.name) };
+            let expected = if is_scoped {
+                variant.name.clone()
+            } else {
+                format!("{}Result", variant.name)
+            };
             v.name == expected
         })
         .map(|v| is_rpc_stream_info(&v.type_name, resolved))
@@ -204,16 +266,26 @@ fn determine_return_type(
     };
 
     let resp_variant = response_variants.iter().find(|v| v.name == expected_name)?;
-    let ct = resolved.resolve_type(&resp_variant.type_name).capnp_type.clone();
+    let ct = resolved
+        .resolve_type(&resp_variant.type_name)
+        .capnp_type
+        .clone();
 
     Some(match ct {
         CapnpType::Void => quote! { () },
         CapnpType::Bool => quote! { bool },
         CapnpType::Text => quote! { String },
         CapnpType::Data => quote! { Vec<u8> },
-        CapnpType::UInt8 | CapnpType::UInt16 | CapnpType::UInt32 | CapnpType::UInt64
-        | CapnpType::Int8 | CapnpType::Int16 | CapnpType::Int32 | CapnpType::Int64
-        | CapnpType::Float32 | CapnpType::Float64 => {
+        CapnpType::UInt8
+        | CapnpType::UInt16
+        | CapnpType::UInt32
+        | CapnpType::UInt64
+        | CapnpType::Int8
+        | CapnpType::Int16
+        | CapnpType::Int32
+        | CapnpType::Int64
+        | CapnpType::Float32
+        | CapnpType::Float64 => {
             let rust_type = rust_type_tokens(&ct.rust_owned_type());
             quote! { #rust_type }
         }
@@ -252,11 +324,15 @@ fn scope_trait_name(client_name: &str) -> String {
 
 /// Generate scope factory method parameters.
 fn scope_factory_params(scope_fields: &[FieldDef], _resolved: &ResolvedSchema) -> Vec<TokenStream> {
-    scope_fields.iter().map(|f| {
-        let name = format_ident!("{}", to_snake_case(&f.name));
-        let ty = rust_type_tokens(&CapnpType::classify_primitive(&f.type_name).rust_param_type());
-        quote! { #name: #ty }
-    }).collect()
+    scope_fields
+        .iter()
+        .map(|f| {
+            let name = format_ident!("{}", to_snake_case(&f.name));
+            let ty =
+                rust_type_tokens(&CapnpType::classify_primitive(&f.type_name).rust_param_type());
+            quote! { #name: #ty }
+        })
+        .collect()
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -264,46 +340,72 @@ fn scope_factory_params(scope_fields: &[FieldDef], _resolved: &ResolvedSchema) -
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Generate trait impl for the top-level client + all scoped clients.
-pub fn generate_trait_impls(service_name: &str, resolved: &ResolvedSchema, types_crate: Option<&syn::Path>) -> TokenStream {
+pub fn generate_trait_impls(
+    service_name: &str,
+    resolved: &ResolvedSchema,
+    types_crate: Option<&syn::Path>,
+) -> TokenStream {
     let mut tokens = TokenStream::new();
 
     let pascal = to_pascal_case(service_name);
     let client_ident = format_ident!("{}Client", pascal);
     let trait_ident = format_ident!("{}Rpc", pascal);
 
-    let scoped_variant_names: Vec<&str> = resolved.raw
+    let scoped_variant_names: Vec<&str> = resolved
+        .raw
         .scoped_clients
         .iter()
         .map(|sc| sc.factory_name.as_str())
         .collect();
 
     // Associated type bindings
-    let assoc_bindings: Vec<TokenStream> = resolved.raw.scoped_clients.iter().map(|sc| {
-        let assoc_name = format_ident!("{}", to_pascal_case(&sc.factory_name));
-        let scoped_client = format_ident!("{}", sc.client_name);
-        quote! { type #assoc_name = #scoped_client; }
-    }).collect();
+    let assoc_bindings: Vec<TokenStream> = resolved
+        .raw
+        .scoped_clients
+        .iter()
+        .map(|sc| {
+            let assoc_name = format_ident!("{}", to_pascal_case(&sc.factory_name));
+            let scoped_client = format_ident!("{}", sc.client_name);
+            quote! { type #assoc_name = #scoped_client; }
+        })
+        .collect();
 
     // Factory method impls
-    let factory_impls: Vec<TokenStream> = resolved.raw.scoped_clients.iter().map(|sc| {
-        let method = format_ident!("{}", to_snake_case(&sc.factory_name));
-        let assoc_name = format_ident!("{}", to_pascal_case(&sc.factory_name));
-        let params = scope_factory_params(&sc.scope_fields, resolved);
-        let param_names: Vec<syn::Ident> = sc.scope_fields.iter().map(|f| {
-            format_ident!("{}", to_snake_case(&f.name))
-        }).collect();
-        quote! {
-            fn #method(&self #(, #params)*) -> Self::#assoc_name {
-                #client_ident::#method(self #(, #param_names),*)
+    let factory_impls: Vec<TokenStream> = resolved
+        .raw
+        .scoped_clients
+        .iter()
+        .map(|sc| {
+            let method = format_ident!("{}", to_snake_case(&sc.factory_name));
+            let assoc_name = format_ident!("{}", to_pascal_case(&sc.factory_name));
+            let params = scope_factory_params(&sc.scope_fields, resolved);
+            let param_names: Vec<syn::Ident> = sc
+                .scope_fields
+                .iter()
+                .map(|f| format_ident!("{}", to_snake_case(&f.name)))
+                .collect();
+            quote! {
+                fn #method(&self #(, #params)*) -> Self::#assoc_name {
+                    #client_ident::#method(self #(, #param_names),*)
+                }
             }
-        }
-    }).collect();
+        })
+        .collect();
 
     // Non-scoped method delegation
-    let method_impls: Vec<TokenStream> = resolved.raw.request_variants.iter()
+    let method_impls: Vec<TokenStream> = resolved
+        .raw
+        .request_variants
+        .iter()
         .filter(|v| !scoped_variant_names.contains(&v.name.as_str()))
         .filter_map(|v| {
-            generate_trait_method_impl(v, &resolved.raw.response_variants, resolved, types_crate, false)
+            generate_trait_method_impl(
+                v,
+                &resolved.raw.response_variants,
+                resolved,
+                types_crate,
+                false,
+            )
         })
         .collect();
 
@@ -319,40 +421,60 @@ pub fn generate_trait_impls(service_name: &str, resolved: &ResolvedSchema, types
 
     // Scoped client trait impls
     for sc in &resolved.raw.scoped_clients {
-        tokens.extend(generate_scope_trait_impl_recursive(sc, resolved, types_crate));
+        tokens.extend(generate_scope_trait_impl_recursive(
+            sc,
+            resolved,
+            types_crate,
+        ));
     }
 
     tokens
 }
 
-fn generate_scope_trait_impl_recursive(sc: &ScopedClient, resolved: &ResolvedSchema, types_crate: Option<&syn::Path>) -> TokenStream {
+fn generate_scope_trait_impl_recursive(
+    sc: &ScopedClient,
+    resolved: &ResolvedSchema,
+    types_crate: Option<&syn::Path>,
+) -> TokenStream {
     let mut tokens = TokenStream::new();
 
     let client_ident = format_ident!("{}", sc.client_name);
     let trait_ident = format_ident!("{}", scope_trait_name(&sc.client_name));
 
     // Nested associated type bindings + factory impls
-    let nested_assoc: Vec<TokenStream> = sc.nested_clients.iter().map(|nested| {
-        let assoc_name = format_ident!("{}", to_pascal_case(&nested.factory_name));
-        let nested_client = format_ident!("{}", nested.client_name);
-        quote! { type #assoc_name = #nested_client; }
-    }).collect();
+    let nested_assoc: Vec<TokenStream> = sc
+        .nested_clients
+        .iter()
+        .map(|nested| {
+            let assoc_name = format_ident!("{}", to_pascal_case(&nested.factory_name));
+            let nested_client = format_ident!("{}", nested.client_name);
+            quote! { type #assoc_name = #nested_client; }
+        })
+        .collect();
 
-    let nested_factory_impls: Vec<TokenStream> = sc.nested_clients.iter().map(|nested| {
-        let method = format_ident!("{}", to_snake_case(&nested.factory_name));
-        let assoc_name = format_ident!("{}", to_pascal_case(&nested.factory_name));
-        let params = scope_factory_params(&nested.scope_fields, resolved);
-        let param_names: Vec<syn::Ident> = nested.scope_fields.iter().map(|f| {
-            format_ident!("{}", to_snake_case(&f.name))
-        }).collect();
-        quote! {
-            fn #method(&self #(, #params)*) -> Self::#assoc_name {
-                #client_ident::#method(self #(, #param_names),*)
+    let nested_factory_impls: Vec<TokenStream> = sc
+        .nested_clients
+        .iter()
+        .map(|nested| {
+            let method = format_ident!("{}", to_snake_case(&nested.factory_name));
+            let assoc_name = format_ident!("{}", to_pascal_case(&nested.factory_name));
+            let params = scope_factory_params(&nested.scope_fields, resolved);
+            let param_names: Vec<syn::Ident> = nested
+                .scope_fields
+                .iter()
+                .map(|f| format_ident!("{}", to_snake_case(&f.name)))
+                .collect();
+            quote! {
+                fn #method(&self #(, #params)*) -> Self::#assoc_name {
+                    #client_ident::#method(self #(, #param_names),*)
+                }
             }
-        }
-    }).collect();
+        })
+        .collect();
 
-    let method_impls: Vec<TokenStream> = sc.inner_request_variants.iter()
+    let method_impls: Vec<TokenStream> = sc
+        .inner_request_variants
+        .iter()
         .filter_map(|v| {
             generate_trait_method_impl(v, &sc.inner_response_variants, resolved, types_crate, true)
         })
@@ -370,7 +492,11 @@ fn generate_scope_trait_impl_recursive(sc: &ScopedClient, resolved: &ResolvedSch
 
     // Recurse into nested scoped clients
     for nested in &sc.nested_clients {
-        tokens.extend(generate_scope_trait_impl_recursive(nested, resolved, types_crate));
+        tokens.extend(generate_scope_trait_impl_recursive(
+            nested,
+            resolved,
+            types_crate,
+        ));
     }
 
     tokens
@@ -386,12 +512,22 @@ fn generate_trait_method_impl(
 ) -> Option<TokenStream> {
     let method_name = format_ident!("{}", to_snake_case(&variant.name));
 
-    let return_type = determine_return_type(&variant.name, response_variants, resolved, is_scoped, types_crate)?;
+    let return_type = determine_return_type(
+        &variant.name,
+        response_variants,
+        resolved,
+        is_scoped,
+        types_crate,
+    )?;
 
     let is_streaming = response_variants
         .iter()
         .find(|v| {
-            let expected = if is_scoped { variant.name.clone() } else { format!("{}Result", variant.name) };
+            let expected = if is_scoped {
+                variant.name.clone()
+            } else {
+                format!("{}Result", variant.name)
+            };
             v.name == expected
         })
         .map(|v| is_rpc_stream_info(&v.type_name, resolved))
@@ -421,7 +557,10 @@ fn generate_trait_method_impl(
                 (Vec::new(), Vec::new())
             } else {
                 let data_name = format_ident!("{}", struct_name);
-                (vec![quote! { request: &#data_name }], vec![quote! { request }])
+                (
+                    vec![quote! { request: &#data_name }],
+                    vec![quote! { request }],
+                )
             }
         }
     };
@@ -477,9 +616,6 @@ pub fn generate_constructors(service_name: &str) -> TokenStream {
     quote! {
         #[cfg(not(target_arch = "wasm32"))]
         impl #client_name {
-            /// The service name used for endpoint resolution.
-            pub const SERVICE_NAME: &'static str = #service_name_lit;
-
             /// Create a new client by looking up the service endpoint from the global registry.
             ///
             /// `destination` is the Ed25519 verifying key of the target service,
@@ -618,7 +754,11 @@ fn resolve_domain_type(domain_path: &str, types_crate: Option<&syn::Path>) -> To
 // Response Enum
 // ─────────────────────────────────────────────────────────────────────────────
 
-pub fn generate_response_enum(service_name: &str, resolved: &ResolvedSchema, types_crate: Option<&syn::Path>) -> TokenStream {
+pub fn generate_response_enum(
+    service_name: &str,
+    resolved: &ResolvedSchema,
+    types_crate: Option<&syn::Path>,
+) -> TokenStream {
     let pascal = to_pascal_case(service_name);
     let enum_name_str = format!("{pascal}ResponseVariant");
     generate_response_enum_from_variants(
@@ -666,7 +806,8 @@ fn generate_enum_variant(
         "Data" => quote! { #variant_pascal(Vec<u8>) },
         "UInt32" | "UInt64" | "Int32" | "Int64" | "Float32" | "Float64" | "UInt8" | "UInt16"
         | "Int8" | "Int16" => {
-            let rust_type = rust_type_tokens(&CapnpType::classify_primitive(&v.type_name).rust_owned_type());
+            let rust_type =
+                rust_type_tokens(&CapnpType::classify_primitive(&v.type_name).rust_owned_type());
             quote! { #variant_pascal(#rust_type) }
         }
         type_name if type_name.starts_with("List(") => {
@@ -708,7 +849,11 @@ fn generate_enum_variant(
 // Client Struct + Impl
 // ─────────────────────────────────────────────────────────────────────────────
 
-pub fn generate_client(service_name: &str, resolved: &ResolvedSchema, types_crate: Option<&syn::Path>) -> TokenStream {
+pub fn generate_client(
+    service_name: &str,
+    resolved: &ResolvedSchema,
+    types_crate: Option<&syn::Path>,
+) -> TokenStream {
     let pascal = to_pascal_case(service_name);
     let client_name = format_ident!("{}Client", pascal);
     let response_type = format_ident!("{}ResponseVariant", pascal);
@@ -720,14 +865,16 @@ pub fn generate_client(service_name: &str, resolved: &ResolvedSchema, types_crat
     let req_type = format_ident!("{}", to_snake_case(&format!("{pascal}Request")));
     let doc = format!("Auto-generated client for the {pascal} service.");
 
-    let scoped_variant_names: Vec<&str> = resolved.raw
+    let scoped_variant_names: Vec<&str> = resolved
+        .raw
         .scoped_clients
         .iter()
         .map(|sc| sc.factory_name.as_str())
         .collect();
 
     // Request methods (portable — uses self.client.call(), not CallOptions)
-    let request_methods: Vec<TokenStream> = resolved.raw
+    let request_methods: Vec<TokenStream> = resolved
+        .raw
         .request_variants
         .iter()
         .filter(|v| !scoped_variant_names.contains(&v.name.as_str()))
@@ -757,7 +904,8 @@ pub fn generate_client(service_name: &str, resolved: &ResolvedSchema, types_crat
     );
 
     // Factory methods for scoped clients
-    let factory_methods: Vec<TokenStream> = resolved.raw
+    let factory_methods: Vec<TokenStream> = resolved
+        .raw
         .scoped_clients
         .iter()
         .map(generate_portable_scoped_factory_method)
@@ -771,6 +919,9 @@ pub fn generate_client(service_name: &str, resolved: &ResolvedSchema, types_crat
         }
 
         impl #client_name {
+            /// Canonical service/destination domain used for cryptographic RPC binding.
+            pub const SERVICE_NAME: &'static str = #service_name;
+
             /// Create from any RpcClient implementation.
             pub fn new(client: std::sync::Arc<dyn hyprstream_rpc::RpcClient>) -> Self {
                 Self { client }
@@ -787,17 +938,17 @@ pub fn generate_client(service_name: &str, resolved: &ResolvedSchema, types_crat
             /// context without mutating the shared client. Safe for use with
             /// connection pooling.
             pub fn request(&self) -> hyprstream_rpc::RequestBuilder<'_> {
-                hyprstream_rpc::RequestBuilder::new(&self.client)
+                hyprstream_rpc::RequestBuilder::for_service(&self.client, Self::SERVICE_NAME)
             }
 
             /// Send a raw request and return the raw response bytes.
             pub async fn call(&self, payload: Vec<u8>) -> anyhow::Result<Vec<u8>> {
-                self.client.call(payload).await
+                self.client.call_for_service(Self::SERVICE_NAME, payload).await
             }
 
             /// Send a streaming request with ephemeral DH pubkey.
             pub async fn call_streaming(&self, payload: Vec<u8>, ephemeral_pubkey: [u8; 32]) -> anyhow::Result<Vec<u8>> {
-                self.client.call_streaming(payload, ephemeral_pubkey).await
+                self.client.call_streaming_for_service(Self::SERVICE_NAME, payload, ephemeral_pubkey).await
             }
 
             #(#request_methods)*
@@ -826,7 +977,17 @@ pub fn generate_portable_request_method(
     is_scoped: bool,
     types_crate: Option<&syn::Path>,
 ) -> TokenStream {
-    generate_request_method_inner(capnp_mod, req_type, response_type, variant, resolved, scope, response_variants, is_scoped, types_crate)
+    generate_request_method_inner(
+        capnp_mod,
+        req_type,
+        response_type,
+        variant,
+        resolved,
+        scope,
+        response_variants,
+        is_scoped,
+        types_crate,
+    )
 }
 
 /// Inner request method generation (transport-agnostic).
@@ -844,9 +1005,17 @@ fn generate_request_method_inner(
 ) -> TokenStream {
     let method_name = format_ident!("{}", to_snake_case(&variant.name));
     let doc = if variant.description.is_empty() {
-        format!("{} ({} variant)", to_snake_case(&variant.name), variant.type_name)
+        format!(
+            "{} ({} variant)",
+            to_snake_case(&variant.name),
+            variant.type_name
+        )
     } else {
-        let scope_info = if variant.scope.is_empty() { String::new() } else { format!("\n\nScope: {}", variant.scope) };
+        let scope_info = if variant.scope.is_empty() {
+            String::new()
+        } else {
+            format!("\n\nScope: {}", variant.scope)
+        };
         format!("{}{}", variant.description, scope_info)
     };
 
@@ -884,12 +1053,23 @@ fn generate_request_method_inner(
 
         (setup, quote! { Self::parse_scoped_response(&response) })
     } else {
-        (TokenStream::new(), quote! { Self::parse_response(&response) })
+        (
+            TokenStream::new(),
+            quote! { Self::parse_response(&response) },
+        )
     };
 
     // Determine typed return info if response_variants are available
     let typed_info = response_variants.and_then(|resp_vars| {
-        find_typed_return_info(&variant.name, resp_vars, resolved, is_scoped, response_type, &parse_call, types_crate)
+        find_typed_return_info(
+            &variant.name,
+            resp_vars,
+            resolved,
+            is_scoped,
+            response_type,
+            &parse_call,
+            types_crate,
+        )
     });
 
     // Detect if this method returns StreamInfo
@@ -1033,8 +1213,8 @@ fn generate_request_method_inner(
         struct_name => {
             if let Some(s) = resolved.find_struct(struct_name) {
                 let nuf: Vec<_> = s.non_union_fields().collect();
-                let is_void_wrapper = nuf.is_empty()
-                    || (nuf.len() == 1 && nuf[0].type_name == "Void");
+                let is_void_wrapper =
+                    nuf.is_empty() || (nuf.len() == 1 && nuf[0].type_name == "Void");
 
                 if is_void_wrapper {
                     let init_method = format_ident!("init_{}", to_snake_case(&variant.name));
@@ -1074,7 +1254,11 @@ fn generate_request_method_inner(
                     }
                 }
             } else {
-                let _comment = format!("TODO: {} — struct {} not found in schema", to_snake_case(&variant.name), struct_name);
+                let _comment = format!(
+                    "TODO: {} — struct {} not found in schema",
+                    to_snake_case(&variant.name),
+                    struct_name
+                );
                 quote! {
                     // #comment
                 }
@@ -1109,7 +1293,10 @@ fn find_typed_return_info(
 
     let resp_variant = response_variants.iter().find(|v| v.name == expected_name)?;
     let variant_pascal = resolved.name(&resp_variant.name).pascal_ident.clone();
-    let ct = resolved.resolve_type(&resp_variant.type_name).capnp_type.clone();
+    let ct = resolved
+        .resolve_type(&resp_variant.type_name)
+        .capnp_type
+        .clone();
 
     let has_error = response_variants.iter().any(|v| v.name == "error");
 
@@ -1166,9 +1353,16 @@ fn find_typed_return_info(
                 }
             },
         }),
-        CapnpType::UInt8 | CapnpType::UInt16 | CapnpType::UInt32 | CapnpType::UInt64
-        | CapnpType::Int8 | CapnpType::Int16 | CapnpType::Int32 | CapnpType::Int64
-        | CapnpType::Float32 | CapnpType::Float64 => {
+        CapnpType::UInt8
+        | CapnpType::UInt16
+        | CapnpType::UInt32
+        | CapnpType::UInt64
+        | CapnpType::Int8
+        | CapnpType::Int16
+        | CapnpType::Int32
+        | CapnpType::Int64
+        | CapnpType::Float32
+        | CapnpType::Float64 => {
             let rust_type = rust_type_tokens(&ct.rust_owned_type());
             Some(TypedReturnInfo {
                 return_type: quote! { #rust_type },
@@ -1275,7 +1469,16 @@ pub fn generate_parse_response_fn(
     let which_ident = format_ident!("Which");
     let match_arms: Vec<TokenStream> = variants
         .iter()
-        .map(|v| generate_parse_match_arm(response_type, capnp_mod, v, resolved, &which_ident, types_crate))
+        .map(|v| {
+            generate_parse_match_arm(
+                response_type,
+                capnp_mod,
+                v,
+                resolved,
+                &which_ident,
+                types_crate,
+            )
+        })
         .collect();
 
     quote! {
@@ -1310,9 +1513,16 @@ pub fn generate_parse_match_arm(
             #which_ident::#variant_pascal(()) => Ok(#response_type::#variant_pascal),
         },
         CapnpType::Bool
-        | CapnpType::UInt8 | CapnpType::UInt16 | CapnpType::UInt32 | CapnpType::UInt64
-        | CapnpType::Int8 | CapnpType::Int16 | CapnpType::Int32 | CapnpType::Int64
-        | CapnpType::Float32 | CapnpType::Float64 => quote! {
+        | CapnpType::UInt8
+        | CapnpType::UInt16
+        | CapnpType::UInt32
+        | CapnpType::UInt64
+        | CapnpType::Int8
+        | CapnpType::Int16
+        | CapnpType::Int32
+        | CapnpType::Int64
+        | CapnpType::Float32
+        | CapnpType::Float64 => quote! {
             #which_ident::#variant_pascal(v) => Ok(#response_type::#variant_pascal(v)),
         },
         CapnpType::Text => quote! {
@@ -1321,9 +1531,17 @@ pub fn generate_parse_match_arm(
         CapnpType::Data => quote! {
             #which_ident::#variant_pascal(v) => Ok(#response_type::#variant_pascal(v?.to_vec())),
         },
-        CapnpType::ListText | CapnpType::ListData | CapnpType::ListPrimitive(_) | CapnpType::ListStruct(_) => {
-            generate_list_parse_arm(&variant_pascal, response_type, &v.type_name, resolved, capnp_mod, which_ident)
-        }
+        CapnpType::ListText
+        | CapnpType::ListData
+        | CapnpType::ListPrimitive(_)
+        | CapnpType::ListStruct(_) => generate_list_parse_arm(
+            &variant_pascal,
+            response_type,
+            &v.type_name,
+            resolved,
+            capnp_mod,
+            which_ident,
+        ),
         CapnpType::Struct(ref name) => {
             if let Some(s) = resolved.find_struct(name) {
                 let data_type = if let Some(ref dt) = s.domain_type {
@@ -1415,26 +1633,34 @@ fn generate_list_parse_arm(
 // Scoped Factory Method
 // ─────────────────────────────────────────────────────────────────────────────
 
-
 /// Generate a scoped factory method for portable clients (no jwt_token field).
 fn generate_portable_scoped_factory_method(sc: &ScopedClient) -> TokenStream {
     let method_name = format_ident!("{}", to_snake_case(&sc.factory_name));
     let client_name_ident = format_ident!("{}", sc.client_name);
     let doc = format!("Create a scoped {} client.", sc.factory_name);
 
-    let params: Vec<TokenStream> = sc.scope_fields.iter().map(|f| {
-        let name = format_ident!("{}", to_snake_case(&f.name));
-        let ty = rust_type_tokens(&CapnpType::classify_primitive(&f.type_name).rust_param_type());
-        quote! { #name: #ty }
-    }).collect();
+    let params: Vec<TokenStream> = sc
+        .scope_fields
+        .iter()
+        .map(|f| {
+            let name = format_ident!("{}", to_snake_case(&f.name));
+            let ty =
+                rust_type_tokens(&CapnpType::classify_primitive(&f.type_name).rust_param_type());
+            quote! { #name: #ty }
+        })
+        .collect();
 
-    let field_inits: Vec<TokenStream> = sc.scope_fields.iter().map(|f| {
-        let name = format_ident!("{}", to_snake_case(&f.name));
-        match f.type_name.as_str() {
-            "Text" => quote! { #name: #name.to_owned() },
-            _ => quote! { #name },
-        }
-    }).collect();
+    let field_inits: Vec<TokenStream> = sc
+        .scope_fields
+        .iter()
+        .map(|f| {
+            let name = format_ident!("{}", to_snake_case(&f.name));
+            match f.type_name.as_str() {
+                "Text" => quote! { #name: #name.to_owned() },
+                _ => quote! { #name },
+            }
+        })
+        .collect();
 
     quote! {
         #[doc = #doc]

--- a/crates/hyprstream-rpc-std/src/vfs_mount.rs
+++ b/crates/hyprstream-rpc-std/src/vfs_mount.rs
@@ -17,9 +17,9 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 
 use async_trait::async_trait;
-use hyprstream_vfs::{DirEntry, Fid, Mount, MountError, Stat};
-use hyprstream_rpc::Subject;
 use hyprstream_rpc::rpc_client::RpcClient;
+use hyprstream_rpc::Subject;
+use hyprstream_vfs::{DirEntry, Fid, Mount, MountError, Stat};
 
 // ============================================================================
 // RpcClient is already Send + Sync — no wrapper needed.
@@ -81,7 +81,9 @@ impl CtlResponseCache {
 /// Monotonic counter for request IDs.
 struct IdCounter(AtomicU64);
 impl IdCounter {
-    fn new() -> Self { Self(AtomicU64::new(1)) }
+    fn new() -> Self {
+        Self(AtomicU64::new(1))
+    }
     fn next(&self) -> u64 {
         self.0.fetch_add(1, Ordering::Relaxed)
     }
@@ -109,8 +111,18 @@ pub enum ServiceDispatchResult {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait ServiceDispatch: Send + Sync {
-    async fn dispatch(&self, method: &str, args_json: &str, client: &dyn RpcClient) -> Result<ServiceDispatchResult, String>;
-    fn metadata(&self) -> (&'static str, &'static [hyprstream_rpc::metadata::MethodMeta]);
+    async fn dispatch(
+        &self,
+        method: &str,
+        args_json: &str,
+        client: &dyn RpcClient,
+    ) -> Result<ServiceDispatchResult, String>;
+    fn metadata(
+        &self,
+    ) -> (
+        &'static str,
+        &'static [hyprstream_rpc::metadata::MethodMeta],
+    );
 }
 
 /// Generic VFS mount driven by a ServiceDispatch implementation.
@@ -159,13 +171,20 @@ impl Mount for GenericServiceMount {
         Ok(())
     }
 
-    async fn read(&self, fid: &Fid, offset: u64, count: u32, _caller: &Subject) -> Result<Vec<u8>, MountError> {
+    async fn read(
+        &self,
+        fid: &Fid,
+        offset: u64,
+        count: u32,
+        _caller: &Subject,
+    ) -> Result<Vec<u8>, MountError> {
         // Check for ctl response first (from previous write)
         if let Some(resp) = self.ctl_response.take() {
             return Ok(slice_read(resp, offset, count));
         }
 
-        let state = fid.downcast_ref::<VfsFidState>()
+        let state = fid
+            .downcast_ref::<VfsFidState>()
             .ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
 
         if state.path.is_empty() {
@@ -176,19 +195,30 @@ impl Mount for GenericServiceMount {
 
         // cat /srv/{service}/{method} → dispatch query method with empty args
         let method = &state.path[0];
-        match self.service.dispatch(method, "{}", self.client.as_ref()).await
-            .map_err(MountError::Io)? {
+        match self
+            .service
+            .dispatch(method, "{}", self.client.as_ref())
+            .await
+            .map_err(MountError::Io)?
+        {
             ServiceDispatchResult::Response(json) => {
                 Ok(slice_read(json.into_bytes(), offset, count))
             }
-            ServiceDispatchResult::Stream { .. } => {
-                Err(MountError::NotSupported("use ctl to start streams, then read from /stream/{topic}/data".into()))
-            }
+            ServiceDispatchResult::Stream { .. } => Err(MountError::NotSupported(
+                "use ctl to start streams, then read from /stream/{topic}/data".into(),
+            )),
         }
     }
 
-    async fn write(&self, fid: &Fid, _offset: u64, data: &[u8], _caller: &Subject) -> Result<u32, MountError> {
-        let state = fid.downcast_ref::<VfsFidState>()
+    async fn write(
+        &self,
+        fid: &Fid,
+        _offset: u64,
+        data: &[u8],
+        _caller: &Subject,
+    ) -> Result<u32, MountError> {
+        let state = fid
+            .downcast_ref::<VfsFidState>()
             .ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
 
         // ctl pattern: data = "command {json_args}" or "command json_args"
@@ -196,13 +226,15 @@ impl Mount for GenericServiceMount {
         let data_str = std::str::from_utf8(data).unwrap_or("").trim();
 
         // Strip shell quotes from around JSON if present
-        let stripped = data_str
-            .trim_end_matches('\'')
-            .trim_end_matches('"');
+        let stripped = data_str.trim_end_matches('\'').trim_end_matches('"');
 
         let (cmd, args_owned);
         if let Some(brace) = stripped.find('{') {
-            let cmd_part = stripped[..brace].trim().trim_end_matches('\'').trim_end_matches('"').trim();
+            let cmd_part = stripped[..brace]
+                .trim()
+                .trim_end_matches('\'')
+                .trim_end_matches('"')
+                .trim();
             let args_part = &stripped[brace..];
             cmd = if cmd_part.is_empty() {
                 state.path.first().map(|s| s.as_str()).unwrap_or("")
@@ -213,7 +245,9 @@ impl Mount for GenericServiceMount {
         } else if stripped.contains(':') && stripped.contains('"') {
             // Looks like stripped JSON (Tcl brace quoting removed outer {})
             // Split on first whitespace to find command, rest is bare JSON
-            let (c, rest) = stripped.split_once(char::is_whitespace).unwrap_or((stripped, ""));
+            let (c, rest) = stripped
+                .split_once(char::is_whitespace)
+                .unwrap_or((stripped, ""));
             cmd = c.trim();
             // Re-wrap bare JSON fields with braces
             args_owned = format!("{{{}}}", rest.trim());
@@ -227,12 +261,18 @@ impl Mount for GenericServiceMount {
         };
         let args_str = args_owned.as_str();
 
-        let dispatch_result = self.service.dispatch(cmd, args_str, self.client.as_ref()).await
+        let dispatch_result = self
+            .service
+            .dispatch(cmd, args_str, self.client.as_ref())
+            .await
             .map_err(MountError::Io)?;
 
         let resp = match dispatch_result {
             ServiceDispatchResult::Response(json) => json.into_bytes(),
-            ServiceDispatchResult::Stream { info, ephemeral_keypair } => {
+            ServiceDispatchResult::Stream {
+                info,
+                ephemeral_keypair,
+            } => {
                 // #468: `info` is the VERIFIED-capnp StreamInfo library type carried
                 // typed through dispatch (decoded + COSE-verified upstream) — no
                 // serde_json round-trip / re-parse at this boundary.
@@ -249,7 +289,9 @@ impl Mount for GenericServiceMount {
                 pubkey_32.copy_from_slice(client_pubkey);
 
                 // Open verified stream handle via RpcClient
-                let handle = self.client.open_stream_from_info(info.clone(), secret_32, pubkey_32)
+                let handle = self
+                    .client
+                    .open_stream_from_info(info.clone(), secret_32, pubkey_32)
                     .await
                     .map_err(|e| MountError::Io(format!("open stream: {e}")))?;
 
@@ -267,7 +309,9 @@ impl Mount for GenericServiceMount {
                     "streamId": info.stream_id,
                     "topic": topic,
                 });
-                serde_json::to_string(&result).unwrap_or_default().into_bytes()
+                serde_json::to_string(&result)
+                    .unwrap_or_default()
+                    .into_bytes()
             }
         };
         let len = resp.len() as u32;
@@ -276,7 +320,8 @@ impl Mount for GenericServiceMount {
     }
 
     async fn readdir(&self, fid: &Fid, _caller: &Subject) -> Result<Vec<DirEntry>, MountError> {
-        let state = fid.downcast_ref::<VfsFidState>()
+        let state = fid
+            .downcast_ref::<VfsFidState>()
             .ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
 
         if state.path.is_empty() {
@@ -298,7 +343,8 @@ impl Mount for GenericServiceMount {
     }
 
     async fn stat(&self, fid: &Fid, _caller: &Subject) -> Result<Stat, MountError> {
-        let state = fid.downcast_ref::<VfsFidState>()
+        let state = fid
+            .downcast_ref::<VfsFidState>()
             .ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
         let (svc_name, _) = self.service.metadata();
         let name = state.path.last().map(|s| s.as_str()).unwrap_or(svc_name);
@@ -319,13 +365,19 @@ impl Mount for GenericServiceMount {
 
 pub struct DocMount {
     render: fn(&[&str]) -> Option<String>,
-    metadata: fn() -> (&'static str, &'static [hyprstream_rpc::metadata::MethodMeta]),
+    metadata: fn() -> (
+        &'static str,
+        &'static [hyprstream_rpc::metadata::MethodMeta],
+    ),
 }
 
 impl DocMount {
     pub fn new(
         render: fn(&[&str]) -> Option<String>,
-        metadata: fn() -> (&'static str, &'static [hyprstream_rpc::metadata::MethodMeta]),
+        metadata: fn() -> (
+            &'static str,
+            &'static [hyprstream_rpc::metadata::MethodMeta],
+        ),
     ) -> Self {
         Self { render, metadata }
     }
@@ -348,8 +400,15 @@ impl Mount for DocMount {
         Ok(())
     }
 
-    async fn read(&self, fid: &Fid, offset: u64, count: u32, _caller: &Subject) -> Result<Vec<u8>, MountError> {
-        let state = fid.downcast_ref::<VfsFidState>()
+    async fn read(
+        &self,
+        fid: &Fid,
+        offset: u64,
+        count: u32,
+        _caller: &Subject,
+    ) -> Result<Vec<u8>, MountError> {
+        let state = fid
+            .downcast_ref::<VfsFidState>()
             .ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
 
         let path_refs: Vec<&str> = state.path.iter().map(|s| s.as_str()).collect();
@@ -362,12 +421,19 @@ impl Mount for DocMount {
         }
     }
 
-    async fn write(&self, _fid: &Fid, _offset: u64, _data: &[u8], _caller: &Subject) -> Result<u32, MountError> {
+    async fn write(
+        &self,
+        _fid: &Fid,
+        _offset: u64,
+        _data: &[u8],
+        _caller: &Subject,
+    ) -> Result<u32, MountError> {
         Err(MountError::NotSupported("docs are read-only".into()))
     }
 
     async fn readdir(&self, fid: &Fid, _caller: &Subject) -> Result<Vec<DirEntry>, MountError> {
-        let state = fid.downcast_ref::<VfsFidState>()
+        let state = fid
+            .downcast_ref::<VfsFidState>()
             .ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
 
         if state.path.is_empty() {
@@ -388,7 +454,8 @@ impl Mount for DocMount {
     }
 
     async fn stat(&self, fid: &Fid, _caller: &Subject) -> Result<Stat, MountError> {
-        let state = fid.downcast_ref::<VfsFidState>()
+        let state = fid
+            .downcast_ref::<VfsFidState>()
             .ok_or_else(|| MountError::InvalidArgument("bad fid".into()))?;
         let name = state.path.last().map(|s| s.as_str()).unwrap_or("doc");
         Ok(Stat::unknown_qid(
@@ -501,10 +568,7 @@ inventory::collect!(MountFactory);
 /// (per-sandbox isolation is by *forking* the namespace, FS-D #365 — not by
 /// re-running this loop).
 #[cfg(not(target_arch = "wasm32"))]
-pub fn mount_all_services(
-    ns: &mut hyprstream_vfs::Namespace,
-    ctx: &MountContext,
-) -> usize {
+pub fn mount_all_services(ns: &mut hyprstream_vfs::Namespace, ctx: &MountContext) -> usize {
     let mut mounted = 0;
     for factory in inventory::iter::<MountFactory> {
         match (factory.construct)(ctx) {
@@ -624,49 +688,85 @@ impl_service_dispatch!(InferenceDispatch, "inference", crate::inference_client);
 pub fn build_browser_namespace(
     registry_client: Arc<dyn RpcClient>,
     model_client: Arc<dyn RpcClient>,
-) -> (hyprstream_vfs::Namespace, Arc<crate::stream_mount::StreamRegistry>) {
+) -> (
+    hyprstream_vfs::Namespace,
+    Arc<crate::stream_mount::StreamRegistry>,
+) {
     let stream_registry = Arc::new(crate::stream_mount::StreamRegistry::new());
     let mut ns = hyprstream_vfs::Namespace::new();
 
     // Service mounts — all use GenericServiceMount with generated dispatch
     let registry_mount: Arc<GenericServiceMount> = Arc::new(GenericServiceMount::new(
-        Arc::clone(&registry_client), Box::new(RegistryDispatch), Arc::clone(&stream_registry),
+        Arc::clone(&registry_client),
+        Box::new(RegistryDispatch),
+        Arc::clone(&stream_registry),
     ));
-    ns.mount("/srv/registry", registry_mount.clone()).expect("mount /srv/registry");
+    ns.mount("/srv/registry", registry_mount.clone())
+        .expect("mount /srv/registry");
     // `/worktree` aliases `/srv/registry` for path-shape parity with the
     // native namespace (see `hyprstream_vfs::STANDARD_NAMESPACE_PATHS`).
     ns.bind_mount("/worktree", registry_mount, hyprstream_vfs::BindFlag::After)
         .expect("bind mount /worktree");
-    ns.mount("/srv/model", Arc::new(GenericServiceMount::new(
-        Arc::clone(&model_client), Box::new(ModelDispatch), Arc::clone(&stream_registry),
-    ))).expect("mount /srv/model");
+    ns.mount(
+        "/srv/model",
+        Arc::new(GenericServiceMount::new(
+            Arc::clone(&model_client),
+            Box::new(ModelDispatch),
+            Arc::clone(&stream_registry),
+        )),
+    )
+    .expect("mount /srv/model");
 
     // Documentation mounts — generated at compile time from schema annotations
-    ns.mount("/srv/registry/doc", Arc::new(DocMount::new(
-        crate::registry_client::render_doc,
-        crate::registry_client::schema_metadata,
-    ))).expect("mount /srv/registry/doc");
-    ns.mount("/srv/model/doc", Arc::new(DocMount::new(
-        crate::model_client::render_doc,
-        crate::model_client::schema_metadata,
-    ))).expect("mount /srv/model/doc");
-    ns.mount("/srv/inference/doc", Arc::new(DocMount::new(
-        crate::inference_client::render_doc,
-        crate::inference_client::schema_metadata,
-    ))).expect("mount /srv/inference/doc");
-    ns.mount("/srv/policy/doc", Arc::new(DocMount::new(
-        crate::policy_client::render_doc,
-        crate::policy_client::schema_metadata,
-    ))).expect("mount /srv/policy/doc");
-    ns.mount("/srv/mcp/doc", Arc::new(DocMount::new(
-        crate::mcp_client::render_doc,
-        crate::mcp_client::schema_metadata,
-    ))).expect("mount /srv/mcp/doc");
+    ns.mount(
+        "/srv/registry/doc",
+        Arc::new(DocMount::new(
+            crate::registry_client::render_doc,
+            crate::registry_client::schema_metadata,
+        )),
+    )
+    .expect("mount /srv/registry/doc");
+    ns.mount(
+        "/srv/model/doc",
+        Arc::new(DocMount::new(
+            crate::model_client::render_doc,
+            crate::model_client::schema_metadata,
+        )),
+    )
+    .expect("mount /srv/model/doc");
+    ns.mount(
+        "/srv/inference/doc",
+        Arc::new(DocMount::new(
+            crate::inference_client::render_doc,
+            crate::inference_client::schema_metadata,
+        )),
+    )
+    .expect("mount /srv/inference/doc");
+    ns.mount(
+        "/srv/policy/doc",
+        Arc::new(DocMount::new(
+            crate::policy_client::render_doc,
+            crate::policy_client::schema_metadata,
+        )),
+    )
+    .expect("mount /srv/policy/doc");
+    ns.mount(
+        "/srv/mcp/doc",
+        Arc::new(DocMount::new(
+            crate::mcp_client::render_doc,
+            crate::mcp_client::schema_metadata,
+        )),
+    )
+    .expect("mount /srv/mcp/doc");
 
     // Stream mount — named pipes for active streaming data
-    ns.mount("/stream", Arc::new(crate::stream_mount::StreamMount::new(
-        Arc::clone(&stream_registry),
-    ))).expect("mount /stream");
+    ns.mount(
+        "/stream",
+        Arc::new(crate::stream_mount::StreamMount::new(Arc::clone(
+            &stream_registry,
+        ))),
+    )
+    .expect("mount /stream");
 
     // `/wanix` is NOT mounted here: it needs a Wanix-provided SharedArrayBuffer
     // that the browser only has when running under Wanix. Wire it separately
@@ -757,6 +857,13 @@ mod automount_tests {
         async fn call(&self, _payload: Vec<u8>) -> anyhow::Result<Vec<u8>> {
             anyhow::bail!("NoopClient: no transport")
         }
+        async fn call_for_service(
+            &self,
+            _service_domain: &str,
+            _payload: Vec<u8>,
+        ) -> anyhow::Result<Vec<u8>> {
+            anyhow::bail!("NoopClient: no transport")
+        }
         async fn call_with_options(
             &self,
             _payload: Vec<u8>,
@@ -764,8 +871,24 @@ mod automount_tests {
         ) -> anyhow::Result<Vec<u8>> {
             anyhow::bail!("NoopClient: no transport")
         }
+        async fn call_with_options_for_service(
+            &self,
+            _service_domain: &str,
+            _payload: Vec<u8>,
+            _options: CallOptions,
+        ) -> anyhow::Result<Vec<u8>> {
+            anyhow::bail!("NoopClient: no transport")
+        }
         async fn call_streaming(
             &self,
+            _payload: Vec<u8>,
+            _ephemeral_pubkey: [u8; 32],
+        ) -> anyhow::Result<Vec<u8>> {
+            anyhow::bail!("NoopClient: no transport")
+        }
+        async fn call_streaming_for_service(
+            &self,
+            _service_domain: &str,
             _payload: Vec<u8>,
             _ephemeral_pubkey: [u8; 32],
         ) -> anyhow::Result<Vec<u8>> {
@@ -817,7 +940,10 @@ mod automount_tests {
 
         // The auto-mount landed at /srv/{name}.
         let prefixes = ns.mount_prefixes();
-        assert!(prefixes.contains(&"/srv/registry"), "prefixes: {prefixes:?}");
+        assert!(
+            prefixes.contains(&"/srv/registry"),
+            "prefixes: {prefixes:?}"
+        );
         assert!(prefixes.contains(&"/srv/model"), "prefixes: {prefixes:?}");
 
         // End-to-end through the auto-registered mount: walk the mount root and

--- a/crates/hyprstream-rpc/schema/common.capnp
+++ b/crates/hyprstream-rpc/schema/common.capnp
@@ -56,6 +56,7 @@ struct RequestEnvelope {
   wth @6 :Data $fixedSize(32) $optional;  # SHA-256 of jwtToken (WIT binding)
   clientDhPublic @7 :Data $fixedSize(32) $optional;  # LEGACY classical DH pubkey (removed at S5 #556; superseded by clientKemPublic)
   clientKemPublic @8 :Data $optional;  # S3 #554: client ephemeral hybrid-KEM RecipientPublic.encode() (X25519+ML-KEM-768) for PQ stream key agreement
+  responseKemRecipient @9 :Data $optional;  # #1044: fresh per-call HyKEM recipient for the unary response (distinct from stream KEM material)
 }
 
 # Signed wrapper - signature covers serialized RequestEnvelope bytes
@@ -109,6 +110,13 @@ struct ResponseEnvelope {
   # The ML-DSA-65 verifying key is NOT carried here; it is resolved by kid from
   # the trust store (kid-anchored), fixing the prior self-certification gap.
   cose @4 :Data;                   # CBOR-encoded nested COSE composite signature
+  encryptedResponse @5 :Data;      # #1044: HyKEM COSE_Encrypt0 of ResponsePlaintext; payload MUST be empty when present
+}
+
+# Authenticated plaintext carried only inside ResponseEnvelope.encryptedResponse.
+struct ResponsePlaintext {
+  requestId @0 :UInt64;
+  payload @1 :Data;
 }
 
 # Authorization subject — bare username or "anonymous".

--- a/crates/hyprstream-rpc/schema/common.capnp
+++ b/crates/hyprstream-rpc/schema/common.capnp
@@ -57,6 +57,7 @@ struct RequestEnvelope {
   clientDhPublic @7 :Data $fixedSize(32) $optional;  # LEGACY classical DH pubkey (removed at S5 #556; superseded by clientKemPublic)
   clientKemPublic @8 :Data $optional;  # S3 #554: client ephemeral hybrid-KEM RecipientPublic.encode() (X25519+ML-KEM-768) for PQ stream key agreement
   responseKemRecipient @9 :Data $optional;  # #1044: fresh per-call HyKEM recipient for the unary response (distinct from stream KEM material)
+  serviceDomain @10 :Text $optional;  # #1044: canonical destination service, authenticated inside the sealed request
 }
 
 # Signed wrapper - signature covers serialized RequestEnvelope bytes

--- a/crates/hyprstream-rpc/src/dial.rs
+++ b/crates/hyprstream-rpc/src/dial.rs
@@ -138,6 +138,30 @@ pub fn dial_with_kem_store<S>(
 where
     S: Signer + 'static,
 {
+    dial_with_crypto_stores(
+        target,
+        signer,
+        server_verifying_key,
+        token,
+        request_kem_store,
+        None,
+    )
+}
+
+/// Dial with both request-confidentiality and response-authentication anchors.
+/// Network response confidentiality requires both stores; absence remains a
+/// fail-closed runtime error at the shared client chokepoint.
+pub fn dial_with_crypto_stores<S>(
+    target: &TransportConfig,
+    signer: S,
+    server_verifying_key: Option<VerifyingKey>,
+    token: Option<String>,
+    request_kem_store: Option<Arc<dyn KemTrustStore>>,
+    response_pq_store: Option<Arc<dyn crate::envelope::PqTrustStore>>,
+) -> Result<Arc<dyn RpcClient>>
+where
+    S: Signer + 'static,
+{
     /// Wrap a built transport as an `RpcClient`, applying the optional default
     /// JWT (CA-signed trust cert included in request envelopes) if present.
     fn build_client<S2, T2>(
@@ -146,6 +170,7 @@ where
         vk: Option<VerifyingKey>,
         token: Option<String>,
         request_kem_store: Option<Arc<dyn KemTrustStore>>,
+        response_pq_store: Option<Arc<dyn crate::envelope::PqTrustStore>>,
     ) -> Arc<dyn RpcClient>
     where
         S2: Signer + 'static,
@@ -154,6 +179,10 @@ where
         let rpc = RpcClientImpl::new(signer, transport, vk);
         let rpc = match request_kem_store {
             Some(store) => rpc.with_request_kem_store(store),
+            None => rpc,
+        };
+        let rpc = match response_pq_store {
+            Some(store) => rpc.with_response_pq_store(store),
             None => rpc,
         };
         let rpc = match token {
@@ -172,9 +201,20 @@ where
                 anyhow!("no in-process service registered for inproc endpoint '{endpoint}'")
             })?;
             let transport = InMemoryTransport::new(processor);
-            Ok(build_client(signer, transport, server_verifying_key, token, request_kem_store))
+            Ok(build_client(
+                signer,
+                transport,
+                server_verifying_key,
+                token,
+                request_kem_store,
+                response_pq_store,
+            ))
         }
-        EndpointType::Quic { addr, server_name, auth } => {
+        EndpointType::Quic {
+            addr,
+            server_name,
+            auth,
+        } => {
             // SECURITY (#185): QUIC channel auth (WebPKI / cert-hash pin) binds the
             // *channel*, not the peer's DID identity. Identity is established at the
             // application layer — the response signature is verified against the
@@ -193,11 +233,20 @@ where
                 server_name.clone(),
                 auth.clone(),
             );
-            Ok(build_client(signer, transport, server_verifying_key, token, request_kem_store))
+            Ok(build_client(
+                signer,
+                transport,
+                server_verifying_key,
+                token,
+                request_kem_store,
+                response_pq_store,
+            ))
         }
-        EndpointType::Iroh { direct_addrs, relay_url, .. }
-            if direct_addrs.is_empty() && relay_url.is_none() =>
-        {
+        EndpointType::Iroh {
+            direct_addrs,
+            relay_url,
+            ..
+        } if direct_addrs.is_empty() && relay_url.is_none() => {
             // Fail fast rather than hand iroh an EndpointId with no reachability,
             // which would fall through to discovery and time out (~10-30s). The
             // resolver is expected to supply at least one direct addr or a relay.
@@ -206,7 +255,11 @@ where
                  not dialable; the resolver must supply reachability"
             )
         }
-        EndpointType::Iroh { node_id, direct_addrs, relay_url } => {
+        EndpointType::Iroh {
+            node_id,
+            direct_addrs,
+            relay_url,
+        } => {
             let response_key = server_verifying_key.ok_or_else(|| {
                 anyhow!(
                     "dial(): iroh reach has no independently resolved application response key; \
@@ -224,6 +277,7 @@ where
                 Some(response_key),
                 token,
                 request_kem_store,
+                response_pq_store,
             ))
         }
         // Same-host `ipc` plane: connect a UdsSession (RPC plane) at the socket
@@ -235,11 +289,25 @@ where
         // + SO_PEERCRED are daemon-owned defense-in-depth (#207).
         EndpointType::Ipc { path } => {
             let transport = crate::transport::lazy_uds::LazyUdsTransport::new(path.clone());
-            Ok(build_client(signer, transport, server_verifying_key, token, request_kem_store))
+            Ok(build_client(
+                signer,
+                transport,
+                server_verifying_key,
+                token,
+                request_kem_store,
+                response_pq_store,
+            ))
         }
         EndpointType::SystemdFd { client_path, .. } => {
             let transport = crate::transport::lazy_uds::LazyUdsTransport::new(client_path.clone());
-            Ok(build_client(signer, transport, server_verifying_key, token, request_kem_store))
+            Ok(build_client(
+                signer,
+                transport,
+                server_verifying_key,
+                token,
+                request_kem_store,
+                response_pq_store,
+            ))
         }
     }
 }
@@ -297,14 +365,16 @@ impl MoqStreamSession {
 /// / `SystemdFd` are same-host endpoints resolved from LOCAL config — never from
 /// a wire-published reach — so they are rejected: a co-located client must use
 /// the same-host UDS fast path instead of dialing.
-pub async fn dial_stream(
-    target: &TransportConfig,
-) -> Result<MoqStreamSession> {
+pub async fn dial_stream(target: &TransportConfig) -> Result<MoqStreamSession> {
     use crate::transport::quinn_transport::{
         connect_pinned_hashes_path, connect_webpki_path, verify_peer_cert_pinned,
     };
     match &target.endpoint {
-        EndpointType::Quic { addr, server_name, auth } => {
+        EndpointType::Quic {
+            addr,
+            server_name,
+            auth,
+        } => {
             let pins = auth.accept_cert_hashes();
             let session = if auth.require_web_pki() {
                 // WebPKI (optionally + pin): validate via system roots + SNI.
@@ -323,7 +393,11 @@ pub async fn dial_stream(
             };
             Ok(MoqStreamSession::Quinn(session))
         }
-        EndpointType::Iroh { node_id, direct_addrs, relay_url } => {
+        EndpointType::Iroh {
+            node_id,
+            direct_addrs,
+            relay_url,
+        } => {
             // #357: dial-by-node_id-alone is now supported — when no direct addrs
             // or relay are supplied, the shared client endpoint's pkarr / n0 DNS
             // discovery (`presets::N0`) resolves the routable addresses from the
@@ -342,9 +416,7 @@ pub async fn dial_stream(
             let session = dial_iroh_moq(node_id, direct_addrs, relay_url).await?;
             Ok(MoqStreamSession::Iroh(session))
         }
-        EndpointType::Ipc { .. }
-        | EndpointType::SystemdFd { .. }
-        | EndpointType::Inproc { .. } => {
+        EndpointType::Ipc { .. } | EndpointType::SystemdFd { .. } | EndpointType::Inproc { .. } => {
             bail!(
                 "dial_stream(): same-host endpoint ({:?}) is resolved from local \
                  config, not dialed from the wire — use the UDS fast path",
@@ -392,10 +464,15 @@ async fn dial_iroh_moq_from_endpoint(
     use iroh::{EndpointAddr, EndpointId, TransportAddr};
 
     let id = EndpointId::from_bytes(node_id).map_err(|e| anyhow!("invalid iroh node_id: {e}"))?;
-    let mut transport_addrs: Vec<TransportAddr> =
-        direct_addrs.iter().copied().map(TransportAddr::Ip).collect();
+    let mut transport_addrs: Vec<TransportAddr> = direct_addrs
+        .iter()
+        .copied()
+        .map(TransportAddr::Ip)
+        .collect();
     if let Some(url) = relay_url {
-        let relay = url.parse().map_err(|e| anyhow!("invalid iroh relay_url '{url}': {e}"))?;
+        let relay = url
+            .parse()
+            .map_err(|e| anyhow!("invalid iroh relay_url '{url}': {e}"))?;
         transport_addrs.push(TransportAddr::Relay(relay));
     }
     let addr = EndpointAddr::from_parts(id, transport_addrs);
@@ -412,9 +489,9 @@ async fn dial_iroh_moq_from_endpoint(
 mod tests {
     use super::*;
     use crate::crypto::SigningKey;
-    use crate::transport::QuicServerAuth;
     use crate::signer::LocalSigner;
     use crate::transport::rpc_session::from_fn;
+    use crate::transport::QuicServerAuth;
     use bytes::Bytes;
     use rand::rngs::OsRng;
 
@@ -446,7 +523,10 @@ mod tests {
         // Service shuts down: drop the only strong ref. The Weak in the
         // registry is now dead and must not resolve (and is pruned).
         drop(proc);
-        assert!(lookup_inproc(name).is_none(), "dead-service entry must not resolve");
+        assert!(
+            lookup_inproc(name).is_none(),
+            "dead-service entry must not resolve"
+        );
     }
 
     #[test]
@@ -457,7 +537,10 @@ mod tests {
 
         let cfg = TransportConfig::inproc(name);
         let client = dial(&cfg, test_signer(), None, None);
-        assert!(client.is_ok(), "dialing a registered inproc endpoint must succeed");
+        assert!(
+            client.is_ok(),
+            "dialing a registered inproc endpoint must succeed"
+        );
 
         unregister_inproc(name);
     }
@@ -466,7 +549,10 @@ mod tests {
     fn dial_inproc_unregistered_errors() {
         let cfg = TransportConfig::inproc("test/dial/never_registered");
         let err = dial(&cfg, test_signer(), None, None);
-        assert!(err.is_err(), "dialing an unregistered inproc endpoint must error");
+        assert!(
+            err.is_err(),
+            "dialing an unregistered inproc endpoint must error"
+        );
     }
 
     #[test]
@@ -475,7 +561,10 @@ mod tests {
         // first send (the socket need not exist yet at dial() time).
         let cfg = TransportConfig::ipc("/tmp/hyprstream-test-dial.sock");
         let client = dial(&cfg, test_signer(), None, None);
-        assert!(client.is_ok(), "ipc dial must build a lazy client without connecting");
+        assert!(
+            client.is_ok(),
+            "ipc dial must build a lazy client without connecting"
+        );
     }
 
     #[test]
@@ -483,7 +572,10 @@ mod tests {
         // systemd socket-activation: client dials the client_path via UDS.
         let cfg = TransportConfig::systemd_fd(7, "/tmp/hyprstream-test-systemd.sock");
         let client = dial(&cfg, test_signer(), None, None);
-        assert!(client.is_ok(), "systemd-fd dial must build a lazy client via client_path");
+        assert!(
+            client.is_ok(),
+            "systemd-fd dial must build a lazy client via client_path"
+        );
     }
 
     #[test]
@@ -492,15 +584,22 @@ mod tests {
         // builds a (lazy, not-yet-connected) client.
         let cfg = TransportConfig::quic("127.0.0.1:9999".parse().unwrap(), "localhost");
         let client = dial(&cfg, test_signer(), None, None);
-        assert!(client.is_ok(), "WebPKI QUIC dial must build a client without connecting");
+        assert!(
+            client.is_ok(),
+            "WebPKI QUIC dial must build a client without connecting"
+        );
     }
 
     #[test]
     fn dial_quic_pinned_builds_client() {
         // Cert-hash-pinned QUIC: builds a lazy client — sync, no I/O.
-        let cfg = TransportConfig::quic_pinned("127.0.0.1:9999".parse().unwrap(), "localhost", [7u8; 32]);
+        let cfg =
+            TransportConfig::quic_pinned("127.0.0.1:9999".parse().unwrap(), "localhost", [7u8; 32]);
         let client = dial(&cfg, test_signer(), None, None);
-        assert!(client.is_ok(), "pinned QUIC dial must build a client without connecting");
+        assert!(
+            client.is_ok(),
+            "pinned QUIC dial must build a client without connecting"
+        );
     }
 
     #[test]
@@ -520,8 +619,14 @@ mod tests {
 
     #[test]
     fn quic_server_auth_rejects_no_requirement() {
-        assert!(QuicServerAuth::pinned(vec![]).is_err(), "empty pin set is no auth");
-        assert!(QuicServerAuth::web_pki_pinned(vec![]).is_err(), "empty pin set is no auth");
+        assert!(
+            QuicServerAuth::pinned(vec![]).is_err(),
+            "empty pin set is no auth"
+        );
+        assert!(
+            QuicServerAuth::web_pki_pinned(vec![]).is_err(),
+            "empty pin set is no auth"
+        );
         assert!(QuicServerAuth::web_pki().require_web_pki());
     }
 
@@ -538,7 +643,8 @@ mod tests {
             Err(e) => e,
         };
         assert!(
-            err.to_string().contains("no iroh client endpoint installed"),
+            err.to_string()
+                .contains("no iroh client endpoint installed"),
             "expected an install-endpoint error (node_id-alone is dialable once an \
              endpoint is installed); got: {err}"
         );

--- a/crates/hyprstream-rpc/src/dial_wasm.rs
+++ b/crates/hyprstream-rpc/src/dial_wasm.rs
@@ -109,10 +109,38 @@ pub async fn dial_with_kem_store(
     jwt: Option<String>,
     request_kem_store: Option<Arc<dyn KemTrustStore>>,
 ) -> Result<Arc<dyn RpcClient>> {
+    dial_with_crypto_stores(
+        url,
+        cert_hash,
+        signer,
+        server_verifying_key,
+        jwt,
+        request_kem_store,
+        None,
+    )
+    .await
+}
+
+/// WebTransport dial seam provisioning both request KEM and response hybrid
+/// signature anchors. The shared client then applies the same response
+/// carrier-check → verify → HyKEM-open ordering as native clients.
+pub async fn dial_with_crypto_stores(
+    url: &str,
+    cert_hash: Option<&str>,
+    signer: JsSigner,
+    server_verifying_key: Option<VerifyingKey>,
+    jwt: Option<String>,
+    request_kem_store: Option<Arc<dyn KemTrustStore>>,
+    response_pq_store: Option<Arc<dyn crate::envelope::PqTrustStore>>,
+) -> Result<Arc<dyn RpcClient>> {
     let transport = WtConnection::connect(url, cert_hash).await?;
     let client = RpcClientImpl::new(signer, transport, server_verifying_key);
     let client = match request_kem_store {
         Some(store) => client.with_request_kem_store(store),
+        None => client,
+    };
+    let client = match response_pq_store {
+        Some(store) => client.with_response_pq_store(store),
         None => client,
     };
     let client = match jwt {

--- a/crates/hyprstream-rpc/src/envelope.rs
+++ b/crates/hyprstream-rpc/src/envelope.rs
@@ -632,6 +632,11 @@ pub struct RequestEnvelope {
     /// Present on streaming requests; the server uses this with its own
     /// ephemeral keypair to derive the shared secret for HMAC chain keys.
     pub client_dh_public: Option<[u8; 32]>,
+
+    /// Fresh per-call hybrid-KEM recipient for the unary response. This is
+    /// distinct from both legacy `client_dh_public` and stream-plane
+    /// `clientKemPublic`, and is carried only inside a sealed network request.
+    pub response_kem_recipient: Option<crate::crypto::hybrid_kem::RecipientPublic>,
 }
 
 impl RequestEnvelope {
@@ -646,6 +651,7 @@ impl RequestEnvelope {
             delegation_token: None,
             wth: None,
             client_dh_public: None,
+            response_kem_recipient: None,
         }
     }
 
@@ -678,6 +684,15 @@ impl RequestEnvelope {
     /// Set the client's ephemeral DH public key for stream key derivation.
     pub fn with_client_dh_public(mut self, key: [u8; 32]) -> Self {
         self.client_dh_public = Some(key);
+        self
+    }
+
+    /// Set the one-shot HyKEM recipient for the corresponding unary response.
+    pub fn with_response_kem_recipient(
+        mut self,
+        recipient: crate::crypto::hybrid_kem::RecipientPublic,
+    ) -> Self {
+        self.response_kem_recipient = Some(recipient);
         self
     }
 
@@ -918,6 +933,37 @@ pub(crate) fn seal_request_envelope(
 /// response cannot verify against the request AAD, and vice-versa.
 fn response_envelope_external_aad() -> Vec<u8> {
     crate::crypto::cose_sign1::build_external_aad(ENVELOPE_SCHEMA_ID, RESPONSE_ENVELOPE_TYPE_ID)
+}
+
+const MAX_RESPONSE_KEM_RECIPIENT_BYTES: usize = 2 * 1024;
+const MAX_ENCRYPTED_RESPONSE_BYTES: usize = 1024 * 1024;
+
+/// Transcript-bound external AAD for the response HyKEM COSE_Encrypt0.
+pub(crate) fn encrypted_response_external_aad(
+    request_id: u64,
+    request_iat: i64,
+    request_nonce: &[u8; 16],
+    server_identity: &[u8; 32],
+    recipient: &crate::crypto::hybrid_kem::RecipientPublic,
+) -> EnvelopeResult<Vec<u8>> {
+    use ciborium::value::Value as CborValue;
+    use sha2::{Digest, Sha256};
+
+    let recipient_hash = Sha256::digest(recipient.encode());
+    let value = CborValue::Array(vec![
+        CborValue::Integer(ENVELOPE_SCHEMA_ID.into()),
+        CborValue::Integer(RESPONSE_ENVELOPE_TYPE_ID.into()),
+        CborValue::Text("hykem-rpc-response-v1".to_owned()),
+        CborValue::Integer(request_id.into()),
+        CborValue::Integer(request_iat.into()),
+        CborValue::Bytes(request_nonce.to_vec()),
+        CborValue::Bytes(server_identity.to_vec()),
+        CborValue::Bytes(recipient_hash.to_vec()),
+    ]);
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&value, &mut buf)
+        .map_err(|e| EnvelopeError::Encryption(format!("encode response HyKEM AAD: {e}")))?;
+    Ok(buf)
 }
 
 /// Resolves the anchored ML-DSA-65 verifying key for an EdDSA signer identity.
@@ -1524,6 +1570,7 @@ impl SignedEnvelope {
             delegation_token: None,
             wth: None,
             client_dh_public: None,
+            response_kem_recipient: None,
         }
     }
 
@@ -1935,6 +1982,9 @@ impl ToCapnp for RequestEnvelope {
         if let Some(ref key) = self.client_dh_public {
             builder.set_client_dh_public(key);
         }
+        if let Some(ref recipient) = self.response_kem_recipient {
+            builder.set_response_kem_recipient(&recipient.encode());
+        }
     }
 }
 
@@ -2002,6 +2052,24 @@ impl FromCapnp for RequestEnvelope {
             }
         };
 
+        let response_kem_recipient = {
+            let data = reader.get_response_kem_recipient()?;
+            if data.is_empty() {
+                None
+            } else {
+                if data.len() > MAX_RESPONSE_KEM_RECIPIENT_BYTES {
+                    return Err(anyhow!(
+                        "responseKemRecipient exceeds {} byte limit",
+                        MAX_RESPONSE_KEM_RECIPIENT_BYTES
+                    ));
+                }
+                Some(
+                    crate::crypto::hybrid_kem::RecipientPublic::decode(data)
+                        .map_err(|e| anyhow!("invalid responseKemRecipient: {e}"))?,
+                )
+            }
+        };
+
         Ok(Self {
             request_id: reader.get_request_id(),
             payload: reader.get_payload()?.to_vec(),
@@ -2011,6 +2079,7 @@ impl FromCapnp for RequestEnvelope {
             delegation_token,
             wth,
             client_dh_public,
+            response_kem_recipient,
         })
     }
 }
@@ -2149,6 +2218,10 @@ pub struct ResponseEnvelope {
     /// Serialized inner response
     pub payload: Vec<u8>,
 
+    /// HyKEM COSE_Encrypt0 carrying a `ResponsePlaintext`. When present the
+    /// outer payload is empty and the hybrid signature covers these bytes.
+    pub encrypted_response: Option<Vec<u8>>,
+
     /// Ed25519 signature (64 bytes) over request_id || payload
     pub sig: [u8; 64],
 
@@ -2242,11 +2315,117 @@ impl ResponseEnvelope {
         Self {
             request_id,
             payload,
+            encrypted_response: None,
             sig,
             cnf,
             cose,
             policy,
         }
+    }
+
+    /// Seal a unary response to the request's one-shot recipient, then
+    /// hybrid-sign the ciphertext in the response signature domain.
+    pub fn new_signed_encrypted(
+        request_id: u64,
+        payload: Vec<u8>,
+        signing_key: &SigningKey,
+        pq_signing_key: &crate::crypto::pq::MlDsaSigningKey,
+        recipient: &crate::crypto::hybrid_kem::RecipientPublic,
+        request_iat: i64,
+        request_nonce: &[u8; 16],
+    ) -> EnvelopeResult<Self> {
+        let mut plaintext = Vec::new();
+        {
+            let mut message = capnp::message::Builder::new_default();
+            let mut builder =
+                message.init_root::<crate::common_capnp::response_plaintext::Builder>();
+            builder.set_request_id(request_id);
+            builder.set_payload(&payload);
+            capnp::serialize::write_message(&mut plaintext, &message).map_err(|e| {
+                EnvelopeError::Encryption(format!("serialize response plaintext: {e}"))
+            })?;
+        }
+        let server_identity = signing_key.verifying_key().to_bytes();
+        let aad = encrypted_response_external_aad(
+            request_id,
+            request_iat,
+            request_nonce,
+            &server_identity,
+            recipient,
+        )?;
+        let ciphertext =
+            crate::crypto::cose_encrypt::seal_to_recipient(recipient, &plaintext, &aad, 0, 0)
+                .map_err(|e| {
+                    EnvelopeError::Encryption(format!("response HyKEM seal failed: {e}"))
+                })?;
+        if ciphertext.len() > MAX_ENCRYPTED_RESPONSE_BYTES {
+            return Err(EnvelopeError::Encryption(
+                "encrypted response exceeds envelope limit".into(),
+            ));
+        }
+        let signing_data = Self::signing_data(request_id, &ciphertext);
+        let signature_obj = signing_key.sign(&signing_data);
+        let cose = Self::build_cose(
+            signing_key,
+            Some(pq_signing_key),
+            crate::crypto::CryptoPolicy::Hybrid,
+            &signing_data,
+        )
+        .map_err(|e| EnvelopeError::Encryption(format!("sign sealed response: {e}")))?;
+        Ok(Self {
+            request_id,
+            payload: Vec::new(),
+            encrypted_response: Some(ciphertext),
+            sig: signature_obj.to_bytes(),
+            cnf: server_identity,
+            cose,
+            policy: crate::crypto::CryptoPolicy::Hybrid,
+        })
+    }
+
+    /// Open a previously verified sealed response with the client's one-shot
+    /// recipient and the transcript retained by the pending call.
+    pub(crate) fn open_encrypted(
+        &self,
+        recipient_keypair: &crate::crypto::hybrid_kem::RecipientKeypair,
+        recipient_public: &crate::crypto::hybrid_kem::RecipientPublic,
+        request_iat: i64,
+        request_nonce: &[u8; 16],
+        expected_server_identity: &[u8; 32],
+    ) -> Result<Vec<u8>> {
+        let ciphertext = self
+            .encrypted_response
+            .as_deref()
+            .ok_or_else(|| anyhow!("cleartext response rejected: sealed response required"))?;
+        if &self.cnf != expected_server_identity {
+            anyhow::bail!("sealed response server identity does not match pending call");
+        }
+        let aad = encrypted_response_external_aad(
+            self.request_id,
+            request_iat,
+            request_nonce,
+            expected_server_identity,
+            recipient_public,
+        )?;
+        let plaintext = crate::crypto::cose_encrypt::open_from_recipient(
+            recipient_keypair,
+            ciphertext,
+            &aad,
+            0,
+            0,
+        )
+        .map_err(|e| anyhow!("response HyKEM open failed: {e}"))?;
+        let reader = read_exact_envelope_message(&plaintext)?;
+        let inner = reader.get_root::<crate::common_capnp::response_plaintext::Reader>()?;
+        let inner_request_id = inner.get_request_id();
+        if inner_request_id != self.request_id {
+            anyhow::bail!(
+                "inner/outer response request id mismatch: {} != {}",
+                inner_request_id,
+                self.request_id
+            );
+        }
+        Ok(inner.get_payload()?.to_vec())
     }
 
     /// Build the nested COSE composite over the response signing-data per policy.
@@ -2321,7 +2500,8 @@ impl ResponseEnvelope {
         pq_store: Option<&dyn PqTrustStore>,
         verify_policy: crate::crypto::CryptoPolicy,
     ) -> Result<()> {
-        let signing_data = Self::signing_data(self.request_id, &self.payload);
+        let signing_bytes = self.encrypted_response.as_deref().unwrap_or(&self.payload);
+        let signing_data = Self::signing_data(self.request_id, signing_bytes);
         let aad = response_envelope_external_aad();
 
         // kid-anchor: resolve the trusted ML-DSA-65 key for this EdDSA identity.
@@ -2371,6 +2551,9 @@ impl ToCapnp for ResponseEnvelope {
     fn write_to(&self, builder: &mut Self::Builder<'_>) {
         builder.set_request_id(self.request_id);
         builder.set_payload(&self.payload);
+        if let Some(ref ciphertext) = self.encrypted_response {
+            builder.set_encrypted_response(ciphertext);
+        }
         builder.set_sig(&self.sig);
         builder.set_cnf(&self.cnf);
         builder.set_cose(&self.cose);
@@ -2396,12 +2579,30 @@ impl FromCapnp for ResponseEnvelope {
         cnf.copy_from_slice(cnf_data);
 
         let cose = reader.get_cose()?.to_vec();
+        let encrypted_data = reader.get_encrypted_response()?;
+        let payload_data = reader.get_payload()?;
+        if !encrypted_data.is_empty() && !payload_data.is_empty() {
+            anyhow::bail!("encrypted response carries a non-empty cleartext payload");
+        }
+        let payload = payload_data.to_vec();
+        let encrypted_response = {
+            let data = encrypted_data;
+            if data.is_empty() {
+                None
+            } else {
+                if data.len() > MAX_ENCRYPTED_RESPONSE_BYTES {
+                    anyhow::bail!("encryptedResponse exceeds envelope limit");
+                }
+                Some(data.to_vec())
+            }
+        };
 
         // `policy` is a signing-time concept; the verifier supplies the verify
         // policy explicitly, so decode to the default here (mirrors SignedEnvelope).
         Ok(Self {
             request_id: reader.get_request_id(),
-            payload: reader.get_payload()?.to_vec(),
+            payload,
+            encrypted_response,
             sig,
             cnf,
             cose,
@@ -2550,15 +2751,26 @@ pub fn unwrap_response_with(
     pq_store: Option<&dyn PqTrustStore>,
     verify_policy: crate::crypto::CryptoPolicy,
 ) -> Result<(u64, Vec<u8>)> {
-    // Deserialize ResponseEnvelope from Cap'n Proto
-    let reader = read_exact_envelope_message(response)?;
-    let response_reader = reader.get_root::<crate::common_capnp::response_envelope::Reader>()?;
-    let envelope = ResponseEnvelope::read_from(response_reader)?;
+    let envelope = read_response_envelope(response, false)?;
 
     // Verify the COSE composite under the supplied policy + anchor.
     envelope.verify_with(expected_pubkey, pq_store, verify_policy)?;
 
     Ok((envelope.request_id, envelope.payload))
+}
+
+/// Bounded response parse with an early encrypted-field gate. When encryption
+/// is required, the cleartext payload is never copied or surfaced.
+pub(crate) fn read_response_envelope(
+    response: &[u8],
+    require_encrypted: bool,
+) -> Result<ResponseEnvelope> {
+    let reader = read_exact_envelope_message(response)?;
+    let response_reader = reader.get_root::<crate::common_capnp::response_envelope::Reader>()?;
+    if require_encrypted && response_reader.get_encrypted_response()?.is_empty() {
+        anyhow::bail!("cleartext response rejected before payload use (INV-2)");
+    }
+    ResponseEnvelope::read_from(response_reader)
 }
 
 #[cfg(test)]
@@ -3017,6 +3229,7 @@ mod tests {
             delegation_token: Some("delegated".to_owned()),
             wth: Some([0xAB; 32]),
             client_dh_public: Some([0xCD; 32]),
+            response_kem_recipient: None,
         };
 
         let mut message = Builder::new_default();
@@ -3058,6 +3271,7 @@ mod tests {
             delegation_token: None,
             wth: None,
             client_dh_public: None,
+            response_kem_recipient: None,
         };
 
         // Seal to the node's #mesh-kem public, dual-signed (EdDSA + ML-DSA-65).
@@ -3118,6 +3332,7 @@ mod tests {
             delegation_token: None,
             wth: None,
             client_dh_public: None,
+            response_kem_recipient: None,
         };
         let signed =
             SignedEnvelope::new_signed_encrypted_mesh_kem(envelope, &node_sk, &pq_sk, &kem_pub)
@@ -3160,6 +3375,7 @@ mod tests {
             delegation_token: None,
             wth: None,
             client_dh_public: None,
+            response_kem_recipient: None,
         };
 
         let mut signed = test_new_signed(envelope, &signing_key);
@@ -3204,6 +3420,7 @@ mod tests {
             delegation_token: None,
             wth: Some([0xAA; 32]),
             client_dh_public: None,
+            response_kem_recipient: None,
         };
 
         let mut signed = test_new_signed(envelope, &signing_key);
@@ -4049,5 +4266,179 @@ mod tests {
             res.is_err(),
             "a request-domain COSE grafted onto a response must be rejected"
         );
+    }
+
+    #[test]
+    fn sealed_response_roundtrip_is_transcript_bound_and_not_plaintext_on_wire() {
+        let (server_sk, server_vk) = generate_signing_keypair();
+        let pq_sk = crate::node_identity::derive_mesh_mldsa_key(&server_sk);
+        let pq_vk = crate::crypto::pq::ml_dsa_vk_from_bytes(
+            &crate::crypto::pq::ml_dsa_sk_to_vk_bytes(&pq_sk),
+        )
+        .unwrap();
+        let store = pq_store_for(server_vk.to_bytes(), &pq_vk);
+        let recipient = crate::crypto::hybrid_kem::generate_recipient(
+            crate::crypto::hybrid_kem::SuiteId::HyKemX25519MlKem768,
+        )
+        .unwrap();
+        let public = recipient.public();
+        let nonce = fresh_test_nonce();
+        let secret_payload = b"response-plaintext-sentinel";
+        let response = ResponseEnvelope::new_signed_encrypted(
+            77,
+            secret_payload.to_vec(),
+            &server_sk,
+            &pq_sk,
+            &public,
+            1234,
+            &nonce,
+        )
+        .unwrap();
+        response
+            .verify_with(Some(&server_vk), Some(&store), CryptoPolicy::Hybrid)
+            .unwrap();
+        let wire = response_to_wire(&response);
+        assert!(!wire
+            .windows(secret_payload.len())
+            .any(|w| w == secret_payload));
+        let opened = response
+            .open_encrypted(&recipient, &public, 1234, &nonce, &server_vk.to_bytes())
+            .unwrap();
+        assert_eq!(opened, secret_payload);
+
+        let wrong_recipient = crate::crypto::hybrid_kem::generate_recipient(
+            crate::crypto::hybrid_kem::SuiteId::HyKemX25519MlKem768,
+        )
+        .unwrap();
+        assert!(response
+            .open_encrypted(
+                &wrong_recipient,
+                &wrong_recipient.public(),
+                1234,
+                &nonce,
+                &server_vk.to_bytes(),
+            )
+            .is_err());
+        assert!(response
+            .open_encrypted(&recipient, &public, 1235, &nonce, &server_vk.to_bytes(),)
+            .is_err());
+        let other_nonce = distinct_test_nonce(&nonce);
+        assert!(response
+            .open_encrypted(
+                &recipient,
+                &public,
+                1234,
+                &other_nonce,
+                &server_vk.to_bytes(),
+            )
+            .is_err());
+        let (other_server, _) = generate_signing_keypair();
+        assert!(response
+            .open_encrypted(
+                &recipient,
+                &public,
+                1234,
+                &nonce,
+                &other_server.verifying_key().to_bytes(),
+            )
+            .is_err());
+    }
+
+    #[test]
+    fn sealed_response_rejects_request_id_substitution_and_validly_signed_garbage() {
+        let (server_sk, server_vk) = generate_signing_keypair();
+        let pq_sk = crate::node_identity::derive_mesh_mldsa_key(&server_sk);
+        let pq_vk = crate::crypto::pq::ml_dsa_vk_from_bytes(
+            &crate::crypto::pq::ml_dsa_sk_to_vk_bytes(&pq_sk),
+        )
+        .unwrap();
+        let store = pq_store_for(server_vk.to_bytes(), &pq_vk);
+        let recipient = crate::crypto::hybrid_kem::generate_recipient(
+            crate::crypto::hybrid_kem::SuiteId::HyKemX25519MlKem768,
+        )
+        .unwrap();
+        let public = recipient.public();
+        let nonce = fresh_test_nonce();
+        let mut response = ResponseEnvelope::new_signed_encrypted(
+            8,
+            b"bound".to_vec(),
+            &server_sk,
+            &pq_sk,
+            &public,
+            99,
+            &nonce,
+        )
+        .unwrap();
+
+        response.request_id = 9;
+        let data = ResponseEnvelope::signing_data(
+            response.request_id,
+            response.encrypted_response.as_deref().unwrap(),
+        );
+        response.sig = server_sk.sign(&data).to_bytes();
+        response.cose =
+            ResponseEnvelope::build_cose(&server_sk, Some(&pq_sk), CryptoPolicy::Hybrid, &data)
+                .unwrap();
+        response
+            .verify_with(Some(&server_vk), Some(&store), CryptoPolicy::Hybrid)
+            .unwrap();
+        assert!(response
+            .open_encrypted(&recipient, &public, 99, &nonce, &server_vk.to_bytes(),)
+            .is_err());
+
+        response.encrypted_response = Some(b"not-a-cose-encrypt0".to_vec());
+        let data =
+            ResponseEnvelope::signing_data(9, response.encrypted_response.as_deref().unwrap());
+        response.sig = server_sk.sign(&data).to_bytes();
+        response.cose =
+            ResponseEnvelope::build_cose(&server_sk, Some(&pq_sk), CryptoPolicy::Hybrid, &data)
+                .unwrap();
+        response
+            .verify_with(Some(&server_vk), Some(&store), CryptoPolicy::Hybrid)
+            .unwrap();
+        assert!(response
+            .open_encrypted(&recipient, &public, 99, &nonce, &server_vk.to_bytes(),)
+            .is_err());
+    }
+
+    #[test]
+    fn cleartext_response_is_refused_by_early_network_gate() {
+        let (sk, _) = generate_signing_keypair();
+        let wire = response_to_wire(&ResponseEnvelope::new_signed(
+            1,
+            b"must-not-surface".to_vec(),
+            &sk,
+        ));
+        assert!(read_response_envelope(&wire, true).is_err());
+    }
+
+    #[test]
+    fn response_recipient_and_ciphertext_sizes_are_bounded() {
+        let mut request_message = capnp::message::Builder::new_default();
+        {
+            let mut builder =
+                request_message.init_root::<crate::common_capnp::request_envelope::Builder>();
+            builder.set_nonce(&fresh_test_nonce());
+            builder.set_response_kem_recipient(&vec![0u8; MAX_RESPONSE_KEM_RECIPIENT_BYTES + 1]);
+        }
+        let request_message_reader = request_message.into_reader();
+        let request_reader = request_message_reader
+            .get_root::<crate::common_capnp::request_envelope::Reader>()
+            .unwrap();
+        assert!(RequestEnvelope::read_from(request_reader).is_err());
+
+        let mut response_message = capnp::message::Builder::new_default();
+        {
+            let mut builder =
+                response_message.init_root::<crate::common_capnp::response_envelope::Builder>();
+            builder.set_sig(&[0u8; 64]);
+            builder.set_cnf(&[0u8; 32]);
+            builder.set_encrypted_response(&vec![0u8; MAX_ENCRYPTED_RESPONSE_BYTES + 1]);
+        }
+        let response_message_reader = response_message.into_reader();
+        let response_reader = response_message_reader
+            .get_root::<crate::common_capnp::response_envelope::Reader>()
+            .unwrap();
+        assert!(ResponseEnvelope::read_from(response_reader).is_err());
     }
 }

--- a/crates/hyprstream-rpc/src/envelope.rs
+++ b/crates/hyprstream-rpc/src/envelope.rs
@@ -637,6 +637,10 @@ pub struct RequestEnvelope {
     /// distinct from both legacy `client_dh_public` and stream-plane
     /// `clientKemPublic`, and is carried only inside a sealed network request.
     pub response_kem_recipient: Option<crate::crypto::hybrid_kem::RecipientPublic>,
+
+    /// Canonical destination service. On untrusted carriers this is required,
+    /// carried only in the signed+sealed request, and checked by dispatch.
+    pub service_domain: Option<String>,
 }
 
 impl RequestEnvelope {
@@ -652,6 +656,7 @@ impl RequestEnvelope {
             wth: None,
             client_dh_public: None,
             response_kem_recipient: None,
+            service_domain: None,
         }
     }
 
@@ -694,6 +699,14 @@ impl RequestEnvelope {
     ) -> Self {
         self.response_kem_recipient = Some(recipient);
         self
+    }
+
+    /// Bind the request to one canonical destination service.
+    pub fn with_service_domain(mut self, service_domain: impl Into<String>) -> Result<Self> {
+        let service_domain = service_domain.into();
+        validate_service_domain(&service_domain)?;
+        self.service_domain = Some(service_domain);
+        Ok(self)
     }
 
     /// Create an envelope for an anonymous request.
@@ -937,6 +950,34 @@ fn response_envelope_external_aad() -> Vec<u8> {
 
 const MAX_RESPONSE_KEM_RECIPIENT_BYTES: usize = 2 * 1024;
 const MAX_ENCRYPTED_RESPONSE_BYTES: usize = 1024 * 1024;
+pub const MAX_SERVICE_DOMAIN_BYTES: usize = 128;
+
+/// Validate the one canonical RPC service/destination identifier.
+///
+/// Domains are compared byte-for-byte and never normalized at a trust
+/// boundary, avoiding aliases between the client and dispatcher.
+pub fn validate_service_domain(service_domain: &str) -> Result<()> {
+    let bytes = service_domain.as_bytes();
+    if bytes.is_empty() || bytes.len() > MAX_SERVICE_DOMAIN_BYTES {
+        anyhow::bail!(
+            "service domain must contain 1..={} bytes",
+            MAX_SERVICE_DOMAIN_BYTES
+        );
+    }
+    if !bytes[0].is_ascii_lowercase() && !bytes[0].is_ascii_digit() {
+        anyhow::bail!("service domain must begin with a lowercase ASCII letter or digit");
+    }
+    if !bytes.iter().all(|byte| {
+        byte.is_ascii_lowercase()
+            || byte.is_ascii_digit()
+            || matches!(byte, b'.' | b'_' | b'-' | b'/')
+    }) {
+        anyhow::bail!(
+            "service domain must use only lowercase ASCII letters, digits, '.', '_', '-', or '/'"
+        );
+    }
+    Ok(())
+}
 
 /// Transcript-bound external AAD for the response HyKEM COSE_Encrypt0.
 pub(crate) fn encrypted_response_external_aad(
@@ -945,6 +986,7 @@ pub(crate) fn encrypted_response_external_aad(
     request_nonce: &[u8; 16],
     server_identity: &[u8; 32],
     recipient: &crate::crypto::hybrid_kem::RecipientPublic,
+    service_domain: &str,
 ) -> EnvelopeResult<Vec<u8>> {
     use ciborium::value::Value as CborValue;
     use sha2::{Digest, Sha256};
@@ -959,6 +1001,7 @@ pub(crate) fn encrypted_response_external_aad(
         CborValue::Bytes(request_nonce.to_vec()),
         CborValue::Bytes(server_identity.to_vec()),
         CborValue::Bytes(recipient_hash.to_vec()),
+        CborValue::Text(service_domain.to_owned()),
     ]);
     let mut buf = Vec::new();
     ciborium::ser::into_writer(&value, &mut buf)
@@ -1571,6 +1614,7 @@ impl SignedEnvelope {
             wth: None,
             client_dh_public: None,
             response_kem_recipient: None,
+            service_domain: None,
         }
     }
 
@@ -1985,6 +2029,9 @@ impl ToCapnp for RequestEnvelope {
         if let Some(ref recipient) = self.response_kem_recipient {
             builder.set_response_kem_recipient(&recipient.encode());
         }
+        if let Some(ref service_domain) = self.service_domain {
+            builder.set_service_domain(service_domain);
+        }
     }
 }
 
@@ -2070,6 +2117,14 @@ impl FromCapnp for RequestEnvelope {
             }
         };
 
+        let service_domain = if reader.has_service_domain() {
+            let value = reader.get_service_domain()?.to_str()?.to_owned();
+            validate_service_domain(&value)?;
+            Some(value)
+        } else {
+            None
+        };
+
         Ok(Self {
             request_id: reader.get_request_id(),
             payload: reader.get_payload()?.to_vec(),
@@ -2080,6 +2135,7 @@ impl FromCapnp for RequestEnvelope {
             wth,
             client_dh_public,
             response_kem_recipient,
+            service_domain,
         })
     }
 }
@@ -2250,6 +2306,24 @@ impl ResponseEnvelope {
         data
     }
 
+    /// Signature transcript for a sealed response. The expected service is
+    /// retained by the pending call rather than trusted from response bytes.
+    fn encrypted_signing_data(
+        request_id: u64,
+        ciphertext: &[u8],
+        service_domain: &str,
+    ) -> EnvelopeResult<Vec<u8>> {
+        validate_service_domain(service_domain)
+            .map_err(|e| EnvelopeError::Encryption(e.to_string()))?;
+        let mut data = Vec::with_capacity(40 + service_domain.len() + ciphertext.len());
+        data.extend_from_slice(b"hykem-rpc-response-signature-v2\0");
+        data.extend_from_slice(&request_id.to_le_bytes());
+        data.extend_from_slice(&(service_domain.len() as u16).to_le_bytes());
+        data.extend_from_slice(service_domain.as_bytes());
+        data.extend_from_slice(ciphertext);
+        Ok(data)
+    }
+
     /// Create and sign a new response envelope (Classical, EdDSA-only).
     ///
     /// The bare constructor defaults to Classical so callers that don't supply a
@@ -2333,7 +2407,10 @@ impl ResponseEnvelope {
         recipient: &crate::crypto::hybrid_kem::RecipientPublic,
         request_iat: i64,
         request_nonce: &[u8; 16],
+        service_domain: &str,
     ) -> EnvelopeResult<Self> {
+        validate_service_domain(service_domain)
+            .map_err(|e| EnvelopeError::Encryption(e.to_string()))?;
         let mut plaintext = Vec::new();
         {
             let mut message = capnp::message::Builder::new_default();
@@ -2352,6 +2429,7 @@ impl ResponseEnvelope {
             request_nonce,
             &server_identity,
             recipient,
+            service_domain,
         )?;
         let ciphertext =
             crate::crypto::cose_encrypt::seal_to_recipient(recipient, &plaintext, &aad, 0, 0)
@@ -2363,7 +2441,7 @@ impl ResponseEnvelope {
                 "encrypted response exceeds envelope limit".into(),
             ));
         }
-        let signing_data = Self::signing_data(request_id, &ciphertext);
+        let signing_data = Self::encrypted_signing_data(request_id, &ciphertext, service_domain)?;
         let signature_obj = signing_key.sign(&signing_data);
         let cose = Self::build_cose(
             signing_key,
@@ -2392,6 +2470,7 @@ impl ResponseEnvelope {
         request_iat: i64,
         request_nonce: &[u8; 16],
         expected_server_identity: &[u8; 32],
+        service_domain: &str,
     ) -> Result<Vec<u8>> {
         let ciphertext = self
             .encrypted_response
@@ -2406,6 +2485,7 @@ impl ResponseEnvelope {
             request_nonce,
             expected_server_identity,
             recipient_public,
+            service_domain,
         )?;
         let plaintext = crate::crypto::cose_encrypt::open_from_recipient(
             recipient_keypair,
@@ -2486,7 +2566,33 @@ impl ResponseEnvelope {
             }
         }
 
-        self.verify_cose(&verifying_key, pq_store, verify_policy)
+        self.verify_cose(&verifying_key, pq_store, verify_policy, None)
+    }
+
+    /// Verify a sealed response against the destination retained by the
+    /// pending call. Generic verification deliberately cannot authenticate an
+    /// encrypted response because it has no expected service domain.
+    pub(crate) fn verify_encrypted_with_service_domain(
+        &self,
+        expected_pubkey: &VerifyingKey,
+        pq_store: &dyn PqTrustStore,
+        service_domain: &str,
+    ) -> Result<()> {
+        validate_service_domain(service_domain)?;
+        if self.encrypted_response.is_none() {
+            anyhow::bail!("cleartext response rejected: sealed response required");
+        }
+        let verifying_key = VerifyingKey::from_bytes(&self.cnf)
+            .map_err(|_| anyhow::anyhow!("Invalid signer public key"))?;
+        if !bool::from(verifying_key.to_bytes().ct_eq(&expected_pubkey.to_bytes())) {
+            anyhow::bail!("Response signed by unexpected key");
+        }
+        self.verify_cose(
+            &verifying_key,
+            Some(pq_store),
+            crate::crypto::CryptoPolicy::Hybrid,
+            Some(service_domain),
+        )
     }
 
     /// Verify the COSE composite signature (authoritative auth check).
@@ -2499,9 +2605,17 @@ impl ResponseEnvelope {
         ed_vk: &VerifyingKey,
         pq_store: Option<&dyn PqTrustStore>,
         verify_policy: crate::crypto::CryptoPolicy,
+        service_domain: Option<&str>,
     ) -> Result<()> {
         let signing_bytes = self.encrypted_response.as_deref().unwrap_or(&self.payload);
-        let signing_data = Self::signing_data(self.request_id, signing_bytes);
+        let signing_data = if self.encrypted_response.is_some() {
+            let service_domain = service_domain.ok_or_else(|| {
+                anyhow!("encrypted response verification requires the pending service domain")
+            })?;
+            Self::encrypted_signing_data(self.request_id, signing_bytes, service_domain)?
+        } else {
+            Self::signing_data(self.request_id, signing_bytes)
+        };
         let aad = response_envelope_external_aad();
 
         // kid-anchor: resolve the trusted ML-DSA-65 key for this EdDSA identity.
@@ -2752,6 +2866,10 @@ pub fn unwrap_response_with(
     verify_policy: crate::crypto::CryptoPolicy,
 ) -> Result<(u64, Vec<u8>)> {
     let envelope = read_response_envelope(response, false)?;
+
+    if envelope.encrypted_response.is_some() {
+        anyhow::bail!("encrypted response requires one-shot pending decapsulation material");
+    }
 
     // Verify the COSE composite under the supplied policy + anchor.
     envelope.verify_with(expected_pubkey, pq_store, verify_policy)?;
@@ -3230,6 +3348,7 @@ mod tests {
             wth: Some([0xAB; 32]),
             client_dh_public: Some([0xCD; 32]),
             response_kem_recipient: None,
+            service_domain: None,
         };
 
         let mut message = Builder::new_default();
@@ -3272,6 +3391,7 @@ mod tests {
             wth: None,
             client_dh_public: None,
             response_kem_recipient: None,
+            service_domain: None,
         };
 
         // Seal to the node's #mesh-kem public, dual-signed (EdDSA + ML-DSA-65).
@@ -3333,6 +3453,7 @@ mod tests {
             wth: None,
             client_dh_public: None,
             response_kem_recipient: None,
+            service_domain: None,
         };
         let signed =
             SignedEnvelope::new_signed_encrypted_mesh_kem(envelope, &node_sk, &pq_sk, &kem_pub)
@@ -3376,6 +3497,7 @@ mod tests {
             wth: None,
             client_dh_public: None,
             response_kem_recipient: None,
+            service_domain: None,
         };
 
         let mut signed = test_new_signed(envelope, &signing_key);
@@ -3421,6 +3543,7 @@ mod tests {
             wth: Some([0xAA; 32]),
             client_dh_public: None,
             response_kem_recipient: None,
+            service_domain: None,
         };
 
         let mut signed = test_new_signed(envelope, &signing_key);
@@ -4292,17 +4415,29 @@ mod tests {
             &public,
             1234,
             &nonce,
+            "service-a",
         )
         .unwrap();
         response
-            .verify_with(Some(&server_vk), Some(&store), CryptoPolicy::Hybrid)
+            .verify_encrypted_with_service_domain(&server_vk, &store, "service-a")
             .unwrap();
         let wire = response_to_wire(&response);
         assert!(!wire
             .windows(secret_payload.len())
             .any(|w| w == secret_payload));
+        let public_unwrap =
+            unwrap_response_with(&wire, Some(&server_vk), Some(&store), CryptoPolicy::Hybrid)
+                .expect_err("public unwrap has no one-shot decapsulation state");
+        assert!(public_unwrap.to_string().contains("decapsulation material"));
         let opened = response
-            .open_encrypted(&recipient, &public, 1234, &nonce, &server_vk.to_bytes())
+            .open_encrypted(
+                &recipient,
+                &public,
+                1234,
+                &nonce,
+                &server_vk.to_bytes(),
+                "service-a",
+            )
             .unwrap();
         assert_eq!(opened, secret_payload);
 
@@ -4317,10 +4452,18 @@ mod tests {
                 1234,
                 &nonce,
                 &server_vk.to_bytes(),
+                "service-a",
             )
             .is_err());
         assert!(response
-            .open_encrypted(&recipient, &public, 1235, &nonce, &server_vk.to_bytes(),)
+            .open_encrypted(
+                &recipient,
+                &public,
+                1235,
+                &nonce,
+                &server_vk.to_bytes(),
+                "service-a",
+            )
             .is_err());
         let other_nonce = distinct_test_nonce(&nonce);
         assert!(response
@@ -4330,6 +4473,7 @@ mod tests {
                 1234,
                 &other_nonce,
                 &server_vk.to_bytes(),
+                "service-a",
             )
             .is_err());
         let (other_server, _) = generate_signing_keypair();
@@ -4340,6 +4484,20 @@ mod tests {
                 1234,
                 &nonce,
                 &other_server.verifying_key().to_bytes(),
+                "service-a",
+            )
+            .is_err());
+        assert!(response
+            .verify_encrypted_with_service_domain(&server_vk, &store, "service-b")
+            .is_err());
+        assert!(response
+            .open_encrypted(
+                &recipient,
+                &public,
+                1234,
+                &nonce,
+                &server_vk.to_bytes(),
+                "service-b",
             )
             .is_err());
     }
@@ -4367,37 +4525,58 @@ mod tests {
             &public,
             99,
             &nonce,
+            "service-a",
         )
         .unwrap();
 
         response.request_id = 9;
-        let data = ResponseEnvelope::signing_data(
+        let data = ResponseEnvelope::encrypted_signing_data(
             response.request_id,
             response.encrypted_response.as_deref().unwrap(),
-        );
+            "service-a",
+        )
+        .unwrap();
         response.sig = server_sk.sign(&data).to_bytes();
         response.cose =
             ResponseEnvelope::build_cose(&server_sk, Some(&pq_sk), CryptoPolicy::Hybrid, &data)
                 .unwrap();
         response
-            .verify_with(Some(&server_vk), Some(&store), CryptoPolicy::Hybrid)
+            .verify_encrypted_with_service_domain(&server_vk, &store, "service-a")
             .unwrap();
         assert!(response
-            .open_encrypted(&recipient, &public, 99, &nonce, &server_vk.to_bytes(),)
+            .open_encrypted(
+                &recipient,
+                &public,
+                99,
+                &nonce,
+                &server_vk.to_bytes(),
+                "service-a",
+            )
             .is_err());
 
         response.encrypted_response = Some(b"not-a-cose-encrypt0".to_vec());
-        let data =
-            ResponseEnvelope::signing_data(9, response.encrypted_response.as_deref().unwrap());
+        let data = ResponseEnvelope::encrypted_signing_data(
+            9,
+            response.encrypted_response.as_deref().unwrap(),
+            "service-a",
+        )
+        .unwrap();
         response.sig = server_sk.sign(&data).to_bytes();
         response.cose =
             ResponseEnvelope::build_cose(&server_sk, Some(&pq_sk), CryptoPolicy::Hybrid, &data)
                 .unwrap();
         response
-            .verify_with(Some(&server_vk), Some(&store), CryptoPolicy::Hybrid)
+            .verify_encrypted_with_service_domain(&server_vk, &store, "service-a")
             .unwrap();
         assert!(response
-            .open_encrypted(&recipient, &public, 99, &nonce, &server_vk.to_bytes(),)
+            .open_encrypted(
+                &recipient,
+                &public,
+                99,
+                &nonce,
+                &server_vk.to_bytes(),
+                "service-a",
+            )
             .is_err());
     }
 

--- a/crates/hyprstream-rpc/src/rpc_client.rs
+++ b/crates/hyprstream-rpc/src/rpc_client.rs
@@ -30,6 +30,17 @@ type TokenProviderBox = Arc<dyn Fn() -> Option<String> + Send + Sync>;
 /// are dropped immediately after the sole response-open attempt.
 struct ResponseRecipientSecret {
     keypair: crate::crypto::hybrid_kem::RecipientKeypair,
+    #[cfg(test)]
+    drop_probe: Option<Arc<std::sync::atomic::AtomicUsize>>,
+}
+
+#[cfg(test)]
+impl Drop for ResponseRecipientSecret {
+    fn drop(&mut self) {
+        if let Some(probe) = &self.drop_probe {
+            probe.fetch_add(1, Ordering::SeqCst);
+        }
+    }
 }
 
 struct PendingResponse {
@@ -38,6 +49,7 @@ struct PendingResponse {
     request_nonce: [u8; 16],
     server_identity: [u8; 32],
     recipient_public: crate::crypto::hybrid_kem::RecipientPublic,
+    service_domain: String,
     secret: ResponseRecipientSecret,
 }
 
@@ -46,6 +58,7 @@ impl std::fmt::Debug for PendingResponse {
         f.debug_struct("PendingResponse")
             .field("request_id", &self.request_id)
             .field("server_identity", &hex::encode(self.server_identity))
+            .field("service_domain", &self.service_domain)
             .finish_non_exhaustive()
     }
 }
@@ -65,6 +78,7 @@ impl PendingResponse {
             self.request_iat,
             &self.request_nonce,
             &self.server_identity,
+            &self.service_domain,
         )
     }
 }
@@ -134,6 +148,7 @@ impl CallOptions {
 /// ```
 pub struct RequestBuilder<'a> {
     client: &'a Arc<dyn RpcClient>,
+    service_domain: Option<&'static str>,
     jwt: Option<String>,
     delegated_bearer: Option<String>,
 }
@@ -155,6 +170,17 @@ impl<'a> RequestBuilder<'a> {
     pub fn new(client: &'a Arc<dyn RpcClient>) -> Self {
         Self {
             client,
+            service_domain: None,
+            jwt: None,
+            delegated_bearer: None,
+        }
+    }
+
+    /// Create a builder bound to a generated client's canonical service.
+    pub fn for_service(client: &'a Arc<dyn RpcClient>, service_domain: &'static str) -> Self {
+        Self {
+            client,
+            service_domain: Some(service_domain),
             jwt: None,
             delegated_bearer: None,
         }
@@ -174,15 +200,18 @@ impl<'a> RequestBuilder<'a> {
 
     /// Send a raw request with these options and return the raw response bytes.
     pub async fn call(self, payload: Vec<u8>) -> Result<Vec<u8>> {
-        self.client
-            .call_with_options(
-                payload,
-                CallOptions {
-                    jwt: self.jwt,
-                    delegated_bearer: self.delegated_bearer,
-                },
-            )
-            .await
+        let options = CallOptions {
+            jwt: self.jwt,
+            delegated_bearer: self.delegated_bearer,
+        };
+        match self.service_domain {
+            Some(service_domain) => {
+                self.client
+                    .call_with_options_for_service(service_domain, payload, options)
+                    .await
+            }
+            None => self.client.call_with_options(payload, options).await,
+        }
     }
 }
 
@@ -210,6 +239,8 @@ pub struct RpcClientImpl<S: Signer, T: Transport + 'static> {
     /// envelopes for carriers that forbid cleartext. Bindings are established
     /// out-of-band by DID keyAgreement / peer attestation; absence fails closed.
     request_kem_store: Option<Arc<dyn KemTrustStore>>,
+    #[cfg(test)]
+    response_secret_drop_probe: Option<Arc<std::sync::atomic::AtomicUsize>>,
 }
 
 impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
@@ -227,6 +258,8 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
             response_verify_policy: None,
             response_pq_store: None,
             request_kem_store: None,
+            #[cfg(test)]
+            response_secret_drop_probe: None,
         }
     }
 
@@ -248,6 +281,15 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
     /// envelopes when the selected transport forbids cleartext.
     pub fn with_request_kem_store(mut self, kem_store: Arc<dyn KemTrustStore>) -> Self {
         self.request_kem_store = Some(kem_store);
+        self
+    }
+
+    #[cfg(test)]
+    fn with_response_secret_drop_probe(
+        mut self,
+        probe: Arc<std::sync::atomic::AtomicUsize>,
+    ) -> Self {
+        self.response_secret_drop_probe = Some(probe);
         self
     }
 
@@ -286,9 +328,30 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
     /// Send a request and return the verified, unwrapped response payload.
     /// Uses the client's default JWT.
     pub async fn call(&self, payload: Vec<u8>) -> Result<Vec<u8>> {
+        self.call_bound(payload, None).await
+    }
+
+    /// Send a request bound to a canonical destination service. Generated
+    /// clients always use this path with their `SERVICE_NAME`.
+    pub async fn call_for_service(
+        &self,
+        service_domain: &str,
+        payload: Vec<u8>,
+    ) -> Result<Vec<u8>> {
+        self.call_bound(payload, Some(service_domain)).await
+    }
+
+    async fn call_bound(&self, payload: Vec<u8>, service_domain: Option<&str>) -> Result<Vec<u8>> {
         let request_id = self.next_id();
         let (signed_bytes, pending) = self
-            .sign_envelope(request_id, payload, None, self.effective_jwt(), None)
+            .sign_envelope(
+                request_id,
+                payload,
+                None,
+                self.effective_jwt(),
+                None,
+                service_domain,
+            )
             .await?;
         let timeout = self.calculate_timeout();
         let response_bytes = self.transport.send(signed_bytes, timeout).await?;
@@ -304,6 +367,27 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
         payload: Vec<u8>,
         ephemeral_pubkey: [u8; 32],
     ) -> Result<Vec<u8>> {
+        self.call_streaming_bound(payload, ephemeral_pubkey, None)
+            .await
+    }
+
+    /// Send a streaming setup request bound to a canonical destination.
+    pub async fn call_streaming_for_service(
+        &self,
+        service_domain: &str,
+        payload: Vec<u8>,
+        ephemeral_pubkey: [u8; 32],
+    ) -> Result<Vec<u8>> {
+        self.call_streaming_bound(payload, ephemeral_pubkey, Some(service_domain))
+            .await
+    }
+
+    async fn call_streaming_bound(
+        &self,
+        payload: Vec<u8>,
+        ephemeral_pubkey: [u8; 32],
+        service_domain: Option<&str>,
+    ) -> Result<Vec<u8>> {
         let request_id = self.next_id();
         let (signed_bytes, pending) = self
             .sign_envelope(
@@ -312,6 +396,7 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
                 Some(ephemeral_pubkey),
                 self.effective_jwt(),
                 None,
+                service_domain,
             )
             .await?;
         let timeout = self.calculate_timeout();
@@ -329,6 +414,17 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
         ephemeral_pubkey: [u8; 32],
         options: CallOptions,
     ) -> Result<Vec<u8>> {
+        self.call_streaming_with_options_bound(payload, ephemeral_pubkey, options, None)
+            .await
+    }
+
+    async fn call_streaming_with_options_bound(
+        &self,
+        payload: Vec<u8>,
+        ephemeral_pubkey: [u8; 32],
+        options: CallOptions,
+        service_domain: Option<&str>,
+    ) -> Result<Vec<u8>> {
         let request_id = self.next_id();
         let jwt = options.jwt.or_else(|| self.effective_jwt());
         let (signed_bytes, pending) = self
@@ -338,6 +434,7 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
                 Some(ephemeral_pubkey),
                 jwt,
                 options.delegated_bearer,
+                service_domain,
             )
             .await?;
         let timeout = self.calculate_timeout();
@@ -355,10 +452,37 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
         payload: Vec<u8>,
         options: CallOptions,
     ) -> Result<Vec<u8>> {
+        self.call_with_options_bound(payload, options, None).await
+    }
+
+    /// Send an option-bearing request bound to a canonical destination.
+    pub async fn call_with_options_for_service(
+        &self,
+        service_domain: &str,
+        payload: Vec<u8>,
+        options: CallOptions,
+    ) -> Result<Vec<u8>> {
+        self.call_with_options_bound(payload, options, Some(service_domain))
+            .await
+    }
+
+    async fn call_with_options_bound(
+        &self,
+        payload: Vec<u8>,
+        options: CallOptions,
+        service_domain: Option<&str>,
+    ) -> Result<Vec<u8>> {
         let request_id = self.next_id();
         let jwt = options.jwt.or_else(|| self.effective_jwt());
         let (signed_bytes, pending) = self
-            .sign_envelope(request_id, payload, None, jwt, options.delegated_bearer)
+            .sign_envelope(
+                request_id,
+                payload,
+                None,
+                jwt,
+                options.delegated_bearer,
+                service_domain,
+            )
             .await?;
         let timeout = self.calculate_timeout();
         let response_bytes = self.transport.send(signed_bytes, timeout).await?;
@@ -453,10 +577,10 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
             if store.ml_dsa_key_for(&server.to_bytes()).is_none() {
                 anyhow::bail!("network response server has no anchored ML-DSA-65 key");
             }
-            response.verify_with(
-                Some(server),
-                Some(store),
-                crate::crypto::CryptoPolicy::Hybrid,
+            response.verify_encrypted_with_service_domain(
+                server,
+                store,
+                &pending.service_domain,
             )?;
             let payload = pending.open(&response)?;
             Ok((response.request_id, payload))
@@ -486,6 +610,7 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
         ephemeral_pubkey: Option<[u8; 32]>,
         jwt: Option<String>,
         delegated_bearer: Option<String>,
+        service_domain: Option<&str>,
     ) -> Result<(Vec<u8>, Option<PendingResponse>)> {
         let mut envelope = RequestEnvelope::new(payload);
         envelope.request_id = request_id;
@@ -498,62 +623,63 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
         if let Some(key) = ephemeral_pubkey {
             envelope = envelope.with_client_dh_public(key);
         }
+        if let Some(service_domain) = service_domain {
+            envelope = envelope.with_service_domain(service_domain)?;
+        }
 
-        let pending = if self.transport.forbids_cleartext_envelope() {
-            let server = self
-                .server_verifying_key
-                .as_ref()
-                .ok_or_else(|| anyhow::anyhow!("network request has no pinned server identity"))?;
+        let (pending, encrypted_envelope) = if self.transport.forbids_cleartext_envelope() {
+            let service_domain = service_domain.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "network request has no canonical service domain; use a generated client or explicit service-bound call"
+                )
+            })?;
+            crate::envelope::validate_service_domain(service_domain)?;
+            let server = self.server_verifying_key.as_ref().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "transport forbids cleartext envelopes but no server verifying key is pinned; refusing to choose a #mesh-kem recipient"
+                )
+            })?;
+            let kem_store = self.request_kem_store.as_ref().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "transport forbids cleartext envelopes but no #mesh-kem trust store is configured; refusing cleartext downgrade"
+                )
+            })?;
+            let recipient = kem_store
+                .kem_recipient_for(&server.to_bytes())
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "transport forbids cleartext envelopes but server {} has no anchored #mesh-kem recipient key",
+                        hex::encode(server.to_bytes())
+                    )
+                })?;
             let keypair = crate::crypto::hybrid_kem::generate_recipient(
                 crate::crypto::hybrid_kem::SuiteId::HyKemX25519MlKem768,
             )?;
             let public = keypair.public();
             envelope = envelope.with_response_kem_recipient(public.clone());
-            Some(PendingResponse {
+            let pending = Some(PendingResponse {
                 request_id,
                 request_iat: envelope.iat,
                 request_nonce: envelope.nonce,
                 server_identity: server.to_bytes(),
                 recipient_public: public,
-                secret: ResponseRecipientSecret { keypair },
-            })
+                service_domain: service_domain.to_owned(),
+                secret: ResponseRecipientSecret {
+                    keypair,
+                    #[cfg(test)]
+                    drop_probe: self.response_secret_drop_probe.clone(),
+                },
+            });
+            let sealed = Some(crate::envelope::seal_request_envelope(
+                &envelope, &recipient,
+            )?);
+            (pending, sealed)
         } else {
-            None
+            (None, None)
         };
 
         let canonical = envelope.to_bytes();
         let ed_pubkey = self.signer.pubkey();
-        let encrypted_envelope = if self.transport.forbids_cleartext_envelope() {
-            let server_key = self.server_verifying_key.as_ref().ok_or_else(|| {
-                anyhow::anyhow!(
-                    "transport forbids cleartext envelopes but no server verifying key \
-                     is pinned; refusing to choose a #mesh-kem recipient"
-                )
-            })?;
-            let kem_store = self.request_kem_store.as_ref().ok_or_else(|| {
-                anyhow::anyhow!(
-                    "transport forbids cleartext envelopes but no #mesh-kem trust \
-                     store is configured; refusing cleartext downgrade"
-                )
-            })?;
-            let recipient = kem_store
-                .kem_recipient_for(&server_key.to_bytes())
-                .ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "transport forbids cleartext envelopes but server {} has no \
-                         anchored #mesh-kem recipient key",
-                        hex::encode(server_key.to_bytes())
-                    )
-                })?;
-
-            // Shared seal path (framing + replay-bound AAD) — single source of
-            // truth with `SignedEnvelope::new_signed_encrypted_mesh_kem`.
-            Some(crate::envelope::seal_request_envelope(
-                &envelope, &recipient,
-            )?)
-        } else {
-            None
-        };
         let signing_data: &[u8] = encrypted_envelope.as_deref().unwrap_or(&canonical);
 
         if encrypted_envelope.is_some() && self.signer.pq_pubkey().is_none() {
@@ -734,15 +860,34 @@ pub trait RpcClient: Send + Sync {
     /// Send a request and return the verified response payload.
     async fn call(&self, payload: Vec<u8>) -> Result<Vec<u8>>;
 
+    /// Send a request bound to a canonical destination service.
+    async fn call_for_service(&self, service_domain: &str, payload: Vec<u8>) -> Result<Vec<u8>>;
+
     /// Send a request with per-call authentication options.
     ///
     /// Uses `options.jwt` if provided, otherwise falls back to the client's
     /// default JWT. Includes `options.delegated_bearer` in the envelope.
     async fn call_with_options(&self, payload: Vec<u8>, options: CallOptions) -> Result<Vec<u8>>;
 
+    /// Send an option-bearing request bound to a canonical destination.
+    async fn call_with_options_for_service(
+        &self,
+        service_domain: &str,
+        payload: Vec<u8>,
+        options: CallOptions,
+    ) -> Result<Vec<u8>>;
+
     /// Send a streaming request with ephemeral DH pubkey.
     async fn call_streaming(&self, payload: Vec<u8>, ephemeral_pubkey: [u8; 32])
         -> Result<Vec<u8>>;
+
+    /// Send a streaming setup request bound to a canonical destination.
+    async fn call_streaming_for_service(
+        &self,
+        service_domain: &str,
+        payload: Vec<u8>,
+        ephemeral_pubkey: [u8; 32],
+    ) -> Result<Vec<u8>>;
 
     /// Open a verified streaming subscription.
     async fn open_stream(&self, payload: Vec<u8>) -> Result<Box<dyn StreamHandle>>;
@@ -767,8 +912,21 @@ impl<S: Signer, T: Transport + 'static> RpcClient for RpcClientImpl<S, T> {
         RpcClientImpl::call(self, payload).await
     }
 
+    async fn call_for_service(&self, service_domain: &str, payload: Vec<u8>) -> Result<Vec<u8>> {
+        RpcClientImpl::call_for_service(self, service_domain, payload).await
+    }
+
     async fn call_with_options(&self, payload: Vec<u8>, options: CallOptions) -> Result<Vec<u8>> {
         RpcClientImpl::call_with_options(self, payload, options).await
+    }
+
+    async fn call_with_options_for_service(
+        &self,
+        service_domain: &str,
+        payload: Vec<u8>,
+        options: CallOptions,
+    ) -> Result<Vec<u8>> {
+        RpcClientImpl::call_with_options_for_service(self, service_domain, payload, options).await
     }
 
     async fn call_streaming(
@@ -777,6 +935,16 @@ impl<S: Signer, T: Transport + 'static> RpcClient for RpcClientImpl<S, T> {
         ephemeral_pubkey: [u8; 32],
     ) -> Result<Vec<u8>> {
         RpcClientImpl::call_streaming(self, payload, ephemeral_pubkey).await
+    }
+
+    async fn call_streaming_for_service(
+        &self,
+        service_domain: &str,
+        payload: Vec<u8>,
+        ephemeral_pubkey: [u8; 32],
+    ) -> Result<Vec<u8>> {
+        RpcClientImpl::call_streaming_for_service(self, service_domain, payload, ephemeral_pubkey)
+            .await
     }
 
     #[cfg(not(feature = "fips"))]
@@ -841,13 +1009,159 @@ mod request_kem_tests {
     use crate::node_identity::derive_mesh_kem_recipient;
     use crate::signer::LocalSigner;
     use crate::transport::rpc_session::{RpcPendingStream, RpcPublishStub};
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
+    use tokio::sync::{oneshot, Mutex, Notify};
 
     /// A carrier that forbids cleartext envelopes; `send` must never be reached
     /// in these tests (they stop at `sign_envelope`).
     struct ForbidsCleartextMock;
 
     struct CleartextResponseMock(Vec<u8>);
+
+    const LIFECYCLE_SUCCESS: u8 = 0;
+    const LIFECYCLE_FAIL_SEND: u8 = 1;
+    const LIFECYCLE_BLOCK: u8 = 2;
+    const LIFECYCLE_SWAP: u8 = 3;
+
+    struct LifecycleState {
+        behavior: AtomicU8,
+        recipients: parking_lot::Mutex<Vec<Vec<u8>>>,
+        swap_waiters: Mutex<Vec<(Vec<u8>, oneshot::Sender<Vec<u8>>)>>,
+        entered: Notify,
+    }
+
+    struct LifecycleTransport {
+        server_sk: crate::crypto::SigningKey,
+        state: Arc<LifecycleState>,
+    }
+
+    impl LifecycleTransport {
+        fn response_for(&self, payload: &[u8]) -> Result<Vec<u8>> {
+            let mut signed = signed_envelope_from_bytes(payload);
+            let server_recipient = derive_mesh_kem_recipient(&self.server_sk)?;
+            signed.decrypt_in_place_mesh_kem(&server_recipient)?;
+            let request = signed.envelope;
+            let recipient = request
+                .response_kem_recipient
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("test request omitted response recipient"))?;
+            let service_domain = request
+                .service_domain
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("test request omitted service domain"))?;
+            self.state
+                .recipients
+                .lock()
+                .push(recipient.encode());
+            let pq_sk = crate::node_identity::derive_mesh_mldsa_key(&self.server_sk);
+            let response = crate::envelope::ResponseEnvelope::new_signed_encrypted(
+                request.request_id,
+                request.payload,
+                &self.server_sk,
+                &pq_sk,
+                recipient,
+                request.iat,
+                &request.nonce,
+                service_domain,
+            )?;
+            let mut message = capnp::message::Builder::new_default();
+            response.write_to(
+                &mut message.init_root::<crate::common_capnp::response_envelope::Builder>(),
+            );
+            let mut bytes = Vec::new();
+            capnp::serialize::write_message(&mut bytes, &message)?;
+            Ok(bytes)
+        }
+    }
+
+    #[async_trait]
+    impl Transport for LifecycleTransport {
+        type Sub = RpcPendingStream;
+        type Pub = RpcPublishStub;
+
+        fn forbids_cleartext_envelope(&self) -> bool {
+            true
+        }
+
+        async fn send(&self, payload: Vec<u8>, _timeout_ms: Option<i32>) -> Result<Vec<u8>> {
+            let response = self.response_for(&payload)?;
+            match self.state.behavior.load(Ordering::SeqCst) {
+                LIFECYCLE_SUCCESS => Ok(response),
+                LIFECYCLE_FAIL_SEND => anyhow::bail!("controlled send failure"),
+                LIFECYCLE_BLOCK => {
+                    self.state.entered.notify_waiters();
+                    std::future::pending().await
+                }
+                LIFECYCLE_SWAP => {
+                    let (tx, rx) = oneshot::channel();
+                    let mut waiters = self.state.swap_waiters.lock().await;
+                    waiters.push((response, tx));
+                    if waiters.len() == 2 {
+                        let (second_response, second_tx) = waiters.pop().unwrap();
+                        let (first_response, first_tx) = waiters.pop().unwrap();
+                        first_tx
+                            .send(second_response)
+                            .map_err(|_| anyhow::anyhow!("first swapped caller was cancelled"))?;
+                        second_tx
+                            .send(first_response)
+                            .map_err(|_| anyhow::anyhow!("second swapped caller was cancelled"))?;
+                    }
+                    drop(waiters);
+                    rx.await
+                        .map_err(|_| anyhow::anyhow!("swap response channel closed"))
+                }
+                other => anyhow::bail!("unknown lifecycle behavior {other}"),
+            }
+        }
+
+        async fn subscribe(&self, _topic: &[u8]) -> Result<Self::Sub> {
+            Ok(futures::stream::pending())
+        }
+
+        async fn publish(&self, _topic: &[u8]) -> Result<Self::Pub> {
+            Ok(RpcPublishStub)
+        }
+    }
+
+    fn lifecycle_client() -> (
+        Arc<RpcClientImpl<LocalSigner, LifecycleTransport>>,
+        Arc<LifecycleState>,
+        Arc<AtomicUsize>,
+    ) {
+        let (server_sk, server_vk) = generate_signing_keypair();
+        let (client_sk, _client_vk) = generate_signing_keypair();
+        let mut kem_store = KeyedKemTrustStore::new();
+        kem_store.bind(
+            server_vk.to_bytes(),
+            derive_mesh_kem_recipient(&server_sk).unwrap().public(),
+        );
+        let pq_sk = crate::node_identity::derive_mesh_mldsa_key(&server_sk);
+        let pq_vk = crate::crypto::pq::ml_dsa_vk_from_bytes(
+            &crate::crypto::pq::ml_dsa_sk_to_vk_bytes(&pq_sk),
+        )
+        .unwrap();
+        let mut pq_store = crate::envelope::KeyedPqTrustStore::new();
+        pq_store.bind(server_vk.to_bytes(), &pq_vk);
+        let state = Arc::new(LifecycleState {
+            behavior: AtomicU8::new(LIFECYCLE_SUCCESS),
+            recipients: parking_lot::Mutex::new(Vec::new()),
+            swap_waiters: Mutex::new(Vec::new()),
+            entered: Notify::new(),
+        });
+        let drops = Arc::new(AtomicUsize::new(0));
+        let client = RpcClientImpl::new(
+            LocalSigner::new(client_sk),
+            LifecycleTransport {
+                server_sk,
+                state: Arc::clone(&state),
+            },
+            Some(server_vk),
+        )
+        .with_request_kem_store(Arc::new(kem_store))
+        .with_response_pq_store(Arc::new(pq_store))
+        .with_response_secret_drop_probe(Arc::clone(&drops));
+        (Arc::new(client), state, drops)
+    }
 
     #[async_trait]
     impl Transport for ForbidsCleartextMock {
@@ -965,7 +1279,14 @@ mod request_kem_tests {
         );
 
         let err = rpc
-            .sign_envelope(1, b"payload".to_vec(), None, None, None)
+            .sign_envelope(
+                1,
+                b"payload".to_vec(),
+                None,
+                None,
+                None,
+                Some("test-service"),
+            )
             .await
             .expect_err("must fail closed without a #mesh-kem store");
         assert!(
@@ -997,7 +1318,14 @@ mod request_kem_tests {
         .with_request_kem_store(Arc::new(kem_store));
 
         let (bytes, pending) = rpc
-            .sign_envelope(1, b"payload".to_vec(), None, None, None)
+            .sign_envelope(
+                1,
+                b"payload".to_vec(),
+                None,
+                None,
+                None,
+                Some("test-service"),
+            )
             .await
             .expect("forwarded store must seal the envelope");
         assert!(
@@ -1048,7 +1376,10 @@ mod request_kem_tests {
         .with_request_kem_store(Arc::new(kem_store))
         .with_response_pq_store(Arc::new(pq_store));
 
-        let err = rpc.call(b"request".to_vec()).await.unwrap_err();
+        let err = rpc
+            .call_for_service("test-service", b"request".to_vec())
+            .await
+            .unwrap_err();
         assert!(
             err.to_string()
                 .contains("cleartext response rejected before payload use"),
@@ -1107,6 +1438,109 @@ mod request_kem_tests {
         assert!(
             sent.load(Ordering::SeqCst),
             "trusted-carrier cleartext must NOT be blocked — send must be reached"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_calls_use_distinct_recipients_and_swapped_live_responses_fail() {
+        let (client, state, _drops) = lifecycle_client();
+        let control = client
+            .call_for_service("service-a", b"control".to_vec())
+            .await
+            .expect("unmutated control must succeed before response swapping");
+        assert_eq!(control, b"control");
+
+        state.behavior.store(LIFECYCLE_SWAP, Ordering::SeqCst);
+        let first = {
+            let client = Arc::clone(&client);
+            tokio::spawn(async move {
+                client
+                    .call_for_service("service-a", b"first".to_vec())
+                    .await
+            })
+        };
+        let second = {
+            let client = Arc::clone(&client);
+            tokio::spawn(async move {
+                client
+                    .call_for_service("service-a", b"second".to_vec())
+                    .await
+            })
+        };
+        assert!(
+            first.await.unwrap().is_err(),
+            "first swapped response must fail"
+        );
+        assert!(
+            second.await.unwrap().is_err(),
+            "second swapped response must fail"
+        );
+
+        let recipients = state.recipients.lock();
+        assert_eq!(recipients.len(), 3);
+        assert_ne!(
+            recipients[1], recipients[2],
+            "concurrent calls must carry distinct response recipients"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancellation_drops_one_shot_response_state() {
+        let (client, state, drops) = lifecycle_client();
+        client
+            .call_for_service("service-a", b"control".to_vec())
+            .await
+            .expect("unmutated control must succeed before cancellation");
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+
+        state.behavior.store(LIFECYCLE_BLOCK, Ordering::SeqCst);
+        let entered = state.entered.notified();
+        let call = {
+            let client = Arc::clone(&client);
+            tokio::spawn(async move {
+                client
+                    .call_for_service("service-a", b"cancelled".to_vec())
+                    .await
+            })
+        };
+        entered.await;
+        call.abort();
+        assert!(call.await.unwrap_err().is_cancelled());
+        assert_eq!(
+            drops.load(Ordering::SeqCst),
+            2,
+            "cancelling a live send must drop its response secret"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_failure_drops_state_and_caller_retry_uses_fresh_recipient() {
+        let (client, state, drops) = lifecycle_client();
+        client
+            .call_for_service("service-a", b"control".to_vec())
+            .await
+            .expect("unmutated control must succeed before send failure");
+
+        state.behavior.store(LIFECYCLE_FAIL_SEND, Ordering::SeqCst);
+        assert!(client
+            .call_for_service("service-a", b"retry-me".to_vec())
+            .await
+            .is_err());
+        assert_eq!(drops.load(Ordering::SeqCst), 2);
+
+        state.behavior.store(LIFECYCLE_SUCCESS, Ordering::SeqCst);
+        let retried = client
+            .call_for_service("service-a", b"retry-me".to_vec())
+            .await
+            .expect("caller retry control succeeds");
+        assert_eq!(retried, b"retry-me");
+        assert_eq!(drops.load(Ordering::SeqCst), 3);
+
+        let recipients = state.recipients.lock();
+        assert_eq!(recipients.len(), 3);
+        assert_ne!(
+            recipients[1], recipients[2],
+            "caller retry must generate a fresh response recipient"
         );
     }
 }

--- a/crates/hyprstream-rpc/src/rpc_client.rs
+++ b/crates/hyprstream-rpc/src/rpc_client.rs
@@ -16,16 +16,58 @@ use std::sync::Arc;
 use anyhow::Result;
 use async_trait::async_trait;
 
-use crate::crypto::VerifyingKey;
-use crate::crypto::hybrid_kem::KemTrustStore;
-use crate::envelope::{
-    self, RequestEnvelope, SignedEnvelope,
-};
-use crate::transport_traits::{Signer, Transport};
 use crate::capnp::{FromCapnp, ToCapnp};
+use crate::crypto::hybrid_kem::KemTrustStore;
+use crate::crypto::VerifyingKey;
+use crate::envelope::{self, RequestEnvelope, SignedEnvelope};
 use crate::stream_consumer::{StreamHandle, StreamHandleImpl};
+use crate::transport_traits::{Signer, Transport};
 
 type TokenProviderBox = Arc<dyn Fn() -> Option<String> + Send + Sync>;
+
+/// Non-cloneable, non-serializable one-call response decapsulation material.
+/// The component secret bytes are `Zeroizing` inside `RecipientKeypair` and
+/// are dropped immediately after the sole response-open attempt.
+struct ResponseRecipientSecret {
+    keypair: crate::crypto::hybrid_kem::RecipientKeypair,
+}
+
+struct PendingResponse {
+    request_id: u64,
+    request_iat: i64,
+    request_nonce: [u8; 16],
+    server_identity: [u8; 32],
+    recipient_public: crate::crypto::hybrid_kem::RecipientPublic,
+    secret: ResponseRecipientSecret,
+}
+
+impl std::fmt::Debug for PendingResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PendingResponse")
+            .field("request_id", &self.request_id)
+            .field("server_identity", &hex::encode(self.server_identity))
+            .finish_non_exhaustive()
+    }
+}
+
+impl PendingResponse {
+    fn open(self, envelope: &crate::envelope::ResponseEnvelope) -> Result<Vec<u8>> {
+        if envelope.request_id != self.request_id {
+            anyhow::bail!(
+                "response request id {} does not match pending request {}",
+                envelope.request_id,
+                self.request_id
+            );
+        }
+        envelope.open_encrypted(
+            &self.secret.keypair,
+            &self.recipient_public,
+            self.request_iat,
+            &self.request_nonce,
+            &self.server_identity,
+        )
+    }
+}
 
 // ============================================================================
 // Per-call options (non-mutating, Send+Sync, owned data)
@@ -100,7 +142,10 @@ impl<'a> std::fmt::Debug for RequestBuilder<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RequestBuilder")
             .field("jwt", &self.jwt.as_ref().map(|_| "***"))
-            .field("delegated_bearer", &self.delegated_bearer.as_ref().map(|_| "***"))
+            .field(
+                "delegated_bearer",
+                &self.delegated_bearer.as_ref().map(|_| "***"),
+            )
             .finish()
     }
 }
@@ -129,10 +174,15 @@ impl<'a> RequestBuilder<'a> {
 
     /// Send a raw request with these options and return the raw response bytes.
     pub async fn call(self, payload: Vec<u8>) -> Result<Vec<u8>> {
-        self.client.call_with_options(payload, CallOptions {
-            jwt: self.jwt,
-            delegated_bearer: self.delegated_bearer,
-        }).await
+        self.client
+            .call_with_options(
+                payload,
+                CallOptions {
+                    jwt: self.jwt,
+                    delegated_bearer: self.delegated_bearer,
+                },
+            )
+            .await
     }
 }
 
@@ -196,10 +246,7 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
 
     /// Set the anchored `#mesh-kem` recipient key store used to encrypt request
     /// envelopes when the selected transport forbids cleartext.
-    pub fn with_request_kem_store(
-        mut self,
-        kem_store: Arc<dyn KemTrustStore>,
-    ) -> Self {
+    pub fn with_request_kem_store(mut self, kem_store: Arc<dyn KemTrustStore>) -> Self {
         self.request_kem_store = Some(kem_store);
         self
     }
@@ -240,10 +287,12 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
     /// Uses the client's default JWT.
     pub async fn call(&self, payload: Vec<u8>) -> Result<Vec<u8>> {
         let request_id = self.next_id();
-        let signed_bytes = self.sign_envelope(request_id, payload, None, self.effective_jwt(), None).await?;
+        let (signed_bytes, pending) = self
+            .sign_envelope(request_id, payload, None, self.effective_jwt(), None)
+            .await?;
         let timeout = self.calculate_timeout();
         let response_bytes = self.transport.send(signed_bytes, timeout).await?;
-        let (_req_id, inner) = self.unwrap_response(&response_bytes)?;
+        let (_req_id, inner) = self.unwrap_response(&response_bytes, request_id, pending)?;
         Ok(inner)
     }
 
@@ -256,12 +305,18 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
         ephemeral_pubkey: [u8; 32],
     ) -> Result<Vec<u8>> {
         let request_id = self.next_id();
-        let signed_bytes = self
-            .sign_envelope(request_id, payload, Some(ephemeral_pubkey), self.effective_jwt(), None)
+        let (signed_bytes, pending) = self
+            .sign_envelope(
+                request_id,
+                payload,
+                Some(ephemeral_pubkey),
+                self.effective_jwt(),
+                None,
+            )
             .await?;
         let timeout = self.calculate_timeout();
         let response_bytes = self.transport.send(signed_bytes, timeout).await?;
-        let (_req_id, inner) = self.unwrap_response(&response_bytes)?;
+        let (_req_id, inner) = self.unwrap_response(&response_bytes, request_id, pending)?;
         Ok(inner)
     }
 
@@ -276,12 +331,18 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
     ) -> Result<Vec<u8>> {
         let request_id = self.next_id();
         let jwt = options.jwt.or_else(|| self.effective_jwt());
-        let signed_bytes = self
-            .sign_envelope(request_id, payload, Some(ephemeral_pubkey), jwt, options.delegated_bearer)
+        let (signed_bytes, pending) = self
+            .sign_envelope(
+                request_id,
+                payload,
+                Some(ephemeral_pubkey),
+                jwt,
+                options.delegated_bearer,
+            )
             .await?;
         let timeout = self.calculate_timeout();
         let response_bytes = self.transport.send(signed_bytes, timeout).await?;
-        let (_req_id, inner) = self.unwrap_response(&response_bytes)?;
+        let (_req_id, inner) = self.unwrap_response(&response_bytes, request_id, pending)?;
         Ok(inner)
     }
 
@@ -296,12 +357,12 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
     ) -> Result<Vec<u8>> {
         let request_id = self.next_id();
         let jwt = options.jwt.or_else(|| self.effective_jwt());
-        let signed_bytes = self
+        let (signed_bytes, pending) = self
             .sign_envelope(request_id, payload, None, jwt, options.delegated_bearer)
             .await?;
         let timeout = self.calculate_timeout();
         let response_bytes = self.transport.send(signed_bytes, timeout).await?;
-        let (_req_id, inner) = self.unwrap_response(&response_bytes)?;
+        let (_req_id, inner) = self.unwrap_response(&response_bytes, request_id, pending)?;
         Ok(inner)
     }
 
@@ -323,7 +384,12 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
     /// hatch. Under `Hybrid` the server's kid-anchored ML-DSA-65 layer is
     /// required (no silent downgrade).
     #[cfg(not(target_arch = "wasm32"))]
-    fn unwrap_response(&self, response_bytes: &[u8]) -> Result<(u64, Vec<u8>)> {
+    fn unwrap_response(
+        &self,
+        response_bytes: &[u8],
+        request_id: u64,
+        pending: Option<PendingResponse>,
+    ) -> Result<(u64, Vec<u8>)> {
         let policy = self
             .response_verify_policy
             .unwrap_or_else(envelope::global_response_verify_policy);
@@ -338,12 +404,7 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
             .response_pq_store
             .as_deref()
             .or(global_store.as_deref());
-        envelope::unwrap_response_with(
-            response_bytes,
-            self.server_verifying_key.as_ref(),
-            store,
-            policy,
-        )
+        self.unwrap_response_with_pending(response_bytes, request_id, pending, store, policy)
     }
 
     /// WASM response unwrap (#277 scope boundary): no process-global response
@@ -351,14 +412,70 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
     /// verify policy is owned by #158 (`wasm_api.rs`) and is intentionally NOT
     /// changed here.
     #[cfg(target_arch = "wasm32")]
-    fn unwrap_response(&self, response_bytes: &[u8]) -> Result<(u64, Vec<u8>)> {
-        envelope::unwrap_response_with(
+    fn unwrap_response(
+        &self,
+        response_bytes: &[u8],
+        request_id: u64,
+        pending: Option<PendingResponse>,
+    ) -> Result<(u64, Vec<u8>)> {
+        self.unwrap_response_with_pending(
             response_bytes,
-            self.server_verifying_key.as_ref(),
+            request_id,
+            pending,
             self.response_pq_store.as_deref(),
             self.response_verify_policy
                 .unwrap_or(crate::crypto::CryptoPolicy::Classical),
         )
+    }
+
+    fn unwrap_response_with_pending(
+        &self,
+        response_bytes: &[u8],
+        request_id: u64,
+        pending: Option<PendingResponse>,
+        pq_store: Option<&dyn envelope::PqTrustStore>,
+        policy: crate::crypto::CryptoPolicy,
+    ) -> Result<(u64, Vec<u8>)> {
+        if self.transport.forbids_cleartext_envelope() {
+            let pending = pending.ok_or_else(|| {
+                anyhow::anyhow!("network response has no one-shot pending recipient")
+            })?;
+            // Carrier gate first: inspect only the bounded encrypted field and
+            // reject cleartext before copying or using the outer payload.
+            let response = envelope::read_response_envelope(response_bytes, true)?;
+            let server = self
+                .server_verifying_key
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("network response has no pinned server identity"))?;
+            let store = pq_store.ok_or_else(|| {
+                anyhow::anyhow!("network response has no anchored ML-DSA-65 trust store")
+            })?;
+            if store.ml_dsa_key_for(&server.to_bytes()).is_none() {
+                anyhow::bail!("network response server has no anchored ML-DSA-65 key");
+            }
+            response.verify_with(
+                Some(server),
+                Some(store),
+                crate::crypto::CryptoPolicy::Hybrid,
+            )?;
+            let payload = pending.open(&response)?;
+            Ok((response.request_id, payload))
+        } else {
+            let (response_id, payload) = envelope::unwrap_response_with(
+                response_bytes,
+                self.server_verifying_key.as_ref(),
+                pq_store,
+                policy,
+            )?;
+            if response_id != request_id {
+                anyhow::bail!(
+                    "response request id {} does not match pending request {}",
+                    response_id,
+                    request_id
+                );
+            }
+            Ok((response_id, payload))
+        }
     }
 
     /// Build, sign, and serialize a request envelope.
@@ -369,7 +486,7 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
         ephemeral_pubkey: Option<[u8; 32]>,
         jwt: Option<String>,
         delegated_bearer: Option<String>,
-    ) -> Result<Vec<u8>> {
+    ) -> Result<(Vec<u8>, Option<PendingResponse>)> {
         let mut envelope = RequestEnvelope::new(payload);
         envelope.request_id = request_id;
         if let Some(token) = jwt {
@@ -381,6 +498,28 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
         if let Some(key) = ephemeral_pubkey {
             envelope = envelope.with_client_dh_public(key);
         }
+
+        let pending = if self.transport.forbids_cleartext_envelope() {
+            let server = self
+                .server_verifying_key
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("network request has no pinned server identity"))?;
+            let keypair = crate::crypto::hybrid_kem::generate_recipient(
+                crate::crypto::hybrid_kem::SuiteId::HyKemX25519MlKem768,
+            )?;
+            let public = keypair.public();
+            envelope = envelope.with_response_kem_recipient(public.clone());
+            Some(PendingResponse {
+                request_id,
+                request_iat: envelope.iat,
+                request_nonce: envelope.nonce,
+                server_identity: server.to_bytes(),
+                recipient_public: public,
+                secret: ResponseRecipientSecret { keypair },
+            })
+        } else {
+            None
+        };
 
         let canonical = envelope.to_bytes();
         let ed_pubkey = self.signer.pubkey();
@@ -409,7 +548,9 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
 
             // Shared seal path (framing + replay-bound AAD) — single source of
             // truth with `SignedEnvelope::new_signed_encrypted_mesh_kem`.
-            Some(crate::envelope::seal_request_envelope(&envelope, &recipient)?)
+            Some(crate::envelope::seal_request_envelope(
+                &envelope, &recipient,
+            )?)
         } else {
             None
         };
@@ -441,34 +582,27 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
         // it byte-distinct from a Classical inner layer.
         let hybrid = self.signer.pq_pubkey().is_some();
         let ed_kid = ed_pubkey.to_vec();
-        let ed_tbs = crate::crypto::cose_sign::inner_tbs(ed_kid.clone(), signing_data, &aad, hybrid);
+        let ed_tbs =
+            crate::crypto::cose_sign::inner_tbs(ed_kid.clone(), signing_data, &aad, hybrid);
         let ed_sig = self.signer.sign(&ed_tbs).await?.to_vec();
 
         // Hybrid component when the signer exposes an ML-DSA-65 key.
         let pq_entry = if let Some(pq_kid) = self.signer.pq_pubkey() {
-            let pq_tbs = crate::crypto::cose_sign::outer_tbs(
-                pq_kid.clone(),
-                signing_data,
-                &ed_sig,
-                &aad,
-            );
+            let pq_tbs =
+                crate::crypto::cose_sign::outer_tbs(pq_kid.clone(), signing_data, &ed_sig, &aad);
             // The inner EdDSA above was already bound to the hybrid-composite
             // alg-id (`hybrid = pq_pubkey().is_some()`), so it cannot fall back to
             // a classical inner. A signer that advertises a PQ key but declines to
             // sign must therefore be a HARD ERROR, not a silent downgrade that
             // would desync inner-AAD (hybrid) from outer-presence (none) and make
             // the peer's inner verification fail (#278 review).
-            let pq_sig = self
-                .signer
-                .pq_sign(&pq_tbs)
-                .await?
-                .ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "signer exposes a PQ public key but pq_sign() returned no \
+            let pq_sig = self.signer.pq_sign(&pq_tbs).await?.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "signer exposes a PQ public key but pq_sign() returned no \
                          signature; refusing to emit a hybrid-bound inner without \
                          its ML-DSA-65 outer (#278)"
-                    )
-                })?;
+                )
+            })?;
             Some((pq_kid, pq_sig))
         } else {
             None
@@ -493,13 +627,12 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
 
         let mut message = capnp::message::Builder::new_default();
         {
-            let mut builder =
-                message.init_root::<crate::common_capnp::signed_envelope::Builder>();
+            let mut builder = message.init_root::<crate::common_capnp::signed_envelope::Builder>();
             signed.write_to(&mut builder);
         }
         let mut bytes = Vec::new();
         capnp::serialize::write_message(&mut bytes, &message)?;
-        Ok(bytes)
+        Ok((bytes, pending))
     }
 
     /// Calculate timeout, defaulting to 30s.
@@ -550,7 +683,9 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
         let (secret, public) = generate_ephemeral_keypair();
         let pub_bytes = public.to_bytes();
 
-        let response = self.call_streaming_with_options(payload, pub_bytes, options).await?;
+        let response = self
+            .call_streaming_with_options(payload, pub_bytes, options)
+            .await?;
         let stream_info = parse_stream_info(&response)?;
 
         let secret_bytes = secret.scalar().to_bytes();
@@ -606,7 +741,8 @@ pub trait RpcClient: Send + Sync {
     async fn call_with_options(&self, payload: Vec<u8>, options: CallOptions) -> Result<Vec<u8>>;
 
     /// Send a streaming request with ephemeral DH pubkey.
-    async fn call_streaming(&self, payload: Vec<u8>, ephemeral_pubkey: [u8; 32]) -> Result<Vec<u8>>;
+    async fn call_streaming(&self, payload: Vec<u8>, ephemeral_pubkey: [u8; 32])
+        -> Result<Vec<u8>>;
 
     /// Open a verified streaming subscription.
     async fn open_stream(&self, payload: Vec<u8>) -> Result<Box<dyn StreamHandle>>;
@@ -635,7 +771,11 @@ impl<S: Signer, T: Transport + 'static> RpcClient for RpcClientImpl<S, T> {
         RpcClientImpl::call_with_options(self, payload, options).await
     }
 
-    async fn call_streaming(&self, payload: Vec<u8>, ephemeral_pubkey: [u8; 32]) -> Result<Vec<u8>> {
+    async fn call_streaming(
+        &self,
+        payload: Vec<u8>,
+        ephemeral_pubkey: [u8; 32],
+    ) -> Result<Vec<u8>> {
         RpcClientImpl::call_streaming(self, payload, ephemeral_pubkey).await
     }
 
@@ -657,7 +797,9 @@ impl<S: Signer, T: Transport + 'static> RpcClient for RpcClientImpl<S, T> {
         client_secret: [u8; 32],
         client_pubkey: [u8; 32],
     ) -> Result<Box<dyn StreamHandle>> {
-        let handle = RpcClientImpl::open_stream_from_info(self, stream_info, &client_secret, &client_pubkey).await?;
+        let handle =
+            RpcClientImpl::open_stream_from_info(self, stream_info, &client_secret, &client_pubkey)
+                .await?;
         Ok(Box::new(handle))
     }
 
@@ -705,6 +847,8 @@ mod request_kem_tests {
     /// in these tests (they stop at `sign_envelope`).
     struct ForbidsCleartextMock;
 
+    struct CleartextResponseMock(Vec<u8>);
+
     #[async_trait]
     impl Transport for ForbidsCleartextMock {
         type Sub = RpcPendingStream;
@@ -725,6 +869,37 @@ mod request_kem_tests {
         async fn publish(&self, _topic: &[u8]) -> Result<Self::Pub> {
             anyhow::bail!("mock transport: no publish")
         }
+    }
+
+    #[async_trait]
+    impl Transport for CleartextResponseMock {
+        type Sub = RpcPendingStream;
+        type Pub = RpcPublishStub;
+
+        fn forbids_cleartext_envelope(&self) -> bool {
+            true
+        }
+
+        async fn send(&self, _payload: Vec<u8>, _timeout_ms: Option<i32>) -> Result<Vec<u8>> {
+            Ok(self.0.clone())
+        }
+
+        async fn subscribe(&self, _topic: &[u8]) -> Result<Self::Sub> {
+            anyhow::bail!("unused")
+        }
+
+        async fn publish(&self, _topic: &[u8]) -> Result<Self::Pub> {
+            anyhow::bail!("unused")
+        }
+    }
+
+    fn response_wire(response: &crate::envelope::ResponseEnvelope) -> Vec<u8> {
+        let mut message = capnp::message::Builder::new_default();
+        let mut builder = message.init_root::<crate::common_capnp::response_envelope::Builder>();
+        response.write_to(&mut builder);
+        let mut bytes = Vec::new();
+        capnp::serialize::write_message(&mut bytes, &message).unwrap();
+        bytes
     }
 
     /// A carrier that records whether `send` was ever reached, with a
@@ -821,10 +996,14 @@ mod request_kem_tests {
         )
         .with_request_kem_store(Arc::new(kem_store));
 
-        let bytes = rpc
+        let (bytes, pending) = rpc
             .sign_envelope(1, b"payload".to_vec(), None, None, None)
             .await
             .expect("forwarded store must seal the envelope");
+        assert!(
+            pending.is_some(),
+            "network call must retain a response secret"
+        );
         let signed = signed_envelope_from_bytes(&bytes);
         assert!(
             signed.is_encrypted(),
@@ -834,6 +1013,46 @@ mod request_kem_tests {
         assert!(
             !bytes.windows(b"payload".len()).any(|w| w == b"payload"),
             "cleartext payload must not appear on the wire"
+        );
+    }
+
+    #[tokio::test]
+    async fn hostile_cleartext_response_is_rejected_before_payload_use() {
+        let (server_sk, server_vk) = generate_signing_keypair();
+        let (client_sk, _) = generate_signing_keypair();
+        let server_pq_sk = crate::node_identity::derive_mesh_mldsa_key(&server_sk);
+        let clear = crate::envelope::ResponseEnvelope::new_signed_hybrid(
+            1,
+            b"cleartext-response-sentinel".to_vec(),
+            &server_sk,
+            &server_pq_sk,
+        );
+
+        let mut kem_store = KeyedKemTrustStore::new();
+        kem_store.bind(
+            server_vk.to_bytes(),
+            derive_mesh_kem_recipient(&server_sk).unwrap().public(),
+        );
+        let server_pq_vk = crate::crypto::pq::ml_dsa_vk_from_bytes(
+            &crate::crypto::pq::ml_dsa_sk_to_vk_bytes(&server_pq_sk),
+        )
+        .unwrap();
+        let mut pq_store = crate::envelope::KeyedPqTrustStore::new();
+        pq_store.bind(server_vk.to_bytes(), &server_pq_vk);
+
+        let rpc = RpcClientImpl::new(
+            LocalSigner::new(client_sk),
+            CleartextResponseMock(response_wire(&clear)),
+            Some(server_vk),
+        )
+        .with_request_kem_store(Arc::new(kem_store))
+        .with_response_pq_store(Arc::new(pq_store));
+
+        let err = rpc.call(b"request".to_vec()).await.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("cleartext response rejected before payload use"),
+            "unexpected error: {err}"
         );
     }
 

--- a/crates/hyprstream-rpc/src/service/dispatch.rs
+++ b/crates/hyprstream-rpc/src/service/dispatch.rs
@@ -103,6 +103,23 @@ where
     };
 
     let request_id = ctx.request_id;
+    let actual_service_domain = service.name();
+    crate::envelope::validate_service_domain(actual_service_domain).with_context(|| {
+        format!("service exposes non-canonical domain '{actual_service_domain}'")
+    })?;
+    match ctx.service_domain.as_deref() {
+        Some(expected) if expected != actual_service_domain => {
+            anyhow::bail!(
+                "authenticated request service domain '{expected}' does not match dispatcher '{actual_service_domain}'"
+            );
+        }
+        None if carrier.forbids_cleartext_envelope() => {
+            anyhow::bail!(
+                "authenticated network request omitted serviceDomain; dropping without response"
+            );
+        }
+        _ => {}
+    }
     if carrier.forbids_cleartext_envelope() && ctx.response_kem_recipient.is_none() {
         anyhow::bail!(
             "authenticated network request omitted responseKemRecipient; dropping without response"
@@ -132,6 +149,7 @@ where
                 recipient,
                 request_iat,
                 &request_nonce,
+                actual_service_domain,
             )
             .map_err(Into::into)
         } else {

--- a/crates/hyprstream-rpc/src/service/dispatch.rs
+++ b/crates/hyprstream-rpc/src/service/dispatch.rs
@@ -80,16 +80,6 @@ where
     } else {
         crate::crypto::CryptoPolicy::Classical
     };
-    let sign_response = |request_id: u64, payload: Vec<u8>| {
-        ResponseEnvelope::new_signed_with_policy(
-            request_id,
-            payload,
-            signing_key,
-            response_pq_key.as_ref(),
-            response_policy,
-        )
-    };
-
     let pq_store_holder = crate::envelope::global_pq_store();
     let base = match verification {
         EnvelopeVerification::FixedSigner(pubkey) => {
@@ -113,6 +103,47 @@ where
     };
 
     let request_id = ctx.request_id;
+    if carrier.forbids_cleartext_envelope() && ctx.response_kem_recipient.is_none() {
+        anyhow::bail!(
+            "authenticated network request omitted responseKemRecipient; dropping without response"
+        );
+    }
+    if carrier.forbids_cleartext_envelope() && response_pq_key.is_none() {
+        anyhow::bail!(
+            "network response requires an ML-DSA-65 signing key; dropping without cleartext"
+        );
+    }
+    let response_recipient = ctx.response_kem_recipient.clone();
+    let request_iat = ctx.request_iat;
+    let request_nonce = ctx.request_nonce;
+    let sign_response = |payload: Vec<u8>| -> Result<ResponseEnvelope> {
+        if carrier.forbids_cleartext_envelope() {
+            let recipient = response_recipient
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("missing authenticated response recipient"))?;
+            let pq_key = response_pq_key
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("missing response ML-DSA-65 signing key"))?;
+            ResponseEnvelope::new_signed_encrypted(
+                request_id,
+                payload,
+                signing_key,
+                pq_key,
+                recipient,
+                request_iat,
+                &request_nonce,
+            )
+            .map_err(Into::into)
+        } else {
+            Ok(ResponseEnvelope::new_signed_with_policy(
+                request_id,
+                payload,
+                signing_key,
+                response_pq_key.as_ref(),
+                response_policy,
+            ))
+        }
+    };
     debug!(
         "{} verified request from {} (id={})",
         service.name(),
@@ -130,7 +161,7 @@ where
             e
         );
         let error_payload = service.build_error_payload(request_id, &e.to_string());
-        let signed_response = sign_response(request_id, error_payload);
+        let signed_response = sign_response(error_payload)?;
 
         let mut message = Builder::new_default();
         let mut builder = message.init_root::<crate::common_capnp::response_envelope::Builder>();
@@ -154,7 +185,7 @@ where
     };
 
     // 4. Sign and serialize response
-    let signed_response = sign_response(request_id, response_payload);
+    let signed_response = sign_response(response_payload)?;
 
     let mut message = Builder::new_default();
     let mut builder = message.init_root::<crate::common_capnp::response_envelope::Builder>();

--- a/crates/hyprstream-rpc/src/service/svc.rs
+++ b/crates/hyprstream-rpc/src/service/svc.rs
@@ -144,6 +144,7 @@ pub struct EnvelopeContext {
     pub(crate) request_iat: i64,
     pub(crate) request_nonce: [u8; 16],
     pub(crate) response_kem_recipient: Option<crate::crypto::hybrid_kem::RecipientPublic>,
+    pub(crate) service_domain: Option<String>,
 
     /// Whether this request originated from a genuine in-process / IPC caller
     /// (the `FixedSigner` mutual-auth plane), as opposed to a networked peer
@@ -178,6 +179,7 @@ impl EnvelopeContext {
             request_iat: envelope.envelope.iat,
             request_nonce: envelope.envelope.nonce,
             response_kem_recipient: envelope.envelope.response_kem_recipient.clone(),
+            service_domain: envelope.envelope.service_domain.clone(),
             // AnySigner / networked plane — NOT a local caller (#328).
             is_local_caller: false,
         }
@@ -201,6 +203,7 @@ impl EnvelopeContext {
             request_iat: envelope.envelope.iat,
             request_nonce: envelope.envelope.nonce,
             response_kem_recipient: envelope.envelope.response_kem_recipient.clone(),
+            service_domain: envelope.envelope.service_domain.clone(),
             // FixedSigner mutual-auth plane — genuine in-process / IPC caller (#328).
             is_local_caller: true,
         }
@@ -228,6 +231,7 @@ impl EnvelopeContext {
             request_iat: 0,
             request_nonce: [0; 16],
             response_kem_recipient: None,
+            service_domain: None,
             // Internal self-call that never crosses a network boundary (#328).
             is_local_caller: true,
         }
@@ -1143,6 +1147,7 @@ mod empty_iss_gate_tests {
             request_iat: 0,
             request_nonce: [0; 16],
             response_kem_recipient: None,
+            service_domain: None,
             is_local_caller,
         }
     }
@@ -1296,6 +1301,7 @@ mod ipc_key_identity_tests {
             request_iat: 0,
             request_nonce: [0; 16],
             response_kem_recipient: None,
+            service_domain: None,
             // AnySigner / networked-or-UDS plane.
             is_local_caller: false,
         }
@@ -1521,6 +1527,7 @@ mod accounting_audit_tests {
             request_iat: 0,
             request_nonce: [0; 16],
             response_kem_recipient: None,
+            service_domain: None,
             is_local_caller: true,
         }
     }
@@ -1574,6 +1581,7 @@ mod accounting_audit_tests {
             request_iat: 0,
             request_nonce: [0; 16],
             response_kem_recipient: None,
+            service_domain: None,
             is_local_caller: false,
         };
         let records = capture(|| {
@@ -1637,6 +1645,7 @@ mod accounting_audit_tests {
             request_iat: 0,
             request_nonce: [0; 16],
             response_kem_recipient: None,
+            service_domain: None,
             is_local_caller: false,
         }
     }

--- a/crates/hyprstream-rpc/src/service/svc.rs
+++ b/crates/hyprstream-rpc/src/service/svc.rs
@@ -69,10 +69,7 @@ fn alg_covers_pq(alg: &str) -> bool {
 /// Hybrid [`CryptoPolicy`] a classical-only (`EdDSA`) JWT is rejected
 /// **independent of JWKS alg-list hygiene**. Under Classical any single alg is
 /// passed through to the per-alg decoders (existing behavior).
-fn jwt_alg_satisfies_policy(
-    policy: crate::crypto::CryptoPolicy,
-    alg: &str,
-) -> anyhow::Result<()> {
+fn jwt_alg_satisfies_policy(policy: crate::crypto::CryptoPolicy, alg: &str) -> anyhow::Result<()> {
     if policy.uses_pq() && !alg_covers_pq(alg) {
         anyhow::bail!(
             "Hybrid crypto policy requires a post-quantum JWT alg; \
@@ -142,6 +139,12 @@ pub struct EnvelopeContext {
     /// Present on streaming requests; extracted from `RequestEnvelope.client_dh_public`.
     client_dh_public: Option<[u8; 32]>,
 
+    /// Authenticated request transcript and one-shot response recipient.
+    /// These are used only by the response seal chokepoint.
+    pub(crate) request_iat: i64,
+    pub(crate) request_nonce: [u8; 16],
+    pub(crate) response_kem_recipient: Option<crate::crypto::hybrid_kem::RecipientPublic>,
+
     /// Whether this request originated from a genuine in-process / IPC caller
     /// (the `FixedSigner` mutual-auth plane), as opposed to a networked peer
     /// (the `AnySigner` plane used by ZMQ-QUIC / iroh / WebTransport).
@@ -172,6 +175,9 @@ impl EnvelopeContext {
             cnf: envelope.cnf,
             envelope_wit_hash: envelope.envelope.wth,
             client_dh_public: envelope.envelope.client_dh_public,
+            request_iat: envelope.envelope.iat,
+            request_nonce: envelope.envelope.nonce,
+            response_kem_recipient: envelope.envelope.response_kem_recipient.clone(),
             // AnySigner / networked plane — NOT a local caller (#328).
             is_local_caller: false,
         }
@@ -192,6 +198,9 @@ impl EnvelopeContext {
             cnf: envelope.cnf,
             envelope_wit_hash: envelope.envelope.wth,
             client_dh_public: envelope.envelope.client_dh_public,
+            request_iat: envelope.envelope.iat,
+            request_nonce: envelope.envelope.nonce,
+            response_kem_recipient: envelope.envelope.response_kem_recipient.clone(),
             // FixedSigner mutual-auth plane — genuine in-process / IPC caller (#328).
             is_local_caller: true,
         }
@@ -216,6 +225,9 @@ impl EnvelopeContext {
             cnf: [0u8; 32],
             envelope_wit_hash: None,
             client_dh_public: None,
+            request_iat: 0,
+            request_nonce: [0; 16],
+            response_kem_recipient: None,
             // Internal self-call that never crosses a network boundary (#328).
             is_local_caller: true,
         }
@@ -1128,6 +1140,9 @@ mod empty_iss_gate_tests {
             cnf: [0u8; 32],
             envelope_wit_hash: None,
             client_dh_public: None,
+            request_iat: 0,
+            request_nonce: [0; 16],
+            response_kem_recipient: None,
             is_local_caller,
         }
     }
@@ -1278,6 +1293,9 @@ mod ipc_key_identity_tests {
             cnf: signer_pubkey,
             envelope_wit_hash: None,
             client_dh_public: None,
+            request_iat: 0,
+            request_nonce: [0; 16],
+            response_kem_recipient: None,
             // AnySigner / networked-or-UDS plane.
             is_local_caller: false,
         }
@@ -1500,6 +1518,9 @@ mod accounting_audit_tests {
             cnf: [0u8; 32],
             envelope_wit_hash: None,
             client_dh_public: None,
+            request_iat: 0,
+            request_nonce: [0; 16],
+            response_kem_recipient: None,
             is_local_caller: true,
         }
     }
@@ -1550,6 +1571,9 @@ mod accounting_audit_tests {
             cnf: [0u8; 32],
             envelope_wit_hash: None,
             client_dh_public: None,
+            request_iat: 0,
+            request_nonce: [0; 16],
+            response_kem_recipient: None,
             is_local_caller: false,
         };
         let records = capture(|| {
@@ -1610,6 +1634,9 @@ mod accounting_audit_tests {
             cnf,
             envelope_wit_hash: None,
             client_dh_public: None,
+            request_iat: 0,
+            request_nonce: [0; 16],
+            response_kem_recipient: None,
             is_local_caller: false,
         }
     }

--- a/crates/hyprstream-rpc/tests/e2e_iroh_transport.rs
+++ b/crates/hyprstream-rpc/tests/e2e_iroh_transport.rs
@@ -34,19 +34,17 @@ use ed25519_dalek::{SigningKey, VerifyingKey};
 use rand::RngCore;
 
 use hyprstream_rpc::crypto::hybrid_kem::KeyedKemTrustStore;
-use hyprstream_rpc::dial::{dial_stream, dial_with_kem_store, MoqStreamSession};
-use hyprstream_rpc::envelope::InMemoryNonceCache;
-use hyprstream_rpc::node_identity::derive_mesh_kem_recipient;
+use hyprstream_rpc::dial::{dial_stream, dial_with_crypto_stores, MoqStreamSession};
+use hyprstream_rpc::envelope::{InMemoryNonceCache, KeyedPqTrustStore};
+use hyprstream_rpc::node_identity::{derive_mesh_kem_recipient, derive_mesh_mldsa_key};
 use hyprstream_rpc::rpc_client::RpcClientImpl;
 use hyprstream_rpc::service::{Continuation, EnvelopeContext, RequestService};
 use hyprstream_rpc::signer::LocalSigner;
 use hyprstream_rpc::transport::iroh_moq::{IrohMoqProtocolHandler, OriginShared};
 use hyprstream_rpc::transport::iroh_rpc::{IrohRpcProtocolHandler, LocalServiceBridge};
-use hyprstream_rpc::transport::iroh_substrate::{
-    ALPN_HYPRSTREAM_RPC, IrohSubstrate, NoopHandler,
-};
-use hyprstream_rpc::transport::lazy_iroh::install_iroh_client_endpoint;
+use hyprstream_rpc::transport::iroh_substrate::{IrohSubstrate, NoopHandler, ALPN_HYPRSTREAM_RPC};
 use hyprstream_rpc::transport::iroh_transport::IrohTransport;
+use hyprstream_rpc::transport::lazy_iroh::install_iroh_client_endpoint;
 use hyprstream_rpc::transport::TransportConfig;
 use iroh::{EndpointAddr, EndpointId, TransportAddr};
 use moq_net::{Client, Origin};
@@ -113,6 +111,16 @@ fn request_kem_store_for(
         recipient.public(),
     );
     Ok(std::sync::Arc::new(store))
+}
+
+fn response_pq_store_for(server_signing: &SigningKey) -> Result<std::sync::Arc<KeyedPqTrustStore>> {
+    let pq_sk = derive_mesh_mldsa_key(server_signing);
+    let pq_vk = hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(
+        &hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(&pq_sk),
+    )?;
+    let mut store = KeyedPqTrustStore::new();
+    store.bind(server_signing.verifying_key().to_bytes(), &pq_vk);
+    Ok(Arc::new(store))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -298,10 +306,8 @@ impl RequestService for ModelService {
         self.signing_key.clone()
     }
 
-    // Force Classical responses: this test exercises the EdDSA-only envelope
-    // path (no PQ store provisioned), matching the verify policy installed below.
     fn pq_signing_key(&self) -> Option<hyprstream_rpc::crypto::pq::MlDsaSigningKey> {
-        None
+        Some(derive_mesh_mldsa_key(&self.signing_key))
     }
 }
 
@@ -358,7 +364,7 @@ impl RequestService for RegistryService {
     }
 
     fn pq_signing_key(&self) -> Option<hyprstream_rpc::crypto::pq::MlDsaSigningKey> {
-        None
+        Some(derive_mesh_mldsa_key(&self.signing_key))
     }
 }
 
@@ -394,7 +400,11 @@ async fn rpc_round_trip_model_status_and_registry_list_over_iroh() -> Result<()>
         ModelService::new(fresh_signing_key()),
         RegistryService::new(
             fresh_signing_key(),
-            vec!["model".to_owned(), "registry".to_owned(), "policy".to_owned()],
+            vec![
+                "model".to_owned(),
+                "registry".to_owned(),
+                "policy".to_owned(),
+            ],
         ),
     );
 
@@ -422,12 +432,13 @@ async fn rpc_round_trip_model_status_and_registry_list_over_iroh() -> Result<()>
 
     let target = TransportConfig::iroh(server_node_id, server_direct.clone(), None);
     let request_kem = request_kem_store_for(&server_signing)?;
-    let rpc: Arc<dyn hyprstream_rpc::rpc_client::RpcClient> = dial_with_kem_store(
+    let rpc: Arc<dyn hyprstream_rpc::rpc_client::RpcClient> = dial_with_crypto_stores(
         &target,
         LocalSigner::new(fresh_signing_key()),
         Some(server_vk),
         None,
         Some(request_kem),
+        Some(response_pq_store_for(&server_signing)?),
     )?;
 
     // ─── RPC round-trip #1: model.status() ──────────────────────────────────
@@ -458,13 +469,16 @@ async fn rpc_round_trip_model_status_and_registry_list_over_iroh() -> Result<()>
     // a regression where `dial()`'s erasure drops a setup step. Uses the SAME
     // shared client endpoint the `dial()` factory rides.
     {
-        let conn = client_endpoint.connect(server_addr, ALPN_HYPRSTREAM_RPC).await?;
+        let conn = client_endpoint
+            .connect(server_addr, ALPN_HYPRSTREAM_RPC)
+            .await?;
         let explicit_rpc = RpcClientImpl::new(
             LocalSigner::new(fresh_signing_key()),
             IrohTransport::new(conn),
             Some(server_vk),
         )
-        .with_request_kem_store(request_kem_store_for(&server_signing)?);
+        .with_request_kem_store(request_kem_store_for(&server_signing)?)
+        .with_response_pq_store(response_pq_store_for(&server_signing)?);
         let r = explicit_rpc.call(encode_op("status", b"explicit")).await?;
         assert_eq!(std::str::from_utf8(&r)?, "model.status:ok:explicit=loaded");
     }
@@ -526,7 +540,7 @@ impl RequestService for CompositeRpcService {
     }
 
     fn pq_signing_key(&self) -> Option<hyprstream_rpc::crypto::pq::MlDsaSigningKey> {
-        None
+        Some(derive_mesh_mldsa_key(&self.signing_key))
     }
 }
 
@@ -630,12 +644,13 @@ async fn one_substrate_serves_rpc_and_rejects_anonymous_moq() -> Result<()> {
     // ── RPC plane over `hyprstream-rpc/1` (via the `dial()` factory) ─────────
     let target = TransportConfig::iroh(server_node_id, server_direct.clone(), None);
     let request_kem = request_kem_store_for(&server_signing)?;
-    let rpc: Arc<dyn hyprstream_rpc::rpc_client::RpcClient> = dial_with_kem_store(
+    let rpc: Arc<dyn hyprstream_rpc::rpc_client::RpcClient> = dial_with_crypto_stores(
         &target,
         LocalSigner::new(fresh_signing_key()),
         Some(server_vk),
         None,
         Some(request_kem),
+        Some(response_pq_store_for(&server_signing)?),
     )?;
     let resp = rpc.call(encode_op("status", b"both-alpns-model")).await?;
     assert_eq!(

--- a/crates/hyprstream-rpc/tests/e2e_iroh_transport.rs
+++ b/crates/hyprstream-rpc/tests/e2e_iroh_transport.rs
@@ -447,19 +447,21 @@ async fn rpc_round_trip_model_status_and_registry_list_over_iroh() -> Result<()>
     // stream, writes the signed envelope, and reads back the signed response,
     // which `RpcClientImpl` verifies against `server_vk`.
     let status_req = encode_op("status", b"qwen3-4b");
-    let resp = rpc.call(status_req).await?;
+    let resp = rpc.call_for_service("composite-rpc", status_req).await?;
     let resp_str = std::str::from_utf8(&resp)?;
     assert_eq!(resp_str, "model.status:ok:qwen3-4b=loaded");
 
     // A second op on the same dialed connection exercises stream multiplexing.
     let status_all_req = encode_op("status", b"");
-    let resp_all = rpc.call(status_all_req).await?;
+    let resp_all = rpc
+        .call_for_service("composite-rpc", status_all_req)
+        .await?;
     let resp_all_str = std::str::from_utf8(&resp_all)?;
     assert_eq!(resp_all_str, "model.status:ok:all=loaded");
 
     // ─── RPC round-trip #2: registry.list() ─────────────────────────────────
     let list_req = encode_op("list", b"");
-    let resp_list = rpc.call(list_req).await?;
+    let resp_list = rpc.call_for_service("composite-rpc", list_req).await?;
     let resp_list_str = std::str::from_utf8(&resp_list)?;
     assert_eq!(resp_list_str, "registry.list:ok:model,registry,policy");
 
@@ -479,7 +481,9 @@ async fn rpc_round_trip_model_status_and_registry_list_over_iroh() -> Result<()>
         )
         .with_request_kem_store(request_kem_store_for(&server_signing)?)
         .with_response_pq_store(response_pq_store_for(&server_signing)?);
-        let r = explicit_rpc.call(encode_op("status", b"explicit")).await?;
+        let r = explicit_rpc
+            .call_for_service("composite-rpc", encode_op("status", b"explicit"))
+            .await?;
         assert_eq!(std::str::from_utf8(&r)?, "model.status:ok:explicit=loaded");
     }
 
@@ -652,7 +656,9 @@ async fn one_substrate_serves_rpc_and_rejects_anonymous_moq() -> Result<()> {
         Some(request_kem),
         Some(response_pq_store_for(&server_signing)?),
     )?;
-    let resp = rpc.call(encode_op("status", b"both-alpns-model")).await?;
+    let resp = rpc
+        .call_for_service("model", encode_op("status", b"both-alpns-model"))
+        .await?;
     assert_eq!(
         std::str::from_utf8(&resp)?,
         "model.status:ok:both-alpns-model=loaded"

--- a/crates/hyprstream-rpc/tests/envelope_canonicalization.rs
+++ b/crates/hyprstream-rpc/tests/envelope_canonicalization.rs
@@ -1,5 +1,5 @@
-use hyprstream_rpc::envelope::{Authorization, RequestEnvelope, SignedEnvelope};
 use ed25519_dalek::SigningKey;
+use hyprstream_rpc::envelope::{Authorization, RequestEnvelope, SignedEnvelope};
 use rand::rngs::OsRng;
 
 fn make_signed(envelope: RequestEnvelope, signing_key: &SigningKey) -> SignedEnvelope {
@@ -21,6 +21,7 @@ fn test_envelope_serialization_deterministic() {
         wth: None,
         client_dh_public: None,
         response_kem_recipient: None,
+        service_domain: None,
     };
 
     let envelope2 = envelope1.clone();
@@ -54,6 +55,7 @@ fn test_envelope_signature_verification_stable() {
         wth: None,
         client_dh_public: None,
         response_kem_recipient: None,
+        service_domain: None,
     };
 
     let signed1 = make_signed(envelope.clone(), &signing_key);
@@ -112,12 +114,16 @@ fn test_envelope_canonical_form() {
         wth: None,
         client_dh_public: None,
         response_kem_recipient: None,
+        service_domain: None,
     };
 
     let bytes = envelope.to_bytes();
 
     let bytes_again = envelope.to_bytes();
-    assert_eq!(bytes, bytes_again, "Multiple serializations must be identical");
+    assert_eq!(
+        bytes, bytes_again,
+        "Multiple serializations must be identical"
+    );
 
     assert!(
         bytes.len() < 200,
@@ -138,6 +144,7 @@ fn test_envelope_with_authorization_deterministic() {
         wth: None,
         client_dh_public: None,
         response_kem_recipient: None,
+        service_domain: None,
     };
 
     let bytes1 = envelope.to_bytes();
@@ -150,6 +157,8 @@ fn test_envelope_with_authorization_deterministic() {
 
 #[test]
 fn test_envelope_different_data_different_bytes() {
+    use hyprstream_rpc::crypto::hybrid_kem::{RecipientPublic, SuiteId};
+
     let envelope1 = RequestEnvelope {
         request_id: 100,
         payload: vec![1, 2, 3],
@@ -159,7 +168,11 @@ fn test_envelope_different_data_different_bytes() {
         delegation_token: None,
         wth: None,
         client_dh_public: None,
-        response_kem_recipient: None,
+        response_kem_recipient: Some(RecipientPublic {
+            suite_id: SuiteId::HyKemX25519MlKem768,
+            eks: vec![vec![0x11; 32], vec![0x22; 1184]],
+        }),
+        service_domain: Some("canonical-a".to_owned()),
     };
 
     let envelope2 = RequestEnvelope {
@@ -171,7 +184,11 @@ fn test_envelope_different_data_different_bytes() {
         delegation_token: None,
         wth: None,
         client_dh_public: None,
-        response_kem_recipient: None,
+        response_kem_recipient: Some(RecipientPublic {
+            suite_id: SuiteId::HyKemX25519MlKem768,
+            eks: vec![vec![0x33; 32], vec![0x44; 1184]],
+        }),
+        service_domain: Some("canonical-b".to_owned()),
     };
 
     let bytes1 = envelope1.to_bytes();
@@ -180,5 +197,37 @@ fn test_envelope_different_data_different_bytes() {
     assert_ne!(
         bytes1, bytes2,
         "Different envelopes must produce different bytes"
+    );
+}
+
+#[test]
+fn test_populated_response_recipient_changes_canonical_bytes() {
+    use hyprstream_rpc::crypto::hybrid_kem::{RecipientPublic, SuiteId};
+
+    let recipient = |x25519: u8, mlkem: u8| RecipientPublic {
+        suite_id: SuiteId::HyKemX25519MlKem768,
+        eks: vec![vec![x25519; 32], vec![mlkem; 1184]],
+    };
+    let first = RequestEnvelope {
+        request_id: 300,
+        payload: vec![7, 8, 9],
+        nonce: [3u8; 16],
+        iat: 3000000000,
+        authorization: Authorization::None,
+        delegation_token: None,
+        wth: None,
+        client_dh_public: None,
+        response_kem_recipient: Some(recipient(0x55, 0x66)),
+        service_domain: Some("canonical-service".to_owned()),
+    };
+    let first_again = first.to_bytes();
+    assert_eq!(first_again, first.to_bytes());
+
+    let mut second = first.clone();
+    second.response_kem_recipient = Some(recipient(0x77, 0x88));
+    assert_ne!(
+        first.to_bytes(),
+        second.to_bytes(),
+        "changing only a populated response recipient must change canonical bytes"
     );
 }

--- a/crates/hyprstream-rpc/tests/envelope_canonicalization.rs
+++ b/crates/hyprstream-rpc/tests/envelope_canonicalization.rs
@@ -20,6 +20,7 @@ fn test_envelope_serialization_deterministic() {
         delegation_token: None,
         wth: None,
         client_dh_public: None,
+        response_kem_recipient: None,
     };
 
     let envelope2 = envelope1.clone();
@@ -52,6 +53,7 @@ fn test_envelope_signature_verification_stable() {
         delegation_token: None,
         wth: None,
         client_dh_public: None,
+        response_kem_recipient: None,
     };
 
     let signed1 = make_signed(envelope.clone(), &signing_key);
@@ -109,6 +111,7 @@ fn test_envelope_canonical_form() {
         delegation_token: None,
         wth: None,
         client_dh_public: None,
+        response_kem_recipient: None,
     };
 
     let bytes = envelope.to_bytes();
@@ -134,6 +137,7 @@ fn test_envelope_with_authorization_deterministic() {
         delegation_token: None,
         wth: None,
         client_dh_public: None,
+        response_kem_recipient: None,
     };
 
     let bytes1 = envelope.to_bytes();
@@ -155,6 +159,7 @@ fn test_envelope_different_data_different_bytes() {
         delegation_token: None,
         wth: None,
         client_dh_public: None,
+        response_kem_recipient: None,
     };
 
     let envelope2 = RequestEnvelope {
@@ -166,6 +171,7 @@ fn test_envelope_different_data_different_bytes() {
         delegation_token: None,
         wth: None,
         client_dh_public: None,
+        response_kem_recipient: None,
     };
 
     let bytes1 = envelope1.to_bytes();

--- a/crates/hyprstream-rpc/tests/inv2_receive_dispatch.rs
+++ b/crates/hyprstream-rpc/tests/inv2_receive_dispatch.rs
@@ -99,6 +99,9 @@ impl RequestService for SentinelService {
         payload: &[u8],
     ) -> Result<(Vec<u8>, Option<Continuation>)> {
         self.invoked.store(true, Ordering::SeqCst);
+        if payload == b"handler-error" {
+            anyhow::bail!("intentional handler failure");
+        }
         Ok((payload.to_vec(), None))
     }
 
@@ -112,6 +115,10 @@ impl RequestService for SentinelService {
 
     fn signing_key(&self) -> SigningKey {
         self.signing_key.clone()
+    }
+
+    fn pq_signing_key(&self) -> Option<MlDsaSigningKey> {
+        Some(derive_mesh_mldsa_key(&self.signing_key))
     }
 
     /// Surface the raw error text (the default returns an empty vec) so the
@@ -131,6 +138,7 @@ fn request_envelope(payload: &[u8]) -> RequestEnvelope {
         delegation_token: None,
         wth: None,
         client_dh_public: None,
+        response_kem_recipient: None,
     }
 }
 
@@ -208,8 +216,14 @@ async fn encrypted_on_untrusted_carrier_dispatches() {
     let nonce_cache = envelope::InMemoryNonceCache::new();
 
     let recipient = derive_mesh_kem_recipient(&k.server_sk).unwrap();
+    let response_recipient = hyprstream_rpc::crypto::hybrid_kem::generate_recipient(
+        hyprstream_rpc::crypto::hybrid_kem::SuiteId::HyKemX25519MlKem768,
+    )
+    .unwrap();
+    let request = request_envelope(b"sealed-payload")
+        .with_response_kem_recipient(response_recipient.public());
     let signed = SignedEnvelope::new_signed_encrypted_mesh_kem(
-        request_envelope(b"sealed-payload"),
+        request,
         &k.client_sk,
         &k.client_pq,
         &recipient.public(),
@@ -233,7 +247,85 @@ async fn encrypted_on_untrusted_carrier_dispatches() {
         "encrypted request must dispatch"
     );
     assert_eq!(response.request_id, 7);
-    assert_eq!(response.payload, b"sealed-payload");
+    assert!(response.payload.is_empty());
+    assert!(response.encrypted_response.is_some());
+}
+
+/// A verified, sealed request that omits the response recipient must be
+/// dropped before claims/handler work on every untrusted carrier. The server
+/// cannot safely construct either a success or error response, so no
+/// cleartext fallback is permitted.
+#[tokio::test]
+async fn missing_response_recipient_drops_without_handler_on_all_network_carriers() {
+    let k = keys();
+    let (service, invoked) = SentinelService::new(k.server_sk.clone());
+    let nonce_cache = envelope::InMemoryNonceCache::new();
+    let server_recipient = derive_mesh_kem_recipient(&k.server_sk).unwrap();
+
+    for carrier in [
+        CarrierContext::iroh(),
+        CarrierContext::quic(),
+        CarrierContext::web_transport(),
+        CarrierContext::untrusted_unknown(),
+    ] {
+        let request = request_envelope(b"must-not-dispatch");
+        let signed = SignedEnvelope::new_signed_encrypted_mesh_kem(
+            request,
+            &k.client_sk,
+            &k.client_pq,
+            &server_recipient.public(),
+        )
+        .unwrap();
+        let result = process_request(
+            &to_wire(&signed),
+            &service,
+            EnvelopeVerification::AnySigner,
+            &k.server_sk,
+            &nonce_cache,
+            carrier,
+        )
+        .await;
+        assert!(result.is_err(), "missing recipient must drop on {carrier}");
+        assert!(!invoked.load(Ordering::SeqCst));
+    }
+}
+
+#[tokio::test]
+async fn post_admission_handler_error_is_sealed_not_cleartext() {
+    let k = keys();
+    let (service, invoked) = SentinelService::new(k.server_sk.clone());
+    let nonce_cache = envelope::InMemoryNonceCache::new();
+    let server_recipient = derive_mesh_kem_recipient(&k.server_sk).unwrap();
+    let response_recipient = hyprstream_rpc::crypto::hybrid_kem::generate_recipient(
+        hyprstream_rpc::crypto::hybrid_kem::SuiteId::HyKemX25519MlKem768,
+    )
+    .unwrap();
+    let request =
+        request_envelope(b"handler-error").with_response_kem_recipient(response_recipient.public());
+    let signed = SignedEnvelope::new_signed_encrypted_mesh_kem(
+        request,
+        &k.client_sk,
+        &k.client_pq,
+        &server_recipient.public(),
+    )
+    .unwrap();
+    let bytes = process_request(
+        &to_wire(&signed),
+        &service,
+        EnvelopeVerification::AnySigner,
+        &k.server_sk,
+        &nonce_cache,
+        CarrierContext::quic(),
+    )
+    .await
+    .unwrap();
+    let response = decode_response(&bytes);
+    assert!(invoked.load(Ordering::SeqCst));
+    assert!(response.payload.is_empty());
+    assert!(response.encrypted_response.is_some());
+    assert!(!bytes
+        .windows(b"intentional handler failure".len())
+        .any(|w| { w == b"intentional handler failure" }));
 }
 
 /// Undecodable bytes on an untrusted carrier follow the cleartext branch

--- a/crates/hyprstream-rpc/tests/inv2_receive_dispatch.rs
+++ b/crates/hyprstream-rpc/tests/inv2_receive_dispatch.rs
@@ -72,6 +72,7 @@ fn keys() -> &'static Keys {
 /// Minimal service whose only job is to record whether the application
 /// handler was ever reached.
 struct SentinelService {
+    name: String,
     transport: TransportConfig,
     signing_key: SigningKey,
     invoked: Arc<AtomicBool>,
@@ -79,9 +80,14 @@ struct SentinelService {
 
 impl SentinelService {
     fn new(signing_key: SigningKey) -> (Self, Arc<AtomicBool>) {
+        Self::new_named(signing_key, "inv2-sentinel")
+    }
+
+    fn new_named(signing_key: SigningKey, name: &str) -> (Self, Arc<AtomicBool>) {
         let invoked = Arc::new(AtomicBool::new(false));
         (
             Self {
+                name: name.to_owned(),
                 transport: TransportConfig::inproc("inv2-sentinel"),
                 signing_key,
                 invoked: Arc::clone(&invoked),
@@ -106,7 +112,7 @@ impl RequestService for SentinelService {
     }
 
     fn name(&self) -> &str {
-        "inv2-sentinel"
+        &self.name
     }
 
     fn transport(&self) -> &TransportConfig {
@@ -128,6 +134,63 @@ impl RequestService for SentinelService {
     }
 }
 
+/// Two logical services may intentionally share one Ed25519/PQ/KEM identity.
+/// The authenticated destination, not the key alone, must prevent forwarding
+/// an exact request for A to B.
+#[tokio::test]
+async fn exact_same_key_request_is_bound_to_destination_service() {
+    let k = keys();
+    let (service_a, invoked_a) = SentinelService::new_named(k.server_sk.clone(), "service-a");
+    let (service_b, invoked_b) = SentinelService::new_named(k.server_sk.clone(), "service-b");
+    let response_recipient = hyprstream_rpc::crypto::hybrid_kem::generate_recipient(
+        hyprstream_rpc::crypto::hybrid_kem::SuiteId::HyKemX25519MlKem768,
+    )
+    .unwrap();
+    let request = request_envelope(b"service-bound-control")
+        .with_service_domain("service-a")
+        .unwrap()
+        .with_response_kem_recipient(response_recipient.public());
+    let server_recipient = derive_mesh_kem_recipient(&k.server_sk).unwrap();
+    let signed = SignedEnvelope::new_signed_encrypted_mesh_kem(
+        request,
+        &k.client_sk,
+        &k.client_pq,
+        &server_recipient.public(),
+    )
+    .unwrap();
+    let wire = to_wire(&signed);
+
+    let forwarded = process_request(
+        &wire,
+        &service_b,
+        EnvelopeVerification::AnySigner,
+        &k.server_sk,
+        &envelope::InMemoryNonceCache::new(),
+        CarrierContext::iroh(),
+    )
+    .await;
+    assert!(
+        forwarded.is_err(),
+        "service B must reject A's exact request"
+    );
+    assert!(!invoked_b.load(Ordering::SeqCst));
+
+    let matching = process_request(
+        &wire,
+        &service_a,
+        EnvelopeVerification::AnySigner,
+        &k.server_sk,
+        &envelope::InMemoryNonceCache::new(),
+        CarrierContext::iroh(),
+    )
+    .await
+    .expect("unmutated matching-service control succeeds");
+    let response = decode_response(&matching);
+    assert!(invoked_a.load(Ordering::SeqCst));
+    assert!(response.payload.is_empty());
+    assert!(response.encrypted_response.is_some());
+}
+
 fn request_envelope(payload: &[u8]) -> RequestEnvelope {
     RequestEnvelope {
         request_id: 7,
@@ -139,6 +202,7 @@ fn request_envelope(payload: &[u8]) -> RequestEnvelope {
         wth: None,
         client_dh_public: None,
         response_kem_recipient: None,
+        service_domain: Some("inv2-sentinel".to_owned()),
     }
 }
 

--- a/crates/hyprstream-rpc/tests/iroh_rpc_e2e.rs
+++ b/crates/hyprstream-rpc/tests/iroh_rpc_e2e.rs
@@ -305,7 +305,9 @@ async fn hykem_encrypted_envelope_round_trip_over_iroh() -> Result<()> {
     .with_response_pq_store(Arc::new(response_pq_store));
 
     // Real encrypted + hybrid-signed envelope round-trip over iroh.
-    let response = rpc.call(b"ping-payload".to_vec()).await?;
+    let response = rpc
+        .call_for_service("iroh-echo", b"ping-payload".to_vec())
+        .await?;
     assert_eq!(&response[..], b"\xECping-payload");
     let received = last_received
         .lock()
@@ -354,7 +356,9 @@ async fn hykem_encrypted_envelope_round_trip_over_iroh() -> Result<()> {
     );
 
     // Second call on the same connection to exercise multiple bidi streams.
-    let response2 = rpc.call(b"second".to_vec()).await?;
+    let response2 = rpc
+        .call_for_service("iroh-echo", b"second".to_vec())
+        .await?;
     assert_eq!(&response2[..], b"\xECsecond");
 
     client.shutdown().await?;
@@ -425,6 +429,7 @@ async fn cleartext_envelope_rejected_on_iroh_receive() -> Result<()> {
         wth: None,
         client_dh_public: None,
         response_kem_recipient: None,
+        service_domain: None,
     };
     let signed = SignedEnvelope::new_signed_hybrid(envelope, &client_signing, &client_pq_sk);
     let mut wire = Vec::new();
@@ -508,6 +513,7 @@ async fn false_encrypted_marker_never_reaches_custom_processor_over_iroh() -> Re
             wth: None,
             client_dh_public: None,
             response_kem_recipient: None,
+            service_domain: None,
         },
         &signer,
     );

--- a/crates/hyprstream-rpc/tests/iroh_rpc_e2e.rs
+++ b/crates/hyprstream-rpc/tests/iroh_rpc_e2e.rs
@@ -94,6 +94,10 @@ impl RequestService for EchoService {
     fn signing_key(&self) -> SigningKey {
         self.signing_key.clone()
     }
+
+    fn pq_signing_key(&self) -> Option<hyprstream_rpc::crypto::pq::MlDsaSigningKey> {
+        Some(derive_mesh_mldsa_key(&self.signing_key))
+    }
 }
 
 fn fresh_signing_key() -> SigningKey {
@@ -174,17 +178,27 @@ async fn silent_drop_oracle_rejects_nonresponsive_peer_control() {
 struct RecordingTransport<T> {
     inner: T,
     last_sent: Arc<Mutex<Option<Vec<u8>>>>,
+    last_received: Arc<Mutex<Option<Vec<u8>>>>,
 }
 
 impl<T> RecordingTransport<T> {
-    fn new(inner: T) -> (Self, Arc<Mutex<Option<Vec<u8>>>>) {
+    fn new(
+        inner: T,
+    ) -> (
+        Self,
+        Arc<Mutex<Option<Vec<u8>>>>,
+        Arc<Mutex<Option<Vec<u8>>>>,
+    ) {
         let last_sent = Arc::new(Mutex::new(None));
+        let last_received = Arc::new(Mutex::new(None));
         (
             Self {
                 inner,
                 last_sent: Arc::clone(&last_sent),
+                last_received: Arc::clone(&last_received),
             },
             last_sent,
+            last_received,
         )
     }
 }
@@ -201,7 +215,9 @@ where
 
     async fn send(&self, payload: Vec<u8>, timeout_ms: Option<i32>) -> Result<Vec<u8>> {
         *self.last_sent.lock().await = Some(payload.clone());
-        self.inner.send(payload, timeout_ms).await
+        let response = self.inner.send(payload, timeout_ms).await?;
+        *self.last_received.lock().await = Some(response.clone());
+        Ok(response)
     }
 
     fn forbids_cleartext_envelope(&self) -> bool {
@@ -249,7 +265,7 @@ async fn hykem_encrypted_envelope_round_trip_over_iroh() -> Result<()> {
     .await?;
 
     let conn = client.connect(server_addr, ALPN_HYPRSTREAM_RPC).await?;
-    let (transport, last_sent) = RecordingTransport::new(IrohTransport::new(conn));
+    let (transport, last_sent, last_received) = RecordingTransport::new(IrohTransport::new(conn));
 
     // Request verification: server anchors the client's mesh ML-DSA key.
     let client_pq_sk = derive_mesh_mldsa_key(&client_signing);
@@ -291,6 +307,25 @@ async fn hykem_encrypted_envelope_round_trip_over_iroh() -> Result<()> {
     // Real encrypted + hybrid-signed envelope round-trip over iroh.
     let response = rpc.call(b"ping-payload".to_vec()).await?;
     assert_eq!(&response[..], b"\xECping-payload");
+    let received = last_received
+        .lock()
+        .await
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("response bytes not recorded"))?;
+    assert!(
+        !received
+            .windows(b"ping-payload".len())
+            .any(|w| w == b"ping-payload"),
+        "clear response payload must not appear on the iroh wire"
+    );
+    let response_reader = capnp::serialize::read_message(
+        &mut std::io::Cursor::new(&received),
+        capnp::message::ReaderOptions::new(),
+    )?;
+    let response_outer =
+        response_reader.get_root::<hyprstream_rpc::common_capnp::response_envelope::Reader>()?;
+    assert!(response_outer.get_payload()?.is_empty());
+    assert!(!response_outer.get_encrypted_response()?.is_empty());
     let sent = last_sent
         .lock()
         .await
@@ -389,6 +424,7 @@ async fn cleartext_envelope_rejected_on_iroh_receive() -> Result<()> {
         delegation_token: None,
         wth: None,
         client_dh_public: None,
+        response_kem_recipient: None,
     };
     let signed = SignedEnvelope::new_signed_hybrid(envelope, &client_signing, &client_pq_sk);
     let mut wire = Vec::new();
@@ -471,6 +507,7 @@ async fn false_encrypted_marker_never_reaches_custom_processor_over_iroh() -> Re
             delegation_token: None,
             wth: None,
             client_dh_public: None,
+            response_kem_recipient: None,
         },
         &signer,
     );


### PR DESCRIPTION
## Summary

Closes #1044.

Adds mandatory HyKEM-sealed, hybrid-signed unary RPC responses for every untrusted carrier. Each call generates a fresh response recipient whose private key remains local to the pending call and is consumed when opening the response.

Generated clients bind canonical SERVICE_NAME into the signed and sealed request and pending state. Dispatch compares that authenticated domain byte-for-byte with the actual RequestService name before handler execution. The same domain is included in response AEAD AAD and the sealed-response signature transcript, preventing cross-service substitution even where services share Ed25519, PQ, and KEM identities. Generic or manual network calls without a stable domain fail closed; trusted-local compatibility remains explicit.

Clients reject cleartext on network carriers, reject encrypted responses through the public unwrap API that lacks one-shot decapsulation state, verify the independently anchored server hybrid signature, open the ciphertext, and require inner and outer request-ID agreement. Server success and post-admission error paths share the sealed response path, with no cleartext or truncation fallback.

## Landed base and scope

Exact base: main at afcb36022aeee88519066bf0cb509700d960ba89.

Exact rebased head: b3bbc30486086dadbd8d42a4fa9b383443fd323b.

The base contains landed #1036, #1043 merge 17233c385a9bc235b3e240348bbbb60df63bf109, and #1006 merge afcb36022aeee88519066bf0cb509700d960ba89. The branch contains exactly two response-confidentiality commits above main. Conflict resolution retained the landed #1006 rule that iroh reach identity cannot substitute for an independently resolved application response key.

Scope is unary responses, including the initial response used to establish streaming calls. This does not claim to close broader transport hardening in #1028. Trusted-local dispatch intentionally retains signed-clear behavior.

## Adversarial coverage

- exact same-key two-service forwarding rejection before handler work, with matching-service control
- service domain bound inside authenticated request, pending state, response AAD, and response signature transcript
- distinct concurrent recipients and rejection of swapped live responses
- cancellation and send-failure cleanup plus fresh recipient on retry
- cleartext response rejection, malformed ciphertext and request-ID substitution rejection
- bounded recipient and encrypted-response parsing with canonicalization coverage
- all untrusted carrier classes plus explicit trusted-local regression
- real iroh encrypted round trip and anonymous MoQ refusal retained from main

## Fresh post-rebase validation

All Cargo validation used isolated target directory target-1045-post1043-sol and ran serially.

- full RPC tests: 708 library tests plus all 11 integration binaries passed
- focused response transcript, destination-domain, lifecycle, carrier-matrix, and canonicalization suites passed
- real iroh RPC 5 of 5 and real iroh transport 4 of 4 passed
- RPC Clippy with warnings denied passed
- browser WASM check passed
- cargo-deny bans and licenses passed with existing informational warnings only
- rpc-std, rpc-derive, and rpc-build all-target checks passed
- downstream hyprstream and hyprstream-service checks passed using the repository documented OpenSSL and PyTorch environment
- git diff check passed

PR remains open and unmerged. Issues #1044 and #1028 remain open pending their stated closure rules.