### PR TITLE
security(crypto): harden canonical COSE sealing (#553)

### DIFF
--- a/crates/hyprstream-rpc/src/crypto/cose_encrypt.rs
+++ b/crates/hyprstream-rpc/src/crypto/cose_encrypt.rs
@@ -13,10 +13,9 @@
 //! claim.  PQUIP / RFC 9794 supplies transition terminology, not wire semantics.
 //!
 //! New consumers should use [`seal`], [`open`], [`seal_prederived`], and
-//! [`open_prederived`] with an owning [`NonceLedger`].  The legacy wrappers at
-//! the bottom remain only for the already-landed envelope path, whose replay
-//! lifecycle is owned by `SignedEnvelope`; they must not be used for new stream
-//! or group lifecycles.
+//! [`open_prederived`] with an owning [`NonceLedger`].  The fresh-encapsulation
+//! envelope wrappers at the bottom remain only for the already-landed signed
+//! envelope path, whose replay lifecycle is owned by `SignedEnvelope`.
 
 use std::collections::HashSet;
 
@@ -64,6 +63,18 @@ const KDF_CONTEXT_LABEL: &[u8] = b"hyprstream cose-encrypt0 context key v2";
 const COMPAT_RECIPIENT_LABEL: &[u8] = b"hyprstream cose-encrypt0 compat recipient v2";
 const COMPAT_KEY_LABEL: &[u8] = b"hyprstream cose-encrypt0 compat key v2";
 const COMPAT_DOMAIN_LABEL: &[u8] = b"hyprstream cose-encrypt0 compat domain v2";
+
+// These structural limits are deliberately much tighter than the 16 MiB wire
+// cap.  This profile has a three-item outer array, at most eight protected
+// headers, one unprotected header, and a five-item `crit` array.  The modest
+// headroom permits future private headers without allowing a small input to
+// amplify into a large generic `ciborium::Value` tree before schema validation.
+const MAX_CBOR_DEPTH: usize = 8;
+const MAX_CBOR_CONTAINER_ITEMS: usize = 32;
+const MAX_CBOR_TOTAL_ITEMS: usize = 64;
+const MAX_PROTECTED_HEADER_BYTES: usize = 4 * 1024;
+const MAX_HEADER_VALUE_BYTES: usize = 4 * 1024;
+const MAX_HEADER_TEXT_BYTES: usize = MAX_IDENTIFIER_BYTES;
 
 /// Authenticated identity and nonce coordinates for one sealed object.
 ///
@@ -448,10 +459,243 @@ fn require_no_unprotected(enc: &CoseEncrypt0) -> Result<()> {
     Ok(())
 }
 
+/// Allocation-free structural validation of the small CBOR subset used by the
+/// COSE profile.  In addition to bounding work, this independently enforces RFC
+/// 8949 core deterministic argument encodings and map-key order (encoded-key
+/// length, then bytewise lexical order).  It intentionally performs no COSE
+/// semantics; `coset` remains the sole semantic decoder below.
+struct CborPreflight<'a> {
+    input: &'a [u8],
+    offset: usize,
+    items: usize,
+    max_byte_string: usize,
+}
+
+impl<'a> CborPreflight<'a> {
+    fn new(input: &'a [u8], max_byte_string: usize) -> Self {
+        Self {
+            input,
+            offset: 0,
+            items: 0,
+            max_byte_string,
+        }
+    }
+
+    fn finish(self) -> Result<()> {
+        if self.offset != self.input.len() {
+            bail!("CBOR contains trailing data");
+        }
+        Ok(())
+    }
+
+    fn read_byte(&mut self) -> Result<u8> {
+        let byte = *self.input.get(self.offset).context("truncated CBOR item")?;
+        self.offset += 1;
+        Ok(byte)
+    }
+
+    fn read_exact<const N: usize>(&mut self) -> Result<[u8; N]> {
+        let end = self.offset.checked_add(N).context("CBOR length overflow")?;
+        let bytes = self
+            .input
+            .get(self.offset..end)
+            .context("truncated CBOR argument")?;
+        self.offset = end;
+        bytes.try_into().context("invalid CBOR argument width")
+    }
+
+    fn head(&mut self) -> Result<(u8, u64)> {
+        self.items = self.items.checked_add(1).context("CBOR item overflow")?;
+        if self.items > MAX_CBOR_TOTAL_ITEMS {
+            bail!("CBOR contains more than {MAX_CBOR_TOTAL_ITEMS} items");
+        }
+        let initial = self.read_byte()?;
+        let major = initial >> 5;
+        let additional = initial & 0x1f;
+        let argument = match additional {
+            value @ 0..=23 => u64::from(value),
+            24 => {
+                let value = u64::from(self.read_byte()?);
+                if value < 24 {
+                    bail!("CBOR argument is not shortest-form encoded");
+                }
+                value
+            }
+            25 => {
+                let value = u64::from(u16::from_be_bytes(self.read_exact()?));
+                if value <= u64::from(u8::MAX) {
+                    bail!("CBOR argument is not shortest-form encoded");
+                }
+                value
+            }
+            26 => {
+                let value = u64::from(u32::from_be_bytes(self.read_exact()?));
+                if value <= u64::from(u16::MAX) {
+                    bail!("CBOR argument is not shortest-form encoded");
+                }
+                value
+            }
+            27 => {
+                let value = u64::from_be_bytes(self.read_exact()?);
+                if value <= u64::from(u32::MAX) {
+                    bail!("CBOR argument is not shortest-form encoded");
+                }
+                value
+            }
+            31 => bail!("indefinite-length CBOR is forbidden"),
+            _ => bail!("reserved CBOR additional-information value"),
+        };
+        Ok((major, argument))
+    }
+
+    fn length(argument: u64) -> Result<usize> {
+        usize::try_from(argument).context("CBOR length does not fit address space")
+    }
+
+    fn bytes(&mut self, expected_major: u8, limit: usize) -> Result<&'a [u8]> {
+        let (major, argument) = self.head()?;
+        if major != expected_major {
+            bail!("unexpected CBOR major type {major}, expected {expected_major}");
+        }
+        let length = Self::length(argument)?;
+        if length > limit {
+            bail!("CBOR string length {length} exceeds {limit}-byte limit");
+        }
+        let end = self
+            .offset
+            .checked_add(length)
+            .context("CBOR string length overflow")?;
+        let bytes = self
+            .input
+            .get(self.offset..end)
+            .context("truncated CBOR string")?;
+        self.offset = end;
+        Ok(bytes)
+    }
+
+    fn container(&mut self, expected_major: u8) -> Result<usize> {
+        let (major, argument) = self.head()?;
+        if major != expected_major {
+            bail!("unexpected CBOR major type {major}, expected {expected_major}");
+        }
+        let length = Self::length(argument)?;
+        if length > MAX_CBOR_CONTAINER_ITEMS {
+            bail!("CBOR container has {length} entries; limit is {MAX_CBOR_CONTAINER_ITEMS}");
+        }
+        Ok(length)
+    }
+
+    fn item(&mut self, depth: usize) -> Result<()> {
+        if depth > MAX_CBOR_DEPTH {
+            bail!("CBOR nesting exceeds depth {MAX_CBOR_DEPTH}");
+        }
+        let start = self.offset;
+        let (major, argument) = self.head()?;
+        match major {
+            0 | 1 => {}
+            2 | 3 => {
+                let length = Self::length(argument)?;
+                let limit = if major == 2 {
+                    self.max_byte_string
+                } else {
+                    MAX_HEADER_TEXT_BYTES
+                };
+                if length > limit {
+                    bail!("CBOR string length {length} exceeds {limit}-byte limit");
+                }
+                self.offset = self
+                    .offset
+                    .checked_add(length)
+                    .context("CBOR string length overflow")?;
+                if self.offset > self.input.len() {
+                    bail!("truncated CBOR string");
+                }
+            }
+            4 => {
+                let length = Self::length(argument)?;
+                if length > MAX_CBOR_CONTAINER_ITEMS {
+                    bail!("CBOR array has {length} entries; limit is {MAX_CBOR_CONTAINER_ITEMS}");
+                }
+                for _ in 0..length {
+                    self.item(depth + 1)?;
+                }
+            }
+            5 => {
+                let length = Self::length(argument)?;
+                if length > MAX_CBOR_CONTAINER_ITEMS {
+                    bail!("CBOR map has {length} entries; limit is {MAX_CBOR_CONTAINER_ITEMS}");
+                }
+                let mut previous_key: Option<(usize, usize)> = None;
+                for _ in 0..length {
+                    let key_start = self.offset;
+                    self.item(depth + 1)?;
+                    let key_end = self.offset;
+                    if let Some((previous_start, previous_end)) = previous_key {
+                        let previous = &self.input[previous_start..previous_end];
+                        let current = &self.input[key_start..key_end];
+                        if (previous.len(), previous) >= (current.len(), current) {
+                            bail!("CBOR map keys are duplicate or not in deterministic order");
+                        }
+                    }
+                    previous_key = Some((key_start, key_end));
+                    self.item(depth + 1)?;
+                }
+            }
+            // Tags, floats, simple values, and break are not used anywhere in
+            // this fixed COSE profile.  Rejecting them keeps the preflight small
+            // and prevents semantic-decoder discrepancies.
+            6 | 7 => bail!("unsupported CBOR type in COSE_Encrypt0 profile"),
+            _ => unreachable!("CBOR major type is three bits"),
+        }
+        if self.offset <= start {
+            bail!("CBOR scanner made no progress");
+        }
+        Ok(())
+    }
+}
+
+fn preflight_cose_encrypt0(cose_bytes: &[u8]) -> Result<()> {
+    let mut outer = CborPreflight::new(cose_bytes, MAX_HEADER_VALUE_BYTES);
+    let top_level_items = outer.container(4)?;
+    if top_level_items != 3 {
+        bail!("COSE_Encrypt0 must be a definite three-element array");
+    }
+
+    let protected = outer.bytes(2, MAX_PROTECTED_HEADER_BYTES)?;
+    let mut protected_scanner = CborPreflight::new(protected, MAX_HEADER_VALUE_BYTES);
+    let protected_entries = protected_scanner.container(5)?;
+    if protected_entries > 16 {
+        bail!("protected header map has too many entries");
+    }
+    // Rewind and scan the entire map so key ordering and nested values are
+    // checked by the same generic deterministic scanner.
+    protected_scanner.offset = 0;
+    protected_scanner.items = 0;
+    protected_scanner.item(0)?;
+    protected_scanner.finish()?;
+
+    let unprotected_start = outer.offset;
+    let unprotected_entries = outer.container(5)?;
+    if unprotected_entries > 16 {
+        bail!("unprotected header map has too many entries");
+    }
+    outer.offset = unprotected_start;
+    outer.items -= 1;
+    outer.item(0)?;
+
+    let ciphertext = outer.bytes(2, MAX_PLAINTEXT_BYTES + 16)?;
+    if ciphertext.len() < 16 {
+        bail!("COSE_Encrypt0 ciphertext is shorter than its AEAD tag");
+    }
+    outer.finish()
+}
+
 fn parse_canonical(cose_bytes: &[u8]) -> Result<CoseEncrypt0> {
     if cose_bytes.len() > MAX_COSE_BYTES {
         bail!("COSE_Encrypt0 exceeds {MAX_COSE_BYTES}-byte limit");
     }
+    preflight_cose_encrypt0(cose_bytes)
+        .context("COSE_Encrypt0 failed bounded deterministic CBOR preflight")?;
     let enc = CoseEncrypt0::from_slice(cose_bytes)
         .map_err(|error| anyhow::anyhow!("malformed COSE_Encrypt0: {error}"))?;
     let ciphertext_len = enc
@@ -626,22 +870,6 @@ fn compatibility_context(
     })
 }
 
-fn compatibility_key_context(
-    base_key: &[u8; 32],
-    external_aad: &[u8],
-    epoch: u64,
-    sequence: u64,
-) -> Result<SealContext> {
-    let epoch = u32::try_from(epoch).context("epoch exceeds u32 nonce domain")?;
-    Ok(SealContext {
-        recipient_id: digest_parts(COMPAT_RECIPIENT_LABEL, &[base_key]).to_vec(),
-        key_id: digest_parts(COMPAT_KEY_LABEL, &[base_key]).to_vec(),
-        nonce_domain: digest_parts(COMPAT_DOMAIN_LABEL, &[external_aad]),
-        epoch,
-        sequence,
-    })
-}
-
 fn digest_parts(label: &[u8], parts: &[&[u8]]) -> [u8; 32] {
     let mut hash = Sha256::new();
     hash.update(label);
@@ -694,38 +922,6 @@ pub fn open_from_recipient(
     open_core(&base_key, recipient.suite_id, &context, &enc, external_aad)
 }
 
-/// Compatibility wrapper for pre-derived key callers.
-///
-/// New code must use [`seal_prederived`] with an owning [`NonceLedger`].
-pub fn seal_with_key(
-    base_key: &[u8; 32],
-    suite: SuiteId,
-    plaintext: &[u8],
-    external_aad: &[u8],
-    epoch: u64,
-    sequence: u64,
-) -> Result<Vec<u8>> {
-    let context = compatibility_key_context(base_key, external_aad, epoch, sequence)?;
-    seal_core(base_key, suite, &context, None, plaintext, external_aad)
-}
-
-/// Compatibility wrapper for pre-derived key callers.
-///
-/// New code must use [`open_prederived`] with an owning [`NonceLedger`].
-pub fn open_with_key(
-    base_key: &[u8; 32],
-    expected_suite: SuiteId,
-    cose_bytes: &[u8],
-    external_aad: &[u8],
-    epoch: u64,
-    sequence: u64,
-) -> Result<Vec<u8>> {
-    let context = compatibility_key_context(base_key, external_aad, epoch, sequence)?;
-    let enc = parse_canonical(cose_bytes)?;
-    require_no_unprotected(&enc)?;
-    open_core(base_key, expected_suite, &context, &enc, external_aad)
-}
-
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -761,6 +957,44 @@ mod tests {
             .find(|(label, _)| label == &Label::Int(HDR_KEM_MATERIAL))
             .unwrap();
         *header_value = CborValue::Bytes(value.encode());
+    }
+
+    fn encode_value(value: &CborValue) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        ciborium::ser::into_writer(value, &mut bytes).unwrap();
+        bytes
+    }
+
+    fn mutate_protected_map(
+        sealed: &[u8],
+        mutation: impl FnOnce(&mut Vec<(CborValue, CborValue)>),
+    ) -> Vec<u8> {
+        let mut top: CborValue = ciborium::de::from_reader(sealed).unwrap();
+        let top_array = match &mut top {
+            CborValue::Array(items) => items,
+            _ => panic!("COSE_Encrypt0 must be an array"),
+        };
+        let protected_bytes = match &mut top_array[0] {
+            CborValue::Bytes(bytes) => bytes,
+            _ => panic!("protected header must be a byte string"),
+        };
+        let mut protected: CborValue =
+            ciborium::de::from_reader(protected_bytes.as_slice()).unwrap();
+        let map = match &mut protected {
+            CborValue::Map(entries) => entries,
+            _ => panic!("protected header must contain a map"),
+        };
+        mutation(map);
+        *protected_bytes = encode_value(&protected);
+        encode_value(&top)
+    }
+
+    fn replace_once(bytes: &mut Vec<u8>, needle: &[u8], replacement: &[u8]) {
+        let offset = bytes
+            .windows(needle.len())
+            .position(|candidate| candidate == needle)
+            .expect("mutation target must exist");
+        bytes.splice(offset..offset + needle.len(), replacement.iter().copied());
     }
 
     #[test]
@@ -950,6 +1184,170 @@ mod tests {
     }
 
     #[test]
