### PR TITLE
ci: move the merge-gate build+test onto Graviton (arm64, #1011)

### DIFF
--- a/.github/scripts/graviton-build-test.sh
+++ b/.github/scripts/graviton-build-test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Merge-gate build + test for the self-hosted Graviton (arm64) fleet, run INSIDE
+# the rust-builder container as a NON-ROOT user (#1011). rust.yml invokes it as:
+#   runuser -u ci -- bash -euo pipefail /build/.github/scripts/graviton-build-test.sh
+# from the bind-mounted workspace (cwd = /build). Root-only setup (cargo-nextest,
+# git-lfs, wasm rustup targets, the ci user + perms) happens in the workflow before
+# this runs; kept in a committed file so it is readable/reviewable rather than an
+# escaped inline heredoc.
+set -euo pipefail
+
+# The rust toolchain lives under root's home in the image; the workflow made it
+# a+rwX and created this ci user. CARGO_HOME/RUSTUP_HOME point back at it.
+export PATH="/root/.cargo/bin:/usr/local/bin:${PATH}"
+export CARGO_HOME=/root/.cargo
+export RUSTUP_HOME=/root/.rustup
+export SCCACHE_DIR="${PWD}/.sccache"
+mkdir -p "${SCCACHE_DIR}"
+
+# Same-filesystem TMPDIR: the overlay_fsmount tests rename across layers, which
+# fails EXDEV (cross-device link) when temp dirs land on /tmp (tmpfs) while the
+# workspace is on another filesystem. Keep temp on the workspace fs.
+export TMPDIR="${PWD}/.citmp"
+mkdir -p "${TMPDIR}"
+
+# Default features (parity with the former x86 gate); libtorch is the image's
+# aarch64 wheel at /opt/libtorch, so NO download-libtorch feature here.
+cargo build --release
+
+# wasm guest artifacts for the sandbox/mount tests (deny-on-missing-guest guard).
+# cd INTO each guest crate so cargo reads its .cargo/config.toml (the python guest
+# needs getrandom_backend="custom" for wasm32-unknown-unknown; see #1013).
+( cd crates/hyprstream-workers-python-guest && cargo build --release --target wasm32-unknown-unknown )
+( cd crates/hyprstream-workers-wasmtime-fsguest && cargo build --release --target wasm32-wasip1 )
+export HYPRSTREAM_PYGUEST_WASM="${PWD}/crates/hyprstream-workers-python-guest/target/wasm32-unknown-unknown/release/hyprstream_workers_python_guest.wasm"
+export HYPRSTREAM_FSGUEST_WASM="${PWD}/crates/hyprstream-workers-wasmtime-fsguest/target/wasm32-wasip1/release/hyprstream-workers-wasmtime-fsguest.wasm"
+
+# nextest ci profile enforces the per-test slow-timeout from .config/nextest.toml;
+# fail-fast (the default) is what the merge gate wants.
+cargo nextest run --cargo-profile ci-test --profile ci
+# nextest does not run doctests; keep them in the merge gate.
+cargo test --release --doc
+
+sccache --show-stats

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,8 +45,9 @@ env:
 # AWS creds from the OIDC step are passed into the container by name (`-e VAR`
 # with no value forwards the host value) so the image's sccache reaches S3.
 #
-# The merge-gate `build` job stays on ubuntu-latest for now (arm64 default-feature
-# test validation is not green yet) — see its inline note.
+# The merge-gate `build` job runs the same way (#1011): self-hosted Graviton,
+# inside the rust-builder container, default features with the image's aarch64
+# libtorch (no `download-libtorch`) — see its inline note.
 jobs:
   clippy:
     name: Clippy
@@ -149,11 +150,18 @@ jobs:
     # merge queue. (Per-PR AppImage artifacts were dropped with the PR build; the
     # `appimage.yml` workflow still builds the AppImage on push to `main`.)
     if: github.event_name != 'pull_request'
-    # NOTE: the merge-gate build+test stays on ubuntu-latest for now. The arm64
-    # default-feature nextest suite has NOT been validated green on Graviton yet
-    # (runner-smoke test run failed), so the required gate does not move until it
-    # is. clippy + wasm (above) run on Graviton via podman run; this job does not.
-    runs-on: ubuntu-latest
+    # MERGE GATE runs on the self-hosted Graviton (arm64) fleet, INSIDE the
+    # prebuilt rust-builder container via `podman run` — the same layer clippy +
+    # wasm use (#1011). Two consequences of arm64-in-container vs the old
+    # ubuntu-latest job:
+    #   1. libtorch comes from the image (/opt/libtorch, the aarch64 pip wheel);
+    #      there is NO `download-libtorch` feature (no aarch64 libtorch zip
+    #      exists). Default features are otherwise unchanged, so coverage
+    #      (systemd/kata-vm/nspawn/otel/gittorrent/xet) matches the former gate.
+    #   2. build deps (capnproto, libsystemd-dev) and sccache are baked into the
+    #      image, so there is no host apt-get / sccache-action; cargo-nextest is
+    #      not baked in, so it is fetched into the container below.
+    runs-on: [self-hosted, linux, arm64, graviton, hyprstream-merge-gate]
     needs: clippy  # Only build if clippy passes
     # Merge-gate backstop: fail before the merge queue's 120min timeout (ruleset
     # check_response_timeout_minutes) so a hang yields a definitive failure and the
@@ -161,14 +169,11 @@ jobs:
     # nextest step uses the ci-test Cargo profile to avoid release ThinLTO on test
     # binaries, so 90min should retain headroom while catching regressions.
     timeout-minutes: 90
-    env:
-      SCCACHE_IDLE_TIMEOUT: 0
 
     steps:
     - uses: actions/checkout@v4
-
-    - name: Install build dependencies
-      run: sudo apt-get update && sudo apt-get install -y capnproto libsystemd-dev pkg-config libssl-dev
+      with:
+        persist-credentials: false
 
     - name: Configure AWS credentials (OIDC → sccache S3)
       uses: aws-actions/configure-aws-credentials@v4
@@ -176,53 +181,55 @@ jobs:
         role-to-assume: ${{ vars.AWS_SCCACHE_ROLE_ARN }}
         aws-region: ${{ vars.AWS_SCCACHE_REGION }}
 
-    - name: Setup sccache
-      uses: mozilla-actions/sccache-action@v0.0.9
+    - name: Pull builder image
+      run: podman pull "$BUILDER_IMAGE"
 
-    - name: Build
-      run: cargo build --release --verbose --features download-libtorch
-
-    - name: Build wasm guest artifacts (for sandbox/mount tests)
-      # The workers-python / workers-wasmtime sandbox tests hard-fail under CI
-      # (deny-on-missing-guest guard) when their wasm guest artifacts are absent —
-      # the guard forces CI to actually exercise the sandbox. These guests are
-      # EXCLUDED standalone crates with their own target dirs, so build them
-      # explicitly; nextest locates them via HYPRSTREAM_*_WASM on the test step.
-      #
-      # IMPORTANT: `cd` into each guest crate dir before building. Cargo discovers
-      # .cargo/config.toml from the INVOCATION cwd, NOT the --manifest-path dir, so
-      # building from the repo root misses crates/hyprstream-workers-python-guest/
-      # .cargo/config.toml — which sets `--cfg getrandom_backend="custom"` for the
-      # wasm32-unknown-unknown target. Without it getrandom emits a hard
-      # compile_error!("...wasm32-unknown-unknown targets are not supported...").
-      # cd-ing in is the only invocation that honors the per-crate config (the
-      # fsguest has no such config today, but the same pattern is correct for both
-      # and is robust to a future config being added). See #1013 follow-up.
+    # Full merge-gate build + test in ONE container so sccache stays warm and the
+    # bind-mounted target/ persists across build → wasm-guests → nextest →
+    # doctests. Mirrors the clippy/wasm invocation (libtorch + sccache-to-S3 from
+    # the image); AWS creds forward by name (`-e VAR` with no value passes the
+    # host value) so the in-image sccache reaches the same-region S3 bucket.
+    - name: Build + test (release, in rust-builder container)
       run: |
-        rustup target add wasm32-unknown-unknown wasm32-wasip1
-        ( cd crates/hyprstream-workers-python-guest && \
-          cargo build --release --target wasm32-unknown-unknown )
-        ( cd crates/hyprstream-workers-wasmtime-fsguest && \
-          cargo build --release --target wasm32-wasip1 )
+        podman run --rm \
+          -v "$PWD":/build:Z -w /build \
+          -e RUSTC_WRAPPER=sccache -e SCCACHE_BUCKET -e SCCACHE_REGION \
+          -e SCCACHE_IDLE_TIMEOUT=0 \
+          -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
+          -e AWS_REGION -e AWS_DEFAULT_REGION \
+          -e LIBTORCH=/opt/libtorch -e LD_LIBRARY_PATH=/opt/libtorch/lib \
+          -e LIBTORCH_BYPASS_VERSION_CHECK=1 -e OPENSSL_NO_VENDOR=1 \
+          -e CARGO_INCREMENTAL=0 -e CARGO_TERM_COLOR=always \
+          "$BUILDER_IMAGE" \
+          bash -euo pipefail -c '
+            # Default features (parity with the former x86 gate); libtorch from the
+            # image means NO --features download-libtorch here.
+            cargo build --release --verbose
 
-    - name: Install cargo-nextest
-      uses: taiki-e/install-action@nextest
+            # wasm guest artifacts for the sandbox/mount tests (deny-on-missing-guest
+            # guard). cd INTO each guest crate dir: cargo discovers .cargo/config.toml
+            # from the invocation cwd, not --manifest-path, and the python guest needs
+            # its getrandom_backend="custom" cfg for wasm32-unknown-unknown. See #1013.
+            rustup target add wasm32-unknown-unknown wasm32-wasip1
+            ( cd crates/hyprstream-workers-python-guest && \
+              cargo build --release --target wasm32-unknown-unknown )
+            ( cd crates/hyprstream-workers-wasmtime-fsguest && \
+              cargo build --release --target wasm32-wasip1 )
 
-    - name: Run tests (nextest, per-test timeout)
-      # nextest enforces the per-TEST slow-timeout from .config/nextest.toml
-      # ([profile.ci]): a single deadlocked test is SIGKILLed after ~3min and fails
-      # fast, instead of stalling the job until the 90min job / 120min queue
-      # timeout. The cap is per-test on purpose — the legit suite is long (~76min),
-      # so a per-step timeout could not tell a hang from healthy runtime.
-      env:
-        HYPRSTREAM_PYGUEST_WASM: ${{ github.workspace }}/crates/hyprstream-workers-python-guest/target/wasm32-unknown-unknown/release/hyprstream_workers_python_guest.wasm
-        HYPRSTREAM_FSGUEST_WASM: ${{ github.workspace }}/crates/hyprstream-workers-wasmtime-fsguest/target/wasm32-wasip1/release/hyprstream-workers-wasmtime-fsguest.wasm
-      run: cargo nextest run --cargo-profile ci-test --profile ci --features download-libtorch
+            # cargo-nextest is not baked into the builder image; fetch the arm64
+            # binary (get.nexte.st linux-arm == aarch64) onto PATH in the container.
+            curl -LsSf https://get.nexte.st/latest/linux-arm | tar zxf - -C /usr/local/bin
 
-    - name: Run doctests
-      # nextest does not run doctests; keep them in the merge gate.
-      run: cargo test --release --doc --features download-libtorch
+            # nextest enforces the per-TEST slow-timeout from .config/nextest.toml
+            # ([profile.ci]): a deadlocked test is SIGKILLed rather than stalling the
+            # job to its 90min / the queue to its 120min timeout. Guest wasm paths are
+            # container-absolute (/build is the bind mount).
+            export HYPRSTREAM_PYGUEST_WASM=/build/crates/hyprstream-workers-python-guest/target/wasm32-unknown-unknown/release/hyprstream_workers_python_guest.wasm
+            export HYPRSTREAM_FSGUEST_WASM=/build/crates/hyprstream-workers-wasmtime-fsguest/target/wasm32-wasip1/release/hyprstream-workers-wasmtime-fsguest.wasm
+            cargo nextest run --cargo-profile ci-test --profile ci
 
-    - name: sccache stats
-      if: always()
-      run: sccache --show-stats
+            # nextest does not run doctests; keep them in the merge gate.
+            cargo test --release --doc
+
+            sccache --show-stats
+          '

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -207,63 +207,54 @@ jobs:
           -e CARGO_INCREMENTAL=0 -e CARGO_TERM_COLOR=always \
           "$BUILDER_IMAGE" \
           bash -euo pipefail -c '
-            # Default features (parity with the former x86 gate); libtorch from the
-            # image means NO --features download-libtorch here.
-            #
-            # Runs at full parallelism: the fleet is on memory-optimized r8g/r7g
-            # (8 vCPU / 64 GiB = 8 GiB/vCPU, metal #1011), which absorbs a full
-            # release link at all cores. (The earlier c8g.2xlarge at 2 GiB/vCPU
-            # OOM-killed the runner, so the fix was instance RAM, not a jobs cap.)
-            # No --verbose: it emits a line per rustc invocation and floods the
-            # Actions log pipeline, truncating the visible log ~4min in and hiding
-            # the actual failure. Keep it off so real errors are readable.
-            cargo build --release
-
-            # wasm guest artifacts for the sandbox/mount tests (deny-on-missing-guest
-            # guard). cd INTO each guest crate dir: cargo discovers .cargo/config.toml
-            # from the invocation cwd, not --manifest-path, and the python guest needs
-            # its getrandom_backend="custom" cfg for wasm32-unknown-unknown. See #1013.
-            rustup target add wasm32-unknown-unknown wasm32-wasip1
-            ( cd crates/hyprstream-workers-python-guest && \
-              cargo build --release --target wasm32-unknown-unknown )
-            ( cd crates/hyprstream-workers-wasmtime-fsguest && \
-              cargo build --release --target wasm32-wasip1 )
-
-            # cargo-nextest is not baked into the builder image; fetch the arm64
-            # binary (get.nexte.st linux-arm == aarch64) onto PATH in the container.
+            # ---- root setup (these belong in the builder image; #1011 follow-up) ----
+            # cargo-nextest (get.nexte.st linux-arm == aarch64) onto PATH.
             curl -LsSf https://get.nexte.st/latest/linux-arm | tar zxf - -C /usr/local/bin
-
-            # git-lfs: the git2db LFS worktree tests shell out to the git-lfs binary.
-            # GitHub-hosted ubuntu-latest ships it preinstalled (why the old gate
-            # passed); the arm64 builder image does not, so install it here. TODO:
-            # bake git-lfs into the rust-builder image and drop this step (#1011).
+            # git-lfs: the git2db LFS worktree tests shell out to it. ubuntu-latest
+            # shipped it preinstalled (why the old gate passed); the image does not.
             apt-get update && apt-get install -y --no-install-recommends git-lfs
             git lfs install --system --skip-repo
+            # Add the wasm targets while still root (rustup home is root-owned).
+            rustup target add wasm32-unknown-unknown wasm32-wasip1
 
-            # nextest enforces the per-TEST slow-timeout from .config/nextest.toml
-            # ([profile.ci]): a deadlocked test is SIGKILLed rather than stalling the
-            # job to its 90min / the queue to its 120min timeout. Guest wasm paths are
-            # container-absolute (/build is the bind mount).
-            export HYPRSTREAM_PYGUEST_WASM=/build/crates/hyprstream-workers-python-guest/target/wasm32-unknown-unknown/release/hyprstream_workers_python_guest.wasm
-            export HYPRSTREAM_FSGUEST_WASM=/build/crates/hyprstream-workers-wasmtime-fsguest/target/wasm32-wasip1/release/hyprstream-workers-wasmtime-fsguest.wasm
-            # TEMP (#1011 validation): --no-fail-fast enumerates EVERY arm64 failure
-            # in one pass. Its full console output is too large for the Actions log
-            # API to serve, so capture to a file (uploaded as an artifact below) and
-            # print ONLY the FAIL/summary lines here. Revert to plain fail-fast (no
-            # redirection/artifact) for the real gate.
-            set +e
-            cargo nextest run --cargo-profile ci-test --profile ci --no-fail-fast > /build/nextest-arm64.log 2>&1
-            nextest_rc=$?
-            cargo test --release --doc > /build/doctest-arm64.log 2>&1
-            doctest_rc=$?
-            set -e
-            echo "===== nextest failures (full log in the arm64-test-logs artifact) ====="
-            grep -E "FAIL \[|Summary \[|tests run:|error\[|panicked at|not available" /build/nextest-arm64.log | tail -100 || true
-            echo "===== doctest tail ====="
-            grep -E "test result|error\[|FAILED|panicked at" /build/doctest-arm64.log | tail -30 || true
-            sccache --show-stats
-            echo "nextest_rc=$nextest_rc doctest_rc=$doctest_rc"
-            [ "$nextest_rc" -eq 0 ] && [ "$doctest_rc" -eq 0 ]
+            # Build + test run as a NON-ROOT user. Several fail-closed tests assert a
+            # write to a read-only dir is rejected, but root bypasses file permissions,
+            # so they pass only as non-root (as the old ubuntu-latest gate ran). Make
+            # the toolchain usable by the ci user and hand it the workspace (fresh
+            # checkout, no target/ yet, so the chown is cheap).
+            useradd -m ci
+            chmod a+rx /root
+            chmod -R a+rwX /root/.cargo /root/.rustup
+            chown -R ci:ci /build
+
+            runuser -u ci -- bash -euo pipefail -c "
+              export PATH=/root/.cargo/bin:/usr/local/bin:\$PATH
+              export CARGO_HOME=/root/.cargo RUSTUP_HOME=/root/.rustup
+              export SCCACHE_DIR=/build/.sccache && mkdir -p /build/.sccache
+              # Same-filesystem TMPDIR: overlay_fsmount rename-across-layers fails
+              # EXDEV (cross-device link) when temp dirs land on /tmp (tmpfs) while the
+              # workspace is on another fs. Keep temp on the workspace fs.
+              mkdir -p /build/.citmp && export TMPDIR=/build/.citmp
+              export HYPRSTREAM_PYGUEST_WASM=/build/crates/hyprstream-workers-python-guest/target/wasm32-unknown-unknown/release/hyprstream_workers_python_guest.wasm
+              export HYPRSTREAM_FSGUEST_WASM=/build/crates/hyprstream-workers-wasmtime-fsguest/target/wasm32-wasip1/release/hyprstream-workers-wasmtime-fsguest.wasm
+              cargo build --release
+              ( cd crates/hyprstream-workers-python-guest && cargo build --release --target wasm32-unknown-unknown )
+              ( cd crates/hyprstream-workers-wasmtime-fsguest && cargo build --release --target wasm32-wasip1 )
+              # TEMP (#1011 validation): --no-fail-fast enumerates every failure in one
+              # pass; its full output is too large for the Actions log API, so capture
+              # to files (uploaded as an artifact) and print only FAIL/summary lines.
+              set +e
+              cargo nextest run --cargo-profile ci-test --profile ci --no-fail-fast > /build/nextest-arm64.log 2>&1
+              nextest_rc=\$?
+              cargo test --release --doc > /build/doctest-arm64.log 2>&1
+              doctest_rc=\$?
+              set -e
+              echo ===== nextest failures =====
+              grep -E \"FAIL |Summary |tests run:|not available\" /build/nextest-arm64.log | tail -100 || true
+              sccache --show-stats || true
+              echo nextest_rc=\$nextest_rc doctest_rc=\$doctest_rc
+              [ \"\$nextest_rc\" -eq 0 ] && [ \"\$doctest_rc\" -eq 0 ]
+            "
           '
 
     # TEMP (#1011 validation): full nextest/doctest output, reliable regardless of

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -247,12 +247,33 @@ jobs:
             export HYPRSTREAM_PYGUEST_WASM=/build/crates/hyprstream-workers-python-guest/target/wasm32-unknown-unknown/release/hyprstream_workers_python_guest.wasm
             export HYPRSTREAM_FSGUEST_WASM=/build/crates/hyprstream-workers-wasmtime-fsguest/target/wasm32-wasip1/release/hyprstream-workers-wasmtime-fsguest.wasm
             # TEMP (#1011 validation): --no-fail-fast enumerates EVERY arm64 failure
-            # in one pass instead of stopping at the first, so env/arch gaps surface
-            # together. Revert to plain fail-fast for the real gate.
-            cargo nextest run --cargo-profile ci-test --profile ci --no-fail-fast
-
-            # nextest does not run doctests; keep them in the merge gate.
-            cargo test --release --doc
-
+            # in one pass. Its full console output is too large for the Actions log
+            # API to serve, so capture to a file (uploaded as an artifact below) and
+            # print ONLY the FAIL/summary lines here. Revert to plain fail-fast (no
+            # redirection/artifact) for the real gate.
+            set +e
+            cargo nextest run --cargo-profile ci-test --profile ci --no-fail-fast > /build/nextest-arm64.log 2>&1
+            nextest_rc=$?
+            cargo test --release --doc > /build/doctest-arm64.log 2>&1
+            doctest_rc=$?
+            set -e
+            echo "===== nextest failures (full log in the arm64-test-logs artifact) ====="
+            grep -E "FAIL \[|Summary \[|tests run:|error\[|panicked at|not available" /build/nextest-arm64.log | tail -100 || true
+            echo "===== doctest tail ====="
+            grep -E "test result|error\[|FAILED|panicked at" /build/doctest-arm64.log | tail -30 || true
             sccache --show-stats
+            echo "nextest_rc=$nextest_rc doctest_rc=$doctest_rc"
+            [ "$nextest_rc" -eq 0 ] && [ "$doctest_rc" -eq 0 ]
           '
+
+    # TEMP (#1011 validation): full nextest/doctest output, reliable regardless of
+    # the Actions log-size limit. Remove with the other validation-only bits.
+    - name: Upload arm64 test logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: arm64-test-logs
+        path: |
+          nextest-arm64.log
+          doctest-arm64.log
+        if-no-files-found: warn

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -233,13 +233,23 @@ jobs:
             # binary (get.nexte.st linux-arm == aarch64) onto PATH in the container.
             curl -LsSf https://get.nexte.st/latest/linux-arm | tar zxf - -C /usr/local/bin
 
+            # git-lfs: the git2db LFS worktree tests shell out to the git-lfs binary.
+            # GitHub-hosted ubuntu-latest ships it preinstalled (why the old gate
+            # passed); the arm64 builder image does not, so install it here. TODO:
+            # bake git-lfs into the rust-builder image and drop this step (#1011).
+            apt-get update && apt-get install -y --no-install-recommends git-lfs
+            git lfs install --system --skip-repo
+
             # nextest enforces the per-TEST slow-timeout from .config/nextest.toml
             # ([profile.ci]): a deadlocked test is SIGKILLed rather than stalling the
             # job to its 90min / the queue to its 120min timeout. Guest wasm paths are
             # container-absolute (/build is the bind mount).
             export HYPRSTREAM_PYGUEST_WASM=/build/crates/hyprstream-workers-python-guest/target/wasm32-unknown-unknown/release/hyprstream_workers_python_guest.wasm
             export HYPRSTREAM_FSGUEST_WASM=/build/crates/hyprstream-workers-wasmtime-fsguest/target/wasm32-wasip1/release/hyprstream-workers-wasmtime-fsguest.wasm
-            cargo nextest run --cargo-profile ci-test --profile ci
+            # TEMP (#1011 validation): --no-fail-fast enumerates EVERY arm64 failure
+            # in one pass instead of stopping at the first, so env/arch gaps surface
+            # together. Revert to plain fail-fast for the real gate.
+            cargo nextest run --cargo-profile ci-test --profile ci --no-fail-fast
 
             # nextest does not run doctests; keep them in the merge gate.
             cargo test --release --doc

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -208,11 +208,18 @@ jobs:
             # root bypasses file permissions, so they pass only as non-root (the old
             # ubuntu-latest gate ran non-root). These three installs belong in the
             # builder image and move there in the #1011 follow-up:
-            #   - cargo-nextest (get.nexte.st linux-arm == aarch64)
+            #   - cargo-nextest, pinned to an exact version + verified SHA-256 (never
+            #     the mutable get.nexte.st/latest — this runs in a container holding
+            #     AWS creds, so an unpinned fetch is a supply-chain risk; the image
+            #     follow-up removes the download entirely)
             #   - git-lfs (git2db LFS worktree tests shell out to it; ubuntu-latest
             #     shipped it, the image does not)
             #   - the wasm rustup targets (added while root; rustup home is root-owned)
-            curl -LsSf https://get.nexte.st/latest/linux-arm | tar zxf - -C /usr/local/bin
+            NEXTEST_VERSION=0.9.140
+            NEXTEST_SHA256=8b3f4d4560b6b0f83774fecc6be07e47716dbad0eb0bb6c3890f478f4affe4b6
+            curl -fsSL "https://get.nexte.st/${NEXTEST_VERSION}/linux-arm" -o /tmp/nextest.tar.gz
+            echo "${NEXTEST_SHA256}  /tmp/nextest.tar.gz" | sha256sum -c -
+            tar zxf /tmp/nextest.tar.gz -C /usr/local/bin && rm -f /tmp/nextest.tar.gz
             apt-get update && apt-get install -y --no-install-recommends git-lfs
             git lfs install --system --skip-repo
             rustup target add wasm32-unknown-unknown wasm32-wasip1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -149,11 +149,7 @@ jobs:
     # feedback; `build` is the required check enforced by the `protection` ruleset's
     # merge queue. (Per-PR AppImage artifacts were dropped with the PR build; the
     # `appimage.yml` workflow still builds the AppImage on push to `main`.)
-    # TEMPORARY (#1011 validation, REVERT before merge): the second clause lets
-    # this job run on the pull_request event for THIS branch only, so the arm64
-    # build+test can be watched directly on the PR before it becomes the required
-    # merge gate. No other PR is affected. Remove it to restore merge-gate-only.
-    if: github.event_name != 'pull_request' || github.head_ref == 'ewindisch/1011-build-on-graviton'
+    if: github.event_name != 'pull_request'
     # MERGE GATE runs on the self-hosted Graviton (arm64) fleet, INSIDE the
     # prebuilt rust-builder container via `podman run` — the same layer clippy +
     # wasm use (#1011). Two consequences of arm64-in-container vs the old
@@ -207,64 +203,22 @@ jobs:
           -e CARGO_INCREMENTAL=0 -e CARGO_TERM_COLOR=always \
           "$BUILDER_IMAGE" \
           bash -euo pipefail -c '
-            # ---- root setup (these belong in the builder image; #1011 follow-up) ----
-            # cargo-nextest (get.nexte.st linux-arm == aarch64) onto PATH.
+            # Root-only setup, then hand build+test to a NON-ROOT user. Several
+            # fail-closed tests assert a write to a read-only dir is rejected, but
+            # root bypasses file permissions, so they pass only as non-root (the old
+            # ubuntu-latest gate ran non-root). These three installs belong in the
+            # builder image and move there in the #1011 follow-up:
+            #   - cargo-nextest (get.nexte.st linux-arm == aarch64)
+            #   - git-lfs (git2db LFS worktree tests shell out to it; ubuntu-latest
+            #     shipped it, the image does not)
+            #   - the wasm rustup targets (added while root; rustup home is root-owned)
             curl -LsSf https://get.nexte.st/latest/linux-arm | tar zxf - -C /usr/local/bin
-            # git-lfs: the git2db LFS worktree tests shell out to it. ubuntu-latest
-            # shipped it preinstalled (why the old gate passed); the image does not.
             apt-get update && apt-get install -y --no-install-recommends git-lfs
             git lfs install --system --skip-repo
-            # Add the wasm targets while still root (rustup home is root-owned).
             rustup target add wasm32-unknown-unknown wasm32-wasip1
-
-            # Build + test run as a NON-ROOT user. Several fail-closed tests assert a
-            # write to a read-only dir is rejected, but root bypasses file permissions,
-            # so they pass only as non-root (as the old ubuntu-latest gate ran). Make
-            # the toolchain usable by the ci user and hand it the workspace (fresh
-            # checkout, no target/ yet, so the chown is cheap).
             useradd -m ci
             chmod a+rx /root
             chmod -R a+rwX /root/.cargo /root/.rustup
             chown -R ci:ci /build
-
-            runuser -u ci -- bash -euo pipefail -c "
-              export PATH=/root/.cargo/bin:/usr/local/bin:\$PATH
-              export CARGO_HOME=/root/.cargo RUSTUP_HOME=/root/.rustup
-              export SCCACHE_DIR=/build/.sccache && mkdir -p /build/.sccache
-              # Same-filesystem TMPDIR: overlay_fsmount rename-across-layers fails
-              # EXDEV (cross-device link) when temp dirs land on /tmp (tmpfs) while the
-              # workspace is on another fs. Keep temp on the workspace fs.
-              mkdir -p /build/.citmp && export TMPDIR=/build/.citmp
-              export HYPRSTREAM_PYGUEST_WASM=/build/crates/hyprstream-workers-python-guest/target/wasm32-unknown-unknown/release/hyprstream_workers_python_guest.wasm
-              export HYPRSTREAM_FSGUEST_WASM=/build/crates/hyprstream-workers-wasmtime-fsguest/target/wasm32-wasip1/release/hyprstream-workers-wasmtime-fsguest.wasm
-              cargo build --release
-              ( cd crates/hyprstream-workers-python-guest && cargo build --release --target wasm32-unknown-unknown )
-              ( cd crates/hyprstream-workers-wasmtime-fsguest && cargo build --release --target wasm32-wasip1 )
-              # TEMP (#1011 validation): --no-fail-fast enumerates every failure in one
-              # pass; its full output is too large for the Actions log API, so capture
-              # to files (uploaded as an artifact) and print only FAIL/summary lines.
-              set +e
-              cargo nextest run --cargo-profile ci-test --profile ci --no-fail-fast > /build/nextest-arm64.log 2>&1
-              nextest_rc=\$?
-              cargo test --release --doc > /build/doctest-arm64.log 2>&1
-              doctest_rc=\$?
-              set -e
-              echo ===== nextest failures =====
-              grep -E \"FAIL |Summary |tests run:|not available\" /build/nextest-arm64.log | tail -100 || true
-              sccache --show-stats || true
-              echo nextest_rc=\$nextest_rc doctest_rc=\$doctest_rc
-              [ \"\$nextest_rc\" -eq 0 ] && [ \"\$doctest_rc\" -eq 0 ]
-            "
+            runuser -u ci -- bash -euo pipefail /build/.github/scripts/graviton-build-test.sh
           '
-
-    # TEMP (#1011 validation): full nextest/doctest output, reliable regardless of
-    # the Actions log-size limit. Remove with the other validation-only bits.
-    - name: Upload arm64 test logs
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: arm64-test-logs
-        path: |
-          nextest-arm64.log
-          doctest-arm64.log
-        if-no-files-found: warn

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -167,12 +167,13 @@ jobs:
     #      not baked in, so it is fetched into the container below.
     runs-on: [self-hosted, linux, arm64, graviton, hyprstream-merge-gate]
     needs: clippy  # Only build if clippy passes
-    # Merge-gate backstop: fail before the merge queue's 120min timeout (ruleset
-    # check_response_timeout_minutes) so a hang yields a definitive failure and the
-    # queue keeps moving instead of timing out and kicking every queued PR. The
-    # nextest step uses the ci-test Cargo profile to avoid release ThinLTO on test
-    # binaries, so 90min should retain headroom while catching regressions.
-    timeout-minutes: 90
+    # Backstop below the fleet's 150-min reaper cap (metal reaper_max_lifetime_
+    # minutes) so a genuine hang fails definitively rather than being reaped
+    # mid-run. A COLD-cache build+test can approach this; once sccache (S3) is
+    # warm, real runs finish well under the merge queue's 120-min
+    # check_response_timeout. The nextest ci-test profile avoids release ThinLTO
+    # on test binaries to keep the suite bounded.
+    timeout-minutes: 140
 
     steps:
     - uses: actions/checkout@v4
@@ -204,19 +205,19 @@ jobs:
           -e LIBTORCH=/opt/libtorch -e LD_LIBRARY_PATH=/opt/libtorch/lib \
           -e LIBTORCH_BYPASS_VERSION_CHECK=1 -e OPENSSL_NO_VENDOR=1 \
           -e CARGO_INCREMENTAL=0 -e CARGO_TERM_COLOR=always \
-          -e CARGO_BUILD_JOBS=4 -e RUST_TEST_THREADS=4 \
           "$BUILDER_IMAGE" \
           bash -euo pipefail -c '
             # Default features (parity with the former x86 gate); libtorch from the
             # image means NO --features download-libtorch here.
             #
-            # CARGO_BUILD_JOBS=4 (set via -e above): the c8g.2xlarge is 8 vCPU /
-            # 16GiB — same RAM as the old ubuntu-latest gate but twice the cores, so
-            # cargos default of one job per core runs 8-way and OOM-kills a full
-            # release link on 16GiB. 4-way matches the parallelism the 16GiB x86
-            # runner used successfully. Bump instance RAM (not this cap) if the
-            # build wall-time becomes the constraint.
-            cargo build --release --verbose
+            # Runs at full parallelism: the fleet is on memory-optimized r8g/r7g
+            # (8 vCPU / 64 GiB = 8 GiB/vCPU, metal #1011), which absorbs a full
+            # release link at all cores. (The earlier c8g.2xlarge at 2 GiB/vCPU
+            # OOM-killed the runner, so the fix was instance RAM, not a jobs cap.)
+            # No --verbose: it emits a line per rustc invocation and floods the
+            # Actions log pipeline, truncating the visible log ~4min in and hiding
+            # the actual failure. Keep it off so real errors are readable.
+            cargo build --release
 
             # wasm guest artifacts for the sandbox/mount tests (deny-on-missing-guest
             # guard). cd INTO each guest crate dir: cargo discovers .cargo/config.toml
@@ -238,10 +239,7 @@ jobs:
             # container-absolute (/build is the bind mount).
             export HYPRSTREAM_PYGUEST_WASM=/build/crates/hyprstream-workers-python-guest/target/wasm32-unknown-unknown/release/hyprstream_workers_python_guest.wasm
             export HYPRSTREAM_FSGUEST_WASM=/build/crates/hyprstream-workers-wasmtime-fsguest/target/wasm32-wasip1/release/hyprstream-workers-wasmtime-fsguest.wasm
-            # --test-threads bounded for the same 16GiB memory reason as
-            # CARGO_BUILD_JOBS: libtorch-loading tests are memory-heavy and the
-            # 8-vCPU default over-subscribes RAM.
-            cargo nextest run --cargo-profile ci-test --profile ci --test-threads 4
+            cargo nextest run --cargo-profile ci-test --profile ci
 
             # nextest does not run doctests; keep them in the merge gate.
             cargo test --release --doc

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -204,10 +204,18 @@ jobs:
           -e LIBTORCH=/opt/libtorch -e LD_LIBRARY_PATH=/opt/libtorch/lib \
           -e LIBTORCH_BYPASS_VERSION_CHECK=1 -e OPENSSL_NO_VENDOR=1 \
           -e CARGO_INCREMENTAL=0 -e CARGO_TERM_COLOR=always \
+          -e CARGO_BUILD_JOBS=4 -e RUST_TEST_THREADS=4 \
           "$BUILDER_IMAGE" \
           bash -euo pipefail -c '
             # Default features (parity with the former x86 gate); libtorch from the
             # image means NO --features download-libtorch here.
+            #
+            # CARGO_BUILD_JOBS=4 (set via -e above): the c8g.2xlarge is 8 vCPU /
+            # 16GiB — same RAM as the old ubuntu-latest gate but twice the cores, so
+            # cargos default of one job per core runs 8-way and OOM-kills a full
+            # release link on 16GiB. 4-way matches the parallelism the 16GiB x86
+            # runner used successfully. Bump instance RAM (not this cap) if the
+            # build wall-time becomes the constraint.
             cargo build --release --verbose
 
             # wasm guest artifacts for the sandbox/mount tests (deny-on-missing-guest
@@ -230,7 +238,10 @@ jobs:
             # container-absolute (/build is the bind mount).
             export HYPRSTREAM_PYGUEST_WASM=/build/crates/hyprstream-workers-python-guest/target/wasm32-unknown-unknown/release/hyprstream_workers_python_guest.wasm
             export HYPRSTREAM_FSGUEST_WASM=/build/crates/hyprstream-workers-wasmtime-fsguest/target/wasm32-wasip1/release/hyprstream-workers-wasmtime-fsguest.wasm
-            cargo nextest run --cargo-profile ci-test --profile ci
+            # --test-threads bounded for the same 16GiB memory reason as
+            # CARGO_BUILD_JOBS: libtorch-loading tests are memory-heavy and the
+            # 8-vCPU default over-subscribes RAM.
+            cargo nextest run --cargo-profile ci-test --profile ci --test-threads 4
 
             # nextest does not run doctests; keep them in the merge gate.
             cargo test --release --doc

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -149,7 +149,11 @@ jobs:
     # feedback; `build` is the required check enforced by the `protection` ruleset's
     # merge queue. (Per-PR AppImage artifacts were dropped with the PR build; the
     # `appimage.yml` workflow still builds the AppImage on push to `main`.)
-    if: github.event_name != 'pull_request'
+    # TEMPORARY (#1011 validation, REVERT before merge): the second clause lets
+    # this job run on the pull_request event for THIS branch only, so the arm64
+    # build+test can be watched directly on the PR before it becomes the required
+    # merge gate. No other PR is affected. Remove it to restore merge-gate-only.
+    if: github.event_name != 'pull_request' || github.head_ref == 'ewindisch/1011-build-on-graviton'
     # MERGE GATE runs on the self-hosted Graviton (arm64) fleet, INSIDE the
     # prebuilt rust-builder container via `podman run` — the same layer clippy +
     # wasm use (#1011). Two consequences of arm64-in-container vs the old


### PR DESCRIPTION
## What

Moves the required `build` merge gate off GitHub-hosted `ubuntu-latest` (x86_64) onto the self-hosted **Graviton (arm64)** fleet, running inside the prebuilt `rust-builder` container via `podman run` — the same execution layer clippy/wasm already use and the one `graviton-build-validate.yml` (#1011) proved out.

## Why

Today only the fast **clippy/wasm** lint jobs run on Graviton; the heavy build+test — the *one required merge-gate check* — runs on ubuntu-latest x86. So the fleet named `hyprstream-merge-gate` does not actually gate on the build, and the gate pays GitHub-hosted minutes + pulls the sccache bucket cross-internet + tests only x86 (arm64 is a required release target).

## How / coverage

- **Same feature coverage** as the old gate: default features (`gittorrent, xet, systemd, otel, kata-vm, nspawn`). The only change is libtorch comes from the image's **aarch64 wheel at `/opt/libtorch`** instead of the x86-only `download-libtorch` feature (no aarch64 libtorch zip exists at download.pytorch.org).
- Build deps (`capnproto`, `libsystemd-dev`) and `sccache` are baked into the image; `cargo-nextest` is fetched in-container (arm64).
- Full sequence in one container so sccache stays warm and `target/` persists: `cargo build --release` → wasm guest artifacts → `cargo nextest run --profile ci` → doctests.
- sccache → **same-region S3** (no cross-internet cache pull).

## Validation / risk

The arm64 `cargo build` has gone green on Graviton (#1011 validate runs), but the **nextest + doctest suite has never run on arm64**. This PR is intentionally **self-validating via the merge queue**: the `build` job is merge-gate-only (`if: github.event_name != 'pull_request'`), so it runs when this PR enters the queue. **If arm64 tests fail, this PR simply does not merge and `main` is unaffected.** Any real arm64 test failures surfaced here are the remaining #1011 work.

Closes #1011.