### PR TITLE
ci: disable claude-code-review workflow (broken OAuth token)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,11 @@ on:
 
 jobs:
   claude-review:
+    # Disabled: CLAUDE_CODE_OAUTH_TOKEN is broken — the action fails auth before
+    # reviewing any code (is_error:true, ~2s, no findings) on every PR since
+    # 2026-07-11. Re-enable once the token is rotated. See #1046.
+    if: false
+
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
## Summary
The \`Claude Code Review\` GitHub Action has been failing on every PR since at least 2026-07-11 — confirmed across multiple unrelated PRs (#1035, #1036, #1037, #1040). Pulling the actual run logs shows the SDK initializes then immediately errors out (\`is_error:true\`, ~2s duration, \`total_cost_usd: 0\`, \`num_turns: 1\`) — it never reviews any code. This points to \`secrets.CLAUDE_CODE_OAUTH_TOKEN\` being expired/invalid, not a content issue: the same workflow succeeded on PRs as recently as 3 days prior.

Filed #1046 to track the token rotation (needs repo admin access I don't have). This PR just disables the job (\`if: false\`) so it stops posting a failing, noisy check on every PR in the meantime — the workflow file is left otherwise intact for an easy re-enable once the token is fixed.

## Test plan
- N/A — CI-config-only change (disables a job via \`if: false\`)