### PR TITLE
Enforce fail-closed mandatory hybrid crypto posture

### DIFF
--- a/crates/hyprstream-rpc/Cargo.toml
+++ b/crates/hyprstream-rpc/Cargo.toml
@@ -155,9 +155,12 @@ systemd = { version = "0.10", optional = true }
 default = []
 fips = ["p256", "hmac", "hyprstream-crypto/fips"]  # FIPS mode uses P-256 + HMAC-SHA256 (hkdf is always enabled)
 # `pq-hybrid` is retained as a NO-OP alias for source/build compatibility.
-# Post-quantum primitives (ML-DSA-65 + ML-KEM-768) are now ALWAYS compiled;
-# Classical vs Hybrid is selected at runtime via `crypto::CryptoPolicy`. See M3.
+# Post-quantum primitives (ML-DSA-65 + ML-KEM-768) are always compiled and the
+# production policy is the pinned Hybrid suite.
 pq-hybrid = []
+# Enables EdDSA-only compatibility fixtures for downstream tests. Never enable
+# this feature in a production artifact.
+test-classical-policy = []
 systemd = ["dep:systemd"]
 
 [build-dependencies]

--- a/crates/hyprstream-rpc/src/crypto/mod.rs
+++ b/crates/hyprstream-rpc/src/crypto/mod.rs
@@ -39,22 +39,21 @@ pub mod key_exchange;
 pub mod broadcast_primitives;
 pub mod signing;
 
-/// Runtime crypto mode selecting how envelopes/tokens are signed and verified.
+/// Policy-selected envelope/token signature suite.
 ///
 /// This REPLACES the old compile-time `pq-hybrid` cargo feature. PQ primitives
-/// (ML-DSA-65, ML-KEM-768) are always compiled; the policy chooses whether they
-/// are used at runtime.
+/// (ML-DSA-65, ML-KEM-768) are always compiled. Production exposes only the
+/// pinned hybrid suite: there is no runtime algorithm negotiation or downgrade.
 ///
 /// - `Hybrid` (default): sign with a COSE composite (EdDSA + ML-DSA-65) and
 ///   REQUIRE both components to verify.
-/// - `Classical`: sign with EdDSA only and accept EdDSA-only signatures. A
-///   `Classical` verifier still accepts a `Hybrid`-signed item via its EdDSA
-///   component (RFC 7517 skip-unknown interop).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CryptoPolicy {
-    /// EdDSA only (classical).
+    /// Test-only EdDSA mode for low-level compatibility fixtures. This variant
+    /// is absent from every production library build.
+    #[cfg(any(test, feature = "test-classical-policy"))]
     Classical,
-    /// EdDSA + ML-DSA-65 composite (post-quantum hybrid). Default.
+    /// Pinned EdDSA + ML-DSA-65 composite suite. Default and mandatory.
     #[default]
     Hybrid,
 }
