### PR TITLE
feat(pds): persist accepted did:at9p state

### DIFF
--- a/crates/hyprstream-pds/src/at9p_chain.rs
+++ b/crates/hyprstream-pds/src/at9p_chain.rs
@@ -289,7 +289,7 @@ pub fn validate_successor(
 /// `Ok(true)` iff `a` is strictly before `b`. Pure integer parse — no clock, no
 /// external date crate. Malformed input is an error (fail-closed), never a
 /// silent `false`.
-fn datetime_before(a: &str, b: &str) -> anyhow::Result<bool> {
+pub(crate) fn datetime_before(a: &str, b: &str) -> anyhow::Result<bool> {
     Ok(datetime_nanos(a)? < datetime_nanos(b)?)
 }
 

--- a/crates/hyprstream-pds/src/at9p_duplicity.rs
+++ b/crates/hyprstream-pds/src/at9p_duplicity.rs
@@ -953,6 +953,9 @@ pub enum AdmissionError {
         /// Epoch of the existing watermark that refused the re-seed.
         existing_epoch: u64,
     },
+    /// The durable accepted predecessor is an update whose validity window has
+    /// elapsed. An expired head cannot authorize a later rotation.
+    AcceptedHeadNotFresh(anyhow::Error),
     /// The underlying [`WatermarkStore`] failed (I/O, poisoned lock). Fail-closed:
     /// a watermark that cannot be read or written is treated as blocking, never
     /// bypassed.
@@ -990,6 +993,9 @@ impl std::fmt::Display for AdmissionError {
                 "duplicity guard: watermark for {subject_cid512:?} already exists at epoch {existing_epoch}; refusing re-seed (anti-rollback)"
             ),
             Self::Store(err) => write!(f, "duplicity guard: watermark store error: {err}"),
+            Self::AcceptedHeadNotFresh(err) => {
+                write!(f, "duplicity guard: accepted predecessor is not fresh: {err}")
+            }
             Self::MalformedPredecessor(err) => {
                 write!(f, "duplicity guard: anchored predecessor did not decode: {err}")
             }
@@ -1001,7 +1007,9 @@ impl std::error::Error for AdmissionError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Successor(err) => Some(err),
-            Self::Store(err) | Self::MalformedPredecessor(err) => Some(err.as_ref()),
+            Self::Store(err)
+            | Self::AcceptedHeadNotFresh(err)
+            | Self::MalformedPredecessor(err) => Some(err.as_ref()),
             _ => None,
         }
     }
@@ -1246,6 +1254,9 @@ impl<S: WatermarkStore, A: DuplicityAlarmSink> DuplicityGuard<S, A> {
                     .ok_or_else(|| AdmissionError::NotSeeded {
                         subject_cid512: subject.clone(),
                     })?;
+                accepted
+                    .ensure_fresh(now)
+                    .map_err(AdmissionError::AcceptedHeadNotFresh)?;
                 let watermark = accepted.watermark();
 
             // (1) Idempotent replay of the accepted head: same epoch AND same
@@ -1782,6 +1793,34 @@ mod tests {
             other => panic!("expected Advanced, got {other:?}"),
         };
         assert_eq!(s2.epoch, 2);
+        assert_eq!(guard.store_alarm_count(), 0);
+    }
+
+    #[test]
+    fn expired_accepted_head_cannot_authorize_successor() {
+        let (g, n1, n2, n3) = (signer(), signer(), signer(), signer());
+        let (cap0, s0) = genesis(&g, &[&n1]);
+        let guard = guard();
+        guard.seed_genesis(&verified_genesis(&cap0)).unwrap();
+        let r1 = update_salted(
+            &s0.subject_cid512,
+            1,
+            s0.record_digest,
+            &n1,
+            &[&n2],
+            "2026-07-10T00:00:00Z",
+            None,
+        );
+        let s1 = match guard.admit_successor(&r1, NOW).unwrap() {
+            Admission::Advanced(state) => state,
+            other => panic!("expected advance, got {other:?}"),
+        };
+        let r2 = update(&s1.subject_cid512, 2, s1.record_digest, &n2, &[&n3]);
+        assert!(matches!(
+            guard.admit_successor(&r2, "2026-07-11T00:00:00Z"),
+            Err(AdmissionError::AcceptedHeadNotFresh(_))
+        ));
+        assert_eq!(guard.watermark(&s0.subject_cid512).unwrap().unwrap().epoch, 1);
         assert_eq!(guard.store_alarm_count(), 0);
     }
 

--- a/crates/hyprstream-pds/src/at9p_duplicity.rs
+++ b/crates/hyprstream-pds/src/at9p_duplicity.rs
@@ -386,29 +386,49 @@ impl PredecessorRecord<'_> {
 /// in-memory [`InMemoryWatermarkStore`] is provided for tests; the daemon/PDS
 /// supplies the durable atomic implementation.
 ///
