### PR TITLE
fix(ledger): bind spend authorization to the minted transfer id (#985)

### DIFF
--- a/crates/hyprstream/src/services/ledger/credit_gate.rs
+++ b/crates/hyprstream/src/services/ledger/credit_gate.rs
@@ -12,11 +12,11 @@
 //! # Spend-authorization verification (§5.3)
 //!
 //! The subject signs `{grant_cid, host, transfer_id, max_amount, exp}` with its
-//! identity key (COSE composite; Classical-only clients yield Classical-
-//! assurance receipts, labeled not rejected). [`CreditGate::verify_spend_authz`]
-//! verifies that signature against the *same* verified key material as the
-//! envelope. The authorization is captured at admission — no signature
-//! round-trip at completion time.
+//! identity key using a PQ-hybrid COSE composite. Ledger admission is an
+//! internal surface, so Classical-only signatures are rejected.
+//! [`CreditGate::verify_spend_authz`] verifies that signature against the
+//! *same* verified key material as the envelope. The authorization is captured
+//! at admission — no signature round-trip at completion time.
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -127,19 +127,16 @@ impl SpendAuthorization {
 }
 
 impl CreditGate {
-    /// Verify a spend-authorization signature against the subject's verified
-    /// key material (§5.3). `require_pq` follows the cell's `CryptoPolicy` — a
-    /// Classical-only client yields a Classical-assurance receipt (labeled, not
-    /// rejected), so callers pass `require_pq = false` when no PQ key is
-    /// presented.
+    /// Verify a PQ-hybrid spend-authorization signature against the subject's
+    /// verified key material (§5.3). Ledger admission is internal, so absent
+    /// PQ key material fails closed rather than selecting Classical policy.
     pub fn verify_spend_authz(
         authz: &SpendAuthorization,
         ed_vk: &ed25519_dalek::VerifyingKey,
         pq_vk: Option<&MlDsaVerifyingKey>,
-        require_pq: bool,
     ) -> Result<(), DenyReason> {
         let payload = authz.digest();
-        verify_composite(&authz.signature, ed_vk, pq_vk, &payload, &[], require_pq)
+        verify_composite(&authz.signature, ed_vk, pq_vk, &payload, &[], true)
             .map(|_| ())
             .map_err(|e| DenyReason::InvalidSpendAuthorization(e.to_string()))
     }
@@ -505,10 +502,10 @@ mod tests {
             hyprstream_crypto::cose_sign::sign_composite(&ed_sk, Some(&pq_sk), &digest, &[])
                 .unwrap();
 
-        assert!(CreditGate::verify_spend_authz(&authz, &ed_vk, Some(&pq_vk), true).is_ok());
+        assert!(CreditGate::verify_spend_authz(&authz, &ed_vk, Some(&pq_vk)).is_ok());
 
         // Tamper: raising max_amount invalidates the signature.
         authz.max_amount = 2000;
-        assert!(CreditGate::verify_spend_authz(&authz, &ed_vk, Some(&pq_vk), true).is_err());
+        assert!(CreditGate::verify_spend_authz(&authz, &ed_vk, Some(&pq_vk)).is_err());
     }
 }

--- a/crates/hyprstream/src/services/ledger/enforcer.rs
+++ b/crates/hyprstream/src/services/ledger/enforcer.rs
@@ -166,7 +166,6 @@ pub struct LocalEnforcer {
     breaker: Arc<DebtBreaker>,
     cell_identity: Did,
     reserve_timeout_s: u32,
-    require_pq: bool,
 }
 
 impl std::fmt::Debug for LocalEnforcer {
@@ -174,7 +173,6 @@ impl std::fmt::Debug for LocalEnforcer {
         f.debug_struct("LocalEnforcer")
             .field("cell_identity", &self.cell_identity)
             .field("reserve_timeout_s", &self.reserve_timeout_s)
-            .field("require_pq", &self.require_pq)
             .finish()
     }
 }
@@ -195,7 +193,6 @@ impl LocalEnforcer {
             breaker,
             cell_identity,
             reserve_timeout_s: config.reserve_timeout_secs,
-            require_pq: config.require_pq_signatures,
         }
     }
 
