### PR TITLE
fix(xet): propagate P2P fetch provenance so unvalidated provider bytes can't skip the persist gate (#1115)

### DIFF
--- a/crates/git-xet-filter/Cargo.toml
+++ b/crates/git-xet-filter/Cargo.toml
@@ -55,6 +55,10 @@ tokio-test.workspace = true
 tracing-subscriber.workspace = true
 tempfile.workspace = true
 parking_lot.workspace = true
+# `testing` brings the in-memory mock object plane so the gittorrent
+# backend's regression tests can drive a real GitTorrentService with
+# deterministic provider behavior (no network).
+hyprstream-p2p = { path = "../hyprstream-p2p", features = ["testing"] }
 
 [features]
 default = ["xet-storage"]

--- a/crates/git-xet-filter/src/gittorrent_storage.rs
+++ b/crates/git-xet-filter/src/gittorrent_storage.rs
@@ -81,7 +81,16 @@ impl GittorrentStorage {
     /// Fetch reconstruction bytes for a Merkle hash without committing any
     /// CID binding. The returned flag is `true` when the bytes did not come
     /// from the already-validated local p2p store and should be persisted by
-    /// the caller only after end-to-end validation.
+    /// the caller only after end-to-end validation — i.e. when they arrived
+    /// via the HTTPS fallback OR via an uncommitted provider hit on a
+    /// non-self-verifying (XET Merkle) CID. The flag is `false` only when
+    /// the service reports the bytes as committed (local store hit or a
+    /// self-verifying fetch that the service committed itself).
+    ///
+    /// Provenance is taken structurally from
+    /// [`GitTorrentService::get_object_by_cid_with_provenance`]; it is never
+    /// assumed from the mere fact of a P2P hit, because the service returns
+    /// provider-fetched XET Merkle bytes without committing them.
     ///
     /// This is an internal helper rather than a [`StorageBackend`] method:
     /// the trait exposes only the `smudge_*` surface, and the extra
@@ -94,9 +103,13 @@ impl GittorrentStorage {
             )
         })?;
 
