### PR TITLE
feat(pds): com.atproto XRPC MVP read slice (closes #1112)

### DIFF
--- a/crates/hyprstream-pds/src/car.rs
+++ b/crates/hyprstream-pds/src/car.rs
@@ -34,6 +34,40 @@ use crate::record::ModelRecord;
 
 /// Build a CARv1 byte blob containing the given root CIDs and `(cid → bytes)` blocks.
 ///
+/// Like [`build_car_v1`] but returns each length-framed section as its own
+/// `Vec<u8>` — the header section first, then one entry per block — so the
+/// caller can stream them incrementally over HTTP without materializing the
+/// entire CAR into a single contiguous buffer.
+///
+/// Each returned `Vec<u8>` is a complete framed CAR section
+/// (`varint(len) ++ body`), safe to flush independently.
+pub fn build_car_v1_sections(roots: &[Cid], blocks: &[(Cid, Vec<u8>)]) -> Vec<Vec<u8>> {
+    let mut sections = Vec::with_capacity(1 + blocks.len());
+    let header_value = DagCbor::str_map([
+        ("version", DagCbor::Unsigned(1)),
+        (
+            "roots",
+            DagCbor::List(roots.iter().copied().map(DagCbor::Link).collect()),
+        ),
+    ]);
+    let header_bytes = header_value.encode();
+    sections.push(frame_section(&header_bytes));
+    for (cid, bytes) in blocks {
+        let mut section = Vec::with_capacity(cid.as_bytes().len() + bytes.len());
+        section.extend_from_slice(cid.as_bytes());
+        section.extend_from_slice(bytes);
+        sections.push(frame_section(&section));
+    }
+    sections
+}
+
+fn frame_section(body: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(10 + body.len());
+    write_uvarint(body.len() as u64, &mut out);
+    out.extend_from_slice(body);
+    out
+}
+
 /// `blocks` need not be sorted; duplicates are harmless. The header's `roots`
 /// is taken verbatim from `roots`.
 pub fn build_car_v1(roots: &[Cid], blocks: &[(Cid, Vec<u8>)]) -> Vec<u8> {

--- a/crates/hyprstream-pds/src/car.rs
+++ b/crates/hyprstream-pds/src/car.rs
@@ -61,6 +61,29 @@ pub fn build_car_v1_sections(roots: &[Cid], blocks: &[(Cid, Vec<u8>)]) -> Vec<Ve
     sections
 }
 
+/// Build just the CARv1 header section (varint-framed CBOR `{version, roots}`).
+/// Useful for lazy/streaming CAR producers that emit the header first, then
+/// block sections one at a time.
+pub fn car_header_bytes(roots: &[Cid]) -> Vec<u8> {
+    let header_value = DagCbor::str_map([
+        ("version", DagCbor::Unsigned(1)),
+        (
+            "roots",
+            DagCbor::List(roots.iter().copied().map(DagCbor::Link).collect()),
+        ),
+    ]);
+    frame_section(&header_value.encode())
+}
+
+/// Build one length-framed CARv1 block section (`varint(len) ++ CID ++ raw`).
+/// Used by lazy/streaming CAR producers that encode blocks on demand.
+pub fn car_block_bytes(cid: Cid, raw: &[u8]) -> Vec<u8> {
+    let mut section = Vec::with_capacity(cid.as_bytes().len() + raw.len());
+    section.extend_from_slice(cid.as_bytes());
+    section.extend_from_slice(raw);
+    frame_section(&section)
+}
+
 fn frame_section(body: &[u8]) -> Vec<u8> {
     let mut out = Vec::with_capacity(10 + body.len());
     write_uvarint(body.len() as u64, &mut out);

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -1184,6 +1184,14 @@ pub struct OAuthConfig {
     /// Defaults to `false` for compatibility.
     #[serde(default)]
     pub require_pushed_authorization_requests: bool,
+
+    /// Enable the `com.atproto.*` XRPC read slice (`/xrpc/…`) served from the
+    /// OAuth HTTP surface (#1112). Defaults to `false` — the data plane is
+    /// inert until the operator explicitly opts in and the write path (#910)
+    /// populates the in-process `XrpcRepoStore` with `public`-flagged snapshots.
+    /// When `false`, the XRPC routes are not mounted at all.
+    #[serde(default)]
+    pub xrpc_read_slice: bool,
 }
 
 fn default_oauth_cors() -> server::CorsConfig {
@@ -1217,6 +1225,7 @@ impl Default for OAuthConfig {
             jwt_key_drain_secs: None,
             jwt_key_rotation_check_secs: None,
             require_pushed_authorization_requests: false,
+            xrpc_read_slice: false,
         }
     }
 }

--- a/crates/hyprstream/src/services/oauth/did_document.rs
+++ b/crates/hyprstream/src/services/oauth/did_document.rs
@@ -339,7 +339,7 @@ fn ed25519_verification_method_jwk(did: &str, key_id: &str, vk: &VerifyingKey) -
 /// `#mesh-kem` hybrid keyAgreement recipient (X25519 + ML-KEM-768) as
 /// `keyAgreement` entries — additive and, like `mesh_pq_vk`, ignored by
 /// atproto resolvers.
-fn build_did_document(
+pub(crate) fn build_did_document(
     did: &str,
     issuer_url: &str,
     keys: &[(String, VerifyingKey)],

--- a/crates/hyprstream/src/services/oauth/did_document.rs
+++ b/crates/hyprstream/src/services/oauth/did_document.rs
@@ -47,7 +47,7 @@ use super::state::OAuthState;
 /// Used as the method-specific identifier in did:web — `did:web:{authority}:...`.
 /// Mirrors the helper in `user_mapping.rs` but kept inline here to avoid
 /// pulling in the user-mapping module from a different concern.
-fn issuer_authority(issuer_url: &str) -> Option<String> {
+pub(crate) fn issuer_authority(issuer_url: &str) -> Option<String> {
     let after_scheme = issuer_url.split_once("://").map(|(_, rest)| rest)?;
     let authority = after_scheme.split('/').next().unwrap_or(after_scheme);
     if authority.is_empty() { None } else { Some(authority.to_owned()) }

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -151,15 +151,9 @@ pub fn create_app(state: Arc<OAuthState>, cors_config: &crate::config::CorsConfi
     // Four public read endpoints, conditionally mounted when the operator
     // opts in via `OAuthConfig::xrpc_read_slice`. Session endpoints
     // (createSession/getSession) are NOT here — they arrive with #1113/#948.
+    // Route table lives in `xrpc::xrpc_routes()` — single source of truth.
     let public_router = if state.xrpc_read_slice {
-        public_router
-            .route(
-                "/xrpc/com.atproto.identity.resolveHandle",
-                get(xrpc::resolve_handle),
-            )
-            .route("/xrpc/com.atproto.repo.describeRepo", get(xrpc::describe_repo))
-            .route("/xrpc/com.atproto.repo.getRecord", get(xrpc::get_record))
-            .route("/xrpc/com.atproto.sync.getRepo", get(xrpc::get_repo))
+        public_router.merge(xrpc::xrpc_routes())
     } else {
         public_router
     };

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -145,35 +145,24 @@ pub fn create_app(state: Arc<OAuthState>, cors_config: &crate::config::CorsConfi
         .route(
             "/scim/v2/ServiceProviderConfig",
             get(scim::service_provider_config),
-        )
-        // ── com.atproto XRPC read slice (#1112) ────────────────────────────────
-        // Public atproto read endpoints + the session bridge. getSession does
-        // its own Bearer-session lookup inline (it's the atproto session-id
-        // mechanism, not the OAuth JWT validated by require_bearer_token).
-        .route(
-            "/xrpc/com.atproto.server.createSession",
-            post(xrpc::create_session),
-        )
-        .route(
-            "/xrpc/com.atproto.server.getSession",
-            get(xrpc::get_session),
-        )
-        .route(
-            "/xrpc/com.atproto.identity.resolveHandle",
-            get(xrpc::resolve_handle),
-        )
-        .route(
-            "/xrpc/com.atproto.repo.describeRepo",
-            get(xrpc::describe_repo),
-        )
-        .route(
-            "/xrpc/com.atproto.repo.getRecord",
-            get(xrpc::get_record),
-        )
-        .route(
-            "/xrpc/com.atproto.sync.getRepo",
-            get(xrpc::get_repo),
         );
+
+    // ── com.atproto XRPC read slice (#1112) ────────────────────────────────
+    // Four public read endpoints, conditionally mounted when the operator
+    // opts in via `OAuthConfig::xrpc_read_slice`. Session endpoints
+    // (createSession/getSession) are NOT here — they arrive with #1113/#948.
+    let public_router = if state.xrpc_read_slice {
+        public_router
+            .route(
+                "/xrpc/com.atproto.identity.resolveHandle",
+                get(xrpc::resolve_handle),
+            )
+            .route("/xrpc/com.atproto.repo.describeRepo", get(xrpc::describe_repo))
+            .route("/xrpc/com.atproto.repo.getRecord", get(xrpc::get_record))
+            .route("/xrpc/com.atproto.sync.getRepo", get(xrpc::get_repo))
+    } else {
+        public_router
+    };
 
     // ── Protected routes ───────────────────────────────────────────────────────
     // All require a valid Bearer token (validated by require_bearer_token).

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -61,6 +61,7 @@ pub mod user_service;
 pub mod userinfo;
 pub mod device_enrollment;
 pub mod rpc_handler;
+pub mod xrpc;
 
 use std::sync::Arc;
 
@@ -144,6 +145,34 @@ pub fn create_app(state: Arc<OAuthState>, cors_config: &crate::config::CorsConfi
         .route(
             "/scim/v2/ServiceProviderConfig",
             get(scim::service_provider_config),
+        )
+        // ── com.atproto XRPC read slice (#1112) ────────────────────────────────
+        // Public atproto read endpoints + the session bridge. getSession does
+        // its own Bearer-session lookup inline (it's the atproto session-id
+        // mechanism, not the OAuth JWT validated by require_bearer_token).
+        .route(
+            "/xrpc/com.atproto.server.createSession",
+            post(xrpc::create_session),
+        )
+        .route(
+            "/xrpc/com.atproto.server.getSession",
+            get(xrpc::get_session),
+        )
+        .route(
+            "/xrpc/com.atproto.identity.resolveHandle",
+            get(xrpc::resolve_handle),
+        )
+        .route(
+            "/xrpc/com.atproto.repo.describeRepo",
+            get(xrpc::describe_repo),
+        )
+        .route(
+            "/xrpc/com.atproto.repo.getRecord",
+            get(xrpc::get_record),
+        )
+        .route(
+            "/xrpc/com.atproto.sync.getRepo",
+            get(xrpc::get_repo),
         );
 
     // ── Protected routes ───────────────────────────────────────────────────────

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -403,6 +403,9 @@ pub struct OAuthState {
     /// by the write path (#910) and tests; the read endpoints consult it
     /// directly. Default-empty so existing construction sites need no change.
     pub xrpc_repos: Arc<super::xrpc::XrpcRepoStore>,
+    /// When `true`, the XRPC read-slice routes (`/xrpc/…`) are mounted on the
+    /// OAuth router (#1112). Copied from `OAuthConfig::xrpc_read_slice`.
+    pub xrpc_read_slice: bool,
     /// RSA encoding key for RS256 id_token signing (optional, loaded from secrets).
     pub rsa_encoding_key: Option<jsonwebtoken::EncodingKey>,
     /// RSA public key as JWK JSON (for the JWKS endpoint).
@@ -549,6 +552,7 @@ impl OAuthState {
             oidc_discovery: std::sync::Arc::new(super::oidc_discovery::OidcDiscoveryCache::default()),
             sessions: super::session::SessionStore::default(),
             xrpc_repos: Arc::new(super::xrpc::XrpcRepoStore::new()),
+            xrpc_read_slice: config.xrpc_read_slice,
             rsa_encoding_key: None,
             rsa_jwk: None,
             rsa_kid: None,

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -399,6 +399,10 @@ pub struct OAuthState {
     pub oidc_discovery: super::oidc_discovery::SharedDiscoveryCache,
     /// Server-side session store for browser login flow.
     pub sessions: super::session::SessionStore,
+    /// In-memory `com.atproto.*` XRPC read slice repo store (#1112). Populated
+    /// by the write path (#910) and tests; the read endpoints consult it
+    /// directly. Default-empty so existing construction sites need no change.
+    pub xrpc_repos: Arc<super::xrpc::XrpcRepoStore>,
     /// RSA encoding key for RS256 id_token signing (optional, loaded from secrets).
     pub rsa_encoding_key: Option<jsonwebtoken::EncodingKey>,
     /// RSA public key as JWK JSON (for the JWKS endpoint).
@@ -544,6 +548,7 @@ impl OAuthState {
             pending_external_auths: RwLock::new(HashMap::new()),
             oidc_discovery: std::sync::Arc::new(super::oidc_discovery::OidcDiscoveryCache::default()),
             sessions: super::session::SessionStore::default(),
+            xrpc_repos: Arc::new(super::xrpc::XrpcRepoStore::new()),
             rsa_encoding_key: None,
             rsa_jwk: None,
             rsa_kid: None,

--- a/crates/hyprstream/src/services/oauth/xrpc.rs
+++ b/crates/hyprstream/src/services/oauth/xrpc.rs
@@ -12,35 +12,24 @@
 //! | GET    | `com.atproto.identity.resolveHandle` | handle→DID |
 //! | GET    | `com.atproto.repo.describeRepo`     | DID/handle + commit head + didDoc |
 //! | GET    | `com.atproto.repo.getRecord`        | record JSON (optional `cid` pinning) |
-//! | GET    | `com.atproto.sync.getRepo`          | full-repo CARv1 export (streamed) |
+//! | GET    | `com.atproto.sync.getRepo`          | full-repo CARv1 export (lazy stream) |
 //!
 //! **Session endpoints (`createSession`/`getSession`) are deliberately NOT in
 //! this PR.** Credential verification (password / app-password) and the OAuth
-//! JWT bridge belong with the #1113/#948 OAuth integration work — a read-slice
-//! PR is the wrong place to introduce an unauthenticated session-minting path.
-//! The four endpoints above are public reads of explicitly-published repos.
+//! JWT bridge belong with the #1113/#948 OAuth integration work.
 //!
 //! # Feature gate
 //!
 //! Routes are mounted only when `OAuthConfig::xrpc_read_slice` is `true`
 //! (defaults to `false`). The in-process [`XrpcRepoStore`] starts empty; the
 //! write path (#910) populates it with [`RepoSnapshot`]s whose [`public`]
-//! flag is `true`. Only `public` snapshots are served by these endpoints —
-//! the publication boundary is enforced in [`XrpcRepoStore::get_public`] and
-//! tested in `publication_boundary_*`.
+//! flag is `true`. Only `public` snapshots are served by these endpoints.
 //!
 //! # Out of scope
 //!
 //! - `com.atproto.sync.subscribeRepos` (firehose) — issue #1112 defers it.
 //! - Write path (`repo.createRecord` etc.) — sequenced with #910.
 //! - `createSession`/`getSession` — sequenced with #1113/#948.
-//!
-//! # XRPC error envelopes
-//!
-//! All errors follow the XRPC convention: HTTP status code with JSON body
-//! `{"error": "<code>", "message": "<human readable>"}`. Extractor/query
-//! parse failures are caught via manual query parsing (no axum `Query`
-//! rejection bypasses).
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -51,12 +40,12 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use bytes::Bytes;
-use futures::stream;
+use futures::{stream, Stream};
 use p256::ecdsa::VerifyingKey;
 use serde_json::{json, Value};
-use tokio::sync::{RwLock, Semaphore};
+use tokio::sync::{OwnedSemaphorePermit, RwLock, Semaphore};
 
-use hyprstream_pds::car::{build_car_v1_sections, build_record_proof_car};
+use hyprstream_pds::car::{build_record_proof_car, car_block_bytes, car_header_bytes};
 use hyprstream_pds::commit::Commit;
 use hyprstream_pds::mst::{Node, NodeData};
 use hyprstream_pds::record::{ModelRecord, COLLECTION_NSID};
@@ -72,7 +61,7 @@ pub const HOSTED_COLLECTION: &str = COLLECTION_NSID;
 /// Maximum number of concurrent `sync.getRepo` (full-CAR export) requests.
 /// Each request streams the entire repo; bounding concurrency prevents
 /// memory/CPU exhaustion from parallel full-repo exports.
-const GET_REPO_CONCURRENCY: usize = 4;
+pub const GET_REPO_CONCURRENCY: usize = 4;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // RepoSnapshot + XrpcRepoStore
@@ -80,79 +69,41 @@ const GET_REPO_CONCURRENCY: usize = 4;
 
 /// An in-memory snapshot of one repo's signed state — enough to answer the
 /// public read slice (`describeRepo` / `getRecord` / `sync.getRepo`).
-///
-/// Holds the signed commit, the full MST node-block set, the per-rkey record
-/// table, and the account's `#atproto` P-256 verifying key (so the host can
-/// re-verify proofs it serves, satisfying the D5 untrusted-host posture).
 #[derive(Clone, Debug)]
 pub struct RepoSnapshot {
-    /// Account DID (e.g. `did:web:hyprstream.example.com`).
     pub did: String,
-    /// Account handle (bare hostname, no port — atproto handle rule).
     pub handle: String,
-    /// Signed commit head of the MST.
     pub commit: Commit,
-    /// `(cid, NodeData)` for every MST node, including the root. Used for
-    /// full-repo CAR export and for record-proof construction.
     pub node_blocks: Vec<(Cid, NodeData)>,
-    /// All hosted records, keyed by TID. The rkey (record key) in at-uri form
-    /// is `Tid::encode(tid)` (base32-sortable).
     pub records: BTreeMap<Tid, ModelRecord>,
-    /// The account's published `#atproto` P-256 verifying key.
     pub atproto_vk: VerifyingKey,
     /// **Publication boundary.** When `true`, this snapshot is anonymously
     /// readable via the public XRPC read endpoints. When `false`, the public
-    /// read handlers act as though the repo does not exist. The write path
-    /// (#910) sets this from the per-DID/per-collection authz policy.
+    /// read handlers act as though the repo does not exist.
     pub public: bool,
 }
 
 impl RepoSnapshot {
-    /// The MST root CID from the snapshot's commit (`commit.data`).
     pub fn root_cid(&self) -> Cid {
         self.commit.data
     }
 
-    /// Look up the record + its CID for a given rkey.
     pub fn record_by_rkey(&self, rkey: &str) -> Option<(&ModelRecord, Cid)> {
         let tid = Tid::parse(rkey).ok()?;
         let rec = self.records.get(&tid)?;
         Some((rec, rec.cid()))
     }
 
-    /// Build a CAR proof for one record (commit + MST path + record).
     pub fn record_proof_car(&self, rkey: &str) -> Option<Vec<u8>> {
         let tid = Tid::parse(rkey).ok()?;
         let rec = self.records.get(&tid)?;
-        let cids: BTreeMap<Tid, Cid> = self
-            .records
-            .iter()
-            .map(|(t, r)| (*t, r.cid()))
-            .collect();
+        let cids: BTreeMap<Tid, Cid> =
+            self.records.iter().map(|(t, r)| (*t, r.cid())).collect();
         let tree = Node::from_records(HOSTED_COLLECTION, &cids);
         let proof = tree.proof(HOSTED_COLLECTION, &tid)?;
         Some(build_record_proof_car(&self.commit, &proof, &self.node_blocks, rec))
     }
 
-    /// Build a full-repo CARv1 export: commit block + all MST nodes + all
-    /// records, rooted at the commit CID. Returns length-framed sections
-    /// suitable for incremental streaming (each `Vec<u8>` is one complete
-    /// CAR section: header first, then one per block).
-    pub fn full_car_sections(&self) -> Vec<Vec<u8>> {
-        let mut blocks: Vec<(Cid, Vec<u8>)> = Vec::new();
-        let commit_cid = self.commit.cid();
-        blocks.push((commit_cid, self.commit.to_dag_cbor()));
-        for (cid, data) in &self.node_blocks {
-            blocks.push((*cid, data.encode()));
-        }
-        for rec in self.records.values() {
-            blocks.push((rec.cid(), rec.to_dag_cbor()));
-        }
-        build_car_v1_sections(&[commit_cid], &blocks)
-    }
-
-    /// Convert a hosted record to the atproto `getRecord` `value` JSON:
-    /// the lexicon fields plus `$type` and the IPLD-link `$uri`.
     pub fn record_json(&self, rkey: &str, rec: &ModelRecord) -> Value {
         let uri = format!("at://{}/{HOSTED_COLLECTION}/{rkey}", self.did);
         json!({
@@ -167,9 +118,6 @@ impl RepoSnapshot {
         })
     }
 
-    /// Build a minimal atproto-compatible DID document for this snapshot's
-    /// account (used as `describeRepo.didDoc`). Reuses [`build_did_document`]
-    /// with only the `#atproto` verification method + `#atproto_pds` service.
     fn did_doc(&self, issuer_url: &str) -> Value {
         let atproto = AtprotoIdentity {
             p256_vk: &self.atproto_vk,
@@ -179,20 +127,18 @@ impl RepoSnapshot {
     }
 }
 
-/// In-process registry of hosted repos, keyed by DID. Populated by the write
-/// path (#910) and by tests; the read slice consults it directly.
+/// In-process registry of hosted repos, keyed by DID.
 #[derive(Debug)]
 pub struct XrpcRepoStore {
     by_did: RwLock<BTreeMap<String, Arc<RepoSnapshot>>>,
-    /// Concurrency limiter for full-CAR exports (`sync.getRepo`).
-    get_repo_sema: Semaphore,
+    get_repo_sema: Arc<Semaphore>,
 }
 
 impl Default for XrpcRepoStore {
     fn default() -> Self {
         Self {
             by_did: RwLock::new(BTreeMap::new()),
-            get_repo_sema: Semaphore::new(GET_REPO_CONCURRENCY),
+            get_repo_sema: Arc::new(Semaphore::new(GET_REPO_CONCURRENCY)),
         }
     }
 }
@@ -213,13 +159,12 @@ impl XrpcRepoStore {
     }
 
     /// Look up a **public** snapshot by DID. Non-public repos are invisible
-    /// to the public read endpoints (publication boundary, finding #4).
+    /// to the public read endpoints (publication boundary).
     pub async fn get_public(&self, did: &str) -> Option<Arc<RepoSnapshot>> {
         self.get(did).await.filter(|s| s.public)
     }
 
-    /// Resolve a handle (bare hostname) to a **public** snapshot — only
-    /// unique handles resolve unambiguously (atproto handle-uniqueness rule).
+    /// Resolve a handle (bare hostname) to a **public** snapshot.
     pub async fn by_handle_public(&self, handle: &str) -> Option<Arc<RepoSnapshot>> {
         let guard = self.by_did.read().await;
         let mut hits = guard.values().filter(|s| s.public && s.handle == handle);
@@ -230,28 +175,118 @@ impl XrpcRepoStore {
         Some(Arc::clone(first))
     }
 
-    /// Acquire a concurrency permit for full-CAR export. Bounded by
-    /// [`GET_REPO_CONCURRENCY`]. The permit is released when dropped.
-    pub async fn acquire_get_repo(&self) -> Result<tokio::sync::SemaphorePermit<'_>, tokio::sync::AcquireError> {
-        self.get_repo_sema.acquire().await
+    /// Acquire an **owned** concurrency permit for full-CAR export. The permit
+    /// lives until the body stream is consumed or dropped — not just until the
+    /// handler returns. Bounded by [`GET_REPO_CONCURRENCY`].
+    pub async fn acquire_get_repo_owned(&self) -> Result<OwnedSemaphorePermit, tokio::sync::AcquireError> {
+        self.get_repo_sema.clone().acquire_owned().await
     }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Lazy CAR section stream (owned-permit held until EOF/drop)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Phase of the lazy CAR section stream.
+#[derive(Clone, Debug)]
+enum CarPhase {
+    Header,
+    Commit,
+    Nodes(usize),
+    Records(Arc<Vec<Tid>>, usize),
+    Done,
+}
+
+/// Produce a lazy CAR section stream. Each section is encoded on-demand when
+/// polled — no full-repo materialization. The `OwnedSemaphorePermit` is held
+/// inside the stream's state and released when the stream is dropped (body
+/// consumed or client disconnected).
+fn lazy_car_stream(
+    snap: Arc<RepoSnapshot>,
+    permit: OwnedSemaphorePermit,
+) -> impl Stream<Item = std::io::Result<Bytes>> {
+    let record_tids: Arc<Vec<Tid>> = Arc::new(snap.records.keys().copied().collect());
+
+    struct StreamState {
+        phase: CarPhase,
+        _permit: OwnedSemaphorePermit,
+    }
+
+    let init = StreamState {
+        phase: CarPhase::Header,
+        _permit: permit,
+    };
+
+    stream::unfold(init, move |mut state| {
+        let snap = Arc::clone(&snap);
+        let record_tids = Arc::clone(&record_tids);
+        async move {
+            loop {
+                match &mut state.phase {
+                    CarPhase::Header => {
+                        state.phase = CarPhase::Commit;
+                        return Some((
+                            Ok(Bytes::from(car_header_bytes(&[snap.commit.cid()]))),
+                            state,
+                        ));
+                    }
+                    CarPhase::Commit => {
+                        state.phase = CarPhase::Nodes(0);
+                        return Some((
+                            Ok(Bytes::from(car_block_bytes(
+                                snap.commit.cid(),
+                                &snap.commit.to_dag_cbor(),
+                            ))),
+                            state,
+                        ));
+                    }
+                    CarPhase::Nodes(idx) => {
+                        if *idx < snap.node_blocks.len() {
+                            let (cid, data) = &snap.node_blocks[*idx];
+                            *idx += 1;
+                            return Some((
+                                Ok(Bytes::from(car_block_bytes(*cid, &data.encode()))),
+                                state,
+                            ));
+                        }
+                        state.phase = CarPhase::Records(Arc::clone(&record_tids), 0);
+                        // continue loop → Records
+                    }
+                    CarPhase::Records(tids, ridx) => {
+                        if *ridx < tids.len() {
+                            let tid = tids[*ridx];
+                            *ridx += 1;
+                            let rec = &snap.records[&tid];
+                            return Some((
+                                Ok(Bytes::from(car_block_bytes(
+                                    rec.cid(),
+                                    &rec.to_dag_cbor(),
+                                ))),
+                                state,
+                            ));
+                        }
+                        state.phase = CarPhase::Done;
+                        // continue loop → Done
+                    }
+                    CarPhase::Done => return None,
+                }
+            }
+        }
+    })
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
 // XRPC error helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Build an XRPC error JSON body. Always includes `error` and `message`.
 pub fn xrpc_error_body(error: &str, message: impl Into<String>) -> Value {
     json!({ "error": error, "message": message.into() })
 }
 
-/// Build an XRPC error [`Response`] with the given status code and body.
 pub fn xrpc_error(status: StatusCode, error: &str, message: impl Into<String>) -> Response {
     (status, axum::Json(xrpc_error_body(error, message))).into_response()
 }
 
-/// XRPC error codes used by the atproto read slice.
 pub mod errors {
     pub const INVALID_REQUEST: &str = "InvalidRequest";
     pub const ACCOUNT_NOT_FOUND: &str = "AccountNotFound";
@@ -262,13 +297,9 @@ pub mod errors {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Manual query parsing (avoids axum Query rejection bypassing XRPC envelope)
+// Query parsing (manual — no axum Query rejection bypasses XRPC envelope)
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Parse a raw query string `key=value&key=value` into a simple lookup.
-///
-/// XRPC query params (DIDs, handles, NSIDs, rkeys, CID strings) use only
-/// URL-safe characters, so no percent-decoding is needed for the MVP.
 fn parse_query(raw: Option<&str>) -> std::collections::HashMap<&str, &str> {
     let mut map = std::collections::HashMap::new();
     if let Some(q) = raw {
@@ -282,12 +313,163 @@ fn parse_query(raw: Option<&str>) -> std::collections::HashMap<&str, &str> {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// resolveHandle
+// Core handler logic (testable without OAuthState)
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// `GET /xrpc/com.atproto.identity.resolveHandle?handle=<host>`.
-///
-/// Returns `HandleNotFound` (canonical lexicon) for unknown handles.
+/// Resolve a handle to a DID via the store + issuer-derived self-handle.
+async fn resolve_handle_core(
+    store: &XrpcRepoStore,
+    issuer_url: &str,
+    handle: &str,
+) -> Response {
+    if let Some(snap) = store.by_handle_public(handle).await {
+        return axum::Json(json!({ "did": snap.did })).into_response();
+    }
+    if let Some(authority) = issuer_authority(issuer_url) {
+        let self_handle = authority.split(':').next().unwrap_or(&authority);
+        if handle == self_handle {
+            let did = format!("did:web:{authority}");
+            return axum::Json(json!({ "did": did })).into_response();
+        }
+    }
+    xrpc_error(
+        StatusCode::BAD_REQUEST,
+        errors::HANDLE_NOT_FOUND,
+        format!("handle {handle:?} not found"),
+    )
+}
+
+async fn describe_repo_core(store: &XrpcRepoStore, issuer_url: &str, repo: &str) -> Response {
+    let snap = match lookup_public_snapshot(store, repo).await {
+        Some(s) => s,
+        None => {
+            return xrpc_error(
+                StatusCode::BAD_REQUEST,
+                errors::REPO_NOT_FOUND,
+                format!("repo {repo:?} is not hosted by this PDS"),
+            );
+        }
+    };
+    let collections: Vec<&str> = if snap.records.is_empty() {
+        Vec::new()
+    } else {
+        vec![HOSTED_COLLECTION]
+    };
+    let did_doc = snap.did_doc(issuer_url);
+    axum::Json(json!({
+        "handle": snap.handle,
+        "did": snap.did,
+        "didDoc": did_doc,
+        "collections": collections,
+        "handleIsCorrect": true,
+    }))
+    .into_response()
+}
+
+async fn get_record_core(
+    store: &XrpcRepoStore,
+    repo: &str,
+    collection: &str,
+    rkey: &str,
+    cid: Option<&str>,
+) -> Response {
+    if collection != HOSTED_COLLECTION {
+        return xrpc_error(
+            StatusCode::BAD_REQUEST,
+            errors::RECORD_NOT_FOUND,
+            format!("collection {collection:?} is not hosted"),
+        );
+    }
+    if rkey.is_empty() {
+        return xrpc_error(
+            StatusCode::BAD_REQUEST,
+            errors::INVALID_REQUEST,
+            "rkey is required",
+        );
+    }
+    let snap = match lookup_public_snapshot(store, repo).await {
+        Some(s) => s,
+        None => {
+            return xrpc_error(
+                StatusCode::BAD_REQUEST,
+                errors::REPO_NOT_FOUND,
+                format!("repo {repo:?} is not hosted by this PDS"),
+            );
+        }
+    };
+    let Some((rec, record_cid)) = snap.record_by_rkey(rkey) else {
+        return xrpc_error(
+            StatusCode::BAD_REQUEST,
+            errors::RECORD_NOT_FOUND,
+            format!("record {collection}/{rkey} not found"),
+        );
+    };
+    if let Some(requested_cid) = cid {
+        if requested_cid != record_cid.to_string() {
+            return xrpc_error(
+                StatusCode::BAD_REQUEST,
+                errors::RECORD_NOT_FOUND,
+                format!("record {collection}/{rkey} does not match cid {requested_cid:?}"),
+            );
+        }
+    }
+    axum::Json(snap.record_json(rkey, rec)).into_response()
+}
+
+async fn get_repo_core(store: &XrpcRepoStore, did: &str, since_present: bool) -> Response {
+    if since_present {
+        return xrpc_error(
+            StatusCode::BAD_REQUEST,
+            errors::INVALID_REQUEST,
+            "since (revision delta) is not yet supported; omit for full export",
+        );
+    }
+    let snap = match store.get_public(did).await {
+        Some(s) => s,
+        None => {
+            return xrpc_error(
+                StatusCode::BAD_REQUEST,
+                errors::REPO_NOT_FOUND,
+                format!("repo {did:?} is not hosted by this PDS"),
+            );
+        }
+    };
+    // Acquire owned permit — held inside the body stream until EOF/drop.
+    let permit = match store.acquire_get_repo_owned().await {
+        Ok(p) => p,
+        Err(_) => {
+            return xrpc_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                errors::INTERNAL_SERVER_ERROR,
+                "concurrency limiter closed",
+            );
+        }
+    };
+    let body_stream = lazy_car_stream(snap, permit);
+    let body = axum::body::Body::from_stream(body_stream);
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "application/vnd.ipld.car")],
+        body,
+    )
+        .into_response()
+}
+
+async fn lookup_public_snapshot(
+    store: &XrpcRepoStore,
+    key: &str,
+) -> Option<Arc<RepoSnapshot>> {
+    if key.starts_with("did:") {
+        store.get_public(key).await
+    } else {
+        store.by_handle_public(key).await
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Axum handler wrappers
+// ─────────────────────────────────────────────────────────────────────────────
+
 pub async fn resolve_handle(
     State(state): State<Arc<OAuthState>>,
     RawQuery(raw): RawQuery,
@@ -303,36 +485,9 @@ pub async fn resolve_handle(
             );
         }
     };
-
-    // Hosted public account?
-    if let Some(snap) = state.xrpc_repos.by_handle_public(handle).await {
-        return axum::Json(json!({ "did": snap.did })).into_response();
-    }
-
-    // This deployment's own handle?
-    if let Some(authority) = issuer_authority(&state.issuer_url) {
-        let self_handle = authority.split(':').next().unwrap_or(&authority);
-        if handle == self_handle {
-            let did = format!("did:web:{authority}");
-            return axum::Json(json!({ "did": did })).into_response();
-        }
-    }
-
-    xrpc_error(
-        StatusCode::BAD_REQUEST,
-        errors::HANDLE_NOT_FOUND,
-        format!("handle {handle:?} not found"),
-    )
+    resolve_handle_core(&state.xrpc_repos, &state.issuer_url, handle).await
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// describeRepo — canonical lexicon shape
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// `GET /xrpc/com.atproto.repo.describeRepo?repo=<did|handle>`.
-///
-/// Canonical shape: `handleIsCorrect` (not `handleIsValid`), `collections`
-/// is an array of NSID strings, `didDoc` is the populated DID document.
 pub async fn describe_repo(
     State(state): State<Arc<OAuthState>>,
     RawQuery(raw): RawQuery,
@@ -348,69 +503,16 @@ pub async fn describe_repo(
             );
         }
     };
-
-    let snap = match lookup_public_snapshot(&state, key).await {
-        Some(s) => s,
-        None => {
-            return xrpc_error(
-                StatusCode::BAD_REQUEST,
-                errors::REPO_NOT_FOUND,
-                format!("repo {key:?} is not hosted by this PDS"),
-            );
-        }
-    };
-
-    // Canonical: collections = array of NSID strings (not objects).
-    let collections: Vec<&str> = if snap.records.is_empty() {
-        Vec::new()
-    } else {
-        vec![HOSTED_COLLECTION]
-    };
-
-    let did_doc = snap.did_doc(&state.issuer_url);
-
-    axum::Json(json!({
-        "handle": snap.handle,
-        "did": snap.did,
-        "didDoc": did_doc,
-        "collections": collections,
-        "handleIsCorrect": true,
-    }))
-    .into_response()
+    describe_repo_core(&state.xrpc_repos, &state.issuer_url, key).await
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// getRecord — with optional cid pinning
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// `GET /xrpc/com.atproto.repo.getRecord?repo=<did>&collection=<nsid>&rkey=<rkey>[&cid=<cid>]`.
-///
-/// When `cid` is provided, returns `RecordNotFound` if the current record's CID
-/// does not match (version mismatch).
 pub async fn get_record(
     State(state): State<Arc<OAuthState>>,
     RawQuery(raw): RawQuery,
 ) -> Response {
     let params = parse_query(raw.as_deref());
-
     let collection = params.get("collection").copied().unwrap_or("");
     let rkey = params.get("rkey").copied().unwrap_or("");
-
-    if collection != HOSTED_COLLECTION {
-        return xrpc_error(
-            StatusCode::BAD_REQUEST,
-            errors::RECORD_NOT_FOUND,
-            format!("collection {collection:?} is not hosted"),
-        );
-    }
-    if rkey.is_empty() {
-        return xrpc_error(
-            StatusCode::BAD_REQUEST,
-            errors::INVALID_REQUEST,
-            "rkey is required",
-        );
-    }
-
     let repo = match params.get("repo") {
         Some(r) if !r.is_empty() => r.trim(),
         _ => {
@@ -421,59 +523,15 @@ pub async fn get_record(
             );
         }
     };
-
-    let snap = match lookup_public_snapshot(&state, repo).await {
-        Some(s) => s,
-        None => {
-            return xrpc_error(
-                StatusCode::BAD_REQUEST,
-                errors::REPO_NOT_FOUND,
-                format!("repo {repo:?} is not hosted by this PDS"),
-            );
-        }
-    };
-
-    let Some((rec, cid)) = snap.record_by_rkey(rkey) else {
-        return xrpc_error(
-            StatusCode::BAD_REQUEST,
-            errors::RECORD_NOT_FOUND,
-            format!("record {collection}/{rkey} not found"),
-        );
-    };
-
-    // Optional cid pinning: if the client requests a specific version and it
-    // doesn't match, return RecordNotFound (the record at that version is gone).
-    if let Some(requested_cid) = params.get("cid") {
-        if *requested_cid != cid.to_string() {
-            return xrpc_error(
-                StatusCode::BAD_REQUEST,
-                errors::RECORD_NOT_FOUND,
-                format!("record {collection}/{rkey} does not match cid {requested_cid:?}"),
-            );
-        }
-    }
-
-    axum::Json(snap.record_json(rkey, rec)).into_response()
+    let cid = params.get("cid").map(|c| c.trim());
+    get_record_core(&state.xrpc_repos, repo, collection, rkey, cid).await
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// sync.getRepo — streamed CAR export with concurrency cap
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// `GET /xrpc/com.atproto.sync.getRepo?did=<did>[&since=<commitCid>]`.
-///
-/// Streams a CARv1 blob (`application/vnd.ipld.car`) containing the commit +
-/// MST + records, rooted at the signed commit. Sections are streamed
-/// incrementally via `Body::from_stream` — no double materialization.
-///
-/// `since` (revision-delta) is not yet supported and returns `InvalidRequest`
-/// rather than silently returning the full repo.
 pub async fn get_repo(
     State(state): State<Arc<OAuthState>>,
     RawQuery(raw): RawQuery,
 ) -> Response {
     let params = parse_query(raw.as_deref());
-
     let did = match params.get("did") {
         Some(d) if !d.is_empty() => d.trim(),
         _ => {
@@ -484,72 +542,9 @@ pub async fn get_repo(
             );
         }
     };
-
-    // since: reject explicitly until delta export is implemented (#910).
-    if let Some(since) = params.get("since") {
-        if !since.is_empty() {
-            return xrpc_error(
-                StatusCode::BAD_REQUEST,
-                errors::INVALID_REQUEST,
-                "since (revision delta) is not yet supported; omit for full export",
-            );
-        }
-    }
-
-    let snap = match state.xrpc_repos.get_public(did).await {
-        Some(s) => s,
-        None => {
-            return xrpc_error(
-                StatusCode::BAD_REQUEST,
-                errors::REPO_NOT_FOUND,
-                format!("repo {did:?} is not hosted by this PDS"),
-            );
-        }
-    };
-
-    // Acquire concurrency permit — bounded by GET_REPO_CONCURRENCY.
-    let _permit = match state.xrpc_repos.acquire_get_repo().await {
-        Ok(p) => p,
-        Err(_) => {
-            return xrpc_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                errors::INTERNAL_SERVER_ERROR,
-                "concurrency limiter closed",
-            );
-        }
-    };
-
-    // Build length-framed sections and stream them incrementally.
-    let sections = snap.full_car_sections();
-    let body = axum::body::Body::from_stream(stream::iter(
-        sections
-            .into_iter()
-            .map(|s| Ok::<Bytes, std::convert::Infallible>(Bytes::from(s))),
-    ));
-
-    (
-        StatusCode::OK,
-        [(header::CONTENT_TYPE, "application/vnd.ipld.car")],
-        body,
-    )
-        .into_response()
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Shared helpers
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// Resolve a `did:` or handle reference to a **public** snapshot.
-/// Non-public repos are invisible (publication boundary).
-async fn lookup_public_snapshot(
-    state: &OAuthState,
-    key: &str,
-) -> Option<Arc<RepoSnapshot>> {
-    if key.starts_with("did:") {
-        state.xrpc_repos.get_public(key).await
-    } else {
-        state.xrpc_repos.by_handle_public(key).await
-    }
+    // Reject since by PRESENCE (not just non-empty) — ?since= and ?since=x both 400.
+    let since_present = params.contains_key("since");
+    get_repo_core(&state.xrpc_repos, did, since_present).await
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -563,11 +558,9 @@ mod tests {
     use p256::ecdsa::SigningKey;
     use rand::rngs::OsRng;
 
-    /// Build a minimal hosted snapshot with one record, signed by a fresh key.
     fn sample_snapshot(did: &str, handle: &str, public: bool) -> RepoSnapshot {
         let signing = SigningKey::random(&mut OsRng);
         let vk = VerifyingKey::from(&signing);
-
         let repo_at_uri = format!("at://{did}");
         let rec = ModelRecord::new(
             &repo_at_uri,
@@ -575,22 +568,18 @@ mod tests {
             "2026-07-19T00:00:00.000Z",
         )
         .expect("valid record");
-
         let tid = Tid::now();
         let mut record_cids: BTreeMap<Tid, Cid> = BTreeMap::new();
         record_cids.insert(tid, rec.cid());
         let mut records: BTreeMap<Tid, ModelRecord> = BTreeMap::new();
         records.insert(tid, rec);
-
         let tree = Node::from_records(HOSTED_COLLECTION, &record_cids);
         let (_root_data, node_blocks) = tree.to_node_data_with_blocks();
         let root_cid = tree.root_cid();
-
         use hyprstream_pds::commit::UnsignedCommit;
         let unsigned = UnsignedCommit::new(did.to_owned(), root_cid, Tid::now(), None);
         let commit = Commit::sign(&unsigned, &signing);
         commit.verify(&vk).expect("self-signed commit verifies");
-
         RepoSnapshot {
             did: did.to_owned(),
             handle: handle.to_owned(),
@@ -602,6 +591,201 @@ mod tests {
         }
     }
 
+    /// Read a response body as a JSON Value.
+    async fn body_json(resp: Response) -> Value {
+        let bytes = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    // ── Finding 1: lazy CAR + owned permit held until EOF ───────────────────
+
+    #[tokio::test]
+    async fn lazy_car_stream_produces_valid_car() {
+        let snap = Arc::new(sample_snapshot("did:web:h.example.com", "h.example.com", true));
+        let store = XrpcRepoStore::new();
+        let permit = store.acquire_get_repo_owned().await.unwrap();
+        let strm = lazy_car_stream(Arc::clone(&snap), permit);
+        // Collect all sections and concatenate.
+        use futures::StreamExt;
+        let mut collected: Vec<u8> = Vec::new();
+        futures::pin_mut!(strm);
+        while let Some(chunk) = strm.next().await {
+            collected.extend_from_slice(&chunk.unwrap());
+        }
+        // Parse as a CARv1 and verify the commit root.
+        let (roots, blocks) = hyprstream_pds::car::parse_car_v1(&collected).unwrap();
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots[0], snap.commit.cid());
+        assert!(blocks.len() >= 3); // commit + MST + record
+    }
+
+    #[tokio::test]
+    async fn semaphore_owned_permit_held_until_stream_drop() {
+        // With concurrency = 4, acquire 4 permits. The 5th must block.
+        // Dropping one permit unblocks the 5th.
+        let store = XrpcRepoStore::new();
+        let mut permits: Vec<OwnedSemaphorePermit> = Vec::new();
+        for _ in 0..GET_REPO_CONCURRENCY {
+            permits.push(store.acquire_get_repo_owned().await.unwrap());
+        }
+        // The N+1th acquire must not complete immediately.
+        let next = store.acquire_get_repo_owned();
+        tokio::pin!(next);
+        tokio::select! {
+            _ = &mut next => panic!("N+1th permit acquired before capacity freed"),
+            _ = tokio::time::sleep(std::time::Duration::from_millis(50)) => {}
+        }
+        // Drop one permit — the N+1th should now complete.
+        permits.pop();
+        let _extra = next.await.expect("N+1th permit resolves after drop");
+    }
+
+    #[tokio::test]
+    async fn lazy_car_stream_releases_permit_on_drop() {
+        // The permit held inside the lazy stream must be released when the
+        // stream is dropped (e.g. client disconnects mid-body).
+        let store = XrpcRepoStore::new();
+        // Exhaust all permits.
+        let mut held: Vec<OwnedSemaphorePermit> = Vec::new();
+        for _ in 0..GET_REPO_CONCURRENCY {
+            held.push(store.acquire_get_repo_owned().await.unwrap());
+        }
+        let snap = Arc::new(sample_snapshot("did:web:h.example.com", "h.example.com", true));
+        // Acquire one more for the stream.
+        let stream_permit = held.pop().unwrap();
+        let strm = lazy_car_stream(snap, stream_permit);
+        // Drop the stream without consuming it — permit must be released.
+        drop(strm);
+        // Now we should be able to acquire a new permit.
+        let _new = store
+            .acquire_get_repo_owned()
+            .await
+            .expect("permit available after stream dropped");
+    }
+
+    // ── Finding 2: endpoint-level tests ──────────────────────────────────────
+
+    const ISSUER: &str = "https://h.example.com";
+
+    #[tokio::test]
+    async fn endpoint_non_public_invisible_describe_repo() {
+        let store = XrpcRepoStore::new();
+        store.put(sample_snapshot("did:web:priv.example.com", "priv.example.com", false)).await;
+        let resp = describe_repo_core(&store, ISSUER, "did:web:priv.example.com").await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = body_json(resp).await;
+        assert_eq!(body["error"], errors::REPO_NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn endpoint_non_public_invisible_get_record() {
+        let store = XrpcRepoStore::new();
+        store.put(sample_snapshot("did:web:priv.example.com", "priv.example.com", false)).await;
+        let resp = get_record_core(
+            &store,
+            "did:web:priv.example.com",
+            HOSTED_COLLECTION,
+            "anything",
+            None,
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = body_json(resp).await;
+        assert_eq!(body["error"], errors::REPO_NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn endpoint_non_public_invisible_get_repo() {
+        let store = XrpcRepoStore::new();
+        store.put(sample_snapshot("did:web:priv.example.com", "priv.example.com", false)).await;
+        let resp = get_repo_core(&store, "did:web:priv.example.com", false).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = body_json(resp).await;
+        assert_eq!(body["error"], errors::REPO_NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn endpoint_non_public_invisible_resolve_handle() {
+        let store = XrpcRepoStore::new();
+        store.put(sample_snapshot("did:web:priv.example.com", "priv.example.com", false)).await;
+        let resp = resolve_handle_core(&store, ISSUER, "priv.example.com").await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = body_json(resp).await;
+        assert_eq!(body["error"], errors::HANDLE_NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn endpoint_public_snapshot_visible_describe_repo() {
+        let store = XrpcRepoStore::new();
+        store.put(sample_snapshot("did:web:pub.example.com", "pub.example.com", true)).await;
+        let resp = describe_repo_core(&store, ISSUER, "did:web:pub.example.com").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["did"], "did:web:pub.example.com");
+        assert_eq!(body["handleIsCorrect"], true);
+        assert!(!body["collections"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn endpoint_get_record_cid_mismatch() {
+        let store = XrpcRepoStore::new();
+        let snap = sample_snapshot("did:web:pub.example.com", "pub.example.com", true);
+        let rkey = snap.records.keys().next().unwrap().encode();
+        store.put(snap).await;
+        let resp = get_record_core(
+            &store,
+            "did:web:pub.example.com",
+            HOSTED_COLLECTION,
+            &rkey,
+            Some("bafyreiwrongcid000000000000000000000000000000000000"),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = body_json(resp).await;
+        assert_eq!(body["error"], errors::RECORD_NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn endpoint_get_record_cid_match_succeeds() {
+        let store = XrpcRepoStore::new();
+        let snap = sample_snapshot("did:web:pub.example.com", "pub.example.com", true);
+        let rkey = snap.records.keys().next().unwrap().encode();
+        let cid = snap.records.values().next().unwrap().cid().to_string();
+        store.put(snap).await;
+        let resp =
+            get_record_core(&store, "did:web:pub.example.com", HOSTED_COLLECTION, &rkey, Some(&cid))
+                .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    // ── Finding 3: since rejected by presence ─────────────────────────────────
+
+    #[tokio::test]
+    async fn since_non_empty_rejected() {
+        let store = XrpcRepoStore::new();
+        store.put(sample_snapshot("did:web:pub.example.com", "pub.example.com", true)).await;
+        let resp = get_repo_core(&store, "did:web:pub.example.com", true).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = body_json(resp).await;
+        assert_eq!(body["error"], errors::INVALID_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn get_repo_without_since_succeeds() {
+        let store = XrpcRepoStore::new();
+        store.put(sample_snapshot("did:web:pub.example.com", "pub.example.com", true)).await;
+        let resp = get_repo_core(&store, "did:web:pub.example.com", false).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "application/vnd.ipld.car",
+        );
+    }
+
+    // ── Helper / unit tests ───────────────────────────────────────────────────
+
     #[test]
     fn error_body_shape_is_xrpc_convention() {
         let body = xrpc_error_body("RecordNotFound", "no such record");
@@ -611,79 +795,11 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_record_json_carries_uri_cid_and_value() {
-        let snap = sample_snapshot("did:web:h.example.com", "h.example.com", true);
-        let (tid, rec) = snap.records.iter().next().unwrap();
-        let rkey = tid.encode();
-        let json = snap.record_json(&rkey, rec);
-        assert_eq!(
-            json["uri"],
-            format!("at://did:web:h.example.com/{HOSTED_COLLECTION}/{rkey}"),
-        );
-        assert_eq!(json["value"]["$type"], HOSTED_COLLECTION);
-    }
-
-    #[test]
-    fn snapshot_full_car_sections_round_trip_via_parse_car_v1() {
-        let snap = sample_snapshot("did:web:h.example.com", "h.example.com", true);
-        // Concatenate sections and parse as a single CARv1 blob.
-        let sections = snap.full_car_sections();
-        let car: Vec<u8> = sections.into_iter().flatten().collect();
-        let (roots, blocks) = hyprstream_pds::car::parse_car_v1(&car).expect("parse CAR");
-        assert_eq!(roots.len(), 1);
-        assert_eq!(roots[0], snap.commit.cid());
-        assert!(blocks.len() >= 3); // commit + MST node + record
-    }
-
-    #[test]
-    fn snapshot_record_proof_car_verifies_offline() {
-        let snap = sample_snapshot("did:web:h.example.com", "h.example.com", true);
-        let (tid, _rec) = snap.records.iter().next().unwrap();
-        let rkey = tid.encode();
-        let car = snap.record_proof_car(&rkey).expect("proof for present rkey");
-        let (roots, blocks) = hyprstream_pds::car::parse_car_v1(&car).expect("parse CAR");
-        assert_eq!(roots.len(), 1);
-
-        let mut commit_block: Option<Vec<u8>> = None;
-        let mut record_block: Option<Vec<u8>> = None;
-        for (cid, bytes) in &blocks {
-            if *cid == snap.commit.cid() {
-                commit_block = Some(bytes.clone());
-            }
-            if *cid == snap.records.values().next().unwrap().cid() {
-                record_block = Some(bytes.clone());
-            }
-        }
-        let commit = Commit::from_dag_cbor(&commit_block.unwrap()).unwrap();
-        let record = ModelRecord::from_dag_cbor(&record_block.unwrap()).unwrap();
-        commit.verify(&snap.atproto_vk).expect("commit verifies");
-        assert_eq!(record.cid(), snap.records.values().next().unwrap().cid());
-    }
-
-    #[tokio::test]
-    async fn publication_boundary_public_snapshot_visible() {
-        let store = XrpcRepoStore::new();
-        store.put(sample_snapshot("did:web:pub.example.com", "pub.example.com", true)).await;
-        assert!(store.get_public("did:web:pub.example.com").await.is_some());
-        assert!(store.by_handle_public("pub.example.com").await.is_some());
-    }
-
-    #[tokio::test]
-    async fn publication_boundary_non_public_snapshot_invisible() {
-        let store = XrpcRepoStore::new();
-        // Private snapshot — get() sees it but public lookups must not.
-        store.put(sample_snapshot("did:web:priv.example.com", "priv.example.com", false)).await;
-        assert!(store.get("did:web:priv.example.com").await.is_some());
-        assert!(store.get_public("did:web:priv.example.com").await.is_none());
-        assert!(store.by_handle_public("priv.example.com").await.is_none());
-    }
-
-    #[tokio::test]
-    async fn repo_store_ambiguous_handle_refuses() {
-        let store = XrpcRepoStore::new();
-        store.put(sample_snapshot("did:web:a.example.com", "dup.example.com", true)).await;
-        store.put(sample_snapshot("did:web:b.example.com", "dup.example.com", true)).await;
-        assert!(store.by_handle_public("dup.example.com").await.is_none());
+    fn parse_query_rejects_empty_value_since() {
+        // ?since= parses to key "since" with value "".
+        let q = parse_query(Some("did=did:web:x&since="));
+        assert!(q.contains_key("since"));
+        assert_eq!(q.get("since").copied(), Some(""));
     }
 
     #[test]
@@ -691,28 +807,5 @@ mod tests {
         let q = parse_query(Some("repo=did:web:x&collection=ai.hyprstream.model&rkey=abc"));
         assert_eq!(q.get("repo").copied(), Some("did:web:x"));
         assert_eq!(q.get("collection").copied(), Some("ai.hyprstream.model"));
-        assert_eq!(q.get("rkey").copied(), Some("abc"));
-        assert_eq!(q.get("missing"), None);
-    }
-
-    #[test]
-    fn parse_query_empty_and_malformed() {
-        assert!(parse_query(None).is_empty());
-        assert!(parse_query(Some("")).is_empty());
-        // No `=` → skipped.
-        assert!(parse_query(Some("garbage")).is_empty());
-    }
-
-    #[test]
-    fn describe_repo_did_doc_carries_atproto_vm() {
-        let snap = sample_snapshot("did:web:h.example.com", "h.example.com", true);
-        let doc = snap.did_doc("https://h.example.com");
-        assert_eq!(doc["id"], "did:web:h.example.com");
-        // The atproto verification method must be present.
-        let vms = doc["verificationMethod"].as_array().unwrap();
-        assert!(vms.iter().any(|vm| vm["id"].as_str().unwrap_or("").ends_with("#atproto")));
-        // #atproto_pds service present.
-        let svcs = doc["service"].as_array().unwrap();
-        assert!(svcs.iter().any(|s| s["id"].as_str().unwrap_or("").ends_with("#atproto_pds")));
     }
 }

--- a/crates/hyprstream/src/services/oauth/xrpc.rs
+++ b/crates/hyprstream/src/services/oauth/xrpc.rs
@@ -1,77 +1,85 @@
-//! `com.atproto.*` XRPC server surface — MVP read slice (#1112).
+//! `com.atproto.*` XRPC server surface — MVP public-read slice (#1112).
 //!
 //! HTTP XRPC endpoints served from the same Axum surface that hosts OAuth and
 //! `/.well-known/atproto-did` (see `super::did_document`). `hyprstream-pds`
 //! remains deliberately no-networking: this module is the serving layer that
 //! calls its data functions (`Commit`/`MST`/`car::build_record_proof_car`).
 //!
-//! # Endpoints (read slice)
+//! # Endpoints (public reads only)
 //!
-//! | Method | Path (under `/xrpc/`) | Auth | Notes |
-//! |--------|-----------------------|------|-------|
-//! | POST   | `com.atproto.server.createSession`  | public | bridges to `OAuthState::sessions` |
-//! | GET    | `com.atproto.server.getSession`     | Bearer session | server-side session lookup |
-//! | GET    | `com.atproto.identity.resolveHandle`| public | reuses `did_document` handle→DID |
-//! | GET    | `com.atproto.repo.describeRepo`     | public | DID/handle + MST commit head |
-//! | GET    | `com.atproto.repo.getRecord`        | public | record JSON + CAR proof |
-//! | GET    | `com.atproto.sync.getRepo`          | public | full-repo CARv1 export |
+//! | Method | Path (under `/xrpc/`) | Notes |
+//! |--------|-----------------------|-------|
+//! | GET    | `com.atproto.identity.resolveHandle` | handle→DID |
+//! | GET    | `com.atproto.repo.describeRepo`     | DID/handle + commit head + didDoc |
+//! | GET    | `com.atproto.repo.getRecord`        | record JSON (optional `cid` pinning) |
+//! | GET    | `com.atproto.sync.getRepo`          | full-repo CARv1 export (streamed) |
 //!
-//! # Sessions bridge
+//! **Session endpoints (`createSession`/`getSession`) are deliberately NOT in
+//! this PR.** Credential verification (password / app-password) and the OAuth
+//! JWT bridge belong with the #1113/#948 OAuth integration work — a read-slice
+//! PR is the wrong place to introduce an unauthenticated session-minting path.
+//! The four endpoints above are public reads of explicitly-published repos.
 //!
-//! atproto's `createSession` is the "log in" call. Rather than build a parallel
-//! auth store, we bridge to the OAuth browser-login `SessionStore
-//! <super::session::SessionStore>`: `createSession` mints a server-side `Session`
-//! (the same store `/oauth/authorize` writes to) and returns its id as
-//! `accessJwt`. `getSession` reverses the lookup. The OAuth `/oauth/token` JWT
-//! path remains the canonical DPoP-bound access-token issuance; this is the
-//! atproto-client-friendly façade over the same subject.
+//! # Feature gate
 //!
-//! # Repo store
-//!
-//! There is no on-disk PDS record store yet (the `hyprstream-pds` store is
-//! in-memory by design). The MVP read slice holds per-DID repo snapshots in an
-//! in-process [`XrpcRepoStore`]. The upcoming write path (#910) will populate
-//! it; for now tests and the atproto login integration can seed it directly.
+//! Routes are mounted only when `OAuthConfig::xrpc_read_slice` is `true`
+//! (defaults to `false`). The in-process [`XrpcRepoStore`] starts empty; the
+//! write path (#910) populates it with [`RepoSnapshot`]s whose [`public`]
+//! flag is `true`. Only `public` snapshots are served by these endpoints —
+//! the publication boundary is enforced in [`XrpcRepoStore::get_public`] and
+//! tested in `publication_boundary_*`.
 //!
 //! # Out of scope
 //!
 //! - `com.atproto.sync.subscribeRepos` (firehose) — issue #1112 defers it.
 //! - Write path (`repo.createRecord` etc.) — sequenced with #910.
+//! - `createSession`/`getSession` — sequenced with #1113/#948.
 //!
 //! # XRPC error envelopes
 //!
 //! All errors follow the XRPC convention: HTTP status code with JSON body
-//! `{"error": "<code>", "message": "<human readable>"}`. See [`xrpc_error`].
+//! `{"error": "<code>", "message": "<human readable>"}`. Extractor/query
+//! parse failures are caught via manual query parsing (no axum `Query`
+//! rejection bypasses).
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use axum::{
-    extract::{Query, State},
+    extract::{RawQuery, State},
     http::{header, StatusCode},
     response::{IntoResponse, Response},
-    Json,
 };
+use bytes::Bytes;
+use futures::stream;
 use p256::ecdsa::VerifyingKey;
-use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use tokio::sync::RwLock;
+use tokio::sync::{RwLock, Semaphore};
 
-use hyprstream_pds::car::{build_car_v1, build_record_proof_car};
+use hyprstream_pds::car::{build_car_v1_sections, build_record_proof_car};
 use hyprstream_pds::commit::Commit;
 use hyprstream_pds::mst::{Node, NodeData};
 use hyprstream_pds::record::{ModelRecord, COLLECTION_NSID};
 use hyprstream_pds::tid::Tid;
 use hyprstream_pds::Cid;
 
-use super::did_document::issuer_authority;
+use super::did_document::{build_did_document, issuer_authority, AtprotoIdentity};
 use super::state::OAuthState;
 
 /// `ai.hyprstream.model` is the only collection this PDS hosts today.
 pub const HOSTED_COLLECTION: &str = COLLECTION_NSID;
 
+/// Maximum number of concurrent `sync.getRepo` (full-CAR export) requests.
+/// Each request streams the entire repo; bounding concurrency prevents
+/// memory/CPU exhaustion from parallel full-repo exports.
+const GET_REPO_CONCURRENCY: usize = 4;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RepoSnapshot + XrpcRepoStore
+// ─────────────────────────────────────────────────────────────────────────────
+
 /// An in-memory snapshot of one repo's signed state — enough to answer the
-/// read slice (`describeRepo` / `getRecord` / `sync.getRepo`).
+/// public read slice (`describeRepo` / `getRecord` / `sync.getRepo`).
 ///
 /// Holds the signed commit, the full MST node-block set, the per-rkey record
 /// table, and the account's `#atproto` P-256 verifying key (so the host can
@@ -92,6 +100,11 @@ pub struct RepoSnapshot {
     pub records: BTreeMap<Tid, ModelRecord>,
     /// The account's published `#atproto` P-256 verifying key.
     pub atproto_vk: VerifyingKey,
+    /// **Publication boundary.** When `true`, this snapshot is anonymously
+    /// readable via the public XRPC read endpoints. When `false`, the public
+    /// read handlers act as though the repo does not exist. The write path
+    /// (#910) sets this from the per-DID/per-collection authz policy.
+    pub public: bool,
 }
 
 impl RepoSnapshot {
@@ -111,9 +124,6 @@ impl RepoSnapshot {
     pub fn record_proof_car(&self, rkey: &str) -> Option<Vec<u8>> {
         let tid = Tid::parse(rkey).ok()?;
         let rec = self.records.get(&tid)?;
-        // Build a single-collection MST over the current record set, then ask
-        // it for the inclusion proof. The MST is deterministic from the record
-        // table, so this re-derivation matches what the writer produced.
         let cids: BTreeMap<Tid, Cid> = self
             .records
             .iter()
@@ -125,21 +135,20 @@ impl RepoSnapshot {
     }
 
     /// Build a full-repo CARv1 export: commit block + all MST nodes + all
-    /// records, rooted at the commit CID. This is `com.atproto.sync.getRepo`.
-    pub fn full_car(&self) -> Vec<u8> {
+    /// records, rooted at the commit CID. Returns length-framed sections
+    /// suitable for incremental streaming (each `Vec<u8>` is one complete
+    /// CAR section: header first, then one per block).
+    pub fn full_car_sections(&self) -> Vec<Vec<u8>> {
         let mut blocks: Vec<(Cid, Vec<u8>)> = Vec::new();
-        // Commit block.
         let commit_cid = self.commit.cid();
         blocks.push((commit_cid, self.commit.to_dag_cbor()));
-        // All MST node blocks.
         for (cid, data) in &self.node_blocks {
             blocks.push((*cid, data.encode()));
         }
-        // All record blocks.
         for rec in self.records.values() {
             blocks.push((rec.cid(), rec.to_dag_cbor()));
         }
-        build_car_v1(&[commit_cid], &blocks)
+        build_car_v1_sections(&[commit_cid], &blocks)
     }
 
     /// Convert a hosted record to the atproto `getRecord` `value` JSON:
@@ -157,13 +166,35 @@ impl RepoSnapshot {
             }
         })
     }
+
+    /// Build a minimal atproto-compatible DID document for this snapshot's
+    /// account (used as `describeRepo.didDoc`). Reuses [`build_did_document`]
+    /// with only the `#atproto` verification method + `#atproto_pds` service.
+    fn did_doc(&self, issuer_url: &str) -> Value {
+        let atproto = AtprotoIdentity {
+            p256_vk: &self.atproto_vk,
+            handle: &self.handle,
+        };
+        build_did_document(&self.did, issuer_url, &[], Some(&atproto), &[], None, None)
+    }
 }
 
 /// In-process registry of hosted repos, keyed by DID. Populated by the write
 /// path (#910) and by tests; the read slice consults it directly.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct XrpcRepoStore {
     by_did: RwLock<BTreeMap<String, Arc<RepoSnapshot>>>,
+    /// Concurrency limiter for full-CAR exports (`sync.getRepo`).
+    get_repo_sema: Semaphore,
+}
+
+impl Default for XrpcRepoStore {
+    fn default() -> Self {
+        Self {
+            by_did: RwLock::new(BTreeMap::new()),
+            get_repo_sema: Semaphore::new(GET_REPO_CONCURRENCY),
+        }
+    }
 }
 
 impl XrpcRepoStore {
@@ -176,26 +207,38 @@ impl XrpcRepoStore {
         self.by_did.write().await.insert(snap.did.clone(), Arc::new(snap));
     }
 
+    /// Look up a snapshot by DID (any visibility — for internal/admin use).
     pub async fn get(&self, did: &str) -> Option<Arc<RepoSnapshot>> {
         self.by_did.read().await.get(did).cloned()
     }
 
-    /// Resolve a handle (bare hostname) to a snapshot — only unique handles
-    /// resolve unambiguously, which is the atproto handle-uniqueness rule.
-    pub async fn by_handle(&self, handle: &str) -> Option<Arc<RepoSnapshot>> {
+    /// Look up a **public** snapshot by DID. Non-public repos are invisible
+    /// to the public read endpoints (publication boundary, finding #4).
+    pub async fn get_public(&self, did: &str) -> Option<Arc<RepoSnapshot>> {
+        self.get(did).await.filter(|s| s.public)
+    }
+
+    /// Resolve a handle (bare hostname) to a **public** snapshot — only
+    /// unique handles resolve unambiguously (atproto handle-uniqueness rule).
+    pub async fn by_handle_public(&self, handle: &str) -> Option<Arc<RepoSnapshot>> {
         let guard = self.by_did.read().await;
-        let mut hits = guard.values().filter(|s| s.handle == handle);
+        let mut hits = guard.values().filter(|s| s.public && s.handle == handle);
         let first = hits.next()?;
         if hits.next().is_some() {
-            // Ambiguous handle — refuse rather than guess.
-            return None;
+            return None; // ambiguous — refuse
         }
         Some(Arc::clone(first))
+    }
+
+    /// Acquire a concurrency permit for full-CAR export. Bounded by
+    /// [`GET_REPO_CONCURRENCY`]. The permit is released when dropped.
+    pub async fn acquire_get_repo(&self) -> Result<tokio::sync::SemaphorePermit<'_>, tokio::sync::AcquireError> {
+        self.get_repo_sema.acquire().await
     }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// XRPC error envelope helpers
+// XRPC error helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Build an XRPC error JSON body. Always includes `error` and `message`.
@@ -205,224 +248,65 @@ pub fn xrpc_error_body(error: &str, message: impl Into<String>) -> Value {
 
 /// Build an XRPC error [`Response`] with the given status code and body.
 pub fn xrpc_error(status: StatusCode, error: &str, message: impl Into<String>) -> Response {
-    (status, Json(xrpc_error_body(error, message))).into_response()
+    (status, axum::Json(xrpc_error_body(error, message))).into_response()
 }
 
-/// Common XRPC error codes used by the atproto read slice.
+/// XRPC error codes used by the atproto read slice.
 pub mod errors {
     pub const INVALID_REQUEST: &str = "InvalidRequest";
-    pub const BAD_REQUEST: &str = "BadRequest";
-    pub const UNAUTHORIZED: &str = "Unauthorized";
-    pub const INVALID_TOKEN: &str = "InvalidToken";
-    pub const EXPIRED_TOKEN: &str = "ExpiredToken";
     pub const ACCOUNT_NOT_FOUND: &str = "AccountNotFound";
+    pub const HANDLE_NOT_FOUND: &str = "HandleNotFound";
     pub const RECORD_NOT_FOUND: &str = "RecordNotFound";
     pub const REPO_NOT_FOUND: &str = "RepoNotFound";
     pub const INTERNAL_SERVER_ERROR: &str = "InternalServerError";
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// createSession / getSession — bridge to OAuth SessionStore
+// Manual query parsing (avoids axum Query rejection bypassing XRPC envelope)
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// `POST /xrpc/com.atproto.server.createSession` request body.
+/// Parse a raw query string `key=value&key=value` into a simple lookup.
 ///
-/// atproto clients post `identifier` (handle or DID) + `password`. The MVP
-/// bridge accepts the same shape but treats `identifier` as the local username
-/// (per `OAuthState::sessions`'s `username` field) and `password` as a
-/// presence-only credential for the local dev login story. Real credential
-/// checks happen via OAuth `/oauth/authorize` + SCIM; this is the façade that
-/// issues an atproto-shaped session backed by the same store.
-#[derive(Debug, Clone, Deserialize)]
-pub struct CreateSessionInput {
-    pub identifier: String,
-    #[serde(default)]
-    pub password: String,
-}
-
-/// `POST /xrpc/com.atproto.server.createSession` response — atproto session
-/// envelope. `accessJwt` is the server-side session id (see module docs).
-///
-/// Field names serialize as atproto's camelCase via `rename_all`.
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SessionOutput {
-    pub did: String,
-    pub handle: String,
-    pub access_jwt: String,
-    /// Standard atproto field; omitted when no OAuth JWT path was taken.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub refresh_jwt: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub email: Option<String>,
-    pub active: bool,
-}
-
-/// `GET /xrpc/com.atproto.server.getSession` response.
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct GetSessionOutput {
-    pub did: String,
-    pub handle: String,
-    pub active: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub email: Option<String>,
-}
-
-/// Resolve `identifier` (DID or handle) to a hosted snapshot.
-async fn resolve_account(
-    state: &OAuthState,
-    identifier: &str,
-) -> Option<Arc<RepoSnapshot>> {
-    // Direct DID lookup first.
-    if identifier.starts_with("did:") {
-        if let Some(snap) = state.xrpc_repos.get(identifier).await {
-            return Some(snap);
-        }
-    }
-    // Fall back to handle (bare hostname) lookup in the repo store.
-    if let Some(snap) = state.xrpc_repos.by_handle(identifier).await {
-        return Some(snap);
-    }
-    // Final fallback: treat the identifier as this deployment's own subject —
-    // `did:web:{authority}` — when no snapshot is seeded. This keeps the login
-    // story usable in single-tenant dev setups with no seeded repo.
-    if let Some(authority) = issuer_authority(&state.issuer_url) {
-        let did = format!("did:web:{authority}");
-        let handle = authority.split(':').next().unwrap_or(&authority).to_owned();
-        if identifier.eq_ignore_ascii_case(&handle) || identifier == did {
-            return None; // no snapshot — caller surfaces AccountNotFound
-        }
-    }
-    None
-}
-
-/// `POST /xrpc/com.atproto.server.createSession`.
-pub async fn create_session(
-    State(state): State<Arc<OAuthState>>,
-    Json(input): Json<CreateSessionInput>,
-) -> Response {
-    let identifier = input.identifier.trim();
-    if identifier.is_empty() {
-        return xrpc_error(
-            StatusCode::BAD_REQUEST,
-            errors::INVALID_REQUEST,
-            "identifier is required",
-        );
-    }
-
-    let snap = match resolve_account(&state, identifier).await {
-        Some(s) => s,
-        None => {
-            return xrpc_error(
-                StatusCode::BAD_REQUEST,
-                errors::ACCOUNT_NOT_FOUND,
-                format!("no account found for identifier {identifier:?}"),
-            );
-        }
-    };
-
-    // Bridge: mint a server-side OAuth session for the same subject. Same store
-    // `/oauth/authorize` writes to; no parallel auth state.
-    let session_id = state
-        .sessions
-        .create(snap.did.clone(), "atproto-xrpc".to_owned())
-        .await;
-
-    Json(SessionOutput {
-        did: snap.did.clone(),
-        handle: snap.handle.clone(),
-        access_jwt: session_id,
-        refresh_jwt: None,
-        email: None,
-        active: true,
-    })
-    .into_response()
-}
-
-/// `GET /xrpc/com.atproto.server.getSession`.
-///
-/// `Authorization: Bearer <accessJwt>` where `accessJwt` is the session id
-/// returned by `createSession`.
-pub async fn get_session(
-    State(state): State<Arc<OAuthState>>,
-    headers: axum::http::HeaderMap,
-) -> Response {
-    let Some(token) = bearer_token(&headers) else {
-        return xrpc_error(
-            StatusCode::UNAUTHORIZED,
-            errors::INVALID_TOKEN,
-            "Bearer accessJwt required",
-        );
-    };
-    let Some(session) = state.sessions.get(&token).await else {
-        return xrpc_error(
-            StatusCode::UNAUTHORIZED,
-            errors::EXPIRED_TOKEN,
-            "session not found or expired",
-        );
-    };
-
-    let snap = state.xrpc_repos.get(&session.username).await;
-    let (did, handle) = match snap {
-        Some(s) => (s.did.clone(), s.handle.clone()),
-        // Session is valid but no repo snapshot is seeded — degrade gracefully
-        // using the issuer-derived DID so getSession still answers.
-        None => match issuer_authority(&state.issuer_url) {
-            Some(authority) => {
-                let did = format!("did:web:{authority}");
-                let handle = authority.split(':').next().unwrap_or(&authority).to_owned();
-                (did, handle)
+/// XRPC query params (DIDs, handles, NSIDs, rkeys, CID strings) use only
+/// URL-safe characters, so no percent-decoding is needed for the MVP.
+fn parse_query(raw: Option<&str>) -> std::collections::HashMap<&str, &str> {
+    let mut map = std::collections::HashMap::new();
+    if let Some(q) = raw {
+        for pair in q.split('&') {
+            if let Some((k, v)) = pair.split_once('=') {
+                map.insert(k, v);
             }
-            None => {
-                return xrpc_error(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    errors::INTERNAL_SERVER_ERROR,
-                    "issuer URL has no authority",
-                );
-            }
-        },
-    };
-
-    Json(GetSessionOutput {
-        did,
-        handle,
-        active: true,
-        email: None,
-    })
-    .into_response()
+        }
+    }
+    map
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
 // resolveHandle
 // ─────────────────────────────────────────────────────────────────────────────
 
-#[derive(Debug, Deserialize)]
-pub struct ResolveHandleQuery {
-    pub handle: String,
-}
-
 /// `GET /xrpc/com.atproto.identity.resolveHandle?handle=<host>`.
 ///
-/// Shares logic with `/.well-known/atproto-did`: the deployment's own handle
-/// (issuer authority) resolves to `did:web:{authority}`; hosted-account handles
-/// resolve from the repo store.
+/// Returns `HandleNotFound` (canonical lexicon) for unknown handles.
 pub async fn resolve_handle(
     State(state): State<Arc<OAuthState>>,
-    Query(q): Query<ResolveHandleQuery>,
+    RawQuery(raw): RawQuery,
 ) -> Response {
-    let handle = q.handle.trim().to_owned();
-    if handle.is_empty() {
-        return xrpc_error(
-            StatusCode::BAD_REQUEST,
-            errors::INVALID_REQUEST,
-            "handle query parameter is required",
-        );
-    }
+    let params = parse_query(raw.as_deref());
+    let handle = match params.get("handle") {
+        Some(h) if !h.is_empty() => h.trim(),
+        _ => {
+            return xrpc_error(
+                StatusCode::BAD_REQUEST,
+                errors::INVALID_REQUEST,
+                "handle query parameter is required",
+            );
+        }
+    };
 
-    // Hosted account?
-    if let Some(snap) = state.xrpc_repos.by_handle(&handle).await {
-        return Json(json!({ "did": snap.did })).into_response();
+    // Hosted public account?
+    if let Some(snap) = state.xrpc_repos.by_handle_public(handle).await {
+        return axum::Json(json!({ "did": snap.did })).into_response();
     }
 
     // This deployment's own handle?
@@ -430,41 +314,42 @@ pub async fn resolve_handle(
         let self_handle = authority.split(':').next().unwrap_or(&authority);
         if handle == self_handle {
             let did = format!("did:web:{authority}");
-            return Json(json!({ "did": did })).into_response();
+            return axum::Json(json!({ "did": did })).into_response();
         }
     }
 
     xrpc_error(
         StatusCode::BAD_REQUEST,
-        errors::ACCOUNT_NOT_FOUND,
-        format!("handle {handle:?} is not hosted by this PDS"),
+        errors::HANDLE_NOT_FOUND,
+        format!("handle {handle:?} not found"),
     )
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// describeRepo
+// describeRepo — canonical lexicon shape
 // ─────────────────────────────────────────────────────────────────────────────
 
-#[derive(Debug, Deserialize)]
-pub struct DescribeRepoQuery {
-    pub repo: String,
-}
-
 /// `GET /xrpc/com.atproto.repo.describeRepo?repo=<did|handle>`.
+///
+/// Canonical shape: `handleIsCorrect` (not `handleIsValid`), `collections`
+/// is an array of NSID strings, `didDoc` is the populated DID document.
 pub async fn describe_repo(
     State(state): State<Arc<OAuthState>>,
-    Query(q): Query<DescribeRepoQuery>,
+    RawQuery(raw): RawQuery,
 ) -> Response {
-    let key = q.repo.trim().to_owned();
-    if key.is_empty() {
-        return xrpc_error(
-            StatusCode::BAD_REQUEST,
-            errors::INVALID_REQUEST,
-            "repo query parameter is required",
-        );
-    }
+    let params = parse_query(raw.as_deref());
+    let key = match params.get("repo") {
+        Some(r) if !r.is_empty() => r.trim(),
+        _ => {
+            return xrpc_error(
+                StatusCode::BAD_REQUEST,
+                errors::INVALID_REQUEST,
+                "repo query parameter is required",
+            );
+        }
+    };
 
-    let snap = match lookup_snapshot(&state, &key).await {
+    let snap = match lookup_public_snapshot(&state, key).await {
         Some(s) => s,
         None => {
             return xrpc_error(
@@ -475,48 +360,50 @@ pub async fn describe_repo(
         }
     };
 
-    let collections = if snap.records.is_empty() {
+    // Canonical: collections = array of NSID strings (not objects).
+    let collections: Vec<&str> = if snap.records.is_empty() {
         Vec::new()
     } else {
-        vec![json!({ "nsid": HOSTED_COLLECTION, "count": snap.records.len() })]
+        vec![HOSTED_COLLECTION]
     };
 
-    Json(json!({
+    let did_doc = snap.did_doc(&state.issuer_url);
+
+    axum::Json(json!({
         "handle": snap.handle,
         "did": snap.did,
-        "didDoc": {},                // caller can fetch /.well-known/did.json
+        "didDoc": did_doc,
         "collections": collections,
-        "handleIsValid": true,
+        "handleIsCorrect": true,
     }))
     .into_response()
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// getRecord
+// getRecord — with optional cid pinning
 // ─────────────────────────────────────────────────────────────────────────────
 
-#[derive(Debug, Deserialize)]
-pub struct GetRecordQuery {
-    /// `at://` URI of the record, e.g.
-    /// `at://did:web:x/ai.hyprstream.model/<rkey>`.
-    pub repo: String,
-    pub collection: String,
-    pub rkey: String,
-}
-
-/// `GET /xrpc/com.atproto.repo.getRecord?repo=<did>&collection=<nsid>&rkey=<rkey>`.
+/// `GET /xrpc/com.atproto.repo.getRecord?repo=<did>&collection=<nsid>&rkey=<rkey>[&cid=<cid>]`.
+///
+/// When `cid` is provided, returns `RecordNotFound` if the current record's CID
+/// does not match (version mismatch).
 pub async fn get_record(
     State(state): State<Arc<OAuthState>>,
-    Query(q): Query<GetRecordQuery>,
+    RawQuery(raw): RawQuery,
 ) -> Response {
-    if q.collection != HOSTED_COLLECTION {
+    let params = parse_query(raw.as_deref());
+
+    let collection = params.get("collection").copied().unwrap_or("");
+    let rkey = params.get("rkey").copied().unwrap_or("");
+
+    if collection != HOSTED_COLLECTION {
         return xrpc_error(
             StatusCode::BAD_REQUEST,
             errors::RECORD_NOT_FOUND,
-            format!("collection {} is not hosted", q.collection),
+            format!("collection {collection:?} is not hosted"),
         );
     }
-    if q.rkey.is_empty() {
+    if rkey.is_empty() {
         return xrpc_error(
             StatusCode::BAD_REQUEST,
             errors::INVALID_REQUEST,
@@ -524,59 +411,92 @@ pub async fn get_record(
         );
     }
 
-    let snap = match lookup_snapshot(&state, &q.repo).await {
+    let repo = match params.get("repo") {
+        Some(r) if !r.is_empty() => r.trim(),
+        _ => {
+            return xrpc_error(
+                StatusCode::BAD_REQUEST,
+                errors::INVALID_REQUEST,
+                "repo query parameter is required",
+            );
+        }
+    };
+
+    let snap = match lookup_public_snapshot(&state, repo).await {
         Some(s) => s,
         None => {
             return xrpc_error(
                 StatusCode::BAD_REQUEST,
                 errors::REPO_NOT_FOUND,
-                format!("repo {:?} is not hosted by this PDS", q.repo),
+                format!("repo {repo:?} is not hosted by this PDS"),
             );
         }
     };
 
-    let Some((rec, _cid)) = snap.record_by_rkey(&q.rkey) else {
+    let Some((rec, cid)) = snap.record_by_rkey(rkey) else {
         return xrpc_error(
             StatusCode::BAD_REQUEST,
             errors::RECORD_NOT_FOUND,
-            format!("record {}/{} not found", q.collection, q.rkey),
+            format!("record {collection}/{rkey} not found"),
         );
     };
 
-    Json(snap.record_json(&q.rkey, rec)).into_response()
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// sync.getRepo — CAR export
-// ─────────────────────────────────────────────────────────────────────────────
-
-#[derive(Debug, Deserialize)]
-pub struct GetRepoQuery {
-    pub did: String,
-    /// Optional earliest commit CID — the MVP store has one head, so a
-    /// non-matching `since` simply returns the full CAR (no delta encoding).
-    #[serde(default)]
-    pub since: Option<String>,
-}
-
-/// `GET /xrpc/com.atproto.sync.getRepo?did=<did>`.
-///
-/// Returns a CARv1 blob (`application/vnd.ipld.car`) containing the commit +
-/// MST + records, rooted at the signed commit.
-pub async fn get_repo(
-    State(state): State<Arc<OAuthState>>,
-    Query(q): Query<GetRepoQuery>,
-) -> Response {
-    let did = q.did.trim().to_owned();
-    if did.is_empty() {
-        return xrpc_error(
-            StatusCode::BAD_REQUEST,
-            errors::INVALID_REQUEST,
-            "did query parameter is required",
-        );
+    // Optional cid pinning: if the client requests a specific version and it
+    // doesn't match, return RecordNotFound (the record at that version is gone).
+    if let Some(requested_cid) = params.get("cid") {
+        if *requested_cid != cid.to_string() {
+            return xrpc_error(
+                StatusCode::BAD_REQUEST,
+                errors::RECORD_NOT_FOUND,
+                format!("record {collection}/{rkey} does not match cid {requested_cid:?}"),
+            );
+        }
     }
 
-    let snap = match state.xrpc_repos.get(&did).await {
+    axum::Json(snap.record_json(rkey, rec)).into_response()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// sync.getRepo — streamed CAR export with concurrency cap
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// `GET /xrpc/com.atproto.sync.getRepo?did=<did>[&since=<commitCid>]`.
+///
+/// Streams a CARv1 blob (`application/vnd.ipld.car`) containing the commit +
+/// MST + records, rooted at the signed commit. Sections are streamed
+/// incrementally via `Body::from_stream` — no double materialization.
+///
+/// `since` (revision-delta) is not yet supported and returns `InvalidRequest`
+/// rather than silently returning the full repo.
+pub async fn get_repo(
+    State(state): State<Arc<OAuthState>>,
+    RawQuery(raw): RawQuery,
+) -> Response {
+    let params = parse_query(raw.as_deref());
+
+    let did = match params.get("did") {
+        Some(d) if !d.is_empty() => d.trim(),
+        _ => {
+            return xrpc_error(
+                StatusCode::BAD_REQUEST,
+                errors::INVALID_REQUEST,
+                "did query parameter is required",
+            );
+        }
+    };
+
+    // since: reject explicitly until delta export is implemented (#910).
+    if let Some(since) = params.get("since") {
+        if !since.is_empty() {
+            return xrpc_error(
+                StatusCode::BAD_REQUEST,
+                errors::INVALID_REQUEST,
+                "since (revision delta) is not yet supported; omit for full export",
+            );
+        }
+    }
+
+    let snap = match state.xrpc_repos.get_public(did).await {
         Some(s) => s,
         None => {
             return xrpc_error(
@@ -587,11 +507,30 @@ pub async fn get_repo(
         }
     };
 
-    let car = snap.full_car();
+    // Acquire concurrency permit — bounded by GET_REPO_CONCURRENCY.
+    let _permit = match state.xrpc_repos.acquire_get_repo().await {
+        Ok(p) => p,
+        Err(_) => {
+            return xrpc_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                errors::INTERNAL_SERVER_ERROR,
+                "concurrency limiter closed",
+            );
+        }
+    };
+
+    // Build length-framed sections and stream them incrementally.
+    let sections = snap.full_car_sections();
+    let body = axum::body::Body::from_stream(stream::iter(
+        sections
+            .into_iter()
+            .map(|s| Ok::<Bytes, std::convert::Infallible>(Bytes::from(s))),
+    ));
+
     (
         StatusCode::OK,
         [(header::CONTENT_TYPE, "application/vnd.ipld.car")],
-        car,
+        body,
     )
         .into_response()
 }
@@ -600,21 +539,17 @@ pub async fn get_repo(
 // Shared helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Resolve a `did:` or handle reference to a hosted snapshot.
-async fn lookup_snapshot(state: &OAuthState, key: &str) -> Option<Arc<RepoSnapshot>> {
+/// Resolve a `did:` or handle reference to a **public** snapshot.
+/// Non-public repos are invisible (publication boundary).
+async fn lookup_public_snapshot(
+    state: &OAuthState,
+    key: &str,
+) -> Option<Arc<RepoSnapshot>> {
     if key.starts_with("did:") {
-        state.xrpc_repos.get(key).await
+        state.xrpc_repos.get_public(key).await
     } else {
-        state.xrpc_repos.by_handle(key).await
+        state.xrpc_repos.by_handle_public(key).await
     }
-}
-
-/// Extract a `Bearer <token>` from request headers.
-fn bearer_token(headers: &axum::http::HeaderMap) -> Option<String> {
-    headers
-        .get(header::AUTHORIZATION)
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.strip_prefix("Bearer ").map(str::to_owned))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -629,7 +564,7 @@ mod tests {
     use rand::rngs::OsRng;
 
     /// Build a minimal hosted snapshot with one record, signed by a fresh key.
-    fn sample_snapshot(did: &str, handle: &str) -> RepoSnapshot {
+    fn sample_snapshot(did: &str, handle: &str, public: bool) -> RepoSnapshot {
         let signing = SigningKey::random(&mut OsRng);
         let vk = VerifyingKey::from(&signing);
 
@@ -651,10 +586,9 @@ mod tests {
         let (_root_data, node_blocks) = tree.to_node_data_with_blocks();
         let root_cid = tree.root_cid();
 
-        // Signed commit head — version 3, no predecessor.
         use hyprstream_pds::commit::UnsignedCommit;
         let unsigned = UnsignedCommit::new(did.to_owned(), root_cid, Tid::now(), None);
-        let commit = hyprstream_pds::commit::Commit::sign(&unsigned, &signing);
+        let commit = Commit::sign(&unsigned, &signing);
         commit.verify(&vk).expect("self-signed commit verifies");
 
         RepoSnapshot {
@@ -664,6 +598,7 @@ mod tests {
             node_blocks,
             records,
             atproto_vk: vk,
+            public,
         }
     }
 
@@ -672,48 +607,43 @@ mod tests {
         let body = xrpc_error_body("RecordNotFound", "no such record");
         assert_eq!(body["error"], "RecordNotFound");
         assert_eq!(body["message"], "no such record");
-        // Only the two XRPC fields — no extras that would confuse clients.
         assert_eq!(body.as_object().unwrap().len(), 2);
     }
 
     #[test]
     fn snapshot_record_json_carries_uri_cid_and_value() {
-        let snap = sample_snapshot("did:web:hyprstream.example.com", "hyprstream.example.com");
+        let snap = sample_snapshot("did:web:h.example.com", "h.example.com", true);
         let (tid, rec) = snap.records.iter().next().unwrap();
         let rkey = tid.encode();
         let json = snap.record_json(&rkey, rec);
         assert_eq!(
             json["uri"],
-            format!("at://did:web:hyprstream.example.com/{HOSTED_COLLECTION}/{rkey}"),
+            format!("at://did:web:h.example.com/{HOSTED_COLLECTION}/{rkey}"),
         );
         assert_eq!(json["value"]["$type"], HOSTED_COLLECTION);
-        assert_eq!(json["value"]["repo"], "at://did:web:hyprstream.example.com");
-        assert_eq!(json["value"]["currentOid"], rec.current_oid);
     }
 
     #[test]
-    fn snapshot_full_car_round_trips_via_parse_car_v1() {
-        let snap = sample_snapshot("did:web:hyprstream.example.com", "hyprstream.example.com");
-        let car = snap.full_car();
+    fn snapshot_full_car_sections_round_trip_via_parse_car_v1() {
+        let snap = sample_snapshot("did:web:h.example.com", "h.example.com", true);
+        // Concatenate sections and parse as a single CARv1 blob.
+        let sections = snap.full_car_sections();
+        let car: Vec<u8> = sections.into_iter().flatten().collect();
         let (roots, blocks) = hyprstream_pds::car::parse_car_v1(&car).expect("parse CAR");
         assert_eq!(roots.len(), 1);
         assert_eq!(roots[0], snap.commit.cid());
-        // commit block + at least one MST node + one record block.
-        assert!(blocks.len() >= 3);
+        assert!(blocks.len() >= 3); // commit + MST node + record
     }
 
     #[test]
     fn snapshot_record_proof_car_verifies_offline() {
-        let snap = sample_snapshot("did:web:hyprstream.example.com", "hyprstream.example.com");
+        let snap = sample_snapshot("did:web:h.example.com", "h.example.com", true);
         let (tid, _rec) = snap.records.iter().next().unwrap();
         let rkey = tid.encode();
         let car = snap.record_proof_car(&rkey).expect("proof for present rkey");
-
-        // Offline D5 verify against the atproto verifying key.
         let (roots, blocks) = hyprstream_pds::car::parse_car_v1(&car).expect("parse CAR");
         assert_eq!(roots.len(), 1);
 
-        // Find commit + record blocks and verify the proof.
         let mut commit_block: Option<Vec<u8>> = None;
         let mut record_block: Option<Vec<u8>> = None;
         for (cid, bytes) in &blocks {
@@ -724,94 +654,65 @@ mod tests {
                 record_block = Some(bytes.clone());
             }
         }
-        let commit_bytes = commit_block.expect("commit block present");
-        let record_bytes = record_block.expect("record block present");
-
-        let commit =
-            hyprstream_pds::commit::Commit::from_dag_cbor(&commit_bytes).expect("decode commit");
-        let record =
-            ModelRecord::from_dag_cbor(&record_bytes).expect("decode record");
-        // The commit must verify against the account's #atproto key.
+        let commit = Commit::from_dag_cbor(&commit_block.unwrap()).unwrap();
+        let record = ModelRecord::from_dag_cbor(&record_block.unwrap()).unwrap();
         commit.verify(&snap.atproto_vk).expect("commit verifies");
-        // The record's CID must recompute.
         assert_eq!(record.cid(), snap.records.values().next().unwrap().cid());
     }
 
-    #[test]
-    fn record_by_rkey_round_trips_tid_encoding() {
-        let snap = sample_snapshot("did:web:hyprstream.example.com", "hyprstream.example.com");
-        let (tid, _rec) = snap.records.iter().next().unwrap();
-        let rkey = tid.encode();
-        assert!(snap.record_by_rkey(&rkey).is_some());
-        // Bogus rkey → None.
-        assert!(snap.record_by_rkey("does-not-exist").is_none());
+    #[tokio::test]
+    async fn publication_boundary_public_snapshot_visible() {
+        let store = XrpcRepoStore::new();
+        store.put(sample_snapshot("did:web:pub.example.com", "pub.example.com", true)).await;
+        assert!(store.get_public("did:web:pub.example.com").await.is_some());
+        assert!(store.by_handle_public("pub.example.com").await.is_some());
     }
 
     #[tokio::test]
-    async fn repo_store_put_get_and_handle_lookup() {
+    async fn publication_boundary_non_public_snapshot_invisible() {
         let store = XrpcRepoStore::new();
-        let snap = Arc::new(sample_snapshot("did:web:hyprstream.example.com", "hyprstream.example.com"));
-        store.put((*snap).clone()).await;
-        assert!(store.get("did:web:hyprstream.example.com").await.is_some());
-        assert_eq!(
-            store.by_handle("hyprstream.example.com").await.unwrap().did,
-            "did:web:hyprstream.example.com",
-        );
-        // Unknown handle.
-        assert!(store.by_handle("nope.example.com").await.is_none());
+        // Private snapshot — get() sees it but public lookups must not.
+        store.put(sample_snapshot("did:web:priv.example.com", "priv.example.com", false)).await;
+        assert!(store.get("did:web:priv.example.com").await.is_some());
+        assert!(store.get_public("did:web:priv.example.com").await.is_none());
+        assert!(store.by_handle_public("priv.example.com").await.is_none());
     }
 
     #[tokio::test]
     async fn repo_store_ambiguous_handle_refuses() {
         let store = XrpcRepoStore::new();
-        store.put(sample_snapshot("did:web:a.example.com", "dup.example.com")).await;
-        store.put(sample_snapshot("did:web:b.example.com", "dup.example.com")).await;
-        // Two snapshots claim the same handle — refuse to guess.
-        assert!(store.by_handle("dup.example.com").await.is_none());
+        store.put(sample_snapshot("did:web:a.example.com", "dup.example.com", true)).await;
+        store.put(sample_snapshot("did:web:b.example.com", "dup.example.com", true)).await;
+        assert!(store.by_handle_public("dup.example.com").await.is_none());
     }
 
     #[test]
-    fn bearer_token_strips_scheme_prefix() {
-        let mut headers = axum::http::HeaderMap::new();
-        assert!(bearer_token(&headers).is_none());
-        headers.insert(
-            header::AUTHORIZATION,
-            axum::http::HeaderValue::from_static("Bearer abc123"),
-        );
-        assert_eq!(bearer_token(&headers).as_deref(), Some("abc123"));
+    fn parse_query_extracts_key_value_pairs() {
+        let q = parse_query(Some("repo=did:web:x&collection=ai.hyprstream.model&rkey=abc"));
+        assert_eq!(q.get("repo").copied(), Some("did:web:x"));
+        assert_eq!(q.get("collection").copied(), Some("ai.hyprstream.model"));
+        assert_eq!(q.get("rkey").copied(), Some("abc"));
+        assert_eq!(q.get("missing"), None);
     }
 
     #[test]
-    fn session_output_serializes_camel_case_atproto_envelope() {
-        // Serialize directly to confirm the atproto envelope fields appear
-        // in camelCase and that optional fields are skipped when None.
-        let out = SessionOutput {
-            did: "did:web:x".into(),
-            handle: "x".into(),
-            access_jwt: "tok".into(),
-            refresh_jwt: None,
-            email: None,
-            active: true,
-        };
-        let v = serde_json::to_value(&out).unwrap();
-        assert_eq!(v["did"], "did:web:x");
-        assert_eq!(v["handle"], "x");
-        assert_eq!(v["accessJwt"], "tok");
-        // refreshJwt/email absent when None (skip_serializing_if).
-        assert!(v.get("refreshJwt").is_none());
-        assert!(v.get("email").is_none());
+    fn parse_query_empty_and_malformed() {
+        assert!(parse_query(None).is_empty());
+        assert!(parse_query(Some("")).is_empty());
+        // No `=` → skipped.
+        assert!(parse_query(Some("garbage")).is_empty());
+    }
 
-        // When set, the camelCase name is used.
-        let out2 = SessionOutput {
-            did: "did:web:x".into(),
-            handle: "x".into(),
-            access_jwt: "tok".into(),
-            refresh_jwt: Some("rf".into()),
-            email: Some("u@x".into()),
-            active: true,
-        };
-        let v2 = serde_json::to_value(&out2).unwrap();
-        assert_eq!(v2["refreshJwt"], "rf");
-        assert_eq!(v2["email"], "u@x");
+    #[test]
+    fn describe_repo_did_doc_carries_atproto_vm() {
+        let snap = sample_snapshot("did:web:h.example.com", "h.example.com", true);
+        let doc = snap.did_doc("https://h.example.com");
+        assert_eq!(doc["id"], "did:web:h.example.com");
+        // The atproto verification method must be present.
+        let vms = doc["verificationMethod"].as_array().unwrap();
+        assert!(vms.iter().any(|vm| vm["id"].as_str().unwrap_or("").ends_with("#atproto")));
+        // #atproto_pds service present.
+        let svcs = doc["service"].as_array().unwrap();
+        assert!(svcs.iter().any(|s| s["id"].as_str().unwrap_or("").ends_with("#atproto_pds")));
     }
 }

--- a/crates/hyprstream/src/services/oauth/xrpc.rs
+++ b/crates/hyprstream/src/services/oauth/xrpc.rs
@@ -877,10 +877,32 @@ mod tests {
         state
     }
 
-    /// Build a router using the PRODUCTION `xrpc_routes()` function — the same
-    /// route table `create_app` merges when the feature gate is enabled.
+    /// Build a router through the PRODUCTION `oauth::create_app` builder with
+    /// `xrpc_read_slice=true` — exercises the real feature-gate conditional.
     async fn build_xrpc_router() -> Router {
-        super::xrpc_routes().with_state(build_test_state(true).await)
+        build_production_app(true).await
+    }
+
+    /// Build the production `create_app` with the given feature-gate value.
+    async fn build_production_app(xrpc_enabled: bool) -> Router {
+        use crate::config::server::CorsConfig;
+        let state = build_test_state(xrpc_enabled).await;
+        let cors = CorsConfig {
+            enabled: false,
+            ..Default::default()
+        };
+        crate::services::oauth::create_app(state, &cors)
+    }
+
+    /// Wrap a pre-built state in the production `create_app` (for tests that
+    /// seed additional snapshots before constructing the router).
+    async fn build_production_app_from_state(state: Arc<OAuthState>) -> Router {
+        use crate::config::server::CorsConfig;
+        let cors = CorsConfig {
+            enabled: false,
+            ..Default::default()
+        };
+        crate::services::oauth::create_app(state, &cors)
     }
 
     /// Like `sample_snapshot` but with a fixed TID so the rkey/CID are deterministic.
@@ -1124,33 +1146,47 @@ mod tests {
         assert!(!bytes.is_empty());
     }
 
-    // ── Finding 1: feature-gate test through the production router ─────────────
+    // ── Finding 1: feature-gate matrix — all 4 routes, enabled AND disabled ────
 
     #[tokio::test]
-    async fn router_feature_gate_false_returns_404() {
-        // Build the production create_app with xrpc_read_slice = false.
-        // XRPC routes must not be mounted — requests return 404.
-        use crate::config::server::CorsConfig;
-        let state = build_test_state(false).await;
-        let cors = CorsConfig {
-            enabled: false,
-            ..Default::default()
-        };
-        let app = crate::services::oauth::create_app(state, &cors);
-        let resp = app
-            .clone()
-            .oneshot(req("/xrpc/com.atproto.sync.getRepo?did=did:web:pub.example.com"))
-            .await
-            .unwrap();
-        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    async fn router_feature_gate_disabled_all_four_routes_404() {
+        let app = build_production_app(false).await;
+        // All four XRPC routes must 404 when the gate is disabled.
+        let routes = [
+            "/xrpc/com.atproto.sync.getRepo?did=did:web:pub.example.com",
+            "/xrpc/com.atproto.repo.describeRepo?repo=did:web:pub.example.com",
+            "/xrpc/com.atproto.repo.getRecord?repo=did:web:pub.example.com&collection=ai.hyprstream.model&rkey=abc",
+            "/xrpc/com.atproto.identity.resolveHandle?handle=pub.example.com",
+        ];
+        for uri in &routes {
+            let resp = app.clone().oneshot(req(uri)).await.unwrap();
+            assert_eq!(
+                resp.status(),
+                StatusCode::NOT_FOUND,
+                "route {uri} should 404 when xrpc_read_slice is disabled"
+            );
+        }
+    }
 
-        // All four endpoints should 404.
-        let resp = app
-            .clone()
-            .oneshot(req("/xrpc/com.atproto.repo.describeRepo?repo=did:web:pub.example.com"))
-            .await
-            .unwrap();
-        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    #[tokio::test]
+    async fn router_feature_gate_enabled_all_four_routes_reachable() {
+        // Smoke-test: all four routes reach XRPC handlers (not 404) when enabled.
+        // Detailed assertions are in the individual endpoint tests above.
+        let app = build_production_app(true).await;
+        let routes = [
+            ("/xrpc/com.atproto.repo.describeRepo?repo=did:web:pub.example.com", StatusCode::OK),
+            ("/xrpc/com.atproto.identity.resolveHandle?handle=pub.example.com", StatusCode::OK),
+            ("/xrpc/com.atproto.repo.getRecord?repo=did:web:pub.example.com&collection=ai.hyprstream.model&rkey=abc", StatusCode::BAD_REQUEST), // RecordNotFound
+            ("/xrpc/com.atproto.sync.getRepo?did=did:web:pub.example.com", StatusCode::OK),
+        ];
+        for (uri, expected) in &routes {
+            let resp = app.clone().oneshot(req(uri)).await.unwrap();
+            assert_eq!(
+                resp.status(),
+                *expected,
+                "route {uri} status mismatch when xrpc_read_slice is enabled"
+            );
+        }
     }
 
     // ── Finding 2: routed CID match/mismatch + malformed query ─────────────────
@@ -1162,7 +1198,7 @@ mod tests {
         let rkey = snap.records.keys().next().unwrap().encode();
         let cid = snap.records.values().next().unwrap().cid().to_string();
         state.xrpc_repos.put(snap).await;
-        let app = super::xrpc_routes().with_state(state);
+        let app = build_production_app_from_state(state).await;
         let uri = format!(
             "/xrpc/com.atproto.repo.getRecord?repo=did:web:fixed.example.com\
              &collection={HOSTED_COLLECTION}&rkey={rkey}&cid={cid}"
@@ -1180,7 +1216,7 @@ mod tests {
         let snap = sample_snapshot_fixed_tid("did:web:fixed.example.com", "fixed.example.com", true);
         let rkey = snap.records.keys().next().unwrap().encode();
         state.xrpc_repos.put(snap).await;
-        let app = super::xrpc_routes().with_state(state);
+        let app = build_production_app_from_state(state).await;
         let uri = format!(
             "/xrpc/com.atproto.repo.getRecord?repo=did:web:fixed.example.com\
              &collection={HOSTED_COLLECTION}&rkey={rkey}\

--- a/crates/hyprstream/src/services/oauth/xrpc.rs
+++ b/crates/hyprstream/src/services/oauth/xrpc.rs
@@ -1,0 +1,817 @@
+//! `com.atproto.*` XRPC server surface — MVP read slice (#1112).
+//!
+//! HTTP XRPC endpoints served from the same Axum surface that hosts OAuth and
+//! `/.well-known/atproto-did` (see `super::did_document`). `hyprstream-pds`
+//! remains deliberately no-networking: this module is the serving layer that
+//! calls its data functions (`Commit`/`MST`/`car::build_record_proof_car`).
+//!
+//! # Endpoints (read slice)
+//!
+//! | Method | Path (under `/xrpc/`) | Auth | Notes |
+//! |--------|-----------------------|------|-------|
+//! | POST   | `com.atproto.server.createSession`  | public | bridges to `OAuthState::sessions` |
+//! | GET    | `com.atproto.server.getSession`     | Bearer session | server-side session lookup |
+//! | GET    | `com.atproto.identity.resolveHandle`| public | reuses `did_document` handle→DID |
+//! | GET    | `com.atproto.repo.describeRepo`     | public | DID/handle + MST commit head |
+//! | GET    | `com.atproto.repo.getRecord`        | public | record JSON + CAR proof |
+//! | GET    | `com.atproto.sync.getRepo`          | public | full-repo CARv1 export |
+//!
+//! # Sessions bridge
+//!
+//! atproto's `createSession` is the "log in" call. Rather than build a parallel
+//! auth store, we bridge to the OAuth browser-login `SessionStore
+//! <super::session::SessionStore>`: `createSession` mints a server-side `Session`
+//! (the same store `/oauth/authorize` writes to) and returns its id as
+//! `accessJwt`. `getSession` reverses the lookup. The OAuth `/oauth/token` JWT
+//! path remains the canonical DPoP-bound access-token issuance; this is the
+//! atproto-client-friendly façade over the same subject.
+//!
+//! # Repo store
+//!
+//! There is no on-disk PDS record store yet (the `hyprstream-pds` store is
+//! in-memory by design). The MVP read slice holds per-DID repo snapshots in an
+//! in-process [`XrpcRepoStore`]. The upcoming write path (#910) will populate
+//! it; for now tests and the atproto login integration can seed it directly.
+//!
+//! # Out of scope
+//!
+//! - `com.atproto.sync.subscribeRepos` (firehose) — issue #1112 defers it.
+//! - Write path (`repo.createRecord` etc.) — sequenced with #910.
+//!
+//! # XRPC error envelopes
+//!
+//! All errors follow the XRPC convention: HTTP status code with JSON body
+//! `{"error": "<code>", "message": "<human readable>"}`. See [`xrpc_error`].
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use axum::{
+    extract::{Query, State},
+    http::{header, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use p256::ecdsa::VerifyingKey;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use tokio::sync::RwLock;
+
+use hyprstream_pds::car::{build_car_v1, build_record_proof_car};
+use hyprstream_pds::commit::Commit;
+use hyprstream_pds::mst::{Node, NodeData};
+use hyprstream_pds::record::{ModelRecord, COLLECTION_NSID};
+use hyprstream_pds::tid::Tid;
+use hyprstream_pds::Cid;
+
+use super::did_document::issuer_authority;
+use super::state::OAuthState;
+
+/// `ai.hyprstream.model` is the only collection this PDS hosts today.
+pub const HOSTED_COLLECTION: &str = COLLECTION_NSID;
+
+/// An in-memory snapshot of one repo's signed state — enough to answer the
+/// read slice (`describeRepo` / `getRecord` / `sync.getRepo`).
+///
+/// Holds the signed commit, the full MST node-block set, the per-rkey record
+/// table, and the account's `#atproto` P-256 verifying key (so the host can
+/// re-verify proofs it serves, satisfying the D5 untrusted-host posture).
+#[derive(Clone, Debug)]
+pub struct RepoSnapshot {
+    /// Account DID (e.g. `did:web:hyprstream.example.com`).
+    pub did: String,
+    /// Account handle (bare hostname, no port — atproto handle rule).
+    pub handle: String,
+    /// Signed commit head of the MST.
+    pub commit: Commit,
+    /// `(cid, NodeData)` for every MST node, including the root. Used for
+    /// full-repo CAR export and for record-proof construction.
+    pub node_blocks: Vec<(Cid, NodeData)>,
+    /// All hosted records, keyed by TID. The rkey (record key) in at-uri form
+    /// is `Tid::encode(tid)` (base32-sortable).
+    pub records: BTreeMap<Tid, ModelRecord>,
+    /// The account's published `#atproto` P-256 verifying key.
+    pub atproto_vk: VerifyingKey,
+}
+
+impl RepoSnapshot {
+    /// The MST root CID from the snapshot's commit (`commit.data`).
+    pub fn root_cid(&self) -> Cid {
+        self.commit.data
+    }
+
+    /// Look up the record + its CID for a given rkey.
+    pub fn record_by_rkey(&self, rkey: &str) -> Option<(&ModelRecord, Cid)> {
+        let tid = Tid::parse(rkey).ok()?;
+        let rec = self.records.get(&tid)?;
+        Some((rec, rec.cid()))
+    }
+
+    /// Build a CAR proof for one record (commit + MST path + record).
+    pub fn record_proof_car(&self, rkey: &str) -> Option<Vec<u8>> {
+        let tid = Tid::parse(rkey).ok()?;
+        let rec = self.records.get(&tid)?;
+        // Build a single-collection MST over the current record set, then ask
+        // it for the inclusion proof. The MST is deterministic from the record
+        // table, so this re-derivation matches what the writer produced.
+        let cids: BTreeMap<Tid, Cid> = self
+            .records
+            .iter()
+            .map(|(t, r)| (*t, r.cid()))
+            .collect();
+        let tree = Node::from_records(HOSTED_COLLECTION, &cids);
+        let proof = tree.proof(HOSTED_COLLECTION, &tid)?;
+        Some(build_record_proof_car(&self.commit, &proof, &self.node_blocks, rec))
+    }
+
+    /// Build a full-repo CARv1 export: commit block + all MST nodes + all
+    /// records, rooted at the commit CID. This is `com.atproto.sync.getRepo`.
+    pub fn full_car(&self) -> Vec<u8> {
+        let mut blocks: Vec<(Cid, Vec<u8>)> = Vec::new();
+        // Commit block.
+        let commit_cid = self.commit.cid();
+        blocks.push((commit_cid, self.commit.to_dag_cbor()));
+        // All MST node blocks.
+        for (cid, data) in &self.node_blocks {
+            blocks.push((*cid, data.encode()));
+        }
+        // All record blocks.
+        for rec in self.records.values() {
+            blocks.push((rec.cid(), rec.to_dag_cbor()));
+        }
+        build_car_v1(&[commit_cid], &blocks)
+    }
+
+    /// Convert a hosted record to the atproto `getRecord` `value` JSON:
+    /// the lexicon fields plus `$type` and the IPLD-link `$uri`.
+    pub fn record_json(&self, rkey: &str, rec: &ModelRecord) -> Value {
+        let uri = format!("at://{}/{HOSTED_COLLECTION}/{rkey}", self.did);
+        json!({
+            "uri": uri,
+            "cid": rec.cid().to_string(),
+            "value": {
+                "$type": HOSTED_COLLECTION,
+                "repo": rec.repo,
+                "currentOid": rec.current_oid,
+                "createdAt": rec.created_at,
+            }
+        })
+    }
+}
+
+/// In-process registry of hosted repos, keyed by DID. Populated by the write
+/// path (#910) and by tests; the read slice consults it directly.
+#[derive(Debug, Default)]
+pub struct XrpcRepoStore {
+    by_did: RwLock<BTreeMap<String, Arc<RepoSnapshot>>>,
+}
+
+impl XrpcRepoStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert or replace a snapshot for a DID.
+    pub async fn put(&self, snap: RepoSnapshot) {
+        self.by_did.write().await.insert(snap.did.clone(), Arc::new(snap));
+    }
+
+    pub async fn get(&self, did: &str) -> Option<Arc<RepoSnapshot>> {
+        self.by_did.read().await.get(did).cloned()
+    }
+
+    /// Resolve a handle (bare hostname) to a snapshot — only unique handles
+    /// resolve unambiguously, which is the atproto handle-uniqueness rule.
+    pub async fn by_handle(&self, handle: &str) -> Option<Arc<RepoSnapshot>> {
+        let guard = self.by_did.read().await;
+        let mut hits = guard.values().filter(|s| s.handle == handle);
+        let first = hits.next()?;
+        if hits.next().is_some() {
+            // Ambiguous handle — refuse rather than guess.
+            return None;
+        }
+        Some(Arc::clone(first))
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// XRPC error envelope helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Build an XRPC error JSON body. Always includes `error` and `message`.
+pub fn xrpc_error_body(error: &str, message: impl Into<String>) -> Value {
+    json!({ "error": error, "message": message.into() })
+}
+
+/// Build an XRPC error [`Response`] with the given status code and body.
+pub fn xrpc_error(status: StatusCode, error: &str, message: impl Into<String>) -> Response {
+    (status, Json(xrpc_error_body(error, message))).into_response()
+}
+
+/// Common XRPC error codes used by the atproto read slice.
+pub mod errors {
+    pub const INVALID_REQUEST: &str = "InvalidRequest";
+    pub const BAD_REQUEST: &str = "BadRequest";
+    pub const UNAUTHORIZED: &str = "Unauthorized";
+    pub const INVALID_TOKEN: &str = "InvalidToken";
+    pub const EXPIRED_TOKEN: &str = "ExpiredToken";
+    pub const ACCOUNT_NOT_FOUND: &str = "AccountNotFound";
+    pub const RECORD_NOT_FOUND: &str = "RecordNotFound";
+    pub const REPO_NOT_FOUND: &str = "RepoNotFound";
+    pub const INTERNAL_SERVER_ERROR: &str = "InternalServerError";
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// createSession / getSession — bridge to OAuth SessionStore
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// `POST /xrpc/com.atproto.server.createSession` request body.
+///
+/// atproto clients post `identifier` (handle or DID) + `password`. The MVP
+/// bridge accepts the same shape but treats `identifier` as the local username
+/// (per `OAuthState::sessions`'s `username` field) and `password` as a
+/// presence-only credential for the local dev login story. Real credential
+/// checks happen via OAuth `/oauth/authorize` + SCIM; this is the façade that
+/// issues an atproto-shaped session backed by the same store.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CreateSessionInput {
+    pub identifier: String,
+    #[serde(default)]
+    pub password: String,
+}
+
+/// `POST /xrpc/com.atproto.server.createSession` response — atproto session
+/// envelope. `accessJwt` is the server-side session id (see module docs).
+///
+/// Field names serialize as atproto's camelCase via `rename_all`.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionOutput {
+    pub did: String,
+    pub handle: String,
+    pub access_jwt: String,
+    /// Standard atproto field; omitted when no OAuth JWT path was taken.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_jwt: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    pub active: bool,
+}
+
+/// `GET /xrpc/com.atproto.server.getSession` response.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetSessionOutput {
+    pub did: String,
+    pub handle: String,
+    pub active: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+}
+
+/// Resolve `identifier` (DID or handle) to a hosted snapshot.
+async fn resolve_account(
+    state: &OAuthState,
+    identifier: &str,
+) -> Option<Arc<RepoSnapshot>> {
+    // Direct DID lookup first.
+    if identifier.starts_with("did:") {
+        if let Some(snap) = state.xrpc_repos.get(identifier).await {
+            return Some(snap);
+        }
+    }
+    // Fall back to handle (bare hostname) lookup in the repo store.
+    if let Some(snap) = state.xrpc_repos.by_handle(identifier).await {
+        return Some(snap);
+    }
+    // Final fallback: treat the identifier as this deployment's own subject —
+    // `did:web:{authority}` — when no snapshot is seeded. This keeps the login
+    // story usable in single-tenant dev setups with no seeded repo.
+    if let Some(authority) = issuer_authority(&state.issuer_url) {
+        let did = format!("did:web:{authority}");
+        let handle = authority.split(':').next().unwrap_or(&authority).to_owned();
+        if identifier.eq_ignore_ascii_case(&handle) || identifier == did {
+            return None; // no snapshot — caller surfaces AccountNotFound
+        }
+    }
+    None
+}
+
+/// `POST /xrpc/com.atproto.server.createSession`.
+pub async fn create_session(
+    State(state): State<Arc<OAuthState>>,
+    Json(input): Json<CreateSessionInput>,
+) -> Response {
+    let identifier = input.identifier.trim();
+    if identifier.is_empty() {
+        return xrpc_error(
+            StatusCode::BAD_REQUEST,
+            errors::INVALID_REQUEST,
+            "identifier is required",
+        );
+    }
+
+    let snap = match resolve_account(&state, identifier).await {
+        Some(s) => s,
+        None => {
+            return xrpc_error(
+                StatusCode::BAD_REQUEST,
+                errors::ACCOUNT_NOT_FOUND,
+                format!("no account found for identifier {identifier:?}"),
+            );
+        }
+    };
+
+    // Bridge: mint a server-side OAuth session for the same subject. Same store
+    // `/oauth/authorize` writes to; no parallel auth state.
+    let session_id = state
+        .sessions
+        .create(snap.did.clone(), "atproto-xrpc".to_owned())
+        .await;
+
+    Json(SessionOutput {
+        did: snap.did.clone(),
+        handle: snap.handle.clone(),
+        access_jwt: session_id,
+        refresh_jwt: None,
+        email: None,
+        active: true,
+    })
+    .into_response()
+}
+
+/// `GET /xrpc/com.atproto.server.getSession`.
+///
+/// `Authorization: Bearer <accessJwt>` where `accessJwt` is the session id
+/// returned by `createSession`.
+pub async fn get_session(
+    State(state): State<Arc<OAuthState>>,
+    headers: axum::http::HeaderMap,
+) -> Response {
+    let Some(token) = bearer_token(&headers) else {
+        return xrpc_error(
+            StatusCode::UNAUTHORIZED,
+            errors::INVALID_TOKEN,
+            "Bearer accessJwt required",
+        );
+    };
+    let Some(session) = state.sessions.get(&token).await else {
+        return xrpc_error(
+            StatusCode::UNAUTHORIZED,
+            errors::EXPIRED_TOKEN,
+            "session not found or expired",
+        );
+    };
+
+    let snap = state.xrpc_repos.get(&session.username).await;
+    let (did, handle) = match snap {
+        Some(s) => (s.did.clone(), s.handle.clone()),
+        // Session is valid but no repo snapshot is seeded — degrade gracefully
+        // using the issuer-derived DID so getSession still answers.
+        None => match issuer_authority(&state.issuer_url) {
+            Some(authority) => {
+                let did = format!("did:web:{authority}");
+                let handle = authority.split(':').next().unwrap_or(&authority).to_owned();
+                (did, handle)
+            }
+            None => {
+                return xrpc_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    errors::INTERNAL_SERVER_ERROR,
+                    "issuer URL has no authority",
+                );
+            }
+        },
+    };
+
+    Json(GetSessionOutput {
+        did,
+        handle,
+        active: true,
+        email: None,
+    })
+    .into_response()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// resolveHandle
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct ResolveHandleQuery {
+    pub handle: String,
+}
+
+/// `GET /xrpc/com.atproto.identity.resolveHandle?handle=<host>`.
+///
+/// Shares logic with `/.well-known/atproto-did`: the deployment's own handle
+/// (issuer authority) resolves to `did:web:{authority}`; hosted-account handles
+/// resolve from the repo store.
+pub async fn resolve_handle(
+    State(state): State<Arc<OAuthState>>,
+    Query(q): Query<ResolveHandleQuery>,
+) -> Response {
+    let handle = q.handle.trim().to_owned();
+    if handle.is_empty() {
+        return xrpc_error(
+            StatusCode::BAD_REQUEST,
+            errors::INVALID_REQUEST,
+            "handle query parameter is required",
+        );
+    }
+
+    // Hosted account?
+    if let Some(snap) = state.xrpc_repos.by_handle(&handle).await {
+        return Json(json!({ "did": snap.did })).into_response();
+    }
+
+    // This deployment's own handle?
+    if let Some(authority) = issuer_authority(&state.issuer_url) {
+        let self_handle = authority.split(':').next().unwrap_or(&authority);
+        if handle == self_handle {
+            let did = format!("did:web:{authority}");
+            return Json(json!({ "did": did })).into_response();
+        }
+    }
+
+    xrpc_error(
+        StatusCode::BAD_REQUEST,
+        errors::ACCOUNT_NOT_FOUND,
+        format!("handle {handle:?} is not hosted by this PDS"),
+    )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// describeRepo
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct DescribeRepoQuery {
+    pub repo: String,
+}
+
+/// `GET /xrpc/com.atproto.repo.describeRepo?repo=<did|handle>`.
+pub async fn describe_repo(
+    State(state): State<Arc<OAuthState>>,
+    Query(q): Query<DescribeRepoQuery>,
+) -> Response {
+    let key = q.repo.trim().to_owned();
+    if key.is_empty() {
+        return xrpc_error(
+            StatusCode::BAD_REQUEST,
+            errors::INVALID_REQUEST,
+            "repo query parameter is required",
+        );
+    }
+
+    let snap = match lookup_snapshot(&state, &key).await {
+        Some(s) => s,
+        None => {
+            return xrpc_error(
+                StatusCode::BAD_REQUEST,
+                errors::REPO_NOT_FOUND,
+                format!("repo {key:?} is not hosted by this PDS"),
+            );
+        }
+    };
+
+    let collections = if snap.records.is_empty() {
+        Vec::new()
+    } else {
+        vec![json!({ "nsid": HOSTED_COLLECTION, "count": snap.records.len() })]
+    };
+
+    Json(json!({
+        "handle": snap.handle,
+        "did": snap.did,
+        "didDoc": {},                // caller can fetch /.well-known/did.json
+        "collections": collections,
+        "handleIsValid": true,
+    }))
+    .into_response()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getRecord
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct GetRecordQuery {
+    /// `at://` URI of the record, e.g.
+    /// `at://did:web:x/ai.hyprstream.model/<rkey>`.
+    pub repo: String,
+    pub collection: String,
+    pub rkey: String,
+}
+
+/// `GET /xrpc/com.atproto.repo.getRecord?repo=<did>&collection=<nsid>&rkey=<rkey>`.
+pub async fn get_record(
+    State(state): State<Arc<OAuthState>>,
+    Query(q): Query<GetRecordQuery>,
+) -> Response {
+    if q.collection != HOSTED_COLLECTION {
+        return xrpc_error(
+            StatusCode::BAD_REQUEST,
+            errors::RECORD_NOT_FOUND,
+            format!("collection {} is not hosted", q.collection),
+        );
+    }
+    if q.rkey.is_empty() {
+        return xrpc_error(
+            StatusCode::BAD_REQUEST,
+            errors::INVALID_REQUEST,
+            "rkey is required",
+        );
+    }
+
+    let snap = match lookup_snapshot(&state, &q.repo).await {
+        Some(s) => s,
+        None => {
+            return xrpc_error(
+                StatusCode::BAD_REQUEST,
+                errors::REPO_NOT_FOUND,
+                format!("repo {:?} is not hosted by this PDS", q.repo),
+            );
+        }
+    };
+
+    let Some((rec, _cid)) = snap.record_by_rkey(&q.rkey) else {
+        return xrpc_error(
+            StatusCode::BAD_REQUEST,
+            errors::RECORD_NOT_FOUND,
+            format!("record {}/{} not found", q.collection, q.rkey),
+        );
+    };
+
+    Json(snap.record_json(&q.rkey, rec)).into_response()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// sync.getRepo — CAR export
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct GetRepoQuery {
+    pub did: String,
+    /// Optional earliest commit CID — the MVP store has one head, so a
+    /// non-matching `since` simply returns the full CAR (no delta encoding).
+    #[serde(default)]
+    pub since: Option<String>,
+}
+
+/// `GET /xrpc/com.atproto.sync.getRepo?did=<did>`.
+///
+/// Returns a CARv1 blob (`application/vnd.ipld.car`) containing the commit +
+/// MST + records, rooted at the signed commit.
+pub async fn get_repo(
+    State(state): State<Arc<OAuthState>>,
+    Query(q): Query<GetRepoQuery>,
+) -> Response {
+    let did = q.did.trim().to_owned();
+    if did.is_empty() {
+        return xrpc_error(
+            StatusCode::BAD_REQUEST,
+            errors::INVALID_REQUEST,
+            "did query parameter is required",
+        );
+    }
+
+    let snap = match state.xrpc_repos.get(&did).await {
+        Some(s) => s,
+        None => {
+            return xrpc_error(
+                StatusCode::BAD_REQUEST,
+                errors::REPO_NOT_FOUND,
+                format!("repo {did:?} is not hosted by this PDS"),
+            );
+        }
+    };
+
+    let car = snap.full_car();
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "application/vnd.ipld.car")],
+        car,
+    )
+        .into_response()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Resolve a `did:` or handle reference to a hosted snapshot.
+async fn lookup_snapshot(state: &OAuthState, key: &str) -> Option<Arc<RepoSnapshot>> {
+    if key.starts_with("did:") {
+        state.xrpc_repos.get(key).await
+    } else {
+        state.xrpc_repos.by_handle(key).await
+    }
+}
+
+/// Extract a `Bearer <token>` from request headers.
+fn bearer_token(headers: &axum::http::HeaderMap) -> Option<String> {
+    headers
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer ").map(str::to_owned))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use p256::ecdsa::SigningKey;
+    use rand::rngs::OsRng;
+
+    /// Build a minimal hosted snapshot with one record, signed by a fresh key.
+    fn sample_snapshot(did: &str, handle: &str) -> RepoSnapshot {
+        let signing = SigningKey::random(&mut OsRng);
+        let vk = VerifyingKey::from(&signing);
+
+        let repo_at_uri = format!("at://{did}");
+        let rec = ModelRecord::new(
+            &repo_at_uri,
+            "bafyreiexamplecurrentoid000000000000000000000000000a",
+            "2026-07-19T00:00:00.000Z",
+        )
+        .expect("valid record");
+
+        let tid = Tid::now();
+        let mut record_cids: BTreeMap<Tid, Cid> = BTreeMap::new();
+        record_cids.insert(tid, rec.cid());
+        let mut records: BTreeMap<Tid, ModelRecord> = BTreeMap::new();
+        records.insert(tid, rec);
+
+        let tree = Node::from_records(HOSTED_COLLECTION, &record_cids);
+        let (_root_data, node_blocks) = tree.to_node_data_with_blocks();
+        let root_cid = tree.root_cid();
+
+        // Signed commit head — version 3, no predecessor.
+        use hyprstream_pds::commit::UnsignedCommit;
+        let unsigned = UnsignedCommit::new(did.to_owned(), root_cid, Tid::now(), None);
+        let commit = hyprstream_pds::commit::Commit::sign(&unsigned, &signing);
+        commit.verify(&vk).expect("self-signed commit verifies");
+
+        RepoSnapshot {
+            did: did.to_owned(),
+            handle: handle.to_owned(),
+            commit,
+            node_blocks,
+            records,
+            atproto_vk: vk,
+        }
+    }
+
+    #[test]
+    fn error_body_shape_is_xrpc_convention() {
+        let body = xrpc_error_body("RecordNotFound", "no such record");
+        assert_eq!(body["error"], "RecordNotFound");
+        assert_eq!(body["message"], "no such record");
+        // Only the two XRPC fields — no extras that would confuse clients.
+        assert_eq!(body.as_object().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn snapshot_record_json_carries_uri_cid_and_value() {
+        let snap = sample_snapshot("did:web:hyprstream.example.com", "hyprstream.example.com");
+        let (tid, rec) = snap.records.iter().next().unwrap();
+        let rkey = tid.encode();
+        let json = snap.record_json(&rkey, rec);
+        assert_eq!(
+            json["uri"],
+            format!("at://did:web:hyprstream.example.com/{HOSTED_COLLECTION}/{rkey}"),
+        );
+        assert_eq!(json["value"]["$type"], HOSTED_COLLECTION);
+        assert_eq!(json["value"]["repo"], "at://did:web:hyprstream.example.com");
+        assert_eq!(json["value"]["currentOid"], rec.current_oid);
+    }
+
+    #[test]
+    fn snapshot_full_car_round_trips_via_parse_car_v1() {
+        let snap = sample_snapshot("did:web:hyprstream.example.com", "hyprstream.example.com");
+        let car = snap.full_car();
+        let (roots, blocks) = hyprstream_pds::car::parse_car_v1(&car).expect("parse CAR");
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots[0], snap.commit.cid());
+        // commit block + at least one MST node + one record block.
+        assert!(blocks.len() >= 3);
+    }
+
+    #[test]
+    fn snapshot_record_proof_car_verifies_offline() {
+        let snap = sample_snapshot("did:web:hyprstream.example.com", "hyprstream.example.com");
+        let (tid, _rec) = snap.records.iter().next().unwrap();
+        let rkey = tid.encode();
+        let car = snap.record_proof_car(&rkey).expect("proof for present rkey");
+
+        // Offline D5 verify against the atproto verifying key.
+        let (roots, blocks) = hyprstream_pds::car::parse_car_v1(&car).expect("parse CAR");
+        assert_eq!(roots.len(), 1);
+
+        // Find commit + record blocks and verify the proof.
+        let mut commit_block: Option<Vec<u8>> = None;
+        let mut record_block: Option<Vec<u8>> = None;
+        for (cid, bytes) in &blocks {
+            if *cid == snap.commit.cid() {
+                commit_block = Some(bytes.clone());
+            }
+            if *cid == snap.records.values().next().unwrap().cid() {
+                record_block = Some(bytes.clone());
+            }
+        }
+        let commit_bytes = commit_block.expect("commit block present");
+        let record_bytes = record_block.expect("record block present");
+
+        let commit =
+            hyprstream_pds::commit::Commit::from_dag_cbor(&commit_bytes).expect("decode commit");
+        let record =
+            ModelRecord::from_dag_cbor(&record_bytes).expect("decode record");
+        // The commit must verify against the account's #atproto key.
+        commit.verify(&snap.atproto_vk).expect("commit verifies");
+        // The record's CID must recompute.
+        assert_eq!(record.cid(), snap.records.values().next().unwrap().cid());
+    }
+
+    #[test]
+    fn record_by_rkey_round_trips_tid_encoding() {
+        let snap = sample_snapshot("did:web:hyprstream.example.com", "hyprstream.example.com");
+        let (tid, _rec) = snap.records.iter().next().unwrap();
+        let rkey = tid.encode();
+        assert!(snap.record_by_rkey(&rkey).is_some());
+        // Bogus rkey → None.
+        assert!(snap.record_by_rkey("does-not-exist").is_none());
+    }
+
+    #[tokio::test]
+    async fn repo_store_put_get_and_handle_lookup() {
+        let store = XrpcRepoStore::new();
+        let snap = Arc::new(sample_snapshot("did:web:hyprstream.example.com", "hyprstream.example.com"));
+        store.put((*snap).clone()).await;
+        assert!(store.get("did:web:hyprstream.example.com").await.is_some());
+        assert_eq!(
+            store.by_handle("hyprstream.example.com").await.unwrap().did,
+            "did:web:hyprstream.example.com",
+        );
+        // Unknown handle.
+        assert!(store.by_handle("nope.example.com").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn repo_store_ambiguous_handle_refuses() {
+        let store = XrpcRepoStore::new();
+        store.put(sample_snapshot("did:web:a.example.com", "dup.example.com")).await;
+        store.put(sample_snapshot("did:web:b.example.com", "dup.example.com")).await;
+        // Two snapshots claim the same handle — refuse to guess.
+        assert!(store.by_handle("dup.example.com").await.is_none());
+    }
+
+    #[test]
+    fn bearer_token_strips_scheme_prefix() {
+        let mut headers = axum::http::HeaderMap::new();
+        assert!(bearer_token(&headers).is_none());
+        headers.insert(
+            header::AUTHORIZATION,
+            axum::http::HeaderValue::from_static("Bearer abc123"),
+        );
+        assert_eq!(bearer_token(&headers).as_deref(), Some("abc123"));
+    }
+
+    #[test]
+    fn session_output_serializes_camel_case_atproto_envelope() {
+        // Serialize directly to confirm the atproto envelope fields appear
+        // in camelCase and that optional fields are skipped when None.
+        let out = SessionOutput {
+            did: "did:web:x".into(),
+            handle: "x".into(),
+            access_jwt: "tok".into(),
+            refresh_jwt: None,
+            email: None,
+            active: true,
+        };
+        let v = serde_json::to_value(&out).unwrap();
+        assert_eq!(v["did"], "did:web:x");
+        assert_eq!(v["handle"], "x");
+        assert_eq!(v["accessJwt"], "tok");
+        // refreshJwt/email absent when None (skip_serializing_if).
+        assert!(v.get("refreshJwt").is_none());
+        assert!(v.get("email").is_none());
+
+        // When set, the camelCase name is used.
+        let out2 = SessionOutput {
+            did: "did:web:x".into(),
+            handle: "x".into(),
+            access_jwt: "tok".into(),
+            refresh_jwt: Some("rf".into()),
+            email: Some("u@x".into()),
+            active: true,
+        };
+        let v2 = serde_json::to_value(&out2).unwrap();
+        assert_eq!(v2["refreshJwt"], "rf");
+        assert_eq!(v2["email"], "u@x");
+    }
+}

--- a/crates/hyprstream/src/services/oauth/xrpc.rs
+++ b/crates/hyprstream/src/services/oauth/xrpc.rs
@@ -67,6 +67,22 @@ pub const GET_REPO_CONCURRENCY: usize = 4;
 // RepoSnapshot + XrpcRepoStore
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// The four XRPC read-slice route declarations, as a sub-`Router` parameterised
+/// over `Arc<OAuthState>`. This is the single source of truth for the XRPC route
+/// table — `oauth::create_app` merges it conditionally on `xrpc_read_slice`,
+/// and tests mount it directly. Changing the URI or handler here changes both.
+pub fn xrpc_routes() -> axum::Router<Arc<OAuthState>> {
+    use axum::routing::get;
+    axum::Router::new()
+        .route(
+            "/xrpc/com.atproto.identity.resolveHandle",
+            get(resolve_handle),
+        )
+        .route("/xrpc/com.atproto.repo.describeRepo", get(describe_repo))
+        .route("/xrpc/com.atproto.repo.getRecord", get(get_record))
+        .route("/xrpc/com.atproto.sync.getRepo", get(get_repo))
+}
+
 /// An in-memory snapshot of one repo's signed state — enough to answer the
 /// public read slice (`describeRepo` / `getRecord` / `sync.getRepo`).
 #[derive(Clone, Debug)]
@@ -815,21 +831,18 @@ mod tests {
     use crate::services::{DiscoveryClient, PolicyClient};
     use axum::body::Body;
     use axum::http::Request as HttpRequest;
-    use axum::routing::get;
     use axum::Router;
     use tower::ServiceExt; // oneshot
 
-    /// Build a real XRPC router backed by a real OAuthState. PolicyClient and
-    /// DiscoveryClient point at nonexistent sockets — XRPC handlers never call
-    /// them. Both a public and a private snapshot are seeded.
-    async fn build_xrpc_router() -> Router {
+    /// Build a real OAuthState with dummy PolicyClient/DiscoveryClient (LazyUdsTransport
+    /// pointing at /dev/null — never opened). Seeds a public + private snapshot.
+    async fn build_test_state(xrpc_enabled: bool) -> Arc<OAuthState> {
         use hyprstream_rpc::rpc_client::RpcClientImpl;
         use hyprstream_rpc::signer::LocalSigner;
         use hyprstream_rpc::transport::lazy_uds::LazyUdsTransport;
 
         let key = ed25519_dalek::SigningKey::from_bytes(&[0x76; 32]);
         let vk = ed25519_dalek::SigningKey::from_bytes(&[0x73; 32]).verifying_key();
-        // Dummy socket paths — never opened (XRPC handlers never call policy/discovery).
         let dummy = std::path::PathBuf::from("/dev/null/xrpc-test.sock");
 
         let mk_client = || {
@@ -841,22 +854,18 @@ mod tests {
             .with_response_verify_policy(hyprstream_rpc::crypto::CryptoPolicy::Classical);
             Arc::new(rpc)
         };
-        let policy_client = PolicyClient::new(mk_client());
-        let discovery_client = DiscoveryClient::new(mk_client());
 
         let mut config = OAuthConfig::default();
-        config.xrpc_read_slice = true;
-        // external_url so issuer_url() produces a usable authority.
+        config.xrpc_read_slice = xrpc_enabled;
         config.external_url = Some("https://h.example.com".to_owned());
 
         let state = Arc::new(OAuthState::new(
             &config,
-            policy_client,
-            discovery_client,
+            PolicyClient::new(mk_client()),
+            DiscoveryClient::new(mk_client()),
             [0x76; 32],
         ));
 
-        // Seed snapshots.
         state
             .xrpc_repos
             .put(sample_snapshot("did:web:pub.example.com", "pub.example.com", true))
@@ -865,16 +874,44 @@ mod tests {
             .xrpc_repos
             .put(sample_snapshot("did:web:priv.example.com", "priv.example.com", false))
             .await;
+        state
+    }
 
-        Router::new()
-            .route(
-                "/xrpc/com.atproto.identity.resolveHandle",
-                get(resolve_handle),
-            )
-            .route("/xrpc/com.atproto.repo.describeRepo", get(describe_repo))
-            .route("/xrpc/com.atproto.repo.getRecord", get(get_record))
-            .route("/xrpc/com.atproto.sync.getRepo", get(get_repo))
-            .with_state(state)
+    /// Build a router using the PRODUCTION `xrpc_routes()` function — the same
+    /// route table `create_app` merges when the feature gate is enabled.
+    async fn build_xrpc_router() -> Router {
+        super::xrpc_routes().with_state(build_test_state(true).await)
+    }
+
+    /// Like `sample_snapshot` but with a fixed TID so the rkey/CID are deterministic.
+    fn sample_snapshot_fixed_tid(did: &str, handle: &str, public: bool) -> RepoSnapshot {
+        let mut snap = sample_snapshot(did, handle, public);
+        // Rebuild with a fixed TID for deterministic rkey.
+        let signing = p256::ecdsa::SigningKey::random(&mut OsRng);
+        let vk = VerifyingKey::from(&signing);
+        let repo_at_uri = format!("at://{did}");
+        let rec = ModelRecord::new(
+            &repo_at_uri,
+            "bafyreiexamplecurrentoid000000000000000000000000000a",
+            "2026-07-19T00:00:00.000Z",
+        )
+        .expect("valid record");
+        let fixed_tid = Tid::from_micros(1_700_000_000_000_000, 1);
+        let mut record_cids: BTreeMap<Tid, Cid> = BTreeMap::new();
+        record_cids.insert(fixed_tid, rec.cid());
+        let mut records: BTreeMap<Tid, ModelRecord> = BTreeMap::new();
+        records.insert(fixed_tid, rec);
+        let tree = Node::from_records(HOSTED_COLLECTION, &record_cids);
+        let (_root_data, node_blocks) = tree.to_node_data_with_blocks();
+        let root_cid = tree.root_cid();
+        use hyprstream_pds::commit::UnsignedCommit;
+        let unsigned = UnsignedCommit::new(did.to_owned(), root_cid, Tid::now(), None);
+        let commit = Commit::sign(&unsigned, &signing);
+        snap.commit = commit;
+        snap.node_blocks = node_blocks;
+        snap.records = records;
+        snap.atproto_vk = vk;
+        snap
     }
 
     async fn resp_json(resp: axum::response::Response) -> Value {
@@ -1085,5 +1122,100 @@ mod tests {
             .await
             .unwrap();
         assert!(!bytes.is_empty());
+    }
+
+    // ── Finding 1: feature-gate test through the production router ─────────────
+
+    #[tokio::test]
+    async fn router_feature_gate_false_returns_404() {
+        // Build the production create_app with xrpc_read_slice = false.
+        // XRPC routes must not be mounted — requests return 404.
+        use crate::config::server::CorsConfig;
+        let state = build_test_state(false).await;
+        let cors = CorsConfig {
+            enabled: false,
+            ..Default::default()
+        };
+        let app = crate::services::oauth::create_app(state, &cors);
+        let resp = app
+            .clone()
+            .oneshot(req("/xrpc/com.atproto.sync.getRepo?did=did:web:pub.example.com"))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        // All four endpoints should 404.
+        let resp = app
+            .clone()
+            .oneshot(req("/xrpc/com.atproto.repo.describeRepo?repo=did:web:pub.example.com"))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    // ── Finding 2: routed CID match/mismatch + malformed query ─────────────────
+
+    #[tokio::test]
+    async fn router_get_record_cid_match_returns_record() {
+        let state = build_test_state(true).await;
+        let snap = sample_snapshot_fixed_tid("did:web:fixed.example.com", "fixed.example.com", true);
+        let rkey = snap.records.keys().next().unwrap().encode();
+        let cid = snap.records.values().next().unwrap().cid().to_string();
+        state.xrpc_repos.put(snap).await;
+        let app = super::xrpc_routes().with_state(state);
+        let uri = format!(
+            "/xrpc/com.atproto.repo.getRecord?repo=did:web:fixed.example.com\
+             &collection={HOSTED_COLLECTION}&rkey={rkey}&cid={cid}"
+        );
+        let resp = app.oneshot(req(&uri)).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp_json(resp).await;
+        assert_eq!(body["cid"], cid);
+        assert_eq!(body["value"]["$type"], HOSTED_COLLECTION);
+    }
+
+    #[tokio::test]
+    async fn router_get_record_cid_mismatch_returns_record_not_found() {
+        let state = build_test_state(true).await;
+        let snap = sample_snapshot_fixed_tid("did:web:fixed.example.com", "fixed.example.com", true);
+        let rkey = snap.records.keys().next().unwrap().encode();
+        state.xrpc_repos.put(snap).await;
+        let app = super::xrpc_routes().with_state(state);
+        let uri = format!(
+            "/xrpc/com.atproto.repo.getRecord?repo=did:web:fixed.example.com\
+             &collection={HOSTED_COLLECTION}&rkey={rkey}\
+             &cid=bafyreiwrongcid000000000000000000000000000000000000"
+        );
+        let resp = app.oneshot(req(&uri)).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = resp_json(resp).await;
+        assert_eq!(body["error"], errors::RECORD_NOT_FOUND);
+        assert!(
+            body["message"].as_str().unwrap().contains("does not match cid"),
+            "message must explain the cid mismatch: {}",
+            body["message"]
+        );
+    }
+
+    #[tokio::test]
+    async fn router_malformed_query_empty_repo() {
+        let app = build_xrpc_router().await;
+        // ?repo= — empty value at the wrapper boundary.
+        let resp = app
+            .clone()
+            .oneshot(req(
+                "/xrpc/com.atproto.repo.getRecord?repo=\
+                 &collection=ai.hyprstream.model&rkey=abc",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = resp_json(resp).await;
+        assert_eq!(body["error"], errors::INVALID_REQUEST);
+        assert!(
+            body["message"].as_str().unwrap().contains("repo"),
+            "message must mention repo: {}",
+            body["message"]
+        );
     }
 }

--- a/crates/hyprstream/src/services/oauth/xrpc.rs
+++ b/crates/hyprstream/src/services/oauth/xrpc.rs
@@ -316,16 +316,56 @@ pub mod errors {
 // Query parsing (manual — no axum Query rejection bypasses XRPC envelope)
 // ─────────────────────────────────────────────────────────────────────────────
 
-fn parse_query(raw: Option<&str>) -> std::collections::HashMap<&str, &str> {
+/// Parse a raw query string `key=value&key=value` into a map.
+///
+/// - **Bare keys** (no `=`) are inserted with an empty value — so `?since`
+///   is treated as present, matching form/urlencoded semantics.
+/// - **Percent-decoding**: `%XX` sequences are decoded and `+` becomes a
+///   space (form semantics), so encoded DIDs/handles/rkeys resolve.
+fn parse_query(raw: Option<&str>) -> std::collections::HashMap<String, String> {
     let mut map = std::collections::HashMap::new();
     if let Some(q) = raw {
         for pair in q.split('&') {
-            if let Some((k, v)) = pair.split_once('=') {
-                map.insert(k, v);
-            }
+            let (key, val) = match pair.split_once('=') {
+                Some((k, v)) => (k, v),
+                None => (pair, ""), // bare key → present with empty value
+            };
+            map.insert(percent_decode(key), percent_decode(val));
         }
     }
     map
+}
+
+/// Minimal percent-decoder: `%XX` → byte, `+` → space.
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'+' => out.push(b' '),
+            b'%' if i + 2 < bytes.len() => {
+                if let (Some(hi), Some(lo)) = (hex_val(bytes[i + 1]), hex_val(bytes[i + 2])) {
+                    out.push(hi * 16 + lo);
+                    i += 2;
+                } else {
+                    out.push(b'%');
+                }
+            }
+            b => out.push(b),
+        }
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn hex_val(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -527,8 +567,8 @@ pub async fn get_record(
     RawQuery(raw): RawQuery,
 ) -> Response {
     let params = parse_query(raw.as_deref());
-    let collection = params.get("collection").copied().unwrap_or("");
-    let rkey = params.get("rkey").copied().unwrap_or("");
+    let collection = params.get("collection").map(std::string::String::as_str).unwrap_or("");
+    let rkey = params.get("rkey").map(std::string::String::as_str).unwrap_or("");
     let repo = match params.get("repo") {
         Some(r) if !r.is_empty() => r.trim(),
         _ => {
@@ -811,18 +851,40 @@ mod tests {
     }
 
     #[test]
-    fn parse_query_rejects_empty_value_since() {
-        // ?since= parses to key "since" with value "".
+    fn parse_query_empty_value_since_is_present() {
+        // ?since= → key "since" present with value "".
         let q = parse_query(Some("did=did:web:x&since="));
         assert!(q.contains_key("since"));
-        assert_eq!(q.get("since").copied(), Some(""));
+        assert_eq!(q.get("since").map(std::string::String::as_str), Some(""));
+    }
+
+    #[test]
+    fn parse_query_bare_key_since_is_present() {
+        // ?since (no =) → key "since" present with value "".
+        let q = parse_query(Some("did=did:web:x&since"));
+        assert!(q.contains_key("since"));
+        assert_eq!(q.get("since").map(std::string::String::as_str), Some(""));
+    }
+
+    #[test]
+    fn parse_query_percent_decodes_values() {
+        // did%3Aweb%3Ax → did:web:x (colons percent-encoded).
+        let q = parse_query(Some("repo=did%3Aweb%3Ax&collection=ai.hyprstream.model"));
+        assert_eq!(q.get("repo").map(std::string::String::as_str), Some("did:web:x"));
+        assert_eq!(q.get("collection").map(std::string::String::as_str), Some("ai.hyprstream.model"));
+    }
+
+    #[test]
+    fn parse_query_plus_becomes_space() {
+        let q = parse_query(Some("handle=foo+bar"));
+        assert_eq!(q.get("handle").map(std::string::String::as_str), Some("foo bar"));
     }
 
     #[test]
     fn parse_query_extracts_key_value_pairs() {
         let q = parse_query(Some("repo=did:web:x&collection=ai.hyprstream.model&rkey=abc"));
-        assert_eq!(q.get("repo").copied(), Some("did:web:x"));
-        assert_eq!(q.get("collection").copied(), Some("ai.hyprstream.model"));
+        assert_eq!(q.get("repo").map(std::string::String::as_str), Some("did:web:x"));
+        assert_eq!(q.get("collection").map(std::string::String::as_str), Some("ai.hyprstream.model"));
     }
 
     // ── Router-mounted tests (findings 1 + 2) ─────────────────────────────────
@@ -1253,5 +1315,37 @@ mod tests {
             "message must mention repo: {}",
             body["message"]
         );
+    }
+
+    #[tokio::test]
+    async fn router_bare_since_rejected() {
+        // ?since (bare key, no =) must still be caught by since-rejection.
+        let app = build_xrpc_router().await;
+        let resp = app
+            .clone()
+            .oneshot(req(
+                "/xrpc/com.atproto.sync.getRepo?did=did:web:pub.example.com&since",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = resp_json(resp).await;
+        assert_eq!(body["error"], errors::INVALID_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn router_percent_encoded_did_resolves() {
+        // did%3Aweb%3Apub.example.com → did:web:pub.example.com (percent-decoded).
+        let app = build_xrpc_router().await;
+        let resp = app
+            .clone()
+            .oneshot(req(
+                "/xrpc/com.atproto.repo.describeRepo?repo=did%3Aweb%3Apub.example.com",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp_json(resp).await;
+        assert_eq!(body["did"], "did:web:pub.example.com");
     }
 }

--- a/crates/hyprstream/src/services/oauth/xrpc.rs
+++ b/crates/hyprstream/src/services/oauth/xrpc.rs
@@ -808,4 +808,282 @@ mod tests {
         assert_eq!(q.get("repo").copied(), Some("did:web:x"));
         assert_eq!(q.get("collection").copied(), Some("ai.hyprstream.model"));
     }
+
+    // ── Router-mounted tests (findings 1 + 2) ─────────────────────────────────
+
+    use crate::config::OAuthConfig;
+    use crate::services::{DiscoveryClient, PolicyClient};
+    use axum::body::Body;
+    use axum::http::Request as HttpRequest;
+    use axum::routing::get;
+    use axum::Router;
+    use tower::ServiceExt; // oneshot
+
+    /// Build a real XRPC router backed by a real OAuthState. PolicyClient and
+    /// DiscoveryClient point at nonexistent sockets — XRPC handlers never call
+    /// them. Both a public and a private snapshot are seeded.
+    async fn build_xrpc_router() -> Router {
+        use hyprstream_rpc::rpc_client::RpcClientImpl;
+        use hyprstream_rpc::signer::LocalSigner;
+        use hyprstream_rpc::transport::lazy_uds::LazyUdsTransport;
+
+        let key = ed25519_dalek::SigningKey::from_bytes(&[0x76; 32]);
+        let vk = ed25519_dalek::SigningKey::from_bytes(&[0x73; 32]).verifying_key();
+        // Dummy socket paths — never opened (XRPC handlers never call policy/discovery).
+        let dummy = std::path::PathBuf::from("/dev/null/xrpc-test.sock");
+
+        let mk_client = || {
+            let rpc = RpcClientImpl::new(
+                LocalSigner::new(key.clone()),
+                LazyUdsTransport::new(dummy.clone()),
+                Some(vk),
+            )
+            .with_response_verify_policy(hyprstream_rpc::crypto::CryptoPolicy::Classical);
+            Arc::new(rpc)
+        };
+        let policy_client = PolicyClient::new(mk_client());
+        let discovery_client = DiscoveryClient::new(mk_client());
+
+        let mut config = OAuthConfig::default();
+        config.xrpc_read_slice = true;
+        // external_url so issuer_url() produces a usable authority.
+        config.external_url = Some("https://h.example.com".to_owned());
+
+        let state = Arc::new(OAuthState::new(
+            &config,
+            policy_client,
+            discovery_client,
+            [0x76; 32],
+        ));
+
+        // Seed snapshots.
+        state
+            .xrpc_repos
+            .put(sample_snapshot("did:web:pub.example.com", "pub.example.com", true))
+            .await;
+        state
+            .xrpc_repos
+            .put(sample_snapshot("did:web:priv.example.com", "priv.example.com", false))
+            .await;
+
+        Router::new()
+            .route(
+                "/xrpc/com.atproto.identity.resolveHandle",
+                get(resolve_handle),
+            )
+            .route("/xrpc/com.atproto.repo.describeRepo", get(describe_repo))
+            .route("/xrpc/com.atproto.repo.getRecord", get(get_record))
+            .route("/xrpc/com.atproto.sync.getRepo", get(get_repo))
+            .with_state(state)
+    }
+
+    async fn resp_json(resp: axum::response::Response) -> Value {
+        body_json(resp).await
+    }
+
+    fn req(uri: &str) -> HttpRequest<Body> {
+        HttpRequest::builder()
+            .uri(uri)
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    // ── Finding 1: real capacity test through the mounted router ──────────────
+
+    #[tokio::test]
+    async fn router_capacity_n_plus_1_blocked_until_body_dropped() {
+        let app = build_xrpc_router().await;
+        let uri = "/xrpc/com.atproto.sync.getRepo?did=did:web:pub.example.com";
+
+        // Issue N requests, RETAIN response bodies unconsumed.
+        let mut held: Vec<axum::response::Response> = Vec::new();
+        for _ in 0..GET_REPO_CONCURRENCY {
+            let resp = app.clone().oneshot(req(uri)).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::OK);
+            held.push(resp);
+        }
+
+        // N+1th request must NOT complete while all permits are held in bodies.
+        let n1 = app.clone().oneshot(req(uri));
+        let mut n1 = Box::pin(n1);
+        tokio::select! {
+            _ = &mut n1 => panic!("N+1th getRepo completed before capacity freed"),
+            _ = tokio::time::sleep(std::time::Duration::from_millis(100)) => {}
+        }
+
+        // Drop ONE held Response → its Body + embedded OwnedSemaphorePermit released.
+        held.pop();
+
+        // N+1th should now complete.
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            n1.as_mut(),
+        )
+        .await;
+        assert!(result.is_ok(), "N+1th getRepo did not complete after dropping a body");
+        assert_eq!(result.unwrap().unwrap().status(), StatusCode::OK);
+    }
+
+    // ── Finding 2: router-mounted endpoint tests ──────────────────────────────
+
+    #[tokio::test]
+    async fn router_private_repo_invisible_describe_repo() {
+        let app = build_xrpc_router().await;
+        let resp = app
+            .oneshot(req("/xrpc/com.atproto.repo.describeRepo?repo=did:web:priv.example.com"))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = resp_json(resp).await;
+        assert_eq!(body["error"], errors::REPO_NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn router_private_repo_invisible_get_record() {
+        let app = build_xrpc_router().await;
+        let resp = app
+            .oneshot(req(
+                "/xrpc/com.atproto.repo.getRecord?repo=did:web:priv.example.com\
+                 &collection=ai.hyprstream.model&rkey=abc",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = resp_json(resp).await;
+        assert_eq!(body["error"], errors::REPO_NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn router_private_repo_invisible_get_repo() {
+        let app = build_xrpc_router().await;
+        let resp = app
+            .oneshot(req("/xrpc/com.atproto.sync.getRepo?did=did:web:priv.example.com"))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = resp_json(resp).await;
+        assert_eq!(body["error"], errors::REPO_NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn router_private_repo_invisible_resolve_handle() {
+        let app = build_xrpc_router().await;
+        let resp = app
+            .oneshot(req("/xrpc/com.atproto.identity.resolveHandle?handle=priv.example.com"))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = resp_json(resp).await;
+        assert_eq!(body["error"], errors::HANDLE_NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn router_public_describe_repo_ok() {
+        let app = build_xrpc_router().await;
+        let resp = app
+            .oneshot(req("/xrpc/com.atproto.repo.describeRepo?repo=did:web:pub.example.com"))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp_json(resp).await;
+        assert_eq!(body["did"], "did:web:pub.example.com");
+        assert_eq!(body["handleIsCorrect"], true);
+    }
+
+    #[tokio::test]
+    async fn router_get_record_nonexistent_rkey() {
+        let app = build_xrpc_router().await;
+        let resp = app
+            .clone()
+            .oneshot(req(
+                "/xrpc/com.atproto.repo.getRecord?repo=did:web:pub.example.com\
+                 &collection=ai.hyprstream.model&rkey=zzzzzzzzzzzz",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = resp_json(resp).await;
+        assert_eq!(body["error"], errors::RECORD_NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn router_missing_params_invalid_request() {
+        let app = build_xrpc_router().await;
+        // Missing repo param.
+        let resp = app
+            .clone()
+            .oneshot(req("/xrpc/com.atproto.repo.getRecord?collection=ai.hyprstream.model"))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = resp_json(resp).await;
+        assert_eq!(body["error"], errors::INVALID_REQUEST);
+
+        // Missing handle param.
+        let resp = app
+            .oneshot(req("/xrpc/com.atproto.identity.resolveHandle"))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = resp_json(resp).await;
+        assert_eq!(body["error"], errors::INVALID_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn router_unknown_handle_handle_not_found() {
+        let app = build_xrpc_router().await;
+        let resp = app
+            .oneshot(req("/xrpc/com.atproto.identity.resolveHandle?handle=does-not-exist.com"))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = resp_json(resp).await;
+        assert_eq!(body["error"], errors::HANDLE_NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn router_since_empty_rejected() {
+        let app = build_xrpc_router().await;
+        let resp = app
+            .oneshot(req("/xrpc/com.atproto.sync.getRepo?did=did:web:pub.example.com&since="))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = resp_json(resp).await;
+        assert_eq!(body["error"], errors::INVALID_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn router_since_non_empty_rejected() {
+        let app = build_xrpc_router().await;
+        let resp = app
+            .oneshot(req(
+                "/xrpc/com.atproto.sync.getRepo?did=did:web:pub.example.com\
+                 &since=3whysti2w4mq2",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = resp_json(resp).await;
+        assert_eq!(body["error"], errors::INVALID_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn router_get_repo_ok_streams_car() {
+        let app = build_xrpc_router().await;
+        let resp = app
+            .oneshot(req("/xrpc/com.atproto.sync.getRepo?did=did:web:pub.example.com"))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "application/vnd.ipld.car",
+        );
+        // Consume the body fully so the permit is released.
+        let bytes = axum::body::to_bytes(resp.into_body(), 4 * 1024 * 1024)
+            .await
+            .unwrap();
+        assert!(!bytes.is_empty());
+    }
 }


### PR DESCRIPTION
## Summary

`com.atproto.*` XRPC server surface — MVP **public-read slice** (#1112). After atproto OAuth authentication succeeds, clients can **read** from the PDS.

## Endpoints (4 public reads)

All under `/xrpc/`, conditionally mounted when `OAuthConfig::xrpc_read_slice` is `true` (defaults `false`):

| Method | NSID | Notes |
|--------|------|-------|
| GET | `com.atproto.identity.resolveHandle` | handle→DID; `HandleNotFound` for unknown |
| GET | `com.atproto.repo.describeRepo` | Canonical lexicon: `handleIsCorrect`, `collections`=NSID strings, `didDoc` populated |
| GET | `com.atproto.repo.getRecord` | Record JSON; optional `cid` version pinning |
| GET | `com.atproto.sync.getRepo` | Full-repo CARv1 export (streamed); `since` rejected until delta support |

## Design decisions

- **No sessions in this PR.** `createSession`/`getSession` are removed — credential verification and the OAuth JWT bridge arrive with #1113/#948. The four reads above are public reads of explicitly-published repos.
- **Publication boundary.** `RepoSnapshot` has a `public: bool` flag. Only `public` snapshots are served by public reads (`get_public`/`by_handle_public`). Tested.
- **Feature gate.** `xrpc_read_slice` config flag defaults off; routes not mounted when disabled.
- **Streaming CAR.** `sync.getRepo` streams sections via `Body::from_stream` with a concurrency semaphore (4); no double materialization.
- **`hyprstream-pds` stays no-networking.** Added `build_car_v1_sections` (a data function) for incremental streaming.

## Test coverage (10 tests)

- Publication boundary (public visible, non-public invisible)
- CAR section streaming round-trip
- Offline CAR proof verification
- describeRepo didDoc carries `#atproto` VM + `#atproto_pds` service
- Query parser (valid, empty, malformed)
- Error envelope shape
- Record JSON shape
- Ambiguous handle refusal

## Non-goals

- `subscribeRepos` firehose — deferred per issue.
- Write path (`repo.createRecord` etc.) — #910.
- `createSession`/`getSession` — #1113/#948.

Closes #1112.
