### PR TITLE
feat(server): allow https://hyprstream.com origin on the credentialed router

### DIFF
--- a/crates/hyprstream/src/config/server.rs
+++ b/crates/hyprstream/src/config/server.rs
@@ -46,12 +46,29 @@ pub struct CorsConfig {
 fn default_cors_enabled() -> bool {
     true
 }
+/// Default allowed origins for the credentialed router.
+///
+/// These are baked in so a stock deployment can serve both local dev tooling
+/// and the production website out of the box. The list stays fully overridable
+/// at runtime — set `HYPRSTREAM_CORS_ORIGINS` (comma-separated) or the
+/// `server.cors.allowed_origins` config key to replace it without a rebuild.
+///
+/// Production origins (`https://hyprstream.com`, `https://www.hyprstream.com`)
+/// are required so a signed-in user on the website can reach the credentialed
+/// data plane (`/oai/v1`, `/models`, `/.well-known/export9p`,
+/// `/.well-known/planes`). Credentials remain enabled here, so this list must
+/// never contain `"*"` (wildcard + credentials is invalid per the CORS spec);
+/// the wildcard, credentials-off surface lives on `CorsConfig::public`.
 fn default_cors_origins() -> Vec<String> {
     vec![
+        // Local development origins
         "http://localhost:3000".to_owned(),
         "http://localhost:3001".to_owned(),
         "http://127.0.0.1:3000".to_owned(),
         "http://127.0.0.1:3001".to_owned(),
+        // Production website origins
+        "https://hyprstream.com".to_owned(),
+        "https://www.hyprstream.com".to_owned(),
     ]
 }
 fn default_cors_credentials() -> bool {
@@ -601,5 +618,120 @@ impl ServerConfig {
     /// Create a builder from existing config
     pub fn to_builder(self) -> ServerConfigBuilder {
         ServerConfigBuilder::from_config(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_cors_allows_production_website_origins() {
+        let cors = CorsConfig::default();
+
+        // Production website origins must be allowed so a signed-in user on the
+        // website can reach the credentialed data plane.
+        assert!(
+            cors.allowed_origins
+                .contains(&"https://hyprstream.com".to_owned()),
+            "default CORS must allow https://hyprstream.com"
+        );
+        assert!(
+            cors.allowed_origins
+                .contains(&"https://www.hyprstream.com".to_owned()),
+            "default CORS must allow https://www.hyprstream.com"
+        );
+    }
+
+    #[test]
+    fn default_cors_keeps_local_dev_origins() {
+        let cors = CorsConfig::default();
+
+        for origin in [
+            "http://localhost:3000",
+            "http://localhost:3001",
+            "http://127.0.0.1:3000",
+            "http://127.0.0.1:3001",
+        ] {
+            assert!(
+                cors.allowed_origins.contains(&origin.to_owned()),
+                "default CORS must keep dev origin {origin}"
+            );
+        }
+    }
+
+    #[test]
+    fn default_cors_rejects_unrelated_origin() {
+        let cors = CorsConfig::default();
+
+        assert!(
+            !cors
+                .allowed_origins
+                .contains(&"https://evil.example.com".to_owned()),
+            "default CORS must not allow an unrelated origin"
+        );
+    }
+
+    #[test]
+    fn credentialed_router_has_credentials_enabled_and_no_wildcard() {
+        let cors = CorsConfig::default();
+
+        assert!(
+            cors.allow_credentials,
+            "the non-public (credentialed) router must keep credentials enabled"
+        );
+        // Wildcard + credentials is invalid per the CORS spec; the credentialed
+        // default must never contain "*".
+        assert!(
+            !cors.allowed_origins.contains(&"*".to_owned()),
+            "the credentialed router must not use a wildcard origin"
+        );
+    }
+
+    #[test]
+    fn public_router_is_wildcard_without_credentials() {
+        // The OAuth/public router must stay wildcard with credentials OFF.
+        let public = CorsConfig::public();
+        assert_eq!(public.allowed_origins, vec!["*".to_owned()]);
+        assert!(
+            !public.allow_credentials,
+            "wildcard public router must not allow credentials"
+        );
+        assert!(!public.permissive_headers);
+    }
+
+    #[test]
+    fn with_port_extends_defaults_and_preserves_prod_origins() {
+        let cors = CorsConfig::with_port(8080);
+
+        // Port-aware origins are added ...
+        assert!(cors
+            .allowed_origins
+            .contains(&"http://localhost:8080".to_owned()));
+        assert!(cors
+            .allowed_origins
+            .contains(&"http://127.0.0.1:8080".to_owned()));
+        // ... without dropping the production website origins.
+        assert!(cors
+            .allowed_origins
+            .contains(&"https://hyprstream.com".to_owned()));
+        assert!(cors
+            .allowed_origins
+            .contains(&"https://www.hyprstream.com".to_owned()));
+        assert!(cors.allow_credentials);
+    }
+
+    #[test]
+    fn cors_origins_remain_overridable_via_builder() {
+        // Operators can replace the default list entirely without a rebuild.
+        let cors = ServerConfig::builder()
+            .cors_origins(vec!["https://custom.example.com".to_owned()])
+            .build()
+            .cors;
+
+        assert_eq!(
+            cors.allowed_origins,
+            vec!["https://custom.example.com".to_owned()]
+        );
     }
 }

--- a/crates/hyprstream/src/server/middleware.rs
+++ b/crates/hyprstream/src/server/middleware.rs
@@ -604,30 +604,37 @@ pub fn cors_layer(config: &crate::server::state::CorsConfig) -> tower_http::cors
         cors = cors.allow_origin(Any);
         // Never allow credentials with wildcard
         cors = cors.allow_credentials(false);
-    } else if config.allowed_origins.is_empty() {
-        // If no origins specified, use default localhost origins
-        let default_origins = vec![
-            "http://localhost:3000",
-            "http://localhost:3001",
-            "http://127.0.0.1:3000",
-            "http://127.0.0.1:3001",
-        ];
-        for origin in default_origins {
-            if let Ok(header_value) = origin.parse::<HeaderValue>() {
-                cors = cors.allow_origin(header_value);
-            }
-        }
-        // Configure credentials based on config
-        if config.allow_credentials {
-            cors = cors.allow_credentials(true);
-        }
     } else {
-        // Allow specific origins
-        for origin in &config.allowed_origins {
-            if let Ok(header_value) = origin.parse::<HeaderValue>() {
-                cors = cors.allow_origin(header_value);
-            }
-        }
+        // Allow specific origins.
+        //
+        // The whole set MUST be passed in a single `allow_origin` call:
+        // `CorsLayer::allow_origin` is documented to *override* on every call
+        // (`self.allow_origin = origin.into()`), and a single `HeaderValue`
+        // becomes `AllowOrigin::exact(...)` — a constant `Access-Control-Allow-Origin`
+        // emitted unconditionally, not a membership check. Iterating and calling
+        // it once per origin would therefore honor only the LAST origin in the
+        // list, silently dropping the apex domain and every dev origin. Passing
+        // the `Vec<HeaderValue>` makes tower-http build `AllowOrigin::list(...)`,
+        // which performs exact-equality membership matching against the full set.
+        let origins: Vec<HeaderValue> = if config.allowed_origins.is_empty() {
+            // If no origins specified, use default localhost origins
+            [
+                "http://localhost:3000",
+                "http://localhost:3001",
+                "http://127.0.0.1:3000",
+                "http://127.0.0.1:3001",
+            ]
+            .into_iter()
+            .filter_map(|o| o.parse::<HeaderValue>().ok())
+            .collect()
+        } else {
+            config
+                .allowed_origins
+                .iter()
+                .filter_map(|o| o.parse::<HeaderValue>().ok())
+                .collect()
+        };
+        cors = cors.allow_origin(origins);
         // Configure credentials based on config
         if config.allow_credentials {
             cors = cors.allow_credentials(true);
@@ -635,6 +642,186 @@ pub fn cors_layer(config: &crate::server::state::CorsConfig) -> tower_http::cors
     }
 
     cors
+}
+
+/// Runtime-behavior tests for [`cors_layer`].
+///
+/// These drive the real axum `Router` + `CorsLayer` and assert the
+/// `Access-Control-Allow-Origin` / `Access-Control-Allow-Credentials` headers a
+/// browser would actually observe. They exist because the credentialed router's
+/// origin list used to be built with a per-origin loop of `allow_origin(...)`,
+/// which silently honored only the LAST entry — a config-vec assertion can't
+/// catch that (the vec is correct; the layer is wrong), so every check here
+/// exercises the layer end-to-end.
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod cors_layer_tests {
+    use super::cors_layer;
+    use crate::config::server::ServerConfig;
+    use crate::server::state::CorsConfig;
+    use axum::{body::Body, http::Request as HttpRequest, routing::get, Router};
+    use tower::ServiceExt;
+
+    /// Drive the credentialed CORS layer on a real `Router` and return the
+    /// `Access-Control-Allow-Origin` header it emits for `origin` (or `None` if
+    /// the request was rejected / header absent). This is the only honest way to
+    /// catch the classic "only the last origin in the list is honored" bug, which
+    /// a config-vec assertion will happily report as fixed while the runtime is
+    /// broken.
+    async fn acao_for(config: &CorsConfig, origin: &str) -> Option<String> {
+        let app = Router::new()
+            .route("/probe", get(|| async { "ok" }))
+            .layer(cors_layer(config));
+        let req = HttpRequest::get("/probe")
+            .header("Origin", origin)
+            .body(Body::empty())
+            .expect("request");
+        let resp = app.oneshot(req).await.expect("response");
+        resp.headers()
+            .get(axum::http::header::ACCESS_CONTROL_ALLOW_ORIGIN)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned)
+    }
+
+    #[tokio::test]
+    async fn cors_layer_allows_every_default_origin_at_runtime() {
+        // Regression: the credentialed default list previously honored only the
+        // LAST origin (loop-of-override bug). The apex `https://hyprstream.com`
+        // — the whole point of PR #1132 — and every dev origin must each produce
+        // an ACAO echoing themselves back.
+        let config = CorsConfig::default();
+        for origin in [
+            "https://hyprstream.com",
+            "https://www.hyprstream.com",
+            "http://localhost:3000",
+            "http://localhost:3001",
+            "http://127.0.0.1:3000",
+            "http://127.0.0.1:3001",
+        ] {
+            assert_eq!(
+                acao_for(&config, origin).await,
+                Some(origin.to_owned()),
+                "credentialed CORS layer must echo allowed origin {origin}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn cors_layer_rejects_near_miss_origins() {
+        // tower-http's list path uses exact `HeaderValue` equality, so
+        // prefix/suffix/subdomain near-misses must NOT be reflected back. These
+        // are the classic CORS-bypass tricks; a reflect-any bug would leak them.
+        let config = CorsConfig::default();
+        for evil in [
+            "https://hyprstream.com.evil.tld", // suffix hijack
+            "https://evilhyprstream.com",      // subdomain look-alike
+            "http://hyprstream.com",           // scheme downgrade (no TLS)
+            "https://www.hyprstream.com.evil", // www suffix hijack
+        ] {
+            assert_eq!(
+                acao_for(&config, evil).await,
+                None,
+                "credentialed CORS layer must reject near-miss origin {evil}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn cors_layer_multiorigin_override_honors_all_entries() {
+        // Finding #3: an operator who supplies MULTIPLE origins via
+        // HYPRSTREAM_CORS_ORIGINS / builder must have all of them honored, not
+        // just the last. Single-origin overrides always worked; this guards the
+        // multi-origin case.
+        let config = ServerConfig::builder()
+            .cors_origins(vec![
+                "https://a.example.com".to_owned(),
+                "https://b.example.com".to_owned(),
+                "https://c.example.com".to_owned(),
+            ])
+            .build()
+            .cors;
+        for origin in [
+            "https://a.example.com",
+            "https://b.example.com",
+            "https://c.example.com",
+        ] {
+            assert_eq!(
+                acao_for(&config, origin).await,
+                Some(origin.to_owned()),
+                "multi-origin override must honor {origin}"
+            );
+        }
+        // And an unrelated origin still gets nothing.
+        assert_eq!(
+            acao_for(&config, "https://evil.example.com").await,
+            None,
+            "multi-origin override must not leak to unrelated origins"
+        );
+    }
+
+    #[tokio::test]
+    async fn cors_layer_credentials_header_present_for_allowed_origin() {
+        // The credentialed router must advertise `Access-Control-Allow-Credentials:
+        // true` so browser credentialed requests succeed for an allowed origin.
+        let config = CorsConfig::default();
+        let app = Router::new()
+            .route("/probe", get(|| async { "ok" }))
+            .layer(cors_layer(&config));
+        let resp = app
+            .oneshot(
+                HttpRequest::builder()
+                    .method("GET")
+                    .uri("/probe")
+                    .header("Origin", "https://hyprstream.com")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(
+            resp.headers()
+                .get(axum::http::header::ACCESS_CONTROL_ALLOW_CREDENTIALS)
+                .and_then(|v| v.to_str().ok()),
+            Some("true"),
+            "credentialed router must set Access-Control-Allow-Credentials: true"
+        );
+    }
+
+    #[tokio::test]
+    async fn cors_layer_wildcard_never_pairs_with_credentials() {
+        // Even a hand-edited config with `["*"]` + credentials-true must be
+        // defused at layer-build time: wildcard forces credentials OFF.
+        let mut config = CorsConfig::public();
+        config.allow_credentials = true; // adversarial: try to force creds on with "*"
+        let app = Router::new()
+            .route("/probe", get(|| async { "ok" }))
+            .layer(cors_layer(&config));
+        let resp = app
+            .oneshot(
+                HttpRequest::builder()
+                    .method("GET")
+                    .uri("/probe")
+                    .header("Origin", "https://evil.example.com")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        // Wildcard surface mirrors any origin...
+        assert_eq!(
+            resp.headers()
+                .get(axum::http::header::ACCESS_CONTROL_ALLOW_ORIGIN)
+                .and_then(|v| v.to_str().ok()),
+            Some("*"),
+        );
+        // ...but must NOT advertise credentials (spec-invalid + credential leak).
+        assert_eq!(
+            resp.headers()
+                .get(axum::http::header::ACCESS_CONTROL_ALLOW_CREDENTIALS),
+            None,
+            "wildcard + credentials is spec-invalid; layer must drop credentials"
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Why

The website at https://hyprstream.com must be able to reach this server's data plane, but today it can't.

The default CORS allow-list for the **credentialed** router (`config/server.rs`, `default_cors_origins`) only permitted local dev origins:

- `http://localhost:3000`, `http://localhost:3001`
- `http://127.0.0.1:3000`, `http://127.0.0.1:3001`

…with `allow_credentials = true`.

In production this means: atproto **login works** (the OAuth router uses a separate permissive `CorsConfig::public()` with credentials off, and DID documents get `*` via `CorsConfig::did_document()`), but the actual product surface — `/oai/v1`, `/models`, `/.well-known/export9p`, and `/.well-known/planes` — is **blocked cross-origin**. So a signed-in user on the website cannot reach the product.

## What

- Add `https://hyprstream.com` and `https://www.hyprstream.com` to the default credentialed allow-list, keeping the existing localhost/127.0.0.1 dev origins.
- The list remains **fully overridable** at runtime via `HYPRSTREAM_CORS_ORIGINS` (comma-separated) or the `server.cors.allowed_origins` config key — operators can add origins without a rebuild. This PR only extends the DEFAULT.

## Safety

- `allow_credentials = true` is preserved on this router, and **no wildcard (`*`) is introduced** here — wildcard + credentials is invalid/unsafe per the CORS spec, and the existing env-override logic already forces credentials off if `*` is ever configured.
- The OAuth **public** router (`CorsConfig::public()`, credentials off) and the **DID-document** router (`CorsConfig::did_document()`) are untouched.

## Tests

Added unit tests in `config::server` asserting:
- the prod origins (`hyprstream.com`, `www.hyprstream.com`) are allowed;
- the local dev origins are retained;
- an unrelated origin (`evil.example.com`) is rejected;
- credentials remain enabled with **no wildcard** on the credentialed router;
- the public router stays wildcard + credentials-off;
- `with_port` still extends defaults while preserving the prod origins;
- the origin list is overridable via the builder.

## Verification

Scoped to the `hyprstream` crate (main is currently RED for the release image build due to unrelated arrow-schema skew, being fixed on `fix/arrow-version-skew`):

- `cargo build -p hyprstream` ✅
- `cargo test -p hyprstream --lib config::` ✅ (7 new tests pass)
- `cargo clippy -p hyprstream -- -D warnings` ✅
- `cargo fmt --check`: the crate shows pre-existing, environment-wide formatting diffs (nightly import-grouping vs. the pinned 1.97.0 stable rustfmt) unrelated to this change; the added code introduces no new diffs.