### PR TITLE
ci: bake CI deps into the rust-builder image, drop per-run installs (#1011)

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -13,6 +13,7 @@ on:
     branches: [main, ewindisch/runner-smoke-test]
     paths:
       - 'Dockerfile'
+      - 'rust-toolchain.toml'
       - '.github/workflows/build-image.yml'
   schedule:
     # Weekly rebuild to pick up base-image/toolchain security updates.

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -33,10 +33,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Compute immutable tag (Dockerfile content hash)
+      - name: Compute immutable tag (hash of all image inputs)
         id: tag
         run: |
-          h=$(git hash-object Dockerfile | cut -c1-12)
+          # Hash every input that affects image contents so the tag stays
+          # content-addressed: the Dockerfile AND rust-toolchain.toml (COPYed in to
+          # provision the pinned toolchain). Hashing only the Dockerfile would let a
+          # toolchain-only change overwrite the same date-tag with different bytes.
+          h=$(git hash-object Dockerfile rust-toolchain.toml | sha256sum | cut -c1-12)
           echo "sha=$h" >> "$GITHUB_OUTPUT"
           echo "date=$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -161,8 +161,9 @@ jobs:
     #      (systemd/kata-vm/nspawn/otel/gittorrent/xet) matches the former gate.
     #   2. all tooling is baked into the image — build deps (capnproto,
     #      libsystemd-dev), sccache, cargo-nextest, git-lfs, and the pinned
-    #      toolchain (components + wasm targets) — so the job fetches nothing over
-    #      the network at runtime (only sets up the non-root ci user below).
+    #      toolchain (components + wasm targets) — so the job installs no TOOLING
+    #      over the network at runtime (cargo still fetches workspace/crate deps,
+    #      served by sccache-S3 + crates.io). It only sets up the non-root ci user.
     runs-on: [self-hosted, linux, arm64, graviton, hyprstream-merge-gate]
     needs: clippy  # Only build if clippy passes
     # Backstop below the fleet's 150-min reaper cap (metal reaper_max_lifetime_

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,8 +23,11 @@ env:
   SCCACHE_BUCKET: ${{ vars.AWS_SCCACHE_BUCKET }}
   SCCACHE_REGION: ${{ vars.AWS_SCCACHE_REGION }}
   CARGO_INCREMENTAL: 0
-  # Pin the arm64 image resolved from :latest on 2026-07-14. Bump this digest
-  # deliberately after a builder-image publish so CI inputs remain reproducible.
+  # Pinned arm64 rust-builder image (built by build-image.yml): toolchain +
+  # libtorch + capnproto + sccache + cargo-nextest + git-lfs + the pinned Rust
+  # toolchain's components/targets, all baked. Bump this digest deliberately after
+  # a builder-image publish so CI inputs stay reproducible (a follow-up automates
+  # the bump — see build-image.yml).
   BUILDER_IMAGE: ghcr.io/hyprstream/rust-builder-arm64@sha256:aa9feb1c8432ebf4583fcfc9c8236c371cb050f489c4d0882a7f2d8c8589120e
 
 # The fast lint jobs (clippy, wasm) run on the self-hosted Graviton (arm64)
@@ -156,9 +159,10 @@ jobs:
     #      there is NO `download-libtorch` feature (no aarch64 libtorch zip
     #      exists). Default features are otherwise unchanged, so coverage
     #      (systemd/kata-vm/nspawn/otel/gittorrent/xet) matches the former gate.
-    #   2. build deps (capnproto, libsystemd-dev) and sccache are baked into the
-    #      image, so there is no host apt-get / sccache-action; cargo-nextest is
-    #      not baked in, so it is fetched into the container below.
+    #   2. all tooling is baked into the image — build deps (capnproto,
+    #      libsystemd-dev), sccache, cargo-nextest, git-lfs, and the pinned
+    #      toolchain (components + wasm targets) — so the job fetches nothing over
+    #      the network at runtime (only sets up the non-root ci user below).
     runs-on: [self-hosted, linux, arm64, graviton, hyprstream-merge-gate]
     needs: clippy  # Only build if clippy passes
     # Backstop below the fleet's 150-min reaper cap (metal reaper_max_lifetime_

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ env:
   CARGO_INCREMENTAL: 0
   # Pin the arm64 image resolved from :latest on 2026-07-14. Bump this digest
   # deliberately after a builder-image publish so CI inputs remain reproducible.
-  BUILDER_IMAGE: ghcr.io/hyprstream/rust-builder-arm64@sha256:ffc858b5d7c050129f6f6e7d73366f5b45f7be274e8c5161df9623fa25e027c2
+  BUILDER_IMAGE: ghcr.io/hyprstream/rust-builder-arm64@sha256:aa9feb1c8432ebf4583fcfc9c8236c371cb050f489c4d0882a7f2d8c8589120e
 
 # The fast lint jobs (clippy, wasm) run on the self-hosted Graviton (arm64)
 # runners and drive the build through `podman run` against the prebuilt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ env:
   CARGO_INCREMENTAL: 0
   # Pin the arm64 image resolved from :latest on 2026-07-14. Bump this digest
   # deliberately after a builder-image publish so CI inputs remain reproducible.
-  BUILDER_IMAGE: ghcr.io/hyprstream/rust-builder-arm64@sha256:92d8b445f8020e38a4ab08a5868b98819630e3bbf3425f3e281b0e66f1e4b9d5
+  BUILDER_IMAGE: ghcr.io/hyprstream/rust-builder-arm64@sha256:ffc858b5d7c050129f6f6e7d73366f5b45f7be274e8c5161df9623fa25e027c2
 
 # The fast lint jobs (clippy, wasm) run on the self-hosted Graviton (arm64)
 # runners and drive the build through `podman run` against the prebuilt
@@ -82,7 +82,6 @@ jobs:
           -e CARGO_INCREMENTAL=0 -e CARGO_TERM_COLOR=always \
           "$BUILDER_IMAGE" \
           bash -euo pipefail -c '
-            rustup component add clippy
             cargo clippy --workspace --all-targets -- -D warnings
             sccache --show-stats
           '
@@ -137,7 +136,6 @@ jobs:
           -e RUSTFLAGS='--cfg=web_sys_unstable_apis' \
           "$BUILDER_IMAGE" \
           bash -euo pipefail -c '
-            rustup target add wasm32-unknown-unknown
             cargo check --target wasm32-unknown-unknown -p hyprstream-rpc
             sccache --show-stats
           '
@@ -203,26 +201,12 @@ jobs:
           -e CARGO_INCREMENTAL=0 -e CARGO_TERM_COLOR=always \
           "$BUILDER_IMAGE" \
           bash -euo pipefail -c '
-            # Root-only setup, then hand build+test to a NON-ROOT user. Several
-            # fail-closed tests assert a write to a read-only dir is rejected, but
-            # root bypasses file permissions, so they pass only as non-root (the old
-            # ubuntu-latest gate ran non-root). These three installs belong in the
-            # builder image and move there in the #1011 follow-up:
-            #   - cargo-nextest, pinned to an exact version + verified SHA-256 (never
-            #     the mutable get.nexte.st/latest — this runs in a container holding
-            #     AWS creds, so an unpinned fetch is a supply-chain risk; the image
-            #     follow-up removes the download entirely)
-            #   - git-lfs (git2db LFS worktree tests shell out to it; ubuntu-latest
-            #     shipped it, the image does not)
-            #   - the wasm rustup targets (added while root; rustup home is root-owned)
-            NEXTEST_VERSION=0.9.140
-            NEXTEST_SHA256=8b3f4d4560b6b0f83774fecc6be07e47716dbad0eb0bb6c3890f478f4affe4b6
-            curl -fsSL "https://get.nexte.st/${NEXTEST_VERSION}/linux-arm" -o /tmp/nextest.tar.gz
-            echo "${NEXTEST_SHA256}  /tmp/nextest.tar.gz" | sha256sum -c -
-            tar zxf /tmp/nextest.tar.gz -C /usr/local/bin && rm -f /tmp/nextest.tar.gz
-            apt-get update && apt-get install -y --no-install-recommends git-lfs
-            git lfs install --system --skip-repo
-            rustup target add wasm32-unknown-unknown wasm32-wasip1
+            # cargo-nextest, git-lfs, the wasm targets and clippy are baked into the
+            # builder image (BUILDER_IMAGE, Dockerfile builder-cpu-arm64) — no runtime
+            # installs here. Only set up the NON-ROOT user: several fail-closed tests
+            # assert a write to a read-only dir is rejected, but root bypasses file
+            # permissions, so they pass only as non-root (the old ubuntu-latest gate
+            # ran non-root). Make the toolchain usable by ci and hand it the workspace.
             useradd -m ci
             chmod a+rx /root
             chmod -R a+rwX /root/.cargo /root/.rustup

--- a/Dockerfile
+++ b/Dockerfile
@@ -189,15 +189,12 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 ENV LIBTORCH=/opt/libtorch
 ENV LD_LIBRARY_PATH=/opt/libtorch/lib
 
-# Toolchain-independent CI tooling for the merge-gate job (rust.yml), baked here
-# so the job does not fetch these over the network at runtime (removes per-run
-# apt/curl round-trips and their flake risk; #1011 follow-up):
+# CI tooling for the merge-gate job (rust.yml), baked here so the job does not
+# fetch anything over the network at runtime (removes per-run round-trips and
+# their flake/supply-chain risk; #1011 follow-up):
 #   - git-lfs: git2db's LFS worktree tests shell out to the git-lfs binary.
 #   - cargo-nextest: pinned + SHA-256 verified (never get.nexte.st/latest — a
 #     mutable fetch that would otherwise run in an AWS-credentialed container).
-# Rust *targets* and *components* are toolchain-scoped and the repo pins its
-# toolchain via rust-toolchain.toml (channel + components + targets), so they are
-# NOT baked here — rustup provisions them for the pinned toolchain at first use.
 ARG NEXTEST_VERSION=0.9.140
 ARG NEXTEST_SHA256=8b3f4d4560b6b0f83774fecc6be07e47716dbad0eb0bb6c3890f478f4affe4b6
 RUN apt-get update && apt-get install -y --no-install-recommends git-lfs \
@@ -208,6 +205,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends git-lfs \
     && tar zxf /tmp/nextest.tar.gz -C /root/.cargo/bin \
     && rm -f /tmp/nextest.tar.gz \
     && cargo-nextest --version && git-lfs --version
+
+# Pre-provision the repo's pinned Rust toolchain (channel + components + targets)
+# from rust-toolchain.toml so the merge gate does NOT rustup-download it at
+# runtime. Channel is read from the file (no version duplication); the component/
+# target adds operate on that active toolchain. build-image.yml rebuilds on
+# rust-toolchain.toml changes so the baked toolchain stays in sync with the pin.
+COPY rust-toolchain.toml /tmp/tc/rust-toolchain.toml
+RUN cd /tmp/tc \
+    && rustup show \
+    && rustup component add clippy rustfmt \
+    && rustup target add wasm32-unknown-unknown wasm32-wasip1 \
+    && rustup target list --installed | grep -qx wasm32-wasip1 \
+    && rm -rf /tmp/tc
 
 #############################################
 # Select Builder Based on Variant

--- a/Dockerfile
+++ b/Dockerfile
@@ -189,13 +189,15 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 ENV LIBTORCH=/opt/libtorch
 ENV LD_LIBRARY_PATH=/opt/libtorch/lib
 
-# CI tooling for the merge-gate job (rust.yml), baked here so the job does not
-# fetch these over the network at runtime (removes per-run apt/curl round-trips
-# and their flake risk; #1011 follow-up):
+# Toolchain-independent CI tooling for the merge-gate job (rust.yml), baked here
+# so the job does not fetch these over the network at runtime (removes per-run
+# apt/curl round-trips and their flake risk; #1011 follow-up):
 #   - git-lfs: git2db's LFS worktree tests shell out to the git-lfs binary.
 #   - cargo-nextest: pinned + SHA-256 verified (never get.nexte.st/latest — a
 #     mutable fetch that would otherwise run in an AWS-credentialed container).
-#   - the wasm targets + clippy component the jobs need.
+# Rust *targets* and *components* are toolchain-scoped and the repo pins its
+# toolchain via rust-toolchain.toml (channel + components + targets), so they are
+# NOT baked here — rustup provisions them for the pinned toolchain at first use.
 ARG NEXTEST_VERSION=0.9.140
 ARG NEXTEST_SHA256=8b3f4d4560b6b0f83774fecc6be07e47716dbad0eb0bb6c3890f478f4affe4b6
 RUN apt-get update && apt-get install -y --no-install-recommends git-lfs \
@@ -205,8 +207,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends git-lfs \
     && echo "${NEXTEST_SHA256}  /tmp/nextest.tar.gz" | sha256sum -c - \
     && tar zxf /tmp/nextest.tar.gz -C /root/.cargo/bin \
     && rm -f /tmp/nextest.tar.gz \
-    && rustup target add wasm32-unknown-unknown wasm32-wasip1 \
-    && rustup component add clippy \
     && cargo-nextest --version && git-lfs --version
 
 #############################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -189,6 +189,26 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 ENV LIBTORCH=/opt/libtorch
 ENV LD_LIBRARY_PATH=/opt/libtorch/lib
 
+# CI tooling for the merge-gate job (rust.yml), baked here so the job does not
+# fetch these over the network at runtime (removes per-run apt/curl round-trips
+# and their flake risk; #1011 follow-up):
+#   - git-lfs: git2db's LFS worktree tests shell out to the git-lfs binary.
+#   - cargo-nextest: pinned + SHA-256 verified (never get.nexte.st/latest — a
+#     mutable fetch that would otherwise run in an AWS-credentialed container).
+#   - the wasm targets + clippy component the jobs need.
+ARG NEXTEST_VERSION=0.9.140
+ARG NEXTEST_SHA256=8b3f4d4560b6b0f83774fecc6be07e47716dbad0eb0bb6c3890f478f4affe4b6
+RUN apt-get update && apt-get install -y --no-install-recommends git-lfs \
+    && git lfs install --system --skip-repo \
+    && rm -rf /var/lib/apt/lists/* && apt-get clean \
+    && curl -fsSL "https://get.nexte.st/${NEXTEST_VERSION}/linux-arm" -o /tmp/nextest.tar.gz \
+    && echo "${NEXTEST_SHA256}  /tmp/nextest.tar.gz" | sha256sum -c - \
+    && tar zxf /tmp/nextest.tar.gz -C /root/.cargo/bin \
+    && rm -f /tmp/nextest.tar.gz \
+    && rustup target add wasm32-unknown-unknown wasm32-wasip1 \
+    && rustup component add clippy \
+    && cargo-nextest --version && git-lfs --version
+
 #############################################
 # Select Builder Based on Variant
 #############################################

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -7,3 +7,7 @@
 [toolchain]
 channel = "1.97.0"
 components = ["clippy", "rustfmt"]
+# Declared here (not `rustup target add` in CI) so the pinned toolchain provisions
+# them consistently for CI and local dev. The wasm32 targets are needed by the
+# browser/WebTransport build (hyprstream-rpc) and the sandbox wasm guests.
+targets = ["wasm32-unknown-unknown", "wasm32-wasip1"]


### PR DESCRIPTION
## What

Follow-up to the Graviton merge-gate migration (#1055). Bakes the CI dependencies into the `rust-builder-arm64` image and removes the per-run installs from the workflow.

**Dockerfile (`builder-cpu-arm64`):** adds `git-lfs`, `cargo-nextest` (pinned **0.9.140** + SHA-256 verified), the `wasm32-unknown-unknown`/`wasm32-wasip1` targets, and the `clippy` component.

**rust.yml:** pins `BUILDER_IMAGE` to the new digest (`sha256:ffc858b5…`) and deletes the runtime installs from all three jobs:
- **build:** the `get.nexte.st` nextest download, `apt-get install git-lfs`, `rustup target add wasm32…`
- **clippy:** `rustup component add clippy`
- **wasm:** `rustup target add wasm32-unknown-unknown`

## Why

Each merge-gate build made ~4 network round-trips (ghcr aside) just to set up tooling — slow and a reliability/supply-chain risk inside an AWS-credentialed container (CodeRabbit flagged the unpinned nextest fetch on #1055; that fetch is now gone entirely). Baking them makes the gate faster and removes those failure modes.

## Validation

The new image was built + published via `build-image.yml` on this branch (run 29580161570) and pinned by digest. The merge_group runs the slimmed workflow against the baked image — self-validating; if a baked tool is missing/wrong, it won't merge.

## Follow-ups (separate PRs)
1. **metal:** set the AMI `prepull_image` to this digest (finishes #996) + rebake, so jobs stop cold-pulling the multi-GB image.
2. **automation:** wire `build-image.yml` → auto-PR bumping this digest → conditional AMI rebake.