### PR TITLE
fix(auth): make service secret profiles explicit

### DIFF
--- a/crates/hyprstream-service/src/service/manager/units.rs
+++ b/crates/hyprstream-service/src/service/manager/units.rs
@@ -91,6 +91,56 @@ pub const ALL_CREDENTIAL_NAMES: &[&str] = &[
     "service-jwt",
 ];
 
+/// Build credential directives for a user service unit.
+///
+/// A non-policy service must have its own plaintext signing key available for
+/// `LoadCredential=`. Falling through to `ImportCredential=signing-key` would
+/// import the node/CA root key from the flat credstore into that service.
+fn credential_directives(
+    service: &str,
+    names: &[&str],
+    credstore: &std::path::Path,
+    plain_creds: &std::path::Path,
+) -> Result<String> {
+    let mut import_lines = String::new();
+
+    for name in names {
+        // Per-service credentials (signing-key, service-jwt): each service
+        // has its own independent Ed25519 key stored in a subdirectory.
+        //
+        // ImportCredential requires the credstore file name to match the
+        // runtime name, but per-service creds are encrypted with prefixed
+        // names (e.g. model-signing-key). Use LoadCredential to load from
+        // the plaintext file directly, making it available as the unprefixed
+        // name the runtime expects.
+        //
+        // Policy is special: its "signing-key" IS the CA key, stored flat
+        // in the encrypted credstore, so ImportCredential works for it.
+        if SERVICE_CREDENTIAL_NAMES.contains(name) && service != "policy" {
+            let plain_path = plain_creds.join(service).join(name);
+            if plain_path.is_file() {
+                import_lines.push_str(&format!(
+                    "LoadCredential={name}:{}\n",
+                    plain_path.display()
+                ));
+                continue;
+            }
+            if *name == "signing-key" {
+                anyhow::bail!(
+                    "per-service signing key '{}' is missing; refusing to import the node/CA root key as service '{}'. Re-run 'hyprstream service install' after provisioning service credentials",
+                    plain_path.display(),
+                    service
+                );
+            }
+        }
+        if credstore.join(name).exists() {
+            import_lines.push_str(&format!("ImportCredential={name}\n"));
+        }
+    }
+
+    Ok(import_lines)
+}
+
 /// Generate a systemd service unit for a service.
 ///
 /// # Arguments
@@ -184,37 +234,7 @@ pub fn service_unit(service: &str, use_systemd_creds: bool, depends_on: &[&str])
             .map(|d| d.join("hyprstream").join("credentials"))
             .unwrap_or_default();
 
-        let mut import_lines = String::new();
-
-        for name in &names {
-            // Per-service credentials (signing-key, service-jwt): each service
-            // has its own independent Ed25519 key stored in a subdirectory.
-            //
-            // ImportCredential requires the credstore file name to match the
-            // runtime name, but per-service creds are encrypted with prefixed
-            // names (e.g. model-signing-key).  Use LoadCredential to load from
-            // the plaintext file directly, making it available as the unprefixed
-            // name the runtime expects.
-            //
-            // Policy is special: its "signing-key" IS the CA key, stored flat
-            // in the encrypted credstore, so ImportCredential works for it.
-            if SERVICE_CREDENTIAL_NAMES.contains(name) && service != "policy" {
-                let plain_path = plain_creds.join(service).join(name);
-                if plain_path.exists() {
-                    import_lines.push_str(&format!(
-                        "LoadCredential={name}:{}\n",
-                        plain_path.display()
-                    ));
-                    continue;
-                }
-                // Fall through: no per-service plaintext file, try encrypted credstore
-            }
-            if credstore.join(name).exists() {
-                import_lines.push_str(&format!("ImportCredential={name}\n"));
-            }
-        }
-
-        let all_cred_lines = import_lines;
+        let all_cred_lines = credential_directives(service, &names, &credstore, &plain_creds)?;
 
         if all_cred_lines.is_empty() {
             String::new()
@@ -373,4 +393,36 @@ WantedBy=multi-user.target
 "#,
         exec = exec.display(),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_service_signing_key_never_falls_back_to_node_key() -> Result<()> {
+        let temp = tempfile::TempDir::new()?;
+        let credstore = temp.path().join("credstore.encrypted");
+        let plain_creds = temp.path().join("credentials");
+        std::fs::create_dir_all(&credstore)?;
+        std::fs::create_dir_all(plain_creds.join("model"))?;
+
+        // This is the dangerous fallback credential: the node/CA root key is
+        // present under the runtime name expected by the service.
+        std::fs::write(credstore.join("signing-key"), b"encrypted-root-key")?;
+
+        let error = match credential_directives(
+            "model",
+            SERVICE_CREDENTIAL_NAMES,
+            &credstore,
+            &plain_creds,
+        ) {
+            Err(error) => error,
+            Ok(lines) => anyhow::bail!("dangerous signing-key fallback returned: {lines}"),
+        };
+        let message = error.to_string();
+        assert!(message.contains("per-service signing key"));
+        assert!(message.contains("refusing to import the node/CA root key"));
+        Ok(())
+    }
 }