-/// Implementations must be safe for concurrent use (`Send + Sync`). The trait
-/// makes **no** atomicity guarantee across `get`/`put`: a `get` followed by a
-/// `put` are two independent calls, and concurrent callers can interleave
-/// between them. Atomicity of the read-modify-write in [`DuplicityGuard::
-/// admit_successor`] is the **guard's** responsibility — it holds a per-DID
-/// admission lock across the whole classification+advance so concurrent
-/// admissions of the same DID serialize. The store owns only its own interior
-/// mutability (each individual call is sound under concurrency); it does NOT
-/// need to provide compare-and-swap.
+/// Implementations must be safe for concurrent use (`Send + Sync`) and MUST
+/// serialize [`conditional_advance`](WatermarkStore::conditional_advance)
+/// across every guard sharing the store. A guard-local lock is only an
+/// optimization: the durable store is the authority and the conditional write
+/// is the security boundary.
 pub trait WatermarkStore: Send + Sync {
     /// Load the complete accepted state. Implementations must re-verify that
     /// the retained head bytes derive the returned watermark fields.
     fn get(&self, subject_cid512: &str) -> anyhow::Result<Option<AcceptedAt9pState>>;
 
-    /// Atomically replace head/body and watermark/terminal state as one durable
-    /// commit. A successful return must survive restart; partial state must not
-    /// be observable after recovery.
-    fn put(&self, state: &AcceptedAt9pState) -> anyhow::Result<()>;
+    /// Advance from exactly `expected` to `state` as one atomic durable commit.
+    /// `None` means the identity must still be unseeded. There is deliberately
+    /// no unconditional public write API.
+    fn conditional_advance(
+        &self,
+        expected: Option<Watermark>,
+        state: &AcceptedAt9pState,
+    ) -> anyhow::Result<ConditionalAdvance>;
+}
+
+impl<T: WatermarkStore + ?Sized> WatermarkStore for Arc<T> {
+    fn get(&self, subject_cid512: &str) -> anyhow::Result<Option<AcceptedAt9pState>> {
+        (**self).get(subject_cid512)
+    }
+
+    fn conditional_advance(
+        &self,
+        expected: Option<Watermark>,
+        state: &AcceptedAt9pState,
+    ) -> anyhow::Result<ConditionalAdvance> {
+        (**self).conditional_advance(expected, state)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ConditionalAdvance {
+    Committed,
+    Conflict(Box<AcceptedAt9pState>),
 }
 
 /// In-memory [`WatermarkStore`] — a `Mutex<HashMap<..>>`. Suitable for tests and
-/// single-process use; **not** durable across restarts. The durable seam is
-/// intentionally left for #886 follow-up (no RocksDB wired here).
+/// single-process use; **not** durable across restarts. Production wires this
+/// trait to the signed, checkpointed RocksDB store owned by the PDS service.
 #[derive(Default)]
 pub struct InMemoryWatermarkStore {
     marks: Mutex<HashMap<String, AcceptedAt9pState>>,
@@ -425,11 +445,21 @@ impl WatermarkStore for InMemoryWatermarkStore {
         Ok(self.marks.lock().get(subject_cid512).cloned())
     }
 
-    fn put(&self, state: &AcceptedAt9pState) -> anyhow::Result<()> {
-        self.marks
-            .lock()
-            .insert(state.subject_cid512.clone(), state.clone());
-        Ok(())
+    fn conditional_advance(
+        &self,
+        expected: Option<Watermark>,
+        state: &AcceptedAt9pState,
+    ) -> anyhow::Result<ConditionalAdvance> {
+        let mut marks = self.marks.lock();
+        let current = marks.get(&state.subject_cid512).cloned();
+        if current.as_ref().map(AcceptedAt9pState::watermark) != expected {
+            return current.map_or_else(
+                || anyhow::bail!("conditional advance expected an existing head, but none exists"),
+                |current| Ok(ConditionalAdvance::Conflict(Box::new(current))),
+            );
+        }
+        marks.insert(state.subject_cid512.clone(), state.clone());
+        Ok(ConditionalAdvance::Committed)
     }
 }
 
@@ -992,13 +1022,8 @@ impl std::error::Error for AdmissionError {
 pub struct DuplicityGuard<S: WatermarkStore, A: DuplicityAlarmSink> {
     store: S,
     alarm: A,
-    /// Per-DID admission locks. Holding one of these across the whole
-    /// `admit_successor`/`seed_genesis` read-modify-write is what makes the R6
-    /// watermark advance atomic (see FIX in #959): without it, two concurrent
-    /// divergent-but-B1-valid epoch-`(N+1)` successors of the same head could
-    /// BOTH observe the head, BOTH pass B1, and BOTH `put` — defeating
-    /// duplicity detection. The `WatermarkStore` trait offers no atomicity of
-    /// its own, so the guard owns it here.
+    /// Per-DID optimization locks for calls through this guard instance. The
+    /// store-owned conditional advance is authoritative across guards.
     admit_locks: Mutex<HashMap<String, Arc<Mutex<()>>>>,
 }
 
@@ -1080,7 +1105,7 @@ impl<S: WatermarkStore, A: DuplicityAlarmSink> DuplicityGuard<S, A> {
     /// anchor backward. The only overwrite permitted is an idempotent re-seed
     /// of the exact same genesis (epoch 0, identical `record_digest`), which is
     /// a no-op success. The per-DID admission lock is held across the
-    /// read-then-conditional-`put` so this check is race-free against a
+    /// read-then-conditional-advance so this check is race-free against a
     /// concurrent `admit_successor`.
     ///
     /// If the genesis pre-commits to no next keys, the seeded watermark is
@@ -1092,20 +1117,29 @@ impl<S: WatermarkStore, A: DuplicityAlarmSink> DuplicityGuard<S, A> {
             .map_err(AdmissionError::MalformedPredecessor)?;
         let subject = &accepted.subject_cid512;
         self.with_admission_lock(subject, || {
-            if let Some(existing) = self.store.get(subject).map_err(AdmissionError::Store)? {
-                // Idempotent re-seed of the exact same genesis is a no-op success.
-                if existing.epoch == 0 && existing.head_digest == accepted.head_digest {
-                    return Ok(());
+            loop {
+                if let Some(existing) = self.store.get(subject).map_err(AdmissionError::Store)? {
+                    // Idempotent re-seed of the exact same genesis is a no-op success.
+                    if existing.epoch == 0 && existing.head_digest == accepted.head_digest {
+                        return Ok(());
+                    }
+                    // Anything else — an already-advanced watermark, or a different
+                    // genesis — is the anti-rollback anchor; refuse rather than let a
+                    // re-seed clobber it.
+                    return Err(AdmissionError::AlreadySeeded {
+                        subject_cid512: subject.clone(),
+                        existing_epoch: existing.epoch,
+                    });
                 }
-                // Anything else — an already-advanced watermark, or a different
-                // genesis — is the anti-rollback anchor; refuse rather than let a
-                // re-seed clobber it.
-                return Err(AdmissionError::AlreadySeeded {
-                    subject_cid512: subject.clone(),
-                    existing_epoch: existing.epoch,
-                });
+                match self
+                    .store
+                    .conditional_advance(None, &accepted)
+                    .map_err(AdmissionError::Store)?
+                {
+                    ConditionalAdvance::Committed => return Ok(()),
+                    ConditionalAdvance::Conflict(_) => continue,
+                }
             }
-            self.store.put(&accepted).map_err(AdmissionError::Store)
         })
     }
 
@@ -1202,16 +1236,17 @@ impl<S: WatermarkStore, A: DuplicityAlarmSink> DuplicityGuard<S, A> {
         // Hold the per-DID admission lock across the ENTIRE read-modify-write so
         // concurrent admissions of this DID serialize (FIX in #959, R6 property).
         self.with_admission_lock(subject, || {
-            // A DID we've never seeded has no anchored baseline; refuse rather than
-            // trust an unanchored predecessor (fail-closed first contact).
-            let accepted = self
-                .store
-                .get(subject)
-                .map_err(AdmissionError::Store)?
-                .ok_or_else(|| AdmissionError::NotSeeded {
-                    subject_cid512: subject.clone(),
-                })?;
-            let watermark = accepted.watermark();
+            loop {
+                // A DID we've never seeded has no anchored baseline; refuse rather than
+                // trust an unanchored predecessor (fail-closed first contact).
+                let accepted = self
+                    .store
+                    .get(subject)
+                    .map_err(AdmissionError::Store)?
+                    .ok_or_else(|| AdmissionError::NotSeeded {
+                        subject_cid512: subject.clone(),
+                    })?;
+                let watermark = accepted.watermark();
 
             // (1) Idempotent replay of the accepted head: same epoch AND same
             // recomputed digest as the persisted watermark means the candidate is
@@ -1326,12 +1361,16 @@ impl<S: WatermarkStore, A: DuplicityAlarmSink> DuplicityGuard<S, A> {
             let terminal = state.next_key_commitments.is_empty();
             let accepted = AcceptedAt9pState::from_accepted_update(candidate.clone());
             debug_assert_eq!(accepted.watermark(), Watermark::from_state(&state));
-            self.store.put(&accepted).map_err(AdmissionError::Store)?;
-            Ok(if terminal {
-                Admission::Frozen(state)
-            } else {
-                Admission::Advanced(state)
-            })
+            match self.store.conditional_advance(Some(watermark), &accepted)
+                .map_err(AdmissionError::Store)? {
+                ConditionalAdvance::Committed => return Ok(if terminal {
+                    Admission::Frozen(state)
+                } else {
+                    Admission::Advanced(state)
+                }),
+                ConditionalAdvance::Conflict(_) => continue,
+            }
+            }
         })
     }
 
@@ -2160,6 +2199,44 @@ mod tests {
             "watermark digest must be one of the candidates"
         );
         assert_eq!(guard.store_alarm_count(), N - 1);
+    }
+
+    #[test]
+    fn independent_guards_share_store_cas() {
+        const N: usize = 8;
+        let (g, n1, n2) = (signer(), signer(), signer());
+        let nexts: Vec<_> = (0..N).map(|_| signer()).collect();
+        let store = Arc::new(InMemoryWatermarkStore::new());
+        let a = DuplicityGuard::new(Arc::clone(&store));
+        let b = DuplicityGuard::new(store);
+        let (cap0, s0) = genesis(&g, &[&n1]);
+        a.seed_genesis(&verified_genesis(&cap0)).unwrap();
+        let r1 = update(&s0.subject_cid512, 1, s0.record_digest, &n1, &[&n2]);
+        let s1 = match a.admit_successor(&r1, NOW).unwrap() {
+            Admission::Advanced(state) => state,
+            other => panic!("expected advance, got {other:?}"),
+        };
+        let records: Vec<_> = nexts.iter().enumerate().map(|(i, next)| update_salted(
+            &s1.subject_cid512, 2, s1.record_digest, &n2, &[next], FUTURE,
+            Some(&format!("independent-{i}")),
+        )).collect();
+        let barrier = std::sync::Barrier::new(N);
+        let outcomes = Mutex::new(Vec::new());
+        std::thread::scope(|scope| {
+            for (i, record) in records.iter().enumerate() {
+                let guard = if i % 2 == 0 { &a } else { &b };
+                let outcomes = &outcomes;
+                let barrier = &barrier;
+                scope.spawn(move || {
+                    barrier.wait();
+                    outcomes.lock().push(guard.admit_successor(record, NOW));
+                });
+            }
+        });
+        let outcomes = outcomes.into_inner();
+        assert_eq!(outcomes.iter().filter(|o| matches!(o, Ok(Admission::Advanced(_)))).count(), 1);
+        assert_eq!(outcomes.iter().filter(|o| matches!(o, Err(AdmissionError::Duplicity(_)))).count(), N - 1);
+        assert_eq!(b.watermark(&s0.subject_cid512).unwrap().unwrap().epoch, 2);
     }
 
     // ---- FIX (#959): seed_genesis is rollback-safe ------------------------

--- a/crates/hyprstream-pds/src/at9p_duplicity.rs
+++ b/crates/hyprstream-pds/src/at9p_duplicity.rs
@@ -110,12 +110,13 @@
 //! `admit_successor` in the running daemon is a separate epic step and is not
 //! claimed live here.)
 //!
-//! # Persistence seam (#886)
+//! # Persistence seam (#886/#1004)
 //!
-//! The watermark store is a trait ([`WatermarkStore`]) with an in-memory impl
-//! ([`InMemoryWatermarkStore`]) for tests and single-process use. A durable
-//! backend (RocksDB/Valkey) plugs in behind the same trait — **intentionally not
-//! wired here** (#886 scopes the seam, not the storage engine).
+//! [`WatermarkStore`] persists the complete accepted head/body together with
+//! its watermark and terminal state. [`InMemoryWatermarkStore`] supports unit
+//! tests; the running PDS implements the same contract with one synchronous
+//! atomic RocksDB value, so recovery cannot pair a new watermark with an old
+//! body (or vice versa).
 
 use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
@@ -131,8 +132,9 @@ use hyprstream_crypto::pq::{
     ml_dsa_sk_to_vk_bytes, ml_dsa_vk_from_bytes, MlDsaSigningKey, MlDsaVerifyingKey,
 };
 
-use crate::at9p::{h512, Capsule, UpdateRecord, H512_LEN};
+use crate::at9p::{h512, Capsule, CapsuleBody, UpdateRecord, H512_LEN};
 use crate::at9p_chain::{validate_successor, ChainState, SuccessorError};
+use crate::at9p_gate::VerifiedCapsule;
 
 /// The persistent per-DID duplicity high-watermark: design #879 §7.2/R6's
 /// `(epoch, H512(accepted record))` pair, plus the terminal flag that carries
@@ -168,9 +170,151 @@ impl Watermark {
     }
 }
 
-/// The predecessor head a caller presents to [`DuplicityGuard::admit_successor`]
-/// as the anchor for the next link — a genesis [`Capsule`] (epoch 0) or an
-/// [`UpdateRecord`] (epoch ≥ 1).
+/// Provenance of the durable accepted head. This identifies which verified
+/// record supplies [`AcceptedAt9pState::current`] without claiming live key
+/// possession, endpoint reachability, admission, or global latest consensus.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AcceptedAt9pProvenance {
+    /// The complete GATE-verified immutable genesis capsule is the head.
+    Genesis { cid512: String },
+    /// A pinned-hybrid signed successor accepted against the prior durable head.
+    Update { prev_record_digest: [u8; H512_LEN] },
+}
+
+/// Complete record retained as the accepted head.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AcceptedAt9pHead {
+    Genesis(Capsule),
+    Update(UpdateRecord),
+}
+
+/// Typed, re-verifiable current `did:at9p` state exposed to identity-bound
+/// resolver/admission consumers.
+///
+/// `current` carries the current authorized signing keys, services, aliases,
+/// and commitments. Service entries remain signed claims to validate and try;
+/// this type deliberately carries no liveness, reach, possession, selection,
+/// or admission verdict.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AcceptedAt9pState {
+    pub subject_cid512: String,
+    pub did: String,
+    pub epoch: u64,
+    pub head_digest: [u8; H512_LEN],
+    pub terminal: bool,
+    pub current: CapsuleBody,
+    /// Successor expiry. Genesis has no update expiry.
+    pub expires_at: Option<String>,
+    pub provenance: AcceptedAt9pProvenance,
+    head: AcceptedAt9pHead,
+}
+
+impl AcceptedAt9pState {
+    /// Construct the initial durable state only from the unforgeable GATE
+    /// witness. There is no caller/config seed constructor.
+    pub fn from_verified_genesis(verified: &VerifiedCapsule) -> anyhow::Result<Self> {
+        let capsule = verified.capsule().clone();
+        let chain = ChainState::genesis(&capsule)?;
+        anyhow::ensure!(
+            chain.subject_cid512 == verified.cid512(),
+            "verified genesis subject/cid mismatch"
+        );
+        Ok(Self {
+            subject_cid512: chain.subject_cid512.clone(),
+            did: verified.did(),
+            epoch: 0,
+            head_digest: chain.record_digest,
+            terminal: chain.next_key_commitments.is_empty(),
+            current: capsule.body.clone(),
+            expires_at: None,
+            provenance: AcceptedAt9pProvenance::Genesis {
+                cid512: chain.subject_cid512,
+            },
+            head: AcceptedAt9pHead::Genesis(capsule),
+        })
+    }
+
+    fn from_accepted_update(record: UpdateRecord) -> Self {
+        let chain = ChainState::from_validated_update(&record);
+        Self {
+            subject_cid512: chain.subject_cid512.clone(),
+            did: format!(
+                "{}{}",
+                crate::at9p_gate::DID_AT9P_PREFIX,
+                chain.subject_cid512
+            ),
+            epoch: chain.epoch,
+            head_digest: chain.record_digest,
+            terminal: chain.next_key_commitments.is_empty(),
+            current: record.new_capsule_body.clone(),
+            expires_at: Some(record.expires_at.clone()),
+            provenance: AcceptedAt9pProvenance::Update {
+                prev_record_digest: record.prev_record_digest,
+            },
+            head: AcceptedAt9pHead::Update(record),
+        }
+    }
+
+    /// Rebuild a stored genesis through the complete GATE pipeline.
+    pub fn from_persisted_genesis(bytes: &[u8]) -> anyhow::Result<Self> {
+        let capsule = Capsule::from_dag_cbor(bytes)?;
+        let cid512 = capsule.cid512()?;
+        let verified = crate::at9p_gate::verify_genesis_capsule(&cid512, bytes)
+            .map_err(|e| anyhow::anyhow!("persisted genesis GATE rejected: {e}"))?;
+        Self::from_verified_genesis(&verified)
+    }
+
+    /// Rebuild a successor previously committed by the accepted-state owner.
+    /// Canonical/schema validation is repeated and all derived watermark fields
+    /// are recomputed from the retained bytes.
+    pub fn from_persisted_update(bytes: &[u8]) -> anyhow::Result<Self> {
+        let record = UpdateRecord::from_dag_cbor(bytes)?;
+        let signer = record
+            .new_capsule_body
+            .subject_keys
+            .first()
+            .ok_or_else(|| anyhow::anyhow!("persisted update has no current signing key"))?;
+        crate::at9p_sign::verify_update_record(&record, signer)
+            .map_err(|e| anyhow::anyhow!("persisted update signature rejected: {e}"))?;
+        Ok(Self::from_accepted_update(record))
+    }
+
+    /// Fail closed if the accepted update has expired at `now`. Genesis has no
+    /// successor expiry and remains current until a successor is accepted.
+    pub fn ensure_fresh(&self, now: &str) -> anyhow::Result<()> {
+        if let Some(expires_at) = &self.expires_at {
+            anyhow::ensure!(
+                crate::at9p_chain::datetime_before(now, expires_at)?,
+                "accepted did:at9p state expired at {expires_at} (now {now})"
+            );
+        }
+        Ok(())
+    }
+
+    pub fn watermark(&self) -> Watermark {
+        Watermark {
+            epoch: self.epoch,
+            record_digest: self.head_digest,
+            terminal: self.terminal,
+        }
+    }
+
+    /// Complete canonical head record for durable re-verification/recovery.
+    pub fn head(&self) -> &AcceptedAt9pHead {
+        &self.head
+    }
+
+    fn predecessor(&self) -> PredecessorRecord<'_> {
+        match &self.head {
+            AcceptedAt9pHead::Genesis(capsule) => PredecessorRecord::Genesis(capsule),
+            AcceptedAt9pHead::Update(record) => PredecessorRecord::Update(record),
+        }
+    }
+}
+
+/// The predecessor head the guard derives from its durable accepted state — a
+/// genesis [`Capsule`] (epoch 0) or an [`UpdateRecord`] (epoch ≥ 1). This is
+/// private so callers cannot supply predecessor authority.
 ///
 /// # Why a record, not a [`ChainState`] (#961)
 ///
@@ -199,7 +343,7 @@ impl Watermark {
 /// [`admit_successor`](DuplicityGuard::admit_successor) contract that #959
 /// documented as an interim measure.
 #[derive(Clone, Copy, Debug)]
-pub enum PredecessorRecord<'a> {
+enum PredecessorRecord<'a> {
     /// The genesis capsule — the epoch-0 head. Presented when the watermark sits
     /// at genesis. The caller MUST have already GATE-verified it (self-signature
     /// and `H512(bytes) == cid512`); the guard re-anchors it against the
@@ -215,7 +359,7 @@ impl PredecessorRecord<'_> {
     /// from a field — so the anchor compares the record's true digest against
     /// [`Watermark::record_digest`]. This is the whole point of #961: the value
     /// the watermark pins is verified to describe *these* bytes.
-    pub fn record_digest(&self) -> [u8; H512_LEN] {
+    fn record_digest(&self) -> [u8; H512_LEN] {
         match self {
             PredecessorRecord::Genesis(cap) => h512(&cap.encode_value()),
             PredecessorRecord::Update(rec) => h512(&rec.encode_value()),
@@ -227,7 +371,7 @@ impl PredecessorRecord<'_> {
     /// [`record_digest`](Self::record_digest) against the watermark: the
     /// `next_key_commitments` carried by the returned state are the record's,
     /// never a caller's claim.
-    pub fn to_chain_state(&self) -> anyhow::Result<ChainState> {
+    fn derive_chain_state(&self) -> anyhow::Result<ChainState> {
         match self {
             PredecessorRecord::Genesis(cap) => ChainState::genesis(cap),
             PredecessorRecord::Update(rec) => Ok(ChainState::from_validated_update(rec)),
@@ -235,12 +379,12 @@ impl PredecessorRecord<'_> {
     }
 }
 
-/// Persistence seam for the per-DID duplicity watermark (#886).
+/// Persistence seam for the complete accepted state and its per-DID duplicity
+/// watermark (#886/#1004).
 ///
 /// Keyed by `subject_cid512` (the genesis cid that names the identity). The
-/// in-memory [`InMemoryWatermarkStore`] is provided; a durable backend
-/// (RocksDB/Valkey) implements the same three methods — **not wired here** by
-/// design.
+/// in-memory [`InMemoryWatermarkStore`] is provided for tests; the daemon/PDS
+/// supplies the durable atomic implementation.
 ///
 /// Implementations must be safe for concurrent use (`Send + Sync`). The trait
 /// makes **no** atomicity guarantee across `get`/`put`: a `get` followed by a
@@ -252,13 +396,14 @@ impl PredecessorRecord<'_> {
 /// mutability (each individual call is sound under concurrency); it does NOT
 /// need to provide compare-and-swap.
 pub trait WatermarkStore: Send + Sync {
-    /// The current watermark for `subject_cid512`, or `None` if this DID has not
-    /// been seeded yet (first contact).
-    fn get(&self, subject_cid512: &str) -> anyhow::Result<Option<Watermark>>;
+    /// Load the complete accepted state. Implementations must re-verify that
+    /// the retained head bytes derive the returned watermark fields.
+    fn get(&self, subject_cid512: &str) -> anyhow::Result<Option<AcceptedAt9pState>>;
 
-    /// Persist `watermark` as the new high-watermark for `subject_cid512`,
-    /// replacing any prior value.
-    fn put(&self, subject_cid512: &str, watermark: Watermark) -> anyhow::Result<()>;
+    /// Atomically replace head/body and watermark/terminal state as one durable
+    /// commit. A successful return must survive restart; partial state must not
+    /// be observable after recovery.
+    fn put(&self, state: &AcceptedAt9pState) -> anyhow::Result<()>;
 }
 
 /// In-memory [`WatermarkStore`] — a `Mutex<HashMap<..>>`. Suitable for tests and
@@ -266,7 +411,7 @@ pub trait WatermarkStore: Send + Sync {
 /// intentionally left for #886 follow-up (no RocksDB wired here).
 #[derive(Default)]
 pub struct InMemoryWatermarkStore {
-    marks: Mutex<HashMap<String, Watermark>>,
+    marks: Mutex<HashMap<String, AcceptedAt9pState>>,
 }
 
 impl InMemoryWatermarkStore {
@@ -276,14 +421,14 @@ impl InMemoryWatermarkStore {
 }
 
 impl WatermarkStore for InMemoryWatermarkStore {
-    fn get(&self, subject_cid512: &str) -> anyhow::Result<Option<Watermark>> {
-        Ok(self.marks.lock().get(subject_cid512).copied())
+    fn get(&self, subject_cid512: &str) -> anyhow::Result<Option<AcceptedAt9pState>> {
+        Ok(self.marks.lock().get(subject_cid512).cloned())
     }
 
-    fn put(&self, subject_cid512: &str, watermark: Watermark) -> anyhow::Result<()> {
+    fn put(&self, state: &AcceptedAt9pState) -> anyhow::Result<()> {
         self.marks
             .lock()
-            .insert(subject_cid512.to_owned(), watermark);
+            .insert(state.subject_cid512.clone(), state.clone());
         Ok(())
     }
 }
@@ -926,8 +1071,8 @@ impl<S: WatermarkStore, A: DuplicityAlarmSink> DuplicityGuard<S, A> {
         f()
     }
 
-    /// Seed the watermark for a DID from its **GATE-verified** genesis
-    /// [`ChainState`] (epoch 0).
+    /// Seed complete accepted state for a DID from its unforgeable
+    /// [`VerifiedCapsule`] GATE witness (epoch 0).
     ///
     /// **Anti-rollback (FIX in #959):** refuses to overwrite a watermark that
     /// is already-advanced (`epoch > 0`) or that anchors a *different* genesis
@@ -942,12 +1087,14 @@ impl<S: WatermarkStore, A: DuplicityAlarmSink> DuplicityGuard<S, A> {
     /// **terminal** immediately — a declared-immutable identity (B3, #887).
     /// Callers must seed only from a genesis they have themselves verified
     /// (`H512(bytes) == cid512` + self-signature).
-    pub fn seed_genesis(&self, genesis: &ChainState) -> Result<(), AdmissionError> {
-        let subject = &genesis.subject_cid512;
+    pub fn seed_genesis(&self, genesis: &VerifiedCapsule) -> Result<(), AdmissionError> {
+        let accepted = AcceptedAt9pState::from_verified_genesis(genesis)
+            .map_err(AdmissionError::MalformedPredecessor)?;
+        let subject = &accepted.subject_cid512;
         self.with_admission_lock(subject, || {
             if let Some(existing) = self.store.get(subject).map_err(AdmissionError::Store)? {
                 // Idempotent re-seed of the exact same genesis is a no-op success.
-                if existing.epoch == 0 && existing.record_digest == genesis.record_digest {
+                if existing.epoch == 0 && existing.head_digest == accepted.head_digest {
                     return Ok(());
                 }
                 // Anything else — an already-advanced watermark, or a different
@@ -958,14 +1105,25 @@ impl<S: WatermarkStore, A: DuplicityAlarmSink> DuplicityGuard<S, A> {
                     existing_epoch: existing.epoch,
                 });
             }
-            self.store
-                .put(subject, Watermark::from_state(genesis))
-                .map_err(AdmissionError::Store)
+            self.store.put(&accepted).map_err(AdmissionError::Store)
         })
     }
 
     /// The current persisted watermark for a DID, or `None` if unseeded.
     pub fn watermark(&self, subject_cid512: &str) -> Result<Option<Watermark>, AdmissionError> {
+        self.store
+            .get(subject_cid512)
+            .map(|state| state.map(|state| state.watermark()))
+            .map_err(AdmissionError::Store)
+    }
+
+    /// Complete accepted current state, including current authorized body and
+    /// provenance. This is state acceptance only, never reach/liveness or live
+    /// possession/admission authority.
+    pub fn accepted_state(
+        &self,
+        subject_cid512: &str,
+    ) -> Result<Option<AcceptedAt9pState>, AdmissionError> {
         self.store
             .get(subject_cid512)
             .map_err(AdmissionError::Store)
@@ -977,8 +1135,8 @@ impl<S: WatermarkStore, A: DuplicityAlarmSink> DuplicityGuard<S, A> {
     ///
     /// # Predecessor anchoring (#961 — the provenance boundary)
     ///
-    /// `predecessor` is the head record ([`PredecessorRecord`]), **not** a
-    /// caller-supplied [`ChainState`]. The guard recomputes the predecessor's
+    /// The predecessor is loaded from the complete durable accepted state, not
+    /// supplied by the caller. The guard recomputes the predecessor's
     /// `H512` and anchors it against the persisted [`Watermark::record_digest`]
     /// **before** B1 runs, then derives the authoritative `ChainState` from the
     /// anchored record. This proves the `next_key_commitments` B1's
@@ -1012,8 +1170,8 @@ impl<S: WatermarkStore, A: DuplicityAlarmSink> DuplicityGuard<S, A> {
     ///    caller-supplied predecessor. So B1 is not run and no predecessor
     ///    commitments are consulted, which is the #961 invariant in the small: the
     ///    guard never trusts a predecessor field to classify a non-advancing
-    ///    record. Because B1 cannot run here (the committing predecessor at
-    ///    `epoch - 1` is not retained under R6 watermark-only persistence), these
+    ///    record. Because B1 cannot run here (complete current-head persistence
+    ///    does not retain the committing predecessor at `epoch - 1`), these
     ///    duplicity verdicts are **unauthenticated divergence indications**, not
     ///    proof the identity holder signed the divergent record — see
     ///    [`DuplicityAlarm`].
@@ -1037,7 +1195,6 @@ impl<S: WatermarkStore, A: DuplicityAlarmSink> DuplicityGuard<S, A> {
     /// never moves the honest watermark).
     pub fn admit_successor(
         &self,
-        predecessor: PredecessorRecord<'_>,
         candidate: &UpdateRecord,
         now: &str,
     ) -> Result<Admission, AdmissionError> {
@@ -1047,13 +1204,14 @@ impl<S: WatermarkStore, A: DuplicityAlarmSink> DuplicityGuard<S, A> {
         self.with_admission_lock(subject, || {
             // A DID we've never seeded has no anchored baseline; refuse rather than
             // trust an unanchored predecessor (fail-closed first contact).
-            let watermark = self
+            let accepted = self
                 .store
                 .get(subject)
                 .map_err(AdmissionError::Store)?
                 .ok_or_else(|| AdmissionError::NotSeeded {
                     subject_cid512: subject.clone(),
                 })?;
+            let watermark = accepted.watermark();
 
             // (1) Idempotent replay of the accepted head: same epoch AND same
             // recomputed digest as the persisted watermark means the candidate is
@@ -1085,7 +1243,7 @@ impl<S: WatermarkStore, A: DuplicityAlarmSink> DuplicityGuard<S, A> {
             // B1's signer-authorization gate — is the advance path below.
             if cand_epoch < watermark.epoch {
                 // A valid record below the high-watermark. We keep only the
-                // watermark, not full history, so we cannot prove this is the record
+                // complete current head, not full history, so we cannot prove this is the record
                 // we accepted at that epoch — and per R6 a client that has accepted
                 // epoch N never accepts < N. Fail closed as a fork; never prefer.
                 return Err(self.raise_duplicity(
@@ -1110,6 +1268,20 @@ impl<S: WatermarkStore, A: DuplicityAlarmSink> DuplicityGuard<S, A> {
                 ));
             }
 
+            // A higher record must explicitly extend the persisted accepted
+            // head. This is classified before signature validation because the
+            // retained watermark is the authority boundary; selecting a
+            // maximum epoch on another branch is forbidden.
+            if candidate.prev_record_digest != watermark.record_digest {
+                return Err(self.raise_duplicity(
+                    subject,
+                    DuplicityKind::HigherEpochFork,
+                    &watermark,
+                    cand_epoch,
+                    cand_digest,
+                ));
+            }
+
             // (4) Advance path (cand_epoch > watermark). ANCHOR (#961): recompute the
             // predecessor's H512 from its bytes and refuse to trust ANY field of it
             // unless it matches the persisted watermark digest. This is the structural
@@ -1120,6 +1292,7 @@ impl<S: WatermarkStore, A: DuplicityAlarmSink> DuplicityGuard<S, A> {
             // present a foreign record with its own, different digest — caught here.)
             // The check runs BEFORE B1 so a forged/foreign predecessor never reaches
             // the signer-authorization gate.
+            let predecessor = accepted.predecessor();
             let pred_digest = predecessor.record_digest();
             if pred_digest != watermark.record_digest {
                 // Higher-epoch record chained through a non-watermark head — the
@@ -1134,11 +1307,11 @@ impl<S: WatermarkStore, A: DuplicityAlarmSink> DuplicityGuard<S, A> {
             }
 
             // The predecessor is anchored. Derive its authoritative ChainState from
-            // the record's own fields (never a caller claim). `to_chain_state` only
+            // the record's own fields (never a caller claim). `derive_chain_state` only
             // fails on a structural decode inconsistency against an already-hashed
             // record — fail closed as malformed rather than trust a partial state.
             let predecessor_state = predecessor
-                .to_chain_state()
+                .derive_chain_state()
                 .map_err(AdmissionError::MalformedPredecessor)?;
 
             // (5) B1: is the candidate an authorized successor of the AUTHENTIC
@@ -1151,9 +1324,9 @@ impl<S: WatermarkStore, A: DuplicityAlarmSink> DuplicityGuard<S, A> {
             // candidate is a valid successor of it. Advance the watermark; freeze if
             // the new head pre-commits to nothing (B3).
             let terminal = state.next_key_commitments.is_empty();
-            self.store
-                .put(subject, Watermark::from_state(&state))
-                .map_err(AdmissionError::Store)?;
+            let accepted = AcceptedAt9pState::from_accepted_update(candidate.clone());
+            debug_assert_eq!(accepted.watermark(), Watermark::from_state(&state));
+            self.store.put(&accepted).map_err(AdmissionError::Store)?;
             Ok(if terminal {
                 Admission::Frozen(state)
             } else {
@@ -1274,6 +1447,11 @@ mod tests {
         let capsule = sign_capsule(body, &g.ed_sk, &g.pq_sk).unwrap();
         let state = ChainState::genesis(&capsule).unwrap();
         (capsule, state)
+    }
+
+    fn verified_genesis(capsule: &Capsule) -> VerifiedCapsule {
+        let bytes = capsule.to_dag_cbor().unwrap();
+        crate::at9p_gate::verify_genesis_capsule(&capsule.cid512().unwrap(), &bytes).unwrap()
     }
 
     /// Update-record signed by `signer_key`, revealing it as the new primary
@@ -1537,17 +1715,14 @@ mod tests {
         let (g, n1, n2) = (signer(), signer(), signer());
         let (cap0, s0) = genesis(&g, &[&n1]);
         let guard = guard();
-        guard.seed_genesis(&s0).unwrap();
+        guard.seed_genesis(&verified_genesis(&cap0)).unwrap();
         // Watermark starts at genesis (epoch 0, non-terminal).
         let wm0 = guard.watermark(&s0.subject_cid512).unwrap().unwrap();
         assert_eq!(wm0.epoch, 0);
         assert!(!wm0.terminal);
 
         let r1 = update(&s0.subject_cid512, 1, s0.record_digest, &n1, &[&n2]);
-        let s1 = match guard
-            .admit_successor(PredecessorRecord::Genesis(&cap0), &r1, NOW)
-            .unwrap()
-        {
+        let s1 = match guard.admit_successor(&r1, NOW).unwrap() {
             Admission::Advanced(s) => s,
             other => panic!("expected Advanced, got {other:?}"),
         };
@@ -1563,10 +1738,7 @@ mod tests {
         // Extend once more: predecessor is now the watermark head s1.
         let (n3,) = (signer(),);
         let r2 = update(&s1.subject_cid512, 2, s1.record_digest, &n2, &[&n3]);
-        let s2 = match guard
-            .admit_successor(PredecessorRecord::Update(&r1), &r2, NOW)
-            .unwrap()
-        {
+        let s2 = match guard.admit_successor(&r2, NOW).unwrap() {
             Admission::Advanced(s) => s,
             other => panic!("expected Advanced, got {other:?}"),
         };
@@ -1579,15 +1751,11 @@ mod tests {
         let (g, n1, n2) = (signer(), signer(), signer());
         let (cap0, s0) = genesis(&g, &[&n1]);
         let guard = guard();
-        guard.seed_genesis(&s0).unwrap();
+        guard.seed_genesis(&verified_genesis(&cap0)).unwrap();
         let r1 = update(&s0.subject_cid512, 1, s0.record_digest, &n1, &[&n2]);
-        guard
-            .admit_successor(PredecessorRecord::Genesis(&cap0), &r1, NOW)
-            .unwrap();
+        guard.admit_successor(&r1, NOW).unwrap();
         // Present the SAME record again: idempotent, no alarm, watermark unchanged.
-        let outcome = guard
-            .admit_successor(PredecessorRecord::Genesis(&cap0), &r1, NOW)
-            .unwrap();
+        let outcome = guard.admit_successor(&r1, NOW).unwrap();
         assert_eq!(outcome, Admission::AlreadyKnown);
         assert_eq!(guard.store_alarm_count(), 0);
     }
@@ -1599,7 +1767,7 @@ mod tests {
         let (g, n1, n2a, n2b) = (signer(), signer(), signer(), signer());
         let (cap0, s0) = genesis(&g, &[&n1]);
         let guard = guard();
-        guard.seed_genesis(&s0).unwrap();
+        guard.seed_genesis(&verified_genesis(&cap0)).unwrap();
 
         // Honest r1 at epoch 1, accepted → watermark (1, digest_a).
         let r1a = update_salted(
@@ -1611,9 +1779,7 @@ mod tests {
             FUTURE,
             Some("honest"),
         );
-        guard
-            .admit_successor(PredecessorRecord::Genesis(&cap0), &r1a, NOW)
-            .unwrap();
+        guard.admit_successor(&r1a, NOW).unwrap();
 
         // Divergent r1' at epoch 1: ALSO signed by the committed key n1, ALSO
         // chaining from genesis — individually B1-valid — but a different body
@@ -1630,9 +1796,7 @@ mod tests {
         );
         assert_ne!(record_digest(&r1a), record_digest(&r1b));
 
-        let err = guard
-            .admit_successor(PredecessorRecord::Genesis(&cap0), &r1b, NOW)
-            .unwrap_err();
+        let err = guard.admit_successor(&r1b, NOW).unwrap_err();
         match err {
             AdmissionError::Duplicity(alarm) => {
                 assert_eq!(alarm.kind, DuplicityKind::SameEpochFork);
@@ -1659,7 +1823,7 @@ mod tests {
         let (g, n1, n2, n1_forknext) = (signer(), signer(), signer(), signer());
         let (cap0, s0) = genesis(&g, &[&n1]);
         let guard = guard();
-        guard.seed_genesis(&s0).unwrap();
+        guard.seed_genesis(&verified_genesis(&cap0)).unwrap();
 
         // Honest: genesis → r1 (epoch 1) → r2 (epoch 2). Watermark at epoch 2.
         let r1 = update_salted(
@@ -1671,18 +1835,13 @@ mod tests {
             FUTURE,
             Some("honest-1"),
         );
-        let s1 = match guard
-            .admit_successor(PredecessorRecord::Genesis(&cap0), &r1, NOW)
-            .unwrap()
-        {
+        let s1 = match guard.admit_successor(&r1, NOW).unwrap() {
             Admission::Advanced(s) => s,
             other => panic!("{other:?}"),
         };
         let (n3,) = (signer(),);
         let r2 = update(&s1.subject_cid512, 2, s1.record_digest, &n2, &[&n3]);
-        guard
-            .admit_successor(PredecessorRecord::Update(&r1), &r2, NOW)
-            .unwrap();
+        guard.admit_successor(&r2, NOW).unwrap();
         assert_eq!(
             guard.watermark(&s0.subject_cid512).unwrap().unwrap().epoch,
             2
@@ -1702,9 +1861,7 @@ mod tests {
             FUTURE,
             Some("fork"),
         );
-        let err = guard
-            .admit_successor(PredecessorRecord::Genesis(&cap0), &fork1, NOW)
-            .unwrap_err();
+        let err = guard.admit_successor(&fork1, NOW).unwrap_err();
         match err {
             AdmissionError::Duplicity(alarm) => {
                 assert_eq!(alarm.kind, DuplicityKind::BelowWatermarkFork);
@@ -1731,7 +1888,7 @@ mod tests {
         let (g, n1, n2) = (signer(), signer(), signer());
         let (cap0, s0) = genesis(&g, &[&n1]);
         let guard = guard();
-        guard.seed_genesis(&s0).unwrap();
+        guard.seed_genesis(&verified_genesis(&cap0)).unwrap();
 
         // Honest r1 accepted → watermark at epoch 1 (digest_a).
         let r1a = update_salted(
@@ -1743,9 +1900,7 @@ mod tests {
             FUTURE,
             Some("honest"),
         );
-        let _s1a = guard
-            .admit_successor(PredecessorRecord::Genesis(&cap0), &r1a, NOW)
-            .unwrap();
+        let _s1a = guard.admit_successor(&r1a, NOW).unwrap();
 
         // Attacker builds a DIVERGENT epoch-1 record r1b (a fork head we never
         // accepted), then a "successor" r2b at epoch 2 chaining through r1b. r2b
@@ -1766,9 +1921,7 @@ mod tests {
 
         // Present r2b with its own (fork) predecessor s1b. B1 passes; the guard
         // catches that s1b is NOT our watermark head.
-        let err = guard
-            .admit_successor(PredecessorRecord::Update(&r1b), &r2b, NOW)
-            .unwrap_err();
+        let err = guard.admit_successor(&r2b, NOW).unwrap_err();
         match err {
             AdmissionError::Duplicity(alarm) => {
                 assert_eq!(alarm.kind, DuplicityKind::HigherEpochFork);
@@ -1793,7 +1946,7 @@ mod tests {
         let (cap0, s0) = genesis(&g, &[]);
         assert!(s0.next_key_commitments.is_empty());
         let guard = guard();
-        guard.seed_genesis(&s0).unwrap();
+        guard.seed_genesis(&verified_genesis(&cap0)).unwrap();
 
         // The seeded watermark is terminal at epoch 0.
         let wm = guard.watermark(&s0.subject_cid512).unwrap().unwrap();
@@ -1802,9 +1955,7 @@ mod tests {
 
         // Any attempted successor is refused as frozen — B1 is not even reached.
         let rec = update(&s0.subject_cid512, 1, s0.record_digest, &n1, &[&n1]);
-        let err = guard
-            .admit_successor(PredecessorRecord::Genesis(&cap0), &rec, NOW)
-            .unwrap_err();
+        let err = guard.admit_successor(&rec, NOW).unwrap_err();
         assert!(
             matches!(err, AdmissionError::FrozenIdentity { epoch: 0 }),
             "expected FrozenIdentity, got {err:?}"
@@ -1822,14 +1973,11 @@ mod tests {
         let (g, n1, later) = (signer(), signer(), signer());
         let (cap0, s0) = genesis(&g, &[&n1]);
         let guard = guard();
-        guard.seed_genesis(&s0).unwrap();
+        guard.seed_genesis(&verified_genesis(&cap0)).unwrap();
 
         // Final rotation r1: signed by committed n1, pre-committing to EMPTY.
         let r1 = update(&s0.subject_cid512, 1, s0.record_digest, &n1, &[]);
-        let s1 = match guard
-            .admit_successor(PredecessorRecord::Genesis(&cap0), &r1, NOW)
-            .unwrap()
-        {
+        let s1 = match guard.admit_successor(&r1, NOW).unwrap() {
             Admission::Frozen(s) => s,
             other => panic!("expected Frozen (exhausted rotation accepted), got {other:?}"),
         };
@@ -1843,9 +1991,7 @@ mod tests {
 
         // Any further rotation is denied — frozen forever, no recovery.
         let r2 = update(&s1.subject_cid512, 2, s1.record_digest, &later, &[&later]);
-        let err = guard
-            .admit_successor(PredecessorRecord::Update(&r1), &r2, NOW)
-            .unwrap_err();
+        let err = guard.admit_successor(&r2, NOW).unwrap_err();
         assert!(
             matches!(err, AdmissionError::FrozenIdentity { epoch: 1 }),
             "expected FrozenIdentity at epoch 1, got {err:?}"
@@ -1862,22 +2008,17 @@ mod tests {
         let (g, n1) = (signer(), signer());
         let (cap0, s0) = genesis(&g, &[&n1]);
         let guard = guard();
-        guard.seed_genesis(&s0).unwrap();
+        guard.seed_genesis(&verified_genesis(&cap0)).unwrap();
 
         // Final rotation r1 (pre-commits to nothing) accepted → Frozen.
         let r1 = update(&s0.subject_cid512, 1, s0.record_digest, &n1, &[]);
-        match guard
-            .admit_successor(PredecessorRecord::Genesis(&cap0), &r1, NOW)
-            .unwrap()
-        {
+        match guard.admit_successor(&r1, NOW).unwrap() {
             Admission::Frozen(_) => {}
             other => panic!("expected Frozen, got {other:?}"),
         }
 
         // Byte-identical replay of r1: idempotent success, not FrozenIdentity.
-        let outcome = guard
-            .admit_successor(PredecessorRecord::Genesis(&cap0), &r1, NOW)
-            .unwrap();
+        let outcome = guard.admit_successor(&r1, NOW).unwrap();
         assert_eq!(outcome, Admission::AlreadyKnown);
         // Watermark untouched and still terminal; no alarm raised.
         let wm = guard.watermark(&s0.subject_cid512).unwrap().unwrap();
@@ -1888,9 +2029,7 @@ mod tests {
         // A DIFFERENT record is still refused as frozen.
         let (later,) = (signer(),);
         let r2 = update(&s0.subject_cid512, 2, record_digest(&r1), &later, &[&later]);
-        let err = guard
-            .admit_successor(PredecessorRecord::Update(&r1), &r2, NOW)
-            .unwrap_err();
+        let err = guard.admit_successor(&r2, NOW).unwrap_err();
         assert!(
             matches!(err, AdmissionError::FrozenIdentity { epoch: 1 }),
             "expected FrozenIdentity, got {err:?}"
@@ -1902,13 +2041,11 @@ mod tests {
     #[test]
     fn unseeded_did_is_refused() {
         let (g, n1, n2) = (signer(), signer(), signer());
-        let (cap0, s0) = genesis(&g, &[&n1]);
+        let (_cap0, s0) = genesis(&g, &[&n1]);
         let guard = guard();
         // No seed_genesis.
         let r1 = update(&s0.subject_cid512, 1, s0.record_digest, &n1, &[&n2]);
-        let err = guard
-            .admit_successor(PredecessorRecord::Genesis(&cap0), &r1, NOW)
-            .unwrap_err();
+        let err = guard.admit_successor(&r1, NOW).unwrap_err();
         assert!(
             matches!(err, AdmissionError::NotSeeded { .. }),
             "expected NotSeeded, got {err:?}"
@@ -1920,12 +2057,10 @@ mod tests {
         let (g, n1, evil, n2) = (signer(), signer(), signer(), signer());
         let (cap0, s0) = genesis(&g, &[&n1]);
         let guard = guard();
-        guard.seed_genesis(&s0).unwrap();
+        guard.seed_genesis(&verified_genesis(&cap0)).unwrap();
         // Signed by an uncommitted key → B1 SignerNotCommitted, NOT duplicity.
         let rec = update(&s0.subject_cid512, 1, s0.record_digest, &evil, &[&n2]);
-        let err = guard
-            .admit_successor(PredecessorRecord::Genesis(&cap0), &rec, NOW)
-            .unwrap_err();
+        let err = guard.admit_successor(&rec, NOW).unwrap_err();
         assert!(
             matches!(
                 err,
@@ -1952,14 +2087,11 @@ mod tests {
         let next_refs: Vec<&Signer> = nexts.iter().collect();
         let (cap0, s0) = genesis(&g, &[&n1]);
         let guard = guard();
-        guard.seed_genesis(&s0).unwrap();
+        guard.seed_genesis(&verified_genesis(&cap0)).unwrap();
 
         // Honest r1 (epoch 1) accepted → watermark at (1, digest_r1).
         let r1 = update(&s0.subject_cid512, 1, s0.record_digest, &n1, &[&n2]);
-        let s1 = match guard
-            .admit_successor(PredecessorRecord::Genesis(&cap0), &r1, NOW)
-            .unwrap()
-        {
+        let s1 = match guard.admit_successor(&r1, NOW).unwrap() {
             Admission::Advanced(s) => s,
             other => panic!("expected Advanced, got {other:?}"),
         };
@@ -1989,14 +2121,11 @@ mod tests {
 
         let outcomes: Mutex<Vec<Result<Admission, AdmissionError>>> = Mutex::new(Vec::new());
         let guard = &guard;
-        // Predecessor for every concurrent admission is the watermark head r1
-        // (epoch 1), presented as the anchored record — not the derived state.
-        let pred = PredecessorRecord::Update(&r1);
         std::thread::scope(|scope| {
             for rec in &records {
                 let outcomes = &outcomes;
                 scope.spawn(move || {
-                    outcomes.lock().push(guard.admit_successor(pred, rec, NOW));
+                    outcomes.lock().push(guard.admit_successor(rec, NOW));
                 });
             }
         });
@@ -2040,8 +2169,8 @@ mod tests {
         let (cap0, s0) = genesis(&g, &[&n1]);
         let guard = guard();
         // First seed and an idempotent re-seed of the exact same genesis are OK.
-        guard.seed_genesis(&s0).unwrap();
-        guard.seed_genesis(&s0).unwrap();
+        guard.seed_genesis(&verified_genesis(&cap0)).unwrap();
+        guard.seed_genesis(&verified_genesis(&cap0)).unwrap();
         assert_eq!(
             guard.watermark(&s0.subject_cid512).unwrap().unwrap().epoch,
             0
@@ -2049,16 +2178,14 @@ mod tests {
 
         // Advance the chain to epoch 1.
         let r1 = update(&s0.subject_cid512, 1, s0.record_digest, &n1, &[&n2]);
-        guard
-            .admit_successor(PredecessorRecord::Genesis(&cap0), &r1, NOW)
-            .unwrap();
+        guard.admit_successor(&r1, NOW).unwrap();
         assert_eq!(
             guard.watermark(&s0.subject_cid512).unwrap().unwrap().epoch,
             1
         );
 
         // A stray / hostile re-seed must NOT roll the anchor back to genesis.
-        let err = guard.seed_genesis(&s0).unwrap_err();
+        let err = guard.seed_genesis(&verified_genesis(&cap0)).unwrap_err();
         assert!(
             matches!(
                 err,
@@ -2092,7 +2219,7 @@ mod tests {
         let guard =
             DuplicityGuard::with_durable_alarm(InMemoryWatermarkStore::new(), &wal, ed_sk, pq_sk)
                 .unwrap();
-        guard.seed_genesis(&s0).unwrap();
+        guard.seed_genesis(&verified_genesis(&cap0)).unwrap();
 
         // Honest r1 accepted (no alarm).
         let r1a = update_salted(
@@ -2104,9 +2231,7 @@ mod tests {
             FUTURE,
             Some("honest"),
         );
-        guard
-            .admit_successor(PredecessorRecord::Genesis(&cap0), &r1a, NOW)
-            .unwrap();
+        guard.admit_successor(&r1a, NOW).unwrap();
         assert_eq!(
             std::fs::metadata(&wal).unwrap().len(),
             ALARM_WAL_MAGIC.len() as u64,
@@ -2123,9 +2248,7 @@ mod tests {
             FUTURE,
             Some("evil"),
         );
-        let err = guard
-            .admit_successor(PredecessorRecord::Genesis(&cap0), &r1b, NOW)
-            .unwrap_err();
+        let err = guard.admit_successor(&r1b, NOW).unwrap_err();
         assert!(
             matches!(err, AdmissionError::Duplicity(_)),
             "expected Duplicity, got {err:?}"
@@ -2160,7 +2283,7 @@ mod tests {
         let (g, n1) = (signer(), signer());
         let (cap0, s0) = genesis(&g, &[&n1]);
         let guard = guard();
-        guard.seed_genesis(&s0).unwrap();
+        guard.seed_genesis(&verified_genesis(&cap0)).unwrap();
 
         // K_evil was NEVER pre-committed by the honest genesis.
         let (evil,) = (signer(),);
@@ -2171,9 +2294,7 @@ mod tests {
         // (its digest == watermark); the guard derives commitments [commit(n1)]
         // from the record's bytes, NOT from any caller claim, so K_evil is not
         // authorized — B1 rejects it, fail-closed.
-        let err = guard
-            .admit_successor(PredecessorRecord::Genesis(&cap0), &attack, NOW)
-            .unwrap_err();
+        let err = guard.admit_successor(&attack, NOW).unwrap_err();
         assert!(
             matches!(
                 err,
@@ -2205,7 +2326,7 @@ mod tests {
         let (g, n1, n2) = (signer(), signer(), signer());
         let (cap0, s0) = genesis(&g, &[&n1]);
         let guard = guard();
-        guard.seed_genesis(&s0).unwrap();
+        guard.seed_genesis(&verified_genesis(&cap0)).unwrap();
 
         // Honest r1a accepted → watermark at epoch 1 (digest of r1a), committing n2.
         let r1a = update_salted(
@@ -2217,9 +2338,7 @@ mod tests {
             FUTURE,
             Some("honest"),
         );
-        let _s1a = guard
-            .admit_successor(PredecessorRecord::Genesis(&cap0), &r1a, NOW)
-            .unwrap();
+        let _s1a = guard.admit_successor(&r1a, NOW).unwrap();
 
         // Foreign fork head r1b: commits to K_evil (n2b), same epoch, different
         // digest than r1a. Its commitment to n2b is real — but it is NOT our head.
@@ -2241,9 +2360,7 @@ mod tests {
         // Present r1b as the predecessor. The advance path's anchor recomputes
         // r1b's digest and finds it != watermark → HigherEpochFork. B1 never runs,
         // so n2b's commitment in the foreign head is never trusted.
-        let err = guard
-            .admit_successor(PredecessorRecord::Update(&r1b), &r2b, NOW)
-            .unwrap_err();
+        let err = guard.admit_successor(&r2b, NOW).unwrap_err();
         match err {
             AdmissionError::Duplicity(alarm) => {
                 assert_eq!(alarm.kind, DuplicityKind::HigherEpochFork);

--- a/crates/hyprstream-rpc-std/schema/registry.capnp
+++ b/crates/hyprstream-rpc-std/schema/registry.capnp
@@ -90,6 +90,9 @@ struct RegistryRequest {
     # mirrors authorize_get_blob's per-repo "query" check, one verb up. A read
     # grant never implies write.
     putBlob @11 :PutBlobRequest $scope(write) $mcpDescription("Ingest content-addressed bytes; server computes the merkle and binds merkle→repo provenance");
+    # #1004: caller supplies untrusted bytes only; GATE/durable predecessor is authority.
+    ingestAt9pCandidate @12 :At9pCandidateRequest $scope(write)
+        $mcpDescription("Submit untrusted did:at9p genesis/update bytes to the durable acceptance PEP");
   }
 }
 
@@ -180,6 +183,7 @@ struct RegistryResponse {
     # Content-addressed blob ingest result — the SERVER-COMPUTED merkle (never
     # caller-supplied) plus the stored xorb set. See PutBlobResult / epic #654.
     putBlobResult @12 :PutBlobResult;
+    ingestAt9pCandidateResult @13 :AcceptedAt9pStateInfo;
   }
 }
 
@@ -409,6 +413,20 @@ struct PutBlobResult {
   xorbHashes @1 :List(Text);
   # Bytes actually stored after global dedup (0 if fully deduplicated).
   bytesStored @2 :UInt64;
+}
+
+enum At9pCandidateKind { genesis @0; successor @1; }
+struct At9pCandidateRequest {
+  did @0 :Text;
+  kind @1 :At9pCandidateKind;
+  recordBytes @2 :Data;
+  now @3 :Text;
+}
+struct AcceptedAt9pStateInfo {
+  did @0 :Text;
+  epoch @1 :UInt64;
+  headDigest @2 :Data;
+  terminal @3 :Bool;
 }
 
 # Create Worktree Request (repoId removed — curried into RepositoryClient)

--- a/crates/hyprstream-rpc-std/schema/registry.capnp
+++ b/crates/hyprstream-rpc-std/schema/registry.capnp
@@ -420,7 +420,6 @@ struct At9pCandidateRequest {
   did @0 :Text;
   kind @1 :At9pCandidateKind;
   recordBytes @2 :Data;
-  now @3 :Text;
 }
 struct AcceptedAt9pStateInfo {
   did @0 :Text;

--- a/crates/hyprstream/src/services/discovery.rs
+++ b/crates/hyprstream/src/services/discovery.rs
@@ -122,8 +122,15 @@ fn at9p_state_key(subject_cid512: &str) -> Vec<u8> {
     format!("at9p-state\0{subject_cid512}").into_bytes()
 }
 
-const AT9P_STATE_MAGIC: &[u8; 8] = b"AT9PST01";
+const AT9P_STATE_MAGIC: &[u8; 8] = b"AT9PST02";
 const AT9P_STATE_HEADER_LEN: usize = 8 + 1 + 8 + 64 + 1 + 4;
+const AT9P_ACCEPTANCE_MAGIC: &[u8; 8] = b"AT9PAC01";
+const ED25519_KEY_LEN: usize = 32;
+const ED25519_SIGNATURE_LEN: usize = 64;
+const AT9P_ACCEPTANCE_PREFIX_LEN: usize =
+    AT9P_ACCEPTANCE_MAGIC.len() + ED25519_KEY_LEN + ED25519_SIGNATURE_LEN;
+const AT9P_ACCEPTANCE_KEY_AAD: &[u8] = b"hyprstream-at9p-acceptance-key/1";
+const AT9P_ACCEPTANCE_STATE_AAD: &[u8] = b"hyprstream-at9p-accepted-state/1";
 
 /// Split a full record key back into `(collection, tid)`, given the `did` it
 /// was built for.
@@ -163,6 +170,10 @@ fn parse_record_key(key: &[u8], did: &str) -> AnyResult<(String, Tid)> {
 /// callers that need a live view reopen per read (see [`RecordBacking::ReadOnly`]).
 pub struct PdsRecordStore {
     backing: RecordBacking,
+    /// Trusted deployment identity that certifies the purpose-derived key on
+    /// daemon-authenticated accepted-state envelopes. This is verification
+    /// material only; the resolver still holds no signing key.
+    at9p_acceptance_identity: Option<ed25519_dalek::VerifyingKey>,
 }
 
 enum RecordBacking {
@@ -188,6 +199,7 @@ impl PdsRecordStore {
             .with_context(|| format!("failed to open PDS record store (rw) at {path:?}"))?;
         Ok(Self {
             backing: RecordBacking::ReadWrite(db),
+            at9p_acceptance_identity: None,
         })
     }
 
@@ -201,7 +213,14 @@ impl PdsRecordStore {
             .with_context(|| format!("failed to open PDS record store (ro) at {path:?}"))?;
         Ok(Self {
             backing: RecordBacking::ReadOnly(path.to_path_buf()),
+            at9p_acceptance_identity: None,
         })
+    }
+
+    /// Pin the deployment identity that certifies accepted-state envelopes.
+    pub fn with_at9p_acceptance_identity(mut self, identity: ed25519_dalek::VerifyingKey) -> Self {
+        self.at9p_acceptance_identity = Some(identity);
+        self
     }
 
     /// Atomically persist a record and the repo's freshly-signed commit.
@@ -227,7 +246,11 @@ impl PdsRecordStore {
         Ok(())
     }
 
-    fn load_at9p_state(&self, subject_cid512: &str) -> AnyResult<Option<AcceptedAt9pState>> {
+    fn load_at9p_state(
+        &self,
+        subject_cid512: &str,
+        acceptance_identity: &ed25519_dalek::VerifyingKey,
+    ) -> AnyResult<Option<AcceptedAt9pState>> {
         let bytes = match &self.backing {
             RecordBacking::ReadWrite(db) => db.get(at9p_state_key(subject_cid512))?,
             RecordBacking::ReadOnly(path) => {
@@ -236,7 +259,7 @@ impl PdsRecordStore {
             }
         };
         let Some(bytes) = bytes else { return Ok(None) };
-        decode_at9p_state(subject_cid512, &bytes).map(Some)
+        decode_at9p_state(subject_cid512, &bytes, acceptance_identity).map(Some)
     }
 
     /// Typed accepted-current state read path for resolver/admission consumers.
@@ -250,7 +273,11 @@ impl PdsRecordStore {
         let subject = did
             .strip_prefix(DID_AT9P_PREFIX)
             .ok_or_else(|| anyhow!("identifier is not did:at9p: {did:?}"))?;
-        let Some(state) = self.load_at9p_state(subject)? else {
+        let acceptance_identity = self
+            .at9p_acceptance_identity
+            .as_ref()
+            .ok_or_else(|| anyhow!("accepted-state verification identity is not configured"))?;
+        let Some(state) = self.load_at9p_state(subject, acceptance_identity)? else {
             return Ok(None);
         };
         anyhow::ensure!(state.did == did, "accepted at9p state DID mismatch");
@@ -260,11 +287,16 @@ impl PdsRecordStore {
         Ok(Some(state))
     }
 
-    fn put_at9p_state(&self, state: &AcceptedAt9pState) -> AnyResult<()> {
+    fn put_at9p_state(
+        &self,
+        state: &AcceptedAt9pState,
+        acceptance_identity: &ed25519_dalek::SigningKey,
+        audit_key: &ed25519_dalek::SigningKey,
+    ) -> AnyResult<()> {
         let RecordBacking::ReadWrite(db) = &self.backing else {
             bail!("accepted did:at9p state write attempted on a read-only PDS store");
         };
-        let encoded = encode_at9p_state(state)?;
+        let encoded = encode_at9p_state(state, acceptance_identity, audit_key)?;
         let mut options = rocksdb::WriteOptions::default();
         options.set_sync(true);
         db.put_opt(at9p_state_key(&state.subject_cid512), encoded, &options)
@@ -364,7 +396,14 @@ impl PdsRecordStore {
     }
 }
 
-fn encode_at9p_state(state: &AcceptedAt9pState) -> AnyResult<Vec<u8>> {
+fn acceptance_message(domain: &[u8], payload: &[u8]) -> Vec<u8> {
+    let mut message = Vec::with_capacity(domain.len() + payload.len());
+    message.extend_from_slice(domain);
+    message.extend_from_slice(payload);
+    message
+}
+
+fn encode_at9p_state_body(state: &AcceptedAt9pState) -> AnyResult<Vec<u8>> {
     let (kind, head) = match state.head() {
         AcceptedAt9pHead::Genesis(capsule) => (0u8, capsule.to_dag_cbor()?),
         AcceptedAt9pHead::Update(record) => (1u8, record.to_dag_cbor()?),
@@ -381,7 +420,85 @@ fn encode_at9p_state(state: &AcceptedAt9pState) -> AnyResult<Vec<u8>> {
     Ok(out)
 }
 
-fn decode_at9p_state(subject_cid512: &str, bytes: &[u8]) -> AnyResult<AcceptedAt9pState> {
+/// Wrap one complete state value in a daemon-authenticated envelope. The
+/// stable deployment identity certifies the purpose-derived audit key, and the
+/// audit key signs the exact state bytes. A different internally valid at9p
+/// fork therefore cannot be substituted by someone who can edit RocksDB.
+fn encode_at9p_state(
+    state: &AcceptedAt9pState,
+    acceptance_identity: &ed25519_dalek::SigningKey,
+    audit_key: &ed25519_dalek::SigningKey,
+) -> AnyResult<Vec<u8>> {
+    use ed25519_dalek::Signer as _;
+
+    let body = encode_at9p_state_body(state)?;
+    let audit_vk = audit_key.verifying_key().to_bytes();
+    let key_signature =
+        acceptance_identity.sign(&acceptance_message(AT9P_ACCEPTANCE_KEY_AAD, &audit_vk));
+    let state_signature = audit_key.sign(&acceptance_message(AT9P_ACCEPTANCE_STATE_AAD, &body));
+    let mut out =
+        Vec::with_capacity(AT9P_ACCEPTANCE_PREFIX_LEN + body.len() + ED25519_SIGNATURE_LEN);
+    out.extend_from_slice(AT9P_ACCEPTANCE_MAGIC);
+    out.extend_from_slice(&audit_vk);
+    out.extend_from_slice(&key_signature.to_bytes());
+    out.extend_from_slice(&body);
+    out.extend_from_slice(&state_signature.to_bytes());
+    Ok(out)
+}
+
+fn decode_at9p_state(
+    subject_cid512: &str,
+    bytes: &[u8],
+    acceptance_identity: &ed25519_dalek::VerifyingKey,
+) -> AnyResult<AcceptedAt9pState> {
+    anyhow::ensure!(
+        bytes.len() >= AT9P_ACCEPTANCE_PREFIX_LEN + AT9P_STATE_HEADER_LEN + ED25519_SIGNATURE_LEN,
+        "accepted at9p envelope is truncated"
+    );
+    anyhow::ensure!(
+        bytes.starts_with(AT9P_ACCEPTANCE_MAGIC),
+        "accepted at9p envelope has bad version"
+    );
+    let audit_vk_bytes: [u8; ED25519_KEY_LEN] = bytes
+        .get(AT9P_ACCEPTANCE_MAGIC.len()..AT9P_ACCEPTANCE_MAGIC.len() + ED25519_KEY_LEN)
+        .ok_or_else(|| anyhow!("accepted at9p envelope missing audit key"))?
+        .try_into()?;
+    let key_sig_start = AT9P_ACCEPTANCE_MAGIC.len() + ED25519_KEY_LEN;
+    let key_sig_end = key_sig_start + ED25519_SIGNATURE_LEN;
+    let key_signature = ed25519_dalek::Signature::from_bytes(
+        bytes
+            .get(key_sig_start..key_sig_end)
+            .ok_or_else(|| anyhow!("accepted at9p envelope missing key certificate"))?
+            .try_into()?,
+    );
+    acceptance_identity
+        .verify_strict(
+            &acceptance_message(AT9P_ACCEPTANCE_KEY_AAD, &audit_vk_bytes),
+            &key_signature,
+        )
+        .context("accepted at9p audit-key certificate rejected")?;
+    let audit_vk = ed25519_dalek::VerifyingKey::from_bytes(&audit_vk_bytes)
+        .context("accepted at9p envelope has malformed audit key")?;
+    let state_sig_start = bytes.len() - ED25519_SIGNATURE_LEN;
+    let body = bytes
+        .get(AT9P_ACCEPTANCE_PREFIX_LEN..state_sig_start)
+        .ok_or_else(|| anyhow!("accepted at9p envelope missing state body"))?;
+    let state_signature = ed25519_dalek::Signature::from_bytes(
+        bytes
+            .get(state_sig_start..)
+            .ok_or_else(|| anyhow!("accepted at9p envelope missing state signature"))?
+            .try_into()?,
+    );
+    audit_vk
+        .verify_strict(
+            &acceptance_message(AT9P_ACCEPTANCE_STATE_AAD, body),
+            &state_signature,
+        )
+        .context("accepted at9p daemon acceptance signature rejected")?;
+    decode_at9p_state_body(subject_cid512, body)
+}
+
+fn decode_at9p_state_body(subject_cid512: &str, bytes: &[u8]) -> AnyResult<AcceptedAt9pState> {
     anyhow::ensure!(
         bytes.len() >= AT9P_STATE_HEADER_LEN,
         "accepted at9p state is truncated"
@@ -451,15 +568,19 @@ fn decode_at9p_state(subject_cid512: &str, bytes: &[u8]) -> AnyResult<AcceptedAt
 #[derive(Clone)]
 struct RocksAt9pStateStore {
     store: Arc<PdsRecordStore>,
+    acceptance_identity: ed25519_dalek::SigningKey,
+    audit_key: ed25519_dalek::SigningKey,
 }
 
 impl WatermarkStore for RocksAt9pStateStore {
     fn get(&self, subject_cid512: &str) -> AnyResult<Option<AcceptedAt9pState>> {
-        self.store.load_at9p_state(subject_cid512)
+        self.store
+            .load_at9p_state(subject_cid512, &self.acceptance_identity.verifying_key())
     }
 
     fn put(&self, state: &AcceptedAt9pState) -> AnyResult<()> {
-        self.store.put_at9p_state(state)
+        self.store
+            .put_at9p_state(state, &self.acceptance_identity, &self.audit_key)
     }
 }
 
@@ -475,13 +596,18 @@ impl At9pStateIngest {
     pub fn open(
         store: Arc<PdsRecordStore>,
         alarm_path: &Path,
-        ed_sk: ed25519_dalek::SigningKey,
+        acceptance_identity: ed25519_dalek::SigningKey,
+        audit_ed_sk: ed25519_dalek::SigningKey,
         pq_sk: hyprstream_rpc::crypto::pq::MlDsaSigningKey,
     ) -> AnyResult<Self> {
         let guard = DuplicityGuard::with_durable_alarm(
-            RocksAt9pStateStore { store },
+            RocksAt9pStateStore {
+                store,
+                acceptance_identity,
+                audit_key: audit_ed_sk.clone(),
+            },
             alarm_path,
-            ed_sk,
+            audit_ed_sk,
             pq_sk,
         )?;
         Ok(Self { guard })
@@ -1487,8 +1613,15 @@ mod pds_store_tests {
 
     fn production_at9p_publisher(store: Arc<PdsRecordStore>, alarm: &Path) -> PdsPublisher {
         let (audit_ed, audit_pq) = audit_keys();
-        let ingest = At9pStateIngest::open(Arc::clone(&store), alarm, audit_ed, audit_pq)
-            .expect("open accepted-state owner");
+        let acceptance_identity = ed25519_dalek::SigningKey::from_bytes(&[90u8; 32]);
+        let ingest = At9pStateIngest::open(
+            Arc::clone(&store),
+            alarm,
+            acceptance_identity,
+            audit_ed,
+            audit_pq,
+        )
+        .expect("open accepted-state owner");
         PdsPublisher::new(
             store,
             DID.to_owned(),
@@ -1672,11 +1805,67 @@ mod pds_store_tests {
         };
         let key = at9p_state_key(&cid);
         let mut encoded = db.get(&key).expect("get").expect("stored state");
-        encoded[16] ^= 1; // mutate persisted epoch without changing the head body
+        encoded[AT9P_ACCEPTANCE_PREFIX_LEN + 16] ^= 1;
+        // Mutate persisted epoch without changing the retained head body or
+        // recomputing the daemon acceptance signature.
         db.put(&key, encoded).expect("inject mutation");
         assert!(
             publisher.accepted_at9p_state(&did, None).is_err(),
             "a partial watermark/body representation must fail closed"
+        );
+    }
+
+    #[test]
+    fn accepted_at9p_read_rejects_attacker_selected_signed_fork() {
+        use hyprstream_pds::at9p_sign::{sign_capsule, sign_update_record};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(PdsRecordStore::open(dir.path()).expect("open rw"));
+        let (genesis_signer, n1, n2) = (at9p_signer(21), at9p_signer(22), at9p_signer(23));
+        let genesis = sign_capsule(
+            at9p_body(&genesis_signer, &[&n1], "genesis"),
+            &genesis_signer.ed,
+            &genesis_signer.pq,
+        )
+        .expect("genesis");
+        let genesis_bytes = genesis.to_dag_cbor().expect("genesis bytes");
+        let cid = genesis.cid512().expect("cid");
+        let did = format!("{DID_AT9P_PREFIX}{cid}");
+        let publisher = production_at9p_publisher(Arc::clone(&store), &dir.path().join("alarm"));
+        publisher
+            .ingest_at9p_genesis(&did, &genesis_bytes)
+            .expect("seed");
+
+        // This update is internally canonical, correctly linked, and signed by
+        // the identity's committed key. It was never selected by this daemon.
+        let fork = sign_update_record(
+            cid.clone(),
+            1,
+            hyprstream_pds::at9p::h512(&genesis_bytes),
+            at9p_body(&n1, &[&n2], "attacker-selected-fork"),
+            "2099-01-01T00:00:00Z".to_owned(),
+            &n1.ed,
+            &n1.pq,
+        )
+        .expect("signed fork");
+        let fork_state =
+            AcceptedAt9pState::from_persisted_update(&fork.to_dag_cbor().expect("fork bytes"))
+                .expect("internally valid fork state");
+
+        // A process that can rewrite RocksDB but lacks the stable deployment
+        // identity can only certify the substituted value with its own key.
+        let attacker_identity = ed25519_dalek::SigningKey::from_bytes(&[70u8; 32]);
+        let attacker_audit = ed25519_dalek::SigningKey::from_bytes(&[71u8; 32]);
+        let forged = encode_at9p_state(&fork_state, &attacker_identity, &attacker_audit)
+            .expect("forge self-consistent envelope");
+        let RecordBacking::ReadWrite(db) = &store.backing else {
+            panic!("writer")
+        };
+        db.put(at9p_state_key(&cid), forged)
+            .expect("inject attacker-selected fork");
+        assert!(
+            publisher.accepted_at9p_state(&did, None).is_err(),
+            "an identity-valid fork without daemon acceptance must fail closed"
         );
     }
 }

--- a/crates/hyprstream/src/services/discovery.rs
+++ b/crates/hyprstream/src/services/discovery.rs
@@ -15,6 +15,10 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, bail, Context as _, Result as AnyResult};
 use hyprstream_discovery::{RecordCarData, RecordResolver};
+use hyprstream_pds::at9p_duplicity::{
+    AcceptedAt9pHead, AcceptedAt9pState, DuplicityGuard, WalDuplicityAlarmSink, WatermarkStore,
+};
+use hyprstream_pds::at9p_gate::{verify_did_at9p, DID_AT9P_PREFIX};
 use hyprstream_pds::car::build_record_proof_car;
 use hyprstream_pds::commit::{Commit, UnsignedCommit};
 use hyprstream_pds::ledger::{AllocationRecord, CheckpointRecord, ReceiptRecord};
@@ -39,7 +43,6 @@ impl PolicyAuthProvider {
     pub fn new(client: crate::services::PolicyClient) -> Self {
         Self { client }
     }
-
 }
 
 #[async_trait(?Send)]
@@ -115,6 +118,13 @@ fn commit_key(did: &str) -> Vec<u8> {
     format!("commit\0{did}").into_bytes()
 }
 
+fn at9p_state_key(subject_cid512: &str) -> Vec<u8> {
+    format!("at9p-state\0{subject_cid512}").into_bytes()
+}
+
+const AT9P_STATE_MAGIC: &[u8; 8] = b"AT9PST01";
+const AT9P_STATE_HEADER_LEN: usize = 8 + 1 + 8 + 64 + 1 + 4;
+
 /// Split a full record key back into `(collection, tid)`, given the `did` it
 /// was built for.
 fn parse_record_key(key: &[u8], did: &str) -> AnyResult<(String, Tid)> {
@@ -176,7 +186,9 @@ impl PdsRecordStore {
         opts.create_if_missing(true);
         let db = rocksdb::DB::open(&opts, path)
             .with_context(|| format!("failed to open PDS record store (rw) at {path:?}"))?;
-        Ok(Self { backing: RecordBacking::ReadWrite(db) })
+        Ok(Self {
+            backing: RecordBacking::ReadWrite(db),
+        })
     }
 
     /// Open the store read-only at `path`, for resolvers that never write
@@ -187,7 +199,9 @@ impl PdsRecordStore {
         let opts = readonly_opts();
         let _probe = rocksdb::DB::open_for_read_only(&opts, path, false)
             .with_context(|| format!("failed to open PDS record store (ro) at {path:?}"))?;
-        Ok(Self { backing: RecordBacking::ReadOnly(path.to_path_buf()) })
+        Ok(Self {
+            backing: RecordBacking::ReadOnly(path.to_path_buf()),
+        })
     }
 
     /// Atomically persist a record and the repo's freshly-signed commit.
@@ -211,6 +225,50 @@ impl PdsRecordStore {
         batch.put(commit_key(did), commit.to_dag_cbor());
         db.write(batch).context("PDS record+commit write failed")?;
         Ok(())
+    }
+
+    fn load_at9p_state(&self, subject_cid512: &str) -> AnyResult<Option<AcceptedAt9pState>> {
+        let bytes = match &self.backing {
+            RecordBacking::ReadWrite(db) => db.get(at9p_state_key(subject_cid512))?,
+            RecordBacking::ReadOnly(path) => {
+                let db = rocksdb::DB::open_for_read_only(&readonly_opts(), path, false)?;
+                db.get(at9p_state_key(subject_cid512))?
+            }
+        };
+        let Some(bytes) = bytes else { return Ok(None) };
+        decode_at9p_state(subject_cid512, &bytes).map(Some)
+    }
+
+    /// Typed accepted-current state read path for resolver/admission consumers.
+    /// Read-only store instances reopen RocksDB for a live view, just like PDS
+    /// record resolution. `now` enforces update expiry when supplied.
+    pub fn accepted_at9p_state(
+        &self,
+        did: &str,
+        now: Option<&str>,
+    ) -> AnyResult<Option<AcceptedAt9pState>> {
+        let subject = did
+            .strip_prefix(DID_AT9P_PREFIX)
+            .ok_or_else(|| anyhow!("identifier is not did:at9p: {did:?}"))?;
+        let Some(state) = self.load_at9p_state(subject)? else {
+            return Ok(None);
+        };
+        anyhow::ensure!(state.did == did, "accepted at9p state DID mismatch");
+        if let Some(now) = now {
+            state.ensure_fresh(now)?;
+        }
+        Ok(Some(state))
+    }
+
+    fn put_at9p_state(&self, state: &AcceptedAt9pState) -> AnyResult<()> {
+        let RecordBacking::ReadWrite(db) = &self.backing else {
+            bail!("accepted did:at9p state write attempted on a read-only PDS store");
+        };
+        let encoded = encode_at9p_state(state)?;
+        let mut options = rocksdb::WriteOptions::default();
+        options.set_sync(true);
+        db.put_opt(at9p_state_key(&state.subject_cid512), encoded, &options)
+            .context("synchronous accepted did:at9p state commit failed")
     }
 
     /// The stable record-key TID for `repo_id`, derived **deterministically**
@@ -300,11 +358,175 @@ impl PdsRecordStore {
     fn build_tree(records: &BTreeMap<(String, Tid), ModelRecord>) -> Node {
         let keyed: BTreeMap<String, hyprstream_pds::cid::Cid> = records
             .iter()
-            .map(|((collection, tid), rec)| {
-                (format!("{collection}/{}", tid.encode()), rec.cid())
-            })
+            .map(|((collection, tid), rec)| (format!("{collection}/{}", tid.encode()), rec.cid()))
             .collect();
         Node::from_keyed_records(&keyed)
+    }
+}
+
+fn encode_at9p_state(state: &AcceptedAt9pState) -> AnyResult<Vec<u8>> {
+    let (kind, head) = match state.head() {
+        AcceptedAt9pHead::Genesis(capsule) => (0u8, capsule.to_dag_cbor()?),
+        AcceptedAt9pHead::Update(record) => (1u8, record.to_dag_cbor()?),
+    };
+    let head_len = u32::try_from(head.len()).context("accepted at9p head exceeds u32")?;
+    let mut out = Vec::with_capacity(AT9P_STATE_HEADER_LEN + head.len());
+    out.extend_from_slice(AT9P_STATE_MAGIC);
+    out.push(kind);
+    out.extend_from_slice(&state.epoch.to_be_bytes());
+    out.extend_from_slice(&state.head_digest);
+    out.push(u8::from(state.terminal));
+    out.extend_from_slice(&head_len.to_be_bytes());
+    out.extend_from_slice(&head);
+    Ok(out)
+}
+
+fn decode_at9p_state(subject_cid512: &str, bytes: &[u8]) -> AnyResult<AcceptedAt9pState> {
+    anyhow::ensure!(
+        bytes.len() >= AT9P_STATE_HEADER_LEN,
+        "accepted at9p state is truncated"
+    );
+    anyhow::ensure!(
+        bytes.starts_with(AT9P_STATE_MAGIC),
+        "accepted at9p state has bad version"
+    );
+    let kind = *bytes
+        .get(8)
+        .ok_or_else(|| anyhow!("accepted at9p state missing kind"))?;
+    let epoch = u64::from_be_bytes(
+        bytes
+            .get(9..17)
+            .ok_or_else(|| anyhow!("accepted at9p state missing epoch"))?
+            .try_into()?,
+    );
+    let digest: [u8; 64] = bytes
+        .get(17..81)
+        .ok_or_else(|| anyhow!("accepted at9p state missing digest"))?
+        .try_into()?;
+    let terminal = match bytes
+        .get(81)
+        .ok_or_else(|| anyhow!("accepted at9p state missing terminal flag"))?
+    {
+        0 => false,
+        1 => true,
+        _ => bail!("accepted at9p state has invalid terminal flag"),
+    };
+    let head_len = u32::from_be_bytes(
+        bytes
+            .get(82..86)
+            .ok_or_else(|| anyhow!("accepted at9p state missing length"))?
+            .try_into()?,
+    ) as usize;
+    anyhow::ensure!(
+        bytes.len() == AT9P_STATE_HEADER_LEN + head_len,
+        "accepted at9p state length mismatch"
+    );
+    let head = bytes
+        .get(AT9P_STATE_HEADER_LEN..)
+        .ok_or_else(|| anyhow!("accepted at9p state missing head"))?;
+    let state = match kind {
+        0 => AcceptedAt9pState::from_persisted_genesis(head)?,
+        1 => AcceptedAt9pState::from_persisted_update(head)?,
+        _ => bail!("accepted at9p state has unknown head kind {kind}"),
+    };
+    anyhow::ensure!(
+        state.subject_cid512 == subject_cid512,
+        "accepted at9p state subject mismatch"
+    );
+    anyhow::ensure!(
+        state.epoch == epoch,
+        "accepted at9p state epoch/body mismatch"
+    );
+    anyhow::ensure!(
+        state.head_digest == digest,
+        "accepted at9p state digest/body mismatch"
+    );
+    anyhow::ensure!(
+        state.terminal == terminal,
+        "accepted at9p state terminal/body mismatch"
+    );
+    Ok(state)
+}
+
+#[derive(Clone)]
+struct RocksAt9pStateStore {
+    store: Arc<PdsRecordStore>,
+}
+
+impl WatermarkStore for RocksAt9pStateStore {
+    fn get(&self, subject_cid512: &str) -> AnyResult<Option<AcceptedAt9pState>> {
+        self.store.load_at9p_state(subject_cid512)
+    }
+
+    fn put(&self, state: &AcceptedAt9pState) -> AnyResult<()> {
+        self.store.put_at9p_state(state)
+    }
+}
+
+/// Sole production ownership boundary for accepted current `did:at9p` state.
+/// It GATE-seeds genesis, reloads predecessors exclusively from durable state,
+/// calls the duplicity guard for every successor, and atomically commits the
+/// complete accepted head. It does not dial, select reach, or admit carriers.
+pub struct At9pStateIngest {
+    guard: DuplicityGuard<RocksAt9pStateStore, WalDuplicityAlarmSink>,
+}
+
+impl At9pStateIngest {
+    pub fn open(
+        store: Arc<PdsRecordStore>,
+        alarm_path: &Path,
+        ed_sk: ed25519_dalek::SigningKey,
+        pq_sk: hyprstream_rpc::crypto::pq::MlDsaSigningKey,
+    ) -> AnyResult<Self> {
+        let guard = DuplicityGuard::with_durable_alarm(
+            RocksAt9pStateStore { store },
+            alarm_path,
+            ed_sk,
+            pq_sk,
+        )?;
+        Ok(Self { guard })
+    }
+
+    pub fn ingest_genesis(&self, did: &str, capsule_bytes: &[u8]) -> AnyResult<AcceptedAt9pState> {
+        let verified = verify_did_at9p(did, capsule_bytes)
+            .map_err(|e| anyhow!("did:at9p genesis ingest rejected: {e}"))?;
+        self.guard.seed_genesis(&verified)?;
+        self.accepted_state(did, None)
+    }
+
+    pub fn ingest_successor(
+        &self,
+        did: &str,
+        update_bytes: &[u8],
+        now: &str,
+    ) -> AnyResult<AcceptedAt9pState> {
+        let subject = did
+            .strip_prefix(DID_AT9P_PREFIX)
+            .ok_or_else(|| anyhow!("identifier is not did:at9p: {did:?}"))?;
+        let candidate = hyprstream_pds::at9p::UpdateRecord::from_dag_cbor(update_bytes)?;
+        anyhow::ensure!(
+            candidate.subject_cid512 == subject,
+            "update subject does not match ingest DID"
+        );
+        self.guard.admit_successor(&candidate, now)?;
+        self.accepted_state(did, Some(now))
+    }
+
+    /// Read the complete accepted snapshot. Supplying `now` enforces successor
+    /// expiry before the state is exposed to a consumer.
+    pub fn accepted_state(&self, did: &str, now: Option<&str>) -> AnyResult<AcceptedAt9pState> {
+        let subject = did
+            .strip_prefix(DID_AT9P_PREFIX)
+            .ok_or_else(|| anyhow!("identifier is not did:at9p: {did:?}"))?;
+        let state = self
+            .guard
+            .accepted_state(subject)?
+            .ok_or_else(|| anyhow!("no accepted did:at9p state for {did}"))?;
+        anyhow::ensure!(state.did == did, "accepted at9p state DID mismatch");
+        if let Some(now) = now {
+            state.ensure_fresh(now)?;
+        }
+        Ok(state)
     }
 }
 
@@ -351,6 +573,7 @@ fn harden_store_dir(path: &Path) {
 /// The resolver never sees the key.
 pub struct PdsPublisher {
     store: Arc<PdsRecordStore>,
+    at9p_state: Option<At9pStateIngest>,
     /// This node's own `did:key` identity — the `repo` at-uri authority for
     /// every record this node publishes (single-node, self-hosted PDS; a
     /// per-account DID scheme is out of scope for #910a).
@@ -380,10 +603,53 @@ impl PdsPublisher {
     ) -> Self {
         Self {
             store,
+            at9p_state: None,
             did,
             signing_key,
             publish_lock: parking_lot::Mutex::new(()),
         }
+    }
+
+    /// Install the daemon-owned accepted-state ingest boundary. Production
+    /// construction always calls this; the optional form keeps isolated PDS
+    /// pointer-store tests free of unrelated audit-key setup.
+    pub fn with_at9p_state_ingest(mut self, ingest: At9pStateIngest) -> Self {
+        self.at9p_state = Some(ingest);
+        self
+    }
+
+    pub fn ingest_at9p_genesis(
+        &self,
+        did: &str,
+        capsule_bytes: &[u8],
+    ) -> AnyResult<AcceptedAt9pState> {
+        self.at9p_state
+            .as_ref()
+            .ok_or_else(|| anyhow!("accepted did:at9p ingest is not configured"))?
+            .ingest_genesis(did, capsule_bytes)
+    }
+
+    pub fn ingest_at9p_successor(
+        &self,
+        did: &str,
+        update_bytes: &[u8],
+        now: &str,
+    ) -> AnyResult<AcceptedAt9pState> {
+        self.at9p_state
+            .as_ref()
+            .ok_or_else(|| anyhow!("accepted did:at9p ingest is not configured"))?
+            .ingest_successor(did, update_bytes, now)
+    }
+
+    pub fn accepted_at9p_state(
+        &self,
+        did: &str,
+        now: Option<&str>,
+    ) -> AnyResult<AcceptedAt9pState> {
+        self.at9p_state
+            .as_ref()
+            .ok_or_else(|| anyhow!("accepted did:at9p ingest is not configured"))?
+            .accepted_state(did, now)
     }
 
     /// Publish (or advance) the `ai.hyprstream.model` record for `repo_id`,
@@ -556,14 +822,17 @@ fn next_rev(prev: Tid) -> Tid {
 /// there. Once that lands, swap this call for the real encoder; nothing else
 /// in the publish path needs to change.
 fn git_oid_to_cid_string(oid_hex: &str) -> AnyResult<String> {
-    let oid_bytes = hex::decode(oid_hex).with_context(|| format!("git OID {oid_hex:?} is not valid hex"))?;
+    let oid_bytes =
+        hex::decode(oid_hex).with_context(|| format!("git OID {oid_hex:?} is not valid hex"))?;
     Ok(hyprstream_pds::cid::Cid::from_raw(&oid_bytes).encode())
 }
 
 /// The current UTC time in the atproto `datetime` lexicon format
 /// (ISO-8601, millisecond precision, trailing `Z`).
 fn atproto_datetime_now() -> String {
-    chrono::Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string()
+    chrono::Utc::now()
+        .format("%Y-%m-%dT%H:%M:%S%.3fZ")
+        .to_string()
 }
 
 /// `RecordResolver` over a [`PdsRecordStore`]. Builds CAR proofs via the
@@ -577,6 +846,14 @@ pub struct PdsRecordResolver {
 impl PdsRecordResolver {
     pub fn new(store: Arc<PdsRecordStore>) -> Self {
         Self { store }
+    }
+
+    pub fn accepted_at9p_state(
+        &self,
+        did: &str,
+        now: &str,
+    ) -> AnyResult<Option<AcceptedAt9pState>> {
+        self.store.accepted_at9p_state(did, Some(now))
     }
 }
 
@@ -610,7 +887,12 @@ fn proof_car(
         .proof(collection, &tid)
         .ok_or_else(|| anyhow!("record present but no MST proof — store inconsistent"))?;
     let (_root_data, node_blocks) = tree.to_node_data_with_blocks();
-    Ok(build_record_proof_car(&repo.commit, &proof, &node_blocks, record))
+    Ok(build_record_proof_car(
+        &repo.commit,
+        &proof,
+        &node_blocks,
+        record,
+    ))
 }
 
 #[async_trait(?Send)]
@@ -673,7 +955,12 @@ impl RecordResolver for PdsRecordResolver {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic
+)]
 mod pds_store_tests {
     use super::*;
     use hyprstream_pds::car::{parse_car_v1, verify_record_proof};
@@ -743,7 +1030,10 @@ mod pds_store_tests {
 
         // Reconstruct the proof the same way the resolver does (store holds no
         // key), and run the offline verifier against the published key.
-        let repo = store.load_repo(DID).expect("load ok").expect("repo present");
+        let repo = store
+            .load_repo(DID)
+            .expect("load ok")
+            .expect("repo present");
         let tid = PdsRecordStore::tid_for_repo("repo-a");
         let record = repo
             .records
@@ -769,7 +1059,9 @@ mod pds_store_tests {
         let first = store.load_repo(DID).expect("load").expect("repo").commit;
         assert!(first.prev.is_none(), "genesis commit has no prev");
 
-        publisher.publish("repo-a", SAMPLE_OID_2).expect("publish 2");
+        publisher
+            .publish("repo-a", SAMPLE_OID_2)
+            .expect("publish 2");
         let second = store.load_repo(DID).expect("load").expect("repo").commit;
         assert_eq!(
             second.prev,
@@ -846,10 +1138,15 @@ mod pds_store_tests {
             .expect("resolve ok")
             .expect("record present");
         assert_eq!(got.uri, format!("at://{DID}/{collection}/{}", tid.encode()));
-        commit_from_car(&got.car).verify(vk).expect("commit verifies");
+        commit_from_car(&got.car)
+            .verify(vk)
+            .expect("commit verifies");
 
         // Full offline proof, reconstructed the way the resolver does it.
-        let repo = store.load_repo(DID).expect("load ok").expect("repo present");
+        let repo = store
+            .load_repo(DID)
+            .expect("load ok")
+            .expect("repo present");
         let record = repo
             .records
             .get(&(collection.to_owned(), tid))
@@ -876,7 +1173,9 @@ mod pds_store_tests {
 
         let store = Arc::new(PdsRecordStore::open(dir.path()).expect("open rw"));
         let publisher = PdsPublisher::new(Arc::clone(&store), DID.to_owned(), sk);
-        publisher.publish("repo-a", SAMPLE_OID).expect("publish model");
+        publisher
+            .publish("repo-a", SAMPLE_OID)
+            .expect("publish model");
         publisher
             .publish_record(NAME_COLLECTION, "name-a", SAMPLE_OID_2)
             .expect("publish name");
@@ -942,7 +1241,12 @@ mod pds_store_tests {
 
         // Each ledger collection resolves with a valid keyless proof.
         resolve_and_verify(&store, &vk, alloc_ns::COLLECTION_NSID, &alloc.grant);
-        resolve_and_verify(&store, &vk, receipt_ns::COLLECTION_NSID, &receipt.transfer_id);
+        resolve_and_verify(
+            &store,
+            &vk,
+            receipt_ns::COLLECTION_NSID,
+            &receipt.transfer_id,
+        );
 
         // The published pointer's currentOid is the ledger record's content CID —
         // the record is content-addressed, so its bytes are recoverable/verifiable.
@@ -970,7 +1274,9 @@ mod pds_store_tests {
 
         let store = Arc::new(PdsRecordStore::open(dir.path()).expect("open rw"));
         let publisher = PdsPublisher::new(Arc::clone(&store), DID.to_owned(), sk);
-        publisher.publish("repo-a", SAMPLE_OID).expect("publish model");
+        publisher
+            .publish("repo-a", SAMPLE_OID)
+            .expect("publish model");
         let tid_a = PdsRecordStore::tid_for_repo("repo-a");
         let record_a_before = store
             .load_repo(DID)
@@ -993,7 +1299,10 @@ mod pds_store_tests {
             .get(&(COLLECTION_NSID.to_owned(), tid_a))
             .cloned()
             .expect("record a still present");
-        assert_eq!(record_a_before, record_a_after, "B write must not touch A's record");
+        assert_eq!(
+            record_a_before, record_a_after,
+            "B write must not touch A's record"
+        );
         resolve_and_verify(&store, &vk, COLLECTION_NSID, "repo-a");
         resolve_and_verify(&store, &vk, NAME_COLLECTION, "name-a");
 
@@ -1003,7 +1312,10 @@ mod pds_store_tests {
         let resolver = PdsRecordResolver::new(Arc::clone(&store));
         let cross = block_on(resolver.resolve_record(DID, COLLECTION_NSID, &tid_name.encode()))
             .expect("resolve ok");
-        assert!(cross.is_none(), "collections must not alias onto each other");
+        assert!(
+            cross.is_none(),
+            "collections must not alias onto each other"
+        );
     }
 
     #[test]
@@ -1119,5 +1431,252 @@ mod pds_store_tests {
         assert_eq!(first, second, "the same repo must always get the same rkey");
         let other = PdsRecordStore::tid_for_repo("repo-b");
         assert_ne!(first, other, "distinct repos must not alias onto one rkey");
+    }
+
+    struct At9pSigner {
+        ed: ed25519_dalek::SigningKey,
+        pq: hyprstream_rpc::crypto::pq::MlDsaSigningKey,
+        pair: hyprstream_pds::at9p::HybridKeyPair,
+    }
+
+    fn at9p_signer(tag: u8) -> At9pSigner {
+        use hyprstream_rpc::crypto::pq::{ml_dsa_generate_keypair, ml_dsa_vk_bytes};
+        let mut seed = [0u8; 32];
+        seed[0] = tag;
+        seed[31] = tag.wrapping_add(17);
+        let ed = ed25519_dalek::SigningKey::from_bytes(&seed);
+        let (pq, pq_vk) = ml_dsa_generate_keypair();
+        let pair = hyprstream_pds::at9p::HybridKeyPair::new(
+            ed.verifying_key().to_bytes().to_vec(),
+            ml_dsa_vk_bytes(&pq_vk),
+        )
+        .expect("hybrid pair");
+        At9pSigner { ed, pq, pair }
+    }
+
+    fn at9p_body(
+        current: &At9pSigner,
+        next: &[&At9pSigner],
+        service_tag: &str,
+    ) -> hyprstream_pds::at9p::CapsuleBody {
+        use hyprstream_pds::at9p::{
+            CapsuleBody, ServiceEndpoint, ServiceEntry, ServiceType, Transport,
+        };
+        let endpoint = ServiceEndpoint::new(Transport::Iroh, format!("iroh://{service_tag}"))
+            .expect("endpoint");
+        let service =
+            ServiceEntry::new("#ns", ServiceType::NinePExport, endpoint).expect("service");
+        let mut body =
+            CapsuleBody::new(vec![current.pair.clone()], vec![service]).expect("capsule body");
+        body.next_key_commitments = next
+            .iter()
+            .map(|signer| signer.pair.commitment_digest())
+            .collect();
+        body
+    }
+
+    fn audit_keys() -> (
+        ed25519_dalek::SigningKey,
+        hyprstream_rpc::crypto::pq::MlDsaSigningKey,
+    ) {
+        (
+            ed25519_dalek::SigningKey::from_bytes(&[91u8; 32]),
+            hyprstream_rpc::crypto::pq::ml_dsa_sk_from_seed(&[92u8; 32]),
+        )
+    }
+
+    fn production_at9p_publisher(store: Arc<PdsRecordStore>, alarm: &Path) -> PdsPublisher {
+        let (audit_ed, audit_pq) = audit_keys();
+        let ingest = At9pStateIngest::open(Arc::clone(&store), alarm, audit_ed, audit_pq)
+            .expect("open accepted-state owner");
+        PdsPublisher::new(
+            store,
+            DID.to_owned(),
+            SigningKey::random(&mut rand::rngs::OsRng),
+        )
+        .with_at9p_state_ingest(ingest)
+    }
+
+    #[test]
+    fn production_at9p_ingest_rotation_forks_expiry_terminal_and_restart() {
+        use hyprstream_pds::at9p_sign::{sign_capsule, sign_update_record};
+
+        const NOW: &str = "2026-07-16T12:00:00Z";
+        const FUTURE: &str = "2099-01-01T00:00:00Z";
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("pds");
+        let alarm_path = dir.path().join("at9p-alarm.wal");
+        let (genesis_signer, n1, n2, n3) = (
+            at9p_signer(1),
+            at9p_signer(2),
+            at9p_signer(3),
+            at9p_signer(4),
+        );
+        let genesis = sign_capsule(
+            at9p_body(&genesis_signer, &[&n1], "genesis"),
+            &genesis_signer.ed,
+            &genesis_signer.pq,
+        )
+        .expect("signed genesis");
+        let genesis_bytes = genesis.to_dag_cbor().expect("genesis bytes");
+        let did = format!("{DID_AT9P_PREFIX}{}", genesis.cid512().expect("cid"));
+
+        let u1 = sign_update_record(
+            genesis.cid512().expect("cid"),
+            1,
+            hyprstream_pds::at9p::h512(&genesis_bytes),
+            at9p_body(&n1, &[&n2], "rotated"),
+            FUTURE.to_owned(),
+            &n1.ed,
+            &n1.pq,
+        )
+        .expect("u1");
+
+        {
+            let store = Arc::new(PdsRecordStore::open(&db_path).expect("open rw"));
+            let publisher = production_at9p_publisher(store, &alarm_path);
+            let seeded = publisher
+                .ingest_at9p_genesis(&did, &genesis_bytes)
+                .expect("GATE seed");
+            assert_eq!(seeded.epoch, 0);
+            assert_eq!(seeded.current.subject_keys[0], genesis_signer.pair);
+
+            let accepted = publisher
+                .ingest_at9p_successor(&did, &u1.to_dag_cbor().expect("u1 bytes"), NOW)
+                .expect("accept rotation");
+            assert_eq!(accepted.epoch, 1);
+            assert_eq!(accepted.current.subject_keys[0], n1.pair);
+            assert_ne!(accepted.current.subject_keys[0], genesis_signer.pair);
+            assert_eq!(
+                accepted.current.services[0].endpoint.address,
+                "iroh://rotated"
+            );
+
+            // Same-epoch, separately valid fork: fail closed and durably alarm.
+            let fork = sign_update_record(
+                genesis.cid512().expect("cid"),
+                1,
+                hyprstream_pds::at9p::h512(&genesis_bytes),
+                at9p_body(&n1, &[&n2], "same-epoch-fork"),
+                FUTURE.to_owned(),
+                &n1.ed,
+                &n1.pq,
+            )
+            .expect("fork");
+            assert!(publisher
+                .ingest_at9p_successor(&did, &fork.to_dag_cbor().expect("fork bytes"), NOW)
+                .is_err());
+            let alarm_after_same = std::fs::metadata(&alarm_path).expect("alarm WAL").len();
+
+            // A higher record whose link is not the durable head is never chosen.
+            let off_head = sign_update_record(
+                genesis.cid512().expect("cid"),
+                2,
+                [44u8; 64],
+                at9p_body(&n2, &[&n3], "off-head"),
+                FUTURE.to_owned(),
+                &n2.ed,
+                &n2.pq,
+            )
+            .expect("off-head");
+            assert!(publisher
+                .ingest_at9p_successor(&did, &off_head.to_dag_cbor().expect("bytes"), NOW)
+                .is_err());
+            assert!(std::fs::metadata(&alarm_path).expect("alarm WAL").len() > alarm_after_same);
+
+            // Expiry rejects without changing the accepted head.
+            let expired = sign_update_record(
+                genesis.cid512().expect("cid"),
+                2,
+                accepted.head_digest,
+                at9p_body(&n2, &[&n3], "expired"),
+                "2026-01-01T00:00:00Z".to_owned(),
+                &n2.ed,
+                &n2.pq,
+            )
+            .expect("expired");
+            assert!(publisher
+                .ingest_at9p_successor(&did, &expired.to_dag_cbor().expect("bytes"), NOW)
+                .is_err());
+            assert_eq!(
+                publisher
+                    .accepted_at9p_state(&did, Some(NOW))
+                    .expect("state")
+                    .epoch,
+                1
+            );
+
+            // A valid final rotation persists terminal state; later successors
+            // fail closed before any genesis/key fallback.
+            let terminal = sign_update_record(
+                genesis.cid512().expect("cid"),
+                2,
+                accepted.head_digest,
+                at9p_body(&n2, &[], "terminal"),
+                FUTURE.to_owned(),
+                &n2.ed,
+                &n2.pq,
+            )
+            .expect("terminal");
+            let terminal_state = publisher
+                .ingest_at9p_successor(&did, &terminal.to_dag_cbor().expect("bytes"), NOW)
+                .expect("accept terminal");
+            assert!(terminal_state.terminal);
+            let after_terminal = sign_update_record(
+                genesis.cid512().expect("cid"),
+                3,
+                terminal_state.head_digest,
+                at9p_body(&n3, &[&n3], "forbidden"),
+                FUTURE.to_owned(),
+                &n3.ed,
+                &n3.pq,
+            )
+            .expect("syntactically genuine successor");
+            assert!(publisher
+                .ingest_at9p_successor(&did, &after_terminal.to_dag_cbor().expect("bytes"), NOW)
+                .is_err());
+        }
+
+        // Reopen verifies the signed alarm WAL and recovers the complete atomic
+        // state. Re-seed and rollback remain refused after restart.
+        let store = Arc::new(PdsRecordStore::open(&db_path).expect("reopen rw"));
+        let publisher = production_at9p_publisher(store, &alarm_path);
+        let recovered = publisher
+            .accepted_at9p_state(&did, Some(NOW))
+            .expect("recover state");
+        assert_eq!(recovered.epoch, 2);
+        assert!(recovered.terminal);
+        assert_eq!(recovered.current.subject_keys[0], n2.pair);
+        assert!(publisher.ingest_at9p_genesis(&did, &genesis_bytes).is_err());
+        assert!(publisher
+            .ingest_at9p_successor(&did, &u1.to_dag_cbor().expect("u1 bytes"), NOW)
+            .is_err());
+    }
+
+    #[test]
+    fn accepted_at9p_read_rejects_watermark_body_mutation() {
+        use hyprstream_pds::at9p_sign::sign_capsule;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(PdsRecordStore::open(dir.path()).expect("open rw"));
+        let signer = at9p_signer(11);
+        let capsule = sign_capsule(at9p_body(&signer, &[], "immutable"), &signer.ed, &signer.pq)
+            .expect("capsule");
+        let bytes = capsule.to_dag_cbor().expect("bytes");
+        let cid = capsule.cid512().expect("cid");
+        let did = format!("{DID_AT9P_PREFIX}{cid}");
+        let publisher = production_at9p_publisher(Arc::clone(&store), &dir.path().join("alarm"));
+        publisher.ingest_at9p_genesis(&did, &bytes).expect("seed");
+
+        let RecordBacking::ReadWrite(db) = &store.backing else {
+            panic!("writer")
+        };
+        let key = at9p_state_key(&cid);
+        let mut encoded = db.get(&key).expect("get").expect("stored state");
+        encoded[16] ^= 1; // mutate persisted epoch without changing the head body
+        db.put(&key, encoded).expect("inject mutation");
+        assert!(
+            publisher.accepted_at9p_state(&did, None).is_err(),
+            "a partial watermark/body representation must fail closed"
+        );
     }
 }

--- a/crates/hyprstream/src/services/discovery.rs
+++ b/crates/hyprstream/src/services/discovery.rs
@@ -15,8 +15,10 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, bail, Context as _, Result as AnyResult};
 use hyprstream_discovery::{RecordCarData, RecordResolver};
+use hyprstream_pds::at9p::h512;
 use hyprstream_pds::at9p_duplicity::{
-    AcceptedAt9pHead, AcceptedAt9pState, DuplicityGuard, WalDuplicityAlarmSink, WatermarkStore,
+    AcceptedAt9pHead, AcceptedAt9pState, ConditionalAdvance, DuplicityGuard,
+    WalDuplicityAlarmSink, Watermark, WatermarkStore,
 };
 use hyprstream_pds::at9p_gate::{verify_did_at9p, DID_AT9P_PREFIX};
 use hyprstream_pds::car::build_record_proof_car;
@@ -121,6 +123,9 @@ fn commit_key(did: &str) -> Vec<u8> {
 fn at9p_state_key(subject_cid512: &str) -> Vec<u8> {
     format!("at9p-state\0{subject_cid512}").into_bytes()
 }
+fn at9p_checkpoint_key(subject_cid512: &str) -> Vec<u8> {
+    format!("at9p-checkpoint\0{subject_cid512}").into_bytes()
+}
 
 const AT9P_STATE_MAGIC: &[u8; 8] = b"AT9PST02";
 const AT9P_STATE_HEADER_LEN: usize = 8 + 1 + 8 + 64 + 1 + 4;
@@ -131,6 +136,10 @@ const AT9P_ACCEPTANCE_PREFIX_LEN: usize =
     AT9P_ACCEPTANCE_MAGIC.len() + ED25519_KEY_LEN + ED25519_SIGNATURE_LEN;
 const AT9P_ACCEPTANCE_KEY_AAD: &[u8] = b"hyprstream-at9p-acceptance-key/1";
 const AT9P_ACCEPTANCE_STATE_AAD: &[u8] = b"hyprstream-at9p-accepted-state/1";
+const AT9P_CHECKPOINT_MAGIC: &[u8; 8] = b"AT9PCK01";
+const AT9P_CHECKPOINT_PAYLOAD_LEN: usize = 8 + 8 + 64 + 1 + 64;
+const AT9P_CHECKPOINT_LEN: usize = AT9P_CHECKPOINT_PAYLOAD_LEN + ED25519_SIGNATURE_LEN;
+const AT9P_CHECKPOINT_AAD: &[u8] = b"hyprstream-at9p-monotonic-checkpoint/1";
 
 /// Split a full record key back into `(collection, tid)`, given the `did` it
 /// was built for.
@@ -174,6 +183,7 @@ pub struct PdsRecordStore {
     /// daemon-authenticated accepted-state envelopes. This is verification
     /// material only; the resolver still holds no signing key.
     at9p_acceptance_identity: Option<ed25519_dalek::VerifyingKey>,
+    at9p_advance_lock: parking_lot::Mutex<()>,
 }
 
 enum RecordBacking {
@@ -200,6 +210,7 @@ impl PdsRecordStore {
         Ok(Self {
             backing: RecordBacking::ReadWrite(db),
             at9p_acceptance_identity: None,
+            at9p_advance_lock: parking_lot::Mutex::new(()),
         })
     }
 
@@ -214,6 +225,7 @@ impl PdsRecordStore {
         Ok(Self {
             backing: RecordBacking::ReadOnly(path.to_path_buf()),
             at9p_acceptance_identity: None,
+            at9p_advance_lock: parking_lot::Mutex::new(()),
         })
     }
 
@@ -251,15 +263,13 @@ impl PdsRecordStore {
         subject_cid512: &str,
         acceptance_identity: &ed25519_dalek::VerifyingKey,
     ) -> AnyResult<Option<AcceptedAt9pState>> {
-        let bytes = match &self.backing {
-            RecordBacking::ReadWrite(db) => db.get(at9p_state_key(subject_cid512))?,
+        match &self.backing {
+            RecordBacking::ReadWrite(db) => load_at9p_state_from_db(db, subject_cid512, acceptance_identity),
             RecordBacking::ReadOnly(path) => {
                 let db = rocksdb::DB::open_for_read_only(&readonly_opts(), path, false)?;
-                db.get(at9p_state_key(subject_cid512))?
+                load_at9p_state_from_db(&db, subject_cid512, acceptance_identity)
             }
-        };
-        let Some(bytes) = bytes else { return Ok(None) };
-        decode_at9p_state(subject_cid512, &bytes, acceptance_identity).map(Some)
+        }
     }
 
     /// Typed accepted-current state read path for resolver/admission consumers.
@@ -287,20 +297,33 @@ impl PdsRecordStore {
         Ok(Some(state))
     }
 
-    fn put_at9p_state(
+    fn conditional_advance_at9p_state(
         &self,
+        expected: Option<Watermark>,
         state: &AcceptedAt9pState,
         acceptance_identity: &ed25519_dalek::SigningKey,
         audit_key: &ed25519_dalek::SigningKey,
-    ) -> AnyResult<()> {
+    ) -> AnyResult<ConditionalAdvance> {
         let RecordBacking::ReadWrite(db) = &self.backing else {
             bail!("accepted did:at9p state write attempted on a read-only PDS store");
         };
+        let _advance = self.at9p_advance_lock.lock();
+        let current = load_at9p_state_from_db(db, &state.subject_cid512, &acceptance_identity.verifying_key())?;
+        if current.as_ref().map(AcceptedAt9pState::watermark) != expected {
+            return current.map_or_else(
+                || bail!("conditional accepted-state advance expected a durable head, but none exists"),
+                |current| Ok(ConditionalAdvance::Conflict(Box::new(current))),
+            );
+        }
         let encoded = encode_at9p_state(state, acceptance_identity, audit_key)?;
+        let checkpoint = encode_at9p_checkpoint(state, &encoded, acceptance_identity)?;
+        let mut batch = rocksdb::WriteBatch::default();
+        batch.put(at9p_state_key(&state.subject_cid512), encoded);
+        batch.put(at9p_checkpoint_key(&state.subject_cid512), checkpoint);
         let mut options = rocksdb::WriteOptions::default();
         options.set_sync(true);
-        db.put_opt(at9p_state_key(&state.subject_cid512), encoded, &options)
-            .context("synchronous accepted did:at9p state commit failed")
+        db.write_opt(batch, &options).context("synchronous accepted did:at9p state+checkpoint commit failed")?;
+        Ok(ConditionalAdvance::Committed)
     }
 
     /// The stable record-key TID for `repo_id`, derived **deterministically**
@@ -401,6 +424,68 @@ fn acceptance_message(domain: &[u8], payload: &[u8]) -> Vec<u8> {
     message.extend_from_slice(domain);
     message.extend_from_slice(payload);
     message
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct At9pCheckpoint { watermark: Watermark, envelope_digest: [u8; 64] }
+
+fn checkpoint_message(subject: &str, payload: &[u8]) -> AnyResult<Vec<u8>> {
+    let len = u32::try_from(subject.len()).context("at9p subject exceeds u32")?;
+    let mut out = Vec::with_capacity(AT9P_CHECKPOINT_AAD.len() + 4 + subject.len() + payload.len());
+    out.extend_from_slice(AT9P_CHECKPOINT_AAD);
+    out.extend_from_slice(&len.to_be_bytes());
+    out.extend_from_slice(subject.as_bytes());
+    out.extend_from_slice(payload);
+    Ok(out)
+}
+
+fn encode_at9p_checkpoint(state: &AcceptedAt9pState, envelope: &[u8], identity: &ed25519_dalek::SigningKey) -> AnyResult<Vec<u8>> {
+    use ed25519_dalek::Signer as _;
+    let mut payload = Vec::with_capacity(AT9P_CHECKPOINT_LEN);
+    payload.extend_from_slice(AT9P_CHECKPOINT_MAGIC);
+    payload.extend_from_slice(&state.epoch.to_be_bytes());
+    payload.extend_from_slice(&state.head_digest);
+    payload.push(u8::from(state.terminal));
+    payload.extend_from_slice(&h512(envelope));
+    let sig = identity.sign(&checkpoint_message(&state.subject_cid512, &payload)?);
+    payload.extend_from_slice(&sig.to_bytes());
+    Ok(payload)
+}
+
+fn decode_at9p_checkpoint(subject: &str, bytes: &[u8], identity: &ed25519_dalek::VerifyingKey) -> AnyResult<At9pCheckpoint> {
+    anyhow::ensure!(bytes.len() == AT9P_CHECKPOINT_LEN, "accepted at9p checkpoint length mismatch");
+    let payload = bytes.get(..AT9P_CHECKPOINT_PAYLOAD_LEN)
+        .ok_or_else(|| anyhow!("accepted at9p checkpoint payload missing"))?;
+    anyhow::ensure!(payload.starts_with(AT9P_CHECKPOINT_MAGIC), "accepted at9p checkpoint has bad version");
+    let sig = ed25519_dalek::Signature::from_bytes(bytes.get(AT9P_CHECKPOINT_PAYLOAD_LEN..)
+        .ok_or_else(|| anyhow!("accepted at9p checkpoint signature missing"))?.try_into()?);
+    identity.verify_strict(&checkpoint_message(subject, payload)?, &sig)
+        .context("accepted at9p monotonic checkpoint signature rejected")?;
+    let epoch = u64::from_be_bytes(payload.get(8..16).ok_or_else(|| anyhow!("checkpoint epoch missing"))?.try_into()?);
+    let record_digest = payload.get(16..80).ok_or_else(|| anyhow!("checkpoint digest missing"))?.try_into()?;
+    let terminal = match payload.get(80) { Some(0) => false, Some(1) => true, _ => bail!("invalid checkpoint terminal flag") };
+    Ok(At9pCheckpoint {
+        watermark: Watermark { epoch, record_digest, terminal },
+        envelope_digest: payload.get(81..145).ok_or_else(|| anyhow!("checkpoint envelope digest missing"))?.try_into()?,
+    })
+}
+
+fn load_at9p_state_from_db(db: &rocksdb::DB, subject: &str, identity: &ed25519_dalek::VerifyingKey) -> AnyResult<Option<AcceptedAt9pState>> {
+    let snapshot = db.snapshot();
+    let envelope = snapshot.get(at9p_state_key(subject))?;
+    let checkpoint = snapshot.get(at9p_checkpoint_key(subject))?;
+    match (envelope, checkpoint) {
+        (None, None) => Ok(None),
+        (Some(_), None) => bail!("accepted at9p state exists without its monotonic checkpoint"),
+        (None, Some(_)) => bail!("accepted at9p checkpoint exists without its state envelope"),
+        (Some(envelope), Some(checkpoint)) => {
+            let state = decode_at9p_state(subject, &envelope, identity)?;
+            let checkpoint = decode_at9p_checkpoint(subject, &checkpoint, identity)?;
+            anyhow::ensure!(checkpoint.watermark == state.watermark(), "accepted at9p checkpoint/body watermark mismatch");
+            anyhow::ensure!(checkpoint.envelope_digest == h512(&envelope), "accepted at9p checkpoint/state envelope mismatch");
+            Ok(Some(state))
+        }
+    }
 }
 
 fn encode_at9p_state_body(state: &AcceptedAt9pState) -> AnyResult<Vec<u8>> {
@@ -578,9 +663,8 @@ impl WatermarkStore for RocksAt9pStateStore {
             .load_at9p_state(subject_cid512, &self.acceptance_identity.verifying_key())
     }
 
-    fn put(&self, state: &AcceptedAt9pState) -> AnyResult<()> {
-        self.store
-            .put_at9p_state(state, &self.acceptance_identity, &self.audit_key)
+    fn conditional_advance(&self, expected: Option<Watermark>, state: &AcceptedAt9pState) -> AnyResult<ConditionalAdvance> {
+        self.store.conditional_advance_at9p_state(expected, state, &self.acceptance_identity, &self.audit_key)
     }
 }
 
@@ -1631,6 +1715,92 @@ mod pds_store_tests {
     }
 
     #[test]
+    fn independent_production_guards_share_rocks_cas() {
+        use hyprstream_pds::at9p_duplicity::{Admission, DuplicityGuard};
+        use hyprstream_pds::at9p_sign::{sign_capsule, sign_update_record};
+        use std::sync::Barrier;
+
+        const NOW: &str = "2026-07-16T12:00:00Z";
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("pds");
+        let store = Arc::new(PdsRecordStore::open(&db_path).expect("open"));
+        let (g, n1, n2) = (at9p_signer(41), at9p_signer(42), at9p_signer(43));
+        let genesis = sign_capsule(at9p_body(&g, &[&n1], "genesis"), &g.ed, &g.pq)
+            .expect("genesis");
+        let genesis_bytes = genesis.to_dag_cbor().expect("genesis bytes");
+        let cid = genesis.cid512().expect("cid");
+        let did = format!("{DID_AT9P_PREFIX}{cid}");
+        let verified = verify_did_at9p(&did, &genesis_bytes).expect("verified genesis");
+        let acceptance_identity = ed25519_dalek::SigningKey::from_bytes(&[90u8; 32]);
+        let make_guard = |alarm: &str| {
+            let (audit_ed, audit_pq) = audit_keys();
+            DuplicityGuard::with_durable_alarm(
+                RocksAt9pStateStore {
+                    store: Arc::clone(&store),
+                    acceptance_identity: acceptance_identity.clone(),
+                    audit_key: audit_ed.clone(),
+                },
+                dir.path().join(alarm),
+                audit_ed,
+                audit_pq,
+            )
+            .expect("guard")
+        };
+        let guard_a = Arc::new(make_guard("alarm-a"));
+        let guard_b = Arc::new(make_guard("alarm-b"));
+        guard_a.seed_genesis(&verified).expect("seed");
+        let candidate_a = sign_update_record(
+            cid.clone(),
+            1,
+            h512(&genesis_bytes),
+            at9p_body(&n1, &[&n2], "winner-a"),
+            "2099-01-01T00:00:00Z".to_owned(),
+            &n1.ed,
+            &n1.pq,
+        )
+        .expect("candidate a");
+        let candidate_b = sign_update_record(
+            cid,
+            1,
+            h512(&genesis_bytes),
+            at9p_body(&n1, &[&n2], "winner-b"),
+            "2099-01-01T00:00:00Z".to_owned(),
+            &n1.ed,
+            &n1.pq,
+        )
+        .expect("candidate b");
+        let barrier = Arc::new(Barrier::new(3));
+        let run = |guard: Arc<DuplicityGuard<_, _>>,
+                   candidate: hyprstream_pds::at9p::UpdateRecord| {
+            let barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                barrier.wait();
+                guard.admit_successor(&candidate, NOW)
+            })
+        };
+        let thread_a = run(guard_a, candidate_a);
+        let thread_b = run(guard_b, candidate_b);
+        barrier.wait();
+        let results = [thread_a.join().expect("thread a"), thread_b.join().expect("thread b")];
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| matches!(result, Ok(Admission::Advanced(_))))
+                .count(),
+            1,
+            "the RocksDB CAS must allow exactly one independently locked guard to advance"
+        );
+        assert_eq!(
+            store
+                .load_at9p_state(&did[DID_AT9P_PREFIX.len()..], &acceptance_identity.verifying_key())
+                .expect("load")
+                .expect("state")
+                .epoch,
+            1
+        );
+    }
+
+    #[test]
     fn production_at9p_ingest_rotation_forks_expiry_terminal_and_restart() {
         use hyprstream_pds::at9p_sign::{sign_capsule, sign_update_record};
 
@@ -1813,6 +1983,51 @@ mod pds_store_tests {
             publisher.accepted_at9p_state(&did, None).is_err(),
             "a partial watermark/body representation must fail closed"
         );
+    }
+
+    #[test]
+    fn accepted_checkpoint_rejects_old_envelope_and_reverse_mismatch() {
+        use hyprstream_pds::at9p_sign::{sign_capsule, sign_update_record};
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("pds");
+        let alarm = dir.path().join("alarm");
+        let store = Arc::new(PdsRecordStore::open(&db_path).expect("open"));
+        let (g, n1, n2) = (at9p_signer(31), at9p_signer(32), at9p_signer(33));
+        let genesis = sign_capsule(at9p_body(&g, &[&n1], "genesis"), &g.ed, &g.pq).expect("genesis");
+        let genesis_bytes = genesis.to_dag_cbor().expect("bytes");
+        let cid = genesis.cid512().expect("cid");
+        let did = format!("{DID_AT9P_PREFIX}{cid}");
+        let publisher = production_at9p_publisher(Arc::clone(&store), &alarm);
+        publisher.ingest_at9p_genesis(&did, &genesis_bytes).expect("seed");
+        let RecordBacking::ReadWrite(db) = &store.backing else { panic!("writer") };
+        let state_key = at9p_state_key(&cid);
+        let checkpoint_key = at9p_checkpoint_key(&cid);
+        let old_state = db.get(&state_key).unwrap().unwrap();
+        let old_checkpoint = db.get(&checkpoint_key).unwrap().unwrap();
+        let update = sign_update_record(
+            cid.clone(), 1, h512(&genesis_bytes), at9p_body(&n1, &[&n2], "rotated"),
+            "2099-01-01T00:00:00Z".to_owned(), &n1.ed, &n1.pq,
+        ).expect("update");
+        publisher.ingest_at9p_successor(&did, &update.to_dag_cbor().unwrap(), "2026-07-16T12:00:00Z").expect("advance");
+        let new_state = db.get(&state_key).unwrap().unwrap();
+        let new_checkpoint = db.get(&checkpoint_key).unwrap().unwrap();
+        db.delete(&state_key).expect("simulate state-half missing");
+        assert!(publisher.accepted_at9p_state(&did, None).is_err());
+        db.put(&state_key, &new_state).expect("restore state");
+        db.delete(&checkpoint_key).expect("simulate checkpoint-half missing");
+        assert!(publisher.accepted_at9p_state(&did, None).is_err());
+        db.put(&checkpoint_key, &new_checkpoint).expect("restore checkpoint");
+        db.put(&state_key, old_state).expect("old envelope replay");
+        assert!(publisher.accepted_at9p_state(&did, None).is_err());
+        db.put(&state_key, new_state).expect("restore body");
+        db.put(&checkpoint_key, old_checkpoint).expect("old checkpoint replay");
+        assert!(publisher.accepted_at9p_state(&did, None).is_err());
+        db.put(&checkpoint_key, new_checkpoint).expect("restore checkpoint");
+        assert_eq!(publisher.accepted_at9p_state(&did, None).unwrap().epoch, 1);
+        drop(publisher);
+        drop(store);
+        let reopened = Arc::new(PdsRecordStore::open(&db_path).expect("reopen"));
+        assert_eq!(production_at9p_publisher(reopened, &alarm).accepted_at9p_state(&did, None).unwrap().epoch, 1);
     }
 
     #[test]

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -633,13 +633,30 @@ fn create_registry_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawn
         })
         .ok_or_else(|| anyhow::anyhow!("no active ES256 #atproto key for PDS publish"))?;
         let atproto_key: p256::ecdsa::SigningKey = (*active).clone();
-        let store = crate::services::discovery::PdsRecordStore::open(&store_dir)?;
+        let store = Arc::new(crate::services::discovery::PdsRecordStore::open(&store_dir)?);
+        // The alarm WAL must remain verifiable across OAuth key rotations and
+        // process restarts. Derive a dedicated, stable audit identity from the
+        // node/service root available in this deployment mode; the second
+        // derivation keeps the ML-DSA material separate from the Ed25519 key.
+        let audit_ed = hyprstream_rpc::node_identity::derive_purpose_key(
+            ctx.signing_key(),
+            "hyprstream-at9p-audit-ed25519-v1",
+        );
+        let audit_pq = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&audit_ed);
+        let alarm_path = store_dir.with_extension("at9p-duplicity.wal");
+        let at9p_state = crate::services::discovery::At9pStateIngest::open(
+            Arc::clone(&store),
+            &alarm_path,
+            audit_ed,
+            audit_pq,
+        )?;
         let node_did = hyprstream_rpc::did_key::ed25519_to_did_key(&ctx.verifying_key().to_bytes());
         Ok(crate::services::discovery::PdsPublisher::new(
-            Arc::new(store),
+            store,
             node_did,
             atproto_key,
-        ))
+        )
+        .with_at9p_state_ingest(at9p_state))
     })()
     .map_err(|e| tracing::warn!("PDS publish disabled: {e}"))
     .ok();

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -633,20 +633,25 @@ fn create_registry_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawn
         })
         .ok_or_else(|| anyhow::anyhow!("no active ES256 #atproto key for PDS publish"))?;
         let atproto_key: p256::ecdsa::SigningKey = (*active).clone();
-        let store = Arc::new(crate::services::discovery::PdsRecordStore::open(&store_dir)?);
+        let acceptance_identity = ctx.signing_key().clone();
         // The alarm WAL must remain verifiable across OAuth key rotations and
         // process restarts. Derive a dedicated, stable audit identity from the
         // node/service root available in this deployment mode; the second
         // derivation keeps the ML-DSA material separate from the Ed25519 key.
         let audit_ed = hyprstream_rpc::node_identity::derive_purpose_key(
-            ctx.signing_key(),
+            &acceptance_identity,
             "hyprstream-at9p-audit-ed25519-v1",
         );
         let audit_pq = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&audit_ed);
+        let store = Arc::new(
+            crate::services::discovery::PdsRecordStore::open(&store_dir)?
+                .with_at9p_acceptance_identity(acceptance_identity.verifying_key()),
+        );
         let alarm_path = store_dir.with_extension("at9p-duplicity.wal");
         let at9p_state = crate::services::discovery::At9pStateIngest::open(
             Arc::clone(&store),
             &alarm_path,
+            acceptance_identity,
             audit_ed,
             audit_pq,
         )?;
@@ -1717,9 +1722,20 @@ fn create_discovery_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spaw
     // proof). This is the #910a security fix — a read path that re-signed a
     // commit on every `getRecord` (and so needed the private key) was the root
     // of the key-exposure problem; atproto never re-signs on read.
+    // In-process factories share the stable node root. In IPC mode the
+    // registry process signs with its stable service credential, whose public
+    // key is anchored in the global service trust store.
+    let at9p_acceptance_identity = if ctx.is_ipc() {
+        hyprstream_service::global_trust_store()
+            .resolve_one("registry")
+            .ok_or_else(|| anyhow::anyhow!("trust store has no registry key"))?
+    } else {
+        ctx.verifying_key()
+    };
     let pds_store = std::sync::Arc::new(
         open_pds_store_readonly(&pds_store_dir()?)
-            .context("failed to open PDS record store (read-only)")?,
+            .context("failed to open PDS record store (read-only)")?
+            .with_at9p_acceptance_identity(at9p_acceptance_identity),
     );
     let record_resolver = crate::services::discovery::PdsRecordResolver::new(pds_store);
 

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -647,7 +647,7 @@ fn create_registry_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawn
             crate::services::discovery::PdsRecordStore::open(&store_dir)?
                 .with_at9p_acceptance_identity(acceptance_identity.verifying_key()),
         );
-        let alarm_path = store_dir.with_extension("at9p-duplicity.wal");
+        let alarm_path = store_dir.join("at9p-duplicity.wal");
         let at9p_state = crate::services::discovery::At9pStateIngest::open(
             Arc::clone(&store),
             &alarm_path,

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -342,7 +342,7 @@ pub struct RegistryService {
     /// Publishes/advances a repo's `ai.hyprstream.model` PDS record on
     /// register + commit (#910a). `None` means this node has no PDS
     /// configured — register/commit proceed exactly as before.
-    pds_publisher: Option<crate::services::discovery::PdsPublisher>,
+    pds_publisher: Option<Arc<crate::services::discovery::PdsPublisher>>,
 }
 
 /// Progress reporter that sends updates via a tokio mpsc channel.
@@ -437,7 +437,7 @@ impl RegistryService {
     /// `commitWithAuthor` (the RPC promote also drives) will publish/advance
     /// the repo's `ai.hyprstream.model` record through it.
     pub fn with_pds_publisher(mut self, publisher: crate::services::discovery::PdsPublisher) -> Self {
-        self.pds_publisher = Some(publisher);
+        self.pds_publisher = Some(Arc::new(publisher));
         self
     }
 
@@ -1849,21 +1849,28 @@ impl RegistryHandler for RegistryService {
     async fn handle_ingest_at9p_candidate(&self, _ctx: &EnvelopeContext, _request_id: u64,
         data: &At9pCandidateRequest,
     ) -> Result<RegistryResponseVariant> {
-        let result = (|| -> Result<AcceptedAt9pStateInfo> {
+        let result = async {
             anyhow::ensure!(!data.did.is_empty(), "did is required");
             anyhow::ensure!(!data.record_bytes.is_empty(), "candidate bytes are required");
             anyhow::ensure!(data.record_bytes.len() <= MAX_AT9P_CANDIDATE_BYTES, "candidate exceeds ingest cap");
             let publisher = self.pds_publisher.as_ref()
                 .ok_or_else(|| anyhow!("accepted did:at9p ingest is not configured"))?;
-            let state = match data.kind {
-                At9pCandidateKind::Genesis => publisher.ingest_at9p_genesis(&data.did, &data.record_bytes)?,
+            let publisher = Arc::clone(publisher);
+            let did = data.did.clone();
+            let record_bytes = data.record_bytes.clone();
+            let kind = data.kind;
+            let now = chrono::Utc::now()
+                .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+            let state = tokio::task::spawn_blocking(move || match kind {
+                At9pCandidateKind::Genesis => publisher.ingest_at9p_genesis(&did, &record_bytes),
                 At9pCandidateKind::Successor => {
-                    anyhow::ensure!(!data.now.is_empty(), "successor evaluation time is required");
-                    publisher.ingest_at9p_successor(&data.did, &data.record_bytes, &data.now)?
+                    publisher.ingest_at9p_successor(&did, &record_bytes, &now)
                 }
-            };
-            Ok(AcceptedAt9pStateInfo { did: state.did, epoch: state.epoch, head_digest: state.head_digest.to_vec(), terminal: state.terminal })
-        })();
+            })
+            .await
+            .map_err(|error| anyhow!("at9p candidate worker failed: {error}"))??;
+            Ok::<_, anyhow::Error>(AcceptedAt9pStateInfo { did: state.did, epoch: state.epoch, head_digest: state.head_digest.to_vec(), terminal: state.terminal })
+        }.await;
         Ok(match result {
             Ok(info) => RegistryResponseVariant::IngestAt9pCandidateResult(info),
             Err(error) => reg_error(&format!("at9p candidate rejected: {error}")),
@@ -3534,13 +3541,13 @@ mod tests {
         let did = format!("{}{}", hyprstream_pds::at9p_gate::DID_AT9P_PREFIX, cid);
         assert_eq!(client.ingest_at9p_candidate(&At9pCandidateRequest {
             did: did.clone(), kind: At9pCandidateKind::Genesis,
-            record_bytes: genesis_bytes.clone(), now: String::new(),
+            record_bytes: genesis_bytes.clone(),
         }).await.unwrap().epoch, 0);
         let update = sign_update_record(cid.clone(), 1, hyprstream_pds::at9p::h512(&genesis_bytes),
             at9p_test_body(&n1, &[&n2], "rotated"), "2099-01-01T00:00:00Z".to_owned(), &n1.ed, &n1.pq).unwrap();
         let accepted = client.ingest_at9p_candidate(&At9pCandidateRequest {
             did: did.clone(), kind: At9pCandidateKind::Successor,
-            record_bytes: update.to_dag_cbor().unwrap(), now: NOW.to_owned(),
+            record_bytes: update.to_dag_cbor().unwrap(),
         }).await.unwrap();
         assert_eq!(accepted.epoch, 1);
         let resolver = crate::services::discovery::PdsRecordResolver::new(Arc::clone(&store));
@@ -3550,26 +3557,26 @@ mod tests {
             at9p_test_body(&n1, &[&n2], "fork"), "2099-01-01T00:00:00Z".to_owned(), &n1.ed, &n1.pq).unwrap();
         assert!(client.ingest_at9p_candidate(&At9pCandidateRequest {
             did: did.clone(), kind: At9pCandidateKind::Successor,
-            record_bytes: fork.to_dag_cbor().unwrap(), now: NOW.to_owned(),
+            record_bytes: fork.to_dag_cbor().unwrap(),
         }).await.is_err());
         let expired = sign_update_record(cid.clone(), 2, state.head_digest,
             at9p_test_body(&n2, &[], "expired"), "2026-01-01T00:00:00Z".to_owned(), &n2.ed, &n2.pq).unwrap();
         assert!(client.ingest_at9p_candidate(&At9pCandidateRequest {
             did: did.clone(), kind: At9pCandidateKind::Successor,
-            record_bytes: expired.to_dag_cbor().unwrap(), now: NOW.to_owned(),
+            record_bytes: expired.to_dag_cbor().unwrap(),
         }).await.is_err());
         let terminal = sign_update_record(cid.clone(), 2, state.head_digest,
             at9p_test_body(&n2, &[], "terminal"), "2099-01-01T00:00:00Z".to_owned(), &n2.ed, &n2.pq).unwrap();
         let terminal_state = client.ingest_at9p_candidate(&At9pCandidateRequest {
             did: did.clone(), kind: At9pCandidateKind::Successor,
-            record_bytes: terminal.to_dag_cbor().unwrap(), now: NOW.to_owned(),
+            record_bytes: terminal.to_dag_cbor().unwrap(),
         }).await.unwrap();
         assert!(terminal_state.terminal);
         let after_terminal = sign_update_record(cid, 3, terminal_state.head_digest.try_into().unwrap(),
             at9p_test_body(&n3, &[&n3], "forbidden"), "2099-01-01T00:00:00Z".to_owned(), &n3.ed, &n3.pq).unwrap();
         assert!(client.ingest_at9p_candidate(&At9pCandidateRequest {
             did, kind: At9pCandidateKind::Successor,
-            record_bytes: after_terminal.to_dag_cbor().unwrap(), now: NOW.to_owned(),
+            record_bytes: after_terminal.to_dag_cbor().unwrap(),
         }).await.is_err());
         let _ = handle.stop().await;
         drop(policy_handle);

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -35,6 +35,7 @@ use crate::services::generated::registry_client::{
     CloneRequest, RegisterRequest,
     GetBlobRequest, GetBlobRequestContent,
     PutBlobRequest, PutBlobResult,
+    At9pCandidateRequest, At9pCandidateKind, AcceptedAt9pStateInfo,
     CreateWorktreeRequest, RemoveWorktreeRequest,
     BranchRequest, CheckoutRequest, StageFilesRequest,
     CommitRequest, MergeRequest, ContinueMergeRequest,
@@ -159,6 +160,7 @@ const FID_IDLE_TIMEOUT: Duration = Duration::from_secs(300);
 /// Model-weight-scale blobs are NOT intended for the inline path; a streaming
 /// upload channel (additive schema follow-up) will carry those. 64 MiB.
 const MAX_INLINE_UPLOAD: u64 = 64 * 1024 * 1024;
+const MAX_AT9P_CANDIDATE_BYTES: usize = 4 * 1024 * 1024;
 
 fn now_epoch_secs() -> u64 {
     SystemTime::now()
@@ -1844,6 +1846,30 @@ impl RegistryHandler for RegistryService {
         }
     }
 
+    async fn handle_ingest_at9p_candidate(&self, _ctx: &EnvelopeContext, _request_id: u64,
+        data: &At9pCandidateRequest,
+    ) -> Result<RegistryResponseVariant> {
+        let result = (|| -> Result<AcceptedAt9pStateInfo> {
+            anyhow::ensure!(!data.did.is_empty(), "did is required");
+            anyhow::ensure!(!data.record_bytes.is_empty(), "candidate bytes are required");
+            anyhow::ensure!(data.record_bytes.len() <= MAX_AT9P_CANDIDATE_BYTES, "candidate exceeds ingest cap");
+            let publisher = self.pds_publisher.as_ref()
+                .ok_or_else(|| anyhow!("accepted did:at9p ingest is not configured"))?;
+            let state = match data.kind {
+                At9pCandidateKind::Genesis => publisher.ingest_at9p_genesis(&data.did, &data.record_bytes)?,
+                At9pCandidateKind::Successor => {
+                    anyhow::ensure!(!data.now.is_empty(), "successor evaluation time is required");
+                    publisher.ingest_at9p_successor(&data.did, &data.record_bytes, &data.now)?
+                }
+            };
+            Ok(AcceptedAt9pStateInfo { did: state.did, epoch: state.epoch, head_digest: state.head_digest.to_vec(), terminal: state.terminal })
+        })();
+        Ok(match result {
+            Ok(info) => RegistryResponseVariant::IngestAt9pCandidateResult(info),
+            Err(error) => reg_error(&format!("at9p candidate rejected: {error}")),
+        })
+    }
+
 }
 
 impl RegistryService {
@@ -3373,6 +3399,29 @@ mod tests {
     use hyprstream_service::ServiceManager;
     use tempfile::TempDir;
 
+    struct At9pTestSigner {
+        ed: ed25519_dalek::SigningKey,
+        pq: hyprstream_rpc::crypto::pq::MlDsaSigningKey,
+        pair: hyprstream_pds::at9p::HybridKeyPair,
+    }
+    fn at9p_test_signer(tag: u8) -> At9pTestSigner {
+        use hyprstream_rpc::crypto::pq::{ml_dsa_generate_keypair, ml_dsa_vk_bytes};
+        let mut seed = [0u8; 32]; seed[0] = tag;
+        let ed = ed25519_dalek::SigningKey::from_bytes(&seed);
+        let (pq, vk) = ml_dsa_generate_keypair();
+        let pair = hyprstream_pds::at9p::HybridKeyPair::new(
+            ed.verifying_key().to_bytes().to_vec(), ml_dsa_vk_bytes(&vk)).unwrap();
+        At9pTestSigner { ed, pq, pair }
+    }
+    fn at9p_test_body(current: &At9pTestSigner, next: &[&At9pTestSigner], tag: &str) -> hyprstream_pds::at9p::CapsuleBody {
+        use hyprstream_pds::at9p::{CapsuleBody, ServiceEndpoint, ServiceEntry, ServiceType, Transport};
+        let service = ServiceEntry::new("#ns", ServiceType::NinePExport,
+            ServiceEndpoint::new(Transport::Iroh, format!("iroh://{tag}")).unwrap()).unwrap();
+        let mut body = CapsuleBody::new(vec![current.pair.clone()], vec![service]).unwrap();
+        body.next_key_commitments = next.iter().map(|s| s.pair.commitment_digest()).collect();
+        body
+    }
+
     #[tokio::test]
     async fn test_registry_service_health_check() {
         use hyprstream_service::InprocManager;
@@ -3439,6 +3488,91 @@ mod tests {
 
         // Stop the service
         let _ = handle.stop().await;
+    }
+
+    #[tokio::test]
+    async fn registry_rpc_is_live_at9p_candidate_boundary() {
+        use hyprstream_pds::at9p_sign::{sign_capsule, sign_update_record};
+        use hyprstream_service::InprocManager;
+        const NOW: &str = "2026-07-16T12:00:00Z";
+        let _ = hyprstream_rpc::envelope::install_verify_config(hyprstream_rpc::envelope::EnvelopeVerifyConfig {
+            policy: hyprstream_rpc::crypto::CryptoPolicy::Classical, pq_store: None,
+        });
+        let root = TempDir::new().unwrap();
+        let models = root.path().join("models");
+        let pds = root.path().join("pds");
+        let (key, _) = generate_signing_keypair();
+        let policy_manager = Arc::new(PolicyManager::permissive().await.unwrap());
+        let policy_git = Arc::new(RwLock::new(Git2DB::open(&models).await.unwrap()));
+        let policy = PolicyService::new(policy_manager, Arc::new(key.clone()),
+            crate::config::TokenConfig::default(), policy_git,
+            TransportConfig::inproc("at9p-policy"));
+        let manager = InprocManager::new();
+        let policy_handle = manager.spawn(Box::new(policy)).await.unwrap();
+        let policy_client = PolicyClient::for_endpoint("inproc://at9p-policy", key.clone(), key.verifying_key(), None).unwrap();
+        let store = Arc::new(crate::services::discovery::PdsRecordStore::open(&pds).unwrap()
+            .with_at9p_acceptance_identity(key.verifying_key()));
+        let ingest = crate::services::discovery::At9pStateIngest::open(
+            Arc::clone(&store), &root.path().join("alarm"), key.clone(),
+            ed25519_dalek::SigningKey::from_bytes(&[81u8; 32]),
+            hyprstream_rpc::crypto::pq::ml_dsa_sk_from_seed(&[82u8; 32])).unwrap();
+        let publisher = crate::services::discovery::PdsPublisher::new(Arc::clone(&store),
+            "did:key:test".to_owned(), p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng))
+            .with_at9p_state_ingest(ingest);
+        let registry = RegistryService::new(&models, policy_client,
+            TransportConfig::inproc("at9p-registry"), key.clone()).await.unwrap()
+            .with_pds_publisher(publisher);
+        let mut handle = manager.spawn(Box::new(registry)).await.unwrap();
+        let client = RegistryClient::for_endpoint("inproc://at9p-registry", key.clone(), key.verifying_key(), None).unwrap();
+        let (g, n1, n2, n3) = (
+            at9p_test_signer(1), at9p_test_signer(2),
+            at9p_test_signer(3), at9p_test_signer(4),
+        );
+        let genesis = sign_capsule(at9p_test_body(&g, &[&n1], "genesis"), &g.ed, &g.pq).unwrap();
+        let genesis_bytes = genesis.to_dag_cbor().unwrap();
+        let cid = genesis.cid512().unwrap();
+        let did = format!("{}{}", hyprstream_pds::at9p_gate::DID_AT9P_PREFIX, cid);
+        assert_eq!(client.ingest_at9p_candidate(&At9pCandidateRequest {
+            did: did.clone(), kind: At9pCandidateKind::Genesis,
+            record_bytes: genesis_bytes.clone(), now: String::new(),
+        }).await.unwrap().epoch, 0);
+        let update = sign_update_record(cid.clone(), 1, hyprstream_pds::at9p::h512(&genesis_bytes),
+            at9p_test_body(&n1, &[&n2], "rotated"), "2099-01-01T00:00:00Z".to_owned(), &n1.ed, &n1.pq).unwrap();
+        let accepted = client.ingest_at9p_candidate(&At9pCandidateRequest {
+            did: did.clone(), kind: At9pCandidateKind::Successor,
+            record_bytes: update.to_dag_cbor().unwrap(), now: NOW.to_owned(),
+        }).await.unwrap();
+        assert_eq!(accepted.epoch, 1);
+        let resolver = crate::services::discovery::PdsRecordResolver::new(Arc::clone(&store));
+        let state = resolver.accepted_at9p_state(&did, NOW).unwrap().unwrap();
+        assert_eq!(state.current.subject_keys[0], n1.pair);
+        let fork = sign_update_record(cid.clone(), 1, hyprstream_pds::at9p::h512(&genesis_bytes),
+            at9p_test_body(&n1, &[&n2], "fork"), "2099-01-01T00:00:00Z".to_owned(), &n1.ed, &n1.pq).unwrap();
+        assert!(client.ingest_at9p_candidate(&At9pCandidateRequest {
+            did: did.clone(), kind: At9pCandidateKind::Successor,
+            record_bytes: fork.to_dag_cbor().unwrap(), now: NOW.to_owned(),
+        }).await.is_err());
+        let expired = sign_update_record(cid.clone(), 2, state.head_digest,
+            at9p_test_body(&n2, &[], "expired"), "2026-01-01T00:00:00Z".to_owned(), &n2.ed, &n2.pq).unwrap();
+        assert!(client.ingest_at9p_candidate(&At9pCandidateRequest {
+            did: did.clone(), kind: At9pCandidateKind::Successor,
+            record_bytes: expired.to_dag_cbor().unwrap(), now: NOW.to_owned(),
+        }).await.is_err());
+        let terminal = sign_update_record(cid.clone(), 2, state.head_digest,
+            at9p_test_body(&n2, &[], "terminal"), "2099-01-01T00:00:00Z".to_owned(), &n2.ed, &n2.pq).unwrap();
+        let terminal_state = client.ingest_at9p_candidate(&At9pCandidateRequest {
+            did: did.clone(), kind: At9pCandidateKind::Successor,
+            record_bytes: terminal.to_dag_cbor().unwrap(), now: NOW.to_owned(),
+        }).await.unwrap();
+        assert!(terminal_state.terminal);
+        let after_terminal = sign_update_record(cid, 3, terminal_state.head_digest.try_into().unwrap(),
+            at9p_test_body(&n3, &[&n3], "forbidden"), "2099-01-01T00:00:00Z".to_owned(), &n3.ed, &n3.pq).unwrap();
+        assert!(client.ingest_at9p_candidate(&At9pCandidateRequest {
+            did, kind: At9pCandidateKind::Successor,
+            record_bytes: after_terminal.to_dag_cbor().unwrap(), now: NOW.to_owned(),
+        }).await.is_err());
+        let _ = handle.stop().await;
+        drop(policy_handle);
     }
 
     // ── #432 getBlob authz: the hash is NOT a capability ──────────────────────

--- a/docs/at9p-accepted-state.md
+++ b/docs/at9p-accepted-state.md
@@ -1,0 +1,33 @@
+# did:at9p accepted-state transaction boundary
+
+Issue #1004 is owned by the daemon's sole read-write PDS process. That process
+constructs one `At9pStateIngest` beside `PdsPublisher`, backed by the same
+RocksDB instance and by a `DuplicityGuard::with_durable_alarm` using dedicated,
+purpose-derived Ed25519 and ML-DSA-65 audit keys. The derivation starts from
+the deployment's stable node/service root, so alarm verification survives both
+process restart and unrelated OAuth signing-key rotation.
+
+Each DID has one versioned accepted-state value. The value contains the head
+kind and canonical head bytes together with the epoch, H512 head digest, and
+terminal flag. Genesis ingest first runs the complete GATE pipeline and derives
+the seed exclusively from the verified capsule. Successor ingest calls
+`admit_successor`; the guard reloads and decodes that durable head and derives
+its own predecessor. Callers cannot provide a seed or predecessor state.
+
+The store replaces the complete value with one synchronous RocksDB write. A
+RocksDB write is atomic, its WAL is enabled, and `sync=true` makes successful
+ingest crash-durable before it is returned. Consequently recovery sees either
+the prior complete value or the replacement complete value. There are no
+separate body and watermark keys, so a new watermark with an old body (or the
+reverse) is not representable. Reads decode the head, recompute its digest and
+derived epoch/terminal fields, and reject any mismatch before returning the
+typed `AcceptedAt9pState`.
+
+Duplicity alarms use the existing separately fsynced, hybrid-signed alarm WAL.
+An alarm never advances accepted state. Restart reopens and verifies both the
+accepted-state value and the alarm WAL before ingest becomes available.
+
+This boundary remembers only the state this node accepted. It does not claim
+global-latest consensus or first-contact fork detection, does not treat service
+entries as reach/liveness/admission authority, and never falls back to a caller,
+configuration seed, or genesis keys after an accepted rotation.

--- a/docs/at9p-accepted-state.md
+++ b/docs/at9p-accepted-state.md
@@ -38,8 +38,10 @@ re-reads and is classified against the durable winner, never `Advanced`.
 The ordinary registry RPC schema exposes authenticated
 `ingestAt9pCandidate`. Network/PDS callers supply untrusted DID and record bytes
 only; genesis authority comes solely from GATE and successor authority solely
-from the verified durable predecessor. Consumers read the typed verified PDS
-seam.
+from the fresh verified durable predecessor. Expiry is evaluated with the
+daemon's UTC clock, never caller-supplied time, and the synchronous crypto/
+RocksDB transaction runs on the service's blocking worker pool. Consumers read
+the typed verified PDS seam.
 
 Duplicity alarms use the existing separately fsynced, hybrid-signed alarm WAL.
 An alarm never advances accepted state. Restart eagerly reopens and verifies

--- a/docs/at9p-accepted-state.md
+++ b/docs/at9p-accepted-state.md
@@ -7,11 +7,14 @@ purpose-derived Ed25519 and ML-DSA-65 audit keys. The derivation starts from
 the deployment's stable node/service root, so alarm verification survives both
 process restart and unrelated OAuth signing-key rotation.
 
-Each DID has one versioned accepted-state value. The value contains the head
+Each DID has a versioned accepted-state envelope and a distinct monotonic-head
+checkpoint key. The envelope contains the head
 kind and canonical head bytes together with the epoch, H512 head digest, and
 terminal flag. A daemon-authenticated envelope also contains the purpose-derived
 audit public key, a certificate for that key from the deployment's stable
-node/service identity, and an audit-key signature over the complete state.
+node/service identity, and an audit-key signature over the complete state. The
+deployment-signed checkpoint binds `(epoch, head digest, terminal)` to the H512
+digest of that exact envelope.
 Thus an internally valid attacker-selected fork cannot be substituted in
 RocksDB and mistaken for the fork this daemon accepted. Genesis ingest first
 runs the complete GATE pipeline and derives the seed exclusively from the
@@ -19,15 +22,24 @@ verified capsule. Successor ingest calls `admit_successor`; the guard reloads
 and decodes that durable head and derives its own predecessor. Callers cannot
 provide a seed or predecessor state.
 
-The store replaces the complete value with one synchronous RocksDB write. A
-RocksDB write is atomic, its WAL is enabled, and `sync=true` makes successful
-ingest crash-durable before it is returned. Consequently recovery sees either
-the prior complete value or the replacement complete value. There are no
-separate body and watermark keys, so a new watermark with an old body (or the
-reverse) is not representable. Reads decode the head, recompute its digest and
-derived epoch/terminal fields, verify the deployment certificate and daemon
-acceptance signature, and reject any mismatch before returning the typed
-`AcceptedAt9pState`.
+The store advances envelope and checkpoint in one synchronous RocksDB
+`WriteBatch`. Before the commit point a snapshot exposes the complete old pair;
+after it, the complete new pair. Missing keys and every cross-generation,
+signature, envelope-digest, epoch, head-digest, or terminal mismatch fail
+closed. Thus replaying an older otherwise-valid envelope alone cannot make it
+visible after the checkpoint advances.
+
+Admission has no unconditional write API. The store commits only when its
+verified durable head still equals the expected `(epoch, digest, terminal)`.
+All production guards share one `Arc<PdsRecordStore>` owner and store-level CAS
+lock; RocksDB excludes a second read-write owner for the directory. A loser
+re-reads and is classified against the durable winner, never `Advanced`.
+
+The ordinary registry RPC schema exposes authenticated
+`ingestAt9pCandidate`. Network/PDS callers supply untrusted DID and record bytes
+only; genesis authority comes solely from GATE and successor authority solely
+from the verified durable predecessor. Consumers read the typed verified PDS
+seam.
 
 Duplicity alarms use the existing separately fsynced, hybrid-signed alarm WAL.
 An alarm never advances accepted state. Restart eagerly reopens and verifies
@@ -39,3 +51,8 @@ This boundary remembers only the state this node accepted. It does not claim
 global-latest consensus or first-contact fork detection, does not treat service
 entries as reach/liveness/admission authority, and never falls back to a caller,
 configuration seed, or genesis keys after an accepted rotation.
+
+This rollback guarantee protects the production store API and recovery
+protocol. An attacker able to atomically roll back every trusted external/local
+monotonic anchor, including both signed keys, requires an off-host anchor and is
+outside this local-store guarantee.

--- a/docs/at9p-accepted-state.md
+++ b/docs/at9p-accepted-state.md
@@ -9,10 +9,15 @@ process restart and unrelated OAuth signing-key rotation.
 
 Each DID has one versioned accepted-state value. The value contains the head
 kind and canonical head bytes together with the epoch, H512 head digest, and
-terminal flag. Genesis ingest first runs the complete GATE pipeline and derives
-the seed exclusively from the verified capsule. Successor ingest calls
-`admit_successor`; the guard reloads and decodes that durable head and derives
-its own predecessor. Callers cannot provide a seed or predecessor state.
+terminal flag. A daemon-authenticated envelope also contains the purpose-derived
+audit public key, a certificate for that key from the deployment's stable
+node/service identity, and an audit-key signature over the complete state.
+Thus an internally valid attacker-selected fork cannot be substituted in
+RocksDB and mistaken for the fork this daemon accepted. Genesis ingest first
+runs the complete GATE pipeline and derives the seed exclusively from the
+verified capsule. Successor ingest calls `admit_successor`; the guard reloads
+and decodes that durable head and derives its own predecessor. Callers cannot
+provide a seed or predecessor state.
 
 The store replaces the complete value with one synchronous RocksDB write. A
 RocksDB write is atomic, its WAL is enabled, and `sync=true` makes successful
@@ -20,12 +25,15 @@ ingest crash-durable before it is returned. Consequently recovery sees either
 the prior complete value or the replacement complete value. There are no
 separate body and watermark keys, so a new watermark with an old body (or the
 reverse) is not representable. Reads decode the head, recompute its digest and
-derived epoch/terminal fields, and reject any mismatch before returning the
-typed `AcceptedAt9pState`.
+derived epoch/terminal fields, verify the deployment certificate and daemon
+acceptance signature, and reject any mismatch before returning the typed
+`AcceptedAt9pState`.
 
 Duplicity alarms use the existing separately fsynced, hybrid-signed alarm WAL.
-An alarm never advances accepted state. Restart reopens and verifies both the
-accepted-state value and the alarm WAL before ingest becomes available.
+An alarm never advances accepted state. Restart eagerly reopens and verifies
+the alarm WAL before ingest becomes available. Accepted-state values are
+verified lazily but fail closed on every load, before they can anchor an ingest
+or be returned to a consumer.
 
 This boundary remembers only the state this node accepted. It does not claim
 global-latest consensus or first-contact fork detection, does not treat service


### PR DESCRIPTION
Refs #1004

## Summary
- make the daemon PDS writer own the only production `did:at9p` acceptance boundary
- advance accepted state through a store-owned expected-head CAS shared across independent guards
- atomically persist the signed accepted-state envelope and a separate deployment-signed monotonic checkpoint in one synchronous RocksDB `WriteBatch`
- verify both keys from one RocksDB snapshot and fail closed on missing halves, cross-generation mismatch, rollback, or signature/body mismatch
- expose authenticated `ingestAt9pCandidate` on the ordinary Registry RPC handler; callers provide only untrusted DID/record bytes
- retain typed `AcceptedAt9pState` reads for downstream identity-bound consumers

## Transaction and recovery
The protocol is documented in `docs/at9p-accepted-state.md`. The envelope retains the canonical head plus derived watermark fields and the certified audit-key acceptance signature. The distinct checkpoint is signed by the stable deployment identity and binds `(epoch, head digest, terminal)` to the H512 digest of that exact envelope.

Envelope and checkpoint advance in one WAL-backed, `sync=true` `WriteBatch`. Recovery sees the complete old pair or complete new pair. Reads use one snapshot and reject either missing half, reverse mismatch, old-envelope replay against a new checkpoint, invalid signatures, and derived-field mismatch. The store has no unconditional write API: its conditional advance compares the verified durable watermark under the shared store lock before committing, so independently locked guards cannot both win.

The Registry receiver invokes GATE-only genesis ingest or durable-predecessor successor ingest. It is fail-closed when the production publisher is absent, caps candidate bytes, requires an evaluation time for successors, and returns only the typed accepted-state summary.

This remains accepted local state only. It does not claim global-latest consensus, endpoint reach/liveness, possession, carrier selection, or admission authority. Atomic rollback of every trusted local/external monotonic anchor requires an off-host anchor and is outside this local-store guarantee.

## Validation at `795d6b71a082fa91ea2d46d35f535a1c228bacd6`
- old-envelope, reverse-mismatch, missing-half crash-window, and restart mutations: passed
- independent in-memory and production RocksDB guard CAS barrier mutations: exactly one winner
- live in-process Registry client/handler mutation: genesis and rotation accepted; fork, expired update, and post-terminal successor rejected; typed resolver observed rotated state
- accepted-predecessor expiry and daemon-clock backdating mutations: passed
- `cargo test -p hyprstream-pds --lib --no-fail-fast`: 199 passed
- `cargo test -p hyprstream --lib --no-fail-fast`: 993 passed, 1 ignored
- strict affected-package Clippy with `-D warnings`: passed
- repository pre-commit workspace/all-targets/release Clippy with `-D warnings`: passed
- `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo check --target wasm32-unknown-unknown -p hyprstream-rpc`: passed
- `cargo deny check bans licenses`: passed

Hosted exact-head gates are being rerun after this force-push.
