### PR TITLE
fix(git-xet-filter): move fetch_from_hash out of the StorageBackend impl

### DIFF
--- a/crates/git-xet-filter/src/gittorrent_storage.rs
+++ b/crates/git-xet-filter/src/gittorrent_storage.rs
@@ -77,6 +77,46 @@ impl GittorrentStorage {
     ) -> Self {
         Self { service, fallback }
     }
+
+    /// Fetch reconstruction bytes for a Merkle hash without committing any
+    /// CID binding. The returned flag is `true` when the bytes did not come
+    /// from the already-validated local p2p store and should be persisted by
+    /// the caller only after end-to-end validation.
+    ///
+    /// This is an internal helper rather than a [`StorageBackend`] method:
+    /// the trait exposes only the `smudge_*` surface, and the extra
+    /// `uncommitted` flag is meaningful solely to this backend's callers.
+    async fn fetch_from_hash(&self, hash: &merklehash::MerkleHash) -> Result<(Vec<u8>, bool)> {
+        let cid = hyprstream_p2p::ContentCid::xet_merkle(hash.as_bytes()).map_err(|e| {
+            XetError::new(
+                XetErrorKind::DownloadFailed,
+                format!("CID encoding failed: {e}"),
+            )
+        })?;
+
+        // Try P2P first
+        match self.service.get_object_by_cid(&cid).await {
+            Ok(Some(data)) => return Ok((data, false)),
+            Ok(None) => {
+                tracing::debug!("Object {} not found in DHT, trying fallback", hash);
+            }
+            Err(e) => {
+                tracing::warn!("DHT fetch failed for {}: {e}", hash);
+            }
+        }
+
+        // Fallback to HTTPS origin; caching is deferred to the caller until
+        // the pointer's size and SHA-256 checks pass.
+        if let Some(ref fb) = self.fallback {
+            let data = fb.smudge_from_hash(hash).await?;
+            return Ok((data, true));
+        }
+
+        Err(XetError::new(
+            XetErrorKind::DownloadFailed,
+            format!("Object {hash} not found in DHT or fallback"),
+        ))
+    }
 }
 
 #[cfg(feature = "xet-storage")]
@@ -208,42 +248,6 @@ impl super::storage::StorageBackend for GittorrentStorage {
         // validate against, so fetched bytes are never committed to the p2p
         // plane on this path — only `smudge_bytes` caches, after validation.
         Ok(self.fetch_from_hash(hash).await?.0)
-    }
-
-    /// Fetch reconstruction bytes for a Merkle hash without committing any
-    /// CID binding. The returned flag is `true` when the bytes did not come
-    /// from the already-validated local p2p store and should be persisted by
-    /// the caller only after end-to-end validation.
-    async fn fetch_from_hash(&self, hash: &merklehash::MerkleHash) -> Result<(Vec<u8>, bool)> {
-        let cid = hyprstream_p2p::ContentCid::xet_merkle(hash.as_bytes()).map_err(|e| {
-            XetError::new(
-                XetErrorKind::DownloadFailed,
-                format!("CID encoding failed: {e}"),
-            )
-        })?;
-
-        // Try P2P first
-        match self.service.get_object_by_cid(&cid).await {
-            Ok(Some(data)) => return Ok((data, false)),
-            Ok(None) => {
-                tracing::debug!("Object {} not found in DHT, trying fallback", hash);
-            }
-            Err(e) => {
-                tracing::warn!("DHT fetch failed for {}: {e}", hash);
-            }
-        }
-
-        // Fallback to HTTPS origin; caching is deferred to the caller until
-        // the pointer's size and SHA-256 checks pass.
-        if let Some(ref fb) = self.fallback {
-            let data = fb.smudge_from_hash(hash).await?;
-            return Ok((data, true));
-        }
-
-        Err(XetError::new(
-            XetErrorKind::DownloadFailed,
-            format!("Object {hash} not found in DHT or fallback"),
-        ))
     }
 
     async fn smudge_from_hash_to_file(


### PR DESCRIPTION
## Why

`main` is currently **red**: the `Rust` workflow fails on `838453f5` with

```
error[E0407]: method `fetch_from_hash` is not a member of trait `super::storage::StorageBackend`
  --> crates/git-xet-filter/src/gittorrent_storage.rs:217:5
error[E0599]: no method named `fetch_from_hash` found ... (call sites at :164 and :210)
```

Every open PR inherits this failure, so with the ALLGREEN merge-queue gate **nothing can merge** until it is fixed. This PR is the unblocker; it is not related to any feature work.

## What

`fetch_from_hash` was defined inside `impl StorageBackend for GittorrentStorage` but is not declared on the trait. It is an internal helper — the trait exposes only the `smudge_*` surface, and the extra `uncommitted` flag is meaningful solely to this backend's own callers (`smudge_bytes`, `smudge_from_hash`). Moved verbatim into the inherent `impl GittorrentStorage` block. No behavior change.

## Why it reached main

`gittorrent_storage` is gated behind `gittorrent-transport`, which is **not** in this crate's default features. A per-package `cargo clippy -p git-xet-filter` does not compile the module at all; only the workspace build reaches it via feature unification. This is the known feature-gated-module CI gap.

## Verification

- `cargo clippy -p git-xet-filter --all-targets --features gittorrent-transport -- -D warnings` — clean (this is the config that reproduces the failure; without the feature the file isn't compiled).
- Pre-commit release clippy mirror (full workspace) passed.

Note: `--all-features` surfaces a *separate*, pre-existing break in `ssh_client.rs` (russh API drift, `ssh-transport` feature). CI does not pass `--all-features`, so it is out of scope here and left untouched.