### PR TITLE
fix(cli): trust local self-signed cert in sign-challenge (#450)

### DIFF
--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -2713,14 +2713,27 @@ fn main() -> Result<()> {
             let code_challenge = sub_m.get_one::<String>("code_challenge").cloned();
             let server = sub_m.get_one::<String>("server").cloned();
             let insecure = sub_m.get_flag("insecure");
+            // Pass the already-loaded config (honors `--config`) so the OAuth
+            // issuer URL and the local self-signed cert's secrets dir are
+            // resolved from the user's selected configuration, not re-derived
+            // from defaults (#450). `config_for_service` is the surviving
+            // clone (`config` itself is moved into AppContext above).
+            let sign_cfg = config_for_service.clone();
             with_runtime(
                 RuntimeConfig {
                     device: DeviceConfig::request_cpu(),
                     multi_threaded: false,
                 },
                 || async move {
-                    handle_sign_challenge(user_code, nonce, code_challenge, server, insecure)
-                        .await
+                    handle_sign_challenge(
+                        user_code,
+                        nonce,
+                        code_challenge,
+                        server,
+                        insecure,
+                        Some(&sign_cfg),
+                    )
+                    .await
                 },
             )?;
         }

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -232,6 +232,12 @@ fn build_cli() -> ClapCommand {
                     .long("server")
                     .required(false)
                     .help("OAuth server URL (default: from config or http://localhost:6791)"),
+            )
+            .arg(
+                Arg::new("insecure")
+                    .long("insecure")
+                    .action(clap::ArgAction::SetTrue)
+                    .help("Disable TLS certificate verification (use only against a trusted local dev server). By default the local self-signed dev cert is trusted automatically."),
             ),
     );
 
@@ -2706,13 +2712,15 @@ fn main() -> Result<()> {
             let nonce = sub_m.get_one::<String>("nonce").cloned();
             let code_challenge = sub_m.get_one::<String>("code_challenge").cloned();
             let server = sub_m.get_one::<String>("server").cloned();
+            let insecure = sub_m.get_flag("insecure");
             with_runtime(
                 RuntimeConfig {
                     device: DeviceConfig::request_cpu(),
                     multi_threaded: false,
                 },
                 || async move {
-                    handle_sign_challenge(user_code, nonce, code_challenge, server).await
+                    handle_sign_challenge(user_code, nonce, code_challenge, server, insecure)
+                        .await
                 },
             )?;
         }

