### PR TITLE
docs(discovery): record placement indexer design

### DIFF
--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -28,7 +28,7 @@ use crate::generated::discovery_client::{
 use crate::placement_index::PlacementIndex;
 use crate::scheduling;
 
-use anyhow::{Context,Result};
+use anyhow::{Context, Result};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use hyprstream_rpc::identity::Did;
 use hyprstream_util::ttl_cache::TtlCache;
@@ -52,6 +52,10 @@ const LIVENESS_TTL: Duration = Duration::from_secs(45);
 /// large bound doesn't cost anything until it's actually full.
 const LIVENESS_CACHE_MAX_ENTRIES: usize = 16_384;
 const LIVENESS_CACHE_REAP_BUDGET: usize = 32;
+/// Bound retry work for an admitted DID whose repo is absent, invalid, or does
+/// not yet contain a node record. This prevents heartbeat-rate resolver polls
+/// while allowing eventual recovery when a placement record is later published.
+const PLACEMENT_INGEST_RETRY_TTL: Duration = Duration::from_secs(300);
 const ANNOUNCED_ENDPOINT_TTL: Duration = Duration::from_secs(90);
 
 /// Default bound applied to `queryCandidates` when the caller passes
@@ -778,10 +782,13 @@ pub struct DiscoveryService {
     /// Domain the TLS endorsement covers (empty when no endorsement).
     tls_domain: String,
     /// #524 P1 — durable placement directory (labels/declared-resources/group
-    /// consents), refreshed by polling `record_resolver` lazily: the first
-    /// `reportNodeLiveness` heartbeat seen for a DID with no ingested
-    /// `NodeRecord` yet triggers a poll of its repo.
+    /// consents), refreshed by polling `record_resolver` lazily for an admitted
+    /// heartbeat DID with no ingested `NodeRecord` yet.
     placement_index: PlacementIndex,
+    /// Bounded retry gate for first-seen placement repository polls. A DID is
+    /// marked before resolver access, so absent/invalid/non-node repos cannot
+    /// turn heartbeat frequency into unbounded work.
+    placement_ingest_attempts: TtlCache<Did, ()>,
     /// #524 P1 — live allocatable capacity + load per node, TTL'd
     /// (`LIVENESS_TTL`). Backs the hard-exclusion-on-staleness rule in
     /// `queryCandidates`.
@@ -817,6 +824,10 @@ impl DiscoveryService {
             tls_endorsement: Vec::new(),
             tls_domain: String::new(),
             placement_index: PlacementIndex::new(),
+            placement_ingest_attempts: TtlCache::new(
+                LIVENESS_CACHE_MAX_ENTRIES,
+                LIVENESS_CACHE_REAP_BUDGET,
+            ),
             liveness: TtlCache::new(LIVENESS_CACHE_MAX_ENTRIES, LIVENESS_CACHE_REAP_BUDGET),
             transport,
         }
@@ -2293,7 +2304,9 @@ impl RpcClient for ProductionRpcClient {
                 let p = payload.clone();
                 let s = service.clone();
                 async move {
-                    c.call_streaming_for_service_with_method(&s, method_discriminator, p, ephemeral).await }
+                    c.call_streaming_for_service_with_method(&s, method_discriminator, p, ephemeral)
+                        .await
+                }
             })
             .await?
             .0)
@@ -2365,9 +2378,9 @@ fn parse_announced_quic(endpoint: &str) -> anyhow::Result<TransportConfig> {
     let rest = endpoint
         .strip_prefix("quic://")
         .ok_or_else(|| anyhow::anyhow!("announced QUIC endpoint must start with quic://"))?;
-    let (reach, encoded_hashes) = rest.split_once('#').map_or((rest, None), |(reach, hashes)| {
-        (reach, Some(hashes))
-    });
+    let (reach, encoded_hashes) = rest
+        .split_once('#')
+        .map_or((rest, None), |(reach, hashes)| (reach, Some(hashes)));
     let (server_name, addr) = reach.split_once(':').ok_or_else(|| {
         anyhow::anyhow!("announced QUIC endpoint must be quic://<server-name>:<socket-addr>")
     })?;
@@ -2389,7 +2402,9 @@ fn parse_announced_quic(endpoint: &str) -> anyhow::Result<TransportConfig> {
                     .decode(value)
                     .context("invalid announced QUIC certificate hash")?
                     .try_into()
-                    .map_err(|_| anyhow::anyhow!("announced QUIC certificate hash must be 32 bytes"))
+                    .map_err(|_| {
+                        anyhow::anyhow!("announced QUIC certificate hash must be 32 bytes")
+                    })
             })
             .collect::<Result<Vec<[u8; 32]>>>()?;
         anyhow::ensure!(!hashes.is_empty(), "announced QUIC pin set is empty");