--- a/crates/hyprstream-service/src/service/manager/units.rs
+++ b/crates/hyprstream-service/src/service/manager/units.rs
@@ -91,11 +91,14 @@ pub const ALL_CREDENTIAL_NAMES: &[&str] = &[
     "service-jwt",
 ];
 
-/// Build credential directives for a user service unit.
+/// Build credential directives for a service unit.
 ///
-/// A non-policy service must have its own plaintext signing key available for
-/// `LoadCredential=`. Falling through to `ImportCredential=signing-key` would
-/// import the node/CA root key from the flat credstore into that service.
+/// This is the single, path-independent fail-closed guard shared by both the
+/// user-unit (`service_unit`) and system-unit (`system_service_unit`) emission
+/// paths. A non-policy service must have its own plaintext signing key
+/// available for `LoadCredential=`. Falling through to
+/// `ImportCredential=signing-key` would import the node/CA root key from the
+/// flat credstore into that service.
 fn credential_directives(
     service: &str,
     names: &[&str],
@@ -139,6 +142,40 @@ fn credential_directives(
     }
 
     Ok(import_lines)
+}
+
+/// Build the credential section for a system-wide service unit.
+///
+/// Kept separate from `system_service_unit` so the system path can be tested
+/// with injectable paths while still routing every credential through the
+/// shared [`credential_directives`] fail-closed guard.
+fn system_creds_section(
+    service: &str,
+    is_appimage: bool,
+    credstore: &std::path::Path,
+    plain_creds: &std::path::Path,
+) -> Result<String> {
+    let mut names: Vec<&'static str> = NODE_CREDENTIAL_NAMES.to_vec();
+    names.extend(SERVICE_CREDENTIAL_NAMES.iter().copied());
+    if service == "oauth" {
+        names.extend(OAUTH_CREDENTIAL_NAMES.iter().copied());
+    }
+    if service == "policy" {
+        names.extend(POLICY_CREDENTIAL_NAMES.iter().copied());
+    }
+
+    let import_lines = credential_directives(service, &names, credstore, plain_creds)?;
+
+    Ok(if import_lines.is_empty() {
+        String::new()
+    } else {
+        let private_mounts = if is_appimage {
+            ""
+        } else {
+            "\nPrivateMounts=yes"
+        };
+        format!("\n{import_lines}Environment=HYPRSTREAM__SECRETS__PATH=%d{private_mounts}")
+    })
 }
 
 /// Generate a systemd service unit for a service.
@@ -359,6 +396,22 @@ pub fn system_service_unit(service: &str, depends_on: &[&str]) -> Result<String>
         format!("\n{env_directives}")
     };
 
