### PR TITLE
fix(xet): preserve Merkle hash domain in P2P storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7121,6 +7121,7 @@ dependencies = [
  "git2",
  "glob",
  "hex",
+ "hyprstream-rpc",
  "iroh-blobs",
  "mainline",
  "multihash",

--- a/crates/git-xet-filter/src/gittorrent_storage.rs
+++ b/crates/git-xet-filter/src/gittorrent_storage.rs
@@ -1,7 +1,8 @@
 //! GittorrentStorage — StorageBackend implementation for P2P distribution.
 //!
 //! Fetches XET objects via gittorrent's DHT network with fallback to HTTPS origin.
-//! MerkleHash (32-byte SHA256) maps directly to gittorrent's Sha256Hash.
+//! XET `MerkleHash` values cross into hyprstream-p2p as self-describing CIDs;
+//! they are never reinterpreted as SHA-256.
 
 #[cfg(feature = "xet-storage")]
 use async_trait::async_trait;
@@ -9,6 +10,51 @@ use std::path::Path;
 use std::sync::Arc;
 
 use crate::error::{Result, XetError, XetErrorKind};
+
+const XET_MERKLE_FIELD: &str = "xet-merkle";
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct GittorrentPointer {
+    xet: String,
+    #[serde(rename = "xet-merkle")]
+    xet_merkle: String,
+    sha256: String,
+    size: u64,
+}
+
+impl GittorrentPointer {
+    fn parse(pointer: &str) -> Result<Self> {
+        let parsed: Self = serde_json::from_str(pointer).map_err(|e| {
+            XetError::new(
+                XetErrorKind::InvalidPointer,
+                format!("Invalid gittorrent pointer: {e}"),
+            )
+        })?;
+        if parsed.xet != "gittorrent" {
+            return Err(XetError::new(
+                XetErrorKind::InvalidPointer,
+                "Pointer is not a gittorrent XET pointer",
+            ));
+        }
+        parsed.merkle_hash()?;
+        hyprstream_p2p::Sha256Hash::new(&parsed.sha256).map_err(|e| {
+            XetError::new(
+                XetErrorKind::InvalidPointer,
+                format!("Invalid sha256 field: {e}"),
+            )
+        })?;
+        Ok(parsed)
+    }
+
+    fn merkle_hash(&self) -> Result<merklehash::MerkleHash> {
+        merklehash::MerkleHash::from_hex(&self.xet_merkle).map_err(|e| {
+            XetError::new(
+                XetErrorKind::InvalidPointer,
+                format!("Invalid {XET_MERKLE_FIELD} field: {e}"),
+            )
+        })
+    }
+}
 
 /// P2P storage backend using gittorrent DHT.
 ///
@@ -39,30 +85,67 @@ impl super::storage::StorageBackend for GittorrentStorage {
     async fn clean_file(&self, path: &Path) -> Result<String> {
         // Read file and delegate to clean_bytes
         let data = tokio::fs::read(path).await.map_err(|e| {
-            XetError::new(XetErrorKind::IoError, format!("Failed to read {}: {e}", path.display()))
+            XetError::new(
+                XetErrorKind::IoError,
+                format!("Failed to read {}: {e}", path.display()),
+            )
         })?;
         self.clean_bytes(&data).await
     }
 
     fn is_pointer(&self, content: &str) -> bool {
-        // Only match gittorrent-specific pointers, not standard XET pointers
-        content.contains("\"xet\":\"gittorrent\"") || content.contains("\"xet\": \"gittorrent\"")
+        GittorrentPointer::parse(content).is_ok()
     }
 
     async fn clean_bytes(&self, data: &[u8]) -> Result<String> {
-        // Store in gittorrent DHT
-        let hash = self
-            .service
-            .put_object(data.to_vec())
+        // XET's keyed-BLAKE3 Merkle root cannot be derived from the raw-file
+        // SHA-256. Let the XET origin perform the real clean operation, then
+        // carry that root into the P2P key and pointer extension verbatim.
+        let fallback = self.fallback.as_ref().ok_or_else(|| {
+            XetError::new(
+                XetErrorKind::UploadFailed,
+                "gittorrent clean requires an XET origin to compute xet-merkle",
+            )
+        })?;
+        let xet_pointer = fallback.clean_bytes(data).await?;
+        let xet_info: data::XetFileInfo = serde_json::from_str(&xet_pointer).map_err(|e| {
+            XetError::new(
+                XetErrorKind::InvalidPointer,
+                format!("XET origin returned an invalid pointer: {e}"),
+            )
+        })?;
+        let merkle = xet_info.merkle_hash().map_err(|e| {
+            XetError::new(
+                XetErrorKind::InvalidPointer,
+                format!("XET origin returned an invalid Merkle hash: {e}"),
+            )
+        })?;
+        let cid = hyprstream_p2p::ContentCid::xet_merkle(merkle.as_bytes()).map_err(|e| {
+            XetError::new(
+                XetErrorKind::UploadFailed,
+                format!("CID encoding failed: {e}"),
+            )
+        })?;
+
+        self.service
+            .put_object_by_cid(cid, data.to_vec())
             .await
             .map_err(|e| XetError::new(XetErrorKind::UploadFailed, e.to_string()))?;
 
-        // Return a pointer referencing the SHA256 hash
-        Ok(format!(
-            r#"{{"xet":"gittorrent","sha256":"{}","size":{}}}"#,
-            hash.as_str(),
-            data.len()
-        ))
+        let sha256 = hyprstream_p2p::crypto::hash::sha256_git(data)
+            .map_err(|e| XetError::new(XetErrorKind::UploadFailed, e.to_string()))?;
+        serde_json::to_string(&GittorrentPointer {
+            xet: "gittorrent".to_owned(),
+            xet_merkle: merkle.to_string(),
+            sha256: sha256.to_string(),
+            size: data.len() as u64,
+        })
+        .map_err(|e| {
+            XetError::new(
+                XetErrorKind::InvalidPointer,
+                format!("Failed to serialize gittorrent pointer: {e}"),
+            )
+        })
     }
 
     async fn smudge_file(&self, pointer: &str, output_path: &Path) -> Result<()> {
@@ -76,22 +159,46 @@ impl super::storage::StorageBackend for GittorrentStorage {
     }
 
     async fn smudge_bytes(&self, pointer: &str) -> Result<Vec<u8>> {
-        // Parse hash from pointer JSON
-        let hash = parse_sha256_from_pointer(pointer)?;
-        let merkle = merklehash::MerkleHash::from_hex(&hash).map_err(|e| {
-            XetError::new(XetErrorKind::InvalidPointer, format!("Invalid hash: {e}"))
+        let pointer = GittorrentPointer::parse(pointer)?;
+        let merkle = pointer.merkle_hash()?;
+        let data = self.smudge_from_hash(&merkle).await?;
+        if data.len() as u64 != pointer.size {
+            return Err(XetError::new(
+                XetErrorKind::DownloadFailed,
+                format!(
+                    "Size mismatch: expected {}, got {}",
+                    pointer.size,
+                    data.len()
+                ),
+            ));
+        }
+        let expected = hyprstream_p2p::Sha256Hash::new(pointer.sha256).map_err(|e| {
+            XetError::new(
+                XetErrorKind::InvalidPointer,
+                format!("Invalid sha256 field: {e}"),
+            )
         })?;
-        self.smudge_from_hash(&merkle).await
+        if !hyprstream_p2p::crypto::hash::verify_sha256(&data, &expected)
+            .map_err(|e| XetError::new(XetErrorKind::DownloadFailed, e.to_string()))?
+        {
+            return Err(XetError::new(
+                XetErrorKind::DownloadFailed,
+                "SHA-256 validation failed for gittorrent object",
+            ));
+        }
+        Ok(data)
     }
 
     async fn smudge_from_hash(&self, hash: &merklehash::MerkleHash) -> Result<Vec<u8>> {
-        // MerkleHash is 32-byte SHA256, same as hyprstream_p2p::Sha256Hash
-        let gt_hash = hyprstream_p2p::Sha256Hash::from_bytes(hash.as_bytes()).map_err(|e| {
-            XetError::new(XetErrorKind::DownloadFailed, format!("Hash conversion: {e}"))
+        let cid = hyprstream_p2p::ContentCid::xet_merkle(hash.as_bytes()).map_err(|e| {
+            XetError::new(
+                XetErrorKind::DownloadFailed,
+                format!("CID encoding failed: {e}"),
+            )
         })?;
 
         // Try P2P first
-        match self.service.get_object(&gt_hash).await {
+        match self.service.get_object_by_cid(&cid).await {
             Ok(Some(data)) => return Ok(data),
             Ok(None) => {
                 tracing::debug!("Object {} not found in DHT, trying fallback", hash);
@@ -103,7 +210,11 @@ impl super::storage::StorageBackend for GittorrentStorage {
 
         // Fallback to HTTPS origin
         if let Some(ref fb) = self.fallback {
-            return fb.smudge_from_hash(hash).await;
+            let data = fb.smudge_from_hash(hash).await?;
+            if let Err(e) = self.service.put_object_by_cid(cid, data.clone()).await {
+                tracing::warn!("Failed to cache XET object in gittorrent: {e}");
+            }
+            return Ok(data);
         }
 
         Err(XetError::new(
@@ -127,37 +238,29 @@ impl super::storage::StorageBackend for GittorrentStorage {
     }
 }
 
-/// Extract SHA256 hash from a pointer JSON string.
-fn parse_sha256_from_pointer(pointer: &str) -> Result<String> {
-    // Simple extraction without pulling in a JSON parser dependency
-    // Format: {"xet":"gittorrent","sha256":"<hex>","size":<n>}
-    let start = pointer.find("\"sha256\":\"").ok_or_else(|| {
-        XetError::new(XetErrorKind::InvalidPointer, "Missing sha256 field")
-    })? + 10;
-    let end = pointer[start..].find('"').ok_or_else(|| {
-        XetError::new(XetErrorKind::InvalidPointer, "Unterminated sha256 value")
-    })? + start;
-    Ok(pointer[start..end].to_string())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_parse_sha256_from_pointer() -> Result<()> {
-        let pointer =
-            r#"{"xet":"gittorrent","sha256":"a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2","size":1024}"#;
-        let hash = parse_sha256_from_pointer(pointer)?;
+    fn test_parse_pointer_carries_distinct_hash_domains() -> Result<()> {
+        let pointer = r#"{"xet":"gittorrent","xet-merkle":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef","sha256":"abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789","size":1024}"#;
+        let parsed = GittorrentPointer::parse(pointer)?;
         assert_eq!(
-            hash,
-            "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+            parsed.xet_merkle,
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        );
+        assert_eq!(
+            parsed.sha256,
+            "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
         );
         Ok(())
     }
 
     #[test]
     fn test_parse_invalid_pointer() {
-        assert!(parse_sha256_from_pointer("not a pointer").is_err());
+        assert!(GittorrentPointer::parse("not a pointer").is_err());
+        let legacy = r#"{"xet":"gittorrent","sha256":"abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789","size":1}"#;
+        assert!(GittorrentPointer::parse(legacy).is_err());
     }
 }

--- a/crates/git-xet-filter/src/gittorrent_storage.rs
+++ b/crates/git-xet-filter/src/gittorrent_storage.rs
@@ -161,7 +161,7 @@ impl super::storage::StorageBackend for GittorrentStorage {
     async fn smudge_bytes(&self, pointer: &str) -> Result<Vec<u8>> {
         let pointer = GittorrentPointer::parse(pointer)?;
         let merkle = pointer.merkle_hash()?;
-        let data = self.smudge_from_hash(&merkle).await?;
+        let (data, uncommitted) = self.fetch_from_hash(&merkle).await?;
         if data.len() as u64 != pointer.size {
             return Err(XetError::new(
                 XetErrorKind::DownloadFailed,
@@ -186,10 +186,35 @@ impl super::storage::StorageBackend for GittorrentStorage {
                 "SHA-256 validation failed for gittorrent object",
             ));
         }
+        if uncommitted {
+            // The bytes passed the pointer's end-to-end size + SHA-256 checks;
+            // only now is it safe to bind them to the Merkle CID in the p2p
+            // object plane (a Merkle CID cannot verify raw bytes on its own).
+            let cid = hyprstream_p2p::ContentCid::xet_merkle(merkle.as_bytes()).map_err(|e| {
+                XetError::new(
+                    XetErrorKind::DownloadFailed,
+                    format!("CID encoding failed: {e}"),
+                )
+            })?;
+            if let Err(e) = self.service.put_object_by_cid(cid, data.clone()).await {
+                tracing::warn!("Failed to cache XET object in gittorrent: {e}");
+            }
+        }
         Ok(data)
     }
 
     async fn smudge_from_hash(&self, hash: &merklehash::MerkleHash) -> Result<Vec<u8>> {
+        // Hash-only callers carry no pointer metadata (size, SHA-256) to
+        // validate against, so fetched bytes are never committed to the p2p
+        // plane on this path — only `smudge_bytes` caches, after validation.
+        Ok(self.fetch_from_hash(hash).await?.0)
+    }
+
+    /// Fetch reconstruction bytes for a Merkle hash without committing any
+    /// CID binding. The returned flag is `true` when the bytes did not come
+    /// from the already-validated local p2p store and should be persisted by
+    /// the caller only after end-to-end validation.
+    async fn fetch_from_hash(&self, hash: &merklehash::MerkleHash) -> Result<(Vec<u8>, bool)> {
         let cid = hyprstream_p2p::ContentCid::xet_merkle(hash.as_bytes()).map_err(|e| {
             XetError::new(
                 XetErrorKind::DownloadFailed,
@@ -199,7 +224,7 @@ impl super::storage::StorageBackend for GittorrentStorage {
 
         // Try P2P first
         match self.service.get_object_by_cid(&cid).await {
-            Ok(Some(data)) => return Ok(data),
+            Ok(Some(data)) => return Ok((data, false)),
             Ok(None) => {
                 tracing::debug!("Object {} not found in DHT, trying fallback", hash);
             }
@@ -208,13 +233,11 @@ impl super::storage::StorageBackend for GittorrentStorage {
             }
         }
 
-        // Fallback to HTTPS origin
+        // Fallback to HTTPS origin; caching is deferred to the caller until
+        // the pointer's size and SHA-256 checks pass.
         if let Some(ref fb) = self.fallback {
             let data = fb.smudge_from_hash(hash).await?;
-            if let Err(e) = self.service.put_object_by_cid(cid, data.clone()).await {
-                tracing::warn!("Failed to cache XET object in gittorrent: {e}");
-            }
-            return Ok(data);
+            return Ok((data, true));
         }
 
         Err(XetError::new(

--- a/crates/git-xet-filter/src/gittorrent_storage.rs
+++ b/crates/git-xet-filter/src/gittorrent_storage.rs
@@ -80,6 +80,45 @@ impl GittorrentStorage {
 }
 
 #[cfg(feature = "xet-storage")]
+impl GittorrentStorage {
+    /// Fetch reconstruction bytes for a Merkle hash without committing any
+    /// CID binding. The returned flag is `true` when the bytes did not come
+    /// from the already-validated local p2p store and should be persisted by
+    /// the caller only after end-to-end validation.
+    async fn fetch_from_hash(&self, hash: &merklehash::MerkleHash) -> Result<(Vec<u8>, bool)> {
+        let cid = hyprstream_p2p::ContentCid::xet_merkle(hash.as_bytes()).map_err(|e| {
+            XetError::new(
+                XetErrorKind::DownloadFailed,
+                format!("CID encoding failed: {e}"),
+            )
+        })?;
+
+        // Try P2P first
+        match self.service.get_object_by_cid(&cid).await {
+            Ok(Some(data)) => return Ok((data, false)),
+            Ok(None) => {
+                tracing::debug!("Object {} not found in DHT, trying fallback", hash);
+            }
+            Err(e) => {
+                tracing::warn!("DHT fetch failed for {}: {e}", hash);
+            }
+        }
+
+        // Fallback to HTTPS origin; caching is deferred to the caller until
+        // the pointer's size and SHA-256 checks pass.
+        if let Some(ref fb) = self.fallback {
+            let data = fb.smudge_from_hash(hash).await?;
+            return Ok((data, true));
+        }
+
+        Err(XetError::new(
+            XetErrorKind::DownloadFailed,
+            format!("Object {hash} not found in DHT or fallback"),
+        ))
+    }
+}
+
+#[cfg(feature = "xet-storage")]
 #[async_trait]
 impl super::storage::StorageBackend for GittorrentStorage {
     async fn clean_file(&self, path: &Path) -> Result<String> {
@@ -208,42 +247,6 @@ impl super::storage::StorageBackend for GittorrentStorage {
         // validate against, so fetched bytes are never committed to the p2p
         // plane on this path — only `smudge_bytes` caches, after validation.
         Ok(self.fetch_from_hash(hash).await?.0)
-    }
-
-    /// Fetch reconstruction bytes for a Merkle hash without committing any
-    /// CID binding. The returned flag is `true` when the bytes did not come
-    /// from the already-validated local p2p store and should be persisted by
-    /// the caller only after end-to-end validation.
-    async fn fetch_from_hash(&self, hash: &merklehash::MerkleHash) -> Result<(Vec<u8>, bool)> {
-        let cid = hyprstream_p2p::ContentCid::xet_merkle(hash.as_bytes()).map_err(|e| {
-            XetError::new(
-                XetErrorKind::DownloadFailed,
-                format!("CID encoding failed: {e}"),
-            )
-        })?;
-
-        // Try P2P first
-        match self.service.get_object_by_cid(&cid).await {
-            Ok(Some(data)) => return Ok((data, false)),
-            Ok(None) => {
-                tracing::debug!("Object {} not found in DHT, trying fallback", hash);
-            }
-            Err(e) => {
-                tracing::warn!("DHT fetch failed for {}: {e}", hash);
-            }
-        }
-
-        // Fallback to HTTPS origin; caching is deferred to the caller until
-        // the pointer's size and SHA-256 checks pass.
-        if let Some(ref fb) = self.fallback {
-            let data = fb.smudge_from_hash(hash).await?;
-            return Ok((data, true));
-        }
-
-        Err(XetError::new(
-            XetErrorKind::DownloadFailed,
-            format!("Object {hash} not found in DHT or fallback"),
-        ))
     }
 
     async fn smudge_from_hash_to_file(

--- a/crates/hyprstream-p2p/Cargo.toml
+++ b/crates/hyprstream-p2p/Cargo.toml
@@ -65,6 +65,7 @@ tempfile = "3.0"
 
 # XET integration dependencies
 async-trait = "0.1"
+hyprstream-rpc = { path = "../hyprstream-rpc" }
 
 # Mainline (BEP5) DHT locator for did:at9p (#889, epic #880 Track C) — the
 # untrusted rendezvous plane for the iroh-blobs object facade (F3, #901).

--- a/crates/hyprstream-p2p/src/blobs.rs
+++ b/crates/hyprstream-p2p/src/blobs.rs
@@ -170,10 +170,14 @@ impl IrohBlobStore {
             }
             Some(_) => {}
             None => {
-                index.insert(cid.clone(), tag.hash);
+                // Persist the sidecar entry before publishing the in-memory
+                // binding: if the append fails after an insert, a retry would
+                // hit the `Some(_)` arm above and never re-attempt the append,
+                // losing the mapping across restarts.
                 if let Some(path) = &self.index_path {
                     append_index_entry(path, &cid, &tag.hash).await?;
                 }
+                index.insert(cid.clone(), tag.hash);
             }
         }
         drop(index);

--- a/crates/hyprstream-p2p/src/blobs.rs
+++ b/crates/hyprstream-p2p/src/blobs.rs
@@ -6,25 +6,25 @@
 //! git-xet-filter and git2db:
 //!
 //! ```text
-//! put_object(Vec<u8>)      -> Sha256Hash
-//! get_object(&Sha256Hash)  -> Option<Vec<u8>>
+//! put_object(Vec<u8>)              -> Sha256Hash
+//! get_object(&Sha256Hash)          -> Option<Vec<u8>>
+//! put_object_by_cid(ContentCid, ..) -> ()
+//! get_object_by_cid(&ContentCid)    -> Option<Vec<u8>>
 //! ```
 //!
-//! # SHA256 ↔ BLAKE3 bridge
+//! # CID → BLAKE3 locator index
 //!
-//! iroh-blobs addresses content by BLAKE3, while the consumer contract is
-//! keyed by SHA256 (XET `MerkleHash` maps 1:1 onto `Sha256Hash`). Rather than
-//! re-keying the consumers, this module keeps the SHA256 facade and maintains
-//! a `sha256 → blake3` index at put time — the facade-preserving shape the
-//! epic ratified. The index is a *locator only*, never a trust root: bytes
-//! fetched through it are BLAKE3-verified by iroh-blobs on read and then
-//! re-verified here against the requested SHA256, so a corrupted or poisoned
-//! index entry can fail a lookup but can never serve wrong bytes.
+//! iroh-blobs addresses raw bytes by BLAKE3. Consumers address several domains:
+//! raw Git objects use SHA-256, while XET file reconstruction DAGs use a keyed
+//! BLAKE3 `MerkleHash`. Those are carried in a self-describing [`ContentCid`]
+//! and indexed to the raw iroh-blobs hash without collapsing algorithm or
+//! content-domain identity. SHA-256 methods remain compatibility wrappers that
+//! construct a `git-raw + sha2-256` CID.
 //!
 //! For the persistent (`FsStore`) backend the index is an append-only sidecar
-//! file (`sha256-blake3.index`, one `sha256hex blake3hex` line per object)
-//! loaded at open. Malformed or unverifiable lines are skipped with a warning
-//! (the object merely becomes unreachable via SHA256 until re-put).
+//! file (`sha256-blake3.index`, one `cid blake3hex` line per object) loaded at
+//! open. Legacy `sha256hex blake3hex` entries are upgraded in memory to a Git
+//! object CID. Malformed entries are skipped with a warning.
 //!
 //! # Scope
 //!
@@ -43,7 +43,7 @@ use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
 
 use crate::crypto::hash::{sha256_git, verify_sha256};
-use crate::{Error, Result, Sha256Hash};
+use crate::{ContentCid, Error, Result, Sha256Hash};
 
 /// Sidecar index file name (relative to the `FsStore` root).
 const INDEX_FILE: &str = "sha256-blake3.index";
@@ -62,13 +62,13 @@ impl Backend {
     }
 }
 
-/// Content-addressed object store backed by iroh-blobs, keyed by SHA256.
+/// Content-addressed object store backed by iroh-blobs, keyed by canonical CIDs.
 ///
-/// See the module docs for the SHA256 ↔ BLAKE3 bridging model.
+/// See the module docs for the CID → BLAKE3 locator model.
 pub struct IrohBlobStore {
     backend: Backend,
-    /// sha256 → blake3 mapping (locator only — reads re-verify SHA256).
-    index: Mutex<HashMap<Sha256Hash, Blake3Hash>>,
+    /// canonical content CID → raw-byte BLAKE3 mapping (locator only).
+    index: Mutex<HashMap<ContentCid, Blake3Hash>>,
     /// Append-only index persistence (fs backend only).
     index_path: Option<PathBuf>,
 }
@@ -86,7 +86,7 @@ impl IrohBlobStore {
     /// Open (or create) a persistent store rooted at `root`.
     ///
     /// Blob bytes live in the iroh-blobs `FsStore` under `root`; the
-    /// sha256→blake3 index is an append-only sidecar file next to it.
+    /// CID→blake3 index is an append-only sidecar file next to it.
     pub async fn open_fs(root: impl AsRef<Path>) -> Result<Self> {
         let root = root.as_ref();
         tokio::fs::create_dir_all(root).await?;
@@ -107,11 +107,12 @@ impl IrohBlobStore {
     /// Store an object, returning its SHA256 hash (the consumer-facing key).
     ///
     /// The bytes are added to the iroh-blobs store (BLAKE3-addressed, tagged
-    /// so garbage collection cannot reclaim them) and the sha256→blake3
+    /// so garbage collection cannot reclaim them) and the Git CID→blake3
     /// mapping is recorded.
     pub async fn put_object(&self, data: Vec<u8>) -> Result<Sha256Hash> {
         let sha256 = sha256_git(&data)?;
-        self.put_verified_object(sha256, data).await
+        self.put_verified_object(sha256.clone(), data).await?;
+        Ok(sha256)
     }
 
     /// Store bytes under an expected SHA256 key after re-verifying them.
@@ -130,6 +131,28 @@ impl IrohBlobStore {
             )));
         }
 
+        let cid = ContentCid::git_sha256(&expected_sha256)?;
+        self.put_object_by_cid(cid, data).await?;
+        Ok(expected_sha256)
+    }
+
+    /// Store bytes under an algorithm-preserving content CID.
+    ///
+    /// Raw Git SHA-256 CIDs are re-verified against the bytes here. An XET
+    /// Merkle CID addresses the reconstruction DAG rather than the raw file,
+    /// so its binding is established by the XET clean operation and the LFS
+    /// SHA-256 remains the end-to-end raw-file integrity check.
+    pub async fn put_object_by_cid(&self, cid: ContentCid, data: Vec<u8>) -> Result<()> {
+        verify_raw_cid_when_applicable(&cid, &data)?;
+        let raw_hash = Blake3Hash::new(&data);
+        if let Some(existing) = self.index.lock().await.get(&cid).copied() {
+            if existing != raw_hash {
+                return Err(Error::other(format!(
+                    "content CID {cid} is already bound to a different raw blob"
+                )));
+            }
+        }
+
         let tag = self
             .backend
             .store()
@@ -139,19 +162,24 @@ impl IrohBlobStore {
             .map_err(|e| Error::other(format!("iroh-blobs add failed: {e}")))?;
 
         let mut index = self.index.lock().await;
-        if index.insert(expected_sha256.clone(), tag.hash).is_none() {
-            if let Some(path) = &self.index_path {
-                append_index_entry(path, &expected_sha256, &tag.hash).await?;
+        match index.get(&cid) {
+            Some(existing) if *existing != tag.hash => {
+                return Err(Error::other(format!(
+                    "content CID {cid} is already bound to a different raw blob"
+                )));
+            }
+            Some(_) => {}
+            None => {
+                index.insert(cid.clone(), tag.hash);
+                if let Some(path) = &self.index_path {
+                    append_index_entry(path, &cid, &tag.hash).await?;
+                }
             }
         }
         drop(index);
 
-        tracing::debug!(
-            "stored object sha256={} blake3={}",
-            expected_sha256,
-            tag.hash
-        );
-        Ok(expected_sha256)
+        tracing::debug!(content_cid = %cid, blake3 = %tag.hash, "stored object");
+        Ok(())
     }
 
     /// Fetch an object by its SHA256 hash.
@@ -160,9 +188,15 @@ impl IrohBlobStore {
     /// index resolves but the retrieved bytes do not hash back to the
     /// requested SHA256 (poisoned/corrupt mapping — never served).
     pub async fn get_object(&self, hash: &Sha256Hash) -> Result<Option<Vec<u8>>> {
+        let cid = ContentCid::git_sha256(hash)?;
+        self.get_object_by_cid(&cid).await
+    }
+
+    /// Fetch an object by its self-describing content CID.
+    pub async fn get_object_by_cid(&self, cid: &ContentCid) -> Result<Option<Vec<u8>>> {
         let blake3 = {
             let index = self.index.lock().await;
-            match index.get(hash) {
+            match index.get(cid) {
                 Some(b3) => *b3,
                 None => return Ok(None),
             }
@@ -173,17 +207,13 @@ impl IrohBlobStore {
             Err(e) => {
                 // Index entry without a backing blob: unreachable object, not
                 // a hard error for a cache-shaped lookup API.
-                tracing::warn!("indexed blob {blake3} missing from store for sha256 {hash}: {e}");
+                tracing::warn!("indexed blob {blake3} missing from store for CID {cid}: {e}");
                 return Ok(None);
             }
         };
 
         let data = bytes.to_vec();
-        if !verify_sha256(&data, hash)? {
-            return Err(Error::other(format!(
-                "sha256 verification failed for object {hash} (index maps to blake3 {blake3})"
-            )));
-        }
+        verify_raw_cid_when_applicable(cid, &data)?;
         Ok(Some(data))
     }
 
@@ -192,15 +222,21 @@ impl IrohBlobStore {
     /// This is the seam F2 (#900) uses to announce/locate providers: the
     /// locator plane finds peers, iroh-blobs transfers by BLAKE3.
     pub async fn blake3_of(&self, hash: &Sha256Hash) -> Option<Blake3Hash> {
-        self.index.lock().await.get(hash).copied()
+        let cid = ContentCid::git_sha256(hash).ok()?;
+        self.blake3_of_cid(&cid).await
     }
 
-    /// Number of SHA256-addressable objects.
+    /// Resolve the raw-byte BLAKE3 hash backing a content CID, if known.
+    pub async fn blake3_of_cid(&self, cid: &ContentCid) -> Option<Blake3Hash> {
+        self.index.lock().await.get(cid).copied()
+    }
+
+    /// Number of CID-addressable objects.
     pub async fn len(&self) -> usize {
         self.index.lock().await.len()
     }
 
-    /// Whether the store has no SHA256-addressable objects.
+    /// Whether the store has no CID-addressable objects.
     pub async fn is_empty(&self) -> bool {
         self.index.lock().await.is_empty()
     }
@@ -220,7 +256,7 @@ impl IrohBlobStore {
 }
 
 /// Load the sidecar index, skipping (with a warning) any malformed lines.
-async fn load_index(path: &Path) -> Result<HashMap<Sha256Hash, Blake3Hash>> {
+async fn load_index(path: &Path) -> Result<HashMap<ContentCid, Blake3Hash>> {
     let mut index = HashMap::new();
     let contents = match tokio::fs::read_to_string(path).await {
         Ok(c) => c,
@@ -233,14 +269,20 @@ async fn load_index(path: &Path) -> Result<HashMap<Sha256Hash, Blake3Hash>> {
         if line.is_empty() {
             continue;
         }
-        let parsed = line.split_once(' ').and_then(|(sha_hex, b3_hex)| {
-            let sha = Sha256Hash::new(sha_hex).ok()?;
+        let parsed = line.split_once(' ').and_then(|(key, b3_hex)| {
+            let cid = ContentCid::new(key)
+                .or_else(|_| {
+                    // Backward compatibility for the original SHA256-only index.
+                    let sha = Sha256Hash::new(key)?;
+                    ContentCid::git_sha256(&sha)
+                })
+                .ok()?;
             let b3 = b3_hex.parse::<Blake3Hash>().ok()?;
-            Some((sha, b3))
+            Some((cid, b3))
         });
         match parsed {
-            Some((sha, b3)) => {
-                index.insert(sha, b3);
+            Some((cid, b3)) => {
+                index.insert(cid, b3);
             }
             None => {
                 tracing::warn!(
@@ -254,17 +296,38 @@ async fn load_index(path: &Path) -> Result<HashMap<Sha256Hash, Blake3Hash>> {
     Ok(index)
 }
 
-/// Append one `sha256hex blake3hex` line to the sidecar index.
-async fn append_index_entry(path: &Path, sha256: &Sha256Hash, blake3: &Blake3Hash) -> Result<()> {
+/// Append one `cid blake3hex` line to the sidecar index.
+async fn append_index_entry(path: &Path, cid: &ContentCid, blake3: &Blake3Hash) -> Result<()> {
     let mut file = tokio::fs::OpenOptions::new()
         .create(true)
         .append(true)
         .open(path)
         .await?;
-    file.write_all(format!("{sha256} {blake3}\n").as_bytes())
+    file.write_all(format!("{cid} {blake3}\n").as_bytes())
         .await?;
     file.flush().await?;
     Ok(())
+}
+
+fn verify_raw_cid_when_applicable(cid: &ContentCid, data: &[u8]) -> Result<()> {
+    let decoded = cid.decoded()?;
+    use hyprstream_rpc::cid::{Codec, HashAlgo};
+
+    match (decoded.codec, decoded.multihash.algo) {
+        (Codec::GitRaw, HashAlgo::Sha2_256) => {
+            let expected = Sha256Hash::from_bytes(&decoded.multihash.digest)?;
+            if !verify_sha256(data, &expected)? {
+                return Err(Error::other(format!(
+                    "sha256 verification failed for Git object CID {cid}"
+                )));
+            }
+            Ok(())
+        }
+        (Codec::XetShard, HashAlgo::Blake3) if decoded.multihash.digest.len() == 32 => Ok(()),
+        (codec, algo) => Err(Error::other(format!(
+            "unsupported object CID domain: codec={codec:?}, algorithm={algo:?}"
+        ))),
+    }
 }
 
 #[cfg(test)]
@@ -336,6 +399,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_xet_cid_cannot_be_rebound_to_different_bytes() -> Result<()> {
+        let store = IrohBlobStore::new_memory();
+        let cid = ContentCid::xet_merkle(&[0x7b; 32])?;
+
+        store
+            .put_object_by_cid(cid.clone(), b"first reconstruction".to_vec())
+            .await?;
+        assert!(store
+            .put_object_by_cid(cid.clone(), b"different reconstruction".to_vec())
+            .await
+            .is_err());
+        assert_eq!(
+            store.get_object_by_cid(&cid).await?.as_deref(),
+            Some(b"first reconstruction".as_slice())
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_fs_persistence_across_reopen() -> Result<()> {
         let dir = TempDir::new()?;
         let data = b"persisted across reopen".to_vec();
@@ -370,21 +452,23 @@ mod tests {
             pair
         };
 
-        // Poison the sidecar: cross-wire a's sha256 to b's blake3.
+        // Poison the sidecar: cross-wire a's Git CID to b's blake3.
         let index_path = dir.path().join(INDEX_FILE);
         let contents = tokio::fs::read_to_string(&index_path).await?;
         let mut b3 = HashMap::new();
         for line in contents.lines() {
-            if let Some((sha, blake)) = line.split_once(' ') {
-                b3.insert(sha.to_owned(), blake.to_owned());
+            if let Some((cid, blake)) = line.split_once(' ') {
+                b3.insert(cid.to_owned(), blake.to_owned());
             }
         }
+        let cid_a = ContentCid::git_sha256(&sha_a)?;
+        let cid_b = ContentCid::git_sha256(&sha_b)?;
         let poisoned = format!(
             "{} {}\n{} {}\n",
-            sha_a,
-            b3[sha_b.as_str()],
-            sha_b,
-            b3[sha_a.as_str()]
+            cid_a,
+            b3[cid_b.as_str()],
+            cid_b,
+            b3[cid_a.as_str()]
         );
         tokio::fs::write(&index_path, poisoned).await?;
 

--- a/crates/hyprstream-p2p/src/service.rs
+++ b/crates/hyprstream-p2p/src/service.rs
@@ -413,6 +413,23 @@ impl GitTorrentService {
         }
 
         if let Some(data) = self.object_plane.fetcher.fetch(cid, providers).await? {
+            // A raw Git CID self-verifies inside `put_object_by_cid`, so
+            // provider bytes can be committed here. A XET Merkle CID addresses
+            // the reconstruction DAG rather than the raw file, so this layer
+            // cannot verify the fetched bytes: return them uncommitted and
+            // leave persistence to the caller, which must validate them
+            // (pointer size + SHA-256) before calling `put_object_by_cid`.
+            let decoded = cid.decoded()?;
+            let self_verifying = matches!(
+                (decoded.codec, decoded.multihash.algo),
+                (
+                    hyprstream_rpc::cid::Codec::GitRaw,
+                    hyprstream_rpc::cid::HashAlgo::Sha2_256
+                )
+            );
+            if !self_verifying {
+                return Ok(Some(data));
+            }
             self.object_plane
                 .blobs
                 .put_object_by_cid(cid.clone(), data.clone())
@@ -1044,6 +1061,48 @@ mod tests {
             Some(data.as_slice())
         );
         assert_eq!(fetcher.calls().await, 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_get_object_returns_remote_xet_bytes_uncommitted() -> crate::error::Result<()> {
+        let temp_dir = TempDir::new()?;
+        let locator = Arc::new(MockObjectLocator::default());
+        let fetcher = Arc::new(MockBlobFetcher::default());
+        let service = GitTorrentService::new_with_object_plane(
+            test_config(temp_dir.path()),
+            locator.clone(),
+            fetcher.clone(),
+        )
+        .await?;
+
+        let data = b"xet reconstruction bytes".to_vec();
+        let cid = ContentCid::xet_merkle(&[0x7f; 32])?;
+        locator
+            .add_provider(
+                locator_cid_from_content(&cid),
+                PeerContact::untrusted(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 6881)),
+            )
+            .await;
+        fetcher.objects.lock().await.insert(cid.clone(), data.clone());
+
+        assert_eq!(
+            service.get_object_by_cid(&cid).await?.as_deref(),
+            Some(data.as_slice())
+        );
+        // A Merkle CID cannot verify raw bytes, so provider bytes must not be
+        // committed to the local store or cache before the caller validates.
+        assert!(service
+            .object_plane
+            .blobs
+            .get_object_by_cid(&cid)
+            .await?
+            .is_none());
+        assert_eq!(
+            service.get_object_by_cid(&cid).await?.as_deref(),
+            Some(data.as_slice())
+        );
+        assert_eq!(fetcher.calls().await, 2, "uncommitted bytes are re-fetched");
         Ok(())
     }
 

--- a/crates/hyprstream-p2p/src/service.rs
+++ b/crates/hyprstream-p2p/src/service.rs
@@ -4,11 +4,10 @@
 //! - Git repository operations using git2
 //! - Content-addressed object storage/transfer via iroh-blobs + the mainline
 //!   locator (the libp2p Kademlia DHT was retired in F3, #901)
-//! - SHA256-based content addressing and distribution
+//! - CID-based content addressing and distribution
 
-#[cfg(test)]
 use crate::crypto::hash::sha256_git;
-use crate::{Error, GitTorrentUrl, Result, Sha256Hash};
+use crate::{ContentCid, Error, GitTorrentUrl, Result, Sha256Hash};
 
 use crate::blobs::IrohBlobStore;
 use crate::locator::{Cid512, MainlineLocator, PeerContact, CID512_LEN};
@@ -217,8 +216,8 @@ pub struct GitTorrentService {
     object_plane: ObjectPlane,
     /// Local repository metadata
     repositories: Arc<RwLock<HashMap<String, RepositoryMetadata>>>,
-    /// Git object cache
-    object_cache: Arc<RwLock<HashMap<Sha256Hash, Vec<u8>>>>,
+    /// Object cache keyed by the complete content CID.
+    object_cache: Arc<RwLock<HashMap<ContentCid, Vec<u8>>>>,
 }
 
 struct ObjectPlane {
@@ -247,11 +246,8 @@ impl ObjectLocator for MainlineLocator {
 
 #[async_trait]
 trait RemoteBlobFetcher: Send + Sync {
-    async fn fetch(
-        &self,
-        hash: &Sha256Hash,
-        providers: Vec<PeerContact>,
-    ) -> Result<Option<Vec<u8>>>;
+    async fn fetch(&self, cid: &ContentCid, providers: Vec<PeerContact>)
+        -> Result<Option<Vec<u8>>>;
 }
 
 #[derive(Debug, Default)]
@@ -277,7 +273,7 @@ impl ObjectLocator for NoopObjectLocator {
 impl RemoteBlobFetcher for IrohMainlineBlobFetcher {
     async fn fetch(
         &self,
-        hash: &Sha256Hash,
+        cid: &ContentCid,
         providers: Vec<PeerContact>,
     ) -> Result<Option<Vec<u8>>> {
         // C2 currently exposes BEP5 socket contacts. The iroh-blobs downloader
@@ -285,7 +281,7 @@ impl RemoteBlobFetcher for IrohMainlineBlobFetcher {
         // point until the locator carries endpoint identity metadata.
         if !providers.is_empty() {
             tracing::debug!(
-                "found {} mainline providers for sha256 {hash}, but endpoint-id fetch is not wired yet",
+                "found {} mainline providers for content CID {cid}, but endpoint-id fetch is not wired yet",
                 providers.len(),
             );
         }
@@ -303,10 +299,12 @@ fn locator_cid_from_blake3(hash: Blake3Hash) -> Cid512 {
     Cid512::from_bytes(cid)
 }
 
-fn locator_cid_from_sha256(hash: &Sha256Hash) -> Cid512 {
+fn locator_cid_from_content(cid: &ContentCid) -> Cid512 {
     let mut hasher = blake3::Hasher::new();
-    hasher.update(b"hyprstream.gittorrent.sha256-facade.locator.v1");
-    hasher.update(&hash.to_bytes());
+    hasher.update(b"hyprstream.gittorrent.content-cid.locator.v1");
+    // Hash the complete canonical CID, including its codec and multihash
+    // algorithm. Equal-width digests from different domains cannot alias.
+    hasher.update(cid.as_str().as_bytes());
 
     let mut cid = [0u8; CID512_LEN];
     hasher.finalize_xof().fill(&mut cid);
@@ -388,33 +386,39 @@ impl GitTorrentService {
 
     /// Get a Git object by SHA256 hash
     pub async fn get_object(&self, hash: &Sha256Hash) -> Result<Option<Vec<u8>>> {
+        let cid = ContentCid::git_sha256(hash)?;
+        self.get_object_by_cid(&cid).await
+    }
+
+    /// Get an object by its canonical content CID.
+    pub async fn get_object_by_cid(&self, cid: &ContentCid) -> Result<Option<Vec<u8>>> {
         // Check local cache first
         {
             let cache = self.object_cache.read().await;
-            if let Some(data) = cache.get(hash) {
+            if let Some(data) = cache.get(cid) {
                 return Ok(Some(data.clone()));
             }
         }
 
-        if let Some(data) = self.object_plane.blobs.get_object(hash).await? {
+        if let Some(data) = self.object_plane.blobs.get_object_by_cid(cid).await? {
             let mut cache = self.object_cache.write().await;
-            cache.insert(hash.clone(), data.clone());
+            cache.insert(cid.clone(), data.clone());
             return Ok(Some(data));
         }
 
-        let cid = locator_cid_from_sha256(hash);
-        let providers = self.object_plane.locator.providers(&cid).await?;
+        let rendezvous = locator_cid_from_content(cid);
+        let providers = self.object_plane.locator.providers(&rendezvous).await?;
         if providers.is_empty() {
             return Ok(None);
         }
 
-        if let Some(data) = self.object_plane.fetcher.fetch(hash, providers).await? {
+        if let Some(data) = self.object_plane.fetcher.fetch(cid, providers).await? {
             self.object_plane
                 .blobs
-                .put_verified_object(hash.clone(), data.clone())
+                .put_object_by_cid(cid.clone(), data.clone())
                 .await?;
             let mut cache = self.object_cache.write().await;
-            cache.insert(hash.clone(), data.clone());
+            cache.insert(cid.clone(), data.clone());
             return Ok(Some(data));
         }
 
@@ -423,29 +427,43 @@ impl GitTorrentService {
 
     /// Store a Git object, returning its SHA256 hash (the consumer-facing key).
     pub async fn put_object(&self, data: Vec<u8>) -> Result<Sha256Hash> {
-        let hash = self.object_plane.blobs.put_object(data.clone()).await?;
+        let hash = sha256_git(&data)?;
+        let cid = ContentCid::git_sha256(&hash)?;
+        self.put_object_by_cid(cid, data).await?;
+        Ok(hash)
+    }
+
+    /// Store an object under a canonical content CID.
+    pub async fn put_object_by_cid(&self, cid: ContentCid, data: Vec<u8>) -> Result<()> {
+        self.object_plane
+            .blobs
+            .put_object_by_cid(cid.clone(), data.clone())
+            .await?;
         let blake3 = self
             .object_plane
             .blobs
-            .blake3_of(&hash)
+            .blake3_of_cid(&cid)
             .await
-            .ok_or_else(|| Error::not_found(format!("missing blake3 index for {hash}")))?;
-        let cid = locator_cid_from_blake3(blake3);
+            .ok_or_else(|| Error::not_found(format!("missing blake3 index for {cid}")))?;
+        let blob_rendezvous = locator_cid_from_blake3(blake3);
 
         if let Some(port) = self.object_plane.announce_port {
-            let facade_cid = locator_cid_from_sha256(&hash);
-            self.object_plane.locator.announce(&cid, Some(port)).await?;
+            let content_rendezvous = locator_cid_from_content(&cid);
             self.object_plane
                 .locator
-                .announce(&facade_cid, Some(port))
+                .announce(&blob_rendezvous, Some(port))
+                .await?;
+            self.object_plane
+                .locator
+                .announce(&content_rendezvous, Some(port))
                 .await?;
         }
 
         let mut cache = self.object_cache.write().await;
-        cache.insert(hash.clone(), data);
+        cache.insert(cid.clone(), data);
 
-        tracing::debug!("Stored object with hash: {}", hash);
-        Ok(hash)
+        tracing::debug!("Stored object with CID: {cid}");
+        Ok(())
     }
 
     /// Store all objects from a repository individually through the object
@@ -876,13 +894,15 @@ mod tests {
 
     #[derive(Default)]
     struct MockBlobFetcher {
-        objects: Mutex<StdHashMap<Sha256Hash, Vec<u8>>>,
+        objects: Mutex<StdHashMap<ContentCid, Vec<u8>>>,
         calls: Mutex<usize>,
     }
 
     impl MockBlobFetcher {
-        async fn insert(&self, hash: Sha256Hash, data: Vec<u8>) {
-            self.objects.lock().await.insert(hash, data);
+        async fn insert(&self, hash: Sha256Hash, data: Vec<u8>) -> Result<()> {
+            let cid = ContentCid::git_sha256(&hash)?;
+            self.objects.lock().await.insert(cid, data);
+            Ok(())
         }
 
         async fn calls(&self) -> usize {
@@ -894,11 +914,11 @@ mod tests {
     impl RemoteBlobFetcher for MockBlobFetcher {
         async fn fetch(
             &self,
-            hash: &Sha256Hash,
+            cid: &ContentCid,
             _providers: Vec<PeerContact>,
         ) -> Result<Option<Vec<u8>>> {
             *self.calls.lock().await += 1;
-            Ok(self.objects.lock().await.get(hash).cloned())
+            Ok(self.objects.lock().await.get(cid).cloned())
         }
     }
 
@@ -940,8 +960,23 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn test_content_rendezvous_preserves_cid_domain() -> crate::error::Result<()> {
+        let digest = [0x5a; 32];
+        let git = ContentCid::git_sha256(&Sha256Hash::from_bytes(&digest)?)?;
+        let xet = ContentCid::xet_merkle(&digest)?;
+
+        assert_ne!(git, xet);
+        assert_ne!(
+            locator_cid_from_content(&git),
+            locator_cid_from_content(&xet),
+            "rendezvous derivation must include CID codec and hash algorithm"
+        );
+        Ok(())
+    }
+
     #[tokio::test]
-    async fn test_object_storage_announces_blake3_and_facade_cids() -> crate::error::Result<()> {
+    async fn test_object_storage_announces_blake3_and_content_cids() -> crate::error::Result<()> {
         let temp_dir = TempDir::new()?;
         let locator = Arc::new(MockObjectLocator::default());
         let fetcher = Arc::new(MockBlobFetcher::default());
@@ -956,6 +991,7 @@ mod tests {
 
         let data = b"announced object".to_vec();
         let hash = service.put_object(data.clone()).await?;
+        let content_cid = ContentCid::git_sha256(&hash)?;
         let blake3 = service
             .object_plane
             .blobs
@@ -965,7 +1001,7 @@ mod tests {
         let announcements = locator.announcements().await;
 
         assert!(announcements.contains(&(locator_cid_from_blake3(blake3), Some(4242))));
-        assert!(announcements.contains(&(locator_cid_from_sha256(&hash), Some(4242))));
+        assert!(announcements.contains(&(locator_cid_from_content(&content_cid), Some(4242))));
         assert_eq!(
             service.get_object(&hash).await?.as_deref(),
             Some(data.as_slice())
@@ -988,13 +1024,14 @@ mod tests {
 
         let data = b"remote object".to_vec();
         let hash = sha256_git(&data)?;
+        let content_cid = ContentCid::git_sha256(&hash)?;
         locator
             .add_provider(
-                locator_cid_from_sha256(&hash),
+                locator_cid_from_content(&content_cid),
                 PeerContact::untrusted(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 6881)),
             )
             .await;
-        fetcher.insert(hash.clone(), data.clone()).await;
+        fetcher.insert(hash.clone(), data.clone()).await?;
 
         assert_eq!(
             service.get_object(&hash).await?.as_deref(),
@@ -1024,15 +1061,16 @@ mod tests {
         .await?;
 
         let requested_hash = sha256_git(b"wanted")?;
+        let content_cid = ContentCid::git_sha256(&requested_hash)?;
         locator
             .add_provider(
-                locator_cid_from_sha256(&requested_hash),
+                locator_cid_from_content(&content_cid),
                 PeerContact::untrusted(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 6881)),
             )
             .await;
         fetcher
             .insert(requested_hash.clone(), b"poisoned".to_vec())
-            .await;
+            .await?;
 
         assert!(service.get_object(&requested_hash).await.is_err());
         assert!(service

--- a/crates/hyprstream-p2p/src/types.rs
+++ b/crates/hyprstream-p2p/src/types.rs
@@ -3,6 +3,65 @@
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+/// Canonical CIDv1 envelope for an object-plane key.
+///
+/// The CID carries both the content domain (multicodec) and hash algorithm
+/// (multihash). Keeping the complete envelope at crate boundaries prevents
+/// equal-width digests such as an XET MerkleHash and SHA-256 from being
+/// silently reinterpreted as one another.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ContentCid(String);
+
+impl ContentCid {
+    /// Parse and validate a canonical CID understood by hyprstream.
+    pub fn new(cid: impl Into<String>) -> crate::Result<Self> {
+        let cid = cid.into();
+        hyprstream_rpc::cid::decode_cid(&cid)
+            .map_err(|e| crate::Error::other(format!("invalid content CID: {e}")))?;
+        Ok(Self(cid))
+    }
+
+    /// Address a raw Git object by its SHA-256 digest.
+    pub fn git_sha256(hash: &Sha256Hash) -> crate::Result<Self> {
+        let digest = hash.to_bytes();
+        let cid = hyprstream_rpc::cid::encode_cid(
+            hyprstream_rpc::cid::Codec::GitRaw,
+            hyprstream_rpc::cid::HashAlgo::Sha2_256,
+            &digest,
+        )
+        .map_err(|e| crate::Error::other(format!("failed to encode Git object CID: {e}")))?;
+        Ok(Self(cid))
+    }
+
+    /// Address a XET file reconstruction DAG by its real keyed-BLAKE3 Merkle hash.
+    pub fn xet_merkle(hash: &[u8]) -> crate::Result<Self> {
+        let cid = hyprstream_rpc::cid::encode_cid(
+            hyprstream_rpc::cid::Codec::XetShard,
+            hyprstream_rpc::cid::HashAlgo::Blake3,
+            hash,
+        )
+        .map_err(|e| crate::Error::other(format!("failed to encode XET Merkle CID: {e}")))?;
+        Ok(Self(cid))
+    }
+
+    /// Return the canonical CID text used for persistence and rendezvous derivation.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub(crate) fn decoded(&self) -> crate::Result<hyprstream_rpc::cid::Cid> {
+        hyprstream_rpc::cid::decode_cid(&self.0)
+            .map_err(|e| crate::Error::other(format!("invalid stored content CID: {e}")))
+    }
+}
+
+impl std::fmt::Display for ContentCid {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
 /// Fixed-width domain prefixes for DHT key derivation (4 bytes each)
 /// These ensure SHA1 and SHA256 git objects are stored in separate DHT keyspaces
 const DOMAIN_SHA1: &[u8; 4] = b"sha1";
@@ -181,7 +240,6 @@ impl MutableKey {
     }
 }
 
-
 /// A Git SHA256 hash (64 hex characters)
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Sha256Hash(pub String);
@@ -199,7 +257,10 @@ impl Sha256Hash {
     /// Create from bytes
     pub fn from_bytes(bytes: &[u8]) -> crate::Result<Self> {
         if bytes.len() != 32 {
-            return Err(crate::Error::InvalidSha256(format!("Expected 32 bytes, got {}", bytes.len())));
+            return Err(crate::Error::InvalidSha256(format!(
+                "Expected 32 bytes, got {}",
+                bytes.len()
+            )));
         }
         Ok(Sha256Hash(hex::encode(bytes)))
     }
@@ -241,8 +302,6 @@ pub struct GitRefs {
     /// Creation timestamp
     pub created_at: u64,
 }
-
-
 
 /// GitTorrent URL variants
 #[derive(Debug, Clone)]
@@ -306,7 +365,6 @@ impl GitTorrentUrl {
         }
     }
 
-
     /// Get the commit hash if this is a commit-based URL
     pub fn commit_hash(&self) -> Option<&Sha256Hash> {
         match self {
@@ -345,35 +403,75 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_content_cid_preserves_xet_merkle_domain() -> crate::Result<()> {
+        let digest = [0x42; 32];
+        let merkle = ContentCid::xet_merkle(&digest)?;
+        let git = ContentCid::git_sha256(&Sha256Hash::from_bytes(&digest)?)?;
+
+        let decoded = merkle.decoded()?;
+        assert_eq!(decoded.codec, hyprstream_rpc::cid::Codec::XetShard);
+        assert_eq!(
+            decoded.multihash.algo,
+            hyprstream_rpc::cid::HashAlgo::Blake3
+        );
+        assert_eq!(decoded.multihash.digest, digest);
+        assert_ne!(
+            merkle, git,
+            "equal-width digest bytes in different domains must not alias"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn test_sha256_creation() -> crate::error::Result<()> {
-        let sha256 = Sha256Hash::new("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")?;
-        assert_eq!(sha256.as_str(), "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+        let sha256 =
+            Sha256Hash::new("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")?;
+        assert_eq!(
+            sha256.as_str(),
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        );
         Ok(())
     }
 
     #[test]
     fn test_invalid_sha256() {
         assert!(Sha256Hash::new("invalid").is_err());
-        assert!(Sha256Hash::new("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdeg").is_err()); // invalid char
-        assert!(Sha256Hash::new("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde").is_err()); // too short
+        assert!(Sha256Hash::new(
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdeg"
+        )
+        .is_err()); // invalid char
+        assert!(
+            Sha256Hash::new("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde")
+                .is_err()
+        ); // too short
     }
 
     #[test]
     fn test_gittorrent_url_parsing() -> crate::error::Result<()> {
         // Test commit hash URL (new format)
-        let url = GitTorrentUrl::parse("gittorrent://0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")?;
+        let url = GitTorrentUrl::parse(
+            "gittorrent://0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        )?;
         match url {
             GitTorrentUrl::Commit { hash } => {
-                assert_eq!(hash.as_str(), "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+                assert_eq!(
+                    hash.as_str(),
+                    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                );
             }
             _ => panic!("Expected Commit variant"),
         }
 
         // Test commit hash with refs URL
-        let url = GitTorrentUrl::parse("gittorrent://0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef?refs")?;
+        let url = GitTorrentUrl::parse(
+            "gittorrent://0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef?refs",
+        )?;
         match url {
             GitTorrentUrl::CommitWithRefs { hash } => {
-                assert_eq!(hash.as_str(), "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+                assert_eq!(
+                    hash.as_str(),
+                    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                );
             }
             _ => panic!("Expected CommitWithRefs variant"),
         }
@@ -444,11 +542,15 @@ mod tests {
         // Too short
         assert!(GitHash::from_hex("0123456789").is_err());
         // Too long
-        assert!(GitHash::from_hex("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef00").is_err());
+        assert!(GitHash::from_hex(
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef00"
+        )
+        .is_err());
         // Invalid hex chars
         assert!(GitHash::from_hex("ghijklmnopqrstuvwxyz0123456789abcdef01234567").is_err());
         // Wrong length (not 40 or 64)
-        assert!(GitHash::from_hex("0123456789abcdef0123456789abcdef012345678").is_err()); // 41 chars
+        assert!(GitHash::from_hex("0123456789abcdef0123456789abcdef012345678").is_err());
+        // 41 chars
     }
 
     #[test]
@@ -503,5 +605,4 @@ mod tests {
         assert!(sha1.is_sha1());
         assert!(sha256.is_sha256());
     }
-
 }

--- a/crates/hyprstream-p2p/src/types.rs
+++ b/crates/hyprstream-p2p/src/types.rs
@@ -9,17 +9,28 @@ use sha2::{Digest, Sha256};
 /// (multihash). Keeping the complete envelope at crate boundaries prevents
 /// equal-width digests such as an XET MerkleHash and SHA-256 from being
 /// silently reinterpreted as one another.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 #[serde(transparent)]
 pub struct ContentCid(String);
 
 impl ContentCid {
     /// Parse and validate a canonical CID understood by hyprstream.
+    ///
+    /// The input is re-encoded to the canonical lowercase base32 text before
+    /// being stored: base32 decoding is case-insensitive, so equivalent
+    /// spellings must collapse to one representation — `Eq`/`Hash` and the
+    /// rendezvous derivation all operate on the string form.
     pub fn new(cid: impl Into<String>) -> crate::Result<Self> {
         let cid = cid.into();
-        hyprstream_rpc::cid::decode_cid(&cid)
+        let decoded = hyprstream_rpc::cid::decode_cid(&cid)
             .map_err(|e| crate::Error::other(format!("invalid content CID: {e}")))?;
-        Ok(Self(cid))
+        let canonical = hyprstream_rpc::cid::encode_cid(
+            decoded.codec,
+            decoded.multihash.algo,
+            &decoded.multihash.digest,
+        )
+        .map_err(|e| crate::Error::other(format!("failed to canonicalize content CID: {e}")))?;
+        Ok(Self(canonical))
     }
 
     /// Address a raw Git object by its SHA-256 digest.
@@ -59,6 +70,19 @@ impl ContentCid {
 impl std::fmt::Display for ContentCid {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.0)
+    }
+}
+
+/// Route deserialization through [`ContentCid::new`] so every ingress path
+/// validates and canonicalizes — a transparent derive would accept arbitrary
+/// strings verbatim.
+impl<'de> Deserialize<'de> for ContentCid {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        ContentCid::new(s).map_err(serde::de::Error::custom)
     }
 }
 
@@ -419,6 +443,32 @@ mod tests {
             merkle, git,
             "equal-width digest bytes in different domains must not alias"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_content_cid_canonicalizes_spelling_on_new() -> crate::Result<()> {
+        let canonical = ContentCid::xet_merkle(&[0x42; 32])?;
+        // base32 is case-insensitive on decode: an uppercase spelling of the
+        // same CID must collapse to the identical canonical value.
+        let shouted = format!("b{}", canonical.as_str()[1..].to_ascii_uppercase());
+        let reparsed = ContentCid::new(shouted)?;
+        assert_eq!(reparsed, canonical);
+        assert_eq!(reparsed.as_str(), canonical.as_str());
+        Ok(())
+    }
+
+    #[test]
+    fn test_content_cid_deserialize_validates_and_canonicalizes() -> crate::Result<()> {
+        let canonical = ContentCid::git_sha256(&Sha256Hash::new(
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        )?)?;
+        let shouted = format!("b{}", canonical.as_str()[1..].to_ascii_uppercase());
+        let parsed: ContentCid = serde_json::from_str(&format!("\"{shouted}\""))
+            .map_err(|e| crate::Error::other(e.to_string()))?;
+        assert_eq!(parsed, canonical);
+
+        assert!(serde_json::from_str::<ContentCid>("\"not-a-cid\"").is_err());
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- carry the real XET Merkle root through the `xet-merkle` field and encode it as an `xet-shard + blake3` CID instead of reinterpreting it as SHA-256
- key the iroh blob index, local cache, remote-fetch seam, and DHT content rendezvous by the complete CID while preserving SHA-256 wrappers for raw Git objects
- retain raw-file SHA-256 and size validation, reject legacy SHA-only gittorrent pointers, migrate legacy sidecar index entries, and prevent CID rebinding across different raw blobs

## Validation

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- pre-commit release gate: `cargo clippy --workspace --all-targets --release -- -D warnings`
- `cargo clippy -p hyprstream-p2p -p git-xet-filter --all-targets --features git-xet-filter/gittorrent-transport -- -D warnings`
- `cargo test -p hyprstream-p2p --lib`
- `cargo test -p git-xet-filter --features gittorrent-transport --lib`
- `cargo test -p git2db lfs --lib --features gittorrent-transport`
- `cargo deny check bans licenses`
- direct `rustfmt --check` for every changed Rust file

The workspace-wide `cargo fmt --all -- --check` command cannot initialize in this linked worktree because `crates/bitsandbytes-sys/Cargo.toml` resolves workspace membership against the primary checkout. The changed Rust files pass direct rustfmt checks.

Closes #1093