@@ -2962,7 +2977,7 @@ mod resolver_tests {
 
     fn accepted_state(tag: u8) -> (AcceptedAt9pState, SigningKey) {
         let signing = SigningKey::from_bytes(&[tag; 32]);
-        let pq_signing = hyprstream_rpc::node_identity::derive_mesh_mldsa_key (&signing);
+        let pq_signing = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&signing);
         let keys = HybridKeyPair::new(
             signing.verifying_key().to_bytes().to_vec(),
             ml_dsa_sk_to_vk_bytes(&pq_signing),
@@ -3025,7 +3040,9 @@ mod resolver_tests {
                 endpoint,
                 service_jwt: "verified-by-handler".to_owned(),
                 service_did: Did::from(state.did.clone()),
-                capabilities: ["hyprstream-rpc/1".to_owned(), "hyprstream-moq/1".to_owned()].into_iter().collect(),
+                capabilities: ["hyprstream-rpc/1".to_owned(), "hyprstream-moq/1".to_owned()]
+                    .into_iter()
+                    .collect(),
                 accepted_state_digest: state.head_digest.to_vec(),
                 accepted_state_epoch: state.epoch,
                 response_key_id: format!("{}#response-current", state.did),
@@ -3229,7 +3246,10 @@ mod resolver_tests {
             .and_then(|entries| entries.first_mut())
             .expect("fixture route")
             .endpoint = "quic://localhost:127.0.0.1:10".to_owned();
-        assert!(resolver.verify_browser_binding(&route_binding).await.is_err());
+        assert!(resolver
+            .verify_browser_binding(&route_binding)
+            .await
+            .is_err());
 
         let (resolver, _) = production_fixture(false);
         resolver
@@ -3239,9 +3259,9 @@ mod resolver_tests {
             .and_then(|entries| entries.first_mut())
             .expect("fixture pin")
             .endpoint = format!(
-                "quic://localhost:127.0.0.1:9#{}",
-                URL_SAFE_NO_PAD.encode([0x51; 32])
-            );
+            "quic://localhost:127.0.0.1:9#{}",
+            URL_SAFE_NO_PAD.encode([0x51; 32])
+        );
         let pin_binding = binding_for(&resolver).await;
         resolver
             .announced_endpoints
@@ -3250,9 +3270,9 @@ mod resolver_tests {
             .and_then(|entries| entries.first_mut())
             .expect("fixture pin rotation")
             .endpoint = format!(
-                "quic://localhost:127.0.0.1:9#{}",
-                URL_SAFE_NO_PAD.encode([0x52; 32])
-            );
+            "quic://localhost:127.0.0.1:9#{}",
+            URL_SAFE_NO_PAD.encode([0x52; 32])
+        );
         assert!(resolver.verify_browser_binding(&pin_binding).await.is_err());
     }
 
@@ -4839,8 +4859,9 @@ impl DiscoveryHandler for DiscoveryService {
     ///
     /// Re-inserting (heartbeating) an admitted node refreshes its TTL entry. The
     /// first heartbeat seen for a DID this directory hasn't ingested a
-    /// `NodeRecord` for yet lazily triggers a one-shot poll of that DID's repo
-    /// (day-1 ingestion cadence — see the `placement_index` module docs); a
+    /// `NodeRecord` for yet may lazily trigger a repo poll. The bounded retry
+    /// gate records an attempt before resolver access, so absent/invalid/non-
+    /// node repos are retried only after [`PLACEMENT_INGEST_RETRY_TTL`]; a
     /// failure there does not fail the admitted heartbeat itself.
     async fn handle_report_node_liveness(
         &self,
@@ -4885,7 +4906,13 @@ impl DiscoveryHandler for DiscoveryService {
         };
         self.liveness.insert(data.node.clone(), live, LIVENESS_TTL);
 
-        if self.placement_index.record_uri(&node_did).is_none() {
+        if self.placement_index.record_uri(&node_did).is_none()
+            && self.placement_ingest_attempts.insert_if_absent(
+                data.node.clone(),
+                (),
+                PLACEMENT_INGEST_RETRY_TTL,
+            )
+        {
             if let Some(resolver) = &self.record_resolver {
                 if let Err(e) = self
                     .placement_index
@@ -5490,6 +5517,40 @@ mod query_candidates_tests {
             resolver.resolved.lock().is_empty(),
             "denied DID must not reach RecordResolver::resolve_repo"
         );
+    }
+
+    /// An admitted DID with no repo is polled once per bounded retry window,
+    /// not once per heartbeat. Its liveness report still refreshes normally.
+    #[tokio::test]
+    async fn absent_node_repo_does_not_poll_again_before_retry_window() {
+        let did = "did:web:node-without-repo.example.com";
+        let resolver = Arc::new(TrackingRepoResolver {
+            repos: HashMap::new(),
+            resolved: parking_lot::Mutex::new(Vec::new()),
+        });
+        let (sk, vk) = hyprstream_rpc::crypto::generate_signing_keypair();
+        let svc = DiscoveryService::new(
+            Arc::new(sk),
+            vk,
+            hyprstream_rpc::transport::TransportConfig::inproc("placement-retry-test"),
+        )
+        .with_auth_provider(Box::new(AllowAll))
+        .with_record_resolver(resolver.clone());
+
+        heartbeat(&svc, did, vec![], 0.9).await;
+        heartbeat(&svc, did, vec![("cpu", "8")], 0.1).await;
+
+        assert_eq!(
+            resolver.resolved.lock().as_slice(),
+            [did],
+            "two heartbeats before retry expiry must produce one repo poll"
+        );
+        let live = svc
+            .liveness
+            .get(&Did::new(did.to_owned()))
+            .expect("admitted heartbeat must still refresh liveness");
+        assert!((live.load_fraction - 0.1).abs() < f32::EPSILON);
+        assert_eq!(live.allocatable, vec![("cpu".to_owned(), "8".to_owned())]);
     }
 
     fn empty_query(max_candidates: u32) -> QueryCandidatesRequest {

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -4323,17 +4323,19 @@ impl DiscoveryHandler for DiscoveryService {
 
     /// #524 P1 — node liveness heartbeat. The auto-generated dispatch gate
     /// already ran a `discovery:ReportNodeLiveness`/`write` authz check before
-    /// this handler was invoked (mirrors `handle_announce`, which needs no
-    /// additional internal check for the same reason).
+    /// this handler was invoked. Before accepting a DID-specific heartbeat,
+    /// additionally require write admission for that candidate. This prevents
+    /// an authorized caller from using arbitrary heartbeat DIDs to grow the
+    /// durable placement directory or trigger unbounded resolver work.
     ///
-    /// Re-inserting (heartbeating) the same node refreshes its TTL entry. The
+    /// Re-inserting (heartbeating) an admitted node refreshes its TTL entry. The
     /// first heartbeat seen for a DID this directory hasn't ingested a
     /// `NodeRecord` for yet lazily triggers a one-shot poll of that DID's repo
     /// (day-1 ingestion cadence — see the `placement_index` module docs); a
-    /// failure there does not fail the heartbeat itself.
+    /// failure there does not fail the admitted heartbeat itself.
     async fn handle_report_node_liveness(
         &self,
-        _ctx: &EnvelopeContext,
+        ctx: &EnvelopeContext,
         _request_id: u64,
         data: &NodeLiveness,
     ) -> Result<DiscoveryResponseVariant> {
@@ -4342,6 +4344,19 @@ impl DiscoveryHandler for DiscoveryService {
             return Ok(DiscoveryResponseVariant::Error(ErrorInfo {
                 message: "node is required".to_owned(),
                 code: "INVALID_ARGUMENT".to_owned(),
+                details: String::new(),
+            }));
+        }
+
+        // The generic dispatch gate authorizes calling reportNodeLiveness; it
+        // does not authorize claiming liveness for a particular DID. Gate the
+        // DID before touching either the bounded volatile cache or the
+        // unbounded-by-heartbeat placement snapshot index.
+        let resource = format!("placement:candidate:{node_did}");
+        if let Err(e) = self.authorize(ctx, &resource, "write").await {
+            return Ok(DiscoveryResponseVariant::Error(ErrorInfo {
+                message: format!("unauthorized to report liveness for {resource}: {e}"),
+                code: "UNAUTHORIZED".to_owned(),
                 details: String::new(),
             }));
         }
@@ -4757,8 +4772,8 @@ mod query_candidates_tests {
         }
     }
 
-    /// Denies exactly the `placement:candidate:<did>` resource for one DID;
-    /// allows everything else (including the dispatch-level auto-gate checks).
+    /// Denies `query` access to exactly one `placement:candidate:<did>`
+    /// resource; allows write admission so that test setup can heartbeat it.
     struct DenyNode(String);
     #[async_trait(?Send)]
     impl AuthorizationProvider for DenyNode {
@@ -4767,9 +4782,49 @@ mod query_candidates_tests {
             _subject: &str,
             _domain: &str,
             resource: &str,
-            _operation: &str,
+            operation: &str,
         ) -> Result<bool> {
-            Ok(resource != format!("placement:candidate:{}", self.0))
+            Ok(resource != format!("placement:candidate:{}", self.0) || operation != "query")
+        }
+    }
+
+    /// Denies `write` admission for exactly one node DID.
+    struct DenyNodeLiveness(String);
+    #[async_trait(?Send)]
+    impl AuthorizationProvider for DenyNodeLiveness {
+        async fn check(
+            &self,
+            _subject: &str,
+            _domain: &str,
+            resource: &str,
+            operation: &str,
+        ) -> Result<bool> {
+            Ok(resource != format!("placement:candidate:{}", self.0) || operation != "write")
+        }
+    }
+
+    /// Records repository lookups so admission tests can prove a denied DID
+    /// never reaches `RecordResolver::resolve_repo`.
+    struct TrackingRepoResolver {
+        repos: HashMap<String, Vec<u8>>,
+        resolved: parking_lot::Mutex<Vec<String>>,
+    }
+    #[async_trait(?Send)]
+    impl RecordResolver for TrackingRepoResolver {
+        async fn resolve_record(
+            &self,
+            _did: &str,
+            _collection: &str,
+            _rkey: &str,
+        ) -> Result<Option<RecordCarData>> {
+            Ok(None)
+        }
+        async fn resolve_repo(&self, did: &str) -> Result<Option<RecordCarData>> {
+            self.resolved.lock().push(did.to_owned());
+            Ok(self.repos.get(did).map(|car| RecordCarData {
+                uri: format!("at://{did}"),
+                car: car.clone(),
+            }))
         }
     }
 
@@ -4878,6 +4933,54 @@ mod query_candidates_tests {
             resp,
             DiscoveryResponseVariant::ReportNodeLivenessResult
         ));
+    }
+
+    /// A denied heartbeat must not create a volatile liveness entry or trigger
+    /// a first-seen repository poll, even if the caller passed the generic
+    /// reportNodeLiveness dispatch gate.
+    #[tokio::test]
+    async fn liveness_admission_denial_skips_cache_and_repository_ingest() {
+        let did = "did:web:unadmitted-node.example.com";
+        let rec = sample_node_record(did, vec![]);
+        let resolver = Arc::new(TrackingRepoResolver {
+            repos: HashMap::from([(did.to_owned(), node_repo_car(did, &rec))]),
+            resolved: parking_lot::Mutex::new(Vec::new()),
+        });
+        let (sk, vk) = hyprstream_rpc::crypto::generate_signing_keypair();
+        let svc = DiscoveryService::new(
+            Arc::new(sk),
+            vk,
+            hyprstream_rpc::transport::TransportConfig::inproc("liveness-admission-test"),
+        )
+        .with_auth_provider(Box::new(DenyNodeLiveness(did.to_owned())))
+        .with_record_resolver(resolver.clone());
+        let req = NodeLiveness {
+            node: Did::new(did.to_owned()),
+            allocatable: vec![],
+            load_fraction: 0.1,
+            ts: 0,
+        };
+
+        let response = svc
+            .handle_report_node_liveness(&test_ctx(), 1, &req)
+            .await
+            .unwrap();
+        assert!(matches!(
+            response,
+            DiscoveryResponseVariant::Error(ErrorInfo { ref code, .. }) if code == "UNAUTHORIZED"
+        ));
+        assert!(
+            svc.liveness.get(&Did::new(did.to_owned())).is_none(),
+            "denied DID must not receive a liveness entry"
+        );
+        assert!(
+            svc.placement_index.record_uri(did).is_none(),
+            "denied DID must not receive placement facts"
+        );
+        assert!(
+            resolver.resolved.lock().is_empty(),
+            "denied DID must not reach RecordResolver::resolve_repo"
+        );
     }
 
     fn empty_query(max_candidates: u32) -> QueryCandidatesRequest {

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -3276,9 +3276,12 @@ mod resolver_tests {
         )
         .with_cnf_jwk(service_signing.verifying_key().as_bytes());
         let jwt = hyprstream_rpc::auth::jwt::encode_service_jwt(&claims, &root);
-        let signed = hyprstream_rpc::SignedEnvelope::new_signed(
+        let service_pq_signing =
+            hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&service_signing);
+        let signed = hyprstream_rpc::SignedEnvelope::new_signed_hybrid(
             hyprstream_rpc::RequestEnvelope::anonymous(Vec::new()),
             &service_signing,
+            &service_pq_signing,
         );
         let ctx = EnvelopeContext::from_verified_as_system(&signed);
         let kem = hyprstream_rpc::crypto::hybrid_kem::generate_recipient(

--- a/docs/placement-indexer-architecture.md
+++ b/docs/placement-indexer-architecture.md
@@ -1,0 +1,203 @@
+# Placement Record Indexer / Discovery AppView
+
+This document records the design settled by #564 for the P1 placement directory
+implemented by #524. It separates durable placement capabilities from volatile
+load, defines the trust and freshness boundaries, and records the EventService
+AppView shape that supersedes the original proposed `moq_event::BackfillSource`
+widening.
+
+## Scope and outcome
+
+The placement directory is an in-process index owned by `DiscoveryService`.
+`queryCandidates` uses it to discover a bounded set of candidate node DIDs;
+it is not a global scheduler or cross-cell directory (that work remains #522).
+
+P1 materializes records in these collections:
+
+- `ai.hyprstream.placement.node`: a node's labels, declared capacities, and
+  group-consent URIs.
+- `ai.hyprstream.placement.group`: group metadata owned by the publishing DID.
+- `ai.hyprstream.placement.groupItem`: the group owner's membership claim.
+- `ai.hyprstream.placement.workload`: decoded as part of a repository snapshot,
+  but not used to filter P1 candidates.
+
+The candidate identity is a `Did`; there is no separate `nodeId`. A selected
+candidate includes the node record's `at://` URI so a caller that needs a proof
+can retrieve the signed source record with `getRecord`.
+
+## Day-one ingestion: authenticated repository snapshots
+
+Day one deliberately does **not** use `moq_event::BackfillSource` or introduce
+a placement-specific firehose consumer. `BackfillSource` is a legacy,
+OID-scoped event API; widening it to `{ Oid | Did }` would preserve the wrong
+key model. The existing P1 implementation instead polls the injected
+`RecordResolver` for a bootstrap set of node DIDs:
+
+```text
+bootstrap DID (discovery announce; final admission policy at implementation review)
+  -> RecordResolver::resolve_repo(did)
+  -> CARv1: commit + complete MST + record blocks
+  -> validate, decode placement collections
+  -> replace that DID's snapshot in PlacementIndex
+  -> rebuild derived directory maps
+```
+
+A refresh replaces a DID's complete snapshot, never merges records indefinitely.
+Thus removal of a source record removes its derived labels and membership claims
+at the next successful poll. A missing repo likewise clears the older snapshot;
+a resolver, CAR, signature, or decoding failure clears it and does not admit
+partially decoded facts.
+
+### Ingest trust boundary
+
+The resolver is a source adapter, not the integrity root. Before any record can
+enter the index, the ingestion path must:
+
+1. Require exactly one CAR root and locate the commit block.
+2. Recompute and compare the CID of every CAR block, including the commit,
+   MST nodes, and records.
+3. Require `commit.did == did` to prevent a valid repo from one DID being
+   replayed as another.
+4. When `RecordResolver::resolve_verifying_key` supplies the DID's `#atproto`
+   P-256 key, verify the commit signature before materializing facts.
+5. Walk the MST with a visited-set and bounded visit budget, then decode only
+   known placement record schemas.
+
+The CID check matters even when the commit signature verifies: the commit signs
+the root CID, not arbitrary bytes handed to the index under a declared CID.
+Without content binding, substituted MST or record blocks could forge group
+membership.
+
+`Ok(None)` from `resolve_verifying_key` retains the day-one trusted-resolver
+posture: structural and CID validation are still mandatory, but authentication
+of the remote DID is delegated to the in-process resolver boundary. Resolving
+foreign DID-document `#atproto` methods is a federation-hardening follow-up.
+Until then, placement data is scheduling metadata, while the requester's
+per-candidate policy authorization remains the hard query boundary.
+
+## Materialized state and query path
+
+`PlacementIndex` retains a raw snapshot per source DID and rebuilds the derived
+maps after each refresh:
+
+```text
+DID -> { node facts, owned groups, group-item claims, workload count }
+DID -> node { record URI, labels, declared resources, consented group URIs }
+group at-URI -> group metadata
+group at-URI -> claimed member DIDs
+```
+
+This representation makes delete/replace semantics simple and avoids retaining
+stale materialized facts. The current P1 fleet size is small enough that selector
+evaluation scans the known, live node set. A future high-cardinality AppView may
+add an inverted `label key/value -> DID set` index, but must preserve the same
+selector semantics for `In`, `NotIn`, `Exists`, `DoesNotExist`, `Gt`, and `Lt`.
+It must not hard-code CPU, GPU, or memory names: labels and resource names are
+generic key/value data.
+
+A group is effective only with **bidirectional consent**:
+
+```text
+group owner publishes GroupItemRecord(group, subject = node DID)
+AND
+node's NodeRecord.groups contains that exact group at-URI
+```
+
+The index exposes each effective membership as synthetic label
+`group/<group-at-uri>=true`. Using a group-specific label key is intentional:
+the label selector model has one value per key, so multiple `group=<uri>`
+entries would cause ambiguous or silently incomplete matching.
+
+`queryCandidates` performs these steps in order:
+
+1. Start with DIDs that have a durable indexed `NodeRecord` **and** an unexpired
+   liveness entry.
+2. Evaluate label selectors, including synthetic group labels.
+3. Evaluate generic resource requests against the liveness report's
+   `allocatable` resources, not the durable declared capacity.
+4. Perform a fail-closed authorization check for each surviving
+   `placement:candidate:<did>` resource.
+5. Rank the authorized candidates by lower load and stable DID tie-break,
+   then apply the caller/default result bound. `total_matching` is computed
+   before that bound so truncation remains observable.
+
+Ranking, affinity, and stickiness are deliberately outside P1.
+
+## Freshness model
+
+Durable capability facts and live scheduling facts have distinct freshness
+contracts:
+
+| Layer | Source | Freshness | Failure behavior |
+| --- | --- | --- | --- |
+| Labels, declared capacity, group records | polled signed repository snapshot | bounded by poll interval / later event lag | old facts are replaced or cleared on refresh failure; they cannot make an unlived node eligible |
+| Allocatable capacity and load | `reportNodeLiveness` | real time within TTL | `TtlCache` expiry hard-excludes the node from candidates |
+
+The hard exclusion is the ratified default: a node without a fresh liveness
+advertisement is unavailable, rather than returned with a stale marker. A
+soft/stale result mode, if ever added, must be opt-in and must not silently
+become the scheduling default.
+
+`reportNodeLiveness` may trigger first-seen ingestion for a node, but reporting
+liveness does not itself establish durable placement capabilities. The two
+layers remain independent by design.
+
+## Memory and operational bounds
+
+The P1 index is process-local and bounded by the cell's admitted/bootstrap DID
+set, not the full federation. Operators must bound the bootstrap input (the
+recommended source is discovery announcements), repository/CAR read size,
+maximum records and labels per DID, MST visit budget, polling concurrency, and
+query result count. P1 already bounds the returned candidate set; an AppView
+implementation must retain that bound and reject/skip oversized source
+snapshots rather than allowing a peer-controlled record graph to consume
+unbounded DiscoveryService memory.
+
+Raw snapshots are needed for atomic replace semantics. Derived maps are rebuilt
+from those snapshots after an ingest, keeping read-side queries lock-bounded and
+preventing deletion leaks. Metrics should expose poll age/failure, indexed DID
+count, decoded record counts, rejected snapshots, liveness-cache size/expiry,
+and query truncation.
+
+## Day-two EventService AppView
+
+The live tail uses the public-profile EventService firehose defined by EV3
+(#603). Its canonical subject is:
+
+```text
+CanonicalSubject { did, nsid, rkey }
+```
+
+The AppView consumes only placement NSIDs for admitted DIDs. Its cold-start/live
+seam is:
+
+```text
+record-store snapshot (RecordResolver -> CAR/MST validation)
+  -> establish EventService firehose cursor
+  -> apply commits whose (DID, NSID) match placement collections
+  -> atomically publish an updated per-DID snapshot
+```
+
+Cursor handoff must avoid a gap between the snapshot and tail: subscribe or
+capture a high-water cursor first, read the snapshot, then replay from that
+cursor before accepting the live edge. Each event still passes the same schema,
+content-binding, DID/authority, and replace/delete validation as a polled
+snapshot; firehose delivery is not an authority bypass.
+
+This replaces, rather than widens, the old OID-keyed `BackfillSource`. The
+read-snapshot-then-tail concept in `BackfillMode` remains useful, but the
+bespoke OID naming is retired in favor of canonical record subjects. Longer
+term, the snapshot read converges with #705's subject-authorized VFS/CAS record
+store; the EventService firehose remains the live event plane.
+
+## Non-goals and follow-ups
+
+- Cross-cell/global directory fan-out, affinity, and stickiness: #522.
+- Firehose cursoring and EventService AppView implementation: day two after the
+  EV3 subject model; not a `BackfillSource` API change.
+- Foreign DID `#atproto` key resolution: federation-hardening follow-up.
+- A soft stale-liveness policy: only as an explicit future configuration.
+
+This design answers #564 while preserving the P1 implementation boundary set
+by #524: local, bounded, authenticated repository materialization plus a
+separate, TTL-bounded volatile load layer.


### PR DESCRIPTION
## Summary
- record the ratified P1 placement-indexer design and its trust/freshness boundaries
- document CAR/MST validation, bidirectional group consent, generic selector/resource matching, and hard TTL liveness exclusion
- specify the deferred EventService AppView using canonical `(did, nsid, rkey)` subjects instead of widening legacy OID backfill APIs

## Validation
- `cargo test -p hyprstream-discovery`
- `cargo clippy -p hyprstream-discovery --all-targets --all-features -- -D warnings`
- pre-commit full release Clippy/CI mirror

`cargo fmt --all --check` is blocked by the worktree metadata mismatch in `crates/bitsandbytes-sys`, which resolves its workspace to the parent checkout. No Rust source changed.

Closes #564.