### PR TITLE
feat: de-singletonize producer reach config

### DIFF
--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -3702,7 +3702,7 @@ impl DiscoveryHandler for DiscoveryService {
         _request_id: u64,
     ) -> Result<DiscoveryResponseVariant> {
         Ok(DiscoveryResponseVariant::Error(ErrorInfo {
-            message: "prepareStream removed — use StreamChannel::prepare_stream for authenticated streaming".to_owned(),
+            message: "prepareStream removed — use StreamChannel::prepare_identified_stream for authenticated streaming".to_owned(),
             code: "REMOVED".to_owned(),
             details: String::new(),
         }))
@@ -3715,7 +3715,7 @@ impl DiscoveryHandler for DiscoveryService {
     ) -> Result<DiscoveryResponseVariant> {
         Ok(DiscoveryResponseVariant::Error(ErrorInfo {
             message:
-                "getStream removed — use StreamChannel::prepare_stream for authenticated streaming"
+                "getStream removed — use StreamChannel::prepare_identified_stream for authenticated streaming"
                     .to_owned(),
             code: "REMOVED".to_owned(),
             details: String::new(),
@@ -3728,7 +3728,7 @@ impl DiscoveryHandler for DiscoveryService {
         _request_id: u64,
     ) -> Result<DiscoveryResponseVariant> {
         Ok(DiscoveryResponseVariant::Error(ErrorInfo {
-            message: "listStreams removed — use StreamChannel::prepare_stream for authenticated streaming".to_owned(),
+            message: "listStreams removed — use StreamChannel::prepare_identified_stream for authenticated streaming".to_owned(),
             code: "REMOVED".to_owned(),
             details: String::new(),
         }))

--- a/crates/hyprstream-rpc/src/moq_stream.rs
+++ b/crates/hyprstream-rpc/src/moq_stream.rs
@@ -409,6 +409,10 @@ pub struct MoqStreamOrigin {
     inner: Arc<OriginInner>,
 }
 
+/// Mutable per-service MoQ origin source. `None` preserves the process-global
+/// origin for services that do not need relay isolation.
+pub type MoqStreamOriginHandle = Arc<RwLock<Option<MoqStreamOrigin>>>;
+
 /// Builder for [`MoqStreamOrigin`] — set the prefix and publish gate before the
 /// shared `Arc` is constructed (avoids clone-on-write of the origin tree).
 pub struct MoqStreamOriginBuilder {

--- a/crates/hyprstream-rpc/src/moq_stream.rs
+++ b/crates/hyprstream-rpc/src/moq_stream.rs
@@ -51,7 +51,7 @@ use std::sync::{Arc, OnceLock};
 use anyhow::{anyhow, ensure, Context, Result};
 use bytes::Bytes;
 use moq_net::{BroadcastProducer, Group, OriginConsumer, OriginProducer, Track, TrackProducer};
-use parking_lot::Mutex;
+use parking_lot::{Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
 
 use crate::crypto::StreamHmacState;
@@ -92,21 +92,7 @@ pub fn global_moq_uds_path() -> Option<&'static Path> {
     GLOBAL_MOQ_UDS_PATH.get().map(PathBuf::as_path)
 }
 
-// ============================================================================
-// Process-global producer reach (#274) — the network-routable way external
-// subscribers reach this node's moq plane. Set once when the QUIC /
-// web_transport_quinn server binds; read by every StreamInfo producer site so
-// the `reach` field is built from ONE source (no per-site assembly, no drift),
-// the same Rust value `root_did_document()` uses for its QuicTransport entry.
-// ============================================================================
-
-/// The node's network-routable moq reach: the bound QUIC address, its TLS
-/// server name, and the leaf-cert SHA-256 pins. `None` until the daemon binds
-/// its `web_transport_quinn` server (UDS-only / unit-test deployments).
-static GLOBAL_PRODUCER_REACH: OnceLock<NodeStreamReach> = OnceLock::new();
-
-/// The node's own moq reach parameters — the single source for the `reach`
-/// list every StreamInfo producer publishes.
+/// Bound QUIC reach for one service's MoQ producer.
 #[derive(Clone, Debug)]
 pub struct NodeStreamReach {
     /// Bound socket address external subscribers dial (`/moq` over WebTransport).
@@ -117,118 +103,8 @@ pub struct NodeStreamReach {
     pub cert_hashes: Vec<[u8; 32]>,
 }
 
-/// Register the node's network-routable moq reach (idempotent — first wins).
-///
-/// Called once when the daemon binds its `web_transport_quinn` server, with the
-/// same `(addr, server_name, cert_hash)` the RPC endpoint registers and the
-/// DID-doc `#quic` entry advertises.
-pub fn init_global_producer_reach(reach: NodeStreamReach) -> bool {
-    GLOBAL_PRODUCER_REACH.set(reach).is_ok()
-}
-
-/// Borrow the node's registered network reach, if the QUIC server is bound.
-pub fn global_producer_reach() -> Option<&'static NodeStreamReach> {
-    GLOBAL_PRODUCER_REACH.get()
-}
-
-/// The node's own iroh `EndpointId` (Ed25519 public key) once the iroh substrate
-/// is bound (#357). Registered separately from [`GLOBAL_PRODUCER_REACH`] because
-/// the QUIC reach is set when the quinn server binds, whereas iroh binds slightly
-/// later in the same bootstrap; folding it back into the first-wins
-/// [`NodeStreamReach`] would require reordering the bind sequence.
-static GLOBAL_IROH_NODE_ID: OnceLock<[u8; 32]> = OnceLock::new();
-
-/// Register the node's iroh `EndpointId` so [`producer_reach`] can advertise an
-/// iroh-direct [`Destination`] for native peers (#357). Idempotent (first wins).
-///
-/// Called once when the daemon binds its iroh substrate (the `node_id` ==
-/// `signing_key.verifying_key()`, already covered by the node's DID).
-pub fn init_global_iroh_node_id(node_id: [u8; 32]) -> bool {
-    GLOBAL_IROH_NODE_ID.set(node_id).is_ok()
-}
-
-/// Borrow the node's registered iroh `EndpointId`, if the iroh substrate is bound.
-pub fn global_iroh_node_id() -> Option<&'static [u8; 32]> {
-    GLOBAL_IROH_NODE_ID.get()
-}
-
-// ============================================================================
-// Process-global producer-chosen moq RELAY (#358) — the rendezvous endpoint a
-// producing service advertises so that NEITHER the publisher NOR the subscriber
-// must be directly reachable by the other: both rendezvous through this relay.
-//
-// The relay is *producer-chosen* (default = the service's PDS / federation
-// anchor) and set once when the producing node learns its relay. It is the
-// network-routable `TransportConfig` of the relay's moq plane — the SAME codec
-// the DID document's transport `service` entries use ([`crate::service_entry`]),
-// so the advertised stream relay and the DID transport address never drift.
-//
-// The relay carries AEAD-sealed ciphertext it cannot read (the `enc_key` /
-// `TaggedPayload` path seals at source) and never holds the `mac_key` /
-// `enc_key`: it is blind by construction, not by trust. Per-PDS, shared, and
-// oblivious relays are therefore all safe for content confidentiality.
-// ============================================================================
-
-/// The producer-chosen moq relay this node rendezvouses through (#358).
-///
-/// Held as the wire-form [`crate::stream_info::TransportConfig`] (the reach
-/// codec), so the SAME value is both advertised verbatim in `StreamInfo.reach`
-/// and dialed (via the shared [`reach_to_transport_config`] resolver) by the
-/// relay client — no per-site assembly, no drift between the advertised stream
-/// relay and the dialed one.
-///
-/// `None` until the node is configured with a relay (no relay = direct-only
-/// advertisement, the S1/S2 behaviour). The default deployment co-locates this
-/// with the node's `#atproto_pds` DID service entry where the node is the PDS.
-static GLOBAL_RELAY_REACH: OnceLock<crate::stream_info::TransportConfig> = OnceLock::new();
-
-/// Register the producer-chosen moq relay endpoint (idempotent — first wins).
-///
-/// `relay` is the relay's network-routable transport in wire-reach form
-/// ([`crate::stream_info::TransportConfig`] — Quic / WebTransport or iroh). A
-/// node sources this from its resolved DID transport entry decoded by the SAME
-/// [`crate::service_entry`] codec the DID document uses (default: the PDS /
-/// federation anchor), never hand-assembled — see [`relay_reach_from_decoded`].
-///
-/// After this is set, [`producer_reach`] advertises a `Role::Relay`
-/// [`Destination`] and [`serve_origin_to_relay_background`] should be spawned to
-/// announce this node's broadcasts UP to the relay.
-pub fn init_global_relay_reach(relay: crate::stream_info::TransportConfig) -> bool {
-    GLOBAL_RELAY_REACH.set(relay).is_ok()
-}
-
-/// Borrow the producer-chosen relay endpoint (wire-reach form), if configured.
-pub fn global_relay_reach() -> Option<&'static crate::stream_info::TransportConfig> {
-    GLOBAL_RELAY_REACH.get()
-}
-
-// ============================================================================
-// Per-server reach context (#384) — de-singletonize GLOBAL_RELAY_REACH.
-//
-// Relay/reach choice is logically PER-STREAM, but was historically wired
-// PER-PROCESS through three `OnceLock` singletons (`GLOBAL_IROH_NODE_ID`,
-// `GLOBAL_PRODUCER_REACH`, `GLOBAL_RELAY_REACH`). That granularity prevented a
-// relay-only-anonymized stream X from coexisting with a direct stream Y in the
-// same process, blocked per-tenant relay isolation, and the first-write-wins
-// `OnceLock` semantics silently clobbered later writes.
-//
-// [`ProducerReachConfig`] carries the node/server's reach inputs as plain,
-// `Clone` config data (trivially `Send + Sync`). The reach list is built by its
-// [`ProducerReachConfig::reach`] METHOD reading its OWN fields — never process
-// globals. A per-stream relay override
-// ([`ProducerReachConfig::reach_with_relay`]) lets one stream pick a different
-// relay (or go relay-only / anonymized) while another in the same process stays
-// direct — the heterogeneous-anonymization property #384 requires.
-//
-// The process globals remain ONLY as a populated-once compatibility source for
-// the deprecated free-function [`producer_reach`]; new code threads a
-// `ProducerReachConfig` (see [`global_reach_config`]). (Tier 3 — scheduled
-// relay selection — is deliberately not built but not structurally precluded:
-// a scheduler can simply hand a per-stream override to `reach_with_relay`.)
-// ============================================================================
-
 /// A node/server's moq reach inputs (#384) — the per-server context that builds
-/// a producer's `StreamInfo.reach`, replacing the three `OnceLock` singletons.
+/// a producer's `StreamInfo.reach`.
 ///
 /// Plain config data (`Clone`, `Send + Sync`). The common-case relay is a
 /// server-global value (often an anycast PDS / federation-anchor address)
@@ -248,6 +124,10 @@ pub struct ProducerReachConfig {
     /// override may supersede this for an individual stream.
     pub relay: Option<crate::stream_info::TransportConfig>,
 }
+
+/// Mutable per-service reach source. The service spawner fills it with the
+/// actual QUIC and iroh bind results before the service accepts requests.
+pub type ProducerReachConfigHandle = Arc<RwLock<ProducerReachConfig>>;
 
 impl ProducerReachConfig {
     /// Build this server's `StreamInfo.reach` using its server-global relay.
@@ -361,32 +241,6 @@ pub enum RelayChoice {
     NoRelay,
 }
 
-/// Snapshot the process globals into a [`ProducerReachConfig`] (#384 compat).
-///
-/// Bridges the deprecated [`producer_reach`] free function (and call sites not
-/// yet threaded with a `ProducerReachConfig`) to the per-server context. New
-/// code should thread an explicit [`ProducerReachConfig`] instead — this reads
-/// the `OnceLock` singletons whose first-write-wins clobbering #384 removes.
-pub fn global_reach_config() -> ProducerReachConfig {
-    ProducerReachConfig {
-        iroh_node_id: global_iroh_node_id().copied(),
-        quic_reach: global_producer_reach().cloned(),
-        relay: global_relay_reach().cloned(),
-    }
-}
-
-/// Build the `StreamInfo.reach` list for a producer on this node (#274).
-///
-/// **Deprecated (#384):** reads the process-global `OnceLock` singletons, which
-/// cannot express per-stream / per-tenant relay choice and clobber on a second
-/// write. New code should construct a [`ProducerReachConfig`] (threaded from the
-/// daemon bind site) and call [`ProducerReachConfig::reach`] /
-/// [`ProducerReachConfig::reach_with_relay`]. Retained as a thin compatibility
-/// shim over [`global_reach_config`] for call sites not yet threaded.
-pub fn producer_reach() -> Vec<crate::stream_info::Destination> {
-    global_reach_config().reach()
-}
-
 /// Build the producer-chosen relay's wire-reach [`crate::stream_info::TransportConfig`]
 /// from a DID-document transport entry decoded by [`crate::service_entry`] (#358).
 ///
@@ -394,7 +248,7 @@ pub fn producer_reach() -> Vec<crate::stream_info::Destination> {
 /// address from drifting: a node resolves its relay's DID service entry (default
 /// `#atproto_pds`), decodes it with the shared [`crate::service_entry::decode_service_entry`]
 /// codec, and passes the resulting [`crate::transport::TransportConfig`] here to
-/// obtain the wire-reach form to register via [`init_global_relay_reach`].
+/// obtain the wire-reach form to place in a [`ProducerReachConfig`].
 ///
 /// Returns `None` for same-host transports (`ipc`/`inproc`/`systemd-fd`), which
 /// are never network-routable relay endpoints.
@@ -1768,8 +1622,8 @@ fn assert_relay_path_pinned(cfg: &crate::transport::TransportConfig) -> Result<(
 /// holds the session open, and reconnects on failure. The task runs for the
 /// process lifetime.
 ///
-/// Called once by the producing service's factory after [`init_global_relay_reach`]
-/// — typically with `global_moq_origin().producer()`. No-op-safe to omit when the
+/// Called by the producing service after its relay reach is configured —
+/// typically with `global_moq_origin().producer()`. No-op-safe to omit when the
 /// node has no relay (direct-only deployments).
 pub fn serve_origin_to_relay_background(
     producer: OriginProducer,
@@ -2647,7 +2501,7 @@ mod tests {
         use crate::transport::EndpointType;
 
         let node_id = [0x7u8; 32];
-        // This is exactly the Destination `producer_reach()` emits for the iroh arm.
+        // This is exactly the Destination `ProducerReachConfig::reach()` emits for iroh.
         let reach = Destination {
             role: Role::Direct,
             transport: ReachTransport::Iroh(IrohReach {

--- a/crates/hyprstream-rpc/src/moq_stream.rs
+++ b/crates/hyprstream-rpc/src/moq_stream.rs
@@ -2006,7 +2006,7 @@ mod tests {
     async fn moq_stream_round_trip() -> Result<()> {
         let origin = origin();
         let (_client_secret, client_pub) = crate::crypto::generate_ephemeral_keypair();
-        let ctx = StreamContext::from_dh(&client_pub.to_bytes())?;
+        let ctx = StreamContext::from_third_party_interop_dh(&client_pub.to_bytes())?;
         let topic = ctx.topic().to_owned();
         let mac_key = *ctx.mac_key();
         // #321: DH path is AEAD-on; the verifier shares the same enc_key.
@@ -2364,7 +2364,7 @@ mod tests {
     async fn any_stream_publisher_moq_round_trip() -> Result<()> {
         let origin = origin();
         let (_client_secret, client_pub) = crate::crypto::generate_ephemeral_keypair();
-        let ctx = StreamContext::from_dh(&client_pub.to_bytes())?;
+        let ctx = StreamContext::from_third_party_interop_dh(&client_pub.to_bytes())?;
         let topic = ctx.topic().to_owned();
         let mac_key = *ctx.mac_key();
         // #321: DH path is AEAD-on; the verifier shares the same enc_key.
@@ -3065,7 +3065,7 @@ mod tests {
 
         let origin = origin();
         let (_cs, client_pub) = crate::crypto::generate_ephemeral_keypair();
-        let ctx = StreamContext::from_dh(&client_pub.to_bytes())?;
+        let ctx = StreamContext::from_third_party_interop_dh(&client_pub.to_bytes())?;
         let topic = ctx.topic().to_owned();
         let mac_key = *ctx.mac_key();
         let enc_key = *ctx.enc_key().expect("DH ctx has enc_key");

--- a/crates/hyprstream-rpc/src/service/svc.rs
+++ b/crates/hyprstream-rpc/src/service/svc.rs
@@ -522,6 +522,12 @@ pub trait RequestService: 'static {
         None
     }
 
+    /// Optional per-service MoQ origin source. The unified spawner installs a
+    /// scoped origin here when this service has a relay configured.
+    fn moq_origin_handle(&self) -> Option<crate::moq_stream::MoqStreamOriginHandle> {
+        None
+    }
+
     /// ML-DSA-65 signing key for the post-quantum half of the response COSE
     /// composite (#275). When `Some`, `process_request` signs the
     /// `ResponseEnvelope` under the Hybrid policy (EdDSA + ML-DSA-65); when

--- a/crates/hyprstream-rpc/src/service/svc.rs
+++ b/crates/hyprstream-rpc/src/service/svc.rs
@@ -516,6 +516,12 @@ pub trait RequestService: 'static {
     /// Ed25519 signing key for signing responses.
     fn signing_key(&self) -> SigningKey;
 
+    /// Mutable reach source filled by the unified service spawner after the
+    /// service's QUIC and iroh listeners bind.
+    fn producer_reach_config_handle(&self) -> Option<crate::moq_stream::ProducerReachConfigHandle> {
+        None
+    }
+
     /// ML-DSA-65 signing key for the post-quantum half of the response COSE
     /// composite (#275). When `Some`, `process_request` signs the
     /// `ResponseEnvelope` under the Hybrid policy (EdDSA + ML-DSA-65); when
@@ -1025,8 +1031,8 @@ pub struct QuicLoopConfig {
     pub on_iroh_bound: Option<Box<dyn FnOnce(String, [u8; 32]) + Send>>,
     /// #358: the producer-chosen moq RELAY this node rendezvouses through, in
     /// wire-reach form ([`crate::stream_info::TransportConfig`]). When set, the
-    /// spawner registers it via [`crate::moq_stream::init_global_relay_reach`] (so
-    /// `producer_reach()` advertises a `Role::Relay` reach) and links this node's
+    /// spawner places it in the service's `ProducerReachConfig` (so published
+    /// streams advertise a `Role::Relay` reach) and links this node's
     /// streaming origin UP to the relay
     /// ([`crate::moq_stream::serve_origin_to_relay_background`]) — restoring the
     /// rendezvous property: neither publisher nor subscriber need be directly

--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -683,6 +683,8 @@ pub struct StreamChannel {
     pq_signing_key: Option<crate::crypto::pq::MlDsaSigningKey>,
     /// Per-service reach source, updated by the service spawner after bind.
     reach_config: crate::moq_stream::ProducerReachConfigHandle,
+    /// Optional service-scoped origin installed when this service links a relay.
+    moq_origin: crate::moq_stream::MoqStreamOriginHandle,
 }
 
 impl StreamChannel {
@@ -703,6 +705,7 @@ impl StreamChannel {
             reach_config: std::sync::Arc::new(parking_lot::RwLock::new(
                 crate::moq_stream::ProducerReachConfig::default(),
             )),
+            moq_origin: std::sync::Arc::new(parking_lot::RwLock::new(None)),
         }
     }
 
@@ -721,6 +724,17 @@ impl StreamChannel {
     /// Return this channel's service-owned reach handle.
     pub fn reach_config_handle(&self) -> crate::moq_stream::ProducerReachConfigHandle {
         self.reach_config.clone()
+    }
+
+    /// Share a service-owned MoQ origin handle with this channel.
+    pub fn with_moq_origin_handle(mut self, handle: crate::moq_stream::MoqStreamOriginHandle) -> Self {
+        self.moq_origin = handle;
+        self
+    }
+
+    /// Return this channel's service-owned MoQ origin handle.
+    pub fn moq_origin_handle(&self) -> crate::moq_stream::MoqStreamOriginHandle {
+        self.moq_origin.clone()
     }
 
     /// Install the node's persistent ML-DSA-65 signing key, replacing the
@@ -807,8 +821,12 @@ impl StreamChannel {
         &self,
         ctx: &StreamContext,
     ) -> Result<crate::moq_stream::AnyStreamPublisher> {
-        let origin = crate::moq_stream::global_moq_origin()
-            .ok_or_else(|| anyhow::anyhow!("no moq stream origin — server not initialized"))?;
+        let scoped_origin = self.moq_origin.read().clone();
+        let origin = match scoped_origin.as_ref() {
+            Some(origin) => origin,
+            None => crate::moq_stream::global_moq_origin()
+                .ok_or_else(|| anyhow::anyhow!("no moq stream origin — server not initialized"))?,
+        };
         // #321: on the DH (mesh) path, sign each StreamBlock with the node's per-host
         // hybrid identity (Ed25519 + the deterministically-derived mesh ML-DSA key)
         // so consumers can attribute blocks to this host (C-PROV / threat T3). The
@@ -1411,6 +1429,26 @@ mod tests {
         };
         assert_eq!(addr(&stream_a), "127.0.0.1:4101");
         assert_eq!(addr(&stream_b), "127.0.0.1:4102");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stream_channel_uses_service_scoped_moq_origin() -> Result<()> {
+        let scoped_origin = crate::moq_stream::MoqStreamOrigin::standalone().build();
+        let origin_handle = std::sync::Arc::new(parking_lot::RwLock::new(Some(scoped_origin.clone())));
+        let channel = StreamChannel::new(SigningKey::from_bytes(&[3; 32]))
+            .with_moq_origin_handle(origin_handle);
+        let (_, client_pub) = crate::crypto::generate_ephemeral_keypair();
+        let stream = channel.prepare_stream(&client_pub.to_bytes(), 60).await?;
+        let _publisher = channel.publisher(&stream).await?;
+
+        let path = scoped_origin.broadcast_path(stream.topic());
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            scoped_origin.consumer().announced_broadcast(&path),
+        )
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("scoped origin did not announce {path}"))?;
         Ok(())
     }
 

--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -230,7 +230,7 @@ pub struct StreamContext {
     /// reach is per-stream too, not just `relay_choice`.
     ///
     /// When no explicit config is threaded, [`from_dh`](Self::from_dh) seeds it
-    /// from [`global_reach_config`](crate::moq_stream::global_reach_config) — a
+    /// from an empty [`ProducerReachConfig`](crate::moq_stream::ProducerReachConfig) — a
     /// one-time per-stream snapshot (the documented compat source), not a
     /// per-`reach()`-call global read.
     reach_config: crate::moq_stream::ProducerReachConfig,
@@ -314,13 +314,7 @@ impl StreamContext {
             cancel_token: CancellationToken::new(),
             qos: crate::stream_info::StreamOpt::default(),
             relay_choice: crate::moq_stream::RelayChoice::default(),
-            // Snapshot the node's reach inputs ONCE, per-stream, at construction
-            // (#384). `reach()` then reads this captured field instead of the
-            // process globals on every call. A `StreamChannel` with an explicit
-            // per-server `ProducerReachConfig` overrides this via
-            // `with_reach_config` (prepare_stream), making the base reach fully
-            // per-stream rather than global-sourced.
-            reach_config: crate::moq_stream::global_reach_config(),
+            reach_config: crate::moq_stream::ProducerReachConfig::default(),
             // Classical (legacy) path: no hybrid KEM material; the client keys
             // off the server ephemeral `dhPublic`. Removed at the S5 fail-closed
             // flip (#556) once all call-sites use `from_hybrid_identified`.
@@ -368,7 +362,7 @@ impl StreamContext {
             cancel_token: CancellationToken::new(),
             qos: crate::stream_info::StreamOpt::default(),
             relay_choice: crate::moq_stream::RelayChoice::default(),
-            reach_config: crate::moq_stream::global_reach_config(),
+            reach_config: crate::moq_stream::ProducerReachConfig::default(),
             kem_ciphertexts: Some(material.encode()),
             epoch_ratchet: Some(Arc::new(parking_lot::Mutex::new(Some(ratchet)))),
         })
@@ -501,12 +495,11 @@ impl StreamContext {
 
     /// Thread an explicit per-server reach config into this stream (#384).
     ///
-    /// Replaces the [`from_dh`](Self::from_dh) global snapshot with the supplied
-    /// per-server [`ProducerReachConfig`](crate::moq_stream::ProducerReachConfig),
+    /// Supplies the per-server [`ProducerReachConfig`](crate::moq_stream::ProducerReachConfig)
+    /// for this stream,
     /// so the base (iroh/QUIC) reach this stream advertises is the server's own —
-    /// not the process global. [`StreamChannel::prepare_stream_with_claims`]
-    /// calls this when the channel was built with
-    /// [`StreamChannel::with_reach_config`].
+    /// [`StreamChannel::prepare_stream_with_claims`] applies its current service
+    /// config before it returns the context.
     pub fn with_reach_config(
         mut self,
         reach_config: crate::moq_stream::ProducerReachConfig,
@@ -523,8 +516,7 @@ impl StreamContext {
     /// Build this stream's `StreamInfo.reach` from the node's per-server reach
     /// config and this stream's [`relay_choice`](Self::relay_choice) (#384).
     ///
-    /// This is the threaded replacement for the deprecated free-function
-    /// `producer_reach()`: a producer that holds a `StreamContext` calls this so
+    /// A producer that holds a `StreamContext` calls this so
     /// the stream's relay/anonymization posture **and** its base iroh/QUIC reach
     /// are honoured per-stream. Both come from the context's own
     /// [`reach_config`](Self::reach_config) field — captured at construction (and
@@ -689,13 +681,8 @@ pub struct StreamChannel {
     /// deterministically from the node's persistent Ed25519 signing key (#157)
     /// in [`Self::new`]; override with [`Self::with_pq_key`].
     pq_signing_key: Option<crate::crypto::pq::MlDsaSigningKey>,
-    /// Explicit per-server reach config threaded into every `StreamContext` this
-    /// channel prepares (#384). `None` → each context snapshots
-    /// [`global_reach_config`](crate::moq_stream::global_reach_config) in
-    /// `from_dh` (the compat default). `Some` → heterogeneous per-server reach:
-    /// the channel's own iroh/QUIC/relay inputs are used for the base reach,
-    /// independent of the process globals. Set via [`Self::with_reach_config`].
-    reach_config: Option<crate::moq_stream::ProducerReachConfig>,
+    /// Per-service reach source, updated by the service spawner after bind.
+    reach_config: crate::moq_stream::ProducerReachConfigHandle,
 }
 
 impl StreamChannel {
@@ -713,24 +700,27 @@ impl StreamChannel {
         Self {
             signing_key,
             pq_signing_key,
-            reach_config: None,
+            reach_config: std::sync::Arc::new(parking_lot::RwLock::new(
+                crate::moq_stream::ProducerReachConfig::default(),
+            )),
         }
     }
 
-    /// Thread an explicit per-server reach config (#384).
-    ///
-    /// Every `StreamContext` this channel prepares is populated with `cfg` (via
-    /// [`StreamContext::with_reach_config`]) so its base iroh/QUIC reach — not
-    /// just its relay choice — comes from this server's own config rather than
-    /// the process-global `OnceLock`s. This is the threading hook that makes
-    /// heterogeneous-per-server reach fully work; a server constructs its
-    /// [`ProducerReachConfig`](crate::moq_stream::ProducerReachConfig) at its
-    /// bind site and hands it here. When unset, contexts fall back to the
-    /// per-stream [`global_reach_config`](crate::moq_stream::global_reach_config)
-    /// snapshot.
+    /// Initialize this channel's reach configuration.
     pub fn with_reach_config(mut self, cfg: crate::moq_stream::ProducerReachConfig) -> Self {
-        self.reach_config = Some(cfg);
+        self.reach_config = std::sync::Arc::new(parking_lot::RwLock::new(cfg));
         self
+    }
+
+    /// Share a service-owned reach handle with this channel.
+    pub fn with_reach_config_handle(mut self, handle: crate::moq_stream::ProducerReachConfigHandle) -> Self {
+        self.reach_config = handle;
+        self
+    }
+
+    /// Return this channel's service-owned reach handle.
+    pub fn reach_config_handle(&self) -> crate::moq_stream::ProducerReachConfigHandle {
+        self.reach_config.clone()
     }
 
     /// Install the node's persistent ML-DSA-65 signing key, replacing the
@@ -781,14 +771,8 @@ impl StreamChannel {
         expiry_secs: i64,
         _claims: Option<Claims>,
     ) -> Result<StreamContext> {
-        // 1. DH key exchange. Thread this channel's explicit per-server reach
-        // config when set (#384) so the stream's base iroh/QUIC reach is the
-        // server's own, not the process global; otherwise the context keeps the
-        // per-stream `global_reach_config()` snapshot `from_dh` captured.
-        let mut stream_ctx = StreamContext::from_dh(client_ephemeral_pubkey)?;
-        if let Some(cfg) = &self.reach_config {
-            stream_ctx = stream_ctx.with_reach_config(cfg.clone());
-        }
+        let stream_ctx = StreamContext::from_dh(client_ephemeral_pubkey)?
+            .with_reach_config(self.reach_config.read().clone());
 
         // Spawn JWT expiry timeout as universal backstop.
         let token = stream_ctx.cancel_token().clone();
@@ -1390,6 +1374,44 @@ mod tests {
 
         // Chain state should advance to mac2
         assert_eq!(state.prev_mac_bytes(), &mac2[..]);
+    }
+
+    #[tokio::test]
+    async fn stream_channels_keep_distinct_service_reach() -> Result<()> {
+        use crate::moq_stream::{NodeStreamReach, ProducerReachConfig};
+        use crate::stream_info::TransportConfig;
+
+        let config = |port| -> Result<ProducerReachConfig> {
+            Ok(ProducerReachConfig {
+                iroh_node_id: None,
+                quic_reach: Some(NodeStreamReach {
+                    addr: format!("127.0.0.1:{port}").parse()?,
+                    server_name: format!("server-{port}"),
+                    cert_hashes: vec![[port as u8; 32]],
+                }),
+                relay: None,
+            })
+        };
+        let channel_a = StreamChannel::new(SigningKey::from_bytes(&[1; 32]))
+            .with_reach_config(config(4101)?);
+        let channel_b = StreamChannel::new(SigningKey::from_bytes(&[2; 32]))
+            .with_reach_config(config(4102)?);
+        let (_, client_pub) = crate::crypto::generate_ephemeral_keypair();
+
+        let stream_a = channel_a
+            .prepare_stream(&client_pub.to_bytes(), 60)
+            .await?;
+        let stream_b = channel_b
+            .prepare_stream(&client_pub.to_bytes(), 60)
+            .await?;
+
+        let addr = |stream: &StreamContext| match &stream.reach()[0].transport {
+            TransportConfig::Quic(reach) => reach.addr.clone(),
+            other => panic!("expected QUIC reach, got {other:?}"),
+        };
+        assert_eq!(addr(&stream_a), "127.0.0.1:4101");
+        assert_eq!(addr(&stream_b), "127.0.0.1:4102");
+        Ok(())
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -169,7 +169,9 @@ pub use crate::crypto::StreamHmacState;
 
 /// Encapsulates all state needed to produce a stream.
 ///
-/// Created by `StreamingService::prepare_stream()` after DH key exchange.
+/// Created by an identified stream preparation API after the pinned hybrid
+/// post-quantum handshake, or by the explicitly named third-party
+/// interoperability DH edge.
 /// Contains everything needed to:
 /// - Return stream info to client (stream_id, server_pubkey)
 /// - Create a `StreamPublisher` for sending data
@@ -178,7 +180,7 @@ pub use crate::crypto::StreamHmacState;
 ///
 /// ```ignore
 /// // In service handler:
-/// let ctx = self.prepare_stream(envelope_ctx)?;
+/// let ctx = self.prepare_identified_stream(envelope_ctx, accepted_binding, 600).await?;
 ///
 /// // Return to client:
 /// let response = Response::stream_started(ctx.stream_id(), ctx.server_pubkey());
@@ -192,21 +194,22 @@ pub use crate::crypto::StreamHmacState;
 pub struct StreamContext {
     /// Human-readable stream ID (for logging/display)
     stream_id: String,
-    /// DH-derived topic (64 hex chars) - used for ZMQ routing
+    /// Key-exchange-derived topic (64 hex chars) - used for stream routing
     topic: String,
-    /// DH-derived HMAC key for authenticated stream blocks
+    /// Key-exchange-derived HMAC key for authenticated stream blocks
     mac_key: [u8; 32],
-    /// DH-derived AES-256-GCM key for transport-level AEAD of payloads (#321).
-    /// `Some` only on the DH path (`from_dh`): the mesh/networked stream plane
+    /// Key-exchange-derived AES-256-GCM key for transport-level AEAD of payloads (#321).
+    /// `Some` on both keyed paths: identified hybrid streams and the explicitly
+    /// named third-party interoperability DH edge. The mesh/networked stream plane
     /// seals each Data/Complete payload under this key. `None` on the keyless
     /// `new()` path (e.g. NotificationService topics, whose payloads are already
     /// E2E-encrypted at the app layer), where transport AEAD is not applied.
     enc_key: Option<[u8; 32]>,
-    /// Server's ephemeral public key - client needs this for DH
+    /// Server's ephemeral public key for the third-party interoperability DH edge.
     server_pubkey: [u8; 32],
-    /// DH-derived control channel topic (64 hex chars)
+    /// Key-exchange-derived control channel topic (64 hex chars)
     ctrl_topic: String,
-    /// DH-derived control channel HMAC key
+    /// Key-exchange-derived control channel HMAC key
     ctrl_mac_key: [u8; 32],
     /// Cancellation token — fired by control listener or JWT expiry
     cancel_token: CancellationToken,
@@ -229,7 +232,8 @@ pub struct StreamContext {
     /// [`StreamChannel::with_reach_config`] populates this so the base (iroh/QUIC)
     /// reach is per-stream too, not just `relay_choice`.
     ///
-    /// When no explicit config is threaded, [`from_dh`](Self::from_dh) seeds it
+    /// When no explicit config is threaded, the third-party interoperability
+    /// constructor seeds it
     /// from an empty [`ProducerReachConfig`](crate::moq_stream::ProducerReachConfig) — a
     /// one-time per-stream snapshot (the documented compat source), not a
     /// per-`reach()`-call global read.
@@ -238,7 +242,8 @@ pub struct StreamContext {
     /// Hybrid KEM ciphertexts to emit in `StreamInfo.kemCiphertexts` (S3 #554).
     /// `Some` on the hybrid post-quantum path
     /// ([`from_hybrid_identified`](Self::from_hybrid_identified));
-    /// `None` on the legacy classical [`from_dh`](Self::from_dh) and the keyless
+    /// `None` on the legacy classical
+    /// [`from_third_party_interop_dh`](Self::from_third_party_interop_dh) and the keyless
     /// [`new`](Self::new) paths.
     kem_ciphertexts: Option<Vec<u8>>,
     /// Shared one-shot identified producer state. The outer `Option` is a
@@ -278,7 +283,13 @@ impl StreamContext {
         }
     }
 
-    /// Create stream context by performing DH key exchange.
+    /// Create a stream context for the explicitly named third-party
+    /// interoperability edge by performing a classical DH key exchange.
+    ///
+    /// Same-cell and federated callers must use
+    /// [`Self::from_hybrid_identified`] instead.  Keeping this constructor
+    /// explicitly named prevents a verified HyKEM recipient from being
+    /// silently downgraded to classical AEAD.
     ///
     /// # Arguments
     /// * `client_ephemeral_pubkey` - Client's ephemeral public key from request
@@ -286,7 +297,7 @@ impl StreamContext {
     /// # Returns
     /// Stream context with DH-derived topic and mac_key
     #[cfg(not(feature = "fips"))]
-    pub fn from_dh(client_ephemeral_pubkey: &[u8]) -> Result<Self> {
+    pub fn from_third_party_interop_dh(client_ephemeral_pubkey: &[u8]) -> Result<Self> {
         use crate::crypto::generate_ephemeral_keypair;
 
         let (server_secret, server_pubkey) = generate_ephemeral_keypair();
@@ -333,7 +344,8 @@ impl StreamContext {
     /// client's ephemeral keypair (X25519 + ML-KEM legs).
     ///
     /// Fail-closed: a malformed / wrong-suite `client_kem_public` is rejected.
-    /// This is the post-quantum replacement for [`from_dh`](Self::from_dh).
+    /// This is the required path for same-cell and federated callers with a
+    /// verified identified-stream recipient.
     pub fn from_hybrid_identified(
         client_kem_public: &[u8],
         binding: crate::stream_epoch::IdentifiedStreamBinding,
@@ -411,7 +423,7 @@ impl StreamContext {
         &self.stream_id
     }
 
-    /// Get the DH-derived topic (for ZMQ routing).
+    /// Get the key-exchange-derived topic (for stream routing).
     pub fn topic(&self) -> &str {
         &self.topic
     }
@@ -421,10 +433,11 @@ impl StreamContext {
         &self.mac_key
     }
 
-    /// Get the transport AEAD key (#321), if this is a DH-keyed stream.
+    /// Get the transport AEAD key (#321), if this is a keyed stream.
     ///
-    /// `Some` on the DH path (mesh/networked stream — AEAD ON), `None` on the
-    /// keyless `new()` path (payloads already E2E-encrypted at the app layer).
+    /// `Some` on identified hybrid and third-party interoperability streams
+    /// (AEAD ON), `None` on the keyless `new()` path (payloads already
+    /// E2E-encrypted at the app layer).
     pub fn enc_key(&self) -> Option<&[u8; 32]> {
         self.enc_key.as_ref()
     }
@@ -441,7 +454,7 @@ impl StreamContext {
         self
     }
 
-    /// Get the server's ephemeral public key (client needs this for DH).
+    /// Get the server's ephemeral public key for the interoperability DH edge.
     pub fn server_pubkey(&self) -> &[u8; 32] {
         &self.server_pubkey
     }
@@ -498,7 +511,8 @@ impl StreamContext {
     /// Supplies the per-server [`ProducerReachConfig`](crate::moq_stream::ProducerReachConfig)
     /// for this stream,
     /// so the base (iroh/QUIC) reach this stream advertises is the server's own —
-    /// [`StreamChannel::prepare_stream_with_claims`] applies its current service
+    /// [`StreamChannel::prepare_identified_stream_with_claims`] and
+    /// [`StreamChannel::prepare_third_party_interop_stream_with_claims`] apply their current service
     /// config before it returns the context.
     pub fn with_reach_config(
         mut self,
@@ -652,7 +666,7 @@ pub use crate::stream_consumer::StreamVerifier;
 ///
 /// `StreamChannel` handles the complexity of:
 /// - Async PUSH socket creation and lazy initialization (via tmq)
-/// - DH key exchange via `StreamContext::from_dh()`
+/// - identified hybrid key exchange via `StreamContext::from_hybrid_identified()`
 /// - Stream pre-authorization with StreamService
 /// - Endpoint discovery via the registry
 ///
@@ -662,8 +676,10 @@ pub use crate::stream_consumer::StreamVerifier;
 /// // In service initialization
 /// let stream_channel = StreamChannel::new(signing_key.clone());
 ///
-/// // In request handler
-/// let stream_ctx = stream_channel.prepare_stream(&client_pubkey, 600).await?;
+/// // In a same-cell/federated request handler, after accepting the binding:
+/// let stream_ctx = stream_channel
+///     .prepare_identified_stream(&envelope_ctx, binding, 600)
+///     .await?;
 ///
 /// // In async context
 /// let mut publisher = stream_channel.publisher(&stream_ctx).await?;
@@ -746,56 +762,130 @@ impl StreamChannel {
         self
     }
 
-    /// Prepare a stream with DH key exchange and pre-authorization.
+    /// Prepare an identified stream with the pinned hybrid post-quantum
+    /// handshake and pre-authorization.
     ///
     /// This method:
-    /// 1. Performs DH key exchange to derive topic and MAC key
-    /// 2. Pre-authorizes the stream with StreamService
+    /// 1. Uses the authenticated recipient from the verified envelope
+    /// 2. Binds it to the accepted identified-stream state before deriving keys
+    /// 3. Pre-authorizes the stream with StreamService
     ///
     /// # Arguments
-    /// * `client_ephemeral_pubkey` - Client's ephemeral public key (32 bytes)
+    /// * `envelope_ctx` - Verified request context containing the HyKEM recipient
+    /// * `binding` - Accepted-current identity, capability, route, and epoch binding
     /// * `expiry_secs` - Stream expiration in seconds from now
     ///
     /// # Returns
     /// `StreamContext` ready for publishing
-    pub async fn prepare_stream(
+    pub async fn prepare_identified_stream(
         &self,
-        client_ephemeral_pubkey: &[u8],
+        envelope_ctx: &crate::service::EnvelopeContext,
+        binding: crate::stream_epoch::IdentifiedStreamBinding,
         expiry_secs: i64,
     ) -> Result<StreamContext> {
-        self.prepare_stream_with_claims(client_ephemeral_pubkey, expiry_secs, None)
+        self.prepare_identified_stream_with_claims(envelope_ctx, binding, expiry_secs, None)
             .await
     }
 
-    /// Prepare a stream with DH key exchange, pre-authorization, and claims.
+    /// Prepare an identified stream with claims.
     ///
-    /// Same as `prepare_stream()` but allows passing user claims for authorization.
-    /// Claims are forwarded to StreamService for subscription-time validation.
+    /// The recipient is read only from the verified [`crate::service::EnvelopeContext`];
+    /// callers must supply the accepted-current binding.  This API deliberately
+    /// has no classical fallback: a request with a verified HyKEM recipient is
+    /// never downgraded to a DH-derived stream.
     ///
     /// # Arguments
-    /// * `client_ephemeral_pubkey` - Client's ephemeral public key (32 bytes)
+    /// * `envelope_ctx` - Verified request context containing the HyKEM recipient
+    /// * `binding` - Accepted-current identity, capability, route, and epoch binding
     /// * `expiry_secs` - Stream expiration in seconds from now
     /// * `claims` - Optional user claims for authorization
     ///
     /// # Returns
     /// `StreamContext` ready for publishing
-    pub async fn prepare_stream_with_claims(
+    pub async fn prepare_identified_stream_with_claims(
+        &self,
+        envelope_ctx: &crate::service::EnvelopeContext,
+        binding: crate::stream_epoch::IdentifiedStreamBinding,
+        expiry_secs: i64,
+        claims: Option<Claims>,
+    ) -> Result<StreamContext> {
+        let recipient = envelope_ctx.stream_kem_recipient().ok_or_else(|| {
+            anyhow::anyhow!(
+                "identified stream preparation requires a verified HyKEM recipient in the request envelope"
+            )
+        })?;
+        self.prepare_identified_stream_for_verified_recipient_with_claims(
+            recipient,
+            binding,
+            expiry_secs,
+            claims,
+        )
+        .await
+    }
+
+    /// Perform identified setup after the envelope verification chokepoint has
+    /// yielded the recipient.  Keeping this seam private prevents arbitrary
+    /// request bytes from being treated as an authenticated recipient while
+    /// making the no-downgrade property directly testable.
+    async fn prepare_identified_stream_for_verified_recipient_with_claims(
+        &self,
+        recipient: &crate::crypto::hybrid_kem::RecipientPublic,
+        binding: crate::stream_epoch::IdentifiedStreamBinding,
+        expiry_secs: i64,
+        _claims: Option<Claims>,
+    ) -> Result<StreamContext> {
+        let stream_ctx = StreamContext::from_hybrid_identified(&recipient.encode(), binding)?
+            .with_reach_config(self.reach_config.read().clone());
+
+        self.arm_expiry(&stream_ctx, expiry_secs);
+
+        Ok(stream_ctx)
+    }
+
+    /// Prepare a legacy stream for an explicitly selected third-party
+    /// interoperability peer.
+    ///
+    /// This is the only `StreamChannel` entry point that uses classical DH.
+    /// Same-cell and federated callers must use
+    /// [`Self::prepare_identified_stream`] with their verified envelope and
+    /// accepted [`crate::stream_epoch::IdentifiedStreamBinding`].
+    pub async fn prepare_third_party_interop_stream(
+        &self,
+        client_ephemeral_pubkey: &[u8],
+        expiry_secs: i64,
+    ) -> Result<StreamContext> {
+        self.prepare_third_party_interop_stream_with_claims(
+            client_ephemeral_pubkey,
+            expiry_secs,
+            None,
+        )
+        .await
+    }
+
+    /// Same as [`Self::prepare_third_party_interop_stream`], with optional
+    /// authorization claims for the legacy third-party interoperability edge.
+    pub async fn prepare_third_party_interop_stream_with_claims(
         &self,
         client_ephemeral_pubkey: &[u8],
         expiry_secs: i64,
         _claims: Option<Claims>,
     ) -> Result<StreamContext> {
-        let stream_ctx = StreamContext::from_dh(client_ephemeral_pubkey)?
+        let stream_ctx = StreamContext::from_third_party_interop_dh(client_ephemeral_pubkey)?
             .with_reach_config(self.reach_config.read().clone());
 
+        self.arm_expiry(&stream_ctx, expiry_secs);
+
+        Ok(stream_ctx)
+    }
+
+    /// Spawn the universal stream-expiry backstop after key setup succeeds.
+    fn arm_expiry(&self, stream_ctx: &StreamContext, expiry_secs: i64) {
         // Spawn JWT expiry timeout as universal backstop.
         let token = stream_ctx.cancel_token().clone();
         tokio::spawn(async move {
             tokio::time::sleep(std::time::Duration::from_secs(expiry_secs.max(0) as u64)).await;
             token.cancel();
         });
-
-        Ok(stream_ctx)
     }
 
     /// Register a topic with the stream plane.
@@ -927,7 +1017,10 @@ impl StreamChannel {
 ///
 /// ```ignore
 /// fn handle_clone_stream(&self, ...) -> Result<ResponseStream<CloneTask>> {
-///     let stream_ctx = self.stream_channel.prepare_stream(&pubkey, 600)?;
+///     let stream_ctx = self
+///         .stream_channel
+///         .prepare_third_party_interop_stream(&pubkey, 600)
+///         .await?;
 ///
 ///     let response = build_response(request_id, &stream_ctx);
 ///
@@ -1220,7 +1313,8 @@ fn pubkey_to_32(pubkey: &[u8]) -> [u8; 32] {
 
 /// Derive the `(mac_key, enc_key, topic)` triple from a client-side DH exchange (#321).
 ///
-/// This is the consumer-side counterpart to `StreamContext::from_dh` (the server side).
+/// This is the consumer-side counterpart to
+/// `StreamContext::from_third_party_interop_dh` (the server side).
 /// Call this before constructing a `MoqStreamHandle` when you have the raw keys from
 /// `generate_ephemeral_keypair()` and the server pubkey from `StreamInfo`.
 pub fn derive_client_stream_keys(
@@ -1417,10 +1511,10 @@ mod tests {
         let (_, client_pub) = crate::crypto::generate_ephemeral_keypair();
 
         let stream_a = channel_a
-            .prepare_stream(&client_pub.to_bytes(), 60)
+            .prepare_third_party_interop_stream(&client_pub.to_bytes(), 60)
             .await?;
         let stream_b = channel_b
-            .prepare_stream(&client_pub.to_bytes(), 60)
+            .prepare_third_party_interop_stream(&client_pub.to_bytes(), 60)
             .await?;
 
         let addr = |stream: &StreamContext| match &stream.reach()[0].transport {
@@ -1433,13 +1527,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn identified_preparation_uses_hybrid_material_not_interop_dh() -> Result<()> {
+        use crate::crypto::hybrid_kem::{generate_recipient, SuiteId};
+        use crate::stream_epoch::{
+            IdentifiedStreamBinding, StreamAcceptedState, StreamCarrierProfile, StreamRouteRole,
+        };
+
+        let binding = IdentifiedStreamBinding::new(
+            StreamCarrierProfile::OwnedHybridTransport,
+            StreamRouteRole::Direct,
+            "did:at9p:producer",
+            "did:at9p:consumer",
+            StreamAcceptedState {
+                identity_did: "did:at9p:producer".into(),
+                digest: [0x51; 64],
+                epoch: 7,
+            },
+            StreamAcceptedState {
+                identity_did: "did:at9p:consumer".into(),
+                digest: [0x61; 64],
+                epoch: 8,
+            },
+            "inference.generate",
+            "infer:model:qwen",
+            "local/streams/identified",
+            "did:at9p:producer#mesh-kem",
+            "urn:hyprstream:stream-client:one-shot",
+            64,
+        )?;
+        let recipient = generate_recipient(SuiteId::HyKemX25519MlKem768)?;
+        let channel = StreamChannel::new(SigningKey::from_bytes(&[4; 32]));
+
+        let stream = channel
+            .prepare_identified_stream_for_verified_recipient_with_claims(
+                &recipient.public(),
+                binding,
+                60,
+                None,
+            )
+            .await?;
+
+        assert!(stream.kem_ciphertexts().is_some());
+        assert!(stream.has_epoch_ratchet());
+        assert_eq!(stream.server_pubkey(), &[0; 32]);
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn stream_channel_uses_service_scoped_moq_origin() -> Result<()> {
         let scoped_origin = crate::moq_stream::MoqStreamOrigin::standalone().build();
         let origin_handle = std::sync::Arc::new(parking_lot::RwLock::new(Some(scoped_origin.clone())));
         let channel = StreamChannel::new(SigningKey::from_bytes(&[3; 32]))
             .with_moq_origin_handle(origin_handle);
         let (_, client_pub) = crate::crypto::generate_ephemeral_keypair();
-        let stream = channel.prepare_stream(&client_pub.to_bytes(), 60).await?;
+        let stream = channel
+            .prepare_third_party_interop_stream(&client_pub.to_bytes(), 60)
+            .await?;
         let _publisher = channel.publisher(&stream).await?;
 
         let path = scoped_origin.broadcast_path(stream.topic());

--- a/crates/hyprstream-rpc/tests/moq_networked.rs
+++ b/crates/hyprstream-rpc/tests/moq_networked.rs
@@ -60,7 +60,7 @@ async fn networked_moq_subscribe_receives_mac_verified_frames() -> Result<()> {
     // Derive the stream's DH-bound topic + MAC key; the publisher and the client
     // verifier share them exactly (the client gets them via DH in production).
     let (_client_secret, client_pub) = hyprstream_rpc::crypto::generate_ephemeral_keypair();
-    let ctx = StreamContext::from_dh(&client_pub.to_bytes())?;
+    let ctx = StreamContext::from_third_party_interop_dh(&client_pub.to_bytes())?;
     let topic = ctx.topic().to_owned();
     let mac_key = *ctx.mac_key();
     // #321: the DH path is AEAD-on; the consumer shares the same enc_key.

--- a/crates/hyprstream-rpc/tests/moq_relay_rendezvous.rs
+++ b/crates/hyprstream-rpc/tests/moq_relay_rendezvous.rs
@@ -103,7 +103,7 @@ async fn moq_relay_rendezvous() -> Result<()> {
 
     // ── Stream identity (DH-derived topic + MAC key, shared producer/consumer) ──
     let (_client_secret, client_pub) = hyprstream_rpc::crypto::generate_ephemeral_keypair();
-    let ctx = StreamContext::from_dh(&client_pub.to_bytes())?;
+    let ctx = StreamContext::from_third_party_interop_dh(&client_pub.to_bytes())?;
     let topic = ctx.topic().to_owned();
     let mac_key = *ctx.mac_key();
 
@@ -156,12 +156,13 @@ async fn moq_relay_rendezvous() -> Result<()> {
     let mut track = bc.subscribe_track(&moq_net::Track::new(STREAM_TRACK))?;
 
     // ── Publish through the relay; verify the chained-HMAC end-to-end ──────────
-    // The producer (`from_dh` ctx) seals each payload under the DH `enc_key` (#321),
+    // The producer (third-party interoperability ctx) seals each payload under the
+    // DH `enc_key` (#321),
     // so the verifier must open it with the SAME key — otherwise `Tagged` frames pass
     // through undecrypted and never become `Data`/`Complete`. Mirrors the production
     // consumers (stream_consumer.rs + moq_stream.rs all call `.with_enc_key`).
     let mut verifier = StreamVerifier::new(mac_key, topic.clone())
-        .with_enc_key(*ctx.enc_key().expect("from_dh ctx derives the AEAD enc_key (#321)"));
+        .with_enc_key(*ctx.enc_key().expect("interop DH ctx derives the AEAD enc_key (#321)"));
     let mut got: Vec<StreamPayload> = Vec::new();
 
     // Publish one group at a time and drain it so the ordered chain is observed.
@@ -312,7 +313,7 @@ async fn relay_choice_only_anonymizes_stream_end_to_end() -> Result<()> {
 
     // ── Now drive ACTUAL delivery using ONLY the advertised (relay-only) reach ──
     let (_client_secret, client_pub) = hyprstream_rpc::crypto::generate_ephemeral_keypair();
-    let ctx = StreamContext::from_dh(&client_pub.to_bytes())?;
+    let ctx = StreamContext::from_third_party_interop_dh(&client_pub.to_bytes())?;
     let topic = ctx.topic().to_owned();
     let mac_key = *ctx.mac_key();
 
@@ -358,12 +359,13 @@ async fn relay_choice_only_anonymizes_stream_end_to_end() -> Result<()> {
     .ok_or_else(|| anyhow!("broadcast not announced via relay"))?;
     let track = bc.subscribe_track(&moq_net::Track::new(STREAM_TRACK))?;
 
-    // The producer (`from_dh` ctx) seals each payload under the DH `enc_key` (#321),
+    // The producer (third-party interoperability ctx) seals each payload under the
+    // DH `enc_key` (#321),
     // so the verifier must open it with the SAME key — otherwise `Tagged` frames pass
     // through undecrypted and never become `Data`/`Complete`. Mirrors the production
     // consumers (stream_consumer.rs + moq_stream.rs all call `.with_enc_key`).
     let mut verifier = StreamVerifier::new(mac_key, topic.clone())
-        .with_enc_key(*ctx.enc_key().expect("from_dh ctx derives the AEAD enc_key (#321)"));
+        .with_enc_key(*ctx.enc_key().expect("interop DH ctx derives the AEAD enc_key (#321)"));
     // Publish FIRST, then read the group (the moq group exists once published) —
     // matches the `next_frame` ordering in `moq_relay_rendezvous`.
     publisher.publish_data(b"anon").await?;

--- a/crates/hyprstream-rpc/tests/moq_relay_rendezvous.rs
+++ b/crates/hyprstream-rpc/tests/moq_relay_rendezvous.rs
@@ -93,7 +93,7 @@ async fn moq_relay_rendezvous() -> Result<()> {
     let relay_task = tokio::spawn(relay_rpc.run());
 
     // The producer-advertised relay reach (this is exactly the `Role::Relay`
-    // Destination `producer_reach()` emits when a relay is configured).
+    // Destination `ProducerReachConfig::reach()` emits when a relay is configured).
     let relay_pin = cert_sha256(&relay_cert);
     let relay_reach = ReachTransport::Quic(QuicReach {
         addr: relay_addr.to_string(),

--- a/crates/hyprstream-service/src/service/spawner/service.rs
+++ b/crates/hyprstream-service/src/service/spawner/service.rs
@@ -67,6 +67,7 @@ impl<S: RequestService + Send + Sync + 'static> Spawnable for UnifiedServiceConf
         let server_pubkey = signing_key.verifying_key();
         let service_name = RequestService::name(&service).to_owned();
         let reach_config_handle = service.producer_reach_config_handle();
+        let moq_origin_handle = service.moq_origin_handle();
 
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -129,6 +130,17 @@ impl<S: RequestService + Send + Sync + 'static> Spawnable for UnifiedServiceConf
                     actual_addr
                 };
                 let pin = hyprstream_rpc::transport::quinn_transport::cert_sha256(&qc.cert_chain[0]);
+                let relay_origin = qc.moq_relay.as_ref().map(|_| {
+                    hyprstream_rpc::moq_stream::MoqStreamOrigin::standalone()
+                        .with_prefix(hyprstream_rpc::moq_stream::DEFAULT_PREFIX)
+                        .build()
+                });
+                if let Some(handle) = &moq_origin_handle {
+                    *handle.write() = relay_origin.clone();
+                }
+                let moq_origin = relay_origin
+                    .clone()
+                    .or_else(|| hyprstream_rpc::moq_stream::global_moq_origin().cloned());
 
                 let mut rpc_server = hyprstream_rpc::transport::quinn_transport::QuinnRpcServer::with_capacity(
                     wt_server,
@@ -136,8 +148,9 @@ impl<S: RequestService + Send + Sync + 'static> Spawnable for UnifiedServiceConf
                     signing_key.clone(),
                     hyprstream_rpc::transport::rpc_session::DEFAULT_STREAM_LIMIT,
                 );
-                // Multiplex moq on the same endpoint when the global origin is up.
-                if let Some(origin) = hyprstream_rpc::moq_stream::global_moq_origin() {
+                // Relay-configured services get a distinct origin; other services
+                // retain the process-global origin and existing behavior.
+                if let Some(origin) = &moq_origin {
                     rpc_server = rpc_server.with_moq_consumer(origin.consumer().clone());
                     // #276: subscribe-authz + per-tenant announce scoping. The
                     // default config is permissive (no resolver, no authorizer)
@@ -195,9 +208,10 @@ impl<S: RequestService + Send + Sync + 'static> Spawnable for UnifiedServiceConf
                     cb(service_name.clone(), advertise_addr, qc.server_name.clone());
                 }
 
-                // Link each service's configured relay to the shared origin.
+                // Link a relay only to this service's scoped origin. The shared
+                // process origin would leak other services' broadcasts into it.
                 if let Some(relay) = qc.moq_relay.take() {
-                    if let Some(origin) = hyprstream_rpc::moq_stream::global_moq_origin() {
+                    if let Some(origin) = relay_origin {
                         hyprstream_rpc::moq_stream::serve_origin_to_relay_background(
                             origin.producer().clone(),
                             relay,
@@ -228,9 +242,9 @@ impl<S: RequestService + Send + Sync + 'static> Spawnable for UnifiedServiceConf
                     );
                     let iroh_secret = iroh_transport_key.to_bytes();
                     let node_id: [u8; 32] = iroh_transport_key.verifying_key().to_bytes();
-                    // moq plane: reuse the SAME global origin the quinn `/moq`
-                    // path serves, so broadcasts are visible over both transports.
-                    let moq_handler = match hyprstream_rpc::moq_stream::global_moq_origin() {
+                    // Use the same service-specific origin as the quinn `/moq`
+                    // path, so relay-scoped broadcasts remain isolated on iroh.
+                    let moq_handler = match moq_origin.as_ref() {
                         Some(origin) => {
                             let shared = hyprstream_rpc::transport::iroh_moq::OriginShared::from_pair(
                                 origin.producer().clone(),

--- a/crates/hyprstream-service/src/service/spawner/service.rs
+++ b/crates/hyprstream-service/src/service/spawner/service.rs
@@ -66,6 +66,7 @@ impl<S: RequestService + Send + Sync + 'static> Spawnable for UnifiedServiceConf
         let signing_key = RequestService::signing_key(&service);
         let server_pubkey = signing_key.verifying_key();
         let service_name = RequestService::name(&service).to_owned();
+        let reach_config_handle = service.producer_reach_config_handle();
 
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -179,39 +180,32 @@ impl<S: RequestService + Send + Sync + 'static> Spawnable for UnifiedServiceConf
                         None,
                     );
                 }
-                hyprstream_rpc::moq_stream::init_global_producer_reach(
-                    hyprstream_rpc::moq_stream::NodeStreamReach {
+                if let Some(handle) = &reach_config_handle {
+                    *handle.write() = hyprstream_rpc::moq_stream::ProducerReachConfig {
+                        iroh_node_id: None,
+                        quic_reach: Some(hyprstream_rpc::moq_stream::NodeStreamReach {
                         addr: advertise_addr,
                         server_name: qc.server_name.clone(),
                         cert_hashes: vec![pin],
-                    },
-                    // The iroh node_id is registered separately once the iroh
-                    // substrate binds (it is not known at the QUIC-bind point);
-                    // see init_global_iroh_node_id below (#357).
-                );
+                        }),
+                        relay: qc.moq_relay.clone(),
+                    };
+                }
                 if let Some(cb) = qc.on_quic_bound.take() {
                     cb(service_name.clone(), advertise_addr, qc.server_name.clone());
                 }
 
-                // #358: if a producer-chosen relay is configured, register it so
-                // `producer_reach()` advertises a `Role::Relay` reach, and link
-                // this node's streaming origin UP to the relay so subscribers can
-                // rendezvous through it without dialing the producer. Idempotent
-                // (first-wins) across services sharing the process-global origin.
+                // Link each service's configured relay to the shared origin.
                 if let Some(relay) = qc.moq_relay.take() {
-                    let registered =
-                        hyprstream_rpc::moq_stream::init_global_relay_reach(relay.clone());
-                    if registered {
-                        if let Some(origin) = hyprstream_rpc::moq_stream::global_moq_origin() {
-                            hyprstream_rpc::moq_stream::serve_origin_to_relay_background(
-                                origin.producer().clone(),
-                                relay,
-                            );
-                            tracing::info!(
-                                service = %service_name,
-                                "moq relay rendezvous enabled (announcing origin UP to relay; advertising Role::Relay reach)"
-                            );
-                        }
+                    if let Some(origin) = hyprstream_rpc::moq_stream::global_moq_origin() {
+                        hyprstream_rpc::moq_stream::serve_origin_to_relay_background(
+                            origin.producer().clone(),
+                            relay,
+                        );
+                        tracing::info!(
+                            service = %service_name,
+                            "moq relay rendezvous enabled (announcing origin UP to relay)"
+                        );
                     }
                 }
 
@@ -264,10 +258,9 @@ impl<S: RequestService + Send + Sync + 'static> Spawnable for UnifiedServiceConf
                             let _ = hyprstream_rpc::transport::lazy_iroh::install_iroh_client_endpoint(
                                 substrate.owned_client_endpoint(),
                             );
-                            // #357: register our iroh node_id so producer_reach()
-                            // advertises an iroh-direct Destination for native
-                            // peers (dial-by-node_id via pkarr; NAT + cross-instance).
-                            let _ = hyprstream_rpc::moq_stream::init_global_iroh_node_id(node_id);
+                            if let Some(handle) = &reach_config_handle {
+                                handle.write().iroh_node_id = Some(node_id);
+                            }
                             // Advertise iroh reachability only now that the carrier
                             // is bound; EndpointId is never application authority.
                             if let Some(cb) = qc.on_iroh_bound.take() {

--- a/crates/hyprstream-workers/src/runtime/service.rs
+++ b/crates/hyprstream-workers/src/runtime/service.rs
@@ -147,7 +147,10 @@ impl WorkerService {
         // Create event publisher for worker lifecycle events
         let event_publisher = EventPublisher::new("worker")?;
 
-        let stream_channel = Arc::new(StreamChannel::new(signing_key.clone()));
+        let stream_channel = Arc::new(
+            StreamChannel::new(signing_key.clone())
+                .with_reach_config(hyprstream_rpc::moq_stream::ProducerReachConfig::default()),
+        );
         Ok(Self {
             sandbox_pool,
             image_store,
@@ -1417,6 +1420,10 @@ impl WorkerHandler for WorkerService {
 
 #[async_trait(?Send)]
 impl RequestService for WorkerService {
+    fn producer_reach_config_handle(&self) -> Option<hyprstream_rpc::moq_stream::ProducerReachConfigHandle> {
+        Some(self.stream_channel.reach_config_handle())
+    }
+
     async fn handle_request(&self, ctx: &EnvelopeContext, payload: &[u8]) -> AnyhowResult<(Vec<u8>, Option<hyprstream_rpc::service::Continuation>)> {
         debug!(
             "Worker request from {} (request_id={})",

--- a/crates/hyprstream-workers/src/runtime/service.rs
+++ b/crates/hyprstream-workers/src/runtime/service.rs
@@ -909,7 +909,7 @@ impl WorkerService {
 
         // DH + pre-authorization via StreamChannel — atomic, no pending state
         let stream_ctx = self.stream_channel
-            .prepare_stream_with_claims(&client_pubkey, 600, claims).await
+            .prepare_third_party_interop_stream_with_claims(&client_pubkey, 600, claims).await
             .map_err(|e| anyhow::anyhow!("Stream preparation failed: {}", e))?
             .with_qos_preset::<hyprstream_rpc::stream_info::Pipe>();
 

--- a/crates/hyprstream-workers/src/runtime/service.rs
+++ b/crates/hyprstream-workers/src/runtime/service.rs
@@ -1424,6 +1424,10 @@ impl RequestService for WorkerService {
         Some(self.stream_channel.reach_config_handle())
     }
 
+    fn moq_origin_handle(&self) -> Option<hyprstream_rpc::moq_stream::MoqStreamOriginHandle> {
+        Some(self.stream_channel.moq_origin_handle())
+    }
+
     async fn handle_request(&self, ctx: &EnvelopeContext, payload: &[u8]) -> AnyhowResult<(Vec<u8>, Option<hyprstream_rpc::service::Continuation>)> {
         debug!(
             "Worker request from {} (request_id={})",

--- a/crates/hyprstream/src/services/inference.rs
+++ b/crates/hyprstream/src/services/inference.rs
@@ -380,7 +380,8 @@ impl InferenceService {
         };
 
         // Create StreamChannel upfront.
-        let stream_channel = StreamChannel::new(signing_key.clone());
+        let stream_channel = StreamChannel::new(signing_key.clone())
+            .with_reach_config(hyprstream_rpc::moq_stream::ProducerReachConfig::default());
 
         Ok(InferenceService {
             inner: Arc::new(InferenceServiceInner {

--- a/crates/hyprstream/src/services/inference.rs
+++ b/crates/hyprstream/src/services/inference.rs
@@ -570,7 +570,8 @@ impl InferenceService {
     /// This is the first phase of streaming that runs BEFORE the REP response is sent.
     /// The actual streaming happens in `execute_stream` which runs AFTER the response.
     ///
-    /// Uses `StreamContext::from_dh()` from hyprstream-rpc for DH key exchange:
+    /// Uses the explicitly named third-party interoperability DH edge from
+    /// hyprstream-rpc when no accepted identified-stream binding is available:
     /// 1. Server generates ephemeral Ristretto255 keypair
     /// 2. Server computes shared secret: DH(server_secret, client_ephemeral_pubkey)
     /// 3. Both parties derive topic and mac_key from shared secret using HKDF
@@ -608,7 +609,7 @@ impl InferenceService {
             .ok_or_else(|| anyhow!("StreamChannel not initialized"))?;
 
         let stream_ctx = stream_channel
-            .prepare_stream_with_claims(client_pub_bytes, expiry_secs, claims)
+            .prepare_third_party_interop_stream_with_claims(client_pub_bytes, expiry_secs, claims)
             .await?
             .with_qos_preset::<hyprstream_rpc::stream_info::Job>();
 
@@ -1069,7 +1070,7 @@ impl InferenceService {
         let claims = ctx.claims().cloned();
 
         let stream_ctx = stream_channel
-            .prepare_stream_with_claims(client_pub_ref, expiry_secs, claims)
+            .prepare_third_party_interop_stream_with_claims(client_pub_ref, expiry_secs, claims)
             .await?
             .with_qos_preset::<hyprstream_rpc::stream_info::Job>();
 
@@ -2130,7 +2131,7 @@ impl InferenceHandler for InferenceService {
         let claims = ctx.claims().cloned();
 
         let stream_ctx = stream_channel
-            .prepare_stream_with_claims(client_pub_ref, expiry_secs, claims)
+            .prepare_third_party_interop_stream_with_claims(client_pub_ref, expiry_secs, claims)
             .await?
             .with_qos_preset::<hyprstream_rpc::stream_info::Job>();
 

--- a/crates/hyprstream/src/services/metrics.rs
+++ b/crates/hyprstream/src/services/metrics.rs
@@ -596,6 +596,10 @@ impl RequestService for MetricsService {
         Some(self.inner.stream_channel.reach_config_handle())
     }
 
+    fn moq_origin_handle(&self) -> Option<hyprstream_rpc::moq_stream::MoqStreamOriginHandle> {
+        Some(self.inner.stream_channel.moq_origin_handle())
+    }
+
     async fn handle_request(
         &self,
         ctx: &EnvelopeContext,

--- a/crates/hyprstream/src/services/metrics.rs
+++ b/crates/hyprstream/src/services/metrics.rs
@@ -316,7 +316,7 @@ impl MetricsHandler for MetricsService {
         let stream_ctx = self
             .inner
             .stream_channel
-            .prepare_stream(&q.ephemeral_pubkey, 600)
+            .prepare_third_party_interop_stream(&q.ephemeral_pubkey, 600)
             .await?;
 
         let broadcast_path = hyprstream_rpc::moq_stream::global_moq_origin()

--- a/crates/hyprstream/src/services/metrics.rs
+++ b/crates/hyprstream/src/services/metrics.rs
@@ -68,7 +68,8 @@ impl MetricsService {
         signing_key: SigningKey,
         policy_client: PolicyClient,
     ) -> Self {
-        let stream_channel = StreamChannel::new(signing_key.clone());
+        let stream_channel = StreamChannel::new(signing_key.clone())
+            .with_reach_config(hyprstream_rpc::moq_stream::ProducerReachConfig::default());
         Self {
             inner: Arc::new(MetricsInner {
                 orchestrator,
@@ -591,6 +592,10 @@ impl MetricsHandler for MetricsService {
 
 #[async_trait(?Send)]
 impl RequestService for MetricsService {
+    fn producer_reach_config_handle(&self) -> Option<hyprstream_rpc::moq_stream::ProducerReachConfigHandle> {
+        Some(self.inner.stream_channel.reach_config_handle())
+    }
+
     async fn handle_request(
         &self,
         ctx: &EnvelopeContext,

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -809,7 +809,9 @@ impl RegistryService {
             .with_moq_origin_handle(self.moq_origin.clone());
 
         // 10 minutes expiry for clone operations
-        let stream_ctx = stream_channel.prepare_stream(client_pub_bytes, 600).await?;
+        let stream_ctx = stream_channel
+            .prepare_third_party_interop_stream(client_pub_bytes, 600)
+            .await?;
 
         debug!(
             stream_id = %stream_ctx.stream_id(),
@@ -1048,7 +1050,9 @@ impl RegistryService {
             .with_reach_config_handle(self.reach_config.clone())
             .with_moq_origin_handle(self.moq_origin.clone());
         // 10 minutes expiry — weights are GB-scale.
-        let stream_ctx = stream_channel.prepare_stream(client_pub_bytes, 600).await?;
+        let stream_ctx = stream_channel
+            .prepare_third_party_interop_stream(client_pub_bytes, 600)
+            .await?;
 
         debug!(
             stream_id = %stream_ctx.stream_id(),

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -326,6 +326,7 @@ pub struct RegistryService {
     transport: TransportConfig,
     signing_key: SigningKey,
     reach_config: hyprstream_rpc::moq_stream::ProducerReachConfigHandle,
+    moq_origin: hyprstream_rpc::moq_stream::MoqStreamOriginHandle,
     /// 9P fid table for filesystem operations.
     fid_table: Arc<FidTable>,
     /// Cached contained roots for worktrees: (repo_id, worktree_name) → ContainedFs.
@@ -419,6 +420,7 @@ impl RegistryService {
             reach_config: Arc::new(parking_lot::RwLock::new(
                 hyprstream_rpc::moq_stream::ProducerReachConfig::default(),
             )),
+            moq_origin: Arc::new(parking_lot::RwLock::new(None)),
             fid_table,
             contained_roots: DashMap::new(),
             editing_table,
@@ -803,7 +805,8 @@ impl RegistryService {
         // Create StreamChannel for DH key exchange and publishing
         let stream_channel = StreamChannel::new(self.signing_key.clone())
             .with_reach_config(hyprstream_rpc::moq_stream::ProducerReachConfig::default())
-            .with_reach_config_handle(self.reach_config.clone());
+            .with_reach_config_handle(self.reach_config.clone())
+            .with_moq_origin_handle(self.moq_origin.clone());
 
         // 10 minutes expiry for clone operations
         let stream_ctx = stream_channel.prepare_stream(client_pub_bytes, 600).await?;
@@ -1042,7 +1045,8 @@ impl RegistryService {
 
         let stream_channel = StreamChannel::new(self.signing_key.clone())
             .with_reach_config(hyprstream_rpc::moq_stream::ProducerReachConfig::default())
-            .with_reach_config_handle(self.reach_config.clone());
+            .with_reach_config_handle(self.reach_config.clone())
+            .with_moq_origin_handle(self.moq_origin.clone());
         // 10 minutes expiry — weights are GB-scale.
         let stream_ctx = stream_channel.prepare_stream(client_pub_bytes, 600).await?;
 
@@ -3162,6 +3166,10 @@ impl WorktreeHandler for RegistryService {
 impl RequestService for RegistryService {
     fn producer_reach_config_handle(&self) -> Option<hyprstream_rpc::moq_stream::ProducerReachConfigHandle> {
         Some(self.reach_config.clone())
+    }
+
+    fn moq_origin_handle(&self) -> Option<hyprstream_rpc::moq_stream::MoqStreamOriginHandle> {
+        Some(self.moq_origin.clone())
     }
 
     async fn handle_request(&self, ctx: &EnvelopeContext, payload: &[u8]) -> Result<(Vec<u8>, Option<crate::services::Continuation>)> {

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -325,6 +325,7 @@ pub struct RegistryService {
     // Infrastructure (for Spawnable)
     transport: TransportConfig,
     signing_key: SigningKey,
+    reach_config: hyprstream_rpc::moq_stream::ProducerReachConfigHandle,
     /// 9P fid table for filesystem operations.
     fid_table: Arc<FidTable>,
     /// Cached contained roots for worktrees: (repo_id, worktree_name) → ContainedFs.
@@ -415,6 +416,9 @@ impl RegistryService {
             policy_client,
             transport,
             signing_key,
+            reach_config: Arc::new(parking_lot::RwLock::new(
+                hyprstream_rpc::moq_stream::ProducerReachConfig::default(),
+            )),
             fid_table,
             contained_roots: DashMap::new(),
             editing_table,
@@ -797,7 +801,9 @@ impl RegistryService {
             .ok_or_else(|| anyhow!("Streaming requires client ephemeral pubkey for E2E authentication"))?;
 
         // Create StreamChannel for DH key exchange and publishing
-        let stream_channel = StreamChannel::new(self.signing_key.clone());
+        let stream_channel = StreamChannel::new(self.signing_key.clone())
+            .with_reach_config(hyprstream_rpc::moq_stream::ProducerReachConfig::default())
+            .with_reach_config_handle(self.reach_config.clone());
 
         // 10 minutes expiry for clone operations
         let stream_ctx = stream_channel.prepare_stream(client_pub_bytes, 600).await?;
@@ -1034,7 +1040,9 @@ impl RegistryService {
         let client_pub_bytes = client_ephemeral_pubkey
             .ok_or_else(|| anyhow!("Streaming requires client ephemeral pubkey for E2E authentication"))?;
 
-        let stream_channel = StreamChannel::new(self.signing_key.clone());
+        let stream_channel = StreamChannel::new(self.signing_key.clone())
+            .with_reach_config(hyprstream_rpc::moq_stream::ProducerReachConfig::default())
+            .with_reach_config_handle(self.reach_config.clone());
         // 10 minutes expiry — weights are GB-scale.
         let stream_ctx = stream_channel.prepare_stream(client_pub_bytes, 600).await?;
 
@@ -1051,7 +1059,7 @@ impl RegistryService {
             stream_id: stream_ctx.stream_id().to_owned(),
             dh_public: *stream_ctx.server_pubkey(),
             broadcast_path,
-            announced_at: hyprstream_rpc::moq_stream::producer_reach(),
+            announced_at: stream_ctx.reach(),
             ..Default::default()
         };
 
@@ -3152,6 +3160,10 @@ impl WorktreeHandler for RegistryService {
 
 #[async_trait(?Send)]
 impl RequestService for RegistryService {
+    fn producer_reach_config_handle(&self) -> Option<hyprstream_rpc::moq_stream::ProducerReachConfigHandle> {
+        Some(self.reach_config.clone())
+    }
+
     async fn handle_request(&self, ctx: &EnvelopeContext, payload: &[u8]) -> Result<(Vec<u8>, Option<crate::services::Continuation>)> {
         dispatch_registry(self, ctx, payload).await
     }

--- a/crates/hyprstream/src/tui/service.rs
+++ b/crates/hyprstream/src/tui/service.rs
@@ -347,7 +347,7 @@ impl TuiService {
             // The blocks remain HMAC-chain authenticated. (AEAD stays mandatory + ON
             // for the DH-keyed mesh inference stream, whose consumer derives enc_key.)
             match ctx.ephemeral_pubkey() {
-                Some(pubkey) => Ok(StreamContext::from_dh(&pubkey)?
+                Some(pubkey) => Ok(StreamContext::from_third_party_interop_dh(&pubkey)?
                     .without_aead()
                     .with_reach_config(reach_config.clone())),
                 None => {

--- a/crates/hyprstream/src/tui/service.rs
+++ b/crates/hyprstream/src/tui/service.rs
@@ -141,6 +141,8 @@ pub struct TuiService {
     signing_key: SigningKey,
     /// Bound reach for streams served by this TUI instance.
     reach_config: hyprstream_rpc::moq_stream::ProducerReachConfigHandle,
+    /// Optional relay-scoped MoQ origin for this TUI instance.
+    moq_origin: hyprstream_rpc::moq_stream::MoqStreamOriginHandle,
     /// Per-session viewer registration channels + frame loop tokens.
     sessions: SessionRegistry,
     /// Per-viewer stdin queues (for pollStdin RPC).
@@ -175,6 +177,7 @@ impl TuiService {
             reach_config: Arc::new(parking_lot::RwLock::new(
                 hyprstream_rpc::moq_stream::ProducerReachConfig::default(),
             )),
+            moq_origin: Arc::new(parking_lot::RwLock::new(None)),
             sessions: Arc::new(RwLock::new(HashMap::new())),
             stdin_queues: Arc::new(parking_lot::Mutex::new(HashMap::new())),
             policy_client: None,
@@ -402,6 +405,7 @@ impl TuiService {
         let sk = self.signing_key.clone();
         let stdin_queues = Arc::clone(&self.stdin_queues);
         let reach_config = self.reach_config.clone();
+        let moq_origin = self.moq_origin.clone();
         let continuation: Continuation = Box::pin(async move {
             let mut reg = sessions_reg.write().await;
             let (sender, _cancel) = reg.entry(sid).or_insert_with(|| {
@@ -411,7 +415,7 @@ impl TuiService {
                 let s = Arc::clone(&tui_state);
                 let c = cancel.clone();
                 let sq = Arc::clone(&stdin_queues);
-                tokio::task::spawn_local(run_frame_loop(s, sid, rx, sk, c, sq, reach_config));
+                tokio::task::spawn_local(run_frame_loop(s, sid, rx, sk, c, sq, reach_config, moq_origin));
                 info!(session_id = sid, "Frame loop spawned");
                 (tx, cancel)
             });
@@ -1698,6 +1702,10 @@ impl RequestService for TuiService {
         Some(self.reach_config.clone())
     }
 
+    fn moq_origin_handle(&self) -> Option<hyprstream_rpc::moq_stream::MoqStreamOriginHandle> {
+        Some(self.moq_origin.clone())
+    }
+
     async fn handle_request(
         &self,
         _ctx: &EnvelopeContext,
@@ -1880,6 +1888,7 @@ pub(crate) async fn run_frame_loop(
     cancel: CancellationToken,
     stdin_queues: StdinQueues,
     reach_config: hyprstream_rpc::moq_stream::ProducerReachConfigHandle,
+    moq_origin: hyprstream_rpc::moq_stream::MoqStreamOriginHandle,
 ) {
     let mut interval = tokio::time::interval(std::time::Duration::from_millis(33));
     let mut event_rx = {
@@ -1904,7 +1913,8 @@ pub(crate) async fn run_frame_loop(
     // StreamChannel for creating publisher sockets (ZMQ or moq, auto-dispatched).
     let stream_channel = StreamChannel::new(signing_key)
         .with_reach_config(hyprstream_rpc::moq_stream::ProducerReachConfig::default())
-        .with_reach_config_handle(reach_config);
+        .with_reach_config_handle(reach_config)
+        .with_moq_origin_handle(moq_origin);
 
     info!(session_id, "Frame loop started");
 

--- a/crates/hyprstream/src/tui/service.rs
+++ b/crates/hyprstream/src/tui/service.rs
@@ -139,6 +139,8 @@ pub struct TuiService {
     transport: TransportConfig,
     /// Signing key (required by RequestService).
     signing_key: SigningKey,
+    /// Bound reach for streams served by this TUI instance.
+    reach_config: hyprstream_rpc::moq_stream::ProducerReachConfigHandle,
     /// Per-session viewer registration channels + frame loop tokens.
     sessions: SessionRegistry,
     /// Per-viewer stdin queues (for pollStdin RPC).
@@ -170,6 +172,9 @@ impl TuiService {
             next_viewer_id: AtomicU32::new(1),
             transport,
             signing_key,
+            reach_config: Arc::new(parking_lot::RwLock::new(
+                hyprstream_rpc::moq_stream::ProducerReachConfig::default(),
+            )),
             sessions: Arc::new(RwLock::new(HashMap::new())),
             stdin_queues: Arc::new(parking_lot::Mutex::new(HashMap::new())),
             policy_client: None,
@@ -331,6 +336,7 @@ impl TuiService {
         // Create FD-indexed stream contexts: [0]=stdin (input relay), [1]=stdout (frames).
         // DH key exchange derives context from client's ephemeral pubkey.
         // If no pubkey (local/test connections), generate random standalone contexts.
+        let reach_config = self.reach_config.read().clone();
         let make_stream_ctx = |label: &str| -> Result<StreamContext> {
             // #321: the TUI PTY/shell viewer receives only `(mac_key, topic)` out of
             // band (see tui_handlers / shell_handlers) and never derives the DH
@@ -338,7 +344,9 @@ impl TuiService {
             // The blocks remain HMAC-chain authenticated. (AEAD stays mandatory + ON
             // for the DH-keyed mesh inference stream, whose consumer derives enc_key.)
             match ctx.ephemeral_pubkey() {
-                Some(pubkey) => Ok(StreamContext::from_dh(&pubkey)?.without_aead()),
+                Some(pubkey) => Ok(StreamContext::from_dh(&pubkey)?
+                    .without_aead()
+                    .with_reach_config(reach_config.clone())),
                 None => {
                     use rand::RngCore;
                     let mut rng = rand::thread_rng();
@@ -351,7 +359,7 @@ impl TuiService {
                         hex::encode(topic_bytes),
                         mac_key,
                         [0u8; 32],
-                    ))
+                    ).with_reach_config(reach_config.clone()))
                 }
             }
         };
@@ -393,6 +401,7 @@ impl TuiService {
         let tui_state = Arc::clone(&self.state);
         let sk = self.signing_key.clone();
         let stdin_queues = Arc::clone(&self.stdin_queues);
+        let reach_config = self.reach_config.clone();
         let continuation: Continuation = Box::pin(async move {
             let mut reg = sessions_reg.write().await;
             let (sender, _cancel) = reg.entry(sid).or_insert_with(|| {
@@ -402,7 +411,7 @@ impl TuiService {
                 let s = Arc::clone(&tui_state);
                 let c = cancel.clone();
                 let sq = Arc::clone(&stdin_queues);
-                tokio::task::spawn_local(run_frame_loop(s, sid, rx, sk, c, sq));
+                tokio::task::spawn_local(run_frame_loop(s, sid, rx, sk, c, sq, reach_config));
                 info!(session_id = sid, "Frame loop spawned");
                 (tx, cancel)
             });
@@ -1556,14 +1565,7 @@ impl TuiService {
             connect.set_viewer_id(viewer_id);
             connect.set_session_id(session_id);
 
-            // #356: the node's network-routable moq reach (the bound QUIC `/moq`
-            // endpoint, registered when the daemon's web_transport_quinn server
-            // binds). Shared across all FD streams — they all live on this node's
-            // one moq plane. A cross-process viewer dials this reach instead of its
-            // own local moq UDS plane (see StreamInfo.announcedAt docs / connect_moq_reach).
-            // #384: TUI FD streams are node-local infrastructure → server-global
-            // reach (ServerDefault); no per-stream RelayChoice posture applies.
-            let reach = hyprstream_rpc::moq_stream::global_reach_config().reach();
+            let reach = self.reach_config.read().reach();
 
             // FD-indexed streams: [0]=stdin (input relay), [1]=stdout (frames)
             let mut stream_list = connect.reborrow().init_streams(streams.len() as u32);
@@ -1692,6 +1694,10 @@ impl TuiService {
 
 #[async_trait(?Send)]
 impl RequestService for TuiService {
+    fn producer_reach_config_handle(&self) -> Option<hyprstream_rpc::moq_stream::ProducerReachConfigHandle> {
+        Some(self.reach_config.clone())
+    }
+
     async fn handle_request(
         &self,
         _ctx: &EnvelopeContext,
@@ -1873,6 +1879,7 @@ pub(crate) async fn run_frame_loop(
     signing_key: SigningKey,
     cancel: CancellationToken,
     stdin_queues: StdinQueues,
+    reach_config: hyprstream_rpc::moq_stream::ProducerReachConfigHandle,
 ) {
     let mut interval = tokio::time::interval(std::time::Duration::from_millis(33));
     let mut event_rx = {
@@ -1895,7 +1902,9 @@ pub(crate) async fn run_frame_loop(
     let mut heartbeat_at = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
 
     // StreamChannel for creating publisher sockets (ZMQ or moq, auto-dispatched).
-    let stream_channel = StreamChannel::new(signing_key);
+    let stream_channel = StreamChannel::new(signing_key)
+        .with_reach_config(hyprstream_rpc::moq_stream::ProducerReachConfig::default())
+        .with_reach_config_handle(reach_config);
 
     info!(session_id, "Frame loop started");
 
@@ -2418,7 +2427,7 @@ mod tests {
     /// #356: the PTY StreamInfo must carry the producer's networked reach so a
     /// cross-process viewer dials the TUI service's QUIC `/moq` endpoint instead
     /// of its own local moq UDS plane. This exercises the exact encode path
-    /// `build_connect_response` uses — `producer_reach()` → `Destination::write_to`
+    /// `build_connect_response` uses — `ProducerReachConfig::reach()` → `Destination::write_to`
     /// into the tui StreamInfo capnp `announcedAt` field — and reads it back through
     /// the generated `tui_client::StreamInfo` decoder, asserting the Quic dial params
     /// survive the round-trip intact (the chat-inference fix relied on the same
@@ -2426,20 +2435,21 @@ mod tests {
     #[test]
     fn pty_stream_info_carries_dialable_reach() {
         use hyprstream_rpc::capnp::FromCapnp;
-        use hyprstream_rpc::moq_stream::{init_global_producer_reach, producer_reach, NodeStreamReach};
+        use hyprstream_rpc::moq_stream::{NodeStreamReach, ProducerReachConfig};
 
-        // Register a networked reach exactly as the QUIC bind does (idempotent —
-        // first wins; ignore the result so concurrent tests don't fail this one).
         let addr: std::net::SocketAddr = "127.0.0.1:4433".parse().expect("addr");
-        let _ = init_global_producer_reach(NodeStreamReach {
-            addr,
-            server_name: "localhost".to_owned(),
-            cert_hashes: vec![[0x11u8; 32]],
-        });
-        let reach = producer_reach();
+        let reach = ProducerReachConfig {
+            iroh_node_id: None,
+            quic_reach: Some(NodeStreamReach {
+                addr,
+                server_name: "localhost".to_owned(),
+                cert_hashes: vec![[0x11u8; 32]],
+            }),
+            relay: None,
+        }.reach();
         assert!(
             !reach.is_empty(),
-            "producer_reach() must be non-empty after registering a NodeStreamReach"
+            "local ProducerReachConfig must produce a dialable reach"
         );
 
         // Build a tui StreamInfo capnp the same way build_connect_response does.
@@ -2473,11 +2483,7 @@ mod tests {
             reach.len(),
             "decoded StreamInfo.announcedAt must round-trip the producer reach"
         );
-        // The round-tripped reach must match the registered producer reach
-        // exactly. (Compare against the captured `producer_reach()` rather than a
-        // hardcoded cert hash: the process-global `NodeStreamReach` is first-wins,
-        // so a sibling test that registers first wins the OnceLock — what matters
-        // is that the encode/decode round-trip is lossless.)
+        // The round-tripped reach must match the service-local reach exactly.
         assert_eq!(
             decoded.announced_at, reach,
             "decoded StreamInfo.announcedAt must round-trip the producer reach exactly"


### PR DESCRIPTION
Closes #502.

## Summary
- remove process-global producer, iroh, and relay reach state
- thread each service’s mutable reach handle from bind through StreamChannel construction
- add a two-service regression test proving distinct advertised QUIC reach in one process

## Validation
- cargo clippy --workspace --all-targets --features download-libtorch -- -D warnings
- cargo nextest run --cargo-profile ci-test --profile ci --features download-libtorch (3147 passed)
- focused RPC and TUI reach tests
- Python and WASI guest release builds