### PR TITLE
feat(oauth): atproto OAuth AS conformance profile (closes #1113)

### DIFF
--- a/crates/hyprstream-rpc-std/schema/oauth.capnp
+++ b/crates/hyprstream-rpc-std/schema/oauth.capnp
@@ -101,6 +101,7 @@ struct UserInfo {
   active @6 :Bool;
   externalId @7 :Text;
   pubkeys @8 :List(PubkeyEntry);  # Multiple pubkeys per user
+  atprotoDid @9 :Text $optional;  # Mapped did:plc / host-form did:web (#1113/#1124)
 }
 
 struct PubkeyEntry {

--- a/crates/hyprstream-rpc-std/schema/policy.capnp
+++ b/crates/hyprstream-rpc-std/schema/policy.capnp
@@ -136,6 +136,10 @@ struct IssueToken {
   # When present, the issued token carries cnf.jkt instead of cnf.jwk.
   # Takes precedence over userPubKey.
   dpopJkt @5 :Text $optional;
+
+  # Optional issuer override for profile-specific OAuth tokens.
+  # Empty uses PolicyService's configured default issuer.
+  issuer @6 :Text $optional;
 }
 
 # Apply a built-in policy template

--- a/crates/hyprstream-rpc/schema/common.capnp
+++ b/crates/hyprstream-rpc/schema/common.capnp
@@ -164,6 +164,7 @@ struct Claims {
   token @6 :Text;        # Original JWT for e2e verification by downstream services
   iss @7 :Text;          # Issuer URL (RFC 7519); hyprstream node that minted this token
   pubKey @8 :Text;       # Ed25519 public key (base64url) for service identity tokens
+  oauthScope @9 :Text;   # Signed OAuth grant ceiling (space-delimited scope claim)
 }
 
 # UTC timestamp with nanosecond precision

--- a/crates/hyprstream-rpc/src/auth/claims.rs
+++ b/crates/hyprstream-rpc/src/auth/claims.rs
@@ -2,7 +2,8 @@
 //!
 //! Two claim types:
 //! - [`Claims`] — access token claims used throughout the RPC layer.
-//!   Authorization is enforced server-side via Casbin policies, not JWT scopes.
+//!   OAuth grants carry their granted scope set in the signed JWT so consumers
+//!   can attenuate authority without falling back to subject-wide policy.
 //! - [`IdTokenClaims`] — OIDC ID Token claims (Section 2 of OpenID Connect
 //!   Core 1.0). Only used by the OAuth token endpoint when `scope=openid`.
 
@@ -109,8 +110,9 @@ pub struct ActClaim {
 
 /// JWT claims for authentication.
 ///
-/// Note: Authorization is enforced via Casbin policies server-side.
-/// Scopes are NOT embedded in JWTs.
+/// Casbin remains the server-side policy authority. OAuth access tokens also
+/// carry the grant's scope ceiling so a verifier can enforce the intersection
+/// of subject policy and the authority delegated by that specific grant.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Claims {
     /// Issuer URL — the hyprstream node that minted this token.
@@ -128,6 +130,13 @@ pub struct Claims {
     /// RFC 8707 audience claim for resource indicator binding.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub aud: Option<String>,
+    /// OAuth 2.0 granted scope set, serialized as a space-delimited string.
+    ///
+    /// This is optional because non-OAuth service tokens do not originate from
+    /// an OAuth grant. Consumers that derive authority from OAuth scopes MUST
+    /// use [`Self::has_scope`] and fail closed when this claim is absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
     /// RFC 8705 / WIMSE proof-of-possession confirmation claim.
     ///
     /// Binds the Ed25519 signing key to the JWT-attested identity via a standard
@@ -202,6 +211,7 @@ impl std::fmt::Debug for Claims {
             .field("iat", &self.iat)
             .field("jti", &self.jti)
             .field("aud", &self.aud)
+            .field("scope", &self.scope)
             .field("cnf", &self.cnf)
             .field("token", &self.token.as_ref().map(|_| "[REDACTED]"))
             .field("clearance", &self.clearance)
@@ -285,6 +295,9 @@ impl FromCapnp for Claims {
             iat: reader.get_iat(),
             jti: None,
             aud,
+            // OAuth scopes are JWT-carried authority and deliberately are not
+            // reconstructed from the legacy Cap'n Proto scope list.
+            scope: None,
             cnf,
             token,
             // MAC clearance (S8/#574) is not carried on the Cap'n Proto envelope
@@ -311,6 +324,7 @@ impl Claims {
             iat,
             jti: None,
             aud: None,
+            scope: None,
             cnf: None,
             token: None,
             clearance: None,
@@ -340,6 +354,25 @@ impl Claims {
     pub fn with_audience(mut self, audience: Option<String>) -> Self {
         self.aud = audience;
         self
+    }
+
+    /// Set the OAuth 2.0 granted scope claim.
+    pub fn with_scope(mut self, scope: Option<String>) -> Self {
+        self.scope = scope.filter(|value| !value.trim().is_empty());
+        self
+    }
+
+    /// Iterate over the exact scopes granted to this token.
+    ///
+    /// An absent claim yields an empty iterator, keeping scope-based consumers
+    /// fail closed for legacy and non-OAuth tokens.
+    pub fn granted_scopes(&self) -> impl Iterator<Item = &str> {
+        self.scope.as_deref().into_iter().flat_map(str::split_whitespace)
+    }
+
+    /// Return whether this token's signed grant contains `required` exactly.
+    pub fn has_scope(&self, required: &str) -> bool {
+        self.granted_scopes().any(|granted| granted == required)
     }
 
     /// Attach original JWT token for e2e verification by downstream services.
@@ -510,6 +543,22 @@ impl crate::auth::mac::SubjectContextClaims for Claims {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn oauth_scope_claim_is_exact_and_absence_fails_closed() {
+        let plain = Claims::new("alice".to_owned(), 1000, 2000);
+        assert!(!plain.has_scope("atproto"));
+        assert!(!serde_json::to_string(&plain).unwrap().contains("\"scope\""));
+
+        let scoped = plain.with_scope(Some("atproto transition:generic".to_owned()));
+        assert!(scoped.has_scope("atproto"));
+        assert!(scoped.has_scope("transition:generic"));
+        assert!(!scoped.has_scope("transition"));
+        assert_eq!(
+            scoped.granted_scopes().collect::<Vec<_>>(),
+            vec!["atproto", "transition:generic"]
+        );
+    }
 
     #[test]
     fn test_act_claim_serde_roundtrip_and_default_none() {

--- a/crates/hyprstream-rpc/src/auth/claims.rs
+++ b/crates/hyprstream-rpc/src/auth/claims.rs
@@ -243,6 +243,9 @@ impl ToCapnp for Claims {
                 builder.set_pub_key(&jwk.x);
             }
         }
+        if let Some(ref scope) = self.scope {
+            builder.set_oauth_scope(scope);
+        }
         // Write empty scopes list for wire compatibility
         builder.reborrow().init_scopes(0);
     }
@@ -252,9 +255,15 @@ impl FromCapnp for Claims {
     type Reader<'a> = common_capnp::claims::Reader<'a>;
 
     fn read_from(reader: Self::Reader<'_>) -> Result<Self> {
-        // Scopes on the wire are ignored - authorization is via Casbin
         let aud = reader
             .get_aud()
+            .ok()
+            .and_then(|s| s.to_str().ok())
+            .map(std::borrow::ToOwned::to_owned)
+            .filter(|s| !s.is_empty());
+
+        let scope = reader
+            .get_oauth_scope()
             .ok()
             .and_then(|s| s.to_str().ok())
             .map(std::borrow::ToOwned::to_owned)
@@ -295,9 +304,9 @@ impl FromCapnp for Claims {
             iat: reader.get_iat(),
             jti: None,
             aud,
-            // OAuth scopes are JWT-carried authority and deliberately are not
-            // reconstructed from the legacy Cap'n Proto scope list.
-            scope: None,
+            // The dedicated OAuth field preserves the signed grant ceiling;
+            // the legacy structured scope list remains unused by Claims.
+            scope,
             cnf,
             token,
             // MAC clearance (S8/#574) is not carried on the Cap'n Proto envelope
@@ -558,6 +567,21 @@ mod tests {
             scoped.granted_scopes().collect::<Vec<_>>(),
             vec!["atproto", "transition:generic"]
         );
+    }
+
+    #[test]
+    fn oauth_scope_survives_capnp_envelope_roundtrip() -> anyhow::Result<()> {
+        let claims = Claims::new("alice".to_owned(), 1000, 2000)
+            .with_scope(Some("atproto transition:generic".to_owned()));
+        let mut message = capnp::message::Builder::new_default();
+        let mut builder = message.init_root::<common_capnp::claims::Builder>();
+        claims.write_to(&mut builder);
+
+        let decoded = Claims::read_from(builder.into_reader())?;
+        assert_eq!(decoded.scope, claims.scope);
+        assert!(decoded.has_scope("atproto"));
+        assert!(decoded.has_scope("transition:generic"));
+        Ok(())
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/auth/key_source.rs
+++ b/crates/hyprstream-rpc/src/auth/key_source.rs
@@ -117,10 +117,27 @@ pub trait JwtKeySource: Send + Sync + 'static {
 #[derive(Clone)]
 pub struct ClusterKeySource {
     ca_verifying_key: VerifyingKey,
-    local_issuer_url: String,
     local_issuers_vec: Vec<String>,
     ml_dsa_vks: Arc<std::sync::RwLock<Vec<crate::crypto::pq::MlDsaVerifyingKey>>>,
     composite_keys: Arc<super::CompositeKeySet>,
+}
+
+fn local_issuer_aliases(local_issuer_url: &str) -> Vec<String> {
+    if local_issuer_url.is_empty() {
+        return Vec::new();
+    }
+    let mut issuers = vec![local_issuer_url.to_owned()];
+    // Keep this byte-for-byte aligned with OAuthState::canonical_issuer_origin:
+    // the atproto issuer is the configured scheme + authority with its path
+    // removed, without URL-library normalization of ports or casing.
+    if let Some((scheme, rest)) = local_issuer_url.split_once("://") {
+        let authority = rest.split('/').next().unwrap_or_default();
+        let origin = format!("{scheme}://{authority}");
+        if !scheme.is_empty() && !authority.is_empty() && origin != local_issuer_url {
+            issuers.push(origin);
+        }
+    }
+    issuers
 }
 
 impl ClusterKeySource {
@@ -131,14 +148,9 @@ impl ClusterKeySource {
     /// * `ca_verifying_key` - The cluster's CA verifying key (from PolicyService)
     /// * `local_issuer_url` - The OAuth issuer URL (e.g., "http://127.0.0.1:9080")
     pub fn new(ca_verifying_key: VerifyingKey, local_issuer_url: String) -> Self {
-        let local_issuers_vec = if local_issuer_url.is_empty() {
-            vec![]
-        } else {
-            vec![local_issuer_url.clone()]
-        };
+        let local_issuers_vec = local_issuer_aliases(&local_issuer_url);
         Self {
             ca_verifying_key,
-            local_issuer_url,
             local_issuers_vec,
             ml_dsa_vks: Arc::new(std::sync::RwLock::new(Vec::new())),
             composite_keys: super::global_composite_key_set(),
@@ -184,8 +196,10 @@ impl JwtKeySource for ClusterKeySource {
         if issuer.is_empty() {
             return true;
         }
-        // Match against local issuer URL
-        issuer == self.local_issuer_url
+        // The atproto profile emits the canonical origin while generic OAuth
+        // retains the configured issuer (which may carry a path). Both are
+        // exact local aliases; sibling paths and foreign origins remain denied.
+        self.local_issuers_vec.iter().any(|local| local == issuer)
     }
 
     fn local_issuers(&self) -> &[String] {
@@ -306,7 +320,6 @@ struct CachedKey {
 /// - Semaphore bounds concurrent JWKS fetches
 pub struct JwksKeySource {
     mode: JwksMode,
-    local_issuer_url: String,
     local_issuers_vec: Vec<String>,
     fetcher: JwksFetcher,
     cache: RwLock<HashMap<String, CachedKey>>,
@@ -339,14 +352,9 @@ pub struct JwksKeySource {
 
 impl JwksKeySource {
     pub fn new(mode: JwksMode, local_issuer_url: String, fetcher: JwksFetcher) -> Self {
-        let local_issuers_vec = if local_issuer_url.is_empty() {
-            vec![]
-        } else {
-            vec![local_issuer_url.clone()]
-        };
+        let local_issuers_vec = local_issuer_aliases(&local_issuer_url);
         Self {
             mode,
-            local_issuer_url,
             local_issuers_vec,
             fetcher,
             cache: RwLock::new(HashMap::new()),
@@ -397,7 +405,7 @@ impl JwksKeySource {
     }
 
     fn is_local(&self, issuer: &str) -> bool {
-        issuer.is_empty() || issuer == self.local_issuer_url
+        issuer.is_empty() || self.local_issuers_vec.iter().any(|local| local == issuer)
     }
 
     async fn resolve_jwks_url(&self, issuer: &str) -> Result<String> {
@@ -594,6 +602,31 @@ mod tests {
 
         let key = ks.get_key("http://localhost:9080", None).await?;
         assert_eq!(key, test_ca_key());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn local_key_sources_trust_canonical_origin_for_path_issuer() -> anyhow::Result<()> {
+        let configured = "https://pds.example.test/configured/path";
+        let origin = "https://pds.example.test";
+        let ks = ClusterKeySource::new(test_ca_key(), configured.to_owned());
+        assert!(ks.is_trusted(configured));
+        assert!(ks.is_trusted(origin));
+        assert!(!ks.is_trusted("https://pds.example.test/other"));
+        assert_eq!(ks.get_key(origin, None).await?, test_ca_key());
+        assert_eq!(ks.local_issuers(), &[configured, origin]);
+
+        let fetcher: JwksFetcher = std::sync::Arc::new(|_url: String| {
+            Box::pin(async move { anyhow::bail!("network must not be used") })
+        });
+        let jwks = JwksKeySource::new(
+            JwksMode::Isolated { jwks_url: "https://pds.example.test/oauth/jwks".to_owned() },
+            configured.to_owned(),
+            fetcher,
+        )
+        .with_local_ca_key(test_ca_key());
+        assert!(jwks.is_trusted(origin));
+        assert_eq!(jwks.local_issuers(), &[configured, origin]);
         Ok(())
     }
 

--- a/crates/hyprstream/src/auth/key_rotation.rs
+++ b/crates/hyprstream/src/auth/key_rotation.rs
@@ -2211,6 +2211,7 @@ mod tests {
                         subject: Some("multiprocess-policy".to_owned()),
                         user_pub_key: None,
                         dpop_jkt: None,
+                        issuer: None,
                     })
                     .await?
                     .token;
@@ -2338,6 +2339,7 @@ mod tests {
                         subject: Some("stale-policy".to_owned()),
                         user_pub_key: None,
                         dpop_jkt: None,
+                        issuer: None,
                     })
                     .await;
                 anyhow::ensure!(result.is_err(), "stale PolicyService minted a token");
@@ -2508,6 +2510,7 @@ mod tests {
                         subject: Some("restart-policy".to_owned()),
                         user_pub_key: None,
                         dpop_jkt: None,
+                        issuer: None,
                     })
                     .await?
                     .token;
@@ -2643,6 +2646,7 @@ mod tests {
                     subject: Some("pre-rotation-policy".to_owned()),
                     user_pub_key: None,
                     dpop_jkt: None,
+                    issuer: None,
                 })
                 .await?;
             let client = reqwest::Client::new();
@@ -2871,6 +2875,7 @@ mod tests {
                         subject: Some("timeout-policy".to_owned()),
                         user_pub_key: None,
                         dpop_jkt: None,
+                        issuer: None,
                     })
                     .await?
                     .token;

--- a/crates/hyprstream/src/auth/key_rotation.rs
+++ b/crates/hyprstream/src/auth/key_rotation.rs
@@ -2135,6 +2135,7 @@ mod tests {
                         expires_at: std::time::Instant::now() + std::time::Duration::from_secs(60),
                         username: "multiprocess-oauth".to_owned(),
                         verifying_key: None,
+                        dpop_jkt: None,
                         },
                     );
                 }

--- a/crates/hyprstream/src/auth/key_rotation.rs
+++ b/crates/hyprstream/src/auth/key_rotation.rs
@@ -2136,6 +2136,7 @@ mod tests {
                         username: "multiprocess-oauth".to_owned(),
                         verifying_key: None,
                         dpop_jkt: None,
+                        client_assertion_jkt: None,
                         },
                     );
                 }

--- a/crates/hyprstream/src/auth/mod.rs
+++ b/crates/hyprstream/src/auth/mod.rs
@@ -31,7 +31,7 @@ pub use key_rotation::{MlDsaSigningKeyStore, MlDsaKeySlot};
 pub use policy_manager::{PolicyManager, PolicyError, write_policy_file, global_policy_manager, set_global_policy_manager};
 pub use policy_migration::migrate_policy_csv;
 pub use policy_templates::{PolicyTemplate, ServicePolicyRule, SERVICE_BASE_POLICIES, get_template, get_templates};
-pub use user_store::{DeviceRecord, DeviceStore, KeyAlgorithm, UserFilter, UserProfile, UserStore, PubkeyEntry, pubkey_fingerprint, decode_pubkey_base64};
+pub use user_store::{DeviceRecord, DeviceStore, KeyAlgorithm, UserFilter, UserProfile, UserProfilePatch, UserStore, PubkeyEntry, pubkey_fingerprint, decode_pubkey_base64};
 pub use rocksdb_store::RocksDbUserStore;
 #[cfg(feature = "valkey")]
 pub use valkey::ValkeyUserStore;

--- a/crates/hyprstream/src/auth/rocksdb_store.rs
+++ b/crates/hyprstream/src/auth/rocksdb_store.rs
@@ -16,7 +16,7 @@ use ed25519_dalek::VerifyingKey;
 use std::io::Cursor;
 use std::path::Path;
 
-use super::user_store::{pubkey_fingerprint, matches_filter, DeviceRecord, DeviceStore, KeyAlgorithm, PubkeyEntry, UserFilter, UserProfile, UserStore};
+use super::user_store::{pubkey_fingerprint, matches_filter, DeviceRecord, DeviceStore, KeyAlgorithm, PubkeyEntry, UserFilter, UserProfile, UserProfilePatch, UserStore};
 
 const USER_PREFIX: &[u8] = b"user:";
 const PUBKEY_PREFIX: &[u8] = b"pubkey:";
@@ -315,31 +315,31 @@ impl UserStore for RocksDbUserStore {
         Ok(sub)
     }
 
-    async fn set_profile(&self, username: &str, update: UserProfile) -> Result<()> {
+    async fn set_profile(&self, username: &str, update: UserProfilePatch) -> Result<()> {
         let (mut sub, mut profile, pubkeys) = self.get_raw(username)
             .with_context(|| format!("User '{}' not found", username))?
             .ok_or_else(|| anyhow!("User '{}' not found", username))?;
 
-        if let Some(s) = update.sub {
+        if let Some(Some(s)) = update.sub {
             sub = s;
         }
-        if update.name.is_some() {
-            profile.name = update.name;
+        if let Some(value) = update.name {
+            profile.name = value;
         }
-        if update.email.is_some() {
-            profile.email = update.email;
+        if let Some(value) = update.email {
+            profile.email = value;
         }
-        if update.email_verified.is_some() {
-            profile.email_verified = update.email_verified;
+        if let Some(value) = update.email_verified {
+            profile.email_verified = value;
         }
-        if update.active.is_some() {
-            profile.active = update.active;
+        if let Some(value) = update.active {
+            profile.active = value;
         }
-        if update.external_id.is_some() {
-            profile.external_id = update.external_id;
+        if let Some(value) = update.external_id {
+            profile.external_id = value;
         }
-        if update.atproto_did.is_some() {
-            profile.atproto_did = update.atproto_did;
+        if let Some(value) = update.atproto_did {
+            profile.atproto_did = value;
         }
 
         self.put_user(username, &sub, &profile, &pubkeys)?;
@@ -884,7 +884,7 @@ mod tests {
                 active: Some(true),
                 external_id: Some("ext-123".to_owned()),
                 atproto_did: Some("did:plc:abcdefghijklmnqrstuvwx2p".to_owned()),
-            }).await?;
+            }.into()).await?;
         }
         // Open a fresh store instance to verify persistence
         let store2 = RocksDbUserStore::open(dir.path())?;
@@ -897,6 +897,27 @@ mod tests {
             profile.atproto_did.as_deref(),
             Some("did:plc:abcdefghijklmnqrstuvwx2p")
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_atproto_did_can_be_explicitly_cleared() -> Result<()> {
+        let dir = TempDir::new()?;
+        let store = std::sync::Arc::new(make_store(dir.path()));
+        store.register("alice").await?;
+        store.set_profile("alice", UserProfilePatch {
+            atproto_did: Some(Some("did:plc:abcdefghijklmnqrstuvwx2p".to_owned())),
+            ..Default::default()
+        }).await?;
+
+        let service = crate::services::oauth::user_service::UserService::new(store.clone());
+        service.update("alice", crate::services::oauth::user_service::UserUpdate {
+            atproto_did: Some(None),
+            ..Default::default()
+        }).await?;
+
+        let profile = store.get_profile("alice").await?.unwrap();
+        assert_eq!(profile.atproto_did, None);
         Ok(())
     }
 

--- a/crates/hyprstream/src/auth/rocksdb_store.rs
+++ b/crates/hyprstream/src/auth/rocksdb_store.rs
@@ -130,6 +130,9 @@ impl RocksDbUserStore {
             if let Some(ref eid) = profile.external_id {
                 ui.set_external_id(eid);
             }
+            if let Some(ref did) = profile.atproto_did {
+                ui.set_atproto_did(did);
+            }
 
             // Serialize pubkeys list
             let mut pk_list = ui.init_pubkeys(pubkeys.len() as u32);
@@ -190,7 +193,7 @@ impl RocksDbUserStore {
                 None
             },
             external_id: text_or_none(ui.get_external_id()),
-            atproto_did: None,
+            atproto_did: text_or_none(ui.get_atproto_did()),
         };
 
         // Deserialize pubkeys list
@@ -334,6 +337,9 @@ impl UserStore for RocksDbUserStore {
         }
         if update.external_id.is_some() {
             profile.external_id = update.external_id;
+        }
+        if update.atproto_did.is_some() {
+            profile.atproto_did = update.atproto_did;
         }
 
         self.put_user(username, &sub, &profile, &pubkeys)?;
@@ -877,7 +883,7 @@ mod tests {
                 email_verified: Some(true),
                 active: Some(true),
                 external_id: Some("ext-123".to_owned()),
-                atproto_did: None,
+                atproto_did: Some("did:plc:abcdefghijklmnqrstuvwx2p".to_owned()),
             }).await?;
         }
         // Open a fresh store instance to verify persistence
@@ -887,6 +893,10 @@ mod tests {
         assert_eq!(profile.external_id.as_deref(), Some("ext-123"));
         assert_eq!(profile.active, Some(true));
         assert_eq!(profile.email_verified, Some(true));
+        assert_eq!(
+            profile.atproto_did.as_deref(),
+            Some("did:plc:abcdefghijklmnqrstuvwx2p")
+        );
         Ok(())
     }
 

--- a/crates/hyprstream/src/auth/rocksdb_store.rs
+++ b/crates/hyprstream/src/auth/rocksdb_store.rs
@@ -190,6 +190,7 @@ impl RocksDbUserStore {
                 None
             },
             external_id: text_or_none(ui.get_external_id()),
+            atproto_did: None,
         };
 
         // Deserialize pubkeys list
@@ -876,6 +877,7 @@ mod tests {
                 email_verified: Some(true),
                 active: Some(true),
                 external_id: Some("ext-123".to_owned()),
+                atproto_did: None,
             }).await?;
         }
         // Open a fresh store instance to verify persistence

--- a/crates/hyprstream/src/auth/user_store.rs
+++ b/crates/hyprstream/src/auth/user_store.rs
@@ -29,6 +29,11 @@ pub struct UserProfile {
     /// External identity ID from upstream IdP (SCIM: externalId).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub external_id: Option<String>,
+    /// The account's mapped atproto DID (did:plc or host-form did:web), if
+    /// provisioned. PROVISIONING is tracked in #1124; the LOOKUP seam exists
+    /// here so the atproto OAuth profile can emit the mapped DID as `sub` (#1113 r5).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub atproto_did: Option<String>,
 }
 
 /// The public-key algorithm of a stored [`PubkeyEntry`].

--- a/crates/hyprstream/src/auth/user_store.rs
+++ b/crates/hyprstream/src/auth/user_store.rs
@@ -36,6 +36,32 @@ pub struct UserProfile {
     pub atproto_did: Option<String>,
 }
 
+/// Tri-state patch for profile fields: omitted, explicitly cleared, or replaced.
+#[derive(Debug, Clone, Default)]
+pub struct UserProfilePatch {
+    pub sub: Option<Option<String>>,
+    pub name: Option<Option<String>>,
+    pub email: Option<Option<String>>,
+    pub email_verified: Option<Option<bool>>,
+    pub active: Option<Option<bool>>,
+    pub external_id: Option<Option<String>>,
+    pub atproto_did: Option<Option<String>>,
+}
+
+impl From<UserProfile> for UserProfilePatch {
+    fn from(profile: UserProfile) -> Self {
+        Self {
+            sub: profile.sub.map(Some),
+            name: profile.name.map(Some),
+            email: profile.email.map(Some),
+            email_verified: profile.email_verified.map(Some),
+            active: profile.active.map(Some),
+            external_id: profile.external_id.map(Some),
+            atproto_did: profile.atproto_did.map(Some),
+        }
+    }
+}
+
 /// The public-key algorithm of a stored [`PubkeyEntry`].
 ///
 /// - [`Ed25519`](Self::Ed25519) — classical anchor only (the pre-#439 default,
@@ -152,8 +178,8 @@ pub trait UserStore: Send + Sync {
     /// Register a new user. Returns the generated subject UUID.
     async fn register(&self, username: &str) -> Result<String>;
 
-    /// Update a user's profile fields (merge semantics).
-    async fn set_profile(&self, username: &str, profile: UserProfile) -> Result<()>;
+    /// Update a user's profile fields with tri-state patch semantics.
+    async fn set_profile(&self, username: &str, patch: UserProfilePatch) -> Result<()>;
 
     /// Remove a user and all their pubkeys.
     async fn remove(&self, username: &str) -> Result<bool>;

--- a/crates/hyprstream/src/auth/valkey.rs
+++ b/crates/hyprstream/src/auth/valkey.rs
@@ -94,7 +94,7 @@ impl UserStore for ValkeyUserStore {
 
         // Merge: new fields overwrite existing; None in `new` keeps existing value.
         let merged = UserProfile {
-            sub: new.sub.or(existing.sub.clone()),
+            sub: new.sub.or_else(|| existing.sub.clone()),
             name: new.name.or(existing.name),
             email: new.email.or(existing.email),
             email_verified: new.email_verified.or(existing.email_verified),
@@ -216,7 +216,6 @@ impl UserStore for ValkeyUserStore {
             let descending = filter.sort_order.as_deref() == Some("descending");
             results.sort_by(|(a_name, a_prof), (b_name, b_prof)| {
                 let ord = match sort_by.as_str() {
-                    "userName" => a_name.cmp(b_name),
                     "id" | "sub" => a_prof.sub.cmp(&b_prof.sub),
                     _ => a_name.cmp(b_name),
                 };
@@ -242,8 +241,7 @@ impl UserStore for ValkeyUserStore {
     async fn list_pubkeys(&self, username: &str) -> Result<Vec<PubkeyEntry>> {
         let fps: Vec<String> = self.pool
             .smembers(format!("hs:user:{username}:keys"))
-            .await
-            .unwrap_or_default();
+            .await?;
         let mut entries = Vec::new();
         for fp in fps {
             let val: Option<String> = self.pool.get(format!("hs:key:{fp}")).await?;
@@ -381,6 +379,51 @@ impl UserStore for ValkeyUserStore {
             let json = serde_json::to_string(&stored)?;
             self.pool.set::<(), _, _>(format!("hs:key:{fingerprint}"), json, None, None, false).await?;
         }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn list_pubkeys_propagates_smembers_read_error() -> Result<()> {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        // A tiny RESP server accepts Fred's connection setup, then returns a
+        // synthetic Valkey error for SMEMBERS. This directly exercises the
+        // backend seam and would regress to Ok(empty) if list_pubkeys swallowed
+        // the read error again.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let address = listener.local_addr()?;
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await?;
+            let mut buffer = [0_u8; 1024];
+            loop {
+                let read = socket.read(&mut buffer).await?;
+                if read == 0 {
+                    break;
+                }
+                let command = String::from_utf8_lossy(&buffer[..read]);
+                let response = if command.contains("SMEMBERS") {
+                    "-ERR synthetic SMEMBERS read failure\r\n"
+                } else {
+                    "+OK\r\n"
+                };
+                socket.write_all(response.as_bytes()).await?;
+            }
+            Ok::<(), std::io::Error>(())
+        });
+
+        let config = RedisConfig::from_url(&format!("redis://{address}"))?;
+        let pool = Builder::from_config(config).build_pool(1)?;
+        let _connection = pool.connect();
+        pool.wait_for_connect().await?;
+        let store = ValkeyUserStore { pool };
+
+        assert!(store.list_pubkeys("alice").await.is_err());
+        server.abort();
         Ok(())
     }
 }

--- a/crates/hyprstream/src/auth/valkey.rs
+++ b/crates/hyprstream/src/auth/valkey.rs
@@ -100,6 +100,7 @@ impl UserStore for ValkeyUserStore {
             email_verified: new.email_verified.or(existing.email_verified),
             active: new.active.or(existing.active),
             external_id: new.external_id.or(existing.external_id),
+            atproto_did: new.atproto_did.or(existing.atproto_did),
         };
 
         // Write new externalId index.

--- a/crates/hyprstream/src/auth/valkey.rs
+++ b/crates/hyprstream/src/auth/valkey.rs
@@ -20,7 +20,8 @@ use fred::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use super::user_store::{
-    matches_filter, pubkey_fingerprint, PubkeyEntry, ScimFilter, UserFilter, UserProfile, UserStore,
+    matches_filter, pubkey_fingerprint, PubkeyEntry, ScimFilter, UserFilter, UserProfile,
+    UserProfilePatch, UserStore,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -82,25 +83,25 @@ impl UserStore for ValkeyUserStore {
         Ok(sub)
     }
 
-    async fn set_profile(&self, username: &str, new: UserProfile) -> Result<()> {
+    async fn set_profile(&self, username: &str, new: UserProfilePatch) -> Result<()> {
         let existing = self.get_profile_raw(username).await?.unwrap_or_default();
 
         // Remove stale externalId index if it changed.
         if let Some(ref old_extid) = existing.external_id {
-            if new.external_id.as_deref() != Some(old_extid.as_str()) {
+            if new.external_id.as_ref().is_some_and(|value| value.as_deref() != Some(old_extid)) {
                 let _: i64 = self.pool.del(format!("hs:idx:extid:{old_extid}")).await.unwrap_or(0);
             }
         }
 
-        // Merge: new fields overwrite existing; None in `new` keeps existing value.
+        // Apply tri-state patch fields: omitted keeps existing, explicit None clears.
         let merged = UserProfile {
-            sub: new.sub.or_else(|| existing.sub.clone()),
-            name: new.name.or(existing.name),
-            email: new.email.or(existing.email),
-            email_verified: new.email_verified.or(existing.email_verified),
-            active: new.active.or(existing.active),
-            external_id: new.external_id.or(existing.external_id),
-            atproto_did: new.atproto_did.or(existing.atproto_did),
+            sub: new.sub.unwrap_or(existing.sub),
+            name: new.name.unwrap_or(existing.name),
+            email: new.email.unwrap_or(existing.email),
+            email_verified: new.email_verified.unwrap_or(existing.email_verified),
+            active: new.active.unwrap_or(existing.active),
+            external_id: new.external_id.unwrap_or(existing.external_id),
+            atproto_did: new.atproto_did.unwrap_or(existing.atproto_did),
         };
 
         // Write new externalId index.

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -1224,7 +1224,10 @@ impl Default for OAuthConfig {
             jwt_key_lead_secs: None,
             jwt_key_drain_secs: None,
             jwt_key_rotation_check_secs: None,
-            require_pushed_authorization_requests: false,
+            // #1113 rev2 finding 5: the atproto profile requires PAR, and PAR
+            // is supported unconditionally — default true so the AS advertises
+            // `require_pushed_authorization_requests: true` out of the box.
+            require_pushed_authorization_requests: true,
             xrpc_read_slice: false,
         }
     }

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -1263,16 +1263,11 @@ impl OAuthConfig {
         std::time::Duration::from_secs(self.jwt_key_rotation_check_secs.unwrap_or(6 * 3600))
     }
 
-    /// Get the issuer URL as a canonical exact origin (scheme://host[:port]),
-    /// using external_url if set, otherwise deriving from host:port.
+    /// Get the configured issuer URL, preserving an explicit path when set,
+    /// otherwise deriving it from host:port.
     /// Auto-derives `https://` when global TLS is enabled.
-    ///
-    /// #1113 rev2 F5: canonicalize at the SOURCE so EVERY consumer — access-
-    /// token `iss` (via PolicyService), metadata, userinfo, protected-resource,
-    /// redirect — gets the normalized value. A configured trailing slash or
-    /// path in `external_url` is stripped here, not in each consumer.
     pub fn issuer_url(&self) -> String {
-        let raw = if let Some(ref url) = self.external_url {
+        if let Some(ref url) = self.external_url {
             url.clone()
         } else {
             let scheme = if HyprConfig::load().map(|c| c.tls.enabled).unwrap_or(false) {
@@ -1282,19 +1277,6 @@ impl OAuthConfig {
             };
             let host = if self.host == "0.0.0.0" { "localhost" } else { &self.host };
             format!("{scheme}://{host}:{}", self.port)
-        };
-        // Canonicalize to exact origin — strip trailing slash/path.
-        if let Some(origin) = raw.split_once("://").and_then(|(scheme, rest)| {
-            let authority = rest.split('/').next()?;
-            if authority.is_empty() || scheme.is_empty() {
-                None
-            } else {
-                Some(format!("{scheme}://{authority}"))
-            }
-        }) {
-            origin
-        } else {
-            raw
         }
     }
 }

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -1224,10 +1224,10 @@ impl Default for OAuthConfig {
             jwt_key_lead_secs: None,
             jwt_key_drain_secs: None,
             jwt_key_rotation_check_secs: None,
-            // #1113 rev2 finding 5: the atproto profile requires PAR, and PAR
-            // is supported unconditionally — default true so the AS advertises
-            // `require_pushed_authorization_requests: true` out of the box.
-            require_pushed_authorization_requests: true,
+            // #1113 rev2 F6: do NOT default true globally — that breaks
+            // existing inline non-atproto auth. PAR is enforced on the
+            // atproto profile at the authorize handler level.
+            require_pushed_authorization_requests: false,
             xrpc_read_slice: false,
         }
     }
@@ -1324,15 +1324,16 @@ pub struct CredentialsConfig {
     pub valkey: ValkeyCredentialsConfig,
 }
 fn default_oauth_scopes() -> Vec<String> {
+    // The DEFAULT GRANT set when a client omits `scope`. atproto transition
+    // scopes are deliberately ABSENT — they are supported-but-explicit opt-in
+    // scopes that activate the strict atproto profile; including them here
+    // would silently activate the strict profile for omitted-scope requests
+    // (#1113 rev2 F4/F6). They ARE advertised in scopes_supported (see
+    // metadata.rs `advertised_scopes`).
     vec![
         "read:*:*".to_owned(),
         "infer:model:*".to_owned(),
         "write:*:*".to_owned(),
-        // atproto OAuth AS conformance (#1113): the PDS is its own AS, so the
-        // atproto transition scopes are advertised in scopes_supported and
-        // accepted when requested by stock atproto clients.
-        "atproto".to_owned(),
-        "transition:generic".to_owned(),
     ]
 }
 fn default_oauth_token_ttl() -> u32 { 3600 }

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -1325,6 +1325,11 @@ fn default_oauth_scopes() -> Vec<String> {
         "read:*:*".to_owned(),
         "infer:model:*".to_owned(),
         "write:*:*".to_owned(),
+        // atproto OAuth AS conformance (#1113): the PDS is its own AS, so the
+        // atproto transition scopes are advertised in scopes_supported and
+        // accepted when requested by stock atproto clients.
+        "atproto".to_owned(),
+        "transition:generic".to_owned(),
     ]
 }
 fn default_oauth_token_ttl() -> u32 { 3600 }

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -1263,10 +1263,16 @@ impl OAuthConfig {
         std::time::Duration::from_secs(self.jwt_key_rotation_check_secs.unwrap_or(6 * 3600))
     }
 
-    /// Get the issuer URL, using external_url if set, otherwise deriving from host:port.
+    /// Get the issuer URL as a canonical exact origin (scheme://host[:port]),
+    /// using external_url if set, otherwise deriving from host:port.
     /// Auto-derives `https://` when global TLS is enabled.
+    ///
+    /// #1113 rev2 F5: canonicalize at the SOURCE so EVERY consumer — access-
+    /// token `iss` (via PolicyService), metadata, userinfo, protected-resource,
+    /// redirect — gets the normalized value. A configured trailing slash or
+    /// path in `external_url` is stripped here, not in each consumer.
     pub fn issuer_url(&self) -> String {
-        if let Some(ref url) = self.external_url {
+        let raw = if let Some(ref url) = self.external_url {
             url.clone()
         } else {
             let scheme = if HyprConfig::load().map(|c| c.tls.enabled).unwrap_or(false) {
@@ -1276,6 +1282,19 @@ impl OAuthConfig {
             };
             let host = if self.host == "0.0.0.0" { "localhost" } else { &self.host };
             format!("{scheme}://{host}:{}", self.port)
+        };
+        // Canonicalize to exact origin — strip trailing slash/path.
+        if let Some(origin) = raw.split_once("://").and_then(|(scheme, rest)| {
+            let authority = rest.split('/').next()?;
+            if authority.is_empty() || scheme.is_empty() {
+                None
+            } else {
+                Some(format!("{scheme}://{authority}"))
+            }
+        }) {
+            origin
+        } else {
+            raw
         }
     }
 }

--- a/crates/hyprstream/src/services/oauth/auth.rs
+++ b/crates/hyprstream/src/services/oauth/auth.rs
@@ -9,6 +9,7 @@
 
 use std::sync::Arc;
 
+use hyprstream_rpc::auth::JtiBlocklist as _;
 use subtle::ConstantTimeEq;
 use axum::{
     extract::{Request, State},
@@ -22,7 +23,8 @@ pub use crate::server::middleware::AuthenticatedUser;
 
 /// Require a valid Bearer or DPoP token on the request.
 ///
-/// Validates the Ed25519-signed JWT against the server's verifying key.
+/// Routes JWT verification by the protected `alg` header, then validates the
+/// exact OAuth-self audience and one of this node's exact profile issuers.
 /// When `Authorization: DPoP` is used, also verifies the `DPoP` proof header and
 /// checks that `cnf.jkt` in the token matches the proof key's thumbprint.
 /// Inserts `AuthenticatedUser` into request extensions on success.
@@ -71,15 +73,7 @@ pub async fn require_bearer_token(
         None
     };
 
-    let vk = match ed25519_dalek::VerifyingKey::from_bytes(&state.verifying_key_bytes) {
-        Ok(k) => k,
-        Err(_) => {
-            return (StatusCode::INTERNAL_SERVER_ERROR, "server configuration error")
-                .into_response();
-        }
-    };
-
-    let claims = match hyprstream_rpc::auth::jwt::decode(&token, &vk, None) {
+    let claims = match validate_oauth_access_token(&state, &token).await {
         Ok(c) => c,
         Err(_) => {
             return (
@@ -194,4 +188,68 @@ pub async fn require_bearer_token(
     });
 
     next.run(request).await
+}
+
+/// Verify a JWT access token against the OAuth server's complete local signing
+/// surface. PolicyService mints composite tokens, while classical EdDSA remains
+/// accepted for explicitly classical deployments and legacy rotation slots.
+///
+/// Audience and issuer are mandatory here: the OAuth server is its own RFC 9728
+/// protected resource, whose canonical resource identifier is the origin-only
+/// atproto issuer. A configured issuer carrying a path remains a valid issuer
+/// for generic-profile tokens minted by this same server, but never an audience.
+pub(super) async fn validate_oauth_access_token(
+    state: &OAuthState,
+    token: &str,
+) -> Result<hyprstream_rpc::auth::Claims, &'static str> {
+    let header = hyprstream_rpc::auth::parse_protected_header(token)
+        .map_err(|_| "JWT header invalid")?;
+    if !hyprstream_rpc::auth::is_rfc9068_access_token_type(&header.typ) {
+        return Err("JWT type invalid");
+    }
+
+    let expected_audience = state.atproto_issuer_url();
+    let claims = match header.alg.as_str() {
+        "ML-DSA-65-Ed25519" => {
+            let dispatch = hyprstream_rpc::auth::parse_composite_dispatch(
+                token,
+                hyprstream_rpc::auth::RFC9068_ACCESS_TOKEN_TYPES,
+            )
+            .map_err(|_| "composite JWT dispatch invalid")?;
+            let snapshot = hyprstream_rpc::auth::global_composite_key_set().snapshot();
+            let pair = snapshot
+                .pair(dispatch.kid())
+                .ok_or("composite JWT kid unknown")?;
+            hyprstream_rpc::auth::jwt::decode_composite(
+                token,
+                pair.ml_dsa(),
+                pair.ed25519(),
+                Some(&expected_audience),
+                &dispatch,
+            )
+            .map_err(|_| "composite JWT validation failed")?
+        }
+        "EdDSA" => {
+            let key = state
+                .jwt_bearer_verifying_key()
+                .await
+                .ok_or("EdDSA verification key unavailable")?;
+            hyprstream_rpc::auth::jwt::decode(token, &key, Some(&expected_audience))
+                .map_err(|_| "EdDSA JWT validation failed")?
+        }
+        _ => return Err("JWT algorithm unsupported"),
+    };
+
+    let issuer_is_local = claims.iss == expected_audience || claims.iss == state.issuer_url;
+    if !issuer_is_local {
+        return Err("JWT issuer invalid");
+    }
+    if claims
+        .jti
+        .as_deref()
+        .is_some_and(|jti| state.jti_blocklist.as_ref().is_some_and(|list| list.is_revoked(jti)))
+    {
+        return Err("JWT revoked");
+    }
+    Ok(claims)
 }

--- a/crates/hyprstream/src/services/oauth/auth.rs
+++ b/crates/hyprstream/src/services/oauth/auth.rs
@@ -194,10 +194,10 @@ pub async fn require_bearer_token(
 /// surface. PolicyService mints composite tokens, while classical EdDSA remains
 /// accepted for explicitly classical deployments and legacy rotation slots.
 ///
-/// Audience and issuer are mandatory here: the OAuth server is its own RFC 9728
-/// protected resource, whose canonical resource identifier is the origin-only
-/// atproto issuer. A configured issuer carrying a path remains a valid issuer
-/// for generic-profile tokens minted by this same server, but never an audience.
+/// Audience and issuer are mandatory here. The canonical origin is the OAuth
+/// server's RFC 9728 resource identifier, while the configured issuer remains
+/// an accepted local audience alias for default-audience tokens minted before
+/// the resource indicator is known. No other audience is accepted.
 pub(super) async fn validate_oauth_access_token(
     state: &OAuthState,
     token: &str,
@@ -208,7 +208,17 @@ pub(super) async fn validate_oauth_access_token(
         return Err("JWT type invalid");
     }
 
-    let expected_audience = state.atproto_issuer_url();
+    let canonical_audience = state.atproto_issuer_url();
+    let unverified = hyprstream_rpc::auth::decode_unverified(token)
+        .map_err(|_| "JWT claims invalid")?;
+    let expected_audience = match unverified.aud.as_deref() {
+        Some(audience)
+            if audience == canonical_audience || audience == state.issuer_url.as_str() =>
+        {
+            audience.to_owned()
+        }
+        _ => return Err("JWT audience invalid"),
+    };
     let claims = match header.alg.as_str() {
         "ML-DSA-65-Ed25519" => {
             let dispatch = hyprstream_rpc::auth::parse_composite_dispatch(
@@ -240,7 +250,7 @@ pub(super) async fn validate_oauth_access_token(
         _ => return Err("JWT algorithm unsupported"),
     };
 
-    let issuer_is_local = claims.iss == expected_audience || claims.iss == state.issuer_url;
+    let issuer_is_local = claims.iss == canonical_audience || claims.iss == state.issuer_url;
     if !issuer_is_local {
         return Err("JWT issuer invalid");
     }

--- a/crates/hyprstream/src/services/oauth/authorize.rs
+++ b/crates/hyprstream/src/services/oauth/authorize.rs
@@ -208,6 +208,16 @@ pub async fn authorize_get(
     let scopes = params.scope.as_deref().unwrap_or(
         &state.default_scopes.join(" ")
     ).to_owned();
+    let mut effective_request = params.clone();
+    effective_request.scope = Some(scopes.clone());
+    let effective_scopes: Vec<String> = scopes.split_whitespace().map(str::to_owned).collect();
+    if super::state::atproto_profile_active(&effective_scopes) && effective_request.dpop_jkt.is_none() {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            "The atproto profile requires a Pushed Authorization Request with a DPoP proof.",
+        );
+    }
 
     // Extract redirect hostname for display
     let redirect_host = url::Url::parse(&params.redirect_uri)
@@ -224,14 +234,14 @@ pub async fn authorize_get(
 
     // Generate a nonce, store it server-side (5-min TTL, single-use on POST).
     let nonce = issue_nonce(&state).await;
-    // Stash the PAR-bound DPoP key thumbprint alongside the nonce so it
-    // reaches authorize_post without crossing the browser (#1113 rev2).
+    // Bind the complete resolved request to the consent nonce. Hidden form
+    // fields are transport echoes only and cannot change authority on POST.
     state
         .pending_authorize_bindings
         .write()
         .await
         .insert(nonce.clone(), super::state::AuthorizeBinding {
-            dpop_jkt: params.dpop_jkt.clone(),
+            request: effective_request.clone(),
         });
 
     // Render challenge form
@@ -239,18 +249,32 @@ pub async fn authorize_get(
         &client_name,
         &scopes,
         &redirect_host,
-        &params.client_id,
-        &params.redirect_uri,
-        &params.code_challenge,
-        params.state.as_deref().unwrap_or(""),
-        params.resource.as_deref().unwrap_or(""),
+        &effective_request.client_id,
+        &effective_request.redirect_uri,
+        &effective_request.code_challenge,
+        effective_request.state.as_deref().unwrap_or(""),
+        effective_request.resource.as_deref().unwrap_or(""),
         &nonce,
-        params.nonce.as_deref().unwrap_or(""),
+        effective_request.nonce.as_deref().unwrap_or(""),
         None,
         localhost_warning.as_deref(),
     );
 
     Html(html).into_response()
+}
+
+fn nonempty(value: Option<&str>) -> Option<&str> {
+    value.filter(|value| !value.is_empty())
+}
+
+fn consent_form_matches_request(form: &ConsentForm, request: &AuthorizeParams) -> bool {
+    form.client_id == request.client_id
+        && form.redirect_uri == request.redirect_uri
+        && form.code_challenge == request.code_challenge
+        && form.scope == request.scope.as_deref().unwrap_or("")
+        && nonempty(form.state.as_deref()) == nonempty(request.state.as_deref())
+        && nonempty(form.resource.as_deref()) == nonempty(request.resource.as_deref())
+        && nonempty(form.oidc_nonce.as_deref()) == nonempty(request.nonce.as_deref())
 }
 
 /// POST /oauth/authorize — verify Ed25519 signature, issue auth code
@@ -276,13 +300,19 @@ pub async fn authorize_post(
             None => (false, None),
         }
     };
+    let Some(authorize_binding) = authorize_binding else {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            "Authorization request is missing or already consumed",
+        );
+    };
+    let effective = &authorize_binding.request;
+
     if !nonce_valid {
-        // Nonce was not issued by this server, already consumed, or expired.
-        // Validate redirect_uri and re-derive client info from the registry.
-        // If either fails, return an error page rather than re-rendering with
-        // attacker-controlled values.
+        // Re-render only from the server-side snapshot; the submitted form is untrusted.
         let Some((client_name, redirect_host, localhost_warning)) =
-            derive_display_info(&state, &form.client_id, &form.redirect_uri).await
+            derive_display_info(&state, &effective.client_id, &effective.redirect_uri).await
         else {
             return Html(render_error_page(
                 "Invalid Request",
@@ -292,35 +322,41 @@ pub async fn authorize_post(
         let fresh_nonce = issue_nonce(&state).await;
         // #1113 rev2 F3: re-stash the binding on error-retry so the PAR
         // key binding survives a nonce-expired re-render.
-        if let Some(ref binding) = authorize_binding {
-            state
-                .pending_authorize_bindings
-                .write()
-                .await
-                .insert(fresh_nonce.clone(), binding.clone());
-        }
+        state
+            .pending_authorize_bindings
+            .write()
+            .await
+            .insert(fresh_nonce.clone(), authorize_binding.clone());
         let html = render_challenge_page(
             &client_name,
-            &form.scope,
+            effective.scope.as_deref().unwrap_or(""),
             &redirect_host,
-            &form.client_id,
-            &form.redirect_uri,
-            &form.code_challenge,
-            form.state.as_deref().unwrap_or(""),
-            form.resource.as_deref().unwrap_or(""),
+            &effective.client_id,
+            &effective.redirect_uri,
+            &effective.code_challenge,
+            effective.state.as_deref().unwrap_or(""),
+            effective.resource.as_deref().unwrap_or(""),
             &fresh_nonce,
-            form.oidc_nonce.as_deref().unwrap_or(""),
+            effective.nonce.as_deref().unwrap_or(""),
             Some("Authorization request expired. Please try again."),
             localhost_warning.as_deref(),
         );
         return Html(html).into_response();
     }
 
+    if !consent_form_matches_request(&form, effective) {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            "Authorization request parameters changed after consent was displayed",
+        );
+    }
+
     // Reconstruct challenge: "{fingerprint}:{nonce}:{code_challenge}"
     // Binds signature to the key identity and the PKCE session. The server
     // does not trust client-declared usernames — it resolves the username
     // from the pubkey reverse index keyed by `form.fingerprint`.
-    let challenge_str = format!("{}:{}:{}", form.fingerprint, form.nonce, form.code_challenge);
+    let challenge_str = format!("{}:{}:{}", form.fingerprint, form.nonce, effective.code_challenge);
 
     // Get user store
     let user_store = match state.user_store_reader() {
@@ -350,7 +386,7 @@ pub async fn authorize_post(
             // Never trust the POST body for display values; return an error page if
             // the client or redirect_uri is no longer valid.
             let Some((client_name, redirect_host, localhost_warning)) =
-                derive_display_info(&state, &form.client_id, &form.redirect_uri).await
+                derive_display_info(&state, &effective.client_id, &effective.redirect_uri).await
             else {
                 return Html(render_error_page(
                     "Invalid Request",
@@ -362,24 +398,22 @@ pub async fn authorize_post(
             // #1113 rev2 F3: re-stash the PAR-bound DPoP jkt under the fresh
             // nonce so one failed consent signature doesn't lose the PAR key
             // binding (which would break the later token exchange).
-            if let Some(ref binding) = authorize_binding {
-                state
-                    .pending_authorize_bindings
-                    .write()
-                    .await
-                    .insert(fresh_nonce.clone(), binding.clone());
-            }
+            state
+                .pending_authorize_bindings
+                .write()
+                .await
+                .insert(fresh_nonce.clone(), authorize_binding.clone());
             let html = render_challenge_page(
                 &client_name,
-                &form.scope,
+                effective.scope.as_deref().unwrap_or(""),
                 &redirect_host,
-                &form.client_id,
-                &form.redirect_uri,
-                &form.code_challenge,
-                form.state.as_deref().unwrap_or(""),
-                form.resource.as_deref().unwrap_or(""),
+                &effective.client_id,
+                &effective.redirect_uri,
+                &effective.code_challenge,
+                effective.state.as_deref().unwrap_or(""),
+                effective.resource.as_deref().unwrap_or(""),
                 &fresh_nonce,
-                form.oidc_nonce.as_deref().unwrap_or(""),
+                effective.nonce.as_deref().unwrap_or(""),
                 Some(e.message()),
                 localhost_warning.as_deref(),
             );
@@ -396,12 +430,14 @@ pub async fn authorize_post(
     // server-supported and client-declared scopes BEFORE minting an auth
     // code. Garbage / undeclared tokens → invalid_scope. The granted set
     // (intersection) is what the token response will echo (RFC 6749 §3.3).
-    let requested_scopes: Vec<String> = form
+    let requested_scopes: Vec<String> = effective
         .scope
+        .as_deref()
+        .unwrap_or("")
         .split_whitespace()
         .map(std::borrow::ToOwned::to_owned)
         .collect();
-    let client_declared = resolve_client_declared_scopes(&state, &form.client_id).await;
+    let client_declared = resolve_client_declared_scopes(&state, &effective.client_id).await;
     let require_atproto = super::state::atproto_profile_active(&requested_scopes);
     let granted_scopes = match super::state::validate_requested_scopes(
         &requested_scopes,
@@ -418,31 +454,31 @@ pub async fn authorize_post(
             );
         }
     };
-    let resource = form.resource.as_ref().filter(|s| !s.is_empty()).cloned();
+    let resource = effective.resource.as_ref().filter(|s| !s.is_empty()).cloned();
 
     let pending = PendingAuthCode {
         code: code.clone(),
-        client_id: form.client_id.clone(),
-        redirect_uri: form.redirect_uri.clone(),
-        code_challenge: form.code_challenge.clone(),
+        client_id: effective.client_id.clone(),
+        redirect_uri: effective.redirect_uri.clone(),
+        code_challenge: effective.code_challenge.clone(),
         scopes: granted_scopes,
-        oidc_nonce: form.oidc_nonce.clone(),
+        oidc_nonce: effective.nonce.clone(),
         resource,
         created_at: Instant::now(),
         expires_at: Instant::now() + Duration::from_secs(60),
         username: resolved_username.clone(),
         verifying_key: Some(verifying_key),
         // PAR-bound DPoP key thumbprint (#1113 rev2 finding 3).
-        dpop_jkt: authorize_binding.as_ref().and_then(|b| b.dpop_jkt.clone()),
+        dpop_jkt: effective.dpop_jkt.clone(),
     };
 
     state.pending_codes.write().await.insert(code.clone(), pending);
 
     tracing::info!(
-        client_id = %form.client_id,
+        client_id = %effective.client_id,
         username = %resolved_username,
         fingerprint = %form.fingerprint,
-        redirect_uri = %form.redirect_uri,
+        redirect_uri = %effective.redirect_uri,
         "Authorization code issued, redirecting"
     );
 
@@ -451,12 +487,15 @@ pub async fn authorize_post(
     // / OAuth 2.1 authorization-response-iss-parameter. The AS advertises
     // `authorization_response_iss_parameter_supported: true` — the stock
     // atproto client throws "iss missing" if it's absent.
-    let redirect_iss = super::state::canonical_issuer_origin(&state.issuer_url)
-        .unwrap_or_else(|| state.issuer_url.clone());
+    let redirect_iss = if require_atproto {
+        state.atproto_issuer_url()
+    } else {
+        state.issuer_url.clone()
+    };
     let redirect_url = match build_authorize_redirect_url(
-        &form.redirect_uri,
+        &effective.redirect_uri,
         &code,
-        form.state.as_deref(),
+        effective.state.as_deref(),
         &redirect_iss,
     ) {
         Ok(u) => u,

--- a/crates/hyprstream/src/services/oauth/authorize.rs
+++ b/crates/hyprstream/src/services/oauth/authorize.rs
@@ -50,6 +50,11 @@ pub struct AuthorizeParams {
     /// OIDC nonce — echoed into id_token (OpenID Connect Core 1.0, Section 3.1.2.1)
     #[serde(default)]
     pub nonce: Option<String>,
+    /// DPoP key thumbprint (`jkt`) bound at PAR (#1113 rev2 finding 3). When
+    /// the atproto profile is active this is REQUIRED and the token endpoint
+    /// must receive a DPoP proof from the same key.
+    #[serde(default)]
+    pub dpop_jkt: Option<String>,
 }
 
 /// Loosely-typed authorize query.
@@ -219,6 +224,15 @@ pub async fn authorize_get(
 
     // Generate a nonce, store it server-side (5-min TTL, single-use on POST).
     let nonce = issue_nonce(&state).await;
+    // Stash the PAR-bound DPoP key thumbprint alongside the nonce so it
+    // reaches authorize_post without crossing the browser (#1113 rev2).
+    state
+        .pending_authorize_bindings
+        .write()
+        .await
+        .insert(nonce.clone(), super::state::AuthorizeBinding {
+            dpop_jkt: params.dpop_jkt.clone(),
+        });
 
     // Render challenge form
     let html = render_challenge_page(
@@ -246,11 +260,20 @@ pub async fn authorize_post(
 ) -> Response {
     // Validate and consume the nonce. Rejects forged nonces and enforces the 5-min TTL.
     // Single-use: remove from pending_nonces whether valid or expired.
-    let nonce_valid = {
+    let (nonce_valid, authorize_binding) = {
         let mut nonces = state.pending_nonces.write().await;
         match nonces.remove(&form.nonce) {
-            Some(expiry) => Instant::now() < expiry,
-            None => false,
+            Some(expiry) => {
+                let valid = Instant::now() < expiry;
+                // Consume the PAR-bound DPoP jkt alongside the nonce (#1113 rev2).
+                let binding = state
+                    .pending_authorize_bindings
+                    .write()
+                    .await
+                    .remove(&form.nonce);
+                (valid, binding)
+            }
+            None => (false, None),
         }
     };
     if !nonce_valid {
@@ -350,7 +373,32 @@ pub async fn authorize_post(
     rand::rngs::OsRng.fill_bytes(&mut code_bytes);
     let code = URL_SAFE_NO_PAD.encode(code_bytes);
 
-    let scopes: Vec<String> = form.scope.split_whitespace().map(std::borrow::ToOwned::to_owned).collect();
+    // #1113 rev2 finding 4: validate the requested scope set against the
+    // server-supported and client-declared scopes BEFORE minting an auth
+    // code. Garbage / undeclared tokens → invalid_scope. The granted set
+    // (intersection) is what the token response will echo (RFC 6749 §3.3).
+    let requested_scopes: Vec<String> = form
+        .scope
+        .split_whitespace()
+        .map(std::borrow::ToOwned::to_owned)
+        .collect();
+    let client_declared = resolve_client_declared_scopes(&state, &form.client_id).await;
+    let require_atproto = super::state::atproto_profile_active(&requested_scopes);
+    let granted_scopes = match super::state::validate_requested_scopes(
+        &requested_scopes,
+        &state.default_scopes,
+        if client_declared.is_empty() { None } else { Some(&client_declared) },
+        require_atproto,
+    ) {
+        Ok(g) => g,
+        Err(_) => {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_scope",
+                "Requested scope is not supported or not declared by the client",
+            );
+        }
+    };
     let resource = form.resource.as_ref().filter(|s| !s.is_empty()).cloned();
 
     let pending = PendingAuthCode {
@@ -358,13 +406,15 @@ pub async fn authorize_post(
         client_id: form.client_id.clone(),
         redirect_uri: form.redirect_uri.clone(),
         code_challenge: form.code_challenge.clone(),
-        scopes,
+        scopes: granted_scopes,
         oidc_nonce: form.oidc_nonce.clone(),
         resource,
         created_at: Instant::now(),
         expires_at: Instant::now() + Duration::from_secs(60),
         username: resolved_username.clone(),
         verifying_key: Some(verifying_key),
+        // PAR-bound DPoP key thumbprint (#1113 rev2 finding 3).
+        dpop_jkt: authorize_binding.as_ref().and_then(|b| b.dpop_jkt.clone()),
     };
 
     state.pending_codes.write().await.insert(code.clone(), pending);
@@ -489,6 +539,7 @@ async fn resolve_authorize_query(
         scope,
         resource,
         nonce,
+        dpop_jkt: None,
     })
 }
 
@@ -538,6 +589,25 @@ async fn derive_display_info(
         .unwrap_or_else(|| redirect_uri.to_owned());
     let localhost_warning = compute_localhost_warning(&client.redirect_uris);
     Some((client_name, redirect_host, localhost_warning))
+}
+
+/// Resolve a client's declared scope tokens for `invalid_scope` validation
+/// (#1113 rev2 finding 4). CIMD-shaped client_ids (HTTPS URLs) resolve via
+/// the CIMD cache; DCR UUIDs via the registry. Returns an empty vec when the
+/// client is unknown or declared no scopes (→ no client-side restriction).
+async fn resolve_client_declared_scopes(state: &OAuthState, client_id: &str) -> Vec<String> {
+    let client = if client_id.starts_with("https://") {
+        match state.cimd_cache.get(client_id).await {
+            Some(c) => c,
+            None => return Vec::new(),
+        }
+    } else {
+        match state.clients.read().await.get(client_id) {
+            Some(c) => c.clone(),
+            None => return Vec::new(),
+        }
+    };
+    client.declared_scopes()
 }
 
 /// Build the consent-screen localhost warning when every registered

--- a/crates/hyprstream/src/services/oauth/authorize.rs
+++ b/crates/hyprstream/src/services/oauth/authorize.rs
@@ -290,6 +290,15 @@ pub async fn authorize_post(
             )).into_response();
         };
         let fresh_nonce = issue_nonce(&state).await;
+        // #1113 rev2 F3: re-stash the binding on error-retry so the PAR
+        // key binding survives a nonce-expired re-render.
+        if let Some(ref binding) = authorize_binding {
+            state
+                .pending_authorize_bindings
+                .write()
+                .await
+                .insert(fresh_nonce.clone(), binding.clone());
+        }
         let html = render_challenge_page(
             &client_name,
             &form.scope,
@@ -350,6 +359,16 @@ pub async fn authorize_post(
             };
             // Issue a fresh nonce so re-render shows a signable challenge.
             let fresh_nonce = issue_nonce(&state).await;
+            // #1113 rev2 F3: re-stash the PAR-bound DPoP jkt under the fresh
+            // nonce so one failed consent signature doesn't lose the PAR key
+            // binding (which would break the later token exchange).
+            if let Some(ref binding) = authorize_binding {
+                state
+                    .pending_authorize_bindings
+                    .write()
+                    .await
+                    .insert(fresh_nonce.clone(), binding.clone());
+            }
             let html = render_challenge_page(
                 &client_name,
                 &form.scope,
@@ -386,7 +405,7 @@ pub async fn authorize_post(
     let require_atproto = super::state::atproto_profile_active(&requested_scopes);
     let granted_scopes = match super::state::validate_requested_scopes(
         &requested_scopes,
-        &state.default_scopes,
+        &state.server_supported_scopes(),
         if client_declared.is_empty() { None } else { Some(&client_declared) },
         require_atproto,
     ) {
@@ -428,19 +447,20 @@ pub async fn authorize_post(
     );
 
     // Build redirect URL using url::Url to ensure proper percent-encoding of `state`.
-    let redirect_url = match url::Url::parse(&form.redirect_uri) {
-        Ok(mut u) => {
-            {
-                let mut q = u.query_pairs_mut();
-                q.append_pair("code", &code);
-                if let Some(ref s) = form.state {
-                    q.append_pair("state", s);
-                }
-            }
-            u.to_string()
-        }
+    // #1113 rev2 F5: append `iss` (the issuer) to the redirect per RFC 9207
+    // / OAuth 2.1 authorization-response-iss-parameter. The AS advertises
+    // `authorization_response_iss_parameter_supported: true` — the stock
+    // atproto client throws "iss missing" if it's absent.
+    let redirect_iss = super::state::canonical_issuer_origin(&state.issuer_url)
+        .unwrap_or_else(|| state.issuer_url.clone());
+    let redirect_url = match build_authorize_redirect_url(
+        &form.redirect_uri,
+        &code,
+        form.state.as_deref(),
+        &redirect_iss,
+    ) {
+        Ok(u) => u,
         Err(_) => {
-            // redirect_uri was validated on GET; this should not happen
             return error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "server_error",
@@ -506,6 +526,21 @@ async fn resolve_authorize_query(
             "This server requires a Pushed Authorization Request (RFC 9126). \
              Submit your authorization parameters to /oauth/par first and use the returned request_uri.",
         ));
+    }
+    // #1113 rev2 F6: the atproto profile mandates PAR — an inline (non-PAR)
+    // authorization request that includes the `atproto` scope is rejected.
+    // This keeps inline non-atproto auth working while enforcing the atproto
+    // strict profile (DPoP binding at PAR).
+    if let Some(ref scope_str) = query.scope {
+        if super::state::atproto_profile_active(
+            &scope_str.split_whitespace().map(str::to_owned).collect::<Vec<_>>(),
+        ) {
+            return Err(error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_request",
+                "The atproto profile requires a Pushed Authorization Request (RFC 9126) with a DPoP proof.",
+            ));
+        }
     }
 
     // Inline path: enforce the originally-required fields.
@@ -608,6 +643,28 @@ async fn resolve_client_declared_scopes(state: &OAuthState, client_id: &str) -> 
         }
     };
     client.declared_scopes()
+}
+
+/// Build the authorization redirect URL (#1113 rev2 F5).
+/// Pure function so the `iss` query parameter is unit-testable without
+/// constructing an OAuthState. RFC 9207 / OAuth 2.1 iss-parameter support
+/// requires `iss` on every authorization-code redirect.
+pub(crate) fn build_authorize_redirect_url(
+    redirect_uri: &str,
+    code: &str,
+    state: Option<&str>,
+    iss: &str,
+) -> Result<String, ()> {
+    let mut u = url::Url::parse(redirect_uri).map_err(|_| ())?;
+    {
+        let mut q = u.query_pairs_mut();
+        q.append_pair("code", code);
+        q.append_pair("iss", iss);
+        if let Some(s) = state {
+            q.append_pair("state", s);
+        }
+    }
+    Ok(u.to_string())
 }
 
 /// Build the consent-screen localhost warning when every registered
@@ -828,5 +885,49 @@ mod tests {
     #[test]
     fn localhost_warning_empty_returns_none() {
         assert!(compute_localhost_warning(&[]).is_none());
+    }
+
+    /// #1113 rev2 F5: the authorization redirect URL MUST include `iss`
+    /// (RFC 9207). The stock atproto client throws "iss missing" when
+    /// `authorization_response_iss_parameter_supported: true` is advertised.
+    #[test]
+    fn authorize_redirect_includes_iss_parameter() {
+        let url = build_authorize_redirect_url(
+            "https://client.example/cb",
+            "authcode123",
+            Some("xyz"),
+            "https://pds.example.com",
+        )
+        .unwrap();
+        let parsed = url::Url::parse(&url).unwrap();
+        assert_eq!(
+            parsed.query_pairs().find(|(k, _)| k == "iss"),
+            Some(("iss".into(), "https://pds.example.com".into())),
+            "redirect MUST include iss: {url}"
+        );
+        assert_eq!(
+            parsed.query_pairs().find(|(k, _)| k == "code"),
+            Some(("code".into(), "authcode123".into()))
+        );
+    }
+
+    /// #1113 rev2 F5: iss is canonicalized to exact origin (no trailing slash).
+    #[test]
+    fn authorize_redirect_iss_is_canonical_origin() {
+        let url = build_authorize_redirect_url(
+            "https://client.example/cb",
+            "code",
+            None,
+            "https://pds.example.com",
+        )
+        .unwrap();
+        let parsed = url::Url::parse(&url).unwrap();
+        let iss = parsed
+            .query_pairs()
+            .find(|(k, _)| k == "iss")
+            .map(|(_, v)| v.to_string())
+            .unwrap();
+        assert_eq!(iss, "https://pds.example.com");
+        assert!(!iss.ends_with('/'), "iss must be origin (no trailing slash)");
     }
 }

--- a/crates/hyprstream/src/services/oauth/authorize.rs
+++ b/crates/hyprstream/src/services/oauth/authorize.rs
@@ -55,6 +55,11 @@ pub struct AuthorizeParams {
     /// must receive a DPoP proof from the same key.
     #[serde(default)]
     pub dpop_jkt: Option<String>,
+    /// RFC 7638 thumbprint of the client-assertion key verified at PAR
+    /// (#1146 T3.3). When set, token redemption must present a
+    /// `client_assertion` signed by the same key.
+    #[serde(default)]
+    pub client_assertion_jkt: Option<String>,
 }
 
 /// Loosely-typed authorize query.
@@ -437,7 +442,23 @@ pub async fn authorize_post(
         .split_whitespace()
         .map(std::borrow::ToOwned::to_owned)
         .collect();
-    let client_declared = resolve_client_declared_scopes(&state, &effective.client_id).await;
+    let client_declared = match resolve_client_declared_scopes(&state, &effective.client_id).await {
+        Some(declared) => declared,
+        None => {
+            // #1146 T1.1: the client (and therefore its scope ceiling)
+            // could not be resolved — fail closed rather than silently
+            // validating against the full server-supported set.
+            tracing::warn!(
+                client_id = %effective.client_id,
+                "authorize: client unresolvable at scope validation — failing closed"
+            );
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_scope",
+                "Requested scope is not supported or not declared by the client",
+            );
+        }
+    };
     let require_atproto = super::state::atproto_profile_active(&requested_scopes);
     let granted_scopes = match super::state::validate_requested_scopes(
         &requested_scopes,
@@ -470,6 +491,8 @@ pub async fn authorize_post(
         verifying_key: Some(verifying_key),
         // PAR-bound DPoP key thumbprint (#1113 rev2 finding 3).
         dpop_jkt: effective.dpop_jkt.clone(),
+        // PAR-bound client-assertion key thumbprint (#1146 T3.3).
+        client_assertion_jkt: effective.client_assertion_jkt.clone(),
     };
 
     state.pending_codes.write().await.insert(code.clone(), pending);
@@ -614,6 +637,7 @@ async fn resolve_authorize_query(
         resource,
         nonce,
         dpop_jkt: None,
+        client_assertion_jkt: None,
     })
 }
 
@@ -667,21 +691,27 @@ async fn derive_display_info(
 
 /// Resolve a client's declared scope tokens for `invalid_scope` validation
 /// (#1113 rev2 finding 4). CIMD-shaped client_ids (HTTPS URLs) resolve via
-/// the CIMD cache; DCR UUIDs via the registry. Returns an empty vec when the
-/// client is unknown or declared no scopes (→ no client-side restriction).
-async fn resolve_client_declared_scopes(state: &OAuthState, client_id: &str) -> Vec<String> {
+/// the CIMD cache; DCR UUIDs via the registry.
+///
+/// #1146 T1.1: a CIMD cache miss RE-RESOLVES the client (policy check +
+/// metadata re-fetch) instead of silently dropping the declared scope
+/// ceiling — an aged-out cache entry must never degrade to "no
+/// restriction". Returns `None` (fail closed) when the client cannot be
+/// resolved at all; `Some(vec![])` only when a resolved client declared
+/// no scope ceiling.
+async fn resolve_client_declared_scopes(state: &OAuthState, client_id: &str) -> Option<Vec<String>> {
     let client = if client_id.starts_with("https://") {
         match state.cimd_cache.get(client_id).await {
             Some(c) => c,
-            None => return Vec::new(),
+            // Cache miss: re-resolve rather than dropping the ceiling.
+            // resolve_cimd_client re-runs the federation:register policy
+            // check and re-fetches metadata; any failure fails closed.
+            None => resolve_cimd_client(state, client_id).await.ok()?,
         }
     } else {
-        match state.clients.read().await.get(client_id) {
-            Some(c) => c.clone(),
-            None => return Vec::new(),
-        }
+        state.clients.read().await.get(client_id)?.clone()
     };
-    client.declared_scopes()
+    Some(client.declared_scopes())
 }
 
 /// Build the authorization redirect URL (#1113 rev2 F5).
@@ -968,5 +998,98 @@ mod tests {
             .unwrap();
         assert_eq!(iss, "https://pds.example.com");
         assert!(!iss.ends_with('/'), "iss must be origin (no trailing slash)");
+    }
+
+    /// #1146 T1.1: `resolve_client_declared_scopes` must re-resolve a CIMD
+    /// client on cache miss and fail closed (`None`) when the client cannot
+    /// be resolved — never silently degrade to "no scope restriction".
+    #[tokio::test]
+    async fn resolve_client_declared_scopes_fail_closed_on_miss() {
+        use hyprstream_rpc::crypto::CryptoPolicy;
+        use hyprstream_rpc::rpc_client::RpcClientImpl;
+        use hyprstream_rpc::signer::LocalSigner;
+        use hyprstream_rpc::transport::lazy_uds::LazyUdsTransport;
+
+        let signing_key = ed25519_dalek::SigningKey::from_bytes(&[0x41; 32]);
+        let remote_key = ed25519_dalek::SigningKey::from_bytes(&[0x42; 32]).verifying_key();
+        let make_client = || {
+            Arc::new(
+                RpcClientImpl::new(
+                    LocalSigner::new(signing_key.clone()),
+                    LazyUdsTransport::new("/dev/null/oauth-scope-resolve-test.sock".into()),
+                    Some(remote_key),
+                )
+                .with_response_verify_policy(CryptoPolicy::Classical),
+            )
+        };
+        let config = crate::config::OAuthConfig::default();
+        let state = OAuthState::new(
+            &config,
+            crate::services::PolicyClient::new(make_client()),
+            crate::services::DiscoveryClient::new(make_client()),
+            signing_key.verifying_key().to_bytes(),
+        );
+
+        let make_registered = |client_id: &str, scope: Option<&str>, is_cimd: bool| {
+            crate::services::oauth::state::RegisteredClient {
+                client_id: client_id.to_owned(),
+                redirect_uris: vec!["https://app.example.com/cb".to_owned()],
+                client_name: None,
+                client_uri: None,
+                logo_uri: None,
+                grant_types: vec![],
+                response_types: vec![],
+                token_endpoint_auth_method: None,
+                jwks: None,
+                jwks_uri: None,
+                hyprstream_node_did: None,
+                scope: scope.map(str::to_owned),
+                dpop_bound_access_tokens: None,
+                is_cimd,
+                registered_at: Instant::now(),
+            }
+        };
+
+        // Unknown DCR client → fail closed (was: empty vec = no restriction).
+        assert!(
+            resolve_client_declared_scopes(&state, "no-such-client")
+                .await
+                .is_none(),
+            "unknown DCR client must fail closed"
+        );
+
+        // CIMD cache miss on an unresolvable client_id → re-resolve attempt
+        // fails (policy RPC unreachable / fetch fails) → fail closed.
+        assert!(
+            resolve_client_declared_scopes(&state, "https://unresolvable.example.test/cimd.json")
+                .await
+                .is_none(),
+            "unresolvable CIMD client must fail closed, not drop the ceiling"
+        );
+
+        // DCR registry hit → declared scopes (empty vec = declared no ceiling).
+        state
+            .clients
+            .write()
+            .await
+            .insert("dcr-client".to_owned(), make_registered("dcr-client", Some("atproto"), false));
+        assert_eq!(
+            resolve_client_declared_scopes(&state, "dcr-client").await,
+            Some(vec!["atproto".to_owned()])
+        );
+
+        // CIMD cache hit → declared scopes.
+        let cimd_id = "https://app.example.com/client.json";
+        state
+            .cimd_cache
+            .insert(
+                make_registered(cimd_id, Some("atproto"), true),
+                Duration::from_secs(300),
+            )
+            .await;
+        assert_eq!(
+            resolve_client_declared_scopes(&state, cimd_id).await,
+            Some(vec!["atproto".to_owned()])
+        );
     }
 }

--- a/crates/hyprstream/src/services/oauth/cimd_cache.rs
+++ b/crates/hyprstream/src/services/oauth/cimd_cache.rs
@@ -127,6 +127,7 @@ mod tests {
             jwks: None,
             jwks_uri: None,
             hyprstream_node_did: None,
+            scope: None,
             is_cimd: true,
             registered_at: Instant::now(),
         }

--- a/crates/hyprstream/src/services/oauth/cimd_cache.rs
+++ b/crates/hyprstream/src/services/oauth/cimd_cache.rs
@@ -128,6 +128,7 @@ mod tests {
             jwks_uri: None,
             hyprstream_node_did: None,
             scope: None,
+            dpop_bound_access_tokens: None,
             is_cimd: true,
             registered_at: Instant::now(),
         }

--- a/crates/hyprstream/src/services/oauth/client_auth.rs
+++ b/crates/hyprstream/src/services/oauth/client_auth.rs
@@ -391,6 +391,7 @@ mod tests {
             jwks: Some(jwks),
             jwks_uri: None,
             hyprstream_node_did: None,
+            scope: None,
             is_cimd: true,
             registered_at: Instant::now(),
         }

--- a/crates/hyprstream/src/services/oauth/client_auth.rs
+++ b/crates/hyprstream/src/services/oauth/client_auth.rs
@@ -6,11 +6,16 @@
 //!
 //! The client assertion is a JWT signed by one of the keys in the
 //! registered client's `jwks` field (inline) or via `jwks_uri`
-//! (deferred). Claim requirements per RFC 7523 §3:
+//! (deferred). Claim requirements per RFC 7523 §3 + the atproto OAuth
+//! profile (#1146 T1.2/T3.3):
 //!   iss == sub == client_id
-//!   aud == token endpoint URL (canonical)
+//!   aud == the AS issuer (atproto mandates this form; RFC 7523 §3 also
+//!          permits the token endpoint URL, so the token endpoint accepts
+//!          both. PAR accepts the issuer only.)
 //!   exp > now
-//!   jti SHOULD be present; we treat absence as a soft warning
+//!   iat present and not in the future (beyond 60s clock skew)
+//!   jti present and unique per client until exp (replay registry in
+//!       `OAuthState::assertion_jti_seen`)
 //!   alg per the JWKS key kty/crv (RS256, ES256, EdDSA)
 //!
 //! Spec reference: MCP 2025-11-25 § Client ID Metadata Documents lists
@@ -23,7 +28,9 @@ use std::time::{Duration, Instant};
 
 use super::state::{OAuthState, RegisteredClient};
 use crate::auth::id_token_verify::{algorithm_for_key_pub, build_decoding_key};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use jsonwebtoken::{decode, DecodingKey, Validation};
+use sha2::{Digest as _, Sha256};
 
 /// HTTP fetch timeout for jwks_uri. Same as CIMD document fetch.
 const JWKS_URI_FETCH_TIMEOUT: Duration = Duration::from_secs(10);
@@ -76,6 +83,17 @@ impl std::error::Error for ClientAuthError {}
 pub const JWT_BEARER_ASSERTION_TYPE: &str =
     "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
 
+/// A successfully verified client assertion.
+#[derive(Debug, Clone)]
+pub struct VerifiedAssertion {
+    /// The verified JWT claims (caller-side use: logging, `jti` audits).
+    pub claims: Value,
+    /// RFC 7638 thumbprint (SHA-256, base64url) of the JWKS key that
+    /// verified the signature. Callers bind sessions to this so a later
+    /// request cannot switch to another registered key (#1146 T3.3).
+    pub key_jkt: String,
+}
+
 /// Decide whether a registered client requires `private_key_jwt`. Default
 /// is "no" — i.e. public client / PKCE-only — unless the registration
 /// explicitly set `token_endpoint_auth_method=private_key_jwt`.
@@ -88,23 +106,47 @@ pub fn requires_private_key_jwt(client: &RegisteredClient) -> bool {
 
 /// Verify an RFC 7523 client_assertion against the registered client's
 /// JWKS — inline `jwks` if present, otherwise fetched from `jwks_uri`
-/// (cached for `state.client_jwks_uri_cache_ttl`). `expected_audience` is the canonical
-/// token endpoint URL.
+/// (cached for `state.client_jwks_uri_cache_ttl`). `expected_audiences`
+/// is the accepted `aud` set: the AS issuer (mandated by the atproto
+/// OAuth profile) plus, at the token endpoint only, the token endpoint
+/// URL (permitted by RFC 7523 §3 for legacy clients).
 ///
-/// On success, returns the verified JWT's claims for caller-side use
-/// (typically just to log the `jti` for replay-cache decisions).
+/// On success, records the assertion's `jti` in the replay registry
+/// (single-use per client until `exp`) and returns the verified claims
+/// plus the verifying key's thumbprint for session binding.
 pub async fn verify_client_assertion(
     state: &OAuthState,
     client: &RegisteredClient,
     assertion_type: &str,
     assertion: &str,
-    expected_audience: &str,
-) -> Result<Value, ClientAuthError> {
+    expected_audiences: &[String],
+) -> Result<VerifiedAssertion, ClientAuthError> {
     if assertion_type != JWT_BEARER_ASSERTION_TYPE {
         return Err(ClientAuthError::UnsupportedAssertionType(assertion_type.to_owned()));
     }
     let keys = resolve_keys(state, client).await?;
-    verify_assertion_with_keys(&keys, &client.client_id, assertion, expected_audience)
+    let verified =
+        verify_assertion_with_keys(&keys, &client.client_id, assertion, expected_audiences)?;
+
+    // Replay registry (RFC 7523 §3: the AS MUST NOT accept the same jti
+    // more than once). check_claims already required jti/exp, so the
+    // lookups below are defensive-only.
+    let jti = verified
+        .claims
+        .get("jti")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ClientAuthError::InvalidClaim("missing jti".to_owned()))?;
+    let exp = verified
+        .claims
+        .get("exp")
+        .and_then(Value::as_i64)
+        .ok_or_else(|| ClientAuthError::InvalidClaim("missing exp".to_owned()))?;
+    if !state.check_and_record_assertion_jti(&client.client_id, jti, exp) {
+        return Err(ClientAuthError::InvalidClaim(
+            "jti already used (assertion replay)".to_owned(),
+        ));
+    }
+    Ok(verified)
 }
 
 /// Pure-sync core verification: given a set of candidate keys, verify
@@ -114,8 +156,8 @@ pub fn verify_assertion_with_keys(
     keys: &[Value],
     client_id: &str,
     assertion: &str,
-    expected_audience: &str,
-) -> Result<Value, ClientAuthError> {
+    expected_audiences: &[String],
+) -> Result<VerifiedAssertion, ClientAuthError> {
     let keys = keys.to_vec();
 
     // Parse the header to learn alg + (optional) kid before iterating keys.
@@ -184,8 +226,13 @@ pub fn verify_assertion_with_keys(
         match decode::<Value>(assertion, &decoding_key, &validation) {
             Ok(data) => {
                 let claims = data.claims;
-                check_claims(&claims, client_id, expected_audience)?;
-                return Ok(claims);
+                check_claims(&claims, client_id, expected_audiences)?;
+                let key_jkt = jwk_thumbprint_sha256(jwk).ok_or_else(|| {
+                    ClientAuthError::InvalidClaim(
+                        "cannot compute thumbprint of verifying JWK".to_owned(),
+                    )
+                })?;
+                return Ok(VerifiedAssertion { claims, key_jkt });
             }
             Err(e) => {
                 tracing::debug!(
@@ -324,10 +371,43 @@ async fn fetch_jwks_uri(state: &OAuthState, url: &str) -> Result<Value, ClientAu
     Ok(jwks)
 }
 
+/// RFC 7638 JWK thumbprint (SHA-256, base64url) over the required
+/// members of an OKP/EC/RSA key. Used to bind a session to the exact
+/// assertion key that verified — switching to another registered key
+/// changes the thumbprint (#1146 T3.3).
+///
+/// The member lists are already in lexicographic order as required by
+/// RFC 7638 §3.2. JWK key material is base64url by construction, so the
+/// canonical JSON needs no string escaping.
+fn jwk_thumbprint_sha256(jwk: &Value) -> Option<String> {
+    let get = |name: &str| jwk.get(name).and_then(Value::as_str);
+    let kty = get("kty")?;
+    let members: Vec<(&str, &str)> = match kty {
+        "OKP" => vec![("crv", get("crv")?), ("kty", kty), ("x", get("x")?)],
+        "EC" => vec![
+            ("crv", get("crv")?),
+            ("kty", kty),
+            ("x", get("x")?),
+            ("y", get("y")?),
+        ],
+        "RSA" => vec![("e", get("e")?), ("kty", kty), ("n", get("n")?)],
+        _ => return None,
+    };
+    let canonical = format!(
+        "{{{}}}",
+        members
+            .iter()
+            .map(|(k, v)| format!("\"{k}\":\"{v}\""))
+            .collect::<Vec<_>>()
+            .join(",")
+    );
+    Some(URL_SAFE_NO_PAD.encode(Sha256::digest(canonical.as_bytes())))
+}
+
 fn check_claims(
     claims: &Value,
     client_id: &str,
-    expected_audience: &str,
+    expected_audiences: &[String],
 ) -> Result<(), ClientAuthError> {
     let iss = claims.get("iss").and_then(Value::as_str)
         .ok_or_else(|| ClientAuthError::InvalidClaim("missing iss".to_owned()))?;
@@ -344,26 +424,50 @@ fn check_claims(
         )));
     }
 
+    let now = chrono::Utc::now().timestamp();
+
+    // iat is REQUIRED (#1146 T3.3): together with the mandatory jti it
+    // bounds the replay window and gives operators an issuance-time
+    // audit anchor. Reject assertions dated beyond a 60s clock skew.
+    let iat = claims.get("iat").and_then(Value::as_i64)
+        .ok_or_else(|| ClientAuthError::InvalidClaim("missing iat".to_owned()))?;
+    if iat > now + 60 {
+        return Err(ClientAuthError::InvalidClaim(format!(
+            "iat {iat} is in the future (now={now})"
+        )));
+    }
+
+    // jti is REQUIRED (#1146 T3.3): it keys the replay registry. RFC 7523
+    // §3 makes it optional, but this AS mandates it — without a unique
+    // jti there is no replay protection for a bearer assertion.
+    match claims.get("jti").and_then(Value::as_str) {
+        Some(jti) if !jti.is_empty() => {}
+        _ => return Err(ClientAuthError::InvalidClaim("missing jti".to_owned())),
+    }
+
     // Explicit exp check — defend against jsonwebtoken's
     // Validation::validate_exp behaviour quirks across versions.
     let exp = claims.get("exp").and_then(Value::as_i64)
         .ok_or_else(|| ClientAuthError::InvalidClaim("missing exp".to_owned()))?;
-    let now = chrono::Utc::now().timestamp();
     if exp <= now {
         return Err(ClientAuthError::InvalidClaim(format!(
             "exp {exp} is not in the future (now={now})"
         )));
     }
 
-    // aud may be a string or an array of strings (RFC 7519 §4.1.3).
+    // aud may be a string or an array of strings (RFC 7519 §4.1.3). It
+    // must include one of the accepted audiences: the AS issuer (atproto
+    // mandate) and, where the caller allows it, the token endpoint URL
+    // (RFC 7523 §3).
+    let aud_matches = |candidate: &str| expected_audiences.iter().any(|e| e == candidate);
     let aud_ok = match claims.get("aud") {
-        Some(Value::String(s)) => s == expected_audience,
-        Some(Value::Array(a)) => a.iter().any(|v| v.as_str() == Some(expected_audience)),
+        Some(Value::String(s)) => aud_matches(s),
+        Some(Value::Array(a)) => a.iter().filter_map(Value::as_str).any(aud_matches),
         _ => false,
     };
     if !aud_ok {
         return Err(ClientAuthError::InvalidClaim(format!(
-            "aud does not include '{expected_audience}'"
+            "aud does not include any of {expected_audiences:?}"
         )));
     }
 
@@ -392,6 +496,7 @@ mod tests {
             jwks_uri: None,
             hyprstream_node_did: None,
             scope: None,
+            dpop_bound_access_tokens: None,
             is_cimd: true,
             registered_at: Instant::now(),
         }
@@ -427,41 +532,141 @@ mod tests {
         vec![jwk]
     }
 
-    #[test]
-    fn valid_assertion_round_trip() {
-        let (sk, jwk) = ed25519_keypair_and_jwk();
-        let claims = serde_json::json!({
+    /// The accepted audience set used by the token endpoint: the AS
+    /// issuer (atproto-mandated form) plus the token endpoint URL
+    /// (RFC 7523 §3 form).
+    fn token_endpoint_audiences() -> Vec<String> {
+        vec![
+            "https://hs.test".to_owned(),
+            "https://hs.test/oauth/token".to_owned(),
+        ]
+    }
+
+    /// Baseline valid claims: iss/sub, issuer-form aud, iat, jti, exp.
+    fn valid_claims() -> serde_json::Value {
+        serde_json::json!({
             "iss": "https://app.test/c",
             "sub": "https://app.test/c",
-            "aud": "https://hs.test/oauth/token",
+            "aud": "https://hs.test",
+            "iat": chrono::Utc::now().timestamp(),
             "exp": chrono::Utc::now().timestamp() + 60,
             "jti": "j1",
-        });
-        let assertion = make_ed_assertion(&sk, claims);
+        })
+    }
+
+    #[test]
+    fn valid_assertion_round_trip() {
+        // #1146 T1.2: the atproto-mandated audience is the AS ISSUER.
+        let (sk, jwk) = ed25519_keypair_and_jwk();
+        let assertion = make_ed_assertion(&sk, valid_claims());
         let got = verify_assertion_with_keys(
             &keys_array(jwk),
             "https://app.test/c",
             &assertion,
-            "https://hs.test/oauth/token",
+            &token_endpoint_audiences(),
         );
         assert!(got.is_ok(), "verify failed: {:?}", got.err());
     }
 
     #[test]
-    fn rejects_wrong_audience() {
+    fn accepts_token_endpoint_audience_rfc7523() {
+        // RFC 7523 §3 permits the token endpoint URL as aud; the token
+        // endpoint accepts both forms for legacy clients.
         let (sk, jwk) = ed25519_keypair_and_jwk();
-        let claims = serde_json::json!({
-            "iss": "https://app.test/c",
-            "sub": "https://app.test/c",
-            "aud": "https://attacker.test/oauth/token",
-            "exp": chrono::Utc::now().timestamp() + 60,
-        });
+        let mut claims = valid_claims();
+        claims["aud"] = serde_json::json!("https://hs.test/oauth/token");
         let assertion = make_ed_assertion(&sk, claims);
         let got = verify_assertion_with_keys(
             &keys_array(jwk),
             "https://app.test/c",
             &assertion,
-            "https://hs.test/oauth/token",
+            &token_endpoint_audiences(),
+        );
+        assert!(got.is_ok(), "token-endpoint aud must verify: {:?}", got.err());
+    }
+
+    #[test]
+    fn rejects_issuer_audience_when_not_accepted() {
+        // PAR accepts ONLY the issuer form (#1146 T1.2/T3.3): an
+        // assertion audience of the token endpoint must fail there.
+        let (sk, jwk) = ed25519_keypair_and_jwk();
+        let mut claims = valid_claims();
+        claims["aud"] = serde_json::json!("https://hs.test/oauth/token");
+        let assertion = make_ed_assertion(&sk, claims);
+        let got = verify_assertion_with_keys(
+            &keys_array(jwk),
+            "https://app.test/c",
+            &assertion,
+            &["https://hs.test".to_owned()],
+        );
+        assert!(matches!(got, Err(ClientAuthError::InvalidClaim(_))));
+    }
+
+    #[test]
+    fn rejects_missing_iat() {
+        let (sk, jwk) = ed25519_keypair_and_jwk();
+        let mut claims = valid_claims();
+        claims.as_object_mut().unwrap().remove("iat");
+        let assertion = make_ed_assertion(&sk, claims);
+        let got = verify_assertion_with_keys(
+            &keys_array(jwk),
+            "https://app.test/c",
+            &assertion,
+            &token_endpoint_audiences(),
+        );
+        assert!(
+            matches!(&got, Err(ClientAuthError::InvalidClaim(c)) if c.contains("iat")),
+            "missing iat must be rejected: {got:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_future_iat() {
+        let (sk, jwk) = ed25519_keypair_and_jwk();
+        let mut claims = valid_claims();
+        claims["iat"] = serde_json::json!(chrono::Utc::now().timestamp() + 3600);
+        let assertion = make_ed_assertion(&sk, claims);
+        let got = verify_assertion_with_keys(
+            &keys_array(jwk),
+            "https://app.test/c",
+            &assertion,
+            &token_endpoint_audiences(),
+        );
+        assert!(
+            matches!(&got, Err(ClientAuthError::InvalidClaim(c)) if c.contains("iat")),
+            "future iat must be rejected: {got:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_missing_jti() {
+        let (sk, jwk) = ed25519_keypair_and_jwk();
+        let mut claims = valid_claims();
+        claims.as_object_mut().unwrap().remove("jti");
+        let assertion = make_ed_assertion(&sk, claims);
+        let got = verify_assertion_with_keys(
+            &keys_array(jwk),
+            "https://app.test/c",
+            &assertion,
+            &token_endpoint_audiences(),
+        );
+        assert!(
+            matches!(&got, Err(ClientAuthError::InvalidClaim(c)) if c.contains("jti")),
+            "missing jti must be rejected: {got:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_wrong_audience() {
+        let (sk, jwk) = ed25519_keypair_and_jwk();
+        let mut claims = valid_claims();
+        claims["aud"] = serde_json::json!("https://attacker.test/oauth/token");
+        let assertion = make_ed_assertion(&sk, claims);
+        let got = verify_assertion_with_keys(
+            &keys_array(jwk),
+            "https://app.test/c",
+            &assertion,
+            &token_endpoint_audiences(),
         );
         assert!(matches!(got, Err(ClientAuthError::InvalidClaim(_))));
     }
@@ -469,18 +674,15 @@ mod tests {
     #[test]
     fn rejects_wrong_iss() {
         let (sk, jwk) = ed25519_keypair_and_jwk();
-        let claims = serde_json::json!({
-            "iss": "https://impostor.test/c",
-            "sub": "https://impostor.test/c",
-            "aud": "https://hs.test/oauth/token",
-            "exp": chrono::Utc::now().timestamp() + 60,
-        });
+        let mut claims = valid_claims();
+        claims["iss"] = serde_json::json!("https://impostor.test/c");
+        claims["sub"] = serde_json::json!("https://impostor.test/c");
         let assertion = make_ed_assertion(&sk, claims);
         let got = verify_assertion_with_keys(
             &keys_array(jwk),
             "https://app.test/c",
             &assertion,
-            "https://hs.test/oauth/token",
+            &token_endpoint_audiences(),
         );
         assert!(matches!(got, Err(ClientAuthError::InvalidClaim(_))));
     }
@@ -488,18 +690,14 @@ mod tests {
     #[test]
     fn rejects_expired_assertion() {
         let (sk, jwk) = ed25519_keypair_and_jwk();
-        let claims = serde_json::json!({
-            "iss": "https://app.test/c",
-            "sub": "https://app.test/c",
-            "aud": "https://hs.test/oauth/token",
-            "exp": chrono::Utc::now().timestamp() - 60,
-        });
+        let mut claims = valid_claims();
+        claims["exp"] = serde_json::json!(chrono::Utc::now().timestamp() - 60);
         let assertion = make_ed_assertion(&sk, claims);
         let got = verify_assertion_with_keys(
             &keys_array(jwk),
             "https://app.test/c",
             &assertion,
-            "https://hs.test/oauth/token",
+            &token_endpoint_audiences(),
         );
         assert!(got.is_err(), "expired assertion should not verify: {got:?}");
     }
@@ -510,7 +708,7 @@ mod tests {
             &[],
             "https://app.test/c",
             "irrelevant",
-            "https://hs.test/oauth/token",
+            &token_endpoint_audiences(),
         );
         assert!(got.is_err(), "empty key set must not verify");
     }
@@ -582,7 +780,7 @@ mod tests {
             &[rsa_jwk],
             "https://app.test/c",
             &bogus_assertion,
-            "https://hs.test/oauth/token",
+            &token_endpoint_audiences(),
         );
         assert!(
             matches!(got, Err(ClientAuthError::InvalidSignature)),

--- a/crates/hyprstream/src/services/oauth/client_auth.rs
+++ b/crates/hyprstream/src/services/oauth/client_auth.rs
@@ -9,9 +9,10 @@
 //! (deferred). Claim requirements per RFC 7523 §3 + the atproto OAuth
 //! profile (#1146 T1.2/T3.3):
 //!   iss == sub == client_id
-//!   aud == the AS issuer (atproto mandates this form; RFC 7523 §3 also
-//!          permits the token endpoint URL, so the token endpoint accepts
-//!          both. PAR accepts the issuer only.)
+//!   aud == the AS issuer. The atproto OAuth profile mandates this form;
+//!          RFC 7523 §3 permits the token endpoint URL too, but this AS
+//!          accepts the issuer ALONE at every endpoint (PAR and token) —
+//!          see #1146 T1.2.
 //!   exp > now
 //!   iat present and not in the future (beyond 60s clock skew)
 //!   jti present and unique per client until exp (replay registry in
@@ -107,9 +108,8 @@ pub fn requires_private_key_jwt(client: &RegisteredClient) -> bool {
 /// Verify an RFC 7523 client_assertion against the registered client's
 /// JWKS — inline `jwks` if present, otherwise fetched from `jwks_uri`
 /// (cached for `state.client_jwks_uri_cache_ttl`). `expected_audiences`
-/// is the accepted `aud` set: the AS issuer (mandated by the atproto
-/// OAuth profile) plus, at the token endpoint only, the token endpoint
-/// URL (permitted by RFC 7523 §3 for legacy clients).
+/// is the accepted `aud` set — on every profile path this is the AS
+/// issuer alone (atproto mandate, #1146 T1.2).
 ///
 /// On success, records the assertion's `jti` in the replay registry
 /// (single-use per client until `exp`) and returns the verified claims
@@ -378,7 +378,9 @@ async fn fetch_jwks_uri(state: &OAuthState, url: &str) -> Result<Value, ClientAu
 ///
 /// The member lists are already in lexicographic order as required by
 /// RFC 7638 §3.2. JWK key material is base64url by construction, so the
-/// canonical JSON needs no string escaping.
+/// canonical JSON needs no string escaping. Any other `kty` returns
+/// `None`, which the caller treats as an authentication failure — unknown
+/// key types fail closed rather than falling back to a weaker binding.
 fn jwk_thumbprint_sha256(jwk: &Value) -> Option<String> {
     let get = |name: &str| jwk.get(name).and_then(Value::as_str);
     let kty = get("kty")?;
@@ -456,9 +458,8 @@ fn check_claims(
     }
 
     // aud may be a string or an array of strings (RFC 7519 §4.1.3). It
-    // must include one of the accepted audiences: the AS issuer (atproto
-    // mandate) and, where the caller allows it, the token endpoint URL
-    // (RFC 7523 §3).
+    // must include one of the accepted audiences — on all profile paths
+    // that is the AS issuer alone (#1146 T1.2).
     let aud_matches = |candidate: &str| expected_audiences.iter().any(|e| e == candidate);
     let aud_ok = match claims.get("aud") {
         Some(Value::String(s)) => aud_matches(s),
@@ -532,14 +533,10 @@ mod tests {
         vec![jwk]
     }
 
-    /// The accepted audience set used by the token endpoint: the AS
-    /// issuer (atproto-mandated form) plus the token endpoint URL
-    /// (RFC 7523 §3 form).
-    fn token_endpoint_audiences() -> Vec<String> {
-        vec![
-            "https://hs.test".to_owned(),
-            "https://hs.test/oauth/token".to_owned(),
-        ]
+    /// The accepted audience set used by BOTH the PAR and token endpoints
+    /// (#1146 T1.2 rev): the AS issuer alone.
+    fn issuer_audiences() -> Vec<String> {
+        vec!["https://hs.test".to_owned()]
     }
 
     /// Baseline valid claims: iss/sub, issuer-form aud, iat, jti, exp.
@@ -563,15 +560,17 @@ mod tests {
             &keys_array(jwk),
             "https://app.test/c",
             &assertion,
-            &token_endpoint_audiences(),
+            &issuer_audiences(),
         );
         assert!(got.is_ok(), "verify failed: {:?}", got.err());
     }
 
     #[test]
-    fn accepts_token_endpoint_audience_rfc7523() {
-        // RFC 7523 §3 permits the token endpoint URL as aud; the token
-        // endpoint accepts both forms for legacy clients.
+    fn rejects_token_endpoint_audience() {
+        // #1146 T1.2 (rev): RFC 7523 §3 permits the token endpoint URL as
+        // aud, but the atproto OAuth profile mandates the issuer ALONE.
+        // Accepting the endpoint form would leave it valid as an assertion
+        // target — it must be rejected at the token endpoint too.
         let (sk, jwk) = ed25519_keypair_and_jwk();
         let mut claims = valid_claims();
         claims["aud"] = serde_json::json!("https://hs.test/oauth/token");
@@ -580,26 +579,12 @@ mod tests {
             &keys_array(jwk),
             "https://app.test/c",
             &assertion,
-            &token_endpoint_audiences(),
+            &issuer_audiences(),
         );
-        assert!(got.is_ok(), "token-endpoint aud must verify: {:?}", got.err());
-    }
-
-    #[test]
-    fn rejects_issuer_audience_when_not_accepted() {
-        // PAR accepts ONLY the issuer form (#1146 T1.2/T3.3): an
-        // assertion audience of the token endpoint must fail there.
-        let (sk, jwk) = ed25519_keypair_and_jwk();
-        let mut claims = valid_claims();
-        claims["aud"] = serde_json::json!("https://hs.test/oauth/token");
-        let assertion = make_ed_assertion(&sk, claims);
-        let got = verify_assertion_with_keys(
-            &keys_array(jwk),
-            "https://app.test/c",
-            &assertion,
-            &["https://hs.test".to_owned()],
+        assert!(
+            matches!(got, Err(ClientAuthError::InvalidClaim(_))),
+            "token-endpoint aud must be rejected (issuer-only): {got:?}"
         );
-        assert!(matches!(got, Err(ClientAuthError::InvalidClaim(_))));
     }
 
     #[test]
@@ -612,7 +597,7 @@ mod tests {
             &keys_array(jwk),
             "https://app.test/c",
             &assertion,
-            &token_endpoint_audiences(),
+            &issuer_audiences(),
         );
         assert!(
             matches!(&got, Err(ClientAuthError::InvalidClaim(c)) if c.contains("iat")),
@@ -630,7 +615,7 @@ mod tests {
             &keys_array(jwk),
             "https://app.test/c",
             &assertion,
-            &token_endpoint_audiences(),
+            &issuer_audiences(),
         );
         assert!(
             matches!(&got, Err(ClientAuthError::InvalidClaim(c)) if c.contains("iat")),
@@ -648,7 +633,7 @@ mod tests {
             &keys_array(jwk),
             "https://app.test/c",
             &assertion,
-            &token_endpoint_audiences(),
+            &issuer_audiences(),
         );
         assert!(
             matches!(&got, Err(ClientAuthError::InvalidClaim(c)) if c.contains("jti")),
@@ -666,7 +651,7 @@ mod tests {
             &keys_array(jwk),
             "https://app.test/c",
             &assertion,
-            &token_endpoint_audiences(),
+            &issuer_audiences(),
         );
         assert!(matches!(got, Err(ClientAuthError::InvalidClaim(_))));
     }
@@ -682,7 +667,7 @@ mod tests {
             &keys_array(jwk),
             "https://app.test/c",
             &assertion,
-            &token_endpoint_audiences(),
+            &issuer_audiences(),
         );
         assert!(matches!(got, Err(ClientAuthError::InvalidClaim(_))));
     }
@@ -697,7 +682,7 @@ mod tests {
             &keys_array(jwk),
             "https://app.test/c",
             &assertion,
-            &token_endpoint_audiences(),
+            &issuer_audiences(),
         );
         assert!(got.is_err(), "expired assertion should not verify: {got:?}");
     }
@@ -708,7 +693,7 @@ mod tests {
             &[],
             "https://app.test/c",
             "irrelevant",
-            &token_endpoint_audiences(),
+            &issuer_audiences(),
         );
         assert!(got.is_err(), "empty key set must not verify");
     }
@@ -780,7 +765,7 @@ mod tests {
             &[rsa_jwk],
             "https://app.test/c",
             &bogus_assertion,
-            &token_endpoint_audiences(),
+            &issuer_audiences(),
         );
         assert!(
             matches!(got, Err(ClientAuthError::InvalidSignature)),

--- a/crates/hyprstream/src/services/oauth/device.rs
+++ b/crates/hyprstream/src/services/oauth/device.rs
@@ -116,6 +116,19 @@ pub async fn device_authorize(
             .collect();
         let client_declared = client.declared_scopes();
         let require_atproto = super::state::atproto_profile_active(&requested);
+        // #1146 T1.3: the atproto OAuth profile has no device authorization
+        // grant — rejecting here is what keeps the "atproto ⇒ DPoP
+        // sender-bound" invariant intact. Without this guard the device
+        // flow minted malformed `token_type: "DPoP"` tokens with `cnf`
+        // bound to the user's login key, which no client can ever prove
+        // possession of.
+        if require_atproto {
+            return device_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_scope",
+                "The atproto profile has no device authorization grant; use PAR + authorization code",
+            );
+        }
         match super::state::validate_requested_scopes(
             &requested,
             &state.server_supported_scopes(),

--- a/crates/hyprstream/src/services/oauth/device.rs
+++ b/crates/hyprstream/src/services/oauth/device.rs
@@ -57,6 +57,7 @@ pub struct VerifyForm {
 }
 
 /// POST /oauth/device — Device Authorization Endpoint (RFC 8628 Section 3.1)
+#[allow(clippy::redundant_closure_for_method_calls)] // owned vs borrowed RegisteredClient
 pub async fn device_authorize(
     State(state): State<Arc<OAuthState>>,
     Form(params): Form<DeviceAuthRequest>,
@@ -95,13 +96,47 @@ pub async fn device_authorize(
     rand::rngs::OsRng.fill_bytes(&mut nonce_bytes);
     let nonce = URL_SAFE_NO_PAD.encode(nonce_bytes);
 
-    let scopes: Vec<String> = params
-        .scope
-        .as_deref()
-        .unwrap_or(&state.default_scopes.join(" "))
-        .split_whitespace()
-        .map(std::borrow::ToOwned::to_owned)
-        .collect();
+    let scopes: Vec<String> = {
+        // #1113 rev2 F4: validate requested scopes against server-supported
+        // ∩ client-declared (no arbitrary scope text reaching issuance).
+        let requested: Vec<String> = params
+            .scope
+            .as_deref()
+            .unwrap_or(&state.default_scopes.join(" "))
+            .split_whitespace()
+            .map(std::borrow::ToOwned::to_owned)
+            .collect();
+        let client_declared = if params.client_id.starts_with("https://") {
+            super::registration::resolve_cimd_client(&state, &params.client_id)
+                .await
+                .map(|c| c.declared_scopes())
+                .unwrap_or_default()
+        } else {
+            state
+                .clients
+                .read()
+                .await
+                .get(&params.client_id)
+                .map(|c| c.declared_scopes())
+                .unwrap_or_default()
+        };
+        let require_atproto = super::state::atproto_profile_active(&requested);
+        match super::state::validate_requested_scopes(
+            &requested,
+            &state.server_supported_scopes(),
+            if client_declared.is_empty() { None } else { Some(&client_declared) },
+            require_atproto,
+        ) {
+            Ok(g) => g,
+            Err(_) => {
+                return device_error(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_scope",
+                    "Requested scope is not supported or not declared by the client",
+                );
+            }
+        }
+    };
 
     let resource = params.resource.filter(|s| !s.is_empty());
 

--- a/crates/hyprstream/src/services/oauth/device.rs
+++ b/crates/hyprstream/src/services/oauth/device.rs
@@ -62,26 +62,33 @@ pub async fn device_authorize(
     State(state): State<Arc<OAuthState>>,
     Form(params): Form<DeviceAuthRequest>,
 ) -> Response {
-    // Validate client exists. CIMD URLs live in cimd_cache; DCR UUIDs
-    // live in state.clients. The device flow doesn't need full client
-    // metadata here — just existence — so a cheap presence check suffices.
-    let known = if params.client_id.starts_with("https://") {
-        // For CIMD, an absent cache entry doesn't necessarily mean an
-        // unknown client — it may just be a cold cache. Resolve through
-        // the cache-aside path which will fetch on miss.
-        super::registration::resolve_cimd_client(&state, &params.client_id)
-            .await
-            .is_ok()
+    // #1113 r4 F2: resolve the client ONCE and reject on failure
+    // (invalid_client). Previously, CIMD errors and unknown registered
+    // clients collapsed to empty scope via unwrap_or_default.
+    let client = if params.client_id.starts_with("https://") {
+        match super::registration::resolve_cimd_client(&state, &params.client_id).await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(client_id = %params.client_id, error = %e, "device: CIMD resolution failed");
+                return device_error(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_client",
+                    "Unknown client_id. Register first via POST /oauth/register",
+                );
+            }
+        }
     } else {
-        state.clients.read().await.contains_key(&params.client_id)
+        match state.clients.read().await.get(&params.client_id) {
+            Some(c) => c.clone(),
+            None => {
+                return device_error(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_client",
+                    "Unknown client_id. Register first via POST /oauth/register",
+                );
+            }
+        }
     };
-    if !known {
-        return device_error(
-            StatusCode::BAD_REQUEST,
-            "invalid_client",
-            "Unknown client_id. Register first via POST /oauth/register",
-        );
-    }
 
     // Generate device_code (32 bytes, URL-safe base64)
     let mut device_code_bytes = [0u8; 32];
@@ -97,8 +104,9 @@ pub async fn device_authorize(
     let nonce = URL_SAFE_NO_PAD.encode(nonce_bytes);
 
     let scopes: Vec<String> = {
-        // #1113 rev2 F4: validate requested scopes against server-supported
-        // ∩ client-declared (no arbitrary scope text reaching issuance).
+        // #1113 rev2 F4 / r4 F2: validate requested scopes against
+        // server-supported ∩ client-declared. Client is already resolved
+        // above; use its declared scopes directly (no unwrap_or_default).
         let requested: Vec<String> = params
             .scope
             .as_deref()
@@ -106,20 +114,7 @@ pub async fn device_authorize(
             .split_whitespace()
             .map(std::borrow::ToOwned::to_owned)
             .collect();
-        let client_declared = if params.client_id.starts_with("https://") {
-            super::registration::resolve_cimd_client(&state, &params.client_id)
-                .await
-                .map(|c| c.declared_scopes())
-                .unwrap_or_default()
-        } else {
-            state
-                .clients
-                .read()
-                .await
-                .get(&params.client_id)
-                .map(|c| c.declared_scopes())
-                .unwrap_or_default()
-        };
+        let client_declared = client.declared_scopes();
         let require_atproto = super::state::atproto_profile_active(&requested);
         match super::state::validate_requested_scopes(
             &requested,

--- a/crates/hyprstream/src/services/oauth/did_document.rs
+++ b/crates/hyprstream/src/services/oauth/did_document.rs
@@ -606,7 +606,25 @@ pub async fn user_did_document(
         None => Vec::new(),
     };
 
-    let doc = build_did_document(&did, &state.issuer_url, &keys, None, &[], None, None);
+    // #1113 rev2 finding 2: serve a COMPLETE atproto account DID document so
+    // that resolving the token `sub` (a did:web:{authority}:users:{username})
+    // yields a PDS whose `AtprotoPersonalDataServer` service points at THIS
+    // host — the round-trip the stock @atproto/oauth-client-browser requires
+    // (PDS metadata issuer == this AS). The hosted-account `#atproto` VM is
+    // the node's active ES256 key (the PDS signs atproto ops on the account's
+    // behalf), and `alsoKnownAs` carries an `at://{handle}` alias.
+    let atproto_signing = match state.es256_key_store.as_ref() {
+        Some(store) => store.active_key().await,
+        None => None,
+    };
+    let handle_host = authority.split(':').next().unwrap_or(authority.as_str());
+    let handle = format!("{username}.{handle_host}");
+    let atproto = atproto_signing.as_ref().map(|sk| AtprotoIdentity {
+        p256_vk: sk.verifying_key(),
+        handle: handle.as_str(),
+    });
+
+    let doc = build_did_document(&did, &state.issuer_url, &keys, atproto.as_ref(), &[], None, None);
     (
         StatusCode::OK,
         [(header::CONTENT_TYPE, "application/did+json")],
@@ -840,6 +858,44 @@ mod tests {
 
         // alsoKnownAs handle.
         assert_eq!(doc["alsoKnownAs"][0].as_str().unwrap(), "at://hyprstream.example.com");
+    }
+
+    /// #1113 rev2 finding 2/7: the per-user atproto DID document (served at
+    /// `/users/:u/did.json` for a `did:web:{authority}:users:{u}` token `sub`)
+    /// carries an `AtprotoPersonalDataServer` service whose `serviceEndpoint`
+    /// is THIS AS's origin — the round-trip the stock atproto client performs
+    /// (resolve `sub` → PDS service → PDS metadata issuer == AS). Mirrors the
+    /// `user_did_document` handler's construction exactly.
+    #[test]
+    fn per_user_atproto_doc_pds_service_points_at_issuer() {
+        let p256_sk = p256::ecdsa::SigningKey::random(&mut OsRng);
+        let p256_vk = p256_sk.verifying_key();
+        let issuer = "https://pds.example.com";
+        let did = "did:web:pds.example.com:users:alice";
+        let handle = "alice.pds.example.com";
+        let atproto = AtprotoIdentity { p256_vk, handle };
+        let doc = build_did_document(did, issuer, &[], Some(&atproto), &[], None, None);
+
+        // The atproto PDS service is present and points at the issuer origin.
+        let pds = doc["service"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|s| s["type"] == "AtprotoPersonalDataServer")
+            .expect("AtprotoPersonalDataServer service required for the sub→PDS round-trip");
+        assert_eq!(
+            pds["serviceEndpoint"].as_str().unwrap(),
+            issuer,
+            "PDS serviceEndpoint MUST equal the AS issuer (PDS = its own AS)"
+        );
+        // The account handle alias is present.
+        assert_eq!(doc["alsoKnownAs"][0].as_str().unwrap(), "at://alice.pds.example.com");
+        // The hosted-account #atproto VM (P-256 Multikey) is present.
+        assert!(doc["verificationMethod"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|vm| vm["id"].as_str() == Some(&format!("{did}#atproto"))));
     }
 
     #[test]

--- a/crates/hyprstream/src/services/oauth/did_document.rs
+++ b/crates/hyprstream/src/services/oauth/did_document.rs
@@ -81,6 +81,34 @@ fn issuer_origin(issuer_url: &str) -> Option<String> {
     }
 }
 
+fn normalize_atproto_handle(handle: &str) -> Option<String> {
+    let handle = handle.trim_end_matches('.').to_ascii_lowercase();
+    if handle.len() > 253 || handle.split('.').count() < 2 {
+        return None;
+    }
+    let valid = handle.split('.').all(|label| {
+        !label.is_empty()
+            && label.len() <= 63
+            && !label.starts_with('-')
+            && !label.ends_with('-')
+            && label.bytes().all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+    });
+    valid.then_some(handle)
+}
+
+fn configured_handle_host(issuer_url: &str) -> Option<String> {
+    let url = url::Url::parse(issuer_url).ok()?;
+    match url.host()? {
+        url::Host::Domain(host) => normalize_atproto_handle(host),
+        url::Host::Ipv4(_) | url::Host::Ipv6(_) => None,
+    }
+}
+
+fn account_handle(username: &str, issuer_url: &str) -> Option<String> {
+    let host = configured_handle_host(issuer_url)?;
+    normalize_atproto_handle(&format!("{username}.{host}"))
+}
+
 /// Build the multibase z-encoded P-256 public key per the `Multikey` /
 /// did:key conventions used by atproto.
 ///
@@ -466,14 +494,10 @@ pub async fn root_did_document(
         Some(store) => store.active_key().await,
         None => None,
     };
-    // The atproto handle is a bare hostname (no port); strip any port the
-    // authority carries (the DID identifier keeps the port, the handle does not).
-    let handle = authority.split(':').next().unwrap_or(authority.as_str());
+    let handle = configured_handle_host(&state.issuer_url);
     let atproto_vk = atproto_sk.as_ref().map(|sk| sk.verifying_key());
-    let atproto = atproto_vk.map(|vk| AtprotoIdentity {
-        p256_vk: vk,
-        handle,
-    });
+    let atproto = atproto_vk.zip(handle.as_deref())
+        .map(|(vk, handle)| AtprotoIdentity { p256_vk: vk, handle });
 
     // Transport `service` entries: populate QUIC entry when cert hash is available (#185).
     // The cert hash was set at OAuthService startup from the node's QUIC TLS cert,
@@ -617,12 +641,9 @@ pub async fn user_did_document(
         Some(store) => store.active_key().await,
         None => None,
     };
-    let handle_host = authority.split(':').next().unwrap_or(authority.as_str());
-    let handle = format!("{username}.{handle_host}");
-    let atproto = atproto_signing.as_ref().map(|sk| AtprotoIdentity {
-        p256_vk: sk.verifying_key(),
-        handle: handle.as_str(),
-    });
+    let handle = account_handle(&username, &state.issuer_url);
+    let atproto = atproto_signing.as_ref().zip(handle.as_deref())
+        .map(|(sk, handle)| AtprotoIdentity { p256_vk: sk.verifying_key(), handle });
 
     let doc = build_did_document(&did, &state.issuer_url, &keys, atproto.as_ref(), &[], None, None);
     (
@@ -741,6 +762,21 @@ mod tests {
     #[test]
     fn issuer_authority_rejects_no_scheme() {
         assert_eq!(issuer_authority("example.com"), None);
+    }
+
+    #[test]
+    fn ipv6_issuer_does_not_synthesize_atproto_handle() {
+        assert_eq!(configured_handle_host("https://[::1]:6791"), None);
+        assert_eq!(account_handle("alice", "https://[::1]:6791"), None);
+    }
+
+    #[test]
+    fn invalid_username_label_does_not_synthesize_atproto_handle() {
+        assert_eq!(account_handle("alice_bad", "https://pds.example.com"), None);
+        assert_eq!(
+            account_handle("Alice", "https://PDS.Example.COM").as_deref(),
+            Some("alice.pds.example.com")
+        );
     }
 
     #[test]

--- a/crates/hyprstream/src/services/oauth/introspection.rs
+++ b/crates/hyprstream/src/services/oauth/introspection.rs
@@ -3,7 +3,8 @@
 //! `POST /oauth/introspect` — validates a token and returns its metadata.
 //! Caller must authenticate with a Bearer token.
 //!
-//! - JWT access tokens: verified against the server's Ed25519 key.
+//! - JWT access tokens: routed by algorithm and verified against the server's
+//!   exact published composite pair or Ed25519 key.
 //! - Opaque refresh tokens: looked up from RocksDB with lazy expiry.
 //! - Any failure → `{"active": false}` per RFC 7662 § 2.2.
 
@@ -33,19 +34,14 @@ pub async fn introspect_token(
 ) -> Response {
     // JWT tokens contain dots; opaque tokens do not.
     if params.token.contains('.') {
-        introspect_jwt(&state, &params.token)
+        introspect_jwt(&state, &params.token).await
     } else {
         introspect_refresh(&state, &params.token).await
     }
 }
 
-fn introspect_jwt(state: &Arc<OAuthState>, token: &str) -> Response {
-    let vk = match ed25519_dalek::VerifyingKey::from_bytes(&state.verifying_key_bytes) {
-        Ok(k) => k,
-        Err(_) => return inactive_response(),
-    };
-
-    let claims = match hyprstream_rpc::auth::jwt::decode(token, &vk, None) {
+async fn introspect_jwt(state: &Arc<OAuthState>, token: &str) -> Response {
+    let claims = match super::auth::validate_oauth_access_token(state, token).await {
         Ok(c) => c,
         Err(_) => return inactive_response(),
     };
@@ -66,6 +62,7 @@ fn introspect_jwt(state: &Arc<OAuthState>, token: &str) -> Response {
             "exp": claims.exp,
             "iat": claims.iat,
             "aud": claims.aud,
+            "scope": claims.scope,
         })),
     )
         .into_response()

--- a/crates/hyprstream/src/services/oauth/introspection.rs
+++ b/crates/hyprstream/src/services/oauth/introspection.rs
@@ -74,14 +74,14 @@ fn introspect_jwt(state: &Arc<OAuthState>, token: &str) -> Response {
 async fn introspect_refresh(state: &Arc<OAuthState>, token: &str) -> Response {
     match state.get_refresh_token(token).await {
         Ok(Some(entry)) => {
-            // #1113: report the account DID as `sub` for atproto conformance,
-            // matching the access-token subject. The refresh-token entry is
-            // keyed on the internal username; fall back to it if DID
-            // derivation fails (introspection is informational — the token
-            // path itself fails closed at mint time).
-            let sub = state
-                .subject_did(&entry.username)
-                .unwrap_or_else(|_| entry.username.clone());
+            // Match the mint boundary: generic tokens retain the username,
+            // while active atproto-profile tokens report the mapped DID.
+            let sub = if super::state::atproto_profile_active(&entry.scopes) {
+                state.check_atproto_account_eligibility(&entry.username).await
+                    .unwrap_or_else(|_| entry.username.clone())
+            } else {
+                entry.username.clone()
+            };
             (
                 StatusCode::OK,
                 [(header::CACHE_CONTROL, "no-store"), (header::PRAGMA, "no-cache")],

--- a/crates/hyprstream/src/services/oauth/introspection.rs
+++ b/crates/hyprstream/src/services/oauth/introspection.rs
@@ -73,19 +73,29 @@ fn introspect_jwt(state: &Arc<OAuthState>, token: &str) -> Response {
 
 async fn introspect_refresh(state: &Arc<OAuthState>, token: &str) -> Response {
     match state.get_refresh_token(token).await {
-        Ok(Some(entry)) => (
-            StatusCode::OK,
-            [(header::CACHE_CONTROL, "no-store"), (header::PRAGMA, "no-cache")],
-            Json(serde_json::json!({
-                "active": true,
-                "token_type": "refresh_token",
-                "sub": entry.username,
-                "client_id": entry.client_id,
-                "scope": entry.scopes.join(" "),
-                "exp": entry.expires_at_unix,
-            })),
-        )
-            .into_response(),
+        Ok(Some(entry)) => {
+            // #1113: report the account DID as `sub` for atproto conformance,
+            // matching the access-token subject. The refresh-token entry is
+            // keyed on the internal username; fall back to it if DID
+            // derivation fails (introspection is informational — the token
+            // path itself fails closed at mint time).
+            let sub = state
+                .subject_did(&entry.username)
+                .unwrap_or_else(|_| entry.username.clone());
+            (
+                StatusCode::OK,
+                [(header::CACHE_CONTROL, "no-store"), (header::PRAGMA, "no-cache")],
+                Json(serde_json::json!({
+                    "active": true,
+                    "token_type": "refresh_token",
+                    "sub": sub,
+                    "client_id": entry.client_id,
+                    "scope": entry.scopes.join(" "),
+                    "exp": entry.expires_at_unix,
+                })),
+            )
+                .into_response()
+        }
         _ => inactive_response(),
     }
 }

--- a/crates/hyprstream/src/services/oauth/jwt_bearer.rs
+++ b/crates/hyprstream/src/services/oauth/jwt_bearer.rs
@@ -109,6 +109,7 @@ pub async fn exchange_jwt_bearer(
             subject: Some(sub.clone()),
             user_pub_key: None,
             dpop_jkt: None,
+            issuer: None,
         })
         .await;
 

--- a/crates/hyprstream/src/services/oauth/metadata.rs
+++ b/crates/hyprstream/src/services/oauth/metadata.rs
@@ -28,20 +28,16 @@ fn base_metadata(issuer: &str, scopes: &[String], require_par: bool) -> serde_js
     if !scopes_supported.iter().any(|scope| scope == "pds:attach") {
         scopes_supported.push("pds:attach".to_owned());
     }
-    // #1113 rev2 finding 5: canonicalize the issuer to an exact origin before
-    // emitting it anywhere — a trailing slash or path in external_url would
-    // produce double-slash endpoint URLs and a non-origin issuer the stock
-    // resolver rejects against the discovery origin.
-    let issuer = super::state::canonical_issuer_origin(issuer).unwrap_or_else(|| issuer.to_owned());
+    let endpoint_base = issuer.trim_end_matches('/');
     serde_json::json!({
         "issuer": issuer,
-        "authorization_endpoint": format!("{}/oauth/authorize", issuer),
-        "token_endpoint": format!("{}/oauth/token", issuer),
-        "registration_endpoint": format!("{}/oauth/register", issuer),
-        "device_authorization_endpoint": format!("{}/oauth/device", issuer),
-        "pushed_authorization_request_endpoint": format!("{}/oauth/par", issuer),
+        "authorization_endpoint": format!("{endpoint_base}/oauth/authorize"),
+        "token_endpoint": format!("{endpoint_base}/oauth/token"),
+        "registration_endpoint": format!("{endpoint_base}/oauth/register"),
+        "device_authorization_endpoint": format!("{endpoint_base}/oauth/device"),
+        "pushed_authorization_request_endpoint": format!("{endpoint_base}/oauth/par"),
         "require_pushed_authorization_requests": require_par,
-        "jwks_uri": format!("{}/oauth/jwks", issuer),
+        "jwks_uri": format!("{endpoint_base}/oauth/jwks"),
         "response_types_supported": ["code"],
         "grant_types_supported": ["authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:device_code"],
         "code_challenge_methods_supported": ["S256"],
@@ -58,11 +54,16 @@ fn base_metadata(issuer: &str, scopes: &[String], require_par: bool) -> serde_js
     })
 }
 
+fn atproto_metadata(issuer: &str, scopes: &[String], require_par: bool) -> serde_json::Value {
+    let issuer = super::state::canonical_issuer_origin(issuer).unwrap_or_else(|| issuer.to_owned());
+    base_metadata(&issuer, scopes, require_par)
+}
+
 /// GET /.well-known/oauth-authorization-server (RFC 8414)
 pub async fn authorization_server_metadata(
     State(state): State<Arc<OAuthState>>,
 ) -> impl IntoResponse {
-    Json(base_metadata(
+    Json(atproto_metadata(
         &state.issuer_url,
         &state.default_scopes,
         state.require_pushed_authorization_requests,
@@ -83,7 +84,7 @@ pub async fn openid_configuration(
     // OIDC-specific fields
     let obj = meta.as_object_mut().unwrap_or_else(|| unreachable!());
     obj.insert("userinfo_endpoint".into(),
-        serde_json::Value::String(format!("{}/oauth/userinfo", issuer)));
+        serde_json::Value::String(format!("{}/oauth/userinfo", issuer.trim_end_matches('/'))));
     obj.insert("id_token_signing_alg_values_supported".into(),
         serde_json::json!(["EdDSA", "RS256"]));
     obj.insert("subject_types_supported".into(),
@@ -145,7 +146,7 @@ mod tests {
     /// origin issuer (no trailing slash/path).
     #[test]
     fn authorization_server_metadata_has_atproto_profile_fields() {
-        let meta = base_metadata("https://pds.example.com/", &["atproto".to_owned()], true);
+        let meta = atproto_metadata("https://pds.example.com/", &["atproto".to_owned()], true);
 
         // Issuer canonicalized to exact origin (trailing slash stripped).
         assert_eq!(meta["issuer"].as_str(), Some("https://pds.example.com"));
@@ -187,5 +188,17 @@ mod tests {
             meta["authorization_response_iss_parameter_supported"].as_bool(),
             Some(true)
         );
+    }
+
+    #[test]
+    fn issuer_paths_are_profile_specific() {
+        let configured = "https://as.example/tenant";
+        let generic = base_metadata(configured, &["read:*:*".to_owned()], false);
+        assert_eq!(generic["issuer"], configured);
+        assert_eq!(generic["token_endpoint"], "https://as.example/tenant/oauth/token");
+
+        let atproto = atproto_metadata(configured, &["atproto".to_owned()], true);
+        assert_eq!(atproto["issuer"], "https://as.example");
+        assert_eq!(atproto["token_endpoint"], "https://as.example/oauth/token");
     }
 }

--- a/crates/hyprstream/src/services/oauth/metadata.rs
+++ b/crates/hyprstream/src/services/oauth/metadata.rs
@@ -15,6 +15,11 @@ fn base_metadata(issuer: &str, scopes: &[String], require_par: bool) -> serde_js
     if !scopes_supported.iter().any(|scope| scope == "pds:attach") {
         scopes_supported.push("pds:attach".to_owned());
     }
+    // #1113 rev2 finding 5: canonicalize the issuer to an exact origin before
+    // emitting it anywhere — a trailing slash or path in external_url would
+    // produce double-slash endpoint URLs and a non-origin issuer the stock
+    // resolver rejects against the discovery origin.
+    let issuer = super::state::canonical_issuer_origin(issuer).unwrap_or_else(|| issuer.to_owned());
     serde_json::json!({
         "issuer": issuer,
         "authorization_endpoint": format!("{}/oauth/authorize", issuer),
@@ -27,7 +32,14 @@ fn base_metadata(issuer: &str, scopes: &[String], require_par: bool) -> serde_js
         "response_types_supported": ["code"],
         "grant_types_supported": ["authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:device_code"],
         "code_challenge_methods_supported": ["S256"],
-        "token_endpoint_auth_methods_supported": ["none"],
+        // #1113 rev2 finding 5: atproto profile metadata. The AS accepts both
+        // public clients (PKCE) and `private_key_jwt` (RFC 7523), signs token
+        // endpoint assertions with ES256, signals DPoP-ES256 support, and
+        // emits `authorization_endpoint` `iss` query parameter on redirects.
+        "token_endpoint_auth_methods_supported": ["none", "private_key_jwt"],
+        "token_endpoint_auth_signing_alg_values_supported": ["ES256"],
+        "dpop_signing_alg_values_supported": ["ES256"],
+        "authorization_response_iss_parameter_supported": true,
         "scopes_supported": scopes_supported,
         "client_id_metadata_document_supported": true,
     })
@@ -111,6 +123,56 @@ mod tests {
         assert_eq!(
             meta["pushed_authorization_request_endpoint"].as_str(),
             Some("https://pds.example.com/oauth/par")
+        );
+    }
+
+    /// #1113 rev2 finding 5: the RFC 8414 document carries the full atproto
+    /// profile metadata surface — private_key_jwt client auth, ES256 token
+    /// signing alg, DPoP ES256, iss-parameter support, and a canonical
+    /// origin issuer (no trailing slash/path).
+    #[test]
+    fn authorization_server_metadata_has_atproto_profile_fields() {
+        let meta = base_metadata("https://pds.example.com/", &["atproto".to_owned()], true);
+
+        // Issuer canonicalized to exact origin (trailing slash stripped).
+        assert_eq!(meta["issuer"].as_str(), Some("https://pds.example.com"));
+        assert_eq!(
+            meta["token_endpoint"].as_str(),
+            Some("https://pds.example.com/oauth/token"),
+            "no double-slash from a trailing-slash issuer"
+        );
+
+        let auth_methods: Vec<&str> = meta["token_endpoint_auth_methods_supported"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert!(auth_methods.contains(&"none"), "public clients (PKCE) must be accepted");
+        assert!(
+            auth_methods.contains(&"private_key_jwt"),
+            "private_key_jwt must be advertised"
+        );
+
+        let token_algs: Vec<&str> = meta["token_endpoint_auth_signing_alg_values_supported"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert!(token_algs.contains(&"ES256"));
+
+        let dpop_algs: Vec<&str> = meta["dpop_signing_alg_values_supported"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert!(dpop_algs.contains(&"ES256"));
+
+        assert_eq!(
+            meta["authorization_response_iss_parameter_supported"].as_bool(),
+            Some(true)
         );
     }
 }

--- a/crates/hyprstream/src/services/oauth/metadata.rs
+++ b/crates/hyprstream/src/services/oauth/metadata.rs
@@ -24,7 +24,7 @@ fn advertised_scopes(default_scopes: &[String]) -> Vec<String> {
 
 /// Base metadata fields shared between RFC 8414 and OIDC discovery.
 fn base_metadata(issuer: &str, scopes: &[String], require_par: bool) -> serde_json::Value {
-    let mut scopes_supported = scopes.to_vec();
+    let mut scopes_supported = advertised_scopes(scopes);
     if !scopes_supported.iter().any(|scope| scope == "pds:attach") {
         scopes_supported.push("pds:attach".to_owned());
     }
@@ -33,7 +33,6 @@ fn base_metadata(issuer: &str, scopes: &[String], require_par: bool) -> serde_js
     // produce double-slash endpoint URLs and a non-origin issuer the stock
     // resolver rejects against the discovery origin.
     let issuer = super::state::canonical_issuer_origin(issuer).unwrap_or_else(|| issuer.to_owned());
-    let scopes = advertised_scopes(scopes);
     serde_json::json!({
         "issuer": issuer,
         "authorization_endpoint": format!("{}/oauth/authorize", issuer),

--- a/crates/hyprstream/src/services/oauth/metadata.rs
+++ b/crates/hyprstream/src/services/oauth/metadata.rs
@@ -9,6 +9,19 @@ use axum::{extract::State, response::IntoResponse, Json};
 
 use super::state::OAuthState;
 
+/// The full set of scopes the AS advertises in `scopes_supported` (#1113 rev2 F4).
+/// Extends the operator's default grant set with the atproto transition scopes,
+/// which are supported-but-explicit (NOT silently granted on omitted scope).
+fn advertised_scopes(default_scopes: &[String]) -> Vec<String> {
+    let mut scopes = default_scopes.to_vec();
+    for atproto_scope in &["atproto", "transition:generic"] {
+        if !scopes.iter().any(|s| s == *atproto_scope) {
+            scopes.push((*atproto_scope).to_owned());
+        }
+    }
+    scopes
+}
+
 /// Base metadata fields shared between RFC 8414 and OIDC discovery.
 fn base_metadata(issuer: &str, scopes: &[String], require_par: bool) -> serde_json::Value {
     let mut scopes_supported = scopes.to_vec();
@@ -20,6 +33,7 @@ fn base_metadata(issuer: &str, scopes: &[String], require_par: bool) -> serde_js
     // produce double-slash endpoint URLs and a non-origin issuer the stock
     // resolver rejects against the discovery origin.
     let issuer = super::state::canonical_issuer_origin(issuer).unwrap_or_else(|| issuer.to_owned());
+    let scopes = advertised_scopes(scopes);
     serde_json::json!({
         "issuer": issuer,
         "authorization_endpoint": format!("{}/oauth/authorize", issuer),

--- a/crates/hyprstream/src/services/oauth/metadata.rs
+++ b/crates/hyprstream/src/services/oauth/metadata.rs
@@ -71,3 +71,46 @@ pub async fn openid_configuration(
 
     Json(meta)
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    /// #1113: the atproto OAuth AS conformance scopes (`atproto`,
+    /// `transition:generic`) are advertised in `scopes_supported` so stock
+    /// atproto clients (e.g. `@atproto/oauth-client-browser`) discover them.
+    #[test]
+    fn authorization_server_metadata_advertises_atproto_scopes() {
+        let scopes = vec![
+            "read:*:*".to_owned(),
+            "write:*:*".to_owned(),
+            "atproto".to_owned(),
+            "transition:generic".to_owned(),
+        ];
+        let meta = base_metadata("https://pds.example.com", &scopes, true);
+        let advertised: Vec<&str> = meta["scopes_supported"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert!(advertised.contains(&"atproto"), "scopes_supported missing atproto: {advertised:?}");
+        assert!(
+            advertised.contains(&"transition:generic"),
+            "scopes_supported missing transition:generic: {advertised:?}"
+        );
+    }
+
+    /// #1113: PAR is mandatory for the atproto AS profile, and the AS metadata
+    /// must reflect `require_pushed_authorization_requests: true`.
+    #[test]
+    fn authorization_server_metadata_requires_par_when_configured() {
+        let meta = base_metadata("https://pds.example.com", &[], true);
+        assert_eq!(meta["require_pushed_authorization_requests"].as_bool(), Some(true));
+        assert_eq!(
+            meta["pushed_authorization_request_endpoint"].as_str(),
+            Some("https://pds.example.com/oauth/par")
+        );
+    }
+}

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -264,12 +264,14 @@ async fn handle_logout(
 /// browsers can bootstrap a WebTransport connection via DiscoveryService,
 /// then resolve all other service endpoints from there.
 async fn oauth_self_protected_resource_metadata(
-    State(_state): State<Arc<OAuthState>>,
+    State(state): State<Arc<OAuthState>>,
 ) -> axum::Json<ProtectedResourceMetadata> {
-    let config = crate::config::HyprConfig::load().unwrap_or_default();
-    let issuer_url = config.oauth.issuer_url();
+    // #1113 r4 F5: use the CANONICAL issuer from OAuthState (same
+    // normalization as token claims/redirect), NOT raw config.issuer_url().
+    // A configured trailing-slash/path must be consistent everywhere.
+    let issuer_url = state.issuer_url.clone();
 
-    // Use issuer URL as the resource
+    // Use issuer URL as the resource (PDS = its own AS).
     let resource = issuer_url.clone();
 
     let mut meta = protected_resource_metadata(&resource, &issuer_url);
@@ -277,6 +279,7 @@ async fn oauth_self_protected_resource_metadata(
     meta.scopes_supported = Some(self_resource_scopes());
 
     // Include the QUIC TLS cert hash so browsers can pin the self-signed certificate.
+    let config = crate::config::HyprConfig::load().unwrap_or_default();
     if let Ok((cert_chain, _)) = config.quic.load_tls_materials() {
         meta.x_cert_hash = Some(hyprstream_rpc::transport::zmtp_quic::cert_hash(
             &cert_chain[0],

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -32,9 +32,10 @@ pub mod challenge;
 pub mod cimd_cache;
 pub mod client_auth;
 pub mod device;
+pub mod device_enrollment;
 pub mod did_document;
-pub mod federation_entity;
 pub mod dpop;
+pub mod federation_entity;
 pub mod introspection;
 pub mod jwks;
 pub mod jwt_bearer;
@@ -47,6 +48,7 @@ pub mod oidc_discovery;
 pub mod par;
 pub mod registration;
 pub mod revocation;
+pub mod rpc_handler;
 pub mod scim;
 pub mod scim_types;
 pub mod session;
@@ -56,11 +58,9 @@ pub mod token;
 pub mod token_exchange;
 pub mod token_store;
 pub mod user_mapping;
-pub mod wit_bootstrap;
 pub mod user_service;
 pub mod userinfo;
-pub mod device_enrollment;
-pub mod rpc_handler;
+pub mod wit_bootstrap;
 pub mod xrpc;
 
 use std::sync::Arc;
@@ -127,8 +127,14 @@ pub fn create_app(state: Arc<OAuthState>, cors_config: &crate::config::CorsConfi
             get(device::verify_get).post(device::verify_post),
         )
         .route("/oauth/device/nonce", get(device::device_nonce))
-        .route("/api/device/challenge", post(device_enrollment::device_challenge_handler))
-        .route("/api/device/enroll", post(device_enrollment::device_enroll_handler))
+        .route(
+            "/api/device/challenge",
+            post(device_enrollment::device_challenge_handler),
+        )
+        .route(
+            "/api/device/enroll",
+            post(device_enrollment::device_enroll_handler),
+        )
         .route("/oauth/revoke", post(revocation::revoke_token))
         .route("/oauth/logout", post(handle_logout))
         .route(
@@ -209,11 +215,20 @@ pub fn create_app(state: Arc<OAuthState>, cors_config: &crate::config::CorsConfi
     // endpoints like /oauth/token (closes #472).
     let mut did_router = Router::new()
         // Phase 0c — did:web document endpoints
-        .route("/.well-known/did.json", get(did_document::root_did_document))
+        .route(
+            "/.well-known/did.json",
+            get(did_document::root_did_document),
+        )
         // atproto handle→DID HTTP resolution (#500) — plaintext bare DID
         .route("/.well-known/atproto-did", get(did_document::atproto_did))
-        .route("/users/:username/did.json", get(did_document::user_did_document))
-        .route("/clients/:client_id/did.json", get(did_document::client_did_document));
+        .route(
+            "/users/:username/did.json",
+            get(did_document::user_did_document),
+        )
+        .route(
+            "/clients/:client_id/did.json",
+            get(did_document::client_did_document),
+        );
 
     let mut api_router = public_router.merge(protected_router);
 
@@ -227,14 +242,16 @@ pub fn create_app(state: Arc<OAuthState>, cors_config: &crate::config::CorsConfi
         ));
     }
 
-    let router = api_router.merge(did_router).layer(axum::middleware::from_fn(
-        |req: axum::extract::Request, next: axum::middleware::Next| async move {
-            let method = req.method().clone();
-            let uri = req.uri().clone();
-            tracing::info!(%method, %uri, "OAuth request");
-            next.run(req).await
-        },
-    ));
+    let router = api_router
+        .merge(did_router)
+        .layer(axum::middleware::from_fn(
+            |req: axum::extract::Request, next: axum::middleware::Next| async move {
+                let method = req.method().clone();
+                let uri = req.uri().clone();
+                tracing::info!(%method, %uri, "OAuth request");
+                next.run(req).await
+            },
+        ));
 
     router.with_state(state)
 }
@@ -382,7 +399,10 @@ impl OAuthService {
     }
 
     /// Attach the shared JTI blocklist (same Arc as PolicyService).
-    pub fn with_jti_blocklist(mut self, bl: Arc<hyprstream_rpc::auth::InMemoryJtiBlocklist>) -> Self {
+    pub fn with_jti_blocklist(
+        mut self,
+        bl: Arc<hyprstream_rpc::auth::InMemoryJtiBlocklist>,
+    ) -> Self {
         self.jti_blocklist = Some(bl);
         self
     }
@@ -964,17 +984,617 @@ pub fn protected_resource_metadata(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::get_unwrap)]
 mod tests {
     use super::registration::validate_redirect_uri;
     use super::*;
 
+    fn encode_form(fields: &[(&str, &str)]) -> String {
+        let mut serializer = url::form_urlencoded::Serializer::new(String::new());
+        serializer.extend_pairs(fields.iter().copied());
+        serializer.finish()
+    }
+
+    async fn post_form(
+        app: &Router,
+        uri: &str,
+        fields: &[(&str, &str)],
+        dpop: Option<&str>,
+        accept_json: bool,
+    ) -> axum::response::Response {
+        use tower::ServiceExt as _;
+
+        let mut builder = axum::http::Request::post(uri).header(
+            axum::http::header::CONTENT_TYPE,
+            "application/x-www-form-urlencoded",
+        );
+        if let Some(proof) = dpop {
+            builder = builder.header("DPoP", proof);
+        }
+        if accept_json {
+            builder = builder.header(axum::http::header::ACCEPT, "application/json");
+        }
+        app.clone()
+            .oneshot(
+                builder
+                    .body(axum::body::Body::from(encode_form(fields)))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    async fn get(app: &Router, uri: &str) -> axum::response::Response {
+        use tower::ServiceExt as _;
+
+        app.clone()
+            .oneshot(
+                axum::http::Request::get(uri)
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    async fn response_json(response: axum::response::Response) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    async fn response_text(response: axum::response::Response) -> String {
+        let bytes = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        String::from_utf8(bytes.to_vec()).unwrap()
+    }
+
+    fn html_hidden_value<'a>(html: &'a str, name: &str) -> &'a str {
+        let prefix = format!(r#"name="{name}" value=""#);
+        let rest = html.split_once(&prefix).unwrap().1;
+        rest.split_once('"').unwrap().0
+    }
+
+    fn dpop_proof(
+        signing_key: &p256::ecdsa::SigningKey,
+        htu: &str,
+        jti: &str,
+        nonce: Option<&str>,
+    ) -> String {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+        use p256::ecdsa::signature::Signer as _;
+
+        let point = signing_key.verifying_key().to_encoded_point(false);
+        let header = serde_json::json!({
+            "typ": "dpop+jwt",
+            "alg": "ES256",
+            "jwk": {
+                "kty": "EC",
+                "crv": "P-256",
+                "x": URL_SAFE_NO_PAD.encode(point.x().unwrap()),
+                "y": URL_SAFE_NO_PAD.encode(point.y().unwrap()),
+            }
+        });
+        let mut payload = serde_json::json!({
+            "jti": jti,
+            "htm": "POST",
+            "htu": htu,
+            "iat": chrono::Utc::now().timestamp(),
+        });
+        if let Some(value) = nonce {
+            payload["nonce"] = serde_json::Value::String(value.to_owned());
+        }
+        let header = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&header).unwrap());
+        let payload = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&payload).unwrap());
+        let signing_input = format!("{header}.{payload}");
+        let signature: p256::ecdsa::Signature = signing_key.sign(signing_input.as_bytes());
+        format!(
+            "{signing_input}.{}",
+            URL_SAFE_NO_PAD.encode(signature.to_bytes())
+        )
+    }
+
+    fn jwt_claims(token: &str) -> serde_json::Value {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+
+        let payload = token.split('.').nth(1).expect("JWT payload");
+        serde_json::from_slice(&URL_SAFE_NO_PAD.decode(payload).expect("JWT payload base64"))
+            .expect("JWT payload JSON")
+    }
+
+    // Rust mirror of @atproto/oauth-types 0.7.5
+    // atprotoOAuthTokenResponseSchema. The upstream schema extends the base
+    // OAuth response with literal DPoP, required atproto DID sub, required
+    // atproto-containing scope, and an absent id_token.
+    #[derive(serde::Deserialize)]
+    struct AtprotoOAuthTokenResponse075 {
+        access_token: String,
+        token_type: String,
+        scope: String,
+        refresh_token: Option<String>,
+        expires_in: Option<f64>,
+        sub: String,
+    }
+
+    fn parse_atproto_token_response_075(
+        value: serde_json::Value,
+    ) -> anyhow::Result<AtprotoOAuthTokenResponse075> {
+        anyhow::ensure!(
+            value.get("id_token").is_none(),
+            "atproto OAuth token response must not contain id_token"
+        );
+        let parsed: AtprotoOAuthTokenResponse075 = serde_json::from_value(value)?;
+        anyhow::ensure!(parsed.token_type == "DPoP", "token_type must be DPoP");
+        anyhow::ensure!(
+            parsed.scope.bytes().all(|byte| {
+                byte == b' '
+                    || byte == b'!'
+                    || (b'#'..=b'[').contains(&byte)
+                    || (b']'..=b'~').contains(&byte)
+            }),
+            "scope is not an OAuth scope value"
+        );
+        anyhow::ensure!(
+            parsed.scope.split(' ').any(|scope| scope == "atproto"),
+            "scope must contain atproto"
+        );
+        super::state::subject_did_for("https://schema.invalid", &parsed.sub)?;
+        Ok(parsed)
+    }
+
+    // Publish a disk-backed composite Policy signing pair so this test uses
+    // the real PolicyService JWT issuance path. The tiny authority directory
+    // remains because the process-global mint barrier checks disk each time.
+    fn configure_test_policy_signing_authority() -> anyhow::Result<()> {
+        use hyprstream_rpc::auth::{CompositeKeyPair, CompositePairRole, CompositePairState};
+
+        let authority_dir = tempfile::TempDir::new()?.keep();
+        let ledger = authority_dir.join("ledger.json");
+        let committed = authority_dir.join("committed");
+        let prefix = authority_dir.join("committed-ledger");
+        let lock = authority_dir.join("ledger.lock");
+        let key_set = hyprstream_rpc::auth::global_composite_key_set();
+        let version = key_set.snapshot().version() + 1;
+        let digest = format!("oauth-handler-r5-{version}");
+        let generation = serde_json::to_vec(&serde_json::json!({
+            "version": version,
+            "component_digest": digest,
+        }))?;
+        std::fs::write(&ledger, &generation)?;
+        std::fs::write(&committed, &generation)?;
+        std::fs::write(
+            authority_dir.join(format!("committed-ledger-{version}-{digest}.json")),
+            &generation,
+        )?;
+
+        let (ml_signing, ml_verifying) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();
+        let ed_signing = Arc::new(ed25519_dalek::SigningKey::from_bytes(&[0x61; 32]));
+        let kid = hyprstream_rpc::auth::composite_kid(&ml_verifying, &ed_signing.verifying_key());
+        let now = chrono::Utc::now().timestamp();
+        let pair = CompositeKeyPair::signing(
+            kid,
+            Arc::new(ml_signing),
+            ed_signing,
+            CompositePairRole::Policy,
+            CompositePairState::Active,
+            now - 60,
+            now + 86_400,
+        );
+        key_set.configure_authority(ledger, committed, prefix, lock);
+        key_set.publish(version, digest, vec![pair])?;
+        Ok(())
+    }
+
+    /// #1113 r5 handler-level conformance suite. Every HTTP exchange goes
+    /// through the production create_app router and token issuance traverses
+    /// a real in-process PolicyService.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn oauth_handler_atproto_and_legacy_conformance() -> anyhow::Result<()> {
+        use base64::{
+            engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
+            Engine as _,
+        };
+        use ed25519_dalek::Signer as _;
+        use hyprstream_rpc::crypto::CryptoPolicy;
+        use hyprstream_rpc::rpc_client::RpcClientImpl;
+        use hyprstream_rpc::signer::LocalSigner;
+        use hyprstream_rpc::transport::lazy_uds::LazyUdsTransport;
+        use hyprstream_rpc::transport::TransportConfig;
+        use hyprstream_service::{InprocManager, ServiceManager as _};
+        use sha2::{Digest as _, Sha256};
+
+        use super::state::RegisteredClient;
+        use super::token_store::RocksDbTokenStore;
+        use crate::auth::rocksdb_store::RocksDbUserStore;
+        use crate::auth::{PolicyManager, UserProfile, UserStore};
+        use crate::services::{DiscoveryClient, PolicyClient, PolicyService};
+
+        const ISSUER: &str = "https://pds.example.test";
+        const CLIENT_ID: &str = "handler-client";
+        const REDIRECT_URI: &str = "https://client.example.test/callback";
+        const MAPPED_DID: &str = "did:plc:abcdefghijklmnqrstuvwx2p";
+        const PKCE_VERIFIER: &str = "r5-handler-pkce-verifier-abcdefghijklmnopqrstuvwxyz012345";
+
+        let _ = hyprstream_rpc::envelope::install_verify_config(
+            hyprstream_rpc::envelope::EnvelopeVerifyConfig {
+                policy: CryptoPolicy::Classical,
+                pq_store: None,
+            },
+        );
+        let _ = hyprstream_rpc::envelope::install_response_verify_config(
+            hyprstream_rpc::envelope::ResponseVerifyConfig {
+                policy: CryptoPolicy::Classical,
+                pq_store: None,
+            },
+        );
+        configure_test_policy_signing_authority()?;
+
+        let service_key = ed25519_dalek::SigningKey::from_bytes(&[0x62; 32]);
+        let policy_tag = format!("oauth-handler-r5-{}", uuid::Uuid::new_v4());
+        let git_dir = tempfile::TempDir::new()?;
+        let git2db = Arc::new(tokio::sync::RwLock::new(
+            git2db::Git2DB::open(git_dir.path()).await?,
+        ));
+        let policy_service = PolicyService::new(
+            Arc::new(PolicyManager::permissive().await?),
+            Arc::new(service_key.clone()),
+            crate::config::TokenConfig::default(),
+            git2db,
+            TransportConfig::inproc(&policy_tag),
+        )
+        .with_default_audience(ISSUER.to_owned());
+        let manager = InprocManager::new();
+        let mut policy_handle = manager.spawn(Box::new(policy_service)).await?;
+        let policy_client = PolicyClient::for_local_endpoint_bootstrap(
+            &format!("inproc://{policy_tag}"),
+            service_key.clone(),
+            service_key.verifying_key(),
+            None,
+        )?;
+
+        let user_dir = tempfile::TempDir::new()?;
+        let user_store = Arc::new(RocksDbUserStore::open(user_dir.path())?);
+        let user_key = ed25519_dalek::SigningKey::from_bytes(&[0x63; 32]);
+        user_store.register("alice").await?;
+        let fingerprint = user_store
+            .add_pubkey(
+                "alice",
+                user_key.verifying_key(),
+                Some("handler-test".to_owned()),
+            )
+            .await?;
+        user_store
+            .set_profile(
+                "alice",
+                UserProfile {
+                    atproto_did: Some(MAPPED_DID.to_owned()),
+                    ..Default::default()
+                },
+            )
+            .await?;
+        assert_eq!(
+            user_store
+                .get_profile("alice")
+                .await?
+                .and_then(|profile| profile.atproto_did),
+            Some(MAPPED_DID.to_owned())
+        );
+
+        let dummy_key = ed25519_dalek::SigningKey::from_bytes(&[0x64; 32]);
+        let dummy_remote = ed25519_dalek::SigningKey::from_bytes(&[0x65; 32]).verifying_key();
+        let dummy_rpc = Arc::new(
+            RpcClientImpl::new(
+                LocalSigner::new(dummy_key),
+                LazyUdsTransport::new("/dev/null/oauth-handler-discovery.sock".into()),
+                Some(dummy_remote),
+            )
+            .with_response_verify_policy(CryptoPolicy::Classical),
+        );
+        let mut config = crate::config::OAuthConfig::default();
+        // A configured path and trailing slash must normalize everywhere.
+        config.external_url = Some(format!("{ISSUER}/configured/path/"));
+        let mut oauth_state = OAuthState::new(
+            &config,
+            policy_client,
+            DiscoveryClient::new(dummy_rpc),
+            service_key.verifying_key().to_bytes(),
+        )
+        .with_user_store(user_store);
+        let token_dir = tempfile::TempDir::new()?;
+        oauth_state.with_token_store_impl(Arc::new(RocksDbTokenStore::open(
+            token_dir.path().join("refresh.db"),
+        )?));
+        let state = Arc::new(oauth_state);
+        state.clients.write().await.insert(
+            CLIENT_ID.to_owned(),
+            RegisteredClient {
+                client_id: CLIENT_ID.to_owned(),
+                redirect_uris: vec![REDIRECT_URI.to_owned()],
+                client_name: Some("Handler Conformance Client".to_owned()),
+                client_uri: None,
+                logo_uri: None,
+                grant_types: vec![
+                    "authorization_code".to_owned(),
+                    "refresh_token".to_owned(),
+                    "urn:ietf:params:oauth:grant-type:device_code".to_owned(),
+                ],
+                response_types: vec!["code".to_owned()],
+                token_endpoint_auth_method: Some("none".to_owned()),
+                jwks: None,
+                jwks_uri: None,
+                hyprstream_node_did: None,
+                scope: Some("atproto read:*:*".to_owned()),
+                is_cimd: false,
+                registered_at: std::time::Instant::now(),
+            },
+        );
+        let cors = crate::config::server::CorsConfig {
+            enabled: false,
+            ..Default::default()
+        };
+        let app = create_app(Arc::clone(&state), &cors);
+
+        // Device authorization rejects unknown clients at the real endpoint.
+        let unknown_device = post_form(
+            &app,
+            "/oauth/device",
+            &[("client_id", "unknown-client"), ("scope", "read:*:*")],
+            None,
+            false,
+        )
+        .await;
+        assert_eq!(unknown_device.status(), axum::http::StatusCode::BAD_REQUEST);
+        assert_eq!(
+            response_json(unknown_device).await["error"],
+            "invalid_client"
+        );
+
+        // PAR binds the atproto request to a real ES256 DPoP key.
+        let dpop_key = p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
+        let code_challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(PKCE_VERIFIER.as_bytes()));
+        let par_proof = dpop_proof(
+            &dpop_key,
+            &format!("{ISSUER}/oauth/par"),
+            "handler-par-jti",
+            None,
+        );
+        let par = post_form(
+            &app,
+            "/oauth/par",
+            &[
+                ("client_id", CLIENT_ID),
+                ("redirect_uri", REDIRECT_URI),
+                ("code_challenge", &code_challenge),
+                ("code_challenge_method", "S256"),
+                ("response_type", "code"),
+                ("state", "client-state"),
+                ("scope", "atproto"),
+                ("resource", ISSUER),
+            ],
+            Some(&par_proof),
+            false,
+        )
+        .await;
+        assert_eq!(par.status(), axum::http::StatusCode::CREATED);
+        let par_nonce = par
+            .headers()
+            .get("DPoP-Nonce")
+            .and_then(|value| value.to_str().ok())
+            .unwrap()
+            .to_owned();
+        let par_json = response_json(par).await;
+        let request_uri = par_json["request_uri"].as_str().unwrap();
+
+        // GET authorize consumes the PAR and renders the real consent callback.
+        let authorize_uri = format!(
+            "/oauth/authorize?{}",
+            encode_form(&[("request_uri", request_uri), ("client_id", CLIENT_ID)])
+        );
+        let authorize = get(&app, &authorize_uri).await;
+        assert_eq!(authorize.status(), axum::http::StatusCode::OK);
+        let authorize_html = response_text(authorize).await;
+        let authorize_nonce = html_hidden_value(&authorize_html, "nonce").to_owned();
+        let challenge = format!("{fingerprint}:{authorize_nonce}:{code_challenge}");
+        let signature = STANDARD.encode(user_key.sign(challenge.as_bytes()).to_bytes());
+        let callback = post_form(
+            &app,
+            "/oauth/authorize",
+            &[
+                ("client_id", CLIENT_ID),
+                ("redirect_uri", REDIRECT_URI),
+                ("code_challenge", &code_challenge),
+                ("scope", "atproto"),
+                ("state", "client-state"),
+                ("resource", ISSUER),
+                ("nonce", &authorize_nonce),
+                ("fingerprint", &fingerprint),
+                ("signature", &signature),
+            ],
+            None,
+            false,
+        )
+        .await;
+        assert_eq!(callback.status(), axum::http::StatusCode::SEE_OTHER);
+        let location = callback
+            .headers()
+            .get(axum::http::header::LOCATION)
+            .and_then(|value| value.to_str().ok())
+            .unwrap();
+        let location = url::Url::parse(location)?;
+        let callback_params: std::collections::HashMap<_, _> =
+            location.query_pairs().into_owned().collect();
+        assert_eq!(callback_params.get("iss").map(String::as_str), Some(ISSUER));
+        assert_eq!(
+            callback_params.get("state").map(String::as_str),
+            Some("client-state")
+        );
+        let code = callback_params.get("code").unwrap();
+
+        // Exchange the code and parse the emitted response against the exact
+        // @atproto/oauth-types 0.7.5 token-response constraints.
+        let token_proof = dpop_proof(
+            &dpop_key,
+            &format!("{ISSUER}/oauth/token"),
+            "handler-token-jti",
+            Some(&par_nonce),
+        );
+        let token = post_form(
+            &app,
+            "/oauth/token",
+            &[
+                ("grant_type", "authorization_code"),
+                ("client_id", CLIENT_ID),
+                ("code", code),
+                ("redirect_uri", REDIRECT_URI),
+                ("code_verifier", PKCE_VERIFIER),
+            ],
+            Some(&token_proof),
+            false,
+        )
+        .await;
+        assert_eq!(token.status(), axum::http::StatusCode::OK);
+        let token_nonce = token
+            .headers()
+            .get("DPoP-Nonce")
+            .and_then(|value| value.to_str().ok())
+            .unwrap()
+            .to_owned();
+        let token_response = parse_atproto_token_response_075(response_json(token).await)?;
+        assert_eq!(token_response.sub, MAPPED_DID);
+        assert!(token_response.expires_in.is_some());
+        let refresh_token = token_response.refresh_token.unwrap();
+        let claims = jwt_claims(&token_response.access_token);
+        assert_eq!(claims["iss"], ISSUER);
+        assert_eq!(claims["sub"], MAPPED_DID);
+        assert_eq!(claims["aud"], ISSUER);
+
+        // A missing refresh proof is rejected before consumption. Retrying
+        // the same refresh token with the bound key and nonce must succeed.
+        let stranded_attempt = post_form(
+            &app,
+            "/oauth/token",
+            &[
+                ("grant_type", "refresh_token"),
+                ("client_id", CLIENT_ID),
+                ("refresh_token", &refresh_token),
+            ],
+            None,
+            false,
+        )
+        .await;
+        assert_eq!(
+            stranded_attempt.status(),
+            axum::http::StatusCode::BAD_REQUEST
+        );
+        assert_eq!(
+            response_json(stranded_attempt).await["error"],
+            "invalid_dpop_proof"
+        );
+        assert!(state.get_refresh_token(&refresh_token).await?.is_some());
+        let refresh_proof = dpop_proof(
+            &dpop_key,
+            &format!("{ISSUER}/oauth/token"),
+            "handler-refresh-jti",
+            Some(&token_nonce),
+        );
+        let refreshed = post_form(
+            &app,
+            "/oauth/token",
+            &[
+                ("grant_type", "refresh_token"),
+                ("client_id", CLIENT_ID),
+                ("refresh_token", &refresh_token),
+            ],
+            Some(&refresh_proof),
+            false,
+        )
+        .await;
+        assert_eq!(refreshed.status(), axum::http::StatusCode::OK);
+        let refreshed_json = response_json(refreshed).await;
+        assert_eq!(refreshed_json["token_type"], "DPoP");
+        assert_eq!(refreshed_json["sub"], MAPPED_DID);
+        assert_ne!(refreshed_json["refresh_token"], refresh_token);
+        assert!(state.get_refresh_token(&refresh_token).await?.is_none());
+        let refreshed_claims = jwt_claims(refreshed_json["access_token"].as_str().unwrap());
+        assert_eq!(refreshed_claims["sub"], MAPPED_DID);
+
+        // A real generic device flow retains the local username byte-for-byte
+        // and the legacy Bearer response shape.
+        let device = post_form(
+            &app,
+            "/oauth/device",
+            &[
+                ("client_id", CLIENT_ID),
+                ("scope", "read:*:*"),
+                ("resource", ISSUER),
+            ],
+            None,
+            false,
+        )
+        .await;
+        assert_eq!(device.status(), axum::http::StatusCode::OK);
+        let device_json = response_json(device).await;
+        let device_code = device_json["device_code"].as_str().unwrap();
+        let user_code = device_json["user_code"].as_str().unwrap();
+        let nonce_uri = format!(
+            "/oauth/device/nonce?{}",
+            encode_form(&[("user_code", user_code)])
+        );
+        let device_nonce = response_json(get(&app, &nonce_uri).await).await;
+        let normalized_code = user_code.replace('-', "");
+        let device_challenge = format!(
+            "alice:{normalized_code}:{}",
+            device_nonce["nonce"].as_str().unwrap()
+        );
+        let device_signature =
+            STANDARD.encode(user_key.sign(device_challenge.as_bytes()).to_bytes());
+        let approved = post_form(
+            &app,
+            "/oauth/device/verify",
+            &[
+                ("user_code", user_code),
+                ("username", "alice"),
+                ("signature", &device_signature),
+            ],
+            None,
+            true,
+        )
+        .await;
+        assert_eq!(approved.status(), axum::http::StatusCode::OK);
+        let device_token = post_form(
+            &app,
+            "/oauth/token",
+            &[
+                ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+                ("client_id", CLIENT_ID),
+                ("device_code", device_code),
+            ],
+            None,
+            false,
+        )
+        .await;
+        assert_eq!(device_token.status(), axum::http::StatusCode::OK);
+        let device_token_json = response_json(device_token).await;
+        assert_eq!(device_token_json["token_type"], "Bearer");
+        assert!(device_token_json.get("sub").is_none());
+        let device_claims = jwt_claims(device_token_json["access_token"].as_str().unwrap());
+        assert_eq!(device_claims["sub"], "alice");
+        assert_eq!(device_claims["iss"], ISSUER);
+        assert_eq!(device_claims["aud"], ISSUER);
+
+        policy_handle.stop().await?;
+        Ok(())
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn oauth_iroh_refuses_arbitrary_rpc_and_anonymous_moq_before_dispatch(
     ) -> anyhow::Result<()> {
-        use hyprstream_rpc::transport::iroh_substrate::{
-            ALPN_HYPRSTREAM_RPC, ALPN_MOQ_LITE, IrohSubstrate, NoopHandler,
-        };
         use hyprstream_rpc::envelope::{RequestEnvelope, SignedEnvelope};
+        use hyprstream_rpc::transport::iroh_substrate::{
+            IrohSubstrate, NoopHandler, ALPN_HYPRSTREAM_RPC, ALPN_MOQ_LITE,
+        };
         use hyprstream_rpc::ToCapnp as _;
         use iroh::{EndpointAddr, TransportAddr};
         use moq_net::Client;
@@ -1023,11 +1643,9 @@ mod tests {
         if let Ok((mut send, mut recv)) = rpc.open_bi().await {
             let _ = send.write_all(&signed_crud_bytes).await;
             let _ = send.finish();
-            let response = tokio::time::timeout(
-                std::time::Duration::from_secs(2),
-                recv.read_to_end(1024),
-            )
-            .await;
+            let response =
+                tokio::time::timeout(std::time::Duration::from_secs(2), recv.read_to_end(1024))
+                    .await;
             assert!(
                 !matches!(response, Ok(Ok(ref bytes)) if !bytes.is_empty()),
                 "refused OAuth RPC ALPN must not produce a user-CRUD response"
@@ -1070,7 +1688,10 @@ mod tests {
 
         // atproto transition scopes are advertised.
         let scopes = self_resource_scopes();
-        assert!(scopes.contains(&"atproto".to_owned()), "missing atproto: {scopes:?}");
+        assert!(
+            scopes.contains(&"atproto".to_owned()),
+            "missing atproto: {scopes:?}"
+        );
         assert!(
             scopes.contains(&"transition:generic".to_owned()),
             "missing transition:generic: {scopes:?}"

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -286,7 +286,7 @@ async fn oauth_self_protected_resource_metadata(
     // #1113 r4 F5: use the CANONICAL issuer from OAuthState (same
     // normalization as token claims/redirect), NOT raw config.issuer_url().
     // A configured trailing-slash/path must be consistent everywhere.
-    let issuer_url = state.issuer_url.clone();
+    let issuer_url = state.atproto_issuer_url();
 
     // Use issuer URL as the resource (PDS = its own AS).
     let resource = issuer_url.clone();
@@ -1024,6 +1024,26 @@ mod tests {
             .unwrap()
     }
 
+    async fn post_form_bearer(
+        app: &Router,
+        uri: &str,
+        fields: &[(&str, &str)],
+        bearer: &str,
+    ) -> axum::response::Response {
+        use tower::ServiceExt as _;
+
+        app.clone()
+            .oneshot(
+                axum::http::Request::post(uri)
+                    .header(axum::http::header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                    .header(axum::http::header::AUTHORIZATION, format!("Bearer {bearer}"))
+                    .body(axum::body::Body::from(encode_form(fields)))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
     async fn get(app: &Router, uri: &str) -> axum::response::Response {
         use tower::ServiceExt as _;
 
@@ -1212,6 +1232,7 @@ mod tests {
         use crate::services::{DiscoveryClient, PolicyClient, PolicyService};
 
         const ISSUER: &str = "https://pds.example.test";
+        const GENERIC_ISSUER: &str = "https://pds.example.test/configured/path";
         const CLIENT_ID: &str = "handler-client";
         const REDIRECT_URI: &str = "https://client.example.test/callback";
         const MAPPED_DID: &str = "did:plc:abcdefghijklmnqrstuvwx2p";
@@ -1246,7 +1267,7 @@ mod tests {
             git2db,
             TransportConfig::inproc(&policy_tag),
         )
-        .with_default_audience(ISSUER.to_owned());
+        .with_default_audience(GENERIC_ISSUER.to_owned());
         let manager = InprocManager::new();
         let mut policy_handle = manager.spawn(Box::new(policy_service)).await?;
         let policy_client = PolicyClient::for_local_endpoint_bootstrap(
@@ -1273,7 +1294,7 @@ mod tests {
                 UserProfile {
                     atproto_did: Some(MAPPED_DID.to_owned()),
                     ..Default::default()
-                },
+                }.into(),
             )
             .await?;
         assert_eq!(
@@ -1295,8 +1316,8 @@ mod tests {
             .with_response_verify_policy(CryptoPolicy::Classical),
         );
         let mut config = crate::config::OAuthConfig::default();
-        // A configured path and trailing slash must normalize everywhere.
-        config.external_url = Some(format!("{ISSUER}/configured/path/"));
+        // Generic OAuth preserves this path; atproto emissions use its origin.
+        config.external_url = Some(GENERIC_ISSUER.to_owned());
         let mut oauth_state = OAuthState::new(
             &config,
             policy_client,
@@ -1522,6 +1543,39 @@ mod tests {
         let refreshed_claims = jwt_claims(refreshed_json["access_token"].as_str().unwrap());
         assert_eq!(refreshed_claims["sub"], MAPPED_DID);
 
+        // A non-atproto PAR consent cannot be upgraded to the atproto profile
+        // by mutating hidden fields on the callback POST.
+        let downgrade_challenge =
+            URL_SAFE_NO_PAD.encode(Sha256::digest(GENERIC_PKCE_VERIFIER.as_bytes()));
+        let downgrade_par = post_form(&app, "/oauth/par", &[
+            ("client_id", CLIENT_ID), ("redirect_uri", REDIRECT_URI),
+            ("code_challenge", &downgrade_challenge), ("code_challenge_method", "S256"),
+            ("response_type", "code"), ("state", "scope-binding-state"),
+            ("scope", "read:*:*"), ("resource", ISSUER),
+        ], None, false).await;
+        assert_eq!(downgrade_par.status(), axum::http::StatusCode::CREATED);
+        let downgrade_par_json = response_json(downgrade_par).await;
+        let downgrade_request_uri = downgrade_par_json["request_uri"].as_str().unwrap();
+        let downgrade_authorize_uri = format!(
+            "/oauth/authorize?{}",
+            encode_form(&[("request_uri", downgrade_request_uri), ("client_id", CLIENT_ID)])
+        );
+        let downgrade_authorize = get(&app, &downgrade_authorize_uri).await;
+        assert_eq!(downgrade_authorize.status(), axum::http::StatusCode::OK);
+        let downgrade_html = response_text(downgrade_authorize).await;
+        let downgrade_nonce = html_hidden_value(&downgrade_html, "nonce").to_owned();
+        let downgrade_signed = format!("{fingerprint}:{downgrade_nonce}:{downgrade_challenge}");
+        let downgrade_signature = STANDARD.encode(user_key.sign(downgrade_signed.as_bytes()).to_bytes());
+        let upgraded_callback = post_form(&app, "/oauth/authorize", &[
+            ("client_id", CLIENT_ID), ("redirect_uri", REDIRECT_URI),
+            ("code_challenge", &downgrade_challenge), ("scope", "atproto"),
+            ("state", "scope-binding-state"), ("resource", ISSUER),
+            ("nonce", &downgrade_nonce), ("fingerprint", &fingerprint),
+            ("signature", &downgrade_signature),
+        ], None, false).await;
+        assert_eq!(upgraded_callback.status(), axum::http::StatusCode::BAD_REQUEST);
+        assert_eq!(response_json(upgraded_callback).await["error"], "invalid_request");
+
         // A real generic authorization-code flow retains the local username
         // byte-for-byte and emits the legacy Bearer response shape.
         let generic_code_challenge =
@@ -1579,6 +1633,10 @@ mod tests {
             generic_callback_params.get("state").map(String::as_str),
             Some("generic-client-state")
         );
+        assert_eq!(
+            generic_callback_params.get("iss").map(String::as_str),
+            Some(GENERIC_ISSUER)
+        );
         let generic_code = generic_callback_params.get("code").unwrap();
         let generic_token = post_form(
             &app,
@@ -1598,10 +1656,28 @@ mod tests {
         let generic_token_json = response_json(generic_token).await;
         assert_eq!(generic_token_json["token_type"], "Bearer");
         assert!(generic_token_json.get("sub").is_none());
-        let generic_claims = jwt_claims(generic_token_json["access_token"].as_str().unwrap());
+        let generic_access_token = generic_token_json["access_token"].as_str().unwrap().to_owned();
+        let generic_refresh_token = generic_token_json["refresh_token"].as_str().unwrap().to_owned();
+        let generic_claims = jwt_claims(&generic_access_token);
         assert_eq!(generic_claims["sub"], "alice");
-        assert_eq!(generic_claims["iss"], ISSUER);
+        assert_eq!(generic_claims["iss"], GENERIC_ISSUER);
         assert_eq!(generic_claims["aud"], ISSUER);
+        let now = chrono::Utc::now().timestamp();
+        let introspection_caller = hyprstream_rpc::auth::jwt::encode(
+            &hyprstream_rpc::auth::Claims::new("introspection-test".to_owned(), now, now + 300),
+            &service_key,
+        );
+        let generic_introspection = post_form_bearer(
+            &app,
+            "/oauth/introspect",
+            &[("token", &generic_refresh_token)],
+            &introspection_caller,
+        ).await;
+        let generic_introspection_status = generic_introspection.status();
+        let generic_introspection_json = response_json(generic_introspection).await;
+        assert_eq!(generic_introspection_status, axum::http::StatusCode::OK, "{generic_introspection_json}");
+        assert_eq!(generic_introspection_json["active"], true);
+        assert_eq!(generic_introspection_json["sub"], "alice");
 
         // A real generic device flow retains the local username byte-for-byte
         // and the legacy Bearer response shape.
@@ -1664,7 +1740,7 @@ mod tests {
         assert!(device_token_json.get("sub").is_none());
         let device_claims = jwt_claims(device_token_json["access_token"].as_str().unwrap());
         assert_eq!(device_claims["sub"], "alice");
-        assert_eq!(device_claims["iss"], ISSUER);
+        assert_eq!(device_claims["iss"], GENERIC_ISSUER);
         assert_eq!(device_claims["aud"], ISSUER);
 
         policy_handle.stop().await?;

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -1116,6 +1116,33 @@ mod tests {
         )
     }
 
+    fn private_key_jwt_assertion(
+        signing_key: &p256::ecdsa::SigningKey,
+        client_id: &str,
+        audience: &str,
+        jti: &str,
+    ) -> String {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+        use p256::ecdsa::signature::Signer as _;
+
+        let header = serde_json::json!({"alg": "ES256", "typ": "JWT", "kid": "private-k1"});
+        let claims = serde_json::json!({
+            "iss": client_id,
+            "sub": client_id,
+            "aud": audience,
+            "exp": chrono::Utc::now().timestamp() + 60,
+            "jti": jti,
+        });
+        let header = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&header).unwrap());
+        let claims = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&claims).unwrap());
+        let signing_input = format!("{header}.{claims}");
+        let signature: p256::ecdsa::Signature = signing_key.sign(signing_input.as_bytes());
+        format!(
+            "{signing_input}.{}",
+            URL_SAFE_NO_PAD.encode(signature.to_bytes())
+        )
+    }
+
     fn jwt_claims(token: &str) -> serde_json::Value {
         use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 
@@ -1234,6 +1261,7 @@ mod tests {
         const ISSUER: &str = "https://pds.example.test";
         const GENERIC_ISSUER: &str = "https://pds.example.test/configured/path";
         const CLIENT_ID: &str = "handler-client";
+        const PRIVATE_CLIENT_ID: &str = "handler-private-client";
         const REDIRECT_URI: &str = "https://client.example.test/callback";
         const MAPPED_DID: &str = "did:plc:abcdefghijklmnqrstuvwx2p";
         const PKCE_VERIFIER: &str = "r5-handler-pkce-verifier-abcdefghijklmnopqrstuvwxyz012345";
@@ -1349,6 +1377,33 @@ mod tests {
                 jwks_uri: None,
                 hyprstream_node_did: None,
                 scope: Some("atproto read:*:*".to_owned()),
+                is_cimd: false,
+                registered_at: std::time::Instant::now(),
+            },
+        );
+        let private_client_key = p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
+        let private_client_point = private_client_key.verifying_key().to_encoded_point(false);
+        state.clients.write().await.insert(
+            PRIVATE_CLIENT_ID.to_owned(),
+            RegisteredClient {
+                client_id: PRIVATE_CLIENT_ID.to_owned(),
+                redirect_uris: vec![REDIRECT_URI.to_owned()],
+                client_name: Some("Handler Private Client".to_owned()),
+                client_uri: None,
+                logo_uri: None,
+                grant_types: vec!["authorization_code".to_owned()],
+                response_types: vec!["code".to_owned()],
+                token_endpoint_auth_method: Some("private_key_jwt".to_owned()),
+                jwks: Some(serde_json::json!({"keys": [{
+                    "kty": "EC",
+                    "crv": "P-256",
+                    "x": URL_SAFE_NO_PAD.encode(private_client_point.x().unwrap()),
+                    "y": URL_SAFE_NO_PAD.encode(private_client_point.y().unwrap()),
+                    "kid": "private-k1",
+                }]})),
+                jwks_uri: None,
+                hyprstream_node_did: None,
+                scope: Some("atproto".to_owned()),
                 is_cimd: false,
                 registered_at: std::time::Instant::now(),
             },
@@ -1492,6 +1547,147 @@ mod tests {
         assert_eq!(claims["iss"], ISSUER);
         assert_eq!(claims["sub"], MAPPED_DID);
         assert_eq!(claims["aud"], ISSUER);
+
+        // A confidential atproto client signs private_key_jwt for the
+        // canonical token endpoint advertised by the atproto metadata, even
+        // though the configured generic issuer carries a path.
+        let advertised_metadata = response_json(
+            get(&app, "/.well-known/oauth-authorization-server").await,
+        ).await;
+        let advertised_token_endpoint = advertised_metadata["token_endpoint"]
+            .as_str()
+            .unwrap()
+            .to_owned();
+        assert_eq!(advertised_token_endpoint, format!("{ISSUER}/oauth/token"));
+
+        let private_dpop_key = p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
+        let private_verifier = "private-client-pkce-verifier-abcdefghijklmnopqrstuvwxyz012345";
+        let private_challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(private_verifier.as_bytes()));
+        let private_par_proof = dpop_proof(
+            &private_dpop_key,
+            &format!("{ISSUER}/oauth/par"),
+            "private-client-par-jti",
+            None,
+        );
+        let private_par = post_form(
+            &app,
+            "/oauth/par",
+            &[
+                ("client_id", PRIVATE_CLIENT_ID),
+                ("redirect_uri", REDIRECT_URI),
+                ("code_challenge", &private_challenge),
+                ("code_challenge_method", "S256"),
+                ("response_type", "code"),
+                ("state", "private-client-state"),
+                ("scope", "atproto"),
+                ("resource", ISSUER),
+            ],
+            Some(&private_par_proof),
+            false,
+        ).await;
+        assert_eq!(private_par.status(), axum::http::StatusCode::CREATED);
+        let private_dpop_nonce = private_par.headers()
+            .get("DPoP-Nonce")
+            .and_then(|value| value.to_str().ok())
+            .unwrap()
+            .to_owned();
+        let private_par_json = response_json(private_par).await;
+        let private_request_uri = private_par_json["request_uri"].as_str().unwrap();
+        let private_authorize_uri = format!(
+            "/oauth/authorize?{}",
+            encode_form(&[
+                ("request_uri", private_request_uri),
+                ("client_id", PRIVATE_CLIENT_ID),
+            ])
+        );
+        let private_authorize = get(&app, &private_authorize_uri).await;
+        assert_eq!(private_authorize.status(), axum::http::StatusCode::OK);
+        let private_authorize_html = response_text(private_authorize).await;
+        let private_nonce = html_hidden_value(&private_authorize_html, "nonce").to_owned();
+        let private_signed = format!("{fingerprint}:{private_nonce}:{private_challenge}");
+        let private_signature = STANDARD.encode(user_key.sign(private_signed.as_bytes()).to_bytes());
+        let private_callback = post_form(
+            &app,
+            "/oauth/authorize",
+            &[
+                ("client_id", PRIVATE_CLIENT_ID),
+                ("redirect_uri", REDIRECT_URI),
+                ("code_challenge", &private_challenge),
+                ("scope", "atproto"),
+                ("state", "private-client-state"),
+                ("resource", ISSUER),
+                ("nonce", &private_nonce),
+                ("fingerprint", &fingerprint),
+                ("signature", &private_signature),
+            ],
+            None,
+            false,
+        ).await;
+        assert_eq!(private_callback.status(), axum::http::StatusCode::SEE_OTHER);
+        let private_location = private_callback.headers()
+            .get(axum::http::header::LOCATION)
+            .and_then(|value| value.to_str().ok())
+            .unwrap();
+        let private_location = url::Url::parse(private_location)?;
+        let private_callback_params: std::collections::HashMap<_, _> =
+            private_location.query_pairs().into_owned().collect();
+        let private_code = private_callback_params["code"].clone();
+        let private_token_proof = dpop_proof(
+            &private_dpop_key,
+            &advertised_token_endpoint,
+            "private-client-token-jti",
+            Some(&private_dpop_nonce),
+        );
+        let assertion_type = super::client_auth::JWT_BEARER_ASSERTION_TYPE;
+        let wrong_assertion = private_key_jwt_assertion(
+            &private_client_key,
+            PRIVATE_CLIENT_ID,
+            "https://attacker.example/oauth/token",
+            "private-client-wrong-aud",
+        );
+        let wrong_audience = post_form(
+            &app,
+            "/oauth/token",
+            &[
+                ("grant_type", "authorization_code"),
+                ("client_id", PRIVATE_CLIENT_ID),
+                ("code", &private_code),
+                ("redirect_uri", REDIRECT_URI),
+                ("code_verifier", private_verifier),
+                ("client_assertion_type", assertion_type),
+                ("client_assertion", &wrong_assertion),
+            ],
+            Some(&private_token_proof),
+            false,
+        ).await;
+        assert_eq!(wrong_audience.status(), axum::http::StatusCode::UNAUTHORIZED);
+        assert_eq!(response_json(wrong_audience).await["error"], "invalid_client");
+
+        let canonical_assertion = private_key_jwt_assertion(
+            &private_client_key,
+            PRIVATE_CLIENT_ID,
+            &advertised_token_endpoint,
+            "private-client-canonical-aud",
+        );
+        let private_token = post_form(
+            &app,
+            "/oauth/token",
+            &[
+                ("grant_type", "authorization_code"),
+                ("client_id", PRIVATE_CLIENT_ID),
+                ("code", &private_code),
+                ("redirect_uri", REDIRECT_URI),
+                ("code_verifier", private_verifier),
+                ("client_assertion_type", assertion_type),
+                ("client_assertion", &canonical_assertion),
+            ],
+            Some(&private_token_proof),
+            false,
+        ).await;
+        assert_eq!(private_token.status(), axum::http::StatusCode::OK);
+        let private_token_json = response_json(private_token).await;
+        assert_eq!(private_token_json["token_type"], "DPoP");
+        assert_eq!(jwt_claims(private_token_json["access_token"].as_str().unwrap())["iss"], ISSUER);
 
         // A missing refresh proof is rejected before consumption. Retrying
         // the same refresh token with the bound key and nonce must succeed.

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -1547,6 +1547,7 @@ mod tests {
         assert_eq!(claims["iss"], ISSUER);
         assert_eq!(claims["sub"], MAPPED_DID);
         assert_eq!(claims["aud"], ISSUER);
+        assert_eq!(claims["scope"], "atproto");
 
         // A confidential atproto client signs private_key_jwt for the
         // canonical token endpoint advertised by the atproto metadata, even
@@ -1738,6 +1739,7 @@ mod tests {
         assert!(state.get_refresh_token(&refresh_token).await?.is_none());
         let refreshed_claims = jwt_claims(refreshed_json["access_token"].as_str().unwrap());
         assert_eq!(refreshed_claims["sub"], MAPPED_DID);
+        assert_eq!(refreshed_claims["scope"], "atproto");
 
         // A non-atproto PAR consent cannot be upgraded to the atproto profile
         // by mutating hidden fields on the callback POST.
@@ -1858,22 +1860,74 @@ mod tests {
         assert_eq!(generic_claims["sub"], "alice");
         assert_eq!(generic_claims["iss"], GENERIC_ISSUER);
         assert_eq!(generic_claims["aud"], ISSUER);
-        let now = chrono::Utc::now().timestamp();
-        let introspection_caller = hyprstream_rpc::auth::jwt::encode(
-            &hyprstream_rpc::auth::Claims::new("introspection-test".to_owned(), now, now + 300),
-            &service_key,
-        );
+        assert_eq!(generic_claims["scope"], "read:*:*");
+
+        // The real composite token minted above authenticates to a protected
+        // OAuth route. This failed when middleware routed every JWT through
+        // the fixed EdDSA key.
         let generic_introspection = post_form_bearer(
             &app,
             "/oauth/introspect",
             &[("token", &generic_refresh_token)],
-            &introspection_caller,
+            &generic_access_token,
         ).await;
         let generic_introspection_status = generic_introspection.status();
         let generic_introspection_json = response_json(generic_introspection).await;
         assert_eq!(generic_introspection_status, axum::http::StatusCode::OK, "{generic_introspection_json}");
         assert_eq!(generic_introspection_json["active"], true);
         assert_eq!(generic_introspection_json["sub"], "alice");
+
+        // JWT introspection uses the same composite/audience/issuer validator
+        // and returns the signed grant scope rather than subject-wide policy.
+        let access_introspection = post_form_bearer(
+            &app,
+            "/oauth/introspect",
+            &[("token", &generic_access_token)],
+            &generic_access_token,
+        ).await;
+        assert_eq!(access_introspection.status(), axum::http::StatusCode::OK);
+        let access_introspection_json = response_json(access_introspection).await;
+        assert_eq!(access_introspection_json["active"], true);
+        assert_eq!(access_introspection_json["scope"], "read:*:*");
+
+        let snapshot = hyprstream_rpc::auth::global_composite_key_set().snapshot();
+        let signing_pair = snapshot
+            .active_signing_pair(hyprstream_rpc::auth::CompositePairRole::Policy)
+            .unwrap();
+        let (ml_signing, ed_signing) = signing_pair.signing_keys().unwrap();
+        let now = chrono::Utc::now().timestamp();
+        let wrong_audience = crate::auth::jwt::encode_composite_ml_dsa_65_ed25519(
+            &hyprstream_rpc::auth::Claims::new("alice".to_owned(), now, now + 300)
+                .with_issuer(GENERIC_ISSUER.to_owned())
+                .with_audience(Some("https://other-resource.example.test".to_owned()))
+                .with_scope(Some("read:*:*".to_owned())),
+            &ml_signing,
+            &ed_signing,
+        );
+        let rejected_audience = post_form_bearer(
+            &app,
+            "/oauth/introspect",
+            &[("token", &generic_refresh_token)],
+            &wrong_audience,
+        ).await;
+        assert_eq!(rejected_audience.status(), axum::http::StatusCode::UNAUTHORIZED);
+
+        let wrong_issuer = crate::auth::jwt::encode_composite_ml_dsa_65_ed25519(
+            &hyprstream_rpc::auth::Claims::new("alice".to_owned(), now, now + 300)
+                .with_issuer("https://other-issuer.example.test".to_owned())
+                .with_audience(Some(ISSUER.to_owned()))
+                .with_scope(Some("read:*:*".to_owned())),
+            &ml_signing,
+            &ed_signing,
+        );
+        let rejected_issuer = post_form_bearer(
+            &app,
+            "/oauth/introspect",
+            &[("token", &wrong_issuer)],
+            &generic_access_token,
+        ).await;
+        assert_eq!(rejected_issuer.status(), axum::http::StatusCode::OK);
+        assert_eq!(response_json(rejected_issuer).await["active"], false);
 
         // A real generic device flow retains the local username byte-for-byte
         // and the legacy Bearer response shape.
@@ -1938,6 +1992,7 @@ mod tests {
         assert_eq!(device_claims["sub"], "alice");
         assert_eq!(device_claims["iss"], GENERIC_ISSUER);
         assert_eq!(device_claims["aud"], ISSUER);
+        assert_eq!(device_claims["scope"], "read:*:*");
 
         policy_handle.stop().await?;
         Ok(())

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -1888,9 +1888,42 @@ mod tests {
         assert_eq!(wrong_audience.status(), axum::http::StatusCode::UNAUTHORIZED);
         assert_eq!(response_json(wrong_audience).await["error"], "invalid_client");
 
+        // #1146 T1.2 (rev): the RFC 7523 token-endpoint audience form is NOT
+        // accepted at the token endpoint either — atproto mandates the AS
+        // issuer alone at every endpoint. This pins the narrowing: accepting
+        // both forms was the review-flagged deviation.
+        let endpoint_aud_assertion = private_key_jwt_assertion(
+            &private_client_key,
+            "private-k1",
+            PRIVATE_CLIENT_ID,
+            &advertised_token_endpoint,
+            "private-client-endpoint-aud",
+        );
+        let endpoint_audience = post_form(
+            &app,
+            "/oauth/token",
+            &[
+                ("grant_type", "authorization_code"),
+                ("client_id", PRIVATE_CLIENT_ID),
+                ("code", &private_code),
+                ("redirect_uri", REDIRECT_URI),
+                ("code_verifier", private_verifier),
+                ("client_assertion_type", assertion_type),
+                ("client_assertion", &endpoint_aud_assertion),
+            ],
+            Some(&private_token_proof),
+            false,
+        ).await;
+        assert_eq!(
+            endpoint_audience.status(),
+            axum::http::StatusCode::UNAUTHORIZED,
+            "the token-endpoint audience form must be rejected (issuer-only)"
+        );
+        assert_eq!(response_json(endpoint_audience).await["error"], "invalid_client");
+
         // #1146 T1.2: the reference confidential client sends the AS ISSUER
-        // as the assertion audience — previously rejected, now the
-        // canonical accepted form.
+        // as the assertion audience — previously rejected, now the ONLY
+        // accepted form (issuer-only at PAR and token).
         let canonical_assertion = private_key_jwt_assertion(
             &private_client_key,
             "private-k1",

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -1118,6 +1118,7 @@ mod tests {
 
     fn private_key_jwt_assertion(
         signing_key: &p256::ecdsa::SigningKey,
+        kid: &str,
         client_id: &str,
         audience: &str,
         jti: &str,
@@ -1125,11 +1126,12 @@ mod tests {
         use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
         use p256::ecdsa::signature::Signer as _;
 
-        let header = serde_json::json!({"alg": "ES256", "typ": "JWT", "kid": "private-k1"});
+        let header = serde_json::json!({"alg": "ES256", "typ": "JWT", "kid": kid});
         let claims = serde_json::json!({
             "iss": client_id,
             "sub": client_id,
             "aud": audience,
+            "iat": chrono::Utc::now().timestamp(),
             "exp": chrono::Utc::now().timestamp() + 60,
             "jti": jti,
         });
@@ -1377,12 +1379,17 @@ mod tests {
                 jwks_uri: None,
                 hyprstream_node_did: None,
                 scope: Some("atproto read:*:*".to_owned()),
+                dpop_bound_access_tokens: None,
                 is_cimd: false,
                 registered_at: std::time::Instant::now(),
             },
         );
         let private_client_key = p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
         let private_client_point = private_client_key.verifying_key().to_encoded_point(false);
+        // A second registered key for the same client: proves refresh cannot
+        // switch assertion keys mid-session (#1146 T3.3).
+        let private_client_key_2 = p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
+        let private_client_point_2 = private_client_key_2.verifying_key().to_encoded_point(false);
         state.clients.write().await.insert(
             PRIVATE_CLIENT_ID.to_owned(),
             RegisteredClient {
@@ -1400,10 +1407,17 @@ mod tests {
                     "x": URL_SAFE_NO_PAD.encode(private_client_point.x().unwrap()),
                     "y": URL_SAFE_NO_PAD.encode(private_client_point.y().unwrap()),
                     "kid": "private-k1",
+                }, {
+                    "kty": "EC",
+                    "crv": "P-256",
+                    "x": URL_SAFE_NO_PAD.encode(private_client_point_2.x().unwrap()),
+                    "y": URL_SAFE_NO_PAD.encode(private_client_point_2.y().unwrap()),
+                    "kid": "private-k2",
                 }]})),
                 jwks_uri: None,
                 hyprstream_node_did: None,
                 scope: Some("atproto".to_owned()),
+                dpop_bound_access_tokens: Some(true),
                 is_cimd: false,
                 registered_at: std::time::Instant::now(),
             },
@@ -1427,6 +1441,108 @@ mod tests {
         assert_eq!(
             response_json(unknown_device).await["error"],
             "invalid_client"
+        );
+
+        // #1146 T1.3: the atproto profile has no device authorization grant —
+        // `scope=atproto` is rejected at the device endpoint (it previously
+        // minted malformed DPoP tokens cnf-bound to the user's login key).
+        let atproto_device = post_form(
+            &app,
+            "/oauth/device",
+            &[("client_id", CLIENT_ID), ("scope", "atproto")],
+            None,
+            false,
+        )
+        .await;
+        assert_eq!(atproto_device.status(), axum::http::StatusCode::BAD_REQUEST);
+        assert_eq!(
+            response_json(atproto_device).await["error"],
+            "invalid_scope"
+        );
+
+        // #1146 T1.1: a fetched CIMD client's declared scope ceiling is
+        // enforced at PAR. This client declares only `atproto`; requesting
+        // `transition:generic` must be rejected (the fetched-metadata path
+        // previously dropped the ceiling entirely).
+        const CIMD_CLIENT_ID: &str = "https://client.example.test/cimd.json";
+        state
+            .cimd_cache
+            .insert(
+                RegisteredClient {
+                    client_id: CIMD_CLIENT_ID.to_owned(),
+                    redirect_uris: vec![REDIRECT_URI.to_owned()],
+                    client_name: Some("Handler CIMD Client".to_owned()),
+                    client_uri: None,
+                    logo_uri: None,
+                    grant_types: vec!["authorization_code".to_owned()],
+                    response_types: vec!["code".to_owned()],
+                    token_endpoint_auth_method: Some("none".to_owned()),
+                    jwks: None,
+                    jwks_uri: None,
+                    hyprstream_node_did: None,
+                    scope: Some("atproto".to_owned()),
+                    dpop_bound_access_tokens: Some(true),
+                    is_cimd: true,
+                    registered_at: std::time::Instant::now(),
+                },
+                std::time::Duration::from_secs(300),
+            )
+            .await;
+        let cimd_par_challenge =
+            URL_SAFE_NO_PAD.encode(Sha256::digest(b"cimd-ceiling-pkce-verifier-abcdefghijklmnopqrstuvwxyz"));
+        let cimd_over_scope_par = post_form(
+            &app,
+            "/oauth/par",
+            &[
+                ("client_id", CIMD_CLIENT_ID),
+                ("redirect_uri", REDIRECT_URI),
+                ("code_challenge", &cimd_par_challenge),
+                ("code_challenge_method", "S256"),
+                ("response_type", "code"),
+                ("scope", "atproto transition:generic"),
+                ("resource", ISSUER),
+            ],
+            None,
+            false,
+        )
+        .await;
+        assert_eq!(
+            cimd_over_scope_par.status(),
+            axum::http::StatusCode::BAD_REQUEST,
+            "CIMD client must not exceed its declared scope ceiling"
+        );
+        assert_eq!(
+            response_json(cimd_over_scope_par).await["error"],
+            "invalid_scope"
+        );
+        // Positive control: the declared scope itself is still granted.
+        let cimd_dpop_key = p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
+        let cimd_par_proof = dpop_proof(
+            &cimd_dpop_key,
+            &format!("{ISSUER}/oauth/par"),
+            "cimd-ceiling-par-jti",
+            None,
+        );
+        let cimd_in_scope_par = post_form(
+            &app,
+            "/oauth/par",
+            &[
+                ("client_id", CIMD_CLIENT_ID),
+                ("redirect_uri", REDIRECT_URI),
+                ("code_challenge", &cimd_par_challenge),
+                ("code_challenge_method", "S256"),
+                ("response_type", "code"),
+                ("scope", "atproto"),
+                ("resource", ISSUER),
+            ],
+            Some(&cimd_par_proof),
+            false,
+        )
+        .await;
+        assert_eq!(
+            cimd_in_scope_par.status(),
+            axum::http::StatusCode::CREATED,
+            "declared scope must remain grantable"
         );
 
         // PAR binds the atproto request to a real ES256 DPoP key.
@@ -1548,9 +1664,9 @@ mod tests {
         assert_eq!(claims["sub"], MAPPED_DID);
         assert_eq!(claims["aud"], ISSUER);
 
-        // A confidential atproto client signs private_key_jwt for the
-        // canonical token endpoint advertised by the atproto metadata, even
-        // though the configured generic issuer carries a path.
+        // A confidential atproto client signs private_key_jwt with the AS
+        // issuer as the assertion audience (atproto mandate, #1146 T1.2),
+        // even though the configured generic issuer carries a path.
         let advertised_metadata = response_json(
             get(&app, "/.well-known/oauth-authorization-server").await,
         ).await;
@@ -1560,14 +1676,89 @@ mod tests {
             .to_owned();
         assert_eq!(advertised_token_endpoint, format!("{ISSUER}/oauth/token"));
 
+        let assertion_type = super::client_auth::JWT_BEARER_ASSERTION_TYPE;
         let private_dpop_key = p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
         let private_verifier = "private-client-pkce-verifier-abcdefghijklmnopqrstuvwxyz012345";
         let private_challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(private_verifier.as_bytes()));
+
+        // #1146 T3.3: confidential clients MUST authenticate at PAR — a
+        // pushed request without a client_assertion is rejected.
+        let no_auth_par_proof = dpop_proof(
+            &private_dpop_key,
+            &format!("{ISSUER}/oauth/par"),
+            "private-client-par-jti-noauth",
+            None,
+        );
+        let no_auth_par = post_form(
+            &app,
+            "/oauth/par",
+            &[
+                ("client_id", PRIVATE_CLIENT_ID),
+                ("redirect_uri", REDIRECT_URI),
+                ("code_challenge", &private_challenge),
+                ("code_challenge_method", "S256"),
+                ("response_type", "code"),
+                ("state", "private-client-state"),
+                ("scope", "atproto"),
+                ("resource", ISSUER),
+            ],
+            Some(&no_auth_par_proof),
+            false,
+        )
+        .await;
+        assert_eq!(no_auth_par.status(), axum::http::StatusCode::UNAUTHORIZED);
+        assert_eq!(response_json(no_auth_par).await["error"], "invalid_client");
+
+        // #1146 T1.2: at PAR the assertion audience MUST be the AS issuer —
+        // the RFC 7523 token-endpoint form accepted at /oauth/token is not
+        // sufficient here.
+        let par_endpoint_aud_assertion = private_key_jwt_assertion(
+            &private_client_key,
+            "private-k1",
+            PRIVATE_CLIENT_ID,
+            &format!("{ISSUER}/oauth/token"),
+            "private-par-endpoint-aud-jti",
+        );
+        let wrong_aud_par_proof = dpop_proof(
+            &private_dpop_key,
+            &format!("{ISSUER}/oauth/par"),
+            "private-client-par-jti-wrongaod",
+            None,
+        );
+        let wrong_aud_par = post_form(
+            &app,
+            "/oauth/par",
+            &[
+                ("client_id", PRIVATE_CLIENT_ID),
+                ("redirect_uri", REDIRECT_URI),
+                ("code_challenge", &private_challenge),
+                ("code_challenge_method", "S256"),
+                ("response_type", "code"),
+                ("state", "private-client-state"),
+                ("scope", "atproto"),
+                ("resource", ISSUER),
+                ("client_assertion_type", assertion_type),
+                ("client_assertion", &par_endpoint_aud_assertion),
+            ],
+            Some(&wrong_aud_par_proof),
+            false,
+        )
+        .await;
+        assert_eq!(wrong_aud_par.status(), axum::http::StatusCode::UNAUTHORIZED);
+        assert_eq!(response_json(wrong_aud_par).await["error"], "invalid_client");
+
         let private_par_proof = dpop_proof(
             &private_dpop_key,
             &format!("{ISSUER}/oauth/par"),
             "private-client-par-jti",
             None,
+        );
+        let private_par_assertion = private_key_jwt_assertion(
+            &private_client_key,
+            "private-k1",
+            PRIVATE_CLIENT_ID,
+            ISSUER,
+            "private-par-assertion-jti",
         );
         let private_par = post_form(
             &app,
@@ -1581,6 +1772,8 @@ mod tests {
                 ("state", "private-client-state"),
                 ("scope", "atproto"),
                 ("resource", ISSUER),
+                ("client_assertion_type", assertion_type),
+                ("client_assertion", &private_par_assertion),
             ],
             Some(&private_par_proof),
             false,
@@ -1632,15 +1825,47 @@ mod tests {
         let private_callback_params: std::collections::HashMap<_, _> =
             private_location.query_pairs().into_owned().collect();
         let private_code = private_callback_params["code"].clone();
+
+        // #1146 T3.3: a client_assertion is single-use — re-presenting the
+        // exact assertion accepted at PAR above (same jti) is replay and
+        // must be rejected, even at a different endpoint.
+        let replay_assertion_proof = dpop_proof(
+            &private_dpop_key,
+            &advertised_token_endpoint,
+            "private-client-token-jti-replay",
+            Some(&private_dpop_nonce),
+        );
+        let replayed_assertion = post_form(
+            &app,
+            "/oauth/token",
+            &[
+                ("grant_type", "authorization_code"),
+                ("client_id", PRIVATE_CLIENT_ID),
+                ("code", &private_code),
+                ("redirect_uri", REDIRECT_URI),
+                ("code_verifier", private_verifier),
+                ("client_assertion_type", assertion_type),
+                ("client_assertion", &private_par_assertion),
+            ],
+            Some(&replay_assertion_proof),
+            false,
+        ).await;
+        assert_eq!(
+            replayed_assertion.status(),
+            axum::http::StatusCode::UNAUTHORIZED,
+            "a replayed client_assertion jti must be rejected"
+        );
+        assert_eq!(response_json(replayed_assertion).await["error"], "invalid_client");
+
         let private_token_proof = dpop_proof(
             &private_dpop_key,
             &advertised_token_endpoint,
             "private-client-token-jti",
             Some(&private_dpop_nonce),
         );
-        let assertion_type = super::client_auth::JWT_BEARER_ASSERTION_TYPE;
         let wrong_assertion = private_key_jwt_assertion(
             &private_client_key,
+            "private-k1",
             PRIVATE_CLIENT_ID,
             "https://attacker.example/oauth/token",
             "private-client-wrong-aud",
@@ -1663,10 +1888,14 @@ mod tests {
         assert_eq!(wrong_audience.status(), axum::http::StatusCode::UNAUTHORIZED);
         assert_eq!(response_json(wrong_audience).await["error"], "invalid_client");
 
+        // #1146 T1.2: the reference confidential client sends the AS ISSUER
+        // as the assertion audience — previously rejected, now the
+        // canonical accepted form.
         let canonical_assertion = private_key_jwt_assertion(
             &private_client_key,
+            "private-k1",
             PRIVATE_CLIENT_ID,
-            &advertised_token_endpoint,
+            ISSUER,
             "private-client-canonical-aud",
         );
         let private_token = post_form(
@@ -1685,9 +1914,154 @@ mod tests {
             false,
         ).await;
         assert_eq!(private_token.status(), axum::http::StatusCode::OK);
+        let private_token_nonce = private_token
+            .headers()
+            .get("DPoP-Nonce")
+            .and_then(|value| value.to_str().ok())
+            .unwrap()
+            .to_owned();
         let private_token_json = response_json(private_token).await;
         assert_eq!(private_token_json["token_type"], "DPoP");
         assert_eq!(jwt_claims(private_token_json["access_token"].as_str().unwrap())["iss"], ISSUER);
+        let private_refresh_token = private_token_json["refresh_token"]
+            .as_str()
+            .unwrap()
+            .to_owned();
+
+        // #1146 T3.3: the session is bound to the assertion key verified at
+        // PAR/issuance. Refresh presenting an assertion from ANOTHER
+        // currently-registered key (private-k2) must be rejected — and must
+        // not consume the single-use refresh token.
+        let switch_assertion = private_key_jwt_assertion(
+            &private_client_key_2,
+            "private-k2",
+            PRIVATE_CLIENT_ID,
+            ISSUER,
+            "private-refresh-switch-jti",
+        );
+        let switch_proof = dpop_proof(
+            &private_dpop_key,
+            &advertised_token_endpoint,
+            "private-refresh-switch-dpop-jti",
+            Some(&private_token_nonce),
+        );
+        let switch_refresh = post_form(
+            &app,
+            "/oauth/token",
+            &[
+                ("grant_type", "refresh_token"),
+                ("client_id", PRIVATE_CLIENT_ID),
+                ("refresh_token", &private_refresh_token),
+                ("client_assertion_type", assertion_type),
+                ("client_assertion", &switch_assertion),
+            ],
+            Some(&switch_proof),
+            false,
+        )
+        .await;
+        assert_eq!(
+            switch_refresh.status(),
+            axum::http::StatusCode::UNAUTHORIZED,
+            "refresh must not switch to another registered assertion key"
+        );
+        assert_eq!(response_json(switch_refresh).await["error"], "invalid_client");
+        assert!(
+            state.get_refresh_token(&private_refresh_token).await?.is_some(),
+            "a rejected client authentication must not consume the refresh token"
+        );
+
+        // Refresh with the BOUND key succeeds and rotates.
+        let bound_assertion = private_key_jwt_assertion(
+            &private_client_key,
+            "private-k1",
+            PRIVATE_CLIENT_ID,
+            ISSUER,
+            "private-refresh-bound-jti",
+        );
+        let bound_proof = dpop_proof(
+            &private_dpop_key,
+            &advertised_token_endpoint,
+            "private-refresh-bound-dpop-jti",
+            Some(&private_token_nonce),
+        );
+        let bound_refresh = post_form(
+            &app,
+            "/oauth/token",
+            &[
+                ("grant_type", "refresh_token"),
+                ("client_id", PRIVATE_CLIENT_ID),
+                ("refresh_token", &private_refresh_token),
+                ("client_assertion_type", assertion_type),
+                ("client_assertion", &bound_assertion),
+            ],
+            Some(&bound_proof),
+            false,
+        )
+        .await;
+        assert_eq!(bound_refresh.status(), axum::http::StatusCode::OK);
+        let bound_refresh_nonce = bound_refresh
+            .headers()
+            .get("DPoP-Nonce")
+            .and_then(|value| value.to_str().ok())
+            .unwrap()
+            .to_owned();
+        let bound_refresh_json = response_json(bound_refresh).await;
+        let rotated_refresh_token = bound_refresh_json["refresh_token"]
+            .as_str()
+            .unwrap()
+            .to_owned();
+        assert_ne!(rotated_refresh_token, private_refresh_token);
+
+        // #1146 T3.3: removing the bound key from the client's JWKS revokes
+        // the session — the rotated refresh can no longer authenticate.
+        {
+            let mut clients = state.clients.write().await;
+            let entry = clients.get_mut(PRIVATE_CLIENT_ID).unwrap();
+            let keys = entry.jwks.as_ref().unwrap()["keys"].as_array().unwrap();
+            let remaining: Vec<serde_json::Value> = keys
+                .iter()
+                .filter(|k| k["kid"].as_str() != Some("private-k1"))
+                .cloned()
+                .collect();
+            entry.jwks = Some(serde_json::json!({"keys": remaining}));
+        }
+        let removed_key_assertion = private_key_jwt_assertion(
+            &private_client_key,
+            "private-k1",
+            PRIVATE_CLIENT_ID,
+            ISSUER,
+            "private-refresh-removed-jti",
+        );
+        let removed_key_proof = dpop_proof(
+            &private_dpop_key,
+            &advertised_token_endpoint,
+            "private-refresh-removed-dpop-jti",
+            Some(&bound_refresh_nonce),
+        );
+        let removed_key_refresh = post_form(
+            &app,
+            "/oauth/token",
+            &[
+                ("grant_type", "refresh_token"),
+                ("client_id", PRIVATE_CLIENT_ID),
+                ("refresh_token", &rotated_refresh_token),
+                ("client_assertion_type", assertion_type),
+                ("client_assertion", &removed_key_assertion),
+            ],
+            Some(&removed_key_proof),
+            false,
+        )
+        .await;
+        assert_eq!(
+            removed_key_refresh.status(),
+            axum::http::StatusCode::UNAUTHORIZED,
+            "key removal from the client JWKS must revoke the session"
+        );
+        assert_eq!(response_json(removed_key_refresh).await["error"], "invalid_client");
+        assert!(
+            state.get_refresh_token(&rotated_refresh_token).await?.is_some(),
+            "a rejected client authentication must not consume the refresh token"
+        );
 
         // A missing refresh proof is rejected before consumption. Retrying
         // the same refresh token with the bound key and nonce must succeed.

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -1216,6 +1216,8 @@ mod tests {
         const REDIRECT_URI: &str = "https://client.example.test/callback";
         const MAPPED_DID: &str = "did:plc:abcdefghijklmnqrstuvwx2p";
         const PKCE_VERIFIER: &str = "r5-handler-pkce-verifier-abcdefghijklmnopqrstuvwxyz012345";
+        const GENERIC_PKCE_VERIFIER: &str =
+            "r7-generic-pkce-verifier-abcdefghijklmnopqrstuvwxyz012345";
 
         let _ = hyprstream_rpc::envelope::install_verify_config(
             hyprstream_rpc::envelope::EnvelopeVerifyConfig {
@@ -1519,6 +1521,87 @@ mod tests {
         assert!(state.get_refresh_token(&refresh_token).await?.is_none());
         let refreshed_claims = jwt_claims(refreshed_json["access_token"].as_str().unwrap());
         assert_eq!(refreshed_claims["sub"], MAPPED_DID);
+
+        // A real generic authorization-code flow retains the local username
+        // byte-for-byte and emits the legacy Bearer response shape.
+        let generic_code_challenge =
+            URL_SAFE_NO_PAD.encode(Sha256::digest(GENERIC_PKCE_VERIFIER.as_bytes()));
+        let generic_authorize_uri = format!(
+            "/oauth/authorize?{}",
+            encode_form(&[
+                ("client_id", CLIENT_ID),
+                ("redirect_uri", REDIRECT_URI),
+                ("code_challenge", &generic_code_challenge),
+                ("code_challenge_method", "S256"),
+                ("response_type", "code"),
+                ("state", "generic-client-state"),
+                ("scope", "read:*:*"),
+                ("resource", ISSUER),
+            ])
+        );
+        let generic_authorize = get(&app, &generic_authorize_uri).await;
+        assert_eq!(generic_authorize.status(), axum::http::StatusCode::OK);
+        let generic_authorize_html = response_text(generic_authorize).await;
+        let generic_authorize_nonce =
+            html_hidden_value(&generic_authorize_html, "nonce").to_owned();
+        let generic_challenge =
+            format!("{fingerprint}:{generic_authorize_nonce}:{generic_code_challenge}");
+        let generic_signature =
+            STANDARD.encode(user_key.sign(generic_challenge.as_bytes()).to_bytes());
+        let generic_callback = post_form(
+            &app,
+            "/oauth/authorize",
+            &[
+                ("client_id", CLIENT_ID),
+                ("redirect_uri", REDIRECT_URI),
+                ("code_challenge", &generic_code_challenge),
+                ("scope", "read:*:*"),
+                ("state", "generic-client-state"),
+                ("resource", ISSUER),
+                ("nonce", &generic_authorize_nonce),
+                ("fingerprint", &fingerprint),
+                ("signature", &generic_signature),
+            ],
+            None,
+            false,
+        )
+        .await;
+        assert_eq!(generic_callback.status(), axum::http::StatusCode::SEE_OTHER);
+        let generic_location = generic_callback
+            .headers()
+            .get(axum::http::header::LOCATION)
+            .and_then(|value| value.to_str().ok())
+            .unwrap();
+        let generic_location = url::Url::parse(generic_location)?;
+        let generic_callback_params: std::collections::HashMap<_, _> =
+            generic_location.query_pairs().into_owned().collect();
+        assert_eq!(
+            generic_callback_params.get("state").map(String::as_str),
+            Some("generic-client-state")
+        );
+        let generic_code = generic_callback_params.get("code").unwrap();
+        let generic_token = post_form(
+            &app,
+            "/oauth/token",
+            &[
+                ("grant_type", "authorization_code"),
+                ("client_id", CLIENT_ID),
+                ("code", generic_code),
+                ("redirect_uri", REDIRECT_URI),
+                ("code_verifier", GENERIC_PKCE_VERIFIER),
+            ],
+            None,
+            false,
+        )
+        .await;
+        assert_eq!(generic_token.status(), axum::http::StatusCode::OK);
+        let generic_token_json = response_json(generic_token).await;
+        assert_eq!(generic_token_json["token_type"], "Bearer");
+        assert!(generic_token_json.get("sub").is_none());
+        let generic_claims = jwt_claims(generic_token_json["access_token"].as_str().unwrap());
+        assert_eq!(generic_claims["sub"], "alice");
+        assert_eq!(generic_claims["iss"], ISSUER);
+        assert_eq!(generic_claims["aud"], ISSUER);
 
         // A real generic device flow retains the local username byte-for-byte
         // and the legacy Bearer response shape.

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -1256,6 +1256,7 @@ mod tests {
         use super::token_store::RocksDbTokenStore;
         use crate::auth::rocksdb_store::RocksDbUserStore;
         use crate::auth::{PolicyManager, UserProfile, UserStore};
+        use crate::services::generated::policy_client::IssueToken;
         use crate::services::{DiscoveryClient, PolicyClient, PolicyService};
 
         const ISSUER: &str = "https://pds.example.test";
@@ -1370,6 +1371,7 @@ mod tests {
                     "authorization_code".to_owned(),
                     "refresh_token".to_owned(),
                     "urn:ietf:params:oauth:grant-type:device_code".to_owned(),
+                    "urn:ietf:params:oauth:grant-type:token-exchange".to_owned(),
                 ],
                 response_types: vec!["code".to_owned()],
                 token_endpoint_auth_method: Some("none".to_owned()),
@@ -1861,6 +1863,126 @@ mod tests {
         assert_eq!(generic_claims["iss"], GENERIC_ISSUER);
         assert_eq!(generic_claims["aud"], ISSUER);
         assert_eq!(generic_claims["scope"], "read:*:*");
+
+        // A token minted without an explicit resource uses PolicyService's
+        // configured path-bearing default audience. The AS must accept that
+        // exact local alias on its own protected routes.
+        let default_audience_token = state
+            .policy_client
+            .issue_token(&IssueToken {
+                requested_scopes: Some(vec!["read:*:*".to_owned()]),
+                ttl: Some(300),
+                audience: None,
+                subject: Some("default-audience-user".to_owned()),
+                user_pub_key: None,
+                dpop_jkt: None,
+                issuer: None,
+            })
+            .await?
+            .token;
+        assert_eq!(jwt_claims(&default_audience_token)["aud"], GENERIC_ISSUER);
+        let default_audience_auth = post_form_bearer(
+            &app,
+            "/oauth/introspect",
+            &[("token", &generic_access_token)],
+            &default_audience_token,
+        )
+        .await;
+        assert_eq!(
+            default_audience_auth.status(),
+            axum::http::StatusCode::OK,
+            "the AS must accept its path-bearing default audience alias"
+        );
+
+        // Token exchange may only attenuate the verified subject token's signed
+        // grant. A caller holding read:*:* cannot write transition:generic into
+        // a newly signed scope claim.
+        let inflation_subject = state
+            .policy_client
+            .issue_token(&IssueToken {
+                requested_scopes: Some(vec!["read:*:*".to_owned()]),
+                ttl: Some(300),
+                audience: Some(ISSUER.to_owned()),
+                subject: Some("scope-inflation-user".to_owned()),
+                user_pub_key: None,
+                dpop_jkt: None,
+                issuer: None,
+            })
+            .await?
+            .token;
+        let inflated_exchange = post_form(
+            &app,
+            "/oauth/token",
+            &[
+                (
+                    "grant_type",
+                    "urn:ietf:params:oauth:grant-type:token-exchange",
+                ),
+                ("client_id", CLIENT_ID),
+                ("subject_token", &inflation_subject),
+                (
+                    "subject_token_type",
+                    "urn:ietf:params:oauth:token-type:access_token",
+                ),
+                ("scope", "transition:generic"),
+                ("audience", ISSUER),
+            ],
+            None,
+            false,
+        )
+        .await;
+        assert_eq!(
+            inflated_exchange.status(),
+            axum::http::StatusCode::BAD_REQUEST
+        );
+        assert_eq!(response_json(inflated_exchange).await["error"], "invalid_scope");
+
+        // The same endpoint accepts a production composite access token and
+        // preserves a requested subset of its signed grant. This exercises the
+        // shared algorithm/audience/issuer validator on the subject-token path.
+        let valid_exchange_subject = state
+            .policy_client
+            .issue_token(&IssueToken {
+                requested_scopes: Some(vec![
+                    "read:*:*".to_owned(),
+                    "transition:generic".to_owned(),
+                ]),
+                ttl: Some(300),
+                audience: Some(ISSUER.to_owned()),
+                subject: Some("scope-valid-user".to_owned()),
+                user_pub_key: None,
+                dpop_jkt: None,
+                issuer: None,
+            })
+            .await?
+            .token;
+        let valid_exchange = post_form(
+            &app,
+            "/oauth/token",
+            &[
+                (
+                    "grant_type",
+                    "urn:ietf:params:oauth:grant-type:token-exchange",
+                ),
+                ("client_id", CLIENT_ID),
+                ("subject_token", &valid_exchange_subject),
+                (
+                    "subject_token_type",
+                    "urn:ietf:params:oauth:token-type:access_token",
+                ),
+                ("scope", "read:*:*"),
+                ("audience", ISSUER),
+            ],
+            None,
+            false,
+        )
+        .await;
+        assert_eq!(valid_exchange.status(), axum::http::StatusCode::OK);
+        let valid_exchange_json = response_json(valid_exchange).await;
+        let valid_exchange_claims =
+            jwt_claims(valid_exchange_json["access_token"].as_str().unwrap());
+        assert_eq!(valid_exchange_claims["sub"], "scope-valid-user");
+        assert_eq!(valid_exchange_claims["scope"], "read:*:*");
 
         // The real composite token minted above authenticates to a protected
         // OAuth route. This failed when middleware routed every JWT through

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -274,13 +274,7 @@ async fn oauth_self_protected_resource_metadata(
 
     let mut meta = protected_resource_metadata(&resource, &issuer_url);
     meta.resource_name = Some("HyprStream OAuth 2.1 Authorization Server".to_owned());
-    meta.scopes_supported = Some(vec![
-        "openid".into(),
-        "read:*:*".into(),
-        "write:*:*".into(),
-        "infer:model:*".into(),
-        "pds:attach".into(),
-    ]);
+    meta.scopes_supported = Some(self_resource_scopes());
 
     // Include the QUIC TLS cert hash so browsers can pin the self-signed certificate.
     if let Ok((cert_chain, _)) = config.quic.load_tls_materials() {
@@ -290,6 +284,21 @@ async fn oauth_self_protected_resource_metadata(
     }
 
     axum::Json(meta)
+}
+
+/// Scopes advertised by the OAuth service's own RFC 9728 protected-resource
+/// document. Includes the atproto transition scopes (#1113) so stock atproto
+/// clients can discover them at the resource (PDS = its own AS).
+fn self_resource_scopes() -> Vec<String> {
+    vec![
+        "openid".into(),
+        "read:*:*".into(),
+        "write:*:*".into(),
+        "infer:model:*".into(),
+        "pds:attach".into(),
+        "atproto".into(),
+        "transition:generic".into(),
+    ]
 }
 
 /// OAuth 2.1 Authorization Server service.
@@ -1042,6 +1051,26 @@ mod tests {
         assert_eq!(
             meta.bearer_methods_supported.as_deref(),
             Some(&["header".to_owned()][..])
+        );
+    }
+
+    /// #1113: the PDS is its own AS, so the self protected-resource document
+    /// must advertise the atproto transition scopes AND point
+    /// `authorization_servers` at itself (resource == issuer).
+    #[test]
+    fn test_self_protected_resource_advertises_atproto_profile() {
+        // PDS = its own AS: resource and authorization_servers[0] are the same.
+        let issuer = "https://pds.example.com";
+        let meta = protected_resource_metadata(issuer, issuer);
+        assert_eq!(meta.resource, issuer);
+        assert_eq!(meta.authorization_servers, vec![issuer.to_owned()]);
+
+        // atproto transition scopes are advertised.
+        let scopes = self_resource_scopes();
+        assert!(scopes.contains(&"atproto".to_owned()), "missing atproto: {scopes:?}");
+        assert!(
+            scopes.contains(&"transition:generic".to_owned()),
+            "missing transition:generic: {scopes:?}"
         );
     }
 

--- a/crates/hyprstream/src/services/oauth/oidc_callback.rs
+++ b/crates/hyprstream/src/services/oauth/oidc_callback.rs
@@ -490,6 +490,7 @@ pub async fn external_callback(
         expires_at: Instant::now() + Duration::from_secs(60),
         username: mapped_subject,
         verifying_key: None, // external OIDC — no local Ed25519 key binding
+        dpop_jkt: None, // external OIDC flow — no PAR DPoP binding
     };
     state.pending_codes.write().await.insert(code.clone(), auth_code);
 

--- a/crates/hyprstream/src/services/oauth/oidc_callback.rs
+++ b/crates/hyprstream/src/services/oauth/oidc_callback.rs
@@ -491,6 +491,7 @@ pub async fn external_callback(
         username: mapped_subject,
         verifying_key: None, // external OIDC — no local Ed25519 key binding
         dpop_jkt: None, // external OIDC flow — no PAR DPoP binding
+        client_assertion_jkt: None, // external OIDC flow — no PAR client-auth binding
     };
     state.pending_codes.write().await.insert(code.clone(), auth_code);
 

--- a/crates/hyprstream/src/services/oauth/oidc_callback.rs
+++ b/crates/hyprstream/src/services/oauth/oidc_callback.rs
@@ -549,7 +549,7 @@ async fn provision_federated_user(
         external_id: external_claims["sub"].as_str().map(str::to_owned),
         atproto_did: None,
     };
-    if let Err(e) = store.set_profile(subject, profile).await {
+    if let Err(e) = store.set_profile(subject, profile.into()).await {
         tracing::warn!(subject = %subject, error = %e, "Failed to set profile for federated user");
     }
 

--- a/crates/hyprstream/src/services/oauth/oidc_callback.rs
+++ b/crates/hyprstream/src/services/oauth/oidc_callback.rs
@@ -547,6 +547,7 @@ async fn provision_federated_user(
         email_verified: external_claims["email_verified"].as_bool(),
         active: Some(true),
         external_id: external_claims["sub"].as_str().map(str::to_owned),
+        atproto_did: None,
     };
     if let Err(e) = store.set_profile(subject, profile).await {
         tracing::warn!(subject = %subject, error = %e, "Failed to set profile for federated user");

--- a/crates/hyprstream/src/services/oauth/par.rs
+++ b/crates/hyprstream/src/services/oauth/par.rs
@@ -228,7 +228,8 @@ pub async fn push_authorization_request(
                 );
             }
         };
-        let par_endpoint = format!("{}/oauth/par", state.issuer_url.trim_end_matches('/'));
+        let atproto_issuer = state.atproto_issuer_url();
+        let par_endpoint = format!("{}/oauth/par", atproto_issuer.trim_end_matches('/'));
         match super::dpop::verify_dpop_proof(&dpop_header, "POST", &par_endpoint, None) {
             Ok(proof) => {
                 // Record the jkt so future token-endpoint proofs from this

--- a/crates/hyprstream/src/services/oauth/par.rs
+++ b/crates/hyprstream/src/services/oauth/par.rs
@@ -192,7 +192,7 @@ pub async fn push_authorization_request(
     let require_atproto = super::state::atproto_profile_active(&requested_scopes);
     let granted_scopes = match super::state::validate_requested_scopes(
         &requested_scopes,
-        &state.default_scopes,
+        &state.server_supported_scopes(),
         if client_declared.is_empty() { None } else { Some(&client_declared) },
         require_atproto,
     ) {

--- a/crates/hyprstream/src/services/oauth/par.rs
+++ b/crates/hyprstream/src/services/oauth/par.rs
@@ -57,6 +57,14 @@ pub struct ParForm {
     pub resource: Option<String>,
     #[serde(default)]
     pub nonce: Option<String>,
+    /// RFC 7523 client assertion — REQUIRED at PAR for confidential
+    /// (`private_key_jwt`) clients: the atproto OAuth profile authenticates
+    /// confidential clients during the authorization request, which for a
+    /// PAR-mandatory profile is here (#1146 T3.3).
+    #[serde(default)]
+    pub client_assertion: Option<String>,
+    #[serde(default)]
+    pub client_assertion_type: Option<String>,
 }
 
 /// PAR success response body (RFC 9126 §2.2).
@@ -209,6 +217,61 @@ pub async fn push_authorization_request(
     // string into the stored snapshot so authorize/token see the exact set.
     let granted_scope_str = granted_scopes.join(" ");
 
+    // #1146 T3.3 (+T1.2): authenticate confidential clients at PAR. The
+    // atproto OAuth profile authenticates confidential clients during the
+    // authorization request — which, for a PAR-mandatory profile, is here.
+    // The assertion audience is the AS ISSUER (atproto mandate; the token
+    // endpoint additionally accepts the RFC 7523 endpoint-URL form, PAR
+    // does not). The verified key's RFC 7638 thumbprint is bound into the
+    // snapshot so token redemption and refresh must use the SAME key.
+    let client_assertion_jkt = {
+        let needs_auth = super::client_auth::requires_private_key_jwt(&registered_client);
+        let has_assertion =
+            form.client_assertion.is_some() && form.client_assertion_type.is_some();
+        if needs_auth && !has_assertion {
+            return par_error(
+                StatusCode::UNAUTHORIZED,
+                "invalid_client",
+                Some("client_assertion required"),
+            );
+        }
+        if has_assertion {
+            let assertion = form.client_assertion.as_deref().unwrap_or_else(|| unreachable!());
+            let atype = form
+                .client_assertion_type
+                .as_deref()
+                .unwrap_or_else(|| unreachable!());
+            let issuer = state.issuer_for_scopes(&granted_scopes);
+            match super::client_auth::verify_client_assertion(
+                &state,
+                &registered_client,
+                atype,
+                assertion,
+                std::slice::from_ref(&issuer),
+            )
+            .await
+            {
+                Ok(verified) => Some(verified.key_jkt),
+                Err(e) => {
+                    // Opaque response, detailed log — same rationale as
+                    // the token endpoint's invalid_client handling.
+                    tracing::warn!(
+                        client_id = %form.client_id,
+                        error = %e,
+                        "client_assertion verification failed at PAR"
+                    );
+                    return par_error(
+                        StatusCode::UNAUTHORIZED,
+                        "invalid_client",
+                        None,
+                    );
+                }
+            }
+        } else {
+            None
+        }
+    };
+
     // #1113 rev2 finding 3: atproto profile requires DPoP. Capture and verify
     // the DPoP proof at PAR, bind its `jkt` into the authorization request so
     // the token endpoint can require a proof from the SAME key. Non-atproto
@@ -269,6 +332,7 @@ pub async fn push_authorization_request(
         resource: form.resource,
         nonce: form.nonce,
         dpop_jkt: dpop_jkt.clone(),
+        client_assertion_jkt,
     };
 
     // Generate a random URN. RFC 9126 §2.2 / atproto OAuth use the standard

--- a/crates/hyprstream/src/services/oauth/par.rs
+++ b/crates/hyprstream/src/services/oauth/par.rs
@@ -23,7 +23,7 @@ use std::time::Instant;
 
 use axum::{
     extract::State,
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
     Form, Json,
 };
@@ -96,6 +96,7 @@ fn par_error(status: StatusCode, error: &'static str, description: Option<&str>)
 /// client should navigate the browser to via `/oauth/authorize?request_uri=...`.
 pub async fn push_authorization_request(
     State(state): State<Arc<OAuthState>>,
+    req_headers: HeaderMap,
     Form(form): Form<ParForm>,
 ) -> Response {
     // Validate response_type
@@ -124,9 +125,9 @@ pub async fn push_authorization_request(
     }
 
     // Resolve client (CIMD or dynamically registered) and pull redirect URIs.
-    let redirect_uris = if form.client_id.starts_with("https://") {
+    let registered_client = if form.client_id.starts_with("https://") {
         match resolve_cimd_client(&state, &form.client_id).await {
-            Ok(client) => client.redirect_uris,
+            Ok(client) => Some(client),
             Err(e) => {
                 // The resolver's error spans federation:register policy
                 // denial, PolicyService RPC outage, and CIMD doc fetch
@@ -148,7 +149,7 @@ pub async fn push_authorization_request(
     } else {
         let clients = state.clients.read().await;
         match clients.get(&form.client_id) {
-            Some(client) => client.redirect_uris.clone(),
+            Some(client) => Some(client.clone()),
             None => {
                 return par_error(
                     StatusCode::BAD_REQUEST,
@@ -159,13 +160,101 @@ pub async fn push_authorization_request(
         }
     };
 
-    if !validate_redirect_uri(&form.redirect_uri, &redirect_uris) {
+    let registered_client = match registered_client {
+        Some(c) => c,
+        None => {
+            return par_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_client",
+                None,
+            );
+        }
+    };
+
+    if !validate_redirect_uri(&form.redirect_uri, &registered_client.redirect_uris) {
         return par_error(
             StatusCode::BAD_REQUEST,
             "invalid_redirect_uri",
             Some("redirect_uri does not match registered URIs"),
         );
     }
+
+    // #1113 rev2 finding 4: validate requested scope against server-supported
+    // ∩ client-declared. Garbage / undeclared tokens → invalid_scope.
+    let requested_scopes: Vec<String> = form
+        .scope
+        .as_deref()
+        .unwrap_or(&state.default_scopes.join(" "))
+        .split_whitespace()
+        .map(str::to_owned)
+        .collect();
+    let client_declared = registered_client.declared_scopes();
+    let require_atproto = super::state::atproto_profile_active(&requested_scopes);
+    let granted_scopes = match super::state::validate_requested_scopes(
+        &requested_scopes,
+        &state.default_scopes,
+        if client_declared.is_empty() { None } else { Some(&client_declared) },
+        require_atproto,
+    ) {
+        Ok(g) => g,
+        Err(_) => {
+            return par_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_scope",
+                Some("Requested scope is not supported or not declared by the client"),
+            );
+        }
+    };
+    // `atproto` activates the strict profile — echo back the granted scope
+    // string into the stored snapshot so authorize/token see the exact set.
+    let granted_scope_str = granted_scopes.join(" ");
+
+    // #1113 rev2 finding 3: atproto profile requires DPoP. Capture and verify
+    // the DPoP proof at PAR, bind its `jkt` into the authorization request so
+    // the token endpoint can require a proof from the SAME key. Non-atproto
+    // requests keep DPoP optional (RFC 9449 general behavior).
+    let dpop_jkt = if require_atproto {
+        let dpop_header = req_headers
+            .get("DPoP")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned);
+        let dpop_header = match dpop_header {
+            Some(h) => h,
+            None => {
+                return par_error(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_request",
+                    Some("atproto profile requires a DPoP proof header"),
+                );
+            }
+        };
+        let par_endpoint = format!("{}/oauth/par", state.issuer_url.trim_end_matches('/'));
+        match super::dpop::verify_dpop_proof(&dpop_header, "POST", &par_endpoint, None) {
+            Ok(proof) => {
+                // Record the jkt so future token-endpoint proofs from this
+                // key are nonce-bound (RFC 9449 §8). Single-use jti check.
+                if !state.check_and_record_dpop_jti(&proof.jti, proof.iat) {
+                    return par_error(
+                        StatusCode::BAD_REQUEST,
+                        "invalid_dpop_proof",
+                        Some("DPoP proof jti already used"),
+                    );
+                }
+                state.mark_dpop_client_nonced(&proof.jkt).await;
+                Some(proof.jkt)
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "DPoP proof verification failed at PAR");
+                return par_error(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_dpop_proof",
+                    None,
+                );
+            }
+        }
+    } else {
+        None
+    };
 
     // Build the AuthorizeParams snapshot to store.
     let params = AuthorizeParams {
@@ -175,9 +264,10 @@ pub async fn push_authorization_request(
         code_challenge_method: form.code_challenge_method,
         response_type: form.response_type,
         state: form.state,
-        scope: form.scope,
+        scope: Some(granted_scope_str),
         resource: form.resource,
         nonce: form.nonce,
+        dpop_jkt: dpop_jkt.clone(),
     };
 
     // Generate a random URN. RFC 9126 §2.2 / atproto OAuth use the standard
@@ -196,12 +286,27 @@ pub async fn push_authorization_request(
         },
     );
 
-    (
+    // #1113 rev2 finding 3: when DPoP was bound, issue a fresh server nonce
+    // and return it in the `DPoP-Nonce` header so the client can include it
+    // in subsequent proofs (matches the atproto client's PAR response handling).
+    let dpop_nonce = if dpop_jkt.is_some() {
+        Some(state.issue_dpop_nonce().await)
+    } else {
+        None
+    };
+
+    let mut resp = (
         StatusCode::CREATED,
         Json(ParResponse {
             request_uri,
             expires_in: PAR_TTL_SECS,
         }),
     )
-        .into_response()
+        .into_response();
+    if let Some(nonce) = dpop_nonce {
+        if let Ok(val) = axum::http::HeaderValue::from_str(&nonce) {
+            resp.headers_mut().insert("DPoP-Nonce", val);
+        }
+    }
+    resp
 }

--- a/crates/hyprstream/src/services/oauth/registration.rs
+++ b/crates/hyprstream/src/services/oauth/registration.rs
@@ -62,6 +62,11 @@ pub struct RegistrationRequest {
     /// deployments use it to associate the OAuth device grant with the host.
     #[serde(default)]
     pub hyprstream_node_did: Option<String>,
+    /// Space-separated scope tokens this client intends to request (RFC 7591 /
+    /// RFC 6749 §3.3). Stored verbatim and enforced as the upper bound on
+    /// requested scopes at PAR/authorize (#1113 rev2 finding 4).
+    #[serde(default)]
+    pub scope: Option<String>,
 }
 
 /// Dynamic client registration response (RFC 7591 §3.2.1).
@@ -85,6 +90,8 @@ pub struct RegistrationResponse {
     pub jwks: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub jwks_uri: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
 }
 
 /// POST /oauth/register — Dynamic Client Registration (RFC 7591)
@@ -201,6 +208,7 @@ pub async fn register_client(
         jwks: req.jwks.clone(),
         jwks_uri: req.jwks_uri.clone(),
         hyprstream_node_did: req.hyprstream_node_did.clone(),
+        scope: req.scope.clone(),
         is_cimd: false,
         registered_at: Instant::now(),
     };
@@ -236,6 +244,7 @@ pub async fn register_client(
         token_endpoint_auth_method: req.token_endpoint_auth_method,
         jwks: req.jwks,
         jwks_uri: req.jwks_uri,
+        scope: req.scope,
     }).into_response()
 }
 
@@ -482,6 +491,7 @@ pub async fn fetch_client_metadata(
             jwks: doc.jwks,
             jwks_uri: doc.jwks_uri,
             hyprstream_node_did: None,
+            scope: None,
             is_cimd: true,
             registered_at: Instant::now(),
         },
@@ -669,6 +679,7 @@ mod tests {
             token_endpoint_auth_method: None,
             jwks: None,
             jwks_uri: None,
+            scope: None,
         };
         let json = serde_json::to_value(&resp).unwrap();
         let obj = json.as_object().unwrap();

--- a/crates/hyprstream/src/services/oauth/registration.rs
+++ b/crates/hyprstream/src/services/oauth/registration.rs
@@ -209,6 +209,8 @@ pub async fn register_client(
         jwks_uri: req.jwks_uri.clone(),
         hyprstream_node_did: req.hyprstream_node_did.clone(),
         scope: req.scope.clone(),
+        // DCR (RFC 7591) requests do not carry this atproto CIMD field.
+        dpop_bound_access_tokens: None,
         is_cimd: false,
         registered_at: Instant::now(),
     };
@@ -269,6 +271,46 @@ pub struct ClientIdMetadataDocument {
     pub jwks: Option<serde_json::Value>,
     #[serde(default)]
     pub jwks_uri: Option<String>,
+    /// Space-separated scope tokens the client declares (RFC 7591 §2 /
+    /// CIMD §4). Enforced as the ceiling on requested scopes at
+    /// PAR/authorize — without this a fetched CIMD client could request
+    /// any server-supported scope (#1146 T1.1).
+    #[serde(default)]
+    pub scope: Option<String>,
+    /// atproto OAuth: confidential clients declare
+    /// `dpop_bound_access_tokens: true`. Parsed and retained; enforcement
+    /// is follow-up work (#1146 T1.1).
+    #[serde(default)]
+    pub dpop_bound_access_tokens: Option<bool>,
+}
+
+/// Convert a validated Client ID Metadata Document into a
+/// [`RegisteredClient`]. Carries the declared `scope` ceiling and
+/// `dpop_bound_access_tokens` flag — dropping them here is what silently
+/// disabled the client-declared scope ceiling for fetched clients
+/// (#1146 T1.1). Factored out of [`fetch_client_metadata`] so the
+/// mapping is unit-testable without a live HTTP fetch.
+pub(crate) fn registered_client_from_cimd_doc(
+    client_id_url: &str,
+    doc: ClientIdMetadataDocument,
+) -> RegisteredClient {
+    RegisteredClient {
+        client_id: client_id_url.to_owned(),
+        redirect_uris: doc.redirect_uris,
+        client_name: doc.client_name,
+        client_uri: doc.client_uri,
+        logo_uri: doc.logo_uri,
+        grant_types: doc.grant_types,
+        response_types: doc.response_types,
+        token_endpoint_auth_method: doc.token_endpoint_auth_method,
+        jwks: doc.jwks,
+        jwks_uri: doc.jwks_uri,
+        hyprstream_node_did: None,
+        scope: doc.scope,
+        dpop_bound_access_tokens: doc.dpop_bound_access_tokens,
+        is_cimd: true,
+        registered_at: Instant::now(),
+    }
 }
 
 /// Resolve a CIMD client: cache-aside lookup, fetch on miss.
@@ -479,22 +521,7 @@ pub async fn fetch_client_metadata(
     }
 
     Ok((
-        RegisteredClient {
-            client_id: client_id_url.to_owned(),
-            redirect_uris: doc.redirect_uris,
-            client_name: doc.client_name,
-            client_uri: doc.client_uri,
-            logo_uri: doc.logo_uri,
-            grant_types: doc.grant_types,
-            response_types: doc.response_types,
-            token_endpoint_auth_method: doc.token_endpoint_auth_method,
-            jwks: doc.jwks,
-            jwks_uri: doc.jwks_uri,
-            hyprstream_node_did: None,
-            scope: None,
-            is_cimd: true,
-            registered_at: Instant::now(),
-        },
+        registered_client_from_cimd_doc(client_id_url, doc),
         max_age,
     ))
 }
@@ -653,6 +680,44 @@ mod tests {
         });
         let doc: ClientIdMetadataDocument = serde_json::from_value(json).unwrap();
         assert!(doc.client_name.is_none());
+    }
+
+    /// #1146 T1.1: a fetched CIMD document's declared `scope` MUST survive
+    /// into the `RegisteredClient` — dropping it silently disabled the
+    /// client-declared scope ceiling for the fetched-metadata path.
+    #[test]
+    fn cimd_scope_ceiling_carried_into_registered_client() {
+        let json = serde_json::json!({
+            "client_id": "https://app.example.com/client.json",
+            "redirect_uris": ["https://app.example.com/cb"],
+            "scope": "atproto",
+            "dpop_bound_access_tokens": true,
+        });
+        let doc: ClientIdMetadataDocument = serde_json::from_value(json).unwrap();
+        let client =
+            registered_client_from_cimd_doc("https://app.example.com/client.json", doc);
+        assert!(client.is_cimd);
+        assert_eq!(client.scope.as_deref(), Some("atproto"));
+        assert_eq!(client.declared_scopes(), vec!["atproto".to_owned()]);
+        assert_eq!(client.dpop_bound_access_tokens, Some(true));
+    }
+
+    /// #1146 T1.1: a CIMD document with no `scope` field declares no
+    /// client-side ceiling (`None` → unrestricted), distinct from an
+    /// explicit declaration.
+    #[test]
+    fn cimd_without_scope_declares_no_ceiling() {
+        let json = serde_json::json!({
+            "client_id": "https://app.example.com/client.json",
+            "redirect_uris": ["https://app.example.com/cb"],
+        });
+        let doc: ClientIdMetadataDocument = serde_json::from_value(json).unwrap();
+        assert!(doc.scope.is_none());
+        assert!(doc.dpop_bound_access_tokens.is_none());
+        let client =
+            registered_client_from_cimd_doc("https://app.example.com/client.json", doc);
+        assert!(client.scope.is_none());
+        assert!(client.declared_scopes().is_empty());
     }
 
     #[test]

--- a/crates/hyprstream/src/services/oauth/rpc_handler.rs
+++ b/crates/hyprstream/src/services/oauth/rpc_handler.rs
@@ -63,6 +63,7 @@ impl OAuthRpcHandler {
             email_verified: info.email_verified,
             active: info.active,
             external_id: info.external_id.clone().unwrap_or_default(),
+            atproto_did: info.atproto_did.clone(),
             pubkeys: info.pubkeys.iter().map(|pk| crate::services::generated::oauth_client::PubkeyEntry {
                 fingerprint: pk.fingerprint.clone(),
                 pubkey_base64: pk.pubkey_base64.clone(),

--- a/crates/hyprstream/src/services/oauth/rpc_handler.rs
+++ b/crates/hyprstream/src/services/oauth/rpc_handler.rs
@@ -173,6 +173,7 @@ impl OauthHandler for OAuthRpcHandler {
             email: data.email.as_ref().filter(|s| !s.is_empty()).map(|s| Some(s.clone())),
             external_id: data.external_id.as_ref().filter(|s| !s.is_empty()).map(|s| Some(s.clone())),
             email_verified: None,
+            atproto_did: None,
         };
         match svc.update(&data.username, update).await {
             Ok(info) => Ok(OauthResponseVariant::UpdateUserResult(Self::user_info_to_rpc(&info))),

--- a/crates/hyprstream/src/services/oauth/scim.rs
+++ b/crates/hyprstream/src/services/oauth/scim.rs
@@ -318,6 +318,7 @@ pub async fn create_user(
             email: email.map(Some),
             external_id: external_id.map(Some),
             email_verified: None,
+            atproto_did: None,
         };
         if let Err(e) = svc.update(&user_name, update).await {
             return scim_error_simple(500, &e.to_string());
@@ -412,6 +413,7 @@ pub async fn replace_user(
         email: email.map(Some),
         external_id: external_id.map(Some),
         email_verified: None,
+            atproto_did: None,
     };
 
     match svc.update(&info.username, update).await {

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -181,6 +181,47 @@ mod tests {
 
         assert!(public.is_none());
     }
+
+    /// #1113: a local username maps to a `did:web` subject so the access
+    /// token `sub` is the account DID — what atproto clients expect.
+    #[test]
+    fn subject_did_for_local_username_is_did_web() {
+        let did = subject_did_for("https://pds.example.com", "alice").unwrap();
+        assert_eq!(did, "did:web:pds.example.com:users:alice");
+    }
+
+    /// #1113: loopback/dev issuers preserve the port in the did:web authority.
+    #[test]
+    fn subject_did_for_loopback_preserves_port() {
+        let did = subject_did_for("http://127.0.0.1:6791", "alice").unwrap();
+        assert_eq!(did, "did:web:127.0.0.1:6791:users:alice");
+    }
+
+    /// #1113: supported atproto account DIDs (`did:plc`, `did:web`) from an
+    /// external mapper pass through unchanged — never double-wrapped.
+    #[test]
+    fn subject_did_for_supported_account_did_passthrough() {
+        for did in ["did:plc:xyz123", "did:web:foo.com:users:bob"] {
+            assert_eq!(subject_did_for("https://pds.example.com", did).unwrap(), did);
+        }
+    }
+
+    /// #1113 correction: `did:at9p` (and other non-plc/non-web DID methods)
+    /// are NOT eligible for atproto OAuth tokens — subject derivation fails
+    /// closed so the token path rejects issuance.
+    #[test]
+    fn subject_did_for_at9p_fails_closed() {
+        let err = subject_did_for("https://pds.example.com", "did:at9p:abc").unwrap_err();
+        assert!(matches!(err, SubjectDidError::UnsupportedMethod));
+    }
+
+    /// #1113: a username that would corrupt a did:web path is rejected rather
+    /// than producing a malformed DID.
+    #[test]
+    fn subject_did_for_path_corrupting_username_rejected() {
+        let err = subject_did_for("https://pds.example.com", "alice/bob").unwrap_err();
+        assert!(matches!(err, SubjectDidError::IncompatibleUsername));
+    }
 }
 
 /// A pending authorization code awaiting token exchange.
@@ -833,6 +874,21 @@ impl OAuthState {
         self.dpop_clients_seen.write().await.insert(jkt.to_owned(), expiry);
     }
 
+    /// Derive the JWT `sub` claim for an atproto-conformant access token.
+    ///
+    /// atproto OAuth requires the access token's `sub` to be the account's
+    /// DID. Locally enrolled users are addressed by username, so we synthesize
+    /// a `did:web:{authority}:users:{username}` subject — mirroring the
+    /// external-OIDC `DidWeb` mapping in [`super::user_mapping`]. Subjects
+    /// that already carry a supported atproto account DID (`did:plc`,
+    /// `did:web`) pass through unchanged. `did:at9p` and other DID methods
+    /// are NOT eligible for atproto OAuth tokens and return
+    /// [`SubjectDidError::UnsupportedMethod`] so the caller fails closed
+    /// (#1113 correction).
+    pub fn subject_did(&self, local_subject: &str) -> Result<String, SubjectDidError> {
+        subject_did_for(&self.issuer_url, local_subject)
+    }
+
     /// Attach an RSA key for RS256 id_token signing (OIDC interop).
     ///
     /// `rsa_der` is the PKCS#8 DER-encoded RSA private key.
@@ -916,4 +972,52 @@ impl OAuthState {
             }
         });
     }
+}
+
+/// Derive the atproto-conformant DID `sub` for a local subject (#1113).
+///
+/// Free-function form of [`OAuthState::subject_did`] so the mapping is
+/// unit-testable without constructing a full `OAuthState`.
+///
+/// **atproto account DID methods (#1113 correction):** only `did:plc` and
+/// `did:web` are eligible subjects for atproto OAuth tokens. `did:at9p` (and
+/// any other DID method) is rejected via [`SubjectDidError::UnsupportedMethod`]
+/// — the token path fails closed rather than minting a token for an
+/// ineligible subject.
+pub fn subject_did_for(
+    issuer_url: &str,
+    local_subject: &str,
+) -> Result<String, SubjectDidError> {
+    // did:plc and did:web are the supported atproto account DIDs — pass through.
+    if local_subject.starts_with("did:plc:") || local_subject.starts_with("did:web:") {
+        return Ok(local_subject.to_owned());
+    }
+    // Any other did: method (notably did:at9p) is NOT eligible for atproto
+    // OAuth tokens — fail closed (#1113 correction).
+    if local_subject.starts_with("did:") {
+        return Err(SubjectDidError::UnsupportedMethod);
+    }
+    let authority = super::user_mapping::extract_authority(issuer_url)
+        .map_err(|_| SubjectDidError::InvalidIssuer)?;
+    // did:web path segments are colon-separated; reject usernames that would
+    // corrupt the DID (mirrors user_mapping::DidWeb validation).
+    if local_subject.contains(['#', '?', '/']) {
+        return Err(SubjectDidError::IncompatibleUsername);
+    }
+    Ok(format!("did:web:{authority}:users:{local_subject}"))
+}
+
+/// Errors raised by [`subject_did_for`] / [`OAuthState::subject_did`].
+#[derive(Debug, thiserror::Error)]
+pub enum SubjectDidError {
+    /// The subject carries a DID method that is not eligible for atproto
+    /// OAuth tokens (e.g. `did:at9p`). The token path fails closed.
+    #[error("DID method not eligible for atproto OAuth tokens")]
+    UnsupportedMethod,
+    /// The issuer URL could not be parsed into a did:web authority.
+    #[error("invalid issuer URL for did:web subject")]
+    InvalidIssuer,
+    /// The local username contains characters that would corrupt a did:web path.
+    #[error("local username incompatible with did:web path")]
+    IncompatibleUsername,
 }

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -3,20 +3,20 @@
 //! Manages registered clients, pending authorization codes, refresh tokens,
 //! and delegates token issuance to PolicyService via ZMQ.
 
+use anyhow::Context as _;
+use base64::Engine as _;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use anyhow::Context as _;
-use base64::Engine as _;
 use tokio::sync::RwLock;
-use serde::{Deserialize, Serialize};
 
+use super::token_store::TokenStore;
+use super::user_service::UserService;
 use crate::auth::user_store::UserStore;
 use crate::config::OAuthConfig;
 use crate::services::{DiscoveryClient, PolicyClient};
 use hyprstream_util::TtlCache;
-use super::token_store::TokenStore;
-use super::user_service::UserService;
 
 /// Extract RSA public key components (n, e) from PKCS#8 DER and build a JWK.
 ///
@@ -34,9 +34,13 @@ fn extract_rsa_jwk_from_der(pkcs8_der: &[u8], kid: &str) -> Option<serde_json::V
 
     let output = std::process::Command::new("openssl")
         .args([
-            "pkey", "-inform", "DER", "-in",
+            "pkey",
+            "-inform",
+            "DER",
+            "-in",
             temp.path().to_str()?,
-            "-noout", "-text",
+            "-noout",
+            "-text",
         ])
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())
@@ -63,9 +67,7 @@ fn extract_rsa_jwk_from_der(pkcs8_der: &[u8], kid: &str) -> Option<serde_json::V
         }
         if in_modulus {
             // Lines like "    00:ab:cd:..."
-            let hex_part: String = trimmed.chars()
-                .filter(char::is_ascii_hexdigit)
-                .collect();
+            let hex_part: String = trimmed.chars().filter(char::is_ascii_hexdigit).collect();
             n_hex.push_str(&hex_part);
         }
     }
@@ -179,8 +181,114 @@ pub struct AuthorizeBinding {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use crate::auth::user_store::UserProfile;
+    use async_trait::async_trait;
     use hyprstream_rpc::crypto::CryptoPolicy;
     use rand::rngs::OsRng;
+
+    fn state_with_user_store(store: Arc<dyn UserStore>) -> OAuthState {
+        use hyprstream_rpc::rpc_client::RpcClientImpl;
+        use hyprstream_rpc::signer::LocalSigner;
+        use hyprstream_rpc::transport::lazy_uds::LazyUdsTransport;
+
+        let signing_key = ed25519_dalek::SigningKey::from_bytes(&[0x41; 32]);
+        let remote_key = ed25519_dalek::SigningKey::from_bytes(&[0x42; 32]).verifying_key();
+        let make_client = || {
+            Arc::new(
+                RpcClientImpl::new(
+                    LocalSigner::new(signing_key.clone()),
+                    LazyUdsTransport::new("/dev/null/oauth-eligibility-test.sock".into()),
+                    Some(remote_key),
+                )
+                .with_response_verify_policy(CryptoPolicy::Classical),
+            )
+        };
+        let mut config = OAuthConfig::default();
+        config.external_url = Some("https://pds.example.test".to_owned());
+        OAuthState::new(
+            &config,
+            PolicyClient::new(make_client()),
+            DiscoveryClient::new(make_client()),
+            signing_key.verifying_key().to_bytes(),
+        )
+        .with_user_store(store)
+    }
+
+    struct KeyReadErrorStore {
+        profile: UserProfile,
+    }
+
+    #[async_trait]
+    impl UserStore for KeyReadErrorStore {
+        async fn get_profile(&self, _username: &str) -> anyhow::Result<Option<UserProfile>> {
+            Ok(Some(self.profile.clone()))
+        }
+
+        async fn register(&self, _username: &str) -> anyhow::Result<String> {
+            anyhow::bail!("not used")
+        }
+
+        async fn set_profile(&self, _username: &str, _profile: UserProfile) -> anyhow::Result<()> {
+            anyhow::bail!("not used")
+        }
+
+        async fn remove(&self, _username: &str) -> anyhow::Result<bool> {
+            anyhow::bail!("not used")
+        }
+
+        async fn list_users(&self) -> Vec<String> {
+            Vec::new()
+        }
+
+        async fn search(
+            &self,
+            _filter: &crate::auth::user_store::UserFilter,
+        ) -> anyhow::Result<Vec<(String, UserProfile)>> {
+            anyhow::bail!("not used")
+        }
+
+        async fn set_active(&self, _username: &str, _active: bool) -> anyhow::Result<()> {
+            anyhow::bail!("not used")
+        }
+
+        async fn list_pubkeys(
+            &self,
+            _username: &str,
+        ) -> anyhow::Result<Vec<crate::auth::user_store::PubkeyEntry>> {
+            anyhow::bail!("synthetic key read failure")
+        }
+
+        async fn add_pubkey(
+            &self,
+            _username: &str,
+            _pubkey: ed25519_dalek::VerifyingKey,
+            _label: Option<String>,
+        ) -> anyhow::Result<String> {
+            anyhow::bail!("not used")
+        }
+
+        async fn add_pubkey_hybrid(
+            &self,
+            _username: &str,
+            _pubkey: ed25519_dalek::VerifyingKey,
+            _ml_dsa_vk: Vec<u8>,
+            _label: Option<String>,
+        ) -> anyhow::Result<String> {
+            anyhow::bail!("not used")
+        }
+
+        async fn remove_pubkey(&self, _username: &str, _fingerprint: &str) -> anyhow::Result<bool> {
+            anyhow::bail!("not used")
+        }
+
+        async fn get_pubkey_user(&self, _fingerprint: &str) -> anyhow::Result<Option<String>> {
+            anyhow::bail!("not used")
+        }
+
+        async fn touch_pubkey(&self, _username: &str, _fingerprint: &str) -> anyhow::Result<()> {
+            anyhow::bail!("not used")
+        }
+    }
 
     #[test]
     fn mesh_kem_derivation_failure_fails_closed_under_hybrid() {
@@ -329,12 +437,91 @@ mod tests {
         assert_eq!(err, SubjectDidError::At9pBackedAccount);
     }
 
+    /// #1113 r5: the default production backend must retain the mapped DID,
+    /// and the real account lookup (keys + profile) must reach the success
+    /// path after closing and reopening RocksDB.
+    #[tokio::test]
+    async fn atproto_eligibility_succeeds_after_rocksdb_roundtrip() {
+        use crate::auth::rocksdb_store::RocksDbUserStore;
+        use crate::auth::user_store::UserProfile;
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+        let signing_key = ed25519_dalek::SigningKey::from_bytes(&[0x33; 32]);
+        {
+            let store = RocksDbUserStore::open(dir.path()).unwrap();
+            store.register("alice").await.unwrap();
+            store
+                .add_pubkey(
+                    "alice",
+                    signing_key.verifying_key(),
+                    Some("login".to_owned()),
+                )
+                .await
+                .unwrap();
+            store
+                .set_profile(
+                    "alice",
+                    UserProfile {
+                        atproto_did: Some("did:plc:abcdefghijklmnqrstuvwx2p".to_owned()),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .unwrap();
+        }
+
+        let reopened: Arc<dyn UserStore> = Arc::new(RocksDbUserStore::open(dir.path()).unwrap());
+        assert_eq!(
+            reopened
+                .get_profile("alice")
+                .await
+                .unwrap()
+                .unwrap()
+                .atproto_did
+                .as_deref(),
+            Some("did:plc:abcdefghijklmnqrstuvwx2p")
+        );
+        let state = state_with_user_store(reopened);
+        assert_eq!(
+            state
+                .check_atproto_account_eligibility("alice")
+                .await
+                .unwrap(),
+            "did:plc:abcdefghijklmnqrstuvwx2p"
+        );
+    }
+
+    /// #1113 r5: a profile read that would otherwise succeed cannot mask a
+    /// key-store failure. The account is rejected rather than downgraded to
+    /// an apparently keyless identity.
+    #[tokio::test]
+    async fn atproto_eligibility_key_read_error_fails_closed() {
+        let store = Arc::new(KeyReadErrorStore {
+            profile: UserProfile {
+                atproto_did: Some("did:plc:abcdefghijklmnqrstuvwx2p".to_owned()),
+                ..Default::default()
+            },
+        });
+        let state = state_with_user_store(store);
+        assert_eq!(
+            state
+                .check_atproto_account_eligibility("alice")
+                .await
+                .unwrap_err(),
+            SubjectDidError::NoAtprotoIdentity
+        );
+    }
+
     /// #1113 rev2 finding 7: atproto profile activates only when `atproto` is
     /// in the granted set — device/generic flows without it stay non-atproto.
     #[test]
     fn atproto_profile_detection() {
         assert!(atproto_profile_active(&["atproto".to_owned()]));
-        assert!(atproto_profile_active(&["atproto".to_owned(), "read:*:*".to_owned()]));
+        assert!(atproto_profile_active(&[
+            "atproto".to_owned(),
+            "read:*:*".to_owned()
+        ]));
         assert!(!atproto_profile_active(&["read:*:*".to_owned()]));
         assert!(!atproto_profile_active(&[]));
     }
@@ -344,7 +531,11 @@ mod tests {
     /// yield invalid_scope and the actual granted set is returned.
     #[test]
     fn validate_requested_scopes_rejects_garbage() {
-        let server = ["atproto".to_owned(), "transition:generic".to_owned(), "read:*:*".to_owned()];
+        let server = [
+            "atproto".to_owned(),
+            "transition:generic".to_owned(),
+            "read:*:*".to_owned(),
+        ];
         let res = validate_requested_scopes(
             &["atproto".to_owned(), "bogus".to_owned()],
             &server,
@@ -358,7 +549,11 @@ mod tests {
     /// with server-supported, intersected with the client's declared scopes.
     #[test]
     fn validate_requested_scopes_intersects_client_declared() {
-        let server = ["atproto".to_owned(), "transition:generic".to_owned(), "read:*:*".to_owned()];
+        let server = [
+            "atproto".to_owned(),
+            "transition:generic".to_owned(),
+            "read:*:*".to_owned(),
+        ];
         let declared = ["atproto".to_owned(), "read:*:*".to_owned()];
         let granted = validate_requested_scopes(
             &["atproto".to_owned(), "read:*:*".to_owned()],
@@ -569,10 +764,6 @@ pub struct RefreshTokenEntry {
     /// keeps the generic OAuth 2.1 rotation path unchanged.
     #[serde(default)]
     pub ucan_grant: Option<UcanGrantRefresh>,
-    /// DPoP key thumbprint bound at issuance (#1113 rev2 F3). The refresh
-    /// path requires a proof from the SAME key for atproto-scoped tokens.
-    #[serde(default)]
-    pub dpop_jkt: Option<String>,
 }
 
 /// Re-evaluation context persisted alongside a UCAN-grant refresh token so the
@@ -776,9 +967,8 @@ fn mesh_kem_public_for_policy(
 ) -> anyhow::Result<Option<hyprstream_rpc::crypto::hybrid_kem::RecipientPublic>> {
     match derive(key) {
         Ok(kem_kp) => Ok(Some(kem_kp.public())),
-        Err(e) if policy.uses_pq() => Err(e).context(
-            "failed to derive #mesh-kem hybrid keyAgreement identity under Hybrid policy",
-        ),
+        Err(e) if policy.uses_pq() => Err(e)
+            .context("failed to derive #mesh-kem hybrid keyAgreement identity under Hybrid policy"),
         Err(e) => {
             tracing::warn!(
                 error = %e,
@@ -797,7 +987,12 @@ impl OAuthState {
     /// Inline reap budget per access (heap pops). Bounds tail latency.
     const DPOP_JTI_REAP_BUDGET: usize = 64;
 
-    pub fn new(config: &OAuthConfig, policy_client: PolicyClient, discovery_client: DiscoveryClient, verifying_key_bytes: [u8; 32]) -> Self {
+    pub fn new(
+        config: &OAuthConfig,
+        policy_client: PolicyClient,
+        discovery_client: DiscoveryClient,
+        verifying_key_bytes: [u8; 32],
+    ) -> Self {
         Self {
             clients: RwLock::new(HashMap::new()),
             pending_authorize_bindings: RwLock::new(HashMap::new()),
@@ -833,7 +1028,9 @@ impl OAuthState {
             signing_key: None,
             authority_hints: config.authority_hints.clone(),
             pending_external_auths: RwLock::new(HashMap::new()),
-            oidc_discovery: std::sync::Arc::new(super::oidc_discovery::OidcDiscoveryCache::default()),
+            oidc_discovery: std::sync::Arc::new(
+                super::oidc_discovery::OidcDiscoveryCache::default(),
+            ),
             sessions: super::session::SessionStore::default(),
             xrpc_repos: Arc::new(super::xrpc::XrpcRepoStore::new()),
             xrpc_read_slice: config.xrpc_read_slice,
@@ -938,7 +1135,10 @@ impl OAuthState {
     /// When set, `POST /oauth/revoke` on access tokens writes the JTI into
     /// this blocklist so the PolicyService RPC enforcement path also rejects
     /// revoked tokens — closing the gap between HTTP revocation and RPC auth.
-    pub fn with_jti_blocklist(mut self, bl: Arc<hyprstream_rpc::auth::InMemoryJtiBlocklist>) -> Self {
+    pub fn with_jti_blocklist(
+        mut self,
+        bl: Arc<hyprstream_rpc::auth::InMemoryJtiBlocklist>,
+    ) -> Self {
         self.jti_blocklist = Some(bl);
         self
     }
@@ -1011,7 +1211,8 @@ impl OAuthState {
         policy: hyprstream_rpc::crypto::CryptoPolicy,
     ) -> anyhow::Result<Self> {
         let pq_sk = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&key);
-        self.mesh_pq_verifying_key = Some(hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(&pq_sk));
+        self.mesh_pq_verifying_key =
+            Some(hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(&pq_sk));
         self.mesh_kem_public = mesh_kem_public_for_policy(&key, policy, |key| {
             hyprstream_rpc::node_identity::derive_mesh_kem_recipient(key)
         })?;
@@ -1025,7 +1226,12 @@ impl OAuthState {
     }
 
     /// Persist a refresh token entry to the store.
-    pub async fn put_refresh_token(&self, token: &str, entry: &RefreshTokenEntry, ttl_secs: u64) -> anyhow::Result<()> {
+    pub async fn put_refresh_token(
+        &self,
+        token: &str,
+        entry: &RefreshTokenEntry,
+        ttl_secs: u64,
+    ) -> anyhow::Result<()> {
         let Some(ref store) = self.token_db else {
             tracing::warn!("Refresh token store not configured — token will not survive restart");
             return Ok(());
@@ -1034,7 +1240,10 @@ impl OAuthState {
     }
 
     /// Look up a refresh token. Returns `None` if not found or expired (lazy expiry).
-    pub async fn get_refresh_token(&self, token: &str) -> anyhow::Result<Option<RefreshTokenEntry>> {
+    pub async fn get_refresh_token(
+        &self,
+        token: &str,
+    ) -> anyhow::Result<Option<RefreshTokenEntry>> {
         let Some(ref store) = self.token_db else {
             return Ok(None);
         };
@@ -1107,7 +1316,10 @@ impl OAuthState {
     /// window per nonce TTL).
     pub async fn mark_dpop_client_nonced(&self, jkt: &str) {
         let expiry = chrono::Utc::now().timestamp() + 300;
-        self.dpop_clients_seen.write().await.insert(jkt.to_owned(), expiry);
+        self.dpop_clients_seen
+            .write()
+            .await
+            .insert(jkt.to_owned(), expiry);
     }
 
     /// Validate the JWT `sub` claim for an atproto-conformant access token
@@ -1142,17 +1354,19 @@ impl OAuthState {
         &self,
         username: &str,
     ) -> Result<String, SubjectDidError> {
-        let user_store = self.user_store_reader().ok_or(SubjectDidError::NoAtprotoIdentity)?;
+        let user_store = self
+            .user_store_reader()
+            .ok_or(SubjectDidError::NoAtprotoIdentity)?;
 
-        let pubkeys = user_store
-            .list_pubkeys(username)
-            .await
-            .unwrap_or_default();
-        let profile = user_store
-            .get_profile(username)
-            .await
-            .ok()
-            .flatten();
+        // Fail closed: a malformed/transient key-store read must never be
+        // reinterpreted as "this account has no keys". Doing so can hide a
+        // HybridEd25519MlDsa65 (at9p) binding and incorrectly admit a mapped
+        // profile to the atproto OAuth profile.
+        let pubkeys = user_store.list_pubkeys(username).await.map_err(|error| {
+            tracing::warn!(%username, %error, "atproto eligibility key lookup failed closed");
+            SubjectDidError::NoAtprotoIdentity
+        })?;
+        let profile = user_store.get_profile(username).await.ok().flatten();
 
         evaluate_atproto_eligibility(&pubkeys, profile.as_ref(), &self.issuer_url)
     }
@@ -1240,7 +1454,11 @@ impl OAuthState {
                     // dpop_jti_seen is a TtlCache (self-evicting); sweep the
                     // nonce + client-dedup maps only.
                     state.dpop_nonces.write().await.retain(|_, exp| *exp > now);
-                    state.dpop_clients_seen.write().await.retain(|_, exp| *exp > now);
+                    state
+                        .dpop_clients_seen
+                        .write()
+                        .await
+                        .retain(|_, exp| *exp > now);
                 }
 
                 // Sweep expired external auth flows
@@ -1272,7 +1490,10 @@ pub fn evaluate_atproto_eligibility(
     use crate::auth::user_store::KeyAlgorithm;
 
     // 1. Reject at9p-backed accounts by inspecting the key algorithm.
-    if pubkeys.iter().any(|pk| pk.algorithm == KeyAlgorithm::HybridEd25519MlDsa65) {
+    if pubkeys
+        .iter()
+        .any(|pk| pk.algorithm == KeyAlgorithm::HybridEd25519MlDsa65)
+    {
         return Err(SubjectDidError::At9pBackedAccount);
     }
 
@@ -1302,10 +1523,7 @@ pub fn evaluate_atproto_eligibility(
 /// validation, not a string-prefix match — an at9p-backed account whose
 /// enrolled identifier is a plain username is rejected just like any other
 /// non-DID subject.
-pub fn subject_did_for(
-    _issuer_url: &str,
-    subject: &str,
-) -> Result<String, SubjectDidError> {
+pub fn subject_did_for(_issuer_url: &str, subject: &str) -> Result<String, SubjectDidError> {
     // did:plc — the only non-`did:web` atproto method. A valid did:plc
     // identifier has exactly 24 chars of base32-lowercase (a-z, 2-7), per
     // the atproto PLC spec. The vendored @atproto/did schema rejects shorter

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -133,9 +133,14 @@ pub struct RegisteredClient {
     pub hyprstream_node_did: Option<String>,
     /// Space-separated scope tokens the client declared at registration
     /// (RFC 7591 / RFC 6749 §3.3). Requested scopes at PAR/authorize are
-    /// validated as a subset of this (#1113 rev2). `None` for legacy/CIMD
-    /// clients → treated as "no client-side restriction".
+    /// validated as a subset of this (#1113 rev2). `None` → treated as
+    /// "no client-side restriction" (the client declared no ceiling).
     pub scope: Option<String>,
+    /// atproto OAuth: confidential clients set `dpop_bound_access_tokens:
+    /// true` in their metadata document. Parsed and retained here (#1146);
+    /// enforcement (rejecting confidential clients that omit it on the
+    /// atproto profile) is follow-up work.
+    pub dpop_bound_access_tokens: Option<bool>,
     /// True if this client was registered via Client ID Metadata Document (HTTPS URL client_id)
     pub is_cimd: bool,
     pub registered_at: Instant,
@@ -541,6 +546,7 @@ mod tests {
                 resource: None,
                 nonce: None,
                 dpop_jkt: None,
+                client_assertion_jkt: None,
             },
         };
         let now = Instant::now();
@@ -692,6 +698,11 @@ pub struct PendingAuthCode {
     /// atproto profile is active, the token endpoint must receive a DPoP
     /// proof from the same key.
     pub dpop_jkt: Option<String>,
+    /// RFC 7638 thumbprint of the client-assertion key verified at PAR
+    /// (#1146 T3.3). When set, the token endpoint must receive a
+    /// `client_assertion` signed by the same key, and the binding is
+    /// carried into the issued refresh token.
+    pub client_assertion_jkt: Option<String>,
 }
 
 impl PendingAuthCode {
@@ -786,6 +797,13 @@ pub struct RefreshTokenEntry {
     /// this exact key; it is carried forward during refresh-token rotation.
     #[serde(default)]
     pub dpop_jkt: Option<String>,
+    /// RFC 7638 thumbprint of the client-assertion key this session was
+    /// issued under (#1146 T3.3). When set, refresh requires a
+    /// `client_assertion` verified by the same key — refresh cannot switch
+    /// to another registered key, and removing the key from the client's
+    /// JWKS revokes the session. Carried forward during rotation.
+    #[serde(default)]
+    pub client_assertion_jkt: Option<String>,
     /// Present only for UCAN-grant refresh tokens (`client_id` `ucan-grant:{sub}`).
     ///
     /// MAC #547 / B1 (#673): refresh of a UCAN grant is NOT a free re-mint — the
@@ -915,6 +933,11 @@ pub struct OAuthState {
     /// the shared `TtlCache` with atomic check-and-record — see
     /// `check_and_record_dpop_jti`. TTL = iat + 120s per entry.
     pub dpop_jti_seen: TtlCache<String, ()>,
+    /// Seen client-assertion JTIs for replay prevention (RFC 7523 §3 /
+    /// atproto OAuth; #1146 T3.3). Keyed `{client_id}\u{1f}{jti}`; TTL =
+    /// the assertion's remaining `exp` lifetime. See
+    /// `check_and_record_assertion_jti`.
+    pub assertion_jti_seen: TtlCache<String, ()>,
     /// Server-issued DPoP nonces. Value = expiry unix timestamp.
     pub dpop_nonces: RwLock<HashMap<String, i64>>,
     /// Per-client (keyed by DPoP `jkt` thumbprint) nonce-issuance state.
@@ -1016,6 +1039,11 @@ impl OAuthState {
     const DPOP_JTI_MAX_ENTRIES: usize = 10_000;
     /// Inline reap budget per access (heap pops). Bounds tail latency.
     const DPOP_JTI_REAP_BUDGET: usize = 64;
+    /// Client-assertion jti replay-dedup cache: same bounds as the DPoP
+    /// registry; per-entry TTL is the assertion's remaining lifetime.
+    const ASSERTION_JTI_MAX_ENTRIES: usize = 10_000;
+    /// Inline reap budget per access (heap pops). Bounds tail latency.
+    const ASSERTION_JTI_REAP_BUDGET: usize = 64;
 
     pub fn new(
         config: &OAuthConfig,
@@ -1063,6 +1091,10 @@ impl OAuthState {
             rsa_jwk: None,
             rsa_kid: None,
             dpop_jti_seen: TtlCache::new(Self::DPOP_JTI_MAX_ENTRIES, Self::DPOP_JTI_REAP_BUDGET),
+            assertion_jti_seen: TtlCache::new(
+                Self::ASSERTION_JTI_MAX_ENTRIES,
+                Self::ASSERTION_JTI_REAP_BUDGET,
+            ),
             dpop_nonces: RwLock::new(HashMap::new()),
             dpop_clients_seen: RwLock::new(HashMap::new()),
             trusted_issuers: config.trusted_issuers.clone(),
@@ -1303,6 +1335,27 @@ impl OAuthState {
         let ttl_secs = ((iat + 120) - now).max(0) as u64;
         self.dpop_jti_seen
             .insert_if_absent(jti.to_owned(), (), Duration::from_secs(ttl_secs))
+    }
+
+    /// Check a client-assertion JTI for replay and record it if new
+    /// (#1146 T3.3; RFC 7523 §3 — an AS MUST NOT accept the same `jti`
+    /// more than once).
+    ///
+    /// Keyed by `{client_id}\u{1f}{jti}` so distinct clients cannot
+    /// collide on the same identifier. The entry lives until the
+    /// assertion's own `exp`, after which a replayed assertion would be
+    /// rejected as expired anyway.
+    ///
+    /// Returns `true` when the JTI is fresh (caller should proceed);
+    /// `false` when it was seen within its validity window (replay).
+    pub fn check_and_record_assertion_jti(&self, client_id: &str, jti: &str, exp: i64) -> bool {
+        let now = chrono::Utc::now().timestamp();
+        let ttl_secs = (exp - now).max(0) as u64;
+        self.assertion_jti_seen.insert_if_absent(
+            format!("{client_id}\u{1f}{jti}"),
+            (),
+            Duration::from_secs(ttl_secs),
+        )
     }
 
     /// Issue a fresh server-side DPoP nonce (RFC 9449 §8).

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -169,12 +169,11 @@ impl PushedAuthRequest {
 }
 
 /// Server-side state stashed between `authorize_get` and `authorize_post`,
-/// keyed by the consent nonce (#1113 rev2). Carries the PAR-bound DPoP key
-/// thumbprint so it reaches the token endpoint without crossing the browser.
-#[derive(Debug, Clone, Default)]
+/// keyed by the consent nonce. Carries the complete resolved authorization
+/// request so hidden form fields never become mutable authority on POST.
+#[derive(Debug, Clone)]
 pub struct AuthorizeBinding {
-    /// DPoP `jkt` verified at PAR. `None` for non-PAR / non-DPoP requests.
-    pub dpop_jkt: Option<String>,
+    pub request: super::authorize::AuthorizeParams,
 }
 
 #[cfg(test)]
@@ -228,7 +227,7 @@ mod tests {
             anyhow::bail!("not used")
         }
 
-        async fn set_profile(&self, _username: &str, _profile: UserProfile) -> anyhow::Result<()> {
+        async fn set_profile(&self, _username: &str, _profile: crate::auth::UserProfilePatch) -> anyhow::Result<()> {
             anyhow::bail!("not used")
         }
 
@@ -465,7 +464,7 @@ mod tests {
                     UserProfile {
                         atproto_did: Some("did:plc:abcdefghijklmnqrstuvwx2p".to_owned()),
                         ..Default::default()
-                    },
+                    }.into(),
                 )
                 .await
                 .unwrap();
@@ -524,6 +523,40 @@ mod tests {
         ]));
         assert!(!atproto_profile_active(&["read:*:*".to_owned()]));
         assert!(!atproto_profile_active(&[]));
+    }
+
+    #[tokio::test]
+    async fn authorize_binding_sweep_tracks_live_nonces() {
+        let store = Arc::new(KeyReadErrorStore { profile: UserProfile::default() });
+        let state = state_with_user_store(store);
+        let binding = AuthorizeBinding {
+            request: crate::services::oauth::authorize::AuthorizeParams {
+                client_id: "client".to_owned(),
+                redirect_uri: "https://client.example/callback".to_owned(),
+                code_challenge: "challenge".to_owned(),
+                code_challenge_method: "S256".to_owned(),
+                response_type: "code".to_owned(),
+                state: None,
+                scope: Some("read:*:*".to_owned()),
+                resource: None,
+                nonce: None,
+                dpop_jkt: None,
+            },
+        };
+        let now = Instant::now();
+        state.pending_nonces.write().await.insert("live".to_owned(), now + Duration::from_secs(60));
+        state.pending_nonces.write().await.insert("expired".to_owned(), now - Duration::from_secs(1));
+        let mut bindings = state.pending_authorize_bindings.write().await;
+        bindings.insert("live".to_owned(), binding.clone());
+        bindings.insert("expired".to_owned(), binding.clone());
+        bindings.insert("orphan".to_owned(), binding);
+        drop(bindings);
+
+        state.sweep_authorize_sessions(now).await;
+
+        let bindings = state.pending_authorize_bindings.read().await;
+        assert_eq!(bindings.len(), 1);
+        assert!(bindings.contains_key("live"));
     }
 
     /// #1113 rev2 finding 4: requested scopes are validated against the
@@ -817,11 +850,8 @@ pub struct OAuthState {
     /// Pending authorize nonces (single-use, 5-min TTL).
     /// Proves a nonce was issued by this server and hasn't been replayed.
     pub pending_nonces: RwLock<HashMap<String, Instant>>,
-    /// Server-side authorize-session bindings keyed by the consent nonce:
-    /// carries the PAR-bound `dpop_jkt` (#1113 rev2 finding 3) so the
-    /// DPoP key bound at PAR reaches `authorize_post` without crossing the
-    /// browser (a hidden form field would be client-controlled). Consumed
-    /// single-use alongside the nonce.
+    /// Complete resolved authorization requests, keyed and consumed alongside
+    /// the consent nonce so browser-carried fields are never authority.
     pub pending_authorize_bindings: RwLock<HashMap<String, AuthorizeBinding>>,
     /// Pending Pushed Authorization Requests (RFC 9126), keyed by `request_uri`.
     /// Single-use, 60s TTL. In-memory is correct here — no value to persistence.
@@ -1009,12 +1039,7 @@ impl OAuthState {
             token_db: None,
             policy_client,
             discovery_client,
-            // #1113 rev2 F5: canonicalize to exact origin (scheme://host[:port])
-            // so ALL emissions — token claims, metadata, redirect iss, userinfo
-            // endpoint — use the normalized origin, not raw external_url which
-            // may carry a trailing slash or path.
-            issuer_url: canonical_issuer_origin(&config.issuer_url())
-                .unwrap_or_else(|| config.issuer_url()),
+            issuer_url: config.issuer_url(),
             default_scopes: config.default_scopes.clone(),
             token_ttl: config.token_ttl_seconds,
             refresh_token_ttl: config.refresh_token_ttl_seconds,
@@ -1336,6 +1361,20 @@ impl OAuthState {
         subject_did_for(&self.issuer_url, subject)
     }
 
+    /// Origin-only issuer required by the atproto OAuth profile.
+    pub fn atproto_issuer_url(&self) -> String {
+        canonical_issuer_origin(&self.issuer_url).unwrap_or_else(|| self.issuer_url.clone())
+    }
+
+    /// Select the issuer used at a profile-sensitive mint/redirect boundary.
+    pub fn issuer_for_scopes(&self, scopes: &[String]) -> String {
+        if atproto_profile_active(scopes) {
+            self.atproto_issuer_url()
+        } else {
+            self.issuer_url.clone()
+        }
+    }
+
     /// Check whether an account is eligible for the atproto OAuth profile
     /// and return the account's mapped atproto DID (#1113 r5 / #1124 split).
     ///
@@ -1421,12 +1460,8 @@ impl OAuthState {
                     codes.retain(|_, code| !code.is_expired());
                 }
 
-                // Sweep expired authorize nonces (5-min TTL)
-                {
-                    let now = Instant::now();
-                    let mut nonces = state.pending_nonces.write().await;
-                    nonces.retain(|_, expiry| *expiry > now);
-                }
+                // Sweep expired authorize nonces and their request snapshots.
+                state.sweep_authorize_sessions(Instant::now()).await;
 
                 // Sweep expired PAR requests (60s TTL)
                 {
@@ -1472,6 +1507,13 @@ impl OAuthState {
                 state.sessions.sweep().await;
             }
         });
+    }
+
+    async fn sweep_authorize_sessions(&self, now: Instant) {
+        let mut nonces = self.pending_nonces.write().await;
+        nonces.retain(|_, expiry| *expiry > now);
+        let mut bindings = self.pending_authorize_bindings.write().await;
+        bindings.retain(|nonce, _| nonces.contains_key(nonce));
     }
 }
 

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -207,45 +207,58 @@ mod tests {
         assert!(public.is_none());
     }
 
-    /// #1113: a local username maps to a `did:web` subject so the access
-    /// token `sub` is the account DID — what atproto clients expect.
+    /// #1113 rev2 / #1124: a local username has NO atproto identity →
+    /// rejected (fail closed). Synthesizing a path-form did:web is
+    /// spec-invalid and was removed; provisioning is tracked in #1124.
     #[test]
-    fn subject_did_for_local_username_is_did_web() {
-        let did = subject_did_for("https://pds.example.com", "alice").unwrap();
-        assert_eq!(did, "did:web:pds.example.com:users:alice");
+    fn subject_did_for_local_username_rejected() {
+        let err = subject_did_for("https://pds.example.com", "alice").unwrap_err();
+        assert_eq!(err, SubjectDidError::NoAtprotoIdentity);
     }
 
-    /// #1113: loopback/dev issuers preserve the port in the did:web authority.
+    /// #1113 rev2: a valid `did:plc` is accepted (real atproto account DID).
     #[test]
-    fn subject_did_for_loopback_preserves_port() {
-        let did = subject_did_for("http://127.0.0.1:6791", "alice").unwrap();
-        assert_eq!(did, "did:web:127.0.0.1:6791:users:alice");
+    fn subject_did_for_did_plc_accepted() {
+        assert_eq!(
+            subject_did_for("https://x", "did:plc:abc123xyz").unwrap(),
+            "did:plc:abc123xyz"
+        );
     }
 
-    /// #1113: supported atproto account DIDs (`did:plc`, `did:web`) from an
-    /// external mapper pass through unchanged — never double-wrapped.
+    /// #1113 rev2: a host-form `did:web:host[:port]` (NO path) is accepted.
     #[test]
-    fn subject_did_for_supported_account_did_passthrough() {
-        for did in ["did:plc:xyz123", "did:web:foo.com:users:bob"] {
-            assert_eq!(subject_did_for("https://pds.example.com", did).unwrap(), did);
-        }
+    fn subject_did_for_host_form_did_web_accepted() {
+        assert_eq!(
+            subject_did_for("https://x", "did:web:pds.example.com").unwrap(),
+            "did:web:pds.example.com"
+        );
+        assert_eq!(
+            subject_did_for("https://x", "did:web:127.0.0.1:6791").unwrap(),
+            "did:web:127.0.0.1:6791"
+        );
     }
 
-    /// #1113 correction: `did:at9p` (and other non-plc/non-web DID methods)
-    /// are NOT eligible for atproto OAuth tokens — subject derivation fails
-    /// closed so the token path rejects issuance.
+    /// #1113 rev2: a path-form did:web (rejected by the atproto DID profile)
+    /// is rejected — the atproto DID profile forbids path components.
+    #[test]
+    fn subject_did_for_path_form_did_web_rejected() {
+        let err = subject_did_for("https://x", "did:web:pds.example.com:users:alice").unwrap_err();
+        assert_eq!(err, SubjectDidError::PathFormDidWeb);
+    }
+
+    /// #1113 correction: `did:at9p` and other non-plc/non-web DID methods
+    /// are NOT eligible for atproto OAuth tokens.
     #[test]
     fn subject_did_for_at9p_fails_closed() {
         let err = subject_did_for("https://pds.example.com", "did:at9p:abc").unwrap_err();
-        assert!(matches!(err, SubjectDidError::UnsupportedMethod));
+        assert_eq!(err, SubjectDidError::UnsupportedMethod);
     }
 
-    /// #1113: a username that would corrupt a did:web path is rejected rather
-    /// than producing a malformed DID.
+    /// #1113 rev2: a malformed did:plc (empty body) is rejected.
     #[test]
-    fn subject_did_for_path_corrupting_username_rejected() {
-        let err = subject_did_for("https://pds.example.com", "alice/bob").unwrap_err();
-        assert!(matches!(err, SubjectDidError::IncompatibleUsername));
+    fn subject_did_for_malformed_plc_rejected() {
+        let err = subject_did_for("https://x", "did:plc:").unwrap_err();
+        assert_eq!(err, SubjectDidError::MalformedDid);
     }
 
     /// #1113 rev2 finding 7: atproto profile activates only when `atproto` is
@@ -328,6 +341,34 @@ mod tests {
             Some("http://127.0.0.1:6791")
         );
         assert!(canonical_issuer_origin("pds.example.com").is_none());
+    }
+
+    /// #1113 rev2 F4/F6: the default grant set (omitted-scope fallback) must
+    /// NOT include `atproto` — those scopes are supported-but-explicit. A
+    /// client that omits `scope` must NOT silently activate the strict profile.
+    #[test]
+    fn default_scopes_do_not_include_atproto() {
+        let cfg = crate::config::OAuthConfig::default();
+        assert!(
+            !cfg.default_scopes.iter().any(|s| s == "atproto"),
+            "default_scopes must NOT include atproto (supported-but-explicit): {:?}",
+            cfg.default_scopes
+        );
+        // But server_supported_scopes DOES include it.
+        let supported = advertised_scopes_for_test(&cfg.default_scopes);
+        assert!(supported.iter().any(|s| s == "atproto"));
+        assert!(supported.iter().any(|s| s == "transition:generic"));
+    }
+
+    /// Helper mirroring the advertised_scopes logic for test assertions.
+    fn advertised_scopes_for_test(default_scopes: &[String]) -> Vec<String> {
+        let mut scopes = default_scopes.to_vec();
+        for s in &["atproto", "transition:generic"] {
+            if !scopes.iter().any(|x| x == *s) {
+                scopes.push((*s).to_owned());
+            }
+        }
+        scopes
     }
 }
 
@@ -460,6 +501,10 @@ pub struct RefreshTokenEntry {
     /// keeps the generic OAuth 2.1 rotation path unchanged.
     #[serde(default)]
     pub ucan_grant: Option<UcanGrantRefresh>,
+    /// DPoP key thumbprint bound at issuance (#1113 rev2 F3). The refresh
+    /// path requires a proof from the SAME key for atproto-scoped tokens.
+    #[serde(default)]
+    pub dpop_jkt: Option<String>,
 }
 
 /// Re-evaluation context persisted alongside a UCAN-grant refresh token so the
@@ -701,7 +746,12 @@ impl OAuthState {
             token_db: None,
             policy_client,
             discovery_client,
-            issuer_url: config.issuer_url(),
+            // #1113 rev2 F5: canonicalize to exact origin (scheme://host[:port])
+            // so ALL emissions — token claims, metadata, redirect iss, userinfo
+            // endpoint — use the normalized origin, not raw external_url which
+            // may carry a trailing slash or path.
+            issuer_url: canonical_issuer_origin(&config.issuer_url())
+                .unwrap_or_else(|| config.issuer_url()),
             default_scopes: config.default_scopes.clone(),
             token_ttl: config.token_ttl_seconds,
             refresh_token_ttl: config.refresh_token_ttl_seconds,
@@ -992,19 +1042,33 @@ impl OAuthState {
         self.dpop_clients_seen.write().await.insert(jkt.to_owned(), expiry);
     }
 
-    /// Derive the JWT `sub` claim for an atproto-conformant access token.
+    /// Validate the JWT `sub` claim for an atproto-conformant access token
+    /// (#1113 rev2 / #1124 split).
     ///
-    /// atproto OAuth requires the access token's `sub` to be the account's
-    /// DID. Locally enrolled users are addressed by username, so we synthesize
-    /// a `did:web:{authority}:users:{username}` subject — mirroring the
-    /// external-OIDC `DidWeb` mapping in [`super::user_mapping`]. Subjects
-    /// that already carry a supported atproto account DID (`did:plc`,
-    /// `did:web`) pass through unchanged. `did:at9p` and other DID methods
-    /// are NOT eligible for atproto OAuth tokens and return
-    /// [`SubjectDidError::UnsupportedMethod`] so the caller fails closed
-    /// (#1113 correction).
-    pub fn subject_did(&self, local_subject: &str) -> Result<String, SubjectDidError> {
-        subject_did_for(&self.issuer_url, local_subject)
+    /// atproto OAuth requires the access token's `sub` to be a real,
+    /// resolvable atproto account DID: `did:plc:<opaque>` or host-form
+    /// `did:web:<host>[:port]` (NO path component — the atproto DID profile
+    /// rejects `did:web:host:users:alice`). A hyprstream-local account
+    /// (enrolled by Ed25519 username) has no atproto DID yet; provisioning
+    /// is tracked in #1124. Such accounts are REJECTED from the atproto
+    /// profile (fail closed), never minted a spec-invalid path-form alias.
+    pub fn subject_did(&self, subject: &str) -> Result<String, SubjectDidError> {
+        subject_did_for(&self.issuer_url, subject)
+    }
+
+    /// The full set of scopes this AS supports (#1113 rev2 F4).
+    /// Extends `default_scopes` (the omitted-scope grant set) with the
+    /// atproto transition scopes, which are supported-but-explicit: a client
+    /// must request them to activate the strict profile; omitting `scope`
+    /// grants only `default_scopes`.
+    pub fn server_supported_scopes(&self) -> Vec<String> {
+        let mut scopes = self.default_scopes.clone();
+        for atproto_scope in &["atproto", "transition:generic"] {
+            if !scopes.iter().any(|s| s == *atproto_scope) {
+                scopes.push((*atproto_scope).to_owned());
+            }
+        }
+        scopes
     }
 
     /// Attach an RSA key for RS256 id_token signing (OIDC interop).
@@ -1092,52 +1156,84 @@ impl OAuthState {
     }
 }
 
-/// Derive the atproto-conformant DID `sub` for a local subject (#1113).
+/// Validate that a subject is a real, resolvable atproto account DID (#1113
+/// rev2 → #1124 split).
 ///
-/// Free-function form of [`OAuthState::subject_did`] so the mapping is
-/// unit-testable without constructing a full `OAuthState`.
+/// The atproto DID profile (`@atproto/did`) accepts only:
+/// - `did:plc:<opaque>` — the registered PLC-directory form.
+/// - `did:web:<host>[:port]` — the **host-form only** (NO path component);
+///   `did:web:host:users:alice` is explicitly rejected by the atproto DID
+///   profile.
 ///
-/// **atproto account DID methods (#1113 correction):** only `did:plc` and
-/// `did:web` are eligible subjects for atproto OAuth tokens. `did:at9p` (and
-/// any other DID method) is rejected via [`SubjectDidError::UnsupportedMethod`]
-/// — the token path fails closed rather than minting a token for an
-/// ineligible subject.
+/// Hyprstream-local accounts (enrolled by Ed25519 username) do NOT yet carry
+/// a real atproto DID — provisioning one is tracked in #1124. Such accounts
+/// are REJECTED from the atproto profile (fail closed with
+/// [`SubjectDidError::NoAtprotoIdentity`]) rather than being minted a
+/// spec-invalid path-form did:web. This function performs DID-form
+/// validation, not a string-prefix match — an at9p-backed account whose
+/// enrolled identifier is a plain username is rejected just like any other
+/// non-DID subject.
 pub fn subject_did_for(
-    issuer_url: &str,
-    local_subject: &str,
+    _issuer_url: &str,
+    subject: &str,
 ) -> Result<String, SubjectDidError> {
-    // did:plc and did:web are the supported atproto account DIDs — pass through.
-    if local_subject.starts_with("did:plc:") || local_subject.starts_with("did:web:") {
-        return Ok(local_subject.to_owned());
+    // did:plc — the only non-`did:web` atproto method. Pass through a
+    // well-formed `did:plc:` identifier unchanged.
+    if let Some(rest) = subject.strip_prefix("did:plc:") {
+        if !rest.is_empty() && rest.chars().all(|c| c.is_ascii_alphanumeric()) {
+            return Ok(subject.to_owned());
+        }
+        return Err(SubjectDidError::MalformedDid);
     }
-    // Any other did: method (notably did:at9p) is NOT eligible for atproto
-    // OAuth tokens — fail closed (#1113 correction).
-    if local_subject.starts_with("did:") {
+    // did:web — host-form only. The atproto DID profile rejects path
+    // components (`/`-segments encoded as extra colon groups are allowed by
+    // the base did:web spec, but atproto's narrower profile does not). A
+    // host-form did:web has exactly one path segment after the method:
+    // `did:web:<host>[:port]`. Reject `did:web:<host>:users:...` (path form).
+    if let Some(rest) = subject.strip_prefix("did:web:") {
+        if rest.is_empty() {
+            return Err(SubjectDidError::MalformedDid);
+        }
+        // atproto host-form: no `/`, no `:`-delimited path beyond host[:port].
+        // A path-form did:web (e.g. `did:web:host:users:alice`) carries
+        // additional colon segments; reject it.
+        if rest.contains('/') {
+            return Err(SubjectDidError::PathFormDidWeb);
+        }
+        let segment_count = rest.split(':').count();
+        // host[:port] → 1 or 2 segments. ≥3 implies a path form.
+        if segment_count > 2 {
+            return Err(SubjectDidError::PathFormDidWeb);
+        }
+        return Ok(subject.to_owned());
+    }
+    // Any other did: method (did:at9p, did:key, ...) is NOT eligible.
+    if subject.starts_with("did:") {
         return Err(SubjectDidError::UnsupportedMethod);
     }
-    let authority = super::user_mapping::extract_authority(issuer_url)
-        .map_err(|_| SubjectDidError::InvalidIssuer)?;
-    // did:web path segments are colon-separated; reject usernames that would
-    // corrupt the DID (mirrors user_mapping::DidWeb validation).
-    if local_subject.contains(['#', '?', '/']) {
-        return Err(SubjectDidError::IncompatibleUsername);
-    }
-    Ok(format!("did:web:{authority}:users:{local_subject}"))
+    // A non-DID subject (local username) has no atproto identity — fail
+    // closed. Provisioning real DIDs for hosted accounts is tracked in #1124.
+    Err(SubjectDidError::NoAtprotoIdentity)
 }
 
 /// Errors raised by [`subject_did_for`] / [`OAuthState::subject_did`].
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum SubjectDidError {
     /// The subject carries a DID method that is not eligible for atproto
-    /// OAuth tokens (e.g. `did:at9p`). The token path fails closed.
+    /// OAuth tokens (e.g. `did:at9p`, `did:key`). The token path fails closed.
     #[error("DID method not eligible for atproto OAuth tokens")]
     UnsupportedMethod,
-    /// The issuer URL could not be parsed into a did:web authority.
-    #[error("invalid issuer URL for did:web subject")]
-    InvalidIssuer,
-    /// The local username contains characters that would corrupt a did:web path.
-    #[error("local username incompatible with did:web path")]
-    IncompatibleUsername,
+    /// A did:plc/did:web identifier is malformed (empty or illegal body).
+    #[error("malformed atproto DID")]
+    MalformedDid,
+    /// A path-form did:web (e.g. `did:web:host:users:alice`) is rejected by
+    /// the atproto DID profile — only host-form did:web is accepted.
+    #[error("path-form did:web rejected by atproto DID profile")]
+    PathFormDidWeb,
+    /// A non-DID subject (local username) has no atproto identity. Real
+    /// atproto DID provisioning for hosted accounts is tracked in #1124.
+    #[error("account has no atproto identity; provisioning tracked in #1124")]
+    NoAtprotoIdentity,
 }
 
 /// The atproto transition scope name. Its presence in a granted scope set

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -129,9 +129,25 @@ pub struct RegisteredClient {
     /// Optional host `did:key` supplied by a PDS attachment client. Validated
     /// during registration and retained for PDS identity association.
     pub hyprstream_node_did: Option<String>,
+    /// Space-separated scope tokens the client declared at registration
+    /// (RFC 7591 / RFC 6749 §3.3). Requested scopes at PAR/authorize are
+    /// validated as a subset of this (#1113 rev2). `None` for legacy/CIMD
+    /// clients → treated as "no client-side restriction".
+    pub scope: Option<String>,
     /// True if this client was registered via Client ID Metadata Document (HTTPS URL client_id)
     pub is_cimd: bool,
     pub registered_at: Instant,
+}
+
+impl RegisteredClient {
+    /// The client's declared scope tokens, parsed from [`Self::scope`].
+    /// Empty when the client declared no scopes (no client-side restriction).
+    pub fn declared_scopes(&self) -> Vec<String> {
+        self.scope
+            .as_deref()
+            .map(|s| s.split_whitespace().map(str::to_owned).collect())
+            .unwrap_or_default()
+    }
 }
 
 /// A Pushed Authorization Request (RFC 9126) awaiting consumption.
@@ -148,6 +164,15 @@ impl PushedAuthRequest {
     pub fn is_expired(&self) -> bool {
         Instant::now() > self.expires_at
     }
+}
+
+/// Server-side state stashed between `authorize_get` and `authorize_post`,
+/// keyed by the consent nonce (#1113 rev2). Carries the PAR-bound DPoP key
+/// thumbprint so it reaches the token endpoint without crossing the browser.
+#[derive(Debug, Clone, Default)]
+pub struct AuthorizeBinding {
+    /// DPoP `jkt` verified at PAR. `None` for non-PAR / non-DPoP requests.
+    pub dpop_jkt: Option<String>,
 }
 
 #[cfg(test)]
@@ -222,6 +247,88 @@ mod tests {
         let err = subject_did_for("https://pds.example.com", "alice/bob").unwrap_err();
         assert!(matches!(err, SubjectDidError::IncompatibleUsername));
     }
+
+    /// #1113 rev2 finding 7: atproto profile activates only when `atproto` is
+    /// in the granted set — device/generic flows without it stay non-atproto.
+    #[test]
+    fn atproto_profile_detection() {
+        assert!(atproto_profile_active(&["atproto".to_owned()]));
+        assert!(atproto_profile_active(&["atproto".to_owned(), "read:*:*".to_owned()]));
+        assert!(!atproto_profile_active(&["read:*:*".to_owned()]));
+        assert!(!atproto_profile_active(&[]));
+    }
+
+    /// #1113 rev2 finding 4: requested scopes are validated against the
+    /// server-supported ∩ client-declared sets; garbage/undeclared tokens
+    /// yield invalid_scope and the actual granted set is returned.
+    #[test]
+    fn validate_requested_scopes_rejects_garbage() {
+        let server = ["atproto".to_owned(), "transition:generic".to_owned(), "read:*:*".to_owned()];
+        let res = validate_requested_scopes(
+            &["atproto".to_owned(), "bogus".to_owned()],
+            &server,
+            None,
+            true,
+        );
+        assert_eq!(res.unwrap_err(), ScopeError::InvalidScope);
+    }
+
+    /// #1113 rev2 finding 4: the granted set is the intersection of requested
+    /// with server-supported, intersected with the client's declared scopes.
+    #[test]
+    fn validate_requested_scopes_intersects_client_declared() {
+        let server = ["atproto".to_owned(), "transition:generic".to_owned(), "read:*:*".to_owned()];
+        let declared = ["atproto".to_owned(), "read:*:*".to_owned()];
+        let granted = validate_requested_scopes(
+            &["atproto".to_owned(), "read:*:*".to_owned()],
+            &server,
+            Some(&declared),
+            true,
+        )
+        .unwrap();
+        assert_eq!(granted, vec!["atproto".to_owned(), "read:*:*".to_owned()]);
+        // Client did NOT declare transition:generic → requesting it is invalid.
+        let res = validate_requested_scopes(
+            &["atproto".to_owned(), "transition:generic".to_owned()],
+            &server,
+            Some(&declared),
+            true,
+        );
+        assert_eq!(res.unwrap_err(), ScopeError::InvalidScope);
+    }
+
+    /// #1113 rev2 finding 4: when the atproto profile is requested, `atproto`
+    /// MUST survive into the granted set, else AtprotoRequired.
+    #[test]
+    fn validate_requested_scopes_requires_atproto_when_profile_active() {
+        let server = ["atproto".to_owned(), "read:*:*".to_owned()];
+        let res = validate_requested_scopes(&["read:*:*".to_owned()], &server, None, true);
+        assert_eq!(res.unwrap_err(), ScopeError::AtprotoRequired);
+        // Non-atproto request (require_atproto=false) does not require it.
+        let granted =
+            validate_requested_scopes(&["read:*:*".to_owned()], &server, None, false).unwrap();
+        assert_eq!(granted, vec!["read:*:*".to_owned()]);
+    }
+
+    /// #1113 rev2 finding 5: the issuer is canonicalized to an exact origin
+    /// (scheme://host[:port]) — trailing slash and path are stripped so
+    /// endpoint URLs and the token `iss` are well-formed.
+    #[test]
+    fn canonical_issuer_origin_strips_path_and_slash() {
+        assert_eq!(
+            canonical_issuer_origin("https://pds.example.com/").as_deref(),
+            Some("https://pds.example.com")
+        );
+        assert_eq!(
+            canonical_issuer_origin("https://pds.example.com/oauth/par").as_deref(),
+            Some("https://pds.example.com")
+        );
+        assert_eq!(
+            canonical_issuer_origin("http://127.0.0.1:6791").as_deref(),
+            Some("http://127.0.0.1:6791")
+        );
+        assert!(canonical_issuer_origin("pds.example.com").is_none());
+    }
 }
 
 /// A pending authorization code awaiting token exchange.
@@ -244,6 +351,10 @@ pub struct PendingAuthCode {
     /// Ed25519 verifying key verified during challenge-response.
     /// Included in the JWT `pub_key` claim to bind the user's key identity.
     pub verifying_key: Option<ed25519_dalek::VerifyingKey>,
+    /// DPoP key thumbprint bound at PAR (#1113 rev2 finding 3). When the
+    /// atproto profile is active, the token endpoint must receive a DPoP
+    /// proof from the same key.
+    pub dpop_jkt: Option<String>,
 }
 
 impl PendingAuthCode {
@@ -402,6 +513,12 @@ pub struct OAuthState {
     /// Pending authorize nonces (single-use, 5-min TTL).
     /// Proves a nonce was issued by this server and hasn't been replayed.
     pub pending_nonces: RwLock<HashMap<String, Instant>>,
+    /// Server-side authorize-session bindings keyed by the consent nonce:
+    /// carries the PAR-bound `dpop_jkt` (#1113 rev2 finding 3) so the
+    /// DPoP key bound at PAR reaches `authorize_post` without crossing the
+    /// browser (a hidden form field would be client-controlled). Consumed
+    /// single-use alongside the nonce.
+    pub pending_authorize_bindings: RwLock<HashMap<String, AuthorizeBinding>>,
     /// Pending Pushed Authorization Requests (RFC 9126), keyed by `request_uri`.
     /// Single-use, 60s TTL. In-memory is correct here — no value to persistence.
     pub pending_par_requests: RwLock<HashMap<String, super::state::PushedAuthRequest>>,
@@ -570,6 +687,7 @@ impl OAuthState {
     pub fn new(config: &OAuthConfig, policy_client: PolicyClient, discovery_client: DiscoveryClient, verifying_key_bytes: [u8; 32]) -> Self {
         Self {
             clients: RwLock::new(HashMap::new()),
+            pending_authorize_bindings: RwLock::new(HashMap::new()),
             cimd_cache: Arc::new(super::cimd_cache::CimdCache::new(
                 super::cimd_cache::CimdCacheConfig::default(),
             )),
@@ -1020,4 +1138,99 @@ pub enum SubjectDidError {
     /// The local username contains characters that would corrupt a did:web path.
     #[error("local username incompatible with did:web path")]
     IncompatibleUsername,
+}
+
+/// The atproto transition scope name. Its presence in a granted scope set
+/// activates the strict atproto OAuth profile (#1113 rev2): DPoP-mandatory,
+/// DID subject, `token_type: DPoP` response, scope enforcement.
+pub const ATPROTO_SCOPE: &str = "atproto";
+
+/// True when the granted scope set activates the atproto strict profile.
+pub fn atproto_profile_active(scopes: &[String]) -> bool {
+    scopes.iter().any(|s| s == ATPROTO_SCOPE)
+}
+
+/// Normalize a single scope token. RFC 6749 §3.3 scope tokens are `1*(%x21 /
+/// %x23-5B / %x5D-7E)` — no space, no `"`, no control chars. Returns `None`
+/// for tokens that are empty or contain characters outside the allowed set.
+pub fn normalize_scope_token(tok: &str) -> Option<&str> {
+    if tok.is_empty() {
+        return None;
+    }
+    if tok.bytes().all(|b| b >= 0x21 && b != b'"' && b != 0x7f) {
+        Some(tok)
+    } else {
+        None
+    }
+}
+
+/// Validate a requested scope set against the server-supported and (optionally)
+/// client-declared scopes (#1113 rev2 finding 4).
+///
+/// Returns the **actual granted set** (the intersection of requested with the
+/// server-supported set, intersected with `client_declared` when provided),
+/// preserving the server's canonical ordering of the supported scopes.
+///
+/// - Unknown / undeclared / malformed requested tokens yield
+///   [`ScopeError::InvalidScope`] (RFC 6749 §4.1.2.1 / §3.3) so the caller
+///   rejects with `invalid_scope`.
+/// - When `require_atproto` is true (the atproto profile), the granted set
+///   MUST contain [`ATPROTO_SCOPE`]; otherwise [`ScopeError::AtprotoRequired`].
+pub fn validate_requested_scopes(
+    requested: &[String],
+    server_supported: &[String],
+    client_declared: Option<&[String]>,
+    require_atproto: bool,
+) -> Result<Vec<String>, ScopeError> {
+    // The set the client is permitted to ask for.
+    let allowed: Vec<&str> = match client_declared {
+        Some(declared) if !declared.is_empty() => server_supported
+            .iter()
+            .filter(|s| declared.iter().any(|d| d == *s))
+            .map(String::as_str)
+            .collect(),
+        _ => server_supported.iter().map(String::as_str).collect(),
+    };
+
+    let mut granted: Vec<String> = Vec::new();
+    for tok in requested {
+        let tok = normalize_scope_token(tok).ok_or(ScopeError::InvalidScope)?;
+        if !allowed.contains(&tok) {
+            return Err(ScopeError::InvalidScope);
+        }
+        if !granted.iter().any(|g| g == tok) {
+            granted.push(tok.to_owned());
+        }
+    }
+    if require_atproto && !granted.iter().any(|s| s == ATPROTO_SCOPE) {
+        return Err(ScopeError::AtprotoRequired);
+    }
+    Ok(granted)
+}
+
+/// Errors raised by [`validate_requested_scopes`].
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ScopeError {
+    /// A requested scope token is unknown, undeclared by the client, or
+    /// malformed → reject with OAuth `invalid_scope` (RFC 6749 §3.3).
+    #[error("invalid or unsupported scope")]
+    InvalidScope,
+    /// The atproto profile is active but `atproto` is not in the granted set.
+    #[error("atproto scope required for this profile")]
+    AtprotoRequired,
+}
+
+/// Canonicalize an issuer/external URL to an exact origin (scheme://host[:port])
+/// with no trailing slash and no path (#1113 rev2 finding 5). Returns `None`
+/// when the URL has no scheme or authority.
+pub fn canonical_issuer_origin(issuer_url: &str) -> Option<String> {
+    let (scheme, rest) = issuer_url.split_once("://")?;
+    if scheme.is_empty() {
+        return None;
+    }
+    let authority = rest.split('/').next()?;
+    if authority.is_empty() {
+        return None;
+    }
+    Some(format!("{scheme}://{authority}"))
 }

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -270,6 +270,65 @@ mod tests {
         assert_eq!(err, SubjectDidError::MalformedDid);
     }
 
+    /// #1113 r5: a classical account WITH a mapped did:plc succeeds —
+    /// the mapped DID is returned (the positive success path).
+    #[test]
+    fn atproto_eligibility_mapped_did_plc_succeeds() {
+        use crate::auth::user_store::{KeyAlgorithm, PubkeyEntry, UserProfile};
+        let pubkeys = vec![PubkeyEntry {
+            fingerprint: "key1".into(),
+            pubkey: ed25519_dalek::VerifyingKey::from_bytes(&[1u8; 32]).unwrap(),
+            label: None,
+            created_at: 0,
+            last_used_at: None,
+            algorithm: KeyAlgorithm::Ed25519,
+            pq_pubkey: None,
+        }];
+        let mut profile = UserProfile::default();
+        profile.atproto_did = Some("did:plc:abcdefghijklmnqrstuvwx2p".into());
+        let did = evaluate_atproto_eligibility(&pubkeys, Some(&profile), "https://x").unwrap();
+        assert_eq!(did, "did:plc:abcdefghijklmnqrstuvwx2p");
+    }
+
+    /// #1113 r5: a classical account WITHOUT a mapping fails closed.
+    #[test]
+    fn atproto_eligibility_no_mapping_fails_closed() {
+        use crate::auth::user_store::{KeyAlgorithm, PubkeyEntry, UserProfile};
+        let pubkeys = vec![PubkeyEntry {
+            fingerprint: "key1".into(),
+            pubkey: ed25519_dalek::VerifyingKey::from_bytes(&[1u8; 32]).unwrap(),
+            label: None,
+            created_at: 0,
+            last_used_at: None,
+            algorithm: KeyAlgorithm::Ed25519,
+            pq_pubkey: None,
+        }];
+        let profile = UserProfile::default();
+        let err = evaluate_atproto_eligibility(&pubkeys, Some(&profile), "https://x").unwrap_err();
+        assert_eq!(err, SubjectDidError::NoAtprotoIdentity);
+    }
+
+    /// #1113 r5: an at9p-backed account is rejected from the atproto profile
+    /// — inspected via the key mapping, not the subject string.
+    #[test]
+    fn atproto_eligibility_at9p_account_rejected() {
+        use crate::auth::user_store::{KeyAlgorithm, PubkeyEntry, UserProfile};
+        let pubkeys = vec![PubkeyEntry {
+            fingerprint: "pq-key".into(),
+            pubkey: ed25519_dalek::VerifyingKey::from_bytes(&[1u8; 32]).unwrap(),
+            label: None,
+            created_at: 0,
+            last_used_at: None,
+            algorithm: KeyAlgorithm::HybridEd25519MlDsa65,
+            pq_pubkey: Some(vec![0u8; 1952]), // ML-DSA-65 public key bytes
+        }];
+        let mut profile = UserProfile::default();
+        // Even with a mapped DID, the at9p key algorithm rejects first.
+        profile.atproto_did = Some("did:plc:abcdefghijklmnqrstuvwx2p".into());
+        let err = evaluate_atproto_eligibility(&pubkeys, Some(&profile), "https://x").unwrap_err();
+        assert_eq!(err, SubjectDidError::At9pBackedAccount);
+    }
+
     /// #1113 rev2 finding 7: atproto profile activates only when `atproto` is
     /// in the granted set — device/generic flows without it stay non-atproto.
     #[test]
@@ -1066,32 +1125,36 @@ impl OAuthState {
     }
 
     /// Check whether an account is eligible for the atproto OAuth profile
-    /// (#1113 rev2 → #1124 split).
+    /// and return the account's mapped atproto DID (#1113 r5 / #1124 split).
     ///
     /// This inspects the ACCOUNT/KEY MAPPING, not the subject string:
     /// 1. Rejects at9p-backed accounts (any key with
     ///    [`KeyAlgorithm::HybridEd25519MlDsa65`] → [`SubjectDidError::At9pBackedAccount`]).
-    /// 2. Since hyprstream does not yet provision real atproto DIDs for its
-    ///    own accounts (#1124), an account without a mapped DID fails closed
+    /// 2. Looks up the account's MAPPED atproto DID from the profile's
+    ///    `atproto_did` field. If present and valid → returns it (success).
+    /// 3. An account without a mapped DID fails closed
     ///    ([`SubjectDidError::NoAtprotoIdentity`]).
     ///
-    /// When #1124 provisions DIDs, this method will be updated to check the
-    /// durable DID mapping and validate it via [`subject_did_for`].
+    /// PROVISIONING mappings (creating did:plc, etc.) is #1124 — out of scope.
+    /// The LOOKUP + success path exists here so the atproto OAuth profile can
+    /// emit the mapped DID as `sub` when an account has one.
     pub async fn check_atproto_account_eligibility(
         &self,
         username: &str,
     ) -> Result<String, SubjectDidError> {
-        // 1. Inspect the account's enrolled keys for at9p-backed enrollment.
-        if let Some(user_store) = self.user_store_reader() {
-            if let Ok(pubkeys) = user_store.list_pubkeys(username).await {
-                if pubkeys.iter().any(|pk| pk.algorithm.is_hybrid()) {
-                    return Err(SubjectDidError::At9pBackedAccount);
-                }
-            }
-        }
-        // 2. No mapped atproto DID exists for this account yet (#1124).
-        //    Fail closed — do not accept an arbitrary did:plc string as sub.
-        Err(SubjectDidError::NoAtprotoIdentity)
+        let user_store = self.user_store_reader().ok_or(SubjectDidError::NoAtprotoIdentity)?;
+
+        let pubkeys = user_store
+            .list_pubkeys(username)
+            .await
+            .unwrap_or_default();
+        let profile = user_store
+            .get_profile(username)
+            .await
+            .ok()
+            .flatten();
+
+        evaluate_atproto_eligibility(&pubkeys, profile.as_ref(), &self.issuer_url)
     }
 
     /// The full set of scopes this AS supports (#1113 rev2 F4).
@@ -1192,6 +1255,34 @@ impl OAuthState {
             }
         });
     }
+}
+
+/// Evaluate atproto account eligibility from the account's stored keys and
+/// profile (#1113 r5 / #1124 split). Free-function form so it is unit-testable
+/// without constructing an OAuthState or UserStore.
+///
+/// - at9p-backed account (any key with `HybridEd25519MlDsa65`) → reject.
+/// - account with a mapped `atproto_did` on its profile → validate and return.
+/// - account without a mapping → `NoAtprotoIdentity` (fail closed, #1124).
+pub fn evaluate_atproto_eligibility(
+    pubkeys: &[crate::auth::user_store::PubkeyEntry],
+    profile: Option<&crate::auth::user_store::UserProfile>,
+    issuer_url: &str,
+) -> Result<String, SubjectDidError> {
+    use crate::auth::user_store::KeyAlgorithm;
+
+    // 1. Reject at9p-backed accounts by inspecting the key algorithm.
+    if pubkeys.iter().any(|pk| pk.algorithm == KeyAlgorithm::HybridEd25519MlDsa65) {
+        return Err(SubjectDidError::At9pBackedAccount);
+    }
+
+    // 2. Look up the account's MAPPED atproto DID from the profile.
+    if let Some(did) = profile.and_then(|p| p.atproto_did.as_deref()) {
+        return subject_did_for(issuer_url, did);
+    }
+
+    // 3. No mapped atproto DID — fail closed.
+    Err(SubjectDidError::NoAtprotoIdentity)
 }
 
 /// Validate that a subject is a real, resolvable atproto account DID (#1113

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -220,8 +220,8 @@ mod tests {
     #[test]
     fn subject_did_for_did_plc_accepted() {
         assert_eq!(
-            subject_did_for("https://x", "did:plc:abc123xyz").unwrap(),
-            "did:plc:abc123xyz"
+            subject_did_for("https://x", "did:plc:abcdefghijklmnqrstuvwx2p").unwrap(),
+            "did:plc:abcdefghijklmnqrstuvwx2p"
         );
     }
 
@@ -258,6 +258,15 @@ mod tests {
     #[test]
     fn subject_did_for_malformed_plc_rejected() {
         let err = subject_did_for("https://x", "did:plc:").unwrap_err();
+        assert_eq!(err, SubjectDidError::MalformedDid);
+    }
+
+    /// #1113 r4: a SHORT did:plc (e.g. 9 chars) is rejected — @atproto/did
+    /// requires exactly 24 base32 chars. The old fixture `did:plc:abc123xyz`
+    /// passed validation but failed the real schema.
+    #[test]
+    fn subject_did_for_short_plc_rejected() {
+        let err = subject_did_for("https://x", "did:plc:abc123xyz").unwrap_err();
         assert_eq!(err, SubjectDidError::MalformedDid);
     }
 
@@ -1056,6 +1065,35 @@ impl OAuthState {
         subject_did_for(&self.issuer_url, subject)
     }
 
+    /// Check whether an account is eligible for the atproto OAuth profile
+    /// (#1113 rev2 → #1124 split).
+    ///
+    /// This inspects the ACCOUNT/KEY MAPPING, not the subject string:
+    /// 1. Rejects at9p-backed accounts (any key with
+    ///    [`KeyAlgorithm::HybridEd25519MlDsa65`] → [`SubjectDidError::At9pBackedAccount`]).
+    /// 2. Since hyprstream does not yet provision real atproto DIDs for its
+    ///    own accounts (#1124), an account without a mapped DID fails closed
+    ///    ([`SubjectDidError::NoAtprotoIdentity`]).
+    ///
+    /// When #1124 provisions DIDs, this method will be updated to check the
+    /// durable DID mapping and validate it via [`subject_did_for`].
+    pub async fn check_atproto_account_eligibility(
+        &self,
+        username: &str,
+    ) -> Result<String, SubjectDidError> {
+        // 1. Inspect the account's enrolled keys for at9p-backed enrollment.
+        if let Some(user_store) = self.user_store_reader() {
+            if let Ok(pubkeys) = user_store.list_pubkeys(username).await {
+                if pubkeys.iter().any(|pk| pk.algorithm.is_hybrid()) {
+                    return Err(SubjectDidError::At9pBackedAccount);
+                }
+            }
+        }
+        // 2. No mapped atproto DID exists for this account yet (#1124).
+        //    Fail closed — do not accept an arbitrary did:plc string as sub.
+        Err(SubjectDidError::NoAtprotoIdentity)
+    }
+
     /// The full set of scopes this AS supports (#1113 rev2 F4).
     /// Extends `default_scopes` (the omitted-scope grant set) with the
     /// atproto transition scopes, which are supported-but-explicit: a client
@@ -1177,10 +1215,13 @@ pub fn subject_did_for(
     _issuer_url: &str,
     subject: &str,
 ) -> Result<String, SubjectDidError> {
-    // did:plc — the only non-`did:web` atproto method. Pass through a
-    // well-formed `did:plc:` identifier unchanged.
+    // did:plc — the only non-`did:web` atproto method. A valid did:plc
+    // identifier has exactly 24 chars of base32-lowercase (a-z, 2-7), per
+    // the atproto PLC spec. The vendored @atproto/did schema rejects shorter
+    // suffixes like `did:plc:abc123xyz` (9 chars; @atproto/did rejects
+    // anything shorter than 24 base32 chars).
     if let Some(rest) = subject.strip_prefix("did:plc:") {
-        if !rest.is_empty() && rest.chars().all(|c| c.is_ascii_alphanumeric()) {
+        if rest.len() == 24 && rest.chars().all(|c| matches!(c, 'a'..='z' | '2'..='7')) {
             return Ok(subject.to_owned());
         }
         return Err(SubjectDidError::MalformedDid);
@@ -1234,6 +1275,11 @@ pub enum SubjectDidError {
     /// atproto DID provisioning for hosted accounts is tracked in #1124.
     #[error("account has no atproto identity; provisioning tracked in #1124")]
     NoAtprotoIdentity,
+    /// The account is at9p-backed (enrolled with a hybrid PQ key) —
+    /// inspected via the account/key mapping, not the subject string.
+    /// at9p accounts are not eligible for atproto OAuth tokens.
+    #[error("at9p-backed account not eligible for atproto OAuth")]
+    At9pBackedAccount,
 }
 
 /// The atproto transition scope name. Its presence in a granted scope set

--- a/crates/hyprstream/src/services/oauth/token.rs
+++ b/crates/hyprstream/src/services/oauth/token.rs
@@ -823,27 +823,13 @@ async fn issue_token_with_refresh(
     //
     // atproto profile: the access token's `sub` MUST be the account's real
     // atproto DID. The eligibility check inspects the ACCOUNT/KEY MAPPING
-    // (not the subject string): at9p-backed accounts are rejected, and an
-    // account without a mapped atproto DID fails closed (#1124).
+    // (not the subject string): at9p-backed accounts are rejected; an account
+    // with a mapped atproto DID gets that DID as `sub`; an account without a
+    // mapped DID fails closed (#1124). The returned DID is already form-
+    // validated by evaluate_atproto_eligibility → subject_did_for.
     let jwt_sub = if atproto_profile {
         match state.check_atproto_account_eligibility(sub).await {
-            Ok(mapped_did) => {
-                // Future (#1124): the mapped DID is validated by subject_did_for
-                // to ensure it parses as a real atproto DID. Currently this path
-                // is unreachable — check_atproto_account_eligibility always
-                // returns Err(NoAtprotoIdentity) until provisioning lands.
-                match super::state::subject_did_for(&state.issuer_url, &mapped_did) {
-                    Ok(validated) => validated,
-                    Err(e) => {
-                        tracing::warn!(mapped_did = %mapped_did, error = %e, "mapped DID failed form validation");
-                        return token_error(
-                            StatusCode::BAD_REQUEST,
-                            "invalid_request",
-                            Some("account atproto DID failed validation"),
-                        );
-                    }
-                }
-            }
+            Ok(mapped_did) => mapped_did,
             Err(e) => {
                 tracing::warn!(local_subject = %sub, error = %e, "rejecting atproto token issuance: account not eligible");
                 return token_error(

--- a/crates/hyprstream/src/services/oauth/token.rs
+++ b/crates/hyprstream/src/services/oauth/token.rs
@@ -497,6 +497,9 @@ async fn exchange_refresh_token(
         }
     };
 
+    // #1113 rev2 F3: validate client_id and DPoP BEFORE consuming the
+    // single-use refresh token. Consuming first and failing second strands
+    // the legitimate session on a missing/invalid proof.
     if params.client_id != entry.client_id {
         return token_error(
             StatusCode::BAD_REQUEST,
@@ -536,7 +539,7 @@ async fn exchange_refresh_token(
         .await;
     }
 
-    // Verify DPoP before consuming the refresh token. A `use_dpop_nonce`
+    // Verify DPoP before consuming the refresh token. A use_dpop_nonce
     // response must leave the credential available for the RFC 9449 retry.
     let dpop_jkt = match verify_dpop_at_token_endpoint(&state, dpop_header.as_deref()).await {
         None => None,
@@ -552,6 +555,21 @@ async fn exchange_refresh_token(
             "invalid_dpop_proof",
             Some("DPoP proof must use the key bound to this refresh token"),
         );
+    }
+
+    // The atproto profile is always DPoP-mandatory and sender-bound, even if
+    // a malformed legacy refresh entry somehow lacks a stored thumbprint.
+    if super::state::atproto_profile_active(&entry.scopes) {
+        match (&dpop_jkt, &entry.dpop_jkt) {
+            (Some(proof_jkt), Some(bound_jkt)) if proof_jkt == bound_jkt => {}
+            _ => {
+                return token_error(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_dpop_proof",
+                    Some("atproto profile requires a DPoP proof from the key bound at issuance"),
+                );
+            }
+        }
     }
 
     // Atomically claim only after all retryable DPoP validation succeeds.
@@ -814,7 +832,7 @@ async fn issue_token_with_refresh(
                 return token_error(
                     StatusCode::BAD_REQUEST,
                     "invalid_request",
-                    Some("account subject is not eligible for an atproto OAuth token"),
+                    Some("account has no atproto identity; provisioning tracked in #1124"),
                 );
             }
         }
@@ -884,6 +902,7 @@ async fn issue_token_with_refresh(
                     verifying_key_bytes: user_verifying_key.map(|vk| *vk.as_bytes()),
                     dpop_jkt: dpop_jkt.clone(),
                     ucan_grant: None, // generic OAuth refresh; not a UCAN grant (MAC #547 B1)
+                    dpop_jkt: dpop_jkt.clone(), // #1113 rev2 F3: sender-bind the refresh token
                 };
                 if let Err(e) = state.put_refresh_token(&refresh_token, &entry, state.refresh_token_ttl as u64).await {
                     tracing::error!(error = %e, "Failed to persist refresh token");
@@ -1151,22 +1170,31 @@ mod tests {
 
     /// #1113 rev2 finding 1: the atproto token response matches
     /// atprotoOAuthTokenResponseSchema — `token_type: "DPoP"`, a top-level
-    /// `sub` that is a did:plc/did:web, and a scope containing `atproto`.
+    /// `sub` that is a valid atproto DID (did:plc or host-form did:web), and
+    /// a scope containing `atproto`. Uses a valid `did:plc` subject (the
+    /// spec-valid form; path-form did:web is rejected by @atproto/did — #1124).
     #[test]
     fn atproto_token_response_matches_schema_shape() {
         let json = build_token_response_json(
             true,
             "access-jwt",
-            "did:web:pds.example.com:users:alice",
+            "did:plc:abc123xyz",
             "atproto transition:generic",
             3600,
             "rt",
         );
         assert_eq!(json["token_type"].as_str(), Some("DPoP"));
         let sub = json["sub"].as_str().expect("top-level sub required");
+        // Valid atproto DID: did:plc (or host-form did:web with NO path).
         assert!(
-            sub.starts_with("did:plc:") || sub.starts_with("did:web:"),
-            "atproto sub must be an account DID, got {sub}"
+            sub.starts_with("did:plc:") || {
+                if let Some(rest) = sub.strip_prefix("did:web:") {
+                    rest.split(':').count() <= 2 && !rest.contains('/')
+                } else {
+                    false
+                }
+            },
+            "atproto sub must be did:plc or host-form did:web (no path), got {sub}"
         );
         let scope = json["scope"].as_str().expect("scope required");
         assert!(scope.split_whitespace().any(|s| s == "atproto"), "scope missing atproto");

--- a/crates/hyprstream/src/services/oauth/token.rs
+++ b/crates/hyprstream/src/services/oauth/token.rs
@@ -289,9 +289,10 @@ async fn enforce_client_authentication(
 async fn verify_dpop_at_token_endpoint(
     state: &OAuthState,
     dpop_header: Option<&str>,
+    issuer: &str,
 ) -> Option<Result<String, Response>> {
     let proof_str = dpop_header?;
-    let token_endpoint = format!("{}/oauth/token", state.issuer_url.trim_end_matches('/'));
+    let token_endpoint = format!("{}/oauth/token", issuer.trim_end_matches('/'));
     let proof = match super::dpop::verify_dpop_proof(proof_str, "POST", &token_endpoint, None) {
         Ok(p) => p,
         Err(e) => {
@@ -433,7 +434,8 @@ async fn exchange_authorization_code(
     }
 
     // Verify DPoP if present.
-    let dpop_jkt = match verify_dpop_at_token_endpoint(&state, dpop_header.as_deref()).await {
+    let token_issuer = state.issuer_for_scopes(&pending.scopes);
+    let dpop_jkt = match verify_dpop_at_token_endpoint(&state, dpop_header.as_deref(), &token_issuer).await {
         None => None,
         Some(Ok(jkt)) => Some(jkt),
         Some(Err(resp)) => return resp,
@@ -541,7 +543,8 @@ async fn exchange_refresh_token(
 
     // Verify DPoP before consuming the refresh token. A use_dpop_nonce
     // response must leave the credential available for the RFC 9449 retry.
-    let dpop_jkt = match verify_dpop_at_token_endpoint(&state, dpop_header.as_deref()).await {
+    let token_issuer = state.issuer_for_scopes(&entry.scopes);
+    let dpop_jkt = match verify_dpop_at_token_endpoint(&state, dpop_header.as_deref(), &token_issuer).await {
         None => None,
         Some(Ok(jkt)) => Some(jkt),
         Some(Err(resp)) => return resp,
@@ -687,7 +690,8 @@ async fn exchange_device_code(
 
             // Verify DPoP before consuming the device code. A
             // `use_dpop_nonce` response must leave it available for retry.
-            let dpop_jkt = match verify_dpop_at_token_endpoint(&state, dpop_header.as_deref()).await {
+            let token_issuer = state.issuer_for_scopes(&scopes);
+            let dpop_jkt = match verify_dpop_at_token_endpoint(&state, dpop_header.as_deref(), &token_issuer).await {
                 None => None,
                 Some(Ok(jkt)) => Some(jkt),
                 Some(Err(resp)) => return resp,
@@ -842,6 +846,7 @@ async fn issue_token_with_refresh(
     } else {
         sub.to_owned()
     };
+    let token_issuer = state.issuer_for_scopes(&scopes);
 
     let result = state
         .policy_client
@@ -852,6 +857,7 @@ async fn issue_token_with_refresh(
             subject: Some(jwt_sub.clone()),
             user_pub_key: user_pub_key_b64,
             dpop_jkt: dpop_jkt.clone(),
+            issuer: Some(token_issuer.clone()),
         })
         .await;
 
@@ -917,7 +923,7 @@ async fn issue_token_with_refresh(
             let id_token = if has_openid && initial_auth && state.signing_key.is_some() {
                 let id_exp = now + 300; // 5-minute id_token lifetime
                 let mut id_claims = hyprstream_rpc::auth::IdTokenClaims::new(
-                    state.issuer_url.clone(),
+                    token_issuer,
                     sub.to_owned(),
                     client_id.to_owned(),
                     now,

--- a/crates/hyprstream/src/services/oauth/token.rs
+++ b/crates/hyprstream/src/services/oauth/token.rs
@@ -185,6 +185,32 @@ pub async fn exchange_token(
 ///
 /// Returns Ok on success; the caller proceeds with the grant. Returns
 /// Err(Response) with the appropriate token error response on failure.
+async fn bound_grant_scopes(
+    state: &OAuthState,
+    params: &TokenRequest,
+) -> Option<Vec<String>> {
+    match params.grant_type.as_str() {
+        "authorization_code" => {
+            let code = params.code.as_deref()?;
+            let pending = state.pending_codes.read().await;
+            let entry = pending.get(code)?;
+            (entry.client_id == params.client_id).then(|| entry.scopes.clone())
+        }
+        "refresh_token" => {
+            let refresh_token = params.refresh_token.as_deref()?;
+            let entry = state.get_refresh_token(refresh_token).await.ok().flatten()?;
+            (entry.client_id == params.client_id).then_some(entry.scopes)
+        }
+        gt if gt == DEVICE_CODE_GRANT_TYPE => {
+            let device_code = params.device_code.as_deref()?;
+            let pending = state.pending_device_codes.read().await;
+            let entry = pending.get(device_code)?;
+            (entry.client_id == params.client_id).then(|| entry.scopes.clone())
+        }
+        _ => None,
+    }
+}
+
 async fn enforce_client_authentication(
     state: &OAuthState,
     params: &TokenRequest,
@@ -244,10 +270,15 @@ async fn enforce_client_authentication(
     if has_assertion {
         let assertion = params.client_assertion.as_deref().unwrap_or_else(|| unreachable!());
         let atype = params.client_assertion_type.as_deref().unwrap_or_else(|| unreachable!());
-        let token_endpoint = format!(
-            "{}/oauth/token",
-            state.issuer_url.trim_end_matches('/')
-        );
+        // Derive the assertion audience from the immutable grant, not from
+        // caller-supplied scopes. atproto grants use the origin-only endpoint
+        // advertised in RFC 8414 metadata; generic grants preserve the
+        // configured path-bearing issuer.
+        let issuer = match bound_grant_scopes(state, params).await {
+            Some(scopes) => state.issuer_for_scopes(&scopes),
+            None => state.issuer_url.clone(),
+        };
+        let token_endpoint = format!("{}/oauth/token", issuer.trim_end_matches('/'));
         if let Err(e) = super::client_auth::verify_client_assertion(
             state, &client, atype, assertion, &token_endpoint,
         ).await {

--- a/crates/hyprstream/src/services/oauth/token.rs
+++ b/crates/hyprstream/src/services/oauth/token.rs
@@ -311,16 +311,19 @@ async fn enforce_client_authentication(
         // advertised in RFC 8414 metadata; generic grants preserve the
         // configured path-bearing issuer.
         //
-        // #1146 T1.2: the atproto OAuth profile mandates `aud` == the AS
-        // ISSUER (the reference confidential client sends exactly that);
-        // RFC 7523 §3 also permits the token endpoint URL. The token
-        // endpoint accepts both forms — the issuer first.
+        // #1146 T1.2: the accepted audience is the AS ISSUER — alone. The
+        // atproto OAuth profile mandates the issuer; RFC 7523 §3 also
+        // permits the token endpoint URL, but atproto does not, and
+        // `private_key_jwt` client auth ships with this conformance chain,
+        // so no deployed legacy client needs the endpoint form. Accepting
+        // both would leave the endpoint URL valid as an assertion target
+        // (replayable at any endpoint applying the same broadened rule).
+        // PAR accepts the issuer only as well (`par.rs`).
         let issuer = match bound_grant_scopes(state, params).await {
             Some(scopes) => state.issuer_for_scopes(&scopes),
             None => state.issuer_url.clone(),
         };
-        let token_endpoint = format!("{}/oauth/token", issuer.trim_end_matches('/'));
-        let expected_audiences = [issuer, token_endpoint];
+        let expected_audiences = [issuer];
         match super::client_auth::verify_client_assertion(
             state, &client, atype, assertion, &expected_audiences,
         ).await {

--- a/crates/hyprstream/src/services/oauth/token.rs
+++ b/crates/hyprstream/src/services/oauth/token.rs
@@ -905,7 +905,6 @@ async fn issue_token_with_refresh(
                     verifying_key_bytes: user_verifying_key.map(|vk| *vk.as_bytes()),
                     dpop_jkt: dpop_jkt.clone(),
                     ucan_grant: None, // generic OAuth refresh; not a UCAN grant (MAC #547 B1)
-                    dpop_jkt: dpop_jkt.clone(), // #1113 rev2 F3: sender-bind the refresh token
                 };
                 if let Err(e) = state.put_refresh_token(&refresh_token, &entry, state.refresh_token_ttl as u64).await {
                     tracing::error!(error = %e, "Failed to persist refresh token");

--- a/crates/hyprstream/src/services/oauth/token.rs
+++ b/crates/hyprstream/src/services/oauth/token.rs
@@ -1189,11 +1189,18 @@ mod tests {
     /// client can re-sign and replay the proof.
     #[test]
     fn use_dpop_nonce_error_carries_atproto_retry_contract() {
-        let resp = use_dpop_nonce_error("abc123", "DPoP proof must include a server-issued nonce");
+        // Draw the test nonce from OsRng exactly as production
+        // (`OAuthState::issue_dpop_nonce`) does. A hard-coded literal here
+        // tripped CodeQL `rust/hard-coded-cryptographic-value` (#1121) — a
+        // false positive (test-only value, never a crypto sink), but the
+        // literal-free form is also a more faithful test of the real shape.
+        use rand::Rng;
+        let nonce = URL_SAFE_NO_PAD.encode(rand::rngs::OsRng.gen::<[u8; 16]>());
+        let resp = use_dpop_nonce_error(&nonce, "DPoP proof must include a server-issued nonce");
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
         assert_eq!(
             resp.headers().get("DPoP-Nonce").and_then(|v| v.to_str().ok()),
-            Some("abc123"),
+            Some(nonce.as_str()),
             "DPoP-Nonce header MUST carry the fresh nonce for client retry"
         );
     }
@@ -1203,8 +1210,26 @@ mod tests {
     /// (graceful) but the error contract the client keys on is preserved.
     #[test]
     fn use_dpop_nonce_error_keeps_400_on_unheaderable_nonce() {
-        let resp = use_dpop_nonce_error("not valid token", "expired");
+        // Map OsRng bytes into the C0 control range (0x00–0x1F): every byte
+        // is then invalid in an HTTP header value, so
+        // `HeaderValue::from_str` MUST reject it and the header is omitted.
+        // (The previous "not valid token" literal contained only spaces,
+        // which ARE valid header bytes — the header was silently inserted
+        // and the graceful-omission branch went untested. The literal also
+        // tripped CodeQL `rust/hard-coded-cryptographic-value`, #1121.)
+        use rand::Rng;
+        let bytes: Vec<u8> = rand::rngs::OsRng
+            .gen::<[u8; 8]>()
+            .into_iter()
+            .map(|b| b % 0x20)
+            .collect();
+        let nonce = String::from_utf8(bytes).expect("C0 control bytes are valid UTF-8");
+        let resp = use_dpop_nonce_error(&nonce, "expired");
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert!(
+            resp.headers().get("DPoP-Nonce").is_none(),
+            "unheaderable nonce MUST be omitted from the response"
+        );
     }
 
     /// #1113 rev2 finding 1: the atproto token response matches

--- a/crates/hyprstream/src/services/oauth/token.rs
+++ b/crates/hyprstream/src/services/oauth/token.rs
@@ -340,6 +340,12 @@ async fn verify_dpop_at_token_endpoint(
 
 /// Build a `400 use_dpop_nonce` response with the current nonce in the
 /// `DPoP-Nonce` header (RFC 9449 §8).
+///
+/// atproto contract (#1113): `@atproto/oauth-client-browser` retries a token
+/// request on `400` + `{"error":"use_dpop_nonce"}` + a fresh `DPoP-Nonce`
+/// header — the client re-signs the DPoP proof carrying the new nonce and
+/// replays the request. This is the 400 form (not the resource-server 401
+/// form used in `auth.rs`); both carry the same `DPoP-Nonce` header.
 fn use_dpop_nonce_error(nonce: &str, description: &str) -> Response {
     // `description` here is always client-actionable ("nonce required",
     // "nonce expired") — that's the whole point of RFC 9449 §8: tell
@@ -734,7 +740,10 @@ fn generate_refresh_token() -> String {
 
 /// Issue a JWT access token via PolicyService, plus a rotated refresh token.
 ///
-/// `sub` is the JWT subject (username). Must be non-empty:
+/// `sub` is the internal account username used for server-side bookkeeping
+/// (refresh-token entry, profile lookup, device link). The emitted JWT's
+/// `sub` claim is the atproto-conformant DID derived from it via
+/// [`OAuthState::subject_did`] (#1113). Must be non-empty:
 /// - authorization_code flow: pass `pending.username` (the Ed25519-authenticated user from the consent page)
 /// - refresh_token flow: pass the original sub from the RefreshTokenEntry
 /// - device_code flow: pass the approving user's username (from challenge-response)
@@ -762,13 +771,35 @@ async fn issue_token_with_refresh(
         None
     };
 
+    // atproto OAuth AS conformance (#1113): the access token's `sub` MUST be
+    // the account's DID. `sub` arriving here is the internal username (auth
+    // code / refresh / device flows resolve it from the credential store);
+    // derive the DID-form subject for the emitted JWT. Internal bookkeeping
+    // (refresh-token entry, profile lookup, device link) keeps using the
+    // raw username so lookups remain keyed on the enrollment identity.
+    //
+    // #1113 correction: only `did:plc` / `did:web` (and synthesized
+    // `did:web`) are eligible atproto token subjects. `did:at9p` and other
+    // DID methods fail closed — no token is minted for an ineligible subject.
+    let jwt_sub = match state.subject_did(sub) {
+        Ok(did) => did,
+        Err(e) => {
+            tracing::warn!(local_subject = %sub, error = %e, "rejecting token issuance: subject not eligible for atproto OAuth");
+            return token_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_request",
+                Some("account subject is not eligible for an atproto OAuth token"),
+            );
+        }
+    };
+
     let result = state
         .policy_client
         .issue_token(&IssueToken {
             requested_scopes: Some(scopes.clone()),
             ttl: Some(state.token_ttl),
             audience: resource.clone(),
-            subject: Some(sub.to_owned()),
+            subject: Some(jwt_sub),
             user_pub_key: user_pub_key_b64,
             dpop_jkt: dpop_jkt.clone(),
         })
@@ -1027,5 +1058,29 @@ mod tests {
                 "opaque response unexpectedly leaks `{forbidden}`: {serialized}"
             );
         }
+    }
+
+    /// #1113: the DPoP nonce-retry contract that
+    /// `@atproto/oauth-client-browser` relies on — HTTP 400 with
+    /// `error: use_dpop_nonce` AND a `DPoP-Nonce` response header so the
+    /// client can re-sign and replay the proof.
+    #[test]
+    fn use_dpop_nonce_error_carries_atproto_retry_contract() {
+        let resp = use_dpop_nonce_error("abc123", "DPoP proof must include a server-issued nonce");
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            resp.headers().get("DPoP-Nonce").and_then(|v| v.to_str().ok()),
+            Some("abc123"),
+            "DPoP-Nonce header MUST carry the fresh nonce for client retry"
+        );
+    }
+
+    /// #1113: a nonce value that is not a valid HTTP header token still
+    /// yields a 400 `use_dpop_nonce` body — the nonce header is omitted
+    /// (graceful) but the error contract the client keys on is preserved.
+    #[test]
+    fn use_dpop_nonce_error_keeps_400_on_unheaderable_nonce() {
+        let resp = use_dpop_nonce_error("not valid token", "expired");
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/crates/hyprstream/src/services/oauth/token.rs
+++ b/crates/hyprstream/src/services/oauth/token.rs
@@ -439,6 +439,31 @@ async fn exchange_authorization_code(
         Some(Err(resp)) => return resp,
     };
 
+    // #1113 rev2 finding 3 + 6: the atproto profile (granted scope set
+    // includes `atproto`) is a STRICT path — DPoP is mandatory and the proof
+    // key MUST match the `jkt` bound at PAR (stored on the auth code). Non-
+    // atproto flows keep DPoP optional and their existing behavior.
+    if super::state::atproto_profile_active(&pending.scopes) {
+        match (dpop_jkt.as_ref(), pending.dpop_jkt.as_ref()) {
+            (Some(proof_jkt), Some(bound_jkt)) if proof_jkt == bound_jkt => {
+                // DPoP key matches the PAR binding — proceed.
+            }
+            _ => {
+                tracing::warn!(
+                    client_id = %params.client_id,
+                    proof_jkt = ?dpop_jkt,
+                    bound_jkt = ?pending.dpop_jkt,
+                    "atproto profile requires a DPoP proof matching the PAR-bound key"
+                );
+                return token_error(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_dpop_proof",
+                    Some("atproto profile requires a DPoP proof from the key bound at PAR"),
+                );
+            }
+        }
+    }
+
     tracing::info!(client_id = %params.client_id, username = %pending.username, "PKCE verified, issuing token");
     let sub = pending.username.clone();
     let vk_ref = pending.verifying_key.as_ref();
@@ -763,6 +788,7 @@ async fn issue_token_with_refresh(
     vault_device_cookie: Option<String>,
 ) -> Response {
     let scope_str = scopes.join(" ");
+    let atproto_profile = super::state::atproto_profile_active(&scopes);
 
     // DPoP jkt takes priority; fall back to raw key bytes for cnf.jwk.
     let user_pub_key_b64 = if dpop_jkt.is_none() {
@@ -771,26 +797,29 @@ async fn issue_token_with_refresh(
         None
     };
 
-    // atproto OAuth AS conformance (#1113): the access token's `sub` MUST be
-    // the account's DID. `sub` arriving here is the internal username (auth
-    // code / refresh / device flows resolve it from the credential store);
-    // derive the DID-form subject for the emitted JWT. Internal bookkeeping
-    // (refresh-token entry, profile lookup, device link) keeps using the
-    // raw username so lookups remain keyed on the enrollment identity.
+    // #1113 rev2 finding 6: the DID subject / did:at9p fail-closed rule is
+    // CONDITIONAL on the atproto profile. Non-atproto flows (device, WIT,
+    // generic authorization-code) keep their existing username subject
+    // byte-for-byte — the atproto strict path only activates when the granted
+    // scope set includes `atproto`.
     //
-    // #1113 correction: only `did:plc` / `did:web` (and synthesized
-    // `did:web`) are eligible atproto token subjects. `did:at9p` and other
-    // DID methods fail closed — no token is minted for an ineligible subject.
-    let jwt_sub = match state.subject_did(sub) {
-        Ok(did) => did,
-        Err(e) => {
-            tracing::warn!(local_subject = %sub, error = %e, "rejecting token issuance: subject not eligible for atproto OAuth");
-            return token_error(
-                StatusCode::BAD_REQUEST,
-                "invalid_request",
-                Some("account subject is not eligible for an atproto OAuth token"),
-            );
+    // atproto profile: the access token's `sub` MUST be the account's DID
+    // (`did:plc` / `did:web`). `did:at9p` and other DID methods are NOT
+    // eligible and fail closed (no token minted).
+    let jwt_sub = if atproto_profile {
+        match state.subject_did(sub) {
+            Ok(did) => did,
+            Err(e) => {
+                tracing::warn!(local_subject = %sub, error = %e, "rejecting atproto token issuance: subject not eligible");
+                return token_error(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_request",
+                    Some("account subject is not eligible for an atproto OAuth token"),
+                );
+            }
         }
+    } else {
+        sub.to_owned()
     };
 
     let result = state
@@ -799,7 +828,7 @@ async fn issue_token_with_refresh(
             requested_scopes: Some(scopes.clone()),
             ttl: Some(state.token_ttl),
             audience: resource.clone(),
-            subject: Some(jwt_sub),
+            subject: Some(jwt_sub.clone()),
             user_pub_key: user_pub_key_b64,
             dpop_jkt: dpop_jkt.clone(),
         })
@@ -903,13 +932,14 @@ async fn issue_token_with_refresh(
                 None
             };
 
-            let mut response_json = serde_json::json!({
-                "access_token": token_info.token,
-                "token_type": if dpop_jkt.is_some() { "DPoP" } else { "Bearer" },
-                "expires_in": expires_in,
-                "scope": scope_str,
-                "refresh_token": refresh_token,
-            });
+            let mut response_json = build_token_response_json(
+                atproto_profile,
+                &token_info.token,
+                &jwt_sub,
+                &scope_str,
+                expires_in,
+                &refresh_token,
+            );
             if let Some(id_token) = id_token {
                 response_json["id_token"] = serde_json::Value::String(id_token);
             }
@@ -938,6 +968,41 @@ async fn issue_token_with_refresh(
                 None,
             )
         }
+    }
+}
+
+/// Build the token-endpoint success response JSON (#1113 rev2 finding 1).
+///
+/// Factored pure so the atproto `atprotoOAuthTokenResponseSchema` shape and the
+/// legacy Bearer shape are both unit-testable without constructing an
+/// `OAuthState` + PolicyClient. When `atproto_profile` is true the response
+/// carries `token_type: "DPoP"` and a top-level `sub` (the account DID), per
+/// the schema the stock `@atproto/oauth-client-browser` parses.
+pub(crate) fn build_token_response_json(
+    atproto_profile: bool,
+    access_token: &str,
+    sub: &str,
+    scope_str: &str,
+    expires_in: i64,
+    refresh_token: &str,
+) -> serde_json::Value {
+    if atproto_profile {
+        serde_json::json!({
+            "access_token": access_token,
+            "token_type": "DPoP",
+            "expires_in": expires_in,
+            "scope": scope_str,
+            "sub": sub,
+            "refresh_token": refresh_token,
+        })
+    } else {
+        serde_json::json!({
+            "access_token": access_token,
+            "token_type": "Bearer",
+            "expires_in": expires_in,
+            "scope": scope_str,
+            "refresh_token": refresh_token,
+        })
     }
 }
 
@@ -1082,5 +1147,77 @@ mod tests {
     fn use_dpop_nonce_error_keeps_400_on_unheaderable_nonce() {
         let resp = use_dpop_nonce_error("not valid token", "expired");
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    /// #1113 rev2 finding 1: the atproto token response matches
+    /// atprotoOAuthTokenResponseSchema — `token_type: "DPoP"`, a top-level
+    /// `sub` that is a did:plc/did:web, and a scope containing `atproto`.
+    #[test]
+    fn atproto_token_response_matches_schema_shape() {
+        let json = build_token_response_json(
+            true,
+            "access-jwt",
+            "did:web:pds.example.com:users:alice",
+            "atproto transition:generic",
+            3600,
+            "rt",
+        );
+        assert_eq!(json["token_type"].as_str(), Some("DPoP"));
+        let sub = json["sub"].as_str().expect("top-level sub required");
+        assert!(
+            sub.starts_with("did:plc:") || sub.starts_with("did:web:"),
+            "atproto sub must be an account DID, got {sub}"
+        );
+        let scope = json["scope"].as_str().expect("scope required");
+        assert!(scope.split_whitespace().any(|s| s == "atproto"), "scope missing atproto");
+        assert_eq!(json["access_token"].as_str(), Some("access-jwt"));
+        assert_eq!(json["refresh_token"].as_str(), Some("rt"));
+    }
+
+    /// #1113 rev2 finding 6 (regression): a non-atproto grant (e.g. device
+    /// flow, scopes without `atproto`) keeps the legacy Bearer shape with NO
+    /// top-level `sub` — existing principals are byte-for-byte unchanged.
+    #[test]
+    fn non_atproto_token_response_is_bearer_without_sub() {
+        let json = build_token_response_json(
+            false,
+            "access-jwt",
+            "alice",
+            "read:*:*",
+            3600,
+            "rt",
+        );
+        assert_eq!(json["token_type"].as_str(), Some("Bearer"));
+        assert!(
+            json.get("sub").is_none(),
+            "non-atproto response MUST NOT carry a top-level sub"
+        );
+    }
+
+    /// #1113 rev2 finding 3: PAR↔token DPoP binding — a proof whose `jkt`
+    /// does not match the PAR-bound thumbprint must be rejected. The binding
+    /// check is a plain equality compare; pin the comparator semantics.
+    #[test]
+    fn dpop_jkt_binding_rejects_mismatched_key() {
+        let bound: Option<String> = Some("jkt-A".into());
+        let proof: Option<String> = Some("jkt-B".into());
+        // The token endpoint accepts only when both are present AND equal.
+        let matches = matches!(
+            (proof.as_ref(), bound.as_ref()),
+            (Some(a), Some(b)) if a == b
+        );
+        assert!(!matches, "mismatched jkt must not bind");
+        let bound2: Option<String> = Some("jkt-A".into());
+        let matches2 = matches!(
+            (proof.as_ref(), bound2.as_ref()),
+            (Some(a), Some(b)) if a == b
+        );
+        assert!(!matches2);
+        let proof_same: Option<String> = Some("jkt-A".into());
+        let matches3 = matches!(
+            (proof_same.as_ref(), bound.as_ref()),
+            (Some(a), Some(b)) if a == b
+        );
+        assert!(matches3, "equal jkt must bind");
     }
 }

--- a/crates/hyprstream/src/services/oauth/token.rs
+++ b/crates/hyprstream/src/services/oauth/token.rs
@@ -113,14 +113,19 @@ pub async fn exchange_token(
     // client's JWKS BEFORE dispatching the grant. Public clients
     // (auth_method=none or unset) skip this — PKCE substitutes for
     // client auth per OAuth 2.1.
-    if let Err(resp) = enforce_client_authentication(&state, &params).await {
-        return resp;
-    }
+    //
+    // On success this yields the RFC 7638 thumbprint of the assertion
+    // key (#1146 T3.3) — the grant handlers persist it into the refresh
+    // entry so the session stays bound to that exact key.
+    let client_assertion_jkt = match enforce_client_authentication(&state, &params).await {
+        Ok(jkt) => jkt,
+        Err(resp) => return resp,
+    };
 
     match params.grant_type.as_str() {
-        "authorization_code" => exchange_authorization_code(state, params, dpop_header, vault_device_cookie).await,
-        "refresh_token" => exchange_refresh_token(state, params, dpop_header, vault_device_cookie).await,
-        gt if gt == DEVICE_CODE_GRANT_TYPE => exchange_device_code(state, params, dpop_header, vault_device_cookie).await,
+        "authorization_code" => exchange_authorization_code(state, params, dpop_header, vault_device_cookie, client_assertion_jkt).await,
+        "refresh_token" => exchange_refresh_token(state, params, dpop_header, vault_device_cookie, client_assertion_jkt).await,
+        gt if gt == DEVICE_CODE_GRANT_TYPE => exchange_device_code(state, params, dpop_header, vault_device_cookie, client_assertion_jkt).await,
         gt if gt == JWT_BEARER_GRANT_TYPE => {
             let assertion = match params.assertion {
                 Some(a) => a,
@@ -174,17 +179,8 @@ pub async fn exchange_token(
     }
 }
 
-/// Enforce token endpoint client authentication.
-///
-/// Resolves the registered client (DCR or CIMD-cached), then:
-///   - If the client requires `private_key_jwt`: `client_assertion` and
-///     `client_assertion_type` MUST be present and verify successfully.
-///   - If the client does NOT require it but an assertion was sent
-///     anyway: we still verify it (best-effort, defense in depth).
-///   - Unknown client_ids return invalid_client.
-///
-/// Returns Ok on success; the caller proceeds with the grant. Returns
-/// Err(Response) with the appropriate token error response on failure.
+/// The immutable scope set of the grant being redeemed, used to derive
+/// the profile-correct issuer for assertion-audience checking.
 async fn bound_grant_scopes(
     state: &OAuthState,
     params: &TokenRequest,
@@ -211,10 +207,50 @@ async fn bound_grant_scopes(
     }
 }
 
+/// The client-assertion key thumbprint bound to the grant being redeemed
+/// (#1146 T3.3): PAR-bound for `authorization_code`, issuance-bound for
+/// `refresh_token`. `None` when the grant carries no binding.
+async fn bound_assertion_jkt(
+    state: &OAuthState,
+    params: &TokenRequest,
+) -> Option<String> {
+    match params.grant_type.as_str() {
+        "authorization_code" => {
+            let code = params.code.as_deref()?;
+            let pending = state.pending_codes.read().await;
+            let entry = pending.get(code)?;
+            (entry.client_id == params.client_id)
+                .then(|| entry.client_assertion_jkt.clone())
+                .flatten()
+        }
+        "refresh_token" => {
+            let refresh_token = params.refresh_token.as_deref()?;
+            let entry = state.get_refresh_token(refresh_token).await.ok().flatten()?;
+            (entry.client_id == params.client_id)
+                .then_some(entry.client_assertion_jkt)
+                .flatten()
+        }
+        _ => None,
+    }
+}
+
+/// Enforce token endpoint client authentication.
+///
+/// Resolves the registered client (DCR or CIMD-cached), then:
+///   - If the client requires `private_key_jwt`: `client_assertion` and
+///     `client_assertion_type` MUST be present and verify successfully.
+///   - If the client does NOT require it but an assertion was sent
+///     anyway: we still verify it (best-effort, defense in depth).
+///   - Unknown client_ids return invalid_client.
+///
+/// Returns the assertion key's RFC 7638 thumbprint when an assertion was
+/// verified (`Ok(Some(jkt))`), `Ok(None)` when no assertion was presented;
+/// the caller proceeds with the grant. Returns Err(Response) with the
+/// appropriate token error response on failure.
 async fn enforce_client_authentication(
     state: &OAuthState,
     params: &TokenRequest,
-) -> Result<(), Response> {
+) -> Result<Option<String>, Response> {
     // CIMD client_ids are HTTPS URLs; DCR client_ids are UUIDs.
     //
     // For CIMD: on cache miss (entry expired between PAR/authorize
@@ -250,7 +286,7 @@ async fn enforce_client_authentication(
         //     CIMD client_id has had two chances to be found.
         //   - DCR clients with UUID IDs are only "absent" if they were
         //     never registered, in which case no pending entry exists.
-        return Ok(());
+        return Ok(None);
     };
 
     let needs_auth = super::client_auth::requires_private_key_jwt(&client);
@@ -271,34 +307,64 @@ async fn enforce_client_authentication(
         let assertion = params.client_assertion.as_deref().unwrap_or_else(|| unreachable!());
         let atype = params.client_assertion_type.as_deref().unwrap_or_else(|| unreachable!());
         // Derive the assertion audience from the immutable grant, not from
-        // caller-supplied scopes. atproto grants use the origin-only endpoint
+        // caller-supplied scopes. atproto grants use the origin-only issuer
         // advertised in RFC 8414 metadata; generic grants preserve the
         // configured path-bearing issuer.
+        //
+        // #1146 T1.2: the atproto OAuth profile mandates `aud` == the AS
+        // ISSUER (the reference confidential client sends exactly that);
+        // RFC 7523 §3 also permits the token endpoint URL. The token
+        // endpoint accepts both forms — the issuer first.
         let issuer = match bound_grant_scopes(state, params).await {
             Some(scopes) => state.issuer_for_scopes(&scopes),
             None => state.issuer_url.clone(),
         };
         let token_endpoint = format!("{}/oauth/token", issuer.trim_end_matches('/'));
-        if let Err(e) = super::client_auth::verify_client_assertion(
-            state, &client, atype, assertion, &token_endpoint,
+        let expected_audiences = [issuer, token_endpoint];
+        match super::client_auth::verify_client_assertion(
+            state, &client, atype, assertion, &expected_audiences,
         ).await {
-            // Full reason goes to logs; the public response stays
-            // opaque so we don't leak the validation logic / order
-            // (iss/sub/aud/exp/signature) to probing attackers.
-            tracing::warn!(
-                client_id = %params.client_id,
-                error = %e,
-                "client_assertion verification failed"
-            );
-            return Err(token_error(
-                StatusCode::UNAUTHORIZED,
-                "invalid_client",
-                None,
-            ));
+            Ok(verified) => {
+                // #1146 T3.3: when the grant was bound to a specific
+                // assertion key (at PAR for authorization_code, at
+                // issuance for refresh_token), the presented assertion
+                // MUST verify under the same key — refresh cannot switch
+                // to another registered key, and removing the bound key
+                // from the client's JWKS revokes the session.
+                if let Some(bound_jkt) = bound_assertion_jkt(state, params).await {
+                    if bound_jkt != verified.key_jkt {
+                        tracing::warn!(
+                            client_id = %params.client_id,
+                            "client_assertion key does not match the grant-bound key"
+                        );
+                        return Err(token_error(
+                            StatusCode::UNAUTHORIZED,
+                            "invalid_client",
+                            None,
+                        ));
+                    }
+                }
+                return Ok(Some(verified.key_jkt));
+            }
+            Err(e) => {
+                // Full reason goes to logs; the public response stays
+                // opaque so we don't leak the validation logic / order
+                // (iss/sub/aud/exp/signature) to probing attackers.
+                tracing::warn!(
+                    client_id = %params.client_id,
+                    error = %e,
+                    "client_assertion verification failed"
+                );
+                return Err(token_error(
+                    StatusCode::UNAUTHORIZED,
+                    "invalid_client",
+                    None,
+                ));
+            }
         }
     }
 
-    Ok(())
+    Ok(None)
 }
 
 /// Verify a DPoP proof for the token endpoint, check JTI replay, enforce
@@ -395,6 +461,7 @@ async fn exchange_authorization_code(
     params: TokenRequest,
     dpop_header: Option<String>,
     vault_device_cookie: Option<String>,
+    client_assertion_jkt: Option<String>,
 ) -> Response {
     let code = match params.code {
         Some(c) => c,
@@ -500,7 +567,7 @@ async fn exchange_authorization_code(
     tracing::info!(client_id = %params.client_id, username = %pending.username, "PKCE verified, issuing token");
     let sub = pending.username.clone();
     let vk_ref = pending.verifying_key.as_ref();
-    issue_token_with_refresh(&state, &params.client_id, pending.scopes, pending.resource, &sub, pending.oidc_nonce, true, vk_ref, dpop_jkt, vault_device_cookie).await
+    issue_token_with_refresh(&state, &params.client_id, pending.scopes, pending.resource, &sub, pending.oidc_nonce, true, vk_ref, dpop_jkt, client_assertion_jkt, vault_device_cookie).await
 }
 
 /// Handle refresh_token grant type (OAuth 2.1 with rotation).
@@ -509,6 +576,7 @@ async fn exchange_refresh_token(
     params: TokenRequest,
     dpop_header: Option<String>,
     vault_device_cookie: Option<String>,
+    client_assertion_jkt: Option<String>,
 ) -> Response {
     let refresh_token = match params.refresh_token {
         Some(rt) => rt,
@@ -628,8 +696,14 @@ async fn exchange_refresh_token(
     let stored_vk: Option<ed25519_dalek::VerifyingKey> = claimed.verifying_key_bytes
         .and_then(|b| ed25519_dalek::VerifyingKey::from_bytes(&b).ok());
 
+    // #1146 T3.3: carry the assertion-key binding forward across rotation.
+    // enforce_client_authentication already verified the presented
+    // assertion against this binding; for a legacy entry without one,
+    // ratchet onto the key that just verified.
+    let carried_assertion_jkt = claimed.client_assertion_jkt.clone().or(client_assertion_jkt);
+
     // Issue new access token + rotated refresh token. No id_token on refresh (OIDC Core § 12.2).
-    issue_token_with_refresh(&state, &claimed.client_id, claimed.scopes, claimed.resource, &claimed.username, None, false, stored_vk.as_ref(), dpop_jkt, vault_device_cookie).await
+    issue_token_with_refresh(&state, &claimed.client_id, claimed.scopes, claimed.resource, &claimed.username, None, false, stored_vk.as_ref(), dpop_jkt, carried_assertion_jkt, vault_device_cookie).await
 }
 
 /// Handle urn:ietf:params:oauth:grant-type:device_code grant type (RFC 8628 Section 3.4).
@@ -638,6 +712,7 @@ async fn exchange_device_code(
     params: TokenRequest,
     dpop_header: Option<String>,
     vault_device_cookie: Option<String>,
+    client_assertion_jkt: Option<String>,
 ) -> Response {
     let device_code = match params.device_code {
         Some(dc) => dc,
@@ -788,7 +863,7 @@ async fn exchange_device_code(
             drop(user_code_map);
 
             // Device flow: no OIDC nonce and not initial OIDC auth.
-            issue_token_with_refresh(&state, &client_id, scopes, resource, &approved_by, None, false, device_vk.as_ref(), dpop_jkt, vault_device_cookie).await
+            issue_token_with_refresh(&state, &client_id, scopes, resource, &approved_by, None, false, device_vk.as_ref(), dpop_jkt, client_assertion_jkt, vault_device_cookie).await
         }
     }
 }
@@ -838,6 +913,7 @@ async fn issue_token_with_refresh(
     initial_auth: bool,
     user_verifying_key: Option<&ed25519_dalek::VerifyingKey>,
     dpop_jkt: Option<String>,
+    client_assertion_jkt: Option<String>,
     vault_device_cookie: Option<String>,
 ) -> Response {
     let scope_str = scopes.join(" ");
@@ -941,6 +1017,7 @@ async fn issue_token_with_refresh(
                     expires_at_unix: now + state.refresh_token_ttl as i64,
                     verifying_key_bytes: user_verifying_key.map(|vk| *vk.as_bytes()),
                     dpop_jkt: dpop_jkt.clone(),
+                    client_assertion_jkt: client_assertion_jkt.clone(),
                     ucan_grant: None, // generic OAuth refresh; not a UCAN grant (MAC #547 B1)
                 };
                 if let Err(e) = state.put_refresh_token(&refresh_token, &entry, state.refresh_token_ttl as u64).await {

--- a/crates/hyprstream/src/services/oauth/token.rs
+++ b/crates/hyprstream/src/services/oauth/token.rs
@@ -815,20 +815,37 @@ async fn issue_token_with_refresh(
         None
     };
 
-    // #1113 rev2 finding 6: the DID subject / did:at9p fail-closed rule is
-    // CONDITIONAL on the atproto profile. Non-atproto flows (device, WIT,
-    // generic authorization-code) keep their existing username subject
-    // byte-for-byte — the atproto strict path only activates when the granted
-    // scope set includes `atproto`.
+    // #1113 rev2 finding 6 / r4 finding 1: the DID subject / account-
+    // eligibility check is CONDITIONAL on the atproto profile. Non-atproto
+    // flows (device, WIT, generic authorization-code) keep their existing
+    // username subject byte-for-byte — the atproto strict path only activates
+    // when the granted scope set includes `atproto`.
     //
-    // atproto profile: the access token's `sub` MUST be the account's DID
-    // (`did:plc` / `did:web`). `did:at9p` and other DID methods are NOT
-    // eligible and fail closed (no token minted).
+    // atproto profile: the access token's `sub` MUST be the account's real
+    // atproto DID. The eligibility check inspects the ACCOUNT/KEY MAPPING
+    // (not the subject string): at9p-backed accounts are rejected, and an
+    // account without a mapped atproto DID fails closed (#1124).
     let jwt_sub = if atproto_profile {
-        match state.subject_did(sub) {
-            Ok(did) => did,
+        match state.check_atproto_account_eligibility(sub).await {
+            Ok(mapped_did) => {
+                // Future (#1124): the mapped DID is validated by subject_did_for
+                // to ensure it parses as a real atproto DID. Currently this path
+                // is unreachable — check_atproto_account_eligibility always
+                // returns Err(NoAtprotoIdentity) until provisioning lands.
+                match super::state::subject_did_for(&state.issuer_url, &mapped_did) {
+                    Ok(validated) => validated,
+                    Err(e) => {
+                        tracing::warn!(mapped_did = %mapped_did, error = %e, "mapped DID failed form validation");
+                        return token_error(
+                            StatusCode::BAD_REQUEST,
+                            "invalid_request",
+                            Some("account atproto DID failed validation"),
+                        );
+                    }
+                }
+            }
             Err(e) => {
-                tracing::warn!(local_subject = %sub, error = %e, "rejecting atproto token issuance: subject not eligible");
+                tracing::warn!(local_subject = %sub, error = %e, "rejecting atproto token issuance: account not eligible");
                 return token_error(
                     StatusCode::BAD_REQUEST,
                     "invalid_request",
@@ -1178,7 +1195,7 @@ mod tests {
         let json = build_token_response_json(
             true,
             "access-jwt",
-            "did:plc:abc123xyz",
+            "did:plc:abcdefghijklmnqrstuvwx2p",
             "atproto transition:generic",
             3600,
             "rt",

--- a/crates/hyprstream/src/services/oauth/token_exchange.rs
+++ b/crates/hyprstream/src/services/oauth/token_exchange.rs
@@ -997,6 +997,7 @@ async fn issue_grant_refresh_token(
         verifying_key_bytes: None,
         dpop_jkt: None,
         ucan_grant: grant_refresh,
+        dpop_jkt: None,
     };
 
     if let Some(db) = &state.token_db {
@@ -1158,6 +1159,7 @@ mod tests {
                 requested_scope: Some("read:model:llama".to_owned()),
                 audience: Some("https://api.example".to_owned()),
             }),
+            dpop_jkt: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         let back: super::super::state::RefreshTokenEntry = serde_json::from_str(&json).unwrap();

--- a/crates/hyprstream/src/services/oauth/token_exchange.rs
+++ b/crates/hyprstream/src/services/oauth/token_exchange.rs
@@ -103,6 +103,7 @@ pub async fn exchange_token_exchange(
             subject: Some(verified.sub.clone()),
             user_pub_key,
             dpop_jkt: None,
+            issuer: None,
         })
         .await;
 

--- a/crates/hyprstream/src/services/oauth/token_exchange.rs
+++ b/crates/hyprstream/src/services/oauth/token_exchange.rs
@@ -29,6 +29,9 @@ struct VerifiedSubject {
     sub: String,
     cnf_key_bytes: Option<[u8; 32]>,
     iat: i64,
+    /// Authority from a locally validated OAuth access-token grant. Identity
+    /// tokens and generic JWTs do not carry a server-authorized OAuth grant.
+    granted_scopes: Option<Vec<String>>,
 }
 
 /// POST /oauth/token — token-exchange grant (RFC 8693).
@@ -63,7 +66,7 @@ pub async fn exchange_token_exchange(
 
     let verified = match subject_token_type {
         TOKEN_TYPE_ID_TOKEN => verify_id_token(state, subject_token).await,
-        TOKEN_TYPE_ACCESS_TOKEN => verify_access_token(state, subject_token),
+        TOKEN_TYPE_ACCESS_TOKEN => verify_access_token(state, subject_token).await,
         TOKEN_TYPE_JWT => verify_jwt(state, subject_token).await,
         _ => return tx_error(
             StatusCode::BAD_REQUEST,
@@ -77,6 +80,17 @@ pub async fn exchange_token_exchange(
         Err(e) => return tx_error(StatusCode::UNAUTHORIZED, "invalid_grant", &e),
     };
 
+    let requested_scopes = match attenuate_exchange_scopes(&verified, scope) {
+        Ok(scopes) => scopes,
+        Err(description) => {
+            return tx_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_scope",
+                description,
+            );
+        }
+    };
+
     // Replay prevention: SHA-256 of the subject token as the replay key.
     // Covers all token types, regardless of whether they carry a jti claim.
     let token_hash = URL_SAFE_NO_PAD.encode(Sha256::digest(subject_token.as_bytes()));
@@ -87,9 +101,6 @@ pub async fn exchange_token_exchange(
             "subject_token already used (replay)",
         );
     }
-
-    let requested_scopes: Option<Vec<String>> =
-        scope.map(|s| s.split_whitespace().map(str::to_owned).collect());
 
     // Encode cnf key bytes for PolicyService (same path as user_pub_key in other flows).
     let user_pub_key = verified.cnf_key_bytes.map(|b| URL_SAFE_NO_PAD.encode(b));
@@ -176,22 +187,27 @@ async fn verify_id_token(state: &Arc<OAuthState>, token: &str) -> Result<Verifie
         sub: claims.sub,
         cnf_key_bytes: None, // ID tokens carry no key binding
         iat: claims.iat,
+        granted_scopes: None,
     })
 }
 
-/// Verify an existing hyprstream at+jwt (downscoping / audience narrowing).
-fn verify_access_token(state: &OAuthState, token: &str) -> Result<VerifiedSubject, String> {
-    let vk = ed25519_dalek::VerifyingKey::from_bytes(&state.verifying_key_bytes)
-        .map_err(|_| "server configuration error: invalid verifying key".to_owned())?;
-
-    let claims = hyprstream_rpc::auth::jwt::decode(token, &vk, None)
+/// Verify an existing hyprstream at+jwt through the same algorithm, audience,
+/// issuer, and revocation checks used by protected OAuth routes.
+async fn verify_access_token(state: &OAuthState, token: &str) -> Result<VerifiedSubject, String> {
+    let claims = super::auth::validate_oauth_access_token(state, token)
+        .await
         .map_err(|e| format!("access_token verification failed: {e}"))?;
 
+    let granted_scopes = claims
+        .scope
+        .as_ref()
+        .map(|_| claims.granted_scopes().map(str::to_owned).collect());
     let cnf_key_bytes = claims.cnf_key_bytes();
     Ok(VerifiedSubject {
         sub: claims.sub,
         cnf_key_bytes,
         iat: claims.iat,
+        granted_scopes,
     })
 }
 
@@ -240,7 +256,53 @@ async fn verify_jwt(state: &Arc<OAuthState>, token: &str) -> Result<VerifiedSubj
         sub: claims.sub,
         cnf_key_bytes,
         iat: claims.iat,
+        granted_scopes: None,
     })
+}
+
+/// Bound an RFC 8693 scope request to authority already present on the verified
+/// subject access token. The signed subject-token grant is the ceiling: callers
+/// may retain or narrow it, never add authority. Subject types without a local
+/// OAuth grant cannot mint a scope claim through token exchange.
+fn attenuate_exchange_scopes(
+    subject: &VerifiedSubject,
+    requested: Option<&str>,
+) -> Result<Option<Vec<String>>, &'static str> {
+    let Some(granted) = subject.granted_scopes.as_ref() else {
+        return if requested.is_some() {
+            Err("subject token carries no OAuth grant to authorize requested scope")
+        } else {
+            Ok(None)
+        };
+    };
+
+    let Some(requested) = requested else {
+        return Ok(Some(granted.clone()));
+    };
+    let requested: Vec<&str> = requested
+        .split_whitespace()
+        .map(|scope| {
+            super::state::normalize_scope_token(scope)
+                .ok_or("requested scope contains an invalid token")
+        })
+        .collect::<Result<_, _>>()?;
+    if requested.is_empty() {
+        return Err("requested scope must not be empty");
+    }
+    if requested
+        .iter()
+        .any(|scope| !granted.iter().any(|allowed| allowed == scope))
+    {
+        return Err("requested scope exceeds the subject token grant");
+    }
+
+    Ok(Some(
+        granted
+            .iter()
+            .filter(|allowed| requested.contains(&allowed.as_str()))
+            .cloned()
+            .collect(),
+    ))
 }
 
 /// Decode `nbf` from JWT payload and reject if in the future (±5s clock skew).

--- a/crates/hyprstream/src/services/oauth/token_exchange.rs
+++ b/crates/hyprstream/src/services/oauth/token_exchange.rs
@@ -997,7 +997,6 @@ async fn issue_grant_refresh_token(
         verifying_key_bytes: None,
         dpop_jkt: None,
         ucan_grant: grant_refresh,
-        dpop_jkt: None,
     };
 
     if let Some(db) = &state.token_db {
@@ -1159,7 +1158,6 @@ mod tests {
                 requested_scope: Some("read:model:llama".to_owned()),
                 audience: Some("https://api.example".to_owned()),
             }),
-            dpop_jkt: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         let back: super::super::state::RefreshTokenEntry = serde_json::from_str(&json).unwrap();

--- a/crates/hyprstream/src/services/oauth/token_exchange.rs
+++ b/crates/hyprstream/src/services/oauth/token_exchange.rs
@@ -997,6 +997,7 @@ async fn issue_grant_refresh_token(
         expires_at_unix: chrono::Utc::now().timestamp() + state.refresh_token_ttl as i64,
         verifying_key_bytes: None,
         dpop_jkt: None,
+        client_assertion_jkt: None,
         ucan_grant: grant_refresh,
     };
 
@@ -1153,6 +1154,7 @@ mod tests {
             expires_at_unix: 9999999999,
             verifying_key_bytes: None,
             dpop_jkt: None,
+            client_assertion_jkt: None,
             ucan_grant: Some(super::super::state::UcanGrantRefresh {
                 grant_cbor_b64: "Zm9vYmFy".to_owned(),
                 grant_cid: blake3::hash(b"the-grant").to_hex().to_string(),

--- a/crates/hyprstream/src/services/oauth/token_store.rs
+++ b/crates/hyprstream/src/services/oauth/token_store.rs
@@ -168,6 +168,7 @@ mod tests {
             expires_at_unix: chrono::Utc::now().timestamp() + 60,
             verifying_key_bytes: None,
             dpop_jkt: None,
+            client_assertion_jkt: None,
             ucan_grant: None,
         };
         store.put("refresh", &entry, 60).await.unwrap();

--- a/crates/hyprstream/src/services/oauth/user_mapping.rs
+++ b/crates/hyprstream/src/services/oauth/user_mapping.rs
@@ -66,7 +66,7 @@ pub fn map_external_identity(
 
 /// Extract the authority component (host[:port]) from a URL, preserving
 /// the port if present. Used for did:web construction per the did:web spec.
-fn extract_authority(url: &str) -> Result<String> {
+pub(crate) fn extract_authority(url: &str) -> Result<String> {
     let after_scheme = url
         .split_once("://")
         .map(|(_, rest)| rest)

--- a/crates/hyprstream/src/services/oauth/user_service.rs
+++ b/crates/hyprstream/src/services/oauth/user_service.rs
@@ -8,7 +8,7 @@ use anyhow::{anyhow, Result};
 use base64::{engine::general_purpose::STANDARD, Engine};
 use ed25519_dalek::VerifyingKey;
 
-use crate::auth::{UserFilter, UserProfile, UserStore, PubkeyEntry, decode_pubkey_base64};
+use crate::auth::{UserFilter, UserProfilePatch, UserStore, PubkeyEntry, decode_pubkey_base64};
 
 /// Shared user information type (SCIM-informed).
 #[derive(Debug, Clone)]
@@ -164,20 +164,19 @@ impl UserService {
 
     /// Update a user's profile fields.
     pub async fn update(&self, username: &str, update: UserUpdate) -> Result<UserInfo> {
-        let existing = self.store
+        self.store
             .get_profile(username).await?
             .ok_or_else(|| anyhow!("User '{}' not found", username))?;
 
-        let merged = UserProfile {
-            sub: existing.sub,
-            name: update.name.unwrap_or(existing.name),
-            email: update.email.unwrap_or(existing.email),
-            email_verified: Some(update.email_verified.unwrap_or_else(|| existing.email_verified.unwrap_or(false))),
-            active: existing.active,
-            external_id: update.external_id.unwrap_or(existing.external_id),
-            atproto_did: update.atproto_did.unwrap_or(existing.atproto_did),
+        let patch = UserProfilePatch {
+            name: update.name,
+            email: update.email,
+            email_verified: update.email_verified.map(Some),
+            external_id: update.external_id,
+            atproto_did: update.atproto_did,
+            ..Default::default()
         };
-        self.store.set_profile(username, merged).await?;
+        self.store.set_profile(username, patch).await?;
 
         self.get(username)
             .await?

--- a/crates/hyprstream/src/services/oauth/user_service.rs
+++ b/crates/hyprstream/src/services/oauth/user_service.rs
@@ -21,6 +21,7 @@ pub struct UserInfo {
     pub email_verified: bool,
     pub active: bool,
     pub external_id: Option<String>,
+    pub atproto_did: Option<String>,
     pub pubkeys: Vec<PubkeyInfo>,
 }
 
@@ -115,6 +116,7 @@ impl UserService {
                     email_verified: profile.email_verified.unwrap_or(false),
                     active: profile.active.unwrap_or(true),
                     external_id: profile.external_id,
+                    atproto_did: profile.atproto_did,
                     pubkeys: pubkeys.iter().map(PubkeyInfo::from).collect(),
                 }))
             }
@@ -148,6 +150,7 @@ impl UserService {
                     email_verified: profile.email_verified.unwrap_or(false),
                     active: profile.active.unwrap_or(true),
                     external_id: profile.external_id,
+                    atproto_did: profile.atproto_did,
                     pubkeys: vec![], // Omitted in list
                 }
             })

--- a/crates/hyprstream/src/services/oauth/user_service.rs
+++ b/crates/hyprstream/src/services/oauth/user_service.rs
@@ -66,6 +66,8 @@ pub struct UserUpdate {
     pub email: Option<Option<String>>,
     pub email_verified: Option<bool>,
     pub external_id: Option<Option<String>>,
+    /// The account's mapped atproto DID (#1113 r5 / #1124 seam).
+    pub atproto_did: Option<Option<String>>,
 }
 
 /// Shared user CRUD service used by both SCIM HTTP and ZMQ RPC transports.
@@ -170,6 +172,7 @@ impl UserService {
             email_verified: Some(update.email_verified.unwrap_or_else(|| existing.email_verified.unwrap_or(false))),
             active: existing.active,
             external_id: update.external_id.unwrap_or(existing.external_id),
+            atproto_did: update.atproto_did.unwrap_or(existing.atproto_did),
         };
         self.store.set_profile(username, merged).await?;
 

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -384,9 +384,13 @@ impl PolicyHandler for PolicyService {
             })
         };
 
-        // Populate iss with the OAuth issuer URL so federation peers can fetch JWKS.
-        // default_audience is the OAuth issuer URL (set via with_default_audience).
-        let issuer = self.default_audience.clone().unwrap_or_default();
+        // OAuth may override the issuer for a profile-specific token (atproto
+        // requires an origin). Other callers retain the configured default.
+        let issuer = data.issuer.as_ref()
+            .filter(|issuer| !issuer.is_empty())
+            .cloned()
+            .or_else(|| self.default_audience.clone())
+            .unwrap_or_default();
         let mut claims = hyprstream_rpc::auth::Claims::new(
             subject,
             now,

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -358,11 +358,19 @@ impl PolicyHandler for PolicyService {
             }));
         }
 
-        // Create and sign JWT with audience binding (RFC 8707)
-        // Scopes are not embedded in JWT - Casbin enforces authorization server-side
+        // Create and sign JWT with audience (RFC 8707) and the OAuth grant's
+        // scope ceiling. Casbin still supplies subject policy; verifiers must
+        // intersect it with this signed per-grant authority (#1146 T2.1).
         let now = chrono::Utc::now().timestamp();
         let audience = data.audience.as_ref().filter(|s| !s.is_empty()).cloned()
             .or_else(|| self.default_audience.clone());
+        let granted_scope = data.requested_scopes.as_ref().map(|scopes| {
+            scopes.iter()
+                .map(String::as_str)
+                .filter(|scope| !scope.is_empty())
+                .collect::<Vec<_>>()
+                .join(" ")
+        });
 
         // Service tokens: cnf.jwk must be the service's REGISTERED key, never a
         // CA-derived guess (#441/#806) — bootstrap generates independent random
@@ -396,7 +404,8 @@ impl PolicyHandler for PolicyService {
             now,
             now + requested_ttl as i64,
         ).with_issuer(issuer)
-         .with_audience(audience);
+         .with_audience(audience)
+         .with_scope(granted_scope);
 
         // DPoP jkt takes priority over userPubKey (RFC 9449 § 6).
         if let Some(ref jkt) = data.dpop_jkt {


### PR DESCRIPTION
## What

Tightens the generic OAuth AS to atproto's profile so a stock atproto client (e.g. `@atproto/oauth-client-browser`, which www-cyberdione-ai uses) completes the flow unmodified. Pairs with the #948 conformance spike; the XRPC read-slice the token is used against is #1112 (in progress in a sibling worktree).

## Changes (all under `crates/hyprstream/src/services/oauth/` + config)

- **Scopes** — advertise and accept `atproto` and `transition:generic`:
  - RFC 8414 AS metadata (`default_oauth_scopes` in `config/mod.rs`)
  - RFC 9728 self protected-resource document (`self_resource_scopes` in `mod.rs`)
- **RFC 9728 self-reference** — the OAuth service's own protected-resource document points `authorization_servers` at the issuer (resource == issuer), confirming **PDS = its own AS**. Pinned by a test.
- **Token `sub` = account DID** (`token.rs`, `state.rs`, `introspection.rs`):
  - `OAuthState::subject_did` / `subject_did_for` derive the DID subject at the mint boundary.
  - Local usernames → synthesized `did:web:{authority}:users:{name}` (mirrors the external-OIDC `DidWeb` mapping in `user_mapping.rs`).
  - `did:plc` / `did:web` pass through unchanged.
  - Internal bookkeeping (refresh-token entry, profile lookup, device link) stays keyed on the username; only the emitted JWT `sub` is the DID.
  - Refresh-token introspection reports the same DID `sub`.
- **#1113 correction — `did:at9p` fails closed**: `did:at9p` (and any non-plc/non-web DID method) is **not** eligible for atproto OAuth tokens. `subject_did_for` returns `SubjectDidError::UnsupportedMethod` and the token path rejects issuance with `400 invalid_request` rather than minting.
- **DPoP nonce retry contract** (`token.rs`) — the `400 use_dpop_nonce` + `DPoP-Nonce` header shape that `@atproto/oauth-client-browser` retries on is documented and pinned by tests. The resource-server `401` form (XRPC side, `auth.rs`) is #1112's territory and is untouched here.

## Tests

`cargo test -p hyprstream --lib` for the new/oauth tests (11 passed):
- metadata: atproto scope advertisement; PAR-required advertisement
- protected-resource: self-reference + atproto scopes
- subject-DID mapping: local username → did:web, loopback port preservation, did:plc/web passthrough, **did:at9p fail-closed**, incompatible-username rejection
- DPoP nonce retry response shape (400 + `use_dpop_nonce` + `DPoP-Nonce`)

## Scope boundary with #1112

No networking/XRPC endpoints are added. The only shared touchpoint is the OAuth-side token/metadata surface; the resource-server (XRPC) `DPoP-Nonce` 401 path lives in `auth.rs` and is deliberately untouched to keep this PR and #1112 from dirtying each other.

Closes #1113.