### PR TITLE
feat(rpc): add identified hybrid stream epochs

### DIFF
--- a/crates/hyprstream-rpc/src/crypto/event_crypto.rs
+++ b/crates/hyprstream-rpc/src/crypto/event_crypto.rs
@@ -350,6 +350,32 @@ pub fn encrypt_event(
     Ok((tag, ciphertext, nonce, commitment))
 }
 
+/// Encrypt with an explicit nonce supplied by a stateful protocol.
+///
+/// This is crate-private because nonce uniqueness becomes the caller's
+/// responsibility.  The identified stream epoch profile derives the nonce from
+/// its direction/track/epoch domain plus the authenticated sequence number.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn encrypt_event_with_nonce(
+    group_key: &[u8; 32],
+    nonce: [u8; 12],
+    aad: &str,
+    plaintext: &[u8],
+) -> Result<(Vec<u8>, Vec<u8>, [u8; 12], [u8; 16]), String> {
+    let commitment = key_commitment(group_key, &nonce);
+    let aead_output = aes_gcm_encrypt(group_key, &nonce, plaintext, aad.as_bytes())?;
+    if aead_output.len() < 16 {
+        return Err("AEAD output too short".to_owned());
+    }
+    let split = aead_output.len() - 16;
+    Ok((
+        aead_output[split..].to_vec(),
+        aead_output[..split].to_vec(),
+        nonce,
+        commitment,
+    ))
+}
+
 /// Decrypt an event with full AAD binding (tag + ciphertext + prefix).
 ///
 /// This is the preferred decryption path for EventEnvelopeV2, which
