### PR TITLE
security(xet): enforce bootstrap-grant authorizer on GET /get_xorb/{hash}/ (#1094)

### DIFF
--- a/crates/hyprstream/src/services/xet.rs
+++ b/crates/hyprstream/src/services/xet.rs
@@ -35,17 +35,23 @@
 //! The HF `/get_xorb/{hash}/` route carries a *xorb hash* and **no `grantRepo`**,
 //! so it cannot be mapped onto the registry's `getBlob` (which is file-merkle +
 //! `grantRepo` and enforces per-repo entitlement — "the hash is not a
-//! capability"). #813 moves this route behind the Subject-threaded CAS mount so
-//! the policy boundary is the same `Mount` surface used by namespaces. The
-//! remaining work is attaching repo/compartment provenance labels to xorb objects
-//! so the mount can make a full AVC decision instead of the current authenticated
-//! floor.
+//! capability"). #813 moved this route behind the Subject-threaded CAS mount so
+//! the policy boundary is the same `Mount` surface used by namespaces, and
+//! #1094 made that boundary **enforcing**: the mount runs
+//! [`BootstrapCasAuthorizer`], where the day-one grant "any authenticated
+//! subject may read xorb X" is an explicit, audited policy object and
+//! everything else is default-deny — plane #1 of #1091's R4b
+//! compile-and-ratchet MAC rollout. The remaining work is attaching
+//! repo/compartment provenance labels to xorb objects (#699) and flowing
+//! subject clearances (#698) so grant breadth ratchets to 0 and the mount can
+//! make a full AVC decision; the ratchet path is documented on
+//! [`BootstrapCasAuthorizer`].
 
 use crate::config::{TlsConfig, XetConfig};
 use crate::server::AuthenticatedUser;
 use crate::server::tls::{resolve_rustls_config, serve_app};
 use crate::services::RegistryClient;
-use crate::storage::cas::{AllowAllCasAuthorizer, CasMount, CasSubstrate, DedupDomain};
+use crate::storage::cas::{BootstrapCasAuthorizer, CasMount, CasSubstrate, DedupDomain};
 use anyhow::Result;
 use axum::{
     Router,
@@ -73,7 +79,8 @@ pub const SERVICE_NAME: &str = "xet";
 pub struct XetState {
     /// L1 CAS substrate backing `/get_xorb` reads (shared with the registry's
     /// `getBlob` reconstruction path, #812). HTTP reads go through `CasMount`
-    /// so the authenticated Subject reaches the VFS policy boundary (#813).
+    /// so the authenticated Subject reaches the VFS policy boundary (#813),
+    /// enforced behind the #1094 bootstrap grant.
     pub store: CasSubstrate,
     /// Authenticated registry client — the write path (`/v1/xorbs`, `/v1/shards`)
     /// must translate through its `putBlob` RPC rather than writing directly.
@@ -212,7 +219,10 @@ async fn get_xorb_handler(
     let mount = CasMount::with_authorizer(
         state.store.clone(),
         DedupDomain::local_default(),
-        AllowAllCasAuthorizer,
+        // #1094 plane #1: enforcing authorizer behind the explicit day-one
+        // bootstrap grant ("any authenticated subject may read xorb X"),
+        // default-deny for everything else. Never AllowAll on this route.
+        BootstrapCasAuthorizer::new(),
     );
     let mut fid = match mount.walk(&["xorb", hash.as_str()], &subject).await {
         Ok(fid) => fid,

--- a/crates/hyprstream/src/storage/cas/mod.rs
+++ b/crates/hyprstream/src/storage/cas/mod.rs
@@ -55,8 +55,9 @@ mod substrate;
 pub use domain::{DedupDomain, InvalidDedupDomain, TrustBoundary};
 pub use manifest::{cid_from_merkle, merkle_from_address, BlobManifest, FILE_RECONSTRUCTION_CODEC};
 pub use mount::{
-    AllowAllCasAuthorizer, CasMount, CasMountAuthorizer, CasMountAuthzRequest, CasMountObjectKind,
-    DenyAllCasAuthorizer, StagingConfig, DEFAULT_STAGING_SLOT_QUOTA, DEFAULT_STAGING_SUBJECT_QUOTA,
+    AllowAllCasAuthorizer, BootstrapCasAuthorizer, CasGrantSubject, CasMount, CasMountAuthorizer,
+    CasMountAuthzRequest, CasMountGrant, CasMountObjectKind, DenyAllCasAuthorizer, StagingConfig,
+    AUTHENTICATED_XORB_READ, DEFAULT_STAGING_SLOT_QUOTA, DEFAULT_STAGING_SUBJECT_QUOTA,
 };
 pub use substrate::CasSubstrate;
 

--- a/crates/hyprstream/src/storage/cas/mount.rs
+++ b/crates/hyprstream/src/storage/cas/mount.rs
@@ -45,6 +45,7 @@ use hyprstream_rpc::Subject;
 use hyprstream_vfs::{DirEntry, Fid, Mount, MountError, Stat, ORDWR, OREAD, OTRUNC, OWRITE};
 use parking_lot::Mutex;
 use tokio::sync::Notify;
+use tracing::{debug, warn};
 
 use super::{CasError, CasSubstrate, DedupDomain};
 use crate::mac::ifc_join;
@@ -86,10 +87,11 @@ pub struct CasMountAuthzRequest<'a> {
 
 /// Per-op authorization hook for [`CasMount`].
 ///
-/// The default constructor uses [`DenyAllCasAuthorizer`]. Production namespaces
-/// must inject a real authorizer from #699/#767 provenance and MAC plumbing;
-/// trusted local single-tenant tools can explicitly opt into
-/// [`AllowAllCasAuthorizer`].
+/// The default constructor uses [`DenyAllCasAuthorizer`]. The live XET read
+/// route uses [`BootstrapCasAuthorizer`] (#1094 plane #1: explicit, audited
+/// bootstrap grants, default-deny). As #699/#767 provenance and MAC plumbing
+/// lands, production namespaces move to a real MAC authorizer; trusted local
+/// single-tenant tools can explicitly opt into [`AllowAllCasAuthorizer`].
 pub trait CasMountAuthorizer: Send + Sync {
     fn authorize(
         &self,
@@ -126,6 +128,159 @@ impl CasMountAuthorizer for AllowAllCasAuthorizer {
         _request: CasMountAuthzRequest<'_>,
     ) -> Result<(), MountError> {
         Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Bootstrap-grant authorizer (#1094)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Who a [`CasMountGrant`] applies to — the *subject breadth* axis the #1094
+/// ratchet narrows.
+///
+/// Today there is exactly one breadth: the authenticated floor. Per-compartment
+/// and per-subject variants arrive with #698 (authority-owned subject
+/// clearances) and #699 (object provenance labels); they are deliberately not
+/// modeled yet — see the ratchet path on [`BootstrapCasAuthorizer`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CasGrantSubject {
+    /// Any authenticated (non-anonymous) [`Subject`]. Anonymous callers never
+    /// match: the floor is *authenticated*, not bearerless.
+    AnyAuthenticated,
+}
+
+impl CasGrantSubject {
+    fn accepts(self, caller: &Subject) -> bool {
+        match self {
+            CasGrantSubject::AnyAuthenticated => !caller.is_anonymous(),
+        }
+    }
+}
+
+/// One explicit authorization grant — the unit of policy the
+/// [`BootstrapCasAuthorizer`] evaluates (#1094).
+///
+/// A request matches a grant when the caller is accepted by `subject`, the
+/// request's [`CasMountObjectKind`] is in `kinds`, and its operation string is
+/// in `operations`. A request matching **no** grant is denied (fail-closed).
+///
+/// The shape mirrors the MAC decision it will become — subject breadth ×
+/// object class × operation — so ratcheting toward the #698/#699 dominance
+/// check (`subject.ctx ⊒ object.label` per op) narrows fields of this struct
+/// instead of replacing an incompatible interim model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CasMountGrant {
+    /// Stable audit name emitted with every decision the grant allows.
+    pub name: &'static str,
+    /// Subject breadth.
+    pub subject: CasGrantSubject,
+    /// Object kinds covered.
+    pub kinds: &'static [CasMountObjectKind],
+    /// Operations covered (matched against [`CasMountAuthzRequest::operation`]).
+    pub operations: &'static [&'static str],
+}
+
+/// The day-one bootstrap grant: **"any authenticated subject may read xorb
+/// X"** (#1094). Covers `open` + `read` on [`CasMountObjectKind::Xorb`] only —
+/// `stat`, `obj/*` reads, and every `stage/*` operation stay denied.
+pub const AUTHENTICATED_XORB_READ: CasMountGrant = CasMountGrant {
+    name: "bootstrap:authenticated-xorb-read",
+    subject: CasGrantSubject::AnyAuthenticated,
+    kinds: &[CasMountObjectKind::Xorb],
+    operations: &["open", "read"],
+};
+
+/// Enforcing authorizer for the live `GET /get_xorb/{hash}/` surface (#1094):
+/// an explicit bootstrap grant list, default-deny, one audit event per decision.
+///
+/// This is plane #1 of #1091's R4b *compile-and-ratchet* MAC rollout: the route
+/// flips to enforcing on day one behind [`AUTHENTICATED_XORB_READ`], making
+/// today's implicit authenticated floor an explicit, auditable policy object
+/// instead of a silent [`AllowAllCasAuthorizer`].
+///
+/// ## Ratchet path (grant breadth → 0)
+///
+/// The day-one grant is maximally broad on two axes: every authenticated
+/// subject, every xorb address. Ratcheting is a deliberate, reviewable edit of
+/// the grant list, sequenced with the MAC-activation prerequisites:
+///
+/// 1. **#699 lands provenance labels** — repo/compartment `security_label`s on
+///    xorb-bearing manifests (carrier-(b)) give each request a real object
+///    label. Grants can then narrow per-domain, then per-compartment.
+/// 2. **#698 flows subject clearances** — authority-owned `Claims.clearance`
+///    gives the caller a real `SecurityContext`; [`CasGrantSubject`] gains
+///    clearance-bearing variants and the decision becomes dominance
+///    (`subject.ctx ⊒ object.label`) per op.
+/// 3. **Breadth 0** — with labels + clearances live, the grant list empties
+///    (== [`DenyAllCasAuthorizer`]) and this type is retired in favor of the
+///    MAC authorizer on the same [`CasMountAuthorizer`] seam.
+///
+/// That labeling/clearance work is **not** in scope here; only the seam and
+/// the day-one grant are.
+///
+/// Audit: allows log at `debug`, denies at `warn` (denials are
+/// security-relevant). Tamper-evident decision audit (#573,
+/// `crate::mac::audit`) takes over when the MAC authorizer lands.
+#[derive(Debug, Clone)]
+pub struct BootstrapCasAuthorizer {
+    grants: Vec<CasMountGrant>,
+}
+
+impl BootstrapCasAuthorizer {
+    /// The day-one policy (#1094): exactly [`AUTHENTICATED_XORB_READ`].
+    pub fn new() -> Self {
+        Self {
+            grants: vec![AUTHENTICATED_XORB_READ],
+        }
+    }
+
+    /// An explicit grant list — the ratchet knob. Narrow the list as #699
+    /// labels and #698 clearances land; an empty list denies everything
+    /// (equivalent to [`DenyAllCasAuthorizer`]).
+    pub fn with_grants(grants: Vec<CasMountGrant>) -> Self {
+        Self { grants }
+    }
+}
+
+impl Default for BootstrapCasAuthorizer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CasMountAuthorizer for BootstrapCasAuthorizer {
+    fn authorize(
+        &self,
+        caller: &Subject,
+        request: CasMountAuthzRequest<'_>,
+    ) -> Result<(), MountError> {
+        for grant in &self.grants {
+            if grant.subject.accepts(caller)
+                && grant.kinds.contains(&request.kind)
+                && grant.operations.contains(&request.operation)
+            {
+                debug!(
+                    subject = %caller,
+                    grant = grant.name,
+                    kind = ?request.kind,
+                    address = request.address,
+                    operation = request.operation,
+                    "CAS bootstrap grant: allow"
+                );
+                return Ok(());
+            }
+        }
+        warn!(
+            subject = %caller,
+            kind = ?request.kind,
+            address = request.address,
+            operation = request.operation,
+            "CAS bootstrap grant: deny (no matching grant)"
+        );
+        Err(MountError::PermissionDenied(format!(
+            "CAS {} {:?} {} denied for {}: no matching bootstrap grant (#1094)",
+            request.operation, request.kind, request.address, caller
+        )))
     }
 }
 
@@ -1376,6 +1531,113 @@ mod tests {
         let entries = mount.readdir(&fid, &caller).await.unwrap();
         let names: Vec<_> = entries.into_iter().map(|e| e.name).collect();
         assert_eq!(names, vec!["obj", "xorb", "stage"]);
+    }
+
+    // ── bootstrap-grant authorizer (#1094) ─────────────────────────────────
+
+    /// Build a substrate holding one xorb and return it with the xorb hash.
+    async fn substrate_with_xorb(bytes: &[u8]) -> (tempfile::TempDir, CasSubstrate, String) {
+        let dir = tempfile::tempdir().unwrap();
+        let substrate = CasSubstrate::new(dir.path());
+        let manifest = substrate
+            .put(&DedupDomain::local_default(), bytes, None)
+            .await
+            .unwrap();
+        let xorb = manifest.xorb_hashes.first().expect("xorb hash").clone();
+        (dir, substrate, xorb)
+    }
+
+    #[tokio::test]
+    async fn bootstrap_grant_allows_authenticated_xorb_read() {
+        let (_dir, substrate, xorb) = substrate_with_xorb(b"bootstrap-xorb").await;
+        let mount = CasMount::with_authorizer(
+            substrate,
+            DedupDomain::local_default(),
+            BootstrapCasAuthorizer::new(),
+        );
+        let caller = Subject::new("alice");
+
+        let mut fid = mount.walk(&["xorb", &xorb], &caller).await.unwrap();
+        mount.open(&mut fid, OREAD, &caller).await.unwrap();
+        let out = mount.read(&fid, 0, 1024, &caller).await.unwrap();
+
+        assert!(!out.is_empty());
+    }
+
+    #[tokio::test]
+    async fn bootstrap_grant_denies_anonymous_xorb_read() {
+        let (_dir, substrate, xorb) = substrate_with_xorb(b"bootstrap-xorb").await;
+        let mount = CasMount::with_authorizer(
+            substrate,
+            DedupDomain::local_default(),
+            BootstrapCasAuthorizer::new(),
+        );
+        let caller = Subject::anonymous();
+
+        let mut fid = mount.walk(&["xorb", &xorb], &caller).await.unwrap();
+        let err = mount.open(&mut fid, OREAD, &caller).await.unwrap_err();
+
+        assert!(matches!(err, MountError::PermissionDenied(_)));
+    }
+
+    #[tokio::test]
+    async fn bootstrap_grant_denies_obj_reads_and_stage_ops() {
+        let (_dir, substrate, xorb) = substrate_with_xorb(b"bootstrap-xorb").await;
+        let manifest = substrate
+            .put(&DedupDomain::local_default(), b"obj-bytes", None)
+            .await
+            .unwrap();
+        let mount = CasMount::with_authorizer(
+            substrate,
+            DedupDomain::local_default(),
+            BootstrapCasAuthorizer::new(),
+        );
+        let caller = Subject::new("alice");
+
+        // obj/* reads are outside the day-one grant.
+        let mut fid = mount
+            .walk(&["obj", &manifest.cid], &caller)
+            .await
+            .unwrap();
+        let err = mount.open(&mut fid, OREAD, &caller).await.unwrap_err();
+        assert!(matches!(err, MountError::PermissionDenied(_)));
+
+        // stat on a xorb is outside the grant (open + read only).
+        let fid = mount.walk(&["xorb", &xorb], &caller).await.unwrap();
+        let err = mount.stat(&fid, &caller).await.unwrap_err();
+        assert!(matches!(err, MountError::PermissionDenied(_)));
+
+        // stage/* ingest is outside the grant.
+        let mut root = mount.walk(&["stage"], &caller).await.unwrap();
+        let err = mount
+            .create(&mut root, "new", 0o600, OWRITE, &caller)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, MountError::PermissionDenied(_)));
+    }
+
+    #[test]
+    fn bootstrap_grant_list_ratchets_to_deny_all() {
+        // The ratchet terminus: an empty grant list denies even the day-one
+        // xorb read, equivalent to DenyAllCasAuthorizer.
+        let authz = BootstrapCasAuthorizer::with_grants(Vec::new());
+        let domain = DedupDomain::local_default();
+        let request = CasMountAuthzRequest {
+            kind: CasMountObjectKind::Xorb,
+            address: "aa00",
+            domain: &domain,
+            operation: "read",
+        };
+        let err = authz.authorize(&Subject::new("alice"), request).unwrap_err();
+        assert!(matches!(err, MountError::PermissionDenied(_)));
+    }
+
+    #[test]
+    fn bootstrap_day_one_grant_matches_exactly_xorb_open_read() {
+        let grant = AUTHENTICATED_XORB_READ;
+        assert_eq!(grant.subject, CasGrantSubject::AnyAuthenticated);
+        assert_eq!(grant.kinds, &[CasMountObjectKind::Xorb]);
+        assert_eq!(grant.operations, &["open", "read"]);
     }
 
     // ── write-then-seal (#814) ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #1094. Plane #1 of #1091's R4b *compile-and-ratchet* MAC rollout: the live `GET /get_xorb/{hash}/` handler no longer builds its `CasMount` with `AllowAllCasAuthorizer`. It now runs a new **`BootstrapCasAuthorizer`** — an enforcing, default-deny authorizer driven by an explicit grant list.

- **Day-one grant** (`AUTHENTICATED_XORB_READ`): "any authenticated subject may read xorb X" — `open` + `read` on `CasMountObjectKind::Xorb` only. Today's implicit authenticated floor becomes an explicit, auditable policy object instead of a silent allow-all.
- **Everything else denies**: `stat`, `obj/*` reads, and every `stage/*` ingest op are outside the grant (previously silently allowed by `AllowAll` on this route).
- **Auditable**: one tracing event per decision (allow at `debug`, deny at `warn`) carrying subject, grant name, object kind, address, and operation.
- **MAC-consistent shape**: a grant is (subject breadth × object kind × operation), mirroring the `subject.ctx ⊒ object.label` dominance decision it becomes under #698/#699 — no incompatible interim authorizer. Anonymous subjects never match (`Subject::is_anonymous` checked in the grant itself, defense-in-depth behind the JWT middleware).

## Ratchet path (grant breadth → 0)

Documented on `BootstrapCasAuthorizer` (and in the `xet.rs` module docs):

1. **#699 lands provenance labels** — repo/compartment `security_label`s on xorb-bearing manifests (carrier-(b)) give each request a real object label; grants then narrow per-domain, then per-compartment.
2. **#698 flows subject clearances** — authority-owned `Claims.clearance` gives the caller a real `SecurityContext`; `CasGrantSubject` gains clearance-bearing variants and the decision becomes MAC dominance per op.
3. **Breadth 0** — the grant list empties (`with_grants(vec![])` ≡ `DenyAllCasAuthorizer`) and this type retires in favor of the MAC authorizer on the same `CasMountAuthorizer` seam. Tamper-evident audit (#573, `crate::mac::audit`) takes over from the tracing events.

The labeling/clearance work itself is deliberately **not** in scope (per the issue).

## Tests / gates

New tests in `storage::cas::mount`:

- `bootstrap_grant_allows_authenticated_xorb_read` — the day-one grant serves a real xorb read end-to-end.
- `bootstrap_grant_denies_anonymous_xorb_read` — the floor is authenticated, not bearerless.
- `bootstrap_grant_denies_obj_reads_and_stage_ops` — obj open, xorb stat, and stage create all deny.
- `bootstrap_grant_list_ratchets_to_deny_all` — empty grant list ≡ DenyAll (ratchet terminus).
- `bootstrap_day_one_grant_matches_exactly_xorb_open_read` — pins the grant's shape.

Existing `xet.rs` handler tests (happy path, Range, 401) pass unchanged against the enforcing authorizer.

- `cargo test -p hyprstream --lib` — **1052 passed, 0 failed** (36 cas::mount/xet-focused, incl. 5 new).
- `cargo clippy -p hyprstream --all-targets -- -D warnings` — clean.
- Pre-commit hook (workspace clippy, mirrors CI) — passed.
- `cargo deny check bans licenses` — ok.
- `cargo doc -p hyprstream --no-deps` — builds; rustdoc warnings are pre-existing (none from these files).

Refs: #654 (authenticated XET read+write epic), #698 / #699 (MAC-activation prerequisites — context, not blockers), #1091 R4b.