### PR TITLE
fix(mac): require approval for compiled policy load

### DIFF
--- a/crates/hyprstream/src/mac/bootload.rs
+++ b/crates/hyprstream/src/mac/bootload.rs
@@ -61,15 +61,18 @@ pub enum BootPolicyError {
 /// **once at load**, and install it process-globally. Returns the installed
 /// [`CompiledPolicy`].
 ///
-/// The signer and verifier use the **same** node keys: at boot the node is its
-/// own baseline-policy authority, so it self-signs and self-verifies the
-/// artifact through the full [`sign_policy`] → [`PolicyLoader::load`] path
+/// The signer and verifier use the supplied policy-authority keypair and run
+/// the artifact through the full [`sign_policy`] → [`PolicyLoader::load`] path
 /// (rather than short-circuiting the crypto). `require_pq = true` — the ML-DSA
 /// outer layer is mandatory; a classical-only signature is rejected.
 ///
 /// The caller MUST have already validated `grant`'s UCAN chain — `compile`
 /// reads only its capability set. Enrollment is the authority-owned
 /// DID→clearance table (#698), embedded in and covered by the signature.
+/// `approval` MUST come from an upstream-verified S5 approval binding (normally
+/// [`PolicyApproval::from_verified`]); this generic path never derives an
+/// approval from the policy it is loading. The loader independently recomputes
+/// the compiled policy hash and rejects a mismatched approval.
 ///
 /// ## Return: `(policy, installed)` — the write-once truth
 ///
@@ -92,24 +95,17 @@ pub enum BootPolicyError {
 /// by `generation`) is the follow-up; until then, treat `installed == false` as
 /// "the earlier policy still governs the seam", never as a successful swap.
 ///
-/// ## Key provenance (self-issued baseline, NOT a distributed trust anchor)
+/// ## Key provenance
 ///
-/// The signer and verifier are the SAME node keys and the approval is derived locally from
-/// this empty baseline, so this is a self-signed, self-approved artifact: the round-trip
-/// exercises the real hybrid `sign_composite` → `verify_composite` path but proves nothing
-/// about an external authority. The node's `ed_sk` (registry identity) and the
-/// `pq_sk` (drawn from the JWT-rotation ML-DSA store) are also a chimera pairing,
-/// not a purpose-built policy-authority key. **Before any *distributed* policy
-/// flow reuses this signer/verifier pairing, key provenance must be settled** —
-/// a dedicated policy-authority keypair whose verifying key is anchored in the
-/// PQ trust store, with `PolicyLoader::with_approval` populated from a verified S5
-/// approval — so the loader verifies against an anchored authority and an independent
-/// approval, not values derived by the same node that signed.
+/// `ed_sk` and `pq_sk` are the policy authority's hybrid signing keys. The
+/// approval is a separate reviewed binding supplied by the caller and checked
+/// independently from the artifact signature.
 pub fn compile_sign_load_install(
     grant: &Ucan,
     lattice: &Lattice,
     permissions: &impl PermissionMap,
     enrollment: BTreeMap<String, SecurityLabel>,
+    approval: PolicyApproval,
     ed_sk: &SigningKey,
     pq_sk: &MlDsaSigningKey,
 ) -> Result<(Arc<CompiledPolicy>, bool), BootPolicyError> {
@@ -117,25 +113,28 @@ pub fn compile_sign_load_install(
     // authority-owned enrollment. Both travel inside the signature.
     let policy = compile(grant, lattice, permissions).with_enrollment(enrollment);
 
+    sign_load_install(policy, approval, ed_sk, pq_sk)
+}
+
+/// Sign, verify-load, and install an already compiled policy. The approval is
+/// always explicit here: arbitrary policy compilation has no self-approval
+/// escape hatch.
+fn sign_load_install(
+    policy: CompiledPolicy,
+    approval: PolicyApproval,
+    ed_sk: &SigningKey,
+    pq_sk: &MlDsaSigningKey,
+) -> Result<(Arc<CompiledPolicy>, bool), BootPolicyError> {
     // Sign hybrid (EdDSA + ML-DSA-65 COSE composite; cose_sign::sign_composite
     // under the HybridPolicySigner adapter).
     let signer = HybridPolicySigner {
         ed_sk,
         pq_sk: Some(pq_sk),
     };
-    // The dormant boot baseline is intentionally self-issued and empty. The production
-    // distribution path must replace this locally derived approval with the verified S5
-    // approval binding described above; PolicyLoader itself never permits a sig-only load.
-    let approval = PolicyApproval {
-        generation: policy.generation,
-        approved_hash: policy.policy_hash()?,
-    };
     let signed = sign_policy(&policy, &signer)?;
 
-    // Verify ONCE at load (require_pq = true, fail-closed). Same key material —
-    // the node self-signs its baseline (see the key-provenance note above); a
-    // production distribution flow would anchor a distinct authority key instead,
-    // but the load/verify contract is identical.
+    // Verify ONCE at load (require_pq = true, fail-closed) against the policy
+    // authority keys, then independently enforce the supplied approval hash.
     let ed_vk = ed_sk.verifying_key();
     // `verifying_key` is provided by the `ml_dsa::Keypair` trait; call it
     // fully-qualified (matching `MlDsaKeySlot::verifying_key`) so this module
@@ -155,33 +154,14 @@ pub fn compile_sign_load_install(
     Ok((policy, installed))
 }
 
-/// Install the node's **dormant baseline** compiled policy at daemon boot.
-///
-/// The baseline is intentionally minimal: a self-issued empty grant over an
-/// empty lattice generation and an empty object registry, so the compiled TE
-/// matrix is empty (grants nothing) and no subject is enrolled. Its only effect
-/// is to make [`crate::mac::compiled_policy`] return `Some`, which switches the
-/// grant path's subject resolver from deny-all to the real
-/// [`EnrollmentSubjectContextResolver`](crate::mac::EnrollmentSubjectContextResolver).
-/// Enforcement stays AllowAll — this is the dormant activation prerequisite, not
-/// the enforcement flip.
-///
-/// Returns `(policy, installed)` from [`compile_sign_load_install`]. At daemon
-/// boot this is the first (and, given the `OnceLock` write-once seam, only)
-/// install, so `installed` is normally `true`; a `false` means a policy was
-/// already installed this process.
-///
-/// A future policy-authoring step (config-driven UCAN grant + enrollment) will
-/// need a **swap-capable** seam to replace this baseline at runtime — it cannot
-/// do so through the current write-once [`install_compiled_policy`] (see that
-/// function's and [`compile_sign_load_install`]'s docs). The empty baseline is
-/// the fail-closed default until that seam lands.
-pub fn install_baseline_boot_policy(
+/// Construct and install the one artifact allowed to derive its approval
+/// locally: the dormant, empty baseline. This helper accepts no grant,
+/// enrollment, lattice, permission map, or approval from its caller, so the
+/// self-approval exception cannot be reused for a non-empty policy.
+fn install_self_approved_empty_baseline(
     ed_sk: &SigningKey,
     pq_sk: &MlDsaSigningKey,
 ) -> Result<(Arc<CompiledPolicy>, bool), BootPolicyError> {
-    // Self-issued empty grant: the node is its own baseline authority and grants
-    // itself nothing. `compile` reads only the (empty) capability set.
     let did = Did::from_ed25519(&ed_sk.verifying_key().to_bytes());
     let grant = Ucan {
         payload: UcanPayload {
@@ -196,18 +176,45 @@ pub fn install_baseline_boot_policy(
         signature: vec![],
     };
 
-    // Empty lattice (generation 1) and empty object registry → empty matrix.
     let lattice = Lattice::new(LatticeVersion(1), []);
     let permissions = ScopePermissionMap::new(SubjectType(1), Vec::<(String, String)>::new());
+    let policy = compile(&grant, &lattice, &permissions).with_enrollment(BTreeMap::new());
+    let approval = PolicyApproval {
+        generation: policy.generation,
+        approved_hash: policy.policy_hash()?,
+    };
 
-    compile_sign_load_install(
-        &grant,
-        &lattice,
-        &permissions,
-        BTreeMap::new(),
-        ed_sk,
-        pq_sk,
-    )
+    sign_load_install(policy, approval, ed_sk, pq_sk)
+}
+
+/// Install the node's **dormant baseline** compiled policy at daemon boot.
+///
+/// The baseline is intentionally minimal: a self-issued empty grant over an
+/// empty lattice generation and an empty object registry, so the compiled TE
+/// matrix is empty (grants nothing) and no subject is enrolled. Its only effect
+/// is to make [`crate::mac::compiled_policy`] return `Some`, which switches the
+/// grant path's subject resolver from deny-all to the real
+/// [`EnrollmentSubjectContextResolver`](crate::mac::EnrollmentSubjectContextResolver).
+/// Enforcement stays AllowAll — this is the dormant activation prerequisite, not
+/// the enforcement flip.
+///
+/// Unlike [`compile_sign_load_install`], this path locally derives an approval;
+/// that exception is confined to a private helper which constructs the empty
+/// policy internally and accepts no caller-controlled policy inputs. At daemon
+/// boot this is the first (and, given the `OnceLock` write-once seam, only)
+/// install, so `installed` is normally `true`; a `false` means a policy was
+/// already installed this process.
+///
+/// A future policy-authoring step (config-driven UCAN grant + enrollment) will
+/// need a **swap-capable** seam to replace this baseline at runtime — it cannot
+/// do so through the current write-once [`install_compiled_policy`] (see that
+/// function's and [`compile_sign_load_install`]'s docs). The empty baseline is
+/// the fail-closed default until that seam lands.
+pub fn install_baseline_boot_policy(
+    ed_sk: &SigningKey,
+    pq_sk: &MlDsaSigningKey,
+) -> Result<(Arc<CompiledPolicy>, bool), BootPolicyError> {
+    install_self_approved_empty_baseline(ed_sk, pq_sk)
 }
 
 #[cfg(test)]
@@ -218,6 +225,7 @@ mod tests {
     use crate::mac::lattice::{Assurance, CompartmentSet, Level};
     use crate::mac::EnrollmentSubjectContextResolver;
     use crate::services::oauth::token_exchange::SubjectContextResolver as _;
+    use hyprstream_rpc::auth::ucan::approval::{ApprovalBinding, SignedApproval};
     use hyprstream_rpc::auth::ucan::capability::{Ability, Capability, Resource};
     use hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair;
     use rand::rngs::OsRng;
@@ -250,7 +258,7 @@ mod tests {
     #[test]
     fn boot_installs_policy_and_resolver_resolves_real_clearance() {
         let ed_sk = SigningKey::generate(&mut OsRng);
-        let (pq_sk, _pq_vk) = ml_dsa_generate_keypair();
+        let (pq_sk, pq_vk) = ml_dsa_generate_keypair();
 
         // A registry with one model, a grant to read it, and an enrolled subject.
         let lattice = Lattice::new(LatticeVersion(1), []);
@@ -262,11 +270,33 @@ mod tests {
             SecurityLabel::new(Level::Secret, Assurance::Classical, CompartmentSet::EMPTY);
         let enrollment = BTreeMap::from([(did.to_owned(), clearance)]);
 
+        // The generic path receives an independently signed+verified S5 binding;
+        // it never derives approval from the policy it is about to load.
+        let expected = compile(&grant, &lattice, &permissions).with_enrollment(enrollment.clone());
+        let binding =
+            ApprovalBinding::new(&grant, expected.generation, expected.policy_hash().unwrap())
+                .unwrap();
+        let signed_approval = SignedApproval::sign(binding, &ed_sk, &pq_sk).unwrap();
+        signed_approval
+            .verify_binds(
+                &ed_sk.verifying_key(),
+                &pq_vk,
+                &grant,
+                expected.generation,
+                &expected.policy_hash().unwrap(),
+            )
+            .unwrap();
+        let verified = signed_approval
+            .verify(&ed_sk.verifying_key(), &pq_vk)
+            .unwrap();
+        let approval = PolicyApproval::from_verified(verified);
+
         let (policy, _installed) = compile_sign_load_install(
             &grant,
             &lattice,
             &permissions,
             enrollment,
+            approval,
             &ed_sk,
             &pq_sk,
         )
@@ -295,6 +325,36 @@ mod tests {
 
         // An unenrolled DID still denies (fail-closed contract unchanged).
         assert!(resolver.resolve("did:key:zStranger").is_none());
+    }
+
+    #[test]
+    fn generic_bootload_rejects_mismatched_approval() {
+        let ed_sk = SigningKey::generate(&mut OsRng);
+        let (pq_sk, _pq_vk) = ml_dsa_generate_keypair();
+        let lattice = Lattice::new(LatticeVersion(7), []);
+        let permissions = ScopePermissionMap::new(SubjectType(1), [("model", "llama")]);
+        let grant = grant_with(vec![cap("mac://model/llama", "query")]);
+        let mismatched = PolicyApproval {
+            generation: 7,
+            approved_hash: [0u8; 32],
+        };
+
+        let result = compile_sign_load_install(
+            &grant,
+            &lattice,
+            &permissions,
+            BTreeMap::new(),
+            mismatched,
+            &ed_sk,
+            &pq_sk,
+        );
+
+        assert!(matches!(
+            result,
+            Err(BootPolicyError::Policy(
+                PolicyDistError::NoMatchingApproval { generation: 7 }
+            ))
+        ));
     }
 
     /// The production baseline: a self-issued empty grant compiles to an empty

--- a/crates/hyprstream/src/mac/bootload.rs
+++ b/crates/hyprstream/src/mac/bootload.rs
@@ -39,7 +39,9 @@ use hyprstream_rpc::auth::ucan::token::{Did, Ucan, UcanPayload};
 use hyprstream_rpc::crypto::pq::MlDsaSigningKey;
 
 use crate::mac::compiled::cose::{HybridPolicySigner, HybridPolicyVerifier};
-use crate::mac::compiled::{sign_policy, CompiledPolicy, PolicyDistError, PolicyLoader};
+use crate::mac::compiled::{
+    sign_policy, CompiledPolicy, PolicyApproval, PolicyDistError, PolicyLoader,
+};
 use crate::mac::compiler::{compile, PermissionMap};
 use crate::mac::lattice::{Lattice, LatticeVersion, SecurityLabel};
 use crate::mac::permission_map::ScopePermissionMap;
@@ -90,18 +92,19 @@ pub enum BootPolicyError {
 /// by `generation`) is the follow-up; until then, treat `installed == false` as
 /// "the earlier policy still governs the seam", never as a successful swap.
 ///
-/// ## Key provenance (self-issued smoke test, NOT a distributed trust anchor)
+/// ## Key provenance (self-issued baseline, NOT a distributed trust anchor)
 ///
-/// The signer and verifier are the SAME node keys and there are no approvals, so
-/// this is a self-signed, self-verified artifact: the round-trip exercises the
-/// real hybrid `sign_composite` → `verify_composite` path but proves nothing
+/// The signer and verifier are the SAME node keys and the approval is derived locally from
+/// this empty baseline, so this is a self-signed, self-approved artifact: the round-trip
+/// exercises the real hybrid `sign_composite` → `verify_composite` path but proves nothing
 /// about an external authority. The node's `ed_sk` (registry identity) and the
 /// `pq_sk` (drawn from the JWT-rotation ML-DSA store) are also a chimera pairing,
 /// not a purpose-built policy-authority key. **Before any *distributed* policy
 /// flow reuses this signer/verifier pairing, key provenance must be settled** —
 /// a dedicated policy-authority keypair whose verifying key is anchored in the
-/// PQ trust store, with `PolicyLoader::with_approval` populated — so the loader
-/// verifies against an anchored authority, not against the same key that signed.
+/// PQ trust store, with `PolicyLoader::with_approval` populated from a verified S5
+/// approval — so the loader verifies against an anchored authority and an independent
+/// approval, not values derived by the same node that signed.
 pub fn compile_sign_load_install(
     grant: &Ucan,
     lattice: &Lattice,
@@ -120,6 +123,13 @@ pub fn compile_sign_load_install(
         ed_sk,
         pq_sk: Some(pq_sk),
     };
+    // The dormant boot baseline is intentionally self-issued and empty. The production
+    // distribution path must replace this locally derived approval with the verified S5
+    // approval binding described above; PolicyLoader itself never permits a sig-only load.
+    let approval = PolicyApproval {
+        generation: policy.generation,
+        approved_hash: policy.policy_hash()?,
+    };
     let signed = sign_policy(&policy, &signer)?;
 
     // Verify ONCE at load (require_pq = true, fail-closed). Same key material —
@@ -136,7 +146,9 @@ pub fn compile_sign_load_install(
         pq_vk: Some(&pq_vk),
         require_pq: true,
     };
-    let loaded = PolicyLoader::new(verifier).load(&signed)?;
+    let loaded = PolicyLoader::new(verifier)
+        .with_approval(approval)
+        .load(&signed)?;
 
     let policy = Arc::new(loaded);
     let installed = install_compiled_policy(policy.clone());

--- a/crates/hyprstream/src/mac/compiled.rs
+++ b/crates/hyprstream/src/mac/compiled.rs
@@ -261,13 +261,14 @@ impl PolicyApproval {
     }
 }
 
-/// PEP side: verify signature + (optionally) match against an approval, then yield the
+/// PEP side: verify signature + match against an approval, then yield the
 /// [`CompiledPolicy`] ready to feed a [`crate::mac::te::LatticeTeEvaluator`]. Fail-closed:
 /// any failure returns an error and NO policy is loaded (the PEP keeps denying).
 pub struct PolicyLoader<V: PolicyVerifier> {
     verifier: V,
-    /// Approvals indexed by generation. If empty, approval-matching is skipped (sig-only);
-    /// production SHOULD populate this (S5).
+    /// Verified approvals indexed by generation. An empty set rejects every policy: a
+    /// signature proves who produced an artifact, while the approval is the independent
+    /// containment binding that authorizes its exact hash (S5).
     approvals: Vec<PolicyApproval>,
 }
 
@@ -289,7 +290,8 @@ impl<V: PolicyVerifier> PolicyLoader<V> {
     /// 1. Decode the canonical policy bytes.
     /// 2. Recompute the hash from the bytes (never trust a transmitted hash).
     /// 3. Verify the composite signature over `(generation, hash)`.
-    /// 4. If approvals are registered, require a matching `(generation, hash)` approval.
+    /// 4. Require a matching `(generation, hash)` approval. No approvals means no policy
+    ///    can load — there is deliberately no signature-only mode.
     pub fn load(&self, signed: &SignedPolicy) -> Result<CompiledPolicy, PolicyDistError> {
         // 1. Decode.
         let canonical: CanonicalPolicy = serde_json::from_slice(&signed.policy_bytes)
@@ -339,17 +341,17 @@ impl<V: PolicyVerifier> PolicyLoader<V> {
         // 3. Signature verify (ONCE, at load — never per op).
         self.verifier.verify(&input, &signed.signature)?;
 
-        // 4. Approval hash-match (containment backstop).
-        if !self.approvals.is_empty() {
-            let matched = self
-                .approvals
-                .iter()
-                .any(|a| a.generation == policy.generation && a.approved_hash == hash);
-            if !matched {
-                return Err(PolicyDistError::NoMatchingApproval {
-                    generation: policy.generation,
-                });
-            }
+        // 4. Approval hash-match (containment backstop). Empty approvals reject too:
+        //    accepting a signature alone would let the compiler/signing authority bypass
+        //    the independent approval that #570 requires.
+        let matched = self
+            .approvals
+            .iter()
+            .any(|a| a.generation == policy.generation && a.approved_hash == hash);
+        if !matched {
+            return Err(PolicyDistError::NoMatchingApproval {
+                generation: policy.generation,
+            });
         }
 
         Ok(policy)
@@ -538,11 +540,27 @@ mod tests {
     #[test]
     fn sign_then_load_roundtrips() {
         let key = [7u8; 32];
-        let signed = sign_policy(&policy(3), &StubSigner { key }).unwrap();
-        let loader = PolicyLoader::new(StubVerifier { key });
+        let policy = policy(3);
+        let approval = PolicyApproval {
+            generation: policy.generation,
+            approved_hash: policy.policy_hash().unwrap(),
+        };
+        let signed = sign_policy(&policy, &StubSigner { key }).unwrap();
+        let loader = PolicyLoader::new(StubVerifier { key }).with_approval(approval);
         let loaded = loader.load(&signed).unwrap();
         assert_eq!(loaded.generation, 3);
         assert_eq!(loaded.matrix.allow_len(), 2);
+    }
+
+    #[test]
+    fn loader_without_approval_rejects_valid_signature() {
+        let key = [7u8; 32];
+        let signed = sign_policy(&policy(3), &StubSigner { key }).unwrap();
+        let loader = PolicyLoader::new(StubVerifier { key });
+        assert!(matches!(
+            loader.load(&signed),
+            Err(PolicyDistError::NoMatchingApproval { generation: 3 })
+        ));
     }
 
     #[test]
@@ -646,12 +664,16 @@ mod tests {
             ("did:key:zAlice".to_owned(), label(Level::Secret)),
             ("did:key:zBob".to_owned(), label(Level::Confidential)),
         ]);
-        let signed = sign_policy(
-            &policy(2).with_enrollment(enrollment.clone()),
-            &StubSigner { key },
-        )
-        .unwrap();
-        let loaded = PolicyLoader::new(StubVerifier { key }).load(&signed).unwrap();
+        let policy = policy(2).with_enrollment(enrollment.clone());
+        let approval = PolicyApproval {
+            generation: policy.generation,
+            approved_hash: policy.policy_hash().unwrap(),
+        };
+        let signed = sign_policy(&policy, &StubSigner { key }).unwrap();
+        let loaded = PolicyLoader::new(StubVerifier { key })
+            .with_approval(approval)
+            .load(&signed)
+            .unwrap();
         assert_eq!(loaded.enrollment, enrollment);
         assert_eq!(loaded.clearance_for("did:key:zBob"), Some(label(Level::Confidential)));
     }


### PR DESCRIPTION
Closes #570.

The S4 PDP, lattice, signed compiled-policy, and AVC implementation landed in #583. This closes the remaining fail-open edge in the distribution boundary: `PolicyLoader` previously accepted a valid signature without any approval configured, despite #570 requiring the recomputed policy hash to match an approval.

## Changes

- require an exact `(generation, policy_hash)` approval for every compiled-policy load
- reject a correctly signed artifact when the loader has no approvals
- preserve the dormant empty boot baseline with an explicitly documented local self-approval
- add regression coverage for the no-approval case and update successful round-trip tests

## Validation

- `cargo test -p hyprstream mac::compiled --lib -- --nocapture` — 14 passed
- `cargo test -p hyprstream mac::bootload --lib -- --nocapture` — 3 passed
- `cargo test -p hyprstream 'mac::' --lib -- --nocapture` — 131 passed
- `cargo test -p hyprstream --lib --tests --no-fail-fast` — full affected package passed (GPU-dependent tests ignored as documented)
- `cargo clippy -p hyprstream --all-targets -- -D warnings` — passed
- repository pre-commit workspace Clippy gate (`--workspace --all-targets --release -- -D warnings`) — passed
