### PR TITLE
fix(metrics): unify arrow-schema across duckdb/datafusion (unblocks release image build)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -55,7 +55,10 @@ node_modules/
 .cache/
 
 # Rust specific
-Cargo.lock
+# NOTE: do NOT ignore Cargo.lock here. The release image build runs
+# `cargo build --release --no-default-features --features otel,gittorrent,xet`
+# and must honor the committed lock so duckdb/datafusion stay on one arrow major.
+# (Historically this entry stripped the lock, letting duckdb float to arrow 58.)
 *.profraw
 
 # Config directories

--- a/Dockerfile
+++ b/Dockerfile
@@ -251,7 +251,7 @@ ENV LD_LIBRARY_PATH=/opt/libtorch/lib
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,target=/sccache \
-    OPENSSL_NO_VENDOR=1 cargo build --release --no-default-features --features otel,gittorrent,xet
+    OPENSSL_NO_VENDOR=1 cargo build --locked --release --no-default-features --features otel,gittorrent,xet
 
 #############################################
 # Runtime Stage Selection (Distroless)

--- a/Dockerfile
+++ b/Dockerfile
@@ -228,8 +228,13 @@ FROM builder-${VARIANT} AS builder
 # Set working directory
 WORKDIR /build
 
-# Copy project files
+# Copy project files. Cargo.lock is REQUIRED: without it `cargo build` regenerates
+# the lock from the registry and the `duckdb`/`datafusion` caret requirements can
+# float across an arrow major boundary (duckdb 1.4.3 -> 1.10504.x pulls arrow 58,
+# while datafusion 50 stays on arrow 56), producing E0308 at the MemTable/DFSchema
+# boundaries. See crates/hyprstream-metrics/Cargo.toml and PR fixing #release-image.
 COPY Cargo.toml ./
+COPY Cargo.lock ./
 COPY crates ./crates
 
 ENV LIBTORCH=/opt/libtorch

--- a/crates/hyprstream-metrics/Cargo.toml
+++ b/crates/hyprstream-metrics/Cargo.toml
@@ -11,13 +11,18 @@ name = "hyprstream_metrics"
 path = "src/lib.rs"
 
 [dependencies]
-# Data processing - use DuckDB's arrow version for consistency
-duckdb = { version = "1.4.3", features = ["bundled"] }
+# Data processing. Pinned EXACTLY (=1.4.3) so the caret requirement can't float
+# duckdb up to a newer 1.x (e.g. 1.10504.x) that pulls arrow-schema 58, which
+# skews against datafusion 50's arrow-schema 56 and breaks the MemTable/DFSchema
+# boundaries in query/planner.rs, storage/datafusion_provider.rs and query/rules/view.rs.
+# Keep duckdb and datafusion on the SAME arrow major; when bumping either, verify
+# `cargo tree -p hyprstream-metrics -i arrow-schema` shows a single version.
+duckdb = { version = "=1.4.3", features = ["bundled"] }
 
 # Re-export arrow from duckdb to avoid version conflicts
 # arrow = { version = "54", package = "arrow" }  # via duckdb
 
-# DataFusion for query planning - try 50 for Arrow 56
+# DataFusion for query planning — 50.x tracks arrow 56, matching duckdb 1.4.3.
 datafusion = "50.0.0"
 datafusion-common = "50.0.0"
 


### PR DESCRIPTION
## Problem

The `docker-build` workflow (all 5 variants: cpu, cuda128, cuda130, rocm71, arm64) failed on `main` @15e0b5fd with `error[E0308]: mismatched types` at the duckdb/datafusion arrow boundary in `hyprstream-metrics`:

- `query/planner.rs:84` — `MemTable::try_new(schema, ...)`
- `storage/datafusion_provider.rs:53`
- `query/rules/view.rs:132` — `DSchema::try_from_qualified_schema`

rustc: *"there are multiple different versions of crate `arrow_schema` in the dependency graph"* — **arrow-schema 56.x** (datafusion 50) and **arrow-schema 58.x** (duckdb). This gates the entire production-deploy milestone: no container image can publish until it's fixed.

## Why CI missed it

The `Rust` workflow **passed** because it honors the committed `Cargo.lock` (which pins `duckdb 1.4.3` → arrow 56). The release image build does **not**:
- The `Dockerfile` copied `Cargo.toml` + `crates/` but **not** `Cargo.lock`.
- `.dockerignore` **explicitly excluded** `Cargo.lock`.

So `cargo build` inside the image regenerated the lock from the registry. The `duckdb = "1.4.3"` manifest entry is a *caret* requirement (`^1.4.3` → `>=1.4.3, <2.0.0`), and a newer `1.x` — `1.10504.x` — exists that depends on **arrow 58**. A lock-less resolve floats duckdb to `1.10504.x`, pulling arrow-schema 58, which skews against datafusion 50's arrow 56 at the `MemTable`/`DFSchema` boundaries.

Verified pre-fix:
```
$ cargo update --dry-run -p duckdb
    Updating duckdb v1.4.3 -> v1.10504.0
    Adding arrow-schema v58.3.0   # ...and arrow 58.x family
```

This is the same class of trap as the recent critical-section link bug (#1131): a defect visible **only** in the release image's flag set.

## Fix (option 1 — unify on one arrow major)

No crate disabled, no image feature flags changed.

- **`crates/hyprstream-metrics/Cargo.toml`** — pin `duckdb = "=1.4.3"` exactly so the bound can never float across the arrow 56↔58 boundary. `duckdb 1.4.3` and `datafusion 50` both resolve to arrow-schema 56. Comment added naming both crates and the `cargo tree -i arrow-schema` check for the next bump.
- **`Dockerfile`** — `COPY Cargo.lock ./` so the image build is reproducible and honors the committed resolution (matching what the `Rust` workflow and local dev test).
- **`.dockerignore`** — stop excluding `Cargo.lock` (with a comment explaining why).

## Acceptance (all green)

| Check | Result |
|---|---|
| `cargo build --release --no-default-features --features otel,gittorrent,xet` (exact image config) | ✅ Finished in 5m23s, exit 0 |
| `cargo build -p hyprstream-metrics` (default features) | ✅ Finished, exit 0 |
| `cargo clippy -p hyprstream-metrics -- -D warnings` | ✅ clean |
| `cargo tree --no-default-features --features otel,gittorrent,xet -i arrow-schema` | ✅ exactly **1** version (`arrow-schema v56.2.0`), down from two |

## Note for reviewers

When bumping `duckdb` or `datafusion` next, re-run `cargo tree -p hyprstream-metrics -i arrow-schema` and confirm a single version; if duckdb moves to a new arrow major, datafusion must move with it (or vice-versa).