### PR TITLE
fix(systemd): persist JWT rotation state to a writable home; close unit credential gaps (#803, #808)

### DIFF
--- a/crates/hyprstream-service/src/service/manager/systemd.rs
+++ b/crates/hyprstream-service/src/service/manager/systemd.rs
@@ -453,7 +453,15 @@ pub fn encrypt_credentials_if_available(secrets_dir: Option<&std::path::Path>) -
     let dir: &std::path::Path = match secrets_dir {
         Some(d) => d,
         None => {
-            default_dir = units::hyprstream_config_dir().map(|d| d.join("credentials"));
+            default_dir = match units::hyprstream_config_dir() {
+                Ok(dir) => dir.map(|d| d.join("credentials")),
+                Err(error) => {
+                    tracing::error!(
+                        "Invalid instance name while resolving credentials directory: {error}"
+                    );
+                    return false;
+                }
+            };
             match default_dir.as_deref() {
                 Some(d) => d,
                 None => {

--- a/crates/hyprstream-service/src/service/manager/systemd.rs
+++ b/crates/hyprstream-service/src/service/manager/systemd.rs
@@ -428,7 +428,16 @@ fn systemd_creds_encrypt(name: &str, plaintext: &[u8], credstore: &std::path::Pa
 /// generated service unit should include `ImportCredential=` directives.
 /// Returns `false` if `systemd-creds` is unavailable or no secrets were found.
 ///
-/// Pass `None` for `secrets_dir` to use the default: `~/.config/hyprstream/credentials`.
+/// Pass `None` for `secrets_dir` to use the default: the instance-namespaced
+/// `~/.config/hyprstream[/instances/{inst}]/credentials`.
+///
+/// # Best-effort defense-in-depth (#808)
+///
+/// The plaintext 0600 files in `secrets_dir` remain the authoritative copy and
+/// are NOT deleted: per-service `LoadCredential=` sources and CLI tooling read
+/// them directly. The encrypted credstore is an additional TPM2/host-key-bound
+/// copy consumed via `ImportCredential=` — protection here is best-effort
+/// defense-in-depth, not the sole at-rest control.
 pub fn encrypt_credentials_if_available(secrets_dir: Option<&std::path::Path>) -> bool {
     if !has_systemd_creds() {
         tracing::warn!(
@@ -444,11 +453,16 @@ pub fn encrypt_credentials_if_available(secrets_dir: Option<&std::path::Path>) -
     let dir: &std::path::Path = match secrets_dir {
         Some(d) => d,
         None => {
-            default_dir = dirs::config_dir()
-                .unwrap_or_else(|| std::path::PathBuf::from("/etc/hyprstream"))
-                .join("hyprstream")
-                .join("credentials");
-            &default_dir
+            default_dir = units::hyprstream_config_dir().map(|d| d.join("credentials"));
+            match default_dir.as_deref() {
+                Some(d) => d,
+                None => {
+                    tracing::warn!(
+                        "Could not determine config dir for secrets; skipping credential encryption"
+                    );
+                    return false;
+                }
+            }
         }
     };
 
@@ -526,25 +540,6 @@ pub fn encrypt_credentials_if_available(secrets_dir: Option<&std::path::Path>) -
     // flat credstore (e.g., model-signing-key, model-service-jwt) so that
     // ImportCredential can decrypt them. Subdirectory encryption was removed
     // because SetLoadCredential doesn't decrypt systemd-creds encrypted files.
-
-    // Encrypt application-level credentials (oauth)
-    for name in units::OAUTH_CREDENTIAL_NAMES {
-        let secret_path = dir.join(name);
-        if !secret_path.exists() {
-            continue;
-        }
-        let plaintext = match std::fs::read(&secret_path) {
-            Ok(b) => b,
-            Err(e) => {
-                tracing::warn!("Could not read secret '{}': {e}", secret_path.display());
-                continue;
-            }
-        };
-        match systemd_creds_encrypt(name, &plaintext, &credstore) {
-            Ok(()) => encrypted_count += 1,
-            Err(e) => tracing::warn!("Failed to encrypt credential '{name}': {e}"),
-        }
-    }
 
     // Encrypt policy-only credentials (ca-key)
     for name in units::POLICY_CREDENTIAL_NAMES {

--- a/crates/hyprstream-service/src/service/manager/units.rs
+++ b/crates/hyprstream-service/src/service/manager/units.rs
@@ -2,9 +2,12 @@
 //!
 //! Generates socket and service unit files for hyprstream services.
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 
 use hyprstream_rpc::paths;
+
+const SECRETS_PROFILE_ENV: &str = "HYPRSTREAM_SECRETS_PROFILE";
+const PER_SERVICE_SCOPED_PROFILE: &str = "per-service-scoped";
 
 /// Generate a systemd socket unit for a service
 ///
@@ -165,7 +168,10 @@ fn system_creds_section(
         } else {
             "\nPrivateMounts=yes"
         };
-        format!("\n{import_lines}Environment=HYPRSTREAM__SECRETS__PATH=%d{private_mounts}")
+        format!(
+            "\n{import_lines}Environment=HYPRSTREAM__SECRETS__PATH=%d\n\
+             Environment={SECRETS_PROFILE_ENV}={PER_SERVICE_SCOPED_PROFILE}{private_mounts}"
+        )
     })
 }
 
@@ -178,11 +184,28 @@ fn system_creds_section(
 ///
 /// Note: the systemd *credstore* itself (`$XDG_CONFIG_HOME/credstore.encrypted`)
 /// is a fixed, systemd-owned location and is intentionally NOT namespaced.
-pub(crate) fn hyprstream_config_dir() -> Option<std::path::PathBuf> {
-    let base = dirs::config_dir()?.join("hyprstream");
-    Some(match std::env::var("HYPRSTREAM_INSTANCE") {
-        Ok(inst) if !inst.is_empty() => base.join("instances").join(inst),
-        _ => base,
+fn validated_instance_name() -> Result<Option<String>> {
+    match std::env::var("HYPRSTREAM_INSTANCE") {
+        Ok(inst) if !inst.is_empty() => {
+            if inst.contains('/') || inst.contains("..") {
+                return Err(anyhow!(
+                    "HYPRSTREAM_INSTANCE must not contain '/' or '..': {:?}",
+                    inst
+                ));
+            }
+            Ok(Some(inst))
+        }
+        _ => Ok(None),
+    }
+}
+
+pub(crate) fn hyprstream_config_dir() -> Result<Option<std::path::PathBuf>> {
+    let Some(base) = dirs::config_dir().map(|dir| dir.join("hyprstream")) else {
+        return Ok(None);
+    };
+    Ok(match validated_instance_name()? {
+        Some(inst) => Some(base.join("instances").join(inst)),
+        None => Some(base),
     })
 }
 
@@ -226,7 +249,7 @@ pub fn service_unit(service: &str, use_systemd_creds: bool, depends_on: &[&str])
             .and_then(|t| t.extension().map(|e| e.eq_ignore_ascii_case("appimage")))
             .unwrap_or(false);
 
-    let hyprstream_instance = std::env::var("HYPRSTREAM_INSTANCE").ok();
+    let hyprstream_instance = validated_instance_name()?;
 
     // Build Environment= directives
     let env_directives = if is_appimage {
@@ -272,7 +295,7 @@ pub fn service_unit(service: &str, use_systemd_creds: bool, depends_on: &[&str])
         // Plaintext credential directory (wizard-written files), instance-
         // namespaced to match StoragePaths (#808):
         //   ~/.config/hyprstream[/instances/{inst}]/credentials/{service}/signing-key
-        let plain_creds = hyprstream_config_dir()
+        let plain_creds = hyprstream_config_dir()?
             .map(|d| d.join("credentials"))
             .unwrap_or_default();
 
@@ -284,9 +307,14 @@ pub fn service_unit(service: &str, use_systemd_creds: bool, depends_on: &[&str])
             // PrivateMounts=yes is recommended for credential users, but it
             // creates a private mount namespace that prevents AppImage FUSE
             // mounts.  Only enable it for non-AppImage executables.
-            let private_mounts = if is_appimage { "" } else { "\nPrivateMounts=yes" };
+            let private_mounts = if is_appimage {
+                ""
+            } else {
+                "\nPrivateMounts=yes"
+            };
             format!(
-                "\n{}Environment=HYPRSTREAM__SECRETS__PATH=%d{private_mounts}",
+                "\n{}Environment=HYPRSTREAM__SECRETS__PATH=%d\n\
+                 Environment={SECRETS_PROFILE_ENV}={PER_SERVICE_SCOPED_PROFILE}{private_mounts}",
                 all_cred_lines
             )
         }
@@ -378,10 +406,12 @@ pub fn system_service_unit(service: &str, depends_on: &[&str]) -> Result<String>
             .and_then(|t| t.extension().map(|e| e.eq_ignore_ascii_case("appimage")))
             .unwrap_or(false);
 
-    let hyprstream_instance = std::env::var("HYPRSTREAM_INSTANCE").ok();
+    let hyprstream_instance = validated_instance_name()?;
 
     let env_directives = if is_appimage {
-        vec![hyprstream_instance.map(|v| format!("Environment=HYPRSTREAM_INSTANCE={v}"))]
+        vec![hyprstream_instance
+            .as_ref()
+            .map(|v| format!("Environment=HYPRSTREAM_INSTANCE={v}"))]
     } else {
         vec![
             std::env::var("LD_LIBRARY_PATH")
@@ -390,7 +420,9 @@ pub fn system_service_unit(service: &str, depends_on: &[&str]) -> Result<String>
             std::env::var("LIBTORCH")
                 .ok()
                 .map(|v| format!("Environment=LIBTORCH={v}")),
-            hyprstream_instance.map(|v| format!("Environment=HYPRSTREAM_INSTANCE={v}")),
+            hyprstream_instance
+                .as_ref()
+                .map(|v| format!("Environment=HYPRSTREAM_INSTANCE={v}")),
         ]
     }
     .into_iter()
@@ -411,8 +443,8 @@ pub fn system_service_unit(service: &str, depends_on: &[&str]) -> Result<String>
     // `hyprstream` user never needs read access to the on-disk originals.
     let creds_section = {
         let credstore = std::path::PathBuf::from("/etc/credstore.encrypted");
-        let plain_creds = match std::env::var("HYPRSTREAM_INSTANCE") {
-            Ok(inst) if !inst.is_empty() => std::path::PathBuf::from("/etc/hyprstream")
+        let plain_creds = match hyprstream_instance {
+            Some(ref inst) => std::path::PathBuf::from("/etc/hyprstream")
                 .join("instances")
                 .join(inst)
                 .join("credentials"),
@@ -464,6 +496,43 @@ WantedBy=multi-user.target
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    static INSTANCE_ENV_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+
+    struct EnvVarGuard {
+        previous: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(value: &str) -> Self {
+            let previous = std::env::var("HYPRSTREAM_INSTANCE").ok();
+            std::env::set_var("HYPRSTREAM_INSTANCE", value);
+            Self { previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => std::env::set_var("HYPRSTREAM_INSTANCE", value),
+                None => std::env::remove_var("HYPRSTREAM_INSTANCE"),
+            }
+        }
+    }
+
+    #[test]
+    fn config_dir_rejects_instance_path_traversal() -> Result<()> {
+        let _serial = INSTANCE_ENV_LOCK.lock();
+        for invalid in ["../other", "nested/name", "name..suffix"] {
+            let _instance = EnvVarGuard::set(invalid);
+            let error = match hyprstream_config_dir() {
+                Err(error) => error,
+                Ok(path) => anyhow::bail!("invalid instance resolved to {path:?}"),
+            };
+            assert!(error.to_string().contains("must not contain '/' or '..'"));
+        }
+        Ok(())
+    }
 
     #[test]
     fn missing_service_signing_key_never_falls_back_to_node_key() -> Result<()> {
@@ -528,6 +597,7 @@ mod tests {
 
         let section = system_creds_section("model", false, &credstore, &plain_creds)?;
         assert!(section.contains("LoadCredential=signing-key:"));
+        assert!(section.contains("Environment=HYPRSTREAM_SECRETS_PROFILE=per-service-scoped"));
         assert!(
             !section.contains("ImportCredential=signing-key"),
             "must never import the flat node/CA root key for a non-policy service: {section}"

--- a/crates/hyprstream-service/src/service/manager/units.rs
+++ b/crates/hyprstream-service/src/service/manager/units.rs
@@ -56,15 +56,6 @@ pub const SERVICE_CREDENTIAL_NAMES: &[&str] = &[
     "service-jwt",
 ];
 
-/// Application-level credentials — only the oauth service needs these.
-///
-/// The credential-store key encrypts the user database (users.toml.age).
-/// The user-signing key is used for Ed25519 challenge-response auth.
-pub const OAUTH_CREDENTIAL_NAMES: &[&str] = &[
-    "credential-store-key",
-    "user-signing-key",
-];
-
 /// Policy-service-only credentials.
 ///
 /// The CA private key is only available to PolicyService (the CA).
@@ -72,15 +63,18 @@ pub const POLICY_CREDENTIAL_NAMES: &[&str] = &[
     "ca-key",
 ];
 
-/// All managed credential names (node + service + application).
+/// All managed credential names (node + service).
 ///
 /// Used by `encrypt_credentials_if_available` to encrypt all secrets
 /// from the secrets directory into the systemd credstore.
+///
+/// `user-signing-key` is deliberately absent: it is a CLI-side client
+/// credential (challenge-response enrollment) with no service-side consumer,
+/// so no unit imports it. The `credential-store-key` name was removed — it had
+/// no producer or consumer anywhere in the tree (#808).
 pub const ALL_CREDENTIAL_NAMES: &[&str] = &[
     "signing-key",
     "rsa-key",
-    "credential-store-key",
-    "user-signing-key",
     "tls-key",
     "tls-cert",
     "quic-key",
@@ -157,9 +151,6 @@ fn system_creds_section(
 ) -> Result<String> {
     let mut names: Vec<&'static str> = NODE_CREDENTIAL_NAMES.to_vec();
     names.extend(SERVICE_CREDENTIAL_NAMES.iter().copied());
-    if service == "oauth" {
-        names.extend(OAUTH_CREDENTIAL_NAMES.iter().copied());
-    }
     if service == "policy" {
         names.extend(POLICY_CREDENTIAL_NAMES.iter().copied());
     }
@@ -178,6 +169,23 @@ fn system_creds_section(
     })
 }
 
+/// Instance-namespaced hyprstream config directory.
+///
+/// Mirrors the `StoragePaths` prefixing used by the bootstrap/config writers
+/// (`$XDG_CONFIG_HOME/hyprstream/instances/{inst}` when `HYPRSTREAM_INSTANCE`
+/// is set) so generated units reference the same credential paths that were
+/// actually provisioned (#808).
+///
+/// Note: the systemd *credstore* itself (`$XDG_CONFIG_HOME/credstore.encrypted`)
+/// is a fixed, systemd-owned location and is intentionally NOT namespaced.
+pub(crate) fn hyprstream_config_dir() -> Option<std::path::PathBuf> {
+    let base = dirs::config_dir()?.join("hyprstream");
+    Some(match std::env::var("HYPRSTREAM_INSTANCE") {
+        Ok(inst) if !inst.is_empty() => base.join("instances").join(inst),
+        _ => base,
+    })
+}
+
 /// Generate a systemd service unit for a service.
 ///
 /// # Arguments
@@ -189,8 +197,8 @@ fn system_creds_section(
 /// # Credential scoping
 ///
 /// All services receive node-level credentials (signing key, TLS/QUIC
-/// materials). Only the `oauth` service additionally receives application-
-/// level secrets (credential-store key, user-signing key).
+/// materials) plus their per-service credentials; only `policy` additionally
+/// receives the CA private key.
 ///
 /// # Startup ordering
 ///
@@ -254,21 +262,18 @@ pub fn service_unit(service: &str, use_systemd_creds: bool, depends_on: &[&str])
             .unwrap_or_default();
 
         // Node-level credentials for all services; add per-service credentials
-        // from the service's subdirectory; add application-level credentials
-        // for oauth; add CA private key for policy.
+        // from the service's subdirectory; add CA private key for policy.
         let mut names: Vec<&'static str> = NODE_CREDENTIAL_NAMES.to_vec();
         names.extend(SERVICE_CREDENTIAL_NAMES.iter().copied());
-        if service == "oauth" {
-            names.extend(OAUTH_CREDENTIAL_NAMES.iter().copied());
-        }
         if service == "policy" {
             names.extend(POLICY_CREDENTIAL_NAMES.iter().copied());
         }
 
-        // Plaintext credential directory (wizard-written files):
-        //   ~/.config/hyprstream/credentials/{service}/signing-key
-        let plain_creds = dirs::config_dir()
-            .map(|d| d.join("hyprstream").join("credentials"))
+        // Plaintext credential directory (wizard-written files), instance-
+        // namespaced to match StoragePaths (#808):
+        //   ~/.config/hyprstream[/instances/{inst}]/credentials/{service}/signing-key
+        let plain_creds = hyprstream_config_dir()
+            .map(|d| d.join("credentials"))
             .unwrap_or_default();
 
         let all_cred_lines = credential_directives(service, &names, &credstore, &plain_creds)?;
@@ -313,6 +318,9 @@ Description=Hyprstream {service} Service{dep_section}
 
 [Service]
 Type=notify
+# Writable state home ($STATE_DIRECTORY) for JWT rotation state — the
+# credentials ramfs ($CREDENTIALS_DIRECTORY) is read-only (#803).
+StateDirectory=hyprstream
 ExecStart={exec} service start {service} --foreground{env_section}{creds_section}{hardening}
 Restart=on-failure
 RestartSec=2s
@@ -396,9 +404,11 @@ pub fn system_service_unit(service: &str, depends_on: &[&str]) -> Result<String>
         format!("\n{env_directives}")
     };
 
-    // System-wide credential plumbing uses FHS system paths. PID 1 reads the
-    // sources as root and exposes them to the service through systemd's
-    // access-restricted credentials ramfs.
+    // System-wide credential plumbing (#808): mirrors the user-unit logic with
+    // FHS system paths. `LoadCredential=`/`ImportCredential=` sources are read
+    // by PID 1 (root) and passed to the service through the private, access-
+    // restricted credentials ramfs ($CREDENTIALS_DIRECTORY), so the
+    // `hyprstream` user never needs read access to the on-disk originals.
     let creds_section = {
         let credstore = std::path::PathBuf::from("/etc/credstore.encrypted");
         let plain_creds = match std::env::var("HYPRSTREAM_INSTANCE") {
@@ -437,6 +447,9 @@ Type=notify
 User=hyprstream
 RuntimeDirectory=hyprstream
 RuntimeDirectoryMode=0750
+# Writable state home ($STATE_DIRECTORY) for JWT rotation state — the
+# credentials ramfs ($CREDENTIALS_DIRECTORY) is read-only (#803).
+StateDirectory=hyprstream
 ExecStart={exec} service start {service} --foreground{env_section}{creds_section}{hardening}
 Restart=on-failure
 RestartSec=2s

--- a/crates/hyprstream/src/auth/identity_store.rs
+++ b/crates/hyprstream/src/auth/identity_store.rs
@@ -313,28 +313,97 @@ pub fn write_ca_verifying_key(credentials_dir: &std::path::Path, key: &Verifying
     write_secret(credentials_dir, "ca-pubkey", key.as_bytes())
 }
 
-/// Load a service JWT (CA-signed certificate binding service name → pubkey).
-pub fn load_service_jwt(credentials_dir: &std::path::Path, service_name: &str) -> Result<Option<String>> {
-    let service_dir = credentials_dir.join(service_name);
-    match read_secret(&service_dir, "service-jwt") {
-        Ok(Some(bytes)) => {
+fn provisioned_service_jwt_dir(
+    credentials_dir: &std::path::Path,
+    service_name: &str,
+    profile: SecretsProfile,
+) -> std::path::PathBuf {
+    match profile {
+        SecretsProfile::SharedDirectory => credentials_dir.join(service_name),
+        SecretsProfile::PerServiceScoped => credentials_dir.to_path_buf(),
+    }
+}
+
+fn writable_service_jwt_dir(
+    credentials_dir: &std::path::Path,
+    service_name: &str,
+    profile: SecretsProfile,
+) -> std::path::PathBuf {
+    let state_dir = super::key_rotation::rotation_state_dir(credentials_dir);
+    if profile == SecretsProfile::PerServiceScoped && state_dir == credentials_dir {
+        state_dir
+    } else {
+        // `$STATE_DIRECTORY` is shared by the generated service units, so the
+        // writable fallback must retain a service-name component even when the
+        // read-only systemd credential directory was already service-scoped.
+        state_dir.join(service_name)
+    }
+}
+
+/// Load a service JWT using the active credential layout.
+///
+/// Renewed state is preferred. When a read-only credential provider caused
+/// writes to fall back to `$STATE_DIRECTORY`/XDG state, the originally
+/// provisioned credential remains the first-boot fallback.
+pub fn load_service_jwt_for_profile(
+    credentials_dir: &std::path::Path,
+    service_name: &str,
+    profile: SecretsProfile,
+) -> Result<Option<String>> {
+    validate_service_name(service_name)?;
+    let state_dir = writable_service_jwt_dir(credentials_dir, service_name, profile);
+    let provisioned_dir = provisioned_service_jwt_dir(credentials_dir, service_name, profile);
+    let bytes = match read_secret(&state_dir, "service-jwt")? {
+        Some(bytes) => Some(bytes),
+        None if state_dir != provisioned_dir => read_secret(&provisioned_dir, "service-jwt")?,
+        None => None,
+    };
+    match bytes {
+        Some(bytes) => {
             let jwt = String::from_utf8(bytes)
                 .context("service-jwt is not valid UTF-8")?;
             Ok(Some(jwt))
         }
-        Ok(None) => Ok(None),
-        Err(e) => Err(e),
+        None => Ok(None),
     }
 }
 
-/// Write a service JWT to the service's credential directory.
+/// Persist a service JWT using the same profile-aware path startup reads.
+pub fn write_service_jwt_for_profile(
+    credentials_dir: &std::path::Path,
+    service_name: &str,
+    profile: SecretsProfile,
+    jwt: &str,
+) -> Result<()> {
+    validate_service_name(service_name)?;
+    let state_dir = writable_service_jwt_dir(credentials_dir, service_name, profile);
+    write_secret(&state_dir, "service-jwt", jwt.as_bytes())
+}
+
+/// Load a service JWT from the shared-directory credential layout.
+pub fn load_service_jwt(
+    credentials_dir: &std::path::Path,
+    service_name: &str,
+) -> Result<Option<String>> {
+    load_service_jwt_for_profile(
+        credentials_dir,
+        service_name,
+        SecretsProfile::SharedDirectory,
+    )
+}
+
+/// Write a service JWT to the shared-directory credential layout.
 pub fn write_service_jwt(
     credentials_dir: &std::path::Path,
     service_name: &str,
     jwt: &str,
 ) -> Result<()> {
-    let service_dir = credentials_dir.join(service_name);
-    write_secret(&service_dir, "service-jwt", jwt.as_bytes())
+    write_service_jwt_for_profile(
+        credentials_dir,
+        service_name,
+        SecretsProfile::SharedDirectory,
+        jwt,
+    )
 }
 
 /// Bootstrap pubkeys — the pubkeys of services needed before discovery is available.
@@ -439,6 +508,30 @@ pub enum SecretsProfile {
     /// The provider has already scoped the directory to one service, so its
     /// credentials use flat names such as `signing-key`.
     PerServiceScoped,
+}
+
+/// Explicit deployment signal for credential-directory layout.
+///
+/// The path override is deliberately separate: setting
+/// `HYPRSTREAM__SECRETS__PATH` alone does not prove that a provider has already
+/// scoped the directory to one service.
+pub const SECRETS_PROFILE_ENV: &str = "HYPRSTREAM_SECRETS_PROFILE";
+
+impl SecretsProfile {
+    pub fn from_env() -> Result<Self> {
+        match std::env::var(SECRETS_PROFILE_ENV) {
+            Err(std::env::VarError::NotPresent) => Ok(Self::SharedDirectory),
+            Ok(value) if value == "shared-directory" => Ok(Self::SharedDirectory),
+            Ok(value) if value == "per-service-scoped" => Ok(Self::PerServiceScoped),
+            Ok(value) => Err(anyhow!(
+                "{SECRETS_PROFILE_ENV} must be 'shared-directory' or \
+                 'per-service-scoped', got {value:?}"
+            )),
+            Err(error) => Err(anyhow!(
+                "{SECRETS_PROFILE_ENV} is not valid Unicode: {error}"
+            )),
+        }
+    }
 }
 
 /// Resolve the Ed25519 signing key a service process should use to sign its
@@ -1006,6 +1099,8 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    static SECRETS_ENV_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     /// Back-date a file's mtime by `days` days using nix utimes.
@@ -1054,6 +1149,7 @@ mod tests {
     /// parallel, so splitting them would race.
     #[test]
     fn test_credentials_dir_precedence() {
+        let _serial = SECRETS_ENV_LOCK.lock();
         const VAR: &str = "HYPRSTREAM__SECRETS__PATH";
 
         // (a) env var set → returns exactly that path.
@@ -1075,6 +1171,106 @@ mod tests {
                 dir.display()
             );
         }
+    }
+
+    #[test]
+    fn test_path_override_alone_keeps_shared_profile_and_service_key_isolation() {
+        let _serial = SECRETS_ENV_LOCK.lock();
+        let dir = TempDir::new().unwrap();
+        let _path = EnvVarGuard::set("HYPRSTREAM__SECRETS__PATH", dir.path().to_str().unwrap());
+        let _profile = EnvVarGuard::unset(SECRETS_PROFILE_ENV);
+
+        let profile = SecretsProfile::from_env().unwrap();
+        assert_eq!(
+            profile,
+            SecretsProfile::SharedDirectory,
+            "a general path override is not proof of per-service scoping"
+        );
+        let model = resolve_service_signing_key(dir.path(), "model", profile).unwrap();
+        let worker = resolve_service_signing_key(dir.path(), "worker", profile).unwrap();
+        assert_ne!(
+            model.to_bytes(),
+            worker.to_bytes(),
+            "services sharing an overridden directory must retain independent keys"
+        );
+        assert!(dir.path().join("model").join("signing-key").exists());
+        assert!(dir.path().join("worker").join("signing-key").exists());
+        assert!(!dir.path().join("signing-key").exists());
+    }
+
+    #[test]
+    fn test_service_jwt_write_round_trips_through_startup_read_layouts() {
+        let dir = TempDir::new().unwrap();
+
+        write_service_jwt_for_profile(
+            dir.path(),
+            "model",
+            SecretsProfile::SharedDirectory,
+            "shared.jwt",
+        )
+        .unwrap();
+        assert_eq!(
+            load_service_jwt_for_profile(dir.path(), "model", SecretsProfile::SharedDirectory,)
+                .unwrap()
+                .as_deref(),
+            Some("shared.jwt")
+        );
+        assert!(dir.path().join("model").join("service-jwt").exists());
+
+        let scoped = dir.path().join("scoped");
+        write_service_jwt_for_profile(
+            &scoped,
+            "model",
+            SecretsProfile::PerServiceScoped,
+            "scoped.jwt",
+        )
+        .unwrap();
+        assert_eq!(
+            load_service_jwt_for_profile(&scoped, "model", SecretsProfile::PerServiceScoped,)
+                .unwrap()
+                .as_deref(),
+            Some("scoped.jwt")
+        );
+        assert!(scoped.join("service-jwt").exists());
+        assert!(!scoped.join("model").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_scoped_service_jwt_renewal_survives_read_only_credentials_restart() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let _serial = SECRETS_ENV_LOCK.lock();
+        let dir = TempDir::new().unwrap();
+        let credentials = dir.path().join("credentials");
+        let state = dir.path().join("state");
+        std::fs::create_dir_all(&credentials).unwrap();
+        std::fs::create_dir_all(&state).unwrap();
+        write_secret(&credentials, "service-jwt", b"provisioned.jwt").unwrap();
+
+        std::fs::set_permissions(&credentials, std::fs::Permissions::from_mode(0o500)).unwrap();
+        let _state = EnvVarGuard::set("STATE_DIRECTORY", state.to_str().unwrap());
+        let _instance = EnvVarGuard::unset("HYPRSTREAM_INSTANCE");
+
+        write_service_jwt_for_profile(
+            &credentials,
+            "model",
+            SecretsProfile::PerServiceScoped,
+            "renewed.jwt",
+        )
+        .unwrap();
+        assert_eq!(
+            load_service_jwt_for_profile(&credentials, "model", SecretsProfile::PerServiceScoped,)
+                .unwrap()
+                .as_deref(),
+            Some("renewed.jwt"),
+            "startup must prefer the renewed JWT written to writable state"
+        );
+        assert_eq!(
+            std::fs::read_to_string(state.join("credentials").join("model").join("service-jwt"))
+                .unwrap(),
+            "renewed.jwt"
+        );
     }
 
     #[test]

--- a/crates/hyprstream/src/auth/identity_store.rs
+++ b/crates/hyprstream/src/auth/identity_store.rs
@@ -881,6 +881,20 @@ pub fn load_or_generate_tls_materials_named(
                 });
             }
 
+            if needs_renewal {
+                // Read-only credentials dir (e.g. systemd $CREDENTIALS_DIRECTORY):
+                // the imported cert ages past validity with no on-disk remedy from
+                // inside the service. Fail loud so operators re-provision (#808).
+                tracing::error!(
+                    "TLS cert '{}' in '{}' is past its renewal threshold but the \
+                     credentials directory is read-only; renewal was SKIPPED and the \
+                     cert will expire. Re-run 'hyprstream service install' to \
+                     re-provision a fresh certificate.",
+                    cert_name,
+                    secrets_dir.display()
+                );
+            }
+
             tracing::info!("Loaded persisted TLS materials from '{}'", secrets_dir.display());
             Ok(TlsMaterials {
                 cert_der,

--- a/crates/hyprstream/src/auth/key_rotation.rs
+++ b/crates/hyprstream/src/auth/key_rotation.rs
@@ -1024,7 +1024,7 @@ pub fn global_es256_key_store(
     let store = ES256_SIGNING_STORE
         .get_or_init(|| Arc::new(load_or_init_es256_key_store(secrets_dir, config)))
         .clone();
-    store.bind_secrets_dir(secrets_dir.to_path_buf());
+    store.bind_secrets_dir(rotation_state_dir(secrets_dir));
     store
 }
 
@@ -1120,6 +1120,57 @@ impl SigningKeyStore {
 
 // ── Persistence ─────────────────────────────────────────────────────────────
 
+/// Resolve the directory JWT rotation *state* is persisted to.
+///
+/// Rotation slots are runtime-mutated state, not provisioned credentials, so
+/// they need a writable home (#803). When `secrets_dir` is writable (bare
+/// metal, dev, non-systemd) the slots live there, as before. When it is
+/// read-only — the systemd `$CREDENTIALS_DIRECTORY` ramfs — slots fall back to
+/// the unit's `$STATE_DIRECTORY` (`StateDirectory=`), or to the XDG state dir
+/// when not running under systemd. Loading always checks the state dir first
+/// and falls back to `secrets_dir`, so credentials provisioned into the
+/// credstore still bootstrap the first boot.
+pub fn rotation_state_dir(secrets_dir: &Path) -> PathBuf {
+    if super::identity_store::is_writable(secrets_dir) {
+        return secrets_dir.to_path_buf();
+    }
+    // systemd: `StateDirectory=` sets $STATE_DIRECTORY to a writable,
+    // service-private dir (colon-separated list when multiple are declared;
+    // hyprstream units declare exactly one).
+    let systemd_state = std::env::var("STATE_DIRECTORY").ok().and_then(|v| {
+        let first = v.split(':').next().unwrap_or_default();
+        if first.is_empty() {
+            None
+        } else {
+            Some(PathBuf::from(first))
+        }
+    });
+    let base = match systemd_state {
+        // Namespace by instance to match the socket/config isolation.
+        Some(dir) => match std::env::var("HYPRSTREAM_INSTANCE") {
+            Ok(inst) if !inst.is_empty() => Some(dir.join("instances").join(inst)),
+            _ => Some(dir),
+        },
+        // Not systemd: XDG state home (already instance-namespaced via the
+        // StoragePaths prefix).
+        None => crate::storage::paths::StoragePaths::new()
+            .and_then(|s| s.state_dir())
+            .ok(),
+    };
+    match base {
+        Some(dir) => dir.join("credentials"),
+        None => {
+            error!(
+                "secrets dir '{}' is read-only and no writable state directory \
+                 could be resolved; JWT rotation state will NOT survive restart \
+                 (all issued tokens are invalidated on every restart)",
+                secrets_dir.display()
+            );
+            secrets_dir.to_path_buf()
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 struct SlotMeta {
     nbf: i64,
@@ -1196,15 +1247,22 @@ pub fn load_or_init_key_store(secrets_dir: &Path, config: &OAuthConfig) -> Signi
     let active_secs = config.active_secs();
     let lead_secs = config.lead_secs();
 
-    let drain = load_slot(secrets_dir, "drain");
-    let mut active = load_slot(secrets_dir, "active");
-    let lead = load_slot(secrets_dir, "lead");
+    // Slots are state: read/write them via the writable state dir (#803),
+    // falling back to the (possibly read-only, provisioned) secrets dir.
+    let state_dir = rotation_state_dir(secrets_dir);
+    let drain = load_slot(&state_dir, "drain").or_else(|| load_slot(secrets_dir, "drain"));
+    let mut active = load_slot(&state_dir, "active").or_else(|| load_slot(secrets_dir, "active"));
+    let lead = load_slot(&state_dir, "lead").or_else(|| load_slot(secrets_dir, "lead"));
 
     if active.is_none() {
         info!("No active JWT signing key found — generating on first boot");
         let slot = generate_slot(now, now + active_secs);
-        if let Err(e) = persist_slot(secrets_dir, "active", &slot) {
-            warn!("Could not persist active JWT key: {e}");
+        if let Err(e) = persist_slot(&state_dir, "active", &slot) {
+            error!(
+                "Could not persist active JWT key to '{}': {e}. The key is \
+                 process-ephemeral — every restart invalidates all issued tokens.",
+                state_dir.display()
+            );
         } else {
             info!("Active JWT key generated (kid={})", slot.kid());
         }
@@ -1218,8 +1276,12 @@ pub fn load_or_init_key_store(secrets_dir: &Path, config: &OAuthConfig) -> Signi
         let lead_nbf = active.as_ref().map(|a| a.exp).unwrap_or(now) - lead_secs;
         let lead_exp = lead_nbf + active_secs;
         let slot = generate_slot(lead_nbf, lead_exp);
-        if let Err(e) = persist_slot(secrets_dir, "lead", &slot) {
-            warn!("Could not persist lead JWT key: {e}");
+        if let Err(e) = persist_slot(&state_dir, "lead", &slot) {
+            error!(
+                "Could not persist lead JWT key to '{}': {e}. Rotation state will \
+                 not survive restart.",
+                state_dir.display()
+            );
         } else {
             info!("Lead JWT key pre-generated at startup (kid={})", slot.kid());
         }
@@ -1227,7 +1289,7 @@ pub fn load_or_init_key_store(secrets_dir: &Path, config: &OAuthConfig) -> Signi
 
     // Re-load lead if we just generated it
     let lead = if should_gen_lead {
-        load_slot(secrets_dir, "lead")
+        load_slot(&state_dir, "lead")
     } else {
         lead
     };
@@ -1305,6 +1367,7 @@ pub async fn rotate_jwt_keys(
     let active_secs = config.active_secs();
     let lead_secs = config.lead_secs();
     let drain_secs = config.drain_secs();
+    let state_dir = rotation_state_dir(secrets_dir);
 
     // 1. Promote lead → active if lead.nbf has passed.
     if let Some(new_lead) = slots.lead.take().filter(|l| l.nbf <= now) {
@@ -1315,19 +1378,27 @@ pub async fn rotate_jwt_keys(
         // Old active → drain (evict old drain first)
         if let Some(prev_drain) = slots.drain.take() {
             info!("Evicting drain JWT key (kid={})", prev_drain.kid());
-            delete_slot(secrets_dir, "drain");
+            delete_slot(&state_dir, "drain");
         }
         if let Some(old_active_slot) = old_active {
-            if let Err(e) = persist_slot(secrets_dir, "drain", &old_active_slot) {
-                warn!("Could not persist drain JWT key: {e}");
+            if let Err(e) = persist_slot(&state_dir, "drain", &old_active_slot) {
+                error!(
+                    "Could not persist drain JWT key to '{}': {e}. Rotation state \
+                     will not survive restart.",
+                    state_dir.display()
+                );
             }
             slots.drain = Some(old_active_slot);
         }
 
-        if let Err(e) = persist_slot(secrets_dir, "active", &new_lead) {
-            warn!("Could not persist active JWT key: {e}");
+        if let Err(e) = persist_slot(&state_dir, "active", &new_lead) {
+            error!(
+                "Could not persist active JWT key to '{}': {e}. The key is \
+                 process-ephemeral — every restart invalidates all issued tokens.",
+                state_dir.display()
+            );
         }
-        delete_slot(secrets_dir, "lead");
+        delete_slot(&state_dir, "lead");
         slots.active = Some(new_lead);
     }
 
@@ -1339,7 +1410,7 @@ pub async fn rotate_jwt_keys(
     {
         let kid = slots.drain.as_ref().map(KeySlot::kid).unwrap_or_default();
         info!("Removing expired drain JWT key (kid={kid})");
-        delete_slot(secrets_dir, "drain");
+        delete_slot(&state_dir, "drain");
         slots.drain = None;
     }
 
@@ -1355,8 +1426,12 @@ pub async fn rotate_jwt_keys(
                     new_lead.kid(),
                     new_lead.nbf
                 );
-                if let Err(e) = persist_slot(secrets_dir, "lead", &new_lead) {
-                    warn!("Could not persist lead JWT key: {e}");
+                if let Err(e) = persist_slot(&state_dir, "lead", &new_lead) {
+                    error!(
+                        "Could not persist lead JWT key to '{}': {e}. Rotation state \
+                         will not survive restart.",
+                        state_dir.display()
+                    );
                 }
                 slots.lead = Some(new_lead);
             }
@@ -1625,8 +1700,11 @@ impl Es256SigningKeyStore {
 /// disk — not the in-memory `OnceLock` — is what makes a cross-process reader
 /// observe a slot promoted by another process.
 pub(crate) fn es256_signing_key_for_kid(secrets_dir: &Path, kid: &str) -> Option<Es256SigningKey> {
+    let state_dir = rotation_state_dir(secrets_dir);
     for name in ["active", "drain", "lead"] {
-        if let Some(slot) = load_es256_slot(secrets_dir, name) {
+        if let Some(slot) =
+            load_es256_slot(&state_dir, name).or_else(|| load_es256_slot(secrets_dir, name))
+        {
             if slot.kid() == kid {
                 return Some((*slot.key).clone());
             }
@@ -1702,26 +1780,34 @@ pub fn load_or_init_es256_key_store(
     let active_secs = config.active_secs();
     let lead_secs = config.lead_secs();
 
-    let mut drain = load_es256_slot(secrets_dir, "drain");
-    let mut active = load_es256_slot(secrets_dir, "active");
-    let mut lead = load_es256_slot(secrets_dir, "lead");
+    let state_dir = rotation_state_dir(secrets_dir);
+    let mut drain =
+        load_es256_slot(&state_dir, "drain").or_else(|| load_es256_slot(secrets_dir, "drain"));
+    let mut active =
+        load_es256_slot(&state_dir, "active").or_else(|| load_es256_slot(secrets_dir, "active"));
+    let mut lead =
+        load_es256_slot(&state_dir, "lead").or_else(|| load_es256_slot(secrets_dir, "lead"));
 
     // Do not serve an already-expired bounded method after restart. This is
     // the same exclusive boundary the verifier and runtime cleanup use.
     if drain.as_ref().is_some_and(|slot| now >= slot.exp) {
-        delete_es256_slot(secrets_dir, "drain");
+        delete_es256_slot(&state_dir, "drain");
         drain = None;
     }
     if lead.as_ref().is_some_and(|slot| now >= slot.exp) {
-        delete_es256_slot(secrets_dir, "lead");
+        delete_es256_slot(&state_dir, "lead");
         lead = None;
     }
 
     if active.is_none() {
         info!("No active ES256 signing key found — generating on first boot");
         let slot = generate_es256_slot(now, now + active_secs);
-        if let Err(e) = persist_es256_slot(secrets_dir, "active", &slot) {
-            warn!("Could not persist active ES256 key: {e}");
+        if let Err(e) = persist_es256_slot(&state_dir, "active", &slot) {
+            error!(
+                "Could not persist active ES256 key to '{}': {e}. The key is \
+                 process-ephemeral — every restart invalidates all issued tokens.",
+                state_dir.display()
+            );
         } else {
             info!("Active ES256 key generated (kid={})", slot.kid());
         }
@@ -1734,13 +1820,17 @@ pub fn load_or_init_es256_key_store(
         let lead_nbf = active.as_ref().map(|a| a.exp).unwrap_or(now) - lead_secs;
         let lead_exp = lead_nbf + active_secs;
         let slot = generate_es256_slot(lead_nbf, lead_exp);
-        if let Err(e) = persist_es256_slot(secrets_dir, "lead", &slot) {
-            warn!("Could not persist lead ES256 key: {e}");
+        if let Err(e) = persist_es256_slot(&state_dir, "lead", &slot) {
+            error!(
+                "Could not persist lead ES256 key to '{}': {e}. Rotation state will \
+                 not survive restart.",
+                state_dir.display()
+            );
         }
     }
 
     let lead = if should_gen_lead {
-        load_es256_slot(secrets_dir, "lead")
+        load_es256_slot(&state_dir, "lead")
     } else {
         lead
     };
@@ -1762,6 +1852,16 @@ pub fn load_or_init_es256_key_store(
 pub async fn rotate_es256_keys(
     config: &OAuthConfig,
     secrets_dir: &Path,
+    store: &Es256SigningKeyStore,
+    now: i64,
+) -> bool {
+    let state_dir = rotation_state_dir(secrets_dir);
+    rotate_es256_keys_in_state_dir(config, &state_dir, store, now).await
+}
+
+async fn rotate_es256_keys_in_state_dir(
+    config: &OAuthConfig,
+    state_dir: &Path,
     store: &Es256SigningKeyStore,
     now: i64,
 ) -> bool {
@@ -1789,29 +1889,35 @@ pub async fn rotate_es256_keys(
         // Persist drain before active. A process that reloads between the two
         // writes can therefore still verify K-signed commits.
         if let Some(ref drain) = new_drain {
-            if let Err(error) = persist_es256_slot(secrets_dir, "drain", drain) {
+            if let Err(error) = persist_es256_slot(state_dir, "drain", drain) {
                 if let Some(ref old_drain) = old_drain {
-                    let _ = persist_es256_slot(secrets_dir, "drain", old_drain);
+                    let _ = persist_es256_slot(state_dir, "drain", old_drain);
                 } else {
-                    delete_es256_slot(secrets_dir, "drain");
+                    delete_es256_slot(state_dir, "drain");
                 }
-                warn!("ES256: failed to persist drain slot; retaining old active: {error}");
+                error!(
+                    "ES256: failed to persist drain slot to '{}'; retaining old active: {error}",
+                    state_dir.display()
+                );
                 return false;
             }
         }
 
-        if let Err(error) = persist_es256_slot(secrets_dir, "active", &new_active) {
+        if let Err(error) = persist_es256_slot(state_dir, "active", &new_active) {
             if let Some(ref old_active) = old_active {
-                let _ = persist_es256_slot(secrets_dir, "active", old_active);
+                let _ = persist_es256_slot(state_dir, "active", old_active);
             } else {
-                delete_es256_slot(secrets_dir, "active");
+                delete_es256_slot(state_dir, "active");
             }
             if let Some(ref old_drain) = old_drain {
-                let _ = persist_es256_slot(secrets_dir, "drain", old_drain);
+                let _ = persist_es256_slot(state_dir, "drain", old_drain);
             } else {
-                delete_es256_slot(secrets_dir, "drain");
+                delete_es256_slot(state_dir, "drain");
             }
-            warn!("ES256: failed to persist promoted active; retaining old active: {error}");
+            error!(
+                "ES256: failed to persist promoted active to '{}'; retaining old active: {error}",
+                state_dir.display()
+            );
             return false;
         }
 
@@ -1825,22 +1931,26 @@ pub async fn rotate_es256_keys(
                         "ES256: failed to restore PDS head after promotion failure: {rollback_error}"
                     );
                 }
-                if let Err(rollback_error) = persist_es256_slot(secrets_dir, "active", old_active) {
+                if let Err(rollback_error) =
+                    persist_es256_slot(state_dir, "active", old_active)
+                {
                     warn!(
                         "ES256: failed to restore persisted active after promotion failure: {rollback_error}"
                     );
                 }
             } else {
-                delete_es256_slot(secrets_dir, "active");
+                delete_es256_slot(state_dir, "active");
             }
             if let Some(ref old_drain) = old_drain {
-                if let Err(rollback_error) = persist_es256_slot(secrets_dir, "drain", old_drain) {
+                if let Err(rollback_error) =
+                    persist_es256_slot(state_dir, "drain", old_drain)
+                {
                     warn!(
                         "ES256: failed to restore persisted drain after promotion failure: {rollback_error}"
                     );
                 }
             } else {
-                delete_es256_slot(secrets_dir, "drain");
+                delete_es256_slot(state_dir, "drain");
             }
             warn!(
                 "ES256: failed to re-sign PDS head; retaining old active and retrying next tick: {error}"
@@ -1848,7 +1958,7 @@ pub async fn rotate_es256_keys(
             return false;
         }
 
-        delete_es256_slot(secrets_dir, "lead");
+        delete_es256_slot(state_dir, "lead");
         slots.drain = new_drain.or(old_drain);
         slots.active = Some(new_active);
         slots.lead = None;
@@ -1859,7 +1969,7 @@ pub async fn rotate_es256_keys(
     // Phase 2: remove expired drain
     if let Some(ref drain) = slots.drain {
         if now >= drain.exp {
-            delete_es256_slot(secrets_dir, "drain");
+            delete_es256_slot(state_dir, "drain");
             slots.drain = None;
             info!("ES256: removed expired drain slot");
         }
@@ -1868,7 +1978,7 @@ pub async fn rotate_es256_keys(
     // A lead is publication-only and must not survive its own bounded window
     // if an administrator supplied inconsistent slot files.
     if slots.lead.as_ref().is_some_and(|lead| now >= lead.exp) {
-        delete_es256_slot(secrets_dir, "lead");
+        delete_es256_slot(state_dir, "lead");
         slots.lead = None;
         info!("ES256: removed expired lead slot");
     }
@@ -1879,8 +1989,12 @@ pub async fn rotate_es256_keys(
             let lead_nbf = active.exp - lead_secs;
             let lead_exp = lead_nbf + active_secs;
             let new_lead = generate_es256_slot(lead_nbf, lead_exp);
-            if let Err(e) = persist_es256_slot(secrets_dir, "lead", &new_lead) {
-                warn!("ES256: failed to persist new lead: {e}");
+            if let Err(e) = persist_es256_slot(state_dir, "lead", &new_lead) {
+                error!(
+                    "ES256: failed to persist new lead to '{}': {e}. Rotation state \
+                     will not survive restart.",
+                    state_dir.display()
+                );
             } else {
                 info!("ES256: generated new lead key (kid={})", new_lead.kid());
             }
@@ -2029,15 +2143,23 @@ mod ml_dsa_rotation {
         let active_secs = config.active_secs();
         let lead_secs = config.lead_secs();
 
-        let drain = load_ml_dsa_slot(secrets_dir, "drain");
-        let mut active = load_ml_dsa_slot(secrets_dir, "active");
-        let lead = load_ml_dsa_slot(secrets_dir, "lead");
+        let state_dir = rotation_state_dir(secrets_dir);
+        let drain = load_ml_dsa_slot(&state_dir, "drain")
+            .or_else(|| load_ml_dsa_slot(secrets_dir, "drain"));
+        let mut active = load_ml_dsa_slot(&state_dir, "active")
+            .or_else(|| load_ml_dsa_slot(secrets_dir, "active"));
+        let lead =
+            load_ml_dsa_slot(&state_dir, "lead").or_else(|| load_ml_dsa_slot(secrets_dir, "lead"));
 
         if active.is_none() {
             info!("No active ML-DSA-65 signing key found — generating on first boot");
             let slot = generate_ml_dsa_slot(now, now + active_secs);
-            if let Err(e) = persist_ml_dsa_slot(secrets_dir, "active", &slot) {
-                warn!("Could not persist active ML-DSA key: {e}");
+            if let Err(e) = persist_ml_dsa_slot(&state_dir, "active", &slot) {
+                error!(
+                    "Could not persist active ML-DSA key to '{}': {e}. The key is \
+                     process-ephemeral — every restart invalidates all issued tokens.",
+                    state_dir.display()
+                );
             } else {
                 info!("Active ML-DSA-65 key generated");
             }
@@ -2050,13 +2172,17 @@ mod ml_dsa_rotation {
             let lead_nbf = active.as_ref().map(|a| a.exp).unwrap_or(now) - lead_secs;
             let lead_exp = lead_nbf + active_secs;
             let slot = generate_ml_dsa_slot(lead_nbf, lead_exp);
-            if let Err(e) = persist_ml_dsa_slot(secrets_dir, "lead", &slot) {
-                warn!("Could not persist lead ML-DSA key: {e}");
+            if let Err(e) = persist_ml_dsa_slot(&state_dir, "lead", &slot) {
+                error!(
+                    "Could not persist lead ML-DSA key to '{}': {e}. Rotation state \
+                     will not survive restart.",
+                    state_dir.display()
+                );
             }
         }
 
         let lead = if should_gen_lead {
-            load_ml_dsa_slot(secrets_dir, "lead")
+            load_ml_dsa_slot(&state_dir, "lead")
         } else {
             lead
         };
@@ -2077,22 +2203,32 @@ mod ml_dsa_rotation {
         let active_secs = config.active_secs();
         let lead_secs = config.lead_secs();
         let drain_secs = config.drain_secs();
+        let state_dir = rotation_state_dir(secrets_dir);
 
         // Phase 1: promote lead → active
         let lead_ready = slots.lead.as_ref().is_some_and(|lead| lead.nbf <= now);
         if lead_ready {
             if let Some(new_active) = slots.lead.take() {
                 if let Some(old_active) = slots.active.take() {
-                    delete_ml_dsa_slot(secrets_dir, "drain");
-                    if let Err(e) = persist_ml_dsa_slot(secrets_dir, "drain", &old_active) {
-                        warn!("ML-DSA: failed to persist drain slot: {e}");
+                    delete_ml_dsa_slot(&state_dir, "drain");
+                    if let Err(e) = persist_ml_dsa_slot(&state_dir, "drain", &old_active) {
+                        error!(
+                            "ML-DSA: failed to persist drain slot to '{}': {e}. Rotation \
+                             state will not survive restart.",
+                            state_dir.display()
+                        );
                     }
                     slots.drain = Some(old_active);
                 }
-                if let Err(e) = persist_ml_dsa_slot(secrets_dir, "active", &new_active) {
-                    warn!("ML-DSA: failed to persist promoted active: {e}");
+                if let Err(e) = persist_ml_dsa_slot(&state_dir, "active", &new_active) {
+                    error!(
+                        "ML-DSA: failed to persist promoted active to '{}': {e}. The key \
+                         is process-ephemeral — every restart invalidates all issued \
+                         tokens.",
+                        state_dir.display()
+                    );
                 }
-                delete_ml_dsa_slot(secrets_dir, "lead");
+                delete_ml_dsa_slot(&state_dir, "lead");
                 slots.active = Some(new_active);
                 info!("ML-DSA: promoted lead → active");
             }
@@ -2101,7 +2237,7 @@ mod ml_dsa_rotation {
         // Phase 2: remove expired drain
         if let Some(ref drain) = slots.drain {
             if now >= drain.exp + drain_secs {
-                delete_ml_dsa_slot(secrets_dir, "drain");
+                delete_ml_dsa_slot(&state_dir, "drain");
                 slots.drain = None;
                 info!("ML-DSA: removed expired drain slot");
             }
@@ -2113,8 +2249,12 @@ mod ml_dsa_rotation {
                 let lead_nbf = active.exp - lead_secs;
                 let lead_exp = lead_nbf + active_secs;
                 let new_lead = generate_ml_dsa_slot(lead_nbf, lead_exp);
-                if let Err(e) = persist_ml_dsa_slot(secrets_dir, "lead", &new_lead) {
-                    warn!("ML-DSA: failed to persist new lead: {e}");
+                if let Err(e) = persist_ml_dsa_slot(&state_dir, "lead", &new_lead) {
+                    error!(
+                        "ML-DSA: failed to persist new lead to '{}': {e}. Rotation state \
+                         will not survive restart.",
+                        state_dir.display()
+                    );
                 } else {
                     info!("ML-DSA: generated new lead key");
                 }
@@ -3658,7 +3798,7 @@ mod tests {
             lead: Some(lead),
         });
         assert!(
-            !rotate_es256_keys(&config, &invalid_secrets_dir, &store, now).await,
+            !rotate_es256_keys_in_state_dir(&config, &invalid_secrets_dir, &store, now).await,
             "failed active persistence must not report promotion"
         );
         {

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -2132,15 +2132,8 @@ fn main() -> Result<()> {
                                     // %d/signing-key, while standalone uses a subdirectory.
                                     // #759: "policy" always resolves to the flat root/CA key regardless of
                                     // secrets profile — see `resolve_service_signing_key` for why.
-                                    let secrets_profile = if std::env::var(
-                                        "HYPRSTREAM__SECRETS__PATH",
-                                    )
-                                    .is_ok()
-                                    {
-                                        hyprstream_core::auth::identity_store::SecretsProfile::PerServiceScoped
-                                    } else {
-                                        hyprstream_core::auth::identity_store::SecretsProfile::SharedDirectory
-                                    };
+                                    let secrets_profile =
+                                        hyprstream_core::auth::identity_store::SecretsProfile::from_env()?;
                                     let own_key = hyprstream_core::auth::identity_store::resolve_service_signing_key(
                                         &secrets_dir, &name, secrets_profile,
                                     )?;
@@ -2159,21 +2152,23 @@ fn main() -> Result<()> {
                                         // that register_service_key() finds it on first call — otherwise
                                         // the trust store only has pubkeys (jwt: None) from bootstrap-pubkeys
                                         // and registration is silently skipped.
-                                        if let Ok(Some(jwt_bytes)) = hyprstream_core::auth::identity_store::read_secret(&secrets_dir, "service-jwt") {
-                                            if let Ok(jwt_str) = String::from_utf8(jwt_bytes) {
-                                                let exp = hyprstream_core::auth::identity_store::decode_jwt_exp_raw(&jwt_str).unwrap_or(0);
-                                                hyprstream_service::global_trust_store().insert(
-                                                    own_key.verifying_key(),
-                                                    hyprstream_service::Attestation {
-                                                        scopes: std::iter::once(name.clone()).collect(),
-                                                        subject: None,
-                                                        jwt: Some(jwt_str),
-                                                        expires_at: exp,
-                                                        attested_by: None,
-                                                    },
-                                                );
-                                                tracing::info!(service = %name, "Seeded trust store with own service-jwt from credential dir");
-                                            }
+                                        if let Ok(Some(jwt_str)) = hyprstream_core::auth::identity_store::load_service_jwt_for_profile(
+                                            &secrets_dir,
+                                            &name,
+                                            secrets_profile,
+                                        ) {
+                                            let exp = hyprstream_core::auth::identity_store::decode_jwt_exp_raw(&jwt_str).unwrap_or(0);
+                                            hyprstream_service::global_trust_store().insert(
+                                                own_key.verifying_key(),
+                                                hyprstream_service::Attestation {
+                                                    scopes: std::iter::once(name.clone()).collect(),
+                                                    subject: None,
+                                                    jwt: Some(jwt_str),
+                                                    expires_at: exp,
+                                                    attested_by: None,
+                                                },
+                                            );
+                                            tracing::info!(service = %name, "Seeded trust store with own service-jwt from credential dir");
                                         }
                                     }
                                 } else {

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -281,8 +281,11 @@ fn decode_jwt_exp(jwt: &str) -> Option<i64> {
 
 /// Spawn a background task that renews this service's JWT when it approaches expiry.
 ///
-/// Checks hourly; renews when ≤7 days remain. Writes the renewed JWT to disk and
-/// updates the global trust store so in-flight RPC calls stay authenticated.
+/// Checks hourly; renews when ≤7 days remain. Updates the global trust store so
+/// in-flight RPC calls stay authenticated, and best-effort persists the renewed
+/// JWT to disk so it survives restart. On a read-only credentials dir (systemd
+/// `$CREDENTIALS_DIRECTORY`) the persist fails with an error-level log — the
+/// service re-registers and obtains a fresh JWT on next startup regardless.
 fn spawn_jwt_renewal_task(
     service_name: &str,
     signing_key: SigningKey,
@@ -369,6 +372,19 @@ fn spawn_jwt_renewal_task(
                             att.expires_at = info.expires_at;
                             trust.insert(vk, att);
                         }
+                    }
+                    // Persist so the renewed JWT survives restart (#803).
+                    if let Err(e) = crate::auth::identity_store::write_service_jwt(
+                        &credentials_dir,
+                        &service_name,
+                        &info.token,
+                    ) {
+                        tracing::error!(
+                            service = service_name,
+                            error = %e,
+                            "renewed service JWT could not be persisted; it is \
+                             process-ephemeral until the next restart re-registers"
+                        );
                     }
                     tracing::info!(
                         service = service_name,

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -147,12 +147,17 @@ pub fn with_checkpointed_native_announcements(
 fn resolve_registration_jwt(
     service_name: &str,
     creds_dir: &std::path::Path,
+    secrets_profile: crate::auth::identity_store::SecretsProfile,
     from_trust: Option<String>,
 ) -> anyhow::Result<String> {
     if let Some(jwt) = from_trust {
         return Ok(jwt);
     }
-    match crate::auth::identity_store::load_service_jwt(creds_dir, service_name) {
+    match crate::auth::identity_store::load_service_jwt_for_profile(
+        creds_dir,
+        service_name,
+        secrets_profile,
+    ) {
         Ok(Some(jwt)) => Ok(jwt),
         Ok(None) => anyhow::bail!(
             "service '{service_name}' cannot register its signing key: \
@@ -201,6 +206,7 @@ fn register_service_key(
     }
 
     let creds_dir = credentials_dir()?;
+    let secrets_profile = crate::auth::identity_store::SecretsProfile::from_env()?;
 
     // The JWT may already be in the trust store (e.g. seeded by an earlier
     // registration in this process); otherwise load it from disk — the
@@ -212,7 +218,8 @@ fn register_service_key(
             .and_then(|vk| trust.get(&vk))
             .and_then(|att| att.jwt.clone())
     };
-    let jwt = resolve_registration_jwt(service_name, &creds_dir, from_trust)?;
+    let jwt =
+        resolve_registration_jwt(service_name, &creds_dir, secrets_profile, from_trust)?;
 
     // Seed the loaded JWT into the trust store so that peer-client construction
     // (`service_token`) and the background renewal task can read it. Bind it to
@@ -261,7 +268,12 @@ fn register_service_key(
     );
 
     // Spawn background JWT renewal for this service
-    spawn_jwt_renewal_task(service_name, signing_key.clone(), creds_dir);
+    spawn_jwt_renewal_task(
+        service_name,
+        signing_key.clone(),
+        creds_dir,
+        secrets_profile,
+    );
 
     Ok(())
 }
@@ -283,13 +295,13 @@ fn decode_jwt_exp(jwt: &str) -> Option<i64> {
 ///
 /// Checks hourly; renews when ≤7 days remain. Updates the global trust store so
 /// in-flight RPC calls stay authenticated, and best-effort persists the renewed
-/// JWT to disk so it survives restart. On a read-only credentials dir (systemd
-/// `$CREDENTIALS_DIRECTORY`) the persist fails with an error-level log — the
-/// service re-registers and obtains a fresh JWT on next startup regardless.
+/// JWT to disk so it survives restart. When credentials are read-only (systemd
+/// `$CREDENTIALS_DIRECTORY`), persistence uses the unit's writable state home.
 fn spawn_jwt_renewal_task(
     service_name: &str,
     signing_key: SigningKey,
     credentials_dir: std::path::PathBuf,
+    secrets_profile: crate::auth::identity_store::SecretsProfile,
 ) {
     let service_name = service_name.to_owned();
     tokio::spawn(async move {
@@ -299,9 +311,10 @@ fn spawn_jwt_renewal_task(
         loop {
             tokio::time::sleep(CHECK_INTERVAL).await;
 
-            let jwt = match crate::auth::identity_store::load_service_jwt(
+            let jwt = match crate::auth::identity_store::load_service_jwt_for_profile(
                 &credentials_dir,
                 &service_name,
+                secrets_profile,
             ) {
                 Ok(Some(j)) => j,
                 _ => continue,
@@ -374,9 +387,10 @@ fn spawn_jwt_renewal_task(
                         }
                     }
                     // Persist so the renewed JWT survives restart (#803).
-                    if let Err(e) = crate::auth::identity_store::write_service_jwt(
+                    if let Err(e) = crate::auth::identity_store::write_service_jwt_for_profile(
                         &credentials_dir,
                         &service_name,
+                        secrets_profile,
                         &info.token,
                     ) {
                         tracing::error!(
@@ -2177,8 +2191,13 @@ mod tests {
     #[test]
     fn resolve_registration_jwt_fails_closed_when_missing() {
         let dir = tempfile::tempdir().unwrap();
-        let err = resolve_registration_jwt("model", dir.path(), None)
-            .expect_err("missing JWT must fail closed, not skip");
+        let err = resolve_registration_jwt(
+            "model",
+            dir.path(),
+            crate::auth::identity_store::SecretsProfile::SharedDirectory,
+            None,
+        )
+        .expect_err("missing JWT must fail closed, not skip");
         let msg = err.to_string();
         assert!(msg.contains("model"), "error names the service: {msg}");
         assert!(
@@ -2191,8 +2210,13 @@ mod tests {
     #[test]
     fn resolve_registration_jwt_prefers_trust_store() {
         let dir = tempfile::tempdir().unwrap();
-        let jwt = resolve_registration_jwt("model", dir.path(), Some("trust.jwt.token".to_owned()))
-            .unwrap();
+        let jwt = resolve_registration_jwt(
+            "model",
+            dir.path(),
+            crate::auth::identity_store::SecretsProfile::SharedDirectory,
+            Some("trust.jwt.token".to_owned()),
+        )
+        .unwrap();
         assert_eq!(jwt, "trust.jwt.token");
     }
 
@@ -2202,7 +2226,13 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         crate::auth::identity_store::write_service_jwt(dir.path(), "model", "disk.jwt.token")
             .unwrap();
-        let jwt = resolve_registration_jwt("model", dir.path(), None).unwrap();
+        let jwt = resolve_registration_jwt(
+            "model",
+            dir.path(),
+            crate::auth::identity_store::SecretsProfile::SharedDirectory,
+            None,
+        )
+        .unwrap();
         assert_eq!(jwt, "disk.jwt.token");
     }
 

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -1441,8 +1441,17 @@ impl PolicyHandler for PolicyService {
 
         // Persist renewed JWT to disk so it survives a server restart
         let credentials_dir = crate::auth::identity_store::credentials_dir()?;
-        if let Err(e) = crate::auth::identity_store::write_service_jwt(&credentials_dir, svc_name, &token) {
-            warn!(service = svc_name, "Failed to persist renewed JWT to disk: {e}");
+        let secrets_profile = crate::auth::identity_store::SecretsProfile::from_env()?;
+        if let Err(e) = crate::auth::identity_store::write_service_jwt_for_profile(
+            &credentials_dir,
+            svc_name,
+            secrets_profile,
+            &token,
+        ) {
+            warn!(
+                service = svc_name,
+                "Failed to persist renewed JWT to disk: {e}"
+            );
         }
 
         info!(service = svc_name, expires_at, "Renewed service JWT");

--- a/crates/hyprstream/src/storage/paths.rs
+++ b/crates/hyprstream/src/storage/paths.rs
@@ -69,6 +69,17 @@ impl StoragePaths {
         Ok(config_dir)
     }
 
+    /// Get the state directory path (XDG state home, instance-namespaced).
+    ///
+    /// Used for runtime-mutated state (e.g. JWT rotation slots, #803) that
+    /// must stay writable even when the config/credentials dir is a read-only
+    /// systemd credentials ramfs.
+    pub fn state_dir(&self) -> Result<PathBuf> {
+        let state_dir = self.base_dirs.get_state_home();
+        self.ensure_dir_exists(&state_dir)?;
+        Ok(state_dir)
+    }
+
     /// Get the temporary download directory
     pub fn temp_download_dir(&self) -> Result<PathBuf> {
         let temp_dir = self.cache_dir()?.join("downloads");


### PR DESCRIPTION
Fixes #803, fixes the actionable items of #808.

## #803 — JWT rotation keys silently ephemeral under systemd

Rotation slots were written into the read-only `$CREDENTIALS_DIRECTORY` ramfs with warn-only error handling, and the slot names were absent from the unit generator's credential lists — so under systemd every service restart minted fresh JWT signing keys and invalidated every outstanding token, silently.

Rotation slots are runtime **state**, not provisioned credentials, so this PR gives them a writable home rather than provisioning them:

- `key_rotation::rotation_state_dir()` resolves: the secrets dir when writable (unchanged behavior off-systemd) → `$STATE_DIRECTORY` under systemd → the XDG state dir (instance-namespaced) otherwise. Loads prefer the state dir and fall back to the secrets dir, so provisioned credentials still bootstrap first boot.
- Both unit generators now emit `StateDirectory=hyprstream`, so `$STATE_DIRECTORY` exists and is writable under systemd.
- All persist failures (Ed25519 / ES256 / ML-DSA slot writes, startup and rotation task) are now `error!` with explicit token-invalidation context instead of `warn!` — fail loud.
- `factories.rs` JWT renewal now actually persists the renewed service JWT via `write_service_jwt` (error-level log on read-only dirs); the doc comment previously claimed a disk write that never happened.

## #808 — unit generation credential gaps

1. **Instance path mismatch**: `units.rs` / `systemd.rs` now resolve the plaintext credentials dir through an instance-namespaced helper mirroring `StoragePaths` (`~/.config/hyprstream/instances/{inst}/credentials`). The systemd credstore path itself is a fixed systemd-owned location and is intentionally not namespaced (cross-instance credstore name collisions noted as a remaining limitation).
2. **System-wide units unplumbed**: `system_service_unit` now emits `LoadCredential=` / `ImportCredential=` (sources: `/etc/hyprstream[/instances/{inst}]/credentials`, `/etc/credstore.encrypted`) and `Environment=HYPRSTREAM__SECRETS__PATH=%d`. PID 1 reads the sources as root and passes them via the private credentials ramfs, so the `hyprstream` user no longer needs read access to root-owned dirs.
3. **Cosmetic credstore encryption**: documented as best-effort defense-in-depth; the plaintext 0600 files remain authoritative (per-service `LoadCredential=` sources and CLI tooling read them), so they are deliberately not deleted.
4. **Stale credential names**: removed `credential-store-key` (verified: no producer or consumer in the tree) and the oauth-unit `user-signing-key` import — the file is a live **CLI-side** client credential (challenge-response enrollment via `load_or_generate_user_signing_key`) but has no service-side consumer, so importing it into the oauth unit was dead directive surface. The on-disk file itself is untouched.
5. **Silent TLS renewal skip**: a cert past its renewal threshold in a read-only credentials dir now logs `error!` with re-provisioning instructions instead of silently loading the aging cert.

## Notes for reviewers

- `auth/identity_store.rs::resolve_service_signing_key` and the `ImportCredential=signing-key` fallback in `units.rs` were **not** touched — owned by the sibling #805/#802 work. No `SecretsProfile` dependency was needed.
- Adjacent gap observed but left out of scope: the composite-pair ledger (`jwt-composite-pairs*`) also lives in the secrets dir and requires write access (flock + atomic writes); under a read-only creds dir it already fails closed (`?`-propagated / warn-and-retain-prior-authority). Moving it to the state dir belongs with the multiprocess-authority work.
- `cargo fmt --check` is red workspace-wide on `main` with the current toolchain (pre-existing drift in `git2db`, `hyprstream-9p`, `chat-core`, etc.); this branch adds zero new drift (verified per-file against HEAD).
- Known unrelated: main's release IMAGE build is red (arrow skew, PR #1133).

## Verification

- `cargo build -p hyprstream` ✓
- `cargo test -p hyprstream --lib` ✓ (1099 passed, 1 ignored)
- `cargo clippy -p hyprstream -p hyprstream-service --all-targets -- -D warnings` ✓
- pre-commit hook (CI-mirror release clippy) ✓