+    // System-wide credential plumbing uses FHS system paths. PID 1 reads the
+    // sources as root and exposes them to the service through systemd's
+    // access-restricted credentials ramfs.
+    let creds_section = {
+        let credstore = std::path::PathBuf::from("/etc/credstore.encrypted");
+        let plain_creds = match std::env::var("HYPRSTREAM_INSTANCE") {
+            Ok(inst) if !inst.is_empty() => std::path::PathBuf::from("/etc/hyprstream")
+                .join("instances")
+                .join(inst)
+                .join("credentials"),
+            _ => std::path::PathBuf::from("/etc/hyprstream/credentials"),
+        };
+
+        system_creds_section(service, is_appimage, &credstore, &plain_creds)?
+    };
+
     let dep_section = if depends_on.is_empty() {
         String::new()
     } else {
@@ -384,7 +437,7 @@ Type=notify
 User=hyprstream
 RuntimeDirectory=hyprstream
 RuntimeDirectoryMode=0750
-ExecStart={exec} service start {service} --foreground{env_section}{hardening}
+ExecStart={exec} service start {service} --foreground{env_section}{creds_section}{hardening}
 Restart=on-failure
 RestartSec=2s
 
@@ -423,6 +476,49 @@ mod tests {
         let message = error.to_string();
         assert!(message.contains("per-service signing key"));
         assert!(message.contains("refusing to import the node/CA root key"));
+        Ok(())
+    }
+
+    #[test]
+    fn system_unit_missing_service_signing_key_never_falls_back_to_node_key() -> Result<()> {
+        let temp = tempfile::TempDir::new()?;
+        let credstore = temp.path().join("credstore.encrypted");
+        let plain_creds = temp.path().join("credentials");
+        std::fs::create_dir_all(&credstore)?;
+        std::fs::create_dir_all(plain_creds.join("model"))?;
+
+        // The dangerous fallback credential: node/CA root key present under
+        // the flat runtime name a non-policy system service could import.
+        std::fs::write(credstore.join("signing-key"), b"encrypted-root-key")?;
+
+        let error = match system_creds_section("model", false, &credstore, &plain_creds) {
+            Err(error) => error,
+            Ok(section) => {
+                anyhow::bail!("system-unit signing-key fallback returned: {section:?}")
+            }
+        };
+        let message = error.to_string();
+        assert!(message.contains("per-service signing key"));
+        assert!(message.contains("refusing to import the node/CA root key"));
+        Ok(())
+    }
+
+    #[test]
+    fn system_unit_loads_present_per_service_key_without_root_fallback() -> Result<()> {
+        let temp = tempfile::TempDir::new()?;
+        let credstore = temp.path().join("credstore.encrypted");
+        let plain_creds = temp.path().join("credentials");
+        std::fs::create_dir_all(&credstore)?;
+        std::fs::create_dir_all(plain_creds.join("model"))?;
+        std::fs::write(credstore.join("signing-key"), b"encrypted-root-key")?;
+        std::fs::write(plain_creds.join("model").join("signing-key"), b"svc-key")?;
+
+        let section = system_creds_section("model", false, &credstore, &plain_creds)?;
+        assert!(section.contains("LoadCredential=signing-key:"));
+        assert!(
+            !section.contains("ImportCredential=signing-key"),
+            "must never import the flat node/CA root key for a non-policy service: {section}"
+        );
         Ok(())
     }
 }

--- a/crates/hyprstream/src/auth/identity_store.rs
+++ b/crates/hyprstream/src/auth/identity_store.rs
@@ -424,6 +424,23 @@ pub fn load_or_generate_node_signing_key(secrets_dir: &std::path::Path) -> Resul
     Ok(key)
 }
 
+/// Describes how a service's credentials directory is scoped.
+///
+/// This is deliberately about directory layout rather than a particular
+/// process manager. Both systemd `LoadCredential` directories and projected
+/// Kubernetes Secret/CSI volumes can present a directory already scoped to a
+/// single service, while standalone multi-process deployments share one
+/// writable directory among services.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SecretsProfile {
+    /// One base directory is shared by all services; non-policy credentials
+    /// live under a `{service_name}/` subdirectory.
+    SharedDirectory,
+    /// The provider has already scoped the directory to one service, so its
+    /// credentials use flat names such as `signing-key`.
+    PerServiceScoped,
+}
+
 /// Resolve the Ed25519 signing key a service process should use to sign its
 /// own RPC responses in `--ipc` (multi-process) deployment.
 ///
@@ -445,22 +462,25 @@ pub fn load_or_generate_node_signing_key(secrets_dir: &std::path::Path) -> Resul
 /// by unexpected key" (#759) — a sibling gap to the CA-derivation fallback
 /// #441 already removed from `resolve_service_key`.
 ///
