### PR TITLE
9P translator: S2 reference-monitor contract + opt-in mediation groundwork (#568)

### DIFF
--- a/crates/hyprstream-9p/src/backend.rs
+++ b/crates/hyprstream-9p/src/backend.rs
@@ -24,6 +24,15 @@ pub struct WalkResult {
     /// number of components traversed; the client treats a short list as
     /// "walk stopped early").
     pub qids: Vec<Qid>,
+    /// Exact request-component prefix to which `newfid` is bound. For a
+    /// non-empty walk this has the same length as `qids`; a short prefix is a
+    /// 9P partial walk. Backends must report their actual binding here rather
+    /// than inferring it from the number of leaf qids they happen to return.
+    ///
+    /// The translator rejects a result that is not a prefix of its request or
+    /// whose QID count disagrees with this prefix, so a backend cannot bind a
+    /// deeper object while making the monitor cache a shallower name.
+    pub reached: Vec<String>,
 }
 
 /// Result of an open/lopen.

--- a/crates/hyprstream-9p/src/lib.rs
+++ b/crates/hyprstream-9p/src/lib.rs
@@ -85,5 +85,5 @@ pub use translator::{
 pub use mac_seam::{
     anonymous_floor, AccessDecider, Action, AnonymousAuthenticator, AttachAuthenticator,
     DenyAllDecider, DenyUnlabeledResolver, ObjectLabelResolver, ObjectRef, ReferenceMonitor,
-    SessionContext, VerifiedTokenScope,
+    SessionContext, VerifiedAttachIdentity, VerifiedTokenScope,
 };

--- a/crates/hyprstream-9p/src/lib.rs
+++ b/crates/hyprstream-9p/src/lib.rs
@@ -46,9 +46,11 @@ pub mod memory;
 // The browser/wasm build reaches the backend through the DMA/Wanix client path.
 #[cfg(not(target_arch = "wasm32"))]
 pub mod translator;
-// Attach-time MAC seam (#568): trait interface for verifying an attach
-// credential and authorizing per-op access, with inert (no-op) defaults.
-// Native-only alongside `translator`, its only consumer today.
+// 9P reference-monitor contract (S2 / #568): the attach-time token seam, the
+// per-op mediation composition (`ReferenceMonitor`), and fail-closed defaults.
+// Dormant groundwork — `Translator` runs without a monitor unless the
+// application installs one (activation is blocked on #698). Native-only
+// alongside `translator`, its only consumer today.
 #[cfg(not(target_arch = "wasm32"))]
 pub mod mac_seam;
 // `MountBackend` bridges a VFS `Mount` (+ `Subject`) to the `Backend` seam so
@@ -81,6 +83,7 @@ pub use translator::{
 };
 #[cfg(not(target_arch = "wasm32"))]
 pub use mac_seam::{
-    anonymous_floor, AccessDecider, Action, AllowAllDecider, AnonymousAuthenticator,
-    AttachAuthenticator, AuditSink, AuditedDecider, NullAuditSink,
+    anonymous_floor, AccessDecider, Action, AnonymousAuthenticator, AttachAuthenticator,
+    DenyAllDecider, DenyUnlabeledResolver, ObjectLabelResolver, ObjectRef, ReferenceMonitor,
+    SessionContext, VerifiedTokenScope,
 };

--- a/crates/hyprstream-9p/src/mac_seam.rs
+++ b/crates/hyprstream-9p/src/mac_seam.rs
@@ -54,9 +54,12 @@
 //!
 //! Concretely, this name↔object gap is **not** covered today:
 //!
-//! - **Partial walks** — handled (the cached path is derived from the backend's
-//!   *returned qid count*, never the requested suffix; see `handle_walk`), but
-//!   only because the translator narrows the name to match the reached object.
+//! - **Partial walks** — the backend reports its exact reached request prefix,
+//!   and the translator rejects a result whose QID count disagrees with that
+//!   prefix. `MountBackend` emits one QID per bound component; `ModelBackend`
+//!   rejects multi-name walks until it can provide that same contract. This
+//!   prevents the former one-leaf-QID/deep-fid mismatch, but still relies on
+//!   the label resolver and backend agreeing on what a reported path names.
 //! - **Path traversal / `..`** — `hyprstream-9p` performs **no** `..`
 //!   canonicalization; `wnames` are concatenated verbatim into the cached path.
 //!   Not exploitable against `MemoryBackend`/`MountBackend` (they resolve
@@ -162,18 +165,38 @@ impl VerifiedTokenScope {
 /// constructor from raw `uname`, `Subject`, claims, paths, or labels.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SessionContext {
+    attach_identity: VerifiedAttachIdentity,
     security_context: SecurityContext,
     token: Option<VerifiedTokenScope>,
+}
+
+/// Stable principal or credential identity returned by an
+/// [`AttachAuthenticator`] after verification.
+///
+/// This is deliberately separate from [`SecurityContext`]: clearance and key
+/// assurance are authorization attributes, not a principal identity. The
+/// verifier must derive this from the verified subject or stable credential
+/// fingerprint, never from an unverified `Tattach.uname` string.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VerifiedAttachIdentity(Arc<str>);
+
+impl VerifiedAttachIdentity {
+    /// Construct an identity obtained from verified credential material.
+    pub fn from_verified_identity(identity: impl Into<Arc<str>>) -> Self {
+        Self(identity.into())
+    }
 }
 
 impl SessionContext {
     /// Combine a verified subject context with the scope of the same verified,
     /// sender-bound token.
     pub fn from_verified_token(
+        attach_identity: VerifiedAttachIdentity,
         security_context: SecurityContext,
         token: VerifiedTokenScope,
     ) -> Self {
         Self {
+            attach_identity,
             security_context,
             token: Some(token),
         }
@@ -184,6 +207,7 @@ impl SessionContext {
     /// makes every operation deny before the AVC/PDP is reached.
     pub fn deny() -> Self {
         Self {
+            attach_identity: VerifiedAttachIdentity::from_verified_identity("denied"),
             security_context: anonymous_floor(),
             token: None,
         }
@@ -205,8 +229,9 @@ impl SessionContext {
     /// Identity comparison for re-attach detection, deliberately distinct from
     /// the derived [`PartialEq`].
     ///
-    /// Two attaches are the *same* session when their verified subject context
-    /// and verified-token scope (label ceiling + permitted operations) match.
+    /// Two attaches are the *same* session when their verified identity,
+    /// verified subject context, and verified-token scope (label ceiling +
+    /// permitted operations) match.
     /// The token's `valid_until` deadline is excluded on purpose: a real
     /// [`AttachAuthenticator`] re-stamps `Instant::now() + ttl` on every
     /// verification of the *same* ticket, so including it would make an
@@ -215,6 +240,9 @@ impl SessionContext {
     /// value equality (useful for diagnostics/tests); *attach identity* — what
     /// `bind_attach_session` checks — is this method.
     pub fn same_attach_identity(&self, other: &SessionContext) -> bool {
+        if self.attach_identity != other.attach_identity {
+            return false;
+        }
         if self.security_context != other.security_context {
             return false;
         }
@@ -448,7 +476,7 @@ mod tests {
     fn authorize_allows_when_all_gates_pass() {
         let monitor = monitor(Some(label(Level::Public)), Arc::new(AllowAll));
         let session =
-            SessionContext::from_verified_token(ctx(Level::Secret), permit_token(&[Action::Read]));
+            SessionContext::from_verified_token(VerifiedAttachIdentity::from_verified_identity("test-subject"), ctx(Level::Secret), permit_token(&[Action::Read]));
         assert!(monitor.authorize(&session, &path(&["a.txt"]), Action::Read));
     }
 
@@ -457,7 +485,7 @@ mod tests {
         // Even a permit-everything decider cannot rescue an unlabeled object.
         let monitor = monitor(None, Arc::new(AllowAll));
         let session =
-            SessionContext::from_verified_token(ctx(Level::Secret), permit_token(&[Action::Read]));
+            SessionContext::from_verified_token(VerifiedAttachIdentity::from_verified_identity("test-subject"), ctx(Level::Secret), permit_token(&[Action::Read]));
         assert!(!monitor.authorize(&session, &path(&["a.txt"]), Action::Read));
     }
 
@@ -466,7 +494,7 @@ mod tests {
         let monitor = monitor(Some(label(Level::Public)), Arc::new(AllowAll));
         assert!(!monitor.authorize(&SessionContext::deny(), &path(&["a.txt"]), Action::Read));
         let read_only =
-            SessionContext::from_verified_token(ctx(Level::Secret), permit_token(&[Action::Read]));
+            SessionContext::from_verified_token(VerifiedAttachIdentity::from_verified_identity("test-subject"), ctx(Level::Secret), permit_token(&[Action::Read]));
         assert!(!monitor.authorize(&read_only, &path(&["a.txt"]), Action::Write));
     }
 
@@ -477,7 +505,7 @@ mod tests {
         // decider and a token whose ceiling covers it.
         let monitor = monitor(Some(label(Level::Secret)), Arc::new(AllowAll));
         let session =
-            SessionContext::from_verified_token(ctx(Level::Public), permit_token(&[Action::Read]));
+            SessionContext::from_verified_token(VerifiedAttachIdentity::from_verified_identity("test-subject"), ctx(Level::Public), permit_token(&[Action::Read]));
         assert!(!monitor.authorize(&session, &path(&["secret.txt"]), Action::Read));
     }
 

--- a/crates/hyprstream-9p/src/mac_seam.rs
+++ b/crates/hyprstream-9p/src/mac_seam.rs
@@ -1,56 +1,60 @@
-//! Attach-time MAC seam for the 9P translator (#568, epic #547).
+//! 9P reference-monitor contract (S2 / #568, epic #547) — **dormant groundwork**.
 //!
-//! `hyprstream-9p` sits *below* `hyprstream` in the dependency graph (the
-//! reverse: `hyprstream` depends on `hyprstream-9p`), so the concrete grant
-//! verification (`mac::exchange`), the compiled-policy PDP (`mac::te`), the
-//! per-op cache (`mac::avc::CachingAvc`), and the audit trail
-//! (`mac::audit::AuditedAvc`) — which all live in the `hyprstream` binary
-//! crate — can never be called from here without a dependency cycle.
+//! `hyprstream-9p` owns the 9P operation choke point but deliberately does not
+//! depend on the application crate that owns MAC policy loading and the AVC.
+//! This module is the dependency-inversion boundary: the application verifies a
+//! sender-bound access token once at `Tattach`, then the translator applies the
+//! label, token, and IFC gates *before* asking an injected local policy monitor
+//! (the application's AVC/PDP adapter).
 //!
-//! Per the ratified interface policy (CLAUDE.md, "Interface policy — MAC on
-//! contracts that don't carry it", rule 2): the fix is dependency inversion,
-//! not moving code. This module defines the trait seam; the `hyprstream`
-//! crate is expected to provide the concrete implementations and inject them
-//! wherever it constructs a [`crate::Translator`] (mirroring the existing
-//! `Backend`/`ModelBackend` precedent — the capnp-RPC-backed `Backend` impl
-//! already lives in the `hyprstream` crate, not here).
+//! The mediation ordering is intentional and non-optional:
 //!
-//! ## Fail-closed defaults ship inert, not deny-by-default
+//! ```text
+//! Tattach: verify sender-bound token -> SessionContext (cached per fid)
+//! each op: resolve content-truth label -> token scope -> IFC -> local AVC/PDP
+//! ```
 //!
-//! [`LabeledObject::security_label`] returning `None` means the object is
-//! **unlabeled**, and per the S1 invariant (`hyprstream_rpc::auth::mac`,
-//! design §1 invariant 2) an unlabeled object MUST deny — there is no
-//! "unlabeled ⇒ floor" default at that layer. Every object in the 9P
-//! namespace is unlabeled today (genesis labeling for 9P nodes is unstarted,
-//! and #699 carrier-b — the content-addressed manifest label field — is still
-//! an open design decision). Wiring a real deny-on-unlabeled
-//! [`AccessDecider`] into the live dispatch path by default would therefore
-//! deny every existing 9P client outright — a severe, silent regression, not
-//! a security fix.
+//! No token, expired token, unlabeled object, or non-dominating subject reaches
+//! the policy monitor, so a permissive policy implementation cannot bypass the
+//! mandatory token/IFC floor. Per-op cost is a fid-table lookup plus a local
+//! AVC call — never UCAN chain validation or Casbin matching.
 //!
-//! So the defaults here ([`AnonymousAuthenticator`], [`AllowAllDecider`])
-//! preserve **today's actual behavior** (no enforcement) exactly. They exist
-//! so the translator has somewhere to hang real enforcement once a caller
-//! opts in via [`Translator::with_authenticator`](crate::Translator::with_authenticator)
-//! / [`Translator::with_decider`](crate::Translator::with_decider) — which the
-//! `hyprstream` crate can do once (a) a standalone "verify a presented S6
-//! access token" entry point exists outside the OAuth HTTP handler, and (b)
-//! object labels are actually available for the mount being served (genesis
-//! labeling, or #699 carrier-b for content-addressed data). Both are called
-//! out as follow-ups in the PR body rather than implemented here.
+//! ## Not active by default
+//!
+//! This is the S2 machinery, not S2 activation. [`Translator`](crate::Translator)
+//! runs **without** a [`ReferenceMonitor`] unless the application installs one
+//! via `with_reference_monitor`, and no production construction installs one
+//! today — per-op behavior is then exactly what it was before this module
+//! existed. Activation is blocked on:
+//!
+//! - **#698** — no production token-issuance path attaches `Claims.clearance`
+//!   yet, so a live monitor would resolve every subject to deny; and
+//! - **object labels for the served mount** — the genesis/manifest resolver
+//!   (`hyprstream::mac::genesis::CompositeObjectLabelResolver`) exists but is
+//!   not yet wired to the 9P export.
+//!
+//! Do not wire a monitor into the production serve paths from this crate; that
+//! wiring lands with the activation change, after #698.
+
+use std::sync::Arc;
+use std::time::Instant;
 
 use async_trait::async_trait;
 use hyprstream_rpc::auth::mac::{
     Assurance, CompartmentSet, Level, SecurityContext, SecurityLabel, VerifiedKeyMaterial,
 };
 
-/// The 9P op an [`AccessDecider`] is being asked to authorize.
+pub use hyprstream_rpc::auth::mac::{ObjectLabelResolver, ObjectRef};
+
+/// The 9P operation an [`AccessDecider`] is asked to authorize.
 ///
 /// Mirrors the translator's dispatch surface (`walk`/`open`/`read`/`write`/
 /// `getattr`/`readdir`) so a real decider can apply per-action policy (e.g.
 /// deny `Write` more aggressively than `Read`). Only ops the translator
-/// actually dispatches appear here — there is no `Tlcreate` handler, so no
-/// `Create` variant (a dead variant would be an unreachable policy surface).
+/// actually dispatches appear here — there is no `Tlcreate`/`Tremove` handler,
+/// so no `Create`/`Remove` variant (a dead variant would be an unreachable
+/// policy surface). `Tclunk` is fid disposal, not an object operation, and is
+/// deliberately not mediated.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Action {
     Walk,
@@ -61,39 +65,129 @@ pub enum Action {
     Readdir,
 }
 
-/// Verifies an attach credential (9P `uname`/`aname`) and derives the
-/// caller's [`SecurityContext`] for the resulting fid.
+/// A verified, sender-bound access-token scope cached for one 9P attach.
 ///
-/// Called exactly once per `Tattach`, mirroring the ratified interface
-/// policy's rule 2 (extend at attach time, never per-op): the derived context
-/// is cached on the fid (see `FidTable`) and reused for every subsequent op
-/// on that fid and its descendants, never re-verified per op.
-#[async_trait]
-pub trait AttachAuthenticator: Send + Sync {
-    /// Verify `uname`/`aname` and return the derived context. Must never
-    /// panic or block indefinitely on a malformed/hostile credential — an
-    /// invalid credential resolves to the anonymous floor context, exactly
-    /// like a missing one (fail-closed by floor, not by rejecting the
-    /// attach outright, so unauthenticated legacy clients keep working).
-    async fn authenticate(&self, uname: &str, aname: &str) -> SecurityContext;
+/// This type intentionally contains only the deny-only token facts needed on
+/// the hot path. Signature/expiry/DPoP verification happens in the
+/// [`AttachAuthenticator`] before constructing it; UCAN chain validation never
+/// runs per operation. The object label is *not* token-supplied: it is passed
+/// to [`Self::authorizes`] by the reference monitor after trusted resolution.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VerifiedTokenScope {
+    label_ceiling: SecurityLabel,
+    operations: Arc<[Action]>,
+    valid_until: Instant,
 }
 
-/// The default, no-op authenticator: every attach resolves to the anonymous
-/// floor context regardless of `uname`/`aname`. This is exactly today's
-/// behavior (the translator performs no identity verification at all), kept
-/// as the default so existing callers see no behavior change.
+impl VerifiedTokenScope {
+    /// Build the local representation of an access token that has already had
+    /// its signature, sender binding, and expiry verified at attach time.
+    ///
+    /// Callers must not derive these values from a UCAN/caveat or a
+    /// caller-supplied label. The monitor independently resolves the object
+    /// label from the mounted object's manifest/genesis source.
+    pub fn from_verified_token(
+        label_ceiling: SecurityLabel,
+        operations: impl Into<Arc<[Action]>>,
+        valid_until: Instant,
+    ) -> Self {
+        Self {
+            label_ceiling,
+            operations: operations.into(),
+            valid_until,
+        }
+    }
+
+    /// The token's label ceiling, for diagnostics and application audit code.
+    pub fn label_ceiling(&self) -> SecurityLabel {
+        self.label_ceiling
+    }
+
+    /// Token gate: unexpired, exact operation membership, and object label no
+    /// more restrictive than the verified token's ceiling.
+    #[inline]
+    pub fn authorizes(&self, object_label: &SecurityLabel, action: Action) -> bool {
+        Instant::now() < self.valid_until
+            && self.operations.contains(&action)
+            && self.label_ceiling.can_access(object_label)
+    }
+}
+
+/// Attach-scoped state cached onto every fid derived from the attach fid.
+///
+/// The public constructor is intentionally named for its trust precondition:
+/// only an [`AttachAuthenticator`] that has verified the presented token and
+/// DPoP sender binding may construct a permitting session. There is no
+/// constructor from raw `uname`, `Subject`, claims, paths, or labels.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SessionContext {
+    security_context: SecurityContext,
+    token: Option<VerifiedTokenScope>,
+}
+
+impl SessionContext {
+    /// Combine a verified subject context with the scope of the same verified,
+    /// sender-bound token.
+    pub fn from_verified_token(
+        security_context: SecurityContext,
+        token: VerifiedTokenScope,
+    ) -> Self {
+        Self {
+            security_context,
+            token: Some(token),
+        }
+    }
+
+    /// A deliberately unusable session for an invalid or absent credential.
+    /// The anonymous security floor is kept for diagnostics; the missing token
+    /// makes every operation deny before the AVC/PDP is reached.
+    pub fn deny() -> Self {
+        Self {
+            security_context: anonymous_floor(),
+            token: None,
+        }
+    }
+
+    /// The context derived at attach from verified identity and key material.
+    pub fn security_context(&self) -> &SecurityContext {
+        &self.security_context
+    }
+
+    /// Apply the mandatory verified-token gate. A missing token is deny.
+    #[inline]
+    pub fn token_authorizes(&self, object_label: &SecurityLabel, action: Action) -> bool {
+        self.token
+            .as_ref()
+            .is_some_and(|token| token.authorizes(object_label, action))
+    }
+}
+
+/// Verifies the `Tattach` credential and returns the session cached per fid.
+///
+/// Implementations verify the S6-minted access token once (hybrid signature,
+/// expiry, DPoP binding, and policy generation), derive `SecurityContext` from
+/// verified identity/key material, and translate the token's authorized subset
+/// to [`VerifiedTokenScope`]. Invalid input returns [`SessionContext::deny`].
+#[async_trait]
+pub trait AttachAuthenticator: Send + Sync {
+    async fn authenticate(&self, uname: &str, aname: &str) -> SessionContext;
+}
+
+/// Fail-closed authenticator: every attach resolves to a deny-only session.
+/// Used by [`ReferenceMonitor`] constructions that have not been given an
+/// application authenticator, and by tests.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct AnonymousAuthenticator;
 
 #[async_trait]
 impl AttachAuthenticator for AnonymousAuthenticator {
-    async fn authenticate(&self, _uname: &str, _aname: &str) -> SecurityContext {
-        anonymous_floor()
+    async fn authenticate(&self, _uname: &str, _aname: &str) -> SessionContext {
+        SessionContext::deny()
     }
 }
 
-/// The anonymous-floor [`SecurityContext`]: `Level::Public`, no compartments,
-/// `VerifiedKeyMaterial::Unverified` (assurance floors at `Unverified`).
+/// The anonymous security floor. It is not authorization: a session at this
+/// floor still has no [`VerifiedTokenScope`] and is denied.
 pub fn anonymous_floor() -> SecurityContext {
     SecurityContext::from_clearance(
         SecurityLabel::new(Level::Public, Assurance::Unverified, CompartmentSet::EMPTY),
@@ -101,88 +195,105 @@ pub fn anonymous_floor() -> SecurityContext {
     )
 }
 
-/// Authorizes one op against a subject's cached [`SecurityContext`].
+/// Fail-closed label resolver for a mount with no content/static label source.
+/// A real export injects the genesis/manifest resolver owned by the
+/// application. Returning `None` is a mandatory deny (design §1 invariant 2).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DenyUnlabeledResolver;
+
+impl ObjectLabelResolver for DenyUnlabeledResolver {
+    fn resolve(&self, _object: ObjectRef<'_>) -> Option<SecurityLabel> {
+        None
+    }
+}
+
+/// The policy decision point behind the mandatory token and IFC gates.
 ///
-/// `object_label` is `None` when no label source is wired for the mount
-/// being served (true for every 9P mount today — see the module-level
-/// documentation on why `None` must NOT be treated as "unrestricted" by a
-/// real implementation). The default [`AllowAllDecider`] ignores both
-/// arguments and always allows, preserving current behavior; a real decider
-/// (injected by the `hyprstream` crate, backed by `mac::avc::CachingAvc`)
-/// must deny when `object_label` is `None`, per the S1 invariant.
+/// `check` is called only after the monitor has resolved a non-optional
+/// object label, checked the attached token's operation/ceiling/TTL, and
+/// enforced `subject.ctx ⊒ object.label`. The concrete application
+/// implementation is a local AVC lookup (with a PDP miss); it must not perform
+/// UCAN chain validation or Casbin matching per operation.
 pub trait AccessDecider: Send + Sync {
-    /// Returns whether `action` is authorized for `ctx` against `object_label`.
+    fn check(&self, ctx: &SecurityContext, object_label: &SecurityLabel, action: Action) -> bool;
+}
+
+/// The fail-closed default policy monitor. It permits nothing.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DenyAllDecider;
+
+impl AccessDecider for DenyAllDecider {
     fn check(
         &self,
-        ctx: &SecurityContext,
-        object_label: Option<&SecurityLabel>,
-        action: Action,
-    ) -> bool;
-}
-
-/// The default, no-op decider: every op is allowed regardless of context or
-/// label. This is exactly today's behavior (the translator performs no
-/// per-op authorization at all), kept as the default so existing callers see
-/// no behavior change until a real decider is explicitly wired in.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct AllowAllDecider;
-
-impl AccessDecider for AllowAllDecider {
-    fn check(&self, _ctx: &SecurityContext, _object_label: Option<&SecurityLabel>, _action: Action) -> bool {
-        true
+        _ctx: &SecurityContext,
+        _object_label: &SecurityLabel,
+        _action: Action,
+    ) -> bool {
+        false
     }
 }
 
-/// Records the outcome of an [`AccessDecider::check`] call for audit.
+/// The reference monitor a [`Translator`](crate::Translator) mediates every
+/// dispatched op through once installed. Bundles the three injection points so
+/// enforcement is all-or-nothing: there is no translator state in which the
+/// token gate runs but the label resolver is absent, or vice versa.
 ///
-/// A real sink (injected by the `hyprstream` crate, backed by
-/// `mac::audit::WalAuditStore`) durably logs the decision; per S7, a
-/// decision that cannot be durably audited must downgrade to deny. The
-/// default [`NullAuditSink`] does not implement that downgrade (there is
-/// nothing to audit against by default) — it is only safe as a default
-/// because [`AllowAllDecider`] is also the default, so no security-relevant
-/// decision is ever made without an explicit opt-in to both a real decider
-/// and a real sink together (see [`AuditedDecider`]).
-pub trait AuditSink: Send + Sync {
-    /// `allowed` is the decision `AuditedDecider` is about to return.
-    fn record(&self, ctx: &SecurityContext, object_label: Option<&SecurityLabel>, action: Action, allowed: bool);
+/// Constructed by the application (`hyprstream` crate) at activation time from
+/// its concrete token verifier, genesis/manifest label resolver, and AVC/PDP
+/// adapter. Not installed by any production path yet — see the module docs.
+pub struct ReferenceMonitor {
+    authenticator: Arc<dyn AttachAuthenticator>,
+    labels: Arc<dyn ObjectLabelResolver + Send + Sync>,
+    decider: Arc<dyn AccessDecider>,
 }
 
-/// The default, no-op audit sink: records nothing.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct NullAuditSink;
-
-impl AuditSink for NullAuditSink {
-    fn record(&self, _ctx: &SecurityContext, _object_label: Option<&SecurityLabel>, _action: Action, _allowed: bool) {}
-}
-
-/// Wraps an [`AccessDecider`] so every decision is also recorded via an
-/// [`AuditSink`], and — mirroring S7's `AuditedAvc` fail-closed contract — a
-/// sink that reports it could not durably record the decision causes the
-/// wrapped decision to be downgraded to deny.
-///
-/// [`AuditSink::record`] here is infallible by trait signature (matching the
-/// simple sinks available at this layer); a real, fallible durable sink
-/// should be adapted to report failure through `allowed` before calling
-/// `record`, or a future revision can widen `AuditSink::record` to return a
-/// `Result` once a concrete durable sink is wired in from the `hyprstream`
-/// crate. Documented here rather than solved speculatively.
-pub struct AuditedDecider<D, S> {
-    inner: D,
-    sink: S,
-}
-
-impl<D: AccessDecider, S: AuditSink> AuditedDecider<D, S> {
-    pub fn new(inner: D, sink: S) -> Self {
-        Self { inner, sink }
+impl ReferenceMonitor {
+    /// Assemble the monitor from its three mandatory seams. There is no
+    /// permissive or partial construction: each argument is required, and the
+    /// crate's fail-closed defaults ([`AnonymousAuthenticator`],
+    /// [`DenyUnlabeledResolver`], [`DenyAllDecider`]) are the explicit choices
+    /// for a seam the application does not supply.
+    pub fn new(
+        authenticator: Arc<dyn AttachAuthenticator>,
+        labels: Arc<dyn ObjectLabelResolver + Send + Sync>,
+        decider: Arc<dyn AccessDecider>,
+    ) -> Self {
+        Self {
+            authenticator,
+            labels,
+            decider,
+        }
     }
-}
 
-impl<D: AccessDecider, S: AuditSink> AccessDecider for AuditedDecider<D, S> {
-    fn check(&self, ctx: &SecurityContext, object_label: Option<&SecurityLabel>, action: Action) -> bool {
-        let allowed = self.inner.check(ctx, object_label, action);
-        self.sink.record(ctx, object_label, action, allowed);
-        allowed
+    /// Verify the `Tattach` credential exactly once for this connection.
+    pub async fn authenticate(&self, uname: &str, aname: &str) -> SessionContext {
+        self.authenticator.authenticate(uname, aname).await
+    }
+
+    /// Complete mediation for one op on `path` under `session`, in the
+    /// mandatory order: trusted label resolution → token gate → independent
+    /// IFC dominance → local policy monitor. Every step fails closed: an
+    /// unresolvable label, missing/expired/insufficient token, non-dominating
+    /// subject, or decider denial all return `false`.
+    pub fn authorize(&self, session: &SessionContext, path: &[String], action: Action) -> bool {
+        let components: Vec<&str> = path.iter().map(String::as_str).collect();
+        let Some(object_label) = self.labels.resolve(ObjectRef::Path(&components)) else {
+            return false;
+        };
+
+        // Token is a deny-only capability gate. Its label ceiling is checked
+        // against the trusted object label, never a token/UCAN-provided label.
+        if !session.token_authorizes(&object_label, action) {
+            return false;
+        }
+
+        // IFC dominance is independent of the token and the policy matrix.
+        if !session.security_context().can_access(&object_label) {
+            return false;
+        }
+
+        self.decider
+            .check(session.security_context(), &object_label, action)
     }
 }
 
@@ -190,50 +301,120 @@ impl<D: AccessDecider, S: AuditSink> AccessDecider for AuditedDecider<D, S> {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
 
-    #[tokio::test]
-    async fn anonymous_authenticator_always_floors() {
-        let auth = AnonymousAuthenticator;
-        let ctx = auth.authenticate("anyone", "anything").await;
-        assert_eq!(ctx.level(), Level::Public);
-        assert_eq!(ctx.assurance(), hyprstream_rpc::auth::mac::Assurance::Unverified);
+    fn label(level: Level) -> SecurityLabel {
+        SecurityLabel::new(level, Assurance::Classical, CompartmentSet::EMPTY)
+    }
+
+    fn ctx(level: Level) -> SecurityContext {
+        // Classical key material so the derived assurance dominates the
+        // Classical-assurance object labels used across these tests.
+        SecurityContext::new(level, CompartmentSet::EMPTY, VerifiedKeyMaterial::Classical)
+    }
+
+    fn permit_token(ops: &[Action]) -> VerifiedTokenScope {
+        VerifiedTokenScope::from_verified_token(
+            label(Level::Secret),
+            Arc::from(ops),
+            Instant::now() + Duration::from_secs(3600),
+        )
+    }
+
+    struct StaticLabels(Option<SecurityLabel>);
+    impl ObjectLabelResolver for StaticLabels {
+        fn resolve(&self, _object: ObjectRef<'_>) -> Option<SecurityLabel> {
+            self.0
+        }
+    }
+
+    struct AllowAll;
+    impl AccessDecider for AllowAll {
+        fn check(
+            &self,
+            _ctx: &SecurityContext,
+            _object_label: &SecurityLabel,
+            _action: Action,
+        ) -> bool {
+            true
+        }
+    }
+
+    fn monitor(labels: Option<SecurityLabel>, decider: Arc<dyn AccessDecider>) -> ReferenceMonitor {
+        ReferenceMonitor::new(
+            Arc::new(AnonymousAuthenticator),
+            Arc::new(StaticLabels(labels)),
+            decider,
+        )
+    }
+
+    fn path(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|s| (*s).to_owned()).collect()
     }
 
     #[test]
-    fn allow_all_decider_ignores_inputs() {
-        let decider = AllowAllDecider;
-        assert!(decider.check(&anonymous_floor(), None, Action::Write));
-        let secret = SecurityLabel::new(
-            Level::Secret,
-            hyprstream_rpc::auth::mac::Assurance::PqHybrid,
-            Default::default(),
+    fn token_scope_requires_unexpired_op_and_label_ceiling() {
+        let scope = VerifiedTokenScope::from_verified_token(
+            label(Level::Confidential),
+            Arc::from([Action::Read]),
+            Instant::now() + Duration::from_secs(10),
         );
-        assert!(decider.check(&anonymous_floor(), Some(&secret), Action::Write));
-    }
-
-    struct DenyAll;
-    impl AccessDecider for DenyAll {
-        fn check(&self, _ctx: &SecurityContext, _object_label: Option<&SecurityLabel>, _action: Action) -> bool {
-            false
-        }
-    }
-
-    #[derive(Default)]
-    struct CountingSink {
-        calls: AtomicUsize,
-    }
-    impl AuditSink for CountingSink {
-        fn record(&self, _ctx: &SecurityContext, _object_label: Option<&SecurityLabel>, _action: Action, _allowed: bool) {
-            self.calls.fetch_add(1, Ordering::SeqCst);
-        }
+        assert!(scope.authorizes(&label(Level::Public), Action::Read));
+        assert!(!scope.authorizes(&label(Level::Public), Action::Write));
+        assert!(!scope.authorizes(&label(Level::Secret), Action::Read));
     }
 
     #[test]
-    fn audited_decider_records_and_forwards_decision() {
-        let sink = CountingSink::default();
-        let decider = AuditedDecider::new(DenyAll, sink);
-        assert!(!decider.check(&anonymous_floor(), None, Action::Read));
-        assert_eq!(decider.sink.calls.load(Ordering::SeqCst), 1);
+    fn expired_or_missing_token_fails_closed() {
+        let expired = VerifiedTokenScope::from_verified_token(
+            label(Level::Secret),
+            Arc::from([Action::Read]),
+            Instant::now() - Duration::from_secs(1),
+        );
+        assert!(!expired.authorizes(&label(Level::Public), Action::Read));
+        assert!(!SessionContext::deny().token_authorizes(&label(Level::Public), Action::Read));
+    }
+
+    #[test]
+    fn authorize_allows_when_all_gates_pass() {
+        let monitor = monitor(Some(label(Level::Public)), Arc::new(AllowAll));
+        let session =
+            SessionContext::from_verified_token(ctx(Level::Secret), permit_token(&[Action::Read]));
+        assert!(monitor.authorize(&session, &path(&["a.txt"]), Action::Read));
+    }
+
+    #[test]
+    fn authorize_denies_unlabeled_before_decider() {
+        // Even a permit-everything decider cannot rescue an unlabeled object.
+        let monitor = monitor(None, Arc::new(AllowAll));
+        let session =
+            SessionContext::from_verified_token(ctx(Level::Secret), permit_token(&[Action::Read]));
+        assert!(!monitor.authorize(&session, &path(&["a.txt"]), Action::Read));
+    }
+
+    #[test]
+    fn authorize_denies_missing_or_scope_violating_token() {
+        let monitor = monitor(Some(label(Level::Public)), Arc::new(AllowAll));
+        assert!(!monitor.authorize(&SessionContext::deny(), &path(&["a.txt"]), Action::Read));
+        let read_only =
+            SessionContext::from_verified_token(ctx(Level::Secret), permit_token(&[Action::Read]));
+        assert!(!monitor.authorize(&read_only, &path(&["a.txt"]), Action::Write));
+    }
+
+    #[test]
+    fn authorize_enforces_ifc_floor_independent_of_decider() {
+        // Permissive policy must not bypass the mandatory IFC floor: a Public
+        // subject reading a Secret object denies even with an allow-all
+        // decider and a token whose ceiling covers it.
+        let monitor = monitor(Some(label(Level::Secret)), Arc::new(AllowAll));
+        let session =
+            SessionContext::from_verified_token(ctx(Level::Public), permit_token(&[Action::Read]));
+        assert!(!monitor.authorize(&session, &path(&["secret.txt"]), Action::Read));
+    }
+
+    #[test]
+    fn deny_unlabeled_resolver_resolves_nothing() {
+        let resolver = DenyUnlabeledResolver;
+        assert!(resolver.resolve(ObjectRef::Path(&["anything"])).is_none());
     }
 }

--- a/crates/hyprstream-9p/src/mac_seam.rs
+++ b/crates/hyprstream-9p/src/mac_seam.rs
@@ -35,6 +35,47 @@
 //!
 //! Do not wire a monitor into the production serve paths from this crate; that
 //! wiring lands with the activation change, after #698.
+//!
+//! ## Mediation is over the *name*, not the *object* (read before relying on it)
+//!
+//! The monitor is authoritative over the **path** a fid is tagged with, not
+//! over the **object** the backend resolves that fid to. [`ReferenceMonitor::
+//! authorize`] resolves the label from `ObjectRef::Path(components)` (the
+//! cached walked path), while the backend independently resolves the fid to an
+//! actual object/handle. Nothing in this contract *binds* the labeled name to
+//! the served object: the invariant "the label checked is the label of the
+//! object served" holds **only if the label resolver and the backend resolve
+//! names identically**. That is a convention, not an enforced invariant — so
+//! the honest statement of #568's "complete mediation" claim is:
+//!
+//! > Every dispatched op is routed through the monitor, **and** the monitor's
+//! > label resolver agrees with the backend's name resolution for the served
+//! > namespace. The first half is by construction; the second is a precondition.
+//!
+//! Concretely, this name↔object gap is **not** covered today:
+//!
+//! - **Partial walks** — handled (the cached path is derived from the backend's
+//!   *returned qid count*, never the requested suffix; see `handle_walk`), but
+//!   only because the translator narrows the name to match the reached object.
+//! - **Path traversal / `..`** — `hyprstream-9p` performs **no** `..`
+//!   canonicalization; `wnames` are concatenated verbatim into the cached path.
+//!   Not exploitable against `MemoryBackend`/`MountBackend` (they resolve
+//!   component-wise from a root), but a future resolver that does not
+//!   canonicalize identically to the backend reopens this gap. Any resolver
+//!   wired at activation **must** canonicalize or reject `..`, or the label
+//!   lookup and the backend resolution can diverge.
+//! - **Bind / symlink / mount indirection** — the VFS supports bind mounts and
+//!   per-process bind namespaces. If a path component resolves through an
+//!   indirection the string-keyed resolver does not model, the label checked is
+//!   for the *name* and the bytes served are for the *target*. `ObjectRef::Cid`
+//!   exists precisely to close this (content-addressed refs bind the label to
+//!   the object, not the name); the 9P seam feeds `ObjectRef::Path`.
+//!
+//! Closing the name↔object TOCTOU by making the monitor authoritative over the
+//! **fid/object** (e.g. resolving labels from the backend's reached object, or
+//! via `ObjectRef::Cid`) is **activation-blocking** alongside #698 and tracked
+//! with #699. Until then, treat "complete mediation by construction" as the
+//! *two-independent-resolutions-agree* claim above, not as object authority.
 
 use std::sync::Arc;
 use std::time::Instant;
@@ -159,6 +200,34 @@ impl SessionContext {
         self.token
             .as_ref()
             .is_some_and(|token| token.authorizes(object_label, action))
+    }
+
+    /// Identity comparison for re-attach detection, deliberately distinct from
+    /// the derived [`PartialEq`].
+    ///
+    /// Two attaches are the *same* session when their verified subject context
+    /// and verified-token scope (label ceiling + permitted operations) match.
+    /// The token's `valid_until` deadline is excluded on purpose: a real
+    /// [`AttachAuthenticator`] re-stamps `Instant::now() + ttl` on every
+    /// verification of the *same* ticket, so including it would make an
+    /// identical, still-valid ticket compare unequal and wrongly reject a
+    /// legitimate re-attach/reconnect (F2). The derived `PartialEq` is plain
+    /// value equality (useful for diagnostics/tests); *attach identity* — what
+    /// `bind_attach_session` checks — is this method.
+    pub fn same_attach_identity(&self, other: &SessionContext) -> bool {
+        if self.security_context != other.security_context {
+            return false;
+        }
+        match (&self.token, &other.token) {
+            // The token's `valid_until` is deliberately ignored: a real
+            // authenticator re-stamps it on every verification of the same
+            // ticket, so it is not part of attach identity.
+            (None, None) => true,
+            (Some(a), Some(b)) => {
+                a.label_ceiling == b.label_ceiling && a.operations == b.operations
+            }
+            _ => false,
+        }
     }
 }
 

--- a/crates/hyprstream-9p/src/memory.rs
+++ b/crates/hyprstream-9p/src/memory.rs
@@ -76,7 +76,7 @@ impl Backend for MemoryBackend {
         if components.is_empty() {
             let link = FidLink { path: None, qid: Self::root_qid(), is_dir: true };
             self.fids.lock().insert(newfid, link);
-            return Ok(WalkResult { qids: vec![Self::root_qid()] });
+            return Ok(WalkResult { qids: vec![Self::root_qid()], reached: Vec::new() });
         }
 
         let name = &components[0];
@@ -89,7 +89,7 @@ impl Backend for MemoryBackend {
 
         let link = FidLink { path: Some(name.clone()), qid: qid.clone(), is_dir: false };
         self.fids.lock().insert(newfid, link);
-        Ok(WalkResult { qids: vec![qid] })
+        Ok(WalkResult { qids: vec![qid], reached: vec![name.clone()] })
     }
 
     async fn open(&self, fid: u32, _flags: u32) -> anyhow::Result<OpenResult> {

--- a/crates/hyprstream-9p/src/memory.rs
+++ b/crates/hyprstream-9p/src/memory.rs
@@ -72,10 +72,16 @@ impl Backend for MemoryBackend {
         newfid: u32,
         components: &[String],
     ) -> anyhow::Result<WalkResult> {
-        // Empty walk = clone/attach to root.
+        // An empty walk clones an existing fid. During attach the source fid
+        // is not bound yet, so materialize the root instead.
         if components.is_empty() {
+            let mut fids = self.fids.lock();
+            if let Some(link) = fids.get(&_fid).cloned() {
+                fids.insert(newfid, link);
+                return Ok(WalkResult { qids: Vec::new(), reached: Vec::new() });
+            }
             let link = FidLink { path: None, qid: Self::root_qid(), is_dir: true };
-            self.fids.lock().insert(newfid, link);
+            fids.insert(newfid, link);
             return Ok(WalkResult { qids: vec![Self::root_qid()], reached: Vec::new() });
         }
 

--- a/crates/hyprstream-9p/src/mount_backend.rs
+++ b/crates/hyprstream-9p/src/mount_backend.rs
@@ -186,24 +186,43 @@ impl Backend for MountBackend {
         // path as parent_path + components. An empty-components walk (attach /
         // clone) re-resolves the source fid's own path.
         let parent_path = self.fids.get(&fid).map(|e| e.path.clone()).unwrap_or_default();
+        let parent_len = parent_path.len();
         let mut new_path = parent_path;
         new_path.extend(components.iter().cloned());
 
-        let refs: Vec<&str> = new_path.iter().map(String::as_str).collect();
-        let handle = self
-            .mount
-            .walk(&refs, self.caller()?)
-            .await
-            .context("mount walk failed")?;
+        // Resolve each component independently so the 9P result carries one
+        // QID for every object the new fid actually traversed. Returning only a
+        // leaf QID while binding `newfid` to the complete path would let the
+        // translator cache a shallower, incorrectly authorized name.
+        let mut qids = Vec::with_capacity(components.len().max(1));
+        let mut handle = None;
+        let mut reached = Vec::with_capacity(components.len());
+        for component_count in 1..=components.len() {
+            let refs: Vec<&str> = new_path[..parent_len + component_count]
+                .iter()
+                .map(String::as_str)
+                .collect();
+            let next = self.mount.walk(&refs, self.caller()?).await.context("mount walk failed")?;
+            let qid = self.qid_of(&next).await?;
+            if let Some(previous) = handle.replace(next) {
+                self.mount.clunk(previous, self.caller()?).await;
+            }
+            qids.push(qid);
+            reached.push(components[component_count - 1].clone());
+        }
 
-        // Mirror `ModelBackend::walk`: return the single leaf qid (the translator
-        // records its qtype for the new fid; clients here walk one hop at a time).
-        let qid = self.qid_of(&handle).await?;
+        if components.is_empty() {
+            let refs: Vec<&str> = new_path.iter().map(String::as_str).collect();
+            let next = self.mount.walk(&refs, self.caller()?).await.context("mount walk failed")?;
+            qids.push(self.qid_of(&next).await?);
+            handle = Some(next);
+        }
+        let handle = handle.ok_or_else(|| anyhow!("mount walk returned no handle"))?;
         self.fids.insert(
             newfid,
             Arc::new(MountFidEntry { path: new_path, handle: Mutex::new(Some(handle)) }),
         );
-        Ok(WalkResult { qids: vec![qid] })
+        Ok(WalkResult { qids, reached })
     }
 
     async fn open(&self, fid: u32, flags: u32) -> Result<OpenResult> {

--- a/crates/hyprstream-9p/src/mount_backend.rs
+++ b/crates/hyprstream-9p/src/mount_backend.rs
@@ -202,8 +202,32 @@ impl Backend for MountBackend {
                 .iter()
                 .map(String::as_str)
                 .collect();
-            let next = self.mount.walk(&refs, self.caller()?).await.context("mount walk failed")?;
-            let qid = self.qid_of(&next).await?;
+            // On any failure past the first successful hop, `handle` still
+            // holds the previously-resolved mount `Fid`. That `Fid` has no
+            // `Drop` cleanup (see `hyprstream_vfs::Fid`) — for a remote mount
+            // it is a live 9P fid held open on the peer — so it must be
+            // explicitly clunked before returning the error, or every walk
+            // that fails past its first component (e.g. `/a/b` where `a`
+            // exists but `b` does not) leaks one backend handle.
+            let next = match self.mount.walk(&refs, self.caller()?).await {
+                Ok(next) => next,
+                Err(e) => {
+                    if let Some(previous) = handle.take() {
+                        self.mount.clunk(previous, self.caller()?).await;
+                    }
+                    return Err(anyhow::Error::new(e).context("mount walk failed"));
+                }
+            };
+            let qid = match self.qid_of(&next).await {
+                Ok(qid) => qid,
+                Err(e) => {
+                    self.mount.clunk(next, self.caller()?).await;
+                    if let Some(previous) = handle.take() {
+                        self.mount.clunk(previous, self.caller()?).await;
+                    }
+                    return Err(e);
+                }
+            };
             if let Some(previous) = handle.replace(next) {
                 self.mount.clunk(previous, self.caller()?).await;
             }
@@ -353,6 +377,73 @@ mod tests {
         assert_eq!(lopen_flags_to_mode(0o1), 1);
         assert_eq!(lopen_flags_to_mode(0o2), 2);
         assert_eq!(lopen_flags_to_mode(0o101), 1);
+    }
+
+    /// Regression: a multi-component walk that fails past its first hop must
+    /// clunk every intermediate `Fid` it resolved before returning the error.
+    /// `Fid` has no `Drop` cleanup — for a remote mount it is a live 9P fid
+    /// held open on the peer — so a dropped-without-clunking handle leaks on
+    /// every walk that ENOENTs past its first component (e.g. `/a/b` where
+    /// `a` exists but `b` does not).
+    #[tokio::test]
+    async fn walk_clunks_intermediate_handle_on_mid_path_failure() {
+        use async_trait::async_trait;
+        use hyprstream_vfs::{DirEntry, Stat};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct TrackedMount {
+            clunks: AtomicUsize,
+        }
+
+        #[async_trait]
+        impl Mount for TrackedMount {
+            async fn walk(&self, components: &[&str], _c: &Subject) -> Result<Fid, MountError> {
+                match components {
+                    [] | ["a"] => Ok(Fid::new(components.len())),
+                    ["a", "b"] => Err(MountError::NotFound("a/b".into())),
+                    other => panic!("unexpected walk: {other:?}"),
+                }
+            }
+            async fn open(&self, _f: &mut Fid, _m: u8, _c: &Subject) -> Result<(), MountError> {
+                Err(MountError::PermissionDenied("open".into()))
+            }
+            async fn read(&self, _f: &Fid, _o: u64, _n: u32, _c: &Subject) -> Result<Vec<u8>, MountError> {
+                Err(MountError::Io("read".into()))
+            }
+            async fn write(&self, _f: &Fid, _o: u64, _d: &[u8], _c: &Subject) -> Result<u32, MountError> {
+                Err(MountError::NotSupported("write".into()))
+            }
+            async fn readdir(&self, _f: &Fid, _c: &Subject) -> Result<Vec<DirEntry>, MountError> {
+                Err(MountError::NotDirectory("readdir".into()))
+            }
+            async fn stat(&self, f: &Fid, _c: &Subject) -> Result<Stat, MountError> {
+                let depth = *f.downcast_ref::<usize>().unwrap_or(&0);
+                Ok(Stat::unknown_qid(0, depth as u64, "x".into(), 0))
+            }
+            async fn clunk(&self, _f: Fid, _c: &Subject) {
+                self.clunks.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let mount = Arc::new(TrackedMount { clunks: AtomicUsize::new(0) });
+        let backend = MountBackend::new(mount.clone(), Subject::new("tenant"));
+
+        // Attach (empty walk) binds fid 0 to the root.
+        backend.attach("tenant").await.unwrap();
+        backend.fids.insert(
+            0,
+            Arc::new(MountFidEntry { path: vec![], handle: Mutex::new(Some(Fid::new(0usize))) }),
+        );
+
+        // Walk fid 0 -> newfid 1 via ["a", "b"]: "a" resolves (handle A is
+        // held), "b" fails. Handle A must be clunked on this error path.
+        let err = backend.walk(0, 1, &["a".to_owned(), "b".to_owned()]).await;
+        assert!(err.is_err(), "walk into a missing leaf must fail");
+        assert_eq!(
+            mount.clunks.load(Ordering::SeqCst),
+            1,
+            "the intermediate handle for \"a\" must be clunked on the \"a/b\" failure, not leaked"
+        );
     }
 
     #[test]

--- a/crates/hyprstream-9p/src/translator.rs
+++ b/crates/hyprstream-9p/src/translator.rs
@@ -481,7 +481,11 @@ impl Translator {
             return Ok(());
         }
         match self.attach_session.get() {
-            Some(existing) if existing == session => Ok(()),
+            // Compare by *attach identity*, not value equality: a real
+            // authenticator re-stamps the token deadline on every verification
+            // of the same ticket, so a value comparison would reject a
+            // legitimate re-attach of an identical, still-valid session (F2).
+            Some(existing) if existing.same_attach_identity(session) => Ok(()),
             Some(_) => Err(anyhow::Error::new(hyprstream_vfs::MountError::PermissionDenied(
                 "conflicting attach session context".to_owned(),
             ))),
@@ -496,28 +500,48 @@ impl Translator {
         wnames: Vec<String>,
     ) -> Result<Response> {
         // The session is inherited from the fid being walked (#568 — the
-        // credential is verified once at attach, never re-verified per op),
-        // and the destination path extends the source fid's walked path.
+        // credential is verified once at attach, never re-verified per op).
+        // The destination path extends the source fid's already-walked path.
         let session = self.fids.session(fid);
-        let mut path = self.fids.path(fid).unwrap_or_default();
-        path.extend(wnames.iter().cloned());
+        let base = self.fids.path(fid).unwrap_or_default();
 
         if let Some(monitor) = &self.monitor {
-            // A walk is checked against its destination, not merely its
-            // source; otherwise a subject could traverse into a high-labeled
-            // object and rely on a later operation to discover the denial.
-            // A fid outside a verified session denies outright.
+            // Complete mediation: authorize *every* hop of the walk, not only
+            // the final destination. Content-truth labels need not be monotone
+            // with depth, so a parent directory can be more classified than a
+            // leaf — a subject must not traverse *through* a high-labeled
+            // directory to reach a lower-labeled object with the intermediate
+            // hops unmediated (F1). A fid outside a verified session denies
+            // outright.
             let Some(session) = session.as_ref() else {
                 return Ok(Response::Error { ecode: libc_eperm() });
             };
-            if !monitor.authorize(session, &path, Action::Walk) {
-                return Ok(Response::Error { ecode: libc_eperm() });
+            let mut prefix = base.clone();
+            for component in &wnames {
+                prefix.push(component.clone());
+                if !monitor.authorize(session, &prefix, Action::Walk) {
+                    return Ok(Response::Error { ecode: libc_eperm() });
+                }
             }
         }
 
         // Mirror of RemoteModelMount::walk: call backend.walk with the source
         // fid, the new fid, and the path components.
         let result = self.backend.walk(fid, newfid, &wnames).await?;
+
+        // Derive the cached path from the backend's *returned qid count*, not
+        // the requested `wnames`. 9P permits `nwqid < nwname` (a partial walk):
+        // the fid then points at the object the backend actually reached, which
+        // may be shallower than the requested path. Caching the unreached
+        // suffix would tag the fid with a name deeper than the served object,
+        // so every later op would resolve the label of a name the backend never
+        // opened — a name↔object TOCTOU (F1/F3). The real MountBackend walks
+        // one hop at a time, so partial returns are a live protocol reality,
+        // not hypothetical.
+        let nwqid = result.qids.len();
+        let mut reached = base;
+        reached.extend(wnames.iter().take(nwqid).cloned());
+
         if wnames.is_empty() {
             // nwname=0 is a fid *clone*: newfid aliases fid (same file), and
             // the backend returns no qids. newfid must still inherit the source
@@ -525,9 +549,10 @@ impl Translator {
             // cached session and a live monitor wrongly denies it for an
             // already-authenticated client (#568).
             let qtype = self.fids.qtype(fid).unwrap_or(0);
-            self.fids.insert(newfid, qtype, session, path);
-        } else if let Some(q) = result.qids.last() {
-            self.fids.insert(newfid, q.qtype, session, path);
+            self.fids.insert(newfid, qtype, session, reached);
+        } else if nwqid > 0 {
+            let qtype = result.qids.last().map(|q| q.qtype).unwrap_or(0);
+            self.fids.insert(newfid, qtype, session, reached);
         }
         Ok(Response::Walk { qids: result.qids })
     }
@@ -1516,6 +1541,162 @@ mod tests {
             errno_from_error(&err),
             EACCES,
             "conflicting attach session must be EACCES",
+        );
+    }
+
+    /// F2: a real `AttachAuthenticator` re-stamps `Instant::now() + ttl` on
+    /// every verification of the *same* ticket. Re-attaching that identical,
+    /// still-valid ticket on a second fid of the same connection must be
+    /// accepted — not rejected as a "conflicting" session. Equality for re-attach
+    /// detection is over identity (subject + token scope), never the timestamp.
+    #[tokio::test]
+    async fn same_valid_ticket_reattach_is_accepted() {
+        struct FreshDeadlineAuth;
+        #[async_trait]
+        impl AttachAuthenticator for FreshDeadlineAuth {
+            async fn authenticate(&self, _uname: &str, _aname: &str) -> SessionContext {
+                // `permit_session` stamps `Instant::now()` into the token, so
+                // each call yields a distinct deadline — exactly what a real
+                // verifier does when re-checking the same ticket.
+                permit_session(Level::Secret, ALL_OPS)
+            }
+        }
+
+        let t = Translator::new(Arc::new(MemoryBackend::default())).with_reference_monitor(
+            Arc::new(ReferenceMonitor::new(
+                Arc::new(FreshDeadlineAuth),
+                Arc::new(StaticLabels(Some(label(Level::Public)))),
+                Arc::new(AllowAll),
+            )),
+        );
+
+        let (_, resp) = t
+            .handle_message(&msg::tattach(1, 1, u32::MAX, "alice-ticket", "/"))
+            .await
+            .unwrap();
+        assert!(matches!(resp, Response::Attach { .. }), "first attach: {resp:?}");
+
+        // Same ticket, freshly-stamped deadline, new fid on the same connection.
+        let (_, resp) = t
+            .handle_message(&msg::tattach(2, 2, u32::MAX, "alice-ticket", "/"))
+            .await
+            .unwrap();
+        assert!(
+            matches!(resp, Response::Attach { .. }),
+            "same valid ticket re-attach must be accepted, got {resp:?}",
+        );
+    }
+
+    /// F1 (defect 1 — intermediate-hop mediation): content-truth labels need
+    /// not be monotone with depth. Here the `secret` directory hop is
+    /// Secret-labeled while its `public` leaf is Public. The walk must mediate
+    /// *every* hop, so a Public subject traversing through the Secret directory
+    /// is refused at the first hop — not cleared against only the (Public)
+    /// final destination.
+    #[tokio::test]
+    async fn walk_mediates_every_hop_not_just_destination() {
+        struct ByDepth;
+        impl ObjectLabelResolver for ByDepth {
+            fn resolve(&self, object: ObjectRef<'_>) -> Option<SecurityLabel> {
+                match object {
+                    // The single directory hop is Secret; anything deeper is Public
+                    // (a non-monotone lattice — the leaf is *less* classified than
+                    // the directory that contains it).
+                    ObjectRef::Path([]) => Some(label(Level::Public)),
+                    ObjectRef::Path([_]) => Some(label(Level::Secret)),
+                    ObjectRef::Path([_, ..]) => Some(label(Level::Public)),
+                    ObjectRef::Cid(_) => None,
+                }
+            }
+        }
+        let backend = MemoryBackend::default();
+        backend.add_file("/secret", b"classified");
+        let t = Translator::new(Arc::new(backend)).with_reference_monitor(Arc::new(
+            ReferenceMonitor::new(
+                Arc::new(StaticAuth(permit_session(Level::Public, ALL_OPS))),
+                Arc::new(ByDepth),
+                Arc::new(AllowAll),
+            ),
+        ));
+
+        t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
+        // Walk through the Secret directory toward the Public leaf. The Public
+        // subject cannot clear the Secret hop, so the walk must deny — even
+        // though the *destination* label is Public.
+        let (_, resp) = t
+            .handle_message(&msg::twalk(2, 0, 1, &["secret", "public"]))
+            .await
+            .unwrap();
+        match resp {
+            Response::Error { ecode } => assert_eq!(ecode, libc_eperm()),
+            other => panic!("expected EPERM at the Secret intermediate hop, got {other:?}"),
+        }
+    }
+
+    /// F1 (defect 2 — partial-walk path poisoning): 9P permits `nwqid < nwname`.
+    /// The fid must be tagged with the path the backend *reached* (the
+    /// returned-qid prefix), never the full requested suffix — otherwise later
+    /// ops resolve the label of a name the backend never opened (a name↔object
+    /// TOCTOU). `PartialWalkBackend` reaches only the first component no matter
+    /// how many are requested.
+    #[tokio::test]
+    async fn partial_walk_caches_reached_path_not_requested_suffix() {
+        use crate::backend::{Backend, OpenResult, StatResult, WalkResult};
+        struct PartialWalkBackend;
+        #[async_trait]
+        impl Backend for PartialWalkBackend {
+            async fn attach(&self, _uname: &str) -> anyhow::Result<()> {
+                Ok(())
+            }
+            async fn walk(
+                &self,
+                _fid: u32,
+                _newfid: u32,
+                _components: &[String],
+            ) -> anyhow::Result<WalkResult> {
+                // Reaches exactly one component, regardless of how many walked.
+                Ok(WalkResult { qids: vec![sample_qid(0, 1)] })
+            }
+            async fn open(&self, _fid: u32, _flags: u32) -> anyhow::Result<OpenResult> {
+                unimplemented!("not reached")
+            }
+            async fn read(&self, _fid: u32, _offset: u64, _count: u32) -> anyhow::Result<Vec<u8>> {
+                unimplemented!("not reached")
+            }
+            async fn write(
+                &self,
+                _fid: u32,
+                _offset: u64,
+                _data: &[u8],
+            ) -> anyhow::Result<u32> {
+                unimplemented!("not reached")
+            }
+            async fn stat(&self, _fid: u32) -> anyhow::Result<StatResult> {
+                unimplemented!("not reached")
+            }
+            async fn readdir(
+                &self,
+                _fid: u32,
+                _offset: u64,
+                _count: u32,
+            ) -> anyhow::Result<Vec<u8>> {
+                unimplemented!("not reached")
+            }
+            async fn clunk(&self, _fid: u32) -> anyhow::Result<()> {
+                Ok(())
+            }
+        }
+
+        // No monitor: this isolates the path-caching fix from mediation.
+        let t = Translator::new(Arc::new(PartialWalkBackend));
+        t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
+        t.handle_message(&msg::twalk(2, 0, 1, &["a", "b"])).await.unwrap();
+
+        let cached = t.fids.path(1).expect("newfid must be tracked");
+        assert_eq!(
+            cached,
+            vec!["a".to_string()],
+            "cached path must be the reached prefix, not the unreached suffix",
         );
     }
 

--- a/crates/hyprstream-9p/src/translator.rs
+++ b/crates/hyprstream-9p/src/translator.rs
@@ -441,12 +441,6 @@ impl Translator {
     }
 
     async fn handle_attach(&self, fid: u32, uname: &str, aname: &str) -> Result<Response> {
-        // Establish the session first: on the attach-time ticket path (H1b) this
-        // validates `uname` and binds the session Subject; on the fixed-subject
-        // path it is a no-op. A denied ticket returns here and is mapped to an
-        // Rlerror by the serve loop — before any fid or mount handle exists.
-        self.backend.attach(uname).await?;
-
         // #568: MAC mediation happens only when a reference monitor is
         // installed (never in production today — activation is blocked on
         // #698). The credential is then verified exactly once at attach, and
@@ -454,7 +448,6 @@ impl Translator {
         let session = match &self.monitor {
             Some(monitor) => {
                 let session = monitor.authenticate(uname, aname).await;
-                self.bind_attach_session(&session)?;
                 // The root fid itself is a mediated object. It has no
                 // synthetic exemption: an unlabeled root or missing/expired
                 // token denies at attach, before any backend object handle
@@ -462,24 +455,27 @@ impl Translator {
                 if !monitor.authorize(&session, &[], Action::Walk) {
                     return Ok(Response::Error { ecode: libc_eperm() });
                 }
+                self.ensure_attach_session_compatible(&session)?;
                 Some(session)
             }
             None => None,
         };
 
-        // Attach establishes the root fid. Walk the empty path to materialize
+        // Only an attach that cleared monitor authorization may bind a backend
+        // subject. Walk the empty path to materialize
         // a root qid from the backend, then record it.
+        self.backend.attach(uname).await?;
         let walk = self.backend.walk(fid, fid, &[]).await?;
+        if let Some(session) = &session {
+            self.bind_attach_session(session)?;
+        }
         let qtype = walk.qids.last().map(|q| q.qtype).unwrap_or(0);
         self.fids.insert(fid, qtype, session, Vec::new());
         let qid = walk.qids.into_iter().next().unwrap_or_default();
         Ok(Response::Attach { qid })
     }
 
-    fn bind_attach_session(&self, session: &SessionContext) -> Result<()> {
-        if self.attach_session.set(session.clone()).is_ok() {
-            return Ok(());
-        }
+    fn ensure_attach_session_compatible(&self, session: &SessionContext) -> Result<()> {
         match self.attach_session.get() {
             // Compare by *attach identity*, not value equality: a real
             // authenticator re-stamps the token deadline on every verification
@@ -489,8 +485,15 @@ impl Translator {
             Some(_) => Err(anyhow::Error::new(hyprstream_vfs::MountError::PermissionDenied(
                 "conflicting attach session context".to_owned(),
             ))),
-            None => Err(anyhow::anyhow!("attach session cell rejected without value")),
+            None => Ok(()),
         }
+    }
+
+    fn bind_attach_session(&self, session: &SessionContext) -> Result<()> {
+        if self.attach_session.set(session.clone()).is_ok() {
+            return Ok(());
+        }
+        self.ensure_attach_session_compatible(session)
     }
 
     async fn handle_walk(
@@ -529,18 +532,18 @@ impl Translator {
         // fid, the new fid, and the path components.
         let result = self.backend.walk(fid, newfid, &wnames).await?;
 
-        // Derive the cached path from the backend's *returned qid count*, not
-        // the requested `wnames`. 9P permits `nwqid < nwname` (a partial walk):
-        // the fid then points at the object the backend actually reached, which
-        // may be shallower than the requested path. Caching the unreached
-        // suffix would tag the fid with a name deeper than the served object,
-        // so every later op would resolve the label of a name the backend never
-        // opened — a name↔object TOCTOU (F1/F3). The real MountBackend walks
-        // one hop at a time, so partial returns are a live protocol reality,
-        // not hypothetical.
+        // The backend is authoritative for the exact request prefix it bound
+        // to `newfid`. Enforce the Backend contract before caching it.
+        if !wnames.is_empty()
+            && (result.qids.len() != result.reached.len()
+                || result.reached.len() > wnames.len()
+                || result.reached != wnames[..result.reached.len()])
+        {
+            return Err(anyhow::anyhow!("backend walk result does not describe its reached prefix"));
+        }
         let nwqid = result.qids.len();
         let mut reached = base;
-        reached.extend(wnames.iter().take(nwqid).cloned());
+        reached.extend(result.reached);
 
         if wnames.is_empty() {
             // nwname=0 is a fid *clone*: newfid aliases fid (same file), and
@@ -1095,7 +1098,8 @@ mod tests {
     // module double as the dormant-default regression guard.
 
     use crate::mac_seam::{
-        AccessDecider, AttachAuthenticator, ObjectLabelResolver, ObjectRef, VerifiedTokenScope,
+        AccessDecider, AttachAuthenticator, ObjectLabelResolver, ObjectRef, VerifiedAttachIdentity,
+        VerifiedTokenScope,
     };
     use hyprstream_rpc::auth::mac::{
         Assurance, CompartmentSet, Level, SecurityContext, SecurityLabel, VerifiedKeyMaterial,
@@ -1115,7 +1119,12 @@ mod tests {
     /// A session at `level` whose verified token permits exactly `ops` (with
     /// a Secret ceiling) for the next hour.
     fn permit_session(level: Level, ops: &[Action]) -> SessionContext {
+        permit_session_as("test-subject", level, ops)
+    }
+
+    fn permit_session_as(identity: &str, level: Level, ops: &[Action]) -> SessionContext {
         SessionContext::from_verified_token(
+            VerifiedAttachIdentity::from_verified_identity(identity),
             ctx(level),
             VerifiedTokenScope::from_verified_token(
                 label(Level::Secret),
@@ -1207,6 +1216,7 @@ mod tests {
     #[tokio::test]
     async fn monitor_denies_expired_token_at_attach() {
         let expired = SessionContext::from_verified_token(
+            VerifiedAttachIdentity::from_verified_identity("test-subject"),
             ctx(Level::Secret),
             VerifiedTokenScope::from_verified_token(
                 label(Level::Secret),
@@ -1332,6 +1342,7 @@ mod tests {
             }
         }
         let session = SessionContext::from_verified_token(
+            VerifiedAttachIdentity::from_verified_identity("test-subject"),
             ctx(Level::Secret),
             VerifiedTokenScope::from_verified_token(
                 label(Level::Confidential),
@@ -1511,12 +1522,14 @@ mod tests {
         #[async_trait]
         impl AttachAuthenticator for TicketAuth {
             async fn authenticate(&self, uname: &str, _aname: &str) -> SessionContext {
-                let level = if uname == "alice-ticket" {
-                    Level::Secret
+                let identity = if uname == "alice-ticket" {
+                    "verified-alice"
                 } else {
-                    Level::Public
+                    "verified-bob"
                 };
-                permit_session(level, ALL_OPS)
+                // Both principals have identical authorization attributes;
+                // only the verifier-produced identity differs.
+                permit_session_as(identity, Level::Secret, ALL_OPS)
             }
         }
 
@@ -1587,6 +1600,84 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn denied_monitored_attach_does_not_poison_valid_retry() {
+        struct TicketAuth;
+        #[async_trait]
+        impl AttachAuthenticator for TicketAuth {
+            async fn authenticate(&self, uname: &str, _aname: &str) -> SessionContext {
+                if uname == "valid-ticket" {
+                    permit_session_as("verified-alice", Level::Secret, ALL_OPS)
+                } else {
+                    SessionContext::deny()
+                }
+            }
+        }
+        let t = Translator::new(Arc::new(MemoryBackend::default())).with_reference_monitor(
+            Arc::new(ReferenceMonitor::new(
+                Arc::new(TicketAuth),
+                Arc::new(StaticLabels(Some(label(Level::Public)))),
+                Arc::new(AllowAll),
+            )),
+        );
+        let (_, denied) = t
+            .handle_message(&msg::tattach(1, 1, u32::MAX, "forged-ticket", "/"))
+            .await
+            .unwrap();
+        assert!(matches!(denied, Response::Error { ecode } if ecode == libc_eperm()));
+        let (_, accepted) = t
+            .handle_message(&msg::tattach(2, 2, u32::MAX, "valid-ticket", "/"))
+            .await
+            .unwrap();
+        assert!(matches!(accepted, Response::Attach { .. }), "valid retry: {accepted:?}");
+    }
+
+    #[tokio::test]
+    async fn mount_backend_multiname_walk_mediates_the_bound_leaf() {
+        use hyprstream_vfs::{SyntheticMount, SyntheticNode};
+
+        struct ByPath;
+        impl ObjectLabelResolver for ByPath {
+            fn resolve(&self, object: ObjectRef<'_>) -> Option<SecurityLabel> {
+                match object {
+                    ObjectRef::Path([] | ["a"]) => Some(label(Level::Public)),
+                    ObjectRef::Path(["a", "b"]) => Some(label(Level::Secret)),
+                    ObjectRef::Path(_) | ObjectRef::Cid(_) => None,
+                }
+            }
+        }
+        struct DenySecretReads;
+        impl AccessDecider for DenySecretReads {
+            fn check(&self, _ctx: &SecurityContext, object_label: &SecurityLabel, action: Action) -> bool {
+                !(action == Action::Read && object_label.level == Level::Secret)
+            }
+        }
+        let root = SyntheticNode::dir().with_child(
+            "a",
+            SyntheticNode::dir().with_child("b", SyntheticNode::file(b"secret-at-a-b".to_vec())),
+        );
+        let backend = MountBackend::new(
+            Arc::new(SyntheticMount::new(root)),
+            hyprstream_rpc::Subject::new("tenant"),
+        );
+        let t = Translator::new(Arc::new(backend)).with_reference_monitor(Arc::new(
+            ReferenceMonitor::new(
+                Arc::new(StaticAuth(permit_session(Level::Secret, ALL_OPS))),
+                Arc::new(ByPath),
+                Arc::new(DenySecretReads),
+            ),
+        ));
+        t.handle_message(&msg::tattach(1, 0, u32::MAX, "ticket", "/")).await.unwrap();
+        let (_, walk) = t.handle_message(&msg::twalk(2, 0, 1, &["a", "b"])).await.unwrap();
+        match walk {
+            Response::Walk { qids } => assert_eq!(qids.len(), 2, "one QID per bound component"),
+            other => panic!("expected successful two-name walk, got {other:?}"),
+        }
+        assert_eq!(t.fids.path(1), Some(vec!["a".into(), "b".into()]));
+        let (_, read) = t.handle_message(&msg::tread(3, 1, 0, 64)).await.unwrap();
+        assert!(matches!(read, Response::Error { ecode } if ecode == libc_eperm()));
+    }
+
     /// F1 (defect 1 — intermediate-hop mediation): content-truth labels need
     /// not be monotone with depth. Here the `secret` directory hop is
     /// Secret-labeled while its `public` leaf is Public. The walk must mediate
@@ -1655,7 +1746,7 @@ mod tests {
                 _components: &[String],
             ) -> anyhow::Result<WalkResult> {
                 // Reaches exactly one component, regardless of how many walked.
-                Ok(WalkResult { qids: vec![sample_qid(0, 1)] })
+                Ok(WalkResult { qids: vec![sample_qid(0, 1)], reached: vec!["a".to_owned()] })
             }
             async fn open(&self, _fid: u32, _flags: u32) -> anyhow::Result<OpenResult> {
                 unimplemented!("not reached")

--- a/crates/hyprstream-9p/src/translator.rs
+++ b/crates/hyprstream-9p/src/translator.rs
@@ -1491,6 +1491,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn review_empty_walk_clone_must_not_rebind_memory_fid_to_root() {
+        struct ByPath;
+        impl ObjectLabelResolver for ByPath {
+            fn resolve(&self, object: ObjectRef<'_>) -> Option<SecurityLabel> {
+                match object {
+                    ObjectRef::Path([]) => Some(label(Level::Secret)),
+                    ObjectRef::Path(["public.txt"]) => Some(label(Level::Public)),
+                    ObjectRef::Path(_) | ObjectRef::Cid(_) => None,
+                }
+            }
+        }
+        struct DenySecretReads;
+        impl AccessDecider for DenySecretReads {
+            fn check(
+                &self,
+                _ctx: &SecurityContext,
+                object_label: &SecurityLabel,
+                action: Action,
+            ) -> bool {
+                !(action == Action::Read && object_label.level == Level::Secret)
+            }
+        }
+
+        let backend = MemoryBackend::default();
+        backend.add_file("/public.txt", b"public");
+        let t = Translator::new(Arc::new(backend)).with_reference_monitor(Arc::new(
+            ReferenceMonitor::new(
+                Arc::new(StaticAuth(permit_session(Level::Secret, ALL_OPS))),
+                Arc::new(ByPath),
+                Arc::new(DenySecretReads),
+            ),
+        ));
+
+        t.handle_message(&msg::tattach(1, 0, u32::MAX, "ticket", "/")).await.unwrap();
+        t.handle_message(&msg::twalk(2, 0, 1, &["public.txt"])).await.unwrap();
+        t.handle_message(&msg::twalk(3, 1, 2, &[])).await.unwrap();
+        let (_, read) = t.handle_message(&msg::tread(4, 2, 0, 4096)).await.unwrap();
+        match read {
+            Response::Read { data } => assert_eq!(&data, b"public"),
+            other => panic!(
+                "clone must still point at public.txt; MemoryBackend rebound it to the Secret root: {other:?}"
+            ),
+        }
+    }
+
+    #[tokio::test]
     async fn connection_scoped_translators_do_not_share_fid_context() {
         let root = Translator::new(Arc::new(MemoryBackend::default())).with_reference_monitor(
             monitor(

--- a/crates/hyprstream-9p/src/translator.rs
+++ b/crates/hyprstream-9p/src/translator.rs
@@ -48,7 +48,6 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use dashmap::DashMap;
-use hyprstream_rpc::auth::mac::SecurityContext;
 use hyprstream_rpc::Subject;
 use hyprstream_vfs::Mount;
 use tokio::io::{split, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
@@ -57,10 +56,7 @@ use tokio::sync::OnceCell;
 use tracing::{debug, error, info, warn};
 
 use crate::backend::Backend;
-use crate::mac_seam::{
-    anonymous_floor, AccessDecider, AllowAllDecider, Action, AnonymousAuthenticator,
-    AttachAuthenticator,
-};
+use crate::mac_seam::{Action, ReferenceMonitor, SessionContext};
 use crate::mount_backend::MountBackend;
 use crate::msg::{
     self, encode_response, parse_request, rflush, Request, Response,
@@ -77,10 +73,14 @@ struct FidState {
     qtype: u8,
     /// Whether open() has succeeded on this fid.
     opened: bool,
-    /// The caller's verified security context, derived once at `Tattach` by
-    /// the translator's [`AttachAuthenticator`] and inherited by every fid
-    /// walked from it (#568) — never re-derived per op.
-    ctx: SecurityContext,
+    /// Session derived once from the verified `Tattach` credential and
+    /// inherited by every descendant fid. `None` when the translator runs
+    /// without a [`ReferenceMonitor`] (the dormant pre-activation default).
+    session: Option<SessionContext>,
+    /// Absolute path of this walked fid, relative to the export root. The
+    /// reference monitor resolves this path through the trusted
+    /// manifest/genesis label resolver before every mediated operation.
+    path: Vec<String>,
 }
 
 /// Server-side fid table: 9P fid → state.
@@ -92,10 +92,19 @@ pub struct FidTable {
 }
 
 impl FidTable {
-    /// Insert state for a fid (from walk/attach), inheriting `ctx` from the
-    /// attach or the source fid being walked.
-    pub fn insert(&self, fid: u32, qtype: u8, ctx: SecurityContext) {
-        self.fids.insert(fid, FidState { qtype, opened: false, ctx });
+    /// Insert state for a fid, inheriting the verified attach session (when a
+    /// monitor is installed) and carrying the absolute walked path used for
+    /// content-label resolution.
+    pub fn insert(&self, fid: u32, qtype: u8, session: Option<SessionContext>, path: Vec<String>) {
+        self.fids.insert(
+            fid,
+            FidState {
+                qtype,
+                opened: false,
+                session,
+                path,
+            },
+        );
     }
 
     /// Mark a fid as opened.
@@ -110,9 +119,15 @@ impl FidTable {
         self.fids.get(&fid).map(|s| s.qtype)
     }
 
-    /// Look up a fid's cached security context (from attach/inherited walk).
-    pub fn security_context(&self, fid: u32) -> Option<SecurityContext> {
-        self.fids.get(&fid).map(|s| s.ctx.clone())
+    /// Look up the verified attach session inherited by a fid (`None` when
+    /// the fid is unknown or the translator runs without a monitor).
+    pub fn session(&self, fid: u32) -> Option<SessionContext> {
+        self.fids.get(&fid).and_then(|s| s.session.clone())
+    }
+
+    /// Look up a fid's absolute export-relative path for trusted label lookup.
+    pub fn path(&self, fid: u32) -> Option<Vec<String>> {
+        self.fids.get(&fid).map(|s| s.path.clone())
     }
 
     /// Remove a fid (clunk).
@@ -128,59 +143,37 @@ pub struct Translator {
     backend: Arc<dyn Backend>,
     backend_factory: Arc<dyn Fn() -> Arc<dyn Backend> + Send + Sync>,
     fids: Arc<FidTable>,
-    attach_ctx: OnceCell<SecurityContext>,
-    /// Verifies the `Tattach` credential and derives the fid's cached
-    /// [`SecurityContext`] (#568). Defaults to [`AnonymousAuthenticator`]
-    /// (always the anonymous floor), matching today's actual behavior — no
-    /// identity verification at attach. Real verification is an explicit
-    /// opt-in via [`Translator::with_authenticator`].
-    authenticator: Arc<dyn AttachAuthenticator>,
-    /// Authorizes each op against the fid's cached context (#568). Defaults
-    /// to [`AllowAllDecider`] (always allow), matching today's actual
-    /// behavior — no per-op authorization. See the module-level docs on
-    /// `mac_seam` for why a real deny-on-unlabeled decider must NOT be the
-    /// default: every object in the 9P namespace is unlabeled today, and the
-    /// S1 invariant is unlabeled ⇒ deny, not ⇒ floor.
-    decider: Arc<dyn AccessDecider>,
+    attach_session: OnceCell<SessionContext>,
+    /// The S2 reference monitor (#568). `None` is the dormant default: the
+    /// translator then performs no MAC enforcement at all, exactly matching
+    /// pre-#568 behavior. Activation (installing a monitor on the production
+    /// serve paths) is blocked on #698 — see the `mac_seam` module docs.
+    monitor: Option<Arc<ReferenceMonitor>>,
 }
 
 impl Translator {
     /// Build a translator over the given backend. The fid table starts empty.
-    /// Attach/authorization use the inert defaults (no behavior change from
-    /// before #568): see [`Translator::with_authenticator`] /
-    /// [`Translator::with_decider`] to opt into real enforcement.
+    /// No reference monitor is installed: per-op behavior is unchanged from
+    /// before #568 until the application opts in via
+    /// [`Translator::with_reference_monitor`].
     pub fn new(backend: Arc<dyn Backend>) -> Self {
         let backend_factory_backend = Arc::clone(&backend);
         Self {
             backend,
             backend_factory: Arc::new(move || Arc::clone(&backend_factory_backend)),
             fids: Arc::new(FidTable::default()),
-            attach_ctx: OnceCell::new(),
-            authenticator: Arc::new(AnonymousAuthenticator),
-            decider: Arc::new(AllowAllDecider),
+            attach_session: OnceCell::new(),
+            monitor: None,
         }
     }
 
-    /// Replace the attach-time credential verifier. The `hyprstream` crate is
-    /// expected to call this with a real verifier (backed by the S6-minted
-    /// access token + the service trust store) once a standalone "verify a
-    /// presented token" entry point exists outside the OAuth HTTP handler —
-    /// see the #568 PR discussion for why that plumbing is not included here.
-    pub fn with_authenticator(mut self, authenticator: Arc<dyn AttachAuthenticator>) -> Self {
-        self.authenticator = authenticator;
-        self
-    }
-
-    /// Replace the per-op access decider. The `hyprstream` crate is expected
-    /// to call this with a real decider (backed by `mac::avc::CachingAvc`,
-    /// optionally wrapped in `mac_seam::AuditedDecider`) once object labels
-    /// are actually available for the mount being served (genesis labeling,
-    /// or #699 carrier-b for content-addressed data) — wiring a real decider
-    /// before that point would deny every existing 9P client, since an
-    /// unlabeled object must deny per the S1 invariant, not fall back to a
-    /// permissive floor.
-    pub fn with_decider(mut self, decider: Arc<dyn AccessDecider>) -> Self {
-        self.decider = decider;
+    /// Install the S2 reference monitor: every dispatched op on every fid is
+    /// then mediated (attach-time token verification, trusted label
+    /// resolution, token gate, independent IFC dominance, then the local
+    /// AVC/PDP), failing closed at each step. Without this call the translator
+    /// enforces nothing — the dormant pre-activation default.
+    pub fn with_reference_monitor(mut self, monitor: Arc<ReferenceMonitor>) -> Self {
+        self.monitor = Some(monitor);
         self
     }
 
@@ -203,9 +196,8 @@ impl Translator {
                     as Arc<dyn Backend>
             }),
             fids: Arc::new(FidTable::default()),
-            attach_ctx: OnceCell::new(),
-            authenticator: Arc::new(AnonymousAuthenticator),
-            decider: Arc::new(AllowAllDecider),
+            attach_session: OnceCell::new(),
+            monitor: None,
         }
     }
 
@@ -238,9 +230,8 @@ impl Translator {
                 )) as Arc<dyn Backend>
             }),
             fids: Arc::new(FidTable::default()),
-            attach_ctx: OnceCell::new(),
-            authenticator: Arc::new(AnonymousAuthenticator),
-            decider: Arc::new(AllowAllDecider),
+            attach_session: OnceCell::new(),
+            monitor: None,
         }
     }
 
@@ -254,9 +245,8 @@ impl Translator {
             backend: (self.backend_factory)(),
             backend_factory: Arc::clone(&self.backend_factory),
             fids: Arc::new(FidTable::default()),
-            attach_ctx: OnceCell::new(),
-            authenticator: Arc::clone(&self.authenticator),
-            decider: Arc::clone(&self.decider),
+            attach_session: OnceCell::new(),
+            monitor: self.monitor.clone(),
         }
     }
 
@@ -456,31 +446,46 @@ impl Translator {
         // path it is a no-op. A denied ticket returns here and is mapped to an
         // Rlerror by the serve loop — before any fid or mount handle exists.
         self.backend.attach(uname).await?;
-        // #568: verify the attach credential exactly once, deriving the
-        // context every fid walked from this attach will inherit. The
-        // default AnonymousAuthenticator always floors — no behavior change
-        // until a real authenticator is injected via `with_authenticator`.
-        let ctx = self.authenticator.authenticate(uname, aname).await;
-        self.bind_attach_context(&ctx)?;
+
+        // #568: MAC mediation happens only when a reference monitor is
+        // installed (never in production today — activation is blocked on
+        // #698). The credential is then verified exactly once at attach, and
+        // the derived session is cached on every fid walked from this one.
+        let session = match &self.monitor {
+            Some(monitor) => {
+                let session = monitor.authenticate(uname, aname).await;
+                self.bind_attach_session(&session)?;
+                // The root fid itself is a mediated object. It has no
+                // synthetic exemption: an unlabeled root or missing/expired
+                // token denies at attach, before any backend object handle
+                // is exposed.
+                if !monitor.authorize(&session, &[], Action::Walk) {
+                    return Ok(Response::Error { ecode: libc_eperm() });
+                }
+                Some(session)
+            }
+            None => None,
+        };
+
         // Attach establishes the root fid. Walk the empty path to materialize
         // a root qid from the backend, then record it.
         let walk = self.backend.walk(fid, fid, &[]).await?;
         let qtype = walk.qids.last().map(|q| q.qtype).unwrap_or(0);
-        self.fids.insert(fid, qtype, ctx);
+        self.fids.insert(fid, qtype, session, Vec::new());
         let qid = walk.qids.into_iter().next().unwrap_or_default();
         Ok(Response::Attach { qid })
     }
 
-    fn bind_attach_context(&self, ctx: &SecurityContext) -> Result<()> {
-        if self.attach_ctx.set(ctx.clone()).is_ok() {
+    fn bind_attach_session(&self, session: &SessionContext) -> Result<()> {
+        if self.attach_session.set(session.clone()).is_ok() {
             return Ok(());
         }
-        match self.attach_ctx.get() {
-            Some(existing) if existing == ctx => Ok(()),
+        match self.attach_session.get() {
+            Some(existing) if existing == session => Ok(()),
             Some(_) => Err(anyhow::Error::new(hyprstream_vfs::MountError::PermissionDenied(
-                "conflicting attach security context".to_owned(),
+                "conflicting attach session context".to_owned(),
             ))),
-            None => Err(anyhow::anyhow!("attach context cell rejected without value")),
+            None => Err(anyhow::anyhow!("attach session cell rejected without value")),
         }
     }
 
@@ -490,25 +495,39 @@ impl Translator {
         newfid: u32,
         wnames: Vec<String>,
     ) -> Result<Response> {
-        if let Some(err) = self.deny(fid, Action::Walk) {
-            return Ok(err);
+        // The session is inherited from the fid being walked (#568 — the
+        // credential is verified once at attach, never re-verified per op),
+        // and the destination path extends the source fid's walked path.
+        let session = self.fids.session(fid);
+        let mut path = self.fids.path(fid).unwrap_or_default();
+        path.extend(wnames.iter().cloned());
+
+        if let Some(monitor) = &self.monitor {
+            // A walk is checked against its destination, not merely its
+            // source; otherwise a subject could traverse into a high-labeled
+            // object and rely on a later operation to discover the denial.
+            // A fid outside a verified session denies outright.
+            let Some(session) = session.as_ref() else {
+                return Ok(Response::Error { ecode: libc_eperm() });
+            };
+            if !monitor.authorize(session, &path, Action::Walk) {
+                return Ok(Response::Error { ecode: libc_eperm() });
+            }
         }
-        // The context is inherited from the fid being walked (#568 — a
-        // context is derived once at attach, never re-verified per op).
-        let ctx = self.fids.security_context(fid).unwrap_or_else(anonymous_floor);
+
         // Mirror of RemoteModelMount::walk: call backend.walk with the source
         // fid, the new fid, and the path components.
         let result = self.backend.walk(fid, newfid, &wnames).await?;
         if wnames.is_empty() {
             // nwname=0 is a fid *clone*: newfid aliases fid (same file), and
             // the backend returns no qids. newfid must still inherit the source
-            // fid's qtype and context — otherwise the clone has no cached
-            // context, floors to anonymous, and a real decider wrongly denies
-            // it for an already-authenticated client (#568).
+            // fid's qtype, session, and path — otherwise the clone has no
+            // cached session and a live monitor wrongly denies it for an
+            // already-authenticated client (#568).
             let qtype = self.fids.qtype(fid).unwrap_or(0);
-            self.fids.insert(newfid, qtype, ctx);
+            self.fids.insert(newfid, qtype, session, path);
         } else if let Some(q) = result.qids.last() {
-            self.fids.insert(newfid, q.qtype, ctx);
+            self.fids.insert(newfid, q.qtype, session, path);
         }
         Ok(Response::Walk { qids: result.qids })
     }
@@ -565,19 +584,21 @@ impl Translator {
         Ok(Response::Readdir { data })
     }
 
-    /// Consults the decider for `fid`+`action` against the fid's cached
-    /// context. Returns `Some(Response::Error)` (EPERM) if denied, `None` if
-    /// allowed. No object label is available at this layer (see the
-    /// `mac_seam` module docs) — `object_label` is always `None` here; a real
-    /// decider must treat that as "deny" per the S1 invariant, not as
-    /// "unrestricted".
+    /// Mediate one op on `fid` through the installed [`ReferenceMonitor`].
+    /// Returns `Some(Response::Error)` (EPERM) when the op is denied, `None`
+    /// when it may proceed to the backend.
     ///
-    /// A fid with no cached context (should not happen — every fid is
-    /// populated at attach or inherits from its parent on walk) is treated
-    /// as the anonymous floor rather than panicking.
+    /// With no monitor installed (the dormant pre-activation default) every
+    /// op proceeds — exactly the pre-#568 behavior. With a monitor, a fid
+    /// outside a verified attach session (unknown fid, or a fid created
+    /// before the monitor saw an attach) fails closed, and the session's
+    /// cached path is mediated as `label → token → IFC → decider`.
     fn deny(&self, fid: u32, action: Action) -> Option<Response> {
-        let ctx = self.fids.security_context(fid).unwrap_or_else(anonymous_floor);
-        if self.decider.check(&ctx, None, action) {
+        let monitor = self.monitor.as_ref()?;
+        let (Some(session), Some(path)) = (self.fids.session(fid), self.fids.path(fid)) else {
+            return Some(Response::Error { ecode: libc_eperm() });
+        };
+        if monitor.authorize(&session, &path, action) {
             None
         } else {
             Some(Response::Error { ecode: libc_eperm() })
@@ -1040,11 +1061,174 @@ mod tests {
         assert!(matches!(resp, Response::Clunk));
     }
 
-    /// #568: a translator with a real (non-default) decider actually blocks
-    /// ops, proving the `deny`/`FidTable::security_context` wiring is live —
-    /// not just present but inert. Uses a decider that denies `Action::Read`
-    /// unconditionally; walk/open (unblocked) still succeed, read is
-    /// rejected with `Rlerror EPERM` rather than reaching the backend.
+    // ── #568 reference-monitor test doubles ───────────────────────────
+    //
+    // The monitor seams are exercised with fakes that stand in for the
+    // application's verified-token authenticator, genesis/manifest label
+    // resolver, and AVC/PDP decider. No production path installs a monitor
+    // yet (activation is blocked on #698); the unmonitored tests in this
+    // module double as the dormant-default regression guard.
+
+    use crate::mac_seam::{
+        AccessDecider, AttachAuthenticator, ObjectLabelResolver, ObjectRef, VerifiedTokenScope,
+    };
+    use hyprstream_rpc::auth::mac::{
+        Assurance, CompartmentSet, Level, SecurityContext, SecurityLabel, VerifiedKeyMaterial,
+    };
+    use std::time::{Duration, Instant};
+
+    fn label(level: Level) -> SecurityLabel {
+        SecurityLabel::new(level, Assurance::Classical, CompartmentSet::EMPTY)
+    }
+
+    fn ctx(level: Level) -> SecurityContext {
+        // Classical key material so the derived assurance dominates the
+        // Classical-assurance object labels used across these tests.
+        SecurityContext::new(level, CompartmentSet::EMPTY, VerifiedKeyMaterial::Classical)
+    }
+
+    /// A session at `level` whose verified token permits exactly `ops` (with
+    /// a Secret ceiling) for the next hour.
+    fn permit_session(level: Level, ops: &[Action]) -> SessionContext {
+        SessionContext::from_verified_token(
+            ctx(level),
+            VerifiedTokenScope::from_verified_token(
+                label(Level::Secret),
+                Arc::from(ops),
+                Instant::now() + Duration::from_secs(3600),
+            ),
+        )
+    }
+
+    const ALL_OPS: &[Action] = &[
+        Action::Walk,
+        Action::Open,
+        Action::Read,
+        Action::Write,
+        Action::Getattr,
+        Action::Readdir,
+    ];
+
+    /// Authenticator returning a fixed session (the token is treated as
+    /// already verified, as a real authenticator would after checking it).
+    struct StaticAuth(SessionContext);
+    #[async_trait]
+    impl AttachAuthenticator for StaticAuth {
+        async fn authenticate(&self, _u: &str, _a: &str) -> SessionContext {
+            self.0.clone()
+        }
+    }
+
+    /// Resolver returning a fixed label for every path (`None` = unlabeled).
+    struct StaticLabels(Option<SecurityLabel>);
+    impl ObjectLabelResolver for StaticLabels {
+        fn resolve(&self, _object: ObjectRef<'_>) -> Option<SecurityLabel> {
+            self.0
+        }
+    }
+
+    struct AllowAll;
+    impl AccessDecider for AllowAll {
+        fn check(
+            &self,
+            _ctx: &SecurityContext,
+            _object_label: &SecurityLabel,
+            _action: Action,
+        ) -> bool {
+            true
+        }
+    }
+
+    fn monitor(
+        auth: SessionContext,
+        resolved: Option<SecurityLabel>,
+        decider: Arc<dyn AccessDecider>,
+    ) -> Arc<ReferenceMonitor> {
+        Arc::new(ReferenceMonitor::new(
+            Arc::new(StaticAuth(auth)),
+            Arc::new(StaticLabels(resolved)),
+            decider,
+        ))
+    }
+
+    /// With a monitor installed, an unlabeled root denies the attach itself:
+    /// the root fid is a mediated object with no synthetic exemption.
+    #[tokio::test]
+    async fn monitor_denies_unlabeled_root_at_attach() {
+        let t = Translator::new(Arc::new(MemoryBackend::default())).with_reference_monitor(
+            monitor(permit_session(Level::Secret, ALL_OPS), None, Arc::new(AllowAll)),
+        );
+        let (_, resp) = t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
+        match resp {
+            Response::Error { ecode } => assert_eq!(ecode, libc_eperm()),
+            other => panic!("expected Rlerror EPERM for unlabeled root, got {other:?}"),
+        }
+    }
+
+    /// A session without a verified token denies at attach, before any
+    /// backend object handle exists.
+    #[tokio::test]
+    async fn monitor_denies_missing_token_at_attach() {
+        let t = Translator::new(Arc::new(MemoryBackend::default())).with_reference_monitor(
+            monitor(SessionContext::deny(), Some(label(Level::Public)), Arc::new(AllowAll)),
+        );
+        let (_, resp) = t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
+        match resp {
+            Response::Error { ecode } => assert_eq!(ecode, libc_eperm()),
+            other => panic!("expected Rlerror EPERM for missing token, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn monitor_denies_expired_token_at_attach() {
+        let expired = SessionContext::from_verified_token(
+            ctx(Level::Secret),
+            VerifiedTokenScope::from_verified_token(
+                label(Level::Secret),
+                Arc::from(ALL_OPS),
+                Instant::now() - Duration::from_secs(1),
+            ),
+        );
+        let t = Translator::new(Arc::new(MemoryBackend::default())).with_reference_monitor(
+            monitor(expired, Some(label(Level::Public)), Arc::new(AllowAll)),
+        );
+        let (_, resp) = t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
+        match resp {
+            Response::Error { ecode } => assert_eq!(ecode, libc_eperm()),
+            other => panic!("expected Rlerror EPERM for expired token, got {other:?}"),
+        }
+    }
+
+    /// When every gate passes — labeled object, unexpired token covering the
+    /// op, dominating subject, permitting decider — the mediated session is
+    /// served end to end.
+    #[tokio::test]
+    async fn monitor_allows_when_all_gates_pass() {
+        let backend = MemoryBackend::default();
+        backend.add_file("/hello.txt", b"hello world");
+        let t = Translator::new(Arc::new(backend)).with_reference_monitor(monitor(
+            permit_session(Level::Secret, ALL_OPS),
+            Some(label(Level::Public)),
+            Arc::new(AllowAll),
+        ));
+
+        let (_, resp) = t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
+        assert!(matches!(resp, Response::Attach { .. }), "got {resp:?}");
+        let (_, resp) = t.handle_message(&msg::twalk(2, 0, 1, &["hello.txt"])).await.unwrap();
+        assert!(matches!(resp, Response::Walk { .. }), "got {resp:?}");
+        let (_, resp) = t.handle_message(&msg::tlopen(3, 1, 0)).await.unwrap();
+        assert!(matches!(resp, Response::Lopen { .. }), "got {resp:?}");
+        let (_, resp) = t.handle_message(&msg::tread(4, 1, 0, 64)).await.unwrap();
+        match resp {
+            Response::Read { data } => assert_eq!(&data, b"hello world"),
+            other => panic!("expected Read, got {other:?}"),
+        }
+    }
+
+    /// #568: a translator with a live monitor actually blocks ops the decider
+    /// rejects, proving the `deny` wiring is live — not just present but
+    /// inert. Walk/open (permitted) still succeed; read is rejected with
+    /// `Rlerror EPERM` rather than reaching the backend.
     #[tokio::test]
     async fn injected_decider_blocks_denied_action() {
         struct DenyReads;
@@ -1052,7 +1236,7 @@ mod tests {
             fn check(
                 &self,
                 _ctx: &SecurityContext,
-                _object_label: Option<&hyprstream_rpc::auth::mac::SecurityLabel>,
+                _object_label: &SecurityLabel,
                 action: Action,
             ) -> bool {
                 !matches!(action, Action::Read)
@@ -1061,11 +1245,14 @@ mod tests {
 
         let backend = MemoryBackend::default();
         backend.add_file("/hello.txt", b"hello world");
-        let t = Translator::new(Arc::new(backend)).with_decider(Arc::new(DenyReads));
+        let t = Translator::new(Arc::new(backend)).with_reference_monitor(monitor(
+            permit_session(Level::Secret, ALL_OPS),
+            Some(label(Level::Public)),
+            Arc::new(DenyReads),
+        ));
 
         t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
-        let (_, resp) =
-            t.handle_message(&msg::twalk(2, 0, 1, &["hello.txt"])).await.unwrap();
+        let (_, resp) = t.handle_message(&msg::twalk(2, 0, 1, &["hello.txt"])).await.unwrap();
         assert!(matches!(resp, Response::Walk { .. }), "walk must still succeed");
 
         let (_, resp) = t.handle_message(&msg::tlopen(3, 1, 0)).await.unwrap();
@@ -1078,8 +1265,129 @@ mod tests {
         }
     }
 
+    /// An op outside the verified token's operation set denies even when the
+    /// decider would permit it — the token gate runs before policy.
+    #[tokio::test]
+    async fn monitor_denies_op_outside_token_scope() {
+        let backend = MemoryBackend::default();
+        backend.add_file("/hello.txt", b"hello world");
+        let t = Translator::new(Arc::new(backend)).with_reference_monitor(monitor(
+            permit_session(Level::Secret, &[Action::Walk, Action::Open, Action::Read]),
+            Some(label(Level::Public)),
+            Arc::new(AllowAll),
+        ));
+
+        t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
+        t.handle_message(&msg::twalk(2, 0, 1, &["hello.txt"])).await.unwrap();
+        t.handle_message(&msg::tlopen(3, 1, 1 /* OWRITE */)).await.unwrap();
+        let (_, resp) = t.handle_message(&msg::twrite(4, 1, 0, b"nope")).await.unwrap();
+        match resp {
+            Response::Error { ecode } => assert_eq!(ecode, libc_eperm()),
+            other => panic!("expected Rlerror EPERM for out-of-scope write, got {other:?}"),
+        }
+        let (_, resp) = t.handle_message(&msg::tread(5, 1, 0, 64)).await.unwrap();
+        assert!(matches!(resp, Response::Read { .. }), "in-scope read must pass: {resp:?}");
+    }
+
+    /// A walk is mediated against its destination label: the token ceiling
+    /// (Confidential) covers the public file but not the Secret one, so the
+    /// second walk denies even though the source fid was authorized.
+    #[tokio::test]
+    async fn monitor_walk_checked_against_destination_label() {
+        struct ByName;
+        impl ObjectLabelResolver for ByName {
+            fn resolve(&self, object: ObjectRef<'_>) -> Option<SecurityLabel> {
+                match object {
+                    ObjectRef::Path(parts) => Some(match parts.last().copied() {
+                        Some("secret.txt") => label(Level::Secret),
+                        _ => label(Level::Public),
+                    }),
+                    ObjectRef::Cid(_) => None,
+                }
+            }
+        }
+        let session = SessionContext::from_verified_token(
+            ctx(Level::Secret),
+            VerifiedTokenScope::from_verified_token(
+                label(Level::Confidential),
+                Arc::from(ALL_OPS),
+                Instant::now() + Duration::from_secs(3600),
+            ),
+        );
+        let backend = MemoryBackend::default();
+        backend.add_file("/hello.txt", b"hi");
+        backend.add_file("/secret.txt", b"classified");
+        let t = Translator::new(Arc::new(backend)).with_reference_monitor(Arc::new(
+            ReferenceMonitor::new(
+                Arc::new(StaticAuth(session)),
+                Arc::new(ByName),
+                Arc::new(AllowAll),
+            ),
+        ));
+
+        t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
+        let (_, resp) = t.handle_message(&msg::twalk(2, 0, 1, &["hello.txt"])).await.unwrap();
+        assert!(matches!(resp, Response::Walk { .. }), "public walk must pass: {resp:?}");
+        let (_, resp) = t.handle_message(&msg::twalk(3, 0, 2, &["secret.txt"])).await.unwrap();
+        match resp {
+            Response::Error { ecode } => assert_eq!(ecode, libc_eperm()),
+            other => panic!("expected Rlerror EPERM above the token ceiling, got {other:?}"),
+        }
+    }
+
+    /// The IFC floor is independent of the token and the policy matrix: a
+    /// Public subject holding a Secret-ceiling token with an allow-all
+    /// decider still cannot walk into a Secret-labeled object.
+    #[tokio::test]
+    async fn monitor_ifc_floor_not_bypassed_by_permissive_decider() {
+        struct AllSecret;
+        impl ObjectLabelResolver for AllSecret {
+            fn resolve(&self, object: ObjectRef<'_>) -> Option<SecurityLabel> {
+                match object {
+                    ObjectRef::Path([]) => Some(label(Level::Public)),
+                    ObjectRef::Path(_) => Some(label(Level::Secret)),
+                    ObjectRef::Cid(_) => None,
+                }
+            }
+        }
+        let backend = MemoryBackend::default();
+        backend.add_file("/secret.txt", b"classified");
+        let t = Translator::new(Arc::new(backend)).with_reference_monitor(Arc::new(
+            ReferenceMonitor::new(
+                Arc::new(StaticAuth(permit_session(Level::Public, ALL_OPS))),
+                Arc::new(AllSecret),
+                Arc::new(AllowAll),
+            ),
+        ));
+
+        let (_, resp) = t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
+        assert!(matches!(resp, Response::Attach { .. }), "public root must attach: {resp:?}");
+        let (_, resp) = t.handle_message(&msg::twalk(2, 0, 1, &["secret.txt"])).await.unwrap();
+        match resp {
+            Response::Error { ecode } => assert_eq!(ecode, libc_eperm()),
+            other => panic!("expected Rlerror EPERM for IFC non-dominance, got {other:?}"),
+        }
+    }
+
+    /// Clunk is fid disposal, not an object operation: it is never mediated,
+    /// so a denied op can never wedge connection teardown.
+    #[tokio::test]
+    async fn clunk_is_not_mediated() {
+        let backend = MemoryBackend::default();
+        backend.add_file("/hello.txt", b"hi");
+        let t = Translator::new(Arc::new(backend)).with_reference_monitor(monitor(
+            permit_session(Level::Secret, &[Action::Walk]),
+            Some(label(Level::Public)),
+            Arc::new(AllowAll),
+        ));
+        t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
+        t.handle_message(&msg::twalk(2, 0, 1, &["hello.txt"])).await.unwrap();
+        let (_, resp) = t.handle_message(&msg::tclunk(3, 1)).await.unwrap();
+        assert!(matches!(resp, Response::Clunk), "clunk must not be mediated: {resp:?}");
+    }
+
     /// #767 review: `getattr` leaks object metadata (qid/mode/size/mtime) and
-    /// must be gated by the decider like every other fid op — it was the one
+    /// must be gated by the monitor like every other fid op — it was the one
     /// ungated op. A decider that denies `Action::Getattr` must produce EPERM.
     #[tokio::test]
     async fn injected_decider_blocks_getattr() {
@@ -1088,7 +1396,7 @@ mod tests {
             fn check(
                 &self,
                 _ctx: &SecurityContext,
-                _object_label: Option<&hyprstream_rpc::auth::mac::SecurityLabel>,
+                _object_label: &SecurityLabel,
                 action: Action,
             ) -> bool {
                 !matches!(action, Action::Getattr)
@@ -1097,7 +1405,11 @@ mod tests {
 
         let backend = MemoryBackend::default();
         backend.add_file("/hello.txt", b"hi");
-        let t = Translator::new(Arc::new(backend)).with_decider(Arc::new(DenyGetattr));
+        let t = Translator::new(Arc::new(backend)).with_reference_monitor(monitor(
+            permit_session(Level::Secret, ALL_OPS),
+            Some(label(Level::Public)),
+            Arc::new(DenyGetattr),
+        ));
 
         t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
         let (_, resp) = t.handle_message(&msg::twalk(2, 0, 1, &["hello.txt"])).await.unwrap();
@@ -1111,81 +1423,46 @@ mod tests {
     }
 
     /// #767 review: a zero-element walk (nwname=0) is a fid *clone*; the new
-    /// fid must inherit the source fid's cached context rather than being left
-    /// untracked (which floored to anonymous under a real decider and wrongly
-    /// denied an already-authenticated client).
+    /// fid must inherit the source fid's cached session rather than being left
+    /// untracked (which would fail closed under a live monitor and wrongly
+    /// deny an already-authenticated client).
     #[tokio::test]
     async fn walk_clone_inherits_source_context() {
-        use async_trait::async_trait;
-        use hyprstream_rpc::auth::mac::{
-            Assurance, CompartmentSet, Level, SecurityLabel, VerifiedKeyMaterial,
-        };
+        let t = Translator::new(Arc::new(MemoryBackend::default())).with_reference_monitor(
+            monitor(
+                permit_session(Level::Secret, ALL_OPS),
+                Some(label(Level::Public)),
+                Arc::new(AllowAll),
+            ),
+        );
 
-        struct ElevatedAuth;
-        #[async_trait]
-        impl AttachAuthenticator for ElevatedAuth {
-            async fn authenticate(&self, _u: &str, _a: &str) -> SecurityContext {
-                SecurityContext::from_clearance(
-                    SecurityLabel::new(Level::Secret, Assurance::Unverified, CompartmentSet::EMPTY),
-                    VerifiedKeyMaterial::Unverified,
-                )
-            }
-        }
-
-        let t = Translator::new(Arc::new(MemoryBackend::default()))
-            .with_authenticator(Arc::new(ElevatedAuth));
-
-        // Attach root fid 0 with the elevated (non-anonymous) context.
+        // Attach root fid 0 with the elevated (non-anonymous) session.
         t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
         // Clone fid 0 -> fid 1 via a zero-element walk.
         let (_, resp) = t.handle_message(&msg::twalk(2, 0, 1, &[])).await.unwrap();
         assert!(matches!(resp, Response::Walk { .. }), "clone walk must succeed");
 
-        // The clone must carry the source's elevated context, not the anon floor.
-        let ctx = t
+        // The clone must carry the source's elevated session, not floor out.
+        let session = t
             .fids
-            .security_context(1)
+            .session(1)
             .expect("cloned fid must be tracked in the fid table");
-        assert_ne!(
-            ctx.level(),
-            Level::Public,
-            "cloned fid must inherit the source's elevated context, not floor to anonymous",
+        assert_eq!(
+            session.security_context().level(),
+            Level::Secret,
+            "cloned fid must inherit the source's elevated session",
         );
     }
 
     #[tokio::test]
     async fn connection_scoped_translators_do_not_share_fid_context() {
-        use async_trait::async_trait;
-        use hyprstream_rpc::auth::mac::{
-            Assurance, CompartmentSet, Level, SecurityLabel, VerifiedKeyMaterial,
-        };
-
-        struct SecretAuth;
-        #[async_trait]
-        impl AttachAuthenticator for SecretAuth {
-            async fn authenticate(&self, _u: &str, _a: &str) -> SecurityContext {
-                SecurityContext::from_clearance(
-                    SecurityLabel::new(Level::Secret, Assurance::Unverified, CompartmentSet::EMPTY),
-                    VerifiedKeyMaterial::Unverified,
-                )
-            }
-        }
-
-        struct DenyAnonymous;
-        impl AccessDecider for DenyAnonymous {
-            fn check(
-                &self,
-                ctx: &SecurityContext,
-                _object_label: Option<&hyprstream_rpc::auth::mac::SecurityLabel>,
-                _action: Action,
-            ) -> bool {
-                ctx.level() != Level::Public
-            }
-        }
-
-        let root = Translator::new(Arc::new(MemoryBackend::default()))
-            .with_authenticator(Arc::new(SecretAuth))
-            .with_decider(Arc::new(DenyAnonymous));
+        let root = Translator::new(Arc::new(MemoryBackend::default())).with_reference_monitor(
+            monitor(
+                permit_session(Level::Secret, ALL_OPS),
+                Some(label(Level::Public)),
+                Arc::new(AllowAll),
+            ),
+        );
         let conn_a = Arc::new(root.connection_scoped());
         let conn_b = Arc::new(root.connection_scoped());
 
@@ -1194,6 +1471,8 @@ mod tests {
             .await
             .unwrap();
 
+        // conn_b never attached: fid 1 is unknown to its table, and a fid
+        // outside a verified session fails closed under a live monitor.
         let (_, resp) = conn_b.handle_message(&msg::twalk(2, 1, 2, &[])).await.unwrap();
         match resp {
             Response::Error { ecode } => assert_eq!(ecode, libc_eperm()),
@@ -1203,29 +1482,26 @@ mod tests {
 
     #[tokio::test]
     async fn translator_rejects_conflicting_attach_security_context() {
-        use async_trait::async_trait;
-        use hyprstream_rpc::auth::mac::{
-            Assurance, CompartmentSet, Level, SecurityLabel, VerifiedKeyMaterial,
-        };
-
         struct TicketAuth;
         #[async_trait]
         impl AttachAuthenticator for TicketAuth {
-            async fn authenticate(&self, uname: &str, _aname: &str) -> SecurityContext {
+            async fn authenticate(&self, uname: &str, _aname: &str) -> SessionContext {
                 let level = if uname == "alice-ticket" {
                     Level::Secret
                 } else {
                     Level::Public
                 };
-                SecurityContext::from_clearance(
-                    SecurityLabel::new(level, Assurance::Unverified, CompartmentSet::EMPTY),
-                    VerifiedKeyMaterial::Unverified,
-                )
+                permit_session(level, ALL_OPS)
             }
         }
 
-        let t = Translator::new(Arc::new(MemoryBackend::default()))
-            .with_authenticator(Arc::new(TicketAuth));
+        let t = Translator::new(Arc::new(MemoryBackend::default())).with_reference_monitor(
+            Arc::new(ReferenceMonitor::new(
+                Arc::new(TicketAuth),
+                Arc::new(StaticLabels(Some(label(Level::Public)))),
+                Arc::new(AllowAll),
+            )),
+        );
         let (_, resp) = t
             .handle_message(&msg::tattach(1, 1, u32::MAX, "alice-ticket", "/"))
             .await
@@ -1239,14 +1515,14 @@ mod tests {
         assert_eq!(
             errno_from_error(&err),
             EACCES,
-            "conflicting attach context must be EACCES",
+            "conflicting attach session must be EACCES",
         );
     }
 
     #[tokio::test]
     async fn fid_table_tracks_open_and_clunk() {
         let table = FidTable::default();
-        table.insert(7, 0x80, anonymous_floor());
+        table.insert(7, 0x80, None, Vec::new());
         assert_eq!(table.qtype(7), Some(0x80));
         table.set_opened(7);
         table.remove(7);

--- a/crates/hyprstream/src/mac/genesis.rs
+++ b/crates/hyprstream/src/mac/genesis.rs
@@ -34,12 +34,14 @@
 //! ## Stage 0: dormant, zero behavior change
 //!
 //! Nothing here flips a decider to enforcing. The composite resolver is
-//! constructed and testable, but the 9P PEP (`hyprstream-9p::mac_seam`) still
-//! defaults to [`AllowAllDecider`](hyprstream_9p::mac_seam::AllowAllDecider), so
-//! no request is allowed or denied differently than before this module existed.
-//! The value delivered now is the **coverage-gate evidence**: proof that a
-//! complete, well-formed genesis exists (or an explicit list of the gaps) so the
-//! activation decision has something to gate on.
+//! constructed and testable, but the 9P PEP (`hyprstream-9p::mac_seam`) stays
+//! dormant: no production [`Translator`](hyprstream_9p::Translator) has a
+//! [`ReferenceMonitor`](hyprstream_9p::mac_seam::ReferenceMonitor) installed,
+//! so no request is allowed or denied differently than before this module
+//! existed (activation is blocked on #698). The value delivered now is the
+//! **coverage-gate evidence**: proof that a complete, well-formed genesis
+//! exists (or an explicit list of the gaps) so the activation decision has
+//! something to gate on.
 
 use std::collections::BTreeSet;
 use std::sync::Arc;

--- a/crates/hyprstream/src/services/kata_9p_backend.rs
+++ b/crates/hyprstream/src/services/kata_9p_backend.rs
@@ -17,8 +17,8 @@
 //!
 //! The translator allocates 9P fids on its side; we forward them unchanged as
 //! the model service's remote fids (same one-to-one scheme `RemoteModelMount`
-//! uses). The first walk component is the model reference; the rest is the
-//! path within the model's synthetic tree.
+//! uses). The first walk component establishes the model reference; later
+//! single-name walks traverse the path within that model's synthetic tree.
 
 use std::sync::atomic::AtomicU32;
 
@@ -91,6 +91,9 @@ impl Backend for ModelBackend {
         newfid: u32,
         components: &[String],
     ) -> anyhow::Result<WalkResult> {
+        if components.len() > 1 {
+            anyhow::bail!("ModelBackend only supports single-name walks; refusing an ambiguous multi-name binding");
+        }
         // Resolve model_ref: prefer a previously-walked parent fid, else take
         // the first walk component as the model_ref.
         let (model_ref, wnames): (String, Vec<String>) = if components.is_empty() {
@@ -101,7 +104,12 @@ impl Backend for ModelBackend {
                 .map(|s| s.model_ref.clone())
                 .ok_or_else(|| anyhow::anyhow!("walk: source fid {fid} has no model_ref"))?;
             (mr, Vec::new())
+        } else if let Some(state) = self.fids.get(&fid) {
+            // Once the model reference is established, subsequent one-name
+            // walks stay in that model's fs scope.
+            (state.model_ref.clone(), components.to_vec())
         } else {
+            // The first component establishes the model reference.
             let model_ref = components[0].clone();
             let rest = components[1..].to_vec();
             (model_ref, rest)
@@ -113,7 +121,7 @@ impl Backend for ModelBackend {
         let RWalk { qid } = self.rt.block_on(fs.walk(&req))?;
         self.fids.insert(newfid, ModelFidState { model_ref });
 
-        Ok(WalkResult { qids: vec![qid_from_rpc(&qid)] })
+        Ok(WalkResult { qids: vec![qid_from_rpc(&qid)], reached: components.to_vec() })
     }
 
     async fn open(&self, fid: u32, flags: u32) -> anyhow::Result<OpenResult> {


### PR DESCRIPTION
## Summary

S2 (#568, epic #547) groundwork for the 9P reference monitor, scoped to what can land **before MAC activation**: the enforcement contract, the fail-closed mediation composition, and full test coverage.

**This PR does not activate S2 enforcement.** No production `Translator` installs a monitor, and per-op behavior is byte-identical to today. Nothing in this PR should be read as "S2 is live".

## Blocked on #698 — activation is deliberately not here

#698 (*subject clearance provenance*) explicitly blocks S2/#568: no production token-issuance path attaches `Claims.clearance`, so any live monitor would resolve every subject to deny (fail-closed but unusable). Object labels for the served mount are likewise not yet wired to the 9P export (the genesis `CompositeObjectLabelResolver` exists but is not installed). Installing `with_reference_monitor` on the production serve paths (`server::routes::ninep`, the UDS/vsock supervisors) is the activation change and lands only after #698.

## What lands

- **`mac_seam` rebuilt as the S2 reference-monitor contract**
  - `VerifiedTokenScope` / `SessionContext`: attach-time-verified, sender-bound token facts cached per fid. The only permitting construction is `from_verified_token`; an invalid/absent credential is `SessionContext::deny()`.
  - `ReferenceMonitor::authorize` — the mandatory mediation order, each step fail-closed:
    1. trusted object-label resolution (the `ObjectLabelResolver`/`ObjectRef` seam from #699 in `hyprstream-rpc` — labels from the manifest/genesis, never from token/UCAN/caveat),
    2. token gate (unexpired ∧ op ∈ scope ∧ object label ⊑ token ceiling),
    3. independent IFC dominance (`subject.ctx ⊒ object.label`),
    4. the local AVC/PDP decider.
    A permissive decider cannot bypass the token/IFC floor; per-op cost is a fid-table lookup plus a local check — no UCAN chain validation, no Casbin-per-op.
  - Fail-closed defaults (`AnonymousAuthenticator`, `DenyUnlabeledResolver`, `DenyAllDecider`).
  - The previous `AllowAllDecider` / `AuditedDecider` / `AuditSink` seam is removed: `AccessDecider::check` now takes a **non-optional** `&SecurityLabel`, so "unlabeled ⇒ deny" is enforced by the monitor composition instead of being re-implemented (or forgotten) per decider.
- **`Translator` gains opt-in mediation** (`with_reference_monitor`):
  - `Tattach` verifies the credential once and caches the session on every walked fid; a conflicting second attach on one connection is rejected (EACCES).
  - `Twalk` is mediated against **every hop** of the walk (each intermediate prefix), not merely the source or final destination; the cached fid path is derived from the backend's returned-qid count so a partial walk (`nwqid < nwname`) cannot poison the cached path.
  - `Tlopen`/`Tread`/`Twrite`/`Tgetattr`/`Treaddir` are mediated per op; a fid outside a verified session fails closed.
  - `Tclunk` is fid disposal, not an object op, and is deliberately unmediated (a denied op must never wedge connection teardown).
  - With no monitor installed (every production constructor today), the translator enforces nothing — the dormant pre-activation default.
- **Tests** (lib + existing integration suites all green):
  - unlabeled object / missing token / expired token deny at attach;
  - op-outside-token-scope, label-above-token-ceiling (destination-checked walk), IFC non-dominance under an allow-all decider, and decider denial each deny per op;
  - all-gates-pass is served end to end; clone-fids inherit the session; connections don't share fid state; conflicting attach sessions are rejected;
  - the pre-existing unmonitored tests pass unchanged, doubling as the dormant-default regression guard.

## Validation

- `cargo test -p hyprstream-9p` — 43 passed (39 lib + 4 integration)
- `cargo clippy -p hyprstream-9p --all-targets -- -D warnings` — clean
- `cargo check -p hyprstream` — clean (genesis doc-comment update only)
- `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo check --target wasm32-unknown-unknown -p hyprstream-9p` — clean (2 pre-existing warnings in untouched wasm-only modules `dma.rs`/`wanix_mount.rs`)

Refs #568


---

## Revision — adversarial review (push `d41898cc8`)

Addressed the three MAJOR findings from the adversarial review. Each fix ships a test verified to **fail without its hunk** (revert → fail → restore).

- **F1 — `Twalk` mediation**: authorizes every hop prefix (not only the destination) so traversal through a high-labeled directory is mediated under non-monotone labels; cached path now derived from the backend's returned-qid count, closing the partial-walk path-poisoning name↔object TOCTOU.
- **F2 — `SessionContext` re-attach equality**: re-attach now compares by attach identity (subject + token scope, excluding `valid_until`), so a still-valid ticket re-stamped with a fresh deadline is accepted, not wrongly EACCES'd.
- **F3 — name vs object (verifiability)**: the `mac_seam` contract docs now state honestly that the monitor is authoritative over the **name** (path), not the **object** (fid); "complete mediation" holds iff the resolver agrees with the backend's name resolution. `..` canonicalization and bind/symlink indirection are documented as not-covered, activation-blocking alongside #698 / tracked with #699.
- **F4 — API break (MINOR, intended)**: this PR removes `AllowAllDecider`/`AuditedDecider`/`AuditSink`/`NullAuditSink`/`with_authenticator`/`with_decider` and changes `AccessDecider::check` and `FidTable` shapes on the MIT `hyprstream-9p` crate. No in-repo consumers remain; external consumers break. Flagging for semver/release notes. (No CHANGELOG file exists in-tree.)

**Tenant scoping (#1155 / #1128)**: this contract does **not** foreclose tenant scoping. The lattice's `CompartmentSet` can encode a tenant as a compartment, enforced by the IFC floor independently of the Casbin `domain:"*"` PDP — and none of the ~30 production `domain:"*"` call sites live in this crate (the 9P monitor bypasses the Casbin domain axis in favor of the compartment lattice, routing around the #1128 gap). Caveat: `AccessDecider::check` takes only `(SecurityContext, SecurityLabel, Action)` — no explicit tenant/domain arg — so per-op **policy** (not IFC) tenant scoping at the PDP would later require widening that signature. Extensible, not foreclosed.

**Validation (revised)**: `cargo test -p hyprstream-9p` — 46 passed (42 lib + 4 integration); `cargo clippy --all-targets --release -- -D warnings` (workspace, the pre-commit gate) — clean. Not merging — left for re-review.


---
## Revision — round 3 (commit 576528519)

This revision answers the re-review findings without activating the monitor in production:

- **Deeper real-backend walk binding:** `WalkResult` now carries a required reached-prefix contract, and the translator rejects non-empty results whose QID count and reached prefix disagree. `MountBackend` resolves each component and returns one QID per actual hop; the model backend refuses ambiguous multi-name walks and supports subsequent one-name traversal within its established model scope. The production-shaped `/a/b` regression verifies that a Secret leaf is denied even when `/a` is Public.
- **Attach identity:** a verifier-produced `VerifiedAttachIdentity` is carried in `SessionContext`; re-attach comparison now includes it plus canonical authorization scope while deliberately excluding the refreshed expiry deadline. Different principals with identical MAC attributes are rejected; the same ticket with a new deadline remains accepted.
- **Denied attach state:** monitor authentication/root authorization and compatibility checks occur before backend attach/session commitment. A denied attach leaves the connection usable for a later valid attach.

### Reference-monitor assessment

- **Complete mediation:** conditional, not absolute. With a monitor installed, every dispatched operation and each reached walk hop is mediated under the backend's checked reached-prefix contract. The remaining path authority is still the documented **two-independent-resolutions-agree** precondition: the label resolver and backend must resolve a reported path to the same object.
- **Tamper-proofness:** partial. Token, label, IFC, unknown-fid, and policy failures remain fail-closed; injected verifier/backend/resolver implementations remain trusted boundaries.
- **Verifiability:** improved but partial. The exact backend walk contract and stable attach identity are explicit and regression-tested; the remaining independent-resolution precondition is documented in `mac_seam`.

### Validation

- `buildq -- cargo test -p hyprstream-9p --lib --no-run`, then focused restored-state tests: pass.
- `buildq -- cargo check -p hyprstream` with the cached CUDA 13.0 libtorch environment: pass.
- The repository pre-commit strict workspace Clippy gate passed before commit.
- Causal reversal made all three new regressions fail, then restoration made them pass: deep MountBackend walk binding; distinct principals with equal authorization attributes; denied attach followed by a valid retry.

Not merging; awaiting review.