### PR TITLE
fix(xet): close reference-face gaps

### DIFF
--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -620,19 +620,14 @@ fn default_oai_host() -> String { "0.0.0.0".to_owned() }
 fn default_oai_port() -> u16 { 6789 }
 fn default_oai_timeout() -> u64 { 300 }
 
-/// XetService configuration — dual-stack HuggingFace-XET CAS HTTP face.
+/// XetService configuration — HuggingFace-XET CAS HTTP face.
 ///
-/// When enabled, exposes the HF-XET CAS wire routes (`/get_xorb/{hash}/`,
+/// When listed in `[services] startup`, exposes the HF-XET CAS wire routes (`/get_xorb/{hash}/`,
 /// `/v1/reconstructions/{hash}`, `/v1/chunks/{key}`, `/v1/xorbs/{key}`,
 /// `/v1/shards`) so a standard xet-enabled git repo can point its CAS endpoint
 /// at hyprstream as an alternative XET backend to HuggingFace. See epic #654.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct XetConfig {
-    /// Whether the XetService is served. Disabled by default: this is a
-    /// foundation surface (most routes 501 pending interop verification).
-    #[serde(default)]
-    pub enabled: bool,
-
     /// Host address for the HTTP server.
     #[serde(default = "default_xet_host")]
     pub host: String,