-        // Try P2P first
-        match self.service.get_object_by_cid(&cid).await {
-            Ok(Some(data)) => return Ok((data, false)),
+        // Try P2P first. Propagate commit provenance rather than assuming
+        // every P2P hit is already-validated: a non-self-verifying CID
+        // (XET Merkle addresses the reconstruction DAG, not the raw file)
+        // is returned uncommitted by the service, and only the caller's
+        // end-to-end size + SHA-256 check can license persisting it.
+        match self.service.get_object_by_cid_with_provenance(&cid).await {
+            Ok(Some(fetch)) => return Ok((fetch.data, !fetch.committed)),
             Ok(None) => {
                 tracing::debug!("Object {} not found in DHT, trying fallback", hash);
             }
@@ -289,5 +302,135 @@ mod tests {
         assert!(GittorrentPointer::parse("not a pointer").is_err());
         let legacy = r#"{"xet":"gittorrent","sha256":"abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789","size":1}"#;
         assert!(GittorrentPointer::parse(legacy).is_err());
+    }
+}
+
+/// Provider-side regression coverage (#1115). These tests drive a real
+/// `GitTorrentService` through its public `testing` mocks so the XET smudge
+/// path — provenance propagation, end-to-end validation, and the persist
+/// gate — flows through production code.
+#[cfg(all(test, feature = "gittorrent-transport"))]
+mod provider_fetch_tests {
+    use super::*;
+    use crate::storage::StorageBackend;
+    use hyprstream_p2p::locator::PeerContact;
+    use hyprstream_p2p::service::testing::{
+        new_service_with_mocks, test_config, MockBlobFetcher, MockObjectLocator,
+    };
+    use hyprstream_p2p::ContentCid;
+    use std::net::{Ipv4Addr, SocketAddrV4};
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    fn p2p_err(e: hyprstream_p2p::Error) -> XetError {
+        XetError::new(XetErrorKind::DownloadFailed, e.to_string())
+    }
+
+    fn io_err(e: std::io::Error) -> XetError {
+        XetError::new(XetErrorKind::IoError, e.to_string())
+    }
+
+    /// Build a storage backed by a mock object plane that advertises `data`
+    /// under `merkle_bytes` from a single local provider.
+    async fn storage_with_provider(
+        temp: &TempDir,
+        merkle_bytes: [u8; 32],
+        data: Vec<u8>,
+    ) -> Result<(
+        GittorrentStorage,
+        Arc<MockObjectLocator>,
+        Arc<MockBlobFetcher>,
+    )> {
+        let locator = Arc::new(MockObjectLocator::default());
+        let fetcher = Arc::new(MockBlobFetcher::default());
+        let service =
+            new_service_with_mocks(test_config(temp.path()), locator.clone(), fetcher.clone())
+                .await
+                .map_err(p2p_err)?;
+        let cid = ContentCid::xet_merkle(&merkle_bytes).map_err(p2p_err)?;
+        locator
+            .add_provider_for_content(
+                &cid,
+                PeerContact::untrusted(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 6881)),
+            )
+            .await;
+        fetcher.insert_raw(cid, data).await;
+        Ok((
+            GittorrentStorage::new(Arc::new(service), None),
+            locator,
+            fetcher,
+        ))
+    }
+
+    fn pointer_json(merkle_hex: &str, sha256_hex: &str, size: u64) -> String {
+        serde_json::json!({
+            "xet": "gittorrent",
+            "xet-merkle": merkle_hex,
+            "sha256": sha256_hex,
+            "size": size,
+        })
+        .to_string()
+    }
+
+    /// Regression for #1115: provider-fetched XET Merkle bytes that pass the
+    /// pointer's end-to-end size + SHA-256 check MUST be persisted to the
+    /// p2p object plane. Before the provenance fix, `fetch_from_hash` mapped
+    /// every P2P hit to `uncommitted = false`, so `smudge_bytes` skipped the
+    /// persist and the next fetch re-hit the provider.
+    #[tokio::test]
+    async fn provider_fetched_xet_bytes_are_persisted_after_validation() -> Result<()> {
+        let temp = TempDir::new().map_err(io_err)?;
+        let data = b"xet payload from provider".to_vec();
+        let merkle_bytes = [0x7f_u8; 32];
+        let merkle_hex: String = merkle_bytes.iter().map(|b| format!("{b:02x}")).collect();
+        let sha256 = hyprstream_p2p::crypto::hash::sha256_git(&data).map_err(p2p_err)?;
+        let (storage, _locator, fetcher) =
+            storage_with_provider(&temp, merkle_bytes, data.clone()).await?;
+        let pointer = pointer_json(&merkle_hex, &sha256.to_string(), data.len() as u64);
+
+        // First smudge: provider fetch + end-to-end validation + persist.
+        let smudged = storage.smudge_bytes(&pointer).await?;
+        assert_eq!(smudged, data);
+        assert_eq!(fetcher.calls().await, 1, "first smudge hits the provider");
+
+        // Second smudge: bytes are now committed locally, so the provider is
+        // NOT consulted again. Before the fix this re-fetched (calls == 2)
+        // because the unvalidated provider bytes were never persisted.
+        let smudged_again = storage.smudge_bytes(&pointer).await?;
+        assert_eq!(smudged_again, data);
+        assert_eq!(
+            fetcher.calls().await,
+            1,
+            "validated provider bytes are served from the local store on retry"
+        );
+        Ok(())
+    }
+
+    /// The persistence gate must NOT fire when validation fails: a provider
+    /// returning the wrong bytes is rejected, not persisted.
+    #[tokio::test]
+    async fn provider_fetched_xet_bytes_with_wrong_sha256_are_rejected() -> Result<()> {
+        let temp = TempDir::new().map_err(io_err)?;
+        let bogus = b"definitely not the real payload".to_vec();
+        let real_sha =
+            hyprstream_p2p::crypto::hash::sha256_git(b"the real payload").map_err(p2p_err)?;
+        let merkle_bytes = [0x33_u8; 32];
+        let merkle_hex: String = merkle_bytes.iter().map(|b| format!("{b:02x}")).collect();
+        let (storage, _locator, _fetcher) =
+            storage_with_provider(&temp, merkle_bytes, bogus).await?;
+        // Pointer describes the real payload; provider serves something else.
+        let pointer = pointer_json(&merkle_hex, &real_sha.to_string(), 16);
+
+        match storage.smudge_bytes(&pointer).await {
+            Err(err) => assert!(
+                matches!(err.kind(), XetErrorKind::DownloadFailed),
+                "validation failure must surface as DownloadFailed, got {:?}",
+                err.kind()
+            ),
+            Ok(bytes) => {
+                panic!("validation must reject provider bytes with wrong SHA-256; got {bytes:?}")
+            }
+        }
+        Ok(())
     }
 }