+    fn reordered_protected_and_unprotected_maps_are_rejected_by_preflight() {
+        let recipient = generate_recipient(SUITE).unwrap();
+        let sealed = seal(
+            &recipient.public(),
+            &context(121),
+            b"secret",
+            AAD,
+            &mut ledger(),
+        )
+        .unwrap();
+
+        let reordered_protected = mutate_protected_map(&sealed, |entries| {
+            let first = entries
+                .iter()
+                .position(|(key, _)| key == &CborValue::Integer(HDR_SUITE_ID.into()))
+                .unwrap();
+            let second = entries
+                .iter()
+                .position(|(key, _)| key == &CborValue::Integer(HDR_RECIPIENT_ID.into()))
+                .unwrap();
+            entries.swap(first, second);
+        });
+        assert!(parse_canonical(&reordered_protected).is_err());
+
+        let mut top: CborValue = ciborium::de::from_reader(sealed.as_slice()).unwrap();
+        let unprotected = match &mut top {
+            CborValue::Array(items) => match &mut items[1] {
+                CborValue::Map(entries) => entries,
+                _ => panic!("unprotected header must be a map"),
+            },
+            _ => panic!("COSE_Encrypt0 must be an array"),
+        };
+        unprotected.push((
+            CborValue::Integer((-65560).into()),
+            CborValue::Integer(1.into()),
+        ));
+        // Both private labels have equal-length encodings; -65539 sorts before
+        // -65560 by its encoded argument.  Swap them to retain a valid map with
+        // a mutation that only the independent ordering check must reject.
+        unprotected.swap(0, 1);
+        assert!(parse_canonical(&encode_value(&top)).is_err());
+    }
+
+    #[test]
+    fn nonminimal_header_keys_and_values_are_rejected_by_preflight() {
+        let recipient = generate_recipient(SUITE).unwrap();
+        let sealed = seal(
+            &recipient.public(),
+            &context(122),
+            b"secret",
+            AAD,
+            &mut ledger(),
+        )
+        .unwrap();
+
+        // -65538 is major type 1 with argument 65537.  Eight argument bytes are
+        // valid CBOR but not the shortest deterministic representation.
+        let mut protected_key = mutate_protected_map(&sealed, |_| {});
+        let mut top: CborValue = ciborium::de::from_reader(protected_key.as_slice()).unwrap();
+        let protected = match &mut top {
+            CborValue::Array(items) => match &mut items[0] {
+                CborValue::Bytes(bytes) => bytes,
+                _ => panic!("protected header must be bytes"),
+            },
+            _ => panic!("COSE_Encrypt0 must be an array"),
+        };
+        replace_once(
+            protected,
+            &[0x3a, 0x00, 0x01, 0x00, 0x01],
+            &[0x3b, 0, 0, 0, 0, 0, 1, 0, 1],
+        );
+        protected_key = encode_value(&top);
+        assert!(parse_canonical(&protected_key).is_err());
+
+        // The suite value 1 follows that key.  Encoding it as 0x18 0x01 is
+        // likewise a valid but non-shortest integer representation.
+        let mut top: CborValue = ciborium::de::from_reader(sealed.as_slice()).unwrap();
+        let protected = match &mut top {
+            CborValue::Array(items) => match &mut items[0] {
+                CborValue::Bytes(bytes) => bytes,
+                _ => panic!("protected header must be bytes"),
+            },
+            _ => panic!("COSE_Encrypt0 must be an array"),
+        };
+        replace_once(
+            protected,
+            &[0x3a, 0x00, 0x01, 0x00, 0x01, 0x01],
+            &[0x3a, 0x00, 0x01, 0x00, 0x01, 0x18, 0x01],
+        );
+        assert!(parse_canonical(&encode_value(&top)).is_err());
+
+        // The unprotected private key -65539 is also rejected when widened.
+        let mut unprotected_key = sealed.clone();
+        replace_once(
+            &mut unprotected_key,
+            &[0x3a, 0x00, 0x01, 0x00, 0x02],
+            &[0x3b, 0, 0, 0, 0, 0, 1, 0, 2],
+        );
+        assert!(parse_canonical(&unprotected_key).is_err());
+
+        // The hybrid material is a 16-bit-length byte string in the valid
+        // object.  Widen only that length argument to 32 bits.
+        let mut unprotected_value = sealed.clone();
+        let key = [0x3a, 0x00, 0x01, 0x00, 0x02];
+        let key_offset = unprotected_value
+            .windows(key.len())
+            .position(|candidate| candidate == key)
+            .unwrap();
+        let value_offset = key_offset + key.len();
+        assert_eq!(unprotected_value[value_offset], 0x59);
+        let high = unprotected_value[value_offset + 1];
+        let low = unprotected_value[value_offset + 2];
+        unprotected_value.splice(
+            value_offset..value_offset + 3,
+            [0x5a, 0x00, 0x00, high, low],
+        );
+        assert!(parse_canonical(&unprotected_value).is_err());
+    }
+
+    #[test]
+    fn hostile_cbor_is_rejected_before_value_tree_amplification() {
+        let ciphertext = [0u8; 16];
+        let finish = |mut prefix: Vec<u8>| {
+            prefix.push(0x50);
+            prefix.extend_from_slice(&ciphertext);
+            prefix
+        };
+
+        // A 12-byte prefix claims more than four billion array members.  The
+        // preflight rejects the declared count without iterating or allocating.
+        let amplified = finish(vec![
+            0x83, 0x41, 0xa0, 0xa1, 0x00, 0x9a, 0xff, 0xff, 0xff, 0xff,
+        ]);
+        assert!(preflight_cose_encrypt0(&amplified).is_err());
+
+        let oversized_container = finish(vec![0x83, 0x41, 0xa0, 0xa1, 0x00, 0x98, 0x21]);
+        assert!(preflight_cose_encrypt0(&oversized_container).is_err());
+
+        let indefinite = finish(vec![0x83, 0x41, 0xa0, 0xbf, 0xff]);
+        assert!(preflight_cose_encrypt0(&indefinite).is_err());
+
+        let mut deep = vec![0x83, 0x41, 0xa0, 0xa1, 0x00];
+        deep.extend(std::iter::repeat_n(0x81, MAX_CBOR_DEPTH + 1));
+        deep.push(0x00);
+        assert!(preflight_cose_encrypt0(&finish(deep)).is_err());
+
+        // A header byte string over the 4 KiB schema limit is rejected from its
+        // five-byte declaration alone, before looking for or allocating bytes.
+        let oversized_string = finish(vec![
+            0x83, 0x41, 0xa0, 0xa1, 0x00, 0x5a, 0x00, 0x00, 0x10, 0x01,
+        ]);
+        assert!(preflight_cose_encrypt0(&oversized_string).is_err());
+
+        let mut trailing = finish(vec![0x83, 0x41, 0xa0, 0xa0]);
+        trailing.push(0x00);
+        assert!(preflight_cose_encrypt0(&trailing).is_err());
+    }
+
+    #[test]
+    fn focused_cose_gate_covers_every_hybrid_component_secret() {
+        assert!(hybrid_kem::combiner_is_sensitive_to_every_component_for_cose());
+    }
+
+    #[test]
     fn truncation_unknown_headers_and_tamper_rejected() {
         let recipient = generate_recipient(SUITE).unwrap();
         let ctx = context(13);
@@ -1111,12 +1509,6 @@ mod tests {
         let sealed = seal_to_recipient(&recipient.public(), b"legacy", AAD, 0, 0).unwrap();
         assert_eq!(
             open_from_recipient(&recipient, &sealed, AAD, 0, 0).unwrap(),
-            b"legacy"
-        );
-        let key = [7; 32];
-        let sealed = seal_with_key(&key, SUITE, b"legacy", AAD, 0, 1).unwrap();
-        assert_eq!(
-            open_with_key(&key, SUITE, &sealed, AAD, 0, 1).unwrap(),
             b"legacy"
         );
     }

--- a/crates/hyprstream-rpc/src/crypto/cose_encrypt.rs
+++ b/crates/hyprstream-rpc/src/crypto/cose_encrypt.rs
@@ -1,44 +1,24 @@
-//! COSE_Encrypt0 hybrid-KEM confidentiality — #553 / S2 of epic #550.
+//! Canonical COSE_Encrypt0 sealing over Hyprstream's pinned hybrid-KEM suite.
 //!
-//! Expresses confidentiality as a standard `COSE_Encrypt0` (RFC 9052) object,
-//! keyed by the S0 hybrid multi-KEM ([`crate::crypto::hybrid_kem`]). This is the
-//! confidentiality counterpart to the `COSE_Sign1`/composite signing in
-//! [`crate::crypto::cose_sign1`] / [`crate::crypto::cose_sign`]. No Rust crate
-//! implements draft-ietf-cose-hpke, so the HPKE-COSE wiring is done here over
-//! `coset` (which provides the `COSE_Encrypt0` CBOR structure with a
-//! bring-your-own-AEAD closure — it performs no crypto itself).
+//! This module implements the reusable confidentiality substrate for #553.  The
+//! outer object and its authenticated-data construction are COSE_Encrypt0 from
+//! RFC 9052, and the content algorithm is the registered ChaCha20/Poly1305 COSE
+//! algorithm (24).  Key establishment is Hyprstream's suite-identified N-KEM
+//! combiner in [`crate::crypto::hybrid_kem`].
 //!
-//! # Construction (draft-ietf-cose-hpke shape)
+//! This is deliberately **not** called HPKE or COSE-HPKE.  Hyprstream's N-KEM
+//! combiner is not an HPKE ciphersuite, and its composite encapsulation material
+//! is not the `enc` / `ek` value defined by `draft-ietf-cose-hpke`.  The private
+//! labels below define a project-local profile and make no draft-interoperability
+//! claim.  PQUIP / RFC 9794 supplies transition terminology, not wire semantics.
 //!
-//! ```text
-//! protected   = { alg: ChaCha20Poly1305 (24), HDR_SUITE_ID: suite_u16 }
-//! unprotected = { HDR_KEM_EK: HybridKemMaterial.encode() }   // the encapsulated key (one-shot only)
-//! ciphertext  = ChaCha20Poly1305_seal(K, N, plaintext, AAD)
-//! ```
-//! - **K** = `HKDF-SHA256-Expand(hybrid_secret, "…chacha20poly1305 key")` — the
-//!   32-byte combiner secret from S0 is already uniform; HKDF-expand gives
-//!   key-separation from any other use of that secret.
-//! - **N** (96-bit) = `be32(epoch) ‖ be64(seq)` — a deterministic counter nonce.
-//!   It is **not** transmitted (no COSE `iv`): both sides derive it from
-//!   `(epoch, seq)`, so it cannot be manipulated on the wire. Uniqueness: a
-//!   re-key bumps `epoch` *and* re-derives **K** (S3/#223), so within one key
-//!   `epoch` is fixed and `seq` is the strictly-monotonic per-block counter ⇒ the
-//!   `(K, N)` pair is unique-forever (the AEAD nonce-reuse invariant). One-shot
-//!   `seal_to_recipient` uses a *fresh* encapsulation (fresh K) per call, so any
-//!   `(epoch, seq)` is safe there.
-//! - **AAD** = `coset Enc_structure( protected_header ‖ external_aad' )`, where
-//!   `external_aad' = CBOR([external_aad, epoch, seq])`. `coset` folds the
-//!   protected header (which carries `alg` + `suite_id`) into the AEAD AAD, so the
-//!   suite id, the AEAD algorithm, the caller's `external_aad`, and `(epoch, seq)`
-//!   are all authenticated — a tampered header, swapped suite, or replay at a
-//!   different `(epoch, seq)` fails decryption.
-//!
-//! # Why this is fail-closed against downgrade
-//!
-//! `open_*` requires `alg == ChaCha20Poly1305` and the protected `suite_id` to
-//! match the recipient's pinned suite; there is no in-band algorithm negotiation
-//! (epic #550 principle 1). [`ALG_XCHACHA20POLY1305_PRIVATE`] is reserved for a
-//! future high-nonce-volume profile but is **not** accepted by default.
+//! New consumers should use [`seal`], [`open`], [`seal_prederived`], and
+//! [`open_prederived`] with an owning [`NonceLedger`].  The legacy wrappers at
+//! the bottom remain only for the already-landed envelope path, whose replay
+//! lifecycle is owned by `SignedEnvelope`; they must not be used for new stream
+//! or group lifecycles.
+
+use std::collections::HashSet;
 
 use anyhow::{bail, Context, Result};
 use chacha20poly1305::aead::{Aead, KeyInit, Payload};
@@ -47,93 +27,240 @@ use coset::cbor::value::Value as CborValue;
 use coset::{
     iana::{self, EnumI64},
     CborSerializable, CoseEncrypt0, CoseEncrypt0Builder, Header, HeaderBuilder, Label,
+    RegisteredLabelWithPrivate,
 };
 use hkdf::Hkdf;
-use sha2::Sha256;
+use sha2::{Digest, Sha256};
 use zeroize::Zeroizing;
 
 use crate::crypto::hybrid_kem::{
     self, HybridKemMaterial, RecipientKeypair, RecipientPublic, SuiteId,
 };
 
-/// COSE algorithm id for ChaCha20/Poly1305 (RFC 9053 §6.3.2, IANA = 24).
+/// Maximum plaintext accepted by this substrate (16 MiB).
+pub const MAX_PLAINTEXT_BYTES: usize = 16 * 1024 * 1024;
+/// Maximum caller-supplied external AAD / transcript bytes (64 KiB).
+pub const MAX_EXTERNAL_AAD_BYTES: usize = 64 * 1024;
+/// Maximum canonical COSE object accepted before parsing or KEM work.
+pub const MAX_COSE_BYTES: usize = MAX_PLAINTEXT_BYTES + 16 * 1024;
+/// Maximum recipient or key identifier length.
+pub const MAX_IDENTIFIER_BYTES: usize = 256;
+/// Maximum number of nonce/replay entries retained by one ledger.
+pub const MAX_LEDGER_ENTRIES: usize = 1_048_576;
+
 const ALG_CHACHA20POLY1305: i64 = iana::Algorithm::ChaCha20Poly1305 as i64;
 
-/// Private-use COSE algorithm code point reserved for XChaCha20-Poly1305 (192-bit
-/// nonce). XChaCha20-Poly1305 is **not** IANA-registered for COSE; this is a
-/// hyprstream-local private-use value (< -65536) reserved for a future
-/// high-nonce-volume profile. NOT accepted by the default `open_*` path.
-pub const ALG_XCHACHA20POLY1305_PRIVATE: i64 = -65537;
-
-/// Protected-header label carrying the HyKEM `suite_id` (u16). Private-use.
+// Project-local private-use labels.  They intentionally do not reuse the
+// provisional `ek` label or algorithm assignments from draft-ietf-cose-hpke.
 const HDR_SUITE_ID: i64 = -65538;
-/// Unprotected-header label carrying the encoded [`HybridKemMaterial`] (the
-/// encapsulated key, "ek"). Private-use. Present only on the one-shot
-/// `seal_to_recipient` path; the stream path keys from the handshake instead.
-const HDR_KEM_EK: i64 = -65539;
+const HDR_KEM_MATERIAL: i64 = -65539;
+const HDR_RECIPIENT_ID: i64 = -65540;
+const HDR_NONCE_DOMAIN: i64 = -65541;
+const HDR_EPOCH: i64 = -65542;
+const HDR_SEQUENCE: i64 = -65543;
 
-/// HKDF-Expand domain label for the content-encryption key.
-const KDF_KEY_LABEL: &[u8] = b"hyprstream cose-encrypt0 v1 chacha20poly1305 key";
+const KDF_KEY_LABEL: &[u8] = b"hyprstream cose-encrypt0 base key v2";
+const KDF_CONTEXT_LABEL: &[u8] = b"hyprstream cose-encrypt0 context key v2";
+const COMPAT_RECIPIENT_LABEL: &[u8] = b"hyprstream cose-encrypt0 compat recipient v2";
+const COMPAT_KEY_LABEL: &[u8] = b"hyprstream cose-encrypt0 compat key v2";
+const COMPAT_DOMAIN_LABEL: &[u8] = b"hyprstream cose-encrypt0 compat domain v2";
 
-// ============================================================================
-// Key / nonce / AAD derivation
-// ============================================================================
-
-/// Derive the 32-byte ChaCha20Poly1305 content key from a 32-byte hybrid-KEM
-/// combiner secret via HKDF-SHA256-Expand with a domain label (key separation).
+/// Authenticated identity and nonce coordinates for one sealed object.
 ///
-/// Exposed so the stream path (S3) can derive the per-stream content key once
-/// from the handshake secret and then call [`seal_with_key`]/[`open_with_key`]
-/// per block without re-deriving.
+/// `nonce_domain` is a lifecycle-generated, collision-resistant identifier for
+/// one direction/track/key domain.  The owner must not reuse it when restarting
+/// a lifecycle with the same key.  Epoch installation and retirement policy is
+/// intentionally outside #553 and belongs to #554/#555.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SealContext {
+    /// Canonical recipient identity (for example, an accepted service DID).
+    pub recipient_id: Vec<u8>,
+    /// Selected recipient key identifier.
+    pub key_id: Vec<u8>,
+    /// Collision-resistant lifecycle/direction/track nonce domain.
+    pub nonce_domain: [u8; 32],
+    /// Installed epoch.  It is encoded as a u32 in the 96-bit nonce.
+    pub epoch: u32,
+    /// Monotonic sequence within the epoch.
+    pub sequence: u64,
+}
+
+impl SealContext {
+    fn validate(&self) -> Result<()> {
+        validate_identifier("recipient id", &self.recipient_id)?;
+        validate_identifier("key id", &self.key_id)?;
+        if self.nonce_domain == [0; 32] {
+            bail!("nonce domain must not be all zero");
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+struct NonceUse {
+    suite: u16,
+    recipient_id: Vec<u8>,
+    key_id: Vec<u8>,
+    nonce_domain: [u8; 32],
+    epoch: u32,
+    sequence: u64,
+}
+
+impl NonceUse {
+    fn new(suite: SuiteId, context: &SealContext) -> Self {
+        Self {
+            suite: suite.as_u16(),
+            recipient_id: context.recipient_id.clone(),
+            key_id: context.key_id.clone(),
+            nonce_domain: context.nonce_domain,
+            epoch: context.epoch,
+            sequence: context.sequence,
+        }
+    }
+}
+
+/// Bounded owning state for outbound nonce-use and inbound replay rejection.
+///
+/// A ledger is directional: do not share the same instance between a sender and
+/// receiver.  `seal*` burns a coordinate before cryptographic work, so even an
+/// error cannot lead to an uncertain nonce being reused.  `open*` records a
+/// coordinate only after successful authentication, preventing invalid packets
+/// from consuming the replay budget.
+#[derive(Debug)]
+pub struct NonceLedger {
+    capacity: usize,
+    seen: HashSet<NonceUse>,
+}
+
+impl NonceLedger {
+    /// Construct a ledger with a finite non-zero capacity.
+    pub fn new(capacity: usize) -> Result<Self> {
+        if capacity == 0 || capacity > MAX_LEDGER_ENTRIES {
+            bail!("nonce ledger capacity must be in 1..={MAX_LEDGER_ENTRIES}");
+        }
+        Ok(Self {
+            capacity,
+            seen: HashSet::with_capacity(capacity.min(4096)),
+        })
+    }
+
+    /// Number of retained nonce/replay coordinates.
+    pub fn len(&self) -> usize {
+        self.seen.len()
+    }
+
+    /// Whether no coordinates are retained.
+    pub fn is_empty(&self) -> bool {
+        self.seen.is_empty()
+    }
+
+    /// Retire one epoch after the owning lifecycle has made it unacceptable.
+    ///
+    /// Removing replay state is safe only after the lifecycle rejects that epoch
+    /// before calling `open`; this method does not itself implement grace policy.
+    pub fn retire_epoch(
+        &mut self,
+        suite: SuiteId,
+        recipient_id: &[u8],
+        key_id: &[u8],
+        nonce_domain: &[u8; 32],
+        epoch: u32,
+    ) {
+        self.seen.retain(|entry| {
+            !(entry.suite == suite.as_u16()
+                && entry.recipient_id == recipient_id
+                && entry.key_id == key_id
+                && &entry.nonce_domain == nonce_domain
+                && entry.epoch == epoch)
+        });
+    }
+
+    fn ensure_unseen(&self, usage: &NonceUse) -> Result<()> {
+        if self.seen.contains(usage) {
+            bail!("nonce coordinate already used or ciphertext replayed");
+        }
+        Ok(())
+    }
+
+    fn record(&mut self, usage: NonceUse) -> Result<()> {
+        self.ensure_unseen(&usage)?;
+        if self.seen.len() >= self.capacity {
+            bail!("nonce ledger capacity exhausted; rotate/retire at lifecycle boundary");
+        }
+        self.seen.insert(usage);
+        Ok(())
+    }
+}
+
+/// Derive a separated base content key from a hybrid combiner secret.
 pub fn derive_aead_key(hybrid_secret: &[u8; 32]) -> Zeroizing<[u8; 32]> {
     let hk = Hkdf::<Sha256>::new(None, hybrid_secret);
     let mut key = [0u8; 32];
-    // Expand to 32 bytes never fails for HKDF-SHA256.
-    #[allow(clippy::expect_used)]
-    hk.expand(KDF_KEY_LABEL, &mut key)
-        .expect("HKDF-SHA256 expand to 32 bytes is infallible");
+    // SHA-256's HKDF output limit is far above 32 bytes.
+    if hk.expand(KDF_KEY_LABEL, &mut key).is_err() {
+        unreachable!("HKDF-SHA256 cannot reject a 32-byte output");
+    }
     Zeroizing::new(key)
 }
 
-/// Deterministic 96-bit nonce `be32(epoch) ‖ be64(seq)`.
-///
-/// `epoch` must fit in 32 bits — it is a per-stream re-key counter, bounded far
-/// below 2^32 in practice; a re-key also re-derives the content key, so `epoch`
-/// is effectively constant within a single key and `seq` carries uniqueness.
-fn derive_nonce(epoch: u64, seq: u64) -> [u8; 12] {
-    debug_assert!(
-        epoch <= u64::from(u32::MAX),
-        "epoch must fit in 32 bits for the AEAD nonce"
+fn validate_identifier(name: &str, value: &[u8]) -> Result<()> {
+    if value.is_empty() || value.len() > MAX_IDENTIFIER_BYTES {
+        bail!("{name} length must be in 1..={MAX_IDENTIFIER_BYTES}");
+    }
+    Ok(())
+}
+
+fn validate_inputs(context: &SealContext, plaintext_len: usize, external_aad: &[u8]) -> Result<()> {
+    context.validate()?;
+    if plaintext_len > MAX_PLAINTEXT_BYTES {
+        bail!("plaintext exceeds {MAX_PLAINTEXT_BYTES}-byte limit");
+    }
+    if external_aad.len() > MAX_EXTERNAL_AAD_BYTES {
+        bail!("external AAD exceeds {MAX_EXTERNAL_AAD_BYTES}-byte limit");
+    }
+    Ok(())
+}
+
+fn derive_context_key(
+    base_key: &[u8; 32],
+    suite: SuiteId,
+    context: &SealContext,
+) -> Result<Zeroizing<[u8; 32]>> {
+    context.validate()?;
+    let mut info = Vec::with_capacity(
+        KDF_CONTEXT_LABEL.len() + context.recipient_id.len() + context.key_id.len() + 80,
     );
-    let mut n = [0u8; 12];
-    n[..4].copy_from_slice(&(epoch as u32).to_be_bytes());
-    n[4..].copy_from_slice(&seq.to_be_bytes());
-    n
+    append_lp(&mut info, KDF_CONTEXT_LABEL)?;
+    info.extend_from_slice(&suite.as_u16().to_be_bytes());
+    append_lp(&mut info, &context.recipient_id)?;
+    append_lp(&mut info, &context.key_id)?;
+    info.extend_from_slice(&context.nonce_domain);
+    info.extend_from_slice(&context.epoch.to_be_bytes());
+
+    let hk =
+        Hkdf::<Sha256>::from_prk(base_key).map_err(|_| anyhow::anyhow!("invalid HKDF base key"))?;
+    let mut key = [0u8; 32];
+    hk.expand(&info, &mut key)
+        .map_err(|_| anyhow::anyhow!("COSE context KDF info too long"))?;
+    Ok(Zeroizing::new(key))
 }
 
-/// Bind the caller's `external_aad` together with `(epoch, seq)` as canonical
-/// CBOR `[bstr external_aad, int epoch, int seq]`. The suite id and AEAD alg are
-/// bound separately via the protected header (folded into the AEAD AAD by coset).
-fn combined_aad(external_aad: &[u8], epoch: u64, seq: u64) -> Vec<u8> {
-    let v = CborValue::Array(vec![
-        CborValue::Bytes(external_aad.to_vec()),
-        CborValue::Integer(epoch.into()),
-        CborValue::Integer(seq.into()),
-    ]);
-    let mut buf = Vec::with_capacity(external_aad.len() + 24);
-    #[allow(clippy::expect_used)]
-    ciborium::ser::into_writer(&v, &mut buf)
-        .expect("CBOR encoding of [bstr,int,int] into a Vec is infallible");
-    buf
+fn append_lp(out: &mut Vec<u8>, value: &[u8]) -> Result<()> {
+    let len = u32::try_from(value.len()).context("context field too long")?;
+    out.extend_from_slice(&len.to_be_bytes());
+    out.extend_from_slice(value);
+    Ok(())
 }
 
-// ============================================================================
-// AEAD closures
-// ============================================================================
+fn derive_nonce(context: &SealContext) -> [u8; 12] {
+    let mut nonce = [0u8; 12];
+    nonce[..4].copy_from_slice(&context.epoch.to_be_bytes());
+    nonce[4..].copy_from_slice(&context.sequence.to_be_bytes());
+    nonce
+}
 
 fn aead_seal(key: &[u8; 32], nonce: &[u8; 12], plaintext: &[u8], aad: &[u8]) -> Result<Vec<u8>> {
-    let cipher = ChaCha20Poly1305::new(Key::from_slice(key));
-    cipher
+    ChaCha20Poly1305::new(Key::from_slice(key))
         .encrypt(
             Nonce::from_slice(nonce),
             Payload {
@@ -145,8 +272,7 @@ fn aead_seal(key: &[u8; 32], nonce: &[u8; 12], plaintext: &[u8], aad: &[u8]) -> 
 }
 
 fn aead_open(key: &[u8; 32], nonce: &[u8; 12], ciphertext: &[u8], aad: &[u8]) -> Result<Vec<u8>> {
-    let cipher = ChaCha20Poly1305::new(Key::from_slice(key));
-    cipher
+    ChaCha20Poly1305::new(Key::from_slice(key))
         .decrypt(
             Nonce::from_slice(nonce),
             Payload {
@@ -157,321 +283,841 @@ fn aead_open(key: &[u8; 32], nonce: &[u8; 12], ciphertext: &[u8], aad: &[u8]) ->
         .map_err(|_| anyhow::anyhow!("ChaCha20Poly1305 decrypt/auth failed"))
 }
 
-// ============================================================================
-// Header build / parse
-// ============================================================================
+fn private_label(value: i64) -> RegisteredLabelWithPrivate<iana::HeaderParameter> {
+    RegisteredLabelWithPrivate::PrivateUse(value)
+}
 
-fn build_protected(suite: SuiteId) -> Header {
+fn critical_headers() -> Vec<RegisteredLabelWithPrivate<iana::HeaderParameter>> {
+    vec![
+        private_label(HDR_SUITE_ID),
+        private_label(HDR_RECIPIENT_ID),
+        private_label(HDR_NONCE_DOMAIN),
+        private_label(HDR_EPOCH),
+        private_label(HDR_SEQUENCE),
+    ]
+}
+
+fn build_protected(suite: SuiteId, context: &SealContext) -> Header {
     HeaderBuilder::new()
         .algorithm(iana::Algorithm::ChaCha20Poly1305)
+        .key_id(context.key_id.clone())
+        .add_critical_label(private_label(HDR_SUITE_ID))
+        .add_critical_label(private_label(HDR_RECIPIENT_ID))
+        .add_critical_label(private_label(HDR_NONCE_DOMAIN))
+        .add_critical_label(private_label(HDR_EPOCH))
+        .add_critical_label(private_label(HDR_SEQUENCE))
         .value(HDR_SUITE_ID, CborValue::Integer(suite.as_u16().into()))
+        .value(
+            HDR_RECIPIENT_ID,
+            CborValue::Bytes(context.recipient_id.clone()),
+        )
+        .value(
+            HDR_NONCE_DOMAIN,
+            CborValue::Bytes(context.nonce_domain.to_vec()),
+        )
+        .value(HDR_EPOCH, CborValue::Integer(context.epoch.into()))
+        .value(HDR_SEQUENCE, CborValue::Integer(context.sequence.into()))
         .build()
 }
 
-fn require_chacha20poly1305(enc: &CoseEncrypt0) -> Result<()> {
-    match enc.protected.header.alg.as_ref() {
-        Some(coset::Algorithm::Assigned(a)) if a.to_i64() == ALG_CHACHA20POLY1305 => Ok(()),
+fn empty_except_rest(header: &Header) -> bool {
+    header.alg.is_none()
+        && header.crit.is_empty()
+        && header.content_type.is_none()
+        && header.key_id.is_empty()
+        && header.iv.is_empty()
+        && header.partial_iv.is_empty()
+        && header.counter_signatures.is_empty()
+}
+
+fn require_exact_protected(
+    enc: &CoseEncrypt0,
+    expected_suite: SuiteId,
+    expected: &SealContext,
+) -> Result<()> {
+    let header = &enc.protected.header;
+    match header.alg.as_ref() {
+        Some(coset::Algorithm::Assigned(a)) if a.to_i64() == ALG_CHACHA20POLY1305 => {}
         Some(coset::Algorithm::Assigned(a)) => {
             bail!(
-                "COSE_Encrypt0 alg {} is not ChaCha20Poly1305 (24)",
+                "COSE_Encrypt0 algorithm {} is not ChaCha20Poly1305 (24)",
                 a.to_i64()
             )
         }
-        Some(coset::Algorithm::PrivateUse(v)) => {
-            bail!("COSE_Encrypt0 private-use alg {v} not accepted (downgrade rejected)")
+        Some(coset::Algorithm::PrivateUse(value)) => {
+            bail!("private-use COSE algorithm {value} is not accepted")
         }
-        Some(coset::Algorithm::Text(s)) => bail!("unsupported text alg: {s}"),
-        None => bail!("COSE_Encrypt0 missing alg in protected header"),
+        Some(coset::Algorithm::Text(value)) => bail!("text COSE algorithm {value} is unsupported"),
+        None => bail!("COSE_Encrypt0 missing protected algorithm"),
+    }
+    if header.crit != critical_headers() {
+        bail!("COSE_Encrypt0 critical-header set/order is not canonical");
+    }
+    if header.key_id != expected.key_id {
+        bail!("COSE_Encrypt0 recipient key id mismatch");
+    }
+    if header.content_type.is_some()
+        || !header.iv.is_empty()
+        || !header.partial_iv.is_empty()
+        || !header.counter_signatures.is_empty()
+    {
+        bail!("COSE_Encrypt0 contains unsupported protected headers");
+    }
+    if header.rest.len() != 5 {
+        bail!("COSE_Encrypt0 protected private-header set is not exact");
+    }
+
+    require_int(
+        header,
+        HDR_SUITE_ID,
+        i128::from(expected_suite.as_u16()),
+        "suite",
+    )?;
+    require_bytes(
+        header,
+        HDR_RECIPIENT_ID,
+        &expected.recipient_id,
+        "recipient id",
+    )?;
+    require_bytes(
+        header,
+        HDR_NONCE_DOMAIN,
+        &expected.nonce_domain,
+        "nonce domain",
+    )?;
+    require_int(header, HDR_EPOCH, i128::from(expected.epoch), "epoch")?;
+    require_int(
+        header,
+        HDR_SEQUENCE,
+        i128::from(expected.sequence),
+        "sequence",
+    )?;
+    Ok(())
+}
+
+fn require_int(header: &Header, label: i64, expected: i128, name: &str) -> Result<()> {
+    match unique_header_value(header, label)? {
+        CborValue::Integer(value) if i128::from(*value) == expected => Ok(()),
+        CborValue::Integer(value) => {
+            let actual = i128::from(*value);
+            bail!("COSE_Encrypt0 {name} mismatch: {actual} != {expected}")
+        }
+        _ => bail!("COSE_Encrypt0 {name} header has wrong type"),
     }
 }
 
-fn read_int_header(h: &Header, label: i64) -> Option<i128> {
-    h.rest.iter().find_map(|(l, v)| match (l, v) {
-        (Label::Int(i), CborValue::Integer(n)) if *i == label => Some((*n).into()),
-        _ => None,
+fn require_bytes(header: &Header, label: i64, expected: &[u8], name: &str) -> Result<()> {
+    match unique_header_value(header, label)? {
+        CborValue::Bytes(value) if value == expected => Ok(()),
+        CborValue::Bytes(_) => bail!("COSE_Encrypt0 {name} mismatch"),
+        _ => bail!("COSE_Encrypt0 {name} header has wrong type"),
+    }
+}
+
+fn unique_header_value(header: &Header, label: i64) -> Result<&CborValue> {
+    let mut values = header.rest.iter().filter_map(|(candidate, value)| {
+        if candidate == &Label::Int(label) {
+            Some(value)
+        } else {
+            None
+        }
+    });
+    let value = values
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("COSE_Encrypt0 missing private header {label}"))?;
+    if values.next().is_some() {
+        bail!("COSE_Encrypt0 duplicate private header {label}");
+    }
+    Ok(value)
+}
+
+fn require_material(enc: &CoseEncrypt0) -> Result<HybridKemMaterial> {
+    if !empty_except_rest(&enc.unprotected) || enc.unprotected.rest.len() != 1 {
+        bail!("COSE_Encrypt0 unprotected header set is not exact");
+    }
+    match unique_header_value(&enc.unprotected, HDR_KEM_MATERIAL)? {
+        CborValue::Bytes(value) => HybridKemMaterial::decode(value),
+        _ => bail!("COSE_Encrypt0 hybrid-KEM material has wrong type"),
+    }
+}
+
+fn require_no_unprotected(enc: &CoseEncrypt0) -> Result<()> {
+    if !enc.unprotected.is_empty() {
+        bail!("pre-derived-key COSE_Encrypt0 must have no unprotected headers");
+    }
+    Ok(())
+}
+
+fn parse_canonical(cose_bytes: &[u8]) -> Result<CoseEncrypt0> {
+    if cose_bytes.len() > MAX_COSE_BYTES {
+        bail!("COSE_Encrypt0 exceeds {MAX_COSE_BYTES}-byte limit");
+    }
+    let enc = CoseEncrypt0::from_slice(cose_bytes)
+        .map_err(|error| anyhow::anyhow!("malformed COSE_Encrypt0: {error}"))?;
+    let ciphertext_len = enc
+        .ciphertext
+        .as_ref()
+        .context("COSE_Encrypt0 has no ciphertext")?
+        .len();
+    if !(16..=MAX_PLAINTEXT_BYTES + 16).contains(&ciphertext_len) {
+        bail!("COSE_Encrypt0 ciphertext length is outside bounded AEAD limits");
+    }
+
+    let mut normalized = enc.clone();
+    normalized.protected.original_data = None;
+    let canonical = normalized
+        .to_vec()
+        .map_err(|error| anyhow::anyhow!("cannot canonicalize COSE_Encrypt0: {error}"))?;
+    if canonical != cose_bytes {
+        bail!("COSE_Encrypt0 is not deterministic/canonical CBOR");
+    }
+    Ok(enc)
+}
+
+fn seal_core(
+    base_key: &[u8; 32],
+    suite: SuiteId,
+    context: &SealContext,
+    material: Option<&HybridKemMaterial>,
+    plaintext: &[u8],
+    external_aad: &[u8],
+) -> Result<Vec<u8>> {
+    validate_inputs(context, plaintext.len(), external_aad)?;
+    let context_key = derive_context_key(base_key, suite, context)?;
+    let nonce = derive_nonce(context);
+    let mut builder = CoseEncrypt0Builder::new().protected(build_protected(suite, context));
+    if let Some(material) = material {
+        let unprotected = HeaderBuilder::new()
+            .value(HDR_KEM_MATERIAL, CborValue::Bytes(material.encode()))
+            .build();
+        builder = builder.unprotected(unprotected);
+    }
+    let enc = builder
+        .try_create_ciphertext(plaintext, external_aad, |pt, cose_aad| {
+            aead_seal(&context_key, &nonce, pt, cose_aad)
+        })?
+        .build();
+    let bytes = enc
+        .to_vec()
+        .map_err(|error| anyhow::anyhow!("serialize COSE_Encrypt0: {error}"))?;
+    if bytes.len() > MAX_COSE_BYTES {
+        bail!("serialized COSE_Encrypt0 exceeds {MAX_COSE_BYTES}-byte limit");
+    }
+    Ok(bytes)
+}
+
+fn open_core(
+    base_key: &[u8; 32],
+    expected_suite: SuiteId,
+    expected: &SealContext,
+    enc: &CoseEncrypt0,
+    external_aad: &[u8],
+) -> Result<Vec<u8>> {
+    validate_inputs(expected, 0, external_aad)?;
+    require_exact_protected(enc, expected_suite, expected)?;
+    let context_key = derive_context_key(base_key, expected_suite, expected)?;
+    let nonce = derive_nonce(expected);
+    enc.decrypt_ciphertext(
+        external_aad,
+        || anyhow::anyhow!("COSE_Encrypt0 has no ciphertext"),
+        |ciphertext, cose_aad| aead_open(&context_key, &nonce, ciphertext, cose_aad),
+    )
+}
+
+/// Seal to a hybrid recipient with bounded canonical COSE and nonce-use state.
+pub fn seal(
+    recipient: &RecipientPublic,
+    context: &SealContext,
+    plaintext: &[u8],
+    external_aad: &[u8],
+    nonce_ledger: &mut NonceLedger,
+) -> Result<Vec<u8>> {
+    validate_inputs(context, plaintext.len(), external_aad)?;
+    nonce_ledger.record(NonceUse::new(recipient.suite_id, context))?;
+    let (material, secret) = hybrid_kem::encapsulate_to(recipient)?;
+    let base_key = derive_aead_key(&secret);
+    seal_core(
+        &base_key,
+        recipient.suite_id,
+        context,
+        Some(&material),
+        plaintext,
+        external_aad,
+    )
+}
+
+/// Open from a hybrid recipient and record replay state after authentication.
+pub fn open(
+    recipient: &RecipientKeypair,
+    expected: &SealContext,
+    cose_bytes: &[u8],
+    external_aad: &[u8],
+    replay_ledger: &mut NonceLedger,
+) -> Result<Vec<u8>> {
+    validate_inputs(expected, 0, external_aad)?;
+    let usage = NonceUse::new(recipient.suite_id, expected);
+    replay_ledger.ensure_unseen(&usage)?;
+    let enc = parse_canonical(cose_bytes)?;
+    require_exact_protected(&enc, recipient.suite_id, expected)?;
+    let material = require_material(&enc)?;
+    if material.suite_id != recipient.suite_id {
+        bail!("hybrid-KEM material suite does not match recipient suite");
+    }
+    let secret = hybrid_kem::decapsulate(recipient, &material)?;
+    let base_key = derive_aead_key(&secret);
+    let plaintext = open_core(&base_key, recipient.suite_id, expected, &enc, external_aad)?;
+    replay_ledger.record(usage)?;
+    Ok(plaintext)
+}
+
+/// Seal with a pre-derived base key and explicit lifecycle-owned nonce state.
+///
+/// The base key must be independently bound to the same pinned suite.  This is
+/// the narrow seam intended for #554/#555 after their handshake/epoch commit.
+pub fn seal_prederived(
+    base_key: &[u8; 32],
+    suite: SuiteId,
+    context: &SealContext,
+    plaintext: &[u8],
+    external_aad: &[u8],
+    nonce_ledger: &mut NonceLedger,
+) -> Result<Vec<u8>> {
+    validate_inputs(context, plaintext.len(), external_aad)?;
+    nonce_ledger.record(NonceUse::new(suite, context))?;
+    seal_core(base_key, suite, context, None, plaintext, external_aad)
+}
+
+/// Open with a pre-derived base key and explicit replay state.
+pub fn open_prederived(
+    base_key: &[u8; 32],
+    expected_suite: SuiteId,
+    expected: &SealContext,
+    cose_bytes: &[u8],
+    external_aad: &[u8],
+    replay_ledger: &mut NonceLedger,
+) -> Result<Vec<u8>> {
+    validate_inputs(expected, 0, external_aad)?;
+    let usage = NonceUse::new(expected_suite, expected);
+    replay_ledger.ensure_unseen(&usage)?;
+    let enc = parse_canonical(cose_bytes)?;
+    require_no_unprotected(&enc)?;
+    let plaintext = open_core(base_key, expected_suite, expected, &enc, external_aad)?;
+    replay_ledger.record(usage)?;
+    Ok(plaintext)
+}
+
+fn compatibility_context(
+    recipient: &RecipientPublic,
+    external_aad: &[u8],
+    epoch: u64,
+    sequence: u64,
+) -> Result<SealContext> {
+    let epoch = u32::try_from(epoch).context("epoch exceeds u32 nonce domain")?;
+    let encoded = recipient.encode();
+    let recipient_id = digest_parts(COMPAT_RECIPIENT_LABEL, &[&encoded]).to_vec();
+    let key_id = digest_parts(COMPAT_KEY_LABEL, &[&encoded]).to_vec();
+    let nonce_domain = digest_parts(COMPAT_DOMAIN_LABEL, &[external_aad]);
+    Ok(SealContext {
+        recipient_id,
+        key_id,
+        nonce_domain,
+        epoch,
+        sequence,
     })
 }
 
-fn read_bytes_header(h: &Header, label: i64) -> Option<Vec<u8>> {
-    h.rest.iter().find_map(|(l, v)| match (l, v) {
-        (Label::Int(i), CborValue::Bytes(b)) if *i == label => Some(b.clone()),
-        _ => None,
+fn compatibility_key_context(
+    base_key: &[u8; 32],
+    external_aad: &[u8],
+    epoch: u64,
+    sequence: u64,
+) -> Result<SealContext> {
+    let epoch = u32::try_from(epoch).context("epoch exceeds u32 nonce domain")?;
+    Ok(SealContext {
+        recipient_id: digest_parts(COMPAT_RECIPIENT_LABEL, &[base_key]).to_vec(),
+        key_id: digest_parts(COMPAT_KEY_LABEL, &[base_key]).to_vec(),
+        nonce_domain: digest_parts(COMPAT_DOMAIN_LABEL, &[external_aad]),
+        epoch,
+        sequence,
     })
 }
 
-fn read_suite(enc: &CoseEncrypt0) -> Result<SuiteId> {
-    let raw = read_int_header(&enc.protected.header, HDR_SUITE_ID)
-        .context("COSE_Encrypt0 missing HyKEM suite id in protected header")?;
-    let u = u16::try_from(raw).map_err(|_| anyhow::anyhow!("suite id {raw} out of range"))?;
-    SuiteId::from_u16(u).ok_or_else(|| anyhow::anyhow!("unknown HyKEM suite id {u}"))
+fn digest_parts(label: &[u8], parts: &[&[u8]]) -> [u8; 32] {
+    let mut hash = Sha256::new();
+    hash.update(label);
+    for part in parts {
+        hash.update((part.len() as u64).to_be_bytes());
+        hash.update(part);
+    }
+    hash.finalize().into()
 }
 
-// ============================================================================
-// One-shot recipient API (envelope path, S4) — encapsulates per call
-// ============================================================================
-
-/// Seal `plaintext` to `recipient` as a `COSE_Encrypt0`: run the S0 hybrid KEM,
-/// key ChaCha20Poly1305 with the combiner secret, and carry the encapsulated key
-/// material in the unprotected header. Fresh encapsulation (fresh key) per call.
+/// Compatibility wrapper for the existing encrypted-envelope lifecycle.
+///
+/// New code must use [`seal`] with an owning [`NonceLedger`].
 pub fn seal_to_recipient(
     recipient: &RecipientPublic,
     plaintext: &[u8],
     external_aad: &[u8],
     epoch: u64,
-    seq: u64,
+    sequence: u64,
 ) -> Result<Vec<u8>> {
+    let context = compatibility_context(recipient, external_aad, epoch, sequence)?;
     let (material, secret) = hybrid_kem::encapsulate_to(recipient)?;
-    let key = derive_aead_key(&secret);
-    let nonce = derive_nonce(epoch, seq);
-    let aad = combined_aad(external_aad, epoch, seq);
-
-    let unprotected = HeaderBuilder::new()
-        .value(HDR_KEM_EK, CborValue::Bytes(material.encode()))
-        .build();
-
-    let mut sealed: Result<()> = Ok(());
-    let enc = CoseEncrypt0Builder::new()
-        .protected(build_protected(recipient.suite_id))
-        .unprotected(unprotected)
-        .create_ciphertext(plaintext, &aad, |pt, coset_aad| {
-            match aead_seal(&key, &nonce, pt, coset_aad) {
-                Ok(ct) => ct,
-                Err(e) => {
-                    sealed = Err(e);
-                    Vec::new()
-                }
-            }
-        })
-        .build();
-    sealed?;
-
-    enc.to_vec()
-        .map_err(|e| anyhow::anyhow!("serialize COSE_Encrypt0: {e}"))
+    let base_key = derive_aead_key(&secret);
+    seal_core(
+        &base_key,
+        recipient.suite_id,
+        &context,
+        Some(&material),
+        plaintext,
+        external_aad,
+    )
 }
 
-/// Open a `COSE_Encrypt0` produced by [`seal_to_recipient`], decapsulating with
-/// `recipient`'s hybrid keypair. Fails closed on alg/suite mismatch.
+/// Compatibility wrapper for the existing encrypted-envelope lifecycle.
+///
+/// New code must use [`open`] with an owning [`NonceLedger`].
 pub fn open_from_recipient(
     recipient: &RecipientKeypair,
     cose_bytes: &[u8],
     external_aad: &[u8],
     epoch: u64,
-    seq: u64,
+    sequence: u64,
 ) -> Result<Vec<u8>> {
-    let enc = CoseEncrypt0::from_slice(cose_bytes)
-        .map_err(|e| anyhow::anyhow!("malformed COSE_Encrypt0: {e}"))?;
-    require_chacha20poly1305(&enc)?;
-
-    let suite = read_suite(&enc)?;
-    if suite != recipient.suite_id {
-        bail!(
-            "COSE_Encrypt0 suite {} != recipient suite {}",
-            suite.as_str(),
-            recipient.suite_id.as_str()
-        );
-    }
-
-    let ek = read_bytes_header(&enc.unprotected, HDR_KEM_EK)
-        .context("COSE_Encrypt0 missing encapsulated-key (HDR_KEM_EK) header")?;
-    let material = HybridKemMaterial::decode(&ek)?;
-    if material.suite_id != suite {
-        bail!("encapsulated material suite mismatch");
-    }
-
+    let context = compatibility_context(&recipient.public(), external_aad, epoch, sequence)?;
+    let enc = parse_canonical(cose_bytes)?;
+    require_exact_protected(&enc, recipient.suite_id, &context)?;
+    let material = require_material(&enc)?;
     let secret = hybrid_kem::decapsulate(recipient, &material)?;
-    let key = derive_aead_key(&secret);
-    let nonce = derive_nonce(epoch, seq);
-    let aad = combined_aad(external_aad, epoch, seq);
-
-    enc.decrypt_ciphertext(
-        &aad,
-        || anyhow::anyhow!("COSE_Encrypt0 has no ciphertext"),
-        |ct, coset_aad| aead_open(&key, &nonce, ct, coset_aad),
-    )
+    let base_key = derive_aead_key(&secret);
+    open_core(&base_key, recipient.suite_id, &context, &enc, external_aad)
 }
 
-// ============================================================================
-// Key-based API (stream path, S3) — key from the handshake, no per-block ek
-// ============================================================================
-
-/// Seal `plaintext` under a content key derived once from a hybrid-KEM handshake
-/// (see [`derive_aead_key`]). No encapsulated-key header — the stream handshake
-/// (S3 #554) carries the KEM material separately. `suite` is bound in the
-/// protected header for domain separation.
+/// Compatibility wrapper for pre-derived key callers.
+///
+/// New code must use [`seal_prederived`] with an owning [`NonceLedger`].
 pub fn seal_with_key(
-    aead_key: &[u8; 32],
+    base_key: &[u8; 32],
     suite: SuiteId,
     plaintext: &[u8],
     external_aad: &[u8],
     epoch: u64,
-    seq: u64,
+    sequence: u64,
 ) -> Result<Vec<u8>> {
-    let nonce = derive_nonce(epoch, seq);
-    let aad = combined_aad(external_aad, epoch, seq);
-
-    let mut sealed: Result<()> = Ok(());
-    let enc = CoseEncrypt0Builder::new()
-        .protected(build_protected(suite))
-        .create_ciphertext(plaintext, &aad, |pt, coset_aad| {
-            match aead_seal(aead_key, &nonce, pt, coset_aad) {
-                Ok(ct) => ct,
-                Err(e) => {
-                    sealed = Err(e);
-                    Vec::new()
-                }
-            }
-        })
-        .build();
-    sealed?;
-
-    enc.to_vec()
-        .map_err(|e| anyhow::anyhow!("serialize COSE_Encrypt0: {e}"))
+    let context = compatibility_key_context(base_key, external_aad, epoch, sequence)?;
+    seal_core(base_key, suite, &context, None, plaintext, external_aad)
 }
 
-/// Open a [`seal_with_key`] object with the pre-derived content key.
+/// Compatibility wrapper for pre-derived key callers.
+///
+/// New code must use [`open_prederived`] with an owning [`NonceLedger`].
 pub fn open_with_key(
-    aead_key: &[u8; 32],
+    base_key: &[u8; 32],
     expected_suite: SuiteId,
     cose_bytes: &[u8],
     external_aad: &[u8],
     epoch: u64,
-    seq: u64,
+    sequence: u64,
 ) -> Result<Vec<u8>> {
-    let enc = CoseEncrypt0::from_slice(cose_bytes)
-        .map_err(|e| anyhow::anyhow!("malformed COSE_Encrypt0: {e}"))?;
-    require_chacha20poly1305(&enc)?;
-    let suite = read_suite(&enc)?;
-    if suite != expected_suite {
-        bail!(
-            "COSE_Encrypt0 suite {} != expected {}",
-            suite.as_str(),
-            expected_suite.as_str()
-        );
-    }
-    let nonce = derive_nonce(epoch, seq);
-    let aad = combined_aad(external_aad, epoch, seq);
-    enc.decrypt_ciphertext(
-        &aad,
-        || anyhow::anyhow!("COSE_Encrypt0 has no ciphertext"),
-        |ct, coset_aad| aead_open(aead_key, &nonce, ct, coset_aad),
-    )
+    let context = compatibility_key_context(base_key, external_aad, epoch, sequence)?;
+    let enc = parse_canonical(cose_bytes)?;
+    require_no_unprotected(&enc)?;
+    open_core(base_key, expected_suite, &context, &enc, external_aad)
 }
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
-    use crate::crypto::hybrid_kem::{generate_recipient, SuiteId};
+    use crate::crypto::hybrid_kem::{generate_recipient, recipient_from_seeds, KemId, KemShare};
 
     const SUITE: SuiteId = SuiteId::HyKemX25519MlKem768;
-    const AAD: &[u8] = b"hyprstream-test-aad";
+    const AAD: &[u8] = b"canonical transcript bytes";
 
-    #[test]
-    fn recipient_roundtrip() {
-        let kp = generate_recipient(SUITE).unwrap();
-        let pt = b"hybrid confidential payload";
-        let sealed = seal_to_recipient(&kp.public(), pt, AAD, 0, 0).unwrap();
-        let opened = open_from_recipient(&kp, &sealed, AAD, 0, 0).unwrap();
-        assert_eq!(opened, pt);
+    fn context(sequence: u64) -> SealContext {
+        SealContext {
+            recipient_id: b"did:at9p:example/service/inference".to_vec(),
+            key_id: b"did:at9p:example#mesh-kem-7".to_vec(),
+            nonce_domain: [0x5a; 32],
+            epoch: 3,
+            sequence,
+        }
+    }
+
+    fn ledger() -> NonceLedger {
+        NonceLedger::new(32).unwrap()
+    }
+
+    fn material(enc: &CoseEncrypt0) -> HybridKemMaterial {
+        require_material(enc).unwrap()
+    }
+
+    fn replace_material(enc: &mut CoseEncrypt0, value: &HybridKemMaterial) {
+        let (_, header_value) = enc
+            .unprotected
+            .rest
+            .iter_mut()
+            .find(|(label, _)| label == &Label::Int(HDR_KEM_MATERIAL))
+            .unwrap();
+        *header_value = CborValue::Bytes(value.encode());
     }
 
     #[test]
-    fn recipient_ciphertext_is_cose_encrypt0_and_hides_plaintext() {
-        let kp = generate_recipient(SUITE).unwrap();
-        let pt = b"secret tokens";
-        let sealed = seal_to_recipient(&kp.public(), pt, AAD, 1, 7).unwrap();
-        assert!(
-            !sealed.windows(pt.len()).any(|w| w == pt),
-            "plaintext must not appear"
-        );
-        // Parses as a COSE_Encrypt0 with the expected alg + suite header.
-        let enc = CoseEncrypt0::from_slice(&sealed).unwrap();
-        require_chacha20poly1305(&enc).unwrap();
-        assert_eq!(read_suite(&enc).unwrap(), SUITE);
-    }
-
-    #[test]
-    fn tampered_ciphertext_rejected() {
-        let kp = generate_recipient(SUITE).unwrap();
-        let mut sealed = seal_to_recipient(&kp.public(), b"x", AAD, 0, 0).unwrap();
-        let n = sealed.len();
-        sealed[n - 1] ^= 0xff; // flip a tag/ciphertext byte
-        assert!(open_from_recipient(&kp, &sealed, AAD, 0, 0).is_err());
-    }
-
-    #[test]
-    fn wrong_recipient_rejected() {
-        let kp = generate_recipient(SUITE).unwrap();
-        let other = generate_recipient(SUITE).unwrap();
-        let sealed = seal_to_recipient(&kp.public(), b"x", AAD, 0, 0).unwrap();
-        assert!(open_from_recipient(&other, &sealed, AAD, 0, 0).is_err());
-    }
-
-    #[test]
-    fn wrong_epoch_seq_rejected() {
-        let kp = generate_recipient(SUITE).unwrap();
-        let sealed = seal_to_recipient(&kp.public(), b"x", AAD, 3, 9).unwrap();
-        assert!(
-            open_from_recipient(&kp, &sealed, AAD, 3, 10).is_err(),
-            "wrong seq"
-        );
-        assert!(
-            open_from_recipient(&kp, &sealed, AAD, 4, 9).is_err(),
-            "wrong epoch"
-        );
-        assert!(
-            open_from_recipient(&kp, &sealed, b"other-aad", 3, 9).is_err(),
-            "wrong aad"
-        );
-    }
-
-    #[test]
-    fn malformed_cose_rejected() {
-        let kp = generate_recipient(SUITE).unwrap();
-        assert!(open_from_recipient(&kp, b"not cbor", AAD, 0, 0).is_err());
-    }
-
-    #[test]
-    fn key_based_roundtrip_and_nonce_separation() {
-        let key = [7u8; 32];
-        let pt0 = b"block zero";
-        let pt1 = b"block one!";
-        let c0 = seal_with_key(&key, SUITE, pt0, AAD, 0, 0).unwrap();
-        let c1 = seal_with_key(&key, SUITE, pt1, AAD, 0, 1).unwrap();
-        assert_eq!(open_with_key(&key, SUITE, &c0, AAD, 0, 0).unwrap(), pt0);
-        assert_eq!(open_with_key(&key, SUITE, &c1, AAD, 0, 1).unwrap(), pt1);
-        // A block sealed at seq=0 must not open at seq=1 (nonce/AAD bound).
-        assert!(open_with_key(&key, SUITE, &c0, AAD, 0, 1).is_err());
-        // Equal plaintext at different seq yields different ciphertext (distinct nonce).
-        let a = seal_with_key(&key, SUITE, pt0, AAD, 0, 0).unwrap();
-        let b = seal_with_key(&key, SUITE, pt0, AAD, 0, 1).unwrap();
-        assert_ne!(a, b);
-    }
-
-    #[test]
-    fn derive_aead_key_deterministic_and_separated() {
-        let secret = [9u8; 32];
-        assert_eq!(*derive_aead_key(&secret), *derive_aead_key(&secret));
-        assert_ne!(
-            *derive_aead_key(&secret),
-            secret,
-            "key must differ from raw secret (HKDF)"
-        );
-    }
-
-    #[test]
-    fn pinned_kat_key_based() {
-        // Pin the key-based seal output for fixed inputs so the construction
-        // (key derivation, nonce, AAD binding, COSE layout) cannot silently drift.
-        let key = [0x42u8; 32];
-        let ct = seal_with_key(&key, SUITE, b"kat-plaintext", b"kat-aad", 0, 0).unwrap();
-        let opened = open_with_key(&key, SUITE, &ct, b"kat-aad", 0, 0).unwrap();
-        assert_eq!(opened, b"kat-plaintext");
-        // Deterministic: same inputs → same bytes (ChaCha20Poly1305 + fixed nonce + fixed key).
-        let ct2 = seal_with_key(&key, SUITE, b"kat-plaintext", b"kat-aad", 0, 0).unwrap();
+    fn recipient_roundtrip_and_replay_rejected() {
+        let recipient = generate_recipient(SUITE).unwrap();
+        let ctx = context(9);
+        let mut outbound = ledger();
+        let sealed = seal(&recipient.public(), &ctx, b"secret", AAD, &mut outbound).unwrap();
+        let mut inbound = ledger();
         assert_eq!(
-            ct, ct2,
-            "key-based seal must be deterministic for fixed inputs"
+            open(&recipient, &ctx, &sealed, AAD, &mut inbound).unwrap(),
+            b"secret"
+        );
+        assert!(open(&recipient, &ctx, &sealed, AAD, &mut inbound).is_err());
+    }
+
+    #[test]
+    fn outbound_nonce_reuse_is_burned() {
+        let recipient = generate_recipient(SUITE).unwrap();
+        let ctx = context(4);
+        let mut outbound = ledger();
+        seal(&recipient.public(), &ctx, b"first", AAD, &mut outbound).unwrap();
+        assert!(seal(&recipient.public(), &ctx, b"second", AAD, &mut outbound).is_err());
+    }
+
+    #[test]
+    fn wrong_context_fields_and_aad_rejected() {
+        let recipient = generate_recipient(SUITE).unwrap();
+        let ctx = context(7);
+        let sealed = seal(&recipient.public(), &ctx, b"secret", AAD, &mut ledger()).unwrap();
+        let mutations = [
+            {
+                let mut value = ctx.clone();
+                value.recipient_id.push(b'x');
+                value
+            },
+            {
+                let mut value = ctx.clone();
+                value.key_id.push(b'x');
+                value
+            },
+            {
+                let mut value = ctx.clone();
+                value.nonce_domain[0] ^= 1;
+                value
+            },
+            {
+                let mut value = ctx.clone();
+                value.epoch += 1;
+                value
+            },
+            {
+                let mut value = ctx.clone();
+                value.sequence += 1;
+                value
+            },
+        ];
+        for mutation in mutations {
+            assert!(open(&recipient, &mutation, &sealed, AAD, &mut ledger()).is_err());
+        }
+        assert!(open(
+            &recipient,
+            &ctx,
+            &sealed,
+            b"wrong transcript",
+            &mut ledger()
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn wrong_recipient_and_cartesian_component_keys_rejected() {
+        let first = generate_recipient(SUITE).unwrap();
+        let second = generate_recipient(SUITE).unwrap();
+        let ctx = context(1);
+        let sealed = seal(&first.public(), &ctx, b"secret", AAD, &mut ledger()).unwrap();
+        assert!(open(&second, &ctx, &sealed, AAD, &mut ledger()).is_err());
+
+        let x_seed = [0x11; 32];
+        let pq_seed_a = [0x22; 64];
+        let pq_seed_b = [0x33; 64];
+        let intended = recipient_from_seeds(SUITE, &[&x_seed, &pq_seed_a]).unwrap();
+        let cartesian = recipient_from_seeds(SUITE, &[&x_seed, &pq_seed_b]).unwrap();
+        let sealed = seal(
+            &intended.public(),
+            &context(2),
+            b"secret",
+            AAD,
+            &mut ledger(),
+        )
+        .unwrap();
+        assert!(open(&cartesian, &context(2), &sealed, AAD, &mut ledger()).is_err());
+    }
+
+    #[test]
+    fn missing_reordered_and_cross_encapsulation_pq_shares_rejected() {
+        let recipient = generate_recipient(SUITE).unwrap();
+        let ctx_a = context(10);
+        let ctx_b = context(11);
+        let sealed_a = seal(&recipient.public(), &ctx_a, b"a", AAD, &mut ledger()).unwrap();
+        let sealed_b = seal(&recipient.public(), &ctx_b, b"b", AAD, &mut ledger()).unwrap();
+        let enc_a = CoseEncrypt0::from_slice(&sealed_a).unwrap();
+        let enc_b = CoseEncrypt0::from_slice(&sealed_b).unwrap();
+
+        let mut missing = material(&enc_a);
+        missing.shares.pop();
+        let mut mutated = enc_a.clone();
+        replace_material(&mut mutated, &missing);
+        mutated.protected.original_data = None;
+        assert!(open(
+            &recipient,
+            &ctx_a,
+            &mutated.to_vec().unwrap(),
+            AAD,
+            &mut ledger()
+        )
+        .is_err());
+
+        let original = material(&enc_a);
+        let reordered = HybridKemMaterial {
+            suite_id: SUITE,
+            shares: vec![original.shares[1].clone(), original.shares[0].clone()],
+        };
+        let mut mutated = enc_a.clone();
+        replace_material(&mut mutated, &reordered);
+        mutated.protected.original_data = None;
+        assert!(open(
+            &recipient,
+            &ctx_a,
+            &mutated.to_vec().unwrap(),
+            AAD,
+            &mut ledger()
+        )
+        .is_err());
+
+        let mut crossed = original;
+        let other = material(&enc_b);
+        assert_eq!(crossed.shares[1].kem_id, KemId::MlKem768);
+        crossed.shares[1] = KemShare {
+            kem_id: KemId::MlKem768,
+            bytes: other.shares[1].bytes.clone(),
+        };
+        let mut mutated = enc_a;
+        replace_material(&mut mutated, &crossed);
+        mutated.protected.original_data = None;
+        assert!(open(
+            &recipient,
+            &ctx_a,
+            &mutated.to_vec().unwrap(),
+            AAD,
+            &mut ledger()
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn noncanonical_and_duplicate_headers_rejected() {
+        let recipient = generate_recipient(SUITE).unwrap();
+        let ctx = context(12);
+        let sealed = seal(&recipient.public(), &ctx, b"secret", AAD, &mut ledger()).unwrap();
+        assert_eq!(sealed[0], 0x83);
+        let mut noncanonical = vec![0x98, 0x03];
+        noncanonical.extend_from_slice(&sealed[1..]);
+        assert!(open(&recipient, &ctx, &noncanonical, AAD, &mut ledger()).is_err());
+
+        let mut top: CborValue = ciborium::de::from_reader(sealed.as_slice()).unwrap();
+        let array = match &mut top {
+            CborValue::Array(value) => value,
+            _ => panic!("COSE_Encrypt0 must be an array"),
+        };
+        let protected = match &mut array[0] {
+            CborValue::Bytes(value) => value,
+            _ => panic!("protected header must be bytes"),
+        };
+        assert!((0xa0..=0xb7).contains(&protected[0]));
+        protected[0] += 1;
+        let duplicate = CborValue::Map(vec![(
+            CborValue::Integer(HDR_SUITE_ID.into()),
+            CborValue::Integer(SUITE.as_u16().into()),
+        )]);
+        let mut encoded_duplicate = Vec::new();
+        ciborium::ser::into_writer(&duplicate, &mut encoded_duplicate).unwrap();
+        protected.extend_from_slice(&encoded_duplicate[1..]);
+        let mut duplicate_wire = Vec::new();
+        ciborium::ser::into_writer(&top, &mut duplicate_wire).unwrap();
+        assert!(open(&recipient, &ctx, &duplicate_wire, AAD, &mut ledger()).is_err());
+    }
+
+    #[test]
+    fn truncation_unknown_headers_and_tamper_rejected() {
+        let recipient = generate_recipient(SUITE).unwrap();
+        let ctx = context(13);
+        let sealed = seal(&recipient.public(), &ctx, b"secret", AAD, &mut ledger()).unwrap();
+        for cut in [0, 1, sealed.len() / 2, sealed.len() - 1] {
+            assert!(open(&recipient, &ctx, &sealed[..cut], AAD, &mut ledger()).is_err());
+        }
+        let mut tampered = sealed.clone();
+        let last = tampered.len() - 1;
+        tampered[last] ^= 0x80;
+        assert!(open(&recipient, &ctx, &tampered, AAD, &mut ledger()).is_err());
+
+        let mut unknown = CoseEncrypt0::from_slice(&sealed).unwrap();
+        unknown
+            .protected
+            .header
+            .rest
+            .push((Label::Int(-65560), CborValue::Integer(1.into())));
+        unknown.protected.original_data = None;
+        assert!(open(
+            &recipient,
+            &ctx,
+            &unknown.to_vec().unwrap(),
+            AAD,
+            &mut ledger()
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn wrong_suite_and_algorithm_headers_rejected() {
+        let recipient = generate_recipient(SUITE).unwrap();
+        let ctx = context(14);
+        let sealed = seal(&recipient.public(), &ctx, b"secret", AAD, &mut ledger()).unwrap();
+
+        let mut wrong_suite = CoseEncrypt0::from_slice(&sealed).unwrap();
+        let (_, suite_value) = wrong_suite
+            .protected
+            .header
+            .rest
+            .iter_mut()
+            .find(|(label, _)| label == &Label::Int(HDR_SUITE_ID))
+            .unwrap();
+        *suite_value = CborValue::Integer(2.into());
+        wrong_suite.protected.original_data = None;
+        assert!(open(
+            &recipient,
+            &ctx,
+            &wrong_suite.to_vec().unwrap(),
+            AAD,
+            &mut ledger()
+        )
+        .is_err());
+
+        let mut wrong_algorithm = CoseEncrypt0::from_slice(&sealed).unwrap();
+        wrong_algorithm.protected.header.alg =
+            Some(coset::Algorithm::Assigned(iana::Algorithm::A256GCM));
+        wrong_algorithm.protected.original_data = None;
+        assert!(open(
+            &recipient,
+            &ctx,
+            &wrong_algorithm.to_vec().unwrap(),
+            AAD,
+            &mut ledger()
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn bounded_inputs_and_ledger_exhaustion_fail_closed() {
+        let recipient = generate_recipient(SUITE).unwrap();
+        let mut one = NonceLedger::new(1).unwrap();
+        seal(&recipient.public(), &context(0), b"a", AAD, &mut one).unwrap();
+        assert!(seal(&recipient.public(), &context(1), b"b", AAD, &mut one).is_err());
+        assert!(NonceLedger::new(0).is_err());
+        assert!(seal(
+            &recipient.public(),
+            &context(2),
+            b"x",
+            &vec![0; MAX_EXTERNAL_AAD_BYTES + 1],
+            &mut ledger()
+        )
+        .is_err());
+        assert!(seal(
+            &recipient.public(),
+            &context(3),
+            &vec![0; MAX_PLAINTEXT_BYTES + 1],
+            AAD,
+            &mut ledger()
+        )
+        .is_err());
+        assert!(open(
+            &recipient,
+            &context(4),
+            &vec![0; MAX_COSE_BYTES + 1],
+            AAD,
+            &mut ledger()
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn prederived_roundtrip_context_key_and_epoch_retirement() {
+        let key = [0x42; 32];
+        let ctx = context(21);
+        let mut outbound = ledger();
+        let sealed = seal_prederived(&key, SUITE, &ctx, b"block", AAD, &mut outbound).unwrap();
+        let mut inbound = ledger();
+        assert_eq!(
+            open_prederived(&key, SUITE, &ctx, &sealed, AAD, &mut inbound).unwrap(),
+            b"block"
+        );
+        inbound.retire_epoch(
+            SUITE,
+            &ctx.recipient_id,
+            &ctx.key_id,
+            &ctx.nonce_domain,
+            ctx.epoch,
+        );
+        assert!(inbound.is_empty());
+    }
+
+    #[test]
+    fn rfc8439_chacha20poly1305_vector() {
+        // RFC 8439 section 2.8.2.  This proves the registered content algorithm;
+        // it is not represented as a Hyprstream/COSE interoperability vector.
+        let key = hex::decode("808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f")
+            .unwrap();
+        let nonce = hex::decode("070000004041424344454647").unwrap();
+        let aad = hex::decode("50515253c0c1c2c3c4c5c6c7").unwrap();
+        let plaintext = hex::decode(concat!(
+            "4c616469657320616e642047656e746c656d656e206f662074686520636c61737320",
+            "6f66202739393a204966204920636f756c64206f6666657220796f75206f6e6c7920",
+            "6f6e652074697020666f7220746865206675747572652c2073756e73637265656e20",
+            "776f756c642062652069742e"
+        ))
+        .unwrap();
+        let expected = hex::decode(concat!(
+            "d31a8d34648e60db7b86afbc53ef7ec2a4aded51296e08fea9e2b5a736ee62d6",
+            "3dbea45e8ca9671282fafb69da92728b1a71de0a9e060b2905d6a5b67ecd3b36",
+            "92ddbd7f2d778b8c9803aee328091b58fab324e4fad675945585808b4831d7bc",
+            "3ff4def08e4b7a9de576d26586cec64b61161ae10b594f09e26a7e902ecbd060",
+            "0691"
+        ))
+        .unwrap();
+        let mut key_array = [0; 32];
+        key_array.copy_from_slice(&key);
+        let mut nonce_array = [0; 12];
+        nonce_array.copy_from_slice(&nonce);
+        assert_eq!(
+            aead_seal(&key_array, &nonce_array, &plaintext, &aad).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn compatibility_wrappers_remain_canonical() {
+        let recipient = generate_recipient(SUITE).unwrap();
+        let sealed = seal_to_recipient(&recipient.public(), b"legacy", AAD, 0, 0).unwrap();
+        assert_eq!(
+            open_from_recipient(&recipient, &sealed, AAD, 0, 0).unwrap(),
+            b"legacy"
+        );
+        let key = [7; 32];
+        let sealed = seal_with_key(&key, SUITE, b"legacy", AAD, 0, 1).unwrap();
+        assert_eq!(
+            open_with_key(&key, SUITE, &sealed, AAD, 0, 1).unwrap(),
+            b"legacy"
         );
     }
 }

--- a/crates/hyprstream-rpc/src/crypto/cose_encrypt.rs
+++ b/crates/hyprstream-rpc/src/crypto/cose_encrypt.rs
@@ -856,6 +856,10 @@ fn compatibility_context(
     epoch: u64,
     sequence: u64,
 ) -> Result<SealContext> {
+    if external_aad.len() > MAX_EXTERNAL_AAD_BYTES {
+        bail!("external AAD exceeds {MAX_EXTERNAL_AAD_BYTES}-byte limit");
+    }
+    recipient.validate()?;
     let epoch = u32::try_from(epoch).context("epoch exceeds u32 nonce domain")?;
     let encoded = recipient.encode();
     let recipient_id = digest_parts(COMPAT_RECIPIENT_LABEL, &[&encoded]).to_vec();
@@ -891,6 +895,7 @@ pub fn seal_to_recipient(
     sequence: u64,
 ) -> Result<Vec<u8>> {
     let context = compatibility_context(recipient, external_aad, epoch, sequence)?;
+    validate_inputs(&context, plaintext.len(), external_aad)?;
     let (material, secret) = hybrid_kem::encapsulate_to(recipient)?;
     let base_key = derive_aead_key(&secret);
     seal_core(
@@ -914,6 +919,7 @@ pub fn open_from_recipient(
     sequence: u64,
 ) -> Result<Vec<u8>> {
     let context = compatibility_context(&recipient.public(), external_aad, epoch, sequence)?;
+    validate_inputs(&context, 0, external_aad)?;
     let enc = parse_canonical(cose_bytes)?;
     require_exact_protected(&enc, recipient.suite_id, &context)?;
     let material = require_material(&enc)?;
@@ -1343,6 +1349,23 @@ mod tests {
     }
 
     #[test]
+    fn deterministic_map_order_is_encoded_length_then_bytewise() {
+        let finish = |mut prefix: Vec<u8>| {
+            prefix.push(0x50);
+            prefix.extend_from_slice(&[0u8; 16]);
+            prefix
+        };
+        // RFC 8949 core deterministic order puts the one-byte encoded key -1
+        // (0x20) before the two-byte encoded key 100 (0x18 0x64), even though a
+        // raw lexicographic comparison alone would reverse them.
+        let canonical = finish(vec![0x83, 0x41, 0xa0, 0xa2, 0x20, 0x00, 0x18, 0x64, 0x00]);
+        assert!(preflight_cose_encrypt0(&canonical).is_ok());
+
+        let reversed = finish(vec![0x83, 0x41, 0xa0, 0xa2, 0x18, 0x64, 0x00, 0x20, 0x00]);
+        assert!(preflight_cose_encrypt0(&reversed).is_err());
+    }
+
+    #[test]
     fn focused_cose_gate_covers_every_hybrid_component_secret() {
         assert!(hybrid_kem::combiner_is_sensitive_to_every_component_for_cose());
     }
@@ -1511,5 +1534,17 @@ mod tests {
             open_from_recipient(&recipient, &sealed, AAD, 0, 0).unwrap(),
             b"legacy"
         );
+    }
+
+    #[test]
+    fn compatibility_wrappers_validate_before_encoding_or_crypto() {
+        let recipient = generate_recipient(SUITE).unwrap();
+        let oversized_aad = vec![0u8; MAX_EXTERNAL_AAD_BYTES + 1];
+        assert!(seal_to_recipient(&recipient.public(), b"legacy", &oversized_aad, 0, 0).is_err());
+        assert!(open_from_recipient(&recipient, &[], &oversized_aad, 0, 0).is_err());
+
+        let mut malformed = recipient.public();
+        malformed.eks.push(vec![0u8; 32]);
+        assert!(seal_to_recipient(&malformed, b"legacy", AAD, 0, 0).is_err());
     }
 }

--- a/crates/hyprstream-rpc/src/crypto/cose_encrypt.rs
+++ b/crates/hyprstream-rpc/src/crypto/cose_encrypt.rs
@@ -12,10 +12,11 @@
 //! labels below define a project-local profile and make no draft-interoperability
 //! claim.  PQUIP / RFC 9794 supplies transition terminology, not wire semantics.
 //!
-//! New consumers should use [`seal`], [`open`], [`seal_prederived`], and
-//! [`open_prederived`] with an owning [`NonceLedger`].  The fresh-encapsulation
-//! envelope wrappers at the bottom remain only for the already-landed signed
-//! envelope path, whose replay lifecycle is owned by `SignedEnvelope`.
+//! New consumers should use [`seal`] and [`seal_prederived`] with an owning
+//! [`OutboundNonceLedger`], and [`open`] and [`open_prederived`] with an owning
+//! [`InboundReplayLedger`].  The fresh-encapsulation envelope wrappers at the
+//! bottom remain only for the already-landed signed envelope path, whose replay
+//! lifecycle is owned by `SignedEnvelope`.
 
 use std::collections::HashSet;
 
@@ -130,24 +131,26 @@ impl NonceUse {
     }
 }
 
-/// Bounded owning state for outbound nonce-use and inbound replay rejection.
+/// Irreversible bounded state for outbound nonce use.
 ///
-/// A ledger is directional: do not share the same instance between a sender and
-/// receiver.  `seal*` burns a coordinate before cryptographic work, so even an
-/// error cannot lead to an uncertain nonce being reused.  `open*` records a
-/// coordinate only after successful authentication, preventing invalid packets
-/// from consuming the replay budget.
+/// One ledger owns the complete lifetime of the base key supplied to `seal*`.
+/// It may be dropped only after that base key has been irreversibly destroyed or
+/// rotated out; constructing a replacement ledger while retaining the key would
+/// discard its nonce-safety history.  Burns are never evicted or retired, and
+/// capacity exhaustion therefore requires base-key rotation.  A coordinate is
+/// burned before cryptographic work, so even an error cannot make an uncertain
+/// nonce reusable.
 #[derive(Debug)]
-pub struct NonceLedger {
+pub struct OutboundNonceLedger {
     capacity: usize,
     seen: HashSet<NonceUse>,
 }
 
-impl NonceLedger {
-    /// Construct a ledger with a finite non-zero capacity.
+impl OutboundNonceLedger {
+    /// Construct outbound state with a finite non-zero lifetime capacity.
     pub fn new(capacity: usize) -> Result<Self> {
         if capacity == 0 || capacity > MAX_LEDGER_ENTRIES {
-            bail!("nonce ledger capacity must be in 1..={MAX_LEDGER_ENTRIES}");
+            bail!("outbound nonce ledger capacity must be in 1..={MAX_LEDGER_ENTRIES}");
         }
         Ok(Self {
             capacity,
@@ -155,20 +158,70 @@ impl NonceLedger {
         })
     }
 
-    /// Number of retained nonce/replay coordinates.
+    /// Number of irreversibly burned nonce coordinates.
     pub fn len(&self) -> usize {
         self.seen.len()
     }
 
-    /// Whether no coordinates are retained.
+    /// Whether no coordinates have been burned.
     pub fn is_empty(&self) -> bool {
         self.seen.is_empty()
     }
 
-    /// Retire one epoch after the owning lifecycle has made it unacceptable.
+    fn ensure_unseen(&self, usage: &NonceUse) -> Result<()> {
+        if self.seen.contains(usage) {
+            bail!("nonce coordinate already used or ciphertext replayed");
+        }
+        Ok(())
+    }
+
+    fn record(&mut self, usage: NonceUse) -> Result<()> {
+        self.ensure_unseen(&usage)?;
+        if self.seen.len() >= self.capacity {
+            bail!("outbound nonce ledger capacity exhausted; destroy and rotate the base key");
+        }
+        self.seen.insert(usage);
+        Ok(())
+    }
+}
+
+/// Bounded state for authenticated inbound replay rejection.
+///
+/// Unlike outbound burns, replay entries may be retired after the public
+/// lifecycle owner has made the corresponding epoch unacceptable before
+/// calling `open*`.  Retirement does not and cannot affect outbound state.
+#[derive(Debug)]
+pub struct InboundReplayLedger {
+    capacity: usize,
+    seen: HashSet<NonceUse>,
+}
+
+impl InboundReplayLedger {
+    /// Construct inbound replay state with a finite non-zero capacity.
+    pub fn new(capacity: usize) -> Result<Self> {
+        if capacity == 0 || capacity > MAX_LEDGER_ENTRIES {
+            bail!("inbound replay ledger capacity must be in 1..={MAX_LEDGER_ENTRIES}");
+        }
+        Ok(Self {
+            capacity,
+            seen: HashSet::with_capacity(capacity.min(4096)),
+        })
+    }
+
+    /// Number of retained authenticated replay coordinates.
+    pub fn len(&self) -> usize {
+        self.seen.len()
+    }
+
+    /// Whether no replay coordinates are retained.
+    pub fn is_empty(&self) -> bool {
+        self.seen.is_empty()
+    }
+
+    /// Retire an inbound epoch after the owner has made it unacceptable.
     ///
-    /// Removing replay state is safe only after the lifecycle rejects that epoch
-    /// before calling `open`; this method does not itself implement grace policy.
+    /// This is replay-retention management only; epoch install, accept, grace,
+    /// and retirement policy remain with #554/#555.
     pub fn retire_epoch(
         &mut self,
         suite: SuiteId,
@@ -188,7 +241,7 @@ impl NonceLedger {
 
     fn ensure_unseen(&self, usage: &NonceUse) -> Result<()> {
         if self.seen.contains(usage) {
-            bail!("nonce coordinate already used or ciphertext replayed");
+            bail!("ciphertext replayed");
         }
         Ok(())
     }
@@ -196,7 +249,7 @@ impl NonceLedger {
     fn record(&mut self, usage: NonceUse) -> Result<()> {
         self.ensure_unseen(&usage)?;
         if self.seen.len() >= self.capacity {
-            bail!("nonce ledger capacity exhausted; rotate/retire at lifecycle boundary");
+            bail!("inbound replay ledger capacity exhausted; retire an unacceptable epoch");
         }
         self.seen.insert(usage);
         Ok(())
@@ -462,7 +515,7 @@ fn require_no_unprotected(enc: &CoseEncrypt0) -> Result<()> {
 /// Allocation-free structural validation of the small CBOR subset used by the
 /// COSE profile.  In addition to bounding work, this independently enforces RFC
 /// 8949 core deterministic argument encodings and map-key order (encoded-key
-/// length, then bytewise lexical order).  It intentionally performs no COSE
+/// bytes compared lexicographically).  It intentionally performs no COSE
 /// semantics; `coset` remains the sole semantic decoder below.
 struct CborPreflight<'a> {
     input: &'a [u8],
@@ -633,7 +686,7 @@ impl<'a> CborPreflight<'a> {
                     if let Some((previous_start, previous_end)) = previous_key {
                         let previous = &self.input[previous_start..previous_end];
                         let current = &self.input[key_start..key_end];
-                        if (previous.len(), previous) >= (current.len(), current) {
+                        if previous >= current {
                             bail!("CBOR map keys are duplicate or not in deterministic order");
                         }
                     }
@@ -774,7 +827,7 @@ pub fn seal(
     context: &SealContext,
     plaintext: &[u8],
     external_aad: &[u8],
-    nonce_ledger: &mut NonceLedger,
+    nonce_ledger: &mut OutboundNonceLedger,
 ) -> Result<Vec<u8>> {
     validate_inputs(context, plaintext.len(), external_aad)?;
     nonce_ledger.record(NonceUse::new(recipient.suite_id, context))?;
@@ -796,7 +849,7 @@ pub fn open(
     expected: &SealContext,
     cose_bytes: &[u8],
     external_aad: &[u8],
-    replay_ledger: &mut NonceLedger,
+    replay_ledger: &mut InboundReplayLedger,
 ) -> Result<Vec<u8>> {
     validate_inputs(expected, 0, external_aad)?;
     let usage = NonceUse::new(recipient.suite_id, expected);
@@ -824,7 +877,7 @@ pub fn seal_prederived(
     context: &SealContext,
     plaintext: &[u8],
     external_aad: &[u8],
-    nonce_ledger: &mut NonceLedger,
+    nonce_ledger: &mut OutboundNonceLedger,
 ) -> Result<Vec<u8>> {
     validate_inputs(context, plaintext.len(), external_aad)?;
     nonce_ledger.record(NonceUse::new(suite, context))?;
@@ -838,7 +891,7 @@ pub fn open_prederived(
     expected: &SealContext,
     cose_bytes: &[u8],
     external_aad: &[u8],
-    replay_ledger: &mut NonceLedger,
+    replay_ledger: &mut InboundReplayLedger,
 ) -> Result<Vec<u8>> {
     validate_inputs(expected, 0, external_aad)?;
     let usage = NonceUse::new(expected_suite, expected);
@@ -886,7 +939,7 @@ fn digest_parts(label: &[u8], parts: &[&[u8]]) -> [u8; 32] {
 
 /// Compatibility wrapper for the existing encrypted-envelope lifecycle.
 ///
-/// New code must use [`seal`] with an owning [`NonceLedger`].
+/// New code must use [`seal`] with an owning [`OutboundNonceLedger`].
 pub fn seal_to_recipient(
     recipient: &RecipientPublic,
     plaintext: &[u8],
@@ -910,7 +963,7 @@ pub fn seal_to_recipient(
 
 /// Compatibility wrapper for the existing encrypted-envelope lifecycle.
 ///
-/// New code must use [`open`] with an owning [`NonceLedger`].
+/// New code must use [`open`] with an owning [`InboundReplayLedger`].
 pub fn open_from_recipient(
     recipient: &RecipientKeypair,
     cose_bytes: &[u8],
@@ -947,8 +1000,12 @@ mod tests {
         }
     }
 
-    fn ledger() -> NonceLedger {
-        NonceLedger::new(32).unwrap()
+    fn outbound_ledger() -> OutboundNonceLedger {
+        OutboundNonceLedger::new(32).unwrap()
+    }
+
+    fn inbound_ledger() -> InboundReplayLedger {
+        InboundReplayLedger::new(32).unwrap()
     }
 
     fn material(enc: &CoseEncrypt0) -> HybridKemMaterial {
@@ -1007,9 +1064,9 @@ mod tests {
     fn recipient_roundtrip_and_replay_rejected() {
         let recipient = generate_recipient(SUITE).unwrap();
         let ctx = context(9);
-        let mut outbound = ledger();
+        let mut outbound = outbound_ledger();
         let sealed = seal(&recipient.public(), &ctx, b"secret", AAD, &mut outbound).unwrap();
-        let mut inbound = ledger();
+        let mut inbound = inbound_ledger();
         assert_eq!(
             open(&recipient, &ctx, &sealed, AAD, &mut inbound).unwrap(),
             b"secret"
@@ -1021,7 +1078,7 @@ mod tests {
     fn outbound_nonce_reuse_is_burned() {
         let recipient = generate_recipient(SUITE).unwrap();
         let ctx = context(4);
-        let mut outbound = ledger();
+        let mut outbound = outbound_ledger();
         seal(&recipient.public(), &ctx, b"first", AAD, &mut outbound).unwrap();
         assert!(seal(&recipient.public(), &ctx, b"second", AAD, &mut outbound).is_err());
     }
@@ -1030,7 +1087,14 @@ mod tests {
     fn wrong_context_fields_and_aad_rejected() {
         let recipient = generate_recipient(SUITE).unwrap();
         let ctx = context(7);
-        let sealed = seal(&recipient.public(), &ctx, b"secret", AAD, &mut ledger()).unwrap();
+        let sealed = seal(
+            &recipient.public(),
+            &ctx,
+            b"secret",
+            AAD,
+            &mut outbound_ledger(),
+        )
+        .unwrap();
         let mutations = [
             {
                 let mut value = ctx.clone();
@@ -1059,14 +1123,14 @@ mod tests {
             },
         ];
         for mutation in mutations {
-            assert!(open(&recipient, &mutation, &sealed, AAD, &mut ledger()).is_err());
+            assert!(open(&recipient, &mutation, &sealed, AAD, &mut inbound_ledger()).is_err());
         }
         assert!(open(
             &recipient,
             &ctx,
             &sealed,
             b"wrong transcript",
-            &mut ledger()
+            &mut inbound_ledger()
         )
         .is_err());
     }
@@ -1076,8 +1140,15 @@ mod tests {
         let first = generate_recipient(SUITE).unwrap();
         let second = generate_recipient(SUITE).unwrap();
         let ctx = context(1);
-        let sealed = seal(&first.public(), &ctx, b"secret", AAD, &mut ledger()).unwrap();
-        assert!(open(&second, &ctx, &sealed, AAD, &mut ledger()).is_err());
+        let sealed = seal(
+            &first.public(),
+            &ctx,
+            b"secret",
+            AAD,
+            &mut outbound_ledger(),
+        )
+        .unwrap();
+        assert!(open(&second, &ctx, &sealed, AAD, &mut inbound_ledger()).is_err());
 
         let x_seed = [0x11; 32];
         let pq_seed_a = [0x22; 64];
@@ -1089,10 +1160,10 @@ mod tests {
             &context(2),
             b"secret",
             AAD,
-            &mut ledger(),
+            &mut outbound_ledger(),
         )
         .unwrap();
-        assert!(open(&cartesian, &context(2), &sealed, AAD, &mut ledger()).is_err());
+        assert!(open(&cartesian, &context(2), &sealed, AAD, &mut inbound_ledger()).is_err());
     }
 
     #[test]
@@ -1100,8 +1171,22 @@ mod tests {
         let recipient = generate_recipient(SUITE).unwrap();
         let ctx_a = context(10);
         let ctx_b = context(11);
-        let sealed_a = seal(&recipient.public(), &ctx_a, b"a", AAD, &mut ledger()).unwrap();
-        let sealed_b = seal(&recipient.public(), &ctx_b, b"b", AAD, &mut ledger()).unwrap();
+        let sealed_a = seal(
+            &recipient.public(),
+            &ctx_a,
+            b"a",
+            AAD,
+            &mut outbound_ledger(),
+        )
+        .unwrap();
+        let sealed_b = seal(
+            &recipient.public(),
+            &ctx_b,
+            b"b",
+            AAD,
+            &mut outbound_ledger(),
+        )
+        .unwrap();
         let enc_a = CoseEncrypt0::from_slice(&sealed_a).unwrap();
         let enc_b = CoseEncrypt0::from_slice(&sealed_b).unwrap();
 
@@ -1115,7 +1200,7 @@ mod tests {
             &ctx_a,
             &mutated.to_vec().unwrap(),
             AAD,
-            &mut ledger()
+            &mut inbound_ledger()
         )
         .is_err());
 
@@ -1132,7 +1217,7 @@ mod tests {
             &ctx_a,
             &mutated.to_vec().unwrap(),
             AAD,
-            &mut ledger()
+            &mut inbound_ledger()
         )
         .is_err());
 
@@ -1151,7 +1236,7 @@ mod tests {
             &ctx_a,
             &mutated.to_vec().unwrap(),
             AAD,
-            &mut ledger()
+            &mut inbound_ledger()
         )
         .is_err());
     }
@@ -1160,11 +1245,18 @@ mod tests {
     fn noncanonical_and_duplicate_headers_rejected() {
         let recipient = generate_recipient(SUITE).unwrap();
         let ctx = context(12);
-        let sealed = seal(&recipient.public(), &ctx, b"secret", AAD, &mut ledger()).unwrap();
+        let sealed = seal(
+            &recipient.public(),
+            &ctx,
+            b"secret",
+            AAD,
+            &mut outbound_ledger(),
+        )
+        .unwrap();
         assert_eq!(sealed[0], 0x83);
         let mut noncanonical = vec![0x98, 0x03];
         noncanonical.extend_from_slice(&sealed[1..]);
-        assert!(open(&recipient, &ctx, &noncanonical, AAD, &mut ledger()).is_err());
+        assert!(open(&recipient, &ctx, &noncanonical, AAD, &mut inbound_ledger()).is_err());
 
         let mut top: CborValue = ciborium::de::from_reader(sealed.as_slice()).unwrap();
         let array = match &mut top {
@@ -1186,7 +1278,14 @@ mod tests {
         protected.extend_from_slice(&encoded_duplicate[1..]);
         let mut duplicate_wire = Vec::new();
         ciborium::ser::into_writer(&top, &mut duplicate_wire).unwrap();
-        assert!(open(&recipient, &ctx, &duplicate_wire, AAD, &mut ledger()).is_err());
+        assert!(open(
+            &recipient,
+            &ctx,
+            &duplicate_wire,
+            AAD,
+            &mut inbound_ledger()
+        )
+        .is_err());
     }
 
     #[test]
@@ -1197,7 +1296,7 @@ mod tests {
             &context(121),
             b"secret",
             AAD,
-            &mut ledger(),
+            &mut outbound_ledger(),
         )
         .unwrap();
 
@@ -1241,7 +1340,7 @@ mod tests {
             &context(122),
             b"secret",
             AAD,
-            &mut ledger(),
+            &mut outbound_ledger(),
         )
         .unwrap();
 
@@ -1349,19 +1448,20 @@ mod tests {
     }
 
     #[test]
-    fn deterministic_map_order_is_encoded_length_then_bytewise() {
+    fn deterministic_map_order_is_core_bytewise_lexicographic() {
         let finish = |mut prefix: Vec<u8>| {
             prefix.push(0x50);
             prefix.extend_from_slice(&[0u8; 16]);
             prefix
         };
-        // RFC 8949 core deterministic order puts the one-byte encoded key -1
-        // (0x20) before the two-byte encoded key 100 (0x18 0x64), even though a
-        // raw lexicographic comparison alone would reverse them.
-        let canonical = finish(vec![0x83, 0x41, 0xa0, 0xa2, 0x20, 0x00, 0x18, 0x64, 0x00]);
+        // RFC 8949 section 4.2.1 compares the deterministic key encodings
+        // bytewise, so 100 (0x18 0x64) sorts before -1 (0x20).  The reverse is
+        // the optional length-first order from section 4.2.3, which this profile
+        // deliberately does not implement.
+        let canonical = finish(vec![0x83, 0x41, 0xa0, 0xa2, 0x18, 0x64, 0x00, 0x20, 0x00]);
         assert!(preflight_cose_encrypt0(&canonical).is_ok());
 
-        let reversed = finish(vec![0x83, 0x41, 0xa0, 0xa2, 0x18, 0x64, 0x00, 0x20, 0x00]);
+        let reversed = finish(vec![0x83, 0x41, 0xa0, 0xa2, 0x20, 0x00, 0x18, 0x64, 0x00]);
         assert!(preflight_cose_encrypt0(&reversed).is_err());
     }
 
@@ -1374,14 +1474,21 @@ mod tests {
     fn truncation_unknown_headers_and_tamper_rejected() {
         let recipient = generate_recipient(SUITE).unwrap();
         let ctx = context(13);
-        let sealed = seal(&recipient.public(), &ctx, b"secret", AAD, &mut ledger()).unwrap();
+        let sealed = seal(
+            &recipient.public(),
+            &ctx,
+            b"secret",
+            AAD,
+            &mut outbound_ledger(),
+        )
+        .unwrap();
         for cut in [0, 1, sealed.len() / 2, sealed.len() - 1] {
-            assert!(open(&recipient, &ctx, &sealed[..cut], AAD, &mut ledger()).is_err());
+            assert!(open(&recipient, &ctx, &sealed[..cut], AAD, &mut inbound_ledger()).is_err());
         }
         let mut tampered = sealed.clone();
         let last = tampered.len() - 1;
         tampered[last] ^= 0x80;
-        assert!(open(&recipient, &ctx, &tampered, AAD, &mut ledger()).is_err());
+        assert!(open(&recipient, &ctx, &tampered, AAD, &mut inbound_ledger()).is_err());
 
         let mut unknown = CoseEncrypt0::from_slice(&sealed).unwrap();
         unknown
@@ -1395,7 +1502,7 @@ mod tests {
             &ctx,
             &unknown.to_vec().unwrap(),
             AAD,
-            &mut ledger()
+            &mut inbound_ledger()
         )
         .is_err());
     }
@@ -1404,7 +1511,14 @@ mod tests {
     fn wrong_suite_and_algorithm_headers_rejected() {
         let recipient = generate_recipient(SUITE).unwrap();
         let ctx = context(14);
-        let sealed = seal(&recipient.public(), &ctx, b"secret", AAD, &mut ledger()).unwrap();
+        let sealed = seal(
+            &recipient.public(),
+            &ctx,
+            b"secret",
+            AAD,
+            &mut outbound_ledger(),
+        )
+        .unwrap();
 
         let mut wrong_suite = CoseEncrypt0::from_slice(&sealed).unwrap();
         let (_, suite_value) = wrong_suite
@@ -1421,7 +1535,7 @@ mod tests {
             &ctx,
             &wrong_suite.to_vec().unwrap(),
             AAD,
-            &mut ledger()
+            &mut inbound_ledger()
         )
         .is_err());
 
@@ -1434,7 +1548,7 @@ mod tests {
             &ctx,
             &wrong_algorithm.to_vec().unwrap(),
             AAD,
-            &mut ledger()
+            &mut inbound_ledger()
         )
         .is_err());
     }
@@ -1442,16 +1556,17 @@ mod tests {
     #[test]
     fn bounded_inputs_and_ledger_exhaustion_fail_closed() {
         let recipient = generate_recipient(SUITE).unwrap();
-        let mut one = NonceLedger::new(1).unwrap();
+        let mut one = OutboundNonceLedger::new(1).unwrap();
         seal(&recipient.public(), &context(0), b"a", AAD, &mut one).unwrap();
         assert!(seal(&recipient.public(), &context(1), b"b", AAD, &mut one).is_err());
-        assert!(NonceLedger::new(0).is_err());
+        assert!(OutboundNonceLedger::new(0).is_err());
+        assert!(InboundReplayLedger::new(0).is_err());
         assert!(seal(
             &recipient.public(),
             &context(2),
             b"x",
             &vec![0; MAX_EXTERNAL_AAD_BYTES + 1],
-            &mut ledger()
+            &mut outbound_ledger()
         )
         .is_err());
         assert!(seal(
@@ -1459,7 +1574,7 @@ mod tests {
             &context(3),
             &vec![0; MAX_PLAINTEXT_BYTES + 1],
             AAD,
-            &mut ledger()
+            &mut outbound_ledger()
         )
         .is_err());
         assert!(open(
@@ -1467,18 +1582,18 @@ mod tests {
             &context(4),
             &vec![0; MAX_COSE_BYTES + 1],
             AAD,
-            &mut ledger()
+            &mut inbound_ledger()
         )
         .is_err());
     }
 
     #[test]
-    fn prederived_roundtrip_context_key_and_epoch_retirement() {
+    fn prederived_outbound_burn_survives_inbound_epoch_retirement() {
         let key = [0x42; 32];
         let ctx = context(21);
-        let mut outbound = ledger();
+        let mut outbound = outbound_ledger();
         let sealed = seal_prederived(&key, SUITE, &ctx, b"block", AAD, &mut outbound).unwrap();
-        let mut inbound = ledger();
+        let mut inbound = inbound_ledger();
         assert_eq!(
             open_prederived(&key, SUITE, &ctx, &sealed, AAD, &mut inbound).unwrap(),
             b"block"
@@ -1491,6 +1606,7 @@ mod tests {
             ctx.epoch,
         );
         assert!(inbound.is_empty());
+        assert!(seal_prederived(&key, SUITE, &ctx, b"again", AAD, &mut outbound).is_err());
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/crypto/hybrid_kem.rs
+++ b/crates/hyprstream-rpc/src/crypto/hybrid_kem.rs
@@ -567,6 +567,32 @@ impl RecipientKeypair {
 }
 
 impl RecipientPublic {
+    /// Validate component count, order-by-position, and public-key lengths
+    /// before callers encode or perform KEM work on manually constructed public
+    /// material.
+    pub(crate) fn validate(&self) -> Result<()> {
+        let components = self.suite_id.components();
+        if self.eks.len() != components.len() {
+            bail!(
+                "recipient has {} encap keys, suite {} needs {}",
+                self.eks.len(),
+                self.suite_id.as_str(),
+                components.len()
+            );
+        }
+        for (index, (&kem, key)) in components.iter().zip(&self.eks).enumerate() {
+            let expected = kem.component().ek_len();
+            if key.len() != expected {
+                bail!(
+                    "recipient component {index} {:?} encap key length {} != expected {expected}",
+                    kem,
+                    key.len()
+                );
+            }
+        }
+        Ok(())
+    }
+
     /// Canonical length-prefixed encoding of the recipient's per-component
     /// encapsulation keys, mirroring [`HybridKemMaterial::encode`]:
     /// `be16(suite_id) ‖ be16(n) ‖ Σ_i (be16(kem_id) ‖ be32(len) ‖ ek_bytes)`.
@@ -704,16 +730,9 @@ pub fn recipient_from_seeds(suite: SuiteId, seeds: &[&[u8]]) -> Result<Recipient
 pub fn encapsulate_to(
     recipient: &RecipientPublic,
 ) -> Result<(HybridKemMaterial, Zeroizing<[u8; 32]>)> {
+    recipient.validate()?;
     let suite = recipient.suite_id;
     let comps = suite.components();
-    if recipient.eks.len() != comps.len() {
-        bail!(
-            "recipient has {} encap keys, suite {} needs {}",
-            recipient.eks.len(),
-            suite.as_str(),
-            comps.len()
-        );
-    }
 
     let mut shares = Vec::with_capacity(comps.len());
     let mut sss = Vec::with_capacity(comps.len());
@@ -722,14 +741,6 @@ pub fn encapsulate_to(
 
     for (i, &kem) in comps.iter().enumerate() {
         let ek = &recipient.eks[i];
-        if ek.len() != kem.component().ek_len() {
-            bail!(
-                "recipient component {:?} encap key length {} != expected {}",
-                kem,
-                ek.len(),
-                kem.component().ek_len()
-            );
-        }
         let (ct, ss) = kem.component().encapsulate(ek)?;
         cts.push(ct.clone());
         shares.push(KemShare {

--- a/crates/hyprstream-rpc/src/crypto/hybrid_kem.rs
+++ b/crates/hyprstream-rpc/src/crypto/hybrid_kem.rs
@@ -402,6 +402,30 @@ fn combine(
     )
 }
 
+/// Focused #553 test seam proving that both the classical and ML-KEM shared
+/// secrets affect the content-key input.  Keeping this beside the private
+/// combiner makes an "ignore the PQ share" mutation visible to the focused
+/// COSE test command as well as this module's broader tests.
+#[cfg(test)]
+pub(crate) fn combiner_is_sensitive_to_every_component_for_cose() -> bool {
+    let suite = SuiteId::HyKemX25519MlKem768;
+    let ciphertexts = vec![vec![9u8; 32], vec![8u8; 1088]];
+    let recipient_eks: Vec<&[u8]> = vec![&[7u8; 32], &[6u8; 1184]];
+    let secret = |first, second| {
+        combine(
+            suite,
+            &[
+                Zeroizing::new(vec![first; 32]),
+                Zeroizing::new(vec![second; 32]),
+            ],
+            &ciphertexts,
+            &recipient_eks,
+        )
+    };
+    let base = secret(1, 2);
+    *base != *secret(0xff, 2) && *base != *secret(1, 0xff)
+}
+
 // ============================================================================
 // Suite-identified wire material + recipient keys
 // ============================================================================

--- a/crates/hyprstream-rpc/src/envelope.rs
+++ b/crates/hyprstream-rpc/src/envelope.rs
@@ -1838,17 +1838,30 @@ impl SignedEnvelope {
     /// Non-mutating timestamp-window validation for early rejection before
     /// signature verification, KEM decapsulation, or decryption.
     fn validate_timestamp(&self) -> EnvelopeResult<()> {
-        let now = current_timestamp();
-        let age = now - self.envelope.iat;
-        if age > MAX_TIMESTAMP_AGE_MS {
+        Self::validate_timestamp_at(self.envelope.iat, current_timestamp())
+    }
+
+    /// Validate `iat` against an explicit clock reading.
+    ///
+    /// Widen both wire-controlled timestamps before subtracting so every `i64`
+    /// input, including the two extremes, has defined fail-closed behavior.
+    /// Both limits are inclusive: an age exactly equal to the past window or a
+    /// future distance exactly equal to the clock-skew allowance is accepted.
+    fn validate_timestamp_at(iat: i64, now: i64) -> EnvelopeResult<()> {
+        let age = i128::from(now) - i128::from(iat);
+        let max_age = i128::from(MAX_TIMESTAMP_AGE_MS);
+        if age > max_age {
             return Err(EnvelopeError::ReplayAttack(format!(
                 "timestamp too old: {age}ms > {MAX_TIMESTAMP_AGE_MS}ms"
             )));
         }
-        if age < -MAX_CLOCK_SKEW_MS {
+
+        let future_distance = i128::from(iat) - i128::from(now);
+        let max_future = i128::from(MAX_CLOCK_SKEW_MS);
+        if future_distance > max_future {
+            let excess = future_distance - max_future;
             return Err(EnvelopeError::ReplayAttack(format!(
-                "timestamp in future: {}ms beyond clock skew tolerance",
-                -age - MAX_CLOCK_SKEW_MS
+                "timestamp in future: {excess}ms beyond clock skew tolerance"
             )));
         }
         Ok(())
@@ -3602,6 +3615,30 @@ mod tests {
         };
         unwrap_and_verify(&original_wire, &options()).expect("original request is accepted");
 
+        // Wire-controlled integer extremes fail in the early non-mutating
+        // timestamp precheck and cannot evict the accepted entry from this
+        // capacity-one cache. The ciphertext signature is intentionally left
+        // valid; changing only outer metadata would otherwise proceed to AEAD.
+        for extreme_iat in [i64::MIN, i64::MAX] {
+            let mut extreme = original.clone();
+            extreme.envelope.nonce = distinct_test_nonce(&original_nonce);
+            extreme.envelope.iat = extreme_iat;
+            extreme
+                .verify_signature_only(&node_vk)
+                .expect("ciphertext signature remains valid");
+            let error = unwrap_and_verify(&signed_envelope_to_wire(&extreme), &options())
+                .expect_err("extreme timestamp is rejected without a panic");
+            assert!(error.to_string().contains(if extreme_iat == i64::MIN {
+                "timestamp too old"
+            } else {
+                "timestamp in future"
+            }));
+            assert!(
+                unwrap_and_verify(&original_wire, &options()).is_err(),
+                "rejected extreme timestamp must not evict accepted replay state"
+            );
+        }
+
         // Authenticated but expired outer metadata is rejected before KEM work
         // and cannot disturb the full capacity-one cache.
         let mut stale = original.clone();
@@ -3662,6 +3699,89 @@ mod tests {
                 .count()
         });
         assert_eq!(accepted, 1);
+    }
+
+    #[test]
+    fn timestamp_window_boundaries_and_extremes_are_overflow_safe() {
+        let now = 0;
+
+        // Both documented limits are inclusive.
+        assert!(SignedEnvelope::validate_timestamp_at(-MAX_TIMESTAMP_AGE_MS, now).is_ok());
+        assert!(SignedEnvelope::validate_timestamp_at(MAX_CLOCK_SKEW_MS, now).is_ok());
+
+        // Values one millisecond inside either inclusive limit also remain valid.
+        assert!(SignedEnvelope::validate_timestamp_at(-MAX_TIMESTAMP_AGE_MS + 1, now).is_ok());
+        assert!(SignedEnvelope::validate_timestamp_at(MAX_CLOCK_SKEW_MS - 1, now).is_ok());
+
+        // The immediately adjacent values outside either window fail closed.
+        assert!(SignedEnvelope::validate_timestamp_at(-MAX_TIMESTAMP_AGE_MS - 1, now).is_err());
+        assert!(SignedEnvelope::validate_timestamp_at(MAX_CLOCK_SKEW_MS + 1, now).is_err());
+
+        // Widening before subtraction defines both ends of the wire domain,
+        // even when the clock is itself at the opposite i64 boundary.
+        assert!(SignedEnvelope::validate_timestamp_at(i64::MIN, now).is_err());
+        assert!(SignedEnvelope::validate_timestamp_at(i64::MAX, now).is_err());
+        assert!(SignedEnvelope::validate_timestamp_at(i64::MIN, i64::MAX).is_err());
+        assert!(SignedEnvelope::validate_timestamp_at(i64::MAX, i64::MIN).is_err());
+    }
+
+    #[test]
+    fn ordinary_unwrap_rejects_extreme_timestamps_for_all_compatibility_paths() {
+        use crate::node_identity::{derive_mesh_kem_recipient, derive_mesh_mldsa_key};
+
+        let (node_sk, node_vk) = generate_signing_keypair();
+        let pq_sk = derive_mesh_mldsa_key(&node_sk);
+        let kem_pub = derive_mesh_kem_recipient(&node_sk)
+            .expect("derive #mesh-kem")
+            .public();
+
+        let clear = SignedEnvelope::new_signed(
+            RequestEnvelope::anonymous(b"clear timestamp boundary".to_vec()),
+            &node_sk,
+        );
+        let encrypted = SignedEnvelope::new_signed_encrypted_mesh_kem(
+            RequestEnvelope::anonymous(b"encrypted timestamp boundary".to_vec()),
+            &node_sk,
+            &pq_sk,
+            &kem_pub,
+        )
+        .expect("seal encrypted boundary fixture");
+
+        for extreme_iat in [i64::MIN, i64::MAX] {
+            for fixture in [&clear, &encrypted] {
+                let mut extreme = fixture.clone();
+                extreme.envelope.iat = extreme_iat;
+                let wire = signed_envelope_to_wire(&extreme);
+
+                for any_signer in [false, true] {
+                    let cache = TestNonceCache::new();
+                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        let opts = if any_signer {
+                            UnwrapOptions::any_signer(&cache)
+                        } else {
+                            UnwrapOptions::fixed_signer(&node_vk, &cache)
+                        }
+                        .with_verify_policy(crate::crypto::CryptoPolicy::Classical);
+                        unwrap_and_verify(&wire, &opts)
+                    }));
+                    let error = result
+                        .expect("wire-controlled timestamp must never panic")
+                        .expect_err("extreme timestamp must fail closed");
+                    assert!(
+                        error.to_string().contains(if extreme_iat == i64::MIN {
+                            "timestamp too old"
+                        } else {
+                            "timestamp in future"
+                        }),
+                        "timestamp rejection must precede signature or KEM work: {error}"
+                    );
+                    assert!(
+                        cache.seen.lock().is_empty(),
+                        "rejected timestamp must not commit replay state"
+                    );
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/envelope.rs
+++ b/crates/hyprstream-rpc/src/envelope.rs
@@ -295,8 +295,8 @@ pub struct UnwrapOptions<'a> {
     /// Ed25519 key is converted to X25519 for DH decryption.
     pub decryption_key: Option<&'a crate::crypto::SigningKey>,
     /// Require the verified wire envelope to carry a non-empty encrypted
-    /// envelope. Enforced after signature/replay verification and before
-    /// decryption or any claims/application processing.
+    /// envelope. Enforced after signature verification and before decryption,
+    /// the final replay commit, or any claims/application processing.
     pub require_encrypted: bool,
     /// kid-anchored ML-DSA-65 trust store used to resolve the PQ verifying key
     /// for the envelope's EdDSA signer. Required under Hybrid policy.
@@ -1599,8 +1599,8 @@ impl SignedEnvelope {
 
     /// Outer placeholder serialized beside `encrypted_envelope`.
     ///
-    /// Replay checks intentionally run before decryption, so the outer envelope
-    /// keeps only non-secret replay metadata. Payload, JWT authorization,
+    /// The outer envelope keeps only non-secret replay metadata until
+    /// authenticated decryption succeeds. Payload, JWT authorization,
     /// delegation bearer, WTH, and streaming DH material live only inside the
     /// COSE_Encrypt0 plaintext and replace this placeholder after decrypt.
     fn redacted_encrypted_envelope(&self) -> RequestEnvelope {
@@ -1618,14 +1618,14 @@ impl SignedEnvelope {
         }
     }
 
-    /// Verify the signature and check replay protection.
+    /// Verify the signature, then atomically commit replay protection.
     ///
     /// # Verification Steps
     ///
     /// 1. Verify signer pubkey matches expected key
     /// 2. Check timestamp is within acceptable window
-    /// 3. Check nonce hasn't been seen before
-    /// 4. Verify Ed25519 signature
+    /// 3. Verify Ed25519 signature
+    /// 4. Atomically check and record the nonce
     ///
     /// # Errors
     ///
@@ -1672,8 +1672,8 @@ impl SignedEnvelope {
             });
         }
 
-        self.check_replay(nonce_cache)?;
-        self.verify_cose(expected_pubkey, pq_store, verify_policy)
+        self.verify_cose(expected_pubkey, pq_store, verify_policy)?;
+        self.check_replay(nonce_cache)
     }
 
     /// Verify signature only (skip replay protection).
@@ -1729,8 +1729,8 @@ impl SignedEnvelope {
                 expected: 32,
                 actual: 0,
             })?;
-        self.check_replay(nonce_cache)?;
-        self.verify_cose(&verifying_key, pq_store, verify_policy)
+        self.verify_cose(&verifying_key, pq_store, verify_policy)?;
+        self.check_replay(nonce_cache)
     }
 
     /// Fu2/#677: like [`Self::verify_with`] but with an explicit
@@ -1753,14 +1753,14 @@ impl SignedEnvelope {
                 actual: hex::encode(self.cnf),
             });
         }
-        self.check_replay(nonce_cache)?;
         self.verify_cose_unanchored(
             expected_pubkey,
             pq_store,
             verify_policy,
             unanchored,
             allowlist,
-        )
+        )?;
+        self.check_replay(nonce_cache)
     }
 
     /// Fu2/#677: any-signer variant of [`Self::verify_with_unanchored_policy`].
@@ -1777,7 +1777,51 @@ impl SignedEnvelope {
                 expected: 32,
                 actual: 0,
             })?;
-        self.check_replay(nonce_cache)?;
+        self.verify_cose_unanchored(
+            &verifying_key,
+            pq_store,
+            verify_policy,
+            unanchored,
+            allowlist,
+        )?;
+        self.check_replay(nonce_cache)
+    }
+
+    fn verify_signature_with_unanchored_policy(
+        &self,
+        expected_pubkey: &VerifyingKey,
+        pq_store: Option<&dyn PqTrustStore>,
+        verify_policy: crate::crypto::CryptoPolicy,
+        unanchored: UnanchoredHybridPolicy,
+        allowlist: &[String],
+    ) -> EnvelopeResult<()> {
+        if !bool::from(self.cnf.ct_eq(&expected_pubkey.to_bytes())) {
+            return Err(EnvelopeError::SignerMismatch {
+                expected: hex::encode(expected_pubkey.to_bytes()),
+                actual: hex::encode(self.cnf),
+            });
+        }
+        self.verify_cose_unanchored(
+            expected_pubkey,
+            pq_store,
+            verify_policy,
+            unanchored,
+            allowlist,
+        )
+    }
+
+    fn verify_any_signature_with_unanchored_policy(
+        &self,
+        pq_store: Option<&dyn PqTrustStore>,
+        verify_policy: crate::crypto::CryptoPolicy,
+        unanchored: UnanchoredHybridPolicy,
+        allowlist: &[String],
+    ) -> EnvelopeResult<()> {
+        let verifying_key =
+            VerifyingKey::from_bytes(&self.cnf).map_err(|_| EnvelopeError::InvalidPublicKey {
+                expected: 32,
+                actual: 0,
+            })?;
         self.verify_cose_unanchored(
             &verifying_key,
             pq_store,
@@ -1947,10 +1991,10 @@ impl SignedEnvelope {
             .encrypted_envelope
             .as_ref()
             .ok_or_else(|| EnvelopeError::Decryption("no encrypted envelope present".into()))?;
-        // Recompute the AAD from the OUTER replay metadata that the server
-        // already replay-checked. This binds those unsigned outer fields into
-        // the AEAD: a network attacker that mutated the outer nonce/iat to evade
-        // the pre-decrypt replay check changes this AAD and the open fails.
+        // Recompute the AAD from the OUTER replay metadata that the server will
+        // commit only after this method succeeds. This binds those unsigned
+        // fields into the AEAD: a network attacker that mutates the outer
+        // nonce/iat changes this AAD and the open fails before replay commit.
         let aad = encrypted_envelope_external_aad(
             self.envelope.request_id,
             self.envelope.iat,
@@ -1974,10 +2018,10 @@ impl SignedEnvelope {
 
         // Defense in depth: the replay metadata the server verified (outer) MUST
         // equal the authenticated inner metadata, so the request that gets
-        // authorized is the same one whose nonce/timestamp were replay-checked.
+        // authorized is the same one whose nonce/timestamp will be replay-checked.
         // The AAD binding above guarantees outer == what-was-sealed on success;
         // this additionally rejects a sender that sealed inner fields diverging
-        // from the outer envelope it presented for the replay check.
+        // from the outer envelope it presented for replay admission.
         if inner.request_id != self.envelope.request_id
             || inner.iat != self.envelope.iat
             || inner.nonce != self.envelope.nonce
@@ -2738,14 +2782,16 @@ pub fn unwrap_and_verify(
     let signed_reader = reader.get_root::<crate::common_capnp::signed_envelope::Reader>()?;
     let mut signed = SignedEnvelope::read_from(signed_reader)?;
 
+    // Authenticate first without mutating replay state.  The compatibility
+    // lifecycle commits the nonce only after canonical COSE parsing, external-
+    // AAD authentication, decryption, and inner/outer equality all succeed.
     match &opts.verification {
         EnvelopeVerification::FixedSigner(pubkey) => {
             // Fu2/#677: production wire verify uses the unanchored-aware path —
             // deny-on-missing-anchor by default, with an opt-in classical-floor
             // allowlist for legacy peers.
-            signed.verify_with_unanchored_policy(
+            signed.verify_signature_with_unanchored_policy(
                 pubkey,
-                opts.nonce_cache,
                 opts.pq_store,
                 opts.verify_policy,
                 opts.unanchored_policy,
@@ -2753,8 +2799,7 @@ pub fn unwrap_and_verify(
             )?;
         }
         EnvelopeVerification::AnySigner => {
-            signed.verify_any_signer_with_unanchored_policy(
-                opts.nonce_cache,
+            signed.verify_any_signature_with_unanchored_policy(
                 opts.pq_store,
                 opts.verify_policy,
                 opts.unanchored_policy,
@@ -2765,7 +2810,7 @@ pub fn unwrap_and_verify(
 
     // INV-2 receive-side policy (#1042): the carrier requirement is supplied
     // by the accept boundary, never by request bytes. Check it only after the
-    // signature and replay admission above, so unauthenticated input cannot
+    // signature above, so unauthenticated input cannot
     // select or exercise a signed policy-error path. A non-empty marker alone
     // is not sufficient: encrypted envelopes continue through canonical KEM
     // open below before any claims or handler sees their payload.
@@ -2789,6 +2834,12 @@ pub fn unwrap_and_verify(
             ));
         }
     }
+
+    // This is the single atomic replay commit for the public compatibility
+    // lifecycle. Invalid signatures, non-canonical ciphertext, wrong AAD,
+    // failed decryption, and inner/outer mismatch cannot consume or evict cache
+    // capacity; concurrent identical valid inputs race here and only one wins.
+    signed.check_replay(opts.nonce_cache)?;
 
     let payload = signed.payload().to_vec();
     Ok((signed, payload))
@@ -2953,6 +3004,17 @@ mod tests {
             *b = !*b;
         }
         out
+    }
+
+    fn signed_envelope_to_wire(envelope: &SignedEnvelope) -> Vec<u8> {
+        let mut message = capnp::message::Builder::new_default();
+        {
+            let mut builder = message.init_root::<common_capnp::signed_envelope::Builder>();
+            envelope.write_to(&mut builder);
+        }
+        let mut wire = Vec::new();
+        capnp::serialize::write_message(&mut wire, &message).expect("serialize signed envelope");
+        wire
     }
 
     /// In-memory kid-anchored PQ trust store for tests.
@@ -3432,7 +3494,7 @@ mod tests {
         // request_id) is unsigned on the wire — the composite signature covers
         // only the ciphertext. It MUST be bound into the COSE_Encrypt0 AEAD so a
         // network attacker cannot mutate the outer nonce/iat to evade the
-        // server's pre-decrypt replay check while the signature still verifies.
+        // server's replay admission while the signature still verifies.
         use crate::node_identity::{derive_mesh_kem_recipient, derive_mesh_mldsa_key};
 
         let (node_sk, node_vk) = generate_signing_keypair();
@@ -3481,6 +3543,95 @@ mod tests {
         good.decrypt_in_place_mesh_kem(&kem_kp)
             .expect("untampered envelope opens");
         assert_eq!(good.envelope.request_id, 42);
+    }
+
+    #[test]
+    fn compatibility_replay_commits_only_after_full_authentication_and_atomically() {
+        use crate::node_identity::{derive_mesh_kem_recipient, derive_mesh_mldsa_key};
+
+        let (node_sk, node_vk) = generate_signing_keypair();
+        let pq_sk = derive_mesh_mldsa_key(&node_sk);
+        let kem_pub = derive_mesh_kem_recipient(&node_sk)
+            .expect("derive #mesh-kem")
+            .public();
+        let original_nonce = fresh_test_nonce();
+        let original = SignedEnvelope::new_signed_encrypted_mesh_kem(
+            RequestEnvelope {
+                request_id: 553,
+                payload: b"authenticated payload".to_vec(),
+                nonce: original_nonce,
+                iat: current_timestamp(),
+                authorization: Authorization::None,
+                delegation_token: None,
+                wth: None,
+                client_dh_public: None,
+                response_kem_recipient: None,
+                service_domain: None,
+            },
+            &node_sk,
+            &pq_sk,
+            &kem_pub,
+        )
+        .expect("seal original");
+        let original_wire = signed_envelope_to_wire(&original);
+
+        // Fill a capacity-one cache with one fully authenticated request.
+        let cache = InMemoryNonceCache::with_config(MAX_TIMESTAMP_AGE_MS, 1);
+        let options = || {
+            UnwrapOptions::fixed_signer(&node_vk, &cache)
+                .with_decryption_key(&node_sk)
+                .require_encrypted(true)
+                .with_verify_policy(crate::crypto::CryptoPolicy::Classical)
+        };
+        unwrap_and_verify(&original_wire, &options()).expect("original request is accepted");
+
+        // A distinct outer nonce plus an invalid signature must not consume or
+        // evict cache capacity.
+        let mut invalid_signature = original.clone();
+        invalid_signature.envelope.nonce = distinct_test_nonce(&original_nonce);
+        let last = invalid_signature.cose.len() - 1;
+        invalid_signature.cose[last] ^= 1;
+        assert!(
+            unwrap_and_verify(&signed_envelope_to_wire(&invalid_signature), &options()).is_err()
+        );
+        assert!(unwrap_and_verify(&original_wire, &options()).is_err());
+
+        // The signature covers the unchanged ciphertext and remains valid, but
+        // the distinct outer nonce changes authenticated external AAD. Failed
+        // AEAD authentication likewise must not touch replay state.
+        let mut invalid_aad = original.clone();
+        invalid_aad.envelope.nonce = distinct_test_nonce(&original_nonce);
+        invalid_aad
+            .verify_signature_only(&node_vk)
+            .expect("ciphertext signature remains valid");
+        assert!(unwrap_and_verify(&signed_envelope_to_wire(&invalid_aad), &options()).is_err());
+
+        // Both invalid attempts independently left the original accepted nonce
+        // resident in the capacity-one cache.
+        assert!(unwrap_and_verify(&original_wire, &options()).is_err());
+
+        // Two concurrent, identical, fully valid inputs perform all validation
+        // before racing at one atomic check-and-insert; exactly one can commit.
+        let concurrent_cache = InMemoryNonceCache::with_config(MAX_TIMESTAMP_AGE_MS, 1);
+        let accepted = std::thread::scope(|scope| {
+            let attempts: Vec<_> = (0..2)
+                .map(|_| {
+                    scope.spawn(|| {
+                        let opts = UnwrapOptions::fixed_signer(&node_vk, &concurrent_cache)
+                            .with_decryption_key(&node_sk)
+                            .require_encrypted(true)
+                            .with_verify_policy(crate::crypto::CryptoPolicy::Classical);
+                        unwrap_and_verify(&original_wire, &opts).is_ok()
+                    })
+                })
+                .collect();
+            attempts
+                .into_iter()
+                .map(|attempt| attempt.join().expect("verification thread"))
+                .filter(|accepted| *accepted)
+                .count()
+        });
+        assert_eq!(accepted, 1);
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/envelope.rs
+++ b/crates/hyprstream-rpc/src/envelope.rs
@@ -1622,8 +1622,8 @@ impl SignedEnvelope {
     ///
     /// # Verification Steps
     ///
-    /// 1. Verify signer pubkey matches expected key
-    /// 2. Check timestamp is within acceptable window
+    /// 1. Check timestamp is within the acceptable window without mutation
+    /// 2. Verify signer pubkey matches expected key
     /// 3. Verify Ed25519 signature
     /// 4. Atomically check and record the nonce
     ///
@@ -1664,6 +1664,7 @@ impl SignedEnvelope {
         pq_store: Option<&dyn PqTrustStore>,
         verify_policy: crate::crypto::CryptoPolicy,
     ) -> EnvelopeResult<()> {
+        self.validate_timestamp()?;
         // 1. Verify signer matches expected (constant-time comparison)
         if !bool::from(self.cnf.ct_eq(&expected_pubkey.to_bytes())) {
             return Err(EnvelopeError::SignerMismatch {
@@ -1724,6 +1725,7 @@ impl SignedEnvelope {
         pq_store: Option<&dyn PqTrustStore>,
         verify_policy: crate::crypto::CryptoPolicy,
     ) -> EnvelopeResult<()> {
+        self.validate_timestamp()?;
         let verifying_key =
             VerifyingKey::from_bytes(&self.cnf).map_err(|_| EnvelopeError::InvalidPublicKey {
                 expected: 32,
@@ -1747,6 +1749,7 @@ impl SignedEnvelope {
         unanchored: UnanchoredHybridPolicy,
         allowlist: &[String],
     ) -> EnvelopeResult<()> {
+        self.validate_timestamp()?;
         if !bool::from(self.cnf.ct_eq(&expected_pubkey.to_bytes())) {
             return Err(EnvelopeError::SignerMismatch {
                 expected: hex::encode(expected_pubkey.to_bytes()),
@@ -1772,6 +1775,7 @@ impl SignedEnvelope {
         unanchored: UnanchoredHybridPolicy,
         allowlist: &[String],
     ) -> EnvelopeResult<()> {
+        self.validate_timestamp()?;
         let verifying_key =
             VerifyingKey::from_bytes(&self.cnf).map_err(|_| EnvelopeError::InvalidPublicKey {
                 expected: 32,
@@ -1831,8 +1835,9 @@ impl SignedEnvelope {
         )
     }
 
-    /// Timestamp window + nonce replay check.
-    fn check_replay(&self, nonce_cache: &dyn NonceCache) -> EnvelopeResult<()> {
+    /// Non-mutating timestamp-window validation for early rejection before
+    /// signature verification, KEM decapsulation, or decryption.
+    fn validate_timestamp(&self) -> EnvelopeResult<()> {
         let now = current_timestamp();
         let age = now - self.envelope.iat;
         if age > MAX_TIMESTAMP_AGE_MS {
@@ -1846,6 +1851,14 @@ impl SignedEnvelope {
                 -age - MAX_CLOCK_SKEW_MS
             )));
         }
+        Ok(())
+    }
+
+    /// Revalidate the timestamp, then atomically check and record the nonce.
+    fn check_replay(&self, nonce_cache: &dyn NonceCache) -> EnvelopeResult<()> {
+        // Recheck at commit time so work performed near a timestamp-window
+        // boundary cannot admit an entry after it expires.
+        self.validate_timestamp()?;
         if !nonce_cache.check_and_insert(&self.envelope.nonce) {
             return Err(EnvelopeError::ReplayAttack("nonce already seen".to_owned()));
         }
@@ -2782,6 +2795,10 @@ pub fn unwrap_and_verify(
     let signed_reader = reader.get_root::<crate::common_capnp::signed_envelope::Reader>()?;
     let mut signed = SignedEnvelope::read_from(signed_reader)?;
 
+    // Reject stale or future requests before signature or KEM work without
+    // mutating replay state. The timestamp is revalidated at final commit.
+    signed.validate_timestamp()?;
+
     // Authenticate first without mutating replay state.  The compatibility
     // lifecycle commits the nonce only after canonical COSE parsing, external-
     // AAD authentication, decryption, and inner/outer equality all succeed.
@@ -3584,6 +3601,19 @@ mod tests {
                 .with_verify_policy(crate::crypto::CryptoPolicy::Classical)
         };
         unwrap_and_verify(&original_wire, &options()).expect("original request is accepted");
+
+        // Authenticated but expired outer metadata is rejected before KEM work
+        // and cannot disturb the full capacity-one cache.
+        let mut stale = original.clone();
+        stale.envelope.nonce = distinct_test_nonce(&original_nonce);
+        stale.envelope.iat = current_timestamp() - MAX_TIMESTAMP_AGE_MS - 1;
+        stale
+            .verify_signature_only(&node_vk)
+            .expect("ciphertext signature remains valid");
+        let stale_error = unwrap_and_verify(&signed_envelope_to_wire(&stale), &options())
+            .expect_err("expired request is rejected");
+        assert!(stale_error.to_string().contains("timestamp too old"));
+        assert!(unwrap_and_verify(&original_wire, &options()).is_err());
 
         // A distinct outer nonce plus an invalid signature must not consume or
         // evict cache capacity.


### PR DESCRIPTION
## Outcome

Hardens the already-landed #553 precursor into a bounded, canonical COSE_Encrypt0 sealing substrate for later stream/group lifecycle owners. This repair is rebased on current `main` at `6626c9de55e2d5e8fb51af0b0b411bb19675fb95` (#1045).

Refs #553 and #550. This does not close #553; a fresh independent security re-review is required.

## Standards audit

- Keeps the RFC 9052 `COSE_Encrypt0` structure and registered ChaCha20/Poly1305 algorithm 24.
- Independently enforces the profile's RFC 8949 section 4.2.1 core deterministic CBOR before semantic decoding: shortest arguments, definite containers, and bytewise lexicographic ordering of each deterministically encoded map key. It does not use the optional section 4.2.3 length-first order.
- Explicitly treats Hyprstream's suite-identified N-KEM combiner and composite encapsulation header as a project profile, not HPKE `enc`/`ek` or draft interoperability.
- Treats PQUIP / RFC 9794 as transition terminology, not a scheme or wire specification.

## Security contract

- Adds authenticated suite, recipient id, selected key id, nonce-domain, epoch, and sequence context, with caller transcript bytes bound as RFC 9052 external AAD.
- Derives a context/epoch-separated AEAD key before applying the deterministic counter nonce.
- Separates irreversible `OutboundNonceLedger` burns from retireable `InboundReplayLedger` state. One outbound ledger owns the complete lifetime of its supplied base key; burns are never evicted or retired, and capacity exhaustion requires destroying/rotating that base key. Public inbound epoch retirement cannot affect outbound uniqueness.
- The signed-envelope compatibility lifecycle verifies the signature, canonical COSE shape, authenticated external AAD, decryption, and inner/outer equality before one atomic replay commit. Invalid inputs cannot consume or evict replay capacity, while concurrent identical valid inputs cannot both succeed.
- Timestamp validity is checked without mutation before signature or KEM work, then revalidated by the same helper at final replay commit. Timestamp distances are widened to `i128` before subtraction, with inclusive past-age and future-skew limits, so every wire `i64` value has defined fail-closed behavior without overflow.
- Performs an allocation-free bounded structural preflight before `coset`/`ciborium` allocation: exact definite three-item outer array; definite containers; explicit depth, entry, total-item, byte/text, and wire limits; overflow/trailing-data rejection.
- Rejects non-canonical or duplicate protected/unprotected maps, unknown/extra headers, truncation, oversize, wrong suite/algorithm/key/recipient/domain/epoch/sequence/AAD, missing/reordered/crossed PQ shares, and Cartesian recipient-key pairing.
- Keeps the public fresh-hybrid-encapsulation compatibility path and public lifecycle-owned sealing APIs; it does not implement #554/#555 epoch policy.

## Regression and mutation evidence

- `i64::MIN` and `i64::MAX` reject without panic through ordinary fixed- and any-signer unwrap for cleartext and encrypted envelopes, before signature/KEM work or replay mutation.
- Exact past/future window limits and values one millisecond inside are accepted; values one millisecond outside reject. Opposite `i64` clock/input extremes also reject without overflow.
- A capacity-one cache retains its accepted nonce after both extreme timestamp attempts; the original remains rejected as a replay. Invalid signature, invalid AAD, expired timestamps, and extreme timestamps cannot consume or evict replay state, and two concurrent identical valid requests yield exactly one success.
- The RFC 8949 section 4.2.1 mixed-width order `[100, -1]` is accepted; the reverse optional length-first order is rejected.
- An outbound pre-derived object remains burned after the matching inbound epoch is publicly retired.
- Existing focused controls remain sensitive to both X25519 and ML-KEM combiner contributions, replay recording, outbound burns, external AAD, context binding, malformed/crossed/Cartesian KEM material, tampering, exact headers, and bounded hostile CBOR.

## Local evidence at `0250d6f4d574cd240f31d8e9d04de1a748489486`

- Focused COSE gate passed twice: 18/18 each run.
- Three new timestamp/replay regression groups passed three consecutive runs; the compatibility replay transaction also passed before the repeated run.
- Full `hyprstream-rpc` library: 720/720 passed.
- All eleven `hyprstream-rpc` integration targets passed independently.
- Strict RPC Clippy passed.
- Release workspace Clippy passed independently and again in the foreground pre-commit hook.
- Local CI-equivalent browser WASM check with `web_sys_unstable_apis` passed.
- `cargo deny check bans licenses` passed with only configured repository warnings.
- Direct rustfmt check and `git diff --check` passed.

An additional non-required release-mode unit-test link was attempted after the required release Clippy gate; the linker was terminated by shared target storage pressure. No semantic gate depended on that redundant link, and the foreground release-Clippy hook subsequently passed before commit.

Hosted exact-head Clippy, WASM, cargo-deny, all CodeQL analyses/aggregate, and CodeRabbit settled successfully. The exact-SHA rereview handoff is issued; the branch remains frozen and unmerged, and #553 remains open pending a fresh detached exact-head review.

## Boundaries

This change does not implement #554 recipient lifecycle, #555 group epoch/membership lifecycle, transport admission, membership distribution, or HPKE draft interoperability. It supplies the canonical bounded sealing substrate those owners can consume.