@@ -267,9 +264,10 @@ impl LocalEnforcer {
         //    the decision that permits work to start, and a zero reservation
         //    cannot be converted into a nonzero post later — so an unsigned
         //    zero admission would be unauthenticated work, not harmless
-        //    accounting (PR #1129 review, finding 1). Classical-only clients
-        //    are accepted only when the operator explicitly disabled the PQ
-        //    requirement; a configured requirement refuses absent evidence.
+        //    accounting (PR #1129 review, finding 1). Ledger admission is an
+        //    internal hyprstream-to-hyprstream surface: PQ-hybrid is mandatory
+        //    and absent PQ key material is a hard rejection, never a request
+        //    to select Classical verification.
         {
             match &req.spend_authz {
                 Some(authz) => {
@@ -311,19 +309,10 @@ impl LocalEnforcer {
                             ),
                         ));
                     }
-                    if self.require_pq && subject.pq_vk.is_none() {
-                        return AdmissionResult::Rejected(Rejection::hard(
-                            DenyReason::InvalidSpendAuthorization(
-                                "configured PQ signature requirement has no authenticated PQ key"
-                                    .to_owned(),
-                            ),
-                        ));
-                    }
                     if let Err(reason) = CreditGate::verify_spend_authz(
                         authz,
                         &subject.ed_vk,
                         subject.pq_vk.as_ref(),
-                        self.require_pq,
                     ) {
                         return AdmissionResult::Rejected(Rejection::hard(reason));
                     }
@@ -597,7 +586,6 @@ mod tests {
         gate.materialize(&cid(1), bal.available);
         let cfg = LedgerConfig {
             enabled: true,
-            require_pq_signatures: false,
             ..LedgerConfig::default()
         };
         let breaker = Arc::new(DebtBreaker::new(&cfg, gate.generation_handle()));
@@ -773,6 +761,46 @@ mod tests {
         }
     }
 
+    /// Ledger admission is an internal surface, so a caller cannot select
+    /// Classical verification by omitting the required ML-DSA-65 key.
+    #[tokio::test]
+    async fn missing_pq_key_denied_hard() {
+        let (enf, holder, grant_cid, _debit, _credit, ed_sk, pq_sk) = fixture(1000).await;
+        let nonce = rand_nonce();
+        let (authz, _ed_vk, _pq_vk, _tid) = signed_authz(
+            &grant_cid,
+            enf.cell_identity(),
+            nonce,
+            100,
+            u64::MAX,
+            &ed_sk,
+            &pq_sk,
+        );
+        let req = AdmissionRequest {
+            authenticated_subject: Some(AuthenticatedSubject {
+                did: holder,
+                ed_vk: ed_sk.verifying_key(),
+                pq_vk: None,
+            }),
+            grant_cid,
+            unit: unit(),
+            amount: 100,
+            nonce,
+            spend_authz: Some(authz),
+        };
+        match enf.admit(&req, 0).await {
+            AdmissionResult::Rejected(r) => {
+                assert!(
+                    matches!(r.reason, DenyReason::InvalidSpendAuthorization(_)),
+                    "expected InvalidSpendAuthorization, got {:?}",
+                    r.reason
+                );
+                assert!(r.retry_after_secs.is_none(), "must be a hard reject");
+            }
+            other => panic!("admission without a PQ key must be denied, got {other:?}"),
+        }
+    }
+
     #[tokio::test]
     async fn admitted_then_post_and_void_roundtrip() {
         let (enf, _holder, grant_cid, debit, credit, ed_sk, pq_sk) = fixture(1000).await;
@@ -813,13 +841,11 @@ mod tests {
         assert!(post.is_ok(), "post should succeed: {post:?}");
     }
 
-    /// A configured PQ requirement is not conditional on whether transport
-    /// happened to expose a PQ key. Missing authenticated material must refuse,
-    /// never turn the policy off (#1145).
+    /// Ledger admission cannot select Classical verification by presenting a
+    /// Classical-only authorization.
     #[tokio::test]
-    async fn configured_pq_requirement_without_authenticated_key_denied_hard() {
-        let (mut enf, holder, grant_cid, _debit, _credit, ed_sk, _pq_sk) = fixture(1000).await;
-        enf.require_pq = true;
+    async fn classical_only_authz_denied_hard() {
+        let (enf, holder, grant_cid, _debit, _credit, ed_sk, _pq_sk) = fixture(1000).await;
         let nonce = rand_nonce();
         let mut authz = SpendAuthorization {
             grant_cid: grant_cid.clone(),


### PR DESCRIPTION
Closes the N1 pre-activation gate from #985 (fable review of PR #981).

## The gap

`admit()` verified the spend authorization's signature, grant binding, host, and amount ceiling — but never compared `authz.transfer_id` to the transfer id minted for this admission, even though that field is folded into the signed digest. One signed authorization therefore authenticated arbitrarily many distinct transfers (different nonces), each up to `max_amount`, for its whole `exp` window: replay amplification within the subject's own credit and a break of the per-transfer authorization semantics (#681).

## The fix

- Mint the deterministic transfer id **before** authz verification (it is a pure hash of `grant_cid` + `nonce`, no side effects) and hard-reject on `authz.transfer_id != transfer_id`.
- Add the negative test the happy path was masking: `authz_for_different_transfer_denied_hard` signs for nonce 7 and submits nonce 8 — signature verifies, minted id differs, admission must hard-reject with `InvalidSpendAuthorization`.

## Verification

All 19 `services::ledger` tests pass under `--features ledger`, including the pre-existing roundtrip (proving the equality check does not break the legitimate single-nonce flow).

## Scope

Deliberately N1-only. N2–N6 from the same review (grant cache not generation-scoped, PQ downgrade labeling, post_actual remainder release, factory block_on, optional hyprstream-crypto) remain open on #985 — N2 was independently re-confirmed as a second activation blocker by the 2026-07-21 UCAN LOE evaluation and should be its own change.

Refs #985, #925, #681. Consumer context: www-cyberdione-ai epic #39 P3 is hard-gated on this landing before any entitlement enforcement activates.