--- a/crates/git-xet-filter/src/gittorrent_storage.rs
+++ b/crates/git-xet-filter/src/gittorrent_storage.rs
@@ -411,7 +411,9 @@ mod provider_fetch_tests {
     #[tokio::test]
     async fn provider_fetched_xet_bytes_with_wrong_sha256_are_rejected() -> Result<()> {
         let temp = TempDir::new().map_err(io_err)?;
-        let bogus = b"definitely not the real payload".to_vec();
+        // Same length as the declared real payload so the size check passes
+        // and the SHA-256 check is the gate actually exercised here.
+        let bogus = b"not real payload".to_vec();
         let real_sha =
             hyprstream_p2p::crypto::hash::sha256_git(b"the real payload").map_err(p2p_err)?;
         let merkle_bytes = [0x33_u8; 32];

--- a/crates/hyprstream-p2p/Cargo.toml
+++ b/crates/hyprstream-p2p/Cargo.toml
@@ -98,6 +98,11 @@ quote = "1"
 default = []
 # Enable additional debug logging
 debug = []
+# Expose the `service::testing` module (in-memory mock object plane) so
+# downstream crates can write regression tests against a real
+# `GitTorrentService` with deterministic provider behavior. No production
+# impact; compiled under `cfg(test)` automatically.
+testing = []
 # F3 (#901) retired the libp2p Kademlia stack. iroh-blobs + the mainline
 # locator are now the unconditional object plane (non-optional deps above).
 # These names remain as no-op markers so existing `--features` flags (e.g. the

--- a/crates/hyprstream-p2p/src/service.rs
+++ b/crates/hyprstream-p2p/src/service.rs
@@ -200,6 +200,30 @@ pub struct RepositoryMetadata {
     pub lfs_chunks: Vec<String>,
 }
 
+/// The bytes of an object fetched by CID, paired with their commit
+/// provenance so callers can decide whether persistence is safe.
+///
+/// `committed == true` means the bytes are already durable in the local
+/// validated store (the in-memory cache or the blob plane) or were
+/// self-verified against the CID and committed during this fetch — safe
+/// for the caller to treat as validated.
+///
+/// `committed == false` means the bytes were returned by a remote
+/// provider under a CID that cannot self-verify them (e.g. an XET Merkle
+/// CID, which addresses the reconstruction DAG rather than the raw file).
+/// The service deliberately does NOT commit such bytes (it cannot prove
+/// they match the CID); the caller MUST validate them end-to-end (e.g.
+/// pointer size + SHA-256) before persisting or treating them as
+/// committed. Conflating this case with `committed == true` lets
+/// unvalidated provider bytes leak past a caller's persistence gate.
+#[derive(Debug, Clone)]
+pub struct ObjectFetch {
+    /// The fetched object bytes.
+    pub data: Vec<u8>,
+    /// Whether the bytes are committed to the local validated store.
+    pub committed: bool,
+}
+
 /// Statistics about objects in a repository
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ObjectStats {
@@ -350,7 +374,7 @@ impl GitTorrentService {
         })
     }
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "testing"))]
     async fn new_with_object_plane(
         config: GitTorrentConfig,
         locator: Arc<dyn ObjectLocator>,
@@ -391,19 +415,51 @@ impl GitTorrentService {
     }
 
     /// Get an object by its canonical content CID.
+    ///
+    /// Discards commit provenance. Callers that persist fetched bytes
+    /// (e.g. the XET smudge path, which must validate before persisting)
+    /// must use [`get_object_by_cid_with_provenance`] instead; treating a
+    /// provider-fetched, non-self-verifying result as already-validated
+    /// bypasses the caller's persistence gate.
     pub async fn get_object_by_cid(&self, cid: &ContentCid) -> Result<Option<Vec<u8>>> {
-        // Check local cache first
+        Ok(self
+            .get_object_by_cid_with_provenance(cid)
+            .await?
+            .map(|fetch| fetch.data))
+    }
+
+    /// Get an object by its canonical content CID, along with its commit
+    /// provenance.
+    ///
+    /// See [`ObjectFetch`] for the meaning of `committed`. The provenance
+    /// is structural: it is derived from which store produced the bytes
+    /// and whether the CID can self-verify them, never from a caller
+    /// assertion. A non-`committed` result must not be persisted without
+    /// end-to-end validation.
+    pub async fn get_object_by_cid_with_provenance(
+        &self,
+        cid: &ContentCid,
+    ) -> Result<Option<ObjectFetch>> {
+        // Check local cache first. The cache only ever holds committed
+        // bytes (see `put_object_by_cid` and the self-verifying provider
+        // path below), so a hit is committed by construction.
         {
             let cache = self.object_cache.read().await;
             if let Some(data) = cache.get(cid) {
-                return Ok(Some(data.clone()));
+                return Ok(Some(ObjectFetch {
+                    data: data.clone(),
+                    committed: true,
+                }));
             }
         }
 
         if let Some(data) = self.object_plane.blobs.get_object_by_cid(cid).await? {
             let mut cache = self.object_cache.write().await;
             cache.insert(cid.clone(), data.clone());
-            return Ok(Some(data));
+            return Ok(Some(ObjectFetch {
+                data,
+                committed: true,
+            }));
         }
 
         let rendezvous = locator_cid_from_content(cid);
@@ -428,7 +484,10 @@ impl GitTorrentService {
                 )
             );
             if !self_verifying {
-                return Ok(Some(data));
+                return Ok(Some(ObjectFetch {
+                    data,
+                    committed: false,
+                }));
             }
             self.object_plane
                 .blobs
@@ -436,7 +495,10 @@ impl GitTorrentService {
                 .await?;
             let mut cache = self.object_cache.write().await;
             cache.insert(cid.clone(), data.clone());
-            return Ok(Some(data));
+            return Ok(Some(ObjectFetch {
+                data,
+                committed: true,
+            }));
         }
 
         Ok(None)
@@ -862,22 +924,31 @@ impl GitTorrentService {
     }
 }
 