--- a/crates/hyprstream/src/cli/sign_challenge.rs
+++ b/crates/hyprstream/src/cli/sign_challenge.rs
@@ -33,6 +33,7 @@ pub async fn handle_sign_challenge(
     nonce: Option<String>,
     code_challenge: Option<String>,
     server: Option<String>,
+    insecure: bool,
 ) -> Result<()> {
     // Load user identity key from OS keyring
     let (signing_key, username) = load_user_signing_key()?;
@@ -40,7 +41,7 @@ pub async fn handle_sign_challenge(
     match (user_code, nonce, code_challenge) {
         // Device flow: sign-challenge ABCD-EFGH
         (Some(user_code), None, None) => {
-            handle_device_flow(signing_key, username, user_code, server).await
+            handle_device_flow(signing_key, username, user_code, server, insecure).await
         }
         // Auth code flow: sign-challenge --nonce N --code-challenge CC
         (None, Some(nonce), Some(code_challenge)) => {
@@ -76,14 +77,15 @@ async fn handle_device_flow(
     username: String,
     user_code: String,
     server: Option<String>,
+    insecure: bool,
 ) -> Result<()> {
     let base_url = resolve_server_url(server);
     let normalized = user_code.replace('-', "").to_uppercase();
 
-    // Fetch the nonce from the server
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(30))
-        .build()?;
+    // Build an HTTP client that trusts the local self-signed dev cert by
+    // default (Option B), or — when `--insecure` is passed — disables TLS
+    // verification entirely (Option A, opt-in with a warning).
+    let client = build_oauth_http_client(insecure)?;
 
     let nonce_url = format!(
         "{}/oauth/device/nonce?user_code={}",
@@ -202,4 +204,136 @@ fn resolve_server_url(server: Option<String>) -> String {
     crate::config::HyprConfig::load()
         .map(|c| c.oauth.issuer_url())
         .unwrap_or_else(|_| "http://localhost:6791".to_owned())
+}
+
+/// Name of the self-signed TLS certificate secret persisted in the shared
+/// secrets directory (see `auth::identity_store::load_or_generate_tls_materials`).
+const LOCAL_TLS_CERT_SECRET: &str = "tls-cert";
+
+/// Build the `reqwest::Client` used to reach the OAuth server.
+///
+/// Two modes, resolving issue #450:
+///
+/// - **`insecure = true`** (Option A, explicit opt-in via `--insecure`):
+///   disables certificate verification entirely with
+///   `danger_accept_invalid_certs(true)` and prints a warning to stderr.
+///   Use this only against throwaway dev servers where importing the cert
+///   is impractical.
+///
+/// - **`insecure = false`** (default, Option B): if the OAuth server uses the
+///   self-signed cert this project generates into the shared secrets
+///   directory (the default local-dev / air-gapped mode — see
+///   `server::tls` and `auth::identity_store::load_or_generate_tls_materials`),
+///   that cert is loaded and added as a trusted root. This makes
+///   `sign-challenge` "just work" against a local install *without* weakening
+///   TLS for any other host. The system trust store is still consulted for
+///   any cert it already trusts (e.g. a real CA-backed deployment), so adding
+///   the local dev cert is strictly additive. If the cert cannot be read
+///   (e.g. the secrets directory does not exist yet, or the server uses a
+///   real CA), we fall through to the system trust store.
+fn build_oauth_http_client(insecure: bool) -> Result<reqwest::Client> {
+    let mut builder = reqwest::Client::builder().timeout(std::time::Duration::from_secs(30));
+
+    if insecure {
+        // Explicit opt-in: blanket TLS bypass. Warn loudly — this defeats
+        // server authentication and must never be a default.
+        eprintln!(
+            "⚠️  --insecure: TLS certificate verification disabled. \
+             Only use against a trusted local dev server."
+        );
+        builder = builder.danger_accept_invalid_certs(true);
+    } else if let Some(cert_der) = load_local_tls_cert() {
+        // Trust the project's own self-signed dev cert (stored as DER).
+        // `from_pem` is backend-agnostic (works for both native-tls and
+        // rustls reqwest backends), so convert DER → PEM here.
+        match reqwest::Certificate::from_pem(&der_to_pem_cert(&cert_der)) {
+            Ok(cert) => {
+                builder = builder.add_root_certificate(cert);
+            }
+            Err(e) => {
+                // Don't hard-fail: a malformed local cert shouldn't block a
+                // user pointing at a real-CA server. Fall through to the
+                // system trust store.
+                tracing::debug!(
+                    "could not parse local TLS cert as a root: {} \
+                     (falling back to system trust store)",
+                    e
+                );
+            }
+        }
+    }
+
+    builder.build().context("failed to build OAuth HTTP client")
+}
+
+/// Load the local self-signed TLS certificate (DER) from the shared secrets
+/// directory, if one is present.
+///
+/// Returns `None` silently when the secrets directory or the cert is absent —
+/// callers fall back to the system trust store.
+fn load_local_tls_cert() -> Option<Vec<u8>> {
+    let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir().ok()?;
+    crate::auth::identity_store::read_secret(&secrets_dir, LOCAL_TLS_CERT_SECRET)
+        .ok()
+        .flatten()
+}
+
+/// Wrap DER-encoded certificate bytes as a PEM block.
+///
+/// reqwest's `Certificate::from_pem` is accepted by every TLS backend, while
+/// `from_der` is native-tls-only — so we convert here to stay backend-agnostic.
+fn der_to_pem_cert(der: &[u8]) -> Vec<u8> {
+    use base64::engine::general_purpose::STANDARD as B64;
+    // base64 output is always ASCII, so we can work in raw bytes and avoid
+    // any UTF-8 validation overhead (or `expect`).
+    let b64 = B64.encode(der);
+    let mut pem: Vec<u8> = Vec::with_capacity(b64.len() + 64);
+    pem.extend_from_slice(b"-----BEGIN CERTIFICATE-----\n");
+    for chunk in b64.as_bytes().chunks(64) {
+        pem.extend_from_slice(chunk);
+        pem.push(b'\n');
+    }
+    pem.extend_from_slice(b"-----END CERTIFICATE-----\n");
+    pem
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn der_to_pem_roundtrips_through_reqwest() {
+        // Generate a throwaway self-signed cert and confirm reqwest accepts
+        // the PEM we produce from its DER encoding.
+        let kp =
+            rcgen::KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256).expect("gen key");
+        let mut params =
+            rcgen::CertificateParams::new(vec!["localhost".to_owned()]).expect("params");
+        params.not_before = time::OffsetDateTime::now_utc();
+        params.not_after = time::OffsetDateTime::now_utc() + time::Duration::days(365);
+        let cert = params.self_signed(&kp).expect("self-signed");
+        let der = cert.der().to_vec();
+
+        let pem = der_to_pem_cert(&der);
+        assert!(pem.starts_with(b"-----BEGIN CERTIFICATE-----\n"));
+        assert!(pem.ends_with(b"-----END CERTIFICATE-----\n"));
+        reqwest::Certificate::from_pem(&pem)
+            .expect("reqwest must accept the PEM we produce from a valid DER cert");
+    }
+
+    #[test]
+    fn der_to_pem_wraps_at_64_columns() {
+        // 256 bytes of DER → base64 is longer than 64 chars, so we must wrap.
+        let der = vec![0u8; 256];
+        let pem = der_to_pem_cert(&der);
+        let text = std::str::from_utf8(&pem).unwrap();
+        for line in text.lines() {
+            // Header/footer lines are exempt; body lines must be ≤ 64 chars.
+            if line.starts_with("-----") {
+                continue;
+            }
+            assert!(line.len() <= 64, "PEM body line exceeds 64 cols: {line}");
+        }
+    }
 }

--- a/crates/hyprstream/src/cli/sign_challenge.rs
+++ b/crates/hyprstream/src/cli/sign_challenge.rs
@@ -28,12 +28,18 @@ use ed25519_dalek::Signer;
 
 
 /// Handle `hyprstream sign-challenge [USER_CODE] [--nonce N] [--code-challenge CC]`
+///
+/// `config` is the already-loaded `HyprConfig` (honoring `--config`/env) so the
+/// OAuth issuer URL *and* the secrets directory holding the local self-signed
+/// cert are resolved from the user's selected configuration, not re-derived
+/// from defaults. `None` falls back to default config resolution.
 pub async fn handle_sign_challenge(
     user_code: Option<String>,
     nonce: Option<String>,
     code_challenge: Option<String>,
     server: Option<String>,
     insecure: bool,
+    config: Option<&crate::config::HyprConfig>,
 ) -> Result<()> {
     // Load user identity key from OS keyring
     let (signing_key, username) = load_user_signing_key()?;
@@ -41,7 +47,7 @@ pub async fn handle_sign_challenge(
     match (user_code, nonce, code_challenge) {
         // Device flow: sign-challenge ABCD-EFGH
         (Some(user_code), None, None) => {
-            handle_device_flow(signing_key, username, user_code, server, insecure).await
+            handle_device_flow(signing_key, username, user_code, server, insecure, config).await
         }
         // Auth code flow: sign-challenge --nonce N --code-challenge CC
         (None, Some(nonce), Some(code_challenge)) => {
@@ -78,14 +84,17 @@ async fn handle_device_flow(
     user_code: String,
     server: Option<String>,
     insecure: bool,
+    config: Option<&crate::config::HyprConfig>,
 ) -> Result<()> {
-    let base_url = resolve_server_url(server);
+    let base_url = resolve_server_url(server, config);
     let normalized = user_code.replace('-', "").to_uppercase();
 
     // Build an HTTP client that trusts the local self-signed dev cert by
     // default (Option B), or — when `--insecure` is passed — disables TLS
-    // verification entirely (Option A, opt-in with a warning).
-    let client = build_oauth_http_client(insecure)?;
+    // verification entirely (Option A, opt-in with a warning). Pass the
+    // loaded config so the cert is looked up in the --config-selected
+    // secrets directory, not a re-derived default location.
+    let client = build_oauth_http_client(insecure, config)?;
 
     let nonce_url = format!(
         "{}/oauth/device/nonce?user_code={}",
@@ -196,10 +205,20 @@ fn load_user_signing_key() -> Result<(ed25519_dalek::SigningKey, String)> {
     Ok((sk, username))
 }
 
-/// Resolve the OAuth server URL from the option or config/default.
-fn resolve_server_url(server: Option<String>) -> String {
+/// Resolve the OAuth server URL from the option or the loaded config.
+///
+/// `config` is the already-loaded configuration (honoring `--config`/env).
+/// We must NOT call `HyprConfig::load()` here: that re-derives the *default*
+/// config location and would ignore a user-supplied `--config`, so the
+/// issuer URL (and, downstream, the secrets dir for the local dev cert)
+/// would be read from the wrong place (#450). When `config` is `None` we
+/// fall back to a fresh default load for backward compatibility.
+fn resolve_server_url(server: Option<String>, config: Option<&crate::config::HyprConfig>) -> String {
     if let Some(s) = server {
         return s;
+    }
+    if let Some(c) = config {
+        return c.oauth.issuer_url();
     }
     crate::config::HyprConfig::load()
         .map(|c| c.oauth.issuer_url())
@@ -231,7 +250,10 @@ const LOCAL_TLS_CERT_SECRET: &str = "tls-cert";
 ///   the local dev cert is strictly additive. If the cert cannot be read
 ///   (e.g. the secrets directory does not exist yet, or the server uses a
 ///   real CA), we fall through to the system trust store.
-fn build_oauth_http_client(insecure: bool) -> Result<reqwest::Client> {
+fn build_oauth_http_client(
+    insecure: bool,
+    config: Option<&crate::config::HyprConfig>,
+) -> Result<reqwest::Client> {
     let mut builder = reqwest::Client::builder().timeout(std::time::Duration::from_secs(30));
 
     if insecure {
@@ -242,7 +264,7 @@ fn build_oauth_http_client(insecure: bool) -> Result<reqwest::Client> {
              Only use against a trusted local dev server."
         );
         builder = builder.danger_accept_invalid_certs(true);
-    } else if let Some(cert_der) = load_local_tls_cert() {
+    } else if let Some(cert_der) = load_local_tls_cert(config) {
         // Trust the project's own self-signed dev cert (stored as DER).
         // `from_pem` is backend-agnostic (works for both native-tls and
         // rustls reqwest backends), so convert DER → PEM here.
@@ -269,10 +291,15 @@ fn build_oauth_http_client(insecure: bool) -> Result<reqwest::Client> {
 /// Load the local self-signed TLS certificate (DER) from the shared secrets
 /// directory, if one is present.
 ///
+/// `config` is the already-loaded configuration (honoring `--config`/env) so
+/// the secrets directory is resolved consistently with wherever the OAuth
+/// server itself is reading from — `resolve_secrets_dir_for(config)`, NOT a
+/// default re-derivation that would miss a custom `--config`.
+///
 /// Returns `None` silently when the secrets directory or the cert is absent —
 /// callers fall back to the system trust store.
-fn load_local_tls_cert() -> Option<Vec<u8>> {
-    let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir().ok()?;
+fn load_local_tls_cert(config: Option<&crate::config::HyprConfig>) -> Option<Vec<u8>> {
+    let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir_for(config).ok()?;
     crate::auth::identity_store::read_secret(&secrets_dir, LOCAL_TLS_CERT_SECRET)
         .ok()
         .flatten()


### PR DESCRIPTION
## Summary

Resolves #450 — `hyprstream sign-challenge` (device flow) failed with `SSL certificate verify error` against the default local-dev install because the OAuth server presents the self-signed cert this project generates.

The issue proposed two options; this implements **both, preferring the secure one**.

### Option B (default, secure) — trust the local self-signed dev cert
The OAuth server's self-signed cert is already persisted (DER) at `<secrets_dir>/tls-cert` by `auth::identity_store::load_or_generate_tls_materials` (the default `tls.mode = self-signed` path in `server::tls`). The CLI runs on the same host, so the cert is available without any new config. The reqwest client now loads it and adds it as a trusted root (`add_root_certificate`).

- No weakening of TLS for any other host — the system trust store is still consulted, so a real-CA deployment keeps verifying normally; trusting the local dev cert is strictly additive.
- If the cert is absent/unreadable (e.g. secrets dir not yet initialized, or the server uses a real CA), we fall through silently to the system trust store.

### Option A (opt-in escape hatch) — `--insecure` flag
For throwaway dev servers where importing the cert is impractical. Sets `danger_accept_invalid_certs(true)` and prints a stderr warning. Never the default.

### Implementation notes
- DER→PEM conversion feeds `Certificate::from_pem` (backend-agnostic — works for both native-tls and rustls reqwest backends; `from_der` is native-tls-only).
- Scope: `sign-challenge` is the only CLI subcommand that calls the OAuth server over reqwest (the inference-REST helpers in `cli/handlers.rs` hit the model API, not OAuth; `bin/main.rs`'s JWKS fetcher is the daemon's own resolver, already on `danger_accept_invalid_certs`). So the fix is applied consistently to the single in-scope command.

### Verification
- `cargo test -p hyprstream --lib cli::sign_challenge` — 2 new unit tests pass (PEM 64-col wrapping; full DER→PEM→`reqwest::Certificate` round-trip).
- `cargo clippy -p hyprstream --lib --bin hyprstream` clean.
- Pre-commit hook (`cargo clippy --workspace --all-targets --release -- -D warnings`) passed.

Closes #450.