### PR TITLE
security(rpc): verify and enforce transport PQ policy (#557)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7200,6 +7200,7 @@ dependencies = [
  "moq-net",
  "n0-error",
  "nix 0.27.1",
+ "noq",
  "once_cell",
  "p256",
  "parking_lot 0.12.4",
@@ -10091,6 +10092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cee32450cf726b223ac4154003c93cb52fbde159ab1240990e88945bf3ae35e"
 dependencies = [
  "aes-gcm",
+ "aws-lc-rs",
  "bytes",
  "derive_more",
  "enum-assoc",
@@ -12804,6 +12806,7 @@ version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "fastbloom",
  "getrandom 0.3.3",

--- a/crates/hyprstream-rpc/Cargo.toml
+++ b/crates/hyprstream-rpc/Cargo.toml
@@ -167,6 +167,11 @@ hyprstream-rpc-build = { path = "../hyprstream-rpc-build" }
 [dev-dependencies]
 tokio-test = { workspace = true }
 tracing-subscriber = { workspace = true }
+noq = { version = "=1.0.0-rc.0", default-features = false, features = ["rustls-aws-lc-rs"] }
+# Quinn hides the negotiated NamedGroup behind this upstream diagnostic feature.
+# Enabling it only for tests lets live zmtp assertions use handshake_data without
+# packet parsing or changing production wire behavior.
+quinn = { workspace = true, features = ["__rustls-post-quantum-test"] }
 
 [lints]
 workspace = true

--- a/crates/hyprstream-rpc/src/transport/iroh_substrate.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_substrate.rs
@@ -105,10 +105,9 @@ impl IrohSubstrate {
     {
         let endpoint = Endpoint::builder(presets::N0)
             .secret_key(SecretKey::from_bytes(&secret_key_bytes))
-            // PQ-hybrid TLS: pin X25519MLKEM768 on the iroh QUIC channel (#557 / S6).
-            // Overrides the preset's default (ring) provider; RFC 7250 raw-public-key
-            // identity binding is orthogonal to kx_groups and unaffected.
-            .crypto_provider(crate::transport::pq_provider::pq_crypto_provider())
+            // Owned mesh policy: require X25519MLKEM768 with no classical
+            // fallback. RFC 7250 raw-public-key identity is orthogonal to kx.
+            .crypto_provider(crate::transport::pq_provider::internal_mesh_crypto_provider())
             .bind()
             .await
             .map_err(|e| anyhow::anyhow!("iroh endpoint bind: {e}"))?;
@@ -270,10 +269,13 @@ impl ProtocolHandler for EchoHandler {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
     use iroh::TransportAddr;
+    use noq::crypto::rustls::HandshakeData;
     use rand::RngCore;
+    use std::sync::Arc;
 
     fn fresh_key() -> [u8; 32] {
         let mut k = [0u8; 32];
@@ -293,6 +295,20 @@ mod tests {
                 .into_iter()
                 .map(TransportAddr::Ip),
         )
+    }
+
+    fn assert_hybrid_handshake(conn: &Connection, alpn: &[u8]) {
+        let data = conn
+            .handshake_data()
+            .expect("completed iroh connection has handshake data")
+            .downcast::<HandshakeData>()
+            .expect("iroh uses noq rustls handshake data");
+        assert_eq!(data.protocol.as_deref(), Some(alpn));
+        assert_eq!(
+            data.negotiated_key_exchange_group,
+            Some(rustls::NamedGroup::X25519MLKEM768),
+            "owned iroh mesh must negotiate X25519MLKEM768"
+        );
     }
 
     /// Smoke test: build two substrates, dial direct (no DNS/pkarr), echo a
@@ -318,6 +334,7 @@ mod tests {
             let conn = client
                 .connect(server_addr.clone(), ALPN_HYPRSTREAM_RPC)
                 .await?;
+            assert_hybrid_handshake(&conn, ALPN_HYPRSTREAM_RPC);
             let (mut send, mut recv) = conn.open_bi().await?;
             send.write_all(b"hello rpc").await?;
             send.finish()?;
@@ -328,6 +345,7 @@ mod tests {
         // Streaming plane round-trip (echo here; real moq-net wiring lands in Phase 3).
         {
             let conn = client.connect(server_addr.clone(), ALPN_MOQ_LITE).await?;
+            assert_hybrid_handshake(&conn, ALPN_MOQ_LITE);
             let (mut send, mut recv) = conn.open_bi().await?;
             send.write_all(b"hello moq").await?;
             send.finish()?;
@@ -339,6 +357,30 @@ mod tests {
         assert_eq!(server.endpoint_id(), server_id);
 
         client.shutdown().await?;
+        server.shutdown().await?;
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn internal_iroh_mesh_rejects_classical_only_peer() -> Result<()> {
+        let server = IrohSubstrate::new(fresh_key(), EchoHandler, EchoHandler).await?;
+        let server_addr = direct_addr(&server);
+        let classical_client = Endpoint::builder(presets::N0)
+            .secret_key(SecretKey::from_bytes(&fresh_key()))
+            .crypto_provider(Arc::new(rustls::crypto::ring::default_provider()))
+            .bind()
+            .await
+            .map_err(|e| anyhow::anyhow!("classical mutation endpoint bind: {e}"))?;
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            classical_client.connect(server_addr, ALPN_HYPRSTREAM_RPC),
+        )
+        .await
+        .expect("classical-only iroh mutation handshake must terminate");
+        assert!(result.is_err(), "internal iroh mesh accepted classical-only TLS");
+
+        classical_client.close().await;
         server.shutdown().await?;
         Ok(())
     }

--- a/crates/hyprstream-rpc/src/transport/iroh_substrate.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_substrate.rs
@@ -81,6 +81,24 @@ pub struct IrohSubstrate {
     router: Router,
 }
 
+/// Capability proving an outbound iroh endpoint was constructed by
+/// [`IrohSubstrate::new`] with the owned hybrid-only crypto provider.
+///
+/// The inner endpoint is intentionally private: an already-bound iroh endpoint
+/// does not expose its effective provider, so arbitrary endpoints cannot be
+/// promoted into the process-global RPC/MoQ dialer.
+#[derive(Clone)]
+pub struct OwnedIrohClientEndpoint(Endpoint);
+
+impl OwnedIrohClientEndpoint {
+    pub(crate) fn install_into(
+        self,
+        slot: &std::sync::OnceLock<Endpoint>,
+    ) -> std::result::Result<(), Self> {
+        slot.set(self.0).map_err(Self)
+    }
+}
+
 impl IrohSubstrate {
     /// Build the substrate from raw 32-byte Ed25519 secret key material.
     ///
@@ -172,6 +190,12 @@ impl IrohSubstrate {
     /// an ALPN not served by this substrate's router.
     pub fn endpoint(&self) -> &Endpoint {
         &self.endpoint
+    }
+
+    /// Clone the endpoint as an owned-provider capability for installation as
+    /// the shared outbound RPC and MoQ dial endpoint.
+    pub fn owned_client_endpoint(&self) -> OwnedIrohClientEndpoint {
+        OwnedIrohClientEndpoint(self.endpoint.clone())
     }
 
     /// Borrow the router (e.g. to inspect or to share lifetime).
@@ -371,13 +395,19 @@ mod tests {
             .await
             .map_err(|e| anyhow::anyhow!("classical mutation endpoint bind: {e}"))?;
 
-        let result = tokio::time::timeout(
-            std::time::Duration::from_secs(5),
-            classical_client.connect(server_addr, ALPN_HYPRSTREAM_RPC),
-        )
-        .await
-        .expect("classical-only iroh mutation handshake must terminate");
-        assert!(result.is_err(), "internal iroh mesh accepted classical-only TLS");
+        for alpn in [ALPN_HYPRSTREAM_RPC, ALPN_MOQ_LITE] {
+            let result = tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                classical_client.connect(server_addr.clone(), alpn),
+            )
+            .await
+            .expect("classical-only iroh mutation handshake must terminate");
+            assert!(
+                result.is_err(),
+                "internal iroh outbound endpoint reached owned ALPN {:?}",
+                String::from_utf8_lossy(alpn)
+            );
+        }
 
         classical_client.close().await;
         server.shutdown().await?;

--- a/crates/hyprstream-rpc/src/transport/iroh_substrate.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_substrate.rs
@@ -58,7 +58,7 @@
 //! NodeIds are reachable and correlate lookup traffic) is **unaffected** by this
 //! demotion — pkarr is still public. Its mitigation is oblivious-relay (#361);
 //! until then, operators that consider the side channel actionable should run a
-//! self-hosted `iroh-dns-server` via [`IrohSubstrate::from_endpoint`].
+//! self-hosted `iroh-dns-server` configured through the owned endpoint builder.
 
 use anyhow::Result;
 use iroh::endpoint::{Connection, presets};
@@ -85,9 +85,10 @@ impl IrohSubstrate {
     /// Build the substrate from raw 32-byte Ed25519 secret key material.
     ///
     /// Uses iroh's `presets::N0` for discovery (n0 DNS + pkarr) and relay
-    /// fallback. Operators wanting self-hosted discovery should bypass this
-    /// constructor and use [`IrohSubstrate::from_endpoint`] with a
-    /// pre-configured `iroh::Endpoint`.
+    /// fallback. Alternate discovery configuration must be added through an
+    /// owned builder that also installs this same hybrid-only provider; a
+    /// prebuilt endpoint cannot safely be accepted because iroh exposes no
+    /// effective-provider introspection after bind.
     ///
     /// **pkarr here is liveness-only** — see the module-level "D3" note. The
     /// published record carries reach hints (relay + direct addrs) for this
@@ -112,7 +113,7 @@ impl IrohSubstrate {
             .await
             .map_err(|e| anyhow::anyhow!("iroh endpoint bind: {e}"))?;
 
-        Ok(Self::from_endpoint(endpoint, moq_handler, rpc_handler))
+        Ok(Self::from_owned_endpoint(endpoint, moq_handler, rpc_handler))
     }
 
     /// Build a hermetic direct-only substrate for unit tests.
@@ -135,19 +136,17 @@ impl IrohSubstrate {
     {
         let endpoint = Endpoint::builder(presets::Empty)
             .secret_key(SecretKey::from_bytes(&secret_key_bytes))
-            .crypto_provider(crate::transport::pq_provider::pq_crypto_provider())
+            .crypto_provider(crate::transport::pq_provider::internal_mesh_crypto_provider())
             .bind()
             .await
             .map_err(|e| anyhow::anyhow!("test iroh endpoint bind: {e}"))?;
 
-        Ok(Self::from_endpoint(endpoint, moq_handler, rpc_handler))
+        Ok(Self::from_owned_endpoint(endpoint, moq_handler, rpc_handler))
     }
 
-    /// Wrap a caller-built endpoint. Useful when the caller wants
-    /// non-default discovery (e.g. self-hosted `iroh-dns-server`), a
-    /// non-default crypto provider, or to share an existing endpoint
-    /// across substrates.
-    pub fn from_endpoint<M, R>(
+    /// Attach the owned ALPNs to an endpoint constructed immediately above.
+    /// Kept private because `Endpoint` does not reveal its effective provider.
+    fn from_owned_endpoint<M, R>(
         endpoint: Endpoint,
         moq_handler: M,
         rpc_handler: R,

--- a/crates/hyprstream-rpc/src/transport/lazy_iroh.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_iroh.rs
@@ -36,7 +36,7 @@ use async_trait::async_trait;
 use tokio::sync::Mutex;
 
 use crate::transport::backoff::LazyState;
-use crate::transport::iroh_substrate::ALPN_HYPRSTREAM_RPC;
+use crate::transport::iroh_substrate::{ALPN_HYPRSTREAM_RPC, OwnedIrohClientEndpoint};
 use crate::transport::iroh_transport::{IrohPendingStream, IrohPublishStub, IrohTransport};
 use crate::transport_traits::Transport;
 
@@ -51,15 +51,34 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// Process-wide client iroh endpoint, installed once at startup.
 static IROH_CLIENT_ENDPOINT: OnceLock<iroh::Endpoint> = OnceLock::new();
 
-/// Install the process-global client iroh [`Endpoint`](iroh::Endpoint) used to
+/// Install the process-global client iroh endpoint used to
 /// originate outbound RPC dials. First-write-wins (mirrors
 /// `install_verify_config`); returns `Err(endpoint)` if one is already set.
 ///
 /// The daemon calls this once during bootstrap with the shared endpoint (the
 /// same one its inbound iroh substrate listens on, so outbound dials reuse the
-/// transport sockets and address).
-pub fn install_iroh_client_endpoint(endpoint: iroh::Endpoint) -> Result<(), iroh::Endpoint> {
-    IROH_CLIENT_ENDPOINT.set(endpoint)
+/// node identity). The capability can only be obtained from
+/// [`crate::transport::iroh_substrate::IrohSubstrate::owned_client_endpoint`],
+/// which proves the endpoint was bound with the exact hybrid-only provider.
+///
+/// Arbitrary already-bound endpoints are rejected by the type system:
+///
+/// ```compile_fail
+/// # let endpoint: iroh::Endpoint = todo!();
+/// hyprstream_rpc::transport::lazy_iroh::install_iroh_client_endpoint(endpoint);
+/// ```
+///
+/// The opaque capability itself also cannot be forged from a raw endpoint:
+///
+/// ```compile_fail
+/// # let endpoint: iroh::Endpoint = todo!();
+/// let _owned =
+///     hyprstream_rpc::transport::iroh_substrate::OwnedIrohClientEndpoint(endpoint);
+/// ```
+pub fn install_iroh_client_endpoint(
+    endpoint: OwnedIrohClientEndpoint,
+) -> Result<(), OwnedIrohClientEndpoint> {
+    endpoint.install_into(&IROH_CLIENT_ENDPOINT)
 }
 
 /// The installed client endpoint, cloned (cheap — iroh `Endpoint` is `Arc`-backed).

--- a/crates/hyprstream-rpc/src/transport/lazy_quinn.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_quinn.rs
@@ -205,7 +205,8 @@ mod tests {
     /// server cert's SHA-256 pin, and a shutdown token. (Mirrors the harness in
     /// `quinn_transport::tests`; `build_server` there is test-private.)
     fn spawn_echo_server() -> (SocketAddr, [u8; 32], CancellationToken) {
-        crate::transport::pq_provider::install_pq_crypto_provider();
+        crate::transport::pq_provider::install_pq_crypto_provider()
+            .expect("install PQ provider");
 
         let cert_key = rcgen::generate_simple_self_signed(vec!["localhost".to_owned()]).unwrap();
         let cert_der = cert_key.cert.der().to_vec();

--- a/crates/hyprstream-rpc/src/transport/pq_provider.rs
+++ b/crates/hyprstream-rpc/src/transport/pq_provider.rs
@@ -10,7 +10,6 @@ use std::sync::Arc;
 
 use rustls::crypto::{aws_lc_rs, CryptoProvider};
 
-#[cfg(test)]
 const INTERNAL_MESH_GROUPS: &[rustls::NamedGroup] = &[rustls::NamedGroup::X25519MLKEM768];
 const EXTERNAL_INTEROP_GROUPS: &[rustls::NamedGroup] = &[
     rustls::NamedGroup::X25519MLKEM768,
@@ -21,6 +20,8 @@ const EXTERNAL_INTEROP_GROUPS: &[rustls::NamedGroup] = &[
 /// declared external-interoperability policy.
 #[derive(Debug)]
 pub struct ProviderPolicyError {
+    expected: &'static [rustls::NamedGroup],
+    boundary: &'static str,
     actual: Vec<rustls::NamedGroup>,
 }
 
@@ -28,9 +29,8 @@ impl std::fmt::Display for ProviderPolicyError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             formatter,
-            "rustls process-default crypto policy mismatch: expected \
-             [X25519MLKEM768, X25519], got {:?}; another provider was installed first",
-            self.actual
+            "rustls {} crypto policy mismatch: expected {:?}, got {:?}",
+            self.boundary, self.expected, self.actual
         )
     }
 }
@@ -69,6 +69,31 @@ fn group_names(provider: &CryptoProvider) -> Vec<rustls::NamedGroup> {
         .collect()
 }
 
+fn validate_provider(
+    provider: &CryptoProvider,
+    expected: &'static [rustls::NamedGroup],
+    boundary: &'static str,
+) -> Result<(), ProviderPolicyError> {
+    let actual = group_names(provider);
+    if actual != expected {
+        return Err(ProviderPolicyError {
+            expected,
+            boundary,
+            actual,
+        });
+    }
+    Ok(())
+}
+
+/// Validate that a caller-supplied config uses the exact owned-mesh policy.
+/// This is intentionally stricter than merely preferring the hybrid group:
+/// any classical fallback makes the config unsuitable for an owned boundary.
+pub fn validate_internal_mesh_crypto_provider(
+    provider: &CryptoProvider,
+) -> Result<(), ProviderPolicyError> {
+    validate_provider(provider, INTERNAL_MESH_GROUPS, "owned-mesh")
+}
+
 /// Install and validate the external-interoperability provider as rustls's
 /// process-wide default.
 ///
@@ -86,12 +111,16 @@ pub fn install_pq_crypto_provider() -> Result<(), ProviderPolicyError> {
     ])
     .install_default();
 
-    let actual =
-        CryptoProvider::get_default().map_or_else(Vec::new, |provider| group_names(provider));
-    if actual != EXTERNAL_INTEROP_GROUPS {
-        return Err(ProviderPolicyError { actual });
-    }
-    Ok(())
+    let provider = CryptoProvider::get_default().ok_or(ProviderPolicyError {
+        expected: EXTERNAL_INTEROP_GROUPS,
+        boundary: "process-default external-interoperability",
+        actual: Vec::new(),
+    })?;
+    validate_provider(
+        provider,
+        EXTERNAL_INTEROP_GROUPS,
+        "process-default external-interoperability",
+    )
 }
 
 #[cfg(test)]

--- a/crates/hyprstream-rpc/src/transport/pq_provider.rs
+++ b/crates/hyprstream-rpc/src/transport/pq_provider.rs
@@ -142,6 +142,29 @@ mod tests {
     }
 
     #[test]
+    fn internal_mesh_rejects_external_reordered_and_duplicate_groups() {
+        let mutations = [
+            provider_with_groups([
+                aws_lc_rs::kx_group::X25519MLKEM768,
+                aws_lc_rs::kx_group::X25519,
+            ]),
+            provider_with_groups([
+                aws_lc_rs::kx_group::X25519,
+                aws_lc_rs::kx_group::X25519MLKEM768,
+            ]),
+            provider_with_groups([
+                aws_lc_rs::kx_group::X25519MLKEM768,
+                aws_lc_rs::kx_group::X25519MLKEM768,
+            ]),
+        ];
+
+        for provider in mutations {
+            validate_internal_mesh_crypto_provider(&provider)
+                .expect_err("every non-exact owned-mesh group list must be rejected");
+        }
+    }
+
+    #[test]
     fn external_interop_live_handshake_allows_classical_peer() {
         let certified = rcgen::generate_simple_self_signed(vec!["localhost".to_owned()])
             .expect("generate test certificate");
@@ -221,23 +244,51 @@ mod tests {
         rustls::crypto::ring::default_provider()
             .install_default()
             .expect("fresh child process must not already have a provider");
-        install_pq_crypto_provider().expect("non-PQ provider must fail closed");
+        let error = install_pq_crypto_provider()
+            .expect_err("non-PQ provider must fail closed with a policy error");
+        panic!("expected ring-first policy rejection: {error}");
     }
 
     #[test]
     fn non_pq_provider_installed_first_fails_closed() {
-        let exe = std::env::current_exe().expect("test executable path");
-        let output = std::process::Command::new(exe)
-            .args([
-                "--ignored",
-                "--exact",
-                "transport::pq_provider::tests::non_pq_provider_installed_first_child",
-            ])
-            .output()
-            .expect("run provider-ordering mutation child");
+        let name = "transport::pq_provider::tests::non_pq_provider_installed_first_child";
+        let output = run_provider_fixture(name);
         assert!(
             !output.status.success(),
             "a ring provider installed first must make startup fail"
         );
+        let child_output = format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            child_output.contains("crypto policy mismatch"),
+            "ring-first fixture must fail for the expected policy error: {child_output}"
+        );
+    }
+
+    fn run_provider_fixture(name: &str) -> std::process::Output {
+        let mut child =
+            std::process::Command::new(std::env::current_exe().expect("test executable path"))
+                .args(["--ignored", "--exact", name])
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .spawn()
+                .expect("spawn provider-ordering mutation child");
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        loop {
+            if child.try_wait().expect("poll provider fixture").is_some() {
+                return child
+                    .wait_with_output()
+                    .expect("collect provider fixture output");
+            }
+            if std::time::Instant::now() >= deadline {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("provider fixture {name} timed out after 30 seconds");
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
     }
 }

--- a/crates/hyprstream-rpc/src/transport/pq_provider.rs
+++ b/crates/hyprstream-rpc/src/transport/pq_provider.rs
@@ -46,6 +46,13 @@ fn provider_with_groups(
     }
 }
 
+fn external_interop_provider() -> CryptoProvider {
+    provider_with_groups([
+        aws_lc_rs::kx_group::X25519MLKEM768,
+        aws_lc_rs::kx_group::X25519,
+    ])
+}
+
 /// Provider for an owned internal-mesh connection. Classical fallback is
 /// intentionally absent, so an X25519-only peer fails the TLS handshake.
 pub fn internal_mesh_crypto_provider() -> Arc<CryptoProvider> {
@@ -55,10 +62,7 @@ pub fn internal_mesh_crypto_provider() -> Arc<CryptoProvider> {
 /// Provider for an explicitly declared external-interoperability boundary.
 /// PQ hybrid is preferred, with classical X25519 retained for non-PQ peers.
 pub fn pq_crypto_provider() -> Arc<CryptoProvider> {
-    Arc::new(provider_with_groups([
-        aws_lc_rs::kx_group::X25519MLKEM768,
-        aws_lc_rs::kx_group::X25519,
-    ]))
+    Arc::new(external_interop_provider())
 }
 
 fn group_names(provider: &CryptoProvider) -> Vec<rustls::NamedGroup> {
@@ -105,11 +109,7 @@ pub fn validate_internal_mesh_crypto_provider(
 /// external policy. Call it before constructing any WebTransport/rustls
 /// builder; a policy violation fails startup instead of downgrading transport.
 pub fn install_pq_crypto_provider() -> Result<(), ProviderPolicyError> {
-    let _ = provider_with_groups([
-        aws_lc_rs::kx_group::X25519MLKEM768,
-        aws_lc_rs::kx_group::X25519,
-    ])
-    .install_default();
+    let _ = external_interop_provider().install_default();
 
     let provider = CryptoProvider::get_default().ok_or(ProviderPolicyError {
         expected: EXTERNAL_INTEROP_GROUPS,

--- a/crates/hyprstream-rpc/src/transport/pq_provider.rs
+++ b/crates/hyprstream-rpc/src/transport/pq_provider.rs
@@ -1,85 +1,214 @@
-//! Post-quantum hybrid TLS crypto provider (#557 / S6 of epic #550).
+//! Post-quantum hybrid TLS crypto-provider policies (#557 / S6 of epic #550).
 //!
-//! Pins the TLS 1.3 key exchange to **X25519MLKEM768** (the hybrid PQ group of
-//! draft-ietf-tls-ecdhe-mlkem / RFC 9370 framing) with classical **X25519** as a
-//! fallback for interop with non-PQ peers. ML-KEM is only available via the
-//! **aws-lc-rs** rustls provider — the `ring` provider this replaces has no
-//! ML-KEM, which is why every `ring::default_provider().install_default()` site
-//! is swapped for [`install_pq_crypto_provider`].
-//!
-//! This is transport-layer **defense-in-depth**. The real, transport-independent
-//! confidentiality guarantee is the application-layer hybrid KEM (`HyKEM`,
-//! [`crate::crypto::hybrid_kem`], S0) which also covers the wasm/browser path
-//! where we cannot touch the WebTransport TLS handshake. Here we harden the QUIC
-//! channel on the paths we own (zmtp, iroh, quinn/WebTransport).
-//!
-//! Native-only: rustls/aws-lc-rs are not part of the wasm32 build.
+//! The owned internal mesh (zmtp and both iroh ALPNs) is hybrid-only: it has no
+//! classical key-exchange fallback. The process-wide provider used by the
+//! external WebTransport/HTTP perimeter deliberately retains X25519 fallback
+//! for browser and third-party interoperability. Application-layer HyKEM is the
+//! primary, transport-independent confidentiality guarantee on every path.
 
 use std::sync::Arc;
 
 use rustls::crypto::{aws_lc_rs, CryptoProvider};
 
-/// Build the pinned PQ-hybrid crypto provider: aws-lc-rs with
-/// `kx_groups = [X25519MLKEM768, X25519]` (hybrid first, classical fallback). All
-/// other parameters are aws-lc-rs defaults (cipher suites, signature schemes).
-///
-/// Pinning `kx_groups` explicitly (rather than relying on the `prefer-post-quantum`
-/// default order) makes the policy deterministic and auditable: a PQ-capable peer
-/// negotiates X25519MLKEM768; a classical-only peer falls back to X25519 (the
-/// channel is then classical, but the app-layer HyKEM stays hybrid).
-fn build_provider() -> CryptoProvider {
+#[cfg(test)]
+const INTERNAL_MESH_GROUPS: &[rustls::NamedGroup] = &[rustls::NamedGroup::X25519MLKEM768];
+const EXTERNAL_INTEROP_GROUPS: &[rustls::NamedGroup] = &[
+    rustls::NamedGroup::X25519MLKEM768,
+    rustls::NamedGroup::X25519,
+];
+
+/// The effective process-wide rustls provider does not match hyprstream's
+/// declared external-interoperability policy.
+#[derive(Debug)]
+pub struct ProviderPolicyError {
+    actual: Vec<rustls::NamedGroup>,
+}
+
+impl std::fmt::Display for ProviderPolicyError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "rustls process-default crypto policy mismatch: expected \
+             [X25519MLKEM768, X25519], got {:?}; another provider was installed first",
+            self.actual
+        )
+    }
+}
+
+impl std::error::Error for ProviderPolicyError {}
+
+fn provider_with_groups(
+    groups: impl IntoIterator<Item = &'static dyn rustls::crypto::SupportedKxGroup>,
+) -> CryptoProvider {
     CryptoProvider {
-        kx_groups: vec![
-            aws_lc_rs::kx_group::X25519MLKEM768,
-            aws_lc_rs::kx_group::X25519,
-        ],
+        kx_groups: groups.into_iter().collect(),
         ..aws_lc_rs::default_provider()
     }
 }
 
-pub fn pq_crypto_provider() -> Arc<CryptoProvider> {
-    Arc::new(build_provider())
+/// Provider for an owned internal-mesh connection. Classical fallback is
+/// intentionally absent, so an X25519-only peer fails the TLS handshake.
+pub fn internal_mesh_crypto_provider() -> Arc<CryptoProvider> {
+    Arc::new(provider_with_groups([aws_lc_rs::kx_group::X25519MLKEM768]))
 }
 
-/// Install [`pq_crypto_provider`] as the process-wide rustls default.
+/// Provider for an explicitly declared external-interoperability boundary.
+/// PQ hybrid is preferred, with classical X25519 retained for non-PQ peers.
+pub fn pq_crypto_provider() -> Arc<CryptoProvider> {
+    Arc::new(provider_with_groups([
+        aws_lc_rs::kx_group::X25519MLKEM768,
+        aws_lc_rs::kx_group::X25519,
+    ]))
+}
+
+fn group_names(provider: &CryptoProvider) -> Vec<rustls::NamedGroup> {
+    provider
+        .kx_groups
+        .iter()
+        .map(|group| group.name())
+        .collect()
+}
+
+/// Install and validate the external-interoperability provider as rustls's
+/// process-wide default.
 ///
-/// Idempotent — the first install in the process wins and later calls are a
-/// no-op (`install_default` returns `Err` once set; we ignore it). Must run
-/// before any rustls `ServerConfig`/`ClientConfig::builder()`, quinn endpoint, or
-/// web-transport endpoint that resolves the process default
-/// (`CryptoProvider::get_default()`). This is the single replacement for the
-/// former `rustls::crypto::ring::default_provider().install_default()` calls; it
-/// also covers the WebTransport (`web-transport-quinn`) path, whose builder has
-/// no provider setter and resolves the process default.
-pub fn install_pq_crypto_provider() {
-    // `install_default` consumes an owned `CryptoProvider` (not an `Arc`); the
-    // first install in the process wins and returns `Ok`, later calls return
-    // `Err(already_set)` which we ignore.
-    let _ = build_provider().install_default();
+/// rustls is first-install-wins. Consequently, silently ignoring
+/// `install_default` failure can leave a process on ring/X25519. This function
+/// always inspects the effective provider after installation and returns an
+/// error if an
+/// earlier initializer installed anything other than the exact declared
+/// external policy. Call it before constructing any WebTransport/rustls
+/// builder; a policy violation fails startup instead of downgrading transport.
+pub fn install_pq_crypto_provider() -> Result<(), ProviderPolicyError> {
+    let _ = provider_with_groups([
+        aws_lc_rs::kx_group::X25519MLKEM768,
+        aws_lc_rs::kx_group::X25519,
+    ])
+    .install_default();
+
+    let actual =
+        CryptoProvider::get_default().map_or_else(Vec::new, |provider| group_names(provider));
+    if actual != EXTERNAL_INTEROP_GROUPS {
+        return Err(ProviderPolicyError { actual });
+    }
+    Ok(())
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
 
-    /// The PQ-hybrid group MUST be offered first, with classical X25519 as the
-    /// only fallback — a regression here would silently drop transport PQ.
     #[test]
-    fn pins_x25519mlkem768_first_then_x25519() {
-        let provider = build_provider();
-        let names: Vec<rustls::NamedGroup> = provider.kx_groups.iter().map(|g| g.name()).collect();
+    fn external_interop_is_pq_first_with_declared_x25519_fallback() {
+        assert_eq!(group_names(&pq_crypto_provider()), EXTERNAL_INTEROP_GROUPS);
+    }
+
+    #[test]
+    fn internal_mesh_is_hybrid_only() {
         assert_eq!(
-            names.first().copied(),
-            Some(rustls::NamedGroup::X25519MLKEM768),
-            "X25519MLKEM768 must be the first (preferred) kx group"
+            group_names(&internal_mesh_crypto_provider()),
+            INTERNAL_MESH_GROUPS
         );
-        let pq = names
-            .iter()
-            .position(|n| *n == rustls::NamedGroup::X25519MLKEM768);
-        let classical = names.iter().position(|n| *n == rustls::NamedGroup::X25519);
+    }
+
+    #[test]
+    fn external_interop_live_handshake_allows_classical_peer() {
+        let certified = rcgen::generate_simple_self_signed(vec!["localhost".to_owned()])
+            .expect("generate test certificate");
+        let cert = certified.cert.der().clone();
+        let key = rustls::pki_types::PrivatePkcs8KeyDer::from(certified.key_pair.serialize_der());
+        let server_config = rustls::ServerConfig::builder_with_provider(pq_crypto_provider())
+            .with_safe_default_protocol_versions()
+            .expect("external provider supports TLS 1.3")
+            .with_no_client_auth()
+            .with_single_cert(vec![cert.clone()], key.into())
+            .expect("valid test certificate");
+
+        let mut roots = rustls::RootCertStore::empty();
+        roots.add(cert).expect("add test root");
+        let client_config = rustls::ClientConfig::builder_with_provider(Arc::new(
+            rustls::crypto::ring::default_provider(),
+        ))
+        .with_safe_default_protocol_versions()
+        .expect("ring supports TLS 1.3")
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+
+        let mut server = rustls::ServerConnection::new(Arc::new(server_config))
+            .expect("build server connection");
+        let mut client = rustls::ClientConnection::new(
+            Arc::new(client_config),
+            "localhost".try_into().expect("valid server name"),
+        )
+        .expect("build client connection");
+
+        for _ in 0..8 {
+            let mut client_records = Vec::new();
+            client
+                .write_tls(&mut client_records)
+                .expect("write client TLS records");
+            if !client_records.is_empty() {
+                server
+                    .read_tls(&mut std::io::Cursor::new(client_records))
+                    .expect("read client TLS records");
+                server
+                    .process_new_packets()
+                    .expect("process client TLS records");
+            }
+
+            let mut server_records = Vec::new();
+            server
+                .write_tls(&mut server_records)
+                .expect("write server TLS records");
+            if !server_records.is_empty() {
+                client
+                    .read_tls(&mut std::io::Cursor::new(server_records))
+                    .expect("read server TLS records");
+                client
+                    .process_new_packets()
+                    .expect("process server TLS records");
+            }
+            if !client.is_handshaking() && !server.is_handshaking() {
+                break;
+            }
+        }
+        assert!(!client.is_handshaking() && !server.is_handshaking());
+        assert_eq!(
+            server
+                .negotiated_key_exchange_group()
+                .expect("completed handshake has a group")
+                .name(),
+            rustls::NamedGroup::X25519,
+            "classical fallback is allowed only by the external interop policy"
+        );
+    }
+
+    // This mutation must run in a fresh process because rustls's default is a
+    // OnceLock. The ignored child test is invoked explicitly by its parent.
+    #[test]
+    #[ignore = "subprocess mutation fixture"]
+    fn non_pq_provider_installed_first_child() {
+        rustls::crypto::ring::default_provider()
+            .install_default()
+            .expect("fresh child process must not already have a provider");
+        install_pq_crypto_provider().expect("non-PQ provider must fail closed");
+    }
+
+    #[test]
+    fn non_pq_provider_installed_first_fails_closed() {
+        let exe = std::env::current_exe().expect("test executable path");
+        let output = std::process::Command::new(exe)
+            .args([
+                "--ignored",
+                "--exact",
+                "transport::pq_provider::tests::non_pq_provider_installed_first_child",
+            ])
+            .output()
+            .expect("run provider-ordering mutation child");
         assert!(
-            matches!((pq, classical), (Some(p), Some(c)) if p < c),
-            "PQ-hybrid must be offered ahead of classical X25519, got {names:?}"
+            !output.status.success(),
+            "a ring provider installed first must make startup fail"
         );
     }
 }

--- a/crates/hyprstream-rpc/src/transport/quinn_transport.rs
+++ b/crates/hyprstream-rpc/src/transport/quinn_transport.rs
@@ -748,6 +748,7 @@ pub fn cert_sha256(cert_der: &[u8]) -> [u8; 32] {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
     use bytes::Bytes;
@@ -785,7 +786,8 @@ mod tests {
     /// with a 0xCD marker prefix, client asserts on the response.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn quinn_rpc_round_trip() -> Result<()> {
-        crate::transport::pq_provider::install_pq_crypto_provider();
+        crate::transport::pq_provider::install_pq_crypto_provider()
+            .expect("install PQ provider");
 
         let processor = crate::transport::rpc_session::from_fn(|req: Bytes| async move {
             let mut out = Vec::with_capacity(1 + req.len());
@@ -816,8 +818,10 @@ mod tests {
     /// wrong => Err, empty set => Err = fail-closed).
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn verify_peer_cert_pinned_accepts_right_rejects_wrong() -> Result<()> {
-        crate::transport::pq_provider::install_pq_crypto_provider();
-        let processor = crate::transport::rpc_session::from_fn(|req: Bytes| async move { Ok(req) });
+        crate::transport::pq_provider::install_pq_crypto_provider()
+            .expect("install PQ provider");
+        let processor =
+            crate::transport::rpc_session::from_fn(|req: Bytes| async move { Ok(req) });
         let (server, addr, cert_der) = build_server()?;
         let rpc_server =
             QuinnRpcServer::new(server, processor, fresh_signing_key()).with_test_trusted_carrier();
@@ -850,7 +854,8 @@ mod tests {
     /// rejected while the first is still live. The first keeps working.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn quinn_connection_cap_rejects_excess() -> Result<()> {
-        crate::transport::pq_provider::install_pq_crypto_provider();
+        crate::transport::pq_provider::install_pq_crypto_provider()
+            .expect("install PQ provider");
 
         let processor = crate::transport::rpc_session::from_fn(|req: Bytes| async move { Ok(req) });
 
@@ -899,7 +904,8 @@ mod tests {
     /// with "now safe to shut down" — no wall-clock sleep races.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn quinn_shutdown_drains_in_flight() -> Result<()> {
-        crate::transport::pq_provider::install_pq_crypto_provider();
+        crate::transport::pq_provider::install_pq_crypto_provider()
+            .expect("install PQ provider");
 
         let entered = Arc::new(tokio::sync::Notify::new());
         let entered_c = Arc::clone(&entered);

--- a/crates/hyprstream-rpc/src/transport/quinn_transport.rs
+++ b/crates/hyprstream-rpc/src/transport/quinn_transport.rs
@@ -621,8 +621,11 @@ impl Transport for QuinnTransport {
 /// Build a quinn WebTransport client session against a server with a CA-issued
 /// certificate, validated via the system root store and the DNS `server_name`
 /// (`QuicServerAuth::web_pki`). Dials `https://{server_name}:{port}/`.
-pub async fn connect_webpki(server_name: &str, port: u16) -> Result<web_transport_quinn::Session> {
-    let client = web_transport_quinn::ClientBuilder::new()
+pub async fn connect_webpki(
+    server_name: &str,
+    port: u16,
+) -> Result<web_transport_quinn::Session> {
+    let client = external_client_builder()?
         .with_system_roots()
         .map_err(|e| anyhow!("quinn client (system roots): {e}"))?;
     let url = url::Url::parse(&format!("https://{server_name}:{port}/"))
@@ -643,7 +646,7 @@ pub async fn connect_pinned_hashes(
     cert_hashes: &[[u8; 32]],
 ) -> Result<web_transport_quinn::Session> {
     let hashes: Vec<Vec<u8>> = cert_hashes.iter().map(|h| h.to_vec()).collect();
-    let client = web_transport_quinn::ClientBuilder::new()
+    let client = external_client_builder()?
         .with_server_certificate_hashes(hashes)
         .map_err(|e| anyhow!("quinn client build: {e}"))?;
     let url =
@@ -693,7 +696,7 @@ pub async fn connect_pinned_hashes_path(
     path: &str,
 ) -> Result<web_transport_quinn::Session> {
     let hashes: Vec<Vec<u8>> = cert_hashes.iter().map(|h| h.to_vec()).collect();
-    let client = web_transport_quinn::ClientBuilder::new()
+    let client = external_client_builder()?
         .with_server_certificate_hashes(hashes)
         .map_err(|e| anyhow!("quinn client build: {e}"))?;
     let url =
@@ -711,7 +714,7 @@ pub async fn connect_webpki_path(
     port: u16,
     path: &str,
 ) -> Result<web_transport_quinn::Session> {
-    let client = web_transport_quinn::ClientBuilder::new()
+    let client = external_client_builder()?
         .with_system_roots()
         .map_err(|e| anyhow!("quinn client (system roots): {e}"))?;
     let url = url::Url::parse(&format!("https://{server_name}:{port}{path}"))
@@ -720,6 +723,16 @@ pub async fn connect_webpki_path(
         .connect(url)
         .await
         .map_err(|e| anyhow!("quinn connect (webpki): {e}"))
+}
+
+/// Every native WebTransport client crosses the external-interoperability
+/// boundary. Install and validate the exact effective process policy before
+/// constructing the third-party builder, whose fallback otherwise depends on
+/// whichever rustls provider won process initialization.
+fn external_client_builder() -> Result<web_transport_quinn::ClientBuilder> {
+    crate::transport::pq_provider::install_pq_crypto_provider()
+        .map_err(|e| anyhow!("external WebTransport crypto policy: {e}"))?;
+    Ok(web_transport_quinn::ClientBuilder::new())
 }
 
 /// Convenience: pin by the full server cert DER (hashes it for you). Used by
@@ -949,5 +962,99 @@ mod tests {
 
         let _ = server_task.await;
         Ok(())
+    }
+
+    async fn exercise_all_native_client_constructors() {
+        // Malformed hostnames make the WebPKI variants stop after builder
+        // construction. Pinned variants are polled briefly against a closed
+        // loopback port; cancellation is enough because policy enforcement is
+        // synchronous at the start of each constructor.
+        let _ = connect_webpki("[", 443).await;
+        let _ = connect_webpki_path("[", 443, "/moq").await;
+        let closed: std::net::SocketAddr = "127.0.0.1:9".parse().expect("test address");
+        let _ = tokio::time::timeout(
+            Duration::from_millis(50),
+            connect_pinned_hashes(closed, &[]),
+        )
+        .await;
+        let _ = tokio::time::timeout(
+            Duration::from_millis(50),
+            connect_pinned_hashes_path(closed, &[], "/moq"),
+        )
+        .await;
+    }
+
+    // These fixtures require fresh processes because rustls's default provider
+    // is a OnceLock. Their parent tests invoke them by exact test name.
+    #[tokio::test]
+    #[ignore = "subprocess provider fixture"]
+    async fn native_clients_install_external_policy_child() {
+        assert!(
+            rustls::crypto::CryptoProvider::get_default().is_none(),
+            "fixture must begin without a process provider"
+        );
+        exercise_all_native_client_constructors().await;
+        crate::transport::pq_provider::install_pq_crypto_provider()
+            .expect("actual client constructors must install the exact external policy");
+    }
+
+    #[tokio::test]
+    #[ignore = "subprocess provider fixture"]
+    async fn native_clients_reject_ring_first_child() {
+        rustls::crypto::ring::default_provider()
+            .install_default()
+            .expect("fixture must install ring first");
+
+        let err = connect_webpki("127.0.0.1", 9)
+            .await
+            .expect_err("ring-first WebPKI constructor must fail before dialing");
+        assert!(err.to_string().contains("crypto policy mismatch"));
+
+        let err = connect_webpki_path("127.0.0.1", 9, "/moq")
+            .await
+            .expect_err("ring-first WebPKI path constructor must fail before dialing");
+        assert!(err.to_string().contains("crypto policy mismatch"));
+
+        let addr = "127.0.0.1:9".parse().expect("test address");
+        let err = connect_pinned_hashes(addr, &[])
+            .await
+            .expect_err("ring-first pinned constructor must fail before dialing");
+        assert!(err.to_string().contains("crypto policy mismatch"));
+
+        let err = connect_pinned_hashes_path(addr, &[], "/moq")
+            .await
+            .expect_err("ring-first pinned path constructor must fail before dialing");
+        assert!(err.to_string().contains("crypto policy mismatch"));
+    }
+
+    fn run_provider_fixture(name: &str) -> std::process::Output {
+        std::process::Command::new(std::env::current_exe().expect("test executable path"))
+            .args(["--ignored", "--exact", name])
+            .output()
+            .expect("run native client provider fixture")
+    }
+
+    #[test]
+    fn native_clients_install_external_policy_in_fresh_process() {
+        let output = run_provider_fixture(
+            "transport::quinn_transport::tests::native_clients_install_external_policy_child",
+        );
+        assert!(
+            output.status.success(),
+            "fresh-process native clients failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
+    fn native_clients_reject_ring_first_in_fresh_process() {
+        let output = run_provider_fixture(
+            "transport::quinn_transport::tests::native_clients_reject_ring_first_child",
+        );
+        assert!(
+            output.status.success(),
+            "ring-first native client policy fixture failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 }

--- a/crates/hyprstream-rpc/src/transport/quinn_transport.rs
+++ b/crates/hyprstream-rpc/src/transport/quinn_transport.rs
@@ -1028,10 +1028,31 @@ mod tests {
     }
 
     fn run_provider_fixture(name: &str) -> std::process::Output {
-        std::process::Command::new(std::env::current_exe().expect("test executable path"))
-            .args(["--ignored", "--exact", name])
-            .output()
-            .expect("run native client provider fixture")
+        let mut child =
+            std::process::Command::new(std::env::current_exe().expect("test executable path"))
+                .args(["--ignored", "--exact", name])
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .spawn()
+                .expect("spawn native client provider fixture");
+        let deadline = std::time::Instant::now() + Duration::from_secs(30);
+        loop {
+            if child
+                .try_wait()
+                .expect("poll native client fixture")
+                .is_some()
+            {
+                return child
+                    .wait_with_output()
+                    .expect("collect native client fixture output");
+            }
+            if std::time::Instant::now() >= deadline {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("native client fixture {name} timed out after 30 seconds");
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
+++ b/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
@@ -1312,27 +1312,19 @@ pub fn cert_hash(cert_der: &[u8]) -> String {
 // TLS Helpers
 // ============================================================================
 
-/// Install the PQ-hybrid (aws-lc-rs, X25519MLKEM768) crypto provider for rustls
-/// (required for QUIC/TLS), replacing the former ring provider (#557 / S6).
-///
-/// Must be called before creating any rustls `ServerConfig` or quinn endpoint.
-/// No-op if already installed (safe to call multiple times). See
-/// [`crate::transport::pq_provider`].
-pub fn ensure_crypto_provider() {
-    crate::transport::pq_provider::install_pq_crypto_provider();
-}
-
 /// Generate a self-signed TLS certificate for development/testing.
 ///
 /// Returns (ServerConfig, cert_der_bytes).
 pub fn server_tls_self_signed(name: &str) -> Result<(rustls::ServerConfig, Vec<u8>)> {
-    ensure_crypto_provider();
     let cert_key = rcgen::generate_simple_self_signed(vec![name.to_owned()])?;
 
     let cert_der = cert_key.cert.der().to_vec();
     let key_der = rustls::pki_types::PrivatePkcs8KeyDer::from(cert_key.key_pair.serialize_der());
 
-    let mut cfg = rustls::ServerConfig::builder()
+    let mut cfg = rustls::ServerConfig::builder_with_provider(
+        crate::transport::pq_provider::internal_mesh_crypto_provider(),
+    )
+        .with_safe_default_protocol_versions()?
         .with_no_client_auth()
         .with_single_cert(vec![cert_der.clone().into()], key_der.into())?;
 
@@ -1349,7 +1341,10 @@ pub fn client_tls_pinned(cert_der: &[u8]) -> Result<rustls::ClientConfig> {
     let mut root_store = rustls::RootCertStore::empty();
     root_store.add(rustls::pki_types::CertificateDer::from_slice(cert_der))?;
 
-    let cfg = rustls::ClientConfig::builder()
+    let cfg = rustls::ClientConfig::builder_with_provider(
+        crate::transport::pq_provider::internal_mesh_crypto_provider(),
+    )
+        .with_safe_default_protocol_versions()?
         .with_root_certificates(root_store)
         .with_no_client_auth();
 
@@ -1364,7 +1359,10 @@ pub fn client_tls_system_roots() -> Result<rustls::ClientConfig> {
     let mut root_store = rustls::RootCertStore::empty();
     root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
 
-    let cfg = rustls::ClientConfig::builder()
+    let cfg = rustls::ClientConfig::builder_with_provider(
+        crate::transport::pq_provider::internal_mesh_crypto_provider(),
+    )
+        .with_safe_default_protocol_versions()?
         .with_root_certificates(root_store)
         .with_no_client_auth();
 
@@ -1403,12 +1401,7 @@ pub use crate::envelope::EnvelopeVerification;
 mod tests {
     use super::*;
     use crate::zmtp_framing::{build_greeting, validate_greeting, build_ready_metadata};
-
-    /// Install the ring crypto provider for rustls (required for TLS tests).
-    /// Delegates to the public module-level function.
-    fn ensure_crypto_provider() {
-        super::ensure_crypto_provider();
-    }
+    use quinn::crypto::rustls::HandshakeData;
 
     #[test]
     fn test_greeting_format() {
@@ -1491,7 +1484,6 @@ mod tests {
 
     #[test]
     fn test_tls_self_signed_generates_valid_cert() {
-        ensure_crypto_provider();
         let (config, cert_der) = server_tls_self_signed("test.local").unwrap();
 
         // Check ALPN is set
@@ -1503,7 +1495,6 @@ mod tests {
 
     #[test]
     fn test_client_tls_pinned_accepts_matching_cert() {
-        ensure_crypto_provider();
         let (_server_config, cert_der) = server_tls_self_signed("test.local").unwrap();
 
         // Should succeed
@@ -1513,6 +1504,88 @@ mod tests {
         // Check ALPN is set
         let config = client_config.unwrap();
         assert!(config.alpn_protocols.iter().any(|p| p == ALPN_ZMTP3));
+    }
+
+    #[tokio::test]
+    async fn zmtp_live_handshake_negotiates_x25519mlkem768() {
+        let (server_tls, cert_der) = server_tls_self_signed("localhost").unwrap();
+        let server = QuicRep::bind("127.0.0.1:0".parse().unwrap(), server_tls).unwrap();
+        let addr = server.local_addr().unwrap();
+        let endpoint = server.endpoint.clone();
+
+        let accepted = tokio::spawn(async move {
+            let connection = endpoint
+                .accept()
+                .await
+                .expect("incoming zmtp connection")
+                .await
+                .expect("complete zmtp handshake");
+            connection
+                .handshake_data()
+                .expect("completed quinn connection has handshake data")
+                .downcast::<HandshakeData>()
+                .expect("quinn rustls handshake data")
+                .negotiated_key_exchange_group
+        });
+
+        let client = QuicReq::connect(addr, "localhost", client_tls_pinned(&cert_der).unwrap())
+            .await
+            .unwrap();
+        let client_group = client
+            .conn
+            .handshake_data()
+            .expect("completed quinn connection has handshake data")
+            .downcast::<HandshakeData>()
+            .expect("quinn rustls handshake data")
+            .negotiated_key_exchange_group;
+
+        assert_eq!(client_group, rustls::NamedGroup::X25519MLKEM768);
+        assert_eq!(
+            accepted.await.unwrap(),
+            rustls::NamedGroup::X25519MLKEM768
+        );
+    }
+
+    #[tokio::test]
+    async fn zmtp_internal_mesh_rejects_classical_only_peer() {
+        let (server_tls, cert_der) = server_tls_self_signed("localhost").unwrap();
+        let server = QuicRep::bind("127.0.0.1:0".parse().unwrap(), server_tls).unwrap();
+        let addr = server.local_addr().unwrap();
+        let endpoint = server.endpoint.clone();
+        let accepted = tokio::spawn(async move {
+            endpoint
+                .accept()
+                .await
+                .expect("incoming classical mutation connection")
+                .await
+        });
+
+        let mut roots = rustls::RootCertStore::empty();
+        roots
+            .add(rustls::pki_types::CertificateDer::from_slice(&cert_der))
+            .unwrap();
+        let mut classical = rustls::ClientConfig::builder_with_provider(Arc::new(
+            rustls::crypto::ring::default_provider(),
+        ))
+        .with_safe_default_protocol_versions()
+        .unwrap()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+        classical.alpn_protocols = vec![ALPN_ZMTP3.to_vec()];
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            QuicReq::connect(addr, "localhost", classical),
+        )
+        .await
+        .expect("classical-only mutation handshake must terminate");
+        assert!(result.is_err(), "internal mesh accepted classical-only TLS");
+
+        let server_result = tokio::time::timeout(std::time::Duration::from_secs(5), accepted)
+            .await
+            .expect("server mutation handshake must terminate")
+            .unwrap();
+        assert!(server_result.is_err(), "server negotiated classical fallback");
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
+++ b/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
@@ -322,6 +322,9 @@ impl QuicRep {
     /// * `addr` - Socket address to bind to
     /// * `tls` - TLS server configuration
     pub fn bind(addr: SocketAddr, tls: rustls::ServerConfig) -> Result<Self> {
+        crate::transport::pq_provider::validate_internal_mesh_crypto_provider(
+            tls.crypto_provider(),
+        )?;
         let quic_server_cfg =
             quinn::ServerConfig::with_crypto(Arc::new(quinn::crypto::rustls::QuicServerConfig::try_from(tls)?));
 
@@ -646,6 +649,9 @@ impl QuicReq {
         server_name: &str,
         tls: rustls::ClientConfig,
     ) -> Result<Self> {
+        crate::transport::pq_provider::validate_internal_mesh_crypto_provider(
+            tls.crypto_provider(),
+        )?;
         let quic_client_config =
             quinn::ClientConfig::new(Arc::new(quinn::crypto::rustls::QuicClientConfig::try_from(
                 tls,
@@ -1548,44 +1554,42 @@ mod tests {
 
     #[tokio::test]
     async fn zmtp_internal_mesh_rejects_classical_only_peer() {
-        let (server_tls, cert_der) = server_tls_self_signed("localhost").unwrap();
-        let server = QuicRep::bind("127.0.0.1:0".parse().unwrap(), server_tls).unwrap();
-        let addr = server.local_addr().unwrap();
-        let endpoint = server.endpoint.clone();
-        let accepted = tokio::spawn(async move {
-            endpoint
-                .accept()
-                .await
-                .expect("incoming classical mutation connection")
-                .await
-        });
-
-        let mut roots = rustls::RootCertStore::empty();
-        roots
-            .add(rustls::pki_types::CertificateDer::from_slice(&cert_der))
-            .unwrap();
         let mut classical = rustls::ClientConfig::builder_with_provider(Arc::new(
             rustls::crypto::ring::default_provider(),
         ))
         .with_safe_default_protocol_versions()
         .unwrap()
-        .with_root_certificates(roots)
+        .with_root_certificates(rustls::RootCertStore::empty())
         .with_no_client_auth();
         classical.alpn_protocols = vec![ALPN_ZMTP3.to_vec()];
 
-        let result = tokio::time::timeout(
-            std::time::Duration::from_secs(5),
-            QuicReq::connect(addr, "localhost", classical),
-        )
-        .await
-        .expect("classical-only mutation handshake must terminate");
-        assert!(result.is_err(), "internal mesh accepted classical-only TLS");
-
-        let server_result = tokio::time::timeout(std::time::Duration::from_secs(5), accepted)
+        let err = QuicReq::connect("127.0.0.1:9".parse().unwrap(), "localhost", classical)
             .await
-            .expect("server mutation handshake must terminate")
-            .unwrap();
-        assert!(server_result.is_err(), "server negotiated classical fallback");
+            .err()
+            .expect("public REQ seam must reject classical config before dialing");
+        assert!(err.to_string().contains("owned-mesh crypto policy mismatch"));
+    }
+
+    #[test]
+    fn zmtp_rep_rejects_classical_only_config_before_bind() {
+        let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_owned()]).unwrap();
+        let key = rustls::pki_types::PrivatePkcs8KeyDer::from(
+            cert.key_pair.serialize_der(),
+        );
+        let mut classical = rustls::ServerConfig::builder_with_provider(Arc::new(
+            rustls::crypto::ring::default_provider(),
+        ))
+        .with_safe_default_protocol_versions()
+        .unwrap()
+        .with_no_client_auth()
+        .with_single_cert(vec![cert.cert.der().clone()], key.into())
+        .unwrap();
+        classical.alpn_protocols = vec![ALPN_ZMTP3.to_vec()];
+
+        let err = QuicRep::bind("127.0.0.1:0".parse().unwrap(), classical)
+            .err()
+            .expect("public REP seam must reject classical config before bind");
+        assert!(err.to_string().contains("owned-mesh crypto policy mismatch"));
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
+++ b/crates/hyprstream-rpc/src/transport/zmtp_quic.rs
@@ -306,6 +306,24 @@ impl Multipart {
 // QUIC Socket Types (server-side)
 // ============================================================================
 
+fn owned_quic_server_config(tls: rustls::ServerConfig) -> Result<quinn::ServerConfig> {
+    crate::transport::pq_provider::validate_internal_mesh_crypto_provider(
+        tls.crypto_provider(),
+    )?;
+    Ok(quinn::ServerConfig::with_crypto(Arc::new(
+        quinn::crypto::rustls::QuicServerConfig::try_from(tls)?,
+    )))
+}
+
+fn owned_quic_client_config(tls: rustls::ClientConfig) -> Result<quinn::ClientConfig> {
+    crate::transport::pq_provider::validate_internal_mesh_crypto_provider(
+        tls.crypto_provider(),
+    )?;
+    Ok(quinn::ClientConfig::new(Arc::new(
+        quinn::crypto::rustls::QuicClientConfig::try_from(tls)?,
+    )))
+}
+
 /// Server-side REP socket over QUIC.
 ///
 /// Accepts QUIC connections; each connection carries one ZmtpStream for ZMTP exchange.
@@ -322,13 +340,7 @@ impl QuicRep {
     /// * `addr` - Socket address to bind to
     /// * `tls` - TLS server configuration
     pub fn bind(addr: SocketAddr, tls: rustls::ServerConfig) -> Result<Self> {
-        crate::transport::pq_provider::validate_internal_mesh_crypto_provider(
-            tls.crypto_provider(),
-        )?;
-        let quic_server_cfg =
-            quinn::ServerConfig::with_crypto(Arc::new(quinn::crypto::rustls::QuicServerConfig::try_from(tls)?));
-
-        let endpoint = quinn::Endpoint::server(quic_server_cfg, addr)?;
+        let endpoint = quinn::Endpoint::server(owned_quic_server_config(tls)?, addr)?;
 
         Ok(Self { endpoint })
     }
@@ -649,16 +661,8 @@ impl QuicReq {
         server_name: &str,
         tls: rustls::ClientConfig,
     ) -> Result<Self> {
-        crate::transport::pq_provider::validate_internal_mesh_crypto_provider(
-            tls.crypto_provider(),
-        )?;
-        let quic_client_config =
-            quinn::ClientConfig::new(Arc::new(quinn::crypto::rustls::QuicClientConfig::try_from(
-                tls,
-            )?));
-
         let mut endpoint = quinn::Endpoint::client("[::]:0".parse()?)?;
-        endpoint.set_default_client_config(quic_client_config);
+        endpoint.set_default_client_config(owned_quic_client_config(tls)?);
 
         let conn = endpoint
             .connect(addr, server_name)?
@@ -719,10 +723,7 @@ pub struct QuicXPub {
 impl QuicXPub {
     /// Bind a QUIC XPUB socket to the given address.
     pub fn bind(addr: SocketAddr, tls: rustls::ServerConfig) -> Result<Self> {
-        let quic_server_cfg =
-            quinn::ServerConfig::with_crypto(Arc::new(quinn::crypto::rustls::QuicServerConfig::try_from(tls)?));
-
-        let endpoint = quinn::Endpoint::server(quic_server_cfg, addr)?;
+        let endpoint = quinn::Endpoint::server(owned_quic_server_config(tls)?, addr)?;
 
         Ok(Self {
             endpoint,
@@ -900,13 +901,8 @@ impl QuicSub {
         server_name: &str,
         tls: rustls::ClientConfig,
     ) -> Result<Self> {
-        let quic_client_config =
-            quinn::ClientConfig::new(Arc::new(quinn::crypto::rustls::QuicClientConfig::try_from(
-                tls,
-            )?));
-
         let mut endpoint = quinn::Endpoint::client("[::]:0".parse()?)?;
-        endpoint.set_default_client_config(quic_client_config);
+        endpoint.set_default_client_config(owned_quic_client_config(tls)?);
 
         let conn = endpoint
             .connect(addr, server_name)?
@@ -991,13 +987,8 @@ impl QuicPush {
         server_name: &str,
         tls: rustls::ClientConfig,
     ) -> Result<Self> {
-        let quic_client_config =
-            quinn::ClientConfig::new(Arc::new(quinn::crypto::rustls::QuicClientConfig::try_from(
-                tls,
-            )?));
-
         let mut endpoint = quinn::Endpoint::client("[::]:0".parse()?)?;
-        endpoint.set_default_client_config(quic_client_config);
+        endpoint.set_default_client_config(owned_quic_client_config(tls)?);
 
         let conn = endpoint
             .connect(addr, server_name)?
@@ -1044,10 +1035,7 @@ pub struct QuicPull {
 impl QuicPull {
     /// Bind a QUIC PULL socket to the given address.
     pub fn bind(addr: SocketAddr, tls: rustls::ServerConfig) -> Result<Self> {
-        let quic_server_cfg =
-            quinn::ServerConfig::with_crypto(Arc::new(quinn::crypto::rustls::QuicServerConfig::try_from(tls)?));
-
-        let endpoint = quinn::Endpoint::server(quic_server_cfg, addr)?;
+        let endpoint = quinn::Endpoint::server(owned_quic_server_config(tls)?, addr)?;
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
 
         Ok(Self {
@@ -1554,29 +1542,35 @@ mod tests {
 
     #[tokio::test]
     async fn zmtp_internal_mesh_rejects_classical_only_peer() {
-        let mut classical = rustls::ClientConfig::builder_with_provider(Arc::new(
+        let err = QuicReq::connect(
+            "127.0.0.1:9".parse().unwrap(),
+            "localhost",
+            classical_client_config(),
+        )
+        .await
+        .err()
+        .expect("public REQ seam must reject classical config before dialing");
+        assert!(err.to_string().contains("owned-mesh crypto policy mismatch"));
+    }
+
+    fn classical_client_config() -> rustls::ClientConfig {
+        let mut config = rustls::ClientConfig::builder_with_provider(Arc::new(
             rustls::crypto::ring::default_provider(),
         ))
         .with_safe_default_protocol_versions()
         .unwrap()
         .with_root_certificates(rustls::RootCertStore::empty())
         .with_no_client_auth();
-        classical.alpn_protocols = vec![ALPN_ZMTP3.to_vec()];
-
-        let err = QuicReq::connect("127.0.0.1:9".parse().unwrap(), "localhost", classical)
-            .await
-            .err()
-            .expect("public REQ seam must reject classical config before dialing");
-        assert!(err.to_string().contains("owned-mesh crypto policy mismatch"));
+        config.alpn_protocols = vec![ALPN_ZMTP3.to_vec()];
+        config
     }
 
-    #[test]
-    fn zmtp_rep_rejects_classical_only_config_before_bind() {
+    fn classical_server_config() -> rustls::ServerConfig {
         let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_owned()]).unwrap();
         let key = rustls::pki_types::PrivatePkcs8KeyDer::from(
             cert.key_pair.serialize_der(),
         );
-        let mut classical = rustls::ServerConfig::builder_with_provider(Arc::new(
+        let mut config = rustls::ServerConfig::builder_with_provider(Arc::new(
             rustls::crypto::ring::default_provider(),
         ))
         .with_safe_default_protocol_versions()
@@ -1584,12 +1578,47 @@ mod tests {
         .with_no_client_auth()
         .with_single_cert(vec![cert.cert.der().clone()], key.into())
         .unwrap();
-        classical.alpn_protocols = vec![ALPN_ZMTP3.to_vec()];
+        config.alpn_protocols = vec![ALPN_ZMTP3.to_vec()];
+        config
+    }
 
-        let err = QuicRep::bind("127.0.0.1:0".parse().unwrap(), classical)
+    fn assert_owned_policy_error<T>(result: Result<T>, seam: &str) {
+        let err = result.err().unwrap_or_else(|| panic!("{seam} accepted classical config"));
+        assert!(
+            err.to_string().contains("owned-mesh crypto policy mismatch"),
+            "{seam} returned the wrong error: {err}"
+        );
+    }
+
+    #[test]
+    fn zmtp_rep_rejects_classical_only_config_before_bind() {
+        let err = QuicRep::bind("127.0.0.1:0".parse().unwrap(), classical_server_config())
             .err()
             .expect("public REP seam must reject classical config before bind");
         assert!(err.to_string().contains("owned-mesh crypto policy mismatch"));
+    }
+
+    #[tokio::test]
+    async fn all_owned_zmtp_socket_families_reject_classical_configs() {
+        let bind_addr = "127.0.0.1:0".parse().unwrap();
+        assert_owned_policy_error(
+            QuicXPub::bind(bind_addr, classical_server_config()),
+            "XPUB bind",
+        );
+        assert_owned_policy_error(
+            QuicPull::bind(bind_addr, classical_server_config()),
+            "PULL bind",
+        );
+
+        let dial_addr = "127.0.0.1:9".parse().unwrap();
+        assert_owned_policy_error(
+            QuicSub::connect(dial_addr, "localhost", classical_client_config()).await,
+            "SUB connect",
+        );
+        assert_owned_policy_error(
+            QuicPush::connect(dial_addr, "localhost", classical_client_config()).await,
+            "PUSH connect",
+        );
     }
 
     #[test]

--- a/crates/hyprstream-rpc/tests/e2e_iroh_transport.rs
+++ b/crates/hyprstream-rpc/tests/e2e_iroh_transport.rs
@@ -187,7 +187,7 @@ fn shared_client_endpoint_blocking() -> iroh::Endpoint {
                         .await
                         .expect("bind shared client endpoint");
                         let endpoint = substrate.endpoint().clone();
-                        let _ = install_iroh_client_endpoint(endpoint.clone());
+                        let _ = install_iroh_client_endpoint(substrate.owned_client_endpoint());
                         tx.send(endpoint).expect("publish shared client endpoint");
                         substrate
                     });

--- a/crates/hyprstream-rpc/tests/moq_networked.rs
+++ b/crates/hyprstream-rpc/tests/moq_networked.rs
@@ -50,7 +50,7 @@ fn build_server() -> Result<(web_transport_quinn::Server, std::net::SocketAddr, 
 /// via `dial_stream`, subscribes, and receives MAC-verified frames.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn networked_moq_subscribe_receives_mac_verified_frames() -> Result<()> {
-    hyprstream_rpc::transport::install_pq_crypto_provider();
+    hyprstream_rpc::transport::install_pq_crypto_provider().expect("install PQ provider");
 
     // Server-side moq origin (the shared broadcast tree external subscribers see).
     let producer = moq_net::Origin::random().produce();

--- a/crates/hyprstream-rpc/tests/moq_relay_rendezvous.rs
+++ b/crates/hyprstream-rpc/tests/moq_relay_rendezvous.rs
@@ -68,7 +68,7 @@ fn build_server() -> Result<(web_transport_quinn::Server, std::net::SocketAddr, 
 /// ever learns the other's address.
 #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn moq_relay_rendezvous() -> Result<()> {
-    hyprstream_rpc::transport::install_pq_crypto_provider();
+    hyprstream_rpc::transport::install_pq_crypto_provider().expect("install PQ provider");
 
     // ── RELAY: a bidirectional /moq endpoint (ingest + re-serve), no keys ──────
     // Its origin starts EMPTY — the broadcast exists only on the producer until
@@ -228,7 +228,7 @@ async fn moq_relay_rendezvous() -> Result<()> {
 /// learn or dial the producer's direct address.
 #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn relay_choice_only_anonymizes_stream_end_to_end() -> Result<()> {
-    hyprstream_rpc::transport::install_pq_crypto_provider();
+    hyprstream_rpc::transport::install_pq_crypto_provider().expect("install PQ provider");
 
     // ── RELAY: bidirectional /moq endpoint, no keys (same as rendezvous) ───────
     let relay_producer = moq_net::Origin::random().produce();

--- a/crates/hyprstream-rpc/tests/wt_ninep_plane.rs
+++ b/crates/hyprstream-rpc/tests/wt_ninep_plane.rs
@@ -86,7 +86,7 @@ impl NinePWtHandler for EchoNineP {
 /// stream round-trips bytes both directions.
 #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn wt_ninep_path_routes_to_handler_and_streams() -> Result<()> {
-    hyprstream_rpc::transport::install_pq_crypto_provider();
+    hyprstream_rpc::transport::install_pq_crypto_provider().expect("install PQ provider");
 
     let (server, addr, cert) = build_server()?;
     let invoked = Arc::new(tokio::sync::Notify::new());
@@ -135,7 +135,7 @@ async fn wt_ninep_path_routes_to_handler_and_streams() -> Result<()> {
 /// off. We assert the server task keeps running afterwards.
 #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn wt_ninep_without_handler_is_declined() -> Result<()> {
-    hyprstream_rpc::transport::install_pq_crypto_provider();
+    hyprstream_rpc::transport::install_pq_crypto_provider().expect("install PQ provider");
 
     let (server, addr, cert) = build_server()?;
     let processor =

--- a/crates/hyprstream-rpc/tests/wt_ninep_plane.rs
+++ b/crates/hyprstream-rpc/tests/wt_ninep_plane.rs
@@ -151,27 +151,23 @@ async fn wt_ninep_without_handler_is_declined() -> Result<()> {
     let server_task = tokio::spawn(rpc.run());
 
     let pin = cert_sha256(&cert);
-    // The path mux runs after the WebTransport handshake. Once the `/9p` arm
-    // finds no handler it returns immediately, so the client can observe the
-    // explicit transport denial either while CONNECT completes or on its first
-    // stream operation. Both are valid; a successful echo or a hang is not.
-    let explicitly_denied = match connect_pinned_hashes_path(addr, &[pin], NINEP_PATH).await {
+    // Require the pinned WebTransport handshake to succeed first. This keeps a
+    // pin, TLS, or generic connection failure from masquerading as evidence
+    // that the `/9p` arm declined the session.
+    let session = connect_pinned_hashes_path(addr, &[pin], NINEP_PATH).await?;
+    let explicitly_denied = match session.open_bi().await {
         Err(_) => true,
-        Ok(session) => match session.open_bi().await {
-            Err(_) => true,
-            Ok((mut send, mut recv)) => {
-                if send.write_all(b"ping").await.is_err() {
-                    true
-                } else {
-                    let mut got = [0u8; 4];
-                    matches!(
-                        tokio::time::timeout(Duration::from_secs(3), recv.read_exact(&mut got),)
-                            .await,
-                        Ok(Err(_))
-                    )
-                }
+        Ok((mut send, mut recv)) => {
+            if send.write_all(b"ping").await.is_err() {
+                true
+            } else {
+                let mut got = [0u8; 4];
+                matches!(
+                    tokio::time::timeout(Duration::from_secs(3), recv.read_exact(&mut got),).await,
+                    Ok(Err(_))
+                )
             }
-        },
+        }
     };
     assert!(
         explicitly_denied,

--- a/crates/hyprstream-service/src/service/spawner/service.rs
+++ b/crates/hyprstream-service/src/service/spawner/service.rs
@@ -84,6 +84,15 @@ impl<S: RequestService + Send + Sync + 'static> Spawnable for UnifiedServiceConf
             let processor: Arc<dyn IrohRequestProcessor> = Arc::new(bridge);
 
             if let Some(mut qc) = quic_config {
+                // web-transport-quinn has no per-builder provider hook and
+                // resolves rustls's process default. Install and validate it at
+                // the actual bind seam so task/thread/subprocess startup cannot
+                // silently inherit a non-PQ first-installed provider (#557).
+                hyprstream_rpc::transport::install_pq_crypto_provider().map_err(|error| {
+                    hyprstream_rpc::error::RpcError::SpawnFailed(format!(
+                        "QUIC crypto provider: {error}"
+                    ))
+                })?;
                 // #274: serve the RPC plane over `web_transport_quinn` (replacing
                 // the bespoke h3 WebTransportServer) and multiplex the moq
                 // streaming plane on the same endpoint via `/moq` path-dispatch.

--- a/crates/hyprstream-service/src/service/spawner/service.rs
+++ b/crates/hyprstream-service/src/service/spawner/service.rs
@@ -262,7 +262,7 @@ impl<S: RequestService + Send + Sync + 'static> Spawnable for UnifiedServiceConf
                             // Install the shared client endpoint (install-once) so
                             // outbound iroh RPC/stream dials reuse this carrier.
                             let _ = hyprstream_rpc::transport::lazy_iroh::install_iroh_client_endpoint(
-                                substrate.endpoint().clone(),
+                                substrate.owned_client_endpoint(),
                             );
                             // #357: register our iroh node_id so producer_reach()
                             // advertises an iroh-direct Destination for native

--- a/crates/hyprstream/src/server/tls.rs
+++ b/crates/hyprstream/src/server/tls.rs
@@ -108,8 +108,8 @@ pub async fn resolve_rustls_config(
     // Ensure the PQ-hybrid (aws-lc-rs, X25519MLKEM768) crypto provider is
     // installed for rustls (#557 / S6). Services that don't use QUIC (which
     // installs it via quinn) need this before any RustlsConfig can be created.
-    // Idempotent — ignores if already set.
-    hyprstream_rpc::transport::install_pq_crypto_provider();
+    // Idempotent, but fail closed if another provider was installed first.
+    hyprstream_rpc::transport::install_pq_crypto_provider()?;
 
     // Per-service override: both cert and key must be set
     if let (Some(cert), Some(key)) = (service_cert, service_key) {

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -849,7 +849,7 @@ impl Spawnable for OAuthService {
                     match build_oauth_iroh_substrate(transport_key.to_bytes()).await {
                         Ok(substrate) => {
                             let _ = hyprstream_rpc::transport::lazy_iroh::install_iroh_client_endpoint(
-                                substrate.endpoint().clone(),
+                                substrate.owned_client_endpoint(),
                             );
                             Some(substrate)
                         }


### PR DESCRIPTION
## Summary

- enforce exact hybrid-only `[X25519MLKEM768]` at every public owned ZMTP and Iroh boundary
- require an opaque `OwnedIrohClientEndpoint` capability from `IrohSubstrate::new`; raw prebound endpoints cannot cross the public installer seam
- route `QuicRep`, `QuicReq`, `QuicXPub`, `QuicSub`, `QuicPush`, and `QuicPull` rustls configs through shared exact-policy validators before bind/dial
- centralize all native WebTransport client construction behind exact process-default validation
- retain X25519 fallback only for the separately named external interoperability policy, exactly `[X25519MLKEM768, X25519]`

## Post-foundation rebase

Rebased onto exact `main` `3bbc78546d08a81e977f7629e5c4b1ad639923e1` after the mandatory unary HyKEM foundation landed. Exact PR head: `a07791b818281e1caa5d69b2e1e7803c76e6cd6e`.

The conflict resolution preserves the landed reach-only, purpose-derived unary sealing and both OAuth refusal ALPNs. It does not restore the superseded NodeId/admission/MoQ design. Foundation commits were not replayed; the merge base is the exact landed `main` SHA.

## Constructor and mutation evidence

All four native `web_transport_quinn::ClientBuilder` paths call one policy-enforcing constructor before builder creation: `connect_webpki`, `connect_pinned_hashes`, and both path variants. Fresh-process tests exercise the real constructors with no prior provider and with ring installed first. The no-prior case installs the exact declared external policy; ring-first returns the exact policy-mismatch error before builder creation or dialing. Subprocess fixtures have a 30-second fail-closed bound.

Every public owned ZMTP rustls-config seam shares one server/client validation layer and rejects classical, reordered, duplicated, or external-fallback group lists before socket activity. Iroh outbound installation is capability-gated because an already-bound endpoint exposes no inspectable provider. Two compile-fail controls prove raw endpoints cannot call the installer or construct its capability, and live classical mutations cover both owned `hyprstream-rpc/1` and `moql` ALPNs.

Live tests assert `X25519MLKEM768` on both sides of ZMTP and independently on both Iroh ALPNs. The separately named external provider has a live X25519 interoperability test. Quinn negotiated-group introspection is test-only; Iroh/noq exposes equivalent handshake data directly. No production wire-format change is introduced.

## Validation at `a07791b818281e1caa5d69b2e1e7803c76e6cd6e`

- `hyprstream-rpc`: 736 library tests passed, 3 intentionally ignored subprocess fixtures; all 11 integration binaries passed
- `hyprstream-service --lib`: 26 passed, 1 systemd-only ignored
- `hyprstream-pds --lib`: 199 passed
- `hyprstream --lib`: 1021 passed, 1 ignored, using documented system OpenSSL/libtorch environment
- RPC doctests: 6 passed, 19 ignored, including both compile-fail capability controls
- exact Iroh two-endpoint/two-ALPN smoke and classical rejection mutations: passed
- live ZMTP hybrid negotiation, classical rejection, pre-bind rejection, and all six owned-family mutations: passed
- provider exact-policy, reordered/duplicate mutation, external X25519 live handshake, clean-process constructors, and ring-first fail-before-dial fixtures: passed
- both `/9p` path-mux integration tests: passed; denial requires a successful pinned WebTransport handshake before stream closure counts
- affected all-target Clippy with `-D warnings`: passed
- repository pre-commit hook (`cargo clippy --workspace --all-targets --release -- -D warnings`): passed
- browser-client WASM check with `web_sys_unstable_apis`: passed
- `cargo deny check bans licenses sources`: passed with only configured warnings
- `git diff --check`: passed

Hosted Clippy, WASM, cargo-deny, all CodeQL languages, and CodeRabbit passed on this exact head; unresolved review-thread count is zero.

## Review and #557 closure scope

The previous independent PASS was scoped to predecessor `a161c1fd89e6d690dabf7c1ea50095bef717f515`; it is not treated as review of this rewrite. This exact head is being handed to a separate read-only GPT-5.6-sol review. This implementation turn does not approve, merge, queue, retarget, or close the PR.

#557 remains open after this PR. Its remaining closure gate is deployed-browser live negotiated-group evidence (or an explicitly revised browser acceptance criterion), plus any separately recorded Flight scope. No browser evidence is fabricated by this rebase.

Refs #557. Does not close #557.