-#[cfg(test)]
-mod tests {
+/// Test infrastructure for downstream crates that need to exercise
+/// `GitTorrentService` against an in-memory, deterministic object plane.
+///
+/// Compiled under `cfg(test)` and the `testing` cargo feature. The mock
+/// store and fetcher simulate a remote provider advertising bytes; the
+/// service is the real production type, so provenance and persistence
+/// flow through the same code paths as in deployment.
+#[cfg(any(test, feature = "testing"))]
+pub mod testing {
     use super::*;
     use std::collections::HashMap as StdHashMap;
-    use std::net::{Ipv4Addr, SocketAddrV4};
-    use tempfile::TempDir;
     use tokio::sync::Mutex;
 
+    /// In-memory `ObjectLocator` that hands back whatever providers were
+    /// registered for a rendezvous CID. Never touches the network.
     #[derive(Default)]
-    struct MockObjectLocator {
+    pub struct MockObjectLocator {
         announcements: Mutex<Vec<(Cid512, Option<u16>)>>,
         providers: Mutex<StdHashMap<Cid512, Vec<PeerContact>>>,
     }
 
     impl MockObjectLocator {
-        async fn add_provider(&self, cid: Cid512, provider: PeerContact) {
+        /// Register a provider for a rendezvous CID, mirroring a BEP5
+        /// `get_peers` hit.
+        pub async fn add_provider(&self, cid: Cid512, provider: PeerContact) {
             self.providers
                 .lock()
                 .await
@@ -886,7 +957,21 @@ mod tests {
                 .push(provider);
         }
 
-        async fn announcements(&self) -> Vec<(Cid512, Option<u16>)> {
+        /// Convenience wrapper: register a provider for a content CID,
+        /// mapping it to its rendezvous CID the way the real mainline
+        /// locator would. Hides the private content→rendezvous mapping
+        /// from downstream test code.
+        pub async fn add_provider_for_content(
+            &self,
+            content_cid: &ContentCid,
+            provider: PeerContact,
+        ) {
+            self.add_provider(locator_cid_from_content(content_cid), provider)
+                .await;
+        }
+
+        /// Announcements recorded by `announce`, in insertion order.
+        pub async fn announcements(&self) -> Vec<(Cid512, Option<u16>)> {
             self.announcements.lock().await.clone()
         }
     }
@@ -909,20 +994,33 @@ mod tests {
         }
     }
 
+    /// In-memory `RemoteBlobFetcher` keyed by content CID. Simulates a
+    /// remote provider returning bytes (which may or may not match the
+    /// CID — the service cannot tell for non-self-verifying CIDs).
     #[derive(Default)]
-    struct MockBlobFetcher {
+    pub struct MockBlobFetcher {
         objects: Mutex<StdHashMap<ContentCid, Vec<u8>>>,
         calls: Mutex<usize>,
     }
 
     impl MockBlobFetcher {
-        async fn insert(&self, hash: Sha256Hash, data: Vec<u8>) -> Result<()> {
+        /// Insert a Git object keyed by its SHA-256 hash (self-verifying).
+        pub async fn insert(&self, hash: Sha256Hash, data: Vec<u8>) -> Result<()> {
             let cid = ContentCid::git_sha256(&hash)?;
             self.objects.lock().await.insert(cid, data);
             Ok(())
         }
 
-        async fn calls(&self) -> usize {
+        /// Insert raw bytes keyed by an arbitrary CID. Used to simulate a
+        /// provider returning bytes under a non-self-verifying CID (e.g.
+        /// an XET Merkle CID), which is the case the service must NOT
+        /// commit before caller validation.
+        pub async fn insert_raw(&self, cid: ContentCid, data: Vec<u8>) {
+            self.objects.lock().await.insert(cid, data);
+        }
+
+        /// Number of `fetch` invocations observed.
+        pub async fn calls(&self) -> usize {
             *self.calls.lock().await
         }
     }
@@ -939,7 +1037,9 @@ mod tests {
         }
     }
 
-    fn test_config(path: &Path) -> GitTorrentConfig {
+    /// Build a `GitTorrentConfig` whose storage lives under `path` and
+    /// whose auto-discovery is off, so tests never reach the network.
+    pub fn test_config(path: &std::path::Path) -> GitTorrentConfig {
         GitTorrentConfig {
             storage_dir: path.to_path_buf(),
             bootstrap_nodes: vec![],
@@ -947,6 +1047,29 @@ mod tests {
             ..Default::default()
         }
     }
+
+    /// Construct a real `GitTorrentService` backed by the supplied mocks.
+    ///
+    /// The private locator/fetcher trait bounds stay internal to this
+    /// module so downstream callers configure the service purely through
+    /// the public mock methods.
+    pub async fn new_service_with_mocks(
+        config: GitTorrentConfig,
+        locator: Arc<MockObjectLocator>,
+        fetcher: Arc<MockBlobFetcher>,
+    ) -> Result<GitTorrentService> {
+        GitTorrentService::new_with_object_plane(config, locator, fetcher).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::testing::{
+        new_service_with_mocks, test_config, MockBlobFetcher, MockObjectLocator,
+    };
+    use std::net::{Ipv4Addr, SocketAddrV4};
+    use tempfile::TempDir;
 
     #[tokio::test]
     async fn test_service_creation() -> crate::error::Result<()> {
@@ -1069,7 +1192,7 @@ mod tests {
         let temp_dir = TempDir::new()?;
         let locator = Arc::new(MockObjectLocator::default());
         let fetcher = Arc::new(MockBlobFetcher::default());
-        let service = GitTorrentService::new_with_object_plane(
+        let service = new_service_with_mocks(
             test_config(temp_dir.path()),
             locator.clone(),
             fetcher.clone(),
@@ -1084,7 +1207,7 @@ mod tests {
                 PeerContact::untrusted(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 6881)),
             )
             .await;
-        fetcher.objects.lock().await.insert(cid.clone(), data.clone());
+        fetcher.insert_raw(cid.clone(), data.clone()).await;
 
         assert_eq!(
             service.get_object_by_cid(&cid).await?.as_deref(),
@@ -1103,6 +1226,76 @@ mod tests {
             Some(data.as_slice())
         );
         assert_eq!(fetcher.calls().await, 2, "uncommitted bytes are re-fetched");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_get_object_by_cid_provenance_distinguishes_committed_from_provider_xet_bytes(
+    ) -> crate::error::Result<()> {
+        // Regression for #1115: provider-fetched XET (non-self-verifying)
+        // bytes must surface as `committed == false` so the caller's
+        // persistence gate fires. A cache/blob hit and a self-verifying
+        // provider fetch must surface as `committed == true`.
+        let temp_dir = TempDir::new()?;
+
+        // --- Provider-fetched XET Merkle bytes: NOT committed. ---
+        let locator = Arc::new(MockObjectLocator::default());
+        let fetcher = Arc::new(MockBlobFetcher::default());
+        let service = new_service_with_mocks(
+            test_config(temp_dir.path()),
+            locator.clone(),
+            fetcher.clone(),
+        )
+        .await?;
+        let xet_data = b"xet reconstruction bytes".to_vec();
+        let xet_cid = ContentCid::xet_merkle(&[0x7f; 32])?;
+        locator
+            .add_provider(
+                locator_cid_from_content(&xet_cid),
+                PeerContact::untrusted(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 6881)),
+            )
+            .await;
+        fetcher.insert_raw(xet_cid.clone(), xet_data.clone()).await;
+
+        let fetch = service
+            .get_object_by_cid_with_provenance(&xet_cid)
+            .await?
+            .ok_or_else(|| crate::Error::not_found("provider did not return the XET object"))?;
+        assert_eq!(fetch.data, xet_data);
+        assert!(
+            !fetch.committed,
+            "provider-fetched XET bytes must not be reported committed"
+        );
+
+        // --- Self-verifying Git CID provider fetch: committed. ---
+        let git_data = b"self-verifying git object".to_vec();
+        let git_hash = sha256_git(&git_data)?;
+        let git_cid = ContentCid::git_sha256(&git_hash)?;
+        locator
+            .add_provider(
+                locator_cid_from_content(&git_cid),
+                PeerContact::untrusted(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 6882)),
+            )
+            .await;
+        fetcher.insert(git_hash, git_data.clone()).await?;
+        let fetch = service
+            .get_object_by_cid_with_provenance(&git_cid)
+            .await?
+            .ok_or_else(|| crate::Error::not_found("provider did not return the Git object"))?;
+        assert_eq!(fetch.data, git_data);
+        assert!(
+            fetch.committed,
+            "self-verifying provider bytes are committed during fetch"
+        );
+
+        // --- Local cache hit (the prior line cached it): committed. ---
+        let fetch = service
+            .get_object_by_cid_with_provenance(&git_cid)
+            .await?
+            .ok_or_else(|| crate::Error::not_found("object was not cached"))?;
+        assert!(fetch.committed, "cache hits are committed");
+        // No additional provider fetch for the cached path.
+        assert_eq!(fetcher.calls().await, 2);
         Ok(())
     }
 


### PR DESCRIPTION
Closes #1115.

## The defect

`GittorrentStorage::fetch_from_hash` mapped **every** successful P2P hit to `(data, false)` — the flag meaning *"already validated locally, safe to treat as committed."* But `GitTorrentService::get_object_by_cid` deliberately returns provider-fetched XET Merkle bytes as `Some(data)` **without committing them** (the CID addresses the reconstruction DAG, not the raw file, so the service cannot self-verify). The caller was therefore told unvalidated bytes were validated.

Verified against `main`: `get_object_by_cid` returns at the non-self-verifying arm (`Ok(Some(data))`) without touching the blob store or cache — confirmed by the existing `test_get_object_returns_remote_xet_bytes_uncommitted`, which asserts the bytes are **not** in the local store after a provider fetch.

## The fix (option (a) — structural)

Propagate commit provenance across the service boundary rather than assuming it from the fact of a P2P hit:

- **`hyprstream-p2p`**: add `ObjectFetch { data, committed }` and `GitTorrentService::get_object_by_cid_with_provenance`. `committed` is `true` for cache/blob hits and for self-verifying (GitRaw+SHA-256) provider fetches the service commits itself; `false` for provider-fetched non-self-verifying (XET Merkle) bytes. `get_object_by_cid` now delegates and discards provenance for existing callers.
- **`git-xet-filter`**: `fetch_from_hash` takes `committed` from the service and returns `uncommitted = !committed`. Provider-fetched XET bytes now flow through `smudge_bytes`'s size + SHA-256 gate and are persisted only once validated.
- **`hyprstream-p2p` `testing` feature**: exposes the in-memory mock object plane (`MockObjectLocator`, `MockBlobFetcher`, `new_service_with_mocks`) so downstream crates can regress against a real `GitTorrentService` with deterministic provider behavior.

## Regression coverage

- `hyprstream-p2p`: provenance contract for provider-fetched XET (`committed=false`), self-verifying fetch (`committed=true`), and cache hits (`committed=true`).
- `git-xet-filter`: provider-fetched XET bytes that pass validation are persisted — the **second** `smudge_bytes` serves from the local store with no re-fetch (`fetcher.calls() == 1`). Confirmed this test fails on the pre-fix mapping (`calls == 2`). Provider bytes with the wrong SHA-256 are rejected, not persisted.

## Validation

The `gittorrent_storage` module is behind the **non-default** `gittorrent-transport` feature; `cargo clippy -p git-xet-filter` does not compile it. Verified clean with the required invocation:

```
cargo clippy -p git-xet-filter --all-targets --features gittorrent-transport -- -D warnings
cargo clippy -p hyprstream-p2p --all-targets --features testing -- -D warnings
```