@@ -717,9 +743,14 @@ mod tests {
         let leaf = "deadbeef".repeat(8); // 64 hex chars, like topic_leaf output
         let epoch = 7u64;
 
-        let (tag, ct, nonce, _commitment) =
-            encrypt_event_keyed(&group_key, &leaf, epoch, plaintext, EventPrivacy::ZeroKnowledge)
-                .unwrap();
+        let (tag, ct, nonce, _commitment) = encrypt_event_keyed(
+            &group_key,
+            &leaf,
+            epoch,
+            plaintext,
+            EventPrivacy::ZeroKnowledge,
+        )
+        .unwrap();
         let recovered = decrypt_event_keyed(&group_key, &nonce, &tag, &ct, &leaf, epoch).unwrap();
         assert_eq!(recovered, plaintext);
 

--- a/crates/hyprstream-rpc/src/crypto/key_exchange.rs
+++ b/crates/hyprstream-rpc/src/crypto/key_exchange.rs
@@ -271,6 +271,56 @@ pub fn client_hybrid_stream_keys(
     derive_stream_keys(&secret, &client_salt, &server_salt)
 }
 
+/// Server side of the transcript-bound identified stream epoch bootstrap.
+///
+/// This is the production successor to [`server_hybrid_stream_keys`].  The
+/// pinned HyKEM combiner secret is mixed with the complete accepted-current
+/// stream binding before any direction/track/epoch traffic key is derived.
+pub fn server_identified_stream_epoch(
+    client_kem_public: &[u8],
+    binding: crate::stream_epoch::IdentifiedStreamBinding,
+) -> EnvelopeResult<(
+    crate::crypto::hybrid_kem::HybridKemMaterial,
+    crate::stream_epoch::StreamEpochRatchet,
+)> {
+    let client_pub = crate::crypto::hybrid_kem::RecipientPublic::decode(client_kem_public)
+        .map_err(|e| EnvelopeError::KeyExchange(format!("invalid client KEM public: {e}")))?;
+    if client_pub.suite_id != crate::stream_epoch::IDENTIFIED_STREAM_SUITE {
+        return Err(EnvelopeError::KeyExchange(
+            "identified stream requires the pinned X25519+ML-KEM-768 suite".into(),
+        ));
+    }
+    let (material, secret) = crate::crypto::hybrid_kem::encapsulate_to(&client_pub)
+        .map_err(|e| EnvelopeError::KeyExchange(format!("hybrid encapsulate failed: {e}")))?;
+    let ratchet = crate::stream_epoch::StreamEpochRatchet::from_hybrid_secret(&secret, binding)
+        .map_err(|e| EnvelopeError::KeyExchange(format!("stream transcript rejected: {e}")))?;
+    Ok((material, ratchet))
+}
+
+/// Client side of the transcript-bound identified stream epoch bootstrap.
+pub fn client_identified_stream_epoch(
+    keypair: &crate::crypto::hybrid_kem::RecipientKeypair,
+    kem_ciphertexts: &[u8],
+    binding: crate::stream_epoch::IdentifiedStreamBinding,
+) -> EnvelopeResult<crate::stream_epoch::StreamEpochRatchet> {
+    if keypair.suite_id != crate::stream_epoch::IDENTIFIED_STREAM_SUITE {
+        return Err(EnvelopeError::KeyExchange(
+            "identified stream requires the pinned X25519+ML-KEM-768 suite".into(),
+        ));
+    }
+    let material = crate::crypto::hybrid_kem::HybridKemMaterial::decode(kem_ciphertexts)
+        .map_err(|e| EnvelopeError::KeyExchange(format!("invalid KEM ciphertexts: {e}")))?;
+    if material.suite_id != crate::stream_epoch::IDENTIFIED_STREAM_SUITE {
+        return Err(EnvelopeError::KeyExchange(
+            "identified stream ciphertexts use the wrong suite".into(),
+        ));
+    }
+    let secret = crate::crypto::hybrid_kem::decapsulate(keypair, &material)
+        .map_err(|e| EnvelopeError::KeyExchange(format!("hybrid decapsulate failed: {e}")))?;
+    crate::stream_epoch::StreamEpochRatchet::from_hybrid_secret(&secret, binding)
+        .map_err(|e| EnvelopeError::KeyExchange(format!("stream transcript rejected: {e}")))
+}
+
 /// One-way epoch ratchet for long-lived streams (S3 #554 / #223).
 ///
 /// Derive the next epoch's key from the current one via a one-way KDF: a

--- a/crates/hyprstream-rpc/src/envelope.rs
+++ b/crates/hyprstream-rpc/src/envelope.rs
@@ -633,6 +633,14 @@ pub struct RequestEnvelope {
     /// ephemeral keypair to derive the shared secret for HMAC chain keys.
     pub client_dh_public: Option<[u8; 32]>,
 
+    /// Fresh, suite-complete HyKEM recipient for identified stream setup.
+    ///
+    /// This is authenticated inside the request envelope and is distinct from
+    /// both the legacy classical DH field and the one-shot unary-response
+    /// recipient.  The server must bind it into an [`IdentifiedStreamBinding`]
+    /// before deriving or releasing stream epoch keys.
+    pub client_kem_public: Option<crate::crypto::hybrid_kem::RecipientPublic>,
+
     /// Fresh per-call hybrid-KEM recipient for the unary response. This is
     /// distinct from both legacy `client_dh_public` and stream-plane
     /// `clientKemPublic`, and is carried only inside a sealed network request.
@@ -655,6 +663,7 @@ impl RequestEnvelope {
             delegation_token: None,
             wth: None,
             client_dh_public: None,
+            client_kem_public: None,
             response_kem_recipient: None,
             service_domain: None,
         }
@@ -690,6 +699,23 @@ impl RequestEnvelope {
     pub fn with_client_dh_public(mut self, key: [u8; 32]) -> Self {
         self.client_dh_public = Some(key);
         self
+    }
+
+    /// Set the identified stream's ephemeral, pinned-suite HyKEM recipient.
+    pub fn with_client_kem_public(
+        mut self,
+        recipient: crate::crypto::hybrid_kem::RecipientPublic,
+    ) -> EnvelopeResult<Self> {
+        recipient
+            .validate()
+            .map_err(|error| EnvelopeError::KeyExchange(error.to_string()))?;
+        if recipient.suite_id != crate::stream_epoch::IDENTIFIED_STREAM_SUITE {
+            return Err(EnvelopeError::KeyExchange(
+                "identified streams require the pinned X25519+ML-KEM-768 suite".into(),
+            ));
+        }
+        self.client_kem_public = Some(recipient);
+        Ok(self)
     }
 
     /// Set the one-shot HyKEM recipient for the corresponding unary response.
@@ -1613,6 +1639,7 @@ impl SignedEnvelope {
             delegation_token: None,
             wth: None,
             client_dh_public: None,
+            client_kem_public: None,
             response_kem_recipient: None,
             service_domain: None,
         }
@@ -2096,6 +2123,9 @@ impl ToCapnp for RequestEnvelope {
         if let Some(ref key) = self.client_dh_public {
             builder.set_client_dh_public(key);
         }
+        if let Some(ref recipient) = self.client_kem_public {
+            builder.set_client_kem_public(&recipient.encode());
+        }
         if let Some(ref recipient) = self.response_kem_recipient {
             builder.set_response_kem_recipient(&recipient.encode());
         }
@@ -2169,6 +2199,28 @@ impl FromCapnp for RequestEnvelope {
             }
         };
 
+        let client_kem_public = {
+            let data = reader.get_client_kem_public()?;
+            if data.is_empty() {
+                None
+            } else {
+                if data.len() > MAX_RESPONSE_KEM_RECIPIENT_BYTES {
+                    return Err(anyhow!(
+                        "clientKemPublic exceeds {} byte limit",
+                        MAX_RESPONSE_KEM_RECIPIENT_BYTES
+                    ));
+                }
+                let recipient = crate::crypto::hybrid_kem::RecipientPublic::decode(data)
+                    .map_err(|e| anyhow!("invalid clientKemPublic: {e}"))?;
+                if recipient.suite_id != crate::stream_epoch::IDENTIFIED_STREAM_SUITE {
+                    return Err(anyhow!(
+                        "clientKemPublic does not use the pinned identified-stream suite"
+                    ));
+                }
+                Some(recipient)
+            }
+        };
+
         let response_kem_recipient = {
             let data = reader.get_response_kem_recipient()?;
             if data.is_empty() {
@@ -2204,6 +2256,7 @@ impl FromCapnp for RequestEnvelope {
             delegation_token,
             wth,
             client_dh_public,
+            client_kem_public,
             response_kem_recipient,
             service_domain,
         })
@@ -3439,6 +3492,7 @@ mod tests {
             delegation_token: Some("delegated".to_owned()),
             wth: Some([0xAB; 32]),
             client_dh_public: Some([0xCD; 32]),
+            client_kem_public: None,
             response_kem_recipient: None,
             service_domain: None,
         };
@@ -3482,6 +3536,7 @@ mod tests {
             delegation_token: None,
             wth: None,
             client_dh_public: None,
+            client_kem_public: None,
             response_kem_recipient: None,
             service_domain: None,
         };
@@ -3544,6 +3599,7 @@ mod tests {
             delegation_token: None,
             wth: None,
             client_dh_public: None,
+            client_kem_public: None,
             response_kem_recipient: None,
             service_domain: None,
         };
@@ -3595,6 +3651,7 @@ mod tests {
                 delegation_token: None,
                 wth: None,
                 client_dh_public: None,
+                client_kem_public: None,
                 response_kem_recipient: None,
                 service_domain: None,
             },
@@ -3797,6 +3854,7 @@ mod tests {
             delegation_token: None,
             wth: None,
             client_dh_public: None,
+            client_kem_public: None,
             response_kem_recipient: None,
             service_domain: None,
         };
@@ -3843,6 +3901,7 @@ mod tests {
             delegation_token: None,
             wth: Some([0xAA; 32]),
             client_dh_public: None,
+            client_kem_public: None,
             response_kem_recipient: None,
             service_domain: None,
         };

--- a/crates/hyprstream-rpc/src/lib.rs
+++ b/crates/hyprstream-rpc/src/lib.rs
@@ -121,6 +121,7 @@ pub mod error;
 pub mod platform;
 pub mod rpc_client;
 pub mod stream_info;
+pub mod stream_epoch;
 pub mod zmtp_framing;
 
 // ============================================================================

--- a/crates/hyprstream-rpc/src/moq_stream.rs
+++ b/crates/hyprstream-rpc/src/moq_stream.rs
@@ -48,7 +48,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, ensure, Context, Result};
 use bytes::Bytes;
 use moq_net::{BroadcastProducer, Group, OriginConsumer, OriginProducer, Track, TrackProducer};
 use parking_lot::Mutex;
@@ -755,29 +755,29 @@ pub struct MoqStreamPublisher {
 }
 
 impl MoqStreamPublisher {
-    /// Prepare (without installing) the authenticated next-epoch commit.
-    pub fn prepare_next_epoch(&self) -> Result<crate::stream_epoch::StreamEpochCommit> {
-        self.epoch_ratchet
-            .as_ref()
-            .ok_or_else(|| anyhow!("stream is not using the identified epoch profile"))?
-            .prepare_next()
-    }
-
-    /// Atomically install an authenticated epoch commit and reset only the
-    /// per-epoch sequence/MAC chain.  `next_group` deliberately does not reset,
-    /// so an immutable MOQT track/group/object identity is never reused with
-    /// different ciphertext.
-    pub fn commit_epoch(&mut self, commit: &crate::stream_epoch::StreamEpochCommit) -> Result<()> {
+    /// Publish an opaque, authenticated control Object under the current epoch,
+    /// then atomically advance the producer to the next epoch. The consumer
+    /// performs the same verify-before-advance transition from the wire Object.
+    /// `next_group` deliberately never resets, preserving immutable MOQT IDs.
+    pub fn publish_next_epoch(&mut self) -> Result<u64> {
         let ratchet = self
             .epoch_ratchet
-            .as_mut()
+            .as_ref()
             .ok_or_else(|| anyhow!("stream is not using the identified epoch profile"))?;
-        let keys = ratchet.commit_prepared(commit)?;
+        let commit = ratchet.prepare_next()?;
+        let mut pending = ratchet.clone();
+        let keys = pending.commit_prepared(&commit)?;
+
+        // The current keys authenticate and encrypt this control Object. Do not
+        // expose or install the pending epoch until stock MoQ accepted the Object.
+        self.write_block(&[StreamPayloadData::EpochCommit(commit)])?;
+
         self.hmac_state =
             StreamHmacState::new(*keys.producer_to_consumer.mac_key, self.topic.clone());
         self.enc_key = Some(*keys.producer_to_consumer.enc_key);
         self.next_sequence = 0;
-        Ok(())
+        self.epoch_ratchet = Some(pending);
+        Ok(keys.epoch)
     }
 
     /// Publish one binary payload as a StreamBlock group.
@@ -790,8 +790,9 @@ impl MoqStreamPublisher {
 
     /// Publish an error payload (terminal).
     pub async fn publish_error(&mut self, message: &str) -> Result<()> {
+        self.write_block(&[StreamPayloadData::Error(message.to_owned())])?;
         self.terminated = true;
-        self.write_block(&[StreamPayloadData::Error(message.to_owned())])
+        Ok(())
     }
 
     /// Complete the stream with metadata (terminal).
@@ -801,8 +802,9 @@ impl MoqStreamPublisher {
 
     /// Complete the stream without consuming `self`.
     pub async fn complete_ref(&mut self, metadata: &[u8]) -> Result<()> {
+        self.write_block(&[StreamPayloadData::Complete(metadata.to_vec())])?;
         self.terminated = true;
-        self.write_block(&[StreamPayloadData::Complete(metadata.to_vec())])
+        Ok(())
     }
 
     /// The opaque topic this publisher serves.
@@ -830,8 +832,19 @@ impl MoqStreamPublisher {
             .epoch_ratchet
             .as_ref()
             .map_or(0, StreamEpochRatchet::epoch);
+        let is_epoch_control = matches!(payloads, [StreamPayloadData::EpochCommit(_)]);
+        if is_epoch_control && self.enc_key.is_none() {
+            anyhow::bail!("identified stream epoch control cannot be serialized without AEAD");
+        }
         if let Some(state) = &self.epoch_ratchet {
-            if sequence_number >= state.binding().max_blocks_per_epoch() {
+            ensure!(
+                !payloads
+                    .iter()
+                    .any(|payload| matches!(payload, StreamPayloadData::Tagged { .. })),
+                "identified stream rejected pre-tagged payload bypass"
+            );
+            let limit = state.binding().max_blocks_per_epoch();
+            if sequence_number > limit || (sequence_number == limit && !is_epoch_control) {
                 anyhow::bail!(
                     "identified stream epoch {epoch} exhausted after {} blocks; authenticated rekey required",
                     state.binding().max_blocks_per_epoch()
@@ -839,13 +852,16 @@ impl MoqStreamPublisher {
             }
         }
         let group_id = self.next_group;
-        self.next_group += 1;
-        self.next_sequence = self
+        let next_group = self
+            .next_group
+            .checked_add(1)
+            .ok_or_else(|| anyhow!("stream Group identity exhausted"))?;
+        let next_sequence = self
             .next_sequence
             .checked_add(1)
             .ok_or_else(|| anyhow!("stream sequence exhausted"))?;
 
-        // #321: on the mesh/DH path (`enc_key = Some`), seal each Data/Complete/Error
+        // #321: on the mesh/DH path (`enc_key = Some`), seal each application/control
         // payload with AES-256-GCM into a `Tagged` payload BEFORE the HMAC chain
         // runs (so the chain authenticates the ciphertext — no double-encryption,
         // ordering/anti-replay unchanged). The AEAD AAD/key-commitment are bound to the block's
@@ -921,7 +937,8 @@ impl MoqStreamPublisher {
             }
             None => signed_region,
         };
-        let mac = self.hmac_state.compute_next(&capnp_bytes);
+        let mut pending_hmac_state = self.hmac_state.clone();
+        let mac = pending_hmac_state.compute_next(&capnp_bytes);
 
         let mut frame = Vec::with_capacity(capnp_bytes.len() + 16);
         frame.extend_from_slice(&capnp_bytes);
@@ -930,6 +947,13 @@ impl MoqStreamPublisher {
         let mut group = self.track.create_group(Group::from(group_id))?;
         group.write_frame(Bytes::from(frame))?;
         group.finish()?;
+
+        // Publication is the commit point: failures above leave all sequence,
+        // identity, and chained-MAC state unchanged, so a retry cannot create a
+        // gap or reuse an already-advanced cryptographic state.
+        self.hmac_state = pending_hmac_state;
+        self.next_group = next_group;
+        self.next_sequence = next_sequence;
         Ok(())
     }
 }
@@ -1012,6 +1036,36 @@ impl MoqStreamHandle {
             mac_key,
             enc_key,
             topic,
+            None,
+            tx,
+            cancel.clone(),
+        ));
+        Self {
+            rx,
+            broadcast_path,
+            cancel,
+        }
+    }
+
+    /// Construct an identified-profile UDS consumer whose receive loop accepts
+    /// authenticated in-band epoch controls before delivering later Objects.
+    pub fn identified(
+        uds_path: String,
+        broadcast_path: String,
+        ratchet: crate::stream_epoch::StreamEpochRatchet,
+    ) -> Self {
+        let keys = ratchet.current_keys();
+        let topic = ratchet.route_topic().to_owned();
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let (tx, rx) =
+            tokio::sync::mpsc::channel::<anyhow::Result<crate::streaming::StreamPayload>>(64);
+        tokio::spawn(moq_stream_handle_task(
+            uds_path,
+            broadcast_path.clone(),
+            *keys.producer_to_consumer.mac_key,
+            *keys.producer_to_consumer.enc_key,
+            topic,
+            Some(ratchet),
             tx,
             cancel.clone(),
         ));
@@ -1083,6 +1137,7 @@ impl MoqStreamHandle {
                 mac_key,
                 enc_key,
                 topic,
+                None,
                 tx,
                 cancel.clone(),
             ));
@@ -1094,6 +1149,7 @@ impl MoqStreamHandle {
                 mac_key,
                 enc_key,
                 topic,
+                None,
                 tx,
                 cancel.clone(),
             ));
@@ -1105,6 +1161,63 @@ impl MoqStreamHandle {
                     .send(Err(anyhow!(
                         "no dialable reach in StreamInfo and no local moq UDS plane — \
                          cannot subscribe to broadcast"
+                    )))
+                    .await;
+            });
+        }
+        Self {
+            rx,
+            broadcast_path,
+            cancel,
+        }
+    }
+
+    /// Construct an identified-profile network consumer. A standard relay sees
+    /// ordinary opaque Objects; this receive loop consumes authenticated epoch
+    /// controls and delivers application payloads only.
+    pub fn networked_identified(
+        reach: Vec<crate::stream_info::Destination>,
+        qos: &crate::stream_info::StreamOpt,
+        broadcast_path: String,
+        ratchet: crate::stream_epoch::StreamEpochRatchet,
+    ) -> Self {
+        let reach = select_reach(&reach, qos);
+        let keys = ratchet.current_keys();
+        let mac_key = *keys.producer_to_consumer.mac_key;
+        let enc_key = *keys.producer_to_consumer.enc_key;
+        let topic = ratchet.route_topic().to_owned();
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let (tx, rx) =
+            tokio::sync::mpsc::channel::<anyhow::Result<crate::streaming::StreamPayload>>(64);
+        let has_dialable_reach = reach.iter().any(|d| reach_to_transport_config(d).is_some());
+        if has_dialable_reach {
+            tokio::spawn(moq_stream_handle_task_networked(
+                reach,
+                broadcast_path.clone(),
+                mac_key,
+                enc_key,
+                topic,
+                Some(ratchet),
+                tx,
+                cancel.clone(),
+            ));
+        } else if let Some(uds) = global_moq_uds_path() {
+            tokio::spawn(moq_stream_handle_task(
+                uds.to_string_lossy().into_owned(),
+                broadcast_path.clone(),
+                mac_key,
+                enc_key,
+                topic,
+                Some(ratchet),
+                tx,
+                cancel.clone(),
+            ));
+        } else {
+            tokio::spawn(async move {
+                let _ = tx
+                    .send(Err(anyhow!(
+                        "no dialable reach in StreamInfo and no local moq UDS plane — \
+                         cannot subscribe to identified broadcast"
                     )))
                     .await;
             });
@@ -1162,6 +1275,7 @@ async fn moq_stream_handle_task(
     mac_key: [u8; 32],
     enc_key: [u8; 32],
     topic: String,
+    epoch_ratchet: Option<crate::stream_epoch::StreamEpochRatchet>,
     tx: tokio::sync::mpsc::Sender<anyhow::Result<crate::streaming::StreamPayload>>,
     cancel: tokio_util::sync::CancellationToken,
 ) {
@@ -1219,6 +1333,9 @@ async fn moq_stream_handle_task(
     };
     // #321: AEAD ON for this DH-keyed mesh stream — open sealed Tagged blocks.
     let mut verifier = StreamVerifier::new(mac_key, topic.clone()).with_enc_key(enc_key);
+    if let Some(ratchet) = epoch_ratchet {
+        verifier = verifier.with_epoch_ratchet(ratchet);
+    }
     // #145: read groups by EXACT sequence (get_group), not arrival-order next_group.
     // Each Group is served on its own QUIC uni-stream, so Groups can arrive out of
     // order; next_group's monotonic cursor returns the first Group with sequence >=
@@ -1748,6 +1865,7 @@ async fn moq_stream_handle_task_networked(
     mac_key: [u8; 32],
     enc_key: [u8; 32],
     topic: String,
+    epoch_ratchet: Option<crate::stream_epoch::StreamEpochRatchet>,
     tx: tokio::sync::mpsc::Sender<anyhow::Result<crate::streaming::StreamPayload>>,
     cancel: tokio_util::sync::CancellationToken,
 ) {
@@ -1799,6 +1917,9 @@ async fn moq_stream_handle_task_networked(
     };
     // #321: AEAD ON for this DH-keyed mesh stream — open sealed Tagged blocks.
     let mut verifier = StreamVerifier::new(mac_key, topic.clone()).with_enc_key(enc_key);
+    if let Some(ratchet) = epoch_ratchet {
+        verifier = verifier.with_epoch_ratchet(ratchet);
+    }
     // #145: read groups by EXACT sequence (get_group), not arrival-order next_group.
     // Each Group is served on its own QUIC uni-stream, so Groups can arrive out of
     // order; next_group's monotonic cursor returns the first Group with sequence >=
@@ -1938,7 +2059,7 @@ pub fn verify_moq_frame_with_provenance(
     Ok(payloads)
 }
 
-/// Seal a single Data/Complete/Error payload into an AES-256-GCM `Tagged` payload
+/// Seal a single Data/Complete/Error/epoch-control payload into an AES-256-GCM `Tagged` payload
 /// (#321). The 1-byte kind tag is prepended to the plaintext so the consumer can
 /// restore the original variant. Already-Tagged/other variants pass through
 /// unchanged (already-Tagged is the E2E notification path).
@@ -1956,13 +2077,24 @@ fn seal_payload(
 ) -> Result<StreamPayloadData> {
     use crate::crypto::event_crypto::{encrypt_event, encrypt_event_with_nonce, EventPrivacy};
     use crate::stream_consumer::{
-        stream_aead_aad, SEALED_KIND_COMPLETE, SEALED_KIND_DATA, SEALED_KIND_ERROR,
+        stream_aead_aad, SEALED_KIND_COMPLETE, SEALED_KIND_DATA, SEALED_KIND_EPOCH_COMMIT,
+        SEALED_KIND_ERROR,
     };
 
+    let control_bytes = match payload {
+        StreamPayloadData::EpochCommit(commit) => Some(commit.encode_control_object()),
+        _ => None,
+    };
     let (kind, body): (u8, &[u8]) = match payload {
         StreamPayloadData::Data(d) => (SEALED_KIND_DATA, d),
         StreamPayloadData::Complete(d) => (SEALED_KIND_COMPLETE, d),
         StreamPayloadData::Error(message) => (SEALED_KIND_ERROR, message.as_bytes()),
+        StreamPayloadData::EpochCommit(_) => (
+            SEALED_KIND_EPOCH_COMMIT,
+            control_bytes
+                .as_deref()
+                .ok_or_else(|| anyhow!("stream epoch control encoding missing"))?,
+        ),
         // Leave non-sealed variants untouched.
         other => return Ok(other.clone()),
     };
@@ -2087,8 +2219,9 @@ mod tests {
             &client_keypair,
             ctx.kem_ciphertexts()
                 .expect("hybrid context has ciphertexts"),
-            binding,
+            binding.clone(),
         )?;
+        let initial_ratchet = client_ratchet.clone();
         let topic = ctx.topic().to_owned();
         let origin = origin();
         let mut publisher = origin.publisher(&ctx)?;
@@ -2098,9 +2231,12 @@ mod tests {
             "epoch block bound must fail closed"
         );
 
-        let commit = publisher.prepare_next_epoch()?;
-        publisher.commit_epoch(&commit)?;
+        assert_eq!(publisher.publish_next_epoch()?, 1);
         publisher.publish_data(b"epoch-one-secret").await?;
+
+        assert_eq!(publisher.publish_next_epoch()?, 2);
+        let private_error = "private model failure: customer prompt rejected";
+        publisher.publish_error(private_error).await?;
 
         let path = origin.broadcast_path(&topic);
         let bc = tokio::time::timeout(
@@ -2113,66 +2249,236 @@ mod tests {
         let mut verifier =
             StreamVerifier::new([0; 32], String::new()).with_epoch_ratchet(client_ratchet);
 
-        let mut group0 = track
-            .get_group(0)
-            .await?
-            .ok_or_else(|| anyhow!("epoch-zero Group missing"))?;
-        let frame0 = group0
-            .read_frame()
-            .await?
-            .ok_or_else(|| anyhow!("epoch-zero Object missing"))?;
+        let mut frames = Vec::new();
+        for group_id in 0..5 {
+            let mut group = track
+                .get_group(group_id)
+                .await?
+                .ok_or_else(|| anyhow!("identified Group {group_id} missing"))?;
+            frames.push(
+                group
+                    .read_frame()
+                    .await?
+                    .ok_or_else(|| anyhow!("identified Object {group_id} missing"))?,
+            );
+        }
+        let frame0 = &frames[0];
         assert!(
             !frame0
                 .windows(b"epoch-zero-secret".len())
                 .any(|window| window == b"epoch-zero-secret"),
             "stock relay-visible Object leaked plaintext"
         );
-        let first = verify_moq_frame(&mut verifier, &topic, &frame0)?;
+        let first = verify_moq_frame(&mut verifier, &topic, frame0)?;
         assert!(matches!(&first[0], StreamPayload::Data(data) if data == b"epoch-zero-secret"));
 
-        verifier.accept_epoch_commit(&commit)?;
+        let control0 = &frames[1];
         assert!(
-            verifier.accept_epoch_commit(&commit).is_err(),
-            "replayed epoch commit accepted"
+            !control0
+                .windows(b"HYSEPK01".len())
+                .any(|window| window == b"HYSEPK01")
+                && !control0
+                    .windows(32)
+                    .any(|window| window == binding.binding_hash()),
+            "relay-visible control Object exposed the epoch-control plaintext"
         );
-        let mut group1 = track
-            .get_group(1)
-            .await?
-            .ok_or_else(|| anyhow!("epoch-one Group missing"))?;
-        let frame1 = group1
-            .read_frame()
-            .await?
-            .ok_or_else(|| anyhow!("epoch-one Object missing"))?;
-        let second = verify_moq_frame(&mut verifier, &topic, &frame1)?;
+        assert!(verify_moq_frame(&mut verifier, &topic, control0)?.is_empty());
+        let second = verify_moq_frame(&mut verifier, &topic, &frames[2])?;
         assert!(matches!(&second[0], StreamPayload::Data(data) if data == b"epoch-one-secret"));
 
-        // Errors are application payloads too: rekey, publish one, and prove a
-        // stock relay cannot read the message while the endpoint restores the
-        // exact Error variant.
-        let error_commit = publisher.prepare_next_epoch()?;
-        publisher.commit_epoch(&error_commit)?;
-        let private_error = "private model failure: customer prompt rejected";
-        publisher.publish_error(private_error).await?;
-        verifier.accept_epoch_commit(&error_commit)?;
-        let mut group2 = track
-            .get_group(2)
-            .await?
-            .ok_or_else(|| anyhow!("error epoch Group missing"))?;
-        let frame2 = group2
-            .read_frame()
-            .await?
-            .ok_or_else(|| anyhow!("error epoch Object missing"))?;
+        assert!(verify_moq_frame(&mut verifier, &topic, &frames[3])?.is_empty());
         assert!(
-            !frame2
+            !frames[4]
                 .windows(private_error.len())
                 .any(|window| window == private_error.as_bytes()),
             "stock relay-visible Object leaked the private error string"
         );
-        let error = verify_moq_frame(&mut verifier, &topic, &frame2)?;
+        let error = verify_moq_frame(&mut verifier, &topic, &frames[4])?;
         assert!(matches!(&error[0], StreamPayload::Error(message) if message == private_error));
-        assert_ne!(frame0, frame1);
-        assert_ne!(frame1, frame2);
+
+        // Each negative control first consumes the real epoch-zero Object so
+        // it has the exact authenticated old-epoch chain state. A subsequent
+        // successful control+data delivery proves every rejection was causal
+        // and left verifier state unchanged.
+        let verifier_after_epoch_zero = || -> Result<StreamVerifier> {
+            let mut verifier = StreamVerifier::new([0; 32], String::new())
+                .with_epoch_ratchet(initial_ratchet.clone());
+            let payloads = verify_moq_frame(&mut verifier, &topic, &frames[0])?;
+            anyhow::ensure!(matches!(
+                &payloads[0],
+                StreamPayload::Data(data) if data == b"epoch-zero-secret"
+            ));
+            Ok(verifier)
+        };
+
+        let mut tampered = frames[1].to_vec();
+        let tampered_index = tampered.len() / 2;
+        tampered[tampered_index] ^= 0x80;
+        let mut tamper_verifier = verifier_after_epoch_zero()?;
+        assert!(verify_moq_frame(&mut tamper_verifier, &topic, &tampered).is_err());
+        assert!(verify_moq_frame(&mut tamper_verifier, &topic, &frames[1])?.is_empty());
+        assert!(matches!(
+            &verify_moq_frame(&mut tamper_verifier, &topic, &frames[2])?[0],
+            StreamPayload::Data(data) if data == b"epoch-one-secret"
+        ));
+
+        let mut replay_verifier = verifier_after_epoch_zero()?;
+        assert!(verify_moq_frame(&mut replay_verifier, &topic, &frames[1])?.is_empty());
+        assert!(verify_moq_frame(&mut replay_verifier, &topic, &frames[1]).is_err());
+        assert!(matches!(
+            &verify_moq_frame(&mut replay_verifier, &topic, &frames[2])?[0],
+            StreamPayload::Data(data) if data == b"epoch-one-secret"
+        ));
+
+        let previous_mac = &frames[0][frames[0].len() - 16..];
+        let mut skipped = initial_ratchet.prepare_next()?;
+        skipped.epoch += 1;
+        let skipped_frame = identified_test_frame(
+            &initial_ratchet,
+            &topic,
+            previous_mac,
+            1,
+            &StreamPayloadData::EpochCommit(skipped),
+        )?;
+        let mut skip_verifier = verifier_after_epoch_zero()?;
+        assert!(verify_moq_frame(&mut skip_verifier, &topic, &skipped_frame).is_err());
+        assert!(verify_moq_frame(&mut skip_verifier, &topic, &frames[1])?.is_empty());
+
+        let foreign_binding = IdentifiedStreamBinding::new(
+            StreamCarrierProfile::StandardPublicRelay,
+            StreamRouteRole::Relay,
+            "did:at9p:producer",
+            "did:at9p:consumer",
+            StreamAcceptedState {
+                identity_did: "did:at9p:producer".into(),
+                digest: [0x31; 64],
+                epoch: 3,
+            },
+            StreamAcceptedState {
+                identity_did: "did:at9p:consumer".into(),
+                digest: [0x41; 64],
+                epoch: 4,
+            },
+            "inference.generate",
+            "infer:model:qwen",
+            "local/streams/foreign",
+            "did:at9p:producer#mesh-kem",
+            "urn:hyprstream:stream-client:one-shot",
+            1,
+        )?;
+        let foreign = crate::stream_epoch::StreamEpochRatchet::from_hybrid_secret(
+            &[0xA5; 32],
+            foreign_binding,
+        )?;
+        let cross_stream_frame = identified_test_frame(
+            &initial_ratchet,
+            &topic,
+            previous_mac,
+            1,
+            &StreamPayloadData::EpochCommit(foreign.prepare_next()?),
+        )?;
+        let mut cross_verifier = verifier_after_epoch_zero()?;
+        assert!(verify_moq_frame(&mut cross_verifier, &topic, &cross_stream_frame).is_err());
+        assert!(verify_moq_frame(&mut cross_verifier, &topic, &frames[1])?.is_empty());
+
+        let clear_payloads = [
+            StreamPayloadData::Data(b"relay-visible forged data".to_vec()),
+            StreamPayloadData::Error("relay-visible forged error".into()),
+            StreamPayloadData::Complete(b"relay-visible forged completion".to_vec()),
+            StreamPayloadData::Data(initial_ratchet.prepare_next()?.encode_control_object()),
+        ];
+        for clear_payload in &clear_payloads {
+            let forged_clear =
+                identified_test_frame(&initial_ratchet, &topic, previous_mac, 1, clear_payload)?;
+            let mut clear_verifier = verifier_after_epoch_zero()?;
+            assert!(verify_moq_frame(&mut clear_verifier, &topic, &forged_clear).is_err());
+            assert!(verify_moq_frame(&mut clear_verifier, &topic, &frames[1])?.is_empty());
+        }
+
+        let clear_heartbeat = identified_clear_heartbeat_frame(&initial_ratchet, previous_mac, 1)?;
+        let mut heartbeat_verifier = verifier_after_epoch_zero()?;
+        assert!(verify_moq_frame(&mut heartbeat_verifier, &topic, &clear_heartbeat).is_err());
+        assert!(verify_moq_frame(&mut heartbeat_verifier, &topic, &frames[1])?.is_empty());
+
+        // Lost/reordered control and next-epoch data-before-control are the same
+        // fail-closed condition. The valid control remains acceptable afterward.
+        let mut reordered_verifier = verifier_after_epoch_zero()?;
+        assert!(verify_moq_frame(&mut reordered_verifier, &topic, &frames[2]).is_err());
+        assert!(verify_moq_frame(&mut reordered_verifier, &topic, &frames[1])?.is_empty());
+        assert!(matches!(
+            &verify_moq_frame(&mut reordered_verifier, &topic, &frames[2])?[0],
+            StreamPayload::Data(data) if data == b"epoch-one-secret"
+        ));
+
+        for pair in frames.windows(2) {
+            assert_ne!(pair[0], pair[1]);
+        }
         Ok(())
+    }
+
+    fn identified_test_frame(
+        ratchet: &crate::stream_epoch::StreamEpochRatchet,
+        topic: &str,
+        previous_mac: &[u8],
+        sequence_number: u64,
+        payload: &StreamPayloadData,
+    ) -> Result<Vec<u8>> {
+        let keys = ratchet.current_keys();
+        let nonce = keys.producer_to_consumer.nonce(
+            sequence_number
+                .checked_mul(1 << 16)
+                .ok_or_else(|| anyhow!("test stream payload nonce counter exhausted"))?,
+        );
+        let payload = if matches!(payload, StreamPayloadData::EpochCommit(_)) {
+            seal_payload(
+                &keys.producer_to_consumer.enc_key,
+                topic,
+                ratchet.epoch(),
+                sequence_number,
+                0,
+                Some(nonce),
+                payload,
+            )?
+        } else {
+            payload.clone()
+        };
+        let capnp = crate::streaming::encode_stream_block(
+            previous_mac,
+            sequence_number,
+            ratchet.epoch(),
+            &[payload],
+        )?;
+        let mac = crate::crypto::keyed_mac_truncated_parts(
+            &keys.producer_to_consumer.mac_key,
+            &[previous_mac, &capnp],
+        );
+        let mut frame = capnp;
+        frame.extend_from_slice(&mac);
+        Ok(frame)
+    }
+
+    fn identified_clear_heartbeat_frame(
+        ratchet: &crate::stream_epoch::StreamEpochRatchet,
+        previous_mac: &[u8],
+        sequence_number: u64,
+    ) -> Result<Vec<u8>> {
+        let mut msg = capnp::message::Builder::new_default();
+        {
+            let mut block = msg.init_root::<crate::streaming_capnp::stream_block::Builder>();
+            block.set_prev_mac(previous_mac);
+            block.set_sequence_number(sequence_number);
+            block.set_epoch(ratchet.epoch());
+            block.init_payloads(1).get(0).set_heartbeat(());
+        }
+        let mut capnp = Vec::new();
+        capnp::serialize::write_message(&mut capnp, &msg)?;
+        let keys = ratchet.current_keys();
+        let mac = crate::crypto::keyed_mac_truncated_parts(
+            &keys.producer_to_consumer.mac_key,
+            &[previous_mac, &capnp],
+        );
+        capnp.extend_from_slice(&mac);
+        Ok(capnp)
     }
 
     /// `AnyStreamPublisher` round-trip: publish via the type alias and verify

--- a/crates/hyprstream-rpc/src/moq_stream.rs
+++ b/crates/hyprstream-rpc/src/moq_stream.rs
@@ -55,6 +55,7 @@ use parking_lot::Mutex;
 use tokio_util::sync::CancellationToken;
 
 use crate::crypto::StreamHmacState;
+use crate::stream_epoch::StreamEpochRatchet;
 use crate::streaming::{StreamContext, StreamPayloadData, StreamVerifier};
 
 // ============================================================================
@@ -327,7 +328,10 @@ impl ProducerReachConfig {
             RelayChoice::NoRelay => None,
         };
         if let Some(relay) = relay {
-            reach.push(Destination { role: Role::Relay, transport: relay });
+            reach.push(Destination {
+                role: Role::Relay,
+                transport: relay,
+            });
         }
 
         reach
@@ -400,25 +404,33 @@ pub fn relay_reach_from_decoded(
     use crate::stream_info::{IrohReach, QuicReach, TransportConfig as ReachTransport};
     use crate::transport::EndpointType;
     match &config.endpoint {
-        EndpointType::Quic { addr, server_name, auth } => Some(ReachTransport::Quic(QuicReach {
+        EndpointType::Quic {
+            addr,
+            server_name,
+            auth,
+        } => Some(ReachTransport::Quic(QuicReach {
             addr: addr.to_string(),
             server_name: server_name.clone(),
-            cert_hashes: auth.accept_cert_hashes().iter().map(|h| h.to_vec()).collect(),
+            cert_hashes: auth
+                .accept_cert_hashes()
+                .iter()
+                .map(|h| h.to_vec())
+                .collect(),
         })),
-        EndpointType::Iroh { node_id, relay_url, .. } => {
+        EndpointType::Iroh {
+            node_id, relay_url, ..
+        } => {
             // A relay carries the moq stream → moql ALPN; relay_url passes through.
             Some(ReachTransport::Iroh(IrohReach {
                 node_id: *node_id,
-                alpn: String::from_utf8_lossy(
-                    crate::transport::iroh_substrate::ALPN_MOQ_LITE,
-                )
-                .into_owned(),
+                alpn: String::from_utf8_lossy(crate::transport::iroh_substrate::ALPN_MOQ_LITE)
+                    .into_owned(),
                 relay_url: relay_url.clone().unwrap_or_default(),
             }))
         }
-        EndpointType::Ipc { .. }
-        | EndpointType::SystemdFd { .. }
-        | EndpointType::Inproc { .. } => None,
+        EndpointType::Ipc { .. } | EndpointType::SystemdFd { .. } | EndpointType::Inproc { .. } => {
+            None
+        }
     }
 }
 
@@ -500,7 +512,11 @@ pub fn serve_moq_uds_background(origin: MoqStreamOrigin, path: PathBuf) {
                     tracing::debug!("moq UDS: unexpected plane 0x{plane:02x} — dropping");
                     return;
                 }
-                if let Err(e) = MoqServer::new().with_publish(consumer).accept(session).await {
+                if let Err(e) = MoqServer::new()
+                    .with_publish(consumer)
+                    .accept(session)
+                    .await
+                {
                     tracing::debug!("moq UDS session ended: {e}");
                 }
             });
@@ -696,6 +712,8 @@ impl MoqStreamOrigin {
             provenance,
             track,
             next_group: 0,
+            next_sequence: 0,
+            epoch_ratchet: ctx.epoch_ratchet(),
             cancel_token: ctx.cancel_token().clone(),
             terminated: false,
             topic: ctx.topic().to_owned(),
@@ -725,13 +743,43 @@ pub struct MoqStreamPublisher {
     /// hybrid COSE signature over its canonical signed region.
     provenance: Option<crate::stream_provenance::ProvenanceSigner>,
     track: TrackProducer,
+    /// Immutable MOQT Object identity: this counter never resets across rekeys.
     next_group: u64,
+    /// Authenticated sequence number within the committed key epoch.
+    next_sequence: u64,
+    /// Identified transcript-bound epoch state; absent on legacy/keyless paths.
+    epoch_ratchet: Option<crate::stream_epoch::StreamEpochRatchet>,
     cancel_token: CancellationToken,
     terminated: bool,
     topic: String,
 }
 
 impl MoqStreamPublisher {
+    /// Prepare (without installing) the authenticated next-epoch commit.
+    pub fn prepare_next_epoch(&self) -> Result<crate::stream_epoch::StreamEpochCommit> {
+        self.epoch_ratchet
+            .as_ref()
+            .ok_or_else(|| anyhow!("stream is not using the identified epoch profile"))?
+            .prepare_next()
+    }
+
+    /// Atomically install an authenticated epoch commit and reset only the
+    /// per-epoch sequence/MAC chain.  `next_group` deliberately does not reset,
+    /// so an immutable MOQT track/group/object identity is never reused with
+    /// different ciphertext.
+    pub fn commit_epoch(&mut self, commit: &crate::stream_epoch::StreamEpochCommit) -> Result<()> {
+        let ratchet = self
+            .epoch_ratchet
+            .as_mut()
+            .ok_or_else(|| anyhow!("stream is not using the identified epoch profile"))?;
+        let keys = ratchet.commit_prepared(commit)?;
+        self.hmac_state =
+            StreamHmacState::new(*keys.producer_to_consumer.mac_key, self.topic.clone());
+        self.enc_key = Some(*keys.producer_to_consumer.enc_key);
+        self.next_sequence = 0;
+        Ok(())
+    }
+
     /// Publish one binary payload as a StreamBlock group.
     pub async fn publish_data(&mut self, data: &[u8]) -> Result<()> {
         if self.cancel_token.is_cancelled() {
@@ -775,12 +823,27 @@ impl MoqStreamPublisher {
     /// Serialize payloads into a StreamBlock, chain the MAC, and append as a
     /// moq Group (one Frame = `capnp || mac`).
     fn write_block(&mut self, payloads: &[StreamPayloadData]) -> Result<()> {
-        // The StreamBlock sequenceNumber (#219) IS the moq Group id — unified so the
-        // in-block sequenceNumber the consumer authenticates matches the transport Group.
-        // epoch is 0 until the #223 key-epoch lifecycle lands.
-        let sequence_number = self.next_group;
+        // `sequenceNumber` is per key epoch. `group_id` below is the immutable,
+        // lifetime-wide MOQT identity and deliberately never resets at rekey.
+        let sequence_number = self.next_sequence;
+        let epoch = self
+            .epoch_ratchet
+            .as_ref()
+            .map_or(0, StreamEpochRatchet::epoch);
+        if let Some(state) = &self.epoch_ratchet {
+            if sequence_number >= state.binding().max_blocks_per_epoch() {
+                anyhow::bail!(
+                    "identified stream epoch {epoch} exhausted after {} blocks; authenticated rekey required",
+                    state.binding().max_blocks_per_epoch()
+                );
+            }
+        }
+        let group_id = self.next_group;
         self.next_group += 1;
-        let epoch = 0u64;
+        self.next_sequence = self
+            .next_sequence
+            .checked_add(1)
+            .ok_or_else(|| anyhow!("stream sequence exhausted"))?;
 
         // #321: on the mesh/DH path (`enc_key = Some`), seal each Data/Complete
         // payload with AES-256-GCM into a `Tagged` payload BEFORE the HMAC chain
@@ -791,9 +854,41 @@ impl MoqStreamPublisher {
         let sealed: Vec<StreamPayloadData>;
         let payloads: &[StreamPayloadData] = match self.enc_key {
             Some(ref enc_key) => {
+                let epoch_keys = self
+                    .epoch_ratchet
+                    .as_ref()
+                    .map(crate::stream_epoch::StreamEpochRatchet::current_keys);
                 sealed = payloads
                     .iter()
-                    .map(|p| seal_payload(enc_key, &self.topic, epoch, p))
+                    .enumerate()
+                    .map(|(index, p)| {
+                        let nonce = epoch_keys
+                            .as_ref()
+                            .map(|keys| {
+                                // One MoQ block currently carries one payload.  Keep
+                                // the index in the checked nonce position so future
+                                // batching cannot reuse a nonce silently.
+                                let counter = sequence_number
+                                    .checked_mul(1 << 16)
+                                    .and_then(|value| value.checked_add(index as u64))
+                                    .ok_or_else(|| {
+                                        anyhow!("stream payload nonce counter exhausted")
+                                    })?;
+                                Ok::<[u8; 12], anyhow::Error>(
+                                    keys.producer_to_consumer.nonce(counter),
+                                )
+                            })
+                            .transpose()?;
+                        seal_payload(
+                            enc_key,
+                            &self.topic,
+                            epoch,
+                            sequence_number,
+                            index,
+                            nonce,
+                            p,
+                        )
+                    })
                     .collect::<Result<Vec<_>>>()?;
                 &sealed
             }
@@ -833,7 +928,7 @@ impl MoqStreamPublisher {
         frame.extend_from_slice(&capnp_bytes);
         frame.extend_from_slice(&mac);
 
-        let mut group = self.track.create_group(Group::from(sequence_number))?;
+        let mut group = self.track.create_group(Group::from(group_id))?;
         group.write_frame(Bytes::from(frame))?;
         group.finish()?;
         Ok(())
@@ -859,7 +954,12 @@ impl MoqStreamPublisher {
     }
 
     /// Publish a progress update (`stage:current:total`).
-    pub async fn publish_progress(&mut self, stage: &str, current: usize, total: usize) -> Result<()> {
+    pub async fn publish_progress(
+        &mut self,
+        stage: &str,
+        current: usize,
+        total: usize,
+    ) -> Result<()> {
         let data = format!("{}:{}:{}", stage, current, total);
         self.publish_data(data.as_bytes()).await
     }
@@ -905,9 +1005,22 @@ impl MoqStreamHandle {
         topic: String,
     ) -> Self {
         let cancel = tokio_util::sync::CancellationToken::new();
-        let (tx, rx) = tokio::sync::mpsc::channel::<anyhow::Result<crate::streaming::StreamPayload>>(64);
-        tokio::spawn(moq_stream_handle_task(uds_path, broadcast_path.clone(), mac_key, enc_key, topic, tx, cancel.clone()));
-        Self { rx, broadcast_path, cancel }
+        let (tx, rx) =
+            tokio::sync::mpsc::channel::<anyhow::Result<crate::streaming::StreamPayload>>(64);
+        tokio::spawn(moq_stream_handle_task(
+            uds_path,
+            broadcast_path.clone(),
+            mac_key,
+            enc_key,
+            topic,
+            tx,
+            cancel.clone(),
+        ));
+        Self {
+            rx,
+            broadcast_path,
+            cancel,
+        }
     }
 
     /// Construct a handle that subscribes over the **network** (#274).
@@ -997,7 +1110,11 @@ impl MoqStreamHandle {
                     .await;
             });
         }
-        Self { rx, broadcast_path, cancel }
+        Self {
+            rx,
+            broadcast_path,
+            cancel,
+        }
     }
 
     /// Receive the next stream payload.
@@ -1055,32 +1172,51 @@ async fn moq_stream_handle_task(
 
     let session = match connect_uds(&uds_path, PLANE_MOQ).await {
         Ok(s) => s,
-        Err(e) => { let _ = tx.send(Err(anyhow!("moq UDS connect {uds_path}: {e}"))).await; return; }
+        Err(e) => {
+            let _ = tx
+                .send(Err(anyhow!("moq UDS connect {uds_path}: {e}")))
+                .await;
+            return;
+        }
     };
     let client_origin = Origin::random().produce();
     let client_consumer = client_origin.consume();
     let moq_client = MoqClient::new().with_consume(client_origin);
     let _session = match moq_client.connect(session).await {
         Ok(s) => s,
-        Err(e) => { let _ = tx.send(Err(anyhow!("moq handshake: {e}"))).await; return; }
+        Err(e) => {
+            let _ = tx.send(Err(anyhow!("moq handshake: {e}"))).await;
+            return;
+        }
     };
     let bc = match tokio::time::timeout(
         BROADCAST_ANNOUNCE_TIMEOUT,
         client_consumer.announced_broadcast(&broadcast_path),
-    ).await {
+    )
+    .await
+    {
         Ok(Some(bc)) => bc,
         Ok(None) => {
-            let _ = tx.send(Err(anyhow!("broadcast {broadcast_path} not announced"))).await;
+            let _ = tx
+                .send(Err(anyhow!("broadcast {broadcast_path} not announced")))
+                .await;
             return;
         }
         Err(_) => {
-            let _ = tx.send(Err(anyhow!("timeout waiting for broadcast {broadcast_path}"))).await;
+            let _ = tx
+                .send(Err(anyhow!(
+                    "timeout waiting for broadcast {broadcast_path}"
+                )))
+                .await;
             return;
         }
     };
     let track = match bc.subscribe_track(&Track::new(STREAM_TRACK)) {
         Ok(t) => t,
-        Err(e) => { let _ = tx.send(Err(anyhow!("subscribe_track: {e}"))).await; return; }
+        Err(e) => {
+            let _ = tx.send(Err(anyhow!("subscribe_track: {e}"))).await;
+            return;
+        }
     };
     // #321: AEAD ON for this DH-keyed mesh stream — open sealed Tagged blocks.
     let mut verifier = StreamVerifier::new(mac_key, topic.clone()).with_enc_key(enc_key);
@@ -1096,37 +1232,43 @@ async fn moq_stream_handle_task(
         if cancel.is_cancelled() {
             break;
         }
-        let mut group = match tokio::time::timeout(GROUP_IDLE_TIMEOUT, track.get_group(expected_seq)).await {
-            Ok(Ok(Some(g))) => g,
-            Ok(Ok(None)) => break, // track ended cleanly
-            Err(_elapsed) => {
-                let _ = tx.send(Err(anyhow!(
-                    "stream idle: no group for {}s",
-                    GROUP_IDLE_TIMEOUT.as_secs()
-                ))).await;
-                break;
-            }
-            Ok(Err(e)) => {
-                let _ = tx.send(Err(anyhow!("moq next_group: {e}"))).await;
-                break;
-            }
-        };
+        let mut group =
+            match tokio::time::timeout(GROUP_IDLE_TIMEOUT, track.get_group(expected_seq)).await {
+                Ok(Ok(Some(g))) => g,
+                Ok(Ok(None)) => break, // track ended cleanly
+                Err(_elapsed) => {
+                    let _ = tx
+                        .send(Err(anyhow!(
+                            "stream idle: no group for {}s",
+                            GROUP_IDLE_TIMEOUT.as_secs()
+                        )))
+                        .await;
+                    break;
+                }
+                Ok(Err(e)) => {
+                    let _ = tx.send(Err(anyhow!("moq next_group: {e}"))).await;
+                    break;
+                }
+            };
         expected_seq += 1;
-        let frame: bytes::Bytes = match tokio::time::timeout(FRAME_READ_TIMEOUT, group.read_frame()).await {
-            Ok(Ok(Some(f))) => f,
-            Ok(Ok(None)) => break, // group ended without a frame
-            Ok(Err(e)) => {
-                let _ = tx.send(Err(anyhow!("frame read error: {e}"))).await;
-                break;
-            }
-            Err(_elapsed) => {
-                let _ = tx.send(Err(anyhow!(
-                    "frame read timeout after {}s",
-                    FRAME_READ_TIMEOUT.as_secs()
-                ))).await;
-                break;
-            }
-        };
+        let frame: bytes::Bytes =
+            match tokio::time::timeout(FRAME_READ_TIMEOUT, group.read_frame()).await {
+                Ok(Ok(Some(f))) => f,
+                Ok(Ok(None)) => break, // group ended without a frame
+                Ok(Err(e)) => {
+                    let _ = tx.send(Err(anyhow!("frame read error: {e}"))).await;
+                    break;
+                }
+                Err(_elapsed) => {
+                    let _ = tx
+                        .send(Err(anyhow!(
+                            "frame read timeout after {}s",
+                            FRAME_READ_TIMEOUT.as_secs()
+                        )))
+                        .await;
+                    break;
+                }
+            };
         match verify_moq_frame(&mut verifier, &topic, &frame) {
             Ok(payloads) => {
                 for p in payloads {
@@ -1188,7 +1330,11 @@ pub fn wire_transport_to_dial(
                 // Pinned self-signed mesh (matches the DID-doc #quic entry).
                 QuicServerAuth::pinned(hashes).ok()?
             };
-            Some(TransportConfig::quic_with_auth(addr, q.server_name.clone(), auth))
+            Some(TransportConfig::quic_with_auth(
+                addr,
+                q.server_name.clone(),
+                auth,
+            ))
         }
         // #320/#357: dial the wire-advertised iroh reach by node_id. iroh binds
         // the dialed `moql` connection to this `EndpointId` (its Ed25519 pubkey);
@@ -1198,7 +1344,11 @@ pub fn wire_transport_to_dial(
         // native peer can dial by node_id alone (no direct addrs are carried on
         // the wire — see `IrohReach` in streaming.capnp).
         ReachTransport::Iroh(i) => {
-            let relay_url = if i.relay_url.is_empty() { None } else { Some(i.relay_url.clone()) };
+            let relay_url = if i.relay_url.is_empty() {
+                None
+            } else {
+                Some(i.relay_url.clone())
+            };
             Some(TransportConfig::iroh(i.node_id, Vec::new(), relay_url))
         }
     }
@@ -1219,26 +1369,34 @@ pub fn dial_transport_to_wire(
     use crate::stream_info::{IrohReach, QuicReach, TransportConfig as ReachTransport};
     use crate::transport::EndpointType;
     match &dial.endpoint {
-        EndpointType::Quic { addr, server_name, auth } => Some(ReachTransport::Quic(QuicReach {
+        EndpointType::Quic {
+            addr,
+            server_name,
+            auth,
+        } => Some(ReachTransport::Quic(QuicReach {
             addr: addr.to_string(),
             server_name: server_name.clone(),
-            cert_hashes: auth.accept_cert_hashes().iter().map(|h| h.to_vec()).collect(),
+            cert_hashes: auth
+                .accept_cert_hashes()
+                .iter()
+                .map(|h| h.to_vec())
+                .collect(),
         })),
         // The wire iroh reach carries the carrier address (nodeId) + relay only; direct
         // addrs are not published (privacy + iroh discovery), matching the
         // DID-doc `IrohTransport` entry shape (#280/#282).
-        EndpointType::Iroh { node_id, relay_url, .. } => Some(ReachTransport::Iroh(IrohReach {
+        EndpointType::Iroh {
+            node_id, relay_url, ..
+        } => Some(ReachTransport::Iroh(IrohReach {
             node_id: *node_id,
-            alpn: String::from_utf8_lossy(
-                crate::transport::iroh_substrate::ALPN_HYPRSTREAM_RPC,
-            )
-            .into_owned(),
+            alpn: String::from_utf8_lossy(crate::transport::iroh_substrate::ALPN_HYPRSTREAM_RPC)
+                .into_owned(),
             relay_url: relay_url.clone().unwrap_or_default(),
         })),
         // Same-host endpoints are never wire-advertised (#320).
-        EndpointType::Inproc { .. }
-        | EndpointType::Ipc { .. }
-        | EndpointType::SystemdFd { .. } => None,
+        EndpointType::Inproc { .. } | EndpointType::Ipc { .. } | EndpointType::SystemdFd { .. } => {
+            None
+        }
     }
 }
 
@@ -1297,7 +1455,12 @@ pub async fn connect_moq_reach(
         };
         match crate::dial::dial_stream(&cfg).await {
             Ok(stream_session) => match stream_session.connect_moq(&moq_client).await {
-                Ok(session) => return Ok(MoqReachConnection { consumer, _session: session }),
+                Ok(session) => {
+                    return Ok(MoqReachConnection {
+                        consumer,
+                        _session: session,
+                    })
+                }
                 Err(e) => last_err = Some(format!("moq handshake: {e}")),
             },
             Err(e) => last_err = Some(e.to_string()),
@@ -1313,7 +1476,10 @@ pub async fn connect_moq_reach(
             .connect(session)
             .await
             .map_err(|e| anyhow!("moq UDS handshake: {e}"))?;
-        return Ok(MoqReachConnection { consumer, _session: session });
+        return Ok(MoqReachConnection {
+            consumer,
+            _session: session,
+        });
     }
 
     // 3. Fail closed.
@@ -1362,7 +1528,11 @@ pub fn select_reach(
     let relay_first = !matches!(qos.retention, Retention::Live);
     let mut ordered: Vec<crate::stream_info::Destination> = Vec::with_capacity(advertised.len());
     // Stable partition: pull the preferred role to the front, keep within-role order.
-    let prefer = if relay_first { Role::Relay } else { Role::Direct };
+    let prefer = if relay_first {
+        Role::Relay
+    } else {
+        Role::Direct
+    };
     ordered.extend(advertised.iter().filter(|d| d.role == prefer).cloned());
     ordered.extend(advertised.iter().filter(|d| d.role != prefer).cloned());
     ordered
@@ -1535,7 +1705,10 @@ pub async fn run_relay_announce_link(
 
     // Reuse the ONE wire-reach → dial-config resolver so the relay is dialed by
     // the same code path (Quic / WebTransport / iroh) every direct reach uses.
-    let dest = crate::stream_info::Destination { role: crate::stream_info::Role::Relay, transport: relay.clone() };
+    let dest = crate::stream_info::Destination {
+        role: crate::stream_info::Role::Relay,
+        transport: relay.clone(),
+    };
     let cfg = reach_to_transport_config(&dest)
         .ok_or_else(|| anyhow!("relay reach is not a dialable network transport"))?;
 
@@ -1587,7 +1760,9 @@ async fn moq_stream_handle_task_networked(
     let conn = match connect_moq_reach(&reach).await {
         Ok(c) => c,
         Err(e) => {
-            let _ = tx.send(Err(anyhow!("moq networked dial failed: {e}"))).await;
+            let _ = tx
+                .send(Err(anyhow!("moq networked dial failed: {e}")))
+                .await;
             return;
         }
     };
@@ -1602,12 +1777,16 @@ async fn moq_stream_handle_task_networked(
     {
         Ok(Some(bc)) => bc,
         Ok(None) => {
-            let _ = tx.send(Err(anyhow!("broadcast {broadcast_path} not announced"))).await;
+            let _ = tx
+                .send(Err(anyhow!("broadcast {broadcast_path} not announced")))
+                .await;
             return;
         }
         Err(_) => {
             let _ = tx
-                .send(Err(anyhow!("timeout waiting for broadcast {broadcast_path}")))
+                .send(Err(anyhow!(
+                    "timeout waiting for broadcast {broadcast_path}"
+                )))
                 .await;
             return;
         }
@@ -1633,35 +1812,43 @@ async fn moq_stream_handle_task_networked(
         if cancel.is_cancelled() {
             break;
         }
-        let mut group = match tokio::time::timeout(GROUP_IDLE_TIMEOUT, track.get_group(expected_seq)).await {
-            Ok(Ok(Some(g))) => g,
-            Ok(Ok(None)) => break,
-            Err(_elapsed) => {
-                let _ = tx
-                    .send(Err(anyhow!("stream idle: no group for {}s", GROUP_IDLE_TIMEOUT.as_secs())))
-                    .await;
-                break;
-            }
-            Ok(Err(e)) => {
-                let _ = tx.send(Err(anyhow!("moq next_group: {e}"))).await;
-                break;
-            }
-        };
+        let mut group =
+            match tokio::time::timeout(GROUP_IDLE_TIMEOUT, track.get_group(expected_seq)).await {
+                Ok(Ok(Some(g))) => g,
+                Ok(Ok(None)) => break,
+                Err(_elapsed) => {
+                    let _ = tx
+                        .send(Err(anyhow!(
+                            "stream idle: no group for {}s",
+                            GROUP_IDLE_TIMEOUT.as_secs()
+                        )))
+                        .await;
+                    break;
+                }
+                Ok(Err(e)) => {
+                    let _ = tx.send(Err(anyhow!("moq next_group: {e}"))).await;
+                    break;
+                }
+            };
         expected_seq += 1;
-        let frame: bytes::Bytes = match tokio::time::timeout(FRAME_READ_TIMEOUT, group.read_frame()).await {
-            Ok(Ok(Some(f))) => f,
-            Ok(Ok(None)) => break,
-            Ok(Err(e)) => {
-                let _ = tx.send(Err(anyhow!("frame read error: {e}"))).await;
-                break;
-            }
-            Err(_elapsed) => {
-                let _ = tx
-                    .send(Err(anyhow!("frame read timeout after {}s", FRAME_READ_TIMEOUT.as_secs())))
-                    .await;
-                break;
-            }
-        };
+        let frame: bytes::Bytes =
+            match tokio::time::timeout(FRAME_READ_TIMEOUT, group.read_frame()).await {
+                Ok(Ok(Some(f))) => f,
+                Ok(Ok(None)) => break,
+                Ok(Err(e)) => {
+                    let _ = tx.send(Err(anyhow!("frame read error: {e}"))).await;
+                    break;
+                }
+                Err(_elapsed) => {
+                    let _ = tx
+                        .send(Err(anyhow!(
+                            "frame read timeout after {}s",
+                            FRAME_READ_TIMEOUT.as_secs()
+                        )))
+                        .await;
+                    break;
+                }
+            };
         match verify_moq_frame(&mut verifier, &topic, &frame) {
             Ok(payloads) => {
                 for p in payloads {
@@ -1763,9 +1950,12 @@ fn seal_payload(
     enc_key: &[u8; 32],
     topic: &str,
     epoch: u64,
+    sequence_number: u64,
+    payload_index: usize,
+    nonce: Option<[u8; 12]>,
     payload: &StreamPayloadData,
 ) -> Result<StreamPayloadData> {
-    use crate::crypto::event_crypto::{encrypt_event, EventPrivacy};
+    use crate::crypto::event_crypto::{encrypt_event, encrypt_event_with_nonce, EventPrivacy};
     use crate::stream_consumer::{stream_aead_aad, SEALED_KIND_COMPLETE, SEALED_KIND_DATA};
 
     let (kind, body): (u8, &[u8]) = match payload {
@@ -1779,10 +1969,12 @@ fn seal_payload(
     plaintext.push(kind);
     plaintext.extend_from_slice(body);
 
-    let aad = stream_aead_aad(topic, epoch);
-    let (tag, ciphertext, nonce, key_commitment) =
-        encrypt_event(enc_key, &aad, &plaintext, EventPrivacy::ZeroKnowledge)
-            .map_err(|e| anyhow!("stream AEAD seal failed: {e}"))?;
+    let aad = stream_aead_aad(topic, epoch, sequence_number, payload_index);
+    let (tag, ciphertext, nonce, key_commitment) = match nonce {
+        Some(nonce) => encrypt_event_with_nonce(enc_key, nonce, &aad, &plaintext),
+        None => encrypt_event(enc_key, &aad, &plaintext, EventPrivacy::ZeroKnowledge),
+    }
+    .map_err(|e| anyhow!("stream AEAD seal failed: {e}"))?;
 
     Ok(StreamPayloadData::Tagged {
         tag,
@@ -1835,24 +2027,123 @@ mod tests {
         let mut verifier = StreamVerifier::new(mac_key, topic.clone()).with_enc_key(enc_key);
         let mut got: Vec<StreamPayload> = Vec::new();
         for _ in 0..3 {
-            let mut group = tokio::time::timeout(
-                std::time::Duration::from_secs(5),
-                track.next_group(),
-            )
-            .await??
-            .ok_or_else(|| anyhow!("next_group None"))?;
-            let frame = tokio::time::timeout(
-                std::time::Duration::from_secs(5),
-                group.read_frame(),
-            )
-            .await??
-            .ok_or_else(|| anyhow!("read_frame None"))?;
+            let mut group =
+                tokio::time::timeout(std::time::Duration::from_secs(5), track.next_group())
+                    .await??
+                    .ok_or_else(|| anyhow!("next_group None"))?;
+            let frame = tokio::time::timeout(std::time::Duration::from_secs(5), group.read_frame())
+                .await??
+                .ok_or_else(|| anyhow!("read_frame None"))?;
             got.extend(verify_moq_frame(&mut verifier, &topic, &frame)?);
         }
 
         assert!(matches!(&got[0], StreamPayload::Data(d) if d == b"hello"));
         assert!(matches!(&got[1], StreamPayload::Data(d) if d == b"world"));
         assert!(matches!(&got[2], StreamPayload::Complete(_)));
+        Ok(())
+    }
+
+    /// #554 identified profile: a standards-compatible MoQT track carries only
+    /// opaque Object bytes, an authenticated rekey resets the per-epoch sequence
+    /// and traffic keys, and the relay-visible Group identity remains monotonic.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn identified_epoch_rekey_keeps_stock_moq_objects_opaque_and_immutable() -> Result<()> {
+        use crate::crypto::hybrid_kem::{generate_recipient, SuiteId};
+        use crate::crypto::key_exchange::client_identified_stream_epoch;
+        use crate::stream_epoch::{
+            IdentifiedStreamBinding, StreamAcceptedState, StreamCarrierProfile, StreamRouteRole,
+        };
+
+        let binding = IdentifiedStreamBinding::new(
+            StreamCarrierProfile::StandardPublicRelay,
+            StreamRouteRole::Relay,
+            "did:at9p:producer",
+            "did:at9p:consumer",
+            StreamAcceptedState {
+                identity_did: "did:at9p:producer".into(),
+                digest: [0x31; 64],
+                epoch: 3,
+            },
+            StreamAcceptedState {
+                identity_did: "did:at9p:consumer".into(),
+                digest: [0x41; 64],
+                epoch: 4,
+            },
+            "inference.generate",
+            "infer:model:qwen",
+            "local/streams/identified",
+            "did:at9p:producer#mesh-kem",
+            "urn:hyprstream:stream-client:one-shot",
+            1,
+        )?;
+        let client_keypair = generate_recipient(SuiteId::HyKemX25519MlKem768)?;
+        let ctx = StreamContext::from_hybrid_identified(
+            &client_keypair.public().encode(),
+            binding.clone(),
+        )?;
+        let client_ratchet = client_identified_stream_epoch(
+            &client_keypair,
+            ctx.kem_ciphertexts()
+                .expect("hybrid context has ciphertexts"),
+            binding,
+        )?;
+        let topic = ctx.topic().to_owned();
+        let origin = origin();
+        let mut publisher = origin.publisher(&ctx)?;
+        publisher.publish_data(b"epoch-zero-secret").await?;
+        assert!(
+            publisher.publish_data(b"must-rekey-first").await.is_err(),
+            "epoch block bound must fail closed"
+        );
+
+        let commit = publisher.prepare_next_epoch()?;
+        publisher.commit_epoch(&commit)?;
+        publisher.publish_data(b"epoch-one-secret").await?;
+
+        let path = origin.broadcast_path(&topic);
+        let bc = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            origin.consumer().announced_broadcast(path.as_str()),
+        )
+        .await?
+        .ok_or_else(|| anyhow!("broadcast not announced"))?;
+        let track = bc.subscribe_track(&Track::new(STREAM_TRACK))?;
+        let mut verifier =
+            StreamVerifier::new([0; 32], String::new()).with_epoch_ratchet(client_ratchet);
+
+        let mut group0 = track
+            .get_group(0)
+            .await?
+            .ok_or_else(|| anyhow!("epoch-zero Group missing"))?;
+        let frame0 = group0
+            .read_frame()
+            .await?
+            .ok_or_else(|| anyhow!("epoch-zero Object missing"))?;
+        assert!(
+            !frame0
+                .windows(b"epoch-zero-secret".len())
+                .any(|window| window == b"epoch-zero-secret"),
+            "stock relay-visible Object leaked plaintext"
+        );
+        let first = verify_moq_frame(&mut verifier, &topic, &frame0)?;
+        assert!(matches!(&first[0], StreamPayload::Data(data) if data == b"epoch-zero-secret"));
+
+        verifier.accept_epoch_commit(&commit)?;
+        assert!(
+            verifier.accept_epoch_commit(&commit).is_err(),
+            "replayed epoch commit accepted"
+        );
+        let mut group1 = track
+            .get_group(1)
+            .await?
+            .ok_or_else(|| anyhow!("epoch-one Group missing"))?;
+        let frame1 = group1
+            .read_frame()
+            .await?
+            .ok_or_else(|| anyhow!("epoch-one Object missing"))?;
+        let second = verify_moq_frame(&mut verifier, &topic, &frame1)?;
+        assert!(matches!(&second[0], StreamPayload::Data(data) if data == b"epoch-one-secret"));
+        assert_ne!(frame0, frame1);
         Ok(())
     }
 
@@ -1884,18 +2175,13 @@ mod tests {
         let mut verifier = StreamVerifier::new(mac_key, topic.clone()).with_enc_key(enc_key);
         let mut got: Vec<StreamPayload> = Vec::new();
         for _ in 0..2 {
-            let mut group = tokio::time::timeout(
-                std::time::Duration::from_secs(5),
-                track.next_group(),
-            )
-            .await??
-            .ok_or_else(|| anyhow!("next_group None"))?;
-            let frame = tokio::time::timeout(
-                std::time::Duration::from_secs(5),
-                group.read_frame(),
-            )
-            .await??
-            .ok_or_else(|| anyhow!("read_frame None"))?;
+            let mut group =
+                tokio::time::timeout(std::time::Duration::from_secs(5), track.next_group())
+                    .await??
+                    .ok_or_else(|| anyhow!("next_group None"))?;
+            let frame = tokio::time::timeout(std::time::Duration::from_secs(5), group.read_frame())
+                .await??
+                .ok_or_else(|| anyhow!("read_frame None"))?;
             got.extend(verify_moq_frame(&mut verifier, &topic, &frame)?);
         }
         assert!(matches!(&got[0], StreamPayload::Data(d) if d == b"ping"));
@@ -1910,7 +2196,11 @@ mod tests {
     fn iroh_reach_dial_wire_roundtrip() {
         use crate::transport::{EndpointType, TransportConfig};
         let node_id = [0x42u8; 32];
-        let dial = TransportConfig::iroh(node_id, Vec::new(), Some("https://relay.example".to_owned()));
+        let dial = TransportConfig::iroh(
+            node_id,
+            Vec::new(),
+            Some("https://relay.example".to_owned()),
+        );
         let wire = dial_transport_to_wire(&dial).expect("iroh dial → wire");
         match &wire {
             crate::stream_info::TransportConfig::Iroh(i) => {
@@ -1922,10 +2212,17 @@ mod tests {
         }
         let back = wire_transport_to_dial(&wire).expect("iroh wire → dial");
         match back.endpoint {
-            EndpointType::Iroh { node_id: n, relay_url, direct_addrs } => {
+            EndpointType::Iroh {
+                node_id: n,
+                relay_url,
+                direct_addrs,
+            } => {
                 assert_eq!(n, node_id);
                 assert_eq!(relay_url.as_deref(), Some("https://relay.example"));
-                assert!(direct_addrs.is_empty(), "wire iroh reach never carries direct addrs");
+                assert!(
+                    direct_addrs.is_empty(),
+                    "wire iroh reach never carries direct addrs"
+                );
             }
             other => panic!("expected dial Iroh, got {other:?}"),
         }
@@ -1937,7 +2234,9 @@ mod tests {
     #[test]
     fn same_host_endpoints_never_wire_advertised() {
         use crate::transport::TransportConfig;
-        assert!(dial_transport_to_wire(&TransportConfig::inproc("hyprstream/inference-x")).is_none());
+        assert!(
+            dial_transport_to_wire(&TransportConfig::inproc("hyprstream/inference-x")).is_none()
+        );
         assert!(dial_transport_to_wire(&TransportConfig::ipc("/tmp/x.sock")).is_none());
     }
 
@@ -1954,7 +2253,9 @@ mod tests {
         });
         let dial = wire_transport_to_dial(&wire).expect("decodes");
         // No relay + no direct addrs ⇒ application RPC dial() fails fast.
-        let signer = crate::signer::LocalSigner::new(crate::crypto::SigningKey::generate(&mut rand::rngs::OsRng));
+        let signer = crate::signer::LocalSigner::new(crate::crypto::SigningKey::generate(
+            &mut rand::rngs::OsRng,
+        ));
         assert!(
             crate::dial::dial(&dial, signer, None, None).is_err(),
             "RPC dial must require explicit reachability and response proof"
@@ -2002,16 +2303,33 @@ mod tests {
                 relay_url: String::new(),
             }),
         };
-        assert_eq!(reach.role, Role::Direct, "iroh reach is a direct producer reach");
+        assert_eq!(
+            reach.role,
+            Role::Direct,
+            "iroh reach is a direct producer reach"
+        );
 
         let cfg = reach_to_transport_config(&reach)
             .expect("an iroh reach with a node_id must resolve to a dialable TransportConfig");
         match cfg.endpoint {
-            EndpointType::Iroh { node_id: got, direct_addrs, relay_url } => {
-                assert_eq!(got, node_id, "resolved node_id must round-trip the advertised one");
+            EndpointType::Iroh {
+                node_id: got,
+                direct_addrs,
+                relay_url,
+            } => {
+                assert_eq!(
+                    got, node_id,
+                    "resolved node_id must round-trip the advertised one"
+                );
                 // S2 advertises node_id alone; discovery supplies reachability.
-                assert!(direct_addrs.is_empty(), "S2 iroh reach carries no direct addrs (pkarr)");
-                assert!(relay_url.is_none(), "S2 iroh reach carries no relay URL (pkarr)");
+                assert!(
+                    direct_addrs.is_empty(),
+                    "S2 iroh reach carries no direct addrs (pkarr)"
+                );
+                assert!(
+                    relay_url.is_none(),
+                    "S2 iroh reach carries no relay URL (pkarr)"
+                );
             }
             other => panic!("iroh reach must resolve to EndpointType::Iroh, got {other:?}"),
         }
@@ -2210,10 +2528,15 @@ mod tests {
             server_name: "pds".to_owned(),
             cert_hashes: vec![vec![1u8; 32]],
         });
-        let cfg = ProducerReachConfig { relay: Some(relay.clone()), ..Default::default() };
+        let cfg = ProducerReachConfig {
+            relay: Some(relay.clone()),
+            ..Default::default()
+        };
         let reach = cfg.reach();
         assert!(
-            reach.iter().any(|d| d.role == Role::Relay && d.transport == relay),
+            reach
+                .iter()
+                .any(|d| d.role == Role::Relay && d.transport == relay),
             "ProducerReachConfig::reach must advertise the configured Role::Relay reach"
         );
     }
@@ -2238,7 +2561,11 @@ mod tests {
 
         // Stream Y: server default → direct (iroh) THEN relay, direct-first order.
         let reach_y = cfg.reach();
-        assert_eq!(reach_y[0].role, Role::Direct, "Y must advertise its direct reach first");
+        assert_eq!(
+            reach_y[0].role,
+            Role::Direct,
+            "Y must advertise its direct reach first"
+        );
         assert!(
             reach_y.iter().any(|d| d.role == Role::Relay),
             "Y must also advertise the server-global relay"
@@ -2252,9 +2579,16 @@ mod tests {
             cert_hashes: vec![vec![9u8; 32]],
         });
         let reach_x = cfg.reach_with_relay(RelayChoice::Only(relay_only.clone()));
-        assert_eq!(reach_x.len(), 1, "relay-only stream X must omit all direct reaches");
+        assert_eq!(
+            reach_x.len(),
+            1,
+            "relay-only stream X must omit all direct reaches"
+        );
         assert_eq!(reach_x[0].role, Role::Relay, "X is relay-only (anonymized)");
-        assert_eq!(reach_x[0].transport, relay_only, "X uses its per-stream relay override");
+        assert_eq!(
+            reach_x[0].transport, relay_only,
+            "X uses its per-stream relay override"
+        );
         assert!(
             !reach_x.iter().any(|d| d.role == Role::Direct),
             "X must NOT leak a direct reach (server authority / anonymization)"
@@ -2262,7 +2596,10 @@ mod tests {
 
         // The two streams genuinely differ in the same process — the property the
         // singletons precluded.
-        assert_ne!(reach_x, reach_y, "X (relay-only) and Y (direct+relay) must differ");
+        assert_ne!(
+            reach_x, reach_y,
+            "X (relay-only) and Y (direct+relay) must differ"
+        );
     }
 
     /// Per-stream relay `Override` swaps the relay but KEEPS the direct reaches
@@ -2285,9 +2622,19 @@ mod tests {
             relay: Some(server_relay.clone()),
         };
         let reach = cfg.reach_with_relay(RelayChoice::Override(tenant_relay.clone()));
-        assert_eq!(reach[0].role, Role::Direct, "override keeps the direct reach, listed first");
-        let relay_d = reach.iter().find(|d| d.role == Role::Relay).expect("relay advertised");
-        assert_eq!(relay_d.transport, tenant_relay, "per-stream override replaces the server relay");
+        assert_eq!(
+            reach[0].role,
+            Role::Direct,
+            "override keeps the direct reach, listed first"
+        );
+        let relay_d = reach
+            .iter()
+            .find(|d| d.role == Role::Relay)
+            .expect("relay advertised");
+        assert_eq!(
+            relay_d.transport, tenant_relay,
+            "per-stream override replaces the server relay"
+        );
     }
 
     /// QoS-driven selection: live pipes prefer DIRECT, retained/fan-out prefer RELAY.
@@ -2298,15 +2645,31 @@ mod tests {
         // Pipe (Retention::Live) → direct-first; within-role order preserved.
         let pipe = Pipe::stream_opt();
         let ordered = select_reach(&advertised, &pipe);
-        assert_eq!(ordered[0].role, Role::Direct, "live pipe must try direct first");
-        assert_eq!(ordered[2].role, Role::Relay, "relay falls to the back for a live pipe");
-        assert_eq!(ordered[0], direct_iroh(1), "within-role advertised order preserved");
+        assert_eq!(
+            ordered[0].role,
+            Role::Direct,
+            "live pipe must try direct first"
+        );
+        assert_eq!(
+            ordered[2].role,
+            Role::Relay,
+            "relay falls to the back for a live pipe"
+        );
+        assert_eq!(
+            ordered[0],
+            direct_iroh(1),
+            "within-role advertised order preserved"
+        );
         assert_eq!(ordered[1], direct_iroh(2));
 
         // Job (retained/resumable) → relay-first.
         let job = Job::stream_opt();
         let ordered = select_reach(&advertised, &job);
-        assert_eq!(ordered[0].role, Role::Relay, "retained job must try relay first");
+        assert_eq!(
+            ordered[0].role,
+            Role::Relay,
+            "retained job must try relay first"
+        );
 
         // Log (retained) → relay-first.
         let log = Log::stream_opt();
@@ -2323,7 +2686,11 @@ mod tests {
         // Even with default (Live → direct-preferred) qos, no direct reach appears.
         let ordered = select_reach(&relay_only, &StreamOpt::default());
         assert_eq!(ordered.len(), 1, "selection must not add or drop reaches");
-        assert_eq!(ordered[0].role, Role::Relay, "a relay-only stream stays relay-only");
+        assert_eq!(
+            ordered[0].role,
+            Role::Relay,
+            "a relay-only stream stays relay-only"
+        );
         assert!(
             !ordered.iter().any(|d| d.role == Role::Direct),
             "the client must NOT fabricate a direct reach the service didn't advertise"
@@ -2335,7 +2702,10 @@ mod tests {
         let mut b = select_reach(&advertised, &Job::stream_opt());
         a.sort_by_key(|d| (d.role == Role::Relay, format!("{d:?}")));
         b.sort_by_key(|d| (d.role == Role::Relay, format!("{d:?}")));
-        assert_eq!(a, b, "selection must be a permutation of the advertised reach");
+        assert_eq!(
+            a, b,
+            "selection must be a permutation of the advertised reach"
+        );
     }
 
     /// `relay_reach_from_decoded` round-trips a DID-decoded transport into the
@@ -2350,7 +2720,8 @@ mod tests {
         }
         // Same-host transports are never relay endpoints.
         assert!(
-            relay_reach_from_decoded(&crate::transport::TransportConfig::ipc("/tmp/x.sock")).is_none(),
+            relay_reach_from_decoded(&crate::transport::TransportConfig::ipc("/tmp/x.sock"))
+                .is_none(),
             "a same-host ipc transport is not a network-routable relay"
         );
     }
@@ -2366,13 +2737,26 @@ mod tests {
             StreamPayloadData::Data(b"hello tokens".to_vec()),
             StreamPayloadData::Complete(b"{\"done\":true}".to_vec()),
         ] {
-            let sealed = seal_payload(&enc_key, topic, epoch, &payload).unwrap();
-            let StreamPayloadData::Tagged { tag, payload: ct, nonce, key_commitment } = &sealed
+            let sealed = seal_payload(&enc_key, topic, epoch, 0, 0, None, &payload).unwrap();
+            let StreamPayloadData::Tagged {
+                tag,
+                payload: ct,
+                nonce,
+                key_commitment,
+            } = &sealed
             else {
                 panic!("seal must produce a Tagged payload");
             };
             let opened = crate::stream_consumer::open_sealed_payload(
-                &enc_key, topic, epoch, tag, ct, nonce, key_commitment,
+                &enc_key,
+                topic,
+                epoch,
+                0,
+                0,
+                tag,
+                ct,
+                nonce,
+                key_commitment,
             )
             .unwrap();
             match (&payload, &opened) {
@@ -2390,23 +2774,52 @@ mod tests {
         let enc_key = [0x42u8; 32];
         let topic = "t";
         let epoch = 1u64;
-        let sealed =
-            seal_payload(&enc_key, topic, epoch, &StreamPayloadData::Data(b"secret".to_vec()))
-                .unwrap();
-        let StreamPayloadData::Tagged { tag, payload: ct, nonce, key_commitment } = &sealed else {
+        let sealed = seal_payload(
+            &enc_key,
+            topic,
+            epoch,
+            0,
+            0,
+            None,
+            &StreamPayloadData::Data(b"secret".to_vec()),
+        )
+        .unwrap();
+        let StreamPayloadData::Tagged {
+            tag,
+            payload: ct,
+            nonce,
+            key_commitment,
+        } = &sealed
+        else {
             panic!("expected Tagged");
         };
 
         // Wrong key.
         let wrong = [0x99u8; 32];
         assert!(crate::stream_consumer::open_sealed_payload(
-            &wrong, topic, epoch, tag, ct, nonce, key_commitment
+            &wrong,
+            topic,
+            epoch,
+            0,
+            0,
+            tag,
+            ct,
+            nonce,
+            key_commitment
         )
         .is_err());
 
         // Wrong epoch (AAD mismatch) — anti-replay across epochs.
         assert!(crate::stream_consumer::open_sealed_payload(
-            &enc_key, topic, 2, tag, ct, nonce, key_commitment
+            &enc_key,
+            topic,
+            2,
+            0,
+            0,
+            tag,
+            ct,
+            nonce,
+            key_commitment
         )
         .is_err());
 
@@ -2416,7 +2829,15 @@ mod tests {
             *b ^= 0xFF;
         }
         assert!(crate::stream_consumer::open_sealed_payload(
-            &enc_key, topic, epoch, tag, &bad_ct, nonce, key_commitment
+            &enc_key,
+            topic,
+            epoch,
+            0,
+            0,
+            tag,
+            &bad_ct,
+            nonce,
+            key_commitment
         )
         .is_err());
     }
@@ -2457,25 +2878,23 @@ mod tests {
         let mut track = bc.subscribe_track(&Track::new(STREAM_TRACK))?;
         let mut frames: Vec<bytes::Bytes> = Vec::new();
         for _ in 0..2 {
-            let mut group = tokio::time::timeout(
-                std::time::Duration::from_secs(5),
-                track.next_group(),
-            )
-            .await??
-            .ok_or_else(|| anyhow!("next_group None"))?;
-            let frame = tokio::time::timeout(
-                std::time::Duration::from_secs(5),
-                group.read_frame(),
-            )
-            .await??
-            .ok_or_else(|| anyhow!("read_frame None"))?;
+            let mut group =
+                tokio::time::timeout(std::time::Duration::from_secs(5), track.next_group())
+                    .await??
+                    .ok_or_else(|| anyhow!("next_group None"))?;
+            let frame = tokio::time::timeout(std::time::Duration::from_secs(5), group.read_frame())
+                .await??
+                .ok_or_else(|| anyhow!("read_frame None"))?;
             frames.push(frame);
         }
 
         // Roster anchoring the host's mesh ML-DSA key + enrolled-set closure.
         use ml_dsa::Keypair;
         let mut roster = KeyedPqTrustStore::new();
-        roster.bind(kid, &crate::node_identity::derive_mesh_mldsa_key(&host_ed).verifying_key());
+        roster.bind(
+            kid,
+            &crate::node_identity::derive_mesh_mldsa_key(&host_ed).verifying_key(),
+        );
         let enrolled = |k: &[u8; 32]| *k == kid;
 
         // Valid: verify HMAC + AEAD + provenance.
@@ -2489,7 +2908,11 @@ mod tests {
         let none_enrolled = |_: &[u8; 32]| false;
         let mut v2 = StreamVerifier::new(mac_key, topic.clone()).with_enc_key(enc_key);
         assert!(verify_moq_frame_with_provenance(
-            &mut v2, &topic, &frames[0], &empty, &none_enrolled
+            &mut v2,
+            &topic,
+            &frames[0],
+            &empty,
+            &none_enrolled
         )
         .is_err());
         Ok(())

--- a/crates/hyprstream-rpc/src/moq_stream.rs
+++ b/crates/hyprstream-rpc/src/moq_stream.rs
@@ -689,6 +689,12 @@ impl MoqStreamOrigin {
         ctx: &StreamContext,
         provenance: Option<crate::stream_provenance::ProvenanceSigner>,
     ) -> Result<MoqStreamPublisher> {
+        let epoch_ratchet = ctx.epoch_ratchet();
+        ensure!(
+            epoch_ratchet.is_none() || ctx.enc_key().is_some(),
+            "identified stream rejected a context with transport AEAD disabled"
+        );
+
         let path = self.broadcast_path(ctx.topic());
         let mut broadcast = self
             .inner
@@ -713,7 +719,7 @@ impl MoqStreamOrigin {
             track,
             next_group: 0,
             next_sequence: 0,
-            epoch_ratchet: ctx.epoch_ratchet(),
+            epoch_ratchet,
             cancel_token: ctx.cancel_token().clone(),
             terminated: false,
             topic: ctx.topic().to_owned(),
@@ -2224,6 +2230,10 @@ mod tests {
         let initial_ratchet = client_ratchet.clone();
         let topic = ctx.topic().to_owned();
         let origin = origin();
+        assert!(
+            origin.publisher(&ctx.clone().without_aead()).is_err(),
+            "identified context accepted an AEAD downgrade before publication"
+        );
         let mut publisher = origin.publisher(&ctx)?;
         publisher.publish_data(b"epoch-zero-secret").await?;
         assert!(

--- a/crates/hyprstream-rpc/src/moq_stream.rs
+++ b/crates/hyprstream-rpc/src/moq_stream.rs
@@ -689,40 +689,45 @@ impl MoqStreamOrigin {
         ctx: &StreamContext,
         provenance: Option<crate::stream_provenance::ProvenanceSigner>,
     ) -> Result<MoqStreamPublisher> {
-        let epoch_ratchet = ctx.epoch_ratchet();
         ensure!(
-            epoch_ratchet.is_none() || ctx.enc_key().is_some(),
+            !ctx.has_epoch_ratchet() || ctx.enc_key().is_some(),
             "identified stream rejected a context with transport AEAD disabled"
         );
+        // Hold the identified producer claim through all fallible MoQ setup.
+        // Every `StreamContext` clone shares this lock/slot. The ratchet is
+        // consumed only once setup succeeds, so a setup error remains retryable
+        // while successful construction cannot restart epoch/group/sequence
+        // zero or reuse the same AEAD key and nonce domain.
+        ctx.with_publisher_epoch_ratchet(|epoch_ratchet| {
+            let path = self.broadcast_path(ctx.topic());
+            let mut broadcast = self
+                .inner
+                .producer
+                .create_broadcast(path.as_str())
+                .ok_or_else(|| anyhow!("create_broadcast denied for {path}"))?;
+            let track = broadcast.create_track(Track::new(STREAM_TRACK))?;
 
-        let path = self.broadcast_path(ctx.topic());
-        let mut broadcast = self
-            .inner
-            .producer
-            .create_broadcast(path.as_str())
-            .ok_or_else(|| anyhow!("create_broadcast denied for {path}"))?;
-        let track = broadcast.create_track(Track::new(STREAM_TRACK))?;
+            // Retain the broadcast producer so it stays announced for the
+            // publisher's lifetime (dropping it would unannounce the broadcast).
+            // Replace-semantics: inserting the same path twice drops the old
+            // BroadcastProducer rather than accumulating indefinitely (#164).
+            self.inner.broadcasts.lock().insert(path, broadcast);
 
-        // Retain the broadcast producer so it stays announced for the
-        // publisher's lifetime (dropping it would unannounce the broadcast).
-        // Replace-semantics: inserting the same path twice drops the old
-        // BroadcastProducer rather than accumulating indefinitely (#164).
-        self.inner.broadcasts.lock().insert(path, broadcast);
-
-        Ok(MoqStreamPublisher {
-            hmac_state: StreamHmacState::new(*ctx.mac_key(), ctx.topic().to_owned()),
-            // #321: AEAD enc_key — `Some` only on the DH (mesh) path. `None` on the
-            // keyless `StreamContext::new` path (NotificationService topics, whose
-            // payloads are already E2E-encrypted), where transport AEAD is skipped.
-            enc_key: ctx.enc_key().copied(),
-            provenance,
-            track,
-            next_group: 0,
-            next_sequence: 0,
-            epoch_ratchet,
-            cancel_token: ctx.cancel_token().clone(),
-            terminated: false,
-            topic: ctx.topic().to_owned(),
+            Ok(MoqStreamPublisher {
+                hmac_state: StreamHmacState::new(*ctx.mac_key(), ctx.topic().to_owned()),
+                // #321: AEAD enc_key — `Some` only on the DH (mesh) path. `None` on the
+                // keyless `StreamContext::new` path (NotificationService topics, whose
+                // payloads are already E2E-encrypted), where transport AEAD is skipped.
+                enc_key: ctx.enc_key().copied(),
+                provenance,
+                track,
+                next_group: 0,
+                next_sequence: 0,
+                epoch_ratchet: epoch_ratchet.take(),
+                cancel_token: ctx.cancel_token().clone(),
+                terminated: false,
+                topic: ctx.topic().to_owned(),
+            })
         })
     }
 }
@@ -2230,11 +2235,16 @@ mod tests {
         let initial_ratchet = client_ratchet.clone();
         let topic = ctx.topic().to_owned();
         let origin = origin();
+        let duplicate_ctx = ctx.clone();
         assert!(
             origin.publisher(&ctx.clone().without_aead()).is_err(),
             "identified context accepted an AEAD downgrade before publication"
         );
         let mut publisher = origin.publisher(&ctx)?;
+        assert!(
+            origin.publisher(&duplicate_ctx).is_err(),
+            "identified context clone created a second epoch-zero publisher"
+        );
         publisher.publish_data(b"epoch-zero-secret").await?;
         assert!(
             publisher.publish_data(b"must-rekey-first").await.is_err(),
@@ -2261,14 +2271,13 @@ mod tests {
 
         let mut frames = Vec::new();
         for group_id in 0..5 {
-            let mut group = track
-                .get_group(group_id)
-                .await?
-                .ok_or_else(|| anyhow!("identified Group {group_id} missing"))?;
+            let mut group =
+                tokio::time::timeout(std::time::Duration::from_secs(5), track.get_group(group_id))
+                    .await??
+                    .ok_or_else(|| anyhow!("identified Group {group_id} missing"))?;
             frames.push(
-                group
-                    .read_frame()
-                    .await?
+                tokio::time::timeout(std::time::Duration::from_secs(5), group.read_frame())
+                    .await??
                     .ok_or_else(|| anyhow!("identified Object {group_id} missing"))?,
             );
         }

--- a/crates/hyprstream-rpc/src/moq_stream.rs
+++ b/crates/hyprstream-rpc/src/moq_stream.rs
@@ -735,7 +735,7 @@ impl MoqStreamOrigin {
 /// `BatchingConfig` in M2b for granularity parity.
 pub struct MoqStreamPublisher {
     hmac_state: StreamHmacState,
-    /// Transport-level AEAD key (#321). `Some` ⇒ each Data/Complete payload is
+    /// Transport-level AEAD key (#321). `Some` ⇒ each Data/Complete/Error payload is
     /// sealed with AES-256-GCM into a `Tagged` payload before the HMAC chain runs;
     /// `None` ⇒ cleartext (keyless notification path).
     enc_key: Option<[u8; 32]>,
@@ -845,11 +845,10 @@ impl MoqStreamPublisher {
             .checked_add(1)
             .ok_or_else(|| anyhow!("stream sequence exhausted"))?;
 
-        // #321: on the mesh/DH path (`enc_key = Some`), seal each Data/Complete
+        // #321: on the mesh/DH path (`enc_key = Some`), seal each Data/Complete/Error
         // payload with AES-256-GCM into a `Tagged` payload BEFORE the HMAC chain
         // runs (so the chain authenticates the ciphertext — no double-encryption,
-        // ordering/anti-replay unchanged). Error frames stay cleartext (operational
-        // status, terminal). The AEAD AAD/key-commitment are bound to the block's
+        // ordering/anti-replay unchanged). The AEAD AAD/key-commitment are bound to the block's
         // `epoch` (and topic), so a rekey can't replay a block across epochs.
         let sealed: Vec<StreamPayloadData>;
         let payloads: &[StreamPayloadData] = match self.enc_key {
@@ -1939,10 +1938,10 @@ pub fn verify_moq_frame_with_provenance(
     Ok(payloads)
 }
 
-/// Seal a single Data/Complete payload into an AES-256-GCM `Tagged` payload
+/// Seal a single Data/Complete/Error payload into an AES-256-GCM `Tagged` payload
 /// (#321). The 1-byte kind tag is prepended to the plaintext so the consumer can
-/// restore the original variant. Error/Tagged/other variants pass through
-/// unchanged (Error is operational, already-Tagged is the E2E notification path).
+/// restore the original variant. Already-Tagged/other variants pass through
+/// unchanged (already-Tagged is the E2E notification path).
 ///
 /// Shares its AAD + kind-tag framing with the cross-target open path
 /// ([`crate::stream_consumer::open_sealed_payload`]).
@@ -1956,11 +1955,14 @@ fn seal_payload(
     payload: &StreamPayloadData,
 ) -> Result<StreamPayloadData> {
     use crate::crypto::event_crypto::{encrypt_event, encrypt_event_with_nonce, EventPrivacy};
-    use crate::stream_consumer::{stream_aead_aad, SEALED_KIND_COMPLETE, SEALED_KIND_DATA};
+    use crate::stream_consumer::{
+        stream_aead_aad, SEALED_KIND_COMPLETE, SEALED_KIND_DATA, SEALED_KIND_ERROR,
+    };
 
     let (kind, body): (u8, &[u8]) = match payload {
         StreamPayloadData::Data(d) => (SEALED_KIND_DATA, d),
         StreamPayloadData::Complete(d) => (SEALED_KIND_COMPLETE, d),
+        StreamPayloadData::Error(message) => (SEALED_KIND_ERROR, message.as_bytes()),
         // Leave non-sealed variants untouched.
         other => return Ok(other.clone()),
     };
@@ -2143,7 +2145,33 @@ mod tests {
             .ok_or_else(|| anyhow!("epoch-one Object missing"))?;
         let second = verify_moq_frame(&mut verifier, &topic, &frame1)?;
         assert!(matches!(&second[0], StreamPayload::Data(data) if data == b"epoch-one-secret"));
+
+        // Errors are application payloads too: rekey, publish one, and prove a
+        // stock relay cannot read the message while the endpoint restores the
+        // exact Error variant.
+        let error_commit = publisher.prepare_next_epoch()?;
+        publisher.commit_epoch(&error_commit)?;
+        let private_error = "private model failure: customer prompt rejected";
+        publisher.publish_error(private_error).await?;
+        verifier.accept_epoch_commit(&error_commit)?;
+        let mut group2 = track
+            .get_group(2)
+            .await?
+            .ok_or_else(|| anyhow!("error epoch Group missing"))?;
+        let frame2 = group2
+            .read_frame()
+            .await?
+            .ok_or_else(|| anyhow!("error epoch Object missing"))?;
+        assert!(
+            !frame2
+                .windows(private_error.len())
+                .any(|window| window == private_error.as_bytes()),
+            "stock relay-visible Object leaked the private error string"
+        );
+        let error = verify_moq_frame(&mut verifier, &topic, &frame2)?;
+        assert!(matches!(&error[0], StreamPayload::Error(message) if message == private_error));
         assert_ne!(frame0, frame1);
+        assert_ne!(frame1, frame2);
         Ok(())
     }
 

--- a/crates/hyprstream-rpc/src/rpc_client.rs
+++ b/crates/hyprstream-rpc/src/rpc_client.rs
@@ -348,6 +348,7 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
                 request_id,
                 payload,
                 None,
+                None,
                 self.effective_jwt(),
                 None,
                 service_domain,
@@ -394,9 +395,41 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
                 request_id,
                 payload,
                 Some(ephemeral_pubkey),
+                None,
                 self.effective_jwt(),
                 None,
                 service_domain,
+            )
+            .await?;
+        let timeout = self.calculate_timeout();
+        let response_bytes = self.transport.send(signed_bytes, timeout).await?;
+        let (_req_id, inner) = self.unwrap_response(&response_bytes, request_id, pending)?;
+        Ok(inner)
+    }
+
+    /// Send an identified stream setup using the pinned classical+ML-KEM
+    /// recipient.  The caller retains the matching keypair and combines the
+    /// returned `StreamInfo.kemCiphertexts` with its accepted-current
+    /// [`IdentifiedStreamBinding`] before opening the stream.
+    pub async fn call_streaming_identified_for_service(
+        &self,
+        service_domain: &str,
+        payload: Vec<u8>,
+        recipient: crate::crypto::hybrid_kem::RecipientPublic,
+    ) -> Result<Vec<u8>> {
+        if recipient.suite_id != crate::stream_epoch::IDENTIFIED_STREAM_SUITE {
+            anyhow::bail!("identified stream recipient does not use the pinned HyKEM suite");
+        }
+        let request_id = self.next_id();
+        let (signed_bytes, pending) = self
+            .sign_envelope(
+                request_id,
+                payload,
+                None,
+                Some(recipient),
+                self.effective_jwt(),
+                None,
+                Some(service_domain),
             )
             .await?;
         let timeout = self.calculate_timeout();
@@ -432,6 +465,7 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
                 request_id,
                 payload,
                 Some(ephemeral_pubkey),
+                None,
                 jwt,
                 options.delegated_bearer,
                 service_domain,
@@ -478,6 +512,7 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
             .sign_envelope(
                 request_id,
                 payload,
+                None,
                 None,
                 jwt,
                 options.delegated_bearer,
@@ -608,6 +643,7 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
         request_id: u64,
         payload: Vec<u8>,
         ephemeral_pubkey: Option<[u8; 32]>,
+        stream_kem_recipient: Option<crate::crypto::hybrid_kem::RecipientPublic>,
         jwt: Option<String>,
         delegated_bearer: Option<String>,
         service_domain: Option<&str>,
@@ -622,6 +658,9 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
         }
         if let Some(key) = ephemeral_pubkey {
             envelope = envelope.with_client_dh_public(key);
+        }
+        if let Some(recipient) = stream_kem_recipient {
+            envelope = envelope.with_client_kem_public(recipient)?;
         }
         if let Some(service_domain) = service_domain {
             envelope = envelope.with_service_domain(service_domain)?;
@@ -1049,10 +1088,7 @@ mod request_kem_tests {
                 .service_domain
                 .as_deref()
                 .ok_or_else(|| anyhow::anyhow!("test request omitted service domain"))?;
-            self.state
-                .recipients
-                .lock()
-                .push(recipient.encode());
+            self.state.recipients.lock().push(recipient.encode());
             let pq_sk = crate::node_identity::derive_mesh_mldsa_key(&self.server_sk);
             let response = crate::envelope::ResponseEnvelope::new_signed_encrypted(
                 request.request_id,
@@ -1285,6 +1321,7 @@ mod request_kem_tests {
                 None,
                 None,
                 None,
+                None,
                 Some("test-service"),
             )
             .await
@@ -1321,6 +1358,7 @@ mod request_kem_tests {
             .sign_envelope(
                 1,
                 b"payload".to_vec(),
+                None,
                 None,
                 None,
                 None,

--- a/crates/hyprstream-rpc/src/service/svc.rs
+++ b/crates/hyprstream-rpc/src/service/svc.rs
@@ -139,6 +139,11 @@ pub struct EnvelopeContext {
     /// Present on streaming requests; extracted from `RequestEnvelope.client_dh_public`.
     client_dh_public: Option<[u8; 32]>,
 
+    /// Authenticated, suite-complete ephemeral HyKEM recipient for an identified
+    /// stream.  This is only key material; handlers must still supply the
+    /// accepted-current [`IdentifiedStreamBinding`] and pass the key-release PEP.
+    client_kem_public: Option<crate::crypto::hybrid_kem::RecipientPublic>,
+
     /// Authenticated request transcript and one-shot response recipient.
     /// These are used only by the response seal chokepoint.
     pub(crate) request_iat: i64,
@@ -176,6 +181,7 @@ impl EnvelopeContext {
             cnf: envelope.cnf,
             envelope_wit_hash: envelope.envelope.wth,
             client_dh_public: envelope.envelope.client_dh_public,
+            client_kem_public: envelope.envelope.client_kem_public.clone(),
             request_iat: envelope.envelope.iat,
             request_nonce: envelope.envelope.nonce,
             response_kem_recipient: envelope.envelope.response_kem_recipient.clone(),
@@ -200,6 +206,7 @@ impl EnvelopeContext {
             cnf: envelope.cnf,
             envelope_wit_hash: envelope.envelope.wth,
             client_dh_public: envelope.envelope.client_dh_public,
+            client_kem_public: envelope.envelope.client_kem_public.clone(),
             request_iat: envelope.envelope.iat,
             request_nonce: envelope.envelope.nonce,
             response_kem_recipient: envelope.envelope.response_kem_recipient.clone(),
@@ -228,6 +235,7 @@ impl EnvelopeContext {
             cnf: [0u8; 32],
             envelope_wit_hash: None,
             client_dh_public: None,
+            client_kem_public: None,
             request_iat: 0,
             request_nonce: [0; 16],
             response_kem_recipient: None,
@@ -374,6 +382,11 @@ impl EnvelopeContext {
     /// Used by streaming handlers to derive shared secrets for HMAC chain keys.
     pub fn ephemeral_pubkey(&self) -> Option<[u8; 32]> {
         self.client_dh_public
+    }
+
+    /// Get the authenticated identified-stream HyKEM recipient.
+    pub fn stream_kem_recipient(&self) -> Option<&crate::crypto::hybrid_kem::RecipientPublic> {
+        self.client_kem_public.as_ref()
     }
 
     /// Whether this request came from a genuine in-process / IPC caller (#328).
@@ -699,8 +712,7 @@ pub trait RequestService: 'static {
         let protected = crate::auth::parse_protected_header(&token)
             .map_err(|e| anyhow::anyhow!("JWT header parse failed: {}", e))?;
         anyhow::ensure!(
-            crate::auth::is_rfc9068_access_token_type(&protected.typ)
-                || protected.typ == "wit+jwt",
+            crate::auth::is_rfc9068_access_token_type(&protected.typ) || protected.typ == "wit+jwt",
             "unsupported JWT typ"
         );
         let kid = Some(protected.kid.clone());
@@ -802,7 +814,10 @@ pub trait RequestService: 'static {
             }
             "ML-DSA-65-Ed25519" => {
                 if !unverified.iss.is_empty()
-                    && !key_source.local_issuers().iter().any(|issuer| issuer == &unverified.iss)
+                    && !key_source
+                        .local_issuers()
+                        .iter()
+                        .any(|issuer| issuer == &unverified.iss)
                 {
                     anyhow::bail!("local composite JWT issuer mismatch");
                 }
@@ -1141,6 +1156,7 @@ mod empty_iss_gate_tests {
             cnf: [0u8; 32],
             envelope_wit_hash: None,
             client_dh_public: None,
+            client_kem_public: None,
             request_iat: 0,
             request_nonce: [0; 16],
             response_kem_recipient: None,
@@ -1287,9 +1303,7 @@ mod empty_iss_gate_tests {
         let claims =
             Claims::new("alice".to_owned(), now, now + 60).with_issuer("https://local".to_owned());
         for typ in crate::auth::RFC9068_ACCESS_TOKEN_TYPES {
-            let header = format!(
-                r#"{{"alg":"ML-DSA-65-Ed25519","typ":"{typ}","kid":"{kid_a}"}}"#
-            );
+            let header = format!(r#"{{"alg":"ML-DSA-65-Ed25519","typ":"{typ}","kid":"{kid_a}"}}"#);
             let valid = composite_token(&header, &claims, &pq_a, &ed_a, false);
             assert!(
                 svc.verify_claims(&mut ctx_with_token(valid, false))
@@ -1332,15 +1346,21 @@ mod empty_iss_gate_tests {
                 false,
             ),
             (
-                format!(r#"{{"alg":"ML-DSA-65-Ed25519","typ":"Application/at+jwt","kid":"{kid_a}"}}"#),
+                format!(
+                    r#"{{"alg":"ML-DSA-65-Ed25519","typ":"Application/at+jwt","kid":"{kid_a}"}}"#
+                ),
                 false,
             ),
             (
-                format!(r#"{{"alg":"ML-DSA-65-Ed25519","typ":"application/AT+JWT","kid":"{kid_a}"}}"#),
+                format!(
+                    r#"{{"alg":"ML-DSA-65-Ed25519","typ":"application/AT+JWT","kid":"{kid_a}"}}"#
+                ),
                 false,
             ),
             (
-                format!(r#"{{"alg":"ML-DSA-65-Ed25519","typ":"application/at+jwt ","kid":"{kid_a}"}}"#),
+                format!(
+                    r#"{{"alg":"ML-DSA-65-Ed25519","typ":"application/at+jwt ","kid":"{kid_a}"}}"#
+                ),
                 false,
             ),
             (
@@ -1409,10 +1429,16 @@ mod empty_iss_gate_tests {
 
         let missing_issuer = Claims::new("alice".to_owned(), now, now + 60);
         let token = composite_token(&valid_header, &missing_issuer, &pq_a, &ed_a, false);
-        assert!(svc.verify_claims(&mut ctx_with_token(token, false)).await.is_err());
+        assert!(svc
+            .verify_claims(&mut ctx_with_token(token, false))
+            .await
+            .is_err());
         let wrong_issuer = claims.clone().with_issuer("https://other".to_owned());
         let token = composite_token(&valid_header, &wrong_issuer, &pq_a, &ed_a, false);
-        assert!(svc.verify_claims(&mut ctx_with_token(token, false)).await.is_err());
+        assert!(svc
+            .verify_claims(&mut ctx_with_token(token, false))
+            .await
+            .is_err());
     }
 
     #[test]
@@ -1505,6 +1531,7 @@ mod ipc_key_identity_tests {
             cnf: signer_pubkey,
             envelope_wit_hash: None,
             client_dh_public: None,
+            client_kem_public: None,
             request_iat: 0,
             request_nonce: [0; 16],
             response_kem_recipient: None,
@@ -1731,6 +1758,7 @@ mod accounting_audit_tests {
             cnf: [0u8; 32],
             envelope_wit_hash: None,
             client_dh_public: None,
+            client_kem_public: None,
             request_iat: 0,
             request_nonce: [0; 16],
             response_kem_recipient: None,
@@ -1785,6 +1813,7 @@ mod accounting_audit_tests {
             cnf: [0u8; 32],
             envelope_wit_hash: None,
             client_dh_public: None,
+            client_kem_public: None,
             request_iat: 0,
             request_nonce: [0; 16],
             response_kem_recipient: None,
@@ -1849,6 +1878,7 @@ mod accounting_audit_tests {
             cnf,
             envelope_wit_hash: None,
             client_dh_public: None,
+            client_kem_public: None,
             request_iat: 0,
             request_nonce: [0; 16],
             response_kem_recipient: None,

--- a/crates/hyprstream-rpc/src/stream_consumer.rs
+++ b/crates/hyprstream-rpc/src/stream_consumer.rs
@@ -304,6 +304,7 @@ impl StreamVerifier {
 
         let payloads_reader = block.get_payloads()?;
         let mut payloads = Vec::with_capacity(payloads_reader.len() as usize);
+        let mut pending_epoch_commit = None;
 
         let mut terminal_seen = self.terminal_seen;
         for i in 0..payloads_reader.len() {
@@ -311,15 +312,33 @@ impl StreamVerifier {
 
             use streaming_capnp::stream_payload::Which;
             let payload = match p.which()? {
-                Which::Data(data_result) => StreamPayload::Data(data_result?.to_vec()),
+                Which::Data(data_result) => {
+                    ensure!(
+                        self.epoch_ratchet.is_none(),
+                        "identified stream rejected cleartext Data payload"
+                    );
+                    StreamPayload::Data(data_result?.to_vec())
+                }
                 Which::Error(err_result) => {
+                    ensure!(
+                        self.epoch_ratchet.is_none(),
+                        "identified stream rejected cleartext Error payload"
+                    );
                     let err = err_result?;
                     StreamPayload::Error(err.get_message()?.to_string()?)
                 }
                 Which::Complete(complete_result) => {
+                    ensure!(
+                        self.epoch_ratchet.is_none(),
+                        "identified stream rejected cleartext Complete payload"
+                    );
                     StreamPayload::Complete(complete_result?.to_vec())
                 }
                 Which::Heartbeat(()) => {
+                    ensure!(
+                        self.epoch_ratchet.is_none(),
+                        "identified stream rejected cleartext Heartbeat payload"
+                    );
                     continue;
                 }
                 Which::Tagged(tagged_result) => {
@@ -327,7 +346,7 @@ impl StreamVerifier {
                     match self.enc_key {
                         // #321: transport AEAD ON — open the sealed payload back into
                         // Data/Complete/Error (fails closed on tamper / wrong key).
-                        Some(ref enc_key) => open_sealed_payload(
+                        Some(ref enc_key) => match open_sealed_payload_inner(
                             enc_key,
                             &self.topic,
                             block_epoch,
@@ -337,7 +356,21 @@ impl StreamVerifier {
                             tagged.get_payload()?,
                             tagged.get_nonce()?,
                             tagged.get_key_commitment()?,
-                        )?,
+                        )? {
+                            OpenedStreamPayload::Application(payload) => payload,
+                            OpenedStreamPayload::EpochCommit(commit) => {
+                                ensure!(
+                                    self.epoch_ratchet.is_some(),
+                                    "stream epoch control on a non-identified stream"
+                                );
+                                ensure!(
+                                    payloads_reader.len() == 1 && i == 0,
+                                    "stream epoch control must be the sole Object payload"
+                                );
+                                pending_epoch_commit = Some(commit);
+                                continue;
+                            }
+                        },
                         // No transport key (E2E notification path): pass Tagged through.
                         None => StreamPayload::Tagged {
                             tag: tagged.get_tag()?.to_vec(),
@@ -357,6 +390,14 @@ impl StreamVerifier {
                 terminal_seen = true;
             }
             payloads.push(payload);
+        }
+
+        if let Some(commit) = pending_epoch_commit {
+            // The control Object was authenticated and opened entirely under
+            // the current epoch. Only now atomically install the next epoch;
+            // failed validation leaves every verifier field unchanged.
+            self.accept_epoch_commit(&commit)?;
+            return Ok(Vec::new());
         }
 
         self.prev_mac = Some(new_prev);
@@ -391,6 +432,12 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 pub(crate) const SEALED_KIND_DATA: u8 = 0x00;
 pub(crate) const SEALED_KIND_COMPLETE: u8 = 0x01;
 pub(crate) const SEALED_KIND_ERROR: u8 = 0x02;
+pub(crate) const SEALED_KIND_EPOCH_COMMIT: u8 = 0x03;
+
+enum OpenedStreamPayload {
+    Application(StreamPayload),
+    EpochCommit(crate::stream_epoch::StreamEpochCommit),
+}
 
 /// Build the AEAD AAD (also the `encrypt_event` "prefix") binding each sealed
 /// payload to its `topic` and key-`epoch` (#321/#223). Reused verbatim by the
@@ -410,6 +457,7 @@ pub(crate) fn stream_aead_aad(
 /// Data/Complete/Error variant. Returns `Err` on tamper / wrong key (fail-closed).
 ///
 /// `epoch` is the StreamBlock's epoch and MUST match the seal-side AAD.
+#[cfg(test)]
 pub(crate) fn open_sealed_payload(
     enc_key: &[u8; 32],
     topic: &str,
@@ -421,6 +469,36 @@ pub(crate) fn open_sealed_payload(
     nonce: &[u8],
     key_commitment: &[u8],
 ) -> Result<StreamPayload> {
+    match open_sealed_payload_inner(
+        enc_key,
+        topic,
+        epoch,
+        sequence_number,
+        payload_index,
+        tag,
+        ciphertext,
+        nonce,
+        key_commitment,
+    )? {
+        OpenedStreamPayload::Application(payload) => Ok(payload),
+        OpenedStreamPayload::EpochCommit(_) => {
+            anyhow::bail!("stream epoch control is not an application payload")
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn open_sealed_payload_inner(
+    enc_key: &[u8; 32],
+    topic: &str,
+    epoch: u64,
+    sequence_number: u64,
+    payload_index: usize,
+    tag: &[u8],
+    ciphertext: &[u8],
+    nonce: &[u8],
+    key_commitment: &[u8],
+) -> Result<OpenedStreamPayload> {
     use crate::crypto::event_crypto::{check_key_commitment, decrypt_event_full};
 
     let nonce12: [u8; 12] = nonce
@@ -446,14 +524,21 @@ pub(crate) fn open_sealed_payload(
         .split_first()
         .ok_or_else(|| anyhow::anyhow!("stream AEAD: empty sealed plaintext (missing kind tag)"))?;
     match kind {
-        SEALED_KIND_DATA => Ok(StreamPayload::Data(body.to_vec())),
-        SEALED_KIND_COMPLETE => Ok(StreamPayload::Complete(body.to_vec())),
-        SEALED_KIND_ERROR => Ok(StreamPayload::Error(
+        SEALED_KIND_DATA => Ok(OpenedStreamPayload::Application(StreamPayload::Data(
+            body.to_vec(),
+        ))),
+        SEALED_KIND_COMPLETE => Ok(OpenedStreamPayload::Application(StreamPayload::Complete(
+            body.to_vec(),
+        ))),
+        SEALED_KIND_ERROR => Ok(OpenedStreamPayload::Application(StreamPayload::Error(
             std::str::from_utf8(body)
                 .map_err(|error| {
                     anyhow::anyhow!("stream AEAD: sealed error is not UTF-8: {error}")
                 })?
                 .to_owned(),
+        ))),
+        SEALED_KIND_EPOCH_COMMIT => Ok(OpenedStreamPayload::EpochCommit(
+            crate::stream_epoch::StreamEpochCommit::decode_control_object(body)?,
         )),
         other => anyhow::bail!("stream AEAD: unknown sealed kind tag {other:#x}"),
     }

--- a/crates/hyprstream-rpc/src/stream_consumer.rs
+++ b/crates/hyprstream-rpc/src/stream_consumer.rs
@@ -9,10 +9,10 @@
 //! - `StreamHandleImpl<T>` — unified stream consumer over any `Transport`
 
 use std::collections::VecDeque;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{ensure, Result};
 use futures::StreamExt;
 
 use crate::crypto::{derive_stream_keys, keyed_mac_truncated, keyed_mac_truncated_parts};
@@ -104,6 +104,9 @@ pub struct StreamVerifier {
     seq_cursor: Option<u64>,
     /// Whether a terminal (`Complete`/`Error`) payload has been observed (for `completion`).
     terminal_seen: bool,
+    /// Explicit identified epoch state.  Epoch commits are accepted separately
+    /// and reset the chain atomically before any next-epoch Object is processed.
+    epoch_ratchet: Option<crate::stream_epoch::StreamEpochRatchet>,
 }
 
 impl StreamVerifier {
@@ -120,6 +123,7 @@ impl StreamVerifier {
             policy: None,
             seq_cursor: None,
             terminal_seen: false,
+            epoch_ratchet: None,
         }
     }
 
@@ -133,6 +137,38 @@ impl StreamVerifier {
         self
     }
 
+    /// Install the identified epoch profile at its current committed epoch.
+    pub fn with_epoch_ratchet(mut self, ratchet: crate::stream_epoch::StreamEpochRatchet) -> Self {
+        let keys = ratchet.current_keys();
+        self.key = *keys.producer_to_consumer.mac_key;
+        self.enc_key = Some(*keys.producer_to_consumer.enc_key);
+        self.topic = ratchet.route_topic().to_owned();
+        self.prev_mac = None;
+        self.seq_cursor = None;
+        self.epoch_ratchet = Some(ratchet);
+        self
+    }
+
+    /// Authenticate and atomically install the next epoch.  Failed, replayed,
+    /// skipped, or cross-stream commits leave the current verifier state intact.
+    pub fn accept_epoch_commit(
+        &mut self,
+        commit: &crate::stream_epoch::StreamEpochCommit,
+    ) -> Result<()> {
+        let ratchet = self
+            .epoch_ratchet
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("stream is not using the identified epoch profile"))?;
+        let mut pending = ratchet.clone();
+        let keys = pending.accept_commit(commit)?;
+        self.key = *keys.producer_to_consumer.mac_key;
+        self.enc_key = Some(*keys.producer_to_consumer.enc_key);
+        self.prev_mac = None;
+        self.seq_cursor = None;
+        self.epoch_ratchet = Some(pending);
+        Ok(())
+    }
+
     /// Create a verifier that enforces `policy` (#163) — used by codegen-generated consumers,
     /// where the contract is a compile-time constant from the service's API contract.
     pub fn with_policy(key: [u8; 32], topic: String, policy: VerifierContract) -> Self {
@@ -144,7 +180,10 @@ impl StreamVerifier {
     /// True if this stream's policy requires a terminal payload before EOF; the consumer must
     /// reject an EOF when this is true and [`StreamVerifier::terminal_seen`] is false.
     pub fn requires_terminal(&self) -> bool {
-        matches!(self.policy.map(|p| p.completion), Some(Completion::EndOfStream))
+        matches!(
+            self.policy.map(|p| p.completion),
+            Some(Completion::EndOfStream)
+        )
     }
 
     /// True once a terminal (`Complete`/`Error`) payload has been observed.
@@ -198,10 +237,10 @@ impl StreamVerifier {
             anyhow::bail!("MAC verification failed");
         }
 
-        // Update chain state
+        // Prepare the chain update, but do not mutate verifier state until the
+        // complete authenticated block (including AEAD payloads) is accepted.
         let mut new_prev = [0u8; 16];
         new_prev.copy_from_slice(received_mac);
-        self.prev_mac = Some(new_prev);
 
         // Parse StreamBlock with a borrowing (zero-copy) reader: the capnp `Reader`
         // references `capnp_data` directly instead of copying the whole block into an
@@ -212,11 +251,21 @@ impl StreamVerifier {
             capnp::message::ReaderOptions::default(),
         )?;
         let block = reader.get_root::<streaming_capnp::stream_block::Reader>()?;
+        let block_epoch = block.get_epoch();
+        if let Some(ratchet) = &self.epoch_ratchet {
+            ensure!(
+                block_epoch == ratchet.epoch(),
+                "stream block epoch {} is not committed epoch {}",
+                block_epoch,
+                ratchet.epoch()
+            );
+        }
 
         // Policy-selected ordering/replay enforcement (#163). The MAC already authenticates
         // `sequenceNumber` (it's inside the block, #219), so a tampered sequenceNumber fails
         // MAC above; here we enforce *position*. `None` policy ⇒ legacy behaviour (MAC chain
         // only, no sequenceNumber/completion checks).
+        let mut next_seq_cursor = self.seq_cursor;
         if let Some(policy) = self.policy {
             let sequence_number = block.get_sequence_number();
             match policy.ordering {
@@ -230,7 +279,11 @@ impl StreamVerifier {
                         }
                     }
                     // First block (late-join): accept its sequenceNumber, then enforce contiguity.
-                    self.seq_cursor = Some(sequence_number.saturating_add(1));
+                    next_seq_cursor = Some(
+                        sequence_number
+                            .checked_add(1)
+                            .ok_or_else(|| anyhow::anyhow!("stream sequenceNumber exhausted"))?,
+                    );
                 }
                 StreamOrdering::Unordered { .. } => {
                     // Media (out-of-order) needs a per-Group *self-authenticating* MAC, not the
@@ -247,19 +300,18 @@ impl StreamVerifier {
 
         // #321: the AEAD AAD binds each sealed payload to (topic, epoch); read the
         // block epoch so a sealed Tagged payload can only open under its own epoch.
-        let block_epoch = block.get_epoch();
+        let block_sequence = block.get_sequence_number();
 
         let payloads_reader = block.get_payloads()?;
         let mut payloads = Vec::with_capacity(payloads_reader.len() as usize);
 
+        let mut terminal_seen = self.terminal_seen;
         for i in 0..payloads_reader.len() {
             let p = payloads_reader.get(i);
 
             use streaming_capnp::stream_payload::Which;
             let payload = match p.which()? {
-                Which::Data(data_result) => {
-                    StreamPayload::Data(data_result?.to_vec())
-                }
+                Which::Data(data_result) => StreamPayload::Data(data_result?.to_vec()),
                 Which::Error(err_result) => {
                     let err = err_result?;
                     StreamPayload::Error(err.get_message()?.to_string()?)
@@ -279,6 +331,8 @@ impl StreamVerifier {
                             enc_key,
                             &self.topic,
                             block_epoch,
+                            block_sequence,
+                            i as usize,
                             tagged.get_tag()?,
                             tagged.get_payload()?,
                             tagged.get_nonce()?,
@@ -296,11 +350,18 @@ impl StreamVerifier {
             };
 
             // Track terminal observation for the `completion` axis (#163).
-            if matches!(payload, StreamPayload::Complete(_) | StreamPayload::Error(_)) {
-                self.terminal_seen = true;
+            if matches!(
+                payload,
+                StreamPayload::Complete(_) | StreamPayload::Error(_)
+            ) {
+                terminal_seen = true;
             }
             payloads.push(payload);
         }
+
+        self.prev_mac = Some(new_prev);
+        self.seq_cursor = next_seq_cursor;
+        self.terminal_seen = terminal_seen;
 
         Ok(payloads)
     }
@@ -333,8 +394,15 @@ pub(crate) const SEALED_KIND_COMPLETE: u8 = 0x01;
 /// Build the AEAD AAD (also the `encrypt_event` "prefix") binding each sealed
 /// payload to its `topic` and key-`epoch` (#321/#223). Reused verbatim by the
 /// publisher seal path; a block replayed under a different epoch fails AEAD open.
-pub(crate) fn stream_aead_aad(topic: &str, epoch: u64) -> String {
-    format!("{topic}|stream-aead-v1|epoch={epoch}")
+pub(crate) fn stream_aead_aad(
+    topic: &str,
+    epoch: u64,
+    sequence_number: u64,
+    payload_index: usize,
+) -> String {
+    format!(
+        "{topic}|identified-stream-object-v1|epoch={epoch}|sequence={sequence_number}|payload={payload_index}"
+    )
 }
 
 /// Open an AEAD-sealed `Tagged` payload (#321), restoring the original
@@ -345,6 +413,8 @@ pub(crate) fn open_sealed_payload(
     enc_key: &[u8; 32],
     topic: &str,
     epoch: u64,
+    sequence_number: u64,
+    payload_index: usize,
     tag: &[u8],
     ciphertext: &[u8],
     nonce: &[u8],
@@ -356,7 +426,10 @@ pub(crate) fn open_sealed_payload(
         .try_into()
         .map_err(|_| anyhow::anyhow!("stream AEAD: bad nonce length {}", nonce.len()))?;
     let commitment16: [u8; 16] = key_commitment.try_into().map_err(|_| {
-        anyhow::anyhow!("stream AEAD: bad key_commitment length {}", key_commitment.len())
+        anyhow::anyhow!(
+            "stream AEAD: bad key_commitment length {}",
+            key_commitment.len()
+        )
     })?;
 
     // Fast committing-AEAD rejection of a wrong-key block before the GCM open.
@@ -364,7 +437,7 @@ pub(crate) fn open_sealed_payload(
         anyhow::bail!("stream AEAD: key commitment mismatch (wrong key or tampered block)");
     }
 
-    let aad = stream_aead_aad(topic, epoch);
+    let aad = stream_aead_aad(topic, epoch, sequence_number, payload_index);
     let plaintext = decrypt_event_full(enc_key, &nonce12, tag, ciphertext, &aad)
         .map_err(|e| anyhow::anyhow!("stream AEAD open failed: {e}"))?;
 
@@ -451,12 +524,9 @@ impl<T: Transport> StreamHandleImpl<T> {
 
         // QoS contract from the signed StreamInfo handshake — enforced for both native and WASM paths.
         // #321: AEAD ON for this DH-keyed (mesh/networked) stream — open sealed Tagged blocks.
-        let verifier = StreamVerifier::with_policy(
-            *keys.mac_key,
-            keys.topic.clone(),
-            stream_info.qos.into(),
-        )
-        .with_enc_key(*keys.enc_key);
+        let verifier =
+            StreamVerifier::with_policy(*keys.mac_key, keys.topic.clone(), stream_info.qos.into())
+                .with_enc_key(*keys.enc_key);
 
         Ok(Self {
             subscriber,
@@ -515,11 +585,9 @@ impl<T: Transport> StreamHandleImpl<T> {
         if let Some(ref pub_handle) = self.publisher {
             let msg = build_stream_control_cancel();
             let mac = keyed_mac_truncated(&self.ctrl_mac_key, &msg);
-            pub_handle.send_frames(&[
-                self.ctrl_topic.as_bytes(),
-                &msg,
-                &mac,
-            ]).await?;
+            pub_handle
+                .send_frames(&[self.ctrl_topic.as_bytes(), &msg, &mac])
+                .await?;
         }
         Ok(())
     }
@@ -657,7 +725,10 @@ impl From<crate::stream_info::StreamOpt> for VerifierContract {
             crate::stream_info::Completion::EndOfStream => Completion::EndOfStream,
             crate::stream_info::Completion::None => Completion::Open,
         };
-        VerifierContract { ordering, completion }
+        VerifierContract {
+            ordering,
+            completion,
+        }
     }
 }
 
@@ -702,7 +773,10 @@ mod policy_tests {
         }
         input.extend_from_slice(&capnp_bytes);
         let mac = keyed_mac_truncated(key, &input);
-        (vec![topic.as_bytes().to_vec(), capnp_bytes, mac.to_vec()], mac)
+        (
+            vec![topic.as_bytes().to_vec(), capnp_bytes, mac.to_vec()],
+            mac,
+        )
     }
 
     #[test]
@@ -713,7 +787,10 @@ mod policy_tests {
         let mut v = StreamVerifier::with_policy(
             key,
             topic.to_owned(),
-            VerifierContract { ordering: StreamOrdering::Ordered, completion: Completion::Open },
+            VerifierContract {
+                ordering: StreamOrdering::Ordered,
+                completion: Completion::Open,
+            },
         );
         let (mut frame, _) = frame(&key, topic, None, 0, false);
         // Corrupt the MAC part (last element of the frame).
@@ -721,7 +798,10 @@ mod policy_tests {
         mac[0] ^= 0xFF; // flip a bit — constant_time_eq must reject this
         let err = v.verify(&frame).unwrap_err().to_string();
         assert!(
-            err.contains("MAC") || err.contains("mac") || err.contains("HMAC") || err.contains("invalid"),
+            err.contains("MAC")
+                || err.contains("mac")
+                || err.contains("HMAC")
+                || err.contains("invalid"),
             "tampered MAC should be rejected, got: {err}"
         );
     }
@@ -733,7 +813,10 @@ mod policy_tests {
         let mut v = StreamVerifier::with_policy(
             key,
             topic.to_owned(),
-            VerifierContract { ordering: StreamOrdering::Ordered, completion: Completion::Open },
+            VerifierContract {
+                ordering: StreamOrdering::Ordered,
+                completion: Completion::Open,
+            },
         );
         let (f5, m5) = frame(&key, topic, None, 5, false); // late-join at seq 5
         v.verify(&f5).unwrap();
@@ -764,7 +847,9 @@ mod policy_tests {
             key,
             topic.to_owned(),
             VerifierContract {
-                ordering: StreamOrdering::Unordered { anti_replay_window: 4 },
+                ordering: StreamOrdering::Unordered {
+                    anti_replay_window: 4,
+                },
                 completion: Completion::Open,
             },
         );
@@ -779,7 +864,10 @@ mod policy_tests {
         let mut v = StreamVerifier::with_policy(
             key,
             topic.to_owned(),
-            VerifierContract { ordering: StreamOrdering::Ordered, completion: Completion::EndOfStream },
+            VerifierContract {
+                ordering: StreamOrdering::Ordered,
+                completion: Completion::EndOfStream,
+            },
         );
         assert!(v.requires_terminal());
         assert!(!v.terminal_seen());
@@ -825,7 +913,10 @@ mod policy_tests {
         // in place of `dhPublic` to try to own the derived keys.
         let (_relay_secret, relay_pub) = generate_ephemeral_keypair();
         let relay_dh_public = relay_pub.to_bytes();
-        assert_ne!(real_dh_public, relay_dh_public, "test setup: keys must differ");
+        assert_ne!(
+            real_dh_public, relay_dh_public,
+            "test setup: keys must differ"
+        );
 
         // Producer derives the REAL stream keys from the real DH (ECDH with the
         // client's public) — these are the keys it seals every frame under.
@@ -847,7 +938,7 @@ mod policy_tests {
             p
         };
         use crate::crypto::event_crypto::{encrypt_event, EventPrivacy};
-        let aad = stream_aead_aad(&topic, epoch);
+        let aad = stream_aead_aad(&topic, epoch, 0, 0);
         let (tag, ciphertext, nonce, key_commitment) =
             encrypt_event(&real_enc, &aad, &plaintext, EventPrivacy::ZeroKnowledge).unwrap();
 
@@ -857,14 +948,15 @@ mod policy_tests {
         let consumer_keys =
             derive_stream_keys(&consumer_shared, &client_pub_bytes, &real_dh_public).unwrap();
         assert_eq!(
-            *consumer_keys.enc_key,
-            real_enc,
+            *consumer_keys.enc_key, real_enc,
             "consumer (real dhPublic) and producer derive the same enc_key"
         );
         let opened = open_sealed_payload(
             &consumer_keys.enc_key,
             &topic,
             epoch,
+            0,
+            0,
             &tag,
             &ciphertext,
             &nonce,
@@ -881,16 +973,18 @@ mod policy_tests {
         //    this branch — it keeps the authenticated `dhPublic`; this case shows
         //    what would happen if the substituted key were used.)
         let sub_shared = ristretto_dh_raw(&client_secret_bytes, &relay_dh_public).unwrap();
-        let sub_keys = derive_stream_keys(&sub_shared, &client_pub_bytes, &relay_dh_public).unwrap();
+        let sub_keys =
+            derive_stream_keys(&sub_shared, &client_pub_bytes, &relay_dh_public).unwrap();
         assert_ne!(
-            *sub_keys.enc_key,
-            real_enc,
+            *sub_keys.enc_key, real_enc,
             "substituted dhPublic MUST derive a different enc_key"
         );
         let subst_err = open_sealed_payload(
             &sub_keys.enc_key,
             &topic,
             epoch,
+            0,
+            0,
             &tag,
             &ciphertext,
             &nonce,
@@ -908,20 +1002,32 @@ mod policy_tests {
         //    belt-and-braces check on the chained-HMAC envelope.
         let real_mac = *real_keys.mac_key;
         let sub_mac = *sub_keys.mac_key;
-        assert_ne!(real_mac, sub_mac, "substituted dhPublic MUST derive a different mac_key");
+        assert_ne!(
+            real_mac, sub_mac,
+            "substituted dhPublic MUST derive a different mac_key"
+        );
         let (real_frame, _) = frame(&real_mac, &topic, None, 0, false);
         // Real consumer (real mac_key) verifies the producer's frame.
         let mut v_real = StreamVerifier::with_policy(
             real_mac,
             topic.clone(),
-            VerifierContract { ordering: StreamOrdering::Ordered, completion: Completion::Open },
+            VerifierContract {
+                ordering: StreamOrdering::Ordered,
+                completion: Completion::Open,
+            },
         );
-        assert!(v_real.verify(&real_frame).is_ok(), "real mac_key verifies the frame");
+        assert!(
+            v_real.verify(&real_frame).is_ok(),
+            "real mac_key verifies the frame"
+        );
         // Substituted consumer (relay mac_key) CANNOT verify the producer's frame.
         let mut v_sub = StreamVerifier::with_policy(
             sub_mac,
             topic,
-            VerifierContract { ordering: StreamOrdering::Ordered, completion: Completion::Open },
+            VerifierContract {
+                ordering: StreamOrdering::Ordered,
+                completion: Completion::Open,
+            },
         );
         assert!(
             v_sub.verify(&real_frame).is_err(),

--- a/crates/hyprstream-rpc/src/stream_consumer.rs
+++ b/crates/hyprstream-rpc/src/stream_consumer.rs
@@ -89,7 +89,7 @@ pub struct VerifierContract {
 pub struct StreamVerifier {
     key: [u8; 32],
     /// Transport-level AEAD key (#321). `Some` ⇒ a `Tagged` payload is opened
-    /// (AES-256-GCM, AAD bound to topic+epoch) back into Data/Complete; `None` ⇒
+    /// (AES-256-GCM, AAD bound to topic+epoch) back into Data/Complete/Error; `None` ⇒
     /// `Tagged` payloads pass through unchanged (the E2E notification path, which
     /// the app layer decrypts itself).
     enc_key: Option<[u8; 32]>,
@@ -130,7 +130,7 @@ impl StreamVerifier {
     /// Set the transport AEAD key so sealed `Tagged` payloads are opened (#321).
     ///
     /// Builder-style; pass the `enc_key` from `derive_client_stream_keys`. With it
-    /// set, the verifier decrypts each `Tagged` block back into Data/Complete and
+    /// set, the verifier decrypts each `Tagged` block back into Data/Complete/Error and
     /// fails closed on tamper / wrong key.
     pub fn with_enc_key(mut self, enc_key: [u8; 32]) -> Self {
         self.enc_key = Some(enc_key);
@@ -326,7 +326,7 @@ impl StreamVerifier {
                     let tagged = tagged_result?;
                     match self.enc_key {
                         // #321: transport AEAD ON — open the sealed payload back into
-                        // Data/Complete (fails closed on tamper / wrong key).
+                        // Data/Complete/Error (fails closed on tamper / wrong key).
                         Some(ref enc_key) => open_sealed_payload(
                             enc_key,
                             &self.topic,
@@ -386,10 +386,11 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 // ============================================================================
 
 /// Plaintext kind tag prepended inside the AEAD-sealed bytes so the open path can
-/// restore the original payload variant (`Data` vs `Complete`) without a schema
-/// change. Authenticated as part of the AEAD plaintext.
+/// restore the original payload variant without a schema change. Authenticated
+/// as part of the AEAD plaintext.
 pub(crate) const SEALED_KIND_DATA: u8 = 0x00;
 pub(crate) const SEALED_KIND_COMPLETE: u8 = 0x01;
+pub(crate) const SEALED_KIND_ERROR: u8 = 0x02;
 
 /// Build the AEAD AAD (also the `encrypt_event` "prefix") binding each sealed
 /// payload to its `topic` and key-`epoch` (#321/#223). Reused verbatim by the
@@ -406,7 +407,7 @@ pub(crate) fn stream_aead_aad(
 }
 
 /// Open an AEAD-sealed `Tagged` payload (#321), restoring the original
-/// Data/Complete variant. Returns `Err` on tamper / wrong key (fail-closed).
+/// Data/Complete/Error variant. Returns `Err` on tamper / wrong key (fail-closed).
 ///
 /// `epoch` is the StreamBlock's epoch and MUST match the seal-side AAD.
 pub(crate) fn open_sealed_payload(
@@ -447,6 +448,13 @@ pub(crate) fn open_sealed_payload(
     match kind {
         SEALED_KIND_DATA => Ok(StreamPayload::Data(body.to_vec())),
         SEALED_KIND_COMPLETE => Ok(StreamPayload::Complete(body.to_vec())),
+        SEALED_KIND_ERROR => Ok(StreamPayload::Error(
+            std::str::from_utf8(body)
+                .map_err(|error| {
+                    anyhow::anyhow!("stream AEAD: sealed error is not UTF-8: {error}")
+                })?
+                .to_owned(),
+        )),
         other => anyhow::bail!("stream AEAD: unknown sealed kind tag {other:#x}"),
     }
 }

--- a/crates/hyprstream-rpc/src/stream_epoch.rs
+++ b/crates/hyprstream-rpc/src/stream_epoch.rs
@@ -244,10 +244,14 @@ impl StreamEpochKeys {
     /// by the authenticated per-epoch sequence number.  The key and prefix both
     /// differ across direction/track/epoch.
     pub fn nonce(&self, sequence_number: u64) -> [u8; 12] {
-        let mut nonce = [0u8; 12];
-        nonce[..4].copy_from_slice(&self.nonce_domain);
-        nonce[4..].copy_from_slice(&sequence_number.to_be_bytes());
-        nonce
+        let sequence = sequence_number.to_be_bytes();
+        std::array::from_fn(|index| {
+            if index < self.nonce_domain.len() {
+                self.nonce_domain[index]
+            } else {
+                sequence[index - self.nonce_domain.len()]
+            }
+        })
     }
 
     pub fn epoch_namespace(&self) -> &[u8; 32] {

--- a/crates/hyprstream-rpc/src/stream_epoch.rs
+++ b/crates/hyprstream-rpc/src/stream_epoch.rs
@@ -29,6 +29,8 @@ const CONTROL_MAC_DOMAIN: &str = "hyprstream identified-stream control-mac v1";
 const REKEY_AUTH_DOMAIN: &str = "hyprstream identified-stream rekey-auth v1";
 const NONCE_DOMAIN: &str = "hyprstream identified-stream nonce-domain v1";
 const EPOCH_NAMESPACE_DOMAIN: &str = "hyprstream identified-stream epoch-namespace v1";
+const CONTROL_OBJECT_MAGIC: &[u8; 8] = b"HYSEPK01";
+const CONTROL_OBJECT_LEN: usize = 154;
 
 const MAX_TEXT: usize = 1024;
 const MAX_CAPABILITY: usize = 4096;
@@ -296,6 +298,47 @@ impl StreamEpochCommit {
         out.extend_from_slice(&self.producer_namespace);
         out.extend_from_slice(&self.consumer_namespace);
         out
+    }
+
+    /// Fixed, versioned control plaintext sealed inside an ordinary opaque
+    /// stream Object. Authentication is still provided by `auth_tag`, the
+    /// current-epoch AEAD, and the chained Object MAC.
+    pub fn encode_control_object(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(CONTROL_OBJECT_LEN);
+        out.extend_from_slice(CONTROL_OBJECT_MAGIC);
+        out.extend_from_slice(&IDENTIFIED_STREAM_VERSION.to_be_bytes());
+        out.extend_from_slice(&self.binding_hash);
+        out.extend_from_slice(&self.previous_epoch.to_be_bytes());
+        out.extend_from_slice(&self.epoch.to_be_bytes());
+        out.extend_from_slice(&self.producer_namespace);
+        out.extend_from_slice(&self.consumer_namespace);
+        out.extend_from_slice(&self.auth_tag);
+        out
+    }
+
+    /// Decode the control plaintext after current-epoch AEAD verification.
+    pub fn decode_control_object(bytes: &[u8]) -> Result<Self> {
+        ensure!(
+            bytes.len() == CONTROL_OBJECT_LEN,
+            "stream epoch control has invalid length {}",
+            bytes.len()
+        );
+        ensure!(
+            &bytes[..8] == CONTROL_OBJECT_MAGIC,
+            "stream epoch control magic mismatch"
+        );
+        ensure!(
+            u16::from_be_bytes(bytes[8..10].try_into()?) == IDENTIFIED_STREAM_VERSION,
+            "stream epoch control version mismatch"
+        );
+        Ok(Self {
+            binding_hash: bytes[10..42].try_into()?,
+            previous_epoch: u64::from_be_bytes(bytes[42..50].try_into()?),
+            epoch: u64::from_be_bytes(bytes[50..58].try_into()?),
+            producer_namespace: bytes[58..90].try_into()?,
+            consumer_namespace: bytes[90..122].try_into()?,
+            auth_tag: bytes[122..154].try_into()?,
+        })
     }
 }
 

--- a/crates/hyprstream-rpc/src/stream_epoch.rs
+++ b/crates/hyprstream-rpc/src/stream_epoch.rs
@@ -1,0 +1,795 @@
+//! Identified point-to-point stream epoch cryptography (#554).
+//!
+//! This module is deliberately carrier-neutral.  A stock MOQT relay forwards the
+//! resulting encrypted Object bytes without learning this transcript or any key.
+//! Network key release remains gated by #726; the types here make the authority
+//! input explicit without implementing the restricted-anonymous work in
+//! #1060-#1062.
+
+use anyhow::{ensure, Result};
+use subtle::ConstantTimeEq;
+use zeroize::Zeroizing;
+
+use crate::crypto::backend::{derive_key, keyed_mac};
+use crate::crypto::hybrid_kem::SuiteId;
+
+/// The only stream KEM suite accepted by this profile.
+pub const IDENTIFIED_STREAM_SUITE: SuiteId = SuiteId::HyKemX25519MlKem768;
+/// Protocol/domain version included in every canonical transcript.
+pub const IDENTIFIED_STREAM_VERSION: u16 = 1;
+
+const SESSION_ROOT_DOMAIN: &str = "hyprstream identified-stream session-root v1";
+const BINDING_HASH_DOMAIN: &str = "hyprstream identified-stream binding-hash v1";
+const ROUTE_TOPIC_DOMAIN: &str = "hyprstream identified-stream route-topic v1";
+const CONTROL_TOPIC_DOMAIN: &str = "hyprstream identified-stream control-topic v1";
+const EPOCH_SECRET_DOMAIN: &str = "hyprstream identified-stream epoch-ratchet v1";
+const DATA_MAC_DOMAIN: &str = "hyprstream identified-stream data-mac v1";
+const DATA_AEAD_DOMAIN: &str = "hyprstream identified-stream data-aead v1";
+const CONTROL_MAC_DOMAIN: &str = "hyprstream identified-stream control-mac v1";
+const REKEY_AUTH_DOMAIN: &str = "hyprstream identified-stream rekey-auth v1";
+const NONCE_DOMAIN: &str = "hyprstream identified-stream nonce-domain v1";
+const EPOCH_NAMESPACE_DOMAIN: &str = "hyprstream identified-stream epoch-namespace v1";
+
+const MAX_TEXT: usize = 1024;
+const MAX_CAPABILITY: usize = 4096;
+
+/// Carrier profile selected by signed resolution/admission policy.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum StreamCarrierProfile {
+    /// Hyprstream owns the endpoint and requires its hybrid transport policy.
+    OwnedHybridTransport = 1,
+    /// A standards-compatible relay is an explicitly untrusted classical carrier.
+    StandardPublicRelay = 2,
+}
+
+/// The selected route's role in the stream transcript.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum StreamRouteRole {
+    Direct = 1,
+    Relay = 2,
+}
+
+/// Direction is a key and nonce domain, never merely descriptive metadata.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum StreamDirection {
+    ProducerToConsumer = 1,
+    ConsumerToProducer = 2,
+}
+
+/// Accepted-current identity state frozen into the stream authorization.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StreamAcceptedState {
+    pub identity_did: String,
+    pub digest: [u8; 64],
+    pub epoch: u64,
+}
+
+impl StreamAcceptedState {
+    fn validate(&self, label: &str) -> Result<()> {
+        validate_did(&self.identity_did, label)?;
+        ensure!(
+            self.digest.iter().any(|byte| *byte != 0),
+            "{label} accepted-state digest is all zero"
+        );
+        Ok(())
+    }
+}
+
+/// Complete identified-session binding consumed by HyKEM and every epoch KDF.
+///
+/// `consumer_state.identity_did` is the identified principal.  Anonymous key
+/// release intentionally has no constructor in this slice.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IdentifiedStreamBinding {
+    carrier_profile: StreamCarrierProfile,
+    route_role: StreamRouteRole,
+    producer_endpoint_did: String,
+    consumer_endpoint_did: String,
+    producer_state: StreamAcceptedState,
+    consumer_state: StreamAcceptedState,
+    service: String,
+    capability: String,
+    track: String,
+    producer_kem_key_id: String,
+    consumer_kem_key_id: String,
+    max_blocks_per_epoch: u64,
+    suite: SuiteId,
+}
+
+impl IdentifiedStreamBinding {
+    /// Build the pinned identified profile.  Suite negotiation is intentionally
+    /// absent: callers cannot request a classical-only or unknown suite.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        carrier_profile: StreamCarrierProfile,
+        route_role: StreamRouteRole,
+        producer_endpoint_did: impl Into<String>,
+        consumer_endpoint_did: impl Into<String>,
+        producer_state: StreamAcceptedState,
+        consumer_state: StreamAcceptedState,
+        service: impl Into<String>,
+        capability: impl Into<String>,
+        track: impl Into<String>,
+        producer_kem_key_id: impl Into<String>,
+        consumer_kem_key_id: impl Into<String>,
+        max_blocks_per_epoch: u64,
+    ) -> Result<Self> {
+        let binding = Self {
+            carrier_profile,
+            route_role,
+            producer_endpoint_did: producer_endpoint_did.into(),
+            consumer_endpoint_did: consumer_endpoint_did.into(),
+            producer_state,
+            consumer_state,
+            service: service.into(),
+            capability: capability.into(),
+            track: track.into(),
+            producer_kem_key_id: producer_kem_key_id.into(),
+            consumer_kem_key_id: consumer_kem_key_id.into(),
+            max_blocks_per_epoch,
+            suite: IDENTIFIED_STREAM_SUITE,
+        };
+        binding.validate()?;
+        Ok(binding)
+    }
+
+    fn validate(&self) -> Result<()> {
+        ensure!(
+            self.suite == IDENTIFIED_STREAM_SUITE,
+            "identified stream requires the pinned X25519+ML-KEM-768 suite"
+        );
+        validate_did(&self.producer_endpoint_did, "producer endpoint")?;
+        validate_did(&self.consumer_endpoint_did, "consumer endpoint")?;
+        self.producer_state.validate("producer")?;
+        self.consumer_state.validate("consumer")?;
+        validate_text(&self.service, "service", MAX_TEXT)?;
+        validate_text(&self.capability, "capability", MAX_CAPABILITY)?;
+        validate_text(&self.track, "track", MAX_TEXT)?;
+        validate_text(&self.producer_kem_key_id, "producer KEM key id", MAX_TEXT)?;
+        validate_text(&self.consumer_kem_key_id, "consumer KEM key id", MAX_TEXT)?;
+        ensure!(
+            self.producer_state.identity_did == self.producer_endpoint_did,
+            "producer endpoint DID does not match accepted state"
+        );
+        ensure!(
+            self.consumer_state.identity_did == self.consumer_endpoint_did,
+            "consumer endpoint DID does not match accepted state"
+        );
+        ensure!(
+            self.max_blocks_per_epoch > 0,
+            "max_blocks_per_epoch must be non-zero"
+        );
+        ensure!(
+            self.max_blocks_per_epoch <= (u64::MAX >> 16),
+            "max_blocks_per_epoch exceeds the deterministic nonce counter domain"
+        );
+        Ok(())
+    }
+
+    /// The policy-pinned suite; this is descriptive, not negotiated.
+    pub fn suite(&self) -> SuiteId {
+        self.suite
+    }
+
+    /// Admission-pinned upper bound before an authenticated epoch transition is required.
+    pub fn max_blocks_per_epoch(&self) -> u64 {
+        self.max_blocks_per_epoch
+    }
+
+    /// Canonical length-framed session transcript.
+    pub fn canonical_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(512);
+        out.extend_from_slice(&IDENTIFIED_STREAM_VERSION.to_be_bytes());
+        out.extend_from_slice(&self.suite.as_u16().to_be_bytes());
+        out.push(self.carrier_profile as u8);
+        out.push(self.route_role as u8);
+        put_text(&mut out, &self.producer_endpoint_did);
+        put_text(&mut out, &self.consumer_endpoint_did);
+        put_state(&mut out, &self.producer_state);
+        put_state(&mut out, &self.consumer_state);
+        put_text(&mut out, &self.service);
+        put_text(&mut out, &self.capability);
+        put_text(&mut out, &self.track);
+        put_text(&mut out, &self.producer_kem_key_id);
+        put_text(&mut out, &self.consumer_kem_key_id);
+        out.extend_from_slice(&self.max_blocks_per_epoch.to_be_bytes());
+        out
+    }
+
+    pub fn binding_hash(&self) -> [u8; 32] {
+        derive_key(BINDING_HASH_DOMAIN, &self.canonical_bytes())
+    }
+}
+
+/// Generic authority seam shared by identified and future anonymous releases.
+///
+/// This module provides no anonymous-capability implementation and derives no
+/// assurance from this enum.  #1060-#1062 must supply a reviewed concrete type
+/// and gate before `AnonymousCapability` can authorize production key release.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum StreamKeyReleasePrincipal<I, A> {
+    Identified(I),
+    AnonymousCapability(A),
+}
+
+/// Authorization/key-release policy seam.  Crypto code consumes an authorized
+/// binding; network implementations must call a gate at the #726 release PEP.
+pub trait StreamKeyReleaseGate<P> {
+    type Grant;
+    fn authorize_release(
+        &self,
+        principal: &P,
+        binding: &IdentifiedStreamBinding,
+    ) -> Result<Self::Grant>;
+}
+
+/// Directional keys for one track epoch.
+#[derive(Clone)]
+pub struct StreamEpochKeys {
+    pub epoch: u64,
+    pub direction: StreamDirection,
+    pub mac_key: Zeroizing<[u8; 32]>,
+    pub enc_key: Zeroizing<[u8; 32]>,
+    pub control_mac_key: Zeroizing<[u8; 32]>,
+    rekey_auth_key: Zeroizing<[u8; 32]>,
+    nonce_domain: [u8; 4],
+    epoch_namespace: [u8; 32],
+}
+
+impl StreamEpochKeys {
+    /// Deterministic AES-GCM nonce: a transcript-derived 32-bit domain followed
+    /// by the authenticated per-epoch sequence number.  The key and prefix both
+    /// differ across direction/track/epoch.
+    pub fn nonce(&self, sequence_number: u64) -> [u8; 12] {
+        let mut nonce = [0u8; 12];
+        nonce[..4].copy_from_slice(&self.nonce_domain);
+        nonce[4..].copy_from_slice(&sequence_number.to_be_bytes());
+        nonce
+    }
+
+    pub fn epoch_namespace(&self) -> &[u8; 32] {
+        &self.epoch_namespace
+    }
+}
+
+/// Both direction domains for one committed epoch.
+#[derive(Clone)]
+pub struct StreamEpochKeySet {
+    pub epoch: u64,
+    pub producer_to_consumer: StreamEpochKeys,
+    pub consumer_to_producer: StreamEpochKeys,
+}
+
+impl StreamEpochKeySet {
+    pub fn for_direction(&self, direction: StreamDirection) -> &StreamEpochKeys {
+        match direction {
+            StreamDirection::ProducerToConsumer => &self.producer_to_consumer,
+            StreamDirection::ConsumerToProducer => &self.consumer_to_producer,
+        }
+    }
+}
+
+/// Authenticated epoch transition.  It contains no traffic key.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StreamEpochCommit {
+    pub binding_hash: [u8; 32],
+    pub previous_epoch: u64,
+    pub epoch: u64,
+    pub producer_namespace: [u8; 32],
+    pub consumer_namespace: [u8; 32],
+    pub auth_tag: [u8; 32],
+}
+
+impl StreamEpochCommit {
+    fn authenticated_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(112);
+        out.extend_from_slice(&self.binding_hash);
+        out.extend_from_slice(&self.previous_epoch.to_be_bytes());
+        out.extend_from_slice(&self.epoch.to_be_bytes());
+        out.extend_from_slice(&self.producer_namespace);
+        out.extend_from_slice(&self.consumer_namespace);
+        out
+    }
+}
+
+/// Stateful, one-way, explicit stream epoch ratchet.
+///
+/// `prepare_next` is non-mutating.  `commit_prepared`/`accept_commit` make the
+/// transition atomic: an invalid or interrupted pending update leaves the prior
+/// committed epoch live and exposes no pending traffic keys.
+#[derive(Clone)]
+pub struct StreamEpochRatchet {
+    binding: IdentifiedStreamBinding,
+    binding_hash: [u8; 32],
+    route_topic: String,
+    control_topic: String,
+    epoch: u64,
+    secret: Zeroizing<[u8; 32]>,
+}
+
+impl StreamEpochRatchet {
+    pub(crate) fn from_hybrid_secret(
+        hybrid_secret: &[u8; 32],
+        binding: IdentifiedStreamBinding,
+    ) -> Result<Self> {
+        binding.validate()?;
+        let binding_bytes = binding.canonical_bytes();
+        let mut root_input = Zeroizing::new(Vec::with_capacity(32 + binding_bytes.len()));
+        root_input.extend_from_slice(hybrid_secret);
+        root_input.extend_from_slice(&binding_bytes);
+        let secret = Zeroizing::new(derive_key(SESSION_ROOT_DOMAIN, &root_input));
+        let binding_hash = binding.binding_hash();
+        let route_topic = hex::encode(derive_label(ROUTE_TOPIC_DOMAIN, &secret, &binding_hash));
+        let control_topic = hex::encode(derive_label(CONTROL_TOPIC_DOMAIN, &secret, &binding_hash));
+        Ok(Self {
+            binding,
+            binding_hash,
+            route_topic,
+            control_topic,
+            epoch: 0,
+            secret,
+        })
+    }
+
+    pub fn binding(&self) -> &IdentifiedStreamBinding {
+        &self.binding
+    }
+
+    pub fn epoch(&self) -> u64 {
+        self.epoch
+    }
+
+    pub fn route_topic(&self) -> &str {
+        &self.route_topic
+    }
+
+    pub fn control_topic(&self) -> &str {
+        &self.control_topic
+    }
+
+    pub fn current_keys(&self) -> StreamEpochKeySet {
+        derive_epoch_key_set(&self.secret, &self.binding, self.epoch)
+    }
+
+    pub fn prepare_next(&self) -> Result<StreamEpochCommit> {
+        let next_epoch = self
+            .epoch
+            .checked_add(1)
+            .ok_or_else(|| anyhow::anyhow!("stream epoch exhausted"))?;
+        let next_secret = next_epoch_secret(&self.secret, &self.binding_hash, next_epoch);
+        let next_keys = derive_epoch_key_set(&next_secret, &self.binding, next_epoch);
+        let mut commit = StreamEpochCommit {
+            binding_hash: self.binding_hash,
+            previous_epoch: self.epoch,
+            epoch: next_epoch,
+            producer_namespace: *next_keys.producer_to_consumer.epoch_namespace(),
+            consumer_namespace: *next_keys.consumer_to_producer.epoch_namespace(),
+            auth_tag: [0u8; 32],
+        };
+        let current = self.current_keys();
+        commit.auth_tag = keyed_mac(
+            &current.producer_to_consumer.rekey_auth_key,
+            &commit.authenticated_bytes(),
+        );
+        Ok(commit)
+    }
+
+    pub fn commit_prepared(&mut self, commit: &StreamEpochCommit) -> Result<StreamEpochKeySet> {
+        self.accept_commit(commit)
+    }
+
+    pub fn accept_commit(&mut self, commit: &StreamEpochCommit) -> Result<StreamEpochKeySet> {
+        ensure!(
+            commit.binding_hash == self.binding_hash,
+            "stream rekey binding mismatch"
+        );
+        ensure!(
+            commit.previous_epoch == self.epoch,
+            "stream rekey is stale, replayed, or skips the committed epoch"
+        );
+        ensure!(
+            commit.epoch
+                == self
+                    .epoch
+                    .checked_add(1)
+                    .ok_or_else(|| anyhow::anyhow!("stream epoch exhausted"))?,
+            "stream rekey target is not the next epoch"
+        );
+        let current = self.current_keys();
+        let expected = keyed_mac(
+            &current.producer_to_consumer.rekey_auth_key,
+            &commit.authenticated_bytes(),
+        );
+        ensure!(
+            bool::from(expected.ct_eq(&commit.auth_tag)),
+            "stream rekey authentication failed"
+        );
+        let next_secret = next_epoch_secret(&self.secret, &self.binding_hash, commit.epoch);
+        let next_keys = derive_epoch_key_set(&next_secret, &self.binding, commit.epoch);
+        ensure!(
+            commit.producer_namespace == *next_keys.producer_to_consumer.epoch_namespace()
+                && commit.consumer_namespace == *next_keys.consumer_to_producer.epoch_namespace(),
+            "stream rekey namespace commitment mismatch"
+        );
+
+        // Atomic commit: all validation above is non-mutating.
+        self.secret = next_secret;
+        self.epoch = commit.epoch;
+        Ok(next_keys)
+    }
+}
+
+fn derive_epoch_key_set(
+    epoch_secret: &[u8; 32],
+    binding: &IdentifiedStreamBinding,
+    epoch: u64,
+) -> StreamEpochKeySet {
+    StreamEpochKeySet {
+        epoch,
+        producer_to_consumer: derive_direction_keys(
+            epoch_secret,
+            binding,
+            epoch,
+            StreamDirection::ProducerToConsumer,
+        ),
+        consumer_to_producer: derive_direction_keys(
+            epoch_secret,
+            binding,
+            epoch,
+            StreamDirection::ConsumerToProducer,
+        ),
+    }
+}
+
+fn derive_direction_keys(
+    epoch_secret: &[u8; 32],
+    binding: &IdentifiedStreamBinding,
+    epoch: u64,
+    direction: StreamDirection,
+) -> StreamEpochKeys {
+    let mut transcript = binding.canonical_bytes();
+    transcript.push(direction as u8);
+    transcript.extend_from_slice(&epoch.to_be_bytes());
+    let derive = |domain: &'static str| {
+        let mut input = Zeroizing::new(Vec::with_capacity(32 + transcript.len()));
+        input.extend_from_slice(epoch_secret);
+        input.extend_from_slice(&transcript);
+        derive_key(domain, &input)
+    };
+    let nonce = derive(NONCE_DOMAIN);
+    let mut nonce_domain = [0u8; 4];
+    nonce_domain.copy_from_slice(&nonce[..4]);
+    StreamEpochKeys {
+        epoch,
+        direction,
+        mac_key: Zeroizing::new(derive(DATA_MAC_DOMAIN)),
+        enc_key: Zeroizing::new(derive(DATA_AEAD_DOMAIN)),
+        control_mac_key: Zeroizing::new(derive(CONTROL_MAC_DOMAIN)),
+        rekey_auth_key: Zeroizing::new(derive(REKEY_AUTH_DOMAIN)),
+        nonce_domain,
+        epoch_namespace: derive(EPOCH_NAMESPACE_DOMAIN),
+    }
+}
+
+fn next_epoch_secret(
+    current: &[u8; 32],
+    binding_hash: &[u8; 32],
+    epoch: u64,
+) -> Zeroizing<[u8; 32]> {
+    let mut input = Zeroizing::new([0u8; 72]);
+    input[..32].copy_from_slice(current);
+    input[32..64].copy_from_slice(binding_hash);
+    input[64..].copy_from_slice(&epoch.to_be_bytes());
+    Zeroizing::new(derive_key(EPOCH_SECRET_DOMAIN, &*input))
+}
+
+fn derive_label(domain: &'static str, secret: &[u8; 32], binding_hash: &[u8; 32]) -> [u8; 32] {
+    let mut input = Zeroizing::new([0u8; 64]);
+    input[..32].copy_from_slice(secret);
+    input[32..].copy_from_slice(binding_hash);
+    derive_key(domain, &*input)
+}
+
+fn validate_did(value: &str, label: &str) -> Result<()> {
+    validate_text(value, label, MAX_TEXT)?;
+    ensure!(value.starts_with("did:"), "{label} is not a DID");
+    Ok(())
+}
+
+fn validate_text(value: &str, label: &str, limit: usize) -> Result<()> {
+    ensure!(!value.is_empty(), "{label} is empty");
+    ensure!(value.len() <= limit, "{label} exceeds {limit} bytes");
+    ensure!(!value.bytes().any(|byte| byte == 0), "{label} contains NUL");
+    Ok(())
+}
+
+fn put_text(out: &mut Vec<u8>, value: &str) {
+    // Bindings are validated and frozen at construction, so this conversion is
+    // infallible in practice. Encoding u64 avoids a panic path in the canonicalizer.
+    let len = u64::try_from(value.len()).unwrap_or(u64::MAX);
+    out.extend_from_slice(&len.to_be_bytes());
+    out.extend_from_slice(value.as_bytes());
+}
+
+fn put_state(out: &mut Vec<u8>, state: &StreamAcceptedState) {
+    put_text(out, &state.identity_did);
+    out.extend_from_slice(&state.digest);
+    out.extend_from_slice(&state.epoch.to_be_bytes());
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn binding(profile: StreamCarrierProfile) -> IdentifiedStreamBinding {
+        IdentifiedStreamBinding::new(
+            profile,
+            StreamRouteRole::Relay,
+            "did:at9p:producer",
+            "did:at9p:consumer",
+            StreamAcceptedState {
+                identity_did: "did:at9p:producer".into(),
+                digest: [0x11; 64],
+                epoch: 7,
+            },
+            StreamAcceptedState {
+                identity_did: "did:at9p:consumer".into(),
+                digest: [0x22; 64],
+                epoch: 9,
+            },
+            "inference.generate",
+            "infer:model:qwen",
+            "local/streams/tokens",
+            "did:at9p:producer#mesh-kem",
+            "urn:hyprstream:ephemeral-kem:123",
+            1024,
+        )
+        .unwrap()
+    }
+
+    fn ratchet(profile: StreamCarrierProfile) -> StreamEpochRatchet {
+        StreamEpochRatchet::from_hybrid_secret(&[0x44; 32], binding(profile)).unwrap()
+    }
+
+    #[test]
+    fn transcript_mutations_separate_every_security_axis() {
+        let base = binding(StreamCarrierProfile::StandardPublicRelay);
+        let base_hash = base.binding_hash();
+        let mut mutations = Vec::new();
+        let mut v = base.clone();
+        v.carrier_profile = StreamCarrierProfile::OwnedHybridTransport;
+        mutations.push(v);
+        let mut v = base.clone();
+        v.route_role = StreamRouteRole::Direct;
+        mutations.push(v);
+        let mut v = base.clone();
+        v.producer_endpoint_did.push_str(":other");
+        v.producer_state.identity_did = v.producer_endpoint_did.clone();
+        mutations.push(v);
+        let mut v = base.clone();
+        v.consumer_endpoint_did.push_str(":other");
+        v.consumer_state.identity_did = v.consumer_endpoint_did.clone();
+        mutations.push(v);
+        let mut v = base.clone();
+        v.producer_state.digest[0] ^= 1;
+        mutations.push(v);
+        let mut v = base.clone();
+        v.consumer_state.epoch += 1;
+        mutations.push(v);
+        let mut v = base.clone();
+        v.capability.push_str(":other");
+        mutations.push(v);
+        let mut v = base.clone();
+        v.service.push_str(":other");
+        mutations.push(v);
+        let mut v = base.clone();
+        v.track.push_str("-other");
+        mutations.push(v);
+        let mut v = base.clone();
+        v.producer_kem_key_id.push_str("-other");
+        mutations.push(v);
+        let mut v = base.clone();
+        v.consumer_kem_key_id.push_str("-other");
+        mutations.push(v);
+        let mut v = base.clone();
+        v.max_blocks_per_epoch += 1;
+        mutations.push(v);
+        for mutation in mutations {
+            assert_ne!(mutation.binding_hash(), base_hash);
+        }
+    }
+
+    #[test]
+    fn direction_track_epoch_keys_and_nonces_are_disjoint() {
+        let r = ratchet(StreamCarrierProfile::StandardPublicRelay);
+        let k0 = r.current_keys();
+        assert_ne!(
+            *k0.producer_to_consumer.enc_key,
+            *k0.consumer_to_producer.enc_key
+        );
+        assert_ne!(
+            k0.producer_to_consumer.nonce(4),
+            k0.consumer_to_producer.nonce(4)
+        );
+        assert_ne!(
+            k0.producer_to_consumer.nonce(4),
+            k0.producer_to_consumer.nonce(5)
+        );
+
+        let mut other_track = binding(StreamCarrierProfile::StandardPublicRelay);
+        other_track.track.push_str("-other");
+        let other = StreamEpochRatchet::from_hybrid_secret(&[0x44; 32], other_track).unwrap();
+        assert_ne!(
+            *k0.producer_to_consumer.enc_key,
+            *other.current_keys().producer_to_consumer.enc_key
+        );
+    }
+
+    #[test]
+    fn authenticated_rekey_is_atomic_replay_safe_and_one_way() {
+        let mut sender = ratchet(StreamCarrierProfile::StandardPublicRelay);
+        let mut receiver = sender.clone();
+        let old = sender.current_keys();
+        let commit = sender.prepare_next().unwrap();
+
+        let mut tampered = commit.clone();
+        tampered.producer_namespace[0] ^= 1;
+        assert!(receiver.accept_commit(&tampered).is_err());
+        assert_eq!(
+            receiver.epoch(),
+            0,
+            "invalid pending update mutated committed state"
+        );
+
+        let sender_next = sender.commit_prepared(&commit).unwrap();
+        let receiver_next = receiver.accept_commit(&commit).unwrap();
+        assert_eq!(sender_next.epoch, 1);
+        assert_eq!(
+            *sender_next.producer_to_consumer.enc_key,
+            *receiver_next.producer_to_consumer.enc_key
+        );
+        assert_ne!(
+            *old.producer_to_consumer.enc_key,
+            *sender_next.producer_to_consumer.enc_key
+        );
+        assert!(
+            receiver.accept_commit(&commit).is_err(),
+            "replayed commit accepted"
+        );
+    }
+
+    #[test]
+    fn profile_substitution_breaks_key_agreement() {
+        let owned = ratchet(StreamCarrierProfile::OwnedHybridTransport);
+        let relay = ratchet(StreamCarrierProfile::StandardPublicRelay);
+        assert_ne!(owned.binding_hash, relay.binding_hash);
+        assert_ne!(
+            *owned.current_keys().producer_to_consumer.enc_key,
+            *relay.current_keys().producer_to_consumer.enc_key
+        );
+    }
+
+    #[test]
+    fn identified_binding_rejects_anonymous_or_stale_shape() {
+        let mut b = binding(StreamCarrierProfile::StandardPublicRelay);
+        b.consumer_endpoint_did = "anonymous".into();
+        assert!(b.validate().is_err());
+        b.consumer_endpoint_did = b.consumer_state.identity_did.clone();
+        b.consumer_state.digest = [0; 64];
+        assert!(b.validate().is_err());
+    }
+
+    #[test]
+    fn pinned_hykem_handshake_requires_both_components_and_binds_context() {
+        use crate::crypto::hybrid_kem::{generate_recipient, HybridKemMaterial};
+        use crate::crypto::key_exchange::{
+            client_identified_stream_epoch, server_identified_stream_epoch,
+        };
+
+        let keypair = generate_recipient(IDENTIFIED_STREAM_SUITE).unwrap();
+        let binding = binding(StreamCarrierProfile::StandardPublicRelay);
+        let (material, server) =
+            server_identified_stream_epoch(&keypair.public().encode(), binding.clone()).unwrap();
+        let client =
+            client_identified_stream_epoch(&keypair, &material.encode(), binding.clone()).unwrap();
+        assert_eq!(
+            *server.current_keys().producer_to_consumer.enc_key,
+            *client.current_keys().producer_to_consumer.enc_key
+        );
+
+        // A classical-only material list is structurally rejected before key use.
+        let mut classical_only = material.clone();
+        classical_only.shares.truncate(1);
+        assert!(client_identified_stream_epoch(
+            &keypair,
+            &classical_only.encode(),
+            binding.clone()
+        )
+        .is_err());
+
+        // Mutating either component changes or invalidates the agreed key.  ML-KEM
+        // uses implicit rejection, so key mismatch is the expected failure signal.
+        for index in 0..material.shares.len() {
+            let mut crossed: HybridKemMaterial = material.clone();
+            crossed.shares[index].bytes[0] ^= 1;
+            if let Ok(crossed_client) =
+                client_identified_stream_epoch(&keypair, &crossed.encode(), binding.clone())
+            {
+                assert_ne!(
+                    *server.current_keys().producer_to_consumer.enc_key,
+                    *crossed_client.current_keys().producer_to_consumer.enc_key
+                );
+            }
+        }
+
+        let mut substituted = binding;
+        substituted.track.push_str("-substituted");
+        let wrong_context =
+            client_identified_stream_epoch(&keypair, &material.encode(), substituted).unwrap();
+        assert_ne!(
+            *server.current_keys().producer_to_consumer.enc_key,
+            *wrong_context.current_keys().producer_to_consumer.enc_key
+        );
+    }
+
+    #[test]
+    fn client_kem_public_survives_authenticated_envelope_codec() {
+        use crate::crypto::hybrid_kem::generate_recipient;
+        use crate::envelope::RequestEnvelope;
+        use crate::{FromCapnp, ToCapnp};
+
+        let recipient = generate_recipient(IDENTIFIED_STREAM_SUITE)
+            .unwrap()
+            .public();
+        let envelope = RequestEnvelope::new(b"start identified stream".to_vec())
+            .with_client_kem_public(recipient.clone())
+            .unwrap();
+        let mut message = capnp::message::Builder::new_default();
+        envelope
+            .write_to(&mut message.init_root::<crate::common_capnp::request_envelope::Builder>());
+        let decoded = RequestEnvelope::read_from(
+            message
+                .into_reader()
+                .get_root::<crate::common_capnp::request_envelope::Reader>()
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(decoded.client_kem_public, Some(recipient));
+    }
+
+    #[test]
+    fn stock_relay_payload_is_opaque_and_forwarded_byte_identically() {
+        use crate::crypto::event_crypto::{decrypt_event_full, encrypt_event_with_nonce};
+        use crate::stream_consumer::stream_aead_aad;
+
+        let ratchet = ratchet(StreamCarrierProfile::StandardPublicRelay);
+        let keys = ratchet.current_keys();
+        let traffic = &keys.producer_to_consumer;
+        let plaintext = b"private inference token";
+        let nonce = traffic.nonce(0);
+        let aad = stream_aead_aad(ratchet.route_topic(), 0, 0, 0);
+        let (tag, ciphertext, sent_nonce, commitment) =
+            encrypt_event_with_nonce(&traffic.enc_key, nonce, &aad, plaintext).unwrap();
+
+        // These are ordinary opaque Object payload bytes.  A stock relay copies
+        // them without a HyKEM/epoch parser or any traffic key.
+        let mut object = Vec::new();
+        object.extend_from_slice(&sent_nonce);
+        object.extend_from_slice(&commitment);
+        object.extend_from_slice(&tag);
+        object.extend_from_slice(&ciphertext);
+        assert!(!object
+            .windows(plaintext.len())
+            .any(|window| window == plaintext));
+        let relayed = object.clone();
+        assert_eq!(relayed, object);
+
+        let opened =
+            decrypt_event_full(&traffic.enc_key, &sent_nonce, &tag, &ciphertext, &aad).unwrap();
+        assert_eq!(opened, plaintext);
+    }
+}

--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -31,6 +31,7 @@
 //! - FIPS mode: HMAC-SHA256 (FIPS 198-1)
 
 use std::future::Future;
+use std::sync::Arc;
 
 use anyhow::Result;
 use capnp::message::Builder;
@@ -240,9 +241,11 @@ pub struct StreamContext {
     /// `None` on the legacy classical [`from_dh`](Self::from_dh) and the keyless
     /// [`new`](Self::new) paths.
     kem_ciphertexts: Option<Vec<u8>>,
-    /// Identified, transcript-bound epoch state.  Present only on the pinned
-    /// HyKEM path; legacy/keyless contexts cannot ratchet into this profile.
-    epoch_ratchet: Option<crate::stream_epoch::StreamEpochRatchet>,
+    /// Shared one-shot identified producer state. The outer `Option` is a
+    /// persistent profile marker; the inner state is consumed exactly once
+    /// across every clone before an identified publisher creates MoQ resources.
+    /// Legacy/keyless contexts have no claim and cannot ratchet into this profile.
+    epoch_ratchet: Option<Arc<parking_lot::Mutex<Option<crate::stream_epoch::StreamEpochRatchet>>>>,
 }
 
 impl StreamContext {
@@ -367,8 +370,38 @@ impl StreamContext {
             relay_choice: crate::moq_stream::RelayChoice::default(),
             reach_config: crate::moq_stream::global_reach_config(),
             kem_ciphertexts: Some(material.encode()),
-            epoch_ratchet: Some(ratchet),
+            epoch_ratchet: Some(Arc::new(parking_lot::Mutex::new(Some(ratchet)))),
         })
+    }
+
+    /// Whether this context was created for the identified epoch profile.
+    ///
+    /// This marker remains true after the producer claim is consumed so policy
+    /// checks such as the transport-AEAD requirement cannot be downgraded.
+    pub(crate) fn has_epoch_ratchet(&self) -> bool {
+        self.epoch_ratchet.is_some()
+    }
+
+    /// Build a publisher while holding the shared identified producer claim.
+    ///
+    /// The callback sees `Some` only once across every clone. It must consume
+    /// the state only after all fallible resource setup succeeds; if setup
+    /// fails first, the claim remains available for a retry. Legacy contexts
+    /// receive an unshared `None` slot.
+    pub(crate) fn with_publisher_epoch_ratchet<T>(
+        &self,
+        build: impl FnOnce(&mut Option<crate::stream_epoch::StreamEpochRatchet>) -> Result<T>,
+    ) -> Result<T> {
+        let Some(claim) = &self.epoch_ratchet else {
+            let mut legacy = None;
+            return build(&mut legacy);
+        };
+        let mut claim = claim.lock();
+        anyhow::ensure!(
+            claim.is_some(),
+            "identified stream publisher already claimed"
+        );
+        build(&mut claim)
     }
 
     /// The hybrid KEM ciphertexts to emit in `StreamInfo.kemCiphertexts` (S3 #554):
@@ -377,11 +410,6 @@ impl StreamContext {
     /// otherwise.
     pub fn kem_ciphertexts(&self) -> Option<&[u8]> {
         self.kem_ciphertexts.as_deref()
-    }
-
-    /// Clone the committed identified epoch state for a publisher/verifier.
-    pub fn epoch_ratchet(&self) -> Option<crate::stream_epoch::StreamEpochRatchet> {
-        self.epoch_ratchet.clone()
     }
 
     /// Get the stream ID (for logging/display).

--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -45,7 +45,9 @@ use crate::crypto::derive_stream_keys;
 
 // DH key types - Ristretto255 (default) or P-256 (FIPS)
 #[cfg(not(feature = "fips"))]
-use crate::crypto::{ristretto_dh as dh_compute, RistrettoPublic as DhPublic, RistrettoSecret as DhSecret};
+use crate::crypto::{
+    ristretto_dh as dh_compute, RistrettoPublic as DhPublic, RistrettoSecret as DhSecret,
+};
 
 #[cfg(feature = "fips")]
 use crate::crypto::{p256_dh as dh_compute, P256PublicKey as DhPublic, P256SecretKey as DhSecret};
@@ -89,11 +91,21 @@ pub struct BatchingConfig {
     pub max_rate: f32,
 }
 
-fn default_min_batch_size() -> usize { 1 }
-fn default_max_batch_size() -> usize { 16 }
-fn default_max_block_bytes() -> usize { 65536 }
-fn default_min_rate() -> f32 { 1.0 }
-fn default_max_rate() -> f32 { 100.0 }
+fn default_min_batch_size() -> usize {
+    1
+}
+fn default_max_batch_size() -> usize {
+    16
+}
+fn default_max_block_bytes() -> usize {
+    65536
+}
+fn default_min_rate() -> f32 {
+    1.0
+}
+fn default_max_rate() -> f32 {
+    100.0
+}
 
 impl Default for BatchingConfig {
     fn default() -> Self {
@@ -220,10 +232,14 @@ pub struct StreamContext {
     reach_config: crate::moq_stream::ProducerReachConfig,
 
     /// Hybrid KEM ciphertexts to emit in `StreamInfo.kemCiphertexts` (S3 #554).
-    /// `Some` on the hybrid post-quantum path ([`from_hybrid`](Self::from_hybrid));
+    /// `Some` on the hybrid post-quantum path
+    /// ([`from_hybrid_identified`](Self::from_hybrid_identified));
     /// `None` on the legacy classical [`from_dh`](Self::from_dh) and the keyless
     /// [`new`](Self::new) paths.
     kem_ciphertexts: Option<Vec<u8>>,
+    /// Identified, transcript-bound epoch state.  Present only on the pinned
+    /// HyKEM path; legacy/keyless contexts cannot ratchet into this profile.
+    epoch_ratchet: Option<crate::stream_epoch::StreamEpochRatchet>,
 }
 
 impl StreamContext {
@@ -252,6 +268,7 @@ impl StreamContext {
             reach_config: crate::moq_stream::ProducerReachConfig::default(),
             // Keyless path: no hybrid KEM material.
             kem_ciphertexts: None,
+            epoch_ratchet: None,
         }
     }
 
@@ -300,8 +317,9 @@ impl StreamContext {
             reach_config: crate::moq_stream::global_reach_config(),
             // Classical (legacy) path: no hybrid KEM material; the client keys
             // off the server ephemeral `dhPublic`. Removed at the S5 fail-closed
-            // flip (#556) once all call-sites use `from_hybrid`.
+            // flip (#556) once all call-sites use `from_hybrid_identified`.
             kem_ciphertexts: None,
+            epoch_ratchet: None,
         })
     }
 
@@ -316,38 +334,51 @@ impl StreamContext {
     ///
     /// Fail-closed: a malformed / wrong-suite `client_kem_public` is rejected.
     /// This is the post-quantum replacement for [`from_dh`](Self::from_dh).
-    pub fn from_hybrid(client_kem_public: &[u8]) -> Result<Self> {
-        let (material, keys) =
-            crate::crypto::key_exchange::server_hybrid_stream_keys(client_kem_public)
+    pub fn from_hybrid_identified(
+        client_kem_public: &[u8],
+        binding: crate::stream_epoch::IdentifiedStreamBinding,
+    ) -> Result<Self> {
+        let (material, ratchet) =
+            crate::crypto::key_exchange::server_identified_stream_epoch(client_kem_public, binding)
                 .map_err(|e| anyhow::anyhow!("hybrid stream handshake: {e}"))?;
+        let keys = ratchet.current_keys();
+        let outbound = &keys.producer_to_consumer;
+        let inbound = &keys.consumer_to_producer;
 
         let stream_id = format!("stream-{}", uuid::Uuid::new_v4());
 
         Ok(Self {
             stream_id,
-            topic: keys.topic,
-            mac_key: *keys.mac_key,
+            topic: ratchet.route_topic().to_owned(),
+            mac_key: *outbound.mac_key,
             // Hybrid path: AEAD ON for the mesh stream plane (#321), keyed by the
             // post-quantum combiner secret.
-            enc_key: Some(*keys.enc_key),
+            enc_key: Some(*outbound.enc_key),
             // No classical server ephemeral pubkey on the hybrid path; the client
             // keys off `kem_ciphertexts`, not `dhPublic`.
             server_pubkey: [0u8; 32],
-            ctrl_topic: keys.ctrl_topic,
-            ctrl_mac_key: *keys.ctrl_mac_key,
+            ctrl_topic: ratchet.control_topic().to_owned(),
+            ctrl_mac_key: *inbound.control_mac_key,
             cancel_token: CancellationToken::new(),
             qos: crate::stream_info::StreamOpt::default(),
             relay_choice: crate::moq_stream::RelayChoice::default(),
             reach_config: crate::moq_stream::global_reach_config(),
             kem_ciphertexts: Some(material.encode()),
+            epoch_ratchet: Some(ratchet),
         })
     }
 
     /// The hybrid KEM ciphertexts to emit in `StreamInfo.kemCiphertexts` (S3 #554):
-    /// `Some` on the hybrid path ([`from_hybrid`](Self::from_hybrid)), `None`
+    /// `Some` on the hybrid path
+    /// ([`from_hybrid_identified`](Self::from_hybrid_identified)), `None`
     /// otherwise.
     pub fn kem_ciphertexts(&self) -> Option<&[u8]> {
         self.kem_ciphertexts.as_deref()
+    }
+
+    /// Clone the committed identified epoch state for a publisher/verifier.
+    pub fn epoch_ratchet(&self) -> Option<crate::stream_epoch::StreamEpochRatchet> {
+        self.epoch_ratchet.clone()
     }
 
     /// Get the stream ID (for logging/display).
@@ -445,7 +476,10 @@ impl StreamContext {
     /// not the process global. [`StreamChannel::prepare_stream_with_claims`]
     /// calls this when the channel was built with
     /// [`StreamChannel::with_reach_config`].
-    pub fn with_reach_config(mut self, reach_config: crate::moq_stream::ProducerReachConfig) -> Self {
+    pub fn with_reach_config(
+        mut self,
+        reach_config: crate::moq_stream::ProducerReachConfig,
+    ) -> Self {
         self.reach_config = reach_config;
         self
     }
@@ -466,7 +500,8 @@ impl StreamContext {
     /// overridable via [`with_reach_config`](Self::with_reach_config)) — so this
     /// no longer reads the process-global `OnceLock`s on each call.
     pub fn reach(&self) -> Vec<crate::stream_info::Destination> {
-        self.reach_config.reach_with_relay(self.relay_choice.clone())
+        self.reach_config
+            .reach_with_relay(self.relay_choice.clone())
     }
 }
 
@@ -478,7 +513,11 @@ impl StreamContext {
 #[derive(Debug, Clone)]
 pub enum ProgressUpdate {
     /// Progress update: stage, current, total
-    Progress { stage: String, current: usize, total: usize },
+    Progress {
+        stage: String,
+        current: usize,
+        total: usize,
+    },
     /// Operation completed successfully
     Complete(Vec<u8>),
     /// Operation failed with error
@@ -543,13 +582,15 @@ impl ChannelProgressReporter {
 
     /// Signal successful completion with metadata.
     pub fn complete(&self, metadata: Vec<u8>) -> Result<()> {
-        self.sender.blocking_send(ProgressUpdate::Complete(metadata))
+        self.sender
+            .blocking_send(ProgressUpdate::Complete(metadata))
             .map_err(|_| anyhow::anyhow!("Progress channel closed"))
     }
 
     /// Signal an error occurred.
     pub fn error(&self, message: &str) -> Result<()> {
-        self.sender.blocking_send(ProgressUpdate::Error(message.to_owned()))
+        self.sender
+            .blocking_send(ProgressUpdate::Error(message.to_owned()))
             .map_err(|_| anyhow::anyhow!("Progress channel closed"))
     }
 }
@@ -559,7 +600,9 @@ impl ChannelProgressReporter {
 /// Returns (sender, receiver) where:
 /// - sender: Pass to `ChannelProgressReporter::new()` for use in blocking operations
 /// - receiver: Poll in async context to forward updates to `StreamPublisher`
-pub fn progress_channel(buffer_size: usize) -> (
+pub fn progress_channel(
+    buffer_size: usize,
+) -> (
     tokio::sync::mpsc::Sender<ProgressUpdate>,
     tokio::sync::mpsc::Receiver<ProgressUpdate>,
 ) {
@@ -685,7 +728,8 @@ impl StreamChannel {
         client_ephemeral_pubkey: &[u8],
         expiry_secs: i64,
     ) -> Result<StreamContext> {
-        self.prepare_stream_with_claims(client_ephemeral_pubkey, expiry_secs, None).await
+        self.prepare_stream_with_claims(client_ephemeral_pubkey, expiry_secs, None)
+            .await
     }
 
     /// Prepare a stream with DH key exchange, pre-authorization, and claims.
@@ -730,7 +774,12 @@ impl StreamChannel {
     /// No-op on the moq path — topics are published lazily by
     /// `MoqStreamPublisher` on first frame; no pre-registration is needed.
     /// Kept for API compatibility with callers such as `NotificationService`.
-    pub async fn register_topic(&self, _topic: &str, _expiry: i64, _claims: Option<Claims>) -> Result<()> {
+    pub async fn register_topic(
+        &self,
+        _topic: &str,
+        _expiry: i64,
+        _claims: Option<Claims>,
+    ) -> Result<()> {
         Ok(())
     }
 
@@ -739,7 +788,10 @@ impl StreamChannel {
     /// Fails loudly if the process-global moq stream origin has not been
     /// initialized (server not started). In production the `streams` factory
     /// always calls `init_global_moq_origin` before any service handles requests.
-    pub async fn publisher(&self, ctx: &StreamContext) -> Result<crate::moq_stream::AnyStreamPublisher> {
+    pub async fn publisher(
+        &self,
+        ctx: &StreamContext,
+    ) -> Result<crate::moq_stream::AnyStreamPublisher> {
         let origin = crate::moq_stream::global_moq_origin()
             .ok_or_else(|| anyhow::anyhow!("no moq stream origin — server not initialized"))?;
         // #321: on the DH (mesh) path, sign each StreamBlock with the node's per-host
@@ -805,7 +857,10 @@ impl StreamChannel {
     /// Used by NotificationService where topics are registered via `register_topic()`
     /// and don't use DH-based key exchange. The transport MAC key is randomly generated
     /// (separate from notification E2E MAC which is embedded in the payload).
-    pub async fn publisher_for_topic(&self, topic: &str) -> Result<crate::moq_stream::AnyStreamPublisher> {
+    pub async fn publisher_for_topic(
+        &self,
+        topic: &str,
+    ) -> Result<crate::moq_stream::AnyStreamPublisher> {
         // Generate a random transport-level MAC key for the HMAC chain.
         // (Not the notification's E2E MAC — that's embedded in the payload.)
         let mut mac_key = [0u8; 32];
@@ -819,7 +874,6 @@ impl StreamChannel {
         );
         self.publisher(&ctx).await
     }
-
 }
 
 // ============================================================================
@@ -949,8 +1003,9 @@ fn max_concurrent_streams_per_service() -> usize {
 fn stream_admission_semaphore(service_name: &str) -> std::sync::Arc<tokio::sync::Semaphore> {
     use parking_lot::RwLock;
     use std::collections::HashMap;
-    static MAP: std::sync::OnceLock<RwLock<HashMap<String, std::sync::Arc<tokio::sync::Semaphore>>>> =
-        std::sync::OnceLock::new();
+    static MAP: std::sync::OnceLock<
+        RwLock<HashMap<String, std::sync::Arc<tokio::sync::Semaphore>>>,
+    > = std::sync::OnceLock::new();
     let map = MAP.get_or_init(|| RwLock::new(HashMap::new()));
     if let Some(sem) = map.read().get(service_name) {
         return std::sync::Arc::clone(sem);
@@ -959,7 +1014,9 @@ fn stream_admission_semaphore(service_name: &str) -> std::sync::Arc<tokio::sync:
         map.write()
             .entry(service_name.to_owned())
             .or_insert_with(|| {
-                std::sync::Arc::new(tokio::sync::Semaphore::new(max_concurrent_streams_per_service()))
+                std::sync::Arc::new(tokio::sync::Semaphore::new(
+                    max_concurrent_streams_per_service(),
+                ))
             }),
     )
 }
@@ -1087,7 +1144,12 @@ pub fn encode_stream_block_with_provenance(
                 StreamPayloadData::Complete(data) => {
                     p.set_complete(data);
                 }
-                StreamPayloadData::Tagged { tag, payload, nonce, key_commitment } => {
+                StreamPayloadData::Tagged {
+                    tag,
+                    payload,
+                    nonce,
+                    key_commitment,
+                } => {
                     let mut tagged = p.init_tagged();
                     tagged.set_tag(tag);
                     tagged.set_payload(payload);
@@ -1158,7 +1220,8 @@ mod tests {
 
         let mut inner_msg = Builder::new_default();
         {
-            let mut register = inner_msg.init_root::<crate::streaming_capnp::stream_register::Builder>();
+            let mut register =
+                inner_msg.init_root::<crate::streaming_capnp::stream_register::Builder>();
             register.set_topic(topic);
             register.set_exp(expiry);
         }
@@ -1196,12 +1259,10 @@ mod tests {
     /// which already verifies the self-asserted `cnf`'s EdDSA without a pin.
     #[test]
     fn stream_register_hybrid_verifies_only_when_pq_anchored() -> anyhow::Result<()> {
+        use crate::common_capnp;
         use crate::crypto::pq::{ml_dsa_generate_keypair, ml_dsa_vk_from_bytes};
         use crate::crypto::CryptoPolicy;
-        use crate::envelope::{
-            InMemoryNonceCache, KeyedPqTrustStore, SignedEnvelope,
-        };
-        use crate::common_capnp;
+        use crate::envelope::{InMemoryNonceCache, KeyedPqTrustStore, SignedEnvelope};
         use crate::FromCapnp;
 
         let signing_key = SigningKey::from_bytes(&[7u8; 32]);
@@ -1220,11 +1281,14 @@ mod tests {
             &mut std::io::Cursor::new(&bytes[..]),
             capnp::message::ReaderOptions::default(),
         )?;
-        let signed = SignedEnvelope::read_from(
-            reader.get_root::<common_capnp::signed_envelope::Reader>()?,
-        )?;
+        let signed =
+            SignedEnvelope::read_from(reader.get_root::<common_capnp::signed_envelope::Reader>()?)?;
 
-        assert_eq!(signed.policy, CryptoPolicy::Hybrid, "must sign Hybrid with PQ key");
+        assert_eq!(
+            signed.policy,
+            CryptoPolicy::Hybrid,
+            "must sign Hybrid with PQ key"
+        );
 
         // Anchored: the signer's ML-DSA vk is bound to its Ed25519 identity.
         let mut store = KeyedPqTrustStore::new();
@@ -1254,7 +1318,9 @@ mod tests {
         // But a tampered/forged inner EdDSA on an unanchored signer is still
         // rejected — the classical floor is a real signature check, not a bypass.
         let mut forged = signed.clone();
-        forged.cnf = SigningKey::from_bytes(&[9u8; 32]).verifying_key().to_bytes();
+        forged.cnf = SigningKey::from_bytes(&[9u8; 32])
+            .verifying_key()
+            .to_bytes();
         let nonce_forged = InMemoryNonceCache::new();
         assert!(
             forged

--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -409,11 +409,11 @@ impl StreamContext {
 
     /// Disable transport-level AEAD for this stream (#321).
     ///
-    /// Clears the AEAD key so the publisher emits cleartext (HMAC-chained) blocks.
-    /// Used for streams whose consumer receives only `(mac_key, topic)` out of band
-    /// and never derives the DH `enc_key` (e.g. the TUI PTY/shell stdout viewer,
-    /// a same-host stream). AEAD remains mandatory and ON for the DH-keyed mesh
-    /// inference stream, whose consumer derives `enc_key` from the same DH.
+    /// Clears the AEAD key so a legacy publisher emits cleartext (HMAC-chained)
+    /// blocks. Identified epoch contexts retain an internal profile marker and
+    /// are rejected by `MoqStreamOrigin::publisher` if this escape hatch is used;
+    /// it exists only for legacy same-host streams whose consumer receives
+    /// `(mac_key, topic)` out of band and cannot derive the classical DH key.
     pub fn without_aead(mut self) -> Self {
         self.enc_key = None;
         self

--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -134,6 +134,9 @@ pub enum StreamPayloadData {
     Error(String),
     /// Completion with app-specific metadata
     Complete(Vec<u8>),
+    /// Internal identified-profile control plaintext. This variant must be
+    /// sealed into `Tagged` before Cap'n Proto serialization.
+    EpochCommit(crate::stream_epoch::StreamEpochCommit),
     /// Encrypted tagged payload with key commitment
     Tagged {
         tag: Vec<u8>,
@@ -1143,6 +1146,11 @@ pub fn encode_stream_block_with_provenance(
                 }
                 StreamPayloadData::Complete(data) => {
                     p.set_complete(data);
+                }
+                StreamPayloadData::EpochCommit(_) => {
+                    anyhow::bail!(
+                        "identified stream epoch control reached cleartext serialization"
+                    );
                 }
                 StreamPayloadData::Tagged {
                     tag,

--- a/crates/hyprstream-rpc/tests/envelope_canonicalization.rs
+++ b/crates/hyprstream-rpc/tests/envelope_canonicalization.rs
@@ -20,6 +20,7 @@ fn test_envelope_serialization_deterministic() {
         delegation_token: None,
         wth: None,
         client_dh_public: None,
+        client_kem_public: None,
         response_kem_recipient: None,
         service_domain: None,
     };
@@ -54,6 +55,7 @@ fn test_envelope_signature_verification_stable() {
         delegation_token: None,
         wth: None,
         client_dh_public: None,
+        client_kem_public: None,
         response_kem_recipient: None,
         service_domain: None,
     };
@@ -113,6 +115,7 @@ fn test_envelope_canonical_form() {
         delegation_token: None,
         wth: None,
         client_dh_public: None,
+        client_kem_public: None,
         response_kem_recipient: None,
         service_domain: None,
     };
@@ -143,6 +146,7 @@ fn test_envelope_with_authorization_deterministic() {
         delegation_token: None,
         wth: None,
         client_dh_public: None,
+        client_kem_public: None,
         response_kem_recipient: None,
         service_domain: None,
     };
@@ -168,6 +172,7 @@ fn test_envelope_different_data_different_bytes() {
         delegation_token: None,
         wth: None,
         client_dh_public: None,
+        client_kem_public: None,
         response_kem_recipient: Some(RecipientPublic {
             suite_id: SuiteId::HyKemX25519MlKem768,
             eks: vec![vec![0x11; 32], vec![0x22; 1184]],
@@ -184,6 +189,7 @@ fn test_envelope_different_data_different_bytes() {
         delegation_token: None,
         wth: None,
         client_dh_public: None,
+        client_kem_public: None,
         response_kem_recipient: Some(RecipientPublic {
             suite_id: SuiteId::HyKemX25519MlKem768,
             eks: vec![vec![0x33; 32], vec![0x44; 1184]],
@@ -217,6 +223,7 @@ fn test_populated_response_recipient_changes_canonical_bytes() {
         delegation_token: None,
         wth: None,
         client_dh_public: None,
+        client_kem_public: None,
         response_kem_recipient: Some(recipient(0x55, 0x66)),
         service_domain: Some("canonical-service".to_owned()),
     };

--- a/crates/hyprstream-rpc/tests/inv2_receive_dispatch.rs
+++ b/crates/hyprstream-rpc/tests/inv2_receive_dispatch.rs
@@ -201,6 +201,7 @@ fn request_envelope(payload: &[u8]) -> RequestEnvelope {
         delegation_token: None,
         wth: None,
         client_dh_public: None,
+        client_kem_public: None,
         response_kem_recipient: None,
         service_domain: Some("inv2-sentinel".to_owned()),
     }

--- a/crates/hyprstream-rpc/tests/iroh_rpc_e2e.rs
+++ b/crates/hyprstream-rpc/tests/iroh_rpc_e2e.rs
@@ -428,6 +428,7 @@ async fn cleartext_envelope_rejected_on_iroh_receive() -> Result<()> {
         delegation_token: None,
         wth: None,
         client_dh_public: None,
+        client_kem_public: None,
         response_kem_recipient: None,
         service_domain: None,
     };
@@ -512,6 +513,7 @@ async fn false_encrypted_marker_never_reaches_custom_processor_over_iroh() -> Re
             delegation_token: None,
             wth: None,
             client_dh_public: None,
+            client_kem_public: None,
             response_kem_recipient: None,
             service_domain: None,
         },

--- a/docs/cryptography-architecture.md
+++ b/docs/cryptography-architecture.md
@@ -464,7 +464,8 @@ epoch committed. The publisher resets the per-epoch sequence and MAC chain but
 never resets its MOQT Group counter, so a cached track/group/object identity is
 never republished with different ciphertext.
 
-The profile is carrier-neutral. A standard MOQT relay forwards ordinary opaque
+The profile is carrier-neutral. Data, completion metadata, and error messages are
+all sealed before framing, so a standard MOQT relay forwards ordinary opaque
 Object bytes and receives neither the transcript nor traffic keys. Network key
 release is still a separate #726 authorization PEP; the generic
 `StreamKeyReleaseGate`/`StreamKeyReleasePrincipal` seam does not implement or

--- a/docs/cryptography-architecture.md
+++ b/docs/cryptography-architecture.md
@@ -437,6 +437,43 @@ fn derive_stream_keys(...) -> Result<StreamKeys> {
 }
 ```
 
+### Identified hybrid stream epochs (#554)
+
+`stream_epoch.rs` defines the production cryptographic profile that replaces the
+legacy Ristretto bootstrap as individual stream producers migrate. The client
+places a fresh, suite-complete `clientKemPublic` in the signed (and, on network
+carriers, sealed) request. The server accepts only the policy-pinned
+`HyKEM-X25519-MLKEM768` suite and returns its suite-identified component
+ciphertexts in the signed `StreamInfo.kemCiphertexts` field.
+
+The HyKEM combiner secret is mixed with one canonical identified-session binding:
+
+- explicit `owned-hybrid-transport` or `standard-public-relay` profile and the
+  direct/relay route role;
+- producer and consumer endpoint DIDs;
+- both accepted-state CID512 digests and epochs;
+- service, capability, track, and both KEM key IDs; and
+- the pinned suite and epoch block limit.
+
+Each direction and epoch expands separate MAC, AEAD, control, rekey-authentication,
+nonce-domain, and epoch-namespace material. AES-GCM nonces are deterministic
+`nonce_domain || sequenceNumber`; the domain changes across direction, track, and
+epoch. An authenticated `StreamEpochCommit` advances the one-way ratchet
+atomically: invalid, skipped, replayed, or cross-stream commits leave the prior
+epoch committed. The publisher resets the per-epoch sequence and MAC chain but
+never resets its MOQT Group counter, so a cached track/group/object identity is
+never republished with different ciphertext.
+
+The profile is carrier-neutral. A standard MOQT relay forwards ordinary opaque
+Object bytes and receives neither the transcript nor traffic keys. Network key
+release is still a separate #726 authorization PEP; the generic
+`StreamKeyReleaseGate`/`StreamKeyReleasePrincipal` seam does not implement or
+claim restricted-anonymous #1060-#1062 authorization.
+
+The legacy `from_dh` constructors remain during the dependency-safe migration and
+are not evidence that #554 or the later global #556 downgrade-removal ticket is
+closed.
+
 ## Chained HMAC
 
 **Location:** `crates/hyprstream-rpc/src/crypto/hmac.rs`

--- a/docs/streaming-service-architecture.md
+++ b/docs/streaming-service-architecture.md
@@ -3,6 +3,13 @@
 moq-lite streaming plane with HMAC-chained end-to-end authentication and
 transport-level AEAD.
 
+> Migration status (#554): the identified hybrid epoch profile is implemented in
+> `stream_epoch.rs` and the authenticated request now carries `clientKemPublic`.
+> Individual service producers shown below still use the legacy Ristretto path
+> until they can consume accepted-current admission/#726 key-release evidence.
+> Do not treat this document's legacy flow as the network security target or as
+> #554 closure evidence.
+
 ## Overview
 
 ```


### PR DESCRIPTION
## Summary

Implements the next dependency-safe identified-principal stream epoch slice for #554 on exact main base `2e50a4c3d006f551138abc0e7e8fd2365dde03da`.

- adds a pinned `HyKEM-X25519-MLKEM768` bootstrap and immutable canonical binding over carrier profile, route role, endpoint identities, both accepted states, service, capability, track, epoch policy, and both KEM key IDs
- derives distinct producer→consumer and consumer→producer MAC, AEAD, control, rekey-auth, nonce-domain, and epoch-namespace material
- adds authenticated, atomic, one-way epoch transitions with replay/skip/cross-binding rejection
- resets only per-epoch sequence/MAC state while preserving monotonically increasing MOQT Group identity
- carries the authenticated `clientKemPublic` request field through Rust envelope/context/client APIs
- keeps stock public relays standards-compatible: they forward ordinary opaque Object bytes without stream keys or a custom parser
- adds a typed authorization/key-release seam for future anonymous capability work without implementing it

## Verification

- `cargo test -p hyprstream-rpc` — 753 passed, 3 ignored unit fixtures; all integration targets and doc tests passed
- `cargo test -p hyprstream-rpc --lib stream_epoch` — 8 passed
- `cargo test -p hyprstream-rpc --lib identified_epoch_rekey_keeps_stock_moq_objects_opaque_and_immutable` — passed
- `cargo clippy -p hyprstream-rpc --all-targets -- -D warnings` — passed
- pre-commit `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `RUSTFLAGS='--cfg=web_sys_unstable_apis' cargo check --target wasm32-unknown-unknown -p hyprstream-rpc` — passed
- `cargo deny check bans licenses` — passed (`bans ok, licenses ok`; repository baseline warnings only)
- `git diff --check` and touched-file `rustfmt --check` — passed

## Explicit boundaries

- This does not implement #555 controller/group epochs.
- This does not enable production network key release before the #726 authorization PEP is integrated.
- This does not implement or claim restricted-anonymous security from #1060-#1062.
- Legacy classical producers remain during migration; this PR does not claim #554 or #556 closure.
- No merge or self-approval is requested; exact-head independent GPT-5.6-sol review is required.

Refs #554.
