### PR TITLE
fix(security): unify schema and TE scope actions

### DIFF
--- a/crates/hyprstream-rpc-derive/src/codegen/vfs.rs
+++ b/crates/hyprstream-rpc-derive/src/codegen/vfs.rs
@@ -76,13 +76,14 @@ impl NodeKind {
     }
 }
 
-/// Whether the method's scope action denotes a mutation (write/manage) vs a read (query).
+/// Whether the method's scope action denotes write/authority vs the schema's
+/// read class (`query`/`subscribe`).
 ///
 /// Scopes come from `$scope`/`$capability` (S3, #547). A `query` (or read-shaped)
-/// scope must project to a read-only node; anything else is treated as a mutation.
+/// scope must project to a read-only node; anything else is treated as authority.
 /// Empty scope (a `$scopeExempt` method) is treated as read (least authority).
-fn scope_is_mutation(scope: &str) -> bool {
-    !matches!(scope, "" | "query" | "read")
+fn scope_is_write_class(scope: &str) -> bool {
+    !matches!(scope, "" | "query" | "subscribe")
 }
 
 /// Whether a method name denotes a listing (projects to a directory by default).
@@ -98,7 +99,7 @@ pub fn infer_kind(scope: &str, arg: &CapnpType, name: &str, is_streaming: bool) 
     if is_streaming {
         return NodeKind::Stream;
     }
-    if scope_is_mutation(scope) {
+    if scope_is_write_class(scope) {
         return NodeKind::Ctl;
     }
     // Read-shaped (query/exempt): pick by argument shape.
@@ -158,17 +159,17 @@ pub fn resolve_kind(
 ///
 /// Returns `Err(message)` on contradiction, naming the offending method.
 pub fn validate_node(method_snake: &str, scope: &str, kind: NodeKind) -> Result<(), String> {
-    let mutation = scope_is_mutation(scope);
-    if mutation && kind.is_read_only() {
+    let write_class = scope_is_write_class(scope);
+    if write_class && kind.is_read_only() {
         return Err(format!(
-            "method `{method_snake}`: write/manage scope `{scope}` cannot project to a \
+            "method `{method_snake}`: write/authority-class scope `{scope}` cannot project to a \
              read-only VFS node (`{kind:?}`) — a 9P read must be side-effect-free; \
              use `$vfsKind(ctl)` or `$vfsKind(stream)`"
         ));
     }
-    if !mutation && matches!(kind, NodeKind::Ctl) {
+    if !write_class && matches!(kind, NodeKind::Ctl) {
         return Err(format!(
-            "method `{method_snake}`: query scope `{scope}` cannot project to a `ctl` node \
+            "method `{method_snake}`: read-class scope `{scope}` cannot project to a `ctl` node \
              — a control-file write invokes the method; use a read kind \
              (`$vfsKind(file|dir|query)`) or give the method a write scope"
         ));
@@ -481,6 +482,9 @@ mod tests {
         assert!(validate_node("list", "query", NodeKind::Dir).is_ok());
         assert!(validate_node("get", "query", NodeKind::File).is_ok());
         assert!(validate_node("search", "query", NodeKind::Query).is_ok());
+        assert!(validate_node("watch", "subscribe", NodeKind::Stream).is_ok());
+        assert!(validate_node("snapshot", "subscribe", NodeKind::File).is_ok());
+        assert!(validate_node("watch", "subscribe", NodeKind::Ctl).is_err());
         // A scope-exempt method (empty scope) is treated as read — ctl still rejected.
         assert!(validate_node("ping", "", NodeKind::File).is_ok());
         assert!(validate_node("ping", "", NodeKind::Ctl).is_err());

--- a/crates/hyprstream-rpc-std/tests/registry_vfs_parity.rs
+++ b/crates/hyprstream-rpc-std/tests/registry_vfs_parity.rs
@@ -100,7 +100,7 @@ fn repo_projects_as_a_subdirectory_with_children() {
 
     // The subdir table obeys the same scope→kind soundness as the top level.
     for n in sub {
-        let is_read = matches!(n.scope, "query" | "read" | "");
+        let is_read = matches!(n.scope, "query" | "subscribe" | "");
         if is_read {
             assert_ne!(n.kind, VfsNodeKind::Ctl, "repo `{}` read must not be a ctl", n.method);
         }
@@ -115,7 +115,7 @@ fn repo_projects_as_a_subdirectory_with_children() {
 #[test]
 fn scope_and_kind_are_consistent() {
     for n in nodes() {
-        let is_read = matches!(n.scope, "query" | "read" | "");
+        let is_read = matches!(n.scope, "query" | "subscribe" | "");
         if is_read {
             assert_ne!(
                 n.kind,

--- a/crates/hyprstream/src/auth/mod.rs
+++ b/crates/hyprstream/src/auth/mod.rs
@@ -22,6 +22,8 @@ pub mod rocksdb_store;
 #[cfg(feature = "valkey")]
 pub mod valkey;
 
+pub use hyprstream_rpc::annotations_capnp::ScopeAction;
+
 pub use federation::FederationKeyResolver;
 pub use jwt::{Claims, JwtError};
 pub use key_rotation::{SigningKeyStore, Es256SigningKeyStore, Es256KeySlot, RotationStores};
@@ -33,6 +35,60 @@ pub use user_store::{DeviceRecord, DeviceStore, KeyAlgorithm, UserFilter, UserPr
 pub use rocksdb_store::RocksDbUserStore;
 #[cfg(feature = "valkey")]
 pub use valkey::ValkeyUserStore;
+
+/// Every schema-defined scope action, in its Cap'n Proto ordinal order.
+///
+/// This is the closed vocabulary used by wildcard UCAN-to-TE expansion. The
+/// values come from the generated schema enum rather than a hand-written MAC
+/// mirror, so adding or reordering a schema action cannot silently change the
+/// action understood by the policy compiler.
+pub const SCHEMA_SCOPE_ACTIONS: [ScopeAction; 14] = [
+    ScopeAction::Query,
+    ScopeAction::Subscribe,
+    ScopeAction::Write,
+    ScopeAction::Create,
+    ScopeAction::Publish,
+    ScopeAction::Infer,
+    ScopeAction::Train,
+    ScopeAction::Context,
+    ScopeAction::Serve,
+    ScopeAction::Spawn,
+    ScopeAction::Manage,
+    ScopeAction::MeshInvoke,
+    ScopeAction::MeshStage,
+    ScopeAction::MeshDelta,
+];
+
+/// Return the canonical capability token for a generated schema action.
+///
+/// This is the single string bridge shared by runtime [`Operation`] parsing
+/// and the MAC permission map.
+pub const fn scope_action_name(action: ScopeAction) -> &'static str {
+    match action {
+        ScopeAction::Query => "query",
+        ScopeAction::Subscribe => "subscribe",
+        ScopeAction::Write => "write",
+        ScopeAction::Create => "create",
+        ScopeAction::Publish => "publish",
+        ScopeAction::Infer => "infer",
+        ScopeAction::Train => "train",
+        ScopeAction::Context => "context",
+        ScopeAction::Serve => "serve",
+        ScopeAction::Spawn => "spawn",
+        ScopeAction::Manage => "manage",
+        ScopeAction::MeshInvoke => "meshInvoke",
+        ScopeAction::MeshStage => "meshStage",
+        ScopeAction::MeshDelta => "meshDelta",
+    }
+}
+
+/// Parse a canonical capability token into the generated schema action.
+/// Unknown tokens fail closed.
+pub fn scope_action_from_name(action: &str) -> Option<ScopeAction> {
+    SCHEMA_SCOPE_ACTIONS
+        .into_iter()
+        .find(|candidate| scope_action_name(*candidate) == action)
+}
 
 /// Operation types that can be controlled via policies
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -101,6 +157,53 @@ pub enum Operation {
 }
 
 impl Operation {
+    /// Convert a schema action to its runtime authorization operation.
+    ///
+    /// The exhaustive match is intentional: adding a `ScopeAction` in the
+    /// schema makes this crate fail to compile until runtime enforcement is
+    /// defined for it.
+    pub const fn from_scope_action(action: ScopeAction) -> Self {
+        match action {
+            ScopeAction::Query => Self::Query,
+            ScopeAction::Subscribe => Self::Subscribe,
+            ScopeAction::Write => Self::Write,
+            ScopeAction::Create => Self::Create,
+            ScopeAction::Publish => Self::Publish,
+            ScopeAction::Infer => Self::Infer,
+            ScopeAction::Train => Self::Train,
+            ScopeAction::Context => Self::Context,
+            ScopeAction::Serve => Self::Serve,
+            ScopeAction::Spawn => Self::Spawn,
+            ScopeAction::Manage => Self::Manage,
+            ScopeAction::MeshInvoke => Self::MeshInvoke,
+            ScopeAction::MeshStage => Self::MeshStage,
+            ScopeAction::MeshDelta => Self::MeshDelta,
+        }
+    }
+
+    /// Return the generated schema action represented by this operation.
+    /// `MeshStatus` is the sole runtime-only operation and reuses the `query`
+    /// capability token at authorization boundaries.
+    pub const fn scope_action(self) -> Option<ScopeAction> {
+        Some(match self {
+            Self::Query => ScopeAction::Query,
+            Self::Subscribe => ScopeAction::Subscribe,
+            Self::Write => ScopeAction::Write,
+            Self::Create => ScopeAction::Create,
+            Self::Publish => ScopeAction::Publish,
+            Self::Infer => ScopeAction::Infer,
+            Self::Train => ScopeAction::Train,
+            Self::Context => ScopeAction::Context,
+            Self::Serve => ScopeAction::Serve,
+            Self::Spawn => ScopeAction::Spawn,
+            Self::Manage => ScopeAction::Manage,
+            Self::MeshInvoke => ScopeAction::MeshInvoke,
+            Self::MeshStage => ScopeAction::MeshStage,
+            Self::MeshDelta => ScopeAction::MeshDelta,
+            Self::MeshStatus => return None,
+        })
+    }
+
     /// Get the short code for this operation
     pub fn code(&self) -> char {
         match self {
@@ -135,27 +238,9 @@ impl Operation {
     /// annotation) and runtime enforcement. `MeshStatus` shares `query` because the
     /// mesh read ability IS the canonical status read (#319), matching `as_str()`.
     pub fn as_capability(&self) -> &'static str {
-        // Arms follow the ScopeAction ordinal blocks (annotations.capnp):
-        // A read, B write/authority, C admin, D mesh-authority.
-        match self {
-            // Block A (@0..@1)
-            Operation::Query | Operation::MeshStatus => "query",
-            Operation::Subscribe => "subscribe",
-            // Block B (@2..@9)
-            Operation::Write => "write",
-            Operation::Create => "create",
-            Operation::Publish => "publish",
-            Operation::Infer => "infer",
-            Operation::Train => "train",
-            Operation::Context => "context",
-            Operation::Serve => "serve",
-            Operation::Spawn => "spawn",
-            // Block C (@10)
-            Operation::Manage => "manage",
-            // Block D (@11..@13)
-            Operation::MeshInvoke => "meshInvoke",
-            Operation::MeshStage => "meshStage",
-            Operation::MeshDelta => "meshDelta",
+        match self.scope_action() {
+            Some(action) => scope_action_name(action),
+            None => "query", // MeshStatus is the runtime specialization of query.
         }
     }
 
@@ -165,33 +250,7 @@ impl Operation {
     ///
     /// Returns `None` for an unknown token; callers MUST fail closed (no default-allow).
     pub fn from_capability(action: &str) -> Option<Self> {
-        // Exact inverse of `as_capability`, arms ordered by ScopeAction ordinal blocks.
-        // 1:1 with `ScopeAction` (#547/#569): `subscribe`/`publish` are distinct enforced
-        // abilities — NOT collapsed into `context`/`serve`. Collapsing them made
-        // `from_capability` non-invertible, so a granted `subscribe:notification:*` /
-        // `publish:notification:*` scope was enforced as `context`/`serve` (granted ≠
-        // enforced).
-        Some(match action {
-            // Block A (@0..@1)
-            "query" => Operation::Query,
-            "subscribe" => Operation::Subscribe,
-            // Block B (@2..@9)
-            "write" => Operation::Write,
-            "create" => Operation::Create,
-            "publish" => Operation::Publish,
-            "infer" => Operation::Infer,
-            "train" => Operation::Train,
-            "context" => Operation::Context,
-            "serve" => Operation::Serve,
-            "spawn" => Operation::Spawn,
-            // Block C (@10)
-            "manage" => Operation::Manage,
-            // Block D (@11..@13)
-            "meshInvoke" => Operation::MeshInvoke,
-            "meshStage" => Operation::MeshStage,
-            "meshDelta" => Operation::MeshDelta,
-            _ => return None,
-        })
+        scope_action_from_name(action).map(Self::from_scope_action)
     }
 
     /// Get the dot-namespaced operation name for policy matching.
@@ -488,6 +547,15 @@ mod tests {
                 "capability token round-trip is not 1:1 for {op:?}",
             );
         }
+        // The runtime bridge is over the generated capnp enum itself, so the
+        // compiler/PEP id and the authorization token cannot drift apart.
+        for (ordinal, action) in SCHEMA_SCOPE_ACTIONS.into_iter().enumerate() {
+            let op = Operation::from_scope_action(action);
+            assert_eq!(op.scope_action(), Some(action));
+            assert_eq!(op.as_capability(), scope_action_name(action));
+            assert_eq!(u16::from(action) as usize, ordinal);
+        }
+        assert_eq!(Operation::MeshStatus.scope_action(), None);
         // `subscribe`/`publish` are distinct enforced abilities — NOT context/serve.
         assert_eq!(Operation::from_capability("subscribe"), Some(Operation::Subscribe));
         assert_eq!(Operation::from_capability("publish"), Some(Operation::Publish));

--- a/crates/hyprstream/src/mac/exchange.rs
+++ b/crates/hyprstream/src/mac/exchange.rs
@@ -428,7 +428,7 @@ pub fn audited_evaluate_refresh<V: UcanVerifier + ?Sized>(
 /// [`audited_evaluate_refresh`]. Builds the [`AuditRecord`] from whatever
 /// context is available (subject may be `None` on an unlabeled-subject
 /// denial; the request's ability may not parse as a canonical
-/// [`crate::mac::te::ScopeAction`] — both are still recorded, using the
+/// [`crate::auth::ScopeAction`] — both are still recorded, using the
 /// sentinel ids documented on [`crate::mac::te::GRANT_PATH_SUBJECT`]).
 fn audit_grant_outcome(
     subject: Option<&SecurityContext>,
@@ -437,8 +437,11 @@ fn audit_grant_outcome(
     result: &Result<GrantDecision, GrantError>,
     sink: &dyn crate::mac::audit::AuditSink,
 ) -> Result<GrantDecision, GrantError> {
+    use crate::auth::scope_action_from_name;
     use crate::mac::audit::{AuditRecord, DecisionReason, DelegationPrincipal};
-    use crate::mac::te::{Action, ScopeAction, ACTION_UNRECOGNIZED, GRANT_PATH_OBJECT, GRANT_PATH_SUBJECT};
+    use crate::mac::te::{
+        ACTION_UNRECOGNIZED, Action, GRANT_PATH_OBJECT, GRANT_PATH_SUBJECT,
+    };
     use hyprstream_rpc::auth::mac::SecurityLabel;
 
     let (decision, reason) = match result {
@@ -457,7 +460,7 @@ fn audit_grant_outcome(
         Err(GrantError::AuditUnavailable) => (Decision::Deny, DecisionReason::GrantAuditFailClosed),
     };
 
-    let action = ScopeAction::parse(request.ability.as_str())
+    let action = scope_action_from_name(request.ability.as_str())
         .map(Action::from)
         .unwrap_or(ACTION_UNRECOGNIZED);
     let record = AuditRecord {

--- a/crates/hyprstream/src/mac/permission_map.rs
+++ b/crates/hyprstream/src/mac/permission_map.rs
@@ -12,7 +12,8 @@
 //!
 //! - `mac://<class>/*` expands to one rule per **registered** object of that
 //!   class — never beyond the registry.
-//! - a `*` ability expands over exactly [`ScopeAction::ALL`] (a closed enum).
+//! - a `*` ability expands over exactly [`SCHEMA_SCOPE_ACTIONS`] (the generated,
+//!   closed schema enum).
 //! - anything unrecognized (class, name, verb) maps to **nothing**
 //!   (fail-closed; never a guessed rule).
 //!
@@ -34,13 +35,13 @@
 //! has no rule and is **denied by default**; the remedy is a re-compile at a
 //! new policy generation, not a silent wildcard.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use hyprstream_rpc::auth::ucan::capability::{Ability, Capability, Caveats, Resource};
 
+use crate::auth::{SCHEMA_SCOPE_ACTIONS, scope_action_from_name, scope_action_name};
 use crate::mac::compiler::{AccessRequest, PermissionMap};
-use crate::mac::te::{Action, ObjectType, ScopeAction, SubjectType, TeRule};
-use std::collections::BTreeSet;
+use crate::mac::te::{Action, ObjectType, SubjectType, TeRule};
 
 /// The production S3-scope permission map. See the module docs for the
 /// injective/exact contract and the registry-determinism rule.
@@ -131,13 +132,16 @@ impl PermissionMap for ScopePermissionMap {
     fn permissions_for(&self, cap: &Capability) -> BTreeSet<TeRule> {
         let mut out = BTreeSet::new();
 
-        // Verb(s): the closed ScopeAction vocabulary. `*` expands over ALL;
+        // Verb(s): the generated, closed ScopeAction vocabulary. `*` expands over ALL;
         // an unrecognized verb grants nothing.
         let ability = cap.ability.as_str();
         let actions: Vec<Action> = if ability == "*" {
-            ScopeAction::ALL.iter().map(|a| Action::from(*a)).collect()
+            SCHEMA_SCOPE_ACTIONS
+                .iter()
+                .map(|a| Action::from(*a))
+                .collect()
         } else {
-            match ScopeAction::parse(ability) {
+            match scope_action_from_name(ability) {
                 Some(a) => vec![Action::from(a)],
                 None => return out,
             }
@@ -178,7 +182,7 @@ impl PermissionMap for ScopePermissionMap {
             return None;
         }
         let (class, name) = self.by_id.get(&rule.object_type)?;
-        let verb = ScopeAction::from_action(rule.action)?.as_str();
+        let verb = scope_action_name(rule.action.scope_action()?);
         Some(AccessRequest {
             resource: Resource::new(format!("mac://{class}/{name}")),
             ability: Ability::new(verb),
@@ -300,7 +304,7 @@ mod tests {
     fn wildcard_ability_expands_to_exactly_the_closed_verb_set() {
         let m = map();
         let rules = m.permissions_for(&cap("mac://model/llama", "*"));
-        assert_eq!(rules.len(), ScopeAction::ALL.len());
+        assert_eq!(rules.len(), SCHEMA_SCOPE_ACTIONS.len());
     }
 
     // ── THE #676 obligation: granted_access upper-bounds the rule's grant ───
@@ -351,12 +355,15 @@ mod tests {
         fn granted_access_upper_bounds_every_request_projecting_to_the_rule(
             class_i in 0usize..4,      // model, adapter + 2 unregistered classes
             name_i in 0usize..5,       // registered + unregistered names
-            verb_i in 0usize..11,      // 9 canonical verbs + 2 junk
+            verb_i in 0usize..(SCHEMA_SCOPE_ACTIONS.len() + 2),
         ) {
             let m = map();
             let classes = ["model", "adapter", "widget", "tensor"];
             let names = ["llama", "qwen", "mistral", "lora-a", "ghost"];
-            let mut verbs: Vec<&str> = ScopeAction::ALL.iter().map(|a| a.as_str()).collect();
+            let mut verbs: Vec<&str> = SCHEMA_SCOPE_ACTIONS
+                .iter()
+                .map(|a| scope_action_name(*a))
+                .collect();
             verbs.push("fly");
             verbs.push("q");
 
@@ -367,7 +374,7 @@ mod tests {
             // The PEP-side projection of the concrete request: same interning
             // the compiler used (object_type via the shared registry, action
             // via the canonical ScopeAction ids).
-            let projected = m.object_type(class, name).zip(ScopeAction::parse(verb)).map(
+            let projected = m.object_type(class, name).zip(scope_action_from_name(verb)).map(
                 |(object_type, a)| TeRule {
                     subject_type: SubjectType(1),
                     object_type,
@@ -408,7 +415,8 @@ mod tests {
         #[test]
         fn distinct_accesses_project_to_distinct_rules(
             i in 0usize..5, j in 0usize..5,
-            vi in 0usize..9, vj in 0usize..9,
+            vi in 0usize..SCHEMA_SCOPE_ACTIONS.len(),
+            vj in 0usize..SCHEMA_SCOPE_ACTIONS.len(),
         ) {
             let m = map();
             let objects = [
@@ -417,8 +425,8 @@ mod tests {
             ];
             let (ci, ni) = objects[i];
             let (cj, nj) = objects[j];
-            let va = ScopeAction::ALL[vi];
-            let vb = ScopeAction::ALL[vj];
+            let va = SCHEMA_SCOPE_ACTIONS[vi];
+            let vb = SCHEMA_SCOPE_ACTIONS[vj];
             let ra = TeRule {
                 subject_type: SubjectType(1),
                 object_type: m.object_type(ci, ni).unwrap(),

--- a/crates/hyprstream/src/mac/te.rs
+++ b/crates/hyprstream/src/mac/te.rs
@@ -41,6 +41,7 @@
 //!   evaluator reads. Casbin's `Enforcer::enforce` is NEVER on this path.
 
 use crate::mac::lattice::{Compartment, Lattice, SecurityLabel};
+pub use hyprstream_rpc::annotations_capnp::ScopeAction;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
@@ -62,106 +63,22 @@ pub struct ObjectType(pub u32);
 #[serde(transparent)]
 pub struct Action(pub u32);
 
-/// S3's canonical action vocabulary (#569), mirrored from the Cap'n Proto `ScopeAction`
-/// enum in `hyprstream-rpc/schema/annotations.capnp` (`$mcpScope(...)`). Keeping the
-/// discriminants 1:1 with that schema enum is what lets S5's UCAN→TE compiler and the PEP
-/// intern the same `cmd`/`$scope` to the same [`Action`] id without a side table.
-///
-/// Note (minimal handling, per #570): `Subscribe`/`Publish` exist in the `ScopeAction`
-/// schema enum but have **no dedicated `auth::Operation` Rust variant** today. They are
-/// represented here so streaming ops are interned to a *stable* id; the
-/// control-plane `Operation` parity for them lands with the streaming-scope work. The
-/// remaining variants line up 1:1 with `auth::Operation` (`Query`/`Write`/`Manage`/
-/// `Infer`/`Train`/`Serve`/`Context`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[repr(u32)]
-pub enum ScopeAction {
-    /// `query @0` ⇄ `Operation::Query`.
-    Query = 0,
-    /// `write @1` ⇄ `Operation::Write`.
-    Write = 1,
-    /// `manage @2` ⇄ `Operation::Manage`.
-    Manage = 2,
-    /// `infer @3` ⇄ `Operation::Infer`.
-    Infer = 3,
-    /// `train @4` ⇄ `Operation::Train`.
-    Train = 4,
-    /// `serve @5` ⇄ `Operation::Serve`.
-    Serve = 5,
-    /// `context @6` ⇄ `Operation::Context`.
-    Context = 6,
-    /// `subscribe @7` — streaming read; no `Operation` parity yet (handled minimally).
-    Subscribe = 7,
-    /// `publish @8` — streaming write; no `Operation` parity yet (handled minimally).
-    Publish = 8,
-}
-
-impl ScopeAction {
-    /// Every canonical action, in schema-discriminant order. The closed action
-    /// vocabulary: a wildcard ability expands over exactly this set (#676).
-    pub const ALL: [ScopeAction; 9] = [
-        ScopeAction::Query,
-        ScopeAction::Write,
-        ScopeAction::Manage,
-        ScopeAction::Infer,
-        ScopeAction::Train,
-        ScopeAction::Serve,
-        ScopeAction::Context,
-        ScopeAction::Subscribe,
-        ScopeAction::Publish,
-    ];
-
-    /// The canonical verb string, exactly as named in the Cap'n Proto
-    /// `ScopeAction` schema enum (`annotations.capnp`). The single string↔id
-    /// assignment shared by the S3 scope parser, the S5 compiler's
-    /// `PermissionMap`, and the PEP — no side tables.
-    #[inline]
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            ScopeAction::Query => "query",
-            ScopeAction::Write => "write",
-            ScopeAction::Manage => "manage",
-            ScopeAction::Infer => "infer",
-            ScopeAction::Train => "train",
-            ScopeAction::Serve => "serve",
-            ScopeAction::Context => "context",
-            ScopeAction::Subscribe => "subscribe",
-            ScopeAction::Publish => "publish",
-        }
-    }
-
-    /// Parse a canonical verb string. `None` for anything else — an
-    /// unrecognized verb grants nothing (fail-closed), never a guess.
-    pub fn parse(s: &str) -> Option<Self> {
-        Self::ALL.into_iter().find(|a| a.as_str() == s)
-    }
-
-    /// Recover the enum from an interned [`Action`] id. `None` for an id
-    /// outside the schema enum — such a rule has no recognized meaning and is
-    /// treated as an escalation by `check_no_escalation` (fail-closed).
-    pub const fn from_action(action: Action) -> Option<Self> {
-        match action.0 {
-            0 => Some(ScopeAction::Query),
-            1 => Some(ScopeAction::Write),
-            2 => Some(ScopeAction::Manage),
-            3 => Some(ScopeAction::Infer),
-            4 => Some(ScopeAction::Train),
-            5 => Some(ScopeAction::Serve),
-            6 => Some(ScopeAction::Context),
-            7 => Some(ScopeAction::Subscribe),
-            8 => Some(ScopeAction::Publish),
-            _ => None,
-        }
-    }
-}
-
 impl Action {
     /// Intern a canonical S3 [`ScopeAction`] to its stable [`Action`] id. The id IS the
     /// schema discriminant, so the assignment is fixed across the compiler and every PEP
     /// (no per-process numbering drift).
     #[inline]
     pub const fn from_scope_action(a: ScopeAction) -> Self {
-        Action(a as u32)
+        Action(a as u16 as u32)
+    }
+
+    /// Recover the generated schema action represented by this interned id.
+    /// Values outside the schema enum fail closed.
+    #[inline]
+    pub fn scope_action(self) -> Option<ScopeAction> {
+        u16::try_from(self.0)
+            .ok()
+            .and_then(|ordinal| ScopeAction::try_from(ordinal).ok())
     }
 }
 
@@ -535,11 +452,16 @@ mod tests {
 
     #[test]
     fn scope_action_interns_to_schema_discriminant() {
-        // Stable 1:1 with the capnp ScopeAction enum so compiler and PEP agree on ids.
-        assert_eq!(Action::from(ScopeAction::Query), Action(0));
-        assert_eq!(Action::from(ScopeAction::Context), Action(6));
-        assert_eq!(Action::from(ScopeAction::Subscribe), Action(7));
-        assert_eq!(Action::from(ScopeAction::Publish), Action(8));
+        // The generated capnp enum is the source of the ids used by compiler and PEP.
+        for scope_action in crate::auth::SCHEMA_SCOPE_ACTIONS {
+            let action = Action::from(scope_action);
+            assert_eq!(action.scope_action(), Some(scope_action));
+            assert_eq!(action.0, u16::from(scope_action) as u32);
+        }
+        assert_eq!(Action::from(ScopeAction::Subscribe), Action(1));
+        assert_eq!(Action::from(ScopeAction::Manage), Action(10));
+        assert_eq!(Action::from(ScopeAction::MeshDelta), Action(13));
+        assert_eq!(Action(u32::MAX).scope_action(), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- make the generated Capnp ScopeAction enum the single runtime, authorization, and TE action vocabulary
- expand UCAN wildcard lowering, inverse permission mapping, and grant auditing across all 14 schema actions using their exact generated ordinals
- classify subscribe with query as read-class in generated VFS contradiction guards, while every authority-class action remains incompatible with read-only nodes

The mandatory scope validator and generated VFS metadata landed previously in #582 and #672. This removes the remaining hand-written nine-action TE mirror and closes the ordinal/vocabulary drift on main.

## Validation

- cargo test -p hyprstream-rpc-build -p hyprstream-rpc-derive -p hyprstream --lib --no-fail-fast
- cargo clippy --workspace --all-targets -- -D warnings
- RUSTFLAGS=--cfg=web_sys_unstable_apis cargo check --target wasm32-unknown-unknown -p hyprstream-rpc
- cargo deny check bans licenses
- cargo build --release
- cargo nextest run --cargo-profile ci-test --profile ci --test-threads 4 --no-fail-fast (3,155 passed; 10 configured skips)
- cargo test --release --doc

Closes #569