-/// - `systemd_mode`: each service's per-unit `LoadCredential` directory
-///   already scopes `secrets_dir` to that one service, so the flat top-level
-///   file is correct for every service, policy included.
-/// - Standalone (non-systemd) `--ipc`: `secrets_dir` is shared across every
+/// - [`SecretsProfile::PerServiceScoped`]: the credential provider already
+///   scopes `secrets_dir` to that one service, so the flat top-level file is
+///   correct for every service, policy included.
+/// - [`SecretsProfile::SharedDirectory`]: `secrets_dir` is shared across every
 ///   spawned service process, so non-policy services use a `{service_name}/`
 ///   subdirectory to avoid collisions — but policy must still resolve to the
 ///   flat root/CA key, matching what bootstrap registered.
 pub fn resolve_service_signing_key(
     secrets_dir: &std::path::Path,
     service_name: &str,
-    systemd_mode: bool,
+    profile: SecretsProfile,
 ) -> Result<SigningKey> {
-    if systemd_mode || service_name == "policy" {
-        load_or_generate_node_signing_key(secrets_dir)
-    } else {
-        load_or_generate_service_signing_key(secrets_dir, service_name)
+    match (profile, service_name) {
+        (_, "policy") | (SecretsProfile::PerServiceScoped, _) => {
+            load_or_generate_node_signing_key(secrets_dir)
+        }
+        (SecretsProfile::SharedDirectory, _) => {
+            load_or_generate_service_signing_key(secrets_dir, service_name)
+        }
     }
 }
 
@@ -1321,7 +1341,9 @@ mod tests {
         // Standalone (non-systemd) `--ipc` startup, resolving policy's own key —
         // this must equal the root key bootstrap registered, not a freshly
         // minted independent key.
-        let resolved = resolve_service_signing_key(dir.path(), "policy", false).unwrap();
+        let resolved =
+            resolve_service_signing_key(dir.path(), "policy", SecretsProfile::SharedDirectory)
+                .unwrap();
         assert_eq!(
             resolved.to_bytes(), root_key.to_bytes(),
             "policy must resolve to the flat root/CA key, matching bootstrap_pubkeys[\"policy\"]"
@@ -1335,11 +1357,25 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_service_signing_key_policy_matches_root_key_in_systemd_mode() {
+    fn test_resolve_service_signing_key_policy_matches_root_key_when_scoped() {
         let dir = TempDir::new().unwrap();
         let root_key = load_or_generate_node_signing_key(dir.path()).unwrap();
-        let resolved = resolve_service_signing_key(dir.path(), "policy", true).unwrap();
+        let resolved =
+            resolve_service_signing_key(dir.path(), "policy", SecretsProfile::PerServiceScoped)
+                .unwrap();
         assert_eq!(resolved.to_bytes(), root_key.to_bytes());
+    }
+
+    #[test]
+    fn test_resolve_service_signing_key_non_policy_uses_flat_key_when_scoped() {
+        let dir = TempDir::new().unwrap();
+        let flat_key = load_or_generate_node_signing_key(dir.path()).unwrap();
+        let resolved =
+            resolve_service_signing_key(dir.path(), "model", SecretsProfile::PerServiceScoped)
+                .unwrap();
+
+        assert_eq!(resolved.to_bytes(), flat_key.to_bytes());
+        assert!(!dir.path().join("model").exists());
     }
 
     #[test]
@@ -1347,7 +1383,9 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let root_key = load_or_generate_node_signing_key(dir.path()).unwrap();
 
-        let model_key = resolve_service_signing_key(dir.path(), "model", false).unwrap();
+        let model_key =
+            resolve_service_signing_key(dir.path(), "model", SecretsProfile::SharedDirectory)
+                .unwrap();
         assert_ne!(
             model_key.to_bytes(), root_key.to_bytes(),
             "non-policy services must keep their own independent key, distinct from the root/CA key"
@@ -1365,12 +1403,20 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let _root_key = load_or_generate_node_signing_key(dir.path()).unwrap();
 
-        let policy_1 = resolve_service_signing_key(dir.path(), "policy", false).unwrap();
-        let policy_2 = resolve_service_signing_key(dir.path(), "policy", false).unwrap();
+        let policy_1 =
+            resolve_service_signing_key(dir.path(), "policy", SecretsProfile::SharedDirectory)
+                .unwrap();
+        let policy_2 =
+            resolve_service_signing_key(dir.path(), "policy", SecretsProfile::SharedDirectory)
+                .unwrap();
         assert_eq!(policy_1.to_bytes(), policy_2.to_bytes());
 
-        let model_1 = resolve_service_signing_key(dir.path(), "model", false).unwrap();
-        let model_2 = resolve_service_signing_key(dir.path(), "model", false).unwrap();
+        let model_1 =
+            resolve_service_signing_key(dir.path(), "model", SecretsProfile::SharedDirectory)
+                .unwrap();
+        let model_2 =
+            resolve_service_signing_key(dir.path(), "model", SecretsProfile::SharedDirectory)
+                .unwrap();
         assert_eq!(model_1.to_bytes(), model_2.to_bytes());
     }
 }

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -2113,12 +2113,21 @@ fn main() -> Result<()> {
                                         }
                                     }
 
-                                    // C3 fix: systemd uses flat %d/signing-key, standalone uses subdirectory.
+                                    // C3 fix: scoped credential providers use flat
+                                    // %d/signing-key, while standalone uses a subdirectory.
                                     // #759: "policy" always resolves to the flat root/CA key regardless of
-                                    // deployment mode — see `resolve_service_signing_key` for why.
-                                    let systemd_mode = std::env::var("HYPRSTREAM__SECRETS__PATH").is_ok();
+                                    // secrets profile — see `resolve_service_signing_key` for why.
+                                    let secrets_profile = if std::env::var(
+                                        "HYPRSTREAM__SECRETS__PATH",
+                                    )
+                                    .is_ok()
+                                    {
+                                        hyprstream_core::auth::identity_store::SecretsProfile::PerServiceScoped
+                                    } else {
+                                        hyprstream_core::auth::identity_store::SecretsProfile::SharedDirectory
+                                    };
                                     let own_key = hyprstream_core::auth::identity_store::resolve_service_signing_key(
-                                        &secrets_dir, &name, systemd_mode,
+                                        &secrets_dir, &name, secrets_profile,
                                     )?;
 
                                     if name == "policy" {
@@ -2198,7 +2207,11 @@ fn main() -> Result<()> {
                                     // key — see `resolve_service_signing_key` for why. This mirrors the
                                     // same fix applied to the `--ipc` branch above.
                                     for svc_name in &service_names {
-                                        let svc_key = hyprstream_core::auth::identity_store::resolve_service_signing_key(&secrets_dir, svc_name, false)
+                                        let svc_key = hyprstream_core::auth::identity_store::resolve_service_signing_key(
+                                            &secrets_dir,
+                                            svc_name,
+                                            hyprstream_core::auth::identity_store::SecretsProfile::SharedDirectory,
+                                        )
                                             .with_context(|| format!("Failed to load signing key for service '{}'", svc_name))?;
                                         ctx = ctx.with_service_key(svc_name, svc_key.clone());
 


### PR DESCRIPTION
## Summary

- replace the systemd-mode boolean with `SecretsProfile::{SharedDirectory, PerServiceScoped}` so credential layout reflects provider scoping and can cover projected Kubernetes Secret/CSI volumes
- preserve the policy service root/CA-key special case and all existing standalone/scoped resolution behavior
- fail systemd unit generation closed when a non-policy service signing key is missing, preventing fallback to the flat node/CA root credential
- add regression coverage for both profile layouts and the missing-key privilege-escalation path

## Validation

- `cargo build -p hyprstream`
- `cargo test -p hyprstream --lib auth::` (332 passed)
- `cargo test -p hyprstream-service missing_service_signing_key_never_falls_back_to_node_key --lib`
- `cargo clippy -p hyprstream -- -D warnings`
- `cargo clippy -p hyprstream-service --all-targets -- -D warnings`
- foreground pre-commit Clippy hook (release profile)
- `cargo fmt --check` remains red repository-wide on pre-existing formatting drift beginning in untouched `crates/cas-serve/src/store.rs`; all changed hunks match rustfmt and `git diff --check` passes

Closes #805
Closes #802