@@ -658,7 +653,6 @@ pub struct XetConfig {
 impl Default for XetConfig {
     fn default() -> Self {
         Self {
-            enabled: false,
             host: default_xet_host(),
             port: default_xet_port(),
             external_url: None,

--- a/crates/hyprstream/src/server/middleware.rs
+++ b/crates/hyprstream/src/server/middleware.rs
@@ -1,7 +1,7 @@
 //! Middleware for authentication, logging, and request processing
 
 use crate::auth::jwt;
-use crate::server::state::ServerState;
+use crate::server::state::{ResourceAuthState, ServerState};
 use axum::{
     extract::{Request, State},
     http::{header, HeaderValue, StatusCode},
@@ -51,7 +51,7 @@ impl std::fmt::Debug for AuthenticatedUser {
 ///
 /// On success, inserts `AuthenticatedUser` into request extensions.
 pub async fn auth_middleware(
-    State(state): State<ServerState>,
+    State(state): State<ResourceAuthState>,
     mut request: Request,
     next: Next,
 ) -> Response {
@@ -91,7 +91,7 @@ pub async fn auth_middleware(
     // ticket validator (H1a / #764). DPoP sender-binding is enforced below,
     // after we hold the claims, because it is header/scheme-specific.
     let local_issuers: &[&str] = &[&*state.oauth_issuer_url];
-    let claims = match verify_token_claims(&state, &token).await {
+    let claims = match verify_resource_token_claims(&state, &token).await {
         Ok(c) => c,
         Err(reason) => {
             warn!(client_ip = %client_ip, method = %method, path = %path, reason, "Auth failure");
@@ -251,7 +251,7 @@ impl RateLimiter {
 /// Defaults: 300 requests per 60-second window (~5 req/s sustained).
 /// Returns 429 when the window quota is exceeded.
 pub async fn rate_limit_middleware(
-    State(state): State<ServerState>,
+    State(state): State<ResourceAuthState>,
     request: Request,
     next: Next,
 ) -> Response {
@@ -398,8 +398,8 @@ fn local_issuer_matches(claims: &jwt::Claims, expected: &str) -> bool {
     claims.iss == expected
 }
 
-pub(crate) async fn verify_token_claims(
-    state: &ServerState,
+async fn verify_resource_token_claims(
+    state: &ResourceAuthState,
     token: &str,
 ) -> Result<jwt::Claims, &'static str> {
     if !token.contains('.') {
@@ -427,7 +427,7 @@ pub(crate) async fn verify_token_claims(
         // MAC/key-rotation path populates at boot and after each ML-DSA rotation.
         // Empty under Classical policy or before the OAuth store is provisioned —
         // in which case a composite token simply fails closed here.
-        let published_composite = { hyprstream_rpc::auth::global_composite_key_set().snapshot() };
+        let published_composite = state.composite_key_set.snapshot();
         let claims = decode_local_multi_key(
             token,
             &state.verifying_key,
@@ -462,8 +462,15 @@ pub(crate) async fn verify_token_claims(
     Ok(claims)
 }
 
+pub(crate) async fn verify_token_claims(
+    state: &ServerState,
+    token: &str,
+) -> Result<jwt::Claims, &'static str> {
+    verify_resource_token_claims(&state.resource_auth_state(), token).await
+}
+
 /// Build WWW-Authenticate header value with resource_metadata URL (RFC 9728).
-fn build_www_authenticate(state: &ServerState) -> String {
+fn build_www_authenticate(state: &ResourceAuthState) -> String {
     let resource_metadata_url = format!(
         "{}/.well-known/oauth-protected-resource",
         state.resource_url

--- a/crates/hyprstream/src/server/mod.rs
+++ b/crates/hyprstream/src/server/mod.rs
@@ -44,6 +44,7 @@ pub fn create_app(state: ServerState) -> Router {
     // Clone config for middleware
     let cors_config = state.config.cors.clone();
     let timeout_duration = Duration::from_secs(state.config.request_timeout_secs);
+    let resource_auth_state = state.resource_auth_state();
 
     // Public browser provisioning is independently rate-limited before the
     // handler can resolve accepted state or perform hybrid signing.
@@ -92,11 +93,11 @@ pub fn create_app(state: ServerState) -> Router {
         .nest("/models", routes::models::create_router())
         // rate_limit added first (inner) → runs after auth sees the authenticated subject
         .layer(axum_middleware::from_fn_with_state(
-            state.clone(),
+            resource_auth_state.clone(),
             middleware::rate_limit_middleware,
         ))
         .layer(axum_middleware::from_fn_with_state(
-            state.clone(),
+            resource_auth_state,
             middleware::auth_middleware,
         ));
 

--- a/crates/hyprstream/src/server/state.rs
+++ b/crates/hyprstream/src/server/state.rs
@@ -80,6 +80,46 @@ pub struct ServerState {
     pub browser_provisioning_rate_limiter: Arc<crate::server::middleware::RateLimiter>,
 }
 
+/// Security state shared by every authenticated HTTP resource face.
+///
+/// Keeping this separate from [`ServerState`] lets thin faces such as Xet use
+/// the exact OAI authentication and rate-limit chain without constructing
+/// inference clients they never call.
+#[derive(Clone)]
+pub struct ResourceAuthState {
+    pub verifying_key: Arc<VerifyingKey>,
+    pub published_jwt_verifying_keys: crate::auth::key_rotation::PublishedEd25519Keys,
+    pub composite_key_set: Arc<hyprstream_rpc::auth::CompositeKeySet>,
+    pub resource_url: String,
+    pub oauth_issuer_url: String,
+    pub federation_resolver: Arc<crate::auth::FederationKeyResolver>,
+    pub jti_blocklist: Arc<hyprstream_rpc::auth::InMemoryJtiBlocklist>,
+    pub dpop_jti_seen: Arc<TtlCache<String, ()>>,
+    pub rate_limiter: Arc<crate::server::middleware::RateLimiter>,
+}
+
+impl ResourceAuthState {
+    pub fn new(
+        verifying_key: VerifyingKey,
+        resource_url: String,
+        oauth_issuer_url: String,
+        federation_resolver: Arc<crate::auth::FederationKeyResolver>,
+        jti_blocklist: Arc<hyprstream_rpc::auth::InMemoryJtiBlocklist>,
+    ) -> Self {
+        Self {
+            verifying_key: Arc::new(verifying_key),
+            published_jwt_verifying_keys: crate::auth::key_rotation::global_ed25519_verifying_keys(),
+            composite_key_set: hyprstream_rpc::auth::global_composite_key_set(),
+            resource_url,
+            oauth_issuer_url,
+            federation_resolver,
+            jti_blocklist,
+            dpop_jti_seen: Arc::new(TtlCache::new(10_000, 64)),
+            rate_limiter: Arc::new(crate::server::middleware::RateLimiter::new(300, 60)),
+        }
+    }
+}
+
 /// Metrics collector
 pub struct Metrics {
     /// Total requests processed
@@ -107,6 +147,21 @@ impl Default for Metrics {
 }
 
 impl ServerState {
+    /// Return the narrow state consumed by the shared HTTP authentication core.
+    pub fn resource_auth_state(&self) -> ResourceAuthState {
+        ResourceAuthState {
+            verifying_key: Arc::clone(&self.verifying_key),
+            published_jwt_verifying_keys: Arc::clone(&self.published_jwt_verifying_keys),
+            composite_key_set: hyprstream_rpc::auth::global_composite_key_set(),
+            resource_url: self.resource_url.clone(),
+            oauth_issuer_url: self.oauth_issuer_url.clone(),
+            federation_resolver: Arc::clone(&self.federation_resolver),
+            jti_blocklist: Arc::clone(&self.jti_blocklist),
+            dpop_jti_seen: Arc::clone(&self.dpop_jti_seen),
+            rate_limiter: Arc::clone(&self.rate_limiter),
+        }
+    }
+
     /// Create a new server state with ZMQ clients
     ///
     /// This is the primary method for creating server state with ZMQ-based services.

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -1174,7 +1174,7 @@ fn create_oai_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
 
 /// Factory for XetService (HuggingFace-XET CAS HTTP face, epic #654).
 ///
-/// Dual-stack HTTP service that speaks the HF-XET CAS wire protocol so a standard
+/// HTTP service that speaks the HF-XET CAS wire protocol so a standard
 /// xet-enabled git repo can point its CAS endpoint at hyprstream. It dials the
 /// `registry` service (reusing the authenticated `putBlob`/`getBlob` core) and
 /// holds no standing CAS write authority of its own. Reads come from the shared
@@ -1183,6 +1183,7 @@ fn create_oai_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
 fn create_xet_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>> {
     info!("Creating XetService");
 
+    use crate::server::state::ResourceAuthState;
     use crate::services::{XetService, XetState};
 
     let config = load_config();
@@ -1195,21 +1196,38 @@ fn create_xet_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
     let registry_client: RegistryClient =
         RegistryClient::from_resolver(sk.clone(), service_token("xet"))?;
 
+    // Reuse the same narrow authentication core as OAI without constructing an
+    // inference-oriented ServerState. The policy client is used by federated
+    // issuer admission and key resolution.
+    let policy_vk = hyprstream_service::global_trust_store()
+        .resolve_one("policy")
+        .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
+    let policy_client =
+        PolicyClient::for_local_bootstrap(sk.clone(), policy_vk, service_token("xet"))?;
+    let federation_resolver = Arc::new(
+        crate::auth::FederationKeyResolver::new(&config.oauth.trusted_issuers)
+            .with_policy_client(Arc::new(policy_client)),
+    );
+    let jti_blocklist = SHARED_JTI_BLOCKLIST
+        .get()
+        .map(Arc::clone)
+        .context("PolicyService did not publish the shared JTI blocklist before Xet startup")?;
+    let auth = ResourceAuthState::new(
+        ctx.jwt_verifying_key(),
+        config.xet.resource_url(),
+        config.oauth.issuer_url(),
+        federation_resolver,
+        jti_blocklist,
+    );
+
     let state = XetState {
         // Reads share the same L1 CAS substrate the registry's getBlob uses (#812).
         store: crate::storage::CasSubstrate::from_env(),
         registry: Some(registry_client),
-        jwt_verifying_key: ctx.jwt_verifying_key(),
-        audience: config.xet.resource_url(),
+        auth,
     };
 
-    let xet_service = XetService::new(
-        config.xet.clone(),
-        config.tls.clone(),
-        state,
-        ctx.transport("xet", SocketKind::Rep),
-        ctx.verifying_key(),
-    );
+    let xet_service = XetService::new(config.xet.clone(), config.tls.clone(), state);
 
     Ok(Box::new(xet_service))
 }

--- a/crates/hyprstream/src/services/xet.rs
+++ b/crates/hyprstream/src/services/xet.rs
@@ -13,22 +13,21 @@
 //! | `POST /v1/xorbs/{key}`               | 501         | xorb→`putBlob(grantRepo)` mapping unresolved |
 //! | `POST /v1/shards`                    | 501         | shard ingest is follow-up |
 //!
-//! # Architecture (mirrors `OAIService`)
+//! # Architecture
 //!
-//! A dual-stack service: an HTTP data plane (this file's axum `Router`) plus an
-//! RPC control channel (health/shutdown) registered via `Spawnable`. It is a
-//! **thin translator** over the authenticated core — it dials the `registry`
+//! An HTTP data plane (this file's axum `Router`) implemented as a **thin
+//! translator** over the authenticated core — it dials the `registry`
 //! service (reusing the authenticated `putBlob`/`getBlob` RPCs) and holds no
 //! standing CAS *write* authority of its own. Reads for `/get_xorb` go through
 //! the Subject-threaded CAS mount, not a bare store read.
 //!
 //! # Auth
 //!
-//! Every route is behind [`xet_auth_middleware`], which requires a valid
-//! `Authorization: Bearer <jwt>` verified with the cluster JWT key
-//! (`ctx.jwt_verifying_key()`) — the same Ed25519 verification path the OAI
-//! service uses. The mapped identity (`sub`) is attached as
-//! [`AuthenticatedUser`] for downstream authorization.
+//! Every data route uses the same shared resource authentication and rate-limit
+//! middleware as OAI: DPoP sender binding/replay protection, federated issuer
+//! resolution, rotation and composite keys, JTI revocation, strict audience
+//! validation, and per-subject quotas. The mapped identity (`sub`) is attached
+//! as [`AuthenticatedUser`] for downstream authorization.
 //!
 //! ## Known provenance gap (foundation-level)
 //!
@@ -48,16 +47,17 @@
 //! [`BootstrapCasAuthorizer`].
 
 use crate::config::{TlsConfig, XetConfig};
-use crate::server::AuthenticatedUser;
+use crate::server::state::ResourceAuthState;
 use crate::server::tls::{resolve_rustls_config, serve_app};
+use crate::server::{AuthenticatedUser, middleware as server_middleware};
 use crate::services::RegistryClient;
 use crate::storage::cas::{BootstrapCasAuthorizer, CasMount, CasSubstrate, DedupDomain};
 use anyhow::Result;
 use axum::{
-    Router,
-    extract::{Path, Request, State},
+    Json, Router,
+    extract::{Path, State},
     http::{HeaderMap, StatusCode, header},
-    middleware::{self, Next},
+    middleware,
     response::{IntoResponse, Response},
     routing::{get, post},
 };
@@ -89,37 +89,24 @@ pub struct XetState {
     /// implemented (the read/auth surface is exercisable without a live registry).
     #[allow(dead_code)]
     pub registry: Option<RegistryClient>,
-    /// Cluster JWT verifying key (Ed25519) — same key path the OAI face uses.
-    pub jwt_verifying_key: VerifyingKey,
-    /// Expected JWT audience (this server's resource URL).
-    pub audience: String,
+    /// Shared OAI-equivalent authentication and rate-limit state.
+    pub auth: ResourceAuthState,
 }
 
-/// XetService — HF-XET CAS HTTP face with an RPC control channel.
+/// XetService — HF-XET CAS HTTP face.
 pub struct XetService {
     config: XetConfig,
     tls_config: TlsConfig,
     state: XetState,
-    control_transport: TransportConfig,
-    #[allow(dead_code)]
-    verifying_key: VerifyingKey,
 }
 
 impl XetService {
     /// Create a new XetService.
-    pub fn new(
-        config: XetConfig,
-        tls_config: TlsConfig,
-        state: XetState,
-        control_transport: TransportConfig,
-        verifying_key: VerifyingKey,
-    ) -> Self {
+    pub fn new(config: XetConfig, tls_config: TlsConfig, state: XetState) -> Self {
         Self {
             config,
             tls_config,
             state,
-            control_transport,
-            verifying_key,
         }
     }
 
@@ -135,7 +122,7 @@ impl XetService {
 /// Build the HF-XET CAS wire router. Route paths are the exact compatibility
 /// contract with xet-core's `cas_client` — do not rename them.
 pub fn create_xet_router(state: XetState) -> Router {
-    Router::new()
+    let protected_routes = Router::new()
         // IMPLEMENTED: raw xorb bytes, Range-aware.
         .route("/get_xorb/:hash/", get(get_xorb_handler))
         // 501 stubs (see module docs for the interop gap each carries).
@@ -143,63 +130,36 @@ pub fn create_xet_router(state: XetState) -> Router {
         .route("/v1/chunks/:key", get(chunks_stub))
         .route("/v1/xorbs/:key", post(upload_xorb_stub))
         .route("/v1/shards", post(upload_shard_stub))
-        // Auth applies to every route above.
+        // Rate limiting is inner, so it sees the identity inserted by auth.
         .layer(middleware::from_fn_with_state(
-            state.clone(),
-            xet_auth_middleware,
+            state.auth.clone(),
+            server_middleware::rate_limit_middleware,
         ))
+        .layer(middleware::from_fn_with_state(
+            state.auth.clone(),
+            server_middleware::auth_middleware,
+        ));
+
+    Router::new()
+        .route(
+            "/.well-known/oauth-protected-resource",
+            get(xet_protected_resource_metadata),
+        )
+        .merge(protected_routes)
         .with_state(state)
 }
 
-/// JWT auth middleware: require `Authorization: Bearer <jwt>`, verify it with the
-/// cluster JWT key (same verification the OAI face performs), and attach the
-/// mapped identity for downstream authorization. Rejects unauthenticated
-/// requests with 401 (fail-closed).
-async fn xet_auth_middleware(
+/// RFC 9728 metadata is Xet's public discovery surface. HTTP faces cannot be
+/// represented by the RPC endpoint registry, whose socket kinds are RPC-only.
+async fn xet_protected_resource_metadata(
     State(state): State<XetState>,
-    mut request: Request,
-    next: Next,
-) -> Response {
-    let token = match bearer_token(request.headers()) {
-        Some(t) => t,
-        None => return unauthorized("missing bearer token"),
-    };
-
-    // Verify with the cluster JWT key, binding the audience to this resource.
-    match crate::auth::jwt::decode(&token, &state.jwt_verifying_key, Some(&state.audience)) {
-        Ok(claims) => {
-            request.extensions_mut().insert(AuthenticatedUser {
-                user: claims.sub,
-                token: Some(token),
-                exp: Some(claims.exp),
-            });
-            next.run(request).await
-        }
-        Err(e) => {
-            warn!(error = %e, "xet auth: JWT validation failed");
-            unauthorized("invalid token")
-        }
-    }
-}
-
-/// Extract a bearer token from the `Authorization` header (RFC 6750).
-fn bearer_token(headers: &HeaderMap) -> Option<String> {
-    let h = headers.get(header::AUTHORIZATION)?.to_str().ok()?;
-    if h.len() > 7 && h[..7].eq_ignore_ascii_case("bearer ") {
-        Some(h[7..].trim().to_owned())
-    } else {
-        None
-    }
-}
-
-/// Standard 401 with `WWW-Authenticate: Bearer`.
-fn unauthorized(detail: &str) -> Response {
-    (
-        StatusCode::UNAUTHORIZED,
-        [(header::WWW_AUTHENTICATE, "Bearer")],
-        detail.to_owned(),
-    )
-        .into_response()
+) -> Json<crate::services::oauth::ProtectedResourceMetadata> {
+    let mut metadata = crate::services::oauth::protected_resource_metadata(
+        &state.auth.resource_url,
+        &state.auth.oauth_issuer_url,
+    );
+    metadata.resource_name = Some("HyprStream HuggingFace-XET CAS API".to_owned());
+    Json(metadata)
 }
 
 /// `GET /get_xorb/{hash}/` — serve the raw bytes of a single xorb, honoring a
@@ -334,12 +294,10 @@ fn parse_range(header_val: Option<&axum::http::HeaderValue>, len: u64) -> RangeO
         },
         // closed: "S-E"
         (s, e) => match (s.parse::<u64>(), e.parse::<u64>()) {
-            (Ok(start), Ok(end)) if start <= end && start <= last => {
-                RangeOutcome::Partial {
-                    start,
-                    end: end.min(last),
-                }
-            }
+            (Ok(start), Ok(end)) if start <= end && start <= last => RangeOutcome::Partial {
+                start,
+                end: end.min(last),
+            },
             (Ok(_), Ok(_)) => RangeOutcome::Unsatisfiable,
             _ => RangeOutcome::Full,
         },
@@ -394,11 +352,7 @@ async fn upload_shard_stub() -> Response {
 
 /// Uniform 501 with a `TODO(#654)`-tagged reason.
 fn not_implemented(reason: &str) -> Response {
-    (
-        StatusCode::NOT_IMPLEMENTED,
-        format!("TODO(#654): {reason}"),
-    )
-        .into_response()
+    (StatusCode::NOT_IMPLEMENTED, format!("TODO(#654): {reason}")).into_response()
 }
 
 impl Spawnable for XetService {
@@ -407,7 +361,9 @@ impl Spawnable for XetService {
     }
 
     fn registrations(&self) -> Vec<(SocketKind, TransportConfig)> {
-        vec![(SocketKind::Rep, self.control_transport.clone())]
+        // Xet has no RequestService implementation or RPC control handler. An
+        // advertised Rep endpoint would therefore be an unservable liveness lie.
+        Vec::new()
     }
 
     fn run(
@@ -436,7 +392,21 @@ impl Spawnable for XetService {
             let scheme = if rustls_config.is_some() { "https" } else { "http" };
             let app = create_xet_router(self.state.clone());
 
-            info!("HF-XET CAS API available at {scheme}://{addr} (get_xorb implemented; other routes 501, see #654)");
+            let audience = &self.state.auth.resource_url;
+            let issuer = &self.state.auth.oauth_issuer_url;
+            if !audience.starts_with(&format!("{scheme}://")) {
+                warn!(
+                    effective_audience = %audience,
+                    served_scheme = scheme,
+                    "Xet JWT audience scheme differs from the HTTP transport; tokens must use the logged effective audience"
+                );
+            }
+
+            info!(
+                effective_audience = %audience,
+                oauth_issuer = %issuer,
+                "HF-XET CAS API available at {scheme}://{addr} (get_xorb implemented; other routes 501, see #654)"
+            );
 
             if let Some(tx) = on_ready {
                 let _ = tx.send(());
@@ -454,32 +424,128 @@ mod tests {
     use super::*;
     use axum::body::Body;
     use axum::http::Request as HttpRequest;
+    use hyprstream_rpc::auth::{
+        CompositeKeyPair, CompositeKeySet, CompositePairRole, CompositePairState,
+        InMemoryJtiBlocklist, JtiBlocklist as _,
+    };
+    use std::collections::HashMap;
     use tower::ServiceExt; // oneshot
+
+    const AUDIENCE: &str = "http://localhost:6792";
+    const ISSUER: &str = "http://localhost:6791";
+
+    // A valid 64-hex (sha256-shaped) content address the store's hash parser accepts.
+    const HASH: &str = "aa00bb11cc22dd33ee44ff5566778899aabbccddeeff00112233445566778899";
+
+    struct TestIssuer {
+        ml_dsa: hyprstream_rpc::crypto::pq::MlDsaSigningKey,
+        ed25519: ed25519_dalek::SigningKey,
+        key_set: Arc<CompositeKeySet>,
+    }
+
+    impl TestIssuer {
+        fn new() -> Self {
+            let (ml_dsa, ml_dsa_vk) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();
+            let ed25519 = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
+            let kid = crate::auth::jwt::composite_kid(&ml_dsa_vk, &ed25519.verifying_key());
+            let pair = CompositeKeyPair::verifying(
+                kid,
+                ml_dsa_vk,
+                ed25519.verifying_key(),
+                CompositePairRole::OAuth,
+                CompositePairState::Active,
+                0,
+                i64::MAX,
+            );
+            let key_set = Arc::new(CompositeKeySet::default());
+            key_set
+                .publish(1, "xet-test-keys".to_owned(), vec![pair])
+                .unwrap();
+            Self {
+                ml_dsa,
+                ed25519,
+                key_set,
+            }
+        }
+
+        fn token(&self, audience: &str, jti: &str) -> String {
+            let now = chrono::Utc::now().timestamp();
+            let mut claims = crate::auth::jwt::Claims::new("alice".to_owned(), now, now + 3600)
+                .with_issuer(ISSUER.to_owned())
+                .with_audience(Some(audience.to_owned()));
+            claims.jti = Some(jti.to_owned());
+            crate::auth::jwt::encode_composite_ml_dsa_65_ed25519(
+                &claims,
+                &self.ml_dsa,
+                &self.ed25519,
+            )
+        }
+    }
+
+    /// Build an XetState over a temp CasStore holding one xorb.
+    fn test_state_with_xorb(dir: &std::path::Path, hash: &str, bytes: &[u8]) -> XetState {
+        std::fs::create_dir_all(dir.join("xorbs")).unwrap();
+        std::fs::write(dir.join("xorbs").join(format!("default.{hash}")), bytes).unwrap();
+
+        let (_sk, vk) = hyprstream_rpc::crypto::generate_signing_keypair();
+        let trusted_issuers = HashMap::new();
+        let federation_resolver =
+            Arc::new(crate::auth::FederationKeyResolver::new(&trusted_issuers));
+
+        XetState {
+            store: CasSubstrate::new(dir),
+            // Write path is 501; no live registry needed to exercise reads/auth.
+            registry: None,
+            auth: ResourceAuthState::new(
+                vk,
+                AUDIENCE.to_owned(),
+                ISSUER.to_owned(),
+                federation_resolver,
+                Arc::new(InMemoryJtiBlocklist::new()),
+            ),
+        }
+    }
+
+    fn with_test_issuer(mut state: XetState, issuer: &TestIssuer) -> XetState {
+        state.auth.composite_key_set = Arc::clone(&issuer.key_set);
+        state
+    }
+
+    fn authorized_request(uri: &str, token: &str) -> HttpRequest<Body> {
+        HttpRequest::builder()
+            .uri(uri)
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .body(Body::empty())
+            .unwrap()
+    }
 
     #[test]
     fn test_service_name() {
         assert_eq!(SERVICE_NAME, "xet");
     }
 
-    /// Build an XetState over a temp CasStore holding one xorb, plus a random
-    /// (never-signed-for) JWT key so auth rejects everything unauthenticated.
-    fn test_state_with_xorb(dir: &std::path::Path, hash: &str, bytes: &[u8]) -> XetState {
-        std::fs::create_dir_all(dir.join("xorbs")).unwrap();
-        std::fs::write(dir.join("xorbs").join(format!("default.{hash}")), bytes).unwrap();
-
-        let (_sk, vk) = hyprstream_rpc::crypto::generate_signing_keypair();
-
-        XetState {
-            store: CasSubstrate::new(dir),
-            // Write path is 501; no live registry needed to exercise reads/auth.
-            registry: None,
-            jwt_verifying_key: vk,
-            audience: "http://localhost:6792".to_owned(),
-        }
+    #[test]
+    fn does_not_advertise_an_unserved_rpc_endpoint() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = test_state_with_xorb(dir.path(), HASH, b"x");
+        let service = XetService::new(XetConfig::default(), TlsConfig::default(), state);
+        assert!(service.registrations().is_empty());
     }
 
-    // A valid 64-hex (sha256-shaped) content address the store's hash parser accepts.
-    const HASH: &str = "aa00bb11cc22dd33ee44ff5566778899aabbccddeeff00112233445566778899";
+    #[test]
+    fn config_has_no_second_enable_switch() {
+        let serialized = serde_json::to_value(XetConfig::default()).unwrap();
+        assert!(serialized.get("enabled").is_none());
+    }
+
+    #[test]
+    fn configured_external_url_is_the_effective_audience() {
+        let config = XetConfig {
+            external_url: Some("https://xet.example.test/cas".to_owned()),
+            ..XetConfig::default()
+        };
+        assert_eq!(config.resource_url(), "https://xet.example.test/cas");
+    }
 
     #[tokio::test]
     async fn get_xorb_happy_path_returns_bytes() {
@@ -550,6 +616,105 @@ mod tests {
             .unwrap();
 
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            resp.headers()
+                .get(header::WWW_AUTHENTICATE)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            format!("Bearer resource_metadata=\"{AUDIENCE}/.well-known/oauth-protected-resource\"")
+        );
+    }
+
+    #[tokio::test]
+    async fn wrong_audience_token_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let issuer = TestIssuer::new();
+        let state = with_test_issuer(test_state_with_xorb(dir.path(), HASH, b"x"), &issuer);
+        let token = issuer.token("https://wrong.example/resource", "wrong-aud");
+
+        let resp = create_xet_router(state)
+            .oneshot(authorized_request(&format!("/get_xorb/{HASH}/"), &token))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn revoked_jti_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let issuer = TestIssuer::new();
+        let state = with_test_issuer(test_state_with_xorb(dir.path(), HASH, b"x"), &issuer);
+        state.auth.jti_blocklist.revoke(
+            "revoked-xet".to_owned(),
+            chrono::Utc::now().timestamp() + 3600,
+        );
+        let token = issuer.token(AUDIENCE, "revoked-xet");
+
+        let resp = create_xet_router(state)
+            .oneshot(authorized_request(&format!("/get_xorb/{HASH}/"), &token))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn shared_subject_rate_limit_is_enforced() {
+        let dir = tempfile::tempdir().unwrap();
+        let issuer = TestIssuer::new();
+        let mut state = with_test_issuer(test_state_with_xorb(dir.path(), HASH, b"x"), &issuer);
+        state.auth.rate_limiter = Arc::new(server_middleware::RateLimiter::new(1, 60));
+        let app = create_xet_router(state);
+
+        let first = app
+            .clone()
+            .oneshot(authorized_request(
+                &format!("/v1/reconstructions/{HASH}"),
+                &issuer.token(AUDIENCE, "rate-1"),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(first.status(), StatusCode::NOT_IMPLEMENTED);
+
+        let second = app
+            .oneshot(authorized_request(
+                &format!("/v1/reconstructions/{HASH}"),
+                &issuer.token(AUDIENCE, "rate-2"),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(second.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[tokio::test]
+    async fn protected_resource_metadata_is_public_and_xet_specific() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = test_state_with_xorb(dir.path(), HASH, b"x");
+
+        let resp = create_xet_router(state)
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/.well-known/oauth-protected-resource")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let metadata: crate::services::oauth::ProtectedResourceMetadata =
+            serde_json::from_slice(&body).unwrap();
+        assert_eq!(metadata.resource, AUDIENCE);
+        assert_eq!(metadata.authorization_servers, vec![ISSUER]);
+        assert_eq!(
+            metadata.resource_name.as_deref(),
+            Some("HyprStream HuggingFace-XET CAS API")
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #1134.

## Implemented

- I1: removed the unserved REP registration. Xet has no RequestService or RPC control handler, so advertising a REP endpoint was a liveness lie. The same strategy generalizes to OAI, which retains the identical defect outside this PR.
- I2: extracted ResourceAuthState and made OAI plus Xet use one auth/rate-limit middleware implementation. Xet now inherits DPoP sender binding and replay checks, federated issuer resolution, Ed25519 rotation slots, composite ML-DSA-65 keys, the shared JTI revocation blocklist, strict audience validation, and per-subject rate limiting.
- I4: added the public RFC 9728 /.well-known/oauth-protected-resource metadata route with Xet resource and issuer values.
- I5: removed XetConfig.enabled; services.startup is now the single enablement switch.
- I6: logs the effective audience and issuer once at startup and warns when the served transport scheme disagrees with the configured audience scheme.

## Deferred by design

- I3 remains blocked on provenance labels (#699) and subject clearances (#698). The existing BootstrapCasAuthorizer ratchet documentation is preserved; no fake AVC was added.
- The write routes remain 501 until entitlement can be enforced; a hash is not treated as a capability.
- OAI REP registration was not changed, per issue scope.

## Tests and validation

- cargo build -p hyprstream: pass
- cargo test -p hyprstream --lib services::xet: pass (16 tests)
- cargo test -p hyprstream --lib server::middleware: pass (22 tests)
- cargo clippy -p hyprstream -- -D warnings: pass
- foreground pre-commit release Clippy hook: pass
- cargo fmt --check: baseline failure under Rust 1.97 across untouched workspace files, beginning in crates/cas-serve/src/store.rs and crates/chat-core/src/capnp.rs; git diff --check passes.