@@ -62,7 +61,11 @@ pub enum CryptoPolicy {
 impl CryptoPolicy {
     /// Whether this policy emits/requires the post-quantum (ML-DSA-65) component.
     pub fn uses_pq(self) -> bool {
-        matches!(self, CryptoPolicy::Hybrid)
+        match self {
+            #[cfg(any(test, feature = "test-classical-policy"))]
+            CryptoPolicy::Classical => false,
+            CryptoPolicy::Hybrid => true,
+        }
     }
 }
 

--- a/crates/hyprstream-rpc/src/envelope.rs
+++ b/crates/hyprstream-rpc/src/envelope.rs
@@ -1371,12 +1371,17 @@ impl SignedEnvelope {
     pub fn new_signed(envelope: RequestEnvelope, signing_key: &SigningKey) -> Self {
         // Default policy is Classical for the bare Ed25519-only constructor so
         // that callers that don't supply a PQ key produce verifiable envelopes.
+        // Infallible: Classical never requires a PQ key, so the only failure
+        // left is a CBOR-encoding error over fixed-shape COSE structures —
+        // fail loud rather than emit a fail-open empty composite.
+        #[allow(clippy::expect_used)]
         Self::new_signed_with_policy(
             envelope,
             signing_key,
             None,
             crate::crypto::CryptoPolicy::Classical,
         )
+        .expect("COSE composite signing must not fail for valid keys")
     }
 
     /// Create and dual-sign a new envelope with Ed25519 + ML-DSA-65 (Hybrid).
@@ -1385,12 +1390,17 @@ impl SignedEnvelope {
         signing_key: &SigningKey,
         pq_signing_key: &crate::crypto::pq::MlDsaSigningKey,
     ) -> Self {
+        // Infallible: the PQ key is statically present, so the only failure
+        // left is a CBOR-encoding error over fixed-shape COSE structures —
+        // fail loud rather than emit a fail-open empty composite.
+        #[allow(clippy::expect_used)]
         Self::new_signed_with_policy(
             envelope,
             signing_key,
             Some(pq_signing_key),
             crate::crypto::CryptoPolicy::Hybrid,
         )
+        .expect("COSE composite signing must not fail for valid keys")
     }
 
     /// Create and sign a new envelope under an explicit [`CryptoPolicy`].
@@ -1405,7 +1415,7 @@ impl SignedEnvelope {
         signing_key: &SigningKey,
         pq_signing_key: Option<&crate::crypto::pq::MlDsaSigningKey>,
         policy: crate::crypto::CryptoPolicy,
-    ) -> Self {
+    ) -> Result<Self> {
         if envelope.wth.is_none() {
             if let Some(jwt) = envelope.jwt_token() {
                 use sha2::{Digest, Sha256};
@@ -1415,15 +1425,13 @@ impl SignedEnvelope {
 
         let envelope_bytes = envelope.to_bytes();
         let signature = signing_key.sign(&envelope_bytes);
-        // SECURITY: no empty-cose fallback. A COSE build failure is a
-        // should-never-happen crypto-encoding error (CBOR-encoding fixed-shape
-        // COSE_Sign1 structures over valid keys); fail loud rather than silently
-        // emit an empty (and thus potentially fail-open) composite.
-        #[allow(clippy::expect_used)]
-        let cose = Self::build_cose(signing_key, pq_signing_key, policy, &envelope_bytes)
-            .expect("COSE composite signing must not fail for valid keys");
+        // SECURITY: no empty-cose fallback. A missing mandatory PQ key or a
+        // COSE encoding error is a fail-closed construction error propagated
+        // to the caller — never substitute an empty (and thus potentially
+        // fail-open) composite, never downgrade to classical.
+        let cose = Self::build_cose(signing_key, pq_signing_key, policy, &envelope_bytes)?;
 
-        Self {
+        Ok(Self {
             envelope,
             sig: signature.to_bytes(),
             cnf: signing_key.verifying_key().to_bytes(),
@@ -1432,7 +1440,7 @@ impl SignedEnvelope {
             cose,
             policy,
             pq_kem_ciphertext: None,
-        }
+        })
     }
 
     /// Build the nested COSE composite signature for the given signing-data per
@@ -2176,6 +2184,10 @@ impl ResponseEnvelope {
     /// This constructor is absent from production builds.
     #[cfg(any(test, feature = "test-classical-policy"))]
     pub fn new_signed(request_id: u64, payload: Vec<u8>, signing_key: &SigningKey) -> Self {
+        // Infallible: Classical never requires a PQ key, so the only failure
+        // left is a CBOR-encoding error over fixed-shape COSE structures —
+        // fail loud rather than emit a fail-open empty composite.
+        #[allow(clippy::expect_used)]
         Self::new_signed_with_policy(
             request_id,
             payload,
@@ -2183,6 +2195,7 @@ impl ResponseEnvelope {
             None,
             crate::crypto::CryptoPolicy::Classical,
         )
+        .expect("COSE composite signing must not fail for valid keys")
     }
 
     /// Create and dual-sign a response with Ed25519 + ML-DSA-65 (Hybrid).
@@ -2192,6 +2205,10 @@ impl ResponseEnvelope {
         signing_key: &SigningKey,
         pq_signing_key: &crate::crypto::pq::MlDsaSigningKey,
     ) -> Self {
+        // Infallible: the PQ key is statically present, so the only failure
+        // left is a CBOR-encoding error over fixed-shape COSE structures —
+        // fail loud rather than emit a fail-open empty composite.
+        #[allow(clippy::expect_used)]
         Self::new_signed_with_policy(
             request_id,
             payload,
@@ -2199,39 +2216,40 @@ impl ResponseEnvelope {
             Some(pq_signing_key),
             crate::crypto::CryptoPolicy::Hybrid,
         )
+        .expect("COSE composite signing must not fail for valid keys")
     }
 
     /// Create and sign a response under an explicit [`CryptoPolicy`].
     ///
     /// Mirrors [`SignedEnvelope::new_signed_with_policy`]:
     /// - `Hybrid`: EdDSA + ML-DSA-65 nested composite; `pq_signing_key` MUST be
-    ///   `Some`; absence is a fail-closed construction error.
+    ///   `Some`; absence is a fail-closed construction error returned as `Err`.
     ///
     /// `sig`/`cnf` are always populated with the raw EdDSA signature + signer
-    /// public key. The COSE build is **fail-closed**: a COSE encoding error
-    /// panics rather than silently emitting an empty (fail-open) composite,
-    /// matching the request side.
+    /// public key. The COSE build is **fail-closed**: a missing mandatory PQ
+    /// key or a COSE encoding error is propagated as `Err` rather than
+    /// silently emitting an empty (fail-open) composite, matching the request
+    /// side.
     pub fn new_signed_with_policy(
         request_id: u64,
         payload: Vec<u8>,
         signing_key: &SigningKey,
         pq_signing_key: Option<&crate::crypto::pq::MlDsaSigningKey>,
         policy: crate::crypto::CryptoPolicy,
-    ) -> Self {
+    ) -> Result<Self> {
         let signing_data = Self::signing_data(request_id, &payload);
 
         let signature_obj = signing_key.sign(&signing_data);
         let sig: [u8; 64] = signature_obj.to_bytes();
         let cnf: [u8; 32] = signing_key.verifying_key().to_bytes();
 
-        // SECURITY: no empty-cose fallback (mirrors SignedEnvelope). A COSE build
-        // failure is a should-never-happen crypto-encoding error; fail loud
-        // rather than emit a potentially fail-open empty composite.
-        #[allow(clippy::expect_used)]
-        let cose = Self::build_cose(signing_key, pq_signing_key, policy, &signing_data)
-            .expect("COSE composite signing must not fail for valid keys");
+        // SECURITY: no empty-cose fallback (mirrors SignedEnvelope). A missing
+        // mandatory PQ key or a COSE encoding error is a fail-closed
+        // construction error propagated to the caller — never substitute an
+        // empty (fail-open) composite, never downgrade to classical.
+        let cose = Self::build_cose(signing_key, pq_signing_key, policy, &signing_data)?;
 
-        Self {
+        Ok(Self {
             request_id,
             payload,
             encrypted_response: None,
@@ -2239,7 +2257,7 @@ impl ResponseEnvelope {
             cnf,
             cose,
             policy,
-        }
+        })
     }
 
     /// Seal a unary response to the request's one-shot recipient, then
@@ -3648,9 +3666,32 @@ mod tests {
             &sk,
             None,
             CryptoPolicy::Classical,
-        );
+        )
+        .expect("classical signing");
         signed.verify_with(&vk, &cache, None, CryptoPolicy::Classical)?;
         Ok(())
+    }
+
+    /// Hybrid construction without a PQ key is a fail-closed `Err` — not a
+    /// panic, and never a silent classical downgrade.
+    #[test]
+    fn m3_hybrid_without_pq_key_errors() {
+        let (sk, _vk) = generate_signing_keypair();
+        assert!(SignedEnvelope::new_signed_with_policy(
+            RequestEnvelope::anonymous(vec![1]),
+            &sk,
+            None,
+            CryptoPolicy::Hybrid,
+        )
+        .is_err());
+        assert!(ResponseEnvelope::new_signed_with_policy(
+            1,
+            vec![1],
+            &sk,
+            None,
+            CryptoPolicy::Hybrid,
+        )
+        .is_err());
     }
 
     /// hybrid: sign + verify composite (both EdDSA + ML-DSA-65 checked).

--- a/crates/hyprstream-rpc/src/envelope.rs
+++ b/crates/hyprstream-rpc/src/envelope.rs
@@ -247,30 +247,6 @@ pub enum EnvelopeVerification<'a> {
     AnySigner,
 }
 
-/// Fu2/#677: how the verifier treats an identity with **no anchored ML-DSA-65
-/// key** (an "unanchored" signer) when verifying under a Hybrid [`CryptoPolicy`].
-///
-/// The composite signature is Weakly Non-Separable (per-identity): the inner
-/// EdDSA is independently verifiable, so whether the outer ML-DSA-65 layer is
-/// *required* is a per-identity decision. The audit (Fu2) found the verifier
-/// accepted unanchored identities classical-only by default — so "hybrid" was
-/// anchor-coverage-dependent, unlike the UCAN verifier which denies on a missing
-/// anchor. This enum makes the posture explicit and pins the **default to
-/// deny-on-missing-anchor**, with an opt-in per-peer allowlist for legacy
-/// classical-only peers (e.g. a pre-PQ federation edge).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum UnanchoredHybridPolicy {
-    /// Fail closed: an unanchored identity is rejected under Hybrid unless its
-    /// Ed25519 verifying key (hex) is present in the supplied allowlist. The
-    /// **production default** ([`UnwrapOptions`] defaults to this).
-    #[default]
-    Deny,
-    /// Accept the classical inner EdDSA only — the legacy WNS backcompat floor.
-    /// Exposed for low-level callers that explicitly opt into per-identity
-    /// classical verification; NOT the production default.
-    AllowClassicalFloor,
-}
-
 /// Options controlling envelope unwrap, verification, and optional decryption.
 ///
 /// # Crypto policy (fail-closed default)
@@ -282,9 +258,6 @@ pub enum UnanchoredHybridPolicy {
 /// MUST supply `pq_store`; under Hybrid with no resolvable anchor the envelope
 /// is **rejected** (fail-closed), never accepted as classical.
 ///
-/// Callers that genuinely need the legacy classical-only path (e.g. WASM in-
-/// browser verification without a PQ trust store) must explicitly downgrade via
-/// [`UnwrapOptions::classical`].
 pub struct UnwrapOptions<'a> {
     /// How to verify the envelope signer.
     pub verification: EnvelopeVerification<'a>,
@@ -303,15 +276,6 @@ pub struct UnwrapOptions<'a> {
     pub pq_store: Option<&'a dyn PqTrustStore>,
     /// Verification policy enforced at this site. Defaults to Hybrid (enforced).
     pub verify_policy: crate::crypto::CryptoPolicy,
-    /// Fu2/#677: posture for an unanchored signer (no ML-DSA-65 anchor) under
-    /// Hybrid. Defaults to [`UnanchoredHybridPolicy::Deny`] (deny-on-missing-
-    /// anchor). Under `Deny`, an unanchored identity is accepted classical-only
-    /// iff its Ed25519 key hex is in [`Self::unanchored_classical_allowlist`].
-    pub unanchored_policy: UnanchoredHybridPolicy,
-    /// Fu2/#677: Ed25519 verifying-key hexes permitted to verify classical-only
-    /// under Hybrid when [`Self::unanchored_policy`] is `Deny`. Empty by default
-    /// (every unanchored identity denied). Anchored identities bypass this list.
-    pub unanchored_classical_allowlist: Vec<String>,
 }
 
 impl<'a> UnwrapOptions<'a> {
@@ -324,8 +288,6 @@ impl<'a> UnwrapOptions<'a> {
             require_encrypted: false,
             pq_store: None,
             verify_policy: crate::crypto::CryptoPolicy::default(),
-            unanchored_policy: UnanchoredHybridPolicy::default(),
-            unanchored_classical_allowlist: Vec::new(),
         }
     }
 
@@ -338,8 +300,6 @@ impl<'a> UnwrapOptions<'a> {
             require_encrypted: false,
             pq_store: None,
             verify_policy: crate::crypto::CryptoPolicy::default(),
-            unanchored_policy: UnanchoredHybridPolicy::default(),
-            unanchored_classical_allowlist: Vec::new(),
         }
     }
 
@@ -363,30 +323,6 @@ impl<'a> UnwrapOptions<'a> {
     /// Set the verification policy explicitly.
     pub fn with_verify_policy(mut self, policy: crate::crypto::CryptoPolicy) -> Self {
         self.verify_policy = policy;
-        self
-    }
-
-    /// Fu2/#677: set the unanchored-signer posture under Hybrid (default `Deny`).
-    pub fn with_unanchored_policy(mut self, policy: UnanchoredHybridPolicy) -> Self {
-        self.unanchored_policy = policy;
-        self
-    }
-
-    /// Fu2/#677: set the Ed25519-key-hex allowlist of unanchored identities
-    /// accepted classical-only under Hybrid+`Deny`.
-    pub fn with_unanchored_allowlist(mut self, allowlist: Vec<String>) -> Self {
-        self.unanchored_classical_allowlist = allowlist;
-        self
-    }
-
-    /// Explicitly downgrade this site to the legacy classical-only verifier.
-    ///
-    /// Use ONLY for surfaces that cannot carry a PQ trust store (e.g. external
-    /// JOSE/classical interop). This accepts a single-EdDSA composite and
-    /// ignores any outer ML-DSA layer.
-    pub fn classical(mut self) -> Self {
-        self.verify_policy = crate::crypto::CryptoPolicy::Classical;
-        self.pq_store = None;
         self
     }
 }
@@ -844,9 +780,10 @@ pub struct SignedEnvelope {
 
     /// M3 (#152): CBOR-encoded COSE_Sign composite signature (detached).
     ///
-    /// Authoritative authentication mechanism. Carries one EdDSA entry
-    /// (Classical) or EdDSA + ML-DSA-65 entries (Hybrid) over the canonical
-    /// signing-data. The ML-DSA-65 verifying key is NOT embedded; it is
+    /// Authoritative authentication mechanism. Production envelopes carry the
+    /// pinned EdDSA + ML-DSA-65 composite over the canonical signing-data.
+    /// EdDSA-only encoding remains available only to test fixtures. The
+    /// ML-DSA-65 verifying key is NOT embedded; it is
     /// resolved by kid from a trust store (kid-anchored), which fixes the
     /// prior self-certification weakness.
     ///
@@ -855,7 +792,7 @@ pub struct SignedEnvelope {
     /// path, but the COSE composite is what `verify*` enforces.
     pub cose: Vec<u8>,
 
-    /// Runtime crypto policy used when this envelope was signed.
+    /// Signature suite marker. Production construction always uses `Hybrid`.
     pub policy: crate::crypto::CryptoPolicy,
 
     /// ML-KEM-768 ciphertext (1088 bytes, present when hybrid encryption is used)
@@ -1114,9 +1051,9 @@ impl PqTrustStore for KeyedPqTrustStore {
 ///
 /// Holds the enforced [`CryptoPolicy`] and the kid-anchored [`PqTrustStore`].
 /// The daemon installs this at startup with `Hybrid` + a real store wired from
-/// the node's hybrid identity (see `key_rotation`). When unset (libraries, unit
-/// tests that don't opt in), verification defaults to `Classical` so unrelated
-/// code paths keep working — production code MUST call [`install_verify_config`].
+/// the node's hybrid identity (see `key_rotation`). When unset, verification
+/// still enforces `Hybrid`; production code MUST call [`install_verify_config`]
+/// to provide the trust anchors needed for successful admission.
 pub struct EnvelopeVerifyConfig {
     pub policy: crate::crypto::CryptoPolicy,
     pub pq_store: Option<std::sync::Arc<dyn PqTrustStore>>,
@@ -1151,33 +1088,21 @@ pub fn verify_config_installed() -> bool {
 /// classical-only envelopes rather than silently accepting EdDSA-only ones
 /// (#160 — this previously defaulted `Classical`, re-opening the M3 fail-open).
 ///
-/// Under `cfg(test)` the uninstalled default stays `Classical`: in-process unit
-/// tests share one `OnceLock` and rely on per-call `UnwrapOptions` overrides
-/// rather than a global install. Integration tests (which compile this crate in
-/// non-test mode) must call [`install_verify_config`] explicitly.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn global_verify_policy() -> crate::crypto::CryptoPolicy {
     if let Some(c) = VERIFY_CONFIG.get() {
         return c.policy;
     }
-    #[cfg(test)]
-    {
-        crate::crypto::CryptoPolicy::Classical
-    }
-    #[cfg(not(test))]
-    {
-        // Fail-closed default. Loud (once — this is on the per-request verify
-        // path), because reaching a verify site with no installed config in
-        // production is a wiring bug (#160).
-        static WARNED: std::sync::Once = std::sync::Once::new();
-        WARNED.call_once(|| {
-            tracing::warn!(
-                "envelope verify config not installed; defaulting to fail-closed Hybrid \
-                 policy. Production code MUST call install_verify_config() at startup."
-            );
-        });
-        crate::crypto::CryptoPolicy::Hybrid
-    }
+    // Fail-closed default. Loud once because reaching a verification site with
+    // no installed config is a production wiring bug (#160).
+    static WARNED: std::sync::Once = std::sync::Once::new();
+    WARNED.call_once(|| {
+        tracing::warn!(
+            "envelope verify config not installed; enforcing the pinned Hybrid suite. \
+             Production code MUST call install_verify_config() at startup."
+        );
+    });
+    crate::crypto::CryptoPolicy::Hybrid
 }
 
 /// The installed kid-anchored PQ trust store, if any.
@@ -1186,8 +1111,8 @@ pub fn global_pq_store() -> Option<std::sync::Arc<dyn PqTrustStore>> {
     VERIFY_CONFIG.get().and_then(|c| c.pq_store.clone())
 }
 
-/// Apply the process-global verify configuration to an `UnwrapOptions`,
-/// unless it has already been explicitly downgraded/overridden.
+/// Apply the mandatory process-global policy and trust store to an
+/// `UnwrapOptions`.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn apply_global_verify_config<'a>(
     mut opts: UnwrapOptions<'a>,
@@ -1198,26 +1123,10 @@ pub fn apply_global_verify_config<'a>(
     opts
 }
 
-/// Name of the mid-rollout escape-hatch env var shared by the request and
-/// response verify paths. Setting it to `classical` downgrades BOTH directions
-/// (operators staging the PQ rollout before peer ML-DSA bindings are
-/// provisioned). Any other value (or unset) means Hybrid.
-pub const ENVELOPE_POLICY_ENV: &str = "HYPRSTREAM_ENVELOPE_POLICY";
-
-/// Parse [`ENVELOPE_POLICY_ENV`] into a [`CryptoPolicy`]. Single source of truth
-/// for the escape hatch so the request side (`install_verify_config` in
-/// `main.rs`) and the response side share identical semantics. Defaults to
-/// fail-closed [`CryptoPolicy::Hybrid`]; only the literal `classical` downgrades.
-#[cfg(not(target_arch = "wasm32"))]
-pub fn envelope_policy_from_env() -> crate::crypto::CryptoPolicy {
-    match std::env::var(ENVELOPE_POLICY_ENV).ok().as_deref() {
-        Some("classical") => crate::crypto::CryptoPolicy::Classical,
-        Some("hybrid") | None => crate::crypto::CryptoPolicy::Hybrid,
-        Some(other) => {
-            tracing::warn!("unknown {ENVELOPE_POLICY_ENV}={other:?}, defaulting to Hybrid");
-            crate::crypto::CryptoPolicy::Hybrid
-        }
-    }
+/// The production policy-selected pinned suite. There is deliberately no
+/// environment or wire input: peers either support it fully or admission fails.
+pub const fn mandatory_envelope_policy() -> crate::crypto::CryptoPolicy {
+    crate::crypto::CryptoPolicy::Hybrid
 }
 
 // ============================================================================
@@ -1272,36 +1181,20 @@ pub fn response_verify_config_installed() -> bool {
 /// request side ([`global_verify_policy`]): production builds default to
 /// [`CryptoPolicy::Hybrid`] so a client that reaches the response-verify path
 /// before `install_response_verify_config` rejects classical-only responses
-/// rather than silently accepting EdDSA-only ones (#277). The escape hatch
-/// ([`ENVELOPE_POLICY_ENV`]`=classical`) is honored even in the uninstalled
-/// path so the response side downgrades in parity with the request side.
-///
-/// Under `cfg(test)` the uninstalled default stays `Classical`: in-process unit
-/// tests share one `OnceLock` and rely on explicit per-call policy overrides.
+/// rather than silently accepting EdDSA-only ones (#277).
 #[cfg(not(target_arch = "wasm32"))]
 pub fn global_response_verify_policy() -> crate::crypto::CryptoPolicy {
     if let Some(c) = RESPONSE_VERIFY_CONFIG.get() {
         return c.policy;
     }
-    #[cfg(test)]
-    {
-        crate::crypto::CryptoPolicy::Classical
-    }
-    #[cfg(not(test))]
-    {
-        // Honor the escape hatch even before install (parity with request side
-        // staging) but otherwise fail closed.
-        let policy = envelope_policy_from_env();
-        static WARNED: std::sync::Once = std::sync::Once::new();
-        WARNED.call_once(|| {
-            tracing::warn!(
-                "response verify config not installed; defaulting to fail-closed \
-                 {policy:?} policy. Production code MUST call \
-                 install_response_verify_config() at startup."
-            );
-        });
-        policy
-    }
+    static WARNED: std::sync::Once = std::sync::Once::new();
+    WARNED.call_once(|| {
+        tracing::warn!(
+            "response verify config not installed; enforcing the pinned Hybrid suite. \
+             Production code MUST call install_response_verify_config() at startup."
+        );
+    });
+    mandatory_envelope_policy()
 }
 
 /// The installed RESPONSE-side kid-anchored PQ trust store, if any.
@@ -1474,6 +1367,7 @@ impl SignedEnvelope {
     /// The signature covers the Cap'n Proto serialized bytes of the envelope.
     /// If the authorization is `IdJag` and `wth` is not already set, `wth`
     /// is auto-populated as SHA-256(jwt) per the WIMSE wth binding.
+    #[cfg(any(test, feature = "test-classical-policy"))]
     pub fn new_signed(envelope: RequestEnvelope, signing_key: &SigningKey) -> Self {
         // Default policy is Classical for the bare Ed25519-only constructor so
         // that callers that don't supply a PQ key produce verifiable envelopes.
@@ -1501,10 +1395,8 @@ impl SignedEnvelope {
 
     /// Create and sign a new envelope under an explicit [`CryptoPolicy`].
     ///
-    /// - `Classical`: emits a single-EdDSA COSE composite. `pq_signing_key` is
-    ///   ignored.
     /// - `Hybrid`: emits an EdDSA + ML-DSA-65 COSE composite. `pq_signing_key`
-    ///   MUST be `Some`; if `None`, falls back to Classical (defensive).
+    ///   MUST be `Some`; absence is a fail-closed construction error.
     ///
     /// `sig`/`cnf` are always populated with the raw EdDSA signature + signer
     /// public key for the cnf key-binding path.
@@ -1553,7 +1445,9 @@ impl SignedEnvelope {
         signing_data: &[u8],
     ) -> Result<Vec<u8>> {
         let pq = if policy.uses_pq() {
-            pq_signing_key
+            Some(pq_signing_key.ok_or_else(|| {
+                anyhow!("mandatory Hybrid suite requires an ML-DSA-65 signing key")
+            })?)
         } else {
             None
         };
@@ -1659,6 +1553,7 @@ impl SignedEnvelope {
     /// - `EnvelopeError::InvalidPublicKey` if signer doesn't match expected
     /// - `EnvelopeError::ReplayAttack` if timestamp or nonce check fails
     /// - `EnvelopeError::InvalidSignature` if signature verification fails
+    #[cfg(any(test, feature = "test-classical-policy"))]
     pub fn verify(
         &self,
         expected_pubkey: &VerifyingKey,
@@ -1678,12 +1573,9 @@ impl SignedEnvelope {
     ///   the envelope's EdDSA signer (`cnf`). The COSE ML-DSA-65 entry must
     ///   verify against this key and its kid must match (kid-anchoring) —
     ///   fixing the self-certification weakness.
-    /// - `verify_policy`: `Hybrid` is Weakly Non-Separable (per-identity): for a
-    ///   signer with an anchored ML-DSA-65 key it ENFORCES the outer layer
-    ///   (rejecting stripped-outer, forged, and self-asserted PQ keys); for an
-    ///   unanchored signer it falls back to verifying the inner EdDSA (classical
-    ///   floor) rather than failing closed. `Classical` verifies only EdDSA and
-    ///   SKIPS any PQ entry (RFC 7517 skip-unknown interop).
+    /// - `verify_policy`: production pins `Hybrid`, which requires an anchored
+    ///   ML-DSA-65 key and enforces the outer layer. Missing anchors, stripped
+    ///   outers, forged keys, and self-asserted PQ keys all fail closed.
     pub fn verify_with(
         &self,
         expected_pubkey: &VerifyingKey,
@@ -1707,6 +1599,7 @@ impl SignedEnvelope {
     /// Verify signature only (skip replay protection).
     ///
     /// Use this for testing or when replay protection is handled elsewhere.
+    #[cfg(any(test, feature = "test-classical-policy"))]
     pub fn verify_signature_only(&self, expected_pubkey: &VerifyingKey) -> EnvelopeResult<()> {
         if !bool::from(self.cnf.ct_eq(&expected_pubkey.to_bytes())) {
             return Err(EnvelopeError::SignerMismatch {
@@ -1741,6 +1634,7 @@ impl SignedEnvelope {
     ///
     /// For WebTransport clients that sign with their own keypair rather than
     /// a shared server key. Still checks timestamp and nonce for replay protection.
+    #[cfg(any(test, feature = "test-classical-policy"))]
     pub fn verify_any_signer(&self, nonce_cache: &dyn NonceCache) -> EnvelopeResult<()> {
         self.verify_any_signer_with(nonce_cache, None, crate::crypto::CryptoPolicy::Classical)
     }
@@ -1760,106 +1654,6 @@ impl SignedEnvelope {
             })?;
         self.verify_cose(&verifying_key, pq_store, verify_policy)?;
         self.check_replay(nonce_cache)
-    }
-
-    /// Fu2/#677: like [`Self::verify_with`] but with an explicit
-    /// [`UnanchoredHybridPolicy`] + classical-floor allowlist governing how an
-    /// *unanchored* signer (no ML-DSA-65 binding in `pq_store`) is treated under
-    /// Hybrid. This is the production wire-verify path
-    /// ([`unwrap_and_verify`]); the default posture is deny-on-missing-anchor.
-    pub fn verify_with_unanchored_policy(
-        &self,
-        expected_pubkey: &VerifyingKey,
-        nonce_cache: &dyn NonceCache,
-        pq_store: Option<&dyn PqTrustStore>,
-        verify_policy: crate::crypto::CryptoPolicy,
-        unanchored: UnanchoredHybridPolicy,
-        allowlist: &[String],
-    ) -> EnvelopeResult<()> {
-        self.validate_timestamp()?;
-        if !bool::from(self.cnf.ct_eq(&expected_pubkey.to_bytes())) {
-            return Err(EnvelopeError::SignerMismatch {
-                expected: hex::encode(expected_pubkey.to_bytes()),
-                actual: hex::encode(self.cnf),
-            });
-        }
-        self.verify_cose_unanchored(
-            expected_pubkey,
-            pq_store,
-            verify_policy,
-            unanchored,
-            allowlist,
-        )?;
-        self.check_replay(nonce_cache)
-    }
-
-    /// Fu2/#677: any-signer variant of [`Self::verify_with_unanchored_policy`].
-    pub fn verify_any_signer_with_unanchored_policy(
-        &self,
-        nonce_cache: &dyn NonceCache,
-        pq_store: Option<&dyn PqTrustStore>,
-        verify_policy: crate::crypto::CryptoPolicy,
-        unanchored: UnanchoredHybridPolicy,
-        allowlist: &[String],
-    ) -> EnvelopeResult<()> {
-        self.validate_timestamp()?;
-        let verifying_key =
-            VerifyingKey::from_bytes(&self.cnf).map_err(|_| EnvelopeError::InvalidPublicKey {
-                expected: 32,
-                actual: 0,
-            })?;
-        self.verify_cose_unanchored(
-            &verifying_key,
-            pq_store,
-            verify_policy,
-            unanchored,
-            allowlist,
-        )?;
-        self.check_replay(nonce_cache)
-    }
-
-    fn verify_signature_with_unanchored_policy(
-        &self,
-        expected_pubkey: &VerifyingKey,
-        pq_store: Option<&dyn PqTrustStore>,
-        verify_policy: crate::crypto::CryptoPolicy,
-        unanchored: UnanchoredHybridPolicy,
-        allowlist: &[String],
-    ) -> EnvelopeResult<()> {
-        if !bool::from(self.cnf.ct_eq(&expected_pubkey.to_bytes())) {
-            return Err(EnvelopeError::SignerMismatch {
-                expected: hex::encode(expected_pubkey.to_bytes()),
-                actual: hex::encode(self.cnf),
-            });
-        }
-        self.verify_cose_unanchored(
-            expected_pubkey,
-            pq_store,
-            verify_policy,
-            unanchored,
-            allowlist,
-        )
-    }
-
-    fn verify_any_signature_with_unanchored_policy(
-        &self,
-        pq_store: Option<&dyn PqTrustStore>,
-        verify_policy: crate::crypto::CryptoPolicy,
-        unanchored: UnanchoredHybridPolicy,
-        allowlist: &[String],
-    ) -> EnvelopeResult<()> {
-        let verifying_key =
-            VerifyingKey::from_bytes(&self.cnf).map_err(|_| EnvelopeError::InvalidPublicKey {
-                expected: 32,
-                actual: 0,
-            })?;
-        self.verify_cose_unanchored(
-            &verifying_key,
-            pq_store,
-            verify_policy,
-            unanchored,
-            allowlist,
-        )
     }
 
     /// Non-mutating timestamp-window validation for early rejection before
@@ -1919,90 +1713,19 @@ impl SignedEnvelope {
         let signing_data = self.signed_bytes();
         let aad = envelope_external_aad();
 
-        // kid-anchor: resolve the trusted ML-DSA-65 key for this EdDSA identity.
-        let anchored_pq = pq_store.and_then(|s| s.ml_dsa_key_for(&self.cnf));
-
-        // WNS posture (draft-ietf-pquip-hybrid-signature-spectrums): the composite is
-        // Weakly Non-Separable — the inner EdDSA is independently verifiable, so PQ
-        // enforcement is applied PER-IDENTITY. Require the ML-DSA-65 outer ONLY for a
-        // signer whose PQ key we have anchored out-of-band; for an unanchored signer,
-        // fall back to the inner EdDSA (classical floor) rather than failing closed.
-        // Safe because ed_vk is derived from this same `cnf` (the PQ-lookup identity ==
-        // the EdDSA-verified identity), so an anchored identity cannot be downgraded by
-        // spoofing cnf, while an unanchored one is no weaker than classical. PQ is NEVER
-        // resolved from the self-asserted COSE entry (that is the self-cert weakness).
-        let require_pq = verify_policy.uses_pq() && anchored_pq.is_some();
-        #[cfg(not(target_arch = "wasm32"))]
-        if verify_policy.uses_pq() && anchored_pq.is_none() {
-            tracing::debug!(
-                "Hybrid policy active but signer has no anchored ML-DSA-65 key; \
-                 verifying classical inner EdDSA (WNS backwards-compat)"
-            );
-        }
-
-        crate::crypto::cose_sign::verify_composite(
-            &self.cose,
-            ed_vk,
-            anchored_pq.as_ref(),
-            &signing_data,
-            &aad,
-            require_pq,
-        )
-        .map_err(|e| EnvelopeError::PqSignatureInvalid(e.to_string()))?;
-
-        Ok(())
-    }
-
-    /// Fu2/#677: COSE composite verify with an explicit
-    /// [`UnanchoredHybridPolicy`] + classical-floor allowlist.
-    ///
-    /// Mirrors [`Self::verify_cose`] but, under a Hybrid policy, no longer
-    /// accepts an unanchored identity classical-only by default: with
-    /// [`UnanchoredHybridPolicy::Deny`] (the production default) an unanchored
-    /// signer is rejected unless its Ed25519 key hex is in `allowlist`. This
-    /// closes the audit's "hybrid is anchor-coverage-dependent" gap — the
-    /// default is now deny-on-missing-anchor, matching the UCAN verifier.
-    fn verify_cose_unanchored(
-        &self,
-        ed_vk: &VerifyingKey,
-        pq_store: Option<&dyn PqTrustStore>,
-        verify_policy: crate::crypto::CryptoPolicy,
-        unanchored: UnanchoredHybridPolicy,
-        allowlist: &[String],
-    ) -> EnvelopeResult<()> {
-        let signing_data = self.signed_bytes();
-        let aad = envelope_external_aad();
-        let anchored_pq = pq_store.and_then(|s| s.ml_dsa_key_for(&self.cnf));
-
-        let require_pq = if verify_policy.uses_pq() && anchored_pq.is_none() {
-            // Unanchored identity under Hybrid: gate the classical floor.
-            match unanchored {
-                UnanchoredHybridPolicy::AllowClassicalFloor => {
-                    #[cfg(not(target_arch = "wasm32"))]
-                    tracing::debug!(
-                        "Hybrid policy active but signer has no anchored ML-DSA-65 key; \
-                         verifying classical inner EdDSA (explicit AllowClassicalFloor)"
-                    );
-                    false
-                }
-                UnanchoredHybridPolicy::Deny => {
-                    let signer_hex = hex::encode(ed_vk.to_bytes());
-                    if allowlist.iter().any(|a| a == &signer_hex) {
-                        // Explicitly-allowlisted legacy peer: classical floor.
-                        false
-                    } else {
-                        return Err(EnvelopeError::PqSignatureInvalid(
-                            "Hybrid policy requires an anchored ML-DSA-65 key for this signer; \
-                             the identity is unanchored and not on the classical-floor allowlist \
-                             (deny-on-missing-anchor, Fu2/#677)"
+        let anchored_pq = if verify_policy.uses_pq() {
+            Some(
+                pq_store
+                    .and_then(|store| store.ml_dsa_key_for(&self.cnf))
+                    .ok_or_else(|| {
+                        EnvelopeError::PqSignatureInvalid(
+                            "mandatory Hybrid suite requires an anchored ML-DSA-65 signer key"
                                 .to_owned(),
-                        ));
-                    }
-                }
-            }
+                        )
+                    })?,
+            )
         } else {
-            // Anchored identity (require the outer under Hybrid) or Classical policy.
-            verify_policy.uses_pq() && anchored_pq.is_some()
+            None
         };
 
         crate::crypto::cose_sign::verify_composite(
@@ -2011,9 +1734,10 @@ impl SignedEnvelope {
             anchored_pq.as_ref(),
             &signing_data,
             &aad,
-            require_pq,
+            verify_policy.uses_pq(),
         )
         .map_err(|e| EnvelopeError::PqSignatureInvalid(e.to_string()))?;
+
         Ok(())
     }
 
@@ -2380,8 +2104,8 @@ impl FromCapnp for SignedEnvelope {
 /// The signing-data is `request_id || payload`, binding the response to a
 /// specific request and ensuring the payload hasn't been tampered with. The
 /// authoritative authentication mechanism is the COSE composite [`cose`] —
-/// one EdDSA entry (Classical) or EdDSA + ML-DSA-65 entries (Hybrid) — over
-/// that signing-data, bound to [`RESPONSE_ENVELOPE_TYPE_ID`] via the COSE
+/// the pinned EdDSA + ML-DSA-65 composite over that signing-data, bound to
+/// [`RESPONSE_ENVELOPE_TYPE_ID`] via the COSE
 /// `external_aad` so it can NEVER verify as a request signature.
 ///
 /// `sig`/`cnf` remain populated with the raw EdDSA signature + signer public
@@ -2410,13 +2134,13 @@ pub struct ResponseEnvelope {
     /// #275: CBOR-encoded nested COSE composite signature (detached).
     ///
     /// Authoritative authentication mechanism, mirroring [`SignedEnvelope::cose`].
-    /// Carries one EdDSA entry (Classical) or EdDSA + ML-DSA-65 entries (Hybrid)
-    /// over the response signing-data (`request_id || payload`), bound to the
+    /// Production carries the pinned EdDSA + ML-DSA-65 composite over the
+    /// response signing-data (`request_id || payload`), bound to the
     /// distinct [`RESPONSE_ENVELOPE_TYPE_ID`] domain. The ML-DSA-65 verifying key
     /// is resolved by kid from a [`PqTrustStore`] (kid-anchored), not embedded.
     pub cose: Vec<u8>,
 
-    /// Runtime crypto policy used when this envelope was signed.
+    /// Signature suite marker. Production construction always uses `Hybrid`.
     pub policy: crate::crypto::CryptoPolicy,
 }
 
@@ -2447,11 +2171,10 @@ impl ResponseEnvelope {
         Ok(data)
     }
 
-    /// Create and sign a new response envelope (Classical, EdDSA-only).
+    /// Create an EdDSA-only response for compatibility tests.
     ///
-    /// The bare constructor defaults to Classical so callers that don't supply a
-    /// PQ key produce verifiable envelopes, mirroring
-    /// [`SignedEnvelope::new_signed`].
+    /// This constructor is absent from production builds.
+    #[cfg(any(test, feature = "test-classical-policy"))]
     pub fn new_signed(request_id: u64, payload: Vec<u8>, signing_key: &SigningKey) -> Self {
         Self::new_signed_with_policy(
             request_id,
@@ -2481,9 +2204,8 @@ impl ResponseEnvelope {
     /// Create and sign a response under an explicit [`CryptoPolicy`].
     ///
     /// Mirrors [`SignedEnvelope::new_signed_with_policy`]:
-    /// - `Classical`: single-EdDSA COSE composite; `pq_signing_key` ignored.
     /// - `Hybrid`: EdDSA + ML-DSA-65 nested composite; `pq_signing_key` MUST be
-    ///   `Some` (if `None`, falls back to Classical, defensive).
+    ///   `Some`; absence is a fail-closed construction error.
     ///
     /// `sig`/`cnf` are always populated with the raw EdDSA signature + signer
     /// public key. The COSE build is **fail-closed**: a COSE encoding error
@@ -2641,7 +2363,9 @@ impl ResponseEnvelope {
         signing_data: &[u8],
     ) -> Result<Vec<u8>> {
         let pq = if policy.uses_pq() {
-            pq_signing_key
+            Some(pq_signing_key.ok_or_else(|| {
+                anyhow!("mandatory Hybrid suite requires an ML-DSA-65 response signing key")
+            })?)
         } else {
             None
         };
@@ -2649,11 +2373,12 @@ impl ResponseEnvelope {
         crate::crypto::cose_sign::sign_composite(signing_key, pq, signing_data, &aad)
     }
 
-    /// Verify the response signature (Classical-only, EdDSA via COSE).
+    /// Verify an EdDSA-only response in compatibility tests.
     ///
     /// Convenience wrapper mirroring [`SignedEnvelope::verify`]: uses the
     /// `Classical` policy and no PQ trust store. For Hybrid enforcement use
     /// [`Self::verify_with`].
+    #[cfg(any(test, feature = "test-classical-policy"))]
     pub fn verify(&self, expected_pubkey: Option<&VerifyingKey>) -> Result<()> {
         self.verify_with(
             expected_pubkey,
@@ -2664,16 +2389,12 @@ impl ResponseEnvelope {
 
     /// Verify with an explicit kid-anchored PQ trust store and verify policy.
     ///
-    /// Mirrors [`SignedEnvelope::verify_with`]'s WNS per-identity semantics:
+    /// Mirrors [`SignedEnvelope::verify_with`]'s mandatory-hybrid semantics:
     /// - `pq_store`: when `Some`, resolves the trust-anchored ML-DSA-65 key for
     ///   the response's EdDSA signer (`cnf`); the outer COSE entry must verify
     ///   against it and its kid must match (kid-anchoring).
-    /// - `verify_policy = Hybrid` is Weakly Non-Separable (per-identity): for a
-    ///   signer with an anchored ML-DSA-65 key it ENFORCES the outer layer — a
-    ///   stripped/forged/self-cert outer on an ANCHORED identity is rejected; for
-    ///   an unanchored signer it falls back to verifying the inner EdDSA
-    ///   (classical floor) rather than failing closed. `Classical` verifies only
-    ///   the inner EdDSA and skips any PQ entry.
+    /// - `verify_policy = Hybrid` requires an anchored ML-DSA-65 key and the
+    ///   intact outer signature. Unanchored and classical-only responses fail.
     pub fn verify_with(
         &self,
         expected_pubkey: Option<&VerifyingKey>,
@@ -2741,26 +2462,19 @@ impl ResponseEnvelope {
         };
         let aad = response_envelope_external_aad();
 
-        // kid-anchor: resolve the trusted ML-DSA-65 key for this EdDSA identity.
-        let anchored_pq = pq_store.and_then(|s| s.ml_dsa_key_for(&self.cnf));
-
-        // WNS posture (draft-ietf-pquip-hybrid-signature-spectrums): the composite is
-        // Weakly Non-Separable — the inner EdDSA is independently verifiable, so PQ
-        // enforcement is applied PER-IDENTITY. Require the ML-DSA-65 outer ONLY for a
-        // signer whose PQ key we have anchored out-of-band; for an unanchored signer,
-        // fall back to the inner EdDSA (classical floor) rather than failing closed.
-        // Safe because ed_vk is derived from this same `cnf` (the PQ-lookup identity ==
-        // the EdDSA-verified identity), so an anchored identity cannot be downgraded by
-        // spoofing cnf, while an unanchored one is no weaker than classical. PQ is NEVER
-        // resolved from the self-asserted COSE entry (that is the self-cert weakness).
-        let require_pq = verify_policy.uses_pq() && anchored_pq.is_some();
-        #[cfg(not(target_arch = "wasm32"))]
-        if verify_policy.uses_pq() && anchored_pq.is_none() {
-            tracing::debug!(
-                "Hybrid policy active but signer has no anchored ML-DSA-65 key; \
-                 verifying classical inner EdDSA (WNS backwards-compat)"
-            );
-        }
+        let anchored_pq = if verify_policy.uses_pq() {
+            Some(
+                pq_store
+                    .and_then(|store| store.ml_dsa_key_for(&self.cnf))
+                    .ok_or_else(|| {
+                        anyhow!(
+                            "mandatory Hybrid suite requires an anchored ML-DSA-65 response key"
+                        )
+                    })?,
+            )
+        } else {
+            None
+        };
 
         crate::crypto::cose_sign::verify_composite(
             &self.cose,
@@ -2768,7 +2482,7 @@ impl ResponseEnvelope {
             anchored_pq.as_ref(),
             &signing_data,
             &aad,
-            require_pq,
+            verify_policy.uses_pq(),
         )
         .map_err(|e| anyhow::anyhow!("Response signature verification failed: {e}"))?;
 
@@ -2865,29 +2579,28 @@ pub fn unwrap_and_verify(
     // mutating replay state. The timestamp is revalidated at final commit.
     signed.validate_timestamp()?;
 
-    // Authenticate first without mutating replay state.  The compatibility
-    // lifecycle commits the nonce only after canonical COSE parsing, external-
+    // Authenticate first without mutating replay state. The lifecycle commits
+    // the nonce only after canonical COSE parsing, external-
     // AAD authentication, decryption, and inner/outer equality all succeed.
     match &opts.verification {
         EnvelopeVerification::FixedSigner(pubkey) => {
-            // Fu2/#677: production wire verify uses the unanchored-aware path —
-            // deny-on-missing-anchor by default, with an opt-in classical-floor
-            // allowlist for legacy peers.
-            signed.verify_signature_with_unanchored_policy(
-                pubkey,
-                opts.pq_store,
-                opts.verify_policy,
-                opts.unanchored_policy,
-                &opts.unanchored_classical_allowlist,
-            )?;
+            if !bool::from(signed.cnf.ct_eq(&pubkey.to_bytes())) {
+                return Err(EnvelopeError::SignerMismatch {
+                    expected: hex::encode(pubkey.to_bytes()),
+                    actual: hex::encode(signed.cnf),
+                }
+                .into());
+            }
+            signed.verify_cose(pubkey, opts.pq_store, opts.verify_policy)?;
         }
         EnvelopeVerification::AnySigner => {
-            signed.verify_any_signature_with_unanchored_policy(
-                opts.pq_store,
-                opts.verify_policy,
-                opts.unanchored_policy,
-                &opts.unanchored_classical_allowlist,
-            )?;
+            let verifying_key = VerifyingKey::from_bytes(&signed.cnf).map_err(|_| {
+                EnvelopeError::InvalidPublicKey {
+                    expected: 32,
+                    actual: 0,
+                }
+            })?;
+            signed.verify_cose(&verifying_key, opts.pq_store, opts.verify_policy)?;
         }
     }
 
@@ -2950,7 +2663,7 @@ pub fn unwrap_envelope(
     Ok((ctx, payload))
 }
 
-/// Unwrap and verify a ResponseEnvelope from wire bytes (Classical-only).
+/// Unwrap an EdDSA-only response in compatibility tests.
 ///
 /// Convenience wrapper over [`unwrap_response_with`] using the `Classical`
 /// policy and no PQ trust store. Mirrors [`SignedEnvelope::verify`]; for Hybrid
@@ -2973,6 +2686,7 @@ pub fn unwrap_envelope(
 /// - Deserialization fails
 /// - Signature verification fails
 /// - Signer doesn't match expected_pubkey (if provided)
+#[cfg(any(test, feature = "test-classical-policy"))]
 pub fn unwrap_response(
     response: &[u8],
     expected_pubkey: Option<&VerifyingKey>,
@@ -2988,11 +2702,9 @@ pub fn unwrap_response(
 /// Unwrap and verify a ResponseEnvelope under an explicit kid-anchored PQ trust
 /// store + verify policy (#275).
 ///
-/// Enforces the COSE composite with the SAME WNS per-identity semantics as
-/// [`unwrap_and_verify`]: under `Hybrid`, an anchored signer must use its
-/// ML-DSA-65 key (a stripped-outer, classical-only, self-cert, or forged outer
-/// on an ANCHORED identity is REJECTED), while an unanchored signer falls back
-/// to the inner EdDSA (classical floor) rather than failing closed.
+/// Enforces the same mandatory-hybrid semantics as [`unwrap_and_verify`]: the
+/// signer must have an anchored ML-DSA-65 key and the outer signature must
+/// verify. Missing anchors and classical-only responses fail closed.
 pub fn unwrap_response_with(
     response: &[u8],
     expected_pubkey: Option<&VerifyingKey>,
@@ -3032,11 +2744,6 @@ mod tests {
     use crate::crypto::signing::generate_signing_keypair;
     use parking_lot::Mutex;
     use std::collections::HashSet;
-
-    /// Serializes tests that mutate the shared `HYPRSTREAM_ENVELOPE_POLICY` env
-    /// var so they don't race under parallel `cargo test`.
-    #[cfg(not(target_arch = "wasm32"))]
-    static ENV_TEST_LOCK: Mutex<()> = Mutex::new(());
 
     /// Simple in-memory nonce cache for testing.
     struct TestNonceCache {
@@ -4029,20 +3736,17 @@ mod tests {
         );
     }
 
-    /// Hybrid policy with NO anchored key falls back to the classical inner
-    /// EdDSA floor (WNS per-identity): an unanchored signer is verified via its
-    /// EdDSA component rather than failing closed. PQ is never trusted from the
-    /// self-asserted COSE entry, so this is no weaker than classical.
+    /// Hybrid policy with no anchored key fails closed.
     #[test]
-    fn m3_hybrid_policy_without_anchor_classical_fallback() -> crate::EnvelopeResult<()> {
+    fn m3_hybrid_policy_without_anchor_rejected() {
         let (sk, vk) = generate_signing_keypair();
         let (pq_sk, _pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
         let cache = TestNonceCache::new();
         let signed =
             SignedEnvelope::new_signed_hybrid(RequestEnvelope::anonymous(vec![1]), &sk, &pq_sk);
-        // Empty store (no anchor) + Hybrid policy → classical inner-EdDSA fallback.
-        signed.verify_with(&vk, &cache, None, CryptoPolicy::Hybrid)?;
-        Ok(())
+        assert!(signed
+            .verify_with(&vk, &cache, None, CryptoPolicy::Hybrid)
+            .is_err());
     }
 
     // -- SNS-specific: strip the outer ML-DSA layer at the cose level and prove
@@ -4180,35 +3884,6 @@ mod tests {
         );
     }
 
-    /// Fu2/#677 allowlist: the same unanchored identity IS accepted when its
-    /// Ed25519 key hex is on the classical-floor allowlist (the legacy-peer
-    /// escape hatch).
-    #[test]
-    fn fu2_unanchored_allowed_via_allowlist() {
-        let ((_sk, vk), wire) = fu2_hybrid_wire_unanchored();
-        let cache = TestNonceCache::new();
-        let opts = UnwrapOptions::fixed_signer(&vk, &cache)
-            .with_verify_policy(CryptoPolicy::Hybrid)
-            .with_unanchored_allowlist(vec![hex::encode(vk.to_bytes())]);
-        let (_signed, payload) = unwrap_and_verify(&wire, &opts)
-            .expect("an allowlisted unanchored identity is accepted (classical floor)");
-        assert_eq!(payload, vec![5, 0, 2]);
-    }
-
-    /// Fu2/#677 explicit opt-in: `AllowClassicalFloor` accepts an unanchored
-    /// identity under Hybrid without an allowlist (the legacy WNS posture,
-    /// available to low-level callers that want it).
-    #[test]
-    fn fu2_unanchored_allowed_via_legacy_policy() {
-        let ((_sk, vk), wire) = fu2_hybrid_wire_unanchored();
-        let cache = TestNonceCache::new();
-        let opts = UnwrapOptions::fixed_signer(&vk, &cache)
-            .with_verify_policy(CryptoPolicy::Hybrid)
-            .with_unanchored_policy(UnanchoredHybridPolicy::AllowClassicalFloor);
-        let (_signed, _payload) = unwrap_and_verify(&wire, &opts)
-            .expect("AllowClassicalFloor accepts an unanchored identity (legacy posture)");
-    }
-
     // =========================================================================
     // #275: ResponseEnvelope COSE composite (Hybrid parity with SignedEnvelope)
     // =========================================================================
@@ -4292,55 +3967,26 @@ mod tests {
 
     // =========================================================================
     // #277: process-global RESPONSE verify config — fail-closed Hybrid default,
-    // anchored-key enforcement, and the shared `classical` escape hatch.
+    // and anchored-key enforcement.
     // =========================================================================
 
-    /// The escape-hatch parser is the single source of truth shared by the
-    /// request and response sides: unset / `hybrid` => fail-closed Hybrid, the
-    /// literal `classical` => downgrade, junk => Hybrid (fail-safe).
-    ///
-    /// `#[cfg(not(target_arch = "wasm32"))]` because `envelope_policy_from_env`
-    /// is native-only (it reads a process env var). Serialized via a mutex with
-    /// the other env-mutating test so they don't race on the shared env var.
-    #[cfg(not(target_arch = "wasm32"))]
+    /// The production selector has exactly one pinned suite and reads no wire
+    /// or environment input.
     #[test]
-    fn resp_escape_hatch_env_parse_parity() {
-        let _guard = ENV_TEST_LOCK.lock();
-        // SAFETY: single-threaded section guarded by ENV_TEST_LOCK.
-        unsafe { std::env::remove_var(ENVELOPE_POLICY_ENV) };
-        assert_eq!(
-            envelope_policy_from_env(),
-            CryptoPolicy::Hybrid,
-            "default must be Hybrid"
-        );
-        unsafe { std::env::set_var(ENVELOPE_POLICY_ENV, "hybrid") };
-        assert_eq!(envelope_policy_from_env(), CryptoPolicy::Hybrid);
-        unsafe { std::env::set_var(ENVELOPE_POLICY_ENV, "classical") };
-        assert_eq!(
-            envelope_policy_from_env(),
-            CryptoPolicy::Classical,
-            "the escape hatch must downgrade the response side in parity with the request side"
-        );
-        unsafe { std::env::set_var(ENVELOPE_POLICY_ENV, "bogus") };
-        assert_eq!(
-            envelope_policy_from_env(),
-            CryptoPolicy::Hybrid,
-            "junk must fail-safe to Hybrid"
-        );
-        unsafe { std::env::remove_var(ENVELOPE_POLICY_ENV) };
+    fn mandatory_policy_is_pinned_hybrid() {
+        assert_eq!(mandatory_envelope_policy(), CryptoPolicy::Hybrid);
     }
 
     /// Process-global RESPONSE verify config drives per-identity enforcement
     /// (#277, WNS posture): once a Hybrid config + admin-anchored
     /// `KeyedPqTrustStore` is installed, a Hybrid response whose server ML-DSA key
-    /// IS anchored verifies with the outer enforced; an UNanchored signer falls
-    /// back to its inner EdDSA (classical floor); but an ANCHORED signer that
-    /// sends a classical-only response is rejected (it must use its PQ key — no
-    /// downgrade for anchored identities). This is the install/consult path native
+    /// IS anchored verifies with the outer enforced; an unanchored signer and an
+    /// anchored signer that sends a classical-only response are both rejected.
+    /// This is the install/consult path native
     /// RPC clients fall back to when no per-client store was set. Single OnceLock
     /// install per test binary, so this is the one test that installs the config.
     #[test]
-    fn resp_global_config_anchored_enforced_unanchored_falls_back() -> anyhow::Result<()> {
+    fn resp_global_config_requires_anchor_and_hybrid_outer() -> anyhow::Result<()> {
         // Anchored signer.
         let (sk, vk) = generate_signing_keypair();
         let (pq_sk, pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
@@ -4372,19 +4018,17 @@ mod tests {
         assert_eq!(rid, 11);
         assert_eq!(payload, vec![7, 7]);
 
-        // Unanchored signer's Hybrid response falls back to its inner EdDSA
-        // (classical floor) under the WNS posture — no anchored ML-DSA key, so PQ
-        // is not enforced for this identity, but the response still verifies.
+        // Unanchored signer is rejected even when it carries a valid hybrid
+        // composite; the verifying key must be policy-anchored.
         let resp2 = ResponseEnvelope::new_signed_hybrid(12, vec![8, 8], &sk2, &pq_sk2);
         let wire2 = response_to_wire(&resp2);
-        let (rid2, payload2) = unwrap_response_with(
+        let unanchored = unwrap_response_with(
             &wire2,
             Some(&vk2),
             Some(store.as_ref()),
             global_response_verify_policy(),
-        )?;
-        assert_eq!(rid2, 12);
-        assert_eq!(payload2, vec![8, 8]);
+        );
+        assert!(unanchored.is_err());
 
         // A Classical-only (inner-EdDSA-only) response from the ANCHORED signer is
         // rejected: an anchored identity must use its PQ key (the outer is enforced
@@ -4487,17 +4131,15 @@ mod tests {
         );
     }
 
-    /// Hybrid policy with NO anchored key falls back to the inner EdDSA classical
-    /// floor (WNS per-identity): an unanchored response signer verifies via its
-    /// EdDSA component rather than failing closed. PQ is never trusted from the
-    /// self-asserted COSE entry, so this is no weaker than classical.
+    /// Hybrid policy with no anchored response key fails closed.
     #[test]
-    fn resp_hybrid_without_anchor_classical_fallback() -> anyhow::Result<()> {
+    fn resp_hybrid_without_anchor_is_rejected() {
         let (sk, vk) = generate_signing_keypair();
         let (pq_sk, _pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
         let resp = ResponseEnvelope::new_signed_hybrid(6, vec![6], &sk, &pq_sk);
-        resp.verify_with(Some(&vk), None, CryptoPolicy::Hybrid)?;
-        Ok(())
+        assert!(resp
+            .verify_with(Some(&vk), None, CryptoPolicy::Hybrid)
+            .is_err());
     }
 
     /// classical-signed response under Hybrid policy → rejected (no downgrade).
@@ -4515,9 +4157,7 @@ mod tests {
     }
 
     // =========================================================================
-    // WNS posture (draft-ietf-pquip-hybrid-signature-spectrums): per-identity PQ
-    // enforcement. Anchored identities cannot downgrade; unanchored identities
-    // fall back to the classical inner-EdDSA floor instead of failing closed.
+    // Mandatory hybrid posture: every identity requires an anchored PQ key.
     // Covers BOTH SignedEnvelope and ResponseEnvelope paths.
     // =========================================================================
 
@@ -4547,11 +4187,9 @@ mod tests {
         );
     }
 
-    /// WNS / SignedEnvelope (2) unanchored classical fallback: empty store, Hybrid
-    /// policy, Hybrid-signed envelope from an UNanchored signer → SUCCEEDS via the
-    /// inner EdDSA floor (the deploy-blocker fix).
+    /// An unanchored signer is rejected with an empty or absent trust store.
     #[test]
-    fn wns_signed_unanchored_classical_fallback() -> crate::EnvelopeResult<()> {
+    fn mandatory_hybrid_signed_unanchored_rejected() {
         let (sk, vk) = generate_signing_keypair();
         let (pq_sk, _pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
         let cache = TestNonceCache::new();
@@ -4561,11 +4199,13 @@ mod tests {
             &pq_sk,
         );
         let empty = TestPqStore { bindings: vec![] };
-        signed.verify_with(&vk, &cache, Some(&empty), CryptoPolicy::Hybrid)?;
-        // Also with no store at all (None), mirroring an empty default deployment.
+        assert!(signed
+            .verify_with(&vk, &cache, Some(&empty), CryptoPolicy::Hybrid)
+            .is_err());
         let cache2 = TestNonceCache::new();
-        signed.verify_with(&vk, &cache2, None, CryptoPolicy::Hybrid)?;
-        Ok(())
+        assert!(signed
+            .verify_with(&vk, &cache2, None, CryptoPolicy::Hybrid)
+            .is_err());
     }
 
     /// WNS / SignedEnvelope (3) anchored enforced: anchored signer + intact Hybrid
@@ -4611,18 +4251,19 @@ mod tests {
         );
     }
 
-    /// WNS / ResponseEnvelope (2) unanchored classical fallback (mirrors the
-    /// SignedEnvelope case for the response path specifically).
+    /// Response verification also rejects unanchored signers.
     #[test]
-    fn wns_response_unanchored_classical_fallback() -> anyhow::Result<()> {
+    fn mandatory_hybrid_response_unanchored_rejected() {
         let (sk, vk) = generate_signing_keypair();
         let (pq_sk, _pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
         let resp = ResponseEnvelope::new_signed_hybrid(21, vec![2, 1], &sk, &pq_sk);
         let empty = TestPqStore { bindings: vec![] };
-        resp.verify_with(Some(&vk), Some(&empty), CryptoPolicy::Hybrid)?;
-        // And with no store at all.
-        resp.verify_with(Some(&vk), None, CryptoPolicy::Hybrid)?;
-        Ok(())
+        assert!(resp
+            .verify_with(Some(&vk), Some(&empty), CryptoPolicy::Hybrid)
+            .is_err());
+        assert!(resp
+            .verify_with(Some(&vk), None, CryptoPolicy::Hybrid)
+            .is_err());
     }
 
     /// WNS / ResponseEnvelope (3) anchored enforced.

--- a/crates/hyprstream-rpc/src/rpc_client.rs
+++ b/crates/hyprstream-rpc/src/rpc_client.rs
@@ -583,7 +583,7 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
             pending,
             self.response_pq_store.as_deref(),
             self.response_verify_policy
-                .unwrap_or(crate::crypto::CryptoPolicy::Classical),
+                .unwrap_or(crate::crypto::CryptoPolicy::Hybrid),
         )
     }
 
@@ -721,12 +721,11 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
         let ed_pubkey = self.signer.pubkey();
         let signing_data: &[u8] = encrypted_envelope.as_deref().unwrap_or(&canonical);
 
-        if encrypted_envelope.is_some() && self.signer.pq_pubkey().is_none() {
-            anyhow::bail!(
-                "transport forbids cleartext envelopes but signer has no ML-DSA-65 \
-                 key; refusing to emit encrypted envelope without hybrid signature"
-            );
-        }
+        let pq_kid = self.signer.pq_pubkey().ok_or_else(|| {
+            anyhow::anyhow!(
+                "mandatory Hybrid suite requires an ML-DSA-65 signer key; refusing request"
+            )
+        })?;
 
         // Raw EdDSA signature (sig/cnf) retained for signer-pubkey advertisement
         // + the JWT cnf key-binding path.
@@ -742,42 +741,26 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
         // outer ML-DSA-65 layer over `canonical ‖ inner_eddsa_signature` so the
         // inner signature is bound into the outer (Strong-Non-Separable).
         //
-        // Hybrid iff the signer exposes an ML-DSA-65 key. In Hybrid mode the inner
-        // EdDSA layer binds the hybrid-composite alg-id into its AAD (#278), making
-        // it byte-distinct from a Classical inner layer.
-        let hybrid = self.signer.pq_pubkey().is_some();
+        // The inner EdDSA layer always binds the pinned hybrid-composite alg-id
+        // into its AAD (#278). There is no classical request construction path.
+        let hybrid = true;
         let ed_kid = ed_pubkey.to_vec();
         let ed_tbs =
             crate::crypto::cose_sign::inner_tbs(ed_kid.clone(), signing_data, &aad, hybrid);
         let ed_sig = self.signer.sign(&ed_tbs).await?.to_vec();
 
-        // Hybrid component when the signer exposes an ML-DSA-65 key.
-        let pq_entry = if let Some(pq_kid) = self.signer.pq_pubkey() {
-            let pq_tbs =
-                crate::crypto::cose_sign::outer_tbs(pq_kid.clone(), signing_data, &ed_sig, &aad);
-            // The inner EdDSA above was already bound to the hybrid-composite
-            // alg-id (`hybrid = pq_pubkey().is_some()`), so it cannot fall back to
-            // a classical inner. A signer that advertises a PQ key but declines to
-            // sign must therefore be a HARD ERROR, not a silent downgrade that
-            // would desync inner-AAD (hybrid) from outer-presence (none) and make
-            // the peer's inner verification fail (#278 review).
-            let pq_sig = self.signer.pq_sign(&pq_tbs).await?.ok_or_else(|| {
-                anyhow::anyhow!(
-                    "signer exposes a PQ public key but pq_sign() returned no \
-                         signature; refusing to emit a hybrid-bound inner without \
-                         its ML-DSA-65 outer (#278)"
-                )
-            })?;
-            Some((pq_kid, pq_sig))
-        } else {
-            None
-        };
-        let policy = if pq_entry.is_some() {
-            crate::crypto::CryptoPolicy::Hybrid
-        } else {
-            crate::crypto::CryptoPolicy::Classical
-        };
-        let cose = crate::crypto::cose_sign::assemble_composite_nested((ed_kid, ed_sig), pq_entry)?;
+        let pq_tbs =
+            crate::crypto::cose_sign::outer_tbs(pq_kid.clone(), signing_data, &ed_sig, &aad);
+        let pq_sig = self.signer.pq_sign(&pq_tbs).await?.ok_or_else(|| {
+            anyhow::anyhow!(
+                "signer exposes a PQ public key but pq_sign() returned no signature; \
+                 refusing to emit an incomplete mandatory Hybrid composite"
+            )
+        })?;
+        let cose = crate::crypto::cose_sign::assemble_composite_nested(
+            (ed_kid, ed_sig),
+            Some((pq_kid, pq_sig)),
+        )?;
 
         let signed = SignedEnvelope {
             envelope,
@@ -786,7 +769,7 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
             encrypted_envelope,
             client_ephemeral_public: None,
             cose,
-            policy,
+            policy: crate::crypto::CryptoPolicy::Hybrid,
             pq_kem_ciphertext: None,
         };
 

--- a/crates/hyprstream-rpc/src/service/dispatch.rs
+++ b/crates/hyprstream-rpc/src/service/dispatch.rs
@@ -69,12 +69,6 @@ where
     //    process-global verify configuration installed at startup (Hybrid
     //    ENFORCED in the daemon). This closes the prior fail-open where the
     //    site hardcoded Classical / no PQ store.
-    // Refuse before admission/dispatch if the service cannot emit the mandatory
-    // pinned hybrid response suite. Missing key material is never a signal to
-    // construct a classical response.
-    let response_pq_key = service.pq_signing_key().ok_or_else(|| {
-        anyhow::anyhow!("service has no ML-DSA-65 response signing key (mandatory Hybrid suite)")
-    })?;
     let pq_store_holder = crate::envelope::global_pq_store();
     let base = match verification {
         EnvelopeVerification::FixedSigner(pubkey) => {
@@ -120,6 +114,14 @@ where
             "authenticated network request omitted responseKemRecipient; dropping without response"
         );
     }
+    // Refuse before dispatch if the service cannot emit the mandatory pinned
+    // hybrid response suite. Missing key material is never a signal to
+    // construct a classical response. Deliberately checked only after envelope
+    // authentication: the default `pq_signing_key()` derives an ML-DSA key per
+    // call, and unauthenticated input must not be able to trigger that work.
+    let response_pq_key = service.pq_signing_key().ok_or_else(|| {
+        anyhow::anyhow!("service has no ML-DSA-65 response signing key (mandatory Hybrid suite)")
+    })?;
     let response_recipient = ctx.response_kem_recipient.clone();
     let request_iat = ctx.request_iat;
     let request_nonce = ctx.request_nonce;
@@ -140,13 +142,13 @@ where
             )
             .map_err(Into::into)
         } else {
-            Ok(ResponseEnvelope::new_signed_with_policy(
+            ResponseEnvelope::new_signed_with_policy(
                 request_id,
                 payload,
                 signing_key,
                 Some(&response_pq_key),
                 crate::crypto::CryptoPolicy::Hybrid,
-            ))
+            )
         }
     };
     debug!(

--- a/crates/hyprstream-rpc/src/service/dispatch.rs
+++ b/crates/hyprstream-rpc/src/service/dispatch.rs
@@ -69,17 +69,12 @@ where
     //    process-global verify configuration installed at startup (Hybrid
     //    ENFORCED in the daemon). This closes the prior fail-open where the
     //    site hardcoded Classical / no PQ store.
-    // Response signing policy (#275): mirror the request side — sign the
-    // strongest composite the server has keys for. When the service exposes an
-    // ML-DSA-65 key, responses are Hybrid (EdDSA + ML-DSA-65); otherwise
-    // Classical. A Classical-only client still verifies via the inner EdDSA
-    // (skip-unknown interop), and a Hybrid-enforcing client requires the anchor.
-    let response_pq_key = service.pq_signing_key();
-    let response_policy = if response_pq_key.is_some() {
-        crate::crypto::CryptoPolicy::Hybrid
-    } else {
-        crate::crypto::CryptoPolicy::Classical
-    };
+    // Refuse before admission/dispatch if the service cannot emit the mandatory
+    // pinned hybrid response suite. Missing key material is never a signal to
+    // construct a classical response.
+    let response_pq_key = service.pq_signing_key().ok_or_else(|| {
+        anyhow::anyhow!("service has no ML-DSA-65 response signing key (mandatory Hybrid suite)")
+    })?;
     let pq_store_holder = crate::envelope::global_pq_store();
     let base = match verification {
         EnvelopeVerification::FixedSigner(pubkey) => {
@@ -125,11 +120,6 @@ where
             "authenticated network request omitted responseKemRecipient; dropping without response"
         );
     }
-    if carrier.forbids_cleartext_envelope() && response_pq_key.is_none() {
-        anyhow::bail!(
-            "network response requires an ML-DSA-65 signing key; dropping without cleartext"
-        );
-    }
     let response_recipient = ctx.response_kem_recipient.clone();
     let request_iat = ctx.request_iat;
     let request_nonce = ctx.request_nonce;
@@ -138,14 +128,11 @@ where
             let recipient = response_recipient
                 .as_ref()
                 .ok_or_else(|| anyhow::anyhow!("missing authenticated response recipient"))?;
-            let pq_key = response_pq_key
-                .as_ref()
-                .ok_or_else(|| anyhow::anyhow!("missing response ML-DSA-65 signing key"))?;
             ResponseEnvelope::new_signed_encrypted(
                 request_id,
                 payload,
                 signing_key,
-                pq_key,
+                &response_pq_key,
                 recipient,
                 request_iat,
                 &request_nonce,
@@ -157,8 +144,8 @@ where
                 request_id,
                 payload,
                 signing_key,
-                response_pq_key.as_ref(),
-                response_policy,
+                Some(&response_pq_key),
+                crate::crypto::CryptoPolicy::Hybrid,
             ))
         }
     };

--- a/crates/hyprstream-rpc/src/service/svc.rs
+++ b/crates/hyprstream-rpc/src/service/svc.rs
@@ -517,9 +517,8 @@ pub trait RequestService: 'static {
     fn signing_key(&self) -> SigningKey;
 
     /// ML-DSA-65 signing key for the post-quantum half of the response COSE
-    /// composite (#275). When `Some`, `process_request` signs the
-    /// `ResponseEnvelope` under the Hybrid policy (EdDSA + ML-DSA-65); when
-    /// `None` it signs Classical (EdDSA-only). The matching ML-DSA-65 public key
+    /// composite (#275). Returning `None` makes `process_request` fail closed
+    /// before dispatch; it never selects an EdDSA-only response. The matching ML-DSA-65 public key
     /// must be anchored in the client's PQ trust store for Hybrid verification
     /// to succeed (peer attestation).
     ///
@@ -531,10 +530,7 @@ pub trait RequestService: 'static {
     /// stores — Ed25519 signer pubkey → ML-DSA vk — is self-consistent, and the
     /// published `#mesh-pq` DID verification method equals this signing key.
     ///
-    /// Mirrors the request-side signing policy: the server emits the strongest
-    /// composite it has keys for; a Classical verifier still accepts it via the
-    /// inner EdDSA (skip-unknown interop). Override to return `None` to force
-    /// Classical-only responses.
+    /// Mirrors the request-side mandatory pinned suite.
     fn pq_signing_key(&self) -> Option<crate::crypto::pq::MlDsaSigningKey> {
         Some(crate::node_identity::derive_mesh_mldsa_key(
             &self.signing_key(),
@@ -593,8 +589,7 @@ pub trait RequestService: 'static {
     /// outright, independent of JWKS `kid_algs` hygiene. The default reads the
     /// process-global envelope verify config (Hybrid in production), so the
     /// per-call policy is test-isolated from sibling tests that mutate the
-    /// shared global — a mock/test service that needs EdDSA acceptance overrides
-    /// this to [`CryptoPolicy::Classical`].
+    /// shared global.
     fn jwt_verify_policy(&self) -> crate::crypto::CryptoPolicy {
         #[cfg(not(target_arch = "wasm32"))]
         {
@@ -602,7 +597,7 @@ pub trait RequestService: 'static {
         }
         #[cfg(target_arch = "wasm32")]
         {
-            crate::crypto::CryptoPolicy::Classical
+            crate::crypto::CryptoPolicy::Hybrid
         }
     }
 

--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -1272,8 +1272,18 @@ mod tests {
         } else {
             crate::crypto::CryptoPolicy::Classical
         };
-        let signed =
-            SignedEnvelope::new_signed_with_policy(envelope, signing_key, pq_signing_key, policy);
+        let signed = match SignedEnvelope::new_signed_with_policy(
+            envelope,
+            signing_key,
+            pq_signing_key,
+            policy,
+        ) {
+            Ok(signed) => signed,
+            Err(e) => {
+                tracing::error!("Failed to sign envelope: {e}");
+                return Vec::new();
+            }
+        };
         let mut msg = Builder::new_default();
         {
             let mut builder = msg.init_root::<common_capnp::signed_envelope::Builder>();

--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -1338,21 +1338,18 @@ mod tests {
             "anchored Hybrid register must verify"
         );
 
-        // Not anchored: empty store under Hybrid falls back to the inner EdDSA
-        // classical floor (WNS per-identity) rather than failing closed. PQ is
-        // never trusted from the self-asserted COSE entry, so this is no weaker
-        // than the pre-existing classical `verify_any_signer` path.
+        // Not anchored: the mandatory Hybrid policy rejects the register even
+        // though its self-asserted composite is cryptographically well formed.
         let empty = KeyedPqTrustStore::new();
         let nonce_empty = InMemoryNonceCache::new();
         assert!(
             signed
                 .verify_any_signer_with(&nonce_empty, Some(&empty), CryptoPolicy::Hybrid)
-                .is_ok(),
-            "unanchored Hybrid register must verify via classical inner-EdDSA fallback"
+                .is_err(),
+            "unanchored Hybrid register must fail closed"
         );
 
-        // But a tampered/forged inner EdDSA on an unanchored signer is still
-        // rejected — the classical floor is a real signature check, not a bypass.
+        // A tampered/forged inner EdDSA is also rejected.
         let mut forged = signed.clone();
         forged.cnf = SigningKey::from_bytes(&[9u8; 32])
             .verifying_key()

--- a/crates/hyprstream-rpc/src/transport/rpc_session.rs
+++ b/crates/hyprstream-rpc/src/transport/rpc_session.rs
@@ -407,7 +407,12 @@ async fn handle_stream<S>(
         }
         Err(e) => {
             tracing::warn!(error = ?e, "rpc-session: trusted-carrier processor error, sending stub error envelope");
-            build_error_envelope(&signing_key, None, &format!("processor error: {e}"))
+            let pq_signing_key = crate::node_identity::derive_mesh_mldsa_key(&signing_key);
+            build_error_envelope(
+                &signing_key,
+                &pq_signing_key,
+                &format!("processor error: {e}"),
+            )
         }
     };
 
@@ -431,27 +436,21 @@ async fn handle_stream<S>(
 /// the payload. Used when the processor itself fails — guarantees the client
 /// sees a parseable envelope rather than EOF.
 ///
-/// #275: emits a COSE composite. When `pq_signing_key` is `Some` the error
-/// envelope is Hybrid (EdDSA + ML-DSA-65); otherwise Classical (EdDSA-only).
-/// A Classical-only client still verifies it via the inner EdDSA (skip-unknown).
+/// #275: emits the mandatory Hybrid COSE composite. Callers must supply both
+/// signing components; this constructor has no classical fallback.
 pub fn build_error_envelope(
     signing_key: &SigningKey,
-    pq_signing_key: Option<&crate::crypto::pq::MlDsaSigningKey>,
+    pq_signing_key: &crate::crypto::pq::MlDsaSigningKey,
     message: &str,
 ) -> Bytes {
     use crate::ToCapnp;
     use capnp::{message::Builder, serialize};
-    let policy = if pq_signing_key.is_some() {
-        crate::crypto::CryptoPolicy::Hybrid
-    } else {
-        crate::crypto::CryptoPolicy::Classical
-    };
     let envelope = crate::envelope::ResponseEnvelope::new_signed_with_policy(
         0,
         message.as_bytes().to_vec(),
         signing_key,
-        pq_signing_key,
-        policy,
+        Some(pq_signing_key),
+        crate::crypto::CryptoPolicy::Hybrid,
     );
     let mut msg = Builder::new_default();
     {

--- a/crates/hyprstream-rpc/src/transport/rpc_session.rs
+++ b/crates/hyprstream-rpc/src/transport/rpc_session.rs
@@ -445,13 +445,21 @@ pub fn build_error_envelope(
 ) -> Bytes {
     use crate::ToCapnp;
     use capnp::{message::Builder, serialize};
-    let envelope = crate::envelope::ResponseEnvelope::new_signed_with_policy(
+    let envelope = match crate::envelope::ResponseEnvelope::new_signed_with_policy(
         0,
         message.as_bytes().to_vec(),
         signing_key,
         Some(pq_signing_key),
         crate::crypto::CryptoPolicy::Hybrid,
-    );
+    ) {
+        Ok(envelope) => envelope,
+        Err(e) => {
+            // Fail closed: never substitute a weaker envelope. The client sees
+            // EOF instead of a signed error response.
+            tracing::error!(error = ?e, "rpc-session: failed signing error envelope");
+            return Bytes::new();
+        }
+    };
     let mut msg = Builder::new_default();
     {
         let mut builder = msg.init_root::<crate::common_capnp::response_envelope::Builder>();

--- a/crates/hyprstream-rpc/src/wasm_api.rs
+++ b/crates/hyprstream-rpc/src/wasm_api.rs
@@ -281,7 +281,7 @@ pub fn register_pq_trust(ed25519_pubkey: &[u8], ml_dsa_vk: &[u8]) -> Result<(), 
 }
 
 /// Remove a peer's ML-DSA-65 binding. After this call, envelopes from that
-/// signer are accepted under Classical (EdDSA-only) policy.
+/// signer fail verification until a new binding is registered.
 ///
 /// # Arguments
 ///
@@ -301,7 +301,8 @@ pub fn unregister_pq_trust(ed25519_pubkey: &[u8]) -> Result<(), JsError> {
 
 /// Clear all registered PQ trust bindings.
 ///
-/// After this call, all signers fall back to Classical (EdDSA-only) policy.
+/// After this call, all envelope verification fails closed until bindings are
+/// registered again.
 #[wasm_bindgen]
 pub fn clear_pq_trust() {
     WASM_PQ_BINDINGS.with(|bindings| bindings.borrow_mut().clear());
@@ -309,11 +310,9 @@ pub fn clear_pq_trust() {
 
 /// Verify a signed envelope (for browser-side services receiving requests from server).
 ///
-/// When the signer's ML-DSA-65 key has been registered via `register_pq_trust`,
-/// Hybrid policy is enforced: the outer ML-DSA-65 layer is required and an
-/// envelope that omits it is rejected. For signers without a registered ML-DSA
-/// key, Classical (EdDSA-only) policy applies — documented WNS until the
-/// browser trust store is provisioned with the peer's PQ key bundle.
+/// The signer's ML-DSA-65 key must be registered via `register_pq_trust` and
+/// the outer signature must verify. A missing binding or outer layer is a hard
+/// error; browser verification has no Ed25519-only fallback.
 ///
 /// # Arguments
 ///
@@ -342,11 +341,9 @@ pub fn verify_signed_envelope(
 
     let nonce_cache = WASM_NONCE_CACHE.with(|c| c.clone());
 
-    // Build a local PqTrustStore from WASM_PQ_BINDINGS. Track whether the
-    // specific signer has a registered ML-DSA binding; only in that case do we
-    // upgrade to Hybrid (enforcing the outer SNS layer). Signers without a
-    // registered key continue under Classical — documented WNS until their PQ
-    // key is provisioned in the browser trust store. (#158)
+    // Build a local PqTrustStore from WASM_PQ_BINDINGS. The expected signer
+    // must have an anchored ML-DSA binding; missing PQ material is a hard
+    // verification error, never an in-band downgrade to Ed25519-only.
     let mut pq_store = KeyedPqTrustStore::new();
     let signer_has_pq = WASM_PQ_BINDINGS.with(|bindings| {
         let b = bindings.borrow();
@@ -362,14 +359,13 @@ pub fn verify_signed_envelope(
         found
     });
 
-    let opts = UnwrapOptions::fixed_signer(&verifying_key, &*nonce_cache);
-    let opts = if signer_has_pq {
-        // Hybrid: outer ML-DSA-65 required for this signer (policy default is already Hybrid).
-        opts.with_pq_store(&pq_store)
-    } else {
-        // No PQ binding: classical fallback (documented WNS for unprovisioned signers).
-        opts.classical()
-    };
+    if !signer_has_pq {
+        return Err(JsError::new(
+            "expected signer has no anchored ML-DSA-65 verification key",
+        ));
+    }
+    let opts = UnwrapOptions::fixed_signer(&verifying_key, &*nonce_cache)
+        .with_pq_store(&pq_store);
 
     let (_signed, payload) = unwrap_and_verify(envelope_bytes, &opts)
         .map_err(|e| JsError::new(&format!("envelope verification failed: {}", e)))?;
@@ -907,4 +903,3 @@ pub fn generate_aes_nonce() -> Vec<u8> {
     rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut nonce);
     nonce.to_vec()
 }
-

--- a/crates/hyprstream-rpc/tests/e2e_iroh_transport.rs
+++ b/crates/hyprstream-rpc/tests/e2e_iroh_transport.rs
@@ -80,15 +80,25 @@ fn direct_addr(substrate: &IrohSubstrate) -> EndpointAddr {
     )
 }
 
-/// Install the Classical verify policy. Integration tests compile this crate in
-/// non-test mode, where the (uninstalled) global verify policy fail-closes to
-/// `Hybrid`; this test exercises the classical (EdDSA-only) wire+envelope path,
-/// so opt in to what it actually validates. Idempotent-by-first-write.
-fn install_classical_verify_policy() {
+fn test_client_signing_key() -> SigningKey {
+    SigningKey::from_bytes(&[0x42; 32])
+}
+
+/// Install the mandatory Hybrid verify policy with the stable test client
+/// identity anchored. Idempotent by first write across this integration binary.
+fn install_hybrid_verify_policy() {
+    let client = test_client_signing_key();
+    let pq_sk = derive_mesh_mldsa_key(&client);
+    let pq_vk = hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(
+        &hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(&pq_sk),
+    )
+    .expect("derived test client ML-DSA key");
+    let mut store = KeyedPqTrustStore::new();
+    store.bind(client.verifying_key().to_bytes(), &pq_vk);
     let _ = hyprstream_rpc::envelope::install_verify_config(
         hyprstream_rpc::envelope::EnvelopeVerifyConfig {
-            policy: hyprstream_rpc::crypto::CryptoPolicy::Classical,
-            pq_store: None,
+            policy: hyprstream_rpc::crypto::CryptoPolicy::Hybrid,
+            pq_store: Some(Arc::new(store)),
         },
     );
 }
@@ -381,7 +391,7 @@ impl RequestService for RegistryService {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn rpc_round_trip_model_status_and_registry_list_over_iroh() -> Result<()> {
-    install_classical_verify_policy();
+    install_hybrid_verify_policy();
 
     // ─── Server: bind Iroh substrate serving `hyprstream-rpc/1` ──────────────
     //
@@ -434,7 +444,7 @@ async fn rpc_round_trip_model_status_and_registry_list_over_iroh() -> Result<()>
     let request_kem = request_kem_store_for(&server_signing)?;
     let rpc: Arc<dyn hyprstream_rpc::rpc_client::RpcClient> = dial_with_crypto_stores(
         &target,
-        LocalSigner::new(fresh_signing_key()),
+        LocalSigner::new(test_client_signing_key()),
         Some(server_vk),
         None,
         Some(request_kem),
@@ -475,7 +485,7 @@ async fn rpc_round_trip_model_status_and_registry_list_over_iroh() -> Result<()>
             .connect(server_addr, ALPN_HYPRSTREAM_RPC)
             .await?;
         let explicit_rpc = RpcClientImpl::new(
-            LocalSigner::new(fresh_signing_key()),
+            LocalSigner::new(test_client_signing_key()),
             IrohTransport::new(conn),
             Some(server_vk),
         )
@@ -618,7 +628,7 @@ async fn anonymous_moq_handshake_over_iroh_is_rejected() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn one_substrate_serves_rpc_and_rejects_anonymous_moq() -> Result<()> {
-    install_classical_verify_policy();
+    install_hybrid_verify_policy();
 
     // ─── Server: one substrate, two real handlers ───────────────────────────
     let shared = OriginShared::new();
@@ -650,7 +660,7 @@ async fn one_substrate_serves_rpc_and_rejects_anonymous_moq() -> Result<()> {
     let request_kem = request_kem_store_for(&server_signing)?;
     let rpc: Arc<dyn hyprstream_rpc::rpc_client::RpcClient> = dial_with_crypto_stores(
         &target,
-        LocalSigner::new(fresh_signing_key()),
+        LocalSigner::new(test_client_signing_key()),
         Some(server_vk),
         None,
         Some(request_kem),

--- a/crates/hyprstream-rpc/tests/envelope_canonicalization.rs
+++ b/crates/hyprstream-rpc/tests/envelope_canonicalization.rs
@@ -1,12 +1,23 @@
 use ed25519_dalek::SigningKey;
-use hyprstream_rpc::envelope::{Authorization, RequestEnvelope, SignedEnvelope};
+use hyprstream_rpc::envelope::{
+    Authorization, KeyedPqTrustStore, RequestEnvelope, SignedEnvelope,
+};
+use hyprstream_rpc::node_identity::derive_mesh_mldsa_key;
 use rand::rngs::OsRng;
 
 fn make_signed(envelope: RequestEnvelope, signing_key: &SigningKey) -> SignedEnvelope {
-    // Classical so the raw Ed25519 `sig` field is deterministic (ML-DSA-65
-    // signatures are randomized/hedged). Composite behavior is tested in the
-    // envelope `cose::`/`crypto::` suites.
-    SignedEnvelope::new_signed(envelope, signing_key)
+    let pq = derive_mesh_mldsa_key(signing_key);
+    SignedEnvelope::new_signed_hybrid(envelope, signing_key, &pq)
+}
+
+fn pq_store(signing_key: &SigningKey) -> anyhow::Result<KeyedPqTrustStore> {
+    let pq = derive_mesh_mldsa_key(signing_key);
+    let vk = hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(
+        &hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(&pq),
+    )?;
+    let mut store = KeyedPqTrustStore::new();
+    store.bind(signing_key.verifying_key().to_bytes(), &vk);
+    Ok(store)
 }
 
 #[test]
@@ -41,7 +52,7 @@ fn test_envelope_serialization_deterministic() {
 }
 
 #[test]
-fn test_envelope_signature_verification_stable() {
+fn test_envelope_signature_verification_stable() -> anyhow::Result<()> {
     let mut csprng = OsRng;
     let signing_key = SigningKey::generate(&mut csprng);
     let verifying_key = signing_key.verifying_key();
@@ -62,6 +73,7 @@ fn test_envelope_signature_verification_stable() {
 
     let signed1 = make_signed(envelope.clone(), &signing_key);
     let signed2 = make_signed(envelope.clone(), &signing_key);
+    let store = pq_store(&signing_key)?;
 
     // Ed25519 signatures MUST be identical (deterministic serialization)
     assert_eq!(
@@ -70,11 +82,23 @@ fn test_envelope_signature_verification_stable() {
     );
 
     assert!(
-        signed1.verify_signature_only(&verifying_key).is_ok(),
+        signed1
+            .verify_signature_only_with(
+                &verifying_key,
+                Some(&store),
+                hyprstream_rpc::crypto::CryptoPolicy::Hybrid,
+            )
+            .is_ok(),
         "First signature must verify"
     );
     assert!(
-        signed2.verify_signature_only(&verifying_key).is_ok(),
+        signed2
+            .verify_signature_only_with(
+                &verifying_key,
+                Some(&store),
+                hyprstream_rpc::crypto::CryptoPolicy::Hybrid,
+            )
+            .is_ok(),
         "Second signature must verify"
     );
 
@@ -99,9 +123,17 @@ fn test_envelope_signature_verification_stable() {
     };
 
     assert!(
-        mixed.verify_signature_only(&verifying_key).is_ok(),
+        mixed
+            .verify_signature_only_with(
+                &verifying_key,
+                Some(&store),
+                hyprstream_rpc::crypto::CryptoPolicy::Hybrid,
+            )
+            .is_ok(),
         "Cross-verification must work due to deterministic serialization"
     );
+
+    Ok(())
 }
 
 #[test]

--- a/crates/hyprstream-rpc/tests/inproc_bridged_e2e.rs
+++ b/crates/hyprstream-rpc/tests/inproc_bridged_e2e.rs
@@ -17,8 +17,9 @@ use ed25519_dalek::{SigningKey, VerifyingKey};
 use rand::RngCore;
 use tokio::sync::Mutex;
 
-use hyprstream_rpc::dial::{dial, register_inproc};
-use hyprstream_rpc::envelope::InMemoryNonceCache;
+use hyprstream_rpc::dial::{dial_with_crypto_stores, register_inproc};
+use hyprstream_rpc::envelope::{InMemoryNonceCache, KeyedPqTrustStore};
+use hyprstream_rpc::node_identity::derive_mesh_mldsa_key;
 use hyprstream_rpc::service::{Continuation, EnvelopeContext, RequestService};
 use hyprstream_rpc::signer::LocalSigner;
 use hyprstream_rpc::transport::iroh_rpc::LocalServiceBridge;
@@ -69,12 +70,17 @@ fn fresh_key() -> SigningKey {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn inproc_bridged_round_trip_and_continuation_spawned() -> Result<()> {
-    // Integration test → hyprstream-rpc in non-test mode → verify policy
-    // fail-closes to Hybrid (#160); opt into the Classical policy this exercises.
+    let client_key = fresh_key();
+    let client_pq = derive_mesh_mldsa_key(&client_key);
+    let client_pq_vk = hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(
+        &hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(&client_pq),
+    )?;
+    let mut request_store = KeyedPqTrustStore::new();
+    request_store.bind(client_key.verifying_key().to_bytes(), &client_pq_vk);
     let _ = hyprstream_rpc::envelope::install_verify_config(
         hyprstream_rpc::envelope::EnvelopeVerifyConfig {
-            policy: hyprstream_rpc::crypto::CryptoPolicy::Classical,
-            pq_store: None,
+            policy: hyprstream_rpc::crypto::CryptoPolicy::Hybrid,
+            pq_store: Some(Arc::new(request_store)),
         },
     );
 
@@ -87,7 +93,7 @@ async fn inproc_bridged_round_trip_and_continuation_spawned() -> Result<()> {
     let svc = StreamingEcho {
         name: NAME.to_owned(),
         transport: TransportConfig::inproc(NAME),
-        signing_key: server_key,
+        signing_key: server_key.clone(),
         fired: Mutex::new(Some(fired_tx)),
     };
 
@@ -99,11 +105,19 @@ async fn inproc_bridged_round_trip_and_continuation_spawned() -> Result<()> {
     register_inproc(NAME, &processor);
 
     // Client side: dial inproc → InMemoryTransport → real SignedEnvelope.
-    let client = dial(
+    let server_pq = derive_mesh_mldsa_key(&server_key);
+    let server_pq_vk = hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(
+        &hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(&server_pq),
+    )?;
+    let mut response_store = KeyedPqTrustStore::new();
+    response_store.bind(server_vk.to_bytes(), &server_pq_vk);
+    let client = dial_with_crypto_stores(
         &TransportConfig::inproc(NAME),
-        LocalSigner::new(fresh_key()),
+        LocalSigner::new(client_key),
         Some(server_vk),
         None,
+        None,
+        Some(Arc::new(response_store)),
     )?;
     let resp = client.call(b"hello-inproc".to_vec()).await?;
     assert_eq!(&resp[..], b"hello-inproc");

--- a/crates/hyprstream-rpc/tests/iroh_rpc_e2e.rs
+++ b/crates/hyprstream-rpc/tests/iroh_rpc_e2e.rs
@@ -503,7 +503,8 @@ async fn false_encrypted_marker_never_reaches_custom_processor_over_iroh() -> Re
     let transport = IrohTransport::new(conn);
 
     let signer = fresh_signing_key();
-    let signed = SignedEnvelope::new_signed(
+    let pq_signer = derive_mesh_mldsa_key(&signer);
+    let signed = SignedEnvelope::new_signed_hybrid(
         RequestEnvelope {
             request_id: 31337,
             payload: b"visible-cleartext-sentinel".to_vec(),
@@ -518,6 +519,7 @@ async fn false_encrypted_marker_never_reaches_custom_processor_over_iroh() -> Re
             service_domain: None,
         },
         &signer,
+        &pq_signer,
     );
     let mut wire = Vec::new();
     {

--- a/crates/hyprstream-rpc/tests/uds_rpc_e2e.rs
+++ b/crates/hyprstream-rpc/tests/uds_rpc_e2e.rs
@@ -21,7 +21,8 @@ use async_trait::async_trait;
 use ed25519_dalek::{SigningKey, VerifyingKey};
 use rand::RngCore;
 
-use hyprstream_rpc::envelope::InMemoryNonceCache;
+use hyprstream_rpc::envelope::{InMemoryNonceCache, KeyedPqTrustStore};
+use hyprstream_rpc::node_identity::derive_mesh_mldsa_key;
 use hyprstream_rpc::rpc_client::RpcClientImpl;
 use hyprstream_rpc::service::{Continuation, EnvelopeContext, RequestService};
 use hyprstream_rpc::signer::LocalSigner;
@@ -83,14 +84,17 @@ fn fresh_signing_key() -> SigningKey {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn signed_envelope_round_trip_over_uds() -> Result<()> {
-    // As an integration test this compiles hyprstream-rpc in non-test mode, where
-    // the uninstalled global verify policy fail-closes to Hybrid (#160). Opt in to
-    // the Classical policy this canary validates. `set`-by-first-write: ignore the
-    // error if another test in this binary already installed a matching config.
+    let client_signing = fresh_signing_key();
+    let client_pq = derive_mesh_mldsa_key(&client_signing);
+    let client_pq_vk = hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(
+        &hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(&client_pq),
+    )?;
+    let mut request_store = KeyedPqTrustStore::new();
+    request_store.bind(client_signing.verifying_key().to_bytes(), &client_pq_vk);
     let _ = hyprstream_rpc::envelope::install_verify_config(
         hyprstream_rpc::envelope::EnvelopeVerifyConfig {
-            policy: hyprstream_rpc::crypto::CryptoPolicy::Classical,
-            pq_store: None,
+            policy: hyprstream_rpc::crypto::CryptoPolicy::Hybrid,
+            pq_store: Some(Arc::new(request_store)),
         },
     );
 
@@ -116,12 +120,18 @@ async fn signed_envelope_round_trip_over_uds() -> Result<()> {
     let srv = tokio::spawn(server.run());
 
     // ─── Client side: real signed envelope over LazyUdsTransport ─────────────
-    let client_signing = fresh_signing_key();
+    let server_pq = derive_mesh_mldsa_key(&server_signing);
+    let server_pq_vk = hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(
+        &hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(&server_pq),
+    )?;
+    let mut response_store = KeyedPqTrustStore::new();
+    response_store.bind(server_verifying.to_bytes(), &server_pq_vk);
     let rpc = RpcClientImpl::new(
         LocalSigner::new(client_signing.clone()),
         LazyUdsTransport::new(path.clone()),
         Some(server_verifying),
-    );
+    )
+    .with_response_pq_store(Arc::new(response_store));
 
     let response = rpc.call(b"ping-payload".to_vec()).await?;
     assert_eq!(&response[..], b"\xECping-payload");

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -238,6 +238,7 @@ serde_json.workspace = true  # JSON output for metadata
 hyprstream-rpc-build.workspace = true  # Shared annotation extraction
 
 [dev-dependencies]
+hyprstream-rpc = { path = "../hyprstream-rpc", features = ["test-classical-policy"] }
 criterion.workspace = true
 proptest.workspace = true  # S5 #571 M2: differential faithfulness property tests
 tempfile.workspace = true

--- a/crates/hyprstream/src/auth/key_rotation.rs
+++ b/crates/hyprstream/src/auth/key_rotation.rs
@@ -2526,8 +2526,7 @@ mod tests {
         let mut command = std::process::Command::new(std::env::current_exe().unwrap());
         command
             .args(["--exact", test_name, "--nocapture"])
-            .env("HYPRSTREAM_COMPOSITE_PRODUCTION_TEST_DIR", dir)
-            .env("HYPRSTREAM_ENVELOPE_POLICY", "hybrid");
+            .env("HYPRSTREAM_COMPOSITE_PRODUCTION_TEST_DIR", dir);
         if test_name.ends_with("composite_crashing_writer_process") {
             command.env("HYPRSTREAM_COMPOSITE_CRASH_AFTER_STAGE", "1");
         }
@@ -2556,7 +2555,6 @@ mod tests {
                     "--nocapture",
                 ])
                 .env(ORCHESTRATOR_DIR, dir.path())
-                .env("HYPRSTREAM_ENVELOPE_POLICY", "hybrid")
                 .status()
                 .unwrap();
             assert!(status.success());

--- a/crates/hyprstream/src/auth/key_rotation.rs
+++ b/crates/hyprstream/src/auth/key_rotation.rs
@@ -1900,10 +1900,6 @@ mod tests {
             false
         }
 
-        fn pq_signing_key(&self) -> Option<hyprstream_rpc::crypto::pq::MlDsaSigningKey> {
-            None
-        }
-
         fn jwt_verify_policy(&self) -> hyprstream_rpc::crypto::CryptoPolicy {
             hyprstream_rpc::crypto::CryptoPolicy::Hybrid
         }

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1431,10 +1431,8 @@ fn install_process_production_resolver(signing_key: &SigningKey) -> Result<()> {
 /// silently downgrading to EdDSA-only. `install_verify_config` is first-write-
 /// wins, so calling it from multiple stages within one process is harmless.
 ///
-/// Policy default is Hybrid (SNS nested COSE); operators mid-rollout, before
-/// peer ML-DSA bindings are provisioned, may set
-/// `HYPRSTREAM_ENVELOPE_POLICY=classical`. Under Hybrid with no anchored peer
-/// key the verifier fails closed (correct, by design).
+/// Policy is pinned to Hybrid (SNS nested COSE). With no anchored peer key the
+/// verifier fails closed (correct, by design).
 /// Install the process-global envelope verify configuration.
 ///
 /// When `oauth` is `Some`, the kid-anchored PQ trust store is populated eagerly
@@ -1442,16 +1440,14 @@ fn install_process_production_resolver(signing_key: &SigningKey) -> Result<()> {
 /// which has no config in scope), the store is empty — identical to the prior
 /// behavior. Either way the store is immutable after install.
 fn install_envelope_verify_config(oauth: Option<&hyprstream_core::config::OAuthConfig>) {
-    use hyprstream_rpc::crypto::CryptoPolicy;
     use hyprstream_rpc::envelope::{
-        envelope_policy_from_env, install_response_verify_config, install_verify_config,
+        install_response_verify_config, install_verify_config, mandatory_envelope_policy,
         EnvelopeVerifyConfig, KeyedPqTrustStore, PqTrustStore, ResponseVerifyConfig,
     };
 
-    // Single source of truth for the rollout escape hatch
-    // (`HYPRSTREAM_ENVELOPE_POLICY`), shared by the request AND response sides
-    // (#277): `classical` downgrades both directions in lock-step.
-    let policy = envelope_policy_from_env();
+    // The application suite is pinned: requests and responses both require
+    // Ed25519 + ML-DSA-65, with no runtime downgrade selector.
+    let policy = mandatory_envelope_policy();
 
     // Mesh kid-anchored PQ trust store (#157, Option A): populated eagerly from
     // admin-configured `mesh_peers`, immutable after install. An empty store
@@ -1511,24 +1507,10 @@ fn install_envelope_verify_config(oauth: Option<&hyprstream_core::config::OAuthC
     })
     .is_ok()
     {
-        match policy {
-            CryptoPolicy::Hybrid => tracing::info!(
-                "envelope verify policy: HYBRID enforced (SNS nested COSE); \
-                 peer ML-DSA bindings required for cross-node traffic"
-            ),
-            CryptoPolicy::Classical => {
-                tracing::error!(
-                    "⚠ SECURITY DOWNGRADE: envelope verify policy is CLASSICAL (EdDSA-only). \
-                     Post-quantum protection is DISABLED for ALL envelope traffic. \
-                     Unset HYPRSTREAM_ENVELOPE_POLICY or set it to 'hybrid' to re-enable PQ enforcement. \
-                     This setting must not be used in production."
-                );
-                eprintln!(
-                    "SECURITY WARNING: HYPRSTREAM_ENVELOPE_POLICY=classical disables post-quantum \
-                     protection. Set to 'hybrid' or unset for production use."
-                );
-            }
-        }
+        tracing::info!(
+            "envelope verify policy: HYBRID enforced (SNS nested COSE); \
+             peer ML-DSA bindings required for cross-node traffic"
+        );
     }
 }
 
@@ -2402,12 +2384,8 @@ fn main() -> Result<()> {
                                 // resolution). Empty `mesh_peers` => empty store =>
                                 // unchanged behavior.
                                 //
-                                // Policy: Hybrid is enforced by default. Operators
-                                // mid-rollout (before peer ML-DSA bindings are
-                                // provisioned) may set
-                                // HYPRSTREAM_ENVELOPE_POLICY=classical to keep the
-                                // legacy EdDSA-only verifier. Under Hybrid with no
-                                // anchored key the verifier FAILS CLOSED.
+                                // Policy: Hybrid is mandatory. With no anchored
+                                // peer key the verifier FAILS CLOSED.
                                 install_envelope_verify_config(Some(&config.oauth));
 
                                 let manager = InprocManager::new();

--- a/crates/hyprstream/src/cli/bootstrap_manager.rs
+++ b/crates/hyprstream/src/cli/bootstrap_manager.rs
@@ -192,9 +192,9 @@ impl BootstrapManager {
             }
         };
 
-        // Root-of-trust enrollment follows node crypto policy (Hybrid default,
-        // fail-closed) — the same selector as envelope traffic.
-        let policy = hyprstream_rpc::envelope::envelope_policy_from_env();
+        // Root-of-trust enrollment uses the same mandatory hybrid suite as
+        // envelope traffic.
+        let policy = hyprstream_rpc::envelope::mandatory_envelope_policy();
         match self.rt.block_on(
             enroll_user(&store, &secrets_dir, username, EnrollKeySource::Generate, policy),
         ) {

--- a/crates/hyprstream/src/cli/enroll.rs
+++ b/crates/hyprstream/src/cli/enroll.rs
@@ -70,8 +70,8 @@ pub struct EnrollOutcome {
 /// [`CryptoPolicy::Hybrid`] (the node default) enrollment mints an Ed25519
 /// anchor **plus** a bound ML-DSA-65 key and writes a hybrid store record; a
 /// missing/unpersistable PQ component is a hard error (fail closed). Under
-/// [`CryptoPolicy::Classical`] a classical-only identity is written with a loud
-/// notice — never a silent downgrade.
+/// The test-only [`CryptoPolicy::Classical`] variant writes a classical-only
+/// identity with a loud notice — never a silent downgrade.
 pub async fn enroll_user(
     store: &RocksDbUserStore,
     secrets_dir: &Path,
@@ -123,12 +123,10 @@ struct ResolvedIdentity {
     notices: Vec<String>,
 }
 
-/// The classical-downgrade notice printed whenever a Classical-policy identity
-/// is enrolled (never silent — CLAUDE.md's fail-loud requirement).
+/// The downgrade notice used by Classical-policy test fixtures.
 fn classical_notice() -> String {
     "classical-only (policy=Classical): this identity is capped at Classical MAC \
-     assurance. Set CryptoPolicy to Hybrid (unset HYPRSTREAM_ENVELOPE_POLICY or \
-     set it to 'hybrid') to enroll a post-quantum identity."
+     assurance. Production enrollment is pinned to Hybrid."
         .to_owned()
 }
 

--- a/crates/hyprstream/src/cli/user_handlers.rs
+++ b/crates/hyprstream/src/cli/user_handlers.rs
@@ -191,11 +191,9 @@ pub async fn handle_user_create(
 
     let source = resolve_create_key_source(generate, key, ssh)?;
 
-    // Post-quantum policy is node policy: Hybrid by default (fail-closed), only
-    // an explicit HYPRSTREAM_ENVELOPE_POLICY=classical downgrades. Enrollment is
-    // a root-of-trust path, so it follows the same selector as envelope traffic
-    // rather than silently minting classical-only identity material.
-    let policy = hyprstream_rpc::envelope::envelope_policy_from_env();
+    // Enrollment is a root-of-trust path and uses the same mandatory hybrid
+    // suite as envelope traffic.
+    let policy = hyprstream_rpc::envelope::mandatory_envelope_policy();
 
     let outcome = enroll_user(&store, &secrets_dir, username, source, policy)
         .await

--- a/crates/hyprstream/src/server/middleware.rs
+++ b/crates/hyprstream/src/server/middleware.rs
@@ -411,7 +411,7 @@ pub(crate) async fn verify_token_claims(
             &published,
             published_composite.pairs(),
             Some(&state.resource_url),
-            !hyprstream_rpc::envelope::envelope_policy_from_env().uses_pq(),
+            false,
         )?;
         if !local_issuer_matches(&claims, &state.oauth_issuer_url) {
             return Err("JWT validation failed");

--- a/crates/hyprstream/src/services/metrics.rs
+++ b/crates/hyprstream/src/services/metrics.rs
@@ -666,9 +666,16 @@ mod tests {
         tag: &str,
     ) -> (MetricsClient, InprocManager) {
         // Tests use Classical (EdDSA-only) keys — install Classical verify
-        // policy so the global fail-closed Hybrid default doesn't reject them.
+        // policy on both the request and response arms so the global
+        // fail-closed Hybrid defaults don't reject them.
         let _ = hyprstream_rpc::envelope::install_verify_config(
             hyprstream_rpc::envelope::EnvelopeVerifyConfig {
+                policy: hyprstream_rpc::crypto::CryptoPolicy::Classical,
+                pq_store: None,
+            },
+        );
+        let _ = hyprstream_rpc::envelope::install_response_verify_config(
+            hyprstream_rpc::envelope::ResponseVerifyConfig {
                 policy: hyprstream_rpc::crypto::CryptoPolicy::Classical,
                 pq_store: None,
             },

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -513,7 +513,7 @@ impl Spawnable for OAuthService {
             );
             info!("ML-DSA-65 signing key rotation store loaded");
             crate::auth::key_rotation::refresh_ml_dsa_verifying_keys(&ml_dsa_store).await;
-            let crypto_policy = hyprstream_rpc::envelope::envelope_policy_from_env();
+            let crypto_policy = hyprstream_rpc::envelope::mandatory_envelope_policy();
 
             // MAC #547 / B2 (#674): construct the S6 grant-path audit sink. A
             // startup-time snapshot of the active ML-DSA-65 key (rotation

--- a/crates/hyprstream/src/services/oauth/token_exchange.rs
+++ b/crates/hyprstream/src/services/oauth/token_exchange.rs
@@ -900,31 +900,28 @@ async fn mint_grant_token(
         jkt: Some(dpop_jkt.to_owned()),
     });
 
-    // S8 (#574) + Fu3/#677: sign via the hybrid composite (EdDSA + ML-DSA-65)
-    // under a Hybrid policy; under Classical use the pinned classical Ed25519
-    // suite. **Hybrid fails closed:** if the node is Hybrid but no ML-DSA-65
-    // signing key is provisioned, refuse to mint rather than silently downgrade
-    // to a classical-only token — mirroring `PolicyService::sign_token` and
+    // S8 (#574) + Fu3/#677: sign via the mandatory hybrid composite (EdDSA +
+    // ML-DSA-65). If no ML-DSA-65 signing key is provisioned, refuse to mint
+    // rather than silently downgrade to a classical-only token — mirroring
+    // `PolicyService::sign_token` and
     // `CoseAuditSigner`. The UCAN grant and approval this token was minted from
     // are already hybrid-signed, so a classical-only minted token would break
     // that chain of hybrid authority.
-    let policy = hyprstream_rpc::envelope::envelope_policy_from_env();
-    let token = if policy.uses_pq() {
-        let snapshot = match hyprstream_rpc::auth::global_composite_key_set().mint_snapshot() {
-            Ok(snapshot) => snapshot,
-            Err(error) => {
-                tracing::error!("composite authority unavailable or stale; refusing to mint: {error}");
-                return tx_error(StatusCode::INTERNAL_SERVER_ERROR, "server_error", "hybrid token authority is not current");
-            }
-        };
-        let signing = snapshot
-            .active_signing_pair(hyprstream_rpc::auth::CompositePairRole::OAuth)
-            .and_then(hyprstream_rpc::auth::CompositeKeyPair::signing_keys);
-        match signing {
-            Some((pq, ed)) => crate::auth::jwt::encode_composite_ml_dsa_65_ed25519(
-                &claims, &pq, &ed,
-            ),
-            None => {
+    let snapshot = match hyprstream_rpc::auth::global_composite_key_set().mint_snapshot() {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            tracing::error!("composite authority unavailable or stale; refusing to mint: {error}");
+            return tx_error(StatusCode::INTERNAL_SERVER_ERROR, "server_error", "hybrid token authority is not current");
+        }
+    };
+    let signing = snapshot
+        .active_signing_pair(hyprstream_rpc::auth::CompositePairRole::OAuth)
+        .and_then(hyprstream_rpc::auth::CompositeKeyPair::signing_keys);
+    let token = match signing {
+        Some((pq, ed)) => crate::auth::jwt::encode_composite_ml_dsa_65_ed25519(
+            &claims, &pq, &ed,
+        ),
+        None => {
             tracing::error!(
                 "no authorized active OAuth composite pair; refusing to mint (fail-closed)"
             );
@@ -933,18 +930,7 @@ async fn mint_grant_token(
                 "server_error",
                 "hybrid token signing pair not provisioned",
             );
-            }
         }
-    } else {
-        let Some(ed_sk) = state.active_jwt_signing_key().await else {
-            tracing::error!("no active JWT signing key configured; cannot mint UCAN grant token");
-            return tx_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "server_error",
-                "token signing not configured",
-            );
-        };
-        crate::auth::jwt::encode(&claims, &ed_sk)
     };
 
     // Optional refresh token (ZSP: refresh re-runs evaluate_refresh, not a free

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -120,13 +120,12 @@ impl PolicyService {
         self
     }
 
-    /// Sign a token, selecting the suite from [`CryptoPolicy`] (Fu3/#677).
+    /// Sign a token with the mandatory hybrid suite (Fu3/#677).
     ///
     /// The composite PQ signature (EdDSA + ML-DSA-65) is used under a Hybrid
-    /// policy; under Classical the Ed25519-only suite is used. **Hybrid fails
-    /// closed:** if the node is Hybrid but no ML-DSA-65 signing key is
-    /// provisioned, this returns `Err` rather than silently minting a
-    /// classical-only token — mirroring [`crate::mac::audit::CoseAuditSigner`],
+    /// policy. If no ML-DSA-65 signing key is provisioned, this returns `Err`
+    /// rather than silently minting a classical-only token — mirroring
+    /// [`crate::mac::audit::CoseAuditSigner`],
     /// which the S7 audit path already gates the same way. Previously this seam
     /// picked composite-vs-classical by *keystore state*, so a Hybrid node with
     /// an empty/rotating ML-DSA store quietly downgraded minted tokens.
@@ -135,34 +134,25 @@ impl PolicyService {
         claims: &hyprstream_rpc::auth::Claims,
         is_service: bool,
     ) -> Result<String> {
-        let policy = hyprstream_rpc::envelope::envelope_policy_from_env();
-        if policy.uses_pq() {
-            let snapshot = hyprstream_rpc::auth::global_composite_key_set()
-                .mint_snapshot()
-                .map_err(|error| anyhow!("composite authority unavailable: {error}"))?;
-            let signing = snapshot
-                .active_signing_pair(hyprstream_rpc::auth::CompositePairRole::Policy)
-                .and_then(hyprstream_rpc::auth::CompositeKeyPair::signing_keys);
-            let Some((ml_key, ed_key)) = signing else {
-                warn!("no authorized active Policy composite pair; refusing to mint");
-                return Err(anyhow!("hybrid token signing pair not provisioned"));
-            };
-            Ok(if is_service {
-                crate::auth::jwt::encode_composite_service_jwt(
-                    claims, &ml_key, &ed_key,
-                )
-            } else {
-                crate::auth::jwt::encode_composite_ml_dsa_65_ed25519(
-                    claims, &ml_key, &ed_key,
-                )
-            })
+        let snapshot = hyprstream_rpc::auth::global_composite_key_set()
+            .mint_snapshot()
+            .map_err(|error| anyhow!("composite authority unavailable: {error}"))?;
+        let signing = snapshot
+            .active_signing_pair(hyprstream_rpc::auth::CompositePairRole::Policy)
+            .and_then(hyprstream_rpc::auth::CompositeKeyPair::signing_keys);
+        let Some((ml_key, ed_key)) = signing else {
+            warn!("no authorized active Policy composite pair; refusing to mint");
+            return Err(anyhow!("hybrid token signing pair not provisioned"));
+        };
+        Ok(if is_service {
+            crate::auth::jwt::encode_composite_service_jwt(
+                claims, &ml_key, &ed_key,
+            )
         } else {
-            Ok(if is_service {
-                crate::auth::jwt::encode_service_jwt(claims, &self.jwt_signing_key)
-            } else {
-                crate::auth::jwt::encode(claims, &self.jwt_signing_key)
-            })
-        }
+            crate::auth::jwt::encode_composite_ml_dsa_65_ed25519(
+                claims, &ml_key, &ed_key,
+            )
+        })
     }
 
     /// Set the JWT key source for verifying JWTs (local and federated).

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -3459,9 +3459,16 @@ mod tests {
         use hyprstream_rpc::transport::TransportConfig;
 
         // Tests use Classical (EdDSA-only) keys — install Classical verify
-        // policy so the global fail-closed Hybrid default doesn't reject them.
+        // policy on both the request and response arms so the global
+        // fail-closed Hybrid defaults don't reject them.
         let _ = hyprstream_rpc::envelope::install_verify_config(
             hyprstream_rpc::envelope::EnvelopeVerifyConfig {
+                policy: hyprstream_rpc::crypto::CryptoPolicy::Classical,
+                pq_store: None,
+            },
+        );
+        let _ = hyprstream_rpc::envelope::install_response_verify_config(
+            hyprstream_rpc::envelope::ResponseVerifyConfig {
                 policy: hyprstream_rpc::crypto::CryptoPolicy::Classical,
                 pq_store: None,
             },
@@ -3529,6 +3536,11 @@ mod tests {
         let _ = hyprstream_rpc::envelope::install_verify_config(hyprstream_rpc::envelope::EnvelopeVerifyConfig {
             policy: hyprstream_rpc::crypto::CryptoPolicy::Classical, pq_store: None,
         });
+        let _ = hyprstream_rpc::envelope::install_response_verify_config(
+            hyprstream_rpc::envelope::ResponseVerifyConfig {
+                policy: hyprstream_rpc::crypto::CryptoPolicy::Classical, pq_store: None,
+            },
+        );
         let root = TempDir::new().unwrap();
         let models = root.path().join("models");
         let pds = root.path().join("pds");

--- a/crates/hyprstream/tests/e2e_9p_walk.rs
+++ b/crates/hyprstream/tests/e2e_9p_walk.rs
@@ -114,6 +114,12 @@ fn install_classical_verify() {
         policy: CryptoPolicy::Classical,
         pq_store: None,
     });
+    let _ = hyprstream_rpc::envelope::install_response_verify_config(
+        hyprstream_rpc::envelope::ResponseVerifyConfig {
+            policy: CryptoPolicy::Classical,
+            pq_store: None,
+        },
+    );
 }
 
 /// Create a temp git repo at `dir/config-repo` with a `config.json`, commit

--- a/docs/cryptography-architecture.md
+++ b/docs/cryptography-architecture.md
@@ -306,9 +306,13 @@ application dispatch or response use.
 The mandatory hybrid signature covers the complete COSE_Encrypt0 bytes. Sealed
 responses additionally bind the retained request ID and expected service domain:
 
-```
+```text
 request_signing_data  = canonical_cose_encrypt0
-response_signing_data = domain || request_id || service_domain || canonical_cose_encrypt0
+response_signing_data = "hykem-rpc-response-signature-v2\0"
+                     || request_id (u64 LE)
+                     || len(service_domain) (u16 LE)
+                     || service_domain
+                     || canonical_cose_encrypt0
 ```
 
 Constructors: `SignedEnvelope::new_signed_encrypted_mesh_kem()` for requests and

--- a/docs/cryptography-architecture.md
+++ b/docs/cryptography-architecture.md
@@ -205,15 +205,17 @@ let verifying_key = signing_key.verifying_key();
 // verifiers resolve peer keys through the service trust store.
 ```
 
-## Hybrid (PQ/T) Signatures — WNS posture
+## Mandatory Hybrid (PQ/T) Signatures
 
 **Location:** `crates/hyprstream-rpc/src/crypto/cose_sign.rs`, `envelope.rs`
 
 Envelopes (request `SignedEnvelope` and response `ResponseEnvelope`) carry a nested
 COSE composite: an **inner EdDSA** `COSE_Sign1` and an **outer ML-DSA-65** (FIPS 204)
 `COSE_Sign1` over `payload ‖ inner_sig`. This is a **Weak Non-Separable (WNS)**
-construction in the IETF PQUIP taxonomy: the inner classical signature stays
-*independently verifiable by design*, enabling gradual PQ migration.
+construction in the IETF PQUIP taxonomy: the inner classical signature is
+structurally separable. Hyprstream's production policy nevertheless gives the
+two signature legs strict **AND semantics**: both must verify against anchored
+key material. Structural WNS is not an admission downgrade.
 
 ### Specs of record
 - **`draft-ietf-pquip-hybrid-signature-spectrums`** (PQUIP WG) — the SNS/WNS spectrum +
@@ -227,37 +229,30 @@ construction in the IETF PQUIP taxonomy: the inner classical signature stays
   (DID `#mesh-pq` Multikey).
 - PQUIP WG: <https://datatracker.ietf.org/wg/pquip/about/>
 
-### Verification rule (per-identity, NOT blanket fail-closed)
+### Verification rule — mandatory fail-closed hybrid
 ```rust
 // envelope.rs :: verify_cose (both SignedEnvelope and ResponseEnvelope)
-let anchored_pq = pq_store.and_then(|s| s.ml_dsa_key_for(&self.cnf));
-let require_pq = verify_policy.uses_pq() && anchored_pq.is_some();
+let anchored_pq = pq_store
+    .and_then(|store| store.ml_dsa_key_for(&self.cnf))
+    .ok_or("mandatory Hybrid suite requires an anchored ML-DSA-65 key")?;
+verify_composite(..., Some(&anchored_pq), ..., /* require_pq */ true)?;
 ```
-Enforce the ML-DSA-65 outer **only** for signer identities whose PQ key is anchored
-out-of-band (`KeyedPqTrustStore`, keyed by the signer's Ed25519 `cnf`). For an
-**unanchored** signer, fall back to the inner EdDSA (classical floor) rather than
-failing closed.
-
-This is safe because `ed_vk = VerifyingKey::from_bytes(&self.cnf)` — the PQ-lookup
-identity *is* the EdDSA-verified identity — and the response path constant-time-pins
-`cnf == expected_pubkey` when the server key is known:
+The ML-DSA-65 key is resolved only from an out-of-band `KeyedPqTrustStore`, keyed
+by the signer's Ed25519 `cnf`; it is never trusted from the COSE object. The
+response path also constant-time-pins `cnf == expected_pubkey` when the server
+key is known.
 
 | Signer state | Behavior | Guarantee |
 |---|---|---|
-| **anchored** | `require_pq = true` → outer enforced | un-downgradable Hybrid (a PQ adversary cannot forge ML-DSA) |
-| **unanchored** | classical inner-EdDSA floor | no weaker than the pre-PQ baseline |
+| **anchored, both signatures valid** | accept | exact pinned hybrid suite |
+| **unanchored or wrong anchor** | reject before payload use | no self-certification or classical floor |
+| **missing/invalid/reordered/duplicated outer** | reject | strict EdDSA + ML-DSA-65 AND semantics |
 
-> **Never** reintroduce blanket fail-closed Hybrid for unanchored peers: it rejected
-> all responses on a fresh install (empty `mesh_peers`), including a node verifying its
-> own in-process services. PQ is also **never** resolved from the self-asserted COSE
-> entry (that would reintroduce the self-cert weakness).
-
-### Rollout / known limitation
-The escape hatch `HYPRSTREAM_ENVELOPE_POLICY=classical` downgrades both directions in
-lock-step for staged rollout. In multi-process mode each service signs with its own
-Ed25519 key but only the node/OAuth `#mesh-pq` VM is published, so remote per-service
-identities verify at the classical floor until each service publishes/anchors its own
-`#mesh-pq` via DID resolution (tracked under #137 / #279).
+`CryptoPolicy::Classical` exists only in the `hyprstream-rpc` unit-test build for
+low-level compatibility fixtures. Production exposes one policy-selected pinned
+suite and reads no environment or in-band algorithm selector. A peer without the
+anchored ML-DSA signing key and anchored hybrid KEM recipient is not partially
+admitted; enrollment, construction, verification, or key release fails closed.
 
 ### DPoP keys are a separate keyspace from DID identity keys (#698 Decision D)
 
@@ -298,48 +293,47 @@ key; a DPoP proof key matching a registered key earns `PqHybrid` for that actor 
 
 ## Envelope Confidentiality
 
-**Location:** `crates/hyprstream-rpc/src/crypto/envelope_crypto.rs`, `envelope.rs`
+**Location:** `crates/hyprstream-rpc/src/crypto/cose_encrypt.rs`, `envelope.rs`
 
-Request envelopes support an optional **encrypted mode** (encrypt-then-sign). The
-serialized `RequestEnvelope` bytes are encrypted with **AES-256-GCM-SIV** and
-carried in `SignedEnvelope.encrypted_envelope`; the cleartext `envelope` field is
-unused on the wire in this mode.
+Network request and response envelopes use canonical COSE_Encrypt0 with
+AES-256-GCM-SIV. The recipient is an out-of-band anchored `#mesh-kem` key for the
+pinned `HyKemX25519MlKem768` suite; the encapsulated X25519 and ML-KEM-768
+components are carried in the protected COSE structure. The outer cleartext
+payload is empty. Missing recipients, missing either KEM contribution, unknown
+or substituted suite IDs, and cleartext on an untrusted carrier all fail before
+application dispatch or response use.
 
-Key agreement is X25519 static-ephemeral DH: the client generates an ephemeral
-X25519 keypair (`client_ephemeral_public`) and derives the AEAD key against the
-server's Ed25519 key converted to X25519 via the birational map
-(`to_montgomery()`), with the KDF context `hyprstream-envelope-v1`.
-
-Under the `Hybrid` crypto policy, encryption is a **hybrid KEM**: an ML-KEM-768
-encapsulation against the server's KEM key is combined with the X25519 secret,
-and the 1088-byte ciphertext travels in `SignedEnvelope.pq_kem_ciphertext`.
-`Hybrid` mode requires both the server ML-KEM key and an ML-DSA-65 signing key —
-it fails closed rather than silently downgrading.
-
-The signature (raw Ed25519 and the COSE composite) covers the encrypted
-signing-data:
+The mandatory hybrid signature covers the complete COSE_Encrypt0 bytes. Sealed
+responses additionally bind the retained request ID and expected service domain:
 
 ```
-signing_data = ciphertext ‖ client_ephemeral_public ‖ [pq_kem_ciphertext]
+request_signing_data  = canonical_cose_encrypt0
+response_signing_data = domain || request_id || service_domain || canonical_cose_encrypt0
 ```
 
-Constructors: `SignedEnvelope::new_signed_encrypted()` (classical) and
-`new_signed_encrypted_hybrid()` / `new_signed_encrypted_with_policy()` (hybrid).
+Constructors: `SignedEnvelope::new_signed_encrypted_mesh_kem()` for requests and
+`ResponseEnvelope::new_signed_encrypted()` for one-shot response recipients.
 
 ## Key Exchange
 
-**Location:** `crates/hyprstream-rpc/src/crypto/key_exchange.rs`
+**Location:** `crates/hyprstream-rpc/src/crypto/hybrid_kem.rs`,
+`crates/hyprstream-rpc/src/stream_epoch.rs`, and the legacy utility
+`crates/hyprstream-rpc/src/crypto/key_exchange.rs`
 
-Streaming responses use HMAC authentication instead of per-token Ed25519 signatures for performance. The HMAC key is derived from a Diffie-Hellman shared secret.
+Production identified streams derive authenticated-encryption, MAC, control, and
+ratchet keys from the pinned X25519 + ML-KEM-768 HyKEM suite. The older
+Ristretto255/P-256 helpers remain local cryptographic utilities and test/migration
+substrate; they are not valid network-suite negotiation outcomes.
 
 ### Supported Algorithms
 
-| Algorithm | Feature Flag | Description |
+| Suite / primitive | Selection | Description |
 |-----------|--------------|-------------|
-| Ristretto255 | Default | Prime-order group on Curve25519 |
-| ECDH P-256 | `fips` | NIST curve for FIPS 140-2 compliance |
+| `HyKemX25519MlKem768` | Mandatory production suite ID | X25519 + ML-KEM-768 combined with strict AND semantics |
+| Ristretto255 | Local utility / legacy migration | Prime-order group on Curve25519; never a production fallback |
+| ECDH P-256 | `fips` local utility | NIST curve helper; never substitutes for the mandatory application HyKEM suite |
 
-### Ristretto255 (Default)
+### Ristretto255 (local/legacy utility)
 
 Ristretto255 is preferred because it eliminates common DH vulnerabilities:
 
@@ -439,8 +433,7 @@ fn derive_stream_keys(...) -> Result<StreamKeys> {
 
 ### Identified hybrid stream epochs (#554)
 
-`stream_epoch.rs` defines the production cryptographic profile that replaces the
-legacy Ristretto bootstrap as individual stream producers migrate. The client
+`stream_epoch.rs` defines the production cryptographic profile. The client
 places a fresh, suite-complete `clientKemPublic` in the signed (and, on network
 carriers, sealed) request. The server accepts only the policy-pinned
 `HyKEM-X25519-MLKEM768` suite and returns its suite-identified component
@@ -464,16 +457,25 @@ epoch committed. The publisher resets the per-epoch sequence and MAC chain but
 never resets its MOQT Group counter, so a cached track/group/object identity is
 never republished with different ciphertext.
 
+The signed carrier policy has exactly two distinct values:
+`owned-hybrid-transport` and `standard-public-relay`. The selected value is bound
+into resolution/admission evidence, the HyKEM transcript, every epoch KDF, and
+Object AAD. A failed owned hybrid TLS/QUIC negotiation cannot select the public
+relay profile; public relay use must already be explicitly authorized. Classical
+transport is only an untrusted carrier and contributes no application assurance.
+
 The profile is carrier-neutral. Data, completion metadata, and error messages are
-all sealed before framing, so a standard MOQT relay forwards ordinary opaque
-Object bytes and receives neither the transcript nor traffic keys. Network key
-release is still a separate #726 authorization PEP; the generic
+all sealed before framing, so a stock MOQT relay forwards ordinary opaque Object
+bytes without understanding private Hyprstream metadata and receives neither the
+transcript nor traffic keys. Before CONNECT/key release/publication, public-relay
+mode requires an anchored hybrid recipient, both KEM contributions, accepted
+current state, endpoint proof, and the encrypted Object path. Network key release
+is still a separate #726 authorization PEP; the generic
 `StreamKeyReleaseGate`/`StreamKeyReleasePrincipal` seam does not implement or
 claim restricted-anonymous #1060-#1062 authorization.
 
-The legacy `from_dh` constructors remain during the dependency-safe migration and
-are not evidence that #554 or the later global #556 downgrade-removal ticket is
-closed.
+Legacy `from_dh` helpers are not reachable as an in-band downgrade from the
+identified production profile.
 
 ## Chained HMAC
 
@@ -777,7 +779,9 @@ for (chunk, mac) in chunks.iter().zip(macs.iter()) {
 | `crates/hyprstream-rpc/src/crypto/cose_sign.rs` | COSE composite (EdDSA + ML-DSA-65) sign/verify |
 | `crates/hyprstream-rpc/src/crypto/cose_sign1.rs` | COSE_Sign1 encoding + `external_aad` schema binding |
 | `crates/hyprstream-rpc/src/crypto/pq.rs` | Post-quantum primitives: ML-DSA-65, ML-KEM-768 |
-| `crates/hyprstream-rpc/src/crypto/envelope_crypto.rs` | Envelope encryption (X25519 DH + AES-256-GCM-SIV, hybrid ML-KEM) |
+| `crates/hyprstream-rpc/src/crypto/cose_encrypt.rs` | Canonical COSE_Encrypt0 sealing/opening |
+| `crates/hyprstream-rpc/src/crypto/hybrid_kem.rs` | Pinned X25519 + ML-KEM-768 HyKEM suite |
+| `crates/hyprstream-rpc/src/stream_epoch.rs` | Carrier-bound identified hybrid stream epochs |
 | `crates/hyprstream-rpc/src/crypto/key_exchange.rs` | Ristretto255/ECDH P-256 key exchange |
 | `crates/hyprstream-rpc/src/crypto/hmac.rs` | Chained HMAC for streaming |
 | `crates/hyprstream-rpc/src/crypto/group_key.rs` | Group-key wrapping for event confidentiality |


### PR DESCRIPTION
## Summary

- pin production envelope and token authentication to the Ed25519 + ML-DSA-65 hybrid suite and remove unanchored/classical fallback behavior
- remove the `HYPRSTREAM_ENVELOPE_POLICY` runtime escape hatch, gate `CryptoPolicy::Classical` behind an explicit test-only feature, and fail construction/admission when PQ signing material or trust anchors are absent
- require hybrid verification in native and WASM clients, migrate RPC fixtures to anchored hybrid identities, and document pinned HyKEM/carrier-profile behavior
- preserve the stock MOQT opaque-forwarding contract and the anonymous-authorization fail-closed boundary

## Validation

- `cargo check -p hyprstream-rpc`
- `cargo check -p hyprstream`
- `cargo test -p hyprstream-rpc --lib` (751 passed, 3 ignored)
- RPC integration suite (all targets passed during implementation)
- `cargo test -p hyprstream-rpc --test envelope_canonicalization` (6 passed)
- `cargo clippy -p hyprstream-rpc -p hyprstream --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets --release -- -D warnings` (foreground pre-commit hook)
- `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo check --target wasm32-unknown-unknown -p hyprstream-rpc`
- `cargo deny check bans licenses`
- `python3 tools/check_pq_anonymous_issuance.py`

Closes #556