### PR TITLE
fix(auth): Operation::all() returns all 15 variants — check_all blindness

### DIFF
--- a/crates/hyprstream/src/auth/mod.rs
+++ b/crates/hyprstream/src/auth/mod.rs
@@ -218,8 +218,8 @@ impl Operation {
             Operation::Publish => 'l',
             Operation::Spawn => 'p',
             Operation::Create => 'r',
-            // Mesh ops (#319) — distinct codes; not part of the model-capability
-            // bitmask (`all()`), so these never collide in `check_all`.
+            // Mesh ops (#319) — distinct codes, so they share the `check_all`
+            // bitmask with the model-capability codes without colliding.
             Operation::MeshInvoke => 'e',
             Operation::MeshStage => 'g',
             Operation::MeshDelta => 'd',
@@ -353,7 +353,9 @@ impl Operation {
         }
     }
 
-    /// All operations
+    /// All operations — every enum variant, so `PolicyManager::check_all` can
+    /// report each one. Hand-maintained until #1091 R4a generates the
+    /// vocabulary from the schema; keep in sync with the enum above.
     pub fn all() -> &'static [Operation] {
         &[
             Operation::Infer,
@@ -363,6 +365,14 @@ impl Operation {
             Operation::Serve,
             Operation::Manage,
             Operation::Context,
+            Operation::Subscribe,
+            Operation::Create,
+            Operation::Publish,
+            Operation::Spawn,
+            Operation::MeshInvoke,
+            Operation::MeshStage,
+            Operation::MeshDelta,
+            Operation::MeshStatus,
         ]
     }
 }
@@ -480,11 +490,18 @@ mod tests {
         assert!(matches!("persist.save".parse::<Operation>(), Ok(Operation::Write)));
         assert!(matches!("serve.api".parse::<Operation>(), Ok(Operation::Serve)));
         assert!(matches!("context.augment".parse::<Operation>(), Ok(Operation::Context)));
-        // Verify format!("{}", op).parse() round-trip for every variant
+        // Verify format!("{}", op).parse() round-trip for every variant.
         for op in Operation::all() {
             let displayed = format!("{}", op);
             let parsed: Operation = displayed.parse().expect("round-trip parse failed");
-            assert_eq!(&parsed, op);
+            // `MeshStatus` shares the `query.status` wire action, which parses
+            // back to its canonical owner `Query` by design (see as_str()).
+            let expected = if *op == Operation::MeshStatus {
+                &Operation::Query
+            } else {
+                op
+            };
+            assert_eq!(&parsed, expected);
         }
         assert!(Operation::from_str("foo").is_err());
     }
@@ -511,9 +528,9 @@ mod tests {
         for op in [Operation::MeshInvoke, Operation::MeshStage, Operation::MeshDelta, Operation::MeshStatus] {
             assert_eq!(Operation::from_code(op.code()), Some(op));
         }
-        // Mesh ops are NOT part of the model-capability set.
+        // Mesh ops are part of `all()` so `check_all` can report them (#1096).
         for op in &[Operation::MeshInvoke, Operation::MeshStage, Operation::MeshDelta, Operation::MeshStatus] {
-            assert!(!Operation::all().contains(op));
+            assert!(Operation::all().contains(op));
         }
     }
 
@@ -568,8 +585,12 @@ mod tests {
     #[test]
     fn test_operation_all() {
         let all = Operation::all();
-        assert_eq!(all.len(), 7);
+        // All 15 variants: 11 core + 4 mesh (#319). Regression guard for #1096 —
+        // `all()` omitted 8 variants, so `check_all` could never report them.
+        assert_eq!(all.len(), 15);
         assert!(all.contains(&Operation::Context));
+        assert!(all.contains(&Operation::Subscribe));
+        assert!(all.contains(&Operation::MeshStatus));
     }
 
     #[test]

--- a/crates/hyprstream/src/auth/mod.rs
+++ b/crates/hyprstream/src/auth/mod.rs
@@ -587,10 +587,27 @@ mod tests {
         let all = Operation::all();
         // All 15 variants: 11 core + 4 mesh (#319). Regression guard for #1096 —
         // `all()` omitted 8 variants, so `check_all` could never report them.
-        assert_eq!(all.len(), 15);
-        assert!(all.contains(&Operation::Context));
-        assert!(all.contains(&Operation::Subscribe));
-        assert!(all.contains(&Operation::MeshStatus));
+        let expected = [
+            Operation::Infer,
+            Operation::Train,
+            Operation::Query,
+            Operation::Write,
+            Operation::Serve,
+            Operation::Manage,
+            Operation::Context,
+            Operation::Subscribe,
+            Operation::Create,
+            Operation::Publish,
+            Operation::Spawn,
+            Operation::MeshInvoke,
+            Operation::MeshStage,
+            Operation::MeshDelta,
+            Operation::MeshStatus,
+        ];
+        assert_eq!(all.len(), expected.len());
+        for op in expected {
+            assert!(all.contains(&op), "Operation::all() is missing {op:?}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #1096.

## Summary

`Operation` has 15 variants, but `Operation::all()` returned only 7. `PolicyManager::check_all` builds its result bitmask by iterating `Operation::all()`, so the 8 omitted variants — `Subscribe`, `Create`, `Publish`, `Spawn`, `MeshInvoke`, `MeshStage`, `MeshDelta`, `MeshStatus` — could never appear in a `check_all` result, regardless of policy. This is the interim fix ahead of #1091 R4a schema codegen of the action vocabulary.

## Fix

`Operation::all()` now returns all 15 variants (`crates/hyprstream/src/auth/mod.rs`), with a rustdoc note that the list is hand-maintained until R4a.

## Caller audit

Every caller of `Operation::all()` / `check_all` was checked (workspace-wide grep), per the issue's instruction:

- **`PolicyManager::check_all`** (`policy_manager.rs:476-487`) — correct as-is once `all()` is complete: all 15 short codes are distinct letters, max shift `'u' - 'a' = 20` < 32 bits, so no bit collisions. `check_all` has **no call sites** outside its definition, so no consumer assumed a 7-bit mask.
- **`test_operation_from_str`** — the Display/parse round-trip over `all()` now reaches `MeshStatus`, which by design shares the `query.status` wire action with `Query` (its canonical parse owner, see `as_str()`). The test asserts that mapping explicitly instead of strict identity.
- **`test_mesh_operation_vocab`** — inverted the now-stale assertion that mesh ops are excluded from `all()`.
- **`test_operation_all`** — `len == 7` → `15`, plus `contains()` checks for previously-omitted variants as a regression guard.
- Updated the two comments that documented the old exclusion (`code()` mesh-code comment, `all()` rustdoc).

## Gates (all green)

- `cargo test -p hyprstream auth:: --lib` — 291 passed, 0 failed
- `cargo clippy -p hyprstream --all-targets -- -D warnings` — clean
- `cargo test -p hyprstream --lib --tests --no-fail-fast` — 1082 passed, 0 failed, 3 ignored (CUDA-env-gated), 19 binaries, exit 0
- Pre-commit hook (release-profile workspace clippy, mirrors CI) — passed

(Rebased onto `origin/main` @ ffed49aa4; no overlap with the 4 new main commits.)